### PR TITLE
chore: remove unused postgres-init-dev volume mount from dev compose

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,6 @@ services:
     image: pgvector/pgvector:pg18
     volumes:
       - postgres:/var/lib/postgresql/data
-      - ./docker/postgres-init-dev:/docker-entrypoint-initdb.d:ro
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres


### PR DESCRIPTION
## What does this PR do?

Removes the unused `postgres-init-dev` volume mount from `docker-compose.dev.yml`. The `./docker/postgres-init-dev` directory was empty and the mount to `/docker-entrypoint-initdb.d` served no purpose—the PostgreSQL init directory is only used when the DB is first created, and with no scripts in it, nothing ran. Hub and Formbricks migrations handle schema setup separately.

## How should this be tested?

- [ ] Run `pnpm db:up` (or `docker compose -f docker-compose.dev.yml up -d postgres`) and confirm Postgres starts successfully
- [ ] Run `pnpm dev` and verify the app connects to the database and migrations run as expected

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits (N/A - simple removal)
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs` (N/A)
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues (N/A - config only)
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary