### PR TITLE
docs: update prefilling docs

### DIFF
--- a/docs/xm-and-surveys/surveys/link-surveys/data-prefilling.mdx
+++ b/docs/xm-and-surveys/surveys/link-surveys/data-prefilling.mdx
@@ -93,11 +93,15 @@ https://app.formbricks.com/s/clin3yxja52k8l80hpwmx4bjy?openText_question_id=I%20
 
 ### CTA Question
 
-Adds 'clicked' as the answer to the CTA question. Alternatively, you can set it to 'dismissed' to skip the question:
+Accepts only 'dismissed' as answer option. Due to the risk of domain abuse, this value cannot be set to 'clicked' via prefilling:
 
 ```txt CTA Question
-https://app.formbricks.com/s/clin3yxja52k8l80hpwmx4bjy?cta_question_id=clicked
+https://app.formbricks.com/s/clin3yxja52k8l80hpwmx4bjy?cta_question_id=dismissed
 ```
+
+<Note>
+  Due to the risk of domain abuse, this value cannot be set to 'clicked' via prefilling.
+</Note>
 
 ### Consent Question
 


### PR DESCRIPTION
<img width="769" alt="image" src="https://github.com/user-attachments/assets/52f38d01-d975-4458-95c2-23543719d11b" />

Add this note to clarify how product behaves https://github.com/formbricks/formbricks/issues/6029#issuecomment-2995354746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that only the "dismissed" answer value is accepted for CTA Question prefilling via URL.
  - Updated example URL to use "dismissed" instead of "clicked".
  - Added a note stating that "clicked" cannot be set via prefilling for security reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->