### PR TITLE
fix(docker): use pg16 and stable tag for Railway compatibility

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: pgvector/pgvector:pg17
+    image: pgvector/pgvector:pg16
     volumes:
       - postgres:/var/lib/postgresql/data
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -202,7 +202,7 @@ x-environment: &environment
 services:
   postgres:
     restart: always
-    image: pgvector/pgvector:pg17
+    image: pgvector/pgvector:pg16
     volumes:
       - postgres:/var/lib/postgresql/data
     environment:
@@ -233,7 +233,7 @@ services:
 
   formbricks:
     restart: always
-    image: ghcr.io/formbricks/formbricks:latest
+    image: ghcr.io/formbricks/formbricks:stable
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Fixes #4998

## What does this PR do?

This PR fixes the Railway deployment issue by updating Docker image tags in the docker-compose files to use versions that are available on Railway:

1. **PostgreSQL image**: Changed `pgvector/pgvector:pg17` to `pgvector/pgvector:pg16` because the `pg17` tag is not available in all registries including Railway
2. **Formbricks image**: Changed `ghcr.io/formbricks/formbricks:latest` to `ghcr.io/formbricks/formbricks:stable` because Railway requires specific tags instead of `:latest`

The `:stable` tag is maintained by the project and points to the latest stable release (see `.github/workflows/move-stable-tag.yml`).

## How should this be tested?

- Deploy Formbricks on Railway using the updated docker-compose.yml
- Verify that the PostgreSQL (pgvector/pgvector:pg16) image pulls successfully
- Verify that the Formbricks (ghcr.io/formbricks/formbricks:stable) image pulls successfully
- Verify that the application starts and runs correctly

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits - N/A (straightforward config change)
- [x] Ran `pnpm build` - N/A (no code changes, only docker-compose config)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs` - N/A
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues - N/A
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) - N/A (no CLA detected)

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR - N/A
- [ ] Updated the Formbricks Docs if changes were necessary - N/A