### PR TITLE
fix: staging AI chart Cube schema

### DIFF
--- a/apps/web/modules/ee/analysis/lib/schema-definition.test.ts
+++ b/apps/web/modules/ee/analysis/lib/schema-definition.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 import {
   FEEDBACK_FIELDS,
@@ -5,6 +7,17 @@ import {
   getFieldById,
   getFilterOperatorsForType,
 } from "./schema-definition";
+
+const chartCubeSchemaPath = fileURLToPath(
+  new URL("../../../../../../charts/formbricks/cube/schema/FeedbackRecords.js", import.meta.url)
+);
+const dockerCubeSchemaPath = fileURLToPath(
+  new URL("../../../../../../docker/cube/schema/FeedbackRecords.js", import.meta.url)
+);
+
+const readChartCubeSchema = (): string => readFileSync(chartCubeSchemaPath, "utf8");
+const readDockerCubeSchema = (): string => readFileSync(dockerCubeSchemaPath, "utf8");
+const getCubeMemberName = (id: string): string => id.replace("FeedbackRecords.", "");
 
 describe("schema-definition", () => {
   describe("getFilterOperatorsForType", () => {
@@ -93,6 +106,21 @@ describe("schema-definition", () => {
         ])
       );
       expect(ids).not.toContain("FeedbackRecords.averageScore");
+    });
+
+    test("only exposes members present in the deployed Cube schema", () => {
+      const chartCubeSchema = readChartCubeSchema();
+      const exposedMembers = [...FEEDBACK_FIELDS.measures, ...FEEDBACK_FIELDS.dimensions].map(({ id }) =>
+        getCubeMemberName(id)
+      );
+
+      for (const member of exposedMembers) {
+        expect(chartCubeSchema).toContain(`    ${member}: {`);
+      }
+    });
+
+    test("keeps the Helm and Docker Cube schemas in sync", () => {
+      expect(readChartCubeSchema()).toBe(readDockerCubeSchema());
     });
   });
 });

--- a/charts/formbricks/cube/schema/FeedbackRecords.js
+++ b/charts/formbricks/cube/schema/FeedbackRecords.js
@@ -9,46 +9,120 @@ cube(`FeedbackRecords`, {
       description: `Total number of feedback responses`,
     },
 
+    uniqueRespondents: {
+      type: `countDistinct`,
+      sql: `${CUBE}.user_id`,
+      description: `Number of unique users who provided feedback`,
+    },
+
+    uniqueResponses: {
+      type: `countDistinct`,
+      sql: `${CUBE}.submission_id`,
+      description: `Number of unique survey submissions (a submission can produce multiple feedback records)`,
+    },
+
     promoterCount: {
       type: `count`,
-      filters: [{ sql: `${CUBE}.value_number >= 9` }],
-      description: `Number of promoters (NPS score 9-10)`,
+      filters: [{ sql: `${CUBE}.field_type = 'nps' AND ${CUBE}.value_number >= 9` }],
+      description: `Number of NPS promoters (score 9-10)`,
     },
 
     detractorCount: {
       type: `count`,
-      filters: [{ sql: `${CUBE}.value_number >= 0 AND ${CUBE}.value_number <= 6` }],
-      description: `Number of detractors (NPS score 0-6)`,
+      filters: [{ sql: `${CUBE}.field_type = 'nps' AND ${CUBE}.value_number BETWEEN 0 AND 6` }],
+      description: `Number of NPS detractors (score 0-6)`,
     },
 
     passiveCount: {
       type: `count`,
-      filters: [{ sql: `${CUBE}.value_number >= 7 AND ${CUBE}.value_number <= 8` }],
-      description: `Number of passives (NPS score 7-8)`,
+      filters: [{ sql: `${CUBE}.field_type = 'nps' AND ${CUBE}.value_number BETWEEN 7 AND 8` }],
+      description: `Number of NPS passives (score 7-8)`,
     },
 
     npsScore: {
       type: `number`,
       sql: `
         CASE
-          WHEN COUNT(*) = 0 THEN 0
+          WHEN COUNT(CASE WHEN ${CUBE}.field_type = 'nps' AND ${CUBE}.value_number IS NOT NULL THEN 1 END) = 0 THEN NULL
           ELSE ROUND(
             (
-              (COUNT(CASE WHEN ${CUBE}.value_number >= 9 THEN 1 END)::numeric -
-               COUNT(CASE WHEN ${CUBE}.value_number >= 0 AND ${CUBE}.value_number <= 6 THEN 1 END)::numeric)
-              / COUNT(*)::numeric
+              (COUNT(CASE WHEN ${CUBE}.field_type = 'nps' AND ${CUBE}.value_number >= 9 THEN 1 END)::numeric -
+               COUNT(CASE WHEN ${CUBE}.field_type = 'nps' AND ${CUBE}.value_number BETWEEN 0 AND 6 THEN 1 END)::numeric)
+              / COUNT(CASE WHEN ${CUBE}.field_type = 'nps' AND ${CUBE}.value_number IS NOT NULL THEN 1 END)::numeric
             ) * 100,
             2
           )
         END
       `,
-      description: `Net Promoter Score: ((Promoters - Detractors) / Total) * 100`,
+      description: `Net Promoter Score: ((Promoters - Detractors) / Answered NPS responses) * 100. NULL when there are no answered NPS responses.`,
     },
 
-    averageScore: {
+    npsAverage: {
       type: `avg`,
       sql: `${CUBE}.value_number`,
-      description: `Average NPS score`,
+      filters: [{ sql: `${CUBE}.field_type = 'nps'` }],
+      description: `Average NPS rating (0-10)`,
+    },
+
+    csatCount: {
+      type: `count`,
+      filters: [{ sql: `${CUBE}.field_type = 'csat' AND ${CUBE}.value_number IS NOT NULL` }],
+      description: `Number of answered CSAT responses (dismissed responses excluded).`,
+    },
+
+    csatSatisfiedCount: {
+      type: `count`,
+      filters: [{ sql: `${CUBE}.field_type = 'csat' AND ${CUBE}.value_number >= 4` }],
+      description: `Number of satisfied CSAT responses (top-2-box on the 1-5 scale)`,
+    },
+
+    csatDissatisfiedCount: {
+      type: `count`,
+      filters: [{ sql: `${CUBE}.field_type = 'csat' AND ${CUBE}.value_number BETWEEN 1 AND 2` }],
+      description: `Number of dissatisfied CSAT responses (bottom-2-box on the 1-5 scale)`,
+    },
+
+    csatNeutralCount: {
+      type: `count`,
+      filters: [{ sql: `${CUBE}.field_type = 'csat' AND ${CUBE}.value_number = 3` }],
+      description: `Number of neutral CSAT responses (middle box on the 1-5 scale)`,
+    },
+
+    csatScore: {
+      type: `number`,
+      sql: `
+        CASE
+          WHEN COUNT(CASE WHEN ${CUBE}.field_type = 'csat' AND ${CUBE}.value_number IS NOT NULL THEN 1 END) = 0 THEN NULL
+          ELSE ROUND(
+            (
+              COUNT(CASE WHEN ${CUBE}.field_type = 'csat' AND ${CUBE}.value_number >= 4 THEN 1 END)::numeric
+              / COUNT(CASE WHEN ${CUBE}.field_type = 'csat' AND ${CUBE}.value_number IS NOT NULL THEN 1 END)::numeric
+            ) * 100,
+            2
+          )
+        END
+      `,
+      description: `CSAT Score: % of answered CSAT responses rated 4 or 5 (top-2-box on the 1-5 scale). NULL when there are no answered CSAT responses.`,
+    },
+
+    csatAverage: {
+      type: `avg`,
+      sql: `${CUBE}.value_number`,
+      filters: [{ sql: `${CUBE}.field_type = 'csat'` }],
+      description: `Average CSAT rating (1-5)`,
+    },
+
+    cesCount: {
+      type: `count`,
+      filters: [{ sql: `${CUBE}.field_type = 'ces' AND ${CUBE}.value_number IS NOT NULL` }],
+      description: `Number of answered CES responses (dismissed responses excluded).`,
+    },
+
+    cesAverage: {
+      type: `avg`,
+      sql: `${CUBE}.value_number`,
+      filters: [{ sql: `${CUBE}.field_type = 'ces'` }],
+      description: `Average CES rating (scale is 1-5 or 1-7 depending on the question)`,
     },
   },
 
@@ -77,22 +151,70 @@ cube(`FeedbackRecords`, {
       description: `Type of feedback field (e.g., nps, text, rating)`,
     },
 
+    fieldLabel: {
+      sql: `field_label`,
+      type: `string`,
+      description: `Human-readable label of the question/field (e.g., "How satisfied are you with support?")`,
+    },
+
+    fieldGroupLabel: {
+      sql: `field_group_label`,
+      type: `string`,
+      description: `Label of the parent composite question for matrix/ranking rows`,
+    },
+
+    language: {
+      sql: `language`,
+      type: `string`,
+      description: `Response language code (e.g., "en", "de"). NULL when language is "default".`,
+    },
+
     collectedAt: {
       sql: `collected_at`,
       type: `time`,
       description: `Timestamp when the feedback was collected`,
     },
 
-    npsValue: {
+    createdAt: {
+      sql: `created_at`,
+      type: `time`,
+      description: `Timestamp when the feedback record was created in Hub`,
+    },
+
+    updatedAt: {
+      sql: `updated_at`,
+      type: `time`,
+      description: `Timestamp when the feedback record was last updated in Hub`,
+    },
+
+    valueNumber: {
       sql: `value_number`,
       type: `number`,
-      description: `Raw NPS score value (0-10)`,
+      description: `Numeric answer value (NPS 0-10, CSAT 1-5, CES 1-5 or 1-7, rating, generic number). Pair with a fieldType filter to keep scales consistent.`,
+    },
+
+    valueText: {
+      sql: `value_text`,
+      type: `string`,
+      description: `Text answer value (open text, or the label of a multiple-choice / categorical answer). Pair with a fieldType filter to keep types consistent.`,
+    },
+
+    valueBoolean: {
+      sql: `value_boolean`,
+      type: `boolean`,
+      description: `Boolean answer value (yes/no questions). Pair with a fieldType filter.`,
+    },
+
+    valueDate: {
+      sql: `value_date`,
+      type: `time`,
+      description: `Date answer value (e.g., "preferred meeting date"). Pair with a fieldType filter.`,
     },
 
     responseId: {
-      sql: `response_id`,
+      sql: `submission_id`,
       type: `string`,
-      description: `Unique identifier linking related feedback records`,
+      description: `Unique identifier linking related feedback records (submission_id in Hub)`,
     },
 
     userId: {


### PR DESCRIPTION
Fixes: ENG-1006

## What changed
- Synced the Helm chart `FeedbackRecords` Cube schema with the Docker Cube schema used locally.
- Added regression coverage so AI chart fields cannot advertise Cube members missing from the deployed Helm schema.
- Added coverage to keep the Helm and Docker Cube schemas in sync.

## Why
AI chart generation in staging was no longer failing on Vertex credentials. The new failure was Cube rejecting the generated query because the deployed Helm schema did not include members exposed to the LLM, for example `FeedbackRecords.npsAverage`.

## Impact
This lets AI-generated charts query the same feedback measures and dimensions the app exposes in `FEEDBACK_FIELDS`, including NPS average, CSAT/CES metrics, and feedback value dimensions.

## Validation
- `CUBEJS_API_URL=http://cube.local CUBEJS_API_SECRET=secret HUB_API_URL=http://hub.local HUB_API_KEY=key pnpm --dir apps/web exec vitest run modules/ee/analysis/lib/schema-definition.test.ts`
- `git diff --check -- apps/web/modules/ee/analysis/lib/schema-definition.test.ts charts/formbricks/cube/schema/FeedbackRecords.js`
- `helm template formbricks-stage charts/formbricks -f /Users/bhagya/work/formbricks/gitops-staging-ai-config/formbricks/values-stage.yaml --namespace formbricks-stage`