### PR TITLE
fix: chart date range type switch + presets include today (backport #8096)

### DIFF
--- a/apps/web/modules/ee/analysis/api/lib/cube-client.ts
+++ b/apps/web/modules/ee/analysis/api/lib/cube-client.ts
@@ -3,6 +3,7 @@ import cubejs, { type Query } from "@cubejs-client/core";
 import { randomUUID } from "node:crypto";
 import { logger } from "@formbricks/logger";
 import type { TChartQuery } from "@formbricks/types/analysis";
+import { expandPresetDateRanges } from "@/modules/ee/analysis/lib/date-presets";
 import { queueAuditEventWithoutRequest } from "@/modules/ee/audit-logs/lib/handler";
 import { UNKNOWN_DATA } from "@/modules/ee/audit-logs/types/audit-log";
 import { type TCubeQuerySource, getCubeApiConfig } from "./cube-config";
@@ -89,7 +90,7 @@ export async function executeTenantScopedQuery(input: TScopedCubeQueryInput) {
 
   try {
     const client = cubejs(token, { apiUrl });
-    const resultSet = await client.load(input.query as Query);
+    const resultSet = await client.load(expandPresetDateRanges(input.query) as Query);
     const result = resultSet.tablePivot();
     queueCubeQueryAuditEvent({ input, requestId, status: "success" });
     return result;

--- a/apps/web/modules/ee/analysis/charts/components/time-dimension-panel.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/time-dimension-panel.tsx
@@ -83,6 +83,24 @@ export function TimeDimensionPanel({
     }
   };
 
+  const handleDateRangeTypeChange = (value: "preset" | "custom") => {
+    setDateRangeType(value);
+    if (!timeDimension) return;
+
+    if (value === "preset") {
+      const nextPreset = presetValue || "last 30 days";
+      if (!presetValue) setPresetValue(nextPreset);
+      onTimeDimensionChange({ ...timeDimension, dateRange: nextPreset });
+      return;
+    }
+
+    const start = customStartDate ?? new Date();
+    const end = customEndDate ?? start;
+    if (!customStartDate) setCustomStartDate(start);
+    if (!customEndDate) setCustomEndDate(end);
+    onTimeDimensionChange({ ...timeDimension, dateRange: [start, end] });
+  };
+
   if (!timeDimension) {
     return (
       <div className="space-y-2">
@@ -150,7 +168,7 @@ export function TimeDimensionPanel({
           <div className="space-y-2">
             <Select
               value={dateRangeType}
-              onValueChange={(value) => setDateRangeType(value as "preset" | "custom")}>
+              onValueChange={(value) => handleDateRangeTypeChange(value as "preset" | "custom")}>
               <SelectTrigger className="w-full bg-white">
                 <SelectValue />
               </SelectTrigger>

--- a/apps/web/modules/ee/analysis/lib/date-presets.ts
+++ b/apps/web/modules/ee/analysis/lib/date-presets.ts
@@ -1,42 +1,12 @@
+import { addDays, formatDate, startOfDay, startOfMonth, startOfQuarter, startOfYear } from "date-fns";
 import type { TChartQuery } from "@formbricks/types/analysis";
-
-const formatDate = (d: Date): string => {
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${year}-${month}-${day}`;
-};
-
-const startOfDay = (d: Date): Date => {
-  const x = new Date(d);
-  x.setHours(0, 0, 0, 0);
-  return x;
-};
-
-const addDays = (d: Date, days: number): Date => {
-  const x = new Date(d);
-  x.setDate(x.getDate() + days);
-  return x;
-};
-
-const startOfMonth = (d: Date): Date => new Date(d.getFullYear(), d.getMonth(), 1);
-
-const startOfQuarter = (d: Date): Date => {
-  const month = d.getMonth();
-  return new Date(d.getFullYear(), month - (month % 3), 1);
-};
-
-const startOfYear = (d: Date): Date => new Date(d.getFullYear(), 0, 1);
 
 // Cube's native "last N days" / "this month" / etc. strings exclude today; we expand them
 // to explicit inclusive ranges so charts behave like every other analytics tool (GA, Mixpanel,
 // PostHog, ...) and include the current partial day.
 const PRESET_RESOLVERS: Record<string, (now: Date) => [Date, Date]> = {
   today: (now) => [startOfDay(now), startOfDay(now)],
-  yesterday: (now) => {
-    const y = addDays(startOfDay(now), -1);
-    return [y, y];
-  },
+  yesterday: (now) => [addDays(startOfDay(now), -1), addDays(startOfDay(now), -1)],
   "last 7 days": (now) => [addDays(startOfDay(now), -6), startOfDay(now)],
   "last 30 days": (now) => [addDays(startOfDay(now), -29), startOfDay(now)],
   "this month": (now) => [startOfMonth(now), startOfDay(now)],
@@ -57,7 +27,10 @@ export const expandPresetDateRanges = (query: TChartQuery, now: Date = new Date(
     const resolver = PRESET_RESOLVERS[td.dateRange.toLowerCase().trim()];
     if (!resolver) return td;
     const [start, end] = resolver(now);
-    return { ...td, dateRange: [formatDate(start), formatDate(end)] as [string, string] };
+    return {
+      ...td,
+      dateRange: [formatDate(start, "yyyy-MM-dd"), formatDate(end, "yyyy-MM-dd")] as [string, string],
+    };
   });
 
   return { ...query, timeDimensions: expanded };

--- a/apps/web/modules/ee/analysis/lib/date-presets.ts
+++ b/apps/web/modules/ee/analysis/lib/date-presets.ts
@@ -1,0 +1,64 @@
+import type { TChartQuery } from "@formbricks/types/analysis";
+
+const formatDate = (d: Date): string => {
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const startOfDay = (d: Date): Date => {
+  const x = new Date(d);
+  x.setHours(0, 0, 0, 0);
+  return x;
+};
+
+const addDays = (d: Date, days: number): Date => {
+  const x = new Date(d);
+  x.setDate(x.getDate() + days);
+  return x;
+};
+
+const startOfMonth = (d: Date): Date => new Date(d.getFullYear(), d.getMonth(), 1);
+
+const startOfQuarter = (d: Date): Date => {
+  const month = d.getMonth();
+  return new Date(d.getFullYear(), month - (month % 3), 1);
+};
+
+const startOfYear = (d: Date): Date => new Date(d.getFullYear(), 0, 1);
+
+// Cube's native "last N days" / "this month" / etc. strings exclude today; we expand them
+// to explicit inclusive ranges so charts behave like every other analytics tool (GA, Mixpanel,
+// PostHog, ...) and include the current partial day.
+const PRESET_RESOLVERS: Record<string, (now: Date) => [Date, Date]> = {
+  today: (now) => [startOfDay(now), startOfDay(now)],
+  yesterday: (now) => {
+    const y = addDays(startOfDay(now), -1);
+    return [y, y];
+  },
+  "last 7 days": (now) => [addDays(startOfDay(now), -6), startOfDay(now)],
+  "last 30 days": (now) => [addDays(startOfDay(now), -29), startOfDay(now)],
+  "this month": (now) => [startOfMonth(now), startOfDay(now)],
+  "last month": (now) => {
+    const firstOfThisMonth = startOfMonth(now);
+    const lastOfLastMonth = addDays(firstOfThisMonth, -1);
+    return [startOfMonth(lastOfLastMonth), lastOfLastMonth];
+  },
+  "this quarter": (now) => [startOfQuarter(now), startOfDay(now)],
+  "this year": (now) => [startOfYear(now), startOfDay(now)],
+};
+
+export const expandPresetDateRanges = (query: TChartQuery, now: Date = new Date()): TChartQuery => {
+  if (!query.timeDimensions?.length) return query;
+
+  const expanded = query.timeDimensions.map((td) => {
+    if (typeof td.dateRange !== "string") return td;
+    const resolver = PRESET_RESOLVERS[td.dateRange.toLowerCase().trim()];
+    if (!resolver) return td;
+    const [start, end] = resolver(now);
+    return { ...td, dateRange: [formatDate(start), formatDate(end)] as [string, string] };
+  });
+
+  return { ...query, timeDimensions: expanded };
+};


### PR DESCRIPTION
Fixes: ENG-1034, ENG-1035

- Linear ENG-1034: https://linear.app/formbricks/issue/ENG-1034
- Linear ENG-1035: https://linear.app/formbricks/issue/ENG-1035

Backport of #8096 to `release/5.0`. Cherry-picked 736f31ea1 cleanly.

See #8096 for the full description, deviation notes, and timezone caveat.

## Test plan
- [ ] `pnpm vitest run modules/ee/analysis/lib/date-presets.test.ts` (14/14 in #8096)
- [ ] `pnpm vitest run modules/ee/analysis/api/lib/cube-client.test.ts` (no regression in #8096)
- [ ] Manual ENG-1034: Custom Range → Update → toggle back to Preset → Update chart re-enables
- [ ] Manual ENG-1035: `Last 7 days` shows today's bar
- [ ] Saved-chart round trip: a chart saved with a preset still opens in Preset mode