### PR TITLE
fix: clear validation settings when disabling open text validation

### DIFF
--- a/apps/web/modules/survey/editor/components/validation-rules-editor.tsx
+++ b/apps/web/modules/survey/editor/components/validation-rules-editor.tsx
@@ -94,6 +94,17 @@ export const ValidationRulesEditor = ({
 
   const handleDisable = () => {
     onUpdateValidation({ rules: [], logic: validationLogic });
+    // Reset inputType to "text" when disabling validation for OpenText elements.
+    // Without this, the HTML input keeps its type (e.g. "url"), which still enforces
+    // browser-native format validation even though the user toggled validation off.
+    if (
+      elementType === TSurveyElementTypeEnum.OpenText &&
+      onUpdateInputType &&
+      inputType !== undefined &&
+      inputType !== "text"
+    ) {
+      onUpdateInputType("text");
+    }
   };
 
   const handleAddRule = (insertAfterIndex: number) => {


### PR DESCRIPTION
## Summary
- Fixes open text question validation not being properly cleared when toggled off
- When validation is disabled, the `inputType` is now reset to `"text"` so the HTML `<input>` no longer enforces browser-native format validation (e.g. URL, email, phone)
- Root cause: `handleDisable` in `ValidationRulesEditor` cleared the rules array but left `element.inputType` as `"url"` (or `"email"`, `"phone"`), causing the HTML input to keep its type attribute and continue enforcing format validation at the browser level

Fixes formbricks/internal#1471

Test issue in lineked ticket

## Test plan
- [ ] Create an open text question
- [ ] Enable URL validation and verify it works (non-URL text is rejected)
- [ ] Disable validation
- [ ] Verify the question accepts any text input without URL validation
- [ ] Re-enable validation and verify it works again
- [ ] Repeat for email and phone input types
