### PR TITLE
fix: (backport) border around language select dropdown (#6914)

### DIFF
--- a/packages/surveys/src/components/general/language-switch.tsx
+++ b/packages/surveys/src/components/general/language-switch.tsx
@@ -99,7 +99,7 @@ export function LanguageSwitch({
       {showLanguageDropdown ? (
         <div
           className={cn(
-            "fb-bg-input-bg fb-text-heading fb-absolute fb-top-10 fb-max-h-64 fb-space-y-2 fb-overflow-auto fb-rounded-md fb-p-2 fb-text-xs",
+            "fb-bg-input-bg fb-text-heading fb-absolute fb-top-10 fb-max-h-64 fb-space-y-2 fb-overflow-auto fb-rounded-md fb-p-2 fb-text-xs fb-border-border fb-border",
             dir === "rtl" ? "fb-left-8" : "fb-right-8"
           )}
           ref={languageDropdownRef}>


### PR DESCRIPTION
Backport of PR #6914

Adds border styling classes (`fb-border-border` and `fb-border`) to the language select dropdown container to fix the missing border around the dropdown.