### PR TITLE
ci: auto-create Linear issues from Dependabot alerts

### DIFF
--- a/.github/workflows/dependabot-to-linear.yml
+++ b/.github/workflows/dependabot-to-linear.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: dependabot-to-linear-sync
+  cancel-in-progress: false
+
 jobs:
   sync:
     name: Sync Dependabot alerts to Linear
@@ -21,6 +25,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -31,4 +37,7 @@ jobs:
         env:
           DEPENDABOT_ALERTS_TOKEN: ${{ secrets.DEPENDABOT_ALERTS_TOKEN }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          # Fallback used by the script if LINEAR_API_KEY is not set; must be
+          # listed here because the job only sees secrets exposed via env.
+          LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
         run: node scripts/dependabot-to-linear.mjs

--- a/.github/workflows/dependabot-to-linear.yml
+++ b/.github/workflows/dependabot-to-linear.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Sync alerts to Linear
         env:

--- a/.github/workflows/dependabot-to-linear.yml
+++ b/.github/workflows/dependabot-to-linear.yml
@@ -1,0 +1,34 @@
+name: Dependabot Alerts to Linear
+
+on:
+  schedule:
+    - cron: "0 11 * * *" # 11:00 UTC = 12:00 CET (noon); +1h during CEST
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    name: Sync Dependabot alerts to Linear
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+
+      - name: Sync alerts to Linear
+        env:
+          DEPENDABOT_ALERTS_TOKEN: ${{ secrets.DEPENDABOT_ALERTS_TOKEN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+        run: node scripts/dependabot-to-linear.mjs

--- a/scripts/dependabot-to-linear.mjs
+++ b/scripts/dependabot-to-linear.mjs
@@ -21,6 +21,10 @@ const DRY_RUN = process.argv.includes("--dry-run");
 const LINEAR_TEAM_ID = "272e6dd2-fcab-4270-be37-1626dce35d2c"; // Engineering
 const LINEAR_TODO_STATE_ID = "c32c8340-e8f8-48f4-a863-afabe3b19e17"; // Todo
 const LINEAR_SECURITY_LABEL_ID = "f9c50a45-3bd9-45e7-a70a-5b88aba910f9"; // security
+// The Engineering team uses T-shirt estimation, where the estimate is a plain
+// integer the UI renders as a size: 1=XS, 2=S, 3=M, 5=L. We default every
+// Dependabot issue to "S".
+const LINEAR_ESTIMATE_S = 2;
 
 // Dependabot severity -> Linear priority (0 none, 1 urgent, 2 high, 3 medium, 4 low)
 const PRIORITY_BY_SEVERITY = {
@@ -114,6 +118,7 @@ async function createIssue(apiKey, { title, description, priority }) {
         teamId: LINEAR_TEAM_ID,
         stateId: LINEAR_TODO_STATE_ID,
         labelIds: [LINEAR_SECURITY_LABEL_ID],
+        estimate: LINEAR_ESTIMATE_S,
         title,
         description,
         priority,

--- a/scripts/dependabot-to-linear.mjs
+++ b/scripts/dependabot-to-linear.mjs
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// Syncs open GitHub Dependabot alerts into Linear issues.
+// Runs daily in CI (.github/workflows/dependabot-to-linear.yml).
+//
+// For each open Dependabot alert it creates one Linear issue (if not already
+// present), on the Engineering team, in the Todo state, with the `security`
+// label and a priority mapped from the alert severity. It is idempotent:
+// issues are matched by a stable `[Dependabot #<number>]` title prefix, so
+// re-running never creates duplicates.
+//
+// Env:
+//   GITHUB_REPOSITORY      "owner/repo" (provided automatically in Actions)
+//   DEPENDABOT_ALERTS_TOKEN  token with "Dependabot alerts: read" (the default
+//                            GITHUB_TOKEN cannot read this API)
+//   LINEAR_API_KEY | LINEAR_ACCESS_KEY  Linear key with issue-create access
+// Flags:
+//   --dry-run  log what would be created without writing to Linear
+
+const DRY_RUN = process.argv.includes("--dry-run");
+
+const LINEAR_TEAM_ID = "272e6dd2-fcab-4270-be37-1626dce35d2c"; // Engineering
+const LINEAR_TODO_STATE_ID = "c32c8340-e8f8-48f4-a863-afabe3b19e17"; // Todo
+const LINEAR_SECURITY_LABEL_ID = "f9c50a45-3bd9-45e7-a70a-5b88aba910f9"; // security
+
+// Dependabot severity -> Linear priority (0 none, 1 urgent, 2 high, 3 medium, 4 low)
+const PRIORITY_BY_SEVERITY = {
+  critical: 1,
+  high: 2,
+  medium: 3,
+  low: 4,
+};
+
+const LINEAR_API_URL = "https://api.linear.app/graphql";
+
+function requireEnv(name, ...fallbacks) {
+  for (const key of [name, ...fallbacks]) {
+    if (process.env[key]) return process.env[key];
+  }
+  throw new Error(`Missing required env var: ${[name, ...fallbacks].join(" or ")}`);
+}
+
+async function fetchOpenAlerts(repo, token) {
+  const alerts = [];
+  let page = 1;
+  const perPage = 100;
+  for (;;) {
+    const url = `https://api.github.com/repos/${repo}/dependabot/alerts?state=open&per_page=${perPage}&page=${page}`;
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "formbricks-dependabot-to-linear",
+      },
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`GitHub API ${res.status} fetching Dependabot alerts: ${body.slice(0, 500)}`);
+    }
+    const batch = await res.json();
+    alerts.push(...batch);
+    if (batch.length < perPage) break;
+    page += 1;
+  }
+  return alerts;
+}
+
+async function linearRequest(apiKey, query, variables) {
+  const res = await fetch(LINEAR_API_URL, {
+    method: "POST",
+    headers: {
+      Authorization: apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json();
+  if (!res.ok || json.errors) {
+    throw new Error(`Linear API error: ${JSON.stringify(json.errors ?? json).slice(0, 500)}`);
+  }
+  return json.data;
+}
+
+async function issueExists(apiKey, titlePrefix) {
+  const data = await linearRequest(
+    apiKey,
+    `query ExistingIssue($teamId: ID!, $prefix: String!) {
+      issues(filter: { team: { id: { eq: $teamId } }, title: { startsWith: $prefix } }, first: 1) {
+        nodes { id }
+      }
+    }`,
+    { teamId: LINEAR_TEAM_ID, prefix: titlePrefix }
+  );
+  return data.issues.nodes.length > 0;
+}
+
+async function createIssue(apiKey, { title, description, priority }) {
+  const data = await linearRequest(
+    apiKey,
+    `mutation CreateIssue($input: IssueCreateInput!) {
+      issueCreate(input: $input) {
+        success
+        issue { identifier url }
+      }
+    }`,
+    {
+      input: {
+        teamId: LINEAR_TEAM_ID,
+        stateId: LINEAR_TODO_STATE_ID,
+        labelIds: [LINEAR_SECURITY_LABEL_ID],
+        title,
+        description,
+        priority,
+      },
+    }
+  );
+  if (!data.issueCreate.success) {
+    throw new Error(`Linear issueCreate returned success=false for: ${title}`);
+  }
+  return data.issueCreate.issue;
+}
+
+function buildIssue(alert) {
+  const number = alert.number;
+  const severity = alert.security_vulnerability?.severity ?? "medium";
+  const priority = PRIORITY_BY_SEVERITY[severity] ?? 3;
+  const pkg = alert.dependency?.package?.name ?? "unknown package";
+  const ecosystem = alert.dependency?.package?.ecosystem ?? "";
+  const advisory = alert.security_advisory ?? {};
+  const vuln = alert.security_vulnerability ?? {};
+  const summary = advisory.summary ?? "Security vulnerability";
+  const ghsa = advisory.ghsa_id ?? "";
+  const cve = advisory.cve_id ?? "";
+  const patched = vuln.first_patched_version?.identifier ?? "no patched version yet";
+  const range = vuln.vulnerable_version_range ?? "unknown";
+
+  const titlePrefix = `[Dependabot #${number}]`;
+  const title = `${titlePrefix} ${pkg} — ${summary}`;
+
+  const description = [
+    `**Dependabot alert [#${number}](${alert.html_url})**`,
+    "",
+    `- **Package:** \`${pkg}\`${ecosystem ? ` (${ecosystem})` : ""}`,
+    `- **Severity:** ${severity}`,
+    ghsa ? `- **Advisory:** ${ghsa}` : null,
+    cve ? `- **CVE:** ${cve}` : null,
+    `- **Affected versions:** ${range}`,
+    `- **Patched version:** ${patched}`,
+    "",
+    advisory.description ? advisory.description : null,
+  ]
+    .filter((line) => line !== null)
+    .join("\n");
+
+  return { titlePrefix, title, description, priority };
+}
+
+async function main() {
+  const repo = requireEnv("GITHUB_REPOSITORY");
+  const ghToken = requireEnv("DEPENDABOT_ALERTS_TOKEN");
+  const linearKey = requireEnv("LINEAR_API_KEY", "LINEAR_ACCESS_KEY");
+
+  console.log(`Fetching open Dependabot alerts for ${repo}${DRY_RUN ? " (dry run)" : ""}…`);
+  const alerts = await fetchOpenAlerts(repo, ghToken);
+  console.log(`Found ${alerts.length} open alert(s).`);
+
+  let created = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const alert of alerts) {
+    const issue = buildIssue(alert);
+    try {
+      if (await issueExists(linearKey, issue.titlePrefix)) {
+        skipped += 1;
+        console.log(`skip   ${issue.titlePrefix} (already in Linear)`);
+        continue;
+      }
+      if (DRY_RUN) {
+        created += 1;
+        console.log(`would  ${issue.title} [priority ${issue.priority}]`);
+        continue;
+      }
+      const result = await createIssue(linearKey, issue);
+      created += 1;
+      console.log(`create ${result.identifier} ${result.url}`);
+    } catch (err) {
+      failed += 1;
+      console.error(`error  ${issue.titlePrefix}: ${err.message}`);
+    }
+  }
+
+  console.log(`Done. created=${created} skipped=${skipped} failed=${failed}${DRY_RUN ? " (dry run)" : ""}`);
+  if (failed > 0) process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err.message ?? err);
+  process.exit(1);
+});

--- a/scripts/dependabot-to-linear.mjs
+++ b/scripts/dependabot-to-linear.mjs
@@ -32,6 +32,10 @@ const PRIORITY_BY_SEVERITY = {
 
 const LINEAR_API_URL = "https://api.linear.app/graphql";
 
+// Abort any outbound request that hangs, so a stuck connection can't tie up the
+// runner until the workflow-level timeout.
+const FETCH_TIMEOUT_MS = 30000;
+
 function requireEnv(name, ...fallbacks) {
   for (const key of [name, ...fallbacks]) {
     if (process.env[key]) return process.env[key];
@@ -46,6 +50,7 @@ async function fetchOpenAlerts(repo, token) {
   for (;;) {
     const url = `https://api.github.com/repos/${repo}/dependabot/alerts?state=open&per_page=${perPage}&page=${page}`;
     const res = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: "application/vnd.github+json",
@@ -68,6 +73,7 @@ async function fetchOpenAlerts(repo, token) {
 async function linearRequest(apiKey, query, variables) {
   const res = await fetch(LINEAR_API_URL, {
     method: "POST",
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     headers: {
       Authorization: apiKey,
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
Automates triaging GitHub Dependabot security alerts into Linear, replacing the current manual process.

- Adds **`scripts/dependabot-to-linear.mjs`** — a zero-dependency Node script (Node 24 native `fetch`) that fetches open Dependabot alerts (paginated), dedupes against existing Linear issues via a stable `[Dependabot #<number>]` title prefix, and creates any missing ones on the **Engineering** team in the **Todo** state, with the **`security`** label and a severity-mapped priority (`critical→Urgent`, `high→High`, `medium→Medium`, `low→Low`). Supports `--dry-run`; idempotent on re-run.
- Adds **`.github/workflows/dependabot-to-linear.yml`** — runs daily at `0 11 * * *` (noon CET) plus manual `workflow_dispatch`, mirroring the pinned-action conventions from `linear-release.yml`.

## Why
GitHub Actions cannot trigger on `dependabot_alert` (not a supported `on:` event) and Linear has no native Dependabot integration, so a scheduled poll-and-reconcile is the simplest approach with no extra infra.

## Required setup before this works (repo admin)
1. **`DEPENDABOT_ALERTS_TOKEN`** secret — fine-grained PAT with **"Dependabot alerts: read"**. The default `GITHUB_TOKEN` returns 403 on this API, so a separate token is mandatory.
2. **`LINEAR_API_KEY`** secret — Linear personal API key with issue-create access. (Kept separate from the existing `LINEAR_ACCESS_KEY`, which is the release-action OAuth token; the script falls back to `LINEAR_ACCESS_KEY` if it has issue-create scope.)

> Note: GitHub Actions cron is UTC, so during CEST (summer) the run lands at 13:00 local instead of noon — acceptable for a daily security poll.

## Test plan
- [ ] Set the two secrets, then trigger via **workflow_dispatch** and confirm the Dependabot API call succeeds (no 403)
- [ ] Optionally append `--dry-run` to the run step first to preview what would be created without writing to Linear
- [ ] Confirm new issues land on Engineering / Todo with the `security` label and correct priority, linking back to the alert
- [ ] Re-run and confirm everything is skipped (idempotency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)