### PR TITLE
fix: release pipeline boolean comparison for is_latest output

### DIFF
--- a/.github/workflows/formbricks-release.yml
+++ b/.github/workflows/formbricks-release.yml
@@ -89,7 +89,7 @@ jobs:
       - check-latest-release
     with:
       IS_PRERELEASE: ${{ github.event.release.prerelease }}
-      MAKE_LATEST: ${{ needs.check-latest-release.outputs.is_latest }}
+      MAKE_LATEST: ${{ needs.check-latest-release.outputs.is_latest == 'true' }}
 
   docker-build-cloud:
     name: Build & push Formbricks Cloud to ECR
@@ -101,7 +101,7 @@ jobs:
     with:
       image_tag: ${{ needs.docker-build-community.outputs.VERSION }}
       IS_PRERELEASE: ${{ github.event.release.prerelease }}
-      MAKE_LATEST: ${{ needs.check-latest-release.outputs.is_latest }}
+      MAKE_LATEST: ${{ needs.check-latest-release.outputs.is_latest == 'true' }}
     needs:
       - check-latest-release
       - docker-build-community
@@ -154,4 +154,4 @@ jobs:
       release_tag: ${{ github.event.release.tag_name }}
       commit_sha: ${{ github.sha }}
       is_prerelease: ${{ github.event.release.prerelease }}
-      make_latest: ${{ needs.check-latest-release.outputs.is_latest }}
+      make_latest: ${{ needs.check-latest-release.outputs.is_latest == 'true' }}


### PR DESCRIPTION
## Problem
The release pipeline was failing due to a misconfiguration in how the `is_latest` output was being evaluated. The fix was already applied in the `release/4.1` branch but was missing from `main`.

## Solution
Updated the workflow to explicitly compare `is_latest` output with the string `'true'` instead of using the raw output value. This ensures proper boolean evaluation since GitHub Actions outputs are strings, and the string `"false"` would be truthy without explicit comparison.

## Changes
- Fixed `MAKE_LATEST` parameter in `docker-build-community` job (line 92)
- Fixed `MAKE_LATEST` parameter in `docker-build-cloud` job (line 104)
- Fixed `make_latest` parameter in `move-stable-tag` job (line 157)

## Related
- Ports fix from commit f9835dd5c11c3ef1560cb368cd6e7f1b4da2baf3 in `release/4.1` branch