### PR TITLE
refactor: preserve return type in withAuditLogging wrapper (#6143)

### DIFF
--- a/apps/web/modules/ee/audit-logs/lib/handler.ts
+++ b/apps/web/modules/ee/audit-logs/lib/handler.ts
@@ -199,18 +199,18 @@ export const queueAuditEvent = async ({
  * @param targetType - The type of target (e.g., "segment", "survey").
  * @param handler - The handler function to wrap. It can be used with both authenticated and unauthenticated actions.
  **/
-export const withAuditLogging = <TParsedInput = Record<string, unknown>>(
+export const withAuditLogging = <TParsedInput = Record<string, unknown>,TReturn = unknown>(
   action: TAuditAction,
   targetType: TAuditTarget,
   handler: (args: {
     ctx: ActionClientCtx | AuthenticatedActionClientCtx;
     parsedInput: TParsedInput;
-  }) => Promise<unknown>
+  }) => Promise<TReturn>
 ) => {
   return async function wrappedAction(args: {
     ctx: ActionClientCtx | AuthenticatedActionClientCtx;
     parsedInput: TParsedInput;
-  }) {
+  }):Promise<TReturn> {
     const { ctx, parsedInput } = args;
     const { auditLoggingCtx } = ctx;
     let result: any;


### PR DESCRIPTION
## What does this PR do?

This PR ensures that the withAuditLogging wrapper preserves the return type of the wrapped server action. Previously, the type was lost and inferred as any, which caused issues with actionClientResponse.data being untyped.

Fixes #6143

## How should this be tested?

-Wrap an action using withAuditLogging and confirm actionClientResponse.data has correct inferred type.
-Manually verify the action still logs audit events.

## Checklist

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
