### PR TITLE
fix: revalidate survey path in response mutations instead of unauthenticated tab-click action

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/actions.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/actions.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { ZResponseFilterCriteria } from "@formbricks/types/responses";
@@ -10,33 +9,6 @@ import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromSurveyId, getWorkspaceIdFromSurveyId } from "@/lib/utils/helper";
 import { getSurveySummary } from "./summary/lib/surveySummary";
-
-const ZRevalidateSurveyIdPathAction = z.object({
-  workspaceId: ZId,
-  surveyId: ZId,
-});
-
-export const revalidateSurveyIdPathAction = authenticatedActionClient
-  .inputSchema(ZRevalidateSurveyIdPathAction)
-  .action(async ({ ctx, parsedInput }) => {
-    await checkAuthorizationUpdated({
-      userId: ctx.user.id,
-      organizationId: await getOrganizationIdFromSurveyId(parsedInput.surveyId),
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-        {
-          type: "workspaceTeam",
-          minPermission: "read",
-          workspaceId: parsedInput.workspaceId,
-        },
-      ],
-    });
-
-    revalidatePath(`/workspaces/${parsedInput.workspaceId}/surveys/${parsedInput.surveyId}`);
-  });
 
 const ZGetResponsesAction = z.object({
   surveyId: ZId,

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/actions.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/actions.ts
@@ -11,9 +11,32 @@ import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-clie
 import { getOrganizationIdFromSurveyId, getWorkspaceIdFromSurveyId } from "@/lib/utils/helper";
 import { getSurveySummary } from "./summary/lib/surveySummary";
 
-export const revalidateSurveyIdPath = async (workspaceId: string, surveyId: string) => {
-  revalidatePath(`/workspaces/${workspaceId}/surveys/${surveyId}`);
-};
+const ZRevalidateSurveyIdPathAction = z.object({
+  workspaceId: ZId,
+  surveyId: ZId,
+});
+
+export const revalidateSurveyIdPathAction = authenticatedActionClient
+  .inputSchema(ZRevalidateSurveyIdPathAction)
+  .action(async ({ ctx, parsedInput }) => {
+    await checkAuthorizationUpdated({
+      userId: ctx.user.id,
+      organizationId: await getOrganizationIdFromSurveyId(parsedInput.surveyId),
+      access: [
+        {
+          type: "organization",
+          roles: ["owner", "manager"],
+        },
+        {
+          type: "workspaceTeam",
+          minPermission: "read",
+          workspaceId: parsedInput.workspaceId,
+        },
+      ],
+    });
+
+    revalidatePath(`/workspaces/${parsedInput.workspaceId}/surveys/${parsedInput.surveyId}`);
+  });
 
 const ZGetResponsesAction = z.object({
   surveyId: ZId,

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/components/SurveyAnalysisNavigation.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/components/SurveyAnalysisNavigation.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { useWorkspace } from "@/app/(app)/workspaces/[workspaceId]/context/workspace-context";
-import { revalidateSurveyIdPath } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/actions";
+import { revalidateSurveyIdPathAction } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/actions";
 import { SecondaryNavigation } from "@/modules/ui/components/secondary-navigation";
 
 interface SurveyAnalysisNavigationProps {
@@ -28,7 +28,7 @@ export const SurveyAnalysisNavigation = ({ survey, activeId }: SurveyAnalysisNav
       href: `${url}/summary?referer=true`,
       current: pathname?.includes("/summary"),
       onClick: () => {
-        revalidateSurveyIdPath(workspace?.id ?? "", survey.id);
+        revalidateSurveyIdPathAction({ workspaceId: workspace?.id ?? "", surveyId: survey.id });
       },
     },
     {
@@ -38,7 +38,7 @@ export const SurveyAnalysisNavigation = ({ survey, activeId }: SurveyAnalysisNav
       href: `${url}/responses?referer=true`,
       current: pathname?.includes("/responses"),
       onClick: () => {
-        revalidateSurveyIdPath(workspace?.id ?? "", survey.id);
+        revalidateSurveyIdPathAction({ workspaceId: workspace?.id ?? "", surveyId: survey.id });
       },
     },
   ];

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/components/SurveyAnalysisNavigation.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/components/SurveyAnalysisNavigation.tsx
@@ -5,7 +5,6 @@ import { usePathname } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { useWorkspace } from "@/app/(app)/workspaces/[workspaceId]/context/workspace-context";
-import { revalidateSurveyIdPathAction } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/actions";
 import { SecondaryNavigation } from "@/modules/ui/components/secondary-navigation";
 
 interface SurveyAnalysisNavigationProps {
@@ -27,9 +26,6 @@ export const SurveyAnalysisNavigation = ({ survey, activeId }: SurveyAnalysisNav
       icon: <PresentationIcon className="h-5 w-5" />,
       href: `${url}/summary?referer=true`,
       current: pathname?.includes("/summary"),
-      onClick: () => {
-        revalidateSurveyIdPathAction({ workspaceId: workspace?.id ?? "", surveyId: survey.id });
-      },
     },
     {
       id: "responses",
@@ -37,9 +33,6 @@ export const SurveyAnalysisNavigation = ({ survey, activeId }: SurveyAnalysisNav
       icon: <InboxIcon className="h-5 w-5" />,
       href: `${url}/responses?referer=true`,
       current: pathname?.includes("/responses"),
-      onClick: () => {
-        revalidateSurveyIdPathAction({ workspaceId: workspace?.id ?? "", surveyId: survey.id });
-      },
     },
   ];
 

--- a/apps/web/modules/analysis/components/SingleResponseCard/actions.ts
+++ b/apps/web/modules/analysis/components/SingleResponseCard/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
@@ -12,6 +13,7 @@ import {
   getOrganizationIdFromResponseId,
   getOrganizationIdFromWorkspaceId,
   getWorkspaceIdFromResponseId,
+  getWorkspaceIdFromSurveyId,
 } from "@/lib/utils/helper";
 import { getTag } from "@/lib/utils/services";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
@@ -63,12 +65,14 @@ export const createTagToResponseAction = authenticatedActionClient
   .inputSchema(ZCreateTagToResponseAction)
   .action(
     withAuditLogging("addedToResponse", "tag", async ({ parsedInput, ctx }) => {
-      const responseWorkspaceId = await getWorkspaceIdFromResponseId(parsedInput.responseId);
+      const response = await getResponse(parsedInput.responseId);
       const tag = await getTag(parsedInput.tagId);
 
-      if (!responseWorkspaceId || !tag) {
+      if (!response || !tag) {
         throw new ResourceNotFoundError("Workspace", null);
       }
+
+      const responseWorkspaceId = await getWorkspaceIdFromSurveyId(response.surveyId);
 
       if (responseWorkspaceId !== tag.workspaceId) {
         throw new Error("Response and tag are not in the same workspace");
@@ -95,6 +99,7 @@ export const createTagToResponseAction = authenticatedActionClient
       ctx.auditLoggingCtx.tagId = parsedInput.tagId;
       const result = await addTagToRespone(parsedInput.responseId, parsedInput.tagId);
       ctx.auditLoggingCtx.newObject = result;
+      revalidatePath(`/workspaces/${responseWorkspaceId}/surveys/${response.surveyId}`);
       return result;
     })
   );
@@ -108,12 +113,14 @@ export const deleteTagOnResponseAction = authenticatedActionClient
   .inputSchema(ZDeleteTagOnResponseAction)
   .action(
     withAuditLogging("removedFromResponse", "tag", async ({ parsedInput, ctx }) => {
-      const responseWorkspaceId = await getWorkspaceIdFromResponseId(parsedInput.responseId);
+      const response = await getResponse(parsedInput.responseId);
       const tag = await getTag(parsedInput.tagId);
       const organizationId = await getOrganizationIdFromResponseId(parsedInput.responseId);
-      if (!responseWorkspaceId || !tag) {
+      if (!response || !tag) {
         throw new ResourceNotFoundError("Workspace", null);
       }
+
+      const responseWorkspaceId = await getWorkspaceIdFromSurveyId(response.surveyId);
 
       if (responseWorkspaceId !== tag.workspaceId) {
         throw new Error("Response and tag are not in the same workspace");
@@ -138,6 +145,7 @@ export const deleteTagOnResponseAction = authenticatedActionClient
       ctx.auditLoggingCtx.tagId = parsedInput.tagId;
       const result = await deleteTagOnResponse(parsedInput.responseId, parsedInput.tagId);
       ctx.auditLoggingCtx.oldObject = result;
+      revalidatePath(`/workspaces/${responseWorkspaceId}/surveys/${response.surveyId}`);
       return result;
     })
   );
@@ -169,6 +177,9 @@ export const deleteResponseAction = authenticatedActionClient.inputSchema(ZDelet
     ctx.auditLoggingCtx.responseId = parsedInput.responseId;
     const result = await deleteResponse(parsedInput.responseId, parsedInput.decrementQuotas);
     ctx.auditLoggingCtx.oldObject = result;
+    revalidatePath(
+      `/workspaces/${await getWorkspaceIdFromSurveyId(result.surveyId)}/surveys/${result.surveyId}`
+    );
     return result;
   })
 );


### PR DESCRIPTION
## Summary

`revalidateSurveyIdPath` in `apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/actions.ts` was a bare exported server action with no auth check — any caller could trigger a Next.js cache bust on any workspace/survey path. It was fired on **every** Summary/Responses tab click to compensate for the response mutation actions not revalidating the survey route after they change data.

Rather than hardening that action (which would add an auth DB round-trip on every tab click), this PR removes it entirely and moves `revalidatePath` to where the data actually changes — the response mutation actions in `modules/analysis/components/SingleResponseCard/actions.ts`:

- `deleteResponseAction`
- `createTagToResponseAction`
- `deleteTagOnResponseAction`

These actions already require `workspaceTeam` `readWrite`, so the revalidation is properly gated. The two tag actions now fetch the response once to derive both `surveyId` and `workspaceId`, replacing a redundant `getWorkspaceIdFromResponseId` lookup.

### Why this is better than gating the action

- **Fully resolves the original react-doctor `server-auth-actions` finding** — the public/exported cache-bust action no longer exists, so there's nothing to gate.
- **Removes the per-navigation auth round-trip** — no server action call on tab switches.
- **Revalidates precisely on mutation** instead of bluntly on navigation.
- Also resolves the two CodeRabbit review findings (client-supplied `workspaceId` in the auth check; unhandled fire-and-forget promise passing `workspace?.id ?? ""`), since the client no longer calls any revalidation action.

## Changes

- **Deleted** `revalidateSurveyIdPathAction` and the now-unused `revalidatePath` import from `(analysis)/actions.ts`.
- **Removed** both `onClick` handlers (and the import) from `SurveyAnalysisNavigation.tsx`.
- **Added** `revalidatePath(\`/workspaces/${workspaceId}/surveys/${surveyId}\`)` to the three response mutation actions.

## Test plan

- [ ] Delete a response, then switch to the Summary tab — counts/summary reflect the deletion without a manual refresh.
- [ ] Add/remove a tag on a response — analysis views stay consistent.
- [ ] `pnpm --filter @formbricks/web test`
- [x] `pnpm typecheck` — no new errors in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)