### PR TITLE
fix: Multiple File Uploads in a row put all the files at the beginning

### DIFF
--- a/packages/surveys/src/components/general/FileInput.tsx
+++ b/packages/surveys/src/components/general/FileInput.tsx
@@ -7,7 +7,7 @@ import { getOriginalFileNameFromUrl } from "@formbricks/lib/storage/utils";
 import { TAllowedFileExtension } from "@formbricks/types/common";
 import { TUploadFileConfig } from "@formbricks/types/storage";
 
-interface MultipleFileInputProps {
+interface FileInputProps {
   allowedFileExtensions?: TAllowedFileExtension[];
   surveyId: string | undefined;
   onUploadCallback: (uploadedUrls: string[]) => void;
@@ -15,7 +15,7 @@ interface MultipleFileInputProps {
   fileUrls: string[] | undefined;
   maxSizeInMB?: number;
   allowMultipleFiles?: boolean;
-  uniqueId?: string;
+  htmlFor?: string;
 }
 
 export const FileInput = ({
@@ -26,8 +26,8 @@ export const FileInput = ({
   fileUrls,
   maxSizeInMB,
   allowMultipleFiles,
-  uniqueId = "",
-}: MultipleFileInputProps) => {
+  htmlFor = "",
+}: FileInputProps) => {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [isUploading, setIsUploading] = useState(false);
 
@@ -208,7 +208,7 @@ export const FileInput = ({
     return true;
   }, [allowMultipleFiles, fileUrls, isUploading]);
 
-  const uniqueIdForInput = useMemo(() => `selectedFile-${uniqueId}`, [uniqueId]);
+  const uniqueHtmlFor = useMemo(() => `selectedFile-${htmlFor}`, [htmlFor]);
 
   return (
     <div
@@ -263,13 +263,13 @@ export const FileInput = ({
       <div>
         {isUploading && (
           <div className="inset-0 flex animate-pulse items-center justify-center rounded-lg py-4">
-            <label htmlFor={uniqueIdForInput} className="text-subheading text-sm font-medium">
+            <label htmlFor={uniqueHtmlFor} className="text-subheading text-sm font-medium">
               Uploading...
             </label>
           </div>
         )}
 
-        <label htmlFor={uniqueIdForInput} onDragOver={(e) => handleDragOver(e)} onDrop={(e) => handleDrop(e)}>
+        <label htmlFor={uniqueHtmlFor} onDragOver={(e) => handleDragOver(e)} onDrop={(e) => handleDrop(e)}>
           {showUploader && (
             <div
               className="focus:outline-brand flex flex-col items-center justify-center py-6 hover:cursor-pointer"
@@ -278,8 +278,8 @@ export const FileInput = ({
                 // Accessibility: if spacebar was pressed pass this down to the input
                 if (e.key === " ") {
                   e.preventDefault();
-                  document.getElementById(uniqueIdForInput)?.click();
-                  document.getElementById(uniqueIdForInput)?.focus();
+                  document.getElementById(uniqueHtmlFor)?.click();
+                  document.getElementById(uniqueHtmlFor)?.focus();
                 }
               }}>
               <svg
@@ -301,8 +301,8 @@ export const FileInput = ({
               </p>
               <input
                 type="file"
-                id={uniqueIdForInput}
-                name={uniqueIdForInput}
+                id={uniqueHtmlFor}
+                name={uniqueHtmlFor}
                 accept={allowedFileExtensions?.map((ext) => `.${ext}`).join(",")}
                 className="hidden"
                 onChange={(e) => {

--- a/packages/surveys/src/components/general/FileInput.tsx
+++ b/packages/surveys/src/components/general/FileInput.tsx
@@ -15,6 +15,7 @@ interface MultipleFileInputProps {
   fileUrls: string[] | undefined;
   maxSizeInMB?: number;
   allowMultipleFiles?: boolean;
+  uniqueId?: string;
 }
 
 export const FileInput = ({
@@ -25,6 +26,7 @@ export const FileInput = ({
   fileUrls,
   maxSizeInMB,
   allowMultipleFiles,
+  uniqueId = "",
 }: MultipleFileInputProps) => {
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [isUploading, setIsUploading] = useState(false);
@@ -206,6 +208,8 @@ export const FileInput = ({
     return true;
   }, [allowMultipleFiles, fileUrls, isUploading]);
 
+  const uniqueIdForInput = useMemo(() => `selectedFile-${uniqueId}`, [uniqueId]);
+
   return (
     <div
       className={`items-left bg-input-bg hover:bg-input-bg-selected border-border relative mt-3 flex w-full flex-col justify-center rounded-lg border-2 border-dashed dark:border-slate-600 dark:bg-slate-700 dark:hover:border-slate-500 dark:hover:bg-slate-800`}>
@@ -259,13 +263,13 @@ export const FileInput = ({
       <div>
         {isUploading && (
           <div className="inset-0 flex animate-pulse items-center justify-center rounded-lg py-4">
-            <label htmlFor="selectedFile" className="text-subheading text-sm font-medium">
+            <label htmlFor={uniqueIdForInput} className="text-subheading text-sm font-medium">
               Uploading...
             </label>
           </div>
         )}
 
-        <label htmlFor="selectedFile" onDragOver={(e) => handleDragOver(e)} onDrop={(e) => handleDrop(e)}>
+        <label htmlFor={uniqueIdForInput} onDragOver={(e) => handleDragOver(e)} onDrop={(e) => handleDrop(e)}>
           {showUploader && (
             <div
               className="focus:outline-brand flex flex-col items-center justify-center py-6 hover:cursor-pointer"
@@ -274,8 +278,8 @@ export const FileInput = ({
                 // Accessibility: if spacebar was pressed pass this down to the input
                 if (e.key === " ") {
                   e.preventDefault();
-                  document.getElementById("selectedFile")?.click();
-                  document.getElementById("selectedFile")?.focus();
+                  document.getElementById(uniqueIdForInput)?.click();
+                  document.getElementById(uniqueIdForInput)?.focus();
                 }
               }}>
               <svg
@@ -297,8 +301,8 @@ export const FileInput = ({
               </p>
               <input
                 type="file"
-                id="selectedFile"
-                name="selectedFile"
+                id={uniqueIdForInput}
+                name={uniqueIdForInput}
                 accept={allowedFileExtensions?.map((ext) => `.${ext}`).join(",")}
                 className="hidden"
                 onChange={(e) => {

--- a/packages/surveys/src/components/questions/FileUploadQuestion.tsx
+++ b/packages/surveys/src/components/questions/FileUploadQuestion.tsx
@@ -85,6 +85,7 @@ export const FileUploadQuestion = ({
             questionId={question.id}
           />
           <FileInput
+            uniqueId={question.id}
             surveyId={surveyId}
             onFileUpload={onFileUpload}
             onUploadCallback={(urls: string[]) => {

--- a/packages/surveys/src/components/questions/FileUploadQuestion.tsx
+++ b/packages/surveys/src/components/questions/FileUploadQuestion.tsx
@@ -85,7 +85,7 @@ export const FileUploadQuestion = ({
             questionId={question.id}
           />
           <FileInput
-            uniqueId={question.id}
+            htmlFor={question.id}
             surveyId={surveyId}
             onFileUpload={onFileUpload}
             onUploadCallback={(urls: string[]) => {

--- a/packages/ui/FileInput/index.tsx
+++ b/packages/ui/FileInput/index.tsx
@@ -42,7 +42,7 @@ interface SelectedFile {
   uploaded: Boolean;
 }
 
-export const FileInput: React.FC<FileInputProps> = ({
+export const FileInput = ({
   id,
   allowedFileExtensions,
   environmentId,
@@ -53,7 +53,7 @@ export const FileInput: React.FC<FileInputProps> = ({
   imageFit = "cover",
   maxSizeInMB,
   isVideoAllowed = false,
-}) => {
+}: FileInputProps) => {
   const [selectedFiles, setSelectedFiles] = useState<SelectedFile[]>([]);
   const [uploadedVideoUrl, setUploadedVideoUrl] = useState(videoUrl ?? "");
   const [activeTab, setActiveTab] = useState(videoUrl ? "video" : "image");


### PR DESCRIPTION
## What does this PR do?
- Multiple File Uploads in a row put all the files at the beginning
- Adds uniqueId prop to FileInput component

Fixes https://github.com/formbricks/formbricks/issues/2596

https://github.com/formbricks/formbricks/assets/56182734/fa51fbcf-e8c2-4f3c-bd85-6373329a2bc3


## How should this be tested?
- Create a survey with a few file upload-type questions(especially enable multi-file upload for a few)
- All questions should keep track of the uploaded files into it

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
