### PR TITLE
feat: Add language as default contact attribute for case-insensitive CSV matching

### DIFF
--- a/apps/web/lib/environment/service.ts
+++ b/apps/web/lib/environment/service.ts
@@ -168,6 +168,12 @@ export const createEnvironment = async (
               description: "Your contact's last name",
               type: "default",
             },
+            {
+              key: "language",
+              name: "Language",
+              description: "The language preference of a contact",
+              type: "default",
+            },
           ],
         },
       },

--- a/apps/web/modules/ee/contacts/components/upload-contacts-button.tsx
+++ b/apps/web/modules/ee/contacts/components/upload-contacts-button.tsx
@@ -1,5 +1,11 @@
 "use client";
 
+import { useTranslate } from "@tolgee/react";
+import { parse } from "csv-parse/sync";
+import { ArrowUpFromLineIcon, FileUpIcon, PlusIcon } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { TContactAttributeKey } from "@formbricks/types/contact-attribute-key";
 import { cn } from "@/lib/cn";
 import { isStringMatch } from "@/lib/utils/helper";
 import { createContactsFromCSVAction } from "@/modules/ee/contacts/actions";
@@ -18,12 +24,6 @@ import {
   DialogTitle,
 } from "@/modules/ui/components/dialog";
 import { StylingTabs } from "@/modules/ui/components/styling-tabs";
-import { useTranslate } from "@tolgee/react";
-import { parse } from "csv-parse/sync";
-import { ArrowUpFromLineIcon, FileUpIcon, PlusIcon } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { TContactAttributeKey } from "@formbricks/types/contact-attribute-key";
 
 interface UploadContactsCSVButtonProps {
   environmentId: string;

--- a/apps/web/modules/ee/contacts/lib/contacts.test.ts
+++ b/apps/web/modules/ee/contacts/lib/contacts.test.ts
@@ -319,6 +319,51 @@ describe("createContactsFromCSV", () => {
       createContactsFromCSV(csvData, environmentId, "skip", { email: "email", name: "name" })
     ).rejects.toThrow(genericError);
   });
+
+  test("handles language attribute key like other default attributes", async () => {
+    vi.mocked(prisma.contact.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.contactAttribute.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.contactAttributeKey.findMany).mockResolvedValue([
+      { key: "email", id: "id-email" },
+      { key: "userId", id: "id-userId" },
+      { key: "firstName", id: "id-firstName" },
+      { key: "lastName", id: "id-lastName" },
+      { key: "language", id: "id-language" },
+    ] as any);
+    vi.mocked(prisma.contact.create).mockResolvedValue({
+      id: "c1",
+      environmentId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      attributes: [
+        { attributeKey: { key: "email" }, value: "john@example.com" },
+        { attributeKey: { key: "userId" }, value: "user123" },
+        { attributeKey: { key: "firstName" }, value: "John" },
+        { attributeKey: { key: "lastName" }, value: "Doe" },
+        { attributeKey: { key: "language" }, value: "en" },
+      ],
+    } as any);
+    const csvData = [
+      {
+        email: "john@example.com",
+        userId: "user123",
+        firstName: "John",
+        lastName: "Doe",
+        language: "en",
+      },
+    ];
+    const result = await createContactsFromCSV(csvData, environmentId, "skip", {
+      email: "email",
+      userId: "userId",
+      firstName: "firstName",
+      lastName: "lastName",
+      language: "language",
+    });
+    expect(Array.isArray(result)).toBe(true);
+    expect(result[0].id).toBe("c1");
+    // language attribute key should already exist, no need to create it
+    expect(prisma.contactAttributeKey.createMany).not.toHaveBeenCalled();
+  });
 });
 
 describe("buildContactWhereClause", () => {

--- a/packages/database/migration/20251016000000_add_language_attribute_key/migration.ts
+++ b/packages/database/migration/20251016000000_add_language_attribute_key/migration.ts
@@ -1,0 +1,60 @@
+/* eslint-disable no-constant-condition -- Required for the while loop */
+/* eslint-disable @typescript-eslint/no-unnecessary-condition -- Required for a while loop here */
+import { createId } from "@paralleldrive/cuid2";
+import { logger } from "@formbricks/logger";
+import type { MigrationScript } from "../../src/scripts/migration-runner";
+
+export const addLanguageAttributeKey: MigrationScript = {
+  type: "data",
+  id: "add_language_attribute_key_v1",
+  name: "20251016000000_add_language_attribute_key",
+  run: async ({ tx }) => {
+    const BATCH_SIZE = 1000;
+    let skip = 0;
+    let totalProcessed = 0;
+
+    logger.info("Starting migration to add language attribute key to environments");
+
+    while (true) {
+      // Fetch environments in batches
+      const environments = await tx.$queryRaw<{ id: string }[]>`
+        SELECT id FROM "Environment" 
+        LIMIT ${BATCH_SIZE} OFFSET ${skip}
+      `;
+
+      if (environments.length === 0) {
+        break;
+      }
+
+      logger.info(`Processing ${environments.length.toString()} environments`);
+
+      // Process each environment
+      for (const env of environments) {
+        // Insert language attribute key if it doesn't exist
+        await tx.$executeRaw`
+          INSERT INTO "ContactAttributeKey" (
+            "id", "created_at", "updated_at", "key", "name", "description", "type", "isUnique", "environmentId"
+          ) VALUES (
+            ${createId()}, 
+            NOW(), 
+            NOW(), 
+            'language', 
+            'Language', 
+            'The language preference of a contact', 
+            'default', 
+            false, 
+            ${env.id}
+          )
+          ON CONFLICT ("key", "environmentId") DO NOTHING
+        `;
+      }
+
+      totalProcessed += environments.length;
+      skip += BATCH_SIZE;
+
+      logger.info(`Processed ${totalProcessed.toString()} environments so far`);
+    }
+
+    logger.info(`Migration completed. Total environments processed: ${totalProcessed.toString()}`);
+  },
+};


### PR DESCRIPTION
## Problem
The CSV upload feature was case-sensitive for the `language` column. When users uploaded CSVs with "Language" (capital L), it would create a new custom attribute instead of mapping to the language attribute.

## Root Cause
`language` was NOT a default attribute key - only `userId`, `email`, `firstName`, and `lastName` were created as default attributes when environments were initialized.

## Solution
Added `language` as a default attribute key, making it work consistently with other default attributes through the existing case-insensitive matching logic.

## Changes
- ✅ Add `language` as a default attribute key in environment creation
- ✅ Create data migration to add `language` attribute key to existing environments  
- ✅ Update tests to verify `language` is treated like other default attributes
- ✅ All 6829 unit tests passing
- ✅ Build successful

## Why This Approach?
✅ **Proper Separation of Concerns**: Default attribute keys are defined in the environment service + database  
✅ **No Hardcoding**: No hardcoded list of default keys in the UI component  
✅ **Consistent with Existing Pattern**: `language` is now treated exactly like `userId`, `email`, `firstName`, `lastName`  
✅ **Backward Compatible**: Migration ensures existing environments get the `language` attribute key  
✅ **Maintainable**: If we add more default attributes in the future, we just add them to the environment service

## Testing
Tested with CSV files containing:
- `language` (lowercase) ✅
- `Language` (capital L) ✅ 
- `LANGUAGE` (all caps) ✅

All variations now correctly map to the `language` attribute without creating duplicates.

Fixes #[issue-number]

## Before
<img width="750" height="649" alt="image" src="https://github.com/user-attachments/assets/00477d94-cc5b-4315-b48c-490b5d34b4d5" />

## After
<img width="659" height="551" alt="image" src="https://github.com/user-attachments/assets/8cd5d756-85f5-48a4-86e7-4ea1f6ccd7d2" />

