### PR TITLE
chore: increase data migration timeout to 600s

### DIFF
--- a/apps/web/scripts/docker/next-start.sh
+++ b/apps/web/scripts/docker/next-start.sh
@@ -55,7 +55,7 @@ else
 fi
 
 echo "🗃️ Running database migrations..."
-run_with_timeout 300 "database migration" sh -c '(cd packages/database && npm run db:migrate:deploy)'
+run_with_timeout 600 "database migration" sh -c '(cd packages/database && npm run db:migrate:deploy)'
 
 echo "🗃️ Running SAML database setup..."
 run_with_timeout 60 "SAML database setup" sh -c '(cd packages/database && npm run db:create-saml-database:deploy)'


### PR DESCRIPTION
This pull request makes a minor adjustment to the startup script by increasing the timeout for running database migrations from 5 minutes to 10 minutes. This change helps prevent timeouts during longer migration processes.

- Increased the timeout for the `db:migrate:deploy` command in `next-start.sh` from 300 seconds to 600 seconds to accommodate longer-running database migrations.