### PR TITLE
chore(infra): enable cluster public access to mitigate tailscale issues

### DIFF
--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -11,20 +11,20 @@ locals {
   tags = {
     Project     = local.project
     Environment = local.environment
-    MangedBy    = "Terraform"
+    ManagedBy   = "Terraform"
     Blueprint   = local.name
   }
   tags_map = {
     prod = {
       Project     = local.project
       Environment = "prod"
-      MangedBy    = "Terraform"
+      ManagedBy   = "Terraform"
       Blueprint   = "${local.project}-prod"
     }
     stage = {
       Project     = local.project
       Environment = "stage"
-      MangedBy    = "Terraform"
+      ManagedBy   = "Terraform"
       Blueprint   = "${local.project}-stage"
     }
   }
@@ -137,7 +137,8 @@ module "eks" {
   cluster_version = "1.32"
 
   enable_cluster_creator_admin_permissions = false
-  cluster_endpoint_public_access           = false
+  cluster_endpoint_public_access           = true  # TEMPORARY: Enable for deployments until Tailscale is fixed by new DevOps engineer
+  cluster_endpoint_public_access_cidrs     = ["0.0.0.0/0"]  # TEMPORARY: Will revert to private + Tailscale access
   cloudwatch_log_group_retention_in_days   = 365
 
   cluster_addons = {


### PR DESCRIPTION
## **Temporary Fix: Enable EKS Public Access for Deployments**

### **Problem**
- Tailscale VPN connectivity to EKS cluster is broken after removing a DevOps team member
- GitHub Actions deployments are failing with `Kubernetes cluster unreachable` errors
- Unable to deploy critical updates to both staging and production environments

### **Temporary Solution**
This PR temporarily enables public access to the EKS cluster API endpoint to restore deployment capability while we await our new DevOps engineer (starting next week) to fix the Tailscale configuration.

### **Changes Made**
```hcl
# Enable temporary public access to EKS API
cluster_endpoint_public_access           = true  # TEMPORARY: Enable for deployments until Tailscale is fixed by new DevOps engineer
cluster_endpoint_public_access_cidrs     = ["0.0.0.0/0"]  # TEMPORARY: Will revert to private + Tailscale access
```

### **Security Considerations**
- ✅ **EKS API requires AWS authentication** - not publicly accessible without valid AWS credentials
- ✅ **Worker nodes remain in private subnets** - application workloads stay secure
- ✅ **Only the control plane API is exposed** - no direct access to applications
- ✅ **GitHub Actions uses IAM roles** - no long-lived credentials exposed

### **Impact**
- **Immediate**: Restores deployment capability for both staging and production
- **Affects**: Both environments (they share the same EKS cluster)
- **Duration**: Temporary until Tailscale is fixed (expected: 2 weeks)

### **Revert Plan**
Once Tailscale is fixed by the new DevOps engineer:
1. Set `cluster_endpoint_public_access = false`
2. Remove `cluster_endpoint_public_access_cidrs` line
3. Verify GitHub Actions works with Tailscale
4. Apply terraform changes

### **Testing**
- [ ] Terraform plan/apply succeeds
- [ ] GitHub Actions can deploy to staging environment
- [ ] GitHub Actions can deploy to production environment
- [ ] Application functionality unaffected

### **Approval**
This is a **minimal, reversible change** to maintain business continuity while we resolve the underlying Tailscale infrastructure issue.