### PR TITLE
fix: rate limit is now enabled on node prod envs only

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -6,7 +6,7 @@ const signUpLimiter = rateLimit({ interval: 60 * 60 * 1000 }); // 60 minutes
 const loginLimiter = rateLimit({ interval: 15 * 60 * 1000 }); // 15 minutes
 
 export async function middleware(request: NextRequest) {
-  if (process.env.IS_FORMBRICKS_CLOUD != "1") {
+  if (process.env.NODE_ENV !== "production") {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## What does this PR do?
Rate Limiting previously was based on the `IS_FORMBRICKS_CLOUD` env var. It is now shifted to use the `NODE_ENV` and rate limit now only comes to place when it is set to production. Else, is disabled.


## Type of change
- [x] Chore (refactoring code, technical debt, workflow improvements)

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://formbricks.com/clmyhzfrymr4ko00hycsg1tvx) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
