### PR TITLE
fix: matrix question logic condition text

### DIFF
--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1459,7 +1459,6 @@
         "is_clicked": "Wird geklickt",
         "is_completely_submitted": "Vollständig eingereicht",
         "is_empty": "Ist leer",
-        "is_not": "Ist nicht",
         "is_not_empty": "Ist nicht leer",
         "is_not_set": "Ist nicht festgelegt",
         "is_partially_submitted": "Teilweise eingereicht",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1459,7 +1459,6 @@
         "is_clicked": "Is clicked",
         "is_completely_submitted": "Is completely submitted",
         "is_empty": "Is empty",
-        "is_not": "Is not",
         "is_not_empty": "Is not empty",
         "is_not_set": "Is not set",
         "is_partially_submitted": "Is partially submitted",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1459,7 +1459,6 @@
         "is_clicked": "Est cliqué",
         "is_completely_submitted": "Est complètement soumis",
         "is_empty": "Est vide",
-        "is_not": "N'est pas",
         "is_not_empty": "N'est pas vide",
         "is_not_set": "N'est pas défini",
         "is_partially_submitted": "Est partiellement soumis",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1459,7 +1459,6 @@
         "is_clicked": "É clicado",
         "is_completely_submitted": "Está completamente submetido",
         "is_empty": "Está vazio",
-        "is_not": "Não está",
         "is_not_empty": "Não está vazio",
         "is_not_set": "Não está definido",
         "is_partially_submitted": "Parcialmente enviado",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1459,7 +1459,6 @@
         "is_clicked": "É clicado",
         "is_completely_submitted": "Está completamente submetido",
         "is_empty": "Está vazio",
-        "is_not": "Não está",
         "is_not_empty": "Não está vazio",
         "is_not_set": "Não está definido",
         "is_partially_submitted": "Está parcialmente submetido",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1459,7 +1459,6 @@
         "is_clicked": "已點擊",
         "is_completely_submitted": "已完全提交",
         "is_empty": "是空的",
-        "is_not": "不是",
         "is_not_empty": "不是空的",
         "is_not_set": "未設定",
         "is_partially_submitted": "已部分提交",

--- a/apps/web/modules/survey/editor/lib/utils.tsx
+++ b/apps/web/modules/survey/editor/lib/utils.tsx
@@ -115,7 +115,7 @@ export const getConditionValueOptions = (
       if (question.type === TSurveyQuestionTypeEnum.Matrix) {
         const rows = question.rows.map((row, rowIdx) => ({
           icon: getQuestionIconMapping(t)[question.type],
-          label: `${getLocalizedValue(question.headline, "default")}: ${getLocalizedValue(row, "default")}`,
+          label: `${getLocalizedValue(row, "default")} (${getLocalizedValue(question.headline, "default")})`,
           value: `${question.id}.${rowIdx}`,
           meta: {
             type: "question",


### PR DESCRIPTION
## What does this PR do?
fixes matrix question logic condition text

Fixes 
![image](https://github.com/user-attachments/assets/853df40b-dfab-40c7-a5f0-f0ea344cf523)


<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the "is_not" translation key from all supported languages in the survey editing interface.
  - Updated matrix question row labels to display as "<row label> (<question headline>)" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->