### PR TITLE
fix(types): use z.coerce.date() for ZActionClass timestamps

### DIFF
--- a/packages/types/action-classes.ts
+++ b/packages/types/action-classes.ts
@@ -87,8 +87,8 @@ export const ZActionClass = z.object({
   key: z.string().trim().min(1).nullable(),
   noCodeConfig: ZActionClassNoCodeConfig.nullable(),
   environmentId: z.string(),
-  createdAt: z.date(),
-  updatedAt: z.date(),
+  createdAt: z.coerce.date(),
+  updatedAt: z.coerce.date(),
 });
 
 export type TActionClass = z.infer<typeof ZActionClass>;


### PR DESCRIPTION
## Summary

When updating surveys via the Management API with triggers, the API rejects ISO date strings for `actionClass.createdAt` and `actionClass.updatedAt` with the error:

```json
{
  "code": "bad_request",
  "message": "Fields are missing or incorrectly formatted",
  "details": {
    "triggers.0.actionClass.createdAt": "Expected date, received string",
    "triggers.0.actionClass.updatedAt": "Expected date, received string"
  }
}
```

## Problem

Since JSON cannot serialize native JavaScript `Date` objects (only strings or numbers), API consumers cannot currently update survey triggers programmatically via the REST API.

**Current behavior:**
- `z.date()` expects a native JavaScript `Date` object
- JSON.parse cannot produce native `Date` objects
- API rejects both ISO strings (`"2025-12-25T00:22:25.125Z"`) and Unix timestamps (`1735086145125`)

## Solution

This PR changes `z.date()` to `z.coerce.date()` in the `ZActionClass` schema for `createdAt` and `updatedAt` fields.

`z.coerce.date()` automatically coerces:
- ISO date strings → `Date` objects
- Unix timestamps (numbers) → `Date` objects  
- Native `Date` objects → `Date` objects (unchanged)

This maintains full backward compatibility while enabling REST API consumers to update survey triggers programmatically.

## Test Plan

- [ ] Verify existing dashboard functionality still works
- [ ] Test updating survey triggers via Management API with ISO date strings
- [ ] Test updating survey triggers via Management API with Unix timestamps

## Related Issues

Creates a fix for the issue documented in my companion bug report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)