### PR TITLE
fix: update Hub runtime defaults for v5 staging

### DIFF
--- a/charts/formbricks/templates/hub-deployment.yaml
+++ b/charts/formbricks/templates/hub-deployment.yaml
@@ -39,6 +39,7 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            runAsUser: 1000
           command:
             - sh
             - -c
@@ -55,6 +56,7 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            runAsUser: 1000
           ports:
             - name: http
               containerPort: 8080

--- a/charts/formbricks/templates/hub-worker-deployment.yaml
+++ b/charts/formbricks/templates/hub-worker-deployment.yaml
@@ -54,6 +54,7 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            runAsUser: 1000
           command:
             - sh
             - -c
@@ -79,6 +80,7 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            runAsUser: 1000
           envFrom:
             - secretRef:
                 name: {{ include "formbricks.hubSecretName" . }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -594,6 +594,7 @@ cube:
   containerSecurityContext:
     readOnlyRootFilesystem: false
     runAsNonRoot: true
+    runAsUser: 1000
 
   livenessProbe:
     httpGet:
@@ -639,10 +640,10 @@ hub:
     # Pinned by digest for immutable, reproducible deployments. When digest is set it takes
     # precedence over tag, and deployment, init container, and migration job all resolve to the
     # same immutable image. Update on each Hub release.
-    # Current digest corresponds to ghcr.io/formbricks/hub:0.2.0.
-    digest: "sha256:14db7b3d285b6e9165b55693f9b83d08beff840a255fd77dd12882ee0a62f5cb"
+    # Current digest corresponds to ghcr.io/formbricks/hub:0.3.0.
+    digest: "sha256:6c39b1143527137e881df785a5b668625a1fe3edb05485bb5ded19f813c8de88"
     # Tag is a fallback for dev/non-prod when digest is cleared; keep aligned with the digest above.
-    tag: "0.2.0"
+    tag: "0.3.0"
     pullPolicy: IfNotPresent
 
   # Optional override for the secret Hub reads from.


### PR DESCRIPTION
Follow-up from the staging release verification.

Changes:
- Bumps the bundled Hub image default to ghcr.io/formbricks/hub:0.3.0 by digest so Hub migrations include the PostgreSQL 16/17 uuidv7 fallback.
- Adds numeric runAsUser: 1000 to Hub API and worker containers/init containers so Kubernetes can enforce runAsNonRoot with the Hub image USER app.
- Adds runAsUser: 1000 to the default Cube container security context; cubejs/cube:v1.6.6 otherwise declares root and is rejected when runAsNonRoot is enabled.

Validation:
- helm lint charts/formbricks --set cube.enabled=true --set secret.enabled=false --set externalSecret.enabled=true --set externalSecret.files.app-secrets.dataFrom.key=stage/formbricks
- helm template formbricks charts/formbricks --set cube.enabled=true --set secret.enabled=false --set externalSecret.enabled=true --set externalSecret.files.app-secrets.dataFrom.key=stage/formbricks
- git diff --check

Live staging verification:
- formbricks-stage is Synced/Healthy on formbricks/formbricks revision 2c22b00e and gitops revision 4966c8e.
- formbricks, formbricks-cube, formbricks-hub, formbricks-hub-worker, and formbricks-hub-embeddings are all ready.
- Cube /readyz returns {"health":"HEALTH"}.