### PR TITLE
chore: remove debug log from next.config.mjs

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -458,7 +458,5 @@ const sentryOptions = {
 // Runtime Sentry reporting still depends on DSN being set via environment variables
 const exportConfig = process.env.SENTRY_AUTH_TOKEN ? withSentryConfig(nextConfig, sentryOptions) : nextConfig;
 
-console.log("BASE PATH", nextConfig.basePath);
-
 
 export default exportConfig;


### PR DESCRIPTION
## What does this PR do?

This PR removes a debug `console.log` statement from `apps/web/next.config.mjs` that was accidentally left in the codebase.

## How should this be tested?

1. Verify that `console.log("BASE PATH", nextConfig.basePath);` is no longer present in `apps/web/next.config.mjs`.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
