### PR TITLE
fix: use document instead of querySelector for exit intent listener to prevent null error

### DIFF
--- a/packages/js-core/src/lib/survey/no-code-action.ts
+++ b/packages/js-core/src/lib/survey/no-code-action.ts
@@ -275,9 +275,7 @@ const checkExitIntentWrapper = (e: MouseEvent): void => {
 
 export const addExitIntentListener = (): void => {
   if (typeof document !== "undefined" && !isExitIntentListenerAdded) {
-    document
-      .querySelector("body")
-      ?.addEventListener("mouseleave", checkExitIntentWrapper as unknown as EventListener);
+    document.addEventListener("mouseleave", checkExitIntentWrapper as unknown as EventListener);
     isExitIntentListenerAdded = true;
   }
 };


### PR DESCRIPTION
## Summary

- Fixes #6659
- `addExitIntentListener` used `document.querySelector("body")?.addEventListener(...)` which throws `TypeError: Cannot read properties of null (reading 'addEventListener')` when `<body>` is not yet in the DOM (e.g., in userscript contexts)
- `removeExitIntentListener` was using `document.removeEventListener(...)` — a mismatched target, so the listener was never actually removed

## Changes

Changed `addExitIntentListener` to attach the `mouseleave` listener directly to `document` instead of `document.querySelector("body")?.`. This:
1. Eliminates the null reference error when `<body>` is absent
2. Keeps add/remove targets consistent (`document` in both functions)
3. `mouseleave` on `document` fires under the same conditions as on `<body>`

## Diff

```diff
-    document
-      .querySelector("body")
-      ?.addEventListener("mouseleave", checkExitIntentWrapper as unknown as EventListener);
+    document.addEventListener("mouseleave", checkExitIntentWrapper as unknown as EventListener);
```