### PR TITLE
feat: lazy loading and endless scrolling for responses page

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponsePage.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponsePage.tsx
@@ -24,6 +24,7 @@ interface ResponsePageProps {
   product: TProduct;
   profile: TProfile;
   environmentTags: TTag[];
+  responsesPerPage: number;
 }
 
 const ResponsePage = ({
@@ -35,6 +36,7 @@ const ResponsePage = ({
   product,
   profile,
   environmentTags,
+  responsesPerPage,
 }: ResponsePageProps) => {
   const { selectedFilter, dateRange, resetState } = useResponseFilter();
 
@@ -74,6 +76,7 @@ const ResponsePage = ({
         survey={survey}
         profile={profile}
         environmentTags={environmentTags}
+        responsesPerPage={responsesPerPage}
       />
     </ContentWrapper>
   );

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTimeline.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTimeline.tsx
@@ -1,4 +1,5 @@
 "use client";
+import React, { useState, useEffect, useRef } from "react";
 import EmptyInAppSurveys from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/components/EmptyInAppSurveys";
 import EmptySpaceFiller from "@formbricks/ui/EmptySpaceFiller";
 import { TEnvironment } from "@formbricks/types/environment";
@@ -15,6 +16,7 @@ interface ResponseTimelineProps {
   survey: TSurvey;
   profile: TProfile;
   environmentTags: TTag[];
+  responsesPerPage: number;
 }
 
 export default function ResponseTimeline({
@@ -23,12 +25,44 @@ export default function ResponseTimeline({
   survey,
   profile,
   environmentTags,
+  responsesPerPage,
 }: ResponseTimelineProps) {
+  const [displayedResponses, setDisplayedResponses] = useState<TResponse[]>([]);
+  const loadingRef = useRef(null);
+
+  useEffect(() => {
+    setDisplayedResponses(responses.slice(0, responsesPerPage));
+  }, [responses]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          setDisplayedResponses((prevResponses) => [
+            ...prevResponses,
+            ...responses.slice(prevResponses.length, prevResponses.length + responsesPerPage),
+          ]);
+        }
+      },
+      { threshold: 0.8 }
+    );
+
+    if (loadingRef.current) {
+      observer.observe(loadingRef.current);
+    }
+
+    return () => {
+      if (loadingRef.current) {
+        observer.unobserve(loadingRef.current);
+      }
+    };
+  }, [responses]);
+
   return (
     <div className="space-y-4">
-      {survey.type === "web" && responses.length === 0 && !environment.widgetSetupCompleted ? (
+      {survey.type === "web" && displayedResponses.length === 0 && !environment.widgetSetupCompleted ? (
         <EmptyInAppSurveys environment={environment} />
-      ) : responses.length === 0 ? (
+      ) : displayedResponses.length === 0 ? (
         <EmptySpaceFiller
           type="response"
           environment={environment}
@@ -36,7 +70,7 @@ export default function ResponseTimeline({
         />
       ) : (
         <div>
-          {responses.map((response) => {
+          {displayedResponses.map((response) => {
             return (
               <div key={response.id}>
                 <SingleResponseCard
@@ -50,6 +84,7 @@ export default function ResponseTimeline({
               </div>
             );
           })}
+          <div ref={loadingRef}></div>
         </div>
       )}
     </div>

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/page.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/page.tsx
@@ -4,7 +4,7 @@ import { authOptions } from "@formbricks/lib/authOptions";
 import ResponsePage from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponsePage";
 import { getAnalysisData } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/data";
 import { getServerSession } from "next-auth";
-import { REVALIDATION_INTERVAL, SURVEY_BASE_URL } from "@formbricks/lib/constants";
+import { RESPONSES_PER_PAGE, REVALIDATION_INTERVAL, SURVEY_BASE_URL } from "@formbricks/lib/constants";
 import ResponsesLimitReachedBanner from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/components/ResponsesLimitReachedBanner";
 import { getEnvironment } from "@formbricks/lib/environment/service";
 import { getProductByEnvironmentId } from "@formbricks/lib/product/service";
@@ -46,6 +46,7 @@ export default async function Page({ params }) {
         product={product}
         environmentTags={tags}
         profile={profile}
+        responsesPerPage={RESPONSES_PER_PAGE}
       />
     </>
   );

--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -61,6 +61,7 @@ export const MAIL_FROM = env.MAIL_FROM;
 export const NEXTAUTH_SECRET = env.NEXTAUTH_SECRET;
 export const NEXTAUTH_URL = env.NEXTAUTH_URL;
 export const ITEMS_PER_PAGE = 50;
+export const RESPONSES_PER_PAGE = 10;
 
 // Storage constants
 export const UPLOADS_DIR = path.resolve("./uploads");


### PR DESCRIPTION
## What does this PR do?
If you have a lot of responses, as of now, the page would really swamp up with all of them with a super tiny nav scroll making it extremely difficult from a UX perspective.

This PR limits to 10 responses and then as soon as the user reaches the second last response of the 10, loads the next 10 and so on. They are, as before, sorted in descending order as per date-time!

Attached video with an example with 3 Responses at a time (for testing purposes):

https://github.com/formbricks/formbricks/assets/55556994/974c9836-57a5-4816-b479-56cd9c27ef6d


## Type of change
- [x] Enhancement (small improvements)

## How should this be tested?

Have more than 10 responses on a survey? Open the summary and then the responses tab to see this in effect!

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://formbricks.com/clmyhzfrymr4ko00hycsg1tvx) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
