### PR TITLE
fix: add delete confirmation modal before deleting tags

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/product/tags/components/EditTagsWrapper.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/product/tags/components/EditTagsWrapper.tsx
@@ -19,7 +19,7 @@ import { EmptySpaceFiller } from "@formbricks/ui/EmptySpaceFiller";
 import { Input } from "@formbricks/ui/Input";
 import { LoadingSpinner } from "@formbricks/ui/LoadingSpinner";
 
-interface TEditTagsWrapperProps {
+interface EditTagsWrapperProps {
   environment: TEnvironment;
   environmentTags: TTag[];
   environmentTagsCount: TTagsCount;
@@ -153,7 +153,7 @@ const SingleTag: React.FC<{
   );
 };
 
-export const EditTagsWrapper: React.FC<TEditTagsWrapperProps> = (props) => {
+export const EditTagsWrapper: React.FC<EditTagsWrapperProps> = (props) => {
   const { environment, environmentTags, environmentTagsCount } = props;
   return (
     <div className="">

--- a/apps/web/app/(app)/environments/[environmentId]/product/tags/components/EditTagsWrapper.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/product/tags/components/EditTagsWrapper.tsx
@@ -19,7 +19,7 @@ import { EmptySpaceFiller } from "@formbricks/ui/EmptySpaceFiller";
 import { Input } from "@formbricks/ui/Input";
 import { LoadingSpinner } from "@formbricks/ui/LoadingSpinner";
 
-interface IEditTagsWrapperProps {
+interface TEditTagsWrapperProps {
   environment: TEnvironment;
   environmentTags: TTag[];
   environmentTagsCount: TTagsCount;
@@ -41,8 +41,6 @@ const SingleTag: React.FC<{
   environmentTags,
 }) => {
   const router = useRouter();
-  // const { updateTag, updateTagError } = useUpdateTag(environment.id, tagId);
-  // const { mergeTags, isMergingTags } = useMergeTags(environment.id);
   const [updateTagError, setUpdateTagError] = useState(false);
   const [isMergingTags, setIsMergingTags] = useState(false);
   const [openDeleteTagDialog, setOpenDeleteTagDialog] = useState(false);
@@ -50,7 +48,7 @@ const SingleTag: React.FC<{
   const confirmDeleteTag = () => {
     deleteTagAction(tagId)
       .then((response) => {
-        toast.success(`${response?.name ?? "Tag"} deleted`);
+        toast.success(`${response?.name ?? "Tag"} tag deleted`);
         updateTagsCount();
         router.refresh();
       })
@@ -155,7 +153,7 @@ const SingleTag: React.FC<{
   );
 };
 
-export const EditTagsWrapper: React.FC<IEditTagsWrapperProps> = (props) => {
+export const EditTagsWrapper: React.FC<TEditTagsWrapperProps> = (props) => {
   const { environment, environmentTags, environmentTagsCount } = props;
   return (
     <div className="">

--- a/apps/web/app/(app)/environments/[environmentId]/product/tags/components/EditTagsWrapper.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/product/tags/components/EditTagsWrapper.tsx
@@ -14,6 +14,7 @@ import { cn } from "@formbricks/lib/cn";
 import { TEnvironment } from "@formbricks/types/environment";
 import { TTag, TTagsCount } from "@formbricks/types/tags";
 import { Button } from "@formbricks/ui/Button";
+import { DeleteDialog } from "@formbricks/ui/DeleteDialog";
 import { EmptySpaceFiller } from "@formbricks/ui/EmptySpaceFiller";
 import { Input } from "@formbricks/ui/Input";
 import { LoadingSpinner } from "@formbricks/ui/LoadingSpinner";
@@ -44,6 +45,19 @@ const SingleTag: React.FC<{
   // const { mergeTags, isMergingTags } = useMergeTags(environment.id);
   const [updateTagError, setUpdateTagError] = useState(false);
   const [isMergingTags, setIsMergingTags] = useState(false);
+  const [openDeleteTagDialog, setOpenDeleteTagDialog] = useState(false);
+
+  const confirmDeleteTag = () => {
+    deleteTagAction(tagId)
+      .then((response) => {
+        toast.success(`${response?.name ?? "Tag"} deleted`);
+        updateTagsCount();
+        router.refresh();
+      })
+      .catch((error) => {
+        toast.error(error?.message ?? "Something went wrong");
+      });
+  };
 
   return (
     <div className="w-full" key={tagId}>
@@ -124,17 +138,16 @@ const SingleTag: React.FC<{
               size="sm"
               // loading={isDeletingTag}
               className="font-medium text-slate-50 focus:border-transparent focus:shadow-transparent focus:outline-transparent focus:ring-0 focus:ring-transparent"
-              onClick={() => {
-                if (confirm("Are you sure you want to delete this tag?")) {
-                  deleteTagAction(tagId).then(() => {
-                    toast.success("Tag deleted");
-                    updateTagsCount();
-                    router.refresh();
-                  });
-                }
-              }}>
+              onClick={() => setOpenDeleteTagDialog(true)}>
               Delete
             </Button>
+            <DeleteDialog
+              open={openDeleteTagDialog}
+              setOpen={setOpenDeleteTagDialog}
+              deleteWhat={tagName}
+              text="Are you sure you want to delete this tag?"
+              onDelete={confirmDeleteTag}
+            />
           </div>
         </div>
       </div>

--- a/packages/ui/SingleResponseCard/components/ResponseTagsWrapper.tsx
+++ b/packages/ui/SingleResponseCard/components/ResponseTagsWrapper.tsx
@@ -91,6 +91,7 @@ export const ResponseTagsWrapper: React.FC<ResponseTagsWrapperProps> = ({
             tags={environmentTags?.map((tag) => ({ value: tag.id, label: tag.name })) ?? []}
             currentTags={tagsState.map((tag) => ({ value: tag.tagId, label: tag.tagName }))}
             createTag={async (tagName) => {
+              setOpen(false);
               await createTagAction(environmentId, tagName?.trim() ?? "")
                 .then((tag) => {
                   setTagsState((prevTags) => [
@@ -103,7 +104,6 @@ export const ResponseTagsWrapper: React.FC<ResponseTagsWrapperProps> = ({
                   createTagToResponeAction(responseId, tag.id).then(() => {
                     updateFetchedResponses();
                     setSearchValue("");
-                    setOpen(false);
                   });
                 })
                 .catch((err) => {
@@ -119,7 +119,6 @@ export const ResponseTagsWrapper: React.FC<ResponseTagsWrapperProps> = ({
                   }
 
                   setSearchValue("");
-                  setOpen(false);
                 });
             }}
             addTag={(tagId) => {

--- a/packages/ui/SingleResponseCard/components/ResponseTagsWrapper.tsx
+++ b/packages/ui/SingleResponseCard/components/ResponseTagsWrapper.tsx
@@ -91,7 +91,6 @@ export const ResponseTagsWrapper: React.FC<ResponseTagsWrapperProps> = ({
             tags={environmentTags?.map((tag) => ({ value: tag.id, label: tag.name })) ?? []}
             currentTags={tagsState.map((tag) => ({ value: tag.tagId, label: tag.tagName }))}
             createTag={async (tagName) => {
-              setOpen(false);
               await createTagAction(environmentId, tagName?.trim() ?? "")
                 .then((tag) => {
                   setTagsState((prevTags) => [
@@ -104,6 +103,7 @@ export const ResponseTagsWrapper: React.FC<ResponseTagsWrapperProps> = ({
                   createTagToResponeAction(responseId, tag.id).then(() => {
                     updateFetchedResponses();
                     setSearchValue("");
+                    setOpen(false);
                   });
                 })
                 .catch((err) => {
@@ -119,6 +119,7 @@ export const ResponseTagsWrapper: React.FC<ResponseTagsWrapperProps> = ({
                   }
 
                   setSearchValue("");
+                  setOpen(false);
                 });
             }}
             addTag={(tagId) => {


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?
Delete Confirmation modal before deleting a tag. This is a replacement to the alert message before deleting the tag.

https://github.com/user-attachments/assets/2674ff91-b37c-41e1-8bad-30104131a590



<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # (issue)
[BUG] Delete tags not working once merge operation is completed. #2886


<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Select the survey
- Click on Responses Tab
- Click on the settings icon
- Delete any tag
- The Delete Confirmation Modal appears with the tag name which you want to delete
- Once you click on delete the tag will be deleted

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [X] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [X] Ran `pnpm build`
- [X] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [X] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
