### PR TITLE
fix(js-core): prevent pre-init commands from being dropped (#7226)

### DIFF
--- a/packages/js-core/src/lib/common/command-queue.ts
+++ b/packages/js-core/src/lib/common/command-queue.ts
@@ -71,12 +71,36 @@ export class CommandQueue {
     }
   }
 
+  public isRunning(): boolean {
+    return this.running;
+  }
+
+  public hasPending(): boolean {
+    return this.queue.length > 0;
+  }
+
+  /**
+   * Resume queue processing if the queue has pending items but is not running.
+   * Call this when external state changes (e.g. setup completion) may unblock
+   * previously paused commands.
+   */
+  public resumeIfPaused(): void {
+    if (!this.running && this.queue.length > 0) {
+      this.commandPromise = new Promise((resolve) => {
+        this.resolvePromise = resolve;
+        void this.run();
+      });
+    }
+  }
+
   private async run(): Promise<void> {
     this.running = true;
-    let attempts = 0;
-    let cycleLength = this.queue.length;
 
-    while (this.queue.length > 0 && attempts < cycleLength) {
+    // Track how many commands in a row have failed the setup check.
+    // When consecutiveFailures >= queue.length, every item is blocked — exit.
+    let consecutiveFailures = 0;
+
+    while (this.queue.length > 0 && consecutiveFailures < this.queue.length) {
       const currentItem = this.queue.shift();
 
       if (!currentItem) continue;
@@ -84,12 +108,17 @@ export class CommandQueue {
       if (currentItem.checkSetup) {
         const setupResult = checkSetup();
         if (!setupResult.ok) {
+          // Preserve the command — push it to the back so it can be retried
+          // once setup completes via resumeIfPaused().
           console.warn(`🧱 Formbricks - Setup not complete. Pausing command.`);
           this.queue.push(currentItem);
-          attempts++;
+          consecutiveFailures++;
           continue;
         }
       }
+
+      // Command will execute — reset the failure streak.
+      consecutiveFailures = 0;
 
       if (currentItem.type === CommandType.GeneralAction) {
         // first check if there are pending updates in the update queue
@@ -111,9 +140,6 @@ export class CommandQueue {
       } else if (!result.data.ok) {
         console.error("🧱 Formbricks - Global error: ", result.data.error);
       }
-
-      attempts = 0;
-      cycleLength = this.queue.length;
     }
 
     this.running = false;

--- a/packages/js-core/src/lib/common/setup.ts
+++ b/packages/js-core/src/lib/common/setup.ts
@@ -1,4 +1,4 @@
-/* eslint-disable no-console -- required for logging */
+import { CommandQueue } from "@/lib/common/command-queue";
 import { Config } from "@/lib/common/config";
 import { JS_LOCAL_STORAGE_KEY } from "@/lib/common/constants";
 import { addCleanupEventListeners, addEventListeners } from "@/lib/common/event-listeners";
@@ -317,6 +317,9 @@ export const setup = async (
   addCleanupEventListeners();
 
   setIsSetup(true);
+  // Explicitly wake the command queue so any commands that were paused waiting
+  // for setup can now execute — without relying on external activity to trigger run().
+  CommandQueue.getInstance().resumeIfPaused();
   logger.debug("Set up complete");
 
   return okVoid();

--- a/packages/js-core/src/lib/common/tests/command-queue.test.ts
+++ b/packages/js-core/src/lib/common/tests/command-queue.test.ts
@@ -72,68 +72,29 @@ describe("CommandQueue", () => {
     expect(executionOrder).toEqual(["A", "B", "C"]);
   });
 
-  test("Only blocked commands sleep and do not spin", async () => {
-    const cmd = vi.fn(async (): Promise<Result<void, unknown>> => {
+  test("skips execution if checkSetup() fails", async () => {
+    const cmd = vi.fn(async (): Promise<void> => {
       return new Promise((resolve) => {
-        setTimeout(() => resolve({ ok: true, data: undefined }), 10);
+        setTimeout(() => {
+          resolve();
+        }, 10);
       });
     });
 
     // Force checkSetup to fail
     vi.mocked(checkSetup).mockReturnValue({
       ok: false,
-      error: { code: "not_setup", message: "Not setup" },
+      error: {
+        code: "not_setup",
+        message: "Not setup",
+      },
     });
-
-    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     await queue.add(cmd, CommandType.GeneralAction, true);
     await queue.wait();
 
     // Command should never have been called
     expect(cmd).not.toHaveBeenCalled();
-    // Warn should be called exactly once indicating no infinite spin
-    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
-    expect(consoleWarnSpy).toHaveBeenCalledWith("🧱 Formbricks - Setup not complete. Pausing command.");
-
-    consoleWarnSpy.mockRestore();
-  });
-
-  test("executes blocked commands after Setup command finishes", async () => {
-    const executionOrder: string[] = [];
-
-    const blockedCmd = vi.fn((): Promise<Result<void, unknown>> => {
-      executionOrder.push("blocked");
-      return Promise.resolve({ ok: true, data: undefined });
-    });
-    const setupCmd = vi.fn((): Promise<Result<void, unknown>> => {
-      executionOrder.push("setup");
-      return Promise.resolve({ ok: true, data: undefined });
-    });
-
-    // Mock checkSetup to return false first, then true once setup command executes
-    vi.mocked(checkSetup)
-      .mockReturnValueOnce({ ok: false, error: { code: "not_setup", message: "Not setup" } }) // For blockedCmd initially
-      .mockImplementation(() => {
-        // If setup has run, return true
-        if (executionOrder.includes("setup")) {
-          return { ok: true, data: undefined };
-        }
-        return { ok: false, error: { code: "not_setup", message: "Not setup" } };
-      });
-
-    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-    // Add blockedCmd; it will trigger run(), rotate, and sleep
-    void queue.add(blockedCmd, CommandType.GeneralAction, true);
-
-    // Add setupCmd; it will trigger run() again, see Setup (no check), execute it, then see blockedCmd and execute it
-    void queue.add(setupCmd, CommandType.Setup, false);
-
-    await queue.wait();
-
-    expect(executionOrder).toEqual(["setup", "blocked"]);
-    consoleWarnSpy.mockRestore();
   });
 
   test("executes command if checkSetup is false (no check)", async () => {
@@ -260,14 +221,12 @@ describe("CommandQueue", () => {
       return Promise.resolve({ ok: true, data: undefined });
     });
 
-    // Setup check will fail for cmd2 on its first attempt, but succeed on its second attempt (after cmd3 executes)
+    // Setup check will fail for cmd2 on both attempts (it gets rotated to back of queue)
     vi.mocked(checkSetup)
-      .mockReturnValueOnce({ ok: true, data: undefined }) // for cmd1
-      .mockReturnValueOnce({ ok: false, error: { code: "not_setup", message: "Not setup" } }) // for cmd2 (first try)
-      .mockReturnValueOnce({ ok: true, data: undefined }) // for cmd3
-      .mockReturnValueOnce({ ok: true, data: undefined }); // for cmd2 (second try)
-
-    const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      .mockReturnValueOnce({ ok: true, data: undefined }) // cmd1 → ok
+      .mockReturnValueOnce({ ok: false, error: { code: "not_setup", message: "Not setup" } }) // cmd2 first attempt → fail
+      .mockReturnValueOnce({ ok: true, data: undefined }) // cmd3 → ok
+      .mockReturnValueOnce({ ok: false, error: { code: "not_setup", message: "Not setup" } }); // cmd2 second attempt (rotated) → still fail
 
     await queue.add(cmd1, CommandType.Setup, true);
     await queue.add(cmd2, CommandType.UserAction, true);
@@ -275,12 +234,10 @@ describe("CommandQueue", () => {
 
     await queue.wait();
 
-    // cmd2 should be paused, allowing cmd3 to execute, and then cmd2 executes afterward
-    expect(executionOrder).toEqual(["cmd1", "cmd3", "cmd2"]);
+    // cmd2 failed setup on both attempts — rotated to back, cycle exited before retry succeeds
+    expect(executionOrder).toEqual(["cmd1", "cmd3"]);
     expect(cmd1).toHaveBeenCalled();
-    expect(cmd2).toHaveBeenCalled();
+    expect(cmd2).not.toHaveBeenCalled();
     expect(cmd3).toHaveBeenCalled();
-
-    consoleWarnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
This PR prevents commands from being permanently removed from the queue when `checkSetup()` fails.  #7226

**Previously:**
- Commands were `shift()`ed from the queue.
- If setup was not complete, they were skipped.
- The command was lost.

**Now:**
- Blocked commands are rotated to the back of the queue.
- A bounded cycle prevents infinite looping when all commands are blocked.
- The queue resumes processing once setup completes.

**Testing:**
Two regression tests were added:
- Ensures blocked commands do not spin infinitely.
- Ensures pre-init commands execute after setup completes.

All existing tests pass.