### PR TITLE
fix: pin Prisma CLI to version 6 in Dockerfile

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -124,7 +124,7 @@ RUN chmod -R 755 ./node_modules/@noble/hashes
 COPY --from=installer /app/node_modules/zod ./node_modules/zod
 RUN chmod -R 755 ./node_modules/zod
 
-RUN npm install -g prisma
+RUN npm install -g prisma@6
 
 # Create a startup script to handle the conditional logic
 COPY --from=installer /app/apps/web/scripts/docker/next-start.sh /home/nextjs/start.sh


### PR DESCRIPTION
## Problem

The Docker build was failing because Prisma CLI 7.0.0 was being installed globally, which is incompatible with our Prisma 6 schema. Prisma 7 introduced breaking changes that require schema migration (moving datasource URLs to `prisma.config.ts`), but our codebase is still on Prisma 6.14.0.

Error:
```
Prisma CLI Version : 7.0.0
Error: The datasource property `url` is no longer supported in schema files.
```

## Solution

Pin the global Prisma CLI installation to version 6 using npm's `@6` notation, which installs the latest version in the 6.x series. This ensures the global CLI matches our project's Prisma 6.14.0 dependency.

## Changes

- Updated `RUN npm install -g prisma` to `RUN npm install -g prisma@6` in `apps/web/Dockerfile`

This prevents Prisma 7 from being installed while still getting the latest Prisma 6.x updates.