### PR TITLE
fix: update systeminformation to 5.27.14

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -46,7 +46,7 @@
     "@lexical/rich-text": "0.36.2",
     "@lexical/table": "0.36.2",
     "@opentelemetry/exporter-prometheus": "0.203.0",
-    "@opentelemetry/host-metrics": "0.36.0",
+    "@opentelemetry/host-metrics": "0.38.0",
     "@opentelemetry/instrumentation": "0.203.0",
     "@opentelemetry/instrumentation-http": "0.203.0",
     "@opentelemetry/instrumentation-runtime-node": "0.17.1",

--- a/package.json
+++ b/package.json
@@ -86,10 +86,11 @@
       "axios": ">=1.12.2",
       "node-forge": ">=1.3.2",
       "tar-fs": "2.1.4",
-      "typeorm": ">=0.3.26"
+      "typeorm": ">=0.3.26",
+      "systeminformation": "5.27.14"
     },
     "comments": {
-      "overrides": "Security fixes for transitive dependencies. Remove when upstream packages update: axios (CVE-2025-58754) - awaiting @boxyhq/saml-jackson update | node-forge (Dependabot #230) - awaiting @boxyhq/saml-jackson update | tar-fs (Dependabot #205) - awaiting upstream dependency updates | typeorm (Dependabot #223) - awaiting @boxyhq/saml-jackson update"
+      "overrides": "Security fixes for transitive dependencies. Remove when upstream packages update: axios (CVE-2025-58754) - awaiting @boxyhq/saml-jackson update | node-forge (Dependabot #230) - awaiting @boxyhq/saml-jackson update | tar-fs (Dependabot #205) - awaiting upstream dependency updates | typeorm (Dependabot #223) - awaiting @boxyhq/saml-jackson update | systeminformation (Dependabot #241) - awaiting @opentelemetry/host-metrics update"
     },
     "patchedDependencies": {
       "next-auth@4.24.12": "patches/next-auth@4.24.12.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   node-forge: '>=1.3.2'
   tar-fs: 2.1.4
   typeorm: '>=0.3.26'
+  systeminformation: 5.27.14
 
 patchedDependencies:
   next-auth@4.24.12:
@@ -199,8 +200,8 @@ importers:
         specifier: 0.203.0
         version: 0.203.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/host-metrics':
-        specifier: 0.36.0
-        version: 0.36.0(@opentelemetry/api@1.9.0)
+        specifier: 0.38.0
+        version: 0.38.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation':
         specifier: 0.203.0
         version: 0.203.0(@opentelemetry/api@1.9.0)
@@ -2964,8 +2965,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/host-metrics@0.36.0':
-    resolution: {integrity: sha512-14lNY57qa21V3ZOl6xrqLMHR0HGlnPIApR6hr3oCw/Dqs5IzxhTwt2X8Stn82vWJJis7j/ezn11oODsizHj2dQ==}
+  '@opentelemetry/host-metrics@0.38.0':
+    resolution: {integrity: sha512-5iiVhDLa3siMiq95P9/VUtwwNR4mv5/2q79iwMXDbw2if+kRsTGQhSQTClN+POpXeZIEFDlHl/R2TTZ1XWCdkA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -10129,8 +10130,8 @@ packages:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  systeminformation@5.23.8:
-    resolution: {integrity: sha512-Osd24mNKe6jr/YoXLLK3k8TMdzaxDffhpCxgkfgBHcapykIkd50HXThM3TCEuHO2pPuCsSx2ms/SunqhU5MmsQ==}
+  systeminformation@5.27.14:
+    resolution: {integrity: sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==}
     engines: {node: '>=8.0.0'}
     os: [darwin, linux, win32, freebsd, openbsd, netbsd, sunos, android]
     hasBin: true
@@ -13843,10 +13844,10 @@ snapshots:
       '@opentelemetry/resources': 2.0.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.0.1(@opentelemetry/api@1.9.0)
 
-  '@opentelemetry/host-metrics@0.36.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/host-metrics@0.38.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      systeminformation: 5.23.8
+      systeminformation: 5.27.14
 
   '@opentelemetry/instrumentation-amqplib@0.50.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -21954,7 +21955,7 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
-  systeminformation@5.23.8: {}
+  systeminformation@5.27.14: {}
 
   tabbable@6.3.0: {}
 


### PR DESCRIPTION
## Summary
This PR addresses the Dependabot alert (#241) regarding a high-severity command injection vulnerability in `systeminformation` (CVE-2025-68154) on Windows systems.

- Updated `@opentelemetry/host-metrics` to `0.38.0`.
- Added a `pnpm` override for `systeminformation` to ensure version `5.27.14` is used across all transitive dependencies.
- Verified that `pnpm build` still passes.

## Test plan
- [x] Run `pnpm build` to verify compatibility.
- [x] Confirm `systeminformation@5.27.14` is resolved in `pnpm-lock.yaml`.