### PR TITLE
fix: resolve language alias for link survey previews (ENG-674)

### DIFF
--- a/apps/web/modules/survey/link/lib/metadata-utils.test.ts
+++ b/apps/web/modules/survey/link/lib/metadata-utils.test.ts
@@ -215,6 +215,76 @@ describe("Metadata Utils", () => {
       expect(result.title).toBe("Welcome Headline");
     });
 
+    test("uses localized metadata when language matches a language code", async () => {
+      const mockSurvey = {
+        id: mockSurveyId,
+        workspaceId: mockWorkspaceId,
+        name: "Test Survey",
+        metadata: {
+          title: { default: "Default Title", "de-AT": "Österreichischer Titel" },
+          description: { default: "Default Description", "de-AT": "Österreichische Beschreibung" },
+        },
+        languages: [
+          { language: { code: "default", alias: null }, default: true, enabled: true },
+          { language: { code: "de-AT", alias: "austrian" }, default: false, enabled: true },
+        ],
+        welcomeCard: { enabled: false } as TSurveyWelcomeCard,
+      } as unknown as TSurvey;
+
+      vi.mocked(getSurvey).mockResolvedValue(mockSurvey);
+
+      const result = await getBasicSurveyMetadata(mockSurveyId, "de-AT");
+
+      expect(result.title).toBe("Österreichischer Titel");
+      expect(result.description).toBe("Österreichische Beschreibung");
+    });
+
+    test("resolves a language alias to the correct localized metadata", async () => {
+      const mockSurvey = {
+        id: mockSurveyId,
+        workspaceId: mockWorkspaceId,
+        name: "Test Survey",
+        metadata: {
+          title: { default: "Default Title", "de-AT": "Österreichischer Titel" },
+          description: { default: "Default Description", "de-AT": "Österreichische Beschreibung" },
+        },
+        languages: [
+          { language: { code: "default", alias: null }, default: true, enabled: true },
+          { language: { code: "de-AT", alias: "austrian" }, default: false, enabled: true },
+        ],
+        welcomeCard: { enabled: false } as TSurveyWelcomeCard,
+      } as unknown as TSurvey;
+
+      vi.mocked(getSurvey).mockResolvedValue(mockSurvey);
+
+      const result = await getBasicSurveyMetadata(mockSurveyId, "austrian");
+
+      expect(result.title).toBe("Österreichischer Titel");
+      expect(result.description).toBe("Österreichische Beschreibung");
+    });
+
+    test("falls back to default metadata when language is not enabled", async () => {
+      const mockSurvey = {
+        id: mockSurveyId,
+        workspaceId: mockWorkspaceId,
+        name: "Test Survey",
+        metadata: {
+          title: { default: "Default Title", "de-AT": "Österreichischer Titel" },
+        },
+        languages: [
+          { language: { code: "default", alias: null }, default: true, enabled: true },
+          { language: { code: "de-AT", alias: "austrian" }, default: false, enabled: false },
+        ],
+        welcomeCard: { enabled: false } as TSurveyWelcomeCard,
+      } as unknown as TSurvey;
+
+      vi.mocked(getSurvey).mockResolvedValue(mockSurvey);
+
+      const result = await getBasicSurveyMetadata(mockSurveyId, "austrian");
+
+      expect(result.title).toBe("Default Title");
+    });
+
     test("handles welcome card headline with recall variables", async () => {
       const { recallToHeadline } = await import("@/lib/utils/recall");
 

--- a/apps/web/modules/survey/link/lib/metadata-utils.ts
+++ b/apps/web/modules/survey/link/lib/metadata-utils.ts
@@ -46,12 +46,22 @@ export const getBasicSurveyMetadata = async (
 
   const metadata = surveyData.metadata;
   const welcomeCard = surveyData.welcomeCard;
-  const useDefaultLanguageCode =
-    languageCode === "default" ||
-    surveyData.languages.find((lang) => lang.language.code === languageCode)?.default;
+
+  // Resolve the language code, accepting either the language code or its alias (case-insensitive).
+  const selectedLanguage =
+    languageCode === "default"
+      ? undefined
+      : surveyData.languages.find(
+          (lang) =>
+            lang.language.code.toLowerCase() === languageCode.toLowerCase() ||
+            lang.language.alias?.toLowerCase() === languageCode.toLowerCase()
+        );
 
   // Determine language code to use for metadata
-  const langCode = useDefaultLanguageCode ? "default" : languageCode;
+  const langCode =
+    !selectedLanguage || selectedLanguage.default || !selectedLanguage.enabled
+      ? "default"
+      : selectedLanguage.language.code;
 
   // Set title - priority: custom link metadata > welcome card > survey name
   const titleFromMetadata = metadata?.title ? getLocalizedValue(metadata.title, langCode) || "" : undefined;


### PR DESCRIPTION
## Summary

Fixes [ENG-674](https://linear.app/formbricks/issue/ENG-674) — survey link previews (Open Graph metadata) did not respect language aliases. A survey set up in DE-AT and triggered via its alias still rendered the link preview in English.

**Root cause:** `getBasicSurveyMetadata` resolved the URL `lang` param only against each language's `code`, never its `alias`. When the param was an alias, no match was found and the metadata silently fell back to the default (English) language. Additionally, even on a code match it passed the raw URL value into `getLocalizedValue`, which keys translations by the actual language code — so an alias would never find the localized text.

**Fix:** Resolve the param against both `code` and `alias` (case-insensitive) and use the resolved language's real `code` for translation lookup, mirroring the existing `getLanguageCode` logic in `survey-renderer.tsx`. Disabled/default languages correctly fall back to `default`.

## Test plan

- [x] Added unit tests in `metadata-utils.test.ts`:
  - localized metadata when the param matches a language code
  - alias resolves to the correct localized metadata
  - falls back to default when the language is disabled
- [x] `vitest run modules/survey/link/lib/metadata-utils.test.ts` — 20/20 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)