### PR TITLE
feat: add docs for setting ENCRYPTION_KEY in .env in contributing guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,7 @@ SHORT_SURVEY_BASE_URL=
 
 # Encryption keys
 # Please set both for now, we will change this in the future
+
 # You can use: `openssl rand -base64 16` to generate one
 FORMBRICKS_ENCRYPTION_KEY=
 

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,14 @@ SURVEY_BASE_URL=http://localhost:3000/i
 # Set this if you want to have a shorter link for surveys
 SHORT_SURVEY_BASE_URL=
 
+# Encryption keys
+# Please set both for now, we will change this in the future
+# You can use: `openssl rand -base64 16` to generate one
+FORMBRICKS_ENCRYPTION_KEY=
+
+# You can use: `openssl rand -base64 24` to generate one
+ENCRYPTION_KEY=
+
 ##############
 #  DATABASE  #
 ##############
@@ -92,12 +100,6 @@ GOOGLE_CLIENT_SECRET=
 
 # Cron Secret
 CRON_SECRET=
-
-# Encryption key
-# You can use: `openssl rand -base64 16` to generate one
-FORMBRICKS_ENCRYPTION_KEY=
-# You can use: `openssl rand -base64 24` to generate one
-ENCRYPTION_KEY=
 
 # Configure this when you want to ship JS & CSS files from a complete URL instead of the current domain
 # ASSET_PREFIX_URL=

--- a/apps/formbricks-com/app/docs/contributing/setup/page.mdx
+++ b/apps/formbricks-com/app/docs/contributing/setup/page.mdx
@@ -53,6 +53,17 @@ To get the project running locally on your machine you need to have the followin
 
    </CodeGroup>
 
+1. Generate a secret value mandatory to be set for the key ENCRYPTION_KEY in the .env file. You can use the following command to generate the random string of required length:
+
+   <CodeGroup title="Set value of ENCRYPTION_KEY">
+
+   ```bash
+   openssl rand -base64 24
+   ```
+
+   </CodeGroup>
+
+
 1. Make sure you have [`Docker`](https://docs.docker.com/compose/) & [`docker-compose`](https://docs.docker.com/compose/) installed and running on your machine. Then run the following command to start the formbricks dev setup:
 
    <CodeGroup title="Start Formbricks Dev Setup">


### PR DESCRIPTION
## What does this PR do?
This PR adds the step to generate and set the value of the new required environment variable ENCRYPTION_KEY in the Contributing Guide

![Screenshot_2023-10-11-14-22-23_1920x1080](https://github.com/formbricks/formbricks/assets/55556994/a3eeb93d-ff6b-47b4-89ca-6b9824825c58)


## Type of change
- [x] This change requires a documentation update


## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary
