### PR TITLE
fix: restore Microsoft SSO account lookup

### DIFF
--- a/apps/web/modules/auth/lib/adapter.test.ts
+++ b/apps/web/modules/auth/lib/adapter.test.ts
@@ -1,0 +1,172 @@
+import { PrismaAdapter } from "@next-auth/prisma-adapter";
+import type { PrismaClient } from "@prisma/client";
+import type { AdapterAccount } from "next-auth/adapters";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { logger } from "@formbricks/logger";
+import { getNextAuthAdapter } from "./adapter";
+
+type TCallbackHandler = (params: unknown) => Promise<unknown>;
+
+const mocks = vi.hoisted(() => ({
+  getUserByAccount: vi.fn(),
+  getUserByEmail: vi.fn(),
+  linkAccount: vi.fn(),
+  unlinkAccount: vi.fn(),
+  createUser: vi.fn(),
+  createSession: vi.fn(),
+}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock("@next-auth/prisma-adapter", () => ({
+  PrismaAdapter: vi.fn(),
+}));
+
+const requireNextAuthModule = createRequire(import.meta.url);
+const nextAuthPackageRoot = path.dirname(requireNextAuthModule.resolve("next-auth"));
+const callbackHandler = requireNextAuthModule(path.join(nextAuthPackageRoot, "core/lib/callback-handler.js"))
+  .default as TCallbackHandler;
+
+const baseAdapter = {
+  getUserByAccount: mocks.getUserByAccount,
+  getUserByEmail: mocks.getUserByEmail,
+  linkAccount: mocks.linkAccount,
+  unlinkAccount: mocks.unlinkAccount,
+  createUser: mocks.createUser,
+  createSession: mocks.createSession,
+};
+
+const prismaClient = {} as PrismaClient;
+
+const azureAccount: AdapterAccount = {
+  userId: "user_1",
+  type: "oauth",
+  provider: "azure-ad",
+  providerAccountId: "sub-123",
+};
+
+describe("getNextAuthAdapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(PrismaAdapter).mockReturnValue(baseAdapter as never);
+  });
+
+  test("normalizes the Microsoft provider id to the canonical value when resolving a user", async () => {
+    const user = { id: "user_1", email: "user@example.com" };
+    mocks.getUserByAccount.mockResolvedValue(user);
+
+    const adapter = getNextAuthAdapter(prismaClient);
+    const result = await adapter.getUserByAccount?.({
+      provider: "azure-ad",
+      providerAccountId: "sub-123",
+    });
+
+    expect(mocks.getUserByAccount).toHaveBeenCalledWith({
+      provider: "azuread",
+      providerAccountId: "sub-123",
+    });
+    expect(result).toBe(user);
+  });
+
+  test("passes already-canonical providers through unchanged", async () => {
+    mocks.getUserByAccount.mockResolvedValue(null);
+
+    const adapter = getNextAuthAdapter(prismaClient);
+    await adapter.getUserByAccount?.({ provider: "google", providerAccountId: "g-1" });
+
+    expect(mocks.getUserByAccount).toHaveBeenCalledWith({
+      provider: "google",
+      providerAccountId: "g-1",
+    });
+  });
+
+  test("normalizes the provider when linking and unlinking accounts", async () => {
+    const adapter = getNextAuthAdapter(prismaClient);
+
+    await adapter.linkAccount?.(azureAccount);
+    await adapter.unlinkAccount?.({ provider: "azure-ad", providerAccountId: "sub-123" });
+
+    expect(mocks.linkAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "azuread", providerAccountId: "sub-123", userId: "user_1" })
+    );
+    expect(mocks.unlinkAccount).toHaveBeenCalledWith({
+      provider: "azuread",
+      providerAccountId: "sub-123",
+    });
+  });
+
+  test("lets the NextAuth OAuth callback resolve canonical Microsoft account rows", async () => {
+    const user = { id: "user_1", email: "user@example.com" };
+    const session = {
+      sessionToken: "session-token",
+      userId: user.id,
+      expires: new Date("2026-01-01T00:00:00.000Z"),
+    };
+
+    mocks.getUserByAccount.mockImplementation(async ({ provider }) => (provider === "azuread" ? user : null));
+    mocks.getUserByEmail.mockResolvedValue(user);
+    mocks.createSession.mockResolvedValue(session);
+
+    const result = await callbackHandler({
+      sessionToken: undefined,
+      profile: { id: "profile_1", email: user.email },
+      account: azureAccount,
+      options: {
+        adapter: getNextAuthAdapter(prismaClient),
+        events: {},
+        jwt: {},
+        provider: { id: "azure-ad" },
+        session: {
+          strategy: "database",
+          generateSessionToken: () => "session-token",
+          maxAge: 60 * 60,
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      session,
+      user,
+      isNewUser: false,
+    });
+    expect(mocks.getUserByAccount).toHaveBeenCalledWith({
+      provider: "azuread",
+      providerAccountId: "sub-123",
+    });
+    expect(mocks.getUserByEmail).not.toHaveBeenCalled();
+    expect(mocks.linkAccount).not.toHaveBeenCalled();
+  });
+
+  test("logs and rethrows when a delegated adapter method fails", async () => {
+    const failure = new Error("database unavailable");
+    mocks.getUserByAccount.mockRejectedValue(failure);
+
+    const adapter = getNextAuthAdapter(prismaClient);
+
+    await expect(
+      adapter.getUserByAccount?.({ provider: "azure-ad", providerAccountId: "sub-123" })
+    ).rejects.toThrow(failure);
+    expect(logger.error).toHaveBeenCalledWith(failure, 'NextAuth Prisma adapter "getUserByAccount" failed');
+  });
+
+  test("preserves base adapter methods that do not key on the provider", () => {
+    const adapter = getNextAuthAdapter(prismaClient);
+    expect(adapter.createUser).toBe(mocks.createUser);
+  });
+
+  test("throws when the base adapter is missing required account methods", () => {
+    vi.mocked(PrismaAdapter).mockReturnValueOnce({} as never);
+    expect(() => getNextAuthAdapter(prismaClient)).toThrow(
+      "PrismaAdapter is missing the account methods required for SSO sign-in"
+    );
+  });
+});

--- a/apps/web/modules/auth/lib/adapter.ts
+++ b/apps/web/modules/auth/lib/adapter.ts
@@ -1,0 +1,65 @@
+import { PrismaAdapter } from "@next-auth/prisma-adapter";
+import type { PrismaClient } from "@prisma/client";
+import type { Adapter, AdapterAccount, AdapterUser } from "next-auth/adapters";
+import { logger } from "@formbricks/logger";
+import { resolveAccountProvider } from "@/modules/ee/sso/lib/provider-normalization";
+
+type TProviderAccountKey = Pick<AdapterAccount, "provider" | "providerAccountId">;
+
+const normalizeProviderKey = <T extends { provider: string }>(value: T): T => ({
+  ...value,
+  provider: resolveAccountProvider(value.provider),
+});
+
+/**
+ * Wraps an adapter method so any failure is logged with context before being re-thrown.
+ * NextAuth turns the re-thrown error into the relevant auth error page, so we keep the
+ * original behaviour while making adapter-level failures observable.
+ */
+const withAdapterErrorLogging =
+  <TArgs extends unknown[], TResult>(method: string, handler: (...args: TArgs) => Promise<TResult>) =>
+  async (...args: TArgs): Promise<TResult> => {
+    try {
+      return await handler(...args);
+    } catch (error) {
+      logger.error(error, `NextAuth Prisma adapter "${method}" failed`);
+      throw error;
+    }
+  };
+
+/**
+ * NextAuth resolves accounts by each provider's NextAuth `id` — Microsoft's is "azure-ad" — but
+ * Formbricks persists the canonical `IdentityProvider` value ("azuread") in `Account.provider`.
+ * Left unreconciled, the adapter's native lookup misses the stored row, falls back to matching by
+ * email, and rejects the sign-in with `OAuthAccountNotLinked`.
+ *
+ * Normalizing the provider at the adapter boundary keeps the native lookup/link/unlink aligned with
+ * both the stored rows and the custom SSO sign-in handler for every provider, without leaking
+ * provider-specific naming into the call sites.
+ */
+export const getNextAuthAdapter = (prismaClient: PrismaClient): Adapter => {
+  const baseAdapter = PrismaAdapter(prismaClient);
+  const { getUserByAccount, linkAccount, unlinkAccount } = baseAdapter;
+
+  if (!getUserByAccount || !linkAccount || !unlinkAccount) {
+    throw new Error("PrismaAdapter is missing the account methods required for SSO sign-in");
+  }
+
+  return {
+    ...baseAdapter,
+    getUserByAccount: withAdapterErrorLogging(
+      "getUserByAccount",
+      async (providerAccount: TProviderAccountKey): Promise<AdapterUser | null> =>
+        getUserByAccount(normalizeProviderKey(providerAccount))
+    ),
+    linkAccount: withAdapterErrorLogging("linkAccount", async (account: AdapterAccount): Promise<void> => {
+      await linkAccount(normalizeProviderKey(account));
+    }),
+    unlinkAccount: withAdapterErrorLogging(
+      "unlinkAccount",
+      async (providerAccount: TProviderAccountKey): Promise<void> => {
+        await unlinkAccount(normalizeProviderKey(providerAccount));
+      }
+    ),
+  };
+};

--- a/apps/web/modules/auth/lib/adapter.ts
+++ b/apps/web/modules/auth/lib/adapter.ts
@@ -1,6 +1,7 @@
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import type { PrismaClient } from "@prisma/client";
-import type { Adapter, AdapterAccount, AdapterUser } from "next-auth/adapters";
+import type { Awaitable } from "next-auth";
+import type { Adapter, AdapterAccount } from "next-auth/adapters";
 import { logger } from "@formbricks/logger";
 import { resolveAccountProvider } from "@/modules/ee/sso/lib/provider-normalization";
 
@@ -17,7 +18,7 @@ const normalizeProviderKey = <T extends { provider: string }>(value: T): T => ({
  * original behaviour while making adapter-level failures observable.
  */
 const withAdapterErrorLogging =
-  <TArgs extends unknown[], TResult>(method: string, handler: (...args: TArgs) => Promise<TResult>) =>
+  <TArgs extends unknown[], TResult>(method: string, handler: (...args: TArgs) => Awaitable<TResult>) =>
   async (...args: TArgs): Promise<TResult> => {
     try {
       return await handler(...args);
@@ -47,19 +48,14 @@ export const getNextAuthAdapter = (prismaClient: PrismaClient): Adapter => {
 
   return {
     ...baseAdapter,
-    getUserByAccount: withAdapterErrorLogging(
-      "getUserByAccount",
-      async (providerAccount: TProviderAccountKey): Promise<AdapterUser | null> =>
-        getUserByAccount(normalizeProviderKey(providerAccount))
+    getUserByAccount: withAdapterErrorLogging("getUserByAccount", (providerAccount: TProviderAccountKey) =>
+      getUserByAccount(normalizeProviderKey(providerAccount))
     ),
-    linkAccount: withAdapterErrorLogging("linkAccount", async (account: AdapterAccount): Promise<void> => {
-      await linkAccount(normalizeProviderKey(account));
-    }),
-    unlinkAccount: withAdapterErrorLogging(
-      "unlinkAccount",
-      async (providerAccount: TProviderAccountKey): Promise<void> => {
-        await unlinkAccount(normalizeProviderKey(providerAccount));
-      }
+    linkAccount: withAdapterErrorLogging("linkAccount", (account: AdapterAccount) =>
+      linkAccount(normalizeProviderKey(account))
+    ),
+    unlinkAccount: withAdapterErrorLogging("unlinkAccount", (providerAccount: TProviderAccountKey) =>
+      unlinkAccount(normalizeProviderKey(providerAccount))
     ),
   };
 };

--- a/apps/web/modules/auth/lib/authOptions.ts
+++ b/apps/web/modules/auth/lib/authOptions.ts
@@ -1,4 +1,3 @@
-import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import type { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { cookies } from "next/headers";
@@ -37,6 +36,7 @@ import {
 import { UNKNOWN_DATA } from "@/modules/ee/audit-logs/types/audit-log";
 import { getSSOProviders } from "@/modules/ee/sso/lib/providers";
 import { handleSsoCallback } from "@/modules/ee/sso/lib/sso-handlers";
+import { getNextAuthAdapter } from "./adapter";
 import { createBrevoCustomer } from "./brevo";
 
 type TSignInCallbackParams = Parameters<NonNullable<NonNullable<NextAuthOptions["callbacks"]>["signIn"]>>[0];
@@ -137,7 +137,7 @@ const handleEnterpriseSsoSignIn = async ({
 };
 
 export const authOptions: NextAuthOptions = {
-  adapter: PrismaAdapter(prisma),
+  adapter: getNextAuthAdapter(prisma),
   providers: [
     CredentialsProvider({
       id: "credentials",

--- a/apps/web/modules/ee/sso/lib/provider-normalization.test.ts
+++ b/apps/web/modules/ee/sso/lib/provider-normalization.test.ts
@@ -3,6 +3,7 @@ import {
   getLegacySsoProviderAliases,
   getSsoProviderLookupCandidates,
   normalizeSsoProvider,
+  resolveAccountProvider,
 } from "./provider-normalization";
 
 describe("SSO provider normalization", () => {
@@ -24,5 +25,14 @@ describe("SSO provider normalization", () => {
   test("includes canonical and legacy provider ids when searching for linked accounts", () => {
     expect(getSsoProviderLookupCandidates("azuread")).toEqual(["azuread", "azure-ad"]);
     expect(getSsoProviderLookupCandidates("google")).toEqual(["google"]);
+  });
+
+  test("resolves NextAuth provider ids to the canonical Account.provider string", () => {
+    expect(resolveAccountProvider("azure-ad")).toBe("azuread");
+    expect(resolveAccountProvider("google")).toBe("google");
+  });
+
+  test("passes unknown providers through unchanged", () => {
+    expect(resolveAccountProvider("credentials")).toBe("credentials");
   });
 });

--- a/apps/web/modules/ee/sso/lib/provider-normalization.ts
+++ b/apps/web/modules/ee/sso/lib/provider-normalization.ts
@@ -37,3 +37,11 @@ export const getSsoProviderLookupCandidates = (provider: string): string[] => {
 
   return [normalizedProvider, ...getLegacySsoProviderAliases(normalizedProvider)];
 };
+
+/**
+ * Resolves a NextAuth provider id (e.g. "azure-ad") to the canonical provider string persisted
+ * in `Account.provider` (e.g. "azuread"). Unknown providers are returned unchanged so callers
+ * never drop a value they were handed.
+ */
+export const resolveAccountProvider = (provider: string): string =>
+  normalizeSsoProvider(provider) ?? provider;


### PR DESCRIPTION
## What does this PR do?

This PR fixes Microsoft SSO login by normalizing NextAuth’s Microsoft provider id (`azure-ad`) to the canonical Formbricks account provider (`azuread`) at the Prisma adapter boundary.

Previously, the custom SSO callback could sync the canonical `azuread` account row, but NextAuth’s later internal account lookup still queried with `azure-ad`. That missed the stored account and caused the flow to fall through to `OAuthAccountNotLinked`.

The adapter wrapper now normalizes provider keys consistently for account lookup, linking, and unlinking, while keeping unknown providers unchanged. It also adds regression coverage for the full NextAuth OAuth callback-handler path.

Fixes [ENG-1082](https://linear.app/formbricks/issue/ENG-1082/microsoft-sso-login-cannot-be-linked)

## How should this be tested?

- Run `pnpm exec eslint modules/auth/lib/adapter.test.ts` from `apps/web`
- Run `pnpm exec dotenv -e ../../.env -- vitest run modules/auth/lib/adapter.test.ts modules/auth/lib/authOptions.test.ts modules/ee/sso/lib/provider-normalization.test.ts modules/ee/sso/lib/tests/sso-handlers.test.ts` from `apps/web`
- Manually verify that an existing Microsoft SSO user can log in with “Continue with Microsoft”

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary