### PR TITLE
fix: show copy icon on legacy environmentId, reintroduce duplicate survey action (ENG-978, ENG-987)

### DIFF
--- a/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
+++ b/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
@@ -99,7 +99,7 @@ export const SurveyDropDownMenu = ({
       });
       if (response?.data) {
         toast.success(t("workspace.surveys.survey_duplicated_successfully"));
-        router.push(`/workspaces/${workspace.id}/surveys/${response.data.id}/edit`);
+        router.refresh();
         return;
       }
       toast.error(getFormattedErrorMessage(response));

--- a/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
+++ b/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { CopyIcon, EyeIcon, LinkIcon, MoreVertical, SquarePenIcon, TrashIcon } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -14,6 +15,7 @@ import { getV3ApiErrorMessage } from "@/modules/api/lib/v3-client";
 import { EditPublicSurveyAlertDialog } from "@/modules/survey/components/edit-public-survey-alert-dialog";
 import { copySurveyLink } from "@/modules/survey/lib/client-utils";
 import { copySurveyToOtherWorkspaceAction } from "@/modules/survey/list/actions";
+import { surveyKeys } from "@/modules/survey/list/lib/query";
 import { TSurveyListItem } from "@/modules/survey/list/types/survey-overview";
 import { DeleteDialog } from "@/modules/ui/components/delete-dialog";
 import {
@@ -48,6 +50,7 @@ export const SurveyDropDownMenu = ({
   const [isDropDownOpen, setIsDropDownOpen] = useState(false);
   const [isCautionDialogOpen, setIsCautionDialogOpen] = useState(false);
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const editHref = `/workspaces/${workspace?.id}/surveys/${survey.id}/edit`;
 
@@ -99,7 +102,10 @@ export const SurveyDropDownMenu = ({
       });
       if (response?.data) {
         toast.success(t("workspace.surveys.survey_duplicated_successfully"));
-        router.refresh();
+        // The list is fetched via React Query (see use-surveys.ts); router.refresh()
+        // alone won't repopulate the client cache. Invalidate the lists prefix to
+        // trigger a refetch so the new draft appears.
+        await queryClient.invalidateQueries({ queryKey: surveyKeys.lists() });
         return;
       }
       toast.error(getFormattedErrorMessage(response));

--- a/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
+++ b/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { EyeIcon, LinkIcon, MoreVertical, SquarePenIcon, TrashIcon } from "lucide-react";
+import { CopyIcon, EyeIcon, LinkIcon, MoreVertical, SquarePenIcon, TrashIcon } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
@@ -9,9 +9,11 @@ import { useTranslation } from "react-i18next";
 import { logger } from "@formbricks/logger";
 import { useWorkspace } from "@/app/(app)/workspaces/[workspaceId]/context/workspace-context";
 import { cn } from "@/lib/cn";
+import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { getV3ApiErrorMessage } from "@/modules/api/lib/v3-client";
 import { EditPublicSurveyAlertDialog } from "@/modules/survey/components/edit-public-survey-alert-dialog";
 import { copySurveyLink } from "@/modules/survey/lib/client-utils";
+import { copySurveyToOtherWorkspaceAction } from "@/modules/survey/list/actions";
 import { TSurveyListItem } from "@/modules/survey/list/types/survey-overview";
 import { DeleteDialog } from "@/modules/ui/components/delete-dialog";
 import {
@@ -42,6 +44,7 @@ export const SurveyDropDownMenu = ({
   const { t } = useTranslation();
   const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [isDuplicating, setIsDuplicating] = useState(false);
   const [isDropDownOpen, setIsDropDownOpen] = useState(false);
   const [isCautionDialogOpen, setIsCautionDialogOpen] = useState(false);
   const router = useRouter();
@@ -85,6 +88,29 @@ export const SurveyDropDownMenu = ({
     setIsCautionDialogOpen(true);
   };
 
+  const handleDuplicateSurvey = async () => {
+    if (!workspace?.id) return;
+    setIsDuplicating(true);
+    setIsDropDownOpen(false);
+    try {
+      const response = await copySurveyToOtherWorkspaceAction({
+        surveyId: survey.id,
+        targetWorkspaceId: workspace.id,
+      });
+      if (response?.data) {
+        toast.success(t("workspace.surveys.survey_duplicated_successfully"));
+        router.push(`/workspaces/${workspace.id}/surveys/${response.data.id}/edit`);
+        return;
+      }
+      toast.error(getFormattedErrorMessage(response));
+    } catch (error) {
+      logger.error(error);
+      toast.error(t("common.something_went_wrong_please_try_again"));
+    } finally {
+      setIsDuplicating(false);
+    }
+  };
+
   if (!hasVisibleActions) {
     return null;
   }
@@ -118,6 +144,22 @@ export const SurveyDropDownMenu = ({
                   <SquarePenIcon className="mr-2 size-4" />
                   {t("common.edit")}
                 </Link>
+              </DropdownMenuItem>
+            )}
+            {canManageSurvey && (
+              <DropdownMenuItem>
+                <button
+                  type="button"
+                  data-testid="duplicate-survey"
+                  className={cn("flex w-full items-center", isDuplicating && "cursor-not-allowed opacity-50")}
+                  disabled={isDuplicating}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    void handleDuplicateSurvey();
+                  }}>
+                  <CopyIcon className="mr-2 size-4" />
+                  {t("common.duplicate")}
+                </button>
               </DropdownMenuItem>
             )}
             {canPreviewOrCopyLink && (

--- a/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
+++ b/apps/web/modules/survey/list/components/survey-dropdown-menu.tsx
@@ -102,9 +102,6 @@ export const SurveyDropDownMenu = ({
       });
       if (response?.data) {
         toast.success(t("workspace.surveys.survey_duplicated_successfully"));
-        // The list is fetched via React Query (see use-surveys.ts); router.refresh()
-        // alone won't repopulate the client cache. Invalidate the lists prefix to
-        // trigger a refetch so the new draft appears.
         await queryClient.invalidateQueries({ queryKey: surveyKeys.lists() });
         return;
       }

--- a/apps/web/modules/workspaces/settings/(setup)/app-connection/page.tsx
+++ b/apps/web/modules/workspaces/settings/(setup)/app-connection/page.tsx
@@ -34,7 +34,6 @@ export const AppConnectionPage = async ({ params }: { params: Promise<{ workspac
               <IdBadge
                 id={workspace.legacyEnvironmentId}
                 label={t("workspace.app-connection.environment_id_legacy")}
-                copyDisabled
               />
             )}
             <IdBadge id={WEBAPP_URL} label={t("workspace.app-connection.webapp_url")} />

--- a/apps/web/playwright/survey-overview.spec.ts
+++ b/apps/web/playwright/survey-overview.spec.ts
@@ -224,7 +224,9 @@ test.describe("Survey overview", () => {
     });
 
     await page.locator("[data-testid='survey-dropdown-trigger']").click();
-    await expect(page.getByText("Duplicate", { exact: true })).toHaveCount(0);
+    // Duplicate stays visible for users who can manage surveys (works on drafts too —
+    // it creates another draft via copySurveyToOtherWorkspaceAction).
+    await expect(page.getByTestId("duplicate-survey")).toBeVisible();
     await expect(page.getByText("Copy...", { exact: true })).toHaveCount(0);
     await expect(page.getByText("Preview", { exact: true })).toHaveCount(0);
     await expect(page.getByTestId("copy-link")).toHaveCount(0);


### PR DESCRIPTION
Bundles two independent QA fixes that are each small enough that splitting feels like noise.

Closes ENG-978 (https://linear.app/formbricks/issue/ENG-978/bug-ui-no-copy-button-on-the-legacy-environmentid-tag)
Closes ENG-987 (https://linear.app/formbricks/issue/ENG-987/survey-overview-dropdown-no-longer-exposes-duplicate-survey-action)

## ENG-978 — legacy environmentId badge missing copy icon

The legacy `environmentId` badge on the app-connection settings page passed `copyDisabled` to `IdBadge`. `IdBadge`'s internal `BadgeContent` already wires `onClick={handleCopy}` regardless of `copyDisabled` — so clicking the badge was copying the value and firing a toast even though no copy icon, tooltip, hover state, or `role="button"` were visible. Affordance and behavior were out of sync.

Fix: drop the `copyDisabled` prop on the legacy environmentId `IdBadge`. The badge now shows the same copy affordance as every other `IdBadge` on the page.

## ENG-987 — survey overview dropdown lost Duplicate action

When the surveys overview was migrated to the v3 API flow, the dropdown's `Duplicate` (and `Copy...`) actions were removed. Backend support never went away:

- `apps/web/modules/survey/list/actions.ts` still exposes `copySurveyToOtherWorkspaceAction`
- `apps/web/modules/survey/list/lib/survey.ts` still implements `copySurveyToOtherWorkspace(...)` and writes the new survey with `status: "draft"`

Fix: re-add a `Duplicate` `<DropdownMenuItem>` in `survey-dropdown-menu.tsx`, gated by `canManageSurvey`. It calls `copySurveyToOtherWorkspaceAction({ surveyId, targetWorkspaceId: workspace.id })` and routes to the new draft's editor on success. Loading state via `isDuplicating` to prevent double-submits. The pattern mirrors `SurveyAnalysisCTA.duplicateSurveyAndRoute`.

Also flipped the Playwright assertion that expected `Duplicate` to be absent from drafts — drafts are exactly the case where duplicating makes sense, so it should be visible.

## Files

- `apps/web/modules/workspaces/settings/(setup)/app-connection/page.tsx` — drop `copyDisabled` from legacy env badge (ENG-978)
- `apps/web/modules/survey/list/components/survey-dropdown-menu.tsx` — add Duplicate handler + menu item (ENG-987)
- `apps/web/playwright/survey-overview.spec.ts` — assert Duplicate is visible on draft overview (ENG-987)

## Test plan

ENG-978:
- [ ] Workspace settings → App connection → legacy `environmentId` row shows the copy icon, tooltip, and hover affordance; click still copies + toasts (now matches the affordance)
- [ ] Behavior unchanged for the non-legacy workspace ID badge above it

ENG-987:
- [ ] Surveys overview → row menu → `Duplicate` is visible for owners/managers (and team members with `readWrite`); not visible for read-only members
- [ ] Click `Duplicate` on a draft → new draft created in the same workspace → routed to the editor of the new survey, success toast
- [ ] Click `Duplicate` on an active survey → same outcome (new copy is a draft per backend behavior)
- [ ] During the in-flight request the menu item shows disabled/opacity state; double-click doesn't trigger two duplicates
- [ ] Backend error → error toast, no navigation
- [ ] Playwright `keeps draft-only actions and optimistically deletes the last survey into the template state` passes with the updated assertion