### PR TITLE
fix(helm): wire bundled cube runtime env

### DIFF
--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -50,10 +50,12 @@ The intended defaults are:
 Cube is part of the baseline Formbricks v5 stack and is deployed by this chart by default
 (`cube.enabled: true`).
 
-- For the chart-managed Cube, `deployment.env.CUBEJS_API_URL` should point at `http://formbricks-cube:4000`
-  when using the default release name.
+- For the chart-managed Cube, the chart renders `deployment.env.CUBEJS_API_URL` automatically as
+  `http://formbricks-cube:4000` when using the default release name.
 - For an external Cube, set `cube.enabled: false` and point `deployment.env.CUBEJS_API_URL` at your
   endpoint.
+- Cube listens on `cube.port`; the chart renders this as an explicit `PORT` env var so values from shared
+  app secrets cannot override the listener port.
 - The generated app secret supplies `CUBEJS_API_SECRET` by default. If you disable generated secrets,
   provide it through your existing secret management flow.
 - Provide `CUBEJS_DB_*` connection variables to the Cube deployment through `cube.envFrom` or `cube.env`.

--- a/charts/formbricks/templates/cube-deployment.yaml
+++ b/charts/formbricks/templates/cube-deployment.yaml
@@ -100,7 +100,9 @@ spec:
             {{- end }}
           {{- end }}
           env:
-            {{- range $key, $value := .Values.cube.env }}
+            - name: PORT
+              value: {{ .Values.cube.port | quote }}
+            {{- range $key, $value := omit (.Values.cube.env | default dict) "PORT" }}
             {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
           volumeMounts:

--- a/charts/formbricks/templates/deployment.yaml
+++ b/charts/formbricks/templates/deployment.yaml
@@ -135,6 +135,10 @@ spec:
             - name: HUB_API_URL
               value: "http://{{ include "formbricks.hubname" . }}:8080"
             {{- end }}
+            {{- if and .Values.cube.enabled (not (hasKey .Values.deployment.env "CUBEJS_API_URL")) }}
+            - name: CUBEJS_API_URL
+              value: "http://{{ include "formbricks.cubeName" . }}:{{ .Values.cube.service.port }}"
+            {{- end }}
             {{- range $key, $value := .Values.deployment.env }}
             {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -98,6 +98,7 @@ deployment:
   # Environment variables passed to the app container.
   # Cube is bundled by default (see the `cube` section below). To use an external Cube cluster instead,
   # set `cube.enabled: false` and provide CUBEJS_API_URL / CUBEJS_API_SECRET here via deployment.env or envFrom.
+  # When bundled Cube is enabled, CUBEJS_API_URL is rendered automatically unless set here.
   env: {}
 
   # Tolerations for scheduling pods on tainted nodes
@@ -613,6 +614,8 @@ cube:
   envFrom: []
 
   env:
+    # PORT is rendered from cube.port so app-level secret values cannot override
+    # the Cube listener port through envFrom.
     CUBEJS_DB_TYPE: "postgres"
     CUBEJS_DEFAULT_API_SCOPES: "meta,data"
     # Keep the in-memory cache/queue driver at one Cube replica only. The chart


### PR DESCRIPTION
## Summary
- render `CUBEJS_API_URL` automatically for the chart-managed Cube service when `cube.enabled=true`
- render Cube `PORT` from `cube.port` so shared app secrets cannot override the listener port
- document the bundled Cube defaults in the chart README and values comments

## Why
During the v5 production rollout, the web app failed to start without `CUBEJS_API_URL`, and Cube inherited `PORT=3000` from app secrets while probes and services expected `4000`. These defaults make the bundled Cube path self-contained and avoid needing live Helm parameter hotfixes.

## Validation
- `helm lint charts/formbricks`
- `helm template formbricks charts/formbricks --set formbricks.webappUrl=https://example.com`
- rendered main Deployment with default bundled Cube and confirmed `HUB_API_URL` plus `CUBEJS_API_URL`
- rendered explicit `deployment.env.CUBEJS_API_URL` override and confirmed no duplicate default
- rendered `cube.env.PORT=3000` override and confirmed Cube still gets one `PORT` from `cube.port`