### PR TITLE
feat: authorization in responseNote actions & cleanup of unused actions

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/actions.ts
@@ -1,32 +1,11 @@
 "use server";
-import { deleteResponse } from "@formbricks/lib/response/service";
-import { updateResponseNote, resolveResponseNote } from "@formbricks/lib/responseNote/service";
 import { createTag } from "@formbricks/lib/tag/service";
 import { addTagToRespone, deleteTagOnResponse } from "@formbricks/lib/tagOnResponse/service";
 import { hasUserEnvironmentAccess } from "@formbricks/lib/environment/auth";
 import { authOptions } from "@formbricks/lib/authOptions";
 import { getServerSession } from "next-auth";
 import { AuthorizationError } from "@formbricks/types/v1/errors";
-import { canUserAccessResponse } from "@formbricks/lib/response/auth";
 import { canUserAccessTagOnResponse } from "@formbricks/lib/tagOnResponse/auth";
-
-export const updateResponseNoteAction = async (responseNoteId: string, text: string) => {
-  await updateResponseNote(responseNoteId, text);
-};
-
-export const resolveResponseNoteAction = async (responseNoteId: string) => {
-  await resolveResponseNote(responseNoteId);
-};
-
-export const deleteResponseAction = async (responseId: string) => {
-  const session = await getServerSession(authOptions);
-  if (!session) throw new AuthorizationError("Not authorized");
-
-  const isAuthorized = await canUserAccessResponse(session.user.id, responseId);
-  if (!isAuthorized) throw new AuthorizationError("Not authorized");
-
-  return await deleteResponse(responseId);
-};
 
 export const createTagAction = async (environmentId: string, tagName: string) => {
   const session = await getServerSession(authOptions);

--- a/packages/lib/responseNote/auth.ts
+++ b/packages/lib/responseNote/auth.ts
@@ -1,0 +1,20 @@
+import { ZId } from "@formbricks/types/v1/environment";
+import { validateInputs } from "../utils/validate";
+import { getResponseNote } from "./service";
+import { unstable_cache } from "next/cache";
+
+export const canUserAccessResponseNote = async (userId: string, responseNoteId: string): Promise<boolean> =>
+  await unstable_cache(
+    async () => {
+      validateInputs([userId, ZId], [responseNoteId, ZId]);
+
+      if (!userId || !responseNoteId) return false;
+
+      const responseNote = await getResponseNote(responseNoteId);
+      if (!responseNote) return false;
+
+      return responseNote.user.id === userId;
+    },
+    [`users-${userId}-responseNotes-${responseNoteId}`],
+    { revalidate: 30 * 60, tags: [`responseNotes-${responseNoteId}`] }
+  )(); // 30 minutes

--- a/packages/lib/responseNote/service.ts
+++ b/packages/lib/responseNote/service.ts
@@ -45,6 +45,24 @@ export const createResponseNote = async (
   }
 };
 
+export const getResponseNote = async (responseNoteId: string): Promise<TResponseNote | null> => {
+  try {
+    const responseNote = await prisma.responseNote.findUnique({
+      where: {
+        id: responseNoteId,
+      },
+      select,
+    });
+    return responseNote;
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      throw new DatabaseError("Database operation failed");
+    }
+
+    throw error;
+  }
+};
+
 export const updateResponseNote = async (responseNoteId: string, text: string): Promise<TResponseNote> => {
   try {
     const updatedResponseNote = await prisma.responseNote.update({

--- a/packages/ui/SingleResponseCard/actions.ts
+++ b/packages/ui/SingleResponseCard/actions.ts
@@ -5,6 +5,7 @@ import { AuthorizationError } from "@formbricks/types/v1/errors";
 import { authOptions } from "@formbricks/lib/authOptions";
 import { deleteResponse } from "@formbricks/lib/response/service";
 import { canUserAccessResponse } from "@formbricks/lib/response/auth";
+import { canUserAccessResponseNote } from "@formbricks/lib/responseNote/auth";
 import {
   updateResponseNote,
   resolveResponseNote,
@@ -23,12 +24,20 @@ export const deleteResponseAction = async (responseId: string) => {
 export const updateResponseNoteAction = async (responseNoteId: string, text: string) => {
   const session = await getServerSession(authOptions);
   if (!session) throw new AuthorizationError("Not authorized");
+
+  const isAuthorized = await canUserAccessResponseNote(session.user!.id, responseNoteId);
+  if (!isAuthorized) throw new AuthorizationError("Not authorized");
+
   await updateResponseNote(responseNoteId, text);
 };
 
 export const resolveResponseNoteAction = async (responseNoteId: string) => {
   const session = await getServerSession(authOptions);
   if (!session) throw new AuthorizationError("Not authorized");
+
+  const isAuthorized = await canUserAccessResponseNote(session.user!.id, responseNoteId);
+  if (!isAuthorized) throw new AuthorizationError("Not authorized");
+
   await resolveResponseNote(responseNoteId);
 };
 


### PR DESCRIPTION
## What does this PR do?
Adds Authorization in responseNote actions & cleanup of unused actions in the old actions file since now we have shifted to the ui component having its own action file.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
