### PR TITLE
ci(e2e): disable rate limiting and set CI environment variable

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -181,6 +181,12 @@ jobs:
           fi
           echo "License key length: ${#LICENSE_KEY}"
 
+      - name: Disable rate limiting for E2E tests
+        run: |
+          echo "RATE_LIMITING_DISABLED=1" >> .env
+          echo "Rate limiting disabled for E2E tests"
+        shell: bash
+
       - name: Run App
         run: |
           echo "Starting app with enterprise license..."
@@ -222,11 +228,14 @@ jobs:
         if: env.AZURE_ENABLED == 'true'
         env:
           PLAYWRIGHT_SERVICE_URL: ${{ secrets.PLAYWRIGHT_SERVICE_URL }}
+          CI: true
         run: |
           pnpm test-e2e:azure
 
       - name: Run E2E Tests (Local)
         if: env.AZURE_ENABLED == 'false'
+        env:
+          CI: true
         run: |
           pnpm test:e2e
 


### PR DESCRIPTION
## Changes

- Disable rate limiting for E2E tests to prevent test failures caused by rate limits
- Set CI environment variable for Playwright to optimize test execution in CI environment
- Apply to both Azure and local E2E test runs

## Why

E2E tests were failing due to rate limiting. This PR adds a new step to disable rate limiting specifically for E2E tests and sets the `CI` environment variable for Playwright, which enables optimizations for CI environments.