### PR TITLE
Exclude updatedAt field in survey update

### DIFF
--- a/apps/web/pages/api/v1/environments/[environmentId]/surveys/[surveyId]/index.ts
+++ b/apps/web/pages/api/v1/environments/[environmentId]/surveys/[surveyId]/index.ts
@@ -78,8 +78,10 @@ export default async function handle(req: NextApiRequest, res: NextApiResponse) 
         surveyId,
       },
     });
-    let data: any = { updatedAt: new Date() };
+    let data: any = {};
     const body = { ...req.body };
+
+    delete body.updatedAt;
 
     // delete unused fields for link surveys
     if (body.type === "link") {


### PR DESCRIPTION
## What does this PR do?

The current ﻿`updatedAt` field's value is passed in the survey’s update API request, so the date remains the same as the ﻿`createdAt` date. As a result, even if many changes are made to the survey, an alert to delete the draft is shown when the Back button is clicked.

To reproduce the bug:
1. Create a new survey
2. Make a change
3. Save
4. Open the same survey
5. Click the Back Button
6. See the alert asking if you want to delete the draft

This PR fixes the issue by removing the ﻿`updatedAt` field from the request body, allowing Prisma to set the datetime correctly.

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

Follow the steps above. It shouldn't now show an alert described in point no 6.

## Checklist

<!-- Please remove all the irrelevant bullets to your PR -->

- <s>I haven't read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- My code doesn't follow the style guidelines of this project
- I haven't performed a self-review of my own code and corrected any misspellings
- I haven't commented my code, particularly in hard-to-understand areas
- I haven't checked if my PR needs changes to the documentation
- I haven't checked if my changes generate no new warnings
- I haven't checked if my changes generate build errors (`pnpm build`) or linting errors (`pnpm lint`)
- I haven't checked if I removed all console.logs's
- I haven't checked for merge conflicts by merging the latest changes from main with `git pull origin main`</s>
