### PR TITLE
feat: add internal cube helm deployment

### DIFF
--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -48,10 +48,14 @@ The intended defaults are:
 
 ## Cube.js for XM Suite v5
 
-This chart does not deploy Cube.js. XM Suite v5 dashboard and analysis features require an external Cube instance.
+XM Suite v5 dashboard and analysis features require Cube.js. Set `cube.enabled=true` to deploy an
+internal Cube service from this chart, or provide an external Cube endpoint.
 
-- Set `deployment.env.CUBEJS_API_URL` to your Cube endpoint.
+- For chart-managed Cube, set `deployment.env.CUBEJS_API_URL` to `http://formbricks-cube:4000`
+  when using the default release name.
+- For external Cube, set `deployment.env.CUBEJS_API_URL` to your Cube endpoint.
 - Provide `CUBEJS_API_SECRET` through your existing secret management flow, such as the generated app secret override or `deployment.envFrom`.
+- Provide `CUBEJS_DB_*` connection variables to the Cube deployment through `cube.envFrom` or `cube.env`.
 - Keep Hub enabled. Cube should point at the same feedback records database that Hub writes to, unless you intentionally split that storage.
 
 ## Hub worker and self-hosted embeddings

--- a/charts/formbricks/cube/cube.js
+++ b/charts/formbricks/cube/cube.js
@@ -1,0 +1,174 @@
+/* eslint-env es2022 */
+
+const TENANT_MEMBER = "FeedbackRecords.tenantId";
+const REQUIRED_SCOPE = "xm:cube:query";
+
+function assertRequiredEnvironmentVariable(name) {
+  const value = process.env[name];
+
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} is required to run Cube`);
+  }
+}
+
+assertRequiredEnvironmentVariable("CUBEJS_API_SECRET");
+
+function getStringClaim(securityContext, claim) {
+  const value = securityContext?.[claim];
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmedValue = value.trim();
+  return trimmedValue.length > 0 ? trimmedValue : null;
+}
+
+function getRequiredStringClaim(securityContext, claim) {
+  const value = getStringClaim(securityContext, claim);
+
+  if (!value) {
+    throw new Error(`Cube query rejected: missing ${claim} security context`);
+  }
+
+  return value;
+}
+
+function collectFilterMembers(filters) {
+  if (!Array.isArray(filters)) {
+    return [];
+  }
+
+  return filters.flatMap((filter) => [
+    ...(typeof filter?.member === "string" ? [filter.member] : []),
+    ...(typeof filter?.dimension === "string" ? [filter.dimension] : []),
+    ...collectFilterMembers(filter?.and),
+    ...collectFilterMembers(filter?.or),
+  ]);
+}
+
+function collectOrderMembers(order) {
+  if (!order) {
+    return [];
+  }
+
+  if (Array.isArray(order)) {
+    return order
+      .map((orderEntry) => (Array.isArray(orderEntry) ? orderEntry[0] : null))
+      .filter((member) => typeof member === "string");
+  }
+
+  if (typeof order === "object") {
+    return Object.keys(order);
+  }
+
+  return [];
+}
+
+function collectTimeDimensionMembers(timeDimensions) {
+  if (!Array.isArray(timeDimensions)) {
+    return [];
+  }
+
+  return timeDimensions
+    .map((timeDimension) => timeDimension?.dimension)
+    .filter((dimension) => typeof dimension === "string");
+}
+
+function collectQueryMembers(query) {
+  const cubeQuery = query ?? {};
+  const members = [
+    ...(Array.isArray(cubeQuery.measures) ? cubeQuery.measures : []),
+    ...(Array.isArray(cubeQuery.dimensions) ? cubeQuery.dimensions : []),
+    ...(Array.isArray(cubeQuery.segments) ? cubeQuery.segments : []),
+    ...collectTimeDimensionMembers(cubeQuery.timeDimensions),
+    ...collectFilterMembers(cubeQuery.filters),
+    ...collectOrderMembers(cubeQuery.order),
+  ].filter((member) => typeof member === "string");
+
+  return Array.from(new Set(members)).sort((a, b) => a.localeCompare(b));
+}
+
+function assertValidSecurityContext(securityContext) {
+  const tenantId = getRequiredStringClaim(securityContext, "tenantId");
+  const feedbackDirectoryId = getRequiredStringClaim(securityContext, "feedbackDirectoryId");
+  const workspaceId = getRequiredStringClaim(securityContext, "workspaceId");
+  const scope = getRequiredStringClaim(securityContext, "scope");
+
+  if (scope !== REQUIRED_SCOPE) {
+    throw new Error("Cube query rejected: invalid Cube query scope");
+  }
+  if (tenantId !== feedbackDirectoryId) {
+    throw new Error("Cube query rejected: tenantId/feedbackDirectoryId mismatch");
+  }
+
+  return {
+    tenantId,
+    feedbackDirectoryId,
+    workspaceId,
+    organizationId: getRequiredStringClaim(securityContext, "organizationId"),
+    userId: getRequiredStringClaim(securityContext, "userId"),
+    requestId: getRequiredStringClaim(securityContext, "jti"),
+    source: getRequiredStringClaim(securityContext, "source"),
+  };
+}
+
+function assertNoCallerTenantMember(query) {
+  for (const member of collectQueryMembers(query)) {
+    if (member === TENANT_MEMBER) {
+      throw new Error("Cube query rejected: tenant filters are enforced by Cube");
+    }
+  }
+}
+
+function logCubeQueryAuditEvent(context, query, { error, status = "success" } = {}) {
+  const errorName = error instanceof Error ? error.name : undefined;
+
+  console.log(
+    JSON.stringify({
+      type: "audit",
+      event: "cube.query",
+      status,
+      timestamp: new Date().toISOString(),
+      tenantId: context.tenantId,
+      feedbackDirectoryId: context.feedbackDirectoryId,
+      workspaceId: context.workspaceId,
+      organizationId: context.organizationId,
+      userId: context.userId,
+      requestId: context.requestId,
+      source: context.source,
+      members: collectQueryMembers(query),
+      ...(errorName ? { errorName } : {}),
+    })
+  );
+}
+
+function queryRewrite(query, rewriteContext) {
+  const cubeQuery = query ?? {};
+  const context = assertValidSecurityContext(rewriteContext?.securityContext);
+
+  try {
+    assertNoCallerTenantMember(cubeQuery);
+  } catch (error) {
+    logCubeQueryAuditEvent(context, cubeQuery, { error, status: "failure" });
+    throw error;
+  }
+
+  const rewrittenQuery = {
+    ...cubeQuery,
+    filters: [
+      ...(Array.isArray(cubeQuery.filters) ? cubeQuery.filters : []),
+      {
+        member: TENANT_MEMBER,
+        operator: "equals",
+        values: [context.tenantId],
+      },
+    ],
+  };
+
+  logCubeQueryAuditEvent(context, rewrittenQuery);
+  return rewrittenQuery;
+}
+
+module.exports = {
+  queryRewrite,
+};

--- a/charts/formbricks/cube/schema/FeedbackRecords.js
+++ b/charts/formbricks/cube/schema/FeedbackRecords.js
@@ -1,0 +1,165 @@
+// This schema maps to the `feedback_records` table owned by the Formbricks Hub Postgres.
+// If the Hub changes column names, types, or the metadata JSONB shape (e.g. the `topics` array),
+// this schema must be updated to match.
+cube(`FeedbackRecords`, {
+  sql: `SELECT * FROM feedback_records`,
+
+  measures: {
+    count: {
+      type: `count`,
+      description: `Total number of feedback responses`,
+    },
+
+    promoterCount: {
+      type: `count`,
+      filters: [{ sql: `${CUBE}.value_number >= 9` }],
+      description: `Number of promoters (NPS score 9-10)`,
+    },
+
+    detractorCount: {
+      type: `count`,
+      filters: [{ sql: `${CUBE}.value_number >= 0 AND ${CUBE}.value_number <= 6` }],
+      description: `Number of detractors (NPS score 0-6)`,
+    },
+
+    passiveCount: {
+      type: `count`,
+      filters: [{ sql: `${CUBE}.value_number >= 7 AND ${CUBE}.value_number <= 8` }],
+      description: `Number of passives (NPS score 7-8)`,
+    },
+
+    npsScore: {
+      type: `number`,
+      sql: `
+        CASE
+          WHEN COUNT(*) = 0 THEN 0
+          ELSE ROUND(
+            (
+              (COUNT(CASE WHEN ${CUBE}.value_number >= 9 THEN 1 END)::numeric -
+               COUNT(CASE WHEN ${CUBE}.value_number <= 6 THEN 1 END)::numeric)
+              / COUNT(*)::numeric
+            ) * 100,
+            2
+          )
+        END
+      `,
+      description: `Net Promoter Score: ((Promoters - Detractors) / Total) * 100`,
+    },
+
+    averageScore: {
+      type: `avg`,
+      sql: `${CUBE}.value_number`,
+      description: `Average NPS score`,
+    },
+  },
+
+  dimensions: {
+    id: {
+      sql: `id`,
+      type: `string`,
+      primaryKey: true,
+    },
+
+    sentiment: {
+      sql: `sentiment`,
+      type: `string`,
+      description: `Sentiment extracted from metadata JSONB field`,
+    },
+
+    sourceType: {
+      sql: `source_type`,
+      type: `string`,
+      description: `Source type of the feedback (e.g., nps_campaign, survey)`,
+    },
+
+    sourceName: {
+      sql: `source_name`,
+      type: `string`,
+      description: `Human-readable name of the source`,
+    },
+
+    fieldType: {
+      sql: `field_type`,
+      type: `string`,
+      description: `Type of feedback field (e.g., nps, text, rating)`,
+    },
+
+    collectedAt: {
+      sql: `collected_at`,
+      type: `time`,
+      description: `Timestamp when the feedback was collected`,
+    },
+
+    npsValue: {
+      sql: `value_number`,
+      type: `number`,
+      description: `Raw NPS score value (0-10)`,
+    },
+
+    responseId: {
+      sql: `response_id`,
+      type: `string`,
+      description: `Unique identifier linking related feedback records`,
+    },
+
+    userId: {
+      sql: `user_id`,
+      type: `string`,
+      description: `Identifier of the user who provided feedback`,
+    },
+
+    emotion: {
+      sql: `emotion`,
+      type: `string`,
+      description: `Emotion extracted from metadata JSONB field`,
+    },
+
+    tenantId: {
+      sql: `tenant_id`,
+      type: `string`,
+      description: `Tenant ID linking to FeedbackDirectory`,
+    },
+  },
+
+  joins: {
+    TopicsUnnested: {
+      sql: `${CUBE}.id = ${TopicsUnnested}.feedback_record_id`,
+      relationship: `hasMany`,
+    },
+  },
+});
+
+cube(`TopicsUnnested`, {
+  sql: `
+    SELECT
+      fr.id as feedback_record_id,
+      topic_elem.topic
+    FROM feedback_records fr
+    CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(fr.metadata->'topics', '[]'::jsonb)) AS topic_elem(topic)
+  `,
+
+  measures: {
+    count: {
+      type: `count`,
+    },
+  },
+
+  dimensions: {
+    id: {
+      sql: `md5(feedback_record_id || '::' || topic)`,
+      type: `string`,
+      primaryKey: true,
+    },
+
+    feedbackRecordId: {
+      sql: `feedback_record_id`,
+      type: `string`,
+    },
+
+    topic: {
+      sql: `topic`,
+      type: `string`,
+      description: `Individual topic from the topics array`,
+    },
+  },
+});

--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -15,6 +15,14 @@ Hub resource name: base name truncated to 59 chars then "-hub" so the suffix is 
 {{- printf "%s-hub" $base | trimSuffix "-" }}
 {{- end }}
 
+{{/*
+Cube.js resource name.
+*/}}
+{{- define "formbricks.cubeName" -}}
+{{- $base := include "formbricks.name" . | trunc 58 | trimSuffix "-" }}
+{{- printf "%s-cube" $base | trimSuffix "-" }}
+{{- end }}
+
 
 {{/*
 Define the application version to be used in labels.

--- a/charts/formbricks/templates/cube-configmap.yaml
+++ b/charts/formbricks/templates/cube-configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.cube.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "formbricks.cubeName" . }}-config
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.cubeName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: cube
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+data:
+  cube.js: |-
+{{ .Files.Get "cube/cube.js" | indent 4 }}
+  FeedbackRecords.js: |-
+{{ .Files.Get "cube/schema/FeedbackRecords.js" | indent 4 }}
+{{- end }}

--- a/charts/formbricks/templates/cube-deployment.yaml
+++ b/charts/formbricks/templates/cube-deployment.yaml
@@ -1,0 +1,108 @@
+{{- if .Values.cube.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "formbricks.cubeName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.cubeName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: cube
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+spec:
+  replicas: {{ .Values.cube.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "formbricks.cubeName" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "formbricks.cubeName" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: cube
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/cube-configmap.yaml") . | sha256sum }}
+    spec:
+      {{- if .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.deployment.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cube.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cube.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cube.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cube.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: cube
+          image: "{{ .Values.cube.image.repository }}:{{ .Values.cube.image.tag }}"
+          imagePullPolicy: {{ .Values.cube.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.cube.port }}
+              protocol: TCP
+          {{- if .Values.cube.envFrom }}
+          envFrom:
+            {{- range $value := .Values.cube.envFrom }}
+            {{- if (eq .type "configmap") }}
+            - configMapRef:
+                {{- if .name }}
+                name: {{ include "formbricks.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
+                {{- else if .nameSuffix }}
+                name: {{ template "formbricks.name" $ }}-{{ include "formbricks.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
+                {{- else }}
+                name: {{ template "formbricks.name" $ }}
+                {{- end }}
+            {{- end }}
+            {{- if (eq .type "secret") }}
+            - secretRef:
+                {{- if .name }}
+                name: {{ include "formbricks.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
+                {{- else if .nameSuffix }}
+                name: {{ template "formbricks.name" $ }}-{{ include "formbricks.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
+                {{- else }}
+                name: {{ template "formbricks.name" $ }}
+                {{- end }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          env:
+            {{- range $key, $value := .Values.cube.env }}
+            - name: {{ include "formbricks.tplvalues.render" ( dict "value" $key "context" $ ) }}
+              {{- if kindIs "string" $value }}
+              value: {{ include "formbricks.tplvalues.render" ( dict "value" $value "context" $ ) | quote }}
+              {{- else }}
+              {{- toYaml $value | nindent 14 }}
+              {{- end }}
+            {{- end }}
+          volumeMounts:
+            - name: cube-config
+              mountPath: /cube/conf/cube.js
+              subPath: cube.js
+              readOnly: true
+            - name: cube-config
+              mountPath: /cube/conf/model/FeedbackRecords.js
+              subPath: FeedbackRecords.js
+              readOnly: true
+          {{- if .Values.cube.resources }}
+          resources:
+            {{- toYaml .Values.cube.resources | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: cube-config
+          configMap:
+            name: {{ include "formbricks.cubeName" . }}-config
+{{- end }}

--- a/charts/formbricks/templates/cube-service.yaml
+++ b/charts/formbricks/templates/cube-service.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.cube.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "formbricks.cubeName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.cubeName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: cube
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+spec:
+  type: {{ .Values.cube.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "formbricks.cubeName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.cube.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -558,6 +558,48 @@ serviceMonitor:
       port: metrics
 
 ##########################################################
+# Cube.js Analytics Configuration
+##########################################################
+cube:
+  # Optional internal Cube.js service for XM Suite v5 analytics.
+  enabled: false
+  replicas: 1
+
+  image:
+    repository: "cubejs/cube"
+    tag: "v1.6.6"
+    pullPolicy: IfNotPresent
+
+  port: 4000
+
+  service:
+    type: ClusterIP
+    port: 4000
+
+  # Secret values such as CUBEJS_API_SECRET and CUBEJS_DB_* should be supplied
+  # through envFrom or another secret-management flow.
+  envFrom: []
+
+  env:
+    CUBEJS_DB_TYPE: "postgres"
+    CUBEJS_DEFAULT_API_SCOPES: "meta,data"
+    CUBEJS_CACHE_AND_QUEUE_DRIVER: "memory"
+    CUBEJS_JWT_ISSUER: "formbricks-web"
+    CUBEJS_JWT_AUDIENCE: "formbricks-cube"
+
+  resources:
+    limits:
+      memory: 1Gi
+    requests:
+      memory: 512Mi
+      cpu: "250m"
+
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+
+##########################################################
 # Hub API Configuration
 # Formbricks Hub image: ghcr.io/formbricks/hub
 ##########################################################
@@ -830,8 +872,9 @@ hub:
     affinity: {}
     topologySpreadConstraints: []
 
-  # Helm does not deploy Cube. XM Suite v5 analytics requires operators to provide an external Cube instance,
-  # set deployment.env.CUBEJS_API_URL, and supply CUBEJS_API_SECRET via an existing secret.
+  # XM Suite v5 analytics also requires Cube. Use cube.enabled=true to deploy
+  # the internal chart-managed Cube service, or set deployment.env.CUBEJS_API_URL
+  # to an operator-managed Cube endpoint.
 
   # Upgrade migration job runs goose + river before Helm upgrades Hub resources.
   # Fresh installs run the same migrations through the Hub deployment init container.


### PR DESCRIPTION
What changed:
- Adds optional chart-managed Cube.js resources for XM Suite v5 analytics.
- Deploys Cube as an internal ClusterIP service using the existing tenant-scoped Cube config and schema.
- Keeps support for external Cube endpoints.
- Updates Helm docs for Cube wiring and required secrets.

Tested:
- helm lint charts/formbricks --set cube.enabled=true --set deployment.env.CUBEJS_API_URL=http://formbricks-cube:4000 --set secret.enabled=false --set externalSecret.enabled=true --set externalSecret.files.app-secrets.dataFrom.key=stage/formbricks
- helm template formbricks-stage /Users/bhagya/work/formbricks/formbricks/charts/formbricks -f /Users/bhagya/work/formbricks/gitops/formbricks/values-stage.yaml

Notes:
- Companion GitOps staging wiring is in https://github.com/formbricks/gitops/pull/114.
- Secrets stay in AWS Secrets Manager.
