### PR TITLE
fix: (backport) fixes single use multi lang surveyUrl issue (#7057)

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/anonymous-links-tab.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/anonymous-links-tab.tsx
@@ -2,7 +2,7 @@
 
 import { CirclePlayIcon, CopyIcon } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { TSurvey } from "@formbricks/types/surveys/types";
@@ -34,7 +34,6 @@ export const AnonymousLinksTab = ({
   locale,
   isReadOnly,
 }: AnonymousLinksTabProps) => {
-  const surveyUrlWithCustomSuid = `${surveyUrl}?suId=CUSTOM-ID`;
   const router = useRouter();
   const { t } = useTranslation();
 
@@ -48,6 +47,12 @@ export const AnonymousLinksTab = ({
     type: "multi-use" | "single-use";
     pendingAction: () => Promise<void> | void;
   } | null>(null);
+
+  const surveyUrlWithCustomSuid = useMemo(() => {
+    const url = new URL(surveyUrl);
+    url.searchParams.set("suId", "CUSTOM-ID");
+    return url.toString();
+  }, [surveyUrl]);
 
   const resetState = () => {
     const { singleUse } = survey;
@@ -177,7 +182,11 @@ export const AnonymousLinksTab = ({
 
       if (!!response?.data?.length) {
         const singleUseIds = response.data;
-        const surveyLinks = singleUseIds.map((singleUseId) => `${surveyUrl}?suId=${singleUseId}`);
+        const surveyLinks = singleUseIds.map((singleUseId) => {
+          const url = new URL(surveyUrl);
+          url.searchParams.set("suId", singleUseId);
+          return url.toString();
+        });
 
         // Create content with just the links
         const csvContent = surveyLinks.join("\n");


### PR DESCRIPTION
Backport of commit 0ecc8aabff4d1c08dbc68d11894a0ab5e36ec64d

This PR backports the fix for single use multi-language survey URL issue to the release/4.5 branch.

**Changes:**
- Fixed URL construction for single-use survey links to properly handle query parameters using the URL API instead of string concatenation
- Added `useMemo` hook to optimize `surveyUrlWithCustomSuid` calculation
- Updated both the custom single-use ID URL and the generated single-use links to use proper URL parameter handling

This fixes issues with multi-language surveys where the survey URL already contains query parameters (like language codes), ensuring the `suId` parameter is properly appended without breaking existing parameters.

**Original Commit:** 0ecc8aabff4d1c08dbc68d11894a0ab5e36ec64d
**Original PR:** #7057
