### PR TITLE
fix: render scheduled-plan-change description placeholders correctly (backport #8064)

### DIFF
--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -2429,7 +2429,7 @@
         "most_popular": "Самый популярный",
         "pending_change_removed": "Запланированное изменение тарифа отменено.",
         "pending_plan_badge": "Запланирован",
-        "pending_plan_change_description": "Твой тариф сменится на {plan} {date}.",
+        "pending_plan_change_description": "Твой тариф сменится на {plan} на {date}.",
         "pending_plan_change_title": "Запланированное изменение тарифа",
         "pending_plan_cta": "Запланирован",
         "per_month": "в месяц",

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -436,17 +436,15 @@ export const PricingTable = ({
           <Alert variant="info" className="max-w-4xl">
             <AlertTitle>{t("workspace.settings.billing.pending_plan_change_title")}</AlertTitle>
             <AlertDescription>
-              {t("workspace.settings.billing.pending_plan_change_description")
-                .replace("{{plan}}", getCurrentCloudPlanLabel(pendingChange.targetPlan, t))
-                .replace(
-                  "{{date}}",
-                  formatDateForDisplay(new Date(pendingChange.effectiveAt), locale, {
-                    year: "numeric",
-                    month: "short",
-                    day: "numeric",
-                    timeZone: "UTC",
-                  })
-                )}
+              {t("workspace.settings.billing.pending_plan_change_description", {
+                plan: getCurrentCloudPlanLabel(pendingChange.targetPlan, t),
+                date: formatDateForDisplay(new Date(pendingChange.effectiveAt), locale, {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                  timeZone: "UTC",
+                }),
+              })}
             </AlertDescription>
             {hasBillingRights && (
               <AlertButton onClick={() => void undoPendingChange()} loading={isPlanActionPending === "undo"}>


### PR DESCRIPTION
Backport of #8064 to `release/5.0`.

Cherry-picked 032066194b9b68e2d2091c9204159d8907732b0b cleanly.