### PR TITLE
fix: OpenTextSummary no longer has "Show more" button

### DIFF
--- a/packages/lib/response/util.ts
+++ b/packages/lib/response/util.ts
@@ -685,7 +685,7 @@ export const getQuestionWiseSummary = (
   survey: TSurvey,
   responses: TResponse[]
 ): TSurveySummary["summary"] => {
-  const VALUES_LIMIT = 10;
+  const VALUES_LIMIT = 50;
   let summary: TSurveySummary["summary"] = [];
 
   survey.questions.forEach((question) => {


### PR DESCRIPTION
## What does this PR do?
Increases the limit of open text responses: 10 -> 50

Fixes #2336 

## How should this be tested?
- Check any open text question summary with more than 10 responses

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary