### PR TITLE
chore: remove posthog provider from top layout

### DIFF
--- a/apps/web/app/(app)/layout.test.tsx
+++ b/apps/web/app/(app)/layout.test.tsx
@@ -68,8 +68,6 @@ describe("(app) AppLayout", () => {
     render(element);
 
     expect(screen.getByTestId("no-mobile-overlay")).toBeInTheDocument();
-    expect(screen.getByTestId("ph-pageview")).toBeInTheDocument();
-    expect(screen.getByTestId("ph-provider")).toBeInTheDocument();
     expect(screen.getByTestId("mock-intercom-wrapper")).toBeInTheDocument();
     expect(screen.getByTestId("toaster-client")).toBeInTheDocument();
     expect(screen.getByTestId("child-content")).toHaveTextContent("Hello from children");

--- a/apps/web/app/(app)/layout.test.tsx
+++ b/apps/web/app/(app)/layout.test.tsx
@@ -33,6 +33,9 @@ vi.mock("@formbricks/lib/constants", () => ({
   OIDC_CLIENT_SECRET: "test-oidc-client-secret",
   OIDC_SIGNING_ALGORITHM: "test-oidc-signing-algorithm",
   WEBAPP_URL: "test-webapp-url",
+  IS_POSTHOG_CONFIGURED: true,
+  POSTHOG_API_HOST: "test-posthog-api-host",
+  POSTHOG_API_KEY: "test-posthog-api-key",
 }));
 
 vi.mock("@/app/(app)/components/FormbricksClient", () => ({
@@ -65,6 +68,8 @@ describe("(app) AppLayout", () => {
     render(element);
 
     expect(screen.getByTestId("no-mobile-overlay")).toBeInTheDocument();
+    expect(screen.getByTestId("ph-pageview")).toBeInTheDocument();
+    expect(screen.getByTestId("ph-provider")).toBeInTheDocument();
     expect(screen.getByTestId("mock-intercom-wrapper")).toBeInTheDocument();
     expect(screen.getByTestId("toaster-client")).toBeInTheDocument();
     expect(screen.getByTestId("child-content")).toHaveTextContent("Hello from children");

--- a/apps/web/app/(app)/layout.test.tsx
+++ b/apps/web/app/(app)/layout.test.tsx
@@ -33,9 +33,6 @@ vi.mock("@formbricks/lib/constants", () => ({
   OIDC_CLIENT_SECRET: "test-oidc-client-secret",
   OIDC_SIGNING_ALGORITHM: "test-oidc-signing-algorithm",
   WEBAPP_URL: "test-webapp-url",
-  IS_POSTHOG_CONFIGURED: true,
-  POSTHOG_API_HOST: "test-posthog-api-host",
-  POSTHOG_API_KEY: "test-posthog-api-key",
 }));
 
 vi.mock("@/app/(app)/components/FormbricksClient", () => ({
@@ -46,12 +43,6 @@ vi.mock("@/app/intercom/IntercomClientWrapper", () => ({
 }));
 vi.mock("@/modules/ui/components/no-mobile-overlay", () => ({
   NoMobileOverlay: () => <div data-testid="no-mobile-overlay" />,
-}));
-vi.mock("@/modules/ui/components/post-hog-client", () => ({
-  PHProvider: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="ph-provider">{children}</div>
-  ),
-  PostHogPageview: () => <div data-testid="ph-pageview" />,
 }));
 vi.mock("@/modules/ui/components/toaster-client", () => ({
   ToasterClient: () => <div data-testid="toaster-client" />,
@@ -74,8 +65,6 @@ describe("(app) AppLayout", () => {
     render(element);
 
     expect(screen.getByTestId("no-mobile-overlay")).toBeInTheDocument();
-    expect(screen.getByTestId("ph-pageview")).toBeInTheDocument();
-    expect(screen.getByTestId("ph-provider")).toBeInTheDocument();
     expect(screen.getByTestId("mock-intercom-wrapper")).toBeInTheDocument();
     expect(screen.getByTestId("toaster-client")).toBeInTheDocument();
     expect(screen.getByTestId("child-content")).toHaveTextContent("Hello from children");

--- a/apps/web/app/layout.test.tsx
+++ b/apps/web/app/layout.test.tsx
@@ -105,7 +105,6 @@ describe("RootLayout", () => {
     console.log("vercel", process.env.VERCEL);
 
     expect(screen.getByTestId("speed-insights")).toBeInTheDocument();
-    expect(screen.getByTestId("ph-provider")).toBeInTheDocument();
     expect(screen.getByTestId("tolgee-next-provider")).toBeInTheDocument();
     expect(screen.getByTestId("sentry-provider")).toBeInTheDocument();
     expect(screen.getByTestId("child")).toHaveTextContent("Child Content");

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,4 @@
 import { SentryProvider } from "@/app/sentry/SentryProvider";
-import { PHProvider } from "@/modules/ui/components/post-hog-client";
 import { TolgeeNextProvider } from "@/tolgee/client";
 import { getLocale } from "@/tolgee/language";
 import { getTolgee } from "@/tolgee/server";
@@ -7,7 +6,7 @@ import { TolgeeStaticData } from "@tolgee/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Metadata } from "next";
 import React from "react";
-import { IS_POSTHOG_CONFIGURED, SENTRY_DSN } from "@formbricks/lib/constants";
+import { SENTRY_DSN } from "@formbricks/lib/constants";
 import "../modules/ui/globals.css";
 
 export const metadata: Metadata = {
@@ -29,11 +28,9 @@ const RootLayout = async ({ children }: { children: React.ReactNode }) => {
       <body className="flex h-dvh flex-col transition-all ease-in-out">
         {process.env.VERCEL === "1" && <SpeedInsights sampleRate={0.1} />}
         <SentryProvider sentryDsn={SENTRY_DSN}>
-          <PHProvider posthogEnabled={IS_POSTHOG_CONFIGURED}>
-            <TolgeeNextProvider language={locale} staticData={staticData as unknown as TolgeeStaticData}>
-              {children}
-            </TolgeeNextProvider>
-          </PHProvider>
+          <TolgeeNextProvider language={locale} staticData={staticData as unknown as TolgeeStaticData}>
+            {children}
+          </TolgeeNextProvider>
         </SentryProvider>
       </body>
     </html>


### PR DESCRIPTION
Removing the PostHog provider from the top layout which led to initialization in link surveys which we should avoid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the application layout by removing an unnecessary provider layer, simplifying the component hierarchy while preserving the overall structure and user interface experience.
- **Bug Fixes**
  - Removed outdated PostHog-related configurations and mock components, resulting in a cleaner test setup.
  - Updated tests to reflect the absence of the removed provider, ensuring accuracy in component validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->