### PR TITLE
feat: implement retry logic and error handling for Notion API requests

### DIFF
--- a/apps/web/lib/notion/service.test.ts
+++ b/apps/web/lib/notion/service.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { writeData } from "@/lib/notion/service";
+
+vi.mock("@/lib/crypto", () => ({
+  symmetricDecrypt: vi.fn(() => "decrypted-notion-token"),
+}));
+
+const notionConfig = {
+  key: {
+    access_token: "encrypted-token",
+    bot_id: "bot-id",
+    token_type: "bearer",
+    duplicated_template_id: null,
+    owner: { type: "workspace", workspace: true, user: null },
+    workspace_icon: null,
+    workspace_id: "workspace-id",
+    workspace_name: "workspace-name",
+  },
+  data: [],
+} as any;
+
+describe("notion service", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  test("writeData retries on 429 and then succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "rate limited", code: "rate_limited" }), {
+          status: 429,
+          headers: {
+            "retry-after": "0",
+            "x-request-id": "req-1",
+            "content-type": "application/json",
+          },
+        })
+      )
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+    global.fetch = fetchMock as any;
+
+    await expect(
+      writeData("db1", { Name: { title: [{ text: { content: "hi" } }] } }, notionConfig)
+    ).resolves.toBe(undefined);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("writeData throws immediately on non-retryable 400", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ message: "bad request", code: "validation_error" }), {
+        status: 400,
+        headers: {
+          "x-request-id": "req-2",
+          "content-type": "application/json",
+        },
+      })
+    );
+
+    global.fetch = fetchMock as any;
+
+    await expect(
+      writeData("db1", { Name: { title: [{ text: { content: "hi" } }] } }, notionConfig)
+    ).rejects.toThrow(/bad request/i);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("writeData retries on network error and then succeeds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+    global.fetch = fetchMock as any;
+
+    const promise = writeData("db1", { Name: { title: [{ text: { content: "hi" } }] } }, notionConfig);
+
+    await vi.runAllTimersAsync();
+    await expect(promise).resolves.toBe(undefined);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/lib/notion/service.ts
+++ b/apps/web/lib/notion/service.ts
@@ -7,19 +7,135 @@ import { ENCRYPTION_KEY } from "@/lib/constants";
 import { symmetricDecrypt } from "@/lib/crypto";
 import { getIntegrationByType } from "../integration/service";
 
+class NotionApiError extends Error {
+  status: number;
+  code?: string;
+  requestId?: string;
+
+  constructor(message: string, opts: { status: number; code?: string; requestId?: string }) {
+    super(message);
+    this.name = "NotionApiError";
+    this.status = opts.status;
+    this.code = opts.code;
+    this.requestId = opts.requestId;
+  }
+}
+
+const NOTION_MAX_ATTEMPTS = 3;
+const NOTION_BACKOFF_MS = 250;
+
+const isRetryableNotionStatus = (status: number): boolean => {
+  return status === 429 || status === 500 || status === 502 || status === 503 || status === 504;
+};
+
+const getNotionRequestId = (headers: Headers): string | undefined => {
+  return headers.get("x-request-id") ?? headers.get("x-notion-request-id") ?? undefined;
+};
+
+const getRetryDelayMs = (attempt: number, headers?: Headers): number => {
+  if (headers) {
+    const retryAfter = headers.get("retry-after");
+    if (retryAfter) {
+      const seconds = Number.parseInt(retryAfter, 10);
+      if (Number.isFinite(seconds) && seconds >= 0) {
+        return Math.min(seconds * 1000, 2000);
+      }
+    }
+  }
+
+  // attempt 1: 0ms, attempt 2: 250ms, attempt 3: 500ms
+  return (attempt - 1) * NOTION_BACKOFF_MS;
+};
+
+const sleep = async (ms: number): Promise<void> => {
+  if (ms <= 0) return;
+  await new Promise<void>((resolve) => setTimeout(resolve, ms));
+};
+
+const parseNotionError = async (res: Response): Promise<{ message: string; code?: string }> => {
+  const fallbackMessage = `Notion API request failed with status ${res.status}`;
+
+  try {
+    const text = await res.text();
+    if (!text) {
+      return { message: fallbackMessage };
+    }
+
+    try {
+      const json = JSON.parse(text) as any;
+      const message = typeof json?.message === "string" ? json.message : fallbackMessage;
+      const code = typeof json?.code === "string" ? json.code : undefined;
+      return { message, code };
+    } catch {
+      return { message: `${fallbackMessage}: ${text}` };
+    }
+  } catch {
+    return { message: fallbackMessage };
+  }
+};
+
+const notionFetch = async (
+  url: string,
+  init: RequestInit,
+  config: TIntegrationNotionConfig
+): Promise<Response> => {
+  const baseHeaders = getHeaders(config);
+  const mergedHeaders = new Headers(init.headers);
+  Object.entries(baseHeaders).forEach(([key, value]) => {
+    if (!mergedHeaders.has(key)) mergedHeaders.set(key, value);
+  });
+
+  for (let attempt = 1; attempt <= NOTION_MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(url, {
+        ...init,
+        headers: mergedHeaders,
+      });
+
+      if (res.ok) {
+        return res;
+      }
+
+      const requestId = getNotionRequestId(res.headers);
+      const { message, code } = await parseNotionError(res);
+      const errorMessage = requestId ? `${message} (requestId: ${requestId})` : message;
+      const error = new NotionApiError(errorMessage, { status: res.status, code, requestId });
+
+      if (attempt < NOTION_MAX_ATTEMPTS && isRetryableNotionStatus(res.status)) {
+        await sleep(getRetryDelayMs(attempt, res.headers));
+        continue;
+      }
+
+      throw error;
+    } catch (error) {
+      // fetch() throws TypeError on network errors.
+      if (attempt < NOTION_MAX_ATTEMPTS && error instanceof TypeError) {
+        await sleep(getRetryDelayMs(attempt));
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  throw new Error("Notion API request failed after retries");
+};
+
 const fetchPages = async (config: TIntegrationNotionConfig) => {
   try {
-    const res = await fetch("https://api.notion.com/v1/search", {
-      headers: getHeaders(config),
-      method: "POST",
-      body: JSON.stringify({
-        page_size: 100,
-        filter: {
-          value: "database",
-          property: "object",
-        },
-      }),
-    });
+    const res = await notionFetch(
+      "https://api.notion.com/v1/search",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          page_size: 100,
+          filter: {
+            value: "database",
+            property: "object",
+          },
+        }),
+      },
+      config
+    );
     return (await res.json()).results;
   } catch (error) {
     throw error;
@@ -45,16 +161,19 @@ export const writeData = async (
   config: TIntegrationNotionConfig
 ) => {
   try {
-    await fetch(`https://api.notion.com/v1/pages`, {
-      headers: getHeaders(config),
-      method: "POST",
-      body: JSON.stringify({
-        parent: {
-          database_id: databaseId,
-        },
-        properties: properties,
-      }),
-    });
+    await notionFetch(
+      `https://api.notion.com/v1/pages`,
+      {
+        method: "POST",
+        body: JSON.stringify({
+          parent: {
+            database_id: databaseId,
+          },
+          properties: properties,
+        }),
+      },
+      config
+    );
   } catch (error) {
     throw error;
   }


### PR DESCRIPTION
## Fixes #7699

## Summary
Notion integration could “randomly” miss creating database entries because our Notion client never checked `Response.ok`. When Notion returned `429/5xx/4xx`, the request was treated as success and the pipeline silently dropped the write.

## Changes
- Add a small Notion fetch wrapper in [apps/web/lib/notion/service.ts](apps/web/lib/notion/service.ts) that:
  - Throws on non-2xx responses (instead of silently succeeding)
  - Retries transient failures (`429`, `5xx`, and network `TypeError`) up to 3 attempts with a small backoff
  - Honors `Retry-After` (capped) when rate-limited
  - Includes the Notion request id in the error message when available
- Update Notion database search + page creation to use this wrapper

## Tests
- Added unit tests: [apps/web/lib/notion/service.test.ts](apps/web/lib/notion/service.test.ts)
- Ran: `pnpm -C apps/web test -- lib/notion/service.test.ts` (suite green)

## Notes / Risk
- On transient Notion failures, writes may take slightly longer (retries/backoff); on success path there’s no behavioral change.
- Non-retryable 4xx errors now fail fast and are properly surfaced/logged (instead of being silently ignored).

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
