### PR TITLE
fix: error should not be thrown if SMTP is unconfigured

### DIFF
--- a/apps/web/modules/email/index.tsx
+++ b/apps/web/modules/email/index.tsx
@@ -50,6 +50,10 @@ interface SendEmailDataProps {
 }
 
 export const sendEmail = async (emailData: SendEmailDataProps): Promise<boolean> => {
+  if (!IS_SMTP_CONFIGURED) {
+    logger.info("SMTP is not configured, skipping email sending");
+    return false;
+  }
   try {
     const transporter = createTransport({
       host: SMTP_HOST,


### PR DESCRIPTION
This pull request introduces a safeguard to ensure emails are only sent if SMTP is properly configured. The key change is the addition of a check for the `IS_SMTP_CONFIGURED` flag at the beginning of the `sendEmail` function.

Enhancements to email sending logic:

* [`apps/web/modules/email/index.tsx`](diffhunk://#diff-3a8bac2f946ee49058c8fe811c9694d9ee8deb0dd3388f18f82d1c4e5b30577cR53-R56): Added a conditional check for `IS_SMTP_CONFIGURED` in the `sendEmail` function. If SMTP is not configured, the function logs a message and skips sending the email, returning `false` instead.