### PR TITLE
fix: update displays data migration run out of memory on many displays

### DIFF
--- a/packages/database/data-migrations/20240905120500_refactor_display_response_relationship/data-migration.ts
+++ b/packages/database/data-migrations/20240905120500_refactor_display_response_relationship/data-migration.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-console -- logging is allowed in migration scripts */
-// RAW QUERY ->
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
@@ -69,8 +68,9 @@ async function runMigration(): Promise<void> {
         .map((display) => display.id);
 
       if (displayIdsToDelete.length > 0) {
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions -- displayIdsToDelete is an array of strings
-        console.log(`Deleting ${displayIdsToDelete.length} displays where the response is missing...`);
+        console.log(
+          `Deleting ${displayIdsToDelete.length.toString()} displays where the response is missing...`
+        );
 
         await transactionPrisma.display.deleteMany({
           where: {

--- a/packages/database/data-migrations/20240905120500_refactor_display_response_relationship/data-migration.ts
+++ b/packages/database/data-migrations/20240905120500_refactor_display_response_relationship/data-migration.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console -- logging is allowed in migration scripts */
-import { type Prisma, PrismaClient } from "@prisma/client";
+import { type Display, PrismaClient, type Response } from "@prisma/client";
 
 const prisma = new PrismaClient();
 const BATCH_SIZE = 1000;
@@ -75,8 +75,8 @@ async function runMigration(): Promise<void> {
         const existingResponseIds = new Set(responses.map((response) => response.id));
 
         // Collect data for updates and deletions
-        const updateResponsePromises: Promise<Prisma.Response>[] = [];
-        const updateDisplayPromises: Promise<Prisma.Display>[] = [];
+        const updateResponsePromises: Promise<Response>[] = [];
+        const updateDisplayPromises: Promise<Display>[] = [];
         const displayIdsToDelete: string[] = [];
 
         for (const display of displays) {
@@ -120,21 +120,19 @@ async function runMigration(): Promise<void> {
         totalDisplaysUpdated += updateDisplayPromises.length;
 
         console.log(
-          `Batch processed: ${ 
-            String(updateResponsePromises.length) 
-            } responses transformed, ${ 
-            String(displayIdsToDelete.length) 
-            } displays deleted`
+          `Batch processed: ${String(updateResponsePromises.length)} responses transformed, ${String(
+            displayIdsToDelete.length
+          )} displays deleted`
         );
-        console.log(`Total displays updated so far: ${  String(totalDisplaysUpdated)}`);
+        console.log(`Total displays updated so far: ${String(totalDisplaysUpdated)}`);
 
         // Move to the next batch
         cursor = { id: displays[displays.length - 1].id };
       }
 
-      console.log(`${String(totalResponseTransformed)  } total responses transformed`);
-      console.log(`${String(totalDisplaysUpdated)  } total displays updated`);
-      console.log(`${String(totalDisplaysDeleted)  } total displays deleted`);
+      console.log(`${String(totalResponseTransformed)} total responses transformed`);
+      console.log(`${String(totalDisplaysUpdated)} total displays updated`);
+      console.log(`${String(totalDisplaysDeleted)} total displays deleted`);
     },
     {
       timeout: TRANSACTION_TIMEOUT,
@@ -142,7 +140,7 @@ async function runMigration(): Promise<void> {
   );
 
   const endTime = Date.now();
-  console.log(`Data migration completed. Total time: ${  ((endTime - startTime) / 1000).toFixed(2)  }s`);
+  console.log(`Data migration completed. Total time: ${((endTime - startTime) / 1000).toFixed(2)}s`);
 }
 
 function handleError(error: unknown): void {

--- a/packages/database/data-migrations/20240905120500_refactor_display_response_relationship/data-migration.ts
+++ b/packages/database/data-migrations/20240905120500_refactor_display_response_relationship/data-migration.ts
@@ -118,12 +118,7 @@ async function runMigration(): Promise<void> {
         totalDisplaysDeleted += displayIdsToDelete.length;
         totalDisplaysUpdated += displaysToUpdate.length;
 
-        console.log(
-          `Batch processed: ${String(updateResponsePromises.length)} responses transformed, ${String(
-            displayIdsToDelete.length
-          )} displays to be deleted`
-        );
-        console.log(`Total displays updated so far: ${String(totalDisplaysUpdated)}`);
+        console.log(`Batch processed. Total displays updated so far: ${String(totalDisplaysUpdated)}`);
 
         // Move to the next batch
         cursor = { id: displays[displays.length - 1].id };

--- a/packages/database/data-migrations/20240905120500_refactor_display_response_relationship/data-migration.ts
+++ b/packages/database/data-migrations/20240905120500_refactor_display_response_relationship/data-migration.ts
@@ -1,78 +1,188 @@
 /* eslint-disable no-console -- logging is allowed in migration scripts */
+// import { PrismaClient } from "@prisma/client";
+// const prisma = new PrismaClient();
+// async function runMigration(): Promise<void> {
+//   await prisma.$transaction(
+//     async (tx) => {
+//       const startTime = Date.now();
+//       console.log("Starting data migration...");
+//       // Fetch all displays
+//       const displays = await tx.display.findMany({
+//         where: {
+//           responseId: {
+//             not: null,
+//           },
+//         },
+//         select: {
+//           id: true,
+//           responseId: true,
+//           // response: {
+//           //   select: { id: true },
+//           // },
+//         },
+//       });
+//       if (displays.length === 0) {
+//         // Stop the migration if there are no Displays
+//         console.log("No Displays found");
+//         return;
+//       }
+//       console.log(`Total displays with responseId: ${displays.length.toString()}`);
+//       let totalResponseTransformed = 0;
+//       let totalDisplaysDeleted = 0;
+//       await Promise.all(
+//         displays.map(async (display) => {
+//           if (!display.responseId) {
+//             return Promise.resolve();
+//           }
+//           const response = await tx.response.findUnique({
+//             where: { id: display.responseId },
+//             select: { id: true },
+//           });
+//           if (response) {
+//             totalResponseTransformed++;
+//             return Promise.all([
+//               tx.response.update({
+//                 where: { id: response.id },
+//                 data: { display: { connect: { id: display.id } } },
+//               }),
+//               tx.display.update({
+//                 where: { id: display.id },
+//                 data: { responseId: null },
+//               }),
+//             ]);
+//           }
+//           totalDisplaysDeleted++;
+//           return tx.display.delete({
+//             where: { id: display.id },
+//           });
+//         })
+//       );
+//       console.log(`${totalResponseTransformed.toString()} responses transformed`);
+//       console.log(`${totalDisplaysDeleted.toString()} displays deleted`);
+//       const endTime = Date.now();
+//       console.log(`Data migration completed. Total time: ${((endTime - startTime) / 1000).toString()}s`);
+//     },
+//     {
+//       timeout: 300000, // 5 minutes
+//     }
+//   );
+// }
+// function handleError(error: unknown): void {
+//   console.error("An error occurred during migration:", error);
+//   process.exit(1);
+// }
+// function handleDisconnectError(): void {
+//   console.error("Failed to disconnect Prisma client");
+//   process.exit(1);
+// }
+// function main(): void {
+//   runMigration()
+//     .catch(handleError)
+//     .finally(() => {
+//       prisma.$disconnect().catch(handleDisconnectError);
+//     });
+// }
+// main();
 import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
+const BATCH_SIZE = 1000; // Adjust the batch size as needed
 
 async function runMigration(): Promise<void> {
-  await prisma.$transaction(
-    async (tx) => {
-      const startTime = Date.now();
-      console.log("Starting data migration...");
+  let totalResponseTransformed = 0;
+  let totalDisplaysDeleted = 0;
+  let skip = 0;
 
-      // Fetch all displays
-      const displays = await tx.display.findMany({
+  const startTime = Date.now();
+  console.log("Starting data migration...");
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, no-constant-condition -- We need a while loop
+  while (true) {
+    // Fetch displays in batches
+    const displays = await prisma.display.findMany({
+      where: {
+        responseId: {
+          not: null,
+        },
+      },
+      select: {
+        id: true,
+        responseId: true,
+      },
+      skip,
+      take: BATCH_SIZE, // Fetch in batches
+    });
+
+    if (displays.length === 0) {
+      console.log("No more displays found");
+      break;
+    }
+
+    console.log(`Processing batch of ${displays.length.toString()} displays...`);
+
+    // Declare local counters for the batch
+    let batchResponseTransformed = 0;
+    const displayIdsToDelete: string[] = [];
+
+    // Use Promise.all to parallelize updates within each batch
+    await Promise.all(
+      displays.map(async (display) => {
+        if (!display.responseId) {
+          return;
+        }
+
+        const response = await prisma.response.findUnique({
+          where: { id: display.responseId },
+          select: { id: true },
+        });
+
+        if (response) {
+          batchResponseTransformed++;
+          await Promise.all([
+            prisma.response.update({
+              where: { id: response.id },
+              data: { display: { connect: { id: display.id } } },
+            }),
+            prisma.display.update({
+              where: { id: display.id },
+              data: { responseId: null },
+            }),
+          ]);
+        } else {
+          // Collect display ids to be deleted later in one `deleteMany` call
+          displayIdsToDelete.push(display.id);
+        }
+      })
+    );
+
+    // If there are displays to delete, do it in one go with `deleteMany`
+    if (displayIdsToDelete.length > 0) {
+      await prisma.display.deleteMany({
         where: {
-          responseId: {
-            not: null,
+          id: {
+            in: displayIdsToDelete,
           },
         },
-        select: {
-          id: true,
-          responseId: true,
-        },
       });
-
-      if (displays.length === 0) {
-        // Stop the migration if there are no Displays
-        console.log("No Displays found");
-        return;
-      }
-
-      console.log(`Total displays with responseId: ${displays.length.toString()}`);
-
-      let totalResponseTransformed = 0;
-      let totalDisplaysDeleted = 0;
-      await Promise.all(
-        displays.map(async (display) => {
-          if (!display.responseId) {
-            return Promise.resolve();
-          }
-
-          const response = await tx.response.findUnique({
-            where: { id: display.responseId },
-            select: { id: true },
-          });
-
-          if (response) {
-            totalResponseTransformed++;
-            return Promise.all([
-              tx.response.update({
-                where: { id: response.id },
-                data: { display: { connect: { id: display.id } } },
-              }),
-              tx.display.update({
-                where: { id: display.id },
-                data: { responseId: null },
-              }),
-            ]);
-          }
-
-          totalDisplaysDeleted++;
-          return tx.display.delete({
-            where: { id: display.id },
-          });
-        })
-      );
-
-      console.log(`${totalResponseTransformed.toString()} responses transformed`);
-      console.log(`${totalDisplaysDeleted.toString()} displays deleted`);
-      const endTime = Date.now();
-      console.log(`Data migration completed. Total time: ${((endTime - startTime) / 1000).toString()}s`);
-    },
-    {
-      timeout: 300000, // 5 minutes
+      totalDisplaysDeleted += displayIdsToDelete.length;
     }
-  );
+
+    // After each batch, aggregate the local batch counts to the total counts
+    totalResponseTransformed += batchResponseTransformed;
+
+    console.log(
+      `Batch processed: ${batchResponseTransformed.toString()} responses transformed, ${displayIdsToDelete.length.toString()} displays deleted`
+    );
+
+    // Move to the next batch
+    skip += BATCH_SIZE;
+  }
+
+  console.log(`${totalResponseTransformed.toString()} total responses transformed`);
+  console.log(`${totalDisplaysDeleted.toString()} total displays deleted`);
+
+  const endTime = Date.now();
+  console.log(`Data migration completed. Total time: ${((endTime - startTime) / 1000).toString()}s`);
 }
 
 function handleError(error: unknown): void {


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

The data migration for migrating displays and responses to the new display <-> response relationship is running into memory issues on databases with many displays.
This PR fixes this by introducing batching for the data migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging with counters for transformed responses, deleted displays, and updated displays.
	- Increased transaction timeout to accommodate longer-running migrations.

- **Bug Fixes**
	- Improved error handling and performance tracking during the migration process.

- **Refactor**
	- Streamlined logic for updating and deleting displays, allowing for batch processing instead of a single transaction.
	- Improved clarity and maintainability of the migration function's structure, optimizing performance for handling larger datasets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->