### PR TITLE
chore: use direct form link on all "request license" buttons instead of /enterprise-license page

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/account/profile/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/account/profile/page.tsx
@@ -3,7 +3,12 @@ import { AccountSecurity } from "@/app/(app)/workspaces/[workspaceId]/settings/a
 import { DeleteAccount } from "@/app/(app)/workspaces/[workspaceId]/settings/account/profile/components/DeleteAccount";
 import { EditProfileDetailsForm } from "@/app/(app)/workspaces/[workspaceId]/settings/account/profile/components/EditProfileDetailsForm";
 import { SettingsCard } from "@/app/(app)/workspaces/[workspaceId]/settings/components/SettingsCard";
-import { EMAIL_VERIFICATION_DISABLED, IS_FORMBRICKS_CLOUD, PASSWORD_RESET_DISABLED } from "@/lib/constants";
+import {
+  EMAIL_VERIFICATION_DISABLED,
+  ENTERPRISE_LICENSE_REQUEST_FORM_URL,
+  IS_FORMBRICKS_CLOUD,
+  PASSWORD_RESET_DISABLED,
+} from "@/lib/constants";
 import { getOrganizationsWhereUserIsSingleOwner } from "@/lib/organization/service";
 import { getUser } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
@@ -66,7 +71,7 @@ const Page = async (props: {
                         : t("common.request_trial_license"),
                       href: IS_FORMBRICKS_CLOUD
                         ? `/workspaces/${params.workspaceId}/settings/organization/billing`
-                        : "https://formbricks.com/upgrade-self-hosting-license",
+                        : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
                     },
                     {
                       text: t("common.learn_more"),

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/components/AISettingsToggle.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/components/AISettingsToggle.tsx
@@ -21,6 +21,7 @@ interface AISettingsToggleProps {
   isInstanceAIConfigured: boolean;
   hasAIPermission: boolean;
   isFormbricksCloud: boolean;
+  enterpriseLicenseRequestFormUrl: string;
 }
 
 export const AISettingsToggle = ({
@@ -29,6 +30,7 @@ export const AISettingsToggle = ({
   isInstanceAIConfigured,
   hasAIPermission,
   isFormbricksCloud,
+  enterpriseLicenseRequestFormUrl,
 }: Readonly<AISettingsToggleProps>) => {
   const { workspace } = useWorkspace();
   const workspaceBasePath = `/workspaces/${workspace?.id}`;
@@ -91,7 +93,7 @@ export const AISettingsToggle = ({
       text: isFormbricksCloud ? t("common.upgrade_plan") : t("common.request_trial_license"),
       href: isFormbricksCloud
         ? `${workspaceBasePath}/settings/organization/billing`
-        : "https://formbricks.com/upgrade-self-hosting-license",
+        : enterpriseLicenseRequestFormUrl,
     },
     {
       text: t("common.learn_more"),

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/page.tsx
@@ -75,6 +75,7 @@ const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
           isInstanceAIConfigured={isInstanceAIConfigured()}
           hasAIPermission={hasAIPermission}
           isFormbricksCloud={IS_FORMBRICKS_CLOUD}
+          enterpriseLicenseRequestFormUrl={ENTERPRISE_LICENSE_REQUEST_FORM_URL}
         />
       </SettingsCard>
       <EmailCustomizationSettings

--- a/apps/web/modules/ee/analysis/charts/components/charts-list-page.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/charts-list-page.tsx
@@ -1,7 +1,7 @@
 import { use } from "react";
 import { getAIDataAnalysisUnavailableReason, getOrganizationAIConfig } from "@/lib/ai/service";
 import { getConnectorsWithMappings } from "@/lib/connector/service";
-import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { ChartsList } from "@/modules/ee/analysis/charts/components/charts-list";
 import { CreateChartButton } from "@/modules/ee/analysis/charts/components/create-chart-button";
@@ -57,7 +57,7 @@ export async function ChartsListPage({ workspaceId }: Readonly<ChartsListPagePro
                 text: IS_FORMBRICKS_CLOUD ? t("common.upgrade_plan") : t("common.request_trial_license"),
                 href: IS_FORMBRICKS_CLOUD
                   ? `/workspaces/${workspaceId}/settings/organization/billing`
-                  : "https://formbricks.com/upgrade-self-hosting-license",
+                  : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
               },
               {
                 text: t("common.learn_more"),

--- a/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
@@ -3,7 +3,7 @@ import { logger } from "@formbricks/logger";
 import type { TChartQuery } from "@formbricks/types/analysis";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { getAIDataAnalysisUnavailableReason, getOrganizationAIConfig } from "@/lib/ai/service";
-import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { executeTenantScopedQuery } from "@/modules/ee/analysis/api/lib/cube-client";
 import { AnalysisPageLayout } from "@/modules/ee/analysis/components/analysis-page-layout";
@@ -82,7 +82,7 @@ export async function DashboardDetailPage({
                 text: IS_FORMBRICKS_CLOUD ? t("common.upgrade_plan") : t("common.request_trial_license"),
                 href: IS_FORMBRICKS_CLOUD
                   ? `/workspaces/${workspaceId}/settings/organization/billing`
-                  : "https://formbricks.com/upgrade-self-hosting-license",
+                  : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
               },
               {
                 text: t("common.learn_more"),

--- a/apps/web/modules/ee/analysis/dashboards/pages/dashboards-list-page.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/pages/dashboards-list-page.tsx
@@ -1,6 +1,6 @@
 import { use } from "react";
 import { getConnectorsWithMappings } from "@/lib/connector/service";
-import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { AnalysisPageLayout } from "@/modules/ee/analysis/components/analysis-page-layout";
 import { NoFeedbackRecordsState } from "@/modules/ee/analysis/components/no-feedback-records-state";
@@ -53,7 +53,7 @@ export const DashboardsListPage = async ({ workspaceId }: Readonly<DashboardsLis
                 text: IS_FORMBRICKS_CLOUD ? t("common.upgrade_plan") : t("common.request_trial_license"),
                 href: IS_FORMBRICKS_CLOUD
                   ? `/workspaces/${workspaceId}/settings/organization/billing`
-                  : "https://formbricks.com/upgrade-self-hosting-license",
+                  : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
               },
               {
                 text: t("common.learn_more"),

--- a/apps/web/modules/ee/feedback-directory/page.tsx
+++ b/apps/web/modules/ee/feedback-directory/page.tsx
@@ -1,4 +1,4 @@
-import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getAccessFlags } from "@/lib/membership/utils";
 import { getTranslate } from "@/lingodotdev/server";
 import { FeedbackDirectoryView } from "@/modules/ee/feedback-directory/components/feedback-directory-view";
@@ -33,7 +33,7 @@ export const FeedbackDirectoriesPage = async (props: { params: Promise<{ workspa
                 text: IS_FORMBRICKS_CLOUD ? t("common.upgrade_plan") : t("common.request_trial_license"),
                 href: IS_FORMBRICKS_CLOUD
                   ? `/workspaces/${params.workspaceId}/settings/organization/billing`
-                  : "https://formbricks.com/upgrade-self-hosting-license",
+                  : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
               },
               {
                 text: t("common.learn_more"),

--- a/apps/web/modules/ee/unify-feedback/page.tsx
+++ b/apps/web/modules/ee/unify-feedback/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { getConnectorsWithMappings } from "@/lib/connector/service";
-import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { NoFeedbackDirectoryEmptyState } from "@/modules/ee/feedback-directory/components/no-feedback-directory-empty-state";
 import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
@@ -51,7 +51,7 @@ export default async function UnifyFeedbackRecordsPage(
                 text: IS_FORMBRICKS_CLOUD ? t("common.upgrade_plan") : t("common.request_trial_license"),
                 href: IS_FORMBRICKS_CLOUD
                   ? `/workspaces/${params.workspaceId}/settings/organization/billing`
-                  : "https://formbricks.com/upgrade-self-hosting-license",
+                  : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
               },
               {
                 text: t("common.learn_more"),

--- a/apps/web/modules/ee/unify-feedback/sources/page.tsx
+++ b/apps/web/modules/ee/unify-feedback/sources/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import { getConnectorsWithMappings } from "@/lib/connector/service";
-import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getSurveys } from "@/lib/survey/service";
 import { getTranslate } from "@/lingodotdev/server";
 import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
@@ -51,7 +51,7 @@ export const WorkspaceFeedbackSourcesPage = async (
                 text: IS_FORMBRICKS_CLOUD ? t("common.upgrade_plan") : t("common.request_trial_license"),
                 href: IS_FORMBRICKS_CLOUD
                   ? `/workspaces/${params.workspaceId}/settings/organization/billing`
-                  : "https://formbricks.com/upgrade-self-hosting-license",
+                  : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
               },
               {
                 text: t("common.learn_more"),

--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/page.tsx
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from "next/navigation";
-import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { NoFeedbackDirectoryEmptyState } from "@/modules/ee/feedback-directory/components/no-feedback-directory-empty-state";
 import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
@@ -46,7 +46,7 @@ export const UnifyTopicsSubtopicsPage = async (
                 text: IS_FORMBRICKS_CLOUD ? t("common.upgrade_plan") : t("common.request_trial_license"),
                 href: IS_FORMBRICKS_CLOUD
                   ? `/workspaces/${params.workspaceId}/settings/organization/billing`
-                  : "https://formbricks.com/upgrade-self-hosting-license",
+                  : ENTERPRISE_LICENSE_REQUEST_FORM_URL,
               },
               {
                 text: t("common.learn_more"),


### PR DESCRIPTION
## Summary

- Replaced hardcoded `https://formbricks.com/upgrade-self-hosting-license` URLs across all locked-feature upgrade prompts with the centralized `ENTERPRISE_LICENSE_REQUEST_FORM_URL` constant from `@/lib/constants`, so self-hosted users land on the actual license request form (`https://app.formbricks.com/s/trvp8tzy5uvsps9rc9qi9l9w?delivery=onpremise&source=ce`) instead of an inconsistent marketing URL.
- For the `AISettingsToggle` client component, the URL is passed down as an `enterpriseLicenseRequestFormUrl` prop from the server parent (matching the existing pattern used by `EmailCustomizationSettings`), since `@/lib/constants` is `server-only`.
