### PR TITLE
fix: back button in survey published modal closes modal instead of navigating

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/ShareEmbedSurvey.test.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/ShareEmbedSurvey.test.tsx
@@ -174,20 +174,32 @@ describe("ShareEmbedSurvey", () => {
     expect(screen.getByText("PanelInfoViewMockContent")).toBeInTheDocument();
   });
 
-  test("calls setOpen(false) when handleInitialPageButton is triggered from EmbedView", async () => {
+  test("returns to 'start' view when handleInitialPageButton is triggered from EmbedView", async () => {
     render(<ShareEmbedSurvey {...defaultProps} modalView="embed" />);
     expect(mockEmbedViewComponent).toHaveBeenCalled();
+    expect(screen.getByText("EmbedViewMockContent")).toBeInTheDocument();
+
     const embedViewButton = screen.getByText("EmbedViewMockContent");
     await userEvent.click(embedViewButton);
-    expect(mockSetOpen).toHaveBeenCalledWith(false);
+
+    // Should go back to start view, not close the modal
+    expect(screen.getByText("environments.surveys.summary.your_survey_is_public 🎉")).toBeInTheDocument();
+    expect(screen.queryByText("EmbedViewMockContent")).not.toBeInTheDocument();
+    expect(mockSetOpen).not.toHaveBeenCalled();
   });
 
-  test("calls setOpen(false) when handleInitialPageButton is triggered from PanelInfoView", async () => {
+  test("returns to 'start' view when handleInitialPageButton is triggered from PanelInfoView", async () => {
     render(<ShareEmbedSurvey {...defaultProps} modalView="panel" />);
     expect(mockPanelInfoViewComponent).toHaveBeenCalled();
+    expect(screen.getByText("PanelInfoViewMockContent")).toBeInTheDocument();
+
     const panelInfoViewButton = screen.getByText("PanelInfoViewMockContent");
     await userEvent.click(panelInfoViewButton);
-    expect(mockSetOpen).toHaveBeenCalledWith(false);
+
+    // Should go back to start view, not close the modal
+    expect(screen.getByText("environments.surveys.summary.your_survey_is_public 🎉")).toBeInTheDocument();
+    expect(screen.queryByText("PanelInfoViewMockContent")).not.toBeInTheDocument();
+    expect(mockSetOpen).not.toHaveBeenCalled();
   });
 
   test("handleOpenChange (when Dialog calls its onOpenChange prop)", () => {

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/ShareEmbedSurvey.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/ShareEmbedSurvey.tsx
@@ -86,7 +86,7 @@ export const ShareEmbedSurvey = ({
   };
 
   const handleInitialPageButton = () => {
-    setOpen(false);
+    setShowView("start");
   };
 
   return (

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/page.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/page.tsx
@@ -68,7 +68,7 @@ const SurveyPage = async (props: { params: Promise<{ environmentId: string; surv
         initialSurveySummary={initialSurveySummary}
       />
 
-      <SettingsId title={t("common.survey_id")} id={surveyId}></SettingsId>
+      <SettingsId title={t("common.survey_id")} id={surveyId} />
     </PageContentWrapper>
   );
 };


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where the back button inside the "Survey Published" modal closes the entire modal instead of navigating to the previous step.

Fixes #5812

## How should this be tested?

1. Create a survey
2. Click "Publish"
3. In the "Survey Published" modal, click any distribution option (e.g., "Embed Survey")
4. On the next screen, click the back button (top left)
5. ✅ You should now be taken back to the previous modal step instead of closing the modal

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
