### PR TITLE
feat: add iframe preview to website embed tab

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/website-embed-tab.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/website-embed-tab.tsx
@@ -55,7 +55,7 @@ export const WebsiteEmbedTab = ({ surveyUrl }: WebsiteEmbedTabProps) => {
         <CopyIcon />
       </Button>
 
-      <p className="text-sm font-medium text-slate-700">{t("common.preview")}</p>
+      <p className="text-base font-semibold text-slate-800">{t("common.preview")}</p>
       <div className="relative h-[500px] w-full overflow-hidden rounded-lg border border-slate-300">
         <iframe
           title={t("common.preview")}

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/website-embed-tab.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/website-embed-tab.tsx
@@ -55,6 +55,7 @@ export const WebsiteEmbedTab = ({ surveyUrl }: WebsiteEmbedTabProps) => {
         <CopyIcon />
       </Button>
 
+      <p className="text-sm font-medium text-slate-700">{t("common.preview")}</p>
       <div className="relative h-[500px] w-full overflow-hidden rounded-lg border border-slate-300">
         <iframe
           title={t("common.preview")}

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/website-embed-tab.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/website-embed-tab.tsx
@@ -49,10 +49,10 @@ export const WebsiteEmbedTab = ({ surveyUrl }: WebsiteEmbedTabProps) => {
         <CopyIcon />
       </Button>
 
-      <div className="relative h-[300px] w-full overflow-hidden rounded-lg border border-slate-300">
+      <div className="relative h-[500px] w-full overflow-hidden rounded-lg border border-slate-300">
         <iframe
           title={t("common.preview")}
-          src={`${surveyUrl}${embedModeEnabled ? "?embed=true" : ""}`}
+          src={`${surveyUrl}?preview=true${embedModeEnabled ? "&embed=true" : ""}`}
           className="absolute inset-0 h-full w-full border-0"
         />
       </div>

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/website-embed-tab.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/website-embed-tab.tsx
@@ -55,7 +55,7 @@ export const WebsiteEmbedTab = ({ surveyUrl }: WebsiteEmbedTabProps) => {
         <CopyIcon />
       </Button>
 
-      <p className="text-base font-semibold text-slate-800">{t("common.preview")}</p>
+      <p className="text-base font-medium text-slate-800">{t("common.preview")}</p>
       <div className="relative h-[500px] w-full overflow-hidden rounded-lg border border-slate-300">
         <iframe
           title={t("common.preview")}

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/website-embed-tab.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/website-embed-tab.tsx
@@ -16,12 +16,18 @@ export const WebsiteEmbedTab = ({ surveyUrl }: WebsiteEmbedTabProps) => {
   const [embedModeEnabled, setEmbedModeEnabled] = useState(false);
   const { t } = useTranslation();
 
-  const iframeCode = `<div style="position: relative; height:80dvh; overflow:auto;"> 
-  <iframe 
-    src="${surveyUrl}${embedModeEnabled ? "?embed=true" : ""}" 
+  const separator = surveyUrl.includes("?") ? "&" : "?";
+
+  const iframeSrc = embedModeEnabled ? `${surveyUrl}${separator}embed=true` : surveyUrl;
+
+  const iframeCode = `<div style="position: relative; height:80dvh; overflow:auto;">
+  <iframe
+    src="${iframeSrc}"
     frameborder="0" style="position: absolute; left:0; top:0; width:100%; height:100%; border:0;">
   </iframe>
 </div>`;
+
+  const previewSrc = `${iframeSrc}${iframeSrc.includes("?") ? "&" : "?"}preview=true`;
 
   return (
     <>
@@ -52,7 +58,7 @@ export const WebsiteEmbedTab = ({ surveyUrl }: WebsiteEmbedTabProps) => {
       <div className="relative h-[500px] w-full overflow-hidden rounded-lg border border-slate-300">
         <iframe
           title={t("common.preview")}
-          src={`${surveyUrl}?preview=true${embedModeEnabled ? "&embed=true" : ""}`}
+          src={previewSrc}
           className="absolute inset-0 h-full w-full border-0"
         />
       </div>

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/website-embed-tab.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/website-embed-tab.tsx
@@ -48,6 +48,14 @@ export const WebsiteEmbedTab = ({ surveyUrl }: WebsiteEmbedTabProps) => {
         {t("common.copy_code")}
         <CopyIcon />
       </Button>
+
+      <div className="relative h-[300px] w-full overflow-hidden rounded-lg border border-slate-300">
+        <iframe
+          title={t("common.preview")}
+          src={`${surveyUrl}${embedModeEnabled ? "?embed=true" : ""}`}
+          className="absolute inset-0 h-full w-full border-0"
+        />
+      </div>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- Adds a live iframe preview to the "Website embed" tab in the share survey modal
- Users can now see how their embedded survey will look before copying the code and deploying
- The preview respects the "Embed Mode" toggle, updating in real-time when toggled
- Preview runs in preview mode (`?preview=true`) so responses are not recorded

Closes https://linear.app/formbricks/issue/ENG-717/iframe-preview

<img width="1058" height="763" alt="Screenshot 2026-04-21 at 4 12 53 PM" src="https://github.com/user-attachments/assets/0a23cbfe-529b-4e37-8190-a0e99ee2229b" />
<img width="1058" height="763" alt="Screenshot 2026-04-21 at 4 12 59 PM" src="https://github.com/user-attachments/assets/c77b9057-1cf4-47d9-8fd4-06bbadd607a7" />


## Test plan
- [ ] Open a survey → Share → Website embed tab
- [ ] Verify the iframe preview renders the survey below the "Copy code" button
- [ ] Toggle "Embed Mode" on/off and verify the preview updates accordingly
- [ ] Verify the preview is scrollable and renders correctly within the modal
- [ ] Verify no responses are recorded from the preview (preview mode)