### PR TITLE
fix: remove duplicate brand color input and refresh appearance preview (ENG-927)

### DIFF
--- a/apps/web/modules/ee/whitelabel/remove-branding/components/edit-branding.tsx
+++ b/apps/web/modules/ee/whitelabel/remove-branding/components/edit-branding.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
@@ -18,6 +19,7 @@ interface EditBrandingProps {
 
 export const EditBranding = ({ type, isEnabled, workspaceId, isReadOnly }: EditBrandingProps) => {
   const { t } = useTranslation();
+  const router = useRouter();
   const [isBrandingEnabled, setIsBrandingEnabled] = useState(isEnabled);
   const [updatingBranding, setUpdatingBranding] = useState(false);
 
@@ -37,6 +39,7 @@ export const EditBranding = ({ type, isEnabled, workspaceId, isReadOnly }: EditB
           ? t("workspace.look.formbricks_branding_shown")
           : t("workspace.look.formbricks_branding_hidden")
       );
+      router.refresh();
     } else {
       const errorMessage = getFormattedErrorMessage(updateBrandingResponse);
       toast.error(errorMessage);

--- a/apps/web/modules/survey/editor/components/form-styling-settings.tsx
+++ b/apps/web/modules/survey/editor/components/form-styling-settings.tsx
@@ -83,23 +83,25 @@ export const FormStylingSettings = ({
         <hr className="py-1 text-slate-600" />
 
         <div className="flex flex-col gap-6 p-6">
-          <div className="grid grid-cols-2 items-end gap-4">
-            <ColorField
-              form={form}
-              name="brandColor.light"
-              label={t("workspace.surveys.edit.brand_color")}
-              description={t("workspace.surveys.edit.brand_color_description")}
-            />
-            <Button
-              type="button"
-              variant="default"
-              className="h-10 justify-center gap-1"
-              onClick={onSuggestColorsClick}
-              disabled={disabled || !onSuggestColorsClick}>
-              <SparklesIcon className="mr-2 h-4 w-4" />
-              {t("workspace.look.suggest_colors")}
-            </Button>
-          </div>
+          {!isSettingsPage && (
+            <div className="grid grid-cols-2 items-end gap-4">
+              <ColorField
+                form={form}
+                name="brandColor.light"
+                label={t("workspace.surveys.edit.brand_color")}
+                description={t("workspace.surveys.edit.brand_color_description")}
+              />
+              <Button
+                type="button"
+                variant="default"
+                className="h-10 justify-center gap-1"
+                onClick={onSuggestColorsClick}
+                disabled={disabled || !onSuggestColorsClick}>
+                <SparklesIcon className="mr-2 h-4 w-4" />
+                {t("workspace.look.suggest_colors")}
+              </Button>
+            </div>
+          )}
 
           {/* Headlines & Descriptions */}
           <StylingSection

--- a/apps/web/modules/workspaces/settings/look/components/edit-logo.tsx
+++ b/apps/web/modules/workspaces/settings/look/components/edit-logo.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { useRouter } from "next/navigation";
 import { ChangeEvent, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
@@ -26,6 +27,7 @@ interface EditLogoProps {
 
 export const EditLogo = ({ workspace, workspaceId, isReadOnly, isStorageConfigured }: EditLogoProps) => {
   const { t } = useTranslation();
+  const router = useRouter();
   const [logoUrl, setLogoUrl] = useState<string | undefined>(workspace.logo?.url || undefined);
   const [logoBgColor, setLogoBgColor] = useState<string | undefined>(workspace.logo?.bgColor || undefined);
   const [isBgColorEnabled, setIsBgColorEnabled] = useState<boolean>(!!workspace.logo?.bgColor);
@@ -77,6 +79,7 @@ export const EditLogo = ({ workspace, workspaceId, isReadOnly, isStorageConfigur
       });
       if (updateWorkspaceResponse?.data) {
         toast.success(t("workspace.look.logo_updated_successfully"));
+        router.refresh();
       } else {
         const errorMessage = getFormattedErrorMessage(updateWorkspaceResponse);
         toast.error(errorMessage);
@@ -107,6 +110,7 @@ export const EditLogo = ({ workspace, workspaceId, isReadOnly, isStorageConfigur
       });
       if (updateWorkspaceResponse?.data) {
         toast.success(t("workspace.look.logo_removed_successfully"));
+        router.refresh();
       } else {
         const errorMessage = getFormattedErrorMessage(updateWorkspaceResponse);
         toast.error(errorMessage);


### PR DESCRIPTION
## What does this PR do?

Fixes [ENG-927](https://linear.app/formbricks/issue/ENG-927/duplicate-brand-color-input-in-appearance).

Two issues on the workspace Appearance settings page:

1. **Brand color input was rendered twice** — once at the top of the Theme card and again inside the "Survey styling" collapsible (because `FormStylingSettings` is shared with the survey editor, where the brand color must remain). Fix: hide the brand color block inside `FormStylingSettings` when `isSettingsPage` is true, so it only renders once on the Appearance page while still showing in the survey editor.

2. **Preview did not auto-update after a logo upload or branding-toggle change** — `EditLogo` and `EditBranding` were calling the update server actions but never refreshing the route, so the parent server component kept passing the stale `workspace` prop into `ThemeStyling`. Fix: call `router.refresh()` after a successful save in `EditLogo.saveChanges`, `EditLogo.removeLogo`, and `EditBranding.toggleBranding`.

## How should this be tested?

- Open workspace → Settings → Appearance.
  - Verify only one "Brand Color" picker is shown in the Theme card.
  - Open the "Survey styling" collapsible — brand color should NOT appear there again.
- Open a survey editor → Styling tab.
  - Open "Survey styling" — brand color picker should still appear (unchanged behavior).
- On the Appearance page:
  - Upload a new logo and click Save → the preview survey on the right should update with the new logo without a manual refresh.
  - Remove the logo → the preview should drop the logo.
  - Toggle a Formbricks branding switch → the preview's branding watermark should update accordingly.