### PR TITLE
fix: include responseStatus filter in active filter count display

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/ResponseFilter.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/ResponseFilter.tsx
@@ -217,7 +217,7 @@ export const ResponseFilter = ({ survey }: ResponseFilterProps) => {
     setFilterValue(selectedFilter);
   }, [selectedFilter]);
 
-  const activeFilterCount = filterValue.filter.length + (filterValue.responseStatus !== "all" ? 1 : 0);
+  const activeFilterCount = filterValue.filter.length + (filterValue.responseStatus === "all" ? 0 : 1);
 
   return (
     <Popover open={isOpen} onOpenChange={handleOpenChange}>


### PR DESCRIPTION

<img width="1044" height="204" alt="image" src="https://github.com/user-attachments/assets/e61cc2ba-6572-4d7d-89c0-0170b089cce8" />


## Problem

The filter button was not showing the count when only the responseStatus filter (Complete/Partial) was active. Users couldn't see that filters like 'Only Completed' were active.

## Solution

Updated the filter count calculation to include the `responseStatus` filter when it's not set to 'all'. The filter button now correctly displays the total count of all active filters.

**Before:**
- Only custom filters (questions, tags, etc.) were counted
- If you had 0 custom filters but selected "Complete responses only", it showed: `Filter` (no count)

**After:**
- Both custom filters AND the responseStatus filter are counted
- If you have 0 custom filters but select "Complete responses only", it shows: `Filter (1)`
- If you have 2 custom filters and select "Partial responses only", it shows: `Filter (3)`

## Changes

- Modified `ResponseFilter.tsx` to calculate `activeFilterCount` including `responseStatus`
- Simple one-line logic change: `filterValue.filter.length + (filterValue.responseStatus !== "all" ? 1 : 0)`

## Testing

✅ Manually tested:
- Select "Complete responses only" (no custom filters) → Shows `Filter (1)`
- Select "Partial responses only" (no custom filters) → Shows `Filter (1)`
- Add custom filter + select "Complete responses only" → Shows `Filter (2)`
- Clear all filters → Shows `Filter` (no count)

**Estimated Effort:** < 1 hour (quick win)