### PR TITLE
fix: survey validation failing with custom questionId logic

### DIFF
--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -63,6 +63,31 @@ export enum TSurveyQuestionTypeEnum {
   Address = "address",
 }
 
+export const ZSurveyQuestionId = z.string().superRefine((id, ctx) => {
+  if (FORBIDDEN_IDS.includes(id)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `Question id is not allowed`,
+    });
+  }
+
+  if (id.includes(" ")) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Question id not allowed, avoid using spaces.",
+    });
+  }
+
+  if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Question id not allowed, use only alphanumeric characters, hyphens, or underscores.",
+    });
+  }
+});
+
+export type TSurveyQuestionId = z.infer<typeof ZSurveyQuestionId>;
+
 export const ZSurveyWelcomeCard = z
   .object({
     enabled: z.boolean(),
@@ -194,7 +219,7 @@ export type TSurveyLogicCondition = z.infer<typeof ZSurveyLogicCondition>;
 export const ZSurveyLogicBase = z.object({
   condition: ZSurveyLogicCondition.optional(),
   value: z.union([z.string(), z.array(z.string())]).optional(),
-  destination: z.string().optional(),
+  destination: ZSurveyQuestionId.optional(),
 });
 
 export const ZSurveyFileUploadLogic = ZSurveyLogicBase.extend({
@@ -294,28 +319,7 @@ export type TSurveyLogic = z.infer<typeof ZSurveyLogic>;
 export type TSurveyPictureSelectionLogic = z.infer<typeof ZSurveyPictureSelectionLogic>;
 
 export const ZSurveyQuestionBase = z.object({
-  id: z.string().superRefine((id, ctx) => {
-    if (FORBIDDEN_IDS.includes(id)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `Question id is not allowed`,
-      });
-    }
-
-    if (id.includes(" ")) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Question id not allowed, avoid using spaces.",
-      });
-    }
-
-    if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Question id not allowed, use only alphanumeric characters, hyphens, or underscores.",
-      });
-    }
-  }),
+  id: ZSurveyQuestionId,
   type: z.string(),
   headline: ZI18nString,
   subheader: ZI18nString.optional(),

--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -194,7 +194,7 @@ export type TSurveyLogicCondition = z.infer<typeof ZSurveyLogicCondition>;
 export const ZSurveyLogicBase = z.object({
   condition: ZSurveyLogicCondition.optional(),
   value: z.union([z.string(), z.array(z.string())]).optional(),
-  destination: z.string().cuid2().optional(),
+  destination: z.string().optional(),
 });
 
 export const ZSurveyFileUploadLogic = ZSurveyLogicBase.extend({


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

survey validation failing when custom questionId is set as a logic jump destination. This PR is re-allowing all valid strings as logic destination.

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
