### PR TITLE
feat: [Backport] cascade delete Hub feedback records on org deletion (#8055)

### DIFF
--- a/apps/web/lib/organization/service.test.ts
+++ b/apps/web/lib/organization/service.test.ts
@@ -46,6 +46,10 @@ vi.mock("@/modules/ee/billing/lib/organization-billing", () => ({
   cleanupStripeCustomer: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("@/modules/hub/service", () => ({
+  deleteFeedbackRecordsByTenant: vi.fn().mockResolvedValue({ data: { deletedCount: 0 }, error: null }),
+}));
+
 describe("Organization Service", () => {
   beforeEach(() => {
     vi.mocked(ensureCloudStripeSetupForOrganization).mockResolvedValue(undefined);
@@ -350,6 +354,7 @@ describe("Organization Service", () => {
         billing: { stripeCustomerId: "cus_123" },
         memberships: [],
         workspaces: [],
+        feedbackDirectories: [],
       } as any);
 
       await deleteOrganization("org1");
@@ -357,6 +362,24 @@ describe("Organization Service", () => {
       if (IS_FORMBRICKS_CLOUD) {
         expect(cleanupStripeCustomer).toHaveBeenCalledWith("cus_123");
       }
+    });
+
+    test("should purge Hub feedback records for each feedback directory", async () => {
+      const { deleteFeedbackRecordsByTenant } = await import("@/modules/hub/service");
+      vi.mocked(prisma.organization.delete).mockResolvedValue({
+        id: "org1",
+        name: "Test Org",
+        billing: null,
+        memberships: [],
+        workspaces: [],
+        feedbackDirectories: [{ id: "frd_1" }, { id: "frd_2" }],
+      } as any);
+
+      await deleteOrganization("org1");
+
+      expect(deleteFeedbackRecordsByTenant).toHaveBeenCalledTimes(2);
+      expect(deleteFeedbackRecordsByTenant).toHaveBeenCalledWith("frd_1");
+      expect(deleteFeedbackRecordsByTenant).toHaveBeenCalledWith("frd_2");
     });
   });
 });

--- a/apps/web/lib/organization/service.test.ts
+++ b/apps/web/lib/organization/service.test.ts
@@ -47,7 +47,10 @@ vi.mock("@/modules/ee/billing/lib/organization-billing", () => ({
 }));
 
 vi.mock("@/modules/hub/service", () => ({
-  deleteFeedbackRecordsByTenant: vi.fn().mockResolvedValue({ data: { deletedCount: 0 }, error: null }),
+  deleteHubTenantData: vi.fn().mockResolvedValue({
+    data: { deletedFeedbackRecords: 0, deletedEmbeddings: 0, deletedWebhooks: 0 },
+    error: null,
+  }),
 }));
 
 describe("Organization Service", () => {
@@ -364,8 +367,8 @@ describe("Organization Service", () => {
       }
     });
 
-    test("should purge Hub feedback records for each feedback directory", async () => {
-      const { deleteFeedbackRecordsByTenant } = await import("@/modules/hub/service");
+    test("should purge Hub-owned data for each feedback directory", async () => {
+      const { deleteHubTenantData } = await import("@/modules/hub/service");
       vi.mocked(prisma.organization.delete).mockResolvedValue({
         id: "org1",
         name: "Test Org",
@@ -377,9 +380,9 @@ describe("Organization Service", () => {
 
       await deleteOrganization("org1");
 
-      expect(deleteFeedbackRecordsByTenant).toHaveBeenCalledTimes(2);
-      expect(deleteFeedbackRecordsByTenant).toHaveBeenCalledWith("frd_1");
-      expect(deleteFeedbackRecordsByTenant).toHaveBeenCalledWith("frd_2");
+      expect(deleteHubTenantData).toHaveBeenCalledTimes(2);
+      expect(deleteHubTenantData).toHaveBeenCalledWith("frd_1");
+      expect(deleteHubTenantData).toHaveBeenCalledWith("frd_2");
     });
   });
 });

--- a/apps/web/lib/organization/service.ts
+++ b/apps/web/lib/organization/service.ts
@@ -19,6 +19,7 @@ import { updateUser } from "@/lib/user/service";
 import { getBillingUsageCycleWindow } from "@/lib/utils/billing";
 import { getWorkspaces } from "@/lib/workspace/service";
 import { cleanupStripeCustomer } from "@/modules/ee/billing/lib/organization-billing";
+import { deleteFeedbackRecordsByTenant } from "@/modules/hub/service";
 import { validateInputs } from "../utils/validate";
 
 export const select = {
@@ -292,12 +293,23 @@ export const deleteOrganization = async (organizationId: string) => {
             id: true,
           },
         },
+        feedbackDirectories: {
+          select: {
+            id: true,
+          },
+        },
       },
     });
 
     const stripeCustomerId = deletedOrganization.billing?.stripeCustomerId;
     if (IS_FORMBRICKS_CLOUD && stripeCustomerId) {
       await cleanupStripeCustomer(stripeCustomerId);
+    }
+
+    // Best-effort: purge feedback records in the Hub for each directory tenant.
+    // Failures are logged inside the gateway and do not roll back the local delete.
+    for (const directory of deletedOrganization.feedbackDirectories) {
+      await deleteFeedbackRecordsByTenant(directory.id);
     }
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {

--- a/apps/web/lib/organization/service.ts
+++ b/apps/web/lib/organization/service.ts
@@ -19,7 +19,7 @@ import { updateUser } from "@/lib/user/service";
 import { getBillingUsageCycleWindow } from "@/lib/utils/billing";
 import { getWorkspaces } from "@/lib/workspace/service";
 import { cleanupStripeCustomer } from "@/modules/ee/billing/lib/organization-billing";
-import { deleteFeedbackRecordsByTenant } from "@/modules/hub/service";
+import { deleteHubTenantData } from "@/modules/hub/service";
 import { validateInputs } from "../utils/validate";
 
 export const select = {
@@ -306,10 +306,11 @@ export const deleteOrganization = async (organizationId: string) => {
       await cleanupStripeCustomer(stripeCustomerId);
     }
 
-    // Best-effort: purge feedback records in the Hub for each directory tenant.
-    // Failures are logged inside the gateway and do not roll back the local delete.
+    // Best-effort: purge Hub-owned data (feedback records, embeddings, webhooks) for each
+    // directory tenant. Failures are logged inside the gateway and do not roll back the
+    // local delete.
     for (const directory of deletedOrganization.feedbackDirectories) {
-      await deleteFeedbackRecordsByTenant(directory.id);
+      await deleteHubTenantData(directory.id);
     }
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {

--- a/apps/web/modules/hub/service.ts
+++ b/apps/web/modules/hub/service.ts
@@ -129,38 +129,51 @@ export const deleteFeedbackRecord = async (id: string): Promise<HubFeedbackRecor
   }
 };
 
-export type HubFeedbackRecordsByTenantDeleteResult = {
-  data: { deletedCount: number } | null;
+export type HubTenantDataDeleteResult = {
+  data: {
+    deletedFeedbackRecords: number;
+    deletedEmbeddings: number;
+    deletedWebhooks: number;
+  } | null;
   error: HubError | null;
 };
 
+type TenantDataDeleteResponse = {
+  tenant_id: string;
+  deleted_feedback_records: number;
+  deleted_embeddings: number;
+  deleted_webhooks: number;
+  message?: string;
+};
+
 /**
- * Delete all feedback records in the Hub for a given tenant.
- * Used when an organization (and its feedback directories) is deleted, so that
- * Hub-side records do not become orphaned.
+ * Purge all Hub-owned data (feedback records, derived embeddings, webhooks) for a tenant.
+ * Called when the owning organization is deleted so Hub-side rows don't become orphaned.
+ * Idempotent on the Hub side; the caller treats failures as best-effort.
  *
- * NOTE: depends on the Hub `bulkDelete` endpoint accepting a `tenant_id`-only
- * payload (no `user_id`). Until that ships, this call will fail with a 4xx and
- * be logged as a warning — caller treats this as best-effort.
+ * Hits `DELETE /v1/tenants/{tenant_id}/data` directly because the SDK doesn't yet expose
+ * a typed method for this endpoint.
  */
-export const deleteFeedbackRecordsByTenant = async (
-  tenantId: string
-): Promise<HubFeedbackRecordsByTenantDeleteResult> => {
+export const deleteHubTenantData = async (tenantId: string): Promise<HubTenantDataDeleteResult> => {
   const client = getHubClient();
   if (!client) {
     return { data: null, error: { ...NO_CONFIG_ERROR } };
   }
 
   try {
-    // Cast: SDK currently requires `user_id`. Hub-side change will accept a
-    // tenant-only payload; until the SDK types catch up we go through `unknown`.
-    const bulkDelete = client.feedbackRecords.bulkDelete as unknown as (params: {
-      tenant_id: string;
-    }) => Promise<{ deleted_count: number }>;
-    const data = await bulkDelete({ tenant_id: tenantId });
-    return { data: { deletedCount: data.deleted_count }, error: null };
+    const data = await client.delete<TenantDataDeleteResponse>(
+      `/v1/tenants/${encodeURIComponent(tenantId)}/data`
+    );
+    return {
+      data: {
+        deletedFeedbackRecords: data.deleted_feedback_records,
+        deletedEmbeddings: data.deleted_embeddings,
+        deletedWebhooks: data.deleted_webhooks,
+      },
+      error: null,
+    };
   } catch (err) {
-    logger.warn({ err, tenantId }, "Hub: deleteFeedbackRecordsByTenant failed");
+    logger.warn({ err, tenantId }, "Hub: deleteHubTenantData failed");
     const status = getErrorStatus(err);
     const message = getErrorMessage(err);
     return { data: null, error: { status, message, detail: message } };

--- a/apps/web/modules/hub/service.ts
+++ b/apps/web/modules/hub/service.ts
@@ -129,6 +129,44 @@ export const deleteFeedbackRecord = async (id: string): Promise<HubFeedbackRecor
   }
 };
 
+export type HubFeedbackRecordsByTenantDeleteResult = {
+  data: { deletedCount: number } | null;
+  error: HubError | null;
+};
+
+/**
+ * Delete all feedback records in the Hub for a given tenant.
+ * Used when an organization (and its feedback directories) is deleted, so that
+ * Hub-side records do not become orphaned.
+ *
+ * NOTE: depends on the Hub `bulkDelete` endpoint accepting a `tenant_id`-only
+ * payload (no `user_id`). Until that ships, this call will fail with a 4xx and
+ * be logged as a warning — caller treats this as best-effort.
+ */
+export const deleteFeedbackRecordsByTenant = async (
+  tenantId: string
+): Promise<HubFeedbackRecordsByTenantDeleteResult> => {
+  const client = getHubClient();
+  if (!client) {
+    return { data: null, error: { ...NO_CONFIG_ERROR } };
+  }
+
+  try {
+    // Cast: SDK currently requires `user_id`. Hub-side change will accept a
+    // tenant-only payload; until the SDK types catch up we go through `unknown`.
+    const bulkDelete = client.feedbackRecords.bulkDelete as unknown as (params: {
+      tenant_id: string;
+    }) => Promise<{ deleted_count: number }>;
+    const data = await bulkDelete({ tenant_id: tenantId });
+    return { data: { deletedCount: data.deleted_count }, error: null };
+  } catch (err) {
+    logger.warn({ err, tenantId }, "Hub: deleteFeedbackRecordsByTenant failed");
+    const status = getErrorStatus(err);
+    const message = getErrorMessage(err);
+    return { data: null, error: { status, message, detail: message } };
+  }
+};
+
 export type ListFeedbackRecordsResult = {
   data: FeedbackRecordListResponse | null;
   error: HubError | null;

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -670,10 +670,10 @@ hub:
     # Pinned by digest for immutable, reproducible deployments. When digest is set it takes
     # precedence over tag, and deployment, init container, and migration job all resolve to the
     # same immutable image. Update on each Hub release.
-    # Current digest corresponds to ghcr.io/formbricks/hub:0.3.0.
-    digest: "sha256:6c39b1143527137e881df785a5b668625a1fe3edb05485bb5ded19f813c8de88"
+    # Current digest corresponds to ghcr.io/formbricks/hub:0.4.0.
+    digest: "sha256:3971dd15fcce22d438ac916266ed72176052460a2bd91808e0995e894faba5bc"
     # Tag is a fallback for dev/non-prod when digest is cleared; keep aligned with the digest above.
-    tag: "0.3.0"
+    tag: "0.4.0"
     pullPolicy: IfNotPresent
 
   # Optional override for the secret Hub reads from.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -97,7 +97,7 @@ services:
   # Keep hub, hub-migrate, and any future hub-worker on the same tag — they share one image and
   # drift breaks migrations or job processing.
   hub-migrate:
-    image: ghcr.io/formbricks/hub:${HUB_IMAGE_TAG:-0.3.0}
+    image: ghcr.io/formbricks/hub:${HUB_IMAGE_TAG:-0.4.0}
     restart: "no"
     entrypoint: ["sh", "-c"]
     command:
@@ -112,7 +112,7 @@ services:
 
   # Formbricks Hub API (ghcr.io/formbricks/hub). Uses a dedicated local Hub database by default.
   hub:
-    image: ghcr.io/formbricks/hub:${HUB_IMAGE_TAG:-0.3.0}
+    image: ghcr.io/formbricks/hub:${HUB_IMAGE_TAG:-0.4.0}
     depends_on:
       hub-migrate:
         condition: service_completed_successfully
@@ -142,7 +142,7 @@ services:
 
   # Hub worker processes async jobs enqueued by the API, including embeddings.
   hub-worker:
-    image: ghcr.io/formbricks/hub:${HUB_IMAGE_TAG:-0.3.0}
+    image: ghcr.io/formbricks/hub:${HUB_IMAGE_TAG:-0.4.0}
     depends_on:
       hub-migrate:
         condition: service_completed_successfully


### PR DESCRIPTION
Backport of #8055 to release/5.0.

## Summary
- `deleteOrganization` fetches each `FeedbackDirectory.id` (= Hub tenant_id) and calls `deleteHubTenantData` after the Prisma cascade clears local rows.
- New `deleteHubTenantData` wrapper in `apps/web/modules/hub/service.ts` hits `DELETE /v1/tenants/{tenant_id}/data` on Hub. Best-effort: failures are logged and never roll back the org deletion.
- Bumps the bundled Hub image to **0.4.0** (dev-compose default + Helm chart digest/tag) since the tenant-scoped delete endpoint is first available there.

## Notes
- Skipped the `modules/hub/service.test.ts` coverage additions from the original PR thread. The `lib/organization/service.test.ts` update (which exercises the cascade path) is included.
- No app-side SDK bump needed — the call uses `client.delete<T>(path)` directly.

## Test plan
- [x] `pnpm vitest run lib/organization/service.test.ts modules/hub/service.test.ts` — 39 passing
- [x] Manual: against local Hub 0.4.0, delete an org with feedback records and confirm `DELETE /v1/tenants/{tenant_id}/data` returns 200 and Hub rows are gone.