### PR TITLE
feat: custom S3 endpoint to use third party storage services

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,20 @@ ENCRYPTION_KEY=
 
 DATABASE_URL='postgresql://postgres:postgres@localhost:5432/formbricks?schema=public'
 
+##############
+# S3 STORAGE #
+##############
+
+# S3 Storage is required for the file uplaod in serverless environments like Vercel
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+S3_REGION=
+# Optional
+S3_BUCKET_NAME=
+# Configure a third party S3 compatible storage service endpoint like StorJ leave empty if you use Amazon S3
+# e.g., gateway.storjshare.io
+S3_ENDPOINT=
+
 ###############
 #  NEXT AUTH  #
 ###############

--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ S3_REGION=
 # Optional
 S3_BUCKET_NAME=
 # Configure a third party S3 compatible storage service endpoint like StorJ leave empty if you use Amazon S3
-# e.g., gateway.storjshare.io
+# e.g., https://gateway.storjshare.io
 S3_ENDPOINT=
 
 ###############

--- a/packages/lib/env.mjs
+++ b/packages/lib/env.mjs
@@ -62,6 +62,7 @@ export const env = createEnv({
     S3_SECRET_KEY: z.string().optional(),
     S3_REGION: z.string().optional(),
     S3_BUCKET_NAME: z.string().optional(),
+    S3_ENDPOINT: z.string().optional(),
     NOTION_OAUTH_CLIENT_ID: z.string().optional(),
     NOTION_OAUTH_CLIENT_SECRET: z.string().optional(),
     AZUREAD_CLIENT_SECRET: z.string().optional(),

--- a/packages/lib/env.mjs
+++ b/packages/lib/env.mjs
@@ -138,6 +138,7 @@ export const env = createEnv({
     S3_ACCESS_KEY: process.env.S3_ACCESS_KEY,
     S3_SECRET_KEY: process.env.S3_SECRET_KEY,
     S3_REGION: process.env.S3_REGION,
+    S3_ENDPOINT: process.env.S3_ENDPOINT,
     S3_BUCKET_NAME: process.env.S3_BUCKET_NAME,
     NOTION_OAUTH_CLIENT_ID: process.env.NOTION_OAUTH_CLIENT_ID,
     NOTION_OAUTH_CLIENT_SECRET: process.env.NOTION_OAUTH_CLIENT_SECRET,

--- a/packages/lib/storage/service.ts
+++ b/packages/lib/storage/service.ts
@@ -29,15 +29,19 @@ const AWS_BUCKET_NAME = env.S3_BUCKET_NAME!;
 const AWS_REGION = env.S3_REGION!;
 const S3_ACCESS_KEY = env.S3_ACCESS_KEY!;
 const S3_SECRET_KEY = env.S3_SECRET_KEY!;
+const S3_ENDPOINT = env.S3_ENDPOINT;
 
 // S3Client Singleton
 
 export const s3Client = new S3Client({
   credentials: {
-    accessKeyId: S3_ACCESS_KEY,
+    accessKeyId: S3_ACCESS_KEY!,
     secretAccessKey: S3_SECRET_KEY!,
   },
   region: AWS_REGION!,
+  ...(S3_ENDPOINT && {
+    endpoint: S3_ENDPOINT,
+  }),
 });
 
 const ensureDirectoryExists = async (dirPath: string) => {
@@ -63,15 +67,15 @@ type TGetFileResponse = {
 type TGetSignedUrlResponse =
   | { signedUrl: string; fileUrl: string; presignedFields: Object }
   | {
-      signedUrl: string;
-      updatedFileName: string;
-      fileUrl: string;
-      signingData: {
-        signature: string;
-        timestamp: number;
-        uuid: string;
-      };
+    signedUrl: string;
+    updatedFileName: string;
+    fileUrl: string;
+    signingData: {
+      signature: string;
+      timestamp: number;
+      uuid: string;
     };
+  };
 
 const getS3SignedUrl = async (fileKey: string): Promise<string> => {
   const [_, accessType] = fileKey.split("/");

--- a/turbo.json
+++ b/turbo.json
@@ -113,6 +113,7 @@
         "S3_SECRET_KEY",
         "S3_REGION",
         "S3_BUCKET_NAME",
+        "S3_ENDPOINT",
         "SENTRY_DSN",
         "SHORT_URL_BASE",
         "SIGNUP_DISABLED",


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

I´ve added the available S3 environment vars to .env.example.
Also added the ability to define a custom S3 endpoint to use Third Party S3 compatible storage services like StorJ.

## How should this be tested?

Register for [StorJ](https://docs.storj.io/dcs/api/s3/s3-compatible-gateway) or another S3 storage provider
Define all environment vars:

- S3_ENDPOINT e.g. https://gateway.storjshare.io
- S3_REGION e.g. eu1
- S3_ACCESS_KEY
- S3_SECRET_KEY
- S3_BUCKET_NAME

## Checklist

- [x] Upload profile picture
- [x] Upload picture question image
- [x] Upload files in file upload question

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] Updated the Formbricks Docs if changes were necessary
