### PR TITLE
#1371 [BUG] Pricing Free/Paid box needs to be centered.

### DIFF
--- a/apps/formbricks-com/components/shared/PricingGetStarted.tsx
+++ b/apps/formbricks-com/components/shared/PricingGetStarted.tsx
@@ -3,9 +3,8 @@ import { Button } from "@formbricks/ui/Button";
 export const GetStartedWithPricing = ({ showDetailed }: { showDetailed: boolean }) => {
   return (
     <>
-      <div className="flex items-center gap-x-4 px-4 pb-4 md:gap-4 md:px-16">
-        <div className="w-1/3"></div>
-        <div className="w-1/3 text-left text-sm text-slate-800 dark:text-slate-100">
+      <div className="xs:flex-row flex flex-col items-center justify-center gap-x-4 px-4 pb-4 md:gap-4 md:px-16">
+        <div className="text-left text-sm text-slate-800 dark:text-slate-100">
           <p className="text-base font-semibold">Free</p>
 
           {showDetailed && (
@@ -23,7 +22,7 @@ export const GetStartedWithPricing = ({ showDetailed }: { showDetailed: boolean 
             Get started - free
           </Button>
         </div>
-        <div className="w-1/3 text-left text-sm text-slate-800 dark:text-slate-100">
+        <div className="xs:mt-0 mt-5 text-left text-sm text-slate-800 dark:text-slate-100">
           <p className="text-base font-semibold"> Paid</p>
           {showDetailed && (
             <p className="leading text-xs text-slate-500 dark:text-slate-400 md:text-base">


### PR DESCRIPTION
## What does this PR do?

#1371 [BUG] Pricing Free/Paid box needs to be centered.
Fixes # (issue)

### BEFORE
![image](https://github.com/formbricks/formbricks/assets/114233864/05638ea2-efb5-4272-a5a1-e914ab880253)

![image](https://github.com/formbricks/formbricks/assets/114233864/1bfa725d-2cb8-4aac-be22-d096f9edabab)


###AFTER

<img width="484" alt="image" src="https://github.com/formbricks/formbricks/assets/114233864/8c80179e-dc9a-4fcc-a595-4d38530d59fc">

<img width="204" alt="image" src="https://github.com/formbricks/formbricks/assets/114233864/73d96100-c93b-460d-b6db-104eb2eec0ee">


##A VIDEO DEMONSTRATION

https://github.com/formbricks/formbricks/assets/114233864/d1c1919f-4d0e-442a-8692-7787a5b2268a



## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

### Required

- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Checked for warnings, there are none
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://formbricks.com/clmyhzfrymr4ko00hycsg1tvx) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
