### PR TITLE
fix: Preview in Email embed is broken

### DIFF
--- a/apps/web/modules/ui/components/editor/components/toolbar-plugin.tsx
+++ b/apps/web/modules/ui/components/editor/components/toolbar-plugin.tsx
@@ -397,7 +397,10 @@ export const ToolbarPlugin = (props: TextEditorProps & { container: HTMLElement 
 
         editor.registerUpdateListener(({ editorState, prevEditorState }) => {
           editorState.read(() => {
-            const textInHtml = $generateHtmlFromNodes(editor).replace(/&lt;/g, "<").replace(/&gt;/g, ">");
+            const textInHtml = $generateHtmlFromNodes(editor)
+              .replace(/&lt;/g, "<")
+              .replace(/&gt;/g, ">")
+              .replace(/white-space:\s*pre-wrap;?/g, "");
             setText.current(textInHtml);
           });
           if (!prevEditorState._selection) editor.blur();


### PR DESCRIPTION
Fixes #6116 

NOTE: - the but was not CTA specific as mentioned in issue, but it was general bug caused in long description irrespective of question (i've demonstrated with two examples).
the issue was cause because for some werid reason `white-space:pre-wrap` preserving intend from first line and adding it to all other lines except first line. 
<img width="886" alt="Screenshot 2025-06-27 at 11 50 34 PM" src="https://github.com/user-attachments/assets/96a73c62-2bfe-491b-986d-6daa3ef25518" />


### Before:

https://github.com/user-attachments/assets/f66a99c1-8633-4e26-ae15-fc7988761cb1

### After:

##### Example 1: CTA Question:
https://github.com/user-attachments/assets/5c85fc0d-f980-4d4c-b7dc-1cb139eda475



##### Example 2: Concent Question:
https://github.com/user-attachments/assets/79a61768-5bae-4ce3-81b5-66e98474c021


## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
