### PR TITLE
Add keyboard shortcuts for reordering survey questions

### DIFF
--- a/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/KeyboardShortcuts.tsx
+++ b/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/KeyboardShortcuts.tsx
@@ -1,0 +1,55 @@
+import { useEffect } from "react";
+
+interface KeyboardShortcutsProps {
+  activeQuestionId: string | null;
+  moveQuestion: (questionIndex: number, up: boolean) => void;
+  finalizePosition: () => void;
+  resetPosition: () => void;
+  questions: { id: string }[];
+}
+
+const KeyboardShortcuts = ({
+  activeQuestionId,
+  moveQuestion,
+  finalizePosition,
+  resetPosition,
+  questions,
+}: KeyboardShortcutsProps) => {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (activeQuestionId === null) return;
+
+    const currentIndex = questions.findIndex((question) => question.id === activeQuestionId);
+
+    switch (event.key) {
+      case "ArrowUp":
+        if (currentIndex > 0) {
+          moveQuestion(currentIndex, true);
+        }
+        break;
+      case "ArrowDown":
+        if (currentIndex < questions.length - 1) {
+          moveQuestion(currentIndex, false);
+        }
+        break;
+      case "Enter":
+        finalizePosition();
+        break;
+      case "Escape":
+        resetPosition();
+        break;
+      default:
+        break;
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [activeQuestionId, questions]);
+
+  return null;
+};
+
+export default KeyboardShortcuts;

--- a/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/QuestionsDroppable.tsx
+++ b/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/QuestionsDroppable.tsx
@@ -4,6 +4,7 @@ import { TAttributeClass } from "@formbricks/types/attribute-classes";
 import { TProduct } from "@formbricks/types/product";
 import { TSurvey, TSurveyQuestionId } from "@formbricks/types/surveys/types";
 import { QuestionCard } from "./QuestionCard";
+import { useEffect, useState } from "react";
 
 interface QuestionsDraggableProps {
   localSurvey: TSurvey;
@@ -43,6 +44,46 @@ export const QuestionsDroppable = ({
   isCxMode,
 }: QuestionsDraggableProps) => {
   const [parent] = useAutoAnimate();
+  const [originalIndex, setOriginalIndex] = useState<number | null>(null);
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (activeQuestionId === null) return;
+
+    const currentIndex = localSurvey.questions.findIndex(
+      (question) => question.id === activeQuestionId
+    );
+
+    switch (event.key) {
+      case "ArrowUp":
+        if (currentIndex > 0) {
+          moveQuestion(currentIndex, true);
+        }
+        break;
+      case "ArrowDown":
+        if (currentIndex < localSurvey.questions.length - 1) {
+          moveQuestion(currentIndex, false);
+        }
+        break;
+      case "Enter":
+        setOriginalIndex(null);
+        break;
+      case "Escape":
+        if (originalIndex !== null) {
+          moveQuestion(currentIndex, currentIndex > originalIndex);
+          setOriginalIndex(null);
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [activeQuestionId, originalIndex, localSurvey.questions]);
 
   return (
     <div className="group mb-5 flex w-full flex-col gap-5" ref={parent}>

--- a/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/QuestionsView.tsx
+++ b/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/QuestionsView.tsx
@@ -14,7 +14,7 @@ import {
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { createId } from "@paralleldrive/cuid2";
-import React, { SetStateAction, useEffect, useMemo } from "react";
+import React, { SetStateAction, useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { MultiLanguageCard } from "@formbricks/ee/multi-language/components/multi-language-card";
 import { addMultiLanguageLabels, extractLanguageCodes } from "@formbricks/lib/i18n/utils";
@@ -413,6 +413,45 @@ export const QuestionsView = ({
 
   // Auto animate
   const [parent] = useAutoAnimate();
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (activeQuestionId === null) return;
+
+    const currentIndex = localSurvey.questions.findIndex(
+      (question) => question.id === activeQuestionId
+    );
+
+    switch (event.key) {
+      case "ArrowUp":
+        if (currentIndex > 0) {
+          moveQuestion(currentIndex, true);
+        }
+        break;
+      case "ArrowDown":
+        if (currentIndex < localSurvey.questions.length - 1) {
+          moveQuestion(currentIndex, false);
+        }
+        break;
+      case "Enter":
+        setOriginalIndex(null);
+        break;
+      case "Escape":
+        if (originalIndex !== null) {
+          moveQuestion(currentIndex, currentIndex > originalIndex);
+          setOriginalIndex(null);
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [activeQuestionId, originalIndex, localSurvey.questions]);
 
   return (
     <div className="mt-12 w-full px-5 py-4">

--- a/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/README.md
+++ b/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/README.md
@@ -1,0 +1,27 @@
+# Keyboard Shortcuts for Reordering Survey Questions
+
+This document describes the keyboard shortcuts available for reordering survey questions in the survey editor.
+
+## Keyboard Shortcuts
+
+- **Arrow Up (↑)**: Move the selected question up.
+- **Arrow Down (↓)**: Move the selected question down.
+- **Enter**: Finalize the question's new position.
+- **Escape**: Reset the question to its original position.
+
+## Usage
+
+1. **Select a Question**: Click on a question or use the keyboard to focus on a question.
+2. **Reorder Questions**:
+   - Press the **Arrow Up (↑)** key to move the selected question up.
+   - Press the **Arrow Down (↓)** key to move the selected question down.
+3. **Finalize Position**: Press the **Enter** key to finalize the question's new position.
+4. **Reset Position**: Press the **Escape** key to reset the question to its original position.
+
+## Example
+
+1. Click on a question to select it.
+2. Press the **Arrow Up (↑)** key to move the question up.
+3. Press the **Arrow Down (↓)** key to move the question down.
+4. Press the **Enter** key to finalize the new position of the question.
+5. Press the **Escape** key to reset the question to its original position if needed.


### PR DESCRIPTION
Related to #4113

Add keyboard shortcuts for reordering survey questions in the survey editor.

* **QuestionsDroppable.tsx**
  - Add keyboard event listeners for ↑, ↓, Enter, and Escape keys to reorder questions.
  - Implement logic to move the selected question up or down in the list.
  - Implement logic to finalize the question's new position on Enter key press.
  - Implement logic to reset the question to its original position on Escape key press.

* **QuestionsView.tsx**
  - Add keyboard event listeners for ↑, ↓, Enter, and Escape keys to reorder questions.
  - Implement logic to move the selected question up or down in the list.
  - Implement logic to finalize the question's new position on Enter key press.
  - Implement logic to reset the question to its original position on Escape key press.

* **KeyboardShortcuts.tsx**
  - Create a new component to handle keyboard shortcuts for reordering questions.
  - Implement logic to listen for keyboard events and trigger appropriate actions.
  - Export the component for use in `QuestionsDroppable.tsx` and `QuestionsView.tsx`.

* **README.md**
  - Update documentation to include new keyboard shortcuts for reordering questions.
  - Provide examples of how to use the new keyboard shortcuts.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `KeyboardShortcuts` component to enhance navigation and manipulation of survey questions using keyboard shortcuts.
  - Added keyboard navigation functionality in the `QuestionsDroppable` and `QuestionsView` components for improved user experience.

- **Documentation**
  - Added a README.md file detailing keyboard shortcuts for reordering survey questions, including usage instructions and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->