### PR TITLE
feat: add SAML telemetry reporting

### DIFF
--- a/apps/web/app/api/(internal)/pipeline/lib/telemetry.test.ts
+++ b/apps/web/app/api/(internal)/pipeline/lib/telemetry.test.ts
@@ -50,6 +50,7 @@ vi.mock("@/lib/env", () => ({
     RECAPTCHA_SITE_KEY: "site-key",
     RECAPTCHA_SECRET_KEY: "secret-key",
     GITHUB_ID: "github-id",
+    SAML_DATABASE_URL: "postgresql://saml.example.com/formbricks",
   },
 }));
 
@@ -138,6 +139,7 @@ describe("sendTelemetryEvents", () => {
     expect(payload.userCount).toBe(5);
     expect(payload.integrations.notion).toBe(true);
     expect(payload.sso.github).toBe(true);
+    expect(payload.sso.saml).toBe(true);
 
     // Check cache update (no TTL parameter)
     expect(mockCacheService.set).toHaveBeenCalledWith("telemetry_last_sent_ts", expect.any(String));

--- a/apps/web/app/api/(internal)/pipeline/lib/telemetry.ts
+++ b/apps/web/app/api/(internal)/pipeline/lib/telemetry.ts
@@ -212,6 +212,7 @@ const sendTelemetry = async (lastSent: number) => {
     google: !!env.GOOGLE_CLIENT_ID || ssoProviders.some((p) => p.provider === "google"),
     azureAd: !!env.AZUREAD_CLIENT_ID || ssoProviders.some((p) => p.provider === "azuread"),
     oidc: !!env.OIDC_CLIENT_ID || ssoProviders.some((p) => p.provider === "openid"),
+    saml: !!env.SAML_DATABASE_URL || ssoProviders.some((p) => p.provider === "saml"),
   };
 
   // Construct telemetry payload with usage statistics and configuration.


### PR DESCRIPTION
## Summary
- add SAML to the telemetry service's existing SSO payload
- detect SAML via SAML env configuration or persisted `saml` account providers
- cover the new telemetry flag in the focused telemetry unit test

## Testing
- pnpm test app/api/'(internal)'/pipeline/lib/telemetry.test.ts