### PR TITLE
fix: split domain docs

### DIFF
--- a/docs/self-hosting/configuration/domain-configuration.mdx
+++ b/docs/self-hosting/configuration/domain-configuration.mdx
@@ -80,7 +80,7 @@ When PUBLIC_URL is configured, the following routes are automatically served fro
 #### Survey Routes
 
 - `/s/{surveyId}` - Individual survey access
-- `/c/{jwt}` - Contact survey pages (JWT-based access)
+- `/c/{jwt}` - Personalized link survey access (JWT-based access)
 - Embedded survey endpoints
 
 #### API Routes

--- a/docs/self-hosting/configuration/domain-configuration.mdx
+++ b/docs/self-hosting/configuration/domain-configuration.mdx
@@ -80,11 +80,26 @@ When PUBLIC_URL is configured, the following routes are automatically served fro
 #### Survey Routes
 
 - `/s/{surveyId}` - Individual survey access
+- `/c/{jwt}` - Contact survey pages (JWT-based access)
 - Embedded survey endpoints
 
 #### API Routes
 
-- `/api/v1/client/{environmentId}/*` - Client API endpoints
+- `/api/v1/client/{environmentId}/*` - Client API endpoints (v1)
+- `/api/v2/client/{environmentId}/*` - Client API endpoints (v2)
+
+#### Static Assets & Next.js Routes
+
+- `/favicon.ico` - Favicon
+- `/_next/*` - Next.js static assets and build files
+- `/sitemap.xml` - SEO sitemap
+- `/robots.txt` - Web crawler instructions
+- `/js/*` - JavaScript files
+- `/css/*` - CSS stylesheets
+- `/images/*` - Image assets
+- `/fonts/*` - Font files
+- `/icons/*` - Icon assets
+- `/public/*` - Public static files
 
 #### Storage Routes
 


### PR DESCRIPTION
split domain docs
## What does this PR do?
Adds middleware exceptions as public routes explicitly in the docs to whitelist them from the firewall.

Fixes 

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
