### PR TITLE
fix: adds dataType filter in bc code

### DIFF
--- a/apps/web/modules/ee/contacts/segments/lib/filter/prisma-query.test.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/filter/prisma-query.test.ts
@@ -1276,6 +1276,7 @@ describe("segmentFilterToPrismaQuery", () => {
         attributeKey: {
           key: "age",
           environmentId: mockEnvironmentId,
+          dataType: "number",
         },
         valueNumber: null,
       },
@@ -1362,7 +1363,7 @@ describe("segmentFilterToPrismaQuery", () => {
             {
               attributes: {
                 some: {
-                  attributeKey: { key: "purchaseDate" },
+                  attributeKey: { key: "purchaseDate", dataType: "date" },
                   OR: [
                     { valueDate: { lt: new Date(targetDate) } },
                     { valueDate: null, value: { lt: new Date(targetDate).toISOString() } },
@@ -1406,7 +1407,7 @@ describe("segmentFilterToPrismaQuery", () => {
             {
               attributes: {
                 some: {
-                  attributeKey: { key: "signupDate" },
+                  attributeKey: { key: "signupDate", dataType: "date" },
                   OR: [
                     { valueDate: { gt: new Date(targetDate) } },
                     { valueDate: null, value: { gt: new Date(targetDate).toISOString() } },
@@ -1451,7 +1452,7 @@ describe("segmentFilterToPrismaQuery", () => {
             {
               attributes: {
                 some: {
-                  attributeKey: { key: "lastActivityDate" },
+                  attributeKey: { key: "lastActivityDate", dataType: "date" },
                   OR: [
                     { valueDate: { gte: new Date(startDate), lte: new Date(endDate) } },
                     {

--- a/apps/web/modules/ee/contacts/segments/lib/filter/prisma-query.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/filter/prisma-query.ts
@@ -107,7 +107,7 @@ const buildDateAttributeFilterWhereClause = (filter: TSegmentAttributeFilter): P
   return {
     attributes: {
       some: {
-        attributeKey: { key: contactAttributeKey },
+        attributeKey: { key: contactAttributeKey, dataType: "date" },
         OR: [{ valueDate: dateCondition }, { valueDate: null, value: stringDateCondition }],
       },
     },
@@ -165,6 +165,7 @@ const buildNumberAttributeFilterWhereClause = async (
       attributeKey: {
         key: contactAttributeKey,
         environmentId,
+        dataType: "number",
       },
       valueNumber: null,
     },
@@ -183,6 +184,7 @@ const buildNumberAttributeFilterWhereClause = async (
     JOIN "ContactAttributeKey" cak ON ca."attributeKeyId" = cak.id
     WHERE cak.key = $1
     AND cak."environmentId" = $4
+    AND cak."dataType" = 'number'
     AND ca."valueNumber" IS NULL
     AND ca.value ~ $3
     AND ca.value::double precision ${sqlOp} $2


### PR DESCRIPTION
## What does this PR do?

Fixes false positives in the segment number/date filter queries that caused P2035 (`too many bind variables`) errors in production.

**Root cause:** `buildNumberAttributeFilterWhereClause` and `buildDateAttributeFilterWhereClause` did not filter by the attribute key's `dataType`. In production, 4.2M+ rows on string-typed keys contain numeric-looking values (e.g. `"42"`, `"1500"`). The backfill script correctly skips these (they're strings, not numbers), so `valueNumber` stays `NULL`. But the `hasUnmigratedRows` check saw those NULLs and incorrectly triggered the raw SQL fallback, which loaded 126K+ contact IDs into memory and hit PostgreSQL's 32,767 bind variable limit on the `IN (...)` clause.

**Changes:**

1. **Number filter (`buildNumberAttributeFilterWhereClause`):**
   - Refactored to a two-path approach: cheap `findFirst` check → clean Prisma query (post-backfill) or scoped raw SQL fallback (during transition).
   - Added `dataType: "number"` to the `findFirst` check so string-typed keys with numeric-looking values are not treated as un-migrated.
   - Added `dataType` and `environmentId` filters to the raw SQL fallback to scope it correctly.

2. **Date filter (`buildDateAttributeFilterWhereClause`):**
   - Added `dataType: "date"` to the `attributeKey` filter so string-typed keys with date-looking values don't match the `OR` fallback branch.

3. **`environmentId` threading:**
   - Threaded `environmentId` through the internal function chain (`processFilters` → `processSingleFilter` → builders) so the number filter fallback path can scope its queries to the current environment.

## How should this be tested?

- Run `npx vitest run apps/web/modules/ee/contacts/segments/lib/filter/prisma-query.test.ts` — all 22 tests pass including 2 new ones.
- **"number filter uses clean Prisma query when backfill is complete"** — verifies that when no un-migrated rows exist, `$queryRawUnsafe` is never called.
- **"number filter falls back to raw SQL when un-migrated rows exist"** — verifies that the fallback runs with `environmentId` and `dataType` scoping, and the `findFirst` check includes `dataType: "number"`.
- To verify the P2035 fix in production: confirm that segment filters with number operators no longer error. The `logger.warn` in the fallback path can be monitored — post-backfill it should never fire.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues