### PR TITLE
fix: handles error in json input parsing in the management endpoints

### DIFF
--- a/apps/web/app/api/v1/management/action-classes/[actionClassId]/route.ts
+++ b/apps/web/app/api/v1/management/action-classes/[actionClassId]/route.ts
@@ -48,8 +48,16 @@ export const PUT = async (
     if (!actionClass) {
       return responses.notFoundResponse("Action Class", params.actionClassId);
     }
-    const actionCLassUpdate = await request.json();
-    const inputValidation = ZActionClassInput.safeParse(actionCLassUpdate);
+
+    let actionClassUpdate;
+    try {
+      actionClassUpdate = await request.json();
+    } catch (error) {
+      console.error(`Error parsing JSON: ${error}`);
+      return responses.badRequestResponse("Malformed JSON input, please check your request body");
+    }
+
+    const inputValidation = ZActionClassInput.safeParse(actionClassUpdate);
     if (!inputValidation.success) {
       return responses.badRequestResponse(
         "Fields are missing or incorrectly formatted",

--- a/apps/web/app/api/v1/management/action-classes/route.ts
+++ b/apps/web/app/api/v1/management/action-classes/route.ts
@@ -24,7 +24,15 @@ export const POST = async (request: Request): Promise<Response> => {
   try {
     const authentication = await authenticateRequest(request);
     if (!authentication) return responses.notAuthenticatedResponse();
-    const actionClassInput = await request.json();
+
+    let actionClassInput;
+    try {
+      actionClassInput = await request.json();
+    } catch (error) {
+      console.error(`Error parsing JSON input: ${error}`);
+      return responses.badRequestResponse("Malformed JSON input, please check your request body");
+    }
+
     const inputValidation = ZActionClassInput.safeParse(actionClassInput);
 
     if (!inputValidation.success) {

--- a/apps/web/app/api/v1/management/attribute-classes/[attributeClassId]/route.ts
+++ b/apps/web/app/api/v1/management/attribute-classes/[attributeClassId]/route.ts
@@ -73,7 +73,15 @@ export const PUT = async (
     if (!attributeClass) {
       return responses.notFoundResponse("Attribute Class", params.attributeClassId);
     }
-    const attributeClassUpdate = await request.json();
+
+    let attributeClassUpdate;
+    try {
+      attributeClassUpdate = await request.json();
+    } catch (error) {
+      console.error(`Error parsing JSON input: ${error}`);
+      return responses.badRequestResponse("Malformed JSON input, please check your request body");
+    }
+
     const inputValidation = ZAttributeClassUpdateInput.safeParse(attributeClassUpdate);
     if (!inputValidation.success) {
       return responses.badRequestResponse(

--- a/apps/web/app/api/v1/management/attribute-classes/route.ts
+++ b/apps/web/app/api/v1/management/attribute-classes/route.ts
@@ -24,7 +24,15 @@ export const POST = async (request: Request): Promise<Response> => {
   try {
     const authentication = await authenticateRequest(request);
     if (!authentication) return responses.notAuthenticatedResponse();
-    const attributeClassInput = await request.json();
+
+    let attributeClassInput;
+    try {
+      attributeClassInput = await request.json();
+    } catch (error) {
+      console.error(`Error parsing JSON input: ${error}`);
+      return responses.badRequestResponse("Malformed JSON input, please check your request body");
+    }
+
     const inputValidation = ZAttributeClassInput.safeParse(attributeClassInput);
 
     if (!inputValidation.success) {

--- a/apps/web/app/api/v1/management/responses/[responseId]/route.ts
+++ b/apps/web/app/api/v1/management/responses/[responseId]/route.ts
@@ -72,7 +72,14 @@ export const PUT = async (
     const authentication = await authenticateRequest(request);
     if (!authentication) return responses.notAuthenticatedResponse();
     await fetchAndValidateResponse(authentication, params.responseId);
-    const responseUpdate = await request.json();
+    let responseUpdate;
+    try {
+      responseUpdate = await request.json();
+    } catch (error) {
+      console.error(`Error parsing JSON: ${error}`);
+      return responses.badRequestResponse("Malformed JSON input, please check your request body");
+    }
+
     const inputValidation = ZResponseUpdateInput.safeParse(responseUpdate);
     if (!inputValidation.success) {
       return responses.badRequestResponse(

--- a/apps/web/app/api/v1/management/storage/route.ts
+++ b/apps/web/app/api/v1/management/storage/route.ts
@@ -14,7 +14,16 @@ import { getSignedUrlForPublicFile } from "./lib/getSignedUrl";
 // this api endpoint will return a signed url for uploading the file to s3 and another url for uploading file to the local storage
 
 export const POST = async (req: NextRequest): Promise<Response> => {
-  const { fileName, fileType, environmentId, allowedFileExtensions } = await req.json();
+  let storageInput;
+
+  try {
+    storageInput = await req.json();
+  } catch (error) {
+    console.error(`Error parsing JSON input: ${error}`);
+    return responses.badRequestResponse("Malformed JSON input, please check your request body");
+  }
+
+  const { fileName, fileType, environmentId, allowedFileExtensions } = storageInput;
 
   if (!fileName) {
     return responses.badRequestResponse("fileName is required");

--- a/apps/web/app/api/v1/management/surveys/[surveyId]/route.ts
+++ b/apps/web/app/api/v1/management/surveys/[surveyId]/route.ts
@@ -62,7 +62,13 @@ export const PUT = async (
     if (!survey) {
       return responses.notFoundResponse("Survey", params.surveyId);
     }
-    const surveyUpdate = await request.json();
+    let surveyUpdate;
+    try {
+      surveyUpdate = await request.json();
+    } catch (error) {
+      console.error(`Error parsing JSON input: ${error}`);
+      return responses.badRequestResponse("Malformed JSON input, please check your request body");
+    }
     const inputValidation = ZSurvey.safeParse({
       ...survey,
       ...surveyUpdate,

--- a/apps/web/app/api/v1/management/surveys/route.ts
+++ b/apps/web/app/api/v1/management/surveys/route.ts
@@ -30,7 +30,15 @@ export const POST = async (request: Request): Promise<Response> => {
   try {
     const authentication = await authenticateRequest(request);
     if (!authentication) return responses.notAuthenticatedResponse();
-    let surveyInput = await request.json();
+
+    let surveyInput;
+    try {
+      surveyInput = await request.json();
+    } catch (error) {
+      console.error(`Error parsing JSON: ${error}`);
+      return responses.badRequestResponse("Malformed JSON input, please check your request body");
+    }
+
     if (surveyInput?.questions && surveyInput.questions[0].headline) {
       const questionHeadline = surveyInput.questions[0].headline;
       if (typeof questionHeadline === "string") {


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

Fixes [formbricks/internal#185](https://github.com/formbricks/internal/issues/185)/
Adds a try catch block around all the json input parsing in the PUT and POST endpoints in the management api

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Send some malformed json input in any management PUT or POST endpoint
- The api should return a 400 bad request error and not a 500 internal server error

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
