### PR TITLE
fix: keyboard accessibility issue (#3768)

### DIFF
--- a/packages/surveys/src/components/questions/ranking-question.tsx
+++ b/packages/surveys/src/components/questions/ranking-question.tsx
@@ -189,6 +189,7 @@ export function RankingQuestion({
                           handleItemClick(item);
                         }}
                         type="button"
+                        aria-label={`Select ${getLocalizedValue(item.label,languageCode)} for ranking`}
                         className="fb-flex fb-gap-x-4 fb-px-4 fb-items-center fb-grow fb-h-full group text-left focus:outline-none">
                         <span
                           className={cn(
@@ -206,12 +207,13 @@ export function RankingQuestion({
                       {isSorted ? (
                         <div className="fb-flex fb-flex-col fb-h-full fb-grow-0 fb-border-l fb-border-border">
                           <button
-                            tabIndex={-1}
+                            tabIndex={isFirst?-1:0}
                             type="button"
                             onClick={(e) => {
                               e.preventDefault();
                               handleMove(item.id, "up");
                             }}
+                            aria-label={`Move ${getLocalizedValue(item.label,languageCode)} up`}
                             className={cn(
                               "fb-px-2 fb-flex fb-flex-1 fb-items-center fb-justify-center",
                               isFirst
@@ -234,7 +236,7 @@ export function RankingQuestion({
                             </svg>
                           </button>
                           <button
-                            tabIndex={-1}
+                            tabIndex={isLast?-1:0}
                             type="button"
                             onClick={(e) => {
                               e.preventDefault();
@@ -246,6 +248,7 @@ export function RankingQuestion({
                                 ? "fb-opacity-30 fb-cursor-not-allowed"
                                 : "hover:fb-bg-black/5 fb-rounded-br-custom fb-transition-colors"
                             )}
+                            aria-label={`Move ${getLocalizedValue(item.label,languageCode)} down`}
                             disabled={isLast}>
                             <svg
                               xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
## What does this PR do?

This PR improves the accessibility of the ranking question component, specifically addressing keyboard navigation and screen reader support. The changes ensure that all interactive controls (such as selection and reordering buttons) are implemented using semantic HTML elements (<button>), are fully keyboard-accessible, and include descriptive aria-labels for screen readers. The up/down arrow controls are now focusable via keyboard, and all actions are clearly described for assistive technologies. This resolves issue #3768 by making the ranking question fully usable for users who rely on keyboard navigation and screen readers

Fixes #3768

## Screenshots ->


![Screenshot from 2025-06-06 16-45-37](https://github.com/user-attachments/assets/f03a493a-4cef-4202-a62b-f472a602113c)


![Screenshot from 2025-06-06 16-45-51](https://github.com/user-attachments/assets/c4284d27-fd59-4e54-8861-379d9ea4204d)


## How should this be tested?

1. Navigate to a survey with a ranking question.
2. Attempt to reorder items using only the keyboard (Tab, Enter).
2. The ranking options and reorder controls are now completely accessible.

