### PR TITLE
fix(helm-chart): missing envFrom when using secret.enabled

### DIFF
--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
               protocol: {{ $config.protocol | default "TCP" | quote }}
             {{- end }}
           {{- end }}
-          {{- if or .Values.deployment.envFrom (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) }}
+          {{- if or .Values.deployment.envFrom (or (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) .Values.secret.enabled) }}
           envFrom:
           {{- if or .Values.secret.enabled (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) }}
           - secretRef:


### PR DESCRIPTION
## What does this PR do?

Fixes #4990 

## How should this be tested?

Running helm template with default values should get envFrom, app-secrets



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved the deployment configuration to support more flexible environment variable sourcing from secret options, ensuring enhanced reliability in deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->