### PR TITLE
fix: tls handshake failure in self-hosting license generation

### DIFF
--- a/docker/formbricks.sh
+++ b/docker/formbricks.sh
@@ -197,6 +197,7 @@ tls:
       alpnProtocols:
         - h2
         - http/1.1
+        - acme-tls/1
 EOT
 
   echo "💡 Created traefik.yaml and traefik-dynamic.yaml file."


### PR DESCRIPTION
## What does this PR do?
tls handshake failure in self-hosting license generation

Fixes #6043 

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Try self-hosting with the current formbricks.sh script, but you’ll notice that the licence generation fails.
- Try self-hosting using the updated script, and everything should work fine.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated TLS configuration to include support for the "acme-tls/1" ALPN protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->