### PR TITLE
fix(charts): time-range crash + sentiment/emotion/response-id cube column mismatches (ENG-907, ENG-906, ENG-915)

### DIFF
--- a/apps/web/modules/ee/analysis/lib/query-builder.ts
+++ b/apps/web/modules/ee/analysis/lib/query-builder.ts
@@ -64,10 +64,13 @@ export function buildCubeQuery(config: ChartBuilderState): TChartQuery {
       timeDim.dateRange = config.timeDimension.dateRange;
     } else if (Array.isArray(config.timeDimension.dateRange)) {
       const [startDate, endDate] = config.timeDimension.dateRange;
-      const formatDate = (date: Date) => {
-        const year = date.getFullYear();
-        const month = String(date.getMonth() + 1).padStart(2, "0");
-        const day = String(date.getDate()).padStart(2, "0");
+      const formatDate = (date: Date | string) => {
+        // dateRange round-trips through JSON (saved chart → parseQueryToState), so the array
+        // elements may already be ISO strings — coerce before formatting.
+        const d = date instanceof Date ? date : new Date(date);
+        const year = d.getFullYear();
+        const month = String(d.getMonth() + 1).padStart(2, "0");
+        const day = String(d.getDate()).padStart(2, "0");
         return `${year}-${month}-${day}`;
       };
       timeDim.dateRange = [formatDate(startDate), formatDate(endDate)];
@@ -137,7 +140,12 @@ export function parseQueryToState(query: TChartQuery): Partial<ChartBuilderState
       config.granularity = timeDim.granularity;
     }
     if (timeDim.dateRange) {
-      config.dateRange = timeDim.dateRange as TimeDimensionConfig["dateRange"];
+      if (typeof timeDim.dateRange === "string") {
+        config.dateRange = timeDim.dateRange;
+      } else if (Array.isArray(timeDim.dateRange) && timeDim.dateRange.length === 2) {
+        // Stored as [isoString, isoString]; lift back into Date objects for the date-picker UI.
+        config.dateRange = [new Date(timeDim.dateRange[0]), new Date(timeDim.dateRange[1])];
+      }
     }
     state.timeDimension = config;
   }

--- a/docker/cube/schema/FeedbackRecords.js
+++ b/docker/cube/schema/FeedbackRecords.js
@@ -61,7 +61,7 @@ cube(`FeedbackRecords`, {
     },
 
     sentiment: {
-      sql: `sentiment`,
+      sql: `${CUBE}.metadata->>'sentiment'`,
       type: `string`,
       description: `Sentiment extracted from metadata JSONB field`,
     },
@@ -97,9 +97,9 @@ cube(`FeedbackRecords`, {
     },
 
     responseId: {
-      sql: `response_id`,
+      sql: `submission_id`,
       type: `string`,
-      description: `Unique identifier linking related feedback records`,
+      description: `Unique identifier linking related feedback records (submission_id in Hub)`,
     },
 
     userId: {
@@ -109,7 +109,7 @@ cube(`FeedbackRecords`, {
     },
 
     emotion: {
-      sql: `emotion`,
+      sql: `${CUBE}.metadata->>'emotion'`,
       type: `string`,
       description: `Emotion extracted from metadata JSONB field`,
     },


### PR DESCRIPTION
## Summary
Two related classes of chart bugs in epic/v5.

### 1 · Time-range chart crash — `date.getFullYear is not a function`
The chart-builder state and the persisted Cube query disagree on what's inside `dateRange`:

| Type | Where | Runtime shape |
|------|-------|---------------|
| `TTimeDimension.dateRange` | `packages/types/analysis.ts` — persisted Cube query (JSON) | `string \| [string, string]` |
| `TimeDimensionConfig.dateRange` | `query-builder.ts` — local chart-builder state used by the date picker | `string \| [Date, Date]` |

`parseQueryToState` cast the persisted `[isoString, isoString]` straight into `[Date, Date]` without converting the elements. Editing any saved time-based chart then ran `formatDate(date).getFullYear()` on a string and threw.

Fixes [ENG-907](https://linear.app/formbricks/issue/ENG-907/bug-time-related-query-crashes-the-whole-app-with-a-runtime-error).

### 2 · "column feedback_records.X does not exist"
Three Cube dimensions on `docker/cube/schema/FeedbackRecords.js` referenced columns that aren't in the Hub `feedback_records` table — so any chart grouping or filtering by them blew up with a Cube/Postgres error:

| Cube dimension | Was | Now | Why |
|----------------|-----|-----|-----|
| `sentiment` | ``SQL: `sentiment` `` | ``SQL: `${CUBE}.metadata->>'sentiment'` `` | Lives in the `metadata` JSONB (matches the existing `TopicsUnnested` pattern). |
| `emotion` | ``SQL: `emotion` `` | ``SQL: `${CUBE}.metadata->>'emotion'` `` | Same. |
| `responseId` | ``SQL: `response_id` `` | ``SQL: `submission_id` `` | Hub's column is `submission_id`; the description already said "linking related feedback records". |

Cross-checked every other dimension and measure against `FeedbackRecordData` from `@formbricks/hub` — the rest are clean.

User-facing labels are unchanged, so saved charts that already reference `FeedbackRecords.sentiment` / `emotion` / `responseId` keep working — they just stop crashing.

Fixes [ENG-906](https://linear.app/formbricks/issue/ENG-906/p0-grouping-charts-by-sentimentemotion-results-in-an-error-in-cube) and [ENG-915](https://linear.app/formbricks/issue/ENG-915/bug-cant-use-sentiment-related-filters-while-making-charts).

## Changes
- `apps/web/modules/ee/analysis/lib/query-builder.ts`
  - `parseQueryToState` lifts a `[isoString, isoString]` `dateRange` back into `[Date, Date]`.
  - `formatDate` defensively accepts `Date | string` and coerces before reading date getters.
- `docker/cube/schema/FeedbackRecords.js`
  - `sentiment` and `emotion` SQL → `metadata->>'<key>'`.
  - `responseId` SQL → `submission_id`.

## Test plan
- [x] Existing 13 `query-builder` unit tests pass.
- [ ] Manual: open a saved chart with a `[startDate, endDate]` time dimension, edit anything, click Preview/Save — no crash; outgoing query has `YYYY-MM-DD` strings.
- [ ] Manual: create a chart with a `count` measure and `Group by` set to `Sentiment` or `Emotion` — query executes; non-null values populate from the metadata JSONB.
- [ ] Manual: same as above but `Group by Response ID` — query executes against `submission_id`.
- [ ] After cube container reloads the schema (restart or watch reload), confirm `/cubejs-api/v1/meta` shows the updated SQL for these three dimensions.