### PR TITLE
Add Support for Email Services in Single Script Prod Setup

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,6 +25,13 @@ x-environment: &environment
     # PostgreSQL password
     POSTGRES_PASSWORD: postgres
 
+    MAIL_FROM:
+    SMTP_HOST:
+    SMTP_PORT:
+    SMTP_SECURE_ENABLED:
+    SMTP_USER:
+    SMTP_PASSWORD:
+
 services:
   postgres:
     restart: always


### PR DESCRIPTION
## What does this PR do?
We now allow users to set custom SMTP email servers to configure email notifications and other services that we have to offer for the user!

## Type of change
- [x] Enhancement (small improvements)

## How should this be tested?
Copy and run the new production.sh script and see your email notifications working!

## Checklist
- [ ] Added a screen recording or screenshots to this PR
- [x] Filled out the "How to test" section in this PR
- [x] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] Updated the Formbricks Docs if changes were necessary
