### PR TITLE
fix: remount AI translation editor on value change, not disabled transition

### DIFF
--- a/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
@@ -26,17 +26,18 @@ export const RichTextTranslationInput = ({
 }: RichTextTranslationInputProps) => {
   const [firstRender, setFirstRender] = useState(true);
   const [editorKey, setEditorKey] = useState(0);
-  const prevDisabledRef = useRef(disabled);
+  // Tracks the most recent value the editor itself produced via setText, so we
+  // can tell external updates (e.g. AI translation fill) apart from the editor's
+  // own write-back and only remount for the former.
+  const lastWrittenRef = useRef(value);
 
-  // Remount the editor when AI translation finishes (disabled transitions from true → false)
-  // so the editor picks up the externally populated value.
   useEffect(() => {
-    if (prevDisabledRef.current && !disabled) {
+    if (value !== lastWrittenRef.current) {
+      lastWrittenRef.current = value;
       setEditorKey((k) => k + 1);
       setFirstRender(true);
     }
-    prevDisabledRef.current = disabled;
-  }, [disabled]);
+  }, [value]);
 
   return (
     <div className={disabled ? "cursor-not-allowed rounded-md opacity-60" : "rounded-md"}>
@@ -47,7 +48,10 @@ export const RichTextTranslationInput = ({
         firstRender={firstRender}
         setFirstRender={setFirstRender}
         getText={() => md.render(value)}
-        setText={(v: string) => onChange(path, v)}
+        setText={(v: string) => {
+          lastWrittenRef.current = v;
+          onChange(path, v);
+        }}
         localSurvey={localSurvey}
         elementId={elementId}
         selectedLanguageCode={languageCode}

--- a/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
@@ -26,14 +26,17 @@ export const RichTextTranslationInput = ({
 }: RichTextTranslationInputProps) => {
   const [firstRender, setFirstRender] = useState(true);
   const [editorKey, setEditorKey] = useState(0);
-  // Tracks the most recent value the editor itself produced via setText, so we
-  // can tell external updates (e.g. AI translation fill) apart from the editor's
-  // own write-back and only remount for the former.
+  // Separates external value changes (e.g. AI fill) from the editor's own write-back so we
+  // only remount for the former.
   const lastWrittenRef = useRef(value);
+  // Suppresses Lexical's mount-time empty listener fire which would otherwise clobber an
+  // externally-applied value back to "".
+  const initialContentSetRef = useRef(false);
 
   useEffect(() => {
     if (value !== lastWrittenRef.current) {
       lastWrittenRef.current = value;
+      initialContentSetRef.current = false;
       setEditorKey((k) => k + 1);
       setFirstRender(true);
     }
@@ -49,6 +52,8 @@ export const RichTextTranslationInput = ({
         setFirstRender={setFirstRender}
         getText={() => md.render(value)}
         setText={(v: string) => {
+          if (!initialContentSetRef.current && v === "") return;
+          initialContentSetRef.current = true;
           lastWrittenRef.current = v;
           onChange(path, v);
         }}


### PR DESCRIPTION
Fixes: ENG-1017
Linear: https://linear.app/formbricks/issue/ENG-1017/ai-translations-not-working

## Summary
AI translation in the Manage Translations modal populates plain-text fields but leaves rich-text editors empty on production builds (reproduces with `pnpm build && pnpm start`, doesn't show up under `pnpm dev`).

The rich-text editor is uncontrolled and only reads its value via `getText()` on mount. `RichTextTranslationInput` was relying on a `disabled` `true → false` transition to remount the Lexical editor and pick up the AI-filled value. Under React's production batching, the editor's own update listener can write an empty serialization back into `draftTranslations` before the remount applies the new value, so the field stays blank — and `isDraftEmpty` then reports it empty (which is why the progress bar showed 3/6 after AI ran).

This change drives the remount off the `value` prop instead, and uses a ref to ignore the re-renders caused by the editor's own write-back so we don't loop. A second commit then suppresses Lexical's mount-time empty listener fire (which would otherwise clobber the AI value back to "" right after the remount).

## Test plan
- [ ] `pnpm build && pnpm start` from `apps/web` (the dev server masks the bug via Strict Mode)
- [ ] Create a survey with at least one rich-text headline and an ending with a default headline + subheader
- [ ] Add a second language, open Manage Translations, click "Translate with AI"
- [ ] Verify all rich-text rows render the translated value and progress reaches N/N
- [ ] Verify typing in a rich-text row still saves (no remount loop)