### PR TITLE
fix: breadcrumb dropdown active state and loading indicators

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/components/organization-breadcrumb.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/components/organization-breadcrumb.tsx
@@ -10,7 +10,7 @@ import {
   SettingsIcon,
 } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { logger } from "@formbricks/logger";
 import { CreateOrganizationModal } from "@/modules/organization/components/CreateOrganizationModal";
@@ -59,12 +59,8 @@ export const OrganizationBreadcrumb = ({
   const [openCreateOrganizationModal, setOpenCreateOrganizationModal] = useState(false);
   const pathname = usePathname();
   const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
+  const [isPending, startTransition] = useTransition();
   const currentOrganization = organizations.find((org) => org.id === currentOrganizationId);
-
-  useEffect(() => {
-    setIsLoading(false);
-  }, [pathname]);
 
   if (!currentOrganization) {
     const errorMessage = `Organization not found for organization id: ${currentOrganizationId}`;
@@ -75,17 +71,19 @@ export const OrganizationBreadcrumb = ({
 
   const handleOrganizationChange = (organizationId: string) => {
     if (organizationId === currentOrganizationId) return;
-    setIsLoading(true);
-    router.push(`/organizations/${organizationId}/`);
+    startTransition(() => {
+      router.push(`/organizations/${organizationId}/`);
+    });
   };
 
   // Hide organization dropdown for single org setups (on-premise)
   const showOrganizationDropdown = isMultiOrgEnabled || organizations.length > 1;
 
   const handleSettingChange = (href: string) => {
-    setIsLoading(true);
-    setIsOrganizationDropdownOpen(false);
-    router.push(href);
+    startTransition(() => {
+      setIsOrganizationDropdownOpen(false);
+      router.push(href);
+    });
   };
 
   const organizationSettings = [
@@ -129,7 +127,7 @@ export const OrganizationBreadcrumb = ({
           <div className="flex items-center gap-1">
             <BuildingIcon className="h-3 w-3" strokeWidth={1.5} />
             <span>{currentOrganization.name}</span>
-            {isLoading && <Loader2 className="h-3 w-3 animate-spin" strokeWidth={1.5} />}
+            {isPending && <Loader2 className="h-3 w-3 animate-spin" strokeWidth={1.5} />}
             {isOrganizationDropdownOpen ? (
               <ChevronDownIcon className="h-3 w-3" strokeWidth={1.5} />
             ) : (

--- a/apps/web/app/(app)/environments/[environmentId]/components/project-breadcrumb.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/components/project-breadcrumb.tsx
@@ -3,7 +3,7 @@
 import * as Sentry from "@sentry/nextjs";
 import { ChevronDownIcon, ChevronRightIcon, CogIcon, FolderOpenIcon, Loader2, PlusIcon } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { logger } from "@formbricks/logger";
 import { CreateProjectModal } from "@/modules/projects/components/create-project-modal";
@@ -59,12 +59,8 @@ export const ProjectBreadcrumb = ({
   const [openCreateProjectModal, setOpenCreateProjectModal] = useState(false);
   const [openLimitModal, setOpenLimitModal] = useState(false);
   const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
+  const [isPending, startTransition] = useTransition();
   const pathname = usePathname();
-
-  useEffect(() => {
-    setIsLoading(false);
-  }, [pathname]);
 
   const projectSettings = [
     {
@@ -115,8 +111,9 @@ export const ProjectBreadcrumb = ({
 
   const handleProjectChange = (projectId: string) => {
     if (projectId === currentProjectId) return;
-    setIsLoading(true);
-    router.push(`/projects/${projectId}/`);
+    startTransition(() => {
+      router.push(`/projects/${projectId}/`);
+    });
   };
 
   const handleAddProject = () => {
@@ -128,8 +125,9 @@ export const ProjectBreadcrumb = ({
   };
 
   const handleProjectSettingsNavigation = (settingId: string) => {
-    setIsLoading(true);
-    router.push(`/environments/${currentEnvironmentId}/project/${settingId}`);
+    startTransition(() => {
+      router.push(`/environments/${currentEnvironmentId}/project/${settingId}`);
+    });
   };
 
   const LimitModalButtons = (): [ModalButton, ModalButton] => {
@@ -169,7 +167,7 @@ export const ProjectBreadcrumb = ({
           <div className="flex items-center gap-1">
             <FolderOpenIcon className="h-3 w-3" strokeWidth={1.5} />
             <span>{currentProject.name}</span>
-            {isLoading && <Loader2 className="h-3 w-3 animate-spin" strokeWidth={1.5} />}
+            {isPending && <Loader2 className="h-3 w-3 animate-spin" strokeWidth={1.5} />}
             {isProjectDropdownOpen ? (
               <ChevronDownIcon className="h-3 w-3" strokeWidth={1.5} />
             ) : (


### PR DESCRIPTION
Fix [breadcrumb dropdown issue where organization and project settings showed incorrect active states:](https://github.com/formbricks/internal/issues/1105)

FIXES:
- Replace substring matching (pathname.includes) with precise path pattern matching
- Organization settings now only highlight in org breadcrumb (/settings/{id})
- Project settings now only highlight in project breadcrumb (/project/{id})
- Account settings (/settings/(account)/{id}) no longer show in either dropdown

CHANGES:
- Add isActiveOrganizationSetting() helper to organization-breadcrumb.tsx
  * Matches /settings/{settingId} pattern only
  * Excludes account settings paths
- Add isActiveProjectSetting() helper to project-breadcrumb.tsx
  * Matches /project/{settingId} pattern only
  * Excludes settings paths
  * Handles sub-pages like /project/integrations/slack

UX IMPROVEMENTS:
- Add loading indicators for all breadcrumb navigation actions
- Loading spinner appears during page navigation
- Loading state resets automatically when pathname changes
- Add handleSettingChange() to organization breadcrumb
- Add handleProjectSettingsNavigation() to project breadcrumb
- Dropdowns close automatically when navigating (org settings)

TESTING:
- All 71 breadcrumb component tests pass
- No linting errors
- Verified with comprehensive path matching test cases