### PR TITLE
docs: add S3 CORS configuration to file uploads documentation

### DIFF
--- a/docs/self-hosting/configuration/file-uploads.mdx
+++ b/docs/self-hosting/configuration/file-uploads.mdx
@@ -297,6 +297,47 @@ Example least-privileged S3 bucket policy:
   Replace `your-bucket-name` with your actual bucket name and `arn:aws:iam::123456789012:user/formbricks-service` with the ARN of your IAM user. This policy allows public read access only to specific paths while restricting write access to your Formbricks service user.
 </Note>
 
+### S3 CORS Configuration
+
+CORS (Cross-Origin Resource Sharing) must be configured on your S3 bucket to allow Formbricks to upload files using presigned POST URLs. Without proper CORS configuration, file uploads from the browser will fail.
+
+Configure CORS on your S3 bucket with the following settings:
+
+```json
+[
+  {
+    "AllowedHeaders": [
+      "*"
+    ],
+    "AllowedMethods": [
+      "POST",
+      "GET",
+      "HEAD",
+      "DELETE",
+      "PUT"
+    ],
+    "AllowedOrigins": [
+      "*"
+    ],
+    "ExposeHeaders": [
+      "ETag",
+      "x-amz-meta-custom-header"
+    ],
+    "MaxAgeSeconds": 3000
+  }
+]
+```
+
+<Note>
+  For production environments, consider restricting `AllowedOrigins` to your specific Formbricks domain(s) instead of using `"*"` for better security. For example: `["https://app.yourdomain.com", "https://yourdomain.com"]`.
+</Note>
+
+**How to configure CORS:**
+
+- **AWS S3**: Navigate to your bucket → Permissions → Cross-origin resource sharing (CORS) → Edit → Paste the JSON configuration
+- **DigitalOcean Spaces**: Navigate to your Space → Settings → CORS Configurations → Add CORS configuration → Paste the JSON
+- **Other S3-compatible providers**: Refer to your provider's documentation for CORS configuration
+
 ### MinIO Security
 
 When using bundled MinIO:


### PR DESCRIPTION
## Summary

This PR adds missing CORS configuration documentation for S3-compatible storage providers in the file uploads documentation.

## Changes

- Added a new "S3 CORS Configuration" section to `docs/self-hosting/configuration/file-uploads.mdx`
- Included the required CORS JSON configuration with all necessary headers, methods, and settings
- Added provider-specific instructions for configuring CORS on AWS S3, DigitalOcean Spaces, and other S3-compatible providers
- Included a security note recommending restricting `AllowedOrigins` in production environments

## Why This Change?

CORS configuration is essential for Formbricks file uploads to work properly, as the application uses presigned POST URLs for browser-based uploads. Without proper CORS configuration, uploads will fail. This documentation was previously missing, making it difficult for users to properly configure their S3 buckets.

## Testing

- [x] Documentation has been reviewed for accuracy
- [x] No linting errors introduced