### PR TITLE
chore: remove semantic PR thank you comment to reduce PR spam

### DIFF
--- a/.github/workflows/semantic-pull-requests.yml
+++ b/.github/workflows/semantic-pull-requests.yml
@@ -56,11 +56,3 @@ jobs:
             ```
             ${{ steps.lint_pr_title.outputs.error_message }}
             ```
-
-      # Delete a previous comment when the issue has been resolved
-      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
-        uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db # v2.9.2
-        with:
-          header: pr-title-lint-error
-          message: |
-            Thank you for following the naming conventions for pull request titles! 🙏


### PR DESCRIPTION
This PR removes the `thank you` message posted in every PR that correctly follows the semantic PR guidelines.

This comment is unnecessary and triggers a new GIthub notification for the PR creator which can be avoided by only posting if the user needs to take action. 