### PR TITLE
Add functionality to set variables based on previous answers

### DIFF
--- a/apps/docs/app/global/conditional-logic/page.mdx
+++ b/apps/docs/app/global/conditional-logic/page.mdx
@@ -159,6 +159,20 @@ Conditons can be based on:
 
 4. **Save Logic**: Click the `Save` button to save the logic block.
 
+## **Setting Variables Based on Previous Answers**
+
+You can now set variables based on previous answers given by the user. This allows you to create more dynamic and personalized surveys.
+
+1. **Add a Variable**: Click the `Add Variable` button to add a new variable.
+
+2. **Assign Variable Value**: In the logic editor, you can now assign the value of a variable based on a previous answer given by the user.
+
+Example:
+
+- Ask the user how much rent they are paying.
+- Assign the answer to a variable.
+- Use the variable in further calculations to show the user their maximum rent.
+
 # Question Logic
 
 This logic is executed when the user answers the question. Logic can be as simple as showing a follow-up question based on the answer or as complex as calculating a score based on multiple answers.

--- a/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/ConditionalLogic.tsx
+++ b/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/components/ConditionalLogic.tsx
@@ -77,6 +77,15 @@ export function ConditionalLogic({
           objective: "jumpToQuestion",
           target: "",
         },
+        {
+          id: createId(),
+          objective: "setVariable",
+          variableId: "",
+          value: {
+            type: "question",
+            value: "",
+          },
+        },
       ],
     };
 

--- a/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/lib/utils.tsx
+++ b/apps/web/app/(app)/(survey-editor)/environments/[environmentId]/surveys/[surveyId]/edit/lib/utils.tsx
@@ -145,6 +145,7 @@ export const actionObjectiveOptions: TComboboxOption[] = [
   { label: "environments.surveys.edit.calculate", value: "calculate" },
   { label: "environments.surveys.edit.require_answer", value: "requireAnswer" },
   { label: "environments.surveys.edit.jump_to_question", value: "jumpToQuestion" },
+  { label: "environments.surveys.edit.set_variable", value: "setVariable" },
 ];
 
 const getQuestionOperatorOptions = (question: TSurveyQuestion): TComboboxOption[] => {


### PR DESCRIPTION
Related to #4084

Add functionality to set variables based on previous answers in conditional logic.

* **ConditionalLogic.tsx**
  - Add a new objective "setVariable" in the `addLogic` function to set variables based on previous answers.

* **utils.tsx**
  - Add "setVariable" to the `actionObjectiveOptions` array.

* **page.mdx**
  - Add a section describing the new functionality of setting variables based on previous answers.
  - Include an example of how to use this new feature.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/formbricks/formbricks/issues/4084?shareId=7616db11-e4f9-4857-b487-b52bf9b64037).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new section in the documentation for "Setting Variables Based on Previous Answers," enhancing guidance on dynamic survey logic.
	- Added a new action type, "setVariable," to the Conditional Logic component, allowing users to set variables based on previous responses.
	- Expanded action objectives in the survey editor to include the new "setVariable" option.

- **Documentation**
	- Enhanced documentation to include clearer instructions and examples for utilizing variables in survey logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->