### PR TITLE
feat: add PostHog experiment wrappers

### DIFF
--- a/apps/web/lib/posthog/client.test.ts
+++ b/apps/web/lib/posthog/client.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getFeatureFlag: vi.fn(),
+  posthog: {
+    __loaded: false,
+    getFeatureFlag: vi.fn(),
+  },
+}));
+
+vi.mock("posthog-js", () => ({
+  default: mocks.posthog,
+}));
+
+describe("getPostHogClientFeatureFlag", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.posthog.__loaded = false;
+    mocks.posthog.getFeatureFlag = mocks.getFeatureFlag;
+  });
+
+  test("returns false before PostHog is initialized", async () => {
+    const { getPostHogClientFeatureFlag } = await import("./client");
+
+    expect(getPostHogClientFeatureFlag("test-flag")).toBe(false);
+    expect(mocks.getFeatureFlag).not.toHaveBeenCalled();
+  });
+
+  test("returns true from posthog.getFeatureFlag", async () => {
+    mocks.posthog.__loaded = true;
+    mocks.getFeatureFlag.mockReturnValue(true);
+
+    const { getPostHogClientFeatureFlag } = await import("./client");
+
+    expect(getPostHogClientFeatureFlag("test-flag")).toBe(true);
+  });
+
+  test("returns false from posthog.getFeatureFlag", async () => {
+    mocks.posthog.__loaded = true;
+    mocks.getFeatureFlag.mockReturnValue(false);
+
+    const { getPostHogClientFeatureFlag } = await import("./client");
+
+    expect(getPostHogClientFeatureFlag("test-flag")).toBe(false);
+  });
+
+  test("returns variant string from posthog.getFeatureFlag", async () => {
+    mocks.posthog.__loaded = true;
+    mocks.getFeatureFlag.mockReturnValue("variant-a");
+
+    const { getPostHogClientFeatureFlag } = await import("./client");
+
+    expect(getPostHogClientFeatureFlag("test-flag")).toBe("variant-a");
+  });
+
+  test("coerces undefined to false", async () => {
+    mocks.posthog.__loaded = true;
+    mocks.getFeatureFlag.mockReturnValue(undefined);
+
+    const { getPostHogClientFeatureFlag } = await import("./client");
+
+    expect(getPostHogClientFeatureFlag("test-flag")).toBe(false);
+  });
+});

--- a/apps/web/lib/posthog/client.ts
+++ b/apps/web/lib/posthog/client.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import posthog from "posthog-js";
-import { TPostHogFeatureFlagValue } from "./types";
+import type { TPostHogFeatureFlagValue } from "./types";
 
 export const getPostHogClientFeatureFlag = (flagKey: string): TPostHogFeatureFlagValue => {
   if (!posthog.__loaded) {
@@ -9,7 +9,7 @@ export const getPostHogClientFeatureFlag = (flagKey: string): TPostHogFeatureFla
   }
 
   const featureFlagValue = posthog.getFeatureFlag(flagKey);
-  return featureFlagValue === undefined ? false : featureFlagValue;
+  return featureFlagValue ?? false;
 };
 
 export type { TPostHogFeatureFlagContext, TPostHogFeatureFlagValue } from "./types";

--- a/apps/web/lib/posthog/client.ts
+++ b/apps/web/lib/posthog/client.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import posthog from "posthog-js";
+import { TPostHogFeatureFlagValue } from "./types";
+
+export const getPostHogClientFeatureFlag = (flagKey: string): TPostHogFeatureFlagValue => {
+  if (!posthog.__loaded) {
+    return false;
+  }
+
+  const featureFlagValue = posthog.getFeatureFlag(flagKey);
+  return featureFlagValue === undefined ? false : featureFlagValue;
+};
+
+export type { TPostHogFeatureFlagContext, TPostHogFeatureFlagValue } from "./types";

--- a/apps/web/lib/posthog/get-feature-flag.test.ts
+++ b/apps/web/lib/posthog/get-feature-flag.test.ts
@@ -11,12 +11,12 @@ describe("getPostHogFeatureFlag", () => {
     vi.resetModules();
   });
 
-  test("returns false when cloud mode is off", async () => {
+  test("returns false when PostHog is not configured", async () => {
     vi.doMock("server-only", () => ({}));
     vi.doMock("@formbricks/logger", () => ({
       logger: { warn: mocks.loggerWarn },
     }));
-    vi.doMock("@/lib/constants", () => ({ IS_FORMBRICKS_CLOUD: false }));
+    vi.doMock("@/lib/constants", () => ({ POSTHOG_KEY: undefined }));
     vi.doMock("./server", () => ({
       posthogServerClient: { getFeatureFlag: mocks.getFeatureFlag },
     }));
@@ -33,7 +33,7 @@ describe("getPostHogFeatureFlag", () => {
     vi.doMock("@formbricks/logger", () => ({
       logger: { warn: mocks.loggerWarn },
     }));
-    vi.doMock("@/lib/constants", () => ({ IS_FORMBRICKS_CLOUD: true }));
+    vi.doMock("@/lib/constants", () => ({ POSTHOG_KEY: "phc_test_key" }));
     vi.doMock("./server", () => ({
       posthogServerClient: null,
     }));
@@ -52,7 +52,7 @@ describe("getPostHogFeatureFlag", () => {
     vi.doMock("@formbricks/logger", () => ({
       logger: { warn: mocks.loggerWarn },
     }));
-    vi.doMock("@/lib/constants", () => ({ IS_FORMBRICKS_CLOUD: true }));
+    vi.doMock("@/lib/constants", () => ({ POSTHOG_KEY: "phc_test_key" }));
     vi.doMock("./server", () => ({
       posthogServerClient: { getFeatureFlag: mocks.getFeatureFlag },
     }));
@@ -81,7 +81,7 @@ describe("getPostHogFeatureFlag", () => {
     vi.doMock("@formbricks/logger", () => ({
       logger: { warn: mocks.loggerWarn },
     }));
-    vi.doMock("@/lib/constants", () => ({ IS_FORMBRICKS_CLOUD: true }));
+    vi.doMock("@/lib/constants", () => ({ POSTHOG_KEY: "phc_test_key" }));
     vi.doMock("./server", () => ({
       posthogServerClient: { getFeatureFlag: mocks.getFeatureFlag },
     }));
@@ -98,7 +98,7 @@ describe("getPostHogFeatureFlag", () => {
     vi.doMock("@formbricks/logger", () => ({
       logger: { warn: mocks.loggerWarn },
     }));
-    vi.doMock("@/lib/constants", () => ({ IS_FORMBRICKS_CLOUD: true }));
+    vi.doMock("@/lib/constants", () => ({ POSTHOG_KEY: "phc_test_key" }));
     vi.doMock("./server", () => ({
       posthogServerClient: { getFeatureFlag: mocks.getFeatureFlag },
     }));
@@ -115,7 +115,7 @@ describe("getPostHogFeatureFlag", () => {
     vi.doMock("@formbricks/logger", () => ({
       logger: { warn: mocks.loggerWarn },
     }));
-    vi.doMock("@/lib/constants", () => ({ IS_FORMBRICKS_CLOUD: true }));
+    vi.doMock("@/lib/constants", () => ({ POSTHOG_KEY: "phc_test_key" }));
     vi.doMock("./server", () => ({
       posthogServerClient: { getFeatureFlag: mocks.getFeatureFlag },
     }));

--- a/apps/web/lib/posthog/get-feature-flag.test.ts
+++ b/apps/web/lib/posthog/get-feature-flag.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getFeatureFlag: vi.fn(),
+  loggerWarn: vi.fn(),
+}));
+
+describe("getPostHogFeatureFlag", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  test("returns false when cloud mode is off", async () => {
+    vi.doMock("server-only", () => ({}));
+    vi.doMock("@formbricks/logger", () => ({
+      logger: { warn: mocks.loggerWarn },
+    }));
+    vi.doMock("@/lib/constants", () => ({ IS_FORMBRICKS_CLOUD: false }));
+    vi.doMock("./server", () => ({
+      posthogServerClient: { getFeatureFlag: mocks.getFeatureFlag },
+    }));
+
+    const { getPostHogFeatureFlag } = await import("./get-feature-flag");
+
+    await expect(getPostHogFeatureFlag("user123", "test-flag")).resolves.toBe(false);
+    expect(mocks.getFeatureFlag).not.toHaveBeenCalled();
+    expect(mocks.loggerWarn).not.toHaveBeenCalled();
+  });
+
+  test("returns false when posthogServerClient is null", async () => {
+    vi.doMock("server-only", () => ({}));
+    vi.doMock("@formbricks/logger", () => ({
+      logger: { warn: mocks.loggerWarn },
+    }));
+    vi.doMock("@/lib/constants", () => ({ IS_FORMBRICKS_CLOUD: true }));
+    vi.doMock("./server", () => ({
+      posthogServerClient: null,
+    }));
+
+    const { getPostHogFeatureFlag } = await import("./get-feature-flag");
+
+    await expect(getPostHogFeatureFlag("user123", "test-flag")).resolves.toBe(false);
+    expect(mocks.getFeatureFlag).not.toHaveBeenCalled();
+    expect(mocks.loggerWarn).not.toHaveBeenCalled();
+  });
+
+  test("forwards distinctId, flagKey, and mapped groups to PostHog", async () => {
+    mocks.getFeatureFlag.mockResolvedValue(true);
+
+    vi.doMock("server-only", () => ({}));
+    vi.doMock("@formbricks/logger", () => ({
+      logger: { warn: mocks.loggerWarn },
+    }));
+    vi.doMock("@/lib/constants", () => ({ IS_FORMBRICKS_CLOUD: true }));
+    vi.doMock("./server", () => ({
+      posthogServerClient: { getFeatureFlag: mocks.getFeatureFlag },
+    }));
+
+    const { getPostHogFeatureFlag } = await import("./get-feature-flag");
+
+    await expect(
+      getPostHogFeatureFlag("user123", "experiment-flag", {
+        organizationId: "org_123",
+        workspaceId: "ws_456",
+      })
+    ).resolves.toBe(true);
+
+    expect(mocks.getFeatureFlag).toHaveBeenCalledWith("experiment-flag", "user123", {
+      groups: {
+        organization: "org_123",
+        workspace: "ws_456",
+      },
+    });
+  });
+
+  test("preserves variant string responses", async () => {
+    mocks.getFeatureFlag.mockResolvedValue("variant-a");
+
+    vi.doMock("server-only", () => ({}));
+    vi.doMock("@formbricks/logger", () => ({
+      logger: { warn: mocks.loggerWarn },
+    }));
+    vi.doMock("@/lib/constants", () => ({ IS_FORMBRICKS_CLOUD: true }));
+    vi.doMock("./server", () => ({
+      posthogServerClient: { getFeatureFlag: mocks.getFeatureFlag },
+    }));
+
+    const { getPostHogFeatureFlag } = await import("./get-feature-flag");
+
+    await expect(getPostHogFeatureFlag("user123", "experiment-flag")).resolves.toBe("variant-a");
+  });
+
+  test("coerces undefined to false", async () => {
+    mocks.getFeatureFlag.mockResolvedValue(undefined);
+
+    vi.doMock("server-only", () => ({}));
+    vi.doMock("@formbricks/logger", () => ({
+      logger: { warn: mocks.loggerWarn },
+    }));
+    vi.doMock("@/lib/constants", () => ({ IS_FORMBRICKS_CLOUD: true }));
+    vi.doMock("./server", () => ({
+      posthogServerClient: { getFeatureFlag: mocks.getFeatureFlag },
+    }));
+
+    const { getPostHogFeatureFlag } = await import("./get-feature-flag");
+
+    await expect(getPostHogFeatureFlag("user123", "experiment-flag")).resolves.toBe(false);
+  });
+
+  test("logs and returns false when PostHog throws", async () => {
+    mocks.getFeatureFlag.mockRejectedValue(new Error("network error"));
+
+    vi.doMock("server-only", () => ({}));
+    vi.doMock("@formbricks/logger", () => ({
+      logger: { warn: mocks.loggerWarn },
+    }));
+    vi.doMock("@/lib/constants", () => ({ IS_FORMBRICKS_CLOUD: true }));
+    vi.doMock("./server", () => ({
+      posthogServerClient: { getFeatureFlag: mocks.getFeatureFlag },
+    }));
+
+    const { getPostHogFeatureFlag } = await import("./get-feature-flag");
+
+    await expect(getPostHogFeatureFlag("user123", "experiment-flag")).resolves.toBe(false);
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      { error: expect.any(Error), flagKey: "experiment-flag" },
+      "Failed to evaluate PostHog feature flag"
+    );
+  });
+});

--- a/apps/web/lib/posthog/get-feature-flag.ts
+++ b/apps/web/lib/posthog/get-feature-flag.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { logger } from "@formbricks/logger";
-import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { POSTHOG_KEY } from "@/lib/constants";
 import { posthogServerClient } from "./server";
 import { TPostHogFeatureFlagContext, TPostHogFeatureFlagValue } from "./types";
 
@@ -18,7 +18,7 @@ export const getPostHogFeatureFlag = async (
   flagKey: string,
   context?: TPostHogFeatureFlagContext
 ): Promise<TPostHogFeatureFlagValue> => {
-  if (!IS_FORMBRICKS_CLOUD || !posthogServerClient) {
+  if (!POSTHOG_KEY || !posthogServerClient) {
     return false;
   }
 

--- a/apps/web/lib/posthog/get-feature-flag.ts
+++ b/apps/web/lib/posthog/get-feature-flag.ts
@@ -1,0 +1,35 @@
+import "server-only";
+import { logger } from "@formbricks/logger";
+import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { posthogServerClient } from "./server";
+import { TPostHogFeatureFlagContext, TPostHogFeatureFlagValue } from "./types";
+
+const buildPostHogGroups = (context?: TPostHogFeatureFlagContext): Record<string, string> | undefined => {
+  const groups = {
+    ...(context?.organizationId ? { organization: context.organizationId } : {}),
+    ...(context?.workspaceId ? { workspace: context.workspaceId } : {}),
+  };
+
+  return Object.keys(groups).length > 0 ? groups : undefined;
+};
+
+export const getPostHogFeatureFlag = async (
+  distinctId: string,
+  flagKey: string,
+  context?: TPostHogFeatureFlagContext
+): Promise<TPostHogFeatureFlagValue> => {
+  if (!IS_FORMBRICKS_CLOUD || !posthogServerClient) {
+    return false;
+  }
+
+  try {
+    const featureFlagValue = await posthogServerClient.getFeatureFlag(flagKey, distinctId, {
+      groups: buildPostHogGroups(context),
+    });
+
+    return featureFlagValue === undefined ? false : featureFlagValue;
+  } catch (error) {
+    logger.warn({ error, flagKey }, "Failed to evaluate PostHog feature flag");
+    return false;
+  }
+};

--- a/apps/web/lib/posthog/get-feature-flag.ts
+++ b/apps/web/lib/posthog/get-feature-flag.ts
@@ -2,7 +2,7 @@ import "server-only";
 import { logger } from "@formbricks/logger";
 import { POSTHOG_KEY } from "@/lib/constants";
 import { posthogServerClient } from "./server";
-import { TPostHogFeatureFlagContext, TPostHogFeatureFlagValue } from "./types";
+import type { TPostHogFeatureFlagContext, TPostHogFeatureFlagValue } from "./types";
 
 const buildPostHogGroups = (context?: TPostHogFeatureFlagContext): Record<string, string> | undefined => {
   const groups = {
@@ -27,7 +27,7 @@ export const getPostHogFeatureFlag = async (
       groups: buildPostHogGroups(context),
     });
 
-    return featureFlagValue === undefined ? false : featureFlagValue;
+    return featureFlagValue ?? false;
   } catch (error) {
     logger.warn({ error, flagKey }, "Failed to evaluate PostHog feature flag");
     return false;

--- a/apps/web/lib/posthog/index.ts
+++ b/apps/web/lib/posthog/index.ts
@@ -1,1 +1,5 @@
+import "server-only";
+
 export { capturePostHogEvent } from "./capture";
+export { getPostHogFeatureFlag } from "./get-feature-flag";
+export type { TPostHogFeatureFlagContext, TPostHogFeatureFlagValue } from "./types";

--- a/apps/web/lib/posthog/types.ts
+++ b/apps/web/lib/posthog/types.ts
@@ -1,0 +1,6 @@
+export type TPostHogFeatureFlagValue = boolean | string;
+
+export type TPostHogFeatureFlagContext = {
+  organizationId?: string;
+  workspaceId?: string;
+};


### PR DESCRIPTION
## Summary

- add server and client PostHog feature-flag wrappers for A/B experiments
- keep evaluation Cloud-only and normalize unsupported/unconfigured cases to `false`
- add focused unit coverage for server and client flag lookup behavior

Fixes ENG-703

## Why

- provide a single safe abstraction for PostHog experiment checks instead of ad hoc SDK calls
- preserve multivariate experiment variants by using `getFeatureFlag(...)` under the hood
- prepare the wrapper interface for organization and workspace scoped experiments without taking the ENG-705 group-analytics dependency in this PR

## Impact

- server code can call `getPostHogFeatureFlag(...)` with optional organization/workspace context
- client code can call `getPostHogClientFeatureFlag(...)` without importing server-only modules
- self-hosted and unconfigured environments continue to behave safely by returning `false`

## Validation

- `pnpm exec vitest run apps/web/lib/posthog/get-feature-flag.test.ts apps/web/lib/posthog/client.test.ts apps/web/lib/posthog/capture.test.ts apps/web/lib/posthog/server.test.ts`
- `pnpm exec eslint apps/web/lib/posthog/index.ts apps/web/lib/posthog/types.ts apps/web/lib/posthog/get-feature-flag.ts apps/web/lib/posthog/client.ts apps/web/lib/posthog/get-feature-flag.test.ts apps/web/lib/posthog/client.test.ts`
- `pnpm exec tsc -p apps/web/tsconfig.json --noEmit` currently fails on unrelated pre-existing repo errors outside this change

Linear: https://linear.app/formbricks/issue/ENG-703/add-ab-experiment-wrapper-for-posthog-experiments
