### PR TITLE
fix: sub-navigation sorting in docs

### DIFF
--- a/apps/docs/app/developer-docs/contributing/get-started/components/FAQ.tsx
+++ b/apps/docs/app/developer-docs/contributing/get-started/components/FAQ.tsx
@@ -43,7 +43,7 @@ const FAQ_DATA = [
         Absolutely! We provide an option for users to host Formbricks on their own server, ensuring even more
         control over data and compliance. And the best part? Self-hosting is available for free, always. For
         documentation on self hosting, click{" "}
-        <a href="/docs/self-hosting/deployment" className="text-brand-dark dark:text-brand-light">
+        <a href="/self-hosting/deployment" className="text-brand-dark dark:text-brand-light">
           here
         </a>
         .

--- a/apps/docs/app/developer-docs/contributing/get-started/page.mdx
+++ b/apps/docs/app/developer-docs/contributing/get-started/page.mdx
@@ -34,8 +34,8 @@ Once you open a PR, you will get a message from the CLA bot to fill out the form
 
 We currently officially support the below methods to set up your development environment for Formbricks:
 
-- [Gitpod](/docs/developer-docs/contributing/gitpod)
-- [GitHub Codespaces](/docs/developer-docs/contributing/codespaces)
+- [Gitpod](/developer-docs/contributing/gitpod)
+- [GitHub Codespaces](/developer-docs/contributing/codespaces)
 - [Local Machine Setup](#local-machine-setup)
 
 Both Gitpod and GitHub Codespaces have a **generous free tier** to explore and develop. For junior developers we suggest using either of these, because you can dive into coding within minutes, not hours.

--- a/apps/docs/components/Navigation.tsx
+++ b/apps/docs/components/Navigation.tsx
@@ -171,13 +171,6 @@ const NavigationGroup = ({
 
   const isParentOpen = (title: string) => openGroups.includes(title);
 
-  const sortedLinks = group.links.map((link) => {
-    if (link.children) {
-      link.children.sort((a, b) => a.title.localeCompare(b.title));
-    }
-    return link;
-  });
-
   return (
     <li className={clsx("relative mt-6", className)}>
       <motion.h2 layout="position" className="font-semibold text-slate-900 dark:text-white">
@@ -192,7 +185,7 @@ const NavigationGroup = ({
           {isActiveGroup && <ActivePageMarker group={group} pathname={pathname || "/docs"} />}
         </AnimatePresence>
         <ul role="list" className="border-l border-transparent">
-          {sortedLinks.map((link) => (
+          {group.links.map((link) => (
             <motion.li key={link.title} layout="position" className="relative">
               {link.href ? (
                 <NavLink


### PR DESCRIPTION
This pull request includes changes to improve the navigation and links in the documentation, ensuring a more consistent and user-friendly experience. The most important changes include updating broken links, removing unnecessary sorting of navigation links, and fixing the paths for self-hosting documentation.

Documentation link updates:

* [`apps/docs/app/developer-docs/contributing/get-started/components/FAQ.tsx`](diffhunk://#diff-5b27d0a4ce24ffd5a494c1bca98dbf5a6fb9dd2a07fed2c347b1d9652e9680ffL46-R46): Fixed the path for the self-hosting documentation link. (`/docs/self-hosting/deployment` to `/self-hosting/deployment`)
* [`apps/docs/app/developer-docs/contributing/get-started/page.mdx`](diffhunk://#diff-08f131b4e5595ad68b28e4ce8cd5f3780a583f1b922f882c87c31324b76832abL37-R38): Updated the paths for Gitpod and GitHub Codespaces links to remove `/docs`. (`/docs/developer-docs/contributing/gitpod` to `/developer-docs/contributing/gitpod`, `/docs/developer-docs/contributing/codespaces` to `/developer-docs/contributing/codespaces`)

Navigation improvements:

* [`apps/docs/components/Navigation.tsx`](diffhunk://#diff-5213f0fa3c37c8ea89d8cb7e5b1339fa369c4375bf13012eaae5d4143bb008abL174-L180): Removed the unnecessary sorting of navigation links within groups. [[1]](diffhunk://#diff-5213f0fa3c37c8ea89d8cb7e5b1339fa369c4375bf13012eaae5d4143bb008abL174-L180) [[2]](diffhunk://#diff-5213f0fa3c37c8ea89d8cb7e5b1339fa369c4375bf13012eaae5d4143bb008abL195-R188)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated FAQ component for easier navigation to self-hosting resources.
	- Enhanced the Formbricks Open Source Contribution Guide with clearer metadata and updated URL paths for Gitpod and GitHub Codespaces.

- **Bug Fixes**
	- Minor formatting and typographical corrections in documentation.

- **Refactor**
	- Simplified navigation handling in the Navigation component for improved performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->