### PR TITLE
chore(infra): increase cloudwatch elb alarm limit to 10

### DIFF
--- a/infra/terraform/cloudwatch.tf
+++ b/infra/terraform/cloudwatch.tf
@@ -47,7 +47,7 @@ locals {
       alarm_description   = "Average API 5XX load balancer error code count is too high"
       comparison_operator = "GreaterThanThreshold"
       evaluation_periods  = 5
-      threshold           = 5
+      threshold           = 10
       period              = 600
       unit                = "Count"
       namespace           = "AWS/ApplicationELB"


### PR DESCRIPTION
This pull request makes a small but important adjustment to the CloudWatch alarm configuration in the Terraform file. The threshold for triggering an alarm on 5XX load balancer error codes has been increased to reduce sensitivity.

* [`infra/terraform/cloudwatch.tf`](diffhunk://#diff-3b85479960c512d8c9c961561a1344f6986846ba39a19263d9a128a0489e7082L50-R50): Updated the `threshold` value in the `locals` block from 5 to 10 for the average API 5XX load balancer error code count alarm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the threshold for the ALB 5XX error CloudWatch alarm to reduce unnecessary alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->