### PR TITLE
fix: github issue template linting issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,16 +1,13 @@
 name: Bug report
 description: "Found a bug? Please fill out the sections below. \U0001F44D"
-title: ""
-labels: bug
-assignees: []
+labels:
+  - bug
 body:
   - type: textarea
     id: issue-summary
     attributes:
       label: Issue Summary
       description: A summary of the issue. This needs to be a clear detailed-rich summary.
-    validations:
-      required: true
     validations:
       required: true
   - type: textarea
@@ -24,5 +21,5 @@ body:
     attributes:
       label: Your Environment
       options:
-        - label: Formbricks Cloud (app.formbricks.com)
-        - label: Self-hosted Formbricks
+        - Formbricks Cloud (app.formbricks.com)
+        - Self-hosted Formbricks

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,8 +1,7 @@
 name: Feature request
 description: "Suggest an idea for this project \U0001F680"
-title: ""
-labels: enhancement
-assignees: []
+labels:
+  - enhancement
 body:
   - type: textarea
     id: problem-description
@@ -26,7 +25,6 @@ body:
     validations:
       required: false
   - type: markdown
-    id: formbricks-info
     attributes:
       value: |
         ### Additional resources 🤓


### PR DESCRIPTION
This pull request includes updates to the bug report and feature request issue templates to improve clarity and streamline the process.

Changes to bug report template:

* Consolidated the `labels` field to use a list format. (`.github/ISSUE_TEMPLATE/bug_report.yml`, [.github/ISSUE_TEMPLATE/bug_report.ymlL3-R4](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL3-R4))
* Removed redundant `validations` entry in the issue summary section. (`.github/ISSUE_TEMPLATE/bug_report.yml`, [.github/ISSUE_TEMPLATE/bug_report.ymlL14-L15](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL14-L15))
* Simplified the options list under the "Your Environment" section. (`.github/ISSUE_TEMPLATE/bug_report.yml`, [.github/ISSUE_TEMPLATE/bug_report.ymlL27-R25](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL27-R25))

Changes to feature request template:

* Consolidated the `labels` field to use a list format. (`.github/ISSUE_TEMPLATE/feature_request.yml`, [.github/ISSUE_TEMPLATE/feature_request.ymlL3-R4](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdL3-R4))
* Removed the unused `id` attribute from the markdown section. (`.github/ISSUE_TEMPLATE/feature_request.yml`, [.github/ISSUE_TEMPLATE/feature_request.ymlL29](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdL29))