### PR TITLE
fix(security): strip sensitive survey and segment metadata from public client API

### DIFF
--- a/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/settings/components/ProjectSettings.tsx
+++ b/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/settings/components/ProjectSettings.tsx
@@ -18,6 +18,7 @@ import { createProjectAction } from "@/app/(app)/environments/[environmentId]/ac
 import { previewSurvey } from "@/app/lib/templates";
 import { FORMBRICKS_SURVEYS_FILTERS_KEY_LS } from "@/lib/localStorage";
 import { buildStylingFromBrandColor } from "@/lib/styling/constants";
+import { toJsEnvironmentStateSurvey } from "@/lib/survey/client-utils";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { TOrganizationTeam } from "@/modules/ee/teams/project-teams/types/team";
 import { CreateTeamModal } from "@/modules/ee/teams/team-list/components/create-team-modal";
@@ -242,7 +243,7 @@ export const ProjectSettings = ({
         <SurveyInline
           appUrl={publicDomain}
           isPreviewMode={true}
-          survey={previewSurvey(projectName || t("common.my_product"), t)}
+          survey={toJsEnvironmentStateSurvey(previewSurvey(projectName || t("common.my_product"), t))}
           styling={previewStyling}
           isBrandingEnabled={false}
           languageCode="default"

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplate.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplate.tsx
@@ -1,6 +1,7 @@
 import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { getPublicDomain } from "@/lib/getPublicUrl";
 import { getProjectByEnvironmentId } from "@/lib/project/service";
+import { toJsEnvironmentStateSurvey } from "@/lib/survey/client-utils";
 import { getSurvey } from "@/lib/survey/service";
 import { getStyling } from "@/lib/utils/styling";
 import { getTranslate } from "@/lingodotdev/server";
@@ -18,7 +19,7 @@ export const getEmailTemplateHtml = async (surveyId: string, locale: string) => 
     throw new ResourceNotFoundError(t("common.workspace"), null);
   }
 
-  const styling = getStyling(project, survey);
+  const styling = getStyling(project, toJsEnvironmentStateSurvey(survey));
   const surveyUrl = getPublicDomain() + "/s/" + survey.id;
   const html = await getPreviewEmailTemplateHtml(survey, surveyUrl, styling, locale, t);
 

--- a/apps/web/app/api/v1/client/[environmentId]/environment/lib/data.ts
+++ b/apps/web/app/api/v1/client/[environmentId]/environment/lib/data.ts
@@ -80,7 +80,7 @@ export const getEnvironmentStateData = async (environmentId: string): Promise<En
           select: {
             id: true,
             welcomeCard: true,
-            name: true,
+            // name intentionally omitted — internal label not needed by the SDK
             questions: true,
             blocks: true,
             variables: true,
@@ -107,13 +107,13 @@ export const getEnvironmentStateData = async (environmentId: string): Promise<En
             styling: true,
             status: true,
             recaptcha: true,
+            // Fetch only what's needed to compute the minimal segment shape.
+            // Titles, descriptions, and filter conditions are evaluated server-side
+            // and must not be sent to the browser.
             segment: {
-              include: {
-                surveys: {
-                  select: {
-                    id: true,
-                  },
-                },
+              select: {
+                id: true,
+                filters: true,
               },
             },
             recontactDays: true,
@@ -147,10 +147,28 @@ export const getEnvironmentStateData = async (environmentId: string): Promise<En
       throw new ResourceNotFoundError("project", null);
     }
 
-    // Transform surveys using existing utility
-    const transformedSurveys = environmentData.surveys.map((survey) =>
-      transformPrismaSurvey<TJsEnvironmentStateSurvey>(survey)
-    );
+    // Transform surveys using the shared utility, then replace the segment with
+    // the minimal public shape (id + hasFilters). We null out segment before
+    // calling transformPrismaSurvey because that function expects a surveys[]
+    // relation on the segment object (used by the management API), which we
+    // intentionally don't fetch here.
+    const transformedSurveys = environmentData.surveys.map((survey) => {
+      const minimalSegment = survey.segment
+        ? {
+            id: survey.segment.id,
+            hasFilters:
+              Array.isArray(survey.segment.filters) && (survey.segment.filters as unknown[]).length > 0,
+          }
+        : null;
+
+      const { segment: _segment, ...surveyWithoutSegment } = survey;
+      const transformed = transformPrismaSurvey<TJsEnvironmentStateSurvey>({
+        ...surveyWithoutSegment,
+        segment: null,
+      });
+
+      return { ...transformed, segment: minimalSegment };
+    });
 
     return {
       environment: {

--- a/apps/web/lib/survey/client-utils.ts
+++ b/apps/web/lib/survey/client-utils.ts
@@ -1,0 +1,15 @@
+import { TJsEnvironmentStateSurvey } from "@formbricks/types/js";
+import { TSurvey } from "@formbricks/types/surveys/types";
+
+/**
+ * Adapts a full management-side `TSurvey` into the minimal
+ * `TJsEnvironmentStateSurvey` shape that the SDK widget / shared SDK utilities
+ * expect. Only the segment shape needs reshaping — the rest of `TSurvey` is a
+ * structural superset of the SDK survey type.
+ */
+export const toJsEnvironmentStateSurvey = (survey: TSurvey): TJsEnvironmentStateSurvey => {
+  return {
+    ...survey,
+    segment: survey.segment ? { id: survey.segment.id, hasFilters: survey.segment.filters.length > 0 } : null,
+  } as unknown as TJsEnvironmentStateSurvey;
+};

--- a/apps/web/modules/ee/quotas/lib/evaluation-service.ts
+++ b/apps/web/modules/ee/quotas/lib/evaluation-service.ts
@@ -3,6 +3,7 @@ import { Prisma, Response } from "@prisma/client";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
 import { TSurveyQuota } from "@formbricks/types/quota";
+import { toJsEnvironmentStateSurvey } from "@/lib/survey/client-utils";
 import { getSurvey } from "@/lib/survey/service";
 import { getQuotas } from "./quotas";
 import { evaluateQuotas, handleQuotas } from "./utils";
@@ -52,7 +53,13 @@ export const evaluateResponseQuotas = async (input: QuotaEvaluationInput): Promi
       return { shouldEndSurvey: false };
     }
     const isDefaultLanguage = survey.languages.find((lang) => lang.default)?.language.code === language;
-    const result = evaluateQuotas(survey, data, variables, quotas, isDefaultLanguage ? "default" : language);
+    const result = evaluateQuotas(
+      toJsEnvironmentStateSurvey(survey),
+      data,
+      variables,
+      quotas,
+      isDefaultLanguage ? "default" : language
+    );
 
     const quotaFull = await handleQuotas(surveyId, responseId, result, responseFinished, prismaClient);
 

--- a/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
+++ b/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { TProjectStyling } from "@formbricks/types/project";
 import { TResponseData } from "@formbricks/types/responses";
 import { TSurvey, TSurveyStyling } from "@formbricks/types/surveys/types";
+import { toJsEnvironmentStateSurvey } from "@/lib/survey/client-utils";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 import { CustomScriptsInjector } from "@/modules/survey/link/components/custom-scripts-injector";
 import { LinkSurveyWrapper } from "@/modules/survey/link/components/link-survey-wrapper";
@@ -133,11 +134,13 @@ export const SurveyClientWrapper = ({
     }
     setResponseData({});
   };
+  const jsSurvey = useMemo(() => toJsEnvironmentStateSurvey(survey), [survey]);
+
   // Determine text direction based on language code for logo positioning only
   // which checks both language code and survey content. This is only for logo UI positioning.
   const logoDir = useMemo(() => {
-    return isRTLLanguage(survey, languageCode) ? "rtl" : "auto";
-  }, [languageCode, survey]);
+    return isRTLLanguage(jsSurvey, languageCode) ? "rtl" : "auto";
+  }, [languageCode, jsSurvey]);
 
   return (
     <>
@@ -169,7 +172,7 @@ export const SurveyClientWrapper = ({
           appUrl={publicDomain}
           environmentId={survey.environmentId}
           isPreviewMode={isPreview}
-          survey={survey}
+          survey={jsSurvey}
           styling={styling}
           languageCode={languageCode}
           isBrandingEnabled={project.linkSurveyBranding}

--- a/apps/web/modules/ui/components/preview-survey/index.tsx
+++ b/apps/web/modules/ui/components/preview-survey/index.tsx
@@ -10,6 +10,7 @@ import { TProjectStyling } from "@formbricks/types/project";
 import { TSurvey, TSurveyLanguage, TSurveyStyling } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
 import { cn } from "@/lib/cn";
+import { toJsEnvironmentStateSurvey } from "@/lib/survey/client-utils";
 import { ClientLogo } from "@/modules/ui/components/client-logo";
 import {
   DropdownMenu,
@@ -272,7 +273,7 @@ export const PreviewSurvey = ({
                   <SurveyInline
                     appUrl={publicDomain}
                     isPreviewMode={true}
-                    survey={survey}
+                    survey={toJsEnvironmentStateSurvey(survey)}
                     isBrandingEnabled={project.inAppSurveyBranding}
                     isRedirectDisabled={true}
                     languageCode={languageCode}
@@ -303,7 +304,7 @@ export const PreviewSurvey = ({
                     <SurveyInline
                       appUrl={publicDomain}
                       isPreviewMode={true}
-                      survey={{ ...survey, type: "link" }}
+                      survey={toJsEnvironmentStateSurvey({ ...survey, type: "link" })}
                       isBrandingEnabled={project.linkSurveyBranding}
                       languageCode={languageCode}
                       responseCount={42}
@@ -388,7 +389,7 @@ export const PreviewSurvey = ({
                 <SurveyInline
                   appUrl={publicDomain}
                   isPreviewMode={true}
-                  survey={survey}
+                  survey={toJsEnvironmentStateSurvey(survey)}
                   isBrandingEnabled={project.inAppSurveyBranding}
                   isRedirectDisabled={true}
                   languageCode={languageCode}
@@ -423,7 +424,7 @@ export const PreviewSurvey = ({
                   <SurveyInline
                     appUrl={publicDomain}
                     isPreviewMode={true}
-                    survey={{ ...survey, type: "link" }}
+                    survey={toJsEnvironmentStateSurvey({ ...survey, type: "link" })}
                     isBrandingEnabled={project.linkSurveyBranding}
                     isRedirectDisabled={true}
                     languageCode={languageCode}

--- a/apps/web/modules/ui/components/theme-styling-preview-survey/index.tsx
+++ b/apps/web/modules/ui/components/theme-styling-preview-survey/index.tsx
@@ -6,6 +6,7 @@ import { Fragment, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TSurvey, TSurveyType } from "@formbricks/types/surveys/types";
 import { cn } from "@/lib/cn";
+import { toJsEnvironmentStateSurvey } from "@/lib/survey/client-utils";
 import { ClientLogo } from "@/modules/ui/components/client-logo";
 import { MediaBackground } from "@/modules/ui/components/media-background";
 import { Modal } from "@/modules/ui/components/preview-survey/components/modal";
@@ -178,7 +179,7 @@ export const ThemeStylingPreviewSurvey = ({
                 <SurveyInline
                   appUrl={publicDomain}
                   isPreviewMode={true}
-                  survey={{ ...survey, type: "app" }}
+                  survey={toJsEnvironmentStateSurvey({ ...survey, type: "app" })}
                   isBrandingEnabled={project.inAppSurveyBranding}
                   isRedirectDisabled={true}
                   onFileUpload={async (file) => file.name}
@@ -205,7 +206,7 @@ export const ThemeStylingPreviewSurvey = ({
                 <SurveyInline
                   appUrl={publicDomain}
                   isPreviewMode={true}
-                  survey={{ ...survey, type: "link" }}
+                  survey={toJsEnvironmentStateSurvey({ ...survey, type: "link" })}
                   isBrandingEnabled={project.linkSurveyBranding}
                   isRedirectDisabled={true}
                   onFileUpload={async (file) => file.name}

--- a/packages/js-core/src/lib/common/setup.ts
+++ b/packages/js-core/src/lib/common/setup.ts
@@ -243,9 +243,9 @@ export const setup = async (
         filteredSurveys,
       });
 
-      const surveyNames = filteredSurveys.map((s) => s.name);
+      const surveyIds = filteredSurveys.map((s) => s.id);
       logger.debug(
-        `${surveyNames.length.toString()} surveys could be shown to current user on trigger: ${surveyNames.join(", ")}`
+        `${surveyIds.length.toString()} surveys could be shown to current user on trigger: ${surveyIds.join(", ")}`
       );
     } catch {
       logger.debug("Error during sync. Please try again.");
@@ -303,9 +303,9 @@ export const setup = async (
         filteredSurveys,
       });
 
-      const surveyNames = filteredSurveys.map((s) => s.name);
+      const surveyIds = filteredSurveys.map((s) => s.id);
       logger.debug(
-        `${surveyNames.length.toString()} surveys could be shown to current user on trigger: ${surveyNames.join(", ")}`
+        `${surveyIds.length.toString()} surveys could be shown to current user on trigger: ${surveyIds.join(", ")}`
       );
     } catch (e) {
       await handleErrorOnFirstSetup(e as { code: string; responseMessage: string });

--- a/packages/js-core/src/lib/common/tests/utils.test.ts
+++ b/packages/js-core/src/lib/common/tests/utils.test.ts
@@ -279,6 +279,52 @@ describe("utils.ts", () => {
       expect(result).toHaveLength(1);
     });
 
+    test("anonymous user: excludes segment-targeted surveys (new shape: hasFilters=true)", () => {
+      environment.data.surveys = [
+        {
+          ...baseSurvey,
+          id: mockSurveyId1,
+          segment: { id: mockSegmentId1, hasFilters: true },
+          displayOption: "respondMultiple",
+        } as TEnvironmentStateSurvey,
+        {
+          ...baseSurvey,
+          id: mockSurveyId2,
+          segment: { id: mockSegmentId2, hasFilters: false },
+          displayOption: "respondMultiple",
+        } as TEnvironmentStateSurvey,
+      ];
+
+      const result = filterSurveys(environment, user);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(mockSurveyId2);
+    });
+
+    test("anonymous user: excludes segment-targeted surveys when cached payload uses legacy shape (filters array)", () => {
+      // Simulates a localStorage payload written by an older SDK version that
+      // still has `segment.filters` and no `hasFilters`. The defensive check
+      // must fall back to the legacy shape so anonymous users don't receive
+      // segment-targeted surveys.
+      environment.data.surveys = [
+        {
+          ...baseSurvey,
+          id: mockSurveyId1,
+          segment: { id: mockSegmentId1, filters: [{ type: "attribute", value: "plan" }] },
+          displayOption: "respondMultiple",
+        } as unknown as TEnvironmentStateSurvey,
+        {
+          ...baseSurvey,
+          id: mockSurveyId2,
+          segment: { id: mockSegmentId2, filters: [] },
+          displayOption: "respondMultiple",
+        } as unknown as TEnvironmentStateSurvey,
+      ];
+
+      const result = filterSurveys(environment, user);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(mockSurveyId2);
+    });
+
     test("filters by segment if userId is set and user has segments", () => {
       user.data.userId = "user_abc";
       user.data.segments = [mockSegmentId1];

--- a/packages/js-core/src/lib/common/utils.ts
+++ b/packages/js-core/src/lib/common/utils.ts
@@ -123,8 +123,7 @@ export const filterSurveys = (
   if (!userId) {
     // exclude surveys that have a segment with filters
     return filteredSurveys.filter((survey) => {
-      const segmentFiltersLength = survey.segment?.filters.length ?? 0;
-      return segmentFiltersLength === 0;
+      return !(survey.segment?.hasFilters ?? false);
     });
   }
 

--- a/packages/js-core/src/lib/common/utils.ts
+++ b/packages/js-core/src/lib/common/utils.ts
@@ -54,6 +54,19 @@ export const wrapThrowsAsync =
   };
 
 /**
+ * Detect whether a survey's segment has filters. Handles both the current
+ * minimal shape (`{ id, hasFilters }`) and the legacy shape with a `filters`
+ * array — older SDKs cached the full segment in localStorage and may still be
+ * read back here within the cache window after an SDK upgrade.
+ */
+export const surveyHasSegmentFilters = (survey: TEnvironmentStateSurvey): boolean => {
+  const segment = survey.segment as { hasFilters?: boolean; filters?: unknown[] } | null | undefined;
+  if (!segment) return false;
+  if (typeof segment.hasFilters === "boolean") return segment.hasFilters;
+  return Array.isArray(segment.filters) && segment.filters.length > 0;
+};
+
+/**
  * Filters surveys based on the displayOption, recontactDays, and segments
  * @param environmentSate -  The environment state
  * @param userState - The user state
@@ -123,7 +136,7 @@ export const filterSurveys = (
   if (!userId) {
     // exclude surveys that have a segment with filters
     return filteredSurveys.filter((survey) => {
-      return !(survey.segment?.hasFilters ?? false);
+      return !surveyHasSegmentFilters(survey);
     });
   }
 

--- a/packages/js-core/src/lib/survey/tests/__mocks__/widget.mock.ts
+++ b/packages/js-core/src/lib/survey/tests/__mocks__/widget.mock.ts
@@ -8,7 +8,6 @@ export const mockEnvironmentId = "n48a66c01dz05k1297vq06pu";
 
 export const mockSurvey: TEnvironmentStateSurvey = {
   id: mockSurveyId,
-  name: "Test Survey",
   welcomeCard: {
     enabled: false,
     timeToFinish: false,

--- a/packages/js-core/src/lib/survey/tests/widget.test.ts
+++ b/packages/js-core/src/lib/survey/tests/widget.test.ts
@@ -89,7 +89,7 @@ describe("widget-file", () => {
     await widget.triggerSurvey(mockSurvey);
 
     expect(mockLogger.debug).toHaveBeenCalledWith(
-      `Survey display of "${mockSurvey.name}" skipped based on displayPercentage.`
+      `Survey display of "${mockSurvey.id}" skipped based on displayPercentage.`
     );
   });
 
@@ -145,7 +145,7 @@ describe("widget-file", () => {
     await widget.renderWidget(mockSurvey);
 
     expect(mockLogger.debug).toHaveBeenCalledWith(
-      `Delaying survey "${mockSurvey.name}" by ${mockSurvey.delay.toString()} seconds.`
+      `Delaying survey "${mockSurvey.id}" by ${mockSurvey.delay.toString()} seconds.`
     );
 
     vi.advanceTimersByTime(mockSurvey.delay * 1000);
@@ -209,7 +209,7 @@ describe("widget-file", () => {
     await widget.renderWidget(mockSurveyNoDelay as unknown as TEnvironmentStateSurvey);
 
     expect(mockLogger.debug).toHaveBeenCalledWith(
-      `Survey "${mockSurvey.name}" is not available in specified language.`
+      `Survey "${mockSurvey.id}" is not available in specified language.`
     );
   });
 
@@ -456,7 +456,7 @@ describe("widget-file", () => {
     await widget.renderWidget({
       ...mockSurvey,
       delay: 0,
-      segment: { id: "seg_1", filters: [{ type: "attribute", value: "plan" }] },
+      segment: { id: "seg_1", hasFilters: true },
     } as unknown as TEnvironmentStateSurvey);
 
     expect(mockUpdateQueue.waitForPendingWork).toHaveBeenCalled();

--- a/packages/js-core/src/lib/survey/tests/widget.test.ts
+++ b/packages/js-core/src/lib/survey/tests/widget.test.ts
@@ -1,6 +1,7 @@
 import { type Mock, type MockInstance, afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { Config } from "@/lib/common/config";
 import { Logger } from "@/lib/common/logger";
+import type * as CommonUtils from "@/lib/common/utils";
 import { filterSurveys, getLanguageCode, shouldDisplayBasedOnPercentage } from "@/lib/common/utils";
 import { mockSurvey } from "@/lib/survey/tests/__mocks__/widget.mock";
 import * as widget from "@/lib/survey/widget";
@@ -34,14 +35,18 @@ vi.mock("@/lib/common/timeout-stack", () => ({
   },
 }));
 
-vi.mock("@/lib/common/utils", () => ({
-  filterSurveys: vi.fn(),
-  getLanguageCode: vi.fn(),
-  getStyling: vi.fn(),
-  shouldDisplayBasedOnPercentage: vi.fn(),
-  wrapThrowsAsync: vi.fn(),
-  handleHiddenFields: vi.fn(),
-}));
+vi.mock("@/lib/common/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof CommonUtils>();
+  return {
+    ...actual,
+    filterSurveys: vi.fn(),
+    getLanguageCode: vi.fn(),
+    getStyling: vi.fn(),
+    shouldDisplayBasedOnPercentage: vi.fn(),
+    wrapThrowsAsync: vi.fn(),
+    handleHiddenFields: vi.fn(),
+  };
+});
 
 const mockUpdateQueue = {
   hasPendingWork: vi.fn().mockReturnValue(false),
@@ -67,7 +72,6 @@ describe("widget-file", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     document.body.innerHTML = "";
-    // @ts-expect-error -- cleaning up mock
     delete window.formbricksSurveys;
 
     getInstanceConfigMock = vi.spyOn(Config, "getInstance");

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -32,7 +32,7 @@ export const triggerSurvey = async (
   if (survey.displayPercentage) {
     const shouldDisplaySurvey = shouldDisplayBasedOnPercentage(survey.displayPercentage);
     if (!shouldDisplaySurvey) {
-      logger.debug(`Survey display of "${survey.name}" skipped based on displayPercentage.`);
+      logger.debug(`Survey display of "${survey.id}" skipped based on displayPercentage.`);
       return; // skip displaying the survey
     }
   }
@@ -67,7 +67,7 @@ export const renderWidget = async (
     logger.debug("Waiting for pending user identification before rendering survey");
     const identificationSucceeded = await updateQueue.waitForPendingWork();
     if (!identificationSucceeded) {
-      const hasSegmentFilters = Array.isArray(survey.segment?.filters) && survey.segment.filters.length > 0;
+      const hasSegmentFilters = survey.segment?.hasFilters ?? false;
 
       if (hasSegmentFilters) {
         logger.debug("User identification failed. Skipping survey with segment filters.");
@@ -80,7 +80,7 @@ export const renderWidget = async (
   }
 
   if (survey.delay) {
-    logger.debug(`Delaying survey "${survey.name}" by ${survey.delay.toString()} seconds.`);
+    logger.debug(`Delaying survey "${survey.id}" by ${survey.delay.toString()} seconds.`);
   }
 
   const { project } = config.get().environment.data;
@@ -93,7 +93,7 @@ export const renderWidget = async (
     const displayLanguage = getLanguageCode(survey, language);
     //if survey is not available in selected language, survey wont be shown
     if (!displayLanguage) {
-      logger.debug(`Survey "${survey.name}" is not available in specified language.`);
+      logger.debug(`Survey "${survey.id}" is not available in specified language.`);
       setIsSurveyRunning(false);
       return;
     }

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -10,6 +10,7 @@ import {
   getStyling,
   handleHiddenFields,
   shouldDisplayBasedOnPercentage,
+  surveyHasSegmentFilters,
 } from "@/lib/common/utils";
 import { UpdateQueue } from "@/lib/user/update-queue";
 import { type TEnvironmentStateSurvey, type TUserState } from "@/types/config";
@@ -67,7 +68,7 @@ export const renderWidget = async (
     logger.debug("Waiting for pending user identification before rendering survey");
     const identificationSucceeded = await updateQueue.waitForPendingWork();
     if (!identificationSucceeded) {
-      const hasSegmentFilters = survey.segment?.hasFilters ?? false;
+      const hasSegmentFilters = surveyHasSegmentFilters(survey);
 
       if (hasSegmentFilters) {
         logger.debug("User identification failed. Skipping survey with segment filters.");

--- a/packages/js-core/src/types/config.ts
+++ b/packages/js-core/src/types/config.ts
@@ -1,10 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies -- required for Prisma types */
-import type { ActionClass, Language, Project, Segment, Survey, SurveyLanguage } from "@prisma/client";
+import type { ActionClass, Language, Project, Survey, SurveyLanguage } from "@prisma/client";
 
 export type TEnvironmentStateSurvey = Pick<
   Survey,
   | "id"
-  | "name"
+  // name intentionally omitted — internal label, not needed by SDK
   | "welcomeCard"
   | "questions"
   | "variables"
@@ -25,7 +25,8 @@ export type TEnvironmentStateSurvey = Pick<
 > & {
   languages: (SurveyLanguage & { language: Language })[];
   triggers: { actionClass: ActionClass }[];
-  segment?: Segment;
+  // Minimal segment shape — full filter logic is evaluated server-side and must not reach the browser
+  segment?: { id: string; hasFilters: boolean };
   displayPercentage: number;
   type: "link" | "app";
   styling?: TSurveyStyling;

--- a/packages/types/js.ts
+++ b/packages/types/js.ts
@@ -2,12 +2,13 @@ import { z } from "zod";
 import { ZActionClass } from "./action-classes";
 import { ZId } from "./common";
 import { ZProject } from "./project";
+import { ZJsEnvironmentStateSegment } from "./segment";
 import { ZUploadFileConfig } from "./storage";
 import { ZSurveyBase, surveyRefinement } from "./surveys/types";
 
 export const ZJsEnvironmentStateSurvey = ZSurveyBase.pick({
   id: true,
-  name: true,
+  // name intentionally omitted — internal label, not needed by SDK
   welcomeCard: true,
   questions: true,
   blocks: true,
@@ -19,7 +20,7 @@ export const ZJsEnvironmentStateSurvey = ZSurveyBase.pick({
   autoClose: true,
   styling: true,
   status: true,
-  segment: true,
+  // segment intentionally omitted from pick — replaced with minimal shape below
   recontactDays: true,
   displayLimit: true,
   displayOption: true,
@@ -31,9 +32,16 @@ export const ZJsEnvironmentStateSurvey = ZSurveyBase.pick({
   isBackButtonHidden: true,
   isAutoProgressingEnabled: true,
   recaptcha: true,
-}).superRefine((survey, ctx) => {
-  surveyRefinement(survey as z.infer<typeof ZSurveyBase>, ctx);
-});
+})
+  .extend({
+    // Only expose what the SDK needs: segment ID for membership check + whether any filters exist.
+    // Full filter logic (titles, descriptions, conditions) is evaluated server-side and must not
+    // be sent to the browser to avoid leaking sensitive targeting data.
+    segment: ZJsEnvironmentStateSegment.nullable(),
+  })
+  .superRefine((survey, ctx) => {
+    surveyRefinement(survey as z.infer<typeof ZSurveyBase>, ctx);
+  });
 
 export type TJsEnvironmentStateSurvey = z.infer<typeof ZJsEnvironmentStateSurvey>;
 

--- a/packages/types/segment.ts
+++ b/packages/types/segment.ts
@@ -349,6 +349,13 @@ export const ZSegment = z.object({
   surveys: z.array(z.string()),
 });
 
+// Minimal segment shape for the public client API — strips sensitive targeting logic
+export const ZJsEnvironmentStateSegment = z.object({
+  id: z.string(),
+  hasFilters: z.boolean(),
+});
+export type TJsEnvironmentStateSegment = z.infer<typeof ZJsEnvironmentStateSegment>;
+
 export const ZSegmentCreateInput = z.object({
   environmentId: z.string(),
   title: z.string(),


### PR DESCRIPTION
## Summary

- **Closes ENG-858.** A security researcher reported that `GET /api/v1/client/{environmentId}/environment` (the public SDK endpoint) was leaking sensitive data: segment filter conditions, segment titles, segment descriptions, and survey names — all readable by anyone with the environment ID. Filter values can contain enterprise customer names and other confidential targeting data.
- None of these fields are actually needed by the SDK. Segment membership is evaluated server-side; the SDK only needs the resulting segment IDs. The fix strips all four fields and replaces the segment shape with `{ id, hasFilters: boolean }`.
- `survey.name` was only used in `logger.debug` calls — replaced with `survey.id` (same diagnostic value, no info leak).
- `segment.title` and `segment.description` were completely unused across `js-core`, `surveys`, and `survey-ui`.

## Changes

| File | Change |
|---|---|
| `packages/types/segment.ts` | New `ZJsEnvironmentStateSegment` — minimal `{ id, hasFilters }` shape |
| `packages/types/js.ts` | Removed `name` + `segment` from pick, extended with minimal segment type |
| `packages/js-core/src/types/config.ts` | Removed `name` from Prisma Pick, narrowed segment type |
| `apps/web/app/api/v1/client/.../environment/lib/data.ts` | Removed `name` from survey select; switched segment from `include` (all fields) to `select: { id, filters }`; computes `hasFilters` and produces minimal segment |
| `packages/js-core/src/lib/common/utils.ts` | `filters.length` → `hasFilters` |
| `packages/js-core/src/lib/survey/widget.ts` | `filters.length` → `hasFilters`; `survey.name` → `survey.id` in debug logs |
| `packages/js-core/src/lib/common/setup.ts` | `s.name` → `s.id` in debug logs |
| `packages/js-core/src/lib/survey/tests/` | Updated mocks and assertions to match new shapes |

v2 client endpoint is a direct re-export of v1 — no changes needed there.

## Test plan

- [x] `pnpm --filter @formbricks/js-core build` — passes
- [x] `pnpm --filter @formbricks/js-core lint` — 0 errors
- [x] `pnpm --filter @formbricks/js-core test` — 262/262 passing
- [x] `pnpm --filter @formbricks/web lint` — 0 errors
- [x] `data.test.ts` (13 tests) and `environmentState.test.ts` (14 tests) — both green
- [ ] Manual: call `GET /api/v1/client/{environmentId}/environment` and verify surveys have no `name` and segments only contain `{ id, hasFilters }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)