### PR TITLE
fix: suggest colors has better success copy (#7258) [Backport to release/4.7]

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -2104,6 +2104,7 @@ checksums:
     environments/workspace/look/show_powered_by_formbricks: a0e96edadec8ef326423feccc9d06be7
     environments/workspace/look/styling_updated_successfully: b8b74b50dde95abcd498633e9d0c891f
     environments/workspace/look/suggest_colors: ddc4543b416ab774007b10a3434343cd
+    environments/workspace/look/suggested_colors_applied_please_save: 226fa70af5efc8ffa0a3755909c8163e
     environments/workspace/look/theme: 21fe00b7a518089576fb83c08631107a
     environments/workspace/look/theme_settings_description: 9fc45322818c3774ab4a44ea14d7836e
     environments/workspace/tags/add: 87c4a663507f2bcbbf79934af8164e13

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "\"Powered by Formbricks\"-Signatur anzeigen",
         "styling_updated_successfully": "Styling erfolgreich aktualisiert",
         "suggest_colors": "Farben vorschlagen",
+        "suggested_colors_applied_please_save": "Vorgeschlagene Farben erfolgreich generiert. Drücke \"Speichern\", um die Änderungen zu übernehmen.",
         "theme": "Theme",
         "theme_settings_description": "Erstelle ein Style-Theme für alle Umfragen. Du kannst für jede Umfrage individuelles Styling aktivieren."
       },

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "Show “Powered by Formbricks” Signature",
         "styling_updated_successfully": "Styling updated successfully",
         "suggest_colors": "Suggest colors",
+        "suggested_colors_applied_please_save": "Suggested colors generated successfully. Press \"Save\" to persist the changes.",
         "theme": "Theme",
         "theme_settings_description": "Create a style theme for all surveys. You can enable custom styling for each survey."
       },

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "Mostrar firma 'Powered by Formbricks'",
         "styling_updated_successfully": "Estilo actualizado correctamente",
         "suggest_colors": "Sugerir colores",
+        "suggested_colors_applied_please_save": "Colores sugeridos generados correctamente. Pulsa \"Guardar\" para conservar los cambios.",
         "theme": "Tema",
         "theme_settings_description": "Crea un tema de estilo para todas las encuestas. Puedes activar el estilo personalizado para cada encuesta."
       },

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "Afficher la signature « Propulsé par Formbricks »",
         "styling_updated_successfully": "Style mis à jour avec succès",
         "suggest_colors": "Suggérer des couleurs",
+        "suggested_colors_applied_please_save": "Couleurs suggérées générées avec succès. Appuyez sur « Enregistrer » pour conserver les modifications.",
         "theme": "Thème",
         "theme_settings_description": "Créez un thème de style pour toutes les enquêtes. Vous pouvez activer un style personnalisé pour chaque enquête."
       },

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "Az „A gépházban: Formbricks” aláírás megjelenítése",
         "styling_updated_successfully": "A stílus sikeresen frissítve",
         "suggest_colors": "Színek ajánlása",
+        "suggested_colors_applied_please_save": "A javasolt színek sikeresen generálva. Nyomd meg a \"Mentés\" gombot a változtatások véglegesítéséhez.",
         "theme": "Téma",
         "theme_settings_description": "Stílustéma létrehozása az összes kérdőívhez. Egyéni stílust engedélyezhet minden egyes kérdőívhez."
       },

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "「Powered by Formbricks」署名を表示",
         "styling_updated_successfully": "スタイルを正常に更新しました",
         "suggest_colors": "カラーを提案",
+        "suggested_colors_applied_please_save": "推奨カラーが正常に生成されました。変更を保存するには「保存」を押してください。",
         "theme": "テーマ",
         "theme_settings_description": "すべてのアンケート用のスタイルテーマを作成します。各アンケートでカスタムスタイルを有効にできます。"
       },

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "Toon 'Powered by Formbricks' handtekening",
         "styling_updated_successfully": "Styling succesvol bijgewerkt",
         "suggest_colors": "Kleuren voorstellen",
+        "suggested_colors_applied_please_save": "Voorgestelde kleuren succesvol gegenereerd. Druk op \"Opslaan\" om de wijzigingen te behouden.",
         "theme": "Thema",
         "theme_settings_description": "Maak een stijlthema voor alle enquêtes. Je kunt aangepaste styling inschakelen voor elke enquête."
       },

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "Mostrar assinatura 'Powered by Formbricks'",
         "styling_updated_successfully": "Estilo atualizado com sucesso",
         "suggest_colors": "Sugerir cores",
+        "suggested_colors_applied_please_save": "Cores sugeridas geradas com sucesso. Pressione \"Salvar\" para manter as alterações.",
         "theme": "Tema",
         "theme_settings_description": "Crie um tema de estilo para todas as pesquisas. Você pode ativar estilo personalizado para cada pesquisa."
       },

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "Mostrar assinatura 'Powered by Formbricks'",
         "styling_updated_successfully": "Estilo atualizado com sucesso",
         "suggest_colors": "Sugerir cores",
+        "suggested_colors_applied_please_save": "Cores sugeridas geradas com sucesso. Pressiona \"Guardar\" para manter as alterações.",
         "theme": "Tema",
         "theme_settings_description": "Crie um tema de estilo para todos os inquéritos. Pode ativar estilos personalizados para cada inquérito."
       },

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "Afișează semnătura „Powered by Formbricks”",
         "styling_updated_successfully": "Stilizarea a fost actualizată cu succes",
         "suggest_colors": "Sugerează culori",
+        "suggested_colors_applied_please_save": "Culorile sugerate au fost generate cu succes. Apasă pe „Salvează” pentru a păstra modificările.",
         "theme": "Temă",
         "theme_settings_description": "Creează o temă de stil pentru toate sondajele. Poți activa stilizare personalizată pentru fiecare sondaj."
       },

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "Показывать подпись «Работает на Formbricks»",
         "styling_updated_successfully": "Стили успешно обновлены",
         "suggest_colors": "Предложить цвета",
+        "suggested_colors_applied_please_save": "Рекомендованные цвета успешно сгенерированы. Нажми «Сохранить», чтобы применить изменения.",
         "theme": "Тема",
         "theme_settings_description": "Создайте стиль для всех опросов. Вы можете включить индивидуальное оформление для каждого опроса."
       },

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "Visa 'Powered by Formbricks'-signatur",
         "styling_updated_successfully": "Stiluppdatering lyckades",
         "suggest_colors": "Föreslå färger",
+        "suggested_colors_applied_please_save": "Föreslagna färger har skapats. Tryck på \"Spara\" för att spara ändringarna.",
         "theme": "Tema",
         "theme_settings_description": "Skapa ett stilmall för alla undersökningar. Du kan aktivera anpassad stil för varje undersökning."
       },

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "显示“Powered by Formbricks”标识",
         "styling_updated_successfully": "样式更新成功",
         "suggest_colors": "推荐颜色",
+        "suggested_colors_applied_please_save": "已成功生成推荐配色。请点击“保存”以保留更改。",
         "theme": "主题",
         "theme_settings_description": "为所有问卷创建一个样式主题。你可以为每个问卷启用自定义样式。"
       },

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -2221,6 +2221,7 @@
         "show_powered_by_formbricks": "顯示「Powered by Formbricks」標記",
         "styling_updated_successfully": "樣式已成功更新",
         "suggest_colors": "建議顏色",
+        "suggested_colors_applied_please_save": "已成功產生建議色彩。請按「儲存」以保存變更。",
         "theme": "主題",
         "theme_settings_description": "為所有調查建立樣式主題。您可以為每個調查啟用自訂樣式。"
       },

--- a/apps/web/modules/projects/settings/look/components/theme-styling.tsx
+++ b/apps/web/modules/projects/settings/look/components/theme-styling.tsx
@@ -100,7 +100,7 @@ export const ThemeStyling = ({
       form.setValue(key as keyof TProjectStyling, value, { shouldDirty: true });
     }
 
-    toast.success(t("environments.workspace.look.styling_updated_successfully"));
+    toast.success(t("environments.workspace.look.suggested_colors_applied_please_save"));
     setConfirmSuggestColorsOpen(false);
   };
 

--- a/apps/web/modules/survey/editor/components/styling-view.tsx
+++ b/apps/web/modules/survey/editor/components/styling-view.tsx
@@ -94,7 +94,7 @@ export const StylingView = ({
       form.setValue(key as keyof TSurveyStyling, value, { shouldDirty: true });
     }
 
-    toast.success(t("environments.workspace.look.styling_updated_successfully"));
+    toast.success(t("environments.workspace.look.suggested_colors_applied_please_save"));
     setConfirmSuggestColorsOpen(false);
   };
 


### PR DESCRIPTION
## Backport PR

Backports **fix: suggest colors has better success copy** (#7258) from `main` to `release/4.7`.

**Original commit:** 6fefd51ccec97abccd82d8360d18cb91638aa4f9

### Changes
- `apps/web/modules/projects/settings/look/components/theme-styling.tsx`
- `apps/web/modules/survey/editor/components/styling-view.tsx`
- Locale files (en-US, de-DE, es-ES, fr-FR, etc.)

Made with [Cursor](https://cursor.com)