### PR TITLE
fix: clean up setTimeout schedules in contact-attribute effects

### DIFF
--- a/apps/web/modules/ee/contacts/components/edit-contact-attributes-modal.tsx
+++ b/apps/web/modules/ee/contacts/components/edit-contact-attributes-modal.tsx
@@ -133,7 +133,7 @@ export const EditContactAttributesModal = ({
         const errorFieldId = `attribute-key-${firstErrorIndex}`;
         const errorElement = document.getElementById(errorFieldId);
         if (errorElement) {
-          setTimeout(() => {
+          const timeoutId = setTimeout(() => {
             errorElement.scrollIntoView({ behavior: "smooth", block: "center" });
             // Try to focus the input inside the combobox if it exists
             const inputElement = errorElement.querySelector("input") as HTMLInputElement;
@@ -143,6 +143,7 @@ export const EditContactAttributesModal = ({
               errorElement.focus();
             }
           }, 100);
+          return () => clearTimeout(timeoutId);
         }
       }
     }

--- a/apps/web/modules/ee/contacts/components/upload-contacts-button.tsx
+++ b/apps/web/modules/ee/contacts/components/upload-contacts-button.tsx
@@ -337,9 +337,10 @@ export const UploadContactsCSVButton = ({
   useEffect(() => {
     if (error && errorContainerRef.current) {
       // Small delay to ensure DOM has updated and the alert is visible
-      setTimeout(() => {
+      const timeoutId = setTimeout(() => {
         errorContainerRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
       }, 100);
+      return () => clearTimeout(timeoutId);
     }
   }, [error]);
 


### PR DESCRIPTION
## Summary

Two `useEffect` hooks in the contacts UI scheduled `setTimeout` callbacks (smooth-scrolling to error rows) without returning a cleanup. If the effect re-ran or the component unmounted before the 100ms timeout fired, the callback would still execute and touch potentially-stale refs / unmounted DOM nodes.

Both now capture the timeout id and return `() => clearTimeout(id)`.

- `modules/ee/contacts/components/upload-contacts-button.tsx:337`
- `modules/ee/contacts/components/edit-contact-attributes-modal.tsx:121`

Flagged by [react-doctor](https://github.com/millionco/react-doctor) as `react-doctor/effect-needs-cleanup` (State & Effects, error).

## Test plan

- [ ] CI green
- [ ] CSV upload still scrolls to error block when validation fails
- [ ] Edit-contact-attributes modal still scrolls/focuses the first invalid row on submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)