### PR TITLE
fix: handle internal server error toast behavior #3302

### DIFF
--- a/apps/web/modules/setup/organization/create/components/create-organization.tsx
+++ b/apps/web/modules/setup/organization/create/components/create-organization.tsx
@@ -35,6 +35,16 @@ export const CreateOrganization = () => {
     try {
       setIsSubmitting(true);
       const createOrganizationResponse = await createOrganizationAction({ organizationName });
+      if (createOrganizationResponse?.serverError) {
+        toast.error(createOrganizationResponse.serverError);
+        setIsSubmitting(false);
+        return;
+      }
+      if (createOrganizationResponse?.serverError) {
+        toast.error(createOrganizationResponse.serverError);
+        setIsSubmitting(false);
+        return;
+      }
       if (createOrganizationResponse?.data) {
         router.push(`/setup/organization/${createOrganizationResponse.data.id}/invite`);
       }


### PR DESCRIPTION
## What does this PR do?
This PR fixes the issue where internal server errors (which return status 200) incorrectly trigger a success toast. I've added a `serverError` check to ensure the user receives accurate feedback when operations fail.

Fixes #3302

## How should this be tested?
1. Use a scenario that triggers an unsuccessful server-side action (e.g., as described in issue #3301).
2. Observe that an error toast appears instead of a false success message.

## Checklist
- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code