### PR TITLE
refactor: rename gethasNoOrganizations to getHasNoOrganizations

### DIFF
--- a/apps/web/app/setup/organization/create/actions.ts
+++ b/apps/web/app/setup/organization/create/actions.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { logger } from "@formbricks/logger";
 import { OperationNotAllowedError } from "@formbricks/types/errors";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
-import { gethasNoOrganizations } from "@/lib/instance/service";
+import { getHasNoOrganizations } from "@/lib/instance/service";
 import { createMembership } from "@/lib/membership/service";
 import { createOrganization } from "@/lib/organization/service";
 import { capturePostHogEvent } from "@/lib/posthog";
@@ -21,7 +21,7 @@ export const createOrganizationAction = authenticatedActionClient
   .inputSchema(ZCreateOrganizationAction)
   .action(
     withAuditLogging("created", "organization", async ({ ctx, parsedInput }) => {
-      const hasNoOrganizations = await gethasNoOrganizations();
+      const hasNoOrganizations = await getHasNoOrganizations();
       const isMultiOrgEnabled = await getIsMultiOrgEnabled();
 
       if (!hasNoOrganizations && !isMultiOrgEnabled) {

--- a/apps/web/app/setup/page.tsx
+++ b/apps/web/app/setup/page.tsx
@@ -1,13 +1,13 @@
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
-import { getIsFreshInstance, gethasNoOrganizations } from "@/lib/instance/service";
+import { getHasNoOrganizations, getIsFreshInstance } from "@/lib/instance/service";
 import { authOptions } from "@/modules/auth/lib/authOptions";
 
 const Page = async () => {
   const [session, isFreshInstance, hasNoOrganizations] = await Promise.all([
     getServerSession(authOptions),
     getIsFreshInstance(),
-    gethasNoOrganizations(),
+    getHasNoOrganizations(),
   ]);
 
   if (isFreshInstance) {

--- a/apps/web/lib/instance/service.ts
+++ b/apps/web/lib/instance/service.ts
@@ -19,7 +19,7 @@ export const getIsFreshInstance = reactCache(async (): Promise<boolean> => {
 });
 
 // Function to check if there are any organizations in the database
-export const gethasNoOrganizations = reactCache(async (): Promise<boolean> => {
+export const getHasNoOrganizations = reactCache(async (): Promise<boolean> => {
   try {
     const organizationCount = await prisma.organization.count();
     return organizationCount === 0;

--- a/apps/web/modules/setup/(fresh-instance)/layout.tsx
+++ b/apps/web/modules/setup/(fresh-instance)/layout.tsx
@@ -1,6 +1,6 @@
 import { getServerSession } from "next-auth";
 import { notFound, redirect } from "next/navigation";
-import { getIsFreshInstance, gethasNoOrganizations } from "@/lib/instance/service";
+import { getHasNoOrganizations, getIsFreshInstance } from "@/lib/instance/service";
 import { authOptions } from "@/modules/auth/lib/authOptions";
 
 export const FreshInstanceLayout = async ({ children }: { children: React.ReactNode }) => {
@@ -8,7 +8,7 @@ export const FreshInstanceLayout = async ({ children }: { children: React.ReactN
   const isFreshInstance = await getIsFreshInstance();
 
   if (!isFreshInstance) {
-    const hasNoOrganizations = await gethasNoOrganizations();
+    const hasNoOrganizations = await getHasNoOrganizations();
 
     if (hasNoOrganizations) {
       if (session) {

--- a/apps/web/modules/setup/organization/create/page.tsx
+++ b/apps/web/modules/setup/organization/create/page.tsx
@@ -3,7 +3,7 @@ import { getServerSession } from "next-auth";
 import { notFound } from "next/navigation";
 import { AuthenticationError } from "@formbricks/types/errors";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
-import { gethasNoOrganizations } from "@/lib/instance/service";
+import { getHasNoOrganizations } from "@/lib/instance/service";
 import { getOrganizationsByUserId } from "@/lib/organization/service";
 import { getUser } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
@@ -29,7 +29,7 @@ export const CreateOrganizationPage = async () => {
     return <ClientLogout />;
   }
 
-  const hasNoOrganizations = await gethasNoOrganizations();
+  const hasNoOrganizations = await getHasNoOrganizations();
   const isMultiOrgEnabled = await getIsMultiOrgEnabled();
   const userOrganizations = await getOrganizationsByUserId(session.user.id);
 


### PR DESCRIPTION
## Summary
- Renames the helper exported from `apps/web/lib/instance/service.ts` to use camelCase, matching the project convention.
- Updates all four call sites (setup page, fresh-instance layout, create-organization action, create-organization page).
- Pure rename — no behavior change.

## Why
Picked up while reviewing #7912. The function name `gethasNoOrganizations` (lowercase `h`) violates the camelCase convention used elsewhere in the codebase. Aligning the source name keeps every call site consistent rather than scattering local aliases.

## Test plan
- [ ] Typecheck passes for the touched files
- [ ] No remaining references to the old name (verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)