### PR TITLE
fix: show error toast when webhook test fails internally

### DIFF
--- a/apps/web/modules/integrations/webhooks/components/webhook-settings-tab.tsx
+++ b/apps/web/modules/integrations/webhooks/components/webhook-settings-tab.tsx
@@ -67,7 +67,7 @@ export const WebhookSettingsTab = ({ webhook, surveys, setOpen, isReadOnly }: We
       }
       setHittingEndpoint(true);
       const testEndpointActionResult = await testEndpointAction({ url: testEndpointInput });
-      if (!testEndpointActionResult?.data) {
+      if (!testEndpointActionResult?.data || testEndpointActionResult?.serverError) {
         const errorMessage = getFormattedErrorMessage(testEndpointActionResult);
         throw new Error(errorMessage);
       }


### PR DESCRIPTION
## What does this PR do?

Fixes #4140

The webhook test endpoint was showing a success message even when the internal API call failed. This change adds a check for serverError in the response to properly display error toasts when the test fails.

## How should this be tested?

1. Go to Integrations → Webhooks
2. Enter an invalid webhook URL (e.g., http://invalid.test)
3. Click "Test Endpoint"
4. Verify error toast appears (instead of success)
5. Enter a valid webhook URL
6. Verify success toast still works

## Checklist

### Required
- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md)
- [x] Self-reviewed my own code
- [x] My changes don't cause any responsiveness issues

### Appreciated
- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
