### PR TITLE
fix: validate empty "Other" text in optional multi-select

### DIFF
--- a/packages/survey-ui/src/components/elements/multi-select.tsx
+++ b/packages/survey-ui/src/components/elements/multi-select.tsx
@@ -278,7 +278,7 @@ function DropdownVariant({
           onChange={handleOtherInputChange}
           placeholder={otherOptionPlaceholder}
           disabled={disabled}
-          required
+          aria-required={true}
           aria-invalid={Boolean(errorMessage)}
           dir={dir}
           className="mt-2 w-full"
@@ -399,7 +399,7 @@ function ListVariant({
                   onChange={handleOtherInputChange}
                   placeholder={otherOptionPlaceholder}
                   disabled={disabled}
-                  required
+                  aria-required={true}
                   aria-invalid={Boolean(errorMessage)}
                   dir={dir}
                   className="mt-2 w-full"

--- a/packages/survey-ui/src/components/elements/single-select.tsx
+++ b/packages/survey-ui/src/components/elements/single-select.tsx
@@ -46,7 +46,7 @@ interface SingleSelectProps {
   /** Currently selected option ID */
   value?: string;
   /** Callback function called when selection changes */
-  onChange: (value: string) => void;
+  onChange: (value: string | undefined) => void;
   /** Whether the field is required (shows asterisk indicator) */
   required?: boolean;
   /** Custom label for the required indicator */
@@ -90,7 +90,7 @@ const useDropdownCommitState = ({
 }: {
   variant: SingleSelectVariant;
   selectedValue: string | undefined;
-  onChange: (value: string) => void;
+  onChange: (value: string | undefined) => void;
   handleDropdownOpen: () => void;
   handleDropdownClose: () => void;
 }): {
@@ -300,7 +300,7 @@ function SingleSelectDropdownVariant({
           onChange={handleOtherInputChange}
           placeholder={otherOptionPlaceholder}
           disabled={disabled}
-          required
+          aria-required={true}
           aria-invalid={Boolean(errorMessage)}
           dir={dir}
           className="mt-2 w-full"
@@ -337,7 +337,7 @@ interface ListVariantProps {
   required: boolean;
   options: SingleSelectOption[];
   selectedValue: string | undefined;
-  onChange: (value: string) => void;
+  onChange: (value: string | undefined) => void;
   hasOtherOption: boolean;
   otherOptionId?: string;
   otherOptionLabel: string;
@@ -382,6 +382,15 @@ function SingleSelectListVariant({
   const regularOptions = options.filter((option) => option.id !== "none");
   const noneOptions = options.filter((option) => option.id === "none");
 
+  const handleSelectedOptionClick = (optionId: string, event: React.MouseEvent<HTMLButtonElement>): void => {
+    if (required || selectedValue !== optionId) {
+      return;
+    }
+
+    event.preventDefault();
+    onChange(undefined);
+  };
+
   return (
     <div className="relative" data-element-input>
       <ElementError errorMessage={errorMessage} dir={dir} />
@@ -408,6 +417,7 @@ function SingleSelectListVariant({
                   id={optionId}
                   disabled={disabled}
                   aria-required={required}
+                  onClick={(event) => handleSelectedOptionClick(option.id, event)}
                 />
                 <span className={cn("mx-3 grow", OPTION_LABEL_CLASS)}>{option.label}</span>
               </span>
@@ -424,6 +434,7 @@ function SingleSelectListVariant({
             isOtherSelected={isOtherSelected}
             otherInputRef={otherInputRef}
             handleOtherInputChange={handleOtherInputChange}
+            handleSelectedOptionClick={handleSelectedOptionClick}
             dir={dir}
             disabled={disabled}
             required={required}
@@ -446,6 +457,7 @@ function SingleSelectListVariant({
                   id={optionId}
                   disabled={disabled}
                   aria-required={required}
+                  onClick={(event) => handleSelectedOptionClick(option.id, event)}
                 />
                 <span className={cn("mx-3 grow", OPTION_LABEL_CLASS)}>{option.label}</span>
               </span>
@@ -466,6 +478,7 @@ interface OtherOptionLabelProps {
   isOtherSelected: boolean;
   otherInputRef: React.RefObject<HTMLInputElement | null>;
   handleOtherInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleSelectedOptionClick: (optionId: string, event: React.MouseEvent<HTMLButtonElement>) => void;
   dir: Direction;
   disabled: boolean;
   required: boolean;
@@ -481,6 +494,7 @@ function OtherOptionLabel({
   isOtherSelected,
   otherInputRef,
   handleOtherInputChange,
+  handleSelectedOptionClick,
   dir,
   disabled,
   required,
@@ -497,6 +511,7 @@ function OtherOptionLabel({
           id={`${inputId}-${otherOptionId}`}
           disabled={disabled}
           aria-required={required}
+          onClick={(event) => handleSelectedOptionClick(otherOptionId, event)}
         />
         <span className={cn("mr-3 ml-3 grow", OPTION_LABEL_CLASS)}>{otherOptionLabel}</span>
       </span>
@@ -508,7 +523,7 @@ function OtherOptionLabel({
           onChange={handleOtherInputChange}
           placeholder={otherOptionPlaceholder}
           disabled={disabled}
-          required
+          aria-required={true}
           aria-invalid={Boolean(errorMessage)}
           dir={dir}
           className="mt-2 w-full"

--- a/packages/surveys/src/components/elements/multiple-choice-single-element.tsx
+++ b/packages/surveys/src/components/elements/multiple-choice-single-element.tsx
@@ -91,8 +91,11 @@ export function MultipleChoiceSingleElement({
     if (isOtherSelected) setOtherValue(value ?? "");
   }, [isOtherSelected, value]);
 
-  const handleChange = (selectedValue: string) => {
-    if (selectedValue === otherOption?.id) {
+  const handleChange = (selectedValue: string | undefined) => {
+    if (selectedValue === undefined) {
+      setOtherValue("");
+      onChange({ [element.id]: undefined });
+    } else if (selectedValue === otherOption?.id) {
       setOtherValue("");
       onChange({ [element.id]: "" });
     } else {

--- a/packages/surveys/src/components/general/block-conditional.tsx
+++ b/packages/surveys/src/components/general/block-conditional.tsx
@@ -219,14 +219,15 @@ export function BlockConditional({
   const validateElementForm = (element: TSurveyElement, form: HTMLFormElement): boolean => {
     const response = value[element.id];
 
+    if (element.type !== TSurveyElementTypeEnum.CTA && !form.checkValidity()) {
+      form.requestSubmit();
+      return false;
+    }
+
     if (
       element.type === TSurveyElementTypeEnum.Address ||
       element.type === TSurveyElementTypeEnum.ContactInfo
     ) {
-      if (!form.checkValidity()) {
-        form.requestSubmit();
-        return false;
-      }
       return true;
     }
 

--- a/packages/surveys/src/lib/validation/evaluator.test.ts
+++ b/packages/surveys/src/lib/validation/evaluator.test.ts
@@ -122,6 +122,56 @@ describe("validateElementResponse", () => {
       expect(result.errors[0].ruleId).toBe("required");
     });
 
+    test("should return error when optional single-select has other selected but no text", () => {
+      const element = {
+        id: "single1",
+        type: TSurveyElementTypeEnum.MultipleChoiceSingle,
+        headline: { default: "Pick" },
+        required: false,
+        choices: [
+          { id: "opt1", label: { default: "Option 1" } },
+          { id: "other", label: { default: "Other" } },
+        ],
+      } as unknown as TSurveyElement;
+
+      const result = validateElementResponse(element, "", "en");
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].ruleId).toBe("required");
+    });
+
+    test("should return error when optional single-select has blank other text", () => {
+      const element = {
+        id: "single1",
+        type: TSurveyElementTypeEnum.MultipleChoiceSingle,
+        headline: { default: "Pick" },
+        required: false,
+        choices: [
+          { id: "opt1", label: { default: "Option 1" } },
+          { id: "other", label: { default: "Other" } },
+        ],
+      } as unknown as TSurveyElement;
+
+      const result = validateElementResponse(element, "   ", "en");
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].ruleId).toBe("required");
+    });
+
+    test("should return valid when optional single-select has no response", () => {
+      const element = {
+        id: "single1",
+        type: TSurveyElementTypeEnum.MultipleChoiceSingle,
+        headline: { default: "Pick" },
+        required: false,
+        choices: [
+          { id: "opt1", label: { default: "Option 1" } },
+          { id: "other", label: { default: "Other" } },
+        ],
+      } as unknown as TSurveyElement;
+
+      const result = validateElementResponse(element, undefined, "en");
+      expect(result.valid).toBe(true);
+    });
+
     test("should return valid when required multi-select has other with text (legacy sentinel)", () => {
       const element = {
         id: "mc1",

--- a/packages/surveys/src/lib/validation/evaluator.test.ts
+++ b/packages/surveys/src/lib/validation/evaluator.test.ts
@@ -94,10 +94,30 @@ describe("validateElementResponse", () => {
         type: TSurveyElementTypeEnum.MultipleChoiceMulti,
         headline: { default: "Pick" },
         required: true,
-        choices: [{ id: "opt1", label: { default: "Option 1" } }],
+        choices: [
+          { id: "opt1", label: { default: "Option 1" } },
+          { id: "other", label: { default: "Other" } },
+        ],
       } as unknown as TSurveyElement;
 
       const result = validateElementResponse(element, ["opt1", ""], "en");
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].ruleId).toBe("required");
+    });
+
+    test("should return error when optional multi-select has other selected but no text", () => {
+      const element = {
+        id: "mc1",
+        type: TSurveyElementTypeEnum.MultipleChoiceMulti,
+        headline: { default: "Pick" },
+        required: false,
+        choices: [
+          { id: "opt1", label: { default: "Option 1" } },
+          { id: "other", label: { default: "Other" } },
+        ],
+      } as unknown as TSurveyElement;
+
+      const result = validateElementResponse(element, ["Option 1", ""], "en");
       expect(result.valid).toBe(false);
       expect(result.errors[0].ruleId).toBe("required");
     });
@@ -108,7 +128,10 @@ describe("validateElementResponse", () => {
         type: TSurveyElementTypeEnum.MultipleChoiceMulti,
         headline: { default: "Pick" },
         required: true,
-        choices: [{ id: "opt1", label: { default: "Option 1" } }],
+        choices: [
+          { id: "opt1", label: { default: "Option 1" } },
+          { id: "other", label: { default: "Other" } },
+        ],
       } as unknown as TSurveyElement;
 
       const result = validateElementResponse(element, ["opt1", "", "custom"], "en");

--- a/packages/surveys/src/lib/validation/evaluator.ts
+++ b/packages/surveys/src/lib/validation/evaluator.ts
@@ -152,6 +152,40 @@ const validateMultiSelectOtherValue = (
   return null;
 };
 
+const validateSingleSelectOtherValue = (
+  element: TSurveyElement,
+  value: TResponseDataValue,
+  languageCode: string,
+  t: TFunction
+): TValidationError | null => {
+  if (element.type !== TSurveyElementTypeEnum.MultipleChoiceSingle || typeof value !== "string") {
+    return null;
+  }
+
+  const hasOtherOption = "choices" in element && element.choices.some((choice) => choice.id === "other");
+  if (!hasOtherOption || (element.required && value === "")) {
+    return null;
+  }
+
+  const knownChoiceIds = element.choices.filter((choice) => choice.id !== "other").map((choice) => choice.id);
+  if (knownChoiceIds.includes(value)) {
+    return null;
+  }
+
+  const knownChoiceLabels = element.choices
+    .filter((choice) => choice.id !== "other")
+    .map((choice) => getLocalizedValue(choice.label, languageCode));
+  if (knownChoiceLabels.includes(value)) {
+    return null;
+  }
+
+  if (value.trim() === "") {
+    return createRequiredError(t);
+  }
+
+  return null;
+};
+
 /**
  * Check required field validation
  */
@@ -392,6 +426,11 @@ export const validateElementResponse = (
   const requiredError = checkRequiredField(element, value, t);
   if (requiredError) {
     errors.push(requiredError);
+  }
+
+  const singleSelectOtherError = validateSingleSelectOtherValue(element, value, languageCode, t);
+  if (singleSelectOtherError) {
+    errors.push(singleSelectOtherError);
   }
 
   const multiSelectOtherError = validateMultiSelectOtherValue(element, value, t);

--- a/packages/surveys/src/lib/validation/evaluator.ts
+++ b/packages/surveys/src/lib/validation/evaluator.ts
@@ -145,7 +145,7 @@ const validateMultiSelectOtherValue = (
   }
 
   const otherText = value[sentinelIndex + 1];
-  if (!otherText || (typeof otherText === "string" && otherText.trim() === "")) {
+  if (typeof otherText !== "string" || otherText.trim() === "") {
     return createRequiredError(t);
   }
 

--- a/packages/surveys/src/lib/validation/evaluator.ts
+++ b/packages/surveys/src/lib/validation/evaluator.ts
@@ -125,6 +125,33 @@ const validateRequiredMatrix = (
   return null;
 };
 
+const validateMultiSelectOtherValue = (
+  element: TSurveyElement,
+  value: TResponseDataValue,
+  t: TFunction
+): TValidationError | null => {
+  if (element.type !== TSurveyElementTypeEnum.MultipleChoiceMulti || !Array.isArray(value)) {
+    return null;
+  }
+
+  const hasOtherOption = "choices" in element && element.choices.some((choice) => choice.id === "other");
+  if (!hasOtherOption) {
+    return null;
+  }
+
+  const sentinelIndex = value.indexOf("");
+  if (sentinelIndex === -1) {
+    return null;
+  }
+
+  const otherText = value[sentinelIndex + 1];
+  if (!otherText || (typeof otherText === "string" && otherText.trim() === "")) {
+    return createRequiredError(t);
+  }
+
+  return null;
+};
+
 /**
  * Check required field validation
  */
@@ -152,17 +179,6 @@ const checkRequiredField = (
 
   if (isEmpty(value)) {
     return createRequiredError(t);
-  }
-
-  // For multi-select: if "other" is selected (sentinel ""), require the other text to be non-empty
-  if (element.type === TSurveyElementTypeEnum.MultipleChoiceMulti && Array.isArray(value)) {
-    const sentinelIndex = value.indexOf("");
-    if (sentinelIndex !== -1) {
-      const otherText = value[sentinelIndex + 1];
-      if (!otherText || (typeof otherText === "string" && otherText.trim() === "")) {
-        return createRequiredError(t);
-      }
-    }
   }
 
   return null;
@@ -376,6 +392,11 @@ export const validateElementResponse = (
   const requiredError = checkRequiredField(element, value, t);
   if (requiredError) {
     errors.push(requiredError);
+  }
+
+  const multiSelectOtherError = validateMultiSelectOtherValue(element, value, t);
+  if (multiSelectOtherError) {
+    errors.push(multiSelectOtherError);
   }
 
   // Validation rules apply to matrix elements regardless of required status


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Validates empty "Other" responses for optional multi-select questions so respondents cannot advance with "Other" selected and no text entered.
- Moves the multi-select "Other" validation out of required-only validation so it applies whenever the option is selected.
- Runs native form validity checks for non-CTA survey elements before advancing, preventing required custom inputs from being skipped.
- Adds regression coverage for optional multi-select "Other" validation.

Fixes ENG-1023

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Run `pnpm --filter @formbricks/surveys exec vitest run src/lib/validation/evaluator.test.ts`.
- Rebuild the survey bundle with `pnpm build --filter=@formbricks/surveys... --force`.
- Start the web app with `pnpm dev`.
- Open or create an optional multi-select survey with an "Other" option.
- Select "Other", leave the text input empty, and click Next. The survey should stay on the same question and show the required-field error.
- Enter text in the "Other" input and click Next. The survey should advance normally.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary

<img width="659" height="439" alt="image" src="https://github.com/user-attachments/assets/2cae1d03-eba9-45cf-bf6a-5f5ae68a4512" />
