### PR TITLE
fix: fixes response card UI for cta question

### DIFF
--- a/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
@@ -3,6 +3,7 @@
 import { CheckCircle2Icon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { TResponseWithQuotas } from "@formbricks/types/responses";
+import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/constants";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { getTextContent } from "@formbricks/types/surveys/validation";
 import { getLocalizedValue } from "@/lib/i18n/utils";
@@ -67,6 +68,16 @@ export const SingleResponseCardBody = ({
           <VerifiedEmail responseData={response.data} />
         )}
         {elements.map((question) => {
+          // Skip CTA elements without external buttons only if they have no response data
+          // This preserves historical data from when buttonExternal was true
+          if (
+            question.type === TSurveyElementTypeEnum.CTA &&
+            !question.buttonExternal &&
+            !response.data[question.id]
+          ) {
+            return null;
+          }
+
           const skipped = skippedQuestions.find((skippedQuestionElement) =>
             skippedQuestionElement.includes(question.id)
           );


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where CTA (Call To Action) elements without external buttons were incorrectly displayed as "skipped" in the response card view.

**Problem:**
- CTA elements with `buttonExternal: false` are presentation-only and don't collect response data
- However, the response card was still rendering them and showing them as "skipped" because `isValidValue(response.data[question.id])` returned false

**Solution:**
- Skip rendering CTA elements that have no external button AND no response data
- Preserve historical response data for CTAs that previously had `buttonExternal: true` but were later changed to `false`

This is consistent with how the survey summary already handles these elements.

## How should this be tested?

- Create a survey with a CTA element that has NO external button (just a "Next" button)
- Add other questions after the CTA
- Submit a response through the survey
- View the response in the responses tab
- Verify the CTA is NOT shown as "skipped" in the response card

**Edge case test:**
- Create a survey with a CTA that HAS an external button
- Submit a response (click or skip the CTA)
- Edit the survey and remove the external button from the CTA
- View the old response
- Verify the CTA response data ("clicked" or historical data) is still visible

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary