### PR TITLE
fix: add bool support

### DIFF
--- a/apps/web/modules/ee/contacts/lib/attribute-storage.ts
+++ b/apps/web/modules/ee/contacts/lib/attribute-storage.ts
@@ -54,7 +54,6 @@ export const prepareNewSDKAttributeForStorage = (
 };
 
 const handleStringType = (value: TRawValue): TAttributeStorageColumns => {
-  // String type - only use value column
   let stringValue: string;
 
   if (value instanceof Date) {

--- a/apps/web/modules/ee/contacts/lib/attributes.ts
+++ b/apps/web/modules/ee/contacts/lib/attributes.ts
@@ -130,7 +130,12 @@ export const updateAttributes = async (
   const messages: TAttributeUpdateMessage[] = [];
   const errors: TAttributeUpdateMessage[] = [];
 
-  // Convert email and userId to strings for lookup (they should always be strings, but handle numbers gracefully)
+  // Coerce boolean values to strings (SDK may send booleans for string attributes)
+  const coercedAttributes: Record<string, string | number> = {};
+  for (const [key, value] of Object.entries(contactAttributesParam)) {
+    coercedAttributes[key] = typeof value === "boolean" ? String(value) : value;
+  }
+
   const emailValue =
     contactAttributesParam.email === null || contactAttributesParam.email === undefined
       ? null
@@ -154,7 +159,7 @@ export const updateAttributes = async (
   const userIdExists = !!existingUserIdAttribute;
 
   // Remove email and/or userId from attributes if they already exist on another contact
-  let contactAttributes = { ...contactAttributesParam };
+  let contactAttributes = { ...coercedAttributes };
 
   // Determine what the final email and userId values will be after this update
   // Only consider a value as "submitted" if it was explicitly included in the attributes

--- a/packages/types/contact-attribute.ts
+++ b/packages/types/contact-attribute.ts
@@ -16,5 +16,5 @@ export type TContactAttribute = z.infer<typeof ZContactAttribute>;
 export const ZContactAttributes = z.record(z.string());
 export type TContactAttributes = z.infer<typeof ZContactAttributes>;
 
-export const ZContactAttributesInput = z.record(z.union([z.string(), z.number()]));
+export const ZContactAttributesInput = z.record(z.union([z.string(), z.number(), z.boolean()]));
 export type TContactAttributesInput = z.infer<typeof ZContactAttributesInput>;


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

Allows boolean values in contact attributes by coercing them to `"true"`/`"false"` strings on the backend. This prevents SDK users (especially mobile SDKs or those bypassing TypeScript types) from getting a hard rejection when a boolean slips into attributes.

**Changes:**
- `packages/types/contact-attribute.ts`: Added `z.boolean()` to `ZContactAttributesInput` so booleans pass Zod validation
- `apps/web/modules/ee/contacts/lib/attributes.ts`: Coerce boolean values to strings at the top of `updateAttributes`, before any downstream processing
- `apps/web/modules/ee/contacts/lib/attributes.test.ts`: Added test for boolean coercion

The JS SDK type signature is intentionally left strict (no `boolean`) — this is a backend-only safety net.

## How should this be tested?

- Send a boolean attribute value (e.g. `{ is_active: true }`) via the SDK or API and verify it is stored as `"true"` string
- Send a mix of boolean, string, and number attributes and verify they are all handled correctly
- Verify that existing string/number/date attribute validation is unaffected

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary