### PR TITLE
fix: Disable paste functionality for account deletion confirmation input field

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/settings/profile/components/DeleteAccount.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/settings/profile/components/DeleteAccount.tsx
@@ -9,7 +9,7 @@ import { ProfileAvatar } from "@formbricks/ui/Avatars";
 import { Session } from "next-auth";
 import { signOut } from "next-auth/react";
 import Image from "next/image";
-import { Dispatch, SetStateAction, useState } from "react";
+import { Dispatch, SetStateAction, useState, useRef } from "react";
 import toast from "react-hot-toast";
 import { deleteProfileAction } from "../actions";
 
@@ -62,6 +62,11 @@ function DeleteAccountModal({ setOpen, open, session }: DeleteAccountModalProps)
       setOpen(false);
     }
   };
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>) => {
+    e.preventDefault();
+  };
 
   return (
     <DeleteDialog
@@ -91,6 +96,8 @@ function DeleteAccountModal({ setOpen, open, session }: DeleteAccountModalProps)
             confirm the definitive deletion of your account:
           </label>
           <Input
+            ref={inputRef}
+            onPaste={handlePaste}
             value={inputValue}
             onChange={handleInputChange}
             placeholder={session.user.email}


### PR DESCRIPTION
## What does this PR do?

This PR addresses the issue #1493 where users were able to paste content into the input field labeled "Please enter example@gmail.com in the following field to confirm the definitive deletion of your account." The fix disables the paste functionality for this specific input field, ensuring that users must manually enter the required email address for account deletion confirmation.

fix #1493

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How should this be tested?

1. Open the application.
2. Navigate to the account deletion confirmation page.
3. Attempt to paste content into the designated input field.
4. Verify that pasting is disabled, and the email address must be manually entered.
5. Ensure that other functionalities on the page are unaffected.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://formbricks.com/clmyhzfrymr4ko00hycsg1tvx) Without it, we won't be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
