### PR TITLE
fix: (backport) jerky animation behaviour (#7158)

### DIFF
--- a/apps/web/modules/ui/components/preview-survey/index.tsx
+++ b/apps/web/modules/ui/components/preview-survey/index.tsx
@@ -259,6 +259,7 @@ export const PreviewSurvey = ({
                       setBlockId = f;
                     }}
                     onFinished={onFinished}
+                    placement={placement}
                     isSpamProtectionEnabled={isSpamProtectionEnabled}
                   />
                 </Modal>
@@ -363,6 +364,7 @@ export const PreviewSurvey = ({
                   }}
                   onFinished={onFinished}
                   isSpamProtectionEnabled={isSpamProtectionEnabled}
+                  placement={placement}
                 />
               </Modal>
             ) : (

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -76,6 +76,7 @@ export function Survey({
   isSpamProtectionEnabled,
   dir = "auto",
   setDir,
+  placement,
 }: SurveyContainerProps) {
   let apiClient: ApiClient | null = null;
 
@@ -916,6 +917,7 @@ export function Survey({
       setBlockId={setBlockId}
       shouldResetBlockId={shouldResetQuestionId}
       fullSizeCards={fullSizeCards}
+      placement={placement}
     />
   );
 }

--- a/packages/surveys/src/components/wrappers/stacked-card.tsx
+++ b/packages/surveys/src/components/wrappers/stacked-card.tsx
@@ -2,6 +2,7 @@ import { MutableRef } from "preact/hooks";
 import { useEffect, useMemo, useState } from "preact/hooks";
 import { JSX } from "preact/jsx-runtime";
 import React from "react";
+import { type TPlacement } from "@formbricks/types/common";
 import { TJsEnvironmentStateSurvey } from "@formbricks/types/js";
 import { TCardArrangementOptions } from "@formbricks/types/styling";
 
@@ -17,6 +18,7 @@ interface StackedCardProps {
   cardWidth: number;
   hovered: boolean;
   cardArrangement: TCardArrangementOptions;
+  placement: TPlacement;
 }
 
 export const StackedCard = ({
@@ -31,17 +33,24 @@ export const StackedCard = ({
   cardWidth,
   hovered,
   cardArrangement,
+  placement,
 }: StackedCardProps) => {
   const isHidden = offset < 0;
   const [delayedOffset, setDelayedOffset] = useState<number>(offset);
   const [contentOpacity, setContentOpacity] = useState<number>(0);
   const currentCardHeight = offset === 0 ? "auto" : offset < 0 ? "initial" : cardHeight;
 
-  const getBottomStyles = () => {
+  const getTopBottomStyles = () => {
     if (survey.type !== "link")
-      return {
-        bottom: 0,
-      };
+      if (placement === "bottomLeft" || placement === "bottomRight") {
+        return {
+          bottom: 0,
+        };
+      } else if (placement === "topLeft" || placement === "topRight") {
+        return {
+          top: 0,
+        };
+      }
   };
 
   const getDummyCardContent = () => {
@@ -111,7 +120,7 @@ export const StackedCard = ({
         pointerEvents: offset === 0 ? "auto" : "none",
         ...borderStyles,
         ...straightCardArrangementStyles,
-        ...getBottomStyles(),
+        ...getTopBottomStyles(),
       }}
       className="pointer rounded-custom bg-survey-bg absolute inset-x-0 overflow-hidden">
       <div

--- a/packages/surveys/src/components/wrappers/stacked-cards-container.tsx
+++ b/packages/surveys/src/components/wrappers/stacked-cards-container.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "preact/hooks";
 import type { JSX } from "react";
+import { type TPlacement } from "@formbricks/types/common";
 import { type TJsEnvironmentStateSurvey } from "@formbricks/types/js";
 import { type TProjectStyling } from "@formbricks/types/project";
 import { type TCardArrangementOptions } from "@formbricks/types/styling";
@@ -19,6 +20,7 @@ interface StackedCardsContainerProps {
   setBlockId: (blockId: string) => void;
   shouldResetBlockId?: boolean;
   fullSizeCards: boolean;
+  placement?: TPlacement;
 }
 
 export function StackedCardsContainer({
@@ -30,6 +32,7 @@ export function StackedCardsContainer({
   setBlockId,
   shouldResetBlockId = true,
   fullSizeCards = false,
+  placement = "bottomRight",
 }: Readonly<StackedCardsContainerProps>) {
   const [hovered, setHovered] = useState(false);
   const highlightBorderColor = survey.styling?.overwriteThemeStyling
@@ -179,6 +182,7 @@ export function StackedCardsContainer({
               cardWidth={cardWidth}
               hovered={hovered}
               cardArrangement={cardArrangement}
+              placement={placement}
             />
           );
         })

--- a/packages/surveys/src/index.ts
+++ b/packages/surveys/src/index.ts
@@ -36,18 +36,35 @@ export const renderSurvey = (props: SurveyContainerProps) => {
       throw new Error(`renderSurvey: Element with id ${containerId} not found.`);
     }
 
-    const { placement, darkOverlay, onClose, clickOutside, ...surveyInlineProps } = props;
+    // if survey type is link, we don't pass the placement, darkOverlay, clickOutside, onClose
+    if (props.survey.type === "link") {
+      const { placement, darkOverlay, onClose, clickOutside, ...surveyInlineProps } = props;
 
-    render(
-      h(
-        I18nProvider,
-        { language },
-        h(RenderSurvey, {
-          ...surveyInlineProps,
-        })
-      ),
-      element
-    );
+      render(
+        h(
+          I18nProvider,
+          { language },
+          h(RenderSurvey, {
+            ...surveyInlineProps,
+          })
+        ),
+        element
+      );
+    } else {
+      // For non-link surveys, pass placement through so it can be used in StackedCard
+      const { darkOverlay, onClose, clickOutside, ...surveyInlineProps } = props;
+
+      render(
+        h(
+          I18nProvider,
+          { language },
+          h(RenderSurvey, {
+            ...surveyInlineProps,
+          })
+        ),
+        element
+      );
+    }
   } else {
     const modalContainer = document.createElement("div");
     modalContainer.id = "formbricks-modal-container";


### PR DESCRIPTION
## Backport

This PR backports the fix from #7158 to the `release/4.6` branch.

**Original commit:** `8f7d225d6aa0b0ad8a214aa027f4d67cc26f882d`

## Problem

Survey cards had jerky animation behavior, particularly when surveys were displayed in different placements (topLeft, topRight, bottomLeft, bottomRight). The `StackedCard` component was hardcoded to use `bottom: 0` positioning, which caused incorrect animations and visual glitches when surveys were positioned at the top of the screen.

## Solution

Fixed the animation behavior by properly passing the `placement` prop through the component tree and using it to determine the correct positioning styles:

1. **Updated `PreviewSurvey` component** (`apps/web/modules/ui/components/preview-survey/index.tsx`):
   - Added `placement` prop to `Survey` component calls for both modal and inline previews

2. **Updated `Survey` component** (`packages/surveys/src/components/general/survey.tsx`):
   - Added `placement` prop to component interface
   - Passed `placement` prop to `StackedCardsContainer`

3. **Updated `StackedCard` component** (`packages/surveys/src/components/wrappers/stacked-card.tsx`):
   - Added `placement` prop to component interface
   - Refactored `getBottomStyles()` to `getTopBottomStyles()` that returns appropriate styles based on placement:
     - `bottomLeft` / `bottomRight`: Uses `bottom: 0`
     - `topLeft` / `topRight`: Uses `top: 0`
   - This ensures cards animate correctly regardless of placement

4. **Updated `StackedCardsContainer` component** (`packages/surveys/src/components/wrappers/stacked-cards-container.tsx`):
   - Added `placement` prop with default value `"bottomRight"`
   - Passed `placement` prop to each `StackedCard` instance

5. **Updated `renderSurvey` function** (`packages/surveys/src/index.ts`):
   - Conditionally handles `placement` prop based on survey type
   - For link surveys: placement is not passed (as it's not applicable)
   - For non-link surveys: placement is passed through to enable proper animation behavior

**Key improvements:**
- Cards now animate smoothly regardless of survey placement
- Proper positioning styles applied based on actual placement (top vs bottom)
- Better separation of concerns between link and non-link survey types

## Testing

- [x] Cherry-picked commit from main branch
- [x] Verified the change applies cleanly to `release/4.6`
- [x] Survey cards now animate smoothly in all placement positions