### PR TITLE
fix: Welcome card not being active by default in every template

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/templates/templates.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/templates/templates.ts
@@ -15,7 +15,7 @@ const hiddenFieldsDefault: TSurveyHiddenFields = {
 };
 
 const welcomeCardDefault: TSurveyWelcomeCard = {
-  enabled: true,
+  enabled: false,
   headline: "Welcome!",
   html: "Thanks for providing your feedback - let's go!",
   timeToFinish: false,


### PR DESCRIPTION
## What does this PR do?

Now, In every template i made welcome card not being active by default. So, whenever user clicked on survey he will hit the 1st question in the survey. In othercase, if he wants welcome card to be active he can do that by changing the default state(false) to true

Fixes # (issue)
#1336

## Type of change


https://github.com/formbricks/formbricks/assets/113505439/1675b4ab-81af-4f27-89b8-7ddbbd092e4f

