### PR TITLE
fix: add TERMS_URL to survey link footer components

### DIFF
--- a/apps/web/modules/survey/link/components/legal-footer.tsx
+++ b/apps/web/modules/survey/link/components/legal-footer.tsx
@@ -23,18 +23,26 @@ export const LegalFooter = ({
   return (
     <div className="absolute bottom-0 z-[1500] h-10 w-full" role="contentinfo">
       <div className="mx-auto flex h-full max-w-2xl items-center justify-center p-2 text-center text-xs text-slate-500">
-        {IMPRINT_URL && (
-          <Link href={IMPRINT_URL} target="_blank" className="hover:underline" tabIndex={-1}>
-            {t("common.imprint")}
-          </Link>
-        )}
-        {IMPRINT_URL && PRIVACY_URL && <span className="px-2">|</span>}
         {PRIVACY_URL && (
           <Link href={PRIVACY_URL} target="_blank" className="hover:underline" tabIndex={-1}>
             {t("common.privacy")}
           </Link>
         )}
-        {PRIVACY_URL && IS_FORMBRICKS_CLOUD && <span className="px-2">|</span>}
+        {PRIVACY_URL && TERMS_URL && <span className="px-2">|</span>}
+        {TERMS_URL && (
+          <Link href={TERMS_URL} target="_blank" className="hover:underline" tabIndex={-1}>
+            {t("common.terms")}
+          </Link>
+        )}
+        {(PRIVACY_URL || TERMS_URL) && IMPRINT_URL && <span className="px-2">|</span>}
+        {IMPRINT_URL && (
+          <Link href={IMPRINT_URL} target="_blank" className="hover:underline" tabIndex={-1}>
+            {t("common.imprint")}
+          </Link>
+        )}
+        {(PRIVACY_URL || TERMS_URL || IMPRINT_URL) && IS_FORMBRICKS_CLOUD && (
+          <span className="px-2">|</span>
+        )}
         {IS_FORMBRICKS_CLOUD && (
           <Link
             href={`https://app.formbricks.com/s/clxbivtla014iye2vfrn436xd?surveyUrl=${surveyUrl}`}
@@ -44,13 +52,6 @@ export const LegalFooter = ({
             {t("common.report_survey")}
           </Link>
         )}
-        {PRIVACY_URL && TERMS_URL && <span className="px-2">|</span>}
-        {TERMS_URL && (
-          <Link href={TERMS_URL} target="_blank" className="hover:underline" tabIndex={-1}>
-            {t("common.terms")}
-          </Link>
-        )}
-        {TERMS_URL && IS_FORMBRICKS_CLOUD && <span className="px-2">|</span>}
       </div>
     </div>
   );

--- a/apps/web/modules/survey/link/components/legal-footer.tsx
+++ b/apps/web/modules/survey/link/components/legal-footer.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 interface LegalFooterProps {
   IMPRINT_URL?: string;
   PRIVACY_URL?: string;
+  TERMS_URL?: string;
   IS_FORMBRICKS_CLOUD: boolean;
   surveyUrl: string;
 }
@@ -13,12 +14,12 @@ interface LegalFooterProps {
 export const LegalFooter = ({
   IMPRINT_URL,
   PRIVACY_URL,
+  TERMS_URL,
   IS_FORMBRICKS_CLOUD,
   surveyUrl,
 }: LegalFooterProps) => {
   const { t } = useTranslation();
-  if (!IMPRINT_URL && !PRIVACY_URL && !IS_FORMBRICKS_CLOUD) return null;
-
+  if (!IMPRINT_URL && !PRIVACY_URL && !TERMS_URL && !IS_FORMBRICKS_CLOUD) return null;
   return (
     <div className="absolute bottom-0 z-[1500] h-10 w-full" role="contentinfo">
       <div className="mx-auto flex h-full max-w-2xl items-center justify-center p-2 text-center text-xs text-slate-500">
@@ -43,6 +44,13 @@ export const LegalFooter = ({
             {t("common.report_survey")}
           </Link>
         )}
+        {PRIVACY_URL && TERMS_URL && <span className="px-2">|</span>}
+        {TERMS_URL && (
+          <Link href={TERMS_URL} target="_blank" className="hover:underline" tabIndex={-1}>
+            {t("common.terms")}
+          </Link>
+        )}
+        {TERMS_URL && IS_FORMBRICKS_CLOUD && <span className="px-2">|</span>}
       </div>
     </div>
   );

--- a/apps/web/modules/survey/link/components/link-survey-wrapper.tsx
+++ b/apps/web/modules/survey/link/components/link-survey-wrapper.tsx
@@ -22,6 +22,7 @@ interface LinkSurveyWrapperProps {
   handleResetSurvey: () => void;
   IMPRINT_URL?: string;
   PRIVACY_URL?: string;
+  TERMS_URL?: string;
   IS_FORMBRICKS_CLOUD: boolean;
   publicDomain: string;
   isBrandingEnabled: boolean;
@@ -40,6 +41,7 @@ export const LinkSurveyWrapper = ({
   handleResetSurvey,
   IMPRINT_URL,
   PRIVACY_URL,
+  TERMS_URL,
   IS_FORMBRICKS_CLOUD,
   publicDomain,
   isBrandingEnabled,
@@ -101,6 +103,7 @@ export const LinkSurveyWrapper = ({
         <LegalFooter
           IMPRINT_URL={IMPRINT_URL}
           PRIVACY_URL={PRIVACY_URL}
+          TERMS_URL={TERMS_URL}
           IS_FORMBRICKS_CLOUD={IS_FORMBRICKS_CLOUD}
           surveyUrl={publicDomain + "/s/" + surveyId}
         />

--- a/apps/web/modules/survey/link/components/pin-screen.tsx
+++ b/apps/web/modules/survey/link/components/pin-screen.tsx
@@ -19,6 +19,7 @@ interface PinScreenProps {
   publicDomain: string;
   IMPRINT_URL?: string;
   PRIVACY_URL?: string;
+  TERMS_URL?: string;
   IS_FORMBRICKS_CLOUD: boolean;
   verifiedEmail?: string;
   languageCode: string;
@@ -40,6 +41,7 @@ export const PinScreen = (props: PinScreenProps) => {
     singleUseResponse,
     IMPRINT_URL,
     PRIVACY_URL,
+    TERMS_URL,
     IS_FORMBRICKS_CLOUD,
     verifiedEmail,
     languageCode,
@@ -134,6 +136,7 @@ export const PinScreen = (props: PinScreenProps) => {
       verifiedEmail={verifiedEmail}
       IMPRINT_URL={IMPRINT_URL}
       PRIVACY_URL={PRIVACY_URL}
+      TERMS_URL={TERMS_URL}
       IS_FORMBRICKS_CLOUD={IS_FORMBRICKS_CLOUD}
     />
   );

--- a/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
+++ b/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
@@ -30,11 +30,12 @@ interface SurveyClientWrapperProps {
   verifiedEmail?: string;
   IMPRINT_URL?: string;
   PRIVACY_URL?: string;
+  TERMS_URL?: string;
   IS_FORMBRICKS_CLOUD: boolean;
 }
 
-let setBlockId = (_: string) => {};
-let setResponseData = (_: TResponseData) => {};
+let setBlockId = (_: string) => { };
+let setResponseData = (_: TResponseData) => { };
 
 export const SurveyClientWrapper = ({
   survey,
@@ -53,6 +54,7 @@ export const SurveyClientWrapper = ({
   verifiedEmail,
   IMPRINT_URL,
   PRIVACY_URL,
+  TERMS_URL,
   IS_FORMBRICKS_CLOUD,
 }: SurveyClientWrapperProps) => {
   const searchParams = useSearchParams();
@@ -146,6 +148,7 @@ export const SurveyClientWrapper = ({
         IS_FORMBRICKS_CLOUD={IS_FORMBRICKS_CLOUD}
         IMPRINT_URL={IMPRINT_URL}
         PRIVACY_URL={PRIVACY_URL}
+        TERMS_URL={TERMS_URL}
         isBrandingEnabled={project.linkSurveyBranding}
         dir={logoDir}>
         <SurveyInline
@@ -175,7 +178,7 @@ export const SurveyClientWrapper = ({
           }}
           singleUseId={singleUseId}
           singleUseResponseId={singleUseResponseId}
-          getSetIsResponseSendingFinished={(_f: (value: boolean) => void) => {}}
+          getSetIsResponseSendingFinished={(_f: (value: boolean) => void) => { }}
           contactId={contactId}
           recaptchaSiteKey={recaptchaSiteKey}
           isSpamProtectionEnabled={isSpamProtectionEnabled}

--- a/apps/web/modules/survey/link/components/survey-renderer.tsx
+++ b/apps/web/modules/survey/link/components/survey-renderer.tsx
@@ -8,6 +8,7 @@ import {
   IS_FORMBRICKS_CLOUD,
   IS_RECAPTCHA_CONFIGURED,
   PRIVACY_URL,
+  TERMS_URL,
   RECAPTCHA_SITE_KEY,
 } from "@/lib/constants";
 import { getPublicDomain } from "@/lib/getPublicUrl";
@@ -141,6 +142,7 @@ export const renderSurvey = async ({
         singleUseResponse={singleUseResponse}
         IMPRINT_URL={IMPRINT_URL}
         PRIVACY_URL={PRIVACY_URL}
+        TERMS_URL={TERMS_URL}
         IS_FORMBRICKS_CLOUD={IS_FORMBRICKS_CLOUD}
         verifiedEmail={verifiedEmail}
         languageCode={languageCode}
@@ -173,6 +175,7 @@ export const renderSurvey = async ({
       verifiedEmail={verifiedEmail}
       IMPRINT_URL={IMPRINT_URL}
       PRIVACY_URL={PRIVACY_URL}
+      TERMS_URL={TERMS_URL}
       IS_FORMBRICKS_CLOUD={IS_FORMBRICKS_CLOUD}
     />
   );


### PR DESCRIPTION
## Problem
`TERMS_URL` was defined in the Docker compose config but was never passed 
to or rendered in the survey link footer components, so it was never 
displayed to survey respondents.

## Solution
Added `TERMS_URL` prop alongside the existing `PRIVACY_URL` through the 
entire component chain:
- `survey-renderer.tsx` → imports from constants, passes to children
- `pin-screen.tsx` → passes through to SurveyClientWrapper
- `survey-client-wrapper.tsx` → passes through to LinkSurveyWrapper  
- `link-survey-wrapper.tsx` → passes through to LegalFooter
- `legal-footer.tsx` → renders the Terms link in the footer UI
