### PR TITLE
fix: remove invalid placeholder ARIA roles from membership role controls

### DIFF
--- a/apps/web/modules/ee/role-management/components/edit-membership-role.tsx
+++ b/apps/web/modules/ee/role-management/components/edit-membership-role.tsx
@@ -112,8 +112,7 @@ export function EditMembershipRole({
             disabled={disableRole}
             loading={loading}
             size="sm"
-            variant="secondary"
-            role="button-role">
+            variant="secondary">
             <span className="ml-1 capitalize">{memberRole}</span>
             <ChevronDownIcon className="h-4 w-4" />
           </Button>
@@ -138,5 +137,5 @@ export function EditMembershipRole({
     );
   }
 
-  return <Badge size="tiny" type="gray" role="badge-role" text={memberRole} className="capitalize" />;
+  return <Badge size="tiny" type="gray" text={memberRole} className="capitalize" />;
 }


### PR DESCRIPTION
## Summary

`role="button-role"` and `role="badge-role"` in `edit-membership-role.tsx` are not valid ARIA roles — they look like placeholder values that were never replaced. The underlying `<Button>` already carries the implicit `button` role, and the `<Badge>` is decorative (its text content conveys the value), so the right fix is to drop both attributes rather than substitute new roles.

Flagged by [react-doctor](https://github.com/millionco/react-doctor) as `react-doctor/aria-role` (Accessibility, error).

## Test plan

- [ ] CI green
- [ ] Screen reader still announces the membership role correctly on the workspace member list

🤖 Generated with [Claude Code](https://claude.com/claude-code)