### PR TITLE
chore: enable performance insights for rds

### DIFF
--- a/infra/terraform/rds.tf
+++ b/infra/terraform/rds.tf
@@ -40,7 +40,8 @@ module "rds-aurora" {
       cidr_blocks = module.vpc.private_subnets_cidr_blocks
     }
   }
-  performance_insights_enabled = true
+  performance_insights_enabled         = true
+  cluster_performance_insights_enabled = true
 
   backup_retention_period = 7
   apply_immediately       = true


### PR DESCRIPTION
This pull request introduces a small but significant update to the `infra/terraform/rds.tf` file. The change enables performance insights at the cluster level for the Aurora RDS module.

* [`infra/terraform/rds.tf`](diffhunk://#diff-362dcc9c4b0f37a60fd1b45915836650a3d03a4ce73ce64ca7d774da259705a7R44): Added the `cluster_performance_insights_enabled` property and set it to `true` in the `rds-aurora` module to enable performance insights for the entire cluster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled cluster-level performance insights monitoring for the RDS Aurora database, providing enhanced visibility into database performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->