### PR TITLE
chore: Add create product link in survey editor

### DIFF
--- a/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/HowToSendCard.tsx
+++ b/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/HowToSendCard.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { cn } from "@formbricks/lib/cn";
 import { TEnvironment } from "@formbricks/types/environment";
+import { TOrganization } from "@formbricks/types/organizations";
 import { TProduct } from "@formbricks/types/product";
 import { TSegment } from "@formbricks/types/segment";
 import { TSurvey, TSurveyType } from "@formbricks/types/surveys/types";
@@ -17,10 +18,17 @@ interface HowToSendCardProps {
   localSurvey: TSurvey;
   setLocalSurvey: (survey: TSurvey | ((TSurvey: TSurvey) => TSurvey)) => void;
   environment: TEnvironment;
+  organization: TOrganization;
   product: TProduct;
 }
 
-export const HowToSendCard = ({ localSurvey, setLocalSurvey, environment, product }: HowToSendCardProps) => {
+export const HowToSendCard = ({
+  localSurvey,
+  setLocalSurvey,
+  environment,
+  product,
+  organization,
+}: HowToSendCardProps) => {
   const [open, setOpen] = useState(false);
   const [appSetupCompleted, setAppSetupCompleted] = useState(false);
   const [websiteSetupCompleted, setWebsiteSetupCompleted] = useState(false);
@@ -215,12 +223,18 @@ export const HowToSendCard = ({ localSurvey, setLocalSurvey, environment, produc
           </RadioGroup>
         </div>
         {promotedFeaturesString && (
-          <div className="mt-2 flex items-center space-x-3 rounded-b-lg border border-slate-200 bg-slate-50/50 px-4 py-2">
-            <AlertCircleIcon className="h-5 w-5 text-slate-500" />
-            <div className="text-slate-500">
+          <div className="mt-2 flex items-center space-x-3 rounded-b-lg border border-slate-200 bg-slate-100 px-4 py-2">
+            🤓
+            <div className="ml-2 text-slate-500">
               <p className="text-xs">
-                You can also use Formbricks to run {promotedFeaturesString} surveys. Create a new product for
-                your {promotedFeaturesString} to use this feature.
+                You can also use Formbricks to run {promotedFeaturesString} surveys.{" "}
+                <Link
+                  target="_blank"
+                  href={`/organizations/${organization.id}/products/new/channel`}
+                  className="underline decoration-slate-400 underline-offset-2">
+                  Create a new product
+                </Link>{" "}
+                for your {promotedFeaturesString} to use this feature.
               </p>
             </div>
           </div>

--- a/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/HowToSendCard.tsx
+++ b/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/HowToSendCard.tsx
@@ -231,7 +231,7 @@ export const HowToSendCard = ({
                 <Link
                   target="_blank"
                   href={`/organizations/${organization.id}/products/new/channel`}
-                  className="underline decoration-slate-400 underline-offset-2">
+                  className="font-medium underline decoration-slate-400 underline-offset-2">
                   Create a new product
                 </Link>{" "}
                 for your {promotedFeaturesString} to use this feature.

--- a/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/SettingsView.tsx
+++ b/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/SettingsView.tsx
@@ -3,6 +3,7 @@ import { TActionClass } from "@formbricks/types/action-classes";
 import { TAttributeClass } from "@formbricks/types/attribute-classes";
 import { TEnvironment } from "@formbricks/types/environment";
 import { TMembershipRole } from "@formbricks/types/memberships";
+import { TOrganization } from "@formbricks/types/organizations";
 import { TProduct } from "@formbricks/types/product";
 import { TSegment } from "@formbricks/types/segment";
 import { TSurvey } from "@formbricks/types/surveys/types";
@@ -15,6 +16,7 @@ import { WhenToSendCard } from "./WhenToSendCard";
 
 interface SettingsViewProps {
   environment: TEnvironment;
+  organization: TOrganization;
   localSurvey: TSurvey;
   setLocalSurvey: (survey: TSurvey) => void;
   actionClasses: TActionClass[];
@@ -29,6 +31,7 @@ interface SettingsViewProps {
 
 export const SettingsView = ({
   environment,
+  organization,
   localSurvey,
   setLocalSurvey,
   actionClasses,
@@ -49,6 +52,7 @@ export const SettingsView = ({
         setLocalSurvey={setLocalSurvey}
         environment={environment}
         product={product}
+        organization={organization}
       />
 
       {localSurvey.type === "app" ? (

--- a/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/SurveyEditor.tsx
+++ b/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/SurveyEditor.tsx
@@ -8,6 +8,7 @@ import { TActionClass } from "@formbricks/types/action-classes";
 import { TAttributeClass } from "@formbricks/types/attribute-classes";
 import { TEnvironment } from "@formbricks/types/environment";
 import { TMembershipRole } from "@formbricks/types/memberships";
+import { TOrganization } from "@formbricks/types/organizations";
 import { TProduct } from "@formbricks/types/product";
 import { TSegment } from "@formbricks/types/segment";
 import { TSurvey, TSurveyEditorTabs, TSurveyStyling } from "@formbricks/types/surveys/types";
@@ -24,6 +25,7 @@ interface SurveyEditorProps {
   survey: TSurvey;
   product: TProduct;
   environment: TEnvironment;
+  organization: TOrganization;
   actionClasses: TActionClass[];
   attributeClasses: TAttributeClass[];
   segments: TSegment[];
@@ -40,6 +42,7 @@ export const SurveyEditor = ({
   survey,
   product,
   environment,
+  organization,
   actionClasses,
   attributeClasses,
   segments,
@@ -185,6 +188,7 @@ export const SurveyEditor = ({
             {activeView === "settings" && (
               <SettingsView
                 environment={environment}
+                organization={organization}
                 localSurvey={localSurvey}
                 setLocalSurvey={setLocalSurvey}
                 actionClasses={actionClasses}

--- a/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/page.tsx
+++ b/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/page.tsx
@@ -80,6 +80,7 @@ const Page = async ({ params }) => {
       attributeClasses={attributeClasses}
       responseCount={responseCount}
       membershipRole={currentUserMembership?.role}
+      organization={organization}
       colors={SURVEY_BG_COLORS}
       segments={segments}
       isUserTargetingAllowed={isUserTargetingAllowed}


### PR DESCRIPTION
problem: users don't understand that different types of apps allow for different types of surveys

step 1: make the "Create a new product" clickable so they find out faster

![image](https://github.com/user-attachments/assets/1f9b80b5-46ce-4051-b832-95bafbe918b3)
