### PR TITLE
fix: Dissmissed responses are (but should not be) counted in the summary graph

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/RatingSummary.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/RatingSummary.tsx
@@ -62,23 +62,15 @@ export const RatingSummary = ({ questionSummary, survey, attributeClasses }: Rat
         ))}
       </div>
       {questionSummary.dismissed && questionSummary.dismissed.count > 0 && (
-        <div className="rounded-b-lg border-t bg-white px-6 pb-6 pt-4">
+        <div className="rounded-b-lg border-t bg-white px-6 py-4">
           <div key="dismissed">
-            <div className="text flex justify-between px-2 pb-2">
-              <div className="mr-8 flex space-x-1">
-                <p className="font-semibold text-slate-700">dismissed</p>
-                <div>
-                  <p className="rounded-lg bg-slate-100 px-2 text-slate-700">
-                    {convertFloatToNDecimal(questionSummary.dismissed.percentage, 1)}%
-                  </p>
-                </div>
-              </div>
+            <div className="text flex justify-between px-2">
+              <p className="font-semibold text-slate-700">dismissed</p>
               <p className="flex w-32 items-end justify-end text-slate-600">
                 {questionSummary.dismissed.count}{" "}
                 {questionSummary.dismissed.count === 1 ? "response" : "responses"}
               </p>
             </div>
-            <ProgressBar barColor="bg-slate-600" progress={questionSummary.dismissed.percentage / 100} />
           </div>
         </div>
       )}

--- a/packages/lib/response/utils.ts
+++ b/packages/lib/response/utils.ts
@@ -867,7 +867,6 @@ export const getQuestionWiseSummary = (
             choiceCountMap[answer]++;
             totalRating += answer;
           } else if (response.ttc && response.ttc[question.id] > 0) {
-            totalResponseCount++;
             dismissed++;
           }
         });
@@ -884,13 +883,11 @@ export const getQuestionWiseSummary = (
         summary.push({
           type: question.type,
           question,
-          average: convertFloatTo2Decimal(totalRating / (totalResponseCount - dismissed)) || 0,
+          average: convertFloatTo2Decimal(totalRating / totalResponseCount) || 0,
           responseCount: totalResponseCount,
           choices: values,
           dismissed: {
             count: dismissed,
-            percentage:
-              totalResponseCount > 0 ? convertFloatTo2Decimal((dismissed / totalResponseCount) * 100) : 0,
           },
         });
 

--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -1085,7 +1085,6 @@ export const ZSurveyQuestionSummaryRating = z.object({
   ),
   dismissed: z.object({
     count: z.number(),
-    percentage: z.number(),
   }),
 });
 


### PR DESCRIPTION
## What does this PR do?
Dismissed responses are (but should not be) counted in the summary graph

Fixes #2908 

![image](https://github.com/user-attachments/assets/60d4b2a7-71ef-44ca-8a02-1d92a6827374)

## How should this be tested?

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
