### PR TITLE
docs: document option ID prefilling

### DIFF
--- a/docs/xm-and-surveys/surveys/link-surveys/data-prefilling.mdx
+++ b/docs/xm-and-surveys/surveys/link-surveys/data-prefilling.mdx
@@ -118,19 +118,18 @@ Single Select and Multi Select questions support prefilling with **option IDs** 
 - **Language-independent:** The same URL works across all survey languages.
 - **Reliable:** No brittle string matching and fewer URL-encoding issues.
 
-### One link per option (with `skipPrefilled=true`)
+### One link per option
 
-When you create one CTA link per answer option (for example in emails), use the option ID as value and append `skipPrefilled=true` so respondents are directly sent to the next question.
+When you create one CTA link per answer option (for example in emails), use the option ID as the parameter value:
 
-```sh Option-ID prefill with skipPrefilled
-https://app.formbricks.com/s/cmoh0584taxoxu501jyvk8tzn?tuk2i9ktui1lee0mfos82czb=e2r697fou23n7ba4vmt7you6&skipPrefilled=true
+```sh Option-ID prefill
+https://app.formbricks.com/s/cmoh0584taxoxu501jyvk8tzn?tuk2i9ktui1lee0mfos82czb=e2r697fou23n7ba4vmt7you6
 ```
 
 In this example:
 
 - `tuk2i9ktui1lee0mfos82czb` is the question ID.
 - `e2r697fou23n7ba4vmt7you6` is the selected option ID.
-- `skipPrefilled=true` skips that prefilled question.
 
 ### How to Find Option IDs
 

--- a/docs/xm-and-surveys/surveys/link-surveys/data-prefilling.mdx
+++ b/docs/xm-and-surveys/surveys/link-surveys/data-prefilling.mdx
@@ -24,8 +24,8 @@ https://app.formbricks.com/s/clin3dxja02k8l80hpwmx4bjy?question_id_1=answer_1&qu
 
 ## How it works
 
-1. To prefill survey questions, add query parameters to the survey URL using the format `questionId=answer`. 
-2. The answer must match the question’s expected type to pass [validation](/xm-and-surveys/surveys/link-surveys/data-prefilling#validation).
+1. To prefill survey questions, add query parameters to the survey URL using the format `questionId=answer`.
+2. The answer must match the question’s expected type to pass [validation](/xm-and-surveys/surveys/link-surveys/data-prefilling#validation). For Single Select and Multi Select questions, `answer` can be either the option label text or the option ID.
 3. The answer needs to be [URL encoded](https://www.urlencoder.org/) (if it contains spaces or special characters)
 
 
@@ -108,15 +108,29 @@ https://app.formbricks.com/s/clin3yxja52k8l80hpwmx4bjy?pictureSelection_question
 ```
 
 
-## Using Option IDs for Choice-Based Questions
+## Using Option IDs for Single Select and Multi Select Questions
 
-All choice-based question types (Single Select, Multi Select, Picture Selection) now support prefilling with **option IDs** in addition to option labels. This is the recommended approach as it's more reliable and doesn't break when you update option text.
+Single Select and Multi Select questions support prefilling with **option IDs** in addition to option labels. This is the most robust approach and the recommended default, especially for multilingual surveys.
 
-### Benefits of Using Option IDs
+### Why Option IDs are recommended
 
-- **Stable:** Option IDs don't change when you edit the option label text
-- **Language-independent:** Works across all survey languages without modification
-- **Reliable:** No issues with special characters or URL encoding of complex text
+- **Stable:** Option IDs don't change when you edit option labels.
+- **Language-independent:** The same URL works across all survey languages.
+- **Reliable:** No brittle string matching and fewer URL-encoding issues.
+
+### One link per option (with `skipPrefilled=true`)
+
+When you create one CTA link per answer option (for example in emails), use the option ID as value and append `skipPrefilled=true` so respondents are directly sent to the next question.
+
+```sh Option-ID prefill with skipPrefilled
+https://app.formbricks.com/s/cmoh0584taxoxu501jyvk8tzn?tuk2i9ktui1lee0mfos82czb=e2r697fou23n7ba4vmt7you6&skipPrefilled=true
+```
+
+In this example:
+
+- `tuk2i9ktui1lee0mfos82czb` is the question ID.
+- `e2r697fou23n7ba4vmt7you6` is the selected option ID.
+- `skipPrefilled=true` skips that prefilled question.
 
 ### How to Find Option IDs
 
@@ -160,7 +174,7 @@ The URL validation works as follows:
 - **Rating or NPS questions:** The response is parsed as a number and verified to be within the valid range.
 - **Consent type questions:** Valid values are "accepted" (consent given) and "dismissed" (consent not given).
 - **Picture Selection questions:** The response is parsed as comma-separated numbers (1-based indices) and verified against available choices.
-- **Single/Multi Select questions:** Values can be either option IDs or exact label text. The system tries to match by option ID first, then falls back to label matching.
+- **Single/Multi Select questions:** Values can be either option IDs or exact label text. The system tries option ID matching first, then falls back to label matching.
 - **Open Text questions:** Any string value is accepted.
 
 <Note>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Updates the Link Survey data prefilling docs to explicitly document prefilling Single Select and Multi Select answers via option IDs, and highlights this as the recommended/most robust approach for multilingual surveys.

Adds a concrete "one link per option" example using the option ID pattern (`questionId=optionId`) and clarifies ID-first matching behavior.

Fixes #(issue)

## How should this be tested?

- Open `docs/xm-and-surveys/surveys/link-surveys/data-prefilling.mdx`
- Verify the "Using Option IDs for Single Select and Multi Select Questions" section now:
  - Recommends option IDs for multilingual reliability
  - Includes the per-option Option-ID prefill example (without `skipPrefilled`)
  - Clarifies that ID matching is attempted before label matching
- Confirm validation text aligns with behavior: Single/Multi Select support ID or label; Picture Selection still uses index values.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45cc0c2d-d5fe-49ac-9a07-7a2a275680b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45cc0c2d-d5fe-49ac-9a07-7a2a275680b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

