### PR TITLE
fix: validate workspace assignment on feedback directory create (ENG-900)

### DIFF
--- a/apps/web/modules/ee/feedback-directory/lib/feedback-directory.test.ts
+++ b/apps/web/modules/ee/feedback-directory/lib/feedback-directory.test.ts
@@ -309,6 +309,27 @@ describe("FeedbackDirectory Service", () => {
       expect(prisma.feedbackDirectory.create).not.toHaveBeenCalled();
     });
 
+    test("allows creation when workspace is only assigned to archived directory", async () => {
+      vi.mocked(prisma.workspace.count).mockResolvedValueOnce(1);
+      vi.mocked(prisma.feedbackDirectoryWorkspace.findFirst).mockResolvedValueOnce(null);
+      vi.mocked(prisma.feedbackDirectory.create).mockResolvedValueOnce({
+        id: mockDirectoryId,
+      } as any);
+
+      const result = await createFeedbackDirectory(mockOrganizationId, "ArchivedOnly", [mockWorkspaceId1]);
+
+      expect(prisma.feedbackDirectoryWorkspace.findFirst).toHaveBeenCalledWith({
+        where: {
+          workspaceId: { in: [mockWorkspaceId1] },
+          feedbackDirectory: { isArchived: false },
+        },
+        select: { workspaceId: true },
+      });
+
+      expect(prisma.feedbackDirectory.create).toHaveBeenCalled();
+      expect(result).toBe(mockDirectoryId);
+    });
+
     test("throws InvalidInputError on duplicate name (unique constraint violation)", async () => {
       const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint", {
         code: "P2002",

--- a/apps/web/modules/ee/feedback-directory/lib/feedback-directory.test.ts
+++ b/apps/web/modules/ee/feedback-directory/lib/feedback-directory.test.ts
@@ -289,6 +289,26 @@ describe("FeedbackDirectory Service", () => {
       ).rejects.toThrow(new InvalidInputError("DIRECTORY_WORKSPACES_INVALID_ORG"));
     });
 
+    test("throws InvalidInputError when a workspace is already assigned to another active directory", async () => {
+      vi.mocked(prisma.workspace.count).mockResolvedValueOnce(1);
+      vi.mocked(prisma.feedbackDirectoryWorkspace.findFirst).mockResolvedValueOnce({
+        workspaceId: mockWorkspaceId1,
+      } as any);
+
+      await expect(
+        createFeedbackDirectory(mockOrganizationId, "Conflicting", [mockWorkspaceId1])
+      ).rejects.toThrow(new InvalidInputError("WORKSPACE_ALREADY_ASSIGNED_TO_DIFFERENT_DIRECTORY"));
+
+      expect(prisma.feedbackDirectoryWorkspace.findFirst).toHaveBeenCalledWith({
+        where: {
+          workspaceId: { in: [mockWorkspaceId1] },
+          feedbackDirectory: { isArchived: false },
+        },
+        select: { workspaceId: true },
+      });
+      expect(prisma.feedbackDirectory.create).not.toHaveBeenCalled();
+    });
+
     test("throws InvalidInputError on duplicate name (unique constraint violation)", async () => {
       const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint", {
         code: "P2002",

--- a/apps/web/modules/ee/feedback-directory/lib/feedback-directory.ts
+++ b/apps/web/modules/ee/feedback-directory/lib/feedback-directory.ts
@@ -454,7 +454,7 @@ const assertWorkspacesNotAssignedElsewhere = async (
   const conflicting = await prisma.feedbackDirectoryWorkspace.findFirst({
     where: {
       workspaceId: { in: workspaceIds },
-      ...(directoryId !== undefined ? { feedbackDirectoryId: { not: directoryId } } : {}),
+      ...(directoryId === undefined ? {} : { feedbackDirectoryId: { not: directoryId } }),
       feedbackDirectory: { isArchived: false },
     },
     select: { workspaceId: true },

--- a/apps/web/modules/ee/feedback-directory/lib/feedback-directory.ts
+++ b/apps/web/modules/ee/feedback-directory/lib/feedback-directory.ts
@@ -279,6 +279,7 @@ export const createFeedbackDirectory = async (
       if (count !== workspaceIds.length) {
         throw new InvalidInputError("DIRECTORY_WORKSPACES_INVALID_ORG");
       }
+      await assertWorkspacesNotAssignedElsewhere(undefined, workspaceIds);
     }
 
     const directory = await prisma.feedbackDirectory.create({
@@ -440,9 +441,12 @@ const pauseConnectorsInWorkspaces = async (
  * Enforces the single-active-FRD-per-workspace invariant. The client UI prevents
  * assigning a workspace to multiple active directories, but the server must also
  * reject such payloads to keep this guarantee under direct API access.
+ *
+ * Pass `directoryId` when updating an existing directory to exclude it from the
+ * conflict check. Omit it on create — every active directory is a conflict.
  */
 const assertWorkspacesNotAssignedElsewhere = async (
-  directoryId: string,
+  directoryId: string | undefined,
   workspaceIds: string[]
 ): Promise<void> => {
   if (workspaceIds.length === 0) return;
@@ -450,7 +454,7 @@ const assertWorkspacesNotAssignedElsewhere = async (
   const conflicting = await prisma.feedbackDirectoryWorkspace.findFirst({
     where: {
       workspaceId: { in: workspaceIds },
-      feedbackDirectoryId: { not: directoryId },
+      ...(directoryId !== undefined ? { feedbackDirectoryId: { not: directoryId } } : {}),
       feedbackDirectory: { isArchived: false },
     },
     select: { workspaceId: true },


### PR DESCRIPTION
## Summary
- `assertWorkspacesNotAssignedElsewhere()` was only invoked on **update**, so the **create** path accepted `workspaceIds` already linked to another active directory — there is no DB-level constraint to backstop this.
- Make the helper's `directoryId` parameter optional; when omitted (create path), every active directory counts as a conflict. Invoke it in `createFeedbackDirectory` after the org-membership check.

Fixes [ENG-900](https://linear.app/formbricks/issue/ENG-900/already-connected-workspace-assignment-to-feedback-directory-issue).

## Test plan
- [x] Unit: added test that create rejects workspaceIds already on an active directory and skips the Prisma create call.
- [x] Unit: existing 38 tests in `feedback-directory.test.ts` still pass.
- [ ] Manual: try creating a feedback directory in the UI assigning a workspace already linked to another active directory — confirm the toast surfaces `WORKSPACE_ALREADY_ASSIGNED_TO_DIFFERENT_DIRECTORY` and no row is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)