### PR TITLE
fix(helm): restore TEI float16 dtype

### DIFF
--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -186,6 +186,7 @@ Autoscaling is opt-in for Hub API, Hub worker, and the embeddings runtime. If yo
 | hub.embeddings.autoscaling.minReplicas                             | int    | `1`                               |             |
 | hub.embeddings.baseUrl                                             | string | `""`                              | Defaults to the internal TEI service URL ending in `/v1`. |
 | hub.embeddings.enabled                                             | bool   | `false`                           |             |
+| hub.embeddings.extraArgs                                           | list   | `["--dtype","float16"]`           | Additional args appended to the generated TEI args. |
 | hub.embeddings.huggingFace.existingSecret                          | string | `""`                              |             |
 | hub.embeddings.huggingFace.token                                   | string | `""`                              |             |
 | hub.embeddings.huggingFace.tokenKey                                | string | `"HF_TOKEN"`                      |             |

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -782,7 +782,10 @@ hub:
     # When empty, the chart renders TEI args from model, servedModelName, port,
     # revision, and persistence.mountPath. Set this to fully override args.
     args: []
-    extraArgs: []
+    # Keeps the default GTE CPU runtime within the default memory budget.
+    extraArgs:
+      - --dtype
+      - float16
     env: {}
 
     port: 8080


### PR DESCRIPTION
## Summary
- restore the default TEI `--dtype float16` extra arg for Hub embeddings
- document the default in the Formbricks chart README
- keeps `Alibaba-NLP/gte-multilingual-base` within the tested 8Gi CPU memory profile

## Verification
- `helm template formbricks-stage charts/formbricks -f /Users/bhagya/work/formbricks/gitops/formbricks/values-stage.yaml --set-string deployment.image.repository=715841356175.dkr.ecr.eu-central-1.amazonaws.com/formbricks/formbricks --set-string deployment.image.tag=staging-test --set-string hub.image.tag=0.3.0 --set-string hub.image.digest=sha256:6c39b1143527137e881df785a5b668625a1fe3edb05485bb5ded19f813c8de88 --show-only templates/hub-embeddings-deployment.yaml`
- `helm lint charts/formbricks -f /Users/bhagya/work/formbricks/gitops/formbricks/values-stage.yaml --set-string deployment.image.repository=715841356175.dkr.ecr.eu-central-1.amazonaws.com/formbricks/formbricks --set-string deployment.image.tag=staging-test --set-string hub.image.tag=0.3.0 --set-string hub.image.digest=sha256:6c39b1143527137e881df785a5b668625a1fe3edb05485bb5ded19f813c8de88`