### PR TITLE
fix: fix typo in self-hosting license page

### DIFF
--- a/apps/docs/app/self-hosting/license/page.mdx
+++ b/apps/docs/app/self-hosting/license/page.mdx
@@ -9,7 +9,7 @@ export const metadata = {
 
 ## Overview
 
-The Formbricks Core source code is licensed under AGPLv3 and available on GitHub. Additionally, we offer features for bigger organisations & enterprises for self-hostesr under a separate Enterprise License.
+The Formbricks Core source code is licensed under AGPLv3 and available on GitHub. Additionally, we offer features for bigger organisations & enterprises for self-hosters under a separate Enterprise License.
 
 <Note>
   Want to present a proof of concept? Request a free 30-day Enterprise Edition trial by [filling out the form


### PR DESCRIPTION
fix: fix typo in self-hosting license page