### PR TITLE
perf: reduce cache TTL to 1 minute for SDK environment state and segments

### DIFF
--- a/apps/web/app/api/v1/client/[environmentId]/environment/lib/environmentState.test.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/environment/lib/environmentState.test.ts
@@ -1,9 +1,3 @@
-import { cache } from "@/lib/cache";
-import { getMonthlyOrganizationResponseCount } from "@/lib/organization/service";
-import {
-  capturePosthogEnvironmentEvent,
-  sendPlanLimitsReachedEventToPosthogWeekly,
-} from "@/lib/posthogServer";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
@@ -12,6 +6,12 @@ import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { TJsEnvironmentState, TJsEnvironmentStateProject } from "@formbricks/types/js";
 import { TOrganization } from "@formbricks/types/organizations";
 import { TSurvey } from "@formbricks/types/surveys/types";
+import { cache } from "@/lib/cache";
+import { getMonthlyOrganizationResponseCount } from "@/lib/organization/service";
+import {
+  capturePosthogEnvironmentEvent,
+  sendPlanLimitsReachedEventToPosthogWeekly,
+} from "@/lib/posthogServer";
 import { EnvironmentStateData, getEnvironmentStateData } from "./data";
 import { getEnvironmentState } from "./environmentState";
 
@@ -285,7 +285,7 @@ describe("getEnvironmentState", () => {
     expect(cache.withCache).toHaveBeenCalledWith(
       expect.any(Function),
       "fb:env:test-environment-id:state",
-      5 * 60 * 1000 // 5 minutes in milliseconds
+      60 * 1000 // 1 minutes in milliseconds
     );
   });
 

--- a/apps/web/app/api/v1/client/[environmentId]/environment/lib/environmentState.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/environment/lib/environmentState.ts
@@ -1,4 +1,8 @@
 import "server-only";
+import { createCacheKey } from "@formbricks/cache";
+import { prisma } from "@formbricks/database";
+import { logger } from "@formbricks/logger";
+import { TJsEnvironmentState } from "@formbricks/types/js";
 import { cache } from "@/lib/cache";
 import { IS_FORMBRICKS_CLOUD, IS_RECAPTCHA_CONFIGURED, RECAPTCHA_SITE_KEY } from "@/lib/constants";
 import { getMonthlyOrganizationResponseCount } from "@/lib/organization/service";
@@ -6,10 +10,6 @@ import {
   capturePosthogEnvironmentEvent,
   sendPlanLimitsReachedEventToPosthogWeekly,
 } from "@/lib/posthogServer";
-import { createCacheKey } from "@formbricks/cache";
-import { prisma } from "@formbricks/database";
-import { logger } from "@formbricks/logger";
-import { TJsEnvironmentState } from "@formbricks/types/js";
 import { getEnvironmentStateData } from "./data";
 
 /**
@@ -80,6 +80,6 @@ export const getEnvironmentState = async (
       return { data };
     },
     createCacheKey.environment.state(environmentId),
-    5 * 60 * 1000 // 5 minutes in milliseconds
+    60 * 1000 // 1 minutes in milliseconds
   );
 };

--- a/apps/web/modules/ee/contacts/api/v1/client/[environmentId]/user/lib/segments.ts
+++ b/apps/web/modules/ee/contacts/api/v1/client/[environmentId]/user/lib/segments.ts
@@ -1,6 +1,3 @@
-import { cache } from "@/lib/cache";
-import { validateInputs } from "@/lib/utils/validate";
-import { evaluateSegment } from "@/modules/ee/contacts/segments/lib/segments";
 import { Prisma } from "@prisma/client";
 import { cache as reactCache } from "react";
 import { createCacheKey } from "@formbricks/cache";
@@ -9,6 +6,9 @@ import { logger } from "@formbricks/logger";
 import { ZId, ZString } from "@formbricks/types/common";
 import { DatabaseError } from "@formbricks/types/errors";
 import { TBaseFilter } from "@formbricks/types/segment";
+import { cache } from "@/lib/cache";
+import { validateInputs } from "@/lib/utils/validate";
+import { evaluateSegment } from "@/modules/ee/contacts/segments/lib/segments";
 
 export const getSegments = reactCache(
   async (environmentId: string) =>
@@ -34,7 +34,7 @@ export const getSegments = reactCache(
         }
       },
       createCacheKey.environment.segments(environmentId),
-      5 * 60 * 1000 // 5 minutes in milliseconds
+      60 * 1000 // 1 minutes in milliseconds
     )
 );
 


### PR DESCRIPTION
## Summary
This PR reduces the cache time-to-live from **5 minutes to 1 minute** for environment state and segments endpoints used by SDKs and in-product surveys.

## Motivation
Improves user experience by providing faster feedback when testing surveys and integrations, reducing the delay between making changes and seeing them reflected.

## What Changed
- ✅ Reduced cache TTL from 5 minutes to 1 minute in `environmentState.ts`
- ✅ Updated corresponding test in `environmentState.test.ts`
- ✅ Reduced cache TTL from 5 minutes to 1 minute in `segments.ts`

## Experiment Goals
This is an **experiment** to:
1. Measure the impact on server load from increased cache miss rate
2. Evaluate whether caching is necessary at these endpoints
3. Determine if the system can effectively handle increased request frequency without server-side caching

## Testing
- Existing tests updated to reflect new cache TTL
- All tests passing with the new configuration

## Notes
If this experiment shows acceptable server load, we may consider reducing the TTL further or removing caching entirely for these endpoints to provide real-time updates to users.