### PR TITLE
Add Timestamps in User Model Response

### DIFF
--- a/packages/lib/services/person.ts
+++ b/packages/lib/services/person.ts
@@ -12,11 +12,15 @@ type TransformPersonInput = {
       name: string;
     };
   }[];
+  createdAt: Date;
+  updatedAt: Date;
 };
 
 export type TransformPersonOutput = {
   id: string;
   attributes: Record<string, string | number>;
+  createdAt: Date;
+  updatedAt: Date;
 };
 
 export const transformPrismaPerson = (person: TransformPersonInput | null): TransformPersonOutput | null => {
@@ -32,6 +36,8 @@ export const transformPrismaPerson = (person: TransformPersonInput | null): Tran
   return {
     id: person.id,
     attributes: attributes,
+    createdAt: person.createdAt,
+    updatedAt: person.updatedAt
   };
 };
 
@@ -78,6 +84,8 @@ export const getPeople = cache(async (environmentId: string): Promise<TPerson[]>
       },
       select: {
         id: true,
+        createdAt: true,
+        updatedAt: true,
         attributes: {
           select: {
             value: true,

--- a/packages/lib/services/response.ts
+++ b/packages/lib/services/response.ts
@@ -19,6 +19,8 @@ const responseSelection = {
   person: {
     select: {
       id: true,
+      createdAt: true,
+      updatedAt: true,
       attributes: {
         select: {
           value: true,

--- a/packages/types/v1/people.ts
+++ b/packages/types/v1/people.ts
@@ -6,6 +6,8 @@ export type TPersonAttributes = z.infer<typeof ZPersonAttributes>;
 export const ZPerson = z.object({
   id: z.string().cuid2(),
   attributes: ZPersonAttributes,
+  createdAt: z.date(),
+  updatedAt: z.date()
 });
 
 export type TPerson = z.infer<typeof ZPerson>;

--- a/packages/types/v1/responses.ts
+++ b/packages/types/v1/responses.ts
@@ -36,6 +36,8 @@ const ZResponse = z.object({
     .object({
       id: z.string().cuid2(),
       attributes: z.record(z.union([z.string(), z.number()])),
+      createdAt: z.date(),
+      updatedAt: z.date(),
     })
     .nullable(),
   personAttributes: ZResponsePersonAttributes,


### PR DESCRIPTION
## What does this PR do?
Sends the `createdAt` and `updatedAt` of the user model in the response primarily in `getPerson()` and `getPeople()` methods and wherever else we deal with the type `TransformPersonOutput` and `ZResponse`

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?
- Call the `getPerson()` method and log the output, you should see the relevant fields

## Checklist
- [ ] Added a screen recording or screenshots to this PR
- [x] Filled out the "How to test" section in this PR
- [x] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] Updated the Formbricks Docs if changes were necessary
