### PR TITLE
fix: switch Manage Subscription button bg to stripe color

### DIFF
--- a/apps/web/modules/ee/billing/components/pricing-card.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-card.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { cn } from "@/lib/cn";
-import { Badge } from "@/modules/ui/components/badge";
-import { Button } from "@/modules/ui/components/button";
-import { ConfirmationModal } from "@/modules/ui/components/confirmation-modal";
 import { useTranslate } from "@tolgee/react";
 import { CheckIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import { TOrganization, TOrganizationBillingPeriod } from "@formbricks/types/organizations";
+import { cn } from "@/lib/cn";
+import { Badge } from "@/modules/ui/components/badge";
+import { Button } from "@/modules/ui/components/button";
+import { ConfirmationModal } from "@/modules/ui/components/confirmation-modal";
 import { TPricingPlan } from "../api/lib/constants";
 
 interface PricingCardProps {
@@ -177,7 +177,7 @@ export const PricingCard = ({
                 await onManageSubscription();
                 setLoading(false);
               }}
-              className="flex justify-center">
+              className="flex justify-center bg-[#635bff]">
               {t("environments.settings.billing.manage_subscription")}
             </Button>
           )}

--- a/apps/web/modules/ee/billing/components/pricing-card.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-card.tsx
@@ -170,7 +170,6 @@ export const PricingCard = ({
 
           {plan.id !== projectFeatureKeys.FREE && isCurrentPlan && (
             <Button
-              variant="secondary"
               loading={loading}
               onClick={async () => {
                 setLoading(true);


### PR DESCRIPTION
Problem: Customers couldn't find where to manage their subscription:

<img width="1564" height="512" alt="image" src="https://github.com/user-attachments/assets/d1b15f01-887c-43fb-b50b-73be3f87beec" />

Changed bg to Stripe color: Purple with white text

After 

<img width="621" height="344" alt="Screenshot 2025-10-01 at 5 06 47 PM" src="https://github.com/user-attachments/assets/8c571a7d-958d-4329-bc6d-7efd56d2c28a" />
