### PR TITLE
fix: allow CTA elements to proceed when marked required (#1415)

### DIFF
--- a/packages/surveys/src/lib/validation/evaluator.ts
+++ b/packages/surveys/src/lib/validation/evaluator.ts
@@ -137,6 +137,11 @@ const checkRequiredField = (
     return null;
   }
 
+  // CTA elements never block progression (informational only)
+  if (element.type === TSurveyElementTypeEnum.CTA) {
+    return null;
+  }
+
   if (element.type === TSurveyElementTypeEnum.Ranking) {
     return validateRequiredRanking(value, t);
   }


### PR DESCRIPTION
## Summary

Fixes an issue where users cannot proceed past a CTA (Call-to-Action) question when it is marked as required, causing survey completion to be blocked.

Fixes https://github.com/formbricks/internal/issues/1415

## Root Cause

This affects **legacy surveys** that were created before the migration to multi-question pages (blocks). In the pre-migration format, it was possible to set `required: true` on CTA questions. After the migration to blocks, the editor was updated to prevent setting required on CTA elements—the required toggle is disabled for newly created CTA elements. However, surveys that already had `required: true` on CTA questions (either from the legacy format or via direct database edits) remained in that state.

The centralized validation in `packages/surveys/src/lib/validation/evaluator.ts` (`checkRequiredField`) did not have a special case for CTA elements. When a CTA had `required: true` and the user tried to proceed without clicking the CTA button, validation would fail and block progression. The UI layer (`block-conditional.tsx`) and the CTA component itself already skip required checks for CTAs, but the evaluator (used by the Client API and other validation paths) was enforcing it.

## Solution

Add an early return in `checkRequiredField` to skip required validation for CTA elements. CTA elements are informational only and should never block survey progression, consistent with the design enforced everywhere else in the codebase (editor, UI component, block-conditional validation).

## Testing

- Verified CTA elements with `required: true` (legacy or manual DB edit) no longer block survey submission
- No change in behavior for newly created CTAs (required toggle remains disabled)

