### PR TITLE
docs: remove links to discontinued  examples repo

### DIFF
--- a/apps/docs/app/app-surveys/framework-guides/page.mdx
+++ b/apps/docs/app/app-surveys/framework-guides/page.mdx
@@ -60,7 +60,7 @@ All you need to do is copy a `<script>` tag to your HTML head, and that’s abou
   </Property>
 </Properties>
 
-Refer to our [Example HTML project](https://github.com/formbricks/examples/tree/main/html) for more help! Now visit the [Validate your Setup](#validate-your-setup) section to verify your setup!
+Now visit the [Validate your Setup](#validate-your-setup) section to verify your setup!
 
 ---
 
@@ -118,7 +118,7 @@ export default App;
   </Property>
 </Properties>
 
-Refer to our [Example ReactJs project](https://github.com/formbricks/examples/tree/main/reactjs) for more help! Now visit the [Validate your Setup](#validate-your-setup) section to verify your setup!
+Now visit the [Validate your Setup](#validate-your-setup) section to verify your setup!
 
 ---
 
@@ -200,8 +200,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 </CodeGroup>
 </Col>
 
-Refer to our [Example NextJS App Directory project](https://github.com/formbricks/examples/tree/main/nextjs-app) for more help!
-
 ### Pages Directory
 
 <Col>
@@ -239,7 +237,6 @@ export default function App({ Component, pageProps }: AppProps) {
 
 </CodeGroup>
 </Col>
-Refer to our [Example NextJS Pages Directory project](https://github.com/formbricks/examples/tree/main/nextjs-pages) for more help!
 
 ### Required customizations to be made
 
@@ -332,7 +329,7 @@ router.afterEach((to, from) => {
   </Property>
 </Properties>
 
-Refer to our [Example VueJs project](https://github.com/formbricks/examples/tree/main/vuejs) for more help! Now visit the [Validate your Setup](#validate-your-setup) section to verify your setup!
+Now visit the [Validate your Setup](#validate-your-setup) section to verify your setup!
 
 ## React Native
 


### PR DESCRIPTION
This pull request includes several changes to the `apps/docs/app/app-surveys/framework-guides/page.mdx` file, mainly focusing on the removal of references to example projects. The most important changes are:

Documentation updates:

* Removed the reference to the Example HTML project.
* Removed the reference to the Example ReactJs project.
* Removed the reference to the Example NextJS App Directory project.
* Removed the reference to the Example NextJS Pages Directory project.
* Removed the reference to the Example VueJs project.