### PR TITLE
fix: only show beforeunload warning when offline support is active (backport #7715)

### DIFF
--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -539,8 +539,8 @@ export function Survey({
   // --- Warn before leaving mid-survey or with unsent offline responses ---
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
-      // Warn if user has started answering but hasn't finished the survey
-      if (history.length > 0 && !isSurveyFinished) {
+      // Warn if user has started answering but hasn't finished the survey (only when offline support is active)
+      if (offlinePersistEnabled && history.length > 0 && !isSurveyFinished) {
         e.preventDefault();
         return;
       }


### PR DESCRIPTION
## Summary
Backport of #7715 to `release/4.9`.

- Gate the `beforeunload` warning behind `offlinePersistEnabled` so it only fires when offline support is actually active, instead of on every survey with unsaved progress.

Original commit: fb5d6145d0341e42918e51a2bb67c0e6d8cccadc