### PR TITLE
fix: update lower-level license files to match main license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023 Formbricks GmbH
+Copyright (c) 2024 Formbricks GmbH
 
 Portions of this software are licensed as follows:
 

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ Copyright (c) 2024 Formbricks GmbH
 Portions of this software are licensed as follows:
 
 - All content that resides under the "packages/ee/" directory of this repository, if that directory exists, is licensed under the license defined in "packages/ee/LICENSE".
-- All content that resides under the "packages/js/", "packages/errors/" and "packages/api/" directories of this repository, if that directories exist, is licensed under the "MIT" license as defined in the "LICENSE" files of these packages.
+- All content that resides under the "packages/js/" and "packages/api/" directories of this repository, if that directories exist, is licensed under the "MIT" license as defined in the "LICENSE" files of these packages.
 - All third party components incorporated into the Formbricks Software are licensed under the original license provided by the owner of the applicable component.
 - Content outside of the above mentioned directories or restrictions above is available under the "AGPLv3" license as defined below.
 

--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ Copyright (c) 2024 Formbricks GmbH
 Portions of this software are licensed as follows:
 
 - All content that resides under the "packages/ee/" directory of this repository, if that directory exists, is licensed under the license defined in "packages/ee/LICENSE".
-- All content that resides under the "packages/js/" and "packages/api/" directories of this repository, if that directories exist, is licensed under the "MIT" license as defined in the "LICENSE" files of these packages.
+- All content that resides under the "packages/js/", "packages/react-native/" and "packages/api/" directories of this repository, if that directories exist, is licensed under the "MIT" license as defined in the "LICENSE" files of these packages.
 - All third party components incorporated into the Formbricks Software are licensed under the original license provided by the owner of the applicable component.
 - Content outside of the above mentioned directories or restrictions above is available under the "AGPLv3" license as defined below.
 

--- a/packages/api/LICENSE
+++ b/packages/api/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Formbricks GmbH
+Copyright (c) 2024 Formbricks GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/js/LICENSE
+++ b/packages/js/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Formbricks GmbH
+Copyright (c) 2024 Formbricks GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/packages/surveys/LICENSE
+++ b/packages/surveys/LICENSE
@@ -1,9 +1,0 @@
-MIT License
-
-Copyright (c) 2023 Formbricks GmbH
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
The main `LICENSE` file has the Formbricks licences correctly, but the lower level files inside the packages were partly wrong, leading to confusion about the licence.

This pull request includes updates to the license information across multiple files, ensuring the correct year and removing redundant license files.

Updates to license information:

* [`LICENSE`](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L1-R1): Updated the copyright year to 2024; add MIT licensed react-native package; remove legacy errors package reference.
* [`packages/api/LICENSE`](diffhunk://#diff-bf1278cc902919ca1e294cfb77a1d499896b47bbe4fbda755f977dfc11378e32L3-R3): Added MIT license file.
* [`packages/js/LICENSE`](diffhunk://#diff-bf1278cc902919ca1e294cfb77a1d499896b47bbe4fbda755f977dfc11378e32L3-R3): Updated the copyright year to 2024.

Removal of redundant license file:

* [`packages/surveys/LICENSE`](diffhunk://#diff-4fa626a70204f60a6e01a2173b0dbc42f6c23c944c12dc30d1a15eba68d32df2L1-L9): Removed MIT license file as already stated correctly in the main license file (AGPLv3)
* [`packages/surveys/LICENSE`](diffhunk://#diff-4fa626a70204f60a6e01a2173b0dbc42f6c23c944c12dc30d1a15eba68d32df2L1-L9): Removed the MIT licence file, as this is already correctly specified in the main licence file (AGPLv3).