### PR TITLE
chore(cursor): add monorepo overview rule and refine database rule metadata

### DIFF
--- a/.cursor/rules/database.mdc
+++ b/.cursor/rules/database.mdc
@@ -1,12 +1,8 @@
 ---
-description: >
-  This rule provides comprehensive knowledge about the Formbricks database structure, relationships, 
-  and data patterns. It should be used **only when the agent explicitly requests database schema-level 
-  details** to support tasks such as: writing/debugging Prisma queries, designing/reviewing data models, 
-  investigating multi-tenancy behavior, creating API endpoints, or understanding data relationships.
-globs: []
-alwaysApply: agent-requested
+description: Database, Data Model and Prisma changes
+alwaysApply: false
 ---
+
 # Formbricks Database Schema Reference
 
 This rule provides a reference to the Formbricks database structure. For the most up-to-date and complete schema definitions, please refer to the schema.prisma file directly.
@@ -16,6 +12,7 @@ This rule provides a reference to the Formbricks database structure. For the mos
 Formbricks uses PostgreSQL with Prisma ORM. The schema is designed for multi-tenancy with strong data isolation between organizations.
 
 ### Core Hierarchy
+
 ```
 Organization
 └── Project
@@ -29,6 +26,7 @@ Organization
 ## Schema Reference
 
 For the complete and up-to-date database schema, please refer to:
+
 - Main schema: `packages/database/schema.prisma`
 - JSON type definitions: `packages/database/json-types.ts`
 
@@ -37,17 +35,22 @@ The schema.prisma file contains all model definitions, relationships, enums, and
 ## Data Access Patterns
 
 ### Multi-tenancy
+
 - All data is scoped by Organization
 - Environment-level isolation for surveys and contacts
 - Project-level grouping for related surveys
 
 ### Soft Deletion
+
 Some models use soft deletion patterns:
+
 - Check `isActive` fields where present
 - Use proper filtering in queries
 
 ### Cascading Deletes
+
 Configured cascade relationships:
+
 - Organization deletion cascades to all child entities
 - Survey deletion removes responses, displays, triggers
 - Contact deletion removes attributes and responses
@@ -55,6 +58,7 @@ Configured cascade relationships:
 ## Common Query Patterns
 
 ### Survey with Responses
+
 ```typescript
 // Include response count and latest responses
 const survey = await prisma.survey.findUnique({
@@ -62,40 +66,40 @@ const survey = await prisma.survey.findUnique({
   include: {
     responses: {
       take: 10,
-      orderBy: { createdAt: 'desc' }
+      orderBy: { createdAt: "desc" },
     },
     _count: {
-      select: { responses: true }
-    }
-  }
+      select: { responses: true },
+    },
+  },
 });
 ```
 
 ### Environment Scoping
+
 ```typescript
 // Always scope by environment
 const surveys = await prisma.survey.findMany({
   where: {
     environmentId: environmentId,
     // Additional filters...
-  }
+  },
 });
 ```
 
 ### Contact with Attributes
+
 ```typescript
 const contact = await prisma.contact.findUnique({
   where: { id: contactId },
   include: {
     attributes: {
       include: {
-        attributeKey: true
-      }
-    }
-  }
+        attributeKey: true,
+      },
+    },
+  },
 });
 ```
 
 This schema supports Formbricks' core functionality: multi-tenant survey management, user targeting, response collection, and analysis, all while maintaining strict data isolation and security.
-
-

--- a/.cursor/rules/database.mdc
+++ b/.cursor/rules/database.mdc
@@ -1,5 +1,5 @@
 ---
-description: Database, Data Model and Prisma changes
+description: It should be used **only when the agent explicitly requests database schema-level, details** to support tasks such as: writing/debugging Prisma queries, designing/reviewing data models, investigating multi-tenancy behavior, creating API endpoints, or understanding data relationships.
 alwaysApply: false
 ---
 

--- a/.cursor/rules/overview.mdc
+++ b/.cursor/rules/overview.mdc
@@ -1,0 +1,74 @@
+---
+alwaysApply: true
+---
+
+### Formbricks Monorepo Overview
+
+- **Project**: Formbricks — open‑source survey and experience management platform. Repo: [formbricks/formbricks](https://github.com/formbricks/formbricks)
+- **Monorepo**: Turborepo + pnpm workspaces. Root configs: [package.json](mdc:package.json), [turbo.json](mdc:turbo.json)
+- **Core app**: Next.js app in `apps/web` with Prisma, Auth.js, TailwindCSS, Vitest, Playwright. Enterprise modules live in [apps/web/modules/ee](mdc:apps/web/modules/ee)
+- **Datastores**: PostgreSQL + Redis. Local dev via [docker-compose.dev.yml](mdc:docker-compose.dev.yml); Prisma schema at [packages/database/schema.prisma](mdc:packages/database/schema.prisma)
+- **Docs & Ops**: Docs in `docs/` (Mintlify), Helm in `helm-chart/`, IaC in `infra/`
+
+### Apps
+
+- **apps/web**: Next.js product application (API, UI, SSO, i18n, emails, uploads, integrations)
+- **apps/storybook**: Storybook for UI components; a11y addon + Vite builder
+
+### Packages
+
+- **@formbricks/database** (`packages/database`): Prisma schema, DB scripts, migrations, data layer
+- **@formbricks/js-core** (`packages/js-core`): Core runtime for web embed / async loader
+- **@formbricks/surveys** (`packages/surveys`): Embeddable survey rendering and helpers
+- **@formbricks/logger** (`packages/logger`): Shared logging (pino) + Zod types
+- **@formbricks/types** (`packages/types`): Shared types (Zod, Prisma clients)
+- **@formbricks/i18n-utils** (`packages/i18n-utils`): i18n helpers and build output
+- **@formbricks/eslint-config** (`packages/config-eslint`): Central ESLint config (Next, TS, Vitest, Prettier)
+- **@formbricks/config-typescript** (`packages/config-typescript`): Central TS config and types
+- **@formbricks/vite-plugins** (`packages/vite-plugins`): Internal Vite plugins
+- **packages/android, packages/ios**: Native SDKs (built with platform toolchains)
+
+### Enterprise‑ready by design
+
+- **Quality & safety**: Strict TypeScript, repo‑wide ESLint + Prettier, lint‑staged + Husky, CI checks, typed env validation
+- **Security‑first**: Auth.js, SSO/SAML/OIDC, session controls, rate limiting, Sentry, structured logging
+
+### Accessible by design
+
+- **UI foundations**: Radix UI, TailwindCSS, Storybook with `@storybook/addon-a11y`, keyboard and screen‑reader‑friendly components
+
+### Root pnpm commands
+
+```bash
+pnpm clean:all           # Clean turbo cache, node_modules, lockfile, coverage, out
+pnpm clean               # Clean turbo cache, node_modules, coverage, out
+pnpm build               # Build all packages/apps (turbo)
+pnpm build:dev           # Dev-optimized builds (where supported)
+pnpm dev                 # Run all dev servers in parallel
+pnpm start               # Start built apps/services
+pnpm go                  # Start DB (docker compose) and run long-running dev tasks
+pnpm generate            # Run generators (e.g., Prisma, API specs)
+pnpm lint                # Lint all
+pnpm format              # Prettier write across repo
+pnpm test                # Unit tests
+pnpm test:coverage       # Unit tests with coverage
+pnpm test:e2e            # Playwright tests
+pnpm test-e2e:azure      # Playwright tests with Azure config
+pnpm storybook           # Run Storybook
+pnpm db:up               # Start local Postgres/Redis via docker compose
+pnpm db:down             # Stop local DB stack
+pnpm db:start            # Project-level DB setup choreography
+pnpm db:push             # Prisma db push (accept data loss in package script)
+pnpm db:migrate:dev      # Apply dev migrations
+pnpm db:migrate:deploy   # Apply prod migrations
+pnpm fb-migrate-dev      # Create DB migration (database package) and prisma generate
+pnpm tolgee-pull         # Pull translation keys for current branch and format
+```
+
+### Essentials for every prompt
+
+- **Tech stack**: Next.js, React 19, TypeScript, Prisma, Zod, TailwindCSS, Turborepo, Vitest, Playwright
+- **Environments**: See `.env.example`. Many tasks require DB up and env variables set
+- **Licensing**: Core under AGPLv3; Enterprise code in `apps/web/modules/ee` (included in Docker, unlocked via Enterprise License Key)
+
+For deeper details, consult per‑package `package.json` and scripts (e.g., [apps/web/package.json](mdc:apps/web/package.json)).


### PR DESCRIPTION
This PR introduces an always-on Cursor rule providing a concise, high-signal overview of the Formbricks monorepo and slightly refines the database rule metadata.

What’s included:
- Add `.cursor/rules/overview.mdc` (alwaysApply: true)
  - Highlights: project identity, turborepo+pnpn setup, core apps & packages with purposes
  - Enterprise-ready & accessibility design principles
  - Full set of root `pnpm` commands for quick reference
  - Essential repo context: envs, datastores, docs/ops, licensing
- Update `.cursor/rules/database.mdc` frontmatter to a clear, concise description to better match the repository’s rule usage style

Why:
- Make the most essential monorepo knowledge available in every prompt to reduce context-switching and improve developer velocity
- Keep deeper package/app details out of the global context to remain concise (dedicated rules can be added separately)

Notes:
- No runtime or app logic changes
- Verified links and file references

Branch: chore/cursor-overview-rule