### PR TITLE
fix: copy recontact options when copying surveys between environments

### DIFF
--- a/apps/web/modules/survey/editor/components/recontact-options-card.tsx
+++ b/apps/web/modules/survey/editor/components/recontact-options-card.tsx
@@ -114,7 +114,12 @@ export const RecontactOptionsCard = ({ localSurvey, setLocalSurvey }: RecontactO
   };
 
   const handleOverwriteDaysChange = (event) => {
-    const value = Number(event.target.value);
+    let value = Number(event.target.value);
+    if (Number.isNaN(value) || value < 1) {
+      value = 1;
+    } else if (value > 365) {
+      value = 365;
+    }
     setInputDays(value);
 
     const updatedSurvey = { ...localSurvey, recontactDays: value };
@@ -122,7 +127,10 @@ export const RecontactOptionsCard = ({ localSurvey, setLocalSurvey }: RecontactO
   };
 
   const handleDisplayLimitChange = (event) => {
-    const value = Number(event.target.value);
+    let value = Number(event.target.value);
+    if (Number.isNaN(value) || value < 1) {
+      value = 1;
+    }
     setDisplayLimit(value);
 
     const updatedSurvey = { ...localSurvey, displayLimit: value } satisfies TSurvey;
@@ -210,6 +218,7 @@ export const RecontactOptionsCard = ({ localSurvey, setLocalSurvey }: RecontactO
                         <Input
                           type="number"
                           min="1"
+                          max="365"
                           id="overwriteDays"
                           value={inputDays}
                           onChange={handleOverwriteDaysChange}

--- a/apps/web/modules/survey/list/lib/survey.test.ts
+++ b/apps/web/modules/survey/list/lib/survey.test.ts
@@ -428,6 +428,9 @@ const mockExistingSurveyDetails = {
   styling: { theme: {} },
   segment: null,
   followUps: [{ name: "Follow Up 1", trigger: {}, action: {} }],
+  displayOption: "respondMultiple" as any,
+  recontactDays: 7,
+  displayLimit: 5,
   triggers: [
     {
       actionClass: {
@@ -752,6 +755,42 @@ describe("copySurveyToOtherEnvironment", () => {
       expect.objectContaining({
         data: expect.objectContaining({
           triggers: { create: [] },
+        }),
+      })
+    );
+  });
+
+  test("should copy recontact options (displayOption, recontactDays, displayLimit)", async () => {
+    await copySurveyToOtherEnvironment(environmentId, surveyId, targetEnvironmentId, userId);
+
+    expect(prisma.survey.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          displayOption: "respondMultiple",
+          recontactDays: 7,
+          displayLimit: 5,
+        }),
+      })
+    );
+  });
+
+  test("should copy recontact options with null values", async () => {
+    const surveyWithNullRecontact = {
+      ...mockExistingSurveyDetails,
+      displayOption: "displayOnce" as any,
+      recontactDays: null,
+      displayLimit: null,
+    };
+    vi.mocked(prisma.survey.findUnique).mockResolvedValue(surveyWithNullRecontact as any);
+
+    await copySurveyToOtherEnvironment(environmentId, surveyId, targetEnvironmentId, userId);
+
+    expect(prisma.survey.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          displayOption: "displayOnce",
+          recontactDays: null,
+          displayLimit: null,
         }),
       })
     );

--- a/apps/web/modules/survey/list/lib/survey.ts
+++ b/apps/web/modules/survey/list/lib/survey.ts
@@ -258,6 +258,9 @@ const getExistingSurvey = async (surveyId: string) => {
       styling: true,
       segment: true,
       followUps: true,
+      displayOption: true,
+      recontactDays: true,
+      displayLimit: true,
       triggers: {
         select: {
           actionClass: {


### PR DESCRIPTION
## Changes
- Fixed bug where recontact options (displayOption, recontactDays, displayLimit) were not copied when copying surveys between environments
- Added validation to clamp recontact days input between 1-365 to prevent invalid values

fixes https://github.com/formbricks/internal/issues/955

## Testing
- All existing tests pass (35 tests in survey.test.ts)
- Added 2 new tests to verify recontact options are copied correctly
- All 452 survey module tests pass