### PR TITLE
fix: better query in the backwards compatible code

### DIFF
--- a/apps/web/modules/ee/contacts/segments/lib/filter/prisma-query.test.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/filter/prisma-query.test.ts
@@ -5,10 +5,14 @@ import { getSegment } from "../segments";
 import { segmentFilterToPrismaQuery } from "./prisma-query";
 
 const mockQueryRawUnsafe = vi.fn();
+const mockFindFirst = vi.fn();
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
     $queryRawUnsafe: (...args: unknown[]) => mockQueryRawUnsafe(...args),
+    contactAttribute: {
+      findFirst: (...args: unknown[]) => mockFindFirst(...args),
+    },
   },
 }));
 
@@ -26,7 +30,9 @@ describe("segmentFilterToPrismaQuery", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default mock: number filter raw SQL returns one matching contact
+    // Default: backfill is complete, no un-migrated rows
+    mockFindFirst.mockResolvedValue(null);
+    // Fallback path mock: raw SQL returns one matching contact when un-migrated rows exist
     mockQueryRawUnsafe.mockResolvedValue([{ contactId: "mock-contact-1" }]);
   });
 
@@ -145,7 +151,16 @@ describe("segmentFilterToPrismaQuery", () => {
             },
           },
         ],
-        OR: [{ id: { in: ["mock-contact-1"] } }],
+        OR: [
+          {
+            attributes: {
+              some: {
+                attributeKey: { key: "age" },
+                valueNumber: { gt: 30 },
+              },
+            },
+          },
+        ],
       });
     }
   });
@@ -757,7 +772,12 @@ describe("segmentFilterToPrismaQuery", () => {
       });
 
       expect(subgroup.AND[0].AND[2]).toStrictEqual({
-        id: { in: ["mock-contact-1"] },
+        attributes: {
+          some: {
+            attributeKey: { key: "age" },
+            valueNumber: { gte: 18 },
+          },
+        },
       });
 
       // Segment inclusion
@@ -1158,10 +1178,23 @@ describe("segmentFilterToPrismaQuery", () => {
         },
       });
 
-      // Second subgroup (numeric operators - now use raw SQL subquery returning contact IDs)
+      // Second subgroup (numeric operators - uses clean Prisma filter post-backfill)
       const secondSubgroup = whereClause.AND?.[0];
       expect(secondSubgroup.AND[1].AND).toContainEqual({
-        id: { in: ["mock-contact-1"] },
+        attributes: {
+          some: {
+            attributeKey: { key: "loginCount" },
+            valueNumber: { gt: 5 },
+          },
+        },
+      });
+      expect(secondSubgroup.AND[1].AND).toContainEqual({
+        attributes: {
+          some: {
+            attributeKey: { key: "purchaseAmount" },
+            valueNumber: { lte: 1000 },
+          },
+        },
       });
 
       // Third subgroup (negation operators in OR clause)
@@ -1194,6 +1227,103 @@ describe("segmentFilterToPrismaQuery", () => {
         },
       });
     }
+  });
+
+  test("number filter falls back to raw SQL when un-migrated rows exist", async () => {
+    mockFindFirst.mockResolvedValue({ id: "unmigrated-row-1" });
+    mockQueryRawUnsafe.mockResolvedValue([{ contactId: "mock-contact-1" }]);
+
+    const filters: TBaseFilters = [
+      {
+        id: "filter_1",
+        connector: null,
+        resource: {
+          id: "attr_1",
+          root: {
+            type: "attribute" as const,
+            contactAttributeKey: "age",
+          },
+          value: 25,
+          qualifier: {
+            operator: "greaterThan",
+          },
+        },
+      },
+    ];
+
+    const result = await segmentFilterToPrismaQuery(mockSegmentId, filters, mockEnvironmentId);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const filterClause = result.data.whereClause.AND?.[1] as any;
+      expect(filterClause.AND[0]).toEqual({
+        OR: [
+          {
+            attributes: {
+              some: {
+                attributeKey: { key: "age" },
+                valueNumber: { gt: 25 },
+              },
+            },
+          },
+          { id: { in: ["mock-contact-1"] } },
+        ],
+      });
+    }
+
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: {
+        attributeKey: {
+          key: "age",
+          environmentId: mockEnvironmentId,
+        },
+        valueNumber: null,
+      },
+      select: { id: true },
+    });
+
+    expect(mockQueryRawUnsafe).toHaveBeenCalled();
+    const sqlCall = mockQueryRawUnsafe.mock.calls[0];
+    expect(sqlCall[0]).toContain('cak."environmentId" = $4');
+    expect(sqlCall[4]).toBe(mockEnvironmentId);
+  });
+
+  test("number filter uses clean Prisma query when backfill is complete", async () => {
+    const filters: TBaseFilters = [
+      {
+        id: "filter_1",
+        connector: null,
+        resource: {
+          id: "attr_1",
+          root: {
+            type: "attribute" as const,
+            contactAttributeKey: "score",
+          },
+          value: 100,
+          qualifier: {
+            operator: "lessEqual",
+          },
+        },
+      },
+    ];
+
+    const result = await segmentFilterToPrismaQuery(mockSegmentId, filters, mockEnvironmentId);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const filterClause = result.data.whereClause.AND?.[1] as any;
+      expect(filterClause.AND[0]).toEqual({
+        attributes: {
+          some: {
+            attributeKey: { key: "score" },
+            valueNumber: { lte: 100 },
+          },
+        },
+      });
+    }
+
+    expect(mockFindFirst).toHaveBeenCalled();
+    expect(mockQueryRawUnsafe).not.toHaveBeenCalled();
   });
 
   // ==========================================
@@ -1638,8 +1768,15 @@ describe("segmentFilterToPrismaQuery", () => {
           mode: "insensitive",
         });
 
-        // Number filter uses raw SQL subquery (transition code) returning contact IDs
-        expect(andConditions[1]).toEqual({ id: { in: ["mock-contact-1"] } });
+        // Number filter uses clean Prisma filter post-backfill
+        expect(andConditions[1]).toEqual({
+          attributes: {
+            some: {
+              attributeKey: { key: "purchaseCount" },
+              valueNumber: { gt: 5 },
+            },
+          },
+        });
 
         // Date filter uses OR fallback with 'valueDate' and string 'value'
         expect((andConditions[2] as unknown as any).attributes.some.OR[0].valueDate).toHaveProperty("gte");


### PR DESCRIPTION
## What does this PR do?

Refactors `buildNumberAttributeFilterWhereClause` in the segment filter → Prisma query pipeline to avoid unconditionally running a raw SQL subquery against the entire `ContactAttribute` table.

**Before:** Every number filter evaluation ran a `$queryRawUnsafe` that scanned `ContactAttribute` rows across all environments (no `environmentId` scope), loaded all matching contact IDs into a Node.js array, and passed them as a huge `IN (...)` clause to the outer Prisma query — even when the `valueNumber` backfill was already complete.

**After:**
- A cheap `findFirst` check detects whether any un-migrated rows (`valueNumber IS NULL`) exist for the given attribute key in the current environment.
- **Post-backfill (common path):** Returns a clean Prisma `where` clause using `valueNumber` directly — no raw SQL, no in-memory array, single query, naturally environment-scoped.
- **During transition:** Falls back to raw SQL, but now scoped by `environmentId` and only targeting `valueNumber IS NULL` rows. Results are combined with the Prisma filter via `OR`.
- Threads `environmentId` through the internal function chain (`processFilters` → `processSingleFilter` → builders) so the fallback path can scope its queries correctly.

## How should this be tested?

- Run the existing test suite: `npx vitest run apps/web/modules/ee/contacts/segments/lib/filter/prisma-query.test.ts` — all 22 tests pass including 2 new ones.
- **New test: "number filter uses clean Prisma query when backfill is complete"** — verifies that when `findFirst` returns `null`, the function returns a Prisma-only filter and `$queryRawUnsafe` is never called.
- **New test: "number filter falls back to raw SQL when un-migrated rows exist"** — verifies that when `findFirst` returns a row, the raw SQL runs with `environmentId` scoping and the result combines both paths via `OR`.
- To verify in a live environment: after running the backfill, query the database for any remaining `valueNumber IS NULL` rows on numeric attribute keys. If zero rows are returned, the raw SQL path will never execute.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues