### PR TITLE
fix: conditional in german translation

### DIFF
--- a/packages/lib/messages/de-DE.json
+++ b/packages/lib/messages/de-DE.json
@@ -1570,7 +1570,7 @@
         "wait_a_few_seconds_after_the_trigger_before_showing_the_survey": "Warte ein paar Sekunden nach dem Auslöser, bevor Du die Umfrage anzeigst",
         "waiting_period": "Wartezeit",
         "welcome_message": "Willkommensnachricht",
-        "when": "Wann",
+        "when": "Wenn",
         "when_conditions_match_waiting_time_will_be_ignored_and_survey_shown": "Wenn die Bedingungen übereinstimmen, wird die Wartezeit ignoriert und die Umfrage angezeigt.",
         "with_the_formbricks_sdk": "mit dem Formbricks SDK",
         "without_a_filter_all_of_your_users_can_be_surveyed": "Ohne Filter können alle deine Nutzer befragt werden.",


### PR DESCRIPTION
This pull request includes a minor change to the `packages/lib/messages/de-DE.json` file. The change corrects the translation of the word "when" from "Wann" to "Wenn".

* [`packages/lib/messages/de-DE.json`](diffhunk://#diff-380b0b03e961188a6ea777d6c59df8a432bcf77187d7ba27c63973efbe67f57cL1573-R1573): Corrected the translation of "when" from "Wann" to "Wenn".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved German localization for survey logic by correcting the translation of "when" from "Wann" to "Wenn."

- **Bug Fixes**
	- Enhanced clarity and correctness of the user interface language for German-speaking users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->