### PR TITLE
fix: Summary auto-update also queries when not in focus

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/components/SurveyAnalysisNavigation.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/components/SurveyAnalysisNavigation.tsx
@@ -92,9 +92,12 @@ export const SurveyAnalysisNavigation = ({
     if (totalResponseCount === null) return "";
     if (filteredResponseCount === null) return `(${totalResponseCount})`;
 
-    if (totalResponseCount === filteredResponseCount) return `(${totalResponseCount})`;
+    const filteredCount = filteredResponseCount;
+    const totalCount = Math.max(totalResponseCount, filteredResponseCount);
 
-    return `(${filteredResponseCount} of ${totalResponseCount})`;
+    if (totalCount === filteredCount) return `(${totalCount})`;
+
+    return `(${filteredCount} of ${totalCount})`;
   };
 
   const navigation = [

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/components/SurveyAnalysisNavigation.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/components/SurveyAnalysisNavigation.tsx
@@ -84,7 +84,8 @@ export const SurveyAnalysisNavigation = ({
       fetchFilteredResponseCount();
     },
     10000,
-    !isShareEmbedModalOpen
+    !isShareEmbedModalOpen,
+    false
   );
 
   const getResponseCountString = () => {

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/components/SurveyAnalysisNavigation.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/components/SurveyAnalysisNavigation.tsx
@@ -10,6 +10,7 @@ import { getResponseCountBySurveySharingKeyAction } from "@/app/share/[sharingKe
 import { InboxIcon, PresentationIcon } from "lucide-react";
 import { useParams, usePathname, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useIntervalWhenFocused } from "@formbricks/lib/utils/hooks/useIntervalWhenFocused";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { SecondaryNavigation } from "@formbricks/ui/SecondaryNavigation";
 
@@ -77,16 +78,14 @@ export const SurveyAnalysisNavigation = ({
     fetchFilteredResponseCount();
   }, [filters, isSharingPage, sharingKey, survey.id]);
 
-  useEffect(() => {
-    if (!isShareEmbedModalOpen) {
-      const interval = setInterval(() => {
-        fetchResponseCount();
-        fetchFilteredResponseCount();
-      }, 10000);
-
-      return () => clearInterval(interval);
-    }
-  }, [isShareEmbedModalOpen]);
+  useIntervalWhenFocused(
+    () => {
+      fetchResponseCount();
+      fetchFilteredResponseCount();
+    },
+    10000,
+    !isShareEmbedModalOpen
+  );
 
   const getResponseCountString = () => {
     if (totalResponseCount === null) return "";

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponsePage.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponsePage.tsx
@@ -131,7 +131,7 @@ export const ResponsePage = ({
       setResponseCount(responseCount);
     };
     handleResponsesCount();
-  }, [filters, isSharingPage, sharingKey, surveyId]);
+  }, [JSON.stringify(filters), isSharingPage, sharingKey, surveyId]);
 
   useEffect(() => {
     const fetchInitialResponses = async () => {
@@ -169,13 +169,13 @@ export const ResponsePage = ({
       }
     };
     fetchInitialResponses();
-  }, [surveyId, filters, responsesPerPage, sharingKey, isSharingPage]);
+  }, [surveyId, JSON.stringify(filters), responsesPerPage, sharingKey, isSharingPage]);
 
   useEffect(() => {
     setPage(1);
     setHasMore(true);
     setResponses([]);
-  }, [filters]);
+  }, [JSON.stringify(filters)]);
 
   return (
     <>

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SummaryPage.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SummaryPage.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/app/share/[sharingKey]/actions";
 import { useParams, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
-import useIntervalWhenFocused from "@formbricks/lib/utils/hooks/useIntervalWhenFocused";
+import { useIntervalWhenFocused } from "@formbricks/lib/utils/hooks/useIntervalWhenFocused";
 import { replaceHeadlineRecall } from "@formbricks/lib/utils/recall";
 import { TAttributeClass } from "@formbricks/types/attribute-classes";
 import { TEnvironment } from "@formbricks/types/environment";
@@ -121,14 +121,15 @@ export const SummaryPage = ({
 
   useEffect(() => {
     handleInitialData();
-  }, [filters, isSharingPage, sharingKey, surveyId]);
+  }, [JSON.stringify(filters), isSharingPage, sharingKey, surveyId]);
 
   useIntervalWhenFocused(
     () => {
       handleInitialData();
     },
     10000,
-    !isShareEmbedModalOpen
+    !isShareEmbedModalOpen,
+    false
   );
 
   const surveyMemoized = useMemo(() => {

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SummaryPage.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SummaryPage.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/app/share/[sharingKey]/actions";
 import { useParams, useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
+import useIntervalWhenFocused from "@formbricks/lib/utils/hooks/useIntervalWhenFocused";
 import { replaceHeadlineRecall } from "@formbricks/lib/utils/recall";
 import { TAttributeClass } from "@formbricks/types/attribute-classes";
 import { TEnvironment } from "@formbricks/types/environment";
@@ -122,15 +123,13 @@ export const SummaryPage = ({
     handleInitialData();
   }, [filters, isSharingPage, sharingKey, surveyId]);
 
-  useEffect(() => {
-    if (!isShareEmbedModalOpen) {
-      const interval = setInterval(() => {
-        handleInitialData();
-      }, 10000);
-
-      return () => clearInterval(interval);
-    }
-  }, [isShareEmbedModalOpen]);
+  useIntervalWhenFocused(
+    () => {
+      handleInitialData();
+    },
+    10000,
+    !isShareEmbedModalOpen
+  );
 
   const surveyMemoized = useMemo(() => {
     return replaceHeadlineRecall(survey, "default", attributeClasses);

--- a/packages/lib/utils/hooks/useIntervalWhenFocused.ts
+++ b/packages/lib/utils/hooks/useIntervalWhenFocused.ts
@@ -35,10 +35,8 @@ export const useIntervalWhenFocused = (
     window.addEventListener("focus", handleFocus);
     window.addEventListener("blur", handleBlur);
 
-    if (!intervalRef.current) {
-      // Handle initial focus
-      handleFocus();
-    }
+    // Handle initial focus
+    handleFocus();
 
     // Cleanup interval and event listeners when the component unmounts or dependencies change
     return () => {

--- a/packages/lib/utils/hooks/useIntervalWhenFocused.ts
+++ b/packages/lib/utils/hooks/useIntervalWhenFocused.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "react";
+
+export const useIntervalWhenFocused = (callback: () => void, intervalDuration: number, isActive: boolean) => {
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleFocus = () => {
+    if (isActive) {
+      // Execute the callback immediately when the tab comes into focus
+      callback();
+
+      // Set the interval to execute the callback every `intervalDuration` milliseconds
+      intervalRef.current = setInterval(() => {
+        callback();
+      }, intervalDuration);
+    }
+  };
+
+  const handleBlur = () => {
+    // Clear the interval when the tab loses focus
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    // Attach focus and blur event listeners
+    window.addEventListener("focus", handleFocus);
+    window.addEventListener("blur", handleBlur);
+
+    if (!intervalRef.current) {
+      // Handle initial focus
+      handleFocus();
+    }
+
+    // Cleanup interval and event listeners when the component unmounts or dependencies change
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+      window.removeEventListener("focus", handleFocus);
+      window.removeEventListener("blur", handleBlur);
+    };
+  }, [isActive, intervalDuration]);
+};
+
+export default useIntervalWhenFocused;

--- a/packages/lib/utils/hooks/useIntervalWhenFocused.ts
+++ b/packages/lib/utils/hooks/useIntervalWhenFocused.ts
@@ -1,12 +1,19 @@
 import { useEffect, useRef } from "react";
 
-export const useIntervalWhenFocused = (callback: () => void, intervalDuration: number, isActive: boolean) => {
+export const useIntervalWhenFocused = (
+  callback: () => void,
+  intervalDuration: number,
+  isActive: boolean,
+  shouldExecuteImmediately = true
+) => {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleFocus = () => {
     if (isActive) {
-      // Execute the callback immediately when the tab comes into focus
-      callback();
+      if (shouldExecuteImmediately) {
+        // Execute the callback immediately when the tab comes into focus
+        callback();
+      }
 
       // Set the interval to execute the callback every `intervalDuration` milliseconds
       intervalRef.current = setInterval(() => {


### PR DESCRIPTION
## What does this PR do?
- fixes Summary auto-update also queries when not in focus
- getSurveySummaryAction is called thrice on page load

Fixes 
https://github.com/formbricks/internal/issues/345
https://github.com/formbricks/internal/issues/343

## How should this be tested?
- There should be no background summary calls on survey summary page
- There should be only one summary call on page land as well as on auto-fetch

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
