### PR TITLE
fix: omit replicas when HPA is enabled

### DIFF
--- a/charts/formbricks/templates/deployment.yaml
+++ b/charts/formbricks/templates/deployment.yaml
@@ -18,7 +18,7 @@ metadata:
   {{- end }}
   {{- end }}
 spec:
-  {{- if .Values.deployment.replicas }}
+  {{- if and (not .Values.autoscaling.enabled) (not (kindIs "invalid" .Values.deployment.replicas)) }}
   replicas: {{ .Values.deployment.replicas }}
   {{- end }}
   selector:

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -83,7 +83,7 @@ deployment:
   # Additional pod annotations
   additionalPodAnnotations: {}
 
-  # Number of replicas
+  # Number of replicas when autoscaling is disabled
   replicas: 1
 
   # Image pull secrets for private container registries


### PR DESCRIPTION
Fixes ENG-801

## Summary
- omit `Deployment.spec.replicas` from the Formbricks chart when HPA is enabled
- keep rendering explicit replica counts when autoscaling is disabled, including `deployment.replicas: 0`
- clarify that `deployment.replicas` applies when autoscaling is disabled

## Why
Fixes #7916. When HPA is enabled, Kubernetes owns the Deployment replica count. Rendering `spec.replicas` in the desired manifest can cause GitOps tools such as Argo CD to fight HPA-managed scale and report drift.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file("charts/formbricks/values.yaml")'
- `helm lint charts/formbricks --set formbricks.webappUrl=https://formbricks.example.com`
- Rendered HPA-enabled and fixed-replica Helm scenarios locally before publishing.
