### PR TITLE
fix: use correct permission check for remove branding feature

### DIFF
--- a/apps/web/modules/projects/settings/look/page.tsx
+++ b/apps/web/modules/projects/settings/look/page.tsx
@@ -2,7 +2,7 @@ import { SettingsCard } from "@/app/(app)/environments/[environmentId]/settings/
 import { cn } from "@/lib/cn";
 import { IS_STORAGE_CONFIGURED, SURVEY_BG_COLORS, UNSPLASH_ACCESS_KEY } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
-import { getWhiteLabelPermission } from "@/modules/ee/license-check/lib/utils";
+import { getRemoveBrandingPermission } from "@/modules/ee/license-check/lib/utils";
 import { BrandingSettingsCard } from "@/modules/ee/whitelabel/remove-branding/components/branding-settings-card";
 import { getEnvironmentAuth } from "@/modules/environments/lib/utils";
 import { ProjectConfigNavigation } from "@/modules/projects/settings/components/project-config-navigation";
@@ -26,7 +26,7 @@ export const ProjectLookSettingsPage = async (props: { params: Promise<{ environ
     throw new Error("Project not found");
   }
 
-  const canRemoveBranding = await getWhiteLabelPermission(organization.billing.plan);
+  const canRemoveBranding = await getRemoveBrandingPermission(organization.billing.plan);
 
   return (
     <PageContentWrapper>


### PR DESCRIPTION
## Problem
Formbricks customers who had the remove branding functionality unlocked were still unable to remove the branding in their Formbricks instance. The issue was that the code was checking for the wrong permission - it was using `getWhiteLabelPermission` instead of `getRemoveBrandingPermission`.

## Solution
Updated the permission check in `apps/web/modules/projects/settings/look/page.tsx` to use `getRemoveBrandingPermission` instead of `getWhiteLabelPermission`. The white label feature is for white labeling emails on the organization level, while remove branding is a separate feature for removing branding from surveys.

## Changes
- Changed import from `getWhiteLabelPermission` to `getRemoveBrandingPermission`
- Updated the permission check call to use the correct function

## Testing
- [ ] Verified that customers with remove branding unlocked can now access the feature