### PR TITLE
fix: handle server errors in survey publish flow

### DIFF
--- a/apps/web/modules/survey/editor/components/survey-menu-bar.tsx
+++ b/apps/web/modules/survey/editor/components/survey-menu-bar.tsx
@@ -425,11 +425,19 @@ export const SurveyMenuBar = ({
       const segment = await handleSegmentUpdate();
       clearSurveyLocalStorage();
 
-      await updateSurveyAction({
+      const publishResult = await updateSurveyAction({
         ...localSurvey,
         status,
         segment,
       });
+
+      if (!publishResult?.data) {
+        const errorMessage = getFormattedErrorMessage(publishResult);
+        toast.error(errorMessage);
+        setIsSurveyPublishing(false);
+        return;
+      }
+
       setIsSurveyPublishing(false);
       // Set flag to prevent beforeunload warning during navigation
       isSuccessfullySavedRef.current = true;
@@ -467,7 +475,7 @@ export const SurveyMenuBar = ({
         />
       </div>
 
-      <div className="mt-3 flex items-center gap-2 sm:mt-0 sm:ml-4">
+      <div className="mt-3 flex items-center gap-2 sm:ml-4 sm:mt-0">
         <AutoSaveIndicator isDraft={localSurvey.status === "draft"} lastSaved={lastAutoSaved} />
         {!isStorageConfigured && (
           <div>


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where publishing a survey with a CTA external button would silently fail, leaving the survey in "draft" status while showing the user a success page.

**Root Cause:** The `handleSurveyPublish` function was not checking the result of `updateSurveyAction`. When the server returned an error (e.g., "External URLs are not enabled for this organization"), the client ignored it and navigated to the success page anyway.

**Symptoms:**
- Survey appeared to publish successfully (success banner shown)
- Status dropdown (In Progress/Paused/Completed) was not displayed on summary page
- Visiting the survey link showed "Survey not found"
- Only occurred with CTA questions that had external button + link enabled

**Fix:** Properly check the result of `updateSurveyAction` and display an error toast if the publish fails, instead of silently navigating to the success page.

## How should this be tested?

- Create a new survey with one block containing:
  - An open text question
  - A CTA question with "External button" and "Link" enabled (any valid URL like `https://example.com`)
- Attempt to publish the survey on a free plan (where external URLs are not allowed)
- **Expected (before fix):** User sees success page but survey remains in draft, shows "Survey not found" on public link
- **Expected (after fix):** User sees error toast "External URLs are not enabled for this organization. Upgrade to use external CTA buttons."

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks)

### Appreciated

- N/A (no UI changes, only error handling fix)