### PR TITLE
fix: case insensitive multi langauge check

### DIFF
--- a/apps/web/app/s/[surveyId]/page.tsx
+++ b/apps/web/app/s/[surveyId]/page.tsx
@@ -129,7 +129,10 @@ const Page = async ({ params, searchParams }: LinkSurveyPageProps) => {
     if (!langParam || !isMultiLanguageAllowed) return "default";
     else {
       const selectedLanguage = survey.languages.find((surveyLanguage) => {
-        return surveyLanguage.language.code === langParam || surveyLanguage.language.alias === langParam;
+        return (
+          surveyLanguage.language.code === langParam.toLowerCase() ||
+          surveyLanguage.language.alias?.toLowerCase() === langParam.toLowerCase()
+        );
       });
       if (selectedLanguage?.default || !selectedLanguage?.enabled) {
         return "default";

--- a/packages/js-core/src/shared/utils.ts
+++ b/packages/js-core/src/shared/utils.ts
@@ -9,7 +9,10 @@ export const getLanguageCode = (survey: TSurvey, attributes: TAttributes): strin
   if (!language) return "default";
   else {
     const selectedLanguage = survey.languages.find((surveyLanguage) => {
-      return surveyLanguage.language.code === language || surveyLanguage.language.alias === language;
+      return (
+        surveyLanguage.language.code === language.toLowerCase() ||
+        surveyLanguage.language.alias?.toLowerCase() === language.toLowerCase()
+      );
     });
     if (selectedLanguage?.default) {
       return "default";


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/formbricks/internal/issues/199

Initially id user sets the language attribute to EN, it didnt show survey in english because we used lower case language codes. Now we first convert language parameter to lowercase and then compare with language code/alias

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Test uppercase language codes

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary
