### PR TITLE
fix: clear user's pending invites before account deletion (ENG-1057)

### DIFF
--- a/apps/web/lib/user/service.test.ts
+++ b/apps/web/lib/user/service.test.ts
@@ -18,6 +18,9 @@ vi.mock("@formbricks/database", () => ({
       delete: vi.fn(),
       findMany: vi.fn(),
     },
+    invite: {
+      deleteMany: vi.fn(),
+    },
   },
 }));
 
@@ -192,6 +195,7 @@ describe("User Service", () => {
   describe("deleteUser", () => {
     test("should delete user and their organizations when they are single owner", async () => {
       vi.mocked(prisma.user.delete).mockResolvedValue(mockPrismaUser);
+      vi.mocked(prisma.invite.deleteMany).mockResolvedValue({ count: 0 });
       vi.mocked(getOrganizationsWhereUserIsSingleOwner).mockResolvedValue(mockOrganizations);
       vi.mocked(deleteOrganization).mockResolvedValue();
 
@@ -200,10 +204,27 @@ describe("User Service", () => {
       expect(result).toEqual(mockPrismaUser);
       expect(getOrganizationsWhereUserIsSingleOwner).toHaveBeenCalledWith("user1");
       expect(deleteOrganization).toHaveBeenCalledWith("org1");
+      expect(prisma.invite.deleteMany).toHaveBeenCalledWith({ where: { creatorId: "user1" } });
       expect(prisma.user.delete).toHaveBeenCalledWith({
         where: { id: "user1" },
         select: publicUserSelect,
       });
+    });
+
+    // Regression for ENG-1057: Invite.creatorId has no onDelete rule, so any
+    // pending invite created by the user must be cleared before user.delete
+    // or Postgres rejects with a foreign-key constraint violation.
+    test("should delete pending invites where the user is creator before deleting the user", async () => {
+      vi.mocked(prisma.user.delete).mockResolvedValue(mockPrismaUser);
+      vi.mocked(prisma.invite.deleteMany).mockResolvedValue({ count: 3 });
+      vi.mocked(getOrganizationsWhereUserIsSingleOwner).mockResolvedValue([]);
+
+      await deleteUser("user1");
+
+      expect(prisma.invite.deleteMany).toHaveBeenCalledWith({ where: { creatorId: "user1" } });
+      const inviteDeleteOrder = vi.mocked(prisma.invite.deleteMany).mock.invocationCallOrder[0];
+      const userDeleteOrder = vi.mocked(prisma.user.delete).mock.invocationCallOrder[0];
+      expect(inviteDeleteOrder).toBeLessThan(userDeleteOrder);
     });
 
     test("should throw DatabaseError when prisma throws", async () => {
@@ -212,6 +233,7 @@ describe("User Service", () => {
         clientVersion: "5.0.0",
       });
       vi.mocked(getOrganizationsWhereUserIsSingleOwner).mockResolvedValue([]);
+      vi.mocked(prisma.invite.deleteMany).mockResolvedValue({ count: 0 });
       vi.mocked(prisma.user.delete).mockRejectedValue(prismaError);
 
       await expect(deleteUser("user1")).rejects.toThrow(DatabaseError);

--- a/apps/web/lib/user/service.ts
+++ b/apps/web/lib/user/service.ts
@@ -114,6 +114,8 @@ export const deleteUser = async (id: string): Promise<TUser> => {
       await deleteOrganization(organization.id);
     }
 
+    await prisma.invite.deleteMany({ where: { creatorId: id } });
+
     const deletedUser = await deleteUserById(id);
     await deleteBrevoCustomerByEmail({ email: deletedUser.email });
 


### PR DESCRIPTION
## Summary

Account deletion was failing with a 500 (`DatabaseError`) for any user who had created at least one pending invite. The fix clears those invites before deleting the user.

Closes ENG-1057.

## The bug

Observed in staging:

```
Invalid `prisma.user.delete()` invocation:
Foreign key constraint violated on the constraint: `Invite_creatorId_fkey`
```

The user reached the delete path successfully, but `prisma.user.delete()` was rejected by Postgres and the account stayed in place.

## Root cause

In `packages/database/schema.prisma`:

```prisma
creator   User @relation("inviteCreatedBy", fields: [creatorId], references: [id])
creatorId String
```

No `onDelete` rule on this relation → Postgres defaults to `NO ACTION` → any `Invite` row where the user is the creator blocks the user delete.

The sibling relation on the same model (`acceptor`) is already `onDelete: Cascade`, which is why accepted invites didn't cause this issue. Only pending invites (`acceptorId` is null, `creatorId` points at the user being deleted) triggered the violation.

## Fix

In `apps/web/lib/user/service.ts`, `deleteUser` now runs

```ts
await prisma.invite.deleteMany({ where: { creatorId: id } });
```

right before `deleteUserById(id)`. Pending invites are tied to a specific inviter and are meaningless once that inviter is gone, so clearing them is the cheapest correct action.

## Why this lives in `deleteUser` and not in the account-deletion action

`deleteUser` is the central user-deletion routine — it already cleans up single-owner organizations for analogous reasons. Putting the invite cleanup here covers every path that deletes a user (account self-deletion, future admin deletions, automated cleanup jobs), not only the one flow the bug was reported through.

## Test coverage

`apps/web/lib/user/service.test.ts`:

- **Existing happy-path test** now also asserts `prisma.invite.deleteMany` was called with `{ where: { creatorId: "user1" } }`.
- **New regression test** `"should delete pending invites where the user is creator before deleting the user"` — verifies both that `invite.deleteMany` is called with the right argument **and** that it runs strictly before `user.delete` (using `mock.invocationCallOrder`). The ordering is the load-bearing property; a future refactor that reordered them would silently re-introduce the FK violation, and this test would catch it.
- **DatabaseError test** updated to mock the new call so it still exercises the error path.

13 / 13 tests pass.

## Acceptance criteria

- ✅ A user with one or more pending invites where they are the creator can complete account deletion successfully.
- ✅ Regression test added.

## Out of scope

- The unrelated Hub `deleteHubTenantData failed — 404 page not found` warning observed during the same flow in staging logs — separate, non-blocking, likely caused by the Hub image on staging still being below 0.4.0.
- Schema-level fix (`onDelete: SetNull` or `onDelete: Cascade`). Either would also work but require a migration and a schema decision (do we want invite history preserved or fully removed?). The code-level fix is sufficient, immediate, and doesn't pre-commit to a schema design.

## Test plan

- [ ] CI passes.
- [ ] On a staging or local environment, log in as a user who has pending invites (or seed one), trigger account deletion, confirm:
  - The account is deleted (200, redirected out).
  - Pending invites from that user are gone from the `Invite` table.
- [ ] Confirm no regression for users without any pending invites — `invite.deleteMany` is a no-op when nothing matches.