### PR TITLE
fix: sonarqube not running for contributors

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target: # Using pull_request_target to access secrets in fork PRs
     types: [opened, synchronize, reopened]
   merge_group:
 permissions:
@@ -14,9 +14,14 @@ jobs:
     name: SonarQube
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+          # For pull_request_target, we need to check out the PR head
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || '' }}
+          # Use GitHub's fetching instead of the action's unsafe code checkouts for PRs
+          repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Setup Node.js 20.x
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af
@@ -51,3 +56,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL || 'https://sonarcloud.io' }}


### PR DESCRIPTION
This pull request includes updates to the SonarQube GitHub Actions workflow to improve security and functionality when analyzing pull requests from forks. The most important changes include switching to `pull_request_target` to access secrets in fork PRs, enhancing the checkout step, and adding a default SonarQube host URL.

Improvements to workflow security and functionality:

* [`.github/workflows/sonarqube.yml`](diffhunk://#diff-a5e11e7bedd328777f4897395a711a4492d413b70b12479230470ec608d96792L7-R7): Changed the event trigger from `pull_request` to `pull_request_target` to allow access to secrets in fork PRs.
* [`.github/workflows/sonarqube.yml`](diffhunk://#diff-a5e11e7bedd328777f4897395a711a4492d413b70b12479230470ec608d96792L17-R24): Enhanced the checkout step to handle PRs by checking out the PR head and using GitHub's fetching mechanism.
* [`.github/workflows/sonarqube.yml`](diffhunk://#diff-a5e11e7bedd328777f4897395a711a4492d413b70b12479230470ec608d96792R59): Added a default value for `SONAR_HOST_URL` in the environment variables to ensure the workflow can run even if the secret is not set.