### PR TITLE
fix: (webhook ui) cache is not getting invalidated

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/integrations/webhooks/page.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/integrations/webhooks/page.tsx
@@ -1,9 +1,12 @@
+export const revalidate = REVALIDATION_INTERVAL;
+
 import WebhookRowData from "@/app/(app)/environments/[environmentId]/integrations/webhooks/WebhookRowData";
 import WebhookTable from "@/app/(app)/environments/[environmentId]/integrations/webhooks/WebhookTable";
 import WebhookTableHeading from "@/app/(app)/environments/[environmentId]/integrations/webhooks/WebhookTableHeading";
 import GoBackButton from "@/components/shared/GoBackButton";
 import { getSurveys } from "@formbricks/lib/services/survey";
 import { getWebhooks } from "@formbricks/lib/services/webhook";
+import { REVALIDATION_INTERVAL } from "@formbricks/lib/constants";
 
 export default async function CustomWebhookPage({ params }) {
   const webhooks = (await getWebhooks(params.environmentId)).sort((a, b) => {


### PR DESCRIPTION
## What does this PR do?
A bug found in the v1.0.3 release is that the Webhooks UI is not rendering the webhooks! Faced issues debugging locally since it was working and then the only possible cause was that I missed to set the revalidation interval to the page! Causing it to cache the response hence not showing the latest data. This PR adds the revalidation interval!

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Added a screen recording or screenshots to this PR
- [ ] Filled out the "How to test" section in this PR
- [x] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] Updated the Formbricks Docs if changes were necessary
