### PR TITLE
fix: suid bugs

### DIFF
--- a/apps/web/app/api/v1/client/[environmentId]/responses/[responseId]/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/responses/[responseId]/route.ts
@@ -57,6 +57,10 @@ export const PUT = async (
     return handleDatabaseError(error, request.url, endpoint, responseId);
   }
 
+  if (response.finished) {
+    return responses.badRequestResponse("Response is already finished", undefined, true);
+  }
+
   // get survey to get environmentId
   let survey;
   try {

--- a/apps/web/app/api/v2/client/[environmentId]/responses/lib/utils.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/lib/utils.ts
@@ -34,7 +34,23 @@ export const checkSurveyValidity = async (
       });
     }
 
-    const url = new URL(responseInput.meta?.url || "");
+    if (!responseInput.meta?.url) {
+      return responses.badRequestResponse("Missing or invalid URL in response metadata", {
+        surveyId: survey.id,
+        environmentId,
+      });
+    }
+
+    let url;
+    try {
+      url = new URL(responseInput.meta.url);
+    } catch (error) {
+      return responses.badRequestResponse("Invalid URL in response metadata", {
+        surveyId: survey.id,
+        environmentId,
+        error: error.message,
+      });
+    }
     const suId = url.searchParams.get("suId");
     if (!suId) {
       return responses.badRequestResponse("Missing single use id", {

--- a/apps/web/app/api/v2/client/[environmentId]/responses/lib/utils.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/lib/utils.ts
@@ -2,6 +2,8 @@ import { getOrganizationBillingByEnvironmentId } from "@/app/api/v2/client/[envi
 import { verifyRecaptchaToken } from "@/app/api/v2/client/[environmentId]/responses/lib/recaptcha";
 import { TResponseInputV2 } from "@/app/api/v2/client/[environmentId]/responses/types/response";
 import { responses } from "@/app/lib/api/response";
+import { ENCRYPTION_KEY } from "@/lib/constants";
+import { symmetricDecrypt } from "@/lib/crypto";
 import { getIsSpamProtectionEnabled } from "@/modules/ee/license-check/lib/utils";
 import { logger } from "@formbricks/logger";
 import { TSurvey } from "@formbricks/types/surveys/types";
@@ -22,6 +24,39 @@ export const checkSurveyValidity = async (
       },
       true
     );
+  }
+
+  if (survey.singleUse?.enabled) {
+    if (!responseInput.singleUseId) {
+      return responses.badRequestResponse("Missing single use id", {
+        surveyId: survey.id,
+        environmentId,
+      });
+    }
+
+    const url = new URL(responseInput.meta?.url || "");
+    const suId = url.searchParams.get("suId");
+    if (!suId) {
+      return responses.badRequestResponse("Missing single use id", {
+        surveyId: survey.id,
+        environmentId,
+      });
+    }
+
+    if (survey.singleUse.isEncrypted) {
+      const decryptedSuId = symmetricDecrypt(suId, ENCRYPTION_KEY);
+      if (decryptedSuId !== responseInput.singleUseId) {
+        return responses.badRequestResponse("Invalid single use id", {
+          surveyId: survey.id,
+          environmentId,
+        });
+      }
+    } else if (responseInput.singleUseId !== suId) {
+      return responses.badRequestResponse("Invalid single use id", {
+        surveyId: survey.id,
+        environmentId,
+      });
+    }
   }
 
   if (survey.recaptcha?.enabled) {

--- a/apps/web/lib/response/service.ts
+++ b/apps/web/lib/response/service.ts
@@ -533,6 +533,7 @@ export const updateResponse = async (
       id: response.id,
       contactId: response.contact?.id,
       surveyId: response.surveyId,
+      ...(response.singleUseId ? { singleUseId: response.singleUseId } : {}),
     });
 
     responseNoteCache.revalidate({

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
@@ -111,7 +111,7 @@ export const updateResponse = async (
     responseCache.revalidate({
       id: updatedResponse.id,
       surveyId: updatedResponse.surveyId,
-      ...(updatedResponse.singleUseId && { singleUseId: updatedResponse.singleUseId }),
+      ...(updatedResponse.singleUseId ? { singleUseId: updatedResponse.singleUseId } : {}),
     });
 
     responseNoteCache.revalidate({

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
@@ -111,6 +111,7 @@ export const updateResponse = async (
     responseCache.revalidate({
       id: updatedResponse.id,
       surveyId: updatedResponse.surveyId,
+      ...(updatedResponse.singleUseId && { singleUseId: updatedResponse.singleUseId }),
     });
 
     responseNoteCache.revalidate({

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
@@ -1,4 +1,5 @@
 import { response, responseId, responseInput, survey } from "./__mocks__/response.mock";
+import { responseCache } from "@/lib/response/cache";
 import { PrismaClientKnownRequestError } from "@prisma/client/runtime/library";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
@@ -19,6 +20,16 @@ vi.mock("../survey", () => ({
 
 vi.mock("../utils", () => ({
   findAndDeleteUploadedFilesInResponse: vi.fn(),
+}));
+
+vi.mock("@/lib/response/cache", () => ({
+  responseCache: {
+    revalidate: vi.fn(),
+    tag: {
+      byId: vi.fn(),
+      byResponseId: vi.fn(),
+    },
+  },
 }));
 
 vi.mock("@formbricks/database", () => ({
@@ -175,7 +186,7 @@ describe("Response Lib", () => {
   });
 
   describe("updateResponse", () => {
-    test("update the response and revalidate caches", async () => {
+    test("update the response and revalidate caches including singleUseId", async () => {
       vi.mocked(prisma.response.update).mockResolvedValue(response);
 
       const result = await updateResponse(responseId, responseInput);
@@ -184,9 +195,36 @@ describe("Response Lib", () => {
         data: responseInput,
       });
 
+      expect(responseCache.revalidate).toHaveBeenCalledWith({
+        id: response.id,
+        surveyId: response.surveyId,
+        singleUseId: response.singleUseId,
+      });
+
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.data).toEqual(response);
+      }
+    });
+
+    test("update the response and revalidate caches", async () => {
+      const responseWithoutSingleUseId = { ...response, singleUseId: null };
+      vi.mocked(prisma.response.update).mockResolvedValue(responseWithoutSingleUseId);
+
+      const result = await updateResponse(responseId, responseInput);
+      expect(prisma.response.update).toHaveBeenCalledWith({
+        where: { id: responseId },
+        data: responseInput,
+      });
+
+      expect(responseCache.revalidate).toHaveBeenCalledWith({
+        id: response.id,
+        surveyId: response.surveyId,
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.data).toEqual(responseWithoutSingleUseId);
       }
     });
 


### PR DESCRIPTION
## What does this PR do?
fixes suId bugs 

Fixes https://github.com/formbricks/internal/issues/587

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Please test the bugs mentioned in the ticket, or connect with @gupta-piyush19 for testing instructions.
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added validation to prevent updates to responses that are already marked as finished.
	- Introduced enhanced validation for surveys with single-use IDs, including support for encrypted single-use IDs and improved error messaging for missing or invalid IDs.

- **Improvements**
	- Updated cache revalidation logic to account for single-use IDs, ensuring more accurate cache management for single-use survey responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->