### PR TITLE
feat(ai): support Vertex AI ADC credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -183,11 +183,12 @@ AZUREAD_TENANT_ID=
 # Configure Formbricks AI at the instance level
 # Set the provider used for AI features on this instance.
 # Accepted values for AI_PROVIDER: aws, google, azure
-# Set AI_MODEL to the provider-specific model or deployment name and configure the matching credentials below.
+# Set AI_MODEL to the provider-specific model or deployment name and configure the matching provider settings below.
 # AI_PROVIDER=google
 # AI_MODEL=gemini-2.5-flash
 
-# Google Cloud credentials for Gemini models
+# Google Cloud settings for Gemini models
+# Credentials are optional when Application Default Credentials are available.
 # AI_GOOGLE_CLOUD_PROJECT=
 # AI_GOOGLE_CLOUD_LOCATION=
 # AI_GOOGLE_CLOUD_CREDENTIALS_JSON=

--- a/apps/web/lib/env.test.ts
+++ b/apps/web/lib/env.test.ts
@@ -79,6 +79,35 @@ describe("env", () => {
     expect(env.DEBUG_SHOW_RESET_LINK).toBe("1");
   });
 
+  test("allows Google Cloud AI configuration to rely on ADC credentials", async () => {
+    setTestEnv({
+      AI_PROVIDER: "google",
+      AI_MODEL: "gemini-2.5-flash",
+      AI_GOOGLE_CLOUD_PROJECT: "test-project",
+      AI_GOOGLE_CLOUD_LOCATION: "us-central1",
+      AI_GOOGLE_CLOUD_CREDENTIALS_JSON: undefined,
+      AI_GOOGLE_CLOUD_APPLICATION_CREDENTIALS: undefined,
+    });
+
+    const { env } = await import("./env");
+
+    expect(env.AI_PROVIDER).toBe("google");
+    expect(env.AI_GOOGLE_CLOUD_PROJECT).toBe("test-project");
+    expect(env.AI_GOOGLE_CLOUD_LOCATION).toBe("us-central1");
+  });
+
+  test("fails to load when Google Cloud credentials JSON is invalid", async () => {
+    setTestEnv({
+      AI_PROVIDER: "google",
+      AI_MODEL: "gemini-2.5-flash",
+      AI_GOOGLE_CLOUD_PROJECT: "test-project",
+      AI_GOOGLE_CLOUD_LOCATION: "us-central1",
+      AI_GOOGLE_CLOUD_CREDENTIALS_JSON: "{not-json}",
+    });
+
+    await expect(import("./env")).rejects.toThrow("AI_GOOGLE_CLOUD_CREDENTIALS_JSON");
+  });
+
   test("uses the configured Cube environment variables", async () => {
     setTestEnv();
     const { env } = await import("./env");

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -68,14 +68,6 @@ const validateGoogleAIConfiguration = (values: TAIConfigurationEnv, ctx: z.Refin
     );
   }
 
-  if (!values.AI_GOOGLE_CLOUD_CREDENTIALS_JSON && !values.AI_GOOGLE_CLOUD_APPLICATION_CREDENTIALS) {
-    addEnvIssue(
-      ctx,
-      "AI_GOOGLE_CLOUD_CREDENTIALS_JSON",
-      "AI_GOOGLE_CLOUD_CREDENTIALS_JSON or AI_GOOGLE_CLOUD_APPLICATION_CREDENTIALS is required when AI_PROVIDER=google"
-    );
-  }
-
   if (values.AI_GOOGLE_CLOUD_CREDENTIALS_JSON) {
     try {
       const parsedCredentials = JSON.parse(values.AI_GOOGLE_CLOUD_CREDENTIALS_JSON) as unknown;

--- a/packages/ai/src/provider.test.ts
+++ b/packages/ai/src/provider.test.ts
@@ -83,6 +83,30 @@ describe("packages/ai provider helpers", () => {
     });
   });
 
+  test("reports a fully configured Google Cloud instance when ADC provides credentials", () => {
+    expect(
+      getAiConfigurationStatus({
+        AI_PROVIDER: "google",
+        AI_MODEL: "gemini-2.5-flash",
+        AI_GOOGLE_CLOUD_PROJECT: "test-project",
+        AI_GOOGLE_CLOUD_LOCATION: "us-central1",
+      })
+    ).toEqual({
+      provider: "google",
+      model: "gemini-2.5-flash",
+      isConfigured: true,
+      missingFields: [],
+      invalidFields: [],
+      providerStatus: {
+        provider: "google",
+        model: "gemini-2.5-flash",
+        isConfigured: true,
+        missingFields: [],
+        invalidFields: [],
+      },
+    });
+  });
+
   test("treats the instance as not configured when AI_PROVIDER is missing", () => {
     expect(
       isAiConfigured({
@@ -205,6 +229,48 @@ describe("packages/ai provider helpers", () => {
     });
     expect(vertexProvider).toHaveBeenCalledWith("gemini-2.5-flash");
     expect(mocks.createVertex).toHaveBeenCalledTimes(1);
+  });
+
+  test("creates a Google Cloud model with application credentials file", () => {
+    const vertexProvider = createMockProvider("google");
+    mocks.createVertex.mockReturnValue(vertexProvider);
+
+    const model = getAiModel({
+      AI_PROVIDER: "google",
+      AI_MODEL: "gemini-2.5-flash",
+      AI_GOOGLE_CLOUD_PROJECT: "test-project",
+      AI_GOOGLE_CLOUD_LOCATION: "us-central1",
+      AI_GOOGLE_CLOUD_APPLICATION_CREDENTIALS: "/tmp/google-cloud.json",
+    });
+
+    expect(model).toEqual({ providerName: "google", modelName: "gemini-2.5-flash" });
+    expect(mocks.createVertex).toHaveBeenCalledWith({
+      project: "test-project",
+      location: "us-central1",
+      googleAuthOptions: {
+        keyFilename: "/tmp/google-cloud.json",
+      },
+    });
+    expect(vertexProvider).toHaveBeenCalledWith("gemini-2.5-flash");
+  });
+
+  test("creates a Google Cloud model using ADC when no credential override is configured", () => {
+    const vertexProvider = createMockProvider("google");
+    mocks.createVertex.mockReturnValue(vertexProvider);
+
+    const model = getAiModel({
+      AI_PROVIDER: "google",
+      AI_MODEL: "gemini-2.5-flash",
+      AI_GOOGLE_CLOUD_PROJECT: "test-project",
+      AI_GOOGLE_CLOUD_LOCATION: "us-central1",
+    });
+
+    expect(model).toEqual({ providerName: "google", modelName: "gemini-2.5-flash" });
+    expect(mocks.createVertex).toHaveBeenCalledWith({
+      project: "test-project",
+      location: "us-central1",
+    });
+    expect(vertexProvider).toHaveBeenCalledWith("gemini-2.5-flash");
   });
 
   test("creates an AWS model with explicit AWS credentials", () => {

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -39,11 +39,6 @@ export const googleProviderAdapter: AIProviderAdapter = {
     }
 
     const credentialsJson = normalizeValue(environment.AI_GOOGLE_CLOUD_CREDENTIALS_JSON);
-    const applicationCredentials = normalizeValue(environment.AI_GOOGLE_CLOUD_APPLICATION_CREDENTIALS);
-
-    if (!credentialsJson && !applicationCredentials) {
-      missingFields.push("AI_GOOGLE_CLOUD_CREDENTIALS_JSON or AI_GOOGLE_CLOUD_APPLICATION_CREDENTIALS");
-    }
 
     if (credentialsJson) {
       try {
@@ -73,15 +68,12 @@ export const googleProviderAdapter: AIProviderAdapter = {
     const credentialsJson = normalizeValue(environment.AI_GOOGLE_CLOUD_CREDENTIALS_JSON);
     const applicationCredentials = normalizeValue(environment.AI_GOOGLE_CLOUD_APPLICATION_CREDENTIALS);
 
-    if (!project || !location || (!credentialsJson && !applicationCredentials)) {
-      throw new AIConfigurationError("providerNotConfigured", "Google Cloud AI credentials are incomplete", {
+    if (!project || !location) {
+      throw new AIConfigurationError("providerNotConfigured", "Google Cloud AI configuration is incomplete", {
         provider: "google",
         missingFields: [
           ...(!project ? ["AI_GOOGLE_CLOUD_PROJECT"] : []),
           ...(!location ? ["AI_GOOGLE_CLOUD_LOCATION"] : []),
-          ...(!credentialsJson && !applicationCredentials
-            ? ["AI_GOOGLE_CLOUD_CREDENTIALS_JSON or AI_GOOGLE_CLOUD_APPLICATION_CREDENTIALS"]
-            : []),
         ],
       });
     }


### PR DESCRIPTION
## Summary
- Allow the Google Vertex AI provider to use Application Default Credentials (ADC) / Workload Identity when explicit credential env vars are not set.
- Keep `AI_GOOGLE_CLOUD_CREDENTIALS_JSON` and `AI_GOOGLE_CLOUD_APPLICATION_CREDENTIALS` as optional overrides for deployments that need key-based auth.
- Keep fail-closed validation for required routing config and malformed credential JSON.
- Add coverage for JSON credentials, application credential files, ADC-only config, and invalid JSON.

## Decision Rationale
The previous validation required either `AI_GOOGLE_CLOUD_CREDENTIALS_JSON` or `AI_GOOGLE_CLOUD_APPLICATION_CREDENTIALS` whenever `AI_PROVIDER=google`. That works for deployments using service-account keys, but it rejects valid Google Cloud deployments that intentionally avoid long-lived keys.

For an open-source/self-hostable project, Google auth should support the standard ADC chain. This covers GKE Workload Identity, Cloud Run / GCE metadata credentials, and local developer setups using `gcloud auth application-default login`. The app cannot reliably detect ADC availability during env parsing, so requiring explicit credential env vars at startup would block secure and supported deployments.

This PR only removes the hard requirement for explicit credential env vars. It still requires `AI_GOOGLE_CLOUD_PROJECT` and `AI_GOOGLE_CLOUD_LOCATION`, because Vertex AI model routing cannot be inferred safely. It also still validates `AI_GOOGLE_CLOUD_CREDENTIALS_JSON` when provided, so malformed JSON fails closed instead of silently falling back to ADC when an operator intended explicit credentials.

## Operator Impact
For Google Cloud runtimes with ADC / Workload Identity, configure:
- `AI_PROVIDER=google`
- `AI_MODEL=<vertex-model>`
- `AI_GOOGLE_CLOUD_PROJECT=<project-id>`
- `AI_GOOGLE_CLOUD_LOCATION=<vertex-region>`

For deployments outside Google Cloud, or where ADC is not available, also configure one of:
- `AI_GOOGLE_CLOUD_CREDENTIALS_JSON`
- `AI_GOOGLE_CLOUD_APPLICATION_CREDENTIALS`

## Validation
- `pnpm --filter @formbricks/ai test`
- `pnpm --dir apps/web exec dotenv -e ../../.env -- vitest run lib/ai/service.test.ts lib/env.test.ts`

Linear: https://linear.app/formbricks/issue/ENG-843/setup-llm-provider-for-formbricks-cloud-euksa
