### PR TITLE
Log Survey Count & Names on Sync in JS widget

### DIFF
--- a/packages/js/src/lib/sync.ts
+++ b/packages/js/src/lib/sync.ts
@@ -2,8 +2,10 @@ import { TJsState } from "@formbricks/types/v1/js";
 import { trackAction } from "./actions";
 import { Config } from "./config";
 import { NetworkError, Result, err, ok } from "./errors";
+import { Logger } from "./logger";
 
 const config = Config.getInstance();
+const logger = Logger.getInstance();
 
 const syncWithBackend = async (): Promise<Result<TJsState, NetworkError>> => {
   const url = `${config.get().apiHost}/api/v1/js/sync`;
@@ -42,6 +44,9 @@ export const sync = async (): Promise<void> => {
   const state = syncResult.value;
   const oldState = config.get().state;
   config.update({ state });
+  const surveyNames = state.surveys.map((s) => s.name);
+  logger.debug("Fetched " + surveyNames.length + " surveys during sync: " + surveyNames);
+
   // if session is new, track action
   if (!oldState?.session || oldState.session.id !== state.session.id) {
     const trackActionResult = await trackAction("New Session");


### PR DESCRIPTION
## What does this PR do?
The sync call now logs the number of surveys fetched and their names in the debug mode for easier debugging to find if a survey is fetched or not! Logging the number makes it much easier to compare from a previous state as compared to iterating through all the names!


## Type of change
- [x] Enhancement (small improvements)

## Checklist
- [ ] Added a screen recording or screenshots to this PR
- [ ] Filled out the "How to test" section in this PR
- [x] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] Updated the Formbricks Docs if changes were necessary
