### PR TITLE
feat: add validation for custom survey closed message heading

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -1625,6 +1625,7 @@ checksums:
     environments/surveys/edit/styling_set_to_theme_styles: f2c108bf422372b00cf7c87f1b042f69
     environments/surveys/edit/subheading: c0f6f57155692fd8006381518ce4fef0
     environments/surveys/edit/subtract: 2d83b8b9ef35110f2583ddc155b6c486
+    environments/surveys/edit/survey_closed_message_heading_required: f7c48e324c4a5c335ec68eaa27b2d67e
     environments/surveys/edit/survey_completed_heading: dae5ac4a02a886dc9d9fc40927091919
     environments/surveys/edit/survey_completed_subheading: db537c356c3ab6564d24de0d11a0fee2
     environments/surveys/edit/survey_display_settings: 8ed19e6a8e1376f7a1ba037d82c4ae11

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "Styling auf Themenstile eingestellt",
         "subheading": "Zwischenüberschrift",
         "subtract": "Subtrahieren -",
+        "survey_closed_message_heading_required": "Füge der benutzerdefinierten Nachricht für geschlossene Umfragen eine Überschrift hinzu.",
         "survey_completed_heading": "Umfrage abgeschlossen",
         "survey_completed_subheading": "Diese kostenlose und quelloffene Umfrage wurde geschlossen",
         "survey_display_settings": "Einstellungen zur Anzeige der Umfrage",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "Styling set to theme styles",
         "subheading": "Subheading",
         "subtract": "Subtract -",
+        "survey_closed_message_heading_required": "Add a heading to the custom survey closed message.",
         "survey_completed_heading": "Survey Completed",
         "survey_completed_subheading": "This free & open-source survey has been closed",
         "survey_display_settings": "Survey Display Settings",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "Estilo configurado según los estilos del tema",
         "subheading": "Subtítulo",
         "subtract": "Restar -",
+        "survey_closed_message_heading_required": "Añade un encabezado al mensaje personalizado de encuesta cerrada.",
         "survey_completed_heading": "Encuesta completada",
         "survey_completed_subheading": "Esta encuesta gratuita y de código abierto ha sido cerrada",
         "survey_display_settings": "Ajustes de visualización de la encuesta",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "Style défini sur les styles du thème",
         "subheading": "Sous-titre",
         "subtract": "Soustraire -",
+        "survey_closed_message_heading_required": "Ajoute un titre au message personnalisé de sondage fermé.",
         "survey_completed_heading": "Enquête terminée",
         "survey_completed_subheading": "Cette enquête gratuite et open-source a été fermée",
         "survey_display_settings": "Paramètres d'affichage de l'enquête",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "A stílus a téma stílusaira állítva",
         "subheading": "Alcím",
         "subtract": "Kivonás -",
+        "survey_closed_message_heading_required": "Adjon hozzá egy címsort az egyéni felmérés lezárási üzenetéhez.",
         "survey_completed_heading": "A kérdőív kitöltve",
         "survey_completed_subheading": "Ez a szabad és nyílt forráskódú kérdőív le lett zárva",
         "survey_display_settings": "Kérdőív megjelenítésének beállításai",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "スタイルをテーマのスタイルに設定しました",
         "subheading": "サブ見出し",
         "subtract": "減算 -",
+        "survey_closed_message_heading_required": "カスタムアンケート終了メッセージに見出しを追加してください。",
         "survey_completed_heading": "フォームが完了しました",
         "survey_completed_subheading": "この無料のオープンソースフォームは閉鎖されました",
         "survey_display_settings": "フォーム表示設定",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "Styling ingesteld op themastijlen",
         "subheading": "Ondertitel",
         "subtract": "Aftrekken -",
+        "survey_closed_message_heading_required": "Voeg een kop toe aan het aangepaste bericht voor gesloten enquêtes.",
         "survey_completed_heading": "Enquête voltooid",
         "survey_completed_subheading": "Deze gratis en open source-enquête is gesloten",
         "survey_display_settings": "Enquêteweergave-instellingen",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "Estilo definido para os estilos do tema",
         "subheading": "Subtítulo",
         "subtract": "Subtrair -",
+        "survey_closed_message_heading_required": "Adicione um título à mensagem personalizada de pesquisa encerrada.",
         "survey_completed_heading": "Pesquisa Concluída",
         "survey_completed_subheading": "Essa pesquisa gratuita e de código aberto foi encerrada",
         "survey_display_settings": "Configurações de Exibição da Pesquisa",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "Estilo definido para estilos do tema",
         "subheading": "Subtítulo",
         "subtract": "Subtrair -",
+        "survey_closed_message_heading_required": "Adiciona um título à mensagem personalizada de inquérito encerrado.",
         "survey_completed_heading": "Inquérito Concluído",
         "survey_completed_subheading": "Este inquérito gratuito e de código aberto foi encerrado",
         "survey_display_settings": "Configurações de Exibição do Inquérito",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "Stilizare setată la stilurile temei",
         "subheading": "Subtitlu",
         "subtract": "Scade -",
+        "survey_closed_message_heading_required": "Adaugă un titlu la mesajul personalizat pentru sondajul închis.",
         "survey_completed_heading": "Sondaj Completat",
         "survey_completed_subheading": "Acest sondaj gratuit și open-source a fost închis",
         "survey_display_settings": "Setări de afișare a sondajului",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "Оформление установлено в соответствии с темой",
         "subheading": "Подзаголовок",
         "subtract": "Вычесть -",
+        "survey_closed_message_heading_required": "Добавьте заголовок к сообщению о закрытом опросе.",
         "survey_completed_heading": "Опрос завершён",
         "survey_completed_subheading": "Этот бесплатный и открытый опрос был закрыт",
         "survey_display_settings": "Настройки отображения опроса",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "Styling inställd på temastil",
         "subheading": "Underrubrik",
         "subtract": "Subtrahera -",
+        "survey_closed_message_heading_required": "Lägg till en rubrik för det anpassade meddelandet när undersökningen är stängd.",
         "survey_completed_heading": "Enkät slutförd",
         "survey_completed_subheading": "Denna gratis och öppenkällkodsenkät har stängts",
         "survey_display_settings": "Visningsinställningar för enkät",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "样式 设置 为 主题 风格",
         "subheading": "子标题",
         "subtract": "减 -",
+        "survey_closed_message_heading_required": "请为自定义调查关闭消息添加标题。",
         "survey_completed_heading": "调查 完成",
         "survey_completed_subheading": "此 免费 & 开源 调查 已 关闭",
         "survey_display_settings": "调查显示设置",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1698,6 +1698,7 @@
         "styling_set_to_theme_styles": "樣式設定為主題樣式",
         "subheading": "副標題",
         "subtract": "減 -",
+        "survey_closed_message_heading_required": "請為自訂的問卷關閉訊息新增標題。",
         "survey_completed_heading": "問卷已完成",
         "survey_completed_subheading": "此免費且開源的問卷已關閉",
         "survey_display_settings": "問卷顯示設定",

--- a/apps/web/modules/survey/editor/lib/validation.test.ts
+++ b/apps/web/modules/survey/editor/lib/validation.test.ts
@@ -316,10 +316,6 @@ describe("validation.isEndingCardValid", () => {
     const card = { ...baseRedirectUrlCard, label: "  " };
     expect(validation.isEndingCardValid(card, surveyLanguagesEnabled)).toBe(false);
   });
-  // test("should return false for redirectUrl card if label is undefined", () => {
-  //   const card = { ...baseRedirectUrlCard, label: undefined };
-  //   expect(validation.isEndingCardValid(card, surveyLanguagesEnabled)).toBe(false);
-  // });
 });
 
 describe("validation.validateElement", () => {
@@ -1026,6 +1022,66 @@ describe("validation.isSurveyValid", () => {
       autoComplete: null,
     };
     expect(validation.isSurveyValid(surveyWithNoLimit, "en", mockT, 5)).toBe(true);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  test("should return false and toast error if a link survey has an empty custom survey closed message heading", () => {
+    const surveyWithEmptyClosedMessageHeading = {
+      ...baseSurvey,
+      type: "link",
+      surveyClosedMessage: {
+        heading: "",
+        subheading: "Closed for now",
+      },
+    } as unknown as TSurvey;
+
+    expect(validation.isSurveyValid(surveyWithEmptyClosedMessageHeading, "en", mockT)).toBe(false);
+    expect(toast.error).toHaveBeenCalledWith(
+      "environments.surveys.edit.survey_closed_message_heading_required"
+    );
+  });
+
+  test("should return false and toast error if a link survey has a whitespace-only custom survey closed message heading", () => {
+    const surveyWithWhitespaceClosedMessageHeading = {
+      ...baseSurvey,
+      type: "link",
+      surveyClosedMessage: {
+        heading: "   ",
+        subheading: "",
+      },
+    } as unknown as TSurvey;
+
+    expect(validation.isSurveyValid(surveyWithWhitespaceClosedMessageHeading, "en", mockT)).toBe(false);
+    expect(toast.error).toHaveBeenCalledWith(
+      "environments.surveys.edit.survey_closed_message_heading_required"
+    );
+  });
+
+  test("should return true if a link survey has a custom survey closed message heading and no subheading", () => {
+    const surveyWithHeadingOnlyClosedMessage = {
+      ...baseSurvey,
+      type: "link",
+      surveyClosedMessage: {
+        heading: "Survey closed",
+        subheading: "",
+      },
+    } as unknown as TSurvey;
+
+    expect(validation.isSurveyValid(surveyWithHeadingOnlyClosedMessage, "en", mockT)).toBe(true);
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  test("should return true if a link survey has a custom survey closed message heading and subheading", () => {
+    const surveyWithClosedMessageContent = {
+      ...baseSurvey,
+      type: "link",
+      surveyClosedMessage: {
+        heading: "Survey closed",
+        subheading: "Thanks for your interest",
+      },
+    } as unknown as TSurvey;
+
+    expect(validation.isSurveyValid(surveyWithClosedMessageContent, "en", mockT)).toBe(true);
     expect(toast.error).not.toHaveBeenCalled();
   });
 

--- a/apps/web/modules/survey/editor/lib/validation.ts
+++ b/apps/web/modules/survey/editor/lib/validation.ts
@@ -151,11 +151,7 @@ export const validationRules = {
 
     for (const field of fieldsToValidate) {
       const fieldValue = (element as unknown as Record<string, Record<string, string> | undefined>)[field];
-      if (
-        fieldValue &&
-        typeof fieldValue[defaultLanguageCode] !== "undefined" &&
-        fieldValue[defaultLanguageCode].trim() !== ""
-      ) {
+      if (fieldValue?.[defaultLanguageCode] !== undefined && fieldValue[defaultLanguageCode].trim() !== "") {
         isValid = isValid && isLabelValidForAllLanguages(fieldValue, languages);
       }
     }
@@ -201,6 +197,16 @@ export const validateSurveyElementsInBatch = (
 
 const isContentValid = (content: Record<string, string> | undefined, surveyLanguages: TSurveyLanguage[]) => {
   return !content || isLabelValidForAllLanguages(content, surveyLanguages);
+};
+
+const hasValidSurveyClosedMessageHeading = (survey: TSurvey): boolean => {
+  if (survey.type !== "link" || !survey.surveyClosedMessage) {
+    return true;
+  }
+
+  const heading = survey.surveyClosedMessage.heading?.trim() ?? "";
+
+  return heading.length > 0;
 };
 
 export const isWelcomeCardValid = (card: TSurveyWelcomeCard, surveyLanguages: TSurveyLanguage[]): boolean => {
@@ -284,6 +290,11 @@ export const isSurveyValid = (
       );
       return false;
     }
+  }
+
+  if (!hasValidSurveyClosedMessageHeading(survey)) {
+    toast.error(t("environments.surveys.edit.survey_closed_message_heading_required"));
+    return false;
   }
 
   return true;


### PR DESCRIPTION
Fixes https://github.com/formbricks/internal/issues/943

Always requires at least headline if custom close message is on.