### PR TITLE
fix: replace hardcoded bg-white with bg-survey-bg

### DIFF
--- a/packages/surveys/src/components/general/block-conditional.tsx
+++ b/packages/surveys/src/components/general/block-conditional.tsx
@@ -295,7 +295,7 @@ export function BlockConditional({
           <div
             className={cn(
               "flex w-full flex-row-reverse justify-between",
-              fullSizeCards ? "sticky bottom-0 bg-white" : ""
+              fullSizeCards ? "sticky bottom-0 bg-survey-bg" : ""
             )}>
             <div>
               <SubmitButton

--- a/packages/surveys/src/components/general/error-component.tsx
+++ b/packages/surveys/src/components/general/error-component.tsx
@@ -21,7 +21,7 @@ export function ErrorComponent({ errorType }: ErrorComponentProps) {
   const error = errorData[errorType];
 
   return (
-    <div className="flex flex-col items-center bg-white p-8 text-center" role="alert" aria-live="assertive">
+    <div className="flex flex-col items-center bg-survey-bg p-8 text-center" role="alert" aria-live="assertive">
       <span className="mb-1.5 text-base leading-6 font-bold text-slate-900">{error.title}</span>
       <p className="max-w-lg text-sm leading-6 font-normal text-slate-600">{error.message}</p>
     </div>

--- a/packages/surveys/src/components/general/response-error-component.tsx
+++ b/packages/surveys/src/components/general/response-error-component.tsx
@@ -19,7 +19,7 @@ export function ResponseErrorComponent({
 }: ResponseErrorComponentProps) {
   const { t } = useTranslation();
   return (
-    <div className="flex flex-col bg-white p-4">
+    <div className="flex flex-col bg-survey-bg p-4">
       <span className="mb-1.5 text-base leading-6 font-bold text-slate-900">
         {t("common.your_feedback_is_stuck")}
       </span>

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -743,7 +743,7 @@ export function Survey({
           return (
             <>
               {localSurvey.type !== "link" ? (
-                <div className="flex h-6 justify-end bg-white pt-2 pr-2">
+                <div className="flex h-6 justify-end bg-survey-bg pt-2 pr-2">
                   <SurveyCloseButton onClose={onClose} />
                 </div>
               ) : null}


### PR DESCRIPTION
## Summary

- Replaced hardcoded `bg-white` with `bg-survey-bg` in two places to ensure survey styling respects user-configured background colors

## Problem

When users customize their survey's background color through styling settings, some UI elements were still rendering with a hardcoded white background, breaking visual consistency.

**Affected components:**

- Submit/Back buttons container in `block-conditional.tsx` (when `fullSizeCards` is enabled)
- Close button container in `survey.tsx` (shown on Recaptcha/InvalidDevice errors)

## Solution

Replaced `bg-white` with `bg-survey-bg` which uses the CSS variable that respects the survey's configured background color.

## Screenshots

### Before: Buttons with white background ignoring custom styling:
  
<img width="831" height="931" alt="image" src="https://github.com/user-attachments/assets/5f8e370e-1b8f-4551-ad3c-06e73e3355ca" />

### After: Buttons respecting custom background color

<img width="831" height="931" alt="image" src="https://github.com/user-attachments/assets/d9ca2e93-7a7c-4d4f-b4b6-2bdad40f2ff8" />
