### PR TITLE
fix: draft release workflow

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - uses: ./.github/actions/dangerous-git-checkout
+
       - name: Configure git
         run: |
           git config --local user.email "github-actions@github.com"
           git config --local user.name "GitHub Actions"
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-
-      - uses: ./.github/actions/dangerous-git-checkout
 
       - name: Setup Node.js 20.x
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formbricks/web",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "scripts": {
     "clean": "rimraf .turbo node_modules .next",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formbricks/web",
-  "version": "3.1.1",
+  "version": "3.1.0",
   "private": true,
   "scripts": {
     "clean": "rimraf .turbo node_modules .next",


### PR DESCRIPTION
This pull request includes a modification to the GitHub Actions workflow file `.github/workflows/draft-release.yml` to reorder the steps for checking out the code and configuring git.

Changes in the GitHub Actions workflow:

* Moved the `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` step to occur before configuring git.
* Moved the `./.github/actions/dangerous-git-checkout` step to occur before configuring git.