### PR TITLE
fix: replace organization name placeholder example

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -1137,7 +1137,7 @@ checksums:
     environments/settings/general/organization_invite_link_ready: e54b37c4ec2e5a9ea9f6bc6e5b512b0b
     environments/settings/general/organization_name: 73c9b31c9032a22bd84a07881942bb04
     environments/settings/general/organization_name_description: ff517b4749a332b94a26110d7c7e771f
-    environments/settings/general/organization_name_placeholder: fc91de3ddc89ab77f30d555778312380
+    environments/settings/general/organization_name_placeholder: abcee7d91a848e573b63a763cfaf6a08
     environments/settings/general/organization_name_updated_successfully: d36ba3a4f614d30b10e696d25da22432
     environments/settings/general/organization_settings: d31952131ad5f0ec72ad96f1ed11bef6
     environments/settings/general/please_add_a_logo: 66d6f97a2e7b27efc04bd653240ee813

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "Dein Einladungslink für die Organisation ist fertig!",
         "organization_name": "Organisationsname",
         "organization_name_description": "Gib deiner Organisation einen Namen.",
-        "organization_name_placeholder": "z. B. Powerpuff Girls",
+        "organization_name_placeholder": "z. B. Acme Inc.",
         "organization_name_updated_successfully": "Organisationsname erfolgreich aktualisiert",
         "organization_settings": "Organisationseinstellungen",
         "please_add_a_logo": "Bitte füge ein Logo hinzu",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "Your organization invite link is ready!",
         "organization_name": "Organization Name",
         "organization_name_description": "Give your organization a descriptive name.",
-        "organization_name_placeholder": "e.g. Power Puff Girls",
+        "organization_name_placeholder": "e.g. Acme Inc.",
         "organization_name_updated_successfully": "Organization name updated successfully",
         "organization_settings": "Organization Settings",
         "please_add_a_logo": "Please add a logo",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "¡Tu enlace de invitación a la organización está listo!",
         "organization_name": "Nombre de la organización",
         "organization_name_description": "Dale a tu organización un nombre descriptivo.",
-        "organization_name_placeholder": "p. ej. Power Puff Girls",
+        "organization_name_placeholder": "p. ej. Acme Inc.",
         "organization_name_updated_successfully": "Nombre de la organización actualizado correctamente",
         "organization_settings": "Configuración de la organización",
         "please_add_a_logo": "Por favor, añade un logotipo",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "Le lien d'invitation de votre organisation est prêt !",
         "organization_name": "Nom de l'organisation",
         "organization_name_description": "Attribuez un nom descriptif à votre organisation.",
-        "organization_name_placeholder": "e.g. Power Puff Girls",
+        "organization_name_placeholder": "e.g. Acme Inc.",
         "organization_name_updated_successfully": "Nom de l'organisation mis à jour avec succès",
         "organization_settings": "Paramètres de l'organisation",
         "please_add_a_logo": "Veuillez ajouter un logo",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "A szervezete meghívási hivatkozása készen áll!",
         "organization_name": "Szervezet neve",
         "organization_name_description": "Adjon a szervezetének egy leíró nevet.",
-        "organization_name_placeholder": "például Pindúr pandúrok",
+        "organization_name_placeholder": "például Acme Inc.",
         "organization_name_updated_successfully": "A szervezet neve sikeresen frissítve",
         "organization_settings": "Szervezet beállításai",
         "please_add_a_logo": "Adjon hozzá egy logót",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "組織の招待リンクが準備できました！",
         "organization_name": "組織名",
         "organization_name_description": "組織に分かりやすい名前を付けます。",
-        "organization_name_placeholder": "例: パワーパフガールズ",
+        "organization_name_placeholder": "例: Acme Inc.",
         "organization_name_updated_successfully": "組織名を正常に更新しました",
         "organization_settings": "組織設定",
         "please_add_a_logo": "ロゴを追加してください",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "De uitnodigingslink voor uw organisatie is gereed!",
         "organization_name": "Organisatienaam",
         "organization_name_description": "Geef uw organisatie een beschrijvende naam.",
-        "organization_name_placeholder": "bijv. Power Puff-meisjes",
+        "organization_name_placeholder": "bijv. Acme Inc.",
         "organization_name_updated_successfully": "Organisatienaam is succesvol bijgewerkt",
         "organization_settings": "Organisatie-instellingen",
         "please_add_a_logo": "Voeg een logo toe",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "O link de convite da sua organização está pronto!",
         "organization_name": "Nome da Organização",
         "organization_name_description": "Dê um nome descritivo pra sua organização.",
-        "organization_name_placeholder": "por exemplo, Meninas Superpoderosas",
+        "organization_name_placeholder": "por exemplo, Acme Inc.",
         "organization_name_updated_successfully": "Nome da organização atualizado com sucesso",
         "organization_settings": "Configurações da Organização",
         "please_add_a_logo": "Por favor, adicione um logo",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "O link de convite da sua organização está pronto!",
         "organization_name": "Nome da Organização",
         "organization_name_description": "Dê à sua organização um nome descritivo.",
-        "organization_name_placeholder": "por exemplo, Power Puff Girls",
+        "organization_name_placeholder": "por exemplo, Acme Inc.",
         "organization_name_updated_successfully": "Nome da organização atualizado com sucesso",
         "organization_settings": "Configurações da organização",
         "please_add_a_logo": "Por favor, adicione um logótipo",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "Linkul de invitație al organizației tale este gata!",
         "organization_name": "Nume Organizație",
         "organization_name_description": "Oferiți organizației dumneavoastră un nume descriptiv.",
-        "organization_name_placeholder": "ex. Power Puff Girls",
+        "organization_name_placeholder": "ex. Acme Inc.",
         "organization_name_updated_successfully": "Numele organizației actualizat cu succes",
         "organization_settings": "Setări Organizație",
         "please_add_a_logo": "Adaugă un logo",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "Ссылка для приглашения в организацию готова!",
         "organization_name": "Название организации",
         "organization_name_description": "Дайте вашей организации понятное название.",
-        "organization_name_placeholder": "например, Power Puff Girls",
+        "organization_name_placeholder": "например, Acme Inc.",
         "organization_name_updated_successfully": "Название организации успешно обновлено",
         "organization_settings": "Настройки организации",
         "please_add_a_logo": "Пожалуйста, добавьте логотип",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "Din organisationsinbjudningslänk är redo!",
         "organization_name": "Organisationsnamn",
         "organization_name_description": "Ge din organisation ett beskrivande namn.",
-        "organization_name_placeholder": "t.ex. Power Puff Girls",
+        "organization_name_placeholder": "t.ex. Acme Inc.",
         "organization_name_updated_successfully": "Organisationsnamn uppdaterat",
         "organization_settings": "Organisationsinställningar",
         "please_add_a_logo": "Vänligen lägg till en logotyp",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "Kuruluş davet bağlantınız hazır!",
         "organization_name": "Kuruluş Adı",
         "organization_name_description": "Kuruluşunuza açıklayıcı bir ad verin.",
-        "organization_name_placeholder": "ör. Power Puff Girls",
+        "organization_name_placeholder": "ör. Acme Inc.",
         "organization_name_updated_successfully": "Organization name başarıyla güncellendi",
         "organization_settings": "Kuruluş Ayarları",
         "please_add_a_logo": "Lütfen bir logo ekleyin",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "您的组织邀请链接已准备好！",
         "organization_name": "组织 名称",
         "organization_name_description": "为您的组织 提供一个描述性的名称",
-        "organization_name_placeholder": "例如 Power Puff Girls",
+        "organization_name_placeholder": "例如 Acme Inc.",
         "organization_name_updated_successfully": "组织 名称 更新 成功",
         "organization_settings": "组织 设置",
         "please_add_a_logo": "请添加 徽标",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1198,7 +1198,7 @@
         "organization_invite_link_ready": "您的組織邀請連結已準備就緒！",
         "organization_name": "組織名稱",
         "organization_name_description": "為您的組織提供描述性名稱。",
-        "organization_name_placeholder": "例如：飛天小女警",
+        "organization_name_placeholder": "例如：Acme Inc.",
         "organization_name_updated_successfully": "組織名稱已成功更新",
         "organization_settings": "組織設定",
         "please_add_a_logo": "請新增標誌",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Replaces the new-organization placeholder example from “Power Puff Girls” to “Acme Inc.” across all locale files that define `organization_name_placeholder`, making the default example more neutral and enterprise-friendly.

Fixes #(issue)

## How should this be tested?

- Open the organization creation flow in any supported locale and check the organization name input placeholder.
- Confirm the placeholder now uses an Acme Inc. example (localized prefix preserved per language).
- Optionally run `rg "Power Puff Girls|Powerpuff Girls|Meninas Superpoderosas|Pindúr pandúrok|パワーパフガールズ|飛天小女警" apps/web/locales` and verify there are no matches.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af4ed8ac-2dce-40da-820f-4b2911ab450e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af4ed8ac-2dce-40da-820f-4b2911ab450e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

