### PR TITLE
fix: point upgrade banner Learn more links to docs (ENG-889)

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/components/AISettingsToggle.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/components/AISettingsToggle.tsx
@@ -95,9 +95,7 @@ export const AISettingsToggle = ({
     },
     {
       text: t("common.learn_more"),
-      href: isFormbricksCloud
-        ? `${workspaceBasePath}/settings/organization/billing`
-        : "https://formbricks.com/learn-more-self-hosting-license",
+      href: "https://formbricks.com/docs/platform/features/ai-features",
     },
   ];
 

--- a/apps/web/modules/ee/analysis/charts/components/charts-list-page.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/charts-list-page.tsx
@@ -61,9 +61,7 @@ export async function ChartsListPage({ workspaceId }: Readonly<ChartsListPagePro
               },
               {
                 text: t("common.learn_more"),
-                href: IS_FORMBRICKS_CLOUD
-                  ? `/workspaces/${workspaceId}/settings/organization/billing`
-                  : "https://formbricks.com/learn-more-self-hosting-license",
+                href: "https://formbricks.com/docs/unify-feedback/features/dashboards-and-charts",
               },
             ]}
           />

--- a/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
@@ -86,9 +86,7 @@ export async function DashboardDetailPage({
               },
               {
                 text: t("common.learn_more"),
-                href: IS_FORMBRICKS_CLOUD
-                  ? `/workspaces/${workspaceId}/settings/organization/billing`
-                  : "https://formbricks.com/learn-more-self-hosting-license",
+                href: "https://formbricks.com/docs/unify-feedback/features/dashboards-and-charts",
               },
             ]}
           />

--- a/apps/web/modules/ee/analysis/dashboards/pages/dashboards-list-page.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/pages/dashboards-list-page.tsx
@@ -57,9 +57,7 @@ export const DashboardsListPage = async ({ workspaceId }: Readonly<DashboardsLis
               },
               {
                 text: t("common.learn_more"),
-                href: IS_FORMBRICKS_CLOUD
-                  ? `/workspaces/${workspaceId}/settings/organization/billing`
-                  : "https://formbricks.com/learn-more-self-hosting-license",
+                href: "https://formbricks.com/docs/unify-feedback/features/dashboards-and-charts",
               },
             ]}
           />

--- a/apps/web/modules/ee/unify-feedback/page.tsx
+++ b/apps/web/modules/ee/unify-feedback/page.tsx
@@ -55,9 +55,7 @@ export default async function UnifyFeedbackRecordsPage(
               },
               {
                 text: t("common.learn_more"),
-                href: IS_FORMBRICKS_CLOUD
-                  ? `/workspaces/${params.workspaceId}/settings/organization/billing`
-                  : "https://formbricks.com/learn-more-self-hosting-license",
+                href: "https://formbricks.com/docs/unify-feedback/overview",
               },
             ]}
           />

--- a/apps/web/modules/ee/whitelabel/remove-branding/components/branding-settings-card.tsx
+++ b/apps/web/modules/ee/whitelabel/remove-branding/components/branding-settings-card.tsx
@@ -29,9 +29,7 @@ export const BrandingSettingsCard = async ({
     },
     {
       text: t("common.learn_more"),
-      href: IS_FORMBRICKS_CLOUD
-        ? `${workspaceBasePath}/settings/organization/billing`
-        : "https://formbricks.com/learn-more-self-hosting-license",
+      href: "https://formbricks.com/docs/self-hosting/advanced/enterprise-features/hide-powered-by-formbricks",
     },
   ];
 


### PR DESCRIPTION
## What does this PR do?

Fixes [ENG-889](https://linear.app/formbricks/issue/ENG-889/incorrect-redirect-in-upgrade-banner).

The "Learn more" button in the upgrade banners was pointing to the billing page on cloud (and to the trial-license landing page on self-hosted), neither of which is documentation. This PR routes those buttons to the actual feature docs:

| Feature | New "Learn more" URL |
|---|---|
| Unify Feedback (Overview) | https://formbricks.com/docs/unify-feedback/overview |
| Dashboards (list + detail) | https://formbricks.com/docs/unify-feedback/features/dashboards-and-charts |
| Charts | https://formbricks.com/docs/unify-feedback/features/dashboards-and-charts |
| AI Features | https://formbricks.com/docs/platform/features/ai-features |
| Remove Branding | https://formbricks.com/docs/self-hosting/advanced/enterprise-features/hide-powered-by-formbricks |

The primary CTA ("Upgrade plan" / "Request trial license") is unchanged — it still routes to billing on cloud and to the upgrade landing page on self-hosted.

## How should this be tested?

For each banner below, click "Learn more" and verify it opens the docs URL in a new tab (not the billing page):

- [ ] Workspace → Unify feedback (when feature gated) — `/modules/ee/unify-feedback/page.tsx`
- [ ] Workspace → Analysis → Dashboards list (when feature gated) — `dashboards-list-page.tsx`
- [ ] Workspace → Analysis → Dashboards → any dashboard (when feature gated) — `dashboard-detail-page.tsx`
- [ ] Workspace → Analysis → Charts (when feature gated) — `charts-list-page.tsx`
- [ ] Workspace → Settings → Organization → General → AI features section (when feature gated) — `AISettingsToggle.tsx`
- [ ] Workspace → Settings → Appearance → Formbricks branding (when feature gated) — `branding-settings-card.tsx`