### PR TITLE
feat: hit ENTER for new option

### DIFF
--- a/apps/web/modules/survey/components/question-form-input/index.tsx
+++ b/apps/web/modules/survey/components/question-form-input/index.tsx
@@ -4,7 +4,7 @@ import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { useTranslate } from "@tolgee/react";
 import { debounce } from "lodash";
 import { ImagePlusIcon, TrashIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   TI18nString,
   TSurvey,
@@ -163,25 +163,6 @@ export const QuestionFormInput = ({
 
   // Hook to synchronize the horizontal scroll position of highlightContainerRef and inputRef.
   useSyncScroll(highlightContainerRef, inputRef);
-
-  useEffect(() => {
-    if (!question) return;
-
-    const isListItem = isChoice || isMatrixLabelRow || isMatrixLabelColumn;
-    if (!isListItem) return;
-
-    const isEmpty = !value || Object.values(value).every((val) => !val || val.trim() === "");
-    if (!isEmpty) return;
-
-    const headlineHasContent =
-      question.headline &&
-      Object.values(question.headline).some((val) => typeof val === "string" && val.trim() !== "");
-
-    if (headlineHasContent && inputRef.current) {
-      inputRef.current.focus();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const createUpdatedText = useCallback(
     (updatedText: string): TI18nString => {

--- a/apps/web/modules/survey/components/question-form-input/index.tsx
+++ b/apps/web/modules/survey/components/question-form-input/index.tsx
@@ -1,15 +1,5 @@
 "use client";
 
-import { createI18nString, extractLanguageCodes } from "@/lib/i18n/utils";
-import { useSyncScroll } from "@/lib/utils/hooks/useSyncScroll";
-import { recallToHeadline } from "@/lib/utils/recall";
-import { MultiLangWrapper } from "@/modules/survey/components/question-form-input/components/multi-lang-wrapper";
-import { RecallWrapper } from "@/modules/survey/components/question-form-input/components/recall-wrapper";
-import { Button } from "@/modules/ui/components/button";
-import { FileInput } from "@/modules/ui/components/file-input";
-import { Input } from "@/modules/ui/components/input";
-import { Label } from "@/modules/ui/components/label";
-import { TooltipRenderer } from "@/modules/ui/components/tooltip";
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { useTranslate } from "@tolgee/react";
 import { debounce } from "lodash";
@@ -24,6 +14,16 @@ import {
   TSurveyRedirectUrlCard,
 } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
+import { createI18nString, extractLanguageCodes } from "@/lib/i18n/utils";
+import { useSyncScroll } from "@/lib/utils/hooks/useSyncScroll";
+import { recallToHeadline } from "@/lib/utils/recall";
+import { MultiLangWrapper } from "@/modules/survey/components/question-form-input/components/multi-lang-wrapper";
+import { RecallWrapper } from "@/modules/survey/components/question-form-input/components/recall-wrapper";
+import { Button } from "@/modules/ui/components/button";
+import { FileInput } from "@/modules/ui/components/file-input";
+import { Input } from "@/modules/ui/components/input";
+import { Label } from "@/modules/ui/components/label";
+import { TooltipRenderer } from "@/modules/ui/components/tooltip";
 import {
   determineImageUploaderVisibility,
   getChoiceLabel,
@@ -50,7 +50,7 @@ interface QuestionFormInputProps {
   label: string;
   maxLength?: number;
   placeholder?: string;
-  ref?: RefObject<HTMLInputElement | null>;
+  externalInputRef?: RefObject<HTMLInputElement | null>;
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
   className?: string;
   locale: TUserLocale;
@@ -78,6 +78,7 @@ export const QuestionFormInput = ({
   locale,
   onKeyDown,
   isStorageConfigured = true,
+  externalInputRef,
 }: QuestionFormInputProps) => {
   const { t } = useTranslate();
   const defaultLanguageCode =
@@ -385,7 +386,7 @@ export const QuestionFormInput = ({
                           placeholder={placeholder ?? getPlaceHolderById(id, t)}
                           aria-label={label}
                           maxLength={maxLength}
-                          ref={inputRef}
+                          ref={externalInputRef ?? inputRef}
                           onBlur={onBlur}
                           className={`absolute top-0 text-black caret-black ${
                             localSurvey.languages?.length > 1 ? "pr-24" : ""

--- a/apps/web/modules/survey/editor/components/matrix-question-form.test.tsx
+++ b/apps/web/modules/survey/editor/components/matrix-question-form.test.tsx
@@ -84,6 +84,7 @@ describe("MatrixQuestionForm - handleKeyDown", () => {
     id: "q1",
     type: TSurveyQuestionTypeEnum.Matrix,
     headline: { default: "Matrix" },
+    required: false,
     rows: [
       { id: "r1", label: { default: "Row 1" } },
       { id: "r2", label: { default: "" } },
@@ -95,42 +96,8 @@ describe("MatrixQuestionForm - handleKeyDown", () => {
     shuffleOption: "none",
   });
 
-  test("Enter focuses first empty row if present", async () => {
+  test("Enter on last row adds a new row", async () => {
     const question = baseQuestion();
-    const localSurvey = makeSurvey([langDefault]);
-    // localSurvey.questions must include current question at questionIdx
-    (localSurvey as any).questions = [question];
-
-    const updateQuestion = vi.fn();
-
-    render(
-      <MatrixQuestionForm
-        localSurvey={localSurvey}
-        question={question}
-        questionIdx={0}
-        updateQuestion={updateQuestion}
-        isInvalid={false}
-        selectedLanguageCode="default"
-        setSelectedLanguageCode={vi.fn()}
-        locale="en-US"
-        isStorageConfigured={true}
-      />
-    );
-
-    const rowInput = screen.getByTestId("qfi-row-0");
-    await userEvent.type(rowInput, "{enter}");
-
-    // When an empty row exists, it should NOT add a new row (no updateQuestion call)
-    expect(updateQuestion).not.toHaveBeenCalled();
-  });
-
-  test("Enter adds a new row if none empty", async () => {
-    const question = baseQuestion();
-    // Make all rows non-empty
-    question.rows = [
-      { id: "r1", label: { default: "Row 1" } },
-      { id: "r2", label: { default: "Row 2" } },
-    ];
     const localSurvey = makeSurvey([langDefault]);
     (localSurvey as any).questions = [question];
 
@@ -150,8 +117,8 @@ describe("MatrixQuestionForm - handleKeyDown", () => {
       />
     );
 
-    const rowInput = screen.getByTestId("qfi-row-0");
-    await userEvent.type(rowInput, "{enter}");
+    const lastRowInput = screen.getByTestId("qfi-row-1");
+    await userEvent.type(lastRowInput, "{enter}");
 
     expect(updateQuestion).toHaveBeenCalledTimes(1);
     const [, payload] = updateQuestion.mock.calls[0];
@@ -161,7 +128,7 @@ describe("MatrixQuestionForm - handleKeyDown", () => {
     );
   });
 
-  test("Enter focuses first empty column if present", async () => {
+  test("Enter on non-last row focuses next row", async () => {
     const question = baseQuestion();
     const localSurvey = makeSurvey([langDefault]);
     (localSurvey as any).questions = [question];
@@ -182,19 +149,14 @@ describe("MatrixQuestionForm - handleKeyDown", () => {
       />
     );
 
-    const colInput = screen.getByTestId("qfi-column-0");
-    await userEvent.type(colInput, "{enter}");
+    const firstRowInput = screen.getByTestId("qfi-row-0");
+    await userEvent.type(firstRowInput, "{enter}");
 
-    // When an empty column exists, it should NOT add a new column
     expect(updateQuestion).not.toHaveBeenCalled();
   });
 
-  test("Enter adds a new column if none empty", async () => {
+  test("Enter on last column adds a new column", async () => {
     const question = baseQuestion();
-    question.columns = [
-      { id: "c1", label: { default: "Col 1" } },
-      { id: "c2", label: { default: "Col 2" } },
-    ];
     const localSurvey = makeSurvey([langDefault]);
     (localSurvey as any).questions = [question];
 
@@ -214,8 +176,8 @@ describe("MatrixQuestionForm - handleKeyDown", () => {
       />
     );
 
-    const colInput = screen.getByTestId("qfi-column-0");
-    await userEvent.type(colInput, "{enter}");
+    const lastColInput = screen.getByTestId("qfi-column-1");
+    await userEvent.type(lastColInput, "{enter}");
 
     expect(updateQuestion).toHaveBeenCalledTimes(1);
     const [, payload] = updateQuestion.mock.calls[0];
@@ -223,5 +185,86 @@ describe("MatrixQuestionForm - handleKeyDown", () => {
     expect(payload.columns[2]).toEqual(
       expect.objectContaining({ id: expect.any(String), label: expect.objectContaining({ default: "" }) })
     );
+  });
+
+  test("Enter on non-last column focuses next column", async () => {
+    const question = baseQuestion();
+    const localSurvey = makeSurvey([langDefault]);
+    (localSurvey as any).questions = [question];
+
+    const updateQuestion = vi.fn();
+
+    render(
+      <MatrixQuestionForm
+        localSurvey={localSurvey}
+        question={question}
+        questionIdx={0}
+        updateQuestion={updateQuestion}
+        isInvalid={false}
+        selectedLanguageCode="default"
+        setSelectedLanguageCode={vi.fn()}
+        locale="en-US"
+        isStorageConfigured={true}
+      />
+    );
+
+    const firstColInput = screen.getByTestId("qfi-column-0");
+    await userEvent.type(firstColInput, "{enter}");
+
+    expect(updateQuestion).not.toHaveBeenCalled();
+  });
+
+  test("Arrow Down on row focuses next row", async () => {
+    const question = baseQuestion();
+    const localSurvey = makeSurvey([langDefault]);
+    (localSurvey as any).questions = [question];
+
+    const updateQuestion = vi.fn();
+
+    render(
+      <MatrixQuestionForm
+        localSurvey={localSurvey}
+        question={question}
+        questionIdx={0}
+        updateQuestion={updateQuestion}
+        isInvalid={false}
+        selectedLanguageCode="default"
+        setSelectedLanguageCode={vi.fn()}
+        locale="en-US"
+        isStorageConfigured={true}
+      />
+    );
+
+    const firstRowInput = screen.getByTestId("qfi-row-0");
+    await userEvent.type(firstRowInput, "{arrowdown}");
+
+    expect(updateQuestion).not.toHaveBeenCalled();
+  });
+
+  test("Arrow Up on row focuses previous row", async () => {
+    const question = baseQuestion();
+    const localSurvey = makeSurvey([langDefault]);
+    (localSurvey as any).questions = [question];
+
+    const updateQuestion = vi.fn();
+
+    render(
+      <MatrixQuestionForm
+        localSurvey={localSurvey}
+        question={question}
+        questionIdx={0}
+        updateQuestion={updateQuestion}
+        isInvalid={false}
+        selectedLanguageCode="default"
+        setSelectedLanguageCode={vi.fn()}
+        locale="en-US"
+        isStorageConfigured={true}
+      />
+    );
+
+    const secondRowInput = screen.getByTestId("qfi-row-1");
+    await userEvent.type(secondRowInput, "{arrowup}");
+
+    expect(updateQuestion).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/modules/survey/editor/components/matrix-question-form.test.tsx
+++ b/apps/web/modules/survey/editor/components/matrix-question-form.test.tsx
@@ -1,335 +1,227 @@
-import { createI18nString } from "@/lib/i18n/utils";
-import { findOptionUsedInLogic } from "@/modules/survey/editor/lib/utils";
 import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { TLanguage } from "@formbricks/types/project";
 import {
   TSurvey,
   TSurveyLanguage,
   TSurveyMatrixQuestion,
   TSurveyQuestionTypeEnum,
 } from "@formbricks/types/surveys/types";
-import { TUserLocale } from "@formbricks/types/user";
 import { MatrixQuestionForm } from "./matrix-question-form";
 
-// Mock cuid2 to track CUID generation
-let cuidIndex = 0;
-
-vi.mock("@paralleldrive/cuid2", () => ({
-  default: {
-    createId: vi.fn(() => `cuid${cuidIndex++}`),
-  },
-}));
-
-// Mock window.matchMedia - required for useAutoAnimate
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: vi.fn().mockImplementation((query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
-});
-
-// Mock @formkit/auto-animate - simplify implementation
 vi.mock("@formkit/auto-animate/react", () => ({
   useAutoAnimate: () => [null],
 }));
 
-// Mock react-hot-toast
-vi.mock("react-hot-toast", () => ({
-  default: {
-    error: vi.fn(),
-  },
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
-// Mock findOptionUsedInLogic
-vi.mock("@/modules/survey/editor/lib/utils", () => ({
-  findOptionUsedInLogic: vi.fn(),
-}));
-
-// Mock constants
-vi.mock("@/lib/constants", () => ({
-  IS_FORMBRICKS_CLOUD: false,
-  ENCRYPTION_KEY: "test",
-  ENTERPRISE_LICENSE_KEY: "test",
-  GITHUB_ID: "test",
-  GITHUB_SECRET: "test",
-  GOOGLE_CLIENT_ID: "test",
-  GOOGLE_CLIENT_SECRET: "test",
-  AZUREAD_CLIENT_ID: "mock-azuread-client-id",
-  AZUREAD_CLIENT_SECRET: "mock-azure-client-secret",
-  AZUREAD_TENANT_ID: "mock-azuread-tenant-id",
-  OIDC_CLIENT_ID: "mock-oidc-client-id",
-  OIDC_CLIENT_SECRET: "mock-oidc-client-secret",
-  OIDC_ISSUER: "mock-oidc-issuer",
-  OIDC_DISPLAY_NAME: "mock-oidc-display-name",
-  OIDC_SIGNING_ALGORITHM: "mock-oidc-signing-algorithm",
-  WEBAPP_URL: "mock-webapp-url",
-  AI_AZURE_LLM_RESSOURCE_NAME: "mock-azure-llm-resource-name",
-  AI_AZURE_LLM_API_KEY: "mock-azure-llm-api-key",
-  AI_AZURE_LLM_DEPLOYMENT_ID: "mock-azure-llm-deployment-id",
-  AI_AZURE_EMBEDDINGS_RESSOURCE_NAME: "mock-azure-embeddings-resource-name",
-  AI_AZURE_EMBEDDINGS_API_KEY: "mock-azure-embeddings-api-key",
-  AI_AZURE_EMBEDDINGS_DEPLOYMENT_ID: "mock-azure-embeddings-deployment-id",
-  IS_PRODUCTION: true,
-  FB_LOGO_URL: "https://example.com/mock-logo.png",
-  SMTP_HOST: "mock-smtp-host",
-  SMTP_PORT: "mock-smtp-port",
-  IS_POSTHOG_CONFIGURED: true,
-}));
-
-// Mock tolgee
-vi.mock("@tolgee/react", () => ({
-  useTranslate: () => ({
-    t: (key: string) => key,
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    transform: null,
+    transition: null,
   }),
+  verticalListSortingStrategy: () => {},
 }));
 
-// Mock QuestionFormInput component
+// Keep QuestionFormInput simple and forward keydown
 vi.mock("@/modules/survey/components/question-form-input", () => ({
-  QuestionFormInput: vi.fn(({ id, updateMatrixLabel, value, updateQuestion, onKeyDown }) => (
-    <div data-testid={`question-input-${id}`}>
-      <input
-        data-testid={`input-${id}`}
-        onChange={(e) => {
-          if (updateMatrixLabel) {
-            const type = id.startsWith("row") ? "row" : "column";
-            const index = parseInt(id.split("-")[1]);
-            updateMatrixLabel(index, type, { default: e.target.value });
-          } else if (updateQuestion) {
-            updateQuestion(0, { [id]: { default: e.target.value } });
-          }
-        }}
-        value={value?.default || ""}
-        onKeyDown={onKeyDown}
-      />
-    </div>
-  )),
+  QuestionFormInput: ({ id, value, onKeyDown }: { id: string; value: any; onKeyDown?: any }) => (
+    <input
+      data-testid={`qfi-${id}`}
+      value={value?.en || value?.de || value?.default || ""}
+      onChange={() => {}}
+      onKeyDown={onKeyDown}
+    />
+  ),
 }));
 
-// Mock ShuffleOptionSelect component
-vi.mock("@/modules/ui/components/shuffle-option-select", () => ({
-  ShuffleOptionSelect: vi.fn(() => <div data-testid="shuffle-option-select" />),
-}));
+describe("MatrixQuestionForm - handleKeyDown", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
 
-// Mock TooltipRenderer component
-vi.mock("@/modules/ui/components/tooltip", () => ({
-  TooltipRenderer: vi.fn(({ children }) => (
-    <div data-testid="tooltip-renderer">
-      {children}
-      <button>Delete</button>
-    </div>
-  )),
-}));
-
-// Mock validation
-vi.mock("../lib/validation", () => ({
-  isLabelValidForAllLanguages: vi.fn().mockReturnValue(true),
-}));
-
-// Mock survey languages
-const mockSurveyLanguages: TSurveyLanguage[] = [
-  {
-    default: true,
-    enabled: true,
-    language: {
-      id: "en",
-      code: "en",
-      alias: "English",
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      projectId: "project-1",
-    },
-  },
-];
-
-// Mock matrix question
-const mockMatrixQuestion: TSurveyMatrixQuestion = {
-  id: "matrix-1",
-  type: TSurveyQuestionTypeEnum.Matrix,
-  headline: createI18nString("Matrix Question", ["en"]),
-  subheader: createI18nString("Please rate the following", ["en"]),
-  required: false,
-  logic: [],
-  rows: [
-    { id: "row-1", label: createI18nString("Row 1", ["en"]) },
-    { id: "row-2", label: createI18nString("Row 2", ["en"]) },
-    { id: "row-3", label: createI18nString("Row 3", ["en"]) },
-  ],
-  columns: [
-    { id: "col-1", label: createI18nString("Column 1", ["en"]) },
-    { id: "col-2", label: createI18nString("Column 2", ["en"]) },
-    { id: "col-3", label: createI18nString("Column 3", ["en"]) },
-  ],
-  shuffleOption: "none",
-};
-
-// Mock survey
-const mockSurvey: TSurvey = {
-  id: "survey-1",
-  name: "Test Survey",
-  questions: [mockMatrixQuestion],
-  languages: mockSurveyLanguages,
-} as unknown as TSurvey;
-
-const mockUpdateQuestion = vi.fn();
-
-const defaultProps = {
-  localSurvey: mockSurvey,
-  question: mockMatrixQuestion,
-  questionIdx: 0,
-  updateQuestion: mockUpdateQuestion,
-  selectedLanguageCode: "en",
-  setSelectedLanguageCode: vi.fn(),
-  isInvalid: false,
-  locale: "en-US" as TUserLocale,
-  isStorageConfigured: true,
-};
-
-describe("MatrixQuestionForm", () => {
   afterEach(() => {
     cleanup();
-    vi.clearAllMocks();
-    cuidIndex = 0;
   });
 
-  test("renders the matrix question form with rows and columns", () => {
-    render(<MatrixQuestionForm {...defaultProps} isStorageConfigured={true} />);
+  const makeSurvey = (languages: Array<Pick<TSurveyLanguage, "language" | "default">>): TSurvey =>
+    ({
+      id: "s1",
+      name: "Survey",
+      type: "link",
+      languages: languages as unknown as TSurveyLanguage[],
+      questions: [] as any,
+      endings: [] as any,
+      createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      environmentId: "env1",
+    }) as unknown as TSurvey;
 
-    expect(screen.getByTestId("question-input-headline")).toBeInTheDocument();
+  const langDefault: TSurveyLanguage = {
+    language: { code: "default" } as unknown as TLanguage,
+    default: true,
+  } as unknown as TSurveyLanguage;
 
-    // Check for rows and columns
-    expect(screen.getByTestId("question-input-row-0")).toBeInTheDocument();
-    expect(screen.getByTestId("question-input-row-1")).toBeInTheDocument();
-    expect(screen.getByTestId("question-input-column-0")).toBeInTheDocument();
-    expect(screen.getByTestId("question-input-column-1")).toBeInTheDocument();
-
-    // Check for shuffle options
-    expect(screen.getByTestId("shuffle-option-select")).toBeInTheDocument();
+  const baseQuestion = (): TSurveyMatrixQuestion => ({
+    id: "q1",
+    type: TSurveyQuestionTypeEnum.Matrix,
+    headline: { default: "Matrix" },
+    rows: [
+      { id: "r1", label: { default: "Row 1" } },
+      { id: "r2", label: { default: "" } },
+    ],
+    columns: [
+      { id: "c1", label: { default: "Col 1" } },
+      { id: "c2", label: { default: "" } },
+    ],
+    shuffleOption: "none",
   });
 
-  test("adds description when button is clicked", async () => {
-    const user = userEvent.setup();
-    const propsWithoutSubheader = {
-      ...defaultProps,
-      question: {
-        ...mockMatrixQuestion,
-        subheader: undefined,
-      },
-    };
+  test("Enter focuses first empty row if present", async () => {
+    const question = baseQuestion();
+    const localSurvey = makeSurvey([langDefault]);
+    // localSurvey.questions must include current question at questionIdx
+    (localSurvey as any).questions = [question];
 
-    const { getByText } = render(
-      <MatrixQuestionForm {...propsWithoutSubheader} isStorageConfigured={true} />
+    const updateQuestion = vi.fn();
+
+    render(
+      <MatrixQuestionForm
+        localSurvey={localSurvey}
+        question={question}
+        questionIdx={0}
+        updateQuestion={updateQuestion}
+        isInvalid={false}
+        selectedLanguageCode="default"
+        setSelectedLanguageCode={vi.fn()}
+        locale="en-US"
+        isStorageConfigured={true}
+      />
     );
 
-    const addDescriptionButton = getByText("environments.surveys.edit.add_description");
-    await user.click(addDescriptionButton);
+    const rowInput = screen.getByTestId("qfi-row-0");
+    await userEvent.type(rowInput, "{enter}");
 
-    expect(mockUpdateQuestion).toHaveBeenCalledWith(0, {
-      subheader: expect.any(Object),
-    });
+    // When an empty row exists, it should NOT add a new row (no updateQuestion call)
+    expect(updateQuestion).not.toHaveBeenCalled();
   });
 
-  test("renders subheader input when subheader is defined", () => {
-    render(<MatrixQuestionForm {...defaultProps} />);
+  test("Enter adds a new row if none empty", async () => {
+    const question = baseQuestion();
+    // Make all rows non-empty
+    question.rows = [
+      { id: "r1", label: { default: "Row 1" } },
+      { id: "r2", label: { default: "Row 2" } },
+    ];
+    const localSurvey = makeSurvey([langDefault]);
+    (localSurvey as any).questions = [question];
 
-    expect(screen.getByTestId("question-input-subheader")).toBeInTheDocument();
+    const updateQuestion = vi.fn();
+
+    render(
+      <MatrixQuestionForm
+        localSurvey={localSurvey}
+        question={question}
+        questionIdx={0}
+        updateQuestion={updateQuestion}
+        isInvalid={false}
+        selectedLanguageCode="default"
+        setSelectedLanguageCode={vi.fn()}
+        locale="en-US"
+        isStorageConfigured={true}
+      />
+    );
+
+    const rowInput = screen.getByTestId("qfi-row-0");
+    await userEvent.type(rowInput, "{enter}");
+
+    expect(updateQuestion).toHaveBeenCalledTimes(1);
+    const [, payload] = updateQuestion.mock.calls[0];
+    expect(payload.rows.length).toBe(3);
+    expect(payload.rows[2]).toEqual(
+      expect.objectContaining({ id: expect.any(String), label: expect.objectContaining({ default: "" }) })
+    );
   });
 
-  test("deletes a row when delete button is clicked", async () => {
-    const user = userEvent.setup();
-    const { findAllByTestId } = render(<MatrixQuestionForm {...defaultProps} />);
-    vi.mocked(findOptionUsedInLogic).mockReturnValueOnce(-1);
+  test("Enter focuses first empty column if present", async () => {
+    const question = baseQuestion();
+    const localSurvey = makeSurvey([langDefault]);
+    (localSurvey as any).questions = [question];
 
-    const deleteButtons = await findAllByTestId("tooltip-renderer");
-    // First delete button is for the first column
-    await user.click(deleteButtons[0].querySelector("button") as HTMLButtonElement);
+    const updateQuestion = vi.fn();
 
-    expect(mockUpdateQuestion).toHaveBeenCalledWith(0, {
-      rows: [mockMatrixQuestion.rows[1], mockMatrixQuestion.rows[2]],
-    });
+    render(
+      <MatrixQuestionForm
+        localSurvey={localSurvey}
+        question={question}
+        questionIdx={0}
+        updateQuestion={updateQuestion}
+        isInvalid={false}
+        selectedLanguageCode="default"
+        setSelectedLanguageCode={vi.fn()}
+        locale="en-US"
+        isStorageConfigured={true}
+      />
+    );
+
+    const colInput = screen.getByTestId("qfi-column-0");
+    await userEvent.type(colInput, "{enter}");
+
+    // When an empty column exists, it should NOT add a new column
+    expect(updateQuestion).not.toHaveBeenCalled();
   });
 
-  test("doesn't delete a row if it would result in less than 2 rows", async () => {
-    const user = userEvent.setup();
-    const propsWithMinRows = {
-      ...defaultProps,
-      question: {
-        ...mockMatrixQuestion,
-        rows: [
-          { id: "row-1", label: createI18nString("Row 1", ["en"]) },
-          { id: "row-2", label: createI18nString("Row 2", ["en"]) },
-        ],
-      },
-    };
+  test("Enter adds a new column if none empty", async () => {
+    const question = baseQuestion();
+    question.columns = [
+      { id: "c1", label: { default: "Col 1" } },
+      { id: "c2", label: { default: "Col 2" } },
+    ];
+    const localSurvey = makeSurvey([langDefault]);
+    (localSurvey as any).questions = [question];
 
-    const { findAllByTestId } = render(<MatrixQuestionForm {...propsWithMinRows} />);
+    const updateQuestion = vi.fn();
 
-    // Try to delete rows until there are only 2 left
-    const deleteButtons = await findAllByTestId("tooltip-renderer");
-    await user.click(deleteButtons[0].querySelector("button") as HTMLButtonElement);
+    render(
+      <MatrixQuestionForm
+        localSurvey={localSurvey}
+        question={question}
+        questionIdx={0}
+        updateQuestion={updateQuestion}
+        isInvalid={false}
+        selectedLanguageCode="default"
+        setSelectedLanguageCode={vi.fn()}
+        locale="en-US"
+        isStorageConfigured={true}
+      />
+    );
 
-    // Try to delete another row, which should fail
-    vi.mocked(mockUpdateQuestion).mockClear();
-    await user.click(deleteButtons[1].querySelector("button") as HTMLButtonElement);
+    const colInput = screen.getByTestId("qfi-column-0");
+    await userEvent.type(colInput, "{enter}");
 
-    // The mockUpdateQuestion should not be called again
-    expect(mockUpdateQuestion).not.toHaveBeenCalled();
-  });
-
-  test("handles row input changes", async () => {
-    const user = userEvent.setup();
-    const { getByTestId } = render(<MatrixQuestionForm {...defaultProps} />);
-
-    const rowInput = getByTestId("input-row-0");
-    await user.clear(rowInput);
-    await user.type(rowInput, "New Row Label");
-
-    expect(mockUpdateQuestion).toHaveBeenCalled();
-  });
-
-  test("handles column input changes", async () => {
-    const user = userEvent.setup();
-    const { getByTestId } = render(<MatrixQuestionForm {...defaultProps} />);
-
-    const columnInput = getByTestId("input-column-0");
-    await user.clear(columnInput);
-    await user.type(columnInput, "New Column Label");
-
-    expect(mockUpdateQuestion).toHaveBeenCalled();
-  });
-
-  test("prevents deletion of a row used in logic", async () => {
-    const { findOptionUsedInLogic } = await import("@/modules/survey/editor/lib/utils");
-    vi.mocked(findOptionUsedInLogic).mockReturnValueOnce(1); // Mock that this row is used in logic
-
-    const user = userEvent.setup();
-    const { findAllByTestId } = render(<MatrixQuestionForm {...defaultProps} />);
-
-    const deleteButtons = await findAllByTestId("tooltip-renderer");
-    await user.click(deleteButtons[0].querySelector("button") as HTMLButtonElement);
-
-    expect(mockUpdateQuestion).not.toHaveBeenCalled();
-  });
-
-  test("prevents deletion of a column used in logic", async () => {
-    const { findOptionUsedInLogic } = await import("@/modules/survey/editor/lib/utils");
-    vi.mocked(findOptionUsedInLogic).mockReturnValueOnce(1); // Mock that this column is used in logic
-
-    const user = userEvent.setup();
-    const { findAllByTestId } = render(<MatrixQuestionForm {...defaultProps} />);
-
-    // Column delete buttons are after row delete buttons
-    const deleteButtons = await findAllByTestId("tooltip-renderer");
-    // Click the first column delete button (index 2)
-    await user.click(deleteButtons[2].querySelector("button") as HTMLButtonElement);
-
-    expect(mockUpdateQuestion).not.toHaveBeenCalled();
+    expect(updateQuestion).toHaveBeenCalledTimes(1);
+    const [, payload] = updateQuestion.mock.calls[0];
+    expect(payload.columns.length).toBe(3);
+    expect(payload.columns[2]).toEqual(
+      expect.objectContaining({ id: expect.any(String), label: expect.objectContaining({ default: "" }) })
+    );
   });
 });

--- a/apps/web/modules/survey/editor/components/matrix-question-form.tsx
+++ b/apps/web/modules/survey/editor/components/matrix-question-form.tsx
@@ -265,7 +265,6 @@ export const MatrixQuestionForm = ({
                       isStorageConfigured={isStorageConfigured}
                       shouldFocus={row.id === focusRowId}
                       onFocused={() => setFocusRowId(null)}
-                      onRequestFocus={(id) => setFocusRowId(id)}
                     />
                   ))}
                 </div>
@@ -314,7 +313,6 @@ export const MatrixQuestionForm = ({
                       isStorageConfigured={isStorageConfigured}
                       shouldFocus={column.id === focusColumnId}
                       onFocused={() => setFocusColumnId(null)}
-                      onRequestFocus={(id) => setFocusColumnId(id)}
                     />
                   ))}
                 </div>

--- a/apps/web/modules/survey/editor/components/matrix-question-form.tsx
+++ b/apps/web/modules/survey/editor/components/matrix-question-form.tsx
@@ -136,7 +136,6 @@ export const MatrixQuestionForm = ({
       }
     }
 
-    // Handle Arrow Up key
     if (e.key === "ArrowUp") {
       e.preventDefault();
       if (currentIndex > 0) {

--- a/apps/web/modules/survey/editor/components/matrix-question-form.tsx
+++ b/apps/web/modules/survey/editor/components/matrix-question-form.tsx
@@ -45,17 +45,24 @@ export const MatrixQuestionForm = ({
   const languageCodes = extractLanguageCodes(localSurvey.languages);
   const { t } = useTranslate();
 
+  const focusItem = (targetIdx: number, type: "row" | "column") => {
+    const input = document.querySelector(`input[id="${type}-${targetIdx}"]`) as HTMLInputElement;
+    if (input) input.focus();
+  };
+
   // Function to add a new Label input field
   const handleAddLabel = (type: "row" | "column") => {
     if (type === "row") {
       const updatedRows = [...question.rows, { id: createId(), label: createI18nString("", languageCodes) }];
       updateQuestion(questionIdx, { rows: updatedRows });
+      setTimeout(() => focusItem(updatedRows.length - 1, type), 0);
     } else {
       const updatedColumns = [
         ...question.columns,
         { id: createId(), label: createI18nString("", languageCodes) },
       ];
       updateQuestion(questionIdx, { columns: updatedColumns });
+      setTimeout(() => focusItem(updatedColumns.length - 1, type), 0);
     }
   };
 
@@ -115,31 +122,26 @@ export const MatrixQuestionForm = ({
   const handleKeyDown = (e: React.KeyboardEvent, type: "row" | "column", currentIndex: number) => {
     const items = type === "row" ? question.rows : question.columns;
 
-    const focusItem = (targetIdx: number) => {
-      const input = document.querySelector(`input[id="${type}-${targetIdx}"]`) as HTMLInputElement;
-      if (input) input.focus();
-    };
-
     if (e.key === "Enter") {
       e.preventDefault();
       if (currentIndex === items.length - 1) {
         handleAddLabel(type);
       } else {
-        focusItem(currentIndex + 1);
+        focusItem(currentIndex + 1, type);
       }
     }
 
     if (e.key === "ArrowDown") {
       e.preventDefault();
       if (currentIndex + 1 < items.length) {
-        focusItem(currentIndex + 1);
+        focusItem(currentIndex + 1, type);
       }
     }
 
     if (e.key === "ArrowUp") {
       e.preventDefault();
       if (currentIndex > 0) {
-        focusItem(currentIndex - 1);
+        focusItem(currentIndex - 1, type);
       }
     }
   };

--- a/apps/web/modules/survey/editor/components/matrix-sortable-item.tsx
+++ b/apps/web/modules/survey/editor/components/matrix-sortable-item.tsx
@@ -5,7 +5,6 @@ import { CSS } from "@dnd-kit/utilities";
 import { useTranslate } from "@tolgee/react";
 import { GripVerticalIcon, TrashIcon } from "lucide-react";
 import type { JSX } from "react";
-import { useEffect, useRef } from "react";
 import {
   TI18nString,
   TSurvey,
@@ -33,8 +32,6 @@ interface MatrixSortableItemProps {
   isInvalid: boolean;
   locale: TUserLocale;
   isStorageConfigured: boolean;
-  shouldFocus?: boolean;
-  onFocused?: () => void;
 }
 
 export const MatrixSortableItem = ({
@@ -52,24 +49,12 @@ export const MatrixSortableItem = ({
   isInvalid,
   locale,
   isStorageConfigured,
-  shouldFocus,
-  onFocused,
 }: MatrixSortableItemProps): JSX.Element => {
   const { t } = useTranslate();
 
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: choice.id,
   });
-
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (shouldFocus && inputRef.current) {
-      inputRef.current.focus();
-      onFocused?.();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldFocus]);
 
   const style = {
     transition: transition ?? "transform 100ms ease",
@@ -97,7 +82,6 @@ export const MatrixSortableItem = ({
           locale={locale}
           onKeyDown={onKeyDown}
           isStorageConfigured={isStorageConfigured}
-          externalInputRef={inputRef}
         />
         {canDelete && (
           <TooltipRenderer data-testid="tooltip-renderer" tooltipContent={t("common.delete")}>

--- a/apps/web/modules/survey/editor/components/matrix-sortable-item.tsx
+++ b/apps/web/modules/survey/editor/components/matrix-sortable-item.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { QuestionFormInput } from "@/modules/survey/components/question-form-input";
-import { Button } from "@/modules/ui/components/button";
-import { TooltipRenderer } from "@/modules/ui/components/tooltip";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useTranslate } from "@tolgee/react";
 import { GripVerticalIcon, TrashIcon } from "lucide-react";
 import type { JSX } from "react";
+import { useEffect, useRef } from "react";
 import {
   TI18nString,
   TSurvey,
@@ -15,6 +13,9 @@ import {
   TSurveyMatrixQuestionChoice,
 } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
+import { QuestionFormInput } from "@/modules/survey/components/question-form-input";
+import { Button } from "@/modules/ui/components/button";
+import { TooltipRenderer } from "@/modules/ui/components/tooltip";
 
 interface MatrixSortableItemProps {
   choice: TSurveyMatrixQuestionChoice;
@@ -32,6 +33,8 @@ interface MatrixSortableItemProps {
   isInvalid: boolean;
   locale: TUserLocale;
   isStorageConfigured: boolean;
+  shouldFocus?: boolean;
+  onFocused?: () => void;
 }
 
 export const MatrixSortableItem = ({
@@ -49,12 +52,24 @@ export const MatrixSortableItem = ({
   isInvalid,
   locale,
   isStorageConfigured,
+  shouldFocus,
+  onFocused,
 }: MatrixSortableItemProps): JSX.Element => {
   const { t } = useTranslate();
 
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({
     id: choice.id,
   });
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (shouldFocus && inputRef.current) {
+      inputRef.current.focus();
+      onFocused?.();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldFocus]);
 
   const style = {
     transition: transition ?? "transform 100ms ease",
@@ -82,6 +97,7 @@ export const MatrixSortableItem = ({
           locale={locale}
           onKeyDown={onKeyDown}
           isStorageConfigured={isStorageConfigured}
+          externalInputRef={inputRef}
         />
         {canDelete && (
           <TooltipRenderer data-testid="tooltip-renderer" tooltipContent={t("common.delete")}>

--- a/apps/web/modules/survey/editor/components/multiple-choice-question-form.test.tsx
+++ b/apps/web/modules/survey/editor/components/multiple-choice-question-form.test.tsx
@@ -72,7 +72,6 @@ describe("MultipleChoiceQuestionForm", () => {
         selectedLanguageCode="default"
         setSelectedLanguageCode={vi.fn()}
         locale="en-US"
-        lastQuestion={false}
         isStorageConfigured={true}
       />
     );

--- a/apps/web/modules/survey/editor/components/multiple-choice-question-form.tsx
+++ b/apps/web/modules/survey/editor/components/multiple-choice-question-form.tsx
@@ -51,7 +51,6 @@ export const MultipleChoiceQuestionForm = ({
   const lastChoiceRef = useRef<HTMLInputElement>(null);
   const [isNew, setIsNew] = useState(true);
   const [isInvalidValue, setisInvalidValue] = useState<string | null>(null);
-  const [focusChoiceId, setFocusChoiceId] = useState<string | null>(null);
 
   const questionRef = useRef<HTMLInputElement>(null);
   const surveyLanguageCodes = extractLanguageCodes(localSurvey.languages);
@@ -108,7 +107,6 @@ export const MultipleChoiceQuestionForm = ({
       newChoices.push(otherChoice);
     }
     updateQuestion(questionIdx, { choices: newChoices });
-    setFocusChoiceId(newChoice.id);
   };
 
   const addOther = () => {
@@ -268,9 +266,6 @@ export const MultipleChoiceQuestionForm = ({
                     surveyLanguageCodes={surveyLanguageCodes}
                     locale={locale}
                     isStorageConfigured={isStorageConfigured}
-                    shouldFocus={choice.id === focusChoiceId}
-                    onFocused={() => setFocusChoiceId(null)}
-                    onRequestFocus={(id) => setFocusChoiceId(id)}
                   />
                 ))}
               </div>

--- a/apps/web/modules/survey/editor/components/multiple-choice-question-form.tsx
+++ b/apps/web/modules/survey/editor/components/multiple-choice-question-form.tsx
@@ -1,12 +1,5 @@
 "use client";
 
-import { createI18nString, extractLanguageCodes } from "@/lib/i18n/utils";
-import { QuestionFormInput } from "@/modules/survey/components/question-form-input";
-import { QuestionOptionChoice } from "@/modules/survey/editor/components/question-option-choice";
-import { findOptionUsedInLogic } from "@/modules/survey/editor/lib/utils";
-import { Button } from "@/modules/ui/components/button";
-import { Label } from "@/modules/ui/components/label";
-import { ShuffleOptionSelect } from "@/modules/ui/components/shuffle-option-select";
 import { DndContext } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { useAutoAnimate } from "@formkit/auto-animate/react";
@@ -23,6 +16,13 @@ import {
   TSurveyQuestionTypeEnum,
 } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
+import { createI18nString, extractLanguageCodes } from "@/lib/i18n/utils";
+import { QuestionFormInput } from "@/modules/survey/components/question-form-input";
+import { QuestionOptionChoice } from "@/modules/survey/editor/components/question-option-choice";
+import { findOptionUsedInLogic } from "@/modules/survey/editor/lib/utils";
+import { Button } from "@/modules/ui/components/button";
+import { Label } from "@/modules/ui/components/label";
+import { ShuffleOptionSelect } from "@/modules/ui/components/shuffle-option-select";
 
 interface MultipleChoiceQuestionFormProps {
   localSurvey: TSurvey;
@@ -52,6 +52,7 @@ export const MultipleChoiceQuestionForm = ({
   const lastChoiceRef = useRef<HTMLInputElement>(null);
   const [isNew, setIsNew] = useState(true);
   const [isInvalidValue, setisInvalidValue] = useState<string | null>(null);
+  const [focusChoiceId, setFocusChoiceId] = useState<string | null>(null);
 
   const questionRef = useRef<HTMLInputElement>(null);
   const surveyLanguageCodes = extractLanguageCodes(localSurvey.languages);
@@ -108,6 +109,7 @@ export const MultipleChoiceQuestionForm = ({
       newChoices.push(otherChoice);
     }
     updateQuestion(questionIdx, { choices: newChoices });
+    setFocusChoiceId(newChoice.id);
   };
 
   const addOther = () => {
@@ -268,6 +270,8 @@ export const MultipleChoiceQuestionForm = ({
                       surveyLanguageCodes={surveyLanguageCodes}
                       locale={locale}
                       isStorageConfigured={isStorageConfigured}
+                      shouldFocus={choice.id === focusChoiceId}
+                      onFocused={() => setFocusChoiceId(null)}
                     />
                   ))}
               </div>

--- a/apps/web/modules/survey/editor/components/multiple-choice-question-form.tsx
+++ b/apps/web/modules/survey/editor/components/multiple-choice-question-form.tsx
@@ -29,7 +29,6 @@ interface MultipleChoiceQuestionFormProps {
   question: TSurveyMultipleChoiceQuestion;
   questionIdx: number;
   updateQuestion: (questionIdx: number, updatedAttributes: Partial<TSurveyMultipleChoiceQuestion>) => void;
-  lastQuestion: boolean;
   selectedLanguageCode: string;
   setSelectedLanguageCode: (language: string) => void;
   isInvalid: boolean;
@@ -250,30 +249,30 @@ export const MultipleChoiceQuestionForm = ({
             }}>
             <SortableContext items={question.choices} strategy={verticalListSortingStrategy}>
               <div className="flex flex-col gap-2" ref={parent}>
-                {question.choices &&
-                  question.choices.map((choice, choiceIdx) => (
-                    <QuestionOptionChoice
-                      key={choice.id}
-                      choice={choice}
-                      choiceIdx={choiceIdx}
-                      questionIdx={questionIdx}
-                      updateChoice={updateChoice}
-                      deleteChoice={deleteChoice}
-                      addChoice={addChoice}
-                      isInvalid={isInvalid}
-                      localSurvey={localSurvey}
-                      selectedLanguageCode={selectedLanguageCode}
-                      setSelectedLanguageCode={setSelectedLanguageCode}
-                      surveyLanguages={surveyLanguages}
-                      question={question}
-                      updateQuestion={updateQuestion}
-                      surveyLanguageCodes={surveyLanguageCodes}
-                      locale={locale}
-                      isStorageConfigured={isStorageConfigured}
-                      shouldFocus={choice.id === focusChoiceId}
-                      onFocused={() => setFocusChoiceId(null)}
-                    />
-                  ))}
+                {question.choices?.map((choice, choiceIdx) => (
+                  <QuestionOptionChoice
+                    key={choice.id}
+                    choice={choice}
+                    choiceIdx={choiceIdx}
+                    questionIdx={questionIdx}
+                    updateChoice={updateChoice}
+                    deleteChoice={deleteChoice}
+                    addChoice={addChoice}
+                    isInvalid={isInvalid}
+                    localSurvey={localSurvey}
+                    selectedLanguageCode={selectedLanguageCode}
+                    setSelectedLanguageCode={setSelectedLanguageCode}
+                    surveyLanguages={surveyLanguages}
+                    question={question}
+                    updateQuestion={updateQuestion}
+                    surveyLanguageCodes={surveyLanguageCodes}
+                    locale={locale}
+                    isStorageConfigured={isStorageConfigured}
+                    shouldFocus={choice.id === focusChoiceId}
+                    onFocused={() => setFocusChoiceId(null)}
+                    onRequestFocus={(id) => setFocusChoiceId(id)}
+                  />
+                ))}
               </div>
             </SortableContext>
           </DndContext>

--- a/apps/web/modules/survey/editor/components/question-card.tsx
+++ b/apps/web/modules/survey/editor/components/question-card.tsx
@@ -1,5 +1,21 @@
 "use client";
 
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useAutoAnimate } from "@formkit/auto-animate/react";
+import { Project } from "@prisma/client";
+import * as Collapsible from "@radix-ui/react-collapsible";
+import { useTranslate } from "@tolgee/react";
+import { ChevronDownIcon, ChevronRightIcon, GripIcon } from "lucide-react";
+import { useState } from "react";
+import {
+  TI18nString,
+  TSurvey,
+  TSurveyQuestion,
+  TSurveyQuestionId,
+  TSurveyQuestionTypeEnum,
+} from "@formbricks/types/surveys/types";
+import { TUserLocale } from "@formbricks/types/user";
 import { cn } from "@/lib/cn";
 import { recallToHeadline } from "@/lib/utils/recall";
 import { QuestionFormInput } from "@/modules/survey/components/question-form-input";
@@ -24,22 +40,6 @@ import { getQuestionIconMap, getTSurveyQuestionTypeEnumName } from "@/modules/su
 import { Alert, AlertButton, AlertTitle } from "@/modules/ui/components/alert";
 import { Label } from "@/modules/ui/components/label";
 import { Switch } from "@/modules/ui/components/switch";
-import { useSortable } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import { useAutoAnimate } from "@formkit/auto-animate/react";
-import { Project } from "@prisma/client";
-import * as Collapsible from "@radix-ui/react-collapsible";
-import { useTranslate } from "@tolgee/react";
-import { ChevronDownIcon, ChevronRightIcon, GripIcon } from "lucide-react";
-import { useState } from "react";
-import {
-  TI18nString,
-  TSurvey,
-  TSurveyQuestion,
-  TSurveyQuestionId,
-  TSurveyQuestionTypeEnum,
-} from "@formbricks/types/surveys/types";
-import { TUserLocale } from "@formbricks/types/user";
 
 interface QuestionCardProps {
   localSurvey: TSurvey;
@@ -301,7 +301,6 @@ export const QuestionCard = ({
               question={question}
               questionIdx={questionIdx}
               updateQuestion={updateQuestion}
-              lastQuestion={lastQuestion}
               selectedLanguageCode={selectedLanguageCode}
               setSelectedLanguageCode={setSelectedLanguageCode}
               isInvalid={isInvalid}
@@ -314,7 +313,6 @@ export const QuestionCard = ({
               question={question}
               questionIdx={questionIdx}
               updateQuestion={updateQuestion}
-              lastQuestion={lastQuestion}
               selectedLanguageCode={selectedLanguageCode}
               setSelectedLanguageCode={setSelectedLanguageCode}
               isInvalid={isInvalid}
@@ -453,7 +451,6 @@ export const QuestionCard = ({
               question={question}
               questionIdx={questionIdx}
               updateQuestion={updateQuestion}
-              lastQuestion={lastQuestion}
               selectedLanguageCode={selectedLanguageCode}
               setSelectedLanguageCode={setSelectedLanguageCode}
               isInvalid={isInvalid}

--- a/apps/web/modules/survey/editor/components/question-option-choice.test.tsx
+++ b/apps/web/modules/survey/editor/components/question-option-choice.test.tsx
@@ -76,25 +76,20 @@ describe("QuestionOptionChoice", () => {
     expect(addButton).toBeDefined();
   });
 
-  test("pressing Enter focuses existing empty option instead of adding", async () => {
+  test("pressing Enter on last choice adds a new choice", async () => {
     const addChoice = vi.fn();
-    const onRequestFocus = vi.fn();
-    const choice = { id: "choice1", label: { default: "Choice 1" } };
+    const choice = { id: "choice2", label: { default: "Choice 2" } };
     const question = {
       id: "question1",
       headline: { default: "Question 1" },
       type: TSurveyQuestionTypeEnum.MultipleChoiceSingle,
-      choices: [
-        choice,
-        { id: "choice2", label: { default: "" } },
-        { id: "other", label: { default: "Other" } },
-      ],
+      choices: [{ id: "choice1", label: { default: "Choice 1" } }, choice],
     } as any;
 
     render(
       <QuestionOptionChoice
         choice={choice}
-        choiceIdx={0}
+        choiceIdx={1}
         questionIdx={0}
         updateChoice={vi.fn()}
         deleteChoice={vi.fn()}
@@ -109,25 +104,23 @@ describe("QuestionOptionChoice", () => {
         surveyLanguageCodes={["default"]}
         locale="en-US"
         isStorageConfigured={true}
-        onRequestFocus={onRequestFocus}
       />
     );
 
     const input = screen.getByTestId("question-form-input");
     await userEvent.type(input, "{enter}");
 
-    expect(onRequestFocus).toHaveBeenCalledWith("choice2");
-    expect(addChoice).not.toHaveBeenCalled();
+    expect(addChoice).toHaveBeenCalledWith(1);
   });
 
-  test("pressing Enter adds a new option when none are empty", async () => {
+  test("pressing Enter on non-last choice focuses next choice", async () => {
     const addChoice = vi.fn();
     const choice = { id: "choice1", label: { default: "Choice 1" } };
     const question = {
       id: "question1",
       headline: { default: "Question 1" },
       type: TSurveyQuestionTypeEnum.MultipleChoiceSingle,
-      choices: [choice, { id: "choice2", label: { default: "Filled" } }],
+      choices: [choice, { id: "choice2", label: { default: "Choice 2" } }],
     } as any;
 
     render(
@@ -154,7 +147,8 @@ describe("QuestionOptionChoice", () => {
     const input = screen.getByTestId("question-form-input");
     await userEvent.type(input, "{enter}");
 
-    expect(addChoice).toHaveBeenCalledWith(0);
+    // Should not add a new choice (not the last one)
+    expect(addChoice).not.toHaveBeenCalled();
   });
 
   test("should call deleteChoice when the 'Delete choice' button is clicked for a standard choice", async () => {

--- a/apps/web/modules/survey/editor/components/question-option-choice.tsx
+++ b/apps/web/modules/survey/editor/components/question-option-choice.tsx
@@ -108,19 +108,23 @@ export const QuestionOptionChoice = ({
               input?.focus();
             };
 
-            // Handle Enter key
+            const addChoiceAndFocus = (idx: number) => {
+              addChoice(idx);
+              // Wait for DOM update before focusing the new input
+              setTimeout(() => focusChoiceInput(idx + 1), 0);
+            };
+
             if (e.key === "Enter" && choice.id !== "other") {
               e.preventDefault();
               const lastChoiceIdx = question.choices.findLastIndex((c) => c.id !== "other");
 
               if (choiceIdx === lastChoiceIdx) {
-                addChoice(choiceIdx);
+                addChoiceAndFocus(choiceIdx);
               } else {
                 focusChoiceInput(choiceIdx + 1);
               }
             }
 
-            // Handle Arrow Down key
             if (e.key === "ArrowDown") {
               e.preventDefault();
               if (choiceIdx + 1 < question.choices.length) {
@@ -128,7 +132,6 @@ export const QuestionOptionChoice = ({
               }
             }
 
-            // Handle Arrow Up key
             if (e.key === "ArrowUp") {
               e.preventDefault();
               if (choiceIdx > 0) {
@@ -184,6 +187,13 @@ export const QuestionOptionChoice = ({
               onClick={(e) => {
                 e.preventDefault();
                 addChoice(choiceIdx);
+                // Wait for DOM update before focusing the new input
+                setTimeout(() => {
+                  const input = document.querySelector(
+                    `input[id="choice-${choiceIdx + 1}"]`
+                  ) as HTMLInputElement;
+                  input?.focus();
+                }, 0);
               }}>
               <PlusIcon />
             </Button>

--- a/apps/web/modules/survey/editor/components/question-option-choice.tsx
+++ b/apps/web/modules/survey/editor/components/question-option-choice.tsx
@@ -72,6 +72,17 @@ export const QuestionOptionChoice = ({
     transform: CSS.Translate.toString(transform),
   };
 
+  const focusChoiceInput = (targetIdx: number) => {
+    const input = document.querySelector(`input[id="choice-${targetIdx}"]`) as HTMLInputElement;
+    input?.focus();
+  };
+
+  const addChoiceAndFocus = (idx: number) => {
+    addChoice(idx);
+    // Wait for DOM update before focusing the new input
+    setTimeout(() => focusChoiceInput(idx + 1), 0);
+  };
+
   return (
     <div className="flex w-full items-center gap-2" ref={setNodeRef} style={style}>
       {/* drag handle */}
@@ -102,18 +113,6 @@ export const QuestionOptionChoice = ({
           locale={locale}
           isStorageConfigured={isStorageConfigured}
           onKeyDown={(e) => {
-            const focusChoiceInput = (targetIdx: number) => {
-              // Use native DOM to focus sibling inputs without prop drilling
-              const input = document.querySelector(`input[id="choice-${targetIdx}"]`) as HTMLInputElement;
-              input?.focus();
-            };
-
-            const addChoiceAndFocus = (idx: number) => {
-              addChoice(idx);
-              // Wait for DOM update before focusing the new input
-              setTimeout(() => focusChoiceInput(idx + 1), 0);
-            };
-
             if (e.key === "Enter" && choice.id !== "other") {
               e.preventDefault();
               const lastChoiceIdx = question.choices.findLastIndex((c) => c.id !== "other");
@@ -186,14 +185,7 @@ export const QuestionOptionChoice = ({
               aria-label="Add choice below"
               onClick={(e) => {
                 e.preventDefault();
-                addChoice(choiceIdx);
-                // Wait for DOM update before focusing the new input
-                setTimeout(() => {
-                  const input = document.querySelector(
-                    `input[id="choice-${choiceIdx + 1}"]`
-                  ) as HTMLInputElement;
-                  input?.focus();
-                }, 0);
+                addChoiceAndFocus(choiceIdx);
               }}>
               <PlusIcon />
             </Button>

--- a/apps/web/modules/survey/editor/components/ranking-question-form.test.tsx
+++ b/apps/web/modules/survey/editor/components/ranking-question-form.test.tsx
@@ -88,7 +88,6 @@ describe("RankingQuestionForm", () => {
         selectedLanguageCode="default"
         setSelectedLanguageCode={mockSetSelectedLanguageCode}
         locale={mockLocale}
-        lastQuestion={false}
         isStorageConfigured={true}
       />
     );
@@ -135,7 +134,6 @@ describe("RankingQuestionForm", () => {
         selectedLanguageCode="default"
         setSelectedLanguageCode={mockSetSelectedLanguageCode}
         locale={mockLocale}
-        lastQuestion={false}
         isStorageConfigured={true}
       />
     );
@@ -190,7 +188,6 @@ describe("RankingQuestionForm", () => {
         selectedLanguageCode="en"
         setSelectedLanguageCode={mockSetSelectedLanguageCode}
         locale={mockLocale}
-        lastQuestion={false}
         isStorageConfigured={true}
       />
     );

--- a/apps/web/modules/survey/editor/components/ranking-question-form.tsx
+++ b/apps/web/modules/survey/editor/components/ranking-question-form.tsx
@@ -1,11 +1,5 @@
 "use client";
 
-import { createI18nString, extractLanguageCodes } from "@/lib/i18n/utils";
-import { QuestionFormInput } from "@/modules/survey/components/question-form-input";
-import { QuestionOptionChoice } from "@/modules/survey/editor/components/question-option-choice";
-import { Button } from "@/modules/ui/components/button";
-import { Label } from "@/modules/ui/components/label";
-import { ShuffleOptionSelect } from "@/modules/ui/components/shuffle-option-select";
 import { DndContext } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { useAutoAnimate } from "@formkit/auto-animate/react";
@@ -15,13 +9,18 @@ import { PlusIcon } from "lucide-react";
 import { type JSX, useEffect, useRef, useState } from "react";
 import { TI18nString, TSurvey, TSurveyRankingQuestion } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
+import { createI18nString, extractLanguageCodes } from "@/lib/i18n/utils";
+import { QuestionFormInput } from "@/modules/survey/components/question-form-input";
+import { QuestionOptionChoice } from "@/modules/survey/editor/components/question-option-choice";
+import { Button } from "@/modules/ui/components/button";
+import { Label } from "@/modules/ui/components/label";
+import { ShuffleOptionSelect } from "@/modules/ui/components/shuffle-option-select";
 
 interface RankingQuestionFormProps {
   localSurvey: TSurvey;
   question: TSurveyRankingQuestion;
   questionIdx: number;
   updateQuestion: (questionIdx: number, updatedAttributes: Partial<TSurveyRankingQuestion>) => void;
-  lastQuestion: boolean;
   selectedLanguageCode: string;
   setSelectedLanguageCode: (language: string) => void;
   isInvalid: boolean;
@@ -43,6 +42,7 @@ export const RankingQuestionForm = ({
   const { t } = useTranslate();
   const lastChoiceRef = useRef<HTMLInputElement>(null);
   const [isInvalidValue, setIsInvalidValue] = useState<string | null>(null);
+  const [focusChoiceId, setFocusChoiceId] = useState<string | null>(null);
 
   const surveyLanguageCodes = extractLanguageCodes(localSurvey.languages);
   const surveyLanguages = localSurvey.languages ?? [];
@@ -69,6 +69,7 @@ export const RankingQuestionForm = ({
     updateQuestion(questionIdx, {
       choices: [...newChoices.slice(0, choiceIdx + 1), newChoice, ...newChoices.slice(choiceIdx + 1)],
     });
+    setFocusChoiceId(newChoice.id);
   };
 
   const addOption = () => {
@@ -84,6 +85,7 @@ export const RankingQuestionForm = ({
     };
 
     updateQuestion(questionIdx, { choices: [...choices, newChoice] });
+    setFocusChoiceId(newChoice.id);
   };
 
   const deleteChoice = (choiceIdx: number) => {
@@ -195,28 +197,30 @@ export const RankingQuestionForm = ({
             }}>
             <SortableContext items={question.choices} strategy={verticalListSortingStrategy}>
               <div className="flex flex-col gap-2" ref={parent}>
-                {question.choices &&
-                  question.choices.map((choice, choiceIdx) => (
-                    <QuestionOptionChoice
-                      key={choice.id}
-                      choice={choice}
-                      choiceIdx={choiceIdx}
-                      questionIdx={questionIdx}
-                      updateChoice={updateChoice}
-                      deleteChoice={deleteChoice}
-                      addChoice={addChoice}
-                      isInvalid={isInvalid}
-                      localSurvey={localSurvey}
-                      selectedLanguageCode={selectedLanguageCode}
-                      setSelectedLanguageCode={setSelectedLanguageCode}
-                      surveyLanguages={surveyLanguages}
-                      question={question}
-                      updateQuestion={updateQuestion}
-                      surveyLanguageCodes={surveyLanguageCodes}
-                      locale={locale}
-                      isStorageConfigured={isStorageConfigured}
-                    />
-                  ))}
+                {question.choices?.map((choice, choiceIdx) => (
+                  <QuestionOptionChoice
+                    key={choice.id}
+                    choice={choice}
+                    choiceIdx={choiceIdx}
+                    questionIdx={questionIdx}
+                    updateChoice={updateChoice}
+                    deleteChoice={deleteChoice}
+                    addChoice={addChoice}
+                    isInvalid={isInvalid}
+                    localSurvey={localSurvey}
+                    selectedLanguageCode={selectedLanguageCode}
+                    setSelectedLanguageCode={setSelectedLanguageCode}
+                    surveyLanguages={surveyLanguages}
+                    question={question}
+                    updateQuestion={updateQuestion}
+                    surveyLanguageCodes={surveyLanguageCodes}
+                    locale={locale}
+                    isStorageConfigured={isStorageConfigured}
+                    shouldFocus={choice.id === focusChoiceId}
+                    onFocused={() => setFocusChoiceId(null)}
+                    onRequestFocus={(id) => setFocusChoiceId(id)}
+                  />
+                ))}
               </div>
             </SortableContext>
           </DndContext>

--- a/apps/web/modules/survey/editor/components/ranking-question-form.tsx
+++ b/apps/web/modules/survey/editor/components/ranking-question-form.tsx
@@ -42,7 +42,6 @@ export const RankingQuestionForm = ({
   const { t } = useTranslate();
   const lastChoiceRef = useRef<HTMLInputElement>(null);
   const [isInvalidValue, setIsInvalidValue] = useState<string | null>(null);
-  const [focusChoiceId, setFocusChoiceId] = useState<string | null>(null);
 
   const surveyLanguageCodes = extractLanguageCodes(localSurvey.languages);
   const surveyLanguages = localSurvey.languages ?? [];
@@ -69,7 +68,6 @@ export const RankingQuestionForm = ({
     updateQuestion(questionIdx, {
       choices: [...newChoices.slice(0, choiceIdx + 1), newChoice, ...newChoices.slice(choiceIdx + 1)],
     });
-    setFocusChoiceId(newChoice.id);
   };
 
   const addOption = () => {
@@ -85,7 +83,6 @@ export const RankingQuestionForm = ({
     };
 
     updateQuestion(questionIdx, { choices: [...choices, newChoice] });
-    setFocusChoiceId(newChoice.id);
   };
 
   const deleteChoice = (choiceIdx: number) => {
@@ -216,9 +213,6 @@ export const RankingQuestionForm = ({
                     surveyLanguageCodes={surveyLanguageCodes}
                     locale={locale}
                     isStorageConfigured={isStorageConfigured}
-                    shouldFocus={choice.id === focusChoiceId}
-                    onFocused={() => setFocusChoiceId(null)}
-                    onRequestFocus={(id) => setFocusChoiceId(id)}
                   />
                 ))}
               </div>


### PR DESCRIPTION
As requested by GetUp, you can now hit ENTER when typing options in Single & Multi Select Questions. If there are empty options, it jumps to the next empty option. If there are no empty options, it creates a new one and readjusts focus.

This makes survey creation faster & smoother.

This applies to:

- Single select
- Multi select
- Ranking and
- Matrix (Cols & Rows)

Additionally, the PR removes the unused "lastQuestion" prop and fixes a few SonarQube issues in the related files.