### PR TITLE
chore: make productionBrowserSourceMaps conditional to decrease build time

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -14,7 +14,8 @@ const nextConfig = {
   basePath: process.env.BASE_PATH || undefined,
   output: "standalone",
   poweredByHeader: false,
-  productionBrowserSourceMaps: true,
+  // Enable source maps only when uploading to Sentry (CI/production); skip for faster local builds
+  productionBrowserSourceMaps: !!process.env.SENTRY_AUTH_TOKEN,
   serverExternalPackages: [
     "@aws-sdk",
     "@opentelemetry/api",


### PR DESCRIPTION
## Summary
Makes `productionBrowserSourceMaps` conditional on `SENTRY_AUTH_TOKEN` instead of always `true`.

## Changes
- Enable source maps only when uploading to Sentry (CI/production)
- Skip source map generation for local builds when `SENTRY_AUTH_TOKEN` is not set

Before: 

<img width="716" height="220" alt="Screenshot 2026-03-02 at 2 52 51 PM" src="https://github.com/user-attachments/assets/c21846d9-2e3a-4a2d-b053-b98f4956736b" />

After: 

<img width="716" height="220" alt="Screenshot 2026-03-02 at 2 48 24 PM" src="https://github.com/user-attachments/assets/082419ee-70af-4243-9035-7339fd5f9eb7" />


## Impact
- **Local builds** (`pnpm build` without SENTRY_AUTH_TOKEN): ~2+ minutes faster
- **CI/production** (with SENTRY_AUTH_TOKEN): No change — Sentry still gets readable stack traces
- **Local dev** (`pnpm dev`): No change — dev source maps are always on
