### PR TITLE
fix: cal.com question not loading properly

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -166,7 +166,7 @@ const nextConfig = {
           {
             key: "Content-Security-Policy",
             value:
-              "default-src 'self'; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https:; font-src 'self' https:; connect-src 'self' https:; frame-src 'self'; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self';",
+              "default-src 'self'; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline' https:; img-src 'self' data: https:; font-src 'self' https:; connect-src 'self' https:; frame-src 'self' https://app.cal.com; media-src 'self' https:; object-src 'none'; base-uri 'self'; form-action 'self';",
           },
         ],
       },


### PR DESCRIPTION
This pull request includes a change to the Content Security Policy (CSP) in the `next.config.mjs` file to allow frames from `https://app.cal.com`.

* [`apps/web/next.config.mjs`](diffhunk://#diff-197cd8ca285a4abd2f21479e0bf6e36e90b08528fcd7f3bdbe8d1221897e377dL169-R169): Updated the CSP to permit frames from `https://app.cal.com`.