### PR TITLE
chore(infra): switch staging to internal lb

### DIFF
--- a/infra/formbricks-cloud-helm/values-staging.yaml.gotmpl
+++ b/infra/formbricks-cloud-helm/values-staging.yaml.gotmpl
@@ -132,10 +132,9 @@ externalSecret:
 ingress:
   annotations:
     alb.ingress.kubernetes.io/certificate-arn: {{ requiredEnv "FORMBRICKS_INGRESS_CERT_ARN" }}
-    alb.ingress.kubernetes.io/group.name: formbricks-stage
+    alb.ingress.kubernetes.io/group.name: internal
     alb.ingress.kubernetes.io/healthcheck-path: /health
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-Res-2021-06
     alb.ingress.kubernetes.io/ssl-redirect: "443"
     alb.ingress.kubernetes.io/target-type: ip


### PR DESCRIPTION
This PR fixes a non-linear commit timeline in #5883

---

This pull request modifies the `infra/formbricks-cloud-helm/values-staging.yaml.gotmpl` file to update the ingress configuration for the staging environment. The changes primarily adjust the ALB (Application Load Balancer) settings.

Ingress configuration updates:

* Changed the `alb.ingress.kubernetes.io/group.name` annotation from `formbricks-stage` to `internal`, likely to reflect a shift to an internal ALB group.
* Removed the `alb.ingress.kubernetes.io/scheme` annotation, which previously specified the ALB as `internet-facing`. This indicates a possible move away from public-facing access.