### PR TITLE
feat: downgrade team functionality when payment subscription has expired

### DIFF
--- a/packages/ee/billing/handlers/subscriptionDeleted.ts
+++ b/packages/ee/billing/handlers/subscriptionDeleted.ts
@@ -3,6 +3,7 @@ import Stripe from "stripe";
 import { getTeam, updateTeam } from "@formbricks/lib/team/service";
 
 import { ProductFeatureKeys, StripeProductNames } from "../lib/constants";
+import { unsubscribeCoreAndAppSurveyFeatures, unsubscribeLinkSurveyProFeatures } from "../lib/downgradePlan";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
   // https://github.com/stripe/stripe-node#configuration
@@ -31,12 +32,14 @@ export const handleSubscriptionDeleted = async (event: Stripe.Event) => {
           "inactive";
         updatedFeatures[ProductFeatureKeys.inAppSurvey as keyof typeof team.billing.features].unlimited =
           false;
+        await unsubscribeCoreAndAppSurveyFeatures(teamId);
         break;
       case StripeProductNames.linkSurvey:
         updatedFeatures[ProductFeatureKeys.linkSurvey as keyof typeof team.billing.features].status =
           "inactive";
         updatedFeatures[ProductFeatureKeys.linkSurvey as keyof typeof team.billing.features].unlimited =
           false;
+        await unsubscribeLinkSurveyProFeatures(teamId);
         break;
       case StripeProductNames.userTargeting:
         updatedFeatures[ProductFeatureKeys.userTargeting as keyof typeof team.billing.features].status =

--- a/packages/ee/billing/lib/downgradePlan.ts
+++ b/packages/ee/billing/lib/downgradePlan.ts
@@ -1,0 +1,23 @@
+import { getProducts, updateProduct } from "@formbricks/lib/product/service";
+
+export const unsubscribeLinkSurveyProFeatures = async (teamId: string) => {
+  const productsOfTeam = await getProducts(teamId);
+  for (const product of productsOfTeam) {
+    if (!product.linkSurveyBranding) {
+      await updateProduct(product.id, {
+        linkSurveyBranding: true,
+      });
+    }
+  }
+};
+
+export const unsubscribeCoreAndAppSurveyFeatures = async (teamId: string) => {
+  const productsOfTeam = await getProducts(teamId);
+  for (const product of productsOfTeam) {
+    if (!product.inAppSurveyBranding) {
+      await updateProduct(product.id, {
+        inAppSurveyBranding: true,
+      });
+    }
+  }
+};


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?
Downgrades the team's ability to change Link Survey Branding & In App Branding when respective paid plans are downgraded in stripe ie end of month!

## How should this be tested?
- Configure Stripe CLI to pass webhooks locally
- Upgrade Team plan
- Cancel it
- Now edit product look and feel to disable branding
- Run subscription sim clock on stripe to a month later so that the sub expires till then
- Now visit the look and feel, it should be on & disabled (since plan expired)

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
