### PR TITLE
chore: update legacy docs rewrites

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -411,7 +411,7 @@
     {
       "destination": "/xm-and-surveys/surveys/website-app-surveys/actions",
       "permanent": true,
-      "source": "/docs/app-surveys/actions"
+      "source": "/app-surveys/actions"
     },
     {
       "destination": "/docs/xm-and-surveys/surveys/website-app-surveys/advanced-targeting",


### PR DESCRIPTION
This pull request includes a small change to the `docs/mint.json` file. The change corrects the source path for a redirection rule.

* [`docs/mint.json`](diffhunk://#diff-c91a604899dfef4b2494c317f4fd39a7f22b79986095f580399347293d534debL414-R414): Updated the `source` path from `/docs/app-surveys/actions` to `/app-surveys/actions` in the redirection rule.