### PR TITLE
fix: docker build error because of deprecated Github cache

### DIFF
--- a/.github/workflows/release-docker-github-experimental.yml
+++ b/.github/workflows/release-docker-github-experimental.yml
@@ -69,7 +69,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1.14.0
+        uses: depot/build-push-action@v1 # v1.14.0
         with:
           project: tw0fqmsx3c
           token: ${{ secrets.DEPOT_PROJECT_TOKEN }}

--- a/.github/workflows/release-docker-github-experimental.yml
+++ b/.github/workflows/release-docker-github-experimental.yml
@@ -69,7 +69,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: depot/build-push-action@v1 # v1.14.0
+        uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1.14.0
         with:
           project: tw0fqmsx3c
           token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
@@ -82,8 +82,6 @@ jobs:
           secrets: |
             database_url=${{ secrets.DUMMY_DATABASE_URL }}
             encryption_key=${{ secrets.DUMMY_ENCRYPTION_KEY }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/.github/workflows/release-docker-github.yml
+++ b/.github/workflows/release-docker-github.yml
@@ -89,7 +89,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1.14.0
+        uses: depot/build-push-action@v1 # v1.14.0
         with:
           project: tw0fqmsx3c
           token: ${{ secrets.DEPOT_PROJECT_TOKEN }}

--- a/.github/workflows/release-docker-github.yml
+++ b/.github/workflows/release-docker-github.yml
@@ -89,7 +89,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: depot/build-push-action@v1 # v1.14.0
+        uses: depot/build-push-action@636daae76684e38c301daa0c5eca1c095b24e780 # v1.14.0
         with:
           project: tw0fqmsx3c
           token: ${{ secrets.DEPOT_PROJECT_TOKEN }}
@@ -102,8 +102,6 @@ jobs:
           secrets: |
             database_url=${{ secrets.DUMMY_DATABASE_URL }}
             encryption_key=${{ secrets.DUMMY_ENCRYPTION_KEY }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/release-docker-github.yml` file. The change simplifies the version reference for the `depot/build-push-action` GitHub Action.

* [`.github/workflows/release-docker-github.yml`](diffhunk://#diff-97f60e2f0f6e69dfe1ae7fce8784e352b5be0d905d9de440b55d449009606717L92-R92): Updated the `uses` field for the `depot/build-push-action` action to use the shorthand `@v1` instead of a specific commit hash. This ensures the workflow always uses the latest compatible version of `v1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated internal workflow configuration for Docker image builds; no impact on user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->