### PR TITLE
chore: Tweak formbricks JS log message

### DIFF
--- a/packages/js-core/src/lib/common/setup.ts
+++ b/packages/js-core/src/lib/common/setup.ts
@@ -257,7 +257,8 @@ export const setup = async (
       });
 
       const surveyNames = filteredSurveys.map((s) => s.name);
-      logger.debug(`Fetched ${surveyNames.length.toString()} surveys during sync: ${surveyNames.join(", ")}`);
+      logger.debug(`Fetched ${environmentState.data.surveys.length.toString()} surveys from the backend`);
+      logger.debug(`${surveyNames.length.toString()} surveys could be shown to current user on trigger: ${surveyNames.join(", ")}`);
     } catch {
       logger.debug("Error during sync. Please try again.");
     }

--- a/packages/js-core/src/lib/common/tests/setup.test.ts
+++ b/packages/js-core/src/lib/common/tests/setup.test.ts
@@ -198,6 +198,10 @@ describe("setup.ts", () => {
           filteredSurveys: [{ name: "S1" }, { name: "S2" }],
         })
       );
+
+      // Check for the new log messages
+      expect(mockLogger.debug).toHaveBeenCalledWith("Fetched 0 surveys from the backend");
+      expect(mockLogger.debug).toHaveBeenCalledWith("0 surveys could be shown to current user on trigger: ");
     });
 
     test("resets config if no valid config found, fetches environment, sets default user", async () => {


### PR DESCRIPTION
Update log messages in `packages/js-core/src/lib/common/setup.ts` to provide clearer information about survey fetching and filtering.

* **Log Messages:**
  - Update the log message to 'Fetched X surveys from the backend'.
  - Add a new log message 'Y surveys could be shown to current user on trigger'.

* **Tests:**
  - Update the test case in `packages/js-core/src/lib/common/tests/setup.test.ts` to check for the new log messages.
  - Add expectations for 'Fetched 0 surveys from the backend' and '0 surveys could be shown to current user on trigger'.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/formbricks/formbricks/pull/5825?shareId=3df7b7e2-b4f4-4660-b58c-0a5f6f308acf).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logging during survey synchronization to provide clearer information about the number of surveys fetched and those available to the user.

- **Tests**
  - Enhanced test coverage to verify the presence of new debug log messages during the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->