### PR TITLE
chore: remove unused npm dependencies from docker image

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -143,8 +143,6 @@ RUN chmod -R 755 ./node_modules/@noble/hashes
 COPY --from=installer /app/node_modules/zod ./node_modules/zod
 RUN chmod -R 755 ./node_modules/zod
 
-RUN npm install -g tsx typescript prisma pino-pretty
-
 EXPOSE 3000
 ENV HOSTNAME "0.0.0.0"
 ENV NODE_ENV="production"


### PR DESCRIPTION
This pull request modifies the `apps/web/Dockerfile` to remove unnecessary global npm installations, streamlining the Docker image setup.

Dockerfile simplification:

* Removed the `RUN npm install -g tsx typescript prisma pino-pretty` command, eliminating the installation of globally scoped npm packages that are not required for the production environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the production build process for the web app by removing the global installation of certain development tools. This change does not affect application features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->