### PR TITLE
chore: remove old CLA form from docs & github templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,7 +32,6 @@ Fixes # (issue)
 - [ ] Removed all `console.logs`
 - [ ] Merged the latest changes from main onto my branch with `git pull origin main`
 - [ ] My changes don't cause any responsiveness issues
-- [ ] First PR at Formbricks? [Please sign the CLA!](https://formbricks.com/clmyhzfrymr4ko00hycsg1tvx) Without it we wont be able to merge it 🙏
 
 ### Appreciated
 

--- a/apps/formbricks-com/app/docs/contributing/introduction/page.mdx
+++ b/apps/formbricks-com/app/docs/contributing/introduction/page.mdx
@@ -42,6 +42,4 @@ If you are at all unsure, just raise it as an enhancement issue first and tell u
 
 To be able to keep working on Formbricks over the coming years, we need to collect a CLA from all relevant contributors.
 
-Please note that we can only get your contribution merged when we have a CLA signed by you.
-
-To access the CLA form, please click [here](https://formbricks.com/clmyhzfrymr4ko00hycsg1tvx)
+Once you open a PR, you will get a message from the CLA bot to fill out the form. Please note that we can only get your contribution merged when we have a CLA signed by you.


### PR DESCRIPTION
## What does this PR do?

 chore: remove old CLA form from docs & github templates