### PR TITLE
fix: remove hardcoded 'public' schema from migrations and add IF EXISTS guards

### DIFF
--- a/packages/database/migration/20250904145727_removes_cron_and_survey_scheduling/migration.sql
+++ b/packages/database/migration/20250904145727_removes_cron_and_survey_scheduling/migration.sql
@@ -8,19 +8,19 @@
 */
 
 -- Update any scheduled surveys to paused
-UPDATE "public"."Survey" SET "status" = 'paused' WHERE "status" = 'scheduled';
+UPDATE "Survey" SET "status" = 'paused' WHERE "status" = 'scheduled';
 
 -- AlterEnum
 BEGIN;
-CREATE TYPE "public"."SurveyStatus_new" AS ENUM ('draft', 'inProgress', 'paused', 'completed');
-ALTER TABLE "public"."Survey" ALTER COLUMN "status" DROP DEFAULT;
-ALTER TABLE "public"."Survey" ALTER COLUMN "status" TYPE "public"."SurveyStatus_new" USING ("status"::text::"public"."SurveyStatus_new");
-ALTER TYPE "public"."SurveyStatus" RENAME TO "SurveyStatus_old";
-ALTER TYPE "public"."SurveyStatus_new" RENAME TO "SurveyStatus";
-DROP TYPE "public"."SurveyStatus_old";
-ALTER TABLE "public"."Survey" ALTER COLUMN "status" SET DEFAULT 'draft';
+CREATE TYPE "SurveyStatus_new" AS ENUM ('draft', 'inProgress', 'paused', 'completed');
+ALTER TABLE "Survey" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "Survey" ALTER COLUMN "status" TYPE "SurveyStatus_new" USING ("status"::text::"SurveyStatus_new");
+ALTER TYPE "SurveyStatus" RENAME TO "SurveyStatus_old";
+ALTER TYPE "SurveyStatus_new" RENAME TO "SurveyStatus";
+DROP TYPE "SurveyStatus_old";
+ALTER TABLE "Survey" ALTER COLUMN "status" SET DEFAULT 'draft';
 COMMIT;
 
 -- AlterTable
-ALTER TABLE "public"."Survey" DROP COLUMN "closeOnDate",
+ALTER TABLE "Survey" DROP COLUMN "closeOnDate",
 DROP COLUMN "runOnDate";

--- a/packages/database/migration/20250911192630_remove_deprecated_fields_and_tables/migration.sql
+++ b/packages/database/migration/20250911192630_remove_deprecated_fields_and_tables/migration.sql
@@ -20,88 +20,88 @@
 */
 -- AlterEnum
 BEGIN;
-CREATE TYPE "public"."SurveyType_new" AS ENUM ('link', 'app');
-ALTER TABLE "public"."Survey" ALTER COLUMN "type" DROP DEFAULT;
-ALTER TABLE "public"."Survey" ALTER COLUMN "type" TYPE "public"."SurveyType_new" USING ("type"::text::"public"."SurveyType_new");
-ALTER TYPE "public"."SurveyType" RENAME TO "SurveyType_old";
-ALTER TYPE "public"."SurveyType_new" RENAME TO "SurveyType";
-DROP TYPE "public"."SurveyType_old";
-ALTER TABLE "public"."Survey" ALTER COLUMN "type" SET DEFAULT 'app';
+CREATE TYPE "SurveyType_new" AS ENUM ('link', 'app');
+ALTER TABLE "Survey" ALTER COLUMN "type" DROP DEFAULT;
+ALTER TABLE "Survey" ALTER COLUMN "type" TYPE "SurveyType_new" USING ("type"::text::"SurveyType_new");
+ALTER TYPE "SurveyType" RENAME TO "SurveyType_old";
+ALTER TYPE "SurveyType_new" RENAME TO "SurveyType";
+DROP TYPE "SurveyType_old";
+ALTER TABLE "Survey" ALTER COLUMN "type" SET DEFAULT 'app';
 COMMIT;
 
 -- DropForeignKey
-ALTER TABLE "public"."Document" DROP CONSTRAINT "Document_environmentId_fkey";
+ALTER TABLE IF EXISTS "Document" DROP CONSTRAINT IF EXISTS "Document_environmentId_fkey";
 
 -- DropForeignKey
-ALTER TABLE "public"."Document" DROP CONSTRAINT "Document_responseId_fkey";
+ALTER TABLE IF EXISTS "Document" DROP CONSTRAINT IF EXISTS "Document_responseId_fkey";
 
 -- DropForeignKey
-ALTER TABLE "public"."Document" DROP CONSTRAINT "Document_surveyId_fkey";
+ALTER TABLE IF EXISTS "Document" DROP CONSTRAINT IF EXISTS "Document_surveyId_fkey";
 
 -- DropForeignKey
-ALTER TABLE "public"."DocumentInsight" DROP CONSTRAINT "DocumentInsight_documentId_fkey";
+ALTER TABLE IF EXISTS "DocumentInsight" DROP CONSTRAINT IF EXISTS "DocumentInsight_documentId_fkey";
 
 -- DropForeignKey
-ALTER TABLE "public"."DocumentInsight" DROP CONSTRAINT "DocumentInsight_insightId_fkey";
+ALTER TABLE IF EXISTS "DocumentInsight" DROP CONSTRAINT IF EXISTS "DocumentInsight_insightId_fkey";
 
 -- DropForeignKey
-ALTER TABLE "public"."Insight" DROP CONSTRAINT "Insight_environmentId_fkey";
+ALTER TABLE IF EXISTS "Insight" DROP CONSTRAINT IF EXISTS "Insight_environmentId_fkey";
 
 -- DropIndex
-DROP INDEX "public"."Display_responseId_key";
+DROP INDEX IF EXISTS "Display_responseId_key";
 
 -- AlterTable
-ALTER TABLE "public"."Display" DROP COLUMN "responseId",
-DROP COLUMN "status";
+ALTER TABLE "Display" DROP COLUMN IF EXISTS "responseId",
+DROP COLUMN IF EXISTS "status";
 
 -- AlterTable
-ALTER TABLE "public"."Environment" DROP COLUMN "widgetSetupCompleted";
+ALTER TABLE "Environment" DROP COLUMN IF EXISTS "widgetSetupCompleted";
 
 -- AlterTable
-ALTER TABLE "public"."Invite" DROP COLUMN "deprecatedRole";
+ALTER TABLE "Invite" DROP COLUMN IF EXISTS "deprecatedRole";
 
 -- AlterTable
-ALTER TABLE "public"."Membership" DROP COLUMN "deprecatedRole";
+ALTER TABLE "Membership" DROP COLUMN IF EXISTS "deprecatedRole";
 
 -- AlterTable
-ALTER TABLE "public"."Project" DROP COLUMN "brandColor",
-DROP COLUMN "highlightBorderColor";
+ALTER TABLE "Project" DROP COLUMN IF EXISTS "brandColor",
+DROP COLUMN IF EXISTS "highlightBorderColor";
 
 -- AlterTable
-ALTER TABLE "public"."Survey" DROP COLUMN "thankYouCard",
-DROP COLUMN "verifyEmail",
+ALTER TABLE "Survey" DROP COLUMN IF EXISTS "thankYouCard",
+DROP COLUMN IF EXISTS "verifyEmail",
 ALTER COLUMN "type" SET DEFAULT 'app';
 
 -- AlterTable
-ALTER TABLE "public"."User" DROP COLUMN "objective",
-DROP COLUMN "role";
+ALTER TABLE "User" DROP COLUMN IF EXISTS "objective",
+DROP COLUMN IF EXISTS "role";
 
 -- DropTable
-DROP TABLE "public"."Document";
+DROP TABLE IF EXISTS "Document";
 
 -- DropTable
-DROP TABLE "public"."DocumentInsight";
+DROP TABLE IF EXISTS "DocumentInsight";
 
 -- DropTable
-DROP TABLE "public"."Insight";
+DROP TABLE IF EXISTS "Insight";
 
 -- DropEnum
-DROP TYPE "public"."DisplayStatus";
+DROP TYPE IF EXISTS "DisplayStatus";
 
 -- DropEnum
-DROP TYPE "public"."InsightCategory";
+DROP TYPE IF EXISTS "InsightCategory";
 
 -- DropEnum
-DROP TYPE "public"."Intention";
+DROP TYPE IF EXISTS "Intention";
 
 -- DropEnum
-DROP TYPE "public"."MembershipRole";
+DROP TYPE IF EXISTS "MembershipRole";
 
 -- DropEnum
-DROP TYPE "public"."Objective";
+DROP TYPE IF EXISTS "Objective";
 
 -- DropEnum
-DROP TYPE "public"."Role";
+DROP TYPE IF EXISTS "Role";
 
 -- DropEnum
-DROP TYPE "public"."Sentiment";
+DROP TYPE IF EXISTS "Sentiment";

--- a/packages/database/migration/20251008104151_api_key_v2/migration.sql
+++ b/packages/database/migration/20251008104151_api_key_v2/migration.sql
@@ -1,9 +1,9 @@
 -- DropIndex
-DROP INDEX IF EXISTS "public"."ApiKey_hashedKey_key";
+DROP INDEX IF EXISTS "ApiKey_hashedKey_key";
 
 -- AlterTable
-ALTER TABLE "public"."ApiKey" ADD COLUMN IF NOT EXISTS "lookupHash" TEXT;
+ALTER TABLE "ApiKey" ADD COLUMN IF NOT EXISTS "lookupHash" TEXT;
 
 -- CreateIndex
-CREATE UNIQUE INDEX IF NOT EXISTS "ApiKey_lookupHash_key" ON "public"."ApiKey"("lookupHash");
+CREATE UNIQUE INDEX IF NOT EXISTS "ApiKey_lookupHash_key" ON "ApiKey"("lookupHash");
 


### PR DESCRIPTION
## Problem

When upgrading self-hosted Formbricks from v3.16.1 to v4.0.1, migrations fail for deployments using a custom PostgreSQL schema (e.g., `DATABASE_URL="postgresql://...?schema=formbricks"`).

Three migrations contained hardcoded `"public"` schema references, causing them to fail when the database uses a different schema name. Additionally, several DROP statements lacked `IF EXISTS` guards, causing failures when tables/types didn't exist in certain migration paths.

This blocked legitimate upgrades for self-hosted users—a supported configuration in Formbricks.

## Root Cause

**Prisma Migrate behavior change:** Between 2023 and 2025, Prisma started generating migrations with explicit `"public"` schema qualifiers for certain operations (enum alterations, DROP statements). Compare:

- ✅ **2023 migration** (working): `CREATE TYPE "SurveyStatus_new" AS ENUM (...)`
- ❌ **2025 migration** (broken): `CREATE TYPE "public"."SurveyStatus_new" AS ENUM (...)`

When schemas are explicitly qualified with `"public"`, PostgreSQL ignores the connection string's `?schema=` parameter, breaking custom schema deployments.

## Changes Made

### 1. Removed hardcoded `"public"` schema references

**Files affected:**
- `packages/database/migration/20250904145727_removes_cron_and_survey_scheduling/migration.sql`
- `packages/database/migration/20250911192630_remove_deprecated_fields_and_tables/migration.sql`
- `packages/database/migration/20251008104151_api_key_v2/migration.sql`

**Changes:**
- Replaced `"public"."TableName"` → `"TableName"`
- Replaced `"public"."TypeName"` → `"TypeName"`

This allows PostgreSQL to use the schema specified in `DATABASE_URL` via the search path.

### 2. Added `IF EXISTS` guards to DROP statements

In `20250911192630_remove_deprecated_fields_and_tables/migration.sql`:
- Added `IF EXISTS` to all `DROP TABLE`, `DROP TYPE`, `DROP INDEX`, and `DROP CONSTRAINT` statements
- Added `IF EXISTS` to `DROP COLUMN` statements in `ALTER TABLE` operations

This prevents migration failures when objects don't exist (e.g., databases that never had the `Document` table).

## Testing

✅ **Before fix:** Migrations fail with `P3009` error on custom schemas  
✅ **After fix:** Migrations respect the schema specified in `DATABASE_URL`  
✅ **Backward compatible:** Works correctly with default `public` schema

## Impact

- **Fixes:** Self-hosted deployments using custom PostgreSQL schemas can now upgrade
- **Scope:** Migration-only changes—no application code affected
- **Risk:** Minimal—removes incorrect hardcoding, adds safety guards

Closes #6747

---

### Commit Details

```
fix: remove hardcoded 'public' schema from migrations and add IF EXISTS guards

- Remove hardcoded 'public' schema references from three migrations
- Add IF EXISTS guards to DROP statements to prevent failures
- Fixes migration failures for self-hosted deployments using custom PostgreSQL schemas
```