### PR TITLE
fix: use cursor pagination for Dependabot alerts + dry-run dispatch

### DIFF
--- a/.github/workflows/dependabot-to-linear.yml
+++ b/.github/workflows/dependabot-to-linear.yml
@@ -3,7 +3,12 @@ name: Dependabot Alerts to Linear
 on:
   schedule:
     - cron: "0 11 * * *" # 11:00 UTC = 12:00 CET (noon); +1h during CEST
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Log what would be created without writing to Linear"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -40,4 +45,4 @@ jobs:
           # Fallback used by the script if LINEAR_API_KEY is not set; must be
           # listed here because the job only sees secrets exposed via env.
           LINEAR_ACCESS_KEY: ${{ secrets.LINEAR_ACCESS_KEY }}
-        run: node scripts/dependabot-to-linear.mjs
+        run: node scripts/dependabot-to-linear.mjs ${{ inputs.dry_run && '--dry-run' || '' }}

--- a/scripts/dependabot-to-linear.mjs
+++ b/scripts/dependabot-to-linear.mjs
@@ -47,12 +47,22 @@ function requireEnv(name, ...fallbacks) {
   throw new Error(`Missing required env var: ${[name, ...fallbacks].join(" or ")}`);
 }
 
+// The Dependabot alerts endpoint uses cursor pagination (`before`/`after`),
+// not `?page=`. The next-page cursor is returned in the response `Link` header
+// as `<url>; rel="next"`. Walk that until there's no next link.
+function parseNextLink(linkHeader) {
+  if (!linkHeader) return null;
+  for (const part of linkHeader.split(",")) {
+    const match = part.match(/<([^>]+)>\s*;\s*rel="next"/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
 async function fetchOpenAlerts(repo, token) {
   const alerts = [];
-  let page = 1;
-  const perPage = 100;
-  for (;;) {
-    const url = `https://api.github.com/repos/${repo}/dependabot/alerts?state=open&per_page=${perPage}&page=${page}`;
+  let url = `https://api.github.com/repos/${repo}/dependabot/alerts?state=open&per_page=100`;
+  while (url) {
     const res = await fetch(url, {
       signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
       headers: {
@@ -68,8 +78,7 @@ async function fetchOpenAlerts(repo, token) {
     }
     const batch = await res.json();
     alerts.push(...batch);
-    if (batch.length < perPage) break;
-    page += 1;
+    url = parseNextLink(res.headers.get("link"));
   }
   return alerts;
 }

--- a/scripts/dependabot-to-linear.mjs
+++ b/scripts/dependabot-to-linear.mjs
@@ -12,7 +12,10 @@
 //   GITHUB_REPOSITORY      "owner/repo" (provided automatically in Actions)
 //   DEPENDABOT_ALERTS_TOKEN  token with "Dependabot alerts: read" (the default
 //                            GITHUB_TOKEN cannot read this API)
-//   LINEAR_API_KEY | LINEAR_ACCESS_KEY  Linear key with issue-create access
+//   LINEAR_API_KEY | LINEAR_ACCESS_KEY  Linear personal API key with BOTH
+//                            `read` (to dedupe against existing issues) and
+//                            `write` / `issues:create` (to create new ones).
+//                            Generated at Settings → API → Personal API keys.
 // Flags:
 //   --dry-run  log what would be created without writing to Linear
 


### PR DESCRIPTION
## Summary
Fixes the daily Dependabot→Linear sync workflow, which was failing with HTTP 400:

> `Pagination using the page parameter is not supported.`

The fix was verified locally by Matti to make sure it works this time ;-) 

The GitHub Dependabot alerts endpoint only supports **cursor pagination** via the `Link` header, not `?page=`. The script now follows the `Link: <url>; rel="next"` cursor until exhausted, matching what the endpoint actually returns.

Also adds a `dry_run` boolean input to `workflow_dispatch` so you can manually trigger the workflow on any branch (or main) to preview what would be created without writing to Linear.

## How to test
**Locally** (no PR needed) — works with any token that has Dependabot alerts read on the repo:

```bash
GITHUB_REPOSITORY=formbricks/formbricks \
DEPENDABOT_ALERTS_TOKEN=<fine-grained PAT> \
LINEAR_API_KEY=<Linear personal API key> \
node scripts/dependabot-to-linear.mjs --dry-run
```

Expected: lists current open alerts (no 400), prints `would [Dependabot #N] <pkg> — <summary> [priority X]` for any not already in Linear.

**On this branch via the Actions UI**:
1. Go to Actions → "Dependabot Alerts to Linear" → Run workflow
2. Pick the `claude/fix-dependabot-pagination` branch
3. Toggle "Log what would be created without writing to Linear" on for a safe preview, or off for a real run

Or from the CLI:
```bash
gh workflow run dependabot-to-linear.yml --ref claude/fix-dependabot-pagination -f dry_run=true
```

## Test plan
- [ ] Trigger workflow_dispatch on this branch with `dry_run=true`; confirm it lists alerts without 400 and writes nothing to Linear
- [ ] Trigger again with `dry_run=false`; confirm new Linear issues appear with the security label, Todo state, S estimate, mapped priority
- [ ] Re-run; confirm everything is skipped (idempotency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)