### PR TITLE
chore: remove unused tailwind import from mobile SDK webviews

### DIFF
--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/webview/FormbricksViewModel.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/webview/FormbricksViewModel.kt
@@ -31,7 +31,6 @@ class FormbricksViewModel : ViewModel() {
             
             <head>
                 <title>Formbricks WebView Survey</title>
-                <script src="https://cdn.tailwindcss.com"></script>
             </head>
 
             <body style="overflow: hidden; height: 100vh; display: flex; flex-direction: column; justify-content: flex-end;">

--- a/packages/ios/FormbricksSDK/FormbricksSDK/WebView/FormbricksViewModel.swift
+++ b/packages/ios/FormbricksSDK/FormbricksSDK/WebView/FormbricksViewModel.swift
@@ -24,7 +24,6 @@ private extension FormbricksViewModel {
             
             <head>
                 <title>Formbricks WebView Survey</title>
-                <script src="https://cdn.tailwindcss.com"></script>
             </head>
 
             <body style="overflow: hidden; height: 100vh; display: flex; flex-direction: column; justify-content: flex-end;">

--- a/packages/react-native/src/components/survey-web-view.tsx
+++ b/packages/react-native/src/components/survey-web-view.tsx
@@ -219,7 +219,6 @@ const renderHtml = (options: Partial<SurveyContainerProps> & { appUrl?: string }
     <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0">
     <head>
       <title>Formbricks WebView Survey</title>
-      <script src="https://cdn.tailwindcss.com"></script>
     </head>
     <body style="overflow: hidden; height: 100vh; margin: 0;">
     </body>


### PR DESCRIPTION
This pull request removes the inclusion of the Tailwind CSS CDN from the HTML head sections in various files across different platforms. This change is aimed at reducing external dependencies and potentially improving loading times.

### Removal of Tailwind CSS CDN:

* [`packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/webview/FormbricksViewModel.kt`](diffhunk://#diff-4d5a89d49609abc3f54481cdf51223f2e3341f39af87a36acf474ef81ff530e5L34): Removed the `<script src="https://cdn.tailwindcss.com"></script>` line from the HTML head section.
* [`packages/ios/FormbricksSDK/FormbricksSDK/WebView/FormbricksViewModel.swift`](diffhunk://#diff-eb010e2be646292e5cb17c428ec96a1d40f632a7869a3b41f69efdfd1fb5b9c9L27): Removed the `<script src="https://cdn.tailwindcss.com"></script>` line from the HTML head section.
* [`packages/react-native/src/components/survey-web-view.tsx`](diffhunk://#diff-61184d75bf68ea3354f35e62b4fc82469d41701f1c148ff573a1dd12e34884baL222): Removed the `<script src="https://cdn.tailwindcss.com"></script>` line from the HTML head section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated survey view styling by removing an external styling asset, which may result in subtle visual adjustments in survey layouts across platforms.
  
- **Chore**
  - Streamlined the HTML template rendering for survey views in our Android, iOS, and React Native apps to ensure a more consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->