### PR TITLE
docs: add beta notes to features currently under development

### DIFF
--- a/apps/docs/app/developer-docs/api-sdk/page.mdx
+++ b/apps/docs/app/developer-docs/api-sdk/page.mdx
@@ -10,6 +10,11 @@ export const metadata = {
 
 # SDK: Formbricks API
 
+<Note>
+  The API SDK is currently in beta and APIs are subject to change. We will do our best to notify you of any
+  changes.
+</Note>
+
 ### Overview
 
 The Formbricks Client API Wrapper is a lightweight package designed to simplify the integration of Formbricks API endpoints into your JavaScript (JS) or TypeScript (TS) projects. With this wrapper, you can easily interact with Formbricks API endpoints without the need for complex setup or manual HTTP requests.

--- a/apps/docs/app/developer-docs/react-native-in-app-surveys/page.mdx
+++ b/apps/docs/app/developer-docs/react-native-in-app-surveys/page.mdx
@@ -10,6 +10,11 @@ export const metadata = {
 
 # React Native: In App Surveys
 
+<Note>
+  The React Native SDK is currently in beta and APIs are subject to change. We will do our best to notify you
+  of any changes.
+</Note>
+
 ### Overview
 
 The Formbricks React Native SDK can be used for seamlessly integrating App Surveys into your React Native Apps. Here, w'll explore how to leverage the SDK for in app surveys. The SDK is [available on npm.](https://www.npmjs.com/package/@formbricks/react-native)

--- a/apps/docs/app/developer-docs/rest-api/page.mdx
+++ b/apps/docs/app/developer-docs/rest-api/page.mdx
@@ -13,6 +13,11 @@ export const metadata = {
 
 # API Overview
 
+<Note>
+  The Formbricks API is currently in beta and is subject to change. We will do our best to notify you of any
+  changes.
+</Note>
+
 Formbricks offers two types of APIs: the **Public Client API** and the **Management API**. Each API serves a different purpose, has different authentication requirements, and provides access to different data and settings.
 
 View our [API Documentation](https://documenter.getpostman.com/view/11026000/2sA3Bq5XEh) in more than 30 frameworks and languages.


### PR DESCRIPTION
This pull request adds a beta notice to multiple developer documentation pages. The notice informs users that the APIs are in beta and subject to change.

Documentation updates:

* [`apps/docs/app/developer-docs/api-sdk/page.mdx`](diffhunk://#diff-126813c6f157309ed5d73f74aa908aba4eaa0e856d887e007b0fdf68aa90af5bR13-R17): Added a beta notice to the SDK overview section.
* [`apps/docs/app/developer-docs/react-native-in-app-surveys/page.mdx`](diffhunk://#diff-2836f0f89fbcf1e01c4eb9f865691e76af462b570e7fba22ca754a10f9a6aba1R13-R17): Added a beta notice to the React Native SDK overview section.
* [`apps/docs/app/developer-docs/rest-api/page.mdx`](diffhunk://#diff-6b545b06a57509805054dde234b46f87a519c7466afb71e68dcc336307b8b41fR16-R20): Added a beta notice to the API overview section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added informational notes to the documentation indicating that the Formbricks API and React Native SDK are currently in beta, with APIs subject to change.
	- Included guidance on securely storing API keys in the REST API documentation.

- **Documentation**
	- Enhanced clarity and user awareness regarding the evolving nature of the SDKs and API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->