### PR TITLE
fix: mark filter button label and 'and' separator as translatable

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/ResponseFilter.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/components/ResponseFilter.tsx
@@ -241,7 +241,7 @@ export const ResponseFilter = ({ survey }: ResponseFilterProps) => {
     <Popover open={isOpen} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <PopoverTriggerButton isOpen={isOpen}>
-          Filter <b>{activeFilterCount > 0 && `(${activeFilterCount})`}</b>
+          {t("common.filter")} <b>{activeFilterCount > 0 && `(${activeFilterCount})`}</b>
         </PopoverTriggerButton>
       </PopoverTrigger>
       <PopoverContent
@@ -329,7 +329,7 @@ export const ResponseFilter = ({ survey }: ResponseFilterProps) => {
               </div>
               {i !== filterValue.filter.length - 1 && (
                 <div className="my-4 flex items-center">
-                  <p className="mr-4 font-semibold text-slate-800">and</p>
+                  <p className="mr-4 font-semibold text-slate-800">{t("common.and")}</p>
                   <hr className="w-full text-slate-600" />
                 </div>
               )}

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "Fehler beim Kopieren in die Zwischenablage",
     "failed_to_load_organizations": "Fehler beim Laden der Organisationen",
     "failed_to_load_workspaces": "Projekte konnten nicht geladen werden",
+    "filter": "Filter",
     "finish": "Fertigstellen",
     "follow_these": "Folge diesen",
     "formbricks_version": "Formbricks Version",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "Failed to copy to clipboard",
     "failed_to_load_organizations": "Failed to load organizations",
     "failed_to_load_workspaces": "Failed to load workspaces",
+    "filter": "Filter",
     "finish": "Finish",
     "follow_these": "Follow these",
     "formbricks_version": "Formbricks Version",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "Error al copiar al portapapeles",
     "failed_to_load_organizations": "Error al cargar organizaciones",
     "failed_to_load_workspaces": "Error al cargar los proyectos",
+    "filter": "Filter",
     "finish": "Finalizar",
     "follow_these": "Sigue estos",
     "formbricks_version": "Versión de Formbricks",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "Échec de la copie dans le presse-papiers",
     "failed_to_load_organizations": "Échec du chargement des organisations",
     "failed_to_load_workspaces": "Échec du chargement des projets",
+    "filter": "Filter",
     "finish": "Terminer",
     "follow_these": "Suivez ceci",
     "formbricks_version": "Version de Formbricks",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "Nem sikerült másolni a vágólapra",
     "failed_to_load_organizations": "Nem sikerült betölteni a szervezeteket",
     "failed_to_load_workspaces": "Nem sikerült a munkaterületek betöltése",
+    "filter": "Filter",
     "finish": "Befejezés",
     "follow_these": "Ezek követése",
     "formbricks_version": "Formbricks verziója",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "クリップボードへのコピーに失敗しました",
     "failed_to_load_organizations": "組織の読み込みに失敗しました",
     "failed_to_load_workspaces": "ワークスペースの読み込みに失敗しました",
+    "filter": "Filter",
     "finish": "完了",
     "follow_these": "こちらの手順に従って",
     "formbricks_version": "Formbricksバージョン",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "Kopiëren naar klembord mislukt",
     "failed_to_load_organizations": "Laden van organisaties mislukt",
     "failed_to_load_workspaces": "Laden van werkruimtes mislukt",
+    "filter": "Filter",
     "finish": "Finish",
     "follow_these": "Volg deze",
     "formbricks_version": "Formbricks-versie",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "Falha ao copiar para a área de transferência",
     "failed_to_load_organizations": "Falha ao carregar organizações",
     "failed_to_load_workspaces": "Falha ao carregar projetos",
+    "filter": "Filter",
     "finish": "Terminar",
     "follow_these": "Siga esses",
     "formbricks_version": "Versão do Formbricks",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "Falha ao copiar para a área de transferência",
     "failed_to_load_organizations": "Falha ao carregar organizações",
     "failed_to_load_workspaces": "Falha ao carregar projetos",
+    "filter": "Filter",
     "finish": "Concluir",
     "follow_these": "Siga estes",
     "formbricks_version": "Versão do Formbricks",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "Nu s-a reușit copierea în clipboard",
     "failed_to_load_organizations": "Nu s-a reușit încărcarea organizațiilor",
     "failed_to_load_workspaces": "Nu s-au putut încărca workspaces",
+    "filter": "Filter",
     "finish": "Finalizează",
     "follow_these": "Urmați acestea",
     "formbricks_version": "Versiunea Formbricks",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "Не удалось скопировать в буфер обмена",
     "failed_to_load_organizations": "Не удалось загрузить организации",
     "failed_to_load_workspaces": "Не удалось загрузить рабочие пространства",
+    "filter": "Filter",
     "finish": "Завершить",
     "follow_these": "Выполните следующие действия",
     "formbricks_version": "Версия Formbricks",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "Misslyckades att kopiera till urklipp",
     "failed_to_load_organizations": "Misslyckades att ladda organisationer",
     "failed_to_load_workspaces": "Det gick inte att ladda arbetsytor",
+    "filter": "Filter",
     "finish": "Slutför",
     "follow_these": "Följ dessa",
     "formbricks_version": "Formbricks-version",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "复制到剪贴板失败",
     "failed_to_load_organizations": "加载组织失败",
     "failed_to_load_workspaces": "加载工作区失败",
+    "filter": "Filter",
     "finish": "完成",
     "follow_these": "遵循 这些",
     "formbricks_version": "Formbricks 版本",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -224,6 +224,7 @@
     "failed_to_copy_to_clipboard": "無法複製到剪貼簿",
     "failed_to_load_organizations": "無法載入組織",
     "failed_to_load_workspaces": "載入工作區失敗",
+    "filter": "Filter",
     "finish": "完成",
     "follow_these": "按照這些步驟",
     "formbricks_version": "Formbricks 版本",


### PR DESCRIPTION
## What does this PR do?

Fixes #7291

The "Filter" button label and the "and" separator in the survey response filter (ResponseFilter.tsx) were hardcoded in English, making them untranslatable for non-English locales.

### Changes

- Replaced hardcoded `Filter` text with `t("common.filter")` in the PopoverTriggerButton
- Replaced hardcoded `and` separator with `t("common.and")` (this key already existed in all locales)
- Added the new `"filter": "Filter"` key to `en-US.json` and all 13 other locale files

### How to test

1. Switch the app language to a non-English locale
2. Navigate to a survey's response summary page
3. Verify the "Filter" button label and "and" separators between filter conditions are now translated

### Checklist
- [x] I have linked the related issue (Fixes #7291)
- [x] My changes follow the project's coding style
- [x] I have tested my changes locally
