### PR TITLE
fix: pin DNS and block redirects on webhook delivery in the response pipeline

### DIFF
--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
@@ -6,6 +6,8 @@ import { processResponsePipelineJob } from "./process-response-pipeline-job";
 const {
   mockFetch,
   mockCaptureSurveyResponsePostHogEvent,
+  mockCreatePinnedDispatcher,
+  mockDispatcherDestroy,
   mockGetIntegrations,
   mockGetResponseCountBySurveyId,
   mockHandleIntegrations,
@@ -21,13 +23,16 @@ const {
   mockSendFollowUpsForResponse,
   mockSendResponseFinishedEmail,
   mockSendTelemetryEvents,
-  mockValidateWebhookUrl,
+  mockValidateAndResolveWebhookUrl,
 } = vi.hoisted(() => {
   process.env.HUB_API_URL ??= "https://hub.test";
+  const dispatcherDestroy = vi.fn().mockResolvedValue(undefined);
 
   return {
     mockFetch: vi.fn(),
     mockCaptureSurveyResponsePostHogEvent: vi.fn(),
+    mockCreatePinnedDispatcher: vi.fn(() => ({ destroy: dispatcherDestroy })),
+    mockDispatcherDestroy: dispatcherDestroy,
     mockGetIntegrations: vi.fn(),
     mockGetResponseCountBySurveyId: vi.fn(),
     mockHandleIntegrations: vi.fn(),
@@ -43,7 +48,7 @@ const {
     mockSendFollowUpsForResponse: vi.fn(),
     mockSendResponseFinishedEmail: vi.fn(),
     mockSendTelemetryEvents: vi.fn(),
-    mockValidateWebhookUrl: vi.fn(),
+    mockValidateAndResolveWebhookUrl: vi.fn(),
   };
 });
 
@@ -80,6 +85,7 @@ vi.mock(import("@/lib/constants"), async (importOriginal) => {
   return {
     ...actual,
     POSTHOG_KEY: undefined,
+    DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS: false,
   };
 });
 
@@ -104,7 +110,8 @@ vi.mock("./posthog", () => ({
 }));
 
 vi.mock("@/lib/utils/validate-webhook-url", () => ({
-  validateWebhookUrl: mockValidateWebhookUrl,
+  validateAndResolveWebhookUrl: mockValidateAndResolveWebhookUrl,
+  createPinnedDispatcher: mockCreatePinnedDispatcher,
 }));
 
 vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
@@ -205,7 +212,9 @@ describe("processResponsePipelineJob", () => {
     mockPrismaUserFindMany.mockResolvedValue([]);
     mockGetResponseCountBySurveyId.mockResolvedValue(1);
     mockHandleIntegrations.mockResolvedValue(undefined);
-    mockValidateWebhookUrl.mockResolvedValue(undefined);
+    mockValidateAndResolveWebhookUrl.mockResolvedValue({ ip: "93.184.216.34", family: 4 });
+    mockDispatcherDestroy.mockResolvedValue(undefined);
+    mockCreatePinnedDispatcher.mockImplementation(() => ({ destroy: mockDispatcherDestroy }));
     mockQueueAuditEventWithoutRequest.mockResolvedValue(undefined);
     mockRecordResponseCreatedMeterEvent.mockResolvedValue(undefined);
     mockSendResponseFinishedEmail.mockResolvedValue(undefined);
@@ -242,7 +251,7 @@ describe("processResponsePipelineJob", () => {
         triggers: { has: "responseCreated" },
       },
     });
-    expect(mockValidateWebhookUrl).toHaveBeenCalledWith("https://example.com/webhook");
+    expect(mockValidateAndResolveWebhookUrl).toHaveBeenCalledWith("https://example.com/webhook");
     expect(mockFetch).toHaveBeenCalledWith(
       "https://example.com/webhook",
       expect.objectContaining({
@@ -481,7 +490,7 @@ describe("processResponsePipelineJob", () => {
         url: "https://example.com/webhook",
       },
     ]);
-    mockValidateWebhookUrl.mockRejectedValue(webhookError);
+    mockValidateAndResolveWebhookUrl.mockRejectedValue(webhookError);
 
     await expect(
       processResponsePipelineJob(
@@ -527,7 +536,7 @@ describe("processResponsePipelineJob", () => {
         locale: "en",
       },
     ]);
-    mockValidateWebhookUrl.mockRejectedValue(webhookError);
+    mockValidateAndResolveWebhookUrl.mockRejectedValue(webhookError);
 
     await expect(
       processResponsePipelineJob(
@@ -777,6 +786,110 @@ describe("processResponsePipelineJob", () => {
         surveyId: "survey_123",
       }),
       "Response pipeline job failed"
+    );
+  });
+
+  test("pins fetch to the resolved webhook IP via undici dispatcher", async () => {
+    mockPrismaWebhookFindMany.mockResolvedValue([
+      {
+        id: "webhook_123",
+        secret: null,
+        url: "https://example.com/webhook",
+      },
+    ]);
+    const pinnedDispatcher = { destroy: mockDispatcherDestroy };
+    mockValidateAndResolveWebhookUrl.mockResolvedValue({ ip: "203.0.113.10", family: 4 });
+    mockCreatePinnedDispatcher.mockReturnValue(pinnedDispatcher);
+
+    await expect(processResponsePipelineJob(baseData, baseContext)).resolves.toBeUndefined();
+
+    expect(mockValidateAndResolveWebhookUrl).toHaveBeenCalledWith("https://example.com/webhook");
+    expect(mockCreatePinnedDispatcher).toHaveBeenCalledWith({ ip: "203.0.113.10", family: 4 });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/webhook",
+      expect.objectContaining({
+        dispatcher: pinnedDispatcher,
+        redirect: "manual",
+      })
+    );
+  });
+
+  test("blocks 3xx redirects from webhook endpoints as delivery failures", async () => {
+    mockPrismaWebhookFindMany.mockResolvedValue([
+      {
+        id: "webhook_123",
+        secret: null,
+        url: "https://example.com/webhook",
+      },
+    ]);
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 302,
+    });
+
+    await expect(processResponsePipelineJob(baseData, baseContext)).rejects.toThrow(
+      "Webhook delivery blocked: redirect status 302"
+    );
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://example.com/webhook",
+      expect.objectContaining({ redirect: "manual" })
+    );
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.any(Error),
+        webhookId: "webhook_123",
+      }),
+      "Response pipeline webhook delivery failed"
+    );
+  });
+
+  test("destroys the pinned dispatcher after a successful webhook delivery", async () => {
+    mockPrismaWebhookFindMany.mockResolvedValue([
+      {
+        id: "webhook_123",
+        secret: null,
+        url: "https://example.com/webhook",
+      },
+    ]);
+
+    await expect(processResponsePipelineJob(baseData, baseContext)).resolves.toBeUndefined();
+
+    expect(mockDispatcherDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  test("destroys the pinned dispatcher when the webhook fetch throws", async () => {
+    mockPrismaWebhookFindMany.mockResolvedValue([
+      {
+        id: "webhook_123",
+        secret: null,
+        url: "https://example.com/webhook",
+      },
+    ]);
+    mockFetch.mockRejectedValue(new Error("connect refused"));
+
+    await expect(processResponsePipelineJob(baseData, baseContext)).rejects.toThrow("connect refused");
+
+    expect(mockDispatcherDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not pin a dispatcher when the resolver returns null (internal URL flag)", async () => {
+    mockPrismaWebhookFindMany.mockResolvedValue([
+      {
+        id: "webhook_123",
+        secret: null,
+        url: "http://localhost:3000/webhook",
+      },
+    ]);
+    mockValidateAndResolveWebhookUrl.mockResolvedValue(null);
+
+    await expect(processResponsePipelineJob(baseData, baseContext)).resolves.toBeUndefined();
+
+    expect(mockCreatePinnedDispatcher).not.toHaveBeenCalled();
+    expect(mockDispatcherDestroy).not.toHaveBeenCalled();
+    expect(mockFetch).toHaveBeenCalledWith(
+      "http://localhost:3000/webhook",
+      expect.objectContaining({ dispatcher: undefined })
     );
   });
 

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
@@ -858,6 +858,29 @@ describe("processResponsePipelineJob", () => {
     expect(mockDispatcherDestroy).toHaveBeenCalledTimes(1);
   });
 
+  test("logs dispatcher cleanup failures without failing a successful webhook delivery", async () => {
+    const cleanupError = new Error("destroy failed");
+    mockPrismaWebhookFindMany.mockResolvedValue([
+      {
+        id: "webhook_123",
+        secret: null,
+        url: "https://example.com/webhook",
+      },
+    ]);
+    mockDispatcherDestroy.mockRejectedValue(cleanupError);
+
+    await expect(processResponsePipelineJob(baseData, baseContext)).resolves.toBeUndefined();
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: cleanupError,
+        webhookId: "webhook_123",
+        webhookUrl: "https://example.com/webhook",
+      }),
+      "Response pipeline webhook dispatcher cleanup failed"
+    );
+  });
+
   test("destroys the pinned dispatcher when the webhook fetch throws", async () => {
     mockPrismaWebhookFindMany.mockResolvedValue([
       {

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
@@ -254,7 +254,19 @@ const createWebhookDeliveryTask = async ({
         throw new Error(`Webhook delivery failed with status ${response.status}`);
       }
     } finally {
-      await dispatcher?.destroy();
+      try {
+        await dispatcher?.destroy();
+      } catch (cleanupError) {
+        logger.warn(
+          {
+            ...logContext,
+            err: cleanupError,
+            webhookId: webhook.id,
+            webhookUrl: webhook.url,
+          },
+          "Response pipeline webhook dispatcher cleanup failed"
+        );
+      }
     }
   } catch (error) {
     logger.error(

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
@@ -7,11 +7,11 @@ import { logger } from "@formbricks/logger";
 import { DatabaseError } from "@formbricks/types/errors";
 import { type TUserLocale, ZUserLocale } from "@formbricks/types/user";
 import { handleConnectorPipeline } from "@/lib/connector/pipeline-handler";
-import { POSTHOG_KEY } from "@/lib/constants";
+import { DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS, POSTHOG_KEY } from "@/lib/constants";
 import { generateStandardWebhookSignature } from "@/lib/crypto";
 import { getIntegrations } from "@/lib/integration/service";
 import { getResponseCountBySurveyId } from "@/lib/response/service";
-import { validateWebhookUrl } from "@/lib/utils/validate-webhook-url";
+import { createPinnedDispatcher, validateAndResolveWebhookUrl } from "@/lib/utils/validate-webhook-url";
 import { queueAuditEventWithoutRequest } from "@/modules/ee/audit-logs/lib/handler";
 import { type TAuditStatus, UNKNOWN_DATA } from "@/modules/ee/audit-logs/types/audit-log";
 import { recordResponseCreatedMeterEvent } from "@/modules/ee/billing/lib/metering";
@@ -136,9 +136,13 @@ const createWebhookMessageId = ({
   webhookId: string;
 }): string => createHash("sha256").update(`${jobId}:${webhookId}:${event}`).digest("hex");
 
+type WebhookFetchOptions = RequestInit & {
+  dispatcher?: ReturnType<typeof createPinnedDispatcher>;
+};
+
 const fetchWithTimeout = async (
   url: string,
-  options: RequestInit,
+  options: WebhookFetchOptions,
   timeoutMs: number = WEBHOOK_TIMEOUT_MS
 ): Promise<Response> => {
   const abortController = new AbortController();
@@ -153,7 +157,7 @@ const fetchWithTimeout = async (
     return await fetch(url, {
       ...options,
       signal,
-    });
+    } as RequestInit);
   } finally {
     clearTimeout(timeoutId);
   }
@@ -222,15 +226,35 @@ const createWebhookDeliveryTask = async ({
       );
     }
 
-    await validateWebhookUrl(webhook.url);
-    const response = await fetchWithTimeout(webhook.url, {
-      method: "POST",
-      headers: requestHeaders,
-      body,
-    });
+    const address = await validateAndResolveWebhookUrl(webhook.url);
+    // Pin TCP connect to the validated IP — closes DNS-rebinding TOCTOU between
+    // validation and fetch. Skip pinning when address is null (DANGEROUSLY flag +
+    // blocked name resolved via /etc/hosts).
+    const dispatcher = address ? createPinnedDispatcher(address) : undefined;
+    // `redirect: "manual"` blocks 30x-based SSRF to private/internal hosts.
+    // Gated on the same env var as URL validation for self-hosters who opted in.
+    const redirectMode: RequestRedirect = DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS ? "follow" : "manual";
 
-    if (!response.ok) {
-      throw new Error(`Webhook delivery failed with status ${response.status}`);
+    try {
+      const response = await fetchWithTimeout(webhook.url, {
+        method: "POST",
+        headers: requestHeaders,
+        body,
+        redirect: redirectMode,
+        dispatcher,
+      });
+
+      // With `redirect: "manual"`, undici returns the actual 30x (not opaqueredirect).
+      // Treat as delivery failure so redirect-based SSRF cannot silently succeed.
+      if (response.status >= 300 && response.status < 400) {
+        throw new Error(`Webhook delivery blocked: redirect status ${response.status}`);
+      }
+
+      if (!response.ok) {
+        throw new Error(`Webhook delivery failed with status ${response.status}`);
+      }
+    } finally {
+      await dispatcher?.destroy();
     }
   } catch (error) {
     logger.error(


### PR DESCRIPTION
## What does this PR do?

Hardens the response-pipeline webhook delivery path against SSRF. The webhook *test* endpoint was already hardened, but actual delivery in `process-response-pipeline-job.ts` still called `validateWebhookUrl` then `fetch` — leaving a DNS-rebinding TOCTOU window and following 30x redirects by default.

  GuardDuty flagged this on EKS Auto Mode worker nodes:
  - `Trojan:EC2/PhishingDomainRequest!DNS` — node queried `*.cname.koyeb.app`
  - `UnauthorizedAccess:EC2/MetadataDNSRebind` — node queried `169.254.169.254.sslip.io` (AWS metadata rebind)

  Changes in `apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts`:

  - Swap `validateWebhookUrl` → `validateAndResolveWebhookUrl` to obtain the pinned resolved address.
  - Build a pinned undici dispatcher via `createPinnedDispatcher(address)` and pass it into `fetch` so TCP connect targets the validated IP (closes DNS-rebinding TOCTOU).
  - Set `redirect: "manual"` by default; `"follow"` only when `DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS` is enabled (parity with `testEndpoint`).
  - Treat 3xx responses as delivery failures (`Webhook delivery blocked: redirect status N`) so redirect-based SSRF cannot silently succeed.
  - Destroy the dispatcher in `finally` on every path.
  - Skip dispatcher creation when the resolver returns `null` (internal-URL flag + blocked hostname resolved via `/etc/hosts`).

  Fixes https://linear.app/formbricks/issue/ENG-1016

  ## How should this be tested?

  Automated regression tests in `process-response-pipeline-job.test.ts`:

  - Pinned dispatcher is built from the resolved address and passed into `fetch`.
  - 3xx responses are blocked as delivery failures with `redirect: "manual"`.
  - Dispatcher is destroyed after a successful delivery.
  - Dispatcher is destroyed when the fetch throws.
  - No dispatcher is created when the resolver returns `null` (`DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS` + localhost).

  Run:

 ```bash
  pnpm --filter @formbricks/web vitest run modules/response-pipeline/lib/process-response-pipeline-job.test.ts
```

  Manual / post-deploy:

  - Confirm a normal public webhook URL still delivers (200/2xx path unchanged).
  - Confirm a webhook URL that returns a 302 to http://169.254.169.254/... is rejected with Webhook delivery blocked: redirect status 302 and does not issue a follow-up
  request.
  - After deploy, review GuardDuty findings on core-eks for new Trojan:EC2/PhishingDomainRequest!DNS / UnauthorizedAccess:EC2/MetadataDNSRebind events from worker nodes —
  expect them to stop.

  Checklist

  Required

  - Filled out the "How to test" section in this PR
  - Read How we Code at Formbricks (https://formbricks.com/docs/contributing/how-we-code)
  - Self-reviewed my own code
  - Commented on my code in hard-to-understand bits
  - Ran pnpm build
  - Checked for warnings, there are none
  - Removed all console.logs
  - Merged the latest changes from main onto my branch with git pull origin main
  - My changes don't cause any responsiveness issues (no UI changes)
  - First PR at Formbricks? Please sign the CLA! (https://cla-assistant.io/formbricks/formbricks)

  Appreciated

  - No UI change — N/A
  - Updated the Formbricks Docs if changes were necessary