### PR TITLE
fix(button): change loader color of secondary button to dark:text-slate-900

### DIFF
--- a/packages/ui/components/Button/index.tsx
+++ b/packages/ui/components/Button/index.tsx
@@ -122,7 +122,9 @@ export const Button: React.ForwardRefExoticComponent<
           <svg
             className={cn(
               "mx-4 h-5 w-5 animate-spin",
-              variant === "primary" ? "text-white dark:text-slate-900" : "text-slate-900"
+              variant === "primary" || variant === "secondary"
+                ? "text-white dark:text-slate-900"
+                : "text-slate-900"
             )}
             xmlns="http://www.w3.org/2000/svg"
             fill="none"


### PR DESCRIPTION
## What does this PR do?
This PR changes the loader color for the secondary button to dark:text-slate-900.

Fixes #3792

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/0ab2686c-1edb-4f86-8779-65d83ae6c9f7">


## How should this be tested?

- Test A: Check the loader color of "Save & Close" button (should be the same as in "Save" button).
- Test B: Check the loader color of "Save" button (should be the same as in "Save & Close" button).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated loading spinner color for "primary" and "secondary" button variants to display in white during loading.
  
- **Bug Fixes**
	- Refined logic for rendering the loading spinner, ensuring consistent visual representation across specified button variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->