### PR TITLE
fix: gate AI chart generation on smartTools, not dataAnalysis (backport #8060)

### DIFF
--- a/apps/web/lib/ai/service.test.ts
+++ b/apps/web/lib/ai/service.test.ts
@@ -4,6 +4,7 @@ import {
   assertOrganizationAIConfigured,
   generateOrganizationAIText,
   getAIDataAnalysisUnavailableReason,
+  getAISmartToolsUnavailableReason,
   getOrganizationAIConfig,
   isInstanceAIConfigured,
 } from "./service";
@@ -205,6 +206,49 @@ describe("AI organization service", () => {
       expect(getAIDataAnalysisUnavailableReason({ ...baseConfig, isInstanceConfigured: false })).toBe(
         "instance_not_configured"
       );
+    });
+  });
+
+  describe("getAISmartToolsUnavailableReason", () => {
+    const baseConfig = {
+      organizationId: "org_1",
+      isAISmartToolsEntitled: true,
+      isAISmartToolsEnabled: true,
+      isAIDataAnalysisEntitled: true,
+      isAIDataAnalysisEnabled: true,
+      isInstanceConfigured: true,
+    };
+
+    test("returns undefined when all checks pass", () => {
+      expect(getAISmartToolsUnavailableReason(baseConfig)).toBeUndefined();
+    });
+
+    test("returns not_in_plan when smart tools entitlement is missing", () => {
+      expect(getAISmartToolsUnavailableReason({ ...baseConfig, isAISmartToolsEntitled: false })).toBe(
+        "not_in_plan"
+      );
+    });
+
+    test("returns not_enabled when smart tools is disabled at org level", () => {
+      expect(getAISmartToolsUnavailableReason({ ...baseConfig, isAISmartToolsEnabled: false })).toBe(
+        "not_enabled"
+      );
+    });
+
+    test("returns instance_not_configured when instance AI is missing", () => {
+      expect(getAISmartToolsUnavailableReason({ ...baseConfig, isInstanceConfigured: false })).toBe(
+        "instance_not_configured"
+      );
+    });
+
+    test("ignores data-analysis flags (smart tools is independent of data analysis state)", () => {
+      expect(
+        getAISmartToolsUnavailableReason({
+          ...baseConfig,
+          isAIDataAnalysisEntitled: false,
+          isAIDataAnalysisEnabled: false,
+        })
+      ).toBeUndefined();
     });
   });
 });

--- a/apps/web/lib/ai/service.ts
+++ b/apps/web/lib/ai/service.ts
@@ -59,6 +59,15 @@ export const getAIDataAnalysisUnavailableReason = (
   return undefined;
 };
 
+export const getAISmartToolsUnavailableReason = (
+  aiConfig: TOrganizationAIConfig
+): TAIUnavailableReason | undefined => {
+  if (!aiConfig.isAISmartToolsEntitled) return "not_in_plan";
+  if (!aiConfig.isAISmartToolsEnabled) return "not_enabled";
+  if (!aiConfig.isInstanceConfigured) return "instance_not_configured";
+  return undefined;
+};
+
 export const assertOrganizationAIConfigured = async (
   organizationId: string,
   capability: "smartTools" | "dataAnalysis"

--- a/apps/web/modules/ee/analysis/charts/actions.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.ts
@@ -363,8 +363,10 @@ export const generateAIChartAction = authenticatedActionClient
 
       await checkDashboardsEnabled(organizationId);
 
-      // Verify AI is entitled, enabled at org level, and configured at instance level
-      await assertOrganizationAIConfigured(organizationId, "dataAnalysis");
+      // Verify AI is entitled, enabled at org level, and configured at instance level.
+      // Uses "smartTools" (not "dataAnalysis") because chart generation only sends the
+      // Cube schema context and the user's prompt to the LLM — no response PII.
+      await assertOrganizationAIConfigured(organizationId, "smartTools");
 
       const { feedbackDirectoryId } = await checkFeedbackDirectoryAccess({
         feedbackDirectoryId: parsedInput.feedbackDirectoryId,

--- a/apps/web/modules/ee/analysis/charts/components/charts-list-page.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/charts-list-page.tsx
@@ -1,5 +1,5 @@
 import { use } from "react";
-import { getAIDataAnalysisUnavailableReason, getOrganizationAIConfig } from "@/lib/ai/service";
+import { getAISmartToolsUnavailableReason, getOrganizationAIConfig } from "@/lib/ai/service";
 import { getConnectorsWithMappings } from "@/lib/connector/service";
 import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
@@ -87,7 +87,7 @@ export async function ChartsListPage({ workspaceId }: Readonly<ChartsListPagePro
     getConnectorsWithMappings(workspaceId),
     getOrganizationAIConfig(organization.id),
   ]);
-  const aiUnavailableReason = getAIDataAnalysisUnavailableReason(aiConfig);
+  const aiUnavailableReason = getAISmartToolsUnavailableReason(aiConfig);
   const isAIAvailable = !aiUnavailableReason;
   const hasFeedbackRecords = await hasFeedbackRecordsInDirectories(
     directories.map((directory) => directory.id)

--- a/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import { logger } from "@formbricks/logger";
 import type { TChartQuery } from "@formbricks/types/analysis";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
-import { getAIDataAnalysisUnavailableReason, getOrganizationAIConfig } from "@/lib/ai/service";
+import { getAISmartToolsUnavailableReason, getOrganizationAIConfig } from "@/lib/ai/service";
 import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
 import { executeTenantScopedQuery } from "@/modules/ee/analysis/api/lib/cube-client";
@@ -99,7 +99,7 @@ export async function DashboardDetailPage({
     getFeedbackDirectoriesByWorkspaceId(workspaceId),
     getOrganizationAIConfig(organization.id),
   ]);
-  const aiUnavailableReason = getAIDataAnalysisUnavailableReason(aiConfig);
+  const aiUnavailableReason = getAISmartToolsUnavailableReason(aiConfig);
   const isAIAvailable = !aiUnavailableReason;
 
   let dashboard;


### PR DESCRIPTION
Backport of #8060 to `release/5.0`.

Cherry-picked 0bef02330205632316895180230745196559f91c cleanly.

Refs ENG-1001.