### PR TITLE
fix: prevent success toast when server returns error in copy survey

### DIFF
--- a/apps/web/modules/survey/list/components/copy-survey-form.tsx
+++ b/apps/web/modules/survey/list/components/copy-survey-form.tsx
@@ -149,7 +149,7 @@ export const CopySurveyForm = ({ defaultProjects, survey, onCancel, setOpen }: C
       const errorsIndexes: number[] = [];
 
       results.forEach((result, index) => {
-        if (result?.data) {
+        if (result?.data && !result?.serverError) {
           successCount++;
         } else {
           errorsIndexes.push(index);


### PR DESCRIPTION
## Summary

When copying surveys to multiple environments, the success toast was firing even when the server returned a `serverError` (HTTP 200 with error payload from `next-safe-action`).

**Root cause:** The check `if (result?.data)` only verifies data exists but doesn't account for the case where `result.serverError` is also set — which happens when a server action throws internally.

**Fix:** Added `&& !result?.serverError` check in `copy-survey-form.tsx`.

## Changes

- `apps/web/modules/survey/list/components/copy-survey-form.tsx` — 1-line fix

## Test plan

- [ ] Copy a survey to an environment where it already exists (triggers server error)
- [ ] Verify no success toast appears
- [ ] Copy a survey successfully — verify success toast still appears

Fixes #3302

🤖 Generated with [Claude Code](https://claude.com/claude-code)