### PR TITLE
fix: fixes responseId client api issue with legacy environmentId

### DIFF
--- a/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   getSurvey: vi.fn(),
   getValidatedResponseUpdateInput: vi.fn(),
   loggerError: vi.fn(),
+  resolveClientApiIds: vi.fn(),
   sendToPipeline: vi.fn(),
   updateResponseWithQuotaEvaluation: vi.fn(),
   validateFileUploads: vi.fn(),
@@ -32,6 +33,10 @@ vi.mock("@/lib/response/service", () => ({
 
 vi.mock("@/lib/survey/service", () => ({
   getSurvey: mocks.getSurvey,
+}));
+
+vi.mock("@/lib/utils/resolve-client-id", () => ({
+  resolveClientApiIds: mocks.resolveClientApiIds,
 }));
 
 vi.mock("@/modules/api/lib/validation", () => ({
@@ -123,6 +128,7 @@ describe("putResponseHandler", () => {
     });
     mocks.getResponse.mockResolvedValue(getBaseExistingResponse());
     mocks.getSurvey.mockResolvedValue(getBaseSurvey());
+    mocks.resolveClientApiIds.mockResolvedValue({ workspaceId });
     mocks.updateResponseWithQuotaEvaluation.mockResolvedValue(getBaseUpdatedResponse());
     mocks.validateFileUploads.mockReturnValue(true);
     mocks.validateOtherOptionLengthForMultipleChoice.mockReturnValue(null);
@@ -237,6 +243,34 @@ describe("putResponseHandler", () => {
       message: "Unknown error occurred",
       details: {},
     });
+  });
+
+  test("returns not found when the workspace id cannot be resolved", async () => {
+    mocks.resolveClientApiIds.mockResolvedValue(null);
+
+    const result = await putResponseHandler(createHandlerParams({ workspaceId: "unknown_workspace_or_env" }));
+
+    expect(result.response.status).toBe(404);
+    await expect(result.response.json()).resolves.toEqual({
+      code: "not_found",
+      message: "Workspace not found",
+      details: {
+        resource_id: "unknown_workspace_or_env",
+        resource_type: "Workspace",
+      },
+    });
+    expect(mocks.getResponse).not.toHaveBeenCalled();
+    expect(mocks.updateResponseWithQuotaEvaluation).not.toHaveBeenCalled();
+  });
+
+  test("accepts updates when the route param is a legacy environment id that resolves to the survey workspace", async () => {
+    mocks.resolveClientApiIds.mockResolvedValue({ workspaceId });
+
+    const result = await putResponseHandler(createHandlerParams({ workspaceId: "legacy_environment_id" }));
+
+    expect(mocks.resolveClientApiIds).toHaveBeenCalledWith("legacy_environment_id");
+    expect(result.response.status).toBe(200);
+    expect(mocks.updateResponseWithQuotaEvaluation).toHaveBeenCalledTimes(1);
   });
 
   test("rejects updates when the response survey does not belong to the requested workspace", async () => {

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.ts
@@ -8,6 +8,7 @@ import { THandlerParams } from "@/app/lib/api/with-api-logging";
 import { sendToPipeline } from "@/app/lib/pipelines";
 import { getResponse } from "@/lib/response/service";
 import { getSurvey } from "@/lib/survey/service";
+import { resolveClientApiIds } from "@/lib/utils/resolve-client-id";
 import { formatValidationErrorsForV1Api, validateResponseData } from "@/modules/api/lib/validation";
 import { validateOtherOptionLengthForMultipleChoice } from "@/modules/api/v2/lib/element";
 import { createQuotaFullObject } from "@/modules/ee/quotas/lib/helpers";
@@ -209,13 +210,21 @@ export const putResponseHandler = async ({
   props,
 }: THandlerParams<TPutRouteParams>): Promise<TRouteResult> => {
   const params = await props.params;
-  const { workspaceId, responseId } = params;
+  const { workspaceId: workspaceIdParam, responseId } = params;
 
   if (!responseId) {
     return {
       response: responses.badRequestResponse("Response ID is missing", undefined, true),
     };
   }
+
+  const resolved = await resolveClientApiIds(workspaceIdParam);
+  if (!resolved) {
+    return {
+      response: responses.notFoundResponse("Workspace", workspaceIdParam, true),
+    };
+  }
+  const { workspaceId } = resolved;
 
   const validatedUpdateInput = await getValidatedResponseUpdateInput(req);
   if ("response" in validatedUpdateInput) {


### PR DESCRIPTION
Fixes https://linear.app/formbricks/issue/ENG-980
the `responseId` client endpoint was throwing a 404 error when called with `environmentId` instead of `workspaceId`