### PR TITLE
fix: prevent OIDC login text overlap with last-used badge

### DIFF
--- a/apps/web/modules/ee/sso/components/open-id-button.tsx
+++ b/apps/web/modules/ee/sso/components/open-id-button.tsx
@@ -46,7 +46,7 @@ export const OpenIdButton = ({
       type="button"
       onClick={handleLogin}
       variant="secondary"
-      className="relative w-full justify-center">
+      className={`relative w-full justify-center ${lastUsed ? "pr-20" : ""}`}>
       {text ? text : t("auth.continue_with_openid")}
       {lastUsed && <span className="absolute right-3 text-xs opacity-50">{t("auth.last_used")}</span>}
     </Button>


### PR DESCRIPTION
## Bug
https://github.com/formbricks/formbricks/issues/7539 — long OIDC button labels can overlap visually when the "last used" badge is present.

## Fix
Reserve space for the absolute-positioned "last used" badge in `OpenIdButton` by adding right padding when `lastUsed` is true.

This keeps the OIDC label centered/readable instead of rendering underneath the badge area.

## Testing
- Verified the rendered class list now adds `pr-20` only when `lastUsed` is true.
- Confirmed this is a minimal UI-only change scoped to the OIDC SSO button.

Happy to address any feedback.

Greetings, saschabuehrle
