### PR TITLE
feat: integrate hub feedback records into unify workspace

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/unify/feedback-records/actions.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/unify/feedback-records/actions.ts
@@ -1,0 +1,197 @@
+"use server";
+
+import { z } from "zod";
+import { ZId } from "@formbricks/types/common";
+import { AuthorizationError } from "@formbricks/types/errors";
+import { authenticatedActionClient } from "@/lib/utils/action-client";
+import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
+import { AuthenticatedActionClientCtx } from "@/lib/utils/action-client/types/context";
+import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
+import { getFeedbackRecordDirectoriesByWorkspaceId } from "@/modules/ee/feedback-record-directory/lib/feedback-record-directory";
+import { createFeedbackRecord, retrieveFeedbackRecord, updateFeedbackRecord } from "@/modules/hub/service";
+import type { FeedbackRecordCreateParams, FeedbackRecordUpdateParams } from "@/modules/hub/types";
+
+const ZFeedbackRecordId = z.uuid();
+
+const ZFeedbackRecordFieldType = z.enum([
+  "text",
+  "categorical",
+  "nps",
+  "csat",
+  "ces",
+  "rating",
+  "number",
+  "boolean",
+  "date",
+]);
+
+const ZFeedbackRecordMetadata = z.record(z.string(), z.unknown());
+
+const ZFeedbackRecordCreateInput = z.object({
+  submission_id: z.string().min(1),
+  tenant_id: ZId,
+  source_type: z.string().min(1),
+  field_id: z.string().min(1),
+  field_type: ZFeedbackRecordFieldType,
+  collected_at: z.iso.datetime().optional(),
+  source_id: z.string().optional().nullable(),
+  source_name: z.string().optional().nullable(),
+  field_label: z.string().optional().nullable(),
+  field_group_id: z.string().optional(),
+  field_group_label: z.string().optional().nullable(),
+  value_text: z.string().optional().nullable(),
+  value_number: z.number().optional(),
+  value_boolean: z.boolean().optional(),
+  value_date: z.iso.datetime().optional(),
+  metadata: ZFeedbackRecordMetadata.optional(),
+  language: z.string().optional(),
+  user_identifier: z.string().optional(),
+});
+
+const ZFeedbackRecordUpdateInput = z
+  .object({
+    value_text: z.string().optional().nullable(),
+    value_number: z.number().optional().nullable(),
+    value_boolean: z.boolean().optional().nullable(),
+    value_date: z.iso.datetime().optional().nullable(),
+    language: z.string().optional().nullable(),
+    metadata: ZFeedbackRecordMetadata.optional(),
+    user_identifier: z.string().optional().nullable(),
+  })
+  .refine(
+    (value) => Object.values(value).some((entry) => entry !== undefined),
+    "At least one field must be provided for update"
+  );
+
+const ZRetrieveFeedbackRecordAction = z.object({
+  workspaceId: ZId,
+  recordId: ZFeedbackRecordId,
+});
+
+const ZCreateFeedbackRecordAction = z.object({
+  workspaceId: ZId,
+  recordInput: ZFeedbackRecordCreateInput,
+});
+
+const ZUpdateFeedbackRecordAction = z.object({
+  workspaceId: ZId,
+  recordId: ZFeedbackRecordId,
+  updateInput: ZFeedbackRecordUpdateInput,
+});
+
+const ensureAccess = async (
+  userId: string,
+  workspaceId: string,
+  minPermission: "read" | "readWrite"
+): Promise<void> => {
+  const organizationId = await getOrganizationIdFromWorkspaceId(workspaceId);
+  await checkAuthorizationUpdated({
+    userId,
+    organizationId,
+    access: [
+      {
+        type: "organization",
+        roles: ["owner", "manager"],
+      },
+      {
+        type: "workspaceTeam",
+        minPermission,
+        workspaceId,
+      },
+    ],
+  });
+};
+
+const getWorkspaceDirectoryIds = async (workspaceId: string): Promise<Set<string>> => {
+  const directories = await getFeedbackRecordDirectoriesByWorkspaceId(workspaceId);
+  return new Set(directories.map((directory) => directory.id));
+};
+
+const assertWorkspaceDirectoryAccess = (directoryIds: Set<string>, tenantId: string): void => {
+  if (!directoryIds.has(tenantId)) {
+    throw new AuthorizationError("Invalid feedback record directory for this workspace");
+  }
+};
+
+export const retrieveFeedbackRecordAction = authenticatedActionClient
+  .inputSchema(ZRetrieveFeedbackRecordAction)
+  .action(
+    async ({
+      ctx,
+      parsedInput,
+    }: {
+      ctx: AuthenticatedActionClientCtx;
+      parsedInput: z.infer<typeof ZRetrieveFeedbackRecordAction>;
+    }) => {
+      await ensureAccess(ctx.user.id, parsedInput.workspaceId, "read");
+
+      const recordResult = await retrieveFeedbackRecord(parsedInput.recordId);
+      if (!recordResult.data || recordResult.error) {
+        throw new Error(recordResult.error?.message || "Failed to retrieve feedback record");
+      }
+
+      const workspaceDirectoryIds = await getWorkspaceDirectoryIds(parsedInput.workspaceId);
+      assertWorkspaceDirectoryAccess(workspaceDirectoryIds, recordResult.data.tenant_id);
+
+      return recordResult.data;
+    }
+  );
+
+export const createFeedbackRecordAction = authenticatedActionClient
+  .inputSchema(ZCreateFeedbackRecordAction)
+  .action(
+    async ({
+      ctx,
+      parsedInput,
+    }: {
+      ctx: AuthenticatedActionClientCtx;
+      parsedInput: z.infer<typeof ZCreateFeedbackRecordAction>;
+    }) => {
+      await ensureAccess(ctx.user.id, parsedInput.workspaceId, "readWrite");
+
+      const workspaceDirectoryIds = await getWorkspaceDirectoryIds(parsedInput.workspaceId);
+      assertWorkspaceDirectoryAccess(workspaceDirectoryIds, parsedInput.recordInput.tenant_id);
+
+      const createResult = await createFeedbackRecord(
+        parsedInput.recordInput as unknown as FeedbackRecordCreateParams
+      );
+      if (!createResult.data || createResult.error) {
+        throw new Error(createResult.error?.message || "Failed to create feedback record");
+      }
+
+      return createResult.data;
+    }
+  );
+
+export const updateFeedbackRecordAction = authenticatedActionClient
+  .inputSchema(ZUpdateFeedbackRecordAction)
+  .action(
+    async ({
+      ctx,
+      parsedInput,
+    }: {
+      ctx: AuthenticatedActionClientCtx;
+      parsedInput: z.infer<typeof ZUpdateFeedbackRecordAction>;
+    }) => {
+      await ensureAccess(ctx.user.id, parsedInput.workspaceId, "readWrite");
+
+      const currentRecordResult = await retrieveFeedbackRecord(parsedInput.recordId);
+      if (!currentRecordResult.data || currentRecordResult.error) {
+        throw new Error(currentRecordResult.error?.message || "Failed to retrieve feedback record");
+      }
+
+      const workspaceDirectoryIds = await getWorkspaceDirectoryIds(parsedInput.workspaceId);
+      assertWorkspaceDirectoryAccess(workspaceDirectoryIds, currentRecordResult.data.tenant_id);
+
+      const updatePayload = Object.fromEntries(
+        Object.entries(parsedInput.updateInput).filter(([, value]) => value !== undefined)
+      ) as unknown as FeedbackRecordUpdateParams;
+
+      const updateResult = await updateFeedbackRecord(parsedInput.recordId, updatePayload);
+      if (!updateResult.data || updateResult.error) {
+        throw new Error(updateResult.error?.message || "Failed to update feedback record");
+      }
+
+      return updateResult.data;
+    }
+  );

--- a/apps/web/app/(app)/workspaces/[workspaceId]/unify/feedback-records/feedback-record-form-drawer.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/unify/feedback-records/feedback-record-form-drawer.tsx
@@ -1,0 +1,988 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { PlusIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { toast } from "react-hot-toast";
+import { useTranslation } from "react-i18next";
+import { v7 as uuidv7 } from "uuid";
+import { z } from "zod";
+import { getFormattedErrorMessage } from "@/lib/utils/helper";
+import type { FeedbackRecordData } from "@/modules/hub/types";
+import { AlertDialog } from "@/modules/ui/components/alert-dialog";
+import { Button } from "@/modules/ui/components/button";
+import {
+  FormControl,
+  FormError,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormProvider,
+} from "@/modules/ui/components/form";
+import { Input } from "@/modules/ui/components/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/modules/ui/components/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/modules/ui/components/sheet";
+import { Switch } from "@/modules/ui/components/switch";
+import {
+  createFeedbackRecordAction,
+  retrieveFeedbackRecordAction,
+  updateFeedbackRecordAction,
+} from "./actions";
+
+type FeedbackRecordDrawerMode = "create" | "edit";
+
+interface FeedbackRecordFormDrawerProps {
+  mode: FeedbackRecordDrawerMode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaceId: string;
+  directories: { id: string; name: string }[];
+  canWrite: boolean;
+  recordId?: string;
+  onSuccess: () => Promise<void> | void;
+}
+
+const FIELD_TYPE_OPTIONS = [
+  "text",
+  "categorical",
+  "nps",
+  "csat",
+  "ces",
+  "rating",
+  "number",
+  "boolean",
+  "date",
+] as const;
+
+const SOURCE_TYPE_PRESET_OPTIONS = [
+  "survey",
+  "review",
+  "feedback_form",
+  "support",
+  "social",
+  "interview",
+  "usability_test",
+  "nps_campaign",
+] as const;
+
+const SOURCE_TYPE_CUSTOM_VALUE = "__custom__";
+
+const ZMetadataEntry = z.object({
+  key: z.string().trim().min(1),
+  value: z.string(),
+});
+
+const ZFeedbackRecordFormValues = z.object({
+  id: z.string().optional(),
+  tenant_id: z.string().min(1),
+  submission_id: z.string().min(1),
+  collected_at: z.string().min(1),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+  source_type: z.string().min(1),
+  source_id: z.string().optional(),
+  source_name: z.string().optional(),
+  field_id: z.string().min(1),
+  field_label: z.string().optional(),
+  field_type: z.enum(FIELD_TYPE_OPTIONS),
+  field_group_id: z.string().optional(),
+  field_group_label: z.string().optional(),
+  value_text: z.string().optional(),
+  value_number: z.string().optional(),
+  value_boolean: z.boolean().optional(),
+  value_date: z.string().optional(),
+  language: z.string().optional(),
+  user_identifier: z.string().optional(),
+  metadataEntries: z.array(ZMetadataEntry),
+});
+
+type TFeedbackRecordFormValues = z.infer<typeof ZFeedbackRecordFormValues>;
+
+const getValueFieldByType = (
+  fieldType: TFeedbackRecordFormValues["field_type"]
+): "value_text" | "value_number" | "value_boolean" | "value_date" => {
+  switch (fieldType) {
+    case "boolean":
+      return "value_boolean";
+    case "date":
+      return "value_date";
+    case "nps":
+    case "csat":
+    case "ces":
+    case "rating":
+    case "number":
+      return "value_number";
+    default:
+      return "value_text";
+  }
+};
+
+const toLocalDateTimeInput = (isoDate: string): string => {
+  const date = new Date(isoDate);
+  if (!Number.isFinite(date.getTime())) {
+    return "";
+  }
+
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+};
+
+const toISOOrUndefined = (dateTimeValue: string | undefined): string | undefined => {
+  if (!dateTimeValue) {
+    return undefined;
+  }
+
+  const parsed = new Date(dateTimeValue);
+  if (!Number.isFinite(parsed.getTime())) {
+    return undefined;
+  }
+
+  return parsed.toISOString();
+};
+
+const getCreateDefaults = (directories: { id: string; name: string }[]): TFeedbackRecordFormValues => {
+  const now = new Date();
+  const defaultDirectoryId = directories[0]?.id ?? "";
+
+  return {
+    id: "",
+    tenant_id: defaultDirectoryId,
+    submission_id: uuidv7(),
+    collected_at: toLocalDateTimeInput(now.toISOString()),
+    created_at: "",
+    updated_at: "",
+    source_type: "survey",
+    source_id: "",
+    source_name: "",
+    field_id: "",
+    field_label: "",
+    field_type: "text",
+    field_group_id: "",
+    field_group_label: "",
+    value_text: "",
+    value_number: "",
+    value_boolean: undefined,
+    value_date: "",
+    language: "",
+    user_identifier: "",
+    metadataEntries: [],
+  };
+};
+
+const mapRecordToValues = (record: FeedbackRecordData): TFeedbackRecordFormValues => {
+  const metadataEntries = Object.entries(record.metadata ?? {})
+    .filter(([, value]) => typeof value === "string")
+    .map(([key, value]) => ({
+      key,
+      value: value as string,
+    }));
+
+  return {
+    id: record.id,
+    tenant_id: record.tenant_id,
+    submission_id: record.submission_id,
+    collected_at: toLocalDateTimeInput(record.collected_at),
+    created_at: record.created_at ? toLocalDateTimeInput(record.created_at) : "",
+    updated_at: record.updated_at ? toLocalDateTimeInput(record.updated_at) : "",
+    source_type: record.source_type,
+    source_id: record.source_id ?? "",
+    source_name: record.source_name ?? "",
+    field_id: record.field_id,
+    field_label: record.field_label ?? "",
+    field_type: record.field_type,
+    field_group_id: record.field_group_id ?? "",
+    field_group_label: record.field_group_label ?? "",
+    value_text: record.value_text ?? "",
+    value_number: record.value_number == null ? "" : String(record.value_number),
+    value_boolean: record.value_boolean,
+    value_date: record.value_date ? toLocalDateTimeInput(record.value_date) : "",
+    language: record.language ?? "",
+    user_identifier: record.user_identifier ?? "",
+    metadataEntries,
+  };
+};
+
+const getReadOnlyMetadataEntries = (record: FeedbackRecordData): { key: string; value: string }[] => {
+  return Object.entries(record.metadata ?? {})
+    .filter(([, value]) => typeof value !== "string")
+    .map(([key, value]) => ({
+      key,
+      value: JSON.stringify(value),
+    }));
+};
+
+const parseNumberValue = (value: string): number | null => {
+  if (value.trim() === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+const formatSourceType = (sourceType: string, t: (key: string) => string): string => {
+  switch (sourceType) {
+    case "formbricks":
+    case "formbricks_survey":
+      return t("workspace.unify.formbricks_surveys");
+    case "csv":
+      return t("workspace.unify.csv_import");
+    default:
+      return sourceType;
+  }
+};
+
+export const FeedbackRecordFormDrawer = ({
+  mode,
+  open,
+  onOpenChange,
+  workspaceId,
+  directories,
+  canWrite,
+  recordId,
+  onSuccess,
+}: Readonly<FeedbackRecordFormDrawerProps>) => {
+  const { t } = useTranslation();
+  const [record, setRecord] = useState<FeedbackRecordData | null>(null);
+  const [isLoadingRecord, setIsLoadingRecord] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDiscardDialogOpen, setIsDiscardDialogOpen] = useState(false);
+
+  const defaultValues = useMemo(() => getCreateDefaults(directories), [directories]);
+
+  const form = useForm<TFeedbackRecordFormValues>({
+    resolver: zodResolver(ZFeedbackRecordFormValues),
+    defaultValues,
+  });
+
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: "metadataEntries",
+  });
+
+  const fieldType = form.watch("field_type");
+  const selectedValueField = getValueFieldByType(fieldType);
+  const isEditMode = mode === "edit";
+  const isReadOnly = isEditMode && !canWrite;
+
+  const [sourceTypeMode, setSourceTypeMode] = useState<string>("survey");
+  const [customSourceType, setCustomSourceType] = useState("");
+
+  const readOnlyMetadataEntries = useMemo(() => (record ? getReadOnlyMetadataEntries(record) : []), [record]);
+
+  const resetForCreate = useCallback(() => {
+    const nextDefaults = getCreateDefaults(directories);
+    form.reset(nextDefaults);
+    setRecord(null);
+    setSourceTypeMode(nextDefaults.source_type);
+    setCustomSourceType("");
+  }, [directories, form]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    if (mode === "create") {
+      resetForCreate();
+      return;
+    }
+
+    if (!recordId) return;
+
+    const loadRecord = async () => {
+      setIsLoadingRecord(true);
+      const result = await retrieveFeedbackRecordAction({ workspaceId, recordId });
+
+      if (!result?.data) {
+        toast.error(getFormattedErrorMessage(result) || t("workspace.unify.failed_to_load_feedback_records"));
+        setIsLoadingRecord(false);
+        return;
+      }
+
+      setRecord(result.data);
+      form.reset(mapRecordToValues(result.data));
+      setSourceTypeMode(
+        SOURCE_TYPE_PRESET_OPTIONS.includes(result.data.source_type as never)
+          ? result.data.source_type
+          : SOURCE_TYPE_CUSTOM_VALUE
+      );
+      setCustomSourceType(
+        SOURCE_TYPE_PRESET_OPTIONS.includes(result.data.source_type as never) ? "" : result.data.source_type
+      );
+      setIsLoadingRecord(false);
+    };
+
+    void loadRecord();
+  }, [form, mode, open, recordId, resetForCreate, t, workspaceId]);
+
+  const requestClose = useCallback(() => {
+    if (form.formState.isDirty && !isSubmitting) {
+      setIsDiscardDialogOpen(true);
+      return;
+    }
+
+    onOpenChange(false);
+  }, [form.formState.isDirty, isSubmitting, onOpenChange]);
+
+  const handleDrawerOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        onOpenChange(true);
+        return;
+      }
+
+      requestClose();
+    },
+    [onOpenChange, requestClose]
+  );
+
+  const handleDiscardChanges = () => {
+    setIsDiscardDialogOpen(false);
+    onOpenChange(false);
+  };
+
+  const setStrictValueValidationError = (message: string) => {
+    form.setError(selectedValueField, { type: "manual", message });
+  };
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    form.clearErrors();
+
+    if (mode === "create") {
+      const requiredValueError = t("workspace.unify.feedback_record_value_required");
+      if (selectedValueField === "value_text" && !values.value_text?.trim()) {
+        setStrictValueValidationError(requiredValueError);
+        return;
+      }
+      if (selectedValueField === "value_number" && parseNumberValue(values.value_number ?? "") == null) {
+        setStrictValueValidationError(requiredValueError);
+        return;
+      }
+      if (selectedValueField === "value_boolean" && values.value_boolean === undefined) {
+        setStrictValueValidationError(requiredValueError);
+        return;
+      }
+      if (selectedValueField === "value_date" && !toISOOrUndefined(values.value_date)) {
+        setStrictValueValidationError(requiredValueError);
+        return;
+      }
+    }
+
+    const metadata = Object.fromEntries(
+      values.metadataEntries
+        .map((entry) => ({
+          key: entry.key.trim(),
+          value: entry.value,
+        }))
+        .filter((entry) => entry.key.length > 0)
+        .map((entry) => [entry.key, entry.value])
+    );
+
+    setIsSubmitting(true);
+
+    try {
+      if (mode === "create") {
+        const sourceTypeValue =
+          sourceTypeMode === SOURCE_TYPE_CUSTOM_VALUE ? customSourceType.trim() : values.source_type;
+
+        const createResult = await createFeedbackRecordAction({
+          workspaceId,
+          recordInput: {
+            submission_id: values.submission_id.trim(),
+            tenant_id: values.tenant_id,
+            source_type: sourceTypeValue,
+            source_id: values.source_id?.trim() ? values.source_id.trim() : null,
+            source_name: values.source_name?.trim() ? values.source_name.trim() : null,
+            field_id: values.field_id.trim(),
+            field_label: values.field_label?.trim() ? values.field_label.trim() : null,
+            field_type: values.field_type,
+            field_group_id: values.field_group_id?.trim() || undefined,
+            field_group_label: values.field_group_label?.trim() ? values.field_group_label.trim() : null,
+            collected_at: toISOOrUndefined(values.collected_at),
+            value_text: selectedValueField === "value_text" ? (values.value_text ?? "") : null,
+            value_number:
+              selectedValueField === "value_number"
+                ? (parseNumberValue(values.value_number ?? "") ?? undefined)
+                : undefined,
+            value_boolean: selectedValueField === "value_boolean" ? values.value_boolean : undefined,
+            value_date: selectedValueField === "value_date" ? toISOOrUndefined(values.value_date) : undefined,
+            metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+            language: values.language?.trim() || undefined,
+            user_identifier: values.user_identifier?.trim() || undefined,
+          },
+        });
+
+        if (!createResult?.data) {
+          toast.error(getFormattedErrorMessage(createResult));
+          setIsSubmitting(false);
+          return;
+        }
+      } else {
+        if (!recordId) {
+          setIsSubmitting(false);
+          return;
+        }
+
+        const preservedMetadata = Object.fromEntries(
+          Object.entries(record?.metadata ?? {}).filter(([, value]) => typeof value !== "string")
+        );
+
+        const updatePayload: Record<string, unknown> = {
+          language: values.language?.trim() || null,
+          user_identifier: values.user_identifier?.trim() || null,
+          metadata: { ...preservedMetadata, ...metadata },
+        };
+
+        if (selectedValueField === "value_text") {
+          updatePayload.value_text = values.value_text?.trim() ?? "";
+        } else if (selectedValueField === "value_number") {
+          updatePayload.value_number = parseNumberValue(values.value_number ?? "");
+        } else if (selectedValueField === "value_boolean") {
+          updatePayload.value_boolean = values.value_boolean ?? null;
+        } else if (selectedValueField === "value_date") {
+          updatePayload.value_date = toISOOrUndefined(values.value_date) ?? null;
+        }
+
+        const updateResult = await updateFeedbackRecordAction({
+          workspaceId,
+          recordId,
+          updateInput: updatePayload as never,
+        });
+
+        if (!updateResult?.data) {
+          toast.error(getFormattedErrorMessage(updateResult));
+          setIsSubmitting(false);
+          return;
+        }
+      }
+
+      toast.success(
+        mode === "create"
+          ? t("workspace.unify.feedback_record_created_successfully")
+          : t("workspace.unify.feedback_record_updated_successfully")
+      );
+      await onSuccess();
+      onOpenChange(false);
+    } finally {
+      setIsSubmitting(false);
+    }
+  });
+
+  const drawerTitle =
+    mode === "create"
+      ? t("workspace.unify.add_feedback_record")
+      : t("workspace.unify.feedback_record_details");
+
+  const drawerDescription =
+    mode === "create"
+      ? t("workspace.unify.add_feedback_record_description")
+      : t("workspace.unify.feedback_record_details_description");
+
+  const valueBooleanStatus = form.watch("value_boolean");
+  let valueBooleanLabel = t("common.not_set");
+  if (valueBooleanStatus === true) {
+    valueBooleanLabel = t("common.yes");
+  } else if (valueBooleanStatus === false) {
+    valueBooleanLabel = t("common.no");
+  }
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={handleDrawerOpenChange}>
+        <SheetContent className="w-full overflow-y-auto bg-white px-5 sm:max-w-2xl">
+          <SheetHeader>
+            <SheetTitle>{drawerTitle}</SheetTitle>
+            <SheetDescription>{drawerDescription}</SheetDescription>
+          </SheetHeader>
+
+          {isLoadingRecord ? (
+            <div className="py-8 text-sm text-slate-500">{t("common.loading")}</div>
+          ) : (
+            <FormProvider {...form}>
+              <form className="space-y-4 py-4" onSubmit={handleSubmit}>
+                <div className="grid grid-cols-2 gap-3">
+                  <FormField
+                    control={form.control}
+                    name="id"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("common.id")}</FormLabel>
+                        <FormControl>
+                          <Input {...field} disabled placeholder={t("workspace.unify.auto_generated")} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="tenant_id"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.feedback_record_directory")}</FormLabel>
+                        <FormControl>
+                          <Select value={field.value} onValueChange={field.onChange} disabled>
+                            <SelectTrigger>
+                              <SelectValue
+                                placeholder={t("workspace.unify.select_feedback_record_directory")}
+                              />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {directories.map((directory) => (
+                                <SelectItem key={directory.id} value={directory.id}>
+                                  {directory.name}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </FormControl>
+                        <FormError />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <FormField
+                    control={form.control}
+                    name="submission_id"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.submission_id")}</FormLabel>
+                        <FormControl>
+                          <Input {...field} disabled={isEditMode || !canWrite} />
+                        </FormControl>
+                        <FormError />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="collected_at"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.collected_at")}</FormLabel>
+                        <FormControl>
+                          <Input {...field} type="datetime-local" disabled={isEditMode || !canWrite} />
+                        </FormControl>
+                        <FormError />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <FormField
+                    control={form.control}
+                    name="created_at"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("common.created_at")}</FormLabel>
+                        <FormControl>
+                          <Input {...field} disabled placeholder={t("workspace.unify.auto_generated")} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="updated_at"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.updated_at")}</FormLabel>
+                        <FormControl>
+                          <Input {...field} disabled placeholder={t("workspace.unify.auto_generated")} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                {isEditMode ? (
+                  <FormField
+                    control={form.control}
+                    name="source_type"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.source_type")}</FormLabel>
+                        <FormControl>
+                          <Input {...field} value={formatSourceType(field.value, t)} disabled />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                ) : (
+                  <div className="space-y-2">
+                    <FormLabel>{t("workspace.unify.source_type")}</FormLabel>
+                    <Select
+                      value={sourceTypeMode}
+                      onValueChange={(value) => {
+                        setSourceTypeMode(value);
+                        if (value !== SOURCE_TYPE_CUSTOM_VALUE) {
+                          form.setValue("source_type", value, { shouldDirty: true });
+                        }
+                      }}
+                      disabled={!canWrite}>
+                      <SelectTrigger>
+                        <SelectValue placeholder={t("workspace.unify.select_feedback_record_source_type")} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {SOURCE_TYPE_PRESET_OPTIONS.map((option) => (
+                          <SelectItem key={option} value={option}>
+                            {option}
+                          </SelectItem>
+                        ))}
+                        <SelectItem value={SOURCE_TYPE_CUSTOM_VALUE}>
+                          {t("workspace.unify.custom_source_type")}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                    {sourceTypeMode === SOURCE_TYPE_CUSTOM_VALUE && (
+                      <Input
+                        value={customSourceType}
+                        onChange={(event) => {
+                          setCustomSourceType(event.target.value);
+                          form.setValue("source_type", event.target.value, { shouldDirty: true });
+                        }}
+                        placeholder={t("workspace.unify.custom_source_type_placeholder")}
+                        disabled={!canWrite}
+                      />
+                    )}
+                    <FormError>{form.formState.errors.source_type?.message}</FormError>
+                  </div>
+                )}
+
+                <div className="grid grid-cols-2 gap-3">
+                  <FormField
+                    control={form.control}
+                    name="source_id"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.source_id")}</FormLabel>
+                        <FormControl>
+                          <Input {...field} disabled={isEditMode || !canWrite} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="source_name"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.source_name")}</FormLabel>
+                        <FormControl>
+                          <Input {...field} disabled={isEditMode || !canWrite} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <FormField
+                    control={form.control}
+                    name="field_id"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.field_id")}</FormLabel>
+                        <FormControl>
+                          <Input {...field} disabled={isEditMode || !canWrite} />
+                        </FormControl>
+                        <FormError />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="field_label"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.field_label")}</FormLabel>
+                        <FormControl>
+                          <Input {...field} disabled={isEditMode || !canWrite} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <FormField
+                    control={form.control}
+                    name="field_type"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.field_type")}</FormLabel>
+                        <FormControl>
+                          <Select
+                            value={field.value}
+                            onValueChange={(value) =>
+                              field.onChange(value as TFeedbackRecordFormValues["field_type"])
+                            }
+                            disabled={isEditMode || !canWrite}>
+                            <SelectTrigger>
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {FIELD_TYPE_OPTIONS.map((option) => (
+                                <SelectItem key={option} value={option}>
+                                  {option}
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="field_group_id"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.field_group_id")}</FormLabel>
+                        <FormControl>
+                          <Input {...field} disabled={isEditMode || !canWrite} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <FormField
+                  control={form.control}
+                  name="field_group_label"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t("workspace.unify.field_group_label")}</FormLabel>
+                      <FormControl>
+                        <Input {...field} disabled={isEditMode || !canWrite} />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="value_text"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t("workspace.unify.value_text")}</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          value={field.value ?? ""}
+                          disabled={selectedValueField !== "value_text" || isReadOnly || !canWrite}
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+
+                <div className="grid grid-cols-2 gap-3">
+                  <FormField
+                    control={form.control}
+                    name="value_number"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.value_number")}</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            value={field.value ?? ""}
+                            type="number"
+                            step="any"
+                            disabled={selectedValueField !== "value_number" || isReadOnly || !canWrite}
+                          />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="value_date"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.value_date")}</FormLabel>
+                        <FormControl>
+                          <Input
+                            {...field}
+                            value={field.value ?? ""}
+                            type="datetime-local"
+                            disabled={selectedValueField !== "value_date" || isReadOnly || !canWrite}
+                          />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <FormField
+                  control={form.control}
+                  name="value_boolean"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t("workspace.unify.value_boolean")}</FormLabel>
+                      <FormControl>
+                        <div className="flex items-center gap-3 rounded-md border border-slate-200 px-3 py-2">
+                          <Switch
+                            checked={field.value ?? false}
+                            onCheckedChange={(checked) => field.onChange(checked)}
+                            disabled={selectedValueField !== "value_boolean" || isReadOnly || !canWrite}
+                          />
+                          <span className="text-sm text-slate-600">{valueBooleanLabel}</span>
+                        </div>
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+                <FormError>{form.formState.errors[selectedValueField]?.message}</FormError>
+
+                <div className="grid grid-cols-2 gap-3">
+                  <FormField
+                    control={form.control}
+                    name="language"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("common.language")}</FormLabel>
+                        <FormControl>
+                          <Input {...field} disabled={!canWrite || isReadOnly} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="user_identifier"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>{t("workspace.unify.user_identifier")}</FormLabel>
+                        <FormControl>
+                          <Input {...field} disabled={!canWrite || isReadOnly} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <FormLabel>{t("workspace.unify.metadata")}</FormLabel>
+                    {canWrite && !isReadOnly && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => append({ key: "", value: "" })}>
+                        <PlusIcon className="h-4 w-4" />
+                        {t("common.add")}
+                      </Button>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    {fields.map((field, index) => (
+                      <div key={field.id} className="grid grid-cols-[1fr_1fr_auto] gap-2">
+                        <FormField
+                          control={form.control}
+                          name={`metadataEntries.${index}.key`}
+                          render={({ field: entryField }) => (
+                            <FormItem>
+                              <FormControl>
+                                <Input
+                                  {...entryField}
+                                  placeholder={t("workspace.unify.metadata_key")}
+                                  disabled={isReadOnly || !canWrite}
+                                />
+                              </FormControl>
+                            </FormItem>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name={`metadataEntries.${index}.value`}
+                          render={({ field: entryField }) => (
+                            <FormItem>
+                              <FormControl>
+                                <Input
+                                  {...entryField}
+                                  placeholder={t("workspace.unify.metadata_value")}
+                                  disabled={isReadOnly || !canWrite}
+                                />
+                              </FormControl>
+                            </FormItem>
+                          )}
+                        />
+                        {canWrite && !isReadOnly && (
+                          <Button type="button" variant="outline" onClick={() => remove(index)}>
+                            {t("common.delete")}
+                          </Button>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+
+                  {readOnlyMetadataEntries.length > 0 && (
+                    <div className="space-y-2">
+                      <p className="text-xs text-slate-500">
+                        {t("workspace.unify.metadata_read_only_entries")}
+                      </p>
+                      {readOnlyMetadataEntries.map((entry) => (
+                        <div
+                          key={entry.key}
+                          className="grid grid-cols-2 gap-2 rounded-md bg-slate-50 p-2 text-xs">
+                          <span className="font-medium text-slate-700">{entry.key}</span>
+                          <span className="truncate text-slate-600" title={entry.value}>
+                            {entry.value}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </form>
+            </FormProvider>
+          )}
+
+          <SheetFooter className="mt-2">
+            <Button variant="outline" onClick={requestClose} disabled={isSubmitting}>
+              {t("common.cancel")}
+            </Button>
+            {canWrite && (
+              <Button onClick={handleSubmit} loading={isSubmitting} disabled={isLoadingRecord}>
+                {mode === "create" ? t("workspace.unify.add_feedback_record") : t("common.save")}
+              </Button>
+            )}
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+
+      <AlertDialog
+        open={isDiscardDialogOpen}
+        setOpen={setIsDiscardDialogOpen}
+        headerText={t("workspace.unify.discard_feedback_record_changes_title")}
+        mainText={t("workspace.unify.discard_feedback_record_changes_description")}
+        confirmBtnLabel={t("common.discard")}
+        declineBtnLabel={t("common.cancel")}
+        declineBtnVariant="outline"
+        onDecline={() => setIsDiscardDialogOpen(false)}
+        onConfirm={handleDiscardChanges}
+      />
+    </>
+  );
+};

--- a/apps/web/app/(app)/workspaces/[workspaceId]/unify/feedback-records/feedback-records-page-client.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/unify/feedback-records/feedback-records-page-client.tsx
@@ -11,22 +11,32 @@ interface FeedbackRecordsPageClientProps {
   workspaceId: string;
   initialRecords: FeedbackRecordData[];
   frdMap: Record<string, string>;
+  csvSources: { id: string; name: string }[];
+  canWrite: boolean;
 }
 
 export function FeedbackRecordsPageClient({
   workspaceId,
   initialRecords,
   frdMap,
-}: FeedbackRecordsPageClientProps) {
+  csvSources,
+  canWrite,
+}: Readonly<FeedbackRecordsPageClientProps>) {
   const { t } = useTranslation();
 
   return (
     <PageContentWrapper>
-      <PageHeader pageTitle={t("workspace.unify.unify_feedback")}>
+      <PageHeader pageTitle={t("workspace.unify.feedback_records")}>
         <UnifyConfigNavigation workspaceId={workspaceId} activeId="feedback-records" />
       </PageHeader>
 
-      <FeedbackRecordsTable workspaceId={workspaceId} initialRecords={initialRecords} frdMap={frdMap} />
+      <FeedbackRecordsTable
+        workspaceId={workspaceId}
+        initialRecords={initialRecords}
+        frdMap={frdMap}
+        csvSources={csvSources}
+        canWrite={canWrite}
+      />
     </PageContentWrapper>
   );
 }

--- a/apps/web/app/(app)/workspaces/[workspaceId]/unify/feedback-records/feedback-records-table.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/unify/feedback-records/feedback-records-table.tsx
@@ -3,13 +3,16 @@
 import { TFunction } from "i18next";
 import {
   CalendarIcon,
+  ChevronDownIcon,
   HashIcon,
   MessageSquareTextIcon,
+  PlusIcon,
   RefreshCwIcon,
   ToggleLeftIcon,
   TypeIcon,
 } from "lucide-react";
-import { useState } from "react";
+import Link from "next/link";
+import { useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { listFeedbackRecordsAction } from "@/lib/connector/actions";
@@ -18,7 +21,16 @@ import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import type { FeedbackRecordData } from "@/modules/hub/types";
 import { Badge } from "@/modules/ui/components/badge";
 import { Button } from "@/modules/ui/components/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/modules/ui/components/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/modules/ui/components/tooltip";
+import { CsvImportModal } from "../sources/components/csv-import-modal";
+import { FeedbackRecordFormDrawer } from "./feedback-record-form-drawer";
 
 const RECORDS_PER_PAGE = 50;
 
@@ -42,6 +54,18 @@ const formatValue = (record: FeedbackRecordData, t: TFunction, locale: string): 
   return "—";
 };
 
+const formatSourceType = (sourceType: string, t: TFunction): string => {
+  switch (sourceType) {
+    case "formbricks":
+    case "formbricks_survey":
+      return t("workspace.unify.formbricks_surveys");
+    case "csv":
+      return t("workspace.unify.csv_import");
+    default:
+      return sourceType;
+  }
+};
+
 function truncate(str: string, maxLen: number): string {
   if (str.length <= maxLen) return str;
   return str.slice(0, maxLen) + "…";
@@ -51,13 +75,48 @@ interface FeedbackRecordsTableProps {
   workspaceId: string;
   initialRecords: FeedbackRecordData[];
   frdMap: Record<string, string>;
+  csvSources: { id: string; name: string }[];
+  canWrite: boolean;
 }
 
-export const FeedbackRecordsTable = ({ workspaceId, initialRecords, frdMap }: FeedbackRecordsTableProps) => {
+export const FeedbackRecordsTable = ({
+  workspaceId,
+  initialRecords,
+  frdMap,
+  csvSources,
+  canWrite,
+}: Readonly<FeedbackRecordsTableProps>) => {
   const { t, i18n } = useTranslation();
   const [records, setRecords] = useState<FeedbackRecordData[]>(initialRecords);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [drawerMode, setDrawerMode] = useState<"create" | "edit">("edit");
+  const [drawerRecordId, setDrawerRecordId] = useState<string | undefined>();
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [csvImportSource, setCsvImportSource] = useState<{ id: string; name: string } | null>(null);
+
+  const directories = useMemo(
+    () =>
+      Object.entries(frdMap)
+        .map(([id, name]) => ({ id, name }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [frdMap]
+  );
+  const feedbackDirectoryName = useMemo(() => {
+    const directoryNames = Array.from(
+      new Set(
+        records
+          .map((record) => frdMap[record.tenant_id])
+          .filter((directoryName): directoryName is string => Boolean(directoryName))
+      )
+    );
+
+    if (directoryNames.length > 0) {
+      return directoryNames.join(", ");
+    }
+
+    return directories[0]?.name ?? "—";
+  }, [directories, frdMap, records]);
 
   const handleRefresh = async () => {
     if (isRefreshing) return;
@@ -100,98 +159,193 @@ export const FeedbackRecordsTable = ({ workspaceId, initialRecords, frdMap }: Fe
 
   const isEmpty = records.length === 0 && !isRefreshing;
 
-  return (
-    <div className="space-y-3">
-      {!isEmpty && (
-        <div className="flex items-center justify-between">
-          <p className="text-sm text-slate-500">
-            {t("workspace.unify.showing_count_loaded", { count: records.length })}
-          </p>
-          <Button
-            variant="secondary"
-            size="sm"
-            onClick={handleRefresh}
-            disabled={isRefreshing}
-            aria-label={t("workspace.unify.refresh_feedback_records")}>
-            <RefreshCwIcon className="h-3.5 w-3.5" aria-hidden="true" />
-          </Button>
-        </div>
-      )}
+  const openEditDrawer = (recordId: string) => {
+    setDrawerMode("edit");
+    setDrawerRecordId(recordId);
+    setIsDrawerOpen(true);
+  };
 
-      <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[900px]">
-            <thead>
-              <tr className="border-b border-slate-200 text-left text-sm text-slate-900 [&>th]:font-semibold">
-                <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.collected_at")}</th>
-                <th className="whitespace-nowrap px-4 py-3">
-                  {t("workspace.unify.feedback_record_directory")}
-                </th>
-                <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.source_type")}</th>
-                <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.source_name")}</th>
-                <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.field_label")}</th>
-                <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.field_type")}</th>
-                <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.value")}</th>
-                <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.user_identifier")}</th>
-              </tr>
-            </thead>
-            {isEmpty ? (
-              <tbody>
-                <tr>
-                  <td colSpan={8}>
-                    <div className="flex h-32 items-center justify-center">
-                      <p className="text-sm text-slate-500">{t("workspace.unify.no_feedback_records")}</p>
-                    </div>
-                  </td>
+  const openCreateDrawer = () => {
+    setDrawerMode("create");
+    setDrawerRecordId(undefined);
+    setIsDrawerOpen(true);
+  };
+
+  const hasCsvSources = csvSources.length > 0;
+
+  return (
+    <>
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          {isEmpty ? (
+            <span />
+          ) : (
+            <p className="text-sm text-slate-500">
+              {t("workspace.unify.showing_count_loaded", {
+                count: records.length,
+                directoryName: feedbackDirectoryName,
+              })}
+            </p>
+          )}
+          <div className="flex items-center gap-2">
+            {canWrite &&
+              (hasCsvSources ? (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button size="sm" variant="secondary">
+                      <PlusIcon className="h-4 w-4" />
+                      {t("workspace.unify.add_feedback_record")}
+                      <ChevronDownIcon className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={openCreateDrawer}>
+                      {t("workspace.unify.add_feedback_record")}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    {csvSources.map((source) => (
+                      <DropdownMenuItem
+                        key={source.id}
+                        onClick={() => {
+                          setCsvImportSource(source);
+                        }}>
+                        {t("workspace.unify.import_via_source_name", { sourceName: source.name })}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              ) : (
+                <Button size="sm" variant="secondary" onClick={openCreateDrawer}>
+                  <PlusIcon className="h-4 w-4" />
+                  {t("workspace.unify.add_feedback_record")}
+                </Button>
+              ))}
+            <Button size="sm" asChild>
+              <Link href={`/workspaces/${workspaceId}/feedback-sources`}>
+                {t("workspace.unify.manage_feedback_sources")}
+              </Link>
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+              aria-label={t("workspace.unify.refresh_feedback_records")}>
+              <RefreshCwIcon className="h-3.5 w-3.5" aria-hidden="true" />
+            </Button>
+          </div>
+        </div>
+
+        <div className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[900px]">
+              <thead>
+                <tr className="border-b border-slate-200 text-left text-sm text-slate-900 [&>th]:font-semibold">
+                  <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.collected_at")}</th>
+                  <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.source_type")}</th>
+                  <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.source_name")}</th>
+                  <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.field_label")}</th>
+                  <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.field_type")}</th>
+                  <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.value")}</th>
+                  <th className="whitespace-nowrap px-4 py-3">{t("workspace.unify.user_identifier")}</th>
                 </tr>
-              </tbody>
-            ) : (
-              <tbody className="divide-y divide-slate-100">
-                {records.map((record) => (
-                  <FeedbackRecordRow
-                    key={record.id}
-                    record={record}
-                    locale={i18n.resolvedLanguage ?? i18n.language ?? "en-US"}
-                    frdName={record.tenant_id ? (frdMap[record.tenant_id] ?? "—") : "—"}
-                    t={t}
-                  />
-                ))}
-              </tbody>
-            )}
-          </table>
+              </thead>
+              {isEmpty ? (
+                <tbody>
+                  <tr>
+                    <td colSpan={7}>
+                      <div className="flex h-32 items-center justify-center">
+                        <p className="text-sm text-slate-500">{t("workspace.unify.no_feedback_records")}</p>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              ) : (
+                <tbody className="divide-y divide-slate-100">
+                  {records.map((record) => (
+                    <FeedbackRecordRow
+                      key={record.id}
+                      record={record}
+                      workspaceId={workspaceId}
+                      locale={i18n.resolvedLanguage ?? i18n.language ?? "en-US"}
+                      t={t}
+                      onClick={() => openEditDrawer(record.id)}
+                    />
+                  ))}
+                </tbody>
+              )}
+            </table>
+          </div>
         </div>
       </div>
-    </div>
+
+      <FeedbackRecordFormDrawer
+        mode={drawerMode}
+        open={isDrawerOpen}
+        onOpenChange={setIsDrawerOpen}
+        workspaceId={workspaceId}
+        directories={directories}
+        canWrite={canWrite}
+        recordId={drawerMode === "edit" ? drawerRecordId : undefined}
+        onSuccess={handleRefresh}
+      />
+
+      {csvImportSource && (
+        <CsvImportModal
+          open={csvImportSource !== null}
+          onOpenChange={(open) => {
+            if (!open) {
+              setCsvImportSource(null);
+            }
+          }}
+          connectorId={csvImportSource.id}
+          workspaceId={workspaceId}
+        />
+      )}
+    </>
   );
 };
 
 const FeedbackRecordRow = ({
   record,
+  workspaceId,
   locale,
-  frdName,
   t,
+  onClick,
 }: {
   record: FeedbackRecordData;
+  workspaceId: string;
   locale: string;
-  frdName: string;
   t: TFunction;
+  onClick: () => void;
 }) => {
   const value = formatValue(record, t, locale);
   const isLongValue = value.length > 60;
+  const isFormbricksSurveySource =
+    (record.source_type === "formbricks" || record.source_type === "formbricks_survey") && !!record.source_id;
+  const surveySummaryHref = `/workspaces/${workspaceId}/surveys/${record.source_id}/summary`;
 
   return (
-    <tr className="text-sm text-slate-700 transition-colors hover:bg-slate-50">
+    <tr
+      className="cursor-pointer text-sm text-slate-700 transition-colors hover:bg-slate-50"
+      onClick={onClick}>
       <td className="whitespace-nowrap px-4 py-3 text-slate-500">
         {formatDateTimeForDisplay(new Date(record.collected_at), locale)}
       </td>
-      <td className="max-w-[200px] truncate px-4 py-3 text-slate-600" title={frdName}>
-        {frdName}
-      </td>
       <td className="whitespace-nowrap px-4 py-3">
-        <Badge text={record.source_type} type="gray" size="tiny" />
+        <Badge text={formatSourceType(record.source_type, t)} type="gray" size="tiny" />
       </td>
       <td className="max-w-[150px] truncate px-4 py-3" title={record.source_name ?? undefined}>
-        {record.source_name ?? "—"}
+        {isFormbricksSurveySource ? (
+          <Link
+            href={surveySummaryHref}
+            className="text-slate-700 underline underline-offset-2 hover:text-slate-900"
+            onClick={(event) => event.stopPropagation()}>
+            {record.source_name ?? "—"}
+          </Link>
+        ) : (
+          <span>{record.source_name ?? "—"}</span>
+        )}
       </td>
       <td className="max-w-[200px] truncate px-4 py-3" title={record.field_label ?? undefined}>
         {record.field_label ?? record.field_id}

--- a/apps/web/app/(app)/workspaces/[workspaceId]/unify/feedback-records/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/unify/feedback-records/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { getConnectorsWithMappings } from "@/lib/connector/service";
 import { getTranslate } from "@/lingodotdev/server";
 import { getFeedbackRecordDirectoriesByWorkspaceId } from "@/modules/ee/feedback-record-directory/lib/feedback-record-directory";
 import { listFeedbackRecords } from "@/modules/hub/service";
@@ -7,7 +8,9 @@ import { FeedbackRecordsPageClient } from "./feedback-records-page-client";
 
 const INITIAL_PAGE_SIZE = 50;
 
-export default async function UnifyFeedbackRecordsPage(props: { params: Promise<{ workspaceId: string }> }) {
+export default async function UnifyFeedbackRecordsPage(
+  props: Readonly<{ params: Promise<{ workspaceId: string }> }>
+) {
   const t = await getTranslate();
   const params = await props.params;
 
@@ -19,11 +22,15 @@ export default async function UnifyFeedbackRecordsPage(props: { params: Promise<
   }
 
   const hasAccess = isOwner || isManager || hasReadAccess || hasReadWriteAccess || hasManageAccess;
+  const canWrite = isOwner || isManager || hasReadWriteAccess || hasManageAccess;
   if (!hasAccess) {
     return notFound();
   }
 
-  const frds = await getFeedbackRecordDirectoriesByWorkspaceId(params.workspaceId);
+  const [frds, connectors] = await Promise.all([
+    getFeedbackRecordDirectoriesByWorkspaceId(params.workspaceId),
+    getConnectorsWithMappings(params.workspaceId),
+  ]);
 
   const results = await Promise.all(
     frds.map((frd) => listFeedbackRecords({ tenant_id: frd.id, limit: INITIAL_PAGE_SIZE }))
@@ -38,8 +45,17 @@ export default async function UnifyFeedbackRecordsPage(props: { params: Promise<
     .slice(0, INITIAL_PAGE_SIZE);
 
   const frdMap = Object.fromEntries(frds.map((f) => [f.id, f.name]));
+  const csvSources = connectors
+    .filter((connector) => connector.type === "csv")
+    .map((connector) => ({ id: connector.id, name: connector.name }));
 
   return (
-    <FeedbackRecordsPageClient workspaceId={params.workspaceId} initialRecords={merged} frdMap={frdMap} />
+    <FeedbackRecordsPageClient
+      workspaceId={params.workspaceId}
+      initialRecords={merged}
+      frdMap={frdMap}
+      csvSources={csvSources}
+      canWrite={canWrite}
+    />
   );
 }

--- a/apps/web/modules/hub/index.ts
+++ b/apps/web/modules/hub/index.ts
@@ -3,7 +3,10 @@ export {
   createFeedbackRecord,
   createFeedbackRecordsBatch,
   listFeedbackRecords,
+  retrieveFeedbackRecord,
+  updateFeedbackRecord,
   type CreateFeedbackRecordResult,
+  type HubFeedbackRecordResult,
   type ListFeedbackRecordsResult,
 } from "./service";
 export type {
@@ -11,4 +14,5 @@ export type {
   FeedbackRecordData,
   FeedbackRecordListParams,
   FeedbackRecordListResponse,
+  FeedbackRecordUpdateParams,
 } from "./types";

--- a/apps/web/modules/hub/service.test.ts
+++ b/apps/web/modules/hub/service.test.ts
@@ -15,7 +15,7 @@ const { getHubClient } = await import("./hub-client");
 const sampleInput: FeedbackRecordCreateParams = {
   field_id: "el-1",
   field_type: "rating",
-  source_type: "formbricks",
+  source_type: "formbricks_survey",
   source_id: "survey-1",
   source_name: "Test Survey",
   field_label: "Question?",

--- a/apps/web/modules/hub/service.ts
+++ b/apps/web/modules/hub/service.ts
@@ -7,12 +7,16 @@ import type {
   FeedbackRecordData,
   FeedbackRecordListParams,
   FeedbackRecordListResponse,
+  FeedbackRecordUpdateParams,
 } from "./types";
 
-export type CreateFeedbackRecordResult = {
+type HubError = { status: number; message: string; detail: string };
+
+export type HubFeedbackRecordResult = {
   data: FeedbackRecordData | null;
-  error: { status: number; message: string; detail: string } | null;
+  error: HubError | null;
 };
+export type CreateFeedbackRecordResult = HubFeedbackRecordResult;
 
 const NO_CONFIG_ERROR = {
   status: 0,
@@ -20,7 +24,7 @@ const NO_CONFIG_ERROR = {
   detail: "HUB_API_KEY is not set; Hub integration is disabled.",
 } as const;
 
-const createResultFromError = (err: unknown): CreateFeedbackRecordResult => {
+const createResultFromError = (err: unknown): HubFeedbackRecordResult => {
   const status = err instanceof FormbricksHub.APIError ? err.status : 0;
   const message = err instanceof Error ? err.message : String(err);
   return { data: null, error: { status, message, detail: message } };
@@ -32,7 +36,7 @@ const createResultFromError = (err: unknown): CreateFeedbackRecordResult => {
  */
 export const createFeedbackRecord = async (
   input: FeedbackRecordCreateParams
-): Promise<CreateFeedbackRecordResult> => {
+): Promise<HubFeedbackRecordResult> => {
   const client = getHubClient();
   if (!client) {
     return { data: null, error: { ...NO_CONFIG_ERROR } };
@@ -46,9 +50,48 @@ export const createFeedbackRecord = async (
   }
 };
 
+/**
+ * Retrieve a single feedback record from the Hub by id.
+ */
+export const retrieveFeedbackRecord = async (id: string): Promise<HubFeedbackRecordResult> => {
+  const client = getHubClient();
+  if (!client) {
+    return { data: null, error: { ...NO_CONFIG_ERROR } };
+  }
+
+  try {
+    const data = await client.feedbackRecords.retrieve(id);
+    return { data, error: null };
+  } catch (err) {
+    logger.warn({ err, id }, "Hub: retrieveFeedbackRecord failed");
+    return createResultFromError(err);
+  }
+};
+
+/**
+ * Update a single feedback record in the Hub by id.
+ */
+export const updateFeedbackRecord = async (
+  id: string,
+  input: FeedbackRecordUpdateParams
+): Promise<HubFeedbackRecordResult> => {
+  const client = getHubClient();
+  if (!client) {
+    return { data: null, error: { ...NO_CONFIG_ERROR } };
+  }
+
+  try {
+    const data = await client.feedbackRecords.update(id, input);
+    return { data, error: null };
+  } catch (err) {
+    logger.warn({ err, id }, "Hub: updateFeedbackRecord failed");
+    return createResultFromError(err);
+  }
+};
+
 export type ListFeedbackRecordsResult = {
   data: FeedbackRecordListResponse | null;
-  error: { status: number; message: string; detail: string } | null;
+  error: HubError | null;
 };
 
 /**
@@ -78,7 +121,7 @@ export const listFeedbackRecords = async (
  */
 export const createFeedbackRecordsBatch = async (
   inputs: FeedbackRecordCreateParams[]
-): Promise<{ results: CreateFeedbackRecordResult[] }> => {
+): Promise<{ results: HubFeedbackRecordResult[] }> => {
   const client = getHubClient();
   if (!client) {
     return {
@@ -90,7 +133,7 @@ export const createFeedbackRecordsBatch = async (
     inputs.map(async (input) => {
       try {
         const data = await client.feedbackRecords.create(input);
-        return { data, error: null as CreateFeedbackRecordResult["error"] };
+        return { data, error: null as HubFeedbackRecordResult["error"] };
       } catch (err) {
         logger.warn({ err, fieldId: input.field_id }, "Hub: createFeedbackRecord failed");
         return createResultFromError(err);

--- a/apps/web/modules/hub/types.ts
+++ b/apps/web/modules/hub/types.ts
@@ -4,3 +4,4 @@ export type FeedbackRecordCreateParams = FormbricksHub.FeedbackRecordCreateParam
 export type FeedbackRecordData = FormbricksHub.FeedbackRecordData;
 export type FeedbackRecordListParams = FormbricksHub.FeedbackRecordListParams;
 export type FeedbackRecordListResponse = FormbricksHub.FeedbackRecordListResponse;
+export type FeedbackRecordUpdateParams = FormbricksHub.FeedbackRecordUpdateParams;


### PR DESCRIPTION
## Summary
- add hub service surface updates for feedback records
- introduce server actions and a form drawer for unify feedback records management
- wire feedback records page and table to the new hub-backed flows

## Test plan
- [x] `pnpm test -- \"modules/hub/service.test.ts\"` (run in `apps/web`)
- [ ] manual smoke test feedback records list/create/edit in unify

Made with [Cursor](https://cursor.com)