### PR TITLE
fix: chart date range type switch + presets include today (ENG-1034, ENG-1035)

### DIFF
--- a/apps/web/modules/ee/analysis/api/lib/cube-client.ts
+++ b/apps/web/modules/ee/analysis/api/lib/cube-client.ts
@@ -3,6 +3,7 @@ import cubejs, { type Query } from "@cubejs-client/core";
 import { randomUUID } from "node:crypto";
 import { logger } from "@formbricks/logger";
 import type { TChartQuery } from "@formbricks/types/analysis";
+import { expandPresetDateRanges } from "@/modules/ee/analysis/lib/date-presets";
 import { queueAuditEventWithoutRequest } from "@/modules/ee/audit-logs/lib/handler";
 import { UNKNOWN_DATA } from "@/modules/ee/audit-logs/types/audit-log";
 import { type TCubeQuerySource, getCubeApiConfig } from "./cube-config";
@@ -89,7 +90,7 @@ export async function executeTenantScopedQuery(input: TScopedCubeQueryInput) {
 
   try {
     const client = cubejs(token, { apiUrl });
-    const resultSet = await client.load(input.query as Query);
+    const resultSet = await client.load(expandPresetDateRanges(input.query) as Query);
     const result = resultSet.tablePivot();
     queueCubeQueryAuditEvent({ input, requestId, status: "success" });
     return result;

--- a/apps/web/modules/ee/analysis/charts/components/time-dimension-panel.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/time-dimension-panel.tsx
@@ -83,6 +83,24 @@ export function TimeDimensionPanel({
     }
   };
 
+  const handleDateRangeTypeChange = (value: "preset" | "custom") => {
+    setDateRangeType(value);
+    if (!timeDimension) return;
+
+    if (value === "preset") {
+      const nextPreset = presetValue || "last 30 days";
+      if (!presetValue) setPresetValue(nextPreset);
+      onTimeDimensionChange({ ...timeDimension, dateRange: nextPreset });
+      return;
+    }
+
+    const start = customStartDate ?? new Date();
+    const end = customEndDate ?? start;
+    if (!customStartDate) setCustomStartDate(start);
+    if (!customEndDate) setCustomEndDate(end);
+    onTimeDimensionChange({ ...timeDimension, dateRange: [start, end] });
+  };
+
   if (!timeDimension) {
     return (
       <div className="space-y-2">
@@ -150,7 +168,7 @@ export function TimeDimensionPanel({
           <div className="space-y-2">
             <Select
               value={dateRangeType}
-              onValueChange={(value) => setDateRangeType(value as "preset" | "custom")}>
+              onValueChange={(value) => handleDateRangeTypeChange(value as "preset" | "custom")}>
               <SelectTrigger className="w-full bg-white">
                 <SelectValue />
               </SelectTrigger>

--- a/apps/web/modules/ee/analysis/lib/date-presets.test.ts
+++ b/apps/web/modules/ee/analysis/lib/date-presets.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import type { TChartQuery } from "@formbricks/types/analysis";
+import { expandPresetDateRanges } from "./date-presets";
+
+const queryWithDateRange = (dateRange: string | [string, string]): TChartQuery => ({
+  measures: ["FeedbackRecords.count"],
+  timeDimensions: [{ dimension: "FeedbackRecords.collectedAt", dateRange }],
+});
+
+// Mid-month, mid-quarter date that exercises month/quarter/year boundaries cleanly.
+const NOW = new Date(2026, 4, 21, 14, 30, 0); // May 21, 2026 14:30 local
+
+describe("expandPresetDateRanges", () => {
+  test("includes today for 'last 7 days'", () => {
+    const result = expandPresetDateRanges(queryWithDateRange("last 7 days"), NOW);
+    expect(result.timeDimensions?.[0].dateRange).toEqual(["2026-05-15", "2026-05-21"]);
+  });
+
+  test("includes today for 'last 30 days'", () => {
+    const result = expandPresetDateRanges(queryWithDateRange("last 30 days"), NOW);
+    expect(result.timeDimensions?.[0].dateRange).toEqual(["2026-04-22", "2026-05-21"]);
+  });
+
+  test("expands 'today' to today..today", () => {
+    const result = expandPresetDateRanges(queryWithDateRange("today"), NOW);
+    expect(result.timeDimensions?.[0].dateRange).toEqual(["2026-05-21", "2026-05-21"]);
+  });
+
+  test("expands 'yesterday' to yesterday..yesterday", () => {
+    const result = expandPresetDateRanges(queryWithDateRange("yesterday"), NOW);
+    expect(result.timeDimensions?.[0].dateRange).toEqual(["2026-05-20", "2026-05-20"]);
+  });
+
+  test("'this month' runs from the 1st through today", () => {
+    const result = expandPresetDateRanges(queryWithDateRange("this month"), NOW);
+    expect(result.timeDimensions?.[0].dateRange).toEqual(["2026-05-01", "2026-05-21"]);
+  });
+
+  test("'last month' is the full previous calendar month", () => {
+    const result = expandPresetDateRanges(queryWithDateRange("last month"), NOW);
+    expect(result.timeDimensions?.[0].dateRange).toEqual(["2026-04-01", "2026-04-30"]);
+  });
+
+  test("'last month' handles year rollover", () => {
+    const janFirst = new Date(2026, 0, 15, 10, 0, 0);
+    const result = expandPresetDateRanges(queryWithDateRange("last month"), janFirst);
+    expect(result.timeDimensions?.[0].dateRange).toEqual(["2025-12-01", "2025-12-31"]);
+  });
+
+  test("'this quarter' starts at the first day of the calendar quarter", () => {
+    const result = expandPresetDateRanges(queryWithDateRange("this quarter"), NOW);
+    expect(result.timeDimensions?.[0].dateRange).toEqual(["2026-04-01", "2026-05-21"]);
+  });
+
+  test("'this year' starts on Jan 1", () => {
+    const result = expandPresetDateRanges(queryWithDateRange("this year"), NOW);
+    expect(result.timeDimensions?.[0].dateRange).toEqual(["2026-01-01", "2026-05-21"]);
+  });
+
+  test("leaves explicit [start, end] tuple unchanged", () => {
+    const result = expandPresetDateRanges(queryWithDateRange(["2026-01-01", "2026-01-15"]), NOW);
+    expect(result.timeDimensions?.[0].dateRange).toEqual(["2026-01-01", "2026-01-15"]);
+  });
+
+  test("leaves an unknown preset string unchanged so Cube can interpret it", () => {
+    const result = expandPresetDateRanges(queryWithDateRange("from -3 days to now"), NOW);
+    expect(result.timeDimensions?.[0].dateRange).toBe("from -3 days to now");
+  });
+
+  test("returns input unchanged when there are no time dimensions", () => {
+    const q: TChartQuery = { measures: ["FeedbackRecords.count"] };
+    expect(expandPresetDateRanges(q, NOW)).toEqual(q);
+  });
+
+  test("preserves other timeDimension fields (granularity, dimension)", () => {
+    const q: TChartQuery = {
+      measures: ["FeedbackRecords.count"],
+      timeDimensions: [
+        { dimension: "FeedbackRecords.collectedAt", granularity: "day", dateRange: "last 7 days" },
+      ],
+    };
+    const result = expandPresetDateRanges(q, NOW);
+    expect(result.timeDimensions?.[0]).toMatchObject({
+      dimension: "FeedbackRecords.collectedAt",
+      granularity: "day",
+      dateRange: ["2026-05-15", "2026-05-21"],
+    });
+  });
+
+  test("does not mutate the input query", () => {
+    const q = queryWithDateRange("last 7 days");
+    const before = JSON.stringify(q);
+    expandPresetDateRanges(q, NOW);
+    expect(JSON.stringify(q)).toBe(before);
+  });
+});

--- a/apps/web/modules/ee/analysis/lib/date-presets.ts
+++ b/apps/web/modules/ee/analysis/lib/date-presets.ts
@@ -1,42 +1,12 @@
+import { addDays, formatDate, startOfDay, startOfMonth, startOfQuarter, startOfYear } from "date-fns";
 import type { TChartQuery } from "@formbricks/types/analysis";
-
-const formatDate = (d: Date): string => {
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-};
-
-const startOfDay = (d: Date): Date => {
-  const x = new Date(d);
-  x.setHours(0, 0, 0, 0);
-  return x;
-};
-
-const addDays = (d: Date, days: number): Date => {
-  const x = new Date(d);
-  x.setDate(x.getDate() + days);
-  return x;
-};
-
-const startOfMonth = (d: Date): Date => new Date(d.getFullYear(), d.getMonth(), 1);
-
-const startOfQuarter = (d: Date): Date => {
-  const month = d.getMonth();
-  return new Date(d.getFullYear(), month - (month % 3), 1);
-};
-
-const startOfYear = (d: Date): Date => new Date(d.getFullYear(), 0, 1);
 
 // Cube's native "last N days" / "this month" / etc. strings exclude today; we expand them
 // to explicit inclusive ranges so charts behave like every other analytics tool (GA, Mixpanel,
 // PostHog, ...) and include the current partial day.
 const PRESET_RESOLVERS: Record<string, (now: Date) => [Date, Date]> = {
   today: (now) => [startOfDay(now), startOfDay(now)],
-  yesterday: (now) => {
-    const y = addDays(startOfDay(now), -1);
-    return [y, y];
-  },
+  yesterday: (now) => [addDays(startOfDay(now), -1), addDays(startOfDay(now), -1)],
   "last 7 days": (now) => [addDays(startOfDay(now), -6), startOfDay(now)],
   "last 30 days": (now) => [addDays(startOfDay(now), -29), startOfDay(now)],
   "this month": (now) => [startOfMonth(now), startOfDay(now)],
@@ -57,7 +27,10 @@ export const expandPresetDateRanges = (query: TChartQuery, now: Date = new Date(
     const resolver = PRESET_RESOLVERS[td.dateRange.toLowerCase().trim()];
     if (!resolver) return td;
     const [start, end] = resolver(now);
-    return { ...td, dateRange: [formatDate(start), formatDate(end)] as [string, string] };
+    return {
+      ...td,
+      dateRange: [formatDate(start, "yyyy-MM-dd"), formatDate(end, "yyyy-MM-dd")] as [string, string],
+    };
   });
 
   return { ...query, timeDimensions: expanded };

--- a/apps/web/modules/ee/analysis/lib/date-presets.ts
+++ b/apps/web/modules/ee/analysis/lib/date-presets.ts
@@ -1,0 +1,64 @@
+import type { TChartQuery } from "@formbricks/types/analysis";
+
+const formatDate = (d: Date): string => {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const startOfDay = (d: Date): Date => {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+};
+
+const addDays = (d: Date, days: number): Date => {
+  const x = new Date(d);
+  x.setDate(x.getDate() + days);
+  return x;
+};
+
+const startOfMonth = (d: Date): Date => new Date(d.getFullYear(), d.getMonth(), 1);
+
+const startOfQuarter = (d: Date): Date => {
+  const month = d.getMonth();
+  return new Date(d.getFullYear(), month - (month % 3), 1);
+};
+
+const startOfYear = (d: Date): Date => new Date(d.getFullYear(), 0, 1);
+
+// Cube's native "last N days" / "this month" / etc. strings exclude today; we expand them
+// to explicit inclusive ranges so charts behave like every other analytics tool (GA, Mixpanel,
+// PostHog, ...) and include the current partial day.
+const PRESET_RESOLVERS: Record<string, (now: Date) => [Date, Date]> = {
+  today: (now) => [startOfDay(now), startOfDay(now)],
+  yesterday: (now) => {
+    const y = addDays(startOfDay(now), -1);
+    return [y, y];
+  },
+  "last 7 days": (now) => [addDays(startOfDay(now), -6), startOfDay(now)],
+  "last 30 days": (now) => [addDays(startOfDay(now), -29), startOfDay(now)],
+  "this month": (now) => [startOfMonth(now), startOfDay(now)],
+  "last month": (now) => {
+    const firstOfThisMonth = startOfMonth(now);
+    const lastOfLastMonth = addDays(firstOfThisMonth, -1);
+    return [startOfMonth(lastOfLastMonth), lastOfLastMonth];
+  },
+  "this quarter": (now) => [startOfQuarter(now), startOfDay(now)],
+  "this year": (now) => [startOfYear(now), startOfDay(now)],
+};
+
+export const expandPresetDateRanges = (query: TChartQuery, now: Date = new Date()): TChartQuery => {
+  if (!query.timeDimensions?.length) return query;
+
+  const expanded = query.timeDimensions.map((td) => {
+    if (typeof td.dateRange !== "string") return td;
+    const resolver = PRESET_RESOLVERS[td.dateRange.toLowerCase().trim()];
+    if (!resolver) return td;
+    const [start, end] = resolver(now);
+    return { ...td, dateRange: [formatDate(start), formatDate(end)] as [string, string] };
+  });
+
+  return { ...query, timeDimensions: expanded };
+};


### PR DESCRIPTION
Fixes: ENG-1034, ENG-1035

- Linear ENG-1034: https://linear.app/formbricks/issue/ENG-1034
- Linear ENG-1035: https://linear.app/formbricks/issue/ENG-1035

## Summary

Two related chart-editor bugs:

### ENG-1034 — Custom → Preset leaves Update chart disabled

In the chart editor, after running an Update with a Custom date range, toggling the date range type back to Preset would leave the Update chart button permanently disabled. The toggle only mutated local UI state (`setDateRangeType`) and never propagated to the parent, so the parent's `timeDimension.dateRange` was still the old custom `[Date, Date]` array. `hasConfigChanged` saw matching queries and stayed false.

Fix: extract the type toggle into `handleDateRangeTypeChange`, which seats the parent `timeDimension.dateRange` to a preset string (when going Custom → Preset) or to a `[start, end]` tuple (when going Preset → Custom). Picking a preset still propagates via the existing `handlePresetChange`; the toggle now pre-seats parent state so the second select isn't a no-op when the user re-picks the same preset they last had.

### ENG-1035 — presets exclude today

Cube v1.6.6 interprets `"last 7 days"` / `"last 30 days"` / `"this month"` / etc. as ranges anchored to **end of yesterday**, so charts excluded the current partial day. Every other analytics tool (GA, Mixpanel, PostHog, Metabase, Looker, ...) includes today.

Fix: new `expandPresetDateRanges(query, now?)` helper that rewrites known preset strings on a `TChartQuery` to explicit inclusive `[YYYY-MM-DD, YYYY-MM-DD]` tuples. Wired in at the Cube boundary (`cube-client.ts` right before `client.load`) so:

- Stored client queries keep the preset string — `hasConfigChanged` stays consistent and saved charts round-trip back to the Preset UI.
- The audit log still records the original (more readable) preset string.
- The expansion benefits both interactive `executeQueryAction` and AI-generated charts via `generateAIChartAction` — both call `executeTenantScopedQuery`.
- Unknown preset strings pass through unchanged so Cube can interpret them.

Range semantics:
| Preset | Range |
| --- | --- |
| `today` | `[today, today]` |
| `yesterday` | `[yesterday, yesterday]` |
| `last 7 days` | `[today − 6, today]` |
| `last 30 days` | `[today − 29, today]` |
| `this month` | `[1st of this month, today]` |
| `last month` | full previous calendar month |
| `this quarter` | `[1st of this quarter, today]` |
| `this year` | `[Jan 1, today]` |

#### One deviation from ENG-1035

The ticket's third acceptance bullet asks the Cube query to "match the canonical Cube preset string." On Cube v1.6.6 the canonical preset string is exactly what excludes today, so satisfying that bullet literally would re-introduce the bug. This PR sends an explicit `[from, to]` array instead — still a valid Cube query, just not the preset token. Flagging for visibility — happy to revisit if you'd rather upgrade Cube or pursue a different approach.

#### Timezone caveat

`expandPresetDateRanges` uses server-local time. The Cube container is typically UTC, so for users in non-UTC timezones near midnight the day boundary may shift. Same caveat already applies to custom date ranges in the existing `buildCubeQuery`. Plumbing per-request user timezone is a bigger change to defer; `TChartQuery` already supports a `timezone` field if we want to go that route later.

## Test plan

- [ ] `pnpm vitest run modules/ee/analysis/lib/date-presets.test.ts` — 14/14 pass (committed in this PR)
- [ ] `pnpm vitest run modules/ee/analysis/api/lib/cube-client.test.ts` — 8/8 still pass (no regression)
- [ ] Manual ENG-1034: open Edit Chart → Custom Range, pick dates, Update → toggle back to Preset → Update chart re-enables immediately
- [ ] Manual ENG-1035: chart with `Last 7 days` preset shows today's bar (with real data spanning the window)
- [ ] Saved-chart round trip: open a chart previously saved with a preset, confirm it still opens in Preset mode (not Custom Range)