### PR TITLE
fix: (Backport) correct typo in recontact waiting time description and adjust da…

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -1826,7 +1826,7 @@ checksums:
     environments/workspace/general/delete_workspace_settings_description: 411ef100f167fc8fca64e833b6c0d030
     environments/workspace/general/error_saving_workspace_information: e7b8022785619ef34de1fb1630b3c476
     environments/workspace/general/only_owners_or_managers_can_delete_workspaces: 58da180cd2610210302d85a9896d80bd
-    environments/workspace/general/recontact_waiting_time: 8977b5160fbf88c456608982b33e246f
+    environments/workspace/general/recontact_waiting_time: 6873c18d51830e2cadef67cce6a2c95c
     environments/workspace/general/recontact_waiting_time_settings_description: ebd64fddbea9387b12c027a18358db7e
     environments/workspace/general/this_action_cannot_be_undone: 3d8b13374ffd3cefc0f3f7ce077bd9c9
     environments/workspace/general/wait_x_days_before_showing_next_survey: d96228788d32ec23dc0d8c8ba77150a6

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1935,7 +1935,7 @@
         "delete_workspace_settings_description": "Delete workspace with all surveys, responses, people, actions and attributes. This cannot be undone.",
         "error_saving_workspace_information": "Error saving workspace information",
         "only_owners_or_managers_can_delete_workspaces": "Only owners or managers can delete workspaces",
-        "recontact_waiting_time": "Cooldown Period (scross surveys)",
+        "recontact_waiting_time": "Cooldown Period (across surveys)",
         "recontact_waiting_time_settings_description": "Control how frequently users can be surveyed across all Website & App Surveys in this workspace.",
         "this_action_cannot_be_undone": "This action cannot be undone.",
         "wait_x_days_before_showing_next_survey": "Wait X days before showing next survey:",

--- a/packages/survey-ui/src/components/elements/date.tsx
+++ b/packages/survey-ui/src/components/elements/date.tsx
@@ -172,7 +172,7 @@ function DateElement({
             onSelect={handleDateSelect}
             locale={dateLocale}
             required={required}
-            className="rounded-input border-input-border bg-input-bg text-input-text shadow-input mx-auto w-full max-w-[25rem] border"
+            className="rounded-input border-input-border bg-input-bg text-input-text shadow-input mx-auto h-[stretch] w-full max-w-[25rem] border"
           />
         </div>
       </div>


### PR DESCRIPTION
Backport of commit 01cc0ab64daee990d3cc4a7dc83cba9661c183d5

This PR backports the fix for typo in recontact waiting time description and date element class adjustment to the release/4.5 branch.

**Changes:**
- Fixed typo: "scross" → "across" in recontact waiting time description
- Added `h-[stretch]` class to date element for improved layout consistency

**Original Commit:** 01cc0ab64daee990d3cc4a7dc83cba9661c183d5
**Original PR:** #7056