### PR TITLE
fix: prevent OIDC button text overlap with 'last used' indicator

### DIFF
--- a/apps/web/modules/ee/sso/components/open-id-button.tsx
+++ b/apps/web/modules/ee/sso/components/open-id-button.tsx
@@ -46,13 +46,9 @@ export const OpenIdButton = ({
       type="button"
       onClick={handleLogin}
       variant="secondary"
-      className="relative w-full justify-center overflow-hidden">
-      <span className={lastUsed ? "truncate pr-16" : "truncate"}>
-        {text ? text : t("auth.continue_with_openid")}
-      </span>
-      {lastUsed && (
-        <span className="absolute right-3 shrink-0 text-xs opacity-50">{t("auth.last_used")}</span>
-      )}
+      className="w-full items-center justify-center gap-2">
+      <span className="truncate">{text ? text : t("auth.continue_with_openid")}</span>
+      {lastUsed && <span className="shrink-0 text-xs opacity-50">{t("auth.last_used")}</span>}
     </Button>
   );
 };

--- a/apps/web/modules/ee/sso/components/open-id-button.tsx
+++ b/apps/web/modules/ee/sso/components/open-id-button.tsx
@@ -46,8 +46,8 @@ export const OpenIdButton = ({
       type="button"
       onClick={handleLogin}
       variant="secondary"
-      className="w-full items-center justify-center gap-2">
-      <span className="truncate">{text ? text : t("auth.continue_with_openid")}</span>
+      className="w-full items-center justify-center gap-2 px-2">
+      <span className="truncate">{text || t("auth.continue_with_openid")}</span>
       {lastUsed && <span className="shrink-0 text-xs opacity-50">{t("auth.last_used")}</span>}
     </Button>
   );

--- a/apps/web/modules/ee/sso/components/open-id-button.tsx
+++ b/apps/web/modules/ee/sso/components/open-id-button.tsx
@@ -46,9 +46,13 @@ export const OpenIdButton = ({
       type="button"
       onClick={handleLogin}
       variant="secondary"
-      className="relative w-full justify-center">
-      {text ? text : t("auth.continue_with_openid")}
-      {lastUsed && <span className="absolute right-3 text-xs opacity-50">{t("auth.last_used")}</span>}
+      className="relative w-full justify-center overflow-hidden">
+      <span className={lastUsed ? "truncate pr-16" : "truncate"}>
+        {text ? text : t("auth.continue_with_openid")}
+      </span>
+      {lastUsed && (
+        <span className="absolute right-3 shrink-0 text-xs opacity-50">{t("auth.last_used")}</span>
+      )}
     </Button>
   );
 };


### PR DESCRIPTION
Fixes #7539.

When `OIDC_DISPLAY_NAME` is set to a long value (e.g. "OIDC lemonldap"), the centered button text extends into the area where the absolutely-positioned "last used" indicator sits (`absolute right-3 opacity-50`). In Firefox, this causes visible text bleed-through where the two labels overlap. In the reporter's French UI, "Continuer avec OIDC lemonldap" runs into "Dernière utilisation" and the tail end of the indicator shows through the main text.

Three changes to `open-id-button.tsx`:

1. Wrapped the main text in `<span className="truncate">` so it ellipsis-truncates before reaching the indicator area
2. Added `overflow-hidden` on the Button to clip any remaining overflow
3. When `lastUsed` is shown, applied `pr-16` on the text span to leave room for the indicator, and `shrink-0` on the indicator span so it doesn't collapse

The other SSO buttons (Google, GitHub, Azure) have the same `absolute right-3` pattern but use fixed-length labels that don't overflow. The OIDC button is the only one with a variable-length `OIDC_DISPLAY_NAME`, so only this button needs the truncation guard.