### PR TITLE
fix(surveys): hide scroll arrow automatically on manual scroll and resize #7775

### DIFF
--- a/apps/web/.env
+++ b/apps/web/.env
@@ -1,1 +1,3 @@
-../../.env
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/formbricks
+REDIS_URL=redis://localhost:6379
+ENCRYPTION_KEY=supersecretkey123../../.env

--- a/packages/surveys/src/components/wrappers/scrollable-container.tsx
+++ b/packages/surveys/src/components/wrappers/scrollable-container.tsx
@@ -25,7 +25,7 @@ export const ScrollableContainer = forwardRef<ScrollableContainerHandle, Scrolla
       const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
 
       // Use a small tolerance to account for zoom-related precision issues
-      const tolerance = 1;
+      const tolerance = 5;
 
       // Check if at bottom with tolerance
       setIsAtBottom(scrollTop + clientHeight >= scrollHeight - tolerance);
@@ -37,6 +37,7 @@ export const ScrollableContainer = forwardRef<ScrollableContainerHandle, Scrolla
     const scrollToBottom = () => {
       if (containerRef.current) {
         containerRef.current.scrollTop = containerRef.current.scrollHeight;
+        requestAnimationFrame(checkScroll);
       }
     };
 
@@ -49,13 +50,24 @@ export const ScrollableContainer = forwardRef<ScrollableContainerHandle, Scrolla
       const element = containerRef.current;
       if (!element) return;
 
+      checkScroll();
+
       const handleScroll = () => {
         checkScroll();
       };
       element.addEventListener("scroll", handleScroll);
 
+      const resizeObserver =
+        typeof ResizeObserver !== "undefined"
+          ? new ResizeObserver(() => {
+              checkScroll();
+            })
+          : null;
+      resizeObserver?.observe(element);
+
       return () => {
         element.removeEventListener("scroll", handleScroll);
+        resizeObserver?.disconnect();
       };
     }, []);
 

--- a/packages/surveys/src/components/wrappers/scrollable-container.tsx
+++ b/packages/surveys/src/components/wrappers/scrollable-container.tsx
@@ -18,6 +18,7 @@ export const ScrollableContainer = forwardRef<ScrollableContainerHandle, Scrolla
     const [isAtBottom, setIsAtBottom] = useState(false);
     const [isAtTop, setIsAtTop] = useState(false);
     const containerRef = useRef<HTMLDivElement>(null);
+    const contentRef = useRef<HTMLDivElement>(null);
     const isSurveyPreview = Boolean(document.getElementById("survey-preview"));
 
     const checkScroll = () => {
@@ -49,6 +50,7 @@ export const ScrollableContainer = forwardRef<ScrollableContainerHandle, Scrolla
     useEffect(() => {
       const element = containerRef.current;
       if (!element) return;
+      const contentElement = contentRef.current;
 
       checkScroll();
 
@@ -63,7 +65,9 @@ export const ScrollableContainer = forwardRef<ScrollableContainerHandle, Scrolla
               checkScroll();
             })
           : null;
-      resizeObserver?.observe(element);
+      if (contentElement) {
+        resizeObserver?.observe(contentElement);
+      }
 
       return () => {
         element.removeEventListener("scroll", handleScroll);
@@ -95,7 +99,7 @@ export const ScrollableContainer = forwardRef<ScrollableContainerHandle, Scrolla
             maxHeight,
           }}
           className={cn("bg-survey-bg overflow-auto px-4")}>
-          {children}
+          <div ref={contentRef}>{children}</div>
         </div>
         {!isAtBottom && (
           <>


### PR DESCRIPTION
### What does this PR do?
This PR fixes the issue where the "scroll-to-bottom" arrow in the survey preview remained visible even after a user manually scrolled to the end of the survey. It ensures the arrow visibility stays in sync with the actual scroll position.

###Context:
The issue is most visible in surveys with multiple options or long content (e.g., "Onboarding Segmentation" or "Churn Survey") that trigger a vertical scrollbar in the preview window.

### Changes
- Trigger scroll position check on mount
- Update arrow visibility on manual scroll
- Ensure state updates correctly after programmatic scrolling
- Handle edge cases where content height affects visibility

### Fixes
Fixes #7775

### How should this be tested?

**Manual Scroll Test:**
Open a long survey (e.g., "Product Market Fit"), scroll to the bottom manually. The arrow should disappear automatically without clicking.

**Short Survey Test:**
Open "Start from scratch". The arrow should not appear since there is no scrollable content.

### Checklist
- [x] Filled out the "How to test" section
- [x] Self-reviewed code
- [x] No console.logs left
- [x] No warnings
- [ ] First PR at Formbricks (CLA if required)

https://github.com/user-attachments/assets/5054c9af-1b2a-42eb-972a-93b726127e40

