### PR TITLE
feat: custom posthog events

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/personal-links-tab.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/personal-links-tab.tsx
@@ -163,6 +163,7 @@ export const PersonalLinksTab = ({
       <UpgradePrompt
         title={t("environments.surveys.share.personal_links.upgrade_prompt_title")}
         description={t("environments.surveys.share.personal_links.upgrade_prompt_description")}
+        feature="personal_links"
         buttons={[
           {
             text: isFormbricksCloud ? t("common.upgrade_plan") : t("common.request_trial_license"),

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/actions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { ZResponseFilterCriteria } from "@formbricks/types/responses";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { getResponseDownloadFile, getResponseFilteringValues } from "@/lib/response/service";
 import { getSurvey } from "@/lib/survey/service";
 import { getTagsByEnvironmentId } from "@/lib/tag/service";
@@ -23,9 +24,11 @@ const ZGetResponsesDownloadUrlAction = z.object({
 export const getResponsesDownloadUrlAction = authenticatedActionClient
   .inputSchema(ZGetResponsesDownloadUrlAction)
   .action(async ({ ctx, parsedInput }) => {
+    const organizationId = await getOrganizationIdFromSurveyId(parsedInput.surveyId);
+
     await checkAuthorizationUpdated({
       userId: ctx.user.id,
-      organizationId: await getOrganizationIdFromSurveyId(parsedInput.surveyId),
+      organizationId,
       access: [
         {
           type: "organization",
@@ -39,11 +42,20 @@ export const getResponsesDownloadUrlAction = authenticatedActionClient
       ],
     });
 
-    return await getResponseDownloadFile(
+    const result = await getResponseDownloadFile(
       parsedInput.surveyId,
       parsedInput.format,
       parsedInput.filterCriteria
     );
+
+    capturePostHogEvent(ctx.user.id, "responses_exported", {
+      survey_id: parsedInput.surveyId,
+      format: parsedInput.format,
+      filter_applied: Object.keys(parsedInput.filterCriteria ?? {}).length > 0,
+      organization_id: organizationId,
+    });
+
+    return result;
   });
 
 const ZGetSurveyFilterDataAction = z.object({

--- a/apps/web/app/(app)/environments/[environmentId]/workspace/integrations/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/workspace/integrations/actions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { ZIntegrationInput } from "@formbricks/types/integration";
 import { createOrUpdateIntegration, deleteIntegration } from "@/lib/integration/service";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import {
@@ -45,6 +46,12 @@ export const createOrUpdateIntegrationAction = authenticatedActionClient
       const result = await createOrUpdateIntegration(parsedInput.environmentId, parsedInput.integrationData);
       ctx.auditLoggingCtx.integrationId = result.id;
       ctx.auditLoggingCtx.newObject = result;
+
+      capturePostHogEvent(ctx.user.id, "integration_connected", {
+        integration_type: parsedInput.integrationData.type,
+        organization_id: organizationId,
+      });
+
       return result;
     })
   );

--- a/apps/web/app/api/(internal)/pipeline/route.ts
+++ b/apps/web/app/api/(internal)/pipeline/route.ts
@@ -10,7 +10,7 @@ import { ZPipelineInput } from "@/app/api/(internal)/pipeline/types/pipelines";
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
 import { cache } from "@/lib/cache";
-import { CRON_SECRET } from "@/lib/constants";
+import { CRON_SECRET, POSTHOG_KEY } from "@/lib/constants";
 import { generateStandardWebhookSignature } from "@/lib/crypto";
 import { getIntegrations } from "@/lib/integration/service";
 import { getOrganizationByEnvironmentId } from "@/lib/organization/service";
@@ -303,22 +303,24 @@ export const POST = async (request: Request) => {
     });
 
     // Sampled PostHog tracking: first response + every 100th
-    const responseCount = await cache.withCache(
-      () => getResponseCountBySurveyId(surveyId),
-      createCacheKey.response.countBySurveyId(surveyId),
-      60 * 1000
-    );
+    if (POSTHOG_KEY) {
+      const responseCount = await cache.withCache(
+        () => getResponseCountBySurveyId(surveyId),
+        createCacheKey.response.countBySurveyId(surveyId),
+        60 * 1000
+      );
 
-    if (responseCount === 1 || responseCount % 100 === 0) {
-      capturePostHogEvent(organization.id, "survey_response_received", {
-        survey_id: surveyId,
-        survey_type: survey.type,
-        organization_id: organization.id,
-        environment_id: environmentId,
-        response_count: responseCount,
-        is_first_response: responseCount === 1,
-        milestone: responseCount === 1 ? "first" : String(responseCount),
-      });
+      if (responseCount === 1 || responseCount % 100 === 0) {
+        capturePostHogEvent(organization.id, "survey_response_received", {
+          survey_id: surveyId,
+          survey_type: survey.type,
+          organization_id: organization.id,
+          environment_id: environmentId,
+          response_count: responseCount,
+          is_first_response: responseCount === 1,
+          milestone: responseCount === 1 ? "first" : String(responseCount),
+        });
+      }
     }
 
     // Send telemetry events

--- a/apps/web/app/api/(internal)/pipeline/route.ts
+++ b/apps/web/app/api/(internal)/pipeline/route.ts
@@ -1,6 +1,7 @@
 import { PipelineTriggers, Webhook } from "@prisma/client";
 import { headers } from "next/headers";
 import { v7 as uuidv7 } from "uuid";
+import { createCacheKey } from "@formbricks/cache";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
@@ -8,10 +9,12 @@ import { sendTelemetryEvents } from "@/app/api/(internal)/pipeline/lib/telemetry
 import { ZPipelineInput } from "@/app/api/(internal)/pipeline/types/pipelines";
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
+import { cache } from "@/lib/cache";
 import { CRON_SECRET } from "@/lib/constants";
 import { generateStandardWebhookSignature } from "@/lib/crypto";
 import { getIntegrations } from "@/lib/integration/service";
 import { getOrganizationByEnvironmentId } from "@/lib/organization/service";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { getResponseCountBySurveyId } from "@/lib/response/service";
 import { getSurvey, updateSurvey } from "@/lib/survey/service";
 import { convertDatesInObject } from "@/lib/time";
@@ -298,6 +301,25 @@ export const POST = async (request: Request) => {
     }).catch((error) => {
       logger.error({ error, responseId: response.id }, "Failed to record response meter event");
     });
+
+    // Sampled PostHog tracking: first response + every 100th
+    const responseCount = await cache.withCache(
+      () => getResponseCountBySurveyId(surveyId),
+      createCacheKey.response.countBySurveyId(surveyId),
+      60 * 1000
+    );
+
+    if (responseCount === 1 || responseCount % 100 === 0) {
+      capturePostHogEvent(organization.id, "survey_response_received", {
+        survey_id: surveyId,
+        survey_type: survey.type,
+        organization_id: organization.id,
+        environment_id: environmentId,
+        response_count: responseCount,
+        is_first_response: responseCount === 1,
+        milestone: responseCount === 1 ? "first" : String(responseCount),
+      });
+    }
 
     // Send telemetry events
     await sendTelemetryEvents();

--- a/apps/web/app/api/v1/client/[environmentId]/environment/lib/environmentState.test.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/environment/lib/environmentState.test.ts
@@ -6,6 +6,7 @@ import { TJsEnvironmentState, TJsEnvironmentStateProject } from "@formbricks/typ
 import { TOrganization } from "@formbricks/types/organizations";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { cache } from "@/lib/cache";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { EnvironmentStateData, getEnvironmentStateData } from "./data";
 import { getEnvironmentState } from "./environmentState";
 
@@ -36,6 +37,11 @@ vi.mock("@/lib/constants", () => ({
   IS_RECAPTCHA_CONFIGURED: true,
   IS_PRODUCTION: true,
   ENTERPRISE_LICENSE_KEY: "mock_enterprise_license_key",
+  POSTHOG_KEY: "phc_test_key",
+}));
+
+vi.mock("@/lib/posthog", () => ({
+  capturePostHogEvent: vi.fn(),
 }));
 
 // Mock @formbricks/cache
@@ -302,5 +308,39 @@ describe("getEnvironmentState", () => {
     const result = await getEnvironmentState(environmentId);
 
     expect(result.data.actionClasses).toEqual([]);
+  });
+
+  test("should capture app_connected PostHog event when app setup completes", async () => {
+    const noCodeAction = {
+      ...mockActionClasses[0],
+      id: "action-2",
+      type: "noCode" as const,
+      key: null,
+    };
+    const incompleteEnvironmentData = {
+      ...mockEnvironmentStateData,
+      environment: {
+        ...mockEnvironmentStateData.environment,
+        appSetupCompleted: false,
+      },
+      actionClasses: [...mockActionClasses, noCodeAction],
+    };
+    vi.mocked(getEnvironmentStateData).mockResolvedValue(incompleteEnvironmentData);
+
+    await getEnvironmentState(environmentId);
+
+    expect(capturePostHogEvent).toHaveBeenCalledWith(environmentId, "app_connected", {
+      num_surveys: 1,
+      num_code_actions: 1,
+      num_no_code_actions: 1,
+    });
+  });
+
+  test("should not capture app_connected event when app setup already completed", async () => {
+    vi.mocked(getEnvironmentStateData).mockResolvedValue(mockEnvironmentStateData);
+
+    await getEnvironmentState(environmentId);
+
+    expect(capturePostHogEvent).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/api/v1/client/[environmentId]/environment/lib/environmentState.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/environment/lib/environmentState.ts
@@ -3,7 +3,8 @@ import { createCacheKey } from "@formbricks/cache";
 import { prisma } from "@formbricks/database";
 import { TJsEnvironmentState } from "@formbricks/types/js";
 import { cache } from "@/lib/cache";
-import { IS_RECAPTCHA_CONFIGURED, RECAPTCHA_SITE_KEY } from "@/lib/constants";
+import { IS_RECAPTCHA_CONFIGURED, POSTHOG_KEY, RECAPTCHA_SITE_KEY } from "@/lib/constants";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { getEnvironmentStateData } from "./data";
 
 /**
@@ -30,6 +31,14 @@ export const getEnvironmentState = async (
           where: { id: environmentId },
           data: { appSetupCompleted: true },
         });
+
+        if (POSTHOG_KEY) {
+          capturePostHogEvent(environmentId, "app_connected", {
+            num_surveys: surveys.length,
+            num_code_actions: actionClasses.filter((ac) => ac.type === "code").length,
+            num_no_code_actions: actionClasses.filter((ac) => ac.type === "noCode").length,
+          });
+        }
       }
 
       // Build the response data

--- a/apps/web/app/setup/organization/create/actions.ts
+++ b/apps/web/app/setup/organization/create/actions.ts
@@ -53,7 +53,6 @@ export const createOrganizationAction = authenticatedActionClient
       capturePostHogEvent(ctx.user.id, "organization_created", {
         organization_id: newOrganization.id,
         is_first_org: hasNoOrganizations,
-        user_id: ctx.user.id,
       });
 
       return newOrganization;

--- a/apps/web/app/setup/organization/create/actions.ts
+++ b/apps/web/app/setup/organization/create/actions.ts
@@ -7,6 +7,7 @@ import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { gethasNoOrganizations } from "@/lib/instance/service";
 import { createMembership } from "@/lib/membership/service";
 import { createOrganization } from "@/lib/organization/service";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import { ensureCloudStripeSetupForOrganization } from "@/modules/ee/billing/lib/organization-billing";
@@ -48,6 +49,12 @@ export const createOrganizationAction = authenticatedActionClient
 
       ctx.auditLoggingCtx.organizationId = newOrganization.id;
       ctx.auditLoggingCtx.newObject = newOrganization;
+
+      capturePostHogEvent(ctx.user.id, "organization_created", {
+        organization_id: newOrganization.id,
+        is_first_org: hasNoOrganizations,
+        user_id: ctx.user.id,
+      });
 
       return newOrganization;
     })

--- a/apps/web/lib/posthog/capture.test.ts
+++ b/apps/web/lib/posthog/capture.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { capturePostHogEvent } from "./capture";
+
+const mocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  loggerWarn: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: { warn: mocks.loggerWarn },
+}));
+
+vi.mock("./server", () => ({
+  posthogServerClient: { capture: mocks.capture },
+}));
+
+describe("capturePostHogEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("calls posthog capture with correct params", () => {
+    capturePostHogEvent("user123", "test_event", { key: "value" });
+
+    expect(mocks.capture).toHaveBeenCalledWith({
+      distinctId: "user123",
+      event: "test_event",
+      properties: {
+        key: "value",
+        $lib: "posthog-node",
+        source: "server",
+      },
+    });
+  });
+
+  test("adds default properties when no properties provided", () => {
+    capturePostHogEvent("user123", "test_event");
+
+    expect(mocks.capture).toHaveBeenCalledWith({
+      distinctId: "user123",
+      event: "test_event",
+      properties: {
+        $lib: "posthog-node",
+        source: "server",
+      },
+    });
+  });
+
+  test("does not throw when capture throws", () => {
+    mocks.capture.mockImplementation(() => {
+      throw new Error("Network error");
+    });
+
+    expect(() => capturePostHogEvent("user123", "test_event")).not.toThrow();
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      { error: expect.any(Error), eventName: "test_event" },
+      "Failed to capture PostHog event"
+    );
+  });
+});
+
+describe("capturePostHogEvent with null client", () => {
+  test("no-ops when posthogServerClient is null", async () => {
+    vi.resetModules();
+
+    vi.doMock("server-only", () => ({}));
+    vi.doMock("@formbricks/logger", () => ({
+      logger: { warn: mocks.loggerWarn },
+    }));
+    vi.doMock("./server", () => ({
+      posthogServerClient: null,
+    }));
+
+    const { capturePostHogEvent: captureWithNullClient } = await import("./capture");
+
+    captureWithNullClient("user123", "test_event", { key: "value" });
+
+    expect(mocks.capture).not.toHaveBeenCalled();
+    expect(mocks.loggerWarn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/posthog/capture.test.ts
+++ b/apps/web/lib/posthog/capture.test.ts
@@ -63,6 +63,7 @@ describe("capturePostHogEvent", () => {
 
 describe("capturePostHogEvent with null client", () => {
   test("no-ops when posthogServerClient is null", async () => {
+    vi.clearAllMocks();
     vi.resetModules();
 
     vi.doMock("server-only", () => ({}));

--- a/apps/web/lib/posthog/capture.ts
+++ b/apps/web/lib/posthog/capture.ts
@@ -1,0 +1,27 @@
+import "server-only";
+import { logger } from "@formbricks/logger";
+import { posthogServerClient } from "./server";
+
+type PostHogEventProperties = Record<string, string | number | boolean | null | undefined>;
+
+export function capturePostHogEvent(
+  distinctId: string,
+  eventName: string,
+  properties?: PostHogEventProperties
+): void {
+  if (!posthogServerClient) return;
+
+  try {
+    posthogServerClient.capture({
+      distinctId,
+      event: eventName,
+      properties: {
+        ...properties,
+        $lib: "posthog-node",
+        source: "server",
+      },
+    });
+  } catch (error) {
+    logger.warn({ error, eventName }, "Failed to capture PostHog event");
+  }
+}

--- a/apps/web/lib/posthog/index.ts
+++ b/apps/web/lib/posthog/index.ts
@@ -1,0 +1,1 @@
+export { capturePostHogEvent } from "./capture";

--- a/apps/web/lib/posthog/server.test.ts
+++ b/apps/web/lib/posthog/server.test.ts
@@ -1,52 +1,50 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const mocks = vi.hoisted(() => ({
-  PostHog: vi.fn().mockImplementation(() => ({
-    capture: vi.fn(),
-    shutdown: vi.fn(),
-  })),
-  loggerError: vi.fn(),
-}));
-
-vi.mock("server-only", () => ({}));
-
-vi.mock("@formbricks/logger", () => ({
-  logger: { error: mocks.loggerError },
-}));
-
-vi.mock("posthog-node", () => ({
-  PostHog: mocks.PostHog,
-}));
-
 describe("server - posthogServerClient", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.resetModules();
+  const g = globalThis as Record<string, unknown>;
 
-    // Clean up globalThis between tests
-    const g = globalThis as Record<string, unknown>;
+  const setupMocks = (opts: {
+    posthogKey?: string;
+    shutdown?: ReturnType<typeof vi.fn>;
+    loggerError?: ReturnType<typeof vi.fn>;
+  }) => {
+    const shutdown = opts.shutdown ?? vi.fn().mockResolvedValue(undefined);
+    const loggerError = opts.loggerError ?? vi.fn();
+
+    vi.doMock("server-only", () => ({}));
+    vi.doMock("@formbricks/logger", () => ({ logger: { error: loggerError } }));
+    vi.doMock("posthog-node", () => ({
+      PostHog: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+        this.capture = vi.fn();
+        this.shutdown = shutdown;
+      }),
+    }));
+    vi.doMock("@/lib/constants", () => ({ POSTHOG_KEY: opts.posthogKey }));
+
+    return { shutdown, loggerError };
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
     delete g.posthogServerClient;
     delete g.posthogHandlersRegistered;
   });
 
   test("returns null when POSTHOG_KEY is not set", async () => {
-    vi.doMock("@/lib/constants", () => ({
-      POSTHOG_KEY: undefined,
-    }));
+    setupMocks({ posthogKey: undefined });
 
     const { posthogServerClient } = await import("./server");
     expect(posthogServerClient).toBeNull();
-    expect(mocks.PostHog).not.toHaveBeenCalled();
   });
 
   test("creates PostHog client when POSTHOG_KEY is set", async () => {
-    vi.doMock("@/lib/constants", () => ({
-      POSTHOG_KEY: "phc_test_key",
-    }));
+    setupMocks({ posthogKey: "phc_test_key" });
 
     const { posthogServerClient } = await import("./server");
     expect(posthogServerClient).not.toBeNull();
-    expect(mocks.PostHog).toHaveBeenCalledWith("phc_test_key", {
+
+    const { PostHog } = await import("posthog-node");
+    expect(PostHog).toHaveBeenCalledWith("phc_test_key", {
       host: "https://eu.i.posthog.com",
       flushAt: 1,
       flushInterval: 0,
@@ -54,15 +52,120 @@ describe("server - posthogServerClient", () => {
   });
 
   test("reuses client from globalThis in development", async () => {
-    const fakeClient = { capture: vi.fn(), shutdown: vi.fn() };
-    (globalThis as Record<string, unknown>).posthogServerClient = fakeClient;
+    const fakeClient = { capture: vi.fn(), shutdown: vi.fn().mockResolvedValue(undefined) };
+    g.posthogServerClient = fakeClient;
 
-    vi.doMock("@/lib/constants", () => ({
-      POSTHOG_KEY: "phc_test_key",
-    }));
+    setupMocks({ posthogKey: "phc_test_key" });
 
     const { posthogServerClient } = await import("./server");
     expect(posthogServerClient).toBe(fakeClient);
-    expect(mocks.PostHog).not.toHaveBeenCalled();
+
+    const { PostHog } = await import("posthog-node");
+    expect(PostHog).not.toHaveBeenCalled();
+  });
+
+  test("caches client on globalThis in non-production", async () => {
+    vi.stubEnv("NODE_ENV", "development");
+
+    setupMocks({ posthogKey: "phc_test_key" });
+
+    const { posthogServerClient } = await import("./server");
+    expect(g.posthogServerClient).toBe(posthogServerClient);
+
+    vi.unstubAllEnvs();
+  });
+
+  test("registers signal handlers once when NEXT_RUNTIME is nodejs", async () => {
+    vi.stubEnv("NEXT_RUNTIME", "nodejs");
+
+    setupMocks({ posthogKey: "phc_test_key" });
+    const processOnSpy = vi.spyOn(process, "on");
+
+    await import("./server");
+
+    expect(processOnSpy).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
+    expect(processOnSpy).toHaveBeenCalledWith("SIGINT", expect.any(Function));
+    expect(g.posthogHandlersRegistered).toBe(true);
+
+    processOnSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  test("does not register signal handlers when already registered", async () => {
+    vi.stubEnv("NEXT_RUNTIME", "nodejs");
+    g.posthogHandlersRegistered = true;
+
+    setupMocks({ posthogKey: "phc_test_key" });
+    const processOnSpy = vi.spyOn(process, "on");
+
+    await import("./server");
+
+    const sigCalls = processOnSpy.mock.calls.filter(([event]) => event === "SIGTERM" || event === "SIGINT");
+    expect(sigCalls).toHaveLength(0);
+
+    processOnSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  test("does not register signal handlers when NEXT_RUNTIME is not nodejs", async () => {
+    vi.stubEnv("NEXT_RUNTIME", "");
+
+    setupMocks({ posthogKey: "phc_test_key" });
+    const processOnSpy = vi.spyOn(process, "on");
+
+    await import("./server");
+
+    const sigCalls = processOnSpy.mock.calls.filter(([event]) => event === "SIGTERM" || event === "SIGINT");
+    expect(sigCalls).toHaveLength(0);
+
+    processOnSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  test("shutdown handler calls shutdown()", async () => {
+    vi.stubEnv("NEXT_RUNTIME", "nodejs");
+
+    const { shutdown } = setupMocks({ posthogKey: "phc_test_key" });
+
+    let sigTermHandler: (() => void) | undefined;
+    const processOnSpy = vi.spyOn(process, "on").mockImplementation((event, handler) => {
+      if (event === "SIGTERM") sigTermHandler = handler as () => void;
+      return process;
+    });
+
+    await import("./server");
+
+    expect(sigTermHandler).toBeDefined();
+    sigTermHandler!();
+    expect(shutdown).toHaveBeenCalled();
+
+    processOnSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  test("shutdown handler logs error if shutdown rejects", async () => {
+    vi.stubEnv("NEXT_RUNTIME", "nodejs");
+
+    const shutdownError = new Error("shutdown failed");
+    const { loggerError } = setupMocks({
+      posthogKey: "phc_test_key",
+      shutdown: vi.fn().mockRejectedValue(shutdownError),
+    });
+
+    let sigTermHandler: (() => void) | undefined;
+    const processOnSpy = vi.spyOn(process, "on").mockImplementation((event, handler) => {
+      if (event === "SIGTERM") sigTermHandler = handler as () => void;
+      return process;
+    });
+
+    await import("./server");
+
+    sigTermHandler!();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(loggerError).toHaveBeenCalledWith(shutdownError, "Error shutting down PostHog server client");
+
+    processOnSpy.mockRestore();
+    vi.unstubAllEnvs();
   });
 });

--- a/apps/web/lib/posthog/server.test.ts
+++ b/apps/web/lib/posthog/server.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  PostHog: vi.fn().mockImplementation(() => ({
+    capture: vi.fn(),
+    shutdown: vi.fn(),
+  })),
+  loggerError: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: { error: mocks.loggerError },
+}));
+
+vi.mock("posthog-node", () => ({
+  PostHog: mocks.PostHog,
+}));
+
+describe("server - posthogServerClient", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    // Clean up globalThis between tests
+    const g = globalThis as Record<string, unknown>;
+    delete g.posthogServerClient;
+    delete g.posthogHandlersRegistered;
+  });
+
+  test("returns null when POSTHOG_KEY is not set", async () => {
+    vi.doMock("@/lib/constants", () => ({
+      POSTHOG_KEY: undefined,
+    }));
+
+    const { posthogServerClient } = await import("./server");
+    expect(posthogServerClient).toBeNull();
+    expect(mocks.PostHog).not.toHaveBeenCalled();
+  });
+
+  test("creates PostHog client when POSTHOG_KEY is set", async () => {
+    vi.doMock("@/lib/constants", () => ({
+      POSTHOG_KEY: "phc_test_key",
+    }));
+
+    const { posthogServerClient } = await import("./server");
+    expect(posthogServerClient).not.toBeNull();
+    expect(mocks.PostHog).toHaveBeenCalledWith("phc_test_key", {
+      host: "https://eu.i.posthog.com",
+      flushAt: 1,
+      flushInterval: 0,
+    });
+  });
+
+  test("reuses client from globalThis in development", async () => {
+    const fakeClient = { capture: vi.fn(), shutdown: vi.fn() };
+    (globalThis as Record<string, unknown>).posthogServerClient = fakeClient;
+
+    vi.doMock("@/lib/constants", () => ({
+      POSTHOG_KEY: "phc_test_key",
+    }));
+
+    const { posthogServerClient } = await import("./server");
+    expect(posthogServerClient).toBe(fakeClient);
+    expect(mocks.PostHog).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/posthog/server.ts
+++ b/apps/web/lib/posthog/server.ts
@@ -7,6 +7,7 @@ const POSTHOG_HOST = "https://eu.i.posthog.com";
 
 const globalForPostHog = globalThis as unknown as {
   posthogServerClient: PostHog | undefined;
+  posthogHandlersRegistered: boolean | undefined;
 };
 
 function createPostHogClient(): PostHog | null {
@@ -26,7 +27,11 @@ if (process.env.NODE_ENV !== "production" && posthogServerClient) {
   globalForPostHog.posthogServerClient = posthogServerClient;
 }
 
-if (process.env.NEXT_RUNTIME === "nodejs" && posthogServerClient) {
+if (
+  process.env.NEXT_RUNTIME === "nodejs" &&
+  posthogServerClient &&
+  !globalForPostHog.posthogHandlersRegistered
+) {
   const shutdownPostHog = () => {
     posthogServerClient?.shutdown().catch((err) => {
       logger.error(err, "Error shutting down PostHog server client");
@@ -34,4 +39,5 @@ if (process.env.NEXT_RUNTIME === "nodejs" && posthogServerClient) {
   };
   process.on("SIGTERM", shutdownPostHog);
   process.on("SIGINT", shutdownPostHog);
+  globalForPostHog.posthogHandlersRegistered = true;
 }

--- a/apps/web/lib/posthog/server.ts
+++ b/apps/web/lib/posthog/server.ts
@@ -1,0 +1,37 @@
+import "server-only";
+import { PostHog } from "posthog-node";
+import { logger } from "@formbricks/logger";
+import { POSTHOG_KEY } from "@/lib/constants";
+
+const POSTHOG_HOST = "https://eu.i.posthog.com";
+
+const globalForPostHog = globalThis as unknown as {
+  posthogServerClient: PostHog | undefined;
+};
+
+function createPostHogClient(): PostHog | null {
+  if (!POSTHOG_KEY) return null;
+
+  return new PostHog(POSTHOG_KEY, {
+    host: POSTHOG_HOST,
+    flushAt: 1,
+    flushInterval: 0,
+  });
+}
+
+export const posthogServerClient: PostHog | null =
+  globalForPostHog.posthogServerClient ?? createPostHogClient();
+
+if (process.env.NODE_ENV !== "production" && posthogServerClient) {
+  globalForPostHog.posthogServerClient = posthogServerClient;
+}
+
+if (process.env.NEXT_RUNTIME === "nodejs" && posthogServerClient) {
+  const shutdownPostHog = () => {
+    posthogServerClient?.shutdown().catch((err) => {
+      logger.error(err, "Error shutting down PostHog server client");
+    });
+  };
+  process.on("SIGTERM", shutdownPostHog);
+  process.on("SIGINT", shutdownPostHog);
+}

--- a/apps/web/modules/api/v2/auth/tests/authenticated-api-client.test.ts
+++ b/apps/web/modules/api/v2/auth/tests/authenticated-api-client.test.ts
@@ -11,6 +11,10 @@ vi.mock("@/modules/api/v2/lib/utils", () => ({
   logApiRequest: vi.fn(),
 }));
 
+vi.mock("@/lib/posthog", () => ({
+  capturePostHogEvent: vi.fn(),
+}));
+
 describe("authenticatedApiClient", () => {
   test("should log request and return response", async () => {
     const request = new Request("http://localhost", {

--- a/apps/web/modules/auth/lib/authOptions.test.ts
+++ b/apps/web/modules/auth/lib/authOptions.test.ts
@@ -3,6 +3,7 @@ import { Provider } from "next-auth/providers/index";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { EMAIL_VERIFICATION_DISABLED } from "@/lib/constants";
+import { capturePostHogEvent } from "@/lib/posthog";
 // Import mocked rate limiting functions
 import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
@@ -35,8 +36,19 @@ vi.mock("@/lib/encryption", () => ({
   symmetricDecrypt: vi.fn((value: string) => value.replace("encrypted_", "")),
 }));
 
+vi.mock("@/lib/crypto", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/crypto")>();
+  return {
+    ...actual,
+    symmetricEncrypt: vi.fn((value: string) => `encrypted_${value}`),
+    symmetricDecrypt: vi.fn((value: string) => value.replace("encrypted_", "")),
+  };
+});
+
 // Mock JWT
-vi.mock("@/lib/jwt");
+vi.mock("@/lib/jwt", () => ({
+  verifyToken: vi.fn(),
+}));
 
 // Mock rate limiting dependencies
 vi.mock("@/modules/core/rate-limit/helpers", () => ({
@@ -70,6 +82,7 @@ vi.mock("@/lib/constants", async (importOriginal) => {
     BREVO_API_KEY: undefined,
     RATE_LIMITING_DISABLED: false,
     CONTROL_HASH: "$2b$12$fzHf9le13Ss9UJ04xzmsjODXpFJxz6vsnupoepF5FiqDECkX2BH5q",
+    POSTHOG_KEY: "phc_test_key",
   };
 });
 
@@ -105,7 +118,19 @@ vi.mock("@formbricks/database", () => ({
       findFirst: vi.fn(),
       findUnique: vi.fn(),
     },
+    membership: {
+      count: vi.fn(),
+    },
   },
+}));
+
+vi.mock("@/modules/auth/lib/user", () => ({
+  updateUser: vi.fn(),
+  updateUserLastLoginAt: vi.fn(),
+}));
+
+vi.mock("@/lib/posthog", () => ({
+  capturePostHogEvent: vi.fn(),
 }));
 
 // Helper to get the provider by id from authOptions.providers.
@@ -345,6 +370,66 @@ describe("authOptions", () => {
           await expect(authOptions.callbacks.signIn({ user, account })).rejects.toThrow(
             "Email Verification is Pending"
           );
+        }
+      });
+
+      test("should capture user_signed_in PostHog event on successful credentials sign-in", async () => {
+        const yesterday = new Date();
+        yesterday.setDate(yesterday.getDate() - 1);
+
+        const user = { ...mockUser, emailVerified: new Date() };
+        const account = { provider: "credentials" } as any;
+
+        vi.mocked(prisma.membership.count).mockResolvedValue(2);
+        vi.mocked(prisma.user.findUnique).mockResolvedValue({ lastLoginAt: yesterday } as any);
+
+        if (authOptions.callbacks?.signIn) {
+          const result = await authOptions.callbacks.signIn({ user, account });
+          expect(result).toBe(true);
+
+          // Allow the fire-and-forget captureSignIn to resolve
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          expect(capturePostHogEvent).toHaveBeenCalledWith(user.id, "user_signed_in", {
+            auth_provider: "credentials",
+            organization_count: 2,
+            is_first_login_today: true,
+          });
+        }
+      });
+
+      test("should set is_first_login_today to false when user already logged in today", async () => {
+        const user = { ...mockUser, emailVerified: new Date() };
+        const account = { provider: "credentials" } as any;
+
+        vi.mocked(prisma.membership.count).mockResolvedValue(1);
+        vi.mocked(prisma.user.findUnique).mockResolvedValue({ lastLoginAt: new Date() } as any);
+
+        if (authOptions.callbacks?.signIn) {
+          await authOptions.callbacks.signIn({ user, account });
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          expect(capturePostHogEvent).toHaveBeenCalledWith(
+            user.id,
+            "user_signed_in",
+            expect.objectContaining({ is_first_login_today: false })
+          );
+        }
+      });
+
+      test("should not throw if captureSignIn prisma query fails", async () => {
+        const user = { ...mockUser, emailVerified: new Date() };
+        const account = { provider: "credentials" } as any;
+
+        vi.mocked(prisma.membership.count).mockRejectedValue(new Error("DB error"));
+
+        if (authOptions.callbacks?.signIn) {
+          const result = await authOptions.callbacks.signIn({ user, account });
+          expect(result).toBe(true);
+
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          expect(capturePostHogEvent).not.toHaveBeenCalled();
         }
       });
     });

--- a/apps/web/modules/auth/lib/authOptions.ts
+++ b/apps/web/modules/auth/lib/authOptions.ts
@@ -10,10 +10,12 @@ import {
   EMAIL_VERIFICATION_DISABLED,
   ENCRYPTION_KEY,
   ENTERPRISE_LICENSE_KEY,
+  POSTHOG_KEY,
   SESSION_MAX_AGE,
 } from "@/lib/constants";
 import { symmetricDecrypt, symmetricEncrypt } from "@/lib/crypto";
 import { verifyToken } from "@/lib/jwt";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { updateUser, updateUserLastLoginAt } from "@/modules/auth/lib/user";
 import {
   logAuthAttempt,
@@ -335,6 +337,25 @@ export const authOptions: NextAuthOptions = {
         "";
 
       const userEmail = user.email ?? "";
+      const userId = user.id as string;
+
+      // Capture sign-in event for PostHog (query BEFORE updating lastLoginAt)
+      const captureSignIn = async (provider: string) => {
+        if (!POSTHOG_KEY) return;
+
+        const [membershipCount, userData] = await Promise.all([
+          prisma.membership.count({ where: { userId } }),
+          prisma.user.findUnique({ where: { id: userId }, select: { lastLoginAt: true } }),
+        ]);
+        const isFirstLoginToday =
+          !userData?.lastLoginAt || userData.lastLoginAt.toDateString() !== new Date().toDateString();
+
+        capturePostHogEvent(userId, "user_signed_in", {
+          auth_provider: provider,
+          organization_count: membershipCount,
+          is_first_login_today: isFirstLoginToday,
+        });
+      };
 
       if (account?.provider === "credentials" || account?.provider === "token") {
         // check if user's email is verified or not
@@ -342,6 +363,7 @@ export const authOptions: NextAuthOptions = {
           logger.error("Email Verification is Pending");
           throw new Error("Email Verification is Pending");
         }
+        await captureSignIn(account.provider);
         await updateUserLastLoginAt(userEmail);
         return true;
       }
@@ -353,10 +375,12 @@ export const authOptions: NextAuthOptions = {
         });
 
         if (result) {
+          await captureSignIn(account.provider);
           await updateUserLastLoginAt(userEmail);
         }
         return result;
       }
+      await captureSignIn(account?.provider ?? "unknown");
       await updateUserLastLoginAt(userEmail);
       return true;
     },

--- a/apps/web/modules/auth/lib/authOptions.ts
+++ b/apps/web/modules/auth/lib/authOptions.ts
@@ -343,18 +343,22 @@ export const authOptions: NextAuthOptions = {
       const captureSignIn = async (provider: string) => {
         if (!POSTHOG_KEY) return;
 
-        const [membershipCount, userData] = await Promise.all([
-          prisma.membership.count({ where: { userId } }),
-          prisma.user.findUnique({ where: { id: userId }, select: { lastLoginAt: true } }),
-        ]);
-        const isFirstLoginToday =
-          !userData?.lastLoginAt || userData.lastLoginAt.toDateString() !== new Date().toDateString();
+        try {
+          const [membershipCount, userData] = await Promise.all([
+            prisma.membership.count({ where: { userId } }),
+            prisma.user.findUnique({ where: { id: userId }, select: { lastLoginAt: true } }),
+          ]);
+          const isFirstLoginToday =
+            userData?.lastLoginAt?.toISOString().slice(0, 10) !== new Date().toISOString().slice(0, 10);
 
-        capturePostHogEvent(userId, "user_signed_in", {
-          auth_provider: provider,
-          organization_count: membershipCount,
-          is_first_login_today: isFirstLoginToday,
-        });
+          capturePostHogEvent(userId, "user_signed_in", {
+            auth_provider: provider,
+            organization_count: membershipCount,
+            is_first_login_today: isFirstLoginToday,
+          });
+        } catch (error) {
+          logger.warn({ error }, "Failed to capture PostHog sign-in event");
+        }
       };
 
       if (account?.provider === "credentials" || account?.provider === "token") {
@@ -363,7 +367,7 @@ export const authOptions: NextAuthOptions = {
           logger.error("Email Verification is Pending");
           throw new Error("Email Verification is Pending");
         }
-        await captureSignIn(account.provider);
+        void captureSignIn(account.provider);
         await updateUserLastLoginAt(userEmail);
         return true;
       }
@@ -375,12 +379,12 @@ export const authOptions: NextAuthOptions = {
         });
 
         if (result) {
-          await captureSignIn(account.provider);
+          void captureSignIn(account.provider);
           await updateUserLastLoginAt(userEmail);
         }
         return result;
       }
-      await captureSignIn(account?.provider ?? "unknown");
+      void captureSignIn(account?.provider ?? "unknown");
       await updateUserLastLoginAt(userEmail);
       return true;
     },

--- a/apps/web/modules/auth/signup/actions.ts
+++ b/apps/web/modules/auth/signup/actions.ts
@@ -9,6 +9,7 @@ import { IS_FORMBRICKS_CLOUD, IS_TURNSTILE_CONFIGURED, TURNSTILE_SECRET_KEY } fr
 import { verifyInviteToken } from "@/lib/jwt";
 import { createMembership } from "@/lib/membership/service";
 import { createOrganization } from "@/lib/organization/service";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { actionClient } from "@/lib/utils/action-client";
 import { ActionClientCtx } from "@/lib/utils/action-client/types/context";
 import { createUser, updateUser } from "@/modules/auth/lib/user";
@@ -210,6 +211,13 @@ export const createUserAction = actionClient.inputSchema(ZCreateUserAction).acti
         isFormbricksCloud: parsedInput.isFormbricksCloud,
         subscribeToSecurityUpdates: parsedInput.subscribeToSecurityUpdates,
         subscribeToProductUpdates: parsedInput.subscribeToProductUpdates,
+      });
+
+      capturePostHogEvent(user.id, "user_signed_up", {
+        auth_provider: "credentials",
+        email_domain: user.email.split("@")[1],
+        signup_source: parsedInput.inviteToken ? "invite" : "direct",
+        invite_organization_id: ctx.auditLoggingCtx.organizationId ?? null,
       });
     }
 

--- a/apps/web/modules/ee/billing/actions.test.ts
+++ b/apps/web/modules/ee/billing/actions.test.ts
@@ -26,6 +26,11 @@ vi.mock("@/lib/utils/action-client", () => ({
 
 vi.mock("@/lib/constants", () => ({
   WEBAPP_URL: "https://app.formbricks.com",
+  POSTHOG_KEY: undefined,
+}));
+
+vi.mock("@/lib/posthog", () => ({
+  capturePostHogEvent: vi.fn(),
 }));
 
 vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({

--- a/apps/web/modules/ee/billing/actions.ts
+++ b/apps/web/modules/ee/billing/actions.ts
@@ -219,6 +219,11 @@ export const startHobbyAction = authenticatedActionClient
 
     await reconcileCloudStripeSubscriptionsForOrganization(parsedInput.organizationId);
     await syncOrganizationBillingFromStripe(parsedInput.organizationId);
+
+    capturePostHogEvent(ctx.user.id, "stayed_on_hobby_plan", {
+      organization_id: parsedInput.organizationId,
+    });
+
     return { success: true };
   });
 
@@ -256,6 +261,10 @@ export const startProTrialAction = authenticatedActionClient
       plan: "pro",
       organization_id: parsedInput.organizationId,
       trial_duration_days: 14,
+    });
+
+    capturePostHogEvent(ctx.user.id, "reverse_trial_started", {
+      organization_id: parsedInput.organizationId,
     });
 
     return { success: true };

--- a/apps/web/modules/ee/billing/actions.ts
+++ b/apps/web/modules/ee/billing/actions.ts
@@ -6,6 +6,7 @@ import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/typ
 import { ZCloudBillingInterval } from "@formbricks/types/organizations";
 import { WEBAPP_URL } from "@/lib/constants";
 import { getOrganization } from "@/lib/organization/service";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromEnvironmentId } from "@/lib/utils/helper";
@@ -250,6 +251,13 @@ export const startProTrialAction = authenticatedActionClient
     await createProTrialSubscription(parsedInput.organizationId, customerId);
     await reconcileCloudStripeSubscriptionsForOrganization(parsedInput.organizationId);
     await syncOrganizationBillingFromStripe(parsedInput.organizationId);
+
+    capturePostHogEvent(ctx.user.id, "free_trial_started", {
+      plan: "pro",
+      organization_id: parsedInput.organizationId,
+      trial_duration_days: 14,
+    });
+
     return { success: true };
   });
 

--- a/apps/web/modules/ee/billing/components/select-plan-card.tsx
+++ b/apps/web/modules/ee/billing/components/select-plan-card.tsx
@@ -3,7 +3,6 @@
 import { CheckIcon, GiftIcon } from "lucide-react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import posthog from "posthog-js";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
@@ -50,9 +49,6 @@ export const SelectPlanCard = ({ nextUrl, organizationId }: SelectPlanCardProps)
 
   const handleStartTrial = async () => {
     setIsStartingTrial(true);
-    if (posthog.__loaded) {
-      posthog.capture("reverse_trial_started", { organization_id: organizationId });
-    }
     try {
       const result = await startProTrialAction({ organizationId });
       if (result?.data) {
@@ -72,9 +68,6 @@ export const SelectPlanCard = ({ nextUrl, organizationId }: SelectPlanCardProps)
 
   const handleContinueHobby = async () => {
     setIsStartingHobby(true);
-    if (posthog.__loaded) {
-      posthog.capture("stayed_on_hobby_plan", { organization_id: organizationId });
-    }
     try {
       const result = await startHobbyAction({ organizationId });
       if (result?.data) {

--- a/apps/web/modules/ee/billing/components/select-plan-card.tsx
+++ b/apps/web/modules/ee/billing/components/select-plan-card.tsx
@@ -3,6 +3,7 @@
 import { CheckIcon, GiftIcon } from "lucide-react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import posthog from "posthog-js";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
@@ -49,6 +50,9 @@ export const SelectPlanCard = ({ nextUrl, organizationId }: SelectPlanCardProps)
 
   const handleStartTrial = async () => {
     setIsStartingTrial(true);
+    if (posthog.__loaded) {
+      posthog.capture("reverse_trial_started", { organization_id: organizationId });
+    }
     try {
       const result = await startProTrialAction({ organizationId });
       if (result?.data) {
@@ -68,6 +72,9 @@ export const SelectPlanCard = ({ nextUrl, organizationId }: SelectPlanCardProps)
 
   const handleContinueHobby = async () => {
     setIsStartingHobby(true);
+    if (posthog.__loaded) {
+      posthog.capture("stayed_on_hobby_plan", { organization_id: organizationId });
+    }
     try {
       const result = await startHobbyAction({ organizationId });
       if (result?.data) {

--- a/apps/web/modules/ee/contacts/components/contacts-page-layout.tsx
+++ b/apps/web/modules/ee/contacts/components/contacts-page-layout.tsx
@@ -16,6 +16,7 @@ interface ContactsPageLayoutProps {
   children: ReactNode;
   upgradePromptTitle?: string;
   upgradePromptDescription?: string;
+  upgradeFeature?: string;
 }
 
 export const ContactsPageLayout = async ({
@@ -28,6 +29,7 @@ export const ContactsPageLayout = async ({
   children,
   upgradePromptTitle,
   upgradePromptDescription,
+  upgradeFeature = "contacts",
 }: ContactsPageLayoutProps) => {
   const t = await getTranslate();
 
@@ -44,6 +46,7 @@ export const ContactsPageLayout = async ({
           <UpgradePrompt
             title={upgradePromptTitle ?? t("environments.contacts.unlock_contacts_title")}
             description={upgradePromptDescription ?? t("environments.contacts.unlock_contacts_description")}
+            feature={upgradeFeature}
             buttons={[
               {
                 text: IS_FORMBRICKS_CLOUD ? t("common.upgrade_plan") : t("common.request_trial_license"),

--- a/apps/web/modules/ee/contacts/segments/page.tsx
+++ b/apps/web/modules/ee/contacts/segments/page.tsx
@@ -45,7 +45,8 @@ export const SegmentsPage = async ({
         />
       }
       upgradePromptTitle={t("environments.segments.unlock_segments_title")}
-      upgradePromptDescription={t("environments.segments.unlock_segments_description")}>
+      upgradePromptDescription={t("environments.segments.unlock_segments_description")}
+      upgradeFeature="segments">
       <SegmentTable
         allSegments={segments}
         segments={filteredSegments}

--- a/apps/web/modules/ee/quotas/components/quotas-card.tsx
+++ b/apps/web/modules/ee/quotas/components/quotas-card.tsx
@@ -171,6 +171,7 @@ export const QuotasCard = ({
               <UpgradePrompt
                 title={t("environments.surveys.edit.quotas.upgrade_prompt_title")}
                 description={t("common.quotas_description")}
+                feature="quotas"
                 buttons={[
                   {
                     text: isFormbricksCloud ? t("common.upgrade_plan") : t("common.request_trial_license"),

--- a/apps/web/modules/ee/sso/lib/sso-handlers.ts
+++ b/apps/web/modules/ee/sso/lib/sso-handlers.ts
@@ -8,6 +8,7 @@ import { DEFAULT_TEAM_ID, SKIP_INVITE_FOR_SSO } from "@/lib/constants";
 import { getIsFreshInstance } from "@/lib/instance/service";
 import { verifyInviteToken } from "@/lib/jwt";
 import { createMembership } from "@/lib/membership/service";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { findMatchingLocale } from "@/lib/utils/locale";
 import { redactPII } from "@/lib/utils/logger-helpers";
 import { createBrevoCustomer } from "@/modules/auth/lib/brevo";
@@ -360,6 +361,14 @@ export const handleSsoCallback = async ({
 
     // send new user to brevo
     createBrevoCustomer({ id: userProfile.id, email: userProfile.email });
+
+    capturePostHogEvent(userProfile.id, "user_signed_up", {
+      auth_provider: provider,
+      email_domain: userProfile.email.split("@")[1],
+      signup_source: callbackUrl?.includes("token=") ? "invite" : "direct",
+      invite_organization_id: organization?.id ?? null,
+    });
+
     await syncSsoAccount(userProfile.id, account);
 
     if (isMultiOrgEnabled) {

--- a/apps/web/modules/ee/sso/lib/tests/sso-handlers.test.ts
+++ b/apps/web/modules/ee/sso/lib/tests/sso-handlers.test.ts
@@ -1,9 +1,11 @@
+import { Organization } from "@prisma/client";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import type { TUser } from "@formbricks/types/user";
 import { upsertAccount } from "@/lib/account/service";
 import { createMembership } from "@/lib/membership/service";
 import { createOrganization, getOrganization } from "@/lib/organization/service";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { findMatchingLocale } from "@/lib/utils/locale";
 import { createBrevoCustomer } from "@/modules/auth/lib/brevo";
 import { createUser, getUserByEmail, updateUser } from "@/modules/auth/lib/user";
@@ -335,6 +337,47 @@ describe("handleSsoCallback", () => {
       expect(createBrevoCustomer).toHaveBeenCalledWith({ id: mockUser.id, email: mockUser.email });
     });
 
+    test("should capture user_signed_up PostHog event for new SSO user", async () => {
+      vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
+      vi.mocked(getUserByEmail).mockResolvedValue(null);
+      vi.mocked(createUser).mockResolvedValue(mockCreatedUser());
+
+      await handleSsoCallback({
+        user: mockUser,
+        account: mockAccount,
+        callbackUrl: "http://localhost:3000",
+      });
+
+      expect(capturePostHogEvent).toHaveBeenCalledWith(mockUser.id, "user_signed_up", {
+        auth_provider: mockAccount.provider,
+        email_domain: "example.com",
+        signup_source: "direct",
+        invite_organization_id: null,
+      });
+    });
+
+    test("should capture user_signed_up with invite signup_source when callbackUrl has token", async () => {
+      vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
+      vi.mocked(getUserByEmail).mockResolvedValue(null);
+      vi.mocked(createUser).mockResolvedValue(mockCreatedUser());
+      vi.mocked(getOrganizationByTeamId).mockResolvedValue(mockOrganization as unknown as Organization);
+      vi.mocked(getAccessControlPermission).mockResolvedValue(true);
+
+      await handleSsoCallback({
+        user: mockUser,
+        account: mockAccount,
+        callbackUrl: "http://localhost:3000?token=invite-token",
+      });
+
+      expect(capturePostHogEvent).toHaveBeenCalledWith(
+        mockUser.id,
+        "user_signed_up",
+        expect.objectContaining({
+          signup_source: "invite",
+        })
+      );
+    });
+
     test("should return true when organization doesn't exist with DEFAULT_TEAM_ID", async () => {
       vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
       vi.mocked(getUserByEmail).mockResolvedValue(null);
@@ -355,7 +398,7 @@ describe("handleSsoCallback", () => {
       vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
       vi.mocked(getUserByEmail).mockResolvedValue(null);
       vi.mocked(createUser).mockResolvedValue(mockCreatedUser());
-      vi.mocked(getOrganizationByTeamId).mockResolvedValue(mockOrganization);
+      vi.mocked(getOrganizationByTeamId).mockResolvedValue(mockOrganization as unknown as Organization);
       vi.mocked(getAccessControlPermission).mockResolvedValue(false);
 
       const result = await handleSsoCallback({

--- a/apps/web/modules/ee/sso/lib/tests/sso-handlers.test.ts
+++ b/apps/web/modules/ee/sso/lib/tests/sso-handlers.test.ts
@@ -102,6 +102,11 @@ vi.mock("@/lib/constants", () => ({
   DEFAULT_TEAM_ID: "team-123",
   DEFAULT_ORGANIZATION_ID: "org-123",
   ENCRYPTION_KEY: "test-encryption-key-32-chars-long",
+  POSTHOG_KEY: undefined,
+}));
+
+vi.mock("@/lib/posthog", () => ({
+  capturePostHogEvent: vi.fn(),
 }));
 
 describe("handleSsoCallback", () => {

--- a/apps/web/modules/ee/teams/team-list/components/teams-view.tsx
+++ b/apps/web/modules/ee/teams/team-list/components/teams-view.tsx
@@ -67,6 +67,7 @@ export const TeamsView = async ({
           title={t("environments.settings.teams.unlock_teams_title")}
           description={t("environments.settings.teams.unlock_teams_description")}
           buttons={buttons}
+          feature="teams"
         />
       )}
     </SettingsCard>

--- a/apps/web/modules/ee/whitelabel/email-customization/components/email-customization-settings.tsx
+++ b/apps/web/modules/ee/whitelabel/email-customization/components/email-customization-settings.tsx
@@ -300,6 +300,7 @@ export const EmailCustomizationSettings = ({
             title={t("environments.settings.general.customize_email_with_a_higher_plan")}
             description={t("environments.settings.general.eliminate_branding_with_whitelabel")}
             buttons={buttons}
+            feature="email_customization"
           />
         )}
 

--- a/apps/web/modules/ee/whitelabel/favicon-customization/components/favicon-customization-settings.tsx
+++ b/apps/web/modules/ee/whitelabel/favicon-customization/components/favicon-customization-settings.tsx
@@ -241,6 +241,7 @@ export const FaviconCustomizationSettings = ({
           title={t("environments.settings.domain.customize_favicon_with_higher_plan")}
           description={t("environments.settings.domain.customize_favicon_description")}
           buttons={buttons}
+          feature="favicon_customization"
         />
       )}
     </SettingsCard>

--- a/apps/web/modules/ee/whitelabel/remove-branding/components/branding-settings-card.tsx
+++ b/apps/web/modules/ee/whitelabel/remove-branding/components/branding-settings-card.tsx
@@ -60,6 +60,7 @@ export const BrandingSettingsCard = async ({
           title={t("environments.workspace.look.remove_branding_with_a_higher_plan")}
           description={t("environments.settings.general.eliminate_branding_with_whitelabel")}
           buttons={buttons}
+          feature="remove_branding"
         />
       )}
       {isReadOnly && (

--- a/apps/web/modules/organization/settings/teams/actions.ts
+++ b/apps/web/modules/organization/settings/teams/actions.ts
@@ -10,6 +10,7 @@ import { INVITE_DISABLED, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { createInviteToken } from "@/lib/jwt";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getAccessFlags } from "@/lib/membership/utils";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromInviteId } from "@/lib/utils/helper";
@@ -326,6 +327,11 @@ export const inviteUserAction = authenticatedActionClient.inputSchema(ZInviteUse
     if (inviteId) {
       await sendInviteMemberEmail(inviteId, parsedInput.email, ctx.user.name ?? "", parsedInput.name ?? "");
     }
+
+    capturePostHogEvent(ctx.user.id, "team_member_invited", {
+      organization_id: parsedInput.organizationId,
+      invitee_role: parsedInput.role,
+    });
 
     return inviteId;
   })

--- a/apps/web/modules/projects/components/project-limit-modal/index.tsx
+++ b/apps/web/modules/projects/components/project-limit-modal/index.tsx
@@ -21,6 +21,7 @@ export const ProjectLimitModal = ({ open, setOpen, projectLimit, buttons }: Proj
           title={t("common.unlock_more_workspaces_with_a_higher_plan")}
           description={t("common.you_have_reached_your_limit_of_workspace_limit", { projectLimit })}
           buttons={buttons}
+          feature="workspaces"
         />
       </DialogContent>
     </Dialog>

--- a/apps/web/modules/survey/components/template-list/actions.ts
+++ b/apps/web/modules/survey/components/template-list/actions.ts
@@ -3,6 +3,7 @@
 import { z } from "zod";
 import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { ZSurveyCreateInput } from "@formbricks/types/surveys/types";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromEnvironmentId, getProjectIdFromEnvironmentId } from "@/lib/utils/helper";
@@ -15,6 +16,7 @@ import { getOrganizationBilling } from "@/modules/survey/lib/survey";
 const ZCreateSurveyAction = z.object({
   environmentId: z.cuid2(),
   surveyBody: ZSurveyCreateInput,
+  createdFrom: z.enum(["blank", "template"]).optional(),
 });
 
 /**
@@ -68,6 +70,15 @@ export const createSurveyAction = authenticatedActionClient.inputSchema(ZCreateS
     ctx.auditLoggingCtx.organizationId = organizationId;
     ctx.auditLoggingCtx.surveyId = result.id;
     ctx.auditLoggingCtx.newObject = result;
+
+    capturePostHogEvent(ctx.user.id, "survey_created", {
+      survey_id: result.id,
+      survey_type: result.type,
+      organization_id: organizationId,
+      question_count: result.questions?.length ?? 0,
+      created_from: parsedInput.createdFrom ?? "template",
+    });
+
     return result;
   })
 );

--- a/apps/web/modules/survey/components/template-list/index.tsx
+++ b/apps/web/modules/survey/components/template-list/index.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from "react-i18next";
 import { ZProjectConfigChannel, ZProjectConfigIndustry } from "@formbricks/types/project";
 import { TSurveyCreateInput, TSurveyType } from "@formbricks/types/surveys/types";
 import { TTemplate, TTemplateFilter, ZTemplateRole } from "@formbricks/types/templates";
-import { templates } from "@/app/lib/templates";
+import { customSurveyTemplate, templates } from "@/app/lib/templates";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { createSurveyAction } from "./actions";
 import { StartFromScratchTemplate } from "./components/start-from-scratch-template";
@@ -58,9 +58,11 @@ export const TemplateList = ({
       type: surveyType,
       createdBy: userId,
     };
+    const isBlank = activeTemplate.name === customSurveyTemplate(t).name;
     const createSurveyResponse = await createSurveyAction({
       environmentId: environmentId,
       surveyBody: augmentedTemplate,
+      createdFrom: isBlank ? "blank" : "template",
     });
 
     if (createSurveyResponse?.data) {

--- a/apps/web/modules/survey/editor/actions.ts
+++ b/apps/web/modules/survey/editor/actions.ts
@@ -22,6 +22,7 @@ import { checkExternalUrlsPermission } from "@/modules/survey/editor/lib/check-e
 import { updateSurvey, updateSurveyDraft } from "@/modules/survey/editor/lib/survey";
 import { ZSurveyDraft } from "@/modules/survey/editor/types/survey";
 import { getSurveyFollowUpsPermission } from "@/modules/survey/follow-ups/lib/utils";
+import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 import { checkSpamProtectionPermission } from "@/modules/survey/lib/permission";
 import { getOrganizationBilling, getSurvey } from "@/modules/survey/lib/survey";
 import { getProject } from "./lib/project";
@@ -150,7 +151,7 @@ export const updateSurveyAction = authenticatedActionClient.inputSchema(ZSurvey)
       capturePostHogEvent(ctx.user.id, "survey_published", {
         survey_id: result.id,
         survey_type: result.type,
-        question_count: result.questions?.length ?? 0,
+        question_count: getElementsFromBlocks(result.blocks).length,
         organization_id: organizationId,
         has_targeting: result.segment ? !result.segment.isPrivate : false,
         language_count: result.languages?.length ?? 0,

--- a/apps/web/modules/survey/editor/actions.ts
+++ b/apps/web/modules/survey/editor/actions.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { ZActionClassInput } from "@formbricks/types/action-classes";
 import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TSurvey, ZSurvey } from "@formbricks/types/surveys/types";
-import { UNSPLASH_ACCESS_KEY, UNSPLASH_ALLOWED_DOMAINS } from "@/lib/constants";
+import { POSTHOG_KEY, UNSPLASH_ACCESS_KEY, UNSPLASH_ALLOWED_DOMAINS } from "@/lib/constants";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { actionClient, authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
@@ -147,7 +147,7 @@ export const updateSurveyAction = authenticatedActionClient.inputSchema(ZSurvey)
     ctx.auditLoggingCtx.oldObject = oldObject;
     ctx.auditLoggingCtx.newObject = result;
 
-    if (result.status !== "draft") {
+    if (POSTHOG_KEY && result.status !== "draft") {
       const isPublish = oldObject?.status === "draft" && result.status === "inProgress";
 
       const posthogEventMetadata = {

--- a/apps/web/modules/survey/editor/actions.ts
+++ b/apps/web/modules/survey/editor/actions.ts
@@ -147,8 +147,8 @@ export const updateSurveyAction = authenticatedActionClient.inputSchema(ZSurvey)
     ctx.auditLoggingCtx.oldObject = oldObject;
     ctx.auditLoggingCtx.newObject = result;
 
-    if (oldObject?.status !== "inProgress" && result.status === "inProgress") {
-      capturePostHogEvent(ctx.user.id, "survey_published", {
+    if (result.status !== "draft") {
+      capturePostHogEvent(ctx.user.id, "survey_updated", {
         survey_id: result.id,
         survey_type: result.type,
         question_count: getElementsFromBlocks(result.blocks).length,

--- a/apps/web/modules/survey/editor/actions.ts
+++ b/apps/web/modules/survey/editor/actions.ts
@@ -148,7 +148,8 @@ export const updateSurveyAction = authenticatedActionClient.inputSchema(ZSurvey)
     ctx.auditLoggingCtx.newObject = result;
 
     if (result.status !== "draft") {
-      capturePostHogEvent(ctx.user.id, "survey_updated", {
+      const isPublish = oldObject?.status === "draft" && result.status === "inProgress";
+      capturePostHogEvent(ctx.user.id, isPublish ? "survey_published" : "survey_updated", {
         survey_id: result.id,
         survey_type: result.type,
         question_count: getElementsFromBlocks(result.blocks).length,
@@ -273,8 +274,6 @@ export const triggerDownloadUnsplashImageAction = actionClient
       const errorData = await response.json();
       throw new Error(errorData.error || "Failed to download image from Unsplash");
     }
-
-    return;
   });
 
 const ZCreateActionClassAction = z.object({

--- a/apps/web/modules/survey/editor/actions.ts
+++ b/apps/web/modules/survey/editor/actions.ts
@@ -6,6 +6,7 @@ import { ZActionClassInput } from "@formbricks/types/action-classes";
 import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TSurvey, ZSurvey } from "@formbricks/types/surveys/types";
 import { UNSPLASH_ACCESS_KEY, UNSPLASH_ALLOWED_DOMAINS } from "@/lib/constants";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { actionClient, authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import {
@@ -144,6 +145,17 @@ export const updateSurveyAction = authenticatedActionClient.inputSchema(ZSurvey)
     const result = await updateSurvey(parsedInput);
     ctx.auditLoggingCtx.oldObject = oldObject;
     ctx.auditLoggingCtx.newObject = result;
+
+    if (oldObject?.status !== "inProgress" && result.status === "inProgress") {
+      capturePostHogEvent(ctx.user.id, "survey_published", {
+        survey_id: result.id,
+        survey_type: result.type,
+        question_count: result.questions?.length ?? 0,
+        organization_id: organizationId,
+        has_targeting: result.segment ? !result.segment.isPrivate : false,
+        language_count: result.languages?.length ?? 0,
+      });
+    }
 
     revalidatePath(`/environments/${result.environmentId}/surveys/${result.id}`);
 

--- a/apps/web/modules/survey/editor/actions.ts
+++ b/apps/web/modules/survey/editor/actions.ts
@@ -149,14 +149,22 @@ export const updateSurveyAction = authenticatedActionClient.inputSchema(ZSurvey)
 
     if (result.status !== "draft") {
       const isPublish = oldObject?.status === "draft" && result.status === "inProgress";
-      capturePostHogEvent(ctx.user.id, isPublish ? "survey_published" : "survey_updated", {
+
+      const posthogEventMetadata = {
         survey_id: result.id,
         survey_type: result.type,
         question_count: getElementsFromBlocks(result.blocks).length,
         organization_id: organizationId,
         has_targeting: result.segment ? !result.segment.isPrivate : false,
         language_count: result.languages?.length ?? 0,
-      });
+      };
+
+      if (isPublish) {
+        capturePostHogEvent(ctx.user.id, "survey_published", posthogEventMetadata);
+        capturePostHogEvent(ctx.user.id, "survey_updated", posthogEventMetadata);
+      } else {
+        capturePostHogEvent(ctx.user.id, "survey_updated", posthogEventMetadata);
+      }
     }
 
     revalidatePath(`/environments/${result.environmentId}/surveys/${result.id}`);

--- a/apps/web/modules/survey/editor/components/targeting-locked-card.tsx
+++ b/apps/web/modules/survey/editor/components/targeting-locked-card.tsx
@@ -41,6 +41,7 @@ export const TargetingLockedCard = ({ isFormbricksCloud, environmentId }: Target
           <UpgradePrompt
             title={t("environments.surveys.edit.unlock_targeting_title")}
             description={t("environments.surveys.edit.unlock_targeting_description")}
+            feature="targeting"
             buttons={[
               {
                 text: isFormbricksCloud ? t("common.upgrade_plan") : t("common.request_trial_license"),

--- a/apps/web/modules/survey/follow-ups/components/follow-ups-view.tsx
+++ b/apps/web/modules/survey/follow-ups/components/follow-ups-view.tsx
@@ -46,6 +46,7 @@ export const FollowUpsView = ({
         <UpgradePrompt
           title={t("environments.surveys.edit.follow_ups_empty_heading")}
           description={t("environments.surveys.edit.follow_ups_empty_description")}
+          feature="follow_ups"
           buttons={[
             {
               text: isFormbricksCloud

--- a/apps/web/modules/ui/components/upgrade-prompt/index.tsx
+++ b/apps/web/modules/ui/components/upgrade-prompt/index.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { KeyIcon } from "lucide-react";
 import Link from "next/link";
 import posthog from "posthog-js";

--- a/apps/web/modules/ui/components/upgrade-prompt/index.tsx
+++ b/apps/web/modules/ui/components/upgrade-prompt/index.tsx
@@ -1,5 +1,6 @@
 import { KeyIcon } from "lucide-react";
 import Link from "next/link";
+import posthog from "posthog-js";
 import { Button } from "@/modules/ui/components/button";
 
 export type ModalButton = {
@@ -12,10 +13,18 @@ interface UpgradePromptProps {
   title: string;
   description?: string;
   buttons: [ModalButton, ModalButton];
+  feature?: string;
 }
 
-export const UpgradePrompt = ({ title, description, buttons }: UpgradePromptProps) => {
+export const UpgradePrompt = ({ title, description, buttons, feature }: UpgradePromptProps) => {
   const [primaryButton, secondaryButton] = buttons;
+
+  const handlePrimaryClick = () => {
+    if (posthog.__loaded && feature) {
+      posthog.capture("upgrade_cta_clicked", { feature });
+    }
+    primaryButton.onClick?.();
+  };
 
   return (
     <div className="flex w-full flex-col items-center gap-6 p-6">
@@ -29,12 +38,16 @@ export const UpgradePrompt = ({ title, description, buttons }: UpgradePromptProp
       <div className="flex gap-3">
         {primaryButton.href ? (
           <Button asChild>
-            <Link href={primaryButton.href} target="_blank" rel="noopener noreferrer">
+            <Link
+              href={primaryButton.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={handlePrimaryClick}>
               {primaryButton.text}
             </Link>
           </Button>
         ) : (
-          <Button onClick={primaryButton.onClick}>{primaryButton.text}</Button>
+          <Button onClick={handlePrimaryClick}>{primaryButton.text}</Button>
         )}
         {secondaryButton.href ? (
           <Button variant="secondary" asChild>

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -33,6 +33,7 @@ const nextConfig = {
     "pino",
     "pino-pretty",
     "pino-opentelemetry-transport",
+    "posthog-node",
   ],
   outputFileTracingIncludes: {
     "/api/auth/**/*": ["../../node_modules/jose/**/*"],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -104,6 +104,7 @@
     "otplib": "12.0.1",
     "papaparse": "5.5.3",
     "posthog-js": "1.360.0",
+    "posthog-node": "5.28.9",
     "prismjs": "1.30.0",
     "qr-code-styling": "1.9.2",
     "qrcode": "1.5.4",

--- a/packages/cache/src/cache-keys.ts
+++ b/packages/cache/src/cache-keys.ts
@@ -35,6 +35,11 @@ export const createCacheKey = {
     fetch_lock: (organizationId: string): CacheKey => makeCacheKey("license", organizationId, "fetch_lock"),
   },
 
+  // Response-related keys
+  response: {
+    countBySurveyId: (surveyId: string): CacheKey => makeCacheKey("response", surveyId, "count"),
+  },
+
   // Rate limiting and security
   rateLimit: {
     core: (namespace: string, identifier: string, windowStart: number): CacheKey =>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -369,6 +369,9 @@ importers:
       posthog-js:
         specifier: 1.360.0
         version: 1.360.0
+      posthog-node:
+        specifier: 5.28.9
+        version: 5.28.9(rxjs@7.8.2)
       prismjs:
         specifier: 1.30.0
         version: 1.30.0
@@ -3311,6 +3314,9 @@ packages:
 
   '@posthog/core@1.23.2':
     resolution: {integrity: sha512-zTDdda9NuSHrnwSOfFMxX/pyXiycF4jtU1kTr8DL61dHhV+7LF6XF1ndRZZTuaGGbfbb/GJYkEsjEX9SXfNZeQ==}
+
+  '@posthog/core@1.24.4':
+    resolution: {integrity: sha512-S+TolwBHSSJz7WWtgaELQWQqXviSm3uf1e+qorWUts0bZcgPwWzhnmhCUZAhvn0NVpTQHDJ3epv+hHbPLl5dHg==}
 
   '@posthog/types@1.360.0':
     resolution: {integrity: sha512-roypbiJ49V3jWlV/lzhXGf0cKLLRj69L4H4ZHW6YsITHlnjQ12cgdPhPS88Bb9nW9xZTVSGWWDjfNGsdgAxsNg==}
@@ -9115,6 +9121,15 @@ packages:
   posthog-js@1.360.0:
     resolution: {integrity: sha512-jkyO+T97yi6RuiexOaXC7AnEGiC+yIfGU5DIUzI5rqBH6MltmtJw/ve2Oxc4jeua2WDr5sXMzo+SS+acbpueAA==}
 
+  posthog-node@5.28.9:
+    resolution: {integrity: sha512-iZWyAYkIAq5QqcYz4q2nXOX+Ivn04Yh8AuKqfFVw0SvBpfli49bNAjyE97qbRTLr+irrzRUELgGIkDC14NgugA==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
     engines: {node: '>=20'}
@@ -14471,6 +14486,10 @@ snapshots:
       playwright: 1.58.2
 
   '@posthog/core@1.23.2':
+    dependencies:
+      cross-spawn: 7.0.6
+
+  '@posthog/core@1.24.4':
     dependencies:
       cross-spawn: 7.0.6
 
@@ -21002,6 +21021,12 @@ snapshots:
       preact: 10.28.2
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.1.0
+
+  posthog-node@5.28.9(rxjs@7.8.2):
+    dependencies:
+      '@posthog/core': 1.24.4
+    optionalDependencies:
+      rxjs: 7.8.2
 
   powershell-utils@0.1.0: {}
 


### PR DESCRIPTION
## What does this PR do?

Adds 10 custom server-side PostHog events to replace fragile autocapture-based tracking. Previously, Formbricks relied entirely on PostHog autocapture with text matching and URL regex — any button label change or URL restructure silently broke analytics. Signup and signin were not tracked at all.

### Changes

**Foundation:**
- Installed `posthog-node` server-side SDK
- Created a PostHog server singleton (`apps/web/lib/posthog/server.ts`) using the `globalThis` pattern (matching Prisma client), with serverless-safe flushing (`flushAt: 1`)
- Created a fire-and-forget `capturePostHogEvent()` helper that never throws and no-ops when `POSTHOG_KEY` is unset (safe for self-hosted)
- Added `posthog-node` to `serverExternalPackages` in `next.config.mjs`

**New events (not previously tracked):**
- `user_signed_up` — fires on credential signup and SSO signup, with `auth_provider`, `email_domain`, `signup_source` (direct/invite)
- `user_signed_in` — fires in NextAuth `signIn` callback with `auth_provider`, `organization_count`, `is_first_login_today` (enrichment queries gated on `POSTHOG_KEY`)

**Migrated from autocapture:**
- `survey_published` — fires on status transition to `inProgress` (not on button click)
- `survey_created` — fires in `createSurveyAction` with new `createdFrom` field (`"blank"` vs `"template"`)
- `organization_created` — fires after org + membership creation, uses pre-computed `hasNoOrganizations` for `is_first_org`
- `free_trial_started` — fires in `startProTrialAction` after Stripe confirmation
- `integration_connected` — fires with `integration_type` and `organization_id`
- `team_member_invited` — fires after invite email sent, with `invitee_role`
- `responses_exported` — fires with `format`, `filter_applied`, `organization_id`
- `survey_response_received` — sampled (1st response + every 100th), uses Redis-cached response count (60s TTL) via `cache.withCache()` to avoid DB hits on every response

## How should this be tested?

- Set `POSTHOG_KEY` env var and verify events appear in PostHog Live Events:
  - Sign up with email/password → `user_signed_up` with `auth_provider: "credentials"`
  - Sign in → `user_signed_in` with `organization_count` and `is_first_login_today`
  - Create a survey from scratch → `survey_created` with `created_from: "blank"`
  - Create a survey from a template → `survey_created` with `created_from: "template"`
  - Publish a survey → `survey_published` with `survey_type`, `question_count`
  - Create an organization → `organization_created`
  - Start a free trial (Formbricks Cloud) → `free_trial_started`
  - Connect an integration → `integration_connected` with `integration_type`
  - Invite a team member → `team_member_invited` with `invitee_role`
  - Export responses → `responses_exported` with `format`
  - Submit survey responses → `survey_response_received` fires on 1st and every 100th
- Unset `POSTHOG_KEY` and verify all flows work normally with no errors (graceful no-op)
- Verify no `console.log` statements, no client-side bundle pollution (`server-only` import)

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
