### PR TITLE
feat: support GKE Envoy ingress split with numeric ports and service annotations

### DIFF
--- a/charts/formbricks/templates/envoy-gateway-resources.yaml
+++ b/charts/formbricks/templates/envoy-gateway-resources.yaml
@@ -28,6 +28,10 @@ spec:
         labels:
           app.kubernetes.io/name: {{ $proxyServiceName }}
           app.kubernetes.io/managed-by: {{ .Release.Service }}
+        {{- if .Values.envoy.formbricks.proxy.service.annotations }}
+        annotations:
+          {{- include "formbricks.tplvalues.render" (dict "value" .Values.envoy.formbricks.proxy.service.annotations "context" $ ) | nindent 10 }}
+        {{- end }}
   logging:
     level:
       default: {{ .Values.envoy.formbricks.proxy.logging.defaultLevel | quote }}

--- a/charts/formbricks/templates/ingress.yaml
+++ b/charts/formbricks/templates/ingress.yaml
@@ -32,7 +32,11 @@ spec:
             service:
               name: {{ default $applicationNameTpl (.serviceName) }}
               port:
+                {{- if hasKey . "servicePortNumber" }}
+                number: {{ .servicePortNumber }}
+                {{- else }}
                 name: {{ default "http" (.servicePort) }}
+                {{- end }}
         {{- end }}
         {{- else }}
         {{ fail "Specify paths for ingress host, check values.yaml" }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -404,6 +404,7 @@ envoy:
       service:
         name: ""
         type: ClusterIP
+        annotations: {}
       logging:
         defaultLevel: info
       telemetry:


### PR DESCRIPTION
## Summary
- add `ingress.hosts[].paths[].servicePortNumber` support in the ingress template
- keep existing name-based service port behavior as fallback
- add `envoy.formbricks.proxy.service.annotations` in values and wire it into `EnvoyProxy.spec.provider.kubernetes.envoyService.annotations`

## Why
GKE ingress path splitting requires backend service port `number` for Envoy service routing (`80`), and Envoy service needs `cloud.google.com/backend-config` annotation for dedicated backend health/security config.