### PR TITLE
docs: startAt for Link Surveys

### DIFF
--- a/apps/formbricks-com/app/docs/link-surveys/start-at-question/page.mdx
+++ b/apps/formbricks-com/app/docs/link-surveys/start-at-question/page.mdx
@@ -1,0 +1,43 @@
+export const metadata = {
+  title: "Start At Specific Question",
+  description: "Start a survey at a specific question using the URL to skip the initial questions.",
+};
+
+#### Link Surveys
+
+# Start At Specific Question
+
+You can start a survey at a specific question from the survey using the URL to skip the initial questions. This is useful when you want to link to a specific question from an external source or want to use the same survey in different parts of the user journey.
+
+## How to Use it?
+
+1. In the Survey Editor, open the Questions Tab and ensure the survey is set as a **Link Survey**.
+
+2. Find the question you want to start at, click on **Show Advanced Settings**, and copy the **Question ID**.
+
+<Note>
+  Each question has a unique Question ID, which is used to identify it in the survey. You can use different
+  Question IDs for multiple **startAt** points in the URL.
+</Note>
+
+3. Append `?startAt=question_id` to your survey's URL, replacing `question_id` with the copied Question ID.
+
+4. Share this modified URL with your users to start the survey at the specified question.
+
+### Sample Link Survey URL with `startAt`
+
+<Col>
+<CodeGroup title="Example Link Survey URL with startAt configured">
+
+```sh
+https://formbricks.com/clny997dj087ho30fdzyf4nkl?startAt=bqd29m94l9k0hnc3azbrexl8
+```
+
+</CodeGroup>
+</Col>
+
+## Use Cases
+
+- **Link to a specific question from an external source:** Use this feature to direct users to a specific question in your survey from emails, chatbots, or web pages, providing a seamless experience.
+- **Use the same survey in different parts of the user journey:** Employ the same survey at various stages of the user journey, starting at different questions to gather comprehensive insights.
+- **Create a personalized survey experience:** Tailor the survey experience by starting at a particular question based on the user's past interactions or preferences, enhancing engagement.

--- a/apps/formbricks-com/components/docs/Navigation.tsx
+++ b/apps/formbricks-com/components/docs/Navigation.tsx
@@ -208,6 +208,7 @@ export const navigation: Array<NavGroup> = [
       { title: "Single Use Links", href: "/docs/link-surveys/single-use-links" },
       { title: "Source Tracking", href: "/docs/link-surveys/source-tracking" },
       { title: "Hidden Fields", href: "/docs/link-surveys/hidden-fields" },
+      { title: "Start At Question", href: "/docs/link-surveys/start-at-question" },
     ],
   },
   {


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?
Adds Documentation for the `startAt` parameter in Link Surveys!
Docs for the feature built in: #2175 


![image](https://github.com/formbricks/formbricks/assets/55556994/82dc00bc-ba50-4085-86bc-f86aa319e037)
![image](https://github.com/formbricks/formbricks/assets/55556994/51fba9d7-4aca-49a1-9dd9-11f461eca62c)


## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
