### PR TITLE
chore: add github issue task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Questions
     url: https://github.com/formbricks/formbricks/discussions

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -6,6 +6,6 @@ body:
     id: task-summary
     attributes:
       label: Task description
-      description: A clear and concise description of the task. This needs to be a clear detailed-rich summary.
+      description: A clear detailed-rich description of the task.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,11 @@
+name: Task (internal)
+description: "Template for creating a task. Used by the Formbricks Team only \U0001f4e5"
+type: task
+body:
+  - type: textarea
+    id: task-summary
+    attributes:
+      label: Task description
+      description: A clear and concise description of the task. This needs to be a clear detailed-rich summary.
+    validations:
+      required: true


### PR DESCRIPTION
This pull request includes updates to the issue templates in the `.github` directory. The changes focus on disabling blank issues and adding a new template for internal tasks.

Updates to issue templates:

* [`.github/ISSUE_TEMPLATE/config.yml`](diffhunk://#diff-1c0d972ee49103af56fd608a77a28e1eb12f6908f263f0f183d46868fdcd8ea2L1-R1): Disabled blank issues by setting `blank_issues_enabled` to false.
* [`.github/ISSUE_TEMPLATE/task.yml`](diffhunk://#diff-24ddb99d0699247fe21dffe7eeee5babbaed4567feae20ced0f8dfb06b4b3f7fR1-R11): Added a new template for creating internal tasks, including a description and a textarea for task summary with required validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Disabled the option to create blank issues to streamline issue reporting.
	- Introduced a new "Questions" link directing users to the discussions page for inquiries.
	- Added a new issue template for tasks, specifically for internal use by the Formbricks Team, ensuring clear task descriptions.

- **Bug Fixes**
	- None

- **Documentation**
	- Updated issue template configuration for better user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->