### PR TITLE
fix: show oversized upload error when mime type is missing

### DIFF
--- a/apps/web/modules/ui/components/file-input/lib/utils.test.ts
+++ b/apps/web/modules/ui/components/file-input/lib/utils.test.ts
@@ -67,6 +67,15 @@ describe("File Input Utils", () => {
       expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("File exceeds 5 MB size limit."));
     });
 
+    test("should show size error for oversized files even when mime type is empty", async () => {
+      const files = [new File(["x".repeat(101000)], "large.ico", { type: "" })];
+
+      const result = await getAllowedFiles(files, ["ico"], 0.1);
+
+      expect(result).toHaveLength(0);
+      expect(toast.error).toHaveBeenCalledWith(expect.stringContaining("File exceeds 0.1 MB size limit."));
+    });
+
     test("should convert HEIC files to JPEG", async () => {
       const heicFile = new File(["test"], "test.heic", { type: "image/heic" });
       const mockConvertedFile = new File(["converted"], "test.jpg", { type: "image/jpeg" });

--- a/apps/web/modules/ui/components/file-input/lib/utils.ts
+++ b/apps/web/modules/ui/components/file-input/lib/utils.ts
@@ -21,7 +21,7 @@ export const getAllowedFiles = async (
   const convertedFiles: File[] = [];
 
   for (const file of files) {
-    if (!file || !file.type) {
+    if (!file) {
       continue;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Fixes missing file-size validation feedback for uploads where the browser reports an empty MIME type (e.g. some `.ico` files).

The shared `getAllowedFiles` helper previously skipped files with no `file.type`, which prevented the `maxSizeInMB` check from running and suppressed the expected error toast. This PR keeps those files in validation flow so extension and size checks still apply.

Also adds a regression test to ensure oversized files with empty MIME types emit the size limit error.

Fixes #(issue)

## How should this be tested?

- Run: `pnpm --filter @formbricks/web exec vitest run modules/ui/components/file-input/lib/utils.test.ts`
- In Organization Settings → Domain, try uploading a favicon over 100KB (especially `.ico`) and verify an error toast appears.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc09937d-b533-4a8c-842a-ed53e980ae3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc09937d-b533-4a8c-842a-ed53e980ae3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

