### PR TITLE
fix: Incorrect Error Toast for Ending Card

### DIFF
--- a/packages/types/surveys/validation.ts
+++ b/packages/types/surveys/validation.ts
@@ -122,7 +122,8 @@ export const validateCardFieldsForAllLanguages = (
   // even if one of the keys is an empty string, its okay but it shouldn't be undefined
 
   const cardTypeLabel =
-    cardType === "welcome" ? "Welcome card" : `Redirect to Url ${((endingCardIndex ?? -1) + 1).toString()}`;
+    cardType === "welcome" ? "Welcome card" : `Ending card ${((endingCardIndex ?? -1) + 1).toString()}`; // Ensure 1-based indexing
+
   const path = cardType === "welcome" ? ["welcomeCard", field] : ["endings", endingCardIndex ?? -1, field];
 
   for (const language of languages) {
@@ -148,7 +149,7 @@ export const validateCardFieldsForAllLanguages = (
 
   const message = isDefaultOnly
     ? `${messagePrefix}${messageField} on the ${cardTypeLabel}${messageSuffix}`
-    : `${messagePrefix}${messageField} on the ${cardTypeLabel}${messageSuffix} -fLang- ${invalidLanguageCodes.join()}`;
+    : `${messagePrefix}${messageField} on the ${cardTypeLabel}${messageSuffix} -fLang- ${invalidLanguageCodes.join(", ")}`;
 
   if (invalidLanguageCodes.length) {
     return {


### PR DESCRIPTION
## What does this PR do?

This PR addresses the issue of incorrect error messages being displayed for ending cards when they are saved with missing fields. Specifically, it resolves the problem where the error toast incorrectly states "The note on the Redirect to Url 1 is missing" instead of the correct message for ending cards.

Fixes #3266 

[fix-wrong-error-toast-message-for-ending-card.webm](https://github.com/user-attachments/assets/ca969237-3a3d-4f43-8101-6e40a540fb7c)


## How should this be tested?

1. Create a survey with an ending card.
2. Erase the headline from the ending card.
3. Attempt to save the survey.
4. Verify that the toast error message

## Checklist

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [X] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [X] Ran `pnpm build`
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [X] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the label for ending cards to "Ending card" for better clarity.
	- Improved error message formatting for invalid language codes, enhancing readability.

- **Bug Fixes**
	- Corrected the context of card type labels to ensure accurate representation during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->