### PR TITLE
feat: add go to dashboard button in error modal

### DIFF
--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -1,7 +1,0 @@
-"use server";
-
-import { redirect } from "next/navigation";
-
-export const redirectHomeAction = () => {
-  redirect("/");
-};

--- a/apps/web/app/actions.ts
+++ b/apps/web/app/actions.ts
@@ -1,0 +1,7 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+export const redirectHomeAction = () => {
+  redirect("/");
+};

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -4,8 +4,6 @@
 import { Button } from "@formbricks/ui/Button";
 import { ErrorComponent } from "@formbricks/ui/ErrorComponent";
 
-import { redirectHomeAction } from "./actions";
-
 export default function Error({ error, reset }: { error: Error; reset: () => void }) {
   if (process.env.NODE_ENV === "development") {
     console.error(error.message);
@@ -18,7 +16,7 @@ export default function Error({ error, reset }: { error: Error; reset: () => voi
         <Button variant="secondary" onClick={() => reset()} className="mr-2">
           Try again
         </Button>
-        <Button variant="darkCTA" onClick={() => redirectHomeAction()} className="">
+        <Button variant="darkCTA" onClick={() => (window.location.href = "/")}>
           Go to Dashboard
         </Button>
       </div>

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -4,6 +4,8 @@
 import { Button } from "@formbricks/ui/Button";
 import { ErrorComponent } from "@formbricks/ui/ErrorComponent";
 
+import { redirectHomeAction } from "./actions";
+
 export default function Error({ error, reset }: { error: Error; reset: () => void }) {
   if (process.env.NODE_ENV === "development") {
     console.error(error.message);
@@ -12,15 +14,14 @@ export default function Error({ error, reset }: { error: Error; reset: () => voi
   return (
     <div className="flex h-full w-full flex-col items-center justify-center">
       <ErrorComponent />
-      <Button
-        variant="secondary"
-        onClick={
-          // Attempt to recover by trying to re-render the segment
-          () => reset()
-        }
-        className="mt-2">
-        Try again
-      </Button>
+      <div className="mt-2">
+        <Button variant="secondary" onClick={() => reset()} className="mr-2">
+          Try again
+        </Button>
+        <Button variant="darkCTA" onClick={() => redirectHomeAction()} className="">
+          Go to Dashboard
+        </Button>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -19,14 +19,14 @@ export default async function Home() {
     return <ClientLogout />;
   }
 
-  if (!ONBOARDING_DISABLED && !session.user.onboardingCompleted) {
-    return redirect(`/onboarding`);
-  }
-
   const teams = await getTeamsByUserId(session.user.id);
   if (!teams || teams.length === 0) {
     console.error("Failed to get teams, redirecting to create-first-team");
     return redirect("/create-first-team");
+  }
+
+  if (!ONBOARDING_DISABLED && !session.user.onboardingCompleted) {
+    return redirect(`/onboarding`);
   }
 
   let environment;


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?
The current Error modal does not have a CTA except for the Try Again which sometimes does not fix the issue making the app unusable. This PR adds a "Go to Dashboard" button that resets the state and lets the user use the app!

Fixes #2045 

## Checklist

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
