### PR TITLE
fix: recover incomplete initial setup

### DIFF
--- a/apps/web/app/setup/page.tsx
+++ b/apps/web/app/setup/page.tsx
@@ -1,0 +1,28 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { getIsFreshInstance, gethasNoOrganizations } from "@/lib/instance/service";
+import { authOptions } from "@/modules/auth/lib/authOptions";
+
+const Page = async () => {
+  const [session, isFreshInstance, hasNoOrganizations] = await Promise.all([
+    getServerSession(authOptions),
+    getIsFreshInstance(),
+    gethasNoOrganizations(),
+  ]);
+
+  if (isFreshInstance) {
+    return redirect("/setup/intro");
+  }
+
+  if (hasNoOrganizations) {
+    if (session) {
+      return redirect("/setup/organization/create");
+    }
+
+    return redirect("/auth/login?callbackUrl=%2Fsetup%2Forganization%2Fcreate");
+  }
+
+  return redirect("/");
+};
+
+export default Page;

--- a/apps/web/modules/setup/(fresh-instance)/layout.tsx
+++ b/apps/web/modules/setup/(fresh-instance)/layout.tsx
@@ -1,14 +1,29 @@
 import { getServerSession } from "next-auth";
-import { notFound } from "next/navigation";
-import { getIsFreshInstance } from "@/lib/instance/service";
+import { notFound, redirect } from "next/navigation";
+import { getIsFreshInstance, gethasNoOrganizations } from "@/lib/instance/service";
 import { authOptions } from "@/modules/auth/lib/authOptions";
 
 export const FreshInstanceLayout = async ({ children }: { children: React.ReactNode }) => {
   const session = await getServerSession(authOptions);
   const isFreshInstance = await getIsFreshInstance();
 
-  if (session || !isFreshInstance) {
+  if (!isFreshInstance) {
+    const hasNoOrganizations = await gethasNoOrganizations();
+
+    if (hasNoOrganizations) {
+      if (session) {
+        return redirect("/setup/organization/create");
+      }
+
+      return redirect("/auth/login?callbackUrl=%2Fsetup%2Forganization%2Fcreate");
+    }
+
     return notFound();
   }
+
+  if (session) {
+    return notFound();
+  }
+
   return <>{children}</>;
 };


### PR DESCRIPTION
## Summary
- Adds a `/setup` route that redirects users to the correct setup step instead of returning 404.
- Makes the fresh-instance setup layout recover when the first user exists but no organization has been created yet.
- Keeps public signup locked down after the first user exists by requiring login before organization creation.

## Why This Fixes ENG-719
1. On self-hosted instances with public signup disabled, the initial setup starts while `user.count() === 0`, so `/` correctly redirects visitors to `/setup/intro`.
2. If the user starts setup and creates the admin account, the instance is no longer considered fresh because `user.count() > 0`.
3. Before this change, that made `/setup/intro` and `/setup/signup` return 404 via `FreshInstanceLayout`, while `/setup` had no route at all. Returning later sent the operator to login without a clear way back into setup.
4. This change treats `user.count() > 0` plus `organization.count() === 0` as an incomplete setup state.
5. In that state, unauthenticated users are sent to `/auth/login?callbackUrl=/setup/organization/create`, and authenticated users are sent directly to `/setup/organization/create`.
6. Once an organization exists, setup-only routes stay unavailable, preserving the existing post-setup behavior.

## Test plan
- Verified touched files have no IDE lint diagnostics.
- Fresh instance, no users: visit `/setup` and confirm it redirects to `/setup/intro`.
- Fresh instance, create the first admin user, then abort before organization creation.
- Return while logged out and visit `/setup`; confirm it redirects to login with callback to `/setup/organization/create`.
- Log in as the created admin and confirm you land on `/setup/organization/create`.
- Visit `/setup/intro` or `/setup/signup` in the incomplete setup state and confirm they recover to organization creation/login instead of 404.
- After creating an organization, confirm `/setup` redirects to `/` and fresh setup pages are no longer accessible.


Made with [Cursor](https://cursor.com)