### PR TITLE
chore: remove deprecated scale plan from stripe subscription update

### DIFF
--- a/apps/web/modules/ee/billing/api/lib/subscription-created-or-updated.ts
+++ b/apps/web/modules/ee/billing/api/lib/subscription-created-or-updated.ts
@@ -94,10 +94,6 @@ export const handleSubscriptionCreatedOrUpdated = async (event: Stripe.Event) =>
       updatedBillingPlan = PROJECT_FEATURE_KEYS.STARTUP;
       break;
 
-    case PROJECT_FEATURE_KEYS.SCALE:
-      updatedBillingPlan = PROJECT_FEATURE_KEYS.SCALE;
-      break;
-
     case PROJECT_FEATURE_KEYS.ENTERPRISE:
       updatedBillingPlan = PROJECT_FEATURE_KEYS.ENTERPRISE;
       break;


### PR DESCRIPTION
This pull request makes a minor change to the billing logic by removing support for the `SCALE` billing plan (deprecated) in the `handleSubscriptionCreatedOrUpdated` function.

- Removed handling for the `SCALE` billing plan in `handleSubscriptionCreatedOrUpdated` within `subscription-created-or-updated.ts`