### PR TITLE
fix: 7817 use fully translated inactive survey headings

### DIFF
--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "Dein Link ist abgelaufen.",
-    "link_expired_description": "Der von dir verwendete Link ist nicht mehr gültig."
+    "link_expired_description": "Der von dir verwendete Link ist nicht mehr gültig.",
+    "link_expired_heading": "Dein Link ist abgelaufen."
   },
   "common": {
     "accepted": "Akzeptiert",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "Bestätige deine E-Mail, um zu antworten",
     "verify_email_before_submission_button": "Überprüfen",
     "verify_email_before_submission_description": "Um an dieser Umfrage teilzunehmen, bitte bestätige deine E-Mail",
-    "want_to_respond": "Möchtest Du antworten?"
+    "want_to_respond": "Möchtest Du antworten?",
+    "paused_heading": "Pausiert",
+    "completed_heading": "Abgeschlossen"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "Your link is expired.",
-    "link_expired_description": "The link you used is no longer valid."
+    "link_expired_description": "The link you used is no longer valid.",
+    "link_expired_heading": "Your link is expired."
   },
   "common": {
     "accepted": "Accepted",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "Verify your email to respond",
     "verify_email_before_submission_button": "Verify",
     "verify_email_before_submission_description": "To respond to this survey, please verify your email",
-    "want_to_respond": "Want to respond?"
+    "want_to_respond": "Want to respond?",
+    "paused_heading": "Paused",
+    "completed_heading": "Completed"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "Tu enlace ha caducado.",
-    "link_expired_description": "El enlace que has utilizado ya no es válido."
+    "link_expired_description": "El enlace que has utilizado ya no es válido.",
+    "link_expired_heading": "Tu enlace ha caducado."
   },
   "common": {
     "accepted": "Aceptado",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "Verifica tu correo electrónico para responder",
     "verify_email_before_submission_button": "Verificar",
     "verify_email_before_submission_description": "Para responder a esta encuesta, por favor verifica tu correo electrónico",
-    "want_to_respond": "¿Quieres responder?"
+    "want_to_respond": "¿Quieres responder?",
+    "paused_heading": "Pausado",
+    "completed_heading": "Completado"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "Votre lien est expiré.",
-    "link_expired_description": "Le lien que vous avez utilisé n'est plus valide."
+    "link_expired_description": "Le lien que vous avez utilisé n'est plus valide.",
+    "link_expired_heading": "Votre lien est expiré."
   },
   "common": {
     "accepted": "Accepté",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "Vérifiez votre email pour répondre.",
     "verify_email_before_submission_button": "Vérifier",
     "verify_email_before_submission_description": "Pour répondre à cette enquête, veuillez vérifier votre e-mail.",
-    "want_to_respond": "Voulez-vous répondre ?"
+    "want_to_respond": "Voulez-vous répondre ?",
+    "paused_heading": "En pause",
+    "completed_heading": "Terminé"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "A hivatkozása lejárt.",
-    "link_expired_description": "Az Ön által használt hivatkozás már nem érvényes."
+    "link_expired_description": "Az Ön által használt hivatkozás már nem érvényes.",
+    "link_expired_heading": "A hivatkozása lejárt."
   },
   "common": {
     "accepted": "Elfogadva",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "Ellenőrizze az e-mail-címét a válaszadáshoz",
     "verify_email_before_submission_button": "Ellenőrzés",
     "verify_email_before_submission_description": "A kérdőívre való válaszadáshoz ellenőrizze az e-mail-címét",
-    "want_to_respond": "Szeretne válaszolni?"
+    "want_to_respond": "Szeretne válaszolni?",
+    "paused_heading": "Szüneteltetve",
+    "completed_heading": "Befejezve"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "リンクの有効期限が切れています。",
-    "link_expired_description": "使用したリンクはすでに無効です。"
+    "link_expired_description": "使用したリンクはすでに無効です。",
+    "link_expired_heading": "リンクの有効期限が切れています。"
   },
   "common": {
     "accepted": "承認済み",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "回答するにはメールアドレスを認証してください",
     "verify_email_before_submission_button": "認証",
     "verify_email_before_submission_description": "このフォームに回答するには、メールアドレスを認証してください",
-    "want_to_respond": "回答しますか？"
+    "want_to_respond": "回答しますか？",
+    "paused_heading": "一時停止",
+    "completed_heading": "完了"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "Uw link is verlopen.",
-    "link_expired_description": "De link die u gebruikte is niet meer geldig."
+    "link_expired_description": "De link die u gebruikte is niet meer geldig.",
+    "link_expired_heading": "Uw link is verlopen."
   },
   "common": {
     "accepted": "Geaccepteerd",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "Verifieer uw e-mailadres om te reageren",
     "verify_email_before_submission_button": "Verifiëren",
     "verify_email_before_submission_description": "Om op deze enquête te reageren, dient u uw e-mailadres te verifiëren",
-    "want_to_respond": "Wilt u reageren?"
+    "want_to_respond": "Wilt u reageren?",
+    "paused_heading": "Gepauzeerd",
+    "completed_heading": "Voltooid"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "Seu link está expirado.",
-    "link_expired_description": "O link que você usou não é mais válido."
+    "link_expired_description": "O link que você usou não é mais válido.",
+    "link_expired_heading": "Seu link está expirado."
   },
   "common": {
     "accepted": "Aceito",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "Verifique seu e-mail para responder",
     "verify_email_before_submission_button": "Verificar",
     "verify_email_before_submission_description": "Para responder a esta pesquisa, confirme seu e-mail",
-    "want_to_respond": "Quer responder?"
+    "want_to_respond": "Quer responder?",
+    "paused_heading": "Pausado",
+    "completed_heading": "Concluído"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "O seu link expirou.",
-    "link_expired_description": "O link que utilizou já não é válido."
+    "link_expired_description": "O link que utilizou já não é válido.",
+    "link_expired_heading": "O seu link expirou."
   },
   "common": {
     "accepted": "Aceite",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "Verifique o seu email para responder",
     "verify_email_before_submission_button": "Verificar",
     "verify_email_before_submission_description": "Para responder a este questionário, por favor verifique o seu email",
-    "want_to_respond": "Quer responder?"
+    "want_to_respond": "Quer responder?",
+    "paused_heading": "Em pausa",
+    "completed_heading": "Concluído"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "Link-ul dumneavoastră a expirat.",
-    "link_expired_description": "Link-ul pe care l-ați utilizat nu mai este valabil."
+    "link_expired_description": "Link-ul pe care l-ați utilizat nu mai este valabil.",
+    "link_expired_heading": "Link-ul dumneavoastră a expirat."
   },
   "common": {
     "accepted": "Acceptat",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "Verificați-vă emailul pentru a răspunde",
     "verify_email_before_submission_button": "Verifică",
     "verify_email_before_submission_description": "Pentru a răspunde la acest sondaj, vă rugăm să vă verificați emailul",
-    "want_to_respond": "Dorești să răspunzi?"
+    "want_to_respond": "Dorești să răspunzi?",
+    "paused_heading": "Pauză",
+    "completed_heading": "Completat"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "Ваша ссылка истекла.",
-    "link_expired_description": "Ссылка, которой вы воспользовались, больше не действительна."
+    "link_expired_description": "Ссылка, которой вы воспользовались, больше не действительна.",
+    "link_expired_heading": "Ваша ссылка истекла."
   },
   "common": {
     "accepted": "Принято",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "Подтвердите свой email, чтобы ответить",
     "verify_email_before_submission_button": "Подтвердить",
     "verify_email_before_submission_description": "Чтобы ответить на этот опрос, пожалуйста, подтвердите свой email",
-    "want_to_respond": "Хотите ответить?"
+    "want_to_respond": "Хотите ответить?",
+    "paused_heading": "Приостановлено",
+    "completed_heading": "Завершено"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "Din länk har gått ut.",
-    "link_expired_description": "Länken du använde är inte längre giltig."
+    "link_expired_description": "Länken du använde är inte längre giltig.",
+    "link_expired_heading": "Din länk har gått ut."
   },
   "common": {
     "accepted": "Accepterad",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "Verifiera din e-post för att svara",
     "verify_email_before_submission_button": "Verifiera",
     "verify_email_before_submission_description": "För att svara på denna enkät, vänligen verifiera din e-post",
-    "want_to_respond": "Vill du svara?"
+    "want_to_respond": "Vill du svara?",
+    "paused_heading": "Pausad",
+    "completed_heading": "Slutförd"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "Bağlantınızın süresi doldu.",
-    "link_expired_description": "Kullandığınız bağlantı artık geçerli değil."
+    "link_expired_description": "Kullandığınız bağlantı artık geçerli değil.",
+    "link_expired_heading": "Bağlantınızın süresi doldu."
   },
   "common": {
     "accepted": "Kabul Edildi",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "Yanıtlamak için email adresinizi doğrulayın",
     "verify_email_before_submission_button": "Doğrula",
     "verify_email_before_submission_description": "Bu survey'e yanıt vermek için lütfen email adresinizi doğrulayın",
-    "want_to_respond": "Yanıtlamak ister misiniz?"
+    "want_to_respond": "Yanıtlamak ister misiniz?",
+    "paused_heading": "Duraklatıldı",
+    "completed_heading": "Tamamlandı"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "您的 链接 已过期。",
-    "link_expired_description": "您 使用 的 链接 已失效。"
+    "link_expired_description": "您 使用 的 链接 已失效。",
+    "link_expired_heading": "您的 链接 已过期。"
   },
   "common": {
     "accepted": "已接受",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "验证 您的 邮件 以 响应",
     "verify_email_before_submission_button": "验证",
     "verify_email_before_submission_description": "要 响应 此 调查，请 验证 您的 邮件",
-    "want_to_respond": "想要 参与 吗？"
+    "want_to_respond": "想要 参与 吗？",
+    "paused_heading": "暂停",
+    "completed_heading": "完成"
   },
   "setup": {
     "intro": {

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -111,7 +111,8 @@
   },
   "c": {
     "link_expired": "您 的 連結 已過期。",
-    "link_expired_description": "您 使用 的 連結 已無效。"
+    "link_expired_description": "您 使用 的 連結 已無效。",
+    "link_expired_heading": "您 的 連結 已過期。"
   },
   "common": {
     "accepted": "已接受",
@@ -2445,7 +2446,9 @@
     "verify_email_before_submission": "驗證您的電子郵件以回應",
     "verify_email_before_submission_button": "驗證",
     "verify_email_before_submission_description": "若要回應此問卷，請驗證您的電子郵件",
-    "want_to_respond": "想要回應嗎？"
+    "want_to_respond": "想要回應嗎？",
+    "paused_heading": "已暫停",
+    "completed_heading": "已完成"
   },
   "setup": {
     "intro": {

--- a/apps/web/modules/survey/link/components/survey-inactive.tsx
+++ b/apps/web/modules/survey/link/components/survey-inactive.tsx
@@ -33,6 +33,14 @@ export const SurveyInactive = async ({
     "link expired": t("c.link_expired_description"),
   };
 
+  const headings = {
+    paused: t("s.paused"),
+    completed: t("s.completed"),
+    "link invalid": t("s.this_looks_fishy"),
+    "response submitted": t("s.survey_already_answered_heading"),
+    "link expired": t("c.link_expired_description"),
+  };
+
   const showCTA =
     status !== "link invalid" &&
     status !== "link expired" &&
@@ -47,7 +55,7 @@ export const SurveyInactive = async ({
         <h1 className="text-4xl font-bold text-slate-800">
           {(status === "completed" || status === "link expired") && surveyClosedMessage
             ? surveyClosedMessage.heading
-            : `${t("common.survey")} ${status}.`}
+            : headings[status]}
         </h1>
         <p className="text-lg leading-10 text-slate-500">
           {status === "completed" && surveyClosedMessage

--- a/apps/web/modules/survey/link/components/survey-inactive.tsx
+++ b/apps/web/modules/survey/link/components/survey-inactive.tsx
@@ -34,11 +34,11 @@ export const SurveyInactive = async ({
   };
 
   const headings = {
-    paused: t("s.paused"),
-    completed: t("s.completed"),
+    paused: t("s.paused_heading"),
+    completed: t("s.completed_heading"),
     "link invalid": t("s.this_looks_fishy"),
     "response submitted": t("s.survey_already_answered_heading"),
-    "link expired": t("c.link_expired_description"),
+    "link expired": t("c.link_expired_heading"),
   };
 
   const showCTA =


### PR DESCRIPTION
## What does this PR do?
Replaces string concatenation in inactive survey headings with status-specific translation keys in survey-inactive.tsx.

Previously the heading used partial translation + raw status interpolation:

```
${t("common.survey")} ${status}.
```

This caused incomplete/awkward translations for some locales.
Now each status maps to a full translated heading string.

Fixes #7817

## How should this be tested?
Open an inactive survey link for each status (paused, completed, link invalid, response submitted, link expired)
Verify the heading is fully translated and no longer rendered via string concatenation
Verify existing closed message override still works when surveyClosedMessage is present for completed / link expired
Checklist

## Required

- Filled out the "How to test" section in this PR
- Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- Self-reviewed my own code
- Commented on my code in hard-to-understand bits
- Ran pnpm build
- Checked for warnings, there are none
- Removed all console.logs
- Merged the latest changes from main onto my branch with git pull origin main
- My changes don't cause any responsiveness issues