### PR TITLE
fix: simplify LRU cache warning to avoid confusion

### DIFF
--- a/apps/web/cache-handler.mjs
+++ b/apps/web/cache-handler.mjs
@@ -61,7 +61,7 @@ CacheHandler.onCreation(async () => {
     // Fallback to LRU handler if Redis client is not available.
     // The application will still work, but the cache will be in memory only and not shared.
     handler = createLruHandler();
-    console.warn("Falling back to LRU handler because Redis client is not available.");
+    console.log("Using LRU handler for caching.");
   }
 
   return {


### PR DESCRIPTION
This pull request includes a small change to the `CacheHandler` in the `apps/web/cache-handler.mjs` file. The change updates the log message when falling back to the LRU handler. Instead of a warning we now show a log since the warning message caused confusion assuming something is wrong.

Logging update:

* [`apps/web/cache-handler.mjs`](diffhunk://#diff-2c42a949924192031e39ecaa1a540ec4135fa62cc01225cae6e42efe7d545c2aL64-R64): Changed the log message from a warning to an informational log when falling back to the LRU handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling and logging for cache creation, changing fallback logging from a warning to an informational message for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->