### PR TITLE
fix(templates): Preserve filters when searching templates

### DIFF
--- a/apps/web/modules/survey/components/template-list/index.tsx
+++ b/apps/web/modules/survey/components/template-list/index.tsx
@@ -74,22 +74,17 @@ export const TemplateList = ({
   };
 
   const filteredTemplates = () => {
-    return templates(t).filter((template) => {
-      if (templateSearch) {
-        return template.name.toLowerCase().includes(templateSearch.toLowerCase());
-      }
-
-      // Parse and validate the filters
+    const allTemplates = templates(t);
+    // Parse and validate the filters
+    const categoryFiltered = allTemplates.filter((template) => {
       const channelParseResult = ZProjectConfigChannel.nullable().safeParse(selectedFilter[0]);
       const industryParseResult = ZProjectConfigIndustry.nullable().safeParse(selectedFilter[1]);
       const roleParseResult = ZTemplateRole.nullable().safeParse(selectedFilter[2]);
-
       // Ensure all validations are successful
       if (!channelParseResult.success || !industryParseResult.success || !roleParseResult.success) {
         // If any validation fails, skip this template
         return true;
       }
-
       // Access the validated data from the parse results
       const validatedChannel = channelParseResult.data;
       const validatedIndustry = industryParseResult.data;
@@ -102,6 +97,14 @@ export const TemplateList = ({
 
       return channelMatch && industryMatch && roleMatch;
     });
+
+    if (templateSearch) {
+      return categoryFiltered.filter((template) =>
+        template.name.toLowerCase().includes(templateSearch.toLowerCase())
+      );
+    }
+
+    return categoryFiltered;
   };
 
   return (


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

This PR fixes the issue where searching would clear the filters on the template page. Now, when you search, It will apply to the templates you've already filtered.

Fixes #6016 

Here's a quick demo:

https://github.com/user-attachments/assets/b3fef4d5-0fee-46bd-9be9-f3dbbaef1692


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the filtering logic for templates to ensure category filters are always applied before name-based search, resulting in more accurate and consistent filtering of templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->