### PR TITLE
fix(ci): backport release tag validation fix to release/4.0

### DIFF
--- a/.github/workflows/move-stable-tag.yml
+++ b/.github/workflows/move-stable-tag.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       release_tag:
-        description: "The release tag name (e.g., v1.2.3)"
+        description: "The release tag name (e.g., 1.2.3)"
         required: true
         type: string
       commit_sha:
@@ -53,8 +53,8 @@ jobs:
           set -euo pipefail
 
           # Validate release tag format
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$ ]]; then
-            echo "❌ Error: Invalid release tag format. Expected format: v1.2.3, v1.2.3-alpha"
+          if [[ ! "$RELEASE_TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$ ]]; then
+            echo "❌ Error: Invalid release tag format. Expected format: 1.2.3, 1.2.3-alpha"
             echo "Provided: $RELEASE_TAG"
             exit 1
           fi


### PR DESCRIPTION
## Description

This PR backports the release tag validation fix from PR #6585 to the release/4.0 branch. The fix updates the CI pipeline to accept the new release tag format without the "v" prefix (e.g., `4.0.0` instead of `v4.0.0`).

## Changes Made

* **Updated regex validation** in `.github/workflows/move-stable-tag.yml`:
  * Removed requirement for "v" prefix in release tag format  
  * Changed from `^v[0-9]+\.[0-9]+\.[0-9]+...` to `^[0-9]+\.[0-9]+\.[0-9]+...`
* **Updated error message** to reflect new expected format (`1.2.3` instead of `v1.2.3`)
* **Updated input description** to show correct format example

## Problem Solved

Resolves the pipeline error:

```
❌ Error: Invalid release tag format. Expected format: v1.2.3, v1.2.3-alpha
Provided: 4.0.0
Error: Process completed with exit code 1.
```

## Testing

The validation now accepts:
* ✅ `4.0.0` (standard release)
* ✅ `4.0.0-alpha` (prerelease) 
* ✅ `4.0.0+build.1` (build metadata)
* ❌ `v4.0.0` (old format, no longer supported)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related

Backport of: #6585
Original commit: 5f99a48