### PR TITLE
fix: resolve inconsistency between data accepted by API and displaying it

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/lib/surveySummary.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/lib/surveySummary.ts
@@ -322,12 +322,10 @@ export const getQuestionSummary = async (
         let values: TSurveyQuestionSummaryOpenText["samples"] = [];
         responses.forEach((response) => {
           const answer = response.data[question.id];
-          // Handle both string and array formats (API can send either)
           let normalizedAnswer: string | null = null;
           if (typeof answer === "string" && answer) {
             normalizedAnswer = answer;
           } else if (Array.isArray(answer) && answer.length > 0) {
-            // Join array values with ", " to match Response Card behavior
             normalizedAnswer = answer.filter((v) => v != null && v !== "").join(", ");
           }
 


### PR DESCRIPTION
### Problem

The Management API accepts data in an Array also for open text questions:

<img width="471" height="187" alt="image" src="https://github.com/user-attachments/assets/d45fc133-6f73-4549-a2c9-0a5f1b7893e7" />

The Summary View didn't show it but the Response View did.

### Solution
Use the same approach we use on the Response Card

<img width="903" height="381" alt="image" src="https://github.com/user-attachments/assets/9ee192db-6001-458f-b811-afb9302c4eb0" />

