### PR TITLE
fix: distributed lock for license fetch when Redis cache is cold

### DIFF
--- a/packages/cache/src/cache-keys.ts
+++ b/packages/cache/src/cache-keys.ts
@@ -32,6 +32,7 @@ export const createCacheKey = {
     status: (organizationId: string): CacheKey => makeCacheKey("license", organizationId, "status"),
     previous_result: (organizationId: string): CacheKey =>
       makeCacheKey("license", organizationId, "previous_result"),
+    fetch_lock: (organizationId: string): CacheKey => makeCacheKey("license", organizationId, "fetch_lock"),
   },
 
   // Rate limiting and security


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #(issue)

- Multi-process stampede when cache is cold: In production (e.g. EKS), multiple Next.js server processes run. When the Redis license cache is cleared (manual flush, upgrade, or restart), every process saw an empty cache at once.
- No cross-process coordination: The previous implementation used cache.withCache(fn, key, ttl): on cache miss, each process independently ran the expensive fn() (DB count + license API call). There was no lock, so all N processes did the full fetch in parallel.
- Result: N × (prisma.response.count + HTTP to license server) = severe CPU spike (e.g. 100% across all cores) until the cache was repopulated. Customers reported this after clearing the Redis license cache post-upgrade.

How this fix works

- Single fetcher when cache is cold: When the license cache key is missing, the first process to acquire a Redis distributed lock (tryLock) runs the expensive fetch and writes the result to Redis. Other processes do not run the fetch.
- Others wait for the result: Processes that do not get the lock poll Redis for the license key (e.g. every 400ms, up to 12s). When the lock holder writes the result, they read it and return without doing their own fetch.
- Fallback if holder is slow or dies: If the cache is still empty after the poll window, a process falls back to running the fetch itself so the system never blocks indefinitely.
- Cache hit unchanged: When the license is already in Redis (or in the 1-min process memory cache), behavior is unchanged: no lock, fast read.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Test A
- Test B

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
