### PR TITLE
fix: wire Cube API secret into Helm defaults

### DIFF
--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -55,7 +55,8 @@ Cube is part of the baseline Formbricks v5 stack and is deployed by this chart b
   when using the default release name.
 - For an external Cube, set `cube.enabled: false` and point `deployment.env.CUBEJS_API_URL` at your
   endpoint.
-- Provide `CUBEJS_API_SECRET` through your existing secret management flow, such as the generated app secret override or `deployment.envFrom`.
+- The generated app secret supplies `CUBEJS_API_SECRET` by default. If you disable generated secrets,
+  provide it through your existing secret management flow.
 - Provide `CUBEJS_DB_*` connection variables to the Cube deployment through `cube.envFrom` or `cube.env`.
 - Keep `cube.replicas=1` while `cube.env.CUBEJS_CACHE_AND_QUEUE_DRIVER` is `memory`. Configure Cube Store before running multiple Cube replicas.
 - Keep Hub enabled. Cube should point at the same feedback records database that Hub writes to, unless you intentionally split that storage.

--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -289,6 +289,15 @@ true
     {{- randAlphaNum 32 -}}
 {{- end -}}
 {{- end }}
+
+{{- define "formbricks.cubejsApiSecret" -}}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "formbricks.appSecretName" .)) }}
+{{- if and $secret (index $secret.data "CUBEJS_API_SECRET") }}
+    {{- index $secret.data "CUBEJS_API_SECRET" | b64dec -}}
+{{- else }}
+    {{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end }}
 {{- define "formbricks.envoy.gatewayClassName" -}}
 {{- if .Values.envoy.formbricks.gatewayClass.name -}}
 {{- .Values.envoy.formbricks.gatewayClass.name | trunc 63 | trimSuffix "-" -}}

--- a/charts/formbricks/templates/cube-deployment.yaml
+++ b/charts/formbricks/templates/cube-deployment.yaml
@@ -70,8 +70,12 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.cube.envFrom }}
+          {{- if or .Values.cube.envFrom (or (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) .Values.secret.enabled) }}
           envFrom:
+            {{- if or .Values.secret.enabled (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) }}
+            - secretRef:
+                name: {{ template "formbricks.name" . }}-app-secrets
+            {{- end }}
             {{- range $value := .Values.cube.envFrom }}
             {{- if (eq .type "configmap") }}
             - configMapRef:

--- a/charts/formbricks/templates/secrets.yaml
+++ b/charts/formbricks/templates/secrets.yaml
@@ -5,6 +5,7 @@
 {{- $redisPassword := include "formbricks.redisPassword" . }}
 {{- $webappUrl := required "formbricks.webappUrl is required. Set it to your Formbricks instance URL (e.g., https://formbricks.example.com)" .Values.formbricks.webappUrl }}
 {{- $hubApiKey := include "formbricks.hubApiKey" . }}
+{{- $cubejsApiSecret := include "formbricks.cubejsApiSecret" . }}
 ---
 apiVersion: v1
 kind: Secret
@@ -31,6 +32,7 @@ data:
   {{- end }}
   HUB_API_KEY: {{ $hubApiKey | b64enc }}
   credential: {{ printf "Bearer %s" $hubApiKey | b64enc }}
+  CUBEJS_API_SECRET: {{ $cubejsApiSecret | b64enc }}
   CRON_SECRET: {{ include "formbricks.cronSecret" . | b64enc }}
   ENCRYPTION_KEY: {{ include "formbricks.encryptionKey" . | b64enc }}
   NEXTAUTH_SECRET: {{ include "formbricks.nextAuthSecret" . | b64enc }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -580,8 +580,9 @@ cube:
     type: ClusterIP
     port: 4000
 
-  # Secret values such as CUBEJS_API_SECRET and CUBEJS_DB_* should be supplied
-  # through envFrom or another secret-management flow.
+  # The generated app secret supplies CUBEJS_API_SECRET when secret.enabled=true.
+  # Secret values such as CUBEJS_DB_* should be supplied through envFrom or another secret-management
+  # flow.
   envFrom: []
 
   env:

--- a/docs/self-hosting/setup/kubernetes.mdx
+++ b/docs/self-hosting/setup/kubernetes.mdx
@@ -116,7 +116,8 @@ Cube is part of the baseline Formbricks v5 stack and is bundled with the chart b
 
 - set `cube.enabled: false` to skip the bundled Cube deployment
 - point the app at your external endpoint via `deployment.env.CUBEJS_API_URL`
-- supply `CUBEJS_API_SECRET` via `deployment.env` or `deployment.envFrom`
+- supply `CUBEJS_API_SECRET` via `deployment.env` or `deployment.envFrom` if you disable generated
+  secrets
 
 ## 4. Upgrade The Deployment
 
@@ -134,8 +135,8 @@ For a Formbricks 4.x to 5.0 migration, confirm the following before running the 
 - `HUB_API_KEY` is present
 - your edge rate-limiting plan is in place
 - any required `AI_*` variables are added
-- `CUBEJS_API_SECRET` is configured (Cube is bundled by default; provide an external endpoint if you set
-  `cube.enabled: false`)
+- `CUBEJS_API_SECRET` is configured (the generated app secret supplies it by default; provide an external
+  endpoint if you set `cube.enabled: false`)
 
 ## 5. Key Values
 


### PR DESCRIPTION
Fixes: ENG-1020

## What changed

- Generate `CUBEJS_API_SECRET` in the Helm-managed `formbricks-app-secrets` Secret.
- Preserve an existing `CUBEJS_API_SECRET` on upgrades via Helm `lookup`.
- Mount the generated/external app secret into the bundled Cube deployment by default.
- Update chart and Kubernetes docs to reflect the generated-secret behavior.

## Why

ENG-1020 found that fresh Helm installs using `secret.enabled=true` generated app secrets for the web app and Hub, but did not include the Cube signing secret. Staging worked because it uses an ExternalSecret-backed `formbricks-app-secrets`; default self-host installs could miss this value unless operators manually supplied it.

## Validation

- `helm lint charts/formbricks --set formbricks.webappUrl=https://qa.example.com`
- `helm template qa charts/formbricks --set formbricks.webappUrl=https://qa.example.com > /tmp/formbricks-default-cube-secret.yaml && kubectl apply --dry-run=client --validate=false -f /tmp/formbricks-default-cube-secret.yaml`
- `helm template qa charts/formbricks --set formbricks.webappUrl=https://qa.example.com --set secret.enabled=false --set externalSecret.enabled=true --set externalSecret.files.app-secrets.data.CUBEJS_API_SECRET.remoteRef.key=formbricks/app --set externalSecret.files.app-secrets.data.CUBEJS_API_SECRET.remoteRef.property=CUBEJS_API_SECRET > /tmp/formbricks-external-secret-cube.yaml && kubectl apply --dry-run=client --validate=false -f /tmp/formbricks-external-secret-cube.yaml`

Linear: ENG-1020