### PR TITLE
fix: do not create a display if the survey is in preview mode

### DIFF
--- a/apps/web/app/s/[surveyId]/LinkSurvey.tsx
+++ b/apps/web/app/s/[surveyId]/LinkSurvey.tsx
@@ -30,9 +30,14 @@ export default function LinkSurvey({ survey }: LinkSurveyProps) {
   const [responseId, setResponseId] = useState<string | null>(null);
   const [displayId, setDisplayId] = useState<string | null>(null);
 
+  const isPreview = new URLSearchParams(window.location.search).get("preview") === "true";
+
   useEffect(() => {
     if (survey) {
       setCurrentQuestion(survey.questions[0]);
+
+      if (isPreview) return;
+
       // create display
       createDisplay(
         { surveyId: survey.id },
@@ -42,7 +47,7 @@ export default function LinkSurvey({ survey }: LinkSurveyProps) {
         setDisplayId(display.id);
       });
     }
-  }, [survey]);
+  }, [survey, isPreview]);
 
   useEffect(() => {
     if (currentQuestion && survey) {
@@ -54,8 +59,6 @@ export default function LinkSurvey({ survey }: LinkSurveyProps) {
       return elementIdx / survey.questions.length;
     }
   }, [currentQuestion, survey]);
-
-  const isPreview = new URLSearchParams(window.location.search).get("preview") === "true";
 
   const restartSurvey = () => {
     setCurrentQuestion(survey.questions[0]);


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes the increase of display count on preview surveys. It should only increase on live surveys.

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Visit preview survey and check that display count is not changing
- Visit live survey and check that it does change

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->
