### PR TITLE
Initialized Gitpod tested scripts

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,6 @@
+FROM gitpod/workspace-full
+
+# Install custom tools, runtime, etc.
+RUN brew install yq 
+
+RUN pnpm install turbo --global

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,17 +1,4 @@
 tasks:
-  - name: errors
-    command: |
-      gp sync-await init && 
-      turbo --filter "@formbricks/errors" go
-
-  - name: api
-    init: |
-      gp sync-await init-install &&
-      bash .gitpod/setup-api.bash
-    command: |
-      gp sync-await init && 
-      turbo --filter "@formbricks/api" go
-    
   - name: demo
     init: |
       gp sync-await init-install && 
@@ -22,18 +9,6 @@ tasks:
       sed -i -r "s#^(NEXT_PUBLIC_FORMBRICKS_API_HOST=).*#\1 $(gp url 3000)#" .env &&
       gp sync-await init && 
       turbo --filter "@formbricks/demo" go
-
-  - name: web
-    init: |
-      gp sync-await init-install && 
-      bash .gitpod/setup-web.bash &&
-      turbo --filter "@formbricks/database" db:down
-    command: |
-      gp sync-await init &&
-      cp .env.example .env &&
-      sed -i -r "s#^(NEXT_PUBLIC_WEBAPP_URL=).*#\1 $(gp url 3000)#" .env &&
-      sed -i -r "s#^(NEXTAUTH_URL=).*#\1 $(gp url 3000)#" .env &&
-      turbo --filter "@formbricks/web" go
 
   - name : website
     command: gp sync-await init && turbo --filter "@formbricks/formbricks-com" dev
@@ -49,6 +24,18 @@ tasks:
       gp tasks list &&
       gp ports await 3002 && gp ports await 3000 && gp open apps/demo/.env && gp preview $(gp url 3002) --external
 
+  - name: web
+    init: |
+      gp sync-await init-install && 
+      bash .gitpod/setup-web.bash &&
+      turbo --filter "@formbricks/database" db:down
+    command: |
+      gp sync-await init &&
+      cp .env.example .env &&
+      sed -i -r "s#^(NEXT_PUBLIC_WEBAPP_URL=).*#\1 $(gp url 3000)#" .env &&
+      sed -i -r "s#^(NEXTAUTH_URL=).*#\1 $(gp url 3000)#" .env &&
+      turbo --filter "@formbricks/web" go
+      
 image:
   file: .gitpod.Dockerfile
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -35,6 +35,9 @@ tasks:
       sed -i -r "s#^(NEXTAUTH_URL=).*#\1 $(gp url 3000)#" .env &&
       turbo --filter "@formbricks/web" go
 
+  - name : website
+    command: gp sync-await init && turbo --filter "@formbricks/formbricks-com" dev
+
   - name: Init Formbricks
     init: |
       cp .env.example .env &&
@@ -53,6 +56,9 @@ ports:
   - port: 3000
     visibility: public
     onOpen: open-browser
+  - port: 3001
+    visibility: public
+    onOpen: ignore
   - port: 3002
     visibility: public
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -59,7 +59,13 @@ ports:
   - port: 5432
     visibility: public
     onOpen: ignore
-
+  - port: 1025
+    visibility: public
+    onOpen: ignore
+  - port: 8025
+    visibility: public
+    onOpen: ignore
+    
 github:
   prebuilds:
     master: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,77 @@
+tasks:
+  - name: errors
+    command: |
+      gp sync-await init && 
+      turbo --filter "@formbricks/errors" go
+
+  - name: api
+    init: |
+      gp sync-await init-install &&
+      bash .gitpod/setup-api.bash
+    command: |
+      gp sync-await init && 
+      turbo --filter "@formbricks/api" go
+    
+  - name: demo
+    init: |
+      gp sync-await init-install && 
+      bash .gitpod/setup-demo.bash
+    command: |
+      cd apps/demo && 
+      cp .env.example .env &&
+      sed -i -r "s#^(NEXT_PUBLIC_FORMBRICKS_API_HOST=).*#\1 $(gp url 3000)#" .env &&
+      gp sync-await init && 
+      turbo --filter "@formbricks/demo" go
+
+  - name: web
+    init: |
+      gp sync-await init-install && 
+      bash .gitpod/setup-web.bash &&
+      turbo --filter "@formbricks/database" db:down
+    command: |
+      gp sync-await init &&
+      cp .env.example .env &&
+      sed -i -r "s#^(NEXT_PUBLIC_WEBAPP_URL=).*#\1 $(gp url 3000)#" .env &&
+      sed -i -r "s#^(NEXTAUTH_URL=).*#\1 $(gp url 3000)#" .env &&
+      turbo --filter "@formbricks/web" go
+
+  - name: Init Formbricks
+    init: |
+      cp .env.example .env &&
+      bash .gitpod/init.bash && 
+      turbo --filter "@formbricks/js" build && 
+      gp sync-done init-install
+    command: |
+      gp sync-done init && 
+      gp tasks list &&
+      gp ports await 3002 && gp ports await 3000 && gp open apps/demo/.env && gp preview $(gp url 3002) --external
+
+image:
+  file: .gitpod.Dockerfile
+
+ports:
+  - port: 3000
+    visibility: public
+    onOpen: open-browser
+  - port: 3002
+    visibility: public
+    onOpen: ignore
+  - port: 5432
+    visibility: public
+    onOpen: ignore
+
+github:
+  prebuilds:
+    master: true
+    pullRequests: true
+    addComment: true
+
+vscode:
+  extensions:
+    - "ban.spellright"
+    - "bradlc.vscode-tailwindcss"
+    - "DavidAnson.vscode-markdownlint"
+    - "dbaeumer.vscode-eslint"
+    - "esbenp.prettier-vscode"
+    - "Prisma.prisma"
+    - "yzhang.markdown-all-in-one"

--- a/.gitpod/init.bash
+++ b/.gitpod/init.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+images=($(yq eval '.services.*.image' packages/database/docker-compose.yml))
+
+pull_image() {
+  docker pull "$1"
+}
+
+# install packages in background
+pnpm i &
+
+# pull images
+for image in "${images[@]}"
+do
+  pull_image "$image" &
+done
+
+wait

--- a/.gitpod/setup-api.bash
+++ b/.gitpod/setup-api.bash
@@ -1,5 +1,0 @@
-for task in $(yq -r -oy '.pipeline."@formbricks/api#go".dependsOn[]' turbo.json); do
-  package="${task%#*}"
-  command="${task#*#}"
-  turbo --filter "$package" $command
-done

--- a/.gitpod/setup-api.bash
+++ b/.gitpod/setup-api.bash
@@ -1,0 +1,5 @@
+for task in $(yq -r -oy '.pipeline."@formbricks/api#go".dependsOn[]' turbo.json); do
+  package="${task%#*}"
+  command="${task#*#}"
+  turbo --filter "$package" $command
+done

--- a/.gitpod/setup-demo.bash
+++ b/.gitpod/setup-demo.bash
@@ -1,0 +1,5 @@
+for task in $(yq -r -oy '.pipeline."@formbricks/demo#go".dependsOn[]' turbo.json); do
+  package="${task%#*}"
+  command="${task#*#}"
+  turbo --filter "$package" $command
+done

--- a/.gitpod/setup-web.bash
+++ b/.gitpod/setup-web.bash
@@ -1,0 +1,5 @@
+for task in $(yq -r -oy '.pipeline."@formbricks/web#go".dependsOn[]' turbo.json); do
+  package="${task%#*}"
+  command="${task#*#}"
+  turbo --filter "$package" $command
+done

--- a/apps/demo/package.json
+++ b/apps/demo/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "clean": "rimraf .turbo node_modules .next",
     "dev": "next dev -p 3002 --turbo",
-    "go": "next dev -p 3002 --turbo",
+    "go": "next dev -p 3002",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -17,6 +17,7 @@
     "db:up": "docker-compose up -d",
     "db:setup": "pnpm db:up && pnpm db:migrate:dev",
     "db:start": "pnpm db:setup",
+    "db:down": "docker-compose down",
     "format": "prisma format",
     "generate": "prisma generate",
     "lint": "eslint ./src --fix",

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,20 @@
       "persistent": true,
       "dependsOn": ["@formbricks/database#db:setup", "@formbricks/js#build"]
     },
+    "@formbricks/demo#go": {
+      "cache": false,
+      "persistent": true,
+      "dependsOn": [
+        "@formbricks/js#build"
+      ]
+    },
+    "@formbricks/api#go": {
+      "cache": false,
+      "persistent": true,
+      "dependsOn": [
+        "@formbricks/errors#build"
+      ]
+    },
     "@formbricks/api#build": {
       "outputs": ["dist/**"],
       "dependsOn": ["^build"]
@@ -91,6 +105,10 @@
       "env": ["PRISMA_GENERATE_DATAPROXY"]
     },
     "db:setup": {
+      "cache": false,
+      "outputs": []
+    },
+    "db:down": {
       "cache": false,
       "outputs": []
     },

--- a/turbo.json
+++ b/turbo.json
@@ -17,13 +17,6 @@
         "@formbricks/js#build"
       ]
     },
-    "@formbricks/api#go": {
-      "cache": false,
-      "persistent": true,
-      "dependsOn": [
-        "@formbricks/errors#build"
-      ]
-    },
     "@formbricks/api#build": {
       "outputs": ["dist/**"],
       "dependsOn": ["^build"]


### PR DESCRIPTION
## What does this PR do? 
Fixes #509 

- Adds Gitpod Scripts with Prebuilds scripts and by abstractions optimized to support turborepo tasks of Formbricks to start under 2 mins!

## Type of change
Added better DevX to open up already setup dev environment to get started Coding/Reviewing and Contributing!!
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How should this be tested?
You can test it by clicking on the below "Open in Gitpod" button as it has prebuilds enabled at [Palanikannan1437:gitpod-integration](https://github.com/Palanikannan1437/formbricks/tree/gitpod-integration)

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/Palanikannan1437/formbricks/tree/gitpod-integration)

# Changes in Detail
## Tasks
Installs `yq` and `turbo` globally before the workspace starts -> `.gitpod.Dockerfile` for starting upon a base custom image building on [workspace-full](https://hub.docker.com/r/gitpod/workspace-full/dockerfile)

1. Init Formbricks: 
   1. Init (during prebuilds):
       1. Initialises env variables 
       2. Installs monorepo deps
       3. Installs the docker images by extracting it from `packages/database/docker-compose.yml`
       4. Builds `@formbricks/js`
   2. Command (during workspace start):
       1. Waits for `web` and `demo` apps to start and opens the `apps/demo/.env` file automatically such that users can start playing around with the demo app by configuring `NEXT_PUBLIC_FORMBRICKS_ENVIRONMENT_ID` straight away!

2. Web : 
     1. Init (during prebuilds):
       1. Installs all build deps for the `@formbricks/web#go` task from `turbo.json` in prebuilds to save time
       2. The above step creates and starts `postgres` and `mailhog` containers to run migrations in prebuilds
       3. Then to cleanup such that the "Init" task isn't infinitely running due to prebuild rules, I added a cleanup `docker compose down` step i.e. `db:down` task to stop running containers.
    2. Command (during workspace start):
       1. Initializes env variables
       2. Replaces `NEXT_PUBLIC_WEBAPP_URL` and `NEXTAUTH_URL` to take in Gitpod URL's ports when running on VSCode browser
       3. Starts the `@formbricks/web` dev env
  
3. Demo:
    1. Init (during prebuilds):
       1. Installs all build deps for the `@formbricks/demo#go` task from `turbo.json` in prebuilds to save time
       2. Cache hits and `@formbricks/js#build` replays (from Init Formbricks task)
    2. Command (during workspace start):
       1. Initializes env variables
       2. Replaces `NEXT_PUBLIC_FORMBRICKS_API_HOST` to take in Gitpod URL's ports when running on VSCode browser
       3. Starts the `@formbricks/demo` dev env

4. Website: Starts the `@formbricks/formbricks-com` dev environment

5. api: This task initializes by running the setup-api.bash script which is similar to `Web` and `Demo` and then runs the turbo command with the "@formbricks/api" filter after syncing with the init task. And hence I've added in `turbo.json`

```
 "@formbricks/api#go": {
      "cache": false,
      "persistent": true,
      "dependsOn": [
        "@formbricks/errors#build"
      ]
 },
```

6. errors: This task runs the turbo command with the "@formbricks/errors" filter after syncing with the init task.

## GitHub Prebuilds

### How to configure Prebuilds?
1. Head over [here](https://www.gitpod.io/docs/configure/projects/prebuilds#enable-prebuilds-on-your-repository-project) and follow these steps to setup Gitpod GitHub app, create a project, etc to make prebuilds work!
2. GitHub prebuilds are enabled for the master branch, pull requests, and adding comments.

It'll finally look like this when it runs on one of your branches....
<img width="1129" alt="image" src="https://github.com/formbricks/formbricks/assets/73993394/aebbc867-1557-4605-9f4e-29d0bc88f065">


## VSCode Extensions Added for Gitpod 
The following VSCode extensions are added to the configuration based on extensions.json in `.vscode` directory:
1. ban.spellright
2. bradlc.vscode-tailwindcss
3. DavidAnson.vscode-markdownlint
4. dbaeumer.vscode-eslint
5. esbenp.prettier-vscode
6. Prisma.prisma
7. yzhang.markdown-all-in-one

## Demo
https://github.com/formbricks/formbricks/assets/73993394/1457abab-df8c-423b-bf3c-00c461531add

## Checklist
- [x] Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary