### PR TITLE
chore: only store actions on the server when enabled in environment

### DIFF
--- a/apps/web/app/api/v1/client/[environmentId]/actions/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/actions/route.ts
@@ -4,6 +4,7 @@ import { getAdvancedTargetingPermission } from "@formbricks/ee/lib/service";
 import { createAction } from "@formbricks/lib/action/service";
 import { IS_FORMBRICKS_CLOUD } from "@formbricks/lib/constants";
 import { getOrganizationByEnvironmentId } from "@formbricks/lib/organization/service";
+import { getHasEnvironmentActionSegment } from "@formbricks/lib/segment/service";
 import { ZActionInput } from "@formbricks/types/actions";
 
 interface Context {
@@ -42,6 +43,13 @@ export const POST = async (req: Request, context: Context): Promise<Response> =>
         return responses.successResponse({}, true);
         //return responses.badRequestResponse("Storing actions is only possible in a paid plan", {}, true);
       }
+    }
+
+    // Storing actions on the server is deprecated
+    // Only allow creating actions if the environment has a segment using actions
+    const hasEnvironmentActionSegment = await getHasEnvironmentActionSegment(context.params.environmentId);
+    if (!hasEnvironmentActionSegment) {
+      return responses.successResponse({}, true);
     }
 
     await createAction(inputValidation.data);

--- a/packages/lib/segment/service.ts
+++ b/packages/lib/segment/service.ts
@@ -705,3 +705,34 @@ export const evaluateSegment = async (
     throw error;
   }
 };
+
+// This function is used to check if the environment has a segment that uses actions
+export const getHasEnvironmentActionSegment = reactCache(
+  (environmentId: string): Promise<boolean> =>
+    cache(
+      async () => {
+        validateInputs([environmentId, ZId]);
+        const segments = await getSegments(environmentId);
+
+        if (!segments || !segments.length) {
+          return false;
+        }
+
+        let hasEnvironmentActionSegment = false;
+
+        for (let segment of segments) {
+          const hasActionFilter = JSON.stringify(segment.filters).includes(`"type":"action"`);
+          if (hasActionFilter) {
+            hasEnvironmentActionSegment = true;
+            break;
+          }
+        }
+
+        return hasEnvironmentActionSegment;
+      },
+      [`getHasActionSegment-${environmentId}`],
+      {
+        tags: [segmentCache.tag.byEnvironmentId(environmentId)],
+      }
+    )()
+);


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

Storing actions on the server will be deprecated soon. This PR changes the storing logic to only store actions on the server if environment has a segment requiring actions.