### PR TITLE
fix: remove cache from identify endpoint to fix issues with recontact time

### DIFF
--- a/apps/web/modules/ee/contacts/api/client/[environmentId]/identify/contacts/[userId]/route.ts
+++ b/apps/web/modules/ee/contacts/api/client/[environmentId]/identify/contacts/[userId]/route.ts
@@ -56,11 +56,7 @@ export const GET = async (
         });
       }
 
-      return responses.successResponse(
-        personState.state,
-        true,
-        "public, s-maxage=600, max-age=840, stale-while-revalidate=600, stale-if-error=600"
-      );
+      return responses.successResponse(personState.state, true);
     } catch (err) {
       if (err instanceof ResourceNotFoundError) {
         return responses.notFoundResponse(err.resourceType, err.resourceId);


### PR DESCRIPTION
This pull request includes a small change to the `GET` function in `apps/web/modules/ee/contacts/api/client/[environmentId]/identify/contacts/[userId]/route.ts`. The change simplifies the success response by removing cache control headers.

* Simplified the success response in `GET` function by removing the cache control headers. (`apps/web/modules/ee/contacts/api/client/[environmentId]/identify/contacts/[userId]/route.ts`) ([apps/web/modules/ee/contacts/api/client/[environmentId]/identify/contacts/[userId]/route.tsL59-R59](diffhunk://#diff-f0173b61015516fe1197fe68591a499d40db47af3055517ed1a9646bfbb35c08L59-R59))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified success response by removing unnecessary caching directives, enhancing clarity of the returned data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->