### PR TITLE
feat: Capture IP Address from survey respondent

### DIFF
--- a/apps/web/modules/survey/editor/components/response-options-card.tsx
+++ b/apps/web/modules/survey/editor/components/response-options-card.tsx
@@ -209,6 +209,10 @@ export const ResponseOptionsCard = ({
     setLocalSurvey({ ...localSurvey, isBackButtonHidden: !localSurvey.isBackButtonHidden });
   };
 
+  const handleIsCaptureIPAddressEnabledToggle = () => {
+    setLocalSurvey({ ...localSurvey, isCaptureIPAddressEnabled: !localSurvey.isCaptureIPAddressEnabled });
+  };
+
   useEffect(() => {
     if (!!localSurvey.surveyClosedMessage) {
       setSurveyClosedMessage({
@@ -290,7 +294,7 @@ export const ResponseOptionsCard = ({
       )}>
       <Collapsible.CollapsibleTrigger asChild className="h-full w-full cursor-pointer">
         <div className="inline-flex px-4 py-4">
-          <div className="flex items-center pl-2 pr-5">
+          <div className="flex items-center pr-5 pl-2">
             <CheckIcon
               strokeWidth={3}
               className="h-7 w-7 rounded-full border border-green-300 bg-green-100 p-1.5 text-green-600"
@@ -328,7 +332,7 @@ export const ResponseOptionsCard = ({
                   value={localSurvey.autoComplete?.toString()}
                   onChange={handleInputResponse}
                   onBlur={handleInputResponseBlur}
-                  className="ml-2 mr-2 inline w-20 bg-white text-center text-sm"
+                  className="mr-2 ml-2 inline w-20 bg-white text-center text-sm"
                 />
                 {t("environments.surveys.edit.completed_responses")}
               </p>
@@ -379,7 +383,7 @@ export const ResponseOptionsCard = ({
                     <Input
                       autoFocus
                       id="heading"
-                      className="mb-4 mt-2 bg-white"
+                      className="mt-2 mb-4 bg-white"
                       name="heading"
                       defaultValue={surveyClosedMessage.heading}
                       onChange={(e) => handleClosedSurveyMessageChange({ heading: e.target.value })}
@@ -434,7 +438,7 @@ export const ResponseOptionsCard = ({
                     <Input
                       autoFocus
                       id="heading"
-                      className="mb-4 mt-2 bg-white"
+                      className="mt-2 mb-4 bg-white"
                       name="heading"
                       value={singleUseMessage.heading}
                       onChange={(e) => handleSingleUseSurveyMessageChange({ heading: e.target.value })}
@@ -442,7 +446,7 @@ export const ResponseOptionsCard = ({
 
                     <Label htmlFor="headline">{t("environments.surveys.edit.subheading")}</Label>
                     <Input
-                      className="mb-4 mt-2 bg-white"
+                      className="mt-2 mb-4 bg-white"
                       id="subheading"
                       name="subheading"
                       value={singleUseMessage.subheading}
@@ -525,6 +529,13 @@ export const ResponseOptionsCard = ({
             onToggle={handleHideBackButtonToggle}
             title={t("environments.surveys.edit.hide_back_button")}
             description={t("environments.surveys.edit.hide_back_button_description")}
+          />
+          <AdvancedOptionToggle
+            htmlId="captureIPAddressButton"
+            isChecked={localSurvey.isCaptureIPAddressEnabled}
+            onToggle={handleIsCaptureIPAddressEnabledToggle}
+            title={t("environments.surveys.edit.capture_ip_address_of_respondent")}
+            description={t("environments.surveys.edit.capture_ip_address_of_respondent_description")}
           />
         </div>
       </Collapsible.CollapsibleContent>

--- a/apps/web/modules/survey/lib/survey.ts
+++ b/apps/web/modules/survey/lib/survey.ts
@@ -42,6 +42,7 @@ export const selectSurvey = {
   resultShareKey: true,
   showLanguageSwitch: true,
   isBackButtonHidden: true,
+  isCaptureIPAddressEnabled: true,
   languages: {
     select: {
       default: true,

--- a/packages/database/migration/20250413114122_add_is_capture_ip_address_enabled_to_survey/migration.sql
+++ b/packages/database/migration/20250413114122_add_is_capture_ip_address_enabled_to_survey/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Survey" ADD COLUMN     "isCaptureIPAddressEnabled" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -418,6 +418,7 @@ model Survey {
   showLanguageSwitch              Boolean?
   documents                       Document[]
   followUps                       SurveyFollowUp[]
+  isCaptureIPAddressEnabled       Boolean          @default(false)
 
   @@index([environmentId, updatedAt])
   @@index([segmentId])

--- a/packages/lib/messages/en-US.json
+++ b/packages/lib/messages/en-US.json
@@ -1322,6 +1322,8 @@
         "cal_username": "Cal.com username or username/event",
         "calculate": "Calculate",
         "capture_a_new_action_to_trigger_a_survey_on": "Capture a new action to trigger a survey on.",
+        "capture_ip_address_of_respondent": "Capture IP address",
+        "capture_ip_address_of_respondent_description": "Captures and stores IP addresses of respondents as metadata.",
         "capture_new_action": "Capture new action",
         "card_arrangement_for_survey_type_derived": "Card Arrangement for {surveyTypeDerived} Surveys",
         "card_background_color": "Card background color",

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -457,6 +457,7 @@ export function Survey({
           meta: {
             ...(isWebEnvironment && { url: window.location.href }),
             action,
+            ...(survey.isCaptureIPAddressEnabled && { isCaptureIPAddressEnabled: true }),
           },
           variables: responseUpdate.variables,
           displayId: surveyState.displayId,

--- a/packages/types/common.ts
+++ b/packages/types/common.ts
@@ -69,3 +69,5 @@ export const getZSafeUrl = (message: string): z.ZodEffects<z.ZodString, string, 
         });
       }
     });
+
+export const ZIP = z.string().ip().optional();

--- a/packages/types/js.ts
+++ b/packages/types/js.ts
@@ -36,6 +36,7 @@ export const ZJsEnvironmentStateSurvey = ZSurvey.innerType()
     delay: true,
     projectOverwrites: true,
     isBackButtonHidden: true,
+    isCaptureIPAddressEnabled: true,
   })
   .superRefine(ZSurvey._def.effect.type === "refinement" ? ZSurvey._def.effect.refinement : () => null);
 

--- a/packages/types/responses.ts
+++ b/packages/types/responses.ts
@@ -245,6 +245,7 @@ export const ZResponseMeta = z.object({
     .optional(),
   country: z.string().optional(),
   action: z.string().optional(),
+  ipAddress: z.string().optional(),
 });
 
 export type TResponseMeta = z.infer<typeof ZResponseMeta>;
@@ -298,6 +299,7 @@ export const ZResponseInput = z.object({
         .optional(),
       country: z.string().optional(),
       action: z.string().optional(),
+      isCaptureIPAddressEnabled: z.boolean().optional(),
     })
     .optional(),
 });

--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -869,6 +869,7 @@ export const ZSurvey = z
     isVerifyEmailEnabled: z.boolean(),
     isSingleResponsePerEmailEnabled: z.boolean(),
     isBackButtonHidden: z.boolean(),
+    isCaptureIPAddressEnabled: z.boolean(),
     pin: z.string().min(4, { message: "PIN must be a four digit number" }).nullish(),
     resultShareKey: z.string().nullable(),
     displayPercentage: z.number().min(0.01).max(100).nullable(),


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #(issue)
Implements feature to capture IP Address from survey respondent based on survey settings 

**Implementation/Technical Approach :**

1. Add column `isCaptureIPAddressEnabled` (boolean) to `Survey` table in schema.prisma.

2. Add settings toggle in `ResponseOptionsCard` component and handler to save setting to db.

3. While rendering the survey, read the value of the above setting. If `true` only capture the IP Address.

    i. While creating request body for new response POST (i.e while creating new response) , include `isCaptureIPAddressEnabled:true` in meta , if above setting is true.
       i.e. inside `packages/surveys/src/components/general/survey.tsx` Survey Component
       
    ii. The above request is received in new response POST action i.e. in `apps/web/app/api/v2/client/[environmentId]/responses/route.ts`. Here is where actual capturing of IP Address from request headers happens.
    
4. Capturing of IP Address is done only if the setting is set to true.

5. The actual Capturing is done by reading the request headers in the fallback order as follows -> "x-forwarded-for" ->
      -> "x-vercel-forwarded-for" -> "CF-Connecting-IP" -> "True-Client-IP" . (Referred Vercel and Cloudfare docs)
      
6. If for some reason capturing fails from all of these headers, it is logged as warning with survey id. If failed it may help to analyze for which scenarios it failed.

7. In case of multiple proxies, the "x-forwarded-for" will have comma separated IP Address of actual client and the proxies. The left most or first IP will be the actual client IP Address.

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

Tested locally by mocking "x-forwarded-for" 
Loom video for same - https://www.loom.com/share/a780d1e637b246f1af359d3fa5c464f5?sid=a3811c75-fbe8-4799-b590-a80a0121952b

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
