### PR TITLE
fix: update test configuration to exclude .next directory from testing

### DIFF
--- a/apps/web/vite.config.mts
+++ b/apps/web/vite.config.mts
@@ -8,7 +8,7 @@ export default defineConfig({
   test: {
     environment: "node",
     environmentMatchGlobs: [["**/*.test.tsx", "jsdom"]],
-    exclude: ["playwright/**", "node_modules/**"],
+    exclude: ["playwright/**", "node_modules/**", ".next/**"],
     setupFiles: ["./vitestSetup.ts"],
     env: loadEnv("", process.cwd(), ""),
     coverage: {


### PR DESCRIPTION
## Fix: Vitest picking up dependency tests from Next.js build output

### What happened
Unit tests were failing on the main branch because Vitest was discovering and running test files inside the `.next/` directory (from Next.js `output: "standalone"`). That output includes copied dependencies like pino and import-in-the-middle, which ship their own tests. Vitest ran those tests, which then failed due to missing dev deps (tape, flush-write-stream, etc.).

### Fix
Updated `apps/web/vite.config.mts` to add `.next/**` to Vitest’s `exclude` so tests under the Next.js build directory are no longer discovered or run.