### PR TITLE
fix: allow CTA elements to proceed when marked required (#7293) [Backport to release/4.7]

### DIFF
--- a/packages/surveys/src/lib/validation/evaluator.ts
+++ b/packages/surveys/src/lib/validation/evaluator.ts
@@ -137,6 +137,11 @@ const checkRequiredField = (
     return null;
   }
 
+  // CTA elements never block progression (informational only)
+  if (element.type === TSurveyElementTypeEnum.CTA) {
+    return null;
+  }
+
   if (element.type === TSurveyElementTypeEnum.Ranking) {
     return validateRequiredRanking(value, t);
   }


### PR DESCRIPTION
## Backport PR

Backports **fix: allow CTA elements to proceed when marked required** (#7293) from `main` to `release/4.7`.

**Original commit:** 589c04a53087bfb28bd2610bb54ed08e62a184cf

Co-authored-by: Cursor <cursoragent@cursor.com>

### Changes
- `packages/surveys/src/lib/validation/evaluator.ts`

Made with [Cursor](https://cursor.com)