### PR TITLE
fix: console warnings in survey ui package

### DIFF
--- a/packages/survey-ui/src/components/general/calendar.tsx
+++ b/packages/survey-ui/src/components/general/calendar.tsx
@@ -188,7 +188,6 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        // @ts-expect-error - React types version mismatch - the project uses React 19 types, but some Radix UI packages (react-day-picker) bundle their own older React types, creating incompatible Ref type definitions
         Root: CalendarRoot,
         Chevron: CalendarChevron,
         DayButton: CalendarDayButton,

--- a/packages/survey-ui/src/components/general/progress.tsx
+++ b/packages/survey-ui/src/components/general/progress.tsx
@@ -9,7 +9,6 @@ export interface ProgressProps extends Omit<React.ComponentProps<"div">, "childr
 function Progress({ className, value, ...props }: Readonly<ProgressProps>): React.JSX.Element {
   const progressValue: number = typeof value === "number" ? value : 0;
   return (
-    // @ts-expect-error - React types version mismatch - the project uses React 19 types, but some Radix UI packages (@radix-ui/react-progress) bundle their own older React types, creating incompatible Ref type definitions
     <ProgressPrimitive.Root
       data-slot="progress"
       value={progressValue}


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes warnings in survey ui package

<img width="1125" height="267" alt="Screenshot 2026-01-19 at 12 25 35 PM" src="https://github.com/user-attachments/assets/1cc6cb81-59cf-42e3-8377-0f58ffc85a11" />


<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Build survey ui package

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary
