### PR TITLE
fix: correct settings sidebar back navigation behavior

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
@@ -22,7 +22,7 @@ import {
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { TOrganizationRole } from "@formbricks/types/memberships";
 import { TOrganization } from "@formbricks/types/organizations";
@@ -110,6 +110,8 @@ export const MainNavigation = ({
 
   const isOwnerOrManager = isManager || isOwner;
   const isSettingsMode = pathname?.includes("/settings");
+  const [previousPathname, setPreviousPathname] = useState<string | null>(null);
+  const currentPathRef = useRef<string | null>(pathname ?? null);
 
   const toggleSidebar = () => {
     setIsCollapsed(!isCollapsed);
@@ -120,6 +122,15 @@ export const MainNavigation = ({
     const isCollapsedValueFromLocalStorage = localStorage.getItem("isMainNavCollapsed") === "true";
     setIsCollapsed(isCollapsedValueFromLocalStorage);
   }, []);
+
+  useEffect(() => {
+    if (!pathname || currentPathRef.current === pathname) {
+      return;
+    }
+
+    setPreviousPathname(currentPathRef.current);
+    currentPathRef.current = pathname;
+  }, [pathname]);
 
   useEffect(() => {
     const toggleTextOpacity = () => {
@@ -194,7 +205,7 @@ export const MainNavigation = ({
   const settingsNavigationItem = useMemo(
     () => ({
       name: t("common.settings"),
-      href: `/workspaces/${workspace.id}/settings`,
+      href: `/workspaces/${workspace.id}/settings/workspace/general`,
       icon: SettingsIcon,
       isActive: isSettingsMode,
       disabled: isMembershipPending || isBilling,
@@ -467,7 +478,11 @@ export const MainNavigation = ({
           {isSettingsMode ? (
             <div className="flex flex-col overflow-hidden">
               <div className="mb-2 px-3">
-                <GoBackButton />
+                <GoBackButton
+                  previousPath={previousPathname}
+                  settingsPathPrefix={`/workspaces/${workspace.id}/settings`}
+                  settingsFallbackUrl={`/workspaces/${workspace.id}/surveys`}
+                />
               </div>
 
               {/* Settings sidebar content */}

--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
@@ -22,7 +22,7 @@ import {
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState, useTransition } from "react";
+import { useCallback, useEffect, useMemo, useState, useTransition } from "react";
 import { useTranslation } from "react-i18next";
 import { TOrganizationRole } from "@formbricks/types/memberships";
 import { TOrganization } from "@formbricks/types/organizations";
@@ -110,8 +110,6 @@ export const MainNavigation = ({
 
   const isOwnerOrManager = isManager || isOwner;
   const isSettingsMode = pathname?.includes("/settings");
-  const [previousPathname, setPreviousPathname] = useState<string | null>(null);
-  const currentPathRef = useRef<string | null>(pathname ?? null);
 
   const toggleSidebar = () => {
     setIsCollapsed(!isCollapsed);
@@ -122,15 +120,6 @@ export const MainNavigation = ({
     const isCollapsedValueFromLocalStorage = localStorage.getItem("isMainNavCollapsed") === "true";
     setIsCollapsed(isCollapsedValueFromLocalStorage);
   }, []);
-
-  useEffect(() => {
-    if (!pathname || currentPathRef.current === pathname) {
-      return;
-    }
-
-    setPreviousPathname(currentPathRef.current);
-    currentPathRef.current = pathname;
-  }, [pathname]);
 
   useEffect(() => {
     const toggleTextOpacity = () => {
@@ -478,11 +467,7 @@ export const MainNavigation = ({
           {isSettingsMode ? (
             <div className="flex flex-col overflow-hidden">
               <div className="mb-2 px-3">
-                <GoBackButton
-                  previousPath={previousPathname}
-                  settingsPathPrefix={`/workspaces/${workspace.id}/settings`}
-                  settingsFallbackUrl={`/workspaces/${workspace.id}/surveys`}
-                />
+                <GoBackButton url={`/workspaces/${workspace.id}/surveys`} />
               </div>
 
               {/* Settings sidebar content */}

--- a/apps/web/modules/ui/components/go-back-button/index.tsx
+++ b/apps/web/modules/ui/components/go-back-button/index.tsx
@@ -1,13 +1,34 @@
 "use client";
 
 import { ArrowLeftIcon } from "lucide-react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/modules/ui/components/button";
 
-export const GoBackButton = ({ url }: { url?: string }) => {
+interface GoBackButtonProps {
+  url?: string;
+  previousPath?: string | null;
+  settingsPathPrefix?: string;
+  settingsFallbackUrl?: string;
+}
+
+export const GoBackButton = ({
+  url,
+  previousPath,
+  settingsPathPrefix,
+  settingsFallbackUrl,
+}: Readonly<GoBackButtonProps>) => {
   const router = useRouter();
+  const pathname = usePathname();
   const { t } = useTranslation();
+
+  const shouldRedirectToSettingsFallback =
+    !!settingsFallbackUrl &&
+    !!settingsPathPrefix &&
+    !!previousPath &&
+    previousPath.startsWith(settingsPathPrefix) &&
+    previousPath !== pathname;
+
   return (
     <Button
       size="sm"
@@ -17,6 +38,12 @@ export const GoBackButton = ({ url }: { url?: string }) => {
           router.push(url);
           return;
         }
+
+        if (shouldRedirectToSettingsFallback) {
+          router.replace(settingsFallbackUrl);
+          return;
+        }
+
         router.back();
       }}>
       <ArrowLeftIcon />

--- a/apps/web/modules/ui/components/go-back-button/index.tsx
+++ b/apps/web/modules/ui/components/go-back-button/index.tsx
@@ -1,33 +1,17 @@
 "use client";
 
 import { ArrowLeftIcon } from "lucide-react";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/modules/ui/components/button";
 
 interface GoBackButtonProps {
   url?: string;
-  previousPath?: string | null;
-  settingsPathPrefix?: string;
-  settingsFallbackUrl?: string;
 }
 
-export const GoBackButton = ({
-  url,
-  previousPath,
-  settingsPathPrefix,
-  settingsFallbackUrl,
-}: Readonly<GoBackButtonProps>) => {
+export const GoBackButton = ({ url }: Readonly<GoBackButtonProps>) => {
   const router = useRouter();
-  const pathname = usePathname();
   const { t } = useTranslation();
-
-  const shouldRedirectToSettingsFallback =
-    !!settingsFallbackUrl &&
-    !!settingsPathPrefix &&
-    !!previousPath &&
-    previousPath.startsWith(settingsPathPrefix) &&
-    previousPath !== pathname;
 
   return (
     <Button
@@ -36,11 +20,6 @@ export const GoBackButton = ({
       onClick={() => {
         if (url) {
           router.push(url);
-          return;
-        }
-
-        if (shouldRedirectToSettingsFallback) {
-          router.replace(settingsFallbackUrl);
           return;
         }
 


### PR DESCRIPTION
Closes ENG-1004 (https://linear.app/formbricks/issue/ENG-1004/settings-back-button-navigates-within-settings-instead-of-exiting-to)

## Summary
- make the settings sidebar entry navigate directly to `/settings/workspace/general` to avoid adding a redirect hop to browser history
- track the previous pathname in workspace navigation and pass it to `GoBackButton` while in settings mode
- if the previous path is another settings route, route to the survey list instead of stepping through settings history; otherwise use normal browser back

## Test plan
- [x] Navigate `Contacts -> Settings -> Back` and verify it returns to `Contacts`
- [x] Navigate across multiple settings pages and verify `Back` routes to `Surveys` instead of traversing each settings page
- [ ] Open a settings page directly in a new tab (no prior history) and verify `Back` exits settings to the Surveys page
- [ ] Run full automated test suite