### PR TITLE
feat: adds stories for logo component

### DIFF
--- a/apps/web/modules/ui/components/logo/index.tsx
+++ b/apps/web/modules/ui/components/logo/index.tsx
@@ -1,4 +1,4 @@
-export const Logo = (props: any) => {
+export const Logo = (props: React.SVGProps<SVGSVGElement>) => {
   return (
     <svg viewBox="0 0 697 150" fill="none" xmlns="http://www.w3.org/2000/svg" {...props}>
       <path

--- a/apps/web/modules/ui/components/logo/stories.tsx
+++ b/apps/web/modules/ui/components/logo/stories.tsx
@@ -1,0 +1,81 @@
+import { Meta, StoryObj } from "@storybook/react-vite";
+import { Logo } from "./index";
+
+interface StoryOptions {
+  showLabel: boolean;
+}
+
+type StoryProps = React.ComponentProps<typeof Logo> & StoryOptions;
+
+const meta: Meta<StoryProps> = {
+  title: "UI/Logo",
+  component: Logo,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    controls: { sort: "alpha", exclude: [] },
+    docs: {
+      description: {
+        component:
+          "The **Logo** component displays the Formbricks wordmark logo with scalable SVG graphics. It includes both the brand icon and text, perfect for headers, navigation, and branding areas.",
+      },
+    },
+  },
+  argTypes: {
+    showLabel: {
+      control: "boolean",
+      description: "Show descriptive label below logo",
+      table: {
+        category: "Appearance",
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+      },
+      order: 2,
+    },
+    className: {
+      control: "text",
+      description: "Additional CSS classes for styling",
+      table: {
+        category: "Appearance",
+        type: { summary: "string" },
+      },
+      order: 1,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<StoryProps>;
+
+const renderLogoWithOptions = (args: StoryProps) => {
+  const { showLabel, ...logoProps } = args;
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <Logo {...logoProps} />
+      {showLabel && <p className={`text-sm font-medium`}>Formbricks Wordmark Logo</p>}
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: renderLogoWithOptions,
+  args: {
+    showLabel: false,
+    className: "h-20",
+  },
+};
+
+export const WithLabel: Story = {
+  render: renderLogoWithOptions,
+  args: {
+    showLabel: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Logo with descriptive label for better context in design documentation.",
+      },
+    },
+  },
+};


### PR DESCRIPTION
## What does this PR do?
adds stories for logo component

Fixes https://github.com/formbricks/internal/issues/901

<img width="2082" height="1812" alt="image" src="https://github.com/user-attachments/assets/f814c82d-dfbd-4302-8300-0e1d96c247b3" />
<img width="2124" height="638" alt="image" src="https://github.com/user-attachments/assets/f070b5b6-4117-4353-be99-3aa5901b81fa" />


## How should this be tested?

- Storybook should contain relevant stories for the component
