### PR TITLE
chore: update github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: Bug report
 description: "Found a bug? Please fill out the sections below. \U0001F44D"
-labels:
-  - bug
+type: bug
 body:
   - type: textarea
     id: issue-summary

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Questions
     url: https://github.com/formbricks/formbricks/discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: Feature request
 description: "Suggest an idea for this project \U0001F680"
-labels:
-  - enhancement
+type: feature
 body:
   - type: textarea
     id: problem-description


### PR DESCRIPTION
This pull request includes changes to the GitHub issue templates to improve their configuration and categorization. The most important changes include updating the bug report and feature request templates to use the `type` field instead of labels, and enabling blank issues in the configuration file.

Improvements to issue templates:

* [`.github/ISSUE_TEMPLATE/bug_report.yml`](diffhunk://#diff-637f7b97bba458badb691a1557c3d4648686292e948dbe3e8360564378b653efL3-R3): Replaced the `labels` field with the `type` field set to `bug`.
* [`.github/ISSUE_TEMPLATE/feature_request.yml`](diffhunk://#diff-c6b098646bf32c644234bec14c2675ea2a3d9c2dc2df450a25aa0e7ff02323cdL3-R3): Replaced the `labels` field with the `type` field set to `feature`.

Configuration changes:

* [`.github/ISSUE_TEMPLATE/config.yml`](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2L1-R1): Enabled blank issues by setting `blank_issues_enabled` to `true`.