### PR TITLE
Fix GitHub issue 6210 for Formbricks

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/settings/(account)/profile/components/EditProfileDetailsForm.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/settings/(account)/profile/components/EditProfileDetailsForm.tsx
@@ -88,6 +88,11 @@ export const EditProfileDetailsForm = ({
     const updatedUserResult = await updateUserAction(data);
 
     if (updatedUserResult?.data) {
+      // Show success toast for name/locale changes when email also changes
+      if (nameChanged || localeChanged) {
+        toast.success(t("environments.settings.profile.personal_information_updated"));
+      }
+
       if (!emailVerificationDisabled) {
         toast.success(t("auth.verification-requested.new_email_verification_success"));
       } else {
@@ -120,7 +125,7 @@ export const EditProfileDetailsForm = ({
           ...data,
           name: data.name.trim(),
         });
-        toast.success(t("environments.settings.profile.profile_updated_successfully"));
+        toast.success(t("environments.settings.profile.personal_information_updated"));
         window.location.reload();
         form.reset(data);
       } catch (error: any) {

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1156,6 +1156,7 @@
         "organizations_delete_message": "Du bist der einzige Besitzer dieser Organisationen, also werden sie <b>auch gelöscht.</b>",
         "permanent_removal_of_all_of_your_personal_information_and_data": "Dauerhafte Entfernung all deiner persönlichen Informationen und Daten",
         "personal_information": "Persönliche Informationen",
+        "personal_information_updated": "Persönliche Informationen aktualisiert",
         "please_enter_email_to_confirm_account_deletion": "Bitte gib {email} in das folgende Feld ein, um die endgültige Löschung deines Kontos zu bestätigen:",
         "profile_updated_successfully": "Dein Profil wurde erfolgreich aktualisiert",
         "remove_image": "Bild entfernen",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1156,6 +1156,7 @@
         "organizations_delete_message": "You are the only owner of these organizations, so they <b>will be deleted as well.</b>",
         "permanent_removal_of_all_of_your_personal_information_and_data": "Permanent removal of all of your personal information and data",
         "personal_information": "Personal information",
+        "personal_information_updated": "Personal information updated",
         "please_enter_email_to_confirm_account_deletion": "Please enter {email} in the following field to confirm the definitive deletion of your account:",
         "profile_updated_successfully": "Your profile was updated successfully",
         "remove_image": "Remove image",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1156,6 +1156,7 @@
         "organizations_delete_message": "Tu es le seul propriétaire de ces organisations, elles <b>seront aussi supprimées.</b>",
         "permanent_removal_of_all_of_your_personal_information_and_data": "Suppression permanente de toutes vos informations et données personnelles.",
         "personal_information": "Informations personnelles",
+        "personal_information_updated": "Informations personnelles mises à jour",
         "please_enter_email_to_confirm_account_deletion": "Veuillez entrer {email} dans le champ suivant pour confirmer la suppression définitive de votre compte :",
         "profile_updated_successfully": "Votre profil a été mis à jour avec succès.",
         "remove_image": "Supprimer l'image",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1156,6 +1156,7 @@
         "organizations_delete_message": "Você é o único dono dessas organizações, então elas <b>também serão apagadas.</b>",
         "permanent_removal_of_all_of_your_personal_information_and_data": "Remoção permanente de todas as suas informações e dados pessoais",
         "personal_information": "Informações pessoais",
+        "personal_information_updated": "Informações pessoais atualizadas",
         "please_enter_email_to_confirm_account_deletion": "Por favor, insira {email} no campo abaixo para confirmar a exclusão definitiva da sua conta:",
         "profile_updated_successfully": "Seu perfil foi atualizado com sucesso",
         "remove_image": "Remover imagem",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1156,6 +1156,7 @@
         "organizations_delete_message": "É o único proprietário destas organizações, por isso <b>também serão eliminadas.</b>",
         "permanent_removal_of_all_of_your_personal_information_and_data": "Remoção permanente de todas as suas informações e dados pessoais",
         "personal_information": "Informações pessoais",
+        "personal_information_updated": "Informações pessoais atualizadas",
         "please_enter_email_to_confirm_account_deletion": "Por favor, insira {email} no campo seguinte para confirmar a eliminação definitiva da sua conta:",
         "profile_updated_successfully": "O seu perfil foi atualizado com sucesso",
         "remove_image": "Remover imagem",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1156,6 +1156,7 @@
         "organizations_delete_message": "您是這些組織的唯一擁有者，因此它們也 <b>將被刪除。</b>",
         "permanent_removal_of_all_of_your_personal_information_and_data": "永久移除您的所有個人資訊和資料",
         "personal_information": "個人資訊",
+        "personal_information_updated": "個人資訊已更新",
         "please_enter_email_to_confirm_account_deletion": "請在以下欄位中輸入 '{'email'}' 以確認永久刪除您的帳戶：",
         "profile_updated_successfully": "您的個人資料已成功更新",
         "remove_image": "移除圖片",


### PR DESCRIPTION
```
fix: Display success toast for account settings updates

## What does this PR do?

This PR addresses the issue where no success toast was displayed when updating account settings (name, email, or language). Previously, a success toast was only shown for email changes, but not for name or locale updates, especially when combined with an email change.

This fix ensures that a "Personal information updated" toast is consistently displayed upon successful updates to name or locale, even when an email change requiring verification is also made. It also adds multi-language support for this new toast message.

Fixes #6210

## How should this be tested?

To test this PR, navigate to your profile settings and perform the following actions, verifying that the appropriate success toasts appear:

-   **Update only name:** Change your name and save.
-   **Update only language:** Change your preferred language and save.
-   **Update name and email:** Change both your name and email address (test both scenarios: with and without email verification required).
-   **Update language and email:** Change both your language and email address (test both scenarios: with and without email verification required).
-   **Update only email:** Change only your email address (ensure the existing email verification toast still appears correctly).
-   **Verify multi-language support:** Change your language settings and then update your profile to confirm the "Personal information updated" toast appears in the selected language.

## Checklist

### Required

-   [x] Filled out the "How to test" section in this PR
-   [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
-   [x] Self-reviewed my own code
-   [x] Commented on my code in hard-to-understand bits
-   [x] Ran `pnpm build`
-   [x] Checked for warnings, there are none
-   [x] Removed all `console.logs`
-   [ ] Merged the latest changes from main onto my branch with `git pull origin main`
-   [ ] My changes don't cause any responsiveness issues
-   [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

-   [ ] If a UI change was made: Added a screen recording or screenshots to this PR
-   [ ] Updated the Formbricks Docs if changes were necessary
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified success message when updating personal information in profile settings, now shown in more scenarios.
* **Localization**
  * Introduced a new translation for the personal information updated message across all supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->