### PR TITLE
fix(cloud): add followup permission check

### DIFF
--- a/apps/web/app/api/(internal)/pipeline/lib/survey-follow-up.ts
+++ b/apps/web/app/api/(internal)/pipeline/lib/survey-follow-up.ts
@@ -94,10 +94,10 @@ export const sendSurveyFollowUps = async (
   organization: TOrganization
 ): Promise<FollowUpResult[]> => {
   // check for permission in Formbricks Cloud
-  const isSurveyFollowUpsAllowed = await getSurveyFollowUpsPermission(organization.billing.plan);
+  const isSurveyFollowUpsAllowed = await getSurveyFollowUpsPermission(organization.billing?.plan);
   if (!isSurveyFollowUpsAllowed) {
     logger.warn(
-      `Survey follow-ups are not allowed for the current billing plan "${organization.billing.plan}". Skipping sending follow-ups.`
+      `Survey follow-ups are not allowed for the current billing plan "${organization.billing?.plan}". Skipping sending follow-ups.`
     );
     return [];
   }

--- a/apps/web/app/api/(internal)/pipeline/lib/survey-follow-up.ts
+++ b/apps/web/app/api/(internal)/pipeline/lib/survey-follow-up.ts
@@ -1,4 +1,5 @@
 import { sendFollowUpEmail } from "@/modules/email";
+import { getSurveyFollowUpsPermission } from "@/modules/survey/follow-ups/lib/utils";
 import { z } from "zod";
 import { TSurveyFollowUpAction } from "@formbricks/database/types/survey-follow-up";
 import { logger } from "@formbricks/logger";
@@ -92,6 +93,14 @@ export const sendSurveyFollowUps = async (
   response: TResponse,
   organization: TOrganization
 ): Promise<FollowUpResult[]> => {
+  // check for permission in Formbricks Cloud
+  const isSurveyFollowUpsAllowed = await getSurveyFollowUpsPermission(organization.billing.plan);
+  if (!isSurveyFollowUpsAllowed) {
+    logger.warn(
+      `Survey follow-ups are not allowed for the current billing plan "${organization.billing.plan}". Skipping sending follow-ups.`
+    );
+    return [];
+  }
   const followUpPromises = survey.followUps.map(async (followUp): Promise<FollowUpResult> => {
     const { trigger } = followUp;
 


### PR DESCRIPTION
This pull request introduces a new permission check to ensure that survey follow-ups are only sent if allowed by the organization's billing plan. The most important changes involve adding a utility function to check permissions and integrating this check into the survey follow-up process.

### Permission Check for Survey Follow-Ups:

* **Added utility function for permission check**: Imported `getSurveyFollowUpsPermission` from the `survey/follow-ups/lib/utils` module to handle permission checks based on the organization's billing plan. (`apps/web/app/api/(internal)/pipeline/lib/survey-follow-up.ts`, [apps/web/app/api/(internal)/pipeline/lib/survey-follow-up.tsR2](diffhunk://#diff-363fad50a5d16ff8d30f6c26bf029830082a630206ba64536c7d1f2194cc29abR2))
* **Integrated permission check into `sendSurveyFollowUps` function**: Before sending survey follow-ups, the function now verifies if the current billing plan allows this feature. If not, a warning is logged, and the process is skipped. (`apps/web/app/api/(internal)/pipeline/lib/survey-follow-up.ts`, [apps/web/app/api/(internal)/pipeline/lib/survey-follow-up.tsR96-R103](diffhunk://#diff-363fad50a5d16ff8d30f6c26bf029830082a630206ba64536c7d1f2194cc29abR96-R103))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Survey follow-up emails are now only sent if allowed by your organization's billing plan. If not permitted, no follow-ups will be processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->