### PR TITLE
fix: attribute-settings-tab-button-link

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/(actionsAndAttributes)/attributes/components/AttributeSettingsTab.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/(actionsAndAttributes)/attributes/components/AttributeSettingsTab.tsx
@@ -76,7 +76,7 @@ export default function AttributeSettingsTab({ attributeClass, setOpen }: Attrib
           <div className="flex items-center">
             <Button
               variant="secondary"
-              href="https://formbricks.com/docs/getting-started/identify-users"
+              href="https://formbricks.com/docs/attributes/identify-users"
               target="_blank">
               Read Docs
             </Button>


### PR DESCRIPTION
## What does this PR do?

It fixes  page not found error, when clicking on attributes settings tab's "Read Docs" button.

Fixes #1217 

video link : https://www.loom.com/share/32ca5c98f8f5455ab981340e6b3a9194?sid=5cebdad1-9033-4f5f-a15e-38a6bac718c2

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## How should this be tested?

Watch out loom video.

- Test A
- Test B

## Checklist


### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
