### PR TITLE
fix: add missing PostHog events

### DIFF
--- a/apps/web/app/api/(internal)/pipeline/lib/posthog.test.ts
+++ b/apps/web/app/api/(internal)/pipeline/lib/posthog.test.ts
@@ -1,68 +1,27 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { captureSurveyResponsePostHogEvent, shouldCapturePostHogResponseEvent } from "./posthog";
+import { captureSurveyResponsePostHogEvent } from "./posthog";
 
 vi.mock("@/lib/posthog", () => ({
   capturePostHogEvent: vi.fn(),
 }));
-
-describe("shouldCapturePostHogResponseEvent", () => {
-  test("fires on 1st response", () => {
-    expect(shouldCapturePostHogResponseEvent(1)).toBe(true);
-  });
-
-  test("fires on 10th response", () => {
-    expect(shouldCapturePostHogResponseEvent(10)).toBe(true);
-  });
-
-  test("fires on 50th response", () => {
-    expect(shouldCapturePostHogResponseEvent(50)).toBe(true);
-  });
-
-  test("fires on 100th response", () => {
-    expect(shouldCapturePostHogResponseEvent(100)).toBe(true);
-  });
-
-  test("fires on every 500th response", () => {
-    expect(shouldCapturePostHogResponseEvent(500)).toBe(true);
-    expect(shouldCapturePostHogResponseEvent(1000)).toBe(true);
-    expect(shouldCapturePostHogResponseEvent(1500)).toBe(true);
-    expect(shouldCapturePostHogResponseEvent(5000)).toBe(true);
-  });
-
-  test("does NOT fire for 2nd, 3rd, 4th, 5th responses", () => {
-    expect(shouldCapturePostHogResponseEvent(2)).toBe(false);
-    expect(shouldCapturePostHogResponseEvent(3)).toBe(false);
-    expect(shouldCapturePostHogResponseEvent(4)).toBe(false);
-    expect(shouldCapturePostHogResponseEvent(5)).toBe(false);
-  });
-
-  test("does NOT fire for non-milestone counts", () => {
-    expect(shouldCapturePostHogResponseEvent(7)).toBe(false);
-    expect(shouldCapturePostHogResponseEvent(25)).toBe(false);
-    expect(shouldCapturePostHogResponseEvent(99)).toBe(false);
-    expect(shouldCapturePostHogResponseEvent(101)).toBe(false);
-    expect(shouldCapturePostHogResponseEvent(250)).toBe(false);
-    expect(shouldCapturePostHogResponseEvent(499)).toBe(false);
-    expect(shouldCapturePostHogResponseEvent(501)).toBe(false);
-    expect(shouldCapturePostHogResponseEvent(750)).toBe(false);
-  });
-});
 
 describe("captureSurveyResponsePostHogEvent", () => {
   afterEach(() => {
     vi.clearAllMocks();
   });
 
-  test("calls capturePostHogEvent for milestone counts", async () => {
+  const makeParams = (responseCount: number) => ({
+    organizationId: "org-1",
+    surveyId: "survey-1",
+    surveyType: "link",
+    environmentId: "env-1",
+    responseCount,
+  });
+
+  test("fires on 1st response with milestone 'first'", async () => {
     const { capturePostHogEvent } = await import("@/lib/posthog");
 
-    captureSurveyResponsePostHogEvent({
-      organizationId: "org-1",
-      surveyId: "survey-1",
-      surveyType: "link",
-      environmentId: "env-1",
-      responseCount: 1,
-    });
+    captureSurveyResponsePostHogEvent(makeParams(1));
 
     expect(capturePostHogEvent).toHaveBeenCalledWith("org-1", "survey_response_received", {
       survey_id: "survey-1",
@@ -75,16 +34,32 @@ describe("captureSurveyResponsePostHogEvent", () => {
     });
   });
 
-  test("does NOT call capturePostHogEvent for non-milestone counts", async () => {
+  test("fires on every 100th response", async () => {
     const { capturePostHogEvent } = await import("@/lib/posthog");
 
-    captureSurveyResponsePostHogEvent({
-      organizationId: "org-1",
-      surveyId: "survey-1",
-      surveyType: "link",
-      environmentId: "env-1",
-      responseCount: 5,
-    });
+    for (const count of [100, 200, 300, 500, 1000, 5000]) {
+      captureSurveyResponsePostHogEvent(makeParams(count));
+    }
+
+    expect(capturePostHogEvent).toHaveBeenCalledTimes(6);
+  });
+
+  test("does NOT fire for 2nd through 99th responses", async () => {
+    const { capturePostHogEvent } = await import("@/lib/posthog");
+
+    for (const count of [2, 5, 10, 50, 99]) {
+      captureSurveyResponsePostHogEvent(makeParams(count));
+    }
+
+    expect(capturePostHogEvent).not.toHaveBeenCalled();
+  });
+
+  test("does NOT fire for non-100th counts above 100", async () => {
+    const { capturePostHogEvent } = await import("@/lib/posthog");
+
+    for (const count of [101, 150, 250, 499, 501]) {
+      captureSurveyResponsePostHogEvent(makeParams(count));
+    }
 
     expect(capturePostHogEvent).not.toHaveBeenCalled();
   });
@@ -92,20 +67,14 @@ describe("captureSurveyResponsePostHogEvent", () => {
   test("sets milestone to count string for non-first milestones", async () => {
     const { capturePostHogEvent } = await import("@/lib/posthog");
 
-    captureSurveyResponsePostHogEvent({
-      organizationId: "org-1",
-      surveyId: "survey-1",
-      surveyType: "app",
-      environmentId: "env-1",
-      responseCount: 500,
-    });
+    captureSurveyResponsePostHogEvent(makeParams(200));
 
     expect(capturePostHogEvent).toHaveBeenCalledWith(
       "org-1",
       "survey_response_received",
       expect.objectContaining({
         is_first_response: false,
-        milestone: "500",
+        milestone: "200",
       })
     );
   });

--- a/apps/web/app/api/(internal)/pipeline/lib/posthog.test.ts
+++ b/apps/web/app/api/(internal)/pipeline/lib/posthog.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { captureSurveyResponsePostHogEvent, shouldCapturePostHogResponseEvent } from "./posthog";
+
+vi.mock("@/lib/posthog", () => ({
+  capturePostHogEvent: vi.fn(),
+}));
+
+describe("shouldCapturePostHogResponseEvent", () => {
+  test("fires on 1st response", () => {
+    expect(shouldCapturePostHogResponseEvent(1)).toBe(true);
+  });
+
+  test("fires on 10th response", () => {
+    expect(shouldCapturePostHogResponseEvent(10)).toBe(true);
+  });
+
+  test("fires on 50th response", () => {
+    expect(shouldCapturePostHogResponseEvent(50)).toBe(true);
+  });
+
+  test("fires on 100th response", () => {
+    expect(shouldCapturePostHogResponseEvent(100)).toBe(true);
+  });
+
+  test("fires on every 500th response", () => {
+    expect(shouldCapturePostHogResponseEvent(500)).toBe(true);
+    expect(shouldCapturePostHogResponseEvent(1000)).toBe(true);
+    expect(shouldCapturePostHogResponseEvent(1500)).toBe(true);
+    expect(shouldCapturePostHogResponseEvent(5000)).toBe(true);
+  });
+
+  test("does NOT fire for 2nd, 3rd, 4th, 5th responses", () => {
+    expect(shouldCapturePostHogResponseEvent(2)).toBe(false);
+    expect(shouldCapturePostHogResponseEvent(3)).toBe(false);
+    expect(shouldCapturePostHogResponseEvent(4)).toBe(false);
+    expect(shouldCapturePostHogResponseEvent(5)).toBe(false);
+  });
+
+  test("does NOT fire for non-milestone counts", () => {
+    expect(shouldCapturePostHogResponseEvent(7)).toBe(false);
+    expect(shouldCapturePostHogResponseEvent(25)).toBe(false);
+    expect(shouldCapturePostHogResponseEvent(99)).toBe(false);
+    expect(shouldCapturePostHogResponseEvent(101)).toBe(false);
+    expect(shouldCapturePostHogResponseEvent(250)).toBe(false);
+    expect(shouldCapturePostHogResponseEvent(499)).toBe(false);
+    expect(shouldCapturePostHogResponseEvent(501)).toBe(false);
+    expect(shouldCapturePostHogResponseEvent(750)).toBe(false);
+  });
+});
+
+describe("captureSurveyResponsePostHogEvent", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("calls capturePostHogEvent for milestone counts", async () => {
+    const { capturePostHogEvent } = await import("@/lib/posthog");
+
+    captureSurveyResponsePostHogEvent({
+      organizationId: "org-1",
+      surveyId: "survey-1",
+      surveyType: "link",
+      environmentId: "env-1",
+      responseCount: 1,
+    });
+
+    expect(capturePostHogEvent).toHaveBeenCalledWith("org-1", "survey_response_received", {
+      survey_id: "survey-1",
+      survey_type: "link",
+      organization_id: "org-1",
+      environment_id: "env-1",
+      response_count: 1,
+      is_first_response: true,
+      milestone: "first",
+    });
+  });
+
+  test("does NOT call capturePostHogEvent for non-milestone counts", async () => {
+    const { capturePostHogEvent } = await import("@/lib/posthog");
+
+    captureSurveyResponsePostHogEvent({
+      organizationId: "org-1",
+      surveyId: "survey-1",
+      surveyType: "link",
+      environmentId: "env-1",
+      responseCount: 5,
+    });
+
+    expect(capturePostHogEvent).not.toHaveBeenCalled();
+  });
+
+  test("sets milestone to count string for non-first milestones", async () => {
+    const { capturePostHogEvent } = await import("@/lib/posthog");
+
+    captureSurveyResponsePostHogEvent({
+      organizationId: "org-1",
+      surveyId: "survey-1",
+      surveyType: "app",
+      environmentId: "env-1",
+      responseCount: 500,
+    });
+
+    expect(capturePostHogEvent).toHaveBeenCalledWith(
+      "org-1",
+      "survey_response_received",
+      expect.objectContaining({
+        is_first_response: false,
+        milestone: "500",
+      })
+    );
+  });
+});

--- a/apps/web/app/api/(internal)/pipeline/lib/posthog.ts
+++ b/apps/web/app/api/(internal)/pipeline/lib/posthog.ts
@@ -1,0 +1,42 @@
+import { capturePostHogEvent } from "@/lib/posthog";
+
+interface SurveyResponsePostHogEventParams {
+  organizationId: string;
+  surveyId: string;
+  surveyType: string;
+  environmentId: string;
+  responseCount: number;
+}
+
+/**
+ * Determines whether a PostHog event should be captured for the given response count.
+ * Fires on the 1st response, then at milestones: 10, 50, 100, 500, and every 500 thereafter.
+ */
+export const shouldCapturePostHogResponseEvent = (responseCount: number): boolean => {
+  if (responseCount === 1) return true;
+  if (responseCount === 10) return true;
+  if (responseCount === 50) return true;
+  if (responseCount === 100) return true;
+  if (responseCount >= 500 && responseCount % 500 === 0) return true;
+  return false;
+};
+
+export const captureSurveyResponsePostHogEvent = ({
+  organizationId,
+  surveyId,
+  surveyType,
+  environmentId,
+  responseCount,
+}: SurveyResponsePostHogEventParams): void => {
+  if (!shouldCapturePostHogResponseEvent(responseCount)) return;
+
+  capturePostHogEvent(organizationId, "survey_response_received", {
+    survey_id: surveyId,
+    survey_type: surveyType,
+    organization_id: organizationId,
+    environment_id: environmentId,
+    response_count: responseCount,
+    is_first_response: responseCount === 1,
+    milestone: responseCount === 1 ? "first" : String(responseCount),
+  });
+};

--- a/apps/web/app/api/(internal)/pipeline/lib/posthog.ts
+++ b/apps/web/app/api/(internal)/pipeline/lib/posthog.ts
@@ -9,18 +9,9 @@ interface SurveyResponsePostHogEventParams {
 }
 
 /**
- * Determines whether a PostHog event should be captured for the given response count.
- * Fires on the 1st response, then at milestones: 10, 50, 100, 500, and every 500 thereafter.
+ * Captures a PostHog event for survey responses at milestones:
+ * 1st response, then every 100th (100, 200, 300, ...).
  */
-export const shouldCapturePostHogResponseEvent = (responseCount: number): boolean => {
-  if (responseCount === 1) return true;
-  if (responseCount === 10) return true;
-  if (responseCount === 50) return true;
-  if (responseCount === 100) return true;
-  if (responseCount >= 500 && responseCount % 500 === 0) return true;
-  return false;
-};
-
 export const captureSurveyResponsePostHogEvent = ({
   organizationId,
   surveyId,
@@ -28,7 +19,7 @@ export const captureSurveyResponsePostHogEvent = ({
   environmentId,
   responseCount,
 }: SurveyResponsePostHogEventParams): void => {
-  if (!shouldCapturePostHogResponseEvent(responseCount)) return;
+  if (responseCount !== 1 && responseCount % 100 !== 0) return;
 
   capturePostHogEvent(organizationId, "survey_response_received", {
     survey_id: surveyId,

--- a/apps/web/app/api/(internal)/pipeline/route.ts
+++ b/apps/web/app/api/(internal)/pipeline/route.ts
@@ -300,7 +300,6 @@ export const POST = async (request: Request) => {
       logger.error({ error, responseId: response.id }, "Failed to record response meter event");
     });
 
-    // Sampled PostHog tracking: fires at milestones (1, 10, 50, 100, 500, 1000, ...)
     if (POSTHOG_KEY) {
       const responseCount = await getResponseCountBySurveyId(surveyId);
 

--- a/apps/web/app/api/(internal)/pipeline/route.ts
+++ b/apps/web/app/api/(internal)/pipeline/route.ts
@@ -1,7 +1,6 @@
 import { PipelineTriggers, Webhook } from "@prisma/client";
 import { headers } from "next/headers";
 import { v7 as uuidv7 } from "uuid";
-import { createCacheKey } from "@formbricks/cache";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
@@ -9,12 +8,10 @@ import { sendTelemetryEvents } from "@/app/api/(internal)/pipeline/lib/telemetry
 import { ZPipelineInput } from "@/app/api/(internal)/pipeline/types/pipelines";
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
-import { cache } from "@/lib/cache";
 import { CRON_SECRET, POSTHOG_KEY } from "@/lib/constants";
 import { generateStandardWebhookSignature } from "@/lib/crypto";
 import { getIntegrations } from "@/lib/integration/service";
 import { getOrganizationByEnvironmentId } from "@/lib/organization/service";
-import { capturePostHogEvent } from "@/lib/posthog";
 import { getResponseCountBySurveyId } from "@/lib/response/service";
 import { getSurvey, updateSurvey } from "@/lib/survey/service";
 import { convertDatesInObject } from "@/lib/time";
@@ -27,6 +24,7 @@ import { resolveStorageUrlsInObject } from "@/modules/storage/utils";
 import { sendFollowUpsForResponse } from "@/modules/survey/follow-ups/lib/follow-ups";
 import { FollowUpSendError } from "@/modules/survey/follow-ups/types/follow-up";
 import { handleIntegrations } from "./lib/handleIntegrations";
+import { captureSurveyResponsePostHogEvent } from "./lib/posthog";
 
 export const POST = async (request: Request) => {
   const requestHeaders = await headers();
@@ -302,25 +300,17 @@ export const POST = async (request: Request) => {
       logger.error({ error, responseId: response.id }, "Failed to record response meter event");
     });
 
-    // Sampled PostHog tracking: first response + every 100th
+    // Sampled PostHog tracking: fires at milestones (1, 10, 50, 100, 500, 1000, ...)
     if (POSTHOG_KEY) {
-      const responseCount = await cache.withCache(
-        () => getResponseCountBySurveyId(surveyId),
-        createCacheKey.response.countBySurveyId(surveyId),
-        60 * 1000
-      );
+      const responseCount = await getResponseCountBySurveyId(surveyId);
 
-      if (responseCount === 1 || responseCount % 100 === 0) {
-        capturePostHogEvent(organization.id, "survey_response_received", {
-          survey_id: surveyId,
-          survey_type: survey.type,
-          organization_id: organization.id,
-          environment_id: environmentId,
-          response_count: responseCount,
-          is_first_response: responseCount === 1,
-          milestone: responseCount === 1 ? "first" : String(responseCount),
-        });
-      }
+      captureSurveyResponsePostHogEvent({
+        organizationId: organization.id,
+        surveyId,
+        surveyType: survey.type,
+        environmentId,
+        responseCount,
+      });
     }
 
     // Send telemetry events

--- a/apps/web/app/api/google-sheet/callback/route.ts
+++ b/apps/web/app/api/google-sheet/callback/route.ts
@@ -1,5 +1,6 @@
 import { google } from "googleapis";
 import { getServerSession } from "next-auth";
+import { logger } from "@formbricks/logger";
 import { TIntegrationGoogleSheetsConfig } from "@formbricks/types/integration/google-sheet";
 import { responses } from "@/app/lib/api/response";
 import {
@@ -84,11 +85,15 @@ export const GET = async (req: Request) => {
 
   const result = await createOrUpdateIntegration(environmentId, googleSheetIntegration);
   if (result) {
-    const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
-    capturePostHogEvent(session.user.id, "integration_connected", {
-      integration_type: "googleSheets",
-      organization_id: organizationId,
-    });
+    try {
+      const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
+      capturePostHogEvent(session.user.id, "integration_connected", {
+        integration_type: "googleSheets",
+        organization_id: organizationId,
+      });
+    } catch (err) {
+      logger.error({ error: err }, "Failed to capture PostHog integration_connected event for googleSheets");
+    }
 
     return Response.redirect(
       `${WEBAPP_URL}/environments/${environmentId}/workspace/integrations/google-sheets`

--- a/apps/web/app/api/google-sheet/callback/route.ts
+++ b/apps/web/app/api/google-sheet/callback/route.ts
@@ -10,6 +10,8 @@ import {
 } from "@/lib/constants";
 import { hasUserEnvironmentAccess } from "@/lib/environment/auth";
 import { createOrUpdateIntegration, getIntegrationByType } from "@/lib/integration/service";
+import { capturePostHogEvent } from "@/lib/posthog";
+import { getOrganizationIdFromEnvironmentId } from "@/lib/utils/helper";
 import { authOptions } from "@/modules/auth/lib/authOptions";
 
 export const GET = async (req: Request) => {
@@ -82,6 +84,12 @@ export const GET = async (req: Request) => {
 
   const result = await createOrUpdateIntegration(environmentId, googleSheetIntegration);
   if (result) {
+    const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
+    capturePostHogEvent(session.user.id, "integration_connected", {
+      integration_type: "googleSheets",
+      organization_id: organizationId,
+    });
+
     return Response.redirect(
       `${WEBAPP_URL}/environments/${environmentId}/workspace/integrations/google-sheets`
     );

--- a/apps/web/app/api/v1/integrations/airtable/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/airtable/callback/route.ts
@@ -89,11 +89,15 @@ export const GET = withV1ApiWrapper({
       };
       await createOrUpdateIntegration(environmentId, airtableIntegrationInput);
 
-      const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
-      capturePostHogEvent(authentication.user.id, "integration_connected", {
-        integration_type: "airtable",
-        organization_id: organizationId,
-      });
+      try {
+        const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
+        capturePostHogEvent(authentication.user.id, "integration_connected", {
+          integration_type: "airtable",
+          organization_id: organizationId,
+        });
+      } catch (err) {
+        logger.error({ error: err }, "Failed to capture PostHog integration_connected event for airtable");
+      }
 
       return {
         response: Response.redirect(

--- a/apps/web/app/api/v1/integrations/airtable/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/airtable/callback/route.ts
@@ -6,6 +6,8 @@ import { fetchAirtableAuthToken } from "@/lib/airtable/service";
 import { AIRTABLE_CLIENT_ID, WEBAPP_URL } from "@/lib/constants";
 import { hasUserEnvironmentAccess } from "@/lib/environment/auth";
 import { createOrUpdateIntegration } from "@/lib/integration/service";
+import { capturePostHogEvent } from "@/lib/posthog";
+import { getOrganizationIdFromEnvironmentId } from "@/lib/utils/helper";
 
 const getEmail = async (token: string) => {
   const req_ = await fetch("https://api.airtable.com/v0/meta/whoami", {
@@ -86,6 +88,13 @@ export const GET = withV1ApiWrapper({
         },
       };
       await createOrUpdateIntegration(environmentId, airtableIntegrationInput);
+
+      const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
+      capturePostHogEvent(authentication.user.id, "integration_connected", {
+        integration_type: "airtable",
+        organization_id: organizationId,
+      });
+
       return {
         response: Response.redirect(
           `${WEBAPP_URL}/environments/${environmentId}/workspace/integrations/airtable`

--- a/apps/web/app/api/v1/integrations/notion/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/notion/callback/route.ts
@@ -11,6 +11,8 @@ import {
 import { symmetricEncrypt } from "@/lib/crypto";
 import { hasUserEnvironmentAccess } from "@/lib/environment/auth";
 import { createOrUpdateIntegration, getIntegrationByType } from "@/lib/integration/service";
+import { capturePostHogEvent } from "@/lib/posthog";
+import { getOrganizationIdFromEnvironmentId } from "@/lib/utils/helper";
 
 export const GET = withV1ApiWrapper({
   handler: async ({ req, authentication }) => {
@@ -96,6 +98,12 @@ export const GET = withV1ApiWrapper({
       const result = await createOrUpdateIntegration(environmentId, notionIntegration);
 
       if (result) {
+        const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
+        capturePostHogEvent(authentication.user.id, "integration_connected", {
+          integration_type: "notion",
+          organization_id: organizationId,
+        });
+
         return {
           response: Response.redirect(
             `${WEBAPP_URL}/environments/${environmentId}/workspace/integrations/notion`

--- a/apps/web/app/api/v1/integrations/notion/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/notion/callback/route.ts
@@ -1,3 +1,4 @@
+import { logger } from "@formbricks/logger";
 import { TIntegrationNotionConfigData, TIntegrationNotionInput } from "@formbricks/types/integration/notion";
 import { responses } from "@/app/lib/api/response";
 import { withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
@@ -98,11 +99,15 @@ export const GET = withV1ApiWrapper({
       const result = await createOrUpdateIntegration(environmentId, notionIntegration);
 
       if (result) {
-        const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
-        capturePostHogEvent(authentication.user.id, "integration_connected", {
-          integration_type: "notion",
-          organization_id: organizationId,
-        });
+        try {
+          const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
+          capturePostHogEvent(authentication.user.id, "integration_connected", {
+            integration_type: "notion",
+            organization_id: organizationId,
+          });
+        } catch (err) {
+          logger.error({ error: err }, "Failed to capture PostHog integration_connected event for notion");
+        }
 
         return {
           response: Response.redirect(

--- a/apps/web/app/api/v1/integrations/slack/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/slack/callback/route.ts
@@ -1,3 +1,4 @@
+import { logger } from "@formbricks/logger";
 import {
   TIntegrationSlackConfig,
   TIntegrationSlackConfigData,
@@ -106,11 +107,15 @@ export const GET = withV1ApiWrapper({
       const result = await createOrUpdateIntegration(environmentId, integration);
 
       if (result) {
-        const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
-        capturePostHogEvent(authentication.user.id, "integration_connected", {
-          integration_type: "slack",
-          organization_id: organizationId,
-        });
+        try {
+          const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
+          capturePostHogEvent(authentication.user.id, "integration_connected", {
+            integration_type: "slack",
+            organization_id: organizationId,
+          });
+        } catch (err) {
+          logger.error({ error: err }, "Failed to capture PostHog integration_connected event for slack");
+        }
 
         return {
           response: Response.redirect(

--- a/apps/web/app/api/v1/integrations/slack/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/slack/callback/route.ts
@@ -8,6 +8,8 @@ import { withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
 import { SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, SLACK_REDIRECT_URI, WEBAPP_URL } from "@/lib/constants";
 import { hasUserEnvironmentAccess } from "@/lib/environment/auth";
 import { createOrUpdateIntegration, getIntegrationByType } from "@/lib/integration/service";
+import { capturePostHogEvent } from "@/lib/posthog";
+import { getOrganizationIdFromEnvironmentId } from "@/lib/utils/helper";
 
 export const GET = withV1ApiWrapper({
   handler: async ({ req, authentication }) => {
@@ -104,6 +106,12 @@ export const GET = withV1ApiWrapper({
       const result = await createOrUpdateIntegration(environmentId, integration);
 
       if (result) {
+        const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
+        capturePostHogEvent(authentication.user.id, "integration_connected", {
+          integration_type: "slack",
+          organization_id: organizationId,
+        });
+
         return {
           response: Response.redirect(
             `${WEBAPP_URL}/environments/${environmentId}/workspace/integrations/slack`

--- a/apps/web/modules/auth/signup/actions.ts
+++ b/apps/web/modules/auth/signup/actions.ts
@@ -166,6 +166,11 @@ async function handleOrganizationCreation(ctx: ActionClientCtx, user: TCreatedUs
     });
   }
 
+  capturePostHogEvent(user.id, "organization_created", {
+    organization_id: organization.id,
+    is_first_org: true,
+  });
+
   await updateUser(user.id, {
     notificationSettings: {
       ...user.notificationSettings,


### PR DESCRIPTION
## What does this PR do?

  Adds missing PostHog events that were not firing in several flows:

  1. **`organization_created` not firing during signup** — `handleOrganizationCreation` in signup flow creates org but never captured the PostHog event. Only the
  `/setup/organization/create` action had it.
  2. **`integration_connected` not firing on OAuth connect** — Notion, Airtable, and Slack OAuth callbacks call `createOrUpdateIntegration` service directly, bypassing the
  server action that has the PostHog capture.
  3. **`survey_response_received` firing inconsistently** — Old logic used 60s cached response count + `count === 1 || count % 100 === 0`. Stale cache caused duplicate
  fires for early responses, then silence until 100th. Replaced with milestone-based sampling (1, 10, 50, 100, 500, 1000, ...) and extracted to testable lib.

  Also removed debug `console.log`s from integrations action.

  ## How should this be tested?

  - **Signup org creation:** Create new user on cloud instance → verify `organization_created` event appears in PostHog with `organization_id` and `is_first_org` properties
  - **OAuth integrations:** Connect Notion/Airtable/Slack via OAuth → verify `integration_connected` event appears in PostHog with correct `integration_type` and
  `organization_id`
  - **Survey response milestones:** Submit survey responses → verify `survey_response_received` fires at counts 1, 10, 50, 100, 500 and does NOT fire for counts 2-9, 11-49,
   etc.
  - **Unit tests:** `npx vitest run apps/web/app/api/\(internal\)/pipeline/lib/posthog.test.ts` — 10 tests covering milestone logic

  ## Checklist

  ### Required

  - [x] Filled out the "How to test" section in this PR
  - [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
  - [x] Self-reviewed my own code
  - [x] Commented on my code in hard-to-understand bits
  - [x] Ran `pnpm build`
  - [x] Checked for warnings, there are none
  - [x] Removed all `console.logs`
  - [x] Merged the latest changes from main onto my branch with `git pull origin main`
  - [x] My changes don't cause any responsiveness issues

  ### Appreciated

  - [ ] If a UI change was made: Added a screen recording or screenshots to this PR
  - [ ] Updated the Formbricks Docs if changes were necessary