### PR TITLE
fix: address Cube chart review feedback

### DIFF
--- a/apps/web/modules/ee/analysis/api/lib/cube-query-rewrite.test.ts
+++ b/apps/web/modules/ee/analysis/api/lib/cube-query-rewrite.test.ts
@@ -215,9 +215,21 @@ describe("cube queryRewrite", () => {
     expect(rewrittenQuery.filters).toEqual([
       { member: "FeedbackRecords.sentiment", operator: "equals", values: ["positive"] },
       { member: "FeedbackRecords.tenantId", operator: "equals", values: ["frd-1"] },
-      { member: "TopicsUnnested.tenantId", operator: "equals", values: ["frd-1"] },
     ]);
     expect(query.filters).toHaveLength(1);
+  });
+
+  test("appends only the TopicsUnnested tenant filter for TopicsUnnested queries", () => {
+    const query = {
+      measures: ["TopicsUnnested.count"],
+      dimensions: ["TopicsUnnested.topic"],
+    };
+
+    const rewrittenQuery = queryRewrite(query, { securityContext });
+
+    expect(rewrittenQuery.filters).toEqual([
+      { member: "TopicsUnnested.tenantId", operator: "equals", values: ["frd-1"] },
+    ]);
   });
 
   test("logs sanitized Cube audit metadata without raw filter values", () => {
@@ -244,7 +256,7 @@ describe("cube queryRewrite", () => {
       source: "charts.executeQueryAction",
     });
     expect(parsed.members).toContain("FeedbackRecords.tenantId");
-    expect(parsed.members).toContain("TopicsUnnested.tenantId");
+    expect(parsed.members).not.toContain("TopicsUnnested.tenantId");
     expect(logPayload).not.toContain("secret-value");
   });
 });

--- a/apps/web/modules/ee/analysis/api/lib/cube-query-rewrite.test.ts
+++ b/apps/web/modules/ee/analysis/api/lib/cube-query-rewrite.test.ts
@@ -36,6 +36,16 @@ describe("cube queryRewrite", () => {
     expect(() => queryRewrite({ measures: ["FeedbackRecords.count"] }, {})).toThrow(
       /missing tenantId security context/
     );
+
+    const logPayload = vi.mocked(console.log).mock.calls[0][0];
+    const parsed = JSON.parse(logPayload);
+    expect(parsed).toMatchObject({
+      type: "audit",
+      event: "cube.query",
+      status: "failure",
+      errorName: "Error",
+      errorMessage: "Cube query rejected: missing tenantId security context",
+    });
   });
 
   test("rejects Cube startup without an API secret", () => {
@@ -91,6 +101,18 @@ describe("cube queryRewrite", () => {
         {
           measures: ["FeedbackRecords.count"],
           filters: [{ member: "FeedbackRecords.tenantId", operator: "equals", values: ["workspace-2"] }],
+        },
+        { securityContext }
+      )
+    ).toThrow(/tenant filters are enforced by Cube/);
+  });
+
+  test("rejects caller-supplied TopicsUnnested tenant filters", () => {
+    expect(() =>
+      queryRewrite(
+        {
+          measures: ["TopicsUnnested.count"],
+          filters: [{ member: "TopicsUnnested.tenantId", operator: "equals", values: ["workspace-2"] }],
         },
         { securityContext }
       )
@@ -193,6 +215,7 @@ describe("cube queryRewrite", () => {
     expect(rewrittenQuery.filters).toEqual([
       { member: "FeedbackRecords.sentiment", operator: "equals", values: ["positive"] },
       { member: "FeedbackRecords.tenantId", operator: "equals", values: ["frd-1"] },
+      { member: "TopicsUnnested.tenantId", operator: "equals", values: ["frd-1"] },
     ]);
     expect(query.filters).toHaveLength(1);
   });
@@ -221,6 +244,7 @@ describe("cube queryRewrite", () => {
       source: "charts.executeQueryAction",
     });
     expect(parsed.members).toContain("FeedbackRecords.tenantId");
+    expect(parsed.members).toContain("TopicsUnnested.tenantId");
     expect(logPayload).not.toContain("secret-value");
   });
 });

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -56,6 +56,7 @@ internal Cube service from this chart, or provide an external Cube endpoint.
 - For external Cube, set `deployment.env.CUBEJS_API_URL` to your Cube endpoint.
 - Provide `CUBEJS_API_SECRET` through your existing secret management flow, such as the generated app secret override or `deployment.envFrom`.
 - Provide `CUBEJS_DB_*` connection variables to the Cube deployment through `cube.envFrom` or `cube.env`.
+- Keep `cube.replicas=1` while `cube.env.CUBEJS_CACHE_AND_QUEUE_DRIVER` is `memory`. Configure Cube Store before running multiple Cube replicas.
 - Keep Hub enabled. Cube should point at the same feedback records database that Hub writes to, unless you intentionally split that storage.
 
 ## Hub worker and self-hosted embeddings

--- a/charts/formbricks/cube/cube.js
+++ b/charts/formbricks/cube/cube.js
@@ -122,6 +122,7 @@ function assertNoCallerTenantMember(query) {
 
 function logCubeQueryAuditEvent(context, query, { error, status = "success" } = {}) {
   const errorName = error instanceof Error ? error.name : undefined;
+  const errorMessage = error instanceof Error ? error.message : error ? String(error) : undefined;
 
   console.log(
     JSON.stringify({
@@ -138,6 +139,7 @@ function logCubeQueryAuditEvent(context, query, { error, status = "success" } = 
       source: context.source,
       members: collectQueryMembers(query),
       ...(errorName ? { errorName } : {}),
+      ...(errorMessage ? { errorMessage } : {}),
     })
   );
 }
@@ -174,15 +176,18 @@ function queryRewrite(query, rewriteContext) {
     throw error;
   }
 
+  const queriedCubePrefixes = new Set(collectQueryMembers(cubeQuery).map((member) => member.split(".")[0]));
   const rewrittenQuery = {
     ...cubeQuery,
     filters: [
       ...(Array.isArray(cubeQuery.filters) ? cubeQuery.filters : []),
-      ...TENANT_MEMBERS.map((member) => ({
-        member,
-        operator: "equals",
-        values: [context.tenantId],
-      })),
+      ...TENANT_MEMBERS.filter((member) => queriedCubePrefixes.has(member.split(".")[0])).map(
+        (member) => ({
+          member,
+          operator: "equals",
+          values: [context.tenantId],
+        })
+      ),
     ],
   };
 

--- a/charts/formbricks/cube/cube.js
+++ b/charts/formbricks/cube/cube.js
@@ -1,6 +1,6 @@
 /* eslint-env es2022 */
 
-const TENANT_MEMBER = "FeedbackRecords.tenantId";
+const TENANT_MEMBERS = ["FeedbackRecords.tenantId", "TopicsUnnested.tenantId"];
 const REQUIRED_SCOPE = "xm:cube:query";
 
 function assertRequiredEnvironmentVariable(name) {
@@ -114,7 +114,7 @@ function assertValidSecurityContext(securityContext) {
 
 function assertNoCallerTenantMember(query) {
   for (const member of collectQueryMembers(query)) {
-    if (member === TENANT_MEMBER) {
+    if (TENANT_MEMBERS.includes(member)) {
       throw new Error("Cube query rejected: tenant filters are enforced by Cube");
     }
   }
@@ -142,9 +142,30 @@ function logCubeQueryAuditEvent(context, query, { error, status = "success" } = 
   );
 }
 
+function logCubeQuerySecurityContextFailure(query, error) {
+  console.log(
+    JSON.stringify({
+      type: "audit",
+      event: "cube.query",
+      status: "failure",
+      timestamp: new Date().toISOString(),
+      members: collectQueryMembers(query),
+      errorName: error instanceof Error ? error.name : undefined,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    })
+  );
+}
+
 function queryRewrite(query, rewriteContext) {
   const cubeQuery = query ?? {};
-  const context = assertValidSecurityContext(rewriteContext?.securityContext);
+  let context;
+
+  try {
+    context = assertValidSecurityContext(rewriteContext?.securityContext);
+  } catch (error) {
+    logCubeQuerySecurityContextFailure(cubeQuery, error);
+    throw error;
+  }
 
   try {
     assertNoCallerTenantMember(cubeQuery);
@@ -157,11 +178,11 @@ function queryRewrite(query, rewriteContext) {
     ...cubeQuery,
     filters: [
       ...(Array.isArray(cubeQuery.filters) ? cubeQuery.filters : []),
-      {
-        member: TENANT_MEMBER,
+      ...TENANT_MEMBERS.map((member) => ({
+        member,
         operator: "equals",
         values: [context.tenantId],
-      },
+      })),
     ],
   };
 

--- a/charts/formbricks/cube/schema/FeedbackRecords.js
+++ b/charts/formbricks/cube/schema/FeedbackRecords.js
@@ -160,6 +160,7 @@ cube(`TopicsUnnested`, {
     tenantId: {
       sql: `tenant_id`,
       type: `string`,
+      description: `Tenant ID for row-level security scoping`,
     },
 
     topic: {

--- a/charts/formbricks/cube/schema/FeedbackRecords.js
+++ b/charts/formbricks/cube/schema/FeedbackRecords.js
@@ -36,7 +36,7 @@ cube(`FeedbackRecords`, {
           ELSE ROUND(
             (
               (COUNT(CASE WHEN ${CUBE}.value_number >= 9 THEN 1 END)::numeric -
-               COUNT(CASE WHEN ${CUBE}.value_number <= 6 THEN 1 END)::numeric)
+               COUNT(CASE WHEN ${CUBE}.value_number >= 0 AND ${CUBE}.value_number <= 6 THEN 1 END)::numeric)
               / COUNT(*)::numeric
             ) * 100,
             2
@@ -133,6 +133,7 @@ cube(`TopicsUnnested`, {
   sql: `
     SELECT
       fr.id as feedback_record_id,
+      fr.tenant_id,
       topic_elem.topic
     FROM feedback_records fr
     CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(fr.metadata->'topics', '[]'::jsonb)) AS topic_elem(topic)
@@ -153,6 +154,11 @@ cube(`TopicsUnnested`, {
 
     feedbackRecordId: {
       sql: `feedback_record_id`,
+      type: `string`,
+    },
+
+    tenantId: {
+      sql: `tenant_id`,
       type: `string`,
     },
 

--- a/charts/formbricks/templates/cube-deployment.yaml
+++ b/charts/formbricks/templates/cube-deployment.yaml
@@ -1,3 +1,7 @@
+{{- $cubeCacheDriver := get (.Values.cube.env | default dict) "CUBEJS_CACHE_AND_QUEUE_DRIVER" | default "" | toString }}
+{{- if and .Values.cube.enabled (gt (int .Values.cube.replicas) 1) (eq $cubeCacheDriver "memory") }}
+{{- fail "cube.env.CUBEJS_CACHE_AND_QUEUE_DRIVER=memory is only supported when cube.replicas=1. Use Cube Store for multiple Cube replicas." }}
+{{- end }}
 {{- if .Values.cube.enabled }}
 ---
 apiVersion: apps/v1
@@ -26,9 +30,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/cube-configmap.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.deployment.imagePullSecrets }}
+      {{- if .Values.cube.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml .Values.deployment.imagePullSecrets | nindent 8 }}
+        {{- toYaml .Values.cube.imagePullSecrets | nindent 8 }}
       {{- end }}
       {{- with .Values.cube.nodeSelector }}
       nodeSelector:
@@ -50,10 +54,22 @@ spec:
         - name: cube
           image: "{{ .Values.cube.image.repository }}:{{ .Values.cube.image.tag }}"
           imagePullPolicy: {{ .Values.cube.image.pullPolicy }}
+          {{- with .Values.cube.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.cube.port }}
               protocol: TCP
+          {{- with .Values.cube.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.cube.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.cube.envFrom }}
           envFrom:
             {{- range $value := .Values.cube.envFrom }}

--- a/charts/formbricks/templates/cube-deployment.yaml
+++ b/charts/formbricks/templates/cube-deployment.yaml
@@ -1,4 +1,4 @@
-{{- $cubeCacheDriver := get (.Values.cube.env | default dict) "CUBEJS_CACHE_AND_QUEUE_DRIVER" | default "" | toString }}
+{{- $cubeCacheDriver := get (.Values.cube.env | default dict) "CUBEJS_CACHE_AND_QUEUE_DRIVER" | default "" | toString | trim | lower }}
 {{- if and .Values.cube.enabled (gt (int .Values.cube.replicas) 1) (eq $cubeCacheDriver "memory") }}
 {{- fail "cube.env.CUBEJS_CACHE_AND_QUEUE_DRIVER=memory is only supported when cube.replicas=1. Use Cube Store for multiple Cube replicas." }}
 {{- end }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -570,6 +570,8 @@ cube:
     tag: "v1.6.6"
     pullPolicy: IfNotPresent
 
+  imagePullSecrets: []
+
   port: 4000
 
   service:
@@ -583,9 +585,33 @@ cube:
   env:
     CUBEJS_DB_TYPE: "postgres"
     CUBEJS_DEFAULT_API_SCOPES: "meta,data"
+    # Keep the in-memory cache/queue driver at one Cube replica only. The chart
+    # fails rendering when this remains "memory" and cube.replicas is greater than 1.
     CUBEJS_CACHE_AND_QUEUE_DRIVER: "memory"
     CUBEJS_JWT_ISSUER: "formbricks-web"
     CUBEJS_JWT_AUDIENCE: "formbricks-cube"
+
+  containerSecurityContext:
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+
+  livenessProbe:
+    httpGet:
+      path: /readyz
+      port: http
+    initialDelaySeconds: 20
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+
+  readinessProbe:
+    httpGet:
+      path: /readyz
+      port: http
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
 
   resources:
     limits:

--- a/docker/cube/cube.js
+++ b/docker/cube/cube.js
@@ -122,6 +122,7 @@ function assertNoCallerTenantMember(query) {
 
 function logCubeQueryAuditEvent(context, query, { error, status = "success" } = {}) {
   const errorName = error instanceof Error ? error.name : undefined;
+  const errorMessage = error instanceof Error ? error.message : error ? String(error) : undefined;
 
   console.log(
     JSON.stringify({
@@ -138,6 +139,7 @@ function logCubeQueryAuditEvent(context, query, { error, status = "success" } = 
       source: context.source,
       members: collectQueryMembers(query),
       ...(errorName ? { errorName } : {}),
+      ...(errorMessage ? { errorMessage } : {}),
     })
   );
 }
@@ -174,15 +176,18 @@ function queryRewrite(query, rewriteContext) {
     throw error;
   }
 
+  const queriedCubePrefixes = new Set(collectQueryMembers(cubeQuery).map((member) => member.split(".")[0]));
   const rewrittenQuery = {
     ...cubeQuery,
     filters: [
       ...(Array.isArray(cubeQuery.filters) ? cubeQuery.filters : []),
-      ...TENANT_MEMBERS.map((member) => ({
-        member,
-        operator: "equals",
-        values: [context.tenantId],
-      })),
+      ...TENANT_MEMBERS.filter((member) => queriedCubePrefixes.has(member.split(".")[0])).map(
+        (member) => ({
+          member,
+          operator: "equals",
+          values: [context.tenantId],
+        })
+      ),
     ],
   };
 

--- a/docker/cube/cube.js
+++ b/docker/cube/cube.js
@@ -1,6 +1,6 @@
 /* eslint-env es2022 */
 
-const TENANT_MEMBER = "FeedbackRecords.tenantId";
+const TENANT_MEMBERS = ["FeedbackRecords.tenantId", "TopicsUnnested.tenantId"];
 const REQUIRED_SCOPE = "xm:cube:query";
 
 function assertRequiredEnvironmentVariable(name) {
@@ -114,7 +114,7 @@ function assertValidSecurityContext(securityContext) {
 
 function assertNoCallerTenantMember(query) {
   for (const member of collectQueryMembers(query)) {
-    if (member === TENANT_MEMBER) {
+    if (TENANT_MEMBERS.includes(member)) {
       throw new Error("Cube query rejected: tenant filters are enforced by Cube");
     }
   }
@@ -142,9 +142,30 @@ function logCubeQueryAuditEvent(context, query, { error, status = "success" } = 
   );
 }
 
+function logCubeQuerySecurityContextFailure(query, error) {
+  console.log(
+    JSON.stringify({
+      type: "audit",
+      event: "cube.query",
+      status: "failure",
+      timestamp: new Date().toISOString(),
+      members: collectQueryMembers(query),
+      errorName: error instanceof Error ? error.name : undefined,
+      errorMessage: error instanceof Error ? error.message : String(error),
+    })
+  );
+}
+
 function queryRewrite(query, rewriteContext) {
   const cubeQuery = query ?? {};
-  const context = assertValidSecurityContext(rewriteContext?.securityContext);
+  let context;
+
+  try {
+    context = assertValidSecurityContext(rewriteContext?.securityContext);
+  } catch (error) {
+    logCubeQuerySecurityContextFailure(cubeQuery, error);
+    throw error;
+  }
 
   try {
     assertNoCallerTenantMember(cubeQuery);
@@ -157,11 +178,11 @@ function queryRewrite(query, rewriteContext) {
     ...cubeQuery,
     filters: [
       ...(Array.isArray(cubeQuery.filters) ? cubeQuery.filters : []),
-      {
-        member: TENANT_MEMBER,
+      ...TENANT_MEMBERS.map((member) => ({
+        member,
         operator: "equals",
         values: [context.tenantId],
-      },
+      })),
     ],
   };
 

--- a/docker/cube/schema/FeedbackRecords.js
+++ b/docker/cube/schema/FeedbackRecords.js
@@ -160,6 +160,7 @@ cube(`TopicsUnnested`, {
     tenantId: {
       sql: `tenant_id`,
       type: `string`,
+      description: `Tenant ID for row-level security scoping`,
     },
 
     topic: {

--- a/docker/cube/schema/FeedbackRecords.js
+++ b/docker/cube/schema/FeedbackRecords.js
@@ -36,7 +36,7 @@ cube(`FeedbackRecords`, {
           ELSE ROUND(
             (
               (COUNT(CASE WHEN ${CUBE}.value_number >= 9 THEN 1 END)::numeric -
-               COUNT(CASE WHEN ${CUBE}.value_number <= 6 THEN 1 END)::numeric)
+               COUNT(CASE WHEN ${CUBE}.value_number >= 0 AND ${CUBE}.value_number <= 6 THEN 1 END)::numeric)
               / COUNT(*)::numeric
             ) * 100,
             2
@@ -133,6 +133,7 @@ cube(`TopicsUnnested`, {
   sql: `
     SELECT
       fr.id as feedback_record_id,
+      fr.tenant_id,
       topic_elem.topic
     FROM feedback_records fr
     CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(fr.metadata->'topics', '[]'::jsonb)) AS topic_elem(topic)
@@ -153,6 +154,11 @@ cube(`TopicsUnnested`, {
 
     feedbackRecordId: {
       sql: `feedback_record_id`,
+      type: `string`,
+    },
+
+    tenantId: {
+      sql: `tenant_id`,
       type: `string`,
     },
 


### PR DESCRIPTION
Addresses CodeRabbit comments from #7955.

Changes:
- Enforces tenant filters for both FeedbackRecords and TopicsUnnested Cube members.
- Adds audit logging for rejected security contexts before claim validation completes.
- Aligns the NPS detractor calculation and exposes tenantId on TopicsUnnested.
- Adds Cube-specific imagePullSecrets, container security context, readiness/liveness probes, and a Helm guard for unsafe multi-replica memory queue usage.
- Keeps the Docker Cube config/schema in sync with the chart-managed Cube config.

Validation:
- helm lint charts/formbricks --set cube.enabled=true --set secret.enabled=false --set externalSecret.enabled=true --set externalSecret.files.app-secrets.dataFrom.key=stage/formbricks
- helm template formbricks charts/formbricks --set cube.enabled=true --set secret.enabled=false --set externalSecret.enabled=true --set externalSecret.files.app-secrets.dataFrom.key=stage/formbricks
- helm template formbricks charts/formbricks --set cube.enabled=true --set cube.replicas=2 --set cube.env.CUBEJS_CACHE_AND_QUEUE_DRIVER=cubestore --set secret.enabled=false --set externalSecret.enabled=true --set externalSecret.files.app-secrets.dataFrom.key=stage/formbricks
- helm template formbricks charts/formbricks --set cube.enabled=true --set cube.replicas=2 --set secret.enabled=false --set externalSecret.enabled=true --set externalSecret.files.app-secrets.dataFrom.key=stage/formbricks failed as expected with the memory-driver guard
- node --check charts/formbricks/cube/cube.js && node --check docker/cube/cube.js && node --check charts/formbricks/cube/schema/FeedbackRecords.js && node --check docker/cube/schema/FeedbackRecords.js
- git diff --check