### PR TITLE
fix-build-error-while-running-on-gitpod

### DIFF
--- a/packages/surveys/src/components/questions/RankingQuestion.tsx
+++ b/packages/surveys/src/components/questions/RankingQuestion.tsx
@@ -57,7 +57,7 @@ export const RankingQuestion = ({
       const shuffledChoiceIds = getShuffledChoicesIds(question.choices, question.shuffleOption);
       return shuffledChoiceIds
         .map((choiceId) => question.choices.find((choice) => choice.id === choiceId))
-        .filter((choice) => choice !== undefined);
+        .filter((choice): choice is TSurveyQuestionChoice => choice !== undefined);
     }
   });
 

--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -2009,7 +2009,7 @@ const validateActions = (
     return undefined;
   });
 
-  const filteredActionIssues = actionIssues.filter((issue) => issue !== undefined);
+  const filteredActionIssues = actionIssues.filter((issue) => issue !== undefined) as z.ZodIssue[];
   return filteredActionIssues;
 };
 


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

This PR Resolves the Issue no. #3309 . 
When we run the project on the Gitpod then we get 2 error. kindly check the issue no. #3309 to get the more details regarding this issue.

Fixes # (issue)

Fixed the both issue. 

## How should this be tested?

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced type safety in the RankingQuestion component for better handling of survey question choices.
	- Introduced new types and refined existing types for survey creation and updates, improving validation logic.

- **Bug Fixes**
	- Improved error handling in validation functions for clearer feedback on invalid conditions and actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->