### PR TITLE
chore: fix broken impressions count

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/lib/surveySummary.test.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/lib/surveySummary.test.ts
@@ -1106,6 +1106,21 @@ describe("getSurveySummary", () => {
       expect.objectContaining({ responseIds: expect.any(Array) })
     );
   });
+
+  test("does not pass responseIds for date-only filterCriteria", async () => {
+    const filterCriteria: TResponseFilterCriteria = {
+      createdAt: {
+        min: new Date("2024-01-01T00:00:00.000Z"),
+        max: new Date("2024-01-31T23:59:59.999Z"),
+      },
+    };
+
+    await getSurveySummary(mockSurveyId, filterCriteria);
+
+    expect(getDisplayCountBySurveyId).toHaveBeenCalledWith(mockSurveyId, {
+      createdAt: filterCriteria.createdAt,
+    });
+  });
 });
 
 describe("getResponsesForSummary", () => {

--- a/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/lib/surveySummary.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/lib/surveySummary.ts
@@ -979,7 +979,7 @@ export const getSurveySummary = reactCache(
       const elements = getElementsFromBlocks(survey.blocks);
 
       const batchSize = 5000;
-      const hasFilter = Object.keys(filterCriteria ?? {}).length > 0;
+      const hasFilter = Object.keys(filterCriteria ?? {}).some((filterKey) => filterKey !== "createdAt");
 
       // Use cursor-based pagination instead of count + offset to avoid expensive queries
       const responses: TSurveySummaryResponse[] = [];

--- a/apps/web/lib/display/service.ts
+++ b/apps/web/lib/display/service.ts
@@ -4,7 +4,7 @@ import { cache as reactCache } from "react";
 import { z } from "zod";
 import { prisma } from "@formbricks/database";
 import { ZId } from "@formbricks/types/common";
-import { TDisplay, TDisplayFilters, TDisplayWithContact } from "@formbricks/types/displays";
+import { TDisplay, TDisplayFilters, TDisplayWithContact, ZDisplayFilters } from "@formbricks/types/displays";
 import { DatabaseError } from "@formbricks/types/errors";
 import { validateInputs } from "../utils/validate";
 
@@ -18,16 +18,29 @@ export const selectDisplay = {
 
 export const getDisplayCountBySurveyId = reactCache(
   async (surveyId: string, filters?: TDisplayFilters): Promise<number> => {
-    validateInputs([surveyId, ZId]);
+    validateInputs([surveyId, ZId], [filters, ZDisplayFilters.optional()]);
+
+    if (filters?.responseIds?.length === 0) {
+      return 0;
+    }
 
     try {
       const displayCount = await prisma.display.count({
         where: {
-          surveyId: surveyId,
+          surveyId,
           ...(filters?.createdAt && {
             createdAt: {
               gte: filters.createdAt.min,
               lte: filters.createdAt.max,
+            },
+          }),
+          ...(filters?.responseIds && {
+            response: {
+              is: {
+                id: {
+                  in: filters.responseIds,
+                },
+              },
             },
           }),
         },

--- a/apps/web/lib/display/tests/display-queries.test.ts
+++ b/apps/web/lib/display/tests/display-queries.test.ts
@@ -4,9 +4,14 @@ import { Prisma } from "@prisma/client";
 import { describe, expect, test, vi } from "vitest";
 import { PrismaErrorType } from "@formbricks/database/types/error";
 import { DatabaseError, ValidationError } from "@formbricks/types/errors";
-import { getDisplaysByContactId, getDisplaysBySurveyIdWithContact } from "../service";
+import {
+  getDisplayCountBySurveyId,
+  getDisplaysByContactId,
+  getDisplaysBySurveyIdWithContact,
+} from "../service";
 
 const mockContactId = "clqnj99r9000008lebgf8734j";
+const mockResponseIds = ["clqnfg59i000208i426pb4wcv", "clqnfg59i000208i426pb4wcw"];
 
 const mockDisplaysForContact = [
   {
@@ -44,6 +49,74 @@ const mockDisplaysWithContact = [
     },
   },
 ];
+
+describe("getDisplayCountBySurveyId", () => {
+  describe("Happy Path", () => {
+    test("counts displays by surveyId", async () => {
+      vi.mocked(prisma.display.count).mockResolvedValue(5);
+
+      const result = await getDisplayCountBySurveyId(mockSurveyId);
+
+      expect(result).toBe(5);
+      expect(prisma.display.count).toHaveBeenCalledWith({
+        where: {
+          surveyId: mockSurveyId,
+        },
+      });
+    });
+
+    test("combines createdAt and responseIds filters", async () => {
+      const createdAt = {
+        min: new Date("2024-01-01T00:00:00.000Z"),
+        max: new Date("2024-01-31T23:59:59.999Z"),
+      };
+      vi.mocked(prisma.display.count).mockResolvedValue(2);
+
+      const result = await getDisplayCountBySurveyId(mockSurveyId, {
+        createdAt,
+        responseIds: mockResponseIds,
+      });
+
+      expect(result).toBe(2);
+      expect(prisma.display.count).toHaveBeenCalledWith({
+        where: {
+          surveyId: mockSurveyId,
+          createdAt: {
+            gte: createdAt.min,
+            lte: createdAt.max,
+          },
+          response: {
+            is: {
+              id: {
+                in: mockResponseIds,
+              },
+            },
+          },
+        },
+      });
+    });
+
+    test("returns 0 without querying when responseIds filter is empty", async () => {
+      const result = await getDisplayCountBySurveyId(mockSurveyId, { responseIds: [] });
+
+      expect(result).toBe(0);
+      expect(prisma.display.count).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Sad Path", () => {
+    test("throws DatabaseError on PrismaClientKnownRequestError", async () => {
+      const errToThrow = new Prisma.PrismaClientKnownRequestError("Mock error", {
+        code: PrismaErrorType.UniqueConstraintViolation,
+        clientVersion: "0.0.1",
+      });
+
+      vi.mocked(prisma.display.count).mockRejectedValue(errToThrow);
+
+      await expect(getDisplayCountBySurveyId(mockSurveyId)).rejects.toThrow(DatabaseError);
+    });
+  });
+});
 
 describe("getDisplaysByContactId", () => {
   describe("Happy Path", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-726

This PR fixes filtered survey summary impressions. The summary flow already passed filtered response IDs into `getDisplayCountBySurveyId`, but the display count service ignored them, so the impressions stat did not correctly reflect response-based filters.

The change:
- Implements `responseIds` support in `getDisplayCountBySurveyId`
- Keeps date-only filters using display `createdAt`, preserving existing impression semantics
- Adds regression coverage for response-based filters, empty response ID filters, and date-only filters

No UI changes.

## How should this be tested?

- Run `pnpm --dir apps/web exec dotenv -e ../../.env -- vitest run lib/display/tests/display-queries.test.ts`
- Run `pnpm --dir apps/web exec dotenv -e ../../.env -- vitest run 'app/(app)/environments/[environmentId]/surveys/[surveyId]/(analysis)/summary/lib/surveySummary.test.ts'`
- Manually verify a survey summary:
  - Add multiple responses with different answer values
  - Apply a response-based filter
  - Confirm `Starts` and `Impressions` reflect the filtered response set
  - Apply a date-only filter
  - Confirm `Impressions` still follows display date filtering

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
