### PR TITLE
chore: parallel processing in lingo.dev

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
     "generate-api-specs": "./scripts/openapi/generate.sh",
     "merge-client-endpoints": "tsx ./scripts/openapi/merge-client-endpoints.ts",
     "generate-and-merge-api-specs": "pnpm run generate-api-specs && pnpm run merge-client-endpoints",
-    "i18n:generate": "npx lingo.dev@latest i18n"
+    "i18n:generate": "npx lingo.dev@latest run && npx lingo.dev@latest lockfile --force"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.879.0",

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -35,7 +35,7 @@
     "clean": "rimraf .turbo node_modules dist",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "i18n:generate": "npx lingo.dev@latest i18n"
+    "i18n:generate": "npx lingo.dev@latest run && npx lingo.dev@latest lockfile --force"
   },
   "dependencies": {
     "@calcom/embed-snippet": "1.3.3",


### PR DESCRIPTION
## Summary

Optimizes the i18n workflow by switching from sequential to parallel processing using the updated Lingo.dev CLI commands.

## Changes

- Updated `i18n:generate` script in `apps/web/package.json`
- Updated `i18n:generate` script in `packages/surveys/package.json`

**Before:**
npx lingo.dev@latest i18n**After:**
npx lingo.dev@latest run && npx lingo.dev@latest lockfile --force

## Benefits

- **Parallel processing**: Distributes translation tasks across multiple workers (default: 10) for faster processing
- **Lockfile tracking**: Enables incremental updates by tracking content changes in `i18n.lock`
- **Better performance**: Significantly reduces processing time for large translation projects

<img width="1025" height="237" alt="Screenshot 2026-01-07 at 6 26 41 PM" src="https://github.com/user-attachments/assets/17874070-5194-4c36-875e-b651ed6286b5" />

<img width="711" height="152" alt="Screenshot 2026-01-07 at 7 06 48 PM" src="https://github.com/user-attachments/assets/c609adc6-f404-43ef-89db-32dd29e4d61d" />


## How to test
Compare i18n time with old setup

## Reference

[Lingo.dev CLI - Large Projects](https://lingo.dev/en/cli/fundamentals/large-projects)