### PR TITLE
fix: Disable Delete and Save buttons in DeleteDialog

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/edit/components/SurveyMenuBar.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/edit/components/SurveyMenuBar.tsx
@@ -45,7 +45,8 @@ export default function SurveyMenuBar({
   const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isConfirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [isMutatingSurvey, setIsMutatingSurvey] = useState(false);
-  const [deleteBtnDisabled, setDeleteBtnDisabled] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   let faultyQuestions: String[] = [];
 
   useEffect(() => {
@@ -334,17 +335,20 @@ export default function SurveyMenuBar({
           deleteWhat="Draft"
           open={isDeleteDialogOpen}
           setOpen={setDeleteDialogOpen}
-          onDelete={() => {
-            deleteSurvey(localSurvey.id);
-            setDeleteBtnDisabled(true);
+          onDelete={async () => {
+            setIsDeleting(true);
+            await deleteSurvey(localSurvey.id);
+            setIsDeleting(false);
           }}
           text="Do you want to delete this draft?"
+          isDeleting={isDeleting}
+          isSaving={isSaving}
           useSaveInsteadOfCancel={true}
-          onSave={() => {
-            saveSurveyAction(true);
-            setDeleteBtnDisabled(true);
+          onSave={async () => {
+            setIsSaving(true);
+            await saveSurveyAction(true);
+            setIsSaving(false);
           }}
-          disabled={deleteBtnDisabled}
         />
         <AlertDialog
           confirmWhat="Survey changes"

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/edit/components/SurveyMenuBar.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/edit/components/SurveyMenuBar.tsx
@@ -45,6 +45,7 @@ export default function SurveyMenuBar({
   const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [isConfirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [isMutatingSurvey, setIsMutatingSurvey] = useState(false);
+  const [deleteBtnDisabled, setDeleteBtnDisabled] = useState(false);
   let faultyQuestions: String[] = [];
 
   useEffect(() => {
@@ -333,10 +334,17 @@ export default function SurveyMenuBar({
           deleteWhat="Draft"
           open={isDeleteDialogOpen}
           setOpen={setDeleteDialogOpen}
-          onDelete={() => deleteSurvey(localSurvey.id)}
+          onDelete={() => {
+            deleteSurvey(localSurvey.id);
+            setDeleteBtnDisabled(true);
+          }}
           text="Do you want to delete this draft?"
           useSaveInsteadOfCancel={true}
-          onSave={() => saveSurveyAction(true)}
+          onSave={() => {
+            saveSurveyAction(true);
+            setDeleteBtnDisabled(true);
+          }}
+          disabled={deleteBtnDisabled}
         />
         <AlertDialog
           confirmWhat="Survey changes"

--- a/packages/ui/DeleteDialog/index.tsx
+++ b/packages/ui/DeleteDialog/index.tsx
@@ -34,6 +34,7 @@ export function DeleteDialog({
       <div>{children}</div>
       <div className="space-x-2 text-right">
         <Button
+          disabled={disabled}
           variant="secondary"
           onClick={() => {
             if (useSaveInsteadOfCancel && onSave) {

--- a/packages/ui/DeleteDialog/index.tsx
+++ b/packages/ui/DeleteDialog/index.tsx
@@ -10,6 +10,7 @@ interface DeleteDialogProps {
   onDelete: () => void;
   text?: string;
   isDeleting?: boolean;
+  isSaving?: boolean;
   useSaveInsteadOfCancel?: boolean;
   onSave?: () => void;
   children?: React.ReactNode;
@@ -23,6 +24,7 @@ export function DeleteDialog({
   onDelete,
   text,
   isDeleting,
+  isSaving,
   useSaveInsteadOfCancel = false,
   onSave,
   children,
@@ -34,7 +36,7 @@ export function DeleteDialog({
       <div>{children}</div>
       <div className="space-x-2 text-right">
         <Button
-          disabled={disabled}
+          loading={isSaving}
           variant="secondary"
           onClick={() => {
             if (useSaveInsteadOfCancel && onSave) {
@@ -44,7 +46,7 @@ export function DeleteDialog({
           }}>
           {useSaveInsteadOfCancel ? "Save" : "Cancel"}
         </Button>
-        <Button variant="warn" onClick={onDelete} loading={isDeleting} disabled={disabled}>
+        <Button variant="warn" onClick={onDelete} loading={isDeleting}>
           Delete
         </Button>
       </div>


### PR DESCRIPTION
## What does this PR do?

This PR addresses the issue where the "Delete" and "Save" buttons in the DeleteDialog component were not being disabled after being clicked, allowing multiple rapid clicks and potentially causing unintended actions.

Fixes #1338

 Loom Video: https://www.loom.com/share/c4973ca8c83a4f289e8b63b0a8c9dad2?sid=b52b9be8-bc6c-40dd-8b2e-b7ed910fa9e9

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

- Open the DeleteDialog component.
- Click the "Delete" button.
- Verify that the "Delete" button becomes disabled after the first click.
- Attempt to click the "Delete" button again to ensure it remains disabled.
- Repeat the above steps for the "Save" button.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [] Ran `pnpm build`
- [x] Checked for warnings; there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
