### PR TITLE
docs: add monitoring page to self-hosting

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -244,7 +244,8 @@
       "pages": [
         "self-hosting/setup/one-click",
         "self-hosting/setup/docker",
-        "self-hosting/setup/cluster-setup"
+        "self-hosting/setup/cluster-setup",
+        "self-hosting/setup/monitoring"
       ]
     },
     {

--- a/docs/self-hosting/setup/monitoring.mdx
+++ b/docs/self-hosting/setup/monitoring.mdx
@@ -1,0 +1,91 @@
+---
+title: "Monitoring"
+description: "Monitoring your Formbricks installation for optimal performance."
+icon: "magnifying-glass-chart"
+---
+
+## Logging
+
+Formbricks follows Next.js best practices with all logs being written to stdout/stderr, making it easy to collect and forward logs to your preferred logging solution.
+
+### Docker Container Logs
+
+```bash
+# One-Click setup
+cd formbricks
+docker compose logs
+
+# Standard Docker commands
+docker logs <container-name>
+docker logs -f <container-name> # Follow logs
+```
+
+### Kubernetes Pod Logs
+
+```bash
+kubectl logs <pod-name> -n <namespace>
+kubectl logs -f <pod-name> -n <namespace> # Follow logs
+```
+
+### Log Forwarding
+
+Since all logs are written to stdout/stderr, you can integrate with various logging solutions:
+
+- ELK Stack (Elasticsearch, Logstash, Kibana)
+- Fluentd/Fluent Bit
+- Datadog
+- Splunk
+- CloudWatch Logs (AWS)
+
+## OpenTelemetry Integration (Beta)
+
+Formbricks leverages Next.js's built-in OpenTelemetry instrumentation for comprehensive observability. When enabled, it automatically instruments various aspects of your application.
+
+Set the following environment variables:
+
+```env
+OTEL_ENABLED=true
+OTEL_ENDPOINT=<your-collector-endpoint>
+OTEL_SERVICE_NAME=formbricks
+NEXT_OTEL_VERBOSE=1 # Optional: enables detailed tracing
+```
+
+### Default Instrumentation
+
+The OpenTelemetry integration automatically tracks:
+
+- HTTP requests and responses
+- Route rendering
+- API route execution
+- Server-side operations
+- Database queries
+- External API calls
+
+### Supported Backends
+
+OpenTelemetry can export data to:
+
+- Jaeger
+- Zipkin
+- Prometheus
+- New Relic
+- Datadog
+- Azure Monitor
+
+### Key Metrics
+
+- HTTP request duration
+- Database performance
+- Memory usage
+- Response times
+- Error rates
+
+## Health Checks
+
+Available endpoints:
+
+```
+GET /health
+```
+
+Use these endpoints for monitoring system health in container orchestration and monitoring tools.


### PR DESCRIPTION
This pull request adds a new monitoring setup guide for self-hosting Formbricks. The most important changes include updating the documentation to include a new monitoring page and providing detailed instructions on logging, OpenTelemetry integration, and health checks.

Documentation updates:

* [`docs/mint.json`](diffhunk://#diff-c91a604899dfef4b2494c317f4fd39a7f22b79986095f580399347293d534debL247-R248): Added a reference to the new `self-hosting/setup/monitoring` page.
* [`docs/self-hosting/setup/monitoring.mdx`](diffhunk://#diff-e2febdcaaa0b05a391947d4e736f0bcdbbe45e7808c81518aa9a12198d33d47eR1-R91): Created a new monitoring setup guide with sections on logging, OpenTelemetry integration, and health checks.