### PR TITLE
fix(security): upgrade qs to fix DoS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,10 +89,11 @@
       "node-forge": ">=1.3.2",
       "tar-fs": "2.1.4",
       "typeorm": ">=0.3.26",
-      "systeminformation": "5.27.14"
+      "systeminformation": "5.27.14",
+      "qs": ">=6.14.1"
     },
     "comments": {
-      "overrides": "Security fixes for transitive dependencies. Remove when upstream packages update: axios (CVE-2025-58754) - awaiting @boxyhq/saml-jackson update | node-forge (Dependabot #230) - awaiting @boxyhq/saml-jackson update | tar-fs (Dependabot #205) - awaiting upstream dependency updates | typeorm (Dependabot #223) - awaiting @boxyhq/saml-jackson update | systeminformation (Dependabot #241) - awaiting @opentelemetry/host-metrics update"
+      "overrides": "Security fixes for transitive dependencies. Remove when upstream packages update: axios (CVE-2025-58754) - awaiting @boxyhq/saml-jackson update | node-forge (Dependabot #230) - awaiting @boxyhq/saml-jackson update | tar-fs (Dependabot #205) - awaiting upstream dependency updates | typeorm (Dependabot #223) - awaiting @boxyhq/saml-jackson update | systeminformation (Dependabot #241) - awaiting @opentelemetry/host-metrics update | qs (Dependabot #245) - awaiting googleapis-common and stripe updates"
     },
     "patchedDependencies": {
       "next-auth@4.24.12": "patches/next-auth@4.24.12.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,7 @@ overrides:
   tar-fs: 2.1.4
   typeorm: '>=0.3.26'
   systeminformation: 5.27.14
+  qs: '>=6.14.1'
 
 patchedDependencies:
   next-auth@4.24.12:
@@ -9378,8 +9379,8 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -19495,7 +19496,7 @@ snapshots:
       extend: 3.0.2
       gaxios: 6.7.1(encoding@0.1.13)
       google-auth-library: 9.15.1(encoding@0.1.13)
-      qs: 6.14.0
+      qs: 6.14.1
       url-template: 2.0.8
       uuid: 11.1.0
     transitivePeerDependencies:
@@ -21323,7 +21324,7 @@ snapshots:
       pngjs: 5.0.0
       yargs: 15.4.1
 
-  qs@6.14.0:
+  qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
 
@@ -22374,7 +22375,7 @@ snapshots:
   stripe@16.12.0:
     dependencies:
       '@types/node': 22.15.18
-      qs: 6.14.0
+      qs: 6.14.1
 
   strnum@1.1.2: {}
 


### PR DESCRIPTION
## Summary
- Adds pnpm override to force `qs>=6.14.1`, fixing the arrayLimit bypass vulnerability that allows DoS via memory exhaustion
- Resolves Dependabot alert #245
- Affected transitive dependencies: `googleapis-common` and `stripe`

## Test plan
- [x] Verified `qs@6.14.1` is now in pnpm-lock.yaml
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)