### PR TITLE
fix: allow back navigation to prefilled questions in email embed surveys

### DIFF
--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -256,6 +256,7 @@ export function Survey({
   const [selectedLanguage, setSelectedLanguage] = useState(languageCode);
   const [loadingElement, setLoadingElement] = useState(false);
   const [history, setHistory] = useState<string[]>([]);
+  const isNavigatingBackRef = useRef(false);
   const [responseData, setResponseData] = useState<TResponseData>(hiddenFieldsRecord ?? {});
   const [_variableStack, setVariableStack] = useState<VariableStackEntry[]>([]);
 
@@ -916,6 +917,8 @@ export function Survey({
   }, [isResponseSendingFinished, isSurveyFinished, onFinished]);
 
   const onSubmit = async (surveyResponseData: TResponseData, responsettc: TResponseTtc) => {
+    isNavigatingBackRef.current = false;
+
     // Get the first responded element ID for tracking
     const respondedElementIds = Object.keys(surveyResponseData);
     const firstRespondedElementId = respondedElementIds[0];
@@ -1003,6 +1006,8 @@ export function Survey({
   };
 
   const onBack = (): void => {
+    isNavigatingBackRef.current = true;
+
     let prevBlockId: string | undefined;
     // use history if available
     if (history.length > 0) {
@@ -1134,7 +1139,7 @@ export function Survey({
               setTtc={setTtc}
               onFileUpload={onFileUpload}
               isFirstBlock={block.id === localSurvey.blocks[0]?.id}
-              skipPrefilled={skipPrefilled}
+              skipPrefilled={skipPrefilled && !isNavigatingBackRef.current}
               prefilledResponseData={offset === 0 ? prefillResponseData : undefined}
               isLastBlock={block.id === localSurvey.blocks[localSurvey.blocks.length - 1].id}
               languageCode={selectedLanguage}


### PR DESCRIPTION
## Summary

When a survey is opened from an email embed (e.g., clicking a rating option), the URL includes `skipPrefilled=true` along with the prefilled answer. The survey correctly auto-submits the first block and skips to the second question.

However, when the user clicks **Back**, they cannot return to the prefilled question — the block remounts with `skipPrefilled` still active, immediately auto-submitting again and pushing the user forward in an infinite loop.

Fixes : https://linear.app/formbricks/issue/ENG-723/going-back-glitches-email-embed-surveys

### Root Cause

In `block-conditional.tsx`, the prefill `useEffect` (with an empty dependency array) runs every time the component mounts. Since `BlockConditional` uses `key={block.id}`, navigating back causes a remount, re-triggering the auto-submit.

### Fix

- Added an `isNavigatingBackRef` ref in `survey.tsx` to track navigation direction
- Set to `true` in `onBack()`, reset to `false` in `onSubmit()`
- Pass `skipPrefilled={skipPrefilled && !isNavigatingBackRef.current}` to `BlockConditional`

This ensures prefilled blocks render normally (with answers pre-populated but visible) when the user navigates back, while preserving auto-skip behavior on initial forward navigation.

## Test Plan

- [ ] Create a survey with a rating question as the first question
- [ ] Set up email embed for the survey
- [ ] Click a rating option in the email — survey should open and skip to question 2
- [ ] Click **Back** — should now show question 1 with the prefilled rating visible
- [ ] Verify the user can change the answer or proceed forward normally
- [ ] Verify that initial forward skip still works on fresh survey load