### PR TITLE
feat: Added Pin Protection to forms

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/edit/ResponseOptionsCard.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/edit/ResponseOptionsCard.tsx
@@ -9,7 +9,7 @@ import { Label } from "@formbricks/ui/Label";
 import { Input } from "@formbricks/ui/Input";
 import { CheckCircleIcon } from "@heroicons/react/24/solid";
 import * as Collapsible from "@radix-ui/react-collapsible";
-import { useEffect, useState } from "react";
+import { KeyboardEventHandler, useEffect, useState } from "react";
 import toast from "react-hot-toast";
 
 interface ResponseOptionsCardProps {
@@ -49,6 +49,10 @@ export default function ResponseOptionsCard({
   });
   const [closeOnDate, setCloseOnDate] = useState<Date>();
 
+  const [verifyProtectWithPinToggle, setVerifyProtectWithPinToggle] = useState(false);
+
+  const [verifyProtectWithPinError, setverifyProtectWithPinError] = useState<string | null>(null);
+
   const handleRedirectCheckMark = () => {
     setRedirectToggle((prev) => !prev);
 
@@ -71,6 +75,34 @@ export default function ResponseOptionsCard({
       return;
     }
     setSurveyCloseOnDateToggle(true);
+  };
+
+  const handleProtectSurveyWithPinToggle = () => {
+    const currentValue = verifyProtectWithPinToggle;
+    if (currentValue === false) setLocalSurvey({ ...localSurvey, pin: null });
+    setVerifyProtectWithPinToggle(!currentValue);
+  };
+
+  const handleProtectSurveryPinChange = (pin: string) => {
+    const pinAsNumber = Number(pin);
+
+    if (isNaN(pinAsNumber)) return toast.error("PIN can only contain numbers");
+    setLocalSurvey({ ...localSurvey, pin: pinAsNumber });
+  };
+
+  const handleProtectSurveyPinBlurEvent = () => {
+    if (!localSurvey.pin) return setverifyProtectWithPinError(null);
+
+    const regexPattern = /^\d{4}$/;
+    const isValidPin = regexPattern.test(`${localSurvey.pin}`);
+
+    if (!isValidPin) return setverifyProtectWithPinError("PIN must be a four digit number.");
+    setverifyProtectWithPinError(null);
+  };
+
+  const handleSurveyPinInputKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
+    const exceptThisSymbols = ["e", "E", "+", "-", "."];
+    if (exceptThisSymbols.includes(e.key)) e.preventDefault();
   };
 
   const handleRedirectUrlChange = (link: string) => {
@@ -187,6 +219,10 @@ export default function ResponseOptionsCard({
     if (localSurvey.redirectUrl) {
       setRedirectUrl(localSurvey.redirectUrl);
       setRedirectToggle(true);
+    }
+
+    if (!!localSurvey.pin) {
+      setVerifyProtectWithPinToggle(true);
     }
 
     if (!!localSurvey.surveyClosedMessage) {
@@ -481,6 +517,35 @@ export default function ResponseOptionsCard({
                       defaultValue={verifyEmailSurveyDetails.subheading}
                       onChange={(e) => handleVerifyEmailSurveyDetailsChange({ subheading: e.target.value })}
                     />
+                  </div>
+                </div>
+              </AdvancedOptionToggle>
+              <AdvancedOptionToggle
+                htmlId="protectSurveryWithPin"
+                isChecked={verifyProtectWithPinToggle}
+                onToggle={handleProtectSurveyWithPinToggle}
+                title="Protect Survery with a PIN"
+                description="Only users who have the PIN can access the survey."
+                childBorder={true}>
+                <div className="flex w-full items-center space-x-1 p-4 pb-4">
+                  <div className="w-full cursor-pointer items-center  bg-slate-50">
+                    <Label htmlFor="headline">Add PIN</Label>
+                    <Input
+                      autoFocus
+                      type="number"
+                      id="heading"
+                      isInvalid={Boolean(verifyProtectWithPinError)}
+                      className="mb-4 mt-2 bg-white"
+                      name="heading"
+                      placeholder="1234"
+                      onBlur={handleProtectSurveyPinBlurEvent}
+                      defaultValue={localSurvey.pin ? localSurvey.pin : undefined}
+                      onKeyDown={handleSurveyPinInputKeyDown}
+                      onChange={(e) => handleProtectSurveryPinChange(e.target.value)}
+                    />
+                    {verifyProtectWithPinError && (
+                      <p className="text-sm text-red-700">{verifyProtectWithPinError}</p>
+                    )}
                   </div>
                 </div>
               </AdvancedOptionToggle>

--- a/apps/web/app/s/[surveyId]/LinkSurveyPinScreen.tsx
+++ b/apps/web/app/s/[surveyId]/LinkSurveyPinScreen.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import type { NextPage } from "next";
+import { TProduct } from "@/../../packages/types/v1/product";
+import { TResponse } from "@/../../packages/types/v1/responses";
+import OtpInput from "react-otp-input";
+import { useCallback, useEffect, useState } from "react";
+import { validateSurveyPin } from "@/app/s/[surveyId]/actions";
+import { TSurvey } from "@/../../packages/types/v1/surveys";
+import LinkSurvey from "@/app/s/[surveyId]/LinkSurvey";
+import { ISurveryPinValidationResponseError } from "@/app/s/[surveyId]/types";
+
+interface LinkSurveyPinScreenProps {
+  surveyId: string;
+  product: TProduct;
+  personId?: string;
+  emailVerificationStatus?: string;
+  prefillAnswer?: string;
+  singleUseId?: string;
+  singleUseResponse?: TResponse;
+  webAppUrl: string;
+}
+
+const LinkSurveyPinScreen: NextPage<LinkSurveyPinScreenProps> = (props) => {
+  const {
+    surveyId,
+    product,
+    webAppUrl,
+    emailVerificationStatus,
+    personId,
+    prefillAnswer,
+    singleUseId,
+    singleUseResponse,
+  } = props;
+
+  const [localPinEntry, setLocalPinEntry] = useState<string>("");
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const [error, setError] = useState<ISurveryPinValidationResponseError>();
+  const [survey, setSurvey] = useState<TSurvey>();
+
+  const _validateSurveyPinAsync = useCallback(async (surveyId: string, pin: number) => {
+    const response = await validateSurveyPin(surveyId, pin);
+    if (response.error) {
+      setError(response.error);
+    } else if (response.survey) {
+      setSurvey(response.survey);
+    }
+    setLoading(false);
+  }, []);
+
+  const resetState = useCallback(() => {
+    setError(undefined);
+    setLoading(false);
+    setLocalPinEntry("");
+  }, []);
+
+  useEffect(() => {
+    if (error) {
+      const timeout = setTimeout(() => resetState(), 2 * 1000);
+      return () => {
+        clearTimeout(timeout);
+      };
+    }
+  }, [error, resetState]);
+
+  useEffect(() => {
+    const validPinRegex = /^\d{4}$/;
+    const isValidPin = validPinRegex.test(localPinEntry);
+
+    const pinAsNumber = Number(localPinEntry);
+
+    if (isValidPin) {
+      // Show loading and check against the server
+      setLoading(true);
+      _validateSurveyPinAsync(surveyId, pinAsNumber);
+      return;
+    }
+
+    setError(undefined);
+    setLoading(false);
+  }, [_validateSurveyPinAsync, localPinEntry, surveyId]);
+
+  if (!survey) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <div className="flex flex-col items-center justify-center">
+          <div className="my-4 font-semibold">
+            <h4>This survey is protected. Enter the PIN below</h4>
+          </div>
+          <OtpInput
+            isDisabled={loading}
+            hasErrored={Boolean(!!error)}
+            value={localPinEntry}
+            onChange={(value) => setLocalPinEntry(value)}
+            numInputs={4}
+            separator={<span style={{ width: "8px" }}></span>}
+            isInputNum={true}
+            shouldAutoFocus={true}
+            inputStyle={{
+              border: "1px solid #CFD3DB",
+              borderRadius: "8px",
+              width: "64px",
+              height: "84px",
+              fontSize: "24px",
+              color: "#000",
+              fontWeight: "400",
+              caretColor: "blue",
+            }}
+            errorStyle={{
+              border: "1px solid red",
+            }}
+            focusStyle={{
+              border: "1px solid #CFD3DB",
+              outline: "none",
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <LinkSurvey
+      survey={survey}
+      product={product}
+      personId={personId}
+      emailVerificationStatus={emailVerificationStatus}
+      prefillAnswer={prefillAnswer}
+      singleUseId={singleUseId}
+      singleUseResponse={singleUseResponse}
+      webAppUrl={webAppUrl}
+    />
+  );
+};
+
+export default LinkSurveyPinScreen;

--- a/apps/web/app/s/[surveyId]/actions.ts
+++ b/apps/web/app/s/[surveyId]/actions.ts
@@ -9,8 +9,16 @@ interface LinkSurveyEmailData {
   } | null;
 }
 
+interface ISurveryPinValidationResponse {
+  error?: ISurveryPinValidationResponseError;
+  survey?: TSurvey;
+}
+
+import { ISurveryPinValidationResponseError } from "@/app/s/[surveyId]/types";
 import { sendLinkSurveyToVerifiedEmail } from "@/lib/email";
 import { verifyTokenForLinkSurvey } from "@formbricks/lib/jwt";
+import { getSurvey } from "@formbricks/lib/survey/service";
+import { TSurvey } from "@formbricks/types/v1/surveys";
 
 export async function sendLinkSurveyEmailAction(data: LinkSurveyEmailData) {
   if (!data.surveyData) {
@@ -20,4 +28,24 @@ export async function sendLinkSurveyEmailAction(data: LinkSurveyEmailData) {
 }
 export async function verifyTokenAction(token: string, surveyId: string): Promise<boolean> {
   return await verifyTokenForLinkSurvey(token, surveyId);
+}
+
+export async function validateSurveyPin(
+  surveyId: string,
+  pin: number
+): Promise<ISurveryPinValidationResponse> {
+  try {
+    const survey = await getSurvey(surveyId);
+    if (!survey) return { error: ISurveryPinValidationResponseError.NOT_FOUND };
+
+    const originalPin = survey.pin;
+
+    if (!originalPin) return { survey };
+
+    if (originalPin !== pin) return { error: ISurveryPinValidationResponseError.INCORRECT_PIN };
+
+    return { survey };
+  } catch (error) {
+    return { error: ISurveryPinValidationResponseError.INTERNAL_SERVER_ERROR };
+  }
 }

--- a/apps/web/app/s/[surveyId]/page.tsx
+++ b/apps/web/app/s/[surveyId]/page.tsx
@@ -12,6 +12,7 @@ import { notFound } from "next/navigation";
 import { getResponseBySingleUseId } from "@formbricks/lib/response/service";
 import { TResponse } from "@formbricks/types/v1/responses";
 import { validateSurveySingleUseId } from "@/lib/singleUseSurveys";
+import LinkSurveyPinScreen from "@/app/s/[surveyId]/LinkSurveyPinScreen";
 
 interface LinkSurveyPageProps {
   params: {
@@ -94,6 +95,23 @@ export default async function LinkSurveyPage({ params, searchParams }: LinkSurve
   let person;
   if (userId) {
     person = await getOrCreatePersonByUserId(userId, survey.environmentId);
+  }
+
+  const isSurveyPinProtected = Boolean(!!survey && survey.pin);
+
+  if (isSurveyPinProtected) {
+    return (
+      <LinkSurveyPinScreen
+        surveyId={survey.id}
+        product={product}
+        personId={person?.id}
+        emailVerificationStatus={emailVerificationStatus}
+        prefillAnswer={isPrefilledAnswerValid ? prefillAnswer : null}
+        singleUseId={isSingleUseSurvey ? singleUseId : undefined}
+        singleUseResponse={singleUseResponse ? singleUseResponse : undefined}
+        webAppUrl={WEBAPP_URL}
+      />
+    );
   }
 
   return (

--- a/apps/web/app/s/[surveyId]/types.ts
+++ b/apps/web/app/s/[surveyId]/types.ts
@@ -1,0 +1,5 @@
+export enum ISurveryPinValidationResponseError {
+  INCORRECT_PIN = "INCORRECT_PIN",
+  INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR",
+  NOT_FOUND = "NOT_FOUND",
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -26,8 +26,8 @@
     "@json2csv/node": "^7.0.3",
     "@paralleldrive/cuid2": "^2.2.2",
     "@radix-ui/react-collapsible": "^1.0.3",
-    "@react-email/components": "^0.0.7",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
+    "@react-email/components": "^0.0.7",
     "@sentry/nextjs": "^7.73.0",
     "@t3-oss/env-nextjs": "^0.7.0",
     "bcryptjs": "^2.4.3",
@@ -37,12 +37,12 @@
     "googleapis": "^126.0.1",
     "jsonwebtoken": "^9.0.2",
     "lodash": "^4.17.21",
-    "otplib": "^12.0.1",
-    "mime": "^3.0.0",
     "lucide-react": "^0.284.0",
+    "mime": "^3.0.0",
     "next": "13.5.4",
     "next-auth": "^4.23.2",
     "nodemailer": "^6.9.5",
+    "otplib": "^12.0.1",
     "posthog-js": "^1.82.1",
     "prismjs": "^1.29.0",
     "qrcode": "^1.5.3",
@@ -53,16 +53,17 @@
     "react-hook-form": "^7.47.0",
     "react-hot-toast": "^2.4.1",
     "react-icons": "^4.11.0",
+    "react-otp-input": "2.3.0",
     "swr": "^2.2.4",
     "ua-parser-js": "^1.0.36",
     "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@formbricks/tsconfig": "workspace:*",
-    "@types/qrcode": "^1.5.2",
     "@types/bcryptjs": "^2.4.4",
     "@types/lodash": "^4.14.199",
     "@types/markdown-it": "^13.0.2",
+    "@types/qrcode": "^1.5.2",
     "eslint-config-formbricks": "workspace:*"
   }
 }

--- a/packages/database/migrations/20231014080020_add_pin_to_survey/migration.sql
+++ b/packages/database/migrations/20231014080020_add_pin_to_survey/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Survey" ADD COLUMN     "pin" INTEGER;

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -262,6 +262,9 @@ model Survey {
   /// @zod.custom(imports.ZSurveyVerifyEmail)
   /// [SurveyVerifyEmail]
   verifyEmail       Json?
+
+  // PIN Protected Surverys
+  pin Int?
 }
 
 model Event {

--- a/packages/lib/survey/service.ts
+++ b/packages/lib/survey/service.ts
@@ -50,6 +50,7 @@ export const selectSurvey = {
   productOverwrites: true,
   surveyClosedMessage: true,
   singleUse: true,
+  pin: true,
   triggers: {
     select: {
       eventClass: {

--- a/packages/types/v1/surveys.ts
+++ b/packages/types/v1/surveys.ts
@@ -287,6 +287,7 @@ export const ZSurvey = z.object({
   surveyClosedMessage: ZSurveyClosedMessage.nullable(),
   singleUse: ZSurveySingleUse.nullable(),
   verifyEmail: ZSurveyVerifyEmail.nullable(),
+  pin: z.number().nullable().optional(),
 });
 
 export const ZSurveyInput = z.object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,6 +349,9 @@ importers:
       react-icons:
         specifier: ^4.11.0
         version: 4.11.0(react@18.2.0)
+      react-otp-input:
+        specifier: 2.3.0
+        version: 2.3.0(react-dom@18.2.0)(react@18.2.0)
       swr:
         specifier: ^2.2.4
         version: 2.2.4(react@18.2.0)
@@ -469,7 +472,6 @@ importers:
       eslint-config-turbo:
         specifier: latest
         version: 1.10.15(eslint@8.51.0)
-
       eslint-plugin-react:
         specifier: 7.33.2
         version: 7.33.2(eslint@8.51.0)
@@ -11631,7 +11633,6 @@ packages:
       stackframe: 1.3.4
     dev: false
 
-
   /es-abstract@1.22.2:
     resolution: {integrity: sha512-YoxfFcDmhjOgWPWsV13+2RNjq1F6UQnfs+8TftwNqtzlmFzEXvlUwdrNrYeaizfjQzRMxkZ6ElWMOJIFKdVqwA==}
     engines: {node: '>= 0.4'}
@@ -12159,7 +12160,6 @@ packages:
       resolve: 2.0.0-next.4
       semver: 6.3.1
       string.prototype.matchall: 4.0.10
-
 
   /eslint-plugin-turbo@1.10.15(eslint@8.51.0):
     resolution: {integrity: sha512-Tv4QSKV/U56qGcTqS/UgOvb9HcKFmWOQcVh3HEaj7of94lfaENgfrtK48E2CckQf7amhKs1i+imhCsNCKjkQyA==}
@@ -20418,6 +20418,16 @@ packages:
       vfile: 5.3.7
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /react-otp-input@2.3.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-xzljlohVaPkUqO4H61x4r7KMRSq2ZPYFFZeSqqVXid+kJNL1UekSBP1xPafvI0eGNpus/PA1447jYZf2EJRY0A==}
+    peerDependencies:
+      react: ^16.2.0
+      react-dom: ^16.2.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react-property@2.0.0:


### PR DESCRIPTION
## What does this PR do?
This PR adds a feature to protect the surveys using a 4-digit PIN and viewers need to enter a PIN to record a response.

Fixes #1089

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [X] New feature (non-breaking change which adds functionality)

## How should this be tested?
- Create a new Form / Survey
- Go to Settings and expand the Response Options
- Toggle the PIN option
- Add PIN to Survey

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand bits
- [X] Ran `pnpm build`
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
