### PR TITLE
fix: prevent offline replay from dropping survey blocks after completion

### DIFF
--- a/packages/surveys/src/lib/response-queue.ts
+++ b/packages/surveys/src/lib/response-queue.ts
@@ -32,23 +32,28 @@ export const delay = (ms: number): Promise<void> => {
   });
 };
 
-// Module-level sync lock keyed by surveyId.
-// Survives ResponseQueue instance recreation (e.g. React useMemo recomputation)
-// so that only one sync runs at a time per survey, even across instances.
+// Module-level locks keyed by surveyId.
+// Survive ResponseQueue instance recreation (e.g. React useMemo recomputation)
+// so that only one sync/send runs at a time per survey, even across instances.
 const syncingBySurvey = new Map<string, boolean>();
+const requestInProgressBySurvey = new Map<string, boolean>();
 
 /** @internal Exposed for tests only. */
 export const _syncLocks = {
-  clear: () => syncingBySurvey.clear(),
+  clear: () => {
+    syncingBySurvey.clear();
+    requestInProgressBySurvey.clear();
+  },
   set: (surveyId: string, value: boolean) => syncingBySurvey.set(surveyId, value),
   get: (surveyId: string) => syncingBySurvey.get(surveyId) ?? false,
+  setRequestInProgress: (surveyId: string, value: boolean) => requestInProgressBySurvey.set(surveyId, value),
+  getRequestInProgress: (surveyId: string) => requestInProgressBySurvey.get(surveyId) ?? false,
 };
 
 export class ResponseQueue {
   readonly queue: TResponseUpdate[] = [];
   readonly config: QueueConfig;
   private surveyState: SurveyState;
-  private isRequestInProgress = false;
   readonly api: ApiClient;
   private responseRecaptchaToken?: string;
   // Maps in-memory queue index → IndexedDB id for cleanup after successful send
@@ -70,6 +75,16 @@ export class ResponseQueue {
   private set isSyncing(value: boolean) {
     if (this.config.surveyId) {
       syncingBySurvey.set(this.config.surveyId, value);
+    }
+  }
+
+  private get isRequestInProgress(): boolean {
+    return this.config.surveyId ? (requestInProgressBySurvey.get(this.config.surveyId) ?? false) : false;
+  }
+
+  private set isRequestInProgress(value: boolean) {
+    if (this.config.surveyId) {
+      requestInProgressBySurvey.set(this.config.surveyId, value);
     }
   }
 
@@ -139,8 +154,8 @@ export class ResponseQueue {
     if (this.config.persistOffline && this.config.surveyId) {
       const pendingCount = await countPendingResponses(this.config.surveyId);
 
-      // Re-check after await — syncPersistedResponses may have started during the yield
-      if (this.isSyncing) {
+      // Re-check after await — another processQueue/sync may have started during the yield
+      if (this.isSyncing || this.isRequestInProgress || this.queue.length === 0) {
         return { success: false };
       }
 

--- a/packages/surveys/src/lib/response-queue.ts
+++ b/packages/surveys/src/lib/response-queue.ts
@@ -32,6 +32,18 @@ export const delay = (ms: number): Promise<void> => {
   });
 };
 
+// Module-level sync lock keyed by surveyId.
+// Survives ResponseQueue instance recreation (e.g. React useMemo recomputation)
+// so that only one sync runs at a time per survey, even across instances.
+const syncingBySurvey = new Map<string, boolean>();
+
+/** @internal Exposed for tests only. */
+export const _syncLocks = {
+  clear: () => syncingBySurvey.clear(),
+  set: (surveyId: string, value: boolean) => syncingBySurvey.set(surveyId, value),
+  get: (surveyId: string) => syncingBySurvey.get(surveyId) ?? false,
+};
+
 export class ResponseQueue {
   readonly queue: TResponseUpdate[] = [];
   readonly config: QueueConfig;
@@ -41,7 +53,6 @@ export class ResponseQueue {
   private responseRecaptchaToken?: string;
   // Maps in-memory queue index → IndexedDB id for cleanup after successful send
   private readonly pendingDbIds: Map<TResponseUpdate, number> = new Map();
-  private isSyncing = false;
 
   constructor(config: QueueConfig, surveyState: SurveyState) {
     this.config = config;
@@ -50,6 +61,16 @@ export class ResponseQueue {
       appUrl: config.appUrl,
       environmentId: config.environmentId,
     });
+  }
+
+  private get isSyncing(): boolean {
+    return this.config.surveyId ? (syncingBySurvey.get(this.config.surveyId) ?? false) : false;
+  }
+
+  private set isSyncing(value: boolean) {
+    if (this.config.surveyId) {
+      syncingBySurvey.set(this.config.surveyId, value);
+    }
   }
 
   setResponseRecaptchaToken(token?: string) {
@@ -111,8 +132,26 @@ export class ResponseQueue {
       return { success: false };
     }
 
-    this.isRequestInProgress = true;
+    // When offline support is active and there are multiple pending entries in
+    // IndexedDB, defer to syncPersistedResponses which drains them in order.
+    // This prevents processQueue and syncPersistedResponses from racing to
+    // create the same response concurrently (duplicate POSTs).
+    if (this.config.persistOffline && this.config.surveyId) {
+      const pendingCount = await countPendingResponses(this.config.surveyId);
+
+      // Re-check after await — syncPersistedResponses may have started during the yield
+      if (this.isSyncing) {
+        return { success: false };
+      }
+
+      if (pendingCount > 1) {
+        void this.syncPersistedResponses();
+        return { success: false };
+      }
+    }
+
     const responseUpdate = this.queue[0];
+    this.isRequestInProgress = true;
 
     const result = await this.sendResponseWithRetry(responseUpdate);
 
@@ -169,6 +208,11 @@ export class ResponseQueue {
 
     // Concurrency guard: prevent duplicate syncs from online/offline flicker
     if (this.isSyncing) return { success: false, syncedCount: 0 };
+
+    // If processQueue already has a request in flight, don't start syncing —
+    // let it finish first to avoid both paths creating the same response.
+    if (this.isRequestInProgress) return { success: false, syncedCount: 0 };
+
     this.isSyncing = true;
 
     try {

--- a/packages/surveys/src/lib/response.queue.test.ts
+++ b/packages/surveys/src/lib/response.queue.test.ts
@@ -3,7 +3,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vit
 import { err, ok } from "@formbricks/types/error-handlers";
 import { TResponseUpdate } from "@formbricks/types/responses";
 import { TResponseErrorCodesEnum } from "@/types/response-error-codes";
-import { ResponseQueue, delay } from "./response-queue";
+import { ResponseQueue, _syncLocks, delay } from "./response-queue";
 import { SurveyState } from "./survey-state";
 
 // Suppress noisy console output from retry logic during tests
@@ -86,6 +86,7 @@ describe("ResponseQueue", () => {
     queue = new ResponseQueue(config, surveyState);
     apiMock = queue.api;
     vi.clearAllMocks();
+    _syncLocks.clear();
   });
 
   test("constructor initializes properties", () => {
@@ -309,9 +310,13 @@ describe("ResponseQueue", () => {
   });
 
   test("processQueue returns false when isSyncing is true", async () => {
-    queue.queue.push(responseUpdate);
-    queue["isSyncing"] = true;
-    const result = await queue.processQueue();
+    const offlineQueue = new ResponseQueue(
+      getConfig({ persistOffline: true, surveyId: "s1" }),
+      getSurveyState()
+    );
+    offlineQueue.queue.push(responseUpdate);
+    _syncLocks.set("s1", true);
+    const result = await offlineQueue.processQueue();
     expect(result.success).toBe(false);
   });
 
@@ -347,7 +352,7 @@ describe("ResponseQueue", () => {
       getConfig({ persistOffline: true, surveyId: "s1" }),
       getSurveyState()
     );
-    offlineQueue["isSyncing"] = true;
+    _syncLocks.set("s1", true);
     const result = await offlineQueue.syncPersistedResponses();
     expect(result).toEqual({ success: false, syncedCount: 0 });
   });
@@ -382,7 +387,7 @@ describe("ResponseQueue", () => {
     expect(result).toEqual({ success: true, syncedCount: 1 });
     expect(removePendingResponse).toHaveBeenCalledWith(10);
     expect(offlineQueue.queue.length).toBe(0);
-    expect(offlineQueue["isSyncing"]).toBe(false);
+    expect(_syncLocks.get("s1")).toBe(false);
   });
 
   test("syncPersistedResponses stops on server error", async () => {
@@ -415,7 +420,7 @@ describe("ResponseQueue", () => {
 
     const result = await offlineQueue.syncPersistedResponses();
     expect(result).toEqual({ success: false, syncedCount: 0 });
-    expect(offlineQueue["isSyncing"]).toBe(false);
+    expect(_syncLocks.get("s1")).toBe(false);
   });
 
   test("syncPersistedResponses retries 404 as createResponse by resetting responseId", async () => {

--- a/packages/surveys/src/lib/response.queue.test.ts
+++ b/packages/surveys/src/lib/response.queue.test.ts
@@ -111,26 +111,30 @@ describe("ResponseQueue", () => {
   });
 
   test("processQueue does nothing if request in progress or queue empty", async () => {
-    queue["isRequestInProgress"] = true;
-    await queue.processQueue();
-    queue["isRequestInProgress"] = false;
-    queue.queue.length = 0;
-    await queue.processQueue();
+    const reqQueue = new ResponseQueue(getConfig({ surveyId: "s1" }), getSurveyState());
+    _syncLocks.setRequestInProgress("s1", true);
+    await reqQueue.processQueue();
+    _syncLocks.setRequestInProgress("s1", false);
+    reqQueue.queue.length = 0;
+    await reqQueue.processQueue();
     expect(true).toBe(true); // just to ensure no errors
   });
 
   test("processQueue sends response and removes from queue on success", async () => {
-    queue.queue.push(responseUpdate);
-    vi.spyOn(queue, "sendResponse").mockResolvedValue(ok(true));
-    await queue.processQueue();
-    expect(queue.queue.length).toBe(0);
-    expect(queue["isRequestInProgress"]).toBe(false);
+    const reqQueue = new ResponseQueue(getConfig({ surveyId: "s1" }), getSurveyState());
+    reqQueue.queue.push(responseUpdate);
+    vi.spyOn(reqQueue, "sendResponse").mockResolvedValue(ok(true));
+    await reqQueue.processQueue();
+    expect(reqQueue.queue.length).toBe(0);
+    expect(_syncLocks.getRequestInProgress("s1")).toBe(false);
   });
 
   test("processQueue retries and calls onResponseSendingFailed on recaptcha error", async () => {
-    queue.queue.push(responseUpdate);
+    const recaptchaConfig = getConfig({ surveyId: "s1" });
+    const recaptchaQueue = new ResponseQueue(recaptchaConfig, getSurveyState());
+    recaptchaQueue.queue.push(responseUpdate);
 
-    vi.spyOn(queue, "sendResponse").mockResolvedValue(
+    vi.spyOn(recaptchaQueue, "sendResponse").mockResolvedValue(
       err({
         code: "internal_server_error",
         message: "An error occurred while sending the response.",
@@ -140,29 +144,31 @@ describe("ResponseQueue", () => {
         },
       })
     );
-    await queue.processQueue();
-    expect(config.onResponseSendingFailed).toHaveBeenCalledWith(
+    await recaptchaQueue.processQueue();
+    expect(recaptchaConfig.onResponseSendingFailed).toHaveBeenCalledWith(
       responseUpdate,
       TResponseErrorCodesEnum.RecaptchaError
     );
-    expect(queue["isRequestInProgress"]).toBe(false);
+    expect(_syncLocks.getRequestInProgress("s1")).toBe(false);
   });
 
   test("processQueue retries and calls onResponseSendingFailed after max attempts", async () => {
-    queue.queue.push(responseUpdate);
-    vi.spyOn(queue, "sendResponse").mockResolvedValue(
+    const reqConfig = getConfig({ surveyId: "s1" });
+    const reqQueue = new ResponseQueue(reqConfig, getSurveyState());
+    reqQueue.queue.push(responseUpdate);
+    vi.spyOn(reqQueue, "sendResponse").mockResolvedValue(
       err({
         code: "internal_server_error",
         message: "An error occurred while sending the response.",
         status: 500,
       })
     );
-    await queue.processQueue();
-    expect(config.onResponseSendingFailed).toHaveBeenCalledWith(
+    await reqQueue.processQueue();
+    expect(reqConfig.onResponseSendingFailed).toHaveBeenCalledWith(
       responseUpdate,
       TResponseErrorCodesEnum.ResponseSendingError
     );
-    expect(queue["isRequestInProgress"]).toBe(false);
+    expect(_syncLocks.getRequestInProgress("s1")).toBe(false);
   });
 
   test("processQueue calls onResponseSendingFinished if finished", async () => {
@@ -219,8 +225,9 @@ describe("ResponseQueue", () => {
   });
 
   test("processQueueAsync returns success false if request in progress", async () => {
-    queue["isRequestInProgress"] = true;
-    const result = await queue.processQueue();
+    const reqQueue = new ResponseQueue(getConfig({ surveyId: "s1" }), getSurveyState());
+    _syncLocks.setRequestInProgress("s1", true);
+    const result = await reqQueue.processQueue();
     expect(result.success).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
Backport of #7743 for release/4.9.

- When `offlineSupport` is enabled, `processQueue` and `syncPersistedResponses` could race to create the same response — one triggered by `add()`'s IndexedDB callback, the other by the `useEffect` that fires on reconnect. This caused duplicate POST creates, and the server would reject subsequent block updates with "Response is already finished" (400), effectively dropping those blocks.
- Moves the `isSyncing` concurrency lock from an instance property to a module-level `Map` keyed by `surveyId`, so it survives `ResponseQueue` instance recreation caused by React `useMemo` recomputation during re-renders.
- Adds a `processQueue` gate that defers to `syncPersistedResponses` when multiple IndexedDB entries exist, with a re-check of `isSyncing` after the async `countPendingResponses` call to catch syncs that started during the yield.
- Adds an `isRequestInProgress` guard in `syncPersistedResponses` to prevent starting a sync while `processQueue` already has a request in flight.

## Test plan
- [ ] Enable offline support on a link survey
- [ ] Fill all questions while fully offline
- [ ] Switch to slow network (3G throttling) and click finish
- [ ] Verify only **one** POST create and sequential PUT updates in the Network tab
- [ ] Verify the response completes without "Response is already finished" errors
- [ ] Verify non-offline surveys are unaffected (all new guards are behind `persistOffline` checks)

Resolves ENG-684