### PR TITLE
fix: set success_action_status on S3 presigned POST to fix CORS on Ceph-based providers

### DIFF
--- a/packages/storage/src/service.test.ts
+++ b/packages/storage/src/service.test.ts
@@ -80,7 +80,7 @@ describe("service.ts", () => {
         Key: "uploads/images/test-file.jpg",
         Fields: {
           "Content-Type": "image/jpeg",
-          // "Content-Encoding": "base64",
+          success_action_status: "201",
         },
         Conditions: [["content-length-range", 0, mockMaxSize]],
       });
@@ -175,7 +175,7 @@ describe("service.ts", () => {
         Key: "uploads/images/test-file.jpg",
         Fields: {
           "Content-Type": "image/jpeg",
-          // "Content-Encoding": "base64",
+          success_action_status: "201",
         },
         Conditions: [["content-length-range", 0, mockMaxSize]],
       });

--- a/packages/storage/src/service.ts
+++ b/packages/storage/src/service.ts
@@ -66,7 +66,7 @@ export const getSignedUploadUrl = async (
       Key: `${filePath}/${fileName}`,
       Fields: {
         "Content-Type": contentType,
-        // "Content-Encoding": "base64",
+        success_action_status: "201",
       },
       Conditions: postConditions,
     });


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/formbricks/formbricks/issues/7086

- Adds `success_action_status: "201"` to the S3 presigned POST fields so the storage provider returns `201 Created` instead of the default `204 No Content`
- Fixes file uploads failing on Ceph/RGW-based S3 providers (e.g. Hetzner Object Storage) where the `204` response omits CORS headers, causing the browser to block the response and report upload failure even though the file was successfully written to the bucket

## Root Cause

When uploading files via presigned POST, S3-compatible providers default to returning `204 No Content`. Ceph/RGW-based providers (like Hetzner Object Storage) do not include `Access-Control-Allow-Origin` headers on `204` responses, even when CORS is properly configured on the bucket. The browser blocks the response, `fetch()` throws a `TypeError: Failed to fetch`, and the app reports "Upload failed" despite the file being successfully stored.

Setting `success_action_status: "201"` instructs the provider to return `201 Created` instead, which correctly includes CORS headers. This is also the [recommended approach in the AWS S3 POST documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html). The change is backward-compatible — `Response.ok` covers both `200-299`, so AWS S3, MinIO, and other providers continue to work.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Unit tests updated and passing (`pnpm test --filter=@formbricks/storage` — 64/64 pass)
- Verified against local MinIO: response changes from `204 No Content` → `201 Created`
- Verify on a Ceph/RGW-based provider (Hetzner Object Storage) that CORS error no longer occurs and uploaded images appear in the UI

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
