### PR TITLE
fix: survey runtime accessibility for keyboard controls

### DIFF
--- a/packages/surveys/src/components/general/element-media.tsx
+++ b/packages/surveys/src/components/general/element-media.tsx
@@ -75,7 +75,11 @@ export function ElementMedia({ imgUrl, videoUrl, altText = "Image", className }:
         target="_blank"
         rel="noreferrer"
         aria-label={t("common.open_in_new_tab")}
-        className="absolute right-2 bottom-2 flex items-center gap-2 rounded-md bg-slate-800/40 p-1.5 text-white opacity-0 backdrop-blur-lg transition duration-300 ease-in-out group-hover/image:opacity-100 hover:bg-slate-800/65">
+        className={cn(
+          "absolute right-2 bottom-2 flex items-center gap-2 rounded-md bg-slate-800/40 p-1.5",
+          "text-white backdrop-blur-lg transition duration-300 ease-in-out",
+          "opacity-0 group-hover/image:opacity-100 hover:bg-slate-800/65 focus:opacity-100"
+        )}>
         {imgUrl ? <ImageDownIcon size={20} /> : <ExpandIcon size={20} />}
       </a>
     </div>

--- a/packages/surveys/src/components/general/language-switch.tsx
+++ b/packages/surveys/src/components/general/language-switch.tsx
@@ -88,7 +88,6 @@ export function LanguageSwitch({
           borderRadius: typeof borderRadius === "number" ? `${borderRadius}px` : borderRadius,
         }}
         onClick={toggleDropdown}
-        tabIndex={-1}
         aria-haspopup="true"
         aria-expanded={showLanguageDropdown}
         aria-label={t("common.language_switch")}


### PR DESCRIPTION
## What does this PR do?

This PR fixes two major keyboard accessibility issues in the survey runtime:

- Makes the survey language switch reachable through normal keyboard navigation by removing the permanent `tabIndex={-1}` from the trigger button.
- Makes the media “Open in new tab” action visible when it receives keyboard focus, not only on mouse hover.

These changes address the keyboard-control slice of the WCAG 2.1 AA findings for the survey runtime:
- F1: Language switch button was skipped by `Tab`.
- F13: Media open action was focusable but visually hidden for keyboard users.

No API, schema, or survey response behavior changes are introduced.

Minor code style changes: I chopped down a very long className using `cn()`

References ENG-798

## How should this be tested?

Manual QA:

F1:
- Open a survey with multiple languages enabled (incl. the language switch).
- Use the `Tab` key to navigate through the survey.
- Verify the language switch button receives keyboard focus.
- Press `Enter` or `Space` on the language switch and verify the language dropdown opens.

F13:
- Open a survey question with an image or video.
- Use `Tab` to move focus to the media “Open in new tab” action.
- Verify the action icon becomes visible on keyboard focus.
- Verify mouse hover behavior for the media action still works as before.

Build/checks:

- `pnpm build --filter=@formbricks/surveys... --force`

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
