### PR TITLE
fix: single use link generation

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/ShareEmbedSurvey.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/ShareEmbedSurvey.tsx
@@ -60,7 +60,7 @@ export const ShareEmbedSurvey = ({
 
   const [activeId, setActiveId] = useState(survey.type === "link" ? tabs[0].id : tabs[3].id);
   const [showView, setShowView] = useState<"start" | "embed" | "panel">("start");
-  const [surveyUrl, setSurveyUrl] = useState(webAppUrl + "/s/" + survey.id);
+  const [surveyUrl, setSurveyUrl] = useState("");
 
   useEffect(() => {
     if (survey.type !== "link") {

--- a/apps/web/modules/analysis/components/ShareSurveyLink/components/SurveyLinkDisplay.tsx
+++ b/apps/web/modules/analysis/components/ShareSurveyLink/components/SurveyLinkDisplay.tsx
@@ -6,10 +6,17 @@ interface SurveyLinkDisplayProps {
 
 export const SurveyLinkDisplay = ({ surveyUrl }: SurveyLinkDisplayProps) => {
   return (
-    <Input
-      autoFocus={true}
-      className="mt-2 w-full min-w-96 text-ellipsis rounded-lg border bg-white px-4 py-2 text-slate-800 caret-transparent"
-      defaultValue={surveyUrl}
-    />
+    <>
+      {surveyUrl ? (
+        <Input
+          autoFocus={true}
+          className="mt-2 w-full min-w-96 text-ellipsis rounded-lg border bg-white px-4 py-2 text-slate-800 caret-transparent"
+          value={surveyUrl}
+        />
+      ) : (
+        //loading state
+        <div className="mt-2 h-10 w-full min-w-96 animate-pulse rounded-lg bg-slate-100 px-4 py-2 text-slate-800 caret-transparent"></div>
+      )}
+    </>
   );
 };

--- a/apps/web/modules/analysis/components/ShareSurveyLink/index.tsx
+++ b/apps/web/modules/analysis/components/ShareSurveyLink/index.tsx
@@ -80,6 +80,7 @@ export const ShareSurveyLink = ({
         <Button
           title={t("environments.surveys.preview_survey_in_a_new_tab")}
           aria-label={t("environments.surveys.preview_survey_in_a_new_tab")}
+          disabled={!surveyUrl}
           onClick={() => {
             let previewUrl = surveyUrl;
             if (previewUrl.includes("?")) {
@@ -93,6 +94,7 @@ export const ShareSurveyLink = ({
           <SquareArrowOutUpRight />
         </Button>
         <Button
+          disabled={!surveyUrl}
           variant="secondary"
           title={t("environments.surveys.copy_survey_link_to_clipboard")}
           aria-label={t("environments.surveys.copy_survey_link_to_clipboard")}
@@ -108,11 +110,13 @@ export const ShareSurveyLink = ({
           title={t("environments.surveys.summary.download_qr_code")}
           aria-label={t("environments.surveys.summary.download_qr_code")}
           size={"icon"}
+          disabled={!surveyUrl}
           onClick={downloadQRCode}>
           <QrCode style={{ width: "24px", height: "24px" }} />
         </Button>
         {survey.singleUse?.enabled && (
           <Button
+            disabled={!surveyUrl}
             title="Regenerate single use survey link"
             aria-label="Regenerate single use survey link"
             onClick={generateNewSingleUseLink}>


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Initially for survey with single use links enabled, in survey share modal we showed link without suid and then it changes to link with suid


https://github.com/user-attachments/assets/63228f03-6053-4e1d-a28a-964a9dc71f57



So if someone immediately copies the link after modal opens, wrong links get copied 

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Test share embed modal for single use survyes

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The survey link display now shows a loading indicator when the survey URL isn’t available.
  - Related action buttons (for previewing, copying, downloading, and regenerating the survey link) are disabled until a valid link is ready, enhancing the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->