### PR TITLE
fix: only show beforeunload warning when offline support is active

### DIFF
--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -539,8 +539,8 @@ export function Survey({
   // --- Warn before leaving mid-survey or with unsent offline responses ---
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      // Warn if user has started answering but hasn't finished the survey
-      if (history.length > 0 && !isSurveyFinished) {
+      // Warn if user has started answering but hasn't finished the survey (only when offline support is active)
+      if (offlinePersistEnabled && history.length > 0 && !isSurveyFinished) {
         e.preventDefault();
         return;
       }


### PR DESCRIPTION
## Summary
- Guard the beforeunload "unsaved changes" warning behind `offlinePersistEnabled` so it only fires when `?offlineSupport=true` is set on link surveys
- Previously the warning fired for all link surveys whenever the user had started answering

Fixes formbricks/internal#1567

## Test plan
- [ ] Open a link survey WITHOUT `?offlineSupport=true`, start answering, close the tab → no browser warning
- [ ] Open a link survey WITH `?offlineSupport=true`, start answering, close the tab → browser warning appears
- [ ] Open a link survey WITH `?offlineSupport=true`, complete the survey, close the tab → no browser warning
- [ ] Go offline with `?offlineSupport=true`, submit responses, close tab → browser warning (unsent responses)