### PR TITLE
fix: await user sync completion in setUserId and setAttributes

### DIFF
--- a/packages/js-core/src/index.ts
+++ b/packages/js-core/src/index.ts
@@ -42,22 +42,27 @@ const setup = async (setupConfig: TConfigInput): Promise<void> => {
 
 const setUserId = async (userId: string): Promise<void> => {
   await queue.add(User.setUserId, CommandType.UserAction, true, userId);
+  await queue.wait();
 };
 
 const setEmail = async (email: string): Promise<void> => {
   await queue.add(Attribute.setAttributes, CommandType.UserAction, true, { email });
+  await queue.wait();
 };
 
 const setAttribute = async (key: string, value: string): Promise<void> => {
   await queue.add(Attribute.setAttributes, CommandType.UserAction, true, { [key]: value });
+  await queue.wait();
 };
 
 const setAttributes = async (attributes: Record<string, string>): Promise<void> => {
   await queue.add(Attribute.setAttributes, CommandType.UserAction, true, attributes);
+  await queue.wait();
 };
 
 const setLanguage = async (language: string): Promise<void> => {
   await queue.add(Attribute.setAttributes, CommandType.UserAction, true, { language });
+  await queue.wait();
 };
 
 const logout = async (): Promise<void> => {


### PR DESCRIPTION
## Problem

Customers reported that surveys were being displayed as anonymous even after calling `setUserId()`. This was caused by a race condition where:

1. `setUserId()` and `setAttributes()` returned immediately after queuing the update
2. The API sync (which sets `contactId`) happened asynchronously with a 500ms debounce
3. If a survey was displayed before the sync completed, it would show as anonymous

## Solution

- Made `setUserId()` and `setAttributes()` await `processUpdates()` completion
- Added `queue.wait()` to all public API functions (`setUserId`, `setAttribute`, `setAttributes`, `setEmail`, `setLanguage`) to ensure commands execute before returning
- Added proper error handling for network failures during sync
- Updated tests to reflect the new async behavior

## Testing

- All existing tests pass
- Added test case for error handling when `processUpdates()` fails
- Verified that functions now properly wait for sync completion

## Impact

When customers use:
```javascript
await formbricks.setUserId(config.userId)
await formbricks.setAttributes(config.attributes)
```

The functions will now fully complete (including API sync) before returning, ensuring that `contactId` is properly set and surveys are correctly identified.