### PR TITLE
fix: attribute activity not loading

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/(people)/attributes/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/(people)/attributes/actions.ts
@@ -21,12 +21,6 @@ export const getSegmentsByAttributeClassAction = authenticatedActionClient
   .action(async ({ ctx, parsedInput }) => {
     await checkAuthorization({
       userId: ctx.user.id,
-      organizationId: await getOrganizationIdFromAttributeClassId(parsedInput.attributeClass.id),
-      rules: ["attributeClass", "read"],
-    });
-
-    await checkAuthorization({
-      userId: ctx.user.id,
       organizationId: await getOrganizationIdFromEnvironmentId(parsedInput.environmentId),
       rules: ["environment", "read"],
     });

--- a/apps/web/app/(app)/environments/[environmentId]/(people)/attributes/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/(people)/attributes/actions.ts
@@ -3,10 +3,7 @@
 import { z } from "zod";
 import { authenticatedActionClient } from "@formbricks/lib/actionClient";
 import { checkAuthorization } from "@formbricks/lib/actionClient/utils";
-import {
-  getOrganizationIdFromAttributeClassId,
-  getOrganizationIdFromEnvironmentId,
-} from "@formbricks/lib/organization/utils";
+import { getOrganizationIdFromEnvironmentId } from "@formbricks/lib/organization/utils";
 import { getSegmentsByAttributeClassName } from "@formbricks/lib/segment/service";
 import { ZAttributeClass } from "@formbricks/types/attribute-classes";
 import { ZId } from "@formbricks/types/common";


### PR DESCRIPTION
This pull request includes a change to the `getSegmentsByAttributeClassAction` function in the `attributes/actions.ts` file. The change modifies the authorization check to use the environment ID instead of the attribute class ID.

Authorization logic update:

* `apps/web/app/(app)/environments/[environmentId]/(people)/attributes/actions.ts`: Changed the `checkAuthorization` function to use `getOrganizationIdFromEnvironmentId` instead of `getOrganizationIdFromAttributeClassId` for obtaining the organization ID. ([apps/web/app/(app)/environments/[environmentId]/(people)/attributes/actions.tsL22-L27](diffhunk://#diff-b017d5115e2b07282f70afe077c81ecd00e356c5954be0e9cbcf6a5246e03543L22-L27))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted authorization checks for reading attribute classes, streamlining user permissions based on environment ID.

This change enhances user experience by simplifying access control while maintaining existing functionality for segment retrieval and survey categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->