### PR TITLE
fix: Github release action unable to access secrets

### DIFF
--- a/.github/workflows/formbricks-release.yml
+++ b/.github/workflows/formbricks-release.yml
@@ -1,4 +1,4 @@
-name: Build and release Formbricks images
+name: Build, release & deploy Formbricks images
 
 on:
   workflow_dispatch:

--- a/.github/workflows/formbricks-release.yml
+++ b/.github/workflows/formbricks-release.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy Formbricks
+name: Build and release Formbricks images
 
 on:
   workflow_dispatch:
@@ -8,20 +8,22 @@ on:
 
 jobs:
   docker-build:
-    name: Build stable docker image
+    name: Build & release stable docker image
     if: startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/release-docker-github.yml
+    secrets: inherit
 
   helm-chart-release:
     name: Release Helm Chart
     uses: ./.github/workflows/release-helm-chart.yml
+    secrets: inherit
     needs:
       - docker-build
     with:
       VERSION: ${{ needs.docker-build.outputs.VERSION }}
 
   deploy-formbricks-cloud:
-    name: Deploy Helm Chart
+    name: Deploy Helm Chart to Formbricks Cloud
     secrets: inherit
     uses: ./.github/workflows/deploy-formbricks-cloud.yml
     needs:

--- a/packages/lib/messages/de-DE.json
+++ b/packages/lib/messages/de-DE.json
@@ -778,7 +778,6 @@
         "add_env_api_key": "{environmentType} API-Schlüssel hinzufügen",
         "api_key": "API-Schlüssel",
         "api_key_copied_to_clipboard": "API-Schlüssel in die Zwischenablage kopiert",
-        "api_key_created": "API-Schlüssel erstellt",
         "api_key_deleted": "API-Schlüssel gelöscht",
         "api_key_label": "API-Schlüssel Label",
         "api_key_security_warning": "Aus Sicherheitsgründen wird der API-Schlüssel nur einmal nach der Erstellung angezeigt. Bitte kopiere ihn sofort an einen sicheren Ort.",

--- a/packages/lib/messages/en-US.json
+++ b/packages/lib/messages/en-US.json
@@ -778,7 +778,6 @@
         "add_env_api_key": "Add {environmentType} API Key",
         "api_key": "API Key",
         "api_key_copied_to_clipboard": "API key copied to clipboard",
-        "api_key_created": "API key created",
         "api_key_deleted": "API Key deleted",
         "api_key_label": "API Key Label",
         "api_key_security_warning": "For security reasons, the API key will only be shown once after creation. Please copy it to your destination right away.",

--- a/packages/lib/messages/fr-FR.json
+++ b/packages/lib/messages/fr-FR.json
@@ -778,7 +778,6 @@
         "add_env_api_key": "Ajouter la clé API {environmentType}",
         "api_key": "Clé API",
         "api_key_copied_to_clipboard": "Clé API copiée dans le presse-papiers",
-        "api_key_created": "Clé API créée",
         "api_key_deleted": "Clé API supprimée",
         "api_key_label": "Étiquette de clé API",
         "api_key_security_warning": "Pour des raisons de sécurité, la clé API ne sera affichée qu'une seule fois après sa création. Veuillez la copier immédiatement à votre destination.",

--- a/packages/lib/messages/pt-BR.json
+++ b/packages/lib/messages/pt-BR.json
@@ -778,7 +778,6 @@
         "add_env_api_key": "Adicionar chave de API {environmentType}",
         "api_key": "Chave de API",
         "api_key_copied_to_clipboard": "Chave da API copiada para a área de transferência",
-        "api_key_created": "Chave da API criada",
         "api_key_deleted": "Chave da API deletada",
         "api_key_label": "Rótulo da Chave API",
         "api_key_security_warning": "Por motivos de segurança, a chave da API será mostrada apenas uma vez após a criação. Por favor, copie-a para o seu destino imediatamente.",

--- a/packages/lib/messages/pt-PT.json
+++ b/packages/lib/messages/pt-PT.json
@@ -778,7 +778,6 @@
         "add_env_api_key": "Adicionar Chave API {environmentType}",
         "api_key": "Chave API",
         "api_key_copied_to_clipboard": "Chave API copiada para a área de transferência",
-        "api_key_created": "Chave API criada",
         "api_key_deleted": "Chave API eliminada",
         "api_key_label": "Etiqueta da Chave API",
         "api_key_security_warning": "Por razões de segurança, a chave API será mostrada apenas uma vez após a criação. Por favor, copie-a para o seu destino imediatamente.",

--- a/packages/lib/messages/zh-Hant-TW.json
+++ b/packages/lib/messages/zh-Hant-TW.json
@@ -778,7 +778,6 @@
         "add_env_api_key": "新增 '{'environmentType'}' API 金鑰",
         "api_key": "API 金鑰",
         "api_key_copied_to_clipboard": "API 金鑰已複製到剪貼簿",
-        "api_key_created": "API 金鑰已建立",
         "api_key_deleted": "API 金鑰已刪除",
         "api_key_label": "API 金鑰標籤",
         "api_key_security_warning": "為安全起見，API 金鑰僅在建立後顯示一次。請立即將其複製到您的目的地。",


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/formbricks-release.yml` file and several localization files. The most important changes include renaming the workflow file, updating job names and adding secrets inheritance, and removing a specific localization string from multiple language files.

Workflow file updates:

* Renamed `.github/workflows/formbricks-deploy.yml` to `.github/workflows/formbricks-release.yml` and updated the workflow name to "Build, release & deploy Formbricks images".
* Updated job names in the workflow to reflect the release process and added `secrets: inherit` to the `docker-build` and `helm-chart-release` jobs.