### PR TITLE
chore: use CUSTOM_CACHE_DISABLED env instead of vercel specific env

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -26,7 +26,8 @@ const nextConfig = {
       "app/api/packages": ["../../packages/js-core/dist/*", "../../packages/surveys/dist/*"],
     },
   },
-  cacheHandler: process.env.VERCEL !== "1" ? require.resolve("./cache-handler.mjs") : undefined,
+  cacheHandler:
+    process.env.CUSTOM_CACHE_DISABLED !== "1" ? require.resolve("./cache-handler.mjs") : undefined,
   transpilePackages: ["@formbricks/database", "@formbricks/ee", "@formbricks/ui", "@formbricks/lib"],
   images: {
     remotePatterns: [

--- a/turbo.json
+++ b/turbo.json
@@ -66,6 +66,7 @@
         "DEFAULT_TEAM_ROLE",
         "ONBOARDING_DISABLED",
         "CRON_SECRET",
+        "CUSTOM_CACHE_DISABLED",
         "CUSTOMER_IO_API_KEY",
         "CUSTOMER_IO_SITE_ID",
         "DEBUG",


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

use CUSTOM_CACHE_DISABLED env instead of vercel specific env to control the cacheHandler behaviour

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->