### PR TITLE
fix: opt billing page forcefully out of static generation

### DIFF
--- a/apps/web/app/(app)/billing-confirmation/page.tsx
+++ b/apps/web/app/(app)/billing-confirmation/page.tsx
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import ConfirmationPage from "./components/ConfirmationPage";
 
 export default function BillingConfirmation({ searchParams }) {


### PR DESCRIPTION
## What does this PR do?
Sentry reported a few runtime errors when people visited the `/billing-confirmation` page because it used the `searchParams` for the page, it could not be rendered the SSG way hence causing error. This PR now forces it to use the SSR method hence hopefully not throwing any such error.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://formbricks.com/clmyhzfrymr4ko00hycsg1tvx) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
