### PR TITLE
fix: add typeorm security override (Dependabot #223)

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,10 +83,11 @@
     },
     "overrides": {
       "axios": ">=1.12.2",
-      "tar-fs": "2.1.4"
+      "tar-fs": "2.1.4",
+      "typeorm": ">=0.3.26"
     },
     "comments": {
-      "overrides": "Security fixes for transitive dependencies. Remove when upstream packages update: axios (CVE-2025-58754) - awaiting @boxyhq/saml-jackson update | tar-fs (Dependabot #205) - awaiting upstream dependency updates"
+      "overrides": "Security fixes for transitive dependencies. Remove when upstream packages update: axios (CVE-2025-58754) - awaiting @boxyhq/saml-jackson update | tar-fs (Dependabot #205) - awaiting upstream dependency updates | typeorm (Dependabot #223) - awaiting @boxyhq/saml-jackson update"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   axios: '>=1.12.2'
   tar-fs: 2.1.4
+  typeorm: '>=0.3.26'
 
 patchedDependencies:
   next-auth@4.24.12:
@@ -5819,6 +5820,14 @@ packages:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
 
+  dedent@1.7.0:
+    resolution: {integrity: sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==}
+    peerDependencies:
+      babel-plugin-macros: ^3.1.0
+    peerDependenciesMeta:
+      babel-plugin-macros:
+        optional: true
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -9537,15 +9546,14 @@ packages:
     resolution: {integrity: sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==}
     engines: {node: '>= 0.4'}
 
-  typeorm@0.3.22:
-    resolution: {integrity: sha512-P/Tsz3UpJ9+K0oryC0twK5PO27zejLYYwMsE8SISfZc1lVHX+ajigiOyWsKbuXpEFMjD9z7UjLzY3+ElVOMMDA==}
+  typeorm@0.3.27:
+    resolution: {integrity: sha512-pNV1bn+1n8qEe8tUNsNdD8ejuPcMAg47u2lUGnbsajiNUr3p2Js1XLKQjBMH0yMRMDfdX8T+fIRejFmIwy9x4A==}
     engines: {node: '>=16.13.0'}
     hasBin: true
     peerDependencies:
       '@google-cloud/spanner': ^5.18.0 || ^6.0.0 || ^7.0.0
-      '@sap/hana-client': ^2.12.25
-      better-sqlite3: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0
-      hdb-pool: ^0.1.6
+      '@sap/hana-client': ^2.14.22
+      better-sqlite3: ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0
       ioredis: ^5.0.4
       mongodb: ^5.8.0 || ^6.0.0
       mssql: ^9.1.1 || ^10.0.1 || ^11.0.1
@@ -9554,7 +9562,7 @@ packages:
       pg: ^8.5.1
       pg-native: ^3.0.0
       pg-query-stream: ^4.0.0
-      redis: ^3.1.1 || ^4.0.0
+      redis: ^3.1.1 || ^4.0.0 || ^5.0.14
       reflect-metadata: ^0.1.14 || ^0.2.0
       sql.js: ^1.4.0
       sqlite3: ^5.0.3
@@ -9566,8 +9574,6 @@ packages:
       '@sap/hana-client':
         optional: true
       better-sqlite3:
-        optional: true
-      hdb-pool:
         optional: true
       ioredis:
         optional: true
@@ -11726,18 +11732,18 @@ snapshots:
       reflect-metadata: 0.2.2
       ripemd160: 2.0.2
       sqlite3: 5.1.7
-      typeorm: 0.3.22(mongodb@6.16.0(@aws-sdk/credential-providers@3.817.0)(socks@2.8.7))(mssql@11.0.1)(mysql2@3.14.1)(pg@8.16.0)(redis@4.7.0)(reflect-metadata@0.2.2)(sqlite3@5.1.7)(ts-node@10.9.2(@types/node@22.15.18)(typescript@5.8.3))
+      typeorm: 0.3.27(mongodb@6.16.0(@aws-sdk/credential-providers@3.817.0)(socks@2.8.7))(mssql@11.0.1)(mysql2@3.14.1)(pg@8.16.0)(redis@4.7.0)(reflect-metadata@0.2.2)(sqlite3@5.1.7)(ts-node@10.9.2(@types/node@22.15.18)(typescript@5.8.3))
     transitivePeerDependencies:
       - '@google-cloud/spanner'
       - '@mongodb-js/zstd'
       - '@sap/hana-client'
       - aws-crt
+      - babel-plugin-macros
       - better-sqlite3
       - bluebird
       - bufferutil
       - debug
       - gcp-metadata
-      - hdb-pool
       - ioredis
       - kerberos
       - mongodb-client-encryption
@@ -16397,6 +16403,8 @@ snapshots:
     dependencies:
       mimic-response: 3.1.0
 
+  dedent@1.7.0: {}
+
   deep-eql@5.0.2: {}
 
   deep-equal@2.2.3:
@@ -20556,7 +20564,7 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typeorm@0.3.22(mongodb@6.16.0(@aws-sdk/credential-providers@3.817.0)(socks@2.8.7))(mssql@11.0.1)(mysql2@3.14.1)(pg@8.16.0)(redis@4.7.0)(reflect-metadata@0.2.2)(sqlite3@5.1.7)(ts-node@10.9.2(@types/node@22.15.18)(typescript@5.8.3)):
+  typeorm@0.3.27(mongodb@6.16.0(@aws-sdk/credential-providers@3.817.0)(socks@2.8.7))(mssql@11.0.1)(mysql2@3.14.1)(pg@8.16.0)(redis@4.7.0)(reflect-metadata@0.2.2)(sqlite3@5.1.7)(ts-node@10.9.2(@types/node@22.15.18)(typescript@5.8.3)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 3.17.0
@@ -20564,6 +20572,7 @@ snapshots:
       buffer: 6.0.3
       dayjs: 1.11.18
       debug: 4.4.3
+      dedent: 1.7.0
       dotenv: 16.5.0
       glob: 10.4.5
       reflect-metadata: 0.2.2
@@ -20581,6 +20590,7 @@ snapshots:
       sqlite3: 5.1.7
       ts-node: 10.9.2(@types/node@22.15.18)(typescript@5.8.3)
     transitivePeerDependencies:
+      - babel-plugin-macros
       - supports-color
 
   typescript@5.8.2: {}


### PR DESCRIPTION
## Summary

This PR adds a pnpm override for `typeorm` to address Dependabot security alert #223.

## Problem

- TypeORM version 0.3.22 (used transitively by `@boxyhq/saml-jackson`) has a SQL injection vulnerability (CVE)
- The vulnerability affects versions `< 0.3.26`
- Patched version: `0.3.26` or higher
- `@boxyhq/saml-jackson` hasn't been updated to use a patched version yet

## Solution

Added `typeorm: ">=0.3.26"` to `pnpm.overrides` in `package.json`, following the same pattern as existing security overrides for `axios` and `tar-fs`.

The override forces all dependencies to use TypeORM >= 0.3.26, which resolves the security vulnerability. After running `pnpm install`, TypeORM was updated from `0.3.22` to `0.3.27`.

## Changes

- Added `typeorm: ">=0.3.26"` to `pnpm.overrides`
- Updated `pnpm-lock.yaml` with the new TypeORM version
- Updated comments section to document this override

## Testing

- ✅ `pnpm install` completed successfully
- ✅ TypeORM updated from 0.3.22 → 0.3.27
- ✅ No linting errors

## Related

- Dependabot Alert: #223
- Parent dependency: `@boxyhq/saml-jackson`