### PR TITLE
fix: fixes notification subscription based on user membership

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/actions.ts
@@ -17,6 +17,7 @@ import {
   OperationNotAllowedError,
   ResourceNotFoundError,
 } from "@formbricks/types/errors";
+import { TUserNotificationSettings } from "@formbricks/types/user";
 
 export const createShortUrlAction = async (url: string) => {
   const session = await getServerSession(authOptions);
@@ -54,7 +55,7 @@ export const createOrganizationAction = async (organizationName: string): Promis
     name: "My Product",
   });
 
-  const updatedNotificationSettings = {
+  const updatedNotificationSettings: TUserNotificationSettings = {
     ...session.user.notificationSettings,
     alert: {
       ...session.user.notificationSettings?.alert,
@@ -63,6 +64,9 @@ export const createOrganizationAction = async (organizationName: string): Promis
       ...session.user.notificationSettings?.weeklySummary,
       [product.id]: true,
     },
+    unsubscribedOrganizationIds: Array.from(
+      new Set([...(session.user.notificationSettings?.unsubscribedOrganizationIds || []), newOrganization.id])
+    ),
   };
 
   await updateUser(session.user.id, {

--- a/apps/web/app/(auth)/invite/page.tsx
+++ b/apps/web/app/(auth)/invite/page.tsx
@@ -85,7 +85,18 @@ const Page = async ({ searchParams }) => {
         session.user?.name ?? "",
         invite.creator.email
       );
-      await updateUser(session.user.id, { onboardingCompleted: true });
+      await updateUser(session.user.id, {
+        onboardingCompleted: true,
+        notificationSettings: {
+          ...session.user.notificationSettings,
+          unsubscribedOrganizationIds: Array.from(
+            new Set([
+              ...(session.user.notificationSettings?.unsubscribedOrganizationIds || []),
+              invite.organizationId,
+            ])
+          ),
+        },
+      });
       return (
         <ContentLayout headline="You’re in 🎉" description="Welcome to the organization.">
           <Button variant="darkCTA" href="/">

--- a/apps/web/app/setup/organization/create/actions.ts
+++ b/apps/web/app/setup/organization/create/actions.ts
@@ -44,6 +44,9 @@ export const createOrganizationAction = async (organizationName: string): Promis
       ...session.user.notificationSettings?.weeklySummary,
       [product.id]: true,
     },
+    unsubscribedOrganizationIds: Array.from(
+      new Set([...(session.user.notificationSettings?.unsubscribedOrganizationIds || []), newOrganization.id])
+    ),
   };
 
   await updateUser(session.user.id, {

--- a/packages/lib/authOptions.ts
+++ b/packages/lib/authOptions.ts
@@ -275,6 +275,23 @@ export const authOptions: NextAuthOptions = {
             ...account,
             userId: userProfile.id,
           });
+
+          const updatedNotificationSettings = {
+            ...userProfile.notificationSettings,
+            alert: {
+              ...userProfile.notificationSettings?.alert,
+            },
+            unsubscribedOrganizationIds: Array.from(
+              new Set([
+                ...(userProfile.notificationSettings?.unsubscribedOrganizationIds || []),
+                organization.id,
+              ])
+            ),
+          };
+
+          await updateUser(userProfile.id, {
+            notificationSettings: updatedNotificationSettings,
+          });
           return true;
         }
         // Without default organization assignment

--- a/packages/lib/survey/service.ts
+++ b/packages/lib/survey/service.ts
@@ -662,14 +662,14 @@ export const createSurvey = async (environmentId: string, surveyBody: TSurveyInp
       }),
     };
 
-    if (createdBy) {
-      await subscribeOrganizationMembersToSurveyResponses(survey.id, createdBy);
-    }
-
     surveyCache.revalidate({
       id: survey.id,
       environmentId: survey.environmentId,
     });
+
+    if (createdBy) {
+      await subscribeOrganizationMembersToSurveyResponses(survey.id, createdBy);
+    }
 
     return transformedSurvey;
   } catch (error) {

--- a/packages/lib/survey/service.ts
+++ b/packages/lib/survey/service.ts
@@ -662,7 +662,9 @@ export const createSurvey = async (environmentId: string, surveyBody: TSurveyInp
       }),
     };
 
-    await subscribeOrganizationMembersToSurveyResponses(environmentId, survey.id);
+    if (createdBy) {
+      await subscribeOrganizationMembersToSurveyResponses(survey.id, createdBy);
+    }
 
     surveyCache.revalidate({
       id: survey.id,


### PR DESCRIPTION
## What does this PR do?
fixes notification subscription based on user membership

Checklist:
1. New organisation:
    no one gets subscribed to the auto-subscribe
2. New product:
    only the product creator would get the weekly updates notifications
3. New survey:
     only survey creator gets subscribed to notifications, this should be subscribed to the product's creator as well, but we don't store that value.



Fixes
https://github.com/formbricks/internal/issues/239

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
