### PR TITLE
fix: release workflow environment is not accessible

### DIFF
--- a/.github/workflows/formbricks-release.yml
+++ b/.github/workflows/formbricks-release.yml
@@ -7,9 +7,6 @@ on:
 permissions:
   contents: read
 
-env:
-  ENVIRONMENT: ${{ github.event.release.prerelease && 'staging' || 'production' }}
-
 jobs:
   docker-build:
     name: Build & release docker image
@@ -36,7 +33,7 @@ jobs:
       - helm-chart-release
     with:
       VERSION: v${{ needs.docker-build.outputs.VERSION }}
-      ENVIRONMENT: ${{ env.ENVIRONMENT }}
+      ENVIRONMENT: ${{ github.event.release.prerelease && 'staging' || 'production' }}
 
   upload-sentry-sourcemaps:
     name: Upload Sentry Sourcemaps
@@ -64,4 +61,4 @@ jobs:
           docker_image: ghcr.io/formbricks/formbricks:v${{ needs.docker-build.outputs.VERSION }}
           release_version: v${{ needs.docker-build.outputs.VERSION }}
           sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          environment: ${{ env.ENVIRONMENT }}
+          environment: ${{ github.event.release.prerelease && 'staging' || 'production' }}


### PR DESCRIPTION
### Summary
GitHub Actions failed to parse the release workflow due to referencing `env.ENVIRONMENT` inside a reusable workflow `with:` block. This PR removes the global `env.ENVIRONMENT` and computes the environment inline where needed.

### Root cause
- Error: “Unrecognized named-value: 'env'” at the reusable workflow call.
- Reason: The `env` context is not available inside `with:` for reusable workflows; only specific contexts like `github`, `inputs`, `needs`, and `vars` are allowed there.

### What changed
- Removed workflow-level `env.ENVIRONMENT`.
- Updated `deploy-formbricks-cloud` to pass:
  - `ENVIRONMENT: ${{ github.event.release.prerelease && 'staging' || 'production' }}`
- Updated `upload-sentry-sourcemaps` to set:
  - `environment: ${{ github.event.release.prerelease && 'staging' || 'production' }}`

### Why this approach
- Avoids invalid `env` usage in `with:` while preserving the same behavior.
- Keeps the logic deterministic and self-contained; no reliance on global env state.
- Reduces risk of scope bleed and ambiguity.
- Works uniformly for both reusable workflow calls and action steps.

### Security considerations
- No secrets involved in the environment expression.
- Maintains minimal GITHUB_TOKEN permissions (`contents: read`).
- Scope is tighter by not exporting a global `env` variable.

### Testing
- Validated with `actionlint`: no findings (exit code 0).
- Verified both affected blocks resolve the environment correctly for prereleases vs. production releases.

### Alternatives considered
- Keep a global `env.ENVIRONMENT`: breaks in `with:` context.
- Job-level env: would still require duplication for contexts where `env` isn’t available.
- A “determine-environment” job with outputs: more indirection for a small piece of logic.
- GitHub Environments: worth exploring for approvals/protections, but out of scope for this fix.