### PR TITLE
fix: remove unused description in createAttribute, updateSurvey to use params surveyId

### DIFF
--- a/apps/web/app/api/v1/management/surveys/[surveyId]/route.ts
+++ b/apps/web/app/api/v1/management/surveys/[surveyId]/route.ts
@@ -67,7 +67,7 @@ export async function PUT(request: Request, { params }: { params: { surveyId: st
         transformErrorToDetails(inputValidation.error)
       );
     }
-    return responses.successResponse(await updateSurvey(inputValidation.data));
+    return responses.successResponse(await updateSurvey({ ...inputValidation.data, id: params.surveyId }));
   } catch (error) {
     return handleErrorResponse(error);
   }

--- a/packages/types/attributeClasses.ts
+++ b/packages/types/attributeClasses.ts
@@ -17,7 +17,7 @@ export const ZAttributeClass = z.object({
 
 export const ZAttributeClassInput = z.object({
   name: z.string(),
-  description: z.string(),
+  description: z.string().optional(),
   type: z.enum(["code"]),
   environmentId: z.string(),
 });


### PR DESCRIPTION

## What does this PR do?
Couple of bugs I found while testing the API:
- createAttribute API input required the description but not use that when creating the attribute so removed that
- updateSurvey API used to check validation for params' surveyId but used to update the one in body, thus making it vulnerable to update a random survey, fixed it to use the params' survey against which we do auth checks


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
