### PR TITLE
fix: matrix table preview

### DIFF
--- a/apps/web/modules/ui/components/preview-survey/index.tsx
+++ b/apps/web/modules/ui/components/preview-survey/index.tsx
@@ -225,10 +225,10 @@ export const PreviewSurvey = ({
         )}>
         {previewMode === "mobile" && (
           <>
-            <p className="absolute top-0 left-0 m-2 rounded bg-slate-100 px-2 py-1 text-xs text-slate-400">
+            <p className="absolute left-0 top-0 m-2 rounded bg-slate-100 px-2 py-1 text-xs text-slate-400">
               Preview
             </p>
-            <div className="absolute top-0 right-0 m-2">
+            <div className="absolute right-0 top-0 m-2">
               <ResetProgressButton onClick={resetProgress} />
             </div>
             <MediaBackground
@@ -265,7 +265,7 @@ export const PreviewSurvey = ({
                 </Modal>
               ) : (
                 <div className="flex h-full w-full flex-col justify-center px-1">
-                  <div className="absolute top-5 left-5">
+                  <div className="absolute left-5 top-5">
                     {!styling.isLogoHidden && (
                       <ClientLogo
                         environmentId={environment.id}
@@ -296,7 +296,7 @@ export const PreviewSurvey = ({
           </>
         )}
         {previewMode === "desktop" && (
-          <div className="flex h-full flex-1 flex-col">
+          <div className="flex h-full w-full flex-1 flex-col">
             <div className="flex h-8 w-full items-center rounded-t-lg bg-slate-100">
               <div className="ml-6 flex space-x-2">
                 <div className="h-3 w-3 rounded-full bg-red-500"></div>
@@ -373,7 +373,7 @@ export const PreviewSurvey = ({
                 styling={styling}
                 ContentRef={ContentRef as React.RefObject<HTMLDivElement>}
                 isEditorView>
-                <div className="absolute top-5 left-5">
+                <div className="absolute left-5 top-5">
                   {!styling.isLogoHidden && (
                     <ClientLogo
                       environmentId={environment.id}

--- a/packages/survey-ui/src/components/elements/matrix.tsx
+++ b/packages/survey-ui/src/components/elements/matrix.tsx
@@ -99,13 +99,13 @@ function Matrix({
 
         {/* Table container with overflow for mobile */}
         <div className="overflow-x-auto">
-          <table className="w-full table-fixed border-collapse">
+          <table className="w-full border-collapse">
             {/* Column headers */}
             <thead>
               <tr>
-                <th className="w-1/4 p-2 text-left" />
+                <th className="p-2 text-left" />
                 {columns.map((column) => (
-                  <th key={column.id} className="break-words p-2 text-center font-normal">
+                  <th key={column.id} className="p-2 text-center font-normal">
                     <Label className="justify-center">{column.label}</Label>
                   </th>
                 ))}


### PR DESCRIPTION
## What does this PR do?

Fixes the preview breaking for matrix questions with very long column/row text.

**Root cause:** The `overflow-x-auto` Tailwind class used on the matrix table's scroll container (`packages/survey-ui/src/components/elements/matrix.tsx`) is missing from the surveys UMD bundle CSS. The bundle includes `overflow-auto`, `overflow-hidden`, etc., but **not** `overflow-x-auto`. Because the `surveys` package CSS build only scans its own source files for Tailwind class usage, `overflow-x-auto` (which is only used in the `survey-ui` matrix component) gets tree-shaken from the final bundle. This means the horizontal scroll container has no effect and the table overflows beyond the card.

## How should this be tested?

- Create a survey with a matrix question
- Add 5+ columns with very long text (e.g. `fkasdmfam sdf ml;almf; al;mdsfm l;adfslm amdslf laa ds salm;fl;masm;llm;m;lmllm;lmlml;lm;lmlmlm;;l;ll;m`)
- Open the survey editor preview in both desktop and mobile modes
- Verify the matrix table stays within the card bounds and shows a horizontal scrollbar when columns exceed the available width
- Test both "app" (modal) and "link" preview types
- Also verify that matrix questions with short/normal text still render correctly without a scrollbar

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary


<img width="536" height="471" alt="Screenshot 2026-02-16 at 5 32 43 PM" src="https://github.com/user-attachments/assets/b93859ea-431b-408e-ada0-b9ebc783890f" />

