### PR TITLE
fix: global error handling js package

### DIFF
--- a/packages/js/src/app.ts
+++ b/packages/js/src/app.ts
@@ -1,37 +1,57 @@
 import { TFormbricksApp } from "@formbricks/js-core/app";
 import { TFormbricksWebsite } from "@formbricks/js-core/website";
 
+import { Result } from "../../types/errorHandlers";
+
 declare global {
   interface Window {
     formbricks: TFormbricksApp | TFormbricksWebsite;
   }
 }
 
-let sdkLoadingPromise: Promise<void> | null = null;
-let isErrorLoadingSdk = false;
-
-async function loadSDK(apiHost: string) {
+// load the sdk, return the result
+async function loadFormbricksAppSDK(apiHost: string): Promise<Result<void>> {
   if (!window.formbricks) {
     const res = await fetch(`${apiHost}/api/packages/app`);
-    if (!res.ok) throw new Error("Failed to load Formbricks App SDK");
+
+    // failed to fetch the app package
+    if (!res.ok) {
+      return { ok: false, error: new Error("Failed to load Formbricks App SDK") };
+    }
+
     const sdkScript = await res.text();
     const scriptTag = document.createElement("script");
     scriptTag.innerHTML = sdkScript;
     document.head.appendChild(scriptTag);
 
-    return new Promise<void>((resolve, reject) => {
-      const checkInterval = setInterval(() => {
-        if (window.formbricks) {
+    const getFormbricks = async () =>
+      new Promise<void>((resolve, reject) => {
+        const checkInterval = setInterval(() => {
+          if (window.formbricks) {
+            clearInterval(checkInterval);
+            resolve();
+          }
+        }, 100);
+
+        setTimeout(() => {
           clearInterval(checkInterval);
-          resolve();
-        }
-      }, 100);
-      setTimeout(() => {
-        clearInterval(checkInterval);
-        reject(new Error("Formbricks SDK loading timed out"));
-      }, 10000);
-    });
+          reject(new Error("Formbricks App SDK loading timed out"));
+        }, 10000);
+      });
+
+    try {
+      await getFormbricks();
+      return { ok: true, data: undefined };
+    } catch (error: any) {
+      // formbricks loading failed, return the error
+      return {
+        ok: false,
+        error: new Error(error.message ?? "Failed to load Formbricks App SDK"),
+      };
+    }
   }
+
+  return { ok: true, data: undefined };
 }
 
 type FormbricksAppMethods = {
@@ -41,31 +61,33 @@ type FormbricksAppMethods = {
 const formbricksProxyHandler: ProxyHandler<TFormbricksApp> = {
   get(_target, prop, _receiver) {
     return async (...args: any[]) => {
-      if (!window.formbricks && !sdkLoadingPromise && !isErrorLoadingSdk) {
-        const { apiHost } = args[0];
-        sdkLoadingPromise = loadSDK(apiHost).catch((error) => {
-          console.error(`🧱 Formbricks - Error loading SDK: ${error}`);
-          sdkLoadingPromise = null;
-          isErrorLoadingSdk = true;
-          return;
-        });
-      }
-
-      if (isErrorLoadingSdk) {
-        return;
-      }
-
-      if (sdkLoadingPromise) {
-        await sdkLoadingPromise;
-      }
-
       if (!window.formbricks) {
-        throw new Error("Formbricks App SDK is not available");
+        if (prop !== "init") {
+          console.error(
+            "🧱 Formbricks - Global error: You need to call formbricks.init before calling any other method"
+          );
+          return;
+        }
+
+        // still need to check if the apiHost is passed
+        if (!args[0]) {
+          console.error("🧱 Formbricks - Global error: You need to pass the apiHost as the first argument");
+          return;
+        }
+
+        const { apiHost } = args[0];
+        const loadSDKResult = await loadFormbricksAppSDK(apiHost);
+        if (!loadSDKResult.ok) {
+          console.error(`🧱 Formbricks - Global error: ${loadSDKResult.error.message}`);
+          return;
+        }
       }
 
       // @ts-expect-error
       if (typeof window.formbricks[prop as FormbricksAppMethods] !== "function") {
-        console.error(`🧱 Formbricks App SDK does not support method ${String(prop)}`);
+        console.error(
+          `🧱 Formbricks - Global error: Formbricks App SDK does not support method ${String(prop)}`
+        );
         return;
       }
 
@@ -73,8 +95,8 @@ const formbricksProxyHandler: ProxyHandler<TFormbricksApp> = {
         // @ts-expect-error
         return (window.formbricks[prop as FormbricksAppMethods] as Function)(...args);
       } catch (error) {
-        console.error(error);
-        throw error;
+        console.error(`Something went wrong: ${error}`);
+        return;
       }
     };
   },

--- a/packages/js/src/app.ts
+++ b/packages/js/src/app.ts
@@ -1,7 +1,7 @@
 import { TFormbricksApp } from "@formbricks/js-core/app";
 import { TFormbricksWebsite } from "@formbricks/js-core/website";
 
-import { Result } from "../../types/errorHandlers";
+import { Result, wrapThrowsAsync } from "../../types/errorHandlers";
 
 declare global {
   interface Window {
@@ -76,7 +76,8 @@ const formbricksProxyHandler: ProxyHandler<TFormbricksApp> = {
         }
 
         const { apiHost } = args[0];
-        const loadSDKResult = await loadFormbricksAppSDK(apiHost);
+        const loadSDKResult = await wrapThrowsAsync(loadFormbricksAppSDK)(apiHost);
+
         if (!loadSDKResult.ok) {
           console.error(`🧱 Formbricks - Global error: ${loadSDKResult.error.message}`);
           return;
@@ -84,7 +85,7 @@ const formbricksProxyHandler: ProxyHandler<TFormbricksApp> = {
       }
 
       // @ts-expect-error
-      if (typeof window.formbricks[prop as FormbricksAppMethods] !== "function") {
+      if (window.formbricks && typeof window.formbricks[prop as FormbricksAppMethods] !== "function") {
         console.error(
           `🧱 Formbricks - Global error: Formbricks App SDK does not support method ${String(prop)}`
         );

--- a/packages/js/src/website.ts
+++ b/packages/js/src/website.ts
@@ -1,7 +1,7 @@
 import { TFormbricksApp } from "@formbricks/js-core/app";
 import { TFormbricksWebsite } from "@formbricks/js-core/website";
 
-import { Result } from "../../types/errorHandlers";
+import { Result, wrapThrowsAsync } from "../../types/errorHandlers";
 
 declare global {
   interface Window {
@@ -76,14 +76,15 @@ const formbricksProxyHandler: ProxyHandler<TFormbricksWebsite> = {
         }
 
         const { apiHost } = args[0];
-        const loadSDKResult = await loadFormbricksWebsiteSDK(apiHost);
+        const loadSDKResult = await wrapThrowsAsync(loadFormbricksWebsiteSDK)(apiHost);
+
         if (!loadSDKResult.ok) {
           console.error(`🧱 Formbricks - Global error: ${loadSDKResult.error.message}`);
           return;
         }
       }
 
-      if (typeof window.formbricks[prop as FormbricksWebsiteMethods] !== "function") {
+      if (window.formbricks && typeof window.formbricks[prop as FormbricksWebsiteMethods] !== "function") {
         console.error(
           `🧱 Formbricks - Global error: Formbricks Website SDK does not support method ${String(prop)}`
         );

--- a/packages/js/src/website.ts
+++ b/packages/js/src/website.ts
@@ -1,30 +1,57 @@
+import { TFormbricksApp } from "@formbricks/js-core/app";
 import { TFormbricksWebsite } from "@formbricks/js-core/website";
 
-let sdkLoadingPromise: Promise<void> | null = null;
-let isErrorLoadingSdk = false;
+import { Result } from "../../types/errorHandlers";
 
-async function loadSDK(apiHost: string) {
+declare global {
+  interface Window {
+    formbricks: TFormbricksApp | TFormbricksWebsite;
+  }
+}
+
+// load the sdk, return the result
+async function loadFormbricksWebsiteSDK(apiHost: string): Promise<Result<void>> {
   if (!window.formbricks) {
     const res = await fetch(`${apiHost}/api/packages/website`);
-    if (!res.ok) throw new Error("Failed to load Formbricks Website SDK");
+
+    // failed to fetch the app package
+    if (!res.ok) {
+      return { ok: false, error: new Error("Failed to load Formbricks Website SDK") };
+    }
+
     const sdkScript = await res.text();
     const scriptTag = document.createElement("script");
     scriptTag.innerHTML = sdkScript;
     document.head.appendChild(scriptTag);
 
-    return new Promise<void>((resolve, reject) => {
-      const checkInterval = setInterval(() => {
-        if (window.formbricks) {
+    const getFormbricks = async () =>
+      new Promise<void>((resolve, reject) => {
+        const checkInterval = setInterval(() => {
+          if (window.formbricks) {
+            clearInterval(checkInterval);
+            resolve();
+          }
+        }, 100);
+
+        setTimeout(() => {
           clearInterval(checkInterval);
-          resolve();
-        }
-      }, 100);
-      setTimeout(() => {
-        clearInterval(checkInterval);
-        reject(new Error("Formbricks SDK loading timed out"));
-      }, 10000);
-    });
+          reject(new Error("Formbricks Website SDK loading timed out"));
+        }, 10000);
+      });
+
+    try {
+      await getFormbricks();
+      return { ok: true, data: undefined };
+    } catch (error: any) {
+      // formbricks loading failed, return the error
+      return {
+        ok: false,
+        error: new Error(error.message ?? "Failed to load Formbricks Website SDK"),
+      };
+    }
   }
+
+  return { ok: true, data: undefined };
 }
 
 type FormbricksWebsiteMethods = {
@@ -34,42 +61,44 @@ type FormbricksWebsiteMethods = {
 const formbricksProxyHandler: ProxyHandler<TFormbricksWebsite> = {
   get(_target, prop, _receiver) {
     return async (...args: any[]) => {
-      if (!window.formbricks && !sdkLoadingPromise && !isErrorLoadingSdk) {
-        const { apiHost } = args[0];
-        sdkLoadingPromise = loadSDK(apiHost).catch((error) => {
-          console.error(`🧱 Formbricks - Error loading SDK: ${error}`);
-          sdkLoadingPromise = null;
-          isErrorLoadingSdk = true;
-          return;
-        });
-      }
-
-      if (isErrorLoadingSdk) {
-        return;
-      }
-
-      if (sdkLoadingPromise) {
-        await sdkLoadingPromise;
-      }
-
       if (!window.formbricks) {
-        throw new Error("Formbricks Website SDK is not available");
+        if (prop !== "init") {
+          console.error(
+            "🧱 Formbricks - Global error: You need to call formbricks.init before calling any other method"
+          );
+          return;
+        }
+
+        // still need to check if the apiHost is passed
+        if (!args[0]) {
+          console.error("🧱 Formbricks - Global error: You need to pass the apiHost as the first argument");
+          return;
+        }
+
+        const { apiHost } = args[0];
+        const loadSDKResult = await loadFormbricksWebsiteSDK(apiHost);
+        if (!loadSDKResult.ok) {
+          console.error(`🧱 Formbricks - Global error: ${loadSDKResult.error.message}`);
+          return;
+        }
       }
 
       if (typeof window.formbricks[prop as FormbricksWebsiteMethods] !== "function") {
-        console.error(`🧱 Formbricks Website SDK does not support method ${String(prop)}`);
+        console.error(
+          `🧱 Formbricks - Global error: Formbricks Website SDK does not support method ${String(prop)}`
+        );
         return;
       }
 
       try {
         return (window.formbricks[prop as FormbricksWebsiteMethods] as Function)(...args);
       } catch (error) {
-        console.error(error);
-        throw error;
+        console.error(`🧱 Formbricks - Global error: Something went wrong: ${error}`);
+        return;
       }
     };
   },
 };
 
-const formbricksWebsite: TFormbricksWebsite = new Proxy({} as TFormbricksWebsite, formbricksProxyHandler);
-export default formbricksWebsite;
+const formbricksApp: TFormbricksWebsite = new Proxy({} as TFormbricksWebsite, formbricksProxyHandler);
+export default formbricksApp;


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

Adds global error handling support for the `@formbricks/js` package, currently if anything goes wrong, the package throws errors which can block the client application in the worst case. This is fixed by returning a `Result` type from the `loadSDK` method and just logging the error instead of throwing it.

Fixes [128](https://github.com/formbricks/internal/issues/128) (issue)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Throw an error from the `app.ts` or `website.ts` file in the `js` package
- The error should just be logged to the console and not thrown

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
