### PR TITLE
chore(infra): increase ressource limits to 1 cpu & 1Gi mem

### DIFF
--- a/infra/formbricks-cloud-helm/values.yaml.gotmpl
+++ b/infra/formbricks-cloud-helm/values.yaml.gotmpl
@@ -77,8 +77,8 @@ deployment:
     limits:
       memory: 2Gi
     requests:
-      cpu: 500m
-      memory: 512Mi
+      cpu: 1
+      memory: 1Gi
   env:
     DOCKER_CRON_ENABLED:
       value: "0"


### PR DESCRIPTION
This pull request includes an update to the resource requests and limits for the deployment configuration in the `infra/formbricks-cloud-helm/values.yaml.gotmpl` file.

Resource configuration changes:

* Increased the `cpu` request from `500m` to `1`.
* Increased the `memory` request from `512Mi` to `1Gi`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Adjusted deployment resource allocations to provide enhanced CPU and memory provisioning for improved performance under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->