### PR TITLE
fix: removes pino pretty from edge runtime

### DIFF
--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -45,6 +45,8 @@ const baseLoggerConfig: LoggerOptions = {
  * - Both: optional pino-opentelemetry-transport for SigNoz log correlation when OTEL is configured
  */
 const buildTransport = (): LoggerOptions["transport"] => {
+  const isEdgeRuntime = process.env.NEXT_RUNTIME === "edge";
+
   const hasOtelEndpoint =
     process.env.NEXT_RUNTIME === "nodejs" && Boolean(process.env.OTEL_EXPORTER_OTLP_ENDPOINT);
 
@@ -77,6 +79,11 @@ const buildTransport = (): LoggerOptions["transport"] => {
   };
 
   if (!IS_PRODUCTION) {
+    // Edge Runtime does not support worker_threads — skip pino-pretty to avoid crashes
+    if (isEdgeRuntime) {
+      return undefined;
+    }
+
     // Development: pretty print + optional OTEL
     if (hasOtelEndpoint) {
       return { targets: [prettyTarget, otelTarget] };


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/formbricks/formbricks/issues/7509

Adds explicit Edge Runtime detection in `packages/logger/src/logger.ts` so that pino-pretty transport is never configured when running in Edge Runtime.

pino-pretty uses `worker_threads` internally, which is not available in Edge Runtime. While pino has auto-detection logic, it is unreliable during Turbopack HMR cycles, causing intermittent `"the worker has exited"` errors. This fix checks `NEXT_RUNTIME === "edge"` in `buildTransport()` and falls back to plain JSON logging, removing the dependency on pino's internal detection.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
