### PR TITLE
fix(api): verify unique constraint target for duplicate email

### DIFF
--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
@@ -119,6 +119,27 @@ describe("Users Lib", () => {
         ]);
       }
     });
+
+    test("returns internal_server_error if unique constraint violation is not on email", async () => {
+      (prisma.user.create as any).mockRejectedValueOnce(
+        new Prisma.PrismaClientKnownRequestError(
+          "Unique constraint failed on the fields: (`organizationId`,`email`)",
+          {
+            code: PrismaErrorType.UniqueConstraintViolation,
+            clientVersion: "1.0.0",
+            meta: { target: ["organizationId"] },
+          }
+        )
+      );
+      const result = await createUser(
+        { name: "Duplicate", email: "test@example.com", role: "member" },
+        "org456"
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe("internal_server_error");
+      }
+    });
   });
 
   describe("updateUser", () => {

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
@@ -1,5 +1,7 @@
+import { Prisma } from "@prisma/client";
 import { describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
+import { PrismaErrorType } from "@formbricks/database/types/error";
 import { TGetUsersFilter } from "@/modules/api/v2/organizations/[organizationId]/users/types/users";
 import { createUser, getUsers, updateUser } from "../users";
 
@@ -91,6 +93,30 @@ describe("Users Lib", () => {
       expect(result.ok).toBe(false);
       if (!result.ok) {
         expect(result.error.type).toBe("internal_server_error");
+      }
+    });
+
+    test("returns conflict error if user with email already exists", async () => {
+      (prisma.user.create as any).mockRejectedValueOnce(
+        new Prisma.PrismaClientKnownRequestError(
+          "Unique constraint failed on the fields: (`email`)",
+          {
+            code: PrismaErrorType.UniqueConstraintViolation,
+            clientVersion: "1.0.0",
+            meta: { target: ["email"] },
+          }
+        )
+      );
+      const result = await createUser(
+        { name: "Duplicate", email: "test@example.com", role: "member" },
+        "org456"
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe("conflict");
+        expect(result.error.details).toEqual([
+          { field: "email", issue: "A user with this email already exists" },
+        ]);
       }
     });
   });

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
@@ -147,10 +147,14 @@ export const createUser = async (
       error instanceof Prisma.PrismaClientKnownRequestError &&
       error.code === PrismaErrorType.UniqueConstraintViolation
     ) {
-      return err({
-        type: "conflict",
-        details: [{ field: "email", issue: `A user with this email already exists` }],
-      });
+      const target = error.meta?.target as string[] | undefined;
+
+      if (target?.includes("email")) {
+        return err({
+          type: "conflict",
+          details: [{ field: "email", issue: "A user with this email already exists" }],
+        });
+      }
     }
 
     return err({

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
@@ -1,5 +1,6 @@
 import { OrganizationRole, Prisma, TeamUserRole } from "@prisma/client";
 import { prisma } from "@formbricks/database";
+import { PrismaErrorType } from "@formbricks/database/types/error";
 import { TUser } from "@formbricks/database/zod/users";
 import { Result, err, ok } from "@formbricks/types/error-handlers";
 import { getUsersQuery } from "@/modules/api/v2/organizations/[organizationId]/users/lib/utils";
@@ -142,6 +143,16 @@ export const createUser = async (
 
     return ok(returnedUser);
   } catch (error) {
+    if (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === PrismaErrorType.UniqueConstraintViolation
+    ) {
+      return err({
+        type: "conflict",
+        details: [{ field: "email", issue: `A user with this email already exists` }],
+      });
+    }
+
     return err({
       type: "internal_server_error",
       details: [{ field: "user", issue: error instanceof Error ? error.message : "Unknown error occurred" }],


### PR DESCRIPTION
## What does this PR do?

This is a maintainer-owned follow-up to #7675 so the change can run CI in the main repository. Credit to @Chronolapse411 for the original contribution.

The original PR fixed duplicate-email user creation to return `409 Conflict` instead of `500`. This follow-up adds the requested guard on `error.meta?.target` so we only return the email-specific conflict when the violated unique constraint includes `email`. Other `P2002` cases continue through the generic error path instead of returning a misleading email message.

Fixes #7537

## How should this be tested?

- From `apps/web`, run `pnpm exec dotenv -e ../../.env -- vitest run 'modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts'`
- Verify duplicate-email `P2002` returns `conflict`
- Verify non-email `P2002` returns `internal_server_error`
