### PR TITLE
fix: updatedAt not set in response update

### DIFF
--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -149,7 +149,7 @@ model Contact {
 model Response {
   id                String            @id @default(cuid())
   createdAt         DateTime          @default(now()) @map(name: "created_at")
-  updatedAt         DateTime          @default(now()) @map(name: "updated_at")
+  updatedAt         DateTime          @default(now()) @updatedAt @map(name: "updated_at")
   finished          Boolean           @default(false)
   survey            Survey            @relation(fields: [surveyId], references: [id], onDelete: Cascade)
   surveyId          String


### PR DESCRIPTION
A customer reported that the response endpoint is not automatically updating the updatedAt field of the response record.
This pull request includes a small but important change to the `packages/database/schema.prisma` file. The change ensures that the `updatedAt` field in the `Response` model is automatically set to the current timestamp whenever the record is updated.

* [`packages/database/schema.prisma`](diffhunk://#diff-aff4becb34f297d4b9f5a8744201839df20f1f4537eb0e875fe074d794cdc1cdL152-R152): Added the `@updatedAt` attribute to the `updatedAt` field in the `Response` model to automatically update the timestamp on record updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Record modification timestamps now update automatically to reflect the most recent changes, ensuring more accurate and reliable data tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->