### PR TITLE
fix: validate string before fetching survey

### DIFF
--- a/apps/web/app/s/[surveyId]/page.tsx
+++ b/apps/web/app/s/[surveyId]/page.tsx
@@ -14,7 +14,6 @@ import { TResponse } from "@formbricks/types/responses";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getEmailVerificationStatus } from "./lib/helpers";
-import { validateInputs } from "@formbricks/lib/utils/validate";
 import { ZId } from "@formbricks/types/environment";
 
 interface LinkSurveyPageProps {
@@ -29,7 +28,11 @@ interface LinkSurveyPageProps {
 }
 
 export async function generateMetadata({ params }: LinkSurveyPageProps): Promise<Metadata> {
-  validateInputs([params.surveyId, ZId]);
+  const validId = ZId.safeParse(params.surveyId);
+  if (!validId.success) {
+    notFound();
+  }
+
   const survey = await getSurvey(params.surveyId);
 
   if (!survey || survey.type !== "link" || survey.status === "draft") {
@@ -76,7 +79,10 @@ export async function generateMetadata({ params }: LinkSurveyPageProps): Promise
 }
 
 export default async function LinkSurveyPage({ params, searchParams }: LinkSurveyPageProps) {
-  validateInputs([params.surveyId, ZId]);
+  const validId = ZId.safeParse(params.surveyId);
+  if (!validId.success) {
+    notFound();
+  }
   const survey = await getSurvey(params.surveyId);
 
   const suId = searchParams.suId;

--- a/apps/web/app/s/[surveyId]/page.tsx
+++ b/apps/web/app/s/[surveyId]/page.tsx
@@ -14,6 +14,8 @@ import { TResponse } from "@formbricks/types/responses";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getEmailVerificationStatus } from "./lib/helpers";
+import { validateInputs } from "@formbricks/lib/utils/validate";
+import { ZId } from "@formbricks/types/environment";
 
 interface LinkSurveyPageProps {
   params: {
@@ -27,6 +29,7 @@ interface LinkSurveyPageProps {
 }
 
 export async function generateMetadata({ params }: LinkSurveyPageProps): Promise<Metadata> {
+  validateInputs([params.surveyId, ZId]);
   const survey = await getSurvey(params.surveyId);
 
   if (!survey || survey.type !== "link" || survey.status === "draft") {
@@ -73,6 +76,7 @@ export async function generateMetadata({ params }: LinkSurveyPageProps): Promise
 }
 
 export default async function LinkSurveyPage({ params, searchParams }: LinkSurveyPageProps) {
+  validateInputs([params.surveyId, ZId]);
   const survey = await getSurvey(params.surveyId);
 
   const suId = searchParams.suId;


### PR DESCRIPTION
## What does this PR do?
Validates param string before fetching a survey for it to reduce error logging in app as well as sentry

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://formbricks.com/clmyhzfrymr4ko00hycsg1tvx) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
