### PR TITLE
chore: add more legacy docs redirects

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -409,7 +409,7 @@
       "source": "/docs/app-surveys/framework-guides"
     },
     {
-      "destination": "/xm-and-surveys/surveys/website-app-surveys/actions",
+      "destination": "/docs/xm-and-surveys/surveys/website-app-surveys/actions",
       "permanent": true,
       "source": "/app-surveys/actions"
     },


### PR DESCRIPTION
This pull request includes a small change to the `docs/mint.json` file. The change updates the `destination` URL for the `/app-surveys/actions` source to a new path. 

* [`docs/mint.json`](diffhunk://#diff-c91a604899dfef4b2494c317f4fd39a7f22b79986095f580399347293d534debL412-R412): Updated the `destination` URL from `/xm-and-surveys/surveys/website-app-surveys/actions` to `/docs/xm-and-surveys/surveys/website-app-surveys/actions`.