### PR TITLE
fix: close tag input immediately on keydown and add tag button click

### DIFF
--- a/packages/ui/SingleResponseCard/components/ResponseTagsWrapper.tsx
+++ b/packages/ui/SingleResponseCard/components/ResponseTagsWrapper.tsx
@@ -91,6 +91,7 @@ export const ResponseTagsWrapper: React.FC<ResponseTagsWrapperProps> = ({
             tags={environmentTags?.map((tag) => ({ value: tag.id, label: tag.name })) ?? []}
             currentTags={tagsState.map((tag) => ({ value: tag.tagId, label: tag.tagName }))}
             createTag={async (tagName) => {
+              setOpen(false);
               await createTagAction(environmentId, tagName?.trim() ?? "")
                 .then((tag) => {
                   setTagsState((prevTags) => [
@@ -103,7 +104,6 @@ export const ResponseTagsWrapper: React.FC<ResponseTagsWrapperProps> = ({
                   createTagToResponeAction(responseId, tag.id).then(() => {
                     updateFetchedResponses();
                     setSearchValue("");
-                    setOpen(false);
                   });
                 })
                 .catch((err) => {
@@ -119,7 +119,6 @@ export const ResponseTagsWrapper: React.FC<ResponseTagsWrapperProps> = ({
                   }
 
                   setSearchValue("");
-                  setOpen(false);
                 });
             }}
             addTag={(tagId) => {


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)
[BUG] Tag input appears soon after a tag is created #2884


https://github.com/user-attachments/assets/c3c866c3-5c03-46c1-8467-c4a62e965b06


<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Create a Survey and Publish it
- Complete the survey which will send a response for the created survey
- Once the response is received, head back to the survey in dashboard and check the responses for the survey.
for the received response add a tag
- Before when adding a tag a text box appeared even after button click or keydown press, but now the text box doesnt appear as the box disappears as soon click or keydown events occur for this action (The promise was taking time to update the state)

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [X] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [X] Ran `pnpm build`
- [] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues
- [X] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [X] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
