### PR TITLE
fix: migrate feedback-sources page to unified settings navigation

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/(workspace)/feedback-sources/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/(workspace)/feedback-sources/page.tsx
@@ -1,1 +1,8 @@
-export { WorkspaceFeedbackSourcesPage as default } from "@/modules/workspaces/settings/sources/page";
+import { redirect } from "next/navigation";
+
+export default async function FeedbackSourcesRedirect(
+  props: Readonly<{ params: Promise<{ workspaceId: string }> }>
+) {
+  const { workspaceId } = await props.params;
+  redirect(`/workspaces/${workspaceId}/settings/workspace/feedback-sources`);
+}

--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/SettingsSidebarContent.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/SettingsSidebarContent.tsx
@@ -13,6 +13,7 @@ import {
   LanguagesIcon,
   ListChecksIcon,
   Loader2,
+  ShapesIcon,
   ShieldIcon,
   TagIcon,
   UnplugIcon,
@@ -274,6 +275,13 @@ export const SettingsSidebarContent = ({
       label: t("common.connect_your_app"),
       href: `${basePath}/workspace/app-connection`,
       icon: <UnplugIcon className={iconClassName} />,
+      disabled: isBilling,
+    },
+    {
+      id: "feedback-sources",
+      label: t("workspace.unify.feedback_sources"),
+      href: `${basePath}/workspace/feedback-sources`,
+      icon: <ShapesIcon className={iconClassName} />,
       disabled: isBilling,
     },
     {

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/feedback-sources/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/feedback-sources/page.tsx
@@ -1,0 +1,1 @@
+export { WorkspaceFeedbackSourcesPage as default } from "@/modules/workspaces/settings/sources/page";

--- a/apps/web/app/(app)/workspaces/[workspaceId]/unify/feedback-records/components/feedback-records-table.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/unify/feedback-records/components/feedback-records-table.tsx
@@ -205,7 +205,7 @@ export const FeedbackRecordsTable = ({
                 </Button>
               ))}
             <Button size="sm" asChild>
-              <Link href={`/workspaces/${workspaceId}/feedback-sources`}>
+              <Link href={`/workspaces/${workspaceId}/settings/workspace/feedback-sources`}>
                 {t("workspace.unify.manage_feedback_sources")}
               </Link>
             </Button>

--- a/apps/web/app/(app)/workspaces/[workspaceId]/unify/sources/components/connectors-page-client.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/unify/sources/components/connectors-page-client.tsx
@@ -17,7 +17,6 @@ import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { Alert, AlertButton, AlertDescription } from "@/modules/ui/components/alert";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
-import { WorkspaceConfigNavigation } from "@/modules/workspaces/settings/components/workspace-config-navigation";
 import { TFieldMapping, TUnifySurvey } from "../types";
 import { ConnectorsTable } from "./connectors-table";
 import { CreateConnectorModal } from "./create-connector-modal";
@@ -166,9 +165,7 @@ export function ConnectorsSection({
 
   return (
     <PageContentWrapper>
-      <PageHeader pageTitle={t("common.workspace_configuration")}>
-        <WorkspaceConfigNavigation activeId="feedback-sources" />
-      </PageHeader>
+      <PageHeader pageTitle={t("workspace.unify.feedback_sources")} />
 
       <SettingsCard
         title={t("workspace.unify.feedback_sources")}

--- a/apps/web/app/(app)/workspaces/[workspaceId]/unify/sources/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/unify/sources/page.tsx
@@ -2,5 +2,5 @@ import { redirect } from "next/navigation";
 
 export default async function UnifySourcesPage(props: { params: Promise<{ workspaceId: string }> }) {
   const params = await props.params;
-  redirect(`/workspaces/${params.workspaceId}/feedback-sources`);
+  redirect(`/workspaces/${params.workspaceId}/settings/workspace/feedback-sources`);
 }

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -477,7 +477,6 @@ checksums:
     common/weeks: 545de30df4f44d3f6d1d344af6a10815
     common/welcome_card: 76081ebd5b2e35da9b0f080323704ae7
     common/workspace: b63ef0e99ee6f7fef6cbe4971ca6cf0f
-    common/workspace_configuration: 81a0f4edd0678adacb8ed86f8b2c7f8f
     common/workspace_created_successfully: bf401ae83da954f1db48724e2a8e40f1
     common/workspace_creation_description: aea2f480ba0c54c5cabac72c9c900ddf
     common/workspace_id: bafef925e1b57b52a69844fdf47aac3c

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -504,7 +504,6 @@
     "weeks": "Wochen",
     "welcome_card": "Willkommenskarte",
     "workspace": "Arbeitsbereich",
-    "workspace_configuration": "Workspace-Konfiguration",
     "workspace_created_successfully": "Workspace erfolgreich erstellt",
     "workspace_creation_description": "Organisiere Umfragen in Workspaces für eine bessere Zugriffskontrolle.",
     "workspace_id": "Workspace-ID",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -504,7 +504,6 @@
     "weeks": "weeks",
     "welcome_card": "Welcome card",
     "workspace": "Workspace",
-    "workspace_configuration": "Workspace configuration",
     "workspace_created_successfully": "Workspace created successfully",
     "workspace_creation_description": "Organize surveys in workspaces for better access control.",
     "workspace_id": "Workspace ID",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -504,7 +504,6 @@
     "weeks": "semanas",
     "welcome_card": "Tarjeta de bienvenida",
     "workspace": "Espacio de trabajo",
-    "workspace_configuration": "Configuración del espacio de trabajo",
     "workspace_created_successfully": "Espacio de trabajo creado correctamente",
     "workspace_creation_description": "Organiza las encuestas en espacios de trabajo para un mejor control de acceso.",
     "workspace_id": "ID del espacio de trabajo",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -504,7 +504,6 @@
     "weeks": "semaines",
     "welcome_card": "Carte de bienvenue",
     "workspace": "Espace de travail",
-    "workspace_configuration": "Configuration de l'espace de travail",
     "workspace_created_successfully": "Espace de travail créé avec succès",
     "workspace_creation_description": "Organise tes enquêtes dans des espaces de travail pour un meilleur contrôle d'accès.",
     "workspace_id": "ID de l'espace de travail",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -504,7 +504,6 @@
     "weeks": "hét",
     "welcome_card": "Üdvözlő kártya",
     "workspace": "Munkaterület",
-    "workspace_configuration": "Munkaterület konfigurációja",
     "workspace_created_successfully": "A munkaterület sikeresen létrehozva",
     "workspace_creation_description": "Kérdőívek munkaterületekre szervezése a jobb hozzáférés-vezérlés érdekében.",
     "workspace_id": "Munkaterület-azonosító",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -504,7 +504,6 @@
     "weeks": "週間",
     "welcome_card": "ウェルカムカード",
     "workspace": "ワークスペース",
-    "workspace_configuration": "ワークスペース設定",
     "workspace_created_successfully": "ワークスペースが正常に作成されました",
     "workspace_creation_description": "アクセス制御を改善するために、フォームをワークスペースで整理します。",
     "workspace_id": "ワークスペースID",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -504,7 +504,6 @@
     "weeks": "weken",
     "welcome_card": "Welkomstkaart",
     "workspace": "Werkruimte",
-    "workspace_configuration": "Werkruimte-configuratie",
     "workspace_created_successfully": "Werkruimte succesvol aangemaakt",
     "workspace_creation_description": "Organiseer enquêtes in werkruimtes voor beter toegangsbeheer.",
     "workspace_id": "Werkruimte-ID",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -504,7 +504,6 @@
     "weeks": "semanas",
     "welcome_card": "Cartão de boas-vindas",
     "workspace": "Espaço de trabalho",
-    "workspace_configuration": "Configuração do Workspace",
     "workspace_created_successfully": "Workspace criado com sucesso",
     "workspace_creation_description": "Organize pesquisas em workspaces para melhor controle de acesso.",
     "workspace_id": "ID do Workspace",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -504,7 +504,6 @@
     "weeks": "semanas",
     "welcome_card": "Cartão de boas-vindas",
     "workspace": "Espaço de trabalho",
-    "workspace_configuration": "Configuração do Espaço de Trabalho",
     "workspace_created_successfully": "Espaço de trabalho criado com sucesso",
     "workspace_creation_description": "Organiza inquéritos em espaços de trabalho para um melhor controlo de acesso.",
     "workspace_id": "ID do Espaço de Trabalho",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -504,7 +504,6 @@
     "weeks": "săptămâni",
     "welcome_card": "Card de bun venit",
     "workspace": "Spațiu de lucru",
-    "workspace_configuration": "Configurarea spațiului de lucru",
     "workspace_created_successfully": "Spațiul de lucru a fost creat cu succes",
     "workspace_creation_description": "Organizează sondajele în workspaces pentru un control mai bun al accesului.",
     "workspace_id": "ID workspace",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -504,7 +504,6 @@
     "weeks": "недели",
     "welcome_card": "Приветственная карточка",
     "workspace": "Рабочее пространство",
-    "workspace_configuration": "Настройка рабочего пространства",
     "workspace_created_successfully": "Рабочее пространство успешно создано",
     "workspace_creation_description": "Организуйте опросы в рабочих пространствах для лучшего контроля доступа.",
     "workspace_id": "ID рабочего пространства",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -504,7 +504,6 @@
     "weeks": "veckor",
     "welcome_card": "Välkomstkort",
     "workspace": "Arbetsyta",
-    "workspace_configuration": "Arbetsytekonfiguration",
     "workspace_created_successfully": "Arbetsytan har skapats",
     "workspace_creation_description": "Organisera enkäter i arbetsytor för bättre åtkomstkontroll.",
     "workspace_id": "Arbetsyte-ID",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -504,7 +504,6 @@
     "weeks": "hafta",
     "welcome_card": "Karşılama kartı",
     "workspace": "Çalışma Alanı",
-    "workspace_configuration": "Çalışma alanı yapılandırması",
     "workspace_created_successfully": "Workspace başarıyla oluşturuldu",
     "workspace_creation_description": "Daha iyi erişim kontrolü için survey'leri çalışma alanlarında düzenleyin.",
     "workspace_id": "Çalışma Alanı ID",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -504,7 +504,6 @@
     "weeks": "周",
     "welcome_card": "欢迎 卡片",
     "workspace": "工作区",
-    "workspace_configuration": "工作区配置",
     "workspace_created_successfully": "工作区创建成功",
     "workspace_creation_description": "在工作区中组织调查，以便更好地进行访问控制。",
     "workspace_id": "工作区 ID",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -504,7 +504,6 @@
     "weeks": "週",
     "welcome_card": "歡迎卡片",
     "workspace": "工作區",
-    "workspace_configuration": "工作區設定",
     "workspace_created_successfully": "工作區已成功建立",
     "workspace_creation_description": "將問卷組織在工作區中，以便更好地控管存取權限。",
     "workspace_id": "工作區 ID",

--- a/apps/web/modules/ee/analysis/components/no-feedback-records-state.tsx
+++ b/apps/web/modules/ee/analysis/components/no-feedback-records-state.tsx
@@ -24,7 +24,7 @@ export const NoFeedbackRecordsState = async ({
             : t("workspace.analysis.no_feedback_records_message")}
         </p>
         <Button asChild size="sm">
-          <Link href={`/workspaces/${workspaceId}/feedback-sources`}>
+          <Link href={`/workspaces/${workspaceId}/settings/workspace/feedback-sources`}>
             {hasFeedbackSources
               ? t("workspace.analysis.manage_feedback_sources")
               : t("workspace.analysis.setup_feedback_source")}

--- a/apps/web/modules/ee/feedback-record-directory/components/feedback-record-directory-settings/feedback-record-directory-settings-modal.tsx
+++ b/apps/web/modules/ee/feedback-record-directory/components/feedback-record-directory-settings/feedback-record-directory-settings-modal.tsx
@@ -285,7 +285,7 @@ export const FeedbackRecordDirectorySettingsModal = ({
                           </div>
                           <a
                             className="text-xs font-medium text-slate-700 hover:text-slate-900 hover:underline"
-                            href={`/workspaces/${c.workspaceId}/feedback-sources`}>
+                            href={`/workspaces/${c.workspaceId}/settings/workspace/feedback-sources`}>
                             {t("common.view")}
                           </a>
                         </li>

--- a/apps/web/modules/workspaces/settings/components/workspace-config-navigation.tsx
+++ b/apps/web/modules/workspaces/settings/components/workspace-config-navigation.tsx
@@ -51,7 +51,7 @@ export const WorkspaceConfigNavigation = ({ activeId, loading }: WorkspaceConfig
       id: "feedback-sources",
       label: t("workspace.unify.feedback_sources"),
       icon: <ShapesIcon className="h-5 w-5" />,
-      href: `${workspaceBasePath}/feedback-sources`,
+      href: `${workspaceBasePath}/settings/workspace/feedback-sources`,
       current: pathname?.includes("/feedback-sources"),
     },
     {


### PR DESCRIPTION
## Summary

The feedback-sources page (`/workspaces/:id/feedback-sources`) was still rendering with the old `WorkspaceConfigNavigation` (horizontal secondary tabs) instead of the unified settings sidebar introduced in #7904. This created an inconsistent navigation experience where users would see the old tab-based nav on this page while all other settings pages used the new sidebar.

<img width="1908" height="965" alt="Screenshot 2026-05-04 at 6 23 09 PM" src="https://github.com/user-attachments/assets/4c772f6b-2c69-423b-89e6-cfac41c13eef" />


## Changes

- **New settings route** — Added `/settings/workspace/feedback-sources` page that renders within the unified settings layout
- **Sidebar entry** — Added "Feedback Sources" to the workspace section of `SettingsSidebarContent`
- **Removed old nav** — Stripped the deprecated `WorkspaceConfigNavigation` from `ConnectorsSection`
- **Redirects** — Old routes (`/feedback-sources` and `/unify/sources`) now redirect to the new settings path
- **Link updates** — Updated all internal links pointing to the old `/feedback-sources` path (feedback records table, analysis empty state, FRD settings modal)

## Test plan

- [ ] Navigate to `/workspaces/:id/settings/workspace/feedback-sources` — should render with the sidebar
- [ ] Click "Feedback Sources" in the settings sidebar — navigates correctly
- [ ] Old `/workspaces/:id/feedback-sources` URL redirects to the new path
- [ ] Links from feedback records table, dashboard empty state, and FRD settings modal all point to the new route