### PR TITLE
docs: add ACCESSIBILITY.md and accessibility issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -1,0 +1,78 @@
+name: Accessibility issue
+description: "Report an accessibility barrier in Formbricks (WCAG, screen reader, keyboard, contrast, etc.)"
+type: bug
+labels: ["accessibility", "bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping make Formbricks accessible to everyone. Please fill in as much as you can — see [ACCESSIBILITY.md](https://github.com/formbricks/formbricks/blob/main/ACCESSIBILITY.md) for context.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What part of Formbricks is affected and what's wrong?
+      placeholder: "e.g. The language switcher in survey runtime can't be reached with Tab."
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open a survey with multiple languages
+        2. Press Tab repeatedly
+        3. Focus never lands on the language switcher
+    validations:
+      required: true
+  - type: input
+    id: wcag
+    attributes:
+      label: Related WCAG criterion (if known)
+      placeholder: "e.g. 2.1.1 Keyboard"
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - "Critical — blocks a user from completing a core task"
+        - "High — significant barrier with no easy workaround"
+        - "Medium — barrier with a workaround"
+        - "Low — minor friction"
+    validations:
+      required: true
+  - type: input
+    id: at
+    attributes:
+      label: Assistive technology
+      placeholder: "e.g. NVDA 2024.1, VoiceOver on macOS 14, keyboard only"
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and OS
+      placeholder: "e.g. Firefox 124 on Windows 11"
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Your Environment
+      options:
+        - Formbricks Cloud (app.formbricks.com)
+        - Self-hosted Formbricks
+    validations:
+      required: true
+  - type: textarea
+    id: other
+    attributes:
+      label: Other information (screenshots, recordings, axe output)

--- a/.github/ISSUE_TEMPLATE/accessibility.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility.yml
@@ -57,12 +57,12 @@ body:
     id: at
     attributes:
       label: Assistive technology
-      placeholder: "e.g. NVDA 2024.1, VoiceOver on macOS 14, keyboard only"
+      placeholder: "e.g. NVDA 2026.1, VoiceOver on macOS 15, keyboard only"
   - type: input
     id: browser
     attributes:
       label: Browser and OS
-      placeholder: "e.g. Firefox 124 on Windows 11"
+      placeholder: "e.g. Firefox 138 on Windows 11"
   - type: dropdown
     id: environment
     attributes:

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -1,85 +1,48 @@
 # Accessibility
 
-Formbricks is committed to making our experience management platform usable by everyone, including people who rely on assistive technologies. This document describes our current accessibility posture, the standards we're working toward, and how you can help.
+Formbricks is committed to making our platform usable by everyone, including people who rely on assistive technologies.
 
-This is a living document. We just completed our first internal audit of the survey runtime and have started landing fixes — expect this page to evolve as work progresses.
+## Standards
 
-## Goals
+We aim to conform to:
 
-We aim to conform to the following standards:
-
-- **[WCAG 2.1 Level AA](https://www.w3.org/TR/WCAG21/)** — the web content baseline procurement teams typically require.
-- **[EN 301 549](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/)** — the European harmonised standard referenced by the **European Accessibility Act (EAA)**, which applies to Formbricks as an EU-based company.
+- **[WCAG 2.1 Level AA](https://www.w3.org/TR/WCAG21/)** — the web content baseline.
+- **[EN 301 549](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/)** — the European harmonised standard referenced by the **European Accessibility Act (EAA)**, applicable to us as a Germany-based company.
 - **Section 508** — for users in US public-sector contexts.
 
-Priority areas where we're focused first:
+## Priorities
 
-- **Keyboard navigation** for the survey runtime and admin app — every interactive control reachable and operable without a mouse.
-- **Screen reader support** — correct semantics, landmark roles, and live regions for status messages.
-- **Visible focus** — every focusable element has a clearly visible focus indicator.
-- **Color and contrast** — text and meaningful UI meet AA contrast ratios across themes.
-- **Forms and errors** — labels are programmatically associated; validation errors are announced.
+1. **End-user surveys** (`packages/surveys`) — everything respondents see and interact with. This is our highest priority because survey takers don't choose Formbricks; the organisations running surveys choose for them.
+2. **Admin app** (`apps/web`) — survey creation, response analysis, and team management used by Formbricks customers.
 
-## Current Status
+In both areas we focus on:
 
-We are **not yet fully WCAG 2.1 AA conformant**. A static accessibility audit of `packages/surveys` on **2026-04-28** identified 14 findings (3 Critical, 7 Major, 4 Minor). Remediation is in progress:
-
-- [#7927](https://github.com/formbricks/formbricks/pull/7927)
-- [#7936](https://github.com/formbricks/formbricks/pull/7936)
-- [#7939](https://github.com/formbricks/formbricks/pull/7939)
-
-A formal VPAT / EN 301 549 conformance statement will be published once the survey runtime and admin app reach a stable AA baseline.
-
-### Known Limitations
-
-- Modal surveys do not yet expose a `role="dialog"` and do not trap keyboard focus.
-- The language switcher in surveys is not yet reachable by keyboard.
-- Several status messages (network errors, validation, progress) are not announced to screen readers.
-- Color contrast has not been verified across all themes — themes are user-configurable and need per-theme review.
-- The admin app (`apps/web`) has not yet been audited.
-
-See the [open accessibility issues](https://github.com/formbricks/formbricks/labels/accessibility) for the live list.
+- Keyboard navigation with a clearly visible focus indicator
+- Screen reader support through semantic HTML and correctly scoped ARIA
+- Sufficient color and contrast
+- Programmatically associated labels and announced status messages
 
 ## Supported Environments
 
-- **Survey runtime** (`packages/surveys`) — embedded in customer websites and rendered as link surveys. Primary accessibility focus.
-- **Admin app** (`apps/web`) — survey creation, response analysis, and team management. Audit pending.
-- **Browsers** — latest two versions of Chrome, Firefox, Safari, and Edge.
-- **Assistive technologies** — we test against VoiceOver (macOS/iOS), NVDA (Windows), and TalkBack (Android). Other AT may work but is not actively validated.
+- Latest two versions of Chrome, Firefox, Safari, and Edge
+- VoiceOver (macOS/iOS), NVDA (Windows), and TalkBack (Android)
 
-## Contributor Requirements
+## Contributing
 
-If you are contributing UI changes, please:
+When contributing UI changes:
 
-1. **Use semantic HTML first.** A `<button>` beats a `<div role="button">`. Reach for ARIA only when native semantics don't fit.
-2. **Keyboard test your change.** Tab through it. Activate every control with Enter/Space. Esc should close overlays.
-3. **Preserve focus.** Don't add `tabIndex={-1}` to interactive elements. Move focus deliberately when content changes (e.g. on modal open).
-4. **Label every control.** Inputs need a programmatically associated `<label>` or `aria-label`. Icon-only buttons need an `aria-label`.
-5. **Announce status changes.** Use `role="alert"` for errors and `role="status"` / `aria-live="polite"` for non-urgent updates. Don't wrap large regions in `aria-live` — scope it tightly.
-6. **Don't rely on color alone** to convey meaning (errors, required fields, status).
-7. **Check contrast.** Text against its background should meet 4.5:1 (3:1 for large text and UI components).
-8. **Run [axe DevTools](https://www.deque.com/axe/devtools/) or Lighthouse** on the page you changed before opening a PR.
-
-PRs that touch UI should mention accessibility considerations in the description.
+- Prefer semantic HTML over ARIA.
+- Tab through your change end-to-end and confirm focus is visible at every stop.
+- Label every control. Don't convey meaning by color alone.
+- Run [axe DevTools](https://www.deque.com/axe/devtools/) or Lighthouse on the page you changed.
 
 ## Reporting Accessibility Issues
 
-If you find an accessibility barrier, please [open an issue](https://github.com/formbricks/formbricks/issues/new?labels=accessibility&template=accessibility.yml) using the accessibility template.
-
-Include:
-
-- The page or component affected
-- Expected vs. actual behavior
-- Steps to reproduce
-- Browser, OS, and assistive technology (e.g. NVDA 2024.1 on Firefox 124)
-- Severity from your perspective (blocker vs. inconvenience)
-
-For issues that block you from completing a task — especially in a procurement or compliance context — email **[hola@formbricks.com](mailto:hola@formbricks.com)** so we can prioritise appropriately.
+If you encounter an accessibility barrier, please [open an issue](https://github.com/formbricks/formbricks/issues/new?labels=accessibility&template=accessibility.yml) using the accessibility template. For blocking issues in a procurement or compliance context, email **[hola@formbricks.com](mailto:hola@formbricks.com)**.
 
 ## Resources
 
 - [WCAG 2.1 Quick Reference](https://www.w3.org/WAI/WCAG21/quickref/)
-- [EN 301 549 (v3.2.1)](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/)
+- [EN 301 549](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/)
 - [European Accessibility Act overview](https://ec.europa.eu/social/main.jsp?catId=1202)
-- [GitHub's Accessibility Best Practices guide](https://opensource.guide/accessibility-best-practices-for-your-project/)
 - [MDN Accessibility Reference](https://developer.mozilla.org/en-US/docs/Web/Accessibility)

--- a/ACCESSIBILITY.md
+++ b/ACCESSIBILITY.md
@@ -1,0 +1,85 @@
+# Accessibility
+
+Formbricks is committed to making our experience management platform usable by everyone, including people who rely on assistive technologies. This document describes our current accessibility posture, the standards we're working toward, and how you can help.
+
+This is a living document. We just completed our first internal audit of the survey runtime and have started landing fixes — expect this page to evolve as work progresses.
+
+## Goals
+
+We aim to conform to the following standards:
+
+- **[WCAG 2.1 Level AA](https://www.w3.org/TR/WCAG21/)** — the web content baseline procurement teams typically require.
+- **[EN 301 549](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/)** — the European harmonised standard referenced by the **European Accessibility Act (EAA)**, which applies to Formbricks as an EU-based company.
+- **Section 508** — for users in US public-sector contexts.
+
+Priority areas where we're focused first:
+
+- **Keyboard navigation** for the survey runtime and admin app — every interactive control reachable and operable without a mouse.
+- **Screen reader support** — correct semantics, landmark roles, and live regions for status messages.
+- **Visible focus** — every focusable element has a clearly visible focus indicator.
+- **Color and contrast** — text and meaningful UI meet AA contrast ratios across themes.
+- **Forms and errors** — labels are programmatically associated; validation errors are announced.
+
+## Current Status
+
+We are **not yet fully WCAG 2.1 AA conformant**. A static accessibility audit of `packages/surveys` on **2026-04-28** identified 14 findings (3 Critical, 7 Major, 4 Minor). Remediation is in progress:
+
+- [#7927](https://github.com/formbricks/formbricks/pull/7927)
+- [#7936](https://github.com/formbricks/formbricks/pull/7936)
+- [#7939](https://github.com/formbricks/formbricks/pull/7939)
+
+A formal VPAT / EN 301 549 conformance statement will be published once the survey runtime and admin app reach a stable AA baseline.
+
+### Known Limitations
+
+- Modal surveys do not yet expose a `role="dialog"` and do not trap keyboard focus.
+- The language switcher in surveys is not yet reachable by keyboard.
+- Several status messages (network errors, validation, progress) are not announced to screen readers.
+- Color contrast has not been verified across all themes — themes are user-configurable and need per-theme review.
+- The admin app (`apps/web`) has not yet been audited.
+
+See the [open accessibility issues](https://github.com/formbricks/formbricks/labels/accessibility) for the live list.
+
+## Supported Environments
+
+- **Survey runtime** (`packages/surveys`) — embedded in customer websites and rendered as link surveys. Primary accessibility focus.
+- **Admin app** (`apps/web`) — survey creation, response analysis, and team management. Audit pending.
+- **Browsers** — latest two versions of Chrome, Firefox, Safari, and Edge.
+- **Assistive technologies** — we test against VoiceOver (macOS/iOS), NVDA (Windows), and TalkBack (Android). Other AT may work but is not actively validated.
+
+## Contributor Requirements
+
+If you are contributing UI changes, please:
+
+1. **Use semantic HTML first.** A `<button>` beats a `<div role="button">`. Reach for ARIA only when native semantics don't fit.
+2. **Keyboard test your change.** Tab through it. Activate every control with Enter/Space. Esc should close overlays.
+3. **Preserve focus.** Don't add `tabIndex={-1}` to interactive elements. Move focus deliberately when content changes (e.g. on modal open).
+4. **Label every control.** Inputs need a programmatically associated `<label>` or `aria-label`. Icon-only buttons need an `aria-label`.
+5. **Announce status changes.** Use `role="alert"` for errors and `role="status"` / `aria-live="polite"` for non-urgent updates. Don't wrap large regions in `aria-live` — scope it tightly.
+6. **Don't rely on color alone** to convey meaning (errors, required fields, status).
+7. **Check contrast.** Text against its background should meet 4.5:1 (3:1 for large text and UI components).
+8. **Run [axe DevTools](https://www.deque.com/axe/devtools/) or Lighthouse** on the page you changed before opening a PR.
+
+PRs that touch UI should mention accessibility considerations in the description.
+
+## Reporting Accessibility Issues
+
+If you find an accessibility barrier, please [open an issue](https://github.com/formbricks/formbricks/issues/new?labels=accessibility&template=accessibility.yml) using the accessibility template.
+
+Include:
+
+- The page or component affected
+- Expected vs. actual behavior
+- Steps to reproduce
+- Browser, OS, and assistive technology (e.g. NVDA 2024.1 on Firefox 124)
+- Severity from your perspective (blocker vs. inconvenience)
+
+For issues that block you from completing a task — especially in a procurement or compliance context — email **[hola@formbricks.com](mailto:hola@formbricks.com)** so we can prioritise appropriately.
+
+## Resources
+
+- [WCAG 2.1 Quick Reference](https://www.w3.org/WAI/WCAG21/quickref/)
+- [EN 301 549 (v3.2.1)](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/)
+- [European Accessibility Act overview](https://ec.europa.eu/social/main.jsp?catId=1202)
+- [GitHub's Accessibility Best Practices guide](https://opensource.guide/accessibility-best-practices-for-your-project/)
+- [MDN Accessibility Reference](https://developer.mozilla.org/en-US/docs/Web/Accessibility)


### PR DESCRIPTION
## Summary

- Adds an initial `ACCESSIBILITY.md` modeled on [GitHub's open-source accessibility guide](https://opensource.guide/accessibility-best-practices-for-your-project/).
- Adds a dedicated accessibility issue template (`.github/ISSUE_TEMPLATE/accessibility.yml`).
- Documents goals (WCAG 2.1 AA, EN 301 549 for the EU **European Accessibility Act**, Section 508), current status from the 2026-04-28 survey runtime audit, known limitations, supported environments, contributor requirements, and how to report barriers.
- References the in-flight remediation PRs (#7927, #7936, #7939).

This is intentionally a first version — we'll iterate as more of the audit findings are fixed, the admin app gets audited, and we move toward a published VPAT / EN 301 549 conformance statement.

## Test plan

- [ ] Verify `ACCESSIBILITY.md` renders correctly on GitHub
- [ ] Verify the new issue template shows up on the "New issue" page with required fields working
- [ ] Sanity-check all external links resolve

Fixes ENG-931