### PR TITLE
docs: adds email address validation note

### DIFF
--- a/docs/self-hosting/auth-behavior.mdx
+++ b/docs/self-hosting/auth-behavior.mdx
@@ -62,3 +62,7 @@ For more information on SSO setup, see:
 - [Azure AD OAuth](./configuration/auth-sso/azure-ad-oauth)
 - [Open ID Connect](./configuration/auth-sso/open-id-connect)
 - [SAML SSO](./configuration/auth-sso/saml-sso)
+
+<Note>
+  Formbricks does not support special characters, such as Cyrillic, in account email addresses to avoid technical, compatibility, and security issues. Additionally, universal support for such addresses is still limited. 
+</Note>


### PR DESCRIPTION
## What does this PR do?
adds email address validation note

Fixes https://formbricks.slack.com/archives/C050S32K42K/p1752613247600409

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

<img width="2310" height="1024" alt="image" src="https://github.com/user-attachments/assets/816fb7b7-a790-4232-8601-33339042c9cc" />


## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note clarifying that account email addresses cannot contain special characters, including Cyrillic, due to technical, compatibility, and security reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->