### PR TITLE
fix: strip client-provided timestamps in client response API (ENG-828)

### DIFF
--- a/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.ts
@@ -104,7 +104,11 @@ export const createResponse = async (
 
     const ttc = initialTtc ? (finished ? calculateTtcTotal(initialTtc) : initialTtc) : {};
 
-    const prismaData = buildPrismaResponseData(responseInput, contact, ttc);
+    const prismaData = buildPrismaResponseData(
+      { ...responseInput, createdAt: undefined, updatedAt: undefined },
+      contact,
+      ttc
+    );
 
     const prismaClient = tx ?? prisma;
 

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
@@ -49,18 +49,7 @@ const buildPrismaResponseData = (
   contact: { id: string; attributes: TContactAttributes } | null,
   ttc: Record<string, number>
 ): Prisma.ResponseCreateInput => {
-  const {
-    surveyId,
-    displayId,
-    finished,
-    data,
-    language,
-    meta,
-    singleUseId,
-    variables,
-    createdAt,
-    updatedAt,
-  } = responseInput;
+  const { surveyId, displayId, finished, data, language, meta, singleUseId, variables } = responseInput;
 
   return {
     survey: {
@@ -84,8 +73,6 @@ const buildPrismaResponseData = (
     singleUseId,
     ...(variables && { variables }),
     ttc: ttc,
-    createdAt,
-    updatedAt,
   };
 };
 


### PR DESCRIPTION
## Summary

- In `POST /api/v1/client/{workspaceId}/responses` (v1) and `POST /api/v2/client/{workspaceId}/responses` (v2), client-provided `createdAt` and `updatedAt` values are now discarded before the Prisma insert — Prisma's `@default(now())` and `@updatedAt` directives take effect instead
- The management API (`POST /api/v1/management/responses`) is intentionally unchanged: it is authenticated and supports legitimate server-side data imports where custom timestamps are needed
- Fixes [GHSA-x6pm-w5px-vhmg](https://github.com/formbricks/formbricks/security/advisories/GHSA-x6pm-w5px-vhmg) — without this, any respondent could backdate or future-date their submission and manipulate time-series analytics

## Test plan

- [ ] Submit a response via the client API with `"createdAt": "2020-01-01T00:00:00Z"` — verify the stored `createdAt` is the current server time, not 2020
- [ ] Submit a response via the management API with a custom `createdAt` — verify it is respected (authenticated import use case preserved)
- [ ] Normal response submission with no timestamps — verify it continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)