### PR TITLE
fix: move SAML jackson opts out of module scope into init()

### DIFF
--- a/apps/web/modules/ee/auth/saml/lib/jackson.ts
+++ b/apps/web/modules/ee/auth/saml/lib/jackson.ts
@@ -5,17 +5,6 @@ import { SAML_AUDIENCE, SAML_DATABASE_URL, SAML_PATH, WEBAPP_URL } from "@/lib/c
 import { preloadConnection } from "@/modules/ee/auth/saml/lib/preload-connection";
 import { getIsSamlSsoEnabled } from "@/modules/ee/license-check/lib/utils";
 
-const opts: JacksonOption = {
-  externalUrl: WEBAPP_URL,
-  samlAudience: SAML_AUDIENCE,
-  samlPath: SAML_PATH,
-  db: {
-    engine: "sql",
-    type: "postgres",
-    url: SAML_DATABASE_URL,
-  },
-};
-
 declare global {
   var oauthController: IOAuthController | undefined;
   var connectionController: IConnectionAPIController | undefined;
@@ -27,6 +16,17 @@ export default async function init() {
   if (!g.oauthController || !g.connectionController) {
     const isSamlSsoEnabled = await getIsSamlSsoEnabled();
     if (!isSamlSsoEnabled) return;
+
+    const opts: JacksonOption = {
+      externalUrl: WEBAPP_URL,
+      samlAudience: SAML_AUDIENCE,
+      samlPath: SAML_PATH,
+      db: {
+        engine: "sql",
+        type: "postgres",
+        url: SAML_DATABASE_URL,
+      },
+    };
 
     const ret = await (await import("@boxyhq/saml-jackson")).controllers(opts);
 


### PR DESCRIPTION
## Summary

`opts` was declared as a module-scope `const` in a `"use server"` file (`modules/ee/auth/saml/lib/jackson.ts`), which [react-doctor](https://github.com/millionco/react-doctor) flagged as `react-doctor/server-no-mutable-module-state` (Server, error).

Although the object happens to be read-only today, the **container itself is shared across requests** — any future mutation (e.g. dynamically overriding `db.url` based on a request property) would silently affect every concurrent request, and the bug would be very hard to spot. Moving the construction inside `init()` makes that footgun impossible.

The fix is structurally minimal:

- Move the `opts` object construction inside `init()`, gated by the existing "controllers not yet initialized" check
- No-op for cache-hit calls (the object is never constructed)
- Behaviorally identical to before on the first call

The intentional `globalThis` singleton cache for the SAML controllers themselves (`g.oauthController`, `g.connectionController`) is left in place — that's a deliberate cross-request singleton for an expensive boot, not unintentional shared state.

## Adjacent concern (not addressed here)

This file has `"use server"` at the top, which technically exposes `init()` as a server action callable via the React Server Actions RPC protocol. That looks unintended — `init()` is only meant to be called from the SAML API route handlers (`api/token/route.ts`, `api/userinfo/route.ts`, `api/authorize/route.ts`). Removing `"use server"` would be cleaner, but the directive's call-site implications need to be confirmed against the boxyhq SAML flow before changing.

## Test plan

Verified locally:
- `pnpm --filter @formbricks/web test` — **5166 / 5166 pass**

Manual checks:
- [ ] First SAML login after server start still works (cold path: `opts` is constructed once, controllers are cached on `globalThis`)
- [ ] Subsequent SAML logins are fast (hot path: cache hit, `opts` is never re-constructed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)