### PR TITLE
fix: landing page build issue due to strapi

### DIFF
--- a/apps/formbricks-com/pages/learn/[slug].tsx
+++ b/apps/formbricks-com/pages/learn/[slug].tsx
@@ -52,6 +52,9 @@ interface ArticleResponse {
 }
 
 export async function getStaticPaths() {
+  if (!process.env.STRAPI_API_KEY) {
+    return { paths: [], fallback: true };
+  }
   const response = await fetch(
     "https://strapi.formbricks.com/api/articles?populate[meta][populate]=*&filters[category][name][$eq]=learn",
     {
@@ -74,6 +77,9 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }) {
+  if (!process.env.STRAPI_API_KEY) {
+    return { props: { article: null } };
+  }
   const res = await fetch(
     `https://strapi.formbricks.com/api/articles?populate[meta][populate]=*&populate[faq][populate]=*&filters[slug][$eq]=${params.slug}`,
     {


### PR DESCRIPTION
## What does this PR do?
We now fetch and build the STRAPI learn pages only if the key exists thus preventing build failures

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Added a screen recording or screenshots to this PR
- [ ] Filled out the "How to test" section in this PR
- [x] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] Updated the Formbricks Docs if changes were necessary
