### PR TITLE
feat: adds response status select in filters

### DIFF
--- a/.cursor/rules/testing-patterns.mdc
+++ b/.cursor/rules/testing-patterns.mdc
@@ -90,7 +90,7 @@ When testing hooks that use React Context:
 vi.mocked(useResponseFilter).mockReturnValue({
   selectedFilter: {
     filter: [],
-    onlyComplete: false,
+    responseStatus: "all",
   },
   setSelectedFilter: vi.fn(),
   selectedOptions: {

--- a/apps/web/app/(app)/environments/[environmentId]/components/ResponseFilterContext.test.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/components/ResponseFilterContext.test.tsx
@@ -28,7 +28,7 @@ const TestComponent = () => {
 
   return (
     <div>
-      <div data-testid="onlyComplete">{selectedFilter.onlyComplete.toString()}</div>
+      <div data-testid="responseStatus">{selectedFilter.responseStatus}</div>
       <div data-testid="filterLength">{selectedFilter.filter.length}</div>
       <div data-testid="questionOptionsLength">{selectedOptions.questionOptions.length}</div>
       <div data-testid="questionFilterOptionsLength">{selectedOptions.questionFilterOptions.length}</div>
@@ -44,7 +44,7 @@ const TestComponent = () => {
                 filterType: { filterValue: "value1", filterComboBoxValue: "option1" },
               },
             ],
-            onlyComplete: true,
+            responseStatus: "complete",
           })
         }>
         Update Filter
@@ -81,7 +81,7 @@ describe("ResponseFilterContext", () => {
       </ResponseFilterProvider>
     );
 
-    expect(screen.getByTestId("onlyComplete").textContent).toBe("false");
+    expect(screen.getByTestId("responseStatus").textContent).toBe("all");
     expect(screen.getByTestId("filterLength").textContent).toBe("0");
     expect(screen.getByTestId("questionOptionsLength").textContent).toBe("0");
     expect(screen.getByTestId("questionFilterOptionsLength").textContent).toBe("0");
@@ -99,7 +99,7 @@ describe("ResponseFilterContext", () => {
     const updateButton = screen.getByText("Update Filter");
     await userEvent.click(updateButton);
 
-    expect(screen.getByTestId("onlyComplete").textContent).toBe("true");
+    expect(screen.getByTestId("responseStatus").textContent).toBe("complete");
     expect(screen.getByTestId("filterLength").textContent).toBe("1");
   });
 

--- a/apps/web/app/(app)/environments/[environmentId]/components/ResponseFilterContext.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/components/ResponseFilterContext.tsx
@@ -16,9 +16,11 @@ export interface FilterValue {
   };
 }
 
+export type TResponseStatus = "all" | "complete" | "partial";
+
 export interface SelectedFilterValue {
   filter: FilterValue[];
-  onlyComplete: boolean;
+  responseStatus: TResponseStatus;
 }
 
 interface SelectedFilterOptions {
@@ -47,7 +49,7 @@ const ResponseFilterProvider = ({ children }: { children: React.ReactNode }) => 
   // state holds the filter selected value
   const [selectedFilter, setSelectedFilter] = useState<SelectedFilterValue>({
     filter: [],
-    onlyComplete: false,
+    responseStatus: "all",
   });
   // state holds all the options of the responses fetched
   const [selectedOptions, setSelectedOptions] = useState<SelectedFilterOptions>({
@@ -67,7 +69,7 @@ const ResponseFilterProvider = ({ children }: { children: React.ReactNode }) => 
     });
     setSelectedFilter({
       filter: [],
-      onlyComplete: false,
+      responseStatus: "all",
     });
   }, []);
 

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SummaryList.test.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SummaryList.test.tsx
@@ -191,7 +191,7 @@ const mockSurvey = {
   variables: [],
 } as unknown as TSurvey;
 
-const mockSelectedFilter = { filter: [], onlyComplete: false };
+const mockSelectedFilter = { filter: [], responseStatus: "all" };
 const mockSetSelectedFilter = vi.fn();
 
 const defaultProps = {
@@ -309,17 +309,13 @@ describe("SummaryList", () => {
 
   test("renders EmptySpaceFiller when responseCount is 0 and summary is not empty (no responses match filter)", () => {
     const summaryWithItem = [createMockQuestionSummary("q1", TSurveyQuestionTypeEnum.OpenText)];
-    render(
-      <SummaryList {...defaultProps} summary={summaryWithItem} responseCount={0} totalResponseCount={10} />
-    );
+    render(<SummaryList {...defaultProps} summary={summaryWithItem} responseCount={0} />);
     expect(screen.getByText("Mocked EmptySpaceFiller")).toBeInTheDocument();
   });
 
   test("renders EmptySpaceFiller when responseCount is 0 and totalResponseCount is 0 (no responses at all)", () => {
     const summaryWithItem = [createMockQuestionSummary("q1", TSurveyQuestionTypeEnum.OpenText)];
-    render(
-      <SummaryList {...defaultProps} summary={summaryWithItem} responseCount={0} totalResponseCount={0} />
-    );
+    render(<SummaryList {...defaultProps} summary={summaryWithItem} responseCount={0} />);
     expect(screen.getByText("Mocked EmptySpaceFiller")).toBeInTheDocument();
   });
 
@@ -397,7 +393,7 @@ describe("SummaryList", () => {
             },
           },
         ],
-        onlyComplete: false,
+        responseStatus: "all",
       });
       // Ensure vi.mocked(toast.success) refers to the spy from the named export
       expect(vi.mocked(toast).success).toHaveBeenCalledWith("Custom add message", { duration: 5000 });
@@ -425,7 +421,7 @@ describe("SummaryList", () => {
         },
       };
       vi.mocked(useResponseFilter).mockReturnValue({
-        selectedFilter: { filter: [existingFilter], onlyComplete: false },
+        selectedFilter: { filter: [existingFilter], responseStatus: "all" },
         setSelectedFilter: mockSetSelectedFilter,
         resetFilter: vi.fn(),
       } as any);
@@ -454,7 +450,7 @@ describe("SummaryList", () => {
             },
           },
         ],
-        onlyComplete: false,
+        responseStatus: "all",
       });
       expect(vi.mocked(toast.success)).toHaveBeenCalledWith(
         "environments.surveys.summary.filter_updated_successfully",

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SummaryList.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SummaryList.tsx
@@ -92,7 +92,7 @@ export const SummaryList = ({ summary, environment, responseCount, survey, local
 
     setSelectedFilter({
       filter: [...filterObject.filter],
-      onlyComplete: filterObject.onlyComplete,
+      responseStatus: filterObject.responseStatus,
     });
   };
 

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/ResponseFilter.test.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/ResponseFilter.test.tsx
@@ -30,6 +30,36 @@ vi.mock("@formkit/auto-animate/react", () => ({
   useAutoAnimate: () => [[vi.fn()]],
 }));
 
+// Mock the Select components
+const mockOnValueChange = vi.fn();
+vi.mock("@/modules/ui/components/select", () => ({
+  Select: ({ children, onValueChange, defaultValue }) => {
+    // Store the onValueChange callback for testing
+    mockOnValueChange.mockImplementation(onValueChange);
+    return (
+      <div data-testid="select-root" data-default-value={defaultValue}>
+        {children}
+      </div>
+    );
+  },
+  SelectTrigger: ({ children, className }) => (
+    <div role="combobox" className={className} data-testid="select-trigger">
+      {children}
+    </div>
+  ),
+  SelectValue: () => <span>environments.surveys.filter.complete_and_partial_responses</span>,
+  SelectContent: ({ children }) => <div data-testid="select-content">{children}</div>,
+  SelectItem: ({ value, children, ...props }) => (
+    <div
+      data-testid={`select-item-${value}`}
+      data-value={value}
+      onClick={() => mockOnValueChange(value)}
+      {...props}>
+      {children}
+    </div>
+  ),
+}));
+
 vi.mock("./QuestionsComboBox", () => ({
   QuestionsComboBox: ({ onChangeValue }) => (
     <div data-testid="questions-combo-box">
@@ -67,7 +97,7 @@ describe("ResponseFilter", () => {
 
   const mockSelectedFilter = {
     filter: [],
-    onlyComplete: false,
+    responseStatus: "all",
   };
 
   const mockSelectedOptions = {
@@ -145,7 +175,7 @@ describe("ResponseFilter", () => {
     expect(
       screen.getByText("environments.surveys.summary.show_all_responses_that_match")
     ).toBeInTheDocument();
-    expect(screen.getByText("environments.surveys.summary.only_completed")).toBeInTheDocument();
+    expect(screen.getByTestId("select-trigger")).toBeInTheDocument();
   });
 
   test("fetches filter data when opened", async () => {
@@ -160,7 +190,7 @@ describe("ResponseFilter", () => {
   test("handles adding new filter", async () => {
     // Start with an empty filter
     vi.mocked(useResponseFilter).mockReturnValue({
-      selectedFilter: { filter: [], onlyComplete: false },
+      selectedFilter: { filter: [], responseStatus: "all" },
       setSelectedFilter: mockSetSelectedFilter,
       selectedOptions: mockSelectedOptions,
       setSelectedOptions: mockSetSelectedOptions,
@@ -178,14 +208,38 @@ describe("ResponseFilter", () => {
     expect(screen.getByTestId("questions-combo-box")).toBeInTheDocument();
   });
 
-  test("handles only complete checkbox toggle", async () => {
+  test("handles response status filter change to complete", async () => {
     render(<ResponseFilter survey={mockSurvey} />);
 
     await userEvent.click(screen.getByText("Filter"));
-    await userEvent.click(screen.getByRole("checkbox"));
+
+    // Simulate selecting "complete" by calling the mock function
+    mockOnValueChange("complete");
+
     await userEvent.click(screen.getByText("common.apply_filters"));
 
-    expect(mockSetSelectedFilter).toHaveBeenCalledWith({ filter: [], onlyComplete: true });
+    expect(mockSetSelectedFilter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseStatus: "complete",
+      })
+    );
+  });
+
+  test("handles response status filter change to partial", async () => {
+    render(<ResponseFilter survey={mockSurvey} />);
+
+    await userEvent.click(screen.getByText("Filter"));
+
+    // Simulate selecting "partial" by calling the mock function
+    mockOnValueChange("partial");
+
+    await userEvent.click(screen.getByText("common.apply_filters"));
+
+    expect(mockSetSelectedFilter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        responseStatus: "partial",
+      })
+    );
   });
 
   test("handles selecting question and filter options", async () => {
@@ -199,7 +253,7 @@ describe("ResponseFilter", () => {
             filterType: { filterComboBoxValue: undefined, filterValue: undefined },
           },
         ],
-        onlyComplete: false,
+        responseStatus: "all",
       },
       setSelectedFilter: setSelectedFilterMock,
       selectedOptions: mockSelectedOptions,
@@ -228,6 +282,6 @@ describe("ResponseFilter", () => {
     await userEvent.click(screen.getByText("Filter"));
     await userEvent.click(screen.getByText("common.clear_all"));
 
-    expect(mockSetSelectedFilter).toHaveBeenCalledWith({ filter: [], onlyComplete: false });
+    expect(mockSetSelectedFilter).toHaveBeenCalledWith({ filter: [], responseStatus: "all" });
   });
 });

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/ResponseFilter.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/ResponseFilter.tsx
@@ -2,17 +2,23 @@
 
 import {
   SelectedFilterValue,
+  TResponseStatus,
   useResponseFilter,
 } from "@/app/(app)/environments/[environmentId]/components/ResponseFilterContext";
 import { getSurveyFilterDataAction } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/actions";
 import { QuestionFilterComboBox } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/QuestionFilterComboBox";
 import { generateQuestionAndFilterOptions } from "@/app/lib/surveys/surveys";
 import { Button } from "@/modules/ui/components/button";
-import { Checkbox } from "@/modules/ui/components/checkbox";
 import { Popover, PopoverContent, PopoverTrigger } from "@/modules/ui/components/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/modules/ui/components/select";
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { useTranslate } from "@tolgee/react";
-import clsx from "clsx";
 import { ChevronDown, ChevronUp, Plus, TrashIcon } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import { TSurvey, TSurveyQuestionTypeEnum } from "@formbricks/types/surveys/types";
@@ -72,7 +78,7 @@ export const ResponseFilter = ({ survey }: ResponseFilterProps) => {
           )?.filterOptions[0],
         },
       };
-      setFilterValue({ filter: [...filterValue.filter], onlyComplete: filterValue.onlyComplete });
+      setFilterValue({ filter: [...filterValue.filter], responseStatus: filterValue.responseStatus });
     } else {
       // Update the existing value at the specified index
       filterValue.filter[index].questionType = value;
@@ -93,7 +99,7 @@ export const ResponseFilter = ({ survey }: ResponseFilterProps) => {
         // keep the filter if questionType is selected and filterComboBoxValue is selected
         return s.questionType.hasOwnProperty("label") && s.filterType.filterComboBoxValue?.length;
       }),
-      onlyComplete: filterValue.onlyComplete,
+      responseStatus: filterValue.responseStatus,
     });
   };
 
@@ -120,8 +126,8 @@ export const ResponseFilter = ({ survey }: ResponseFilterProps) => {
   };
 
   const handleClearAllFilters = () => {
-    setFilterValue((filterValue) => ({ ...filterValue, filter: [] }));
-    setSelectedFilter((selectedFilters) => ({ ...selectedFilters, filter: [] }));
+    setFilterValue((filterValue) => ({ ...filterValue, filter: [], responseStatus: "all" }));
+    setSelectedFilter((selectedFilters) => ({ ...selectedFilters, filter: [], responseStatus: "all" }));
     setIsOpen(false);
   };
 
@@ -158,8 +164,8 @@ export const ResponseFilter = ({ survey }: ResponseFilterProps) => {
     setFilterValue({ ...filterValue });
   };
 
-  const handleCheckOnlyComplete = (checked: boolean) => {
-    setFilterValue({ ...filterValue, onlyComplete: checked });
+  const handleResponseStatusChange = (responseStatus: TResponseStatus) => {
+    setFilterValue({ ...filterValue, responseStatus });
   };
 
   // remove the filter which has already been selected
@@ -212,16 +218,25 @@ export const ResponseFilter = ({ survey }: ResponseFilterProps) => {
             {t("environments.surveys.summary.show_all_responses_where")}
           </p>
           <div className="flex items-center space-x-2">
-            <label className="text-sm font-normal text-slate-600">
-              {t("environments.surveys.summary.only_completed")}
-            </label>
-            <Checkbox
-              className={clsx("rounded-md", filterValue.onlyComplete && "bg-black text-white")}
-              checked={filterValue.onlyComplete}
-              onCheckedChange={(checked) => {
-                typeof checked === "boolean" && handleCheckOnlyComplete(checked);
+            <Select
+              required
+              onValueChange={(val) => {
+                handleResponseStatusChange(val as TResponseStatus);
               }}
-            />
+              defaultValue={filterValue.responseStatus}>
+              <SelectTrigger className="w-full bg-white">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent position="popper">
+                <SelectItem value="all">
+                  {t("environments.surveys.filter.complete_and_partial_responses")}
+                </SelectItem>
+                <SelectItem value="complete">
+                  {t("environments.surveys.filter.complete_responses")}
+                </SelectItem>
+                <SelectItem value="partial">{t("environments.surveys.filter.partial_responses")}</SelectItem>
+              </SelectContent>
+            </Select>
           </div>
         </div>
 

--- a/apps/web/app/lib/surveys/surveys.test.ts
+++ b/apps/web/app/lib/surveys/surveys.test.ts
@@ -320,7 +320,7 @@ describe("surveys", () => {
 
     test("should return empty filters when no selections", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [],
       };
 
@@ -331,7 +331,7 @@ describe("surveys", () => {
 
     test("should filter by completed responses", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: true,
+        responseStatus: "complete",
         filter: [],
       };
 
@@ -342,7 +342,7 @@ describe("surveys", () => {
 
     test("should filter by date range", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [],
       };
 
@@ -355,7 +355,7 @@ describe("surveys", () => {
 
     test("should filter by tags", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: { type: "Tags", label: "Tag 1", id: "tag1" },
@@ -376,7 +376,7 @@ describe("surveys", () => {
 
     test("should filter by open text questions", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: {
@@ -397,7 +397,7 @@ describe("surveys", () => {
 
     test("should filter by address questions", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: {
@@ -418,7 +418,7 @@ describe("surveys", () => {
 
     test("should filter by contact info questions", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: {
@@ -439,7 +439,7 @@ describe("surveys", () => {
 
     test("should filter by ranking questions", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: {
@@ -460,7 +460,7 @@ describe("surveys", () => {
 
     test("should filter by multiple choice single questions", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: {
@@ -481,7 +481,7 @@ describe("surveys", () => {
 
     test("should filter by multiple choice multi questions", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: {
@@ -502,7 +502,7 @@ describe("surveys", () => {
 
     test("should filter by NPS questions with different operations", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: {
@@ -523,7 +523,7 @@ describe("surveys", () => {
 
     test("should filter by rating questions with less than operation", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: {
@@ -544,7 +544,7 @@ describe("surveys", () => {
 
     test("should filter by CTA questions", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: {
@@ -565,7 +565,7 @@ describe("surveys", () => {
 
     test("should filter by consent questions", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: {
@@ -586,7 +586,7 @@ describe("surveys", () => {
 
     test("should filter by picture selection questions", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: {
@@ -607,7 +607,7 @@ describe("surveys", () => {
 
     test("should filter by matrix questions", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: {
@@ -628,7 +628,7 @@ describe("surveys", () => {
 
     test("should filter by hidden fields", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: { type: "Hidden Fields", label: "plan", id: "plan" },
@@ -644,7 +644,7 @@ describe("surveys", () => {
 
     test("should filter by attributes", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: { type: "Attributes", label: "role", id: "role" },
@@ -660,7 +660,7 @@ describe("surveys", () => {
 
     test("should filter by other filters", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: { type: "Other Filters", label: "Language", id: "language" },
@@ -676,7 +676,7 @@ describe("surveys", () => {
 
     test("should filter by meta fields", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: false,
+        responseStatus: "all",
         filter: [
           {
             questionType: { type: "Meta", label: "source", id: "source" },
@@ -692,7 +692,7 @@ describe("surveys", () => {
 
     test("should handle multiple filters together", () => {
       const selectedFilter: SelectedFilterValue = {
-        onlyComplete: true,
+        responseStatus: "complete",
         filter: [
           {
             questionType: {

--- a/apps/web/app/lib/surveys/surveys.ts
+++ b/apps/web/app/lib/surveys/surveys.ts
@@ -242,8 +242,10 @@ export const getFormattedFilters = (
   });
 
   // for completed responses
-  if (selectedFilter.onlyComplete) {
+  if (selectedFilter.responseStatus === "complete") {
     filters["finished"] = true;
+  } else if (selectedFilter.responseStatus === "partial") {
+    filters["finished"] = false;
   }
 
   // for date range responses


### PR DESCRIPTION
## What does this PR do?
Adds response status select in filters

Fixes https://github.com/formbricks/internal/issues/817

## How should this be tested?

- Change the status filter using the select dropdown, and the response should update when the filters are applied.

