### PR TITLE
FIX: localhost URLs fixed 

### DIFF
--- a/apps/formbricks-com/pages/docs/contributing/setup/index.mdx
+++ b/apps/formbricks-com/pages/docs/contributing/setup/index.mdx
@@ -60,9 +60,9 @@ To get the project running locally on your machine you need to have the followin
 
    This only starts the Formbricks main app plus all its dependencies to save memory. If you want to start all apps at once, run `pnpm dev` instead.
 
-   **You can now access the app on [https://localhost:3000](https://localhost:3000)**. You will be automatically redirected to the login. To use your local installation of formbricks, create a new account.
+   **You can now access the app on [http://localhost:3000](http://localhost:3000)**. You will be automatically redirected to the login. To use your local installation of formbricks, create a new account.
 
-   For viewing the confirmation email and other emails the system sends you, you can access mailhog at [https://localhost:8025](https://localhost:8025)
+   For viewing the confirmation email and other emails the system sends you, you can access mailhog at [http://localhost:8025](http://localhost:8025)
 
 ### Build
 

--- a/apps/formbricks-com/pages/docs/self-hosting/deployment/index.mdx
+++ b/apps/formbricks-com/pages/docs/self-hosting/deployment/index.mdx
@@ -40,7 +40,7 @@ docker compose up -d
 # (use docker-compose if you are on an older docker version)
 ```
 
-You can now access the app on [https://localhost:3000](https://localhost:3000). You will be automatically redirected to the login. To use your local installation of Formbricks, create a new account.
+You can now access the app on [http://localhost:3000](http://localhost:3000). You will be automatically redirected to the login. To use your local installation of Formbricks, create a new account.
 
 ## Stop the containers
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -59,7 +59,7 @@ To get the project running locally on your machine you need to have the followin
    pnpm dev
    ```
 
-   **You can now access the app on [https://localhost:3000](https://localhost:3000)**. You will be automatically redirected to the login. To use your local installation of formbricks, create a new account.
+   **You can now access the app on [http://localhost:3000](http://localhost:3000)**. You will be automatically redirected to the login. To use your local installation of formbricks, create a new account.
 
    For viewing the confirmation email and other emails the system sends you, you can access mailhog at [http://localhost:8025](http://localhost:8025)
 


### PR DESCRIPTION
In the documentation, at some places, localhost URLs were started with https instead of http