### PR TITLE
fix: Stop Sync after logout()

### DIFF
--- a/packages/js/src/lib/config.ts
+++ b/packages/js/src/lib/config.ts
@@ -6,6 +6,19 @@ const LOCAL_STORAGE_KEY = "formbricks-js";
 export class Config {
   private static instance: Config | undefined;
   private config: TJsConfig = this.loadFromLocalStorage();
+  private _isSyncAllowed: boolean = true;
+
+  public allowSync() {
+    this._isSyncAllowed = true;
+  }
+
+  public disallowSync() {
+    this._isSyncAllowed = false;
+  }
+
+  public get isSyncAllowed() {
+    return this._isSyncAllowed;
+  }
 
   static getInstance(): Config {
     if (!Config.instance) {

--- a/packages/js/src/lib/init.ts
+++ b/packages/js/src/lib/init.ts
@@ -24,7 +24,7 @@ const logger = Logger.getInstance();
 let syncIntervalId: number | null = null;
 
 const addSyncEventListener = (debug?: boolean): void => {
-  const updateInverval = debug ? 1000 * 30 : 1000 * 60 * 2; // 2 minutes in production, 30 seconds in debug mode
+  const updateInverval = debug ? 1000 * 10 : 1000 * 60 * 2; // 2 minutes in production, 30 seconds in debug mode
   // add event listener to check sync with backend on regular interval
   if (typeof window !== "undefined") {
     // clear any existing interval
@@ -33,6 +33,9 @@ const addSyncEventListener = (debug?: boolean): void => {
     }
     syncIntervalId = window.setInterval(async () => {
       logger.debug("Syncing.");
+      if (!config.isSyncAllowed) {
+        return;
+      }
       await sync();
     }, updateInverval);
     // clear interval on page unload
@@ -55,6 +58,7 @@ export const initialize = async (
   ErrorHandler.getInstance().printStatus();
 
   logger.debug("Start initialize");
+  config.allowSync();
 
   if (!c.environmentId) {
     logger.debug("No environmentId provided");

--- a/packages/js/src/lib/init.ts
+++ b/packages/js/src/lib/init.ts
@@ -24,7 +24,7 @@ const logger = Logger.getInstance();
 let syncIntervalId: number | null = null;
 
 const addSyncEventListener = (debug?: boolean): void => {
-  const updateInverval = debug ? 1000 * 10 : 1000 * 60 * 2; // 2 minutes in production, 30 seconds in debug mode
+  const updateInverval = debug ? 1000 * 30 : 1000 * 60 * 2; // 2 minutes in production, 30 seconds in debug mode
   // add event listener to check sync with backend on regular interval
   if (typeof window !== "undefined") {
     // clear any existing interval
@@ -32,10 +32,10 @@ const addSyncEventListener = (debug?: boolean): void => {
       window.clearInterval(syncIntervalId);
     }
     syncIntervalId = window.setInterval(async () => {
-      logger.debug("Syncing.");
       if (!config.isSyncAllowed) {
         return;
       }
+      logger.debug("Syncing.");
       await sync();
     }, updateInverval);
     // clear interval on page unload

--- a/packages/js/src/lib/person.ts
+++ b/packages/js/src/lib/person.ts
@@ -179,6 +179,7 @@ export const setPersonAttribute = async (
 export const logoutPerson = async (): Promise<void> => {
   logger.debug("Resetting state");
   config.update({ state: undefined });
+  config.disallowSync();
 };
 
 export const resetPerson = async (): Promise<Result<void, NetworkError>> => {

--- a/packages/js/src/lib/person.ts
+++ b/packages/js/src/lib/person.ts
@@ -186,6 +186,7 @@ export const resetPerson = async (): Promise<Result<void, NetworkError>> => {
   logger.debug("Resetting state & getting new state from backend");
   await logoutPerson();
   try {
+    config.allowSync();
     await sync();
     return okVoid();
   } catch (e) {


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
After calling logout() sync stops.

Fixes [1311](https://linear.app/formbricks/issue/FOR-1311/stop-sync-in-formbricks-js-when-logout-is-called)

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Open demo app
Call logout()
Check for logs into console (sync shouldn't occur after logout is called)

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

- [ ] Added a screen recording or screenshots to this PR
- [x] Filled out the "How to test" section in this PR
- [x] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] Updated the Formbricks Docs if changes were necessary
