### PR TITLE
chore: rename responses to completed in stats card

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SummaryMetadata.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SummaryMetadata.tsx
@@ -1,5 +1,4 @@
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
-
 import { TSurveySummary } from "@formbricks/types/surveys";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@formbricks/ui/Tooltip";
 
@@ -73,7 +72,7 @@ export const SummaryMetadata = ({ setShowDropOffs, showDropOffs, surveySummary }
           tooltipText="Number of times the survey has been started."
         />
         <StatCard
-          label="Responses"
+          label="Completed"
           percentage={`${Math.round(completedPercentage)}%`}
           value={completedResponses === 0 ? <span>-</span> : completedResponses}
           tooltipText="Number of times the survey has been completed."

--- a/apps/web/playwright/js.spec.ts
+++ b/apps/web/playwright/js.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from "@playwright/test";
-
 import { finishOnboarding, login, replaceEnvironmentIdInHtml, signUpAndLogin } from "./utils/helper";
 import { users } from "./utils/mock";
 
@@ -131,7 +130,7 @@ test.describe("JS Package Test", async () => {
 
     // Survey should have 1 Response
     await page.waitForTimeout(1000);
-    await expect(page.getByRole("button", { name: "Responses50%" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Completed50%" })).toBeVisible();
     await expect(page.getByText("1 Responses", { exact: true }).first()).toBeVisible();
     await expect(page.getByText("CTR50%")).toBeVisible();
     await expect(page.getByText("Somewhat disappointed100%")).toBeVisible();

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "engines": {
     "node": ">=16.0.0"
   },
-  "packageManager": "pnpm@9.2.0",
+  "packageManager": "pnpm@9.3.0",
   "nextBundleAnalysis": {
     "budget": 358400,
     "budgetPercentIncreaseRed": 20,


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

rename responses to completed in stats card

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
