### PR TITLE
chore: update scorecard action artifact version

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -62,7 +62,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: sarif
           path: results.sarif


### PR DESCRIPTION
This pull request includes an update to the GitHub Actions workflow configuration for the `scorecard.yml` file. The main change involves updating the version of the `actions/upload-artifact` action.

* [`.github/workflows/scorecard.yml`](diffhunk://#diff-2e3112f4e81a9c47df8000638ce3b1b9ca15edcc82b228c207a7a4ff3bc7133fL65-R65): Updated the `actions/upload-artifact` action from version `97a0fba1372883ab732affbe8f94b823f91727db` (v3.pre.node20) to `65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08` (v4.6.0).