### PR TITLE
fix(survey-list): reduce v3 overview query cost

### DIFF
--- a/apps/web/app/api/v3/surveys/parse-v3-surveys-list-query.test.ts
+++ b/apps/web/app/api/v3/surveys/parse-v3-surveys-list-query.test.ts
@@ -34,7 +34,7 @@ describe("parseV3SurveysListQuery", () => {
       expect(r.invalid_params[0]).toEqual({
         name: "foo",
         reason:
-          "Unsupported query parameter. Use only workspaceId, limit, cursor, filter[name][contains], filter[status][in], filter[type][in], sortBy.",
+          "Unsupported query parameter. Use only workspaceId, limit, cursor, includeTotalCount, filter[name][contains], filter[status][in], filter[type][in], sortBy.",
       });
   });
 
@@ -45,7 +45,7 @@ describe("parseV3SurveysListQuery", () => {
       expect(r.invalid_params[0]).toEqual({
         name: "after",
         reason:
-          "Unsupported query parameter. Use only workspaceId, limit, cursor, filter[name][contains], filter[status][in], filter[type][in], sortBy.",
+          "Unsupported query parameter. Use only workspaceId, limit, cursor, includeTotalCount, filter[name][contains], filter[status][in], filter[type][in], sortBy.",
       });
     }
   });
@@ -57,7 +57,7 @@ describe("parseV3SurveysListQuery", () => {
       expect(r.invalid_params[0]).toEqual({
         name: "name",
         reason:
-          "Unsupported query parameter. Use only workspaceId, limit, cursor, filter[name][contains], filter[status][in], filter[type][in], sortBy.",
+          "Unsupported query parameter. Use only workspaceId, limit, cursor, includeTotalCount, filter[name][contains], filter[status][in], filter[type][in], sortBy.",
       });
     }
   });
@@ -68,8 +68,17 @@ describe("parseV3SurveysListQuery", () => {
     if (r.ok) {
       expect(r.limit).toBe(20);
       expect(r.cursor).toBeNull();
+      expect(r.includeTotalCount).toBe(true);
       expect(r.sortBy).toBe("updatedAt");
       expect(r.filterCriteria).toBeUndefined();
+    }
+  });
+
+  test("parses includeTotalCount=false", () => {
+    const r = parseV3SurveysListQuery(params(`workspaceId=${wid}&includeTotalCount=false`));
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.includeTotalCount).toBe(false);
     }
   });
 
@@ -102,7 +111,7 @@ describe("parseV3SurveysListQuery", () => {
       expect(r.invalid_params[0]).toEqual({
         name: "filter[createdBy][in]",
         reason:
-          "Unsupported query parameter. Use only workspaceId, limit, cursor, filter[name][contains], filter[status][in], filter[type][in], sortBy.",
+          "Unsupported query parameter. Use only workspaceId, limit, cursor, includeTotalCount, filter[name][contains], filter[status][in], filter[type][in], sortBy.",
       });
     }
   });

--- a/apps/web/app/api/v3/surveys/parse-v3-surveys-list-query.ts
+++ b/apps/web/app/api/v3/surveys/parse-v3-surveys-list-query.ts
@@ -28,6 +28,7 @@ const SUPPORTED_QUERY_PARAMS = [
   "workspaceId",
   "limit",
   "cursor",
+  "includeTotalCount",
   FILTER_NAME_CONTAINS_QUERY_PARAM,
   FILTER_STATUS_IN_QUERY_PARAM,
   FILTER_TYPE_IN_QUERY_PARAM,
@@ -53,6 +54,11 @@ const ZV3SurveysListQuery = z.object({
   workspaceId: ZId,
   limit: z.coerce.number().int().min(1).max(V3_SURVEYS_MAX_LIMIT).default(V3_SURVEYS_DEFAULT_LIMIT),
   cursor: z.string().min(1).optional(),
+  includeTotalCount: z
+    .enum(["true", "false"])
+    .optional()
+    .transform((value) => value !== "false")
+    .default(true),
   [FILTER_NAME_CONTAINS_QUERY_PARAM]: z
     .string()
     .max(512)
@@ -71,6 +77,7 @@ export type TV3SurveysListQueryParseResult =
       workspaceId: string;
       limit: number;
       cursor: TSurveyListPageCursor | null;
+      includeTotalCount: boolean;
       sortBy: TSurveyListSort;
       filterCriteria: TSurveyFilterCriteria | undefined;
     }
@@ -111,6 +118,7 @@ export function parseV3SurveysListQuery(searchParams: URLSearchParams): TV3Surve
     workspaceId: searchParams.get("workspaceId"),
     limit: searchParams.get("limit") ?? undefined,
     cursor: searchParams.get("cursor")?.trim() || undefined,
+    includeTotalCount: searchParams.get("includeTotalCount")?.trim() || undefined,
     [FILTER_NAME_CONTAINS_QUERY_PARAM]: searchParams.get(FILTER_NAME_CONTAINS_QUERY_PARAM) ?? undefined,
     [FILTER_STATUS_IN_QUERY_PARAM]: statusVals.length > 0 ? statusVals : undefined,
     [FILTER_TYPE_IN_QUERY_PARAM]: typeVals.length > 0 ? typeVals : undefined,
@@ -153,6 +161,7 @@ export function parseV3SurveysListQuery(searchParams: URLSearchParams): TV3Surve
     workspaceId: q.workspaceId,
     limit: q.limit,
     cursor,
+    includeTotalCount: q.includeTotalCount,
     sortBy,
     filterCriteria: buildFilterCriteria(q),
   };

--- a/apps/web/app/api/v3/surveys/route.test.ts
+++ b/apps/web/app/api/v3/surveys/route.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
 import { getSurveyCount } from "@/modules/survey/list/lib/survey";
-import { getSurveyListPage } from "@/modules/survey/list/lib/survey-page";
+import { encodeSurveyListPageCursor, getSurveyListPage } from "@/modules/survey/list/lib/survey-page";
 import { GET } from "./route";
 
 const { mockAuthenticateRequest } = vi.hoisted(() => ({
@@ -255,6 +255,29 @@ describe("GET /api/v3/surveys", () => {
       filterCriteria: undefined,
     });
     expect(getSurveyCount).toHaveBeenCalledWith(resolvedEnvironmentId, undefined);
+  });
+
+  test("skips totalCount when includeTotalCount=false", async () => {
+    vi.mocked(getSurveyListPage).mockResolvedValue({
+      surveys: [],
+      nextCursor: null,
+    });
+    const cursor = encodeSurveyListPageCursor({
+      version: 1,
+      sortBy: "updatedAt",
+      value: "2026-04-15T10:00:00.000Z",
+      id: "survey_1",
+    });
+
+    const req = createRequest(
+      `http://localhost/api/v3/surveys?workspaceId=${validWorkspaceId}&cursor=${cursor}&includeTotalCount=false`
+    );
+    const res = await GET(req, {} as any);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.meta).toEqual({ limit: 20, nextCursor: null, totalCount: null });
+    expect(getSurveyCount).not.toHaveBeenCalled();
   });
 
   test("passes filter query to getSurveyListPage", async () => {

--- a/apps/web/app/api/v3/surveys/route.ts
+++ b/apps/web/app/api/v3/surveys/route.ts
@@ -46,21 +46,22 @@ export const GET = withV3ApiWrapper({
 
       const { environmentId } = authResult;
 
-      const [{ surveys, nextCursor }, totalCount] = await Promise.all([
-        getSurveyListPage(environmentId, {
-          limit: parsed.limit,
-          cursor: parsed.cursor,
-          sortBy: parsed.sortBy,
-          filterCriteria: parsed.filterCriteria,
-        }),
-        getSurveyCount(environmentId, parsed.filterCriteria),
-      ]);
+      const surveyPage = await getSurveyListPage(environmentId, {
+        limit: parsed.limit,
+        cursor: parsed.cursor,
+        sortBy: parsed.sortBy,
+        filterCriteria: parsed.filterCriteria,
+      });
+
+      const totalCount = parsed.includeTotalCount
+        ? await getSurveyCount(environmentId, parsed.filterCriteria)
+        : null;
 
       return successListResponse(
-        surveys.map(serializeV3SurveyListItem),
+        surveyPage.surveys.map(serializeV3SurveyListItem),
         {
           limit: parsed.limit,
-          nextCursor,
+          nextCursor: surveyPage.nextCursor,
           totalCount,
         },
         { requestId, cache: "private, no-store" }

--- a/apps/web/app/api/v3/surveys/route.ts
+++ b/apps/web/app/api/v3/surveys/route.ts
@@ -46,16 +46,16 @@ export const GET = withV3ApiWrapper({
 
       const { environmentId } = authResult;
 
-      const surveyPage = await getSurveyListPage(environmentId, {
+      const surveyPagePromise = getSurveyListPage(environmentId, {
         limit: parsed.limit,
         cursor: parsed.cursor,
         sortBy: parsed.sortBy,
         filterCriteria: parsed.filterCriteria,
       });
-
-      const totalCount = parsed.includeTotalCount
-        ? await getSurveyCount(environmentId, parsed.filterCriteria)
-        : null;
+      const totalCountPromise = parsed.includeTotalCount
+        ? getSurveyCount(environmentId, parsed.filterCriteria)
+        : Promise.resolve(null);
+      const [surveyPage, totalCount] = await Promise.all([surveyPagePromise, totalCountPromise]);
 
       return successListResponse(
         surveyPage.surveys.map(serializeV3SurveyListItem),

--- a/apps/web/modules/survey/list/hooks/use-surveys.test.ts
+++ b/apps/web/modules/survey/list/hooks/use-surveys.test.ts
@@ -77,7 +77,7 @@ describe("useSurveys", () => {
             meta: {
               limit: 20,
               nextCursor: null,
-              totalCount: 2,
+              totalCount: null,
             },
           }),
           { status: 200, headers: { "Content-Type": "application/json" } }
@@ -120,7 +120,7 @@ describe("useSurveys", () => {
     expect(result.current.hasNextPage).toBe(false);
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
-      "/api/v3/surveys?workspaceId=env_1&limit=20&sortBy=relevance&cursor=cursor_1",
+      "/api/v3/surveys?workspaceId=env_1&limit=20&sortBy=relevance&cursor=cursor_1&includeTotalCount=false",
       expect.objectContaining({
         method: "GET",
         cache: "no-store",

--- a/apps/web/modules/survey/list/hooks/use-surveys.ts
+++ b/apps/web/modules/survey/list/hooks/use-surveys.ts
@@ -32,6 +32,7 @@ export const useSurveys = ({
         workspaceId,
         limit,
         cursor: pageParam,
+        includeTotalCount: pageParam === null,
         filters,
         signal,
       }),

--- a/apps/web/modules/survey/list/lib/query.test.ts
+++ b/apps/web/modules/survey/list/lib/query.test.ts
@@ -63,4 +63,25 @@ describe("removeSurveyFromInfiniteData", () => {
   test("returns the original cache when the survey is not present", () => {
     expect(removeSurveyFromInfiniteData(baseData, "missing_survey")).toBe(baseData);
   });
+
+  test("preserves null totalCount for pages that skipped the count query", () => {
+    const dataWithNullTotalCount: InfiniteData<TSurveyListPage> = {
+      ...baseData,
+      pages: [
+        baseData.pages[0],
+        {
+          ...baseData.pages[1],
+          meta: {
+            ...baseData.pages[1].meta,
+            totalCount: null,
+          },
+        },
+      ],
+    };
+
+    const nextData = removeSurveyFromInfiniteData(dataWithNullTotalCount, "survey_a");
+
+    expect(nextData?.pages[0]?.meta.totalCount).toBe(1);
+    expect(nextData?.pages[1]?.meta.totalCount).toBeNull();
+  });
 });

--- a/apps/web/modules/survey/list/lib/query.ts
+++ b/apps/web/modules/survey/list/lib/query.ts
@@ -50,7 +50,7 @@ export function removeSurveyFromInfiniteData(
       ...page,
       meta: {
         ...page.meta,
-        totalCount: Math.max(0, page.meta.totalCount - 1),
+        totalCount: page.meta.totalCount === null ? null : Math.max(0, page.meta.totalCount - 1),
       },
     })),
   };

--- a/apps/web/modules/survey/list/lib/survey-page.test.ts
+++ b/apps/web/modules/survey/list/lib/survey-page.test.ts
@@ -6,6 +6,8 @@ import { DatabaseError, InvalidInputError } from "@formbricks/types/errors";
 import { buildWhereClause } from "@/modules/survey/lib/utils";
 import { decodeSurveyListPageCursor, encodeSurveyListPageCursor, getSurveyListPage } from "./survey-page";
 
+vi.mock("server-only", () => ({}));
+
 vi.mock("@/modules/survey/lib/utils", () => ({
   buildWhereClause: vi.fn(() => ({ AND: [] })),
 }));
@@ -14,6 +16,9 @@ vi.mock("@formbricks/database", () => ({
   prisma: {
     survey: {
       findMany: vi.fn(),
+    },
+    response: {
+      groupBy: vi.fn(),
     },
   },
 }));
@@ -37,7 +42,6 @@ function makeSurveyRow(overrides: Record<string, unknown> = {}) {
     updatedAt: new Date("2025-01-02T00:00:00.000Z"),
     creator: { name: "Alice" },
     singleUse: null,
-    _count: { responses: 3 },
     ...overrides,
   };
 }
@@ -74,12 +78,17 @@ describe("survey-page cursor helpers", () => {
 describe("getSurveyListPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(prisma.survey.findMany).mockReset();
+    vi.mocked(prisma.response.groupBy).mockReset();
   });
 
   test("uses a stable updatedAt order with a next cursor", async () => {
     vi.mocked(prisma.survey.findMany).mockResolvedValue([
       makeSurveyRow({ id: "survey_2", updatedAt: new Date("2025-01-03T00:00:00.000Z") }),
       makeSurveyRow({ id: "survey_1", updatedAt: new Date("2025-01-02T00:00:00.000Z") }),
+    ] as never);
+    vi.mocked(prisma.response.groupBy).mockResolvedValue([
+      { surveyId: "survey_2", _count: { _all: 3 } },
     ] as never);
 
     const page = await getSurveyListPage(environmentId, {
@@ -121,6 +130,9 @@ describe("getSurveyListPage", () => {
     vi.mocked(prisma.survey.findMany).mockResolvedValue([
       makeSurveyRow({ id: "survey_c", name: "Charlie" }),
     ] as never);
+    vi.mocked(prisma.response.groupBy).mockResolvedValue([
+      { surveyId: "survey_c", _count: { _all: 3 } },
+    ] as never);
 
     await getSurveyListPage(environmentId, {
       limit: 2,
@@ -161,6 +173,10 @@ describe("getSurveyListPage", () => {
           updatedAt: new Date("2025-01-01T00:00:00.000Z"),
         }),
       ] as never);
+    vi.mocked(prisma.response.groupBy).mockResolvedValue([
+      { surveyId: "survey_in_progress", _count: { _all: 3 } },
+      { surveyId: "survey_other_1", _count: { _all: 2 } },
+    ] as never);
 
     const page = await getSurveyListPage(environmentId, {
       limit: 2,
@@ -214,6 +230,9 @@ describe("getSurveyListPage", () => {
           updatedAt: new Date("2025-01-02T00:00:00.000Z"),
         }),
       ] as never);
+    vi.mocked(prisma.response.groupBy).mockResolvedValue([
+      { surveyId: "survey_in_progress", _count: { _all: 3 } },
+    ] as never);
 
     const page = await getSurveyListPage(environmentId, {
       limit: 1,
@@ -249,6 +268,9 @@ describe("getSurveyListPage", () => {
         status: "completed",
         updatedAt: new Date("2025-01-01T00:00:00.000Z"),
       }),
+    ] as never);
+    vi.mocked(prisma.response.groupBy).mockResolvedValue([
+      { surveyId: "survey_other_2", _count: { _all: 3 } },
     ] as never);
 
     const page = await getSurveyListPage(environmentId, {

--- a/apps/web/modules/survey/list/lib/survey-page.ts
+++ b/apps/web/modules/survey/list/lib/survey-page.ts
@@ -7,7 +7,12 @@ import { DatabaseError, InvalidInputError } from "@formbricks/types/errors";
 import type { TSurveyFilterCriteria } from "@formbricks/types/surveys/types";
 import { buildWhereClause } from "@/modules/survey/lib/utils";
 import type { TSurvey } from "../types/surveys";
-import { type TSurveyRow, mapSurveyRowsToSurveys, surveySelect } from "./survey-record";
+import {
+  type TSurveyRow,
+  getResponseCountsBySurveyIds,
+  mapSurveyRowsToSurveys,
+  surveySelect,
+} from "./survey-record";
 
 const SURVEY_LIST_CURSOR_VERSION = 1 as const;
 const IN_PROGRESS_BUCKET = "inProgress" as const;
@@ -229,9 +234,14 @@ function getPageRows<T>(rows: T[], limit: number): { pageRows: T[]; hasMore: boo
   };
 }
 
-function buildSurveyListPage(rows: TSurveyRow[], cursor: TSurveyListPageCursor | null): TSurveyListPage {
+async function buildSurveyListPage(
+  rows: TSurveyRow[],
+  cursor: TSurveyListPageCursor | null
+): Promise<TSurveyListPage> {
+  const responseCountsBySurveyId = await getResponseCountsBySurveyIds(rows.map((survey) => survey.id));
+
   return {
-    surveys: mapSurveyRowsToSurveys(rows),
+    surveys: mapSurveyRowsToSurveys(rows, responseCountsBySurveyId),
     nextCursor: cursor ? encodeSurveyListPageCursor(cursor) : null,
   };
 }
@@ -251,7 +261,7 @@ async function getStandardSurveyListPage(
   const { pageRows, hasMore } = getPageRows(surveyRows, options.limit);
   const lastRow = getLastSurveyRow(pageRows);
 
-  return buildSurveyListPage(
+  return await buildSurveyListPage(
     pageRows,
     hasMore && lastRow ? getStandardNextCursor(lastRow, options.sortBy) : null
   );
@@ -308,10 +318,13 @@ function shouldReadInProgressBucket(cursor: TRelevanceSurveyListCursor | null): 
   return !cursor || cursor.bucket === IN_PROGRESS_BUCKET;
 }
 
-function buildRelevancePage(rows: TSurveyRow[], bucket: TRelevanceBucket | null): TSurveyListPage {
+async function buildRelevancePage(
+  rows: TSurveyRow[],
+  bucket: TRelevanceBucket | null
+): Promise<TSurveyListPage> {
   const lastRow = getLastSurveyRow(rows);
 
-  return buildSurveyListPage(rows, bucket && lastRow ? getRelevanceNextCursor(lastRow, bucket) : null);
+  return await buildSurveyListPage(rows, bucket && lastRow ? getRelevanceNextCursor(lastRow, bucket) : null);
 }
 
 async function getInProgressRelevanceStep(
@@ -332,7 +345,7 @@ async function getInProgressRelevanceStep(
   return {
     pageRows,
     remaining: limit - pageRows.length,
-    response: hasMore ? buildRelevancePage(pageRows, IN_PROGRESS_BUCKET) : null,
+    response: hasMore ? await buildRelevancePage(pageRows, IN_PROGRESS_BUCKET) : null,
   };
 }
 
@@ -347,7 +360,7 @@ async function buildInProgressOnlyRelevancePage(
     shouldReadInProgressBucket(cursor) &&
     (await hasMoreRelevanceRowsInOtherBucket(environmentId, filterCriteria));
 
-  return buildRelevancePage(rows, hasOtherRows ? IN_PROGRESS_BUCKET : null);
+  return await buildRelevancePage(rows, hasOtherRows ? IN_PROGRESS_BUCKET : null);
 }
 
 async function getRelevanceSurveyListPage(
@@ -393,7 +406,7 @@ async function getRelevanceSurveyListPage(
   const { pageRows: otherPageRows, hasMore: hasMoreOther } = getPageRows(otherRows, remaining);
   pageRows.push(...otherPageRows);
 
-  return buildRelevancePage(pageRows, hasMoreOther ? OTHER_BUCKET : null);
+  return await buildRelevancePage(pageRows, hasMoreOther ? OTHER_BUCKET : null);
 }
 
 export async function getSurveyListPage(

--- a/apps/web/modules/survey/list/lib/survey-record.ts
+++ b/apps/web/modules/survey/list/lib/survey-record.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "@prisma/client";
+import { prisma } from "@formbricks/database";
 import type { TSurvey } from "@/modules/survey/list/types/surveys";
 
 export const surveySelect = {
@@ -15,22 +16,40 @@ export const surveySelect = {
   status: true,
   singleUse: true,
   environmentId: true,
-  _count: {
-    select: { responses: true },
-  },
 } satisfies Prisma.SurveySelect;
 
 export type TSurveyRow = Prisma.SurveyGetPayload<{ select: typeof surveySelect }>;
 
-export function mapSurveyRowToSurvey(row: TSurveyRow): TSurvey {
-  const { _count, ...survey } = row;
+export async function getResponseCountsBySurveyIds(surveyIds: string[]): Promise<Map<string, number>> {
+  if (surveyIds.length === 0) {
+    return new Map();
+  }
 
+  const responseCounts = await prisma.response.groupBy({
+    by: ["surveyId"],
+    where: {
+      surveyId: {
+        in: surveyIds,
+      },
+    },
+    _count: {
+      _all: true,
+    },
+  });
+
+  return new Map(responseCounts.map(({ surveyId, _count }) => [surveyId, _count._all]));
+}
+
+export function mapSurveyRowToSurvey(row: TSurveyRow, responseCount = 0): TSurvey {
   return {
-    ...survey,
-    responseCount: _count.responses,
+    ...row,
+    responseCount,
   };
 }
 
-export function mapSurveyRowsToSurveys(rows: TSurveyRow[]): TSurvey[] {
-  return rows.map(mapSurveyRowToSurvey);
+export function mapSurveyRowsToSurveys(
+  rows: TSurveyRow[],
+  responseCountsBySurveyId: Map<string, number> = new Map()
+): TSurvey[] {
+  return rows.map((row) => mapSurveyRowToSurvey(row, responseCountsBySurveyId.get(row.id) ?? 0));
 }

--- a/apps/web/modules/survey/list/lib/survey.test.ts
+++ b/apps/web/modules/survey/list/lib/survey.test.ts
@@ -10,6 +10,7 @@ import { getOrganizationByEnvironmentId } from "@/lib/organization/service";
 import { checkForInvalidMediaInBlocks } from "@/lib/survey/utils";
 import { validateInputs } from "@/lib/utils/validate";
 import { getIsQuotasEnabled } from "@/modules/ee/license-check/lib/utils";
+import { getQuotas } from "@/modules/ee/quotas/lib/quotas";
 import { buildOrderByClause, buildWhereClause } from "@/modules/survey/lib/utils";
 import { doesEnvironmentExist } from "@/modules/survey/list/lib/environment";
 import { getProjectWithLanguagesByEnvironmentId } from "@/modules/survey/list/lib/project";
@@ -23,6 +24,8 @@ import {
   getSurveysSortedByRelevance,
 } from "./survey";
 import { surveySelect } from "./survey-record";
+
+vi.mock("server-only", () => ({}));
 
 vi.mock("react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react")>();
@@ -65,6 +68,10 @@ vi.mock("@/modules/ee/license-check/lib/utils", () => ({
   getIsQuotasEnabled: vi.fn(),
 }));
 
+vi.mock("@/modules/ee/quotas/lib/quotas", () => ({
+  getQuotas: vi.fn(),
+}));
+
 vi.mock("@/lingodotdev/server", () => ({
   getTranslate: async () => (key: string, params?: Record<string, unknown>) => {
     if (key === "common.duplicate_copy") return "(copy)";
@@ -85,6 +92,9 @@ vi.mock("@formbricks/database", () => ({
     segment: {
       delete: vi.fn(),
       findFirst: vi.fn(),
+    },
+    response: {
+      groupBy: vi.fn(),
     },
     language: {
       // Added for language connectOrCreate in copySurvey
@@ -127,7 +137,9 @@ const resetMocks = () => {
   vi.mocked(prisma.survey.create).mockReset();
   vi.mocked(prisma.segment.delete).mockReset();
   vi.mocked(prisma.segment.findFirst).mockReset();
+  vi.mocked(prisma.response.groupBy).mockReset();
   vi.mocked(prisma.actionClass.findMany).mockReset();
+  vi.mocked(getQuotas).mockReset();
   vi.mocked(logger.error).mockClear();
 };
 
@@ -153,7 +165,6 @@ const mockSurveyPrisma = {
   status: "draft" as any,
   singleUse: null,
   environmentId,
-  _count: { responses: 10 },
 };
 
 describe("getSurveyCount", () => {
@@ -191,8 +202,9 @@ describe("getSurvey", () => {
   });
 
   test("should return a survey if found", async () => {
-    const prismaSurvey = { ...mockSurveyPrisma, _count: { responses: 5 } };
+    const prismaSurvey = { ...mockSurveyPrisma };
     vi.mocked(prisma.survey.findUnique).mockResolvedValue(prismaSurvey as any);
+    vi.mocked(prisma.response.groupBy).mockResolvedValue([{ surveyId, _count: { _all: 5 } }] as any);
 
     const survey = await getSurvey(surveyId);
 
@@ -241,24 +253,42 @@ describe("getSurveys", () => {
   });
 
   const mockPrismaSurveys = [
-    { ...mockSurveyPrisma, id: "s1", name: "Survey 1", _count: { responses: 1 } },
-    { ...mockSurveyPrisma, id: "s2", name: "Survey 2", _count: { responses: 2 } },
+    { ...mockSurveyPrisma, id: "s1", name: "Survey 1" },
+    { ...mockSurveyPrisma, id: "s2", name: "Survey 2" },
   ];
-  const expectedSurveys: TSurvey[] = mockPrismaSurveys.map((s) => ({
-    id: s.id,
-    createdAt: s.createdAt,
-    updatedAt: s.updatedAt,
-    name: s.name,
-    type: s.type,
-    creator: s.creator,
-    status: s.status,
-    singleUse: s.singleUse,
-    environmentId: s.environmentId,
-    responseCount: s._count.responses,
-  }));
+  const expectedSurveys: TSurvey[] = [
+    {
+      id: "s1",
+      createdAt: mockPrismaSurveys[0].createdAt,
+      updatedAt: mockPrismaSurveys[0].updatedAt,
+      name: "Survey 1",
+      type: mockPrismaSurveys[0].type,
+      creator: mockPrismaSurveys[0].creator,
+      status: mockPrismaSurveys[0].status,
+      singleUse: mockPrismaSurveys[0].singleUse,
+      environmentId: mockPrismaSurveys[0].environmentId,
+      responseCount: 1,
+    },
+    {
+      id: "s2",
+      createdAt: mockPrismaSurveys[1].createdAt,
+      updatedAt: mockPrismaSurveys[1].updatedAt,
+      name: "Survey 2",
+      type: mockPrismaSurveys[1].type,
+      creator: mockPrismaSurveys[1].creator,
+      status: mockPrismaSurveys[1].status,
+      singleUse: mockPrismaSurveys[1].singleUse,
+      environmentId: mockPrismaSurveys[1].environmentId,
+      responseCount: 2,
+    },
+  ];
 
   test("should return surveys with default parameters", async () => {
     vi.mocked(prisma.survey.findMany).mockResolvedValue(mockPrismaSurveys as any);
+    vi.mocked(prisma.response.groupBy).mockResolvedValue([
+      { surveyId: "s1", _count: { _all: 1 } },
+      { surveyId: "s2", _count: { _all: 2 } },
+    ] as any);
     const surveys = await getSurveys(environmentId);
 
     expect(surveys).toEqual(expectedSurveys);
@@ -274,6 +304,7 @@ describe("getSurveys", () => {
 
   test("should return surveys with limit and offset", async () => {
     vi.mocked(prisma.survey.findMany).mockResolvedValue([mockPrismaSurveys[0]] as any);
+    vi.mocked(prisma.response.groupBy).mockResolvedValue([{ surveyId: "s1", _count: { _all: 1 } }] as any);
     const surveys = await getSurveys(environmentId, 1, 1);
 
     expect(surveys).toEqual([expectedSurveys[0]]);
@@ -291,6 +322,10 @@ describe("getSurveys", () => {
     vi.mocked(buildWhereClause).mockReturnValue({ AND: [{ name: { contains: "Test" } }] }); // Mock correct return type
     vi.mocked(buildOrderByClause).mockReturnValue([{ createdAt: "desc" }]); // Mock specific return
     vi.mocked(prisma.survey.findMany).mockResolvedValue(mockPrismaSurveys as any);
+    vi.mocked(prisma.response.groupBy).mockResolvedValue([
+      { surveyId: "s1", _count: { _all: 1 } },
+      { surveyId: "s2", _count: { _all: 2 } },
+    ] as any);
 
     const surveys = await getSurveys(environmentId, undefined, undefined, filterCriteria);
 
@@ -328,13 +363,11 @@ describe("getSurveysSortedByRelevance", () => {
     ...mockSurveyPrisma,
     id: "s_inprog",
     status: "inProgress" as any,
-    _count: { responses: 3 },
   };
   const mockOtherPrisma = {
     ...mockSurveyPrisma,
     id: "s_other",
     status: "completed" as any,
-    _count: { responses: 5 },
   };
 
   const expectedInProgressSurvey: TSurvey = {
@@ -367,6 +400,10 @@ describe("getSurveysSortedByRelevance", () => {
     vi.mocked(prisma.survey.findMany)
       .mockResolvedValueOnce([mockInProgressPrisma] as any) // In-progress surveys
       .mockResolvedValueOnce([mockOtherPrisma] as any); // Additional surveys
+    vi.mocked(prisma.response.groupBy).mockResolvedValue([
+      { surveyId: "s_inprog", _count: { _all: 3 } },
+      { surveyId: "s_other", _count: { _all: 5 } },
+    ] as any);
 
     const surveys = await getSurveysSortedByRelevance(environmentId, 2, 0);
 
@@ -394,6 +431,9 @@ describe("getSurveysSortedByRelevance", () => {
   test("should only fetch inProgress surveys if limit is met", async () => {
     vi.mocked(prisma.survey.count).mockResolvedValue(1);
     vi.mocked(prisma.survey.findMany).mockResolvedValueOnce([mockInProgressPrisma] as any);
+    vi.mocked(prisma.response.groupBy).mockResolvedValue([
+      { surveyId: "s_inprog", _count: { _all: 3 } },
+    ] as any);
 
     const surveys = await getSurveysSortedByRelevance(environmentId, 1, 0);
     expect(surveys).toEqual([expectedInProgressSurvey]);
@@ -507,7 +547,7 @@ describe("copySurveyToOtherEnvironment", () => {
     vi.mocked(prisma.survey.create).mockResolvedValue(mockNewSurveyResult as any);
     vi.mocked(prisma.segment.findFirst).mockResolvedValue(null);
     vi.mocked(prisma.actionClass.findMany).mockResolvedValue([]);
-    vi.mocked(prisma.surveyQuota.findMany).mockResolvedValue([]);
+    vi.mocked(getQuotas).mockResolvedValue([]);
     vi.mocked(getOrganizationByEnvironmentId).mockResolvedValue({
       billing: {},
       id: "org_123",
@@ -645,6 +685,12 @@ describe("copySurveyToOtherEnvironment", () => {
     vi.mocked(prisma.survey.create).mockResolvedValue(mockNewSurveyResult as any);
     vi.mocked(prisma.segment.findFirst).mockResolvedValue(null); // No existing public segment with same title in target
     vi.mocked(prisma.actionClass.findMany).mockResolvedValue([]);
+    vi.mocked(getQuotas).mockResolvedValue([]);
+    vi.mocked(getIsQuotasEnabled).mockResolvedValue(true);
+    vi.mocked(getOrganizationByEnvironmentId).mockResolvedValue({
+      billing: {},
+      id: "org_123",
+    } as any);
 
     // Case 2: Different environment, segment with same title does not exist in target
     await copySurveyToOtherEnvironment(environmentId, surveyId, targetEnvironmentId, userId);
@@ -679,6 +725,12 @@ describe("copySurveyToOtherEnvironment", () => {
     vi.mocked(prisma.survey.create).mockResolvedValue(mockNewSurveyResult as any);
     vi.mocked(prisma.segment.findFirst).mockResolvedValue({ id: "existing_target_seg" } as any); // Segment with same title EXISTS
     vi.mocked(prisma.actionClass.findMany).mockResolvedValue([]);
+    vi.mocked(getQuotas).mockResolvedValue([]);
+    vi.mocked(getIsQuotasEnabled).mockResolvedValue(true);
+    vi.mocked(getOrganizationByEnvironmentId).mockResolvedValue({
+      billing: {},
+      id: "org_123",
+    } as any);
     const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(1234567890);
 
     await copySurveyToOtherEnvironment(environmentId, surveyId, targetEnvironmentId, userId);

--- a/apps/web/modules/survey/list/lib/survey.test.ts
+++ b/apps/web/modules/survey/list/lib/survey.test.ts
@@ -240,6 +240,15 @@ describe("getSurvey", () => {
     expect(logger.error).toHaveBeenCalledWith(prismaError, "Error getting survey");
   });
 
+  test("should throw DatabaseError when response count lookup fails", async () => {
+    const prismaError = makePrismaKnownError();
+    vi.mocked(prisma.survey.findUnique).mockResolvedValue({ ...mockSurveyPrisma } as any);
+    vi.mocked(prisma.response.groupBy).mockRejectedValue(prismaError);
+
+    await expect(getSurvey(surveyId)).rejects.toThrow(DatabaseError);
+    expect(logger.error).toHaveBeenCalledWith(prismaError, "Error getting survey");
+  });
+
   test("should rethrow unknown error", async () => {
     const unknownError = new Error("Unknown error");
     vi.mocked(prisma.survey.findUnique).mockRejectedValue(unknownError);

--- a/apps/web/modules/survey/list/lib/survey.ts
+++ b/apps/web/modules/survey/list/lib/survey.ts
@@ -136,14 +136,21 @@ export const getSurveysSortedByRelevance = reactCache(
 );
 
 export const getSurvey = reactCache(async (surveyId: string): Promise<TSurvey | null> => {
-  let surveyPrisma;
   try {
-    surveyPrisma = await prisma.survey.findUnique({
+    const surveyPrisma = await prisma.survey.findUnique({
       where: {
         id: surveyId,
       },
       select: surveySelect,
     });
+
+    if (!surveyPrisma) {
+      return null;
+    }
+
+    const responseCountsBySurveyId = await getResponseCountsBySurveyIds([surveyPrisma.id]);
+
+    return mapSurveyRowToSurvey(surveyPrisma, responseCountsBySurveyId.get(surveyPrisma.id) ?? 0);
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       logger.error(error, "Error getting survey");
@@ -151,14 +158,6 @@ export const getSurvey = reactCache(async (surveyId: string): Promise<TSurvey | 
     }
     throw error;
   }
-
-  if (!surveyPrisma) {
-    return null;
-  }
-
-  const responseCountsBySurveyId = await getResponseCountsBySurveyIds([surveyPrisma.id]);
-
-  return mapSurveyRowToSurvey(surveyPrisma, responseCountsBySurveyId.get(surveyPrisma.id) ?? 0);
 });
 
 const getExistingSurvey = async (surveyId: string) => {

--- a/apps/web/modules/survey/list/lib/survey.ts
+++ b/apps/web/modules/survey/list/lib/survey.ts
@@ -17,7 +17,13 @@ import { buildOrderByClause, buildWhereClause } from "@/modules/survey/lib/utils
 import { doesEnvironmentExist } from "@/modules/survey/list/lib/environment";
 import { getProjectWithLanguagesByEnvironmentId } from "@/modules/survey/list/lib/project";
 import { TProjectWithLanguages, TSurvey } from "@/modules/survey/list/types/surveys";
-import { mapSurveyRowToSurvey, mapSurveyRowsToSurveys, surveySelect } from "./survey-record";
+import {
+  type TSurveyRow,
+  getResponseCountsBySurveyIds,
+  mapSurveyRowToSurvey,
+  mapSurveyRowsToSurveys,
+  surveySelect,
+} from "./survey-record";
 
 export const getSurveys = reactCache(
   async (
@@ -44,7 +50,11 @@ export const getSurveys = reactCache(
         skip: offset,
       });
 
-      return mapSurveyRowsToSurveys(surveysPrisma);
+      const responseCountsBySurveyId = await getResponseCountsBySurveyIds(
+        surveysPrisma.map((survey) => survey.id)
+      );
+
+      return mapSurveyRowsToSurveys(surveysPrisma, responseCountsBySurveyId);
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         logger.error(error, "Error getting surveys");
@@ -63,7 +73,7 @@ export const getSurveysSortedByRelevance = reactCache(
     filterCriteria?: TSurveyFilterCriteria
   ): Promise<TSurvey[]> => {
     try {
-      let surveys: TSurvey[] = [];
+      let surveyRows: TSurveyRow[] = [];
 
       const inProgressSurveyCount = await prisma.survey.count({
         where: {
@@ -89,7 +99,7 @@ export const getSurveysSortedByRelevance = reactCache(
               skip: offset,
             });
 
-      surveys = mapSurveyRowsToSurveys(inProgressSurveys);
+      surveyRows = inProgressSurveys;
 
       // Determine if additional surveys are needed
       if (offset !== undefined && limit && inProgressSurveys.length < limit) {
@@ -107,10 +117,14 @@ export const getSurveysSortedByRelevance = reactCache(
           skip: newOffset,
         });
 
-        surveys = [...surveys, ...mapSurveyRowsToSurveys(additionalSurveys)];
+        surveyRows = [...surveyRows, ...additionalSurveys];
       }
 
-      return surveys;
+      const responseCountsBySurveyId = await getResponseCountsBySurveyIds(
+        surveyRows.map((survey) => survey.id)
+      );
+
+      return mapSurveyRowsToSurveys(surveyRows, responseCountsBySurveyId);
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         logger.error(error, "Error getting surveys sorted by relevance");
@@ -142,7 +156,9 @@ export const getSurvey = reactCache(async (surveyId: string): Promise<TSurvey | 
     return null;
   }
 
-  return mapSurveyRowToSurvey(surveyPrisma);
+  const responseCountsBySurveyId = await getResponseCountsBySurveyIds([surveyPrisma.id]);
+
+  return mapSurveyRowToSurvey(surveyPrisma, responseCountsBySurveyId.get(surveyPrisma.id) ?? 0);
 });
 
 const getExistingSurvey = async (surveyId: string) => {

--- a/apps/web/modules/survey/list/lib/v3-surveys-client.test.ts
+++ b/apps/web/modules/survey/list/lib/v3-surveys-client.test.ts
@@ -19,4 +19,23 @@ describe("buildSurveyListSearchParams", () => {
       "workspaceId=env_1&limit=20&sortBy=relevance&cursor=cursor_1&filter%5Bname%5D%5Bcontains%5D=Product+feedback&filter%5Bstatus%5D%5Bin%5D=draft&filter%5Bstatus%5D%5Bin%5D=paused&filter%5Btype%5D%5Bin%5D=app&filter%5Btype%5D%5Bin%5D=link"
     );
   });
+
+  test("emits includeTotalCount=false when requested", () => {
+    const searchParams = buildSurveyListSearchParams({
+      workspaceId: "env_1",
+      limit: 20,
+      cursor: "cursor_1",
+      includeTotalCount: false,
+      filters: {
+        name: "",
+        status: [],
+        type: [],
+        sortBy: "relevance",
+      },
+    });
+
+    expect(searchParams.toString()).toBe(
+      "workspaceId=env_1&limit=20&sortBy=relevance&cursor=cursor_1&includeTotalCount=false"
+    );
+  });
 });

--- a/apps/web/modules/survey/list/lib/v3-surveys-client.ts
+++ b/apps/web/modules/survey/list/lib/v3-surveys-client.ts
@@ -23,7 +23,7 @@ export type TSurveyListPage = {
   meta: {
     limit: number;
     nextCursor: string | null;
-    totalCount: number;
+    totalCount: number | null;
   };
 };
 
@@ -39,11 +39,13 @@ export function buildSurveyListSearchParams({
   workspaceId,
   limit,
   cursor,
+  includeTotalCount,
   filters,
 }: {
   workspaceId: string;
   limit: number;
   cursor?: string | null;
+  includeTotalCount?: boolean;
   filters: TSurveyOverviewFilters;
 }): URLSearchParams {
   const normalizedFilters = normalizeSurveyFilters(filters);
@@ -55,6 +57,10 @@ export function buildSurveyListSearchParams({
 
   if (cursor) {
     searchParams.set("cursor", cursor);
+  }
+
+  if (includeTotalCount === false) {
+    searchParams.set("includeTotalCount", "false");
   }
 
   if (normalizedFilters.name) {
@@ -76,17 +82,25 @@ export async function listSurveys({
   workspaceId,
   limit,
   cursor,
+  includeTotalCount,
   filters,
   signal,
 }: {
   workspaceId: string;
   limit: number;
   cursor?: string | null;
+  includeTotalCount?: boolean;
   filters: TSurveyOverviewFilters;
   signal?: AbortSignal;
 }): Promise<TSurveyListPage> {
   const response = await fetch(
-    `/api/v3/surveys?${buildSurveyListSearchParams({ workspaceId, limit, cursor, filters }).toString()}`,
+    `/api/v3/surveys?${buildSurveyListSearchParams({
+      workspaceId,
+      limit,
+      cursor,
+      includeTotalCount,
+      filters,
+    }).toString()}`,
     {
       method: "GET",
       cache: "no-store",

--- a/docker/rustfs-init.sh
+++ b/docker/rustfs-init.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# Shared RustFS bootstrap script.
+# Used directly by docker-compose.dev.yml for local development and used as the
+# source template for the generated rustfs-init.sh in docker/formbricks.sh for
+# one-click/self-hosted installs. packages/storage/src/rustfs-init-bootstrap.test.ts
+# also validates that the generated script stays in sync with this file.
+set -e
+
+rustfs_endpoint_url="${RUSTFS_ENDPOINT_URL:-http://rustfs:9000}"
+
+echo '⏳ Waiting for RustFS to be ready...'
+attempts=0
+max_attempts=30
+until mc alias set rustfs "$rustfs_endpoint_url" "$RUSTFS_ADMIN_USER" "$RUSTFS_ADMIN_PASSWORD" >/dev/null 2>&1 \
+  && mc ls rustfs >/dev/null 2>&1; do
+  attempts=$((attempts + 1))
+  if [ $attempts -ge $max_attempts ]; then
+    printf '❌ Failed to connect to RustFS after %s attempts\n' $max_attempts
+    exit 1
+  fi
+  printf '...still waiting attempt %s/%s\n' $attempts $max_attempts
+  sleep 2
+done
+echo '🔗 RustFS reachable; alias configured.'
+
+echo '🪣 Creating bucket (idempotent)...'
+mc mb rustfs/$RUSTFS_BUCKET_NAME --ignore-existing
+
+if [ -n "${RUSTFS_CORS_ALLOWED_ORIGINS:-}" ]; then
+  echo '🌐 Applying bucket CORS configuration...'
+  cors_file="/tmp/formbricks-cors.xml"
+
+  cat > "$cors_file" << EOF
+<CORSConfiguration>
+  <CORSRule>
+EOF
+
+  old_ifs=$IFS
+  IFS=','
+  for origin in $RUSTFS_CORS_ALLOWED_ORIGINS; do
+    trimmed_origin=$(printf '%s' "$origin" | tr -d '[:space:]')
+    if [ -n "$trimmed_origin" ]; then
+      printf '    <AllowedOrigin>%s</AllowedOrigin>\n' "$trimmed_origin" >> "$cors_file"
+    fi
+  done
+  IFS=$old_ifs
+
+  cat >> "$cors_file" << EOF
+    <AllowedMethod>GET</AllowedMethod>
+    <AllowedMethod>HEAD</AllowedMethod>
+    <AllowedMethod>POST</AllowedMethod>
+    <AllowedMethod>PUT</AllowedMethod>
+    <AllowedMethod>DELETE</AllowedMethod>
+    <AllowedHeader>*</AllowedHeader>
+    <ExposeHeader>ETag</ExposeHeader>
+    <MaxAgeSeconds>3000</MaxAgeSeconds>
+  </CORSRule>
+</CORSConfiguration>
+EOF
+
+  mc cors set rustfs/$RUSTFS_BUCKET_NAME "$cors_file"
+  echo 'CORS configuration applied successfully.'
+fi
+
+echo '📄 Creating JSON policy file...'
+cat > /tmp/formbricks-policy.json << EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:DeleteObject", "s3:GetObject", "s3:PutObject"],
+      "Resource": ["arn:aws:s3:::$RUSTFS_BUCKET_NAME/*"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::$RUSTFS_BUCKET_NAME"]
+    }
+  ]
+}
+EOF
+
+echo '🔒 Creating policy (idempotent)...'
+if ! mc admin policy info rustfs "$RUSTFS_POLICY_NAME" >/dev/null 2>&1; then
+  mc admin policy create rustfs "$RUSTFS_POLICY_NAME" /tmp/formbricks-policy.json || \
+    mc admin policy add rustfs "$RUSTFS_POLICY_NAME" /tmp/formbricks-policy.json
+  echo 'Policy created successfully.'
+else
+  echo 'Policy already exists, skipping creation.'
+fi
+
+echo '👤 Creating service user (idempotent)...'
+if ! mc admin user info rustfs "$RUSTFS_SERVICE_USER" >/dev/null 2>&1; then
+  mc admin user add rustfs "$RUSTFS_SERVICE_USER" "$RUSTFS_SERVICE_PASSWORD"
+  echo 'User created successfully.'
+else
+  echo 'User already exists, skipping creation.'
+fi
+
+echo '🔗 Attaching policy to user (idempotent)...'
+mc admin policy attach rustfs "$RUSTFS_POLICY_NAME" --user "$RUSTFS_SERVICE_USER"
+
+echo '✅ RustFS setup complete!'

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -74,6 +74,13 @@ paths:
           description: |
             Opaque cursor returned as `meta.nextCursor` from the previous page. Omit on the first request.
         - in: query
+          name: includeTotalCount
+          schema:
+            type: boolean
+            default: true
+          description: |
+            Whether to calculate `meta.totalCount` for this request. Set to `false` on cursor-pagination follow-up requests to skip the extra count query; in that case `meta.totalCount` is `null`.
+        - in: query
           name: filter[name][contains]
           schema:
             type: string
@@ -137,8 +144,9 @@ paths:
                         description: Opaque cursor for the next page. `null` when there are no more results.
                       totalCount:
                         type: integer
+                        nullable: true
                         minimum: 0
-                        description: Total number of surveys matching the current filters across all pages.
+                        description: Total number of surveys matching the current filters across all pages. `null` when `includeTotalCount=false`.
         "400":
           description: Bad Request
           content:


### PR DESCRIPTION
## What changed
- batch survey response counts for overview pages instead of asking Prisma for per-row response counts in the list query
- skip `totalCount` recomputation on cursor-based v3 survey pagination requests and only fetch it on the first page
- add coverage for the v3 surveys route, query parsing, client pagination params, cache updates, and survey list data layer changes

## Why
The survey overview became slower after the v3 API migration. Initial page load and `Load more` requests were both paying extra query cost in the new path.

## Impact
- reduces database work for the initial survey overview page
- removes a redundant count query from each `Load more` request
- keeps the existing UI behavior, with the list reading `totalCount` from the first page only

## Root cause
The v3 survey overview path added an extra `totalCount` query on every paginated request, while the survey list path was still doing expensive response counting work for every page of results.

## Validation
- `pnpm exec vitest run app/api/v3/surveys/parse-v3-surveys-list-query.test.ts app/api/v3/surveys/route.test.ts modules/survey/list/lib/v3-surveys-client.test.ts modules/survey/list/lib/query.test.ts modules/survey/list/hooks/use-surveys.test.ts`
- `pnpm exec vitest run apps/web/modules/survey/list/lib/survey.test.ts apps/web/modules/survey/list/lib/survey-page.test.ts`
- `pnpm exec eslint app/api/v3/surveys/parse-v3-surveys-list-query.ts app/api/v3/surveys/parse-v3-surveys-list-query.test.ts app/api/v3/surveys/route.ts app/api/v3/surveys/route.test.ts modules/survey/list/lib/v3-surveys-client.ts modules/survey/list/lib/v3-surveys-client.test.ts modules/survey/list/hooks/use-surveys.ts modules/survey/list/hooks/use-surveys.test.ts modules/survey/list/lib/query.ts modules/survey/list/lib/query.test.ts`
- `pnpm exec eslint apps/web/modules/survey/list/lib/survey.ts apps/web/modules/survey/list/lib/survey-page.ts apps/web/modules/survey/list/lib/survey-record.ts apps/web/modules/survey/list/lib/survey.test.ts apps/web/modules/survey/list/lib/survey-page.test.ts`