### PR TITLE
fix: reordered question recalling latter question after drag-n-drop.

### DIFF
--- a/apps/web/lib/utils/recall.ts
+++ b/apps/web/lib/utils/recall.ts
@@ -52,6 +52,11 @@ export const findRecallInfoById = (text: string, id: string): string | null => {
   return match ? match[0] : null;
 };
 
+export const removeRecallFromText = (text: string, id: string): string => {
+  const pattern = new RegExp(`#recall:${id}\\/fallback:(\\S*)#`, "g");
+  return text.replace(pattern, "");
+};
+
 const getRecallItemLabel = <T extends TSurvey>(
   recallItemId: string,
   survey: T,

--- a/apps/web/modules/survey/editor/components/questions-view.test.tsx
+++ b/apps/web/modules/survey/editor/components/questions-view.test.tsx
@@ -1,4 +1,4 @@
-import { checkForEmptyFallBackValue } from "@/lib/utils/recall";
+import { checkForEmptyFallBackValue, extractIds } from "@/lib/utils/recall";
 import { validateQuestion, validateSurveyQuestionsInBatch } from "@/modules/survey/editor/lib/validation";
 import { DndContext } from "@dnd-kit/core";
 import { createId } from "@paralleldrive/cuid2";
@@ -53,6 +53,8 @@ vi.mock("@/lib/surveyLogic/utils", () => ({
 vi.mock("@/lib/utils/recall", () => ({
   checkForEmptyFallBackValue: vi.fn(),
   extractRecallInfo: vi.fn(),
+  extractIds: vi.fn(),
+  removeRecallFromText: vi.fn(),
 }));
 
 vi.mock("@/modules/ee/multi-language-surveys/components/multi-language-card", () => ({
@@ -429,11 +431,14 @@ describe("QuestionsView", () => {
   });
 
   test("handles question card drag end", async () => {
+    vi.mocked(extractIds).mockReturnValue([]);
     renderComponent();
     const dragButton = screen.getByText("Simulate Drag End questions");
     await userEvent.click(dragButton);
-    expect(setLocalSurvey).toHaveBeenCalledTimes(1);
-    const updatedSurvey = setLocalSurvey.mock.calls[0][0];
+    // setLocalSurvey is called first to save questions with reprocessed recalls
+    // and then to save questions in reordered state.
+    expect(setLocalSurvey).toHaveBeenCalledTimes(2);
+    const updatedSurvey = setLocalSurvey.mock.calls[1][0];
     // Based on the hardcoded IDs in the mock DndContext
     expect(updatedSurvey.questions[0].id).toBe("q2");
     expect(updatedSurvey.questions[1].id).toBe("q1");


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

Currently, if a user add a new question, recalls a previous question in the current question and then (drag-n-drop)'s  the current question before the previous question -- the current question now recall a question after it, which is a bug. A question should only be able to recall the question before it.
We should process the headlines of the questions affected by the reodering to maintain the correct behavior.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #(issue)
Attempts to fix https://github.com/formbricks/formbricks/issues/5983

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
**After**

https://github.com/user-attachments/assets/27bbdfbb-0cd3-42f6-a2bd-dceed4c79206

**Before**


https://github.com/user-attachments/assets/02434ca8-6290-48b3-9827-d46fe94a1d7e



## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Create a survey.
- Add a question and recall the previous question in the current question.
- Drag and drop the current question before the previous question.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved drag-and-drop for survey questions to automatically update and remove outdated recall references in question headlines when questions are reordered.

* **Bug Fixes**
  * Ensured that recall references remain accurate and consistent after reordering survey questions.

* **Tests**
  * Updated tests to validate correct handling of recall references during question reordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->