### PR TITLE
chore: changes storage cache to 5 minutes

### DIFF
--- a/apps/web/app/storage/[environmentId]/[accessType]/[fileName]/lib/get-file.ts
+++ b/apps/web/app/storage/[environmentId]/[accessType]/[fileName]/lib/get-file.ts
@@ -19,7 +19,7 @@ export const getFile = async (
         headers: {
           "Content-Type": metaData.contentType,
           "Content-Disposition": "attachment",
-          "Cache-Control": "public, max-age=1200, s-maxage=1200, stale-while-revalidate=300",
+          "Cache-Control": "public, max-age=300, s-maxage=300, stale-while-revalidate=300",
           Vary: "Accept-Encoding",
         },
       });
@@ -35,10 +35,7 @@ export const getFile = async (
       status: 302,
       headers: {
         Location: signedUrl,
-        "Cache-Control":
-          accessType === "public"
-            ? `public, max-age=3600, s-maxage=3600, stale-while-revalidate=300`
-            : `public, max-age=300, s-maxage=300, stale-while-revalidate=300`,
+        "Cache-Control": "public, max-age=300, s-maxage=300, stale-while-revalidate=300",
       },
     });
   } catch (error: unknown) {

--- a/apps/web/app/storage/[environmentId]/[accessType]/[fileName]/lib/get-file.ts
+++ b/apps/web/app/storage/[environmentId]/[accessType]/[fileName]/lib/get-file.ts
@@ -38,7 +38,7 @@ export const getFile = async (
         "Cache-Control":
           accessType === "public"
             ? `public, max-age=3600, s-maxage=3600, stale-while-revalidate=300`
-            : `public, max-age=600, s-maxage=3600, stale-while-revalidate=300`,
+            : `public, max-age=300, s-maxage=300, stale-while-revalidate=300`,
       },
     });
   } catch (error: unknown) {

--- a/packages/lib/storage/service.ts
+++ b/packages/lib/storage/service.ts
@@ -111,7 +111,7 @@ const getS3SignedUrl = async (fileKey: string): Promise<string> => {
 
   try {
     const s3Client = getS3Client();
-    return await getSignedUrl(s3Client, getObjectCommand, { expiresIn: 300 });
+    return await getSignedUrl(s3Client, getObjectCommand, { expiresIn: 30 * 60 });
   } catch (err) {
     throw err;
   }

--- a/packages/lib/storage/service.ts
+++ b/packages/lib/storage/service.ts
@@ -104,9 +104,6 @@ type TGetSignedUrlResponse =
     };
 
 const getS3SignedUrl = async (fileKey: string): Promise<string> => {
-  const [_, accessType] = fileKey.split("/");
-  const expiresIn = accessType === "public" ? 60 * 60 : 10 * 60;
-
   const getObjectCommand = new GetObjectCommand({
     Bucket: S3_BUCKET_NAME,
     Key: fileKey,
@@ -114,7 +111,7 @@ const getS3SignedUrl = async (fileKey: string): Promise<string> => {
 
   try {
     const s3Client = getS3Client();
-    return await getSignedUrl(s3Client, getObjectCommand, { expiresIn });
+    return await getSignedUrl(s3Client, getObjectCommand, { expiresIn: 300 });
   } catch (err) {
     throw err;
   }


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Changes the cache headers in the storage endpoint to 300 seconds (5 minutes)

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated file caching behavior so that retrieved content is now refreshed consistently every 5 minutes.
  - Standardized file access link expiration to a uniform 30-minute interval for predictable performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->