### PR TITLE
chore: makes rate limit config const

### DIFF
--- a/apps/web/modules/core/rate-limit/rate-limit-configs.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.ts
@@ -30,4 +30,4 @@ export const rateLimitConfigs = {
     upload: { interval: 60, allowedPerInterval: 5, namespace: "storage:upload" }, // 5 per minute
     delete: { interval: 60, allowedPerInterval: 5, namespace: "storage:delete" }, // 5 per minute
   },
-};
+} as const;


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
Marks the rate limit config as `as const`;

## Benefits:

### Before:
<img width="618" height="228" alt="Screenshot 2026-02-17 at 10 51 38" src="https://github.com/user-attachments/assets/408569ad-4e2d-4788-b4fc-97a34896c626" />

### After:
<img width="727" height="199" alt="Screenshot 2026-02-17 at 10 51 57" src="https://github.com/user-attachments/assets/11328e17-1796-4aa7-84fe-a27c06d9d177" />

No need to go into the declaration to check the values 🤩


<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->


