### PR TITLE
fix: response filters icons and text

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.tsx
@@ -136,10 +136,9 @@ export const SelectedCommandItem = ({ label, questionType, type }: Partial<Quest
     }
   };
 
-  const getLabelStyle = () => {
-    if (type !== OptionsType.META) return;
-    if (label === "os") return "uppercase";
-    return "capitalize";
+  const getLabelStyle = (): string | undefined => {
+    if (type !== OptionsType.META) return undefined;
+    return label === "os" ? "uppercase" : "capitalize";
   };
 
   return (

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.tsx
@@ -15,11 +15,13 @@ import { useTranslate } from "@tolgee/react";
 import clsx from "clsx";
 import {
   AirplayIcon,
+  ArrowUpFromDotIcon,
   CheckIcon,
   ChevronDown,
   ChevronUp,
   ContactIcon,
   EyeOff,
+  FlagIcon,
   GlobeIcon,
   GridIcon,
   HashIcon,
@@ -89,8 +91,9 @@ const questionIcons = {
   device: SmartphoneIcon,
   os: AirplayIcon,
   browser: GlobeIcon,
-  source: GlobeIcon,
+  source: ArrowUpFromDotIcon,
   action: MousePointerClickIcon,
+  country: FlagIcon,
 
   // others
   Language: LanguagesIcon,
@@ -135,7 +138,7 @@ export const SelectedCommandItem = ({ label, questionType, type }: Partial<Quest
   return (
     <div className="flex h-5 w-[12rem] items-center sm:w-4/5">
       <span className={clsx("rounded-md p-1", getColor())}>{getIconType()}</span>
-      <p className="ml-3 truncate text-sm text-slate-600">
+      <p className={clsx("ml-3 truncate text-sm text-slate-600", type === OptionsType.META && "capitalize")}>
         {typeof label === "string" ? label : getLocalizedValue(label, "default")}
       </p>
     </div>

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionsComboBox.tsx
@@ -135,10 +135,17 @@ export const SelectedCommandItem = ({ label, questionType, type }: Partial<Quest
       return "bg-amber-500";
     }
   };
+
+  const getLabelStyle = () => {
+    if (type !== OptionsType.META) return;
+    if (label === "os") return "uppercase";
+    return "capitalize";
+  };
+
   return (
     <div className="flex h-5 w-[12rem] items-center sm:w-4/5">
       <span className={clsx("rounded-md p-1", getColor())}>{getIconType()}</span>
-      <p className={clsx("ml-3 truncate text-sm text-slate-600", type === OptionsType.META && "capitalize")}>
+      <p className={clsx("ml-3 truncate text-sm text-slate-600", getLabelStyle())}>
         {typeof label === "string" ? label : getLocalizedValue(label, "default")}
       </p>
     </div>


### PR DESCRIPTION
## What does this PR do?
response filters icons and text

Fixes #6235

## How should this be tested?
<img width="922" height="384" alt="image" src="https://github.com/user-attachments/assets/e99226c3-c381-498b-a9fc-1eb02aec5e12" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated icons for question types, including a new icon for "country" and a revised icon for "source".
* **Style**
  * Improved label styling by applying conditional text capitalization for meta-type options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->