### PR TITLE
Introduce Restart Survey Button on Preview of Survey & Truncate Logic Values

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/PreviewSurvey.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/PreviewSurvey.tsx
@@ -7,11 +7,11 @@ import QuestionConditional from "@/components/preview/QuestionConditional";
 import ThankYouCard from "@/components/preview/ThankYouCard";
 import type { Logic, Question } from "@formbricks/types/questions";
 import { Survey } from "@formbricks/types/surveys";
-import { useEffect, useRef, useState } from "react";
-import type { TProduct } from "@formbricks/types/v1/product";
 import type { TEnvironment } from "@formbricks/types/v1/environment";
+import type { TProduct } from "@formbricks/types/v1/product";
 import { Button } from "@formbricks/ui";
 import { ArrowPathRoundedSquareIcon } from "@heroicons/react/24/outline";
+import { useEffect, useRef, useState } from "react";
 interface PreviewSurveyProps {
   setActiveQuestionId: (id: string | null) => void;
   activeQuestionId?: string | null;
@@ -283,7 +283,7 @@ export default function PreviewSurvey({
         <div className="ml-auto flex items-center">
           <Button
             variant="minimal"
-            className="mx-2 my-4 px-1 py-0.2 text-sm text-slate-400 bg-white"
+            className="mx-2 my-4 px-2 py-0.2 text-sm text-slate-500 bg-white"
             onClick={resetQuestionProgress}>
             Restart
             <ArrowPathRoundedSquareIcon className="ml-2 h-4 w-4" />

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/PreviewSurvey.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/PreviewSurvey.tsx
@@ -283,10 +283,10 @@ export default function PreviewSurvey({
         <div className="ml-auto flex items-center">
           <Button
             variant="minimal"
-            className="px-2 py-1 font-mono text-sm text-slate-400"
+            className="mx-2 my-4 px-1 py-0.2 text-sm text-slate-400 bg-white"
             onClick={resetQuestionProgress}>
             Restart
-            <ArrowPathRoundedSquareIcon className="ml-2 h-4 w-4 text-slate-400" />
+            <ArrowPathRoundedSquareIcon className="ml-2 h-4 w-4" />
           </Button>
         </div>
       </div>

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/PreviewSurvey.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/PreviewSurvey.tsx
@@ -10,6 +10,8 @@ import { Survey } from "@formbricks/types/surveys";
 import { useEffect, useRef, useState } from "react";
 import type { TProduct } from "@formbricks/types/v1/product";
 import type { TEnvironment } from "@formbricks/types/v1/environment";
+import { Button } from "@formbricks/ui";
+import { ArrowPathRoundedSquareIcon } from "@heroicons/react/24/outline";
 interface PreviewSurveyProps {
   setActiveQuestionId: (id: string | null) => void;
   activeQuestionId?: string | null;
@@ -243,6 +245,12 @@ export default function PreviewSurvey({
     setActiveQuestionId(previousQuestionId);
   }
 
+  function resetQuestionProgress() {
+    setProgress(0);
+    setActiveQuestionId(questions[0].id);
+    setStoredResponse({});
+  }
+
   useEffect(() => {
     if (environment && environment.widgetSetupCompleted) {
       setWidgetSetupCompleted(true);
@@ -272,6 +280,15 @@ export default function PreviewSurvey({
             {previewType === "modal" ? "Your web app" : "Preview"}
           </span>
         </p>
+        <div className="ml-auto flex items-center">
+          <Button
+            variant="minimal"
+            className="px-2 py-1 font-mono text-sm text-slate-400"
+            onClick={resetQuestionProgress}>
+            Restart
+            <ArrowPathRoundedSquareIcon className="ml-2 h-4 w-4 text-slate-400" />
+          </Button>
+        </div>
       </div>
 
       {previewType === "modal" ? (

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/edit/LogicEditor.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/edit/LogicEditor.tsx
@@ -245,13 +245,13 @@ export default function LogicEditor({
                 <div className="flex-1 basis-1/5">
                   {!logicConditions[logic.condition].multiSelect ? (
                     <Select value={logic.value} onValueChange={(e) => updateLogic(logicIdx, { value: e })}>
-                      <SelectTrigger>
+                      <SelectTrigger className="overflow-hidden">
                         <SelectValue placeholder="Select match type" />
                       </SelectTrigger>
                       <SelectContent>
                         {logicConditions[logic.condition].values?.map((value) => (
-                          <SelectItem key={value} value={value}>
-                            {value}
+                          <SelectItem key={value} value={value} title={value}>
+                            {truncate(value, 20)}
                           </SelectItem>
                         ))}
                       </SelectContent>


### PR DESCRIPTION
## What does this PR do?
- Introduce Restart Survey Button
- Restart also clears the progress made in the previous questions unlike the back button which stores it
- Uses the Hero Icon for the Restart Icon
- Truncate the logic edit field and hides the overflow for better UX on narrower screens

Due to padding issues and the small size of the button, I went ahead with the "minimal" variant as the other buttons were not looking great.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## Checklist
- [ ] Added a screen recording or screenshots to this PR
- [ ] Filled out the "How to test" section in this PR
- [x] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] Updated the Formbricks Docs if changes were necessary
