### PR TITLE
refactor: align connector enum with formbricks_survey

### DIFF
--- a/apps/web/lib/connector/actions.ts
+++ b/apps/web/lib/connector/actions.ts
@@ -108,7 +108,7 @@ const resolveFormbricksMappingsInput = async (
   const allMappings = await Promise.all(
     entries.map(({ surveyId, elementIds }) => resolveSurveyMappings(surveyId, elementIds))
   );
-  return { type: "formbricks", mappings: allMappings.flat() };
+  return { type: "formbricks_survey", mappings: allMappings.flat() };
 };
 
 const ZFormbricksSurveyMapping = z.object({
@@ -124,7 +124,7 @@ const ZCreateConnectorWithMappingsAction = z
     fieldMappings: z.array(ZConnectorFieldMappingCreateInput).optional(),
   })
   .superRefine((data, ctx) => {
-    if (data.connectorInput.type === "formbricks") {
+    if (data.connectorInput.type === "formbricks_survey") {
       if (!data.formbricksMappings?.length) {
         ctx.addIssue({
           code: "custom",
@@ -298,9 +298,9 @@ export const duplicateConnectorAction = authenticatedActionClient
 
       let mappingsInput: TMappingsInput | undefined;
 
-      if (source.type === "formbricks" && source.formbricksMappings.length > 0) {
+      if (source.type === "formbricks_survey" && source.formbricksMappings.length > 0) {
         mappingsInput = {
-          type: "formbricks",
+          type: "formbricks_survey",
           mappings: source.formbricksMappings.map((m) => ({
             surveyId: m.surveyId,
             elementId: m.elementId,

--- a/apps/web/lib/connector/csv-import.test.ts
+++ b/apps/web/lib/connector/csv-import.test.ts
@@ -57,7 +57,7 @@ describe("importCsvData", () => {
   });
 
   test("throws InvalidInputError for non-csv connector", async () => {
-    const connector = makeConnector({ type: "formbricks" });
+    const connector = makeConnector({ type: "formbricks_survey" });
     await expect(importCsvData(connector, [])).rejects.toThrow(InvalidInputError);
   });
 

--- a/apps/web/lib/connector/import.test.ts
+++ b/apps/web/lib/connector/import.test.ts
@@ -30,7 +30,7 @@ const mockConnector: TConnectorWithMappings = {
   createdAt: NOW,
   updatedAt: NOW,
   name: "Test Connector",
-  type: "formbricks",
+  type: "formbricks_survey",
   status: "active",
   workspaceId: ENV_ID,
   lastSyncAt: null,

--- a/apps/web/lib/connector/import.ts
+++ b/apps/web/lib/connector/import.ts
@@ -37,7 +37,7 @@ export const importHistoricalResponses = async (
   connector: TConnectorWithMappings,
   survey: TSurvey
 ): Promise<TImportResult> => {
-  if (connector.type !== "formbricks") {
+  if (connector.type !== "formbricks_survey") {
     throw new InvalidInputError("Historical import is only supported for Formbricks connectors");
   }
 

--- a/apps/web/lib/connector/pipeline-handler.test.ts
+++ b/apps/web/lib/connector/pipeline-handler.test.ts
@@ -53,7 +53,7 @@ function createConnector(
     createdAt: new Date(),
     updatedAt: new Date(),
     name: "Test Connector",
-    type: "formbricks",
+    type: "formbricks_survey",
     status: "active",
     workspaceId: "env-1",
     feedbackRecordDirectoryId: "frd-1",
@@ -79,7 +79,7 @@ const oneFeedbackRecord = [
   {
     field_id: "el-1",
     field_type: "rating" as const,
-    source_type: "formbricks",
+    source_type: "formbricks_survey",
     source_id: "survey-1",
     source_name: "Test Survey",
     field_label: "Question?",

--- a/apps/web/lib/connector/service.test.ts
+++ b/apps/web/lib/connector/service.test.ts
@@ -47,7 +47,7 @@ const mockConnector = {
   createdAt: NOW,
   updatedAt: NOW,
   name: "Test Connector",
-  type: "formbricks" as const,
+  type: "formbricks_survey" as const,
   status: "active" as const,
   workspaceId: ENV_ID,
   lastSyncAt: null,
@@ -144,7 +144,7 @@ describe("getConnectorsBySurveyId", () => {
     expect(prisma.connector.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: {
-          type: "formbricks",
+          type: "formbricks_survey",
           status: "active",
           formbricksMappings: { some: { surveyId: SURVEY_ID } },
         },
@@ -303,13 +303,18 @@ describe("createConnectorWithMappings", () => {
 
     const result = await createConnectorWithMappings(ENV_ID, {
       name: "New",
-      type: "formbricks",
+      type: "formbricks_survey",
       feedbackRecordDirectoryId: FRD_ID,
     });
 
     expect(tx.connector.create).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: { name: "New", type: "formbricks", workspaceId: ENV_ID, feedbackRecordDirectoryId: FRD_ID },
+        data: {
+          name: "New",
+          type: "formbricks_survey",
+          workspaceId: ENV_ID,
+          feedbackRecordDirectoryId: FRD_ID,
+        },
       })
     );
     expect(tx.connectorFormbricksMapping.create).not.toHaveBeenCalled();
@@ -325,9 +330,9 @@ describe("createConnectorWithMappings", () => {
 
     await createConnectorWithMappings(
       ENV_ID,
-      { name: "FB", type: "formbricks", feedbackRecordDirectoryId: FRD_ID },
+      { name: "FB", type: "formbricks_survey", feedbackRecordDirectoryId: FRD_ID },
       {
-        type: "formbricks",
+        type: "formbricks_survey",
         mappings: [
           { surveyId: SURVEY_ID, elementId: "el-1", hubFieldType: "text" },
           { surveyId: SURVEY_ID, elementId: "el-2", hubFieldType: "nps" },
@@ -392,7 +397,7 @@ describe("createConnectorWithMappings", () => {
     await expect(
       createConnectorWithMappings(ENV_ID, {
         name: "Dup",
-        type: "formbricks",
+        type: "formbricks_survey",
         feedbackRecordDirectoryId: FRD_ID,
       })
     ).rejects.toThrow(InvalidInputError);
@@ -470,7 +475,7 @@ describe("updateConnectorWithMappings", () => {
       ENV_ID,
       { name: "Updated" },
       {
-        type: "formbricks",
+        type: "formbricks_survey",
         mappings: [{ surveyId: SURVEY_ID, elementId: "el-new", hubFieldType: "nps" }],
       }
     );

--- a/apps/web/lib/connector/service.ts
+++ b/apps/web/lib/connector/service.ts
@@ -132,7 +132,7 @@ export const getConnectorsBySurveyId = reactCache(
     try {
       const connectors = await prisma.connector.findMany({
         where: {
-          type: "formbricks",
+          type: "formbricks_survey",
           status: "active",
           formbricksMappings: {
             some: {
@@ -213,7 +213,7 @@ export const deleteConnector = async (connectorId: string, workspaceId: string):
 // -- Composite functions --
 
 export type TFormbricksMappingsInput = {
-  type: "formbricks";
+  type: "formbricks_survey";
   mappings: TConnectorFormbricksMappingCreateInput[];
 };
 
@@ -243,7 +243,7 @@ export const createConnectorWithMappings = async (
         },
       });
 
-      if (mappingsInput?.type === "formbricks") {
+      if (mappingsInput?.type === "formbricks_survey") {
         await Promise.all(
           mappingsInput.mappings.map((mapping) =>
             tx.connectorFormbricksMapping.create({
@@ -311,7 +311,7 @@ export const updateConnectorWithMappings = async (
         },
       });
 
-      if (mappingsInput?.type === "formbricks") {
+      if (mappingsInput?.type === "formbricks_survey") {
         await tx.connectorFormbricksMapping.deleteMany({
           where: { connectorId, workspaceId },
         });

--- a/apps/web/lib/connector/transform.test.ts
+++ b/apps/web/lib/connector/transform.test.ts
@@ -123,7 +123,7 @@ describe("transformResponseToFeedbackRecords", () => {
     const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
-      source_type: "formbricks",
+      source_type: "formbricks_survey",
       field_id: "el-text",
       field_type: "text",
       field_label: "How can we improve?",

--- a/apps/web/lib/connector/transform.ts
+++ b/apps/web/lib/connector/transform.ts
@@ -117,7 +117,7 @@ export function transformResponseToFeedbackRecords(
 
     const feedbackRecord = {
       collected_at: getCollectedAt(response),
-      source_type: "formbricks",
+      source_type: "formbricks_survey",
       submission_id: response.id,
       tenant_id: tenantId,
       field_id: mapping.elementId,

--- a/packages/database/migration/20260422000000_rename_formbricks_connector_type/migration.sql
+++ b/packages/database/migration/20260422000000_rename_formbricks_connector_type/migration.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."ConnectorType" RENAME VALUE 'formbricks' TO 'formbricks_survey';

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -1144,7 +1144,7 @@ model DashboardWidget {
 }
 
 enum ConnectorType {
-  formbricks
+  formbricks_survey
   csv
 }
 
@@ -1171,7 +1171,7 @@ enum HubFieldType {
 ///
 /// @property id - Unique identifier for the connector
 /// @property name - Display name for the connector
-/// @property type - Type of connector (formbricks, webhook, csv, email, slack)
+/// @property type - Type of connector (formbricks_survey, webhook, csv, email, slack)
 /// @property status - Current state of the connector (active, paused)
 /// @property environment - The environment this connector belongs to
 /// @property config - Type-specific configuration (e.g., webhook secret, S3 config)

--- a/packages/types/connector.ts
+++ b/packages/types/connector.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { TSurveyElementTypeEnum } from "./surveys/constants";
 
 // Connector type enum
-export const ZConnectorType = z.enum(["formbricks", "csv"]);
+export const ZConnectorType = z.enum(["formbricks_survey", "csv"]);
 export type TConnectorType = z.infer<typeof ZConnectorType>;
 
 // Connector status enum


### PR DESCRIPTION
## Summary
- rename connector enum usage from `formbricks` to `formbricks_survey`
- align Prisma schema, migration, connector services, and shared connector types
- update connector tests for the renamed enum contract

## Test plan
- [x] `pnpm --filter @formbricks/web test -- apps/web/lib/connector/csv-import.test.ts apps/web/lib/connector/import.test.ts apps/web/lib/connector/pipeline-handler.test.ts apps/web/lib/connector/service.test.ts apps/web/lib/connector/transform.test.ts`

Made with [Cursor](https://cursor.com)