### PR TITLE
feat: add Vitest setup and initial unit tests for action-class schema…

### DIFF
--- a/packages/types/action-classes.test.ts
+++ b/packages/types/action-classes.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect } from "vitest";
+import {
+  ZActionClassNoCodeConfig,
+  ZActionClassPageUrlRule,
+  ZActionClassInput
+} from "./action-classes";
+
+describe("ZActionClassNoCodeConfig (click type)", () => {
+  test("fails when both cssSelector and innerHtml are missing", () => {
+    const result = ZActionClassNoCodeConfig.safeParse({
+      type: "click",
+      urlFilters: [],
+      elementSelector: {}
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0]?.message).toContain(
+      "Either cssSelector or innerHtml"
+    );
+  });
+
+  test("passes when cssSelector is provided", () => {
+    const result = ZActionClassNoCodeConfig.safeParse({
+      type: "click",
+      urlFilters: [],
+      elementSelector: { cssSelector: ".btn" }
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("passes when innerHtml is provided", () => {
+    const result = ZActionClassNoCodeConfig.safeParse({
+      type: "click",
+      urlFilters: [],
+      elementSelector: { innerHtml: "Click me" }
+    });
+
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("ZActionClassPageUrlRule", () => {
+  test("accepts all valid rules", () => {
+    const validRules = [
+      "exactMatch",
+      "contains",
+      "startsWith",
+      "endsWith",
+      "notMatch",
+      "notContains"
+    ];
+
+    for (const rule of validRules) {
+      const result = ZActionClassPageUrlRule.safeParse(rule);
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("rejects an invalid rule", () => {
+    const result = ZActionClassPageUrlRule.safeParse("invalidRule");
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("ZActionClassInput (discriminated union)", () => {
+  test("passes for code type input with required fields", () => {
+    const result = ZActionClassInput.safeParse({
+      name: "Test Action",
+      type: "code",
+      environmentId: "cklb2xk1g0000z6x78j2n1e3w",
+      key: "abc"
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("fails for code type input without key", () => {
+    const result = ZActionClassInput.safeParse({
+      name: "Test Action",
+      type: "code",
+      environmentId: "cklb2xk1g0000z6x78j2n1e3w"
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("passes for noCode type input with valid config", () => {
+    const result = ZActionClassInput.safeParse({
+      name: "NoCode Action",
+      type: "noCode",
+      environmentId: "cklb2xk1g0000z6x78j2n1e3w",
+      noCodeConfig: {
+        type: "click",
+        urlFilters: [
+          {
+            value: "page",
+            rule: "contains"
+          }
+        ],
+        elementSelector: {
+          cssSelector: "#element"
+        }
+      }
+    });
+
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -6,7 +6,9 @@
   "sideEffects": false,
   "scripts": {
     "lint": "eslint . --ext .ts,.js,.tsx,.jsx",
-    "clean": "rimraf node_modules .turbo"
+    "clean": "rimraf node_modules .turbo",
+    "test": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@prisma/client": "6.7.0",
@@ -14,6 +16,9 @@
   },
   "devDependencies": {
     "@formbricks/config-typescript": "workspace:*",
-    "@formbricks/database": "workspace:*"
+    "@formbricks/database": "workspace:*",
+    "typescript": "5.8.3",
+    "vite-tsconfig-paths": "5.1.4",
+    "vitest": "3.1.3"
   }
 }

--- a/packages/types/vite.config.mts
+++ b/packages/types/vite.config.mts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["**/*.test.ts"],
+    exclude: ["**/node_modules/**", "**/integrations/**", "**/dist/**"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      reportsDirectory: "./coverage",
+      include: [
+        "**/*.ts",
+        "!**/*.test.ts",
+        "!**/node_modules/**",
+        "!**/vitest.config.ts"
+      ]
+    },
+  },
+  plugins: [tsconfigPaths()],
+});


### PR DESCRIPTION
## What does this PR do?

Adds Vitest setup to the types package and includes initial unit tests for the action-class schema, specifically targeting custom validators like the one ensuring at least one of cssSelector or innerHtml is present.

Fixes #6094

## How should this be tested?

Run pnpm test in packages/types and confirm all tests pass

## Checklist


- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
