### PR TITLE
fix: allow enterprise oauth display names

### DIFF
--- a/apps/web/modules/auth/lib/user.test.ts
+++ b/apps/web/modules/auth/lib/user.test.ts
@@ -53,6 +53,29 @@ describe("User Management", () => {
       expect(result).toEqual(mockPrismaUser);
     });
 
+    test("creates a user with an Azure AD enterprise display name", async () => {
+      const enterpriseDisplayName = "Oberle,Julian (IT INF) BIG-DE-I";
+      vi.mocked(prisma.user.create).mockResolvedValueOnce({
+        ...mockPrismaUser,
+        name: enterpriseDisplayName,
+      });
+
+      const result = await createUser({
+        email: mockUser.email,
+        name: enterpriseDisplayName,
+        locale: mockUser.locale,
+      });
+
+      expect(result.name).toBe(enterpriseDisplayName);
+      expect(prisma.user.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            name: enterpriseDisplayName,
+          }),
+        })
+      );
+    });
+
     test("throws InvalidInputError when email already exists", async () => {
       const errToThrow = new Prisma.PrismaClientKnownRequestError("Mock error message", {
         code: PrismaErrorType.UniqueConstraintViolation,

--- a/apps/web/modules/auth/lib/user.test.ts
+++ b/apps/web/modules/auth/lib/user.test.ts
@@ -2,7 +2,7 @@ import { Prisma } from "@prisma/client";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { PrismaErrorType } from "@formbricks/database/types/error";
-import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { InvalidInputError, ResourceNotFoundError, ValidationError } from "@formbricks/types/errors";
 import { mockUser } from "./mock-data";
 import { createUser, getUser, getUserByEmail, updateUser, updateUserLastLoginAt } from "./user";
 
@@ -74,6 +74,18 @@ describe("User Management", () => {
           }),
         })
       );
+    });
+
+    test("rejects display names with newline characters", async () => {
+      await expect(
+        createUser({
+          email: mockUser.email,
+          name: "Lastname,Firstname\n(DEPT) COMPANY-CITY",
+          locale: mockUser.locale,
+        })
+      ).rejects.toThrow(ValidationError);
+
+      expect(prisma.user.create).not.toHaveBeenCalled();
     });
 
     test("throws InvalidInputError when email already exists", async () => {

--- a/apps/web/modules/auth/lib/user.test.ts
+++ b/apps/web/modules/auth/lib/user.test.ts
@@ -54,7 +54,7 @@ describe("User Management", () => {
     });
 
     test("creates a user with an Azure AD enterprise display name", async () => {
-      const enterpriseDisplayName = "Oberle,Julian (IT INF) BIG-DE-I";
+      const enterpriseDisplayName = "Lastname,Firstname (DEPT) COMPANY-CITY";
       vi.mocked(prisma.user.create).mockResolvedValueOnce({
         ...mockPrismaUser,
         name: enterpriseDisplayName,

--- a/packages/types/user.ts
+++ b/packages/types/user.ts
@@ -31,7 +31,7 @@ export const ZUserName = z
   .min(1, {
     error: "Name should be at least 1 character long",
   })
-  .regex(/^[\p{L}\p{M}\s'\d-]+$/u, "Invalid name format");
+  .regex(/^[\p{L}\p{M}\s',()\d-]+$/u, "Invalid name format");
 
 export const ZUserEmail = z
   .email({

--- a/packages/types/user.ts
+++ b/packages/types/user.ts
@@ -31,7 +31,7 @@ export const ZUserName = z
   .min(1, {
     error: "Name should be at least 1 character long",
   })
-  .regex(/^[\p{L}\p{M}\s',()\d-]+$/u, "Invalid name format");
+  .regex(/^[\p{L}\p{M} ',()\d-]+$/u, "Invalid name format");
 
 export const ZUserEmail = z
   .email({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Backports #8099 to `release/5.0`.

Allows user display names containing commas and parentheses so Azure AD OAuth name claims in the enterprise format, for example `Lastname,Firstname (DEPT) COMPANY-CITY`, pass shared name validation.

Also tightens the whitespace allowlist from all regex whitespace (`\s`) to a literal space so tabs/newlines are rejected.

Fixes #(issue)

## How should this be tested?

- `pnpm --filter @formbricks/web exec dotenv -e ../../.env -- vitest run modules/auth/lib/user.test.ts`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc422e88-51bb-47bc-902c-56d89f36ed8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc422e88-51bb-47bc-902c-56d89f36ed8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

