### PR TITLE
fix: formbricks_encryption_key requires 24 bytes now and not 16

### DIFF
--- a/docker/production.sh
+++ b/docker/production.sh
@@ -266,9 +266,8 @@ nextauth_secret=$(openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | head -c 32) && 
 echo "🚗 NEXTAUTH_SECRET updated successfully!"
 
 echo "🚙 Updating FORMBRICKS_ENCRYPTION_KEY in the Formbricks container..."
-formbricks_encryption_key=$(openssl rand -base64 16 | tr -dc 'a-zA-Z0-9' | head -c 16) && sed -i "/FORMBRICKS_ENCRYPTION_KEY:$/s/FORMBRICKS_ENCRYPTION_KEY:.*/FORMBRICKS_ENCRYPTION_KEY: $formbricks_encryption_key/" docker-compose.yml
+formbricks_encryption_key=$(openssl rand -base64 24 | tr -dc 'a-zA-Z0-9' | head -c 24) && sed -i "/FORMBRICKS_ENCRYPTION_KEY:$/s/FORMBRICKS_ENCRYPTION_KEY:.*/FORMBRICKS_ENCRYPTION_KEY: $formbricks_encryption_key/" docker-compose.yml
 echo "🚗 FORMBRICKS_ENCRYPTION_KEY updated successfully!"
-
 
 newgrp docker <<END
 


### PR DESCRIPTION
## What does this PR do?
Update Prod script to use 24 bytes so that the prod script works as expected again without throwing any errors.
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?
Run the prod script on any ubuntu machine and it should work

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
