### PR TITLE
chore: remove legacy post-checkout hook

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,2 +1,0 @@
-echo "{\"branchName\": \"$(git rev-parse --abbrev-ref HEAD)\"}" > ./branch.json
-prettier --write ./branch.json


### PR DESCRIPTION
## Summary
- remove `.husky/post-checkout`
- stop generating `branch.json` on checkout
- eliminate the source of `git worktree add` failures when local tooling is not installed

## Verification
- scanned repository for Tolgee references (`tolgee`, `TOLGEE`, `NEXT_PUBLIC_TOLGEE_API_KEY`)
- scanned repository for `branch.json` and `branchName` references
- no matches found in current tree
