### PR TITLE
fix: render copy link button based on single use survey 

### DIFF
--- a/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
+++ b/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
@@ -219,16 +219,18 @@ export const SurveyDropDownMenu = ({
                     {t("common.preview_survey")}
                   </button>
                 </DropdownMenuItem>
-                <DropdownMenuItem>
-                  <button
-                    type="button"
-                    data-testid="copy-link"
-                    className="flex w-full items-center"
-                    onClick={async (e) => handleCopyLink(e)}>
-                    <LinkIcon className="mr-2 h-4 w-4" />
-                    {t("common.copy_link")}
-                  </button>
-                </DropdownMenuItem>
+                {!survey.singleUse?.enabled && (
+                  <DropdownMenuItem>
+                    <button
+                      type="button"
+                      data-testid="copy-link"
+                      className="flex w-full items-center"
+                      onClick={async (e) => handleCopyLink(e)}>
+                      <LinkIcon className="mr-2 h-4 w-4" />
+                      {t("common.copy_link")}
+                    </button>
+                  </DropdownMenuItem>
+                )}
               </>
             )}
             {!isSurveyCreationDeletionDisabled && (


### PR DESCRIPTION

<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

Issue: Users could copy links for single-use surveys even when the links were invalid or had already been used, leading to "Survey link invalid" errors when shared
UX Problem: The "Copy Link" button was always visible regardless of whether the survey was configured for single-use, creating confusion for users

Fixes #6279 

Multiple use link

<img width="1882" height="997" alt="image" src="https://github.com/user-attachments/assets/80825159-5504-4af6-83fa-ddde6fc6b294" />

Single Use Link
<img width="1890" height="978" alt="image" src="https://github.com/user-attachments/assets/20e7abf1-d8bb-44bf-aadf-98fc872714b8" />

Copy Link option is not avilable
<img width="1886" height="1001" alt="image" src="https://github.com/user-attachments/assets/0c4a7087-520a-4636-92b7-c0959c47cbbd" />


## How should this be tested?

Test A: Regular Survey Copy Link Button

- Navigate to the surveys list page
- Create or find a survey that is NOT marked as single-use (default behavior)
- Click on the dropdown menu (three dots) for the survey
- Verify that the "Copy Link" option is visible and clickable
- Click "Copy Link" and verify the link is copied to clipboard

Test B: Single-Use Survey Copy Link Button Hidden

- Create a new survey and mark it as "Single-use" in the survey settings
- Navigate back to the surveys list page
- Click on the dropdown menu (three dots) for the single-use survey
- Verify that the "Copy Link" option is NOT visible in the dropdown menu
- Confirm other menu options (Edit, Delete, etc.) are still present

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Copy Link" option in the survey dropdown menu is now only visible for surveys that do not have single-use enabled.

* **Bug Fixes**
  * Improved visibility logic for the "Copy Link" button to prevent it from appearing for single-use surveys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->