### PR TITLE
fix: restore bullet points in survey preview and public survey (#7356)

### DIFF
--- a/packages/surveys/src/styles/global.css
+++ b/packages/surveys/src/styles/global.css
@@ -57,6 +57,36 @@
   color: var(--fb-subheading-color) !important;
 }
 
+/*
+ * Restore list styling for rich text (questions/descriptions).
+ * Preflight resets ul/ol with list-style:none; these overrides restore bullets/numbers.
+ */
+#fbjs .htmlbody ul,
+#fbjs .htmlbody ol,
+#fbjs [data-variant="headline"] ul,
+#fbjs [data-variant="headline"] ol,
+#fbjs [data-variant="description"] ul,
+#fbjs [data-variant="description"] ol {
+  list-style-position: outside;
+  margin: 0.5em 0;
+  padding-left: 1.5em;
+}
+#fbjs .htmlbody ul,
+#fbjs [data-variant="headline"] ul,
+#fbjs [data-variant="description"] ul {
+  list-style-type: disc;
+}
+#fbjs .htmlbody ol,
+#fbjs [data-variant="headline"] ol,
+#fbjs [data-variant="description"] ol {
+  list-style-type: decimal;
+}
+#fbjs .htmlbody li,
+#fbjs [data-variant="headline"] li,
+#fbjs [data-variant="description"] li {
+  margin: 0.25em 0;
+}
+
 /* without this, it wont override the color */
 #fbjs p.editor-paragraph {
   overflow-wrap: break-word;


### PR DESCRIPTION
## Summary

Fixes a bug where bulleted (and numbered) lists in survey questions and descriptions were displayed correctly in the survey editor but appeared without bullets/numbers in the survey preview and public survey.

## Problem

The survey editor supports rich text lists—users can add bulleted or numbered lists to questions and descriptions. While these render correctly in the editor, the preflight CSS in `packages/surveys/src/styles/preflight.css` applies `list-style: none` to all `ul` and `ol` elements within the `#fbjs` scope (which wraps the survey preview and public survey). This reset removes the default bullet points and list numbers.

The editor runs outside `#fbjs` and does not use this preflight, so bullets appeared there but not in the rendered survey.

## Solution

Added CSS overrides in `packages/surveys/src/styles/global.css` to restore list styling for rich text content areas:

- **`.htmlbody`** – welcome card, ending card, and calendar elements (Headline/Subheader)
- **`[data-variant="headline"]`** – question headlines (via survey-ui ElementHeader/Label)
- **`[data-variant="description"]`** – question descriptions/subheaders

The overrides restore:
- `list-style-type: disc` for unordered lists (`ul`)
- `list-style-type: decimal` for ordered lists (`ol`)
- Appropriate `list-style-position`, `margin`, `padding`, and `li` spacing

## Testing

1. Create a survey with a question that includes a bulleted or numbered list in the headline or description (e.g., type `-` or `*` followed by space for bullets)
2. Verify bullets/numbers appear in the survey preview pane
3. Publish and verify they appear in the public survey

## Screenshots

- **Before:** Lists in preview showed only plain text without bullet symbols

<img width="1897" height="794" alt="Screenshot 2026-02-25 at 6 59 37 PM" src="https://github.com/user-attachments/assets/18d3869c-7ba4-40c7-86ec-f266c3f5599d" />

- **After:** Bullets and numbers display correctly, matching the editor

<img width="1897" height="794" alt="Screenshot 2026-02-25 at 6 58 58 PM" src="https://github.com/user-attachments/assets/1a07054f-4e94-44ff-b280-e909f578af07" />


---
Closes #7356
