### PR TITLE
fix: use createdAt instead of updatedAt in responseCard

### DIFF
--- a/packages/lib/response/service.ts
+++ b/packages/lib/response/service.ts
@@ -114,7 +114,7 @@ export const getResponsesByPersonId = reactCache(
             take: page ? ITEMS_PER_PAGE : undefined,
             skip: page ? ITEMS_PER_PAGE * (page - 1) : undefined,
             orderBy: {
-              updatedAt: "asc",
+              createdAt: "desc",
             },
           });
 

--- a/packages/ui/SingleResponseCard/components/SingleResponseCardHeader.tsx
+++ b/packages/ui/SingleResponseCard/components/SingleResponseCardHeader.tsx
@@ -168,8 +168,8 @@ export const SingleResponseCardHeader = ({
         </div>
 
         <div className="flex items-center space-x-4 text-sm">
-          <time className="text-slate-500" dateTime={timeSince(response.updatedAt.toISOString())}>
-            {timeSince(response.updatedAt.toISOString())}
+          <time className="text-slate-500" dateTime={timeSince(response.createdAt.toISOString())}>
+            {timeSince(response.createdAt.toISOString())}
           </time>
           {user && !isViewer && (
             <TooltipRenderer shouldRender={!canResponseBeDeleted} tooltipContent={deleteSubmissionToolTip}>


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

To improve consistency among the dates used in Formbricks we now use the `createdAt` value in the single response card instead of the `updatedAt` value.