### PR TITLE
feat: Show the number of Responses to Respondents

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/edit/components/EditWelcomeCard.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/edit/components/EditWelcomeCard.tsx
@@ -38,6 +38,7 @@ export default function EditWelcomeCard({
   };
 
   const updateSurvey = (data) => {
+    console.log("data", data);
     setLocalSurvey({
       ...localSurvey,
       welcomeCard: {
@@ -174,6 +175,26 @@ export default function EditWelcomeCard({
                 </Label>
                 <div className="text-sm text-gray-500 dark:text-gray-400">
                   Display an estimate of completion time for survey
+                </div>
+              </div>
+            </div>
+            <div className="mt-8 flex items-center">
+              <div className="mr-2">
+                <Switch
+                  id="numberOfResponses"
+                  name="numberOfResponses"
+                  checked={localSurvey?.welcomeCard?.numberOfResponses}
+                  onCheckedChange={() =>
+                    updateSurvey({ numberOfResponses: !localSurvey.welcomeCard.numberOfResponses })
+                  }
+                />
+              </div>
+              <div className="flex-column">
+                <Label htmlFor="numberOfResponses" className="">
+                  No Of Responses
+                </Label>
+                <div className="text-sm text-gray-500 dark:text-gray-400">
+                  Display the number of Responses to Respondents
                 </div>
               </div>
             </div>

--- a/apps/web/app/s/[surveyId]/page.tsx
+++ b/apps/web/app/s/[surveyId]/page.tsx
@@ -8,7 +8,7 @@ import { checkValidity } from "@/app/s/[surveyId]/lib/prefilling";
 import { REVALIDATION_INTERVAL, WEBAPP_URL } from "@formbricks/lib/constants";
 import { createPerson, getPersonByUserId } from "@formbricks/lib/person/service";
 import { getProductByEnvironmentId } from "@formbricks/lib/product/service";
-import { getResponseBySingleUseId } from "@formbricks/lib/response/service";
+import { getResponseBySingleUseId, getResponseCountBySurveyId } from "@formbricks/lib/response/service";
 import { getSurvey } from "@formbricks/lib/survey/service";
 import { TResponse } from "@formbricks/types/responses";
 import type { Metadata } from "next";
@@ -89,6 +89,7 @@ export default async function LinkSurveyPage({ params, searchParams }: LinkSurve
   const suId = searchParams.suId;
   const isSingleUseSurvey = survey?.singleUse?.enabled;
   const isSingleUseSurveyEncrypted = survey?.singleUse?.isEncrypted;
+  const isNumberOfResponseEnabled = survey?.numberOfResponses;
 
   if (!survey || survey.type !== "link" || survey.status === "draft") {
     notFound();
@@ -167,6 +168,9 @@ export default async function LinkSurveyPage({ params, searchParams }: LinkSurve
 
   const isSurveyPinProtected = Boolean(!!survey && survey.pin);
 
+  if (isNumberOfResponseEnabled) {
+    survey.responseCount = await getResponseCountBySurveyId(survey.id);
+  }
   if (isSurveyPinProtected) {
     return (
       <PinScreen

--- a/apps/web/app/s/[surveyId]/page.tsx
+++ b/apps/web/app/s/[surveyId]/page.tsx
@@ -89,7 +89,6 @@ export default async function LinkSurveyPage({ params, searchParams }: LinkSurve
   const suId = searchParams.suId;
   const isSingleUseSurvey = survey?.singleUse?.enabled;
   const isSingleUseSurveyEncrypted = survey?.singleUse?.isEncrypted;
-  const isNumberOfResponseEnabled = survey?.numberOfResponses;
 
   if (!survey || survey.type !== "link" || survey.status === "draft") {
     notFound();
@@ -168,9 +167,7 @@ export default async function LinkSurveyPage({ params, searchParams }: LinkSurve
 
   const isSurveyPinProtected = Boolean(!!survey && survey.pin);
 
-  if (isNumberOfResponseEnabled) {
-    survey.responseCount = await getResponseCountBySurveyId(survey.id);
-  }
+  survey.responseCount = await getResponseCountBySurveyId(survey.id);
   if (isSurveyPinProtected) {
     return (
       <PinScreen

--- a/packages/database/migrations/20231202162449_test_resposnes/migration.sql
+++ b/packages/database/migrations/20231202162449_test_resposnes/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Survey" ADD COLUMN     "numberOfResponses" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "responseCount" INTEGER DEFAULT 0;

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -296,6 +296,8 @@ model Survey {
   /// [SurveyVerifyEmail]
   verifyEmail       Json?
   pin               String?
+  numberOfResponses Boolean @default(false)
+  responseCount     Int?    @default(0)
 
   @@index([environmentId])
 }

--- a/packages/lib/survey/service.ts
+++ b/packages/lib/survey/service.ts
@@ -22,6 +22,7 @@ import { diffInDays } from "../utils/datetime";
 import { validateInputs } from "../utils/validate";
 import { surveyCache } from "./cache";
 import { formatSurveyDateFields } from "./util";
+import { getResponseCountBySurveyId } from "../response/service";
 
 export const selectSurvey = {
   id: true,
@@ -268,6 +269,7 @@ export const getSurveys = async (environmentId: string, page?: number): Promise<
         const transformedSurvey = {
           ...surveyPrisma,
           triggers: surveyPrisma.triggers.map((trigger) => trigger.actionClass.name),
+          responseCount: await getResponseCountBySurveyId(surveyPrisma.id),
         };
         surveys.push(transformedSurvey);
       }

--- a/packages/lib/survey/service.ts
+++ b/packages/lib/survey/service.ts
@@ -47,6 +47,8 @@ export const selectSurvey = {
   surveyClosedMessage: true,
   singleUse: true,
   pin: true,
+  numberOfResponses: true,
+  responseCount: true,
   triggers: {
     select: {
       actionClass: {

--- a/packages/surveys/src/components/general/Survey.tsx
+++ b/packages/surveys/src/components/general/Survey.tsx
@@ -132,6 +132,7 @@ export function Survey({
           fileUrl={survey.welcomeCard.fileUrl}
           buttonLabel={survey.welcomeCard.buttonLabel}
           timeToFinish={survey.welcomeCard.timeToFinish}
+          numberOfResponses={survey.welcomeCard.numberOfResponses}
           onSubmit={onSubmit}
           survey={survey}
         />

--- a/packages/surveys/src/components/general/WelcomeCard.tsx
+++ b/packages/surveys/src/components/general/WelcomeCard.tsx
@@ -69,6 +69,13 @@ export default function WelcomeCard({
     return `${minutes} minutes`;
   };
 
+  function getNumberOfResponses() {
+    if (survey.responseCount && survey.responseCount > 10) {
+      return `(${survey.responseCount})`;
+    }
+    return ``;
+  }
+
   return (
     <div>
       {fileUrl && (
@@ -96,7 +103,9 @@ export default function WelcomeCard({
       {timeToFinish && (
         <div className="item-center mt-4 flex text-slate-500">
           <TimerIcon />
-          <p className="text-xs">Takes {calculateTimeToComplete()}</p>
+          <p className="text-xs">
+            Takes {calculateTimeToComplete()} {getNumberOfResponses()}
+          </p>
         </div>
       )}
     </div>

--- a/packages/surveys/src/components/general/WelcomeCard.tsx
+++ b/packages/surveys/src/components/general/WelcomeCard.tsx
@@ -71,6 +71,14 @@ export default function WelcomeCard({
     return `${minutes} minutes`;
   };
 
+  function getReponseCount() {
+    if (survey.responseCount && survey.responseCount > 10) {
+      return `${survey.responseCount}`;
+    }
+
+    return "";
+  }
+
   return (
     <div>
       {fileUrl && (
@@ -101,9 +109,9 @@ export default function WelcomeCard({
           <p className="text-xs">Takes {calculateTimeToComplete()}</p>
         </div>
       )}
-      {numberOfResponses && survey.responseCount && survey.responseCount > 10 && (
+      {numberOfResponses && (
         <div className="item-center mt-4 flex text-slate-500">
-          <p className="text-xs">({survey.responseCount}) users completed this survey</p>
+          <p className="text-xs">({getReponseCount()}) users completed this survey</p>
         </div>
       )}
     </div>

--- a/packages/surveys/src/components/general/WelcomeCard.tsx
+++ b/packages/surveys/src/components/general/WelcomeCard.tsx
@@ -71,13 +71,6 @@ export default function WelcomeCard({
     return `${minutes} minutes`;
   };
 
-  // function getNumberOfResponses() {
-  //   if (survey.responseCount && survey.responseCount > 10) {
-  //     return `(${survey.responseCount})`;
-  //   }
-  //   return ``;
-  // }
-
   return (
     <div>
       {fileUrl && (
@@ -102,19 +95,17 @@ export default function WelcomeCard({
           <div className="text-subheading flex items-center text-xs">Press Enter ↵</div>
         </div>
       </div>
-      {/* {timeToFinish && (
+      {timeToFinish && (
         <div className="item-center mt-4 flex text-slate-500">
           <TimerIcon />
-          <p className="text-xs">
-            Takes {calculateTimeToComplete()}
-          </p>
+          <p className="text-xs">Takes {calculateTimeToComplete()}</p>
         </div>
-      )} */}
-      {/* {(numberOfResponses && survey.responseCount && survey.responseCount > 10) && ( */}
-      <div className="item-center mt-4 flex text-slate-500">
-        <p className="text-xs">`(${survey.responseCount})` users completed this survey</p>
-      </div>
-      {/* )} */}
+      )}
+      {numberOfResponses && survey.responseCount && survey.responseCount > 10 && (
+        <div className="item-center mt-4 flex text-slate-500">
+          <p className="text-xs">`(${survey.responseCount})` users completed this survey</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/surveys/src/components/general/WelcomeCard.tsx
+++ b/packages/surveys/src/components/general/WelcomeCard.tsx
@@ -71,14 +71,6 @@ export default function WelcomeCard({
     return `${minutes} minutes`;
   };
 
-  function getReponseCount() {
-    if (survey.responseCount && survey.responseCount > 10) {
-      return `${survey.responseCount}`;
-    }
-
-    return "";
-  }
-
   return (
     <div>
       {fileUrl && (
@@ -109,9 +101,9 @@ export default function WelcomeCard({
           <p className="text-xs">Takes {calculateTimeToComplete()}</p>
         </div>
       )}
-      {numberOfResponses && (
+      {numberOfResponses && survey.responseCount! > 10 && (
         <div className="item-center mt-4 flex text-slate-500">
-          <p className="text-xs">({getReponseCount()}) users completed this survey</p>
+          <p className="text-xs">{survey.responseCount} users completed this survey</p>
         </div>
       )}
     </div>

--- a/packages/surveys/src/components/general/WelcomeCard.tsx
+++ b/packages/surveys/src/components/general/WelcomeCard.tsx
@@ -11,6 +11,7 @@ interface WelcomeCardProps {
   fileUrl?: string;
   buttonLabel?: string;
   timeToFinish?: boolean;
+  numberOfResponses?: boolean;
   onSubmit: (data: TResponseData, ttc: TResponseTtc) => void;
   survey: TSurvey;
 }
@@ -38,6 +39,7 @@ export default function WelcomeCard({
   fileUrl,
   buttonLabel,
   timeToFinish,
+  numberOfResponses,
   onSubmit,
   survey,
 }: WelcomeCardProps) {
@@ -69,12 +71,12 @@ export default function WelcomeCard({
     return `${minutes} minutes`;
   };
 
-  function getNumberOfResponses() {
-    if (survey.responseCount && survey.responseCount > 10) {
-      return `(${survey.responseCount})`;
-    }
-    return ``;
-  }
+  // function getNumberOfResponses() {
+  //   if (survey.responseCount && survey.responseCount > 10) {
+  //     return `(${survey.responseCount})`;
+  //   }
+  //   return ``;
+  // }
 
   return (
     <div>
@@ -100,14 +102,19 @@ export default function WelcomeCard({
           <div className="text-subheading flex items-center text-xs">Press Enter ↵</div>
         </div>
       </div>
-      {timeToFinish && (
+      {/* {timeToFinish && (
         <div className="item-center mt-4 flex text-slate-500">
           <TimerIcon />
           <p className="text-xs">
-            Takes {calculateTimeToComplete()} {getNumberOfResponses()}
+            Takes {calculateTimeToComplete()}
           </p>
         </div>
-      )}
+      )} */}
+      {/* {(numberOfResponses && survey.responseCount && survey.responseCount > 10) && ( */}
+      <div className="item-center mt-4 flex text-slate-500">
+        <p className="text-xs">`(${survey.responseCount})` users completed this survey</p>
+      </div>
+      {/* )} */}
     </div>
   );
 }

--- a/packages/surveys/src/components/general/WelcomeCard.tsx
+++ b/packages/surveys/src/components/general/WelcomeCard.tsx
@@ -103,7 +103,7 @@ export default function WelcomeCard({
       )}
       {numberOfResponses && survey.responseCount && survey.responseCount > 10 && (
         <div className="item-center mt-4 flex text-slate-500">
-          <p className="text-xs">`(${survey.responseCount})` users completed this survey</p>
+          <p className="text-xs">({survey.responseCount}) users completed this survey</p>
         </div>
       )}
     </div>

--- a/packages/types/surveys.ts
+++ b/packages/types/surveys.ts
@@ -27,6 +27,7 @@ export const ZSurveyWelcomeCard = z.object({
   fileUrl: z.string().optional(),
   buttonLabel: z.string().optional(),
   timeToFinish: z.boolean().default(true),
+  numberOfResponses: z.boolean().default(false),
 });
 
 export const ZSurveyHiddenFields = z.object({

--- a/packages/types/surveys.ts
+++ b/packages/types/surveys.ts
@@ -382,6 +382,8 @@ export const ZSurvey = z.object({
   singleUse: ZSurveySingleUse.nullable(),
   verifyEmail: ZSurveyVerifyEmail.nullable(),
   pin: z.string().nullable().optional(),
+  numberOfResponses: z.boolean().default(false),
+  responseCount: z.number().nullable().optional(),
 });
 
 export const ZSurveyInput = z.object({


### PR DESCRIPTION
## What does this PR do?

This PR Show the number of Responses to Respondents as per the requirement in OSSHack Bounty.

![Screenshot 2023-12-03 at 1 37 38 AM](https://github.com/formbricks/formbricks/assets/52622674/605b59d4-3141-4477-86c6-68066f98f0e2)

![Screenshot 2023-12-03 at 1 37 24 AM](https://github.com/formbricks/formbricks/assets/52622674/32ffad78-59ce-4d8c-974f-9d7e32f73d5f)

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Enhancement (small improvements)


## How should this be tested?

- On the while creating a survey switch on the number of responses switch to see the number of users who have already taken that survey, number of users should be greater than 10 only then it will be visible



### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues



