### PR TITLE
fix: deleted responses still show in API

### DIFF
--- a/packages/lib/response/service.ts
+++ b/packages/lib/response/service.ts
@@ -27,6 +27,7 @@ import { createPerson, getPerson, getPersonByUserId, transformPrismaPerson } fro
 import { calculateTtcTotal } from "../response/util";
 import { responseNoteCache } from "../responseNote/cache";
 import { getResponseNotes } from "../responseNote/service";
+import { getSurvey } from "../survey/service";
 import { captureTelemetry } from "../telemetry";
 import { formatDateFields } from "../utils/datetime";
 import { validateInputs } from "../utils/validate";
@@ -592,7 +593,10 @@ export const deleteResponse = async (responseId: string): Promise<TResponse> => 
 
     deleteDisplayByResponseId(responseId, response.surveyId);
 
+    const survey = await getSurvey(response.surveyId);
+
     responseCache.revalidate({
+      environmentId: survey?.environmentId,
       id: response.id,
       personId: response.person?.id,
       surveyId: response.surveyId,


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

Fixes https://github.com/formbricks/formbricks/issues/2021

Fixes a cache validation issue in the response service where deleted surveys still show in the API as long as the cache is valid.

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->