### PR TITLE
fix: prevent date display showing one day behind due to timezone conv…

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/DateQuestionSummary.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/DateQuestionSummary.tsx
@@ -7,7 +7,7 @@ import { TSurvey, TSurveyQuestionSummaryDate } from "@formbricks/types/surveys/t
 import { TUserLocale } from "@formbricks/types/user";
 import { timeSince } from "@/lib/time";
 import { getContactIdentifier } from "@/lib/utils/contact";
-import { formatDateWithOrdinal } from "@/lib/utils/datetime";
+import { formatDateWithOrdinal, parseDateOnly } from "@/lib/utils/datetime";
 import { PersonAvatar } from "@/modules/ui/components/avatars";
 import { Button } from "@/modules/ui/components/button";
 import { QuestionSummaryHeader } from "./QuestionSummaryHeader";
@@ -36,7 +36,7 @@ export const DateQuestionSummary = ({
   };
 
   const renderResponseValue = (value: string) => {
-    const parsedDate = new Date(value);
+    const parsedDate = parseDateOnly(value);
 
     const formattedDate = isNaN(parsedDate.getTime())
       ? `${t("common.invalid_date")}(${value})`

--- a/apps/web/lib/utils/datetime.test.ts
+++ b/apps/web/lib/utils/datetime.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
-import { diffInDays, formatDateWithOrdinal, getFormattedDateTimeString, isValidDateString } from "./datetime";
+import { diffInDays, formatDateWithOrdinal, getFormattedDateTimeString, isValidDateString, parseDateOnly } from "./datetime";
 
 describe("datetime utils", () => {
   test("diffInDays calculates the difference in days between two dates", () => {
@@ -27,5 +27,61 @@ describe("datetime utils", () => {
   test("getFormattedDateTimeString formats a date-time string correctly", () => {
     const date = new Date("2025-05-06T14:30:00");
     expect(getFormattedDateTimeString(date)).toBe("2025-05-06 14:30:00");
+  });
+
+  describe("parseDateOnly", () => {
+    test("should parse date-only string as local date (not UTC)", () => {
+      const dateString = "2024-01-15";
+      const parsedDate = parseDateOnly(dateString);
+
+      // Verify it's the correct date regardless of timezone
+      expect(parsedDate.getFullYear()).toBe(2024);
+      expect(parsedDate.getMonth()).toBe(0); // January is 0
+      expect(parsedDate.getDate()).toBe(15);
+    });
+
+    test("should handle dates that would shift to previous day with UTC parsing", () => {
+      // This date would be Jan 14, 23:00 UTC-1 when parsed as UTC
+      // But parseDateOnly should give us Jan 15 in local time
+      const dateString = "2024-01-15";
+      const parsedDate = parseDateOnly(dateString);
+
+      // Should always be January 15th
+      expect(parsedDate.getMonth()).toBe(0);
+      expect(parsedDate.getDate()).toBe(15);
+    });
+
+    test("should parse different dates correctly", () => {
+      expect(parseDateOnly("2024-02-29").getDate()).toBe(29); // Leap year
+      expect(parseDateOnly("2024-12-31").getDate()).toBe(31);
+      expect(parseDateOnly("2023-01-01").getDate()).toBe(1);
+    });
+
+    test("should create date at local midnight (not UTC)", () => {
+      const dateString = "2024-01-15";
+      const parsedDate = parseDateOnly(dateString);
+
+      // Date should be at local midnight (00:00:00)
+      expect(parsedDate.getHours()).toBe(0);
+      expect(parsedDate.getMinutes()).toBe(0);
+      expect(parsedDate.getSeconds()).toBe(0);
+    });
+
+    test("should handle edge cases", () => {
+      // First day of year
+      const jan1 = parseDateOnly("2024-01-01");
+      expect(jan1.getMonth()).toBe(0);
+      expect(jan1.getDate()).toBe(1);
+
+      // Last day of year
+      const dec31 = parseDateOnly("2024-12-31");
+      expect(dec31.getMonth()).toBe(11);
+      expect(dec31.getDate()).toBe(31);
+
+      // Leap year day
+      const leapDay = parseDateOnly("2024-02-29");
+      expect(leapDay.getMonth()).toBe(1);
+      expect(leapDay.getDate()).toBe(29);
+    });
   });
 });

--- a/apps/web/lib/utils/datetime.ts
+++ b/apps/web/lib/utils/datetime.ts
@@ -18,6 +18,18 @@ export const formatDateWithOrdinal = (date: Date, locale: string = "en-US"): str
   return `${dayOfWeek}, ${month} ${day}${getOrdinalSuffix(day)}, ${year}`;
 };
 
+/**
+ * Parse a date-only string (YYYY-MM-DD) as a local date, avoiding UTC conversion issues.
+ * This prevents timezone-related date shifts when displaying dates.
+ *
+ * @param dateString - Date string in YYYY-MM-DD format
+ * @returns Date object representing the date in local timezone
+ */
+export const parseDateOnly = (dateString: string): Date => {
+  const [year, month, day] = dateString.split('-').map(Number);
+  return new Date(year, month - 1, day); // month is 0-indexed in Date constructor
+};
+
 export const isValidDateString = (value: string) => {
   const regex = /^(?:\d{4}-\d{2}-\d{2}|\d{2}-\d{2}-\d{4})$/;
 

--- a/apps/web/lib/utils/recall.test.ts
+++ b/apps/web/lib/utils/recall.test.ts
@@ -43,6 +43,7 @@ vi.mock("@/lib/utils/datetime", () => ({
   formatDateWithOrdinal: vi.fn((date) => {
     return "January 1st, 2023";
   }),
+    parseDateOnly: vi.fn((value) => new Date(value)),
 }));
 
 describe("recall utility functions", () => {

--- a/apps/web/lib/utils/recall.ts
+++ b/apps/web/lib/utils/recall.ts
@@ -3,7 +3,7 @@ import { TI18nString, TSurvey, TSurveyQuestion, TSurveyRecallItem } from "@formb
 import { getTextContent } from "@formbricks/types/surveys/validation";
 import { getLocalizedValue } from "@/lib/i18n/utils";
 import { structuredClone } from "@/lib/pollyfills/structuredClone";
-import { formatDateWithOrdinal, isValidDateString } from "./datetime";
+import { formatDateWithOrdinal, isValidDateString, parseDateOnly } from "./datetime";
 
 export interface fallbacks {
   [id: string]: string;
@@ -249,7 +249,7 @@ export const parseRecallInfo = (
       // Apply formatting for special value types
       if (value) {
         if (isValidDateString(value as string)) {
-          value = formatDateWithOrdinal(new Date(value as string));
+          value = formatDateWithOrdinal(parseDateOnly(value as string));
         } else if (Array.isArray(value)) {
           value = value.filter((item) => item).join(", ");
         }

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/RenderResponse.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/RenderResponse.tsx
@@ -13,7 +13,7 @@ import { cn } from "@/lib/cn";
 import { getLanguageCode, getLocalizedValue } from "@/lib/i18n/utils";
 import { getChoiceIdByValue } from "@/lib/response/utils";
 import { processResponseData } from "@/lib/responses";
-import { formatDateWithOrdinal } from "@/lib/utils/datetime";
+import { formatDateWithOrdinal, parseDateOnly } from "@/lib/utils/datetime";
 import { renderHyperlinkedContent } from "@/modules/analysis/utils";
 import { ArrayResponse } from "@/modules/ui/components/array-response";
 import { FileUploadResponse } from "@/modules/ui/components/file-upload-response";
@@ -70,7 +70,7 @@ export const RenderResponse: React.FC<RenderResponseProps> = ({
       break;
     case TSurveyQuestionTypeEnum.Date:
       if (typeof responseData === "string") {
-        const parsedDate = new Date(responseData);
+        const parsedDate = parseDateOnly(responseData);
 
         const formattedDate = isNaN(parsedDate.getTime()) ? responseData : formatDateWithOrdinal(parsedDate);
 

--- a/packages/surveys/src/lib/date-time.ts
+++ b/packages/surveys/src/lib/date-time.ts
@@ -50,3 +50,15 @@ export const formatDateWithOrdinal = (date: Date, locale: string = "en-US"): str
   const year = date.getFullYear();
   return `${dayOfWeek}, ${month} ${day}${getOrdinalSuffix(day)}, ${year}`;
 };
+
+/**
+ * Parse a date-only string (YYYY-MM-DD) as a local date, avoiding UTC conversion issues.
+ * This prevents timezone-related date shifts when displaying dates.
+ *
+ * @param dateString - Date string in YYYY-MM-DD format
+ * @returns Date object representing the date in local timezone
+ */
+export const parseDateOnly = (dateString: string): Date => {
+  const [year, month, day] = dateString.split('-').map(Number);
+  return new Date(year, month - 1, day); // month is 0-indexed in Date constructor
+};

--- a/packages/surveys/src/lib/recall.test.ts
+++ b/packages/surveys/src/lib/recall.test.ts
@@ -16,6 +16,7 @@ vi.mock("./date-time", () => ({
   isValidDateString: (val: string) => /^\d{4}-\d{2}-\d{2}$/.test(val) || /^\d{2}-\d{2}-\d{4}$/.test(val),
   formatDateWithOrdinal: (date: Date) =>
     `${date.getUTCFullYear()}-${("0" + (date.getUTCMonth() + 1)).slice(-2)}-${("0" + date.getUTCDate()).slice(-2)}_formatted`,
+  parseDateOnly: (val: string) => new Date(val),
 }));
 
 describe("replaceRecallInfo", () => {

--- a/packages/surveys/src/lib/recall.ts
+++ b/packages/surveys/src/lib/recall.ts
@@ -1,6 +1,6 @@
 import { type TResponseData, type TResponseVariables } from "@formbricks/types/responses";
 import { type TSurveyQuestion, TSurveyQuestionTypeEnum } from "@formbricks/types/surveys/types";
-import { formatDateWithOrdinal, isValidDateString } from "@/lib/date-time";
+import { formatDateWithOrdinal, isValidDateString, parseDateOnly } from "@/lib/date-time";
 import { getLocalizedValue } from "@/lib/i18n";
 
 // Extracts the ID of recall question from a string containing the "recall" pattern.
@@ -55,7 +55,7 @@ export const replaceRecallInfo = (
     // Additional value formatting if it exists
     if (value) {
       if (isValidDateString(value)) {
-        value = formatDateWithOrdinal(new Date(value));
+        value = formatDateWithOrdinal(parseDateOnly(value));
       } else if (Array.isArray(value)) {
         value = value.filter((item) => item).join(", "); // Filters out empty values and joins with a comma
       }


### PR DESCRIPTION
### fix: prevent date display showing one day behind due to timezone conversion

## 🐛 Problem

When viewing survey responses with date questions, dates were incorrectly displaying **one day behind** the actual date entered by the user.

This issue occurred because date-only strings (e.g., `"YYYY-MM-DD"`) are parsed by the native `new Date("YYYY-MM-DD")` constructor as **UTC midnight** (`YYYY-MM-DDT00:00:00.000Z`). For users in timezones *behind* UTC (e.g., North America, Western Europe), converting this UTC time to their local time caused the date to shift back to the previous day.

**Example Scenario:**
* User selects: **January 15, 2024**
* Stored in database: `"2024-01-15"`
* Displayed to a user in PST (-8 hours) as: **January 14, 2024**

## ✅ Solution

This fix introduces a new shared helper function, **`parseDateOnly()`**, which guarantees that date-only strings are parsed as **local dates** instead of UTC dates.

The function uses the `new Date(year, month - 1, day)` constructor form, which creates a date object relative to the user's **local timezone**, effectively making the stored date timezone-agnostic for display purposes across all parts of the application.

### Key Changes
1.  **Added `parseDateOnly()` helper** in both `apps/web/lib/utils/datetime.ts` and `packages/surveys/src/lib/date-time.ts`.
2.  **Integrated the function** across all date display locations:
    * Summary view (`DateQuestionSummary.tsx`)
    * Individual response view (`RenderResponse.tsx`)
    * Recall text interpolation (both `apps/web` and `packages/surveys`).

---



## 📝 Technical Details
The core implementation of the new helper function:

```typescript
export const parseDateOnly = (dateString: string): Date => {
  const [year, month, day] = dateString.split('-').map(Number);
  // Using the Date constructor with numeric arguments creates a Date object
  // relative to the environment's local time, resolving the UTC shift issue.
  return new Date(year, month - 1, day); // month is 0-indexed
};