### PR TITLE
chore(infra): always pull new images on staging

### DIFF
--- a/infra/formbricks-cloud-helm/values-staging.yaml.gotmpl
+++ b/infra/formbricks-cloud-helm/values-staging.yaml.gotmpl
@@ -20,7 +20,7 @@ cronJob:
               key: WEBAPP_URL
               name: formbricks-stage-app-env
       image:
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         repository: quay.io/curl/curl
         tag: latest
       schedule: 0 9 * * *
@@ -43,7 +43,7 @@ cronJob:
               key: WEBAPP_URL
               name: formbricks-stage-app-env
       image:
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         repository: quay.io/curl/curl
         tag: latest
       schedule: 0 0 * * *
@@ -66,7 +66,7 @@ cronJob:
               key: WEBAPP_URL
               name: formbricks-stage-app-env
       image:
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         repository: quay.io/curl/curl
         tag: latest
       schedule: 0 8 * * 1


### PR DESCRIPTION
This pull request updates the `imagePullPolicy` for multiple `cronJob` configurations in the `infra/formbricks-cloud-helm/values-staging.yaml.gotmpl` file to ensure the latest image is always pulled.

Key changes:

* Updated `imagePullPolicy` from `IfNotPresent` to `Always` for the `cronJob` scheduled at `0 9 * * *`. This ensures the latest image is pulled every time the job runs.
* Updated `imagePullPolicy` from `IfNotPresent` to `Always` for the `cronJob` scheduled at `0 0 * * *`. This ensures the latest image is pulled every time the job runs.
* Updated `imagePullPolicy` from `IfNotPresent` to `Always` for the `cronJob` scheduled at `0 8 * * 1`. This ensures the latest image is pulled every time the job runs.