### PR TITLE
chore: revert ECS Github Action

### DIFF
--- a/.github/workflows/ecs-deployment.yml
+++ b/.github/workflows/ecs-deployment.yml
@@ -126,3 +126,4 @@ jobs:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: prod-webapp-ecs-service
           cluster: prod-core-infra-ecs-cluster
+          wait-for-service-stability: true


### PR DESCRIPTION
The PR reverts the changes that were made to the ECS Github Action deploy test for debugging.