### PR TITLE
fix: reject reCAPTCHA-protected requests when server keys are unconfigured

### DIFF
--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/recaptcha.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/recaptcha.test.ts
@@ -26,7 +26,7 @@ describe("verifyRecaptchaToken", () => {
     vi.useRealTimers();
   });
 
-  test("returns true if site key or secret key is missing", async () => {
+  test("returns false (fails closed) if site key or secret key is missing", async () => {
     vi.doMock("@/lib/constants", () => ({
       RECAPTCHA_SITE_KEY: undefined,
       RECAPTCHA_SECRET_KEY: undefined,
@@ -34,8 +34,8 @@ describe("verifyRecaptchaToken", () => {
     // Re-import to get new mocked values
     const { verifyRecaptchaToken: verifyWithNoKeys } = await import("./recaptcha");
     const result = await verifyWithNoKeys("token", 0.5);
-    expect(result).toBe(true);
-    expect(logger.warn).toHaveBeenCalledWith("reCAPTCHA verification skipped: keys not configured");
+    expect(result).toBe(false);
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining("reCAPTCHA verification rejected"));
   });
 
   test("returns false if fetch response is not ok", async () => {

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/recaptcha.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/recaptcha.ts
@@ -12,10 +12,13 @@ export const verifyRecaptchaToken = async (token: string, threshold: number): Pr
   const timeoutId = setTimeout(() => controller.abort(), 5000);
 
   try {
-    // If keys aren't configured, skip verification
+    // Fail closed when keys aren't configured: a survey opted into reCAPTCHA
+    // must not silently bypass spam protection because the server is misconfigured.
     if (!RECAPTCHA_SITE_KEY || !RECAPTCHA_SECRET_KEY) {
-      logger.warn("reCAPTCHA verification skipped: keys not configured");
-      return true;
+      logger.error(
+        "reCAPTCHA verification rejected: RECAPTCHA_SITE_KEY and/or RECAPTCHA_SECRET_KEY are not configured. Set both env vars or disable reCAPTCHA on the survey."
+      );
+      return false;
     }
 
     // Build URL-encoded form data


### PR DESCRIPTION
## Summary

- `verifyRecaptchaToken` was failing open: when `RECAPTCHA_SITE_KEY` / `RECAPTCHA_SECRET_KEY` were missing it returned `true` and logged at `warn`, so self-hosted instances ran "reCAPTCHA-protected" surveys with no actual protection and no clear signal.
- Now fails closed (returns `false`) and logs at `error` with a message naming the missing env vars, so operators get a prominent signal and the existing caller in `utils.ts` rejects the submission with `RECAPTCHA_VERIFICATION_ERROR_CODE`.
- Test updated to assert the new fail-closed behavior.

Resolves ENG-873.

## Test plan

- [x] `pnpm test app/api/v2/client/[workspaceId]/responses/lib/recaptcha.test.ts` — 8/8 pass
- [x] `pnpm test app/api/v2/client/[workspaceId]/responses/lib/utils.test.ts` — 20/20 pass (caller behavior unchanged when verification fails)
- [ ] Manual: with `RECAPTCHA_SITE_KEY` / `RECAPTCHA_SECRET_KEY` unset, submit a response to a survey with reCAPTCHA enabled → 400 with `RECAPTCHA_VERIFICATION_ERROR_CODE` and an error log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)