### PR TITLE
fix: add auth checks to OAuth integration callbacks (#1338)

### DIFF
--- a/apps/web/app/api/v1/integrations/slack/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/slack/callback/route.ts
@@ -5,12 +5,19 @@ import {
   TIntegrationSlackCredential,
 } from "@formbricks/types/integration/slack";
 import { responses } from "@/app/lib/api/response";
-import { withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
+import { TSessionAuthentication, withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
 import { SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, WEBAPP_URL } from "@/lib/constants";
+import { hasUserEnvironmentAccess } from "@/lib/environment/auth";
 import { createOrUpdateIntegration, getIntegrationByType } from "@/lib/integration/service";
 
 export const GET = withV1ApiWrapper({
-  handler: async ({ req }: { req: NextRequest }) => {
+  handler: async ({
+    req,
+    authentication,
+  }: {
+    req: NextRequest;
+    authentication: NonNullable<TSessionAuthentication>;
+  }) => {
     const url = req.url;
     const queryParams = new URLSearchParams(url.split("?")[1]); // Split the URL and get the query parameters
     const environmentId = queryParams.get("state"); // Get the value of the 'state' parameter
@@ -20,6 +27,13 @@ export const GET = withV1ApiWrapper({
     if (!environmentId) {
       return {
         response: responses.badRequestResponse("Invalid environmentId"),
+      };
+    }
+
+    const canUserAccessEnvironment = await hasUserEnvironmentAccess(authentication.user.id, environmentId);
+    if (!canUserAccessEnvironment) {
+      return {
+        response: responses.unauthorizedResponse(),
       };
     }
 


### PR DESCRIPTION
## Summary

Fixes critical security vulnerability in OAuth integration callbacks where an attacker could bind their third-party account (Google, Slack, Notion) to a victim's environment without authentication or environment access checks.


Fixes https://github.com/formbricks/internal/issues/1338
Fixes https://github.com/formbricks/internal/issues/1338

## Changes

### Google Sheets callback (`/api/google-sheet/callback`)
- **Previously**: No authentication - anyone could complete OAuth with any environmentId from the state param
- **Now**: Requires valid session + `hasUserEnvironmentAccess` verification before creating/updating integration

### Slack callback (`/api/v1/integrations/slack/callback`)
- **Previously**: Session required but no environment access check - logged-in users could target other orgs' environments
- **Now**: Adds `hasUserEnvironmentAccess` check (Airtable already had this)

### Notion callback (`/api/v1/integrations/notion/callback`)
- Same fix as Slack

## Attack scenario prevented

1. Attacker obtains any environmentId (URLs, guessable IDs)
2. Initiates OAuth with `state=\<victim_env_id\>`
3. Completes OAuth with their own Google/Slack/Notion account
4. ~~Their account gets bound to victim's environment → export all responses~~ **Now blocked**

## Testing

- Direct navigation to callback with forged state (env ID you don't have access to) returns 401 Unauthorized
- Legitimate flow (from integrations page) continues to work as before

Made with [Cursor](https://cursor.com)