### PR TITLE
fix: update wording to match actual behaviour

### DIFF
--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1316,7 +1316,7 @@
         "columns": "Spalten",
         "company": "Firma",
         "company_logo": "Firmenlogo",
-        "completed_responses": "abgeschlossene Antworten",
+        "completed_responses": "unvollständige oder vollständige Antworten.",
         "concat": "Verketten +",
         "conditional_logic": "Bedingte Logik",
         "confirm_default_language": "Standardsprache bestätigen",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1316,7 +1316,7 @@
         "columns": "Columns",
         "company": "Company",
         "company_logo": "Company logo",
-        "completed_responses": "completed responses.",
+        "completed_responses": "partial or completed responses.",
         "concat": "Concat +",
         "conditional_logic": "Conditional Logic",
         "confirm_default_language": "Confirm default language",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1316,7 +1316,7 @@
         "columns": "Colonnes",
         "company": "Société",
         "company_logo": "Logo de l'entreprise",
-        "completed_responses": "réponses complètes.",
+        "completed_responses": "des réponses partielles ou complètes.",
         "concat": "Concat +",
         "conditional_logic": "Logique conditionnelle",
         "confirm_default_language": "Confirmer la langue par défaut",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1316,7 +1316,7 @@
         "columns": "colunas",
         "company": "empresa",
         "company_logo": "Logo da empresa",
-        "completed_responses": "respostas completas",
+        "completed_responses": "respostas parciais ou completas.",
         "concat": "Concatenar +",
         "conditional_logic": "Lógica Condicional",
         "confirm_default_language": "Confirmar idioma padrão",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1316,7 +1316,7 @@
         "columns": "Colunas",
         "company": "Empresa",
         "company_logo": "Logotipo da empresa",
-        "completed_responses": "respostas concluídas",
+        "completed_responses": "respostas parciais ou completas",
         "concat": "Concatenar +",
         "conditional_logic": "Lógica Condicional",
         "confirm_default_language": "Confirmar idioma padrão",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1316,7 +1316,7 @@
         "columns": "欄位",
         "company": "公司",
         "company_logo": "公司標誌",
-        "completed_responses": "完成的回應。",
+        "completed_responses": "部分或完整答复。",
         "concat": "串連 +",
         "conditional_logic": "條件邏輯",
         "confirm_default_language": "確認預設語言",


### PR DESCRIPTION
<img width="604" height="126" alt="image" src="https://github.com/user-attachments/assets/721230ce-ceaf-413e-91a3-5045c00d04c2" />

This doesn't correctly describe the behaviour, it actually checks partials and completed ones.