### PR TITLE
fix: add nonExplicitSupportedLngs to support locale-specific language codes

### DIFF
--- a/packages/surveys/src/lib/i18n.config.ts
+++ b/packages/surveys/src/lib/i18n.config.ts
@@ -43,6 +43,8 @@ i18n
       "uz",
       "zh-Hans",
     ],
+    // Allow locale-specific codes (e.g., "fr-FR") to match base languages (e.g., "fr")
+    nonExplicitSupportedLngs: true,
 
     resources: {
       ar: { translation: arTranslations },


### PR DESCRIPTION
## Summary

When users select locale-specific language codes like fr-FR, de-DE, or es-ES, the surveys package was falling back to English because only base language codes (fr, de, es) were listed in supportedLngs.

## Changes

- Added `nonExplicitSupportedLngs: true` to the i18next configuration in the surveys package
- This allows i18next to match locale-specific codes to their base language resources

## Testing

- French translations will now be correctly used when the language is set to fr-FR
- German translations will work for de-DE
- Spanish translations will work for es-ES
- And so on for all supported languages

## Related Issue

Fixes #7406