### PR TITLE
Fix: Show unsaved changes dialog only when localSurvey differs from survey

### DIFF
--- a/apps/web/modules/survey/editor/components/survey-editor.tsx
+++ b/apps/web/modules/survey/editor/components/survey-editor.tsx
@@ -50,7 +50,7 @@ interface SurveyEditorProps {
 }
 
 export const SurveyEditor = ({
-  survey,
+  survey: initialSurvey,
   project,
   projectLanguages,
   environment,
@@ -74,9 +74,10 @@ export const SurveyEditor = ({
   userEmail,
   teamMemberDetails,
 }: SurveyEditorProps) => {
+  const [survey, setSurvey] = useState<TSurvey>(() => structuredClone(initialSurvey));
   const [activeView, setActiveView] = useState<TSurveyEditorTabs>("questions");
   const [activeQuestionId, setActiveQuestionId] = useState<string | null>(null);
-  const [localSurvey, setLocalSurvey] = useState<TSurvey | null>(() => structuredClone(survey));
+  const [localSurvey, setLocalSurvey] = useState<TSurvey>(() => structuredClone(initialSurvey));
   const [invalidQuestions, setInvalidQuestions] = useState<string[] | null>(null);
   const [selectedLanguageCode, setSelectedLanguageCode] = useState<string>("default");
   const surveyEditorRef = useRef(null);
@@ -155,6 +156,7 @@ export const SurveyEditor = ({
         setLocalSurvey={setLocalSurvey}
         localSurvey={localSurvey}
         survey={survey}
+        setSurvey={setSurvey}
         environmentId={environment.id}
         activeId={activeView}
         setActiveId={setActiveView}

--- a/apps/web/modules/survey/editor/components/survey-menu-bar.tsx
+++ b/apps/web/modules/survey/editor/components/survey-menu-bar.tsx
@@ -29,6 +29,7 @@ import { isSurveyValid } from "../lib/validation";
 interface SurveyMenuBarProps {
   localSurvey: TSurvey;
   survey: TSurvey;
+  setSurvey: (survey: TSurvey) => void;
   setLocalSurvey: (survey: TSurvey) => void;
   environmentId: string;
   activeId: TSurveyEditorTabs;
@@ -46,6 +47,7 @@ interface SurveyMenuBarProps {
 export const SurveyMenuBar = ({
   localSurvey,
   survey,
+  setSurvey,
   environmentId,
   setLocalSurvey,
   activeId,
@@ -246,6 +248,7 @@ export const SurveyMenuBar = ({
       setIsSurveySaving(false);
       if (updatedSurveyResponse?.data) {
         setLocalSurvey(updatedSurveyResponse.data);
+        setSurvey(updatedSurveyResponse.data);
         toast.success(t("environments.surveys.edit.changes_saved"));
       } else {
         const errorMessage = getFormattedErrorMessage(updatedSurveyResponse);


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Fixes #6192 
###  Problem
The "Your progress might get lost" confirmation dialog was incorrectly shown in the Survey Editor when clicking "Back"—even right after saving the survey.

### Root Cause
After a successful save, the `survey` state in the `SurveyEditor` component is not updated with the latest version returned from the backend. As a result, `localSurvey` (which is updated) and `survey` (which is stale) appear different on the next render. This triggers the "unsaved changes" warning dialog unnecessarily.

###  Fix
Passed the `setSurvey` function correctly to the `SurveyMenuBar` component and ensured the `survey` state is updated after a successful save. This ensures `localSurvey` and `survey` remain in sync and the dialog only shows when actual changes exist.


Here’s a video recording I posted in the issue demonstrating the bug and how it behaves after the fix.


https://github.com/user-attachments/assets/26736227-302e-4e64-a0c2-8cf2ffb95521



---

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

