### PR TITLE
fix: revoke auth cookies on logout

### DIFF
--- a/apps/web/modules/auth/actions/invalidate-sessions.ts
+++ b/apps/web/modules/auth/actions/invalidate-sessions.ts
@@ -1,0 +1,87 @@
+"use server";
+
+import { getServerSession } from "next-auth";
+import { getToken } from "next-auth/jwt";
+import { cookies } from "next/headers";
+import { prisma } from "@formbricks/database";
+import { logger } from "@formbricks/logger";
+import { NEXTAUTH_SECRET } from "@/lib/constants";
+import { authOptions } from "@/modules/auth/lib/authOptions";
+
+/**
+ * Invalidates the current user's session by deleting it from the database.
+ * This is called during logout to ensure JWT tokens cannot be reused.
+ */
+export async function invalidateCurrentSession() {
+  try {
+    const cookieStore = await cookies();
+    const cookieHeader = cookieStore
+      .getAll()
+      .map((c) => `${c.name}=${c.value}`)
+      .join("; ");
+
+    const token = await getToken({
+      req: { headers: { cookie: cookieHeader } } as any,
+      secret: NEXTAUTH_SECRET,
+    });
+
+    const sessionToken = (token as any)?.sessionToken as string | undefined;
+    if (sessionToken) {
+      await prisma.session.deleteMany({ where: { sessionToken } });
+      logger.info({ sessionToken }, "Invalidated current session by sessionToken");
+      return;
+    }
+
+    // Fallback: if we can't decode the token, invalidate all sessions for the current user.
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.id) {
+      logger.warn("No active session to invalidate");
+      return;
+    }
+
+    const result = await prisma.session.deleteMany({ where: { userId: session.user.id } });
+    logger.info({ userId: session.user.id, sessionsDeleted: result.count }, "Invalidated all user sessions");
+  } catch (error) {
+    logger.error(
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "Failed to invalidate current session"
+    );
+    // Don't throw - we don't want to block logout if session deletion fails
+  }
+}
+
+/**
+ * Invalidates all sessions for a given user.
+ * Useful for "logout from all devices" functionality.
+ *
+ * @param userId - The ID of the user whose sessions should be invalidated
+ * @throws Error if the operation fails
+ */
+export async function invalidateAllUserSessions(userId: string) {
+  try {
+    const result = await prisma.session.deleteMany({
+      where: { userId },
+    });
+
+    logger.info(
+      {
+        userId,
+        sessionsDeleted: result.count,
+      },
+      "Invalidated all user sessions"
+    );
+
+    return result.count;
+  } catch (error) {
+    logger.error(
+      {
+        userId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      "Failed to invalidate user sessions"
+    );
+    throw error;
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "i18n:generate": "npx lingo.dev@latest i18n"
   },
   "dependencies": {
+    "@auth/prisma-adapter": "2.11.1",
     "@aws-sdk/client-s3": "3.879.0",
     "@aws-sdk/s3-presigned-post": "3.879.0",
     "@aws-sdk/s3-request-presigner": "3.879.0",

--- a/apps/web/types/next-auth.d.ts
+++ b/apps/web/types/next-auth.d.ts
@@ -1,0 +1,10 @@
+import { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user?: {
+      id: string;
+      isActive: boolean;
+    } & DefaultSession["user"];
+  }
+}

--- a/packages/database/migration/20251211161221_add_session_table/migration.sql
+++ b/packages/database/migration/20251211161221_add_session_table/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "public"."sessions" (
+    "id" TEXT NOT NULL,
+    "session_token" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "public"."verification_tokens" (
+    "identifier" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sessions_session_token_key" ON "public"."sessions"("session_token");
+
+-- CreateIndex
+CREATE INDEX "sessions_user_id_idx" ON "public"."sessions"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "verification_tokens_token_key" ON "public"."verification_tokens"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "verification_tokens_identifier_token_key" ON "public"."verification_tokens"("identifier", "token");
+
+-- AddForeignKey
+ALTER TABLE "public"."sessions" ADD CONSTRAINT "sessions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -832,6 +832,7 @@ model User {
   identityProviderAccountId String?
   memberships               Membership[]
   accounts                  Account[]
+  sessions                  Session[]
   groupId                   String?
   invitesCreated            Invite[]         @relation("inviteCreatedBy")
   invitesAccepted           Invite[]         @relation("inviteAcceptedBy")
@@ -845,6 +846,34 @@ model User {
   isActive                  Boolean          @default(true)
 
   @@index([email])
+}
+
+/// Represents an active user session for authentication.
+/// Used by NextAuth for database session strategy.
+///
+/// @property sessionToken - Unique token identifying the session
+/// @property userId - The user this session belongs to
+/// @property expires - When the session expires
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique @map("session_token")
+  userId       String   @map("user_id")
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("sessions")
+}
+
+/// Stores verification tokens for email verification flows.
+/// Used by NextAuth for magic link authentication.
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
+  @@map("verification_tokens")
 }
 
 /// Defines a segment of contacts based on attributes.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@auth/prisma-adapter':
+        specifier: 2.11.1
+        version: 2.11.1(@prisma/client@6.14.0(prisma@6.14.0(magicast@0.3.5)(typescript@5.8.3))(typescript@5.8.3))(nodemailer@7.0.11)
       '@aws-sdk/client-s3':
         specifier: 3.879.0
         version: 3.879.0
@@ -921,6 +924,25 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@auth/core@0.41.1':
+    resolution: {integrity: sha512-t9cJ2zNYAdWMacGRMT6+r4xr1uybIdmYa49calBPeTqwgAFPV/88ac9TEvCR85pvATiSPt8VaNf+Gt24JIT/uw==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^7.0.7
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
+  '@auth/prisma-adapter@2.11.1':
+    resolution: {integrity: sha512-Ke7DXP0Fy0Mlmjz/ZJLXwQash2UkA4621xCM0rMtEczr1kppLc/njCbUkHkIQ/PnmILjqSPEKeTjDPsYruvkug==}
+    peerDependencies:
+      '@prisma/client': '>=2.26.0 || >=3 || >=4 || >=5 || >=6'
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -8237,6 +8259,14 @@ packages:
     peerDependencies:
       preact: '>=10'
 
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
+
   preact@10.26.6:
     resolution: {integrity: sha512-5SRRBinwpwkaD+OqlBDeITlRgvd8I8QlxHJw9AxSdMNV6O+LodN9nUyYGpSF7sadHjs6RzeFShMexC6DbtWr9g==}
 
@@ -10061,6 +10091,25 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
+
+  '@auth/core@0.41.1(nodemailer@7.0.11)':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.0.11
+      oauth4webapi: 3.8.2
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+    optionalDependencies:
+      nodemailer: 7.0.11
+
+  '@auth/prisma-adapter@2.11.1(@prisma/client@6.14.0(prisma@6.14.0(magicast@0.3.5)(typescript@5.8.3))(typescript@5.8.3))(nodemailer@7.0.11)':
+    dependencies:
+      '@auth/core': 0.41.1(nodemailer@7.0.11)
+      '@prisma/client': 6.14.0(prisma@6.14.0(magicast@0.3.5)(typescript@5.8.3))(typescript@5.8.3)
+    transitivePeerDependencies:
+      - '@simplewebauthn/browser'
+      - '@simplewebauthn/server'
+      - nodemailer
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -19103,6 +19152,12 @@ snapshots:
     dependencies:
       preact: 10.26.6
       pretty-format: 3.8.0
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   preact@10.26.6: {}
 


### PR DESCRIPTION
## What does this PR do?

This fixes a logout/session hijacking issue where captured auth cookies could be reused until expiry. We now persist a server-side session record for JWT logins and validate it on each request, so **logout revokes the cookie immediately** by deleting the corresponding DB session row.

Fixes #(issue)

## How should this be tested?

- Start the app + DB.
- Log in via credentials.
- Confirm a row is created in `public.sessions` for the logged-in user.
- Log out.
- Confirm the session row for the current `session_token` is deleted.
- Attempt to replay the previous cookie/session token: request should be unauthenticated.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary