### PR TITLE
fix: color picker in product logo

### DIFF
--- a/apps/web/modules/projects/settings/look/components/edit-logo.tsx
+++ b/apps/web/modules/projects/settings/look/components/edit-logo.tsx
@@ -179,7 +179,7 @@ export const EditLogo = ({ project, environmentId, isReadOnly }: EditLogoProps) 
               description={t("environments.project.look.add_background_color_description")}
               childBorder
               customContainerClass="p-0"
-              childrenClassName="overflow-visible"
+              childrenContainerClass="overflow-visible"
               disabled={!isEditing}>
               {isBgColorEnabled && (
                 <div className="px-2">

--- a/apps/web/modules/ui/components/advanced-option-toggle/index.tsx
+++ b/apps/web/modules/ui/components/advanced-option-toggle/index.tsx
@@ -12,7 +12,7 @@ interface AdvancedOptionToggleProps {
   childBorder?: boolean;
   customContainerClass?: string;
   disabled?: boolean;
-  childrenClassName?: string;
+  childrenContainerClass?: string;
 }
 
 export const AdvancedOptionToggle = ({
@@ -25,7 +25,7 @@ export const AdvancedOptionToggle = ({
   childBorder,
   customContainerClass,
   disabled = false,
-  childrenClassName,
+  childrenContainerClass,
 }: AdvancedOptionToggleProps) => {
   return (
     <div className={cn("px-4 py-2", customContainerClass)}>
@@ -43,7 +43,7 @@ export const AdvancedOptionToggle = ({
           className={cn(
             "mt-4 flex w-full items-center space-x-1 overflow-hidden rounded-lg bg-slate-50",
             childBorder && "border",
-            childrenClassName
+            childrenContainerClass
           )}>
           {children}
         </div>


### PR DESCRIPTION
## What does this PR do?
fixes color picker in product logo

Fixes https://github.com/formbricks/formbricks/issues/6245
<img width="1882" height="1136" alt="image" src="https://github.com/user-attachments/assets/b0945c23-e285-4c72-ac26-6f2bf714b43a" />


## How should this be tested?

- Color picker should open in product logo settings
