### PR TITLE
chore: revert docker image to old alpine

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:22-alpine3.20 AS base
 
 #
 ## step 1: Prune monorepo


### PR DESCRIPTION
Revert Dockerfile to old alpine version to fix docker build errors.
This pull request includes a small change to the `apps/web/Dockerfile` file. The change updates the base image to a more specific version of Alpine Linux.

* [`apps/web/Dockerfile`](diffhunk://#diff-4eb403c1470ca34300aea23c38f170d0e8b3c16932a5af4c99da390622d3db4eL1-R1): Updated the base image from `node:22-alpine` to `node:22-alpine3.20`.