### PR TITLE
fix: validate displayId ownership on response creation (ENG-825)

### DIFF
--- a/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.test.ts
@@ -1,7 +1,12 @@
 import { Prisma } from "@prisma/client";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
-import { DatabaseError, ResourceNotFoundError, UniqueConstraintError } from "@formbricks/types/errors";
+import {
+  DatabaseError,
+  InvalidInputError,
+  ResourceNotFoundError,
+  UniqueConstraintError,
+} from "@formbricks/types/errors";
 import { TSurveyQuota } from "@formbricks/types/quota";
 import { TResponseInput } from "@formbricks/types/responses";
 import { getOrganization } from "@/lib/organization/service";
@@ -153,6 +158,16 @@ describe("createResponse", () => {
     });
     vi.mocked(prisma.response.create).mockRejectedValue(prismaError);
     await expect(createResponse(mockResponseInput, prisma)).rejects.toThrow(UniqueConstraintError);
+  });
+
+  test("should throw InvalidInputError on P2002 with displayId target (race condition)", async () => {
+    const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+      code: "P2002",
+      clientVersion: "test",
+      meta: { target: ["displayId"] },
+    });
+    vi.mocked(prisma.response.create).mockRejectedValue(prismaError);
+    await expect(createResponse(mockResponseInput, prisma)).rejects.toThrow(InvalidInputError);
   });
 
   test("should throw original error on other Prisma errors", async () => {

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.ts
@@ -121,6 +121,8 @@ export const createResponse = async (
         );
       if (display.responseId)
         throw new InvalidInputError(`Display ${responseInput.displayId} is already linked to a response`);
+      if (display.contactId !== null && display.contactId !== (contact?.id ?? null))
+        throw new InvalidInputError(`Display ${responseInput.displayId} belongs to a different contact`);
     }
 
     const prismaData = buildPrismaResponseData(
@@ -150,6 +152,13 @@ export const createResponse = async (
     return response;
   } catch (error) {
     if (isPrismaKnownRequestError(error)) {
+      if (
+        error.code === "P2002" &&
+        Array.isArray(error.meta?.target) &&
+        error.meta.target.includes("displayId")
+      ) {
+        throw new InvalidInputError(`Display ${responseInput.displayId} is already linked to a response`);
+      }
       if (isSingleUseIdUniqueConstraintError(error)) {
         throw new UniqueConstraintError("Response already submitted for this single-use link");
       }

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.ts
@@ -16,7 +16,7 @@ import {
   isSingleUseIdUniqueConstraintError,
 } from "@/app/api/client/[workspaceId]/responses/lib/response-error";
 import { buildPrismaResponseData } from "@/app/api/v1/lib/utils";
-import { getDisplayForResponseValidation } from "@/lib/display/service";
+import { assertDisplayOwnership } from "@/lib/display/service";
 import { getOrganization } from "@/lib/organization/service";
 import { calculateTtcTotal } from "@/lib/response/utils";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
@@ -111,18 +111,13 @@ export const createResponse = async (
     const ttc = initialTtc ? (finished ? calculateTtcTotal(initialTtc) : initialTtc) : {};
 
     if (responseInput.displayId) {
-      const display = await getDisplayForResponseValidation(responseInput.displayId, tx);
-      if (!display) throw new InvalidInputError(`Display ${responseInput.displayId} not found`);
-      if (display.workspaceId !== workspaceId)
-        throw new InvalidInputError(`Display ${responseInput.displayId} belongs to a different workspace`);
-      if (display.surveyId !== responseInput.surveyId)
-        throw new InvalidInputError(
-          `Display ${responseInput.displayId} is associated with a different survey`
-        );
-      if (display.responseId)
-        throw new InvalidInputError(`Display ${responseInput.displayId} is already linked to a response`);
-      if (display.contactId !== null && display.contactId !== (contact?.id ?? null))
-        throw new InvalidInputError(`Display ${responseInput.displayId} belongs to a different contact`);
+      await assertDisplayOwnership(
+        responseInput.displayId,
+        workspaceId,
+        responseInput.surveyId,
+        contact?.id ?? null,
+        tx
+      );
     }
 
     const prismaData = buildPrismaResponseData(

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.ts
@@ -2,7 +2,12 @@ import "server-only";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@formbricks/database";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
-import { DatabaseError, ResourceNotFoundError, UniqueConstraintError } from "@formbricks/types/errors";
+import {
+  DatabaseError,
+  InvalidInputError,
+  ResourceNotFoundError,
+  UniqueConstraintError,
+} from "@formbricks/types/errors";
 import { TResponseWithQuotaFull } from "@formbricks/types/quota";
 import { TResponse, TResponseInput, ZResponseInput } from "@formbricks/types/responses";
 import { TTag } from "@formbricks/types/tags";
@@ -11,6 +16,7 @@ import {
   isSingleUseIdUniqueConstraintError,
 } from "@/app/api/client/[workspaceId]/responses/lib/response-error";
 import { buildPrismaResponseData } from "@/app/api/v1/lib/utils";
+import { getDisplayForResponseValidation } from "@/lib/display/service";
 import { getOrganization } from "@/lib/organization/service";
 import { calculateTtcTotal } from "@/lib/response/utils";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
@@ -103,6 +109,19 @@ export const createResponse = async (
     }
 
     const ttc = initialTtc ? (finished ? calculateTtcTotal(initialTtc) : initialTtc) : {};
+
+    if (responseInput.displayId) {
+      const display = await getDisplayForResponseValidation(responseInput.displayId, tx);
+      if (!display) throw new InvalidInputError(`Display ${responseInput.displayId} not found`);
+      if (display.workspaceId !== workspaceId)
+        throw new InvalidInputError(`Display ${responseInput.displayId} belongs to a different workspace`);
+      if (display.surveyId !== responseInput.surveyId)
+        throw new InvalidInputError(
+          `Display ${responseInput.displayId} is associated with a different survey`
+        );
+      if (display.responseId)
+        throw new InvalidInputError(`Display ${responseInput.displayId} is already linked to a response`);
+    }
 
     const prismaData = buildPrismaResponseData(
       { ...responseInput, createdAt: undefined, updatedAt: undefined },

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
@@ -2,7 +2,12 @@ import { Prisma } from "@prisma/client";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
-import { DatabaseError, ResourceNotFoundError, UniqueConstraintError } from "@formbricks/types/errors";
+import {
+  DatabaseError,
+  InvalidInputError,
+  ResourceNotFoundError,
+  UniqueConstraintError,
+} from "@formbricks/types/errors";
 import { TResponseWithQuotaFull, TSurveyQuota } from "@formbricks/types/quota";
 import { TResponse } from "@formbricks/types/responses";
 import { TTag } from "@formbricks/types/tags";
@@ -190,7 +195,19 @@ describe("createResponse V2", () => {
     ).rejects.toThrow(UniqueConstraintError);
   });
 
-  test("should throw DatabaseError on P2002 without singleUseId target", async () => {
+  test("should throw DatabaseError on P2002 without singleUseId or displayId target", async () => {
+    const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+      code: "P2002",
+      clientVersion: "test",
+      meta: { target: ["someOtherField"] },
+    });
+    vi.mocked(mockTx.response.create).mockRejectedValue(prismaError);
+    await expect(
+      createResponse(mockResponseInput, mockTx as unknown as Prisma.TransactionClient)
+    ).rejects.toThrow(DatabaseError);
+  });
+
+  test("should throw InvalidInputError on P2002 with displayId target (race condition)", async () => {
     const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
       code: "P2002",
       clientVersion: "test",
@@ -199,7 +216,7 @@ describe("createResponse V2", () => {
     vi.mocked(mockTx.response.create).mockRejectedValue(prismaError);
     await expect(
       createResponse(mockResponseInput, mockTx as unknown as Prisma.TransactionClient)
-    ).rejects.toThrow(DatabaseError);
+    ).rejects.toThrow(InvalidInputError);
   });
 
   test("should throw DatabaseError on non-P2002 Prisma known request error", async () => {

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
@@ -17,7 +17,7 @@ import {
 } from "@/app/api/client/[workspaceId]/responses/lib/response-error";
 import { responseSelection } from "@/app/api/v1/client/[workspaceId]/responses/lib/response";
 import { TResponseInputV2 } from "@/app/api/v2/client/[workspaceId]/responses/types/response";
-import { getDisplayForResponseValidation } from "@/lib/display/service";
+import { assertDisplayOwnership } from "@/lib/display/service";
 import { getOrganization } from "@/lib/organization/service";
 import { calculateTtcTotal } from "@/lib/response/utils";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
@@ -106,18 +106,13 @@ export const createResponse = async (
     const ttc = initialTtc ? (finished ? calculateTtcTotal(initialTtc) : initialTtc) : {};
 
     if (responseInput.displayId) {
-      const display = await getDisplayForResponseValidation(responseInput.displayId, tx);
-      if (!display) throw new InvalidInputError(`Display ${responseInput.displayId} not found`);
-      if (display.workspaceId !== workspaceId)
-        throw new InvalidInputError(`Display ${responseInput.displayId} belongs to a different workspace`);
-      if (display.surveyId !== responseInput.surveyId)
-        throw new InvalidInputError(
-          `Display ${responseInput.displayId} is associated with a different survey`
-        );
-      if (display.responseId)
-        throw new InvalidInputError(`Display ${responseInput.displayId} is already linked to a response`);
-      if (display.contactId !== null && display.contactId !== (contactId ?? null))
-        throw new InvalidInputError(`Display ${responseInput.displayId} belongs to a different contact`);
+      await assertDisplayOwnership(
+        responseInput.displayId,
+        workspaceId,
+        responseInput.surveyId,
+        contactId ?? null,
+        tx
+      );
     }
 
     const prismaData = buildPrismaResponseData(responseInput, contact, ttc);

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
@@ -2,7 +2,12 @@ import "server-only";
 import { Prisma } from "@prisma/client";
 import { prisma } from "@formbricks/database";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
-import { DatabaseError, ResourceNotFoundError, UniqueConstraintError } from "@formbricks/types/errors";
+import {
+  DatabaseError,
+  InvalidInputError,
+  ResourceNotFoundError,
+  UniqueConstraintError,
+} from "@formbricks/types/errors";
 import { TResponseWithQuotaFull } from "@formbricks/types/quota";
 import { TResponse, ZResponseInput } from "@formbricks/types/responses";
 import { TTag } from "@formbricks/types/tags";
@@ -12,6 +17,7 @@ import {
 } from "@/app/api/client/[workspaceId]/responses/lib/response-error";
 import { responseSelection } from "@/app/api/v1/client/[workspaceId]/responses/lib/response";
 import { TResponseInputV2 } from "@/app/api/v2/client/[workspaceId]/responses/types/response";
+import { getDisplayForResponseValidation } from "@/lib/display/service";
 import { getOrganization } from "@/lib/organization/service";
 import { calculateTtcTotal } from "@/lib/response/utils";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
@@ -98,6 +104,19 @@ export const createResponse = async (
     }
 
     const ttc = initialTtc ? (finished ? calculateTtcTotal(initialTtc) : initialTtc) : {};
+
+    if (responseInput.displayId) {
+      const display = await getDisplayForResponseValidation(responseInput.displayId, tx);
+      if (!display) throw new InvalidInputError(`Display ${responseInput.displayId} not found`);
+      if (display.workspaceId !== workspaceId)
+        throw new InvalidInputError(`Display ${responseInput.displayId} belongs to a different workspace`);
+      if (display.surveyId !== responseInput.surveyId)
+        throw new InvalidInputError(
+          `Display ${responseInput.displayId} is associated with a different survey`
+        );
+      if (display.responseId)
+        throw new InvalidInputError(`Display ${responseInput.displayId} is already linked to a response`);
+    }
 
     const prismaData = buildPrismaResponseData(responseInput, contact, ttc);
 

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
@@ -116,6 +116,8 @@ export const createResponse = async (
         );
       if (display.responseId)
         throw new InvalidInputError(`Display ${responseInput.displayId} is already linked to a response`);
+      if (display.contactId !== null && display.contactId !== (contactId ?? null))
+        throw new InvalidInputError(`Display ${responseInput.displayId} belongs to a different contact`);
     }
 
     const prismaData = buildPrismaResponseData(responseInput, contact, ttc);
@@ -141,6 +143,13 @@ export const createResponse = async (
     return response;
   } catch (error) {
     if (isPrismaKnownRequestError(error)) {
+      if (
+        error.code === "P2002" &&
+        Array.isArray(error.meta?.target) &&
+        error.meta.target.includes("displayId")
+      ) {
+        throw new InvalidInputError(`Display ${responseInput.displayId} is already linked to a response`);
+      }
       if (isSingleUseIdUniqueConstraintError(error)) {
         throw new UniqueConstraintError("Response already submitted for this single-use link");
       }

--- a/apps/web/lib/display/service.ts
+++ b/apps/web/lib/display/service.ts
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { prisma } from "@formbricks/database";
 import { ZId } from "@formbricks/types/common";
 import { TDisplay, TDisplayFilters, TDisplayWithContact, ZDisplayFilters } from "@formbricks/types/displays";
-import { DatabaseError } from "@formbricks/types/errors";
+import { DatabaseError, InvalidInputError } from "@formbricks/types/errors";
 import { validateInputs } from "../utils/validate";
 
 export const selectDisplay = {
@@ -178,6 +178,24 @@ export const getDisplayForResponseValidation = async (
     if (error instanceof Prisma.PrismaClientKnownRequestError) throw new DatabaseError(error.message);
     throw error;
   }
+};
+
+export const assertDisplayOwnership = async (
+  displayId: string,
+  workspaceId: string,
+  surveyId: string,
+  contactId: string | null,
+  tx?: Prisma.TransactionClient
+): Promise<void> => {
+  const display = await getDisplayForResponseValidation(displayId, tx);
+  if (!display) throw new InvalidInputError(`Display ${displayId} not found`);
+  if (display.workspaceId !== workspaceId)
+    throw new InvalidInputError(`Display ${displayId} belongs to a different workspace`);
+  if (display.surveyId !== surveyId)
+    throw new InvalidInputError(`Display ${displayId} is associated with a different survey`);
+  if (display.responseId) throw new InvalidInputError(`Display ${displayId} is already linked to a response`);
+  if (display.contactId !== null && display.contactId !== contactId)
+    throw new InvalidInputError(`Display ${displayId} belongs to a different contact`);
 };
 
 export const deleteDisplay = async (displayId: string, tx?: Prisma.TransactionClient): Promise<TDisplay> => {

--- a/apps/web/lib/display/service.ts
+++ b/apps/web/lib/display/service.ts
@@ -146,6 +146,33 @@ export const getDisplaysBySurveyIdWithContact = reactCache(
   }
 );
 
+export const getDisplayForResponseValidation = async (
+  displayId: string,
+  tx?: Prisma.TransactionClient
+): Promise<{ surveyId: string; workspaceId: string; responseId: string | null } | null> => {
+  validateInputs([displayId, ZId]);
+  const client = tx ?? prisma;
+  try {
+    const display = await client.display.findUnique({
+      where: { id: displayId },
+      select: {
+        surveyId: true,
+        response: { select: { id: true } },
+        survey: { select: { workspaceId: true } },
+      },
+    });
+    if (!display) return null;
+    return {
+      surveyId: display.surveyId,
+      workspaceId: display.survey.workspaceId,
+      responseId: display.response?.id ?? null,
+    };
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) throw new DatabaseError(error.message);
+    throw error;
+  }
+};
+
 export const deleteDisplay = async (displayId: string, tx?: Prisma.TransactionClient): Promise<TDisplay> => {
   validateInputs([displayId, ZId]);
   try {

--- a/apps/web/lib/display/service.ts
+++ b/apps/web/lib/display/service.ts
@@ -149,7 +149,12 @@ export const getDisplaysBySurveyIdWithContact = reactCache(
 export const getDisplayForResponseValidation = async (
   displayId: string,
   tx?: Prisma.TransactionClient
-): Promise<{ surveyId: string; workspaceId: string; responseId: string | null } | null> => {
+): Promise<{
+  surveyId: string;
+  workspaceId: string;
+  responseId: string | null;
+  contactId: string | null;
+} | null> => {
   validateInputs([displayId, ZId]);
   const client = tx ?? prisma;
   try {
@@ -157,6 +162,7 @@ export const getDisplayForResponseValidation = async (
       where: { id: displayId },
       select: {
         surveyId: true,
+        contactId: true,
         response: { select: { id: true } },
         survey: { select: { workspaceId: true } },
       },
@@ -166,6 +172,7 @@ export const getDisplayForResponseValidation = async (
       surveyId: display.surveyId,
       workspaceId: display.survey.workspaceId,
       responseId: display.response?.id ?? null,
+      contactId: display.contactId,
     };
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) throw new DatabaseError(error.message);

--- a/apps/web/lib/display/tests/display-queries.test.ts
+++ b/apps/web/lib/display/tests/display-queries.test.ts
@@ -3,14 +3,18 @@ import { prisma } from "@/lib/__mocks__/database";
 import { Prisma } from "@prisma/client";
 import { describe, expect, test, vi } from "vitest";
 import { PrismaErrorType } from "@formbricks/database/types/error";
-import { DatabaseError, ValidationError } from "@formbricks/types/errors";
+import { DatabaseError, InvalidInputError, ValidationError } from "@formbricks/types/errors";
 import {
+  assertDisplayOwnership,
   getDisplayCountBySurveyId,
+  getDisplayForResponseValidation,
   getDisplaysByContactId,
   getDisplaysBySurveyIdWithContact,
 } from "../service";
 
 const mockContactId = "clqnj99r9000008lebgf8734j";
+const mockWorkspaceId = "clqkr8dlv000308jybb08evgz";
+const mockResponseId = "clqnfg59i000208i426pb4wcv";
 const mockResponseIds = ["clqnfg59i000208i426pb4wcv", "clqnfg59i000208i426pb4wcw"];
 
 const mockDisplaysForContact = [
@@ -288,5 +292,98 @@ describe("getDisplaysBySurveyIdWithContact", () => {
 
       await expect(getDisplaysBySurveyIdWithContact(mockSurveyId)).rejects.toThrow(Error);
     });
+  });
+});
+
+const mockDisplayRecord = {
+  surveyId: mockSurveyId,
+  contactId: null as string | null,
+  response: null as { id: string } | null,
+  survey: { workspaceId: mockWorkspaceId },
+};
+
+describe("getDisplayForResponseValidation", () => {
+  test("returns null when display is not found", async () => {
+    vi.mocked(prisma.display.findUnique).mockResolvedValue(null);
+    const result = await getDisplayForResponseValidation(mockDisplayId);
+    expect(result).toBeNull();
+  });
+
+  test("returns mapped shape when display is found", async () => {
+    vi.mocked(prisma.display.findUnique).mockResolvedValue({
+      ...mockDisplayRecord,
+      contactId: mockContactId,
+      response: { id: mockResponseId },
+    } as any);
+    const result = await getDisplayForResponseValidation(mockDisplayId);
+    expect(result).toEqual({
+      surveyId: mockSurveyId,
+      workspaceId: mockWorkspaceId,
+      responseId: mockResponseId,
+      contactId: mockContactId,
+    });
+  });
+
+  test("throws DatabaseError on PrismaClientKnownRequestError", async () => {
+    vi.mocked(prisma.display.findUnique).mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("Mock error", {
+        code: PrismaErrorType.UniqueConstraintViolation,
+        clientVersion: "0.0.1",
+      })
+    );
+    await expect(getDisplayForResponseValidation(mockDisplayId)).rejects.toThrow(DatabaseError);
+  });
+});
+
+describe("assertDisplayOwnership", () => {
+  test("throws InvalidInputError when display is not found", async () => {
+    vi.mocked(prisma.display.findUnique).mockResolvedValue(null);
+    await expect(assertDisplayOwnership(mockDisplayId, mockWorkspaceId, mockSurveyId, null)).rejects.toThrow(
+      InvalidInputError
+    );
+  });
+
+  test("throws InvalidInputError when workspaceId does not match", async () => {
+    vi.mocked(prisma.display.findUnique).mockResolvedValue(mockDisplayRecord as any);
+    await expect(
+      assertDisplayOwnership(mockDisplayId, "wrong-workspace", mockSurveyId, null)
+    ).rejects.toThrow(InvalidInputError);
+  });
+
+  test("throws InvalidInputError when surveyId does not match", async () => {
+    vi.mocked(prisma.display.findUnique).mockResolvedValue(mockDisplayRecord as any);
+    await expect(
+      assertDisplayOwnership(mockDisplayId, mockWorkspaceId, "wrong-survey", null)
+    ).rejects.toThrow(InvalidInputError);
+  });
+
+  test("throws InvalidInputError when display is already linked to a response", async () => {
+    vi.mocked(prisma.display.findUnique).mockResolvedValue({
+      ...mockDisplayRecord,
+      response: { id: mockResponseId },
+    } as any);
+    await expect(assertDisplayOwnership(mockDisplayId, mockWorkspaceId, mockSurveyId, null)).rejects.toThrow(
+      InvalidInputError
+    );
+  });
+
+  test("throws InvalidInputError when contactId does not match", async () => {
+    vi.mocked(prisma.display.findUnique).mockResolvedValue({
+      ...mockDisplayRecord,
+      contactId: "contact-a",
+    } as any);
+    await expect(
+      assertDisplayOwnership(mockDisplayId, mockWorkspaceId, mockSurveyId, "contact-b")
+    ).rejects.toThrow(InvalidInputError);
+  });
+
+  test("resolves without error when all ownership checks pass", async () => {
+    vi.mocked(prisma.display.findUnique).mockResolvedValue({
+      ...mockDisplayRecord,
+      contactId: mockContactId,
+    } as any);
+    await expect(
+      assertDisplayOwnership(mockDisplayId, mockWorkspaceId, mockSurveyId, mockContactId)
+    ).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Adds a new `getDisplayForResponseValidation` helper in `apps/web/lib/display/service.ts` that fetches a Display by ID along with its workspace and existing response linkage
- In `POST /api/v1/client/{workspaceId}/responses` and `POST /api/v2/client/{workspaceId}/responses`, validates the optional `displayId` parameter before creating the response: checks the display exists, belongs to the same workspace, belongs to the same survey, and is not already linked to another response
- Fixes [GHSA-43vf-x743-579v](https://github.com/formbricks/formbricks/security/advisories/GHSA-43vf-x743-579v) — without this, an attacker could link a display from their own workspace to a response in another workspace, polluting display statistics and circumventing survey frequency controls

## Test plan

- [ ] Submit a response with no `displayId` — should succeed as before
- [ ] Submit a response with a valid `displayId` matching the correct workspace and survey — should succeed
- [ ] Submit a response with a `displayId` from a different workspace — expect 400
- [ ] Submit a response with a `displayId` from the correct workspace but a different survey — expect 400
- [ ] Submit a response with a `displayId` already linked to another response — expect 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)