### PR TITLE
fix: prevent success toast when server returns error in copy survey

### DIFF
--- a/apps/web/modules/survey/list/components/copy-survey-form.tsx
+++ b/apps/web/modules/survey/list/components/copy-survey-form.tsx
@@ -149,7 +149,7 @@ export const CopySurveyForm = ({ defaultProjects, survey, onCancel, setOpen }: C
       const errorsIndexes: number[] = [];
 
       results.forEach((result, index) => {
-        if (result?.data) {
+        if (result?.data && !result?.serverError) {
           successCount++;
         } else {
           errorsIndexes.push(index);


### PR DESCRIPTION
## Summary

When copying surveys to multiple environments, a success toast fires even when the server returns an error. This happens because `next-safe-action` can return `{ serverError: "..." }` with HTTP 200, and the current check `if (result?.data)` doesn't guard against `serverError` being set simultaneously.

**Fix:** Added `&& !result?.serverError` to the condition in `copy-survey-form.tsx` line 152.

## Changes

- `apps/web/modules/survey/list/components/copy-survey-form.tsx` — 1-line fix

## Test plan

- [ ] Copy a survey to an environment where it already exists (triggers a server error)
- [ ] Verify no success toast appears on error
- [ ] Copy a survey successfully — verify success toast still appears correctly

Fixes #3302