### PR TITLE
feat: authorization on google integrations

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/integrations/google-sheets/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/integrations/google-sheets/actions.ts
@@ -1,20 +1,43 @@
 "use server";
 
+import { authOptions } from "@/app/api/auth/[...nextauth]/authOptions";
+import { getServerSession } from "next-auth";
 import { getSpreadSheets } from "@formbricks/lib/googleSheet/service";
 import { createOrUpdateIntegration, deleteIntegration } from "@formbricks/lib/integration/service";
 import { TGoogleSheetIntegration } from "@formbricks/types/v1/integrations";
+import { canUserAccessIntegration } from "@formbricks/lib/integration/auth";
+import { AuthorizationError } from "@formbricks/types/v1/errors";
+import { hasUserEnvironmentAccess } from "@formbricks/lib/environment/auth";
 
 export async function upsertIntegrationAction(
   environmentId: string,
   integrationData: Partial<TGoogleSheetIntegration>
 ) {
+  const session = await getServerSession(authOptions);
+  if (!session) throw new AuthorizationError("Not authorized");
+
+  const isAuthorized = await hasUserEnvironmentAccess(session.user.id, environmentId);
+  if (!isAuthorized) throw new AuthorizationError("Not authorized");
+
   return await createOrUpdateIntegration(environmentId, integrationData);
 }
 
 export async function deleteIntegrationAction(integrationId: string) {
+  const session = await getServerSession(authOptions);
+  if (!session) throw new AuthorizationError("Not authorized");
+
+  const isAuthorized = await canUserAccessIntegration(session.user.id, integrationId);
+  if (!isAuthorized) throw new AuthorizationError("Not authorized");
+
   return await deleteIntegration(integrationId);
 }
 
 export async function refreshSheetAction(environmentId: string) {
+  const session = await getServerSession(authOptions);
+  if (!session) throw new AuthorizationError("Not authorized");
+
+  const isAuthorized = await hasUserEnvironmentAccess(session.user.id, environmentId);
+  if (!isAuthorized) throw new AuthorizationError("Not authorized");
+
   return await getSpreadSheets(environmentId);
 }

--- a/packages/lib/integration/auth.ts
+++ b/packages/lib/integration/auth.ts
@@ -1,0 +1,27 @@
+import "server-only";
+
+import { ZId } from "@formbricks/types/v1/environment";
+import { validateInputs } from "../utils/validate";
+import { hasUserEnvironmentAccess } from "../environment/auth";
+import { getIntegration } from "./service";
+import { unstable_cache } from "next/cache";
+import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
+
+export const canUserAccessIntegration = async (userId: string, integrationId: string): Promise<boolean> =>
+  await unstable_cache(
+    async () => {
+      validateInputs([userId, ZId], [integrationId, ZId]);
+      if (!userId) return false;
+
+      const integration = await getIntegration(integrationId);
+      if (!integration) return false;
+
+      const hasAccessToEnvironment = await hasUserEnvironmentAccess(userId, integration.environmentId);
+      if (!hasAccessToEnvironment) return false;
+
+      return true;
+    },
+
+    [`users-${userId}-integrations-${integrationId}`],
+    { revalidate: SERVICES_REVALIDATION_INTERVAL, tags: [`integrations-${integrationId}`] }
+  )();

--- a/packages/lib/integration/service.ts
+++ b/packages/lib/integration/service.ts
@@ -53,6 +53,22 @@ export const getIntegrations = cache(async (environmentId: string): Promise<TInt
   }
 });
 
+export const getIntegration = cache(async (integrationId: string): Promise<TIntegration | null> => {
+  try {
+    const result = await prisma.integration.findUnique({
+      where: {
+        id: integrationId,
+      },
+    });
+    return result;
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      throw new DatabaseError("Database operation failed");
+    }
+    throw error;
+  }
+});
+
 export const deleteIntegration = async (integrationId: string): Promise<void> => {
   try {
     await prisma.integration.delete({


### PR DESCRIPTION
## What does this PR do?
Before this, we had a vulnerability that any user could delete any integration of another user. Now, we do authorization with the base environment of the integration to make sure the user is authorized to perform the action.

## Type of change
- [x] Enhancement (small improvements)

## How should this be tested?
Try passing another integrationId and see if the delete works.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
