### PR TITLE
fix: helm template duplicate label key in migration-job

### DIFF
--- a/charts/formbricks/templates/migration-job.yaml
+++ b/charts/formbricks/templates/migration-job.yaml
@@ -20,7 +20,8 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "formbricks.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/name: {{ include "formbricks.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: migration
     spec:
       restartPolicy: Never


### PR DESCRIPTION
Duplicate of #7411 by @rob-htl. Fixes duplicate app.kubernetes.io/component key in migration-job.yaml.