### PR TITLE
fix: fixes app surveys sdk migration link

### DIFF
--- a/apps/web/modules/workspaces/settings/(setup)/app-connection/page.tsx
+++ b/apps/web/modules/workspaces/settings/(setup)/app-connection/page.tsx
@@ -17,7 +17,7 @@ export const AppConnectionPage = async ({ params }: { params: Promise<{ workspac
   const frameworkGuidesUrl =
     "https://formbricks.com/docs/xm-and-surveys/surveys/website-app-surveys/framework-guides";
   const workspaceIdMigrationUrl =
-    "https://formbricks.com/docs/xm-and-surveys/surveys/website-app-surveys/workspace-id-migration";
+    "https://formbricks.com/docs/surveys/website-app-surveys/workspace-id-migration";
 
   const { workspace } = await getWorkspaceAuth(workspaceId);
 

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -259,7 +259,7 @@ integrations backward compatible during migration.
 
 <Info>
   Formbricks v5 also includes the Environment ID to Workspace ID transition for SDK setup. If you still rely on a
-  legacy Environment ID, read the [Migrate to Workspace ID guide](/xm-and-surveys/surveys/website-app-surveys/workspace-id-migration).
+  legacy Environment ID, read the [Migrate to Workspace ID guide](/surveys/website-app-surveys/workspace-id-migration).
 </Info>
 
 ## v4.7


### PR DESCRIPTION
 ## What does this PR do?

  Fixes broken "Migrate to Workspace ID guide" link on the self-hosting migration docs page. The link pointed to the legacy `/xm-and-surveys/surveys/...` path which 404s. Updated to the current
  `/surveys/website-app-surveys/workspace-id-migration` path. Also fixed the same broken URL constant in the in-app workspace App Connection settings page.

  Reported broken link: https://formbricks.com/docs/xm-and-surveys/surveys/website-app-surveys/workspace-id-migration

  Files changed:
  - `docs/self-hosting/advanced/migration.mdx` — fixed in-doc link
  - `apps/web/modules/workspaces/settings/(setup)/app-connection/page.tsx` — fixed `workspaceIdMigrationUrl` constant

  ## How should this be tested?

  - Open `https://formbricks.com/docs/self-hosting/advanced/migration` and click the **Migrate to Workspace ID guide** link in the v5 section — it should load the migration page, not 404.
  - In the app, go to **Workspace Settings → App Connection**. If a legacy Environment ID is present, click the migration link in the alert — it should open the correct docs page.

  ## Checklist

  ### Required

  - [x] Filled out the "How to test" section in this PR
  - [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
  - [x] Self-reviewed my own code
  - [x] Commented on my code in hard-to-understand bits
  - [x] Ran `pnpm build`
  - [x] Checked for warnings, there are none
  - [x] Removed all `console.logs`
  - [x] Merged the latest changes from main onto my branch with `git pull origin main`
  - [x] My changes don't cause any responsiveness issues
  - [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

  ### Appreciated

  - [ ] If a UI change was made: Added a screen recording or screenshots to this PR
  - [x] Updated the Formbricks Docs if changes were necessary