### PR TITLE
fix: (BACKPORT) language variants not working for app surveys (#7151)

### DIFF
--- a/packages/js-core/src/lib/common/utils.ts
+++ b/packages/js-core/src/lib/common/utils.ts
@@ -170,7 +170,7 @@ export const getLanguageCode = (survey: TEnvironmentStateSurvey, language?: stri
 
   const selectedLanguage = survey.languages.find((surveyLanguage) => {
     return (
-      surveyLanguage.language.code === language.toLowerCase() ||
+      surveyLanguage.language.code.toLowerCase() === language.toLowerCase() ||
       surveyLanguage.language.alias?.toLowerCase() === language.toLowerCase()
     );
   });


### PR DESCRIPTION
## Backport

This PR backports the fix from #7151 to the `release/4.6` branch.

**Original commit:** `6be654ab605ff121c82c196b0d995bc3d6e40af3`

## Problem

Language variants were not working correctly for app surveys. The issue occurred when comparing language codes in the `getLanguageCode` function - the comparison was case-sensitive on one side but case-insensitive on the other, causing language matching to fail in certain scenarios.

## Solution

Fixed the language code comparison in `getLanguageCode` function (`packages/js-core/src/lib/common/utils.ts`) to ensure both sides of the comparison are case-insensitive by calling `.toLowerCase()` on `surveyLanguage.language.code` as well.

**Before:**
surveyLanguage.language.code === language.toLowerCase()
