### PR TITLE
fix: correct matrix/ranking feedback records

### DIFF
--- a/apps/web/lib/connector/transform.test.ts
+++ b/apps/web/lib/connector/transform.test.ts
@@ -40,6 +40,8 @@ const mockSurvey = {
   ],
 } as unknown as TSurvey;
 
+const mockTenantId = "cmp2f6428000504la7iyh87h1";
+
 const mockResponse = {
   id: "resp-1",
   createdAt: NOW,
@@ -84,13 +86,18 @@ describe("transformResponseToFeedbackRecords", () => {
 
   test("returns empty array when response has no data", () => {
     const emptyResponse = { ...mockResponse, data: null } as unknown as TResponse;
-    const result = transformResponseToFeedbackRecords(emptyResponse, mockSurvey, allMappings);
+    const result = transformResponseToFeedbackRecords(emptyResponse, mockSurvey, allMappings, mockTenantId);
     expect(result).toEqual([]);
   });
 
   test("returns empty array when no mappings match the survey", () => {
     const otherSurveyMappings = allMappings.map((m) => ({ ...m, surveyId: "other-survey" }));
-    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, otherSurveyMappings);
+    const result = transformResponseToFeedbackRecords(
+      mockResponse,
+      mockSurvey,
+      otherSurveyMappings,
+      mockTenantId
+    );
     expect(result).toEqual([]);
   });
 
@@ -100,7 +107,7 @@ describe("transformResponseToFeedbackRecords", () => {
       data: { "el-text": "" },
     } as unknown as TResponse;
     const mappings = [createMapping({ elementId: "el-text", hubFieldType: "text" })];
-    const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
     expect(result).toEqual([]);
   });
 
@@ -113,14 +120,14 @@ describe("transformResponseToFeedbackRecords", () => {
       createMapping({ elementId: "el-text", hubFieldType: "text" }),
       createMapping({ elementId: "el-nps", hubFieldType: "nps" }),
     ];
-    const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
     expect(result).toHaveLength(1);
     expect(result[0].field_id).toBe("el-nps");
   });
 
   test("transforms text field correctly", () => {
     const mappings = [createMapping({ elementId: "el-text", hubFieldType: "text" })];
-    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings, mockTenantId);
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       source_type: "formbricks_survey",
@@ -137,7 +144,7 @@ describe("transformResponseToFeedbackRecords", () => {
 
   test("transforms nps field correctly", () => {
     const mappings = [createMapping({ elementId: "el-nps", hubFieldType: "nps" })];
-    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings, mockTenantId);
     expect(result).toHaveLength(1);
     expect(result[0].value_number).toBe(9);
     expect(result[0].field_type).toBe("nps");
@@ -145,28 +152,28 @@ describe("transformResponseToFeedbackRecords", () => {
 
   test("transforms rating field correctly", () => {
     const mappings = [createMapping({ elementId: "el-rating", hubFieldType: "rating" })];
-    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings, mockTenantId);
     expect(result).toHaveLength(1);
     expect(result[0].value_number).toBe(4);
   });
 
   test("transforms date field to ISO string", () => {
     const mappings = [createMapping({ elementId: "el-date", hubFieldType: "date" })];
-    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings, mockTenantId);
     expect(result).toHaveLength(1);
     expect(result[0].value_date).toBe(new Date("2026-01-15").toISOString());
   });
 
   test("transforms boolean field correctly", () => {
     const mappings = [createMapping({ elementId: "el-bool", hubFieldType: "boolean" })];
-    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings, mockTenantId);
     expect(result).toHaveLength(1);
     expect(result[0].value_boolean).toBe(true);
   });
 
   test("transforms categorical (multi-select) field to comma-separated text", () => {
     const mappings = [createMapping({ elementId: "el-multi", hubFieldType: "categorical" })];
-    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings, mockTenantId);
     expect(result).toHaveLength(1);
     expect(result[0].value_text).toBe("feat-a, feat-b");
   });
@@ -175,13 +182,13 @@ describe("transformResponseToFeedbackRecords", () => {
     const mappings = [
       createMapping({ elementId: "el-text", hubFieldType: "text", customFieldLabel: "Custom Label" }),
     ];
-    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings, mockTenantId);
     expect(result[0].field_label).toBe("Custom Label");
   });
 
   test("sets collected_at from response createdAt", () => {
     const mappings = [createMapping({ elementId: "el-text", hubFieldType: "text" })];
-    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings, mockTenantId);
     expect(result[0].collected_at).toBe(NOW.toISOString());
   });
 
@@ -189,7 +196,7 @@ describe("transformResponseToFeedbackRecords", () => {
     const updatedAt = new Date("2026-02-25T10:00:00.000Z");
     const response = { ...mockResponse, createdAt: undefined, updatedAt } as unknown as TResponse;
     const mappings = [createMapping({ elementId: "el-text", hubFieldType: "text" })];
-    const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
     expect(result[0].collected_at).toBe(updatedAt.toISOString());
   });
 
@@ -199,7 +206,7 @@ describe("transformResponseToFeedbackRecords", () => {
       createdAt: "2026-02-26T10:00:00.000Z",
     } as unknown as TResponse;
     const mappings = [createMapping({ elementId: "el-text", hubFieldType: "text" })];
-    const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
     expect(result[0].collected_at).toBe("2026-02-26T10:00:00.000Z");
   });
 
@@ -209,28 +216,22 @@ describe("transformResponseToFeedbackRecords", () => {
     expect(result[0].tenant_id).toBe("tenant-abc");
   });
 
-  test("omits tenant_id when not provided", () => {
-    const mappings = [createMapping({ elementId: "el-text", hubFieldType: "text" })];
-    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, mappings);
-    expect(result[0].tenant_id).toBeUndefined();
-  });
-
   test("omits language when response language is 'default'", () => {
     const response = { ...mockResponse, language: "default" } as unknown as TResponse;
     const mappings = [createMapping({ elementId: "el-text", hubFieldType: "text" })];
-    const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
     expect(result[0].language).toBeUndefined();
   });
 
   test("omits user_id when contact has no userId", () => {
     const response = { ...mockResponse, contact: null } as unknown as TResponse;
     const mappings = [createMapping({ elementId: "el-text", hubFieldType: "text" })];
-    const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+    const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
     expect(result[0].user_id).toBeUndefined();
   });
 
   test("transforms all mappings in a single call", () => {
-    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, allMappings);
+    const result = transformResponseToFeedbackRecords(mockResponse, mockSurvey, allMappings, mockTenantId);
     expect(result).toHaveLength(6);
     const fieldIds = result.map((r) => r.field_id);
     expect(fieldIds).toEqual(["el-text", "el-nps", "el-rating", "el-date", "el-bool", "el-multi"]);
@@ -246,7 +247,7 @@ describe("transformResponseToFeedbackRecords", () => {
       data: { "el-bare": "some text" },
     } as unknown as TResponse;
     const mappings = [createMapping({ elementId: "el-bare", hubFieldType: "text" })];
-    const result = transformResponseToFeedbackRecords(response, survey, mappings);
+    const result = transformResponseToFeedbackRecords(response, survey, mappings, mockTenantId);
     expect(result[0].field_label).toBe("Untitled");
   });
 
@@ -257,7 +258,7 @@ describe("transformResponseToFeedbackRecords", () => {
         data: { "el-nps": "7" },
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-nps", hubFieldType: "nps" })];
-      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
       expect(result[0].value_number).toBe(7);
     });
 
@@ -267,7 +268,7 @@ describe("transformResponseToFeedbackRecords", () => {
         data: { "el-nps": "not-a-number" },
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-nps", hubFieldType: "nps" })];
-      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
       expect(result[0].value_number).toBeUndefined();
     });
 
@@ -277,7 +278,7 @@ describe("transformResponseToFeedbackRecords", () => {
         data: { "el-text": { nested: "value" } },
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-text", hubFieldType: "text" })];
-      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
       expect(result[0].value_text).toBe(JSON.stringify({ nested: "value" }));
     });
 
@@ -287,7 +288,7 @@ describe("transformResponseToFeedbackRecords", () => {
         data: { "el-date": "not-a-date" },
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-date", hubFieldType: "date" })];
-      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
       expect(result[0].value_date).toBeUndefined();
     });
 
@@ -297,7 +298,7 @@ describe("transformResponseToFeedbackRecords", () => {
         data: { "el-bool": "1" },
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-bool", hubFieldType: "boolean" })];
-      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
       expect(result[0].value_boolean).toBe(true);
     });
 
@@ -307,7 +308,7 @@ describe("transformResponseToFeedbackRecords", () => {
         data: { "el-bool": "false" },
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-bool", hubFieldType: "boolean" })];
-      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
       expect(result[0].value_boolean).toBe(false);
     });
 
@@ -317,7 +318,7 @@ describe("transformResponseToFeedbackRecords", () => {
         data: { "el-text": ["a", "b", "c"] },
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-text", hubFieldType: "text" })];
-      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
       expect(result[0].value_text).toBe("a, b, c");
     });
 
@@ -327,7 +328,7 @@ describe("transformResponseToFeedbackRecords", () => {
         data: { "el-multi": "single-choice" },
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-multi", hubFieldType: "categorical" })];
-      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
       expect(result[0].value_text).toBe("single-choice");
     });
 
@@ -337,7 +338,7 @@ describe("transformResponseToFeedbackRecords", () => {
         data: { "el-multi": { row1: "col1", row2: "col2" } },
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-multi", hubFieldType: "categorical" })];
-      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
       expect(result[0].value_text).toBe(JSON.stringify({ row1: "col1", row2: "col2" }));
       expect(result[0].value_text).not.toBe("[object Object]");
     });
@@ -348,7 +349,7 @@ describe("transformResponseToFeedbackRecords", () => {
         data: { "el-multi": ["LabelA", "LabelB", "LabelC"] },
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-multi", hubFieldType: "categorical" })];
-      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
       expect(result).toHaveLength(1);
       expect(result[0].field_id).toBe("el-multi");
       expect(result[0].value_text).toBe("LabelA, LabelB, LabelC");
@@ -360,7 +361,7 @@ describe("transformResponseToFeedbackRecords", () => {
         data: { "el-multi": [] },
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-multi", hubFieldType: "categorical" })];
-      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
       expect(result).toHaveLength(1);
       expect(result[0].value_text).toBe("");
     });
@@ -376,7 +377,7 @@ describe("transformResponseToFeedbackRecords", () => {
           hubFieldType: "unknown-type" as TConnectorFormbricksMapping["hubFieldType"],
         }),
       ];
-      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings, mockTenantId);
       expect(result[0].value_text).toBe(JSON.stringify({ row1: "col1" }));
       expect(result[0].value_text).not.toBe("[object Object]");
     });
@@ -417,7 +418,7 @@ describe("transformResponseToFeedbackRecords", () => {
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-matrix", hubFieldType: "categorical" })];
 
-      const result = transformResponseToFeedbackRecords(response, matrixSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, matrixSurvey, mappings, mockTenantId);
 
       expect(result).toHaveLength(2);
       expect(result.every((r) => r.field_group_id === "el-matrix")).toBe(true);
@@ -446,7 +447,7 @@ describe("transformResponseToFeedbackRecords", () => {
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-matrix", hubFieldType: "categorical" })];
 
-      const result = transformResponseToFeedbackRecords(response, matrixSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, matrixSurvey, mappings, mockTenantId);
 
       expect(result).toHaveLength(1);
       expect(result[0].field_id).toBe("el-matrix__row-1");
@@ -460,10 +461,33 @@ describe("transformResponseToFeedbackRecords", () => {
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-matrix", hubFieldType: "categorical" })];
 
-      const result = transformResponseToFeedbackRecords(response, matrixSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, matrixSurvey, mappings, mockTenantId);
 
       expect(result).toHaveLength(1);
       expect(result[0].field_id).toBe("el-matrix__row-2");
+    });
+
+    test("JSON-stringifies non-string matrix cell value (regression for ENG-891)", () => {
+      const cellObject = { a: 1 };
+      const response = {
+        id: "resp-matrix-obj",
+        createdAt: NOW,
+        data: { "el-matrix": { Speed: cellObject } },
+      } as unknown as TResponse;
+      const mappings = [createMapping({ elementId: "el-matrix", hubFieldType: "categorical" })];
+
+      const result = transformResponseToFeedbackRecords(response, matrixSurvey, mappings, mockTenantId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        field_id: "el-matrix__row-1",
+        field_label: "Speed",
+        field_group_id: "el-matrix",
+        field_group_label: "Rate each feature",
+        metadata: { question_type: "matrix" },
+        value_text: JSON.stringify(cellObject),
+      });
+      expect(result[0].value_text).not.toBe("[object Object]");
     });
 
     test("emits no records for empty matrix response", () => {
@@ -474,7 +498,7 @@ describe("transformResponseToFeedbackRecords", () => {
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-matrix", hubFieldType: "categorical" })];
 
-      const result = transformResponseToFeedbackRecords(response, matrixSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, matrixSurvey, mappings, mockTenantId);
 
       expect(result).toEqual([]);
     });
@@ -512,7 +536,7 @@ describe("transformResponseToFeedbackRecords", () => {
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-ranking", hubFieldType: "categorical" })];
 
-      const result = transformResponseToFeedbackRecords(response, rankingSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, rankingSurvey, mappings, mockTenantId);
 
       expect(result).toHaveLength(3);
       expect(result.every((r) => r.field_group_id === "el-ranking")).toBe(true);
@@ -546,7 +570,7 @@ describe("transformResponseToFeedbackRecords", () => {
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-ranking", hubFieldType: "categorical" })];
 
-      const result = transformResponseToFeedbackRecords(response, rankingSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, rankingSurvey, mappings, mockTenantId);
 
       expect(result).toEqual([]);
     });
@@ -559,7 +583,7 @@ describe("transformResponseToFeedbackRecords", () => {
       } as unknown as TResponse;
       const mappings = [createMapping({ elementId: "el-ranking", hubFieldType: "categorical" })];
 
-      const result = transformResponseToFeedbackRecords(response, rankingSurvey, mappings);
+      const result = transformResponseToFeedbackRecords(response, rankingSurvey, mappings, mockTenantId);
 
       expect(result).toHaveLength(1);
       expect(result[0].field_id).toBe("el-ranking__ch-1");

--- a/apps/web/lib/connector/transform.test.ts
+++ b/apps/web/lib/connector/transform.test.ts
@@ -330,5 +330,240 @@ describe("transformResponseToFeedbackRecords", () => {
       const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
       expect(result[0].value_text).toBe("single-choice");
     });
+
+    test("JSON-stringifies object value for categorical field (matrix/ranking responses)", () => {
+      const response = {
+        ...mockResponse,
+        data: { "el-multi": { row1: "col1", row2: "col2" } },
+      } as unknown as TResponse;
+      const mappings = [createMapping({ elementId: "el-multi", hubFieldType: "categorical" })];
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      expect(result[0].value_text).toBe(JSON.stringify({ row1: "col1", row2: "col2" }));
+      expect(result[0].value_text).not.toBe("[object Object]");
+    });
+
+    test("creates a record for a ranking response (string array)", () => {
+      const response = {
+        ...mockResponse,
+        data: { "el-multi": ["LabelA", "LabelB", "LabelC"] },
+      } as unknown as TResponse;
+      const mappings = [createMapping({ elementId: "el-multi", hubFieldType: "categorical" })];
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      expect(result).toHaveLength(1);
+      expect(result[0].field_id).toBe("el-multi");
+      expect(result[0].value_text).toBe("LabelA, LabelB, LabelC");
+    });
+
+    test("creates a record for an empty ranking response (empty array)", () => {
+      const response = {
+        ...mockResponse,
+        data: { "el-multi": [] },
+      } as unknown as TResponse;
+      const mappings = [createMapping({ elementId: "el-multi", hubFieldType: "categorical" })];
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      expect(result).toHaveLength(1);
+      expect(result[0].value_text).toBe("");
+    });
+
+    test("JSON-stringifies object value for unknown hubFieldType (default branch)", () => {
+      const response = {
+        ...mockResponse,
+        data: { "el-multi": { row1: "col1" } },
+      } as unknown as TResponse;
+      const mappings = [
+        createMapping({
+          elementId: "el-multi",
+          hubFieldType: "unknown-type" as TConnectorFormbricksMapping["hubFieldType"],
+        }),
+      ];
+      const result = transformResponseToFeedbackRecords(response, mockSurvey, mappings);
+      expect(result[0].value_text).toBe(JSON.stringify({ row1: "col1" }));
+      expect(result[0].value_text).not.toBe("[object Object]");
+    });
+  });
+
+  describe("matrix expansion", () => {
+    const matrixSurvey = {
+      id: "survey-1",
+      name: "Matrix Survey",
+      blocks: [
+        {
+          elements: [
+            {
+              id: "el-matrix",
+              type: "matrix",
+              headline: { default: "Rate each feature" },
+              rows: [
+                { id: "row-1", label: { default: "Speed" } },
+                { id: "row-2", label: { default: "Quality" } },
+              ],
+              columns: [
+                { id: "col-1", label: { default: "Good" } },
+                { id: "col-2", label: { default: "Bad" } },
+              ],
+            },
+          ],
+        },
+      ],
+    } as unknown as TSurvey;
+
+    test("emits one record per answered row with shared field_group_id", () => {
+      const response = {
+        id: "resp-matrix",
+        createdAt: NOW,
+        data: { "el-matrix": { Speed: "Good", Quality: "Bad" } },
+        language: "default",
+        contact: { userId: "user-42" },
+      } as unknown as TResponse;
+      const mappings = [createMapping({ elementId: "el-matrix", hubFieldType: "categorical" })];
+
+      const result = transformResponseToFeedbackRecords(response, matrixSurvey, mappings);
+
+      expect(result).toHaveLength(2);
+      expect(result.every((r) => r.field_group_id === "el-matrix")).toBe(true);
+      expect(result.every((r) => r.field_group_label === "Rate each feature")).toBe(true);
+      expect(result.every((r) => r.submission_id === "resp-matrix")).toBe(true);
+      expect(result.every((r) => r.metadata?.question_type === "matrix")).toBe(true);
+
+      expect(result[0]).toMatchObject({
+        field_id: "el-matrix__row-1",
+        field_label: "Speed",
+        field_type: "categorical",
+        value_text: "Good",
+      });
+      expect(result[1]).toMatchObject({
+        field_id: "el-matrix__row-2",
+        field_label: "Quality",
+        value_text: "Bad",
+      });
+    });
+
+    test("skips matrix rows with empty cell value", () => {
+      const response = {
+        id: "resp-matrix-partial",
+        createdAt: NOW,
+        data: { "el-matrix": { Speed: "Good", Quality: "" } },
+      } as unknown as TResponse;
+      const mappings = [createMapping({ elementId: "el-matrix", hubFieldType: "categorical" })];
+
+      const result = transformResponseToFeedbackRecords(response, matrixSurvey, mappings);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].field_id).toBe("el-matrix__row-1");
+    });
+
+    test("skips matrix rows whose label does not match any row choice", () => {
+      const response = {
+        id: "resp-matrix-stale",
+        createdAt: NOW,
+        data: { "el-matrix": { "Old Row Label": "Good", Quality: "Bad" } },
+      } as unknown as TResponse;
+      const mappings = [createMapping({ elementId: "el-matrix", hubFieldType: "categorical" })];
+
+      const result = transformResponseToFeedbackRecords(response, matrixSurvey, mappings);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].field_id).toBe("el-matrix__row-2");
+    });
+
+    test("emits no records for empty matrix response", () => {
+      const response = {
+        id: "resp-empty",
+        createdAt: NOW,
+        data: { "el-matrix": {} },
+      } as unknown as TResponse;
+      const mappings = [createMapping({ elementId: "el-matrix", hubFieldType: "categorical" })];
+
+      const result = transformResponseToFeedbackRecords(response, matrixSurvey, mappings);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("ranking expansion", () => {
+    const rankingSurvey = {
+      id: "survey-1",
+      name: "Ranking Survey",
+      blocks: [
+        {
+          elements: [
+            {
+              id: "el-ranking",
+              type: "ranking",
+              headline: { default: "Rank these features" },
+              choices: [
+                { id: "ch-1", label: { default: "Reports" } },
+                { id: "ch-2", label: { default: "Dashboards" } },
+                { id: "ch-3", label: { default: "Alerts" } },
+              ],
+            },
+          ],
+        },
+      ],
+    } as unknown as TSurvey;
+
+    test("emits one record per ranked item with rank as value_number", () => {
+      const response = {
+        id: "resp-ranking",
+        createdAt: NOW,
+        data: { "el-ranking": ["Dashboards", "Reports", "Alerts"] },
+        language: "default",
+        contact: { userId: "user-42" },
+      } as unknown as TResponse;
+      const mappings = [createMapping({ elementId: "el-ranking", hubFieldType: "categorical" })];
+
+      const result = transformResponseToFeedbackRecords(response, rankingSurvey, mappings);
+
+      expect(result).toHaveLength(3);
+      expect(result.every((r) => r.field_group_id === "el-ranking")).toBe(true);
+      expect(result.every((r) => r.field_group_label === "Rank these features")).toBe(true);
+      expect(result.every((r) => r.field_type === "number")).toBe(true);
+      expect(result.every((r) => r.metadata?.question_type === "ranking")).toBe(true);
+      expect(result.every((r) => r.metadata?.total_items === 3)).toBe(true);
+
+      expect(result[0]).toMatchObject({
+        field_id: "el-ranking__ch-2",
+        field_label: "Dashboards",
+        value_number: 1,
+      });
+      expect(result[1]).toMatchObject({
+        field_id: "el-ranking__ch-1",
+        field_label: "Reports",
+        value_number: 2,
+      });
+      expect(result[2]).toMatchObject({
+        field_id: "el-ranking__ch-3",
+        field_label: "Alerts",
+        value_number: 3,
+      });
+    });
+
+    test("emits no records for empty ranking response", () => {
+      const response = {
+        id: "resp-empty",
+        createdAt: NOW,
+        data: { "el-ranking": [] },
+      } as unknown as TResponse;
+      const mappings = [createMapping({ elementId: "el-ranking", hubFieldType: "categorical" })];
+
+      const result = transformResponseToFeedbackRecords(response, rankingSurvey, mappings);
+
+      expect(result).toEqual([]);
+    });
+
+    test("skips ranking items whose label does not match any choice", () => {
+      const response = {
+        id: "resp-ranking-stale",
+        createdAt: NOW,
+        data: { "el-ranking": ["Reports", "Removed Option"] },
+      } as unknown as TResponse;
+      const mappings = [createMapping({ elementId: "el-ranking", hubFieldType: "categorical" })];
+
+      const result = transformResponseToFeedbackRecords(response, rankingSurvey, mappings);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].field_id).toBe("el-ranking__ch-1");
+      expect(result[0].value_number).toBe(1);
+    });
   });
 });

--- a/apps/web/lib/connector/transform.ts
+++ b/apps/web/lib/connector/transform.ts
@@ -2,14 +2,14 @@ import "server-only";
 import { TConnectorFormbricksMapping, THubFieldType } from "@formbricks/types/connector";
 import { TResponse, TResponseData, TResponseDataValue } from "@formbricks/types/responses";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/constants";
-import {
+import type {
   TSurveyElement,
   TSurveyElementChoice,
   TSurveyMatrixElement,
   TSurveyMatrixElementChoice,
   TSurveyRankingElement,
 } from "@formbricks/types/surveys/elements";
-import { TSurvey } from "@formbricks/types/surveys/types";
+import type { TSurvey } from "@formbricks/types/surveys/types";
 import { getTextContent } from "@formbricks/types/surveys/validation";
 import { getLocalizedValue } from "@/lib/i18n/utils";
 import { getElementsFromBlocks } from "@/lib/survey/utils";
@@ -160,7 +160,7 @@ const expandMatrixToRecords = (
       ...baseFields,
       field_id: `${element.id}__${row.id}`,
       field_type: mapping.hubFieldType,
-      field_label: getChoiceLabel(row, language),
+      field_label: getChoiceLabel(row, "default"),
       field_group_id: element.id,
       field_group_label: groupLabel,
       metadata: { question_type: "matrix" },
@@ -193,7 +193,7 @@ const expandRankingToRecords = (
       ...baseFields,
       field_id: `${element.id}__${choice.id}`,
       field_type: "number",
-      field_label: getChoiceLabel(choice, language),
+      field_label: getChoiceLabel(choice, "default"),
       field_group_id: element.id,
       field_group_label: groupLabel,
       metadata: { question_type: "ranking", total_items: value.length },

--- a/apps/web/lib/connector/transform.ts
+++ b/apps/web/lib/connector/transform.ts
@@ -1,7 +1,14 @@
 import "server-only";
 import { TConnectorFormbricksMapping, THubFieldType } from "@formbricks/types/connector";
 import { TResponse, TResponseData, TResponseDataValue } from "@formbricks/types/responses";
-import { TSurveyElement } from "@formbricks/types/surveys/elements";
+import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/constants";
+import {
+  TSurveyElement,
+  TSurveyElementChoice,
+  TSurveyMatrixElement,
+  TSurveyMatrixElementChoice,
+  TSurveyRankingElement,
+} from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { getTextContent } from "@formbricks/types/surveys/validation";
 import { getLocalizedValue } from "@/lib/i18n/utils";
@@ -12,6 +19,18 @@ const getHeadlineFromElement = (element?: TSurveyElement): string => {
   if (!element?.headline) return "Untitled";
   const raw = getLocalizedValue(element.headline, "default");
   return getTextContent(raw) || "Untitled";
+};
+
+const getChoiceLabel = (choice: { label: TSurveyElementChoice["label"] }, language: string): string => {
+  return getTextContent(getLocalizedValue(choice.label, language));
+};
+
+const findChoiceByLabel = <T extends { id: string; label: TSurveyElementChoice["label"] }>(
+  choices: T[],
+  label: string,
+  language: string
+): T | undefined => {
+  return choices.find((choice) => getChoiceLabel(choice, language) === label);
 };
 
 const toIsoTimestamp = (value: unknown): string | null => {
@@ -83,16 +102,115 @@ const convertValueToHubFields = (
     case "categorical":
       if (typeof value === "string") return { value_text: value };
       if (Array.isArray(value)) return { value_text: value.join(", ") };
+      if (typeof value === "object") return { value_text: JSON.stringify(value) };
       return { value_text: String(value) };
 
     default:
-      return { value_text: typeof value === "string" ? value : String(value) };
+      if (typeof value === "string") return { value_text: value };
+      if (Array.isArray(value)) return { value_text: value.join(", ") };
+      if (typeof value === "object") return { value_text: JSON.stringify(value) };
+      return { value_text: String(value) };
   }
+};
+
+type BaseRecordFields = Pick<
+  FeedbackRecordCreateParams,
+  "collected_at" | "source_type" | "submission_id" | "tenant_id" | "source_id" | "source_name"
+> & {
+  language?: string;
+  user_id?: string;
+};
+
+const buildBaseFields = (
+  response: TResponse,
+  survey: Pick<TSurvey, "id" | "name">,
+  tenantId: string
+): BaseRecordFields => ({
+  collected_at: getCollectedAt(response),
+  source_type: "formbricks_survey",
+  submission_id: response.id,
+  tenant_id: tenantId,
+  source_id: survey.id,
+  source_name: survey.name,
+  ...(response.language && response.language !== "default" ? { language: response.language } : {}),
+  ...(response.contact?.userId ? { user_id: response.contact.userId } : {}),
+});
+
+const expandMatrixToRecords = (
+  element: TSurveyMatrixElement,
+  mapping: TConnectorFormbricksMapping,
+  value: TResponseDataValue,
+  baseFields: BaseRecordFields
+): FeedbackRecordCreateParams[] => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+
+  const language = baseFields.language ?? "default";
+  const groupLabel = mapping.customFieldLabel || getHeadlineFromElement(element);
+  const records: FeedbackRecordCreateParams[] = [];
+
+  for (const [rowLabel, columnLabel] of Object.entries(value)) {
+    if (columnLabel === undefined || columnLabel === null || columnLabel === "") continue;
+
+    const row = findChoiceByLabel<TSurveyMatrixElementChoice>(element.rows, rowLabel, language);
+    if (!row) continue;
+
+    const cellValue = typeof columnLabel === "string" ? columnLabel : String(columnLabel);
+    const valueFields = convertValueToHubFields(cellValue, mapping.hubFieldType);
+
+    records.push({
+      ...baseFields,
+      field_id: `${element.id}__${row.id}`,
+      field_type: mapping.hubFieldType,
+      field_label: getChoiceLabel(row, language),
+      field_group_id: element.id,
+      field_group_label: groupLabel,
+      metadata: { question_type: "matrix" },
+      ...valueFields,
+    });
+  }
+
+  return records;
+};
+
+const expandRankingToRecords = (
+  element: TSurveyRankingElement,
+  mapping: TConnectorFormbricksMapping,
+  value: TResponseDataValue,
+  baseFields: BaseRecordFields
+): FeedbackRecordCreateParams[] => {
+  if (!Array.isArray(value) || value.length === 0) return [];
+
+  const language = baseFields.language ?? "default";
+  const groupLabel = mapping.customFieldLabel || getHeadlineFromElement(element);
+  const records: FeedbackRecordCreateParams[] = [];
+
+  value.forEach((itemLabel, index) => {
+    if (typeof itemLabel !== "string" || itemLabel === "") return;
+
+    const choice = findChoiceByLabel<TSurveyElementChoice>(element.choices, itemLabel, language);
+    if (!choice) return;
+
+    records.push({
+      ...baseFields,
+      field_id: `${element.id}__${choice.id}`,
+      field_type: "number",
+      field_label: getChoiceLabel(choice, language),
+      field_group_id: element.id,
+      field_group_label: groupLabel,
+      metadata: { question_type: "ranking", total_items: value.length },
+      value_number: index + 1,
+    });
+  });
+
+  return records;
 };
 
 /**
  * Transform a Formbricks survey response into FeedbackRecord payloads.
  * Called from the pipeline handler when a response is created/finished.
+ *
+ * Matrix and ranking questions expand into one record per row/item, sharing a
+ * field_group_id so Hub analytics can aggregate across them.
  */
 export function transformResponseToFeedbackRecords(
   response: TResponse,
@@ -106,31 +224,35 @@ export function transformResponseToFeedbackRecords(
   const surveyMappings = mappings.filter((m) => m.surveyId === survey.id);
   const elements = getElementsFromBlocks(survey.blocks);
   const elementMap = new Map(elements.map((el) => [el.id, el]));
+  const baseFields = buildBaseFields(response, survey, tenantId);
   const feedbackRecords: FeedbackRecordCreateParams[] = [];
 
   for (const mapping of surveyMappings) {
     const value = extractResponseValue(responseData, mapping.elementId);
     if (value === undefined || value === null || value === "") continue;
 
-    const fieldLabel = mapping.customFieldLabel || getHeadlineFromElement(elementMap.get(mapping.elementId));
+    const element = elementMap.get(mapping.elementId);
+
+    if (element?.type === TSurveyElementTypeEnum.Matrix) {
+      feedbackRecords.push(...expandMatrixToRecords(element, mapping, value, baseFields));
+      continue;
+    }
+
+    if (element?.type === TSurveyElementTypeEnum.Ranking) {
+      feedbackRecords.push(...expandRankingToRecords(element, mapping, value, baseFields));
+      continue;
+    }
+
+    const fieldLabel = mapping.customFieldLabel || getHeadlineFromElement(element);
     const valueFields = convertValueToHubFields(value, mapping.hubFieldType);
 
-    const feedbackRecord = {
-      collected_at: getCollectedAt(response),
-      source_type: "formbricks_survey",
-      submission_id: response.id,
-      tenant_id: tenantId,
+    feedbackRecords.push({
+      ...baseFields,
       field_id: mapping.elementId,
       field_type: mapping.hubFieldType,
-      source_id: survey.id,
-      source_name: survey.name,
       field_label: fieldLabel,
-      ...(response.language && response.language !== "default" ? { language: response.language } : {}),
-      ...(response.contact?.userId ? { user_id: response.contact.userId } : {}),
       ...valueFields,
-    };
-
-    feedbackRecords.push(feedbackRecord as FeedbackRecordCreateParams);
+    });
   }
 
   return feedbackRecords;

--- a/apps/web/lib/connector/transform.ts
+++ b/apps/web/lib/connector/transform.ts
@@ -154,8 +154,7 @@ const expandMatrixToRecords = (
     const row = findChoiceByLabel<TSurveyMatrixElementChoice>(element.rows, rowLabel, language);
     if (!row) continue;
 
-    const cellValue = typeof columnLabel === "string" ? columnLabel : String(columnLabel);
-    const valueFields = convertValueToHubFields(cellValue, mapping.hubFieldType);
+    const valueFields = convertValueToHubFields(columnLabel as TResponseDataValue, mapping.hubFieldType);
 
     records.push({
       ...baseFields,


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-891 and ENG-892

  Fixes two Hub feedback record bugs surfaced during v5 QA of the Unify Feedback connector:

  **1. Matrix responses rendered as `[object Object]` in Hub records**

  `convertValueToHubFields` in `apps/web/lib/connector/transform.ts` called `String(value)` in the `categorical` and `default` branches. Matrix responses are stored
  as `{ rowLabel: columnLabel }` objects, so `String({...})` produced the literal string `"[object Object]"`, which was then persisted to Hub and rendered verbatim by
   `formatValue` in the feedback records table. Both branches now `JSON.stringify` object values as a defensive fallback.

  **2. Matrix and ranking questions did not populate `field_group_id`**

  Per the [Hub data model](https://hub.formbricks.com/core-concepts/data-model/), composite questions (matrix, ranking, grid) should expand into one feedback record
  per row/item, linked by a shared `field_group_id` so Hub SQL aggregations work natively. Previously, `transformResponseToFeedbackRecords` emitted exactly one
  collapsed record per mapping, which broke the documented analytics patterns (`AVG(value_number) GROUP BY field_label`, etc.).

  This PR adds:
  - `expandMatrixToRecords`: emits one record per answered row with `field_group_id = elementId`, `field_id = <elementId>__<rowId>`, `field_label = row label`,
  `metadata.question_type = "matrix"`, and the cell value routed through the existing `convertValueToHubFields` based on the mapping's `hubFieldType`.
  - `expandRankingToRecords`: emits one record per ranked item with `field_group_id = elementId`, `field_type = "number"`, `value_number = 1-indexed rank`,
  `metadata.question_type = "ranking"`, and `metadata.total_items = N`.
  - Row/choice IDs are resolved by matching response labels against the element's `rows` / `choices` for the response's language. Rows or items whose labels no longer
   match (e.g. renamed/removed options) are skipped.

  All other question types continue to emit a single record as before.

  ## How should this be tested?

  1. Create or open a Unify Feedback connector pointing at a Hub source.
  2. Build a Formbricks survey with one matrix question and one ranking question, then connect both via the connector mapping UI.
  3. **Important:** restart your dev server after pulling this branch. `transform.ts` is `"server-only"` and Next.js HMR does not reliably reload it.
  4. Submit a response with answers to both questions.
  5. Open the Hub feedback records view and verify:
     - **Matrix:** one record per answered row appears. All matrix records share the same `field_group_id` and `submission_id`. `field_label` shows the row label.
  `value_text` shows the column value (no `[object Object]`). `metadata.question_type` is `"matrix"`.
     - **Ranking:** one record per ranked item appears. All ranking records share the same `field_group_id`. `field_type` is `number`, `value_number` matches the rank
   position (1, 2, 3, ...). `metadata.question_type` is `"ranking"`, `metadata.total_items` matches the choice count.
  6. Submit an empty matrix (`{}`) or empty ranking (`[]`) response → no records should be created for those questions.
  7. Rename a matrix row or ranking option in the survey editor, then submit a response that still contains the old label → the stale row/item is skipped (records
  still created for matched labels).
  8. Run `pnpm vitest run lib/connector/transform.test.ts` — 39/39 should pass. Full connector suite: `pnpm vitest run lib/connector/` — 105/105.

  ## Checklist

  ### Required

  - [x] Filled out the "How to test" section in this PR
  - [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
  - [x] Self-reviewed my own code
  - [x] Commented on my code in hard-to-understand bits
  - [x] Ran `pnpm build`
  - [x] Checked for warnings, there are none
  - [x] Removed all `console.logs`
  - [x] Merged the latest changes from main onto my branch with `git pull origin main`
  - [x] My changes don't cause any responsiveness issues
  - [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

  ### Appreciated

  - [ ] If a UI change was made: Added a screen recording or screenshots to this PR
  - [ ] Updated the Formbricks Docs if changes were necessary