### PR TITLE
fix: android sdk callbacks, tweaks and fixes

### DIFF
--- a/packages/android/app/src/main/java/com/formbricks/demo/MainActivity.kt
+++ b/packages/android/app/src/main/java/com/formbricks/demo/MainActivity.kt
@@ -8,7 +8,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.formbricks.formbrickssdk.Formbricks
-import com.formbricks.formbrickssdk.FormbricksCallback
+//import com.formbricks.formbrickssdk.FormbricksCallback
 import com.formbricks.formbrickssdk.helper.FormbricksConfig
 import java.util.UUID
 
@@ -17,32 +17,30 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        Formbricks.callback = object: FormbricksCallback {
-            override fun onSurveyStarted() {
-                Log.d("FormbricksCallback", "onSurveyStarted")
-            }
+//        Formbricks.callback = object: FormbricksCallback {
+//            override fun onSurveyStarted() {
+//                Log.d("FormbricksCallback", "onSurveyStarted")
+//            }
+//
+//            override fun onSurveyFinished() {
+//                Log.d("FormbricksCallback", "onSurveyFinished")
+//            }
+//
+//            override fun onSurveyClosed() {
+//                Log.d("FormbricksCallback", "onSurveyClosed")
+//            }
+//
+//            override fun onError(error: Exception) {
+//                Log.d("FormbricksCallback", "onError: ${error.localizedMessage}")
+//            }
+//
+//        }
 
-            override fun onSurveyFinished() {
-                Log.d("FormbricksCallback", "onSurveyFinished")
-            }
-
-            override fun onSurveyClosed() {
-                Log.d("FormbricksCallback", "onSurveyClosed")
-            }
-
-            override fun onError(error: Exception) {
-                Log.d("FormbricksCallback", "onError: ${error.localizedMessage}")
-            }
-
-        }
-
-        val config = FormbricksConfig.Builder("[appUrl]","[environmentId]")
+        val config = FormbricksConfig.Builder("http://192.168.29.117:3000","cm9qk3m57000n195soukrmqhh")
             .setLoggingEnabled(true)
             .setFragmentManager(supportFragmentManager)
-        Formbricks.setup(this, config.build())
 
-        Formbricks.logout()
-        Formbricks.setUserId(UUID.randomUUID().toString())
+        Formbricks.setup(this, config.build(), true)
 
         setContentView(R.layout.activity_main)
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
@@ -54,6 +52,31 @@ class MainActivity : AppCompatActivity() {
         val button = findViewById<Button>(R.id.button)
         button.setOnClickListener {
             Formbricks.track("click_demo_button")
+        }
+
+        val setUserIdButton = findViewById<Button>(R.id.setUserId)
+        setUserIdButton.setOnClickListener {
+            Formbricks.setUserId(UUID.randomUUID().toString())
+        }
+
+        val setAttributeButton = findViewById<Button>(R.id.setAttribute)
+        setAttributeButton.setOnClickListener {
+            Formbricks.setAttribute("test@web.com", "email")
+        }
+
+        val setAttributesButton = findViewById<Button>(R.id.setAttributes)
+        setAttributesButton.setOnClickListener {
+            Formbricks.setAttributes(mapOf(Pair("attr1", "val1"), Pair("attr2", "val2")))
+        }
+
+        val setLanguageButton = findViewById<Button>(R.id.setLanguage)
+        setLanguageButton.setOnClickListener {
+            Formbricks.setLanguage("vi")
+        }
+
+        val logoutButton = findViewById<Button>(R.id.logout)
+        logoutButton.setOnClickListener {
+            Formbricks.logout()
         }
     }
 }

--- a/packages/android/app/src/main/java/com/formbricks/demo/MainActivity.kt
+++ b/packages/android/app/src/main/java/com/formbricks/demo/MainActivity.kt
@@ -45,7 +45,7 @@ class MainActivity : AppCompatActivity() {
 
         }
 
-        val config = FormbricksConfig.Builder("http://192.168.0.200:3000","cm9qk3m57000n195soukrmqhh")
+        val config = FormbricksConfig.Builder("[appUrl]","[environmentId]")
             .setLoggingEnabled(true)
             .setFragmentManager(supportFragmentManager)
 

--- a/packages/android/app/src/main/java/com/formbricks/demo/MainActivity.kt
+++ b/packages/android/app/src/main/java/com/formbricks/demo/MainActivity.kt
@@ -49,7 +49,7 @@ class MainActivity : AppCompatActivity() {
             .setLoggingEnabled(true)
             .setFragmentManager(supportFragmentManager)
 
-        Formbricks.setup(this, config.build(), true)
+        Formbricks.setup(this, config.build())
 
         setContentView(R.layout.activity_main)
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->

--- a/packages/android/app/src/main/java/com/formbricks/demo/MainActivity.kt
+++ b/packages/android/app/src/main/java/com/formbricks/demo/MainActivity.kt
@@ -8,8 +8,9 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.formbricks.formbrickssdk.Formbricks
-//import com.formbricks.formbrickssdk.FormbricksCallback
+import com.formbricks.formbrickssdk.FormbricksCallback
 import com.formbricks.formbrickssdk.helper.FormbricksConfig
+import com.formbricks.formbrickssdk.model.enums.SuccessType
 import java.util.UUID
 
 class MainActivity : AppCompatActivity() {
@@ -17,26 +18,34 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-//        Formbricks.callback = object: FormbricksCallback {
-//            override fun onSurveyStarted() {
-//                Log.d("FormbricksCallback", "onSurveyStarted")
-//            }
-//
-//            override fun onSurveyFinished() {
-//                Log.d("FormbricksCallback", "onSurveyFinished")
-//            }
-//
-//            override fun onSurveyClosed() {
-//                Log.d("FormbricksCallback", "onSurveyClosed")
-//            }
-//
-//            override fun onError(error: Exception) {
-//                Log.d("FormbricksCallback", "onError: ${error.localizedMessage}")
-//            }
-//
-//        }
+        Formbricks.callback = object: FormbricksCallback {
+            override fun onSurveyStarted() {
+                Log.d("FormbricksCallback", "onSurveyStarted")
+            }
 
-        val config = FormbricksConfig.Builder("http://192.168.29.117:3000","cm9qk3m57000n195soukrmqhh")
+            override fun onSurveyFinished() {
+                Log.d("FormbricksCallback", "onSurveyFinished")
+            }
+
+            override fun onSurveyClosed() {
+                Log.d("FormbricksCallback", "onSurveyClosed")
+            }
+
+            override fun onPageCommitVisible() {
+                Log.d("FormbricksCallback", "onPageCommitVisible")
+            }
+
+            override fun onError(error: Exception) {
+                Log.d("FormbricksCallback", "onError from the CB: ${error.localizedMessage}")
+            }
+
+            override fun onSuccess(successType: SuccessType) {
+                Log.d("FormbricksCallback", "onSuccess: ${successType.name}")
+            }
+
+        }
+
+        val config = FormbricksConfig.Builder("http://192.168.0.200:3000","cm9qk3m57000n195soukrmqhh")
             .setLoggingEnabled(true)
             .setFragmentManager(supportFragmentManager)
 

--- a/packages/android/app/src/main/res/layout/activity_main.xml
+++ b/packages/android/app/src/main/res/layout/activity_main.xml
@@ -11,11 +11,83 @@
         android:id="@+id/button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Click me!"
+        android:text="Track Action"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHorizontal_bias="0.495"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:layout_editor_absoluteX="158dp"
-        tools:layout_editor_absoluteY="336dp" />
+        app:layout_constraintVertical_bias="0.24" />
+
+    <Button
+        android:id="@+id/setUserId"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="161dp"
+        android:layout_marginTop="27dp"
+        android:layout_marginEnd="154dp"
+        android:layout_marginBottom="12dp"
+        android:text="setUserId"
+        android:visibility="visible"
+        app:layout_constraintBottom_toTopOf="@+id/setLanguage"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/button"
+        tools:visibility="visible" />
+
+    <Button
+        android:id="@+id/setLanguage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="161dp"
+        android:layout_marginTop="12dp"
+        android:layout_marginEnd="128dp"
+        android:layout_marginBottom="11dp"
+        android:text="setLanguage"
+        app:layout_constraintBottom_toTopOf="@+id/setAttribute"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/setUserId" />
+
+    <Button
+        android:id="@+id/setAttribute"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="161dp"
+        android:layout_marginTop="5dp"
+        android:layout_marginEnd="128dp"
+        android:layout_marginBottom="2dp"
+        android:text="setAttribute"
+        app:layout_constraintBottom_toTopOf="@+id/setAttributes"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/setLanguage" />
+
+    <Button
+        android:id="@+id/setAttributes"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="161dp"
+        android:layout_marginTop="1dp"
+        android:layout_marginEnd="120dp"
+        android:layout_marginBottom="10dp"
+        android:text="setAttributes"
+        app:layout_constraintBottom_toTopOf="@+id/logout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/setAttribute" />
+
+    <Button
+        android:id="@+id/logout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="177dp"
+        android:layout_marginTop="9dp"
+        android:layout_marginEnd="146dp"
+        android:layout_marginBottom="199dp"
+        android:text="logout"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/setAttributes" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/packages/android/app/src/main/res/xml/network_security_config.xml
+++ b/packages/android/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">192.168.29.117</domain>
+        <domain includeSubdomains="true">192.168.0.200</domain>
         <domain includeSubdomains="true">localhost</domain>
     </domain-config>
 </network-security-config>

--- a/packages/android/app/src/main/res/xml/network_security_config.xml
+++ b/packages/android/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="true">192.168.0.12</domain>
+        <domain includeSubdomains="true">192.168.29.117</domain>
         <domain includeSubdomains="true">localhost</domain>
     </domain-config>
 </network-security-config>

--- a/packages/android/formbricksSDK/consumer-rules.pro
+++ b/packages/android/formbricksSDK/consumer-rules.pro
@@ -1,3 +1,5 @@
 -keep class com.formbricks.formbrickssdk.DataBinderMapperImpl { *; }
 -keep class com.formbricks.formbrickssdk.Formbricks { *; }
 -keep class com.formbricks.formbrickssdk.helper.FormbricksConfig { *; }
+-keep class com.formbricks.formbrickssdk.model.error.SDKError { *; }
+-keep interface com.formbricks.formbrickssdk.FormbricksCallback { *; }

--- a/packages/android/formbricksSDK/proguard-rules.pro
+++ b/packages/android/formbricksSDK/proguard-rules.pro
@@ -34,3 +34,5 @@
 -keep class com.formbricks.formbrickssdk.DataBinderMapperImpl { *; }
 -keep class com.formbricks.formbrickssdk.Formbricks { *; }
 -keep class com.formbricks.formbrickssdk.helper.FormbricksConfig { *; }
+-keep class com.formbricks.formbrickssdk.model.error.SDKError { *; }
+-keep interface com.formbricks.formbrickssdk.FormbricksCallback { *; }

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/Formbricks.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/Formbricks.kt
@@ -44,7 +44,7 @@ object Formbricks {
      * ```
      *
      */
-    fun setup(context: Context, config: FormbricksConfig) {
+    fun setup(context: Context, config: FormbricksConfig, force: Boolean =  false) {
         applicationContext = context
 
         appUrl = config.appUrl
@@ -57,7 +57,7 @@ object Formbricks {
         config.attributes?.get("language")?.let { UserManager.setLanguage(it) }
 
         FormbricksApi.initialize()
-        SurveyManager.refreshEnvironmentIfNeeded()
+        SurveyManager.refreshEnvironmentIfNeeded(force)
         UserManager.syncUserStateIfNeeded()
 
         isInitialized = true
@@ -77,6 +77,12 @@ object Formbricks {
             Logger.e(exception = SDKError.sdkIsNotInitialized)
             return
         }
+
+        if(UserManager.userId != null) {
+            Logger.e("A userId is already set ${UserManager.userId} - please call logout first before setting a new one.")
+            return
+        }
+
         UserManager.set(userId)
     }
 

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/api/FormbricksApi.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/api/FormbricksApi.kt
@@ -6,10 +6,25 @@ import com.formbricks.formbrickssdk.model.user.PostUserBody
 import com.formbricks.formbrickssdk.model.user.UserResponse
 import com.formbricks.formbrickssdk.network.FormbricksApiService
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
 object FormbricksApi {
     var service = FormbricksApiService()
+
+    private suspend fun <T> retryApiCall(
+        retries: Int = 2,
+        delayTime: Long = 1000,
+        block: suspend () -> Result<T>
+    ): Result<T> {
+        repeat(retries) { attempt ->
+            val result = block()
+            if (result.isSuccess) return result
+            println("⚠️ Retry ${attempt + 1} due to error: ${result.exceptionOrNull()?.localizedMessage}")
+            delay(delayTime)
+        }
+        return block()
+    }
 
     fun initialize() {
         service.initialize(
@@ -19,21 +34,25 @@ object FormbricksApi {
     }
 
     suspend fun getEnvironmentState(): Result<EnvironmentDataHolder> = withContext(Dispatchers.IO) {
-        try {
-            val response = service.getEnvironmentStateObject(Formbricks.environmentId)
-            val result = response.getOrThrow()
-            Result.success(result)
-        } catch (e: Exception) {
-            Result.failure(e)
+        retryApiCall {
+            try {
+                val response = service.getEnvironmentStateObject(Formbricks.environmentId)
+                val result = response.getOrThrow()
+                Result.success(result)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
         }
     }
 
     suspend fun postUser(userId: String, attributes: Map<String, *>?): Result<UserResponse> = withContext(Dispatchers.IO) {
-        try {
-            val result = service.postUser(Formbricks.environmentId, PostUserBody.create(userId, attributes)).getOrThrow()
-            Result.success(result)
-        } catch (e: Exception) {
-            Result.failure(e)
+        retryApiCall {
+            try {
+                val result = service.postUser(Formbricks.environmentId, PostUserBody.create(userId, attributes)).getOrThrow()
+                Result.success(result)
+            } catch (e: Exception) {
+                Result.failure(e)
+            }
         }
     }
 }

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/logger/Logger.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/logger/Logger.kt
@@ -10,9 +10,9 @@ object Logger {
         }
     }
 
-    fun e(message: String? = "Exception", exception: RuntimeException? = null) {
+    fun e(exception: RuntimeException) {
         if (Formbricks.loggingEnabled) {
-            Log.e("FormbricksSDK", message, exception)
+            Log.e("FormbricksSDK", exception.localizedMessage, exception)
         }
     }
 

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/manager/SurveyManager.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/manager/SurveyManager.kt
@@ -144,10 +144,11 @@ object SurveyManager {
 
         if (firstSurveyWithActionClass == null) {
             Formbricks.callback?.onError(SDKError.surveyNotFoundError)
+            return
         }
 
-        val isMultiLangSurvey = (firstSurveyWithActionClass?.languages?.size ?: 0) > 1
-        if(firstSurveyWithActionClass != null && isMultiLangSurvey) {
+        val isMultiLangSurvey = (firstSurveyWithActionClass.languages?.size ?: 0) > 1
+        if(isMultiLangSurvey) {
             val currentLanguage = Formbricks.language
             val languageCode = getLanguageCode(firstSurveyWithActionClass, currentLanguage)
 
@@ -161,10 +162,10 @@ object SurveyManager {
             Formbricks.setLanguage(languageCode)
         }
 
-        val shouldDisplay = shouldDisplayBasedOnPercentage(firstSurveyWithActionClass?.displayPercentage)
+        val shouldDisplay = shouldDisplayBasedOnPercentage(firstSurveyWithActionClass.displayPercentage)
 
         if (shouldDisplay) {
-            firstSurveyWithActionClass?.id?.let {
+            firstSurveyWithActionClass.id.let {
                 isShowingSurvey = true
                 val timeout = firstSurveyWithActionClass.delay ?: 0.0
                 stopDisplayTimer()

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/manager/UserManager.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/manager/UserManager.kt
@@ -149,7 +149,14 @@ object UserManager {
      * Logs out the user and clears the user state.
      */
     fun logout() {
+        val isUserIdDefined = userId != null
+
+        if (!isUserIdDefined) {
+            Logger.e("no userId is set, please set a userId first using the setUserId function")
+        }
+
         prefManager.edit().apply {
+            remove(CONTACT_ID_KEY)
             remove(USER_ID_KEY)
             remove(SEGMENTS_KEY)
             remove(DISPLAYS_KEY)
@@ -158,13 +165,20 @@ object UserManager {
             remove(EXPIRES_AT_KEY)
             apply()
         }
+
         backingUserId = null
+        backingContactId = null
         backingSegments = null
         backingDisplays = null
         backingResponses = null
         backingLastDisplayedAt = null
         backingExpiresAt = null
+        Formbricks.language = "default"
         UpdateQueue.current.reset()
+
+        if(isUserIdDefined) {
+            Logger.d("User logged out successfully!")
+        }
     }
 
     private fun startSyncTimer() {

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/model/enums/SuccessType.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/model/enums/SuccessType.kt
@@ -1,0 +1,7 @@
+package com.formbricks.formbrickssdk.model.enums
+
+enum class SuccessType {
+    SET_USER_SUCCESS,
+    GET_ENVIRONMENT_SUCCESS,
+    LOGOUT_SUCCESS
+}

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/model/environment/Survey.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/model/environment/Survey.kt
@@ -4,6 +4,21 @@ import com.google.gson.annotations.SerializedName
 import kotlinx.serialization.Serializable
 
 @Serializable
+data class SurveyLanguage(
+    @SerializedName("enabled") val enabled: Boolean,
+    @SerializedName("default") val default: Boolean,
+    @SerializedName("language") val language: LanguageDetail
+)
+
+@Serializable
+data class LanguageDetail(
+    @SerializedName("id") val id: String,
+    @SerializedName("code") val code: String,
+    @SerializedName("alias") val alias: String?,
+    @SerializedName("projectId") val projectId: String
+)
+
+@Serializable
 data class Survey(
     @SerializedName("id") val id: String,
     @SerializedName("name") val name: String,
@@ -15,4 +30,5 @@ data class Survey(
     @SerializedName("displayOption") val displayOption: String?,
     @SerializedName("segment") val segment: Segment?,
     @SerializedName("styling") val styling: Styling?,
+    @SerializedName("languages") val languages: List<SurveyLanguage>?
 )

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/model/error/SDKError.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/model/error/SDKError.kt
@@ -1,7 +1,27 @@
 package com.formbricks.formbrickssdk.model.error
 
+import androidx.annotation.Keep
+
+@Keep
 object SDKError {
+    // Errors related to SDK initialization and configuration
     val sdkIsNotInitialized = RuntimeException("Formbricks SDK is not initialized")
+    val sdkIsAlreadyInitialized = RuntimeException("Formbricks SDK is already initialized")
     val fragmentManagerIsNotSet = RuntimeException("The fragment manager is not set.")
+
+    // Errors related to network and connectivity
     val connectionIsNotAvailable = RuntimeException("There is no connection.")
+    val unableToLoadFormbicksJs = RuntimeException("Unable to load Formbricks Javascript package.")
+
+    // Errors related to surveys
+    val surveyDisplayFetchError =
+        RuntimeException("Error: creating display: TypeError: Failure to fetch the survey data.")
+    val surveyNotDisplayedError = RuntimeException("Survey was not displayed due to display percentage restrictions.")
+    val unableToRefreshEnvironment = RuntimeException("Unable to refresh environment state.")
+    val missingSurveyId = RuntimeException("Survey id is mandatory to set.")
+    val invalidDisplayOption = RuntimeException("Invalid Display Option.")
+    val unableToPostResponse = RuntimeException("Unable to post survey response.")
+    val surveyNotFoundError = RuntimeException("No survey found matching the action class.")
+    val noUserIdSetError = RuntimeException("No userId is set, please set a userId first using the setUserId function")
+
 }

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/model/user/UserStateData.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/model/user/UserStateData.kt
@@ -8,5 +8,6 @@ data class UserStateData(
     @SerializedName("segments") val segments: List<String>?,
     @SerializedName("displays") val displays: List<Display>?,
     @SerializedName("responses") val responses: List<String>?,
-    @SerializedName("lastDisplayAt") val lastDisplayAt: String?
+    @SerializedName("lastDisplayAt") val lastDisplayAt: String?,
+    @SerializedName("language") val language: String?
 )

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/network/FormbricksService.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/network/FormbricksService.kt
@@ -19,5 +19,4 @@ interface FormbricksService {
     companion object {
         const val API_PREFIX = "/api/v2"
     }
-
 }

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/network/FormbricksService.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/network/FormbricksService.kt
@@ -7,14 +7,13 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
-import retrofit2.http.Query
 
 interface FormbricksService {
     @GET("$API_PREFIX/client/{environmentId}/environment")
-    fun getEnvironmentState(@Path("environmentId") environmentId: String, @Query("randQuery") randQuery: String = System.currentTimeMillis().toString()): Call<Map<String, Any>>
+    fun getEnvironmentState(@Path("environmentId") environmentId: String): Call<Map<String, Any>>
 
     @POST("$API_PREFIX/client/{environmentId}/user")
-    fun postUser(@Path("environmentId") environmentId: String, @Body body: PostUserBody, @Query("randQuery") randQuery: String = System.currentTimeMillis().toString()): Call<UserResponse>
+    fun postUser(@Path("environmentId") environmentId: String, @Body body: PostUserBody): Call<UserResponse>
 
     companion object {
         const val API_PREFIX = "/api/v2"

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/network/FormbricksService.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/network/FormbricksService.kt
@@ -7,14 +7,14 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface FormbricksService {
-
     @GET("$API_PREFIX/client/{environmentId}/environment")
-    fun getEnvironmentState(@Path("environmentId") environmentId: String): Call<Map<String, Any>>
+    fun getEnvironmentState(@Path("environmentId") environmentId: String, @Query("randQuery") randQuery: String = System.currentTimeMillis().toString()): Call<Map<String, Any>>
 
     @POST("$API_PREFIX/client/{environmentId}/user")
-    fun postUser(@Path("environmentId") environmentId: String, @Body body: PostUserBody): Call<UserResponse>
+    fun postUser(@Path("environmentId") environmentId: String, @Body body: PostUserBody, @Query("randQuery") randQuery: String = System.currentTimeMillis().toString()): Call<UserResponse>
 
     companion object {
         const val API_PREFIX = "/api/v2"

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/network/queue/UpdateQueue.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/network/queue/UpdateQueue.kt
@@ -1,7 +1,9 @@
 package com.formbricks.formbrickssdk.network.queue
 
+import com.formbricks.formbrickssdk.Formbricks
 import com.formbricks.formbrickssdk.logger.Logger
 import com.formbricks.formbrickssdk.manager.UserManager
+import com.formbricks.formbrickssdk.model.error.SDKError
 import java.util.*
 import kotlin.concurrent.timer
 
@@ -65,7 +67,9 @@ class UpdateQueue private constructor() {
         val effectiveUserId = userId
             ?: UserManager.userId
         if (effectiveUserId == null) {
-            Logger.d("Error: User ID is not set yet")
+            val error = SDKError.noUserIdSetError
+            Formbricks.callback?.onError(error)
+            Logger.e(error)
             return
         }
 

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/network/queue/UpdateQueue.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/network/queue/UpdateQueue.kt
@@ -36,8 +36,15 @@ class UpdateQueue private constructor() {
     }
 
     fun setLanguage(language: String) {
-        addAttribute("language", language)
-        startDebounceTimer()
+        val effectiveUserId =  userId ?: UserManager.userId
+
+        if(effectiveUserId != null) {
+            addAttribute("language", language)
+            startDebounceTimer()
+        } else {
+            Logger.d("UpdateQueue - updating language locally: ${language}")
+            return
+        }
     }
 
     fun reset() {
@@ -55,14 +62,15 @@ class UpdateQueue private constructor() {
     }
 
     private fun commit() {
-        val currentUserId = userId
-        if (currentUserId == null) {
+        val effectiveUserId = userId
+            ?: UserManager.userId
+        if (effectiveUserId == null) {
             Logger.d("Error: User ID is not set yet")
             return
         }
 
-        Logger.d("UpdateQueue - commit() called on UpdateQueue with $currentUserId and $attributes")
-        UserManager.syncUser(currentUserId, attributes)
+        Logger.d("UpdateQueue - commit() called on UpdateQueue with $effectiveUserId and $attributes")
+        UserManager.syncUser(effectiveUserId, attributes)
     }
 
     companion object {

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/webview/FormbricksFragment.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/webview/FormbricksFragment.kt
@@ -37,9 +37,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.gson.JsonObject
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
-import java.util.Date
 import java.util.Timer
-import java.util.TimerTask
 
 
 class FormbricksFragment : BottomSheetDialogFragment() {
@@ -191,7 +189,6 @@ class FormbricksFragment : BottomSheetDialogFragment() {
 
                 override fun onPageCommitVisible(view: WebView?, url: String?) {
                     dialog?.window?.setDimAmount(0.5f)
-                    Formbricks.callback?.onSurveyStarted()
                     super.onPageCommitVisible(view, url)
                 }
             }

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/webview/FormbricksFragment.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/webview/FormbricksFragment.kt
@@ -7,6 +7,8 @@ import android.content.Intent
 import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.provider.OpenableColumns
 import android.util.Base64
 import android.view.LayoutInflater
@@ -15,7 +17,10 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.webkit.ConsoleMessage
 import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
+import android.webkit.WebViewClient
 import android.widget.FrameLayout
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.FragmentManager
@@ -25,6 +30,7 @@ import com.formbricks.formbrickssdk.R
 import com.formbricks.formbrickssdk.databinding.FragmentFormbricksBinding
 import com.formbricks.formbrickssdk.logger.Logger
 import com.formbricks.formbrickssdk.manager.SurveyManager
+import com.formbricks.formbrickssdk.model.error.SDKError
 import com.formbricks.formbrickssdk.model.javascript.FileUploadData
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -45,10 +51,14 @@ class FormbricksFragment : BottomSheetDialogFragment() {
 
     private var webAppInterface = WebAppInterface(object : WebAppInterface.WebAppCallback {
         override fun onClose() {
-            dismiss()
+            Handler(Looper.getMainLooper()).post {
+                Formbricks.callback?.onSurveyClosed()
+                dismiss()
+            }
         }
 
         override fun onDisplayCreated() {
+            Formbricks.callback?.onSurveyStarted()
             SurveyManager.onNewDisplay(surveyId)
         }
 
@@ -66,6 +76,7 @@ class FormbricksFragment : BottomSheetDialogFragment() {
         }
 
         override fun onSurveyLibraryLoadError() {
+            Formbricks.callback?.onError(SDKError.unableToLoadFormbicksJs)
             dismiss()
         }
     })
@@ -139,6 +150,7 @@ class FormbricksFragment : BottomSheetDialogFragment() {
     @SuppressLint("SetJavaScriptEnabled")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        dialog?.window?.setDimAmount(0.0f)
         binding.formbricksWebview.setBackgroundColor(Color.TRANSPARENT)
         binding.formbricksWebview.let {
 
@@ -150,6 +162,7 @@ class FormbricksFragment : BottomSheetDialogFragment() {
                 override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
                     consoleMessage?.let { cm ->
                         if (cm.messageLevel() == ConsoleMessage.MessageLevel.ERROR) {
+                            Formbricks.callback?.onError(SDKError.surveyDisplayFetchError)
                             dismiss()
                         }
                         val log = "[CONSOLE:${cm.messageLevel()}] \"${cm.message()}\", source: ${cm.sourceId()} (${cm.lineNumber()})"
@@ -164,6 +177,23 @@ class FormbricksFragment : BottomSheetDialogFragment() {
                 domStorageEnabled = true
                 loadWithOverviewMode = true
                 useWideViewPort = true
+            }
+
+            it.webViewClient = object : WebViewClient() {
+                override fun onReceivedError(
+                    view: WebView?,
+                    request: WebResourceRequest?,
+                    error: WebResourceError?
+                ) {
+                    super.onReceivedError(view, request, error)
+                    Logger.d("WebView Error: ${error?.description}")
+                }
+
+                override fun onPageCommitVisible(view: WebView?, url: String?) {
+                    dialog?.window?.setDimAmount(0.5f)
+                    Formbricks.callback?.onSurveyStarted()
+                    super.onPageCommitVisible(view, url)
+                }
             }
 
             it.setOnFocusChangeListener { _, hasFocus ->
@@ -220,5 +250,7 @@ class FormbricksFragment : BottomSheetDialogFragment() {
             fragment.surveyId = surveyId
             fragment.show(childFragmentManager, TAG)
         }
+
+        private const val CLOSING_TIMEOUT_IN_SECONDS = 5L
     }
 }

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/webview/FormbricksViewModel.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/webview/FormbricksViewModel.kt
@@ -128,7 +128,7 @@ class FormbricksViewModel : ViewModel() {
         jsonObject.addProperty("isWebEnvironment", false)
 
         val isMultiLangSurvey =
-            (environmentDataHolder.data?.data?.surveys?.first { it.id === surveyId }?.languages?.size
+            (environmentDataHolder.data?.data?.surveys?.first { it.id == surveyId }?.languages?.size
                 ?: 0) > 1
 
         if (isMultiLangSurvey) {

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/webview/FormbricksViewModel.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/webview/FormbricksViewModel.kt
@@ -123,10 +123,19 @@ class FormbricksViewModel : ViewModel() {
         environmentDataHolder.getSurveyJson(surveyId).let { jsonObject.add("survey", it) }
         jsonObject.addProperty("isBrandingEnabled", true)
         jsonObject.addProperty("appUrl", Formbricks.appUrl)
-        jsonObject.addProperty("languageCode", Formbricks.language)
         jsonObject.addProperty("environmentId", Formbricks.environmentId)
         jsonObject.addProperty("contactId", UserManager.contactId)
         jsonObject.addProperty("isWebEnvironment", false)
+
+        val isMultiLangSurvey =
+            (environmentDataHolder.data?.data?.surveys?.first { it.id === surveyId }?.languages?.size
+                ?: 0) > 1
+
+        if (isMultiLangSurvey) {
+            jsonObject.addProperty("languageCode", Formbricks.language)
+        } else {
+            jsonObject.addProperty("languageCode", "default")
+        }
 
         val hasCustomStyling = environmentDataHolder.data?.data?.surveys?.first { it.id == surveyId }?.styling != null
         val enabled = environmentDataHolder.data?.data?.project?.styling?.allowStyleOverwrite ?: false

--- a/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/webview/WebAppInterface.kt
+++ b/packages/android/formbricksSDK/src/main/java/com/formbricks/formbrickssdk/webview/WebAppInterface.kt
@@ -1,11 +1,13 @@
 package com.formbricks.formbrickssdk.webview
 
 import android.webkit.JavascriptInterface
+import com.formbricks.formbrickssdk.Formbricks
 import com.formbricks.formbrickssdk.logger.Logger
 import com.formbricks.formbrickssdk.model.javascript.JsMessageData
 import com.formbricks.formbrickssdk.model.javascript.EventType
 import com.formbricks.formbrickssdk.model.javascript.FileUploadData
 import com.google.gson.JsonParseException
+import java.lang.RuntimeException
 
 class WebAppInterface(private val callback: WebAppCallback?) {
 
@@ -34,13 +36,16 @@ class WebAppInterface(private val callback: WebAppCallback?) {
                 EventType.ON_SURVEY_LIBRARY_LOAD_ERROR -> { callback?.onSurveyLibraryLoadError() }
             }
         } catch (e: Exception) {
-            Logger.e(e.message)
+            Formbricks.callback?.onError(e)
+            Logger.e(RuntimeException(e.message))
         } catch (e: JsonParseException) {
-            Logger.e("Failed to parse JSON message: $data")
+            Logger.e(RuntimeException("Failed to parse JSON message: $data"))
         } catch (e: IllegalArgumentException) {
-            Logger.e("Invalid message format: $data")
+            Formbricks.callback?.onError(e)
+            Logger.e(RuntimeException("Invalid message format: $data"))
         } catch (e: Exception) {
-            Logger.e("Unexpected error processing message: $data")
+            Formbricks.callback?.onError(e)
+            Logger.e(RuntimeException("Unexpected error processing message: $data"))
         }
     }
 

--- a/packages/ios/FormbricksSDK/FormbricksSDK/Formbricks.swift
+++ b/packages/ios/FormbricksSDK/FormbricksSDK/Formbricks.swift
@@ -41,6 +41,7 @@ import Network
      */
     @objc public static func setup(with config: FormbricksConfig, force: Bool = false) {
         logger = Logger()
+        apiQueue = OperationQueue()
         
         if (force == true) {
             isInitialized = false
@@ -235,6 +236,7 @@ import Network
     }
 
     private static func performCleanup() {
+        userManager?.logout()
         userManager?.cleanupUpdateQueue()
         presentSurveyManager?.dismissView()
         presentSurveyManager = nil


### PR DESCRIPTION
## What does this PR do?

This pull request introduces significant enhancements and fixes to the Formbricks Android SDK, focusing on improving error handling, adding callback support, and expanding functionality for user and survey management. The changes also include updates to the demo app and layout files to showcase the new features.

### SDK Enhancements:
* Added a `FormbricksCallback` interface to handle SDK lifecycle events such as errors and successes (`onError`, `onSuccess`, etc.), and integrated it throughout the SDK for better client feedback. [[1]](diffhunk://#diff-7b30899d6cac80fb8adcabe70d22c291d62547994f249e4e2b8d1c799cb0d034R13-R27) [[2]](diffhunk://#diff-7b30899d6cac80fb8adcabe70d22c291d62547994f249e4e2b8d1c799cb0d034R40-R41)
* Enhanced error handling by invoking callbacks and logging detailed error messages for uninitialized SDK states, duplicate user IDs, and connection issues. [[1]](diffhunk://#diff-7b30899d6cac80fb8adcabe70d22c291d62547994f249e4e2b8d1c799cb0d034L77-R111) [[2]](diffhunk://#diff-7b30899d6cac80fb8adcabe70d22c291d62547994f249e4e2b8d1c799cb0d034L94-R128) [[3]](diffhunk://#diff-7b30899d6cac80fb8adcabe70d22c291d62547994f249e4e2b8d1c799cb0d034L146-R193)
* Introduced a `retryApiCall` utility to retry API requests with exponential backoff for improved reliability. [[1]](diffhunk://#diff-38650361ec621eecc577f52f6801e3dbec8b0d3aadd2856ffcd64e31f6c34d0aR9-R28) [[2]](diffhunk://#diff-38650361ec621eecc577f52f6801e3dbec8b0d3aadd2856ffcd64e31f6c34d0aR37)

### Demo App Updates:
* Added new buttons (`setUserId`, `setAttribute`, `setAttributes`, `setLanguage`, `logout`) in `activity_main.xml` to demonstrate SDK features. Corresponding click listeners were implemented in `MainActivity.kt`. [[1]](diffhunk://#diff-f6f3fec9f6c7f44a792e0f9a220659d227b39b2bda5780c108df644ecab5fe69L14-R92) [[2]](diffhunk://#diff-77504d8a041f9d69d2128e268f810e645b58fb03d6da9f5b890bcb31a7d3adb2R65-R89)
* Updated the `Formbricks.setup` method in the demo app to accept a `forceRefresh` parameter for reinitializing the SDK if needed.

### ProGuard and Network Configuration:
* Updated ProGuard rules to retain new SDK classes and interfaces (`SDKError`, `FormbricksCallback`) for proper functionality in release builds. [[1]](diffhunk://#diff-fb66c8eeaafe232c0732400c924c8fb2b5799fa552ff1f818ae52602e8c8f47dR4-R5) [[2]](diffhunk://#diff-c3de13ed5893e5be9f2986075e8146cdeecfcea2161d4b763ae165aa644ed55aR37-R38)
* Modified `network_security_config.xml` to update the IP address for cleartext traffic.

### Logging Improvements:
* Simplified the `Logger.e` method to remove redundant parameters and ensure consistent error logging.

These updates collectively improve the SDK's usability, reliability, and extensibility while providing a better developer experience.<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->


<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added interactive buttons for user and session management, including setting user ID, attributes, language, and logout.
  - Introduced callback support for survey lifecycle events, errors, and success states, providing real-time feedback to users.
  - Enhanced multi-language survey support with dynamic language selection.

- **Bug Fixes**
  - Improved error handling and user feedback for missing user IDs and survey errors.

- **Chores**
  - Updated network security configuration and ProGuard rules for improved compatibility and security.

- **Documentation**
  - Updated button labels for clearer user actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->