### PR TITLE
chore: make mock passwords more obvious to test suites

### DIFF
--- a/apps/web/playwright/utils/mock.ts
+++ b/apps/web/playwright/utils/mock.ts
@@ -1,55 +1,57 @@
+const MOCK_PASSWORD = "mock_password_for_testing_only";
+
 export const mockUsers = {
   signup: [
     {
       name: "SignUp Flow User 1",
       email: "signup1@formbricks.com",
-      password: "eN791hZ7wNr9IAscf@",
+      password: MOCK_PASSWORD,
     },
   ],
   onboarding: [
     {
       name: "Onboarding User 1",
       email: "onboarding1@formbricks.com",
-      password: "iHalLonErFGK$X901R0",
+      password: MOCK_PASSWORD,
     },
     {
       name: "Onboarding User 2",
       email: "onboarding2@formbricks.com",
-      password: "231Xh7D&dM8u75EjIYV",
+      password: MOCK_PASSWORD,
     },
     {
       name: "Onboarding User 3",
       email: "onboarding3@formbricks.com",
-      password: "231Xh7D&dM8u75EjIYV",
+      password: MOCK_PASSWORD,
     },
   ],
   survey: [
     {
       name: "Survey User 1",
       email: "survey1@formbricks.com",
-      password: "Y1I*EpURUSb32j5XijP",
+      password: MOCK_PASSWORD,
     },
     {
       name: "Survey User 2",
       email: "survey2@formbricks.com",
-      password: "G73*Gjif22F4JKM1pA",
+      password: MOCK_PASSWORD,
     },
     {
       name: "Survey User 3",
       email: "survey3@formbricks.com",
-      password: "Gj2DGji27D&M8u53V",
+      password: MOCK_PASSWORD,
     },
     {
       name: "Survey User 4",
       email: "survey4@formbricks.com",
-      password: "UU3efj8vJa&M8u5M1",
+      password: MOCK_PASSWORD,
     },
   ],
   js: [
     {
       name: "JS User 1",
       email: "js1@formbricks.com",
-      password: "XpP%X9UU3efj8vJa",
+      password: MOCK_PASSWORD,
     },
   ],
   action: [

--- a/apps/web/playwright/utils/mock.ts
+++ b/apps/web/playwright/utils/mock.ts
@@ -1,4 +1,4 @@
-const MOCK_PASSWORD = "mock_password_for_testing_only";
+const MOCK_PASSWORD = "Mock_password_for_testing_0nly";
 
 export const mockUsers = {
   signup: [


### PR DESCRIPTION
This pull request includes a change to the `apps/web/playwright/utils/mock.ts` file to improve the maintainability and security of the mock user data used for testing. The most important change is the introduction of a constant for mock passwords, which replaces hardcoded passwords across various user scenarios.

Improvements to maintainability and security:

* [`apps/web/playwright/utils/mock.ts`](diffhunk://#diff-c4b33608ea6a26af31418721f9c6469a514ecda700ad476ea4eff5f2ccb879aeR1-R54): Introduced a `MOCK_PASSWORD` constant to replace hardcoded passwords for all mock users in the `signup`, `onboarding`, `survey`, and `js` scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Consolidated test credentials by replacing multiple hardcoded password strings with a centralized constant to improve consistency.

- **Tests**
  - Standardized authentication data across different test scenarios, enhancing the reliability and maintainability of our testing environment.

These improvements streamline our internal testing processes without impacting any end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->