### PR TITLE
fix(surveys): prevent button overflow in multi-language editing toolbar

### DIFF
--- a/apps/web/modules/survey/editor/components/multiple-choice-element-form.tsx
+++ b/apps/web/modules/survey/editor/components/multiple-choice-element-form.tsx
@@ -369,8 +369,8 @@ export const MultipleChoiceElementForm = ({
         </div>
 
         <div className="mt-2">
-          <div className="mt-2 flex items-center justify-between space-x-2">
-            <div className="flex gap-2">
+          <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+            <div className="flex flex-wrap gap-2">
               {specialChoices.map((specialChoice) => {
                 if (element.choices.some((c) => c.id === specialChoice.id)) return null;
                 return (


### PR DESCRIPTION
## Summary
Fixes button overflow in the survey editor toolbar when multi-language editing is enabled and the translated button text is longer than English (e.g., Hungarian "Tömeges szerkesztés (Hungarian)").

## Issue
Fixes #7549

## Changes
- Replaced `space-x-2` with `gap-2` and added `flex-wrap` to the toolbar container so buttons wrap to the next line instead of overflowing when text is longer
- Added `flex-wrap` to the inner button group for consistent wrapping behavior

## Testing
- Enable multi-language editing in a survey with multiple choice questions
- Switch to a language with longer button text (e.g., Hungarian)
- Verify the toolbar buttons wrap properly instead of overflowing at 1366×768 resolution
- Confirm no layout issues at 1920×1080 (FullHD) resolution