### PR TITLE
chore: fix openAPI specs throw error

### DIFF
--- a/apps/docs/public/openapi.yaml
+++ b/apps/docs/public/openapi.yaml
@@ -24,6 +24,9 @@ info:
   version: 1.0.0
 servers:
   - url: http://{{baseurl}}
+    variables:
+      baseurl:
+        default: "localhost:3000"
 tags:
   - name: Client API
     description: >-
@@ -151,7 +154,7 @@ tags:
         
 
       Methods allowed: Get All, Get ,Create, and Delete Webhooks
-  
+
 paths:
   /api/v1/client/{environmentId}/displays:
     post:


### PR DESCRIPTION
The openAPI specs threw an error while importing to Insomnia.
This pull request includes a small but important change to the `apps/docs/public/openapi.yaml` file. The change adds a `variables` section to the `servers` block to define the `baseurl` variable with a default value of "localhost:3000".

* [`apps/docs/public/openapi.yaml`](diffhunk://#diff-693109c4cb0f3602c88422d0cd27f1d4e4191bf4668ea40fad8d495a316b54e9R27-R29): Added `variables` section to define `baseurl` with a default value of "localhost:3000".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated OpenAPI specification to include a configurable base URL for easier API testing and development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->