### PR TITLE
chore: remove depot docker build dependency

### DIFF
--- a/.github/workflows/release-docker-github-experimental.yml
+++ b/.github/workflows/release-docker-github-experimental.yml
@@ -31,14 +31,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Depot CLI
-        uses: depot/setup-action@v1
-
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@v3.5.0
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -62,10 +63,8 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: depot/build-push-action@v1
+        uses: docker/build-push-action@v5
         with:
-          project: tw0fqmsx3c
-          token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
           context: .
           file: ./apps/web/Dockerfile
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release-docker-github.yml
+++ b/.github/workflows/release-docker-github.yml
@@ -34,14 +34,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Set up Depot CLI
-        uses: depot/setup-action@v1
-
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@v3.5.0
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
@@ -65,10 +66,8 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: depot/build-push-action@v1
+        uses: docker/build-push-action@v5
         with:
-          project: tw0fqmsx3c
-          token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
           context: .
           file: ./apps/web/Dockerfile
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to replace the use of Depot CLI and build-push actions with Docker's setup-buildx-action and build-push-action. The changes ensure a more streamlined and consistent approach to building and pushing Docker images.

Updates to GitHub Actions workflows:

* [`.github/workflows/release-docker-github-experimental.yml`](diffhunk://#diff-ca771c4570224bd7bedb11ae73bd1ddcbb53e93805797556ec9761dc37e76353L34-R43): Removed the setup of Depot CLI and replaced `depot/build-push-action@v1` with `docker/build-push-action@v5`. Additionally, added the setup of Docker Buildx. [[1]](diffhunk://#diff-ca771c4570224bd7bedb11ae73bd1ddcbb53e93805797556ec9761dc37e76353L34-R43) [[2]](diffhunk://#diff-ca771c4570224bd7bedb11ae73bd1ddcbb53e93805797556ec9761dc37e76353L65-L68)
* [`.github/workflows/release-docker-github.yml`](diffhunk://#diff-97f60e2f0f6e69dfe1ae7fce8784e352b5be0d905d9de440b55d449009606717L37-R46): Removed the setup of Depot CLI and replaced `depot/build-push-action@v1` with `docker/build-push-action@v5`. Additionally, added the setup of Docker Buildx. [[1]](diffhunk://#diff-97f60e2f0f6e69dfe1ae7fce8784e352b5be0d905d9de440b55d449009606717L37-R46) [[2]](diffhunk://#diff-97f60e2f0f6e69dfe1ae7fce8784e352b5be0d905d9de440b55d449009606717L68-L71)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Docker image release workflow by replacing legacy build steps with a modern, efficient process using Docker Buildx.
  - Streamlined image building and pushing to enhance overall release efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->