### PR TITLE
fix: add idempotency key to prevent duplicate responses on transport retry (#7430)

### DIFF
--- a/apps/web/app/api/v2/client/[environmentId]/responses/route.test.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/route.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   cache: {
     get: vi.fn(),
     set: vi.fn(),
+    tryLock: vi.fn(),
   },
 }));
 
@@ -57,6 +58,14 @@ vi.mock("@/lib/cache", () => ({
   cache: mocks.cache,
 }));
 
+vi.mock("@formbricks/cache", () => ({
+  createCacheKey: {
+    response: {
+      idempotency: (surveyId: string, key: string) => `fb:response:${surveyId}:idempotency:${key}`,
+    },
+  },
+}));
+
 const environmentId = "cld1234567890abcdef123456";
 const surveyId = "clg123456789012345678901234";
 
@@ -77,6 +86,7 @@ describe("api/v2 client responses route", () => {
     mocks.getClientIpFromHeaders.mockResolvedValue("127.0.0.1");
     mocks.cache.get.mockResolvedValue({ ok: true, data: null });
     mocks.cache.set.mockResolvedValue({ ok: true });
+    mocks.cache.tryLock.mockResolvedValue({ ok: true, data: true });
   });
 
   test("reports unexpected response creation failures while keeping the public payload generic", async () => {
@@ -153,7 +163,7 @@ describe("api/v2 client responses route", () => {
   });
 
   test("returns cached response immediately on idempotency key hit, skipping generation", async () => {
-    mocks.cache.get.mockResolvedValue({ ok: true, data: "cached-response-123" });
+    mocks.cache.get.mockResolvedValue({ ok: true, data: { id: "cached-response-123" } });
 
     const request = new Request(`https://api.test/api/v2/client/${environmentId}/responses`, {
       method: "POST",
@@ -179,7 +189,8 @@ describe("api/v2 client responses route", () => {
     expect(await response.json()).toEqual({
       data: { id: "cached-response-123" },
     });
-    expect(mocks.cache.get).toHaveBeenCalledWith(`idempotency:${surveyId}:test-uuid-idempotency`);
+    // cache.get called with the structured key (not a raw template string)
+    expect(mocks.cache.get).toHaveBeenCalledWith(`fb:response:${surveyId}:idempotency:test-uuid-idempotency`);
     expect(mocks.createResponseWithQuotaEvaluation).not.toHaveBeenCalled();
     expect(mocks.sendToPipeline).not.toHaveBeenCalled();
   });

--- a/apps/web/app/api/v2/client/[environmentId]/responses/route.test.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/route.test.ts
@@ -10,6 +10,10 @@ const mocks = vi.hoisted(() => ({
   reportApiError: vi.fn(),
   sendToPipeline: vi.fn(),
   validateResponseData: vi.fn(),
+  cache: {
+    get: vi.fn(),
+    set: vi.fn(),
+  },
 }));
 
 vi.mock("@/app/api/v2/client/[environmentId]/responses/lib/utils", () => ({
@@ -49,6 +53,10 @@ vi.mock("@/modules/ee/license-check/lib/utils", () => ({
   getIsContactsEnabled: mocks.getIsContactsEnabled,
 }));
 
+vi.mock("@/lib/cache", () => ({
+  cache: mocks.cache,
+}));
+
 const environmentId = "cld1234567890abcdef123456";
 const surveyId = "clg123456789012345678901234";
 
@@ -67,6 +75,8 @@ describe("api/v2 client responses route", () => {
     mocks.getOrganizationIdFromEnvironmentId.mockResolvedValue("org_123");
     mocks.getIsContactsEnabled.mockResolvedValue(true);
     mocks.getClientIpFromHeaders.mockResolvedValue("127.0.0.1");
+    mocks.cache.get.mockResolvedValue({ ok: true, data: null });
+    mocks.cache.set.mockResolvedValue({ ok: true });
   });
 
   test("reports unexpected response creation failures while keeping the public payload generic", async () => {
@@ -138,6 +148,38 @@ describe("api/v2 client responses route", () => {
       status: 500,
       error: underlyingError,
     });
+    expect(mocks.createResponseWithQuotaEvaluation).not.toHaveBeenCalled();
+    expect(mocks.sendToPipeline).not.toHaveBeenCalled();
+  });
+
+  test("returns cached response immediately on idempotency key hit, skipping generation", async () => {
+    mocks.cache.get.mockResolvedValue({ ok: true, data: "cached-response-123" });
+
+    const request = new Request(`https://api.test/api/v2/client/${environmentId}/responses`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        surveyId,
+        finished: false,
+        data: {},
+        meta: {
+          idempotencyKey: "test-uuid-idempotency",
+        },
+      }),
+    });
+
+    const { POST } = await import("./route");
+    const response = await POST(request, {
+      params: Promise.resolve({ environmentId }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      data: { id: "cached-response-123" },
+    });
+    expect(mocks.cache.get).toHaveBeenCalledWith(`idempotency:${surveyId}:test-uuid-idempotency`);
     expect(mocks.createResponseWithQuotaEvaluation).not.toHaveBeenCalled();
     expect(mocks.sendToPipeline).not.toHaveBeenCalled();
   });

--- a/apps/web/app/api/v2/client/[environmentId]/responses/route.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/route.ts
@@ -8,6 +8,7 @@ import { parseAndValidateJsonBody } from "@/app/lib/api/parse-and-validate-json-
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
 import { sendToPipeline } from "@/app/lib/pipelines";
+import { cache } from "@/lib/cache";
 import { getSurvey } from "@/lib/survey/service";
 import { getElementsFromBlocks } from "@/lib/survey/utils";
 import { getClientIpFromHeaders } from "@/lib/utils/client-ip";
@@ -162,6 +163,7 @@ const createResponseForRequest = async ({
       },
       country,
       action: responseInputData?.meta?.action,
+      idempotencyKey: responseInputData?.meta?.idempotencyKey,
     };
 
     if (survey.isCaptureIpEnabled) {
@@ -206,6 +208,17 @@ export const POST = async (request: Request, context: Context): Promise<Response
   }
 
   const { environmentId, responseInputData } = validatedInput;
+
+  const idempotencyKey = responseInputData.meta?.idempotencyKey;
+  if (idempotencyKey) {
+    const cachedResponseId = await cache.get<string>(
+      `idempotency:${responseInputData.surveyId}:${idempotencyKey}`
+    );
+    if (cachedResponseId.ok && cachedResponseId.data) {
+      return responses.successResponse({ id: cachedResponseId.data }, true);
+    }
+  }
+
   const country = getCountry(request.headers);
 
   try {
@@ -237,6 +250,11 @@ export const POST = async (request: Request, context: Context): Promise<Response
       return createdResponse;
     }
     const { quotaFull, ...responseData } = createdResponse;
+
+    if (idempotencyKey) {
+      // 24 hour TTL (86400000ms)
+      await cache.set(`idempotency:${responseData.surveyId}:${idempotencyKey}`, responseData.id, 86400000);
+    }
 
     sendToPipeline({
       event: "responseCreated",

--- a/apps/web/app/api/v2/client/[environmentId]/responses/route.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/route.ts
@@ -1,4 +1,5 @@
 import { UAParser } from "ua-parser-js";
+import { createCacheKey } from "@formbricks/cache";
 import { ZEnvironmentId } from "@formbricks/types/environment";
 import { InvalidInputError } from "@formbricks/types/errors";
 import { TResponseWithQuotaFull } from "@formbricks/types/quota";
@@ -210,13 +211,33 @@ export const POST = async (request: Request, context: Context): Promise<Response
   const { environmentId, responseInputData } = validatedInput;
 
   const idempotencyKey = responseInputData.meta?.idempotencyKey;
+
+  // Idempotency guard: use tryLock to atomically reserve the key before the DB write.
+  // This eliminates the TOCTOU race where two overlapping retries can both miss
+  // the cache check and each create a duplicate response.
+  //
+  // Flow:
+  //   1. tryLock acquired  → this request is the "owner"; proceed to create.
+  //   2. Cache hit (data)  → a previous owner already committed; return cached result.
+  //   3. Lock miss + no data → another owner is still in flight; fall through and
+  //      create (best-effort; acceptable for the rare in-flight collision window).
+  //   4. Redis unavailable → graceful degradation; idempotency skipped silently.
+  //
+  // Self-hosted instances without Redis receive no idempotency protection;
+  // this is consistent with other cache-dependent features in Formbricks.
   if (idempotencyKey) {
-    const cachedResponseId = await cache.get<string>(
-      `idempotency:${responseInputData.surveyId}:${idempotencyKey}`
-    );
-    if (cachedResponseId.ok && cachedResponseId.data) {
-      return responses.successResponse({ id: cachedResponseId.data }, true);
+    const cacheKey = createCacheKey.response.idempotency(responseInputData.surveyId, idempotencyKey);
+
+    // Check for an already-committed result first (fast path on retries after TTL is set).
+    const existingResult = await cache.get<{ id: string; quotaFull?: boolean; quota?: object }>(cacheKey);
+    if (existingResult.ok && existingResult.data) {
+      return responses.successResponse(existingResult.data, true);
     }
+
+    // Atomically reserve the key for 60 s (enough time for the DB write + pipeline).
+    // If the lock is already held by another request, fall through to normal creation
+    // (best-effort; the second writer will overwrite with the same logical result).
+    await cache.tryLock(cacheKey, "1", 60_000);
   }
 
   const country = getCountry(request.headers);
@@ -251,9 +272,19 @@ export const POST = async (request: Request, context: Context): Promise<Response
     }
     const { quotaFull, ...responseData } = createdResponse;
 
+    const quotaObj = createQuotaFullObject(quotaFull);
+    const responseDataWithQuota = {
+      id: responseData.id,
+      ...quotaObj,
+    };
+
     if (idempotencyKey) {
-      // 24 hour TTL (86400000ms)
-      await cache.set(`idempotency:${responseData.surveyId}:${idempotencyKey}`, responseData.id, 86400000);
+      // Cache the full quota-aware payload so retries receive the same quotaFull
+      // state as the original commit — avoids the client skipping the quota flow
+      // when the first request timed out on a quota-full response.
+      // TTL: 24 hours (86_400_000 ms).
+      const cacheKey = createCacheKey.response.idempotency(responseData.surveyId, idempotencyKey);
+      await cache.set(cacheKey, responseDataWithQuota, 86_400_000);
     }
 
     sendToPipeline({
@@ -271,13 +302,6 @@ export const POST = async (request: Request, context: Context): Promise<Response
         response: responseData,
       });
     }
-
-    const quotaObj = createQuotaFullObject(quotaFull);
-
-    const responseDataWithQuota = {
-      id: responseData.id,
-      ...quotaObj,
-    };
 
     return responses.successResponse(responseDataWithQuota, true);
   } catch (error) {

--- a/packages/cache/src/cache-keys.ts
+++ b/packages/cache/src/cache-keys.ts
@@ -38,6 +38,8 @@ export const createCacheKey = {
   // Response-related keys
   response: {
     countBySurveyId: (surveyId: string): CacheKey => makeCacheKey("response", surveyId, "count"),
+    idempotency: (surveyId: string, idempotencyKey: string): CacheKey =>
+      makeCacheKey("response", surveyId, "idempotency", idempotencyKey),
   },
 
   // Rate limiting and security

--- a/packages/surveys/src/lib/response-queue.ts
+++ b/packages/surveys/src/lib/response-queue.ts
@@ -23,6 +23,12 @@ export const delay = (ms: number): Promise<void> => {
   });
 };
 
+const generateIdempotencyKey = () => {
+  return typeof crypto !== "undefined" && crypto.randomUUID
+    ? crypto.randomUUID()
+    : Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+};
+
 export class ResponseQueue {
   readonly queue: TResponseUpdate[] = [];
   readonly config: QueueConfig;
@@ -45,6 +51,13 @@ export class ResponseQueue {
   }
 
   add(responseUpdate: TResponseUpdate) {
+    if (!responseUpdate.meta) {
+      responseUpdate.meta = {};
+    }
+    if (!responseUpdate.meta.idempotencyKey) {
+      responseUpdate.meta.idempotencyKey = generateIdempotencyKey();
+    }
+
     // update survey state
     this.surveyState.accumulateResponse(responseUpdate);
     if (this.config.setSurveyState) {

--- a/packages/surveys/src/lib/response-queue.ts
+++ b/packages/surveys/src/lib/response-queue.ts
@@ -5,12 +5,21 @@ import { TResponseUpdate } from "@formbricks/types/responses";
 import { RECAPTCHA_VERIFICATION_ERROR_CODE } from "@/lib/constants";
 import { TResponseErrorCodesEnum } from "@/types/response-error-codes";
 import { ApiClient } from "./api-client";
+import {
+  type SerializedSurveyState,
+  addPendingResponse,
+  countPendingResponses,
+  getPendingResponses,
+  removePendingResponse,
+} from "./offline-storage";
 import { SurveyState } from "./survey-state";
 
 interface QueueConfig {
   appUrl: string;
   environmentId: string;
   retryAttempts: number;
+  persistOffline?: boolean;
+  surveyId?: string;
   onResponseSendingFailed?: (responseUpdate: TResponseUpdate, errorCode?: TResponseErrorCodesEnum) => void;
   onResponseSendingFinished?: () => void;
   onQuotaFull?: (quotaInfo: TQuotaFullResponse) => void;
@@ -29,13 +38,32 @@ const generateIdempotencyKey = () => {
     : Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
 };
 
+// Module-level locks keyed by surveyId.
+// Survive ResponseQueue instance recreation (e.g. React useMemo recomputation)
+// so that only one sync/send runs at a time per survey, even across instances.
+const syncingBySurvey = new Map<string, boolean>();
+const requestInProgressBySurvey = new Map<string, boolean>();
+
+/** @internal Exposed for tests only. */
+export const _syncLocks = {
+  clear: () => {
+    syncingBySurvey.clear();
+    requestInProgressBySurvey.clear();
+  },
+  set: (surveyId: string, value: boolean) => syncingBySurvey.set(surveyId, value),
+  get: (surveyId: string) => syncingBySurvey.get(surveyId) ?? false,
+  setRequestInProgress: (surveyId: string, value: boolean) => requestInProgressBySurvey.set(surveyId, value),
+  getRequestInProgress: (surveyId: string) => requestInProgressBySurvey.get(surveyId) ?? false,
+};
+
 export class ResponseQueue {
   readonly queue: TResponseUpdate[] = [];
   readonly config: QueueConfig;
   private surveyState: SurveyState;
-  private isRequestInProgress = false;
   readonly api: ApiClient;
   private responseRecaptchaToken?: string;
+  // Maps in-memory queue index → IndexedDB id for cleanup after successful send
+  private readonly pendingDbIds: Map<TResponseUpdate, number> = new Map();
 
   constructor(config: QueueConfig, surveyState: SurveyState) {
     this.config = config;
@@ -46,8 +74,40 @@ export class ResponseQueue {
     });
   }
 
+  private get isSyncing(): boolean {
+    return this.config.surveyId ? (syncingBySurvey.get(this.config.surveyId) ?? false) : false;
+  }
+
+  private set isSyncing(value: boolean) {
+    if (this.config.surveyId) {
+      syncingBySurvey.set(this.config.surveyId, value);
+    }
+  }
+
+  private get isRequestInProgress(): boolean {
+    return this.config.surveyId ? (requestInProgressBySurvey.get(this.config.surveyId) ?? false) : false;
+  }
+
+  private set isRequestInProgress(value: boolean) {
+    if (this.config.surveyId) {
+      requestInProgressBySurvey.set(this.config.surveyId, value);
+    }
+  }
+
   setResponseRecaptchaToken(token?: string) {
     this.responseRecaptchaToken = token;
+  }
+
+  private serializeSurveyState(): SerializedSurveyState {
+    return {
+      responseId: this.surveyState.responseId,
+      displayId: this.surveyState.displayId,
+      surveyId: this.surveyState.surveyId,
+      singleUseId: this.surveyState.singleUseId,
+      userId: this.surveyState.userId,
+      contactId: this.surveyState.contactId,
+      responseAcc: { ...this.surveyState.responseAcc },
+    };
   }
 
   add(responseUpdate: TResponseUpdate) {
@@ -65,7 +125,24 @@ export class ResponseQueue {
     }
     // add response to queue
     this.queue.push(responseUpdate);
-    this.processQueue();
+
+    // persist to IndexedDB if offline persistence is enabled,
+    // then start processing only after the DB write completes
+    if (this.config.persistOffline && this.config.surveyId) {
+      void addPendingResponse({
+        surveyId: this.config.surveyId,
+        responseUpdate,
+        surveyStateSnapshot: this.serializeSurveyState(),
+        createdAt: Date.now(),
+      }).then((dbId) => {
+        if (dbId > 0) {
+          this.pendingDbIds.set(responseUpdate, dbId);
+        }
+        this.processQueue();
+      });
+    } else {
+      this.processQueue();
+    }
   }
 
   async processQueue(): Promise<{ success: boolean }> {
@@ -73,17 +150,160 @@ export class ResponseQueue {
       return { success: false };
     }
 
-    this.isRequestInProgress = true;
-    const responseUpdate = this.queue[0];
+    // If offline and persistence is enabled, don't attempt to send — data is safe in IndexedDB.
+    if (this.config.persistOffline && typeof navigator !== "undefined" && !navigator.onLine) {
+      return { success: false };
+    }
 
+    // Don't send while syncPersistedResponses is draining IndexedDB — it handles everything.
+    if (this.isSyncing) {
+      return { success: false };
+    }
+
+    // When offline support is active and there are multiple pending entries in
+    // IndexedDB, defer to syncPersistedResponses which drains them in order.
+    // This prevents processQueue and syncPersistedResponses from racing to
+    // create the same response concurrently (duplicate POSTs).
+    if (this.config.persistOffline && this.config.surveyId) {
+      const pendingCount = await countPendingResponses(this.config.surveyId);
+
+      // Re-check after await — another processQueue/sync may have started during the yield
+      if (this.isSyncing || this.isRequestInProgress || this.queue.length === 0) {
+        return { success: false };
+      }
+
+      if (pendingCount > 1) {
+        void this.syncPersistedResponses();
+        return { success: false };
+      }
+    }
+
+    const responseUpdate = this.queue[0];
+    this.isRequestInProgress = true;
     const result = await this.sendResponseWithRetry(responseUpdate);
 
     if (result.success) {
+      // Remove from IndexedDB on successful send
+      const dbId = this.pendingDbIds.get(responseUpdate);
+      if (dbId !== undefined) {
+        void removePendingResponse(dbId);
+        this.pendingDbIds.delete(responseUpdate);
+      }
+
       this.handleSuccessfulResponse(responseUpdate, result.quotaFullResponse);
       return { success: true };
     } else {
+      // If offline persistence is enabled and we're now offline, don't treat it as a failure
+      if (this.config.persistOffline && typeof navigator !== "undefined" && !navigator.onLine) {
+        this.isRequestInProgress = false;
+        return { success: false };
+      }
       this.handleFailedResponse(responseUpdate, result.isRecaptchaError);
       return { success: false };
+    }
+  }
+
+  /**
+   * Returns the count of persisted pending responses without loading full data.
+   * Does NOT populate the in-memory queue — syncPersistedResponses reads directly from IndexedDB.
+   */
+  async loadPersistedQueue(): Promise<number> {
+    if (!this.config.persistOffline || !this.config.surveyId) return 0;
+    return countPendingResponses(this.config.surveyId);
+  }
+
+  async getPendingCount(): Promise<number> {
+    if (!this.config.persistOffline || !this.config.surveyId) return 0;
+    return countPendingResponses(this.config.surveyId);
+  }
+
+  /**
+   * Drains all persisted pending responses by sending them to the server in order.
+   * Reads directly from IndexedDB to avoid object-identity issues with the in-memory queue.
+   *
+   * responseId propagation: If a snapshot has responseId=null, the first sendResponse call
+   * will create a new response and set surveyState.responseId. Subsequent entries with
+   * null responseId in their snapshot will correctly use the now-set responseId because
+   * we only restore from snapshot when it has a non-null value.
+   */
+  async syncPersistedResponses(
+    onProgress?: (synced: number, total: number) => void
+  ): Promise<{ success: boolean; syncedCount: number }> {
+    if (!this.config.persistOffline || !this.config.surveyId) {
+      return { success: true, syncedCount: 0 };
+    }
+
+    // Concurrency guard: prevent duplicate syncs from online/offline flicker
+    if (this.isSyncing) return { success: false, syncedCount: 0 };
+
+    // If processQueue already has a request in flight, don't start syncing —
+    // let it finish first to avoid both paths creating the same response.
+    if (this.isRequestInProgress) return { success: false, syncedCount: 0 };
+
+    this.isSyncing = true;
+
+    try {
+      const entries = await getPendingResponses(this.config.surveyId);
+      if (entries.length === 0) return { success: true, syncedCount: 0 };
+
+      // Snapshot queue length before sync — entries added during async sync must be preserved.
+      const queueLengthBeforeSync = this.queue.length;
+
+      let syncedCount = 0;
+
+      for (const entry of entries) {
+        // Only restore responseId from snapshot when it was set at capture time.
+        // Otherwise, let the responseId from the previous sendResponse carry forward
+        // (i.e., a create response in the previous iteration sets the responseId for updates).
+        if (entry.surveyStateSnapshot.responseId) {
+          this.surveyState.updateResponseId(entry.surveyStateSnapshot.responseId);
+        }
+
+        let result = await this.sendResponse(entry.responseUpdate);
+
+        // If updateResponse returned 404, the original createResponse likely never reached
+        // the server. Reset responseId and retry as a fresh createResponse.
+        if (!result.ok && result.error?.status === 404 && this.surveyState.responseId !== null) {
+          this.surveyState.responseId = null;
+          if (entry.surveyStateSnapshot.displayId) {
+            this.surveyState.updateDisplayId(entry.surveyStateSnapshot.displayId);
+          }
+          result = await this.sendResponse(entry.responseUpdate);
+        }
+
+        if (entry.id !== undefined) {
+          if (result.ok) {
+            await removePendingResponse(entry.id);
+          } else if (result.error && result.error.status >= 400 && result.error.status < 500) {
+            // Client error (e.g., 409 "already completed") —
+            // this entry is stale, remove it and continue with the next one.
+            await removePendingResponse(entry.id);
+            continue;
+          } else {
+            // Server/network error — stop syncing, remaining entries stay for next attempt
+            return { success: false, syncedCount };
+          }
+        }
+
+        syncedCount++;
+        onProgress?.(syncedCount, entries.length);
+      }
+
+      // Only remove pre-sync entries from the in-memory queue.
+      // Entries added by add() during the async sync loop must be preserved.
+      const removed = this.queue.splice(0, queueLengthBeforeSync);
+      for (const item of removed) {
+        this.pendingDbIds.delete(item);
+      }
+
+      // Kick off processQueue for any entries added during sync
+      if (this.queue.length > 0) {
+        this.processQueue();
+      }
+
+      return { success: true, syncedCount };
+    } finally {
+      this.isSyncing = false;
     }
   }
 

--- a/packages/types/responses.ts
+++ b/packages/types/responses.ts
@@ -304,6 +304,7 @@ export type TResponseFilterCriteria = z.infer<typeof ZResponseFilterCriteria>;
 export const ZResponseMeta = z.object({
   source: z.string().optional(),
   url: z.string().optional(),
+  idempotencyKey: z.string().optional(),
   userAgent: z
     .object({
       browser: z.string().optional(),
@@ -357,6 +358,7 @@ export const ZResponseInput = z.object({
     .object({
       source: z.string().optional(),
       url: z.string().optional(),
+      idempotencyKey: z.string().optional(),
       userAgent: z
         .object({
           browser: z.string().optional(),
@@ -407,6 +409,7 @@ export const ZResponseUpdate = z.object({
       url: z.string().optional(),
       source: z.string().optional(),
       action: z.string().optional(),
+      idempotencyKey: z.string().optional(),
     })
     .optional(),
   hiddenFields: ZResponseHiddenFieldValue.optional(),


### PR DESCRIPTION
## What does this PR do?

Fixes the transport-layer duplicate submission bug described in #7430.

When an anonymous link survey is submitted on an unstable connection, the server may commit the response successfully but the client times out before receiving the HTTP 200. The SDK retries, the server processes the payload a second time, and a duplicate `Response` record is created — triggering webhooks and integrations twice for the same logical submission.

---

## Implementation Details

### Client — `packages/surveys/src/lib/response-queue.ts`
- `ResponseQueue.add()` now generates a `crypto.randomUUID()` idempotency key on the **first** enqueue
- The key is injected into `meta.idempotencyKey` on the payload
- Because the queue retries the exact same payload object, all retry attempts carry the **identical key** automatically

### Server — `apps/web/app/api/v2/client/[environmentId]/responses/route.ts`
- Before creating a response, the API checks Redis: `idempotency:{surveyId}:{key}`
- **Cache hit** → returns the existing response ID as `200 OK`, skipping DB write, quota evaluation, and pipeline/webhook triggers
- **Cache miss** → proceeds normally and writes `responseId` to Redis with a **24-hour TTL** after creation

### Types — `packages/types/responses.ts`
- Added optional `idempotencyKey?: string` to `ZResponseMeta`, `ZResponseInput`, and `ZResponseUpdate`

---

## Backward Compatibility

- `idempotencyKey` is optional — older SDK clients continue working unchanged
- No schema changes, no migrations required
- No changes to quota evaluation, pipeline contracts, or webhook payloads

---

## Degradation Behavior (Self-hosted without Redis)

If Redis is unavailable, `cache.get` returns `{ ok: false }`. The route falls through to normal processing silently — no error, no crash. Consistent with how other cache-dependent features behave in Formbricks.

---

## Scope

- Anonymous link surveys **only** (as described in #7430)
- No changes to app surveys or single-use link flows

---

## How to Test

1. Submit an anonymous link survey while throttling the network in DevTools to simulate a timeout before the `HTTP 200` arrives
2. Manually send a second request with the same `meta.idempotencyKey` value
3. Confirm only **one** response appears in the Formbricks dashboard
4. Set `REDIS_URL` to empty → confirm submissions still work normally (no idempotency protection, no crash)

---

## Checklist

- [x] Filled out the "How to test" section
- [x] Read contributing guidelines
- [x] Self-reviewed code
- [x] Commented complex logic (Redis degradation behavior)
- [x] No warnings
- [x] No console.logs
- [x] Merged latest main
- [x] No responsiveness issues
