### PR TITLE
chore: deprecate action filtering in advanced targeting

### DIFF
--- a/apps/docs/app/app-surveys/advanced-targeting/page.mdx
+++ b/apps/docs/app/app-surveys/advanced-targeting/page.mdx
@@ -17,11 +17,17 @@ export const metadata = {
 
 # Advanced Targeting
 
-Advanced Targeting allows you to show surveys to the right group of people. You can target surveys based on user attributes, user events, and more instead of spraying and praying. This helps you get more relevant feedback and make data-driven decisions. All of this without writing a single line of code.
+<Note>
+  Targeting based on actions is deprecated in Advanced Targeting and will be removed soon. We recommend using
+  filters on user attributes to target the survey only to specific groups of users.
+</Note>
 
-<ResponsiveVideo title="Formbricks Multi-language Surveys"
- src="https://www.youtube-nocookie.com/embed/0BQp6N4cXzU?si=KeBM7G7Ch1xtrsOm&amp;controls=0" />
+Advanced Targeting allows you to show surveys to the right group of people. You can target surveys based on user attributes, device type, and more instead of spraying and praying. This helps you get more relevant feedback and make data-driven decisions. All of this without writing a single line of code.
 
+<ResponsiveVideo
+  title="Formbricks Multi-language Surveys"
+  src="https://www.youtube-nocookie.com/embed/0BQp6N4cXzU?si=KeBM7G7Ch1xtrsOm&amp;controls=0"
+/>
 
 ## How to setup Advanced Targeting
 

--- a/packages/ee/advanced-targeting/components/add-filter-modal.tsx
+++ b/packages/ee/advanced-targeting/components/add-filter-modal.tsx
@@ -245,16 +245,18 @@ export function AddFilterModal({
     icon?: React.ReactNode;
   }[] = [
     { id: "all", label: "All" },
-    { id: "actions", label: "Actions", icon: <MousePointerClick className="h-4 w-4" /> },
     { id: "attributes", label: "Person & Attributes", icon: <TagIcon className="h-4 w-4" /> },
     { id: "segments", label: "Segments", icon: <Users2Icon className="h-4 w-4" /> },
     { id: "devices", label: "Devices", icon: <MonitorSmartphoneIcon className="h-4 w-4" /> },
   ];
 
-  const devices = [
-    { id: "phone", name: "Phone" },
-    { id: "desktop", name: "Desktop" },
-  ];
+  const devices = useMemo(
+    () => [
+      { id: "phone", name: "Phone" },
+      { id: "desktop", name: "Desktop" },
+    ],
+    []
+  );
 
   const actionClassesFiltered = useMemo(() => {
     if (!searchValue) return actionClasses;


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Targeting based on actions is deprecated in Advanced Targeting and will be removed soon. We recommend using filters on user attributes to target the survey only to specific groups of users.

This PR only removes the option to select Actions in the Segment editor for new segments. Previously created segments based on actions are still working.

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->