### PR TITLE
fix: validate contact_id

### DIFF
--- a/apps/web/app/api/v2/client/[environmentId]/displays/lib/contact.test.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/displays/lib/contact.test.ts
@@ -21,6 +21,7 @@ vi.mock("react", async () => {
 });
 
 const contactId = "test-contact-id";
+const environmentId = "test-env-id";
 
 describe("doesContactExist", () => {
   afterEach(() => {
@@ -35,23 +36,23 @@ describe("doesContactExist", () => {
       environmentId: "test-env",
     });
 
-    const result = await doesContactExist(contactId);
+    const result = await doesContactExist(contactId, environmentId);
 
     expect(result).toBe(true);
     expect(prisma.contact.findFirst).toHaveBeenCalledWith({
-      where: { id: contactId },
+      where: { id: contactId, environmentId },
       select: { id: true },
     });
   });
 
-  test("should return false if contact does not exist", async () => {
+  test("should return false if contact does not exist in the environment", async () => {
     vi.mocked(prisma.contact.findFirst).mockResolvedValue(null);
 
-    const result = await doesContactExist(contactId);
+    const result = await doesContactExist(contactId, environmentId);
 
     expect(result).toBe(false);
     expect(prisma.contact.findFirst).toHaveBeenCalledWith({
-      where: { id: contactId },
+      where: { id: contactId, environmentId },
       select: { id: true },
     });
   });

--- a/apps/web/app/api/v2/client/[environmentId]/displays/lib/contact.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/displays/lib/contact.ts
@@ -1,10 +1,11 @@
 import { cache as reactCache } from "react";
 import { prisma } from "@formbricks/database";
 
-export const doesContactExist = reactCache(async (id: string): Promise<boolean> => {
+export const doesContactExist = reactCache(async (id: string, environmentId: string): Promise<boolean> => {
   const contact = await prisma.contact.findFirst({
     where: {
       id,
+      environmentId,
     },
     select: {
       id: true,

--- a/apps/web/app/api/v2/client/[environmentId]/displays/lib/display.test.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/displays/lib/display.test.ts
@@ -81,7 +81,7 @@ describe("createDisplay", () => {
     const result = await createDisplay(displayInput);
 
     expect(validateInputs).toHaveBeenCalledWith([displayInput, expect.any(Object)]);
-    expect(doesContactExist).toHaveBeenCalledWith(contactId);
+    expect(doesContactExist).toHaveBeenCalledWith(contactId, environmentId);
     expect(prisma.display.create).toHaveBeenCalledWith({
       data: {
         survey: { connect: { id: surveyId } },
@@ -108,14 +108,14 @@ describe("createDisplay", () => {
     expect(result).toEqual(mockDisplayWithoutContact); // Changed this line
   });
 
-  test("should create a display even if contact does not exist", async () => {
+  test("should create a display without contact if contact does not exist in the environment", async () => {
     vi.mocked(doesContactExist).mockResolvedValue(false);
     vi.mocked(prisma.display.create).mockResolvedValue(mockDisplayWithoutContact); // Expect no contact connection
 
     const result = await createDisplay(displayInput);
 
     expect(validateInputs).toHaveBeenCalledWith([displayInput, expect.any(Object)]);
-    expect(doesContactExist).toHaveBeenCalledWith(contactId);
+    expect(doesContactExist).toHaveBeenCalledWith(contactId, environmentId);
     expect(prisma.display.create).toHaveBeenCalledWith({
       data: {
         survey: { connect: { id: surveyId } },
@@ -142,7 +142,7 @@ describe("createDisplay", () => {
     vi.mocked(prisma.survey.findUnique).mockResolvedValue(null);
 
     await expect(createDisplay(displayInput)).rejects.toThrow(new ResourceNotFoundError("Survey", surveyId));
-    expect(doesContactExist).toHaveBeenCalledWith(contactId);
+    expect(doesContactExist).toHaveBeenCalledWith(contactId, environmentId);
     expect(prisma.survey.findUnique).toHaveBeenCalledWith({
       where: { id: surveyId, environmentId },
     });

--- a/apps/web/app/api/v2/client/[environmentId]/displays/lib/display.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/displays/lib/display.ts
@@ -14,7 +14,7 @@ export const createDisplay = async (displayInput: TDisplayCreateInputV2): Promis
   const { contactId, surveyId, environmentId } = displayInput;
 
   try {
-    const contactExists = contactId ? await doesContactExist(contactId) : false;
+    const contactExists = contactId ? await doesContactExist(contactId, environmentId) : false;
 
     const survey = await prisma.survey.findUnique({
       where: {

--- a/apps/web/app/api/v2/client/[environmentId]/responses/lib/contact.test.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/lib/contact.test.ts
@@ -13,6 +13,7 @@ vi.mock("@formbricks/database", () => ({
 }));
 
 const contactId = "test-contact-id";
+const environmentId = "test-env-id";
 const mockContact = {
   id: contactId,
   attributes: [
@@ -32,10 +33,10 @@ describe("getContact", () => {
       mockContact as unknown as Awaited<ReturnType<typeof prisma.contact.findUnique>>
     );
 
-    const result = await getContact(contactId);
+    const result = await getContact(contactId, environmentId);
 
     expect(prisma.contact.findUnique).toHaveBeenCalledWith({
-      where: { id: contactId },
+      where: { id: contactId, environmentId },
       select: {
         id: true,
         attributes: {
@@ -55,10 +56,10 @@ describe("getContact", () => {
   test("should return null when contact is not found", async () => {
     vi.mocked(prisma.contact.findUnique).mockResolvedValue(null);
 
-    const result = await getContact(contactId);
+    const result = await getContact(contactId, environmentId);
 
     expect(prisma.contact.findUnique).toHaveBeenCalledWith({
-      where: { id: contactId },
+      where: { id: contactId, environmentId },
       select: {
         id: true,
         attributes: {

--- a/apps/web/app/api/v2/client/[environmentId]/responses/lib/contact.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/lib/contact.ts
@@ -2,9 +2,16 @@ import { cache as reactCache } from "react";
 import { prisma } from "@formbricks/database";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
 
-export const getContact = reactCache(async (contactId: string) => {
+type TContactAttributeResult = {
+  attributeKey: {
+    key: string;
+  };
+  value: string;
+};
+
+export const getContact = reactCache(async (contactId: string, environmentId: string) => {
   const contact = await prisma.contact.findUnique({
-    where: { id: contactId },
+    where: { id: contactId, environmentId },
     select: {
       id: true,
       attributes: {
@@ -20,10 +27,13 @@ export const getContact = reactCache(async (contactId: string) => {
     return null;
   }
 
-  const contactAttributes = contact.attributes.reduce<TContactAttributes>((acc, attr) => {
-    acc[attr.attributeKey.key] = attr.value;
-    return acc;
-  }, {});
+  const contactAttributes = contact.attributes.reduce(
+    (acc: TContactAttributes, attr: TContactAttributeResult) => {
+      acc[attr.attributeKey.key] = attr.value;
+      return acc;
+    },
+    {}
+  );
 
   return {
     id: contact.id,

--- a/apps/web/app/api/v2/client/[environmentId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/lib/response.test.ts
@@ -236,6 +236,51 @@ describe("createResponse V2", () => {
     const result = await createResponse(mockResponseInput, mockTx as unknown as Prisma.TransactionClient);
     expect(result.tags).toEqual([mockTag]);
   });
+
+  test("should create response with contact when contact belongs to the environment", async () => {
+    const responseInputWithContact = {
+      ...mockResponseInput,
+      contactId,
+    };
+
+    const result = await createResponse(
+      responseInputWithContact,
+      mockTx as unknown as Prisma.TransactionClient
+    );
+
+    expect(getContact).toHaveBeenCalledWith(contactId, environmentId);
+    expect(mockTx.response.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          contact: { connect: { id: contactId } },
+          contactAttributes: mockContact.attributes,
+        }),
+      })
+    );
+    expect(result.contact).toEqual({
+      id: contactId,
+      userId,
+    });
+  });
+
+  test("should create response without contact when contact is not found in the environment", async () => {
+    vi.mocked(getContact).mockResolvedValue(null);
+    const responseInputWithContact = {
+      ...mockResponseInput,
+      contactId,
+    };
+
+    const result = await createResponse(
+      responseInputWithContact,
+      mockTx as unknown as Prisma.TransactionClient
+    );
+    const createArgs = mockTx.response.create.mock.calls[0][0];
+
+    expect(getContact).toHaveBeenCalledWith(contactId, environmentId);
+    expect(createArgs.data).not.toHaveProperty("contact");
+    expect(createArgs.data).not.toHaveProperty("contactAttributes");
+    expect(result.contact).toBeNull();
+  });
 });
 
 describe("createResponseWithQuotaEvaluation V2", () => {

--- a/apps/web/app/api/v2/client/[environmentId]/responses/lib/response.ts
+++ b/apps/web/app/api/v2/client/[environmentId]/responses/lib/response.ts
@@ -17,7 +17,7 @@ import { getContact } from "./contact";
 export const createResponseWithQuotaEvaluation = async (
   responseInput: TResponseInputV2
 ): Promise<TResponseWithQuotaFull> => {
-  const txResponse = await prisma.$transaction(async (tx) => {
+  const txResponse = await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const response = await createResponse(responseInput, tx);
 
     const quotaResult = await evaluateResponseQuotas({
@@ -101,7 +101,7 @@ export const createResponse = async (
     }
 
     if (contactId) {
-      contact = await getContact(contactId);
+      contact = await getContact(contactId, environmentId);
     }
 
     const ttc = initialTtc ? (finished ? calculateTtcTotal(initialTtc) : initialTtc) : {};


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-874

This PR scopes v2 public client API contact lookups to the requesting `environmentId`.

Previously, `/api/v2/client/[environmentId]/displays` and `/responses` accepted any existing `contactId` from the database. Now, contacts are only connected when the `contactId` belongs to the same environment as the request. Cross-environment contacts are treated like missing contacts, so the request still succeeds without linking a contact.

No public API shape changes, migrations, or docs updates are required.

## How should this be tested?

- `pnpm exec vitest run 'app/api/v2/client/[environmentId]/displays/lib/contact.test.ts' 'app/api/v2/client/[environmentId]/displays/lib/display.test.ts' 'app/api/v2/client/[environmentId]/responses/lib/contact.test.ts' 'app/api/v2/client/[environmentId]/responses/lib/response.test.ts' 'app/api/v2/client/[environmentId]/displays/route.test.ts' 'app/api/v2/client/[environmentId]/responses/route.test.ts'`
- `pnpm exec vitest run --coverage --coverage.include='app/api/v2/client/[environmentId]/displays/lib/contact.ts' --coverage.include='app/api/v2/client/[environmentId]/displays/lib/display.ts' --coverage.include='app/api/v2/client/[environmentId]/responses/lib/contact.ts' --coverage.include='app/api/v2/client/[environmentId]/responses/lib/response.ts' 'app/api/v2/client/[environmentId]/displays/lib/contact.test.ts' 'app/api/v2/client/[environmentId]/displays/lib/display.test.ts' 'app/api/v2/client/[environmentId]/responses/lib/contact.test.ts' 'app/api/v2/client/[environmentId]/responses/lib/response.test.ts' 'app/api/v2/client/[environmentId]/displays/route.test.ts' 'app/api/v2/client/[environmentId]/responses/route.test.ts'`

Coverage for changed implementation files: 100% statements, 100% lines, 100% functions, 87.5% branches.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary
