### PR TITLE
fix: link survey responses may fail when custom survey url is set

### DIFF
--- a/apps/web/app/s/[surveyId]/LinkSurvey.tsx
+++ b/apps/web/app/s/[surveyId]/LinkSurvey.tsx
@@ -42,7 +42,7 @@ export default function LinkSurvey({
     () =>
       new ResponseQueue(
         {
-          apiHost: typeof window !== "undefined" ? window.location?.origin : WEBAPP_URL,
+          apiHost: WEBAPP_URL,
           retryAttempts: 2,
           onResponseSendingFailed: (response) => {
             alert(`Failed to send response: ${JSON.stringify(response, null, 2)}`);


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

link survey responses may fail when custom survey url is set

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update