### PR TITLE
feat: delete uploaded files with response deletion

### DIFF
--- a/packages/lib/response/service.ts
+++ b/packages/lib/response/service.ts
@@ -715,7 +715,7 @@ const findAndDeleteUploadedFilesInResponse = async (response: TResponse, survey:
         throw new Error(`Invalid file path: ${pathname}`);
       }
 
-      await deleteFile(environmentId, accessType as "private" | "public", fileName);
+      return deleteFile(environmentId, accessType as "private" | "public", fileName);
     } catch (error) {
       console.error(`Failed to delete file ${fileUrl}:`, error);
     }

--- a/packages/lib/response/service.ts
+++ b/packages/lib/response/service.ts
@@ -16,7 +16,7 @@ import {
   ZResponseInput,
   ZResponseUpdateInput,
 } from "@formbricks/types/responses";
-import { TSurveySummary } from "@formbricks/types/surveys/types";
+import { TSurvey, TSurveyQuestionTypeEnum, TSurveySummary } from "@formbricks/types/surveys/types";
 import { TTag } from "@formbricks/types/tags";
 import { getAttributes } from "../attribute/service";
 import { cache } from "../cache";
@@ -28,7 +28,7 @@ import { createPerson, getPersonByUserId } from "../person/service";
 import { sendPlanLimitsReachedEventToPosthogWeekly } from "../posthogServer";
 import { responseNoteCache } from "../responseNote/cache";
 import { getResponseNotes } from "../responseNote/service";
-import { putFile } from "../storage/service";
+import { deleteFile, putFile } from "../storage/service";
 import { getSurvey } from "../survey/service";
 import { captureTelemetry } from "../telemetry";
 import { convertToCsv, convertToXlsxBuffer } from "../utils/fileConversion";
@@ -697,6 +697,33 @@ export const updateResponse = async (
   }
 };
 
+const findAndDeleteUploadedFilesInResponse = async (response: TResponse, survey: TSurvey): Promise<void> => {
+  const fileUploadQuestions = new Set(
+    survey.questions.filter((q) => q.type === TSurveyQuestionTypeEnum.FileUpload).map((q) => q.id)
+  );
+
+  const fileUrls = Object.entries(response.data)
+    .filter(([questionId]) => fileUploadQuestions.has(questionId))
+    .flatMap(([, questionResponse]) => questionResponse as string[]);
+
+  const deletionPromises = fileUrls.map(async (fileUrl) => {
+    try {
+      const { pathname } = new URL(fileUrl);
+      const [, environmentId, accessType, fileName] = pathname.split("/").filter(Boolean);
+
+      if (!environmentId || !accessType || !fileName) {
+        throw new Error(`Invalid file path: ${pathname}`);
+      }
+
+      await deleteFile(environmentId, accessType as "private" | "public", fileName);
+    } catch (error) {
+      console.error(`Failed to delete file ${fileUrl}:`, error);
+    }
+  });
+
+  await Promise.all(deletionPromises);
+};
+
 export const deleteResponse = async (responseId: string): Promise<TResponse> => {
   validateInputs([responseId, ZId]);
   try {
@@ -717,6 +744,16 @@ export const deleteResponse = async (responseId: string): Promise<TResponse> => 
     deleteDisplayByResponseId(responseId, response.surveyId);
 
     const survey = await getSurvey(response.surveyId);
+
+    if (survey) {
+      await findAndDeleteUploadedFilesInResponse(
+        {
+          ...responsePrisma,
+          tags: responsePrisma.tags.map((tag) => tag.tag),
+        },
+        survey
+      );
+    }
 
     responseCache.revalidate({
       environmentId: survey?.environmentId,

--- a/packages/lib/response/service.ts
+++ b/packages/lib/response/service.ts
@@ -699,7 +699,9 @@ export const updateResponse = async (
 
 const findAndDeleteUploadedFilesInResponse = async (response: TResponse, survey: TSurvey): Promise<void> => {
   const fileUploadQuestions = new Set(
-    survey.questions.filter((q) => q.type === TSurveyQuestionTypeEnum.FileUpload).map((q) => q.id)
+    survey.questions
+      .filter((question) => question.type === TSurveyQuestionTypeEnum.FileUpload)
+      .map((q) => q.id)
   );
 
   const fileUrls = Object.entries(response.data)


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?
Fixes the bug that files with the responses did not get deleted when the response was deleted

Fixes https://github.com/formbricks/formbricks/issues/2950

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Fill out a survey with a file upload question
- Deleting the response should delete the file

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
