### PR TITLE
Update .env.docker

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -47,7 +47,7 @@ NEXTAUTH_URL=http://localhost:3000
 # SMTP_HOST=localhost
 # SMTP_PORT=1025
 # Enable SMTP_SECURE_ENABLED for TLS (port 465)
-# SMTP_SECURE_ENABLED=0 # Enable for TLS (port 465)
+# SMTP_SECURE_ENABLED=0
 # SMTP_USER=smtpUser
 # SMTP_PASSWORD=smtpPassword
 


### PR DESCRIPTION
removed inline comment for smtp_port to avoid docker build failure 

## What does this PR do?

If the inline comment is kept, the following error occurs during docker image build. 
This occurred on Docker version 24.0.4, build 3713ee1

```log
@formbricks/web:build: ❌ Invalid environment variables: {
@formbricks/web:build:   SMTP_SECURE_ENABLED: [
@formbricks/web:build:     "Invalid enum value. Expected '1' | '0', received '1 # Enable for TLS (port 465)'"
@formbricks/web:build:   ]
@formbricks/web:build: }
@formbricks/web:build: - error Failed to load next.config.mjs, see more info here https://nextjs.org/docs/messages/next-config-error
@formbricks/web:build: 
```

## Type of change

- [x] Chore (refactoring code, technical debt, workflow improvements)

## How should this be tested?

There is no need for testing

## Checklist

- [x] My changes don't cause any responsiveness issues

