### PR TITLE
docs: add n8n community node note

### DIFF
--- a/apps/docs/app/developer-docs/integrations/n8n/page.mdx
+++ b/apps/docs/app/developer-docs/integrations/n8n/page.mdx
@@ -26,14 +26,19 @@ export const metadata = {
 
 # n8n Setup
 
-n8n allows you to build flexible workflows focused on deep data integration. And with sharable templates and a user-friendly UI, the less technical people on your team can collaborate on them too. Unlike other tools, complexity is not a limitation. So you can build whatever you want — without stressing over budget. Hook up Formbricks with n8n and you can send your data to 350+ other apps. Here is how to do it.
-
 <Note>
-  Nail down your survey? Any changes in the survey cause additional work in the n8n node. It makes
-  sense to first settle on the survey you want to run and then get to setting up n8n.
+  The Formbricks n8n node is currently only available in the n8n self-hosted version as a community node. To
+  install it go to "Settings" -> "Community Nodes" and install @formbricks/n8n-nodes-formbricks.
 </Note>
 
+n8n allows you to build flexible workflows focused on deep data integration. And with sharable templates and a user-friendly UI, the less technical people on your team can collaborate on them too. Unlike other tools, complexity is not a limitation. So you can build whatever you want — without stressing over budget. Hook up Formbricks with n8n and you can send your data to 350+ other apps. Here is how to do it.
+
 ## Step 1: Setup your survey incl. `questionId` for every question
+
+<Note>
+  Nailed down your survey? Any changes in the survey cause additional work in the n8n node. It makes sense to
+  first settle on the survey you want to run and then get to setting up n8n.
+</Note>
 
 When setting up the node your life will be easier when you change the `questionId`s of your survey questions. You can only do so **before** you publish your survey.
 


### PR DESCRIPTION
Fixes #4217

This pull request includes changes to the `apps/docs/app/developer-docs/integrations/n8n/page.mdx` file to improve the clarity and accuracy of the documentation regarding the setup and usage of the Formbricks n8n node.

Documentation improvements:

* Updated the note to specify that the Formbricks n8n node is available only in the n8n self-hosted version as a community node and provided installation instructions.
* Reorganized the content to place the note about setting up the survey and the `questionId` for every question in a more logical sequence, improving readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added clarification that the Formbricks n8n node is available only in the self-hosted version as a community node.
	- Included updated installation instructions for the Formbricks node.

- **Documentation**
	- Reorganized content for better flow and clarity regarding the setup process.
	- Emphasized the importance of finalizing the survey before configuring n8n.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->