### PR TITLE
fix: (backport) back button label validation (#6916)

### DIFF
--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -1356,10 +1356,10 @@ export const ZSurvey = z
         }
 
         if (
-          block.backButtonLabel?.[defaultLanguageCode] &&
-          block.backButtonLabel[defaultLanguageCode].trim() !== "" &&
           !isBackButtonHidden &&
-          blockIndex > 0
+          blockIndex > 0 &&
+          block.backButtonLabel?.[defaultLanguageCode] &&
+          block.backButtonLabel[defaultLanguageCode].trim() !== ""
         ) {
           // Validate back button label for all enabled languages
           const enabledLanguages = languages.filter((lang) => lang.enabled);


### PR DESCRIPTION
Backport of PR #6916

Fixes back button label validation by skipping validation when:
- Back button is hidden (`isBackButtonHidden` is true)
- Block index is 0 (first block)

This prevents validation errors when the back button shouldn't be shown or when it's the first block where a back button doesn't make sense.