### PR TITLE
fix: restore Microsoft SSO account lookup (backport to release/5.0)

### DIFF
--- a/apps/web/modules/auth/lib/adapter.ts
+++ b/apps/web/modules/auth/lib/adapter.ts
@@ -1,0 +1,61 @@
+import { PrismaAdapter } from "@next-auth/prisma-adapter";
+import type { PrismaClient } from "@prisma/client";
+import type { Awaitable } from "next-auth";
+import type { Adapter, AdapterAccount } from "next-auth/adapters";
+import { logger } from "@formbricks/logger";
+import { resolveAccountProvider } from "@/modules/ee/sso/lib/provider-normalization";
+
+type TProviderAccountKey = Pick<AdapterAccount, "provider" | "providerAccountId">;
+
+const normalizeProviderKey = <T extends { provider: string }>(value: T): T => ({
+  ...value,
+  provider: resolveAccountProvider(value.provider),
+});
+
+/**
+ * Wraps an adapter method so any failure is logged with context before being re-thrown.
+ * NextAuth turns the re-thrown error into the relevant auth error page, so we keep the
+ * original behaviour while making adapter-level failures observable.
+ */
+const withAdapterErrorLogging =
+  <TArgs extends unknown[], TResult>(method: string, handler: (...args: TArgs) => Awaitable<TResult>) =>
+  async (...args: TArgs): Promise<TResult> => {
+    try {
+      return await handler(...args);
+    } catch (error) {
+      logger.error(error, `NextAuth Prisma adapter "${method}" failed`);
+      throw error;
+    }
+  };
+
+/**
+ * NextAuth resolves accounts by each provider's NextAuth `id` — Microsoft's is "azure-ad" — but
+ * Formbricks persists the canonical `IdentityProvider` value ("azuread") in `Account.provider`.
+ * Left unreconciled, the adapter's native lookup misses the stored row, falls back to matching by
+ * email, and rejects the sign-in with `OAuthAccountNotLinked`.
+ *
+ * Normalizing the provider at the adapter boundary keeps the native lookup/link/unlink aligned with
+ * both the stored rows and the custom SSO sign-in handler for every provider, without leaking
+ * provider-specific naming into the call sites.
+ */
+export const getNextAuthAdapter = (prismaClient: PrismaClient): Adapter => {
+  const baseAdapter = PrismaAdapter(prismaClient);
+  const { getUserByAccount, linkAccount, unlinkAccount } = baseAdapter;
+
+  if (!getUserByAccount || !linkAccount || !unlinkAccount) {
+    throw new Error("PrismaAdapter is missing the account methods required for SSO sign-in");
+  }
+
+  return {
+    ...baseAdapter,
+    getUserByAccount: withAdapterErrorLogging("getUserByAccount", (providerAccount: TProviderAccountKey) =>
+      getUserByAccount(normalizeProviderKey(providerAccount))
+    ),
+    linkAccount: withAdapterErrorLogging("linkAccount", (account: AdapterAccount) =>
+      linkAccount(normalizeProviderKey(account))
+    ),
+    unlinkAccount: withAdapterErrorLogging("unlinkAccount", (providerAccount: TProviderAccountKey) =>
+      unlinkAccount(normalizeProviderKey(providerAccount))
+    ),
+  };
+};

--- a/apps/web/modules/auth/lib/authOptions.ts
+++ b/apps/web/modules/auth/lib/authOptions.ts
@@ -1,4 +1,3 @@
-import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import type { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { cookies } from "next/headers";
@@ -37,6 +36,7 @@ import {
 import { UNKNOWN_DATA } from "@/modules/ee/audit-logs/types/audit-log";
 import { getSSOProviders } from "@/modules/ee/sso/lib/providers";
 import { handleSsoCallback } from "@/modules/ee/sso/lib/sso-handlers";
+import { getNextAuthAdapter } from "./adapter";
 import { createBrevoCustomer } from "./brevo";
 
 type TSignInCallbackParams = Parameters<NonNullable<NonNullable<NextAuthOptions["callbacks"]>["signIn"]>>[0];
@@ -137,7 +137,7 @@ const handleEnterpriseSsoSignIn = async ({
 };
 
 export const authOptions: NextAuthOptions = {
-  adapter: PrismaAdapter(prisma),
+  adapter: getNextAuthAdapter(prisma),
   providers: [
     CredentialsProvider({
       id: "credentials",

--- a/apps/web/modules/ee/sso/lib/provider-normalization.test.ts
+++ b/apps/web/modules/ee/sso/lib/provider-normalization.test.ts
@@ -3,6 +3,7 @@ import {
   getLegacySsoProviderAliases,
   getSsoProviderLookupCandidates,
   normalizeSsoProvider,
+  resolveAccountProvider,
 } from "./provider-normalization";
 
 describe("SSO provider normalization", () => {
@@ -24,5 +25,14 @@ describe("SSO provider normalization", () => {
   test("includes canonical and legacy provider ids when searching for linked accounts", () => {
     expect(getSsoProviderLookupCandidates("azuread")).toEqual(["azuread", "azure-ad"]);
     expect(getSsoProviderLookupCandidates("google")).toEqual(["google"]);
+  });
+
+  test("resolves NextAuth provider ids to the canonical Account.provider string", () => {
+    expect(resolveAccountProvider("azure-ad")).toBe("azuread");
+    expect(resolveAccountProvider("google")).toBe("google");
+  });
+
+  test("passes unknown providers through unchanged", () => {
+    expect(resolveAccountProvider("credentials")).toBe("credentials");
   });
 });

--- a/apps/web/modules/ee/sso/lib/provider-normalization.ts
+++ b/apps/web/modules/ee/sso/lib/provider-normalization.ts
@@ -37,3 +37,11 @@ export const getSsoProviderLookupCandidates = (provider: string): string[] => {
 
   return [normalizedProvider, ...getLegacySsoProviderAliases(normalizedProvider)];
 };
+
+/**
+ * Resolves a NextAuth provider id (e.g. "azure-ad") to the canonical provider string persisted
+ * in `Account.provider` (e.g. "azuread"). Unknown providers are returned unchanged so callers
+ * never drop a value they were handed.
+ */
+export const resolveAccountProvider = (provider: string): string =>
+  normalizeSsoProvider(provider) ?? provider;


### PR DESCRIPTION
Backports #8168 to `release/5.0`.

## Summary

NextAuth resolves accounts by its provider id (`azure-ad`), but Formbricks persists `Account.provider = 'azuread'` (the canonical `IdentityProvider` value). Once sessions moved to database-backed storage in 4.9.0, NextAuth's post-callback adapter lookup started missing the stored row and falling through to `OAuthAccountNotLinked`, breaking Microsoft SSO.

This wraps `PrismaAdapter` so `getUserByAccount` / `linkAccount` / `unlinkAccount` normalize the provider field to canonical before delegating; other providers pass through unchanged.

## Scope of this backport

- ✅ `apps/web/modules/auth/lib/adapter.ts` — the fix
- ✅ `apps/web/modules/auth/lib/authOptions.ts` — wires the wrapped adapter
- ✅ `apps/web/modules/ee/sso/lib/provider-normalization.ts` — new `resolveAccountProvider` helper
- ✅ `apps/web/modules/ee/sso/lib/provider-normalization.test.ts` — test additions for `resolveAccountProvider`
- ❌ `apps/web/modules/auth/lib/adapter.test.ts` — intentionally omitted (new dedicated test file is not part of the backport scope)

## Test plan

- [x] `pnpm exec vitest run modules/ee/sso/lib/provider-normalization.test.ts` — 5/5 pass
- [x] Type check clean
- [ ] Manually verify an existing Microsoft SSO user can log in on a 5.0 instance with "Continue with Microsoft"

🤖 Generated with [Claude Code](https://claude.com/claude-code)