### PR TITLE
feat: add browser language auto-selection

### DIFF
--- a/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.ts
@@ -81,6 +81,7 @@ export const getWorkspaceStateData = async (workspaceId: string): Promise<Worksp
             variables: true,
             type: true,
             showLanguageSwitch: true,
+            autoSelectLanguage: true,
             languages: {
               select: {
                 default: true,

--- a/apps/web/app/lib/templates.ts
+++ b/apps/web/app/lib/templates.ts
@@ -4925,6 +4925,7 @@ export const previewSurvey = (workspaceName: string, t: TFunction): TSurvey => {
     languages: [],
     triggers: [],
     showLanguageSwitch: false,
+    autoSelectLanguage: false,
     followUps: [],
     isBackButtonHidden: false,
     isAutoProgressingEnabled: true,

--- a/apps/web/lib/survey/__mock__/survey.mock.ts
+++ b/apps/web/lib/survey/__mock__/survey.mock.ts
@@ -218,6 +218,7 @@ const baseSurveyProperties = {
   },
   isVerifyEmailEnabled: false,
   isSingleResponsePerEmailEnabled: false,
+  autoSelectLanguage: null,
   attributeFilters: [],
   ...commonMockProperties,
 };

--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -24,6 +24,7 @@ import {
   mockActionClass,
   mockId,
   mockOrganizationOutput,
+  mockSurveyLanguages,
   mockSurveyOutput,
   mockSurveyWithLogic,
   mockTransformedSurveyOutput,
@@ -628,6 +629,33 @@ describe("Tests for createSurvey", () => {
     languages: [],
   } as TSurveyCreateInput;
 
+  const getMultiLanguageCreateSurveyInput = (): TSurveyCreateInput =>
+    ({
+      ...mockCreateSurveyInput,
+      welcomeCard: {
+        ...mockCreateSurveyInput.welcomeCard,
+        headline: { default: "Welcome", de: "Willkommen" },
+      },
+      questions: mockCreateSurveyInput.questions.map((question) => {
+        if ("choices" in question && Array.isArray(question.choices)) {
+          return {
+            ...question,
+            headline: { ...question.headline, de: question.headline.default },
+            choices: question.choices.map((choice) => ({
+              ...choice,
+              label: { ...choice.label, de: choice.label.default },
+            })),
+          };
+        }
+
+        return {
+          ...question,
+          headline: { ...question.headline, de: question.headline.default },
+        };
+      }),
+      languages: mockSurveyLanguages,
+    }) as TSurveyCreateInput;
+
   const mockActionClasses = [
     {
       id: "action-123",
@@ -658,6 +686,45 @@ describe("Tests for createSurvey", () => {
       expect(prisma.survey.create).toHaveBeenCalled();
       expect(result.name).toEqual(mockSurveyOutput.name);
       expect(subscribeOrganizationMembersToSurveyResponses).toHaveBeenCalled();
+    });
+
+    test("enables browser language auto-selection by default for new multi-language surveys", async () => {
+      vi.mocked(getOrganizationByWorkspaceId).mockResolvedValueOnce(mockOrganizationOutput);
+      prisma.survey.create.mockResolvedValueOnce({
+        ...mockSurveyOutput,
+      });
+
+      await createSurvey(mockWorkspaceId, {
+        ...getMultiLanguageCreateSurveyInput(),
+      });
+
+      expect(prisma.survey.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            autoSelectLanguage: true,
+          }),
+        })
+      );
+    });
+
+    test("preserves explicit browser language auto-selection setting on create", async () => {
+      vi.mocked(getOrganizationByWorkspaceId).mockResolvedValueOnce(mockOrganizationOutput);
+      prisma.survey.create.mockResolvedValueOnce({
+        ...mockSurveyOutput,
+      });
+
+      await createSurvey(mockWorkspaceId, {
+        ...getMultiLanguageCreateSurveyInput(),
+        autoSelectLanguage: false,
+      });
+
+      expect(prisma.survey.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            autoSelectLanguage: false,
+          }),
+        })
+      );
     });
 
     test("creates a private segment for app surveys", async () => {

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -65,6 +65,7 @@ export const selectSurvey = {
   singleUse: true,
   pin: true,
   showLanguageSwitch: true,
+  autoSelectLanguage: true,
   recaptcha: true,
   metadata: true,
   customHeadScripts: true,
@@ -631,6 +632,7 @@ export const createSurvey = async (workspaceId: string, surveyBody: TSurveyCreat
     const { createdBy, languages, ...restSurveyBody } = parsedSurveyBody;
     const normalizedCloseOn = restSurveyBody.closeOn instanceof Date ? restSurveyBody.closeOn : null;
     const normalizedPublishOn = restSurveyBody.publishOn instanceof Date ? restSurveyBody.publishOn : null;
+    const hasMultipleEnabledLanguages = (languages ?? []).filter((language) => language.enabled).length > 1;
 
     const actionClasses = await getActionClasses(parsedWorkspaceId);
 
@@ -641,6 +643,8 @@ export const createSurvey = async (workspaceId: string, surveyBody: TSurveyCreat
         publishOn: normalizedPublishOn,
         status: restSurveyBody.status ?? "draft",
       }),
+      autoSelectLanguage:
+        restSurveyBody.autoSelectLanguage ?? (hasMultipleEnabledLanguages ? true : undefined),
       // @ts-expect-error - languages would be undefined in case of empty array
       languages: languages?.length ? languages : undefined,
       triggers: restSurveyBody.triggers

--- a/apps/web/lib/utils/locale.test.ts
+++ b/apps/web/lib/utils/locale.test.ts
@@ -2,7 +2,7 @@ import * as nextHeaders from "next/headers";
 import { describe, expect, test, vi } from "vitest";
 import { AVAILABLE_LOCALES, DEFAULT_LOCALE } from "@/lib/constants";
 import { appLanguages } from "@/lib/i18n/utils";
-import { findMatchingLocale } from "./locale";
+import { findMatchingBrowserLanguageCodes, findMatchingLocale } from "./locale";
 
 // Mock the Next.js headers function
 vi.mock("next/headers", () => ({
@@ -34,6 +34,26 @@ describe("locale", () => {
 
     expect(result).toBe(testLocale);
     expect(nextHeaders.headers).toHaveBeenCalled();
+  });
+
+  test("ignores Accept-Language quality values when matching locales", async () => {
+    vi.mocked(nextHeaders.headers).mockReturnValue({
+      get: vi.fn().mockReturnValue("de-DE;q=0.9,en-US;q=0.8"),
+    } as any);
+
+    const result = await findMatchingLocale();
+
+    expect(result).toBe("de-DE");
+  });
+
+  test("returns browser language codes without quality values", async () => {
+    vi.mocked(nextHeaders.headers).mockReturnValue({
+      get: vi.fn().mockReturnValue("es-MX,es;q=0.9,en-US;q=0.8"),
+    } as any);
+
+    const result = await findMatchingBrowserLanguageCodes();
+
+    expect(result).toEqual(["es-MX", "es", "en-US"]);
   });
 
   test("returns normalized match when available", async () => {

--- a/apps/web/lib/utils/locale.ts
+++ b/apps/web/lib/utils/locale.ts
@@ -2,11 +2,25 @@ import { headers } from "next/headers";
 import { TUserLocale } from "@formbricks/types/user";
 import { AVAILABLE_LOCALES, DEFAULT_LOCALE } from "@/lib/constants";
 
+const getAcceptedLanguageCodesFromHeader = (acceptLanguage: string | null): string[] => {
+  return (
+    acceptLanguage
+      ?.split(",")
+      .map((language) => language.trim().split(";")[0].trim())
+      .filter(Boolean) ?? []
+  );
+};
+
+export const findMatchingBrowserLanguageCodes = async (): Promise<string[]> => {
+  const headersList = await headers();
+  return getAcceptedLanguageCodesFromHeader(headersList.get("accept-language"));
+};
+
 export const findMatchingLocale = async (): Promise<TUserLocale> => {
   const headersList = await headers();
   const acceptLanguage = headersList.get("accept-language");
-  const userLocales = acceptLanguage?.split(",");
-  if (!userLocales) {
+  const userLocales = getAcceptedLanguageCodesFromHeader(acceptLanguage);
+  if (!userLocales.length) {
     return DEFAULT_LOCALE;
   }
   // First, try to find an exact match without normalization

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "Automatisches Speichern deaktiviert",
         "auto_save_disabled_tooltip": "Deine Umfrage wird nur im Entwurfsmodus automatisch gespeichert. So wird sichergestellt, dass öffentliche Umfragen nicht versehentlich aktualisiert werden.",
         "auto_save_on": "Automatisches Speichern an",
+        "auto_select_browser_language": "Browsersprache standardmäßig verwenden",
+        "auto_select_browser_language_description": "Öffnet die Umfrage automatisch in der Browsersprache der befragten Person, wenn diese Sprache aktiv ist. Fällt auf die Standardsprache zurück.",
         "automatically_close_survey_after_n_seconds_if_no_response": "Umfrage automatisch nach <autoCloseInput /> Sekunden schließen, wenn nach dem Auslösen keine Antwort erfolgt.",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "Schließe die Umfrage automatisch nach einer bestimmten Anzahl an Antworten.",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "Schließe die Umfrage automatisch, wenn der Nutzer nach einer bestimmten Anzahl an Sekunden nicht antwortet.",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "Auto-save disabled",
         "auto_save_disabled_tooltip": "Your survey is only auto-saved when in draft. This assures public surveys are not unintentionally updated.",
         "auto_save_on": "Auto-save on",
+        "auto_select_browser_language": "Use browser language by default",
+        "auto_select_browser_language_description": "Automatically open the survey in the respondent's browser language when that language is active. Falls back to the default language.",
         "automatically_close_survey_after_n_seconds_if_no_response": "Automatically close survey after <autoCloseInput /> seconds after trigger if no response.",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "Automatically close the survey after a certain number of responses.",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "Automatically close the survey if the user does not respond after certain number of seconds.",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "Guardado automático desactivado",
         "auto_save_disabled_tooltip": "Su encuesta solo se guarda automáticamente cuando está en borrador. Esto asegura que las encuestas públicas no se actualicen involuntariamente.",
         "auto_save_on": "Guardado automático activado",
+        "auto_select_browser_language": "Usar el idioma del navegador por defecto",
+        "auto_select_browser_language_description": "Abre automáticamente la encuesta en el idioma del navegador de la persona encuestada cuando ese idioma está activo. Si no coincide, usa el idioma predeterminado.",
         "automatically_close_survey_after_n_seconds_if_no_response": "Cerrar automáticamente la encuesta después de <autoCloseInput /> segundos tras el disparador si no hay respuesta.",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "Cerrar automáticamente la encuesta después de un cierto número de respuestas.",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "Cerrar automáticamente la encuesta si el usuario no responde después de cierto número de segundos.",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "Sauvegarde automatique désactivée",
         "auto_save_disabled_tooltip": "Votre sondage n'est sauvegardé automatiquement que lorsqu'il est en brouillon. Cela garantit que les sondages publics ne sont pas mis à jour involontairement.",
         "auto_save_on": "Sauvegarde automatique activée",
+        "auto_select_browser_language": "Utiliser la langue du navigateur par défaut",
+        "auto_select_browser_language_description": "Ouvre automatiquement l'enquête dans la langue du navigateur de la personne interrogée lorsque cette langue est active. Sinon, la langue par défaut est utilisée.",
         "automatically_close_survey_after_n_seconds_if_no_response": "Fermer automatiquement le sondage après <autoCloseInput /> secondes suivant le déclenchement si aucune réponse.",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "Fermer automatiquement l'enquête après un certain nombre de réponses.",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "Fermer automatiquement l'enquête si l'utilisateur ne répond pas après un certain nombre de secondes.",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "Az automatikus mentés letiltva",
         "auto_save_disabled_tooltip": "A kérdőív csak akkor kerül automatikusan mentésre, ha piszkozatban van. Ez biztosítja, hogy a nyilvános kérdőívek ne legyenek véletlenül frissítve.",
         "auto_save_on": "Automatikus mentés bekapcsolva",
+        "auto_select_browser_language": "A böngésző nyelvének használata alapértelmezésként",
+        "auto_select_browser_language_description": "Automatikusan a válaszadó böngészőnyelvén nyitja meg a kérdőívet, ha ez a nyelv aktív. Ellenkező esetben az alapértelmezett nyelvre vált.",
         "automatically_close_survey_after_n_seconds_if_no_response": "Kérdőív automatikus lezárása az aktiváló utáni <autoCloseInput /> másodperc után, ha nincs válasz.",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "A kérdőív automatikus lezárása egy bizonyos számú válasz után.",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "A kérdőív automatikus lezárása, ha a felhasználó nem válaszol egy bizonyos másodpercnyi idő után.",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "自動保存が無効",
         "auto_save_disabled_tooltip": "アンケートは下書き状態の時のみ自動保存されます。これにより、公開中のアンケートが意図せず更新されることを防ぎます。",
         "auto_save_on": "自動保存オン",
+        "auto_select_browser_language": "ブラウザーの言語をデフォルトで使用",
+        "auto_select_browser_language_description": "その言語が有効な場合、回答者のブラウザー言語でアンケートを自動的に開きます。一致しない場合はデフォルト言語に戻ります。",
         "automatically_close_survey_after_n_seconds_if_no_response": "トリガー後、応答がない場合は<autoCloseInput />秒後に自動的にアンケートを閉じます。",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "一定の回答数に達した後にフォームを自動的に閉じます。",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "ユーザーが一定秒数応答しない場合、フォームを自動的に閉じます。",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "Automatisch opslaan uitgeschakeld",
         "auto_save_disabled_tooltip": "Uw enquête wordt alleen automatisch opgeslagen wanneer deze een concept is. Dit zorgt ervoor dat openbare enquêtes niet onbedoeld worden bijgewerkt.",
         "auto_save_on": "Automatisch opslaan aan",
+        "auto_select_browser_language": "Browsertaal standaard gebruiken",
+        "auto_select_browser_language_description": "Opent de enquête automatisch in de browsertaal van de respondent wanneer die taal actief is. Valt terug op de standaardtaal.",
         "automatically_close_survey_after_n_seconds_if_no_response": "Sluit de enquête automatisch na <autoCloseInput /> seconden na activering als er geen reactie is.",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "Sluit de enquête automatisch af na een bepaald aantal reacties.",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "Sluit de enquête automatisch af als de gebruiker na een bepaald aantal seconden niet reageert.",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "Salvamento automático desativado",
         "auto_save_disabled_tooltip": "Sua pesquisa só é salva automaticamente quando está em rascunho. Isso garante que pesquisas públicas não sejam atualizadas involuntariamente.",
         "auto_save_on": "Salvamento automático ativado",
+        "auto_select_browser_language": "Usar o idioma do navegador por padrão",
+        "auto_select_browser_language_description": "Abre automaticamente a pesquisa no idioma do navegador do respondente quando esse idioma está ativo. Caso contrário, usa o idioma padrão.",
         "automatically_close_survey_after_n_seconds_if_no_response": "Fechar a pesquisa automaticamente após <autoCloseInput /> segundos depois do acionamento, caso não haja resposta.",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "Fechar automaticamente a pesquisa depois de um certo número de respostas.",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "Feche automaticamente a pesquisa se o usuário não responder depois de alguns segundos.",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "Guardar automático desativado",
         "auto_save_disabled_tooltip": "O seu inquérito só é guardado automaticamente quando está em rascunho. Isto garante que os inquéritos públicos não sejam atualizados involuntariamente.",
         "auto_save_on": "Guardar automático ativado",
+        "auto_select_browser_language": "Usar o idioma do navegador por predefinição",
+        "auto_select_browser_language_description": "Abre automaticamente o inquérito no idioma do navegador do respondente quando esse idioma está ativo. Caso contrário, usa o idioma predefinido.",
         "automatically_close_survey_after_n_seconds_if_no_response": "Fechar automaticamente o inquérito após <autoCloseInput /> segundos após o acionamento se não houver resposta.",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "Fechar automaticamente o inquérito após um certo número de respostas",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "Fechar automaticamente o inquérito se o utilizador não responder após um certo número de segundos.",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "Salvare automată dezactivată",
         "auto_save_disabled_tooltip": "Chestionarul dvs. este salvat automat doar când este în ciornă. Acest lucru asigură că sondajele publice nu sunt actualizate neintenționat.",
         "auto_save_on": "Salvare automată activată",
+        "auto_select_browser_language": "Folosește implicit limba browserului",
+        "auto_select_browser_language_description": "Deschide automat sondajul în limba browserului respondentului atunci când această limbă este activă. Revine la limba implicită.",
         "automatically_close_survey_after_n_seconds_if_no_response": "Închide automat chestionarul după <autoCloseInput /> secunde de la declanșare dacă nu există răspuns.",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "Închideți automat sondajul după un număr anumit de răspunsuri.",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "Închideți automat sondajul dacă utilizatorul nu răspunde după un anumit număr de secunde.",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "Автосохранение отключено",
         "auto_save_disabled_tooltip": "Ваш опрос автоматически сохраняется только в режиме черновика. Это гарантирует, что публичные опросы не будут случайно обновлены.",
         "auto_save_on": "Автосохранение включено",
+        "auto_select_browser_language": "Использовать язык браузера по умолчанию",
+        "auto_select_browser_language_description": "Автоматически открывает опрос на языке браузера респондента, если этот язык активен. В противном случае используется язык по умолчанию.",
         "automatically_close_survey_after_n_seconds_if_no_response": "Автоматически закрыть опрос через <autoCloseInput /> секунд после запуска, если нет ответа.",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "Автоматически закрывать опрос после определённого количества ответов.",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "Автоматически закрывать опрос, если пользователь не ответил за определённое количество секунд.",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "Automatisk sparning inaktiverad",
         "auto_save_disabled_tooltip": "Din enkät sparas endast automatiskt när den är ett utkast. Detta säkerställer att publika enkäter inte uppdateras oavsiktligt.",
         "auto_save_on": "Automatisk sparning på",
+        "auto_select_browser_language": "Använd webbläsarens språk som standard",
+        "auto_select_browser_language_description": "Öppnar automatiskt enkäten på respondentens webbläsarspråk när det språket är aktivt. Faller tillbaka till standardspråket.",
         "automatically_close_survey_after_n_seconds_if_no_response": "Stäng enkäten automatiskt efter <autoCloseInput /> sekunder om inget svar ges.",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "Stäng enkäten automatiskt efter ett visst antal svar.",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "Stäng enkäten automatiskt om användaren inte svarar efter ett visst antal sekunder.",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "Otomatik kaydetme devre dışı",
         "auto_save_disabled_tooltip": "Anketin otomatik olarak kaydedilmesi yalnızca taslak durumdayken çalışır. Bu, yayınlanmış anketlerin istemeden güncellenmemesini sağlar.",
         "auto_save_on": "Otomatik kaydetme açık",
+        "auto_select_browser_language": "Varsayılan olarak tarayıcı dilini kullan",
+        "auto_select_browser_language_description": "Bu dil aktif olduğunda anketi otomatik olarak yanıtlayıcının tarayıcı dilinde açar. Eşleşme yoksa varsayılan dile döner.",
         "automatically_close_survey_after_n_seconds_if_no_response": "Yanıt alınmazsa, tetiklendikten <autoCloseInput /> saniye sonra anketi otomatik olarak kapat.",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "Belirli sayıda yanıt alındıktan sonra anketi otomatik olarak kapat.",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "Kullanıcı belirli saniye içinde yanıt vermezse anketi otomatik olarak kapat.",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "自动保存已禁用",
         "auto_save_disabled_tooltip": "您的调查仅在草稿状态时自动保存。这确保公开的调查不会被意外更新。",
         "auto_save_on": "自动保存已启用",
+        "auto_select_browser_language": "默认使用浏览器语言",
+        "auto_select_browser_language_description": "当受访者的浏览器语言处于启用状态时，自动以该语言打开调查。否则回退到默认语言。",
         "automatically_close_survey_after_n_seconds_if_no_response": "如果没有回复，在触发后 <autoCloseInput /> 秒自动关闭调查。",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "自动 关闭 调查 在 达到 一定数量 的 回应 后",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "用户未在一定秒数内应答时 自动关闭 问卷",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -2845,6 +2845,8 @@
         "auto_save_disabled": "自動儲存已停用",
         "auto_save_disabled_tooltip": "您的問卷僅在草稿狀態時自動儲存。這確保公開的問卷不會被意外更新。",
         "auto_save_on": "自動儲存已啟用",
+        "auto_select_browser_language": "預設使用瀏覽器語言",
+        "auto_select_browser_language_description": "當受訪者的瀏覽器語言已啟用時，自動以該語言開啟問卷。否則會回到預設語言。",
         "automatically_close_survey_after_n_seconds_if_no_response": "若觸發後無回應，將在 <autoCloseInput /> 秒後自動關閉問卷。",
         "automatically_close_the_survey_after_a_certain_number_of_responses": "在收到一定數量的回覆後自動關閉問卷。",
         "automatically_close_the_survey_if_the_user_does_not_respond_after_certain_number_of_seconds": "如果用戶在特定秒數後未回應，則自動關閉問卷。",

--- a/apps/web/modules/api/v2/management/surveys/types/surveys.ts
+++ b/apps/web/modules/api/v2/management/surveys/types/surveys.ts
@@ -51,6 +51,7 @@ export const ZSurveyInput = ZSurveyWithoutQuestionType.pick({
   styling: true,
   workspaceOverwrites: true,
   showLanguageSwitch: true,
+  autoSelectLanguage: true,
 })
   .partial({
     redirectUrl: true,
@@ -66,6 +67,7 @@ export const ZSurveyInput = ZSurveyWithoutQuestionType.pick({
     styling: true,
     workspaceOverwrites: true,
     showLanguageSwitch: true,
+    autoSelectLanguage: true,
     inlineTriggers: true,
     displayPercentage: true,
   })

--- a/apps/web/modules/survey/lib/survey.ts
+++ b/apps/web/modules/survey/lib/survey.ts
@@ -41,6 +41,7 @@ export const selectSurvey = {
   singleUse: true,
   pin: true,
   showLanguageSwitch: true,
+  autoSelectLanguage: true,
   recaptcha: true,
   isBackButtonHidden: true,
   isAutoProgressingEnabled: true,

--- a/apps/web/modules/survey/link/components/survey-renderer.tsx
+++ b/apps/web/modules/survey/link/components/survey-renderer.tsx
@@ -21,6 +21,7 @@ import { VerifyEmail } from "@/modules/survey/link/components/verify-email";
 import { getEmailVerificationDetails } from "@/modules/survey/link/lib/helper";
 import type { TLinkSurveySearchParams } from "@/modules/survey/link/lib/types";
 import { hasUserIdSearchParam } from "@/modules/survey/link/lib/user-id";
+import { getSurveyLanguageCode } from "@/modules/survey/link/lib/utils";
 import { TWorkspaceContextForLinkSurvey } from "@/modules/survey/link/lib/workspace";
 
 interface SurveyRendererProps {
@@ -34,6 +35,7 @@ interface SurveyRendererProps {
   // New props - pre-fetched in parent
   workspaceContext: TWorkspaceContextForLinkSurvey;
   locale: TUserLocale;
+  browserLanguageCodes?: string[];
   responseCount?: number;
 }
 
@@ -58,6 +60,7 @@ export const renderSurvey = async ({
   isPreview,
   workspaceContext,
   locale,
+  browserLanguageCodes = [],
   responseCount,
 }: SurveyRendererProps) => {
   const langParam = searchParams.lang;
@@ -109,7 +112,7 @@ export const renderSurvey = async ({
         <VerifyEmail
           survey={survey}
           isErrorComponent={true}
-          languageCode={getLanguageCode(langParam, survey)}
+          languageCode={getSurveyLanguageCode(langParam, survey, browserLanguageCodes)}
           styling={workspace.styling}
           locale={locale}
         />
@@ -120,7 +123,7 @@ export const renderSurvey = async ({
         singleUseId={searchParams.suId ?? ""}
         singleUseToken={searchParams.suToken}
         survey={survey}
-        languageCode={getLanguageCode(langParam, survey)}
+        languageCode={getSurveyLanguageCode(langParam, survey, browserLanguageCodes)}
         styling={workspace.styling}
         locale={locale}
       />
@@ -129,7 +132,7 @@ export const renderSurvey = async ({
 
   // Compute final styling based on workspace and survey settings
   const styling = computeStyling(workspace.styling, survey.styling);
-  const languageCode = getLanguageCode(langParam, survey);
+  const languageCode = getSurveyLanguageCode(langParam, survey, browserLanguageCodes);
   const publicDomain = getPublicDomain();
   const canReadUserIdFromUrl =
     allowUrlUserIdLookup && !contactId && hasUserIdSearchParam(searchParams)
@@ -201,25 +204,4 @@ function computeStyling(
     return workspaceStyling;
   }
   return surveyStyling?.overwriteThemeStyling ? surveyStyling : workspaceStyling;
-}
-
-/**
- * Determines the language code to use for the survey.
- * Checks URL parameter against available survey languages and returns
- * "default" if language is not found or disabled.
- */
-function getLanguageCode(langParam: string | undefined, survey: TSurvey): string {
-  if (!langParam) return "default";
-
-  const selectedLanguage = survey.languages.find((surveyLanguage) => {
-    return (
-      surveyLanguage.language.code.toLowerCase() === langParam.toLowerCase() ||
-      surveyLanguage.language.alias?.toLowerCase() === langParam.toLowerCase()
-    );
-  });
-
-  if (!selectedLanguage || selectedLanguage?.default || !selectedLanguage?.enabled) {
-    return "default";
-  }
-  return selectedLanguage.language.code;
 }

--- a/apps/web/modules/survey/link/contact-survey/page.tsx
+++ b/apps/web/modules/survey/link/contact-survey/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { findMatchingLocale } from "@/lib/utils/locale";
+import { findMatchingBrowserLanguageCodes, findMatchingLocale } from "@/lib/utils/locale";
 import { getTranslate } from "@/lingodotdev/server";
 import { verifyContactSurveyToken } from "@/modules/ee/contacts/lib/contact-survey-link";
 import { getResponseCountBySurveyId } from "@/modules/survey/lib/response";
@@ -136,10 +136,11 @@ export const ContactSurveyPage = async (props: ContactSurveyPageProps) => {
     singleUseId = validatedSingleUseId;
   }
 
-  // Parallel fetch of environment context and locale
-  const [workspaceContext, locale, singleUseResponse] = await Promise.all([
+  // Parallel fetch of workspace context, locale, browser language, and contact response
+  const [workspaceContext, locale, browserLanguageCodes, singleUseResponse] = await Promise.all([
     getWorkspaceContextForLinkSurvey(survey.workspaceId),
     findMatchingLocale(),
+    findMatchingBrowserLanguageCodes(),
     // Fetch existing response for this contact
     getExistingContactResponse(survey.id, contactId)(),
   ]);
@@ -158,6 +159,7 @@ export const ContactSurveyPage = async (props: ContactSurveyPageProps) => {
     singleUseResponse,
     workspaceContext,
     locale,
+    browserLanguageCodes,
     responseCount,
   });
 };

--- a/apps/web/modules/survey/link/lib/data.ts
+++ b/apps/web/modules/survey/link/lib/data.ts
@@ -58,6 +58,7 @@ export const getSurveyWithMetadata = reactCache(async (surveyId: string) => {
         styling: true,
         surveyClosedMessage: true,
         showLanguageSwitch: true,
+        autoSelectLanguage: true,
         recaptcha: true,
         metadata: true,
 

--- a/apps/web/modules/survey/link/lib/utils.test.ts
+++ b/apps/web/modules/survey/link/lib/utils.test.ts
@@ -3,7 +3,13 @@ import { TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
 import { TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
-import { getElementsFromSurveyBlocks, getWebAppLocale, isRTL, isRTLLanguage } from "./utils";
+import {
+  getElementsFromSurveyBlocks,
+  getSurveyLanguageCode,
+  getWebAppLocale,
+  isRTL,
+  isRTLLanguage,
+} from "./utils";
 
 const createMockSurvey = (languages: TSurvey["languages"] = []): TSurvey =>
   ({
@@ -45,6 +51,7 @@ const createMockSurvey = (languages: TSurvey["languages"] = []): TSurvey =>
     delay: 0,
     autoComplete: null,
     showLanguageSwitch: null,
+    autoSelectLanguage: null,
     recaptcha: null,
     isBackButtonHidden: false,
     isCaptureIpEnabled: false,
@@ -95,6 +102,80 @@ describe("getWebAppLocale", () => {
   test("matches base language code for variants", () => {
     expect(getWebAppLocale("pt-PT", createMockSurvey())).toBe("pt-PT");
     expect(getWebAppLocale("es-MX", createMockSurvey())).toBe("es-ES");
+  });
+});
+
+describe("getSurveyLanguageCode", () => {
+  const language = (code: string, overrides: Partial<TSurvey["languages"][number]> = {}) => ({
+    language: {
+      id: `lang-${code}`,
+      code,
+      alias: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      projectId: "p1",
+    },
+    default: false,
+    enabled: true,
+    ...overrides,
+  });
+
+  test("uses the URL language parameter before browser language auto-selection", () => {
+    const survey = {
+      ...createMockSurvey([language("en", { default: true }), language("de")]),
+      autoSelectLanguage: true,
+    };
+
+    expect(getSurveyLanguageCode("de", survey, ["en-US"])).toBe("de");
+  });
+
+  test("matches browser language exactly when auto-selection is enabled", () => {
+    const survey = {
+      ...createMockSurvey([language("en", { default: true }), language("de-DE")]),
+      autoSelectLanguage: true,
+    };
+
+    expect(getSurveyLanguageCode(undefined, survey, ["de-DE", "en-US"])).toBe("de-DE");
+  });
+
+  test("matches browser language by base language when exact variant is unavailable", () => {
+    const survey = {
+      ...createMockSurvey([language("en", { default: true }), language("es-ES")]),
+      autoSelectLanguage: true,
+    };
+
+    expect(getSurveyLanguageCode(undefined, survey, ["es-MX", "en-US"])).toBe("es-ES");
+  });
+
+  test("uses aliases and ignores disabled languages", () => {
+    const survey = {
+      ...createMockSurvey([
+        language("en", { default: true }),
+        language("de", { enabled: false }),
+        language("fr-FR", {
+          language: {
+            id: "lang-fr-FR",
+            code: "fr-FR",
+            alias: "fr",
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            projectId: "p1",
+          },
+        }),
+      ]),
+      autoSelectLanguage: true,
+    };
+
+    expect(getSurveyLanguageCode(undefined, survey, ["de-DE", "fr-CA"])).toBe("fr-FR");
+  });
+
+  test("falls back to default language when auto-selection is disabled or unmatched", () => {
+    const survey = createMockSurvey([language("en", { default: true }), language("de")]);
+
+    expect(getSurveyLanguageCode(undefined, survey, ["de-DE"])).toBe("default");
+    expect(getSurveyLanguageCode(undefined, { ...survey, autoSelectLanguage: true }, ["fr-FR"])).toBe(
+      "default"
+    );
   });
 });
 

--- a/apps/web/modules/survey/link/lib/utils.ts
+++ b/apps/web/modules/survey/link/lib/utils.ts
@@ -1,6 +1,7 @@
 import { TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
 import { TSurveyElement } from "@formbricks/types/surveys/elements";
+import { resolveSurveyLanguage } from "@formbricks/types/surveys/language";
 import { TSurvey } from "@formbricks/types/surveys/types";
 
 export function isRTL(text: string): boolean {
@@ -54,6 +55,22 @@ export function isRTLLanguage(survey: TJsWorkspaceStateSurvey, languageCode: str
  */
 export const getElementsFromSurveyBlocks = (blocks: TSurveyBlock[]): TSurveyElement[] =>
   blocks.flatMap((block) => block.elements);
+
+export const getSurveyLanguageCode = (
+  langParam: string | undefined,
+  survey: TSurvey,
+  browserLanguageCodes: string[] = []
+): string => {
+  return (
+    resolveSurveyLanguage({
+      languages: survey.languages,
+      explicitLanguageCode: langParam,
+      browserLanguageCodes,
+      autoSelectLanguage: survey.autoSelectLanguage,
+      unmatchedExplicitLanguageBehavior: "fallback",
+    }) ?? "default"
+  );
+};
 
 /**
  * Maps survey language codes to web app locale codes.

--- a/apps/web/modules/survey/link/page.tsx
+++ b/apps/web/modules/survey/link/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { logger } from "@formbricks/logger";
 import { ZId } from "@formbricks/types/common";
 import { TSurvey } from "@formbricks/types/surveys/types";
-import { findMatchingLocale } from "@/lib/utils/locale";
+import { findMatchingBrowserLanguageCodes, findMatchingLocale } from "@/lib/utils/locale";
 import { getResponseCountBySurveyId } from "@/modules/survey/lib/response";
 import { SurveyInactive } from "@/modules/survey/link/components/survey-inactive";
 import { renderSurvey } from "@/modules/survey/link/components/survey-renderer";
@@ -94,17 +94,18 @@ export const LinkSurveyPage = async (props: LinkSurveyPageProps) => {
       suToken
     );
     if (!validatedSingleUseId) {
-      // Need to fetch workspace for error page - fetch environmentContext for it
-      const environmentContext = await getWorkspaceContextForLinkSurvey(survey.workspaceId);
-      return <SurveyInactive status="link invalid" workspace={environmentContext.workspace} />;
+      // Need to fetch workspace for error page.
+      const workspaceContext = await getWorkspaceContextForLinkSurvey(survey.workspaceId);
+      return <SurveyInactive status="link invalid" workspace={workspaceContext.workspace} />;
     }
     singleUseId = validatedSingleUseId;
   }
 
   // Stage 2: Parallel fetch of all remaining data
-  const [workspaceContext, locale, singleUseResponse] = await Promise.all([
+  const [workspaceContext, locale, browserLanguageCodes, singleUseResponse] = await Promise.all([
     getWorkspaceContextForLinkSurvey(survey.workspaceId),
     findMatchingLocale(),
+    findMatchingBrowserLanguageCodes(),
     // Only fetch single-use response if we have a validated ID
     isSingleUseSurvey && singleUseId
       ? getResponseBySingleUseId(survey.id, singleUseId)()
@@ -126,6 +127,7 @@ export const LinkSurveyPage = async (props: LinkSurveyPageProps) => {
     isPreview,
     workspaceContext,
     locale,
+    browserLanguageCodes,
     responseCount,
   });
 };

--- a/apps/web/modules/survey/multi-language-surveys/components/language-view.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/language-view.tsx
@@ -149,7 +149,7 @@ export const LanguageView = ({
           buttonVariant: "destructive",
           onConfirm: () => {
             // Strip all non-default language keys from the survey data
-            let cleanedSurvey = localSurvey;
+            let cleanedSurvey: TSurvey = { ...localSurvey, autoSelectLanguage: false };
             for (const lang of localSurvey.languages) {
               if (!lang.default) {
                 cleanedSurvey = removeLanguageKeysFromSurvey(cleanedSurvey, lang.language.code);
@@ -172,6 +172,7 @@ export const LanguageView = ({
     const language = workspaceLanguages.find((lang) => lang.code === languageCode);
     if (!language) return;
 
+    const isNewMultiLanguageSurvey = localSurvey.languages.length === 0;
     let languageExists = false;
     const newLanguages =
       localSurvey.languages.map((lang) => {
@@ -187,7 +188,11 @@ export const LanguageView = ({
     }
 
     setConfirmationModalInfo((prev) => ({ ...prev, open: false }));
-    setLocalSurvey({ ...localSurvey, languages: newLanguages });
+    setLocalSurvey({
+      ...localSurvey,
+      languages: newLanguages,
+      autoSelectLanguage: isNewMultiLanguageSurvey ? true : localSurvey.autoSelectLanguage,
+    });
   };
 
   const handleToggleLanguage = (code: string) => {
@@ -254,7 +259,7 @@ export const LanguageView = ({
       buttonText: t("workspace.surveys.edit.remove_translations"),
       buttonVariant: "destructive",
       onConfirm: () => {
-        updateSurveyTranslations(localSurvey, []);
+        updateSurveyTranslations({ ...localSurvey, autoSelectLanguage: false }, []);
         setIsMultiLanguageActivated(false);
         setConfirmationModalInfo((prev) => ({ ...prev, open: false }));
       },
@@ -263,6 +268,10 @@ export const LanguageView = ({
 
   const handleLanguageSwitchToggle = () => {
     setLocalSurvey({ ...localSurvey, showLanguageSwitch: !localSurvey.showLanguageSwitch });
+  };
+
+  const handleAutoSelectLanguageToggle = () => {
+    setLocalSurvey({ ...localSurvey, autoSelectLanguage: !localSurvey.autoSelectLanguage });
   };
 
   const openTranslationModal = (code: string) => {
@@ -487,6 +496,16 @@ export const LanguageView = ({
             description={t(
               "workspace.surveys.edit.enable_participants_to_switch_the_survey_language_at_any_point_during_the_survey"
             )}
+            childBorder={true}
+          />
+          <AdvancedOptionToggle
+            customContainerClass="px-0 pt-0"
+            htmlId="autoSelectLanguage"
+            disabled={enabledLanguages.length <= 1}
+            isChecked={!!localSurvey.autoSelectLanguage}
+            onToggle={handleAutoSelectLanguageToggle}
+            title={t("workspace.surveys.edit.auto_select_browser_language")}
+            description={t("workspace.surveys.edit.auto_select_browser_language_description")}
             childBorder={true}
           />
         </div>

--- a/apps/web/modules/survey/templates/lib/minimal-survey.ts
+++ b/apps/web/modules/survey/templates/lib/minimal-survey.ts
@@ -38,6 +38,7 @@ export const getMinimalSurvey = (t: TFunction): TSurvey => ({
   segment: null,
   languages: [],
   showLanguageSwitch: false,
+  autoSelectLanguage: false,
   isVerifyEmailEnabled: false,
   isSingleResponsePerEmailEnabled: false,
   variables: [],

--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -328,6 +328,11 @@
                                 "example": null,
                                 "type": "boolean"
                               },
+                              "autoSelectLanguage": {
+                                "example": null,
+                                "nullable": true,
+                                "type": "boolean"
+                              },
                               "delay": {
                                 "example": 0,
                                 "type": "integer"
@@ -4471,6 +4476,7 @@
                     {
                       "autoClose": null,
                       "autoComplete": null,
+                      "autoSelectLanguage": null,
                       "createdAt": "2024-08-05T11:08:27.042Z",
                       "createdBy": "clfv1zvij0000ru0gunwpy43a",
                       "delay": 0,
@@ -4655,6 +4661,7 @@
                   "value": {
                     "autoClose": null,
                     "autoComplete": null,
+                    "autoSelectLanguage": null,
                     "createdBy": null,
                     "delay": 0,
                     "displayLimit": null,
@@ -4762,6 +4769,11 @@
               },
               "schema": {
                 "properties": {
+                  "autoSelectLanguage": {
+                    "description": "Whether to automatically select the survey language from the respondent's browser language when a matching active language exists.",
+                    "nullable": true,
+                    "type": "boolean"
+                  },
                   "displayOption": {
                     "enum": ["displayOnce", "displayMultiple", "respondMultiple", "displaySome"],
                     "type": "string"
@@ -4875,6 +4887,7 @@
                   "data": {
                     "autoClose": null,
                     "autoComplete": null,
+                    "autoSelectLanguage": null,
                     "createdAt": "2024-08-05T11:08:27.042Z",
                     "createdBy": "clfv1zvij0000ru0gunwpy43a",
                     "delay": 0,
@@ -5141,6 +5154,7 @@
                   "data": {
                     "autoClose": null,
                     "autoComplete": null,
+                    "autoSelectLanguage": null,
                     "createdAt": "2024-08-05T11:08:27.042Z",
                     "createdBy": "clfv1zvij0000ru0gunwpy43a",
                     "delay": 0,
@@ -5394,6 +5408,7 @@
                   "data": {
                     "autoClose": null,
                     "autoComplete": null,
+                    "autoSelectLanguage": null,
                     "createdAt": "2024-08-05T11:08:27.042Z",
                     "createdBy": "clfv1zvij0000ru0gunwpy43a",
                     "delay": 0,
@@ -5597,6 +5612,7 @@
                   "data": {
                     "autoClose": null,
                     "autoComplete": null,
+                    "autoSelectLanguage": null,
                     "createdAt": "2024-08-05T11:08:27.042Z",
                     "createdBy": "clfv1zvij0000ru0gunwpy43a",
                     "delay": 0,

--- a/docs/surveys/general-features/multi-language-surveys.mdx
+++ b/docs/surveys/general-features/multi-language-surveys.mdx
@@ -37,12 +37,14 @@ How to deliver a specific language depends on the survey type (app or link surve
     ![Add Multiple Languages to your Workspace](/images/xm-and-surveys/surveys/general-features/multi-language-surveys/add-languages.webp)
 
     You can come back to this page anytime to add more languages or remove existing ones.
+
   </Step>
 
   <Step title="Create or Edit Your Survey">
     Return to the dashboard to create a new survey or edit an existing one:
 
     ![Survey Overview](/images/xm-and-surveys/surveys/general-features/multi-language-surveys/surveys-home.webp)
+
   </Step>
 
   <Step title="Enable Multi-language Support">
@@ -52,19 +54,26 @@ How to deliver a specific language depends on the survey type (app or link surve
 
     Choose a **Default Language** for your survey.
 
+    New multi-language surveys use the respondent's browser language by default when a matching active language is
+    available. You can change this anytime with the **Use browser language by default** toggle. This setting is
+    separate from **Show language switch**; you can automatically open the right language without showing respondents a
+    manual language menu.
+
     <Note>Changing the default language will reset all the translations you have made for the survey.</Note>
+
   </Step>
 
   <Step title="Add Supported Languages">
     Add the languages from the dropdown that you want to support in your survey:
 
     ![Enable Multi-language for a survey](/images/xm-and-surveys/surveys/general-features/multi-language-surveys/add-language-in-survey.webp)
+
   </Step>
 
   <Step title="Preview and Translate Content">
 
     You can now see the survey in the selected language by clicking on the language dropdown in any of the questions.
-    
+
     Now you can translate all survey content, including questions, options, and button placeholders, into the selected language.
 
   </Step>
@@ -73,6 +82,18 @@ How to deliver a specific language depends on the survey type (app or link surve
     Once you are done, click on the **Publish** button to save the survey.
   </Step>
 </Steps>
+
+## Language Selection Order
+
+Formbricks selects the survey language in this order:
+
+1. An explicit `lang` URL parameter for link surveys, or an explicit SDK/user language for app surveys. For app
+   surveys, if the explicit SDK/user language is unavailable, the survey is not displayed.
+2. The respondent's browser language when **Use browser language by default** is enabled.
+3. The survey's default language.
+
+Language matching first checks the exact identifier or alias. If there is no exact match, Formbricks checks language
+variants with the same base language, for example `es-MX` can match an active `es-ES` translation.
 
 ## App Surveys Configuration
 
@@ -91,8 +112,11 @@ How to deliver a specific language depends on the survey type (app or link surve
 
     <Note>
       If a user has a language assigned, a survey has multi-language activated and it is missing a translation in
-      the language of the user, the survey will not be displayed.
+      the language of the user, the survey will not be displayed. When no user language is assigned and **Use browser
+      language by default** is enabled, Formbricks uses the browser language and falls back to the survey default if
+      there is no match.
     </Note>
+
   </Step>
 
   <Step title="Start Collecting Responses">
@@ -104,7 +128,10 @@ How to deliver a specific language depends on the survey type (app or link surve
 
 ## Link Surveys Configuration
 
-For link surveys, the translation delivery is dependent on the `lang` URL parameter.
+For link surveys, the `lang` URL parameter always takes priority. If the `lang` parameter contains a supported active
+language, Formbricks opens that language. If it contains an unsupported or disabled language, Formbricks falls back to
+the survey's default language. If no `lang` parameter is present and **Use browser language by default** is enabled,
+Formbricks uses the respondent's browser language when a matching active language is available.
 
 <Steps>
   <Step title="Publish Your Survey">
@@ -122,7 +149,13 @@ For link surveys, the translation delivery is dependent on the `lang` URL parame
 
     - German: [https://app.Formbricks.com/s/clptfos2i1pj516pvhxqyu3bn?lang=de](https://app.Formbricks.com/s/clptfos2i1pj516pvhxqyu3bn?lang=de)
 
-    Without the `lang` parameter, Formbricks will show the survey in the default language you have set.
+    Without the `lang` parameter, Formbricks will use the browser language when **Use browser language by default** is
+    enabled and a matching active language exists. Otherwise, it will show the survey in the default language you have
+    set.
+
+    If the `lang` parameter is present but does not match an active survey language, Formbricks also falls back to the
+    survey's default language.
+
   </Step>
 
   <Step title="Start Collecting Responses">
@@ -174,14 +207,13 @@ Formbricks fully supports Right-to-Left (RTL) languages such as Arabic, Hebrew, 
     Add an RTL language (like Arabic or Hebrew) in the **Survey Languages** settings
   </Step>
 
-  <Step title="Create Translations">
-    Create translations for your survey content in the RTL language
-  </Step>
+<Step title="Create Translations">Create translations for your survey content in the RTL language</Step>
 
   <Step title="Automatic RTL Display">
     The survey will automatically display in RTL format when that language is selected
 
     ![RTL Language Support](/images/xm-and-surveys/surveys/general-features/multi-language-surveys/rtl-support.webp)
+
   </Step>
 </Steps>
 

--- a/packages/database/migration/20260513111900_add_auto_select_language_to_survey/migration.sql
+++ b/packages/database/migration/20260513111900_add_auto_select_language_to_survey/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Survey" ADD COLUMN "autoSelectLanguage" BOOLEAN;

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -404,6 +404,7 @@ model Survey {
   displayPercentage               Decimal?
   languages                       SurveyLanguage[]
   showLanguageSwitch              Boolean?
+  autoSelectLanguage              Boolean?
   followUps                       SurveyFollowUp[]
   /// [SurveyRecaptcha]
   recaptcha                       Json?                        @default("{\"enabled\": false, \"threshold\":0.1}")

--- a/packages/database/zod/surveys.ts
+++ b/packages/database/zod/surveys.ts
@@ -55,6 +55,10 @@ const ZSurveyBase = z.object({
   status: z.enum(SurveyStatus).describe("The status of the survey"),
   thankYouMessage: z.string().nullable().describe("The thank you message of the survey"),
   showLanguageSwitch: z.boolean().nullable().describe("Whether to show the language switch"),
+  autoSelectLanguage: z
+    .boolean()
+    .nullable()
+    .describe("Whether to automatically select the survey language from the respondent's browser"),
   showThankYouMessage: z.boolean().nullable().describe("Whether to show the thank you message"),
   welcomeCard: z
     .object({

--- a/packages/js-core/package.json
+++ b/packages/js-core/package.json
@@ -42,6 +42,9 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"
   },
+  "dependencies": {
+    "@formbricks/types": "workspace:*"
+  },
   "author": "Formbricks <hola@formbricks.com>",
   "devDependencies": {
     "@formbricks/config-typescript": "workspace:*",

--- a/packages/js-core/src/lib/common/tests/__mocks__/config.mock.ts
+++ b/packages/js-core/src/lib/common/tests/__mocks__/config.mock.ts
@@ -21,6 +21,7 @@ export const mockConfig: TConfig = {
           variables: [],
           type: "app", // "link" or "app"
           showLanguageSwitch: true,
+          autoSelectLanguage: false,
           endings: [],
           autoClose: 5,
           status: "inProgress", // whatever statuses you use

--- a/packages/js-core/src/lib/common/tests/utils.test.ts
+++ b/packages/js-core/src/lib/common/tests/utils.test.ts
@@ -478,6 +478,42 @@ describe("utils.ts", () => {
       expect(getLanguageCode(survey, "fr")).toBe("fr");
       expect(getLanguageCode(survey, "fr-FR")).toBe("fr");
     });
+
+    test("returns a loose variant match for the selected language", () => {
+      const survey = {
+        languages: [
+          { language: { code: "en" }, default: true, enabled: true },
+          { language: { code: "es-ES" }, default: false, enabled: true },
+        ],
+      } as unknown as TWorkspaceStateSurvey;
+
+      expect(getLanguageCode(survey, "es-MX")).toBe("es-ES");
+    });
+
+    test("uses fallback languages only when auto-select is enabled", () => {
+      const survey = {
+        autoSelectLanguage: true,
+        languages: [
+          { language: { code: "en" }, default: true, enabled: true },
+          { language: { code: "de" }, default: false, enabled: true },
+        ],
+      } as unknown as TWorkspaceStateSurvey;
+
+      expect(getLanguageCode(survey, undefined, ["de-DE", "en-US"])).toBe("de");
+      expect(getLanguageCode({ ...survey, autoSelectLanguage: false }, undefined, ["de-DE"])).toBe("default");
+    });
+
+    test("does not fall back to browser language when an explicit user language is unavailable", () => {
+      const survey = {
+        autoSelectLanguage: true,
+        languages: [
+          { language: { code: "en" }, default: true, enabled: true },
+          { language: { code: "de" }, default: false, enabled: true },
+        ],
+      } as unknown as TWorkspaceStateSurvey;
+
+      expect(getLanguageCode(survey, "fr", ["de-DE"])).toBeUndefined();
+    });
   });
 
   // ---------------------------------------------------------------------------------

--- a/packages/js-core/src/lib/common/utils.ts
+++ b/packages/js-core/src/lib/common/utils.ts
@@ -1,3 +1,4 @@
+import { resolveSurveyLanguage } from "@formbricks/types/surveys/language";
 import { Logger } from "@/lib/common/logger";
 import type {
   TSurveyStyling,
@@ -173,27 +174,18 @@ export const getDefaultLanguageCode = (survey: TWorkspaceStateSurvey): string | 
   if (defaultSurveyLanguage) return defaultSurveyLanguage.language.code;
 };
 
-export const getLanguageCode = (survey: TWorkspaceStateSurvey, language?: string): string | undefined => {
-  const availableLanguageCodes = survey.languages.map((surveyLanguage) => surveyLanguage.language.code);
-  if (!language) return "default";
-
-  const selectedLanguage = survey.languages.find((surveyLanguage) => {
-    return (
-      surveyLanguage.language.code.toLowerCase() === language.toLowerCase() ||
-      surveyLanguage.language.alias?.toLowerCase() === language.toLowerCase()
-    );
+export const getLanguageCode = (
+  survey: TWorkspaceStateSurvey,
+  language?: string,
+  fallbackLanguages: string[] = []
+): string | undefined => {
+  return resolveSurveyLanguage({
+    languages: survey.languages,
+    explicitLanguageCode: language,
+    browserLanguageCodes: fallbackLanguages,
+    autoSelectLanguage: survey.autoSelectLanguage,
+    unmatchedExplicitLanguageBehavior: "undefined",
   });
-  if (selectedLanguage?.default) {
-    return "default";
-  }
-  if (
-    !selectedLanguage ||
-    !selectedLanguage.enabled ||
-    !availableLanguageCodes.includes(selectedLanguage.language.code)
-  ) {
-    return undefined;
-  }
-  return selectedLanguage.language.code;
 };
 
 export const getSecureRandom = (): number => {

--- a/packages/js-core/src/lib/survey/tests/__mocks__/widget.mock.ts
+++ b/packages/js-core/src/lib/survey/tests/__mocks__/widget.mock.ts
@@ -23,6 +23,7 @@ export const mockSurvey: TWorkspaceStateSurvey = {
   },
   type: "app", // "link" or "app"
   showLanguageSwitch: true,
+  autoSelectLanguage: false,
   endings: [],
   autoClose: 5,
   status: "inProgress", // whatever statuses you use

--- a/packages/js-core/src/lib/survey/tests/widget.test.ts
+++ b/packages/js-core/src/lib/survey/tests/widget.test.ts
@@ -83,6 +83,22 @@ describe("widget-file", () => {
     return formbricksSurveys;
   };
 
+  const setNavigatorMock = (navigatorValue: Partial<Navigator>): void => {
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: navigatorValue,
+    });
+  };
+
+  const restoreNavigator = (navigatorDescriptor: PropertyDescriptor | undefined): void => {
+    if (navigatorDescriptor) {
+      Object.defineProperty(globalThis, "navigator", navigatorDescriptor);
+      return;
+    }
+
+    Reflect.deleteProperty(globalThis, "navigator");
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     document.body.innerHTML = "";
@@ -98,6 +114,23 @@ describe("widget-file", () => {
 
   test("setIsSurveyRunning toggles internal state (covered by usage in other tests)", () => {
     widget.setIsSurveyRunning(true);
+  });
+
+  test("getBrowserLanguageCodes prefers navigator.languages and falls back to navigator.language", () => {
+    const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+
+    try {
+      setNavigatorMock({ languages: ["de-DE", "", "en-US"] as unknown as Navigator["languages"] });
+      expect(widget.getBrowserLanguageCodes()).toEqual(["de-DE", "en-US"]);
+
+      setNavigatorMock({ languages: [] as unknown as Navigator["languages"], language: "fr-FR" });
+      expect(widget.getBrowserLanguageCodes()).toEqual(["fr-FR"]);
+
+      setNavigatorMock({ language: "" });
+      expect(widget.getBrowserLanguageCodes()).toEqual([]);
+    } finally {
+      restoreNavigator(originalNavigator);
+    }
   });
 
   test("triggerSurvey skips if shouldDisplayBasedOnPercentage returns false", async () => {
@@ -226,6 +259,69 @@ describe("widget-file", () => {
     expect(mockLogger.debug).toHaveBeenCalledWith(
       `Survey "${mockSurvey.id}" is not available in specified language.`
     );
+  });
+
+  test("renderWidget passes browser languages when auto-select is enabled and no user language is set", async () => {
+    const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+
+    try {
+      setNavigatorMock({ languages: ["de-DE", "en-US"] as unknown as Navigator["languages"] });
+
+      const mockConfigValue = {
+        get: vi.fn().mockReturnValue({
+          appUrl: "https://fake.app",
+          workspaceId: "env_123",
+          workspace: {
+            data: {
+              settings: {
+                clickOutsideClose: true,
+                overlay: "none",
+                placement: "bottomRight",
+                inAppSurveyBranding: true,
+              },
+            },
+          },
+          user: {
+            data: {
+              userId: "user_abc",
+              displays: [],
+              responses: [],
+              lastDisplayAt: null,
+            },
+          },
+        }),
+        update: vi.fn(),
+      };
+
+      getInstanceConfigMock.mockReturnValue(mockConfigValue as unknown as Config);
+      widget.setIsSurveyRunning(false);
+      (getLanguageCode as Mock).mockReturnValueOnce("de");
+
+      // @ts-expect-error -- mock window.formbricksSurveys
+      window.formbricksSurveys = {
+        renderSurvey: vi.fn(),
+      };
+
+      vi.useFakeTimers();
+
+      const autoSelectSurvey = {
+        ...mockSurvey,
+        autoSelectLanguage: true,
+        delay: 0,
+        languages: [
+          { language: { code: "en" }, default: true, enabled: true },
+          { language: { code: "de" }, default: false, enabled: true },
+        ],
+      } as unknown as TWorkspaceStateSurvey;
+
+      await widget.renderWidget(autoSelectSurvey);
+      vi.advanceTimersByTime(0);
+
+      expect(getLanguageCode).toHaveBeenCalledWith(autoSelectSurvey, undefined, ["de-DE", "en-US"]);
+    } finally {
+      vi.useRealTimers();
+      restoreNavigator(originalNavigator);
+    }
   });
 
   test("closeSurvey removes widget container, resets filtered surveys, sets isSurveyRunning=false", () => {

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -13,10 +13,36 @@ import {
   surveyHasSegmentFilters,
 } from "@/lib/common/utils";
 import { UpdateQueue } from "@/lib/user/update-queue";
-import { type TUserState, type TWorkspaceStateSurvey } from "@/types/config";
+import { type TUserState, type TWorkspaceStateSettings, type TWorkspaceStateSurvey } from "@/types/config";
 import { type TTrackProperties } from "@/types/survey";
 
 let isSurveyRunning = false;
+
+type TWidgetOverlay = "none" | "light" | "dark";
+type TWidgetPlacement = "bottomLeft" | "bottomRight" | "topLeft" | "topRight" | "center";
+interface TWidgetDisplaySettings {
+  clickOutsideClose: boolean;
+  overlay: TWidgetOverlay;
+  placement: TWidgetPlacement;
+  inAppSurveyBranding: boolean;
+}
+
+/**
+ * Reads browser language preferences for auto-selecting app survey translations.
+ */
+export const getBrowserLanguageCodes = (): string[] => {
+  if (typeof navigator === "undefined") return [];
+  if (Array.isArray(navigator.languages)) {
+    const languages = navigator.languages.filter((language): language is string => {
+      return typeof language === "string" && language.trim() !== "";
+    });
+    if (languages.length > 0) return languages;
+  }
+  if (typeof navigator.language === "string" && navigator.language.trim() !== "") {
+    return [navigator.language];
+  }
+  return [];
+};
 
 export const setIsSurveyRunning = (value: boolean): void => {
   isSurveyRunning = value;
@@ -84,14 +110,19 @@ export const renderWidget = async (
     logger.debug(`Delaying survey "${survey.id}" by ${survey.delay.toString()} seconds.`);
   }
 
-  const { settings } = config.get().workspace.data;
+  const settings = config.get().workspace.data.settings as unknown as TWorkspaceStateSettings;
+  const displaySettings = settings as unknown as TWidgetDisplaySettings;
   const { language } = config.get().user.data;
 
   const isMultiLanguageSurvey = survey.languages.length > 1;
   let languageCode = "default";
 
   if (isMultiLanguageSurvey) {
-    const displayLanguage = getLanguageCode(survey, language);
+    const displayLanguage = getLanguageCode(
+      survey,
+      language,
+      survey.autoSelectLanguage ? getBrowserLanguageCodes() : []
+    );
     //if survey is not available in selected language, survey wont be shown
     if (!displayLanguage) {
       logger.debug(`Survey "${survey.id}" is not available in specified language.`);
@@ -102,11 +133,13 @@ export const renderWidget = async (
     languageCode = displayLanguage;
   }
 
-  const workspaceOverwrites = survey.workspaceOverwrites ?? {};
-  const clickOutside = workspaceOverwrites.clickOutsideClose ?? settings.clickOutsideClose;
-  const overlay = workspaceOverwrites.overlay ?? settings.overlay;
-  const placement = workspaceOverwrites.placement ?? settings.placement;
-  const isBrandingEnabled = settings.inAppSurveyBranding;
+  const workspaceOverwrites = (survey.workspaceOverwrites ?? {}) as unknown as Partial<
+    Pick<TWidgetDisplaySettings, "clickOutsideClose" | "overlay" | "placement">
+  >;
+  const clickOutside = workspaceOverwrites.clickOutsideClose ?? displaySettings.clickOutsideClose;
+  const overlay = workspaceOverwrites.overlay ?? displaySettings.overlay;
+  const placement = workspaceOverwrites.placement ?? displaySettings.placement;
+  const isBrandingEnabled = displaySettings.inAppSurveyBranding;
 
   let formbricksSurveys: TFormbricksSurveys;
   try {

--- a/packages/js-core/src/types/config.ts
+++ b/packages/js-core/src/types/config.ts
@@ -10,6 +10,7 @@ export type TWorkspaceStateSurvey = Pick<
   | "variables"
   | "type"
   | "showLanguageSwitch"
+  | "autoSelectLanguage"
   | "endings"
   | "autoClose"
   | "status"

--- a/packages/types/js.ts
+++ b/packages/types/js.ts
@@ -14,6 +14,7 @@ export const ZJsWorkspaceStateSurvey = ZSurveyBase.pick({
   variables: true,
   type: true,
   showLanguageSwitch: true,
+  autoSelectLanguage: true,
   languages: true,
   endings: true,
   autoClose: true,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -12,6 +12,8 @@
   "scripts": {
     "lint": "eslint . --ext .ts,.js,.tsx,.jsx",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "clean": "rimraf node_modules .turbo"
   },
   "dependencies": {
@@ -21,6 +23,8 @@
     "node-html-parser": "7.1.0"
   },
   "devDependencies": {
-    "@formbricks/config-typescript": "workspace:*"
+    "@formbricks/config-typescript": "workspace:*",
+    "@vitest/coverage-v8": "4.0.18",
+    "vitest": "4.0.18"
   }
 }

--- a/packages/types/surveys/language.test.ts
+++ b/packages/types/surveys/language.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "vitest";
+import { matchSurveyLanguage, normalizeLanguageCode, resolveSurveyLanguage } from "./language";
+
+const languages = [
+  {
+    default: true,
+    enabled: true,
+    language: {
+      code: "en",
+      alias: "English",
+    },
+  },
+  {
+    default: false,
+    enabled: true,
+    language: {
+      code: "es-ES",
+      alias: "es",
+    },
+  },
+  {
+    default: false,
+    enabled: false,
+    language: {
+      code: "de",
+      alias: null,
+    },
+  },
+];
+
+describe("survey language helpers", () => {
+  test("normalizes quality values, whitespace, underscores, and case", () => {
+    expect(normalizeLanguageCode(" ZH_Hans_CN ;q=0.9 ")).toBe("zh-hans-cn");
+  });
+
+  test("matches exact codes, aliases, and loose variants while ignoring disabled languages", () => {
+    expect(matchSurveyLanguage(languages, "es")).toBe("es-ES");
+    expect(matchSurveyLanguage(languages, "es-MX")).toBe("es-ES");
+    expect(matchSurveyLanguage(languages, "de-DE")).toBeUndefined();
+  });
+
+  test("resolves explicit language before browser language", () => {
+    expect(
+      resolveSurveyLanguage({
+        languages,
+        explicitLanguageCode: "es-MX",
+        browserLanguageCodes: ["en-US"],
+        autoSelectLanguage: true,
+      })
+    ).toBe("es-ES");
+  });
+
+  test("uses browser language only when enabled and falls back to default", () => {
+    expect(
+      resolveSurveyLanguage({
+        languages,
+        browserLanguageCodes: ["es-MX"],
+        autoSelectLanguage: true,
+      })
+    ).toBe("es-ES");
+
+    expect(
+      resolveSurveyLanguage({
+        languages,
+        browserLanguageCodes: ["es-MX"],
+        autoSelectLanguage: false,
+      })
+    ).toBe("default");
+
+    expect(
+      resolveSurveyLanguage({
+        languages,
+        browserLanguageCodes: ["fr-CA"],
+        autoSelectLanguage: true,
+      })
+    ).toBe("default");
+  });
+
+  test("supports strict unmatched explicit language behavior", () => {
+    expect(
+      resolveSurveyLanguage({
+        languages,
+        explicitLanguageCode: "fr",
+        browserLanguageCodes: ["es-MX"],
+        autoSelectLanguage: true,
+        unmatchedExplicitLanguageBehavior: "undefined",
+      })
+    ).toBeUndefined();
+  });
+});

--- a/packages/types/surveys/language.ts
+++ b/packages/types/surveys/language.ts
@@ -1,0 +1,114 @@
+interface TSurveyLanguageLike {
+  default?: boolean | null;
+  enabled?: boolean | null;
+  language: {
+    code: string;
+    alias?: string | null;
+  };
+}
+
+interface ResolveSurveyLanguageInput<T extends TSurveyLanguageLike> {
+  languages: T[];
+  explicitLanguageCode?: string;
+  browserLanguageCodes?: string[];
+  autoSelectLanguage?: boolean | null;
+  unmatchedExplicitLanguageBehavior?: "fallback" | "undefined";
+}
+
+/**
+ * Normalizes locale identifiers from URLs, SDK calls, and browser headers before matching.
+ */
+export const normalizeLanguageCode = (languageCode: string): string =>
+  languageCode.trim().split(";")[0].trim().replaceAll("_", "-").toLowerCase();
+
+const getBaseLanguageCode = (languageCode: string): string =>
+  normalizeLanguageCode(languageCode).split("-")[0];
+
+const getSelectableLanguageCode = (surveyLanguage: TSurveyLanguageLike): string | undefined => {
+  if (surveyLanguage.default) return "default";
+  if (!surveyLanguage.enabled) return undefined;
+  return surveyLanguage.language.code;
+};
+
+const findExactLanguageMatch = <T extends TSurveyLanguageLike>(
+  languages: T[],
+  languageCode: string
+): string | undefined => {
+  const normalizedLanguageCode = normalizeLanguageCode(languageCode);
+
+  const selectedLanguage = languages.find((surveyLanguage) => {
+    return (
+      normalizeLanguageCode(surveyLanguage.language.code) === normalizedLanguageCode ||
+      (surveyLanguage.language.alias
+        ? normalizeLanguageCode(surveyLanguage.language.alias) === normalizedLanguageCode
+        : false)
+    );
+  });
+
+  return selectedLanguage ? getSelectableLanguageCode(selectedLanguage) : undefined;
+};
+
+const findLooseLanguageMatch = <T extends TSurveyLanguageLike>(
+  languages: T[],
+  languageCode: string
+): string | undefined => {
+  const baseLanguageCode = getBaseLanguageCode(languageCode);
+
+  for (const surveyLanguage of languages) {
+    const selectableLanguageCode = getSelectableLanguageCode(surveyLanguage);
+    if (!selectableLanguageCode) continue;
+
+    const languageBaseCode = getBaseLanguageCode(surveyLanguage.language.code);
+    const aliasBaseCode = surveyLanguage.language.alias
+      ? getBaseLanguageCode(surveyLanguage.language.alias)
+      : undefined;
+
+    if (languageBaseCode === baseLanguageCode || aliasBaseCode === baseLanguageCode) {
+      return selectableLanguageCode;
+    }
+  }
+
+  return undefined;
+};
+
+/**
+ * Matches a requested language against active survey languages by exact code/alias and then base language.
+ */
+export const matchSurveyLanguage = <T extends TSurveyLanguageLike>(
+  languages: T[],
+  languageCode: string
+): string | undefined => {
+  return findExactLanguageMatch(languages, languageCode) ?? findLooseLanguageMatch(languages, languageCode);
+};
+
+/**
+ * Resolves survey language precedence without coupling callers to a delivery channel:
+ * explicit language (URL or SDK/user setting) -\> browser languages when enabled -\> survey default.
+ */
+export const resolveSurveyLanguage = <T extends TSurveyLanguageLike>({
+  languages,
+  explicitLanguageCode,
+  browserLanguageCodes = [],
+  autoSelectLanguage,
+  unmatchedExplicitLanguageBehavior = "fallback",
+}: ResolveSurveyLanguageInput<T>): string | undefined => {
+  if (explicitLanguageCode) {
+    const explicitMatch = matchSurveyLanguage(languages, explicitLanguageCode);
+    if (explicitMatch) return explicitMatch;
+    return unmatchedExplicitLanguageBehavior === "undefined" ? undefined : "default";
+  }
+
+  if (!autoSelectLanguage) return "default";
+
+  for (const browserLanguageCode of browserLanguageCodes) {
+    const exactMatch = findExactLanguageMatch(languages, browserLanguageCode);
+    if (exactMatch) return exactMatch;
+  }
+
+  for (const browserLanguageCode of browserLanguageCodes) {
+    const looseMatch = findLooseLanguageMatch(languages, browserLanguageCode);
+    if (looseMatch) return looseMatch;
+  }
+
+  return "default";
+};

--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -957,6 +957,7 @@ export const ZSurveyBase = z.object({
   workspaceOverwrites: ZSurveyWorkspaceOverwrites.nullable(),
   styling: ZSurveyStyling.nullable(),
   showLanguageSwitch: z.boolean().nullable(),
+  autoSelectLanguage: z.boolean().nullish(),
   surveyClosedMessage: ZSurveyClosedMessage.nullable(),
   segment: ZSegment.nullable(),
   singleUse: ZSurveySingleUse.nullable(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -820,6 +820,10 @@ importers:
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/js-core:
+    dependencies:
+      '@formbricks/types':
+        specifier: workspace:*
+        version: link:../types
     devDependencies:
       '@formbricks/config-typescript':
         specifier: workspace:*
@@ -1096,6 +1100,12 @@ importers:
       '@formbricks/config-typescript':
         specifier: workspace:*
         version: link:../config-typescript
+      '@vitest/coverage-v8':
+        specifier: 4.0.18
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest:
+        specifier: 4.0.18
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/vite-plugins:
     devDependencies:
@@ -1247,6 +1257,7 @@ packages:
   '@aws-sdk/core@3.974.10':
     resolution: {integrity: sha512-ZGFFlYynBR78Y/F8b/7y4i4sgW/iGwJSjoM7AZo5Et6vyr4/L0bunN+uzKMsvecCZyqcPp4RRK7Rs17l0kMujg==}
     engines: {node: '>=20.0.0'}
+    deprecated: Deprecated due to an error deserialization bug in JSON 1.0 protocol services, see https://github.com/aws/aws-sdk-js-v3/pull/8031. Newer version available.
 
   '@aws-sdk/crc64-nvme@3.972.4':
     resolution: {integrity: sha512-HKZIZLbRyvzo/bXZU7Zmk6XqU+1C9DjI56xd02vwuDIxedxBEqP17t9ExhbP9QFeNq/a3l9GOcyirFXxmbDhmw==}
@@ -10421,6 +10432,7 @@ packages:
   recharts@2.15.3:
     resolution: {integrity: sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -11181,10 +11193,6 @@ packages:
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyrainbow@3.0.3:
-    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
   tinyrainbow@3.1.0:
@@ -13406,7 +13414,7 @@ snapshots:
 
   '@babel/generator@7.28.5':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -13504,7 +13512,6 @@ snapshots:
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
-    optional: true
 
   '@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0)':
     dependencies:
@@ -13546,13 +13553,13 @@ snapshots:
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
   '@babel/traverse@7.27.0':
@@ -18042,7 +18049,7 @@ snapshots:
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
   '@types/babel__traverse@7.28.0':
@@ -18381,7 +18388,7 @@ snapshots:
       debug: 4.4.3
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.7.3
+      semver: 7.8.0
       tsutils: 3.21.0(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -18412,7 +18419,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -18427,7 +18434,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -18442,7 +18449,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -18660,7 +18667,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       std-env: 3.10.0
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
       vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.0.1))(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':
@@ -18675,7 +18682,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.2))
+      vitest: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.12(@types/node@25.4.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.2))
 
   '@vitest/eslint-plugin@1.6.17(@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)(vitest@4.1.6)':
     dependencies:
@@ -18704,7 +18711,7 @@ snapshots:
       '@vitest/spy': 4.0.18
       '@vitest/utils': 4.0.18
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/expect@4.1.6':
     dependencies:
@@ -18745,7 +18752,7 @@ snapshots:
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/pretty-format@4.1.6':
     dependencies:
@@ -18791,7 +18798,7 @@ snapshots:
   '@vitest/utils@4.0.18':
     dependencies:
       '@vitest/pretty-format': 4.0.18
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
   '@vitest/utils@4.1.6':
     dependencies:
@@ -18813,7 +18820,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.26':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@vue/shared': 3.5.26
       entities: 7.0.1
       estree-walker: 2.0.2
@@ -20301,7 +20308,7 @@ snapshots:
       get-tsconfig: 4.13.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
@@ -20612,7 +20619,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -21810,13 +21817,13 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.0
+      '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.0
 
   make-error@1.3.6:
     optional: true
@@ -22155,7 +22162,7 @@ snapshots:
 
   node-abi@3.85.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.0
 
   node-abort-controller@3.1.1: {}
 
@@ -22250,13 +22257,13 @@ snapshots:
       consola: 3.4.2
       pathe: 2.0.3
       pkg-types: 2.3.0
-      tinyexec: 1.0.2
+      tinyexec: 1.1.2
 
   nypm@0.6.5:
     dependencies:
       citty: 0.2.2
       pathe: 2.0.3
-      tinyexec: 1.0.2
+      tinyexec: 1.1.2
 
   oauth4webapi@3.8.6: {}
 
@@ -23450,8 +23457,7 @@ snapshots:
 
   semver@7.7.3: {}
 
-  semver@7.8.0:
-    optional: true
+  semver@7.8.0: {}
 
   seq-queue@0.0.5:
     optional: true
@@ -23652,7 +23658,7 @@ snapshots:
       is-plain-obj: 4.1.0
       semver: 7.7.3
       sort-object-keys: 2.0.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
 
   source-map-js@1.2.1: {}
 
@@ -23911,7 +23917,7 @@ snapshots:
       lines-and-columns: 1.2.4
       mz: 2.7.0
       pirates: 4.0.7
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
 
   supports-color@7.2.0:
@@ -24081,8 +24087,6 @@ snapshots:
       picomatch: 4.0.4
 
   tinyrainbow@2.0.0: {}
-
-  tinyrainbow@3.0.3: {}
 
   tinyrainbow@3.1.0: {}
 
@@ -24579,9 +24583,9 @@ snapshots:
       picomatch: 4.0.4
       std-env: 3.10.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
       vite: 7.3.3(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Replaces #7996 with a clean branch history.

Adds a survey language setting to automatically select a respondent's browser language when the survey has a matching active language.

Language precedence is explicit:

1. Explicit language (`?lang=` for link surveys, SDK/user language for app surveys)
2. Browser language when **Use browser language by default** is enabled
3. Survey default language

Matching is centralized in `@formbricks/types/surveys/language` and checks exact identifier/alias first, then loose base-language variants (for example `es-MX` -> `es-ES`). Link surveys fall back to the default language when an explicit URL language is invalid; app surveys preserve existing behavior and do not display when an explicitly assigned user language is unavailable.

Also includes:

- New Prisma field + migration for `autoSelectLanguage`
- UI toggle below **Show language switch** with refined copy
- Default-on behavior for newly activated multi-language surveys, while existing surveys remain off via `null`/`false`
- Management/public API selections and OpenAPI examples
- Multi-language survey documentation updates
- Locale keys for the new UI copy
- Coverage for shared language resolution and callers

Fixes #(issue)

## How should this be tested?

- `pnpm --filter @formbricks/types test -- surveys/language.test.ts` ✅
- `pnpm --filter @formbricks/js-core test -- src/lib/common/tests/utils.test.ts src/lib/survey/tests/widget.test.ts` ✅
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/formbricks CUBEJS_API_SECRET=test CUBEJS_API_URL=http://localhost:4000 HUB_API_URL=http://localhost:3001 HUB_API_KEY=test pnpm --dir apps/web exec vitest run lib/utils/locale.test.ts lib/survey/service.test.ts modules/survey/link/lib/utils.test.ts` ✅
- Conflict marker scan (`rg "^(<<<<<<<|>>>>>>>|=======$)"`) ✅

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none in targeted validation
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b018c2e-0807-4cee-9589-0ff3d2557f0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b018c2e-0807-4cee-9589-0ff3d2557f0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

