### PR TITLE
chore: add expected behaviour to github bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,6 +11,13 @@ body:
     validations:
       required: true
   - type: textarea
+    id: issue-expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: false
+  - type: textarea
     id: other-information
     attributes:
       label: Other information (incl. screenshots, Formbricks version, steps to reproduce,...)


### PR DESCRIPTION
This pull request includes an update to the bug report issue template to gather more detailed information from users.

Enhancements to bug report template:

* [`.github/ISSUE_TEMPLATE/bug_report.yml`](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efR13-R19): Added a new `textarea` field for "Expected Behavior" to allow users to provide a clear and concise description of what they expected to happen.