### PR TITLE
feat: add caching to survey sync

### DIFF
--- a/apps/web/app/api/v1/client/[environmentId]/in-app/sync/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/in-app/sync/route.ts
@@ -80,7 +80,11 @@ export async function GET(
       person: null,
     };
 
-    return responses.successResponse({ ...state }, true);
+    return responses.successResponse(
+      { ...state },
+      true,
+      "public, s-maxage=600, max-age=840, stale-while-revalidate=600, stale-if-error=600"
+    );
   } catch (error) {
     console.error(error);
     return responses.internalServerErrorResponse(`Unable to complete response: ${error.message}`, true);

--- a/apps/web/app/lib/api/response.ts
+++ b/apps/web/app/lib/api/response.ts
@@ -114,16 +114,22 @@ const unauthorizedResponse = (cors: boolean = false) =>
     }
   );
 
-const successResponse = (data: Object, cors: boolean = false) =>
-  NextResponse.json(
+const successResponse = (data: Object, cors: boolean = false, cache: string = "private, no-store") => {
+  const responseHeaders = {
+    ...(cors && { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Credentials": "true" }),
+    "Cache-Control": cache,
+  };
+
+  return NextResponse.json(
     {
       data,
     } as ApiSuccessResponse<typeof data>,
     {
       status: 200,
-      ...(cors && { headers: corsHeaders }),
+      headers: responseHeaders,
     }
   );
+};
 
 const internalServerErrorResponse = (message: string, cors: boolean = false) =>
   NextResponse.json(

--- a/apps/web/app/lib/api/response.ts
+++ b/apps/web/app/lib/api/response.ts
@@ -116,7 +116,7 @@ const unauthorizedResponse = (cors: boolean = false) =>
 
 const successResponse = (data: Object, cors: boolean = false, cache: string = "private, no-store") => {
   const responseHeaders = {
-    ...(cors && { "Access-Control-Allow-Origin": "*", "Access-Control-Allow-Credentials": "true" }),
+    ...(cors && corsHeaders),
     "Cache-Control": cache,
   };
 


### PR DESCRIPTION
## What does this PR do?

This PR adds public caching of 10min to the app.formbricks.com/api/v1/client/<environmentId>/in-app/sync endpoint. Since Formbricks caches the survey endpoint for 15min in the frontend I think it makes sense to also add it to the backend to avoid unnecessary server load.
The cache times are up for discussion, how do you see the balance between rapid updates and server load?

Fixes # (issue)

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

- make a request to app.formbricks.com/api/v1/client/<environmentId>/in-app/sync and check the Cache-Control header
- subsequent request should include Age: 123 headers when using a proxy like Cloudflare or Cloudfront

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
