### PR TITLE
fix: rate-limit isSurveyResponsePresentAction and validateSurveyPinAction (ENG-942)

### DIFF
--- a/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
@@ -79,6 +79,8 @@ describe("rateLimitConfigs", () => {
         "accountDeletion",
         "surveyFollowUp",
         "sendLinkSurveyEmail",
+        "isSurveyResponsePresent",
+        "validateSurveyPin",
         "licenseRecheck",
       ]);
     });

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.ts
@@ -30,6 +30,16 @@ export const rateLimitConfigs = {
       allowedPerInterval: 10,
       namespace: "action:send-link-survey-email",
     }, // 10 per hour
+    isSurveyResponsePresent: {
+      interval: 60,
+      allowedPerInterval: 10,
+      namespace: "action:survey-response-present",
+    }, // 10 per minute — prevents email-enumeration oracle
+    validateSurveyPin: {
+      interval: 60,
+      allowedPerInterval: 10,
+      namespace: "action:validate-survey-pin",
+    }, // 10 per minute — prevents brute-force PIN guessing
     licenseRecheck: { interval: 60, allowedPerInterval: 5, namespace: "action:license-recheck" }, // 5 per minute
   },
 

--- a/apps/web/modules/survey/link/actions.ts
+++ b/apps/web/modules/survey/link/actions.ts
@@ -67,6 +67,9 @@ export const isSurveyResponsePresentAction = actionClient
     await applyIPRateLimit(rateLimitConfigs.actions.isSurveyResponsePresent);
 
     const survey = await getSurveyWithMetadata(parsedInput.surveyId);
+    if (!survey) {
+      throw new ResourceNotFoundError("Survey", parsedInput.surveyId);
+    }
 
     if (!survey.isSingleResponsePerEmailEnabled) {
       throw new InvalidInputError("SINGLE_RESPONSE_PER_EMAIL_NOT_ENABLED");

--- a/apps/web/modules/survey/link/actions.ts
+++ b/apps/web/modules/survey/link/actions.ts
@@ -37,6 +37,8 @@ const ZValidateSurveyPinAction = z.object({
 export const validateSurveyPinAction = actionClient
   .inputSchema(ZValidateSurveyPinAction)
   .action(async ({ parsedInput }) => {
+    await applyIPRateLimit(rateLimitConfigs.actions.validateSurveyPin);
+
     // Get survey data which includes pin information
     const survey = await getSurveyWithMetadata(parsedInput.surveyId);
     if (!survey) {
@@ -62,5 +64,13 @@ const ZIsSurveyResponsePresentAction = z.object({
 export const isSurveyResponsePresentAction = actionClient
   .inputSchema(ZIsSurveyResponsePresentAction)
   .action(async ({ parsedInput }) => {
+    await applyIPRateLimit(rateLimitConfigs.actions.isSurveyResponsePresent);
+
+    const survey = await getSurveyWithMetadata(parsedInput.surveyId);
+
+    if (!survey.isSingleResponsePerEmailEnabled) {
+      throw new InvalidInputError("SINGLE_RESPONSE_PER_EMAIL_NOT_ENABLED");
+    }
+
     return await isSurveyResponsePresent(parsedInput.surveyId, parsedInput.email)();
   });


### PR DESCRIPTION
Fixing a security issue reported by  @geo-chen
Thank you for making Formbricks more secure 🙏

## Why

`isSurveyResponsePresentAction` had no IP rate limiting and no server-side guard
verifying that `isSingleResponsePerEmailEnabled` is actually enabled on the target
survey. This allowed any caller to:

1. **Email-enumeration oracle** — repeatedly call the action with arbitrary email
   addresses to determine whether each one has submitted a response, at unbounded
   speed.
2. **Feature bypass** — probe response presence on surveys where the single-response-
   per-email feature is disabled, leaking information about who responded.

`validateSurveyPinAction` was similarly unprotected against brute-force PIN guessing.

## What's done

- Added `isSurveyResponsePresent` rate-limit config (10 req/min per IP) in
  `rate-limit-configs.ts`.
- Added `validateSurveyPin` rate-limit config (10 req/min per IP).
- `isSurveyResponsePresentAction`: apply rate limit, then guard behind a server-side
  `survey.isSingleResponsePerEmailEnabled` check (mirrors the `isVerifyEmailEnabled`
  guard already in `sendLinkSurveyEmailAction`).
- `validateSurveyPinAction`: apply rate limit before processing the PIN.

## Acceptance criteria

- [ ] Calling `isSurveyResponsePresentAction` more than 10 times per minute from the
  same IP returns a rate-limit error.
- [ ] Calling `isSurveyResponsePresentAction` on a survey without
  `isSingleResponsePerEmailEnabled` returns `SINGLE_RESPONSE_PER_EMAIL_NOT_ENABLED`.
- [ ] Calling `validateSurveyPinAction` more than 10 times per minute from the same
  IP returns a rate-limit error.
- [ ] Normal usage (within limits, feature enabled) continues to work correctly.

Fixes ENG-942

🤖 Generated with [Claude Code](https://claude.com/claude-code)