### PR TITLE
chore: update usage limits for formbricks cloud

### DIFF
--- a/packages/lib/constants.ts
+++ b/packages/lib/constants.ts
@@ -199,15 +199,15 @@ export enum STRIPE_PRICE_LOOKUP_KEYS {
 
 export const BILLING_LIMITS = {
   FREE: {
-    RESPONSES: 500,
-    MIU: 1000,
+    RESPONSES: 1500,
+    MIU: 2000,
   },
   STARTUP: {
-    RESPONSES: 2000,
-    MIU: 2500,
+    RESPONSES: 5000,
+    MIU: 7500,
   },
   SCALE: {
-    RESPONSES: 5000,
-    MIU: 20000,
+    RESPONSES: 10000,
+    MIU: 30000,
   },
 } as const;


### PR DESCRIPTION
This pull request includes changes to the `BILLING_LIMITS` constants in the `packages/lib/constants.ts` file to update the response and MIU limits for different billing tiers.

Changes to billing limits:

* [`packages/lib/constants.ts`](diffhunk://#diff-84a559b7431271bcf747be80243751e28f9e17100616987cb5776afffe63e1a6L202-R211): Updated the `FREE` tier to 1500 responses and 2000 MIU, the `STARTUP` tier to 5000 responses and 7500 MIU, and the `SCALE` tier to 10000 responses and 30000 MIU.