### PR TITLE
fix: open text number question logic evaluation

### DIFF
--- a/apps/web/lib/surveyLogic/utils.ts
+++ b/apps/web/lib/surveyLogic/utils.ts
@@ -502,7 +502,11 @@ const getLeftOperandValue = (
       const responseValue = data[leftOperand.value];
 
       if (currentQuestion.type === "openText" && currentQuestion.inputType === "number") {
-        return Number(responseValue) || undefined;
+        if (responseValue === undefined) return undefined;
+        if (typeof responseValue === "string" && responseValue.trim() === "") return undefined;
+
+        const numberValue = typeof responseValue === "number" ? responseValue : Number(responseValue);
+        return isNaN(numberValue) ? undefined : numberValue;
       }
 
       if (currentQuestion.type === "multipleChoiceSingle" || currentQuestion.type === "multipleChoiceMulti") {

--- a/packages/surveys/src/lib/logic.ts
+++ b/packages/surveys/src/lib/logic.ts
@@ -99,7 +99,10 @@ const getLeftOperandValue = (
       const responseValue = data[leftOperand.value];
 
       if (currentQuestion.type === "openText" && currentQuestion.inputType === "number") {
-        const numberValue = Number(responseValue);
+        if (responseValue === undefined) return undefined;
+        if (typeof responseValue === "string" && responseValue.trim() === "") return undefined;
+
+        const numberValue = typeof responseValue === "number" ? responseValue : Number(responseValue);
         return isNaN(numberValue) ? undefined : numberValue;
       }
 

--- a/packages/surveys/src/lib/logic.ts
+++ b/packages/surveys/src/lib/logic.ts
@@ -99,7 +99,8 @@ const getLeftOperandValue = (
       const responseValue = data[leftOperand.value];
 
       if (currentQuestion.type === "openText" && currentQuestion.inputType === "number") {
-        return Number(responseValue) || undefined;
+        const numberValue = Number(responseValue);
+        return isNaN(numberValue) ? undefined : numberValue;
       }
 
       if (currentQuestion.type === "multipleChoiceSingle" || currentQuestion.type === "multipleChoiceMulti") {


### PR DESCRIPTION
## What does this PR do?
open text number question logic evaluation

Fixes https://github.com/formbricks/internal/issues/760

## How should this be tested?

- Create a survey with an open-text number type question.
- Create two survey endings, ending 1 and ending 2.
- Add a logic rule to the first question: if the value is less than 10, redirect to ending 2; otherwise, redirect to ending 1.
- When the value is 0, redirect to ending 2.

