### PR TITLE
chore: use remote turbocache for building formbricks

### DIFF
--- a/.github/actions/cache-build-web/action.yml
+++ b/.github/actions/cache-build-web/action.yml
@@ -8,6 +8,14 @@ on:
         required: false
         default: "0"
 
+inputs:
+  turbo_token:
+    description: "Turborepo token"
+    required: false
+  turbo_team:
+    description: "Turborepo team"
+    required: false
+
 runs:
   using: "composite"
   steps:
@@ -65,5 +73,5 @@ runs:
       if: steps.cache-build.outputs.cache-hit != 'true'
       shell: bash
       env:
-        TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-        TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+        TURBO_TOKEN: ${{ inputs.turbo_token }}
+        TURBO_TEAM: ${{ inputs.turbo_team }}

--- a/.github/actions/cache-build-web/action.yml
+++ b/.github/actions/cache-build-web/action.yml
@@ -48,9 +48,6 @@ runs:
       run: pnpm install --config.platform=linux --config.architecture=x64
       if: steps.cache-build.outputs.cache-hit != 'true'
       shell: bash
-      env:
-        TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-        TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     - name: create .env
       run: cp .env.example .env

--- a/.github/actions/cache-build-web/action.yml
+++ b/.github/actions/cache-build-web/action.yml
@@ -48,6 +48,9 @@ runs:
       run: pnpm install --config.platform=linux --config.architecture=x64
       if: steps.cache-build.outputs.cache-hit != 'true'
       shell: bash
+      env:
+        TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
     - name: create .env
       run: cp .env.example .env
@@ -62,6 +65,8 @@ runs:
 
     - run: |
         pnpm build --filter=@formbricks/web...
-
       if: steps.cache-build.outputs.cache-hit != 'true'
       shell: bash
+      env:
+        TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/.github/workflows/build-web.yml
+++ b/.github/workflows/build-web.yml
@@ -4,7 +4,7 @@ on:
 
 permissions:
   contents: read
-  
+
 jobs:
   build:
     name: Build Formbricks-web
@@ -25,3 +25,5 @@ jobs:
         id: cache-build-web
         with:
           e2e_testing_mode: "0"
+          turbo_token: ${{ secrets.TURBO_TOKEN }}
+          turbo_team: ${{ vars.TURBO_TEAM }}

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
 jobs:
   validate-docker-build:
     name: Validate Docker Build

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,6 +16,8 @@ on:
 
 env:
   TELEMETRY_DISABLED: 1
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
 permissions:
   id-token: write


### PR DESCRIPTION
This pull request includes updates to the `.github/actions/cache-build-web/action.yml` file to enhance the build process by adding environment variables for Turbo.

Enhancements to the build process:

* Added `TURBO_TOKEN` and `TURBO_TEAM` environment variables to the `pnpm install` step.
* Added `TURBO_TOKEN` and `TURBO_TEAM` environment variables to the `pnpm build` step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced the build process by adding new input parameters and environment variables (`turbo_token` and `turbo_team`) to the GitHub Actions workflows, ensuring improved context and configuration for automated tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->