### PR TITLE
chore: prepare 3.1.3 release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,5 +1,5 @@
-name: Draft release
-run-name: Draft release ${{ inputs.next_version }}
+name: Prepare release
+run-name: Prepare release ${{ inputs.next_version }}
 
 on:
   workflow_dispatch:
@@ -11,9 +11,10 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
-  draft_release:
+  prepare_release:
     runs-on: ubuntu-latest
 
     steps:
@@ -42,14 +43,20 @@ jobs:
           cd apps/web
           pnpm version ${{ inputs.next_version }} --no-workspaces-update
 
-      - name: Commit changes
+      - name: Commit changes and create a branch
         run: |
+          branch_name="release-v${{ inputs.next_version }}"
+          git checkout -b "$branch_name"
           git add .
           git commit -m "chore: release v${{ inputs.next_version }}"
-          git push
+          git push origin "$branch_name"
 
-      - name: Draft release
-        run: gh release create v${{ inputs.next_version }} --generate-notes --draft
+      - name: Create pull request
+        run: |
+          gh pr create \
+            --base main \
+            --head "release-v${{ inputs.next_version }}" \
+            --title "chore: bump version to v${{ inputs.next_version }}" \
+            --body "This PR contains the changes for the v${{ inputs.next_version }} release."
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ inputs.next_version }}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formbricks/web",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "private": true,
   "scripts": {
     "clean": "rimraf .turbo node_modules .next",


### PR DESCRIPTION
This pull request includes updates to the release workflow and a version bump for the `apps/web` package. The most important changes are as follows:

### Workflow updates:

* [`.github/workflows/prepare-release.yml`](diffhunk://#diff-ddf2bab74923dcd43f9f8d05e50bb1adc9ee5366a394d151d1f04a54a6079486L1-R2): Renamed from `draft-release.yml` and updated the workflow name and run-name to "Prepare release".
* [`.github/workflows/prepare-release.yml`](diffhunk://#diff-ddf2bab74923dcd43f9f8d05e50bb1adc9ee5366a394d151d1f04a54a6079486R14-R17): Added `pull-requests: write` permission under `permissions`.
* [`.github/workflows/prepare-release.yml`](diffhunk://#diff-ddf2bab74923dcd43f9f8d05e50bb1adc9ee5366a394d151d1f04a54a6079486L45-L55): Modified the job name from `draft_release` to `prepare_release`, and updated the steps to create a new branch, commit changes, push to the branch, and create a pull request instead of drafting a release.

### Version bump:

* [`apps/web/package.json`](diffhunk://#diff-14b60f636e1a2b0061da57aaf231cb1ed15a5dc0c592425ed82e58fec95d42d8L3-R3): Updated the version from `3.1.2` to `3.1.3`.