### PR TITLE
chore: fast return ping endpoint when telemetry is disabled

### DIFF
--- a/apps/web/app/api/cron/ping/route.ts
+++ b/apps/web/app/api/cron/ping/route.ts
@@ -1,5 +1,6 @@
 import { responses } from "@/app/lib/api/response";
 import { CRON_SECRET } from "@/lib/constants";
+import { env } from "@/lib/env";
 import { captureTelemetry } from "@/lib/telemetry";
 import packageJson from "@/package.json";
 import { headers } from "next/headers";
@@ -11,6 +12,10 @@ export const POST = async () => {
 
   if (!apiKey || apiKey !== CRON_SECRET) {
     return responses.notAuthenticatedResponse();
+  }
+
+  if (env.TELEMETRY_DISABLED !== "1") {
+    return responses.successResponse({}, true);
   }
 
   const [surveyCount, responseCount, userCount] = await Promise.all([


### PR DESCRIPTION
This pull request introduces a new check in the `POST` handler of the `apps/web/app/api/cron/ping/route.ts` file to conditionally bypass telemetry-related operations based on an environment variable. This check was missing previously leading to unnecessary database queries when telemetry is disabled. 

### Key changes:

#### Telemetry bypass based on environment variable:
* [`apps/web/app/api/cron/ping/route.ts`](diffhunk://#diff-0edc2709a65c89ed51b3ad38944331e4d525f95f3fb5eab78f6754bb0411d14fR17-R20): Added a condition to return an early success response if the `TELEMETRY_DISABLED` environment variable is set to `"1"`. This allows telemetry operations to be skipped based on configuration.

#### Import updates:
* [`apps/web/app/api/cron/ping/route.ts`](diffhunk://#diff-0edc2709a65c89ed51b3ad38944331e4d525f95f3fb5eab78f6754bb0411d14fR3): Imported the `env` module to access environment variables, specifically for the `TELEMETRY_DISABLED` configuration.