### PR TITLE
fix: issue of triggering opening and closing question paper on clicking on submenu options

### DIFF
--- a/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/EditorCardMenu.tsx
+++ b/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/EditorCardMenu.tsx
@@ -166,7 +166,9 @@ export const EditorCardMenu = ({
           <div className="flex flex-col">
             {cardType === "question" && (
               <DropdownMenuSub>
-                <DropdownMenuSubTrigger className="cursor-pointer text-sm text-slate-600 hover:text-slate-700">
+                <DropdownMenuSubTrigger
+                  className="cursor-pointer text-sm text-slate-600 hover:text-slate-700"
+                  onClick={(e) => e.preventDefault()}>
                   Change question type
                 </DropdownMenuSubTrigger>
 
@@ -207,7 +209,9 @@ export const EditorCardMenu = ({
 
             {cardType === "question" && (
               <DropdownMenuSub>
-                <DropdownMenuSubTrigger className="cursor-pointer text-sm text-slate-600 hover:text-slate-700">
+                <DropdownMenuSubTrigger
+                  className="cursor-pointer text-sm text-slate-600 hover:text-slate-700"
+                  onClick={(e) => e.preventDefault()}>
                   Add question below
                 </DropdownMenuSubTrigger>
 


### PR DESCRIPTION
## What does this PR do?

Disabled the onClick option for the submenu options so that the question paper is not triggered when clicking on the options.

Fixes #3485


https://github.com/user-attachments/assets/e7e52eb9-fb75-4b75-a26d-db35a07968c8






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved user interaction in the Editor Card Menu with enhanced dropdown functionality for "Change question type" and "Add question below".
  
- **Bug Fixes**
	- Resolved issues with unintended dropdown behavior by adding event handlers to prevent default actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->