### PR TITLE
fix: prevent client environment cache null crash

### DIFF
--- a/apps/web/app/api/v1/client/[workspaceId]/environment/route.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/environment/route.ts
@@ -60,6 +60,21 @@ export const GET = withV1ApiWrapper({
 
       // Use optimized environment state fetcher with new caching approach
       const workspace = await getWorkspaceState(workspaceId);
+
+      // Defense in depth: the cache layer guarantees a non-null contract here
+      // (T extends NonNullable<unknown> on withCache), but a runtime guard
+      // ensures any future regression surfaces as a logged 404 rather than a
+      // 500 from destructuring null.
+      if (!workspace?.data) {
+        logger.error(
+          { workspaceId, url: req.url },
+          "getWorkspaceState returned unexpected null/empty payload"
+        );
+        return {
+          response: responses.notFoundResponse("Workspace", workspaceId),
+        };
+      }
+
       const { data } = workspace;
 
       return {

--- a/apps/web/app/api/v1/client/[workspaceId]/environment/route.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/environment/route.ts
@@ -61,10 +61,7 @@ export const GET = withV1ApiWrapper({
       // Use optimized environment state fetcher with new caching approach
       const workspace = await getWorkspaceState(workspaceId);
 
-      // Defense in depth: the cache layer guarantees a non-null contract here
-      // (T extends NonNullable<unknown> on withCache), but a runtime guard
-      // ensures any future regression surfaces as a logged 404 rather than a
-      // 500 from destructuring null.
+      // Guard against unexpected empty state before destructuring.
       if (!workspace?.data) {
         logger.error(
           { workspaceId, url: req.url },

--- a/apps/web/lib/cache/index.test.ts
+++ b/apps/web/lib/cache/index.test.ts
@@ -9,6 +9,7 @@ const mockCacheService = {
   del: vi.fn(),
   exists: vi.fn(),
   withCache: vi.fn(),
+  withCacheNullable: vi.fn(),
   getRedisClient: vi.fn(),
 };
 
@@ -217,6 +218,31 @@ describe("Cache Index", () => {
 
       expect(mockCacheService.withCache).toHaveBeenCalledWith(mockFn, "cache-key" as CacheKey, 3000);
       expect(result).toBe("cached-result");
+    });
+
+    test("should proxy withCacheNullable method correctly when cache is available", async () => {
+      const mockFn = vi.fn().mockResolvedValue(null);
+      mockCacheService.withCacheNullable.mockResolvedValue(null);
+
+      const result = await cache.withCacheNullable(mockFn, "cache-key" as CacheKey, 3000);
+
+      expect(mockCacheService.withCacheNullable).toHaveBeenCalledWith(mockFn, "cache-key" as CacheKey, 3000);
+      expect(result).toBeNull();
+    });
+
+    test("should execute nullable function directly when cache service fails", async () => {
+      const mockFn = vi.fn().mockResolvedValue("function-result");
+
+      mockGetCacheService.mockResolvedValue({
+        ok: false,
+        error: { code: "CACHE_UNAVAILABLE" },
+      });
+
+      const result = await cache.withCacheNullable(mockFn, "cache-key" as CacheKey, 3000);
+
+      expect(result).toBe("function-result");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(mockCacheService.withCacheNullable).not.toHaveBeenCalled();
     });
 
     test("should execute function directly when cache service fails", async () => {

--- a/apps/web/lib/cache/index.ts
+++ b/apps/web/lib/cache/index.ts
@@ -11,7 +11,12 @@ type CacheService = {
   set(key: string, value: unknown, ttlMs?: number): Promise<CacheResult<void>>;
   del(keys: string[]): Promise<CacheResult<void>>;
   tryLock(key: string, value: string, ttlMs: number): Promise<CacheResult<boolean>>;
-  withCache<T>(fn: () => Promise<T>, key: string, ttlMs: number): Promise<T>;
+  withCache<T extends NonNullable<unknown>>(fn: () => Promise<T>, key: string, ttlMs: number): Promise<T>;
+  withCacheNullable<T extends NonNullable<unknown>>(
+    fn: () => Promise<T | null>,
+    key: string,
+    ttlMs: number
+  ): Promise<T | null>;
   getRedisClient(): RedisClientType | null;
 };
 
@@ -31,7 +36,7 @@ export const cache = new Proxy({} as AsyncCacheService, {
   get(_target, prop: keyof CacheService) {
     // Special-case: withCache must never fail; fall back to direct fn on init failure.
     if (prop === "withCache") {
-      return async <T>(fn: () => Promise<T>, ...rest: [string, number]) => {
+      return async <T extends NonNullable<unknown>>(fn: () => Promise<T>, ...rest: [string, number]) => {
         try {
           const cacheServiceResult = await getCacheService();
 
@@ -41,6 +46,29 @@ export const cache = new Proxy({} as AsyncCacheService, {
 
           const cacheService = cacheServiceResult.data as CacheService;
           return cacheService.withCache(fn, ...rest);
+        } catch (error) {
+          logger.warn({ error }, "Cache unavailable; executing function directly");
+          return await fn();
+        }
+      };
+    }
+
+    // withCacheNullable mirrors withCache's graceful fallback. Kept separate so
+    // the runtime semantics (and logs) don't depend on which overload was used.
+    if (prop === "withCacheNullable") {
+      return async <T extends NonNullable<unknown>>(
+        fn: () => Promise<T | null>,
+        ...rest: [string, number]
+      ) => {
+        try {
+          const cacheServiceResult = await getCacheService();
+
+          if (!cacheServiceResult.ok) {
+            return await fn();
+          }
+
+          const cacheService = cacheServiceResult.data as CacheService;
+          return cacheService.withCacheNullable(fn, ...rest);
         } catch (error) {
           logger.warn({ error }, "Cache unavailable; executing function directly");
           return await fn();

--- a/apps/web/lib/cache/index.ts
+++ b/apps/web/lib/cache/index.ts
@@ -53,8 +53,6 @@ export const cache = new Proxy({} as AsyncCacheService, {
       };
     }
 
-    // withCacheNullable mirrors withCache's graceful fallback. Kept separate so
-    // the runtime semantics (and logs) don't depend on which overload was used.
     if (prop === "withCacheNullable") {
       return async <T extends NonNullable<unknown>>(
         fn: () => Promise<T | null>,

--- a/apps/web/modules/ee/billing/lib/organization-billing.test.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.test.ts
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   prismaOrganizationBillingUpsert: vi.fn(),
   prismaOrganizationBillingUpdate: vi.fn(),
   cacheWithCache: vi.fn(),
+  cacheWithCacheNullable: vi.fn(),
   cacheDel: vi.fn(),
   loggerWarn: vi.fn(),
   getCloudPlanFromProduct: vi.fn(),
@@ -88,6 +89,7 @@ vi.mock("@formbricks/database", () => ({
 vi.mock("@/lib/cache", () => ({
   cache: {
     withCache: mocks.cacheWithCache,
+    withCacheNullable: mocks.cacheWithCacheNullable,
     del: mocks.cacheDel,
   },
 }));
@@ -156,6 +158,7 @@ describe("organization-billing", () => {
         [namespace, identifier, subresource].filter(Boolean).join(":")
     );
     mocks.cacheWithCache.mockImplementation(async (fn: () => Promise<unknown>) => await fn());
+    mocks.cacheWithCacheNullable.mockImplementation(async (fn: () => Promise<unknown>) => await fn());
     mocks.getCloudPlanFromProduct.mockReturnValue("pro");
     mocks.subscriptionsList.mockResolvedValue({ data: [] });
     mocks.customersList.mockResolvedValue({ data: [] });
@@ -1761,7 +1764,7 @@ describe("organization-billing", () => {
       },
       usageCycleAnchor: new Date().toISOString(),
     };
-    mocks.cacheWithCache.mockResolvedValue(cachedBilling);
+    mocks.cacheWithCacheNullable.mockResolvedValue(cachedBilling);
 
     const result = await getOrganizationBillingWithReadThroughSync("org_1");
 
@@ -1774,7 +1777,7 @@ describe("organization-billing", () => {
       stripeCustomerId: "cus_1",
       stripe: { lastSyncedAt: new Date().toISOString() },
     };
-    mocks.cacheWithCache.mockResolvedValue(cachedBilling);
+    mocks.cacheWithCacheNullable.mockResolvedValue(cachedBilling);
 
     const result = await getOrganizationBillingWithReadThroughSync("org_1");
 
@@ -1787,7 +1790,7 @@ describe("organization-billing", () => {
       stripeCustomerId: "cus_1",
       stripe: { lastSyncedAt: new Date(Date.now() - 6 * 60 * 1000).toISOString() },
     };
-    mocks.cacheWithCache.mockResolvedValue(cachedBilling);
+    mocks.cacheWithCacheNullable.mockResolvedValue(cachedBilling);
     mocks.prismaOrganizationBillingFindUnique.mockResolvedValue({
       stripeCustomerId: "cus_1",
       limits: {
@@ -1826,7 +1829,7 @@ describe("organization-billing", () => {
 
     const result = await getOrganizationBillingWithReadThroughSync("org_1");
 
-    expect(mocks.cacheWithCache).not.toHaveBeenCalled();
+    expect(mocks.cacheWithCacheNullable).not.toHaveBeenCalled();
     expect(result).toEqual({
       stripeCustomerId: null,
       limits: {
@@ -1841,7 +1844,7 @@ describe("organization-billing", () => {
 
   test("getOrganizationBillingWithReadThroughSync returns null when organization billing is missing", async () => {
     mocks.prismaOrganizationBillingFindUnique.mockResolvedValue(null);
-    mocks.cacheWithCache.mockImplementation(async (fn: () => Promise<unknown>) => await fn());
+    mocks.cacheWithCacheNullable.mockImplementation(async (fn: () => Promise<unknown>) => await fn());
 
     await expect(getOrganizationBillingWithReadThroughSync("org_1")).resolves.toBeNull();
   });

--- a/apps/web/modules/ee/billing/lib/organization-billing.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.ts
@@ -1218,7 +1218,7 @@ export const getOrganizationBillingWithReadThroughSync = async (
     return await getOrganizationBillingFromDatabase(organizationId);
   }
 
-  const cachedBilling = await cache.withCache(
+  const cachedBilling = await cache.withCacheNullable(
     async () => await getOrganizationBillingFromDatabase(organizationId),
     getBillingCacheKey(organizationId),
     BILLING_SYNC_STALE_MS

--- a/packages/cache/src/cache-integration.test.ts
+++ b/packages/cache/src/cache-integration.test.ts
@@ -432,11 +432,12 @@ describe("Cache Integration Tests - End-to-End Redis Operations", () => {
       return;
     }
 
+    // null is exercised separately below via withCacheNullable, since withCache
+    // is now constrained to non-null values to prevent races on JSON null.
     const testCases = [
       { name: "string", value: "Hello, World!" },
       { name: "number", value: 42.5 },
       { name: "boolean", value: true },
-      { name: "null", value: null },
       { name: "array", value: [1, "two", { three: 3 }, null, true] },
       {
         name: "object",
@@ -506,6 +507,32 @@ describe("Cache Integration Tests - End-to-End Redis Operations", () => {
       logger.info(`✅ ${testCase.name} serialization successful`);
     }
 
+    // Bare `null` written via raw cache.set must not be picked up by
+    // withCacheNullable: the two APIs use different wire formats on purpose
+    // (raw `null` vs the marked envelope), so withCacheNullable should treat
+    // a raw-null entry as a miss and invoke fn().
+    const nullKey = createCacheKey.workspace.state("serialization-null");
+    await cacheService.del([nullKey]);
+    const nullSetResult = await cacheService.set(nullKey, null, 30000);
+    expect(nullSetResult.ok).toBe(true);
+    const nullGetResult = await cacheService.get(nullKey);
+    expect(nullGetResult.ok).toBe(true);
+    if (nullGetResult.ok) {
+      expect(nullGetResult.data).toBeNull();
+    }
+    let nullFnCalled = false;
+    const nullCached = await cacheService.withCacheNullable(
+      async () => {
+        nullFnCalled = true;
+        return "should-not-be-returned";
+      },
+      nullKey,
+      30000
+    );
+    expect(nullFnCalled).toBe(true);
+    expect(nullCached).toBe("should-not-be-returned");
+    logger.info("✅ withCacheNullable correctly ignores entries written via raw cache.set(null)");
+
     logger.info("✅ All data types serialized correctly");
   }, 20000);
 
@@ -546,5 +573,48 @@ describe("Cache Integration Tests - End-to-End Redis Operations", () => {
     logger.info("✅ withCache gracefully degraded to function execution when cache failed");
 
     logger.info("✅ Error handling tests completed successfully");
+  }, 15000);
+
+  test("withCacheNullable: round-trips real values and cached nulls without re-executing fn", async () => {
+    if (!isRedisAvailable || !cacheService) {
+      logger.info("Skipping test: Redis not available");
+      return;
+    }
+
+    const realKey = createCacheKey.workspace.state("nullable-real");
+    const nullKey = createCacheKey.workspace.state("nullable-null");
+    let realCalls = 0;
+    let nullCalls = 0;
+
+    const realFn = async (): Promise<{ id: string } | null> => {
+      realCalls++;
+      return { id: `real-${realCalls}` };
+    };
+    const nullFn = async (): Promise<{ id: string } | null> => {
+      nullCalls++;
+      return null;
+    };
+
+    await cacheService.del([realKey, nullKey]);
+
+    // First call: miss, populate.
+    const realFirst = await cacheService.withCacheNullable(realFn, realKey, 60000);
+    const nullFirst = await cacheService.withCacheNullable(nullFn, nullKey, 60000);
+    expect(realFirst).toEqual({ id: "real-1" });
+    expect(nullFirst).toBeNull();
+    expect(realCalls).toBe(1);
+    expect(nullCalls).toBe(1);
+
+    // Second call: both should be cache hits. The marked nullable envelope
+    // must not be confused with a cache miss.
+    const realSecond = await cacheService.withCacheNullable(realFn, realKey, 60000);
+    const nullSecond = await cacheService.withCacheNullable(nullFn, nullKey, 60000);
+    expect(realSecond).toEqual({ id: "real-1" });
+    expect(nullSecond).toBeNull();
+    expect(realCalls).toBe(1);
+    expect(nullCalls).toBe(1);
+
+    await cacheService.del([realKey, nullKey]);
+    logger.info("✅ withCacheNullable round-trip confirmed for real and null values");
   }, 15000);
 });

--- a/packages/cache/src/cache-integration.test.ts
+++ b/packages/cache/src/cache-integration.test.ts
@@ -432,8 +432,7 @@ describe("Cache Integration Tests - End-to-End Redis Operations", () => {
       return;
     }
 
-    // null is exercised separately below via withCacheNullable, since withCache
-    // is now constrained to non-null values to prevent races on JSON null.
+    // Null serialization is covered below via withCacheNullable.
     const testCases = [
       { name: "string", value: "Hello, World!" },
       { name: "number", value: 42.5 },
@@ -507,10 +506,7 @@ describe("Cache Integration Tests - End-to-End Redis Operations", () => {
       logger.info(`✅ ${testCase.name} serialization successful`);
     }
 
-    // Bare `null` written via raw cache.set must not be picked up by
-    // withCacheNullable: the two APIs use different wire formats on purpose
-    // (raw `null` vs the marked envelope), so withCacheNullable should treat
-    // a raw-null entry as a miss and invoke fn().
+    // Raw cache.set(null) should be a nullable-cache miss.
     const nullKey = createCacheKey.workspace.state("serialization-null");
     await cacheService.del([nullKey]);
     const nullSetResult = await cacheService.set(nullKey, null, 30000);
@@ -597,7 +593,6 @@ describe("Cache Integration Tests - End-to-End Redis Operations", () => {
 
     await cacheService.del([realKey, nullKey]);
 
-    // First call: miss, populate.
     const realFirst = await cacheService.withCacheNullable(realFn, realKey, 60000);
     const nullFirst = await cacheService.withCacheNullable(nullFn, nullKey, 60000);
     expect(realFirst).toEqual({ id: "real-1" });
@@ -605,8 +600,6 @@ describe("Cache Integration Tests - End-to-End Redis Operations", () => {
     expect(realCalls).toBe(1);
     expect(nullCalls).toBe(1);
 
-    // Second call: both should be cache hits. The marked nullable envelope
-    // must not be confused with a cache miss.
     const realSecond = await cacheService.withCacheNullable(realFn, realKey, 60000);
     const nullSecond = await cacheService.withCacheNullable(nullFn, nullKey, 60000);
     expect(realSecond).toEqual({ id: "real-1" });

--- a/packages/cache/src/service.test.ts
+++ b/packages/cache/src/service.test.ts
@@ -272,7 +272,7 @@ describe("CacheService", () => {
       expect(mockRedis.setEx).toHaveBeenCalledWith(key, 5, JSON.stringify(value));
     });
 
-    test("should normalize undefined to null and store as JSON", async () => {
+    test("should warn and skip the write when value is undefined", async () => {
       const key = "test:key" as CacheKey;
       const value = undefined;
       const ttlMs = 60000;
@@ -280,7 +280,11 @@ describe("CacheService", () => {
       const result = await cacheService.set(key, value, ttlMs);
 
       expect(result.ok).toBe(true);
-      expect(mockRedis.setEx).toHaveBeenCalledWith(key, 60, "null");
+      expect(mockRedis.setEx).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(
+        { key, ttlMs },
+        "cache.set called with undefined; skipping write"
+      );
     });
 
     test("should store null values as JSON", async () => {
@@ -596,77 +600,170 @@ describe("CacheService", () => {
       expect(fn).toHaveBeenCalledOnce();
     });
 
-    test("should return cached null value without executing function", async () => {
+    test("should treat stringified null as a cache miss and re-execute fn", async () => {
       const key = "test:key" as CacheKey;
-      const fn = vi.fn().mockResolvedValue({ data: "fresh" });
+      const freshValue = { data: "fresh" };
+      const fn = vi.fn().mockResolvedValue(freshValue);
 
-      // Mock Redis returning stringified null (cached null value)
+      // Redis returns stringified null. Under the old (racy) implementation
+      // this was treated as a cached null value if exists() returned true,
+      // letting a stale null leak to the caller. The new contract is:
+      // JSON null === cache miss, always.
       mockRedis.get.mockResolvedValue("null");
-      mockRedis.exists.mockResolvedValue(1); // Key exists
 
       const result = await cacheService.withCache(fn, key, 60000);
 
-      expect(result).toBeNull();
-      expect(fn).not.toHaveBeenCalled(); // Function should not be executed
+      expect(result).toEqual(freshValue);
+      expect(fn).toHaveBeenCalledOnce();
+      expect(mockRedis.setEx).toHaveBeenCalledWith(key, 60, JSON.stringify(freshValue));
     });
 
-    test("should execute function and cache null result", async () => {
+    test("should not surface stale null under the original GET→EXISTS race window", async () => {
+      // Regression for ENG-1047: Request A's get returns JS null (key absent),
+      // then Request B writes a real value, then A's exists check would see
+      // the key. The old code returned `null as T` here; the new code calls
+      // fn() instead.
       const key = "test:key" as CacheKey;
-      const fn = vi.fn().mockResolvedValue(null); // Function returns null
+      const freshValue = { data: "fresh-from-fn" };
+      const fn = vi.fn().mockResolvedValue(freshValue);
 
-      // Mock cache miss
       mockRedis.get.mockResolvedValue(null);
-      mockRedis.exists.mockResolvedValue(0); // Key doesn't exist
+      // exists is no longer consulted but stub it as if a concurrent writer
+      // had populated the key between our GET and the (now removed) EXISTS.
+      mockRedis.exists.mockResolvedValue(1);
 
       const result = await cacheService.withCache(fn, key, 60000);
+
+      expect(result).toEqual(freshValue);
+      expect(fn).toHaveBeenCalledOnce();
+      expect(mockRedis.exists).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("withCacheNullable", () => {
+    // The wire format for nullable entries is `{ __fb_nullable_v1: true, value }`.
+    // Tests assert the literal string so that any accidental change to the
+    // marker (e.g. version bump) fails loudly and forces an intentional update.
+    const box = (value: unknown): string => JSON.stringify({ __fb_nullable_v1: true, value });
+
+    test("should return cached null without executing fn when boxed null is stored", async () => {
+      const key = "test:nullable-key" as CacheKey;
+      const fn = vi.fn().mockResolvedValue({ id: "fresh" });
+
+      mockRedis.get.mockResolvedValue(box(null));
+
+      const result = await cacheService.withCacheNullable(fn, key, 60000);
+
+      expect(result).toBeNull();
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    test("should compute, box, and cache null on miss", async () => {
+      const key = "test:nullable-key" as CacheKey;
+      const fn = vi.fn().mockResolvedValue(null);
+
+      mockRedis.get.mockResolvedValue(null);
+
+      const result = await cacheService.withCacheNullable(fn, key, 60000);
 
       expect(result).toBeNull();
       expect(fn).toHaveBeenCalledOnce();
-      expect(mockRedis.setEx).toHaveBeenCalledWith(key, 60, "null");
+      expect(mockRedis.setEx).toHaveBeenCalledWith(key, 60, box(null));
     });
 
-    test("should return undefined without caching when function returns undefined", async () => {
-      const key = "test:key" as CacheKey;
-      const fn = vi.fn().mockResolvedValue(undefined); // Function returns undefined
+    test("should compute, box, and cache a real value on miss", async () => {
+      const key = "test:nullable-key" as CacheKey;
+      const freshValue = { id: "real" };
+      const fn = vi.fn().mockResolvedValue(freshValue);
 
-      // Mock cache miss
       mockRedis.get.mockResolvedValue(null);
-      mockRedis.exists.mockResolvedValue(0); // Key doesn't exist
 
-      const result = await cacheService.withCache(fn, key, 60000);
+      const result = await cacheService.withCacheNullable(fn, key, 60000);
+
+      expect(result).toEqual(freshValue);
+      expect(fn).toHaveBeenCalledOnce();
+      expect(mockRedis.setEx).toHaveBeenCalledWith(key, 60, box(freshValue));
+    });
+
+    test("should return boxed cached value without executing fn", async () => {
+      const key = "test:nullable-key" as CacheKey;
+      const cachedValue = { id: "cached" };
+      const fn = vi.fn().mockResolvedValue({ id: "fresh" });
+
+      mockRedis.get.mockResolvedValue(box(cachedValue));
+
+      const result = await cacheService.withCacheNullable(fn, key, 60000);
+
+      expect(result).toEqual(cachedValue);
+      expect(fn).not.toHaveBeenCalled();
+    });
+
+    test("should treat unboxed legacy values as a cache miss and overwrite with boxed value", async () => {
+      const key = "test:nullable-key" as CacheKey;
+      const legacyCachedValue = { id: "legacy" };
+      const freshValue = { id: "fresh" };
+      const fn = vi.fn().mockResolvedValue(freshValue);
+
+      mockRedis.get.mockResolvedValue(JSON.stringify(legacyCachedValue));
+
+      const result = await cacheService.withCacheNullable(fn, key, 60000);
+
+      expect(result).toEqual(freshValue);
+      expect(fn).toHaveBeenCalledOnce();
+      expect(mockRedis.setEx).toHaveBeenCalledWith(key, 60, box(freshValue));
+      expect(logger.debug).toHaveBeenCalledWith(
+        { key, ttlMs: 60000 },
+        "Nullable cache entry is missing marker or value field; treating as cache miss and refreshing"
+      );
+    });
+
+    test("should treat a marker-less object with a `value` field as a cache miss", async () => {
+      // Regression guard: the previous implementation discriminated on the
+      // presence of a `value` property alone, which would mis-unwrap any
+      // caller-supplied object that happened to contain that field.
+      const key = "test:nullable-key" as CacheKey;
+      const collidingShape = { value: { id: "colliding" }, otherField: 123 };
+      const freshValue = { id: "fresh" };
+      const fn = vi.fn().mockResolvedValue(freshValue);
+
+      mockRedis.get.mockResolvedValue(JSON.stringify(collidingShape));
+
+      const result = await cacheService.withCacheNullable(fn, key, 60000);
+
+      expect(result).toEqual(freshValue);
+      expect(fn).toHaveBeenCalledOnce();
+      expect(mockRedis.setEx).toHaveBeenCalledWith(key, 60, box(freshValue));
+    });
+
+    test("should treat a marker-only nullable envelope as a cache miss", async () => {
+      const key = "test:nullable-key" as CacheKey;
+      const malformedBox = { __fb_nullable_v1: true };
+      const freshValue = { id: "fresh" };
+      const fn = vi.fn().mockResolvedValue(freshValue);
+
+      mockRedis.get.mockResolvedValue(JSON.stringify(malformedBox));
+
+      const result = await cacheService.withCacheNullable(fn, key, 60000);
+
+      expect(result).toEqual(freshValue);
+      expect(fn).toHaveBeenCalledOnce();
+      expect(mockRedis.setEx).toHaveBeenCalledWith(key, 60, box(freshValue));
+    });
+
+    test("should not cache undefined returned by a nullable callback", async () => {
+      const key = "test:nullable-key" as CacheKey;
+      const fn = vi.fn().mockResolvedValue(undefined);
+
+      mockRedis.get.mockResolvedValue(null);
+
+      const result = await cacheService.withCacheNullable(
+        fn as unknown as () => Promise<{ id: string } | null>,
+        key,
+        60000
+      );
 
       expect(result).toBeUndefined();
       expect(fn).toHaveBeenCalledOnce();
-      // undefined should NOT be cached to preserve semantics
-      expect(mockRedis.setEx).not.toHaveBeenCalled();
-    });
-
-    test("should distinguish between null and undefined return values", async () => {
-      const nullKey = "test:null-key" as CacheKey;
-      const undefinedKey = "test:undefined-key" as CacheKey;
-
-      const nullFn = vi.fn().mockResolvedValue(null);
-      const undefinedFn = vi.fn().mockResolvedValue(undefined);
-
-      // Mock cache miss for both keys
-      mockRedis.get.mockResolvedValue(null);
-      mockRedis.exists.mockResolvedValue(0);
-
-      // Test null return value - should be cached
-      const nullResult = await cacheService.withCache(nullFn, nullKey, 60000);
-      expect(nullResult).toBeNull();
-      expect(nullFn).toHaveBeenCalledOnce();
-      expect(mockRedis.setEx).toHaveBeenCalledWith(nullKey, 60, "null");
-
-      // Reset mocks
-      vi.clearAllMocks();
-      mockRedis.get.mockResolvedValue(null);
-      mockRedis.exists.mockResolvedValue(0);
-
-      // Test undefined return value - should NOT be cached
-      const undefinedResult = await cacheService.withCache(undefinedFn, undefinedKey, 60000);
-      expect(undefinedResult).toBeUndefined();
-      expect(undefinedFn).toHaveBeenCalledOnce();
       expect(mockRedis.setEx).not.toHaveBeenCalled();
     });
 

--- a/packages/cache/src/service.test.ts
+++ b/packages/cache/src/service.test.ts
@@ -605,10 +605,7 @@ describe("CacheService", () => {
       const freshValue = { data: "fresh" };
       const fn = vi.fn().mockResolvedValue(freshValue);
 
-      // Redis returns stringified null. Under the old (racy) implementation
-      // this was treated as a cached null value if exists() returned true,
-      // letting a stale null leak to the caller. The new contract is:
-      // JSON null === cache miss, always.
+      // Bare JSON null is a miss for non-null cache-aside calls.
       mockRedis.get.mockResolvedValue("null");
 
       const result = await cacheService.withCache(fn, key, 60000);
@@ -618,18 +615,13 @@ describe("CacheService", () => {
       expect(mockRedis.setEx).toHaveBeenCalledWith(key, 60, JSON.stringify(freshValue));
     });
 
-    test("should not surface stale null under the original GET→EXISTS race window", async () => {
-      // Regression for ENG-1047: Request A's get returns JS null (key absent),
-      // then Request B writes a real value, then A's exists check would see
-      // the key. The old code returned `null as T` here; the new code calls
-      // fn() instead.
+    test("should not surface stale null under the original GET/EXISTS race window", async () => {
+      // Simulates the removed GET/EXISTS race from ENG-1047.
       const key = "test:key" as CacheKey;
       const freshValue = { data: "fresh-from-fn" };
       const fn = vi.fn().mockResolvedValue(freshValue);
 
       mockRedis.get.mockResolvedValue(null);
-      // exists is no longer consulted but stub it as if a concurrent writer
-      // had populated the key between our GET and the (now removed) EXISTS.
       mockRedis.exists.mockResolvedValue(1);
 
       const result = await cacheService.withCache(fn, key, 60000);
@@ -641,9 +633,7 @@ describe("CacheService", () => {
   });
 
   describe("withCacheNullable", () => {
-    // The wire format for nullable entries is `{ __fb_nullable_v1: true, value }`.
-    // Tests assert the literal string so that any accidental change to the
-    // marker (e.g. version bump) fails loudly and forces an intentional update.
+    // Keep the nullable wire format explicit in assertions.
     const box = (value: unknown): string => JSON.stringify({ __fb_nullable_v1: true, value });
 
     test("should return cached null without executing fn when boxed null is stored", async () => {
@@ -718,9 +708,6 @@ describe("CacheService", () => {
     });
 
     test("should treat a marker-less object with a `value` field as a cache miss", async () => {
-      // Regression guard: the previous implementation discriminated on the
-      // presence of a `value` property alone, which would mis-unwrap any
-      // caller-supplied object that happened to contain that field.
       const key = "test:nullable-key" as CacheKey;
       const collidingShape = { value: { id: "colliding" }, otherField: 123 };
       const freshValue = { id: "fresh" };

--- a/packages/cache/src/service.test.ts
+++ b/packages/cache/src/service.test.ts
@@ -630,6 +630,27 @@ describe("CacheService", () => {
       expect(fn).toHaveBeenCalledOnce();
       expect(mockRedis.exists).not.toHaveBeenCalled();
     });
+
+    test("should not persist null returned via type erasure (no recompute stampede)", async () => {
+      // withCache<T> is constrained to NonNullable<unknown>, but a caller can
+      // still bypass that through unknown/any plumbing or an erased generic.
+      // If null were written, the read path would treat it as a perpetual miss,
+      // re-running fn() and rewriting "null" on every request for a hot key.
+      const key = "test:key" as CacheKey;
+      const fn = vi.fn().mockResolvedValue(null);
+
+      mockRedis.get.mockResolvedValue(null); // cache miss
+
+      const result = await cacheService.withCache(
+        fn as unknown as () => Promise<{ data: string }>,
+        key,
+        60000
+      );
+
+      expect(result).toBeNull();
+      expect(fn).toHaveBeenCalledOnce();
+      expect(mockRedis.setEx).not.toHaveBeenCalled();
+    });
   });
 
   describe("withCacheNullable", () => {

--- a/packages/cache/src/service.ts
+++ b/packages/cache/src/service.ts
@@ -6,13 +6,7 @@ import { ZCacheKey } from "@/types/keys";
 import { ZTtlMs, ZTtlMsOptional } from "@/types/service";
 import { validateInputs } from "./utils/validation";
 
-/**
- * Sentinel marker stamped onto values cached via {@link CacheService.withCacheNullable}.
- * Using an unlikely property name (rather than just `value`) prevents collisions
- * with caller-supplied objects that happen to have a `value` field, and lets the
- * type guard distinguish boxed entries from legacy/raw cached objects safely.
- * The `v1` suffix lets us bump the wire format if the box shape ever changes.
- */
+/** Marker for the nullable cache wire format. */
 const NULLABLE_BOX_MARKER = "__fb_nullable_v1";
 
 interface NullableCacheBox<T> {
@@ -151,10 +145,7 @@ export class CacheService {
       return validation;
     }
 
-    // Surface accidental undefined writes loudly instead of silently coercing
-    // them to JSON null — caching `undefined` is almost always a programmer
-    // error. Callers that intentionally want to cache a nullable value should
-    // go through withCacheNullable, which boxes the value explicitly.
+    // Undefined is a caller bug, not a cacheable null.
     if (value === undefined) {
       logger.warn({ key, ttlMs }, "cache.set called with undefined; skipping write");
       return ok(undefined);
@@ -254,14 +245,7 @@ export class CacheService {
   /**
    * Cache wrapper for functions (cache-aside).
    *
-   * Cache hit/miss is determined by a single GET — a JSON `null` in Redis is
-   * treated as a miss. This eliminates the GET+EXISTS race that could otherwise
-   * surface a stale null to callers whose contract is non-null.
-   *
-   * T is constrained to NonNullable so callers cannot accidentally rely on
-   * `null` being served from cache. To cache a value that may be `null`, use
-   * {@link withCacheNullable}.
-   *
+   * Bare JSON null is treated as a miss; use withCacheNullable for intentional null values.
    * Never throws due to cache errors; function errors propagate without retry.
    *
    * @param fn - Function to execute (and optionally cache).
@@ -291,11 +275,7 @@ export class CacheService {
   /**
    * Cache wrapper for functions whose result may legitimately be `null`.
    *
-   * Boxes the value in a marked envelope (see {@link NULLABLE_BOX_MARKER})
-   * before writing so that a real cached `null` is distinguishable from a
-   * cache miss without a second Redis round-trip, and so that the unwrap step
-   * cannot be confused by caller objects that happen to expose a `value` field.
-   * The box is stripped before returning to the caller.
+   * Stores results in a marked envelope so cached nulls are distinct from misses.
    *
    * @param fn - Function to execute (and optionally cache); may return null.
    * @param key - Cache key
@@ -324,12 +304,7 @@ export class CacheService {
     }
 
     const fresh = await fn();
-    // Runtime defense beyond what the type system enforces: a buggy caller can
-    // resolve undefined from a Promise typed as `T | null`. Wrapping that in
-    // `{ value: undefined }` would survive trySetCache's own undefined check,
-    // then JSON.stringify would drop the property and persist the garbage
-    // shape `{}` — which fails isNullableCacheBox on every subsequent read and
-    // turns the key into an infinite recompute loop.
+    // Guard against type-erased callers resolving undefined.
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- types exclude undefined; this guards against type-erasure bugs
     if (fresh !== undefined) {
       const box: NullableCacheBox<T> = { [NULLABLE_BOX_MARKER]: true, value: fresh };
@@ -338,11 +313,7 @@ export class CacheService {
     return fresh;
   }
 
-  /**
-   * Shared preamble for the cache-aside wrappers: confirms Redis is reachable
-   * and inputs validate. Returns false when the caller should bypass the cache
-   * and execute the underlying function directly.
-   */
+  /** Returns false when callers should bypass cache and execute directly. */
   private canUseCache(key: CacheKey, ttlMs: number): boolean {
     if (!this.isRedisClientReady()) {
       return false;

--- a/packages/cache/src/service.ts
+++ b/packages/cache/src/service.ts
@@ -358,8 +358,16 @@ export class CacheService {
   }
 
   private async trySetCache(key: CacheKey, value: unknown, ttlMs: number): Promise<void> {
-    if (value === undefined) {
-      return; // Skip caching undefined values
+    // Never persist null/undefined. The read path (tryGetCachedValue) treats a
+    // stored JSON `null` as a cache miss, so writing one is not just useless —
+    // it causes a recompute-and-rewrite loop on every request for a hot key.
+    // This also hardens withCache against a `null` slipping past its
+    // `NonNullable<T>` constraint via type erasure (unknown/any plumbing, casts),
+    // which is the exact class of bug this change set fixes. withCacheNullable is
+    // unaffected: it always writes a non-null boxed envelope, never raw null.
+    if (value === undefined || value === null) {
+      logger.debug({ key, ttlMs }, "Refusing to cache nullish value; treating as non-cacheable");
+      return;
     }
 
     try {

--- a/packages/cache/src/service.ts
+++ b/packages/cache/src/service.ts
@@ -7,6 +7,20 @@ import { ZTtlMs, ZTtlMsOptional } from "@/types/service";
 import { validateInputs } from "./utils/validation";
 
 /**
+ * Sentinel marker stamped onto values cached via {@link CacheService.withCacheNullable}.
+ * Using an unlikely property name (rather than just `value`) prevents collisions
+ * with caller-supplied objects that happen to have a `value` field, and lets the
+ * type guard distinguish boxed entries from legacy/raw cached objects safely.
+ * The `v1` suffix lets us bump the wire format if the box shape ever changes.
+ */
+const NULLABLE_BOX_MARKER = "__fb_nullable_v1";
+
+interface NullableCacheBox<T> {
+  [NULLABLE_BOX_MARKER]: true;
+  value: T | null;
+}
+
+/**
  * Core cache service providing basic Redis operations with JSON serialization
  */
 export class CacheService {
@@ -87,7 +101,8 @@ export class CacheService {
   }
 
   /**
-   * Check if a key exists in cache (for distinguishing cache miss from cached null)
+   * Check if a key exists in cache.
+   * Prefer single-GET cache-aside semantics in withCache to avoid TOCTOU races.
    * @param key - Cache key to check
    * @returns Result containing boolean indicating if key exists
    */
@@ -136,10 +151,17 @@ export class CacheService {
       return validation;
     }
 
+    // Surface accidental undefined writes loudly instead of silently coercing
+    // them to JSON null — caching `undefined` is almost always a programmer
+    // error. Callers that intentionally want to cache a nullable value should
+    // go through withCacheNullable, which boxes the value explicitly.
+    if (value === undefined) {
+      logger.warn({ key, ttlMs }, "cache.set called with undefined; skipping write");
+      return ok(undefined);
+    }
+
     try {
-      // Normalize undefined to null to maintain consistent cached-null semantics
-      const normalizedValue = value === undefined ? null : value;
-      const serialized = JSON.stringify(normalizedValue);
+      const serialized = JSON.stringify(value);
 
       if (ttlMs === undefined) {
         // Set without expiration (persists indefinitely)
@@ -231,21 +253,28 @@ export class CacheService {
 
   /**
    * Cache wrapper for functions (cache-aside).
+   *
+   * Cache hit/miss is determined by a single GET — a JSON `null` in Redis is
+   * treated as a miss. This eliminates the GET+EXISTS race that could otherwise
+   * surface a stale null to callers whose contract is non-null.
+   *
+   * T is constrained to NonNullable so callers cannot accidentally rely on
+   * `null` being served from cache. To cache a value that may be `null`, use
+   * {@link withCacheNullable}.
+   *
    * Never throws due to cache errors; function errors propagate without retry.
-   * Must include null in T to support cached null values.
+   *
    * @param fn - Function to execute (and optionally cache).
    * @param key - Cache key
    * @param ttlMs - Time to live in milliseconds
    * @returns Cached value if present, otherwise fresh result from fn()
    */
-  async withCache<T>(fn: () => Promise<T>, key: CacheKey, ttlMs: number): Promise<T> {
-    if (!this.isRedisClientReady()) {
-      return await fn();
-    }
-
-    const validation = validateInputs([key, ZCacheKey], [ttlMs, ZTtlMs]);
-    if (!validation.ok) {
-      logger.warn({ error: validation.error, key }, "Invalid cache inputs, executing function directly");
+  async withCache<T extends NonNullable<unknown>>(
+    fn: () => Promise<T>,
+    key: CacheKey,
+    ttlMs: number
+  ): Promise<T> {
+    if (!this.canUseCache(key, ttlMs)) {
       return await fn();
     }
 
@@ -259,18 +288,89 @@ export class CacheService {
     return fresh;
   }
 
+  /**
+   * Cache wrapper for functions whose result may legitimately be `null`.
+   *
+   * Boxes the value in a marked envelope (see {@link NULLABLE_BOX_MARKER})
+   * before writing so that a real cached `null` is distinguishable from a
+   * cache miss without a second Redis round-trip, and so that the unwrap step
+   * cannot be confused by caller objects that happen to expose a `value` field.
+   * The box is stripped before returning to the caller.
+   *
+   * @param fn - Function to execute (and optionally cache); may return null.
+   * @param key - Cache key
+   * @param ttlMs - Time to live in milliseconds
+   * @returns Cached value if present (including a cached `null`), otherwise fresh result from fn()
+   */
+  async withCacheNullable<T extends NonNullable<unknown>>(
+    fn: () => Promise<T | null>,
+    key: CacheKey,
+    ttlMs: number
+  ): Promise<T | null> {
+    if (!this.canUseCache(key, ttlMs)) {
+      return await fn();
+    }
+
+    const cachedValue = await this.tryGetCachedValue<unknown>(key, ttlMs);
+    if (cachedValue !== undefined) {
+      if (this.isNullableCacheBox<T>(cachedValue)) {
+        return cachedValue.value;
+      }
+
+      logger.debug(
+        { key, ttlMs },
+        "Nullable cache entry is missing marker or value field; treating as cache miss and refreshing"
+      );
+    }
+
+    const fresh = await fn();
+    // Runtime defense beyond what the type system enforces: a buggy caller can
+    // resolve undefined from a Promise typed as `T | null`. Wrapping that in
+    // `{ value: undefined }` would survive trySetCache's own undefined check,
+    // then JSON.stringify would drop the property and persist the garbage
+    // shape `{}` — which fails isNullableCacheBox on every subsequent read and
+    // turns the key into an infinite recompute loop.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- types exclude undefined; this guards against type-erasure bugs
+    if (fresh !== undefined) {
+      const box: NullableCacheBox<T> = { [NULLABLE_BOX_MARKER]: true, value: fresh };
+      await this.trySetCache(key, box, ttlMs);
+    }
+    return fresh;
+  }
+
+  /**
+   * Shared preamble for the cache-aside wrappers: confirms Redis is reachable
+   * and inputs validate. Returns false when the caller should bypass the cache
+   * and execute the underlying function directly.
+   */
+  private canUseCache(key: CacheKey, ttlMs: number): boolean {
+    if (!this.isRedisClientReady()) {
+      return false;
+    }
+
+    const validation = validateInputs([key, ZCacheKey], [ttlMs, ZTtlMs]);
+    if (!validation.ok) {
+      logger.warn({ error: validation.error, key }, "Invalid cache inputs, executing function directly");
+      return false;
+    }
+
+    return true;
+  }
+
+  private isNullableCacheBox<T>(value: unknown): value is NullableCacheBox<T> {
+    return (
+      typeof value === "object" &&
+      value !== null &&
+      (value as Record<string, unknown>)[NULLABLE_BOX_MARKER] === true &&
+      Object.hasOwn(value, "value")
+    );
+  }
+
   private async tryGetCachedValue<T>(key: CacheKey, ttlMs: number): Promise<T | undefined> {
     try {
       const cacheResult = await this.get<T>(key);
       if (cacheResult.ok && cacheResult.data !== null) {
         return cacheResult.data;
-      }
-
-      if (cacheResult.ok && cacheResult.data === null) {
-        const existsResult = await this.exists(key);
-        if (existsResult.ok && existsResult.data) {
-          return null as T;
-        }
       }
 
       if (!cacheResult.ok) {
@@ -280,7 +380,7 @@ export class CacheService {
         );
       }
     } catch (error) {
-      logger.debug({ error, key, ttlMs }, "Cache get/exists threw; proceeding to compute fresh value");
+      logger.debug({ error, key, ttlMs }, "Cache get threw; proceeding to compute fresh value");
     }
 
     return undefined;


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-1047.

This prevents `/api/v1/client/:workspaceId/environment` and the `/api/v2` alias from crashing when the cache layer returns `null` under a non-null typed contract.

The root issue was a cache race in `withCache`: Redis `GET` could return `null`, then a separate `EXISTS` call could observe a key written by another request and incorrectly return `null as T`. The environment endpoint then destructured that value and threw.

## Changes

- Removes the `GET` + `EXISTS` cache race by treating bare JSON `null` as a cache miss in `withCache`.
- Tightens `withCache` to non-null return contracts.
- Adds `withCacheNullable` for callers that intentionally cache `null`, using a marked nullable envelope to distinguish cached nulls from misses without a second Redis round trip.
- Hardens nullable cache handling against legacy, malformed, and marker-colliding entries so they recompute instead of leaking `undefined`.
- Stops `cache.set` from silently normalizing `undefined` to JSON `null`.
- Switches organization billing read-through cache to `withCacheNullable`, since missing billing can legitimately return `null`.
- Adds a defensive guard in the client environment endpoint so unexpected empty workspace state returns a clean 404 instead of destructuring and 500ing.
- Adds regression coverage for:
  - bare JSON `null` treated as a miss
  - the original GET/EXISTS race window
  - nullable cache round-tripping
  - malformed nullable envelopes
  - marker-less `{ value }` collisions
  - `undefined` not being cached

## How should this be tested?

```bash
pnpm --filter @formbricks/cache typecheck
pnpm --filter @formbricks/cache test -- src/service.test.ts
pnpm --filter @formbricks/web exec vitest run lib/cache/index.test.ts