### PR TITLE
fix: prevent saving when PIN is not exactly four digits

### DIFF
--- a/apps/web/modules/survey/editor/components/survey-menu-bar.tsx
+++ b/apps/web/modules/survey/editor/components/survey-menu-bar.tsx
@@ -214,6 +214,15 @@ export const SurveyMenuBar = ({
     }
 
     try {
+      if (localSurvey.pin !== null) {
+        const fourDigitPattern = /^\d{4}$/;
+
+        if (!fourDigitPattern.test(String(localSurvey.pin))) {
+          toast.error(t("environments.surveys.edit.pin_must_be_a_four_digit_number"));
+          setIsSurveySaving(false);
+          return false;
+        }
+      }
       const isSurveyValidResult = isSurveyValid(localSurvey, selectedLanguageCode, t, responseCount);
       if (!isSurveyValidResult) {
         setIsSurveySaving(false);


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

Adds a client‑side guard so that the Save button is blocked whenever the survey PIN isn’t exactly four numeric digits. If a user enters a PIN of any other length (or with non‑numeric characters), we now show the existing i18n error toast `pin_must_be_a_four_digit_number` and abort the save() call.

Fixes #6248

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->


<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->
Loom Video: https://www.loom.com/share/12139ea83e4942caa6d6d3db57a6d933?sid=d0d77ae3-aaf9-4e44-904a-5e6401a22841

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

1. Navigate to your survey’s Settings → Response Options and toggle on “Protect survey with PIN”.
2. Enter a PIN with fewer or more than four characters (e.g. 123, 12345, or 12ab).
3. Click Save in the top menu bar.
   - You should see the toast error:

       -- “Pin must be a four digit number”

6. The survey should not save or refresh.
7. Enter a valid four‑digit numeric PIN (e.g. 4321), click Save → survey should save successfully.



## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure the survey PIN is either empty or a four-digit number before saving. Users will see an error message if the PIN format is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->