### PR TITLE
fix: missing metadata in landing pages

### DIFF
--- a/apps/formbricks-com/app/docs/actions/code/page.mdx
+++ b/apps/formbricks-com/app/docs/actions/code/page.mdx
@@ -1,7 +1,7 @@
 export const meta = {
-  title: "Code Actions",
+  title: "Implementing Code Actions in Formbricks | Real-time User Action Tracking",
   description:
-    "Integrate code actions in Formbricks using formbricks.track() to trigger surveys based on user actions, like button clicks, for precise insights. All open-source.",
+    "Dive into the world of Formbricks' code actions. Learn how to seamlessly integrate formbricks.track() method into your codebase, enabling real-time tracking of user actions like button clicks, visiting a specfic URL. Up your survey game with precise and exact triggers.",
 };
 
 #### Actions

--- a/apps/formbricks-com/app/docs/actions/no-code/page.mdx
+++ b/apps/formbricks-com/app/docs/actions/no-code/page.mdx
@@ -1,7 +1,7 @@
 export const meta = {
-  title: "No-Code Actions",
+  title: "Implementing No-Code Actions in Formbricks | Real-time User Action Tracking",
   description:
-    "Utilize Formbricks' No-Code Actions like Page URL, innerText, and CSS Selector for easy survey triggers and enhanced user insights.",
+    "Discover the power of Formbricks' No-Code Actions. Easily set up triggers based on Page URL, innerText, and CSS Selectors without touching a line of code. Inccrease user engagement and get insights at precise moments in the user journey.",
 };
 
 #### Actions

--- a/apps/formbricks-com/app/docs/actions/why/page.mdx
+++ b/apps/formbricks-com/app/docs/actions/why/page.mdx
@@ -1,7 +1,7 @@
 export const meta = {
-  title: "What are actions and why are they useful?",
+  title: "Using Actions in Formbricks | Fine-tuning User Moments",
   description:
-    "Actions in Formbricks enable targeted survey displays during specific user journey moments. Enhance user segmentation by tracking actions for granular surveying.",
+    "Dive deep into how actions in Formbricks help products and teams to engage users at precise moments in their journey. Discover the power of actions, from coding to no-code setups, to refine user targeting and generate richer, more detailed user insights.",
 };
 
 #### Actions

--- a/apps/formbricks-com/app/docs/api/api-key-setup/page.mdx
+++ b/apps/formbricks-com/app/docs/api/api-key-setup/page.mdx
@@ -4,9 +4,9 @@ import AddApiKey from "./add-api-key.webp";
 import ApiKeySecret from "./api-key-secret.webp";
 
 export const meta = {
-  title: "API Key Setup",
+  title: "Formbricks API Key: Setup and Testing",
   description:
-    "Generate, store, and delete personal API keys for secure Formbricks access. Ensure safekeeping to prevent unauthorized account control.",
+    "This guide provides step-by-step instructions to generate, store, and delete API keys, ensuring safe and authenticated access to your Formbricks account.",
 };
 
 #### API

--- a/apps/formbricks-com/app/docs/api/display/page.mdx
+++ b/apps/formbricks-com/app/docs/api/display/page.mdx
@@ -1,9 +1,9 @@
 import { Fence } from "@/components/shared/Fence";
 
 export const meta = {
-  title: "Responses API",
+  title: "Formbricks Public Client API Guide: Manage Survey Displays & Responses",
   description:
-    "Explore the Formbricks Public Client API for client-side tasks and integration into your website.",
+    "Dive deep into Formbricks' Public Client API designed for customisation. This comprehensive guide provides detailed instructions on how to mark surveys as displayed as well as responded for individual persons, ensuring seamless client-side interactions without compromising data security.",
 };
 
 #### Management API

--- a/apps/formbricks-com/app/docs/api/overview/page.mdx
+++ b/apps/formbricks-com/app/docs/api/overview/page.mdx
@@ -1,7 +1,7 @@
 export const meta = {
-  title: "API Overview",
+  title: "Formbricks API Overview: Public Client & Management API Breakdown",
   description:
-    "Explore Formbricks' APIs: Public Client API for client-side tasks, and Management API for account management with secure API Key authentication.",
+    "Get a detailed understanding of Formbricks' dual API offerings: the unauthenticated Public Client API optimized for client-side tasks and the secured Management API for advanced account operations. Choose the perfect fit for your integration needs and ensure robust data handling",
 };
 
 #### API

--- a/apps/formbricks-com/app/docs/api/people/page.mdx
+++ b/apps/formbricks-com/app/docs/api/people/page.mdx
@@ -1,9 +1,9 @@
 import { Fence } from "@/components/shared/Fence";
 
 export const meta = {
-  title: "Responses API",
+  title: "Formbricks People API: Fetch or Create Person Overview",
   description:
-    "Explore the Formbricks Public Client API for client-side tasks and integration into your website.",
+    "Dive into Formbricks' People API within the Public Client API suite, designed to work without authentication requirements. Seamlessly fetch or create a person by their userId and environmentId, optimizing client-side interactions while maintaining data privacy.",
 };
 
 #### Management API

--- a/apps/formbricks-com/app/docs/api/responses/page.mdx
+++ b/apps/formbricks-com/app/docs/api/responses/page.mdx
@@ -1,9 +1,9 @@
 import { Fence } from "@/components/shared/Fence";
 
 export const meta = {
-  title: "Responses API",
+  title: "Formbricks Responses API Documentation - Manage Your Survey Data Seamlessly",
   description:
-    "Explore the Formbricks Public Client API for client-side tasks and integration into your website.",
+    "Unlock the full potential of Formbricks' Responses API. From fetching to updating survey responses, our comprehensive guide helps you integrate and manage survey data efficiently without compromising security. Ideal for client-side interactions.",
 };
 
 #### Management API

--- a/apps/formbricks-com/app/docs/api/surveys/page.mdx
+++ b/apps/formbricks-com/app/docs/api/surveys/page.mdx
@@ -1,9 +1,9 @@
 import { Fence } from "@/components/shared/Fence";
 
 export const meta = {
-  title: "Surveys API",
+  title: "Formbricks Surveys API Documentation - How to Retrieve All Surveys",
   description:
-    "Explore the Formbricks Public Client API for client-side tasks and integration into your website.",
+    "Explore the comprehensive guide to the Formbricks Surveys API. Learn how to effectively retrieve all the surveys in your environment with the necessary headers and API key setup. Includes sample request and response formats.",
 };
 
 #### Management API

--- a/apps/formbricks-com/app/docs/api/webhooks/page.mdx
+++ b/apps/formbricks-com/app/docs/api/webhooks/page.mdx
@@ -1,6 +1,6 @@
 export const meta = {
-  title: "Webhook API Overview",
-  description: "Learn how to use the Formbricks Webhook API.",
+  title: "Formbricks Webhook API Documentation - List, Retrieve, Create, and Delete Webhooks",
+  description: "Explore the comprehensive guide to the Formbricks Webhooks API. This is all you need to interact and play with the Formbricks Webhooks and integrate them into any third party app of your choice",
 };
 
 #### Webhook API

--- a/apps/formbricks-com/app/docs/attributes/custom-attributes/page.mdx
+++ b/apps/formbricks-com/app/docs/attributes/custom-attributes/page.mdx
@@ -1,7 +1,7 @@
 export const meta = {
-  title: "Setting attributes with code",
+  title: "Guide for Setting Custom Attributes | Formbricks Documentation",
   description:
-    "Set attributes in code using setAttribute function. Enhance user segmentation, target surveys effectively, and gather valuable insights for better decisions. All open-source.",
+    "Learn how to set attributes in code using setAttribute function. Enhance user segmentation, target surveys effectively, and gather valuable insights for better decisions. Easily send user-specific details for better survey segmentation and gain deeper insights.",
 };
 
 #### Attributes

--- a/apps/formbricks-com/app/docs/attributes/identify-users/page.mdx
+++ b/apps/formbricks-com/app/docs/attributes/identify-users/page.mdx
@@ -1,7 +1,7 @@
 export const meta = {
-  title: "Identifying Users",
+  title: "User Identification in Formbricks | Enhancing Survey Feedback",
   description:
-    "Identify users with Formbricks by setting User ID, email, and custom attributes. Enhance survey targeting and recontacting while maintaining user privacy.",
+    "A comprehensive guide on identifying users in Formbricks without compromising privacy. Learn how to set User ID, email, and custom attributes to optimize survey targeting, recontact users, and control survey intervals, all while respecting user anonymity.",
 };
 
 #### Attributes

--- a/apps/formbricks-com/app/docs/attributes/why/page.mdx
+++ b/apps/formbricks-com/app/docs/attributes/why/page.mdx
@@ -1,7 +1,7 @@
 export const meta = {
-  title: "What are attributes and why are they useful?",
+  title: "Understanding User Attributes in Formbricks Surveys",
   description:
-    "How to use attributes for user segmentation, enhancing survey targeting & results. Improve feedback quality and make data-driven decisions.",
+    "Dive into the importance of attributes in surveys. Learn how key-value pairs can significantly improve survey targeting, enhance feedback quality, and guide data-driven decisions with Formbricks.",
 };
 
 #### Attributes

--- a/apps/formbricks-com/app/docs/best-practices/cancel-subscription/page.mdx
+++ b/apps/formbricks-com/app/docs/best-practices/cancel-subscription/page.mdx
@@ -11,8 +11,8 @@ import PublishSurvey from "./publish-survey.webp";
 import SelectAction from "./select-action.webp";
 
 export const meta = {
-  title: "Learn from Churn",
-  description: "To know how to decrease churn, you have to understand it. Use a micro-survey.",
+  title: "Mastering Churn Surveys with Formbricks | Essential Tips & Steps",
+  description: "Learn how to effectively utilize Formbricks' Churn Surveys to gain deeper insights into user departures. Dive into a step-by-step guide to craft, trigger, and optimize your churn surveys, ensuring you capture invaluable feedback at critical junctures",
 };
 
 #### Best Practices

--- a/apps/formbricks-com/app/docs/best-practices/docs-feedback/page.mdx
+++ b/apps/formbricks-com/app/docs/best-practices/docs-feedback/page.mdx
@@ -11,8 +11,8 @@ import WhenToAsk from "./when-to-ask.webp";
 import CopyIds from "./copy-ids.webp";
 
 export const meta = {
-  title: "Docs Feedback",
-  description: "Docs Feedback allows you to measure how clear your documentation is.",
+  title: "Integrate Docs Feedback in Your Website: A Step-by-Step Guide on getting feedback on your Documentation with Formbricks",
+  description: "Learn the step-by-step process to effectively measure the clarity of your documentation using Formbricks Cloud. Dive into best practices, setting up cloud environments, integrating feedback widgets on your frontend, and connecting to the Formbricks API for a seamless user experience.",
 };
 
 #### Best Practices

--- a/apps/formbricks-com/app/docs/best-practices/feature-chaser/page.mdx
+++ b/apps/formbricks-com/app/docs/best-practices/feature-chaser/page.mdx
@@ -10,8 +10,8 @@ import RecontactOptions from "./recontact-options.webp";
 import SelectAction from "./select-action.webp";
 
 export const meta = {
-  title: "Feature Chaser",
-  description: "Follow up with users who used a specific feature. Gather feedback and improve your product.",
+  title: "Setting Up Feature Chaser Surveys with Formbricks: A Comprehensive Guide",
+  description: "Learn how to harness the power of Formbricks to gather targeted user feedback on specific features. Dive deep into creating, triggering, and publishing the Feature Chaser survey to enhance your product with actionable insights for specific users.",
 };
 
 #### Best Practices

--- a/apps/formbricks-com/app/docs/best-practices/feedback-box/page.mdx
+++ b/apps/formbricks-com/app/docs/best-practices/feedback-box/page.mdx
@@ -12,8 +12,8 @@ import SelectAction from "./select-feedback-button-action.webp";
 import RecontactOptions from "./set-recontact-options.webp";
 
 export const meta = {
-  title: "Feedback Box",
-  description: "The Feedback Box gives your users a direct channel to share their feedback and feel heard.",
+  title: "Implementing the Feedback Box with Formbricks: A Step-by-Step Tutorial",
+  description: "Unlock user insights effortlessly! Discover how to set up the Feedback Box in your app using Formbricks, allowing your users to provide real-time feedback. Follow our comprehensive guide to enhance user experience and respond rapidly to feedback",
 };
 
 #### Best Practices

--- a/apps/formbricks-com/app/docs/best-practices/improve-trial-cr/page.mdx
+++ b/apps/formbricks-com/app/docs/best-practices/improve-trial-cr/page.mdx
@@ -10,8 +10,8 @@ import RecontactOptions from "./recontact-options.webp";
 import SelectAction from "./select-action.webp";
 
 export const meta = {
-  title: "Improve Trial Conversion",
-  description: "Understand how to improve the trial conversions to get more paying customers.",
+  title: "Boost Your Trial Conversion Rates with Formbricks: Comprehensive Guide",
+  description: "Unlock the secret to converting more trial users into paying customers using Formbricks. Understand insights behind trial cancellations and tailor your offering to fit user needs. Dive into our step-by-step tutorial and improve your conversion strategy today",
 };
 
 #### Best Practices

--- a/apps/formbricks-com/app/docs/best-practices/interview-prompt/page.mdx
+++ b/apps/formbricks-com/app/docs/best-practices/interview-prompt/page.mdx
@@ -13,8 +13,8 @@ import RecontactOptions from "./recontact-options.webp";
 import SelectAction from "./select-action.webp";
 
 export const meta = {
-  title: "In-app Interview Prompt",
-  description: "Invite only power users to schedule an interview with your product team.",
+  title: "Maximize User Interview Participation with In-app Interview Prompts",
+  description: "Engage with your power users seamlessly using Formbricks' In-app Interview Prompt. Ditch traditional email invites and experience way more more respondents. Dive into our comprehensive guide on setting up auto-scheduled interviews today and enhance your user understanding",
 };
 
 #### Best Practices

--- a/apps/formbricks-com/app/docs/best-practices/pmf-survey/page.mdx
+++ b/apps/formbricks-com/app/docs/best-practices/pmf-survey/page.mdx
@@ -10,8 +10,8 @@ import RecontactOptions from "./recontact-options.webp";
 import SelectAction from "./select-action.webp";
 
 export const meta = {
-  title: "Product-Market Fit Survey",
-  description: "The Product-Market Fit survey helps you measure, well, Product-Market Fit (PMF).",
+  title: "How to Set Up a Product-Market Fit Survey Using Formbricks - Step-by-Step Guide",
+  description: "Learn to leverage Formbricks to create and implement a Product-Market Fit survey in your web app. Follow our detailed step-by-step guide to measure and understand your PMF effectively. Ensure high data quality, efficient triggers, and actionable insights.",
 };
 
 #### Best Practices

--- a/apps/formbricks-com/app/docs/contributing/demo/page.mdx
+++ b/apps/formbricks-com/app/docs/contributing/demo/page.mdx
@@ -3,8 +3,8 @@ import Image from "next/image";
 import DemoApp from "./demoapp.webp";
 
 export const meta = {
-  title: "Demo App",
-  description: "To test in-app surveys, trigger actions and set attributes, you can use the Demo App.",
+  title: "Formbricks Demo App Guide: Play around with Formbricks",
+  description: "To test in-app surveys, trigger actions and set attributes, you can use the Demo App. This guide provides hands-on examples of sending both code and no-code actions",
 };
 
 #### Contributing

--- a/apps/formbricks-com/app/docs/contributing/introduction/page.mdx
+++ b/apps/formbricks-com/app/docs/contributing/introduction/page.mdx
@@ -1,6 +1,6 @@
 export const meta = {
-  title: "Contribution Guide",
-  description: "How to contribute to Formbricks",
+  title: "Formbricks Open Source Contribution Guide: How to Enhance yourself and Contribute to Formbricks",
+  description: "Join the Formbricks community and learn how to effectively contribute. From raising issues and feature requests to creating PRs, discover the best practices and communicate with our responsive team on Discord",
 };
 
 #### Contributing

--- a/apps/formbricks-com/app/docs/contributing/setup/page.mdx
+++ b/apps/formbricks-com/app/docs/contributing/setup/page.mdx
@@ -1,6 +1,6 @@
 export const meta = {
-  title: "Setup Dev Environment",
-  description: "Setup a development environment for Formbricks.",
+  title: "Formbricks Development Setup: Complete Guide to Local Environment Configuration for Dev",
+  description: "Step-by-step guide to setting up your local development environment for Formbricks. Includes installing essential tools like Node.JS, pnpm, and Docker, and accessing the entire Formbricks stack including the Demo app and the main website",
 };
 
 #### Contributing

--- a/apps/formbricks-com/app/docs/contributing/troubleshooting/page.mdx
+++ b/apps/formbricks-com/app/docs/contributing/troubleshooting/page.mdx
@@ -5,9 +5,9 @@ import UncaughtPromise from "./uncaught-promise.webp";
 import Logout from "./logout.webp";
 
 export const meta = {
-  title: "Troubleshooting",
+  title: "Formbricks Troubleshooting Guide: How to Solve & Debug Common Issues",
   description:
-    "Formbricks is a complex application in constant development. Sometimes, things don't go as planned. Here are some tips to help you troubleshoot.",
+    "Facing issues with Formbricks? This troubleshooting guide covers frequently encountered problems, from Prisma migrations to package errors and more. Detailed solutions, accompanied by visual aids, ensure a smoother user experience with Formbricks",
 };
 
 #### Contributing

--- a/apps/formbricks-com/app/docs/getting-started/framework-guides/page.mdx
+++ b/apps/formbricks-com/app/docs/getting-started/framework-guides/page.mdx
@@ -6,8 +6,8 @@ import WidgetConnected from "./widget-connected.webp";
 import ReactApp from "./react-in-app-survey-app-popup-form.webp";
 
 export const metadata = {
-  title: "Framework Guides",
-  description: "Explore all the possible ways you can integrate Formbricks into your application.",
+  title: "Integrate Formbricks: Comprehensive Framework Guide & Integration Tutorial",
+  description: "Master the integration of Formbricks into your application with our detailed guides. From HTML to ReactJS, NextJS, and VueJS, get step-by-step instructions and ensure seamless setup.",
 };
 
 # Framework Guides

--- a/apps/formbricks-com/app/docs/getting-started/quickstart-in-app-survey/page.mdx
+++ b/apps/formbricks-com/app/docs/getting-started/quickstart-in-app-survey/page.mdx
@@ -14,8 +14,8 @@ import I11 from "./11-survey-logs-in-app-survey-popup.webp";
 import ReactApp from "../framework-guides/react-in-app-survey-app-popup-form.webp";
 
 export const meta = {
-  title: "Collect in app survey responses in 10 minutes",
-  description: "Get your first in app survey response in 10 minutes.",
+  title: "Formbricks Quickstart Guide: In-App Surveys Made Simple",
+  description: "Launch your first in-app survey effortlessly. Dive into our step-by-step guide to set up, integrate, and debug Formbricks in your web app in under 15 minutes.",
 };
 
 #### Getting Started

--- a/apps/formbricks-com/app/docs/integrations/make/page.mdx
+++ b/apps/formbricks-com/app/docs/integrations/make/page.mdx
@@ -15,8 +15,8 @@ import Result from "./result.webp";
 import SelectAction from "./select-action.webp";
 
 export const meta = {
-  title: "Make.com Setup",
-  description: "Wire up Formbricks with Make and 1000+ other apps",
+  title: "Formbricks Integration with Make.com: A Step-by-Step Guide",
+  description: "Discover how to seamlessly integrate Formbricks with Make.com. Dive into our comprehensive guide to set up scenarios, connect with a plethora of apps, and send your survey data to more than 1000 platforms.",
 };
 
 #### Integrations

--- a/apps/formbricks-com/app/docs/integrations/n8n/page.mdx
+++ b/apps/formbricks-com/app/docs/integrations/n8n/page.mdx
@@ -19,8 +19,8 @@ import SuccessConnection from "./success-connection.png";
 import UpdateQuestionId from "./update-question-id.png";
 
 export const meta = {
-  title: "n8n Setup",
-  description: "Wire up Formbricks with n8n and 350+ other apps",
+  title: "Comprehensive Guide to Integrating Formbricks with n8n",
+  description: "Unlock the potential of combining Formbricks with n8n for a streamlined workflow experience. Dive into our step-by-step guide and send your survey data effortlessly to 350+ applications. Streamline your data processes now!",
 };
 
 #### Integrations

--- a/apps/formbricks-com/app/docs/integrations/zapier/page.mdx
+++ b/apps/formbricks-com/app/docs/integrations/zapier/page.mdx
@@ -15,8 +15,8 @@ import UpdateQuestionId from "./update-question-id.webp";
 import ZapierMessage from "./zapier-message.webp";
 
 export const meta = {
-  title: "Zapier Setup",
-  description: "Wire up Formbricks with Zapier and 5000+ other apps",
+  title: "Step-by-Step Guide to Integrating Formbricks with Zapier",
+  description: "Master the integration of Formbricks with Zapier using our detailed guide. Seamlessly connect your surveys to 5000+ apps, automate data transfers, and enhance feedback management. Start optimizing your workflow today.",
 };
 
 #### Integrations

--- a/apps/formbricks-com/app/docs/introduction/how-it-works/page.mdx
+++ b/apps/formbricks-com/app/docs/introduction/how-it-works/page.mdx
@@ -1,7 +1,7 @@
 export const meta = {
-  title: "How Formbricks works",
+  title: "Inside Look: Formbricks In-Product Micro-Surveys",
   description:
-    "Master in-product micro-surveys with Formbricks: user-friendly form builder, precise targeting, seamless integration, and insightful analytics for SaaS products.",
+    "Unlock the full potential of Formbricks: From intuitive form-building and event-based triggers to effortless integrations and deep analytics. Master the art of in-product surveys for your SaaS or digital platform.",
 };
 
 #### Introduction

--- a/apps/formbricks-com/app/docs/introduction/what-is-formbricks/page.mdx
+++ b/apps/formbricks-com/app/docs/introduction/what-is-formbricks/page.mdx
@@ -2,11 +2,12 @@ import { GettingStarted } from "@/components/docs/GettingStarted";
 import { BestPractices } from "@/components/docs/BestPractices";
 import { HeroPattern } from "@/components/docs/HeroPattern";
 import { Button } from "@/components/docs/Button";
+import { SEO } from "@/app/seo";
 
 export const metadata = {
-  title: "Formbricks – Open Source Experience Management",
+  title: "Formbricks: Supercharge Your B2B SaaS with Experience Management",
   description:
-    "Natively embed qualitative user research into your B2B SaaS. Leverage Best Practices for user discovery to increase Product-Market Fit",
+    "Enhance your product with Formbricks – the leading open-source solution for in-product micro-surveys. Dive deep into user research, amplify product-market fit, and uncover the 'why' behind your analytics.",
 };
 
 export const sections = [

--- a/apps/formbricks-com/app/docs/introduction/what-is-formbricks/page.mdx
+++ b/apps/formbricks-com/app/docs/introduction/what-is-formbricks/page.mdx
@@ -2,10 +2,9 @@ import { GettingStarted } from "@/components/docs/GettingStarted";
 import { BestPractices } from "@/components/docs/BestPractices";
 import { HeroPattern } from "@/components/docs/HeroPattern";
 import { Button } from "@/components/docs/Button";
-import { SEO } from "@/app/seo";
 
 export const metadata = {
-  title: "Formbricks: Supercharge Your B2B SaaS with Experience Management",
+  title: "Formbricks: Privacy-first Experience Management",
   description:
     "Enhance your product with Formbricks – the leading open-source solution for in-product micro-surveys. Dive deep into user research, amplify product-market fit, and uncover the 'why' behind your analytics.",
 };

--- a/apps/formbricks-com/app/docs/introduction/why-is-it-better/page.mdx
+++ b/apps/formbricks-com/app/docs/introduction/why-is-it-better/page.mdx
@@ -1,7 +1,7 @@
 export const meta = {
-  title: "Why is Formbricks better?",
+  title: "Formbricks vs. Generic Survey Tools: A Comparative Insight",
   description:
-    "The ultimate survey solution for SaaS, offering in-depth micro-surveys, precise targeting, and seamless integrations. Discover the difference today!",
+    "Discover how Formbricks excels as a specialized in-product micro-survey platform for SaaS. Get unmatched targeting, seamless integrations, and make informed decisions with our open-source advantage.",
 };
 
 #### Introduction 

--- a/apps/formbricks-com/app/docs/link-surveys/data-prefilling/page.mdx
+++ b/apps/formbricks-com/app/docs/link-surveys/data-prefilling/page.mdx
@@ -3,8 +3,8 @@ import Image from "next/image";
 import QuestionId from "./question-id.webp";
 
 export const meta = {
-  title: "Data Prefilling in Link Surveys",
-  description: "Prefill data in your surveys to make it easier for your users to provide feedback.",
+  title: "URL Data Prefilling for Link Surveys in Formbricks",
+  description: "Master the art of data prefilling in Formbricks link surveys. Dive into our guide on how to use URL parameters to prepopulate answers, boosting conversion rates and enhancing user experience. Learn through examples and ensure correct validation for each question type.",
 };
 
 #### Link Surveys

--- a/apps/formbricks-com/app/docs/link-surveys/user-identification/page.mdx
+++ b/apps/formbricks-com/app/docs/link-surveys/user-identification/page.mdx
@@ -3,9 +3,9 @@ import Image from "next/image";
 import PeopleView from "./people-view.webp";
 
 export const meta = {
-  title: "User Identification in Link Surveys",
+  title: "Effective User Identification in Formbricks Link Surveys",
   description:
-    "Identify users in link surveys via URL parameter. Connect responses to existing users in Formbricks.",
+    "Discover how to seamlessly connect responses from Formbricks link surveys to existing users in your database. Learn the intricacies of the userId URL parameter to enhance user tracking, profiling, and segmentation, ensuring more personalized interactions and data-driven decisions.",
 };
 
 #### Link Surveys

--- a/apps/formbricks-com/app/docs/self-hosting/deployment/page.mdx
+++ b/apps/formbricks-com/app/docs/self-hosting/deployment/page.mdx
@@ -1,7 +1,7 @@
 export const meta = {
-  title: "Deploying Formbricks to production",
+  title: "Comprehensive Guide to Self-Hosting Formbricks",
   description:
-    "Utilize Docker-Compose for easy deployment on your machine. Clone the repo, configure settings, and build the image to access the app on localhost.",
+    "Discover versatile options to deploy Formbricks tailored to your expertise level. From Ubuntu setups using shell scripts, swift Docker deployments, to manual source configurations, harness the flexibility and power of Formbricks to fit your unique hosting needs. Dive in today!",
 };
 
 #### Self-Hosting

--- a/apps/formbricks-com/app/docs/self-hosting/docker/page.mdx
+++ b/apps/formbricks-com/app/docs/self-hosting/docker/page.mdx
@@ -1,7 +1,7 @@
 export const meta = {
-  title: "Deploying Formbricks with Docker",
+  title: "Guide to Deploying Formbricks Using Docker",
   description:
-    "Utilize Docker-Compose for easy deployment on your machine. Clone the repo, configure settings, and build the image to access the app on localhost.",
+    "Step-by-step tutorial on how to effortlessly set up and run Formbricks via Docker. Explore the quick deployment process with Docker-Compose, learn how to update Formbricks, and troubleshoot common issues. Ideal for those looking for a hassle-free Formbricks experience",
 };
 
 #### Self-Hosting

--- a/apps/formbricks-com/app/docs/self-hosting/from-source/page.mdx
+++ b/apps/formbricks-com/app/docs/self-hosting/from-source/page.mdx
@@ -1,7 +1,7 @@
 export const meta = {
-  title: "Deploying Formbricks from Source Code",
+  title: "Formbricks Self-Hosting Guide: Deploy from Source Code for Complete Customization",
   description:
-    "Build the Formbricks Image right from the open-sourced codebase and make changes however needed. Deploy it then with the freedom of customizing even the compile-time environment variables.",
+    "Build the Formbricks Image right from the open-sourced codebase and make changes however needed. Deploy it then with the freedom of customizing even the compile-time environment variables. Gain more control and flexibility by customizing compile-time environment variables and configuring your instance. Dive into our comprehensive guide for building and running Formbricks with Docker.",
 };
 
 #### Self-Hosting

--- a/apps/formbricks-com/app/docs/self-hosting/production/page.mdx
+++ b/apps/formbricks-com/app/docs/self-hosting/production/page.mdx
@@ -1,7 +1,7 @@
 export const meta = {
-  title: "Deploying Formbricks to production",
+  title: "Step by Step Guide on Deploying Formbricks to Production on Ubuntu",
   description:
-    "Utilize Docker-Compose for easy deployment on your machine. Clone the repo, configure settings, and build the image to access the app on localhost.",
+    "Master the swift deployment of Formbricks on an Ubuntu server with our step-by-step guide. Use a single command to automate Docker, Postgres DB, SSL certificate configuration, and more. Encounter issues? Dive into our troubleshooting steps or join our community on Discord for assistance.",
 };
 
 #### Self-Hosting

--- a/apps/formbricks-com/pages/demo/index.tsx
+++ b/apps/formbricks-com/pages/demo/index.tsx
@@ -5,7 +5,7 @@ export default function DemoPage() {
   return (
     <LayoutWaitlist
       title="Formbricks Demo"
-      description="Leverage 30+ templates to kick-start your experience management.">
+      description="Play around with our pre-defined 30+ templates and them to kick-start your survey & experience management.">
       <DemoView />
     </LayoutWaitlist>
   );

--- a/apps/formbricks-com/pages/docs-feedback/index.tsx
+++ b/apps/formbricks-com/pages/docs-feedback/index.tsx
@@ -7,7 +7,7 @@ import BestPracticeNavigation from "@/components/shared/BestPracticeNavigation";
 export default function DocsFeedbackPage() {
   return (
     <Layout
-      title="Docs Feedback"
+      title="Get User Feedback in the easiest way possible with Formbricks"
       description="The better your docs, the higher your user adoption. Measure granularly how clear your documentation is.">
       <div className="grid grid-cols-1 items-center md:grid-cols-2 md:gap-12 md:py-20">
         <div className="p-6 md:p-0">

--- a/apps/formbricks-com/pages/feature-chaser/index.tsx
+++ b/apps/formbricks-com/pages/feature-chaser/index.tsx
@@ -7,8 +7,8 @@ import BestPracticeNavigation from "@/components/shared/BestPracticeNavigation";
 export default function FeatureChaserPage() {
   return (
     <Layout
-      title="Feature Chaser"
-      description="Show a survey about a new feature shown only to people who used it.">
+      title="Feature Chaser with Formbricks"
+      description="Show a survey about a new feature shown only to people who used it and gain insightful data.">
       <div className="grid grid-cols-1 items-center md:grid-cols-2 md:gap-12 md:py-20">
         <div className="p-6 md:p-0">
           <UseCaseHeader title="Feature Chaser" difficulty="Easy" setupMinutes="10" />

--- a/apps/formbricks-com/pages/feedback-box/index.tsx
+++ b/apps/formbricks-com/pages/feedback-box/index.tsx
@@ -7,7 +7,7 @@ import BestPracticeNavigation from "@/components/shared/BestPracticeNavigation";
 export default function FeedbackBoxPage() {
   return (
     <Layout
-      title="Feedback Box"
+      title="Feedback Box with Formbricks"
       description="Open a direct channel to your users by allowing them to share feedback with your team.">
       <div className="grid grid-cols-1 items-center md:grid-cols-2 md:gap-12 md:py-20">
         <div className="p-6 md:p-0">

--- a/apps/formbricks-com/pages/gdpr-guide.mdx
+++ b/apps/formbricks-com/pages/gdpr-guide.mdx
@@ -3,6 +3,7 @@ import { Callout } from "@/components/shared/Callout";
 
 export const meta = {
   title: "How to create a GDPR compliant form",
+  description: "Steps to understand how GDPR might be needed for you with Formbricks.",
 };
 
 <Callout title="No legal advice" type="note">

--- a/apps/formbricks-com/pages/gdpr.mdx
+++ b/apps/formbricks-com/pages/gdpr.mdx
@@ -3,6 +3,7 @@ import { Callout } from "@/components/shared/Callout";
 
 export const meta = {
   title: "GDPR FAQs",
+  description: "Frequently asked questions about GDPR and Formbricks",
 };
 
 <Callout title="No legal advice" type="note">

--- a/apps/formbricks-com/pages/improve-trial-conversion/index.tsx
+++ b/apps/formbricks-com/pages/improve-trial-conversion/index.tsx
@@ -7,7 +7,7 @@ import BestPracticeNavigation from "@/components/shared/BestPracticeNavigation";
 export default function MissedTrialPagePage() {
   return (
     <Layout
-      title="Improve Trial Conversion"
+      title="Improve Trial Conversion with Formbricks"
       description="Take the guessing out, convert more trials to paid users with insights.">
       <div className="grid grid-cols-1 items-center md:grid-cols-2 md:gap-12 md:py-20">
         <div className="p-6 md:p-0">

--- a/apps/formbricks-com/pages/interview-prompt/index.tsx
+++ b/apps/formbricks-com/pages/interview-prompt/index.tsx
@@ -7,7 +7,7 @@ import BestPracticeNavigation from "@/components/shared/BestPracticeNavigation";
 export default function InterviewPromptPage() {
   return (
     <Layout
-      title="Interview Prompt"
+      title="Interview Prompt with Formbricks"
       description="Ask only power users users to book a time in your calendar. Get those juicy details.">
       <div className="grid grid-cols-1 items-center md:grid-cols-2 md:gap-12 md:py-20">
         <div className="p-6 md:p-0">

--- a/apps/formbricks-com/pages/learn-from-churn/index.tsx
+++ b/apps/formbricks-com/pages/learn-from-churn/index.tsx
@@ -7,7 +7,7 @@ import BestPracticeNavigation from "@/components/shared/BestPracticeNavigation";
 export default function LearnFromChurnPage() {
   return (
     <Layout
-      title="Learn from Churn"
+      title="Learn from Churn with Formbricks"
       description="Churn is hard, but insightful. Learn from users who changed their mind.">
       <div className="grid grid-cols-1 items-center md:grid-cols-2 md:gap-12 md:py-20">
         <div className="p-6 md:p-0">

--- a/apps/formbricks-com/pages/measure-product-market-fit/index.tsx
+++ b/apps/formbricks-com/pages/measure-product-market-fit/index.tsx
@@ -15,7 +15,7 @@ import Image from "next/image";
 export default function MeasurePMFPage() {
   return (
     <Layout
-      title="Product-Market Fit Survey"
+      title="Product-Market Fit Survey with Formbricks"
       description="Measure Product-Market Fit to understand how to develop your product further.">
       <div className="grid grid-cols-1 items-center md:grid-cols-2 md:gap-12 md:py-20">
         <div className="p-6 md:p-0">

--- a/apps/formbricks-com/pages/onboarding-segmentation/index.tsx
+++ b/apps/formbricks-com/pages/onboarding-segmentation/index.tsx
@@ -6,7 +6,7 @@ import UseCaseHeader from "@/components/shared/UseCaseHeader";
 export default function OnboardingSegmentationPage() {
   return (
     <Layout
-      title="Onboarding Segmentation"
+      title="Onboarding Segmentation with Formbricks"
       description="Add a survey to your onboarding to loop in Formbricks right from the start.">
       <div className="grid grid-cols-1 items-center md:grid-cols-2 md:gap-12 md:py-20">
         <div className="p-6 md:p-0">


### PR DESCRIPTION
## What does this PR do?
Adds Metadata to the missing landing pages. The metadata is then added as meta information just like how next-seo does.

## Type of change
- [x] This change requires a documentation update

## Checklist
- [ ] Added a screen recording or screenshots to this PR
- [ ] Filled out the "How to test" section in this PR
- [x] Read the [contributing guide](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] Updated the Formbricks Docs if changes were necessary
