### PR TITLE
fix: scope display contact lookup to workspace (ENG-818)

### DIFF
--- a/apps/web/app/api/v2/client/[workspaceId]/displays/lib/contact.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/displays/lib/contact.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
-import { doesContactExist } from "./contact";
+import { doesContactExistInWorkspace } from "./contact";
 
 // Mock prisma
 vi.mock("@formbricks/database", () => ({
@@ -23,7 +23,7 @@ vi.mock("react", async () => {
 const contactId = "test-contact-id";
 const workspaceId = "test-workspace-id";
 
-describe("doesContactExist", () => {
+describe("doesContactExistInWorkspace", () => {
   afterEach(() => {
     vi.resetAllMocks();
   });
@@ -35,7 +35,7 @@ describe("doesContactExist", () => {
       updatedAt: new Date(),
     } as any);
 
-    const result = await doesContactExist(contactId, workspaceId);
+    const result = await doesContactExistInWorkspace(contactId, workspaceId);
 
     expect(result).toBe(true);
     expect(prisma.contact.findFirst).toHaveBeenCalledWith({
@@ -47,7 +47,7 @@ describe("doesContactExist", () => {
   test("should return false if contact does not exist in the workspace", async () => {
     vi.mocked(prisma.contact.findFirst).mockResolvedValue(null);
 
-    const result = await doesContactExist(contactId, workspaceId);
+    const result = await doesContactExistInWorkspace(contactId, workspaceId);
 
     expect(result).toBe(false);
     expect(prisma.contact.findFirst).toHaveBeenCalledWith({

--- a/apps/web/app/api/v2/client/[workspaceId]/displays/lib/contact.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/displays/lib/contact.test.ts
@@ -21,24 +21,25 @@ vi.mock("react", async () => {
 });
 
 const contactId = "test-contact-id";
+const workspaceId = "test-workspace-id";
 
 describe("doesContactExist", () => {
   afterEach(() => {
     vi.resetAllMocks();
   });
 
-  test("should return true if contact exists", async () => {
+  test("should return true if contact exists in the workspace", async () => {
     vi.mocked(prisma.contact.findFirst).mockResolvedValue({
       id: contactId,
       createdAt: new Date(),
       updatedAt: new Date(),
     } as any);
 
-    const result = await doesContactExist(contactId);
+    const result = await doesContactExist(contactId, workspaceId);
 
     expect(result).toBe(true);
     expect(prisma.contact.findFirst).toHaveBeenCalledWith({
-      where: { id: contactId },
+      where: { id: contactId, workspaceId },
       select: { id: true },
     });
   });
@@ -46,11 +47,11 @@ describe("doesContactExist", () => {
   test("should return false if contact does not exist in the workspace", async () => {
     vi.mocked(prisma.contact.findFirst).mockResolvedValue(null);
 
-    const result = await doesContactExist(contactId);
+    const result = await doesContactExist(contactId, workspaceId);
 
     expect(result).toBe(false);
     expect(prisma.contact.findFirst).toHaveBeenCalledWith({
-      where: { id: contactId },
+      where: { id: contactId, workspaceId },
       select: { id: true },
     });
   });

--- a/apps/web/app/api/v2/client/[workspaceId]/displays/lib/contact.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/displays/lib/contact.ts
@@ -1,10 +1,11 @@
 import { cache as reactCache } from "react";
 import { prisma } from "@formbricks/database";
 
-export const doesContactExist = reactCache(async (id: string): Promise<boolean> => {
+export const doesContactExist = reactCache(async (id: string, workspaceId: string): Promise<boolean> => {
   const contact = await prisma.contact.findFirst({
     where: {
       id,
+      workspaceId,
     },
     select: {
       id: true,

--- a/apps/web/app/api/v2/client/[workspaceId]/displays/lib/contact.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/displays/lib/contact.ts
@@ -1,16 +1,18 @@
 import { cache as reactCache } from "react";
 import { prisma } from "@formbricks/database";
 
-export const doesContactExist = reactCache(async (id: string, workspaceId: string): Promise<boolean> => {
-  const contact = await prisma.contact.findFirst({
-    where: {
-      id,
-      workspaceId,
-    },
-    select: {
-      id: true,
-    },
-  });
+export const doesContactExistInWorkspace = reactCache(
+  async (id: string, workspaceId: string): Promise<boolean> => {
+    const contact = await prisma.contact.findFirst({
+      where: {
+        id,
+        workspaceId,
+      },
+      select: {
+        id: true,
+      },
+    });
 
-  return !!contact;
-});
+    return !!contact;
+  }
+);

--- a/apps/web/app/api/v2/client/[workspaceId]/displays/lib/display.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/displays/lib/display.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@formbricks/types/errors";
 import { validateInputs } from "@/lib/utils/validate";
 import { TDisplayCreateInputV2 } from "../types/display";
-import { doesContactExist } from "./contact";
+import { doesContactExistInWorkspace } from "./contact";
 import { createDisplay } from "./display";
 
 vi.mock("@/lib/utils/validate", () => ({
@@ -30,7 +30,7 @@ vi.mock("@formbricks/database", () => ({
 }));
 
 vi.mock("./contact", () => ({
-  doesContactExist: vi.fn(),
+  doesContactExistInWorkspace: vi.fn(),
 }));
 
 const workspaceId = "workspace-id-mock";
@@ -81,13 +81,13 @@ describe("createDisplay", () => {
   });
 
   test("should create a display with contactId successfully", async () => {
-    vi.mocked(doesContactExist).mockResolvedValue(true);
+    vi.mocked(doesContactExistInWorkspace).mockResolvedValue(true);
     vi.mocked(prisma.display.create).mockResolvedValue(mockDisplay);
 
     const result = await createDisplay(displayInput);
 
     expect(validateInputs).toHaveBeenCalledWith([displayInput, expect.any(Object)]);
-    expect(doesContactExist).toHaveBeenCalledWith(contactId, workspaceId);
+    expect(doesContactExistInWorkspace).toHaveBeenCalledWith(contactId, workspaceId);
     expect(prisma.display.create).toHaveBeenCalledWith({
       data: {
         survey: { connect: { id: surveyId } },
@@ -104,7 +104,7 @@ describe("createDisplay", () => {
     const result = await createDisplay(displayInputWithoutContact);
 
     expect(validateInputs).toHaveBeenCalledWith([displayInputWithoutContact, expect.any(Object)]);
-    expect(doesContactExist).not.toHaveBeenCalled();
+    expect(doesContactExistInWorkspace).not.toHaveBeenCalled();
     expect(prisma.display.create).toHaveBeenCalledWith({
       data: {
         survey: { connect: { id: surveyId } },
@@ -115,13 +115,13 @@ describe("createDisplay", () => {
   });
 
   test("should create a display without contact if contact does not exist in the workspace", async () => {
-    vi.mocked(doesContactExist).mockResolvedValue(false);
+    vi.mocked(doesContactExistInWorkspace).mockResolvedValue(false);
     vi.mocked(prisma.display.create).mockResolvedValue(mockDisplayWithoutContact); // Expect no contact connection
 
     const result = await createDisplay(displayInput);
 
     expect(validateInputs).toHaveBeenCalledWith([displayInput, expect.any(Object)]);
-    expect(doesContactExist).toHaveBeenCalledWith(contactId, workspaceId);
+    expect(doesContactExistInWorkspace).toHaveBeenCalledWith(contactId, workspaceId);
     expect(prisma.display.create).toHaveBeenCalledWith({
       data: {
         survey: { connect: { id: surveyId } },
@@ -139,16 +139,16 @@ describe("createDisplay", () => {
     });
 
     await expect(createDisplay(displayInput)).rejects.toThrow(ValidationError);
-    expect(doesContactExist).not.toHaveBeenCalled();
+    expect(doesContactExistInWorkspace).not.toHaveBeenCalled();
     expect(prisma.display.create).not.toHaveBeenCalled();
   });
 
   test("should throw InvalidInputError when survey does not exist (P2025)", async () => {
-    vi.mocked(doesContactExist).mockResolvedValue(true);
+    vi.mocked(doesContactExistInWorkspace).mockResolvedValue(true);
     vi.mocked(prisma.survey.findUnique).mockResolvedValue(null);
 
     await expect(createDisplay(displayInput)).rejects.toThrow(new ResourceNotFoundError("Survey", surveyId));
-    expect(doesContactExist).toHaveBeenCalledWith(contactId, workspaceId);
+    expect(doesContactExistInWorkspace).toHaveBeenCalledWith(contactId, workspaceId);
     expect(prisma.survey.findUnique).toHaveBeenCalledWith({
       where: { id: surveyId, workspaceId },
     });
@@ -158,7 +158,7 @@ describe("createDisplay", () => {
   test.each(["draft", "paused", "completed"])(
     "should throw InvalidInputError when survey status is %s",
     async (status) => {
-      vi.mocked(doesContactExist).mockResolvedValue(true);
+      vi.mocked(doesContactExistInWorkspace).mockResolvedValue(true);
       vi.mocked(prisma.survey.findUnique).mockResolvedValue({ ...mockSurvey, status } as any);
 
       await expect(createDisplay(displayInput)).rejects.toThrow(InvalidInputError);
@@ -171,7 +171,7 @@ describe("createDisplay", () => {
       code: "P2002",
       clientVersion: "2.0.0",
     });
-    vi.mocked(doesContactExist).mockResolvedValue(true);
+    vi.mocked(doesContactExistInWorkspace).mockResolvedValue(true);
     vi.mocked(prisma.display.create).mockRejectedValue(prismaError);
 
     await expect(createDisplay(displayInput)).rejects.toThrow(DatabaseError);
@@ -179,15 +179,15 @@ describe("createDisplay", () => {
 
   test("should throw original error on other errors during creation", async () => {
     const genericError = new Error("Something went wrong");
-    vi.mocked(doesContactExist).mockResolvedValue(true);
+    vi.mocked(doesContactExistInWorkspace).mockResolvedValue(true);
     vi.mocked(prisma.display.create).mockRejectedValue(genericError);
 
     await expect(createDisplay(displayInput)).rejects.toThrow(genericError);
   });
 
-  test("should throw original error if doesContactExist fails", async () => {
+  test("should throw original error if doesContactExistInWorkspace fails", async () => {
     const contactCheckError = new Error("Failed to check contact");
-    vi.mocked(doesContactExist).mockRejectedValue(contactCheckError);
+    vi.mocked(doesContactExistInWorkspace).mockRejectedValue(contactCheckError);
 
     await expect(createDisplay(displayInput)).rejects.toThrow(contactCheckError);
     expect(prisma.display.create).not.toHaveBeenCalled();

--- a/apps/web/app/api/v2/client/[workspaceId]/displays/lib/display.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/displays/lib/display.test.ts
@@ -87,7 +87,7 @@ describe("createDisplay", () => {
     const result = await createDisplay(displayInput);
 
     expect(validateInputs).toHaveBeenCalledWith([displayInput, expect.any(Object)]);
-    expect(doesContactExist).toHaveBeenCalledWith(contactId);
+    expect(doesContactExist).toHaveBeenCalledWith(contactId, workspaceId);
     expect(prisma.display.create).toHaveBeenCalledWith({
       data: {
         survey: { connect: { id: surveyId } },
@@ -121,7 +121,7 @@ describe("createDisplay", () => {
     const result = await createDisplay(displayInput);
 
     expect(validateInputs).toHaveBeenCalledWith([displayInput, expect.any(Object)]);
-    expect(doesContactExist).toHaveBeenCalledWith(contactId);
+    expect(doesContactExist).toHaveBeenCalledWith(contactId, workspaceId);
     expect(prisma.display.create).toHaveBeenCalledWith({
       data: {
         survey: { connect: { id: surveyId } },
@@ -148,7 +148,7 @@ describe("createDisplay", () => {
     vi.mocked(prisma.survey.findUnique).mockResolvedValue(null);
 
     await expect(createDisplay(displayInput)).rejects.toThrow(new ResourceNotFoundError("Survey", surveyId));
-    expect(doesContactExist).toHaveBeenCalledWith(contactId);
+    expect(doesContactExist).toHaveBeenCalledWith(contactId, workspaceId);
     expect(prisma.survey.findUnique).toHaveBeenCalledWith({
       where: { id: surveyId, workspaceId },
     });

--- a/apps/web/app/api/v2/client/[workspaceId]/displays/lib/display.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/displays/lib/display.ts
@@ -14,7 +14,7 @@ export const createDisplay = async (displayInput: TDisplayCreateInputV2): Promis
   const { contactId, surveyId, workspaceId } = displayInput;
 
   try {
-    const contactExists = contactId ? await doesContactExist(contactId) : false;
+    const contactExists = contactId ? await doesContactExist(contactId, workspaceId) : false;
 
     const survey = await prisma.survey.findUnique({
       where: {

--- a/apps/web/app/api/v2/client/[workspaceId]/displays/lib/display.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/displays/lib/display.ts
@@ -6,7 +6,7 @@ import {
   ZDisplayCreateInputV2,
 } from "@/app/api/v2/client/[workspaceId]/displays/types/display";
 import { validateInputs } from "@/lib/utils/validate";
-import { doesContactExist } from "./contact";
+import { doesContactExistInWorkspace } from "./contact";
 
 export const createDisplay = async (displayInput: TDisplayCreateInputV2): Promise<{ id: string }> => {
   validateInputs([displayInput, ZDisplayCreateInputV2]);
@@ -14,7 +14,7 @@ export const createDisplay = async (displayInput: TDisplayCreateInputV2): Promis
   const { contactId, surveyId, workspaceId } = displayInput;
 
   try {
-    const contactExists = contactId ? await doesContactExist(contactId, workspaceId) : false;
+    const contactExists = contactId ? await doesContactExistInWorkspace(contactId, workspaceId) : false;
 
     const survey = await prisma.survey.findUnique({
       where: {


### PR DESCRIPTION
## Summary

- `doesContactExist` in `POST /api/v2/client/{workspaceId}/displays` previously checked contact existence by `id` only, allowing a caller to bind a display to a contact from a different workspace
- Adds `workspaceId` to the Prisma `where` clause and threads it through from `createDisplay` — a contact from a foreign workspace now returns `false` and is silently ignored (matching the behaviour for a non-existent contact)
- Updates tests to assert the workspace-scoped query

**Root cause:** [PR #7984](https://github.com/formbricks/formbricks/pull/7984) had fixed this with an `environmentId` filter, but the Formbricks 5 migration ([PR #8017](https://github.com/formbricks/formbricks/pull/8017)) dropped it when renaming `environmentId` → `workspaceId`. The responses path was correctly updated; the displays path was missed.

Fixes [GHSA-rfcc-wqfr-cg55](https://github.com/formbricks/formbricks/security/advisories/GHSA-rfcc-wqfr-cg55)

## Test plan

- [ ] Submit `POST /api/v2/client/{workspaceId}/displays` with a `contactId` from the same workspace — display is created with the contact linked
- [ ] Submit with a `contactId` from a different workspace — display is created without any contact linked (contact silently ignored)
- [ ] Run `apps/web/app/api/v2/client/[workspaceId]/displays/lib/contact.test.ts` and `display.test.ts` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)