### PR TITLE
fix(tooltip): wrap TooltipContent in a Portal for improved rendering

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTableColumns.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTableColumns.tsx
@@ -289,7 +289,8 @@ export const generateResponseTableColumns = (
                 <Link
                   className="text-blue-600 underline underline-offset-2 hover:text-slate-900"
                   href="https://formbricks.com/docs/app-surveys/user-identification"
-                  target="_blank">
+                  target="_blank"
+                  rel="noopener noreferrer">
                   {t("common.learn_more") || "Learn more"}
                 </Link>
               </div>

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTableColumns.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTableColumns.tsx
@@ -284,13 +284,15 @@ export const generateResponseTableColumns = (
               <CircleHelpIcon className="h-3 w-3 text-slate-500" strokeWidth={1.5} />
             </TooltipTrigger>
             <TooltipContent side="bottom" className="font-normal">
-              {t("environments.surveys.responses.how_to_identify_users")}
-              <Link
-                className="underline underline-offset-2 hover:text-slate-900"
-                href="https://formbricks.com/docs/app-surveys/user-identification"
-                target="_blank">
-                {t("common.app_survey")}
-              </Link>
+              <div className="space-y-2">
+                <p>{t("environments.surveys.responses.how_to_identify_users") || "How to identify users"}</p>
+                <Link
+                  className="text-blue-600 underline underline-offset-2 hover:text-slate-900"
+                  href="https://formbricks.com/docs/app-surveys/user-identification"
+                  target="_blank">
+                  {t("common.learn_more") || "Learn more"}
+                </Link>
+              </div>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTableColumns.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTableColumns.tsx
@@ -283,17 +283,15 @@ export const generateResponseTableColumns = (
             <TooltipTrigger>
               <CircleHelpIcon className="h-3 w-3 text-slate-500" strokeWidth={1.5} />
             </TooltipTrigger>
-            <TooltipContent side="bottom" className="font-normal">
-              <div className="space-y-2">
-                <p>{t("environments.surveys.responses.how_to_identify_users") || "How to identify users"}</p>
-                <Link
-                  className="text-blue-600 underline underline-offset-2 hover:text-slate-900"
-                  href="https://formbricks.com/docs/app-surveys/user-identification"
-                  target="_blank"
-                  rel="noopener noreferrer">
-                  {t("common.learn_more") || "Learn more"}
-                </Link>
-              </div>
+            <TooltipContent side="bottom" className="space-x-1 font-normal">
+              <span>{t("environments.surveys.responses.how_to_identify_users")}</span>
+              <Link
+                className="underline underline-offset-2 hover:text-slate-900"
+                href="https://formbricks.com/docs/app-surveys/user-identification"
+                target="_blank"
+                rel="noopener noreferrer">
+                {t("common.app_survey")}
+              </Link>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>

--- a/apps/web/modules/ui/components/tooltip/index.test.tsx
+++ b/apps/web/modules/ui/components/tooltip/index.test.tsx
@@ -30,6 +30,11 @@ vi.mock("@radix-ui/react-tooltip", () => ({
       {children}
     </div>
   ),
+  Portal: ({ children, ...props }: any) => (
+    <div data-testid="tooltip-portal" {...props}>
+      {children}
+    </div>
+  ),
 }));
 
 describe("Tooltip", () => {

--- a/apps/web/modules/ui/components/tooltip/index.tsx
+++ b/apps/web/modules/ui/components/tooltip/index.tsx
@@ -18,15 +18,17 @@ const TooltipContent: React.ComponentType<TooltipPrimitive.TooltipContentProps> 
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "animate-in fade-in-50 data-[side=bottom]:slide-in-from-top-1 data-[side=top]:slide-in-from-bottom-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 z-50 overflow-hidden rounded-md border border-slate-100 bg-white px-3 py-1.5 text-sm text-slate-700 shadow-md",
-      className
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "animate-in fade-in-50 data-[side=bottom]:slide-in-from-top-1 data-[side=top]:slide-in-from-bottom-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 z-50 overflow-hidden rounded-md border border-slate-100 bg-white px-3 py-1.5 text-sm text-slate-700 shadow-md",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 


### PR DESCRIPTION
## What does this PR do?

**Problem:**
During skeleton state the tooltip showed, but after the table rendered, the tooltip appeared as an empty/blank bubble.
It affected the “Person” column header tooltip.

Fixes #6334 
<img width="1419" height="858" alt="Screenshot 2025-08-22 at 8 01 22 PM" src="https://github.com/user-attachments/assets/bc9ea37a-d396-4796-a9c9-fad96bd79443" />

## How should this be tested?

1. Navigate to the Survey Responses page.
2. Hover over the “Person” help icon — a tooltip appears containing text and a link.
3. Click the “Learn more” link — it opens in a new tab.

## Checklist
### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
