### PR TITLE
fix: allow recall-style URLs in buttonLink validation for end screen …

### DIFF
--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -26,12 +26,32 @@ const ZSurveyEndingBase = z.object({
   id: z.string().cuid2(),
 });
 
+const ZSafeUrl = getZSafeUrl("Invalid Button Url in Ending card");
+
+// Validates recall-style URLs like "#recall:<id>/fallback:<text>#"
+const isRecallUrl = (val: string): boolean => /^#recall:[^/]+\/fallback:.*#\s*$/.test(val);
+
+const ZButtonLink = z.string().refine(
+  (val) => {
+    if (isRecallUrl(val)) return true;
+    try {
+      ZSafeUrl.parse(val);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  {
+    message: "Invalid Button Url in Ending card",
+  }
+);
+
 export const ZSurveyEndScreenCard = ZSurveyEndingBase.extend({
   type: z.literal("endScreen"),
   headline: ZI18nString.optional(),
   subheader: ZI18nString.optional(),
   buttonLabel: ZI18nString.optional(),
-  buttonLink: getZSafeUrl("Invalid Button Url in Ending card").optional(),
+  buttonLink: ZButtonLink.optional(),
   imageUrl: z.string().optional(),
   videoUrl: z.string().optional(),
 });


### PR DESCRIPTION
## What does this PR do?

Fixes [#5730](https://github.com/formbricks/formbricks/issues/5730) – The validation for `buttonLink` in the `ZSurveyEndScreenCard` schema was rejecting valid recall-style URLs (e.g. `#recall:xyz/fallback:Text#`).  
This PR updates the validation logic to support these formats while retaining the safety checks from `getZSafeUrl`.

## How should this be tested?

- Add a recall-style URL in the `Button Url` field.
- Ensure the schema accepts it without throwing the "Invalid Button Url in Ending card" error.
- Also test with standard safe URLs (e.g., `https://example.com`) to ensure backward compatibility.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR  
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code  
- [x] Commented on my code in hard-to-understand bits  
- [x] Ran `pnpm build`  
- [x] Checked for warnings, there are none  
- [x] Removed all `console.logs`  
- [x] Merged the latest changes from main onto my branch with `git pull origin main`  
- [x] My changes don't cause any responsiveness issues  
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we won't be able to merge it 🙏  

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR  
- [ ] Updated the Formbricks Docs if changes were necessary  
