### PR TITLE
fix: handle serverError in toast notifications for server actions

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/settings/(account)/profile/components/EditProfileDetailsForm.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/settings/(account)/profile/components/EditProfileDetailsForm.tsx
@@ -116,10 +116,14 @@ export const EditProfileDetailsForm = ({
       setShowModal(true);
     } else {
       try {
-        await updateUserAction({
+        const result = await updateUserAction({
           ...data,
           name: data.name.trim(),
         });
+        if (result?.serverError) {
+          toast.error(getFormattedErrorMessage(result));
+          return;
+        }
         toast.success(t("environments.settings.profile.profile_updated_successfully"));
         window.location.reload();
         form.reset(data);

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTable.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTable.tsx
@@ -29,6 +29,7 @@ import { ResponseTableCell } from "@/app/(app)/environments/[environmentId]/surv
 import { generateResponseTableColumns } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTableColumns";
 import { getResponsesDownloadUrlAction } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/actions";
 import { downloadResponsesFile } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/utils";
+import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { deleteResponseAction } from "@/modules/analysis/components/SingleResponseCard/actions";
 import { Button } from "@/modules/ui/components/button";
 import {
@@ -201,7 +202,10 @@ export const ResponseTable = ({
   };
 
   const deleteResponse = async (responseId: string, params?: { decrementQuotas?: boolean }) => {
-    await deleteResponseAction({ responseId, decrementQuotas: params?.decrementQuotas ?? false });
+    const result = await deleteResponseAction({ responseId, decrementQuotas: params?.decrementQuotas ?? false });
+    if (result?.serverError) {
+      throw new Error(getFormattedErrorMessage(result));
+    }
   };
 
   // Handle downloading selected responses

--- a/apps/web/modules/analysis/components/SingleResponseCard/index.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/index.tsx
@@ -8,6 +8,7 @@ import { TResponse, TResponseWithQuotas } from "@formbricks/types/responses";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { TTag } from "@formbricks/types/tags";
 import { TUser, TUserLocale } from "@formbricks/types/user";
+import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 import { DecrementQuotasCheckbox } from "@/modules/ui/components/decrement-quotas-checkbox";
 import { DeleteDialog } from "@/modules/ui/components/delete-dialog";
@@ -104,7 +105,11 @@ export const SingleResponseCard = ({
       if (isReadOnly) {
         throw new Error(t("common.not_authorized"));
       }
-      await deleteResponseAction({ responseId: response.id, decrementQuotas });
+      const result = await deleteResponseAction({ responseId: response.id, decrementQuotas });
+      if (result?.serverError) {
+        toast.error(getFormattedErrorMessage(result));
+        return;
+      }
       updateResponseList?.([response.id]);
       if (setSelectedResponseId) setSelectedResponseId(null);
       toast.success(t("environments.surveys.responses.response_deleted_successfully"));

--- a/apps/web/modules/ee/contacts/components/contacts-table.tsx
+++ b/apps/web/modules/ee/contacts/components/contacts-table.tsx
@@ -19,6 +19,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TUserLocale } from "@formbricks/types/user";
 import { cn } from "@/lib/cn";
+import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { deleteContactAction } from "@/modules/ee/contacts/actions";
 import { Button } from "@/modules/ui/components/button";
 import {
@@ -220,7 +221,10 @@ export const ContactsTable = ({
   };
 
   const deleteContact = async (contactId: string) => {
-    await deleteContactAction({ contactId });
+    const result = await deleteContactAction({ contactId });
+    if (result?.serverError) {
+      throw new Error(getFormattedErrorMessage(result));
+    }
   };
 
   return (

--- a/apps/web/modules/ee/role-management/components/edit-membership-role.tsx
+++ b/apps/web/modules/ee/role-management/components/edit-membership-role.tsx
@@ -7,6 +7,7 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import type { TOrganizationRole } from "@formbricks/types/memberships";
 import { getAccessFlags } from "@/lib/membership/utils";
+import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { Badge } from "@/modules/ui/components/badge";
 import { Button } from "@/modules/ui/components/button";
 import {
@@ -61,11 +62,21 @@ export function EditMembershipRole({
 
     try {
       if (memberAccepted && memberId) {
-        await updateMembershipAction({ userId: memberId, organizationId, data: { role } });
+        const result = await updateMembershipAction({ userId: memberId, organizationId, data: { role } });
+        if (result?.serverError) {
+          toast.error(getFormattedErrorMessage(result));
+          setLoading(false);
+          return;
+        }
       }
 
       if (inviteId) {
-        await updateInviteAction({ inviteId: inviteId, data: { role } });
+        const result = await updateInviteAction({ inviteId: inviteId, data: { role } });
+        if (result?.serverError) {
+          toast.error(getFormattedErrorMessage(result));
+          setLoading(false);
+          return;
+        }
       }
     } catch (error) {
       toast.error(t("common.something_went_wrong_please_try_again"));

--- a/apps/web/modules/survey/editor/components/create-new-action-tab.tsx
+++ b/apps/web/modules/survey/editor/components/create-new-action-tab.tsx
@@ -8,6 +8,7 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { TActionClassInput } from "@formbricks/types/action-classes";
 import { TSurvey } from "@formbricks/types/surveys/types";
+import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { ActionNameDescriptionFields } from "@/modules/ui/components/action-name-description-fields";
 import { Button } from "@/modules/ui/components/button";
 import { CodeActionForm } from "@/modules/ui/components/code-action-form";
@@ -81,6 +82,11 @@ export const CreateNewActionTab = ({
     const createActionClassResposne = await createActionClassAction({
       action: updatedAction,
     });
+
+    if (createActionClassResposne?.serverError) {
+      toast.error(getFormattedErrorMessage(createActionClassResposne));
+      return;
+    }
 
     if (!createActionClassResposne?.data) return;
 

--- a/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
+++ b/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
@@ -105,7 +105,9 @@ export const SurveyDropDownMenu = ({
         targetEnvironmentId: environmentId,
       });
 
-      if (duplicatedSurveyResponse?.data) {
+      if (duplicatedSurveyResponse?.serverError) {
+        toast.error(getFormattedErrorMessage(duplicatedSurveyResponse));
+      } else if (duplicatedSurveyResponse?.data) {
         const transformedDuplicatedSurvey = await getSurveyAction({
           surveyId: duplicatedSurveyResponse.data.id,
         });

--- a/apps/web/modules/survey/multi-language-surveys/components/edit-language.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/edit-language.tsx
@@ -113,7 +113,9 @@ export function EditLanguage({ project, locale, isReadOnly }: EditLanguageProps)
         languageId,
       });
 
-      if (surveysUsingLanguageResponse?.data) {
+      if (surveysUsingLanguageResponse?.serverError) {
+        toast.error(getFormattedErrorMessage(surveysUsingLanguageResponse));
+      } else if (surveysUsingLanguageResponse?.data) {
         if (surveysUsingLanguageResponse.data.length > 0) {
           const surveyList = surveysUsingLanguageResponse.data
             .map((surveyName) => `• ${surveyName}`)


### PR DESCRIPTION
## Summary

Fixes #3302 — Several components showed success toasts even when server actions returned `serverError` (HTTP 200 with error payload from `next-safe-action`).

## Changes

Added `serverError` checks before success toasts in 8 components:

| Component | Action | Before | After |
|---|---|---|---|
| `SingleResponseCard` | `deleteResponseAction` | Toast success unconditionally | Checks `serverError` first |
| `EditProfileDetailsForm` | `updateUserAction` | Toast success unconditionally | Checks `serverError` first |
| `edit-membership-role` | `updateMembershipAction`, `updateInviteAction` | Silent failure | Shows error toast |
| `ResponseTable` | `deleteResponseAction` (callback) | Toast success unconditionally | Throws on error (caught by parent) |
| `contacts-table` | `deleteContactAction` (callback) | Toast success unconditionally | Throws on error (caught by parent) |
| `create-new-action-tab` | `createActionClassAction` | Silent failure | Shows error toast |
| `survey-dropdown-menu` | `copySurveyToOtherEnvironmentAction` | Checked `data` only — serverError showed success | Checks `serverError` first |
| `edit-language` | `getSurveysUsingGivenLanguageAction` | Checked `data` only — serverError was silently ignored | Checks `serverError` first |

## Pattern used

Follows the existing codebase pattern (~70% of components already use this):

```typescript
const result = await someAction({...});
if (result?.serverError) {
  toast.error(getFormattedErrorMessage(result));
  return;
}
toast.success("...");
```

## Test plan
- [ ] Trigger ISE on each affected action and verify error toast appears
- [ ] Verify success flow still works correctly
- [ ] No regressions in existing toast behavior

/claim #3302
