### PR TITLE
fix: fixes ces rating question's email embed UI (backport to release/5.0)

### DIFF
--- a/apps/web/modules/analysis/components/RatingSmiley/index.tsx
+++ b/apps/web/modules/analysis/components/RatingSmiley/index.tsx
@@ -6,6 +6,7 @@ interface RatingSmileyProps {
   range: number;
   addColors?: boolean;
   baseUrl?: string;
+  size?: number;
 }
 
 const getSmileyColor = (range: number, idx: number) => {
@@ -31,7 +32,8 @@ const getSmiley = (
   range: number,
   active: boolean,
   addColors: boolean,
-  baseUrl?: string
+  baseUrl?: string,
+  size: number = 24
 ): JSX.Element => {
   const activeColor = "bg-rating-fill";
   const inactiveColor = addColors ? getSmileyColor(range, idx) : "bg-fill-none";
@@ -49,6 +51,8 @@ const getSmiley = (
     "grinning-squinting",
   ];
 
+  const containerSize = size * 2;
+
   const icon = (
     <img
       data-testid={faceIcons[iconIdx]}
@@ -58,14 +62,14 @@ const getSmiley = (
           : `/smiley-icons/${faceIcons[iconIdx]}-face.png`
       }
       alt={faceIcons[iconIdx]}
-      width={24}
-      height={24}
+      width={size}
+      height={size}
       className={`${active ? activeColor : inactiveColor} rounded-full`}
     />
   );
 
   return (
-    <table style={{ width: "48px", height: "48px" }}>
+    <table style={{ width: `${containerSize}px`, height: `${containerSize}px` }}>
       {" "}
       {/* NOSONAR S5256 - Need table layout for email compatibility (gmail) */}
       <tr>
@@ -83,6 +87,7 @@ export const RatingSmiley = ({
   range,
   addColors = false,
   baseUrl,
+  size,
 }: RatingSmileyProps): JSX.Element => {
   let iconsIdx: number[] = [];
   if (range === 10) iconsIdx = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -92,5 +97,5 @@ export const RatingSmiley = ({
   else if (range === 4) iconsIdx = [4, 5, 6, 7];
   else if (range === 3) iconsIdx = [4, 5, 7];
 
-  return getSmiley(iconsIdx[idx], idx, range, active, addColors, baseUrl);
+  return getSmiley(iconsIdx[idx], idx, range, active, addColors, baseUrl, size);
 };

--- a/apps/web/modules/analysis/components/RatingSmiley/index.tsx
+++ b/apps/web/modules/analysis/components/RatingSmiley/index.tsx
@@ -69,7 +69,13 @@ const getSmiley = (
   );
 
   return (
-    <table style={{ width: `${containerSize}px`, height: `${containerSize}px` }}>
+    <table
+      style={{
+        width: `${containerSize}px`,
+        height: `${containerSize}px`,
+        marginLeft: "auto",
+        marginRight: "auto",
+      }}>
       {" "}
       {/* NOSONAR S5256 - Need table layout for email compatibility (gmail) */}
       <tr>

--- a/apps/web/modules/email/components/preview-email-template.tsx
+++ b/apps/web/modules/email/components/preview-email-template.tsx
@@ -435,6 +435,7 @@ export async function PreviewEmailTemplate({
               <PreviewScaleLabels
                 defaultLanguageCode={defaultLanguageCode}
                 lowerLabel={firstQuestion.lowerLabel}
+                optionCount={npsOptionCount}
                 styleTokens={styleTokens}
                 upperLabel={firstQuestion.upperLabel}
               />
@@ -518,6 +519,7 @@ export async function PreviewEmailTemplate({
               <PreviewScaleLabels
                 defaultLanguageCode={defaultLanguageCode}
                 lowerLabel={firstQuestion.lowerLabel}
+                optionCount={firstQuestion.range}
                 styleTokens={styleTokens}
                 upperLabel={firstQuestion.upperLabel}
               />
@@ -915,32 +917,35 @@ function PreviewScaleOptionColumn({
 function PreviewScaleLabels({
   defaultLanguageCode,
   lowerLabel,
+  optionCount,
   styleTokens,
   upperLabel,
 }: Readonly<{
   defaultLanguageCode: string;
   lowerLabel: Parameters<typeof getLocalizedValue>[0];
+  optionCount: number;
   styleTokens: PreviewEmailStyleTokens;
   upperLabel: Parameters<typeof getLocalizedValue>[0];
 }>): React.JSX.Element {
+  const columnStyle = getScaleColumnStyle(optionCount);
+  const labelTextStyle = { ...getHelperLabelTextStyle(styleTokens), textAlign: "center" as const };
+
   return (
     <Section className="mt-2 w-full">
       <Row>
-        <Column>
-          <Text className="m-0 text-xs leading-[18px]" style={getHelperLabelTextStyle(styleTokens)}>
-            {getLocalizedValue(lowerLabel, defaultLanguageCode)}
-          </Text>
-        </Column>
-        <Column style={{ textAlign: "right" }}>
-          <Text
-            className="m-0 text-xs leading-[18px]"
-            style={{
-              ...getHelperLabelTextStyle(styleTokens),
-              textAlign: "right",
-            }}>
-            {getLocalizedValue(upperLabel, defaultLanguageCode)}
-          </Text>
-        </Column>
+        {Array.from({ length: optionCount }, (_, i) => {
+          const isFirst = i === 0;
+          const isLast = i === optionCount - 1;
+          return (
+            <Column key={i} style={{ ...columnStyle, textAlign: "center" }}>
+              {isFirst || isLast ? (
+                <Text className="m-0 text-xs leading-[18px]" style={labelTextStyle}>
+                  {getLocalizedValue(isFirst ? lowerLabel : upperLabel, defaultLanguageCode)}
+                </Text>
+              ) : null}
+            </Column>
+          );
+        })}
       </Row>
     </Section>
   );

--- a/apps/web/modules/email/components/preview-email-template.tsx
+++ b/apps/web/modules/email/components/preview-email-template.tsx
@@ -66,6 +66,8 @@ import {
 } from "../lib/preview-email-template-styles";
 import { getNPSOptionColor, getRatingNumberOptionColor } from "../lib/utils";
 
+const EMAIL_RATING_SMILEY_SIZE = 40;
+
 interface PreviewEmailTemplateProps {
   survey: TSurvey;
   surveyUrl: string;
@@ -108,7 +110,7 @@ const getRatingContent = (scale: string, i: number, range: number, isColorCoding
         range={range}
         addColors={isColorCodingEnabled}
         baseUrl={WEBAPP_URL}
-        size={40}
+        size={EMAIL_RATING_SMILEY_SIZE}
       />
     );
   }

--- a/apps/web/modules/email/components/preview-email-template.tsx
+++ b/apps/web/modules/email/components/preview-email-template.tsx
@@ -108,6 +108,7 @@ const getRatingContent = (scale: string, i: number, range: number, isColorCoding
         range={range}
         addColors={isColorCodingEnabled}
         baseUrl={WEBAPP_URL}
+        size={40}
       />
     );
   }
@@ -500,7 +501,7 @@ export async function PreviewEmailTemplate({
                             : undefined,
                         height: ratingOptionHeight,
                         isConnected: isNumberRating,
-                        isTransparent: firstQuestion.scale === "star",
+                        isTransparent: firstQuestion.scale === "star" || firstQuestion.scale === "smiley",
                         optionCount: firstQuestion.range,
                         optionIndex: i,
                       })}>


### PR DESCRIPTION
Backports #8180 to \`release/5.0\`.

## Summary

Two UI fixes for the email-preview rendering of rating-style questions:

1. \`RatingSmiley\` accepts a new optional \`size\` prop so it can be rendered larger in email embeds (40px image / 80px container) instead of the hard-coded 24/48. Default is preserved for all other callers.
2. \`PreviewScaleLabels\` now lays out one column per option, with the lower/upper labels only in the first/last column — so they align under their respective rating buttons.
3. \`isTransparent\` for the smiley scale's option button is now true (matching the star scale).

Fixes [ENG-984](https://linear.app/formbricks/issue/ENG-984/).

## Test plan

- [x] All three upstream commits cherry-pick cleanly onto \`release/5.0\` with no conflicts.
- [ ] Manually verify in Gmail web + Outlook desktop that the email preview for CES / CSAT / NPS / Rating questions:
  - shows the smiley icons at the new larger size, centered.
  - shows lowerLabel under the first option and upperLabel under the last option (not the old left/right two-column layout).
  - does not have weird column-collapse artifacts from the empty spacer columns.

## Commits

- \`dd102593e\` — fixes ces rating email embed UI
- \`642b48671\` — fixes
- \`d6ba03a88\` — fixes feedback