### PR TITLE
feat: auto-fill safe attribute key from label

### DIFF
--- a/apps/web/lib/utils/safe-identifier.test.ts
+++ b/apps/web/lib/utils/safe-identifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { isSafeIdentifier } from "./safe-identifier";
+import { isSafeIdentifier, toSafeIdentifier } from "./safe-identifier";
 
 describe("safe-identifier", () => {
   describe("isSafeIdentifier", () => {
@@ -30,6 +30,25 @@ describe("safe-identifier", () => {
 
     test("returns false for empty string", () => {
       expect(isSafeIdentifier("")).toBe(false);
+    });
+  });
+
+  describe("toSafeIdentifier", () => {
+    test("normalizes free-form labels into safe identifiers", () => {
+      expect(toSafeIdentifier("Date of Birth")).toBe("date_of_birth");
+      expect(toSafeIdentifier("Customer-ID")).toBe("customer_id");
+      expect(toSafeIdentifier("  Preferred Language  ")).toBe("preferred_language");
+      expect(toSafeIdentifier("city__name")).toBe("city_name");
+    });
+
+    test("strips invalid leading characters until first lowercase letter", () => {
+      expect(toSafeIdentifier("123 Date")).toBe("date");
+      expect(toSafeIdentifier("__name")).toBe("name");
+      expect(toSafeIdentifier("99")).toBe("");
+    });
+
+    test("keeps already safe identifiers unchanged", () => {
+      expect(toSafeIdentifier("country_code")).toBe("country_code");
     });
   });
 });

--- a/apps/web/lib/utils/safe-identifier.ts
+++ b/apps/web/lib/utils/safe-identifier.ts
@@ -23,7 +23,8 @@ export const toSafeIdentifier = (value: string): string => {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/_+/g, "_")
-    .replace(/^_+|_+$/g, "");
+    .replace(/^_+/, "")
+    .replace(/_+$/, "");
 
   return normalized.replace(/^[^a-z]+/, "");
 };

--- a/apps/web/lib/utils/safe-identifier.ts
+++ b/apps/web/lib/utils/safe-identifier.ts
@@ -13,6 +13,22 @@ export const isSafeIdentifier = (value: string): boolean => {
 };
 
 /**
+ * Converts a free-form string to a safe identifier candidate.
+ * The output only contains lowercase letters, numbers, and underscores.
+ * It also ensures the identifier starts with a lowercase letter by stripping invalid leading chars.
+ */
+export const toSafeIdentifier = (value: string): string => {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+  return normalized.replace(/^[^a-z]+/, "");
+};
+
+/**
  * Converts a snake_case string to Title Case for display as a label.
  * Example: "job_description" -> "Job Description"
  *          "api_key" -> "Api Key"

--- a/apps/web/lib/utils/safe-identifier.ts
+++ b/apps/web/lib/utils/safe-identifier.ts
@@ -18,15 +18,36 @@ export const isSafeIdentifier = (value: string): boolean => {
  * It also ensures the identifier starts with a lowercase letter by stripping invalid leading chars.
  */
 export const toSafeIdentifier = (value: string): string => {
-  const normalized = value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "_")
-    .replace(/_+/g, "_")
-    .replace(/^_+/, "")
-    .replace(/_+$/, "");
+  const normalized = value.trim().toLowerCase();
+  let safeIdentifier = "";
+  let shouldInsertUnderscore = false;
 
-  return normalized.replace(/^[^a-z]+/, "");
+  for (const char of normalized) {
+    const isLowercaseLetter = char >= "a" && char <= "z";
+    const isDigit = char >= "0" && char <= "9";
+
+    if (isLowercaseLetter || isDigit) {
+      if (shouldInsertUnderscore && safeIdentifier.length > 0) {
+        safeIdentifier += "_";
+      }
+      safeIdentifier += char;
+      shouldInsertUnderscore = false;
+      continue;
+    }
+
+    if (safeIdentifier.length > 0) {
+      shouldInsertUnderscore = true;
+    }
+  }
+
+  for (let i = 0; i < safeIdentifier.length; i++) {
+    const char = safeIdentifier[i];
+    if (char >= "a" && char <= "z") {
+      return safeIdentifier.slice(i);
+    }
+  }
+
+  return "";
 };
 
 /**

--- a/apps/web/modules/ee/contacts/attributes/components/create-attribute-modal.tsx
+++ b/apps/web/modules/ee/contacts/attributes/components/create-attribute-modal.tsx
@@ -7,7 +7,7 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { TContactAttributeDataType } from "@formbricks/types/contact-attribute-key";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
-import { formatSnakeCaseToTitleCase, isSafeIdentifier } from "@/lib/utils/safe-identifier";
+import { formatSnakeCaseToTitleCase, isSafeIdentifier, toSafeIdentifier } from "@/lib/utils/safe-identifier";
 import { Button } from "@/modules/ui/components/button";
 import {
   Dialog,
@@ -57,25 +57,27 @@ export function CreateAttributeModal({ environmentId }: Readonly<CreateAttribute
   };
 
   const handleNameChange = (value: string) => {
-    setFormData((prev) => ({ ...prev, name: value }));
-    if (keyError && formData.key) {
-      validateKey(formData.key);
+    const previousAutoKey = toSafeIdentifier(formData.name);
+    const newAutoKey = toSafeIdentifier(value);
+    const shouldAutoUpdateKey = !formData.key || formData.key === previousAutoKey;
+
+    setFormData((prev) => ({
+      ...prev,
+      name: value,
+      key: shouldAutoUpdateKey ? newAutoKey : prev.key,
+    }));
+
+    if (shouldAutoUpdateKey && keyError) {
+      if (newAutoKey) {
+        validateKey(newAutoKey);
+      } else {
+        setKeyError("");
+      }
     }
   };
 
   const handleKeyChange = (value: string) => {
-    const previousAutoLabel = formData.key ? formatSnakeCaseToTitleCase(formData.key) : "";
-    const newAutoLabel = value ? formatSnakeCaseToTitleCase(value) : "";
-
-    setFormData((prev) => {
-      // Auto-update name if it's empty or matches the previous auto-generated label
-      const shouldAutoUpdateName = !prev.name || prev.name === previousAutoLabel;
-      return {
-        ...prev,
-        key: value,
-        name: shouldAutoUpdateName ? newAutoLabel : prev.name,
-      };
-    });
+    setFormData((prev) => ({ ...prev, key: value }));
     validateKey(value);
   };
 
@@ -165,6 +167,17 @@ export function CreateAttributeModal({ environmentId }: Readonly<CreateAttribute
               <div className="flex flex-col gap-4">
                 <div className="flex flex-col gap-2">
                   <label className="text-sm font-medium text-slate-900">
+                    {t("environments.contacts.attribute_label")}
+                  </label>
+                  <Input
+                    value={formData.name}
+                    onChange={(e) => handleNameChange(e.target.value)}
+                    placeholder={t("environments.contacts.attribute_label_placeholder")}
+                  />
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <label className="text-sm font-medium text-slate-900">
                     {t("environments.contacts.attribute_key")}
                   </label>
                   <Input
@@ -175,17 +188,6 @@ export function CreateAttributeModal({ environmentId }: Readonly<CreateAttribute
                   />
                   {keyError && <p className="text-sm text-red-500">{keyError}</p>}
                   <p className="text-xs text-slate-500">{t("environments.contacts.attribute_key_hint")}</p>
-                </div>
-
-                <div className="flex flex-col gap-2">
-                  <label className="text-sm font-medium text-slate-900">
-                    {t("environments.contacts.attribute_label")}
-                  </label>
-                  <Input
-                    value={formData.name}
-                    onChange={(e) => handleNameChange(e.target.value)}
-                    placeholder={t("environments.contacts.attribute_label_placeholder")}
-                  />
                 </div>
 
                 <div className="flex flex-col gap-2">


### PR DESCRIPTION
<img width="553" height="294" alt="Screenshot 2026-04-19 at 13 39 25" src="https://github.com/user-attachments/assets/3604e83b-346c-4642-b2e9-5e00da8b8ee1" />


## What does this PR do?

Reworks the "Create attribute keys" modal to follow the requested flow:

- Moves **Label** above **Key** in the form.
- Auto-fills the key from label input using safe identifier rules.
- Keeps manual key editing possible (autofill only continues while key is empty or still auto-generated).

Implementation details:

- Added `toSafeIdentifier()` in `apps/web/lib/utils/safe-identifier.ts` to normalize text into a valid key candidate:
  - lowercase only
  - replace non-alphanumeric runs with `_`
  - collapse duplicate separators to a single `_`
  - avoid leading/trailing separators in output
  - remove leading non-letter characters so key starts with a lowercase letter
- Updated `CreateAttributeModal` to generate key from label changes and swapped field order.
- Added tests for `toSafeIdentifier()` in `apps/web/lib/utils/safe-identifier.test.ts`.
- Follow-up: rewrote normalization to a deterministic character loop (no normalization regexes) to address SonarCloud regex hotspot findings.

Fixes #(issue)

## How should this be tested?

- Open Contacts → Attributes → **Create attribute**.
- Verify **Label** field appears before **Key**.
- Enter label `Date of Birth` and confirm key autofills to `date_of_birth`.
- Enter label with symbols/numbers like `123 Favorite-Color!` and confirm key autofills to `favorite_color`.
- Manually edit key and confirm subsequent label typing does not overwrite custom key.
- Confirm key validation still blocks invalid identifiers and allows valid safe identifiers.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5317ee36-9447-4962-bed7-fedb006f083e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5317ee36-9447-4962-bed7-fedb006f083e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

