### PR TITLE
Remove INTERCOM environment variables from .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,8 +189,6 @@ REDIS_URL=redis://localhost:6379
 # The below is used for Rate Limiting (uses In-Memory LRU Cache if not provided) (You can use a service like Webdis for this)
 # REDIS_HTTP_URL:
 
-# INTERCOM_APP_ID=
-# INTERCOM_SECRET_KEY=
 
 # Enable Prometheus metrics
 # PROMETHEUS_ENABLED=


### PR DESCRIPTION
## Summary

This PR removes the INTERCOM environment variables from the `.env.example` file to clean up unused configuration options for self-hosted instances.

## Changes

- Removed `INTERCOM_APP_ID` environment variable from `.env.example`
- Removed `INTERCOM_SECRET_KEY` environment variable from `.env.example`

## Rationale

These INTERCOM variables are not needed for self-hosted instances and removing them simplifies the environment configuration template.

## Testing

- [x] Verified that INTERCOM variables are no longer present in `.env.example`
- [x] Confirmed that the file structure remains intact after removal