### PR TITLE
fix: zlib CVE

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -74,12 +74,10 @@ RUN --mount=type=secret,id=database_url \
 #
 FROM base AS runner
 
-# Upgrade Alpine system packages to pick up security patches.
-RUN apk update && apk upgrade --no-cache
-
-# Update npm to latest, then create user
+# Upgrade Alpine system packages to pick up security patches, update npm to latest, then create user
 # Note: npm's bundled tar has a known vulnerability but npm is only used during build, not at runtime
-RUN npm install --ignore-scripts -g npm@latest \
+RUN apk update && apk upgrade --no-cache \
+    && npm install --ignore-scripts -g npm@latest \
     && addgroup -S nextjs \
     && adduser -S -u 1001 -G nextjs nextjs
 


### PR DESCRIPTION
## What does this PR do?

Adds `apk upgrade` to the Docker runner stage to patch the Alpine system-level `zlib` vulnerability (CVE-2026-22184, CRITICAL — arbitrary code execution via buffer overflow).

The base image `node:24-alpine3.23` ships with `zlib-1.3.1-r2` which is vulnerable. The upgrade pulls in `zlib-1.3.2-r0` from Alpine's repos.

## How should this be tested?

- Build the Docker image and run `trivy image <image>` — confirm `CVE-2026-22184` and `CVE-2026-27171` (zlib) are no longer flagged
- Verify the container starts and runs normally (`docker compose up`)
- Verify database migrations run successfully

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
