### PR TITLE
feat: add beta badge to unify feedback navigation section

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
@@ -43,6 +43,7 @@ import { useSignOut } from "@/modules/auth/hooks/use-sign-out";
 import { TrialAlert } from "@/modules/ee/billing/components/trial-alert";
 import { CreateOrganizationModal } from "@/modules/organization/components/CreateOrganizationModal";
 import { ProfileAvatar } from "@/modules/ui/components/avatars";
+import { Badge } from "@/modules/ui/components/badge";
 import { Button } from "@/modules/ui/components/button";
 import {
   DropdownMenu,
@@ -151,7 +152,17 @@ export const MainNavigation = ({
       },
       {
         id: "unify-feedback",
-        name: t("workspace.unify.unify_feedback"),
+        name: (
+          <span className="inline-flex items-center gap-2">
+            <span>{t("workspace.unify.unify_feedback")}</span>
+            <Badge
+              text="Beta"
+              type="gray"
+              size="tiny"
+              className="normal-case text-[10px] font-semibold tracking-normal"
+            />
+          </span>
+        ),
         items: [
           {
             name: t("workspace.unify.feedback_records"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Adds a subtle inline **Beta** badge next to the **Unify Feedback** section title in the new workspace navigation.

<img width="247" height="162" alt="image" src="https://github.com/user-attachments/assets/a3aa9032-887b-4a81-8088-a9dd2b3be4b8" />


Fixes #(issue)

## How should this be tested?

- Open a workspace on the new `epic/v5` navigation UI.
- Verify the **Unify Feedback** section heading shows a small gray **Beta** badge beside the label.
- Collapse/expand the sidebar and confirm navigation behavior remains unchanged.



