### PR TITLE
fix: fixes unique constraint error with singleUseId and surveyId

### DIFF
--- a/apps/web/app/api/v2/client/[environmentId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/lib/response.test.ts
@@ -2,7 +2,7 @@ import { Prisma } from "@prisma/client";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
-import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { DatabaseError, ResourceNotFoundError, UniqueConstraintError } from "@formbricks/types/errors";
 import { TResponseWithQuotaFull, TSurveyQuota } from "@formbricks/types/quota";
 import { TResponse } from "@formbricks/types/responses";
 import { TTag } from "@formbricks/types/tags";
@@ -175,9 +175,33 @@ describe("createResponse V2", () => {
     ).rejects.toThrow(ResourceNotFoundError);
   });
 
-  test("should throw DatabaseError on Prisma known request error", async () => {
-    const prismaError = new Prisma.PrismaClientKnownRequestError("Test Prisma Error", {
+  test("should throw UniqueConstraintError on P2002 with singleUseId target", async () => {
+    const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
       code: "P2002",
+      clientVersion: "test",
+      meta: { target: ["surveyId", "singleUseId"] },
+    });
+    vi.mocked(mockTx.response.create).mockRejectedValue(prismaError);
+    await expect(
+      createResponse(mockResponseInput, mockTx as unknown as Prisma.TransactionClient)
+    ).rejects.toThrow(UniqueConstraintError);
+  });
+
+  test("should throw DatabaseError on P2002 without singleUseId target", async () => {
+    const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+      code: "P2002",
+      clientVersion: "test",
+      meta: { target: ["displayId"] },
+    });
+    vi.mocked(mockTx.response.create).mockRejectedValue(prismaError);
+    await expect(
+      createResponse(mockResponseInput, mockTx as unknown as Prisma.TransactionClient)
+    ).rejects.toThrow(DatabaseError);
+  });
+
+  test("should throw DatabaseError on non-P2002 Prisma known request error", async () => {
+    const prismaError = new Prisma.PrismaClientKnownRequestError("Test Prisma Error", {
+      code: "P2025",
       clientVersion: "test",
     });
     vi.mocked(mockTx.response.create).mockRejectedValue(prismaError);

--- a/apps/web/app/api/v2/client/[environmentId]/responses/lib/response.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/lib/response.ts
@@ -131,7 +131,7 @@ export const createResponse = async (
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       if (error.code === "P2002") {
         const target = (error.meta?.target as string[]) ?? [];
-        if (target && target.includes("singleUseId")) {
+        if (target?.includes("singleUseId")) {
           throw new UniqueConstraintError("Response already submitted for this single-use link");
         }
       }

--- a/apps/web/app/api/v2/client/[environmentId]/responses/lib/response.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/lib/response.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@formbricks/database";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
-import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { DatabaseError, ResourceNotFoundError, UniqueConstraintError } from "@formbricks/types/errors";
 import { TResponseWithQuotaFull } from "@formbricks/types/quota";
 import { TResponse, ZResponseInput } from "@formbricks/types/responses";
 import { TTag } from "@formbricks/types/tags";
@@ -129,6 +129,13 @@ export const createResponse = async (
     return response;
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error.code === "P2002") {
+        const target = (error.meta?.target as string[]) ?? [];
+        if (target && target.includes("singleUseId")) {
+          throw new UniqueConstraintError("Response already submitted for this single-use link");
+        }
+      }
+
       throw new DatabaseError(error.message);
     }
 

--- a/apps/web/app/api/v2/client/[environmentId]/responses/route.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/route.ts
@@ -1,6 +1,6 @@
 import { UAParser } from "ua-parser-js";
 import { ZEnvironmentId } from "@formbricks/types/environment";
-import { InvalidInputError } from "@formbricks/types/errors";
+import { InvalidInputError, UniqueConstraintError } from "@formbricks/types/errors";
 import { TResponseWithQuotaFull } from "@formbricks/types/quota";
 import { checkSurveyValidity } from "@/app/api/v2/client/[environmentId]/responses/lib/utils";
 import { reportApiError } from "@/app/lib/api/api-error-reporter";
@@ -175,6 +175,10 @@ const createResponseForRequest = async ({
   } catch (error) {
     if (error instanceof InvalidInputError) {
       return responses.badRequestResponse(error.message, undefined, true);
+    }
+
+    if (error instanceof UniqueConstraintError) {
+      return responses.conflictResponse(error.message, undefined, true);
     }
 
     const response = getUnexpectedPublicErrorResponse();

--- a/apps/web/app/lib/api/response.test.ts
+++ b/apps/web/app/lib/api/response.test.ts
@@ -339,6 +339,56 @@ describe("API Response Utilities", () => {
     });
   });
 
+  describe("conflictResponse", () => {
+    test("should return a conflict response", () => {
+      const message = "Resource already exists";
+      const details = { field: "singleUseId" };
+      const response = responses.conflictResponse(message, details);
+
+      expect(response.status).toBe(409);
+
+      return response.json().then((body) => {
+        expect(body).toEqual({
+          code: "conflict",
+          message,
+          details,
+        });
+      });
+    });
+
+    test("should handle undefined details", () => {
+      const message = "Resource already exists";
+      const response = responses.conflictResponse(message);
+
+      expect(response.status).toBe(409);
+
+      return response.json().then((body) => {
+        expect(body).toEqual({
+          code: "conflict",
+          message,
+          details: {},
+        });
+      });
+    });
+
+    test("should include CORS headers when cors is true", () => {
+      const message = "Resource already exists";
+      const response = responses.conflictResponse(message, undefined, true);
+
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("GET, POST, PUT, DELETE, OPTIONS");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Content-Type, Authorization");
+    });
+
+    test("should use custom cache control header when provided", () => {
+      const message = "Resource already exists";
+      const customCache = "no-cache";
+      const response = responses.conflictResponse(message, undefined, false, customCache);
+
+      expect(response.headers.get("Cache-Control")).toBe(customCache);
+    });
+  });
+
   describe("tooManyRequestsResponse", () => {
     test("should return a too many requests response", () => {
       const message = "Rate limit exceeded";

--- a/apps/web/app/lib/api/response.ts
+++ b/apps/web/app/lib/api/response.ts
@@ -16,7 +16,8 @@ interface ApiErrorResponse {
     | "method_not_allowed"
     | "not_authenticated"
     | "forbidden"
-    | "too_many_requests";
+    | "too_many_requests"
+    | "conflict";
   message: string;
   details: {
     [key: string]: string | string[] | number | number[] | boolean | boolean[];
@@ -236,6 +237,30 @@ const internalServerErrorResponse = (
   );
 };
 
+const conflictResponse = (
+  message: string,
+  details?: { [key: string]: string },
+  cors: boolean = false,
+  cache: string = "private, no-store"
+) => {
+  const headers = {
+    ...(cors && corsHeaders),
+    "Cache-Control": cache,
+  };
+
+  return Response.json(
+    {
+      code: "conflict",
+      message,
+      details: details || {},
+    } as ApiErrorResponse,
+    {
+      status: 409,
+      headers,
+    }
+  );
+};
+
 const tooManyRequestsResponse = (
   message: string,
   cors: boolean = false,
@@ -270,4 +295,5 @@ export const responses = {
   successResponse,
   tooManyRequestsResponse,
   forbiddenResponse,
+  conflictResponse,
 };


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?


  Fix unhandled `P2002` unique constraint violation on `(surveyId, singleUseId)` in `POST
  /api/v2/client/{environmentId}/responses`. Previously duplicate single-use submissions
  returned `500 Internal Server Error`, which caused the client
  `ResponseQueue.syncPersistedResponses` to retry indefinitely (4xx are discarded, 5xx are
  retried).

  Now:
  - `createResponse` in `lib/response.ts` detects `PrismaClientKnownRequestError.code ===
  "P2002"` with `meta.target` including `singleUseId` and throws `UniqueConstraintError`
  instead of a generic `DatabaseError`.
  - Route handler catches `UniqueConstraintError` and returns `409 Conflict`.
  - Added `conflictResponse` helper + `"conflict"` code to
  `apps/web/app/lib/api/response.ts`.

  Net effect: duplicate single-use submissions respond `409`, client discards stale queue
  entry, retry loop broken, Sentry noise gone.

  Fixes sentry issue with id `111772929`

  ## How should this be tested?

  - Create a survey with single-use links enabled, generate a link.
  - Manual double-submit: open link → DevTools Network throttle "Slow 3G" → double-click
  submit → 2nd request should return `409` with body `{ code: "conflict", message: "Response
   already submitted for this single-use link" }`.
  - Curl replay: capture the first `POST /api/v2/client/{envId}/responses` payload, replay
  twice in parallel → one `200`, one `409`.
  - Offline sync: set DevTools offline, submit, go back online → `syncPersistedResponses`
  replays → server returns `409` → entry is discarded from IndexedDB (verify via
  `Application → IndexedDB`), no retry loop.
  - Verify no regressions in normal (non-single-use) response submission.
  - Confirm Sentry no longer captures `DatabaseError` for this path.

  ## Checklist

  ### Required

  - [x] Filled out the "How to test" section in this PR
  - [x] Read [How we Code at
  Formbricks](https://formbricks.com/docs/contributing/how-we-code)
  - [x] Self-reviewed my own code
  - [x] Commented on my code in hard-to-understand bits
  - [x] Ran `pnpm build`
  - [x] Checked for warnings, there are none
  - [x] Removed all `console.logs`
  - [x] Merged the latest changes from main onto my branch with `git pull origin main`
  - [x] My changes don't cause any responsiveness issues
  - [ ] First PR at Formbricks? [Please sign the
  CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge
  it 🙏

  ### Appreciated

  - [ ] If a UI change was made: Added a screen recording or screenshots to this PR
  - [ ] Updated the Formbricks Docs if changes were necessary
