### PR TITLE
chore: update 2.7 migration guide

### DIFF
--- a/apps/docs/app/self-hosting/migration-guide/page.mdx
+++ b/apps/docs/app/self-hosting/migration-guide/page.mdx
@@ -10,6 +10,12 @@ export const metadata = {
 
 ## v2.7
 
+<Note>
+  This release sets the foundation for our upcoming AI features, currently in private beta. Formbricks now
+  requires the `pgvector` extension to be installed in the PostgreSQL database. For users of our one-click
+  setup, simply use the `pgvector/pgvector:pg15` image instead of `postgres:15-alpine`.
+</Note>
+
 Formbricks v2.7 includes all the features and improvements developed by the community during hacktoberfest 2024. Additionally we introduce an advanced team-based access control system (requires Formbricks Enterprise Edition).
 
 ### Additional Updates
@@ -44,7 +50,23 @@ docker exec formbricks-postgres-1 pg_dump -Fc -U postgres -d formbricks > formbr
   restore scenario you will need to use `psql` then with an empty `formbricks` database.
 </Note>
 
-2. Pull the latest version of Formbricks:
+2. If you use an older `docker-compose.yml` file from the one-click setup, modify it to use the `pgvector/pgvector:pg15` image instead of `postgres:15-alpine`:
+
+```yaml
+services:
+  postgres:
+    image: pgvector/pgvector:pg15
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - 5432:5432
+```
+
+3. Pull the latest version of Formbricks:
 
 <Col>
 <CodeGroup title="Stop the containers">
@@ -56,7 +78,7 @@ docker compose pull
 </CodeGroup>
 </Col>
 
-3. Stop the running Formbricks instance & remove the related containers:
+4. Stop the running Formbricks instance & remove the related containers:
 
 <Col>
 <CodeGroup title="Stop the containers">
@@ -68,7 +90,7 @@ docker compose down
 </CodeGroup>
 </Col>
 
-4. Restarting the containers with the latest version of Formbricks:
+5. Restarting the containers with the latest version of Formbricks:
 
 <Col>
 <CodeGroup title="Restart the containers">
@@ -80,7 +102,7 @@ docker compose up -d
 </CodeGroup>
 </Col>
 
-5. Now let's migrate the data to the latest schema:
+6. Now let's migrate the data to the latest schema:
 
 <Note>To find your Docker Network name for your Postgres Database, find it using `docker network ls`</Note>
 
@@ -101,7 +123,7 @@ docker run --rm \
 
 The above command will migrate your data to the latest schema. This is a crucial step to migrate your existing data to the new structure. Only if the script runs successful, changes are made to the database. The script can safely run multiple times.
 
-6. That's it! Once the migration is complete, you can **now access your Formbricks instance** at the same URL as before.
+7. That's it! Once the migration is complete, you can **now access your Formbricks instance** at the same URL as before.
 
 ## v2.6
 

--- a/packages/ui/components/BadgeSelect/stories.ts
+++ b/packages/ui/components/BadgeSelect/stories.ts
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { Badge } from "./index";
+import { BadgeSelect } from "./index";
 
 const meta = {
-  title: "ui/Badge",
-  component: Badge,
+  title: "ui/BadgeSelect",
+  component: BadgeSelect,
   tags: ["autodocs"],
   parameters: {
     layout: "centered",
@@ -16,7 +16,7 @@ const meta = {
     size: { control: "select", options: ["small", "normal", "large"] },
     className: { control: "text" },
   },
-} satisfies Meta<typeof Badge>;
+} satisfies Meta<typeof BadgeSelect>;
 
 export default meta;
 


### PR DESCRIPTION
This pull request updates the self-hosting migration guide in the documentation to accommodate new requirements and improve clarity. The main changes include the introduction of a new PostgreSQL image with the `pgvector` extension and updates to the migration steps.

Key changes:

### New PostgreSQL Requirement

* Added a note about the requirement to use the `pgvector` extension for PostgreSQL in the upcoming AI features. Users are advised to use the `pgvector/pgvector:pg15` image instead of `postgres:15-alpine`.

### Migration Steps Update

* Updated the migration guide to include instructions for modifying the `docker-compose.yml` file to use the new PostgreSQL image.
* Adjusted the numbering of the migration steps to reflect the new instructions. [[1]](diffhunk://#diff-82aed406eb6c0b6d6019571a29925a025cd3f198fda045d7edf9015d3231c9bbL59-R81) [[2]](diffhunk://#diff-82aed406eb6c0b6d6019571a29925a025cd3f198fda045d7edf9015d3231c9bbL71-R93) [[3]](diffhunk://#diff-82aed406eb6c0b6d6019571a29925a025cd3f198fda045d7edf9015d3231c9bbL83-R105) [[4]](diffhunk://#diff-82aed406eb6c0b6d6019571a29925a025cd3f198fda045d7edf9015d3231c9bbL104-R126)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated migration guide for Formbricks version 2.7, including new installation requirements for the `pgvector` extension.
  
- **Documentation**
	- Added instructions for using the `pgvector/pgvector:pg15` image in `docker-compose.yml`.
	- Renumbered migration steps for clarity and emphasized the importance of database backups before upgrading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->