### PR TITLE
Fix: Remove region from S3 configuration check when custom endpoint is used

### DIFF
--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -95,7 +95,7 @@ export const MAX_SIZES = {
   pro: 1024 * 1024 * 1024, // 1GB
 } as const;
 export const IS_S3_CONFIGURED: boolean =
-  env.S3_ACCESS_KEY && env.S3_SECRET_KEY && env.S3_REGION && env.S3_BUCKET_NAME ? true : false;
+  env.S3_ACCESS_KEY && env.S3_SECRET_KEY && (env.S3_ENDPOINT_URL ? env.S3_REGION : true) && env.S3_BUCKET_NAME ? true : false;
 
 // Pricing
 export const PRICING_USERTARGETING_FREE_MTU = 2500;


### PR DESCRIPTION
## Fixes

#2181

## What does this PR do?

Add S3_REGION var to optional when S3_CUSTOM_ENDPOINT_URL is set

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Define S3_REGION and check if it is used
- Not define S§_REGION and check if S3 is still used as Storage provider

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
