### PR TITLE
chore: remove service-revalidation-interval to simplify caching

### DIFF
--- a/apps/formbricks-com/app/docs/contributing/creating-a-service/page.mdx
+++ b/apps/formbricks-com/app/docs/contributing/creating-a-service/page.mdx
@@ -211,7 +211,6 @@ We will rewrite the function `getApiKey` we created in the `service.ts` file to 
 ```ts
 import { unstable_cache } from "next/cache";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { apiKeyCache } from "./cache";
 
 export const getApiKey = async (apiKeyId: string): Promise<TApiKey> =>
@@ -242,7 +241,6 @@ export const getApiKey = async (apiKeyId: string): Promise<TApiKey> =>
     [`getApiKey-${apiKeyId}`],
     {
       tags: [apiKeyCache.tag.byId(apiKeyId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 ```
@@ -265,9 +263,7 @@ From the screenshot above we see that `unstable_cache` receives 3 arguments:
 
 1. `fetchData`: In our case this is the exact function of your service without caching (step 3)
 2. `keyParts`: As a rule of thumb, the key must consist of the name of the function and the arguments passed into the function, all separated by a dash. In our case it is called `getApiKey-${apiKeyId}` because the function name is `getApiKey` and we receive only one argument called `apiKeyId`
-3. `options`: which consists of **tags** and **revalidate**
-   1. `tags`: This is where the tags you created in step 4a comes in, tags are created solely based on the arguments passed to the function. (please reference existing services in `packages/lib` to see more variations of this when dealing with more than one argument)
-   2. `revalidate`: We have a global constant for this which you can use called `SERVICES_REVALIDATION_INTERVAL`
+3. `options`: which consists of **tags** that controls the revalidation of the cache. This is where the tags you created in step 4a comes in, tags are created solely based on the arguments passed to the function. (please reference existing services in `packages/lib` to see more variations of this when dealing with more than one argument)
 
 <Note>
 In create, update and delete requests, you don’t need caching however these are the places where the revalidate method is called. For example when the apiKey is deleted we want to call the revalidate method and pass in the id and environmentId, so we invalidate every cached function with `id` and `environmentId` tags.

--- a/apps/web/app/(app)/environments/[environmentId]/(peopleAndSegments)/segments/page.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/(peopleAndSegments)/segments/page.tsx
@@ -6,13 +6,11 @@ import { ACTIONS_TO_EXCLUDE } from "@formbricks/ee/advancedTargeting/lib/constan
 import { getAdvancedTargetingPermission } from "@formbricks/ee/lib/service";
 import { getActionClasses } from "@formbricks/lib/actionClass/service";
 import { getAttributeClasses } from "@formbricks/lib/attributeClass/service";
-import { IS_FORMBRICKS_CLOUD, REVALIDATION_INTERVAL } from "@formbricks/lib/constants";
+import { IS_FORMBRICKS_CLOUD } from "@formbricks/lib/constants";
 import { getEnvironment } from "@formbricks/lib/environment/service";
 import { getSegments } from "@formbricks/lib/segment/service";
 import { getTeamByEnvironmentId } from "@formbricks/lib/team/service";
 import EmptySpaceFiller from "@formbricks/ui/EmptySpaceFiller";
-
-export const revalidate = REVALIDATION_INTERVAL;
 
 export default async function SegmentsPage({ params }) {
   const [environment, segments, attributeClasses, actionClassesFromServer, team] = await Promise.all([

--- a/packages/lib/action/service.ts
+++ b/packages/lib/action/service.ts
@@ -13,7 +13,7 @@ import { DatabaseError } from "@formbricks/types/errors";
 
 import { actionClassCache } from "../actionClass/cache";
 import { createActionClass, getActionClassByEnvironmentIdAndName } from "../actionClass/service";
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL } from "../constants";
+import { ITEMS_PER_PAGE } from "../constants";
 import { activePersonCache } from "../person/cache";
 import { getIsPersonMonthlyActive } from "../person/service";
 import { formatDateFields } from "../utils/datetime";
@@ -61,7 +61,6 @@ export const getActionsByPersonId = async (personId: string, page?: number): Pro
     [`getActionsByPersonId-${personId}-${page}`],
     {
       tags: [actionCache.tag.byPersonId(personId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -114,7 +113,6 @@ export const getActionsByEnvironmentId = async (environmentId: string, page?: nu
     [`getActionsByEnvironmentId-${environmentId}-${page}`],
     {
       tags: [actionCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -211,7 +209,6 @@ export const getActionCountInLastHour = async (actionClassId: string): Promise<n
     [`getActionCountInLastHour-${actionClassId}`],
     {
       tags: [actionClassCache.tag.byId(actionClassId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -237,7 +234,6 @@ export const getActionCountInLast24Hours = async (actionClassId: string): Promis
     [`getActionCountInLast24Hours-${actionClassId}`],
     {
       tags: [actionClassCache.tag.byId(actionClassId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -263,7 +259,6 @@ export const getActionCountInLast7Days = async (actionClassId: string): Promise<
     [`getActionCountInLast7Days-${actionClassId}`],
     {
       tags: [actionClassCache.tag.byId(actionClassId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -293,7 +288,6 @@ export const getActionCountInLastQuarter = async (actionClassId: string, personI
     [`getActionCountInLastQuarter-${actionClassId}-${personId}`],
     {
       tags: [actionClassCache.tag.byId(actionClassId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -323,7 +317,6 @@ export const getActionCountInLastMonth = async (actionClassId: string, personId:
     [`getActionCountInLastMonth-${actionClassId}-${personId}`],
     {
       tags: [actionClassCache.tag.byId(actionClassId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -352,7 +345,6 @@ export const getActionCountInLastWeek = async (actionClassId: string, personId: 
     [`getActionCountInLastWeek-${actionClassId}-${personId}`],
     {
       tags: [actionClassCache.tag.byId(actionClassId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -382,7 +374,6 @@ export const getTotalOccurrencesForAction = async (
     [`getTotalOccurrencesForAction-${actionClassId}-${personId}`],
     {
       tags: [actionClassCache.tag.byId(actionClassId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -419,7 +410,6 @@ export const getLastOccurrenceDaysAgo = async (
     [`getLastOccurrenceDaysAgo-${actionClassId}-${personId}`],
     {
       tags: [actionClassCache.tag.byId(actionClassId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -456,6 +446,5 @@ export const getFirstOccurrenceDaysAgo = async (
     [`getFirstOccurrenceDaysAgo-${actionClassId}-${personId}`],
     {
       tags: [actionClassCache.tag.byId(actionClassId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();

--- a/packages/lib/actionClass/auth.ts
+++ b/packages/lib/actionClass/auth.ts
@@ -4,7 +4,6 @@ import { unstable_cache } from "next/cache";
 
 import { ZId } from "@formbricks/types/environment";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { hasUserEnvironmentAccess } from "../environment/auth";
 import { getMembershipByUserIdTeamId } from "../membership/service";
 import { getAccessFlags } from "../membership/utils";
@@ -36,7 +35,6 @@ export const canUserUpdateActionClass = async (userId: string, actionClassId: st
 
     [`canUserUpdateActionClass-${userId}-${actionClassId}`],
     {
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
       tags: [actionClassCache.tag.byId(actionClassId)],
     }
   )();

--- a/packages/lib/actionClass/service.ts
+++ b/packages/lib/actionClass/service.ts
@@ -16,7 +16,7 @@ import { ZOptionalNumber, ZString } from "@formbricks/types/common";
 import { ZId } from "@formbricks/types/environment";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL } from "../constants";
+import { ITEMS_PER_PAGE } from "../constants";
 import { structuredClone } from "../pollyfills/structuredClone";
 import { formatDateFields } from "../utils/datetime";
 import { validateInputs } from "../utils/validate";
@@ -58,7 +58,6 @@ export const getActionClasses = async (environmentId: string, page?: number): Pr
     [`getActionClasses-${environmentId}-${page}`],
     {
       tags: [actionClassCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return actionClasses.map((actionClass) => formatDateFields(actionClass, ZActionClass));
@@ -89,7 +88,6 @@ export const getActionClassByEnvironmentIdAndName = async (
     [`getActionClassByEnvironmentIdAndName-${environmentId}-${name}`],
     {
       tags: [actionClassCache.tag.byNameAndEnvironmentId(name, environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return actionClass ? formatDateFields(actionClass, ZActionClass) : null;
@@ -116,7 +114,6 @@ export const getActionClass = async (actionClassId: string): Promise<TActionClas
     [`getActionClass-${actionClassId}`],
     {
       tags: [actionClassCache.tag.byId(actionClassId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return actionClass ? formatDateFields(actionClass, ZActionClass) : null;

--- a/packages/lib/apiKey/auth.ts
+++ b/packages/lib/apiKey/auth.ts
@@ -4,7 +4,6 @@ import { unstable_cache } from "next/cache";
 
 import { ZId } from "@formbricks/types/environment";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { hasUserEnvironmentAccess } from "../environment/auth";
 import { validateInputs } from "../utils/validate";
 import { apiKeyCache } from "./cache";
@@ -29,5 +28,5 @@ export const canUserAccessApiKey = async (userId: string, apiKeyId: string): Pro
     },
 
     [`canUserAccessApiKey-${userId}-${apiKeyId}`],
-    { revalidate: SERVICES_REVALIDATION_INTERVAL, tags: [apiKeyCache.tag.byId(apiKeyId)] }
+    { tags: [apiKeyCache.tag.byId(apiKeyId)] }
   )();

--- a/packages/lib/apiKey/service.ts
+++ b/packages/lib/apiKey/service.ts
@@ -10,7 +10,7 @@ import { ZOptionalNumber, ZString } from "@formbricks/types/common";
 import { ZId } from "@formbricks/types/environment";
 import { DatabaseError, InvalidInputError } from "@formbricks/types/errors";
 
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL } from "../constants";
+import { ITEMS_PER_PAGE } from "../constants";
 import { getHash } from "../crypto";
 import { formatDateFields } from "../utils/datetime";
 import { validateInputs } from "../utils/validate";
@@ -44,7 +44,6 @@ export const getApiKey = async (apiKeyId: string): Promise<TApiKey | null> => {
     [`getApiKey-${apiKeyId}`],
     {
       tags: [apiKeyCache.tag.byId(apiKeyId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return apiKey ? formatDateFields(apiKey, ZApiKey) : null;
@@ -75,7 +74,6 @@ export const getApiKeys = async (environmentId: string, page?: number): Promise<
     [`getApiKeys-${environmentId}-${page}`],
     {
       tags: [apiKeyCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return apiKeys.map((apiKey) => formatDateFields(apiKey, ZApiKey));
@@ -145,7 +143,6 @@ export const getApiKeyFromKey = async (apiKey: string): Promise<TApiKey | null> 
     [`getApiKeyFromKey-${apiKey}`],
     {
       tags: [apiKeyCache.tag.byHashedKey(hashedKey)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return apiKeyData ? formatDateFields(apiKeyData, ZApiKey) : null;

--- a/packages/lib/attribute/service.ts
+++ b/packages/lib/attribute/service.ts
@@ -12,7 +12,6 @@ import { DatabaseError } from "@formbricks/types/errors";
 import { attributeCache } from "../attribute/cache";
 import { attributeClassCache } from "../attributeClass/cache";
 import { getAttributeClassByName, getAttributeClasses } from "../attributeClass/service";
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { getPerson, getPersonByUserId } from "../person/service";
 import { validateInputs } from "../utils/validate";
 
@@ -62,7 +61,6 @@ export const getAttributes = async (personId: string): Promise<TAttributes> => {
     [`getAttributes-${personId}`],
     {
       tags: [attributeCache.tag.byPersonId(personId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 };
@@ -98,7 +96,6 @@ export const getAttributesByUserId = async (environmentId: string, userId: strin
     [`getAttributesByUserId-${environmentId}-${userId}`],
     {
       tags: [attributeCache.tag.byEnvironmentIdAndUserId(environmentId, userId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 };
@@ -141,7 +138,6 @@ export const getAttribute = async (name: string, personId: string): Promise<stri
     [`getAttribute-${name}-${personId}`],
     {
       tags: [attributeCache.tag.byNameAndPersonId(name, personId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 };

--- a/packages/lib/attributeClass/auth.ts
+++ b/packages/lib/attributeClass/auth.ts
@@ -4,7 +4,6 @@ import { unstable_cache } from "next/cache";
 
 import { ZId } from "@formbricks/types/environment";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { hasUserEnvironmentAccess } from "../environment/auth";
 import { validateInputs } from "../utils/validate";
 import { getAttributeClass } from "./service";
@@ -32,5 +31,5 @@ export const canUserAccessAttributeClass = async (
     },
 
     [`canUserAccessAttributeClass-${userId}-${attributeClassId}`],
-    { revalidate: SERVICES_REVALIDATION_INTERVAL, tags: [`attributeClasses-${attributeClassId}`] }
+    { tags: [`attributeClasses-${attributeClassId}`] }
   )();

--- a/packages/lib/attributeClass/service.ts
+++ b/packages/lib/attributeClass/service.ts
@@ -18,7 +18,7 @@ import { ZOptionalNumber, ZString } from "@formbricks/types/common";
 import { ZId } from "@formbricks/types/environment";
 import { DatabaseError } from "@formbricks/types/errors";
 
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL } from "../constants";
+import { ITEMS_PER_PAGE } from "../constants";
 import { formatDateFields } from "../utils/datetime";
 import { validateInputs } from "../utils/validate";
 import { attributeClassCache } from "./cache";
@@ -46,7 +46,6 @@ export const getAttributeClass = async (attributeClassId: string): Promise<TAttr
     [`getAttributeClass-${attributeClassId}`],
     {
       tags: [attributeClassCache.tag.byId(attributeClassId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -90,7 +89,6 @@ export const getAttributeClasses = async (
     [`getAttributeClasses-${environmentId}-${page}`],
     {
       tags: [attributeClassCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return attributeClasses.map((attributeClass) => formatDateFields(attributeClass, ZAttributeClass));
@@ -152,7 +150,6 @@ export const getAttributeClassByName = async (environmentId: string, name: strin
     [`getAttributeClassByName-${environmentId}-${name}`],
     {
       tags: [attributeClassCache.tag.byEnvironmentIdAndName(environmentId, name)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return attributeClass ? formatDateFields(attributeClass, ZAttributeClass) : null;

--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -3,8 +3,6 @@ import "server-only";
 import { env } from "./env";
 
 export const IS_FORMBRICKS_CLOUD = env.IS_FORMBRICKS_CLOUD === "1";
-export const REVALIDATION_INTERVAL = 0; //TODO: find a good way to cache and revalidate data when it changes
-export const SERVICES_REVALIDATION_INTERVAL = 60 * 60 * 24; // 24 hours
 export const MAU_LIMIT = IS_FORMBRICKS_CLOUD ? 9000 : 1000000;
 
 // URLs

--- a/packages/lib/display/service.ts
+++ b/packages/lib/display/service.ts
@@ -22,7 +22,7 @@ import { ZId } from "@formbricks/types/environment";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TPerson } from "@formbricks/types/people";
 
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL } from "../constants";
+import { ITEMS_PER_PAGE } from "../constants";
 import { createPerson, getPersonByUserId } from "../person/service";
 import { formatDateFields } from "../utils/datetime";
 import { validateInputs } from "../utils/validate";
@@ -63,7 +63,6 @@ export const getDisplay = async (displayId: string): Promise<TDisplay | null> =>
     [`getDisplay-${displayId}`],
     {
       tags: [displayCache.tag.byId(displayId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return display ? formatDateFields(display, ZDisplay) : null;
@@ -310,7 +309,6 @@ export const getDisplaysByPersonId = async (personId: string, page?: number): Pr
     [`getDisplaysByPersonId-${personId}-${page}`],
     {
       tags: [displayCache.tag.byPersonId(personId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return displays.map((display) => formatDateFields(display, ZDisplay));
@@ -376,6 +374,5 @@ export const getDisplayCountBySurveyId = async (
     [`getDisplayCountBySurveyId-${surveyId}-${JSON.stringify(filters)}`],
     {
       tags: [displayCache.tag.bySurveyId(surveyId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();

--- a/packages/lib/environment/auth.ts
+++ b/packages/lib/environment/auth.ts
@@ -5,7 +5,6 @@ import { prisma } from "@formbricks/database";
 import { ZId } from "@formbricks/types/environment";
 import { DatabaseError } from "@formbricks/types/errors";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { teamCache } from "../team/cache";
 import { validateInputs } from "../utils/validate";
 
@@ -47,7 +46,6 @@ export const hasUserEnvironmentAccess = async (userId: string, environmentId: st
     },
     [`hasUserEnvironmentAccess-${userId}-${environmentId}`],
     {
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
       tags: [teamCache.tag.byEnvironmentId(environmentId), teamCache.tag.byUserId(userId)],
     }
   )();

--- a/packages/lib/environment/service.ts
+++ b/packages/lib/environment/service.ts
@@ -18,7 +18,6 @@ import {
 } from "@formbricks/types/environment";
 import { DatabaseError, ResourceNotFoundError, ValidationError } from "@formbricks/types/errors";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { getProducts } from "../product/service";
 import { getTeamsByUserId } from "../team/service";
 import { formatDateFields } from "../utils/datetime";
@@ -49,7 +48,6 @@ export const getEnvironment = async (environmentId: string): Promise<TEnvironmen
     [`getEnvironment-${environmentId}`],
     {
       tags: [environmentCache.tag.byId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return environment ? formatDateFields(environment, ZEnvironment) : null;
@@ -98,7 +96,6 @@ export const getEnvironments = async (productId: string): Promise<TEnvironment[]
     [`getEnvironments-${productId}`],
     {
       tags: [environmentCache.tag.byProductId(productId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return environments.map((environment) => formatDateFields(environment, ZEnvironment));

--- a/packages/lib/integration/auth.ts
+++ b/packages/lib/integration/auth.ts
@@ -4,7 +4,6 @@ import { unstable_cache } from "next/cache";
 
 import { ZId } from "@formbricks/types/environment";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { hasUserEnvironmentAccess } from "../environment/auth";
 import { validateInputs } from "../utils/validate";
 import { getIntegration } from "./service";
@@ -29,5 +28,7 @@ export const canUserAccessIntegration = async (userId: string, integrationId: st
     },
 
     [`canUserAccessIntegration-${userId}-${integrationId}`],
-    { revalidate: SERVICES_REVALIDATION_INTERVAL, tags: [`integrations-${integrationId}`] }
+    {
+      tags: [`integrations-${integrationId}`],
+    }
   )();

--- a/packages/lib/integration/service.ts
+++ b/packages/lib/integration/service.ts
@@ -14,7 +14,7 @@ import {
   ZIntegrationType,
 } from "@formbricks/types/integration";
 
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL } from "../constants";
+import { ITEMS_PER_PAGE } from "../constants";
 import { formatDateFields } from "../utils/datetime";
 import { validateInputs } from "../utils/validate";
 import { integrationCache } from "./cache";
@@ -81,7 +81,6 @@ export const getIntegrations = async (environmentId: string, page?: number): Pro
     [`getIntegrations-${environmentId}-${page}`],
     {
       tags: [integrationCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return integrations.map((integration) => formatDateFields(integration, ZIntegration));
@@ -105,7 +104,9 @@ export const getIntegration = async (integrationId: string): Promise<TIntegratio
       }
     },
     [`getIntegration-${integrationId}`],
-    { tags: [integrationCache.tag.byId(integrationId)], revalidate: SERVICES_REVALIDATION_INTERVAL }
+    {
+      tags: [integrationCache.tag.byId(integrationId)],
+    }
   )();
   return integration ? formatDateFields(integration, ZIntegration) : null;
 };
@@ -138,7 +139,6 @@ export const getIntegrationByType = async (
     [`getIntegrationByType-${environmentId}-${type}`],
     {
       tags: [integrationCache.tag.byEnvironmentIdAndType(environmentId, type)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return integration ? formatDateFields(integration, ZIntegration) : null;

--- a/packages/lib/invite/service.ts
+++ b/packages/lib/invite/service.ts
@@ -17,7 +17,7 @@ import {
   ZInvitee,
 } from "@formbricks/types/invites";
 
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL } from "../constants";
+import { ITEMS_PER_PAGE } from "../constants";
 import { getMembershipByUserIdTeamId } from "../membership/service";
 import { formatDateFields } from "../utils/datetime";
 import { validateInputs } from "../utils/validate";
@@ -66,7 +66,6 @@ export const getInvitesByTeamId = async (teamId: string, page?: number): Promise
     [`getInvitesByTeamId-${teamId}-${page}`],
     {
       tags: [inviteCache.tag.byTeamId(teamId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return invites.map((invite: TInvite) => formatDateFields(invite, ZInvite));
@@ -160,7 +159,9 @@ export const getInvite = async (inviteId: string): Promise<InviteWithCreator | n
       }
     },
     [`getInvite-${inviteId}`],
-    { tags: [inviteCache.tag.byId(inviteId)], revalidate: SERVICES_REVALIDATION_INTERVAL }
+    {
+      tags: [inviteCache.tag.byId(inviteId)],
+    }
   )();
 
   return invite

--- a/packages/lib/membership/service.ts
+++ b/packages/lib/membership/service.ts
@@ -14,7 +14,7 @@ import {
   ZMembershipUpdateInput,
 } from "@formbricks/types/memberships";
 
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL } from "../constants";
+import { ITEMS_PER_PAGE } from "../constants";
 import { teamCache } from "../team/cache";
 import { validateInputs } from "../utils/validate";
 import { membershipCache } from "./cache";
@@ -65,7 +65,6 @@ export const getMembersByTeamId = async (teamId: string, page?: number): Promise
     [`getMembersByTeamId-${teamId}-${page}`],
     {
       tags: [membershipCache.tag.byTeamId(teamId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -102,7 +101,6 @@ export const getMembershipByUserIdTeamId = async (
     [`getMembershipByUserIdTeamId-${userId}-${teamId}`],
     {
       tags: [membershipCache.tag.byUserId(userId), membershipCache.tag.byTeamId(teamId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -132,7 +130,6 @@ export const getMembershipsByUserId = async (userId: string, page?: number): Pro
     [`getMembershipsByUserId-${userId}-${page}`],
     {
       tags: [membershipCache.tag.byUserId(userId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 

--- a/packages/lib/person/auth.ts
+++ b/packages/lib/person/auth.ts
@@ -4,7 +4,6 @@ import { unstable_cache } from "next/cache";
 
 import { ZId } from "@formbricks/types/environment";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { hasUserEnvironmentAccess } from "../environment/auth";
 import { validateInputs } from "../utils/validate";
 import { personCache } from "./cache";
@@ -30,7 +29,6 @@ export const canUserAccessPerson = async (userId: string, personId: string): Pro
     },
     [`canUserAccessPerson-${userId}-people-${personId}`],
     {
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
       tags: [personCache.tag.byId(personId)],
     }
   )();

--- a/packages/lib/person/service.ts
+++ b/packages/lib/person/service.ts
@@ -9,7 +9,7 @@ import { ZId } from "@formbricks/types/environment";
 import { DatabaseError } from "@formbricks/types/errors";
 import { TPerson, ZPerson } from "@formbricks/types/people";
 
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL } from "../constants";
+import { ITEMS_PER_PAGE } from "../constants";
 import { formatDateFields } from "../utils/datetime";
 import { validateInputs } from "../utils/validate";
 import { activePersonCache, personCache } from "./cache";
@@ -76,7 +76,9 @@ export const getPerson = async (personId: string): Promise<TPerson | null> => {
       }
     },
     [`getPerson-${personId}`],
-    { tags: [personCache.tag.byId(personId)], revalidate: SERVICES_REVALIDATION_INTERVAL }
+    {
+      tags: [personCache.tag.byId(personId)],
+    }
   )();
 
   return prismaPerson ? formatDateFields(prismaPerson, ZPerson) : null;
@@ -107,7 +109,6 @@ export const getPeople = async (environmentId: string, page?: number): Promise<T
     [`getPeople-${environmentId}-${page}`],
     {
       tags: [personCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -138,7 +139,6 @@ export const getPeopleCount = async (environmentId: string): Promise<number> =>
     [`getPeopleCount-${environmentId}`],
     {
       tags: [personCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -240,7 +240,6 @@ export const getPersonByUserId = async (environmentId: string, userId: string): 
     [`getPersonByUserId-${environmentId}-${userId}`],
     {
       tags: [personCache.tag.byEnvironmentIdAndUserId(environmentId, userId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return person ? formatDateFields(person, ZPerson) : null;

--- a/packages/lib/product/auth.ts
+++ b/packages/lib/product/auth.ts
@@ -2,7 +2,6 @@ import { unstable_cache } from "next/cache";
 
 import { ZId } from "@formbricks/types/environment";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { getMembershipByUserIdTeamId } from "../membership/service";
 import { getAccessFlags } from "../membership/utils";
 import { getTeamsByUserId } from "../team/service";
@@ -29,7 +28,6 @@ export const canUserAccessProduct = async (userId: string, productId: string): P
     },
     [`canUserAccessProduct-${userId}-${productId}`],
     {
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
       tags: [productCache.tag.byId(productId), productCache.tag.byUserId(userId)],
     }
   )();

--- a/packages/lib/product/service.ts
+++ b/packages/lib/product/service.ts
@@ -11,7 +11,7 @@ import { DatabaseError, ValidationError } from "@formbricks/types/errors";
 import type { TProduct, TProductUpdateInput } from "@formbricks/types/product";
 import { ZProduct, ZProductUpdateInput } from "@formbricks/types/product";
 
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL, isS3Configured } from "../constants";
+import { ITEMS_PER_PAGE, isS3Configured } from "../constants";
 import { environmentCache } from "../environment/cache";
 import { createEnvironment } from "../environment/service";
 import { deleteLocalFilesByEnvironmentId, deleteS3FilesByEnvironmentId } from "../storage/service";
@@ -63,7 +63,6 @@ export const getProducts = async (teamId: string, page?: number): Promise<TProdu
     [`getProducts-${teamId}-${page}`],
     {
       tags: [productCache.tag.byTeamId(teamId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return products.map((product) => formatDateFields(product, ZProduct));
@@ -100,7 +99,6 @@ export const getProductByEnvironmentId = async (environmentId: string): Promise<
     [`getProductByEnvironmentId-${environmentId}`],
     {
       tags: [productCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return product ? formatDateFields(product, ZProduct) : null;
@@ -180,7 +178,6 @@ export const getProduct = async (productId: string): Promise<TProduct | null> =>
     [`getProduct-${productId}`],
     {
       tags: [productCache.tag.byId(productId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return product ? formatDateFields(product, ZProduct) : null;

--- a/packages/lib/response/auth.ts
+++ b/packages/lib/response/auth.ts
@@ -4,7 +4,6 @@ import { unstable_cache } from "next/cache";
 
 import { ZId } from "@formbricks/types/environment";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { hasUserEnvironmentAccess } from "../environment/auth";
 import { getSurvey } from "../survey/service";
 import { validateInputs } from "../utils/validate";
@@ -34,5 +33,7 @@ export const canUserAccessResponse = async (userId: string, responseId: string):
       }
     },
     [`canUserAccessResponse-${userId}-${responseId}`],
-    { revalidate: SERVICES_REVALIDATION_INTERVAL, tags: [responseCache.tag.byId(responseId)] }
+    {
+      tags: [responseCache.tag.byId(responseId)],
+    }
   )();

--- a/packages/lib/response/service.ts
+++ b/packages/lib/response/service.ts
@@ -28,7 +28,7 @@ import { TSurveySummary } from "@formbricks/types/surveys";
 import { TTag } from "@formbricks/types/tags";
 
 import { getAttributes } from "../attribute/service";
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL, WEBAPP_URL } from "../constants";
+import { ITEMS_PER_PAGE, WEBAPP_URL } from "../constants";
 import { displayCache } from "../display/cache";
 import { deleteDisplayByResponseId, getDisplayCountBySurveyId } from "../display/service";
 import { createPerson, getPerson, getPersonByUserId } from "../person/service";
@@ -154,7 +154,6 @@ export const getResponsesByPersonId = async (
     [`getResponsesByPersonId-${personId}-${page}`],
     {
       tags: [responseCache.tag.byPersonId(personId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -201,7 +200,6 @@ export const getResponseBySingleUseId = async (
     [`getResponseBySingleUseId-${surveyId}-${singleUseId}`],
     {
       tags: [responseCache.tag.bySingleUseId(surveyId, singleUseId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -407,7 +405,6 @@ export const getResponse = async (responseId: string): Promise<TResponse | null>
     [`getResponse-${responseId}`],
     {
       tags: [responseCache.tag.byId(responseId), responseNoteCache.tag.byResponseId(responseId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -461,7 +458,6 @@ export const getResponsePersonAttributes = async (surveyId: string): Promise<TSu
     [`getResponsePersonAttributes-${surveyId}`],
     {
       tags: [responseCache.tag.bySurveyId(surveyId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -525,7 +521,6 @@ export const getResponseMeta = async (surveyId: string): Promise<TSurveyMetaFiel
     [`getResponseMeta-${surveyId}`],
     {
       tags: [responseCache.tag.bySurveyId(surveyId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -584,7 +579,6 @@ export const getResponses = async (
     [`getResponses-${surveyId}-${page}-${batchSize}-${JSON.stringify(filterCriteria)}`],
     {
       tags: [responseCache.tag.bySurveyId(surveyId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -644,7 +638,6 @@ export const getSurveySummary = (
     [`getSurveySummary-${surveyId}-${JSON.stringify(filterCriteria)}`],
     {
       tags: [responseCache.tag.bySurveyId(surveyId), displayCache.tag.bySurveyId(surveyId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -768,7 +761,6 @@ export const getResponsesByEnvironmentId = async (
     [`getResponsesByEnvironmentId-${environmentId}-${page}`],
     {
       tags: [responseCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -917,6 +909,5 @@ export const getResponseCountBySurveyId = async (
     [`getResponseCountBySurveyId-${surveyId}-${JSON.stringify(filterCriteria)}`],
     {
       tags: [responseCache.tag.bySurveyId(surveyId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();

--- a/packages/lib/responseNote/service.ts
+++ b/packages/lib/responseNote/service.ts
@@ -9,7 +9,6 @@ import { ZId } from "@formbricks/types/environment";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TResponseNote, ZResponseNote } from "@formbricks/types/responses";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { responseCache } from "../response/cache";
 import { formatDateFields } from "../utils/datetime";
 import { validateInputs } from "../utils/validate";
@@ -94,7 +93,9 @@ export const getResponseNote = async (responseNoteId: string): Promise<TResponse
       }
     },
     [`getResponseNote-${responseNoteId}`],
-    { tags: [responseNoteCache.tag.byId(responseNoteId)], revalidate: SERVICES_REVALIDATION_INTERVAL }
+    {
+      tags: [responseNoteCache.tag.byId(responseNoteId)],
+    }
   )();
   return responseNote ? formatDateFields(responseNote, ZResponseNote) : null;
 };
@@ -125,7 +126,9 @@ export const getResponseNotes = async (responseId: string): Promise<TResponseNot
       }
     },
     [`getResponseNotes-${responseId}`],
-    { tags: [responseNoteCache.tag.byResponseId(responseId)], revalidate: SERVICES_REVALIDATION_INTERVAL }
+    {
+      tags: [responseNoteCache.tag.byResponseId(responseId)],
+    }
   )();
   return responseNotes.map((responseNote) => formatDateFields(responseNote, ZResponseNote));
 };

--- a/packages/lib/segment/service.ts
+++ b/packages/lib/segment/service.ts
@@ -32,7 +32,6 @@ import {
   getLastOccurrenceDaysAgo,
   getTotalOccurrencesForAction,
 } from "../action/service";
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { structuredClone } from "../pollyfills/structuredClone";
 import { surveyCache } from "../survey/cache";
 import { getSurvey } from "../survey/service";
@@ -145,7 +144,6 @@ export const getSegments = async (environmentId: string): Promise<TSegment[]> =>
     [`getSegments-${environmentId}`],
     {
       tags: [segmentCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -181,7 +179,6 @@ export const getSegment = async (segmentId: string): Promise<TSegment> => {
     [`getSegment-${segmentId}`],
     {
       tags: [segmentCache.tag.byId(segmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -369,7 +366,6 @@ export const getSegmentsByAttributeClassName = async (environmentId: string, att
         segmentCache.tag.byEnvironmentId(environmentId),
         segmentCache.tag.byAttributeClassName(attributeClassName),
       ],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 

--- a/packages/lib/survey/auth.ts
+++ b/packages/lib/survey/auth.ts
@@ -2,7 +2,6 @@ import { unstable_cache } from "next/cache";
 
 import { ZId } from "@formbricks/types/environment";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { hasUserEnvironmentAccess } from "../environment/auth";
 import { getMembershipByUserIdTeamId } from "../membership/service";
 import { getAccessFlags } from "../membership/utils";
@@ -31,7 +30,9 @@ export const canUserAccessSurvey = async (userId: string, surveyId: string): Pro
       }
     },
     [`canUserAccessSurvey-${userId}-${surveyId}`],
-    { revalidate: SERVICES_REVALIDATION_INTERVAL, tags: [surveyCache.tag.byId(surveyId)] }
+    {
+      tags: [surveyCache.tag.byId(surveyId)],
+    }
   )();
 
 export const verifyUserRoleAccess = async (

--- a/packages/lib/survey/service.ts
+++ b/packages/lib/survey/service.ts
@@ -22,7 +22,7 @@ import { getActionsByPersonId } from "../action/service";
 import { getActionClasses } from "../actionClass/service";
 import { attributeCache } from "../attribute/cache";
 import { getAttributes } from "../attribute/service";
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL } from "../constants";
+import { ITEMS_PER_PAGE } from "../constants";
 import { displayCache } from "../display/cache";
 import { getDisplaysByPersonId } from "../display/service";
 import { reverseTranslateSurvey } from "../i18n/reverseTranslation";
@@ -228,7 +228,6 @@ export const getSurvey = async (surveyId: string): Promise<TSurvey | null> => {
     [`getSurvey-${surveyId}`],
     {
       tags: [surveyCache.tag.byId(surveyId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -292,7 +291,6 @@ export const getSurveysByActionClassId = async (actionClassId: string, page?: nu
     [`getSurveysByActionClassId-${actionClassId}-${page}`],
     {
       tags: [surveyCache.tag.byActionClassId(actionClassId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return surveys.map((survey) => formatSurveyDateFields(survey));
@@ -354,7 +352,6 @@ export const getSurveys = async (
     [`getSurveys-${environmentId}-${limit}-${offset}-${JSON.stringify(filterCriteria)}`],
     {
       tags: [surveyCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -397,7 +394,6 @@ export const getSurveyCount = async (environmentId: string): Promise<number> => 
     [`getSurveyCount-${environmentId}`],
     {
       tags: [surveyCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -1054,10 +1050,8 @@ export const getSyncSurveys = async (
         displayCache.tag.byPersonId(personId),
         surveyCache.tag.byEnvironmentId(environmentId),
         productCache.tag.byEnvironmentId(environmentId),
-        // ? Should this be included?
         attributeCache.tag.byPersonId(personId),
       ],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -1188,7 +1182,6 @@ export const getSurveysBySegmentId = async (segmentId: string): Promise<TSurvey[
     [`getSurveysBySegmentId-${segmentId}`],
     {
       tags: [surveyCache.tag.bySegmentId(segmentId), segmentCache.tag.byId(segmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 

--- a/packages/lib/tag/auth.ts
+++ b/packages/lib/tag/auth.ts
@@ -1,10 +1,7 @@
 import "server-only";
 
-import { unstable_cache } from "next/cache";
-
 import { ZId } from "@formbricks/types/environment";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { hasUserEnvironmentAccess } from "../environment/auth";
 import { getMembershipByUserIdTeamId } from "../membership/service";
 import { getAccessFlags } from "../membership/utils";
@@ -12,28 +9,21 @@ import { getTeamByEnvironmentId } from "../team/service";
 import { validateInputs } from "../utils/validate";
 import { getTag } from "./service";
 
-export const canUserAccessTag = async (userId: string, tagId: string): Promise<boolean> =>
-  await unstable_cache(
-    async () => {
-      validateInputs([userId, ZId], [tagId, ZId]);
+export const canUserAccessTag = async (userId: string, tagId: string): Promise<boolean> => {
+  validateInputs([userId, ZId], [tagId, ZId]);
 
-      try {
-        const tag = await getTag(tagId);
-        if (!tag) return false;
+  try {
+    const tag = await getTag(tagId);
+    if (!tag) return false;
 
-        const hasAccessToEnvironment = await hasUserEnvironmentAccess(userId, tag.environmentId);
-        if (!hasAccessToEnvironment) return false;
+    const hasAccessToEnvironment = await hasUserEnvironmentAccess(userId, tag.environmentId);
+    if (!hasAccessToEnvironment) return false;
 
-        return true;
-      } catch (error) {
-        throw error;
-      }
-    },
-    [`canUserAccessTag-${userId}-${tagId}`],
-    {
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
-    }
-  )();
+    return true;
+  } catch (error) {
+    throw error;
+  }
+};
 
 export const verifyUserRoleAccess = async (
   environmentId: string,

--- a/packages/lib/tagOnResponse/auth.ts
+++ b/packages/lib/tagOnResponse/auth.ts
@@ -4,7 +4,6 @@ import { unstable_cache } from "next/cache";
 
 import { ZId } from "@formbricks/types/environment";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { getMembershipByUserIdTeamId } from "../membership/service";
 import { getAccessFlags } from "../membership/utils";
 import { canUserAccessResponse } from "../response/auth";
@@ -33,7 +32,6 @@ export const canUserAccessTagOnResponse = async (
     },
     [`canUserAccessTagOnResponse-${userId}-${tagId}-${responseId}`],
     {
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
       tags: [tagOnResponseCache.tag.byResponseIdAndTagId(responseId, tagId)],
     }
   )();

--- a/packages/lib/tagOnResponse/service.ts
+++ b/packages/lib/tagOnResponse/service.ts
@@ -8,7 +8,6 @@ import { ZId } from "@formbricks/types/environment";
 import { DatabaseError } from "@formbricks/types/errors";
 import { TTagsCount, TTagsOnResponses } from "@formbricks/types/tags";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { responseCache } from "../response/cache";
 import { getResponse } from "../response/service";
 import { validateInputs } from "../utils/validate";
@@ -128,6 +127,5 @@ export const getTagsOnResponsesCount = async (environmentId: string): Promise<TT
     [`getTagsOnResponsesCount-${environmentId}`],
     {
       tags: [tagOnResponseCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();

--- a/packages/lib/team/auth.ts
+++ b/packages/lib/team/auth.ts
@@ -4,7 +4,6 @@ import { unstable_cache } from "next/cache";
 
 import { ZId } from "@formbricks/types/environment";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { getMembershipByUserIdTeamId } from "../membership/service";
 import { getAccessFlags } from "../membership/utils";
 import { teamCache } from "../team/cache";
@@ -29,7 +28,9 @@ export const canUserAccessTeam = async (userId: string, teamId: string): Promise
       }
     },
     [`canUserAccessTeam-${userId}-${teamId}`],
-    { revalidate: SERVICES_REVALIDATION_INTERVAL, tags: [teamCache.tag.byId(teamId)] }
+    {
+      tags: [teamCache.tag.byId(teamId)],
+    }
   )();
 
 export const verifyUserRoleAccess = async (

--- a/packages/lib/team/service.ts
+++ b/packages/lib/team/service.ts
@@ -17,7 +17,7 @@ import {
 } from "@formbricks/types/teams";
 import { TUserNotificationSettings } from "@formbricks/types/user";
 
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL } from "../constants";
+import { ITEMS_PER_PAGE } from "../constants";
 import { environmentCache } from "../environment/cache";
 import { getProducts } from "../product/service";
 import { getUsersWithTeam, updateUser } from "../user/service";
@@ -70,7 +70,6 @@ export const getTeamsByUserId = async (userId: string, page?: number): Promise<T
     [`getTeamsByUserId-${userId}-${page}`],
     {
       tags: [teamCache.tag.byUserId(userId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return teams.map((team) => formatDateFields(team, ZTeam));
@@ -110,7 +109,6 @@ export const getTeamByEnvironmentId = async (environmentId: string): Promise<TTe
     [`getTeamByEnvironmentId-${environmentId}`],
     {
       tags: [teamCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return team ? formatDateFields(team, ZTeam) : null;
@@ -140,7 +138,6 @@ export const getTeam = async (teamId: string): Promise<TTeam | null> => {
     [`getTeam-${teamId}`],
     {
       tags: [teamCache.tag.byId(teamId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return team ? formatDateFields(team, ZTeam) : null;
@@ -299,7 +296,6 @@ export const getTeamsWithPaidPlan = async (): Promise<TTeam[]> => {
     ["getTeamsWithPaidPlan"],
     {
       tags: [],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -350,7 +346,7 @@ export const getMonthlyActiveTeamPeopleCount = async (teamId: string): Promise<n
     },
     [`getMonthlyActiveTeamPeopleCount-${teamId}`],
     {
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
+      revalidate: 60 * 60 * 2, // 2 hours
     }
   )();
 
@@ -394,7 +390,7 @@ export const getMonthlyTeamResponseCount = async (teamId: string): Promise<numbe
     },
     [`getMonthlyTeamResponseCount-${teamId}`],
     {
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
+      revalidate: 60 * 60 * 2, // 2 hours
     }
   )();
 
@@ -421,7 +417,6 @@ export const getTeamBillingInfo = async (teamId: string): Promise<TTeamBilling |
     },
     [`getTeamBillingInfo-${teamId}`],
     {
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
       tags: [teamCache.tag.byId(teamId)],
     }
   )();

--- a/packages/lib/user/service.ts
+++ b/packages/lib/user/service.ts
@@ -10,7 +10,6 @@ import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TMembership } from "@formbricks/types/memberships";
 import { TUser, TUserCreateInput, TUserUpdateInput, ZUser, ZUserUpdateInput } from "@formbricks/types/user";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { createCustomerIoCustomer } from "../customerio";
 import { deleteMembership, updateMembership } from "../membership/service";
 import { deleteTeam } from "../team/service";
@@ -63,7 +62,6 @@ export const getUser = async (id: string): Promise<TUser | null> => {
     [`getUser-${id}`],
     {
       tags: [userCache.tag.byId(id)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -100,7 +98,6 @@ export const getUserByEmail = async (email: string): Promise<TUser | null> => {
     [`getUserByEmail-${email}`],
     {
       tags: [userCache.tag.byEmail(email)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 

--- a/packages/lib/webhook/auth.ts
+++ b/packages/lib/webhook/auth.ts
@@ -2,7 +2,6 @@ import { unstable_cache } from "next/cache";
 
 import { ZId } from "@formbricks/types/environment";
 
-import { SERVICES_REVALIDATION_INTERVAL } from "../constants";
 import { hasUserEnvironmentAccess } from "../environment/auth";
 import { validateInputs } from "../utils/validate";
 import { webhookCache } from "./cache";
@@ -28,6 +27,5 @@ export const canUserAccessWebhook = async (userId: string, webhookId: string): P
     [`canUserAccessWebhook-${userId}-${webhookId}`],
     {
       tags: [webhookCache.tag.byId(webhookId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();

--- a/packages/lib/webhook/service.ts
+++ b/packages/lib/webhook/service.ts
@@ -9,7 +9,7 @@ import { ZId } from "@formbricks/types/environment";
 import { DatabaseError, InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TWebhook, TWebhookInput, ZWebhook, ZWebhookInput } from "@formbricks/types/webhooks";
 
-import { ITEMS_PER_PAGE, SERVICES_REVALIDATION_INTERVAL } from "../constants";
+import { ITEMS_PER_PAGE } from "../constants";
 import { formatDateFields } from "../utils/datetime";
 import { validateInputs } from "../utils/validate";
 import { webhookCache } from "./cache";
@@ -39,7 +39,6 @@ export const getWebhooks = async (environmentId: string, page?: number): Promise
     [`getWebhooks-${environmentId}-${page}`],
     {
       tags: [webhookCache.tag.byEnvironmentId(environmentId)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return webhooks.map((webhook) => formatDateFields(webhook, ZWebhook));
@@ -72,7 +71,6 @@ export const getWebhookCountBySource = async (
     [`getWebhookCountBySource-${environmentId}-${source}`],
     {
       tags: [webhookCache.tag.byEnvironmentIdAndSource(environmentId, source)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
 
@@ -99,7 +97,6 @@ export const getWebhook = async (id: string): Promise<TWebhook | null> => {
     [`getWebhook-${id}`],
     {
       tags: [webhookCache.tag.byId(id)],
-      revalidate: SERVICES_REVALIDATION_INTERVAL,
     }
   )();
   return webhook ? formatDateFields(webhook, ZWebhook) : null;


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

remove service-revalidation-interval to simplify caching. We introduced this interval first as a fallback if our cache revalidation strategy fails but since now it's running reliable, we will remove this fallback to simplify things.

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->