### PR TITLE
fix: backport localized contact-attribute add label to 5.0

### DIFF
--- a/apps/web/modules/ee/contacts/components/upload-contacts-attribute-combobox.tsx
+++ b/apps/web/modules/ee/contacts/components/upload-contacts-attribute-combobox.tsx
@@ -141,7 +141,7 @@ export const UploadContactsAttributeCombobox = ({
                       onClick={handleCreateKey}
                       className="h-8 w-full text-left hover:cursor-pointer hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
                       disabled={!!existingKeyMatch}>
-                      + Add {searchValue}
+                      + {t("common.add")} {searchValue.trim()}
                     </button>
                   ) : (
                     <div className="flex flex-col py-1 text-xs text-slate-500">


### PR DESCRIPTION
## Summary
- Backport the upload-contacts combobox label fix to localize the add action via `t(\"common.add\")`.
- Show the normalized key (`searchValue.trim()`) in the add label so the UI matches the key that is actually created.
- Skip the CSV table `scope=\"col\"` change because `release/5.0` uses a div/span grid in `csv-table.tsx` (no `<th>` exists in this branch), so that exact fix is not applicable without a larger refactor.

## Test plan
- [x] Verify diff only changes `apps/web/modules/ee/contacts/components/upload-contacts-attribute-combobox.tsx`
- [x] Run lints for the edited file (`ReadLints`) and confirm no errors
- [ ] Manual check in contacts upload flow that the add row now renders `+ Add <trimmed-key>` via i18n and still creates the same key


Made with [Cursor](https://cursor.com)