### PR TITLE
fix: apply plan changes immediately for non-standard plans

### DIFF
--- a/apps/web/modules/ee/billing/lib/organization-billing.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.ts
@@ -884,7 +884,11 @@ export const switchOrganizationToCloudPlan = async (input: {
   const currentPlan = resolveCloudPlanFromSubscription(subscription);
   const currentInterval = resolveSubscriptionInterval(subscription);
 
-  const isImmediateUpgrade = CLOUD_PLAN_LEVEL[input.targetPlan] > CLOUD_PLAN_LEVEL[currentPlan];
+  // Non-standard plans (custom, unknown) don't follow the normal tier hierarchy,
+  // so any switch from them to a standard plan should apply immediately.
+  const isNonStandardCurrentPlan = currentPlan === "custom" || currentPlan === "unknown";
+  const isImmediateUpgrade =
+    isNonStandardCurrentPlan || CLOUD_PLAN_LEVEL[input.targetPlan] > CLOUD_PLAN_LEVEL[currentPlan];
   const isSameSelection = currentPlan === input.targetPlan && currentInterval === input.targetInterval;
 
   if (isSameSelection) {


### PR DESCRIPTION
## Summary
- Workspaces on non-standard plans (custom/unknown, e.g. Legacy Free) could not upgrade to Pro through self-serve billing — the change was scheduled for the billing period end instead of applying immediately
- Root cause: `CLOUD_PLAN_LEVEL` ranks `custom` at level 3 (above `pro` at level 1), so `custom → pro` was treated as a downgrade
- Non-standard plans don't follow the standard tier hierarchy, so any switch from them to a standard plan now applies immediately

Fixes https://linear.app/formbricks/issue/ENG-697/legacy-free-customers-cannot-self-serve-upgrade-to-pro

## Test plan
- [ ] Verify a Legacy Free (custom plan) workspace can upgrade to Pro and the change applies immediately
- [ ] Verify standard plan upgrades (hobby → pro, pro → scale) still apply immediately
- [ ] Verify standard plan downgrades (scale → pro, pro → hobby) are still scheduled for period end
- [ ] Verify same-plan selection still returns early without changes