### PR TITLE
fix: add accessible dialog title to project limit modal

### DIFF
--- a/apps/web/modules/projects/components/project-limit-modal/index.tsx
+++ b/apps/web/modules/projects/components/project-limit-modal/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslation } from "react-i18next";
-import { Dialog, DialogContent } from "@/modules/ui/components/dialog";
+import { Dialog, DialogContent, DialogTitle } from "@/modules/ui/components/dialog";
 import { ModalButton, UpgradePrompt } from "@/modules/ui/components/upgrade-prompt";
 
 interface ProjectLimitModalProps {
@@ -17,6 +17,9 @@ export const ProjectLimitModal = ({ open, setOpen, projectLimit, buttons }: Proj
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent>
+        <DialogTitle className="sr-only">
+          {t("common.unlock_more_workspaces_with_a_higher_plan")}
+        </DialogTitle>
         <UpgradePrompt
           title={t("common.unlock_more_workspaces_with_a_higher_plan")}
           description={t("common.you_have_reached_your_limit_of_workspace_limit", { projectLimit })}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds a required `DialogTitle` to `ProjectLimitModal` so `DialogContent` satisfies Radix Dialog accessibility requirements for screen readers while keeping the UI unchanged via `sr-only` styling.

Fixes #(issue)

## How should this be tested?

- Open the project limit modal from the environment navigation flow.
- Confirm the modal renders normally and the previous console warning about missing `DialogTitle` no longer appears.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eacd0107-8b70-43b7-b7f6-dfa6d4756c9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eacd0107-8b70-43b7-b7f6-dfa6d4756c9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

