### PR TITLE
fix: order Helm Hub migrations after Prisma

### DIFF
--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -65,6 +65,7 @@ Cube is part of the baseline Formbricks v5 stack and is deployed by this chart b
 The chart deploys Hub API and, by default, a `hub-worker` deployment. Hub API is insert-only for River jobs; webhook dispatch and embedding jobs are processed by `hub-worker`.
 
 When the Formbricks migration job is enabled, Hub waits for the `formbricks-migration` Job to complete before its own goose/river init migrations run. This keeps fresh shared-database installs from creating Hub tables before Prisma has initialized the Formbricks schema.
+If the Job has already been cleaned up, Hub only continues after all expected Prisma and data migration success markers are present in the database.
 
 Self-hosted embeddings are disabled by default. Set `hub.embeddings.enabled=true` to deploy an internal Hugging Face Text Embeddings Inference (TEI) service and wire Hub API plus Hub worker to it through the OpenAI-compatible endpoint added in Hub:
 
@@ -129,7 +130,7 @@ Autoscaling is opt-in for Hub API, Hub worker, and the embeddings runtime. If yo
 | deployment.containerSecurityContext.runAsNonRoot                   | bool   | `true`                                                                      |                                                           |
 | deployment.env                                                     | object | `{}`                                                                        |                                                           |
 | deployment.envFrom                                                 | string | `nil`                                                                       |                                                           |
-| deployment.image.digest                                            | string | `""`                                                                        |                                                           |
+| deployment.image.digest                                            | string | `""`                                                                        | When set, takes precedence over tag.                      |
 | deployment.image.pullPolicy                                        | string | `"IfNotPresent"`                                                            |                                                           |
 | deployment.image.repository                                        | string | `"ghcr.io/formbricks/formbricks"`                                           |                                                           |
 | deployment.image.tag                                               | string | `""`                                                                        |                                                           |
@@ -224,7 +225,7 @@ Autoscaling is opt-in for Hub API, Hub worker, and the embeddings runtime. If yo
 | hub.migration.waitForFormbricksMigration.enabled                   | bool   | `true`                                                                      |                                                           |
 | hub.migration.waitForFormbricksMigration.intervalSeconds           | int    | `5`                                                                         |                                                           |
 | hub.migration.waitForFormbricksMigration.maxAttempts               | int    | `180`                                                                       |                                                           |
-| hub.migration.waitForFormbricksMigration.missingJobMaxAttempts     | int    | `12`                                                                        |                                                           |
+| hub.migration.waitForFormbricksMigration.missingJobMaxAttempts     | int    | `12`                                                                        | Consecutive missing Job reads before using DB markers.    |
 | hub.pdb.enabled                                                    | bool   | `false`                                                                     |                                                           |
 | hub.replicas                                                       | int    | `1`                                                                         |                                                           |
 | hub.resources.limits.memory                                        | string | `"512Mi"`                                                                   |                                                           |

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -64,6 +64,8 @@ Cube is part of the baseline Formbricks v5 stack and is deployed by this chart b
 
 The chart deploys Hub API and, by default, a `hub-worker` deployment. Hub API is insert-only for River jobs; webhook dispatch and embedding jobs are processed by `hub-worker`.
 
+When the Formbricks migration job is enabled, Hub waits for the `formbricks-migration` Job to complete before its own goose/river init migrations run. This keeps fresh shared-database installs from creating Hub tables before Prisma has initialized the Formbricks schema.
+
 Self-hosted embeddings are disabled by default. Set `hub.embeddings.enabled=true` to deploy an internal Hugging Face Text Embeddings Inference (TEI) service and wire Hub API plus Hub worker to it through the OpenAI-compatible endpoint added in Hub:
 
 ```yaml
@@ -219,6 +221,10 @@ Autoscaling is opt-in for Hub API, Hub worker, and the embeddings runtime. If yo
 | hub.migration.activeDeadlineSeconds                                | int    | `900`                                                                       |                                                           |
 | hub.migration.backoffLimit                                         | int    | `3`                                                                         |                                                           |
 | hub.migration.ttlSecondsAfterFinished                              | int    | `300`                                                                       |                                                           |
+| hub.migration.waitForFormbricksMigration.enabled                   | bool   | `true`                                                                      |                                                           |
+| hub.migration.waitForFormbricksMigration.intervalSeconds           | int    | `5`                                                                         |                                                           |
+| hub.migration.waitForFormbricksMigration.maxAttempts               | int    | `180`                                                                       |                                                           |
+| hub.migration.waitForFormbricksMigration.missingJobMaxAttempts     | int    | `12`                                                                        |                                                           |
 | hub.pdb.enabled                                                    | bool   | `false`                                                                     |                                                           |
 | hub.replicas                                                       | int    | `1`                                                                         |                                                           |
 | hub.resources.limits.memory                                        | string | `"512Mi"`                                                                   |                                                           |

--- a/charts/formbricks/templates/NOTES.txt
+++ b/charts/formbricks/templates/NOTES.txt
@@ -1,6 +1,6 @@
 
 
-{{ .Release.Name | camelcase }} with {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }} has been deployed successfully on {{ template "formbricks.namespace" .}} namespace !
+{{ .Release.Name | camelcase }} with {{ include "formbricks.deploymentImage" . }} has been deployed successfully on {{ template "formbricks.namespace" .}} namespace !
 
 Here's how you can access and manage your deployment:
 ---

--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -157,6 +157,17 @@ If `namespaceOverride` is provided, it will be used; otherwise, it defaults to `
 {{- printf "%s-migration" (include "formbricks.name" .) | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
+{{/*
+Formbricks application image reference. A configured digest takes precedence over the tag.
+*/}}
+{{- define "formbricks.deploymentImage" -}}
+{{- if .Values.deployment.image.digest -}}
+{{- printf "%s@%s" .Values.deployment.image.repository .Values.deployment.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.deployment.image.repository (.Values.deployment.image.tag | default .Chart.AppVersion | default "latest") -}}
+{{- end -}}
+{{- end }}
+
 {{- define "formbricks.hubSecretName" -}}
 {{- default (include "formbricks.appSecretName" .) .Values.hub.existingSecret -}}
 {{- end }}

--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -153,8 +153,16 @@ If `namespaceOverride` is provided, it will be used; otherwise, it defaults to `
 {{- .Values.redis.auth.existingSecretPasswordKey | default "REDIS_PASSWORD" -}}
 {{- end }}
 
+{{- define "formbricks.migrationJobName" -}}
+{{- printf "%s-migration" (include "formbricks.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
 {{- define "formbricks.hubSecretName" -}}
 {{- default (include "formbricks.appSecretName" .) .Values.hub.existingSecret -}}
+{{- end }}
+
+{{- define "formbricks.hubMigrationWaitServiceAccountName" -}}
+{{- printf "%s-migration-wait" (include "formbricks.hubname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
 {{/*

--- a/charts/formbricks/templates/deployment.yaml
+++ b/charts/formbricks/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds | default 30 }}
       containers:
         - name: {{ template "formbricks.name" . }}
-          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion | default "latest" }}
+          image: {{ include "formbricks.deploymentImage" . }}
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           {{- if .Values.deployment.command }}
           command:

--- a/charts/formbricks/templates/hub-deployment.yaml
+++ b/charts/formbricks/templates/hub-deployment.yaml
@@ -39,22 +39,35 @@ spec:
       initContainers:
         {{- if and .Values.migration.enabled .Values.hub.migration.waitForFormbricksMigration.enabled }}
         - name: wait-for-formbricks-migration
-          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion | default "latest" }}
+          image: {{ include "formbricks.deploymentImage" . }}
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           command:
             - node
             - -e
             - |
               const fs = require("fs");
+              const fsp = fs.promises;
               const https = require("https");
+              const path = require("path");
+              const { pathToFileURL } = require("url");
+              const { Prisma, PrismaClient } = require("@prisma/client");
 
-              const maxAttempts = Number.parseInt(process.env.FORMBRICKS_MIGRATION_WAIT_MAX_ATTEMPTS || "180", 10);
-              const missingJobMaxAttempts = Number.parseInt(
-                process.env.FORMBRICKS_MIGRATION_WAIT_MISSING_JOB_MAX_ATTEMPTS || "12",
-                10
+              const parsePositiveInteger = (value, fallback) => {
+                const parsed = Number.parseInt(value || "", 10);
+                return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+              };
+              const maxAttempts = parsePositiveInteger(process.env.FORMBRICKS_MIGRATION_WAIT_MAX_ATTEMPTS, 180);
+              const missingJobMaxAttempts = parsePositiveInteger(
+                process.env.FORMBRICKS_MIGRATION_WAIT_MISSING_JOB_MAX_ATTEMPTS,
+                12
               );
-              const intervalSeconds = Number.parseInt(process.env.FORMBRICKS_MIGRATION_WAIT_INTERVAL_SECONDS || "5", 10);
+              const intervalSeconds = parsePositiveInteger(
+                process.env.FORMBRICKS_MIGRATION_WAIT_INTERVAL_SECONDS,
+                5
+              );
               const jobName = process.env.FORMBRICKS_MIGRATION_JOB_NAME;
+              const migrationsDir = path.resolve("packages/database/dist/migration");
+              const prisma = new PrismaClient();
               const namespace = fs
                 .readFileSync("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "utf8")
                 .trim();
@@ -102,10 +115,125 @@ spec:
                   request.end();
                 });
 
+              const loadExpectedMigrationMarkers = async () => {
+                const entries = await fsp.readdir(migrationsDir, { withFileTypes: true });
+                const schemaMigrationNames = [];
+                const dataMigrationIds = [];
+
+                const migrationEntries = entries
+                  .filter((dirent) => dirent.isDirectory())
+                  .sort((a, b) => a.name.localeCompare(b.name));
+
+                for (const entry of migrationEntries) {
+                  const migrationPath = path.join(migrationsDir, entry.name);
+                  const files = await fsp.readdir(migrationPath);
+
+                  if (files.includes("migration.sql")) {
+                    schemaMigrationNames.push(entry.name);
+                  }
+
+                  if (files.includes("migration.js")) {
+                    const migrationModule = await import(
+                      pathToFileURL(path.join(migrationPath, "migration.js")).href
+                    );
+
+                    for (const exportedValue of Object.values(migrationModule)) {
+                      if (
+                        exportedValue &&
+                        typeof exportedValue === "object" &&
+                        exportedValue.type === "data" &&
+                        exportedValue.id
+                      ) {
+                        dataMigrationIds.push(exportedValue.id);
+                      }
+                    }
+                  }
+                }
+
+                return { schemaMigrationNames, dataMigrationIds };
+              };
+
+              let expectedMigrationMarkersPromise;
+              const getExpectedMigrationMarkers = () => {
+                if (!expectedMigrationMarkersPromise) {
+                  expectedMigrationMarkersPromise = loadExpectedMigrationMarkers();
+                }
+
+                return expectedMigrationMarkersPromise;
+              };
+
+              const hasFormbricksMigrationSuccessMarkers = async () => {
+                try {
+                  const { schemaMigrationNames, dataMigrationIds } = await getExpectedMigrationMarkers();
+
+                  // apply-migrations.js persists success in these DB tables after Prisma/data migrations complete.
+                  if (schemaMigrationNames.length === 0) {
+                    console.log(
+                      `No schema migrations found in ${migrationsDir}; refusing missing-Job success fallback.`
+                    );
+                    return false;
+                  }
+
+                  const appliedSchemaMigrations = await prisma.$queryRaw`
+                    SELECT migration_name
+                    FROM _prisma_migrations
+                    WHERE finished_at IS NOT NULL
+                      AND rolled_back_at IS NULL
+                      AND migration_name IN (${Prisma.join(schemaMigrationNames)})
+                  `;
+                  const appliedSchemaMigrationNames = new Set(
+                    appliedSchemaMigrations.map((migration) => migration.migration_name)
+                  );
+                  const missingSchemaMigrations = schemaMigrationNames.filter(
+                    (migrationName) => !appliedSchemaMigrationNames.has(migrationName)
+                  );
+
+                  if (missingSchemaMigrations.length > 0) {
+                    console.log(
+                      `Prisma migration markers are incomplete; ${missingSchemaMigrations.length} schema migration(s) are missing.`
+                    );
+                    return false;
+                  }
+
+                  if (dataMigrationIds.length === 0) {
+                    return true;
+                  }
+
+                  const appliedDataMigrations = await prisma.$queryRaw`
+                    SELECT id
+                    FROM "DataMigration"
+                    WHERE status = 'applied'
+                      AND id IN (${Prisma.join(dataMigrationIds)})
+                  `;
+                  const appliedDataMigrationIds = new Set(
+                    appliedDataMigrations.map((migration) => migration.id)
+                  );
+                  const missingDataMigrations = dataMigrationIds.filter(
+                    (migrationId) => !appliedDataMigrationIds.has(migrationId)
+                  );
+
+                  if (missingDataMigrations.length > 0) {
+                    console.log(
+                      `Data migration markers are incomplete; ${missingDataMigrations.length} data migration(s) are missing.`
+                    );
+                    return false;
+                  }
+
+                  return true;
+                } catch (error) {
+                  const message = error instanceof Error ? error.message : String(error);
+                  console.log(`Migration success markers are not ready: ${message}`);
+                  return false;
+                }
+              };
+
               (async () => {
+                let missingJobAttempts = 0;
+
                 for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
                   try {
                     const job = await fetchJob();
+                    missingJobAttempts = 0;
                     const conditions = job.status?.conditions || [];
                     const isComplete = conditions.some(
                       (condition) => condition.type === "Complete" && condition.status === "True"
@@ -128,12 +256,30 @@ spec:
                     console.log(`Waiting for ${jobName} to complete (${attempt}/${maxAttempts})...`);
                   } catch (error) {
                     const message = error instanceof Error ? error.message : String(error);
-                    if (error && error.statusCode === 404 && attempt >= missingJobMaxAttempts) {
-                      console.log(`${jobName} was not found after ${attempt} attempts; assuming it was already cleaned up.`);
-                      return;
-                    }
+                    if (error && error.statusCode === 404) {
+                      missingJobAttempts += 1;
 
-                    console.log(`Waiting for ${jobName} to be available (${attempt}/${maxAttempts}): ${message}`);
+                      if (missingJobAttempts >= missingJobMaxAttempts) {
+                        const hasSuccessMarkers = await hasFormbricksMigrationSuccessMarkers();
+
+                        if (hasSuccessMarkers) {
+                          console.log(
+                            `${jobName} was not found after ${missingJobAttempts} consecutive attempts, ` +
+                              "but all Formbricks migration success markers are present; starting Hub migrations."
+                          );
+                          return;
+                        }
+                      }
+
+                      console.log(
+                        `Waiting for ${jobName} to be available (${attempt}/${maxAttempts}; missing ${missingJobAttempts}/${missingJobMaxAttempts}): ${message}`
+                      );
+                    } else {
+                      missingJobAttempts = 0;
+                      console.log(
+                        `Waiting for ${jobName} to be available (${attempt}/${maxAttempts}): ${message}`
+                      );
+                    }
                   }
 
                   await sleep(intervalSeconds * 1000);
@@ -145,8 +291,45 @@ spec:
                 .catch((error) => {
                   console.error(error);
                   process.exitCode = 1;
+                })
+                .finally(async () => {
+                  await prisma.$disconnect().catch((error) => {
+                    console.error(error);
+                  });
                 });
+          {{- if or .Values.deployment.envFrom (or (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) .Values.secret.enabled) }}
+          envFrom:
+          {{- if or .Values.secret.enabled (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) }}
+          - secretRef:
+              name: {{ template "formbricks.name" . }}-app-secrets
+          {{- end }}
+          {{- range $value := .Values.deployment.envFrom }}
+          {{- if (eq .type "configmap") }}
+          - configMapRef:
+              {{- if .name }}
+              name: {{ include "formbricks.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
+              {{- else if .nameSuffix }}
+              name: {{ template "formbricks.name" $ }}-{{ include "formbricks.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
+              {{- else }}
+              name: {{ template "formbricks.name" $ }}
+              {{- end }}
+          {{- end }}
+          {{- if (eq .type "secret") }}
+          - secretRef:
+              {{- if .name }}
+              name: {{ include "formbricks.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
+              {{- else if .nameSuffix }}
+              name: {{ template "formbricks.name" $ }}-{{ include "formbricks.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
+              {{- else }}
+              name: {{ template "formbricks.name" $ }}
+              {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- end }}
           env:
+            {{- range $key, $value := .Values.deployment.env }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
+            {{- end }}
             - name: FORMBRICKS_MIGRATION_JOB_NAME
               value: {{ include "formbricks.migrationJobName" . | quote }}
             - name: FORMBRICKS_MIGRATION_WAIT_MAX_ATTEMPTS

--- a/charts/formbricks/templates/hub-deployment.yaml
+++ b/charts/formbricks/templates/hub-deployment.yaml
@@ -32,7 +32,134 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.deployment.imagePullSecrets | nindent 8 }}
       {{- end }}
+      {{- if and .Values.migration.enabled .Values.hub.migration.waitForFormbricksMigration.enabled }}
+      serviceAccountName: {{ include "formbricks.hubMigrationWaitServiceAccountName" . }}
+      automountServiceAccountToken: true
+      {{- end }}
       initContainers:
+        {{- if and .Values.migration.enabled .Values.hub.migration.waitForFormbricksMigration.enabled }}
+        - name: wait-for-formbricks-migration
+          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion | default "latest" }}
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+          command:
+            - node
+            - -e
+            - |
+              const fs = require("fs");
+              const https = require("https");
+
+              const maxAttempts = Number.parseInt(process.env.FORMBRICKS_MIGRATION_WAIT_MAX_ATTEMPTS || "180", 10);
+              const missingJobMaxAttempts = Number.parseInt(
+                process.env.FORMBRICKS_MIGRATION_WAIT_MISSING_JOB_MAX_ATTEMPTS || "12",
+                10
+              );
+              const intervalSeconds = Number.parseInt(process.env.FORMBRICKS_MIGRATION_WAIT_INTERVAL_SECONDS || "5", 10);
+              const jobName = process.env.FORMBRICKS_MIGRATION_JOB_NAME;
+              const namespace = fs
+                .readFileSync("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "utf8")
+                .trim();
+              const token = fs.readFileSync("/var/run/secrets/kubernetes.io/serviceaccount/token", "utf8");
+              const ca = fs.readFileSync("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt");
+              const host = process.env.KUBERNETES_SERVICE_HOST;
+              const port = process.env.KUBERNETES_SERVICE_PORT || "443";
+              const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+              const jobPath = `/apis/batch/v1/namespaces/${namespace}/jobs/${jobName}`;
+
+              const fetchJob = () =>
+                new Promise((resolve, reject) => {
+                  const request = https.request(
+                    {
+                      host,
+                      port,
+                      path: jobPath,
+                      method: "GET",
+                      ca,
+                      headers: {
+                        Authorization: `Bearer ${token}`,
+                      },
+                    },
+                    (response) => {
+                      let body = "";
+
+                      response.setEncoding("utf8");
+                      response.on("data", (chunk) => {
+                        body += chunk;
+                      });
+                      response.on("end", () => {
+                        if (response.statusCode >= 200 && response.statusCode < 300) {
+                          resolve(JSON.parse(body));
+                          return;
+                        }
+
+                        const error = new Error(`Kubernetes API returned ${response.statusCode}: ${body}`);
+                        error.statusCode = response.statusCode;
+                        reject(error);
+                      });
+                    }
+                  );
+
+                  request.on("error", reject);
+                  request.end();
+                });
+
+              (async () => {
+                for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+                  try {
+                    const job = await fetchJob();
+                    const conditions = job.status?.conditions || [];
+                    const isComplete = conditions.some(
+                      (condition) => condition.type === "Complete" && condition.status === "True"
+                    );
+                    const isFailed = conditions.some(
+                      (condition) => condition.type === "Failed" && condition.status === "True"
+                    );
+
+                    if (isComplete) {
+                      console.log(`${jobName} completed; starting Hub migrations.`);
+                      return;
+                    }
+
+                    if (isFailed) {
+                      console.error(`${jobName} failed; refusing to start Hub migrations.`);
+                      process.exitCode = 1;
+                      return;
+                    }
+
+                    console.log(`Waiting for ${jobName} to complete (${attempt}/${maxAttempts})...`);
+                  } catch (error) {
+                    const message = error instanceof Error ? error.message : String(error);
+                    if (error && error.statusCode === 404 && attempt >= missingJobMaxAttempts) {
+                      console.log(`${jobName} was not found after ${attempt} attempts; assuming it was already cleaned up.`);
+                      return;
+                    }
+
+                    console.log(`Waiting for ${jobName} to be available (${attempt}/${maxAttempts}): ${message}`);
+                  }
+
+                  await sleep(intervalSeconds * 1000);
+                }
+
+                console.error(`Timed out waiting for ${jobName} after ${maxAttempts} attempts.`);
+                process.exitCode = 1;
+              })()
+                .catch((error) => {
+                  console.error(error);
+                  process.exitCode = 1;
+                });
+          env:
+            - name: FORMBRICKS_MIGRATION_JOB_NAME
+              value: {{ include "formbricks.migrationJobName" . | quote }}
+            - name: FORMBRICKS_MIGRATION_WAIT_MAX_ATTEMPTS
+              value: {{ .Values.hub.migration.waitForFormbricksMigration.maxAttempts | quote }}
+            - name: FORMBRICKS_MIGRATION_WAIT_MISSING_JOB_MAX_ATTEMPTS
+              value: {{ .Values.hub.migration.waitForFormbricksMigration.missingJobMaxAttempts | quote }}
+            - name: FORMBRICKS_MIGRATION_WAIT_INTERVAL_SECONDS
+              value: {{ .Values.hub.migration.waitForFormbricksMigration.intervalSeconds | quote }}
+          {{- if .Values.migration.resources }}
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
+          {{- end }}
+        {{- end }}
         - name: hub-migrate
           image: {{ include "formbricks.hubImage" . }}
           imagePullPolicy: {{ .Values.hub.image.pullPolicy }}

--- a/charts/formbricks/templates/hub-migration-wait-rbac.yaml
+++ b/charts/formbricks/templates/hub-migration-wait-rbac.yaml
@@ -1,0 +1,55 @@
+{{- if and .Values.migration.enabled .Values.hub.migration.waitForFormbricksMigration.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "formbricks.hubMigrationWaitServiceAccountName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.hubname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: hub-migration-wait
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "formbricks.hubMigrationWaitServiceAccountName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.hubname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: hub-migration-wait
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+rules:
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    resourceNames:
+      - {{ include "formbricks.migrationJobName" . }}
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "formbricks.hubMigrationWaitServiceAccountName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.hubname" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: hub-migration-wait
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "formbricks.hubMigrationWaitServiceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "formbricks.hubMigrationWaitServiceAccountName" . }}
+    namespace: {{ include "formbricks.namespace" . }}
+{{- end }}

--- a/charts/formbricks/templates/hub-migration-wait-rbac.yaml
+++ b/charts/formbricks/templates/hub-migration-wait-rbac.yaml
@@ -51,5 +51,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "formbricks.hubMigrationWaitServiceAccountName" . }}
-    namespace: {{ include "formbricks.namespace" . }}
+    namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/formbricks/templates/migration-job.yaml
+++ b/charts/formbricks/templates/migration-job.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       containers:
         - name: migration
-          image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag | default .Chart.AppVersion | default "latest" }}
+          image: {{ include "formbricks.deploymentImage" . }}
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           command:
             - node

--- a/charts/formbricks/templates/migration-job.yaml
+++ b/charts/formbricks/templates/migration-job.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ include "formbricks.name" . }}-migration
+  name: {{ include "formbricks.migrationJobName" . }}
   labels:
     {{- include "formbricks.labels" . | nindent 4 }}
   annotations:

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -939,6 +939,7 @@ hub:
     waitForFormbricksMigration:
       enabled: true
       maxAttempts: 180
+      # Consecutive missing Job reads before falling back to persisted Prisma/DataMigration markers.
       missingJobMaxAttempts: 12
       intervalSeconds: 5
 

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -936,6 +936,11 @@ hub:
     ttlSecondsAfterFinished: 300
     backoffLimit: 3
     activeDeadlineSeconds: 900
+    waitForFormbricksMigration:
+      enabled: true
+      maxAttempts: 180
+      missingJobMaxAttempts: 12
+      intervalSeconds: 5
 
   resources:
     limits:


### PR DESCRIPTION
## What does this PR do?

Fixes Linear ENG-1032.

This prevents fresh Helm installs with the bundled shared database from letting Hub/River migrations create the first tables before Formbricks Prisma migrations run. Hub now waits for the `formbricks-migration` Job to complete before the Hub goose/river init migration starts.

Changes included:

- adds a `wait-for-formbricks-migration` init container before Hub's `hub-migrate` init container
- adds a dedicated ServiceAccount, Role, and RoleBinding that can only `get` the specific Formbricks migration Job
- keeps the wait guard enabled only when `migration.enabled=true`
- handles later Hub pod restarts after the migration Job TTL cleanup by proceeding after a short missing-job grace window
- documents the new `hub.migration.waitForFormbricksMigration.*` values

## How should this be tested?

- `helm lint charts/formbricks --set formbricks.webappUrl=http://formbricks.local`
- `helm template eng1032 charts/formbricks --set formbricks.webappUrl=http://formbricks.local --show-only templates/hub-deployment.yaml --show-only templates/hub-migration-wait-rbac.yaml --show-only templates/migration-job.yaml`
- `helm template eng1032 charts/formbricks --set formbricks.webappUrl=http://formbricks.local | kubectl create --dry-run=client --validate=false -f -`
- `helm template eng1032 charts/formbricks --set formbricks.webappUrl=http://formbricks.local --set migration.enabled=false | rg -n "wait-for-formbricks-migration|formbricks-hub-migration-wait|FORMBRICKS_MIGRATION_WAIT"` returns no matches
- `helm template eng1032 charts/formbricks --set formbricks.webappUrl=http://formbricks.local --set hub.migration.waitForFormbricksMigration.enabled=false | rg -n "wait-for-formbricks-migration|formbricks-hub-migration-wait|FORMBRICKS_MIGRATION_WAIT"` returns no matches
- rendered wait script extracted from Helm output and checked with `node --check`
- `git diff --check`

Note: server-side Kubernetes dry-run was not available locally because the current minikube context is stopped / API server refused connections.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Checked for warnings, there are none from Helm lint/render validation
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] Ran `pnpm build` - not run; chart-only change validated with Helm and Kubernetes client dry-run
- [ ] My changes don't cause any responsiveness issues - not applicable; no UI changes

### Appreciated

- [x] Updated the Formbricks Docs if changes were necessary
