### PR TITLE
fix(js-core): preserve concurrent attribute and userId updates during UpdateQueue flush

### DIFF
--- a/packages/js-core/src/lib/user/tests/update-queue-concurrency.test.ts
+++ b/packages/js-core/src/lib/user/tests/update-queue-concurrency.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { Config } from "@/lib/common/config";
+import { sendUpdates } from "@/lib/user/update";
+import { UpdateQueue } from "@/lib/user/update-queue";
+
+// Mock dependencies
+vi.mock("@/lib/common/config", () => ({
+  Config: {
+    getInstance: vi.fn(() => ({
+      get: vi.fn(() => ({
+        user: {
+          data: {
+            userId: "mock-user-id",
+          },
+        },
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/user/update", () => ({
+  sendUpdates: vi.fn(),
+}));
+
+describe("UpdateQueue Concurrency (Bug Reproduction)", () => {
+  let updateQueue: UpdateQueue;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset singleton instance
+    (UpdateQueue as unknown as { instance: null }).instance = null;
+    updateQueue = UpdateQueue.getInstance();
+  });
+
+  test("deterministic data loss: attributes added during sendUpdates are wiped", async () => {
+    let resolveSend: (value: any) => void;
+    const sendPromise = new Promise((resolve) => {
+      resolveSend = resolve;
+    });
+
+    // 1. Mock sendUpdates to hang until we manually resolve it
+    (sendUpdates as any).mockReturnValue(sendPromise);
+
+    // 2. Initial attribute sets triggering a flush
+    updateQueue.updateAttributes({ foo: "bar" });
+    const flushPromise = updateQueue.processUpdates();
+
+    // 3. Advance past debounce (500ms) so sendUpdates is called
+    // Since we aren't using fake timers here for simplicity in async flow,
+    // we just wait a bit longer than the debounce.
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(sendUpdates).toHaveBeenCalledTimes(1);
+    expect(sendUpdates).toHaveBeenCalledWith({
+      updates: {
+        userId: "mock-user-id",
+        attributes: { foo: "bar" },
+      },
+    });
+
+    // Confirm state before concurrent updates arrive
+    expect(updateQueue.getUpdates()?.attributes).toEqual({ foo: "bar" });
+
+    // 4. WHILE the request is "in flight", add new attributes
+    updateQueue.updateAttributes({ biz: "baz" });
+
+    // Also change an existing attribute to test the "value changed" scenario
+    updateQueue.updateAttributes({ foo: "new-bar" });
+
+    // 5. Resolve the network request
+    resolveSend!({
+      ok: true,
+      data: { hasWarnings: false },
+    });
+
+    // 6. Wait for the flush to complete
+    await flushPromise;
+
+    // 7. ASSERTION: The queue should NOT be empty.
+    // It should contain the updates that arrived during the flight.
+    const remainingUpdates = updateQueue.getUpdates();
+
+    expect(remainingUpdates).not.toBeNull();
+    expect(remainingUpdates?.attributes).toEqual({
+      biz: "baz",
+      foo: "new-bar",
+    });
+  });
+});

--- a/packages/js-core/src/lib/user/tests/update-queue-concurrency.test.ts
+++ b/packages/js-core/src/lib/user/tests/update-queue-concurrency.test.ts
@@ -14,6 +14,7 @@ vi.mock("@/lib/common/config", () => ({
           },
         },
       })),
+      update: vi.fn(), // required for language-handling code path in processUpdates
     })),
   },
 }));
@@ -76,15 +77,10 @@ describe("UpdateQueue Concurrency (Bug Reproduction)", () => {
     // 6. Wait for the flush to complete
     await flushPromise;
 
-    // 7. ASSERTION: The queue should NOT be empty.
-    // It should contain the updates that arrived during the flight.
-    const remainingUpdates = updateQueue.getUpdates();
-
-    expect(remainingUpdates).not.toBeNull();
-    expect(remainingUpdates?.attributes).toEqual({
-      biz: "baz",
-      foo: "new-bar",
-    });
+    // 7. ASSERTION: flushPromise now resolves only after all chained flushes complete.
+    // The follow-up flush will have sent the concurrent updates and drained the queue.
+    expect(sendUpdates).toHaveBeenCalledTimes(2);
+    expect(updateQueue.getUpdates()).toBeNull();
   });
 
   test("preserves userId update during in-flight flush without attributes", async () => {
@@ -109,8 +105,13 @@ describe("UpdateQueue Concurrency (Bug Reproduction)", () => {
     resolveRequest!({ ok: true, data: { hasWarnings: false } });
     await flushPromise;
 
-    // 5. ASSERTION: "B" must not be lost to cleanup
-    // If this.updates were wiped unconditionally, userId "B" would be permanently lost.
-    expect(updateQueue.getUpdates()?.userId).toBe("B");
+    // 5. ASSERTION: flushPromise resolves only after the follow-up flush sends userId=B.
+    // Verify two sends happened: first with A, second with B.
+    expect(sendUpdates).toHaveBeenCalledTimes(2);
+    expect(sendUpdates).toHaveBeenLastCalledWith({
+      updates: { userId: "B", attributes: {} },
+    });
+    // Queue must be fully drained — nothing silently dropped, nothing silently stuck.
+    expect(updateQueue.getUpdates()).toBeNull();
   });
 });

--- a/packages/js-core/src/lib/user/tests/update-queue-concurrency.test.ts
+++ b/packages/js-core/src/lib/user/tests/update-queue-concurrency.test.ts
@@ -86,4 +86,31 @@ describe("UpdateQueue Concurrency (Bug Reproduction)", () => {
       foo: "new-bar",
     });
   });
+
+  test("preserves userId update during in-flight flush without attributes", async () => {
+    let resolveRequest: (value: any) => void;
+    const sendPromise = new Promise((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    (sendUpdates as any).mockReturnValue(sendPromise);
+
+    // 1. Start flush with userId = "A"
+    updateQueue.updateUserId("A");
+    const flushPromise = updateQueue.processUpdates();
+
+    // 2. Advance past debounce so sendUpdates is called
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    // 3. Change userId to "B" during in-flight request — no new attributes
+    updateQueue.updateUserId("B");
+
+    // 4. Resolve the network request
+    resolveRequest!({ ok: true, data: { hasWarnings: false } });
+    await flushPromise;
+
+    // 5. ASSERTION: "B" must not be lost to cleanup
+    // If this.updates were wiped unconditionally, userId "B" would be permanently lost.
+    expect(updateQueue.getUpdates()?.userId).toBe("B");
+  });
 });

--- a/packages/js-core/src/lib/user/update-queue.ts
+++ b/packages/js-core/src/lib/user/update-queue.ts
@@ -109,6 +109,9 @@ export class UpdateQueue {
         this.debounceTimeout = null;
         try {
           let currentUpdates = { ...this.updates };
+          // Capture original attributes BEFORE any in-handler mutation (e.g., language stripping)
+          // This ensures the cleanup diff correctly represents what was sent vs what arrived concurrently
+          const originalAttributes = { ...(this.updates?.attributes ?? {}) };
           const config = Config.getInstance();
 
           if (Object.keys(currentUpdates).length > 0) {
@@ -180,7 +183,9 @@ export class UpdateQueue {
 
           if (this.updates) {
             const sentUserId = currentUpdates.userId;
-            const sentAttributes = currentUpdates.attributes ?? {};
+            // Use originalAttributes (pre-mutation) so locally-handled attributes
+            // (e.g., language applied to config) are correctly treated as "sent"
+            const sentAttributes = originalAttributes;
 
             const remainingAttributes: TAttributes = {};
             for (const [key, value] of Object.entries(this.updates.attributes ?? {})) {
@@ -203,11 +208,14 @@ export class UpdateQueue {
           }
 
           this.pendingFlush = null;
-          resolve();
 
+          // Await follow-up flush BEFORE resolving so that callers of await processUpdates()
+          // and waitForPendingWork() see a fully drained queue, not an intermediate state
           if (this.updates) {
-            void this.processUpdates();
+            await this.processUpdates();
           }
+
+          resolve();
         } catch (error: unknown) {
           this.pendingFlush = null;
           logger.error(

--- a/packages/js-core/src/lib/user/update-queue.ts
+++ b/packages/js-core/src/lib/user/update-queue.ts
@@ -179,22 +179,26 @@ export class UpdateQueue {
           }
 
           if (this.updates) {
+            const sentUserId = currentUpdates.userId;
             const sentAttributes = currentUpdates.attributes ?? {};
-            const remainingAttributes: TAttributes = {};
 
+            const remainingAttributes: TAttributes = {};
             for (const [key, value] of Object.entries(this.updates.attributes ?? {})) {
               if (!(key in sentAttributes) || sentAttributes[key] !== value) {
                 remainingAttributes[key] = value as string | number | boolean;
               }
             }
 
-            if (Object.keys(remainingAttributes).length > 0) {
+            // Preserve updates if attributes changed OR if userId changed during the flush
+            const userIdChanged = this.updates.userId != null && this.updates.userId !== sentUserId;
+
+            if (Object.keys(remainingAttributes).length > 0 || userIdChanged) {
               this.updates = {
-                ...this.updates,
+                userId: this.updates.userId,
                 attributes: remainingAttributes,
               };
             } else {
-              this.updates = null;
+              this.clearUpdates();
             }
           }
 

--- a/packages/js-core/src/lib/user/update-queue.ts
+++ b/packages/js-core/src/lib/user/update-queue.ts
@@ -101,10 +101,12 @@ export class UpdateQueue {
 
     if (this.debounceTimeout) {
       clearTimeout(this.debounceTimeout);
+      this.debounceTimeout = null;
     }
 
     const flushPromise = new Promise<void>((resolve, reject) => {
       const handler = async (): Promise<void> => {
+        this.debounceTimeout = null;
         try {
           let currentUpdates = { ...this.updates };
           const config = Config.getInstance();
@@ -176,9 +178,32 @@ export class UpdateQueue {
             }
           }
 
-          this.clearUpdates();
+          if (this.updates) {
+            const sentAttributes = currentUpdates.attributes ?? {};
+            const remainingAttributes: TAttributes = {};
+
+            for (const [key, value] of Object.entries(this.updates.attributes ?? {})) {
+              if (!(key in sentAttributes) || sentAttributes[key] !== value) {
+                remainingAttributes[key] = value as string | number | boolean;
+              }
+            }
+
+            if (Object.keys(remainingAttributes).length > 0) {
+              this.updates = {
+                ...this.updates,
+                attributes: remainingAttributes,
+              };
+            } else {
+              this.updates = null;
+            }
+          }
+
           this.pendingFlush = null;
           resolve();
+
+          if (this.updates) {
+            void this.processUpdates();
+          }
         } catch (error: unknown) {
           this.pendingFlush = null;
           logger.error(


### PR DESCRIPTION
## Problem
`UpdateQueue.processUpdates()` had a race condition around the async
`sendUpdates()` call: 


1. **Attribute data loss**
   Attributes added while a request was in-flight were wiped by the
   unconditional `clearUpdates()` call after the request resolved.

2. **userId loss**
   If `setUserId()` was called during an in-flight flush *without*
   accompanying attributes, the new userId was also lost for the same reason.

## Root Cause
The queue used a "snapshot → await → clear" pattern:
- Snapshot taken before `await sendUpdates(...)`
- Internal state (`this.updates`) could mutate during the await
- `clearUpdates()` removed both sent data *and* newly added data

## Fix
- Keep existing control flow intact (debounce + pendingFlush)
- After the async boundary, diff **live state vs snapshot**
- Preserve:
  - Attributes that were added or changed during the request
  - `userId` if it changed during the request
- Only clear the queue when no new data remains
- Trigger a follow-up `processUpdates()` if updates are still pending

## Tests
Added deterministic concurrency tests:
- Preserves attributes added during an in-flight flush
- Preserves `userId` changes during an in-flight flush (no attributes case)

## Notes
- No changes to debounce, logging, or config behavior
- No retry logic added (existing semantics preserved)

Closes #7770