### PR TITLE
feat: add PostHog group analytics and feature events

### DIFF
--- a/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/channel/page.tsx
+++ b/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/channel/page.tsx
@@ -2,6 +2,7 @@ import { PictureInPicture2Icon, SendIcon, XIcon } from "lucide-react";
 import Link from "next/link";
 import { redirect } from "next/navigation";
 import { OnboardingOptionsContainer } from "@/app/(app)/(onboarding)/organizations/components/OnboardingOptionsContainer";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { getUserProjects } from "@/lib/project/service";
 import { getTranslate } from "@/lingodotdev/server";
 import { getOrganizationAuth } from "@/modules/organization/lib/utils";
@@ -40,6 +41,16 @@ const Page = async (props: ChannelPageProps) => {
   ];
 
   const projects = await getUserProjects(session.user.id, params.organizationId);
+
+  capturePostHogEvent(
+    session.user.id,
+    "workspace_mode_selected",
+    {
+      organization_id: params.organizationId,
+      mode: "surveys",
+    },
+    { organizationId: params.organizationId }
+  );
 
   return (
     <div className="flex min-h-full min-w-full flex-col items-center justify-center space-y-12">

--- a/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/channel/page.tsx
+++ b/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/channel/page.tsx
@@ -44,7 +44,7 @@ const Page = async (props: ChannelPageProps) => {
 
   capturePostHogEvent(
     session.user.id,
-    "workspace_mode_selected",
+    "organization_mode_selected",
     {
       organization_id: params.organizationId,
       mode: "surveys",

--- a/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/settings/page.tsx
+++ b/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/settings/page.tsx
@@ -55,7 +55,7 @@ const Page = async (props: ProjectSettingsPageProps) => {
   if (searchParams.mode === "cx") {
     capturePostHogEvent(
       session.user.id,
-      "workspace_mode_selected",
+      "organization_mode_selected",
       {
         organization_id: params.organizationId,
         mode: "cx",

--- a/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/settings/page.tsx
+++ b/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/settings/page.tsx
@@ -7,6 +7,7 @@ import { getTeamsByOrganizationId } from "@/app/(app)/(onboarding)/lib/onboardin
 import { ProjectSettings } from "@/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/settings/components/ProjectSettings";
 import { DEFAULT_BRAND_COLOR } from "@/lib/constants";
 import { getPublicDomain } from "@/lib/getPublicUrl";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { getUserProjects } from "@/lib/project/service";
 import { getTranslate } from "@/lingodotdev/server";
 import { getAccessControlPermission } from "@/modules/ee/license-check/lib/utils";
@@ -50,6 +51,18 @@ const Page = async (props: ProjectSettingsPageProps) => {
   }
 
   const publicDomain = getPublicDomain();
+
+  if (searchParams.mode === "cx") {
+    capturePostHogEvent(
+      session.user.id,
+      "workspace_mode_selected",
+      {
+        organization_id: params.organizationId,
+        mode: "cx",
+      },
+      { organizationId: params.organizationId }
+    );
+  }
 
   return (
     <div className="flex min-h-full min-w-full flex-col items-center justify-center space-y-12">

--- a/apps/web/app/(app)/environments/[environmentId]/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/actions.ts
@@ -10,6 +10,7 @@ import {
 import { ZProjectUpdateInput } from "@formbricks/types/project";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getOrganization } from "@/lib/organization/service";
+import { capturePostHogEvent, groupIdentifyPostHog } from "@/lib/posthog";
 import { getOrganizationProjectsCount } from "@/lib/project/service";
 import { updateUser } from "@/lib/user/service";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
@@ -79,6 +80,19 @@ export const createProjectAction = authenticatedActionClient.inputSchema(ZCreate
     await updateUser(user.id, {
       notificationSettings: updatedNotificationSettings,
     });
+
+    groupIdentifyPostHog("workspace", project.id, { name: project.name });
+
+    capturePostHogEvent(
+      user.id,
+      "workspace_created",
+      {
+        organization_id: organizationId,
+        workspace_id: project.id,
+        name: project.name,
+      },
+      { organizationId, workspaceId: project.id }
+    );
 
     ctx.auditLoggingCtx.organizationId = organizationId;
     ctx.auditLoggingCtx.projectId = project.id;

--- a/apps/web/app/(app)/environments/[environmentId]/layout.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/layout.tsx
@@ -2,6 +2,8 @@ import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 import { EnvironmentLayout } from "@/app/(app)/environments/[environmentId]/components/EnvironmentLayout";
 import { EnvironmentContextWrapper } from "@/app/(app)/environments/[environmentId]/context/environment-context";
+import { PostHogGroupIdentify } from "@/app/posthog/PostHogGroupIdentify";
+import { POSTHOG_KEY } from "@/lib/constants";
 import { authOptions } from "@/modules/auth/lib/authOptions";
 import { getEnvironmentLayoutData } from "@/modules/environments/lib/utils";
 import EnvironmentStorageHandler from "./components/EnvironmentStorageHandler";
@@ -25,6 +27,14 @@ const EnvLayout = async (props: {
   return (
     <>
       <EnvironmentStorageHandler environmentId={params.environmentId} />
+      {POSTHOG_KEY && (
+        <PostHogGroupIdentify
+          organizationId={layoutData.organization.id}
+          organizationName={layoutData.organization.name}
+          workspaceId={layoutData.project.id}
+          workspaceName={layoutData.project.name}
+        />
+      )}
       <EnvironmentContextWrapper
         environment={layoutData.environment}
         project={layoutData.project}

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/actions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { OperationNotAllowedError, ResourceNotFoundError, UnknownError } from "@formbricks/types/errors";
 import { getEmailTemplateHtml } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplate";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { getSurvey, updateSurvey } from "@/lib/survey/service";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
@@ -146,6 +147,7 @@ export const generatePersonalLinksAction = authenticatedActionClient
   .inputSchema(ZGeneratePersonalLinksAction)
   .action(async ({ ctx, parsedInput }) => {
     const organizationId = await getOrganizationIdFromSurveyId(parsedInput.surveyId);
+    const projectId = await getProjectIdFromSurveyId(parsedInput.surveyId);
     const isContactsEnabled = await getIsContactsEnabled(organizationId);
     if (!isContactsEnabled) {
       throw new OperationNotAllowedError("Contacts are not enabled for this environment");
@@ -153,7 +155,7 @@ export const generatePersonalLinksAction = authenticatedActionClient
 
     await checkAuthorizationUpdated({
       userId: ctx.user.id,
-      organizationId: await getOrganizationIdFromSurveyId(parsedInput.surveyId),
+      organizationId,
       access: [
         {
           type: "organization",
@@ -161,7 +163,7 @@ export const generatePersonalLinksAction = authenticatedActionClient
         },
         {
           type: "projectTeam",
-          projectId: await getProjectIdFromSurveyId(parsedInput.surveyId),
+          projectId,
           minPermission: "readWrite",
         },
       ],
@@ -177,6 +179,18 @@ export const generatePersonalLinksAction = authenticatedActionClient
     if (!contactsResult || contactsResult.length === 0) {
       throw new UnknownError("No contacts found for the selected segment");
     }
+
+    capturePostHogEvent(
+      ctx.user.id,
+      "personal_link_created",
+      {
+        organization_id: organizationId,
+        workspace_id: projectId,
+        survey_id: parsedInput.surveyId,
+        link_count: contactsResult.length,
+      },
+      { organizationId, workspaceId: projectId }
+    );
 
     // Prepare CSV data with the specified headers and order
     const csvHeaders = [

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/actions.ts
@@ -42,18 +42,25 @@ export const getResponsesDownloadUrlAction = authenticatedActionClient
       ],
     });
 
+    const projectId = await getProjectIdFromSurveyId(parsedInput.surveyId);
     const result = await getResponseDownloadFile(
       parsedInput.surveyId,
       parsedInput.format,
       parsedInput.filterCriteria
     );
 
-    capturePostHogEvent(ctx.user.id, "responses_exported", {
-      survey_id: parsedInput.surveyId,
-      format: parsedInput.format,
-      filter_applied: Object.keys(parsedInput.filterCriteria ?? {}).length > 0,
-      organization_id: organizationId,
-    });
+    capturePostHogEvent(
+      ctx.user.id,
+      "responses_exported",
+      {
+        survey_id: parsedInput.surveyId,
+        format: parsedInput.format,
+        filter_applied: Object.keys(parsedInput.filterCriteria ?? {}).length > 0,
+        organization_id: organizationId,
+        workspace_id: projectId,
+      },
+      { organizationId, workspaceId: projectId }
+    );
 
     return result;
   });

--- a/apps/web/app/(app)/environments/[environmentId]/workspace/integrations/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/workspace/integrations/actions.ts
@@ -43,14 +43,22 @@ export const createOrUpdateIntegrationAction = authenticatedActionClient
       });
 
       ctx.auditLoggingCtx.organizationId = organizationId;
+      const projectId = await getProjectIdFromEnvironmentId(parsedInput.environmentId);
       const result = await createOrUpdateIntegration(parsedInput.environmentId, parsedInput.integrationData);
       ctx.auditLoggingCtx.integrationId = result.id;
       ctx.auditLoggingCtx.newObject = result;
 
-      capturePostHogEvent(ctx.user.id, "integration_connected", {
-        integration_type: parsedInput.integrationData.type,
-        organization_id: organizationId,
-      });
+      capturePostHogEvent(
+        ctx.user.id,
+        "integration_connected",
+        {
+          integration_type: parsedInput.integrationData.type,
+          organization_id: organizationId,
+          workspace_id: projectId,
+          environment_id: parsedInput.environmentId,
+        },
+        { organizationId, workspaceId: projectId }
+      );
 
       return result;
     })

--- a/apps/web/app/api/(internal)/pipeline/lib/posthog.test.ts
+++ b/apps/web/app/api/(internal)/pipeline/lib/posthog.test.ts
@@ -12,6 +12,7 @@ describe("captureSurveyResponsePostHogEvent", () => {
 
   const makeParams = (responseCount: number) => ({
     organizationId: "org-1",
+    workspaceId: "ws-1",
     surveyId: "survey-1",
     surveyType: "link",
     environmentId: "env-1",
@@ -23,15 +24,21 @@ describe("captureSurveyResponsePostHogEvent", () => {
 
     captureSurveyResponsePostHogEvent(makeParams(1));
 
-    expect(capturePostHogEvent).toHaveBeenCalledWith("org-1", "survey_response_received", {
-      survey_id: "survey-1",
-      survey_type: "link",
-      organization_id: "org-1",
-      environment_id: "env-1",
-      response_count: 1,
-      is_first_response: true,
-      milestone: "first",
-    });
+    expect(capturePostHogEvent).toHaveBeenCalledWith(
+      "org-1",
+      "survey_response_received",
+      {
+        survey_id: "survey-1",
+        survey_type: "link",
+        organization_id: "org-1",
+        workspace_id: "ws-1",
+        environment_id: "env-1",
+        response_count: 1,
+        is_first_response: true,
+        milestone: "first",
+      },
+      { organizationId: "org-1", workspaceId: "ws-1" }
+    );
   });
 
   test("fires on every 100th response", async () => {
@@ -75,7 +82,8 @@ describe("captureSurveyResponsePostHogEvent", () => {
       expect.objectContaining({
         is_first_response: false,
         milestone: "200",
-      })
+      }),
+      { organizationId: "org-1", workspaceId: "ws-1" }
     );
   });
 });

--- a/apps/web/app/api/(internal)/pipeline/lib/posthog.test.ts
+++ b/apps/web/app/api/(internal)/pipeline/lib/posthog.test.ts
@@ -51,10 +51,20 @@ describe("captureSurveyResponsePostHogEvent", () => {
     expect(capturePostHogEvent).toHaveBeenCalledTimes(6);
   });
 
-  test("does NOT fire for 2nd through 99th responses", async () => {
+  test("fires on every 10th response up to 100", async () => {
     const { capturePostHogEvent } = await import("@/lib/posthog");
 
-    for (const count of [2, 5, 10, 50, 99]) {
+    for (const count of [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]) {
+      captureSurveyResponsePostHogEvent(makeParams(count));
+    }
+
+    expect(capturePostHogEvent).toHaveBeenCalledTimes(10);
+  });
+
+  test("does NOT fire for non-milestone responses under 100", async () => {
+    const { capturePostHogEvent } = await import("@/lib/posthog");
+
+    for (const count of [2, 5, 11, 25, 49, 51, 99]) {
       captureSurveyResponsePostHogEvent(makeParams(count));
     }
 

--- a/apps/web/app/api/(internal)/pipeline/lib/posthog.ts
+++ b/apps/web/app/api/(internal)/pipeline/lib/posthog.ts
@@ -2,6 +2,7 @@ import { capturePostHogEvent } from "@/lib/posthog";
 
 interface SurveyResponsePostHogEventParams {
   organizationId: string;
+  workspaceId: string;
   surveyId: string;
   surveyType: string;
   environmentId: string;
@@ -14,6 +15,7 @@ interface SurveyResponsePostHogEventParams {
  */
 export const captureSurveyResponsePostHogEvent = ({
   organizationId,
+  workspaceId,
   surveyId,
   surveyType,
   environmentId,
@@ -21,13 +23,19 @@ export const captureSurveyResponsePostHogEvent = ({
 }: SurveyResponsePostHogEventParams): void => {
   if (responseCount !== 1 && responseCount % 100 !== 0) return;
 
-  capturePostHogEvent(organizationId, "survey_response_received", {
-    survey_id: surveyId,
-    survey_type: surveyType,
-    organization_id: organizationId,
-    environment_id: environmentId,
-    response_count: responseCount,
-    is_first_response: responseCount === 1,
-    milestone: responseCount === 1 ? "first" : String(responseCount),
-  });
+  capturePostHogEvent(
+    organizationId,
+    "survey_response_received",
+    {
+      survey_id: surveyId,
+      survey_type: surveyType,
+      organization_id: organizationId,
+      workspace_id: workspaceId,
+      environment_id: environmentId,
+      response_count: responseCount,
+      is_first_response: responseCount === 1,
+      milestone: responseCount === 1 ? "first" : String(responseCount),
+    },
+    { organizationId, workspaceId }
+  );
 };

--- a/apps/web/app/api/(internal)/pipeline/lib/posthog.ts
+++ b/apps/web/app/api/(internal)/pipeline/lib/posthog.ts
@@ -11,7 +11,8 @@ interface SurveyResponsePostHogEventParams {
 
 /**
  * Captures a PostHog event for survey responses at milestones:
- * 1st response, then every 100th (100, 200, 300, ...).
+ * 1st response, every 10th for the first 100 (10, 20, ..., 100),
+ * then every 100th (200, 300, 400, ...).
  */
 export const captureSurveyResponsePostHogEvent = ({
   organizationId,
@@ -21,7 +22,11 @@ export const captureSurveyResponsePostHogEvent = ({
   environmentId,
   responseCount,
 }: SurveyResponsePostHogEventParams): void => {
-  if (responseCount !== 1 && responseCount % 100 !== 0) return;
+  const isFirst = responseCount === 1;
+  const isEvery10thUnder100 = responseCount <= 100 && responseCount % 10 === 0;
+  const isEvery100thAbove100 = responseCount > 100 && responseCount % 100 === 0;
+
+  if (!isFirst && !isEvery10thUnder100 && !isEvery100thAbove100) return;
 
   capturePostHogEvent(
     organizationId,

--- a/apps/web/app/api/(internal)/pipeline/route.ts
+++ b/apps/web/app/api/(internal)/pipeline/route.ts
@@ -15,6 +15,7 @@ import { getOrganizationByEnvironmentId } from "@/lib/organization/service";
 import { getResponseCountBySurveyId } from "@/lib/response/service";
 import { getSurvey, updateSurvey } from "@/lib/survey/service";
 import { convertDatesInObject } from "@/lib/time";
+import { getProjectIdFromEnvironmentId } from "@/lib/utils/helper";
 import { validateWebhookUrl } from "@/lib/utils/validate-webhook-url";
 import { queueAuditEvent } from "@/modules/ee/audit-logs/lib/handler";
 import { TAuditStatus, UNKNOWN_DATA } from "@/modules/ee/audit-logs/types/audit-log";
@@ -307,9 +308,11 @@ export const POST = async (request: Request) => {
 
     if (POSTHOG_KEY) {
       const responseCount = await getResponseCountBySurveyId(surveyId);
+      const workspaceId = await getProjectIdFromEnvironmentId(environmentId);
 
       captureSurveyResponsePostHogEvent({
         organizationId: organization.id,
+        workspaceId,
         surveyId,
         surveyType: survey.type,
         environmentId,

--- a/apps/web/app/api/google-sheet/callback/route.ts
+++ b/apps/web/app/api/google-sheet/callback/route.ts
@@ -12,7 +12,7 @@ import {
 import { hasUserEnvironmentAccess } from "@/lib/environment/auth";
 import { createOrUpdateIntegration, getIntegrationByType } from "@/lib/integration/service";
 import { capturePostHogEvent } from "@/lib/posthog";
-import { getOrganizationIdFromEnvironmentId } from "@/lib/utils/helper";
+import { getOrganizationIdFromEnvironmentId, getProjectIdFromEnvironmentId } from "@/lib/utils/helper";
 import { authOptions } from "@/modules/auth/lib/authOptions";
 
 export const GET = async (req: Request) => {
@@ -87,10 +87,18 @@ export const GET = async (req: Request) => {
   if (result) {
     try {
       const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
-      capturePostHogEvent(session.user.id, "integration_connected", {
-        integration_type: "googleSheets",
-        organization_id: organizationId,
-      });
+      const projectId = await getProjectIdFromEnvironmentId(environmentId);
+      capturePostHogEvent(
+        session.user.id,
+        "integration_connected",
+        {
+          integration_type: "googleSheets",
+          organization_id: organizationId,
+          workspace_id: projectId,
+          environment_id: environmentId,
+        },
+        { organizationId, workspaceId: projectId }
+      );
     } catch (err) {
       logger.error({ error: err }, "Failed to capture PostHog integration_connected event for googleSheets");
     }

--- a/apps/web/app/api/v1/client/[environmentId]/environment/lib/environmentState.test.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/environment/lib/environmentState.test.ts
@@ -10,6 +10,11 @@ import { capturePostHogEvent } from "@/lib/posthog";
 import { EnvironmentStateData, getEnvironmentStateData } from "./data";
 import { getEnvironmentState } from "./environmentState";
 
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/utils/validate", () => ({ validateInputs: vi.fn() }));
+vi.mock("@/modules/storage/utils", () => ({ resolveStorageUrlsInObject: vi.fn((obj: unknown) => obj) }));
+vi.mock("@/modules/survey/lib/utils", () => ({ transformPrismaSurvey: vi.fn() }));
+
 // Mock dependencies
 vi.mock("@/lib/cache", () => ({
   cache: {
@@ -21,6 +26,9 @@ vi.mock("@formbricks/database", () => ({
   prisma: {
     environment: {
       update: vi.fn(),
+    },
+    project: {
+      findUnique: vi.fn(),
     },
   },
 }));
@@ -163,6 +171,7 @@ describe("getEnvironmentState", () => {
 
     // Default mocks for successful retrieval
     vi.mocked(getEnvironmentStateData).mockResolvedValue(mockEnvironmentStateData);
+    vi.mocked(prisma.project.findUnique).mockResolvedValue({ organizationId: "test-org-id" });
   });
 
   afterEach(() => {
@@ -329,11 +338,18 @@ describe("getEnvironmentState", () => {
 
     await getEnvironmentState(environmentId);
 
-    expect(capturePostHogEvent).toHaveBeenCalledWith(environmentId, "app_connected", {
-      num_surveys: 1,
-      num_code_actions: 1,
-      num_no_code_actions: 1,
-    });
+    expect(capturePostHogEvent).toHaveBeenCalledWith(
+      environmentId,
+      "app_connected",
+      {
+        num_surveys: 1,
+        num_code_actions: 1,
+        num_no_code_actions: 1,
+        organization_id: "test-org-id",
+        workspace_id: "test-project-id",
+      },
+      { organizationId: "test-org-id", workspaceId: "test-project-id" }
+    );
   });
 
   test("should not capture app_connected event when app setup already completed", async () => {

--- a/apps/web/app/api/v1/client/[environmentId]/environment/lib/environmentState.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/environment/lib/environmentState.ts
@@ -33,11 +33,25 @@ export const getEnvironmentState = async (
         });
 
         if (POSTHOG_KEY) {
-          capturePostHogEvent(environmentId, "app_connected", {
-            num_surveys: surveys.length,
-            num_code_actions: actionClasses.filter((ac) => ac.type === "code").length,
-            num_no_code_actions: actionClasses.filter((ac) => ac.type === "noCode").length,
+          const workspaceId = environment.project.id;
+          const project = await prisma.project.findUnique({
+            where: { id: workspaceId },
+            select: { organizationId: true },
           });
+          const organizationId = project?.organizationId;
+
+          capturePostHogEvent(
+            environmentId,
+            "app_connected",
+            {
+              num_surveys: surveys.length,
+              num_code_actions: actionClasses.filter((ac) => ac.type === "code").length,
+              num_no_code_actions: actionClasses.filter((ac) => ac.type === "noCode").length,
+              organization_id: organizationId ?? "",
+              workspace_id: workspaceId,
+            },
+            organizationId ? { organizationId, workspaceId } : undefined
+          );
         }
       }
 

--- a/apps/web/app/api/v1/integrations/airtable/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/airtable/callback/route.ts
@@ -7,7 +7,7 @@ import { AIRTABLE_CLIENT_ID, WEBAPP_URL } from "@/lib/constants";
 import { hasUserEnvironmentAccess } from "@/lib/environment/auth";
 import { createOrUpdateIntegration, getIntegrationByType } from "@/lib/integration/service";
 import { capturePostHogEvent } from "@/lib/posthog";
-import { getOrganizationIdFromEnvironmentId } from "@/lib/utils/helper";
+import { getOrganizationIdFromEnvironmentId, getProjectIdFromEnvironmentId } from "@/lib/utils/helper";
 
 const getEmail = async (token: string) => {
   const req_ = await fetch("https://api.airtable.com/v0/meta/whoami", {
@@ -95,10 +95,18 @@ export const GET = withV1ApiWrapper({
 
       try {
         const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
-        capturePostHogEvent(authentication.user.id, "integration_connected", {
-          integration_type: "airtable",
-          organization_id: organizationId,
-        });
+        const projectId = await getProjectIdFromEnvironmentId(environmentId);
+        capturePostHogEvent(
+          authentication.user.id,
+          "integration_connected",
+          {
+            integration_type: "airtable",
+            organization_id: organizationId,
+            workspace_id: projectId,
+            environment_id: environmentId,
+          },
+          { organizationId, workspaceId: projectId }
+        );
       } catch (err) {
         logger.error({ error: err }, "Failed to capture PostHog integration_connected event for airtable");
       }

--- a/apps/web/app/api/v1/integrations/notion/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/notion/callback/route.ts
@@ -13,7 +13,7 @@ import { symmetricEncrypt } from "@/lib/crypto";
 import { hasUserEnvironmentAccess } from "@/lib/environment/auth";
 import { createOrUpdateIntegration, getIntegrationByType } from "@/lib/integration/service";
 import { capturePostHogEvent } from "@/lib/posthog";
-import { getOrganizationIdFromEnvironmentId } from "@/lib/utils/helper";
+import { getOrganizationIdFromEnvironmentId, getProjectIdFromEnvironmentId } from "@/lib/utils/helper";
 
 export const GET = withV1ApiWrapper({
   handler: async ({ req, authentication }) => {
@@ -101,10 +101,18 @@ export const GET = withV1ApiWrapper({
       if (result) {
         try {
           const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
-          capturePostHogEvent(authentication.user.id, "integration_connected", {
-            integration_type: "notion",
-            organization_id: organizationId,
-          });
+          const projectId = await getProjectIdFromEnvironmentId(environmentId);
+          capturePostHogEvent(
+            authentication.user.id,
+            "integration_connected",
+            {
+              integration_type: "notion",
+              organization_id: organizationId,
+              workspace_id: projectId,
+              environment_id: environmentId,
+            },
+            { organizationId, workspaceId: projectId }
+          );
         } catch (err) {
           logger.error({ error: err }, "Failed to capture PostHog integration_connected event for notion");
         }

--- a/apps/web/app/api/v1/integrations/slack/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/slack/callback/route.ts
@@ -10,7 +10,7 @@ import { SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, SLACK_REDIRECT_URI, WEBAPP_URL } 
 import { hasUserEnvironmentAccess } from "@/lib/environment/auth";
 import { createOrUpdateIntegration, getIntegrationByType } from "@/lib/integration/service";
 import { capturePostHogEvent } from "@/lib/posthog";
-import { getOrganizationIdFromEnvironmentId } from "@/lib/utils/helper";
+import { getOrganizationIdFromEnvironmentId, getProjectIdFromEnvironmentId } from "@/lib/utils/helper";
 
 export const GET = withV1ApiWrapper({
   handler: async ({ req, authentication }) => {
@@ -109,10 +109,18 @@ export const GET = withV1ApiWrapper({
       if (result) {
         try {
           const organizationId = await getOrganizationIdFromEnvironmentId(environmentId);
-          capturePostHogEvent(authentication.user.id, "integration_connected", {
-            integration_type: "slack",
-            organization_id: organizationId,
-          });
+          const projectId = await getProjectIdFromEnvironmentId(environmentId);
+          capturePostHogEvent(
+            authentication.user.id,
+            "integration_connected",
+            {
+              integration_type: "slack",
+              organization_id: organizationId,
+              workspace_id: projectId,
+              environment_id: environmentId,
+            },
+            { organizationId, workspaceId: projectId }
+          );
         } catch (err) {
           logger.error({ error: err }, "Failed to capture PostHog integration_connected event for slack");
         }

--- a/apps/web/app/posthog/PostHogGroupIdentify.tsx
+++ b/apps/web/app/posthog/PostHogGroupIdentify.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import posthog from "posthog-js";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 interface PostHogGroupIdentifyProps {
   organizationId: string;
@@ -16,8 +16,10 @@ export const PostHogGroupIdentify = ({
   workspaceId,
   workspaceName,
 }: PostHogGroupIdentifyProps) => {
+  const cancelledRef = useRef(false);
+
   useEffect(() => {
-    let cancelled = false;
+    cancelledRef.current = false;
 
     const applyGroups = () => {
       posthog.group("organization", organizationId, { name: organizationName });
@@ -32,7 +34,7 @@ export const PostHogGroupIdentify = ({
     // PostHogIdentify (in app layout) initialises posthog from a sibling
     // useEffect; effect order isn't guaranteed, so poll briefly until loaded.
     const intervalId = setInterval(() => {
-      if (cancelled) return;
+      if (cancelledRef.current) return;
       if (posthog.__loaded) {
         applyGroups();
         clearInterval(intervalId);
@@ -40,12 +42,12 @@ export const PostHogGroupIdentify = ({
     }, 50);
 
     const timeoutId = setTimeout(() => {
-      cancelled = true;
+      cancelledRef.current = true;
       clearInterval(intervalId);
     }, 5000);
 
     return () => {
-      cancelled = true;
+      cancelledRef.current = true;
       clearInterval(intervalId);
       clearTimeout(timeoutId);
     };

--- a/apps/web/app/posthog/PostHogGroupIdentify.tsx
+++ b/apps/web/app/posthog/PostHogGroupIdentify.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import posthog from "posthog-js";
+import { useEffect } from "react";
+
+interface PostHogGroupIdentifyProps {
+  organizationId: string;
+  organizationName: string;
+  workspaceId: string;
+  workspaceName: string;
+}
+
+export const PostHogGroupIdentify = ({
+  organizationId,
+  organizationName,
+  workspaceId,
+  workspaceName,
+}: PostHogGroupIdentifyProps) => {
+  useEffect(() => {
+    let cancelled = false;
+
+    const applyGroups = () => {
+      posthog.group("organization", organizationId, { name: organizationName });
+      posthog.group("workspace", workspaceId, { name: workspaceName });
+    };
+
+    if (posthog.__loaded) {
+      applyGroups();
+      return;
+    }
+
+    // PostHogIdentify (in app layout) initialises posthog from a sibling
+    // useEffect; effect order isn't guaranteed, so poll briefly until loaded.
+    const intervalId = setInterval(() => {
+      if (cancelled) return;
+      if (posthog.__loaded) {
+        applyGroups();
+        clearInterval(intervalId);
+      }
+    }, 50);
+
+    const timeoutId = setTimeout(() => {
+      cancelled = true;
+      clearInterval(intervalId);
+    }, 5000);
+
+    return () => {
+      cancelled = true;
+      clearInterval(intervalId);
+      clearTimeout(timeoutId);
+    };
+  }, [organizationId, organizationName, workspaceId, workspaceName]);
+
+  return null;
+};

--- a/apps/web/app/setup/organization/create/actions.ts
+++ b/apps/web/app/setup/organization/create/actions.ts
@@ -7,7 +7,7 @@ import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { gethasNoOrganizations } from "@/lib/instance/service";
 import { createMembership } from "@/lib/membership/service";
 import { createOrganization } from "@/lib/organization/service";
-import { capturePostHogEvent } from "@/lib/posthog";
+import { capturePostHogEvent, groupIdentifyPostHog } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import { ensureCloudStripeSetupForOrganization } from "@/modules/ee/billing/lib/organization-billing";
@@ -50,10 +50,17 @@ export const createOrganizationAction = authenticatedActionClient
       ctx.auditLoggingCtx.organizationId = newOrganization.id;
       ctx.auditLoggingCtx.newObject = newOrganization;
 
-      capturePostHogEvent(ctx.user.id, "organization_created", {
-        organization_id: newOrganization.id,
-        is_first_org: hasNoOrganizations,
-      });
+      groupIdentifyPostHog("organization", newOrganization.id, { name: newOrganization.name });
+
+      capturePostHogEvent(
+        ctx.user.id,
+        "organization_created",
+        {
+          organization_id: newOrganization.id,
+          is_first_org: hasNoOrganizations,
+        },
+        { organizationId: newOrganization.id }
+      );
 
       return newOrganization;
     })

--- a/apps/web/lib/posthog/capture.test.ts
+++ b/apps/web/lib/posthog/capture.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { capturePostHogEvent } from "./capture";
+import { capturePostHogEvent, groupIdentifyPostHog } from "./capture";
 
 const mocks = vi.hoisted(() => ({
   capture: vi.fn(),
+  groupIdentify: vi.fn(),
   loggerWarn: vi.fn(),
 }));
 
@@ -13,7 +14,7 @@ vi.mock("@formbricks/logger", () => ({
 }));
 
 vi.mock("./server", () => ({
-  posthogServerClient: { capture: mocks.capture },
+  posthogServerClient: { capture: mocks.capture, groupIdentify: mocks.groupIdentify },
 }));
 
 describe("capturePostHogEvent", () => {
@@ -32,6 +33,7 @@ describe("capturePostHogEvent", () => {
         $lib: "posthog-node",
         source: "server",
       },
+      groups: undefined,
     });
   });
 
@@ -45,6 +47,41 @@ describe("capturePostHogEvent", () => {
         $lib: "posthog-node",
         source: "server",
       },
+      groups: undefined,
+    });
+  });
+
+  test("includes organization and workspace groups when provided", () => {
+    capturePostHogEvent(
+      "user123",
+      "test_event",
+      { key: "value" },
+      { organizationId: "org_1", workspaceId: "ws_1" }
+    );
+
+    expect(mocks.capture).toHaveBeenCalledWith({
+      distinctId: "user123",
+      event: "test_event",
+      properties: {
+        key: "value",
+        $lib: "posthog-node",
+        source: "server",
+      },
+      groups: { organization: "org_1", workspace: "ws_1" },
+    });
+  });
+
+  test("includes only organization group when workspaceId missing", () => {
+    capturePostHogEvent("user123", "test_event", undefined, { organizationId: "org_1" });
+
+    expect(mocks.capture).toHaveBeenCalledWith({
+      distinctId: "user123",
+      event: "test_event",
+      properties: {
+        $lib: "posthog-node",
+        source: "server",
+      },
+      groups: { organization: "org_1" },
     });
   });
 
@@ -57,6 +94,44 @@ describe("capturePostHogEvent", () => {
     expect(mocks.loggerWarn).toHaveBeenCalledWith(
       { error: expect.any(Error), eventName: "test_event" },
       "Failed to capture PostHog event"
+    );
+  });
+});
+
+describe("groupIdentifyPostHog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("calls posthog groupIdentify with correct params", () => {
+    groupIdentifyPostHog("organization", "org_1", { name: "Acme" });
+
+    expect(mocks.groupIdentify).toHaveBeenCalledWith({
+      groupType: "organization",
+      groupKey: "org_1",
+      properties: { name: "Acme" },
+    });
+  });
+
+  test("identifies workspace group", () => {
+    groupIdentifyPostHog("workspace", "ws_1", { name: "Marketing" });
+
+    expect(mocks.groupIdentify).toHaveBeenCalledWith({
+      groupType: "workspace",
+      groupKey: "ws_1",
+      properties: { name: "Marketing" },
+    });
+  });
+
+  test("does not throw when groupIdentify throws", () => {
+    mocks.groupIdentify.mockImplementation(() => {
+      throw new Error("Network error");
+    });
+
+    expect(() => groupIdentifyPostHog("organization", "org_1")).not.toThrow();
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      { error: expect.any(Error), groupType: "organization", groupKey: "org_1" },
+      "Failed to identify PostHog group"
     );
   });
 });
@@ -74,11 +149,14 @@ describe("capturePostHogEvent with null client", () => {
       posthogServerClient: null,
     }));
 
-    const { capturePostHogEvent: captureWithNullClient } = await import("./capture");
+    const { capturePostHogEvent: captureWithNullClient, groupIdentifyPostHog: identifyWithNullClient } =
+      await import("./capture");
 
     captureWithNullClient("user123", "test_event", { key: "value" });
+    identifyWithNullClient("organization", "org_1");
 
     expect(mocks.capture).not.toHaveBeenCalled();
+    expect(mocks.groupIdentify).not.toHaveBeenCalled();
     expect(mocks.loggerWarn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/posthog/capture.ts
+++ b/apps/web/lib/posthog/capture.ts
@@ -4,10 +4,24 @@ import { posthogServerClient } from "./server";
 
 type PostHogEventProperties = Record<string, string | number | boolean | null | undefined>;
 
+export type PostHogGroupContext = {
+  organizationId?: string;
+  workspaceId?: string;
+};
+
+const buildGroups = (context?: PostHogGroupContext): Record<string, string> | undefined => {
+  if (!context) return undefined;
+  const groups: Record<string, string> = {};
+  if (context.organizationId) groups.organization = context.organizationId;
+  if (context.workspaceId) groups.workspace = context.workspaceId;
+  return Object.keys(groups).length > 0 ? groups : undefined;
+};
+
 export function capturePostHogEvent(
   distinctId: string,
   eventName: string,
-  properties?: PostHogEventProperties
+  properties?: PostHogEventProperties,
+  groupContext?: PostHogGroupContext
 ): void {
   if (!posthogServerClient) return;
 
@@ -20,8 +34,29 @@ export function capturePostHogEvent(
         $lib: "posthog-node",
         source: "server",
       },
+      groups: buildGroups(groupContext),
     });
   } catch (error) {
     logger.warn({ error, eventName }, "Failed to capture PostHog event");
+  }
+}
+
+type PostHogGroupType = "organization" | "workspace";
+
+export function groupIdentifyPostHog(
+  groupType: PostHogGroupType,
+  groupKey: string,
+  properties?: Record<string, string | number | boolean | null | undefined>
+): void {
+  if (!posthogServerClient) return;
+
+  try {
+    posthogServerClient.groupIdentify({
+      groupType,
+      groupKey,
+      properties,
+    });
+  } catch (error) {
+    logger.warn({ error, groupType, groupKey }, "Failed to identify PostHog group");
   }
 }

--- a/apps/web/lib/posthog/index.ts
+++ b/apps/web/lib/posthog/index.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
-export { capturePostHogEvent } from "./capture";
+export { capturePostHogEvent, groupIdentifyPostHog } from "./capture";
+export type { PostHogGroupContext } from "./capture";
 export { getPostHogFeatureFlag } from "./get-feature-flag";
 export type { TPostHogFeatureFlagContext, TPostHogFeatureFlagValue } from "./types";

--- a/apps/web/modules/account/components/DeleteAccountModal/actions.ts
+++ b/apps/web/modules/account/components/DeleteAccountModal/actions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { logger } from "@formbricks/logger";
 import { AuthorizationError, InvalidInputError, OperationNotAllowedError } from "@formbricks/types/errors";
 import { getOrganizationsWhereUserIsSingleOwner } from "@/lib/organization/service";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { verifyUserPassword } from "@/lib/user/password";
 import { deleteUser, getUser } from "@/lib/user/service";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
@@ -77,6 +78,8 @@ export const deleteUserAction = authenticatedActionClient.inputSchema(z.unknown(
       }
 
       ctx.auditLoggingCtx.oldObject = await getUser(ctx.user.id);
+
+      capturePostHogEvent(ctx.user.id, "delete_account");
 
       await deleteUser(ctx.user.id);
 

--- a/apps/web/modules/account/components/DeleteAccountModal/actions.ts
+++ b/apps/web/modules/account/components/DeleteAccountModal/actions.ts
@@ -79,9 +79,9 @@ export const deleteUserAction = authenticatedActionClient.inputSchema(z.unknown(
 
       ctx.auditLoggingCtx.oldObject = await getUser(ctx.user.id);
 
-      capturePostHogEvent(ctx.user.id, "delete_account");
-
       await deleteUser(ctx.user.id);
+
+      capturePostHogEvent(ctx.user.id, "delete_account");
 
       return { success: true };
     } catch (error) {

--- a/apps/web/modules/auth/signup/actions.ts
+++ b/apps/web/modules/auth/signup/actions.ts
@@ -13,8 +13,8 @@ import {
 } from "@/lib/constants";
 import { verifyInviteToken } from "@/lib/jwt";
 import { createMembership } from "@/lib/membership/service";
-import { createOrganization } from "@/lib/organization/service";
-import { capturePostHogEvent } from "@/lib/posthog";
+import { createOrganization, getOrganization } from "@/lib/organization/service";
+import { capturePostHogEvent, groupIdentifyPostHog } from "@/lib/posthog";
 import { actionClient } from "@/lib/utils/action-client";
 import { ActionClientCtx } from "@/lib/utils/action-client/types/context";
 import { createUser, updateUser } from "@/modules/auth/lib/user";
@@ -116,6 +116,11 @@ async function handleInviteAcceptance(
     role: invite.role,
   });
 
+  const invitedOrganization = await getOrganization(invite.organizationId);
+  if (invitedOrganization) {
+    groupIdentifyPostHog("organization", invitedOrganization.id, { name: invitedOrganization.name });
+  }
+
   if (invite.teamIds) {
     await createTeamMembership(
       {
@@ -166,10 +171,17 @@ async function handleOrganizationCreation(ctx: ActionClientCtx, user: TCreatedUs
     });
   }
 
-  capturePostHogEvent(user.id, "organization_created", {
-    organization_id: organization.id,
-    is_first_org: true,
-  });
+  groupIdentifyPostHog("organization", organization.id, { name: organization.name });
+
+  capturePostHogEvent(
+    user.id,
+    "organization_created",
+    {
+      organization_id: organization.id,
+      is_first_org: true,
+    },
+    { organizationId: organization.id }
+  );
 
   await updateUser(user.id, {
     notificationSettings: {
@@ -236,12 +248,19 @@ export const createUserAction = actionClient.inputSchema(ZCreateUserAction).acti
         subscribeToProductUpdates: parsedInput.subscribeToProductUpdates,
       });
 
-      capturePostHogEvent(user.id, "user_signed_up", {
-        auth_provider: "credentials",
-        email_domain: user.email.split("@")[1],
-        signup_source: parsedInput.inviteToken ? "invite" : "direct",
-        invite_organization_id: ctx.auditLoggingCtx.organizationId ?? null,
-      });
+      capturePostHogEvent(
+        user.id,
+        "user_signed_up",
+        {
+          auth_provider: "credentials",
+          email_domain: user.email.split("@")[1],
+          signup_source: parsedInput.inviteToken ? "invite" : "direct",
+          invite_organization_id: ctx.auditLoggingCtx.organizationId ?? null,
+        },
+        ctx.auditLoggingCtx.organizationId
+          ? { organizationId: ctx.auditLoggingCtx.organizationId }
+          : undefined
+      );
     }
 
     if (user) {

--- a/apps/web/modules/auth/signup/actions.ts
+++ b/apps/web/modules/auth/signup/actions.ts
@@ -116,9 +116,13 @@ async function handleInviteAcceptance(
     role: invite.role,
   });
 
-  const invitedOrganization = await getOrganization(invite.organizationId);
-  if (invitedOrganization) {
-    groupIdentifyPostHog("organization", invitedOrganization.id, { name: invitedOrganization.name });
+  try {
+    const invitedOrganization = await getOrganization(invite.organizationId);
+    if (invitedOrganization) {
+      groupIdentifyPostHog("organization", invitedOrganization.id, { name: invitedOrganization.name });
+    }
+  } catch (error) {
+    logger.warn({ error, organizationId: invite.organizationId }, "Failed to identify org group in PostHog");
   }
 
   if (invite.teamIds) {

--- a/apps/web/modules/ee/billing/actions.ts
+++ b/apps/web/modules/ee/billing/actions.ts
@@ -220,9 +220,14 @@ export const startHobbyAction = authenticatedActionClient
     await reconcileCloudStripeSubscriptionsForOrganization(parsedInput.organizationId);
     await syncOrganizationBillingFromStripe(parsedInput.organizationId);
 
-    capturePostHogEvent(ctx.user.id, "stayed_on_hobby_plan", {
-      organization_id: parsedInput.organizationId,
-    });
+    capturePostHogEvent(
+      ctx.user.id,
+      "stayed_on_hobby_plan",
+      {
+        organization_id: parsedInput.organizationId,
+      },
+      { organizationId: parsedInput.organizationId }
+    );
 
     return { success: true };
   });
@@ -257,15 +262,25 @@ export const startProTrialAction = authenticatedActionClient
     await reconcileCloudStripeSubscriptionsForOrganization(parsedInput.organizationId);
     await syncOrganizationBillingFromStripe(parsedInput.organizationId);
 
-    capturePostHogEvent(ctx.user.id, "free_trial_started", {
-      plan: "pro",
-      organization_id: parsedInput.organizationId,
-      trial_duration_days: 14,
-    });
+    capturePostHogEvent(
+      ctx.user.id,
+      "free_trial_started",
+      {
+        plan: "pro",
+        organization_id: parsedInput.organizationId,
+        trial_duration_days: 14,
+      },
+      { organizationId: parsedInput.organizationId }
+    );
 
-    capturePostHogEvent(ctx.user.id, "reverse_trial_started", {
-      organization_id: parsedInput.organizationId,
-    });
+    capturePostHogEvent(
+      ctx.user.id,
+      "reverse_trial_started",
+      {
+        organization_id: parsedInput.organizationId,
+      },
+      { organizationId: parsedInput.organizationId }
+    );
 
     return { success: true };
   });

--- a/apps/web/modules/ee/contacts/[contactId]/actions.ts
+++ b/apps/web/modules/ee/contacts/[contactId]/actions.ts
@@ -3,6 +3,7 @@
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromContactId, getProjectIdFromContactId } from "@/lib/utils/helper";
@@ -53,6 +54,17 @@ export const generatePersonalSurveyLinkAction = authenticatedActionClient
       const errorMessage = result.error.details?.[0]?.issue || "Failed to generate personal survey link";
       throw new InvalidInputError(errorMessage);
     }
+
+    capturePostHogEvent(
+      ctx.user.id,
+      "personal_link_created",
+      {
+        organization_id: organizationId,
+        workspace_id: projectId,
+        survey_id: parsedInput.surveyId,
+      },
+      { organizationId, workspaceId: projectId }
+    );
 
     return {
       surveyUrl: result.data,

--- a/apps/web/modules/ee/contacts/actions.ts
+++ b/apps/web/modules/ee/contacts/actions.ts
@@ -1,9 +1,11 @@
 "use server";
 
 import { z } from "zod";
+import { prisma } from "@formbricks/database";
 import { ZId } from "@formbricks/types/common";
 import { ZContactAttributesInput } from "@formbricks/types/contact-attribute";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import {
@@ -113,6 +115,10 @@ export const createContactsFromCSVAction = authenticatedActionClient
       });
 
       ctx.auditLoggingCtx.organizationId = organizationId;
+      const projectId = await getProjectIdFromEnvironmentId(parsedInput.environmentId);
+      const existingContactCount = await prisma.contact.count({
+        where: { environmentId: parsedInput.environmentId },
+      });
       const result = await createContactsFromCSV(
         parsedInput.csvData,
         parsedInput.environmentId,
@@ -124,6 +130,20 @@ export const createContactsFromCSVAction = authenticatedActionClient
         ctx.auditLoggingCtx.newObject = {
           contacts: result.contacts,
         };
+
+        capturePostHogEvent(
+          ctx.user.id,
+          "contact_created",
+          {
+            organization_id: organizationId,
+            workspace_id: projectId,
+            environment_id: parsedInput.environmentId,
+            existing_contact_count: existingContactCount,
+            creation_method: "import",
+            import_count: result.contacts.length,
+          },
+          { organizationId, workspaceId: projectId }
+        );
       }
 
       return result;

--- a/apps/web/modules/ee/contacts/attributes/actions.ts
+++ b/apps/web/modules/ee/contacts/attributes/actions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { ZContactAttributeDataType } from "@formbricks/types/contact-attribute-key";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromEnvironmentId, getProjectIdFromEnvironmentId } from "@/lib/utils/helper";
@@ -61,6 +62,18 @@ export const createContactAttributeKeyAction = authenticatedActionClient
       });
 
       ctx.auditLoggingCtx.newObject = contactAttributeKey;
+
+      capturePostHogEvent(
+        ctx.user.id,
+        "contact_attribute_key_created",
+        {
+          organization_id: organizationId,
+          workspace_id: projectId,
+          environment_id: parsedInput.environmentId,
+          key: parsedInput.key,
+        },
+        { organizationId, workspaceId: projectId }
+      );
 
       return contactAttributeKey;
     })

--- a/apps/web/modules/ee/contacts/segments/actions.ts
+++ b/apps/web/modules/ee/contacts/segments/actions.ts
@@ -5,6 +5,7 @@ import { ZId } from "@formbricks/types/common";
 import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { ZSegmentCreateInput, ZSegmentFilters, ZSegmentUpdateInput } from "@formbricks/types/segment";
 import { getOrganization } from "@/lib/organization/service";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { loadNewSegmentInSurvey } from "@/lib/survey/service";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
@@ -91,6 +92,19 @@ export const createSegmentAction = authenticatedActionClient.inputSchema(ZSegmen
     // Set the segmentId in the context to be used in the audit log
     ctx.auditLoggingCtx.segmentId = segment.id;
     ctx.auditLoggingCtx.newObject = segment;
+
+    const projectId = await getProjectIdFromEnvironmentId(parsedInput.environmentId);
+    capturePostHogEvent(
+      ctx.user?.id ?? "",
+      "segment_created",
+      {
+        organization_id: organizationId,
+        workspace_id: projectId,
+        environment_id: parsedInput.environmentId,
+        is_private: parsedInput.isPrivate ?? false,
+      },
+      { organizationId, workspaceId: projectId }
+    );
 
     return segment;
   })

--- a/apps/web/modules/ee/contacts/segments/actions.ts
+++ b/apps/web/modules/ee/contacts/segments/actions.ts
@@ -60,6 +60,7 @@ export const createSegmentAction = authenticatedActionClient.inputSchema(ZSegmen
 
     // Set the organizationId in the context to be used in the audit log
     ctx.auditLoggingCtx.organizationId = organizationId;
+    const projectId = await getProjectIdFromEnvironmentId(parsedInput.environmentId);
 
     await checkAuthorizationUpdated({
       userId: ctx.user?.id ?? "",
@@ -72,7 +73,7 @@ export const createSegmentAction = authenticatedActionClient.inputSchema(ZSegmen
         {
           type: "projectTeam",
           minPermission: "readWrite",
-          projectId: await getProjectIdFromEnvironmentId(parsedInput.environmentId),
+          projectId,
         },
       ],
     });
@@ -93,7 +94,6 @@ export const createSegmentAction = authenticatedActionClient.inputSchema(ZSegmen
     ctx.auditLoggingCtx.segmentId = segment.id;
     ctx.auditLoggingCtx.newObject = segment;
 
-    const projectId = await getProjectIdFromEnvironmentId(parsedInput.environmentId);
     capturePostHogEvent(
       ctx.user?.id ?? "",
       "segment_created",

--- a/apps/web/modules/ee/whitelabel/remove-branding/actions.ts
+++ b/apps/web/modules/ee/whitelabel/remove-branding/actions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { getOrganization } from "@/lib/organization/service";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromProjectId } from "@/lib/utils/helper";
@@ -64,9 +65,39 @@ export const updateProjectBrandingAction = authenticatedActionClient.inputSchema
 
     ctx.auditLoggingCtx.organizationId = organizationId;
     ctx.auditLoggingCtx.projectId = parsedInput.projectId;
-    ctx.auditLoggingCtx.oldObject = await getProject(parsedInput.projectId);
+    const oldProject = await getProject(parsedInput.projectId);
+    ctx.auditLoggingCtx.oldObject = oldProject;
     const result = await updateProjectBranding(parsedInput.projectId, parsedInput.data);
     ctx.auditLoggingCtx.newObject = await getProject(parsedInput.projectId);
+
+    const groupContext = { organizationId, workspaceId: parsedInput.projectId };
+
+    if (oldProject?.linkSurveyBranding === true && parsedInput.data.linkSurveyBranding === false) {
+      capturePostHogEvent(
+        ctx.user.id,
+        "remove_branding_enabled",
+        {
+          organization_id: organizationId,
+          workspace_id: parsedInput.projectId,
+          branding_type: "link",
+        },
+        groupContext
+      );
+    }
+
+    if (oldProject?.inAppSurveyBranding === true && parsedInput.data.inAppSurveyBranding === false) {
+      capturePostHogEvent(
+        ctx.user.id,
+        "remove_branding_enabled",
+        {
+          organization_id: organizationId,
+          workspace_id: parsedInput.projectId,
+          branding_type: "in_app",
+        },
+        groupContext
+      );
+    }
+
     return result;
   })
 );

--- a/apps/web/modules/integrations/webhooks/actions.ts
+++ b/apps/web/modules/integrations/webhooks/actions.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { generateWebhookSecret } from "@/lib/crypto";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import {
@@ -31,6 +32,7 @@ const ZCreateWebhookAction = z.object({
 export const createWebhookAction = authenticatedActionClient.inputSchema(ZCreateWebhookAction).action(
   withAuditLogging("created", "webhook", async ({ ctx, parsedInput }) => {
     const organizationId = await getOrganizationIdFromEnvironmentId(parsedInput.environmentId);
+    const projectId = await getProjectIdFromEnvironmentId(parsedInput.environmentId);
     await checkAuthorizationUpdated({
       userId: ctx.user.id,
       organizationId,
@@ -42,7 +44,7 @@ export const createWebhookAction = authenticatedActionClient.inputSchema(ZCreate
         {
           type: "projectTeam",
           minPermission: "read",
-          projectId: await getProjectIdFromEnvironmentId(parsedInput.environmentId),
+          projectId,
         },
       ],
     });
@@ -53,6 +55,19 @@ export const createWebhookAction = authenticatedActionClient.inputSchema(ZCreate
     );
     ctx.auditLoggingCtx.organizationId = organizationId;
     ctx.auditLoggingCtx.newObject = parsedInput.webhookInput;
+
+    capturePostHogEvent(
+      ctx.user.id,
+      "integration_connected",
+      {
+        integration_type: "webhook",
+        organization_id: organizationId,
+        workspace_id: projectId,
+        environment_id: parsedInput.environmentId,
+      },
+      { organizationId, workspaceId: projectId }
+    );
+
     return webhook;
   })
 );

--- a/apps/web/modules/organization/actions.ts
+++ b/apps/web/modules/organization/actions.ts
@@ -7,6 +7,7 @@ import { TUserNotificationSettings } from "@formbricks/types/user";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { createMembership } from "@/lib/membership/service";
 import { createOrganization } from "@/lib/organization/service";
+import { capturePostHogEvent, groupIdentifyPostHog } from "@/lib/posthog";
 import { updateUser } from "@/lib/user/service";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
@@ -47,9 +48,33 @@ export const createOrganizationAction = authenticatedActionClient
         });
       }
 
-      await createProject(newOrganization.id, {
+      const newProject = await createProject(newOrganization.id, {
         name: "My Project",
       });
+
+      groupIdentifyPostHog("organization", newOrganization.id, { name: newOrganization.name });
+      groupIdentifyPostHog("workspace", newProject.id, { name: newProject.name });
+
+      capturePostHogEvent(
+        ctx.user.id,
+        "organization_created",
+        {
+          organization_id: newOrganization.id,
+          is_first_org: false,
+        },
+        { organizationId: newOrganization.id, workspaceId: newProject.id }
+      );
+
+      capturePostHogEvent(
+        ctx.user.id,
+        "workspace_created",
+        {
+          organization_id: newOrganization.id,
+          workspace_id: newProject.id,
+          name: newProject.name,
+        },
+        { organizationId: newOrganization.id, workspaceId: newProject.id }
+      );
 
       const updatedNotificationSettings: TUserNotificationSettings = {
         ...ctx.user.notificationSettings,

--- a/apps/web/modules/organization/settings/teams/actions.ts
+++ b/apps/web/modules/organization/settings/teams/actions.ts
@@ -328,10 +328,15 @@ export const inviteUserAction = authenticatedActionClient.inputSchema(ZInviteUse
       await sendInviteMemberEmail(inviteId, parsedInput.email, ctx.user.name ?? "", parsedInput.name ?? "");
     }
 
-    capturePostHogEvent(ctx.user.id, "team_member_invited", {
-      organization_id: parsedInput.organizationId,
-      invitee_role: parsedInput.role,
-    });
+    capturePostHogEvent(
+      ctx.user.id,
+      "team_member_invited",
+      {
+        organization_id: parsedInput.organizationId,
+        invitee_role: parsedInput.role,
+      },
+      { organizationId: parsedInput.organizationId }
+    );
 
     return inviteId;
   })

--- a/apps/web/modules/projects/settings/actions.ts
+++ b/apps/web/modules/projects/settings/actions.ts
@@ -6,6 +6,7 @@ import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/typ
 import { ZProjectUpdateInput } from "@formbricks/types/project";
 import { getTeamsByOrganizationId } from "@/app/(app)/(onboarding)/lib/onboarding";
 import { getOrganization } from "@/lib/organization/service";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { getProject } from "@/lib/project/service";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
@@ -72,6 +73,35 @@ export const updateProjectAction = authenticatedActionClient.inputSchema(ZUpdate
     const result = await updateProject(parsedInput.projectId, parsedInput.data);
     ctx.auditLoggingCtx.oldObject = oldObject;
     ctx.auditLoggingCtx.newObject = result;
+
+    const groupContext = { organizationId, workspaceId: parsedInput.projectId };
+
+    if (oldObject?.linkSurveyBranding === true && parsedInput.data.linkSurveyBranding === false) {
+      capturePostHogEvent(
+        ctx.user.id,
+        "remove_branding_enabled",
+        {
+          organization_id: organizationId,
+          workspace_id: parsedInput.projectId,
+          branding_type: "link",
+        },
+        groupContext
+      );
+    }
+
+    if (oldObject?.inAppSurveyBranding === true && parsedInput.data.inAppSurveyBranding === false) {
+      capturePostHogEvent(
+        ctx.user.id,
+        "remove_branding_enabled",
+        {
+          organization_id: organizationId,
+          workspace_id: parsedInput.projectId,
+          branding_type: "in_app",
+        },
+        groupContext
+      );
+    }
+
     return result;
   })
 );

--- a/apps/web/modules/survey/components/template-list/actions.ts
+++ b/apps/web/modules/survey/components/template-list/actions.ts
@@ -66,18 +66,26 @@ export const createSurveyAction = authenticatedActionClient.inputSchema(ZCreateS
       await checkSurveyFollowUpsPermission(organizationId);
     }
 
+    const projectId = await getProjectIdFromEnvironmentId(parsedInput.environmentId);
     const result = await createSurvey(parsedInput.environmentId, parsedInput.surveyBody);
     ctx.auditLoggingCtx.organizationId = organizationId;
     ctx.auditLoggingCtx.surveyId = result.id;
     ctx.auditLoggingCtx.newObject = result;
 
-    capturePostHogEvent(ctx.user.id, "survey_created", {
-      survey_id: result.id,
-      survey_type: result.type,
-      organization_id: organizationId,
-      question_count: result.questions?.length ?? 0,
-      created_from: parsedInput.createdFrom ?? "template",
-    });
+    capturePostHogEvent(
+      ctx.user.id,
+      "survey_created",
+      {
+        survey_id: result.id,
+        survey_type: result.type,
+        organization_id: organizationId,
+        workspace_id: projectId,
+        environment_id: parsedInput.environmentId,
+        question_count: result.questions?.length ?? 0,
+        created_from: parsedInput.createdFrom ?? "template",
+      },
+      { organizationId, workspaceId: projectId }
+    );
 
     return result;
   })

--- a/apps/web/modules/survey/editor/actions.ts
+++ b/apps/web/modules/survey/editor/actions.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { ZActionClassInput } from "@formbricks/types/action-classes";
 import { ZId } from "@formbricks/types/common";
 import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
-import { TSurvey, ZSurvey } from "@formbricks/types/surveys/types";
+import { TSurvey, TSurveyVariable, ZSurvey } from "@formbricks/types/surveys/types";
 import { POSTHOG_KEY, UNSPLASH_ACCESS_KEY, UNSPLASH_ALLOWED_DOMAINS } from "@/lib/constants";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { actionClient, authenticatedActionClient } from "@/lib/utils/action-client";
@@ -27,6 +27,124 @@ import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 import { checkSpamProtectionPermission } from "@/modules/survey/lib/permission";
 import { getOrganizationBilling, getSurvey } from "@/modules/survey/lib/survey";
 import { getProject, getProjectLanguages } from "./lib/project";
+
+type SurveyEditDiffContext = {
+  userId: string;
+  surveyId: string;
+  organizationId: string;
+  workspaceId: string;
+  environmentId: string;
+};
+
+const captureSurveyEditDiffEvents = (
+  oldSurvey: TSurvey | null,
+  newSurvey: TSurvey,
+  context: SurveyEditDiffContext
+): void => {
+  if (!POSTHOG_KEY || !oldSurvey) return;
+
+  const groupContext = { organizationId: context.organizationId, workspaceId: context.workspaceId };
+  const baseProps = {
+    organization_id: context.organizationId,
+    workspace_id: context.workspaceId,
+    environment_id: context.environmentId,
+    survey_id: context.surveyId,
+  };
+
+  // hidden_field_added
+  const oldFieldIds = new Set(oldSurvey.hiddenFields?.fieldIds ?? []);
+  const newFieldIds = newSurvey.hiddenFields?.fieldIds ?? [];
+  const addedFieldIds = newFieldIds.filter((id) => !oldFieldIds.has(id));
+  if (addedFieldIds.length > 0) {
+    capturePostHogEvent(
+      context.userId,
+      "hidden_field_added",
+      { ...baseProps, field_count: newFieldIds.length },
+      groupContext
+    );
+  }
+
+  // conditional_logic_added (per block)
+  const oldBlocks = oldSurvey.blocks ?? [];
+  const newBlocks = newSurvey.blocks ?? [];
+  const oldBlockLogic = new Map<string, number>(
+    oldBlocks.map((b) => [b.id, (b.logic?.length ?? 0) + (b.logicFallback ? 1 : 0)])
+  );
+  for (const block of newBlocks) {
+    const newLogicCount = (block.logic?.length ?? 0) + (block.logicFallback ? 1 : 0);
+    const oldLogicCount = oldBlockLogic.get(block.id) ?? 0;
+    if (newLogicCount > oldLogicCount) {
+      capturePostHogEvent(
+        context.userId,
+        "conditional_logic_added",
+        { ...baseProps, question_id: block.id },
+        groupContext
+      );
+    }
+  }
+
+  // variable_created
+  const oldVariableIds = new Set((oldSurvey.variables ?? []).map((v: TSurveyVariable) => v.id));
+  for (const variable of newSurvey.variables ?? []) {
+    if (!oldVariableIds.has(variable.id)) {
+      capturePostHogEvent(
+        context.userId,
+        "variable_created",
+        { ...baseProps, variable_type: variable.type },
+        groupContext
+      );
+    }
+  }
+
+  // multi_language_enabled / multi_language_created
+  const oldLanguages = oldSurvey.languages ?? [];
+  const newLanguages = newSurvey.languages ?? [];
+  const oldLanguageCodes = new Set(oldLanguages.map((l) => l.language.code));
+  const addedLanguages = newLanguages.filter((l) => !oldLanguageCodes.has(l.language.code));
+
+  if (addedLanguages.length > 0) {
+    const wasMultiLangBefore = oldLanguages.length > 1;
+    const baseLanguageProps = {
+      organization_id: context.organizationId,
+      workspace_id: context.workspaceId,
+    };
+
+    if (!wasMultiLangBefore) {
+      const [first, ...rest] = addedLanguages;
+      capturePostHogEvent(
+        context.userId,
+        "multi_language_enabled",
+        { ...baseLanguageProps, language_code: first.language.code },
+        groupContext
+      );
+      for (const lang of rest) {
+        capturePostHogEvent(
+          context.userId,
+          "multi_language_created",
+          {
+            ...baseLanguageProps,
+            language_code: lang.language.code,
+            existing_language_count: oldLanguages.length,
+          },
+          groupContext
+        );
+      }
+    } else {
+      for (const lang of addedLanguages) {
+        capturePostHogEvent(
+          context.userId,
+          "multi_language_created",
+          {
+            ...baseLanguageProps,
+            language_code: lang.language.code,
+            existing_language_count: oldLanguages.length,
+          },
+          groupContext
+        );
+      }
+    }
+  }
+};
 
 /**
  * Checks if survey follow-ups can be added for the given organization.
@@ -100,6 +218,17 @@ export const updateSurveyDraftAction = authenticatedActionClient.inputSchema(ZSu
     ctx.auditLoggingCtx.oldObject = oldObject;
     ctx.auditLoggingCtx.newObject = result;
 
+    if (POSTHOG_KEY) {
+      const projectId = await getProjectIdFromSurveyId(survey.id);
+      captureSurveyEditDiffEvents(oldObject, result, {
+        userId: ctx.user.id,
+        surveyId: result.id,
+        organizationId,
+        workspaceId: projectId,
+        environmentId: result.environmentId,
+      });
+    }
+
     revalidatePath(`/environments/${result.environmentId}/surveys/${result.id}`);
 
     return result;
@@ -148,23 +277,39 @@ export const updateSurveyAction = authenticatedActionClient.inputSchema(ZSurvey)
     ctx.auditLoggingCtx.oldObject = oldObject;
     ctx.auditLoggingCtx.newObject = result;
 
-    if (POSTHOG_KEY && result.status !== "draft") {
-      const isPublish = oldObject?.status === "draft" && result.status === "inProgress";
+    if (POSTHOG_KEY) {
+      const projectId = await getProjectIdFromSurveyId(parsedInput.id);
 
-      const posthogEventMetadata = {
-        survey_id: result.id,
-        survey_type: result.type,
-        question_count: getElementsFromBlocks(result.blocks).length,
-        organization_id: organizationId,
-        has_targeting: result.segment ? !result.segment.isPrivate : false,
-        language_count: result.languages?.length ?? 0,
-      };
+      captureSurveyEditDiffEvents(oldObject, result, {
+        userId: ctx.user.id,
+        surveyId: result.id,
+        organizationId,
+        workspaceId: projectId,
+        environmentId: result.environmentId,
+      });
 
-      if (isPublish) {
-        capturePostHogEvent(ctx.user.id, "survey_published", posthogEventMetadata);
-        capturePostHogEvent(ctx.user.id, "survey_updated", posthogEventMetadata);
-      } else {
-        capturePostHogEvent(ctx.user.id, "survey_updated", posthogEventMetadata);
+      if (result.status !== "draft") {
+        const isPublish = oldObject?.status === "draft" && result.status === "inProgress";
+
+        const posthogEventMetadata = {
+          survey_id: result.id,
+          survey_type: result.type,
+          question_count: getElementsFromBlocks(result.blocks).length,
+          organization_id: organizationId,
+          workspace_id: projectId,
+          environment_id: result.environmentId,
+          has_targeting: result.segment ? !result.segment.isPrivate : false,
+          language_count: result.languages?.length ?? 0,
+        };
+
+        const groupContext = { organizationId, workspaceId: projectId };
+
+        if (isPublish) {
+          capturePostHogEvent(ctx.user.id, "survey_published", posthogEventMetadata, groupContext);
+          capturePostHogEvent(ctx.user.id, "survey_updated", posthogEventMetadata, groupContext);
+        } else {
+          capturePostHogEvent(ctx.user.id, "survey_updated", posthogEventMetadata, groupContext);
+        }
       }
     }
 
@@ -335,9 +480,27 @@ export const createActionClassAction = authenticatedActionClient.inputSchema(ZCr
     });
 
     ctx.auditLoggingCtx.organizationId = organizationId;
+    const projectId = await getProjectIdFromEnvironmentId(parsedInput.action.environmentId);
     const result = await createActionClass(parsedInput.action.environmentId, parsedInput.action);
     ctx.auditLoggingCtx.actionClassId = result.id;
     ctx.auditLoggingCtx.newObject = result;
+
+    const triggerType =
+      parsedInput.action.type === "code" ? "codeAction" : (parsedInput.action.noCodeConfig?.type ?? "noCode");
+
+    capturePostHogEvent(
+      ctx.user.id,
+      "action_class_created",
+      {
+        organization_id: organizationId,
+        workspace_id: projectId,
+        environment_id: parsedInput.action.environmentId,
+        type: parsedInput.action.type,
+        trigger_type: triggerType,
+      },
+      { organizationId, workspaceId: projectId }
+    );
+
     return result;
   })
 );

--- a/apps/web/modules/survey/editor/actions.ts
+++ b/apps/web/modules/survey/editor/actions.ts
@@ -41,7 +41,7 @@ const captureSurveyEditDiffEvents = (
   newSurvey: TSurvey,
   context: SurveyEditDiffContext
 ): void => {
-  if (!POSTHOG_KEY || !oldSurvey) return;
+  if (!oldSurvey) return;
 
   const groupContext = { organizationId: context.organizationId, workspaceId: context.workspaceId };
   const baseProps = {
@@ -96,7 +96,7 @@ const captureSurveyEditDiffEvents = (
     }
   }
 
-  // multi_language_enabled / multi_language_created
+  // survey_language_enabled / survey_language_added
   const oldLanguages = oldSurvey.languages ?? [];
   const newLanguages = newSurvey.languages ?? [];
   const oldLanguageCodes = new Set(oldLanguages.map((l) => l.language.code));
@@ -104,43 +104,43 @@ const captureSurveyEditDiffEvents = (
 
   if (addedLanguages.length > 0) {
     const wasMultiLangBefore = oldLanguages.length > 1;
-    const baseLanguageProps = {
-      organization_id: context.organizationId,
-      workspace_id: context.workspaceId,
-    };
+    let currentCount = oldLanguages.length;
 
     if (!wasMultiLangBefore) {
       const [first, ...rest] = addedLanguages;
       capturePostHogEvent(
         context.userId,
-        "multi_language_enabled",
-        { ...baseLanguageProps, language_code: first.language.code },
+        "survey_language_enabled",
+        { ...baseProps, language_code: first.language.code, existing_language_count: currentCount },
         groupContext
       );
-      for (let i = 0; i < rest.length; i++) {
+      currentCount++;
+      for (const lang of rest) {
         capturePostHogEvent(
           context.userId,
-          "multi_language_created",
+          "survey_language_added",
           {
-            ...baseLanguageProps,
-            language_code: rest[i].language.code,
-            existing_language_count: oldLanguages.length + 1 + i,
+            ...baseProps,
+            language_code: lang.language.code,
+            existing_language_count: currentCount,
           },
           groupContext
         );
+        currentCount++;
       }
     } else {
-      for (let i = 0; i < addedLanguages.length; i++) {
+      for (const lang of addedLanguages) {
         capturePostHogEvent(
           context.userId,
-          "multi_language_created",
+          "survey_language_added",
           {
-            ...baseLanguageProps,
-            language_code: addedLanguages[i].language.code,
-            existing_language_count: oldLanguages.length + i,
+            ...baseProps,
+            language_code: lang.language.code,
+            existing_language_count: currentCount,
           },
           groupContext
         );
+        currentCount++;
       }
     }
   }
@@ -233,15 +233,13 @@ export const updateSurveyDraftAction = authenticatedActionClient.inputSchema(ZSu
     ctx.auditLoggingCtx.oldObject = oldObject;
     ctx.auditLoggingCtx.newObject = result;
 
-    if (POSTHOG_KEY) {
-      captureSurveyEditDiffEvents(oldObject, result, {
-        userId: ctx.user.id,
-        surveyId: result.id,
-        organizationId,
-        workspaceId: projectId,
-        environmentId: result.environmentId,
-      });
-    }
+    captureSurveyEditDiffEvents(oldObject, result, {
+      userId: ctx.user.id,
+      surveyId: result.id,
+      organizationId,
+      workspaceId: projectId,
+      environmentId: result.environmentId,
+    });
 
     revalidatePath(`/environments/${result.environmentId}/surveys/${result.id}`);
 
@@ -291,17 +289,17 @@ export const updateSurveyAction = authenticatedActionClient.inputSchema(ZSurvey)
     ctx.auditLoggingCtx.oldObject = oldObject;
     ctx.auditLoggingCtx.newObject = result;
 
+    const projectId = await getProjectIdFromSurveyId(parsedInput.id);
+
+    captureSurveyEditDiffEvents(oldObject, result, {
+      userId: ctx.user.id,
+      surveyId: result.id,
+      organizationId,
+      workspaceId: projectId,
+      environmentId: result.environmentId,
+    });
+
     if (POSTHOG_KEY) {
-      const projectId = await getProjectIdFromSurveyId(parsedInput.id);
-
-      captureSurveyEditDiffEvents(oldObject, result, {
-        userId: ctx.user.id,
-        surveyId: result.id,
-        organizationId,
-        workspaceId: projectId,
-        environmentId: result.environmentId,
-      });
-
       if (result.status !== "draft") {
         const isPublish = oldObject?.status === "draft" && result.status === "inProgress";
 

--- a/apps/web/modules/survey/editor/actions.ts
+++ b/apps/web/modules/survey/editor/actions.ts
@@ -117,27 +117,27 @@ const captureSurveyEditDiffEvents = (
         { ...baseLanguageProps, language_code: first.language.code },
         groupContext
       );
-      for (const lang of rest) {
+      for (let i = 0; i < rest.length; i++) {
         capturePostHogEvent(
           context.userId,
           "multi_language_created",
           {
             ...baseLanguageProps,
-            language_code: lang.language.code,
-            existing_language_count: oldLanguages.length,
+            language_code: rest[i].language.code,
+            existing_language_count: oldLanguages.length + 1 + i,
           },
           groupContext
         );
       }
     } else {
-      for (const lang of addedLanguages) {
+      for (let i = 0; i < addedLanguages.length; i++) {
         capturePostHogEvent(
           context.userId,
           "multi_language_created",
           {
             ...baseLanguageProps,
-            language_code: lang.language.code,
-            existing_language_count: oldLanguages.length,
+            language_code: addedLanguages[i].language.code,
+            existing_language_count: oldLanguages.length + i,
           },
           groupContext
         );
@@ -177,6 +177,7 @@ export const updateSurveyDraftAction = authenticatedActionClient.inputSchema(ZSu
     const survey = parsedInput as TSurvey;
 
     const organizationId = await getOrganizationIdFromSurveyId(survey.id);
+    const projectId = await getProjectIdFromSurveyId(survey.id);
     await checkAuthorizationUpdated({
       userId: ctx.user.id,
       organizationId,
@@ -187,7 +188,7 @@ export const updateSurveyDraftAction = authenticatedActionClient.inputSchema(ZSu
         },
         {
           type: "projectTeam",
-          projectId: await getProjectIdFromSurveyId(survey.id),
+          projectId,
           minPermission: "readWrite",
         },
       ],
@@ -219,7 +220,6 @@ export const updateSurveyDraftAction = authenticatedActionClient.inputSchema(ZSu
     ctx.auditLoggingCtx.newObject = result;
 
     if (POSTHOG_KEY) {
-      const projectId = await getProjectIdFromSurveyId(survey.id);
       captureSurveyEditDiffEvents(oldObject, result, {
         userId: ctx.user.id,
         surveyId: result.id,

--- a/apps/web/modules/survey/editor/actions.ts
+++ b/apps/web/modules/survey/editor/actions.ts
@@ -144,6 +144,20 @@ const captureSurveyEditDiffEvents = (
       }
     }
   }
+
+  // follow_up_added
+  const oldFollowUpIds = new Set((oldSurvey.followUps ?? []).map((f) => f.id));
+  const newFollowUps = (newSurvey.followUps ?? []).filter((f) => !f.deleted);
+  for (const followUp of newFollowUps) {
+    if (!oldFollowUpIds.has(followUp.id)) {
+      capturePostHogEvent(
+        context.userId,
+        "follow_up_added",
+        { ...baseProps, follow_up_id: followUp.id },
+        groupContext
+      );
+    }
+  }
 };
 
 /**

--- a/apps/web/modules/survey/multi-language-surveys/lib/actions.ts
+++ b/apps/web/modules/survey/multi-language-surveys/lib/actions.ts
@@ -10,6 +10,7 @@ import {
   getSurveysUsingGivenLanguage,
   updateLanguage,
 } from "@/lib/language/service";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import {
@@ -50,6 +51,18 @@ export const createLanguageAction = authenticatedActionClient.inputSchema(ZCreat
     ctx.auditLoggingCtx.organizationId = organizationId;
     ctx.auditLoggingCtx.languageId = result.id;
     ctx.auditLoggingCtx.newObject = result;
+
+    capturePostHogEvent(
+      ctx.user.id,
+      "workspace_language_created",
+      {
+        organization_id: organizationId,
+        workspace_id: parsedInput.projectId,
+        language_code: result.code,
+      },
+      { organizationId, workspaceId: parsedInput.projectId }
+    );
+
     return result;
   })
 );


### PR DESCRIPTION
## Summary

Closes [ENG-705](https://linear.app/formbricks/issue/ENG-705/add-group-analytics-and-feature-related-events).

Sets up PostHog group analytics for `organization` and `workspace` and adds the feature-level events that were missing in the first PostHog iteration. Without group analytics we couldn't aggregate org-level events (subscription, response received) with user-level events (page clicks) into a single funnel — this PR closes that gap and adds the activation/retention events the [Posthog Setup doc](https://www.notion.so/formbricks/Posthog-Setup-278e5de84a5880db94d6e0d0c5dd9a3b?source=copy_link#32ce5de84a58806e94b2ff876d4bc149) calls out.

## Group analytics

- `capturePostHogEvent` now accepts an optional `groupContext` (`organizationId`, `workspaceId`) and forwards it to PostHog's `groups` argument.
- New `groupIdentifyPostHog(groupType, groupKey, properties)` helper that wraps `posthog-node`'s `groupIdentify`.
- New `PostHogGroupIdentify` client component, mounted in `environments/[environmentId]/layout.tsx`, calls `posthog.group(\"organization\", …)` and `posthog.group(\"workspace\", …)` so all client-side events on env-scoped pages auto-link to both groups. It briefly polls `posthog.__loaded` to avoid an effect-order race with `PostHogIdentify` in the parent layout.
- `groupIdentifyPostHog` is called on:
  - Organization creation (setup flow, signup flow, multi-org action)
  - Invite acceptance — identifies the joined organization
  - Workspace (project) creation

The group type is named `workspace` to align with the long-term Project → Workspace migration; the underlying key is `projectId`, mapped via the existing `getProjectIdFromX` helpers.

## Existing events extended with `groupContext`

`organization_created`, `user_signed_up`, `survey_created`, `survey_published`, `survey_updated`, `responses_exported`, `team_member_invited`, `integration_connected` (action + airtable / slack / notion / google sheets callbacks — also added `workspace_id` and `environment_id` properties), `survey_response_received` (pipeline helper), `free_trial_started`, `reverse_trial_started`, `stayed_on_hobby_plan`.

## New events

| Event | Where | Notable properties |
| --- | --- | --- |
| `workspace_created` | `createProjectAction`, multi-org create | `workspace_id`, `name` |
| `contact_created` | CSV import action | `existing_contact_count`, `creation_method: \"import\"`, `import_count` |
| `contact_attribute_key_created` | Attributes action | `key` |
| `segment_created` | Segments action | `is_private` |
| `action_class_created` | Survey editor action | `type`, `trigger_type` |
| `remove_branding_enabled` | Project settings update | `branding_type: \"link\" \\| \"in_app\"` — fires on `true → false` transitions |
| `personal_link_created` | Generate personal survey link action | `survey_id` |
| `delete_account` | Account deletion action | — |

## Diff-based survey edit events

A shared `captureSurveyEditDiffEvents` helper compares the survey before and after `updateSurvey` / `updateSurveyDraft` and emits:

- `hidden_field_added` (with `field_count`)
- `conditional_logic_added` (per block, with `question_id`)
- `variable_created` (per new variable, with `variable_type`)
- `multi_language_enabled` — fires when the first non-default language is added
- `multi_language_created` — fires for each subsequent language, with `existing_language_count`

## Verification

- Updated `capture.test.ts` (9 tests) and `pipeline/lib/posthog.test.ts` (5 tests) — all 14 PostHog-related tests pass.
- `tsc --noEmit` introduces no net-new error categories vs. `main`; the single new diagnostic is the same kind of `environmentId on ContactWhereInput` mismatch already present hundreds of times across the codebase from the in-flight Project → Workspace migration and will resolve when that lands.

## Test plan

- [ ] Sign up a new user via credentials — confirm `user_signed_up` and `organization_created` fire with `groups.organization` populated in PostHog
- [ ] Sign up via invite — confirm `user_signed_up` carries `groups.organization` for the inviting org and that org is identified via `groupIdentify`
- [ ] Create a new workspace — confirm `workspace_created` fires and `groups.workspace` is populated
- [ ] Open any environment-scoped page — confirm client-side autocapture events are tagged with both `organization` and `workspace` groups in PostHog
- [ ] Connect each integration (action + each OAuth callback) — confirm `integration_connected` includes `integration_type`, `workspace_id`, `environment_id`, and groups
- [ ] Create / publish / update a survey — confirm corresponding events fire with `workspace_id` and groups
- [ ] In the survey editor: add a hidden field, add conditional logic on a block, add a variable, add a non-default language (then a second one) — confirm `hidden_field_added`, `conditional_logic_added`, `variable_created`, `multi_language_enabled`, `multi_language_created` fire as expected
- [ ] Toggle off "Formbricks branding on link surveys" and "Formbricks branding on in-app surveys" — confirm `remove_branding_enabled` fires with the right `branding_type`
- [ ] Import contacts via CSV — confirm `contact_created` with `creation_method: \"import\"` and `import_count`
- [ ] Create a contact attribute key, create a segment, create an action class, generate a personal survey link — confirm corresponding events
- [ ] Delete an account — confirm `delete_account` fires before the user record is removed
- [ ] Start a Pro trial / stay on hobby — confirm `free_trial_started`, `reverse_trial_started`, `stayed_on_hobby_plan` carry `groups.organization`