### PR TITLE
fix: add missing JSX key props in segment-filter SelectItem lists

### DIFF
--- a/apps/web/modules/ee/contacts/segments/components/segment-filter.tsx
+++ b/apps/web/modules/ee/contacts/segments/components/segment-filter.tsx
@@ -811,7 +811,9 @@ function DeviceFilter({
 
         <SelectContent>
           {operatorArr.map((operator) => (
-            <SelectItem value={operator.id}>{operator.name}</SelectItem>
+            <SelectItem key={operator.id} value={operator.id}>
+              {operator.name}
+            </SelectItem>
           ))}
         </SelectContent>
       </Select>
@@ -831,7 +833,9 @@ function DeviceFilter({
             { id: "desktop", name: t("workspace.segments.desktop") },
             { id: "phone", name: t("workspace.segments.phone") },
           ].map((operator) => (
-            <SelectItem value={operator.id}>{operator.name}</SelectItem>
+            <SelectItem key={operator.id} value={operator.id}>
+              {operator.name}
+            </SelectItem>
           ))}
         </SelectContent>
       </Select>


### PR DESCRIPTION
## Summary

Two `<SelectItem>` lists inside `DeviceFilter` (in `segment-filter.tsx`) were missing the `key` prop, producing React's reconciler warning and risking incorrect item reuse across renders. Added `key={operator.id}` on both — the `id` is stable and unique within each list.

Flagged by [react-doctor](https://github.com/millionco/react-doctor) as `react-doctor/jsx-key` (Correctness, error).

## Test plan

- [ ] CI green
- [ ] No DevTools key warning when expanding the device filter dropdown in a segment

🤖 Generated with [Claude Code](https://claude.com/claude-code)