### PR TITLE
fix: click outside close for react-native sdk

### DIFF
--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1303,7 +1303,6 @@
         "casual": "Lässig",
         "caution_edit_duplicate": "Duplizieren & bearbeiten",
         "caution_edit_published_survey": "Eine veröffentlichte Umfrage bearbeiten?",
-        "caution_explanation_all_data_as_download": "Alle Daten, einschließlich früherer Antworten, stehen als Download zur Verfügung.",
         "caution_explanation_intro": "Wir verstehen, dass du vielleicht noch Änderungen vornehmen möchtest. Hier erfährst du, was passiert, wenn du das tust:",
         "caution_explanation_new_responses_separated": "Antworten vor der Änderung werden möglicherweise nicht oder nur teilweise in der Umfragezusammenfassung berücksichtigt.",
         "caution_explanation_only_new_responses_in_summary": "Alle Daten, einschließlich früherer Antworten, bleiben auf der Umfrageübersichtsseite als Download verfügbar.",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1303,7 +1303,6 @@
         "casual": "Casual",
         "caution_edit_duplicate": "Duplicate & edit",
         "caution_edit_published_survey": "Edit a published survey?",
-        "caution_explanation_all_data_as_download": "All data, including past responses are available as download.",
         "caution_explanation_intro": "We understand you might still want to make changes. Here’s what happens if you do: ",
         "caution_explanation_new_responses_separated": "Responses before the change may not or only partially be included in the survey summary.",
         "caution_explanation_only_new_responses_in_summary": "All data, including past responses, remain available as download on the survey summary page.",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1303,7 +1303,6 @@
         "casual": "Décontracté",
         "caution_edit_duplicate": "Dupliquer et modifier",
         "caution_edit_published_survey": "Modifier un sondage publié ?",
-        "caution_explanation_all_data_as_download": "Toutes les données, y compris les réponses passées, sont disponibles en téléchargement.",
         "caution_explanation_intro": "Nous comprenons que vous souhaitiez encore apporter des modifications. Voici ce qui se passe si vous le faites : ",
         "caution_explanation_new_responses_separated": "Les réponses avant le changement peuvent ne pas être ou ne faire partie que partiellement du résumé de l'enquête.",
         "caution_explanation_only_new_responses_in_summary": "Toutes les données, y compris les réponses passées, restent disponibles en téléchargement sur la page de résumé de l'enquête.",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1303,7 +1303,6 @@
         "casual": "Casual",
         "caution_edit_duplicate": "Duplicar e editar",
         "caution_edit_published_survey": "Editar uma pesquisa publicada?",
-        "caution_explanation_all_data_as_download": "Todos os dados, incluindo respostas anteriores, estão disponíveis para download.",
         "caution_explanation_intro": "Entendemos que você ainda pode querer fazer alterações. Aqui está o que acontece se você fizer:",
         "caution_explanation_new_responses_separated": "Respostas antes da mudança podem não ser ou apenas parcialmente incluídas no resumo da pesquisa.",
         "caution_explanation_only_new_responses_in_summary": "Todos os dados, incluindo respostas anteriores, permanecem disponíveis para download na página de resumo da pesquisa.",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1303,7 +1303,6 @@
         "casual": "Casual",
         "caution_edit_duplicate": "Duplicar e editar",
         "caution_edit_published_survey": "Editar um inquérito publicado?",
-        "caution_explanation_all_data_as_download": "Todos os dados, incluindo respostas anteriores, estão disponíveis para download.",
         "caution_explanation_intro": "Entendemos que ainda pode querer fazer alterações. Eis o que acontece se o fizer:",
         "caution_explanation_new_responses_separated": "Respostas antes da alteração podem não estar incluídas ou estar apenas parcialmente incluídas no resumo do inquérito.",
         "caution_explanation_only_new_responses_in_summary": "Todos os dados, incluindo respostas anteriores, permanecem disponíveis para download na página de resumo do inquérito.",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1303,7 +1303,6 @@
         "casual": "隨意",
         "caution_edit_duplicate": "複製 & 編輯",
         "caution_edit_published_survey": "編輯已發佈的調查？",
-        "caution_explanation_all_data_as_download": "所有數據，包括過去的回應，都可以下載。",
         "caution_explanation_intro": "我們了解您可能仍然想要進行更改。如果您這樣做，將會發生以下情況：",
         "caution_explanation_new_responses_separated": "更改前的回應可能未被納入或只有部分包含在調查摘要中。",
         "caution_explanation_only_new_responses_in_summary": "所有數據，包括過去的回應，仍可在調查摘要頁面下載。",

--- a/packages/surveys/src/components/general/render-survey.tsx
+++ b/packages/surveys/src/components/general/render-survey.tsx
@@ -50,12 +50,12 @@ export function RenderSurvey(props: SurveyContainerProps) {
       placement={props.placement}
       darkOverlay={props.darkOverlay}
       clickOutside={props.clickOutside}
+      ignorePlacementForClickOutside={props.ignorePlacementForClickOutside}
       onClose={close}
       isOpen={isOpen}>
       {/* @ts-expect-error -- TODO: fix this */}
       <Survey
         {...props}
-        clickOutside={props.placement === "center" ? props.clickOutside : true}
         onClose={close}
         onFinished={() => {
           props.onFinished?.();

--- a/packages/surveys/src/components/wrappers/survey-container.tsx
+++ b/packages/surveys/src/components/wrappers/survey-container.tsx
@@ -9,6 +9,7 @@ interface SurveyContainerProps {
   children: React.ReactNode;
   onClose?: () => void;
   clickOutside?: boolean;
+  ignorePlacementForClickOutside?: boolean;
   isOpen?: boolean;
 }
 
@@ -19,6 +20,7 @@ export function SurveyContainer({
   children,
   onClose,
   clickOutside,
+  ignorePlacementForClickOutside,
   isOpen = true,
 }: Readonly<SurveyContainerProps>) {
   const modalRef = useRef<HTMLDivElement>(null);
@@ -27,7 +29,11 @@ export function SurveyContainer({
 
   useEffect(() => {
     if (!isModal) return;
-    if (!isCenter) return;
+
+    // If the placement is not center and we don't want to ignore center placement for click outside, we will return early
+    if (!ignorePlacementForClickOutside && !isCenter) {
+      return;
+    }
 
     const handleClickOutside = (e: MouseEvent) => {
       if (
@@ -44,7 +50,7 @@ export function SurveyContainer({
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [clickOutside, onClose, isCenter, isModal, isOpen]);
+  }, [clickOutside, onClose, isCenter, isModal, isOpen, ignorePlacementForClickOutside]);
 
   const getPlacementStyle = (placement: TPlacement): string => {
     switch (placement) {

--- a/packages/types/formbricks-surveys.ts
+++ b/packages/types/formbricks-surveys.ts
@@ -27,6 +27,7 @@ export interface SurveyBaseProps {
   isCardBorderVisible?: boolean;
   startAtQuestionId?: string;
   clickOutside?: boolean;
+  ignorePlacementForClickOutside?: boolean;
   hiddenFieldsRecord?: TResponseHiddenFieldValue;
   shouldResetQuestionId?: boolean;
   fullSizeCards?: boolean;


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?
This is a companion PR to the https://github.com/formbricks/react-native/pull/16 PR which adds the prop to the surveys package for ignoring the placement settings and enabling click outside close

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
