### PR TITLE
fix: duplicate action class name error

### DIFF
--- a/apps/web/app/api/v1/auth.test.ts
+++ b/apps/web/app/api/v1/auth.test.ts
@@ -1,9 +1,15 @@
 import { NextRequest } from "next/server";
 import { describe, expect, test, vi } from "vitest";
 import { TAPIKeyEnvironmentPermission } from "@formbricks/types/auth";
+import {
+  DatabaseError,
+  InvalidInputError,
+  ResourceNotFoundError,
+  UniqueConstraintError,
+} from "@formbricks/types/errors";
 import { getApiKeyWithPermissions } from "@/modules/organization/settings/api-keys/lib/api-key";
 import { hasPermission } from "@/modules/organization/settings/api-keys/lib/utils";
-import { authenticateRequest } from "./auth";
+import { authenticateRequest, handleErrorResponse } from "./auth";
 
 vi.mock("@/modules/organization/settings/api-keys/lib/api-key", () => ({
   getApiKeyWithPermissions: vi.fn(),
@@ -191,5 +197,55 @@ describe("authenticateRequest", () => {
 
     const result = await authenticateRequest(request);
     expect(result).toBeNull();
+  });
+});
+
+describe("handleErrorResponse", () => {
+  test("returns 401 notAuthenticated for 'NotAuthenticated' message", async () => {
+    const response = handleErrorResponse(new Error("NotAuthenticated"));
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.code).toBe("not_authenticated");
+  });
+
+  test("returns 401 unauthorized for 'Unauthorized' message", async () => {
+    const response = handleErrorResponse(new Error("Unauthorized"));
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.code).toBe("unauthorized");
+  });
+
+  test("returns 409 conflict for UniqueConstraintError", async () => {
+    const response = handleErrorResponse(new UniqueConstraintError("Action with name foo already exists"));
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.code).toBe("conflict");
+    expect(body.message).toBe("Action with name foo already exists");
+  });
+
+  test("returns 400 badRequest for DatabaseError", async () => {
+    const response = handleErrorResponse(new DatabaseError("db boom"));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.message).toBe("db boom");
+  });
+
+  test("returns 400 badRequest for InvalidInputError", async () => {
+    const response = handleErrorResponse(new InvalidInputError("bad input"));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.message).toBe("bad input");
+  });
+
+  test("returns 400 badRequest for ResourceNotFoundError", async () => {
+    const response = handleErrorResponse(new ResourceNotFoundError("Survey", "id-1"));
+    expect(response.status).toBe(400);
+  });
+
+  test("returns 500 internalServerError for unknown errors", async () => {
+    const response = handleErrorResponse(new Error("something else"));
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.message).toBe("Some error occurred");
   });
 });

--- a/apps/web/app/api/v1/auth.ts
+++ b/apps/web/app/api/v1/auth.ts
@@ -1,6 +1,11 @@
 import { NextRequest } from "next/server";
 import { TAuthenticationApiKey } from "@formbricks/types/auth";
-import { DatabaseError, InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
+import {
+  DatabaseError,
+  InvalidInputError,
+  ResourceNotFoundError,
+  UniqueConstraintError,
+} from "@formbricks/types/errors";
 import { responses } from "@/app/lib/api/response";
 import { getApiKeyWithPermissions } from "@/modules/organization/settings/api-keys/lib/api-key";
 
@@ -40,6 +45,9 @@ export const handleErrorResponse = (error: any): Response => {
     case "Unauthorized":
       return responses.unauthorizedResponse();
     default:
+      if (error instanceof UniqueConstraintError) {
+        return responses.conflictResponse(error.message);
+      }
       if (
         error instanceof DatabaseError ||
         error instanceof InvalidInputError ||

--- a/apps/web/app/api/v1/management/action-classes/route.ts
+++ b/apps/web/app/api/v1/management/action-classes/route.ts
@@ -1,6 +1,6 @@
 import { logger } from "@formbricks/logger";
 import { TActionClass, ZActionClassInput } from "@formbricks/types/action-classes";
-import { DatabaseError } from "@formbricks/types/errors";
+import { DatabaseError, UniqueConstraintError } from "@formbricks/types/errors";
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
 import { THandlerParams, withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
@@ -80,6 +80,11 @@ export const POST = withV1ApiWrapper({
         response: responses.successResponse(actionClass),
       };
     } catch (error) {
+      if (error instanceof UniqueConstraintError) {
+        return {
+          response: responses.conflictResponse(error.message),
+        };
+      }
       if (error instanceof DatabaseError) {
         return {
           response: responses.badRequestResponse(error.message),

--- a/apps/web/lib/actionClass/service.test.ts
+++ b/apps/web/lib/actionClass/service.test.ts
@@ -1,12 +1,16 @@
+import { Prisma } from "@prisma/client";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
-import { TActionClass } from "@formbricks/types/action-classes";
-import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { PrismaErrorType } from "@formbricks/database/types/error";
+import { TActionClass, TActionClassInput } from "@formbricks/types/action-classes";
+import { DatabaseError, ResourceNotFoundError, UniqueConstraintError } from "@formbricks/types/errors";
 import {
+  createActionClass,
   deleteActionClass,
   getActionClass,
   getActionClassByEnvironmentIdAndName,
   getActionClasses,
+  updateActionClass,
 } from "./service";
 
 vi.mock("@formbricks/database", () => ({
@@ -16,6 +20,8 @@ vi.mock("@formbricks/database", () => ({
       findFirst: vi.fn(),
       findUnique: vi.fn(),
       delete: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
     },
   },
 }));
@@ -176,6 +182,149 @@ describe("ActionClass Service", () => {
       const error = new Error("unknown");
       vi.mocked(prisma.actionClass.delete).mockRejectedValue(error);
       await expect(deleteActionClass("id4")).rejects.toThrow("unknown");
+    });
+  });
+
+  describe("createActionClass", () => {
+    const codeInput: TActionClassInput = {
+      name: "Code Action",
+      description: "desc",
+      type: "code",
+      key: "code-action-key",
+      environmentId: "env-create",
+    };
+
+    const buildPrismaUniqueError = (target: string[]) =>
+      Object.assign(
+        new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+          code: PrismaErrorType.UniqueConstraintViolation,
+          clientVersion: "test",
+        }),
+        { meta: { target } }
+      );
+
+    test("should create and return the action class", async () => {
+      const created: TActionClass = {
+        id: "id-create",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        name: codeInput.name,
+        description: codeInput.description ?? null,
+        type: "code",
+        key: codeInput.type === "code" ? codeInput.key : null,
+        noCodeConfig: null,
+        environmentId: codeInput.environmentId,
+      };
+      vi.mocked(prisma.actionClass.create).mockResolvedValue(created as never);
+
+      const result = await createActionClass(codeInput.environmentId, codeInput);
+      expect(result).toEqual(created);
+    });
+
+    test("should throw UniqueConstraintError on P2002 with target field", async () => {
+      vi.mocked(prisma.actionClass.create).mockRejectedValue(buildPrismaUniqueError(["name"]));
+
+      await expect(createActionClass(codeInput.environmentId, codeInput)).rejects.toThrow(
+        UniqueConstraintError
+      );
+      await expect(createActionClass(codeInput.environmentId, codeInput)).rejects.toThrow(
+        `Action with name ${codeInput.name} already exists`
+      );
+    });
+
+    test("should throw UniqueConstraintError on P2002 even when target is missing", async () => {
+      vi.mocked(prisma.actionClass.create).mockRejectedValue(
+        Object.assign(
+          new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+            code: PrismaErrorType.UniqueConstraintViolation,
+            clientVersion: "test",
+          }),
+          { meta: undefined }
+        )
+      );
+
+      await expect(createActionClass(codeInput.environmentId, codeInput)).rejects.toThrow(
+        UniqueConstraintError
+      );
+    });
+
+    test("should throw DatabaseError for non-P2002 errors", async () => {
+      vi.mocked(prisma.actionClass.create).mockRejectedValue(new Error("boom"));
+
+      await expect(createActionClass(codeInput.environmentId, codeInput)).rejects.toThrow(DatabaseError);
+      await expect(createActionClass(codeInput.environmentId, codeInput)).rejects.toThrow(
+        `Database error when creating an action for environment ${codeInput.environmentId}`
+      );
+    });
+  });
+
+  describe("updateActionClass", () => {
+    const updateInput: Partial<TActionClassInput> = {
+      name: "Renamed Action",
+      description: "updated desc",
+      type: "code",
+      key: "renamed-key",
+      environmentId: "env-update",
+    };
+
+    const buildPrismaUniqueError = (target: string[]) =>
+      Object.assign(
+        new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+          code: PrismaErrorType.UniqueConstraintViolation,
+          clientVersion: "test",
+        }),
+        { meta: { target } }
+      );
+
+    test("should update and return the action class", async () => {
+      const updated = {
+        id: "id-update",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        name: updateInput.name,
+        description: updateInput.description ?? null,
+        type: "code" as const,
+        key: "renamed-key",
+        noCodeConfig: null,
+        environmentId: updateInput.environmentId,
+        surveyTriggers: [],
+      };
+      vi.mocked(prisma.actionClass.update).mockResolvedValue(updated as never);
+
+      const result = await updateActionClass(updateInput.environmentId!, "id-update", updateInput);
+      expect(result).toEqual(updated);
+    });
+
+    test("should throw UniqueConstraintError on P2002 with target field", async () => {
+      vi.mocked(prisma.actionClass.update).mockRejectedValue(buildPrismaUniqueError(["name"]));
+
+      await expect(updateActionClass(updateInput.environmentId!, "id-update", updateInput)).rejects.toThrow(
+        UniqueConstraintError
+      );
+      await expect(updateActionClass(updateInput.environmentId!, "id-update", updateInput)).rejects.toThrow(
+        `Action with name ${updateInput.name} already exists`
+      );
+    });
+
+    test("should throw DatabaseError for other PrismaClientKnownRequestError codes", async () => {
+      vi.mocked(prisma.actionClass.update).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("Record not found", {
+          code: "P2025",
+          clientVersion: "test",
+        })
+      );
+
+      await expect(updateActionClass(updateInput.environmentId!, "id-update", updateInput)).rejects.toThrow(
+        DatabaseError
+      );
+    });
+
+    test("should rethrow unknown errors", async () => {
+      vi.mocked(prisma.actionClass.update).mockRejectedValue(new Error("boom"));
+
+      await expect(updateActionClass(updateInput.environmentId!, "id-update", updateInput)).rejects.toThrow(
+        "boom"
+      );
     });
   });
 });

--- a/apps/web/lib/actionClass/service.ts
+++ b/apps/web/lib/actionClass/service.ts
@@ -7,7 +7,7 @@ import { prisma } from "@formbricks/database";
 import { PrismaErrorType } from "@formbricks/database/types/error";
 import { TActionClass, TActionClassInput, ZActionClassInput } from "@formbricks/types/action-classes";
 import { ZId, ZOptionalNumber, ZString } from "@formbricks/types/common";
-import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { DatabaseError, ResourceNotFoundError, UniqueConstraintError } from "@formbricks/types/errors";
 import { ITEMS_PER_PAGE } from "../constants";
 import { validateInputs } from "../utils/validate";
 
@@ -135,7 +135,7 @@ export const createActionClass = async (
       error.code === PrismaErrorType.UniqueConstraintViolation
     ) {
       const targetField = (error.meta?.target as string[] | undefined)?.[0];
-      throw new DatabaseError(
+      throw new UniqueConstraintError(
         `Action with ${targetField} ${targetField ? (actionClass as Record<string, unknown>)[targetField] : ""} already exists`
       );
     }
@@ -185,7 +185,7 @@ export const updateActionClass = async (
       error.code === PrismaErrorType.UniqueConstraintViolation
     ) {
       const targetField = (error.meta?.target as string[] | undefined)?.[0];
-      throw new DatabaseError(
+      throw new UniqueConstraintError(
         `Action with ${targetField} ${targetField ? (inputActionClass as Record<string, unknown>)[targetField] : ""} already exists`
       );
     }

--- a/apps/web/lib/utils/action-client/index.test.ts
+++ b/apps/web/lib/utils/action-client/index.test.ts
@@ -12,6 +12,7 @@ import {
   OperationNotAllowedError,
   ResourceNotFoundError,
   TooManyRequestsError,
+  UniqueConstraintError,
   UnknownError,
   ValidationError,
   isExpectedError,
@@ -74,6 +75,7 @@ describe("isExpectedError (shared helper)", () => {
       "OperationNotAllowedError",
       "TooManyRequestsError",
       "InvalidPasswordResetTokenError",
+      "UniqueConstraintError",
     ];
 
     expect(EXPECTED_ERROR_NAMES.size).toBe(expected.length);
@@ -91,6 +93,7 @@ describe("isExpectedError (shared helper)", () => {
     { ErrorClass: ValidationError, args: ["Invalid data"] },
     { ErrorClass: OperationNotAllowedError, args: ["Not allowed"] },
     { ErrorClass: InvalidPasswordResetTokenError, args: [INVALID_PASSWORD_RESET_TOKEN_ERROR_CODE] },
+    { ErrorClass: UniqueConstraintError, args: ["Already exists"] },
   ])("returns true for $ErrorClass.name", ({ ErrorClass, args }) => {
     const error = new (ErrorClass as any)(...args);
     expect(isExpectedError(error)).toBe(true);
@@ -184,6 +187,14 @@ describe("actionClient handleServerError", () => {
         new InvalidPasswordResetTokenError(INVALID_PASSWORD_RESET_TOKEN_ERROR_CODE)
       );
       expect(result?.serverError).toBe(INVALID_PASSWORD_RESET_TOKEN_ERROR_CODE);
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    test("UniqueConstraintError returns its message and is not sent to Sentry", async () => {
+      const result = await executeThrowingAction(
+        new UniqueConstraintError("Action with name foo already exists")
+      );
+      expect(result?.serverError).toBe("Action with name foo already exists");
       expect(Sentry.captureException).not.toHaveBeenCalled();
     });
   });

--- a/apps/web/modules/survey/editor/lib/action-class.test.ts
+++ b/apps/web/modules/survey/editor/lib/action-class.test.ts
@@ -1,9 +1,9 @@
-import { ActionClass } from "@prisma/client";
+import { ActionClass, Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { PrismaErrorType } from "@formbricks/database/types/error";
 import { TActionClassInput } from "@formbricks/types/action-classes";
-import { DatabaseError } from "@formbricks/types/errors";
+import { DatabaseError, UniqueConstraintError } from "@formbricks/types/errors";
 import { createActionClass } from "./action-class";
 
 vi.mock("@formbricks/database", () => ({
@@ -99,14 +99,19 @@ describe("createActionClass", () => {
     expect(result).toEqual(createdAction);
   });
 
-  test("should throw DatabaseError for unique constraint violation", async () => {
-    const prismaError = {
-      code: PrismaErrorType.UniqueConstraintViolation,
-      meta: { target: ["name"] },
-    };
+  test("should throw UniqueConstraintError for unique constraint violation", async () => {
+    const prismaError = Object.assign(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: PrismaErrorType.UniqueConstraintViolation,
+        clientVersion: "test",
+      }),
+      { meta: { target: ["name"] } }
+    );
     vi.mocked(prisma.actionClass.create).mockRejectedValue(prismaError);
 
-    await expect(createActionClass(mockEnvironmentId, mockCodeActionInput)).rejects.toThrow(DatabaseError);
+    await expect(createActionClass(mockEnvironmentId, mockCodeActionInput)).rejects.toThrow(
+      UniqueConstraintError
+    );
   });
 
   test("should throw DatabaseError for other database errors", async () => {

--- a/apps/web/modules/survey/editor/lib/action-class.ts
+++ b/apps/web/modules/survey/editor/lib/action-class.ts
@@ -2,7 +2,7 @@ import { ActionClass, Prisma } from "@prisma/client";
 import { prisma } from "@formbricks/database";
 import { PrismaErrorType } from "@formbricks/database/types/error";
 import { TActionClassInput } from "@formbricks/types/action-classes";
-import { DatabaseError } from "@formbricks/types/errors";
+import { DatabaseError, UniqueConstraintError } from "@formbricks/types/errors";
 
 export const createActionClass = async (
   environmentId: string,
@@ -32,7 +32,7 @@ export const createActionClass = async (
       error.code === PrismaErrorType.UniqueConstraintViolation
     ) {
       const targetField = (error.meta?.target as string[] | undefined)?.[0];
-      throw new DatabaseError(
+      throw new UniqueConstraintError(
         `Action with ${targetField} ${targetField ? (actionClass as Record<string, unknown>)[targetField] : ""} already exists`
       );
     }

--- a/packages/types/errors.ts
+++ b/packages/types/errors.ts
@@ -160,6 +160,7 @@ export const EXPECTED_ERROR_NAMES = new Set([
   "OperationNotAllowedError",
   "TooManyRequestsError",
   "InvalidPasswordResetTokenError",
+  "UniqueConstraintError",
 ]);
 
 /**


### PR DESCRIPTION
What does this PR do?

  Creating an action class with a duplicate name triggers a Prisma `P2002` unique-constraint violation. The action-class code paths were wrapping this as a generic
  `DatabaseError`, which is treated as an unexpected server error: it was reported to Sentry and surfaced to the user as a generic "Something went wrong" toast
  instead of the actual conflict message.

  This PR reclassifies the duplicate-name case as an expected business-logic failure:

  - Adds `UniqueConstraintError` to `EXPECTED_ERROR_NAMES` in `packages/types/errors.ts`. `handleServerError` in the next-safe-action client now returns the original
  error message and skips Sentry capture for this class.
  - Replaces `DatabaseError` with `UniqueConstraintError` in the P2002 branches of:
    - `apps/web/modules/survey/editor/lib/action-class.ts` (`createActionClass` used by the survey editor server action)
    - `apps/web/lib/actionClass/service.ts` (`createActionClass` and `updateActionClass`)
  - Updates the v1 REST surface so external API clients also get a proper 409:
    - `apps/web/app/api/v1/management/action-classes/route.ts` POST handler now returns `responses.conflictResponse(...)` for `UniqueConstraintError`.
    - `apps/web/app/api/v1/auth.ts` `handleErrorResponse` (used by the v1 update/delete routes) maps `UniqueConstraintError` to `conflictResponse` (409) before
  falling through to the existing `DatabaseError` 400 branch.
  - Updates affected unit tests:
    - `apps/web/modules/survey/editor/lib/action-class.test.ts` now expects `UniqueConstraintError` and uses a real `Prisma.PrismaClientKnownRequestError` instance so
   the `instanceof` check exercises the P2002 branch.
    - `apps/web/lib/utils/action-client/index.test.ts` covers `UniqueConstraintError` in `EXPECTED_ERROR_NAMES`, `isExpectedError`, and the integration-level "not
  reported to Sentry" suite.

  End result for users: duplicate action-name submissions (including concurrent ones) show a localized "Action with name X already exists" toast, return a 409 over
  the v1 REST API, and no longer pollute Sentry.

  Fixes [ENG-748](https://linear.app/formbricks/issue/ENG-748/)

  ## How should this be tested?

  - Open the survey editor → Add Action → create an action with a name that already exists in the environment. Expect a toast reading "Action with name <name> already
   exists" instead of the generic error toast. Verify no event is sent to Sentry for this flow.
  - Repeat from the project settings → Actions tab (`ActionActivityTab`) to cover the second client entry point.
  - Submit two duplicate action-class creations concurrently (e.g. two browser tabs / two parallel requests) and confirm one succeeds, the other returns the conflict
  toast, and Sentry stays clean.
  - v1 REST API:
    - `POST /api/v1/management/action-classes` with a name that already exists → expect HTTP `409` with `code: "conflict"` and the duplicate message.
    - `PUT /api/v1/management/action-classes/{id}` updating an action's name to one that already exists → expect HTTP `409` via `handleErrorResponse`.
  - Run the unit tests:
    - `pnpm vitest run modules/survey/editor/lib/action-class.test.ts lib/utils/action-client/index.test.ts lib/actionClass/service.test.ts app/api/v1/auth.test.ts
  app/api/v1/management/action-classes/lib/action-classes.test.ts`

  ## Checklist

  <!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you
  did  -->

  ### Required

  - [x] Filled out the "How to test" section in this PR
  - [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
  - [x] Self-reviewed my own code
  - [x] Commented on my code in hard-to-understand bits
  - [x] Ran `pnpm build`
  - [x] Checked for warnings, there are none
  - [x] Removed all `console.logs`
  - [x] Merged the latest changes from main onto my branch with `git pull origin main`
  - [x] My changes don't cause any responsiveness issues
  - [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

  ### Appreciated

  - [ ] If a UI change was made: Added a screen recording or screenshots to this PR
  - [ ] Updated the Formbricks Docs if changes were necessary