### PR TITLE
chore: Harden SSO account linking for existing email-based accounts

### DIFF
--- a/apps/web/app/api/auth/[...nextauth]/route.test.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { GET } from "./route";
 
+type WrappedAuthOptions = {
+  callbacks: {
+    signIn: (params: { user: unknown; account: unknown }) => Promise<boolean | string>;
+  };
+  events: {
+    signIn: (params: { user: unknown; account: unknown; isNewUser: boolean }) => Promise<void>;
+  };
+};
+
 const mocks = vi.hoisted(() => {
   const nextAuthHandler = vi.fn(async () => new Response(null, { status: 200 }));
-  const nextAuth = vi.fn(() => nextAuthHandler);
+  const nextAuth = vi.fn((_authOptions: WrappedAuthOptions) => nextAuthHandler);
 
   return {
     nextAuth,
@@ -54,7 +63,7 @@ vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
   queueAuditEventBackground: mocks.queueAuditEventBackground,
 }));
 
-const getWrappedAuthOptions = async (requestId: string = "req-123") => {
+const getWrappedAuthOptions = async (requestId: string = "req-123"): Promise<WrappedAuthOptions> => {
   const request = new Request("http://localhost/api/auth/signin", {
     headers: { "x-request-id": requestId },
   });
@@ -63,7 +72,17 @@ const getWrappedAuthOptions = async (requestId: string = "req-123") => {
 
   expect(mocks.nextAuth).toHaveBeenCalledTimes(1);
 
-  return mocks.nextAuth.mock.calls[0][0];
+  const firstCall = mocks.nextAuth.mock.calls.at(0);
+  if (!firstCall) {
+    throw new Error("NextAuth was not called");
+  }
+
+  const [authOptions] = firstCall;
+  if (!authOptions) {
+    throw new Error("NextAuth options were not provided");
+  }
+
+  return authOptions;
 };
 
 describe("auth route audit logging", () => {

--- a/apps/web/app/api/auth/[...nextauth]/route.test.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.test.ts
@@ -136,4 +136,34 @@ describe("auth route audit logging", () => {
       })
     );
   });
+
+  test("logs blocked SSO account-linking attempts as SSO failures", async () => {
+    const error = new Error("OAuthAccountNotLinked");
+    mocks.baseSignIn.mockRejectedValueOnce(error);
+
+    const authOptions = await getWrappedAuthOptions("req-sso-failure");
+    const user = { id: "user_3", email: "user3@example.com" };
+    const account = { provider: "google" };
+
+    await expect(authOptions.callbacks.signIn({ user, account })).rejects.toThrow("OAuthAccountNotLinked");
+
+    expect(mocks.queueAuditEventBackground).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "signedIn",
+        targetType: "user",
+        userId: "user_3",
+        targetId: "user_3",
+        organizationId: "unknown",
+        status: "failure",
+        userType: "user",
+        eventId: "req-sso-failure",
+        newObject: expect.objectContaining({
+          email: "user3@example.com",
+          authMethod: "sso",
+          provider: "google",
+          errorMessage: "OAuthAccountNotLinked",
+        }),
+      })
+    );
+  });
 });

--- a/apps/web/lib/account/service.ts
+++ b/apps/web/lib/account/service.ts
@@ -1,8 +1,12 @@
-import { Prisma } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { prisma } from "@formbricks/database";
 import { TAccount, TAccountInput, ZAccountInput } from "@formbricks/types/account";
 import { DatabaseError } from "@formbricks/types/errors";
 import { validateInputs } from "../utils/validate";
+
+type TAccountDbClient = PrismaClient | Prisma.TransactionClient;
+
+const getDbClient = (tx?: Prisma.TransactionClient): TAccountDbClient => tx ?? prisma;
 
 export const createAccount = async (accountData: TAccountInput): Promise<TAccount> => {
   validateInputs([accountData, ZAccountInput]);
@@ -21,7 +25,10 @@ export const createAccount = async (accountData: TAccountInput): Promise<TAccoun
   }
 };
 
-export const upsertAccount = async (accountData: TAccountInput): Promise<TAccount> => {
+export const upsertAccount = async (
+  accountData: TAccountInput,
+  tx?: Prisma.TransactionClient
+): Promise<TAccount> => {
   const [validatedAccountData] = validateInputs([accountData, ZAccountInput]);
   const updateAccountData: Omit<TAccountInput, "userId" | "type" | "provider" | "providerAccountId"> = {
     access_token: validatedAccountData.access_token,
@@ -33,7 +40,7 @@ export const upsertAccount = async (accountData: TAccountInput): Promise<TAccoun
   };
 
   try {
-    const account = await prisma.account.upsert({
+    const account = await getDbClient(tx).account.upsert({
       where: {
         provider_providerAccountId: {
           provider: validatedAccountData.provider,

--- a/apps/web/lib/membership/service.test.ts
+++ b/apps/web/lib/membership/service.test.ts
@@ -68,6 +68,33 @@ describe("Membership Service", () => {
 
       await expect(getMembershipByUserIdOrganizationId(mockUserId, mockOrgId)).rejects.toThrow(UnknownError);
     });
+
+    test("uses the transaction client directly when provided", async () => {
+      const mockMembership: TMembership = {
+        organizationId: mockOrgId,
+        userId: mockUserId,
+        accepted: true,
+        role: "owner",
+      };
+      const tx = {
+        membership: {
+          findUnique: vi.fn().mockResolvedValue(mockMembership),
+        },
+      } as any;
+
+      const result = await getMembershipByUserIdOrganizationId(mockUserId, mockOrgId, tx);
+
+      expect(result).toEqual(mockMembership);
+      expect(tx.membership.findUnique).toHaveBeenCalledWith({
+        where: {
+          userId_organizationId: {
+            userId: mockUserId,
+            organizationId: mockOrgId,
+          },
+        },
+      });
+      expect(prisma.membership.findUnique).not.toHaveBeenCalled();
+    });
   });
 
   describe("createMembership", () => {

--- a/apps/web/lib/membership/service.ts
+++ b/apps/web/lib/membership/service.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { Prisma } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { cache as reactCache } from "react";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
@@ -8,12 +8,20 @@ import { DatabaseError, UnknownError } from "@formbricks/types/errors";
 import { TMembership, ZMembership } from "@formbricks/types/memberships";
 import { validateInputs } from "../utils/validate";
 
+type TMembershipDbClient = PrismaClient | Prisma.TransactionClient;
+
+const getDbClient = (tx?: Prisma.TransactionClient): TMembershipDbClient => tx ?? prisma;
+
 export const getMembershipByUserIdOrganizationId = reactCache(
-  async (userId: string, organizationId: string): Promise<TMembership | null> => {
+  async (
+    userId: string,
+    organizationId: string,
+    tx?: Prisma.TransactionClient
+  ): Promise<TMembership | null> => {
     validateInputs([userId, ZString], [organizationId, ZString]);
 
     try {
-      const membership = await prisma.membership.findUnique({
+      const membership = await getDbClient(tx).membership.findUnique({
         where: {
           userId_organizationId: {
             userId,
@@ -39,12 +47,14 @@ export const getMembershipByUserIdOrganizationId = reactCache(
 export const createMembership = async (
   organizationId: string,
   userId: string,
-  data: Partial<TMembership>
+  data: Partial<TMembership>,
+  tx?: Prisma.TransactionClient
 ): Promise<TMembership> => {
   validateInputs([organizationId, ZString], [userId, ZString], [data, ZMembership.partial()]);
 
   try {
-    const existingMembership = await prisma.membership.findUnique({
+    const prismaClient = getDbClient(tx);
+    const existingMembership = await prismaClient.membership.findUnique({
       where: {
         userId_organizationId: {
           userId,
@@ -59,7 +69,7 @@ export const createMembership = async (
 
     let membership: TMembership;
     if (!existingMembership) {
-      membership = await prisma.membership.create({
+      membership = await prismaClient.membership.create({
         data: {
           userId,
           organizationId,
@@ -68,7 +78,7 @@ export const createMembership = async (
         },
       });
     } else {
-      membership = await prisma.membership.update({
+      membership = await prismaClient.membership.update({
         where: {
           userId_organizationId: {
             userId,

--- a/apps/web/lib/membership/service.ts
+++ b/apps/web/lib/membership/service.ts
@@ -12,37 +12,51 @@ type TMembershipDbClient = PrismaClient | Prisma.TransactionClient;
 
 const getDbClient = (tx?: Prisma.TransactionClient): TMembershipDbClient => tx ?? prisma;
 
-export const getMembershipByUserIdOrganizationId = reactCache(
-  async (
-    userId: string,
-    organizationId: string,
-    tx?: Prisma.TransactionClient
-  ): Promise<TMembership | null> => {
-    validateInputs([userId, ZString], [organizationId, ZString]);
+const getMembershipByUserIdOrganizationIdUncached = async (
+  userId: string,
+  organizationId: string,
+  tx?: Prisma.TransactionClient
+): Promise<TMembership | null> => {
+  validateInputs([userId, ZString], [organizationId, ZString]);
 
-    try {
-      const membership = await getDbClient(tx).membership.findUnique({
-        where: {
-          userId_organizationId: {
-            userId,
-            organizationId,
-          },
+  try {
+    const membership = await getDbClient(tx).membership.findUnique({
+      where: {
+        userId_organizationId: {
+          userId,
+          organizationId,
         },
-      });
+      },
+    });
 
-      if (!membership) return null;
+    if (!membership) return null;
 
-      return membership;
-    } catch (error) {
-      if (error instanceof Prisma.PrismaClientKnownRequestError) {
-        logger.error(error, "Error getting membership by user id and organization id");
-        throw new DatabaseError(error.message);
-      }
-
-      throw new UnknownError("Error while fetching membership");
+    return membership;
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      logger.error(error, "Error getting membership by user id and organization id");
+      throw new DatabaseError(error.message);
     }
+
+    throw new UnknownError("Error while fetching membership");
   }
+};
+
+const getMembershipByUserIdOrganizationIdCached = reactCache(async (userId: string, organizationId: string) =>
+  getMembershipByUserIdOrganizationIdUncached(userId, organizationId)
 );
+
+export const getMembershipByUserIdOrganizationId = async (
+  userId: string,
+  organizationId: string,
+  tx?: Prisma.TransactionClient
+): Promise<TMembership | null> => {
+  if (tx) {
+    return getMembershipByUserIdOrganizationIdUncached(userId, organizationId, tx);
+  }
+
+  return getMembershipByUserIdOrganizationIdCached(userId, organizationId);
+};
 
 export const createMembership = async (
   organizationId: string,

--- a/apps/web/lib/utils/url.test.ts
+++ b/apps/web/lib/utils/url.test.ts
@@ -1,7 +1,7 @@
 import { cleanup } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "vitest";
 import { TActionClassPageUrlRule } from "@formbricks/types/action-classes";
-import { isStringUrl, isValidCallbackUrl, testURLmatch } from "./url";
+import { getValidatedCallbackUrl, isStringUrl, testURLmatch } from "./url";
 
 afterEach(() => {
   cleanup();
@@ -72,23 +72,25 @@ describe("testURLmatch", () => {
   });
 });
 
-describe("isValidCallbackUrl", () => {
+describe("getValidatedCallbackUrl", () => {
   const WEBAPP_URL = "https://webapp.example.com";
 
-  test("returns true for valid callback URL", () => {
-    expect(isValidCallbackUrl("https://webapp.example.com/callback", WEBAPP_URL)).toBe(true);
+  test("returns the normalized callback URL for a valid callback", () => {
+    expect(getValidatedCallbackUrl("https://webapp.example.com/callback", WEBAPP_URL)).toBe(
+      "https://webapp.example.com/callback"
+    );
   });
 
-  test("returns false for invalid scheme", () => {
-    expect(isValidCallbackUrl("ftp://webapp.example.com/callback", WEBAPP_URL)).toBe(false);
+  test("returns null for invalid scheme", () => {
+    expect(getValidatedCallbackUrl("ftp://webapp.example.com/callback", WEBAPP_URL)).toBeNull();
   });
 
-  test("returns false for invalid domain", () => {
-    expect(isValidCallbackUrl("https://malicious.com/callback", WEBAPP_URL)).toBe(false);
+  test("returns null for invalid domain", () => {
+    expect(getValidatedCallbackUrl("https://malicious.com/callback", WEBAPP_URL)).toBeNull();
   });
 
-  test("returns false for malformed URL", () => {
-    expect(isValidCallbackUrl("not-a-valid-url", WEBAPP_URL)).toBe(false);
+  test("returns null for malformed URL", () => {
+    expect(getValidatedCallbackUrl("not-a-valid-url", WEBAPP_URL)).toBeNull();
   });
 });
 

--- a/apps/web/lib/utils/url.ts
+++ b/apps/web/lib/utils/url.ts
@@ -35,20 +35,40 @@ export const testURLmatch = (
 };
 
 // Helper function to validate callback URLs
-export const isValidCallbackUrl = (url: string, WEBAPP_URL: string): boolean => {
+export const getValidatedCallbackUrl = (
+  url: string | null | undefined,
+  WEBAPP_URL: string
+): string | null => {
+  if (!url) {
+    return null;
+  }
+
   try {
-    const parsedUrl = new URL(url);
-    const allowedSchemes = ["https:", "http:"];
-
-    // Extract the domain from WEBAPP_URL
     const parsedWebAppUrl = new URL(WEBAPP_URL);
-    const allowedDomains = [parsedWebAppUrl.hostname];
+    const parsedUrl = new URL(url, parsedWebAppUrl.origin);
+    const allowedSchemes = ["https:", "http:"];
+    const allowedOrigins = new Set([parsedWebAppUrl.origin]);
 
-    return allowedSchemes.includes(parsedUrl.protocol) && allowedDomains.includes(parsedUrl.hostname);
-  } catch (err) {
-    return false;
+    if (!allowedSchemes.includes(parsedUrl.protocol)) {
+      return null;
+    }
+
+    if (!allowedOrigins.has(parsedUrl.origin)) {
+      return null;
+    }
+
+    if (parsedUrl.username || parsedUrl.password) {
+      return null;
+    }
+
+    return parsedUrl.toString();
+  } catch {
+    return null;
   }
 };
+
+export const isValidCallbackUrl = (url: string, WEBAPP_URL: string): boolean =>
+  getValidatedCallbackUrl(url, WEBAPP_URL) !== null;
 
 export const isStringUrl = (url: string): boolean => {
   try {

--- a/apps/web/lib/utils/url.ts
+++ b/apps/web/lib/utils/url.ts
@@ -45,7 +45,15 @@ export const getValidatedCallbackUrl = (
 
   try {
     const parsedWebAppUrl = new URL(WEBAPP_URL);
-    const parsedUrl = new URL(url, parsedWebAppUrl.origin);
+    const isAbsoluteUrl = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
+    const isRootRelativePath = url.startsWith("/");
+
+    // Reject ambiguous non-URL values like "foo" while still allowing safe root-relative paths.
+    if (!isAbsoluteUrl && !isRootRelativePath) {
+      return null;
+    }
+
+    const parsedUrl = isAbsoluteUrl ? new URL(url) : new URL(url, parsedWebAppUrl.origin);
     const allowedSchemes = ["https:", "http:"];
     const allowedOrigins = new Set([parsedWebAppUrl.origin]);
 

--- a/apps/web/lib/utils/url.ts
+++ b/apps/web/lib/utils/url.ts
@@ -75,9 +75,6 @@ export const getValidatedCallbackUrl = (
   }
 };
 
-export const isValidCallbackUrl = (url: string, WEBAPP_URL: string): boolean =>
-  getValidatedCallbackUrl(url, WEBAPP_URL) !== null;
-
 export const isStringUrl = (url: string): boolean => {
   try {
     new URL(url);

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -63,6 +63,8 @@
       "login_with_email": "Mit E-Mail einloggen",
       "lost_access": "Zugang verloren?",
       "new_to_formbricks": "Neu bei Formbricks?",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "Einen Backup-Code verwenden"
     },
     "saml_connection_error": "Etwas ist schiefgelaufen. Bitte überprüfe die App-Konsole für weitere Details.",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -63,6 +63,8 @@
       "login_with_email": "Login with Email",
       "lost_access": "Lost Access?",
       "new_to_formbricks": "New to Formbricks?",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "Use a backup code"
     },
     "saml_connection_error": "Something went wrong. Please check your app console for more details.",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -63,6 +63,8 @@
       "login_with_email": "Iniciar sesión con correo electrónico",
       "lost_access": "¿Has perdido el acceso?",
       "new_to_formbricks": "¿Nuevo en Formbricks?",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "Usar un código de respaldo"
     },
     "saml_connection_error": "Algo salió mal. Por favor, consulta la consola de tu aplicación para más detalles.",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -63,6 +63,8 @@
       "login_with_email": "Se connecter avec un e-mail",
       "lost_access": "Accès perdu ?",
       "new_to_formbricks": "Nouveau sur Formbricks ?",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "Utiliser un code de secours"
     },
     "saml_connection_error": "Quelque chose s'est mal passé. Veuillez vérifier la console de votre application pour plus de détails.",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -63,6 +63,8 @@
       "login_with_email": "Bejelentkezés e-mail-címmel",
       "lost_access": "Elvesztette a hozzáférést?",
       "new_to_formbricks": "Új a Formbicksen?",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "Visszaszerzési kód használata"
     },
     "saml_connection_error": "Valami probléma történt. A további részletekért nézze meg az alkalmazás konzolját.",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -63,6 +63,8 @@
       "login_with_email": "メールアドレスでログイン",
       "lost_access": "アクセスを紛失しましたか？",
       "new_to_formbricks": "Formbricksを初めてご利用ですか？",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "バックアップコードを使用"
     },
     "saml_connection_error": "問題が発生しました。詳細については、アプリのコンソールを確認してください。",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -63,6 +63,8 @@
       "login_with_email": "Inloggen met e-mail",
       "lost_access": "Toegang verloren?",
       "new_to_formbricks": "Nieuw bij Formbricks?",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "Gebruik een back-upcode"
     },
     "saml_connection_error": "Er is iets misgegaan. Controleer uw app-console voor meer details.",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -63,6 +63,8 @@
       "login_with_email": "Entrar com Email",
       "lost_access": "Perdeu o acesso?",
       "new_to_formbricks": "Novo no Formbricks?",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "Usar um código de backup"
     },
     "saml_connection_error": "Algo deu errado. Por favor, verifica o console do app para mais detalhes.",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -63,6 +63,8 @@
       "login_with_email": "Iniciar sessão com Email",
       "lost_access": "Perdeu o acesso?",
       "new_to_formbricks": "Novo no Formbricks?",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "Use um código de backup"
     },
     "saml_connection_error": "Algo correu mal. Por favor, verifique a consola da aplicação para mais detalhes.",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -63,6 +63,8 @@
       "login_with_email": "Autentifică-te cu email",
       "lost_access": "Acces pierdut?",
       "new_to_formbricks": "Nou în Formbricks?",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "Folosiți un cod de rezervă"
     },
     "saml_connection_error": "Ceva nu a mers. Vă rugăm să verificați consola aplicației pentru mai multe detalii.",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -63,6 +63,8 @@
       "login_with_email": "Войти по email",
       "lost_access": "Потеряли доступ?",
       "new_to_formbricks": "Впервые на Formbricks?",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "Использовать резервный код"
     },
     "saml_connection_error": "Что-то пошло не так. Пожалуйста, проверьте консоль приложения для получения подробностей.",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -63,6 +63,8 @@
       "login_with_email": "Logga in med e-post",
       "lost_access": "Förlorad åtkomst?",
       "new_to_formbricks": "Ny på Formbricks?",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "Använd en reservkod"
     },
     "saml_connection_error": "Något gick fel. Kontrollera din appkonsol för mer information.",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -63,6 +63,8 @@
       "login_with_email": "使用 邮箱 登录",
       "lost_access": "失去访问？",
       "new_to_formbricks": "新用户 Formbricks ?",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "使用 备用代码"
     },
     "saml_connection_error": "出了问题。请查看应用 控制台 以获取更多详情。",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -63,6 +63,8 @@
       "login_with_email": "使用電子郵件登入",
       "lost_access": "無法存取？",
       "new_to_formbricks": "初次使用 Formbricks？",
+      "oauth_account_not_linked_description": "This SSO provider is not linked to an existing Formbricks account. Please sign in with the method you used originally. If that was email and password, complete email verification first if you are prompted.",
+      "oauth_account_not_linked_title": "This SSO sign-in could not be linked",
       "use_a_backup_code": "使用備份碼"
     },
     "saml_connection_error": "發生錯誤。請檢查您的 app 主控台以取得更多詳細資料。",

--- a/apps/web/modules/auth/lib/authOptions.test.ts
+++ b/apps/web/modules/auth/lib/authOptions.test.ts
@@ -158,7 +158,7 @@ describe("authOptions", () => {
     });
 
     test("should throw error if user not found", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue(); // Rate limiting passes
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true }); // Rate limiting passes
       vi.spyOn(prisma.user, "findUnique").mockResolvedValue(null);
 
       const credentials = { email: mockUser.email, password: mockPassword };
@@ -169,7 +169,7 @@ describe("authOptions", () => {
     }, 15000);
 
     test("should throw error if user has no password stored", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue(); // Rate limiting passes
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true }); // Rate limiting passes
       vi.spyOn(prisma.user, "findUnique").mockResolvedValue({
         id: mockUser.id,
         email: mockUser.email,
@@ -184,7 +184,7 @@ describe("authOptions", () => {
     }, 15000);
 
     test("should throw error if password verification fails", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue(); // Rate limiting passes
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true }); // Rate limiting passes
       vi.spyOn(prisma.user, "findUnique").mockResolvedValue({
         id: mockUserId,
         email: mockUser.email,
@@ -199,7 +199,7 @@ describe("authOptions", () => {
     }, 15000);
 
     test("should successfully login when credentials are valid", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue(); // Rate limiting passes
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true }); // Rate limiting passes
       const fakeUser = {
         id: mockUserId,
         email: mockUser.email,
@@ -222,7 +222,7 @@ describe("authOptions", () => {
 
     describe("Rate Limiting", () => {
       test("should apply rate limiting before credential validation", async () => {
-        vi.mocked(applyIPRateLimit).mockResolvedValue();
+        vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
         vi.spyOn(prisma.user, "findUnique").mockResolvedValue({
           id: mockUserId,
           email: mockUser.email,
@@ -255,7 +255,7 @@ describe("authOptions", () => {
       });
 
       test("should use correct rate limit configuration", async () => {
-        vi.mocked(applyIPRateLimit).mockResolvedValue();
+        vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
         vi.spyOn(prisma.user, "findUnique").mockResolvedValue({
           id: mockUserId,
           email: mockUser.email,
@@ -278,7 +278,7 @@ describe("authOptions", () => {
 
     describe("Two-Factor Backup Code login", () => {
       test("should throw error if backup codes are missing", async () => {
-        vi.mocked(applyIPRateLimit).mockResolvedValue(); // Rate limiting passes
+        vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true }); // Rate limiting passes
         const mockUser = {
           id: mockUserId,
           email: "2fa@example.com",
@@ -307,7 +307,7 @@ describe("authOptions", () => {
     });
 
     test("should throw error if token is invalid or user not found", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue(); // Rate limiting passes
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true }); // Rate limiting passes
       const credentials = { token: "badtoken" };
 
       await expect(tokenProvider.options.authorize(credentials, {})).rejects.toThrow(
@@ -317,7 +317,7 @@ describe("authOptions", () => {
 
     describe("Rate Limiting", () => {
       test("should apply rate limiting before token verification", async () => {
-        vi.mocked(applyIPRateLimit).mockResolvedValue();
+        vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
 
         const credentials = { token: "sometoken" };
 
@@ -495,7 +495,7 @@ describe("authOptions", () => {
     const credentialsProvider = getProviderById("credentials");
 
     test("should throw error if TOTP code is missing when 2FA is enabled", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue(); // Rate limiting passes
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true }); // Rate limiting passes
       const mockUser = {
         id: mockUserId,
         email: "2fa@example.com",
@@ -513,7 +513,7 @@ describe("authOptions", () => {
     });
 
     test("should throw error if two factor secret is missing", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue(); // Rate limiting passes
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true }); // Rate limiting passes
       const mockUser = {
         id: mockUserId,
         email: "2fa@example.com",

--- a/apps/web/modules/auth/lib/authOptions.test.ts
+++ b/apps/web/modules/auth/lib/authOptions.test.ts
@@ -166,7 +166,7 @@ describe("authOptions", () => {
       await expect(credentialsProvider.options.authorize(credentials, {})).rejects.toThrow(
         "Invalid credentials"
       );
-    });
+    }, 15000);
 
     test("should throw error if user has no password stored", async () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(); // Rate limiting passes
@@ -181,7 +181,7 @@ describe("authOptions", () => {
       await expect(credentialsProvider.options.authorize(credentials, {})).rejects.toThrow(
         "User has no password stored"
       );
-    });
+    }, 15000);
 
     test("should throw error if password verification fails", async () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(); // Rate limiting passes
@@ -196,7 +196,7 @@ describe("authOptions", () => {
       await expect(credentialsProvider.options.authorize(credentials, {})).rejects.toThrow(
         "Invalid credentials"
       );
-    });
+    }, 15000);
 
     test("should successfully login when credentials are valid", async () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue(); // Rate limiting passes
@@ -218,7 +218,7 @@ describe("authOptions", () => {
         email: fakeUser.email,
         emailVerified: fakeUser.emailVerified,
       });
-    });
+    }, 15000);
 
     describe("Rate Limiting", () => {
       test("should apply rate limiting before credential validation", async () => {
@@ -432,6 +432,62 @@ describe("authOptions", () => {
           expect(capturePostHogEvent).not.toHaveBeenCalled();
         }
       });
+    });
+  });
+
+  describe("Enterprise SSO signIn callback", () => {
+    test("should not update lastLoginAt when SSO sign-in is denied", async () => {
+      vi.resetModules();
+
+      const mockHandleSsoCallback = vi.fn().mockRejectedValueOnce(new Error("OAuthAccountNotLinked"));
+      const mockUpdateUserLastLoginAt = vi.fn();
+      const mockCapturePostHogEvent = vi.fn();
+
+      vi.doMock("@/lib/constants", async (importOriginal) => {
+        const actual = await importOriginal<typeof import("@/lib/constants")>();
+        return {
+          ...actual,
+          EMAIL_VERIFICATION_DISABLED: false,
+          SESSION_MAX_AGE: 86400,
+          NEXTAUTH_SECRET: "test-secret",
+          WEBAPP_URL: "http://localhost:3000",
+          ENCRYPTION_KEY: "12345678901234567890123456789012",
+          REDIS_URL: undefined,
+          AUDIT_LOG_ENABLED: false,
+          AUDIT_LOG_GET_USER_IP: false,
+          ENTERPRISE_LICENSE_KEY: "test-enterprise-license",
+          SENTRY_DSN: undefined,
+          BREVO_API_KEY: undefined,
+          RATE_LIMITING_DISABLED: false,
+          CONTROL_HASH: "$2b$12$fzHf9le13Ss9UJ04xzmsjODXpFJxz6vsnupoepF5FiqDECkX2BH5q",
+          POSTHOG_KEY: "phc_test_key",
+        };
+      });
+      vi.doMock("@/modules/ee/sso/lib/providers", () => ({
+        getSSOProviders: vi.fn(() => []),
+      }));
+      vi.doMock("@/modules/ee/sso/lib/sso-handlers", () => ({
+        handleSsoCallback: mockHandleSsoCallback,
+      }));
+      vi.doMock("@/modules/auth/lib/user", () => ({
+        updateUser: vi.fn(),
+        updateUserLastLoginAt: mockUpdateUserLastLoginAt,
+      }));
+      vi.doMock("@/lib/posthog", () => ({
+        capturePostHogEvent: mockCapturePostHogEvent,
+      }));
+
+      const { authOptions: enterpriseAuthOptions } = await import("./authOptions");
+      const user = { ...mockUser, emailVerified: new Date() };
+      const account = { provider: "google", type: "oauth", providerAccountId: "provider-123" } as any;
+
+      await expect(enterpriseAuthOptions.callbacks?.signIn?.({ user, account } as any)).rejects.toThrow(
+        "OAuthAccountNotLinked"
+      );
+
+      expect(mockHandleSsoCallback).toHaveBeenCalled();
+      expect(mockUpdateUserLastLoginAt).not.toHaveBeenCalled();
+      expect(mockCapturePostHogEvent).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/modules/auth/lib/authOptions.ts
+++ b/apps/web/modules/auth/lib/authOptions.ts
@@ -12,10 +12,13 @@ import {
   ENTERPRISE_LICENSE_KEY,
   POSTHOG_KEY,
   SESSION_MAX_AGE,
+  WEBAPP_URL,
 } from "@/lib/constants";
 import { symmetricDecrypt, symmetricEncrypt } from "@/lib/crypto";
 import { verifyToken } from "@/lib/jwt";
 import { capturePostHogEvent } from "@/lib/posthog";
+import { getValidatedCallbackUrl } from "@/lib/utils/url";
+import { getAuthCallbackUrlFromCookies } from "@/modules/auth/lib/callback-url";
 import { updateUser, updateUserLastLoginAt } from "@/modules/auth/lib/user";
 import {
   logAuthAttempt,
@@ -332,9 +335,7 @@ export const authOptions: NextAuthOptions = {
 
       // get callback url from the cookie store,
       const callbackUrl =
-        cookieStore.get("__Secure-next-auth.callback-url")?.value ||
-        cookieStore.get("next-auth.callback-url")?.value ||
-        "";
+        getValidatedCallbackUrl(getAuthCallbackUrlFromCookies(cookieStore), WEBAPP_URL) ?? "";
 
       const userEmail = user.email ?? "";
       const userId = user.id as string;

--- a/apps/web/modules/auth/lib/callback-url.test.ts
+++ b/apps/web/modules/auth/lib/callback-url.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+import {
+  getAuthCallbackUrlFromCookies,
+  getInviteTokenFromCallbackUrl,
+  getRelativeCallbackUrl,
+  resolveAuthCallbackUrl,
+} from "./callback-url";
+
+const WEBAPP_URL = "http://localhost:3000";
+
+describe("auth callback URL helpers", () => {
+  test("prefers a valid callback URL from search params over the cookie", () => {
+    const result = resolveAuthCallbackUrl({
+      searchParamCallbackUrl: "http://localhost:3000/invite?token=search-token",
+      cookieCallbackUrl: "http://localhost:3000/invite?token=cookie-token",
+      webAppUrl: WEBAPP_URL,
+    });
+
+    expect(result).toBe("http://localhost:3000/invite?token=search-token");
+  });
+
+  test("falls back to the callback URL cookie when the query string only contains an auth error", () => {
+    const result = resolveAuthCallbackUrl({
+      searchParamCallbackUrl: undefined,
+      cookieCallbackUrl: "http://localhost:3000/invite?token=cookie-token&source=signin",
+      webAppUrl: WEBAPP_URL,
+    });
+
+    expect(result).toBe("http://localhost:3000/invite?token=cookie-token&source=signin");
+  });
+
+  test("rejects callback URLs on a different origin", () => {
+    const result = resolveAuthCallbackUrl({
+      searchParamCallbackUrl: "https://evil.example/invite?token=bad",
+      cookieCallbackUrl: "https://evil.example/fallback",
+      webAppUrl: WEBAPP_URL,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("returns a relative callback path for in-app navigation", () => {
+    const result = getRelativeCallbackUrl(
+      "http://localhost:3000/invite?token=abc123&source=signin",
+      WEBAPP_URL
+    );
+
+    expect(result).toBe("/invite?token=abc123&source=signin");
+  });
+
+  test("extracts invite tokens from validated callback URLs", () => {
+    const result = getInviteTokenFromCallbackUrl(
+      "http://localhost:3000/invite?token=abc123&source=signin",
+      WEBAPP_URL
+    );
+
+    expect(result).toBe("abc123");
+  });
+
+  test("reads the Auth.js callback URL from the secure cookie first", () => {
+    const result = getAuthCallbackUrlFromCookies({
+      get: (name: string) => {
+        if (name === "__Secure-next-auth.callback-url") {
+          return { value: "http://localhost:3000/invite?token=secure" };
+        }
+
+        return undefined;
+      },
+    });
+
+    expect(result).toBe("http://localhost:3000/invite?token=secure");
+  });
+});

--- a/apps/web/modules/auth/lib/callback-url.test.ts
+++ b/apps/web/modules/auth/lib/callback-url.test.ts
@@ -23,10 +23,21 @@ describe("auth callback URL helpers", () => {
     const result = resolveAuthCallbackUrl({
       searchParamCallbackUrl: undefined,
       cookieCallbackUrl: "http://localhost:3000/invite?token=cookie-token&source=signin",
+      allowCookieFallback: true,
       webAppUrl: WEBAPP_URL,
     });
 
     expect(result).toBe("http://localhost:3000/invite?token=cookie-token&source=signin");
+  });
+
+  test("does not fall back to the callback URL cookie unless explicitly allowed", () => {
+    const result = resolveAuthCallbackUrl({
+      searchParamCallbackUrl: undefined,
+      cookieCallbackUrl: "http://localhost:3000/invite?token=cookie-token&source=signin",
+      webAppUrl: WEBAPP_URL,
+    });
+
+    expect(result).toBeNull();
   });
 
   test("rejects callback URLs on a different origin", () => {

--- a/apps/web/modules/auth/lib/callback-url.ts
+++ b/apps/web/modules/auth/lib/callback-url.ts
@@ -32,18 +32,26 @@ export const getAuthCallbackUrlFromCookies = (cookieStore: TCookieStore): string
 export const resolveAuthCallbackUrl = ({
   searchParamCallbackUrl,
   cookieCallbackUrl,
+  allowCookieFallback = false,
   webAppUrl,
 }: {
   searchParamCallbackUrl?: string | string[];
   cookieCallbackUrl?: string | null;
+  allowCookieFallback?: boolean;
   webAppUrl: string;
 }): string | null => {
   const callbackUrlFromSearchParams = getSearchParamValue(searchParamCallbackUrl);
+  const validatedSearchParamCallbackUrl = getValidatedCallbackUrl(callbackUrlFromSearchParams, webAppUrl);
 
-  return (
-    getValidatedCallbackUrl(callbackUrlFromSearchParams, webAppUrl) ??
-    getValidatedCallbackUrl(cookieCallbackUrl, webAppUrl)
-  );
+  if (validatedSearchParamCallbackUrl) {
+    return validatedSearchParamCallbackUrl;
+  }
+
+  if (!allowCookieFallback) {
+    return null;
+  }
+
+  return getValidatedCallbackUrl(cookieCallbackUrl, webAppUrl);
 };
 
 export const getRelativeCallbackUrl = (callbackUrl: string | null | undefined, webAppUrl: string): string => {

--- a/apps/web/modules/auth/lib/callback-url.ts
+++ b/apps/web/modules/auth/lib/callback-url.ts
@@ -1,0 +1,75 @@
+import { getValidatedCallbackUrl } from "@/lib/utils/url";
+
+export const AUTH_CALLBACK_URL_COOKIE_NAMES = [
+  "__Secure-next-auth.callback-url",
+  "next-auth.callback-url",
+] as const;
+
+type TCookieStore = {
+  get: (name: string) => { value: string } | undefined;
+};
+
+const getSearchParamValue = (value?: string | string[]): string | null => {
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+
+  return value ?? null;
+};
+
+export const getAuthCallbackUrlFromCookies = (cookieStore: TCookieStore): string | null => {
+  for (const cookieName of AUTH_CALLBACK_URL_COOKIE_NAMES) {
+    const callbackUrl = cookieStore.get(cookieName)?.value;
+
+    if (callbackUrl) {
+      return callbackUrl;
+    }
+  }
+
+  return null;
+};
+
+export const resolveAuthCallbackUrl = ({
+  searchParamCallbackUrl,
+  cookieCallbackUrl,
+  webAppUrl,
+}: {
+  searchParamCallbackUrl?: string | string[];
+  cookieCallbackUrl?: string | null;
+  webAppUrl: string;
+}): string | null => {
+  const callbackUrlFromSearchParams = getSearchParamValue(searchParamCallbackUrl);
+
+  return (
+    getValidatedCallbackUrl(callbackUrlFromSearchParams, webAppUrl) ??
+    getValidatedCallbackUrl(cookieCallbackUrl, webAppUrl)
+  );
+};
+
+export const getRelativeCallbackUrl = (callbackUrl: string | null | undefined, webAppUrl: string): string => {
+  const validatedCallbackUrl = getValidatedCallbackUrl(callbackUrl, webAppUrl);
+
+  if (!validatedCallbackUrl) {
+    return "/";
+  }
+
+  const parsedCallbackUrl = new URL(validatedCallbackUrl);
+  const relativeCallbackUrl = `${parsedCallbackUrl.pathname}${parsedCallbackUrl.search}${parsedCallbackUrl.hash}`;
+
+  return relativeCallbackUrl || "/";
+};
+
+export const getInviteTokenFromCallbackUrl = (
+  callbackUrl: string | null | undefined,
+  webAppUrl: string
+): string | null => {
+  const validatedCallbackUrl = getValidatedCallbackUrl(callbackUrl, webAppUrl);
+
+  if (!validatedCallbackUrl) {
+    return null;
+  }
+
+  return new URL(validatedCallbackUrl).searchParams.get("token");
+};
+
+export const getSearchParamString = (value?: string | string[]): string => getSearchParamValue(value) ?? "";

--- a/apps/web/modules/auth/lib/user.ts
+++ b/apps/web/modules/auth/lib/user.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { cache as reactCache } from "react";
 import { prisma } from "@formbricks/database";
 import { PrismaErrorType } from "@formbricks/database/types/error";
@@ -7,11 +7,15 @@ import { DatabaseError, InvalidInputError, ResourceNotFoundError } from "@formbr
 import { TUserCreateInput, TUserUpdateInput, ZUserEmail, ZUserUpdateInput } from "@formbricks/types/user";
 import { validateInputs } from "@/lib/utils/validate";
 
-export const updateUser = async (id: string, data: TUserUpdateInput) => {
+type TUserDbClient = PrismaClient | Prisma.TransactionClient;
+
+const getDbClient = (tx?: Prisma.TransactionClient): TUserDbClient => tx ?? prisma;
+
+export const updateUser = async (id: string, data: TUserUpdateInput, tx?: Prisma.TransactionClient) => {
   validateInputs([id, ZId], [data, ZUserUpdateInput.partial()]);
 
   try {
-    const updatedUser = await prisma.user.update({
+    const updatedUser = await getDbClient(tx).user.update({
       where: {
         id,
       },
@@ -113,10 +117,10 @@ export const getUser = reactCache(async (id: string) => {
   }
 });
 
-export const createUser = async (data: TUserCreateInput) => {
+export const createUser = async (data: TUserCreateInput, tx?: Prisma.TransactionClient) => {
   validateInputs([data, ZUserUpdateInput]);
   try {
-    const user = await prisma.user.create({
+    const user = await getDbClient(tx).user.create({
       data: data,
       select: {
         name: true,

--- a/apps/web/modules/auth/lib/verification-links.test.ts
+++ b/apps/web/modules/auth/lib/verification-links.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import { buildVerificationLinks, buildVerificationRequestedPath } from "./verification-links";
+
+const WEBAPP_URL = "http://localhost:3000";
+
+describe("verification link helpers", () => {
+  test("builds a verification requested path with token only", () => {
+    expect(buildVerificationRequestedPath({ token: "abc123" })).toBe(
+      "/auth/verification-requested?token=abc123"
+    );
+  });
+
+  test("builds a verification requested path that preserves callback URL", () => {
+    expect(
+      buildVerificationRequestedPath({
+        token: "abc123",
+        callbackUrl: "http://localhost:3000/invite?token=invite-token",
+      })
+    ).toBe(
+      "/auth/verification-requested?token=abc123&callbackUrl=http%3A%2F%2Flocalhost%3A3000%2Finvite%3Ftoken%3Dinvite-token"
+    );
+  });
+
+  test("builds absolute verification links that preserve a valid callback URL", () => {
+    expect(
+      buildVerificationLinks({
+        token: "abc123",
+        webAppUrl: WEBAPP_URL,
+        callbackUrl: "http://localhost:3000/environments/test?foo=bar",
+      })
+    ).toEqual({
+      verificationRequestLink:
+        "http://localhost:3000/auth/verification-requested?token=abc123&callbackUrl=http%3A%2F%2Flocalhost%3A3000%2Fenvironments%2Ftest%3Ffoo%3Dbar",
+      verifyLink:
+        "http://localhost:3000/auth/verify?token=abc123&callbackUrl=http%3A%2F%2Flocalhost%3A3000%2Fenvironments%2Ftest%3Ffoo%3Dbar",
+    });
+  });
+
+  test("drops invalid callback URLs from absolute verification links", () => {
+    expect(
+      buildVerificationLinks({
+        token: "abc123",
+        webAppUrl: WEBAPP_URL,
+        callbackUrl: "https://evil.example/phish",
+      })
+    ).toEqual({
+      verificationRequestLink: "http://localhost:3000/auth/verification-requested?token=abc123",
+      verifyLink: "http://localhost:3000/auth/verify?token=abc123",
+    });
+  });
+});

--- a/apps/web/modules/auth/lib/verification-links.ts
+++ b/apps/web/modules/auth/lib/verification-links.ts
@@ -1,0 +1,47 @@
+import { getValidatedCallbackUrl } from "@/lib/utils/url";
+
+const RELATIVE_URL_BASE = "http://localhost";
+
+export const buildVerificationRequestedPath = ({
+  token,
+  callbackUrl,
+}: {
+  token: string;
+  callbackUrl?: string | null;
+}): string => {
+  const verificationRequestedUrl = new URL("/auth/verification-requested", RELATIVE_URL_BASE);
+  verificationRequestedUrl.searchParams.set("token", token);
+
+  if (callbackUrl) {
+    verificationRequestedUrl.searchParams.set("callbackUrl", callbackUrl);
+  }
+
+  return `${verificationRequestedUrl.pathname}${verificationRequestedUrl.search}`;
+};
+
+export const buildVerificationLinks = ({
+  token,
+  webAppUrl,
+  callbackUrl,
+}: {
+  token: string;
+  webAppUrl: string;
+  callbackUrl?: string | null;
+}): { verificationRequestLink: string; verifyLink: string } => {
+  const validatedCallbackUrl = getValidatedCallbackUrl(callbackUrl, webAppUrl);
+  const verifyLink = new URL("/auth/verify", webAppUrl);
+  verifyLink.searchParams.set("token", token);
+
+  const verificationRequestLink = new URL("/auth/verification-requested", webAppUrl);
+  verificationRequestLink.searchParams.set("token", token);
+
+  if (validatedCallbackUrl) {
+    verifyLink.searchParams.set("callbackUrl", validatedCallbackUrl);
+    verificationRequestLink.searchParams.set("callbackUrl", validatedCallbackUrl);
+  }
+
+  return {
+    verificationRequestLink: verificationRequestLink.toString(),
+    verifyLink: verifyLink.toString(),
+  };
+};

--- a/apps/web/modules/auth/login/components/login-form.tsx
+++ b/apps/web/modules/auth/login/components/login-form.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/lib/cn";
 import { FORMBRICKS_LOGGED_IN_WITH_LS } from "@/lib/localStorage";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { createEmailTokenAction } from "@/modules/auth/actions";
+import { buildVerificationRequestedPath } from "@/modules/auth/lib/verification-links";
 import { SSOOptions } from "@/modules/ee/sso/components/sso-options";
 import { TwoFactor } from "@/modules/ee/two-factor-auth/components/two-factor";
 import { TwoFactorBackup } from "@/modules/ee/two-factor-auth/components/two-factor-backup";
@@ -115,10 +116,12 @@ export const LoginForm = ({
       if (signInResponse?.error === "Email Verification is Pending") {
         const emailTokenActionResponse = await createEmailTokenAction({ email: data.email });
         if (emailTokenActionResponse?.data) {
-          const verificationRequestedUrl = new URL("/auth/verification-requested", window.location.origin);
-          verificationRequestedUrl.searchParams.set("token", emailTokenActionResponse.data);
-          verificationRequestedUrl.searchParams.set("callbackUrl", resolvedCallbackUrl);
-          router.push(`${verificationRequestedUrl.pathname}${verificationRequestedUrl.search}`);
+          router.push(
+            buildVerificationRequestedPath({
+              token: emailTokenActionResponse.data,
+              callbackUrl: resolvedCallbackUrl,
+            })
+          );
         } else {
           const errorMessage = getFormattedErrorMessage(emailTokenActionResponse);
           toast.error(errorMessage);
@@ -284,7 +287,7 @@ export const LoginForm = ({
               samlSsoEnabled={samlSsoEnabled}
               samlTenant={samlTenant}
               samlProduct={samlProduct}
-              callbackUrl={resolvedCallbackUrl}
+              returnToUrl={resolvedCallbackUrl}
               source="signin"
             />
           )}

--- a/apps/web/modules/auth/login/components/login-form.tsx
+++ b/apps/web/modules/auth/login/components/login-form.tsx
@@ -115,7 +115,10 @@ export const LoginForm = ({
       if (signInResponse?.error === "Email Verification is Pending") {
         const emailTokenActionResponse = await createEmailTokenAction({ email: data.email });
         if (emailTokenActionResponse?.data) {
-          router.push(`/auth/verification-requested?token=${emailTokenActionResponse?.data}`);
+          const verificationRequestedUrl = new URL("/auth/verification-requested", window.location.origin);
+          verificationRequestedUrl.searchParams.set("token", emailTokenActionResponse.data);
+          verificationRequestedUrl.searchParams.set("callbackUrl", resolvedCallbackUrl);
+          router.push(`${verificationRequestedUrl.pathname}${verificationRequestedUrl.search}`);
         } else {
           const errorMessage = getFormattedErrorMessage(emailTokenActionResponse);
           toast.error(errorMessage);

--- a/apps/web/modules/auth/login/components/login-form.tsx
+++ b/apps/web/modules/auth/login/components/login-form.tsx
@@ -2,8 +2,8 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { signIn } from "next-auth/react";
-import Link from "next/dist/client/link";
-import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 import { toast } from "react-hot-toast";
@@ -16,6 +16,7 @@ import { createEmailTokenAction } from "@/modules/auth/actions";
 import { SSOOptions } from "@/modules/ee/sso/components/sso-options";
 import { TwoFactor } from "@/modules/ee/two-factor-auth/components/two-factor";
 import { TwoFactorBackup } from "@/modules/ee/two-factor-auth/components/two-factor-backup";
+import { Alert, AlertDescription, AlertTitle } from "@/modules/ui/components/alert";
 import { Button } from "@/modules/ui/components/button";
 import { FormControl, FormError, FormField, FormItem } from "@/modules/ui/components/form";
 import { PasswordInput } from "@/modules/ui/components/password-input";
@@ -50,6 +51,11 @@ interface LoginFormProps {
   samlSsoEnabled: boolean;
   samlTenant: string;
   samlProduct: string;
+  oauthError?: string;
+  prefilledEmail?: string;
+  inviteToken?: string | null;
+  resolvedCallbackPath: string;
+  resolvedCallbackUrl: string;
 }
 
 export const LoginForm = ({
@@ -66,16 +72,20 @@ export const LoginForm = ({
   samlSsoEnabled,
   samlTenant,
   samlProduct,
+  oauthError,
+  prefilledEmail,
+  inviteToken,
+  resolvedCallbackPath,
+  resolvedCallbackUrl,
 }: LoginFormProps) => {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const emailRef = useRef<HTMLInputElement>(null);
-  const callbackUrl = searchParams?.get("callbackUrl") ?? "";
+  const oauthAccountNotLinked = oauthError === "OAuthAccountNotLinked";
   const { t } = useTranslation();
 
   const form = useForm<TLoginForm>({
     defaultValues: {
-      email: searchParams?.get("email") ?? "",
+      email: prefilledEmail ?? "",
       password: "",
       totpCode: "",
       backupCode: "",
@@ -89,7 +99,7 @@ export const LoginForm = ({
     }
     try {
       const signInResponse = await signIn("credentials", {
-        callbackUrl: callbackUrl ?? "/",
+        callbackUrl: resolvedCallbackUrl || "/",
         email: data.email.toLowerCase(),
         password: data.password,
         ...(totpLogin && { totpCode: data.totpCode }),
@@ -119,7 +129,7 @@ export const LoginForm = ({
       }
 
       if (!signInResponse?.error) {
-        router.push(searchParams?.get("callbackUrl") ?? "/");
+        router.push(resolvedCallbackPath || "/");
       }
     } catch (error) {
       toast.error(error instanceof Error ? error.message : String(error));
@@ -130,7 +140,6 @@ export const LoginForm = ({
   const [totpLogin, setTotpLogin] = useState(false);
   const [totpBackup, setTotpBackup] = useState(false);
   const formRef = useRef<HTMLFormElement>(null);
-  const inviteToken = callbackUrl ? new URL(callbackUrl).searchParams.get("token") : null;
   const [lastLoggedInWith, setLastLoggedInWith] = useState("");
 
   useEffect(() => {
@@ -167,9 +176,17 @@ export const LoginForm = ({
     <FormProvider {...form}>
       <div className="text-center">
         <h1 className="mb-4 text-slate-700">{formLabel}</h1>
+        {oauthAccountNotLinked && (
+          <Alert variant="error" className="mb-4 text-left">
+            <AlertTitle>{t("auth.login.oauth_account_not_linked_title")}</AlertTitle>
+            <AlertDescription>
+              <p>{t("auth.login.oauth_account_not_linked_description")}</p>
+            </AlertDescription>
+          </Alert>
+        )}
 
         <div className="space-y-2">
-          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-2">
+          <form ref={formRef} onSubmit={form.handleSubmit(onSubmit)} className="space-y-2">
             {TwoFactorComponent}
             {showLogin && (
               <div className={cn(totpLogin && "hidden", "space-y-2")}>
@@ -182,6 +199,7 @@ export const LoginForm = ({
                         <div>
                           <input
                             id="email"
+                            ref={emailRef}
                             type="email"
                             autoComplete="email"
                             required
@@ -234,6 +252,7 @@ export const LoginForm = ({
             )}
             {emailAuthEnabled && (
               <Button
+                type="button"
                 onClick={() => {
                   if (!showLogin) {
                     setShowLogin(true);
@@ -262,7 +281,7 @@ export const LoginForm = ({
               samlSsoEnabled={samlSsoEnabled}
               samlTenant={samlTenant}
               samlProduct={samlProduct}
-              callbackUrl={callbackUrl}
+              callbackUrl={resolvedCallbackUrl}
               source="signin"
             />
           )}

--- a/apps/web/modules/auth/login/page.tsx
+++ b/apps/web/modules/auth/login/page.tsx
@@ -46,11 +46,13 @@ export const LoginPage = async ({
     searchParamsProps,
     cookies(),
   ]);
+  const oauthError = getSearchParamString(searchParams.error);
 
   const resolvedCallbackUrl =
     resolveAuthCallbackUrl({
       searchParamCallbackUrl: searchParams.callbackUrl,
       cookieCallbackUrl: getAuthCallbackUrlFromCookies(cookieStore),
+      allowCookieFallback: oauthError === "OAuthAccountNotLinked",
       webAppUrl: WEBAPP_URL,
     }) ?? WEBAPP_URL;
   const resolvedCallbackPath = getRelativeCallbackUrl(resolvedCallbackUrl, WEBAPP_URL);
@@ -74,7 +76,7 @@ export const LoginPage = async ({
           samlSsoEnabled={samlSsoEnabled}
           samlTenant={SAML_TENANT}
           samlProduct={SAML_PRODUCT}
-          oauthError={getSearchParamString(searchParams.error)}
+          oauthError={oauthError}
           prefilledEmail={getSearchParamString(searchParams.email)}
           inviteToken={inviteToken}
           resolvedCallbackPath={resolvedCallbackPath}

--- a/apps/web/modules/auth/login/page.tsx
+++ b/apps/web/modules/auth/login/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { cookies } from "next/headers";
 import {
   AZURE_OAUTH_ENABLED,
   EMAIL_AUTH_ENABLED,
@@ -11,8 +12,16 @@ import {
   SAML_PRODUCT,
   SAML_TENANT,
   SIGNUP_ENABLED,
+  WEBAPP_URL,
 } from "@/lib/constants";
 import { FormWrapper } from "@/modules/auth/components/form-wrapper";
+import {
+  getAuthCallbackUrlFromCookies,
+  getInviteTokenFromCallbackUrl,
+  getRelativeCallbackUrl,
+  getSearchParamString,
+  resolveAuthCallbackUrl,
+} from "@/modules/auth/lib/callback-url";
 import {
   getIsMultiOrgEnabled,
   getIsSamlSsoEnabled,
@@ -25,14 +34,29 @@ export const metadata: Metadata = {
   description: "Open-source Experience Management. Free & open source.",
 };
 
-export const LoginPage = async () => {
-  const [isMultiOrgEnabled, isSsoEnabled, isSamlSsoEnabled] = await Promise.all([
+export const LoginPage = async ({
+  searchParams: searchParamsProps,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) => {
+  const [isMultiOrgEnabled, isSsoEnabled, isSamlSsoEnabled, searchParams, cookieStore] = await Promise.all([
     getIsMultiOrgEnabled(),
     getIsSsoEnabled(),
     getIsSamlSsoEnabled(),
+    searchParamsProps,
+    cookies(),
   ]);
 
+  const resolvedCallbackUrl =
+    resolveAuthCallbackUrl({
+      searchParamCallbackUrl: searchParams.callbackUrl,
+      cookieCallbackUrl: getAuthCallbackUrlFromCookies(cookieStore),
+      webAppUrl: WEBAPP_URL,
+    }) ?? WEBAPP_URL;
+  const resolvedCallbackPath = getRelativeCallbackUrl(resolvedCallbackUrl, WEBAPP_URL);
+  const inviteToken = getInviteTokenFromCallbackUrl(resolvedCallbackUrl, WEBAPP_URL);
   const samlSsoEnabled = isSamlSsoEnabled && SAML_OAUTH_ENABLED;
+
   return (
     <div className="flex min-h-screen w-full items-center justify-center bg-[#D9F6F4]">
       <FormWrapper>
@@ -50,6 +74,11 @@ export const LoginPage = async () => {
           samlSsoEnabled={samlSsoEnabled}
           samlTenant={SAML_TENANT}
           samlProduct={SAML_PRODUCT}
+          oauthError={getSearchParamString(searchParams.error)}
+          prefilledEmail={getSearchParamString(searchParams.email)}
+          inviteToken={inviteToken}
+          resolvedCallbackPath={resolvedCallbackPath}
+          resolvedCallbackUrl={resolvedCallbackUrl}
         />
       </FormWrapper>
     </div>

--- a/apps/web/modules/auth/signup/actions.ts
+++ b/apps/web/modules/auth/signup/actions.ts
@@ -191,11 +191,17 @@ async function handlePostUserCreation(
   }
 
   if (!emailVerificationDisabled) {
+    const inviteCallbackUrl = inviteToken ? new URL("/invite", WEBAPP_URL) : undefined;
+
+    if (inviteToken) {
+      inviteCallbackUrl.searchParams.set("token", inviteToken);
+    }
+
     await sendVerificationEmail({
       id: user.id,
       email: user.email,
       locale: user.locale,
-      callbackUrl: inviteToken ? `${WEBAPP_URL}/invite?token=${inviteToken}` : undefined,
+      callbackUrl: inviteCallbackUrl?.toString(),
     });
   }
 }

--- a/apps/web/modules/auth/signup/actions.ts
+++ b/apps/web/modules/auth/signup/actions.ts
@@ -191,17 +191,19 @@ async function handlePostUserCreation(
   }
 
   if (!emailVerificationDisabled) {
-    const inviteCallbackUrl = inviteToken ? new URL("/invite", WEBAPP_URL) : undefined;
+    let inviteCallbackUrl: string | undefined;
 
     if (inviteToken) {
-      inviteCallbackUrl.searchParams.set("token", inviteToken);
+      const inviteUrl = new URL("/invite", WEBAPP_URL);
+      inviteUrl.searchParams.set("token", inviteToken);
+      inviteCallbackUrl = inviteUrl.toString();
     }
 
     await sendVerificationEmail({
       id: user.id,
       email: user.email,
       locale: user.locale,
-      callbackUrl: inviteCallbackUrl?.toString(),
+      callbackUrl: inviteCallbackUrl,
     });
   }
 }

--- a/apps/web/modules/auth/signup/actions.ts
+++ b/apps/web/modules/auth/signup/actions.ts
@@ -5,7 +5,12 @@ import { logger } from "@formbricks/logger";
 import { InvalidInputError, UnknownError } from "@formbricks/types/errors";
 import { ZUser, ZUserEmail, ZUserLocale, ZUserName, ZUserPassword } from "@formbricks/types/user";
 import { hashPassword } from "@/lib/auth";
-import { IS_FORMBRICKS_CLOUD, IS_TURNSTILE_CONFIGURED, TURNSTILE_SECRET_KEY } from "@/lib/constants";
+import {
+  IS_FORMBRICKS_CLOUD,
+  IS_TURNSTILE_CONFIGURED,
+  TURNSTILE_SECRET_KEY,
+  WEBAPP_URL,
+} from "@/lib/constants";
 import { verifyInviteToken } from "@/lib/jwt";
 import { createMembership } from "@/lib/membership/service";
 import { createOrganization } from "@/lib/organization/service";
@@ -186,7 +191,12 @@ async function handlePostUserCreation(
   }
 
   if (!emailVerificationDisabled) {
-    await sendVerificationEmail({ id: user.id, email: user.email, locale: user.locale });
+    await sendVerificationEmail({
+      id: user.id,
+      email: user.email,
+      locale: user.locale,
+      callbackUrl: inviteToken ? `${WEBAPP_URL}/invite?token=${inviteToken}` : undefined,
+    });
   }
 }
 

--- a/apps/web/modules/auth/signup/components/signup-form.tsx
+++ b/apps/web/modules/auth/signup/components/signup-form.tsx
@@ -123,9 +123,16 @@ export const SignupForm = ({
       const emailTokenActionResponse = await createEmailTokenAction({ email: data.email });
       const token = emailTokenActionResponse?.data;
 
+      const verificationRequestedUrl = new URL("/auth/verification-requested", window.location.origin);
+      verificationRequestedUrl.searchParams.set("token", token ?? "");
+
+      if (inviteToken) {
+        verificationRequestedUrl.searchParams.set("callbackUrl", callbackUrl);
+      }
+
       const url = emailVerificationDisabled
         ? `/auth/signup-without-verification-success?token=${token}`
-        : `/auth/verification-requested?token=${token}`;
+        : `${verificationRequestedUrl.pathname}${verificationRequestedUrl.search}`;
 
       if (createUserResponse?.data) {
         router.push(url);

--- a/apps/web/modules/auth/signup/components/signup-form.tsx
+++ b/apps/web/modules/auth/signup/components/signup-form.tsx
@@ -11,6 +11,7 @@ import Turnstile, { useTurnstile } from "react-turnstile";
 import { z } from "zod";
 import { TUserLocale, ZUserName, ZUserPassword } from "@formbricks/types/user";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
+import { buildVerificationRequestedPath } from "@/modules/auth/lib/verification-links";
 import { createUserAction } from "@/modules/auth/signup/actions";
 import { TermsPrivacyLinks } from "@/modules/auth/signup/components/terms-privacy-links";
 import { SSOOptions } from "@/modules/ee/sso/components/sso-options";
@@ -84,7 +85,7 @@ export const SignupForm = ({
 
   const turnstile = useTurnstile();
 
-  const callbackUrl = useMemo(() => {
+  const returnToUrl = useMemo(() => {
     if (inviteToken) {
       return webAppUrl + "/invite?token=" + inviteToken;
     } else {
@@ -123,16 +124,12 @@ export const SignupForm = ({
       const emailTokenActionResponse = await createEmailTokenAction({ email: data.email });
       const token = emailTokenActionResponse?.data;
 
-      const verificationRequestedUrl = new URL("/auth/verification-requested", window.location.origin);
-      verificationRequestedUrl.searchParams.set("token", token ?? "");
-
-      if (inviteToken) {
-        verificationRequestedUrl.searchParams.set("callbackUrl", callbackUrl);
-      }
-
       const url = emailVerificationDisabled
         ? `/auth/signup-without-verification-success?token=${token}`
-        : `${verificationRequestedUrl.pathname}${verificationRequestedUrl.search}`;
+        : buildVerificationRequestedPath({
+            token: token ?? "",
+            callbackUrl: inviteToken ? returnToUrl : undefined,
+          });
 
       if (createUserResponse?.data) {
         router.push(url);
@@ -326,7 +323,7 @@ export const SignupForm = ({
           samlSsoEnabled={samlSsoEnabled}
           samlTenant={samlTenant}
           samlProduct={samlProduct}
-          callbackUrl={callbackUrl}
+          returnToUrl={returnToUrl}
           source="signup"
         />
       )}
@@ -335,7 +332,7 @@ export const SignupForm = ({
         <span className="leading-5 text-slate-500">{t("auth.signup.have_an_account")}</span>
         <br />
         <Link
-          href={inviteToken ? `/auth/login?callbackUrl=${callbackUrl}` : "/auth/login"}
+          href={inviteToken ? `/auth/login?callbackUrl=${returnToUrl}` : "/auth/login"}
           className="font-semibold text-slate-600 underline hover:text-slate-700">
           {t("auth.signup.log_in")}
         </Link>

--- a/apps/web/modules/auth/signup/lib/__tests__/team.test.ts
+++ b/apps/web/modules/auth/signup/lib/__tests__/team.test.ts
@@ -195,5 +195,27 @@ describe("Team Management", () => {
 
       expect(result).toBeNull();
     });
+
+    test("uses the transaction client directly when provided", async () => {
+      const tx = {
+        team: {
+          findUnique: vi.fn().mockResolvedValue(mockTeamLookup),
+        },
+      } as any;
+
+      const result = await getTeamForOrganization(MOCK_IDS.teamId, MOCK_IDS.organizationId, tx);
+
+      expect(result).toEqual(mockTeamLookup);
+      expect(tx.team.findUnique).toHaveBeenCalledWith({
+        where: {
+          id: MOCK_IDS.teamId,
+          organizationId: MOCK_IDS.organizationId,
+        },
+        select: {
+          id: true,
+        },
+      });
+      expect(prisma.team.findUnique).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/modules/auth/signup/lib/__tests__/team.test.ts
+++ b/apps/web/modules/auth/signup/lib/__tests__/team.test.ts
@@ -1,9 +1,9 @@
-import { MOCK_IDS, MOCK_INVITE, MOCK_TEAM, MOCK_TEAM_USER } from "./__mocks__/team-mocks";
+import { MOCK_IDS, MOCK_INVITE, MOCK_TEAM_USER } from "./__mocks__/team-mocks";
 import { OrganizationRole } from "@prisma/client";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { CreateMembershipInvite } from "@/modules/auth/signup/types/invites";
-import { createTeamMembership, getTeamProjectIds } from "../team";
+import { createTeamMembership, getTeamForOrganization } from "../team";
 
 // Setup all mocks
 const setupMocks = () => {
@@ -14,7 +14,7 @@ const setupMocks = () => {
         findUnique: vi.fn(),
       },
       teamUser: {
-        create: vi.fn(),
+        upsert: vi.fn(),
       },
     },
   }));
@@ -49,6 +49,8 @@ const setupMocks = () => {
 setupMocks();
 
 describe("Team Management", () => {
+  const mockTeamLookup = { id: MOCK_IDS.teamId };
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -56,8 +58,8 @@ describe("Team Management", () => {
   describe("createTeamMembership", () => {
     describe("when user is an admin", () => {
       test("creates a team membership with admin role", async () => {
-        vi.mocked(prisma.team.findUnique).mockResolvedValue(MOCK_TEAM as unknown as any);
-        vi.mocked(prisma.teamUser.create).mockResolvedValue(MOCK_TEAM_USER);
+        vi.mocked(prisma.team.findUnique).mockResolvedValue(mockTeamLookup as any);
+        vi.mocked(prisma.teamUser.upsert).mockResolvedValue(MOCK_TEAM_USER as any);
 
         await createTeamMembership(MOCK_INVITE, MOCK_IDS.userId);
         expect(prisma.team.findUnique).toHaveBeenCalledWith({
@@ -66,19 +68,24 @@ describe("Team Management", () => {
             organizationId: MOCK_IDS.organizationId,
           },
           select: {
-            projectTeams: {
-              select: {
-                projectId: true,
-              },
-            },
+            id: true,
           },
         });
 
-        expect(prisma.teamUser.create).toHaveBeenCalledWith({
-          data: {
+        expect(prisma.teamUser.upsert).toHaveBeenCalledWith({
+          create: {
             teamId: MOCK_IDS.teamId,
             userId: MOCK_IDS.userId,
             role: "admin",
+          },
+          update: {
+            role: "admin",
+          },
+          where: {
+            teamId_userId: {
+              teamId: MOCK_IDS.teamId,
+              userId: MOCK_IDS.userId,
+            },
           },
         });
       });
@@ -91,19 +98,28 @@ describe("Team Management", () => {
           role: "member" as OrganizationRole,
         };
 
-        vi.mocked(prisma.team.findUnique).mockResolvedValue(MOCK_TEAM as unknown as any);
-        vi.mocked(prisma.teamUser.create).mockResolvedValue({
+        vi.mocked(prisma.team.findUnique).mockResolvedValue(mockTeamLookup as any);
+        vi.mocked(prisma.teamUser.upsert).mockResolvedValue({
           ...MOCK_TEAM_USER,
           role: "contributor",
-        });
+        } as any);
 
         await createTeamMembership(nonAdminInvite, MOCK_IDS.userId);
 
-        expect(prisma.teamUser.create).toHaveBeenCalledWith({
-          data: {
+        expect(prisma.teamUser.upsert).toHaveBeenCalledWith({
+          create: {
             teamId: MOCK_IDS.teamId,
             userId: MOCK_IDS.userId,
             role: "contributor",
+          },
+          update: {
+            role: "contributor",
+          },
+          where: {
+            teamId_userId: {
+              teamId: MOCK_IDS.teamId,
+              userId: MOCK_IDS.userId,
+            },
           },
         });
       });
@@ -111,8 +127,8 @@ describe("Team Management", () => {
 
     describe("error handling", () => {
       test("throws error when database operation fails", async () => {
-        vi.mocked(prisma.team.findUnique).mockResolvedValue(MOCK_TEAM as unknown as any);
-        vi.mocked(prisma.teamUser.create).mockRejectedValue(new Error("Database error"));
+        vi.mocked(prisma.team.findUnique).mockResolvedValue(mockTeamLookup as any);
+        vi.mocked(prisma.teamUser.upsert).mockRejectedValue(new Error("Database error"));
 
         await expect(createTeamMembership(MOCK_INVITE, MOCK_IDS.userId)).rejects.toThrow("Database error");
       });
@@ -127,42 +143,47 @@ describe("Team Management", () => {
 
         vi.mocked(prisma.team.findUnique)
           .mockResolvedValueOnce(null)
-          .mockResolvedValueOnce(MOCK_TEAM as unknown as any);
-        vi.mocked(prisma.teamUser.create).mockResolvedValue(MOCK_TEAM_USER);
+          .mockResolvedValueOnce(mockTeamLookup as any);
+        vi.mocked(prisma.teamUser.upsert).mockResolvedValue(MOCK_TEAM_USER as any);
 
         await createTeamMembership(inviteWithMultipleTeams, MOCK_IDS.userId);
 
         expect(prisma.team.findUnique).toHaveBeenCalledTimes(2);
-        expect(prisma.teamUser.create).toHaveBeenCalledTimes(1);
-        expect(prisma.teamUser.create).toHaveBeenCalledWith({
-          data: {
+        expect(prisma.teamUser.upsert).toHaveBeenCalledTimes(1);
+        expect(prisma.teamUser.upsert).toHaveBeenCalledWith({
+          create: {
             teamId: MOCK_IDS.teamId,
             userId: MOCK_IDS.userId,
             role: "admin",
+          },
+          update: {
+            role: "admin",
+          },
+          where: {
+            teamId_userId: {
+              teamId: MOCK_IDS.teamId,
+              userId: MOCK_IDS.userId,
+            },
           },
         });
       });
     });
   });
 
-  describe("getTeamProjectIds", () => {
-    test("returns team with projectTeams when team exists", async () => {
-      vi.mocked(prisma.team.findUnique).mockResolvedValue(MOCK_TEAM as unknown as any);
+  describe("getTeamForOrganization", () => {
+    test("returns the team when it exists in the organization", async () => {
+      vi.mocked(prisma.team.findUnique).mockResolvedValue(mockTeamLookup as any);
 
-      const result = await getTeamProjectIds(MOCK_IDS.teamId, MOCK_IDS.organizationId);
+      const result = await getTeamForOrganization(MOCK_IDS.teamId, MOCK_IDS.organizationId);
 
-      expect(result).toEqual(MOCK_TEAM);
+      expect(result).toEqual(mockTeamLookup);
       expect(prisma.team.findUnique).toHaveBeenCalledWith({
         where: {
           id: MOCK_IDS.teamId,
           organizationId: MOCK_IDS.organizationId,
         },
         select: {
-          projectTeams: {
-            select: {
-              projectId: true,
-            },
-          },
+          id: true,
         },
       });
     });
@@ -170,7 +191,7 @@ describe("Team Management", () => {
     test("returns null when team does not exist", async () => {
       vi.mocked(prisma.team.findUnique).mockResolvedValue(null);
 
-      const result = await getTeamProjectIds(MOCK_IDS.teamId, MOCK_IDS.organizationId);
+      const result = await getTeamForOrganization(MOCK_IDS.teamId, MOCK_IDS.organizationId);
 
       expect(result).toBeNull();
     });

--- a/apps/web/modules/auth/signup/lib/team.ts
+++ b/apps/web/modules/auth/signup/lib/team.ts
@@ -33,7 +33,7 @@ export const createTeamMembership = async (
       }
 
       await prismaClient.teamUser.upsert({
-        data: {
+        create: {
           teamId,
           userId,
           role: isOwnerOrManager ? "admin" : "contributor",

--- a/apps/web/modules/auth/signup/lib/team.ts
+++ b/apps/web/modules/auth/signup/lib/team.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { Prisma } from "@prisma/client";
+import { Prisma, PrismaClient } from "@prisma/client";
 import { cache as reactCache } from "react";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
@@ -7,7 +7,15 @@ import { DatabaseError } from "@formbricks/types/errors";
 import { getAccessFlags } from "@/lib/membership/utils";
 import { CreateMembershipInvite } from "@/modules/auth/signup/types/invites";
 
-export const createTeamMembership = async (invite: CreateMembershipInvite, userId: string): Promise<void> => {
+type TTeamDbClient = PrismaClient | Prisma.TransactionClient;
+
+const getDbClient = (tx?: Prisma.TransactionClient): TTeamDbClient => tx ?? prisma;
+
+export const createTeamMembership = async (
+  invite: CreateMembershipInvite,
+  userId: string,
+  tx?: Prisma.TransactionClient
+): Promise<void> => {
   const teamIds = invite.teamIds || [];
 
   const userMembershipRole = invite.role;
@@ -15,19 +23,29 @@ export const createTeamMembership = async (invite: CreateMembershipInvite, userI
 
   const isOwnerOrManager = isOwner || isManager;
   try {
+    const prismaClient = getDbClient(tx);
     for (const teamId of teamIds) {
-      const team = await getTeamProjectIds(teamId, invite.organizationId);
+      const team = await getTeamProjectIds(teamId, invite.organizationId, tx);
 
       if (!team) {
         logger.warn({ teamId, userId }, "Team no longer exists during invite acceptance");
         continue;
       }
 
-      await prisma.teamUser.create({
+      await prismaClient.teamUser.upsert({
         data: {
           teamId,
           userId,
           role: isOwnerOrManager ? "admin" : "contributor",
+        },
+        update: {
+          role: isOwnerOrManager ? "admin" : "contributor",
+        },
+        where: {
+          teamId_userId: {
+            teamId,
+            userId,
+          },
         },
       });
     }
@@ -44,9 +62,10 @@ export const createTeamMembership = async (invite: CreateMembershipInvite, userI
 export const getTeamProjectIds = reactCache(
   async (
     teamId: string,
-    organizationId: string
+    organizationId: string,
+    tx?: Prisma.TransactionClient
   ): Promise<{ projectTeams: { projectId: string }[] } | null> => {
-    const team = await prisma.team.findUnique({
+    const team = await getDbClient(tx).team.findUnique({
       where: {
         id: teamId,
         organizationId,

--- a/apps/web/modules/auth/signup/lib/team.ts
+++ b/apps/web/modules/auth/signup/lib/team.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { Prisma, PrismaClient } from "@prisma/client";
+import { Prisma, PrismaClient, Team } from "@prisma/client";
 import { cache as reactCache } from "react";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
@@ -8,6 +8,7 @@ import { getAccessFlags } from "@/lib/membership/utils";
 import { CreateMembershipInvite } from "@/modules/auth/signup/types/invites";
 
 type TTeamDbClient = PrismaClient | Prisma.TransactionClient;
+type TTeamMembershipTarget = Pick<Team, "id">;
 
 const getDbClient = (tx?: Prisma.TransactionClient): TTeamDbClient => tx ?? prisma;
 
@@ -25,7 +26,7 @@ export const createTeamMembership = async (
   try {
     const prismaClient = getDbClient(tx);
     for (const teamId of teamIds) {
-      const team = await getTeamProjectIds(teamId, invite.organizationId, tx);
+      const team = await getTeamForOrganization(teamId, invite.organizationId, tx);
 
       if (!team) {
         logger.warn({ teamId, userId }, "Team no longer exists during invite acceptance");
@@ -59,25 +60,31 @@ export const createTeamMembership = async (
   }
 };
 
-export const getTeamProjectIds = reactCache(
+export const getTeamForOrganization = reactCache(
   async (
     teamId: string,
     organizationId: string,
     tx?: Prisma.TransactionClient
-  ): Promise<{ projectTeams: { projectId: string }[] } | null> => {
-    const team = await getDbClient(tx).team.findUnique({
-      where: {
-        id: teamId,
-        organizationId,
-      },
-      select: {
-        projectTeams: {
-          select: {
-            projectId: true,
+  ): Promise<TTeamMembershipTarget | null> => {
+    const team = tx
+      ? await tx.team.findUnique({
+          where: {
+            id: teamId,
+            organizationId,
           },
-        },
-      },
-    });
+          select: {
+            id: true,
+          },
+        })
+      : await prisma.team.findUnique({
+          where: {
+            id: teamId,
+            organizationId,
+          },
+          select: {
+            id: true,
+          },
+        });
 
     if (!team) {
       return null;

--- a/apps/web/modules/auth/signup/lib/team.ts
+++ b/apps/web/modules/auth/signup/lib/team.ts
@@ -12,6 +12,32 @@ type TTeamMembershipTarget = Pick<Team, "id">;
 
 const getDbClient = (tx?: Prisma.TransactionClient): TTeamDbClient => tx ?? prisma;
 
+const getTeamForOrganizationUncached = async (
+  teamId: string,
+  organizationId: string,
+  tx?: Prisma.TransactionClient
+): Promise<TTeamMembershipTarget | null> => {
+  const team = await getDbClient(tx).team.findUnique({
+    where: {
+      id: teamId,
+      organizationId,
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  if (!team) {
+    return null;
+  }
+
+  return team;
+};
+
+const getTeamForOrganizationCached = reactCache(async (teamId: string, organizationId: string) =>
+  getTeamForOrganizationUncached(teamId, organizationId)
+);
+
 export const createTeamMembership = async (
   invite: CreateMembershipInvite,
   userId: string,
@@ -60,36 +86,14 @@ export const createTeamMembership = async (
   }
 };
 
-export const getTeamForOrganization = reactCache(
-  async (
-    teamId: string,
-    organizationId: string,
-    tx?: Prisma.TransactionClient
-  ): Promise<TTeamMembershipTarget | null> => {
-    const team = tx
-      ? await tx.team.findUnique({
-          where: {
-            id: teamId,
-            organizationId,
-          },
-          select: {
-            id: true,
-          },
-        })
-      : await prisma.team.findUnique({
-          where: {
-            id: teamId,
-            organizationId,
-          },
-          select: {
-            id: true,
-          },
-        });
-
-    if (!team) {
-      return null;
-    }
-
-    return team;
+export const getTeamForOrganization = async (
+  teamId: string,
+  organizationId: string,
+  tx?: Prisma.TransactionClient
+): Promise<TTeamMembershipTarget | null> => {
+  if (tx) {
+    return getTeamForOrganizationUncached(teamId, organizationId, tx);
   }
-);
+
+  return getTeamForOrganizationCached(teamId, organizationId);
+};

--- a/apps/web/modules/auth/verification-requested/actions.test.ts
+++ b/apps/web/modules/auth/verification-requested/actions.test.ts
@@ -29,6 +29,10 @@ vi.mock("@/modules/email", () => ({
   sendVerificationEmail: vi.fn(),
 }));
 
+vi.mock("@/lib/constants", () => ({
+  WEBAPP_URL: "http://localhost:3000",
+}));
+
 vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
   withAuditLogging: vi.fn((_type: string, _object: string, fn: Function) => fn),
 }));
@@ -133,7 +137,7 @@ describe("resendVerificationEmailAction", () => {
 
   describe("Verification Email Resend Flow", () => {
     test("should send verification email when user exists and email is not verified", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue();
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
       vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
 
       const result = await resendVerificationEmailAction({
@@ -143,12 +147,51 @@ describe("resendVerificationEmailAction", () => {
 
       expect(applyIPRateLimit).toHaveBeenCalled();
       expect(getUserByEmail).toHaveBeenCalledWith(validInput.email);
-      expect(sendVerificationEmail).toHaveBeenCalledWith(mockUser);
+      expect(sendVerificationEmail).toHaveBeenCalledWith({
+        ...mockUser,
+        callbackUrl: undefined,
+      });
       expect(result).toEqual({ success: true });
     });
 
+    test("should preserve a valid callback URL when resending the verification email", async () => {
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
+      vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
+
+      await resendVerificationEmailAction({
+        ctx: mockCtx,
+        parsedInput: {
+          ...validInput,
+          callbackUrl: "http://localhost:3000/invite?token=invite-token",
+        },
+      } as any);
+
+      expect(sendVerificationEmail).toHaveBeenCalledWith({
+        ...mockUser,
+        callbackUrl: "http://localhost:3000/invite?token=invite-token",
+      });
+    });
+
+    test("should discard invalid callback URLs when resending the verification email", async () => {
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
+      vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
+
+      await resendVerificationEmailAction({
+        ctx: mockCtx,
+        parsedInput: {
+          ...validInput,
+          callbackUrl: "https://evil.example/phish",
+        },
+      } as any);
+
+      expect(sendVerificationEmail).toHaveBeenCalledWith({
+        ...mockUser,
+        callbackUrl: undefined,
+      });
+    });
+
     test("should return success without sending email when user email is already verified", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue();
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
       vi.mocked(getUserByEmail).mockResolvedValue(mockVerifiedUser as any);
 
       const result = await resendVerificationEmailAction({
@@ -163,7 +206,7 @@ describe("resendVerificationEmailAction", () => {
     });
 
     test("should throw ResourceNotFoundError when user doesn't exist", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue();
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
       vi.mocked(getUserByEmail).mockResolvedValue(null);
 
       await expect(
@@ -187,7 +230,7 @@ describe("resendVerificationEmailAction", () => {
     });
 
     test("should set audit context userId when sending verification email", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue();
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
       vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
 
       const testCtx = {
@@ -207,7 +250,7 @@ describe("resendVerificationEmailAction", () => {
     });
 
     test("should not set audit context userId when email is already verified", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue();
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
       vi.mocked(getUserByEmail).mockResolvedValue(mockVerifiedUser as any);
 
       const testCtx = {
@@ -241,7 +284,7 @@ describe("resendVerificationEmailAction", () => {
     });
 
     test("should handle user lookup errors after rate limiting", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue();
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
       vi.mocked(getUserByEmail).mockRejectedValue(new Error("Database error"));
 
       await expect(
@@ -255,7 +298,7 @@ describe("resendVerificationEmailAction", () => {
     });
 
     test("should handle email sending errors after rate limiting", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue();
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
       vi.mocked(getUserByEmail).mockResolvedValue(mockUser as any);
       vi.mocked(sendVerificationEmail).mockRejectedValue(new Error("Email service error"));
 
@@ -277,7 +320,7 @@ describe("resendVerificationEmailAction", () => {
 
       // This would be caught by the Zod schema validation in the actual action
       // but we test the behavior if it somehow gets through
-      vi.mocked(applyIPRateLimit).mockResolvedValue();
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
       vi.mocked(getUserByEmail).mockResolvedValue(null);
 
       await expect(
@@ -293,7 +336,7 @@ describe("resendVerificationEmailAction", () => {
 
       // This would be caught by the Zod schema validation in the actual action
       // but we test the behavior if it somehow gets through
-      vi.mocked(applyIPRateLimit).mockResolvedValue();
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
       vi.mocked(getUserByEmail).mockResolvedValue(null);
 
       await expect(
@@ -320,7 +363,7 @@ describe("resendVerificationEmailAction", () => {
     });
 
     test("should not leak information about user existence through different error messages", async () => {
-      vi.mocked(applyIPRateLimit).mockResolvedValue();
+      vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
       vi.mocked(getUserByEmail).mockResolvedValue(null);
 
       // Both non-existent users should throw the same ResourceNotFoundError

--- a/apps/web/modules/auth/verification-requested/actions.ts
+++ b/apps/web/modules/auth/verification-requested/actions.ts
@@ -3,7 +3,9 @@
 import { z } from "zod";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { ZUserEmail } from "@formbricks/types/user";
+import { WEBAPP_URL } from "@/lib/constants";
 import { actionClient } from "@/lib/utils/action-client";
+import { getValidatedCallbackUrl } from "@/lib/utils/url";
 import { getUserByEmail } from "@/modules/auth/lib/user";
 import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
@@ -12,6 +14,7 @@ import { sendVerificationEmail } from "@/modules/email";
 
 const ZResendVerificationEmailAction = z.object({
   email: ZUserEmail,
+  callbackUrl: z.string().max(2000).optional(),
 });
 
 export const resendVerificationEmailAction = actionClient.inputSchema(ZResendVerificationEmailAction).action(
@@ -28,7 +31,12 @@ export const resendVerificationEmailAction = actionClient.inputSchema(ZResendVer
       };
     }
     ctx.auditLoggingCtx.userId = user.id;
-    await sendVerificationEmail({ id: user.id, email: user.email, locale: user.locale });
+    await sendVerificationEmail({
+      id: user.id,
+      email: user.email,
+      locale: user.locale,
+      callbackUrl: getValidatedCallbackUrl(parsedInput.callbackUrl, WEBAPP_URL) ?? undefined,
+    });
     return {
       success: true,
     };

--- a/apps/web/modules/auth/verification-requested/components/request-verification-email.tsx
+++ b/apps/web/modules/auth/verification-requested/components/request-verification-email.tsx
@@ -9,9 +9,10 @@ import { resendVerificationEmailAction } from "../actions";
 
 interface RequestVerificationEmailProps {
   email: string | null;
+  callbackUrl?: string | null;
 }
 
-export const RequestVerificationEmail = ({ email }: RequestVerificationEmailProps) => {
+export const RequestVerificationEmail = ({ email, callbackUrl }: RequestVerificationEmailProps) => {
   const { t } = useTranslation();
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -29,7 +30,7 @@ export const RequestVerificationEmail = ({ email }: RequestVerificationEmailProp
 
   const requestVerificationEmail = async () => {
     if (!email) return toast.error(t("auth.verification-requested.no_email_provided"));
-    const response = await resendVerificationEmailAction({ email });
+    const response = await resendVerificationEmailAction({ email, callbackUrl: callbackUrl ?? undefined });
     if (response?.data) {
       toast.success(t("auth.verification-requested.verification_email_resent_successfully"));
     } else {

--- a/apps/web/modules/auth/verification-requested/page.tsx
+++ b/apps/web/modules/auth/verification-requested/page.tsx
@@ -1,18 +1,28 @@
+import { cookies } from "next/headers";
 import { logger } from "@formbricks/logger";
 import { ZUserEmail } from "@formbricks/types/user";
+import { WEBAPP_URL } from "@/lib/constants";
 import { getEmailFromEmailToken } from "@/lib/jwt";
 import { getTranslate } from "@/lingodotdev/server";
 import { FormWrapper } from "@/modules/auth/components/form-wrapper";
+import { getAuthCallbackUrlFromCookies, resolveAuthCallbackUrl } from "@/modules/auth/lib/callback-url";
 import { RequestVerificationEmail } from "@/modules/auth/verification-requested/components/request-verification-email";
 import { VerificationMessage } from "@/modules/auth/verification-requested/components/verification-message";
 
 export const VerificationRequestedPage = async ({
   searchParams,
 }: {
-  searchParams: Promise<{ token: string }>;
+  searchParams: Promise<{ token: string; callbackUrl?: string | string[] }>;
 }) => {
   const t = await getTranslate();
-  const { token } = await searchParams;
+  const [params, cookieStore] = await Promise.all([searchParams, cookies()]);
+  const { token, callbackUrl } = params;
+  const resolvedCallbackUrl = resolveAuthCallbackUrl({
+    searchParamCallbackUrl: callbackUrl,
+    cookieCallbackUrl: getAuthCallbackUrlFromCookies(cookieStore),
+    allowCookieFallback: true,
+    webAppUrl: WEBAPP_URL,
+  });
   try {
     const email = getEmailFromEmailToken(token);
     const parsedEmail = ZUserEmail.safeParse(email);
@@ -29,7 +39,7 @@ export const VerificationRequestedPage = async ({
               {t("auth.verification-requested.you_didnt_receive_an_email_or_your_link_expired")}
             </p>
             <div className="mt-5">
-              <RequestVerificationEmail email={email.toLowerCase()} />
+              <RequestVerificationEmail email={email.toLowerCase()} callbackUrl={resolvedCallbackUrl} />
             </div>
           </>
         </FormWrapper>

--- a/apps/web/modules/auth/verify/components/sign-in.tsx
+++ b/apps/web/modules/auth/verify/components/sign-in.tsx
@@ -3,15 +3,15 @@
 import { signIn } from "next-auth/react";
 import { useEffect } from "react";
 
-export const SignIn = ({ token, webAppUrl }: { token: string; webAppUrl: string }) => {
+export const SignIn = ({ token, callbackUrl }: { token: string; callbackUrl: string }) => {
   useEffect(() => {
     if (token) {
       signIn("token", {
         token: token,
-        callbackUrl: webAppUrl,
+        callbackUrl,
       });
     }
-  }, [token, webAppUrl]);
+  }, [callbackUrl, token]);
 
   return <></>;
 };

--- a/apps/web/modules/auth/verify/page.tsx
+++ b/apps/web/modules/auth/verify/page.tsx
@@ -1,16 +1,30 @@
+import { cookies } from "next/headers";
 import { WEBAPP_URL } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { FormWrapper } from "@/modules/auth/components/form-wrapper";
+import { getAuthCallbackUrlFromCookies, resolveAuthCallbackUrl } from "@/modules/auth/lib/callback-url";
 import { SignIn } from "@/modules/auth/verify/components/sign-in";
 
-export const VerifyPage = async ({ searchParams }: { searchParams: Promise<{ token?: string }> }) => {
+export const VerifyPage = async ({
+  searchParams,
+}: {
+  searchParams: Promise<{ token?: string; callbackUrl?: string | string[] }>;
+}) => {
   const t = await getTranslate();
-  const { token } = await searchParams;
+  const [params, cookieStore] = await Promise.all([searchParams, cookies()]);
+  const { token, callbackUrl } = params;
+  const resolvedCallbackUrl =
+    resolveAuthCallbackUrl({
+      searchParamCallbackUrl: callbackUrl,
+      cookieCallbackUrl: getAuthCallbackUrlFromCookies(cookieStore),
+      allowCookieFallback: true,
+      webAppUrl: WEBAPP_URL,
+    }) ?? WEBAPP_URL;
 
   return token ? (
     <FormWrapper>
       <p className="text-center">{t("auth.verify.verifying")}</p>
-      <SignIn token={token} webAppUrl={WEBAPP_URL} />
+      <SignIn token={token} callbackUrl={resolvedCallbackUrl} />
     </FormWrapper>
   ) : (
     <p className="text-center">{t("auth.verify.no_token_provided")}</p>

--- a/apps/web/modules/ee/sso/components/azure-button.tsx
+++ b/apps/web/modules/ee/sso/components/azure-button.tsx
@@ -4,30 +4,30 @@ import { signIn } from "next-auth/react";
 import { useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { FORMBRICKS_LOGGED_IN_WITH_LS } from "@/lib/localStorage";
-import { getCallbackUrl } from "@/modules/ee/sso/lib/utils";
+import { getSsoReturnToUrl } from "@/modules/ee/sso/lib/utils";
 import { Button } from "@/modules/ui/components/button";
 import { MicrosoftIcon } from "@/modules/ui/components/icons";
 
 interface AzureButtonProps {
-  inviteUrl?: string;
+  returnToUrl?: string;
   directRedirect?: boolean;
   lastUsed?: boolean;
   source: "signin" | "signup";
 }
 
-export const AzureButton = ({ inviteUrl, directRedirect = false, lastUsed, source }: AzureButtonProps) => {
+export const AzureButton = ({ returnToUrl, directRedirect = false, lastUsed, source }: AzureButtonProps) => {
   const { t } = useTranslation();
   const handleLogin = useCallback(async () => {
     if (typeof window !== "undefined") {
       localStorage.setItem(FORMBRICKS_LOGGED_IN_WITH_LS, "Azure");
     }
-    const callbackUrlWithSource = getCallbackUrl(inviteUrl, source);
+    const returnToUrlWithSource = getSsoReturnToUrl(returnToUrl, source);
 
     await signIn("azure-ad", {
       redirect: true,
-      callbackUrl: callbackUrlWithSource,
+      callbackUrl: returnToUrlWithSource,
     });
-  }, [inviteUrl, source]);
+  }, [returnToUrl, source]);
 
   useEffect(() => {
     if (directRedirect) {

--- a/apps/web/modules/ee/sso/components/github-button.tsx
+++ b/apps/web/modules/ee/sso/components/github-button.tsx
@@ -3,27 +3,27 @@
 import { signIn } from "next-auth/react";
 import { useTranslation } from "react-i18next";
 import { FORMBRICKS_LOGGED_IN_WITH_LS } from "@/lib/localStorage";
-import { getCallbackUrl } from "@/modules/ee/sso/lib/utils";
+import { getSsoReturnToUrl } from "@/modules/ee/sso/lib/utils";
 import { Button } from "@/modules/ui/components/button";
 import { GithubIcon } from "@/modules/ui/components/icons";
 
 interface GithubButtonProps {
-  inviteUrl?: string;
+  returnToUrl?: string;
   lastUsed?: boolean;
   source: "signin" | "signup";
 }
 
-export const GithubButton = ({ inviteUrl, lastUsed, source }: GithubButtonProps) => {
+export const GithubButton = ({ returnToUrl, lastUsed, source }: GithubButtonProps) => {
   const { t } = useTranslation();
   const handleLogin = async () => {
     if (typeof window !== "undefined") {
       localStorage.setItem(FORMBRICKS_LOGGED_IN_WITH_LS, "Github");
     }
-    const callbackUrlWithSource = getCallbackUrl(inviteUrl, source);
+    const returnToUrlWithSource = getSsoReturnToUrl(returnToUrl, source);
 
     await signIn("github", {
       redirect: true,
-      callbackUrl: callbackUrlWithSource,
+      callbackUrl: returnToUrlWithSource,
     });
   };
 

--- a/apps/web/modules/ee/sso/components/google-button.tsx
+++ b/apps/web/modules/ee/sso/components/google-button.tsx
@@ -3,27 +3,27 @@
 import { signIn } from "next-auth/react";
 import { useTranslation } from "react-i18next";
 import { FORMBRICKS_LOGGED_IN_WITH_LS } from "@/lib/localStorage";
-import { getCallbackUrl } from "@/modules/ee/sso/lib/utils";
+import { getSsoReturnToUrl } from "@/modules/ee/sso/lib/utils";
 import { Button } from "@/modules/ui/components/button";
 import { GoogleIcon } from "@/modules/ui/components/icons";
 
 interface GoogleButtonProps {
-  inviteUrl?: string;
+  returnToUrl?: string;
   lastUsed?: boolean;
   source: "signin" | "signup";
 }
 
-export const GoogleButton = ({ inviteUrl, lastUsed, source }: GoogleButtonProps) => {
+export const GoogleButton = ({ returnToUrl, lastUsed, source }: GoogleButtonProps) => {
   const { t } = useTranslation();
   const handleLogin = async () => {
     if (typeof window !== "undefined") {
       localStorage.setItem(FORMBRICKS_LOGGED_IN_WITH_LS, "Google");
     }
-    const callbackUrlWithSource = getCallbackUrl(inviteUrl, source);
+    const returnToUrlWithSource = getSsoReturnToUrl(returnToUrl, source);
 
     await signIn("google", {
       redirect: true,
-      callbackUrl: callbackUrlWithSource,
+      callbackUrl: returnToUrlWithSource,
     });
   };
 

--- a/apps/web/modules/ee/sso/components/open-id-button.tsx
+++ b/apps/web/modules/ee/sso/components/open-id-button.tsx
@@ -4,11 +4,11 @@ import { signIn } from "next-auth/react";
 import { useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { FORMBRICKS_LOGGED_IN_WITH_LS } from "@/lib/localStorage";
-import { getCallbackUrl } from "@/modules/ee/sso/lib/utils";
+import { getSsoReturnToUrl } from "@/modules/ee/sso/lib/utils";
 import { Button } from "@/modules/ui/components/button";
 
 interface OpenIdButtonProps {
-  inviteUrl?: string;
+  returnToUrl?: string;
   lastUsed?: boolean;
   directRedirect?: boolean;
   text?: string;
@@ -16,7 +16,7 @@ interface OpenIdButtonProps {
 }
 
 export const OpenIdButton = ({
-  inviteUrl,
+  returnToUrl,
   lastUsed,
   directRedirect = false,
   text,
@@ -27,13 +27,13 @@ export const OpenIdButton = ({
     if (typeof window !== "undefined") {
       localStorage.setItem(FORMBRICKS_LOGGED_IN_WITH_LS, "OpenID");
     }
-    const callbackUrlWithSource = getCallbackUrl(inviteUrl, source);
+    const returnToUrlWithSource = getSsoReturnToUrl(returnToUrl, source);
 
     await signIn("openid", {
       redirect: true,
-      callbackUrl: callbackUrlWithSource,
+      callbackUrl: returnToUrlWithSource,
     });
-  }, [inviteUrl, source]);
+  }, [returnToUrl, source]);
 
   useEffect(() => {
     if (directRedirect) {

--- a/apps/web/modules/ee/sso/components/saml-button.tsx
+++ b/apps/web/modules/ee/sso/components/saml-button.tsx
@@ -7,18 +7,18 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { FORMBRICKS_LOGGED_IN_WITH_LS } from "@/lib/localStorage";
 import { doesSamlConnectionExistAction } from "@/modules/ee/sso/actions";
-import { getCallbackUrl } from "@/modules/ee/sso/lib/utils";
+import { getSsoReturnToUrl } from "@/modules/ee/sso/lib/utils";
 import { Button } from "@/modules/ui/components/button";
 
 interface SamlButtonProps {
-  inviteUrl?: string;
+  returnToUrl?: string;
   lastUsed?: boolean;
   samlTenant: string;
   samlProduct: string;
   source: "signin" | "signup";
 }
 
-export const SamlButton = ({ inviteUrl, lastUsed, samlTenant, samlProduct, source }: SamlButtonProps) => {
+export const SamlButton = ({ returnToUrl, lastUsed, samlTenant, samlProduct, source }: SamlButtonProps) => {
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -34,13 +34,13 @@ export const SamlButton = ({ inviteUrl, lastUsed, samlTenant, samlProduct, sourc
       return;
     }
 
-    const callbackUrlWithSource = getCallbackUrl(inviteUrl, source);
+    const returnToUrlWithSource = getSsoReturnToUrl(returnToUrl, source);
 
     signIn(
       "saml",
       {
         redirect: true,
-        callbackUrl: callbackUrlWithSource,
+        callbackUrl: returnToUrlWithSource,
       },
       {
         tenant: samlTenant,

--- a/apps/web/modules/ee/sso/components/sso-options.tsx
+++ b/apps/web/modules/ee/sso/components/sso-options.tsx
@@ -15,7 +15,7 @@ interface SSOOptionsProps {
   azureOAuthEnabled: boolean;
   oidcOAuthEnabled: boolean;
   oidcDisplayName?: string;
-  callbackUrl: string;
+  returnToUrl: string;
   samlSsoEnabled: boolean;
   samlTenant: string;
   samlProduct: string;
@@ -28,7 +28,7 @@ export const SSOOptions = ({
   azureOAuthEnabled,
   oidcOAuthEnabled,
   oidcDisplayName,
-  callbackUrl,
+  returnToUrl,
   samlSsoEnabled,
   samlTenant,
   samlProduct,
@@ -46,17 +46,17 @@ export const SSOOptions = ({
   return (
     <div className="space-y-2">
       {googleOAuthEnabled && (
-        <GoogleButton inviteUrl={callbackUrl} lastUsed={lastLoggedInWith === "Google"} source={source} />
+        <GoogleButton returnToUrl={returnToUrl} lastUsed={lastLoggedInWith === "Google"} source={source} />
       )}
       {githubOAuthEnabled && (
-        <GithubButton inviteUrl={callbackUrl} lastUsed={lastLoggedInWith === "Github"} source={source} />
+        <GithubButton returnToUrl={returnToUrl} lastUsed={lastLoggedInWith === "Github"} source={source} />
       )}
       {azureOAuthEnabled && (
-        <AzureButton inviteUrl={callbackUrl} lastUsed={lastLoggedInWith === "Azure"} source={source} />
+        <AzureButton returnToUrl={returnToUrl} lastUsed={lastLoggedInWith === "Azure"} source={source} />
       )}
       {oidcOAuthEnabled && (
         <OpenIdButton
-          inviteUrl={callbackUrl}
+          returnToUrl={returnToUrl}
           lastUsed={lastLoggedInWith === "OpenID"}
           text={t("auth.continue_with_oidc", { oidcDisplayName })}
           source={source}
@@ -64,7 +64,7 @@ export const SSOOptions = ({
       )}
       {samlSsoEnabled && (
         <SamlButton
-          inviteUrl={callbackUrl}
+          returnToUrl={returnToUrl}
           lastUsed={lastLoggedInWith === "Saml"}
           samlTenant={samlTenant}
           samlProduct={samlProduct}

--- a/apps/web/modules/ee/sso/lib/providers.test.ts
+++ b/apps/web/modules/ee/sso/lib/providers.test.ts
@@ -41,6 +41,7 @@ describe("SSO Providers", () => {
   test("should configure SAML provider correctly", () => {
     const providers = getSSOProviders();
     const samlProvider = providers[4];
+    const googleProvider = providers[1];
 
     expect(samlProvider.id).toBe("saml");
     expect(samlProvider.name).toBe("BoxyHQ SAML");
@@ -50,6 +51,7 @@ describe("SSO Providers", () => {
     expect((samlProvider as any).authorization?.url).toBe("https://test-app.com/api/auth/saml/authorize");
     expect(samlProvider.token).toBe("https://test-app.com/api/auth/saml/token");
     expect(samlProvider.userinfo).toBe("https://test-app.com/api/auth/saml/userinfo");
-    expect(samlProvider.allowDangerousEmailAccountLinking).toBe(true);
+    expect(googleProvider.allowDangerousEmailAccountLinking).toBeUndefined();
+    expect(samlProvider.allowDangerousEmailAccountLinking).toBeUndefined();
   });
 });

--- a/apps/web/modules/ee/sso/lib/providers.ts
+++ b/apps/web/modules/ee/sso/lib/providers.ts
@@ -26,7 +26,6 @@ export const getSSOProviders = () => [
   GoogleProvider({
     clientId: GOOGLE_CLIENT_ID || "",
     clientSecret: GOOGLE_CLIENT_SECRET || "",
-    allowDangerousEmailAccountLinking: true,
   }),
   AzureAD({
     clientId: AZUREAD_CLIENT_ID || "",
@@ -81,7 +80,6 @@ export const getSSOProviders = () => [
       clientId: "dummy",
       clientSecret: "dummy",
     },
-    allowDangerousEmailAccountLinking: true,
   },
 ];
 

--- a/apps/web/modules/ee/sso/lib/sso-handlers.ts
+++ b/apps/web/modules/ee/sso/lib/sso-handlers.ts
@@ -1,4 +1,4 @@
-import type { IdentityProvider, Organization } from "@prisma/client";
+import type { IdentityProvider, Organization, Prisma } from "@prisma/client";
 import type { Account } from "next-auth";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
@@ -24,19 +24,93 @@ import {
 import { getFirstOrganization } from "@/modules/ee/sso/lib/organization";
 import { createDefaultTeamMembership, getOrganizationByTeamId } from "@/modules/ee/sso/lib/team";
 
-const syncSsoAccount = async (userId: string, account: Account) => {
-  await upsertAccount({
-    userId,
-    type: account.type,
-    provider: account.provider,
-    providerAccountId: account.providerAccountId,
-    ...(account.access_token !== undefined ? { access_token: account.access_token } : {}),
-    ...(account.refresh_token !== undefined ? { refresh_token: account.refresh_token } : {}),
-    ...(account.expires_at !== undefined ? { expires_at: account.expires_at } : {}),
-    ...(account.scope !== undefined ? { scope: account.scope } : {}),
-    ...(account.token_type !== undefined ? { token_type: account.token_type } : {}),
-    ...(account.id_token !== undefined ? { id_token: account.id_token } : {}),
-  });
+const LINKED_SSO_LOOKUP_SELECT = {
+  id: true,
+  email: true,
+  locale: true,
+  emailVerified: true,
+  isActive: true,
+  identityProvider: true,
+  identityProviderAccountId: true,
+} as const;
+
+const OAUTH_ACCOUNT_NOT_LINKED_ERROR = "OAuthAccountNotLinked";
+
+const syncSsoAccount = async (userId: string, account: Account, tx?: Prisma.TransactionClient) => {
+  await upsertAccount(
+    {
+      userId,
+      type: account.type,
+      provider: account.provider,
+      providerAccountId: account.providerAccountId,
+      ...(account.access_token !== undefined ? { access_token: account.access_token } : {}),
+      ...(account.refresh_token !== undefined ? { refresh_token: account.refresh_token } : {}),
+      ...(account.expires_at !== undefined ? { expires_at: account.expires_at } : {}),
+      ...(account.scope !== undefined ? { scope: account.scope } : {}),
+      ...(account.token_type !== undefined ? { token_type: account.token_type } : {}),
+      ...(account.id_token !== undefined ? { id_token: account.id_token } : {}),
+    },
+    tx
+  );
+};
+
+const syncLinkedSsoUser = async ({
+  linkedUser,
+  user,
+  account,
+  contextLogger,
+  logSource,
+}: {
+  linkedUser: Pick<TUser, "id" | "email">;
+  user: TUser;
+  account: Account;
+  contextLogger: ReturnType<typeof logger.withContext>;
+  logSource: "account_row" | "legacy_identity_provider";
+}) => {
+  contextLogger.debug(
+    {
+      linkedUserId: linkedUser.id,
+      emailMatches: linkedUser.email === user.email,
+      logSource,
+    },
+    "Found existing linked SSO user"
+  );
+
+  if (linkedUser.email === user.email) {
+    await syncSsoAccount(linkedUser.id, account);
+    contextLogger.debug(
+      { linkedUserId: linkedUser.id, logSource },
+      "SSO callback successful: linked user, email matches"
+    );
+    return true;
+  }
+
+  contextLogger.debug(
+    { linkedUserId: linkedUser.id, logSource },
+    "Email changed in SSO provider, checking for conflicts"
+  );
+
+  const otherUserWithEmail = await getUserByEmail(user.email);
+
+  if (!otherUserWithEmail) {
+    contextLogger.debug(
+      { linkedUserId: linkedUser.id, action: "email_update", logSource },
+      "No other user with this email found, updating linked user email after SSO provider change"
+    );
+
+    await updateUser(linkedUser.id, { email: user.email });
+    await syncSsoAccount(linkedUser.id, account);
+    return true;
+  }
+
+  contextLogger.debug(
+    { linkedUserId: linkedUser.id, conflictingUserId: otherUserWithEmail.id, logSource },
+    "SSO callback failed: email conflict after provider change"
+  );
+
+  throw new Error(
+    "Looks like you updated your email somewhere else. A user with this new email exists already."
+  );
 };
 
 export const handleSsoCallback = async ({
@@ -92,93 +166,73 @@ export const handleSsoCallback = async ({
   }
 
   if (account.provider) {
-    // check if accounts for this provider / account Id already exists
     contextLogger.debug(
-      { lookupType: "sso_provider_account" },
-      "Checking for existing user with SSO provider"
+      { lookupType: "account_provider_account_id" },
+      "Checking for existing linked user by provider account"
     );
 
-    const existingUserWithAccount = await prisma.user.findFirst({
-      include: {
-        accounts: {
-          where: {
-            provider: account.provider,
-          },
+    const existingLinkedAccount = await prisma.account.findUnique({
+      where: {
+        provider_providerAccountId: {
+          provider: account.provider,
+          providerAccountId: account.providerAccountId,
         },
       },
+      select: {
+        user: {
+          select: LINKED_SSO_LOOKUP_SELECT,
+        },
+      },
+    });
+
+    if (existingLinkedAccount?.user) {
+      return syncLinkedSsoUser({
+        linkedUser: existingLinkedAccount.user,
+        user,
+        account,
+        contextLogger,
+        logSource: "account_row",
+      });
+    }
+
+    contextLogger.debug(
+      { lookupType: "legacy_identity_provider_account_id" },
+      "No account row found, checking for legacy linked SSO user"
+    );
+
+    const existingLegacyLinkedUser = await prisma.user.findFirst({
       where: {
         identityProvider: provider,
         identityProviderAccountId: account.providerAccountId,
       },
+      select: LINKED_SSO_LOOKUP_SELECT,
     });
 
-    if (existingUserWithAccount) {
-      contextLogger.debug(
-        {
-          existingUserId: existingUserWithAccount.id,
-          emailMatches: existingUserWithAccount.email === user.email,
-        },
-        "Found existing user with SSO provider"
-      );
-
-      // User with this provider found
-      // check if email still the same
-      if (existingUserWithAccount.email === user.email) {
-        await syncSsoAccount(existingUserWithAccount.id, account);
-        contextLogger.debug(
-          { existingUserId: existingUserWithAccount.id },
-          "SSO callback successful: existing user, email matches"
-        );
-        return true;
-      }
-
-      contextLogger.debug(
-        { existingUserId: existingUserWithAccount.id },
-        "Email changed in SSO provider, checking for conflicts"
-      );
-
-      // user seemed to change his email within the provider
-      // check if user with this email already exist
-      // if not found just update user with new email address
-      // if found throw an error (TODO find better solution)
-      const otherUserWithEmail = await getUserByEmail(user.email);
-
-      if (!otherUserWithEmail) {
-        contextLogger.debug(
-          { existingUserId: existingUserWithAccount.id, action: "email_update" },
-          "No other user with this email found, updating user email after SSO provider change"
-        );
-
-        await updateUser(existingUserWithAccount.id, { email: user.email });
-        await syncSsoAccount(existingUserWithAccount.id, account);
-        return true;
-      }
-
-      contextLogger.debug(
-        { existingUserId: existingUserWithAccount.id, conflictingUserId: otherUserWithEmail.id },
-        "SSO callback failed: email conflict after provider change"
-      );
-
-      throw new Error(
-        "Looks like you updated your email somewhere else. A user with this new email exists already."
-      );
+    if (existingLegacyLinkedUser) {
+      return syncLinkedSsoUser({
+        linkedUser: existingLegacyLinkedUser,
+        user,
+        account,
+        contextLogger,
+        logSource: "legacy_identity_provider",
+      });
     }
 
-    // There is no existing account for this identity provider / account id
-    // check if user account with this email already exists
-    // if user already exists throw error and request password login
-    contextLogger.debug({ lookupType: "email" }, "No existing SSO account found, checking for user by email");
+    // There is no existing linked account for this identity provider / account id
+    // check if a user account with this email already exists and fail closed if so
+    contextLogger.debug({ lookupType: "email" }, "No linked SSO account found, checking for user by email");
 
     const existingUserWithEmail = await getUserByEmail(user.email);
 
     if (existingUserWithEmail) {
-      await syncSsoAccount(existingUserWithEmail.id, account);
       contextLogger.debug(
-        { existingUserId: existingUserWithEmail.id, action: "existing_user_login" },
-        "SSO callback successful: existing user found by email"
+        {
+          existingUserId: existingUserWithEmail.id,
+          existingIdentityProvider: existingUserWithEmail.identityProvider,
+        },
+        "SSO callback blocked: existing user found by email without linked provider account"
       );
-      // Sign in the user with the existing account
-      return true;
+      throw new Error(OAUTH_ACCOUNT_NOT_LINKED_ERROR);
     }
 
     contextLogger.debug(
@@ -339,19 +393,66 @@ export const handleSsoCallback = async ({
     }
 
     contextLogger.debug({ hasUserName: !!userName, identityProvider: provider }, "Creating new SSO user");
+    const matchedLocale = await findMatchingLocale();
 
-    const userProfile = await createUser({
-      name:
-        userName ||
-        user.email
-          .split("@")[0]
-          .replace(/[^'\p{L}\p{M}\s\d-]+/gu, " ")
-          .trim(),
-      email: user.email,
-      emailVerified: new Date(Date.now()),
-      identityProvider: provider,
-      identityProviderAccountId: account.providerAccountId,
-      locale: await findMatchingLocale(),
+    const userProfile = await prisma.$transaction(async (tx) => {
+      const createdUser = await createUser(
+        {
+          name:
+            userName ||
+            user.email
+              .split("@")[0]
+              .replace(/[^'\p{L}\p{M}\s\d-]+/gu, " ")
+              .trim(),
+          email: user.email,
+          emailVerified: new Date(Date.now()),
+          identityProvider: provider,
+          identityProviderAccountId: account.providerAccountId,
+          locale: matchedLocale,
+        },
+        tx
+      );
+
+      await syncSsoAccount(createdUser.id, account, tx);
+
+      if (organization) {
+        contextLogger.debug(
+          { newUserId: createdUser.id, organizationId: organization.id, role: "member" },
+          "Assigning user to organization"
+        );
+        await createMembership(organization.id, createdUser.id, { role: "member", accepted: true }, tx);
+
+        if (SKIP_INVITE_FOR_SSO && DEFAULT_TEAM_ID) {
+          contextLogger.debug(
+            { newUserId: createdUser.id, defaultTeamId: DEFAULT_TEAM_ID },
+            "Creating default team membership"
+          );
+          await createDefaultTeamMembership(createdUser.id, tx);
+        }
+
+        const updatedNotificationSettings: TUserNotificationSettings = {
+          ...createdUser.notificationSettings,
+          alert: {
+            ...createdUser.notificationSettings?.alert,
+          },
+          unsubscribedOrganizationIds: Array.from(
+            new Set([
+              ...(createdUser.notificationSettings?.unsubscribedOrganizationIds || []),
+              organization.id,
+            ])
+          ),
+        };
+
+        await updateUser(
+          createdUser.id,
+          {
+            notificationSettings: updatedNotificationSettings,
+          },
+          tx
+        );
+      }
+
+      return createdUser;
     });
 
     contextLogger.debug(
@@ -369,8 +470,6 @@ export const handleSsoCallback = async ({
       invite_organization_id: organization?.id ?? null,
     });
 
-    await syncSsoAccount(userProfile.id, account);
-
     if (isMultiOrgEnabled) {
       contextLogger.debug(
         { isMultiOrgEnabled, newUserId: userProfile.id },
@@ -381,33 +480,6 @@ export const handleSsoCallback = async ({
 
     // Default organization assignment if env variable is set
     if (organization) {
-      contextLogger.debug(
-        { newUserId: userProfile.id, organizationId: organization.id, role: "member" },
-        "Assigning user to organization"
-      );
-      await createMembership(organization.id, userProfile.id, { role: "member", accepted: true });
-
-      if (SKIP_INVITE_FOR_SSO && DEFAULT_TEAM_ID) {
-        contextLogger.debug(
-          { newUserId: userProfile.id, defaultTeamId: DEFAULT_TEAM_ID },
-          "Creating default team membership"
-        );
-        await createDefaultTeamMembership(userProfile.id);
-      }
-
-      const updatedNotificationSettings: TUserNotificationSettings = {
-        ...userProfile.notificationSettings,
-        alert: {
-          ...userProfile.notificationSettings?.alert,
-        },
-        unsubscribedOrganizationIds: Array.from(
-          new Set([...(userProfile.notificationSettings?.unsubscribedOrganizationIds || []), organization.id])
-        ),
-      };
-
-      await updateUser(userProfile.id, {
-        notificationSettings: updatedNotificationSettings,
-      });
       return true;
     }
     // Without default organization assignment

--- a/apps/web/modules/ee/sso/lib/team.ts
+++ b/apps/web/modules/ee/sso/lib/team.ts
@@ -1,5 +1,5 @@
 import "server-only";
-import { Organization, Team } from "@prisma/client";
+import { Organization, Prisma, PrismaClient, Team } from "@prisma/client";
 import { cache as reactCache } from "react";
 import { z } from "zod";
 import { prisma } from "@formbricks/database";
@@ -9,6 +9,10 @@ import { DEFAULT_TEAM_ID } from "@/lib/constants";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { validateInputs } from "@/lib/utils/validate";
 import { createTeamMembership } from "@/modules/auth/signup/lib/team";
+
+type TSsoTeamDbClient = PrismaClient | Prisma.TransactionClient;
+
+const getDbClient = (tx?: Prisma.TransactionClient): TSsoTeamDbClient => tx ?? prisma;
 
 export const getOrganizationByTeamId = reactCache(async (teamId: string): Promise<Organization | null> => {
   validateInputs([teamId, z.cuid2()]);
@@ -52,8 +56,9 @@ const getTeam = reactCache(async (teamId: string): Promise<Team> => {
   }
 });
 
-export const createDefaultTeamMembership = async (userId: string) => {
+export const createDefaultTeamMembership = async (userId: string, tx?: Prisma.TransactionClient) => {
   try {
+    const prismaClient = getDbClient(tx);
     const defaultTeamId = DEFAULT_TEAM_ID;
 
     if (!defaultTeamId) {
@@ -61,17 +66,29 @@ export const createDefaultTeamMembership = async (userId: string) => {
       return;
     }
 
-    const defaultTeam = await getTeam(defaultTeamId);
+    const defaultTeam = tx
+      ? await prismaClient.team.findUnique({
+          where: {
+            id: defaultTeamId,
+          },
+        })
+      : await getTeam(defaultTeamId);
 
     if (!defaultTeam) {
       logger.error("Default team not found");
       return;
     }
 
-    const organizationMembership = await getMembershipByUserIdOrganizationId(
-      userId,
-      defaultTeam.organizationId
-    );
+    const organizationMembership = tx
+      ? await prismaClient.membership.findUnique({
+          where: {
+            userId_organizationId: {
+              userId,
+              organizationId: defaultTeam.organizationId,
+            },
+          },
+        })
+      : await getMembershipByUserIdOrganizationId(userId, defaultTeam.organizationId);
 
     if (!organizationMembership) {
       logger.error("Organization membership not found");
@@ -86,7 +103,8 @@ export const createDefaultTeamMembership = async (userId: string) => {
         role: membershipRole,
         teamIds: [defaultTeamId],
       },
-      userId
+      userId,
+      tx
     );
   } catch (error) {
     logger.error(

--- a/apps/web/modules/ee/sso/lib/team.ts
+++ b/apps/web/modules/ee/sso/lib/team.ts
@@ -79,16 +79,11 @@ export const createDefaultTeamMembership = async (userId: string, tx?: Prisma.Tr
       return;
     }
 
-    const organizationMembership = tx
-      ? await prismaClient.membership.findUnique({
-          where: {
-            userId_organizationId: {
-              userId,
-              organizationId: defaultTeam.organizationId,
-            },
-          },
-        })
-      : await getMembershipByUserIdOrganizationId(userId, defaultTeam.organizationId);
+    const organizationMembership = await getMembershipByUserIdOrganizationId(
+      userId,
+      defaultTeam.organizationId,
+      tx
+    );
 
     if (!organizationMembership) {
       logger.error("Organization membership not found");

--- a/apps/web/modules/ee/sso/lib/tests/sso-handlers.test.ts
+++ b/apps/web/modules/ee/sso/lib/tests/sso-handlers.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import type { TUser } from "@formbricks/types/user";
 import { upsertAccount } from "@/lib/account/service";
+import { getIsFreshInstance } from "@/lib/instance/service";
 import { createMembership } from "@/lib/membership/service";
 import { createOrganization, getOrganization } from "@/lib/organization/service";
 import { capturePostHogEvent } from "@/lib/posthog";
@@ -52,11 +53,19 @@ vi.mock("@/modules/ee/license-check/lib/utils", () => ({
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
+    $transaction: vi.fn(async (callback: (tx: Record<string, never>) => unknown) => await callback({})),
+    account: {
+      findUnique: vi.fn(),
+    },
     user: {
       findFirst: vi.fn(),
       count: vi.fn(), // Add count mock for user
     },
   },
+}));
+
+vi.mock("@/lib/instance/service", () => ({
+  getIsFreshInstance: vi.fn(),
 }));
 
 vi.mock("@/modules/ee/sso/lib/team", () => ({
@@ -121,6 +130,7 @@ describe("handleSsoCallback", () => {
     vi.mocked(getIsSamlSsoEnabled).mockResolvedValue(true);
     vi.mocked(findMatchingLocale).mockResolvedValue("en-US");
     vi.mocked(getIsMultiOrgEnabled).mockResolvedValue(true);
+    vi.mocked(getIsFreshInstance).mockResolvedValue(true);
 
     // Mock organization-related functions
     vi.mocked(getOrganization).mockResolvedValue(mockOrganization);
@@ -183,10 +193,11 @@ describe("handleSsoCallback", () => {
 
   describe("Existing user handling", () => {
     test("should return true if user with account already exists and email is the same", async () => {
-      vi.mocked(prisma.user.findFirst).mockResolvedValue({
-        ...mockUser,
-        email: mockUser.email,
-        accounts: [{ provider: mockAccount.provider }],
+      vi.mocked(prisma.account.findUnique).mockResolvedValue({
+        user: {
+          ...mockUser,
+          email: mockUser.email,
+        },
       } as any);
 
       const result = await handleSsoCallback({
@@ -196,26 +207,35 @@ describe("handleSsoCallback", () => {
       });
 
       expect(result).toBe(true);
-      expect(prisma.user.findFirst).toHaveBeenCalledWith({
-        include: {
-          accounts: {
-            where: {
-              provider: mockAccount.provider,
-            },
+      expect(prisma.account.findUnique).toHaveBeenCalledWith({
+        where: {
+          provider_providerAccountId: {
+            provider: mockAccount.provider,
+            providerAccountId: mockAccount.providerAccountId,
           },
         },
-        where: {
-          identityProvider: mockAccount.provider.toLowerCase().replace("-", ""),
-          identityProviderAccountId: mockAccount.providerAccountId,
+        select: {
+          user: {
+            select: {
+              id: true,
+              email: true,
+              locale: true,
+              emailVerified: true,
+              isActive: true,
+              identityProvider: true,
+              identityProviderAccountId: true,
+            },
+          },
         },
       });
     });
 
     test("should not overwrite stored tokens when the provider omits them", async () => {
-      vi.mocked(prisma.user.findFirst).mockResolvedValue({
-        ...mockUser,
-        email: mockUser.email,
-        accounts: [{ provider: mockAccount.provider }],
+      vi.mocked(prisma.account.findUnique).mockResolvedValue({
+        user: {
+          ...mockUser,
+          email: mockUser.email,
+        },
       } as any);
 
       const result = await handleSsoCallback({
@@ -233,12 +253,15 @@ describe("handleSsoCallback", () => {
       });
 
       expect(result).toBe(true);
-      expect(upsertAccount).toHaveBeenCalledWith({
-        userId: mockUser.id,
-        type: mockAccount.type,
-        provider: mockAccount.provider,
-        providerAccountId: mockAccount.providerAccountId,
-      });
+      expect(upsertAccount).toHaveBeenCalledWith(
+        {
+          userId: mockUser.id,
+          type: mockAccount.type,
+          provider: mockAccount.provider,
+          providerAccountId: mockAccount.providerAccountId,
+        },
+        undefined
+      );
     });
 
     test("should update user email if user with account exists but email changed", async () => {
@@ -246,10 +269,9 @@ describe("handleSsoCallback", () => {
         ...mockUser,
         id: "existing-user-id",
         email: "old-email@example.com",
-        accounts: [{ provider: mockAccount.provider }],
       };
 
-      vi.mocked(prisma.user.findFirst).mockResolvedValue(existingUser as any);
+      vi.mocked(prisma.account.findUnique).mockResolvedValue({ user: existingUser } as any);
       vi.mocked(getUserByEmail).mockResolvedValue(null);
       vi.mocked(updateUser).mockResolvedValue({ ...existingUser, email: mockUser.email });
 
@@ -268,10 +290,9 @@ describe("handleSsoCallback", () => {
         ...mockUser,
         id: "existing-user-id",
         email: "old-email@example.com",
-        accounts: [{ provider: mockAccount.provider }],
       };
 
-      vi.mocked(prisma.user.findFirst).mockResolvedValue(existingUser as any);
+      vi.mocked(prisma.account.findUnique).mockResolvedValue({ user: existingUser } as any);
       vi.mocked(getUserByEmail).mockResolvedValue({
         id: "another-user-id",
         email: mockUser.email,
@@ -292,16 +313,13 @@ describe("handleSsoCallback", () => {
       );
     });
 
-    test("should return true if user with email already exists", async () => {
-      vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
-      vi.mocked(getUserByEmail).mockResolvedValue({
-        id: "existing-user-id",
-        email: mockUser.email,
-        emailVerified: mockUser.emailVerified,
+    test("should backfill the account row for legacy linked SSO users", async () => {
+      vi.mocked(prisma.account.findUnique).mockResolvedValue(null);
+      vi.mocked(prisma.user.findFirst).mockResolvedValue({
+        ...mockUser,
         identityProvider: "google",
-        locale: mockUser.locale,
-        isActive: true,
-      });
+        identityProviderAccountId: mockAccount.providerAccountId,
+      } as any);
 
       const result = await handleSsoCallback({
         user: mockUser,
@@ -310,6 +328,91 @@ describe("handleSsoCallback", () => {
       });
 
       expect(result).toBe(true);
+      expect(upsertAccount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: mockUser.id,
+          provider: mockAccount.provider,
+          providerAccountId: mockAccount.providerAccountId,
+        }),
+        undefined
+      );
+    });
+
+    test("should reject verified email users whose SSO provider is not already linked", async () => {
+      vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
+      vi.mocked(getUserByEmail).mockResolvedValue({
+        id: "existing-user-id",
+        email: mockUser.email,
+        emailVerified: new Date(),
+        identityProvider: "email",
+        locale: mockUser.locale,
+        isActive: true,
+      });
+
+      await expect(
+        handleSsoCallback({
+          user: mockUser,
+          account: mockAccount,
+          callbackUrl: "http://localhost:3000",
+        })
+      ).rejects.toThrow("OAuthAccountNotLinked");
+      expect(upsertAccount).not.toHaveBeenCalled();
+      expect(updateUser).not.toHaveBeenCalled();
+      expect(createUser).not.toHaveBeenCalled();
+      expect(createMembership).not.toHaveBeenCalled();
+      expect(createBrevoCustomer).not.toHaveBeenCalled();
+      expect(capturePostHogEvent).not.toHaveBeenCalled();
+    });
+
+    test("should reject unverified email users whose SSO provider is not already linked", async () => {
+      vi.mocked(prisma.account.findUnique).mockResolvedValue(null);
+      vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
+      vi.mocked(getUserByEmail).mockResolvedValue({
+        id: "existing-user-id",
+        email: mockUser.email,
+        emailVerified: null,
+        identityProvider: "email",
+        locale: mockUser.locale,
+        isActive: true,
+      });
+
+      await expect(
+        handleSsoCallback({
+          user: mockUser,
+          account: mockAccount,
+          callbackUrl: "http://localhost:3000",
+        })
+      ).rejects.toThrow("OAuthAccountNotLinked");
+      expect(upsertAccount).not.toHaveBeenCalled();
+      expect(updateUser).not.toHaveBeenCalled();
+      expect(createUser).not.toHaveBeenCalled();
+      expect(createMembership).not.toHaveBeenCalled();
+      expect(createBrevoCustomer).not.toHaveBeenCalled();
+      expect(capturePostHogEvent).not.toHaveBeenCalled();
+    });
+
+    test("should reject existing users from a different SSO provider when no link exists", async () => {
+      vi.mocked(prisma.account.findUnique).mockResolvedValue(null);
+      vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
+      vi.mocked(getUserByEmail).mockResolvedValue({
+        id: "existing-user-id",
+        email: mockUser.email,
+        emailVerified: new Date(),
+        identityProvider: "github",
+        locale: mockUser.locale,
+        isActive: true,
+      });
+
+      await expect(
+        handleSsoCallback({
+          user: mockUser,
+          account: mockAccount,
+          callbackUrl: "http://localhost:3000",
+        })
+      ).rejects.toThrow("OAuthAccountNotLinked");
+      expect(upsertAccount).not.toHaveBeenCalled();
+      expect(updateUser).not.toHaveBeenCalled();
+      expect(createUser).not.toHaveBeenCalled();
     });
   });
 
@@ -326,14 +429,17 @@ describe("handleSsoCallback", () => {
       });
 
       expect(result).toBe(true);
-      expect(createUser).toHaveBeenCalledWith({
-        name: mockUser.name,
-        email: mockUser.email,
-        emailVerified: expect.any(Date),
-        identityProvider: mockAccount.provider.toLowerCase().replace("-", ""),
-        identityProviderAccountId: mockAccount.providerAccountId,
-        locale: "en-US",
-      });
+      expect(createUser).toHaveBeenCalledWith(
+        {
+          name: mockUser.name,
+          email: mockUser.email,
+          emailVerified: expect.any(Date),
+          identityProvider: mockAccount.provider.toLowerCase().replace("-", ""),
+          identityProviderAccountId: mockAccount.providerAccountId,
+          locale: "en-US",
+        },
+        expect.anything()
+      );
       expect(createBrevoCustomer).toHaveBeenCalledWith({ id: mockUser.id, email: mockUser.email });
     });
 
@@ -435,7 +541,8 @@ describe("handleSsoCallback", () => {
       expect(createUser).toHaveBeenCalledWith(
         expect.objectContaining({
           name: "Direct Name",
-        })
+        }),
+        expect.anything()
       );
     });
 
@@ -461,7 +568,8 @@ describe("handleSsoCallback", () => {
       expect(createUser).toHaveBeenCalledWith(
         expect.objectContaining({
           name: "John Doe",
-        })
+        }),
+        expect.anything()
       );
     });
 
@@ -488,7 +596,8 @@ describe("handleSsoCallback", () => {
       expect(createUser).toHaveBeenCalledWith(
         expect.objectContaining({
           name: "preferred.user",
-        })
+        }),
+        expect.anything()
       );
     });
 
@@ -516,7 +625,8 @@ describe("handleSsoCallback", () => {
       expect(createUser).toHaveBeenCalledWith(
         expect.objectContaining({
           name: "test user",
-        })
+        }),
+        expect.anything()
       );
     });
   });
@@ -545,7 +655,8 @@ describe("handleSsoCallback", () => {
       expect(createUser).toHaveBeenCalledWith(
         expect.objectContaining({
           name: "Direct Name",
-        })
+        }),
+        expect.anything()
       );
     });
 
@@ -572,7 +683,8 @@ describe("handleSsoCallback", () => {
       expect(createUser).toHaveBeenCalledWith(
         expect.objectContaining({
           name: "John Doe",
-        })
+        }),
+        expect.anything()
       );
     });
   });
@@ -581,6 +693,7 @@ describe("handleSsoCallback", () => {
     test("should return false when auto-provisioning is disabled and no callback URL or multi-org", async () => {
       vi.resetModules();
 
+      vi.mocked(getIsFreshInstance).mockResolvedValue(false);
       vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
       vi.mocked(getUserByEmail).mockResolvedValue(null);
       vi.mocked(getIsMultiOrgEnabled).mockResolvedValue(false);
@@ -620,6 +733,23 @@ describe("handleSsoCallback", () => {
           callbackUrl: "http://localhost:3000",
         })
       ).rejects.toThrow("Locale error");
+    });
+
+    test("should not trigger signup side effects when transactional provisioning fails", async () => {
+      vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
+      vi.mocked(getUserByEmail).mockResolvedValue(null);
+      vi.mocked(createUser).mockRejectedValue(new Error("Create user failed"));
+
+      await expect(
+        handleSsoCallback({
+          user: mockUser,
+          account: mockAccount,
+          callbackUrl: "http://localhost:3000",
+        })
+      ).rejects.toThrow("Create user failed");
+
+      expect(createBrevoCustomer).not.toHaveBeenCalled();
+      expect(capturePostHogEvent).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/modules/ee/sso/lib/tests/team.test.ts
+++ b/apps/web/modules/ee/sso/lib/tests/team.test.ts
@@ -67,9 +67,6 @@ describe("Team Management", () => {
       test("creates the default team membership successfully", async () => {
         vi.mocked(prisma.team.findUnique).mockResolvedValue(MOCK_DEFAULT_TEAM);
         vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(MOCK_ORGANIZATION_MEMBERSHIP);
-        vi.mocked(prisma.team.findUnique).mockResolvedValue({
-          projectTeams: { projectId: ["test-project-id"] },
-        } as any);
         vi.mocked(prisma.teamUser.upsert).mockResolvedValue(MOCK_DEFAULT_TEAM_USER as any);
 
         await createDefaultTeamMembership(MOCK_IDS.userId);
@@ -79,6 +76,11 @@ describe("Team Management", () => {
             id: "team-123",
           },
         });
+        expect(getMembershipByUserIdOrganizationId).toHaveBeenCalledWith(
+          MOCK_IDS.userId,
+          MOCK_DEFAULT_TEAM.organizationId,
+          undefined
+        );
 
         expect(prisma.teamUser.upsert).toHaveBeenCalledWith({
           create: {
@@ -96,6 +98,27 @@ describe("Team Management", () => {
             },
           },
         });
+      });
+
+      test("passes the transaction client into membership resolution when provided", async () => {
+        const tx = {
+          team: {
+            findUnique: vi.fn().mockResolvedValue(MOCK_DEFAULT_TEAM),
+          },
+          teamUser: {
+            upsert: vi.fn().mockResolvedValue(MOCK_DEFAULT_TEAM_USER),
+          },
+        } as any;
+
+        vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(MOCK_ORGANIZATION_MEMBERSHIP);
+
+        await createDefaultTeamMembership(MOCK_IDS.userId, tx);
+
+        expect(getMembershipByUserIdOrganizationId).toHaveBeenCalledWith(
+          MOCK_IDS.userId,
+          MOCK_DEFAULT_TEAM.organizationId,
+          tx
+        );
       });
     });
 

--- a/apps/web/modules/ee/sso/lib/tests/team.test.ts
+++ b/apps/web/modules/ee/sso/lib/tests/team.test.ts
@@ -20,7 +20,7 @@ const setupMocks = () => {
         findUnique: vi.fn(),
       },
       teamUser: {
-        create: vi.fn(),
+        upsert: vi.fn(),
       },
     },
   }));
@@ -70,7 +70,7 @@ describe("Team Management", () => {
         vi.mocked(prisma.team.findUnique).mockResolvedValue({
           projectTeams: { projectId: ["test-project-id"] },
         } as any);
-        vi.mocked(prisma.teamUser.create).mockResolvedValue(MOCK_DEFAULT_TEAM_USER);
+        vi.mocked(prisma.teamUser.upsert).mockResolvedValue(MOCK_DEFAULT_TEAM_USER as any);
 
         await createDefaultTeamMembership(MOCK_IDS.userId);
 
@@ -80,11 +80,20 @@ describe("Team Management", () => {
           },
         });
 
-        expect(prisma.teamUser.create).toHaveBeenCalledWith({
-          data: {
+        expect(prisma.teamUser.upsert).toHaveBeenCalledWith({
+          create: {
             teamId: "team-123",
             userId: MOCK_IDS.userId,
             role: "admin",
+          },
+          update: {
+            role: "admin",
+          },
+          where: {
+            teamId_userId: {
+              teamId: "team-123",
+              userId: MOCK_IDS.userId,
+            },
           },
         });
       });
@@ -106,7 +115,7 @@ describe("Team Management", () => {
       test("handles database errors gracefully", async () => {
         vi.mocked(prisma.team.findUnique).mockResolvedValue(MOCK_DEFAULT_TEAM);
         vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(MOCK_ORGANIZATION_MEMBERSHIP);
-        vi.mocked(prisma.teamUser.create).mockRejectedValue(new Error("Database error"));
+        vi.mocked(prisma.teamUser.upsert).mockRejectedValue(new Error("Database error"));
 
         await createDefaultTeamMembership(MOCK_IDS.userId);
       });

--- a/apps/web/modules/ee/sso/lib/tests/utils.test.ts
+++ b/apps/web/modules/ee/sso/lib/tests/utils.test.ts
@@ -1,34 +1,34 @@
 import { describe, expect, test } from "vitest";
-import { getCallbackUrl } from "../utils";
+import { getSsoReturnToUrl } from "../utils";
 
-describe("getCallbackUrl", () => {
-  test("should return base URL with source when no inviteUrl is provided", () => {
-    const result = getCallbackUrl(undefined, "test-source");
+describe("getSsoReturnToUrl", () => {
+  test("should return base URL with source when no return URL is provided", () => {
+    const result = getSsoReturnToUrl(undefined, "test-source");
     expect(result).toBe("/?source=test-source");
   });
 
-  test("should append source parameter to inviteUrl with existing query parameters", () => {
-    const result = getCallbackUrl("https://example.com/invite?param=value", "test-source");
+  test("should append source parameter to the return URL with existing query parameters", () => {
+    const result = getSsoReturnToUrl("https://example.com/invite?param=value", "test-source");
     expect(result).toBe("https://example.com/invite?param=value&source=test-source");
   });
 
-  test("should append source parameter to inviteUrl without existing query parameters", () => {
-    const result = getCallbackUrl("https://example.com/invite", "test-source");
+  test("should append source parameter to the return URL without existing query parameters", () => {
+    const result = getSsoReturnToUrl("https://example.com/invite", "test-source");
     expect(result).toBe("https://example.com/invite?source=test-source");
   });
 
   test("should handle empty source parameter", () => {
-    const result = getCallbackUrl("https://example.com/invite", "");
+    const result = getSsoReturnToUrl("https://example.com/invite", "");
     expect(result).toBe("https://example.com/invite");
   });
 
   test("should avoid serializing undefined source parameters", () => {
-    const result = getCallbackUrl("https://example.com/invite", undefined);
+    const result = getSsoReturnToUrl("https://example.com/invite", undefined);
     expect(result).toBe("https://example.com/invite");
   });
 
   test("should replace an existing source parameter instead of duplicating it", () => {
-    const result = getCallbackUrl("https://example.com/invite?source=signup&token=abc", "signin");
+    const result = getSsoReturnToUrl("https://example.com/invite?source=signup&token=abc", "signin");
     expect(result).toBe("https://example.com/invite?source=signin&token=abc");
   });
 });

--- a/apps/web/modules/ee/sso/lib/tests/utils.test.ts
+++ b/apps/web/modules/ee/sso/lib/tests/utils.test.ts
@@ -19,11 +19,16 @@ describe("getCallbackUrl", () => {
 
   test("should handle empty source parameter", () => {
     const result = getCallbackUrl("https://example.com/invite", "");
-    expect(result).toBe("https://example.com/invite?source=");
+    expect(result).toBe("https://example.com/invite");
   });
 
-  test("should handle undefined source parameter", () => {
+  test("should avoid serializing undefined source parameters", () => {
     const result = getCallbackUrl("https://example.com/invite", undefined);
-    expect(result).toBe("https://example.com/invite?source=undefined");
+    expect(result).toBe("https://example.com/invite");
+  });
+
+  test("should replace an existing source parameter instead of duplicating it", () => {
+    const result = getCallbackUrl("https://example.com/invite?source=signup&token=abc", "signin");
+    expect(result).toBe("https://example.com/invite?source=signin&token=abc");
   });
 });

--- a/apps/web/modules/ee/sso/lib/utils.ts
+++ b/apps/web/modules/ee/sso/lib/utils.ts
@@ -1,5 +1,14 @@
 export const getCallbackUrl = (inviteUrl?: string, source?: string) => {
-  return inviteUrl
-    ? `${inviteUrl}${inviteUrl.includes("?") ? "&" : "?"}source=${source}`
-    : `/?source=${source}`;
+  const fallbackBaseUrl = "http://localhost";
+  const callbackUrl = new URL(inviteUrl ?? "/", fallbackBaseUrl);
+
+  if (source) {
+    callbackUrl.searchParams.set("source", source);
+  }
+
+  if (!inviteUrl || inviteUrl.startsWith("/")) {
+    return `${callbackUrl.pathname}${callbackUrl.search}${callbackUrl.hash}`;
+  }
+
+  return callbackUrl.toString();
 };

--- a/apps/web/modules/ee/sso/lib/utils.ts
+++ b/apps/web/modules/ee/sso/lib/utils.ts
@@ -1,14 +1,14 @@
-export const getCallbackUrl = (inviteUrl?: string, source?: string) => {
+export const getSsoReturnToUrl = (returnToUrl?: string, source?: string) => {
   const fallbackBaseUrl = "http://localhost";
-  const callbackUrl = new URL(inviteUrl ?? "/", fallbackBaseUrl);
+  const nextReturnToUrl = new URL(returnToUrl ?? "/", fallbackBaseUrl);
 
   if (source) {
-    callbackUrl.searchParams.set("source", source);
+    nextReturnToUrl.searchParams.set("source", source);
   }
 
-  if (!inviteUrl || inviteUrl.startsWith("/")) {
-    return `${callbackUrl.pathname}${callbackUrl.search}${callbackUrl.hash}`;
+  if (!returnToUrl || returnToUrl.startsWith("/")) {
+    return `${nextReturnToUrl.pathname}${nextReturnToUrl.search}${nextReturnToUrl.hash}`;
   }
 
-  return callbackUrl.toString();
+  return nextReturnToUrl.toString();
 };

--- a/apps/web/modules/email/index.tsx
+++ b/apps/web/modules/email/index.tsx
@@ -41,6 +41,7 @@ import { getPublicDomain } from "@/lib/getPublicUrl";
 import { createEmailChangeToken, createInviteToken, createToken, createTokenForLinkSurvey } from "@/lib/jwt";
 import { getOrganizationByEnvironmentId } from "@/lib/organization/service";
 import { getElementResponseMapping } from "@/lib/responses";
+import { getValidatedCallbackUrl } from "@/lib/utils/url";
 import { getTranslate } from "@/lingodotdev/server";
 import { resolveStorageUrl } from "@/modules/storage/utils";
 
@@ -126,22 +127,32 @@ export const sendVerificationEmail = async ({
   id,
   email,
   locale,
+  callbackUrl,
 }: {
   id: string;
   email: TUserEmail;
   locale: TUserLocale;
+  callbackUrl?: string;
 }): Promise<boolean> => {
   try {
     const t = await getTranslate(locale);
     const token = createToken(id, {
       expiresIn: "1d",
     });
-    const verifyLink = `${WEBAPP_URL}/auth/verify?token=${encodeURIComponent(token)}`;
-    const verificationRequestLink = `${WEBAPP_URL}/auth/verification-requested?token=${encodeURIComponent(token)}`;
+    const validatedCallbackUrl = getValidatedCallbackUrl(callbackUrl, WEBAPP_URL);
+    const verifyLink = new URL("/auth/verify", WEBAPP_URL);
+    verifyLink.searchParams.set("token", token);
+    const verificationRequestLink = new URL("/auth/verification-requested", WEBAPP_URL);
+    verificationRequestLink.searchParams.set("token", token);
+
+    if (validatedCallbackUrl) {
+      verifyLink.searchParams.set("callbackUrl", validatedCallbackUrl);
+      verificationRequestLink.searchParams.set("callbackUrl", validatedCallbackUrl);
+    }
 
     const html = await renderVerificationEmail({
-      verificationRequestLink,
-      verifyLink,
+      verificationRequestLink: verificationRequestLink.toString(),
+      verifyLink: verifyLink.toString(),
       t,
       ...legalProps,
     });

--- a/apps/web/modules/email/index.tsx
+++ b/apps/web/modules/email/index.tsx
@@ -41,8 +41,8 @@ import { getPublicDomain } from "@/lib/getPublicUrl";
 import { createEmailChangeToken, createInviteToken, createToken, createTokenForLinkSurvey } from "@/lib/jwt";
 import { getOrganizationByEnvironmentId } from "@/lib/organization/service";
 import { getElementResponseMapping } from "@/lib/responses";
-import { getValidatedCallbackUrl } from "@/lib/utils/url";
 import { getTranslate } from "@/lingodotdev/server";
+import { buildVerificationLinks } from "@/modules/auth/lib/verification-links";
 import { resolveStorageUrl } from "@/modules/storage/utils";
 
 export const IS_SMTP_CONFIGURED = Boolean(SMTP_HOST && SMTP_PORT);
@@ -139,20 +139,15 @@ export const sendVerificationEmail = async ({
     const token = createToken(id, {
       expiresIn: "1d",
     });
-    const validatedCallbackUrl = getValidatedCallbackUrl(callbackUrl, WEBAPP_URL);
-    const verifyLink = new URL("/auth/verify", WEBAPP_URL);
-    verifyLink.searchParams.set("token", token);
-    const verificationRequestLink = new URL("/auth/verification-requested", WEBAPP_URL);
-    verificationRequestLink.searchParams.set("token", token);
-
-    if (validatedCallbackUrl) {
-      verifyLink.searchParams.set("callbackUrl", validatedCallbackUrl);
-      verificationRequestLink.searchParams.set("callbackUrl", validatedCallbackUrl);
-    }
+    const { verifyLink, verificationRequestLink } = buildVerificationLinks({
+      token,
+      webAppUrl: WEBAPP_URL,
+      callbackUrl,
+    });
 
     const html = await renderVerificationEmail({
-      verificationRequestLink: verificationRequestLink.toString(),
-      verifyLink: verifyLink.toString(),
+      verificationRequestLink,
+      verifyLink,
       t,
       ...legalProps,
     });

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -29,7 +29,19 @@ vi.mock("@/lib/constants", () => ({
 }));
 
 vi.mock("@/lib/utils/url", () => ({
-  isValidCallbackUrl: (url: string) => url.startsWith("http://localhost:3000"),
+  getValidatedCallbackUrl: (url: string | null, webAppUrl: string) => {
+    if (!url) {
+      return null;
+    }
+
+    try {
+      const parsedWebAppUrl = new URL(webAppUrl);
+      const parsedUrl = new URL(url, parsedWebAppUrl.origin);
+      return parsedUrl.origin === parsedWebAppUrl.origin ? parsedUrl.toString() : null;
+    } catch {
+      return null;
+    }
+  },
 }));
 
 vi.mock("@formbricks/logger", () => ({
@@ -61,6 +73,19 @@ describe("proxy", () => {
 
     const response = await proxy(
       new NextRequest("http://localhost:3000/auth/login?callbackUrl=https%3A%2F%2Fevil.example")
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid callback URL" });
+  });
+
+  test("rejects callback URLs that only match the hostname on a different port", async () => {
+    mockGetProxySession.mockResolvedValue(null);
+
+    const response = await proxy(
+      new NextRequest(
+        "http://localhost:3000/auth/login?callbackUrl=http%3A%2F%2Flocalhost%3A4000%2Fenvironments%2Ftest"
+      )
     );
 
     expect(response.status).toBe(400);

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -4,7 +4,7 @@ import { logger } from "@formbricks/logger";
 import { isPublicDomainConfigured, isRequestFromPublicDomain } from "@/app/middleware/domain-utils";
 import { isAuthProtectedRoute, isRouteAllowedForDomain } from "@/app/middleware/endpoint-validator";
 import { WEBAPP_URL } from "@/lib/constants";
-import { isValidCallbackUrl } from "@/lib/utils/url";
+import { getValidatedCallbackUrl } from "@/lib/utils/url";
 import { getProxySession } from "@/modules/auth/lib/proxy-session";
 
 const handleAuth = async (request: NextRequest): Promise<Response | null> => {
@@ -16,13 +16,14 @@ const handleAuth = async (request: NextRequest): Promise<Response | null> => {
   }
 
   const callbackUrl = request.nextUrl.searchParams.get("callbackUrl");
+  const validatedCallbackUrl = getValidatedCallbackUrl(callbackUrl, WEBAPP_URL);
 
-  if (callbackUrl && !isValidCallbackUrl(callbackUrl, WEBAPP_URL)) {
+  if (callbackUrl && !validatedCallbackUrl) {
     return NextResponse.json({ error: "Invalid callback URL" }, { status: 400 });
   }
 
-  if (session && callbackUrl) {
-    return NextResponse.redirect(callbackUrl);
+  if (session && validatedCallbackUrl) {
+    return NextResponse.redirect(validatedCallbackUrl);
   }
 
   return null;

--- a/docs/development/technical-handbook/background-job-processing.mdx
+++ b/docs/development/technical-handbook/background-job-processing.mdx
@@ -1,0 +1,401 @@
+---
+title: "Background Job Processing"
+description: "How BullMQ works in Formbricks today, including the migrated response pipeline workload."
+icon: "code"
+---
+
+This page documents the current BullMQ-based background job system in Formbricks and the first real workload that now runs on it: the response pipeline.
+
+## Current State
+
+Formbricks now uses BullMQ as an in-process background job system inside the Next.js web application.
+
+The current implementation includes:
+
+- a shared `@formbricks/jobs` package that owns queue creation, schemas, scheduling, and worker runtime concerns
+- a Next.js startup hook that starts one BullMQ worker runtime per Node.js process without blocking app boot
+- app-level enqueue helpers for request handlers
+- an app-owned BullMQ response pipeline processor that replaces the legacy internal HTTP pipeline route
+
+The first migrated workload is:
+
+- `response-pipeline.process`
+
+This means response-related side effects no longer depend on an internal `fetch()` back into the same app process.
+
+## Why This Exists
+
+The original response pipeline lived behind an internal Next.js route:
+
+```text
+apps/web/app/api/(internal)/pipeline
+```
+
+That model had a few problems:
+
+- it was tightly coupled to the request lifecycle
+- it relied on an internal HTTP hop instead of a typed background-job boundary
+- it was harder to observe, retry, and scale safely
+
+BullMQ addresses that by moving post-response work behind a queue while keeping the first version operationally simple for self-hosted users.
+
+## High-Level Architecture
+
+```mermaid
+graph TD
+    A["API route or server code"] --> B["enqueueResponsePipelineEvents()"]
+    B --> C["getResponseSnapshotForPipeline()"]
+    B --> D["BackgroundJobProducer.enqueueResponsePipeline()"]
+    D --> E["BullMQ queue: background-jobs"]
+    F["instrumentation.ts"] --> G["registerJobsWorker()"]
+    G --> H["startJobsRuntime()"]
+    H --> I["BullMQ workers"]
+    I --> J["response-pipeline.process override"]
+    J --> K["processResponsePipelineJob()"]
+    E --> I
+    E --> L["Redis / Valkey"]
+    I --> L
+```
+
+## Responsibilities By Layer
+
+### App Layer
+
+- `apps/web/app/lib/pipelines.ts`
+  Owns enqueueing for response pipeline events. It gates queueing, hydrates the response snapshot once, logs failures, and never throws back into request handlers.
+- `apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts`
+  Owns app-specific execution of response-pipeline jobs.
+- `apps/web/modules/response-pipeline/lib/handle-integrations.ts`
+  Owns Slack, Notion, Airtable, and Google Sheets integration fan-out for the pipeline.
+- `apps/web/modules/response-pipeline/lib/telemetry.ts`
+  Owns telemetry dispatch logic used by the response-created path.
+- `apps/web/instrumentation-jobs.ts`
+  Registers the app-owned response-pipeline handler override with the shared BullMQ runtime and schedules retry after transient startup failures.
+- `apps/web/lib/jobs/config.ts`
+  Turns environment configuration into queueing and worker-bootstrap decisions. Queue producers depend on `REDIS_URL`; worker startup additionally depends on `BULLMQ_WORKER_ENABLED`.
+
+### Shared Jobs Layer
+
+- `packages/jobs/src/types.ts`
+  Defines typed payload schemas such as `TResponsePipelineJobData`.
+- `packages/jobs/src/definitions.ts`
+  Defines stable job names and payload validation.
+- `packages/jobs/src/queue.ts`
+  Owns producer-side enqueueing and scheduling.
+- `packages/jobs/src/runtime.ts`
+  Starts workers, connects Redis, and handles graceful shutdown.
+- `packages/jobs/src/processors/registry.ts`
+  Validates payloads and dispatches named jobs, applying app-provided handler overrides when registered.
+
+## Response Pipeline Flow
+
+The response pipeline now runs fully in the background worker.
+
+### Enqueueing
+
+When a response is created or updated, the request path calls:
+
+```ts
+enqueueResponsePipelineEvents({
+  environmentId,
+  surveyId,
+  responseId,
+  events,
+});
+```
+
+That helper:
+
+1. deduplicates requested events
+2. checks whether BullMQ queueing is enabled
+3. uses the just-written response snapshot when the caller already has it
+4. otherwise loads the latest response snapshot once via `getResponseSnapshotForPipeline(responseId)` using an uncached read
+5. enqueues one BullMQ job per event with the shared snapshot payload
+6. waits for the enqueue attempt to complete, then logs enqueue failures without failing the original request
+
+### Execution
+
+At worker startup, `apps/web/instrumentation-jobs.ts` registers an app-owned override for:
+
+- `response-pipeline.process`
+
+That override delegates to `processResponsePipelineJob(...)`, which performs:
+
+- webhook delivery for all pipeline events
+- integrations for `responseFinished`
+- response-finished notification emails
+- follow-up delivery
+- survey auto-complete updates and audit logging
+- response-created billing metering
+- response-created telemetry dispatch
+
+Current retry semantics are intentionally asymmetric:
+
+- webhook delivery failures fail early BullMQ attempts so retries can happen at the job level
+- if webhook delivery is still failing on the final BullMQ attempt, the worker logs that retries are exhausted and continues with the remaining event-specific side effects
+- integration, email, telemetry, metering, follow-up, and survey auto-complete failures are logged inside the processor and do not fail the whole job
+
+## Acceptance Criteria Review
+
+### Pipeline Execution
+
+Satisfied.
+
+- New response create/update flows enqueue BullMQ jobs instead of calling an internal HTTP route.
+- The job payload contains `environmentId`, `surveyId`, `event`, and an authoritative response snapshot.
+- The response pipeline executes inside the BullMQ worker runtime.
+
+### Feature Parity
+
+Mostly satisfied for the legacy response pipeline behavior that existed in the old route.
+
+The migrated BullMQ processor preserves:
+
+- webhook delivery
+- integrations
+- response-finished emails
+- follow-up execution
+- survey auto-complete and audit logging
+- response-created billing metering
+- response-created telemetry
+
+One important behavior change still exists today:
+
+- webhook delivery failures delay the remaining side effects until the final BullMQ attempt
+
+That is closer to the legacy route, because the pipeline eventually continues even if webhook delivery never succeeds. It is still not exact feature parity, though, because the legacy route continued immediately while the BullMQ worker waits until retries are exhausted before it degrades webhook failure into a logged condition.
+
+### Architecture
+
+Satisfied.
+
+- Enqueueing lives in the app layer through `apps/web/app/lib/pipelines.ts`.
+- Execution lives in the worker path under `apps/web/modules/response-pipeline/lib`.
+- `@formbricks/jobs` stays responsible for queue/runtime concerns and typed job contracts.
+
+### Cleanup
+
+Satisfied.
+
+The legacy internal route has been removed:
+
+```text
+apps/web/app/api/(internal)/pipeline/route.ts
+```
+
+The runtime path no longer depends on the old internal-route folder structure, and the remaining pipeline-only test mock under that deleted folder has been removed as part of the migration cleanup.
+
+### Reliability
+
+Satisfied at the current ticket scope.
+
+BullMQ jobs use shared default retry behavior:
+
+- `attempts: 3`
+- exponential backoff starting at `1000ms`
+
+Failures are logged with structured metadata such as:
+
+- `jobId`
+- `attempt`
+- `jobName`
+- `queueName`
+- `environmentId`
+- `surveyId`
+- `responseId`
+
+Request handlers remain non-blocking:
+
+- if Redis is unavailable
+- if queueing is disabled
+- if snapshot hydration fails
+- if enqueueing fails
+
+the request still completes, and the failure is logged.
+
+Worker startup is also non-blocking:
+
+- Next.js boot does not await BullMQ readiness
+- startup failures are logged
+- the web app schedules a retry instead of requiring an immediate process restart
+
+### Worker Integration
+
+Satisfied.
+
+The response pipeline is processed by the same BullMQ worker runtime started from Next.js instrumentation. No standalone worker service was introduced as part of this migration.
+
+### Developer Experience
+
+Satisfied.
+
+The public app-level API for request handlers is intentionally small:
+
+- `enqueueResponsePipelineEvents(...)`
+
+This keeps queue names, Redis concerns, and BullMQ details out of response routes.
+
+## Comparison With The Legacy Route
+
+### Previous Implementation
+
+The legacy internal route accepted a full response payload directly and then executed the entire pipeline synchronously inside the route handler.
+
+Key characteristics of that model:
+
+- request handlers performed an internal authenticated `fetch()` back into the same app
+- the route received the response payload directly instead of hydrating it from a queue-side snapshot
+- webhook failures were logged and did not block the rest of the pipeline
+- response-finished integrations, emails, follow-ups, and survey auto-complete ran in the same route execution
+- response-created metering was fire-and-forget while telemetry was awaited
+
+### Current BullMQ Implementation
+
+The current branch enqueues a typed snapshot-based BullMQ job and executes the pipeline inside the in-process worker registered from Next.js instrumentation.
+
+Key characteristics of the current model:
+
+- request handlers enqueue directly through `enqueueResponsePipelineEvents(...)`
+- handlers now pass the just-written `TResponse` snapshot when they already have it
+- callers that do not already have a response snapshot use an uncached pipeline-specific lookup
+- worker startup is non-blocking and retries after transient failures
+- webhook failures fail early attempts so BullMQ can retry them
+- on the final attempt, webhook failures are logged and the remaining side effects continue
+- response-created metering is awaited before the BullMQ job completes
+
+### Net Result
+
+Compared to the legacy route, the current branch is:
+
+- architecturally stronger
+- safer to scale and operate
+- easier to observe through structured job logging
+- closer to legacy feature parity than the earlier BullMQ iterations on this branch
+
+The main remaining semantic difference is timing:
+
+- the legacy route continued past webhook failures immediately
+- the BullMQ worker now continues only after webhook retries are exhausted
+
+That is an intentional trade-off in the current branch, not an accident.
+
+## Current Queue Model
+
+The queue remains intentionally small:
+
+- queue name: `background-jobs`
+- prefix: `formbricks:jobs`
+- job names:
+  - `system.test-log`
+  - `response-pipeline.process`
+
+The response pipeline is the first production workload on this queue.
+
+## Local Development
+
+Local development works end to end as long as Redis is available and the worker is enabled.
+
+Required inputs:
+
+- `REDIS_URL`
+- optionally `BULLMQ_WORKER_ENABLED`
+- optionally `BULLMQ_WORKER_COUNT`
+- optionally `BULLMQ_WORKER_CONCURRENCY`
+
+Behavior:
+
+- if `REDIS_URL` is missing, queueing is skipped
+- if `BULLMQ_WORKER_ENABLED=0`, the worker is not started, but request-side enqueueing can still stay enabled in deployments that point at a separate BullMQ worker
+- outside tests, the worker is enabled by default
+
+This makes it possible to develop request flows without hard-failing when Redis is absent, while still supporting full local end-to-end verification when Redis is running.
+
+## Operational Notes
+
+### Logging
+
+The current implementation logs:
+
+- worker startup failures
+- Redis connection failures
+- enqueue failures
+- job failures
+- webhook delivery failures
+- integration failures
+- email delivery failures
+- follow-up failures
+- survey auto-complete update failures
+- metering failures
+- telemetry failures
+
+### Shutdown
+
+The worker runtime registers `SIGTERM` and `SIGINT` handlers, closes workers and queue handles, and then closes Redis connections. This keeps shutdown behavior predictable inside the web process.
+
+## Current Limitations
+
+The migration satisfies the ticket, but a few larger architectural limits remain by design.
+
+### Dual-Write Boundary
+
+Response writes happen in Postgres and background jobs are enqueued in Redis. Those are separate systems, so this remains a dual-write boundary.
+
+This means Formbricks currently has:
+
+- non-blocking enqueue semantics
+- at-least-once background execution
+- no transactional guarantee that the product write and Redis enqueue succeed together
+
+That trade-off was accepted for this BullMQ phase.
+
+### In-Process Workers
+
+Workers run inside the Next.js app process.
+
+That keeps self-hosting simple, but it also means:
+
+- job capacity still shares resources with the web process
+- heavy background work is still Node.js-local
+- scaling job throughput also scales the app runtime
+
+### Webhook-Gated Retries
+
+Webhook delivery still happens before the rest of the `responseFinished` side effects.
+
+That gives Formbricks job-level retries for webhook delivery, but it also means:
+
+- `responseFinished` side effects do not run on the early retry attempts
+- the remaining side effects only continue after webhook retries are exhausted
+- this is closer to legacy behavior than failing forever, but it is still not immediate parity
+
+This is the current behavior of the branch and should be evaluated explicitly if we want stricter feature parity with the legacy route.
+
+### Logs-First Observability
+
+The current system has strong structured logging, but it does not yet provide:
+
+- queue dashboards
+- retry tooling
+- latency metrics
+- product-native workflow inspection
+
+Those are future improvements, not blockers for the current migration.
+
+## Recommended Next Steps
+
+Now that the response pipeline is on BullMQ, the most useful next steps are:
+
+1. migrate additional low-risk async workloads behind the same producer/runtime boundary
+2. add queue metrics and worker health visibility beyond logs
+3. define explicit idempotency rules for side-effect-heavy jobs
+4. decide which future workloads should remain Node-local and which should eventually move to a different runtime
+
+## Practical Conclusion
+
+Formbricks now has:
+
+- a production-capable BullMQ foundation
+- a real migrated workload
+- a clean separation between request-time enqueueing and background execution
+
+The response pipeline migration should be considered complete for the current ticket scope.


### PR DESCRIPTION
## What does this PR do?

Fixes formbricks/internal#1511

This PR hardens SSO account reuse for existing same-email accounts by failing closed unless the provider account is already linked.

Summary:
- Makes `Account(provider, providerAccountId)` the canonical SSO lookup path.
- Keeps a legacy fallback for users that only have `identityProvider` / `identityProviderAccountId`, and backfills the missing `Account` row when that legacy path is used.
- Blocks unauthenticated same-email SSO reuse with `OAuthAccountNotLinked` instead of implicitly reusing or activating an existing Formbricks user.
- Removes dangerous email auto-linking from the Google and SAML provider configs.
- Surfaces a localized inline `OAuthAccountNotLinked` error on the login page.
- Preserves the original invite / deep-link destination through the blocked-SSO recovery flow, including the email-verification path.
- Tightens callback URL validation to exact-origin checks and narrows callback-cookie fallback so generic `/auth/login` renders do not inherit stale redirect state.
- Moves new-user SSO provisioning writes into a transaction and keeps signup side effects outside the transaction.
- Adds regression coverage for same-email SSO denial, already-linked success, legacy linked-account backfill, callback validation/restoration, verification callback preservation, and provider safety defaults.

Important scope note:
- This PR intentionally does **not** add a new authenticated provider-linking settings flow.
- Supported linking in this PR remains “already linked accounts only”.
- No database schema changes or public API changes are introduced.

## How should this be tested?

- Try signing in with SSO when a verified email/password account already exists for the same email.
  - Expected: sign-in is blocked with the inline `OAuthAccountNotLinked` message.
  - Expected: no silent linking or activation happens.

- Try signing in with SSO when an unverified email/password account already exists for the same email.
  - Expected: sign-in is blocked with the same generic `OAuthAccountNotLinked` message.
  - Expected: the account is not activated.
  - Expected: if the user switches to email/password and completes email verification, they resume the original invite / destination flow.

- Try signing in with SSO when the email already exists on an account linked to a different provider.
  - Expected: sign-in is blocked with `OAuthAccountNotLinked`.

- Try signing in with an already linked provider account.
  - Expected: sign-in still succeeds.

- Verify the login page does not reuse a stale callback cookie during a normal `/auth/login` visit.
  - Expected: cookie fallback only applies to the blocked SSO recovery case.

- Run the targeted auth / SSO test suites:
  - `pnpm exec vitest run modules/auth/lib/verification-links.test.ts modules/auth/lib/callback-url.test.ts modules/auth/verification-requested/actions.test.ts modules/auth/lib/authOptions.test.ts 'app/api/auth/[...nextauth]/route.test.ts' modules/auth/signup/lib/__tests__/team.test.ts modules/ee/sso/lib/tests/sso-handlers.test.ts modules/ee/sso/lib/tests/team.test.ts modules/ee/sso/lib/tests/utils.test.ts proxy.test.ts`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
