### PR TITLE
fix: enable Tailscale subnet routes for EKS access

### DIFF
--- a/.github/workflows/deploy-formbricks-cloud.yml
+++ b/.github/workflows/deploy-formbricks-cloud.yml
@@ -52,6 +52,7 @@ jobs:
           oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
           tags: tag:github
+          args: --accept-routes
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@f24d7193d98baebaeacc7e2227925dd47cc267f5 # v4.2.0


### PR DESCRIPTION

## 🔍 Root Cause
- EKS cluster endpoint is private-only (`10.0.54.118` in VPC `10.0.0.0/16`)
- `tailscale-eks-router` correctly advertises subnet routes for `10.0.0.0/16`
- GitHub Actions was connecting to Tailscale but **not accepting subnet routes**
- Traffic to EKS endpoint was attempting internet routing instead of VPC routing

## ✅ Solution
Added `args: --accept-routes` to the `tailscale/github-action@v3` configuration.

This enables GitHub Actions runners to:
- Accept advertised subnet routes from `tailscale-eks-router`
- Route traffic to `10.0.54.118` through the subnet router into the VPC
- Successfully reach the private EKS cluster

## 🔧 Changes
- `.github/workflows/deploy-formbricks-cloud.yml`: Added `args: --accept-routes` to Tailscale step

## 🧪 Testing
- [x] Verified autoApprovers are working (audit logs show GitHub runners getting approved)
- [x] Confirmed subnet router is advertising `10.0.0.0/16` routes
- [x] Validated EKS endpoint is within advertised subnet range

## 📚 Context
This restores the functionality that was working previously. The route acceptance likely got lost when the Tailscale configuration was updated after removing a team member.

## 📖 References
- [Tailscale subnet routes documentation](https://tailscale.com/kb/1019/subnets)
- [tailscale/github-action repository](https://github.com/tailscale/github-action)