### PR TITLE
chore(networking): add vpc CIDR blocks on database and cluster

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -161,15 +161,13 @@ module "eks" {
   }
 
   cluster_security_group_additional_rules = {
-    ingress = [
-      {
-        description = "Allow all traffic from the VPC CIDR"
-        from_port  = 0
-        to_port    = 0
-        protocol   = "-1"
-        cidr_blocks = [local.vpc_cidr]
-      }
-    ]
+    ingress_from_vpc_cidr = {
+      description = "Allow all traffic from the VPC CIDR"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = [local.vpc_cidr]
+    }
   }
 
   kms_key_administrators = [

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -166,6 +166,7 @@ module "eks" {
       from_port   = 0
       to_port     = 0
       protocol    = "-1"
+      type        = "ingress"
       cidr_blocks = [local.vpc_cidr]
     }
   }

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -137,7 +137,7 @@ module "eks" {
   cluster_version = "1.32"
 
   enable_cluster_creator_admin_permissions = false
-  cluster_endpoint_public_access           = true
+  cluster_endpoint_public_access           = false
   cloudwatch_log_group_retention_in_days   = 365
 
   cluster_addons = {
@@ -158,6 +158,18 @@ module "eks" {
     vpc-cni = {
       most_recent = true
     }
+  }
+
+  cluster_security_group_additional_rules = {
+    ingress = [
+      {
+        description = "Allow all traffic from the VPC CIDR"
+        from_port  = 0
+        to_port    = 0
+        protocol   = "-1"
+        cidr_blocks = [local.vpc_cidr]
+      }
+    ]
   }
 
   kms_key_administrators = [

--- a/infra/terraform/rds.tf
+++ b/infra/terraform/rds.tf
@@ -49,7 +49,7 @@ module "rds-aurora" {
   db_subnet_group_name = module.vpc.database_subnet_group_name
   security_group_rules = {
     vpc_ingress = {
-      cidr_blocks = module.vpc.private_subnets_cidr_blocks
+      cidr_blocks = [module.vpc.vpc_cidr_block]
     }
   }
   performance_insights_enabled         = true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Disabled public access to the EKS cluster endpoint.
  - Updated security group rules to allow all internal VPC traffic to the EKS cluster.
  - Expanded RDS Aurora access to permit connections from the entire VPC CIDR block instead of just private subnets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->