### PR TITLE
fix: adds close button on response error screen

### DIFF
--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -1049,20 +1049,39 @@ export function Survey({
       switch (errorType) {
         case TResponseErrorCodesEnum.ResponseSendingError:
           return (
-            <ResponseErrorComponent
-              responseData={responseQueue?.getUnsentData() ?? responseData}
-              questions={questions}
-              onRetry={retryResponse}
-              isRetrying={isRetrying}
-            />
+            <>
+              {localSurvey.type !== "link" ? (
+                <div className="bg-survey-bg relative h-8 w-full">
+                  <div className="flex w-full items-center justify-end">
+                    <SurveyCloseButton
+                      onClose={onClose}
+                      hoverColor={styling.inputBgColor?.light ?? "#f8fafc"}
+                      borderRadius={styling.roundness ?? 8}
+                    />
+                  </div>
+                </div>
+              ) : null}
+              <ResponseErrorComponent
+                responseData={responseQueue?.getUnsentData() ?? responseData}
+                questions={questions}
+                onRetry={retryResponse}
+                isRetrying={isRetrying}
+              />
+            </>
           );
         case TResponseErrorCodesEnum.RecaptchaError:
         case TResponseErrorCodesEnum.InvalidDeviceError:
           return (
             <>
               {localSurvey.type !== "link" ? (
-                <div className="bg-survey-bg flex h-6 justify-end pt-2 pr-2">
-                  <SurveyCloseButton onClose={onClose} />
+                <div className="bg-survey-bg relative h-8 w-full">
+                  <div className="flex w-full items-center justify-end">
+                    <SurveyCloseButton
+                      onClose={onClose}
+                      hoverColor={styling.inputBgColor?.light ?? "#f8fafc"}
+                      borderRadius={styling.roundness ?? 8}
+                    />
+                  </div>
                 </div>
               ) : null}
               <ErrorComponent errorType={errorType} />


### PR DESCRIPTION
Fixes https://linear.app/formbricks/issue/ENG-1029

Adds the close button in the survey response error UI

<img width="409" height="322" alt="Screenshot 2026-05-21 at 13 27 23" src="https://github.com/user-attachments/assets/537037d2-d92c-4e6c-a0b1-a5c94c97d569" />
