### PR TITLE
fix: overloading slider on exceeding max limits in pricing tier

### DIFF
--- a/packages/ui/BillingSlider/index.tsx
+++ b/packages/ui/BillingSlider/index.tsx
@@ -18,7 +18,9 @@ export const BillingSlider = React.forwardRef<React.ElementRef<typeof SliderPrim
       className={cn("relative flex w-full touch-none select-none items-center", className)}
       {...props}>
       <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-slate-300">
-        <div style={{ width: `${(value / max) * 100}%` }} className="absolute h-full bg-slate-800"></div>
+        <div
+          style={{ width: `calc(${Math.min(value / max, 0.93) * 100}%)` }}
+          className="absolute h-full bg-slate-800"></div>
         <div
           style={{
             width: `${((freeTierLimit - value) / max) * 100}%`,
@@ -27,11 +29,13 @@ export const BillingSlider = React.forwardRef<React.ElementRef<typeof SliderPrim
           className="absolute h-full bg-slate-500"></div>
       </SliderPrimitive.Track>
 
-      <div style={{ left: `${(value / max) * 100}%` }} className="absolute mt-4 h-6 w-px bg-slate-500"></div>
+      <div
+        style={{ left: `calc(${Math.min(value / max, 0.93) * 100}%)` }}
+        className="absolute mt-4 h-6 w-px bg-slate-500"></div>
 
       <div
-        style={{ left: `calc(${(value / max) * 100}% + 0.5rem)` }}
-        className="absolute mt-12 text-sm text-slate-700 dark:text-slate-200">
+        style={{ left: `calc(${Math.min(value / max, 0.93) * 100}% + 0.5rem)` }}
+        className="absolute mt-16 text-sm text-slate-700 dark:text-slate-200">
         <p className="text-xs">
           Current:
           <br />


### PR DESCRIPTION
## What does this PR do?
The slider currently exceeds the card and the page 😓 when the current count exceeds the max value! This PR limits the same to max 93% of the slider so that the text is also visible and it stays under the card

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://formbricks.com/clmyhzfrymr4ko00hycsg1tvx) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
