### PR TITLE
fix(security): reject client-supplied emailVerificationDisabled in signup (ENG-816)

### DIFF
--- a/apps/web/modules/auth/signup/actions.ts
+++ b/apps/web/modules/auth/signup/actions.ts
@@ -201,8 +201,7 @@ async function handleOrganizationCreation(ctx: ActionClientCtx, user: TCreatedUs
 async function handlePostUserCreation(
   ctx: ActionClientCtx,
   user: TCreatedUser,
-  inviteToken: string | undefined,
-  emailVerificationDisabled: boolean | undefined
+  inviteToken: string | undefined
 ): Promise<void> {
   if (inviteToken) {
     await handleInviteAcceptance(ctx, inviteToken, user);
@@ -210,7 +209,7 @@ async function handlePostUserCreation(
     await handleOrganizationCreation(ctx, user);
   }
 
-  if (!emailVerificationDisabled) {
+  if (!EMAIL_VERIFICATION_DISABLED) {
     let inviteCallbackUrl: string | undefined;
 
     if (inviteToken) {
@@ -242,7 +241,7 @@ export const createUserAction = actionClient.inputSchema(ZCreateUserAction).acti
     );
 
     if (!userAlreadyExisted && user) {
-      await handlePostUserCreation(ctx, user, parsedInput.inviteToken, EMAIL_VERIFICATION_DISABLED);
+      await handlePostUserCreation(ctx, user, parsedInput.inviteToken);
 
       await subscribeUserToMailingList({
         email: user.email,

--- a/apps/web/modules/auth/signup/actions.ts
+++ b/apps/web/modules/auth/signup/actions.ts
@@ -6,6 +6,7 @@ import { InvalidInputError, UnknownError } from "@formbricks/types/errors";
 import { ZUser, ZUserEmail, ZUserLocale, ZUserName, ZUserPassword } from "@formbricks/types/user";
 import { hashPassword } from "@/lib/auth";
 import {
+  EMAIL_VERIFICATION_DISABLED,
   IS_FORMBRICKS_CLOUD,
   IS_TURNSTILE_CONFIGURED,
   TURNSTILE_SECRET_KEY,
@@ -45,7 +46,6 @@ const ZCreateUserAction = z.object({
   password: ZUserPassword,
   inviteToken: z.string().optional(),
   userLocale: ZUserLocale.optional(),
-  emailVerificationDisabled: z.boolean().optional(),
   turnstileToken: z
     .string()
     .optional()
@@ -53,7 +53,6 @@ const ZCreateUserAction = z.object({
       (token) => !IS_TURNSTILE_CONFIGURED || (IS_TURNSTILE_CONFIGURED && token),
       "CAPTCHA verification required"
     ),
-  isFormbricksCloud: z.boolean(),
   subscribeToSecurityUpdates: z.boolean().optional(),
   subscribeToProductUpdates: z.boolean().optional(),
 });
@@ -243,11 +242,11 @@ export const createUserAction = actionClient.inputSchema(ZCreateUserAction).acti
     );
 
     if (!userAlreadyExisted && user) {
-      await handlePostUserCreation(ctx, user, parsedInput.inviteToken, parsedInput.emailVerificationDisabled);
+      await handlePostUserCreation(ctx, user, parsedInput.inviteToken, EMAIL_VERIFICATION_DISABLED);
 
       await subscribeUserToMailingList({
         email: user.email,
-        isFormbricksCloud: parsedInput.isFormbricksCloud,
+        isFormbricksCloud: IS_FORMBRICKS_CLOUD,
         subscribeToSecurityUpdates: parsedInput.subscribeToSecurityUpdates,
         subscribeToProductUpdates: parsedInput.subscribeToProductUpdates,
       });

--- a/apps/web/modules/auth/signup/components/signup-form.tsx
+++ b/apps/web/modules/auth/signup/components/signup-form.tsx
@@ -114,9 +114,7 @@ export const SignupForm = ({
         password: data.password,
         userLocale,
         inviteToken: inviteToken ?? "",
-        emailVerificationDisabled,
         turnstileToken,
-        isFormbricksCloud,
         subscribeToSecurityUpdates,
         subscribeToProductUpdates,
       });


### PR DESCRIPTION
## What does this PR do?

Closes the trust-boundary violation tracked in [ENG-816](https://linear.app/formbricks/issue/ENG-816) / [GHSA-mm9v-v2qg-mw4v](https://github.com/formbricks/formbricks/security/advisories/GHSA-mm9v-v2qg-mw4v).

The signup server action accepted two security-relevant flags from the client payload — `emailVerificationDisabled` and `isFormbricksCloud` — and forwarded them straight to the branches that decide whether to send the verification email and which mailing-list mode to use. A forged signup request could set `emailVerificationDisabled: true` and skip the verification email even on instances where the server is configured to require it.

This PR:

- Removes `emailVerificationDisabled` and `isFormbricksCloud` from `ZCreateUserAction` so the Zod parse strips them from any client payload.
- Reads `EMAIL_VERIFICATION_DISABLED` and `IS_FORMBRICKS_CLOUD` from `@/lib/constants` inside the action body. These are the authoritative server-side values backed by env vars.
- Stops the signup form from forwarding the two props to the server action. They remain as local props for the redirect-URL UX decision after signup (a non-security concern; the value is already server-rendered via `signup/page.tsx`).

The fresh-instance signup page (`modules/setup/(fresh-instance)/signup/page.tsx`) uses the same form component, so it picks up the fix for free.

## How should this be tested?

Cloud-style server (`EMAIL_VERIFICATION_DISABLED=0`):
- Sign up via the UI as a normal user — the verification email should arrive.
- POST directly to the `createUserAction` endpoint with a forged `{ emailVerificationDisabled: true, ... }` payload — confirm the verification email is still sent and the user is created with `emailVerified: null`.

Self-hosted style server (`EMAIL_VERIFICATION_DISABLED=1`):
- Sign up via the UI — confirm no verification email is sent and the user can log in directly. Behaviour unchanged.

## Notes for reviewer

- Once this lands on `main`, please backport to the active release branches per the standard security backport process; the issue affects any version of the signup action that accepts the client-supplied flag.
- The advisory is published; references can be removed from the commit message if you'd rather keep the GHSA link out of the public title.

## Checklist

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Ran type-check on changed files
- [x] No new warnings
- [x] No console.logs