### PR TITLE
fix(api): return 409 Conflict instead of 500 when creating user with duplicate email

### DIFF
--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
@@ -119,6 +119,27 @@ describe("Users Lib", () => {
         ]);
       }
     });
+
+    test("returns internal_server_error if unique constraint violation is not on email", async () => {
+      (prisma.user.create as any).mockRejectedValueOnce(
+        new Prisma.PrismaClientKnownRequestError(
+          "Unique constraint failed on the fields: (`organizationId`,`email`)",
+          {
+            code: PrismaErrorType.UniqueConstraintViolation,
+            clientVersion: "1.0.0",
+            meta: { target: ["organizationId"] },
+          }
+        )
+      );
+      const result = await createUser(
+        { name: "Duplicate", email: "test@example.com", role: "member" },
+        "org456"
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe("internal_server_error");
+      }
+    });
   });
 
   describe("updateUser", () => {

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
@@ -1,5 +1,7 @@
+import { Prisma } from "@prisma/client";
 import { describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
+import { PrismaErrorType } from "@formbricks/database/types/error";
 import { TGetUsersFilter } from "@/modules/api/v2/organizations/[organizationId]/users/types/users";
 import { createUser, getUsers, updateUser } from "../users";
 
@@ -91,6 +93,30 @@ describe("Users Lib", () => {
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.error.type).toBe("internal_server_error");
+      }
+    });
+
+    test("returns conflict error if user with email already exists", async () => {
+      (prisma.user.create as any).mockRejectedValueOnce(
+        new Prisma.PrismaClientKnownRequestError(
+          "Unique constraint failed on the fields: (`email`)",
+          {
+            code: PrismaErrorType.UniqueConstraintViolation,
+            clientVersion: "1.0.0",
+            meta: { target: ["email"] },
+          }
+        )
+      );
+      const result = await createUser(
+        { name: "Duplicate", email: "test@example.com", role: "member" },
+        "org456"
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe("conflict");
+        expect(result.error.details).toEqual([
+          { field: "email", issue: "A user with this email already exists" },
+        ]);
       }
     });
   });

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
@@ -147,10 +147,14 @@ export const createUser = async (
       error instanceof Prisma.PrismaClientKnownRequestError &&
       error.code === PrismaErrorType.UniqueConstraintViolation
     ) {
-      return err({
-        type: "conflict",
-        details: [{ field: "email", issue: `A user with this email already exists` }],
-      });
+      const target = error.meta?.target as string[] | undefined;
+
+      if (target?.includes("email")) {
+        return err({
+          type: "conflict",
+          details: [{ field: "email", issue: "A user with this email already exists" }],
+        });
+      }
     }
 
     return err({

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
@@ -1,5 +1,6 @@
 import { OrganizationRole, Prisma, TeamUserRole } from "@prisma/client";
 import { prisma } from "@formbricks/database";
+import { PrismaErrorType } from "@formbricks/database/types/error";
 import { TUser } from "@formbricks/database/zod/users";
 import { Result, err, ok } from "@formbricks/types/error-handlers";
 import { getUsersQuery } from "@/modules/api/v2/organizations/[organizationId]/users/lib/utils";
@@ -142,6 +143,16 @@ export const createUser = async (
 
     return ok(returnedUser);
   } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === PrismaErrorType.UniqueConstraintViolation
+    ) {
+      return err({
+        type: "conflict",
+        details: [{ field: "email", issue: `A user with this email already exists` }],
+      });
+    }
+
     return err({
       type: "internal_server_error",
       details: [{ field: "user", issue: error instanceof Error ? error.message : "Unknown error occurred" }],


### PR DESCRIPTION
## Problem

When a user is deleted via the Formbricks UI and then recreated through the Management API v2 (POST /api/v2/organizations/{orgId}/users), the API returns a **500 Internal Server Error** with an unhelpful Prisma error message. This happens because:

1. The user record still exists in the database (or was incompletely cleaned up)
2. The email field has a @unique constraint in the Prisma schema
3. The createUser function in the API v2 users lib attempts a raw prisma.user.create() without handling the unique constraint violation

## Root Cause

The createUser function's catch block treated **all** errors uniformly as internal_server_error, including Prisma's P2002 (unique constraint violation) error. This means a perfectly valid client error (duplicate email) was surfaced as a server error with no actionable information.

## Fix

- Import PrismaErrorType and check for Prisma.PrismaClientKnownRequestError with code P2002 (UniqueConstraintViolation)
- Return a conflict (HTTP 409) response with a clear error message: *'A user with this email already exists'*
- Non-unique-constraint errors continue to return internal_server_error as before

## Changes

### pps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
- Added import for PrismaErrorType  
- Added P2002 check in the createUser catch block before the generic error fallback

### pps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
- Added imports for Prisma and PrismaErrorType
- Added test case: *'returns conflict error if user with email already exists'* — verifies the function returns 	ype: 'conflict' with proper details when a P2002 error is thrown

## Testing

- Unit test added and follows existing codebase patterns (see 	eams.test.ts for the same PrismaClientKnownRequestError mocking approach)
- The existing tests remain unchanged and unaffected

Fixes #7537