### PR TITLE
Mention Editing Build-time Variables in deployment Guides

### DIFF
--- a/apps/formbricks-com/app/docs/self-hosting/docker/page.mdx
+++ b/apps/formbricks-com/app/docs/self-hosting/docker/page.mdx
@@ -165,4 +165,12 @@ formbricks-quickstart-formbricks-1  | Listening on port 3000 url: http://<random
 
 You can close the logs again with `CTRL + C`.
 
+<Note>
+## Customizing the Build Time variables
+
+To edit any of the variables that start with `NEXT_PUBLIC_`, you need to rebuild the Formbricks Docker from source! It is just one
+more added step and is not as much of a hassle as you think! Please check the [Building from Source](/docs/self-hosting/from-source) section!
+
+</Note>
+
 Still facing issues? [Join our Discord!](https://formbricks.com/discord) and we'd be glad to assist you!

--- a/apps/formbricks-com/app/docs/self-hosting/from-source/page.mdx
+++ b/apps/formbricks-com/app/docs/self-hosting/from-source/page.mdx
@@ -32,6 +32,7 @@ Ensure `docker` & `docker compose` are installed on your server/system. Both are
 2.  **Modify the `.env.docker` file as required by your setup.** <br/> This file comes with a basic setup and Formbricks works without making any changes to the file. To enable email sending functionality you need to configure the SMTP settings. If you configured your email credentials, you can also comment the following lines to enable email verification (`# NEXT_PUBLIC_EMAIL_VERIFICATION_DISABLED=1`) and password reset (`# NEXT_PUBLIC_PASSWORD_RESET_DISABLED=1`)
 
         <Note>
+           ## Editing a NEXT_PUBLIC_* variable?
           Note: All environment variables starting with `NEXT_PUBLIC_` are used at build time. When you change
           environment variables later, you need to rebuild the image with `docker compose build` for the changes
           to take effect.

--- a/apps/formbricks-com/app/docs/self-hosting/production/page.mdx
+++ b/apps/formbricks-com/app/docs/self-hosting/production/page.mdx
@@ -168,6 +168,14 @@ cd formbricks && docker compose logs -f
 
 You can close the logs again with `CTRL + C`.
 
+<Note>
+## Customizing the Build Time variables
+
+To edit any of the variables that start with `NEXT_PUBLIC_`, you need to rebuild the Formbricks Docker from source! It is just one
+more added step and is not as much of a hassle as you think! Please check the [Building from Source](/docs/self-hosting/from-source) section!
+
+</Note>
+
 ## Troubleshooting
 
 If you encounter any issues, consider the following steps:
@@ -180,4 +188,4 @@ If you encounter any issues, consider the following steps:
 
 - **Check Formbricks Logs**: Run `cd formbricks && docker compose logs` to check the logs of the Formbricks stack.
 
-- **Still can’t figure it out?**: [Join our Discord!](https://formbricks.com/discord)
+**Still can’t figure it out?**: [Join our Discord!](https://formbricks.com/discord)


### PR DESCRIPTION
## What does this PR do?
We faced quite a few queries about people trying to edit the `NEXT_PUBLIC_` and since they are configured at build-time, the changes are not reflected resulting in a bad UX! This PR adds a Note and a link to the **From Source** page to the other 2 deployment guides ie the Docker and the Single Script setup Guide.

## Type of change
- [x] Enhancement (small improvements)
- [x] This change requires a documentation update

## Checklist
- [ ] Added a screen recording or screenshots to this PR
- [ ] Filled out the "How to test" section in this PR
- [x] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] Updated the Formbricks Docs if changes were necessary
