### PR TITLE
fix: failing e2e test

### DIFF
--- a/apps/web/playwright/survey.spec.ts
+++ b/apps/web/playwright/survey.spec.ts
@@ -886,18 +886,13 @@ test.describe("Testing Survey with advanced logic", async () => {
     });
 
     await test.step("Verify Survey Response", async () => {
+      await page.goBack();
+      await page.waitForURL(/\/environments\/[^/]+\/surveys\/[^/]+\/summary(\?.*)?$/);
+
       const currentUrl = page.url();
-      const environmentIdMatch = currentUrl.match(/\/environments\/([^/]+)/);
-      const surveyIdMatch = currentUrl.match(/\/surveys\/([^/]+)/);
+      const updatedUrl = currentUrl.replace("summary?share=true", "responses");
 
-      if (!environmentIdMatch || !surveyIdMatch) {
-        throw new Error("Unable to extract environmentId or surveyId from the URL");
-      }
-
-      const environmentId = environmentIdMatch[1];
-      const surveyId = surveyIdMatch[1];
-
-      await page.goto(`/environments/${environmentId}/surveys/${surveyId}/responses`);
+      await page.goto(updatedUrl);
       await page.waitForSelector("#response-table");
 
       await expect(page.getByRole("cell", { name: "score" })).toBeVisible();

--- a/apps/web/playwright/survey.spec.ts
+++ b/apps/web/playwright/survey.spec.ts
@@ -886,13 +886,18 @@ test.describe("Testing Survey with advanced logic", async () => {
     });
 
     await test.step("Verify Survey Response", async () => {
-      await page.goBack();
-      await page.waitForURL(/\/environments\/[^/]+\/surveys\/[^/]+\/summary(\?.*)?$/);
+      const currentUrl = page.url();
+      const environmentIdMatch = currentUrl.match(/\/environments\/([^/]+)/);
+      const surveyIdMatch = currentUrl.match(/\/surveys\/([^/]+)/);
 
-      await page.waitForLoadState("networkidle");
+      if (!environmentIdMatch || !surveyIdMatch) {
+        throw new Error("Unable to extract environmentId or surveyId from the URL");
+      }
 
-      await page.getByRole("button", { name: "Close" }).click();
-      await page.getByRole("link").filter({ hasText: "Responses" }).click();
+      const environmentId = environmentIdMatch[1];
+      const surveyId = surveyIdMatch[1];
+
+      await page.goto(`/environments/${environmentId}/surveys/${surveyId}/responses`);
       await page.waitForSelector("#response-table");
 
       await expect(page.getByRole("cell", { name: "score" })).toBeVisible();


### PR DESCRIPTION
This pull request includes changes to the `apps/web/playwright/survey.spec.ts` file to improve the robustness of survey response verification in tests. The key changes involve extracting environment and survey IDs from the URL and navigating directly to the responses page.

Improvements to test robustness:

* [`apps/web/playwright/survey.spec.ts`](diffhunk://#diff-8b47ad86c284eed0a171ed111afb56745711a30daa4522875d42f50ccbdbfbb2L889-R900): Extracted `environmentId` and `surveyId` from the current URL and used them to navigate directly to the survey responses page, ensuring the correct page is loaded for verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Enhanced the survey response verification process for greater reliability.
  - Streamlined the navigation flow, allowing for more direct access to survey responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->