### PR TITLE
fix: add validations for displayId in client response APIs

### DIFF
--- a/apps/web/lib/display/service.ts
+++ b/apps/web/lib/display/service.ts
@@ -62,3 +62,21 @@ export const deleteDisplay = async (displayId: string): Promise<TDisplay> => {
     throw error;
   }
 };
+
+export const getDisplay = reactCache(
+  async (displayId: string): Promise<{ id: string; surveyId: string } | null> => {
+    validateInputs([displayId, ZId]);
+    try {
+      const display = await prisma.display.findUnique({
+        where: { id: displayId },
+        select: { id: true, surveyId: true },
+      });
+      return display;
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw new DatabaseError(error.message);
+      }
+      throw error;
+    }
+  }
+);

--- a/packages/types/responses.ts
+++ b/packages/types/responses.ts
@@ -297,7 +297,7 @@ export const ZResponseInput = z.object({
   environmentId: z.string().cuid2(),
   surveyId: z.string().cuid2(),
   userId: z.string().nullish(),
-  displayId: z.string().nullish(),
+  displayId: z.string().cuid2().nullish(),
   singleUseId: z.string().nullable().optional(),
   finished: z.boolean(),
   endingId: z.string().nullish(),


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Added validation to check if displayId is cuid and exists in the database before creating a response
Return a properly formatted generic error message without leaking any info
Fixed the issue for both v1 and v2 API endpoints
verifying that the display belongs to the correct survey context.

Fixes #6026

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
![image](https://github.com/user-attachments/assets/c6eeacb7-21ee-49fe-8fa4-df5c419167eb)

![image](https://github.com/user-attachments/assets/9c76aa0a-f476-49d4-b9d3-da51523a2c74)
![image](https://github.com/user-attachments/assets/6d8a899c-7375-4879-91bd-a80cefaa8dd5)

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Make a POST request to ```/api/v2/client/[environmentId]/responses``` OR ```/api/v1/client/[environmentId]/responses```
- JSON payload as: 
`{
    "data": {
      <your-response-data>
    },
    "finished": true,
    "surveyId": "<your-survey-id>",
    // some non-existent displayId OR displayId of another survey
    "displayId": "displayId",
    "singleUseId": null
}`

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
