### PR TITLE
fix: lodash vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
       "effect": "3.20.0",
       "flatted": "3.4.2",
       "hono": "4.12.7",
+      "lodash": "4.18.1",
       "@microsoft/api-extractor>minimatch": "10.2.4",
       "node-forge": ">=1.3.2",
       "qs": "6.14.2",
@@ -108,7 +109,7 @@
       "diff": ">=8.0.3"
     },
     "comments": {
-      "overrides": "Security fixes for transitive dependencies. Remove when upstream packages update: @hono/node-server/hono (Dependabot #313/#316/#317) - awaiting Prisma update | @tootallnate/once (Dependabot #305) - awaiting sqlite3/node-gyp chain update | schema-utils@3>ajv (Dependabot #287) - awaiting eslint/file-loader schema-utils update | axios (CVE-2025-58754, CVE-2026-25639) - awaiting @boxyhq/saml-jackson update | protobufjs (ENG-716 / CVE-2026-41242) - awaiting @boxyhq/saml-jackson and OpenTelemetry transitive updates | effect (Dependabot #339) - awaiting Prisma update | flatted (Dependabot #324/#338) - awaiting eslint/flat-cache update | minimatch (Dependabot #288/#294/#297) - awaiting react-email/glob update | node-forge (Dependabot #230) - awaiting @boxyhq/saml-jackson update | qs (Dependabot #277) - awaiting googleapis/googleapis-common update | rollup (Dependabot #291) - awaiting Vite patch adoption | socket.io-parser (Dependabot #334) - awaiting react-email/socket.io update | tar (CVE-2026-23745/23950/24842/26960) - awaiting @boxyhq/saml-jackson/sqlite3 dependency updates | typeorm (Dependabot #223) - awaiting @boxyhq/saml-jackson update | undici (Dependabot #319/#322/#323) - awaiting jsdom/vitest/isomorphic-dompurify updates | fast-xml-parser (CVE-2026-25896/26278/33036/33349) - awaiting exact upstream pin updates | diff (Dependabot #269) - awaiting upstream patch range adoption"
+      "overrides": "Security fixes for transitive dependencies. Remove when upstream packages update: @hono/node-server/hono (Dependabot #313/#316/#317) - awaiting Prisma update | @tootallnate/once (Dependabot #305) - awaiting sqlite3/node-gyp chain update | schema-utils@3>ajv (Dependabot #287) - awaiting eslint/file-loader schema-utils update | axios (CVE-2025-58754, CVE-2026-25639) - awaiting @boxyhq/saml-jackson update | protobufjs (ENG-716 / CVE-2026-41242) - awaiting @boxyhq/saml-jackson and OpenTelemetry transitive updates | effect (Dependabot #339) - awaiting Prisma update | flatted (Dependabot #324/#338) - awaiting eslint/flat-cache update | lodash (Dependabot #360) - awaiting @boxyhq/saml-jackson, Prisma/Chevrotain, and @microsoft/api-extractor transitive updates | minimatch (Dependabot #288/#294/#297) - awaiting react-email/glob update | node-forge (Dependabot #230) - awaiting @boxyhq/saml-jackson update | qs (Dependabot #277) - awaiting googleapis/googleapis-common update | rollup (Dependabot #291) - awaiting Vite patch adoption | socket.io-parser (Dependabot #334) - awaiting react-email/socket.io update | tar (CVE-2026-23745/23950/24842/26960) - awaiting @boxyhq/saml-jackson/sqlite3 dependency updates | typeorm (Dependabot #223) - awaiting @boxyhq/saml-jackson update | undici (Dependabot #319/#322/#323) - awaiting jsdom/vitest/isomorphic-dompurify updates | fast-xml-parser (CVE-2026-25896/26278/33036/33349) - awaiting exact upstream pin updates | diff (Dependabot #269) - awaiting upstream patch range adoption"
     },
     "patchedDependencies": {
       "next-auth@4.24.13": "patches/next-auth@4.24.13.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,7 @@ overrides:
   effect: 3.20.0
   flatted: 3.4.2
   hono: 4.12.7
+  lodash: 4.18.1
   '@microsoft/api-extractor>minimatch': 10.2.4
   node-forge: '>=1.3.2'
   qs: 6.14.2
@@ -8954,12 +8955,6 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
-
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -13503,7 +13498,7 @@ snapshots:
       encoding: 0.1.13
       ipaddr.js: 2.2.0
       jose: 6.0.11
-      lodash: 4.17.21
+      lodash: 4.18.1
       mixpanel: 0.18.1
       mongodb: 6.16.0(@aws-sdk/credential-providers@3.817.0)(socks@2.8.7)
       mssql: 11.0.1
@@ -13563,13 +13558,13 @@ snapshots:
     dependencies:
       '@chevrotain/gast': 10.5.0
       '@chevrotain/types': 10.5.0
-      lodash: 4.17.21
+      lodash: 4.18.1
     optional: true
 
   '@chevrotain/gast@10.5.0':
     dependencies:
       '@chevrotain/types': 10.5.0
-      lodash: 4.17.21
+      lodash: 4.18.1
     optional: true
 
   '@chevrotain/types@10.5.0':
@@ -14362,7 +14357,7 @@ snapshots:
       '@rushstack/terminal': 0.22.3(@types/node@25.4.0)
       '@rushstack/ts-command-line': 5.3.3(@types/node@25.4.0)
       diff: 8.0.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       minimatch: 10.2.4
       resolve: 1.22.11
       semver: 7.5.4
@@ -19278,7 +19273,7 @@ snapshots:
       '@chevrotain/gast': 10.5.0
       '@chevrotain/types': 10.5.0
       '@chevrotain/utils': 10.5.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       regexp-to-ast: 0.5.0
     optional: true
 
@@ -21583,10 +21578,6 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   lodash.once@4.1.1: {}
-
-  lodash@4.17.21: {}
-
-  lodash@4.17.23: {}
 
   lodash@4.18.1: {}
 


### PR DESCRIPTION
## What changed

- Added a root pnpm override to force all `lodash` resolutions to `4.18.1`.
- Regenerated `pnpm-lock.yaml` so transitive copies from `@boxyhq/saml-jackson`, Prisma/Chevrotain, and `@microsoft/api-extractor` resolve to the patched version.
- Documented the override in the existing pnpm override comments.

## Why

Dependabot flagged `lodash` versions `>= 4.0.0, <= 4.17.23` for code injection via `_.template` imports key names. The direct app dependency was already on `4.18.1`, but vulnerable transitive copies remained in the lockfile and the parent packages do not currently provide a low-risk direct update path.

## Validation

- `pnpm install --lockfile-only`
- `pnpm why lodash --recursive` reports only `lodash@4.18.1`
- Grep confirmed no remaining `lodash@4.17.21`, `lodash@4.17.23`, or vulnerable snapshot entries in `package.json` / `pnpm-lock.yaml`