### PR TITLE
chore: upgrade node-alpine image to 3.22

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine3.21 AS base
+FROM node:22-alpine3.22 AS base
 
 #
 ## step 1: Prune monorepo


### PR DESCRIPTION
This pull request updates the Node.js Alpine base image version used in the `apps/web/Dockerfile` to ensure the application is built on the latest stable and secure environment.

Dependency update:

* Updated the base image from `node:22-alpine3.21` to `node:22-alpine3.22` in `apps/web/Dockerfile` to use the latest Alpine patch release.