### PR TITLE
fix: harden Helm env value rendering (backport #8070)

### DIFF
--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -92,6 +92,26 @@ This function allows rendering values dynamically.
     {{- end }}
 {{- end }}
 
+{{/*
+Render a Kubernetes EnvVar from chart env maps.
+Scalar values become quoted string values. Map values are rendered as EnvVar fields,
+which keeps advanced forms such as valueFrom supported.
+*/}}
+{{- define "formbricks.envVarValue" -}}
+{{- $value := .value -}}
+{{- if kindIs "map" $value -}}
+{{- include "formbricks.tplvalues.render" (dict "value" $value "context" .context) -}}
+{{- else if kindIs "invalid" $value -}}
+value: ""
+{{- else -}}
+value: {{ include "formbricks.tplvalues.render" (dict "value" (toString $value) "context" .context) | trim | quote }}
+{{- end -}}
+{{- end }}
+
+{{- define "formbricks.envVar" -}}
+- name: {{ include "formbricks.tplvalues.render" (dict "value" .name "context" .context) }}
+  {{- include "formbricks.envVarValue" (dict "value" .value "context" .context) | nindent 2 }}
+{{- end }}
 
 {{/*
 Allow the release namespace to be overridden.

--- a/charts/formbricks/templates/cube-deployment.yaml
+++ b/charts/formbricks/templates/cube-deployment.yaml
@@ -97,12 +97,7 @@ spec:
           {{- end }}
           env:
             {{- range $key, $value := .Values.cube.env }}
-            - name: {{ include "formbricks.tplvalues.render" ( dict "value" $key "context" $ ) }}
-              {{- if kindIs "string" $value }}
-              value: {{ include "formbricks.tplvalues.render" ( dict "value" $value "context" $ ) | quote }}
-              {{- else }}
-              {{- toYaml $value | nindent 14 }}
-              {{- end }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
           volumeMounts:
             - name: cube-config

--- a/charts/formbricks/templates/deployment.yaml
+++ b/charts/formbricks/templates/deployment.yaml
@@ -136,12 +136,7 @@ spec:
               value: "http://{{ include "formbricks.hubname" . }}:8080"
             {{- end }}
             {{- range $key, $value := .Values.deployment.env }}
-            - name: {{ include "formbricks.tplvalues.render" ( dict "value" $key "context" $ ) }}
-              {{- if kindIs "string" $value }}
-              value: {{ include "formbricks.tplvalues.render" ( dict "value" $value "context" $ ) | quote }}
-              {{- else }}
-              {{- toYaml $value | nindent 14 }}
-              {{- end }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
           {{- if .Values.deployment.resources }}
           resources:

--- a/charts/formbricks/templates/hub-deployment.yaml
+++ b/charts/formbricks/templates/hub-deployment.yaml
@@ -73,8 +73,7 @@ spec:
             {{- include "formbricks.hubEmbeddingEnv" (dict "root" $ "env" .Values.hub.env) | nindent 12 }}
             {{- range $key, $value := .Values.hub.env }}
             {{- if not (and $.Values.hub.embeddings.enabled (include "formbricks.hubEmbeddingEnvManaged" (dict "key" $key))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
             {{- end }}
           {{- if .Values.hub.resources }}

--- a/charts/formbricks/templates/hub-embeddings-deployment.yaml
+++ b/charts/formbricks/templates/hub-embeddings-deployment.yaml
@@ -129,8 +129,7 @@ spec:
             {{- end }}
             {{- range $key, $value := .Values.hub.embeddings.env }}
             {{- if not (or (and $.Values.hub.embeddings.auth.enabled (eq $key "API_KEY")) (and (or $.Values.hub.embeddings.huggingFace.existingSecret $.Values.hub.embeddings.huggingFace.token) (eq $key "HF_TOKEN"))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
             {{- end }}
           {{- end }}

--- a/charts/formbricks/templates/hub-worker-deployment.yaml
+++ b/charts/formbricks/templates/hub-worker-deployment.yaml
@@ -90,14 +90,12 @@ spec:
             {{- include "formbricks.hubEmbeddingEnv" (dict "root" $ "env" $workerEnv) | nindent 12 }}
             {{- range $key, $value := .Values.hub.env }}
             {{- if and (not (hasKey $.Values.hub.worker.env $key)) (not (and $.Values.hub.embeddings.enabled (include "formbricks.hubEmbeddingEnvManaged" (dict "key" $key)))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
             {{- end }}
             {{- range $key, $value := .Values.hub.worker.env }}
             {{- if not (and $.Values.hub.embeddings.enabled (include "formbricks.hubEmbeddingEnvManaged" (dict "key" $key))) }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
             {{- end }}
           {{- end }}

--- a/charts/formbricks/templates/migration-job.yaml
+++ b/charts/formbricks/templates/migration-job.yaml
@@ -82,12 +82,7 @@ spec:
           {{- end }}
           env:
             {{- range $key, $value := .Values.deployment.env }}
-            - name: {{ include "formbricks.tplvalues.render" ( dict "value" $key "context" $ ) }}
-              {{- if kindIs "string" $value }}
-              value: {{ include "formbricks.tplvalues.render" ( dict "value" $value "context" $ ) | quote }}
-              {{- else }}
-              {{- toYaml $value | nindent 14 }}
-              {{- end }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
           {{- if .Values.migration.resources }}
           resources:


### PR DESCRIPTION
Backport of #8070 to `release/5.0`.

Cherry-picked 9266f6458865a05ca806ab3b6407c9911265b319 with auto-merge in `_helpers.tpl` and `cube-deployment.yaml`; no conflicts.

Refs ENG-1021.