### PR TITLE
chore: drop unused exports flagged by only-export-components

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/components/ResponseDataView.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/components/ResponseDataView.tsx
@@ -38,20 +38,17 @@ const formatArrayToRecord = (responseValue: TResponseDataValue, keys: string[]):
   return result;
 };
 
-// Export for testing
-export const formatAddressData = (responseValue: TResponseDataValue): Record<string, string> => {
+const formatAddressData = (responseValue: TResponseDataValue): Record<string, string> => {
   const addressKeys = ["addressLine1", "addressLine2", "city", "state", "zip", "country"];
   return formatArrayToRecord(responseValue, addressKeys);
 };
 
-// Export for testing
-export const formatContactInfoData = (responseValue: TResponseDataValue): Record<string, string> => {
+const formatContactInfoData = (responseValue: TResponseDataValue): Record<string, string> => {
   const contactInfoKeys = ["firstName", "lastName", "email", "phone", "company"];
   return formatArrayToRecord(responseValue, contactInfoKeys);
 };
 
-// Export for testing
-export const extractResponseData = (response: TResponseWithQuotas, survey: TSurvey): Record<string, any> => {
+const extractResponseData = (response: TResponseWithQuotas, survey: TSurvey): Record<string, any> => {
   const responseData: Record<string, any> = {};
 
   const elements = getElementsFromBlocks(survey.blocks);

--- a/apps/web/modules/survey/components/template-list/components/template-tags.tsx
+++ b/apps/web/modules/survey/components/template-list/components/template-tags.tsx
@@ -17,7 +17,7 @@ interface TemplateTagsProps {
 
 type NonNullabeChannel = NonNullable<TWorkspaceConfigChannel>;
 
-export const getRoleBasedStyling = (role: TTemplateRole | undefined): string => {
+const getRoleBasedStyling = (role: TTemplateRole | undefined): string => {
   switch (role) {
     case "productManager":
       return "border-blue-300 bg-blue-50 text-blue-500";

--- a/apps/web/modules/ui/components/multi-select/badge.tsx
+++ b/apps/web/modules/ui/components/multi-select/badge.tsx
@@ -26,4 +26,4 @@ function Badge({ className, variant, ...props }: BadgeProps) {
   return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
 
-export { Badge, badgeVariants };
+export { Badge };


### PR DESCRIPTION
## Summary

Three component files exported helpers/variants that no callers actually use. The unused `export` keyword forces Fast Refresh to treat the file as a "mixed exports" boundary and skip HMR for the component on every save during dev.

| File | Was exported | Used externally? |
| --- | --- | --- |
| `template-tags.tsx` | `getRoleBasedStyling` | No (only line 70 in same file) |
| `ResponseDataView.tsx` | `formatAddressData`, `formatContactInfoData`, `extractResponseData` (each marked "// Export for testing") | No test file imports them |
| `multi-select/badge.tsx` | `badgeVariants` | No (only used in the same file's `Badge`) |

Removing the `export` keyword is the smallest correct fix per `react-doctor/only-export-components` (Architecture, error).

## Why this PR only covers 3 of the 16 findings

The remaining 13 hits in this cluster split into two groups, both intentionally out of scope here:

1. **Source files where the second export is genuinely public** — `preview-email-template.tsx` (`getPreviewEmailTemplateHtml` is imported from `emailTemplate.tsx`), `MappingRow.tsx` (`TMapping` / `createEmptyMapping` used by `AddIntegrationModal.tsx`), `add-filter-modal.tsx` (`handleAddFilter`), `ElementsComboBox.tsx` (`OptionsType` enum + types), `ResponseTableColumns.tsx`. Each requires creating a sibling `*.utils.ts` or `*.types.ts` file plus updating all importers — a real refactor that should be its own PR.

2. **Storybook stories files** (6 of them: `confirmation-modal/stories.tsx`, `delete-dialog/stories.tsx`, `dialog/stories.tsx`, `slider/stories.tsx`, `tag/stories.tsx`, `tab-nav/stories.tsx`). Storybook ships its own HMR; Fast Refresh's "single-export-per-file" assumption doesn't apply the same way. Worth a project-level config exclusion in `react-doctor.config.json` rather than touching every file.

## Test plan

Verified locally:
- `pnpm --filter @formbricks/web test` — **5166 / 5166 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)