### PR TITLE
fix: formtribe page should only be shown in light mode

### DIFF
--- a/apps/formbricks-com/pages/formtribe/index.tsx
+++ b/apps/formbricks-com/pages/formtribe/index.tsx
@@ -11,6 +11,7 @@ import Mac from "@/images/formtribe/package.jpeg";
 import Pandey from "@/images/formtribe/pandeyman.jpeg";
 import Shubham from "@/images/formtribe/shubham.jpeg";
 import Timeline from "@/images/formtribe/timeline.png";
+import { useEffect } from "react";
 
 const HowTo = [
   {
@@ -212,6 +213,10 @@ const FAQ = [
 ];
 
 export default function FormTribeHackathon() {
+  // dark mode fix
+  useEffect(() => {
+    document.documentElement.classList.remove("dark");
+  }, []);
   return (
     <LayoutLight
       title="FormbTribe Hackathon"


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

formtribe page should only be shown in light mode

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

