### PR TITLE
fix: AI translation rich-text editors stay empty (backport #8084)

### DIFF
--- a/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
@@ -26,17 +26,18 @@ export const RichTextTranslationInput = ({
 }: RichTextTranslationInputProps) => {
   const [firstRender, setFirstRender] = useState(true);
   const [editorKey, setEditorKey] = useState(0);
-  const prevDisabledRef = useRef(disabled);
+  // Tracks the most recent value the editor itself produced via setText, so we
+  // can tell external updates (e.g. AI translation fill) apart from the editor's
+  // own write-back and only remount for the former.
+  const lastWrittenRef = useRef(value);
 
-  // Remount the editor when AI translation finishes (disabled transitions from true → false)
-  // so the editor picks up the externally populated value.
   useEffect(() => {
-    if (prevDisabledRef.current && !disabled) {
+    if (value !== lastWrittenRef.current) {
+      lastWrittenRef.current = value;
       setEditorKey((k) => k + 1);
       setFirstRender(true);
     }
-    prevDisabledRef.current = disabled;
-  }, [disabled]);
+  }, [value]);
 
   return (
     <div className={disabled ? "cursor-not-allowed rounded-md opacity-60" : "rounded-md"}>
@@ -47,7 +48,10 @@ export const RichTextTranslationInput = ({
         firstRender={firstRender}
         setFirstRender={setFirstRender}
         getText={() => md.render(value)}
-        setText={(v: string) => onChange(path, v)}
+        setText={(v: string) => {
+          lastWrittenRef.current = v;
+          onChange(path, v);
+        }}
         localSurvey={localSurvey}
         elementId={elementId}
         selectedLanguageCode={languageCode}

--- a/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
@@ -26,14 +26,17 @@ export const RichTextTranslationInput = ({
 }: RichTextTranslationInputProps) => {
   const [firstRender, setFirstRender] = useState(true);
   const [editorKey, setEditorKey] = useState(0);
-  // Tracks the most recent value the editor itself produced via setText, so we
-  // can tell external updates (e.g. AI translation fill) apart from the editor's
-  // own write-back and only remount for the former.
+  // Separates external value changes (e.g. AI fill) from the editor's own write-back so we
+  // only remount for the former.
   const lastWrittenRef = useRef(value);
+  // Suppresses Lexical's mount-time empty listener fire which would otherwise clobber an
+  // externally-applied value back to "".
+  const initialContentSetRef = useRef(false);
 
   useEffect(() => {
     if (value !== lastWrittenRef.current) {
       lastWrittenRef.current = value;
+      initialContentSetRef.current = false;
       setEditorKey((k) => k + 1);
       setFirstRender(true);
     }
@@ -49,6 +52,8 @@ export const RichTextTranslationInput = ({
         setFirstRender={setFirstRender}
         getText={() => md.render(value)}
         setText={(v: string) => {
+          if (!initialContentSetRef.current && v === "") return;
+          initialContentSetRef.current = true;
           lastWrittenRef.current = v;
           onChange(path, v);
         }}


### PR DESCRIPTION
Fixes: ENG-1017
Linear: https://linear.app/formbricks/issue/ENG-1017/ai-translations-not-working

Backport of #8084 to `release/5.0`. Opened ahead of #8084 merging — merge after the main PR is in.

Cherry-picked b3fd46d16 + c719cc14f cleanly.

## Test plan
- [ ] `pnpm build && pnpm start` from `apps/web` (the dev server masks the bug via Strict Mode)
- [ ] Create a survey with rich-text headlines and an ending with headline + subheader
- [ ] Add a second language, open Manage Translations, click "Translate with AI"
- [ ] All rich-text rows should render the translated value and progress reaches N/N
- [ ] Typing in a rich-text row still saves (no remount loop)