### PR TITLE
Add Loading State to Action Delete & Person Delete Buttons

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/(actionsAndAttributes)/actions/ActionSettingsTab.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/(actionsAndAttributes)/actions/ActionSettingsTab.tsx
@@ -42,6 +42,7 @@ export default function ActionSettingsTab({ environmentId, actionClass, setOpen 
     },
   });
   const [isUpdatingAction, setIsUpdatingAction] = useState(false);
+  const [isDeletingAction, setIsDeletingAction] = useState(false);
 
   const onSubmit = async (data) => {
     const filteredNoCodeConfig = filterNoCodeConfig(data.noCodeConfig as NoCodeConfig);
@@ -79,6 +80,20 @@ export default function ActionSettingsTab({ environmentId, actionClass, setOpen 
     setIsMatch(match);
     if (match === "yes") toast.success("Your survey would be shown on this URL.");
     if (match === "no") toast.error("Your survey would not be shown.");
+  };
+
+  const handleDeleteAction = async () => {
+    try {
+      setIsDeletingAction(true);
+      await deleteActionClass(environmentId, actionClass.id);
+      router.refresh();
+      toast.success("Action deleted successfully");
+      setOpen(false);
+    } catch (error) {
+      toast.error("Something went wrong. Please try again.");
+    } finally {
+      setIsDeletingAction(false);
+    }
   };
 
   return (
@@ -288,18 +303,10 @@ export default function ActionSettingsTab({ environmentId, actionClass, setOpen 
       <DeleteDialog
         open={openDeleteDialog}
         setOpen={setOpenDeleteDialog}
+        isDeleting={isDeletingAction}
         deleteWhat={"Action"}
         text="Are you sure you want to delete this action? This also removes this action as a trigger from all your surveys."
-        onDelete={async () => {
-          setOpen(false);
-          try {
-            await deleteActionClass(environmentId, actionClass.id);
-            router.refresh();
-            toast.success("Action deleted successfully");
-          } catch (error) {
-            toast.error("Something went wrong. Please try again.");
-          }
-        }}
+        onDelete={handleDeleteAction}
       />
     </div>
   );

--- a/apps/web/app/(app)/environments/[environmentId]/people/[personId]/HeadingSection.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/people/[personId]/HeadingSection.tsx
@@ -19,10 +19,19 @@ export default function HeadingSection({
   const router = useRouter();
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [isDeletingPerson, setIsDeletingPerson] = useState(false);
+
   const handleDeletePerson = async () => {
-    await deletePersonAction(person.id);
-    router.push(`/environments/${environmentId}/people`);
-    toast.success("Person deleted successfully.");
+    try {
+      setIsDeletingPerson(true);
+      await deletePersonAction(person.id);
+      router.push(`/environments/${environmentId}/people`);
+      toast.success("Person deleted successfully.");
+    } catch (error) {
+      toast.error(error.message);
+    } finally {
+      setIsDeletingPerson(false);
+    }
   };
 
   return (
@@ -46,6 +55,7 @@ export default function HeadingSection({
         setOpen={setDeleteDialogOpen}
         deleteWhat="person"
         onDelete={handleDeletePerson}
+        isDeleting={isDeletingPerson}
       />
     </>
   );


### PR DESCRIPTION
## What does this PR do?
Adds loader and state management for the loaders in deletion of action and person!

## Fixes
It takes 20ish seconds to delete an action on prod:
- The modal closes immediately after button click and the action is still visible. Instead, add a loading state to the delete button and wait for the action to be deleted to close it.

Make sure the frontend does not display the action even though it was deleted.

Same is true for deleting a person

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Added a screen recording or screenshots to this PR
- [ ] Filled out the "How to test" section in this PR
- [x] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] Updated the Formbricks Docs if changes were necessary
