### PR TITLE
chore: run sonarqube manually

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -1,10 +1,11 @@
 name: SonarQube
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+#  push:
+#    branches:
+#      - main
+#  pull_request:
+#    types: [opened, synchronize, reopened]
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/sonarqube.yml` file to modify the trigger conditions for the SonarQube workflow. The most important change is switching from automatic triggers on push and pull request events to a manual trigger.

Workflow trigger modification:

* [`.github/workflows/sonarqube.yml`](diffhunk://#diff-a5e11e7bedd328777f4897395a711a4492d413b70b12479230470ec608d96792L3-R8): Changed the workflow trigger from automatic triggers on push and pull request events to a manual trigger using `workflow_dispatch`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated SonarQube workflow configuration to use manual triggering instead of automatic event-based triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->