### PR TITLE
fix: (Backport) fixes user api attribute override error (#7050)

### DIFF
--- a/apps/web/modules/ee/contacts/lib/update-contact-attributes.ts
+++ b/apps/web/modules/ee/contacts/lib/update-contact-attributes.ts
@@ -13,11 +13,6 @@ export interface UpdateContactAttributesResult {
   updatedAttributeKeys?: TContactAttributeKey[];
 }
 
-/**
- * Updates contact attributes for a single contact.
- * Handles loading contact data, extracting userId, calling updateAttributes,
- * and detecting if new attribute keys were created.
- */
 export const updateContactAttributes = async (
   contactId: string,
   attributes: TContactAttributes
@@ -43,8 +38,9 @@ export const updateContactAttributes = async (
   const currentAttributeKeys = await getContactAttributeKeys(environmentId);
   const currentKeysSet = new Set(currentAttributeKeys.map((key) => key.key));
 
-  // Call the existing updateAttributes function
-  const updateResult = await updateAttributes(contactId, userId, environmentId, attributes);
+  // Call updateAttributes with deleteRemovedAttributes: true
+  // UI forms submit all attributes, so any missing attribute should be deleted
+  const updateResult = await updateAttributes(contactId, userId, environmentId, attributes, true);
 
   // Merge any messages from updateAttributes
   if (updateResult.messages) {


### PR DESCRIPTION
Backport of #7050

This PR backports the fix for user API attribute override error to the release/4.5 branch.

**Changes:**
- Added `deleteRemovedAttributes` parameter to `updateAttributes` function with default `false` to enable merge behavior for API calls
- Updated `updateContactAttributes` to pass `true` for `deleteRemovedAttributes` since UI forms submit all attributes
- Added JSDoc documentation explaining the behavior

**Original PR:** #7050
**Original Commit:** 1d125bdac2c3b67e8551e94f16be23d186d7d575

Note: Test file changes were excluded from this backport.