### PR TITLE
fix: reject SSO auto-provisioning when AUTH_SSO_DEFAULT_TEAM_ID is missing

### DIFF
--- a/apps/web/modules/ee/sso/lib/sso-handlers.ts
+++ b/apps/web/modules/ee/sso/lib/sso-handlers.ts
@@ -264,6 +264,14 @@ const provisionNewSsoUser = async ({
     "License and instance configuration checked"
   );
 
+  if (!isFirstUser && !isMultiOrgEnabled && SKIP_INVITE_FOR_SSO && !DEFAULT_TEAM_ID) {
+    contextLogger.error(
+      { reason: "missing_default_team_id" },
+      "SSO callback rejected: AUTH_SKIP_INVITE_FOR_SSO is enabled but AUTH_SSO_DEFAULT_TEAM_ID is not configured. Refusing to auto-provision new SSO user into an arbitrary organization."
+    );
+    return false;
+  }
+
   if (!isFirstUser && !SKIP_INVITE_FOR_SSO && !isMultiOrgEnabled) {
     if (!callbackUrl) {
       contextLogger.debug(

--- a/apps/web/modules/ee/sso/lib/tests/sso-handlers.test.ts
+++ b/apps/web/modules/ee/sso/lib/tests/sso-handlers.test.ts
@@ -120,12 +120,21 @@ vi.mock("@formbricks/logger", () => ({
   },
 }));
 
+const constantsOverrides = vi.hoisted(() => ({
+  SKIP_INVITE_FOR_SSO: false as boolean,
+  DEFAULT_TEAM_ID: "team-123" as string | undefined,
+}));
+
 vi.mock("@/lib/constants", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/constants")>();
   return {
     ...actual,
-    SKIP_INVITE_FOR_SSO: 0,
-    DEFAULT_TEAM_ID: "team-123",
+    get SKIP_INVITE_FOR_SSO() {
+      return constantsOverrides.SKIP_INVITE_FOR_SSO;
+    },
+    get DEFAULT_TEAM_ID() {
+      return constantsOverrides.DEFAULT_TEAM_ID;
+    },
   };
 });
 
@@ -147,6 +156,8 @@ const transactionUser = {
 describe("handleSsoCallback", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    constantsOverrides.SKIP_INVITE_FOR_SSO = false;
+    constantsOverrides.DEFAULT_TEAM_ID = "team-123";
 
     vi.mocked(prisma.$transaction).mockImplementation(
       async (callback: (tx: any) => unknown) =>
@@ -703,6 +714,80 @@ describe("handleSsoCallback", () => {
 
     expect(result).toBe(false);
     expect(createUser).not.toHaveBeenCalled();
+  });
+
+  test("rejects auto-provisioning when SKIP_INVITE_FOR_SSO is enabled but DEFAULT_TEAM_ID is missing", async () => {
+    vi.mocked(prisma.account.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+    vi.mocked(getIsFreshInstance).mockResolvedValue(false);
+    vi.mocked(getIsMultiOrgEnabled).mockResolvedValue(false);
+    constantsOverrides.SKIP_INVITE_FOR_SSO = true;
+    constantsOverrides.DEFAULT_TEAM_ID = undefined;
+
+    const result = await handleSsoCallback({
+      user: mockUser,
+      account: mockAccount,
+      callbackUrl: "http://localhost:3000",
+    });
+
+    expect(result).toBe(false);
+    expect(getFirstOrganization).not.toHaveBeenCalled();
+    expect(getOrganizationByTeamId).not.toHaveBeenCalled();
+    expect(createUser).not.toHaveBeenCalled();
+    expect(createMembership).not.toHaveBeenCalled();
+  });
+
+  test("rejects auto-provisioning when DEFAULT_TEAM_ID is empty string", async () => {
+    vi.mocked(prisma.account.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+    vi.mocked(getIsFreshInstance).mockResolvedValue(false);
+    vi.mocked(getIsMultiOrgEnabled).mockResolvedValue(false);
+    constantsOverrides.SKIP_INVITE_FOR_SSO = true;
+    constantsOverrides.DEFAULT_TEAM_ID = "";
+
+    const result = await handleSsoCallback({
+      user: mockUser,
+      account: mockAccount,
+      callbackUrl: "http://localhost:3000",
+    });
+
+    expect(result).toBe(false);
+    expect(getFirstOrganization).not.toHaveBeenCalled();
+    expect(createUser).not.toHaveBeenCalled();
+  });
+
+  test("allows auto-provisioning when SKIP_INVITE_FOR_SSO and DEFAULT_TEAM_ID are both set", async () => {
+    vi.mocked(prisma.account.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.user.findFirst).mockResolvedValue(null);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue(null);
+    vi.mocked(getIsFreshInstance).mockResolvedValue(false);
+    vi.mocked(getIsMultiOrgEnabled).mockResolvedValue(false);
+    constantsOverrides.SKIP_INVITE_FOR_SSO = true;
+    constantsOverrides.DEFAULT_TEAM_ID = "team-123";
+    vi.mocked(createUser).mockResolvedValue(
+      mockCreatedUser("Auto Provisioned User") as typeof mockUser & {
+        notificationSettings: { alert: Record<string, never>; unsubscribedOrganizationIds: string[] };
+      }
+    );
+    transactionAccount.findUnique.mockResolvedValue(null);
+
+    const result = await handleSsoCallback({
+      user: mockUser,
+      account: mockAccount,
+      callbackUrl: "http://localhost:3000",
+    });
+
+    expect(result).toBe(true);
+    expect(getOrganizationByTeamId).toHaveBeenCalledWith("team-123");
+    expect(getFirstOrganization).not.toHaveBeenCalled();
+    expect(createMembership).toHaveBeenCalledWith(
+      mockOrganization.id,
+      mockUser.id,
+      { role: "member", accepted: true },
+      expect.anything()
+    );
   });
 
   test("assigns invited SSO users into the resolved organization and syncs notification settings", async () => {


### PR DESCRIPTION
## What does this PR do?                    
                                                                                          
  Closes a privilege-escalation gap in the SSO new-user provisioning flow.                
                                                                                          
  When `AUTH_SKIP_INVITE_FOR_SSO=1` was set without `AUTH_SSO_DEFAULT_TEAM_ID`, `provisionNewSsoUser` fell back to `getFirstOrganization()` — a `prisma.organization.findFirst({})` with no `where` clause. Any user authenticating via SSO was silently auto-joined as `member` (with `accepted: true`) into whatever organization happened to sit first in the database. In multi-tenant self-hosted deployments, or single-tenant instances that had accumulated extra orgs, this enabled cross-tenant data exposure. The existing access-control gate (`getAccessControlPermission`) only blocked when access control was *not* licensed AND no `callbackUrl` was present, so Enterprise instances were not protected.

This PR makes the misconfiguration fail closed: when `!isFirstUser && !isMultiOrgEnabled && SKIP_INVITE_FOR_SSO && !DEFAULT_TEAM_ID`, the SSO callback is rejected with a clear log line. Existing user authentication is unaffected — only the new-user provisioning path is gated. The invite flow is untouched.                                            
   
Fixes [ENG-696](https://linear.app/formbricks/issue/ENG-696)                                                     
                                                                                        
  ## How should this be tested?          

  Automated:                                  
  - `pnpm vitest run modules/ee/sso/lib/tests/sso-handlers.test.ts` — 26/26 pass,
  including 3 new cases:                      
    - rejects when `SKIP_INVITE_FOR_SSO=true && DEFAULT_TEAM_ID=undefined`                
    - rejects when `SKIP_INVITE_FOR_SSO=true && DEFAULT_TEAM_ID=""`
    - allows when both are set, asserts `getOrganizationByTeamId` used and                
  `getFirstOrganization` not called                                                     
                                                                                          
  Manual (self-hosted):                                                                   
  1. Deploy with SSO configured (e.g. OIDC / Keycloak), at least one existing org and one 
  existing user in DB, multi-org disabled.                                                
  2. Set `AUTH_SKIP_INVITE_FOR_SSO=1`, leave `AUTH_SSO_DEFAULT_TEAM_ID` empty. Sign in as 
  a brand-new SSO user → expect rejection (no user created, error log
  `missing_default_team_id`).                                                             
  3. Set `AUTH_SSO_DEFAULT_TEAM_ID=<valid-team-id>`. Sign in as a brand-new SSO user →  
  expect successful provisioning into that team's organization.                           
  4. Sign in as an already-linked SSO user with `AUTH_SSO_DEFAULT_TEAM_ID` empty → expect
  normal sign-in (existing users unaffected).                                             
                                                                                          
  ## Checklist                           
                                                                                          
  ### Required                                                                          
                                                                                          
  - [x] Filled out the "How to test" section in this PR                                 
  - [x] Read [How we Code at              
  Formbricks](https://formbricks.com/docs/contributing/how-we-code)
  - [x] Self-reviewed my own code                                                         
  - [x] Commented on my code in hard-to-understand bits
  - [x] Ran `pnpm build`                                                                  
  - [x] Checked for warnings, there are none                                            
  - [x] Removed all `console.logs`       
  - [x] Merged the latest changes from main onto my branch with `git pull origin main`    
  - [x] My changes don't cause any responsiveness issues
  - [ ] First PR at Formbricks? [Please sign the                                          
  CLA!](https://cla-assistant.io/formbricks/formbricks)                                   
                                          
  ### Appreciated                                                                         
                                                                                          
  - [ ] If a UI change was made: Added a screen recording or screenshots to this PR (N/A —
   backend-only)                                                                          
  - [ ] Updated the Formbricks Docs if changes were necessary           