### PR TITLE
fix: skip free plan subscription renewal webhooks to prevent Make credit drain

### DIFF
--- a/apps/web/modules/ee/billing/api/lib/stripe-webhook.test.ts
+++ b/apps/web/modules/ee/billing/api/lib/stripe-webhook.test.ts
@@ -17,26 +17,20 @@ vi.mock("./stripe-client", () => ({
 }));
 
 const hobbyProduct = {
-  id: "prod_hobby",
+  id: "prod_U8jd2XNJgewiiA",
   metadata: { formbricks_plan: "hobby" },
+  deleted: false,
+} as Stripe.Product;
+
+const legacyFreeProduct = {
+  id: "prod_U8jeQdtjaUrVUf",
+  metadata: { formbricks_plan: "custom" },
   deleted: false,
 } as Stripe.Product;
 
 const proProduct = {
   id: "prod_pro",
   metadata: { formbricks_plan: "pro" },
-  deleted: false,
-} as Stripe.Product;
-
-const legacyFreeProduct = {
-  id: "prod_legacy_free",
-  metadata: { formbricks_plan: "free" },
-  deleted: false,
-} as Stripe.Product;
-
-const legacyStartupProduct = {
-  id: "prod_legacy_startup",
-  metadata: { formbricks_plan: "startup" },
   deleted: false,
 } as Stripe.Product;
 
@@ -86,18 +80,6 @@ describe("isFreePlanSubscriptionRenewal", () => {
   test("returns true for legacy free subscription renewal", () => {
     const event = makeSubscriptionUpdatedEvent({
       product: legacyFreeProduct,
-      previousAttributes: {
-        current_period_start: 1710000000,
-        current_period_end: 1712678400,
-      },
-    });
-
-    expect(isFreePlanSubscriptionRenewal(event)).toBe(true);
-  });
-
-  test("returns true for legacy startup subscription renewal", () => {
-    const event = makeSubscriptionUpdatedEvent({
-      product: legacyStartupProduct,
       previousAttributes: {
         current_period_start: 1710000000,
         current_period_end: 1712678400,
@@ -170,7 +152,7 @@ describe("isFreePlanSubscriptionRenewal", () => {
       type: "customer.subscription.updated",
       data: {
         object: {
-          items: { data: [{ price: { product: "prod_hobby" } }] },
+          items: { data: [{ price: { product: "prod_U8jd2XNJgewiiA" } }] },
         },
         previous_attributes: { current_period_start: 1710000000 },
       },
@@ -193,6 +175,21 @@ describe("isFreePlanSubscriptionRenewal", () => {
   test("returns false for mixed free and pro items", () => {
     const event = makeSubscriptionUpdatedEvent({
       product: [hobbyProduct, proProduct],
+      previousAttributes: { current_period_start: 1710000000 },
+    });
+
+    expect(isFreePlanSubscriptionRenewal(event)).toBe(false);
+  });
+
+  test("returns false for unknown product ID", () => {
+    const unknownProduct = {
+      id: "prod_unknown",
+      metadata: { formbricks_plan: "hobby" },
+      deleted: false,
+    } as Stripe.Product;
+
+    const event = makeSubscriptionUpdatedEvent({
+      product: unknownProduct,
       previousAttributes: { current_period_start: 1710000000 },
     });
 

--- a/apps/web/modules/ee/billing/api/lib/stripe-webhook.test.ts
+++ b/apps/web/modules/ee/billing/api/lib/stripe-webhook.test.ts
@@ -28,8 +28,20 @@ const proProduct = {
   deleted: false,
 } as Stripe.Product;
 
+const legacyFreeProduct = {
+  id: "prod_legacy_free",
+  metadata: { formbricks_plan: "free" },
+  deleted: false,
+} as Stripe.Product;
+
+const legacyStartupProduct = {
+  id: "prod_legacy_startup",
+  metadata: { formbricks_plan: "startup" },
+  deleted: false,
+} as Stripe.Product;
+
 const makeSubscriptionUpdatedEvent = (opts: {
-  product: Stripe.Product;
+  product: Stripe.Product | Stripe.Product[];
   previousAttributes: Record<string, unknown>;
 }): Stripe.Event =>
   ({
@@ -37,7 +49,9 @@ const makeSubscriptionUpdatedEvent = (opts: {
     data: {
       object: {
         items: {
-          data: [{ price: { product: opts.product } }],
+          data: Array.isArray(opts.product)
+            ? opts.product.map((p) => ({ price: { product: p } }))
+            : [{ price: { product: opts.product } }],
         },
       },
       previous_attributes: opts.previousAttributes,
@@ -48,12 +62,12 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe("isHobbySubscriptionRenewal", () => {
-  let isHobbySubscriptionRenewal: (event: Stripe.Event) => boolean;
+describe("isFreePlanSubscriptionRenewal", () => {
+  let isFreePlanSubscriptionRenewal: (event: Stripe.Event) => boolean;
 
   beforeAll(async () => {
     const mod = await import("./stripe-webhook");
-    isHobbySubscriptionRenewal = mod.isHobbySubscriptionRenewal;
+    isFreePlanSubscriptionRenewal = mod.isFreePlanSubscriptionRenewal;
   });
 
   test("returns true for hobby subscription with only billing period changes", () => {
@@ -66,7 +80,31 @@ describe("isHobbySubscriptionRenewal", () => {
       },
     });
 
-    expect(isHobbySubscriptionRenewal(event)).toBe(true);
+    expect(isFreePlanSubscriptionRenewal(event)).toBe(true);
+  });
+
+  test("returns true for legacy free subscription renewal", () => {
+    const event = makeSubscriptionUpdatedEvent({
+      product: legacyFreeProduct,
+      previousAttributes: {
+        current_period_start: 1710000000,
+        current_period_end: 1712678400,
+      },
+    });
+
+    expect(isFreePlanSubscriptionRenewal(event)).toBe(true);
+  });
+
+  test("returns true for legacy startup subscription renewal", () => {
+    const event = makeSubscriptionUpdatedEvent({
+      product: legacyStartupProduct,
+      previousAttributes: {
+        current_period_start: 1710000000,
+        current_period_end: 1712678400,
+      },
+    });
+
+    expect(isFreePlanSubscriptionRenewal(event)).toBe(true);
   });
 
   test("returns false for pro subscription renewal", () => {
@@ -78,7 +116,7 @@ describe("isHobbySubscriptionRenewal", () => {
       },
     });
 
-    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+    expect(isFreePlanSubscriptionRenewal(event)).toBe(false);
   });
 
   test("returns false when items changed (plan upgrade)", () => {
@@ -90,7 +128,7 @@ describe("isHobbySubscriptionRenewal", () => {
       },
     });
 
-    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+    expect(isFreePlanSubscriptionRenewal(event)).toBe(false);
   });
 
   test("returns false when status changed (cancellation)", () => {
@@ -102,7 +140,7 @@ describe("isHobbySubscriptionRenewal", () => {
       },
     });
 
-    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+    expect(isFreePlanSubscriptionRenewal(event)).toBe(false);
   });
 
   test("returns false for non-subscription-updated events", () => {
@@ -111,7 +149,7 @@ describe("isHobbySubscriptionRenewal", () => {
       data: { object: {}, previous_attributes: {} },
     } as unknown as Stripe.Event;
 
-    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+    expect(isFreePlanSubscriptionRenewal(event)).toBe(false);
   });
 
   test("returns false when previous_attributes is missing", () => {
@@ -124,7 +162,7 @@ describe("isHobbySubscriptionRenewal", () => {
       },
     } as unknown as Stripe.Event;
 
-    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+    expect(isFreePlanSubscriptionRenewal(event)).toBe(false);
   });
 
   test("returns false when product is a string (not expanded)", () => {
@@ -138,7 +176,7 @@ describe("isHobbySubscriptionRenewal", () => {
       },
     } as unknown as Stripe.Event;
 
-    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+    expect(isFreePlanSubscriptionRenewal(event)).toBe(false);
   });
 
   test("returns true when only billing_cycle_anchor changes", () => {
@@ -149,22 +187,15 @@ describe("isHobbySubscriptionRenewal", () => {
       },
     });
 
-    expect(isHobbySubscriptionRenewal(event)).toBe(true);
+    expect(isFreePlanSubscriptionRenewal(event)).toBe(true);
   });
 
-  test("returns false for mixed hobby and pro items", () => {
-    const event = {
-      type: "customer.subscription.updated",
-      data: {
-        object: {
-          items: {
-            data: [{ price: { product: hobbyProduct } }, { price: { product: proProduct } }],
-          },
-        },
-        previous_attributes: { current_period_start: 1710000000 },
-      },
-    } as unknown as Stripe.Event;
+  test("returns false for mixed free and pro items", () => {
+    const event = makeSubscriptionUpdatedEvent({
+      product: [hobbyProduct, proProduct],
+      previousAttributes: { current_period_start: 1710000000 },
+    });
 
-    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+    expect(isFreePlanSubscriptionRenewal(event)).toBe(false);
   });
 });

--- a/apps/web/modules/ee/billing/api/lib/stripe-webhook.test.ts
+++ b/apps/web/modules/ee/billing/api/lib/stripe-webhook.test.ts
@@ -1,0 +1,170 @@
+import Stripe from "stripe";
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest";
+
+vi.mock("@formbricks/logger", () => ({
+  logger: { debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/modules/ee/billing/lib/organization-billing", () => ({
+  findOrganizationIdByStripeCustomerId: vi.fn(),
+  reconcileCloudStripeSubscriptionsForOrganization: vi.fn(),
+  syncOrganizationBillingFromStripe: vi.fn(),
+}));
+
+vi.mock("./stripe-client", () => ({
+  getStripeClient: vi.fn(),
+  getStripeWebhookSecret: vi.fn(),
+}));
+
+const hobbyProduct = {
+  id: "prod_hobby",
+  metadata: { formbricks_plan: "hobby" },
+  deleted: false,
+} as Stripe.Product;
+
+const proProduct = {
+  id: "prod_pro",
+  metadata: { formbricks_plan: "pro" },
+  deleted: false,
+} as Stripe.Product;
+
+const makeSubscriptionUpdatedEvent = (opts: {
+  product: Stripe.Product;
+  previousAttributes: Record<string, unknown>;
+}): Stripe.Event =>
+  ({
+    type: "customer.subscription.updated",
+    data: {
+      object: {
+        items: {
+          data: [{ price: { product: opts.product } }],
+        },
+      },
+      previous_attributes: opts.previousAttributes,
+    },
+  }) as unknown as Stripe.Event;
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("isHobbySubscriptionRenewal", () => {
+  let isHobbySubscriptionRenewal: (event: Stripe.Event) => boolean;
+
+  beforeAll(async () => {
+    const mod = await import("./stripe-webhook");
+    isHobbySubscriptionRenewal = mod.isHobbySubscriptionRenewal;
+  });
+
+  test("returns true for hobby subscription with only billing period changes", () => {
+    const event = makeSubscriptionUpdatedEvent({
+      product: hobbyProduct,
+      previousAttributes: {
+        current_period_start: 1710000000,
+        current_period_end: 1712678400,
+        latest_invoice: "inv_old",
+      },
+    });
+
+    expect(isHobbySubscriptionRenewal(event)).toBe(true);
+  });
+
+  test("returns false for pro subscription renewal", () => {
+    const event = makeSubscriptionUpdatedEvent({
+      product: proProduct,
+      previousAttributes: {
+        current_period_start: 1710000000,
+        current_period_end: 1712678400,
+      },
+    });
+
+    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+  });
+
+  test("returns false when items changed (plan upgrade)", () => {
+    const event = makeSubscriptionUpdatedEvent({
+      product: hobbyProduct,
+      previousAttributes: {
+        current_period_start: 1710000000,
+        items: { data: [] },
+      },
+    });
+
+    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+  });
+
+  test("returns false when status changed (cancellation)", () => {
+    const event = makeSubscriptionUpdatedEvent({
+      product: hobbyProduct,
+      previousAttributes: {
+        status: "active",
+        current_period_end: 1712678400,
+      },
+    });
+
+    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+  });
+
+  test("returns false for non-subscription-updated events", () => {
+    const event = {
+      type: "customer.subscription.created",
+      data: { object: {}, previous_attributes: {} },
+    } as unknown as Stripe.Event;
+
+    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+  });
+
+  test("returns false when previous_attributes is missing", () => {
+    const event = {
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          items: { data: [{ price: { product: hobbyProduct } }] },
+        },
+      },
+    } as unknown as Stripe.Event;
+
+    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+  });
+
+  test("returns false when product is a string (not expanded)", () => {
+    const event = {
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          items: { data: [{ price: { product: "prod_hobby" } }] },
+        },
+        previous_attributes: { current_period_start: 1710000000 },
+      },
+    } as unknown as Stripe.Event;
+
+    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+  });
+
+  test("returns true when only billing_cycle_anchor changes", () => {
+    const event = makeSubscriptionUpdatedEvent({
+      product: hobbyProduct,
+      previousAttributes: {
+        billing_cycle_anchor: 1710000000,
+      },
+    });
+
+    expect(isHobbySubscriptionRenewal(event)).toBe(true);
+  });
+
+  test("returns false for mixed hobby and pro items", () => {
+    const event = {
+      type: "customer.subscription.updated",
+      data: {
+        object: {
+          items: {
+            data: [{ price: { product: hobbyProduct } }, { price: { product: proProduct } }],
+          },
+        },
+        previous_attributes: { current_period_start: 1710000000 },
+      },
+    } as unknown as Stripe.Event;
+
+    expect(isHobbySubscriptionRenewal(event)).toBe(false);
+  });
+});

--- a/apps/web/modules/ee/billing/api/lib/stripe-webhook.ts
+++ b/apps/web/modules/ee/billing/api/lib/stripe-webhook.ts
@@ -99,12 +99,15 @@ const resolveOrganizationId = async (eventObject: Stripe.Event.Data.Object): Pro
   return await findOrganizationIdByStripeCustomerId(customerId);
 };
 
+const PAID_PLANS = new Set(["pro", "scale", "custom"]);
+
 /**
- * Detects hobby subscription renewals that only roll the billing period forward.
- * These $0 plan renewals generate ~10k events/month and don't change any meaningful
- * billing state — skipping them avoids unnecessary processing and downstream webhook noise.
+ * Detects free-tier subscription renewals that only roll the billing period forward.
+ * These $0 plan renewals (hobby, legacy free, legacy startup) generate ~10k events/month
+ * and don't change any meaningful billing state — skipping them avoids unnecessary
+ * processing and downstream webhook noise.
  */
-export const isHobbySubscriptionRenewal = (event: Stripe.Event): boolean => {
+export const isFreePlanSubscriptionRenewal = (event: Stripe.Event): boolean => {
   if (event.type !== "customer.subscription.updated") return false;
 
   const subscription = event.data.object;
@@ -113,17 +116,18 @@ export const isHobbySubscriptionRenewal = (event: Stripe.Event): boolean => {
 
   if (!previousAttributes) return false;
 
-  // Check that every line item belongs to the hobby plan
+  // Check that every line item can be confirmed as a non-paid plan.
+  // If any product is unexpanded (string), deleted, or belongs to a paid plan, don't skip.
   const items = subscription.items?.data;
-  const isHobbyPlan =
-    items?.length &&
-    items.every((item) => {
-      const product = item.price?.product;
-      if (!product || typeof product === "string" || product.deleted) return false;
-      return product.metadata?.formbricks_plan === "hobby";
-    });
+  if (!items?.length) return false;
 
-  if (!isHobbyPlan) return false;
+  const allConfirmedFree = items.every((item) => {
+    const product = item.price?.product;
+    if (!product || typeof product === "string" || product.deleted) return false;
+    return !PAID_PLANS.has(product.metadata?.formbricks_plan);
+  });
+
+  if (!allConfirmedFree) return false;
 
   // A pure renewal only touches billing period fields and latest_invoice.
   // If items or status changed, this is a real update (upgrade, cancellation, etc.)
@@ -181,8 +185,8 @@ export const webhookHandler = async (requestBody: string, stripeSignature: strin
     return { status: 200, message: { received: true } };
   }
 
-  if (isHobbySubscriptionRenewal(event)) {
-    logger.debug({ eventId: event.id }, "Skipping hobby subscription renewal");
+  if (isFreePlanSubscriptionRenewal(event)) {
+    logger.debug({ eventId: event.id }, "Skipping free plan subscription renewal");
     return { status: 200, message: { received: true } };
   }
 

--- a/apps/web/modules/ee/billing/api/lib/stripe-webhook.ts
+++ b/apps/web/modules/ee/billing/api/lib/stripe-webhook.ts
@@ -99,6 +99,46 @@ const resolveOrganizationId = async (eventObject: Stripe.Event.Data.Object): Pro
   return await findOrganizationIdByStripeCustomerId(customerId);
 };
 
+/**
+ * Detects hobby subscription renewals that only roll the billing period forward.
+ * These $0 plan renewals generate ~10k events/month and don't change any meaningful
+ * billing state — skipping them avoids unnecessary processing and downstream webhook noise.
+ */
+export const isHobbySubscriptionRenewal = (event: Stripe.Event): boolean => {
+  if (event.type !== "customer.subscription.updated") return false;
+
+  const subscription = event.data.object;
+  const previousAttributes = (event.data as { previous_attributes?: Record<string, unknown> })
+    .previous_attributes;
+
+  if (!previousAttributes) return false;
+
+  // Check that every line item belongs to the hobby plan
+  const isHobbyPlan = subscription.items?.data?.every((item) => {
+    const product = item.price?.product;
+    if (!product || typeof product === "string" || product.deleted) return false;
+    return product.metadata?.formbricks_plan === "hobby";
+  });
+
+  if (!isHobbyPlan) return false;
+
+  // A pure renewal only touches billing period fields and latest_invoice.
+  // If items or status changed, this is a real update (upgrade, cancellation, etc.)
+  const changedKeys = new Set(Object.keys(previousAttributes));
+  const renewalOnlyKeys = new Set([
+    "current_period_start",
+    "current_period_end",
+    "latest_invoice",
+    "billing_cycle_anchor",
+  ]);
+
+  for (const key of changedKeys) {
+    if (!renewalOnlyKeys.has(key)) return false;
+  }
+
+  return true;
+};
+
 const getUnresolvedOrganizationResponse = (event: Stripe.Event) => {
   logger.warn(
     { eventType: event.type, eventId: event.id },
@@ -135,6 +175,11 @@ export const webhookHandler = async (requestBody: string, stripeSignature: strin
   }
 
   if (!relevantEvents.has(event.type)) {
+    return { status: 200, message: { received: true } };
+  }
+
+  if (isHobbySubscriptionRenewal(event)) {
+    logger.debug({ eventId: event.id }, "Skipping hobby subscription renewal");
     return { status: 200, message: { received: true } };
   }
 

--- a/apps/web/modules/ee/billing/api/lib/stripe-webhook.ts
+++ b/apps/web/modules/ee/billing/api/lib/stripe-webhook.ts
@@ -99,13 +99,13 @@ const resolveOrganizationId = async (eventObject: Stripe.Event.Data.Object): Pro
   return await findOrganizationIdByStripeCustomerId(customerId);
 };
 
-const PAID_PLANS = new Set(["pro", "scale", "custom"]);
+const FREE_PLAN_PRODUCT_IDS = new Set(["prod_U8jd2XNJgewiiA", "prod_U8jeQdtjaUrVUf"]);
 
 /**
  * Detects free-tier subscription renewals that only roll the billing period forward.
- * These $0 plan renewals (hobby, legacy free, legacy startup) generate ~10k events/month
- * and don't change any meaningful billing state — skipping them avoids unnecessary
- * processing and downstream webhook noise.
+ * These $0 plan renewals (hobby, legacy free) generate ~10k events/month and don't
+ * change any meaningful billing state — skipping them avoids unnecessary processing
+ * and downstream webhook noise.
  */
 export const isFreePlanSubscriptionRenewal = (event: Stripe.Event): boolean => {
   if (event.type !== "customer.subscription.updated") return false;
@@ -116,18 +116,17 @@ export const isFreePlanSubscriptionRenewal = (event: Stripe.Event): boolean => {
 
   if (!previousAttributes) return false;
 
-  // Check that every line item can be confirmed as a non-paid plan.
-  // If any product is unexpanded (string), deleted, or belongs to a paid plan, don't skip.
+  // Check that every line item belongs to a known free plan product
   const items = subscription.items?.data;
   if (!items?.length) return false;
 
-  const allConfirmedFree = items.every((item) => {
+  const allFreePlan = items.every((item) => {
     const product = item.price?.product;
     if (!product || typeof product === "string" || product.deleted) return false;
-    return !PAID_PLANS.has(product.metadata?.formbricks_plan);
+    return FREE_PLAN_PRODUCT_IDS.has(product.id);
   });
 
-  if (!allConfirmedFree) return false;
+  if (!allFreePlan) return false;
 
   // A pure renewal only touches billing period fields and latest_invoice.
   // If items or status changed, this is a real update (upgrade, cancellation, etc.)

--- a/apps/web/modules/ee/billing/api/lib/stripe-webhook.ts
+++ b/apps/web/modules/ee/billing/api/lib/stripe-webhook.ts
@@ -114,11 +114,14 @@ export const isHobbySubscriptionRenewal = (event: Stripe.Event): boolean => {
   if (!previousAttributes) return false;
 
   // Check that every line item belongs to the hobby plan
-  const isHobbyPlan = subscription.items?.data?.every((item) => {
-    const product = item.price?.product;
-    if (!product || typeof product === "string" || product.deleted) return false;
-    return product.metadata?.formbricks_plan === "hobby";
-  });
+  const items = subscription.items?.data;
+  const isHobbyPlan =
+    items?.length &&
+    items.every((item) => {
+      const product = item.price?.product;
+      if (!product || typeof product === "string" || product.deleted) return false;
+      return product.metadata?.formbricks_plan === "hobby";
+    });
 
   if (!isHobbyPlan) return false;
 


### PR DESCRIPTION
## Summary

Free-tier subscription renewals on Stripe ($0 plans — hobby and legacy free) generate ~10k `customer.subscription.updated` events per month. These events only roll the billing period forward without changing any meaningful billing state, but they still trigger full reconciliation and downstream Make.com webhooks — draining Make credits for no reason.

This PR adds an early return in the Stripe webhook handler that detects and skips these no-op renewal events for all free-tier plans.

Fixes https://linear.app/formbricks/issue/ENG-698/investigate-stripe-subscriptionupdate-events-for-legacy-free-plans

## Changes

- **`isFreePlanSubscriptionRenewal(event)`** — New exported guard function that identifies free plan renewals by checking:
  - Event type is `customer.subscription.updated`
  - All subscription line items belong to known free plan products by product ID (`prod_U8jd2XNJgewiiA` for hobby, `prod_U8jeQdtjaUrVUf` for legacy free)
  - Products must be expanded (not string IDs) and non-deleted to be matched
  - The only changed fields in `previous_attributes` are billing-period fields (`current_period_start`, `current_period_end`, `latest_invoice`, `billing_cycle_anchor`)
  - Real updates (upgrades, cancellations, item changes) are **not** skipped
- **Early return in `webhookHandler`** — Calls the guard after signature verification and returns `200` immediately for free plan renewals

## Test plan

- [x] Added comprehensive test suite (`stripe-webhook.test.ts`) covering 11 cases:
  - Hobby renewal with billing period changes → skipped
  - Legacy free subscription renewal → skipped
  - Pro subscription renewal → processed
  - Items changed (plan upgrade) → processed
  - Status changed (cancellation) → processed
  - Non-subscription-updated events → processed
  - Missing previous_attributes → processed
  - Unexpanded product (string ID) → processed (conservative)
  - Only billing_cycle_anchor change → skipped
  - Mixed free + pro items → processed
  - Unknown product ID with hobby metadata → processed (not in allowlist)