### PR TITLE
fix: patch protobufjs transitive vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,12 @@
       "@tootallnate/once": "3.0.1",
       "schema-utils@3.3.0>ajv": "6.14.0",
       "axios": "1.13.5",
+      "@grpc/proto-loader@0.7.15>protobufjs": "7.5.5",
+      "@grpc/proto-loader@0.8.0>protobufjs": "7.5.5",
+      "@opentelemetry/otlp-transformer@0.57.1>protobufjs": "7.5.5",
+      "@opentelemetry/otlp-transformer@0.208.0>protobufjs": "7.5.5",
+      "@opentelemetry/otlp-transformer@0.212.0>protobufjs": "8.0.1",
+      "@opentelemetry/otlp-transformer@0.213.0>protobufjs": "7.5.5",
       "effect": "3.20.0",
       "flatted": "3.4.2",
       "hono": "4.12.7",
@@ -102,7 +108,7 @@
       "diff": ">=8.0.3"
     },
     "comments": {
-      "overrides": "Security fixes for transitive dependencies. Remove when upstream packages update: @hono/node-server/hono (Dependabot #313/#316/#317) - awaiting Prisma update | @tootallnate/once (Dependabot #305) - awaiting sqlite3/node-gyp chain update | schema-utils@3>ajv (Dependabot #287) - awaiting eslint/file-loader schema-utils update | axios (CVE-2025-58754, CVE-2026-25639) - awaiting @boxyhq/saml-jackson update | effect (Dependabot #339) - awaiting Prisma update | flatted (Dependabot #324/#338) - awaiting eslint/flat-cache update | minimatch (Dependabot #288/#294/#297) - awaiting react-email/glob update | node-forge (Dependabot #230) - awaiting @boxyhq/saml-jackson update | qs (Dependabot #277) - awaiting googleapis/googleapis-common update | rollup (Dependabot #291) - awaiting Vite patch adoption | socket.io-parser (Dependabot #334) - awaiting react-email/socket.io update | tar (CVE-2026-23745/23950/24842/26960) - awaiting @boxyhq/saml-jackson/sqlite3 dependency updates | typeorm (Dependabot #223) - awaiting @boxyhq/saml-jackson update | undici (Dependabot #319/#322/#323) - awaiting jsdom/vitest/isomorphic-dompurify updates | fast-xml-parser (CVE-2026-25896/26278/33036/33349) - awaiting exact upstream pin updates | diff (Dependabot #269) - awaiting upstream patch range adoption"
+      "overrides": "Security fixes for transitive dependencies. Remove when upstream packages update: @hono/node-server/hono (Dependabot #313/#316/#317) - awaiting Prisma update | @tootallnate/once (Dependabot #305) - awaiting sqlite3/node-gyp chain update | schema-utils@3>ajv (Dependabot #287) - awaiting eslint/file-loader schema-utils update | axios (CVE-2025-58754, CVE-2026-25639) - awaiting @boxyhq/saml-jackson update | protobufjs (ENG-716 / CVE-2026-41242) - awaiting @boxyhq/saml-jackson and OpenTelemetry transitive updates | effect (Dependabot #339) - awaiting Prisma update | flatted (Dependabot #324/#338) - awaiting eslint/flat-cache update | minimatch (Dependabot #288/#294/#297) - awaiting react-email/glob update | node-forge (Dependabot #230) - awaiting @boxyhq/saml-jackson update | qs (Dependabot #277) - awaiting googleapis/googleapis-common update | rollup (Dependabot #291) - awaiting Vite patch adoption | socket.io-parser (Dependabot #334) - awaiting react-email/socket.io update | tar (CVE-2026-23745/23950/24842/26960) - awaiting @boxyhq/saml-jackson/sqlite3 dependency updates | typeorm (Dependabot #223) - awaiting @boxyhq/saml-jackson update | undici (Dependabot #319/#322/#323) - awaiting jsdom/vitest/isomorphic-dompurify updates | fast-xml-parser (CVE-2026-25896/26278/33036/33349) - awaiting exact upstream pin updates | diff (Dependabot #269) - awaiting upstream patch range adoption"
     },
     "patchedDependencies": {
       "next-auth@4.24.13": "patches/next-auth@4.24.13.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,12 @@ overrides:
   '@tootallnate/once': 3.0.1
   schema-utils@3.3.0>ajv: 6.14.0
   axios: 1.13.5
+  '@grpc/proto-loader@0.7.15>protobufjs': 7.5.5
+  '@grpc/proto-loader@0.8.0>protobufjs': 7.5.5
+  '@opentelemetry/otlp-transformer@0.57.1>protobufjs': 7.5.5
+  '@opentelemetry/otlp-transformer@0.208.0>protobufjs': 7.5.5
+  '@opentelemetry/otlp-transformer@0.212.0>protobufjs': 8.0.1
+  '@opentelemetry/otlp-transformer@0.213.0>protobufjs': 7.5.5
   effect: 3.20.0
   flatted: 3.4.2
   hono: 4.12.7
@@ -9962,12 +9968,12 @@ packages:
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
-  protobufjs@8.0.0:
-    resolution: {integrity: sha512-jx6+sE9h/UryaCZhsJWbJtTEy47yXoGNYI4z8ZaRncM0zBKeRqjO2JEcOUYwrYGb1WLhXM1FfMzW3annvFv0rw==}
+  protobufjs@8.0.1:
+    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
     engines: {node: '>=12.0.0'}
 
   proxy-from-env@1.1.0:
@@ -13946,14 +13952,14 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   '@grpc/proto-loader@0.8.0':
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
       yargs: 17.7.2
 
   '@hono/node-server@1.19.10(hono@4.12.7)':
@@ -15395,7 +15401,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   '@opentelemetry/otlp-transformer@0.212.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15406,7 +15412,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.212.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.5.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.5.1(@opentelemetry/api@1.9.0)
-      protobufjs: 8.0.0
+      protobufjs: 8.0.1
 
   '@opentelemetry/otlp-transformer@0.213.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15417,7 +15423,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.213.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.6.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   '@opentelemetry/otlp-transformer@0.57.1(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -15428,7 +15434,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.57.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 1.30.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 1.30.1(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   '@opentelemetry/propagator-b3@2.6.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -22619,7 +22625,7 @@ snapshots:
       signal-exit: 3.0.7
     optional: true
 
-  protobufjs@7.5.4:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -22634,7 +22640,7 @@ snapshots:
       '@types/node': 25.4.0
       long: 5.3.2
 
-  protobufjs@8.0.0:
+  protobufjs@8.0.1:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2


### PR DESCRIPTION
## Summary

This PR remediates the `protobufjs` security alert tracked in `ENG-716` by pinning the vulnerable transitive dependency paths via root `pnpm.overrides` and refreshing the lockfile.

## What Changed

- pin `@grpc/proto-loader` transitive `protobufjs` resolution to `7.5.5`
- pin `@opentelemetry/otlp-transformer` transitive `protobufjs` resolution to `7.5.5` or `8.0.1`, depending on the upstream line
- refresh `pnpm-lock.yaml` so the resolved graph no longer includes vulnerable `protobufjs` versions

## Why

GitHub/Dependabot flagged arbitrary code execution in `protobufjs` for versions `< 7.5.5` and `8.0.0`.

In this repo the vulnerable versions were introduced transitively through:

- `@boxyhq/saml-jackson -> @boxyhq/metrics -> @grpc/proto-loader`
- `@formbricks/web` OpenTelemetry exporters and transformers
- `@formbricks/logger -> pino-opentelemetry-transport -> otlp-logger -> @opentelemetry/otlp-transformer`

Using `pnpm.overrides` keeps the remediation narrow and avoids a broader upgrade across BoxyHQ or OpenTelemetry packages.

## Impact

- removes vulnerable `protobufjs` resolutions from the dependency graph
- keeps the application dependency surface otherwise unchanged
- documents the temporary transitive override in the existing security override comment block

## Validation

- `pnpm install`
- `pnpm why protobufjs --recursive`
- `pnpm --filter @formbricks/logger build`

## Notes

A broader `pnpm --filter @formbricks/web build` check is currently blocked by unrelated local workspace/runtime issues on this machine:

- missing built output for `@formbricks/ai`
- missing `rolldown` native binding during the local `@formbricks/ai` build

Those issues were present outside the scope of this dependency fix.

Related: `ENG-716`
