### PR TITLE
fix: disables tabs when single use is enabled [Backport]

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/share-survey-modal.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/share-survey-modal.tsx
@@ -29,7 +29,7 @@ import {
   SquareStack,
   UserIcon,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { TSegment } from "@formbricks/types/segment";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { TUser } from "@formbricks/types/user";
@@ -77,6 +77,7 @@ export const ShareSurveyModal = ({
     description: string;
     componentType: React.ComponentType<unknown>;
     componentProps: unknown;
+    disabled?: boolean;
   }[] = useMemo(
     () => [
       {
@@ -111,6 +112,7 @@ export const ShareSurveyModal = ({
           isContactsEnabled,
           isFormbricksCloud,
         },
+        disabled: survey.singleUse?.enabled,
       },
       {
         id: ShareViaType.WEBSITE_EMBED,
@@ -121,6 +123,7 @@ export const ShareSurveyModal = ({
         description: t("environments.surveys.share.embed_on_website.description"),
         componentType: WebsiteEmbedTab,
         componentProps: { surveyUrl },
+        disabled: survey.singleUse?.enabled,
       },
       {
         id: ShareViaType.EMAIL,
@@ -131,6 +134,7 @@ export const ShareSurveyModal = ({
         description: t("environments.surveys.share.send_email.description"),
         componentType: EmailTab,
         componentProps: { surveyId: survey.id, email },
+        disabled: survey.singleUse?.enabled,
       },
       {
         id: ShareViaType.SOCIAL_MEDIA,
@@ -141,6 +145,7 @@ export const ShareSurveyModal = ({
         description: t("environments.surveys.share.social_media.description"),
         componentType: SocialMediaTab,
         componentProps: { surveyUrl, surveyTitle: survey.name },
+        disabled: survey.singleUse?.enabled,
       },
       {
         id: ShareViaType.QR_CODE,
@@ -151,6 +156,7 @@ export const ShareSurveyModal = ({
         description: t("environments.surveys.summary.qr_code_description"),
         componentType: QRCodeTab,
         componentProps: { surveyUrl },
+        disabled: survey.singleUse?.enabled,
       },
       {
         id: ShareViaType.DYNAMIC_POPUP,
@@ -177,9 +183,9 @@ export const ShareSurveyModal = ({
       t,
       survey,
       publicDomain,
-      setSurveyUrl,
       user.locale,
       surveyUrl,
+      isReadOnly,
       environmentId,
       segments,
       isContactsEnabled,
@@ -188,9 +194,14 @@ export const ShareSurveyModal = ({
     ]
   );
 
-  const [activeId, setActiveId] = useState<ShareViaType | ShareSettingsType>(
-    survey.type === "link" ? ShareViaType.ANON_LINKS : ShareViaType.APP
-  );
+  const getDefaultActiveId = useCallback(() => {
+    if (survey.type !== "link") {
+      return ShareViaType.APP;
+    }
+    return ShareViaType.ANON_LINKS;
+  }, [survey.type]);
+
+  const [activeId, setActiveId] = useState<ShareViaType | ShareSettingsType>(getDefaultActiveId());
 
   useEffect(() => {
     if (open) {
@@ -198,11 +209,19 @@ export const ShareSurveyModal = ({
     }
   }, [open, modalView]);
 
+  // Ensure active tab is not disabled - if it is, switch to default
+  useEffect(() => {
+    const activeTab = linkTabs.find((tab) => tab.id === activeId);
+    if (activeTab?.disabled) {
+      setActiveId(getDefaultActiveId());
+    }
+  }, [activeId, linkTabs, getDefaultActiveId]);
+
   const handleOpenChange = (open: boolean) => {
     setOpen(open);
     if (!open) {
       setShowView("start");
-      setActiveId(ShareViaType.ANON_LINKS);
+      setActiveId(getDefaultActiveId());
     }
   };
 

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/share-view.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/share-view.tsx
@@ -34,6 +34,7 @@ interface ShareViewProps {
     componentProps: any;
     title: string;
     description?: string;
+    disabled?: boolean;
   }>;
   activeId: ShareViaType | ShareSettingsType;
   setActiveId: React.Dispatch<React.SetStateAction<ShareViaType | ShareSettingsType>>;
@@ -109,12 +110,13 @@ export const ShareView = ({ tabs, activeId, setActiveId }: ShareViewProps) => {
                             onClick={() => setActiveId(tab.id)}
                             className={cn(
                               "flex w-full justify-start rounded-md p-2 text-slate-600 hover:bg-slate-100 hover:text-slate-900",
-                              tab.id === activeId
+                              tab.id === activeId && !tab.disabled
                                 ? "bg-slate-100 font-medium text-slate-900"
                                 : "text-slate-700"
                             )}
                             tooltip={tab.label}
-                            isActive={tab.id === activeId}>
+                            isActive={tab.id === activeId}
+                            disabled={tab.disabled}>
                             <tab.icon className="h-4 w-4 text-slate-700" />
                             <span>{tab.label}</span>
                           </SidebarMenuButton>
@@ -136,9 +138,10 @@ export const ShareView = ({ tabs, activeId, setActiveId }: ShareViewProps) => {
                 <Button
                   variant="ghost"
                   onClick={() => setActiveId(tab.id)}
+                  disabled={tab.disabled}
                   className={cn(
                     "rounded-md px-4 py-2",
-                    tab.id === activeId
+                    tab.id === activeId && !tab.disabled
                       ? "bg-white text-slate-900 shadow-sm hover:bg-white"
                       : "border-transparent text-slate-700 hover:text-slate-900"
                   )}>


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?
Backport for the merged PR: https://github.com/formbricks/formbricks/pull/6410

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Open the share modal for a link survey and turn on single use links
- The website, email embeds and social media and QR code tabs should get disabled

with single use disabled:
<img width="978" height="711" alt="Screenshot 2025-08-13 at 9 18 24 PM" src="https://github.com/user-attachments/assets/42b511fa-dcba-4308-a9e5-9bad1907425b" />

with single use enabled:
<img width="967" height="705" alt="Screenshot 2025-08-13 at 9 19 06 PM" src="https://github.com/user-attachments/assets/d812e216-1ada-4c4e-8816-d949265a35f6" />

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
