### PR TITLE
fix: validate "Other" option text on required questions and remove duplicate response entry

### DIFF
--- a/apps/web/lib/response/utils.ts
+++ b/apps/web/lib/response/utils.ts
@@ -81,7 +81,11 @@ export const extractChoiceIdsFromResponse = (
 
   if (Array.isArray(responseValue)) {
     // Multiple choice case - response is an array of selected choice labels
-    return responseValue.map(findChoiceByLabel).filter((choiceId): choiceId is string => choiceId !== null);
+    // Filter out empty string sentinel used as "other" marker in multipleChoiceMulti
+    return responseValue
+      .filter((v) => v !== "")
+      .map(findChoiceByLabel)
+      .filter((choiceId): choiceId is string => choiceId !== null);
   } else if (typeof responseValue === "string") {
     // Single choice case - response is a single choice label
     const choiceId = findChoiceByLabel(responseValue);

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/RenderResponse.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/RenderResponse.tsx
@@ -163,10 +163,12 @@ export const RenderResponse: React.FC<RenderResponseProps> = ({
           />
         );
       } else if (Array.isArray(responseData)) {
-        const itemsArray = responseData.map((choice) => {
-          const choiceId = getChoiceIdByValue(choice, element);
-          return { value: choice, id: choiceId };
-        });
+        const itemsArray = responseData
+          .filter((choice) => choice !== "")
+          .map((choice) => {
+            const choiceId = getChoiceIdByValue(choice, element);
+            return { value: choice, id: choiceId };
+          });
         return (
           <>
             {element.type === TSurveyElementTypeEnum.Ranking ? (

--- a/packages/survey-ui/src/components/elements/multi-select.tsx
+++ b/packages/survey-ui/src/components/elements/multi-select.tsx
@@ -280,6 +280,7 @@ function DropdownVariant({
           placeholder={otherOptionPlaceholder}
           disabled={disabled}
           aria-required={required}
+          aria-invalid={Boolean(errorMessage)}
           dir={dir}
           className="mt-2 w-full"
         />
@@ -401,6 +402,7 @@ function ListVariant({
                   placeholder={otherOptionPlaceholder}
                   disabled={disabled}
                   aria-required={required}
+                  aria-invalid={Boolean(errorMessage)}
                   dir={dir}
                   className="mt-2 w-full"
                   ref={otherInputRef}

--- a/packages/survey-ui/src/components/elements/single-select.tsx
+++ b/packages/survey-ui/src/components/elements/single-select.tsx
@@ -272,6 +272,7 @@ function SingleSelect({
                 onChange={handleOtherInputChange}
                 placeholder={otherOptionPlaceholder}
                 disabled={disabled}
+                aria-invalid={Boolean(errorMessage)}
                 dir={dir}
                 className="mt-2 w-full"
               />
@@ -334,6 +335,7 @@ function SingleSelect({
                       placeholder={otherOptionPlaceholder}
                       disabled={disabled}
                       aria-required={required}
+                      aria-invalid={Boolean(errorMessage)}
                       dir={dir}
                       className="mt-2 w-full"
                     />

--- a/packages/surveys/src/components/elements/multiple-choice-multi-element.tsx
+++ b/packages/surveys/src/components/elements/multiple-choice-multi-element.tsx
@@ -169,8 +169,7 @@ export function MultipleChoiceMultiElement({
     setOtherValue(newOtherValue);
     const baseLabels = getNormalizedSelectedLabels();
 
-    const nextValue = [...baseLabels, ""];
-    if (newOtherValue.trim()) nextValue.push(newOtherValue);
+    const nextValue = [...baseLabels, newOtherValue];
 
     onChange({ [element.id]: nextValue });
   };
@@ -227,8 +226,7 @@ export function MultipleChoiceMultiElement({
     });
 
     if (isOtherNowSelected) {
-      nextLabels.push("");
-      if (otherValue.trim()) nextLabels.push(otherValue);
+      nextLabels.push(otherValue);
     } else if (otherValue) {
       // If other was deselected, clear any stale other value
       setOtherValue("");

--- a/packages/surveys/src/lib/validation/evaluator.test.ts
+++ b/packages/surveys/src/lib/validation/evaluator.test.ts
@@ -88,6 +88,46 @@ describe("validateElementResponse", () => {
       expect(result.valid).toBe(true);
     });
 
+    test("should return error when required multi-select has other selected but no text", () => {
+      const element = {
+        id: "mc1",
+        type: TSurveyElementTypeEnum.MultipleChoiceMulti,
+        headline: { default: "Pick" },
+        required: true,
+        choices: [{ id: "opt1", label: { default: "Option 1" } }],
+      } as unknown as TSurveyElement;
+
+      const result = validateElementResponse(element, ["opt1", ""], "en");
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].ruleId).toBe("required");
+    });
+
+    test("should return valid when required multi-select has other with text (legacy sentinel)", () => {
+      const element = {
+        id: "mc1",
+        type: TSurveyElementTypeEnum.MultipleChoiceMulti,
+        headline: { default: "Pick" },
+        required: true,
+        choices: [{ id: "opt1", label: { default: "Option 1" } }],
+      } as unknown as TSurveyElement;
+
+      const result = validateElementResponse(element, ["opt1", "", "custom"], "en");
+      expect(result.valid).toBe(true);
+    });
+
+    test("should return valid when required multi-select has other text without sentinel", () => {
+      const element = {
+        id: "mc1",
+        type: TSurveyElementTypeEnum.MultipleChoiceMulti,
+        headline: { default: "Pick" },
+        required: true,
+        choices: [{ id: "opt1", label: { default: "Option 1" } }],
+      } as unknown as TSurveyElement;
+
+      const result = validateElementResponse(element, ["opt1", "custom"], "en");
+      expect(result.valid).toBe(true);
+    });
+
     test("should handle required ranking element - at least one ranked", () => {
       const element: TSurveyElement = {
         id: "rank1",

--- a/packages/surveys/src/lib/validation/evaluator.ts
+++ b/packages/surveys/src/lib/validation/evaluator.ts
@@ -154,6 +154,17 @@ const checkRequiredField = (
     return createRequiredError(t);
   }
 
+  // For multi-select: if "other" is selected (sentinel ""), require the other text to be non-empty
+  if (element.type === TSurveyElementTypeEnum.MultipleChoiceMulti && Array.isArray(value)) {
+    const sentinelIndex = value.indexOf("");
+    if (sentinelIndex !== -1) {
+      const otherText = value[sentinelIndex + 1];
+      if (!otherText || (typeof otherText === "string" && otherText.trim() === "")) {
+        return createRequiredError(t);
+      }
+    }
+  }
+
   return null;
 };
 


### PR DESCRIPTION
## Summary
- Validate that "Other" option text is non-empty on required multi-select questions before allowing progression
- Filter out the empty sentinel string from multi-select response display to prevent duplicate "Other" badges in the response tab

Fixes formbricks/internal#1561

## Test plan
- [ ] Create a required multi-select question with "Other" option
- [ ] Select "Other" but leave text empty → cannot proceed (validation error)
- [ ] Select "Other" and enter text → can proceed normally
- [ ] Select regular options without "Other" → can proceed normally
- [ ] Submit a response with "Other" filled → response tab shows single "Other" entry with value (no empty duplicate)
- [ ] Required single-select with "Other" empty → still blocked (existing behavior, verify no regression)