### PR TITLE
fix: generate single surveys only if enabled

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/page.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/page.tsx
@@ -30,7 +30,12 @@ export default async function Page({ params }) {
     getEnvironment(params.environmentId),
   ]);
   const isSingleUseSurvey = survey.singleUse?.enabled ?? false;
-  const singleUseIds = generateSingleUseIds(survey.singleUse?.isEncrypted ?? false);
+
+  let singleUseIds: string[] | undefined = undefined;
+  if (isSingleUseSurvey) {
+    singleUseIds = generateSingleUseIds(survey.singleUse?.isEncrypted ?? false);
+  }
+
   if (!environment) {
     throw new Error("Environment not found");
   }


### PR DESCRIPTION
## What does this PR do?
generate single surveys from the lib only when it is enabled to avoid app crashing if the env var is not set

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
### Required
- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
