### PR TITLE
fix: use logical CSS direction classes for RTL matrix question

### DIFF
--- a/packages/survey-ui/src/components/elements/matrix.tsx
+++ b/packages/survey-ui/src/components/elements/matrix.tsx
@@ -130,7 +130,7 @@ function Matrix({
                     disabled={disabled}
                     aria-required={required}
                     aria-invalid={Boolean(errorMessage)}>
-                    <tr className={cn("relative", baseBgColor)}>
+                    <tr className={cn("relative", baseBgColor)} dir={dir}>
                       {/* Row label */}
                       <th scope="row" className={cn("rounded-s-input p-2 align-middle")}>
                         <div className="flex flex-col gap-0 leading-none">


### PR DESCRIPTION
## Summary
- Replaces physical CSS direction classes with logical equivalents in the matrix question component
- `text-left` → `text-start`, `rounded-l-*` → `rounded-s-*`, `rounded-r-*` → `rounded-e-*`
- Ensures correct rendering for RTL languages (Arabic, Hebrew, etc.)

Fixes formbricks/internal#1469

## Test plan
- [ ] Open a survey with a matrix question in LTR mode — verify no visual changes
- [ ] Switch to an RTL language (e.g., Arabic)
- [ ] Verify the matrix question renders correctly with proper RTL layout
- [ ] Check border radius is on the correct sides in RTL mode
