### PR TITLE
fix: updates the minimum permission in projectTeam access from `read` to `readWrite`

### DIFF
--- a/apps/web/modules/integrations/webhooks/actions.ts
+++ b/apps/web/modules/integrations/webhooks/actions.ts
@@ -43,7 +43,7 @@ export const createWebhookAction = authenticatedActionClient.inputSchema(ZCreate
         },
         {
           type: "projectTeam",
-          minPermission: "read",
+          minPermission: "readWrite",
           projectId,
         },
       ],


### PR DESCRIPTION
Fixes https://linear.app/formbricks/issue/ENG-824/ghsa-hpff-44ph-3xmf-read-only-project-team-members-can-create-webhooks

In the `createWebhookAction`, the `minPermission` option for the `projectTeam` type access was set to `read` instead of `readWrite`. This was inconsistent with the other actions in the same file (`updateWebhookAction` and `deleteWebhookAction`)