### PR TITLE
chore: update pre-commit hook to address husky warning

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 # Load environment variables from .env files
 if [ -f .env ]; then
   set -a


### PR DESCRIPTION
## What does this PR do?

This PR removes the deprecated lines from the husky pre-commit hook that were causing warnings and are scheduled to fail in husky v10.0.0.

Deprecated lines removed:
- `#!/bin/sh`
- `. "$(dirname "$0")/_/husky.sh"`

## How should this be tested?

1. Try to make a commit.
2. Observe that the husky pre-commit hook still runs (e.g., `pnpm lint-staged` and translation workflow).
3. Confirm that the deprecation warning is no longer present.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary