### PR TITLE
fix: mark language selector tooltip as translatable

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -355,6 +355,7 @@ checksums:
     common/select: 5ac04c47a98deb85906bc02e0de91ab0
     common/select_all: eedc7cdb02de467c15dc418a066a77f2
     common/select_filter: c50082c3981f1161022f9787a19aed71
+    common/select_language: d75cf5fbce8a4c7a9055e2210af74480
     common/select_survey: bac52e59c7847417bef6fe7b7096b475
     common/select_teams: ae5d451929846ae6367562bc671a1af9
     common/selected: 9f09e059ba20c88ed34e2b4e8e032d56

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -382,6 +382,7 @@
     "select": "Auswählen",
     "select_all": "Alles auswählen",
     "select_filter": "Filter auswählen",
+    "select_language": "Sprache auswählen",
     "select_survey": "Umfrage auswählen",
     "select_teams": "Teams auswählen",
     "selected": "Ausgewählt",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -382,6 +382,7 @@
     "select": "Select",
     "select_all": "Select all",
     "select_filter": "Select filter",
+    "select_language": "Select Language",
     "select_survey": "Select Survey",
     "select_teams": "Select teams",
     "selected": "Selected",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -382,6 +382,7 @@
     "select": "Seleccionar",
     "select_all": "Seleccionar todo",
     "select_filter": "Seleccionar filtro",
+    "select_language": "Seleccionar idioma",
     "select_survey": "Seleccionar encuesta",
     "select_teams": "Seleccionar equipos",
     "selected": "Seleccionado",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -382,6 +382,7 @@
     "select": "Sélectionner",
     "select_all": "Sélectionner tout",
     "select_filter": "Sélectionner un filtre",
+    "select_language": "Sélectionner la langue",
     "select_survey": "Sélectionner l'enquête",
     "select_teams": "Sélectionner les équipes",
     "selected": "Sélectionné",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -382,6 +382,7 @@
     "select": "Kiválasztás",
     "select_all": "Összes kiválasztása",
     "select_filter": "Szűrő kiválasztása",
+    "select_language": "Nyelv kiválasztása",
     "select_survey": "Kérdőív kiválasztása",
     "select_teams": "Csapatok kiválasztása",
     "selected": "Kiválasztva",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -382,6 +382,7 @@
     "select": "選択",
     "select_all": "すべて選択",
     "select_filter": "フィルターを選択",
+    "select_language": "言語を選択",
     "select_survey": "フォームを選択",
     "select_teams": "チームを選択",
     "selected": "選択済み",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -382,6 +382,7 @@
     "select": "Selecteer",
     "select_all": "Selecteer alles",
     "select_filter": "Filter selecteren",
+    "select_language": "Selecteer taal",
     "select_survey": "Selecteer Enquête",
     "select_teams": "Selecteer teams",
     "selected": "Gekozen",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -382,6 +382,7 @@
     "select": "Selecionar",
     "select_all": "Selecionar tudo",
     "select_filter": "Selecionar filtro",
+    "select_language": "Selecionar Idioma",
     "select_survey": "Selecionar Pesquisa",
     "select_teams": "Selecionar times",
     "selected": "Selecionado",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -382,6 +382,7 @@
     "select": "Selecionar",
     "select_all": "Selecionar tudo",
     "select_filter": "Selecionar filtro",
+    "select_language": "Selecionar Idioma",
     "select_survey": "Selecionar Inquérito",
     "select_teams": "Selecionar equipas",
     "selected": "Selecionado",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -382,6 +382,7 @@
     "select": "Selectați",
     "select_all": "Selectați toate",
     "select_filter": "Selectați filtrul",
+    "select_language": "Selectează limba",
     "select_survey": "Selectați chestionar",
     "select_teams": "Selectați echipele",
     "selected": "Selectat",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -382,6 +382,7 @@
     "select": "Выбрать",
     "select_all": "Выбрать все",
     "select_filter": "Выбрать фильтр",
+    "select_language": "Выберите язык",
     "select_survey": "Выбрать опрос",
     "select_teams": "Выбрать команды",
     "selected": "Выбрано",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -382,6 +382,7 @@
     "select": "Välj",
     "select_all": "Välj alla",
     "select_filter": "Välj filter",
+    "select_language": "Välj språk",
     "select_survey": "Välj enkät",
     "select_teams": "Välj team",
     "selected": "Vald",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -382,6 +382,7 @@
     "select": "选择",
     "select_all": "选择 全部",
     "select_filter": "选择过滤器",
+    "select_language": "选择语言",
     "select_survey": "选择 调查",
     "select_teams": "选择 团队",
     "selected": "已选择",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -382,6 +382,7 @@
     "select": "選擇",
     "select_all": "全選",
     "select_filter": "選擇篩選器",
+    "select_language": "選擇語言",
     "select_survey": "選擇問卷",
     "select_teams": "選擇 團隊",
     "selected": "已選取",

--- a/apps/web/modules/analysis/components/ShareSurveyLink/components/LanguageDropdown.tsx
+++ b/apps/web/modules/analysis/components/ShareSurveyLink/components/LanguageDropdown.tsx
@@ -1,5 +1,6 @@
 import { Languages } from "lucide-react";
 import { getLanguageLabel } from "@formbricks/i18n-utils/src/utils";
+import { useTranslation } from "react-i18next";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
 import { getEnabledLanguages } from "@/lib/i18n/utils";
@@ -17,7 +18,12 @@ interface LanguageDropdownProps {
   locale: TUserLocale;
 }
 
-export const LanguageDropdown = ({ survey, setLanguage, locale }: LanguageDropdownProps) => {
+export const LanguageDropdown = ({
+  survey,
+  setLanguage,
+  locale,
+}: LanguageDropdownProps) => {
+  const { t } = useTranslation();
   const enabledLanguages = getEnabledLanguages(survey.languages ?? []);
 
   if (enabledLanguages.length <= 1) {
@@ -27,7 +33,7 @@ export const LanguageDropdown = ({ survey, setLanguage, locale }: LanguageDropdo
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="secondary" title="Select Language" aria-label="Select Language">
+        <Button variant="secondary" title={t("common.select_language")} aria-label={t("common.select_language")}>
           <Languages className="h-5 w-5" />
         </Button>
       </DropdownMenuTrigger>


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

This pull request marks language selector tooltip as translatable. Other fields are already translatable on the same screen.

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Create a multi-language survey with enabled language selector and publish it.
- Hover the mouse over the language selector and see the tooltip.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [X] Filled out the "How to test" section in this PR
- [X] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [X] Self-reviewed my own code
- [X] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [X] Checked for warnings, there are none
- [X] Removed all `console.logs`
- [X] Merged the latest changes from main onto my branch with `git pull origin main`
- [X] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
