### PR TITLE
fix: active tab scale with viewport

### DIFF
--- a/apps/web/modules/ui/components/options-switch/index.tsx
+++ b/apps/web/modules/ui/components/options-switch/index.tsx
@@ -21,17 +21,25 @@ export const OptionsSwitch = ({
   const [highlightStyle, setHighlightStyle] = useState({});
   const containerRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if (containerRef.current) {
-      const activeElement = containerRef.current.querySelector(`[data-value="${currentOption}"]`);
-      if (activeElement) {
-        const { offsetLeft, offsetWidth } = activeElement as HTMLElement;
-        setHighlightStyle({
-          left: `${offsetLeft}px`,
-          width: `${offsetWidth}px`,
-        });
+    const updateHighlight = () => {
+      if (containerRef.current) {
+        const activeElement = containerRef.current.querySelector(`[data-value="${currentOption}"]`);
+        if (activeElement) {
+          const { offsetLeft, offsetWidth } = activeElement as HTMLElement;
+          setHighlightStyle({
+            left: `${offsetLeft}px`,
+            width: `${offsetWidth}px`,
+          });
+        }
       }
     }
-  }, [currentOption]);
+    // Initial call
+    updateHighlight();
+
+    // Listen to resize
+    window.addEventListener("resize", updateHighlight);
+    return () => window.removeEventListener("resize", updateHighlight);
+  }, [currentOption, containerRef]);
 
   return (
     <div


### PR DESCRIPTION
Fixes #5912 

The active tab highlight now resizes with the rest of the UI :
[Watch Loom Video](https://www.loom.com/share/defd7082811349a8941b58ca8186190f?sid=8ca18099-7157-4c89-9982-2120d041fb32)

### Problem Before
The highlight styling ran only once — on mount or when currentOption changed — so it became misaligned when the window was resized.

### What I Did
Added a resize event listener to update the highlight position and width dynamically when the viewport changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the responsiveness and reliability of option highlighting in the options switch component, ensuring the highlight stays correctly positioned during window resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->