### PR TITLE
Ci/CD: Push Formbricks Image to Dockerhub on Release with GitHub Actions

### DIFF
--- a/.github/workflows/release-on-dockerhub.yml
+++ b/.github/workflows/release-on-dockerhub.yml
@@ -1,0 +1,40 @@
+name: Release Formbricks Image on Dockerhub
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release-image-on-dockerhub:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Get Release Tag
+        id: extract_release_tag
+        run: |
+          TAG=${{ github.ref }}
+          TAG=${TAG#refs/tags/v}
+          echo "RELEASE_TAG=$TAG" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./apps/web/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/formbricks:${{ env.RELEASE_TAG }}
+            ${{ secrets.DOCKER_USERNAME }}/formbricks:latest

--- a/apps/formbricks-com/pages/docs/self-hosting/deployment/index.mdx
+++ b/apps/formbricks-com/pages/docs/self-hosting/deployment/index.mdx
@@ -8,68 +8,151 @@ export const meta = {
     "Utilize Docker-Compose for easy deployment on your machine. Clone the repo, configure settings, and build the image to access the app on localhost.",
 };
 
-<Callout title="Public Beta" type="warning">
-  Formbricks is not yet stable. Please reach out to us when you deploy Formbricks in production:
-  hola@formbricks.com
-</Callout>
+At Formbricks, we understand that different users have different needs, and we strive to cater to a wide variety of situations. This is why we provide two ways of running our application using Docker:
 
-## Deploy with Docker-Compose
+1. **Fast Setup with a Pre-built Docker Image:** This method is designed for those who want to quickly set up and start using Formbricks without getting into the technicalities of Docker or the build process. When you choose this method, you're using an image that we've already built for you. The pre-built image is ready-to-run, and it only requires minimal configuration on your part. This approach is perfect for getting a functional instance of Formbricks up and running with minimal hassle. It's as easy as downloading the Docker image and firing up the container.
 
-The easiest way to deploy Formbricks on your own machine is using Docker. This requires Docker and the docker compose plugin on your system to work.
+2. **Manual Setup by Building the Docker Image from Source:** This approach provides the flexibility to configure every aspect of your Formbricks instance, including environment variables that need to be set at build time. While we don't recommend changing the source code of Formbricks, this method allows you to set your own configuration that might be necessary for specific deployment needs. Keep in mind that this method requires a more in-depth understanding of Docker and the build process. However, the trade-off is the additional control and flexibility you gain, making it worth considering if you're a more advanced user or have very specific configuration needs.
 
-Clone the repository:
+Please note that regardless of the method you choose, Formbricks is designed to be easy-to-use and flexible. So choose the method that best fits your comfort level and requirements, and start leveraging the power of Formbricks today!
 
-```bash
-git clone https://github.com/formbricks/formbricks.git && cd formbricks
-```
+---
 
-Create a `.env` file based on `.env.docker` and change all fields according to your setup. This file comes with a basic setup and Formbricks works without making any changes to the file. To enable email sending functionality you need to configure the SMTP settings in the `.env` file. If you configured your email credentials, you can also comment the following lines to enable email verification (`# NEXT_PUBLIC_EMAIL_VERIFICATION_DISABLED=1`) and password reset (`# NEXT_PUBLIC_PASSWORD_RESET_DISABLED=1`)
+## Requirements
 
-Copy the `.env.docker` file to `.env` and edit it with an editor of your choice if needed.
+Ensure `docker` & `docker compose` are installed on your server/system. Both are typically included with Docker utilities, like Docker Desktop and Rancher Desktop.
 
-```bash
-cp .env.docker .env
-```
+**Note**: `docker compose` without the hyphen is now the primary method of using docker-compose, according to the Docker documentation.
 
-Note: The environment variables are used at build time. When you change environment variables later, you need to rebuild the image with `docker compose build` for the changes to take effect.
+## (Most users) Running the pre-built Docker Image
 
-Finally start the docker compose process to build and spin up the Formbricks container as well as the PostgreSQL database.
+This is suitable for those who are testing Formbricks or running it with minimal to no modifications. For this we use the [public Docker image](https://hub.docker.com/r/formbricks/formbricks) and a simple docker-compose file.
 
-```bash
-docker compose up -d
-# (use docker-compose if you are on an older docker version)
-```
+1. **Create a New Directory for Formbricks**
 
-You can now access the app on [http://localhost:3000](http://localhost:3000). You will be automatically redirected to the login. To use your local installation of Formbricks, create a new account.
+   Open a terminal and create a new directory for Formbricks, then navigate into this new directory:
 
-## Stop the containers
+   ```bash
+   mkdir formbricks-quickstart && cd formbricks-quickstart
+   ```
 
-To stop the containers, run:
+2. **Download the Docker-Compose File**
 
-```bash
-docker compose down
-```
+   Download the docker-compose file directly from the Formbricks repository:
 
-## Update Formbricks
+   ```bash
+   curl -o docker-compose.yml https://raw.githubusercontent.com/formbricks/formbricks/docker/main/docker-compose.yml
+   ```
 
-To update Formbricks, pull the latest changes from the repository:
+3. **Generate NextAuth Secret**
 
-```bash
-git pull
-```
+   Next, you need to generate a NextAuth secret. This will be used for session signing and encryption. The `sed` command below generates a random string using `openssl`, then replaces the `NEXTAUTH_SECRET:` placeholder in the `docker-compose.yml` file with this generated secret:
 
-and rebuild the image:
+   ```bash
+   sed -i "/NEXTAUTH_SECRET:$/s/NEXTAUTH_SECRET:.\*/NEXTAUTH_SECRET: $(openssl rand -base64 32)/" docker-compose.yml
+   ```
 
-```bash
-docker compose build
-```
+4. **Start the Docker Setup**
 
-Then you can stop and restart the containers again:
+   You're now ready to start the Formbricks Docker setup. The following command will start Formbricks together with a postgreSQL database using Docker Compose:
 
-```bash
-docker compose down
-docker compose up -d
-```
+   ```bash
+   docker compose up -d
+   ```
+
+   The `-d` flag will run the containers in detached mode, meaning they'll run in the background.
+
+5. **Visit Formbricks in Your Browser**
+
+   After starting the Docker setup, visit http://localhost:3000 in your browser to interact with the Formbricks application. The first time you access this page, you'll be greeted by a setup wizard. Follow the prompts to define your first user and get started.
+
+## Updating Formbricks
+
+1. Stop the Formbricks stack
+
+   ```bash
+   docker compose down
+   ```
+
+2. Pull the latest changes
+
+   ```bash
+   docker compose pull
+   ```
+
+3. Update env vars as necessary.
+4. Re-start the Formbricks stack
+
+   ```bash
+   docker compose up -d
+   ```
+
+## (Advanced users) Build and Run Formbricks
+
+1.  Clone the repository:
+
+    ```bash
+    git clone https://github.com/formbricks/formbricks.git && cd formbricks
+    ```
+
+    Create a `.env` file based on `.env.docker` and change all fields according to your setup. This file comes with a basic setup and Formbricks works without making any changes to the file. To enable email sending functionality you need to configure the SMTP settings in the `.env` file. If you configured your email credentials, you can also comment the following lines to enable email verification (`# NEXT_PUBLIC_EMAIL_VERIFICATION_DISABLED=1`) and password reset (`# NEXT_PUBLIC_PASSWORD_RESET_DISABLED=1`)
+
+2.  Copy the `.env.docker` file to `.env` and edit it with an editor of your choice if needed.
+
+    ```bash
+    cp .env.docker .env
+    ```
+
+    Note: The environment variables are used at build time. When you change environment variables later, you need to rebuild the image with `docker compose build` for the changes to take effect.
+
+3.  Finally start the docker compose process to build and spin up the Formbricks container as well as the PostgreSQL database.
+
+    ```bash
+    docker compose up -d
+    # (use docker-compose if you are on an older docker version)
+    ```
+
+    You can now access the app on [http://localhost:3000](http://localhost:3000). You will be automatically redirected to the login. To use your local installation of Formbricks, create a new account.
+
+Certainly, here is the reformatted version for Formbricks environment variables.
+
+### Important Run-time Variables
+
+These variables must also be provided at runtime.
+
+| Variable               | Description                                                                             | Required | Default                                                                 |
+| ---------------------- | --------------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------- |
+| NEXT_PUBLIC_WEBAPP_URL | Base URL of the site.                                                                   | required | `http://localhost:3000`                                                 |
+| DATABASE_URL           | Database URL with credentials.                                                          | required | `postgresql://postgres:postgres@postgres:5432/formbricks?schema=public` |
+| NEXTAUTH_SECRET        | Secret for NextAuth, used for session signing and encryption.                           | required | (Generated by the user)                                                 |
+| NEXTAUTH_URL           | Location of the auth server. By default, this is the Formbricks docker instance itself. | required | `http://localhost:3000`                                                 |
+
+### Build-time Variables
+
+These variables must be provided at the time of the docker build and can be provided by updating the `.env` file.
+
+| Variable                                | Description                                                                                  | Required                                      | Default                 |
+| --------------------------------------- | -------------------------------------------------------------------------------------------- | --------------------------------------------- | ----------------------- |
+| NEXT_PUBLIC_WEBAPP_URL                  | Base URL injected into static files.                                                         | required                                      | `http://localhost:3000` |
+| PRISMA_GENERATE_DATAPROXY               | Enables a dedicated connection pool for Prisma using Prisma Data Proxy. Uncomment to enable. | optional                                      |                         |
+| NEXT_PUBLIC_EMAIL_VERIFICATION_DISABLED | Disables email verification if set to `1`.                                                   | optional                                      |                         |
+| NEXT_PUBLIC_PASSWORD_RESET_DISABLED     | Disables password reset functionality if set to `1`.                                         | optional                                      |                         |
+| NEXT_PUBLIC_SIGNUP_DISABLED             | Disables the ability for new users to create an account if set to `1`.                       | optional                                      |                         |
+| NEXT_PUBLIC_INVITE_DISABLED             | Disables the ability for invited users to create an account if set to `1`.                   | optional                                      |                         |
+| NEXT_PUBLIC_PRIVACY_URL                 | URL for privacy policy.                                                                      | optional                                      |                         |
+| NEXT_PUBLIC_TERMS_URL                   | URL for terms of service.                                                                    | optional                                      |                         |
+| NEXT_PUBLIC_IMPRINT_URL                 | URL for imprint.                                                                             | optional                                      |                         |
+| SENTRY_IGNORE_API_RESOLUTION_ERROR      | Disables Sentry warning if set to `1`.                                                       | optional                                      |                         |
+| NEXT_PUBLIC_SENTRY_DSN                  | DSN for Sentry error tracking.                                                               | optional                                      |                         |
+| NEXT_PUBLIC_GITHUB_AUTH_ENABLED         | Enables GitHub login if set to `1`.                                                          | optional                                      |                         |
+| GITHUB_ID                               | Client ID for GitHub.                                                                        | optional (required if GitHub auth is enabled) |                         |
+| GITHUB_SECRET                           | Secret for GitHub.                                                                           | optional (required if GitHub auth is enabled) |                         |
+| NEXT_PUBLIC_GOOGLE_AUTH_ENABLED         | Enables Google login if set to `1`.                                                          | optional                                      |                         |
+| GOOGLE_CLIENT_ID                        | Client ID for Google.                                                                        | optional (required if Google auth is enabled) |                         |
+| GOOGLE_CLIENT_SECRET                    | Secret for Google.                                                                           | optional (required if Google auth is enabled) |                         |
+| CRON_SECRET                             | Secret for running cron jobs.                                                                | optional                                      |                         |
+
+Please refer to the [Formbricks Instructions](https://github.com/formbricks/formbricks) for more details on generating these variables.
 
 ## Debugging
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 COPY . .
 # Copy .env file because Docker don't follow symlinks
-COPY .env /app/apps/web/
+COPY .env.docker /app/apps/web/.env
 
 RUN pnpm install
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -34,4 +34,11 @@ COPY --from=installer --chown=nextjs:nodejs /app/apps/web/public ./apps/web/publ
 COPY --from=installer --chown=nextjs:nodejs /app/packages/database/schema.prisma ./packages/database/schema.prisma
 COPY --from=installer --chown=nextjs:nodejs /app/packages/database/migrations ./packages/database/migrations
 
-CMD pnpm dlx prisma migrate deploy && node apps/web/server.js
+ENV NEXTAUTH_SECRET=$NEXTAUTH_SECRET
+
+CMD if [ "$NEXTAUTH_SECRET" != "RANDOM_STRING" ]; then \
+        pnpm dlx prisma migrate deploy && node apps/web/server.js; \
+    else \
+        echo "ERROR: Please set a value for NEXTAUTH_SECRET in .env.docker!"; \
+        exit 1; \
+    fi

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+# Docker Setup
+
+Quickly run the Formbricks webapp locally with docker!
+
+## Steps to run locally
+1. `mkdir formbricks-quickstart && cd formbricks-quickstart`
+2. `curl -o docker-compose.yml https://raw.githubusercontent.com/formbricks/formbricks/docker/main/docker-compose.yml`
+3. `docker compose up`
+4. Now visit http://localhost:3000
+
+
+Note: For detailed documentation of local setup, take a look at our [self hosting docs](https://formbricks.com/docs/self-hosting/deployment)

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,12 +1,45 @@
-# Docker Setup
+# Formbricks Quickstart Using Docker
 
-Quickly run the Formbricks webapp locally with docker!
+Follow the instructions below to quickly get Formbricks running on your system with Docker. This guide is designed for most users who want a straightforward setup process.
 
-## Steps to run locally
-1. `mkdir formbricks-quickstart && cd formbricks-quickstart`
-2. `curl -o docker-compose.yml https://raw.githubusercontent.com/formbricks/formbricks/docker/main/docker-compose.yml`
-3. `docker compose up`
-4. Now visit http://localhost:3000
+1. **Create a New Directory for Formbricks**
 
+   Open a terminal and create a new directory for Formbricks, then navigate into this new directory:
+
+   \```bash
+   mkdir formbricks-quickstart && cd formbricks-quickstart
+   \```
+
+2. **Download the Docker-Compose File**
+
+   Download the docker-compose file directly from the Formbricks repository:
+
+   \```bash
+   curl -o docker-compose.yml https://raw.githubusercontent.com/formbricks/formbricks/docker/main/docker-compose.yml
+   \```
+
+3. **Generate NextAuth Secret**
+
+   Next, you need to generate a NextAuth secret. This will be used for session signing and encryption. The `sed` command below generates a random string using `openssl`, then replaces the `NEXTAUTH_SECRET:` placeholder in the `docker-compose.yml` file with this generated secret:
+
+   \```bash
+   sed -i "/NEXTAUTH_SECRET:$/s/NEXTAUTH_SECRET:.\*/NEXTAUTH_SECRET: $(openssl rand -base64 32)/" docker-compose.yml
+   \```
+
+4. **Start the Docker Setup**
+
+   You're now ready to start the Formbricks Docker setup. The following command will start Formbricks together with a postgreSQL database using Docker Compose:
+
+   \```bash
+   docker compose up -d
+   \```
+
+   The `-d` flag will run the containers in detached mode, meaning they'll run in the background.
+
+5. **Visit Formbricks in Your Browser**
+
+   After starting the Docker setup, visit http://localhost:3000 in your browser to interact with the Formbricks application. The first time you access this page, you'll be greeted by a setup wizard. Follow the prompts to define your first user and get started.
+
+Enjoy using Formbricks!
 
 Note: For detailed documentation of local setup, take a look at our [self hosting docs](https://formbricks.com/docs/self-hosting/deployment)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ x-environment: &environment
     # NextJS Auth
     # @see: https://next-auth.js.org/configuration/options#nextauth_secret
     # You can use: `openssl rand -base64 32` to generate one
-    NEXTAUTH_SECRET: RANDOM_STRIN
+    NEXTAUTH_SECRET: RANDOM_STRING
     # Set this to your public-facing URL, e.g., https://example.com
     # You do not need the NEXTAUTH_URL environment variable in Vercel.
     NEXTAUTH_URL: http://localhost:3000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ x-environment: &environment
     # NextJS Auth
     # @see: https://next-auth.js.org/configuration/options#nextauth_secret
     # You can use: `openssl rand -base64 32` to generate one
-    NEXTAUTH_SECRET: RANDOM_STRING
+    NEXTAUTH_SECRET:
     # Set this to your public-facing URL, e.g., https://example.com
     # You do not need the NEXTAUTH_URL environment variable in Vercel.
     NEXTAUTH_URL: http://localhost:3000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,45 @@
+version: "3.3"
+x-environment: &environment
+  environment:
+    ########################################################################
+    # ------------ MANDATORY (CHANGE ACCORDING TO YOUR SETUP) ------------#
+    ########################################################################
+
+    # PostgreSQL DB for Formbricks to connect to
+    DATABASE_URL: "postgresql://postgres:postgres@postgres:5432/formbricks?schema=public"
+
+    # Uncomment to enable a dedicated connection pool for Prisma using Prisma Data Proxy
+    # Cold boots will be faster and you'll be able to scale your DB independently of your app.
+    # @see https://www.prisma.io/docs/data-platform/data-proxy/use-data-proxy
+    # PRISMA_GENERATE_DATAPROXY=true
+    PRISMA_GENERATE_DATAPROXY:
+
+    # NextJS Auth
+    # @see: https://next-auth.js.org/configuration/options#nextauth_secret
+    # You can use: `openssl rand -base64 32` to generate one
+    NEXTAUTH_SECRET: RANDOM_STRIN
+    # Set this to your public-facing URL, e.g., https://example.com
+    # You do not need the NEXTAUTH_URL environment variable in Vercel.
+    NEXTAUTH_URL: http://localhost:3000
+
+services:
+  postgres:
+    restart: always
+    image: postgres:15-alpine
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
+
+  formbricks:
+    restart: always
+    image: formbricks/formbricks:latest
+    depends_on:
+      - postgres
+    ports:
+      - 3000:3000
+    <<: *environment
+
+volumes:
+  postgres:
+    driver: local


### PR DESCRIPTION
## What does this PR do?
Whenever we tag a commit prefixed with "v", this actions gets triggered and builds the Formbricks docker image and pushes it to `formbricks/formbricks`.

For example, for a tag v1.0.0:
- We will push to the formbricks dockerhub an image as: 
    - `formbricks/formbricks:1.0.0`
    - `formbricks/formbricks:latest`


TODO:
- [x] Set GitHub Actions Secret: `DOCKER_USERNAME`
- [x] Set GitHub Actions Secret: `DOCKER_PASSWORD`

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How I tested?
- Pushed from gh actions from my fork to my dockerhub here: https://hub.docker.com/repository/docker/laalshaitaan/formbricks/tags?page=1&ordering=last_updated
- Tested by running this with the `formbricks/docker`'s docker-compose.yml


## Checklist
- [ ] Added a screen recording or screenshots to this PR
- [ ] Filled out the "How to test" section in this PR
- [ ] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] Updated the Formbricks Docs if changes were necessary
