### PR TITLE
fix: backport billing-only settings access to 5.0

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/SettingsSidebarContent.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/SettingsSidebarContent.tsx
@@ -335,6 +335,7 @@ export const SettingsSidebarContent = ({
       href: `${basePath}/organization/feedback-directories`,
       icon: <FoldersIcon className={iconClassName} />,
       hidden: isMember,
+      disabled: !isOwnerOrManager,
     },
     {
       id: "org-api-keys",
@@ -373,12 +374,14 @@ export const SettingsSidebarContent = ({
       label: t("common.your_profile"),
       href: `${basePath}/account/profile`,
       icon: <UserCircleIcon className={iconClassName} />,
+      disabled: isBilling,
     },
     {
       id: "notifications",
       label: t("common.notifications"),
       href: `${basePath}/account/notifications`,
       icon: <BellIcon className={iconClassName} />,
+      disabled: isBilling,
     },
   ];
 

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/account/layout.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/account/layout.tsx
@@ -1,4 +1,11 @@
-const AccountSettingsLayout = (props: { children: React.ReactNode }) => {
+import { redirectBillingRoleFromRestrictedSettings } from "@/app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role";
+
+const AccountSettingsLayout = async (props: Readonly<{
+  params: Promise<{ workspaceId: string }>;
+  children: React.ReactNode;
+}>) => {
+  const params = await props.params;
+  await redirectBillingRoleFromRestrictedSettings(params.workspaceId);
   return <>{props.children}</>;
 };
 

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role.test.ts
@@ -1,0 +1,54 @@
+import { redirect } from "next/navigation";
+import { describe, expect, test, vi } from "vitest";
+import { getBillingFallbackPath } from "@/lib/membership/navigation";
+import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
+import { redirectBillingRoleFromRestrictedSettings } from "./redirect-billing-role";
+
+const mocks = vi.hoisted(() => ({
+  getBillingFallbackPath: vi.fn(),
+  getWorkspaceAuth: vi.fn(),
+  isFormbricksCloud: false,
+}));
+
+vi.mock("@/lib/constants", () => ({
+  IS_FORMBRICKS_CLOUD: mocks.isFormbricksCloud,
+}));
+
+vi.mock("@/lib/membership/navigation", () => ({
+  getBillingFallbackPath: mocks.getBillingFallbackPath,
+}));
+
+vi.mock("@/modules/workspaces/lib/utils", () => ({
+  getWorkspaceAuth: mocks.getWorkspaceAuth,
+}));
+
+const workspaceId = "workspace-1";
+const billingFallbackPath = `/workspaces/${workspaceId}/settings/organization/billing`;
+
+const getWorkspaceAuthResponse = (isBilling: boolean) =>
+  ({
+    isBilling,
+  }) as Awaited<ReturnType<typeof getWorkspaceAuth>>;
+
+describe("redirectBillingRoleFromRestrictedSettings", () => {
+  test("does not redirect non-billing workspace members", async () => {
+    vi.mocked(getWorkspaceAuth).mockResolvedValue(getWorkspaceAuthResponse(false));
+
+    await expect(redirectBillingRoleFromRestrictedSettings(workspaceId)).resolves.toBeUndefined();
+
+    expect(getWorkspaceAuth).toHaveBeenCalledWith(workspaceId);
+    expect(getBillingFallbackPath).not.toHaveBeenCalled();
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  test("redirects billing users to the billing fallback path", async () => {
+    vi.mocked(getWorkspaceAuth).mockResolvedValue(getWorkspaceAuthResponse(true));
+    vi.mocked(getBillingFallbackPath).mockReturnValue(billingFallbackPath);
+
+    await redirectBillingRoleFromRestrictedSettings(workspaceId);
+
+    expect(getWorkspaceAuth).toHaveBeenCalledWith(workspaceId);
+    expect(getBillingFallbackPath).toHaveBeenCalledWith(workspaceId, mocks.isFormbricksCloud);
+    expect(redirect).toHaveBeenCalledWith(billingFallbackPath);
+  });
+});

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role.ts
@@ -1,0 +1,12 @@
+import { redirect } from "next/navigation";
+import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { getBillingFallbackPath } from "@/lib/membership/navigation";
+import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
+
+export const redirectBillingRoleFromRestrictedSettings = async (workspaceId: string): Promise<void> => {
+  const { isBilling } = await getWorkspaceAuth(workspaceId);
+
+  if (isBilling) {
+    redirect(getBillingFallbackPath(workspaceId, IS_FORMBRICKS_CLOUD));
+  }
+};

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/api-keys/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/api-keys/page.tsx
@@ -1,3 +1,11 @@
+import { redirectBillingRoleFromRestrictedSettings } from "@/app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role";
 import { APIKeysPage } from "@/modules/organization/settings/api-keys/page";
 
-export default APIKeysPage;
+const Page = async (props: Readonly<{ params: Promise<{ workspaceId: string }> }>) => {
+  const params = await props.params;
+  await redirectBillingRoleFromRestrictedSettings(params.workspaceId);
+
+  return APIKeysPage(props);
+};
+
+export default Page;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/billing/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/billing/page.tsx
@@ -1,3 +1,18 @@
+import { redirect } from "next/navigation";
+import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { getBillingFallbackPath } from "@/lib/membership/navigation";
 import { PricingPage } from "@/modules/ee/billing/page";
+import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
 
-export default PricingPage;
+const Page = async (props: Readonly<{ params: Promise<{ workspaceId: string }> }>) => {
+  const params = await props.params;
+  const { isBilling } = await getWorkspaceAuth(params.workspaceId);
+
+  if (isBilling && !IS_FORMBRICKS_CLOUD) {
+    redirect(getBillingFallbackPath(params.workspaceId, IS_FORMBRICKS_CLOUD));
+  }
+
+  return PricingPage(props);
+};
+
+export default Page;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/domain/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/domain/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { AuthenticationError } from "@formbricks/types/errors";
 import { SettingsCard } from "@/app/(app)/workspaces/[workspaceId]/settings/components/SettingsCard";
+import { redirectBillingRoleFromRestrictedSettings } from "@/app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role";
 import { PrettyUrlsTable } from "@/app/(app)/workspaces/[workspaceId]/settings/organization/domain/components/pretty-urls-table";
 import { IS_FORMBRICKS_CLOUD, IS_STORAGE_CONFIGURED } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
@@ -12,8 +13,9 @@ import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper
 import { PageHeader } from "@/modules/ui/components/page-header";
 import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
 
-const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
+const Page = async (props: Readonly<{ params: Promise<{ workspaceId: string }> }>) => {
   const params = await props.params;
+  await redirectBillingRoleFromRestrictedSettings(params.workspaceId);
   const t = await getTranslate();
 
   if (IS_FORMBRICKS_CLOUD) {

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/page.tsx
@@ -1,9 +1,10 @@
 import { CheckIcon } from "lucide-react";
 import Link from "next/link";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { EnterpriseLicenseFeaturesTable } from "@/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/components/EnterpriseLicenseFeaturesTable";
 import { EnterpriseLicenseStatus } from "@/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/components/EnterpriseLicenseStatus";
 import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { getBillingFallbackPath } from "@/lib/membership/navigation";
 import { getTranslate } from "@/lingodotdev/server";
 import { GRACE_PERIOD_MS, getEnterpriseLicense } from "@/modules/ee/license-check/lib/license";
 import { Button } from "@/modules/ui/components/button";
@@ -11,14 +12,18 @@ import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper
 import { PageHeader } from "@/modules/ui/components/page-header";
 import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
 
-const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
+const Page = async (props: Readonly<{ params: Promise<{ workspaceId: string }> }>) => {
   const params = await props.params;
   const t = await getTranslate();
+  const { isBilling, isMember } = await getWorkspaceAuth(params.workspaceId);
+
+  if (isBilling && IS_FORMBRICKS_CLOUD) {
+    redirect(getBillingFallbackPath(params.workspaceId, IS_FORMBRICKS_CLOUD));
+  }
+
   if (IS_FORMBRICKS_CLOUD) {
     return notFound();
   }
-
-  const { isMember } = await getWorkspaceAuth(params.workspaceId);
 
   const isPricingDisabled = isMember;
 

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/feedback-directories/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/feedback-directories/page.tsx
@@ -1,1 +1,11 @@
-export { FeedbackDirectoriesPage as default } from "@/modules/ee/feedback-directory/page";
+import { redirectBillingRoleFromRestrictedSettings } from "@/app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role";
+import { FeedbackDirectoriesPage } from "@/modules/ee/feedback-directory/page";
+
+const Page = async (props: Readonly<{ params: Promise<{ workspaceId: string }> }>) => {
+  const params = await props.params;
+  await redirectBillingRoleFromRestrictedSettings(params.workspaceId);
+
+  return FeedbackDirectoriesPage(props);
+};
+
+export default Page;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/page.tsx
@@ -1,3 +1,4 @@
+import { redirectBillingRoleFromRestrictedSettings } from "@/app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role";
 import { isInstanceAIConfigured } from "@/lib/ai/service";
 import {
   ENTERPRISE_LICENSE_REQUEST_FORM_URL,
@@ -26,8 +27,9 @@ import { DeleteOrganization } from "./components/DeleteOrganization";
 import { EditOrganizationNameForm } from "./components/EditOrganizationNameForm";
 import { SecurityListTip } from "./components/SecurityListTip";
 
-const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
+const Page = async (props: Readonly<{ params: Promise<{ workspaceId: string }> }>) => {
   const params = await props.params;
+  await redirectBillingRoleFromRestrictedSettings(params.workspaceId);
   const t = await getTranslate();
 
   const { session, currentUserMembership, organization, isOwner, isManager } = await getWorkspaceAuth(

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/teams/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/teams/page.tsx
@@ -1,3 +1,11 @@
+import { redirectBillingRoleFromRestrictedSettings } from "@/app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role";
 import { TeamsPage } from "@/modules/organization/settings/teams/page";
 
-export default TeamsPage;
+const Page = async (props: Readonly<{ params: Promise<{ workspaceId: string }> }>) => {
+  const params = await props.params;
+  await redirectBillingRoleFromRestrictedSettings(params.workspaceId);
+
+  return TeamsPage(props);
+};
+
+export default Page;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/page.tsx
@@ -1,7 +1,9 @@
 import { redirect } from "next/navigation";
+import { redirectBillingRoleFromRestrictedSettings } from "@/app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role";
 
-const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
+const Page = async (props: Readonly<{ params: Promise<{ workspaceId: string }> }>) => {
   const params = await props.params;
+  await redirectBillingRoleFromRestrictedSettings(params.workspaceId);
   return redirect(`/workspaces/${params.workspaceId}/settings/workspace/general`);
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Backports #8053 to `release/5.0`.

Enforces billing-role settings restrictions server-side so billing users are redirected to the billing settings page on Cloud and the enterprise settings page on self-hosted deployments. It also guards direct URL access to restricted organization/account settings pages and aligns the sidebar disabled state for Feedback Directories with other inaccessible settings entries.

Related: ENG-982

## How should this be tested?

- [x] `pnpm exec eslint "apps/web/app/(app)/workspaces/[workspaceId]/components/SettingsSidebarContent.tsx" "apps/web/app/(app)/workspaces/[workspaceId]/settings/account/layout.tsx" "apps/web/app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role.test.ts" "apps/web/app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role.ts" "apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/api-keys/page.tsx" "apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/billing/page.tsx" "apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/domain/page.tsx" "apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/page.tsx" "apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/feedback-directories/page.tsx" "apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/page.tsx" "apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/teams/page.tsx" "apps/web/app/(app)/workspaces/[workspaceId]/settings/page.tsx"`
- [x] `pnpm --filter @formbricks/web exec vitest run "app/(app)/workspaces/[workspaceId]/settings/lib/redirect-billing-role.test.ts"`
- Manual regression from #8053:
  - Verify as billing role on Cloud: restricted settings URLs redirect to `/settings/organization/billing`.
  - Verify as billing role on self-hosted: restricted settings URLs redirect to `/settings/organization/enterprise`.
  - Verify owners/managers retain access to organization/account settings pages.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-611cd4ac-b0bd-4a0f-b585-6b88835c0d39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-611cd4ac-b0bd-4a0f-b585-6b88835c0d39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

