### PR TITLE
Fix Docker Compose URL for cURL

### DIFF
--- a/apps/formbricks-com/pages/docs/self-hosting/deployment/index.mdx
+++ b/apps/formbricks-com/pages/docs/self-hosting/deployment/index.mdx
@@ -41,7 +41,7 @@ This is suitable for those who are testing Formbricks or running it with minimal
    Download the docker-compose file directly from the Formbricks repository:
 
    ```bash
-   curl -o docker-compose.yml https://raw.githubusercontent.com/formbricks/formbricks/docker/main/docker-compose.yml
+   curl -o docker-compose.yml https://raw.githubusercontent.com/formbricks/formbricks/main/docker/docker-compose.yml
    ```
 
 3. **Generate NextAuth Secret**


### PR DESCRIPTION
## What does this PR do?
The URL had a misplaced branch name in the cURL URL for formbricks quickstart local deployment method. That is now fixed in this PR!

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## Checklist

- [ ] Added a screen recording or screenshots to this PR
- [ ] Filled out the "How to test" section in this PR
- [ ] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [x] Updated the Formbricks Docs if changes were necessary
