### PR TITLE
fix: fixes personalized links when single use id is enabled

### DIFF
--- a/apps/web/modules/api/v2/management/surveys/[surveyId]/contact-links/contacts/[contactId]/route.ts
+++ b/apps/web/modules/api/v2/management/surveys/[surveyId]/contact-links/contacts/[contactId]/route.ts
@@ -92,7 +92,7 @@ export const GET = async (request: Request, props: { params: Promise<TContactLin
         });
       }
 
-      const surveyUrlResult = getContactSurveyLink(params.contactId, params.surveyId, 7);
+      const surveyUrlResult = await getContactSurveyLink(params.contactId, params.surveyId, 7);
 
       if (!surveyUrlResult.ok) {
         return handleApiError(request, surveyUrlResult.error);

--- a/apps/web/modules/api/v2/management/surveys/[surveyId]/contact-links/segments/[segmentId]/route.ts
+++ b/apps/web/modules/api/v2/management/surveys/[surveyId]/contact-links/segments/[segmentId]/route.ts
@@ -82,32 +82,34 @@ export const GET = async (
       }
 
       // Generate survey links for each contact
-      const contactLinks = contacts
-        .map((contact) => {
-          const { contactId, attributes } = contact;
+      const contactLinks = await Promise.all(
+        contacts
+          .map(async (contact) => {
+            const { contactId, attributes } = contact;
 
-          const surveyUrlResult = getContactSurveyLink(
-            contactId,
-            params.surveyId,
-            query?.expirationDays || undefined
-          );
-
-          if (!surveyUrlResult.ok) {
-            logger.error(
-              { error: surveyUrlResult.error, contactId: contactId, surveyId: params.surveyId },
-              "Failed to generate survey URL for contact"
+            const surveyUrlResult = await getContactSurveyLink(
+              contactId,
+              params.surveyId,
+              query?.expirationDays || undefined
             );
-            return null;
-          }
 
-          return {
-            contactId,
-            attributes,
-            surveyUrl: surveyUrlResult.data,
-            expiresAt,
-          };
-        })
-        .filter(Boolean);
+            if (!surveyUrlResult.ok) {
+              logger.error(
+                { error: surveyUrlResult.error, contactId: contactId, surveyId: params.surveyId },
+                "Failed to generate survey URL for contact"
+              );
+              return null;
+            }
+
+            return {
+              contactId,
+              attributes,
+              surveyUrl: surveyUrlResult.data,
+              expiresAt,
+            };
+          })
+          .filter(Boolean)
+      );
 
       return responses.successResponse({
         data: contactLinks,

--- a/apps/web/modules/api/v2/management/surveys/[surveyId]/contact-links/segments/[segmentId]/route.ts
+++ b/apps/web/modules/api/v2/management/surveys/[surveyId]/contact-links/segments/[segmentId]/route.ts
@@ -83,36 +83,35 @@ export const GET = async (
 
       // Generate survey links for each contact
       const contactLinks = await Promise.all(
-        contacts
-          .map(async (contact) => {
-            const { contactId, attributes } = contact;
+        contacts.map(async (contact) => {
+          const { contactId, attributes } = contact;
 
-            const surveyUrlResult = await getContactSurveyLink(
-              contactId,
-              params.surveyId,
-              query?.expirationDays || undefined
+          const surveyUrlResult = await getContactSurveyLink(
+            contactId,
+            params.surveyId,
+            query?.expirationDays || undefined
+          );
+
+          if (!surveyUrlResult.ok) {
+            logger.error(
+              { error: surveyUrlResult.error, contactId: contactId, surveyId: params.surveyId },
+              "Failed to generate survey URL for contact"
             );
+            return null;
+          }
 
-            if (!surveyUrlResult.ok) {
-              logger.error(
-                { error: surveyUrlResult.error, contactId: contactId, surveyId: params.surveyId },
-                "Failed to generate survey URL for contact"
-              );
-              return null;
-            }
-
-            return {
-              contactId,
-              attributes,
-              surveyUrl: surveyUrlResult.data,
-              expiresAt,
-            };
-          })
-          .filter(Boolean)
+          return {
+            contactId,
+            attributes,
+            surveyUrl: surveyUrlResult.data,
+            expiresAt,
+          };
+        })
       );
 
+      const filteredContactLinks = contactLinks.filter(Boolean);
       return responses.successResponse({
-        data: contactLinks,
+        data: filteredContactLinks,
         meta,
       });
     },

--- a/apps/web/modules/ee/contacts/lib/contacts.ts
+++ b/apps/web/modules/ee/contacts/lib/contacts.ts
@@ -502,29 +502,28 @@ export const generatePersonalLinks = async (surveyId: string, segmentId: string,
 
   // Generate survey links for each contact
   const contactLinks = await Promise.all(
-    contactsResult
-      .map(async (contact) => {
-        const { contactId, attributes } = contact;
+    contactsResult.map(async (contact) => {
+      const { contactId, attributes } = contact;
 
-        const surveyUrlResult = await getContactSurveyLink(contactId, surveyId, expirationDays);
+      const surveyUrlResult = await getContactSurveyLink(contactId, surveyId, expirationDays);
 
-        if (!surveyUrlResult.ok) {
-          logger.error(
-            { error: surveyUrlResult.error, contactId: contactId, surveyId: surveyId },
-            "Failed to generate survey URL for contact"
-          );
-          return null;
-        }
+      if (!surveyUrlResult.ok) {
+        logger.error(
+          { error: surveyUrlResult.error, contactId: contactId, surveyId: surveyId },
+          "Failed to generate survey URL for contact"
+        );
+        return null;
+      }
 
-        return {
-          contactId,
-          attributes,
-          surveyUrl: surveyUrlResult.data,
-          expirationDays,
-        };
-      })
-      .filter(Boolean)
+      return {
+        contactId,
+        attributes,
+        surveyUrl: surveyUrlResult.data,
+        expirationDays,
+      };
+    })
   );
 
-  return contactLinks;
+  const filteredContactLinks = contactLinks.filter(Boolean);
+  return filteredContactLinks;
 };

--- a/apps/web/modules/ee/contacts/lib/contacts.ts
+++ b/apps/web/modules/ee/contacts/lib/contacts.ts
@@ -501,28 +501,30 @@ export const generatePersonalLinks = async (surveyId: string, segmentId: string,
   }
 
   // Generate survey links for each contact
-  const contactLinks = contactsResult
-    .map((contact) => {
-      const { contactId, attributes } = contact;
+  const contactLinks = Promise.all(
+    contactsResult
+      .map(async (contact) => {
+        const { contactId, attributes } = contact;
 
-      const surveyUrlResult = getContactSurveyLink(contactId, surveyId, expirationDays);
+        const surveyUrlResult = await getContactSurveyLink(contactId, surveyId, expirationDays);
 
-      if (!surveyUrlResult.ok) {
-        logger.error(
-          { error: surveyUrlResult.error, contactId: contactId, surveyId: surveyId },
-          "Failed to generate survey URL for contact"
-        );
-        return null;
-      }
+        if (!surveyUrlResult.ok) {
+          logger.error(
+            { error: surveyUrlResult.error, contactId: contactId, surveyId: surveyId },
+            "Failed to generate survey URL for contact"
+          );
+          return null;
+        }
 
-      return {
-        contactId,
-        attributes,
-        surveyUrl: surveyUrlResult.data,
-        expirationDays,
-      };
-    })
-    .filter(Boolean);
+        return {
+          contactId,
+          attributes,
+          surveyUrl: surveyUrlResult.data,
+          expirationDays,
+        };
+      })
+      .filter(Boolean)
+  );
 
   return contactLinks;
 };

--- a/apps/web/modules/ee/contacts/lib/contacts.ts
+++ b/apps/web/modules/ee/contacts/lib/contacts.ts
@@ -501,7 +501,7 @@ export const generatePersonalLinks = async (surveyId: string, segmentId: string,
   }
 
   // Generate survey links for each contact
-  const contactLinks = Promise.all(
+  const contactLinks = await Promise.all(
     contactsResult
       .map(async (contact) => {
         const { contactId, attributes } = contact;

--- a/apps/web/modules/survey/link/lib/helper.test.ts
+++ b/apps/web/modules/survey/link/lib/helper.test.ts
@@ -1,9 +1,14 @@
+import { validateSurveySingleUseId } from "@/app/lib/singleUseSurveys";
 import { verifyTokenForLinkSurvey } from "@/lib/jwt";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { getEmailVerificationDetails } from "./helper";
+import { checkAndValidateSingleUseId, getEmailVerificationDetails } from "./helper";
 
 vi.mock("@/lib/jwt", () => ({
   verifyTokenForLinkSurvey: vi.fn(),
+}));
+
+vi.mock("@/app/lib/singleUseSurveys", () => ({
+  validateSurveySingleUseId: vi.fn(),
 }));
 
 describe("getEmailVerificationDetails", () => {
@@ -52,5 +57,91 @@ describe("getEmailVerificationDetails", () => {
 
     expect(result).toEqual({ status: "not-verified" });
     expect(mockedVerifyTokenForLinkSurvey).toHaveBeenCalledWith(testToken, testSurveyId);
+  });
+});
+
+describe("checkAndValidateSingleUseId", () => {
+  const mockedValidateSurveySingleUseId = vi.mocked(validateSurveySingleUseId);
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("returns null when no suid is provided", () => {
+    const result = checkAndValidateSingleUseId();
+
+    expect(result).toBeNull();
+    expect(mockedValidateSurveySingleUseId).not.toHaveBeenCalled();
+  });
+
+  test("returns null when suid is empty string", () => {
+    const result = checkAndValidateSingleUseId("");
+
+    expect(result).toBeNull();
+    expect(mockedValidateSurveySingleUseId).not.toHaveBeenCalled();
+  });
+
+  test("returns null when suid is undefined", () => {
+    const result = checkAndValidateSingleUseId(undefined);
+
+    expect(result).toBeNull();
+    expect(mockedValidateSurveySingleUseId).not.toHaveBeenCalled();
+  });
+
+  test("returns suid as-is when isEncrypted is false", () => {
+    const testSuid = "plain-suid-123";
+    const result = checkAndValidateSingleUseId(testSuid, false);
+
+    expect(result).toBe(testSuid);
+    expect(mockedValidateSurveySingleUseId).not.toHaveBeenCalled();
+  });
+
+  test("returns suid as-is when isEncrypted is not provided (defaults to false)", () => {
+    const testSuid = "plain-suid-123";
+    const result = checkAndValidateSingleUseId(testSuid);
+
+    expect(result).toBe(testSuid);
+    expect(mockedValidateSurveySingleUseId).not.toHaveBeenCalled();
+  });
+
+  test("returns validated suid when isEncrypted is true and validation succeeds", () => {
+    const encryptedSuid = "encrypted-suid-123";
+    const validatedSuid = "validated-suid-456";
+    mockedValidateSurveySingleUseId.mockReturnValueOnce(validatedSuid);
+
+    const result = checkAndValidateSingleUseId(encryptedSuid, true);
+
+    expect(result).toBe(validatedSuid);
+    expect(mockedValidateSurveySingleUseId).toHaveBeenCalledWith(encryptedSuid);
+  });
+
+  test("returns null when isEncrypted is true and validation returns undefined", () => {
+    const encryptedSuid = "invalid-encrypted-suid";
+    mockedValidateSurveySingleUseId.mockReturnValueOnce(undefined);
+
+    const result = checkAndValidateSingleUseId(encryptedSuid, true);
+
+    expect(result).toBeNull();
+    expect(mockedValidateSurveySingleUseId).toHaveBeenCalledWith(encryptedSuid);
+  });
+
+  test("returns null when isEncrypted is true and validation returns empty string", () => {
+    const encryptedSuid = "invalid-encrypted-suid";
+    mockedValidateSurveySingleUseId.mockReturnValueOnce("");
+
+    const result = checkAndValidateSingleUseId(encryptedSuid, true);
+
+    expect(result).toBeNull();
+    expect(mockedValidateSurveySingleUseId).toHaveBeenCalledWith(encryptedSuid);
+  });
+
+  test("returns null when isEncrypted is true and validation returns null", () => {
+    const encryptedSuid = "invalid-encrypted-suid";
+    mockedValidateSurveySingleUseId.mockReturnValueOnce(null as any);
+
+    const result = checkAndValidateSingleUseId(encryptedSuid, true);
+
+    expect(result).toBeNull();
+    expect(mockedValidateSurveySingleUseId).toHaveBeenCalledWith(encryptedSuid);
   });
 });

--- a/apps/web/modules/survey/link/lib/helper.test.ts
+++ b/apps/web/modules/survey/link/lib/helper.test.ts
@@ -81,13 +81,6 @@ describe("checkAndValidateSingleUseId", () => {
     expect(mockedValidateSurveySingleUseId).not.toHaveBeenCalled();
   });
 
-  test("returns null when suid is undefined", () => {
-    const result = checkAndValidateSingleUseId(undefined);
-
-    expect(result).toBeNull();
-    expect(mockedValidateSurveySingleUseId).not.toHaveBeenCalled();
-  });
-
   test("returns suid as-is when isEncrypted is false", () => {
     const testSuid = "plain-suid-123";
     const result = checkAndValidateSingleUseId(testSuid, false);

--- a/apps/web/modules/survey/link/lib/helper.ts
+++ b/apps/web/modules/survey/link/lib/helper.ts
@@ -28,7 +28,7 @@ export const getEmailVerificationDetails = async (
 };
 
 export const checkAndValidateSingleUseId = (suid?: string, isEncrypted = false): string | null => {
-  if (!suid) return null;
+  if (!suid?.trim()) return null;
 
   if (isEncrypted) {
     const validatedSingleUseId = validateSurveySingleUseId(suid);

--- a/apps/web/modules/survey/link/lib/helper.ts
+++ b/apps/web/modules/survey/link/lib/helper.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { validateSurveySingleUseId } from "@/app/lib/singleUseSurveys";
 import { verifyTokenForLinkSurvey } from "@/lib/jwt";
 
 interface emailVerificationDetails {
@@ -24,4 +25,16 @@ export const getEmailVerificationDetails = async (
       return { status: "not-verified" };
     }
   }
+};
+
+export const checkAndValidateSingleUseId = (suid?: string, isEncrypted = false): string | null => {
+  if (!suid) return null;
+
+  if (isEncrypted) {
+    const validatedSingleUseId = validateSurveySingleUseId(suid);
+    if (!validatedSingleUseId) return null;
+    return validatedSingleUseId;
+  }
+
+  return suid;
 };

--- a/apps/web/modules/survey/link/page.test.tsx
+++ b/apps/web/modules/survey/link/page.test.tsx
@@ -13,6 +13,16 @@ import { logger } from "@formbricks/logger";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { LinkSurveyPage, generateMetadata } from "./page";
 
+// Mock server-side constants to prevent client-side access
+vi.mock("@/lib/constants", () => ({
+  IS_FORMBRICKS_CLOUD: false,
+  IS_RECAPTCHA_CONFIGURED: false,
+  RECAPTCHA_SITE_KEY: "test-key",
+  IMPRINT_URL: "https://example.com/imprint",
+  PRIVACY_URL: "https://example.com/privacy",
+  ENCRYPTION_KEY: "0".repeat(32),
+}));
+
 // Mock dependencies
 vi.mock("next/navigation", () => ({
   notFound: vi.fn(),

--- a/apps/web/modules/survey/link/page.tsx
+++ b/apps/web/modules/survey/link/page.tsx
@@ -1,7 +1,7 @@
-import { validateSurveySingleUseId } from "@/app/lib/singleUseSurveys";
 import { SurveyInactive } from "@/modules/survey/link/components/survey-inactive";
 import { renderSurvey } from "@/modules/survey/link/components/survey-renderer";
 import { getResponseBySingleUseId, getSurveyWithMetadata } from "@/modules/survey/link/lib/data";
+import { checkAndValidateSingleUseId } from "@/modules/survey/link/lib/helper";
 import { getProjectByEnvironmentId } from "@/modules/survey/link/lib/project";
 import { getMetadataForLinkSurvey } from "@/modules/survey/link/metadata";
 import type { Metadata } from "next";
@@ -60,23 +60,13 @@ export const LinkSurveyPage = async (props: LinkSurveyPageProps) => {
   let singleUseId: string | undefined = undefined;
 
   if (isSingleUseSurvey) {
-    // check if the single use id is present for single use surveys
-    if (!suId) {
+    const validatedSingleUseId = checkAndValidateSingleUseId(suId, isSingleUseSurveyEncrypted);
+    if (!validatedSingleUseId) {
       const project = await getProjectByEnvironmentId(survey.environmentId);
       return <SurveyInactive status="link invalid" project={project ?? undefined} />;
     }
 
-    // if encryption is enabled, validate the single use id
-    let validatedSingleUseId: string | undefined = undefined;
-    if (isSingleUseSurveyEncrypted) {
-      validatedSingleUseId = validateSurveySingleUseId(suId);
-      if (!validatedSingleUseId) {
-        const project = await getProjectByEnvironmentId(survey.environmentId);
-        return <SurveyInactive status="link invalid" project={project ?? undefined} />;
-      }
-    }
-    // if encryption is disabled, use the suId as is
-    singleUseId = validatedSingleUseId ?? suId;
+    singleUseId = validatedSingleUseId;
   }
 
   let singleUseResponse;


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?
Fixes #6164 

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Enable single-use-id in a link survey
- Download a personalized survey link from the personalized link tab in the sharing modal

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for single-use survey links, including encrypted and unencrypted options.
  * Survey links now include a single-use identifier when configured, enhancing link security.

* **Bug Fixes**
  * Improved handling and validation of single-use survey links, displaying appropriate messages for invalid or expired links.

* **Refactor**
  * Survey link generation and validation processes are now asynchronous for improved reliability.
  * Validation logic for single-use survey IDs has been centralized and streamlined.

* **Tests**
  * Expanded test coverage for survey link generation and single-use ID validation scenarios.
  * Added new tests for single-use survey ID validation helper functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->