### PR TITLE
fix: make HUB_API_URL optional in env validation

### DIFF
--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -196,7 +196,7 @@ const parsedEnv = createEnv({
     CUBEJS_JWT_ISSUER: ZOptionalNonEmptyString,
     HTTP_PROXY: z.url().optional(),
     HTTPS_PROXY: z.url().optional(),
-    HUB_API_URL: z.url(),
+    HUB_API_URL: z.url().optional(),
     HUB_API_KEY: z.string().optional(),
     IMPRINT_URL: z
       .url()


### PR DESCRIPTION
## Summary

- Makes `HUB_API_URL` optional (`z.url().optional()`) in the Zod env validation schema, matching `HUB_API_KEY` next to it
- Fixes the `5.0.0-beta.1` Docker release build failure where `HUB_API_URL` is not available at build time
- Also fixes local `pnpm go` failing when `HUB_API_URL` is not set in `.env`

## Context

The [CI failure](https://github.com/formbricks/formbricks/actions/runs/25489717185/job/74794361737) in the community Docker release build was caused by:

```
❌ Invalid environment variables: [
  { expected: 'string', code: 'invalid_type', path: [ 'HUB_API_URL' ],
    message: 'Invalid input: expected string, received undefined' }
]
```

`HUB_API_URL` is a runtime config (pointing to the Hub service) and should not be required at build time.

## Test plan

- [ ] Verify `pnpm go` works without `HUB_API_URL` in `.env`
- [ ] Verify Docker build succeeds without `HUB_API_URL` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)