### PR TITLE
fix: remove white label info from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Additional to the AGPL licensed Formbricks core, this repository contains code l
 
 ### White-Labeling Formbricks and Other Licensing Needs
 
-If you have other licensing requirements such as White-Labeling please [send us an email](mailto:hola@formbricks.com).
+We currently do not offer Formbricks white-labeled. Any other needs? [Send us an email](mailto:hola@formbricks.com).
 
 ### Why charge for Enterprise Features?
 

--- a/apps/docs/app/self-hosting/license/page.mdx
+++ b/apps/docs/app/self-hosting/license/page.mdx
@@ -58,7 +58,7 @@ Additional to the AGPL licensed Formbricks core, this repository contains code l
 
 ## White-Labeling Formbricks and Other Licensing Needs
 
-If you have other licensing requirements such as White-Labeling please [send us an email](mailto:hola@formbricks.com).
+We currently do not offer Formbricks white-labeled. Any other needs? [Send us an email](mailto:hola@formbricks.com).
 
 ## Why charge for Enterprise Features?
 


### PR DESCRIPTION
fix: remove white label info from docs