### PR TITLE
chore: prepare 3.1 release

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formbricks/web",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "scripts": {
     "clean": "rimraf .turbo node_modules .next",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -902,13 +902,13 @@ importers:
         specifier: 3.712.0
         version: 3.712.0
       '@formbricks/api':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../api
       '@formbricks/database':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../database
       '@formbricks/types':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../types
       '@paralleldrive/cuid2':
         specifier: 2.2.2


### PR DESCRIPTION
This pull request includes updates to the versioning and dependency management for the `@formbricks/web` package and its associated workspaces.

Versioning updates:

* [`apps/web/package.json`](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L3-R3): Updated the version of `@formbricks/web` from `3.0.0` to `3.1.0`.

Dependency management updates:

* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL905-R911): Changed the specifier for `@formbricks/api`, `@formbricks/database`, and `@formbricks/types` from `'*'` to `workspace:*` to ensure they are linked correctly within the workspace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Update**
  - Incremented package version from 3.0.0 to 3.1.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->