### PR TITLE
fix: move link surveys above in docs navbar & rename user identification

### DIFF
--- a/apps/formbricks-com/app/docs/link-surveys/user-identification/page.mdx
+++ b/apps/formbricks-com/app/docs/link-surveys/user-identification/page.mdx
@@ -3,14 +3,14 @@ import Image from "next/image";
 import PeopleView from "./people-view.webp";
 
 export const metadata = {
-  title: "Effective User Identification in Formbricks Link Surveys",
+  title: "Effective Identify Users in Formbricks Link Surveys",
   description:
     "Discover how to seamlessly connect responses from Formbricks link surveys to existing users in your database. Learn the intricacies of the userId URL parameter to enhance user tracking, profiling, and segmentation, ensuring more personalized interactions and data-driven decisions.",
 };
 
 #### Link Surveys
 
-# User Identification in Link Surveys
+# Identify Users in Link Surveys
 
 Identifying users in link features lets you connect responses from link surveys with existing users in your Formbricks database.
 

--- a/apps/formbricks-com/components/docs/Navigation.tsx
+++ b/apps/formbricks-com/components/docs/Navigation.tsx
@@ -213,6 +213,14 @@ export const navigation: Array<NavGroup> = [
     ],
   },
   {
+    title: "Link Surveys",
+    links: [
+      { title: "Data Prefilling", href: "/docs/link-surveys/data-prefilling" },
+      { title: "Identify Users", href: "/docs/link-surveys/user-identification" },
+      { title: "Single Use Links", href: "/docs/link-surveys/single-use-links" },
+    ],
+  },
+  {
     title: "Best Practices",
     links: [
       { title: "Learn from Churn", href: "/docs/best-practices/cancel-subscription" },
@@ -232,14 +240,6 @@ export const navigation: Array<NavGroup> = [
       { title: "Make.com", href: "/docs/integrations/make" },
       { title: "n8n", href: "/docs/integrations/n8n" },
       { title: "Zapier", href: "/docs/integrations/zapier" },
-    ],
-  },
-  {
-    title: "Link Surveys",
-    links: [
-      { title: "Data Prefilling", href: "/docs/link-surveys/data-prefilling" },
-      { title: "User Identification", href: "/docs/link-surveys/user-identification" },
-      { title: "Single Use Links", href: "/docs/link-surveys/single-use-links" },
     ],
   },
   {


### PR DESCRIPTION
## What does this PR do?
- Moves Link Survey Section above in the Navigation Hierarchy ie just below the Actions Section
- Renames User Identification to Identify Users for consistency


## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://formbricks.com/clmyhzfrymr4ko00hycsg1tvx) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
