### PR TITLE
fix: default environment redirect

### DIFF
--- a/apps/web/app/page.test.tsx
+++ b/apps/web/app/page.test.tsx
@@ -152,7 +152,8 @@ describe("Page", () => {
     const { getIsFreshInstance } = await import("@/lib/instance/service");
     const { getUser } = await import("@/lib/user/service");
     const { getOrganizationsByUserId } = await import("@/lib/organization/service");
-    const { getProjectEnvironmentsByOrganizationIds } = await import("@/lib/project/service");
+    const { getUserProjectEnvironmentsByOrganizationIds: getProjectEnvironmentsByOrganizationIds } =
+      await import("@/lib/project/service");
     const { getMembershipByUserIdOrganizationId } = await import("@/lib/membership/service");
     const { getAccessFlags } = await import("@/lib/membership/utils");
     const { redirect } = await import("next/navigation");
@@ -241,7 +242,8 @@ describe("Page", () => {
     const { getServerSession } = await import("next-auth");
     const { getIsFreshInstance } = await import("@/lib/instance/service");
     const { getUser } = await import("@/lib/user/service");
-    const { getProjectEnvironmentsByOrganizationIds } = await import("@/lib/project/service");
+    const { getUserProjectEnvironmentsByOrganizationIds: getProjectEnvironmentsByOrganizationIds } =
+      await import("@/lib/project/service");
     const { getOrganizationsByUserId } = await import("@/lib/organization/service");
     const { getMembershipByUserIdOrganizationId } = await import("@/lib/membership/service");
     const { getAccessFlags } = await import("@/lib/membership/utils");
@@ -334,7 +336,8 @@ describe("Page", () => {
     const { getOrganizationsByUserId } = await import("@/lib/organization/service");
     const { getMembershipByUserIdOrganizationId } = await import("@/lib/membership/service");
     const { getAccessFlags } = await import("@/lib/membership/utils");
-    const { getProjectEnvironmentsByOrganizationIds } = await import("@/lib/project/service");
+    const { getUserProjectEnvironmentsByOrganizationIds: getProjectEnvironmentsByOrganizationIds } =
+      await import("@/lib/project/service");
     const { render } = await import("@testing-library/react");
 
     const mockUser: TUser = {

--- a/apps/web/app/page.test.tsx
+++ b/apps/web/app/page.test.tsx
@@ -8,7 +8,7 @@ import { TUser } from "@formbricks/types/user";
 import Page from "./page";
 
 vi.mock("@/lib/project/service", () => ({
-  getProjectEnvironmentsByOrganizationIds: vi.fn(),
+  getUserProjectEnvironmentsByOrganizationIds: vi.fn(),
 }));
 
 vi.mock("@/lib/instance/service", () => ({
@@ -152,8 +152,7 @@ describe("Page", () => {
     const { getIsFreshInstance } = await import("@/lib/instance/service");
     const { getUser } = await import("@/lib/user/service");
     const { getOrganizationsByUserId } = await import("@/lib/organization/service");
-    const { getUserProjectEnvironmentsByOrganizationIds: getProjectEnvironmentsByOrganizationIds } =
-      await import("@/lib/project/service");
+    const { getUserProjectEnvironmentsByOrganizationIds } = await import("@/lib/project/service");
     const { getMembershipByUserIdOrganizationId } = await import("@/lib/membership/service");
     const { getAccessFlags } = await import("@/lib/membership/utils");
     const { redirect } = await import("next/navigation");
@@ -221,7 +220,7 @@ describe("Page", () => {
     } as any);
     vi.mocked(getIsFreshInstance).mockResolvedValue(false);
     vi.mocked(getUser).mockResolvedValue(mockUser);
-    vi.mocked(getProjectEnvironmentsByOrganizationIds).mockResolvedValue(
+    vi.mocked(getUserProjectEnvironmentsByOrganizationIds).mockResolvedValue(
       mockUserProjects as unknown as TProject[]
     );
     vi.mocked(getOrganizationsByUserId).mockResolvedValue([mockOrganization]);
@@ -242,8 +241,7 @@ describe("Page", () => {
     const { getServerSession } = await import("next-auth");
     const { getIsFreshInstance } = await import("@/lib/instance/service");
     const { getUser } = await import("@/lib/user/service");
-    const { getUserProjectEnvironmentsByOrganizationIds: getProjectEnvironmentsByOrganizationIds } =
-      await import("@/lib/project/service");
+    const { getUserProjectEnvironmentsByOrganizationIds } = await import("@/lib/project/service");
     const { getOrganizationsByUserId } = await import("@/lib/organization/service");
     const { getMembershipByUserIdOrganizationId } = await import("@/lib/membership/service");
     const { getAccessFlags } = await import("@/lib/membership/utils");
@@ -312,7 +310,7 @@ describe("Page", () => {
     } as any);
     vi.mocked(getIsFreshInstance).mockResolvedValue(false);
     vi.mocked(getUser).mockResolvedValue(mockUser);
-    vi.mocked(getProjectEnvironmentsByOrganizationIds).mockResolvedValue(
+    vi.mocked(getUserProjectEnvironmentsByOrganizationIds).mockResolvedValue(
       mockUserProjects as unknown as TProject[]
     );
     vi.mocked(getOrganizationsByUserId).mockResolvedValue([mockOrganization]);
@@ -336,8 +334,7 @@ describe("Page", () => {
     const { getOrganizationsByUserId } = await import("@/lib/organization/service");
     const { getMembershipByUserIdOrganizationId } = await import("@/lib/membership/service");
     const { getAccessFlags } = await import("@/lib/membership/utils");
-    const { getUserProjectEnvironmentsByOrganizationIds: getProjectEnvironmentsByOrganizationIds } =
-      await import("@/lib/project/service");
+    const { getUserProjectEnvironmentsByOrganizationIds } = await import("@/lib/project/service");
     const { render } = await import("@testing-library/react");
 
     const mockUser: TUser = {
@@ -435,7 +432,7 @@ describe("Page", () => {
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(getOrganizationsByUserId).mockResolvedValue([mockOrganization]);
     vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(mockMembership);
-    vi.mocked(getProjectEnvironmentsByOrganizationIds).mockResolvedValue(mockUserProjects);
+    vi.mocked(getUserProjectEnvironmentsByOrganizationIds).mockResolvedValue(mockUserProjects);
     vi.mocked(getAccessFlags).mockReturnValue({
       isManager: false,
       isOwner: false,

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,7 +3,7 @@ import { getIsFreshInstance } from "@/lib/instance/service";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getAccessFlags } from "@/lib/membership/utils";
 import { getOrganizationsByUserId } from "@/lib/organization/service";
-import { getProjectEnvironmentsByOrganizationIds } from "@/lib/project/service";
+import { getUserProjectEnvironmentsByOrganizationIds } from "@/lib/project/service";
 import { getUser } from "@/lib/user/service";
 import { authOptions } from "@/modules/auth/lib/authOptions";
 import { ClientLogout } from "@/modules/ui/components/client-logout";
@@ -34,7 +34,10 @@ const Page = async () => {
     return redirect("/setup/organization/create");
   }
 
-  const projectsByOrg = await getProjectEnvironmentsByOrganizationIds(userOrganizations.map((org) => org.id));
+  const projectsByOrg = await getUserProjectEnvironmentsByOrganizationIds(
+    userOrganizations.map((org) => org.id),
+    user.id
+  );
 
   // Flatten all environments from all projects across all organizations
   const allEnvironments = projectsByOrg.flatMap((project) => project.environments);

--- a/apps/web/lib/project/service.test.ts
+++ b/apps/web/lib/project/service.test.ts
@@ -7,8 +7,8 @@ import { ITEMS_PER_PAGE } from "../constants";
 import {
   getProject,
   getProjectByEnvironmentId,
-  getProjectEnvironmentsByOrganizationIds,
   getProjects,
+  getUserProjectEnvironmentsByOrganizationIds,
   getUserProjects,
 } from "./service";
 
@@ -499,7 +499,7 @@ describe("Project Service", () => {
 
     vi.mocked(prisma.project.findMany).mockResolvedValue(mockProjects as any);
 
-    const result = await getProjectEnvironmentsByOrganizationIds([organizationId1, organizationId2]);
+    const result = await getUserProjectEnvironmentsByOrganizationIds([organizationId1, organizationId2]);
 
     expect(result).toEqual(mockProjects);
     expect(prisma.project.findMany).toHaveBeenCalledWith({
@@ -518,7 +518,7 @@ describe("Project Service", () => {
 
     vi.mocked(prisma.project.findMany).mockResolvedValue([]);
 
-    const result = await getProjectEnvironmentsByOrganizationIds([organizationId1, organizationId2]);
+    const result = await getUserProjectEnvironmentsByOrganizationIds([organizationId1, organizationId2]);
 
     expect(result).toEqual([]);
     expect(prisma.project.findMany).toHaveBeenCalledWith({
@@ -540,12 +540,12 @@ describe("Project Service", () => {
     });
     vi.mocked(prisma.project.findMany).mockRejectedValue(prismaError);
 
-    await expect(getProjectEnvironmentsByOrganizationIds([organizationId1, organizationId2])).rejects.toThrow(
-      DatabaseError
-    );
+    await expect(
+      getUserProjectEnvironmentsByOrganizationIds([organizationId1, organizationId2])
+    ).rejects.toThrow(DatabaseError);
   });
 
   test("getProjectsByOrganizationIds should throw ValidationError with wrong input", async () => {
-    await expect(getProjectEnvironmentsByOrganizationIds(["wrong-id"])).rejects.toThrow(ValidationError);
+    await expect(getUserProjectEnvironmentsByOrganizationIds(["wrong-id"])).rejects.toThrow(ValidationError);
   });
 });

--- a/apps/web/lib/project/service.ts
+++ b/apps/web/lib/project/service.ts
@@ -192,9 +192,7 @@ export const getUserProjectEnvironmentsByOrganizationIds = reactCache(
         return [];
       }
 
-      const whereConditions: Prisma.ProjectWhereInput[] = [];
-
-      for (const membership of memberships) {
+      const whereConditions: Prisma.ProjectWhereInput[] = memberships.map((membership) => {
         let projectWhereClause: Prisma.ProjectWhereInput = {
           organizationId: membership.organizationId,
         };
@@ -216,8 +214,8 @@ export const getUserProjectEnvironmentsByOrganizationIds = reactCache(
           };
         }
 
-        whereConditions.push(projectWhereClause);
-      }
+        return projectWhereClause;
+      });
 
       const projects = await prisma.project.findMany({
         where: {


### PR DESCRIPTION
## What does this PR do?
Fixes the default environment redirect

Fixes #6027 

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Project environment data is now personalized based on the current user, displaying only environments relevant to the user's memberships and roles.

- **Bug Fixes**
  - Updated data retrieval to ensure users only see project environments they have access to within selected organizations.

- **Tests**
  - Adjusted test cases to reflect the new user-specific project environment logic, including scenarios for membership absence and team-based access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->