### PR TITLE
chore: consolidate CE enterprise trial license links to a single form…

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/settings/(account)/profile/page.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/settings/(account)/profile/page.tsx
@@ -1,7 +1,12 @@
 import { AuthenticationError } from "@formbricks/types/errors";
 import { AccountSettingsNavbar } from "@/app/(app)/environments/[environmentId]/settings/(account)/components/AccountSettingsNavbar";
 import { AccountSecurity } from "@/app/(app)/environments/[environmentId]/settings/(account)/profile/components/AccountSecurity";
-import { EMAIL_VERIFICATION_DISABLED, IS_FORMBRICKS_CLOUD, PASSWORD_RESET_DISABLED } from "@/lib/constants";
+import {
+  EMAIL_VERIFICATION_DISABLED,
+  ENTERPRISE_LICENSE_REQUEST_FORM_URL,
+  IS_FORMBRICKS_CLOUD,
+  PASSWORD_RESET_DISABLED,
+} from "@/lib/constants";
 import { getOrganizationsWhereUserIsSingleOwner } from "@/lib/organization/service";
 import { getUser } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
@@ -65,7 +70,7 @@ const Page = async (props: { params: Promise<{ environmentId: string }> }) => {
                         : t("common.request_trial_license"),
                       href: IS_FORMBRICKS_CLOUD
                         ? `/environments/${params.environmentId}/settings/billing`
-                        : "https://formbricks.com/upgrade-self-hosting-license",
+                        : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
                     },
                     {
                       text: t("common.learn_more"),

--- a/apps/web/app/(app)/environments/[environmentId]/settings/(organization)/enterprise/page.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/settings/(organization)/enterprise/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { OrganizationSettingsNavbar } from "@/app/(app)/environments/[environmentId]/settings/(organization)/components/OrganizationSettingsNavbar";
 import { EnterpriseLicenseStatus } from "@/app/(app)/environments/[environmentId]/settings/(organization)/enterprise/components/EnterpriseLicenseStatus";
-import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { GRACE_PERIOD_MS, getEnterpriseLicense } from "@/modules/ee/license-check/lib/license";
 import { getEnvironmentAuth } from "@/modules/environments/lib/utils";
@@ -173,7 +173,7 @@ const Page = async (props: { params: Promise<{ environmentId: string }> }) => {
               </p>
               <Button asChild>
                 <Link
-                  href="https://app.formbricks.com/s/clvupq3y205i5yrm3sm9v1xt5"
+                  href={ENTERPRISE_LICENSE_REQUEST_FORM_URL}
                   target="_blank"
                   rel="noopener noreferrer nofollow"
                   referrerPolicy="no-referrer">

--- a/apps/web/app/(app)/environments/[environmentId]/settings/(organization)/general/page.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/settings/(organization)/general/page.tsx
@@ -1,6 +1,11 @@
 import { OrganizationSettingsNavbar } from "@/app/(app)/environments/[environmentId]/settings/(organization)/components/OrganizationSettingsNavbar";
 import { isInstanceAIConfigured } from "@/lib/ai/service";
-import { FB_LOGO_URL, IS_FORMBRICKS_CLOUD, IS_STORAGE_CONFIGURED } from "@/lib/constants";
+import {
+  ENTERPRISE_LICENSE_REQUEST_FORM_URL,
+  FB_LOGO_URL,
+  IS_FORMBRICKS_CLOUD,
+  IS_STORAGE_CONFIGURED,
+} from "@/lib/constants";
 import { getUser } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
 import { getIsMultiOrgEnabled, getWhiteLabelPermission } from "@/modules/ee/license-check/lib/utils";
@@ -80,6 +85,7 @@ const Page = async (props: { params: Promise<{ environmentId: string }> }) => {
         fbLogoUrl={FB_LOGO_URL}
         user={user}
         isStorageConfigured={IS_STORAGE_CONFIGURED}
+        enterpriseLicenseRequestFormUrl={ENTERPRISE_LICENSE_REQUEST_FORM_URL}
       />
       {isMultiOrgEnabled && (
         <SettingsCard

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/page.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/page.tsx
@@ -2,7 +2,12 @@ import { AuthenticationError, ResourceNotFoundError } from "@formbricks/types/er
 import { SurveyAnalysisNavigation } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/components/SurveyAnalysisNavigation";
 import { ResponsePage } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/responses/components/ResponsePage";
 import { SurveyAnalysisCTA } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SurveyAnalysisCTA";
-import { IS_FORMBRICKS_CLOUD, IS_STORAGE_CONFIGURED, RESPONSES_PER_PAGE } from "@/lib/constants";
+import {
+  ENTERPRISE_LICENSE_REQUEST_FORM_URL,
+  IS_FORMBRICKS_CLOUD,
+  IS_STORAGE_CONFIGURED,
+  RESPONSES_PER_PAGE,
+} from "@/lib/constants";
 import { getPublicDomain } from "@/lib/getPublicUrl";
 import { getResponseCountBySurveyId, getResponses } from "@/lib/response/service";
 import { getSurvey } from "@/lib/survey/service";
@@ -72,6 +77,7 @@ const Page = async (props: { params: Promise<{ environmentId: string; surveyId: 
             isContactsEnabled={isContactsEnabled}
             isFormbricksCloud={IS_FORMBRICKS_CLOUD}
             isStorageConfigured={IS_STORAGE_CONFIGURED}
+            enterpriseLicenseRequestFormUrl={ENTERPRISE_LICENSE_REQUEST_FORM_URL}
           />
         }>
         <SurveyAnalysisNavigation activeId="responses" />

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SurveyAnalysisCTA.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SurveyAnalysisCTA.tsx
@@ -31,6 +31,7 @@ interface SurveyAnalysisCTAProps {
   isContactsEnabled: boolean;
   isFormbricksCloud: boolean;
   isStorageConfigured: boolean;
+  enterpriseLicenseRequestFormUrl: string;
 }
 
 interface ModalState {
@@ -47,6 +48,7 @@ export const SurveyAnalysisCTA = ({
   isContactsEnabled,
   isFormbricksCloud,
   isStorageConfigured,
+  enterpriseLicenseRequestFormUrl,
 }: SurveyAnalysisCTAProps) => {
   const { t } = useTranslation();
   const router = useRouter();
@@ -231,6 +233,7 @@ export const SurveyAnalysisCTA = ({
           isReadOnly={isReadOnly}
           isStorageConfigured={isStorageConfigured}
           projectCustomScripts={project.customHeadScripts}
+          enterpriseLicenseRequestFormUrl={enterpriseLicenseRequestFormUrl}
         />
       )}
       <SuccessMessage />

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/share-survey-modal.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/share-survey-modal.tsx
@@ -54,6 +54,7 @@ interface ShareSurveyModalProps {
   isReadOnly: boolean;
   isStorageConfigured: boolean;
   projectCustomScripts?: string | null;
+  enterpriseLicenseRequestFormUrl: string;
 }
 
 export const ShareSurveyModal = ({
@@ -69,6 +70,7 @@ export const ShareSurveyModal = ({
   isReadOnly,
   isStorageConfigured,
   projectCustomScripts,
+  enterpriseLicenseRequestFormUrl,
 }: ShareSurveyModalProps) => {
   const environmentId = survey.environmentId;
   const [surveyUrl, setSurveyUrl] = useState<string>(getSurveyUrl(survey, publicDomain, "default"));
@@ -108,6 +110,7 @@ export const ShareSurveyModal = ({
           segments,
           isContactsEnabled,
           isFormbricksCloud,
+          enterpriseLicenseRequestFormUrl,
         },
         disabled: survey.singleUse?.enabled,
       },

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/personal-links-tab.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/personal-links-tab.tsx
@@ -7,7 +7,6 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { TSegment } from "@formbricks/types/segment";
 import { DocumentationLinks } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/documentation-links";
-import { ENTERPRISE_LICENSE_REQUEST_FORM_URL } from "@/lib/constants";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { Button } from "@/modules/ui/components/button";
 import { DatePicker } from "@/modules/ui/components/date-picker";
@@ -35,6 +34,7 @@ interface PersonalLinksTabProps {
   segments: TSegment[];
   isContactsEnabled: boolean;
   isFormbricksCloud: boolean;
+  enterpriseLicenseRequestFormUrl: string;
 }
 
 interface PersonalLinksFormData {
@@ -75,6 +75,7 @@ export const PersonalLinksTab = ({
   surveyId,
   isContactsEnabled,
   isFormbricksCloud,
+  enterpriseLicenseRequestFormUrl,
 }: PersonalLinksTabProps) => {
   const { t } = useTranslation();
 
@@ -170,7 +171,7 @@ export const PersonalLinksTab = ({
             text: isFormbricksCloud ? t("common.upgrade_plan") : t("common.request_trial_license"),
             href: isFormbricksCloud
               ? `/environments/${environmentId}/settings/billing`
-              : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
+              : enterpriseLicenseRequestFormUrl,
           },
           {
             text: t("common.learn_more"),

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/personal-links-tab.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/personal-links-tab.tsx
@@ -7,6 +7,7 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { TSegment } from "@formbricks/types/segment";
 import { DocumentationLinks } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/shareEmbedModal/documentation-links";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL } from "@/lib/constants";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { Button } from "@/modules/ui/components/button";
 import { DatePicker } from "@/modules/ui/components/date-picker";
@@ -169,7 +170,7 @@ export const PersonalLinksTab = ({
             text: isFormbricksCloud ? t("common.upgrade_plan") : t("common.request_trial_license"),
             href: isFormbricksCloud
               ? `/environments/${environmentId}/settings/billing`
-              : "https://formbricks.com/upgrade-self-hosting-license",
+              : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
           },
           {
             text: t("common.learn_more"),

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/page.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/page.tsx
@@ -4,7 +4,12 @@ import { SurveyAnalysisNavigation } from "@/app/(app)/environments/[environmentI
 import { SummaryPage } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SummaryPage";
 import { SurveyAnalysisCTA } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/components/SurveyAnalysisCTA";
 import { getSurveySummary } from "@/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/lib/surveySummary";
-import { DEFAULT_LOCALE, IS_FORMBRICKS_CLOUD, IS_STORAGE_CONFIGURED } from "@/lib/constants";
+import {
+  DEFAULT_LOCALE,
+  ENTERPRISE_LICENSE_REQUEST_FORM_URL,
+  IS_FORMBRICKS_CLOUD,
+  IS_STORAGE_CONFIGURED,
+} from "@/lib/constants";
 import { getPublicDomain } from "@/lib/getPublicUrl";
 import { getSurvey } from "@/lib/survey/service";
 import { getUser } from "@/lib/user/service";
@@ -74,6 +79,7 @@ const SurveyPage = async (props: { params: Promise<{ environmentId: string; surv
             isContactsEnabled={isContactsEnabled}
             isFormbricksCloud={IS_FORMBRICKS_CLOUD}
             isStorageConfigured={IS_STORAGE_CONFIGURED}
+            enterpriseLicenseRequestFormUrl={ENTERPRISE_LICENSE_REQUEST_FORM_URL}
           />
         }>
         <SurveyAnalysisNavigation activeId="summary" />

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -153,6 +153,9 @@ export const DEBUG = env.DEBUG === "1";
 // Enterprise License constant
 export const ENTERPRISE_LICENSE_KEY = env.ENTERPRISE_LICENSE_KEY;
 
+export const ENTERPRISE_LICENSE_REQUEST_FORM_URL =
+  "https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=onpremise&source=ce";
+
 export const REDIS_URL = env.REDIS_URL;
 export const RATE_LIMITING_DISABLED = env.RATE_LIMITING_DISABLED === "1";
 export const TELEMETRY_DISABLED = env.TELEMETRY_DISABLED === "1";

--- a/apps/web/modules/ee/contacts/components/contacts-page-layout.tsx
+++ b/apps/web/modules/ee/contacts/components/contacts-page-layout.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from "react";
-import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
@@ -52,7 +52,7 @@ export const ContactsPageLayout = async ({
                 text: IS_FORMBRICKS_CLOUD ? t("common.upgrade_plan") : t("common.request_trial_license"),
                 href: IS_FORMBRICKS_CLOUD
                   ? `/environments/${environmentId}/settings/billing`
-                  : "https://formbricks.com/upgrade-self-hosting-license",
+                  : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
               },
               {
                 text: t("common.learn_more"),

--- a/apps/web/modules/ee/quotas/components/quotas-card.tsx
+++ b/apps/web/modules/ee/quotas/components/quotas-card.tsx
@@ -10,6 +10,7 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { TSurveyQuota, TSurveyQuotaInput } from "@formbricks/types/quota";
 import { TSurvey } from "@formbricks/types/surveys/types";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL } from "@/lib/constants";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import {
   createQuotaAction,
@@ -177,7 +178,7 @@ export const QuotasCard = ({
                     text: isFormbricksCloud ? t("common.upgrade_plan") : t("common.request_trial_license"),
                     href: isFormbricksCloud
                       ? `/environments/${environmentId}/settings/billing`
-                      : "https://formbricks.com/upgrade-self-hosting-license",
+                      : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
                   },
                   {
                     text: t("common.learn_more"),

--- a/apps/web/modules/ee/quotas/components/quotas-card.tsx
+++ b/apps/web/modules/ee/quotas/components/quotas-card.tsx
@@ -10,7 +10,6 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { TSurveyQuota, TSurveyQuotaInput } from "@formbricks/types/quota";
 import { TSurvey } from "@formbricks/types/surveys/types";
-import { ENTERPRISE_LICENSE_REQUEST_FORM_URL } from "@/lib/constants";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import {
   createQuotaAction,
@@ -30,6 +29,7 @@ interface QuotasCardProps {
   isFormbricksCloud?: boolean;
   quotas: TSurveyQuota[];
   hasResponses: boolean;
+  enterpriseLicenseRequestFormUrl: string;
 }
 
 const AddQuotaButton = ({
@@ -68,6 +68,7 @@ export const QuotasCard = ({
   isFormbricksCloud,
   quotas,
   hasResponses,
+  enterpriseLicenseRequestFormUrl,
 }: QuotasCardProps) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
@@ -178,7 +179,7 @@ export const QuotasCard = ({
                     text: isFormbricksCloud ? t("common.upgrade_plan") : t("common.request_trial_license"),
                     href: isFormbricksCloud
                       ? `/environments/${environmentId}/settings/billing`
-                      : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
+                      : enterpriseLicenseRequestFormUrl,
                   },
                   {
                     text: t("common.learn_more"),

--- a/apps/web/modules/ee/teams/team-list/components/teams-view.tsx
+++ b/apps/web/modules/ee/teams/team-list/components/teams-view.tsx
@@ -1,7 +1,7 @@
 import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { TOrganizationRole } from "@formbricks/types/memberships";
 import { SettingsCard } from "@/app/(app)/environments/[environmentId]/settings/components/SettingsCard";
-import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { TeamsTable } from "@/modules/ee/teams/team-list/components/teams-table";
 import { getProjectsByOrganizationId } from "@/modules/ee/teams/team-list/lib/project";
@@ -41,7 +41,7 @@ export const TeamsView = async ({
       text: IS_FORMBRICKS_CLOUD ? t("common.upgrade_plan") : t("common.request_trial_license"),
       href: IS_FORMBRICKS_CLOUD
         ? `/environments/${environmentId}/settings/billing`
-        : "https://formbricks.com/docs/self-hosting/license#30-day-trial-license-request",
+        : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
     },
     {
       text: t("common.learn_more"),

--- a/apps/web/modules/ee/whitelabel/email-customization/components/email-customization-settings.tsx
+++ b/apps/web/modules/ee/whitelabel/email-customization/components/email-customization-settings.tsx
@@ -11,6 +11,7 @@ import { TAllowedFileExtension } from "@formbricks/types/storage";
 import { TUser } from "@formbricks/types/user";
 import { SettingsCard } from "@/app/(app)/environments/[environmentId]/settings/components/SettingsCard";
 import { cn } from "@/lib/cn";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL } from "@/lib/constants";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import {
   removeOrganizationEmailLogoUrlAction,
@@ -184,7 +185,7 @@ export const EmailCustomizationSettings = ({
       text: isFormbricksCloud ? t("common.upgrade_plan") : t("common.request_trial_license"),
       href: isFormbricksCloud
         ? `/environments/${environmentId}/settings/billing`
-        : "https://formbricks.com/upgrade-self-hosting-license",
+        : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
     },
     {
       text: t("common.learn_more"),

--- a/apps/web/modules/ee/whitelabel/email-customization/components/email-customization-settings.tsx
+++ b/apps/web/modules/ee/whitelabel/email-customization/components/email-customization-settings.tsx
@@ -11,7 +11,6 @@ import { TAllowedFileExtension } from "@formbricks/types/storage";
 import { TUser } from "@formbricks/types/user";
 import { SettingsCard } from "@/app/(app)/environments/[environmentId]/settings/components/SettingsCard";
 import { cn } from "@/lib/cn";
-import { ENTERPRISE_LICENSE_REQUEST_FORM_URL } from "@/lib/constants";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import {
   removeOrganizationEmailLogoUrlAction,
@@ -37,6 +36,7 @@ interface EmailCustomizationSettingsProps {
   user: TUser | null;
   fbLogoUrl: string;
   isStorageConfigured: boolean;
+  enterpriseLicenseRequestFormUrl: string;
 }
 
 export const EmailCustomizationSettings = ({
@@ -48,6 +48,7 @@ export const EmailCustomizationSettings = ({
   user,
   fbLogoUrl,
   isStorageConfigured,
+  enterpriseLicenseRequestFormUrl,
 }: EmailCustomizationSettingsProps) => {
   const { t } = useTranslation();
 
@@ -185,7 +186,7 @@ export const EmailCustomizationSettings = ({
       text: isFormbricksCloud ? t("common.upgrade_plan") : t("common.request_trial_license"),
       href: isFormbricksCloud
         ? `/environments/${environmentId}/settings/billing`
-        : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
+        : enterpriseLicenseRequestFormUrl,
     },
     {
       text: t("common.learn_more"),

--- a/apps/web/modules/ee/whitelabel/remove-branding/components/branding-settings-card.tsx
+++ b/apps/web/modules/ee/whitelabel/remove-branding/components/branding-settings-card.tsx
@@ -1,6 +1,6 @@
 import { Project } from "@prisma/client";
 import { SettingsCard } from "@/app/(app)/environments/[environmentId]/settings/components/SettingsCard";
-import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { EditBranding } from "@/modules/ee/whitelabel/remove-branding/components/edit-branding";
 import { Alert, AlertDescription } from "@/modules/ui/components/alert";
@@ -26,7 +26,7 @@ export const BrandingSettingsCard = async ({
       text: IS_FORMBRICKS_CLOUD ? t("common.upgrade_plan") : t("common.request_trial_license"),
       href: IS_FORMBRICKS_CLOUD
         ? `/environments/${environmentId}/settings/billing`
-        : "https://formbricks.com/upgrade-self-hosting-license",
+        : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
     },
     {
       text: t("common.learn_more"),

--- a/apps/web/modules/organization/settings/teams/components/edit-memberships/organization-actions.tsx
+++ b/apps/web/modules/organization/settings/teams/components/edit-memberships/organization-actions.tsx
@@ -39,6 +39,7 @@ interface OrganizationActionsProps {
   isStorageConfigured: boolean;
   isTeamAdmin: boolean;
   userAdminTeamIds?: string[];
+  enterpriseLicenseRequestFormUrl: string;
 }
 
 export const OrganizationActions = ({
@@ -56,6 +57,7 @@ export const OrganizationActions = ({
   isStorageConfigured,
   isTeamAdmin,
   userAdminTeamIds,
+  enterpriseLicenseRequestFormUrl,
 }: OrganizationActionsProps) => {
   const router = useRouter();
   const { t } = useTranslation();
@@ -174,6 +176,7 @@ export const OrganizationActions = ({
         isOwnerOrManager={isOwnerOrManager}
         isTeamAdmin={isTeamAdmin}
         userAdminTeamIds={userAdminTeamIds}
+        enterpriseLicenseRequestFormUrl={enterpriseLicenseRequestFormUrl}
       />
 
       <Dialog open={isLeaveOrganizationModalOpen} onOpenChange={setIsLeaveOrganizationModalOpen}>

--- a/apps/web/modules/organization/settings/teams/components/invite-member/individual-invite-tab.tsx
+++ b/apps/web/modules/organization/settings/teams/components/invite-member/individual-invite-tab.tsx
@@ -10,6 +10,7 @@ import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { TOrganizationRole, ZOrganizationRole } from "@formbricks/types/memberships";
 import { ZUserName } from "@formbricks/types/user";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL } from "@/lib/constants";
 import { AddMemberRole } from "@/modules/ee/role-management/components/add-member-role";
 import { TOrganizationTeam } from "@/modules/ee/teams/team-list/types/team";
 import { Alert, AlertDescription } from "@/modules/ui/components/alert";
@@ -191,7 +192,7 @@ export const IndividualInviteTab = ({
                 href={
                   isFormbricksCloud
                     ? `/environments/${environmentId}/settings/billing`
-                    : "https://formbricks.com/upgrade-self-hosting-license"
+                    : ENTERPRISE_LICENSE_REQUEST_FORM_URL
                 }>
                 {t("common.upgrade_plan")}
               </Link>

--- a/apps/web/modules/organization/settings/teams/components/invite-member/individual-invite-tab.tsx
+++ b/apps/web/modules/organization/settings/teams/components/invite-member/individual-invite-tab.tsx
@@ -10,7 +10,6 @@ import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { TOrganizationRole, ZOrganizationRole } from "@formbricks/types/memberships";
 import { ZUserName } from "@formbricks/types/user";
-import { ENTERPRISE_LICENSE_REQUEST_FORM_URL } from "@/lib/constants";
 import { AddMemberRole } from "@/modules/ee/role-management/components/add-member-role";
 import { TOrganizationTeam } from "@/modules/ee/teams/team-list/types/team";
 import { Alert, AlertDescription } from "@/modules/ui/components/alert";
@@ -30,6 +29,7 @@ interface IndividualInviteTabProps {
   environmentId: string;
   membershipRole?: TOrganizationRole;
   showTeamAdminRestrictions: boolean;
+  enterpriseLicenseRequestFormUrl: string;
 }
 
 export const IndividualInviteTab = ({
@@ -41,6 +41,7 @@ export const IndividualInviteTab = ({
   environmentId,
   membershipRole,
   showTeamAdminRestrictions,
+  enterpriseLicenseRequestFormUrl,
 }: IndividualInviteTabProps) => {
   const ZFormSchema = z.object({
     name: ZUserName,
@@ -192,7 +193,7 @@ export const IndividualInviteTab = ({
                 href={
                   isFormbricksCloud
                     ? `/environments/${environmentId}/settings/billing`
-                    : ENTERPRISE_LICENSE_REQUEST_FORM_URL
+                    : enterpriseLicenseRequestFormUrl
                 }>
                 {t("common.upgrade_plan")}
               </Link>

--- a/apps/web/modules/organization/settings/teams/components/invite-member/invite-member-modal.tsx
+++ b/apps/web/modules/organization/settings/teams/components/invite-member/invite-member-modal.tsx
@@ -30,6 +30,7 @@ interface InviteMemberModalProps {
   isOwnerOrManager: boolean;
   isTeamAdmin: boolean;
   userAdminTeamIds?: string[];
+  enterpriseLicenseRequestFormUrl: string;
 }
 
 export const InviteMemberModal = ({
@@ -45,6 +46,7 @@ export const InviteMemberModal = ({
   isOwnerOrManager,
   isTeamAdmin,
   userAdminTeamIds,
+  enterpriseLicenseRequestFormUrl,
 }: InviteMemberModalProps) => {
   const [type, setType] = useState<"individual" | "bulk">("individual");
 
@@ -68,6 +70,7 @@ export const InviteMemberModal = ({
         teams={filteredTeams}
         membershipRole={membershipRole}
         showTeamAdminRestrictions={showTeamAdminRestrictions}
+        enterpriseLicenseRequestFormUrl={enterpriseLicenseRequestFormUrl}
       />
     ),
     bulk: (

--- a/apps/web/modules/organization/settings/teams/components/members-view.tsx
+++ b/apps/web/modules/organization/settings/teams/components/members-view.tsx
@@ -2,7 +2,12 @@ import { Suspense } from "react";
 import { TOrganizationRole } from "@formbricks/types/memberships";
 import { TOrganization } from "@formbricks/types/organizations";
 import { SettingsCard } from "@/app/(app)/environments/[environmentId]/settings/components/SettingsCard";
-import { INVITE_DISABLED, IS_FORMBRICKS_CLOUD, IS_STORAGE_CONFIGURED } from "@/lib/constants";
+import {
+  ENTERPRISE_LICENSE_REQUEST_FORM_URL,
+  INVITE_DISABLED,
+  IS_FORMBRICKS_CLOUD,
+  IS_STORAGE_CONFIGURED,
+} from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { getIsMultiOrgEnabled } from "@/modules/ee/license-check/lib/utils";
 import { getTeamsWhereUserIsAdmin } from "@/modules/ee/teams/lib/roles";
@@ -70,6 +75,7 @@ export const MembersView = async ({
           isAccessControlAllowed={isAccessControlAllowed}
           isFormbricksCloud={IS_FORMBRICKS_CLOUD}
           isStorageConfigured={IS_STORAGE_CONFIGURED}
+          enterpriseLicenseRequestFormUrl={ENTERPRISE_LICENSE_REQUEST_FORM_URL}
           environmentId={environmentId}
           isMultiOrgEnabled={isMultiOrgEnabled}
           teams={teams}

--- a/apps/web/modules/survey/editor/components/settings-view.tsx
+++ b/apps/web/modules/survey/editor/components/settings-view.tsx
@@ -29,6 +29,7 @@ interface SettingsViewProps {
   isFormbricksCloud: boolean;
   isQuotasAllowed: boolean;
   quotas: TSurveyQuota[];
+  enterpriseLicenseRequestFormUrl: string;
 }
 
 export const SettingsView = ({
@@ -46,6 +47,7 @@ export const SettingsView = ({
   projectPermission,
   isFormbricksCloud,
   quotas,
+  enterpriseLicenseRequestFormUrl,
 }: SettingsViewProps) => {
   const isAppSurvey = localSurvey.type === "app";
 
@@ -70,7 +72,11 @@ export const SettingsView = ({
               </div>
             </div>
           ) : (
-            <TargetingLockedCard isFormbricksCloud={isFormbricksCloud} environmentId={environment.id} />
+            <TargetingLockedCard
+              isFormbricksCloud={isFormbricksCloud}
+              environmentId={environment.id}
+              enterpriseLicenseRequestFormUrl={enterpriseLicenseRequestFormUrl}
+            />
           )}
         </div>
       ) : null}
@@ -89,6 +95,7 @@ export const SettingsView = ({
         isFormbricksCloud={isFormbricksCloud}
         quotas={quotas}
         hasResponses={responseCount > 0}
+        enterpriseLicenseRequestFormUrl={enterpriseLicenseRequestFormUrl}
       />
 
       <ResponseOptionsCard

--- a/apps/web/modules/survey/editor/components/survey-editor.tsx
+++ b/apps/web/modules/survey/editor/components/survey-editor.tsx
@@ -51,6 +51,7 @@ interface SurveyEditorProps {
   quotas: TSurveyQuota[];
   isExternalUrlsAllowed: boolean;
   publicDomain: string;
+  enterpriseLicenseRequestFormUrl: string;
 }
 
 export const SurveyEditor = ({
@@ -80,6 +81,7 @@ export const SurveyEditor = ({
   quotas,
   isExternalUrlsAllowed,
   publicDomain,
+  enterpriseLicenseRequestFormUrl,
 }: SurveyEditorProps) => {
   const [activeView, setActiveView] = useState<TSurveyEditorTabs>("elements");
   const [activeElementId, setActiveElementId] = useState<string | null>(null);
@@ -266,6 +268,7 @@ export const SurveyEditor = ({
               isFormbricksCloud={isFormbricksCloud}
               isQuotasAllowed={isQuotasAllowed}
               quotas={quotas}
+              enterpriseLicenseRequestFormUrl={enterpriseLicenseRequestFormUrl}
             />
           )}
 
@@ -280,6 +283,7 @@ export const SurveyEditor = ({
               userEmail={userEmail}
               teamMemberDetails={teamMemberDetails}
               locale={locale}
+              enterpriseLicenseRequestFormUrl={enterpriseLicenseRequestFormUrl}
             />
           )}
         </main>

--- a/apps/web/modules/survey/editor/components/targeting-locked-card.tsx
+++ b/apps/web/modules/survey/editor/components/targeting-locked-card.tsx
@@ -4,15 +4,19 @@ import * as Collapsible from "@radix-ui/react-collapsible";
 import { LockIcon } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ENTERPRISE_LICENSE_REQUEST_FORM_URL } from "@/lib/constants";
 import { UpgradePrompt } from "@/modules/ui/components/upgrade-prompt";
 
 interface TargetingLockedCardProps {
   isFormbricksCloud: boolean;
   environmentId: string;
+  enterpriseLicenseRequestFormUrl: string;
 }
 
-export const TargetingLockedCard = ({ isFormbricksCloud, environmentId }: TargetingLockedCardProps) => {
+export const TargetingLockedCard = ({
+  isFormbricksCloud,
+  environmentId,
+  enterpriseLicenseRequestFormUrl,
+}: TargetingLockedCardProps) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
 
@@ -48,7 +52,7 @@ export const TargetingLockedCard = ({ isFormbricksCloud, environmentId }: Target
                 text: isFormbricksCloud ? t("common.upgrade_plan") : t("common.request_trial_license"),
                 href: isFormbricksCloud
                   ? `/environments/${environmentId}/settings/billing`
-                  : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
+                  : enterpriseLicenseRequestFormUrl,
               },
               {
                 text: t("common.learn_more"),

--- a/apps/web/modules/survey/editor/components/targeting-locked-card.tsx
+++ b/apps/web/modules/survey/editor/components/targeting-locked-card.tsx
@@ -4,6 +4,7 @@ import * as Collapsible from "@radix-ui/react-collapsible";
 import { LockIcon } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL } from "@/lib/constants";
 import { UpgradePrompt } from "@/modules/ui/components/upgrade-prompt";
 
 interface TargetingLockedCardProps {
@@ -47,7 +48,7 @@ export const TargetingLockedCard = ({ isFormbricksCloud, environmentId }: Target
                 text: isFormbricksCloud ? t("common.upgrade_plan") : t("common.request_trial_license"),
                 href: isFormbricksCloud
                   ? `/environments/${environmentId}/settings/billing`
-                  : "https://formbricks.com/upgrade-self-hosting-license",
+                  : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
               },
               {
                 text: t("common.learn_more"),

--- a/apps/web/modules/survey/editor/page.tsx
+++ b/apps/web/modules/survey/editor/page.tsx
@@ -1,6 +1,7 @@
 import { ResourceNotFoundError } from "@formbricks/types/errors";
 import {
   DEFAULT_LOCALE,
+  ENTERPRISE_LICENSE_REQUEST_FORM_URL,
   IS_FORMBRICKS_CLOUD,
   IS_STORAGE_CONFIGURED,
   MAIL_FROM,
@@ -138,6 +139,7 @@ export const SurveyEditorPage = async (props: {
       quotas={quotas}
       isExternalUrlsAllowed={isExternalUrlsAllowed}
       publicDomain={publicDomain}
+      enterpriseLicenseRequestFormUrl={ENTERPRISE_LICENSE_REQUEST_FORM_URL}
     />
   );
 };

--- a/apps/web/modules/survey/follow-ups/components/follow-ups-view.tsx
+++ b/apps/web/modules/survey/follow-ups/components/follow-ups-view.tsx
@@ -6,7 +6,6 @@ import { useTranslation } from "react-i18next";
 import { TSurveyFollowUp } from "@formbricks/database/types/survey-follow-up";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
-import { ENTERPRISE_LICENSE_REQUEST_FORM_URL } from "@/lib/constants";
 import { TFollowUpEmailToUser } from "@/modules/survey/editor/types/survey-follow-up";
 import { FollowUpItem } from "@/modules/survey/follow-ups/components/follow-up-item";
 import { FollowUpModal } from "@/modules/survey/follow-ups/components/follow-up-modal";
@@ -23,6 +22,7 @@ interface FollowUpsViewProps {
   userEmail: string;
   teamMemberDetails: TFollowUpEmailToUser[];
   locale: TUserLocale;
+  enterpriseLicenseRequestFormUrl: string;
 }
 
 export const FollowUpsView = ({
@@ -35,6 +35,7 @@ export const FollowUpsView = ({
   userEmail,
   teamMemberDetails,
   locale,
+  enterpriseLicenseRequestFormUrl,
 }: FollowUpsViewProps) => {
   const { t } = useTranslation();
   const [addFollowUpModalOpen, setAddFollowUpModalOpen] = useState(false);
@@ -55,7 +56,7 @@ export const FollowUpsView = ({
                 : t("common.request_trial_license"),
               href: isFormbricksCloud
                 ? `/environments/${localSurvey.environmentId}/settings/billing`
-                : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
+                : enterpriseLicenseRequestFormUrl,
             },
             {
               text: t("common.learn_more"),

--- a/apps/web/modules/survey/follow-ups/components/follow-ups-view.tsx
+++ b/apps/web/modules/survey/follow-ups/components/follow-ups-view.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { TSurveyFollowUp } from "@formbricks/database/types/survey-follow-up";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL } from "@/lib/constants";
 import { TFollowUpEmailToUser } from "@/modules/survey/editor/types/survey-follow-up";
 import { FollowUpItem } from "@/modules/survey/follow-ups/components/follow-up-item";
 import { FollowUpModal } from "@/modules/survey/follow-ups/components/follow-up-modal";
@@ -54,7 +55,7 @@ export const FollowUpsView = ({
                 : t("common.request_trial_license"),
               href: isFormbricksCloud
                 ? `/environments/${localSurvey.environmentId}/settings/billing`
-                : "https://formbricks.com/docs/self-hosting/license",
+                : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
             },
             {
               text: t("common.learn_more"),

--- a/docs/self-hosting/advanced/license.mdx
+++ b/docs/self-hosting/advanced/license.mdx
@@ -8,7 +8,7 @@ The Formbricks core source code is licensed under AGPLv3 and available on GitHub
 
 <Note>
   Want to get your hands on the Enterprise Edition? [Request a free Enterprise Edition
-  Trial](https://formbricks.com/enterprise-license?source=docs) License to build a fully functioning Proof of
+  Trial](https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=onpremise&source=docs) License to build a fully functioning Proof of
   Concept.
 </Note>
 
@@ -38,11 +38,11 @@ The Formbricks core application is licensed under the [AGPLv3 Open Source Licens
 
 ### The Enterprise Edition
 
-Additional to the AGPL licensed Formbricks core, this repository contains code licensed under an Enterprise license. The [code](https://github.com/formbricks/formbricks/tree/main/apps/web/modules/ee) and [license](https://github.com/formbricks/formbricks/blob/main/apps/web/modules/ee/LICENSE) for the enterprise functionality can be found in the `/apps/web/modules/ee` folder of this repository. This additional functionality is not part of the AGPLv3 licensed Formbricks core and is designed to meet the needs of larger teams and enterprises. This advanced functionality is already included in the Docker images, but you need an [Enterprise License Key](https://formbricks.com/enterprise-license?source=docs) to unlock it.
+Additional to the AGPL licensed Formbricks core, this repository contains code licensed under an Enterprise license. The [code](https://github.com/formbricks/formbricks/tree/main/apps/web/modules/ee) and [license](https://github.com/formbricks/formbricks/blob/main/apps/web/modules/ee/LICENSE) for the enterprise functionality can be found in the `/apps/web/modules/ee` folder of this repository. This additional functionality is not part of the AGPLv3 licensed Formbricks core and is designed to meet the needs of larger teams and enterprises. This advanced functionality is already included in the Docker images, but you need an [Enterprise License Key](https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=onpremise&source=docs) to unlock it.
 
 <Note>
   Want to get your hands on the Enterprise Edition? [Request a free Enterprise Edition
-  Trial](https://formbricks.com/enterprise-license?source=docs) License to build a fully functioning Proof of
+  Trial](https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=onpremise&source=docs) License to build a fully functioning Proof of
   Concept.
 </Note>
 


### PR DESCRIPTION
## Summary
We observed on our marketing page that moving lead flow from CTA -> `/enterprise-license` -> `request form` to CTA -> `request form` increased the number of leads by three times.

This PR replicates the same for CE and Docs sources.

## Changes

- Added ENTERPRISE_LICENSE_REQUEST_FORM_URL constant in lib/constants.ts — single source of truth for the CE trial license form URL (source=ce)
- Replaced all scattered CE upgrade URLs across 11 components with the new constant — branding settings, email customization, contacts, quotas, teams, targeting, follow-ups, personal links, profile, invite member, and the enterprise settings page
- Updated docs (license.mdx) — replaced 3 occurrences of the old formbricks.com/enterprise-license link with the form URL using source=docs