### PR TITLE
feat: add Linear Releases integration to CI pipeline

### DIFF
--- a/.github/workflows/formbricks-release.yml
+++ b/.github/workflows/formbricks-release.yml
@@ -155,3 +155,28 @@ jobs:
       commit_sha: ${{ github.sha }}
       is_prerelease: ${{ github.event.release.prerelease }}
       make_latest: ${{ needs.check-latest-release.outputs.is_latest == 'true' }}
+
+  linear-release-complete:
+    name: Mark Linear release as complete
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - docker-build-community
+    if: ${{ !github.event.release.prerelease }}
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Complete Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          command: complete
+          version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/formbricks-release.yml
+++ b/.github/workflows/formbricks-release.yml
@@ -162,6 +162,9 @@ jobs:
     timeout-minutes: 5
     needs:
       - docker-build-community
+      - docker-build-cloud
+      - helm-chart-release
+      - move-stable-tag
     if: ${{ !github.event.release.prerelease }}
     steps:
       - name: Harden the runner
@@ -175,7 +178,7 @@ jobs:
           fetch-depth: 0
 
       - name: Complete Linear release
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b # v0.7.0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
           command: complete

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -25,6 +25,6 @@ jobs:
           fetch-depth: 0
 
       - name: Sync Linear release
-        uses: linear/linear-release-action@v0
+        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b # v0.7.0
         with:
           access_key: ${{ secrets.LINEAR_ACCESS_KEY }}

--- a/.github/workflows/linear-release.yml
+++ b/.github/workflows/linear-release.yml
@@ -1,0 +1,30 @@
+name: Linear Release Sync
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  linear-release:
+    name: Sync release to Linear
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Sync Linear release
+        uses: linear/linear-release-action@v0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}


### PR DESCRIPTION
## Summary

This PR adds support for Linears new **Releases** feature: https://linear.app/docs/releases

- Adds `.github/workflows/linear-release.yml` — triggers on every push to `main`, syncs commits containing Linear issue references to the configured release pipeline
- Extends `.github/workflows/formbricks-release.yml` — adds a `linear-release-complete` job that marks the Linear release as complete when a GitHub release is published (non-prerelease only)

## Setup required

Add `LINEAR_ACCESS_KEY` as a repository secret (Settings → Secrets and variables → Actions). The key is available in the Linear pipeline settings.

## Test plan

- [ ] Merge to main and verify a Linear release is created/updated in the pipeline
- [ ] Publish a GitHub release and verify the Linear release is marked as complete
- [ ] Confirm `LINEAR_ACCESS_KEY` secret is added to the repository

Fixes ENG-838

🤖 Generated with [Claude Code](https://claude.com/claude-code)