### PR TITLE
feat: adds line break support in open text question textarea

### DIFF
--- a/packages/surveys/src/components/questions/open-text-question.tsx
+++ b/packages/surveys/src/components/questions/open-text-question.tsx
@@ -138,7 +138,7 @@ export function OpenTextQuestion({
               tabIndex={isCurrent ? 0 : -1}
               aria-label="textarea"
               id={question.id}
-              placeholder={getLocalizedValue(question.placeholder, languageCode)}
+              placeholder={getLocalizedValue(question.placeholder, languageCode, true)}
               dir={dir}
               required={question.required}
               value={value}

--- a/packages/surveys/src/lib/i18n.ts
+++ b/packages/surveys/src/lib/i18n.ts
@@ -6,7 +6,7 @@ const isI18nObject = (obj: any): obj is TI18nString => {
 };
 
 // Matches \r\n, \n, \r, and their HTML entity variants
-const ESCAPED_NEWLINES = /\\r\\n|\\n|\\r|&#10;|&#13;/g;
+const ESCAPED_NEWLINES = /\\r\\n|&#13;&#10;|\\n|\\r|&#10;|&#13;/g;
 
 export const unescapeNewlines = (s: string): string => s.replace(ESCAPED_NEWLINES, "\n");
 

--- a/packages/surveys/src/lib/i18n.ts
+++ b/packages/surveys/src/lib/i18n.ts
@@ -5,15 +5,31 @@ const isI18nObject = (obj: any): obj is TI18nString => {
   return typeof obj === "object" && obj !== null && Object.keys(obj).includes("default");
 };
 
-export const getLocalizedValue = (value: TI18nString | undefined, languageId: string): string => {
+// Matches \r\n, \n, \r, and their HTML entity variants
+const ESCAPED_NEWLINES = /\\r\\n|\\n|\\r|&#10;|&#13;/g;
+
+export const unescapeNewlines = (s: string): string => s.replace(ESCAPED_NEWLINES, "\n");
+
+export const getLocalizedValue = (
+  value: TI18nString | undefined,
+  languageId: string,
+  replaceNewLines: boolean = false
+): string => {
   if (!value) {
     return "";
   }
+
+  let result = "";
+
   if (isI18nObject(value)) {
     if (typeof value[languageId] === "string") {
-      return value[languageId];
+      result = value[languageId];
+    } else {
+      result = value.default;
     }
-    return value.default;
+
+    result = replaceNewLines ? unescapeNewlines(result) : result;
   }
-  return "";
+
+  return result;
 };


### PR DESCRIPTION
## What does this PR do?
Adds line break support in the open-text question textarea

Fixes https://github.com/formbricks/formbricks/issues/6436

<img width="3468" height="1134" alt="image" src="https://github.com/user-attachments/assets/8e958906-90b0-41d3-873a-fc987fea92b3" />

## How should this be tested?

- Support for line breaks should include:
  - `&#10;` → Line Feed (\n)
  - `&#13;` → Carriage Return (\r)
  - `\r`
  - `\n`
  - `\r\n` (CRLF)