### PR TITLE
fix: object fit for logo on welcome card

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/edit/components/EditWelcomeCard.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/edit/components/EditWelcomeCard.tsx
@@ -109,6 +109,7 @@ export default function EditWelcomeCard({
                   updateSurvey({ fileUrl: url[0] });
                 }}
                 fileUrl={localSurvey?.welcomeCard?.fileUrl}
+                imageFit="contain"
               />
             </div>
             <div className="mt-3">

--- a/packages/ui/FileInput/index.tsx
+++ b/packages/ui/FileInput/index.tsx
@@ -23,6 +23,7 @@ interface FileInputProps {
   onFileUpload: (uploadedUrl: string[] | undefined) => void;
   fileUrl?: string | string[];
   multiple?: boolean;
+  imageFit?: "cover" | "contain";
 }
 
 interface SelectedFile {
@@ -38,6 +39,7 @@ const FileInput: React.FC<FileInputProps> = ({
   onFileUpload,
   fileUrl,
   multiple = false,
+  imageFit = "cover",
 }) => {
   const [selectedFiles, setSelectedFiles] = useState<SelectedFile[]>([]);
 
@@ -252,7 +254,7 @@ const FileInput: React.FC<FileInputProps> = ({
                   src={selectedFiles[0].url}
                   alt={selectedFiles[0].name}
                   fill
-                  style={{ objectFit: "cover" }}
+                  style={{ objectFit: imageFit }}
                   quality={100}
                   className={!selectedFiles[0].uploaded ? "opacity-50" : ""}
                 />


### PR DESCRIPTION
## What does this PR do?

Logos looked pretty bad on the welcome cards. 

Fixes # (issue)

Introduced object fit prop so it can be changed to `contain` if needed:

<img width="705" alt="image" src="https://github.com/formbricks/formbricks/assets/72809645/e1a7b144-958f-4ac1-bea5-1df5a8a6f894">

vs 

<img width="628" alt="image" src="https://github.com/formbricks/formbricks/assets/72809645/06205e37-b1dd-424e-8d4f-df521450abed">

## Type of change

<!-- Please mark the relevant points by using [x] -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [X] Enhancement (small improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change adds a new database migration
- [ ] This change requires a documentation update

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->