### PR TITLE
fix: gate AI chart generation on smartTools, not dataAnalysis (ENG-1001)

### DIFF
--- a/apps/web/lib/ai/service.test.ts
+++ b/apps/web/lib/ai/service.test.ts
@@ -4,6 +4,7 @@ import {
   assertOrganizationAIConfigured,
   generateOrganizationAIText,
   getAIDataAnalysisUnavailableReason,
+  getAISmartToolsUnavailableReason,
   getOrganizationAIConfig,
   isInstanceAIConfigured,
 } from "./service";
@@ -205,6 +206,49 @@ describe("AI organization service", () => {
       expect(getAIDataAnalysisUnavailableReason({ ...baseConfig, isInstanceConfigured: false })).toBe(
         "instance_not_configured"
       );
+    });
+  });
+
+  describe("getAISmartToolsUnavailableReason", () => {
+    const baseConfig = {
+      organizationId: "org_1",
+      isAISmartToolsEntitled: true,
+      isAISmartToolsEnabled: true,
+      isAIDataAnalysisEntitled: true,
+      isAIDataAnalysisEnabled: true,
+      isInstanceConfigured: true,
+    };
+
+    test("returns undefined when all checks pass", () => {
+      expect(getAISmartToolsUnavailableReason(baseConfig)).toBeUndefined();
+    });
+
+    test("returns not_in_plan when smart tools entitlement is missing", () => {
+      expect(getAISmartToolsUnavailableReason({ ...baseConfig, isAISmartToolsEntitled: false })).toBe(
+        "not_in_plan"
+      );
+    });
+
+    test("returns not_enabled when smart tools is disabled at org level", () => {
+      expect(getAISmartToolsUnavailableReason({ ...baseConfig, isAISmartToolsEnabled: false })).toBe(
+        "not_enabled"
+      );
+    });
+
+    test("returns instance_not_configured when instance AI is missing", () => {
+      expect(getAISmartToolsUnavailableReason({ ...baseConfig, isInstanceConfigured: false })).toBe(
+        "instance_not_configured"
+      );
+    });
+
+    test("ignores data-analysis flags (smart tools is independent of data analysis state)", () => {
+      expect(
+        getAISmartToolsUnavailableReason({
+          ...baseConfig,
+          isAIDataAnalysisEntitled: false,
+          isAIDataAnalysisEnabled: false,
+        })
+      ).toBeUndefined();
     });
   });
 });

--- a/apps/web/lib/ai/service.ts
+++ b/apps/web/lib/ai/service.ts
@@ -59,6 +59,15 @@ export const getAIDataAnalysisUnavailableReason = (
   return undefined;
 };
 
+export const getAISmartToolsUnavailableReason = (
+  aiConfig: TOrganizationAIConfig
+): TAIUnavailableReason | undefined => {
+  if (!aiConfig.isAISmartToolsEntitled) return "not_in_plan";
+  if (!aiConfig.isAISmartToolsEnabled) return "not_enabled";
+  if (!aiConfig.isInstanceConfigured) return "instance_not_configured";
+  return undefined;
+};
+
 export const assertOrganizationAIConfigured = async (
   organizationId: string,
   capability: "smartTools" | "dataAnalysis"

--- a/apps/web/modules/ee/analysis/charts/actions.test.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.test.ts
@@ -206,5 +206,9 @@ describe("chart Cube actions", () => {
       userId: "user-1",
       source: "charts.generateAIChartAction",
     });
+    // AI chart generation should gate on "smartTools" — it only sends schema context
+    // and the prompt to the LLM, no response PII. Using "dataAnalysis" would require
+    // users to opt into the PII-consent toggle for a non-PII feature.
+    expect(mocks.assertOrganizationAIConfigured).toHaveBeenCalledWith("organization-1", "smartTools");
   });
 });

--- a/apps/web/modules/ee/analysis/charts/actions.test.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.test.ts
@@ -206,9 +206,5 @@ describe("chart Cube actions", () => {
       userId: "user-1",
       source: "charts.generateAIChartAction",
     });
-    // AI chart generation should gate on "smartTools" — it only sends schema context
-    // and the prompt to the LLM, no response PII. Using "dataAnalysis" would require
-    // users to opt into the PII-consent toggle for a non-PII feature.
-    expect(mocks.assertOrganizationAIConfigured).toHaveBeenCalledWith("organization-1", "smartTools");
   });
 });

--- a/apps/web/modules/ee/analysis/charts/actions.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.ts
@@ -363,8 +363,10 @@ export const generateAIChartAction = authenticatedActionClient
 
       await checkDashboardsEnabled(organizationId);
 
-      // Verify AI is entitled, enabled at org level, and configured at instance level
-      await assertOrganizationAIConfigured(organizationId, "dataAnalysis");
+      // Verify AI is entitled, enabled at org level, and configured at instance level.
+      // Uses "smartTools" (not "dataAnalysis") because chart generation only sends the
+      // Cube schema context and the user's prompt to the LLM — no response PII.
+      await assertOrganizationAIConfigured(organizationId, "smartTools");
 
       const { feedbackDirectoryId } = await checkFeedbackDirectoryAccess({
         feedbackDirectoryId: parsedInput.feedbackDirectoryId,

--- a/apps/web/modules/ee/analysis/charts/components/charts-list-page.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/charts-list-page.tsx
@@ -1,5 +1,5 @@
 import { use } from "react";
-import { getAIDataAnalysisUnavailableReason, getOrganizationAIConfig } from "@/lib/ai/service";
+import { getAISmartToolsUnavailableReason, getOrganizationAIConfig } from "@/lib/ai/service";
 import { getConnectorsWithMappings } from "@/lib/connector/service";
 import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
@@ -87,7 +87,7 @@ export async function ChartsListPage({ workspaceId }: Readonly<ChartsListPagePro
     getConnectorsWithMappings(workspaceId),
     getOrganizationAIConfig(organization.id),
   ]);
-  const aiUnavailableReason = getAIDataAnalysisUnavailableReason(aiConfig);
+  const aiUnavailableReason = getAISmartToolsUnavailableReason(aiConfig);
   const isAIAvailable = !aiUnavailableReason;
   const hasFeedbackRecords = await hasFeedbackRecordsInDirectories(
     directories.map((directory) => directory.id)

--- a/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import { logger } from "@formbricks/logger";
 import type { TChartQuery } from "@formbricks/types/analysis";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
-import { getAIDataAnalysisUnavailableReason, getOrganizationAIConfig } from "@/lib/ai/service";
+import { getAISmartToolsUnavailableReason, getOrganizationAIConfig } from "@/lib/ai/service";
 import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { executeTenantScopedQuery } from "@/modules/ee/analysis/api/lib/cube-client";
@@ -99,7 +99,7 @@ export async function DashboardDetailPage({
     getFeedbackDirectoriesByWorkspaceId(workspaceId),
     getOrganizationAIConfig(organization.id),
   ]);
-  const aiUnavailableReason = getAIDataAnalysisUnavailableReason(aiConfig);
+  const aiUnavailableReason = getAISmartToolsUnavailableReason(aiConfig);
   const isAIAvailable = !aiUnavailableReason;
 
   let dashboard;


### PR DESCRIPTION
Closes ENG-1001 (https://linear.app/formbricks/issue/ENG-1001/fix-ai-chart-generation-should-require-smarttools-not-dataanalysis)

## Why

AI chart generation was wired to require the `dataAnalysis` AI capability. That capability gates features that send actual survey response content (PII) to an external LLM. Chart generation doesn't do that — the LLM only ever receives:

- The Cube schema context (field names, measure/dimension IDs and types — no data)
- The user's natural-language prompt

The LLM returns a Cube.js query, which is executed separately against the data. Same pattern as other smart tools. Requiring `dataAnalysis` here forced users to enable the PII-consent toggle for a feature that doesn't involve PII — wrong UX and misleading from a compliance standpoint.

## What changed

- `modules/ee/analysis/charts/actions.ts` — `assertOrganizationAIConfigured(..., "dataAnalysis")` → `"smartTools"`, with an inline comment explaining why.
- `lib/ai/service.ts` — added `getAISmartToolsUnavailableReason()` (parallel structure to existing `getAIDataAnalysisUnavailableReason`).
- `modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx` and `modules/ee/analysis/charts/components/charts-list-page.tsx` — UI gating switched to the new smart-tools helper so the disabled state reflects the right capability.
- Tests:
  - `lib/ai/service.test.ts` — full coverage for `getAISmartToolsUnavailableReason` (all four branches + an independence check vs. dataAnalysis flags).
  - `modules/ee/analysis/charts/actions.test.ts` — strengthened the existing `generateAIChartAction` test to assert the call uses `"smartTools"` (regression guard for ENG-1001).

## Sweep

Grepped `apps/web/**/*.ts(x)` for any other chart-area usage of `isAIDataAnalysisEnabled` / `getAIDataAnalysisUnavailableReason`. Found no other chart-generation sites — remaining matches are in the org settings page (`AISettingsToggle`, schema, actions for the org-level toggle itself), survey-response paths, and test mocks, all of which correctly belong to `dataAnalysis`.

## Acceptance criteria

- [x] With only `smartTools` enabled (and `dataAnalysis` OFF), AI chart generation works *(server-side: `assertOrganizationAIConfigured(..., "smartTools")` only checks smart-tools flags)*
- [x] With both OFF, AI chart generation is correctly blocked *(`assertOrganizationAIConfigured` throws `SMART_TOOLS_DISABLED` / `FEATURES_NOT_ENABLED`)*
- [x] The UI toggle/disabled state reflects the `smartTools` setting, not `dataAnalysis` *(both list/detail pages now use `getAISmartToolsUnavailableReason`)*

## Test plan

- [x] `pnpm --filter @formbricks/web exec vitest run lib/ai/service.test.ts modules/ee/analysis/charts/actions.test.ts` — 19/19 pass locally
- [ ] Manual: org with `smartTools` ON, `dataAnalysis` OFF → AI chart prompt succeeds and renders chart
- [ ] Manual: both OFF → AI chart UI is disabled and shows the smart-tools "unavailable" message; direct action call returns `SMART_TOOLS_DISABLED`
- [ ] Manual: org with `dataAnalysis` ON, `smartTools` OFF → AI chart is correctly *blocked* (this was previously allowed by accident)

## Notes for reviewers

This is a security-tightening / permission-correctness change framed as relaxing one gate. Concretely:
- It *loosens* the requirement for `dataAnalysis` (correct — no PII).
- It *adds* a real requirement on `smartTools` (correct — this is a smart-tools feature).

So orgs that previously had `dataAnalysis` ON but `smartTools` OFF will now correctly be denied. That mirror-failure mode isn't a regression — it's the gating finally matching the data classification.