### PR TITLE
fix: sonarqube action not running in merge queue

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -6,6 +6,7 @@ on:
       - main
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/sonarqube.yml` file. The change adds a new trigger for `merge_group` under the `on:` section to the SonarQube workflow.

* [`.github/workflows/sonarqube.yml`](diffhunk://#diff-a5e11e7bedd328777f4897395a711a4492d413b70b12479230470ec608d96792R9): Added `merge_group` to the workflow triggers.