### PR TITLE
fix: fixes sentry ref issue

### DIFF
--- a/packages/survey-ui/src/components/general/dropdown-menu.tsx
+++ b/packages/survey-ui/src/components/general/dropdown-menu.tsx
@@ -20,12 +20,14 @@ function DropdownMenuTrigger({ ...props }: React.ComponentProps<typeof DropdownM
 function DropdownMenuContent({
   className,
   sideOffset = 4,
+  ref,
   ...props
 }: Readonly<React.ComponentProps<typeof DropdownMenuPrimitive.Content>>) {
   return (
     <DropdownMenuPrimitive.Portal>
       <div id="fbjs">
         <DropdownMenuPrimitive.Content
+          ref={ref}
           data-slot="dropdown-menu-content"
           sideOffset={sideOffset}
           className={cn(

--- a/packages/survey-ui/src/components/general/dropdown-search.tsx
+++ b/packages/survey-ui/src/components/general/dropdown-search.tsx
@@ -58,7 +58,9 @@ export function useDropdownSearch<T extends { id: string; label: string }>({
 
   const focusSearchAndLockSide = (): void => {
     searchInputRef.current?.focus();
-    const side = contentRef.current?.dataset.side;
+    const dataset = contentRef.current?.dataset;
+    if (!dataset) return;
+    const side = dataset.side;
     if (side === "top" || side === "bottom") setLockedSide(side);
   };
 


### PR DESCRIPTION
## What does this PR do?

  Fixes a `TypeError: Cannot read properties of undefined (reading 'side')` that was firing ~751 times in production (Sentry issue `111670203`, escalating since 2026-04-13) on the public survey page (`/s/...`)
  whenever users opened a searchable single-select or multi-select dropdown (options > 3).

  **Root cause:** `DropdownMenuContent` in `packages/survey-ui/src/components/general/dropdown-menu.tsx` is a plain function component that never forwarded `ref` through to the underlying
  `DropdownMenuPrimitive.Content`. Consumers in `single-select.tsx` and `multi-select.tsx` pass `contentRef` to it so that `useDropdownSearch#focusSearchAndLockSide` can read `dataset.side` and lock the dropdown
  side during search filtering. Because the ref was never attached to the actual Radix DOM node, `contentRef.current?.dataset` resolved to `undefined`, and accessing `.side` on it threw.

  **Fix:**
  - `dropdown-menu.tsx` — explicitly destructure `ref` from props and pass it through to `DropdownMenuPrimitive.Content` (React 19 ref-as-prop).
  - `dropdown-search.tsx` — add a defensive `!dataset` early-return in `focusSearchAndLockSide` to harden against any future race with Radix's positioning pass.

  Fixes FORMBRICKS-Y6 (Sentry 111670203)

  ## How should this be tested?

  - Open a survey that contains a single-select or multi-select question with `variant="dropdown"` and **more than 3 options** (the `SEARCH_THRESHOLD`, which enables the in-dropdown search input).
  - Open the dropdown — the search input should receive focus automatically, and the dropdown should lock to its opened side (`top` or `bottom`) so it doesn't jump around as the search filters the list.
  - Type a query, confirm filtering works and the dropdown does not re-flip sides mid-search.
  - Verify no `TypeError` appears in the browser console.
  - Repeat on mobile Chrome (where the original error was also reported).
  - `pnpm --filter @formbricks/survey-ui test` — all 60 tests should pass.

  ## Checklist

  ### Required

  - [x] Filled out the "How to test" section in this PR
  - [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
  - [x] Self-reviewed my own code
  - [x] Commented on my code in hard-to-understand bits
  - [x] Ran `pnpm build`
  - [x] Checked for warnings, there are none
  - [x] Removed all `console.logs`
  - [x] Merged the latest changes from main onto my branch with `git pull origin main`
  - [x] My changes don't cause any responsiveness issues
  - [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

  ### Appreciated

  - [ ] If a UI change was made: Added a screen recording or screenshots to this PR
  - [ ] Updated the Formbricks Docs if changes were necessary
