### PR TITLE
fix: always validate only responseData fields in client/management APIs (#7296) [Backport to release/4.7]

### DIFF
--- a/apps/web/app/api/v1/client/[environmentId]/responses/[responseId]/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/responses/[responseId]/route.ts
@@ -44,13 +44,10 @@ const validateResponse = (
     ...responseUpdateInput.data,
   };
 
-  const isFinished = responseUpdateInput.finished ?? false;
-
   const validationErrors = validateResponseData(
     survey.blocks,
     mergedData,
     responseUpdateInput.language ?? response.language ?? "en",
-    isFinished,
     survey.questions
   );
 

--- a/apps/web/app/api/v1/client/[environmentId]/responses/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/responses/route.ts
@@ -41,7 +41,6 @@ const validateResponse = (responseInputData: TResponseInput, survey: TSurvey) =>
     survey.blocks,
     responseInputData.data,
     responseInputData.language ?? "en",
-    responseInputData.finished,
     survey.questions
   );
 

--- a/apps/web/app/api/v1/management/responses/[responseId]/route.ts
+++ b/apps/web/app/api/v1/management/responses/[responseId]/route.ts
@@ -146,7 +146,6 @@ export const PUT = withV1ApiWrapper({
         result.survey.blocks,
         responseUpdate.data,
         responseUpdate.language ?? "en",
-        responseUpdate.finished,
         result.survey.questions
       );
 

--- a/apps/web/app/api/v1/management/responses/route.ts
+++ b/apps/web/app/api/v1/management/responses/route.ts
@@ -155,7 +155,6 @@ export const POST = withV1ApiWrapper({
         surveyResult.survey.blocks,
         responseInput.data,
         responseInput.language ?? "en",
-        responseInput.finished,
         surveyResult.survey.questions
       );
 

--- a/apps/web/app/api/v2/client/[environmentId]/responses/route.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/route.ts
@@ -112,7 +112,6 @@ export const POST = async (request: Request, context: Context): Promise<Response
     survey.blocks,
     responseInputData.data,
     responseInputData.language ?? "en",
-    responseInputData.finished,
     survey.questions
   );
 

--- a/apps/web/modules/api/lib/validation.ts
+++ b/apps/web/modules/api/lib/validation.ts
@@ -9,13 +9,13 @@ import { getElementsFromBlocks } from "@/lib/survey/utils";
 import { ApiErrorDetails } from "@/modules/api/v2/types/api-error";
 
 /**
- * Validates response data against survey validation rules
- * Handles partial responses (in-progress) by only validating present fields when finished is false
+ * Validates response data against survey validation rules.
+ * Only validates elements that have data in responseData - never validates
+ * all survey elements regardless of completion status.
  *
  * @param blocks - Survey blocks containing elements with validation rules (preferred)
  * @param responseData - Response data to validate (keyed by element ID)
  * @param languageCode - Language code for error messages (defaults to "en")
- * @param finished - Whether the response is finished (defaults to true for management APIs)
  * @param questions - Survey questions (legacy format, used as fallback if blocks are empty)
  * @returns Validation error map keyed by element ID, or null if validation passes
  */
@@ -23,7 +23,6 @@ export const validateResponseData = (
   blocks: TSurveyBlock[] | undefined | null,
   responseData: TResponseData,
   languageCode: string = "en",
-  finished: boolean = true,
   questions?: TSurveyQuestion[] | undefined | null
 ): TValidationErrorMap | null => {
   // Use blocks if available, otherwise transform questions to blocks
@@ -42,11 +41,8 @@ export const validateResponseData = (
   // Extract elements from blocks
   const allElements = getElementsFromBlocks(blocksToUse);
 
-  // If response is not finished, only validate elements that are present in the response data
-  // This prevents "required" errors for fields the user hasn't reached yet
-  const elementsToValidate = finished
-    ? allElements
-    : allElements.filter((element) => Object.keys(responseData).includes(element.id));
+  // Always validate only elements that are present in responseData
+  const elementsToValidate = allElements.filter((element) => Object.keys(responseData).includes(element.id));
 
   // Validate selected elements
   const errorMap = validateBlockResponses(elementsToValidate, responseData, languageCode);

--- a/apps/web/modules/api/v2/management/responses/[responseId]/route.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/route.ts
@@ -198,7 +198,6 @@ export const PUT = (request: Request, props: { params: Promise<{ responseId: str
         questionsResponse.data.blocks,
         body.data,
         body.language ?? "en",
-        body.finished,
         questionsResponse.data.questions
       );
 

--- a/apps/web/modules/api/v2/management/responses/route.ts
+++ b/apps/web/modules/api/v2/management/responses/route.ts
@@ -134,7 +134,6 @@ export const POST = async (request: Request) =>
         surveyQuestions.data.blocks,
         body.data,
         body.language ?? "en",
-        body.finished,
         surveyQuestions.data.questions
       );
 


### PR DESCRIPTION
## Backport PR

Backports **fix: always validate only responseData fields in client/management APIs** (#7296) from `main` to `release/4.7`.

**Original commit:** f4ac9a8292fdc290e4e41d8ec3c80efecc544232

Co-authored-by: Cursor <cursoragent@cursor.com>

### Changes
- API response routes (v1/client, v1/management, v2/client, v2/management)
- `apps/web/modules/api/lib/validation.ts` and related tests

Made with [Cursor](https://cursor.com)