### PR TITLE
fix: keep "Feedback Records" highlighted on Topics & Subtopics tab (ENG-1030)

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
@@ -173,7 +173,7 @@ export const MainNavigation = ({
             name: t("workspace.unify.feedback_records"),
             href: `/workspaces/${workspace.id}/unify/feedback-records`,
             icon: MessageSquareTextIcon,
-            isActive: pathname?.includes("/unify/feedback-records"),
+            isActive: pathname?.includes("/unify/"),
             isHidden: false,
             disabled: isMembershipPending || isBilling,
           },


### PR DESCRIPTION
## What does this PR do?

Fixes [ENG-1030](https://linear.app/formbricks/issue/ENG-1030).

The main-nav `isActive` predicate for "Feedback Records" only matched the exact path `/unify/feedback-records`, so navigating to the Topics & Subtopics sub-tab (`/unify/topics-subtopics`) removed the active highlight. Broaden the match to `/unify/` so every sub-view of that section keeps the parent nav item highlighted.

## Change

`apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx:176`

```diff
- isActive: pathname?.includes("/unify/feedback-records"),
+ isActive: pathname?.includes("/unify/"),
```

Every route under `/workspaces/[workspaceId]/unify/*` belongs to the Feedback Records section:
- `/unify/feedback-records` — the default sub-view
- `/unify/topics-subtopics` — Topics & Subtopics tab (the one that was breaking)
- `/unify` and `/unify/sources` — both immediately redirect (to `/unify/feedback-records` and `/settings/workspace/feedback-sources` respectively), so they never render with the nav highlighted in any case

## How should this be tested?

- Open a workspace, click "Feedback Records" in the left nav → highlight appears ✓
- Switch to the "Topics & Subtopics" sub-tab → "Feedback Records" stays highlighted in the left nav ✓
- Click "Dashboards" or "Surveys" → "Feedback Records" loses the highlight ✓