### PR TITLE
fix: read appSetupCompleted from workspace prop in survey editor (ENG-928)

### DIFF
--- a/apps/web/modules/survey/editor/components/how-to-send-card.tsx
+++ b/apps/web/modules/survey/editor/components/how-to-send-card.tsx
@@ -7,7 +7,6 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TSegment } from "@formbricks/types/segment";
 import { TSurvey, TSurveyType } from "@formbricks/types/surveys/types";
-import { useWorkspace } from "@/app/(app)/workspaces/[workspaceId]/context/workspace-context";
 import { getDefaultEndingCard } from "@/app/lib/survey-builder";
 import { cn } from "@/lib/cn";
 import { Alert, AlertButton, AlertDescription, AlertTitle } from "@/modules/ui/components/alert";
@@ -18,11 +17,11 @@ import { RadioGroup, RadioGroupItem } from "@/modules/ui/components/radio-group"
 interface HowToSendCardProps {
   localSurvey: TSurvey;
   setLocalSurvey: (survey: TSurvey | ((TSurvey: TSurvey) => TSurvey)) => void;
+  appSetupCompleted: boolean;
 }
 
-export const HowToSendCard = ({ localSurvey, setLocalSurvey }: HowToSendCardProps) => {
-  const { workspace } = useWorkspace();
-  const workspaceBasePath = `/workspaces/${workspace?.id}`;
+export const HowToSendCard = ({ localSurvey, setLocalSurvey, appSetupCompleted }: HowToSendCardProps) => {
+  const workspaceBasePath = `/workspaces/${localSurvey.workspaceId}`;
   const [open, setOpen] = useState(false);
   const { t } = useTranslation();
 
@@ -82,7 +81,7 @@ export const HowToSendCard = ({ localSurvey, setLocalSurvey }: HowToSendCardProp
       icon: MonitorIcon,
       description: t("workspace.surveys.edit.app_survey_description"),
       comingSoon: false,
-      alert: !workspace?.appSetupCompleted,
+      alert: !appSetupCompleted,
     },
   ];
 

--- a/apps/web/modules/survey/editor/components/settings-view.tsx
+++ b/apps/web/modules/survey/editor/components/settings-view.tsx
@@ -30,6 +30,7 @@ interface SettingsViewProps {
   isQuotasAllowed: boolean;
   quotas: TSurveyQuota[];
   locale: TUserLocale;
+  appSetupCompleted: boolean;
 }
 
 export const SettingsView = ({
@@ -47,12 +48,17 @@ export const SettingsView = ({
   isFormbricksCloud,
   quotas,
   locale,
+  appSetupCompleted,
 }: SettingsViewProps) => {
   const isAppSurvey = localSurvey.type === "app";
 
   return (
     <div className="mt-12 space-y-3 p-5">
-      <HowToSendCard localSurvey={localSurvey} setLocalSurvey={setLocalSurvey} />
+      <HowToSendCard
+        localSurvey={localSurvey}
+        setLocalSurvey={setLocalSurvey}
+        appSetupCompleted={appSetupCompleted}
+      />
 
       {localSurvey.type === "app" ? (
         <div>

--- a/apps/web/modules/survey/editor/components/survey-editor.tsx
+++ b/apps/web/modules/survey/editor/components/survey-editor.tsx
@@ -265,6 +265,7 @@ export const SurveyEditor = ({
               isQuotasAllowed={isQuotasAllowed}
               quotas={quotas}
               locale={locale}
+              appSetupCompleted={localWorkspace.appSetupCompleted}
             />
           )}
 


### PR DESCRIPTION
## What does this PR do?

Fixes [ENG-928](https://linear.app/formbricks/issue/ENG-928/connected-app-still-shows-sdk-not-connected).

The survey editor's "How to send" card was always showing the *"Formbricks SDK is not connected"* warning, even after the SDK had been connected and the workspace's app-connection page confirmed it.

### Root cause

The survey editor route lives under the `(survey-editor)` route group (`app/(app)/(survey-editor)/workspaces/[workspaceId]/layout.tsx`), which is a sibling of the main workspace layout that provides `WorkspaceContext`. As a result, `useWorkspace()` inside `how-to-send-card.tsx` falls back to `{ workspace: null }`. The alert condition was:

```ts
alert: !workspace?.appSetupCompleted,
```

Because `workspace` is `null`, `workspace?.appSetupCompleted` is `undefined`, so the alert always rendered. The same broken `workspace?.id` was also used to build the `"Connect Formbricks"` button URL — so on click it would have opened `/workspaces/undefined/app-connection`.

### Fix

Thread `appSetupCompleted` through props from the survey editor (which already keeps `localWorkspace` fresh via `refetchWorkspaceAction` on tab-visibility change) → `SettingsView` → `HowToSendCard`. Drop the `useWorkspace()` context lookup in `HowToSendCard` and derive `workspaceBasePath` from `localSurvey.workspaceId` instead.

## How should this be tested?

- Open a workspace that already has its SDK connected (verify on `/workspaces/<id>/settings/workspace/app-connection` that the status indicator shows green / "Receiving data").
- Open any survey → Settings → "How to send".
- Select "Website / app survey". The "Formbricks SDK is not connected" warning should NOT appear.
- For a workspace that has *not* connected an SDK, the warning should still appear, and the "Connect Formbricks" button should open `/workspaces/<workspaceId>/app-connection` correctly (no `undefined` in the URL).
- After connecting the SDK in a separate tab and returning to the editor, the warning should disappear once the existing `useDocumentVisibility` hook refreshes `localWorkspace`.