### PR TITLE
docs: fix last occurence of old sdk call from docs

### DIFF
--- a/apps/docs/app/developer-docs/js-sdk/page.mdx
+++ b/apps/docs/app/developer-docs/js-sdk/page.mdx
@@ -48,7 +48,7 @@ Initialize the Formbricks JS Client for surveys. When used in a web app, pass a 
 <CodeGroup title="Initialize Formbricks">
 
 ```javascript
-import formbricks from "@formbricks/js/app";
+import formbricks from "@formbricks/js";
 
 formbricks.init({
   environmentId: "<your-environment-id>", // required


### PR DESCRIPTION
This pull request includes a small change to the `apps/docs/app/developer-docs/js-sdk/page.mdx` file. The change corrects the import statement for the Formbricks JS client.

* [`apps/docs/app/developer-docs/js-sdk/page.mdx`](diffhunk://#diff-86facb8b24ec664c3709d0358e3517278a48b65ab28f31ec3f0361bfc7c8d1f3L51-R51): Corrected the import statement for the Formbricks JS client from `@formbricks/js/app` to `@formbricks/js`.