### PR TITLE
fix: github issues url required login

### DIFF
--- a/.github/workflows/release-docker-github.yml
+++ b/.github/workflows/release-docker-github.yml
@@ -19,7 +19,6 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-  DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/formbricks?schema=public"
 
 permissions:
   contents: read

--- a/apps/web/app/(app)/environments/[environmentId]/components/TopControlButtons.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/components/TopControlButtons.tsx
@@ -39,7 +39,7 @@ export const TopControlButtons = ({
 
       <TooltipRenderer tooltipContent={t("common.share_feedback")}>
         <Button variant="ghost" size="icon" className="h-fit w-fit bg-slate-50 p-1" asChild>
-          <Link href="https://github.com/formbricks/formbricks/issues/new/choose" target="_blank">
+          <Link href="https://github.com/formbricks/formbricks/issues" target="_blank">
             <BugIcon />
           </Link>
         </Button>


### PR DESCRIPTION
This pull request includes a couple of changes to the configuration and UI components to improve security and user experience.

Configuration changes:
* [`.github/workflows/release-docker-github.yml`](diffhunk://#diff-97f60e2f0f6e69dfe1ae7fce8784e352b5be0d905d9de440b55d449009606717L22): Removed the hardcoded `DATABASE_URL` from the environment variables to enhance security.

UI component changes:
* `apps/web/app/(app)/environments/[environmentId]/components/TopControlButtons.tsx`: Updated the link URL in the `TopControlButtons` component to direct users to the issues page instead of the new issue creation page for better navigation. ([apps/web/app/(app)/environments/[environmentId]/components/TopControlButtons.tsxL42-R42](diffhunk://#diff-d462e6bae2a9f91b995cbce3cb921689550bfedccd79a3060d063d38e8a5cae8L42-R42))