### PR TITLE
fix: include partial response in trigger description

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -1192,6 +1192,7 @@ checksums:
     environments/settings/profile/update_personal_info: 5806f9bae0248a604cf85a2d8790a606
     environments/settings/profile/warning_cannot_delete_account: 07c25c3829149cd7171e7ad88229deac
     environments/settings/profile/warning_cannot_undo: dd1b2a59ff244b362d1d0d4eb1dbf7c6
+    environments/settings/profile/wrong_password: e3523f78b302d11b33af6cc40d8df9da
     environments/settings/teams/add_members_description: 96e1e7125a0dfeaecc2c238eda3a216f
     environments/settings/teams/add_workspaces_description: f0f0cdd4d1032fbcb83d34a780bdfa52
     environments/settings/teams/all_members_added: 0541be1777b5c838f2e039035488506c
@@ -1481,7 +1482,7 @@ checksums:
     environments/surveys/edit/hide_question_settings: 99127cd016db2f7fc80333b36473c0ef
     environments/surveys/edit/hostname: 9bdaa7692869999df51bb60d58d9ef62
     environments/surveys/edit/if_you_need_more_please: a7d208c283caf6b93800b809fca80768
-    environments/surveys/edit/if_you_really_want_that_answer_ask_until_you_get_it: 31c18a8c7c578db2ba49eed663d1739f
+    environments/surveys/edit/if_you_really_want_that_answer_ask_until_you_get_it: 5abd8b702f9fb0e3815c3413d6f8aef6
     environments/surveys/edit/ignore_global_waiting_time: e08db543ace4935625e0961cc6e60489
     environments/surveys/edit/ignore_global_waiting_time_description: 37d173a4d537622de40677389238d859
     environments/surveys/edit/image: 048ba7a239de0fbd883ade8558415830

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "Frageeinstellungen ausblenden",
         "hostname": "Hostname",
         "if_you_need_more_please": "Wenn Sie mehr benötigen, bitte",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "Weiterhin anzeigen, wenn ausgelöst, bis eine Antwort abgegeben wird.",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "Immer anzeigen, wenn ausgelöst, bis eine Antwort oder Teilantwort übermittelt wurde.",
         "ignore_global_waiting_time": "Abkühlphase ignorieren",
         "ignore_global_waiting_time_description": "Diese Umfrage kann angezeigt werden, wenn ihre Bedingungen erfüllt sind, auch wenn kürzlich eine andere Umfrage angezeigt wurde.",
         "image": "Bild",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "Hide Question settings",
         "hostname": "Hostname",
         "if_you_need_more_please": "If you need more, please",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "Keep showing whenever triggered until a response is submitted.",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "Keep showing whenever triggered until a response or partial response is submitted.",
         "ignore_global_waiting_time": "Ignore Cooldown Period",
         "ignore_global_waiting_time_description": "This survey can show whenever its conditions are met, even if another survey was shown recently.",
         "image": "Image",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "Ocultar ajustes de la pregunta",
         "hostname": "Nombre de host",
         "if_you_need_more_please": "Si necesitas más, por favor",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "Seguir mostrando cuando se active hasta que se envíe una respuesta.",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "Seguir mostrando cada vez que se active hasta que se envíe una respuesta o respuesta parcial.",
         "ignore_global_waiting_time": "Ignorar periodo de espera",
         "ignore_global_waiting_time_description": "Esta encuesta puede mostrarse siempre que se cumplan sus condiciones, incluso si otra encuesta se mostró recientemente.",
         "image": "Imagen",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "Masquer les paramètres de la question",
         "hostname": "Nom d'hôte",
         "if_you_need_more_please": "Si vous avez besoin de plus, veuillez",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "Continuer à afficher à chaque déclenchement jusqu'à ce qu'une réponse soit soumise.",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "Continuer à afficher à chaque déclenchement jusqu'à ce qu'une réponse ou une réponse partielle soit soumise.",
         "ignore_global_waiting_time": "Ignorer la période de refroidissement",
         "ignore_global_waiting_time_description": "Cette enquête peut s'afficher chaque fois que ses conditions sont remplies, même si une autre enquête a été affichée récemment.",
         "image": "Image",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "Kérdésbeállítások elrejtése",
         "hostname": "Gépnév",
         "if_you_need_more_please": "Ha többre van szüksége, akkor",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "Maradjon megjelenítve bármikor is aktiválódott, amíg egy választ el nem küldenek.",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "Továbbra is megjelenítés minden egyes aktiváláskor, amíg választ vagy részleges választ nem küldenek be.",
         "ignore_global_waiting_time": "Várakozási időszak figyelmen kívül hagyása",
         "ignore_global_waiting_time_description": "Ez a kérdőív akkor jelenhet meg, ha a feltételei teljesülnek, még akkor is, ha egy másik kérdőív jelent meg nemrég.",
         "image": "Kép",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "質問設定を非表示",
         "hostname": "ホスト名",
         "if_you_need_more_please": "さらに必要な場合は、",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "回答が提出されるまで、トリガーされるたびに表示し続けます。",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "回答または一部の回答が送信されるまで、トリガーされるたびに表示し続けます。",
         "ignore_global_waiting_time": "クールダウン期間を無視",
         "ignore_global_waiting_time_description": "このフォームは、最近別のフォームが表示されていても、条件が満たされればいつでも表示できます。",
         "image": "画像",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "Vraaginstellingen verbergen",
         "hostname": "Hostnaam",
         "if_you_need_more_please": "Als je meer nodig hebt,",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "Blijf tonen wanneer geactiveerd totdat een reactie is ingediend.",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "Blijf tonen wanneer geactiveerd totdat een antwoord of gedeeltelijk antwoord is ingediend.",
         "ignore_global_waiting_time": "Afkoelperiode negeren",
         "ignore_global_waiting_time_description": "Deze enquête kan worden getoond wanneer aan de voorwaarden wordt voldaan, zelfs als er onlangs een andere enquête is getoond.",
         "image": "Afbeelding",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "Ocultar configurações da pergunta",
         "hostname": "nome do host",
         "if_you_need_more_please": "Se você precisar de mais, por favor",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "Continuar mostrando sempre que acionada até que uma resposta seja enviada.",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "Continue mostrando sempre que acionado até que uma resposta ou resposta parcial seja enviada.",
         "ignore_global_waiting_time": "Ignorar período de espera",
         "ignore_global_waiting_time_description": "Esta pesquisa pode ser mostrada sempre que suas condições forem atendidas, mesmo que outra pesquisa tenha sido mostrada recentemente.",
         "image": "imagem",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "Ocultar definições da pergunta",
         "hostname": "Nome do host",
         "if_you_need_more_please": "Se precisar de mais, por favor",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "Continuar a mostrar sempre que acionado até que uma resposta seja submetida.",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "Continuar a mostrar sempre que acionado até que uma resposta ou resposta parcial seja submetida.",
         "ignore_global_waiting_time": "Ignorar período de espera",
         "ignore_global_waiting_time_description": "Este inquérito pode ser mostrado sempre que as suas condições forem cumpridas, mesmo que outro inquérito tenha sido mostrado recentemente.",
         "image": "Imagem",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "Ascunde setările întrebării",
         "hostname": "Nume gazdă",
         "if_you_need_more_please": "Dacă aveți nevoie de mai mult, vă rugăm",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "Continuă afișarea ori de câte ori este declanșat până când se trimite un răspuns.",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "Continuă să afișezi de fiecare dată când este declanșat, până când se trimite un răspuns sau un răspuns parțial.",
         "ignore_global_waiting_time": "Ignoră perioada de răcire",
         "ignore_global_waiting_time_description": "Acest sondaj poate fi afișat ori de câte ori condițiile sale sunt îndeplinite, chiar dacă un alt sondaj a fost afișat recent.",
         "image": "Imagine",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "Скрыть настройки вопроса",
         "hostname": "Имя хоста",
         "if_you_need_more_please": "Если вам нужно больше, пожалуйста",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "Показывать каждый раз при срабатывании, пока не будет получен ответ.",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "Продолжай показывать при каждом срабатывании триггера, пока не будет отправлен ответ или частичный ответ.",
         "ignore_global_waiting_time": "Игнорировать период ожидания",
         "ignore_global_waiting_time_description": "Этот опрос может отображаться при выполнении условий, даже если недавно уже был показан другой опрос.",
         "image": "Изображение",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "Dölj frågeinställningar",
         "hostname": "Värdnamn",
         "if_you_need_more_please": "Om du behöver mer, vänligen",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "Fortsätt visa när villkoren är uppfyllda tills ett svar skickas in.",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "Fortsätt visa varje gång det utlöses tills ett svar eller ett delsvar skickas in.",
         "ignore_global_waiting_time": "Ignorera väntetid",
         "ignore_global_waiting_time_description": "Denna enkät kan visas när dess villkor är uppfyllda, även om en annan enkät nyligen visats.",
         "image": "Bild",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "Soru ayarlarını gizle",
         "hostname": "Ana bilgisayar adı",
         "if_you_need_more_please": "Daha fazlasına ihtiyacınız varsa lütfen",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "Yanıt gönderilene kadar tetiklendiğinde göstermeye devam et.",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "Bir yanıt veya kısmi yanıt gönderilene kadar her tetiklendiğinde göstermeye devam et.",
         "ignore_global_waiting_time": "Bekleme Süresini Yoksay",
         "ignore_global_waiting_time_description": "Bu survey, yakın zamanda başka bir survey gösterilmiş olsa bile koşulları sağlandığında gösterilebilir.",
         "image": "Görsel",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "隐藏问题设置",
         "hostname": "主 机 名",
         "if_you_need_more_please": "如果您需要更多，请",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "每次触发时都会显示，直到提交回应为止。",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "持续在触发时显示，直到提交响应或部分响应。",
         "ignore_global_waiting_time": "忽略冷却期",
         "ignore_global_waiting_time_description": "只要满足条件，此调查即可显示，即使最近刚显示过其他调查。",
         "image": "图片",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1553,7 +1553,7 @@
         "hide_question_settings": "隱藏問題設定",
         "hostname": "主機名稱",
         "if_you_need_more_please": "如果您需要更多，請",
-        "if_you_really_want_that_answer_ask_until_you_get_it": "每次觸發時都顯示，直到提交回應為止。",
+        "if_you_really_want_that_answer_ask_until_you_get_it": "持續顯示，直到使用者提交回應或部分回應為止。",
         "ignore_global_waiting_time": "忽略冷卻期",
         "ignore_global_waiting_time_description": "此問卷在符合條件時即可顯示，即使最近已顯示過其他問卷。",
         "image": "圖片",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Updates the trigger description copy to explicitly mention partial responses.

Fixes #(issue)

## How should this be tested?

- Open the survey trigger settings where "Ask until they submit a response" is shown.
- Verify the helper text reads: "Keep showing whenever triggered until a response or partial response is submitted."

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ae67f0c-3774-42ca-92d6-d8797996cd82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ae67f0c-3774-42ca-92d6-d8797996cd82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

