### PR TITLE
fix: add missing filter option

### DIFF
--- a/apps/web/modules/survey/list/components/survey-filters.tsx
+++ b/apps/web/modules/survey/list/components/survey-filters.tsx
@@ -31,9 +31,10 @@ const getCreatorOptions = (t: TFunction): TFilterOption[] => [
 ];
 
 const getStatusOptions = (t: TFunction): TFilterOption[] => [
+  { label: t("common.draft"), value: "draft" },
+  { label: t("common.in_progress"), value: "inProgress" },
   { label: t("common.paused"), value: "paused" },
   { label: t("common.completed"), value: "completed" },
-  { label: t("common.draft"), value: "draft" },
 ];
 
 const getSortOptions = (t: TFunction): TSortOption[] => [


### PR DESCRIPTION
<img width="508" height="328" alt="image" src="https://github.com/user-attachments/assets/f82002f1-0a25-4621-a5cb-b827dea3ed53" />

In progress filter was missing for no reason.