### PR TITLE
feat: add pod disruption budget for helm chart (#7339) [Backport to release/4.7]

### DIFF
--- a/charts/formbricks/templates/NOTES.txt
+++ b/charts/formbricks/templates/NOTES.txt
@@ -118,11 +118,39 @@ Scaling:
    kubectl get hpa -n {{ .Release.Namespace }} {{ include "formbricks.name" . }}
    ```
 {{- else }}
-   HPA is **not enabled**. Your deployment has a fixed number of `{{ .Values.replicaCount }}` replicas.
+   HPA is **not enabled**. Your deployment has a fixed number of `{{ .Values.deployment.replicas }}` replicas.
    Manually scale using:
    ```sh
    kubectl scale deployment -n {{ .Release.Namespace }} {{ include "formbricks.name" . }} --replicas=<desired_number>
    ```
+{{- end }}
+
+---
+
+Pod Disruption Budget:
+
+{{- if .Values.pdb.enabled }}
+   A PodDisruptionBudget is active to protect against voluntary disruptions.
+   {{- if not (kindIs "invalid" .Values.pdb.minAvailable) }}
+   - **Min Available**: `{{ .Values.pdb.minAvailable }}`
+   {{- end }}
+   {{- if not (kindIs "invalid" .Values.pdb.maxUnavailable) }}
+   - **Max Unavailable**: `{{ .Values.pdb.maxUnavailable }}`
+   {{- end }}
+
+   Check PDB status:
+   ```sh
+   kubectl get pdb -n {{ .Release.Namespace }} {{ include "formbricks.name" . }}
+   ```
+   {{- if and .Values.autoscaling.enabled (eq (int .Values.autoscaling.minReplicas) 1) }}
+
+   WARNING: autoscaling.minReplicas is 1. With minAvailable: 1, the PDB
+   will block all node drains when only 1 replica is running. Set
+   autoscaling.minReplicas to at least 2 for proper HA protection.
+   {{- end }}
+{{- else }}
+   PDB is **not enabled**. Voluntary disruptions (node drains, upgrades) may
+   take down all pods simultaneously.
 {{- end }}
 
 ---

--- a/charts/formbricks/templates/pdb.yaml
+++ b/charts/formbricks/templates/pdb.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.pdb.enabled }}
+{{- $hasMinAvailable := not (kindIs "invalid" .Values.pdb.minAvailable) -}}
+{{- $hasMaxUnavailable := not (kindIs "invalid" .Values.pdb.maxUnavailable) -}}
+{{- if and $hasMinAvailable $hasMaxUnavailable }}
+  {{- fail "pdb.minAvailable and pdb.maxUnavailable are mutually exclusive; set only one" }}
+{{- end }}
+{{- if not (or $hasMinAvailable $hasMaxUnavailable) }}
+  {{- fail "pdb.enabled is true but neither pdb.minAvailable nor pdb.maxUnavailable is set; set exactly one" }}
+{{- end }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "formbricks.name" . }}
+  labels:
+    {{- include "formbricks.labels" . | nindent 4 }}
+    {{- with .Values.pdb.additionalLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.pdb.annotations }}
+  annotations:
+    {{- toYaml .Values.pdb.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if $hasMinAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if $hasMaxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+  {{- if .Values.pdb.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ .Values.pdb.unhealthyPodEvictionPolicy }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "formbricks.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -215,6 +215,42 @@ autoscaling:
           periodSeconds: 60 # Add at most 2 pods every minute
 
 ##########################################################
+# Pod Disruption Budget (PDB)
+#
+# Ensures a minimum number of pods remain available during
+# voluntary disruptions (node drains, cluster upgrades, etc.).
+#
+# IMPORTANT:
+#   - minAvailable and maxUnavailable are MUTUALLY EXCLUSIVE.
+#     Setting both will cause a helm install/upgrade failure.
+#     To switch, set the unused one to null in your override file.
+#   - Accepts an integer (e.g., 1) or a percentage string (e.g., "25%").
+#   - For PDB to provide real HA protection, ensure
+#     autoscaling.minReplicas >= 2 (or deployment.replicas >= 2
+#     if HPA is disabled). With only 1 replica and minAvailable: 1,
+#     the PDB will block ALL node drains and cluster upgrades.
+##########################################################
+pdb:
+  enabled: true
+  additionalLabels: {}
+  annotations: {}
+
+  # Minimum pods that must remain available during disruptions.
+  # Set to null and configure maxUnavailable instead if preferred.
+  minAvailable: 1
+
+  # Maximum pods that can be unavailable during disruptions.
+  # Mutually exclusive with minAvailable — uncomment and set
+  # minAvailable to null to use this instead.
+  # maxUnavailable: 1
+
+  # Eviction policy for unhealthy pods (Kubernetes 1.27+).
+  # "IfHealthy"    — unhealthy pods count toward the budget (default).
+  # "AlwaysAllow"  — unhealthy pods can always be evicted,
+  #                  preventing them from blocking node drain.
+  # unhealthyPodEvictionPolicy: AlwaysAllow
+
+##########################################################
 # Service Configuration
 ##########################################################
 service:


### PR DESCRIPTION
## Backport PR

Backports **feat: add pod disruption budget for helm chart** (#7339) from `main` to `release/4.7`.

**Original commit:** 5c7ea33fb0a160f4224fd6c15d341e5a4b314c82

### Changes
- `charts/formbricks/templates/pdb.yaml` (new)
- `charts/formbricks/templates/NOTES.txt`
- `charts/formbricks/values.yaml`

Made with [Cursor](https://cursor.com)