### PR TITLE
fix: limit number of surveys in environment state

### DIFF
--- a/apps/web/app/api/v1/client/[environmentId]/environment/lib/survey.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/environment/lib/survey.ts
@@ -21,6 +21,10 @@ export const getSurveysForEnvironmentState = reactCache(
             where: {
               environmentId,
             },
+            orderBy: {
+              createdAt: "desc",
+            },
+            take: 30,
             select: {
               id: true,
               welcomeCard: true,


### PR DESCRIPTION
This pull request makes a small but important change to the `getSurveysForEnvironmentState` function in `survey.ts`. The change ensures that survey results are consistently ordered by their creation date in descending order and limits the number of surveys retrieved to 30.

In performance tests with hundreds or thousands of surveys we have seen that the `/client/environment` endpoint payload will significally grow with more surveys and eventually fail.

* `apps/web/app/api/v1/client/[environmentId]/environment/lib/survey.ts`: Added `orderBy` to sort surveys by `createdAt` in descending order and `take` to limit the results to 30. ([apps/web/app/api/v1/client/[environmentId]/environment/lib/survey.tsR24-R27](diffhunk://#diff-6f88f3aa8c4a1499e7ccda436591d1a13fb0a92445e2aa6564e21098caaf5e0eR24-R27))