### PR TITLE
fix: pin Dockerfile global package versions for reproducible builds

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -20,7 +20,7 @@ FROM base AS installer
 # Enable corepack and prepare pnpm
 RUN npm install --ignore-scripts -g corepack@0.35.0
 RUN corepack enable
-RUN corepack prepare pnpm@10.28.2 --activate
+RUN corepack prepare pnpm@10.32.1 --activate
 
 # Install necessary build tools and compilers
 RUN apk update && apk add --no-cache cmake g++ gcc jq make openssl-dev python3

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -18,7 +18,7 @@ FROM node:24-alpine3.23 AS base
 FROM base AS installer
 
 # Enable corepack and prepare pnpm
-RUN npm install --ignore-scripts -g corepack@latest
+RUN npm install --ignore-scripts -g corepack@0.35.0
 RUN corepack enable
 RUN corepack prepare pnpm@10.28.2 --activate
 
@@ -56,7 +56,7 @@ COPY . .
 RUN touch apps/web/.env
 
 # Install the dependencies
-RUN pnpm install --ignore-scripts
+RUN pnpm install --ignore-scripts --frozen-lockfile
 
 # Build the database package first
 RUN pnpm build --filter=@formbricks/database
@@ -82,7 +82,7 @@ FROM base AS runner
 # Upgrade Alpine system packages to pick up security patches, update npm to latest, then create user
 # Note: npm's bundled tar has a known vulnerability but npm is only used during build, not at runtime
 RUN apk update && apk upgrade --no-cache \
-    && npm install --ignore-scripts -g npm@latest \
+    && npm install --ignore-scripts -g npm@11.15.0 \
     && addgroup -S nextjs \
     && adduser -S -u 1001 -G nextjs nextjs
 
@@ -155,7 +155,7 @@ COPY --from=installer /app/node_modules/otlp-logger ./node_modules/otlp-logger
 RUN chmod -R 755 ./node_modules/otlp-logger
 
 # Install prisma CLI globally for database migrations and fix permissions for nextjs user
-RUN npm install --ignore-scripts -g prisma@6 \
+RUN npm install --ignore-scripts -g prisma@6.19.3 \
     && chown -R nextjs:nextjs /usr/local/lib/node_modules/prisma
 
 # Create a startup script to handle the conditional logic


### PR DESCRIPTION
## Summary

Resolves four `docker:S8543` (MAJOR, SECURITY-impact) SonarQube findings on `apps/web/Dockerfile` by replacing floating tags with pinned versions, so a compromised or accidental upstream tag swap can't land in our build images.

| Line | Before | After |
| --- | --- | --- |
| 21 | `corepack@latest` | `corepack@0.35.0` |
| 59 | `pnpm install --ignore-scripts` | `pnpm install --ignore-scripts --frozen-lockfile` |
| 85 | `npm@latest` | `npm@11.15.0` |
| 158 | `prisma@6` (semver range) | `prisma@6.19.3` (matches `packages/database/package.json`) |

Versions chosen:
- `corepack@0.35.0`, `npm@11.15.0` — current `latest` on npm registry at the time of this PR
- `prisma@6.19.3` — exact match for the declared dependency, so the global CLI no longer drifts from what the codebase is compiled against
- `--frozen-lockfile` — Docker builds now fail rather than silently regenerating `pnpm-lock.yaml`

These pins should be bumped intentionally (via PR) when we want to take new versions; that's the point.

## Related

- The remaining tracked security item — Security Hotspot `typescript:S2068` on `apps/web/playwright/utils/mock.ts:1` (`MOCK_PASSWORD = "Mock_password_for_testing_0nly"`) — has been **marked SAFE in SonarQube** with a review comment explaining it's a test fixture. No code change needed.
- The two BLOCKER `secrets:S8215` bcrypt control-hash findings are handled in #8122.

## Test plan

- [ ] CI builds the `apps/web` Docker image successfully with the pinned versions
- [ ] `--frozen-lockfile` does not error against the committed `pnpm-lock.yaml`
- [ ] Once Sonar re-scans, the four `docker:S8543` findings on `apps/web/Dockerfile` are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)