### PR TITLE
fix: redirect user if they visit onboarding page without auth

### DIFF
--- a/apps/web/app/(app)/onboarding/page.tsx
+++ b/apps/web/app/(app)/onboarding/page.tsx
@@ -7,11 +7,12 @@ import { getProductByEnvironmentId } from "@formbricks/lib/product/service";
 import { getProfile } from "@formbricks/lib/profile/service";
 import { getServerSession } from "next-auth";
 import Onboarding from "./components/Onboarding";
+import { redirect } from "next/navigation";
 
 export default async function OnboardingPage() {
   const session = await getServerSession(authOptions);
   if (!session) {
-    throw new Error("No session found");
+    redirect("/auth/login");
   }
   const userId = session?.user.id;
   const environment = await getFirstEnvironmentByUserId(userId);


### PR DESCRIPTION
## What does this PR do?
Sentry reported 46 instances of users getting a Session not Found error specifically on the Onboarding page that we have. We currently just show the user an error without any CTA. This case is possible for when a token expires or the session JWT is not valid anymore. To tackle this, we now redirect them back to the login page so that a new token can be generated and then they will be taken to the page they should be as per the normal flow.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://formbricks.com/clmyhzfrymr4ko00hycsg1tvx) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
