### PR TITLE
fix: include description and key fields in saved actions search

### DIFF
--- a/apps/web/modules/survey/editor/components/saved-actions-tab.tsx
+++ b/apps/web/modules/survey/editor/components/saved-actions-tab.tsx
@@ -45,9 +45,13 @@ export const SavedActionsTab = ({
       <Input
         type="text"
         onChange={(e) => {
+          const query = e.target.value.toLowerCase();
           setFilteredActionClasses(
-            availableActions.filter((actionClass) =>
-              actionClass.name.toLowerCase().includes(e.target.value.toLowerCase())
+            availableActions.filter(
+              (actionClass) =>
+                actionClass.name.toLowerCase().includes(query) ||
+                (actionClass.description ?? "").toLowerCase().includes(query) ||
+                (actionClass.key ?? "").toLowerCase().includes(query)
             )
           );
         }}


### PR DESCRIPTION
## Summary

Fixes #7231

The search input in the "Saved Actions" tab only filters by `actionClass.name`. This means searching for text in the description or key fields returns zero results.

## Changes

Expanded the filter in `saved-actions-tab.tsx` to also match against `actionClass.description` and `actionClass.key` (both nullable, so null-coalesced to empty string).

## Before
- Searching `"onboarding"` returns 0 results even if an action's description contains it
- Searching `"user.create"` returns 0 results even if it matches a key

## After
- Search matches against name, description, and key fields