### PR TITLE
fix: use standalone output only for docker image builds

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -16,6 +16,9 @@ RUN touch /app/apps/web/.env
 RUN pnpm install
 
 # Build the project
+ENV DOCKER_BUILD 1
+ENV NEXT_TELEMETRY_DISABLED 1
+
 RUN pnpm post-install --filter=web...
 RUN pnpm turbo run build --filter=web...
 
@@ -45,8 +48,8 @@ EXPOSE 3000
 ENV HOSTNAME "0.0.0.0"
 
 CMD if [ "$NEXTAUTH_SECRET" != "RANDOM_STRING" ]; then \
-        pnpm dlx prisma migrate deploy && node apps/web/server.js; \
+    pnpm dlx prisma migrate deploy && node apps/web/server.js; \
     else \
-        echo "ERROR: Please set a value for NEXTAUTH_SECRET in your docker compose variables!"; \
-        exit 1; \
+    echo "ERROR: Please set a value for NEXTAUTH_SECRET in your docker compose variables!"; \
+    exit 1; \
     fi

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -6,7 +6,7 @@ import { createId } from "@paralleldrive/cuid2";
 
 const nextConfig = {
   assetPrefix: process.env.ASSET_PREFIX_URL || undefined,
-  output: "standalone",
+  output: process.env.DOCKER_BUILD ? "standalone" : undefined,
   experimental: {
     serverActions: true,
   },

--- a/turbo.json
+++ b/turbo.json
@@ -94,7 +94,8 @@
         "AWS_ACCESS_KEY",
         "AWS_SECRET_KEY",
         "S3_REGION",
-        "S3_BUCKET_NAME"
+        "S3_BUCKET_NAME",
+        "DOCKER_BUILD"
       ]
     },
     "post-install": {


### PR DESCRIPTION
## What does this PR do?

enable standalone output only for docker build, otherwise use regular output

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Enhancement (small improvements)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B
