### PR TITLE
fix: fixes PIN 4 digit length error

### DIFF
--- a/apps/web/modules/survey/editor/components/response-options-card.tsx
+++ b/apps/web/modules/survey/editor/components/response-options-card.tsx
@@ -420,6 +420,8 @@ export const ResponseOptionsCard = ({
                   />
                 </div>
               </AdvancedOptionToggle>
+
+              {/* Protect Survey with Pin */}
               <AdvancedOptionToggle
                 htmlId="protectSurveyWithPin"
                 isChecked={isPinProtectionEnabled}
@@ -442,6 +444,7 @@ export const ResponseOptionsCard = ({
                     defaultValue={localSurvey.pin ? localSurvey.pin : undefined}
                     onKeyDown={handleSurveyPinInputKeyDown}
                     onChange={(e) => handleProtectSurveyPinChange(e.target.value)}
+                    maxLength={4}
                   />
                   {verifyProtectWithPinError && (
                     <p className="pt-1 text-sm text-red-700">{verifyProtectWithPinError}</p>

--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -849,7 +849,7 @@ export const ZSurvey = z
     recaptcha: ZSurveyRecaptcha.nullable(),
     isSingleResponsePerEmailEnabled: z.boolean(),
     isBackButtonHidden: z.boolean(),
-    pin: z.string().min(4, { message: "PIN must be a four digit number" }).nullish(),
+    pin: z.string().length(4, { message: "PIN must be a four digit number" }).nullish(),
     resultShareKey: z.string().nullable(),
     displayPercentage: z.number().min(0.01).max(100).nullable(),
     languages: z.array(ZSurveyLanguage),


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

Fixes #6248

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- In the survey editor, try to enter a PIN which is longer than 4 digits, you shouldn't be able to do it
- The server should also return the error about the PIN being a 4 digit number

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a descriptive label above the survey PIN protection option for improved clarity.

* **Improvements**
  * Restricted the survey PIN input to a maximum of four characters.
  * Enhanced validation to require the survey PIN to be exactly four characters long.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->