### PR TITLE
fix: response tag UI issues in response modal

### DIFF
--- a/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardMetadata.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardMetadata.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from "react-i18next";
 import { getLanguageLabel } from "@formbricks/i18n-utils/src/utils";
 import { TResponse } from "@formbricks/types/responses";
 import { TUserLocale } from "@formbricks/types/user";
-import { Button } from "@/modules/ui/components/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/modules/ui/components/tooltip";
 
 interface InfoIconButtonProps {
@@ -26,9 +25,11 @@ const InfoIconButton = ({
     <TooltipProvider delayDuration={0}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button variant="outline" size="icon" aria-label={ariaLabel}>
+          <button
+            className="flex h-4 w-4 items-center justify-center rounded text-slate-500 hover:text-slate-700"
+            aria-label={ariaLabel}>
             <Icon className="h-4 w-4" />
-          </Button>
+          </button>
         </TooltipTrigger>
         <TooltipContent avoidCollisions align="start" side="bottom" className={maxWidth}>
           {tooltipContent}

--- a/apps/web/modules/ui/components/tags-combobox/index.tsx
+++ b/apps/web/modules/ui/components/tags-combobox/index.tsx
@@ -79,14 +79,14 @@ export const TagsCombobox = ({
 
             return 0;
           }}>
-          <div className="p-1">
+          <div className="px-1 pt-1">
             <CommandInput
               placeholder={
                 tagsToSearch?.length === 0
                   ? t("environments.workspace.tags.add_tag")
                   : t("environments.workspace.tags.search_tags")
               }
-              className="border-b border-none border-transparent shadow-none outline-0 ring-offset-transparent focus:border-none focus:border-transparent focus:shadow-none focus:outline-0 focus:ring-offset-transparent"
+              className="h-8 border-b border-none border-transparent py-1 shadow-none outline-0 ring-offset-transparent focus:border-none focus:border-transparent focus:shadow-none focus:outline-0 focus:ring-offset-transparent"
               value={searchValue}
               onValueChange={(search) => setSearchValue(search)}
               onKeyDown={(e) => {
@@ -103,7 +103,7 @@ export const TagsCombobox = ({
             />
           </div>
           <CommandList className="border-0">
-            <CommandGroup>
+            <CommandGroup className="p-0">
               {tagsToSearch?.map((tag) => {
                 return (
                   <CommandItem


### PR DESCRIPTION
## Summary
- Fix metadata icon button in response tags area: replaced the oversized `Button` component (`h-9 w-9` / 36x36px with outline border) with a compact `h-4 w-4` (16x16) element, eliminating the rectangular hover background
- Fix TagsCombobox popover spacing: removed extra bottom padding from `CommandGroup` (`p-1` → `p-0`), changed input wrapper from `p-1` to `px-1 pt-1`, and reduced `CommandInput` height from `h-9` to `h-8` with tighter vertical padding

Resolves ENG-303

## Test plan
- [ ] Open a survey response modal with contact attributes/device info metadata
- [ ] Hover over the metadata icon buttons — verify the hover area is a compact square, not a tall rectangle
- [ ] Click "Add Tag" to open the tags combobox popover
- [ ] Verify no extra whitespace at the bottom of the popover
- [ ] Verify the search input text is properly aligned with minimal spacing
- [ ] Verify tags can still be searched, added, and created through the combobox