### PR TITLE
fix: preserve legacy SDK shape with placeholder segment data

### DIFF
--- a/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.test.ts
@@ -103,6 +103,7 @@ describe("getWorkspaceStateData", () => {
         id: workspaceId,
         appSetupCompleted: true,
         workspaceSettings: {
+          id: workspaceId,
           recontactDays: 30,
           clickOutsideClose: true,
           overlay: "none",
@@ -111,7 +112,14 @@ describe("getWorkspaceStateData", () => {
           styling: { allowStyleOverwrite: false },
         },
       },
-      surveys: mockWorkspaceData.surveys,
+      // `survey.name` is replaced with a back-compat placeholder; segment was
+      // null in the mock so the sanitized segment stays null.
+      surveys: [
+        {
+          ...mockWorkspaceData.surveys[0],
+          name: "[deprecated] survey name omitted from public API - will be removed soon",
+        },
+      ],
       actionClasses: mockWorkspaceData.actionClasses,
     });
 
@@ -211,6 +219,7 @@ describe("getWorkspaceStateData", () => {
     const result = await getWorkspaceStateData(workspaceId);
 
     expect(result.workspace.workspaceSettings).toEqual({
+      id: workspaceId,
       recontactDays: 14,
       clickOutsideClose: false,
       overlay: "dark",

--- a/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.ts
@@ -42,6 +42,7 @@ export const getWorkspaceStateData = async (workspaceId: string): Promise<Worksp
       where: { id: workspaceId },
       select: {
         id: true,
+        legacyEnvironmentId: true,
         appSetupCompleted: true,
         recontactDays: true,
         clickOutsideClose: true,
@@ -72,7 +73,9 @@ export const getWorkspaceStateData = async (workspaceId: string): Promise<Worksp
           select: {
             id: true,
             welcomeCard: true,
-            // name intentionally omitted — internal label not needed by the SDK
+            // `name` deliberately not selected — internal label not needed by the
+            // SDK and replaced with a fixed placeholder below so older SDKs that
+            // decoded `Survey.name` as a required field keep working.
             questions: true,
             blocks: true,
             variables: true,
@@ -99,9 +102,9 @@ export const getWorkspaceStateData = async (workspaceId: string): Promise<Worksp
             styling: true,
             status: true,
             recaptcha: true,
-            // Fetch only what's needed to compute the minimal segment shape.
-            // Titles, descriptions, and filter conditions are evaluated server-side
-            // and must not be sent to the browser.
+            // Only need to know if any filters exist so we can compute
+            // `hasFilters`. Real filter values, segment title/description, and
+            // surveys-list relation are never exposed to clients.
             segment: {
               select: {
                 id: true,
@@ -135,17 +138,46 @@ export const getWorkspaceStateData = async (workspaceId: string): Promise<Worksp
       throw new ResourceNotFoundError("workspace", workspaceId);
     }
 
-    // Transform surveys using the shared utility, then replace the segment with
-    // the minimal public shape (id + hasFilters). We null out segment before
-    // calling transformPrismaSurvey because that function expects a surveys[]
-    // relation on the segment object (used by the management API), which we
-    // intentionally don't fetch here.
+    // Backwards-compat response shape for SDKs from before PR #7931. Those
+    // clients decoded `survey.name` and the full `segment` object as required
+    // fields, so the response must still carry that shape — but every field
+    // that could leak sensitive targeting data is replaced with a placeholder.
+    // The actual segment-membership check happens server-side (segment IDs in
+    // POST /user); SDKs only inspect `filters.length` / `hasFilters` locally.
+    //
+    // `environmentId` mirrors `legacyEnvironmentId ?? workspace.id`, matching
+    // the `/me` endpoints' pattern so migrated workspaces keep returning the
+    // original env ID older clients persisted.
+    const legacyOrCurrentId = workspaceData.legacyEnvironmentId ?? workspaceData.id;
+    const placeholderDate = new Date(0);
+    const placeholderFilter = {
+      id: "placeholder",
+      connector: null,
+      resource: {
+        id: "placeholder",
+        root: { type: "device", deviceType: "phone" },
+        value: "deprecated",
+        qualifier: { operator: "equals" },
+      },
+    };
+
     const transformedSurveys = workspaceData.surveys.map((survey) => {
-      const minimalSegment = survey.segment
+      const realHasFilters =
+        Array.isArray(survey.segment?.filters) && (survey.segment.filters as unknown[]).length > 0;
+
+      const sanitizedSegment = survey.segment
         ? {
             id: survey.segment.id,
-            hasFilters:
-              Array.isArray(survey.segment.filters) && (survey.segment.filters as unknown[]).length > 0,
+            title: "[deprecated] segment title omitted from public API - will be removed soon",
+            description: null,
+            isPrivate: true,
+            filters: realHasFilters ? [placeholderFilter] : [],
+            environmentId: legacyOrCurrentId,
+            workspaceId: legacyOrCurrentId,
+            createdAt: placeholderDate,
+            updatedAt: placeholderDate,
+            surveys: [],
+            hasFilters: realHasFilters,
           }
         : null;
 
@@ -155,7 +187,11 @@ export const getWorkspaceStateData = async (workspaceId: string): Promise<Worksp
         segment: null,
       });
 
-      return { ...transformed, segment: minimalSegment };
+      return {
+        ...transformed,
+        name: "[deprecated] survey name omitted from public API - will be removed soon",
+        segment: sanitizedSegment,
+      };
     });
 
     return {
@@ -163,6 +199,7 @@ export const getWorkspaceStateData = async (workspaceId: string): Promise<Worksp
         id: workspaceData.id,
         appSetupCompleted: workspaceData.appSetupCompleted,
         workspaceSettings: {
+          id: workspaceData.id,
           recontactDays: workspaceData.recontactDays,
           clickOutsideClose: workspaceData.clickOutsideClose,
           overlay: workspaceData.overlay,
@@ -171,7 +208,11 @@ export const getWorkspaceStateData = async (workspaceId: string): Promise<Worksp
           styling: resolveStorageUrlsInObject(workspaceData.styling),
         },
       },
-      surveys: resolveStorageUrlsInObject(transformedSurveys),
+      // The runtime shape carries extra back-compat fields (placeholder
+      // segment, `hasFilters`, mirrored `environmentId`) that aren't part of
+      // the modern `TJsWorkspaceStateSurvey`. Cast through unknown — this is
+      // intentional and only this endpoint's response widens the type.
+      surveys: resolveStorageUrlsInObject(transformedSurveys) as unknown as TJsWorkspaceStateSurvey[],
       actionClasses: workspaceData.actionClasses,
     };
   } catch (error) {

--- a/packages/types/js.ts
+++ b/packages/types/js.ts
@@ -1,14 +1,13 @@
 import { z } from "zod";
 import { ZActionClass } from "./action-classes";
 import { ZId } from "./common";
-import { ZJsWorkspaceStateSegment } from "./segment";
 import { ZUploadFileConfig } from "./storage";
 import { ZSurveyBase, surveyRefinement } from "./surveys/types";
 import { ZWorkspace } from "./workspace";
 
 export const ZJsWorkspaceStateSurvey = ZSurveyBase.pick({
   id: true,
-  // name intentionally omitted — internal label, not needed by SDK
+  name: true,
   welcomeCard: true,
   questions: true,
   blocks: true,
@@ -20,7 +19,7 @@ export const ZJsWorkspaceStateSurvey = ZSurveyBase.pick({
   autoClose: true,
   styling: true,
   status: true,
-  // segment intentionally omitted from pick — replaced with minimal shape below
+  segment: true,
   recontactDays: true,
   displayLimit: true,
   displayOption: true,
@@ -32,16 +31,9 @@ export const ZJsWorkspaceStateSurvey = ZSurveyBase.pick({
   isBackButtonHidden: true,
   isAutoProgressingEnabled: true,
   recaptcha: true,
-})
-  .extend({
-    // Only expose what the SDK needs: segment ID for membership check + whether any filters exist.
-    // Full filter logic (titles, descriptions, conditions) is evaluated server-side and must not
-    // be sent to the browser to avoid leaking sensitive targeting data.
-    segment: ZJsWorkspaceStateSegment.nullable(),
-  })
-  .superRefine((survey, ctx) => {
-    surveyRefinement(survey as z.infer<typeof ZSurveyBase>, ctx);
-  });
+}).superRefine((survey, ctx) => {
+  surveyRefinement(survey as z.infer<typeof ZSurveyBase>, ctx);
+});
 
 export type TJsWorkspaceStateSurvey = z.infer<typeof ZJsWorkspaceStateSurvey>;
 
@@ -56,6 +48,7 @@ export const ZJsWorkspaceStateActionClass = ZActionClass.pick({
 export type TJsWorkspaceStateActionClass = z.infer<typeof ZJsWorkspaceStateActionClass>;
 
 export const ZJsWorkspaceStateWorkspaceSetting = ZWorkspace.pick({
+  id: true,
   recontactDays: true,
   clickOutsideClose: true,
   overlay: true,


### PR DESCRIPTION
## What does this PR do?

  Restores the response shape of `GET /api/v{1,2}/client/{workspaceId}/environment` so SDKs released before #7931 (which decoded `survey.name` and the full `segment` object as required fields) keep working, while still withholding every piece of sensitive targeting data that PR #7931 was added to strip.

  Background: the strip in #7931 broke any client that decoded the response with a strict schema — notably the iOS SDK on
  `release/1.2`, which fails `Codable` decoding on missing `survey.name` and missing `segment.{title,filters,environmentId,…}`.
  Those binaries are already in the wild, and neither the iOS SDK nor the JS SDK sends an identifying header, so the server can't route old vs. new traffic by User-Agent.

  Approach: keep the response shape that old SDKs expect, but populate the sensitive fields with placeholders. The data still never leaves the server:
  - `survey.name` is no longer selected from the DB and is replaced with a fixed placeholder string.
  - `segment.{title, description, createdAt, updatedAt, surveys}` are placeholders.
  - `segment.filters` is `[]` when the survey has no targeting, or a single dummy primitive-device filter when targeting is enabled
   — enough for old SDKs to decode and for `surveyHasSegmentFilters` to return `true`. Real filter contents are never read from the
   DB.
  - `segment.environmentId` mirrors `legacyEnvironmentId ?? workspace.id`, matching the same back-compat pattern used by
  `/api/v1/management/me` and `/api/v2/me`.
  - `segment.hasFilters` is still set so modern SDKs hit the fast path without falling back to `filters.length`.

  Verified that no SDK evaluates filter contents on the device — segment membership is computed server-side and returned via `POST
  /user`. SDKs only inspect `filters.length` / `hasFilters`:
  - `release/1.2` iOS — `SurveyManager.swift`, only reads `segment.id` and `segment.filters.isEmpty`.
  - `main` iOS — `Segment.swift` decoder reads `hasFilters` (or derives from `filters.length` for cached payloads).
  - JS — `packages/js-core/src/lib/common/utils.ts#surveyHasSegmentFilters` handles both shapes.  

## How should this be tested?

  - Run the backend locally against a workspace that has at least one app survey, both with and without segment targeting.
  - Hit `GET /api/v2/client/{workspaceIdOrLegacyEnvironmentId}/environment` directly with `curl | jq` and confirm:
    - `data.surveys[].name` is the placeholder string, not the real survey name.
    - For a survey with targeting: `data.surveys[].segment.filters` has exactly one entry, `hasFilters` is `true`, and
  `title`/`description` are the placeholder values.
    - For a survey without targeting: `data.surveys[].segment.filters` is `[]` and `hasFilters` is `false`.
    - `data.surveys[].segment.environmentId` equals `workspace.legacyEnvironmentId` for migrated workspaces, otherwise
  `workspace.id`.
  - Point the **old** iOS SDK (`formbricks/ios` `release/1.2`) at the local backend, run `Formbricks.setup`, and confirm:
    - The environment decode succeeds (previously failed with `keyNotFound("environmentId")` on segment).
    - A survey with `displayOption: "displayMultiple"` is correctly shown once and filtered out after a response is submitted.
  - Point the **new** iOS SDK (`formbricks/ios` `main`) at the local backend and confirm the same flows work end-to-end — `Segment`
   decoder reads `hasFilters` from the response.
  - Run the JS SDK against the local backend and verify `surveyHasSegmentFilters` returns the right boolean for both targeting and
  non-targeting surveys.
  - Confirm typecheck and existing tests still pass: `npx tsc -p apps/web/tsconfig.json --noEmit`, `pnpm --filter @formbricks/web
  lint`, `pnpm --filter @formbricks/js-core test`.

  ## Checklist

  ### Required

  - [x] Filled out the "How to test" section in this PR
  - [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
  - [x] Self-reviewed my own code
  - [x] Commented on my code in hard-to-understand bits
  - [x] Ran `pnpm build`
  - [x] Checked for warnings, there are none
  - [x] Removed all `console.logs`
  - [x] Merged the latest changes from main onto my branch with `git pull origin main`
  - [x] My changes don't cause any responsiveness issues
  - [x] First PR at Formbricks? Please sign the CLA — N/A

  ### Appreciated

  - [ ] If a UI change was made: N/A (API-only change)
  - [ ] Updated the Formbricks Docs if changes were necessary — N/A