### PR TITLE
fix: return 404 when response is deleted mid-update

### DIFF
--- a/apps/web/app/api/v1/auth.test.ts
+++ b/apps/web/app/api/v1/auth.test.ts
@@ -313,9 +313,18 @@ describe("handleErrorResponse", () => {
     expect(body.message).toBe("bad input");
   });
 
-  test("returns 400 badRequest for ResourceNotFoundError", async () => {
+  test("returns 404 notFound for ResourceNotFoundError", async () => {
     const response = handleErrorResponse(new ResourceNotFoundError("Survey", "id-1"));
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body).toEqual({
+      code: "not_found",
+      message: "Survey not found",
+      details: {
+        resource_id: "id-1",
+        resource_type: "Survey",
+      },
+    });
   });
 
   test("returns 500 internalServerError for unknown errors", async () => {

--- a/apps/web/app/api/v1/auth.ts
+++ b/apps/web/app/api/v1/auth.ts
@@ -29,11 +29,10 @@ export const handleErrorResponse = (error: any): Response => {
       if (error instanceof UniqueConstraintError) {
         return responses.conflictResponse(error.message);
       }
-      if (
-        error instanceof DatabaseError ||
-        error instanceof InvalidInputError ||
-        error instanceof ResourceNotFoundError
-      ) {
+      if (error instanceof ResourceNotFoundError) {
+        return responses.notFoundResponse(error.resourceType, error.resourceId);
+      }
+      if (error instanceof DatabaseError || error instanceof InvalidInputError) {
         return responses.badRequestResponse(error.message);
       }
       return responses.internalServerErrorResponse("Some error occurred");

--- a/apps/web/lib/response/service.test.ts
+++ b/apps/web/lib/response/service.test.ts
@@ -1,6 +1,7 @@
 import { Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
+import { PrismaErrorType } from "@formbricks/database/types/error";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TResponseUpdateInput } from "@formbricks/types/responses";
 import { updateResponse } from "./service";
@@ -323,6 +324,36 @@ describe("updateResponse", () => {
       const responseInput = createMockResponseInput();
 
       await expect(updateResponse(mockResponseId, responseInput)).rejects.toThrow(DatabaseError);
+    });
+
+    test("should throw ResourceNotFoundError when response is deleted during update", async () => {
+      const currentResponse = createMockCurrentResponse();
+      vi.mocked(prisma.response.findUnique).mockResolvedValue(currentResponse as any);
+      vi.mocked(prisma.response.update).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("Record to update not found", {
+          code: PrismaErrorType.RelatedRecordDoesNotExist,
+          clientVersion: "5.0.0",
+        })
+      );
+
+      const responseInput = createMockResponseInput();
+
+      await expect(updateResponse(mockResponseId, responseInput)).rejects.toThrow(ResourceNotFoundError);
+    });
+
+    test("should throw ResourceNotFoundError when Prisma reports a missing response record", async () => {
+      const currentResponse = createMockCurrentResponse();
+      vi.mocked(prisma.response.findUnique).mockResolvedValue(currentResponse as any);
+      vi.mocked(prisma.response.update).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("Record does not exist", {
+          code: PrismaErrorType.RecordDoesNotExist,
+          clientVersion: "5.0.0",
+        })
+      );
+
+      const responseInput = createMockResponseInput();
+
+      await expect(updateResponse(mockResponseId, responseInput)).rejects.toThrow(ResourceNotFoundError);
     });
   });
 });

--- a/apps/web/lib/response/service.ts
+++ b/apps/web/lib/response/service.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@prisma/client";
 import { cache as reactCache } from "react";
 import { z } from "zod";
 import { prisma } from "@formbricks/database";
+import { PrismaErrorType } from "@formbricks/database/types/error";
 import { logger } from "@formbricks/logger";
 import { ZId, ZOptionalNumber, ZString } from "@formbricks/types/common";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
@@ -569,6 +570,13 @@ export const updateResponse = async (
     return response;
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (
+        error.code === PrismaErrorType.RecordDoesNotExist ||
+        error.code === PrismaErrorType.RelatedRecordDoesNotExist
+      ) {
+        throw new ResourceNotFoundError("Response", responseId);
+      }
+
       throw new DatabaseError(error.message);
     }
 


### PR DESCRIPTION
Fixes: ENG-956

## What changed

- Map Prisma missing-record errors from `updateResponse()` to `ResourceNotFoundError` when a response is deleted between the initial lookup and the update.
- Return the existing v1 `not_found` API response for `ResourceNotFoundError` instead of serializing it as a bad request.
- Add targeted coverage for the response update race and v1 error serialization.

## Why

The response update route performs a preflight lookup before persisting changes. If the response is deleted after that lookup but before `prisma.response.update()` runs, Prisma reports the missing row and the API previously surfaced it as an error instead of a 404.

## Validation

- `CUBEJS_API_URL=http://localhost HUB_API_URL=http://localhost HUB_API_KEY=test pnpm exec dotenv -e ../../.env -- vitest run app/api/v1/auth.test.ts lib/response/service.test.ts 'app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.test.ts'`