### PR TITLE
fix: copy database package.json to Docker runner stage (backport #7371)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -101,6 +101,9 @@ RUN chown -R nextjs:nextjs ./apps/web/public && chmod -R 755 ./apps/web/public
 # Create packages/database directory structure with proper ownership for runtime migrations
 RUN mkdir -p ./packages/database/migrations && chown -R nextjs:nextjs ./packages/database
 
+COPY --from=installer /app/packages/database/package.json ./packages/database/package.json
+RUN chown nextjs:nextjs ./packages/database/package.json && chmod 644 ./packages/database/package.json
+
 COPY --from=installer /app/packages/database/schema.prisma ./packages/database/schema.prisma
 RUN chown nextjs:nextjs ./packages/database/schema.prisma && chmod 644 ./packages/database/schema.prisma
 


### PR DESCRIPTION
## What does this PR do?

Backport of #7371 to `release/4.7` for patch release `4.7.5`.

Cherry-picked from commit `68c142273`.

**Original fix:** The Docker runner stage was missing `packages/database/package.json`, which declares `"type": "module"`. Without it, Node.js falls back to the root `package.json` (from `apps/web`) which lacks this field, causing `MODULE_TYPELESS_PACKAGE_JSON` warnings and double-parsing overhead when running startup migration scripts.

This copies `packages/database/package.json` into the runner stage so Node.js correctly resolves the ES module type on first parse.

## How should this be tested?

- Build the Docker image and verify container startup logs no longer show `MODULE_TYPELESS_PACKAGE_JSON` warnings for `apply-migrations.js` or `create-saml-database.js`
- Verify database migrations and SAML database setup still complete successfully
- Confirm the container reaches healthy state


Made with [Cursor](https://cursor.com)