### PR TITLE
fix: harden Helm env value rendering

### DIFF
--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -92,6 +92,26 @@ This function allows rendering values dynamically.
     {{- end }}
 {{- end }}
 
+{{/*
+Render a Kubernetes EnvVar from chart env maps.
+Scalar values become quoted string values. Map values are rendered as EnvVar fields,
+which keeps advanced forms such as valueFrom supported.
+*/}}
+{{- define "formbricks.envVarValue" -}}
+{{- $value := .value -}}
+{{- if kindIs "map" $value -}}
+{{- include "formbricks.tplvalues.render" (dict "value" $value "context" .context) -}}
+{{- else if kindIs "invalid" $value -}}
+value: ""
+{{- else -}}
+value: {{ include "formbricks.tplvalues.render" (dict "value" (toString $value) "context" .context) | trim | quote }}
+{{- end -}}
+{{- end }}
+
+{{- define "formbricks.envVar" -}}
+- name: {{ include "formbricks.tplvalues.render" (dict "value" .name "context" .context) }}
+  {{- include "formbricks.envVarValue" (dict "value" .value "context" .context) | nindent 2 }}
+{{- end }}
 
 {{/*
 Allow the release namespace to be overridden.

--- a/charts/formbricks/templates/cube-deployment.yaml
+++ b/charts/formbricks/templates/cube-deployment.yaml
@@ -97,12 +97,7 @@ spec:
           {{- end }}
           env:
             {{- range $key, $value := .Values.cube.env }}
-            - name: {{ include "formbricks.tplvalues.render" ( dict "value" $key "context" $ ) }}
-              {{- if kindIs "string" $value }}
-              value: {{ include "formbricks.tplvalues.render" ( dict "value" $value "context" $ ) | quote }}
-              {{- else }}
-              {{- toYaml $value | nindent 14 }}
-              {{- end }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
           volumeMounts:
             - name: cube-config

--- a/charts/formbricks/templates/deployment.yaml
+++ b/charts/formbricks/templates/deployment.yaml
@@ -136,12 +136,7 @@ spec:
               value: "http://{{ include "formbricks.hubname" . }}:8080"
             {{- end }}
             {{- range $key, $value := .Values.deployment.env }}
-            - name: {{ include "formbricks.tplvalues.render" ( dict "value" $key "context" $ ) }}
-              {{- if kindIs "string" $value }}
-              value: {{ include "formbricks.tplvalues.render" ( dict "value" $value "context" $ ) | quote }}
-              {{- else }}
-              {{- toYaml $value | nindent 14 }}
-              {{- end }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
           {{- if .Values.deployment.resources }}
           resources:

--- a/charts/formbricks/templates/hub-deployment.yaml
+++ b/charts/formbricks/templates/hub-deployment.yaml
@@ -73,8 +73,7 @@ spec:
             {{- include "formbricks.hubEmbeddingEnv" (dict "root" $ "env" .Values.hub.env) | nindent 12 }}
             {{- range $key, $value := .Values.hub.env }}
             {{- if not (and $.Values.hub.embeddings.enabled (include "formbricks.hubEmbeddingEnvManaged" (dict "key" $key))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
             {{- end }}
           {{- if .Values.hub.resources }}

--- a/charts/formbricks/templates/hub-embeddings-deployment.yaml
+++ b/charts/formbricks/templates/hub-embeddings-deployment.yaml
@@ -129,8 +129,7 @@ spec:
             {{- end }}
             {{- range $key, $value := .Values.hub.embeddings.env }}
             {{- if not (or (and $.Values.hub.embeddings.auth.enabled (eq $key "API_KEY")) (and (or $.Values.hub.embeddings.huggingFace.existingSecret $.Values.hub.embeddings.huggingFace.token) (eq $key "HF_TOKEN"))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
             {{- end }}
           {{- end }}

--- a/charts/formbricks/templates/hub-worker-deployment.yaml
+++ b/charts/formbricks/templates/hub-worker-deployment.yaml
@@ -90,14 +90,12 @@ spec:
             {{- include "formbricks.hubEmbeddingEnv" (dict "root" $ "env" $workerEnv) | nindent 12 }}
             {{- range $key, $value := .Values.hub.env }}
             {{- if and (not (hasKey $.Values.hub.worker.env $key)) (not (and $.Values.hub.embeddings.enabled (include "formbricks.hubEmbeddingEnvManaged" (dict "key" $key)))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
             {{- end }}
             {{- range $key, $value := .Values.hub.worker.env }}
             {{- if not (and $.Values.hub.embeddings.enabled (include "formbricks.hubEmbeddingEnvManaged" (dict "key" $key))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
             {{- end }}
           {{- end }}

--- a/charts/formbricks/templates/migration-job.yaml
+++ b/charts/formbricks/templates/migration-job.yaml
@@ -82,12 +82,7 @@ spec:
           {{- end }}
           env:
             {{- range $key, $value := .Values.deployment.env }}
-            - name: {{ include "formbricks.tplvalues.render" ( dict "value" $key "context" $ ) }}
-              {{- if kindIs "string" $value }}
-              value: {{ include "formbricks.tplvalues.render" ( dict "value" $value "context" $ ) | quote }}
-              {{- else }}
-              {{- toYaml $value | nindent 14 }}
-              {{- end }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
           {{- if .Values.migration.resources }}
           resources:


### PR DESCRIPTION
Fixes: ENG-1021

## What
- Add a shared Helm helper for rendering Kubernetes `env` entries from chart env maps.
- Quote scalar env values after template rendering so numeric and boolean overrides render as strings.
- Preserve map-style env entries such as `valueFrom` for advanced secret/config references across web, migration, Cube, Hub, worker, and embeddings templates.

## Why
ENG-1021 found that scalar values supplied through Helm `--set`, for example `deployment.env.S3_FORCE_PATH_STYLE=1`, rendered as numeric YAML values. Kubernetes EnvVar `value` fields require strings, so those manifests fail validation.

## Validation
- `helm lint charts/formbricks --set formbricks.webappUrl=https://qa.example.com`
- `helm template qa charts/formbricks --set formbricks.webappUrl=https://qa.example.com --set deployment.env.S3_FORCE_PATH_STYLE=1 --show-only templates/deployment.yaml`
- `helm template qa charts/formbricks --set formbricks.webappUrl=https://qa.example.com --set deployment.env.S3_FORCE_PATH_STYLE=1 --set deployment.env.FEATURE_FLAG=true --set 'deployment.env.SECRET_TOKEN.valueFrom.secretKeyRef.name=my-secret' --set 'deployment.env.SECRET_TOKEN.valueFrom.secretKeyRef.key=token' --show-only templates/deployment.yaml`
- `helm template qa charts/formbricks --set formbricks.webappUrl=https://qa.example.com --set cube.env.CUBE_NUMERIC=1 --set hub.env.HUB_NUMERIC=2 --set hub.worker.env.WORKER_FLAG=false --set hub.embeddings.enabled=true --set hub.embeddings.env.TEI_NUMERIC=3 > /tmp/formbricks-env-scalars.yaml && kubectl apply --dry-run=client --validate=false -f /tmp/formbricks-env-scalars.yaml`

Refs ENG-1021.