### PR TITLE
fix: input combobox height (#7256) [Backport to release/4.7]

### DIFF
--- a/apps/web/modules/ui/components/input-combo-box/index.tsx
+++ b/apps/web/modules/ui/components/input-combo-box/index.tsx
@@ -226,7 +226,7 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
             tabIndex={0}
             aria-controls="options"
             aria-expanded={open}
-            className={cn("flex h-full w-full cursor-pointer items-center justify-end bg-white pr-2", {
+            className={cn("flex w-full cursor-pointer items-center justify-end bg-white pr-2 h-10", {
               "w-10 justify-center pr-0": withInput && inputType !== "dropdown",
               "pointer-events-none": isClearing,
             })}>


### PR DESCRIPTION
## Backport PR

Backports **fix: input combobox height** (#7256) from `main` to `release/4.7`.

**Original commit:** 5aa1427e64e147b27c180f95d2aeda29fd8779ef

### Changes
- Fix input combobox height in `apps/web/modules/ui/components/input-combo-box/index.tsx`

Made with [Cursor](https://cursor.com)