### PR TITLE
Extend Webhook with surveyIds filter

### DIFF
--- a/apps/formbricks-com/pages/docs/webhook-api/create-webhook/index.mdx
+++ b/apps/formbricks-com/pages/docs/webhook-api/create-webhook/index.mdx
@@ -27,10 +27,16 @@ export const meta = {
       required: true,
     },
     {
-      label: "trigger",
-      type: "string",
-      description: "The event that will trigger the webhook.",
+      label: "triggers",
+      type: "string[]",
+      description: "List of events that will trigger the webhook",
       required: true,
+    },
+    {
+      label: "surveyIds",
+      type: "string[]",
+      description:
+        "List of survey IDs that will trigger the webhook. If not provided, the webhook will be triggered for all surveys.",
     },
   ]}
   example={`{
@@ -51,7 +57,8 @@ export const meta = {
     "environmentId": "clisypjy4000319t4imm289uo",
     "triggers": [
         "responseFinished"
-    ]
+    ],
+    "surveyIds": ["clisypjy4000319t4imm289uo"]
   }
 }`,
     },
@@ -82,9 +89,10 @@ export const meta = {
   ]}
 />
 
-| field name | required | default | description                                                                                            |
-| ---------- | -------- | ------- | ------------------------------------------------------------------------------------------------------ |
-| url        | yes      | -       | The endpoint that the webhook will send data to                                                        |
-| trigger    | yes      | -       | The event that will trigger the webhook ("responseCreated" or "responseUpdated" or "responseFinished") |
+| field name | required | default | description                                                                                                       |
+| ---------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| url        | yes      | -       | The endpoint that the webhook will send data to                                                                   |
+| trigger    | yes      | -       | The event that will trigger the webhook ("responseCreated" or "responseUpdated" or "responseFinished")            |
+| surveyIds  | no       | -       | List of survey IDs that will trigger the webhook. If not provided, the webhook will be triggered for all surveys. |
 
 export default ({ children }) => <Layout meta={meta}>{children}</Layout>;

--- a/apps/web/app/api/pipeline/route.ts
+++ b/apps/web/app/api/pipeline/route.ts
@@ -51,6 +51,18 @@ export async function POST(request: Request) {
       triggers: {
         hasSome: event,
       },
+      OR: [
+        {
+          surveyIds: {
+            has: surveyId,
+          },
+        },
+        {
+          surveyIds: {
+            isEmpty: true,
+          },
+        },
+      ],
     },
   });
 

--- a/packages/database/migrations/20230710112555_add_survey_ids_to_webhooks/migration.sql
+++ b/packages/database/migrations/20230710112555_add_survey_ids_to_webhooks/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Webhook" ADD COLUMN     "surveyIds" TEXT[];

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -37,6 +37,7 @@ model Webhook {
   environment   Environment        @relation(fields: [environmentId], references: [id], onDelete: Cascade)
   environmentId String
   triggers      PipelineTriggers[]
+  surveyIds     String[]
 }
 
 model Attribute {
@@ -313,19 +314,19 @@ enum WidgetPlacement {
 }
 
 model Product {
-  id                  String                @id @default(cuid())
-  createdAt           DateTime              @default(now()) @map(name: "created_at")
-  updatedAt           DateTime              @updatedAt @map(name: "updated_at")
+  id                  String          @id @default(cuid())
+  createdAt           DateTime        @default(now()) @map(name: "created_at")
+  updatedAt           DateTime        @updatedAt @map(name: "updated_at")
   name                String
-  team                Team                  @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  team                Team            @relation(fields: [teamId], references: [id], onDelete: Cascade)
   teamId              String
   environments        Environment[]
-  brandColor          String                @default("#64748b")
-  recontactDays       Int                   @default(7)
-  formbricksSignature Boolean               @default(true)
-  placement           WidgetPlacement       @default(bottomRight)
-  clickOutsideClose   Boolean               @default(true)
-  darkOverlay         Boolean               @default(false)
+  brandColor          String          @default("#64748b")
+  recontactDays       Int             @default(7)
+  formbricksSignature Boolean         @default(true)
+  placement           WidgetPlacement @default(bottomRight)
+  clickOutsideClose   Boolean         @default(true)
+  darkOverlay         Boolean         @default(false)
 }
 
 enum Plan {

--- a/packages/lib/services/webhook.ts
+++ b/packages/lib/services/webhook.ts
@@ -39,13 +39,14 @@ export const createWebhook = async (
   webhookInput: TWebhookInput
 ): Promise<TWebhook> => {
   try {
-    if (!webhookInput.url || !webhookInput.trigger) {
+    if (!webhookInput.url || !webhookInput.triggers) {
       throw new InvalidInputError("Missing URL or trigger in webhook input");
     }
     return await prisma.webhook.create({
       data: {
         url: webhookInput.url,
-        triggers: [webhookInput.trigger],
+        triggers: webhookInput.triggers,
+        surveyIds: webhookInput.surveyIds || [],
         environment: {
           connect: {
             id: environmentId,

--- a/packages/types/v1/webhooks.ts
+++ b/packages/types/v1/webhooks.ts
@@ -14,7 +14,8 @@ export type TWebhook = z.infer<typeof ZWebhook>;
 
 export const ZWebhookInput = z.object({
   url: z.string().url(),
-  trigger: ZPipelineTrigger,
+  triggers: z.array(ZPipelineTrigger),
+  surveyIds: z.array(z.string().cuid2()).optional(),
 });
 
 export type TWebhookInput = z.infer<typeof ZWebhookInput>;


### PR DESCRIPTION
Extend Webhook with surveyIds filter. Rename `trigger` to `triggers` to allow users to provide multiple trigger events for one webhook.

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Create a new webhook according to the updated docs
- List and delete webhooks
- Trigger a webhook for the selected triggers, check if surveyIds filter works

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

- [ ] Added a screen recording or screenshots to this PR
- [ ] Filled out the "How to test" section in this PR
- [ ] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] Updated the Formbricks Docs if changes were necessary
