### PR TITLE
fix: fixes survey createdBy filtering for null createdBy surveys

### DIFF
--- a/packages/lib/survey/util.ts
+++ b/packages/lib/survey/util.ts
@@ -50,7 +50,18 @@ export const buildWhereClause = (filterCriteria?: TSurveyFilterCriteria) => {
         whereClause.push({ createdBy: filterCriteria.createdBy.userId });
       }
       if (filterCriteria.createdBy.value[0] === "others") {
-        whereClause.push({ createdBy: { not: filterCriteria.createdBy.userId } });
+        whereClause.push({
+          OR: [
+            {
+              createdBy: {
+                not: filterCriteria.createdBy.userId,
+              },
+            },
+            {
+              createdBy: null,
+            },
+          ],
+        });
       }
     }
   }


### PR DESCRIPTION
## What does this PR do?
- fixes survey createdBy filtering for null createdBy surveys

Fixes
https://github.com/formbricks/internal/issues/124

## How should this be tested?
- Add a new member to the team
- Create a survey using the invited user's account in the invited team.
- Remove the invited user from the team
- Delete the invited user's account
- Now the survey would have `null` in the createdBy.
- Do the survey filtering, and this survey should be visible under the `createdBy:Others` filter

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary