### PR TITLE
docs: align rate limiting docs with current code enforcement

### DIFF
--- a/docs/self-hosting/advanced/rate-limiting.mdx
+++ b/docs/self-hosting/advanced/rate-limiting.mdx
@@ -90,5 +90,5 @@ After changing this value, restart the server.
 ## Operational Notes
 
 - Redis/Valkey is required for robust rate limiting (`REDIS_URL`).
-- If Redis is unavailable at runtime, rate-limiter checks currently fail open (requests are allowed).
-- Authentication failure audit logging also uses throttling internally, but that mechanism does not return `429` or block requests.
+- If Redis is unavailable at runtime, rate-limiter checks currently fail open (requests are allowed through without enforcement).
+- Authentication failure audit logging uses a separate throttle (`shouldLogAuthFailure()`) and is intentionally **fail-closed**: when Redis is unavailable or errors occur, audit log entries are **skipped entirely** rather than written without throttle control. This prevents spam while preserving the hash-integrity chain required for compliance. In other words, if Redis is down, no authentication-failure audit logs will be recorded—requests themselves are still allowed (fail-open rate limiting above), but the audit trail for those failures will not be written.


### PR DESCRIPTION
## Summary
- update self-hosting rate-limiting docs to match actual enforced limits in code
- add explicit Management API limits for v1 and v2
- document identifier scope (IP hash, API key ID, user ID, organization ID)
- add currently non-rate-limited endpoint exceptions and v1/v2 429 response shapes
- add operational notes for Redis dependency and fail-open behavior

## Testing
- not run (docs-only change)