### PR TITLE
fix(helm): stop forcing TEI float16 dtype

### DIFF
--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -782,9 +782,7 @@ hub:
     # When empty, the chart renders TEI args from model, servedModelName, port,
     # revision, and persistence.mountPath. Set this to fully override args.
     args: []
-    extraArgs:
-      - --dtype
-      - float16
+    extraArgs: []
     env: {}
 
     port: 8080


### PR DESCRIPTION
## What does this PR do?

Removes the default `--dtype float16` extra arg from the Formbricks Helm chart's Hub embeddings TEI deployment.

Staging showed TEI successfully serves `Alibaba-NLP/gte-multilingual-base` through the Candle backend, but the forced float16 override causes a misleading ORT startup error because ORT only supports float32 in this path. Leaving `extraArgs` empty lets TEI choose the compatible backend/defaults while preserving the ability to override args explicitly when needed.

## How should this be tested?

- `helm lint charts/formbricks --set formbricks.webappUrl=https://example.com --set hub.embeddings.enabled=true`
- `helm template formbricks charts/formbricks --set formbricks.webappUrl=https://example.com --set hub.embeddings.enabled=true`
- Verified rendered embeddings manifest no longer contains `--dtype`.
- `git diff --check`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Checked for warnings, there are none from Helm validation
- [x] Removed all `console.logs`
- [x] My changes don't cause any responsiveness issues (no UI changes)

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR (not applicable)
- [ ] Updated the Formbricks Docs if changes were necessary (not applicable)
