### PR TITLE
fix: duplicate switch cases

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.test.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.test.tsx
@@ -1,7 +1,14 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { OptionsType, QuestionOption, QuestionOptions, QuestionsComboBox } from "./QuestionsComboBox";
+import { TSurveyQuestionTypeEnum } from "@formbricks/types/surveys/types";
+import {
+  OptionsType,
+  QuestionOption,
+  QuestionOptions,
+  QuestionsComboBox,
+  SelectedCommandItem,
+} from "./QuestionsComboBox";
 
 describe("QuestionsComboBox", () => {
   afterEach(() => {
@@ -51,5 +58,69 @@ describe("QuestionsComboBox", () => {
     // Check if the input is gone and the selected item is displayed
     expect(screen.queryByPlaceholderText("common.search...")).toBeNull();
     expect(screen.getByText("Q1")).toBeInTheDocument(); // Verify the selected item is now displayed
+  });
+});
+
+describe("SelectedCommandItem", () => {
+  test("renders question icon and color for QUESTIONS with questionType", () => {
+    const { container } = render(
+      <SelectedCommandItem
+        label="Q1"
+        type={OptionsType.QUESTIONS}
+        questionType={TSurveyQuestionTypeEnum.OpenText}
+      />
+    );
+    expect(container.querySelector(".bg-brand-dark")).toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeInTheDocument();
+    expect(container.textContent).toContain("Q1");
+  });
+
+  test("renders attribute icon and color for ATTRIBUTES", () => {
+    const { container } = render(<SelectedCommandItem label="Attr" type={OptionsType.ATTRIBUTES} />);
+    expect(container.querySelector(".bg-indigo-500")).toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeInTheDocument();
+    expect(container.textContent).toContain("Attr");
+  });
+
+  test("renders hidden field icon and color for HIDDEN_FIELDS", () => {
+    const { container } = render(<SelectedCommandItem label="Hidden" type={OptionsType.HIDDEN_FIELDS} />);
+    expect(container.querySelector(".bg-amber-500")).toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeInTheDocument();
+    expect(container.textContent).toContain("Hidden");
+  });
+
+  test("renders meta icon and color for META with label", () => {
+    const { container } = render(<SelectedCommandItem label="device" type={OptionsType.META} />);
+    expect(container.querySelector(".bg-amber-500")).toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeInTheDocument();
+    expect(container.textContent).toContain("device");
+  });
+
+  test("renders other icon and color for OTHERS with label", () => {
+    const { container } = render(<SelectedCommandItem label="Language" type={OptionsType.OTHERS} />);
+    expect(container.querySelector(".bg-amber-500")).toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeInTheDocument();
+    expect(container.textContent).toContain("Language");
+  });
+
+  test("renders tag icon and color for TAGS", () => {
+    const { container } = render(<SelectedCommandItem label="Tag1" type={OptionsType.TAGS} />);
+    expect(container.querySelector(".bg-indigo-500")).toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeInTheDocument();
+    expect(container.textContent).toContain("Tag1");
+  });
+
+  test("renders fallback color and no icon for unknown type", () => {
+    const { container } = render(<SelectedCommandItem label="Unknown" type={"UNKNOWN"} />);
+    expect(container.querySelector(".bg-amber-500")).toBeInTheDocument();
+    expect(container.querySelector("svg")).not.toBeInTheDocument();
+    expect(container.textContent).toContain("Unknown");
+  });
+
+  test("renders fallback for non-string label", () => {
+    const { container } = render(
+      <SelectedCommandItem label={{ default: "NonString" }} type={OptionsType.QUESTIONS} />
+    );
+    expect(container.textContent).toContain("NonString");
   });
 });

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.tsx
@@ -104,7 +104,7 @@ const getIcon = (type: string) => {
   return IconComponent ? <IconComponent width={18} height={18} className="text-white" /> : null;
 };
 
-const SelectedCommandItem = ({ label, questionType, type }: Partial<QuestionOption>) => {
+export const SelectedCommandItem = ({ label, questionType, type }: Partial<QuestionOption>) => {
   const getIconType = () => {
     if (type) {
       if (type === OptionsType.QUESTIONS && questionType) {

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.tsx
@@ -64,61 +64,60 @@ interface QuestionComboBoxProps {
   onChangeValue: (option: QuestionOption) => void;
 }
 
+const questionIcons = {
+  // questions
+  [TSurveyQuestionTypeEnum.OpenText]: MessageSquareTextIcon,
+  [TSurveyQuestionTypeEnum.Rating]: StarIcon,
+  [TSurveyQuestionTypeEnum.CTA]: MousePointerClickIcon,
+  [TSurveyQuestionTypeEnum.MultipleChoiceMulti]: ListIcon,
+  [TSurveyQuestionTypeEnum.MultipleChoiceSingle]: Rows3Icon,
+  [TSurveyQuestionTypeEnum.NPS]: NetPromoterScoreIcon,
+  [TSurveyQuestionTypeEnum.Consent]: CheckIcon,
+  [TSurveyQuestionTypeEnum.PictureSelection]: ImageIcon,
+  [TSurveyQuestionTypeEnum.Matrix]: GridIcon,
+  [TSurveyQuestionTypeEnum.Ranking]: ListOrderedIcon,
+  [TSurveyQuestionTypeEnum.Address]: HomeIcon,
+  [TSurveyQuestionTypeEnum.ContactInfo]: ContactIcon,
+
+  // attributes
+  [OptionsType.ATTRIBUTES]: User,
+
+  // hidden fields
+  [OptionsType.HIDDEN_FIELDS]: EyeOff,
+
+  // meta
+  device: SmartphoneIcon,
+  os: AirplayIcon,
+  browser: GlobeIcon,
+  source: GlobeIcon,
+  action: MousePointerClickIcon,
+
+  // others
+  Language: LanguagesIcon,
+
+  // tags
+  [OptionsType.TAGS]: HashIcon,
+};
+
+const getIcon = (type: string) => {
+  const IconComponent = questionIcons[type];
+  return IconComponent ? <IconComponent width={18} height={18} className="text-white" /> : null;
+};
+
 const SelectedCommandItem = ({ label, questionType, type }: Partial<QuestionOption>) => {
   const getIconType = () => {
-    switch (type) {
-      case OptionsType.QUESTIONS:
-        switch (questionType) {
-          case TSurveyQuestionTypeEnum.OpenText:
-            return <MessageSquareTextIcon width={18} height={18} className="text-white" />;
-          case TSurveyQuestionTypeEnum.Rating:
-            return <StarIcon width={18} height={18} className="text-white" />;
-          case TSurveyQuestionTypeEnum.CTA:
-            return <MousePointerClickIcon width={18} height={18} className="text-white" />;
-          case TSurveyQuestionTypeEnum.MultipleChoiceMulti:
-            return <ListIcon width={18} height={18} className="text-white" />;
-          case TSurveyQuestionTypeEnum.MultipleChoiceSingle:
-            return <Rows3Icon width={18} height={18} className="text-white" />;
-          case TSurveyQuestionTypeEnum.NPS:
-            return <NetPromoterScoreIcon width={18} height={18} className="text-white" />;
-          case TSurveyQuestionTypeEnum.Consent:
-            return <CheckIcon width={18} height={18} className="text-white" />;
-          case TSurveyQuestionTypeEnum.PictureSelection:
-            return <ImageIcon width={18} height={18} className="text-white" />;
-          case TSurveyQuestionTypeEnum.Matrix:
-            return <GridIcon width={18} height={18} className="text-white" />;
-          case TSurveyQuestionTypeEnum.Ranking:
-            return <ListOrderedIcon width={18} height={18} className="text-white" />;
-          case TSurveyQuestionTypeEnum.Address:
-            return <HomeIcon width={18} height={18} className="text-white" />;
-          case TSurveyQuestionTypeEnum.ContactInfo:
-            return <ContactIcon width={18} height={18} className="text-white" />;
-        }
-      case OptionsType.ATTRIBUTES:
-        return <User width={18} height={18} className="text-white" />;
-
-      case OptionsType.HIDDEN_FIELDS:
-        return <EyeOff width={18} height={18} className="text-white" />;
-      case OptionsType.META:
-        switch (label) {
-          case "device":
-            return <SmartphoneIcon width={18} height={18} className="text-white" />;
-          case "os":
-            return <AirplayIcon width={18} height={18} className="text-white" />;
-          case "browser":
-            return <GlobeIcon width={18} height={18} className="text-white" />;
-          case "source":
-            return <GlobeIcon width={18} height={18} className="text-white" />;
-          case "action":
-            return <MousePointerClickIcon width={18} height={18} className="text-white" />;
-        }
-      case OptionsType.OTHERS:
-        switch (label) {
-          case "Language":
-            return <LanguagesIcon width={18} height={18} className="text-white" />;
-        }
-      case OptionsType.TAGS:
-        return <HashIcon width={18} height={18} className="text-white" />;
+    if (type) {
+      if (type === OptionsType.QUESTIONS && questionType) {
+        return getIcon(questionType);
+      } else if (type === OptionsType.ATTRIBUTES) {
+        return getIcon(OptionsType.ATTRIBUTES);
+      } else if (type === OptionsType.HIDDEN_FIELDS) {
+        return getIcon(OptionsType.HIDDEN_FIELDS);
+      } else if ([OptionsType.META, OptionsType.OTHERS].includes(type) && label) {
+        return getIcon(label);
+      } else if (type === OptionsType.TAGS) {
+        return getIcon(OptionsType.TAGS);
+      }
     }
   };
 

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.tsx
@@ -18,11 +18,12 @@ import {
   CheckIcon,
   ChevronDown,
   ChevronUp,
+  ContactIcon,
   EyeOff,
   GlobeIcon,
   GridIcon,
   HashIcon,
-  HelpCircleIcon,
+  HomeIcon,
   ImageIcon,
   LanguagesIcon,
   ListIcon,
@@ -74,8 +75,6 @@ const SelectedCommandItem = ({ label, questionType, type }: Partial<QuestionOpti
             return <StarIcon width={18} height={18} className="text-white" />;
           case TSurveyQuestionTypeEnum.CTA:
             return <MousePointerClickIcon width={18} height={18} className="text-white" />;
-          case TSurveyQuestionTypeEnum.OpenText:
-            return <HelpCircleIcon width={18} height={18} className="text-white" />;
           case TSurveyQuestionTypeEnum.MultipleChoiceMulti:
             return <ListIcon width={18} height={18} className="text-white" />;
           case TSurveyQuestionTypeEnum.MultipleChoiceSingle:
@@ -90,6 +89,10 @@ const SelectedCommandItem = ({ label, questionType, type }: Partial<QuestionOpti
             return <GridIcon width={18} height={18} className="text-white" />;
           case TSurveyQuestionTypeEnum.Ranking:
             return <ListOrderedIcon width={18} height={18} className="text-white" />;
+          case TSurveyQuestionTypeEnum.Address:
+            return <HomeIcon width={18} height={18} className="text-white" />;
+          case TSurveyQuestionTypeEnum.ContactInfo:
+            return <ContactIcon width={18} height={18} className="text-white" />;
         }
       case OptionsType.ATTRIBUTES:
         return <User width={18} height={18} className="text-white" />;
@@ -164,7 +167,7 @@ export const QuestionsComboBox = ({ options, selected, onChangeValue }: Question
             value={inputValue}
             onValueChange={setInputValue}
             placeholder={t("common.search") + "..."}
-            className="h-5 border-none border-transparent p-0 shadow-none ring-offset-transparent outline-0 focus:border-none focus:border-transparent focus:shadow-none focus:ring-offset-transparent focus:outline-0"
+            className="h-5 border-none border-transparent p-0 shadow-none outline-0 ring-offset-transparent focus:border-none focus:border-transparent focus:shadow-none focus:outline-0 focus:ring-offset-transparent"
           />
         )}
         <div>


### PR DESCRIPTION
## What does this PR do?
duplicate switch cases

Fixes duplicate switch cases and refactors the icon map

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the logic for displaying icons in survey question selections, resulting in more consistent and maintainable icon rendering.
  - Updated visual styles for input focus and outlines for a smoother user experience.
- **Tests**
  - Added comprehensive tests to ensure correct icon and background color rendering across all question types and labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->