### PR TITLE
fix: permissions in release workflow

### DIFF
--- a/.github/workflows/deploy-formbricks-cloud.yml
+++ b/.github/workflows/deploy-formbricks-cloud.yml
@@ -37,7 +37,7 @@ on:
 
 permissions:
   id-token: write
-  contents: write
+  contents: read
 
 jobs:
   helmfile-deploy:

--- a/.github/workflows/formbricks-release.yml
+++ b/.github/workflows/formbricks-release.yml
@@ -10,6 +10,10 @@ permissions:
 jobs:
   docker-build:
     name: Build & release docker image
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     uses: ./.github/workflows/release-docker-github.yml
     secrets: inherit
     with:
@@ -17,6 +21,9 @@ jobs:
 
   helm-chart-release:
     name: Release Helm Chart
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/release-helm-chart.yml
     secrets: inherit
     needs:
@@ -26,6 +33,9 @@ jobs:
 
   deploy-formbricks-cloud:
     name: Deploy Helm Chart to Formbricks Cloud
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
     uses: ./.github/workflows/deploy-formbricks-cloud.yml
     needs:


### PR DESCRIPTION
### Why these changes were needed
- Permission denial from reusable workflows: The called workflows requested `packages: write` and `id-token: write` at job level, but the calling jobs only had the default `contents: read`. GitHub rejected the run with a permissions mismatch error.

### What changed
- Minimal job-level permissions
  - `docker-build` (calls `release-docker-github.yml`):
    - `permissions: contents: read, packages: write, id-token: write`
  - `helm-chart-release` (calls `release-helm-chart.yml`):
    - `permissions: contents: read, packages: write`
  - `deploy-formbricks-cloud` (assumes AWS role using OIDC):
    - `permissions: contents: read, id-token: write`

### Why this approach
- Granting only the minimal permissions at the calling job level satisfies the reusable workflows’ requirements and adheres to least-privilege best practices.