### PR TITLE
fix: ecs Github Action

### DIFF
--- a/.github/workflows/ecs-deployment.yml
+++ b/.github/workflows/ecs-deployment.yml
@@ -88,7 +88,12 @@ jobs:
         env:
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}
-        run: cosign sign --yes ${{ steps.meta.outputs.tags }}@${{ steps.build-and-push.outputs.digest }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}
     
     outputs:
       image_tag_sha: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This PR reverts the changes made to Github Action to sign docker images using cosign. As new version introduces instability.

Test Plan:
- https://github.com/formbricks/formbricks/actions/runs/7887747430