### PR TITLE
fix: prevent survey widget CSS from polluting host page styles

### DIFF
--- a/packages/surveys/postcss.config.cjs
+++ b/packages/surveys/postcss.config.cjs
@@ -101,20 +101,19 @@ scopeLayerTheme.postcss = true;
 // with the initial values. This gives the survey widget the defaults it needs
 // while keeping everything scoped.
 const replaceAtPropertyWithScoped = () => {
-  const collected = new Map();
   return {
     postcssPlugin: "postcss-replace-at-property-with-scoped",
-    AtRule: {
-      property: (atRule) => {
+    OnceExit(root) {
+      const collected = new Map();
+      root.walkAtRules("property", (atRule) => {
         if (!atRule.params.startsWith("--tw-")) return;
         const name = atRule.params;
         atRule.walkDecls("initial-value", (decl) => {
           collected.set(name, decl.value);
         });
         atRule.remove();
-      },
-    },
-    OnceExit(root) {
+      });
+
       if (collected.size === 0) return;
       const postcss = require("postcss");
       const rule = postcss.rule({

--- a/packages/surveys/postcss.config.cjs
+++ b/packages/surveys/postcss.config.cjs
@@ -57,6 +57,78 @@ const stripLayerProperties = () => {
 };
 stripLayerProperties.postcss = true;
 
+// Re-scopes `:root` and `:host` selectors inside `@layer theme` to `#fbjs`.
+//
+// Problem: Tailwind v4 emits `@layer theme { :root, :host { --color-*; --spacing; ... } }`
+// which sets CSS custom properties globally. When the survey widget injects this
+// into the host page, it overrides the host site's own Tailwind theme variables,
+// causing buttons and other styled elements to change color/appearance.
+//
+// Fix: Replace `:root` / `:host` selectors with `#fbjs` so theme variables are
+// scoped to the survey widget. CSS custom properties inherit, so all survey
+// descendants still pick them up.
+const scopeLayerTheme = () => {
+  return {
+    postcssPlugin: "postcss-scope-layer-theme",
+    AtRule: {
+      layer: (atRule) => {
+        if (atRule.params !== "theme") return;
+        atRule.walkRules((rule) => {
+          rule.selectors = rule.selectors.map((sel) => {
+            if (sel === ":root" || sel === ":host") return "#fbjs";
+            return sel;
+          });
+        });
+      },
+    },
+  };
+};
+scopeLayerTheme.postcss = true;
+
+// Replaces global `@property --tw-*` declarations with a scoped `#fbjs` rule
+// that provides the same initial values.
+//
+// Problem: `@property` is globally scoped by spec and cannot be confined to
+// `#fbjs`. Tailwind v4 emits declarations like:
+//   @property --tw-gradient-to-position { syntax: "<length-percentage>"; inherits: false; initial-value: 100% }
+//
+// `inherits: false` breaks inheritance of `--tw-*` custom properties on the
+// host page, and the `syntax` constraint rejects host-page values that don't
+// match. Both cause host-page Tailwind v3 utilities to lose their styling.
+//
+// Fix: Collect each property's initial-value, remove the `@property` rule,
+// then emit a single `#fbjs, #fbjs *, #fbjs ::before, #fbjs ::after` rule
+// with the initial values. This gives the survey widget the defaults it needs
+// while keeping everything scoped.
+const replaceAtPropertyWithScoped = () => {
+  const collected = new Map();
+  return {
+    postcssPlugin: "postcss-replace-at-property-with-scoped",
+    AtRule: {
+      property: (atRule) => {
+        if (!atRule.params.startsWith("--tw-")) return;
+        const name = atRule.params;
+        atRule.walkDecls("initial-value", (decl) => {
+          collected.set(name, decl.value);
+        });
+        atRule.remove();
+      },
+    },
+    OnceExit(root) {
+      if (collected.size === 0) return;
+      const postcss = require("postcss");
+      const rule = postcss.rule({
+        selectors: ["#fbjs", "#fbjs *", "#fbjs ::before", "#fbjs ::after", "#fbjs ::backdrop"],
+      });
+      for (const [name, value] of collected) {
+        rule.append(postcss.decl({ prop: name, value }));
+      }
+      root.append(rule);
+    },
+  };
+};
+replaceAtPropertyWithScoped.postcss = true;
+
 module.exports = {
-  plugins: [require("@tailwindcss/postcss"), require("autoprefixer"), remtoEm(), stripLayerProperties()],
+  plugins: [require("@tailwindcss/postcss"), require("autoprefixer"), remtoEm(), stripLayerProperties(), scopeLayerTheme(), replaceAtPropertyWithScoped()],
 };


### PR DESCRIPTION
## Summary

Extends the CSS isolation fix from #7685 to cover two additional global pollution vectors in the survey widget's Tailwind v4 output:

- **`@layer theme`** — contains `:root, :host` selectors that override the host page's Tailwind theme variables (`--color-*`, `--spacing`, `--font-*`). Fixed by rewriting selectors to `#fbjs`.
- **`@property --tw-*`** — globally registers `--tw-*` custom properties with `inherits: false` and strict `syntax` constraints. This breaks inheritance of the host page's own `--tw-*` variables (e.g. `--tw-text-opacity`, `--tw-gradient-to-position`), causing buttons, gradients, and shadows to lose styling when a survey triggers. Fixed by replacing `@property` declarations with a scoped `#fbjs` rule providing the same initial values.

<img width="1264" height="982" alt="Screenshot 2026-04-22 at 3 53 57 PM" src="https://github.com/user-attachments/assets/59b1c6a3-736b-4467-9032-f880093c8783" />

Fixes https://linear.app/formbricks/issue/ENG-682/widget-breaks-tailwind-gradients-on-host-pages


## Root cause

Tailwind v4 emits three mechanisms for CSS custom property initialization — all globally scoped by CSS spec:

| Mechanism | Scoped by `#fbjs`? | Status |
|---|---|---|
| `@layer properties { *, ::before, ::after { ... } }` | No | Fixed in #7685 |
| `@layer theme { :root, :host { ... } }` | No | **Fixed in this PR** |
| `@property --tw-* { inherits: false; ... }` | No | **Fixed in this PR** |

## Test plan

- [ ] Build `packages/surveys` and confirm `@property --tw-*` declarations are absent from `dist/index.umd.cjs`
- [ ] Confirm `@layer theme` selectors use `#fbjs` instead of `:root, :host`
- [ ] Confirm a scoped `#fbjs, #fbjs *, ...` rule with `--tw-*` initial values is present
- [ ] Load the SDK on a Tailwind v3/v4 host page, trigger a survey, and verify host page buttons/shadows/gradients are unaffected
- [ ] Verify survey widget renders correctly (borders, shadows, gradients intact)