### PR TITLE
fix: use block terminology in conditional logic docs

### DIFF
--- a/docs/xm-and-surveys/surveys/general-features/conditional-logic.mdx
+++ b/docs/xm-and-surveys/surveys/general-features/conditional-logic.mdx
@@ -87,14 +87,14 @@ Action is of the following types:
   
   ![Action Require](/images/xm-and-surveys/surveys/general-features/conditional-logic/action-require.webp)
 
-  * **Jump to Question**: Skip to a specific question. The user will be redirected to the specified question based on the condition.
+  * **Jump to Block**: Skip to a specific block. The user will be redirected to the specified block based on the condition.
   
   ![Action Jump](/images/xm-and-surveys/surveys/general-features/conditional-logic/action-jump.webp)
 
 * **Save Logic**: Click the `Save` button to save the logic block.
 
-## Question Logic
+## Block Logic
 
-This logic is executed when the user answers the question. Logic can be as simple as showing a follow-up question based on the answer or as complex as calculating a score based on multiple answers.
+This logic is executed when the user reaches the block. Logic can be as simple as showing a follow-up block based on earlier answers or as complex as calculating a score based on multiple answers.
 
-![Question Logic](/images/xm-and-surveys/surveys/general-features/conditional-logic/question-logic.webp)
+![Block Logic](/images/xm-and-surveys/surveys/general-features/conditional-logic/question-logic.webp)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Updates Conditional Logic documentation to consistently use block-based terminology instead of question-based terminology where logic targets are described.

Specifically in `docs/xm-and-surveys/surveys/general-features/conditional-logic.mdx`:
- Renamed action label from **Jump to Question** to **Jump to Block**
- Updated action description to refer to redirecting to a block
- Renamed section heading from **Question Logic** to **Block Logic**
- Updated section description and image alt text to block terminology

Fixes #(issue)

## How should this be tested?

- Open `docs/xm-and-surveys/surveys/general-features/conditional-logic.mdx` and confirm block terminology is used for jump/logic naming
- Run grep checks to confirm no stale wording remains:
  - `rg -i "jump\s+to\s+(a\s+)?(specific\s+)?question" docs --glob "*.mdx"`
  - `rg -i "question logic" docs --glob "*.mdx"`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ce32a38-aef5-4032-919e-63b143b1eabc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ce32a38-aef5-4032-919e-63b143b1eabc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

