### PR TITLE
chore: use github bug report form instead of formbricks form

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/components/TopControlBar.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/components/TopControlBar.tsx
@@ -1,6 +1,5 @@
 import { TopControlButtons } from "@/app/(app)/environments/[environmentId]/components/TopControlButtons";
 import { TTeamPermission } from "@/modules/ee/teams/project-teams/types/team";
-import { IS_FORMBRICKS_CLOUD } from "@formbricks/lib/constants";
 import { TEnvironment } from "@formbricks/types/environment";
 import { TOrganizationRole } from "@formbricks/types/memberships";
 
@@ -24,7 +23,6 @@ export const TopControlBar = ({
           <TopControlButtons
             environment={environment}
             environments={environments}
-            isFormbricksCloud={IS_FORMBRICKS_CLOUD}
             membershipRole={membershipRole}
             projectPermission={projectPermission}
           />

--- a/apps/web/app/(app)/environments/[environmentId]/components/TopControlButtons.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/components/TopControlButtons.tsx
@@ -6,9 +6,9 @@ import { getTeamPermissionFlags } from "@/modules/ee/teams/utils/teams";
 import { Button } from "@/modules/ui/components/button";
 import { TooltipRenderer } from "@/modules/ui/components/tooltip";
 import { useTranslate } from "@tolgee/react";
-import { CircleUserIcon, MessageCircleQuestionIcon, PlusIcon } from "lucide-react";
+import { BugIcon, CircleUserIcon, PlusIcon } from "lucide-react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
-import formbricks from "@formbricks/js";
 import { getAccessFlags } from "@formbricks/lib/membership/utils";
 import { TEnvironment } from "@formbricks/types/environment";
 import { TOrganizationRole } from "@formbricks/types/memberships";
@@ -16,7 +16,6 @@ import { TOrganizationRole } from "@formbricks/types/memberships";
 interface TopControlButtonsProps {
   environment: TEnvironment;
   environments: TEnvironment[];
-  isFormbricksCloud: boolean;
   membershipRole?: TOrganizationRole;
   projectPermission: TTeamPermission | null;
 }
@@ -24,7 +23,6 @@ interface TopControlButtonsProps {
 export const TopControlButtons = ({
   environment,
   environments,
-  isFormbricksCloud,
   membershipRole,
   projectPermission,
 }: TopControlButtonsProps) => {
@@ -38,19 +36,15 @@ export const TopControlButtons = ({
   return (
     <div className="z-50 flex items-center space-x-2">
       {!isBilling && <EnvironmentSwitch environment={environment} environments={environments} />}
-      {isFormbricksCloud && (
-        <TooltipRenderer tooltipContent={t("common.share_feedback")}>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-fit w-fit bg-slate-50 p-1"
-            onClick={() => {
-              formbricks.track("Top Menu: Product Feedback");
-            }}>
-            <MessageCircleQuestionIcon />
-          </Button>
-        </TooltipRenderer>
-      )}
+
+      <TooltipRenderer tooltipContent={t("common.share_feedback")}>
+        <Button variant="ghost" size="icon" className="h-fit w-fit bg-slate-50 p-1" asChild>
+          <Link href="https://github.com/formbricks/formbricks/issues/new/choose" target="_blank">
+            <BugIcon />
+          </Link>
+        </Button>
+      </TooltipRenderer>
+
       <TooltipRenderer tooltipContent={t("common.account")}>
         <Button
           variant="ghost"

--- a/packages/lib/messages/de-DE.json
+++ b/packages/lib/messages/de-DE.json
@@ -778,6 +778,7 @@
         "add_env_api_key": "{environmentType} API-Schlüssel hinzufügen",
         "api_key": "API-Schlüssel",
         "api_key_copied_to_clipboard": "API-Schlüssel in die Zwischenablage kopiert",
+        "api_key_created": "API-Schlüssel erstellt",
         "api_key_deleted": "API-Schlüssel gelöscht",
         "api_key_label": "API-Schlüssel Label",
         "api_key_security_warning": "Aus Sicherheitsgründen wird der API-Schlüssel nur einmal nach der Erstellung angezeigt. Bitte kopiere ihn sofort an einen sicheren Ort.",

--- a/packages/lib/messages/en-US.json
+++ b/packages/lib/messages/en-US.json
@@ -778,6 +778,7 @@
         "add_env_api_key": "Add {environmentType} API Key",
         "api_key": "API Key",
         "api_key_copied_to_clipboard": "API key copied to clipboard",
+        "api_key_created": "API key created",
         "api_key_deleted": "API Key deleted",
         "api_key_label": "API Key Label",
         "api_key_security_warning": "For security reasons, the API key will only be shown once after creation. Please copy it to your destination right away.",

--- a/packages/lib/messages/fr-FR.json
+++ b/packages/lib/messages/fr-FR.json
@@ -778,6 +778,7 @@
         "add_env_api_key": "Ajouter la clé API {environmentType}",
         "api_key": "Clé API",
         "api_key_copied_to_clipboard": "Clé API copiée dans le presse-papiers",
+        "api_key_created": "Clé API créée",
         "api_key_deleted": "Clé API supprimée",
         "api_key_label": "Étiquette de clé API",
         "api_key_security_warning": "Pour des raisons de sécurité, la clé API ne sera affichée qu'une seule fois après sa création. Veuillez la copier immédiatement à votre destination.",

--- a/packages/lib/messages/pt-BR.json
+++ b/packages/lib/messages/pt-BR.json
@@ -778,6 +778,7 @@
         "add_env_api_key": "Adicionar chave de API {environmentType}",
         "api_key": "Chave de API",
         "api_key_copied_to_clipboard": "Chave da API copiada para a área de transferência",
+        "api_key_created": "Chave da API criada",
         "api_key_deleted": "Chave da API deletada",
         "api_key_label": "Rótulo da Chave API",
         "api_key_security_warning": "Por motivos de segurança, a chave da API será mostrada apenas uma vez após a criação. Por favor, copie-a para o seu destino imediatamente.",

--- a/packages/lib/messages/pt-PT.json
+++ b/packages/lib/messages/pt-PT.json
@@ -778,6 +778,7 @@
         "add_env_api_key": "Adicionar Chave API {environmentType}",
         "api_key": "Chave API",
         "api_key_copied_to_clipboard": "Chave API copiada para a área de transferência",
+        "api_key_created": "Chave API criada",
         "api_key_deleted": "Chave API eliminada",
         "api_key_label": "Etiqueta da Chave API",
         "api_key_security_warning": "Por razões de segurança, a chave API será mostrada apenas uma vez após a criação. Por favor, copie-a para o seu destino imediatamente.",

--- a/packages/lib/messages/zh-Hant-TW.json
+++ b/packages/lib/messages/zh-Hant-TW.json
@@ -778,6 +778,7 @@
         "add_env_api_key": "新增 '{'environmentType'}' API 金鑰",
         "api_key": "API 金鑰",
         "api_key_copied_to_clipboard": "API 金鑰已複製到剪貼簿",
+        "api_key_created": "API 金鑰已建立",
         "api_key_deleted": "API 金鑰已刪除",
         "api_key_label": "API 金鑰標籤",
         "api_key_security_warning": "為安全起見，API 金鑰僅在建立後顯示一次。請立即將其複製到您的目的地。",


### PR DESCRIPTION
Changing the "Provide feedback" button using Formbricks to a general button redirecting to the Github create issues page.

Changes to components:

* Removed the `isFormbricksCloud` property from `TopControlBar` and `TopControlButtons` components. (`apps/web/app/(app)/environments/[environmentId]/components/TopControlBar.tsx`, `apps/web/app/(app)/environments/[environmentId]/components/TopControlButtons.tsx`) ([apps/web/app/(app)/environments/[environmentId]/components/TopControlBar.tsxL3](diffhunk://#diff-440811ae8fbbff666572ea1f36ee42e58eb4367df8ceb19465e718173a07595fL3), [apps/web/app/(app)/environments/[environmentId]/components/TopControlBar.tsxL27](diffhunk://#diff-440811ae8fbbff666572ea1f36ee42e58eb4367df8ceb19465e718173a07595fL27), [apps/web/app/(app)/environments/[environmentId]/components/TopControlButtons.tsxL9-L27](diffhunk://#diff-d462e6bae2a9f91b995cbce3cb921689550bfedccd79a3060d063d38e8a5cae8L9-L27), [apps/web/app/(app)/environments/[environmentId]/components/TopControlButtons.tsxL41-R47](diffhunk://#diff-d462e6bae2a9f91b995cbce3cb921689550bfedccd79a3060d063d38e8a5cae8L41-R47))
* Added a new feedback button that links to GitHub issues in `TopControlButtons` component. (`apps/web/app/(app)/environments/[environmentId]/components/TopControlButtons.tsx`) ([apps/web/app/(app)/environments/[environmentId]/components/TopControlButtons.tsxL41-R47](diffhunk://#diff-d462e6bae2a9f91b995cbce3cb921689550bfedccd79a3060d063d38e8a5cae8L41-R47))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the feedback control so that users are now directed to our GitHub issues page with a refreshed icon and tooltip for improved ease of access.
	- Added new confirmation messages for API key creation, available in multiple languages to enhance the localized user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->