### PR TITLE
add default question summary when response list is empty for CTA and …

### DIFF
--- a/apps/web/app/environments/[environmentId]/surveys/[surveyId]/summary/CTASummary.tsx
+++ b/apps/web/app/environments/[environmentId]/surveys/[surveyId]/summary/CTASummary.tsx
@@ -16,10 +16,11 @@ interface ChoiceResult {
 export default function CTASummary({ questionSummary }: CTASummaryProps) {
   const ctr: ChoiceResult = useMemo(() => {
     const clickedAbs = questionSummary.responses.filter((response) => response.value === "clicked").length;
-
+    const count = questionSummary.responses.length;
+    if (count === 0) return { count: 0, percentage: 0 };
     return {
-      count: questionSummary.responses.length,
-      percentage: clickedAbs / questionSummary.responses.length,
+      count: count,
+      percentage: clickedAbs / count,
     };
   }, [questionSummary]);
 

--- a/apps/web/app/environments/[environmentId]/surveys/[surveyId]/summary/ConsentSummary.tsx
+++ b/apps/web/app/environments/[environmentId]/surveys/[surveyId]/summary/ConsentSummary.tsx
@@ -2,6 +2,7 @@ import { ConsentQuestion } from "@formbricks/types/questions";
 import type { QuestionSummary } from "@formbricks/types/responses";
 import { ProgressBar } from "@formbricks/ui";
 import { InboxStackIcon } from "@heroicons/react/24/solid";
+import { useMemo } from "react";
 
 interface ConsentSummaryProps {
   questionSummary: QuestionSummary<ConsentQuestion>;
@@ -16,15 +17,20 @@ interface ChoiceResult {
 }
 
 export default function ConsentSummary({ questionSummary }: ConsentSummaryProps) {
-  const total = questionSummary.responses.length;
-  const clickedAbs = questionSummary.responses.filter((response) => response.value !== "dismissed").length;
-  const ctr: ChoiceResult = {
-    count: total,
-    acceptedCount: clickedAbs,
-    acceptedPercentage: clickedAbs / total,
-    dismissedCount: total - clickedAbs,
-    dismissedPercentage: 1 - clickedAbs / total,
-  };
+  const ctr: ChoiceResult = useMemo(() => {
+    const total = questionSummary.responses.length;
+    const clickedAbs = questionSummary.responses.filter((response) => response.value !== "dismissed").length;
+    if (total === 0) {
+      return { count: 0, acceptedCount: 0, acceptedPercentage: 0, dismissedCount: 0, dismissedPercentage: 0 };
+    }
+    return {
+      count: total,
+      acceptedCount: clickedAbs,
+      acceptedPercentage: clickedAbs / total,
+      dismissedCount: total - clickedAbs,
+      dismissedPercentage: 1 - clickedAbs / total,
+    };
+  }, [questionSummary]);
 
   return (
     <div className=" rounded-lg border border-slate-200 bg-slate-50 shadow-sm">


### PR DESCRIPTION
…Consent question summaries

## What does this PR do?

Checks if the response list is empty, then returning a default question summary to prevent NaN% from appearing and a full progress bar for CTA and consent question summaries.

Fixes #514 

[<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->](https://www.loom.com/share/8f349a5535d4422f9a1c81bb143a0585)

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

Create a new survey with one question. Complete the survey once. Edit the survey and add a CTA and consent question. Go to the survey summary page. Check the CTA and consent question summaries. They should both be at 0% for all answers and the progress bars should reflect 0%.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

- [x] Added a screen recording or screenshots to this PR
- [x] Filled out the "How to test" section in this PR
- [x] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] Updated the Formbricks Docs if changes were necessary
