### PR TITLE
fix: remove subheader field from survey element presets

### DIFF
--- a/apps/web/modules/survey/lib/elements.tsx
+++ b/apps/web/modules/survey/lib/elements.tsx
@@ -168,7 +168,6 @@ export const getElementTypes = (t: TFunction): TElement[] => [
     icon: MousePointerClickIcon,
     preset: {
       headline: createI18nString("", []),
-      subheader: createI18nString("", []),
       ctaButtonLabel: createI18nString(t("templates.book_interview"), []),
       buttonUrl: "",
       buttonExternal: true,
@@ -182,7 +181,6 @@ export const getElementTypes = (t: TFunction): TElement[] => [
     icon: CheckIcon,
     preset: {
       headline: createI18nString("", []),
-      subheader: createI18nString("", []),
       label: createI18nString("", []),
     },
   },


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/formbricks/internal/issues/1251

We noticed that when a CTA or consent question is added, the description field is auto-focused by default. This doesn’t happen with other question types because their presets don’t include a description initially—it’s set to undefined. To address this, we aligned the CTA and consent behavior with the others by updating their presets, which resolves the auto-focus issue.

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Add CTA / consent question. Check if description is focused

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary
