### PR TITLE
fix: run PR checks on every pull requests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,8 +10,6 @@ permissions:
 
 on:
   pull_request:
-    branches:
-      - main
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
This fixes an issue that PR checks are not running on other target branches than main (e.g. `epic/...`).

This pull request modifies the `.github/workflows/pr.yml` file to update the triggers for the workflow. The change removes the branch-specific trigger for `main`, allowing the workflow to run on all pull requests regardless of the branch.