### PR TITLE
fix: add loading skeleton for responses page

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/loading.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/loading.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
+import { PageHeader } from "@/modules/ui/components/page-header";
+import { SkeletonLoader } from "@/modules/ui/components/skeleton-loader";
+
+const Loading = () => {
+  return (
+    <PageContentWrapper>
+      <PageHeader pageTitle="" />
+      <div className="flex h-9 animate-pulse gap-2">
+        <div className="h-9 w-36 rounded-full bg-slate-200" />
+        <div className="h-9 w-36 rounded-full bg-slate-200" />
+        <div className="h-9 w-36 rounded-full bg-slate-200" />
+        <div className="h-9 w-36 rounded-full bg-slate-200" />
+      </div>
+      <SkeletonLoader type="summary" />
+    </PageContentWrapper>
+  );
+};
+
+export default Loading;

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/loading.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/loading.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
+import { PageHeader } from "@/modules/ui/components/page-header";
+
+const Loading = () => {
+  const { t } = useTranslation();
+
+  return (
+    <PageContentWrapper>
+      <PageHeader pageTitle={t("common.responses")} />
+      {/* Filter bar placeholder */}
+      <div className="flex h-9 animate-pulse gap-1.5">
+        <div className="h-9 w-36 rounded-full bg-slate-200" />
+        <div className="h-9 w-36 rounded-full bg-slate-200" />
+      </div>
+      {/* Toolbar placeholder */}
+      <div className="flex animate-pulse items-center justify-between py-2">
+        <div className="h-8 w-48 rounded-md bg-slate-200" />
+        <div className="flex gap-2">
+          <div className="h-8 w-8 rounded-md bg-slate-200" />
+          <div className="h-8 w-8 rounded-md bg-slate-200" />
+        </div>
+      </div>
+      {/* Table skeleton */}
+      <div className="overflow-hidden rounded-xl border border-slate-200">
+        {/* Header row */}
+        <div className="flex h-12 items-center gap-4 border-b border-slate-200 bg-slate-100 px-4">
+          <div className="h-4 w-4 rounded bg-slate-200" />
+          <div className="h-4 w-24 animate-pulse rounded bg-slate-200" />
+          <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
+          <div className="h-4 w-40 animate-pulse rounded bg-slate-200" />
+          <div className="h-4 w-40 animate-pulse rounded bg-slate-200" />
+          <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
+        </div>
+        {/* Data rows */}
+        {Array.from({ length: 10 }, (_, i) => (
+          <div
+            key={i}
+            className="flex h-12 items-center gap-4 border-b border-slate-100 px-4 last:border-b-0">
+            <div className="h-4 w-4 rounded bg-slate-200" />
+            <div className="h-4 w-24 animate-pulse rounded bg-slate-200" />
+            <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
+            <div className="h-4 w-40 animate-pulse rounded bg-slate-200" />
+            <div className="h-4 w-40 animate-pulse rounded bg-slate-200" />
+            <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
+          </div>
+        ))}
+      </div>
+    </PageContentWrapper>
+  );
+};
+
+export default Loading;

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/loading.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/loading.tsx
@@ -3,6 +3,7 @@
 import { useTranslation } from "react-i18next";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
+import { SkeletonLoader } from "@/modules/ui/components/skeleton-loader";
 
 const Loading = () => {
   const { t } = useTranslation();
@@ -10,44 +11,11 @@ const Loading = () => {
   return (
     <PageContentWrapper>
       <PageHeader pageTitle={t("common.responses")} />
-      {/* Filter bar placeholder */}
       <div className="flex h-9 animate-pulse gap-1.5">
         <div className="h-9 w-36 rounded-full bg-slate-200" />
         <div className="h-9 w-36 rounded-full bg-slate-200" />
       </div>
-      {/* Toolbar placeholder */}
-      <div className="flex animate-pulse items-center justify-between py-2">
-        <div className="h-8 w-48 rounded-md bg-slate-200" />
-        <div className="flex gap-2">
-          <div className="h-8 w-8 rounded-md bg-slate-200" />
-          <div className="h-8 w-8 rounded-md bg-slate-200" />
-        </div>
-      </div>
-      {/* Table skeleton */}
-      <div className="overflow-hidden rounded-xl border border-slate-200">
-        {/* Header row */}
-        <div className="flex h-12 items-center gap-4 border-b border-slate-200 bg-slate-100 px-4">
-          <div className="h-4 w-4 rounded bg-slate-200" />
-          <div className="h-4 w-24 animate-pulse rounded bg-slate-200" />
-          <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
-          <div className="h-4 w-40 animate-pulse rounded bg-slate-200" />
-          <div className="h-4 w-40 animate-pulse rounded bg-slate-200" />
-          <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
-        </div>
-        {/* Data rows */}
-        {Array.from({ length: 10 }, (_, i) => (
-          <div
-            key={i}
-            className="flex h-12 items-center gap-4 border-b border-slate-100 px-4 last:border-b-0">
-            <div className="h-4 w-4 rounded bg-slate-200" />
-            <div className="h-4 w-24 animate-pulse rounded bg-slate-200" />
-            <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
-            <div className="h-4 w-40 animate-pulse rounded bg-slate-200" />
-            <div className="h-4 w-40 animate-pulse rounded bg-slate-200" />
-            <div className="h-4 w-32 animate-pulse rounded bg-slate-200" />
-          </div>
-        ))}
-      </div>
+      <SkeletonLoader type="responseTable" />
     </PageContentWrapper>
   );
 };

--- a/apps/web/modules/ui/components/skeleton-loader/index.tsx
+++ b/apps/web/modules/ui/components/skeleton-loader/index.tsx
@@ -1,7 +1,7 @@
 import { Skeleton } from "@/modules/ui/components/skeleton";
 
 type SkeletonLoaderProps = {
-  type: "response" | "summary";
+  type: "response" | "responseTable" | "summary";
 };
 
 export const SkeletonLoader = ({ type }: SkeletonLoaderProps) => {
@@ -21,6 +21,46 @@ export const SkeletonLoader = ({ type }: SkeletonLoaderProps) => {
             <div className="h-12 w-full rounded-full bg-slate-200"></div>
           </div>
         </Skeleton>
+      </div>
+    );
+  }
+
+  if (type === "responseTable") {
+    const row = (
+      <div className="flex h-12 items-center gap-4 border-b border-slate-100 px-4 last:border-b-0">
+        <Skeleton className="h-4 w-4 rounded bg-slate-200" />
+        <Skeleton className="h-4 w-24 rounded bg-slate-200" />
+        <Skeleton className="h-4 w-32 rounded bg-slate-200" />
+        <Skeleton className="h-4 w-40 rounded bg-slate-200" />
+        <Skeleton className="h-4 w-40 rounded bg-slate-200" />
+        <Skeleton className="h-4 w-32 rounded bg-slate-200" />
+      </div>
+    );
+
+    return (
+      <div data-testid="skeleton-loader-response-table">
+        {/* Toolbar placeholder */}
+        <div className="flex items-center justify-between py-2">
+          <Skeleton className="h-8 w-48 rounded-md bg-slate-200" />
+          <div className="flex gap-2">
+            <Skeleton className="h-8 w-8 rounded-md bg-slate-200" />
+            <Skeleton className="h-8 w-8 rounded-md bg-slate-200" />
+          </div>
+        </div>
+        {/* Table */}
+        <div className="overflow-hidden rounded-xl border border-slate-200">
+          <div className="flex h-12 items-center gap-4 border-b border-slate-200 bg-slate-100 px-4">
+            <Skeleton className="h-4 w-4 rounded bg-slate-200" />
+            <Skeleton className="h-4 w-24 rounded bg-slate-200" />
+            <Skeleton className="h-4 w-32 rounded bg-slate-200" />
+            <Skeleton className="h-4 w-40 rounded bg-slate-200" />
+            <Skeleton className="h-4 w-40 rounded bg-slate-200" />
+            <Skeleton className="h-4 w-32 rounded bg-slate-200" />
+          </div>
+          {Array.from({ length: 10 }, (_, i) => (
+            <div key={i}>{row}</div>
+          ))}
+        </div>
       </div>
     );
   }

--- a/apps/web/modules/ui/components/skeleton-loader/index.tsx
+++ b/apps/web/modules/ui/components/skeleton-loader/index.tsx
@@ -28,22 +28,22 @@ export const SkeletonLoader = ({ type }: SkeletonLoaderProps) => {
   if (type === "responseTable") {
     const renderTableCells = () => (
       <>
-        <div className="h-4 w-4 rounded-xl bg-slate-400" />
-        <div className="h-4 w-24 rounded-xl bg-slate-200" />
-        <div className="h-4 w-32 rounded-xl bg-slate-200" />
-        <div className="h-4 w-40 rounded-xl bg-slate-200" />
-        <div className="h-4 w-40 rounded-xl bg-slate-200" />
-        <div className="h-4 w-32 rounded-xl bg-slate-200" />
+        <Skeleton className="h-4 w-4 rounded-xl bg-slate-400" />
+        <Skeleton className="h-4 w-24 rounded-xl bg-slate-200" />
+        <Skeleton className="h-4 w-32 rounded-xl bg-slate-200" />
+        <Skeleton className="h-4 w-40 rounded-xl bg-slate-200" />
+        <Skeleton className="h-4 w-40 rounded-xl bg-slate-200" />
+        <Skeleton className="h-4 w-32 rounded-xl bg-slate-200" />
       </>
     );
 
     return (
       <div className="animate-pulse space-y-4" data-testid="skeleton-loader-response-table">
         <div className="flex items-center justify-between">
-          <div className="h-8 w-48 rounded-md bg-slate-300" />
+          <Skeleton className="h-8 w-48 rounded-md bg-slate-300" />
           <div className="flex gap-2">
-            <div className="h-8 w-8 rounded-md bg-slate-300" />
-            <div className="h-8 w-8 rounded-md bg-slate-300" />
+            <Skeleton className="h-8 w-8 rounded-md bg-slate-300" />
+            <Skeleton className="h-8 w-8 rounded-md bg-slate-300" />
           </div>
         </div>
         <div className="overflow-hidden rounded-xl border border-slate-200">

--- a/apps/web/modules/ui/components/skeleton-loader/index.tsx
+++ b/apps/web/modules/ui/components/skeleton-loader/index.tsx
@@ -26,39 +26,36 @@ export const SkeletonLoader = ({ type }: SkeletonLoaderProps) => {
   }
 
   if (type === "responseTable") {
-    const row = (
-      <div className="flex h-12 items-center gap-4 border-b border-slate-100 px-4 last:border-b-0">
-        <Skeleton className="h-4 w-4 rounded bg-slate-200" />
-        <Skeleton className="h-4 w-24 rounded bg-slate-200" />
-        <Skeleton className="h-4 w-32 rounded bg-slate-200" />
-        <Skeleton className="h-4 w-40 rounded bg-slate-200" />
-        <Skeleton className="h-4 w-40 rounded bg-slate-200" />
-        <Skeleton className="h-4 w-32 rounded bg-slate-200" />
-      </div>
+    const renderTableCells = () => (
+      <>
+        <div className="h-4 w-4 rounded-xl bg-slate-400" />
+        <div className="h-4 w-24 rounded-xl bg-slate-200" />
+        <div className="h-4 w-32 rounded-xl bg-slate-200" />
+        <div className="h-4 w-40 rounded-xl bg-slate-200" />
+        <div className="h-4 w-40 rounded-xl bg-slate-200" />
+        <div className="h-4 w-32 rounded-xl bg-slate-200" />
+      </>
     );
 
     return (
-      <div data-testid="skeleton-loader-response-table">
-        {/* Toolbar placeholder */}
-        <div className="flex items-center justify-between py-2">
-          <Skeleton className="h-8 w-48 rounded-md bg-slate-200" />
+      <div className="animate-pulse space-y-4" data-testid="skeleton-loader-response-table">
+        <div className="flex items-center justify-between">
+          <div className="h-8 w-48 rounded-md bg-slate-300" />
           <div className="flex gap-2">
-            <Skeleton className="h-8 w-8 rounded-md bg-slate-200" />
-            <Skeleton className="h-8 w-8 rounded-md bg-slate-200" />
+            <div className="h-8 w-8 rounded-md bg-slate-300" />
+            <div className="h-8 w-8 rounded-md bg-slate-300" />
           </div>
         </div>
-        {/* Table */}
         <div className="overflow-hidden rounded-xl border border-slate-200">
           <div className="flex h-12 items-center gap-4 border-b border-slate-200 bg-slate-100 px-4">
-            <Skeleton className="h-4 w-4 rounded bg-slate-200" />
-            <Skeleton className="h-4 w-24 rounded bg-slate-200" />
-            <Skeleton className="h-4 w-32 rounded bg-slate-200" />
-            <Skeleton className="h-4 w-40 rounded bg-slate-200" />
-            <Skeleton className="h-4 w-40 rounded bg-slate-200" />
-            <Skeleton className="h-4 w-32 rounded bg-slate-200" />
+            {renderTableCells()}
           </div>
           {Array.from({ length: 10 }, (_, i) => (
-            <div key={i}>{row}</div>
+            <div
+              key={i}
+              className="flex h-12 items-center gap-4 border-b border-slate-100 px-4 last:border-b-0">
+              {renderTableCells()}
+            </div>
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- The responses page had no `loading.tsx`, so Next.js fell back to the nearest ancestor — the **survey list** loading skeleton — showing the wrong UI during page transitions.
- Adds a dedicated loading skeleton that matches the response table layout (filter bar, toolbar, table with 10 shimmer rows).

## Test plan
- [ ] Navigate to a survey's responses tab and verify the table skeleton appears (not the survey list cards)
- [ ] Hard-refresh the responses page and confirm the skeleton renders correctly
- [ ] Navigate between summary and responses tabs to verify smooth loading transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)