### PR TITLE
fix: add response limitations to sync endpoint

### DIFF
--- a/apps/web/app/api/v1/client/[environmentId]/in-app/sync/[userId]/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/in-app/sync/[userId]/route.ts
@@ -76,16 +76,14 @@ export async function GET(
       }
       // check userTargeting subscription
       const hasUserTargetingSubscription =
-        (team?.billing?.features.userTargeting.status &&
-          team?.billing?.features.userTargeting.status in ["active", "canceled"]) ||
-        team?.billing?.features.userTargeting.unlimited;
+        team?.billing?.features.userTargeting.status &&
+        team?.billing?.features.userTargeting.status in ["active", "canceled"];
       const currentMau = await getMonthlyActiveTeamPeopleCount(team.id);
       isMauLimitReached = !hasUserTargetingSubscription && currentMau >= PRICING_USERTARGETING_FREE_MTU;
       // check inAppSurvey subscription
       const hasInAppSurveySubscription =
-        (team?.billing?.features.inAppSurvey.status &&
-          team?.billing?.features.inAppSurvey.status in ["active", "canceled"]) ||
-        team?.billing?.features.inAppSurvey.unlimited;
+        team?.billing?.features.inAppSurvey.status &&
+        team?.billing?.features.inAppSurvey.status in ["active", "canceled"];
       const currentResponseCount = await getMonthlyTeamResponseCount(team.id);
       isInAppSurveyLimitReached =
         !hasInAppSurveySubscription && currentResponseCount >= PRICING_APPSURVEYS_FREE_RESPONSES;

--- a/apps/web/app/api/v1/client/[environmentId]/in-app/sync/[userId]/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/in-app/sync/[userId]/route.ts
@@ -76,14 +76,14 @@ export async function GET(
       }
       // check userTargeting subscription
       const hasUserTargetingSubscription =
-        team.billing?.features.userTargeting.status &&
-        team.billing?.features.userTargeting.status in ["active", "canceled"];
+        team.billing.features.userTargeting.status &&
+        ["active", "canceled"].includes(team.billing.features.userTargeting.status);
       const currentMau = await getMonthlyActiveTeamPeopleCount(team.id);
       isMauLimitReached = !hasUserTargetingSubscription && currentMau >= PRICING_USERTARGETING_FREE_MTU;
       // check inAppSurvey subscription
       const hasInAppSurveySubscription =
-        team.billing?.features.inAppSurvey.status &&
-        team.billing?.features.inAppSurvey.status in ["active", "canceled"];
+        team.billing.features.inAppSurvey.status &&
+        ["active", "canceled"].includes(team.billing.features.inAppSurvey.status);
       const currentResponseCount = await getMonthlyTeamResponseCount(team.id);
       isInAppSurveyLimitReached =
         !hasInAppSurveySubscription && currentResponseCount >= PRICING_APPSURVEYS_FREE_RESPONSES;

--- a/apps/web/app/api/v1/client/[environmentId]/in-app/sync/[userId]/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/in-app/sync/[userId]/route.ts
@@ -76,14 +76,14 @@ export async function GET(
       }
       // check userTargeting subscription
       const hasUserTargetingSubscription =
-        team?.billing?.features.userTargeting.status &&
-        team?.billing?.features.userTargeting.status in ["active", "canceled"];
+        team.billing?.features.userTargeting.status &&
+        team.billing?.features.userTargeting.status in ["active", "canceled"];
       const currentMau = await getMonthlyActiveTeamPeopleCount(team.id);
       isMauLimitReached = !hasUserTargetingSubscription && currentMau >= PRICING_USERTARGETING_FREE_MTU;
       // check inAppSurvey subscription
       const hasInAppSurveySubscription =
-        team?.billing?.features.inAppSurvey.status &&
-        team?.billing?.features.inAppSurvey.status in ["active", "canceled"];
+        team.billing?.features.inAppSurvey.status &&
+        team.billing?.features.inAppSurvey.status in ["active", "canceled"];
       const currentResponseCount = await getMonthlyTeamResponseCount(team.id);
       isInAppSurveyLimitReached =
         !hasInAppSurveySubscription && currentResponseCount >= PRICING_APPSURVEYS_FREE_RESPONSES;

--- a/apps/web/app/api/v1/client/[environmentId]/in-app/sync/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/in-app/sync/route.ts
@@ -51,8 +51,8 @@ export async function GET(
       }
       // check inAppSurvey subscription
       const hasInAppSurveySubscription =
-        team?.billing?.features.inAppSurvey.status &&
-        team?.billing?.features.inAppSurvey.status in ["active", "canceled"];
+        team.billing.features.inAppSurvey.status &&
+        team.billing.features.inAppSurvey.status in ["active", "canceled"];
       const currentResponseCount = await getMonthlyTeamResponseCount(team.id);
       isInAppSurveyLimitReached =
         !hasInAppSurveySubscription && currentResponseCount >= PRICING_APPSURVEYS_FREE_RESPONSES;

--- a/apps/web/app/api/v1/client/[environmentId]/in-app/sync/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/in-app/sync/route.ts
@@ -3,9 +3,11 @@ import { transformErrorToDetails } from "@/app/lib/api/validator";
 import { NextRequest, NextResponse } from "next/server";
 
 import { getActionClasses } from "@formbricks/lib/actionClass/service";
+import { IS_FORMBRICKS_CLOUD, PRICING_APPSURVEYS_FREE_RESPONSES } from "@formbricks/lib/constants";
 import { getEnvironment, updateEnvironment } from "@formbricks/lib/environment/service";
 import { getProductByEnvironmentId } from "@formbricks/lib/product/service";
 import { getSurveys } from "@formbricks/lib/survey/service";
+import { getMonthlyTeamResponseCount, getTeamByEnvironmentId } from "@formbricks/lib/team/service";
 import { TJsStateSync, ZJsPublicSyncInput } from "@formbricks/types/js";
 
 export async function OPTIONS(): Promise<NextResponse> {
@@ -38,6 +40,25 @@ export async function GET(
       throw new Error("Environment does not exist");
     }
 
+    // check if MAU limit is reached
+    let isInAppSurveyLimitReached = false;
+    if (IS_FORMBRICKS_CLOUD) {
+      // check team subscriptons
+      const team = await getTeamByEnvironmentId(environmentId);
+
+      if (!team) {
+        throw new Error("Team does not exist");
+      }
+      // check inAppSurvey subscription
+      const hasInAppSurveySubscription =
+        (team?.billing?.features.inAppSurvey.status &&
+          team?.billing?.features.inAppSurvey.status in ["active", "canceled"]) ||
+        team?.billing?.features.inAppSurvey.unlimited;
+      const currentResponseCount = await getMonthlyTeamResponseCount(team.id);
+      isInAppSurveyLimitReached =
+        !hasInAppSurveySubscription && currentResponseCount >= PRICING_APPSURVEYS_FREE_RESPONSES;
+    }
+
     if (!environment?.widgetSetupCompleted) {
       await updateEnvironment(environment.id, { widgetSetupCompleted: true });
     }
@@ -52,7 +73,9 @@ export async function GET(
     }
 
     const state: TJsStateSync = {
-      surveys: surveys.filter((survey) => survey.status === "inProgress" && survey.type === "web"),
+      surveys: !isInAppSurveyLimitReached
+        ? surveys.filter((survey) => survey.status === "inProgress" && survey.type === "web")
+        : [],
       noCodeActionClasses: noCodeActionClasses.filter((actionClass) => actionClass.type === "noCode"),
       product,
       person: null,

--- a/apps/web/app/api/v1/client/[environmentId]/in-app/sync/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/in-app/sync/route.ts
@@ -51,9 +51,8 @@ export async function GET(
       }
       // check inAppSurvey subscription
       const hasInAppSurveySubscription =
-        (team?.billing?.features.inAppSurvey.status &&
-          team?.billing?.features.inAppSurvey.status in ["active", "canceled"]) ||
-        team?.billing?.features.inAppSurvey.unlimited;
+        team?.billing?.features.inAppSurvey.status &&
+        team?.billing?.features.inAppSurvey.status in ["active", "canceled"];
       const currentResponseCount = await getMonthlyTeamResponseCount(team.id);
       isInAppSurveyLimitReached =
         !hasInAppSurveySubscription && currentResponseCount >= PRICING_APPSURVEYS_FREE_RESPONSES;

--- a/apps/web/app/api/v1/client/[environmentId]/in-app/sync/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/in-app/sync/route.ts
@@ -52,7 +52,7 @@ export async function GET(
       // check inAppSurvey subscription
       const hasInAppSurveySubscription =
         team.billing.features.inAppSurvey.status &&
-        team.billing.features.inAppSurvey.status in ["active", "canceled"];
+        ["active", "canceled"].includes(team.billing.features.inAppSurvey.status);
       const currentResponseCount = await getMonthlyTeamResponseCount(team.id);
       isInAppSurveyLimitReached =
         !hasInAppSurveySubscription && currentResponseCount >= PRICING_APPSURVEYS_FREE_RESPONSES;


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

add response limitations from cloud plan to sync endpoint. Don't send surveys to the client if the response limit is reached for this month.

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update
