### PR TITLE
fix: Add rate limit to forgot password route

### DIFF
--- a/apps/web/app/api/v1/users/forgot-password/route.ts
+++ b/apps/web/app/api/v1/users/forgot-password/route.ts
@@ -1,10 +1,13 @@
 import { prisma } from "@formbricks/database";
 import { sendForgotPasswordEmail } from "@formbricks/email";
+import { loginLimiter } from "@/app/middleware/bucket";
 
 export const POST = async (request: Request) => {
   const { email } = await request.json();
 
   try {
+    await loginLimiter(request.headers.get("x-forwarded-for") || request.connection.remoteAddress);
+
     const foundUser = await prisma.user.findUnique({
       where: {
         email: email.toLowerCase(),

--- a/apps/web/app/middleware/bucket.ts
+++ b/apps/web/app/middleware/bucket.ts
@@ -29,3 +29,8 @@ export const syncUserIdentificationLimiter = rateLimit({
   interval: SYNC_USER_IDENTIFICATION_RATE_LIMIT.interval,
   allowedPerInterval: SYNC_USER_IDENTIFICATION_RATE_LIMIT.allowedPerInterval,
 });
+
+export const forgotPasswordLimiter = rateLimit({
+  interval: LOGIN_RATE_LIMIT.interval,
+  allowedPerInterval: LOGIN_RATE_LIMIT.allowedPerInterval,
+});

--- a/apps/web/app/middleware/endpointValidator.ts
+++ b/apps/web/app/middleware/endpointValidator.ts
@@ -28,3 +28,5 @@ export const isSyncWithUserIdentificationEndpoint = (
   const match = url.match(regex);
   return match ? { environmentId: match[1], userId: match[2] } : false;
 };
+
+export const forgotPasswordRoute = (url: string) => url === "/api/v1/users/forgot-password";

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -4,6 +4,7 @@ import {
   shareUrlLimiter,
   signUpLimiter,
   syncUserIdentificationLimiter,
+  forgotPasswordLimiter,
 } from "@/app/middleware/bucket";
 import {
   clientSideApiRoute,
@@ -12,6 +13,7 @@ import {
   loginRoute,
   shareUrlRoute,
   signupRoute,
+  forgotPasswordRoute,
 } from "@/app/middleware/endpointValidator";
 import { getToken } from "next-auth/jwt";
 import { NextResponse } from "next/server";
@@ -60,6 +62,8 @@ export const middleware = async (request: NextRequest) => {
         }
       } else if (shareUrlRoute(request.nextUrl.pathname)) {
         await shareUrlLimiter(`share-${ip}`);
+      } else if (forgotPasswordRoute(request.nextUrl.pathname)) {
+        await forgotPasswordLimiter(`forgot-password-${ip}`);
       }
       return NextResponse.next();
     } catch (e) {
@@ -83,5 +87,6 @@ export const config = {
     "/api/auth/signout",
     "/auth/login",
     "/api/packages/:path*",
+    "/api/v1/users/forgot-password",
   ],
 };


### PR DESCRIPTION
Add rate limiting to the `/auth/forgot-password` route.

* Import `loginLimiter` in `apps/web/app/api/v1/users/forgot-password/route.ts` and apply it to the `POST` function.
* Add `forgotPasswordLimiter` in `apps/web/app/middleware/bucket.ts` with the same limits as `loginLimiter`.
* Add `forgotPasswordRoute` function in `apps/web/app/middleware/endpointValidator.ts` to identify the `/auth/forgot-password` route.
* Update `apps/web/middleware.ts` to include `forgotPasswordLimiter` and `forgotPasswordRoute` in the rate limiting logic.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/formbricks/formbricks?shareId=4566ed88-2ccc-4bee-b27d-6e7daf799f02).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced rate limiting for the "forgot password" functionality to enhance security and prevent abuse.
	- Added a dedicated route validation for the forgot password endpoint.

- **Bug Fixes**
	- Improved error handling related to rate limiting for forgot password requests.

- **Chores**
	- Updated middleware to include new rate limiter and routing checks for the forgot password functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->