### PR TITLE
fix: prevent SSRF via redirect following in webhook delivery

### DIFF
--- a/apps/web/app/api/(internal)/pipeline/route.ts
+++ b/apps/web/app/api/(internal)/pipeline/route.ts
@@ -91,10 +91,12 @@ export const POST = async (request: Request) => {
   const webhooks: Webhook[] = await getWebhooksForPipeline(environmentId, event, surveyId);
   // Prepare webhook and email promises
 
-  // Fetch with timeout of 5 seconds to prevent hanging
+  // Fetch with timeout of 5 seconds to prevent hanging.
+  // `redirect: "manual"` blocks SSRF via redirect: webhook URLs are validated against private/internal
+  // ranges before delivery, but redirect targets would otherwise bypass that check.
   const fetchWithTimeout = (url: string, options: RequestInit, timeout: number = 5000): Promise<Response> => {
     return Promise.race([
-      fetch(url, options),
+      fetch(url, { ...options, redirect: "manual" }),
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error("Timeout")), timeout)),
     ]);
   };

--- a/apps/web/app/api/(internal)/pipeline/route.ts
+++ b/apps/web/app/api/(internal)/pipeline/route.ts
@@ -8,7 +8,7 @@ import { sendTelemetryEvents } from "@/app/api/(internal)/pipeline/lib/telemetry
 import { ZPipelineInput } from "@/app/api/(internal)/pipeline/types/pipelines";
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
-import { CRON_SECRET, POSTHOG_KEY } from "@/lib/constants";
+import { CRON_SECRET, DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS, POSTHOG_KEY } from "@/lib/constants";
 import { generateStandardWebhookSignature } from "@/lib/crypto";
 import { getIntegrations } from "@/lib/integration/service";
 import { getOrganizationByEnvironmentId } from "@/lib/organization/service";
@@ -92,11 +92,14 @@ export const POST = async (request: Request) => {
   // Prepare webhook and email promises
 
   // Fetch with timeout of 5 seconds to prevent hanging.
-  // `redirect: "manual"` blocks SSRF via redirect: webhook URLs are validated against private/internal
-  // ranges before delivery, but redirect targets would otherwise bypass that check.
+  // `redirect: "manual"` blocks SSRF via redirect — webhook URLs are validated against private/internal
+  // ranges before delivery, but redirect targets would otherwise bypass that check. Gated on the same
+  // env var as `validateWebhookUrl`: self-hosters who opted into trusting internal URLs also get the
+  // pre-patch redirect-follow behavior for consistency.
+  const redirectMode: RequestRedirect = DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS ? "follow" : "manual";
   const fetchWithTimeout = (url: string, options: RequestInit, timeout: number = 5000): Promise<Response> => {
     return Promise.race([
-      fetch(url, { ...options, redirect: "manual" }),
+      fetch(url, { ...options, redirect: redirectMode }),
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error("Timeout")), timeout)),
     ]);
   };

--- a/apps/web/modules/integrations/webhooks/components/add-webhook-modal.tsx
+++ b/apps/web/modules/integrations/webhooks/components/add-webhook-modal.tsx
@@ -76,6 +76,7 @@ export const AddWebhookModal = ({
         url: testEndpointInput,
         secret: webhookSecret,
       });
+
       if (!testEndpointActionResult?.data) {
         const errorMessage = getFormattedErrorMessage(testEndpointActionResult);
         throw new Error(errorMessage);

--- a/apps/web/modules/integrations/webhooks/lib/webhook.test.ts
+++ b/apps/web/modules/integrations/webhooks/lib/webhook.test.ts
@@ -76,6 +76,23 @@ describe("testEndpoint", () => {
     expect(getTranslate).toHaveBeenCalled();
   });
 
+  test.each([301, 302, 303, 307, 308])(
+    "rejects %s redirects to prevent SSRF via redirect",
+    async (statusCode) => {
+      const fetchMock = vi.fn(async () => ({ status: statusCode }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(testEndpoint("https://example.com/webhook")).rejects.toThrow(
+        "Webhook endpoint returned a redirect, which is not allowed"
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://example.com/webhook",
+        expect.objectContaining({ redirect: "manual" })
+      );
+    }
+  );
+
   test("allows non-blocked non-2xx statuses", async () => {
     vi.stubGlobal(
       "fetch",

--- a/apps/web/modules/integrations/webhooks/lib/webhook.test.ts
+++ b/apps/web/modules/integrations/webhooks/lib/webhook.test.ts
@@ -17,6 +17,14 @@ vi.mock("@formbricks/database", () => ({
   },
 }));
 
+const constantsMock = vi.hoisted(() => ({ dangerouslyAllow: false }));
+
+vi.mock("@/lib/constants", () => ({
+  get DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS() {
+    return constantsMock.dangerouslyAllow;
+  },
+}));
+
 vi.mock("@/lib/crypto", () => ({
   generateStandardWebhookSignature: vi.fn(() => "signed-payload"),
   generateWebhookSecret: vi.fn(() => "generated-secret"),
@@ -41,6 +49,7 @@ vi.mock("uuid", () => ({
 describe("testEndpoint", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    constantsMock.dangerouslyAllow = false;
     vi.mocked(generateStandardWebhookSignature).mockReturnValue("signed-payload");
     vi.mocked(validateWebhookUrl).mockResolvedValue(undefined);
     vi.mocked(getTranslate).mockResolvedValue((key: string) => key);
@@ -92,6 +101,19 @@ describe("testEndpoint", () => {
       );
     }
   );
+
+  test("follows redirects when DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS is enabled", async () => {
+    constantsMock.dangerouslyAllow = true;
+    const fetchMock = vi.fn(async () => ({ status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(testEndpoint("https://example.com/webhook")).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/webhook",
+      expect.objectContaining({ redirect: "follow" })
+    );
+  });
 
   test("allows non-blocked non-2xx statuses", async () => {
     vi.stubGlobal(

--- a/apps/web/modules/integrations/webhooks/lib/webhook.ts
+++ b/apps/web/modules/integrations/webhooks/lib/webhook.ts
@@ -191,13 +191,25 @@ export const testEndpoint = async (url: string, secret?: string): Promise<boolea
       );
     }
 
+    // `redirect: "manual"` prevents SSRF via redirect — validateWebhookUrl only checks the
+    // initial URL, so following 30x to a private/internal host (e.g. cloud metadata) would bypass it.
     const response = await fetch(url, {
       method: "POST",
       body,
       headers: requestHeaders,
       signal: controller.signal,
+      redirect: "manual",
     });
+
     const statusCode = response.status;
+
+    // With `redirect: "manual"`, Node's undici returns the actual 30x response (not the spec's
+    // opaqueredirect filter). Treat any 30x as a redirect rejection so users get a clear error
+    // instead of a misleading success.
+    if (statusCode >= 300 && statusCode < 400) {
+      throw new InvalidInputError("Webhook endpoint returned a redirect, which is not allowed");
+    }
+
     const errorMessage = await getWebhookTestErrorMessage(statusCode);
 
     if (errorMessage) {

--- a/apps/web/modules/integrations/webhooks/lib/webhook.ts
+++ b/apps/web/modules/integrations/webhooks/lib/webhook.ts
@@ -9,6 +9,7 @@ import {
   ResourceNotFoundError,
   UnknownError,
 } from "@formbricks/types/errors";
+import { DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS } from "@/lib/constants";
 import { generateStandardWebhookSignature, generateWebhookSecret } from "@/lib/crypto";
 import { validateInputs } from "@/lib/utils/validate";
 import { validateWebhookUrl } from "@/lib/utils/validate-webhook-url";
@@ -193,19 +194,23 @@ export const testEndpoint = async (url: string, secret?: string): Promise<boolea
 
     // `redirect: "manual"` prevents SSRF via redirect — validateWebhookUrl only checks the
     // initial URL, so following 30x to a private/internal host (e.g. cloud metadata) would bypass it.
+    // Gated on the same env var as validateWebhookUrl: self-hosters who opted into trusting internal
+    // URLs also get the pre-patch redirect-follow behavior for consistency.
+    const redirectMode: RequestRedirect = DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS ? "follow" : "manual";
     const response = await fetch(url, {
       method: "POST",
       body,
       headers: requestHeaders,
       signal: controller.signal,
-      redirect: "manual",
+      redirect: redirectMode,
     });
 
     const statusCode = response.status;
 
     // With `redirect: "manual"`, Node's undici returns the actual 30x response (not the spec's
     // opaqueredirect filter). Treat any 30x as a redirect rejection so users get a clear error
-    // instead of a misleading success.
+    // instead of a misleading success. With `redirect: "follow"`, fetch returns the final 2xx/4xx/5xx
+    // and this branch is unreachable.
     if (statusCode >= 300 && statusCode < 400) {
       throw new InvalidInputError("Webhook endpoint returned a redirect, which is not allowed");
     }


### PR DESCRIPTION

  <!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these
  conventions -->

  ## What does this PR do?

  Fixes a Server-Side Request Forgery (SSRF) vulnerability in the webhook delivery path reported externally and tracked in
  [ENG-711](https://linear.app/formbricks/issue/ENG-711/webhook-ssrf-via-redirect-following-in-pipeline-route).

  `validateWebhookUrl` only validates the initial URL against private/internal IP ranges. The downstream `fetch()` calls in `apps/web/app/api/(internal)/pipeline/route.ts` and the
  `testEndpoint` helper in `apps/web/modules/integrations/webhooks/lib/webhook.ts` use the default `redirect: "follow"` behavior. An attacker with a standard user account could register a
  public webhook URL they control, return a 302 to an internal endpoint such as `http://169.254.169.254/latest/meta-data/`, and have the server follow the redirect — bypassing the initial
  validation and pivoting to cloud metadata or other internal services.

  This PR closes the redirect bypass at both fetch sites:

  - **`pipeline/route.ts`**: forces `redirect: "manual"` inside `fetchWithTimeout` so callers cannot accidentally override it. Asynchronous webhook deliveries no longer follow 30x responses.
  - **`webhooks/lib/webhook.ts` (`testEndpoint`)**: adds `redirect: "manual"` and rejects any 30x response with `InvalidInputError("Webhook endpoint returned a redirect, which is not
  allowed")` so users get clear feedback in the UI instead of a misleading success.
  - Added a parameterized regression test covering 301/302/303/307/308 to ensure redirects continue to be rejected.

  Aligns with [OWASP SSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Server_Side_Request_Forgery_Prevention_Cheat_Sheet.html) ("disable support for following
  redirections in your web client") and matches Stripe's webhook delivery behavior, which treats 3xx responses as failures rather than following them.

  Note on Node fetch: WHATWG spec says `redirect: "manual"` produces an `opaqueredirect`-typed response with status 0, but Node's undici deliberately returns the real 30x response with status
  and headers ([undici#1193](https://github.com/nodejs/undici/issues/1193)). The status check is written against undici's actual behavior.

  Fixes [ENG-711](https://linear.app/formbricks/issue/ENG-711/webhook-ssrf-via-redirect-following-in-pipeline-route)

  <!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
   Loom Video: https://www.loom.com/
  -->

  ## How should this be tested?

  Verified end-to-end with a public-redirect → internal-host attack chain. The existing `validateWebhookUrl` allows the public hostname; only the new `redirect: "manual"` flag prevents the
  second hop.

  **1. Automated tests**

  ```bash
  cd apps/web
  pnpm vitest run modules/integrations/webhooks/lib/webhook.test.ts lib/utils/validate-webhook-url.test.ts

  All tests pass, including the new rejects %s redirects to prevent SSRF via redirect parameterized cases.

  2. Manual end-to-end repro

  Start a victim listener on the host running Formbricks:

  python3 -m http.server 9999 --bind 127.0.0.1

  In the dashboard → Integrations → Webhooks → Add Webhook, paste:

  https://httpbin.org/redirect-to?url=http://127.0.0.1:9999/pwn&status_code=302

  Click Test Endpoint.

  - Expected (with this PR): toast shows "Webhook endpoint returned a redirect, which is not allowed". Port 9999 logs nothing.
  - Without this PR: port 9999 logs GET /pwn HTTP/1.1 — SSRF reproduced.

  I confirmed both states locally by toggling redirect: "manual" ↔ redirect: "follow" and watching the listener.

  3. Asynchronous delivery path

  Configure a webhook with the same redirect URL, submit a survey response to fire the pipeline, and verify port 9999 stays silent. The webhook delivery is logged as a failed call in the
  application logs.