### PR TITLE
fix: preserve docs nav scroll position

### DIFF
--- a/apps/formbricks-com/components/docs/Layout.tsx
+++ b/apps/formbricks-com/components/docs/Layout.tsx
@@ -12,6 +12,7 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import MetaInformation from "../shared/MetaInformation";
 import DocsFeedback from "./DocsFeedback";
+import { useRef } from "react";
 
 function GitHubIcon(props: any) {
   return (
@@ -92,6 +93,23 @@ export const Layout: React.FC<LayoutProps> = ({ children, meta }) => {
   let nextPage = allLinks[linkIndex + 1];
   let section = navigation.find((section) => section.links.find((link) => link.href === router.pathname));
 
+  const linkRef = useRef<HTMLLIElement>(null);
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const preserveScroll = () => {
+    const scroll = Math.abs(linkRef.current.getBoundingClientRect().top - linkRef.current.offsetTop);
+    sessionStorage.setItem("scrollPosition", (scroll + 89).toString());
+  };
+
+  useEffect(() => {
+    if (parentRef.current) {
+      const scrollPosition = Number.parseInt(sessionStorage.getItem("scrollPosition"), 10);
+      if (scrollPosition) {
+        parentRef.current.scrollTop = scrollPosition;
+      }
+    }
+  }, []);
+
   return (
     <>
       <MetaInformation
@@ -107,8 +125,15 @@ export const Layout: React.FC<LayoutProps> = ({ children, meta }) => {
           <div className="absolute inset-y-0 right-0 w-[50vw] bg-slate-50 dark:hidden" />
           <div className="absolute bottom-0 right-0 top-16 hidden h-12 w-px bg-gradient-to-t from-slate-800 dark:block" />
           <div className="absolute bottom-0 right-0 top-28 hidden w-px bg-slate-800 dark:block" />
-          <div className="sticky top-[4.5rem] -ml-0.5 h-[calc(100vh-4.5rem)] overflow-y-auto overflow-x-hidden py-16 pl-0.5">
-            <Navigation navigation={navigation} className="w-64 pr-8 xl:w-72 xl:pr-16" />
+          <div
+            className="sticky top-[4.5rem] -ml-0.5 h-[calc(100vh-4.5rem)] overflow-y-auto overflow-x-hidden py-16 pl-0.5"
+            ref={parentRef}>
+            <Navigation
+              navigation={navigation}
+              preserveScroll={preserveScroll}
+              linkRef={linkRef}
+              className="w-64 pr-8 xl:w-72 xl:pr-16"
+            />
           </div>
         </div>
         <div className="min-w-0 max-w-2xl flex-auto px-4 py-16 lg:max-w-none lg:pl-8 lg:pr-0 xl:px-16">

--- a/apps/formbricks-com/components/shared/Navigation.tsx
+++ b/apps/formbricks-com/components/shared/Navigation.tsx
@@ -11,9 +11,11 @@ interface NavigationProps {
     }[];
   }[];
   className: string;
+  preserveScroll: () => void;
+  linkRef: React.RefObject<HTMLLIElement>;
 }
 
-export function Navigation({ navigation, className }: NavigationProps) {
+export function Navigation({ navigation, className, preserveScroll, linkRef }: NavigationProps) {
   let router = useRouter();
 
   return (
@@ -26,8 +28,9 @@ export function Navigation({ navigation, className }: NavigationProps) {
               role="list"
               className="mt-2 space-y-2 border-l-2 border-slate-100 dark:border-slate-800 lg:mt-4 lg:space-y-4 lg:border-slate-200">
               {section.links.map((link) => (
-                <li key={link.href} className="relative">
+                <li key={link.href} className="relative" ref={linkRef}>
                   <Link
+                    onClick={preserveScroll}
                     href={link.href}
                     className={clsx(
                       "block w-full pl-3.5 before:pointer-events-none before:absolute before:-left-1 before:top-1/2 before:h-1.5 before:w-1.5 before:-translate-y-1/2 before:rounded-full",


### PR DESCRIPTION
## What does this PR do?

Fixes #378

### Before

https://github.com/formbricks/formbricks/assets/69904519/2728b411-cd6a-4348-aa3b-cfaf8cb20b18


### After

https://github.com/formbricks/formbricks/assets/69904519/8c29307d-59c5-4e00-a96d-dcb78f58e967


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Go to docs and scroll side nav to the bottom and click on any topic

## Checklist

- [x] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
