### PR TITLE
chore: survey ui console warnings

### DIFF
--- a/packages/survey-ui/vite.config.mts
+++ b/packages/survey-ui/vite.config.mts
@@ -19,6 +19,8 @@ import tailwindcss from "@tailwindcss/vite";
  */
 export default defineConfig({
   build: {
+    // Keep dist when running watch so surveys (and others) can resolve types during parallel go
+    emptyOutDir: false,
     lib: {
       entry: "src/index.ts",
       formats: ["es"],

--- a/packages/surveys/tsconfig.json
+++ b/packages/surveys/tsconfig.json
@@ -7,7 +7,8 @@
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@formbricks/survey-ui": ["../survey-ui"]
     },
     "resolveJsonModule": true
   },

--- a/turbo.json
+++ b/turbo.json
@@ -88,16 +88,16 @@
       "persistent": true
     },
     "@formbricks/surveys#build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["^build", "@formbricks/survey-ui#build"],
       "outputs": ["dist/**"]
     },
     "@formbricks/surveys#build:dev": {
-      "dependsOn": ["^build:dev", "@formbricks/i18n-utils#build"],
+      "dependsOn": ["^build:dev", "@formbricks/i18n-utils#build", "@formbricks/survey-ui#build:dev"],
       "outputs": ["dist/**"]
     },
     "@formbricks/surveys#go": {
       "cache": false,
-      "dependsOn": ["@formbricks/surveys#build"],
+      "dependsOn": ["@formbricks/survey-ui#build", "@formbricks/surveys#build"],
       "persistent": true
     },
     "@formbricks/surveys#test": {


### PR DESCRIPTION
Fix: @formbricks/surveys cannot resolve @formbricks/survey-ui during build / `pnpm go`

<img width="804" height="582" alt="Screenshot 2026-02-09 at 11 30 07 AM" src="https://github.com/user-attachments/assets/77ac53c6-b144-4891-9589-02222618c720" />


## Problem

When running `pnpm go` (or building `@formbricks/surveys` in isolation), the build showed this errors:

```
error TS2307: Cannot find module '@formbricks/survey-ui' or its corresponding type declarations.
```

**Root causes:**

1. **Build order** – Although `surveys` declares a dependency on `@formbricks/survey-ui`, the Turbo pipeline did not explicitly guarantee that `survey-ui` was built before `surveys`. When running only the surveys task or with high concurrency, `surveys` could run before `survey-ui` had produced `dist/`, so the module and its types were missing.

2. **Race with watch** – When `pnpm go` runs, both `survey-ui#go` and `surveys#go` start. The survey-ui watch build uses Vite’s default `emptyOutDir: true`, so it clears `dist/` at the start. That left a window where `surveys`’ type-check (e.g. in `vite-plugin-dts`) could run while `survey-ui`’s `dist/` was empty, triggering the same TS2307 errors.

3. **Type resolution** – The TypeScript run by `vite-plugin-dts` for declaration generation did not always resolve the workspace package `@formbricks/survey-ui` correctly. Adding an explicit path in the surveys package ensures the compiler resolves it to the sibling package and its `dist` types.

## Solution

### 1. Turbo: explicit build dependencies

- **`@formbricks/surveys#build`** – `dependsOn` now includes `@formbricks/survey-ui#build`, so `survey-ui` is always built before `surveys`.
- **`@formbricks/surveys#build:dev`** – `dependsOn` now includes `@formbricks/survey-ui#build:dev`.
- **`@formbricks/surveys#go`** – `dependsOn` now includes `@formbricks/survey-ui#build` (and `@formbricks/surveys#build`), so the watch tasks only start after a full build of `survey-ui` (and `surveys`), and `survey-ui`’s `dist/` is present when `surveys` runs.

This guarantees that whenever `surveys` builds or runs `go`, `survey-ui` has already been built and its `dist/` (and types) exist.

### 2. Survey-ui: do not clear `dist` in watch

- In **`packages/survey-ui/vite.config.mts`**, `build.emptyOutDir` is set to **`false`**.

So when `survey-ui#go` starts its watch build, it no longer wipes `dist/`. The output from `survey-ui#build` remains available for `surveys` (and any other consumer) that runs in parallel, avoiding the race that caused TS2307 during type-checking.

### 3. Surveys: TypeScript path for workspace package

- In **`packages/surveys/tsconfig.json`**, a path mapping was added:

  `"@formbricks/survey-ui": ["../survey-ui"]`

This makes the TypeScript compiler (and thus `vite-plugin-dts`) resolve `@formbricks/survey-ui` to the sibling package directory, which in turn uses its `package.json` `types` (e.g. `dist/index.d.ts`). Resolution is consistent and no longer depends on `node_modules` layout or timing.

## Testing

- run `pnpm go` and checks for console errors
