### PR TITLE
fix: backport Cube API secret Helm defaults to 5.0

### DIFF
--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -55,7 +55,8 @@ Cube is part of the baseline Formbricks v5 stack and is deployed by this chart b
   when using the default release name.
 - For an external Cube, set `cube.enabled: false` and point `deployment.env.CUBEJS_API_URL` at your
   endpoint.
-- Provide `CUBEJS_API_SECRET` through your existing secret management flow, such as the generated app secret override or `deployment.envFrom`.
+- The generated app secret supplies `CUBEJS_API_SECRET` by default. If you disable generated secrets,
+  provide it through your existing secret management flow.
 - Provide `CUBEJS_DB_*` connection variables to the Cube deployment through `cube.envFrom` or `cube.env`.
 - Keep `cube.replicas=1` while `cube.env.CUBEJS_CACHE_AND_QUEUE_DRIVER` is `memory`. Configure Cube Store before running multiple Cube replicas.
 - Keep Hub enabled. Cube should point at the same feedback records database that Hub writes to, unless you intentionally split that storage.

--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -309,6 +309,15 @@ true
     {{- randAlphaNum 32 -}}
 {{- end -}}
 {{- end }}
+
+{{- define "formbricks.cubejsApiSecret" -}}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "formbricks.appSecretName" .)) }}
+{{- if and $secret (index $secret.data "CUBEJS_API_SECRET") }}
+    {{- index $secret.data "CUBEJS_API_SECRET" | b64dec -}}
+{{- else }}
+    {{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end }}
 {{- define "formbricks.envoy.gatewayClassName" -}}
 {{- if .Values.envoy.formbricks.gatewayClass.name -}}
 {{- .Values.envoy.formbricks.gatewayClass.name | trunc 63 | trimSuffix "-" -}}

--- a/charts/formbricks/templates/cube-deployment.yaml
+++ b/charts/formbricks/templates/cube-deployment.yaml
@@ -70,8 +70,12 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.cube.envFrom }}
+          {{- if or .Values.cube.envFrom (or (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) .Values.secret.enabled) }}
           envFrom:
+            {{- if or .Values.secret.enabled (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) }}
+            - secretRef:
+                name: {{ template "formbricks.name" . }}-app-secrets
+            {{- end }}
             {{- range $value := .Values.cube.envFrom }}
             {{- if (eq .type "configmap") }}
             - configMapRef:

--- a/charts/formbricks/templates/secrets.yaml
+++ b/charts/formbricks/templates/secrets.yaml
@@ -5,6 +5,7 @@
 {{- $redisPassword := include "formbricks.redisPassword" . }}
 {{- $webappUrl := required "formbricks.webappUrl is required. Set it to your Formbricks instance URL (e.g., https://formbricks.example.com)" .Values.formbricks.webappUrl }}
 {{- $hubApiKey := include "formbricks.hubApiKey" . }}
+{{- $cubejsApiSecret := include "formbricks.cubejsApiSecret" . }}
 ---
 apiVersion: v1
 kind: Secret
@@ -31,6 +32,7 @@ data:
   {{- end }}
   HUB_API_KEY: {{ $hubApiKey | b64enc }}
   credential: {{ printf "Bearer %s" $hubApiKey | b64enc }}
+  CUBEJS_API_SECRET: {{ $cubejsApiSecret | b64enc }}
   CRON_SECRET: {{ include "formbricks.cronSecret" . | b64enc }}
   ENCRYPTION_KEY: {{ include "formbricks.encryptionKey" . | b64enc }}
   NEXTAUTH_SECRET: {{ include "formbricks.nextAuthSecret" . | b64enc }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -580,8 +580,9 @@ cube:
     type: ClusterIP
     port: 4000
 
-  # Secret values such as CUBEJS_API_SECRET and CUBEJS_DB_* should be supplied
-  # through envFrom or another secret-management flow.
+  # The generated app secret supplies CUBEJS_API_SECRET when secret.enabled=true.
+  # Secret values such as CUBEJS_DB_* should be supplied through envFrom or another secret-management
+  # flow.
   envFrom: []
 
   env:

--- a/docs/self-hosting/setup/kubernetes.mdx
+++ b/docs/self-hosting/setup/kubernetes.mdx
@@ -116,7 +116,8 @@ Cube is part of the baseline Formbricks v5 stack and is bundled with the chart b
 
 - set `cube.enabled: false` to skip the bundled Cube deployment
 - point the app at your external endpoint via `deployment.env.CUBEJS_API_URL`
-- supply `CUBEJS_API_SECRET` via `deployment.env` or `deployment.envFrom`
+- supply `CUBEJS_API_SECRET` via `deployment.env` or `deployment.envFrom` if you disable generated
+  secrets
 
 ## 4. Upgrade The Deployment
 
@@ -134,8 +135,8 @@ For a Formbricks 4.x to 5.0 migration, confirm the following before running the 
 - `HUB_API_KEY` is present
 - your edge rate-limiting plan is in place
 - any required `AI_*` variables are added
-- `CUBEJS_API_SECRET` is configured (Cube is bundled by default; provide an external endpoint if you set
-  `cube.enabled: false`)
+- `CUBEJS_API_SECRET` is configured (the generated app secret supplies it by default; provide an external
+  endpoint if you set `cube.enabled: false`)
 
 ## 5. Key Values
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Backports #8068 to `release/5.0`.

Generates `CUBEJS_API_SECRET` in the Helm-managed `formbricks-app-secrets` Secret, preserves an existing value during upgrades, and wires the secret into the bundled Cube deployment by default.

Related: ENG-1020

## How should this be tested?

- [x] `helm lint charts/formbricks --set formbricks.webappUrl=https://qa.example.com`
- [x] `helm template qa charts/formbricks --set formbricks.webappUrl=https://qa.example.com > /tmp/formbricks-default-cube-secret.yaml`
- [x] `helm template qa charts/formbricks --set formbricks.webappUrl=https://qa.example.com --set secret.enabled=false --set externalSecret.enabled=true --set externalSecret.files.app-secrets.data.CUBEJS_API_SECRET.remoteRef.key=formbricks/app --set externalSecret.files.app-secrets.data.CUBEJS_API_SECRET.remoteRef.property=CUBEJS_API_SECRET > /tmp/formbricks-external-secret-cube.yaml`
- [x] Verified generated manifests include `CUBEJS_API_SECRET` and `formbricks-app-secrets` references for both default and ExternalSecret scenarios.
- [ ] `kubectl apply --dry-run=client --validate=false -f /tmp/formbricks-default-cube-secret.yaml` was attempted but blocked in this cloud environment because no Kubernetes API server is reachable for discovery (`localhost:8080` connection refused).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-611cd4ac-b0bd-4a0f-b585-6b88835c0d39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-611cd4ac-b0bd-4a0f-b585-6b88835c0d39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

