### PR TITLE
docs: adds identifier note in saml sso docs

### DIFF
--- a/docs/development/guides/auth-and-provision/setup-saml-with-identity-providers.mdx
+++ b/docs/development/guides/auth-and-provision/setup-saml-with-identity-providers.mdx
@@ -13,7 +13,7 @@ This guide explains the settings you need to use to configure SAML with your Ide
 
 **Entity ID / Identifier / Audience URI / Audience Restriction:** [https://saml.formbricks.com](https://saml.formbricks.com)
 
-> **Note:** [https://saml.formbricks.com](https://saml.formbricks.com) is a hardcoded value in Formbricks and must match exactly as shown. It serves as the unique identifier for the Formbricks service in SAML assertions.
+> **Note:** [https://saml.formbricks.com](https://saml.formbricks.com) is hardcoded in Formbricks — do not replace it with your instance URL. It is the fixed SP Entity ID and must match exactly as shown in SAML assertions.
 
 **Response:** Signed
 

--- a/docs/development/guides/auth-and-provision/setup-saml-with-identity-providers.mdx
+++ b/docs/development/guides/auth-and-provision/setup-saml-with-identity-providers.mdx
@@ -79,7 +79,7 @@ This guide explains the settings you need to use to configure SAML with your Ide
   </Step>
   <Step title="Enter the SAML Integration Settings as shown and click Next">
     - **Single Sign-On URL**: `https://<your-formbricks-instance>/api/auth/saml/callback` or `http://localhost:3000/api/auth/saml/callback` (if you are running Formbricks locally)
-    - **Audience URI (SP Entity ID)**: `https://saml.formbricks.com` (hardcoded identifier)
+    - **Audience URI (SP Entity ID)**: `https://saml.formbricks.com` (hardcoded; do not replace with your instance URL)
     <img src="/images/development/guides/auth-and-provision/okta/saml-integration-settings.webp" />
   </Step>
   <Step title="Fill the fields mapping as shown and click Next">

--- a/docs/development/guides/auth-and-provision/setup-saml-with-identity-providers.mdx
+++ b/docs/development/guides/auth-and-provision/setup-saml-with-identity-providers.mdx
@@ -13,6 +13,8 @@ This guide explains the settings you need to use to configure SAML with your Ide
 
 **Entity ID / Identifier / Audience URI / Audience Restriction:** [https://saml.formbricks.com](https://saml.formbricks.com)
 
+> **Note:** [https://saml.formbricks.com](https://saml.formbricks.com) is a hardcoded value in Formbricks and must match exactly as shown. It serves as the unique identifier for the Formbricks service in SAML assertions.
+
 **Response:** Signed
 
 **Assertion Signature:** Signed
@@ -77,7 +79,7 @@ This guide explains the settings you need to use to configure SAML with your Ide
   </Step>
   <Step title="Enter the SAML Integration Settings as shown and click Next">
     - **Single Sign-On URL**: `https://<your-formbricks-instance>/api/auth/saml/callback` or `http://localhost:3000/api/auth/saml/callback` (if you are running Formbricks locally)
-    - **Audience URI (SP Entity ID)**: `https://saml.formbricks.com`
+    - **Audience URI (SP Entity ID)**: `https://saml.formbricks.com` (hardcoded identifier)
     <img src="/images/development/guides/auth-and-provision/okta/saml-integration-settings.webp" />
   </Step>
   <Step title="Fill the fields mapping as shown and click Next">


### PR DESCRIPTION
## What does this PR do?
adds identifier note in SAML SSO docs
1. 
<img width="1714" height="592" alt="image" src="https://github.com/user-attachments/assets/1a6c2931-0f6f-4fe9-b751-d745e64cb283" />
2.
<img width="1612" height="1300" alt="image" src="https://github.com/user-attachments/assets/51b7e142-d019-4363-896a-70def64dfa6d" />


Fixes #(issue)


## How should this be tested?

- Check the [docs](https://formbricks.com/docs/development/guides/auth-and-provision/setup-saml-with-identity-providers#saml-with-okta), it should clarify the usage of entity id identifier.

