### PR TITLE
fix: use logical CSS direction classes for RTL matrix question (#7463) [Backport to release/4.8]

### DIFF
--- a/packages/survey-ui/src/components/elements/matrix.tsx
+++ b/packages/survey-ui/src/components/elements/matrix.tsx
@@ -103,7 +103,7 @@ function Matrix({
             {/* Column headers */}
             <thead>
               <tr>
-                <th className="p-2 text-left" />
+                <th className="p-2 text-start" />
                 {columns.map((column) => (
                   <th key={column.id} className="p-2 text-center font-normal">
                     <Label className="justify-center">{column.label}</Label>
@@ -130,9 +130,9 @@ function Matrix({
                     disabled={disabled}
                     aria-required={required}
                     aria-invalid={Boolean(errorMessage)}>
-                    <tr className={cn("relative", baseBgColor)}>
+                    <tr className={cn("relative", baseBgColor)} dir={dir}>
                       {/* Row label */}
-                      <th scope="row" className={cn("rounded-l-input p-2 align-middle")}>
+                      <th scope="row" className={cn("rounded-s-input p-2 align-middle")}>
                         <div className="flex flex-col gap-0 leading-none">
                           <Label>{row.label}</Label>
                         </div>
@@ -145,7 +145,7 @@ function Matrix({
                         return (
                           <td
                             key={column.id}
-                            className={cn("p-2 text-center align-middle", isLastColumn && "rounded-r-input")}>
+                            className={cn("p-2 text-center align-middle", isLastColumn && "rounded-e-input")}>
                             <Label htmlFor={cellId} className="flex cursor-pointer justify-center">
                               <RadioGroupItem
                                 value={column.id}


### PR DESCRIPTION
## Backport PR

Backports **fix: use logical CSS direction classes for RTL matrix question** (#7463) from `main` to `release/4.8`.

**Original commit:** 4015c76f2b3a3e88a03c6c5cd482651d97cfeb66

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>

### Changes
- `packages/survey-ui/src/components/elements/matrix.tsx`

Made with [Cursor](https://cursor.com)