### PR TITLE
fix: handle display with no response data in per question drop off

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SummaryDropOffs.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SummaryDropOffs.tsx
@@ -20,6 +20,7 @@ export default function SummaryDropOffs({ responses, survey, displayCount }: Sum
 
       while (currQuesIdx < survey.questions.length) {
         const currQues = survey.questions[currQuesIdx];
+        if (!currQues) break;
 
         if (!currQues.required) {
           if (!response.data[currQues.id]) {


### PR DESCRIPTION
## What does this PR do?
While testing, I just found out that if a response object is created but no questions are answered, the summary drop off fails since it is unable to find a question which crashes the client side! This PR handles the case for it!

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist


### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://formbricks.com/clmyhzfrymr4ko00hycsg1tvx) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
