### PR TITLE
fix: fixes read only webhook issue

### DIFF
--- a/apps/web/modules/integrations/webhooks/actions.ts
+++ b/apps/web/modules/integrations/webhooks/actions.ts
@@ -157,7 +157,7 @@ export const testEndpointAction = authenticatedActionClient
           },
           {
             type: "workspaceTeam",
-            minPermission: "read",
+            minPermission: "readWrite",
             workspaceId: await getWorkspaceIdFromWebhookId(parsedInput.webhookId),
           },
         ],

--- a/apps/web/modules/integrations/webhooks/components/webhook-settings-tab.tsx
+++ b/apps/web/modules/integrations/webhooks/components/webhook-settings-tab.tsx
@@ -196,9 +196,9 @@ export const WebhookSettingsTab = ({
               onChange={(e) => {
                 setTestEndpointInput(e.target.value);
               }}
-              readOnly={webhook.source !== "user"}
+              readOnly={isReadOnly}
               className={clsx(
-                webhook.source === "user" ? null : "cursor-not-allowed bg-slate-100 text-slate-500",
+                isReadOnly ? "cursor-not-allowed bg-slate-100 text-slate-500" : null,
                 endpointAccessible === true
                   ? "border-green-500 bg-green-50"
                   : endpointAccessible === false
@@ -209,16 +209,18 @@ export const WebhookSettingsTab = ({
               )}
               placeholder={t("workspace.integrations.webhooks.webhook_url_placeholder")}
             />
-            <Button
-              type="button"
-              variant="secondary"
-              loading={hittingEndpoint}
-              className="ml-2 whitespace-nowrap"
-              onClick={() => {
-                handleTestEndpoint(true);
-              }}>
-              {t("workspace.integrations.webhooks.test_endpoint")}
-            </Button>
+            {!isReadOnly && (
+              <Button
+                type="button"
+                variant="secondary"
+                loading={hittingEndpoint}
+                className="ml-2 whitespace-nowrap"
+                onClick={() => {
+                  handleTestEndpoint(true);
+                }}>
+                {t("workspace.integrations.webhooks.test_endpoint")}
+              </Button>
+            )}
           </div>
         </div>
 
@@ -281,7 +283,7 @@ export const WebhookSettingsTab = ({
           <TriggerCheckboxGroup
             selectedTriggers={selectedTriggers}
             onCheckboxChange={handleCheckboxChange}
-            allowChanges={webhook.source === "user" && !isReadOnly}
+            allowChanges={!isReadOnly}
           />
         </div>
 
@@ -293,7 +295,7 @@ export const WebhookSettingsTab = ({
             selectedAllSurveys={selectedAllSurveys}
             onSelectAllSurveys={handleSelectAllSurveys}
             onSelectedSurveyChange={handleSelectedSurveyChange}
-            allowChanges={webhook.source === "user" && !isReadOnly}
+            allowChanges={!isReadOnly}
           />
         </div>
 

--- a/apps/web/modules/integrations/webhooks/components/webhook-settings-tab.tsx
+++ b/apps/web/modules/integrations/webhooks/components/webhook-settings-tab.tsx
@@ -198,7 +198,9 @@ export const WebhookSettingsTab = ({
               }}
               readOnly={isReadOnly || webhook.source !== "user"}
               className={clsx(
-                isReadOnly ? "cursor-not-allowed bg-slate-100 text-slate-500" : null,
+                isReadOnly || webhook.source !== "user"
+                  ? "cursor-not-allowed bg-slate-100 text-slate-500"
+                  : null,
                 endpointAccessible === true
                   ? "border-green-500 bg-green-50"
                   : endpointAccessible === false
@@ -295,7 +297,7 @@ export const WebhookSettingsTab = ({
             selectedAllSurveys={selectedAllSurveys}
             onSelectAllSurveys={handleSelectAllSurveys}
             onSelectedSurveyChange={handleSelectedSurveyChange}
-            allowChanges={!isReadOnly}
+            allowChanges={webhook.source === "user" && !isReadOnly}
           />
         </div>
 

--- a/apps/web/modules/integrations/webhooks/components/webhook-settings-tab.tsx
+++ b/apps/web/modules/integrations/webhooks/components/webhook-settings-tab.tsx
@@ -196,7 +196,7 @@ export const WebhookSettingsTab = ({
               onChange={(e) => {
                 setTestEndpointInput(e.target.value);
               }}
-              readOnly={isReadOnly}
+              readOnly={isReadOnly || webhook.source !== "user"}
               className={clsx(
                 isReadOnly ? "cursor-not-allowed bg-slate-100 text-slate-500" : null,
                 endpointAccessible === true
@@ -283,7 +283,7 @@ export const WebhookSettingsTab = ({
           <TriggerCheckboxGroup
             selectedTriggers={selectedTriggers}
             onCheckboxChange={handleCheckboxChange}
-            allowChanges={!isReadOnly}
+            allowChanges={webhook.source === "user" && !isReadOnly}
           />
         </div>
 


### PR DESCRIPTION
## What does this PR do?

Fixes https://linear.app/formbricks/issue/ENG-814

  Hardens webhook Test Endpoint flow against authorization bypass by read-only workspace members.

  **Background:** Security advisory flagged that read-only project/workspace members could trigger server-side outbound HTTP from the webhook Test Endpoint UI. The redirect-following SSRF portion of the advisory was already mitigated by PR #7877 (`redirect: "manual"` + explicit 30x rejection) and PR #7954 (TCP pinning via undici `Agent` to close DNS-rebind TOCTOU). This PR closes the residual authorization gap.

  **Changes:**
  - `testEndpointAction` now requires `workspaceTeam` `minPermission: "readWrite"` (was `"read"`). Read-only members can no longer trigger outbound requests using a stored webhook's secret.
 - Webhook Settings tab UI gated on `isReadOnly`:
 - URL input is `readOnly` for read-only viewers
 - Test Endpoint button hidden for read-only viewers
 - Triggers / Surveys checkbox groups locked for read-only viewers

  **Files touched:**
  - `apps/web/modules/integrations/webhooks/actions.ts`
  - `apps/web/modules/integrations/webhooks/components/webhook-settings-tab.tsx`

  ## How should this be tested?

  **Setup**
  - Org with two users: User A (owner), User B (workspace member with `read` perm only).
  - User A creates a webhook via the Webhooks UI (source = `user`).

  **1. Read-only UI gating (User B)**
  - Open Webhooks page → click the webhook → Settings tab.
  - URL input is read-only (gray bg, `cursor-not-allowed`).
  - Test Endpoint button is **not** rendered.
  - Triggers and Surveys checkbox groups are disabled.
  - Delete and Save buttons absent (pre-existing behavior).

  **2. Server-side authorization (User B bypasses UI)**
  - Temporarily remove the `!isReadOnly` gate around the Test Endpoint button locally, click Test Endpoint as User B.
  - Expected: server rejects with authorization error (`readWrite` required). Confirms client gate is defense-in-depth, not the sole barrier.

  **3. Owner regression (User A)**
  - URL input editable, Test Endpoint button present.
  - Clicking Test Endpoint with a valid public URL → success toast "endpoint pinged".
  - Editing URL + Save persists the change.
  - Triggers/Surveys toggles work.

  **4. New-webhook flow regression**
  - Add Webhook modal: URL field editable, Test Endpoint button works (path without `webhookId` unchanged).

  **5. SSRF defense-in-depth still works (User A)**
  - Webhook URL: `https://httpbin.org/redirect-to?url=http://169.254.169.254/`
  - Test Endpoint → fails with "Webhook endpoint returned a redirect, which is not allowed".
  - Webhook URL: `http://127.0.0.1:3000/` → fails with "Webhook URL must not point to private or internal IP addresses".

  **6. 3rd-party webhook editing (tradeoff confirmation)**
  - Connect a Zapier/n8n integration to create a webhook with `source !== "user"`.
  - As owner, confirm URL/Triggers/Surveys are now editable (previously locked). This is intentional — verify the integration provider's flow still owns its config
  server-side.

  **Automated**
  ```bash
  pnpm --filter=@formbricks/web test apps/web/modules/integrations/webhooks
  pnpm --filter=@formbricks/web test apps/web/lib/utils/validate-webhook-url
  pnpm build
```

  Checklist

  Required

  - Filled out the "How to test" section in this PR
  - Read How we Code at Formbricks (https://formbricks.com/docs/contributing/how-we-code)
  - Self-reviewed my own code
  - Commented on my code in hard-to-understand bits
  - Ran pnpm build
  - Checked for warnings, there are none
  - Removed all console.logs
  - Merged the latest changes from main onto my branch with git pull origin main
  - My changes don't cause any responsiveness issues
  - First PR at Formbricks? Please sign the CLA! (https://cla-assistant.io/formbricks/formbricks)

  Appreciated

  - If a UI change was made: Added a screen recording or screenshots to this PR
  - Updated the Formbricks Docs if changes were necessary