### PR TITLE
Add autoFocus to Free Text in Standalone Surveys

### DIFF
--- a/apps/web/app/environments/[environmentId]/surveys/[surveyId]/summary/SummaryMetadata.tsx
+++ b/apps/web/app/environments/[environmentId]/surveys/[surveyId]/summary/SummaryMetadata.tsx
@@ -146,6 +146,7 @@ export default function SummaryMetadata({ surveyId, environmentId }) {
               <SurveyStatusDropdown surveyId={surveyId} environmentId={environmentId} />
             ) : null}
             <Button
+              variant="darkCTA"
               className="h-full w-full px-3 lg:px-6"
               href={`/environments/${environmentId}/surveys/${surveyId}/edit`}>
               <PencilSquareIcon className="mr-2 h-5  w-5 text-white" />

--- a/apps/web/components/preview/OpenTextQuestion.tsx
+++ b/apps/web/components/preview/OpenTextQuestion.tsx
@@ -34,6 +34,7 @@ export default function OpenTextQuestion({
       <Subheader subheader={question.subheader} questionId={question.id} />
       <div className="mt-4">
         <textarea
+          autoFocus
           rows={3}
           name={question.id}
           id={question.id}

--- a/apps/web/lib/questions.ts
+++ b/apps/web/lib/questions.ts
@@ -24,6 +24,8 @@ export const questionTypes: QuestionType[] = [
     description: "A single line of text",
     icon: ChatBubbleBottomCenterTextIcon,
     preset: {
+      headline: "Who let the dogs out?",
+      subheader: "Who? Who? Who?",
       placeholder: "Type your answer here...",
     },
   },


### PR DESCRIPTION
## What does this PR do?

minor changes:
- add autoFocus to open text questions standalone (didnt add it to in-app because it might steal focus from what user currently is doing -> bad UX)
- Add default text content for open text question
- Update "Edit" button color to darkCTA


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [X] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## Checklist

Yes
