### PR TITLE
perf: remove redundant database indexes

### DIFF
--- a/packages/database/migration/20260113160531_remove_unused_indexes/migration.sql
+++ b/packages/database/migration/20260113160531_remove_unused_indexes/migration.sql
@@ -1,0 +1,32 @@
+-- DropIndex
+DROP INDEX "public"."Membership_userId_idx";
+
+-- DropIndex
+DROP INDEX "public"."Project_organizationId_idx";
+
+-- DropIndex
+DROP INDEX "public"."Response_surveyId_idx";
+
+-- DropIndex
+DROP INDEX "public"."Segment_environmentId_idx";
+
+-- DropIndex
+DROP INDEX "public"."SurveyAttributeFilter_surveyId_idx";
+
+-- DropIndex
+DROP INDEX "public"."SurveyLanguage_languageId_idx";
+
+-- DropIndex
+DROP INDEX "public"."SurveyQuota_surveyId_idx";
+
+-- DropIndex
+DROP INDEX "public"."SurveyTrigger_surveyId_idx";
+
+-- DropIndex
+DROP INDEX "public"."Tag_environmentId_idx";
+
+-- DropIndex
+DROP INDEX "public"."TagsOnResponses_responseId_idx";
+
+-- DropIndex
+DROP INDEX "public"."User_email_idx";

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -173,7 +173,6 @@ model Response {
   @@index([createdAt])
   @@index([surveyId, createdAt]) // to determine monthly response count
   @@index([contactId, createdAt]) // to determine monthly identified users (persons)
-  @@index([surveyId])
 }
 
 /// Represents a label that can be applied to survey responses.
@@ -193,7 +192,6 @@ model Tag {
   environment   Environment       @relation(fields: [environmentId], references: [id], onDelete: Cascade)
 
   @@unique([environmentId, name])
-  @@index([environmentId])
 }
 
 /// Junction table linking tags to responses.
@@ -208,7 +206,6 @@ model TagsOnResponses {
   tag        Tag      @relation(fields: [tagId], references: [id], onDelete: Cascade)
 
   @@id([responseId, tagId])
-  @@index([responseId])
 }
 
 enum SurveyStatus {
@@ -259,7 +256,6 @@ model SurveyTrigger {
   actionClassId String
 
   @@unique([surveyId, actionClassId])
-  @@index([surveyId])
 }
 
 enum SurveyAttributeFilterCondition {
@@ -297,7 +293,6 @@ model SurveyAttributeFilter {
   value          String
 
   @@unique([surveyId, attributeKeyId])
-  @@index([surveyId])
   @@index([attributeKeyId])
 }
 
@@ -432,7 +427,6 @@ model SurveyQuota {
   countPartialSubmissions Boolean             @default(false)
 
   @@unique([surveyId, name])
-  @@index([surveyId])
 }
 
 /// Junction table linking responses to quotas.
@@ -635,7 +629,6 @@ model Project {
   customHeadScripts   String? // Custom HTML scripts for link surveys (self-hosted only)
 
   @@unique([organizationId, name])
-  @@index([organizationId])
 }
 
 /// Represents the top-level organizational hierarchy in Formbricks.
@@ -690,7 +683,6 @@ model Membership {
   role           OrganizationRole @default(member)
 
   @@id([userId, organizationId])
-  @@index([userId])
   @@index([organizationId])
 }
 
@@ -858,8 +850,6 @@ model User {
   teamUsers                 TeamUser[]
   lastLoginAt               DateTime?
   isActive                  Boolean          @default(true)
-
-  @@index([email])
 }
 
 /// Defines a segment of contacts based on attributes.
@@ -884,7 +874,6 @@ model Segment {
   surveys       Survey[]
 
   @@unique([environmentId, title])
-  @@index([environmentId])
 }
 
 /// Represents a supported language in the system.
@@ -924,7 +913,6 @@ model SurveyLanguage {
 
   @@id([languageId, surveyId])
   @@index([surveyId])
-  @@index([languageId])
 }
 
 /// Represents a team within an organization.


### PR DESCRIPTION
## What does this PR do?

This PR removes 11 redundant database indexes identified by database optimization. These indexes are already covered by existing composite primary keys, unique constraints, or other composite indexes in the PostgreSQL database.

### Redundant Indexes Removed:
1. `Membership_userId_idx` - covered by `@@id([userId, organizationId])`
2. `Project_organizationId_idx` - covered by `@@unique([organizationId, name])`
3. `Response_surveyId_idx` - covered by `@@index([surveyId, createdAt])`
4. `Segment_environmentId_idx` - covered by `@@unique([environmentId, title])`
5. `SurveyAttributeFilter_surveyId_idx` - covered by `@@unique([surveyId, attributeKeyId])`
6. `SurveyLanguage_languageId_idx` - covered by `@@id([languageId, surveyId])`
7. `SurveyQuota_surveyId_idx` - covered by `@@unique([surveyId, name])`
8. `SurveyTrigger_surveyId_idx` - covered by `@@unique([surveyId, actionClassId])`
9. `Tag_environmentId_idx` - covered by `@@unique([environmentId, name])`
10. `TagsOnResponses_responseId_idx` - covered by `@@id([responseId, tagId])`
11. `User_email_idx` - covered by `@unique` on the email field

Fixes #6587

## How should this be tested?

1. Verify that the removed indexes are indeed covered by existing constraints in `packages/database/schema.prisma`.
2. Ensure the new migration `packages/database/migration/20260113160531_remove_unused_indexes/migration.sql` correctly drops the identified indexes.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none