### PR TITLE
chore(docker): add healthchecks and wait for postgres and redis readiness

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -207,6 +207,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 30
+      start_period: 30s
 
   # Redis/Valkey service for caching, rate limiting, and audit logging
   # Remove this service if you want to use an external Redis/Valkey instance
@@ -223,6 +224,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 30
+      start_period: 10s
 
   formbricks:
     restart: always


### PR DESCRIPTION
## What does this PR do?

Adds explicit healthchecks for Postgres and Redis Valkey services and updates docker compose depends_on to wait for service readiness before starting Formbricks.

This improves reliability during first time startup and reduces race conditions where the app starts before its dependencies are ready.

Related to #6597

## How should this be tested?

- docker compose down -v
- docker compose up -d
- Verify Postgres and Redis containers reach healthy state before Formbricks stays up
- Access the app at http://localhost:3000 and complete initial setup

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` (not applicable, docker compose only change)
- [x] Checked for warnings, there are none
- [x] Removed all console.logs
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? Please sign the CLA

### Appreciated

- [ ] UI change screenshots not applicable
- [ ] Docs update not required
