### PR TITLE
fix: recall parsing for headlines with empty strings

### DIFF
--- a/packages/surveys/src/components/general/headline.tsx
+++ b/packages/surveys/src/components/general/headline.tsx
@@ -14,7 +14,7 @@ export function Headline({ headline, questionId, required = true, alignTextCente
       <div
         className={`fb-flex fb-items-center ${alignTextCenter ? "fb-justify-center" : "fb-justify-between"}`}
         dir="auto">
-        {headline}
+        <p>{headline}</p>
         {!required && (
           <span
             className="fb-text-heading fb-mx-2 fb-self-start fb-text-sm fb-font-normal fb-leading-7 fb-opacity-60"

--- a/packages/surveys/src/lib/i18n.test.ts
+++ b/packages/surveys/src/lib/i18n.test.ts
@@ -7,6 +7,9 @@ describe("i18n", () => {
     test("should return empty string for undefined value", () => {
       expect(getLocalizedValue(undefined, "en")).toBe("");
     });
+    test("should return empty string for empty string", () => {
+      expect(getLocalizedValue({ default: "" }, "en")).toBe("");
+    });
 
     test("should return empty string for non-i18n string", () => {
       expect(getLocalizedValue("not an i18n string" as any, "en")).toBe("");

--- a/packages/surveys/src/lib/i18n.ts
+++ b/packages/surveys/src/lib/i18n.ts
@@ -10,7 +10,7 @@ export const getLocalizedValue = (value: TI18nString | undefined, languageId: st
     return "";
   }
   if (isI18nObject(value)) {
-    if (value[languageId]) {
+    if (typeof value[languageId] === "string") {
       return value[languageId];
     }
     return value.default;


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #6067 

For multi language surveys, when language is switched for a question and if that question has an empty headline for that language, then headline of default language was used as a fallback breaking recall parsing

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Steps to reproduce:

1. Navigate to Project Settings > Languages
2. Add a new language (e.g., Spanish - es)
3. Enable the new language for the survey.
4. In the default language, enter a question with some recall values
5. Switch to Spanish in the survey editor
6. Translate the question headline and its content
7. Observe: The recall parsing breaks in the translated version

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of localized values to ensure only valid string translations are returned.
  * Correctly renders headlines within a paragraph element for better structure and accessibility.

* **Tests**
  * Added a test to verify that empty string values in localization are handled as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->