### PR TITLE
fix(security): prevent SSRF via redirect following in webhook delivery

### DIFF
--- a/apps/web/app/api/(internal)/pipeline/route.ts
+++ b/apps/web/app/api/(internal)/pipeline/route.ts
@@ -94,7 +94,7 @@ export const POST = async (request: Request) => {
   // Fetch with timeout of 5 seconds to prevent hanging
   const fetchWithTimeout = (url: string, options: RequestInit, timeout: number = 5000): Promise<Response> => {
     return Promise.race([
-      fetch(url, options),
+      fetch(url, { ...options, redirect: "manual" }),
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error("Timeout")), timeout)),
     ]);
   };


### PR DESCRIPTION
## Summary

- Fixes a blind SSRF vulnerability in the pipeline webhook delivery path (`apps/web/app/api/(internal)/pipeline/route.ts`)
- The `fetch()` call followed HTTP redirects by default, allowing an attacker to register a webhook URL that returns a 302 redirect to an internal endpoint (e.g. `http://169.254.169.254/latest/meta-data/`), bypassing the existing `validateWebhookUrl` check which only validates the initial URL
- Sets `redirect: "manual"` on the fetch call so redirects are not followed, closing the bypass vector

## Context

The existing `validateWebhookUrl` function correctly blocks private IPs, internal hostnames, and cloud metadata endpoints — but only on the **initial** URL. Since `fetch()` defaults to `redirect: "follow"`, an attacker-controlled server could redirect the request to an internal target after validation had already passed.

This is a one-line fix with no functional impact on legitimate webhooks (well-behaved webhook endpoints do not redirect).

## References

- https://linear.app/formbricks/issue/ENG-729/hub-qa-core-hub-lifecycle-setup-crud-and-webhooks

## Test plan

- [ ] Verify webhook delivery still works for normal external URLs
- [ ] Confirm that a webhook URL returning a 3xx redirect no longer causes the server to follow the redirect
- [ ] Existing tests pass