### PR TITLE
fix: return weekly-summary cron early when SMTP not configured

### DIFF
--- a/apps/web/app/api/cron/weekly-summary/route.ts
+++ b/apps/web/app/api/cron/weekly-summary/route.ts
@@ -1,8 +1,9 @@
 import { responses } from "@/app/lib/api/response";
-import { CRON_SECRET } from "@/lib/constants";
+import { CRON_SECRET, SMTP_HOST } from "@/lib/constants";
 import { hasUserEnvironmentAccess } from "@/lib/environment/auth";
 import { sendNoLiveSurveyNotificationEmail, sendWeeklySummaryNotificationEmail } from "@/modules/email";
 import { headers } from "next/headers";
+import { logger } from "@formbricks/logger";
 import { getNotificationResponse } from "./lib/notificationResponse";
 import { getOrganizationIds } from "./lib/organization";
 import { getProjectsByOrganizationId } from "./lib/project";
@@ -14,6 +15,11 @@ export const POST = async (): Promise<Response> => {
   // Check authentication
   if (headersList.get("x-api-key") !== CRON_SECRET) {
     return responses.notAuthenticatedResponse();
+  }
+
+  if (!SMTP_HOST) {
+    logger.info("SMTP_HOST is not configured, skipping weekly summary email");
+    return responses.successResponse({}, true);
   }
 
   const emailSendingPromises: Promise<void>[] = [];


### PR DESCRIPTION
This PR introduces a hotfix for the `v3.16` release in response to a customer-reported issue. The customer observed that, once a week—coinciding with the scheduled run of the weekly summary cron job—the pods experience a sudden spike in CPU usage, ultimately resulting in shutdowns.

We suspect that this behavior is caused by the `weekly summary cron endpoint` being triggered unexpectedly, potentially even multiple times. This endpoint has already been deprecated and removed from the `main` branch due to recurring issues.

However, to provide a timely resolution for the affected customer (who does not have SMTP configured), we are issuing a dedicated bugfix release for the `v3.16` branch.
