### PR TITLE
fix: fixes status schedule updation

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/actions.ts
@@ -150,8 +150,6 @@ export const updateSurveyAction = authenticatedActionClient.schema(ZSurvey).acti
 
       const newSurvey = await updateSurvey(parsedInput);
 
-      revalidatePath(`/environments/${newSurvey.environmentId}/surveys/${newSurvey.id}`);
-
       ctx.auditLoggingCtx.newObject = newSurvey;
 
       return newSurvey;

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/actions.ts
@@ -12,7 +12,6 @@ import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import { checkMultiLanguagePermission } from "@/modules/ee/multi-language-surveys/lib/actions";
 import { getSurveyFollowUpsPermission } from "@/modules/survey/follow-ups/lib/utils";
 import { checkSpamProtectionPermission } from "@/modules/survey/lib/permission";
-import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/actions.ts
@@ -12,6 +12,7 @@ import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import { checkMultiLanguagePermission } from "@/modules/ee/multi-language-surveys/lib/actions";
 import { getSurveyFollowUpsPermission } from "@/modules/survey/follow-ups/lib/utils";
 import { checkSpamProtectionPermission } from "@/modules/survey/lib/permission";
+import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
@@ -148,6 +149,8 @@ export const updateSurveyAction = authenticatedActionClient.schema(ZSurvey).acti
       ctx.auditLoggingCtx.oldObject = oldSurvey;
 
       const newSurvey = await updateSurvey(parsedInput);
+
+      revalidatePath(`/environments/${newSurvey.environmentId}/surveys/${newSurvey.id}`);
 
       ctx.auditLoggingCtx.newObject = newSurvey;
 

--- a/apps/web/modules/survey/editor/actions.ts
+++ b/apps/web/modules/survey/editor/actions.ts
@@ -18,6 +18,7 @@ import { updateSurvey } from "@/modules/survey/editor/lib/survey";
 import { getSurveyFollowUpsPermission } from "@/modules/survey/follow-ups/lib/utils";
 import { checkSpamProtectionPermission } from "@/modules/survey/lib/permission";
 import { getOrganizationBilling, getSurvey } from "@/modules/survey/lib/survey";
+import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { ZActionClassInput } from "@formbricks/types/action-classes";
 import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
@@ -84,6 +85,9 @@ export const updateSurveyAction = authenticatedActionClient.schema(ZSurvey).acti
       const result = await updateSurvey(parsedInput);
       ctx.auditLoggingCtx.oldObject = oldObject;
       ctx.auditLoggingCtx.newObject = result;
+
+      revalidatePath(`/environments/${result.environmentId}/surveys/${result.id}`);
+
       return result;
     }
   )


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

Fixes https://github.com/formbricks/formbricks/issues/6246

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

https://github.com/user-attachments/assets/61598de2-b419-47bb-9887-b38f6048e30a




## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Go to the survey editor and add a start survey on date (or a close survey on date), click save & close
- The summary/responses page being opened should now have the correct survey status in the SurveyStatusDropdown component

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that survey pages display the most up-to-date information immediately after a survey is updated by refreshing the relevant page cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->