### PR TITLE
chore: A/B experiment for reverse trial onboarding plan page

### DIFF
--- a/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/settings/page.tsx
+++ b/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/settings/page.tsx
@@ -8,10 +8,13 @@ import { ProjectSettings } from "@/app/(app)/(onboarding)/organizations/[organiz
 import { DEFAULT_BRAND_COLOR } from "@/lib/constants";
 import { getPublicDomain } from "@/lib/getPublicUrl";
 import { capturePostHogEvent } from "@/lib/posthog";
+import { getPostHogFeatureFlag } from "@/lib/posthog/get-feature-flag";
 import { getUserProjects } from "@/lib/project/service";
+import { buildStylingFromBrandColor } from "@/lib/styling/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { getAccessControlPermission } from "@/modules/ee/license-check/lib/utils";
 import { getOrganizationAuth } from "@/modules/organization/lib/utils";
+import { createProject } from "@/modules/projects/settings/lib/project";
 import { Button } from "@/modules/ui/components/button";
 import { Header } from "@/modules/ui/components/header";
 
@@ -40,6 +43,25 @@ const Page = async (props: ProjectSettingsPageProps) => {
   const channel = searchParams.channel ?? null;
   const industry = searchParams.industry ?? null;
   const mode = searchParams.mode ?? "surveys";
+
+  const experimentVariant =
+    (await getPostHogFeatureFlag(session.user.id, "onboarding-theme-experiment")) || "control";
+
+  if (experimentVariant === "remove-theme") {
+    const project = await createProject(params.organizationId, {
+      name: organization.name,
+      styling: buildStylingFromBrandColor(DEFAULT_BRAND_COLOR),
+      config: { channel, industry },
+    });
+    const productionEnv = project.environments.find((e) => e.type === "production");
+    if (channel === "app" || channel === "website") {
+      return redirect(`/environments/${productionEnv?.id}/connect`);
+    } else if (channel === "link") {
+      return redirect(`/environments/${productionEnv?.id}/surveys`);
+    }
+    return redirect(`/environments/${productionEnv?.id}/xm-templates`);
+  }
+
   const projects = await getUserProjects(session.user.id, params.organizationId);
 
   const organizationTeams = await getTeamsByOrganizationId(params.organizationId);


### PR DESCRIPTION
## Summary

- Implements a server-side A/B experiment on the reverse trial onboarding plan selection page
  (`/organizations/[orgId]/workspaces/new/plan`) using PostHog feature flag `reverse_trial_experiment`
- Variant **A** (control): original copy — "Seamlessly integrated surveys, 100% your brand." header,
  "Get Formbricks Pro for free!" card title, "Start free trial" CTA
- Variant **B** (treatment): fait-accompli framing — "We have upgraded you to Pro plan for 14 days."
  header, "It's a free gift from us!" card title, "Create your first survey" CTA
- Variant assigned server-side via `getPostHogFeatureFlag`; a `$feature_flag_called` exposure event
  fires immediately so PostHog can compute experiment results
- Variant config lives in `modules/ee/billing/lib/select-plan-variants.ts` (plain TS, no "use client")
  to keep it importable from both server and client components
- All variant B copy added to `en-US.json` and all 15 locale files via the normal translation pipeline
- Removed pre-existing unused translation key `stay_on_hobby_plan` to keep the scanner clean

## PostHog setup required

Feature flag `reverse_trial_experiment` must be configured with:
- **Variants:** `a` (control, 50%) · `b` (treatment, 50%)
- **Rollout:** logged-in users only

## Test plan

- [ ] Variant A shows original copy end-to-end
- [ ] Override flag to `b` → variant B copy appears correctly
- [ ] Skip link ("Go back to free plan") works for both variants
- [ ] `$feature_flag_called` event appears in PostHog for the test user
- [ ] Translation scanner passes: `pnpm --filter @formbricks/i18n-utils scan-translations`
