### PR TITLE
fix: route Manage Teams and integration OAuth callbacks to settings (ENG-988)

### DIFF
--- a/apps/web/app/api/google-sheet/callback/route.ts
+++ b/apps/web/app/api/google-sheet/callback/route.ts
@@ -34,7 +34,7 @@ export const GET = async (req: Request) => {
     return responses.unauthorizedResponse();
   }
 
-  const basePath = `/workspaces/${workspaceId}`;
+  const basePath = `/workspaces/${workspaceId}/settings/workspace`;
 
   if (code && typeof code !== "string") {
     return responses.badRequestResponse("`code` must be a string");
@@ -102,7 +102,7 @@ export const GET = async (req: Request) => {
       logger.error({ error: err }, "Failed to capture PostHog integration_connected event for googleSheets");
     }
 
-    return Response.redirect(`${WEBAPP_URL}/${basePath}/integrations/google-sheets`);
+    return Response.redirect(`${WEBAPP_URL}${basePath}/integrations/google-sheets`);
   }
 
   return responses.internalServerErrorResponse("Failed to create or update Google Sheets integration");

--- a/apps/web/app/api/v1/integrations/airtable/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/airtable/callback/route.ts
@@ -51,7 +51,7 @@ export const GET = withV1ApiWrapper({
       };
     }
 
-    const basePath = `/workspaces/${workspaceId}`;
+    const basePath = `/workspaces/${workspaceId}/settings/workspace`;
 
     const client_id = AIRTABLE_CLIENT_ID;
     const redirect_uri = WEBAPP_URL + "/api/v1/integrations/airtable/callback";

--- a/apps/web/app/api/v1/integrations/notion/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/notion/callback/route.ts
@@ -40,7 +40,7 @@ export const GET = withV1ApiWrapper({
       };
     }
 
-    const basePath = `/workspaces/${workspaceId}`;
+    const basePath = `/workspaces/${workspaceId}/settings/workspace`;
 
     if (code && typeof code !== "string") {
       return {

--- a/apps/web/app/api/v1/integrations/slack/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/slack/callback/route.ts
@@ -37,7 +37,7 @@ export const GET = withV1ApiWrapper({
       };
     }
 
-    const basePath = `/workspaces/${workspaceId}`;
+    const basePath = `/workspaces/${workspaceId}/settings/workspace`;
 
     if (code && typeof code !== "string") {
       return {

--- a/apps/web/modules/ee/teams/workspace-teams/components/manage-team.tsx
+++ b/apps/web/modules/ee/teams/workspace-teams/components/manage-team.tsx
@@ -13,7 +13,7 @@ export const ManageTeam = () => {
   const router = useRouter();
 
   const handleManageTeams = () => {
-    router.push(`${workspaceBasePath}/settings/teams`);
+    router.push(`${workspaceBasePath}/settings/organization/teams`);
   };
 
   return (


### PR DESCRIPTION
Closes ENG-988 (https://linear.app/formbricks/issue/ENG-988/multiple-404-routing-redirect-bugs-in-50-qa)

## Summary

Two 404 bugs surfaced during 5.0 QA, both caused by the recent settings-route restructure (settings was reparented under explicit `workspace`/`organization` segments, and a few callers/redirects were missed).

- **Workspace team-access "Manage teams" button** pushed to `/workspaces/:id/settings/teams` → 404. Now goes to `/workspaces/:id/settings/organization/teams`.
- **Integration OAuth callbacks (Google Sheets, Notion, Airtable, Slack)** redirected to `/workspaces/:id/integrations/<provider>` → 404. Now redirect to `/workspaces/:id/settings/workspace/integrations/<provider>`. Implemented by extending `basePath` in each callback to include `/settings/workspace`.

Also cleans up a stray double-slash in the Google Sheets success redirect (`${WEBAPP_URL}/${basePath}` → `${WEBAPP_URL}${basePath}`) so it matches the file's two other redirects.

## Files

- `apps/web/modules/ee/teams/workspace-teams/components/manage-team.tsx`
- `apps/web/app/api/google-sheet/callback/route.ts`
- `apps/web/app/api/v1/integrations/notion/callback/route.ts`
- `apps/web/app/api/v1/integrations/airtable/callback/route.ts`
- `apps/web/app/api/v1/integrations/slack/callback/route.ts`

## Test plan

- [ ] Open workspace settings → Team access → click "Manage teams" → lands on `/settings/organization/teams` (no 404)
- [ ] Connect Google Sheets integration → after OAuth completes, browser lands on `/settings/workspace/integrations/google-sheets`
- [ ] Same for Notion, Airtable, Slack
- [ ] Verify error path on Google Sheets / Notion / Airtable / Slack (e.g. revoke at provider) → still lands on the same settings page, not a 404

## Notes for reviewers

ENG-988 also lists a follow-up: sweep the codebase for any other callers still using the old `/settings/teams` or `/workspace/...` (without `/settings/`) paths. I grepped `apps/web/**/*.ts(x)` and found no other URL strings using those patterns — the remaining `/workspace/...` references in `SettingsSidebarContent.tsx` are already prefixed with `${basePath}` where `basePath = /workspaces/:id/settings`, so they resolve correctly.

This is a UI/routing-only change. No DB migrations, no API contracts changed.