### PR TITLE
chore: add more legacy docs redirects

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -409,7 +409,7 @@
       "source": "/docs/app-surveys/framework-guides"
     },
     {
-      "destination": "/docs/xm-and-surveys/surveys/website-app-surveys/actions",
+      "destination": "/xm-and-surveys/surveys/website-app-surveys/actions",
       "permanent": true,
       "source": "/docs/app-surveys/actions"
     },


### PR DESCRIPTION
This pull request includes a change to the `docs/mint.json` file to correct the destination path for a specific documentation link.

* [`docs/mint.json`](diffhunk://#diff-c91a604899dfef4b2494c317f4fd39a7f22b79986095f580399347293d534debL412-R412): Updated the `destination` path for the `/docs/app-surveys/actions` source to remove the redundant `/docs` prefix.