### PR TITLE
fix: properly escape special characters in question headlines

### DIFF
--- a/apps/web/modules/survey/editor/lib/utils.tsx
+++ b/apps/web/modules/survey/editor/lib/utils.tsx
@@ -42,12 +42,20 @@ export const extractParts = (text: string): string[] => {
       parts.push(text.slice(i));
       break;
     }
-    const end = text.indexOf("\\", start + 1);
-    if (end === -1) {
-      // No matching `\`, treat as plain text
+    
+    // If the next character is a backslash, treat both as plain text
+    if (text[start + 1] === "\\") {
       parts.push(text.slice(i));
       break;
     }
+    
+    const end = text.indexOf("\\", start + 1);
+    // If no closing backslash or it's escaped, treat as plain text
+    if (end === -1 || (end > 0 && text[end - 1] === '\\')) {
+      parts.push(text.slice(i));
+      break;
+    }
+    
     // Add text before the match
     if (start > i) {
       parts.push(text.slice(i, start));


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where special characters like `/\` in a question's headline were being incorrectly formatted.  
Now, these characters are properly escaped and rendered as plain text.

Fixes #6058

## How should this be tested?

1. Navigate to the survey editor.
2. Add a headline with `/\` in the text.
3. Confirm in preview mode that `/\` appears as-is, not malformed or stripped.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
