### PR TITLE
fix(build): pin to alpine 3.16 (fixes prisma install error)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,5 +1,5 @@
 # Add lockfile and package.json's of isolated subworkspace
-FROM node:16-alpine AS installer
+FROM node:16-alpine3.16 AS installer
 RUN apk update
 RUN apk --no-cache add curl libc6-compat
 RUN curl -fsSL "https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linuxstatic-x64" -o /bin/pnpm; chmod +x /bin/pnpm;
@@ -16,7 +16,7 @@ RUN pnpm install
 RUN pnpm dlx prisma generate
 RUN pnpm turbo run build --filter=web...
 
-FROM node:16-alpine AS runner
+FROM node:16-alpine3.16 AS runner
 
 RUN apk --no-cache add curl libc6-compat
 RUN curl -fsSL "https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linuxstatic-x64" -o /bin/pnpm; chmod +x /bin/pnpm;
@@ -31,7 +31,7 @@ WORKDIR /home/nextjs
 COPY --from=installer /app/apps/web/next.config.js .
 COPY --from=installer /app/apps/web/package.json .
 
-# Automatically leverage output traces to reduce image size 
+# Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
 COPY --from=installer --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static


### PR DESCRIPTION
Fixes a build error with prisma on the [latest alpine 3.17](https://github.com/prisma/prisma/issues/16642#issuecomment-1347743938) in the snoopforms branch