### PR TITLE
fix: (BACKPORT) replaced bg-white with survey-bg color in surveys package (#7004)

### DIFF
--- a/packages/surveys/src/components/general/block-conditional.tsx
+++ b/packages/surveys/src/components/general/block-conditional.tsx
@@ -295,7 +295,7 @@ export function BlockConditional({
           <div
             className={cn(
               "flex w-full flex-row-reverse justify-between",
-              fullSizeCards ? "sticky bottom-0 bg-white" : ""
+              fullSizeCards ? "bg-survey-bg sticky bottom-0" : ""
             )}>
             <div>
               <SubmitButton

--- a/packages/surveys/src/components/general/error-component.tsx
+++ b/packages/surveys/src/components/general/error-component.tsx
@@ -21,9 +21,12 @@ export function ErrorComponent({ errorType }: ErrorComponentProps) {
   const error = errorData[errorType];
 
   return (
-    <div className="flex flex-col items-center bg-white p-8 text-center" role="alert" aria-live="assertive">
-      <span className="mb-1.5 text-base leading-6 font-bold text-slate-900">{error.title}</span>
-      <p className="max-w-lg text-sm leading-6 font-normal text-slate-600">{error.message}</p>
+    <div
+      className="bg-survey-bg text-heading flex flex-col items-center p-8 text-center"
+      role="alert"
+      aria-live="assertive">
+      <span className="mb-1.5 text-base leading-6 font-bold">{error.title}</span>
+      <p className="max-w-lg text-sm leading-6 font-normal">{error.message}</p>
     </div>
   );
 }

--- a/packages/surveys/src/components/general/response-error-component.tsx
+++ b/packages/surveys/src/components/general/response-error-component.tsx
@@ -19,11 +19,9 @@ export function ResponseErrorComponent({
 }: ResponseErrorComponentProps) {
   const { t } = useTranslation();
   return (
-    <div className="flex flex-col bg-white p-4">
-      <span className="mb-1.5 text-base leading-6 font-bold text-slate-900">
-        {t("common.your_feedback_is_stuck")}
-      </span>
-      <p className="max-w-md text-sm leading-6 font-normal text-slate-600">
+    <div className="bg-survey-bg text-heading flex flex-col p-4">
+      <span className="mb-1.5 text-base leading-6 font-bold">{t("common.your_feedback_is_stuck")}</span>
+      <p className="max-w-md text-sm leading-6 font-normal">
         {t("common.the_servers_cannot_be_reached_at_the_moment")}
         <br />
         {t("common.please_retry_now_or_try_again_later")}

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -743,7 +743,7 @@ export function Survey({
           return (
             <>
               {localSurvey.type !== "link" ? (
-                <div className="flex h-6 justify-end bg-white pt-2 pr-2">
+                <div className="bg-survey-bg flex h-6 justify-end pt-2 pr-2">
                   <SurveyCloseButton onClose={onClose} />
                 </div>
               ) : null}


### PR DESCRIPTION
Backport of commit a7c4971952fc7f06c07aa9006f646e279082a5cc to release/4.4

Replaces hardcoded bg-white and text-slate-* classes with semantic bg-survey-bg and text-heading classes for better theme support.

