### PR TITLE
fix: product logo is received null from prisma if not set

### DIFF
--- a/packages/types/product.ts
+++ b/packages/types/product.ts
@@ -54,7 +54,7 @@ export const ZProduct = z.object({
   brandColor: ZColor.nullish(),
   highlightBorderColor: ZColor.nullish(),
   languages: z.array(ZLanguage),
-  logo: ZLogo.optional(),
+  logo: ZLogo.nullish(),
 });
 
 export type TProduct = z.infer<typeof ZProduct>;


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?
Go to the Look & Feel page on Production, try to update the product. In your browser console, you should see an error. This is because in the service, we get the product from DB & validate it again, and the DB returns the new logo as `null` whereas currently it accepts it to be an empty object. This PR fixes that.



## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
