### PR TITLE
chore: update upload-artifact to v4

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           pnpm test:e2e
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow configuration to use a newer version of the `upload-artifact` action.

* [`.github/workflows/e2e.yml`](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eL90-R90): Updated the `upload-artifact` action from version 3 to version 4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for E2E tests to use the latest version of the artifact upload action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->