### PR TITLE
fix: clear validation settings when disabling open text validation (#7464) [Backport to release/4.8]

### DIFF
--- a/apps/web/modules/survey/editor/components/validation-rules-editor.tsx
+++ b/apps/web/modules/survey/editor/components/validation-rules-editor.tsx
@@ -94,6 +94,17 @@ export const ValidationRulesEditor = ({
 
   const handleDisable = () => {
     onUpdateValidation({ rules: [], logic: validationLogic });
+    // Reset inputType to "text" when disabling validation for OpenText elements.
+    // Without this, the HTML input keeps its type (e.g. "url"), which still enforces
+    // browser-native format validation even though the user toggled validation off.
+    if (
+      elementType === TSurveyElementTypeEnum.OpenText &&
+      onUpdateInputType &&
+      inputType !== undefined &&
+      inputType !== "text"
+    ) {
+      onUpdateInputType("text");
+    }
   };
 
   const handleAddRule = (insertAfterIndex: number) => {


### PR DESCRIPTION
## Backport PR

Backports **fix: clear validation settings when disabling open text validation** (#7464) from `main` to `release/4.8`.

**Original commit:** 75f44952c7f04cbf61d00410044950b8ed64dc5b

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>

### Changes
- `apps/web/modules/survey/editor/components/validation-rules-editor.tsx`

Made with [Cursor](https://cursor.com)