### PR TITLE
chore: make microsoft login available without tenant

### DIFF
--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -32,8 +32,7 @@ export const EMAIL_VERIFICATION_DISABLED = env.EMAIL_VERIFICATION_DISABLED === "
 
 export const GOOGLE_OAUTH_ENABLED = env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET ? true : false;
 export const GITHUB_OAUTH_ENABLED = env.GITHUB_ID && env.GITHUB_SECRET ? true : false;
-export const AZURE_OAUTH_ENABLED =
-  env.AZUREAD_CLIENT_ID && env.AZUREAD_CLIENT_SECRET && env.AZUREAD_TENANT_ID ? true : false;
+export const AZURE_OAUTH_ENABLED = env.AZUREAD_CLIENT_ID && env.AZUREAD_CLIENT_SECRET ? true : false;
 export const OIDC_OAUTH_ENABLED =
   env.OIDC_CLIENT_ID && env.OIDC_CLIENT_SECRET && env.OIDC_ISSUER ? true : false;
 export const SAML_OAUTH_ENABLED = env.SAML_DATABASE_URL ? true : false;

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1,6 +1,6 @@
 {
   "auth": {
-    "continue_with_azure": "Login mit Azure",
+    "continue_with_azure": "Weiter mit Microsoft",
     "continue_with_email": "Login mit E-Mail",
     "continue_with_github": "Login mit GitHub",
     "continue_with_google": "Login mit Google",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1,6 +1,6 @@
 {
   "auth": {
-    "continue_with_azure": "Continue with Azure",
+    "continue_with_azure": "Continue with Microsoft",
     "continue_with_email": "Continue with Email",
     "continue_with_github": "Continue with GitHub",
     "continue_with_google": "Continue with Google",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1,6 +1,6 @@
 {
   "auth": {
-    "continue_with_azure": "Continuer avec Azure",
+    "continue_with_azure": "Continuer avec Microsoft",
     "continue_with_email": "Continuer avec l'e-mail",
     "continue_with_github": "Continuer avec GitHub",
     "continue_with_google": "Continuer avec Google",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1,6 +1,6 @@
 {
   "auth": {
-    "continue_with_azure": "Continuar com Azure",
+    "continue_with_azure": "Continuar com Microsoft",
     "continue_with_email": "Continuar com o Email",
     "continue_with_github": "Continuar com o GitHub",
     "continue_with_google": "Continuar com o Google",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1,6 +1,6 @@
 {
   "auth": {
-    "continue_with_azure": "Continuar com Azure",
+    "continue_with_azure": "Continuar com Microsoft",
     "continue_with_email": "Continuar com Email",
     "continue_with_github": "Continuar com GitHub",
     "continue_with_google": "Continuar com Google",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1,6 +1,6 @@
 {
   "auth": {
-    "continue_with_azure": "使用 Azure 繼續",
+    "continue_with_azure": "繼續使用 Microsoft",
     "continue_with_email": "使用電子郵件繼續",
     "continue_with_github": "使用 GitHub 繼續",
     "continue_with_google": "使用 Google 繼續",


### PR DESCRIPTION
This pull request updates the OAuth configuration and localization strings to reflect a rebranding from "Azure" to "Microsoft" for authentication options. Additionally, it simplifies the logic for enabling Azure OAuth.

### OAuth Configuration Updates:
* Modified the `AZURE_OAUTH_ENABLED` constant in `apps/web/lib/constants.ts` to remove the dependency on `env.AZUREAD_TENANT_ID`, simplifying the logic for enabling Azure OAuth.

### Localization Updates:
* Updated the "continue_with_azure" localization strings across multiple language files to replace "Azure" with "Microsoft":
  - [`apps/web/locales/de-DE.json`](diffhunk://#diff-579efb4a5d013f515336bed74cd2668962105727952e9edd8d5a6d9fd200a02aL3-R3): Changed "Login mit Azure" to "Weiter mit Microsoft".
  - [`apps/web/locales/en-US.json`](diffhunk://#diff-58646cf8893f8ce2fd9b51c84bed9d33c91a6663bb7d893b1d26a9732981a2b3L3-R3): Changed "Continue with Azure" to "Continue with Microsoft".
  - [`apps/web/locales/fr-FR.json`](diffhunk://#diff-73f43fb98405972673a9a38913e906abc45161455f9cc468f8018e5913bf3046L3-R3): Changed "Continuer avec Azure" to "Continuer avec Microsoft".
  - [`apps/web/locales/pt-BR.json`](diffhunk://#diff-ac0b116044c3d3a9e1e08a02ea44cfc2690e5cd402a11582f96b75ba5201a7b6L3-R3): Changed "Continuar com Azure" to "Continuar com Microsoft".
  - [`apps/web/locales/pt-PT.json`](diffhunk://#diff-cc40ed4e9404a5ea74e1d6fd0768ff08a9d99591f0855e3ab8ed5d614eaa6891L3-R3): Changed "Continuar com Azure" to "Continuar com Microsoft".
  - [`apps/web/locales/zh-Hant-TW.json`](diffhunk://#diff-bcc3d5dde07178f50fec5334d46fdb52674039c6e7e315d96f27b73f7aeb4a3aL3-R3): Changed "使用 Azure 繼續" to "繼續使用 Microsoft".