### PR TITLE
fix: make metadata internal fields optionality uniform in response object

### DIFF
--- a/packages/types/responses.ts
+++ b/packages/types/responses.ts
@@ -31,8 +31,8 @@ const ZResponseNote = z.object({
 export type TResponseNote = z.infer<typeof ZResponseNote>;
 
 export const ZResponseMeta = z.object({
-  source: z.string(),
-  url: z.string(),
+  source: z.string().optional(),
+  url: z.string().optional(),
   userAgent: z.object({
     browser: z.string().optional(),
     os: z.string().optional(),


### PR DESCRIPTION
## What does this PR do?

We only had the metadata fields optional for creation and updation! Whenever we fetched a response, if the response did not have a metadata source/url, it'd crash since the zod validation failed!

This makes sure that the fields are optional in reading as well!

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://formbricks.com/clmyhzfrymr4ko00hycsg1tvx) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
