### PR TITLE
fix: stamp Linear release version before completing release

### DIFF
--- a/.github/workflows/formbricks-release.yml
+++ b/.github/workflows/formbricks-release.yml
@@ -259,6 +259,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Stamp the in-progress release with the tag version before completing it.
+      # complete only looks up a release by version, it never assigns one, so a
+      # versioned sync must run first (Linear's recommended scheduled-pipeline flow).
+      - name: Stamp Linear release version
+        uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b # v0.7.0
+        with:
+          access_key: ${{ secrets.LINEAR_ACCESS_KEY }}
+          version: ${{ github.event.release.tag_name }}
+
       - name: Complete Linear release
         uses: linear/linear-release-action@0353b5fa8c00326913966f00557d68f8f30b8b6b # v0.7.0
         with:


### PR DESCRIPTION
## Summary

The `linear-release-complete` job in `formbricks-release.yml` failed during the 5.0.0 release with:

> Error: Not found - No release found with version "5.0.0" for the specified pipeline.

In a Linear **scheduled** pipeline, the `complete` command only *looks up* a release by version — it never *assigns* one. Our push-to-main syncs build an unversioned in-progress release, and the release-publish job jumped straight to `complete --release-version=<tag>` against a release that was never stamped with that version, so the lookup failed (it had to be renamed by hand).

This adds a versioned `sync` step before `complete`, matching Linear's recommended scheduled-pipeline flow ("prefer always passing `version` in CI"):

1. `sync` with `version: ${{ github.event.release.tag_name }}` — stamps the tag version onto the in-progress release and re-scans commits to attach referenced issues.
2. `complete` with the same version — moves it to the Released stage.

No more manual renaming for future releases.

## Test plan

- [ ] On the next non-prerelease GitHub release, confirm the `Mark Linear release as complete` job succeeds end-to-end.
- [ ] In Linear (Releases → Formbricks), confirm a single release stamped with the tag version lands in **Released** — no leftover unversioned "New release" duplicate.
- [ ] Confirm pre-releases/RCs are still skipped (existing `if: !prerelease` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)