### PR TITLE
fix: prevent environment ID leak in API error responses

### DIFF
--- a/apps/web/app/api/v1/client/[environmentId]/responses/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/responses/route.ts
@@ -123,14 +123,7 @@ export const POST = withV1ApiWrapper({
     }
     if (survey.environmentId !== environmentId) {
       return {
-        response: responses.badRequestResponse(
-          "Survey is part of another environment",
-          {
-            "survey.environmentId": survey.environmentId,
-            environmentId,
-          },
-          true
-        ),
+        response: responses.badRequestResponse("Survey does not belong to this environment", undefined, true),
       };
     }
 

--- a/apps/web/app/api/v1/client/[environmentId]/storage/route.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/storage/route.ts
@@ -75,11 +75,7 @@ export const POST = withV1ApiWrapper({
 
     if (survey.environmentId !== environmentId) {
       return {
-        response: responses.badRequestResponse(
-          "Survey does not belong to the environment",
-          { surveyId, environmentId },
-          true
-        ),
+        response: responses.badRequestResponse("Survey does not belong to this environment", undefined, true),
       };
     }
 

--- a/apps/web/app/api/v1/management/responses/route.ts
+++ b/apps/web/app/api/v1/management/responses/route.ts
@@ -96,14 +96,7 @@ const validateSurvey = async (responseInput: TResponseInput, environmentId: stri
   }
   if (survey.environmentId !== environmentId) {
     return {
-      error: responses.badRequestResponse(
-        "Survey is part of another environment",
-        {
-          "survey.environmentId": survey.environmentId,
-          environmentId,
-        },
-        true
-      ),
+      error: responses.badRequestResponse("Survey does not belong to this environment", undefined, true),
     };
   }
   return { survey };

--- a/apps/web/app/api/v2/client/[environmentId]/responses/lib/utils.test.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/lib/utils.test.ts
@@ -124,11 +124,8 @@ describe("checkSurveyValidity", () => {
     expect(result).toBeInstanceOf(Response);
     expect(result?.status).toBe(400);
     expect(responses.badRequestResponse).toHaveBeenCalledWith(
-      "Survey is part of another environment",
-      {
-        "survey.environmentId": "env-2",
-        environmentId: "env-1",
-      },
+      "Survey does not belong to this environment",
+      undefined,
       true
     );
   });

--- a/apps/web/app/api/v2/client/[environmentId]/responses/lib/utils.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/lib/utils.ts
@@ -17,14 +17,7 @@ export const checkSurveyValidity = async (
   responseInput: TResponseInputV2
 ): Promise<Response | null> => {
   if (survey.environmentId !== environmentId) {
-    return responses.badRequestResponse(
-      "Survey is part of another environment",
-      {
-        "survey.environmentId": survey.environmentId,
-        environmentId,
-      },
-      true
-    );
+    return responses.badRequestResponse("Survey does not belong to this environment", undefined, true);
   }
 
   if (survey.type === "link" && survey.singleUse?.enabled) {


### PR DESCRIPTION
## Summary
- Removed `survey.environmentId` from client-facing error responses when a survey-environment mismatch is detected
- Previously, probing with an arbitrary `environmentId` + valid `surveyId` would return the actual environment ID the survey belongs to
- Fixed in 4 API endpoints: v1 client responses, v2 client responses, v1 client storage, v1 management responses

<img width="750" height="227" alt="Screenshot 2026-04-16 at 5 07 03 PM" src="https://github.com/user-attachments/assets/dd067c3d-9acc-46ff-a2ff-e06ca86053c3" />


## Test plan
- [x] Existing test updated and passing (`utils.test.ts`)
- [ ] Manually verify that `POST /api/v1/client/{envId}/responses` with mismatched envId returns generic error without leaking real environment ID
- [ ] Verify same for `POST /api/v2/client/{envId}/responses`
- [ ] Verify same for `POST /api/v1/client/{envId}/storage`
