### PR TITLE
fix: scorecard filename

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -64,7 +64,7 @@ jobs:
       - name: "Upload artifact"
         uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
         with:
-          name: SARIF-file
+          name: sarif
           path: results.sarif
           retention-days: 5
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/scorecard.yml` file. The change renames the artifact from `SARIF-file` to `sarif` in the upload artifact step.

* [`.github/workflows/scorecard.yml`](diffhunk://#diff-2e3112f4e81a9c47df8000638ce3b1b9ca15edcc82b228c207a7a4ff3bc7133fL67-R67): Renamed the artifact from `SARIF-file` to `sarif` in the `Upload artifact` step.