### PR TITLE
fix: rate-limiting when using a load balancer

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -35,11 +35,10 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  let ip = request.ip ?? request.headers.get("x-real-ip");
-  const forwardedFor = request.headers.get("x-forwarded-for");
-  if (!ip && forwardedFor) {
-    ip = forwardedFor.split(",").at(0) ?? null;
-  }
+  let ip =
+    request.headers.get("cf-connecting-ip") ||
+    request.headers.get("x-forwarded-for")?.split(",")[0].trim() ||
+    request.ip;
 
   if (ip) {
     try {


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes rate-limiting when Formbricks is used behind a load balancer. Previously Formbricks received and rate-limited the IP address of the load balancer instead of the original source.
