### PR TITLE
chore: forward customer state to chatwoot

### DIFF
--- a/apps/web/app/chatwoot/ChatwootWidget.tsx
+++ b/apps/web/app/chatwoot/ChatwootWidget.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
-import { getIsActiveCustomer } from "./actions";
+import { getIsActiveCustomerAction } from "./actions";
 
 interface ChatwootWidgetProps {
   chatwootBaseUrl: string;
@@ -55,8 +55,10 @@ export const ChatwootWidget = ({
     const $chatwoot = getChatwoot();
     if (!$chatwoot) return;
 
-    const isActiveCustomer = await getIsActiveCustomer();
-    $chatwoot.setCustomAttributes({ isActiveCustomer });
+    const response = await getIsActiveCustomerAction();
+    if (response?.data !== undefined) {
+      $chatwoot.setCustomAttributes({ isActiveCustomer: response.data });
+    }
     customerStatusSetRef.current = true;
   }, [getChatwoot]);
 

--- a/apps/web/app/chatwoot/actions.ts
+++ b/apps/web/app/chatwoot/actions.ts
@@ -1,19 +1,18 @@
 "use server";
 
-import { getServerSession } from "next-auth";
+import { TCloudBillingPlan } from "@formbricks/types/organizations";
 import { getOrganizationsByUserId } from "@/lib/organization/service";
-import { authOptions } from "@/modules/auth/lib/authOptions";
+import { authenticatedActionClient } from "@/lib/utils/action-client";
 
-export const getIsActiveCustomer = async (): Promise<boolean> => {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.id) return false;
+export const getIsActiveCustomerAction = authenticatedActionClient.action(async ({ ctx }) => {
+  const paidBillingPlans = new Set<TCloudBillingPlan>(["pro", "scale", "custom"]);
 
-  const organizations = await getOrganizationsByUserId(session.user.id);
+  const organizations = await getOrganizationsByUserId(ctx.user.id);
   return organizations.some((organization) => {
     const stripe = organization.billing.stripe;
-    const isPaidPlan = stripe?.plan === "pro" || stripe?.plan === "scale" || stripe?.plan === "custom";
+    const isPaidPlan = stripe?.plan ? paidBillingPlans.has(stripe.plan) : false;
     const isActiveSubscription =
       stripe?.subscriptionStatus === "active" || stripe?.subscriptionStatus === "trialing";
     return isPaidPlan && isActiveSubscription;
   });
-};
+});


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes https://github.com/formbricks/internal/issues/1479

 Why we fetch on widget open instead of in the layout:                                                                                              
                                                                                                                                                     
  The app layout (app/(app)/layout.tsx) is a Server Component that re-executes on every page navigation. In Next.js 16, the Router Cache default for
  dynamic pages is 0 seconds, meaning every client-side navigation triggers a fresh server render of the layout.                                     
                                                                                                                                                   
  Fetching getOrganizationsByUserId in the layout would result in ~60-150 extra DB queries per hour per user, just to compute a boolean for a        
  Chatwoot attribute that rarely changes (only on plan upgrades/downgrades). reactCache only deduplicates within a single request, so it doesn't help
   across navigations.                                                                                                                               
                                                                                                                                                   
  Instead, we use a server action that's called lazily when the user actually opens the Chatwoot widget (chatwoot:open event). A ref guard           
  (customerStatusSetRef) ensures it only fetches once per session. This reduces DB calls from ~60-150/hour to 0-1 — only when the user actually needs
   support.        

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Test chatwoot

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary
