### PR TITLE
fix: return generic credentials error for SSO-only accounts

### DIFF
--- a/apps/web/modules/auth/lib/authOptions.test.ts
+++ b/apps/web/modules/auth/lib/authOptions.test.ts
@@ -175,7 +175,7 @@ describe("authOptions", () => {
       );
     }, 15000);
 
-    test("should throw error if user has no password stored", async () => {
+    test("should throw generic invalid credentials error if user has no password stored", async () => {
       vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true }); // Rate limiting passes
       vi.spyOn(prisma.user, "findUnique").mockResolvedValue({
         id: mockUser.id,
@@ -186,7 +186,7 @@ describe("authOptions", () => {
       const credentials = { email: mockUser.email, password: mockPassword };
 
       await expect(credentialsProvider.options.authorize(credentials, {})).rejects.toThrow(
-        "User has no password stored"
+        "Invalid credentials"
       );
     }, 15000);
 

--- a/apps/web/modules/auth/lib/authOptions.ts
+++ b/apps/web/modules/auth/lib/authOptions.ts
@@ -117,7 +117,7 @@ export const authOptions: NextAuthOptions = {
 
         if (!user.password) {
           logAuthAttempt("no_password_set", "credentials", "password_validation", user.id, user.email);
-          throw new Error("User has no password stored");
+          throw new Error("Invalid credentials");
         }
 
         if (user.isActive === false) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Replaces the credentials login error message for users without a stored password (SSO-only accounts) with the same generic message used for other credential failures.

This ensures failed credential attempts are indistinguishable across:
- non-existent email
- existing SSO-only account (no password)
- incorrect password

Fixes #(issue)

## How should this be tested?

- Run `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/formbricks pnpm test modules/auth/lib/authOptions.test.ts` in `apps/web`
- Verify `CredentialsProvider (credentials)` test `should throw generic invalid credentials error if user has no password stored` expects `"Invalid credentials"`
- Optionally validate manually: try password login on an SSO-created account and confirm the UI no longer reveals password/SSO status

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e173f992-0f42-49dd-a5e9-49cb93ab2db1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e173f992-0f42-49dd-a5e9-49cb93ab2db1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


fixes ENG-670 

https://linear.app/formbricks/issue/ENG-670/login-error-toast-leaks-account-existence-and-registration-method

