### PR TITLE
fix: disappearing survey preview

### DIFF
--- a/apps/web/app/lib/templates.ts
+++ b/apps/web/app/lib/templates.ts
@@ -4835,7 +4835,7 @@ export const previewSurvey = (projectName: string, t: TFunction): TSurvey => {
     segment: null,
     blocks: [
       {
-        id: createId(),
+        id: "cltxxaa6x0000g8hacxdxeje1",
         name: "Block 1",
         elements: [
           {
@@ -4857,7 +4857,7 @@ export const previewSurvey = (projectName: string, t: TFunction): TSurvey => {
         backButtonLabel: createI18nString(t("templates.preview_survey_question_2_back_button_label"), []),
       },
       {
-        id: createId(),
+        id: "cltxxaa6x0000g8hacxdxeje2",
         name: "Block 2",
         elements: [
           {


### PR DESCRIPTION


### Summary
This PR fixes an issue where the survey preview in the Project Settings/Onboarding flow would disappear (render empty) when typing in the project name or changing brand colors.

### Problem
The `previewSurvey` template function was generating new random IDs (`createId()`) for survey blocks every time it was called.

In the `ProjectSettings` component, `previewSurvey` is called on every render (triggered by state changes like typing in the project name input). Because the block IDs changed on every keystroke, the `Survey` component lost track of the "current block" it was trying to display, causing it to fall back to an empty state or fail to find the active block.

### Solution
Updated `apps/web/app/lib/templates.ts` to use stable, hardcoded IDs for the blocks in the `previewSurvey` template. This ensures that the block IDs remain consistent across re-renders, allowing the Survey component to maintain its state and display the preview correctly while other props (like `projectName` or `brandColor`) are updated.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)