### PR TITLE
style: align main and settings nav icon styling

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
@@ -456,6 +456,7 @@ export const MainNavigation = ({
 
   const switcherIconClasses =
     "flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-100 text-slate-600";
+  const mainNavIconClassName = "h-4 w-4 shrink-0";
   const isInitialWorkspacesLoading =
     isWorkspaceDropdownOpen && !hasInitializedWorkspaces && !workspaceLoadError;
 
@@ -546,7 +547,7 @@ export const MainNavigation = ({
                               disabled={item.disabled}
                               disabledMessage={item.disabled ? disabledNavigationMessage : undefined}
                               linkText={item.name}>
-                              <item.icon strokeWidth={1.5} />
+                              <item.icon className={mainNavIconClassName} strokeWidth={1.5} />
                             </NavigationLink>
                           )
                       )}
@@ -566,7 +567,7 @@ export const MainNavigation = ({
                         settingsNavigationItem.disabled ? disabledNavigationMessage : undefined
                       }
                       linkText={settingsNavigationItem.name}>
-                      <settingsNavigationItem.icon strokeWidth={1.5} />
+                      <settingsNavigationItem.icon className={mainNavIconClassName} strokeWidth={1.5} />
                     </NavigationLink>
                   </ul>
                 </li>

--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/SettingsSidebarContent.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/SettingsSidebarContent.tsx
@@ -157,7 +157,6 @@ const SettingsNavLink = ({
 };
 
 const SectionHeader = ({
-  icon,
   label,
   isCollapsed,
   isTextVisible,
@@ -167,8 +166,7 @@ const SectionHeader = ({
   currentId,
   onSwitcherChange,
   onSwitcherOpen,
-}: {
-  icon: React.ReactNode;
+}: Readonly<{
   label: string;
   isCollapsed: boolean;
   isTextVisible: boolean;
@@ -178,18 +176,17 @@ const SectionHeader = ({
   currentId?: string;
   onSwitcherChange?: (id: string) => void;
   onSwitcherOpen?: () => void;
-}) => {
+}>) => {
   if (isCollapsed) {
-    return <div className="mb-1 mt-3 flex justify-center px-2 text-slate-400">{icon}</div>;
+    return null;
   }
 
   return (
     <div
       className={cn(
-        "mb-1 mt-4 flex min-w-0 items-center gap-2 px-3",
+        "mb-1 mt-4 flex min-w-0 items-center gap-2 px-4",
         isTextVisible ? "opacity-0" : "opacity-100"
       )}>
-      <span className="text-slate-500">{icon}</span>
       <span className="shrink-0 text-xs font-semibold uppercase tracking-wider text-slate-500">{label}</span>
       {switcherName && switcherItems && onSwitcherChange && (
         <DropdownMenu onOpenChange={(open) => open && onSwitcherOpen?.()}>
@@ -408,7 +405,6 @@ export const SettingsSidebarContent = ({
     <div className="flex flex-col overflow-y-auto">
       <div>
         <SectionHeader
-          icon={<FoldersIcon className="size-4" />}
           label={t("common.workspace")}
           isCollapsed={isCollapsed}
           isTextVisible={isTextVisible}
@@ -424,7 +420,6 @@ export const SettingsSidebarContent = ({
 
       <div>
         <SectionHeader
-          icon={<Building2Icon className="size-4" />}
           label={t("common.organization")}
           isCollapsed={isCollapsed}
           isTextVisible={isTextVisible}
@@ -439,12 +434,7 @@ export const SettingsSidebarContent = ({
       </div>
 
       <div>
-        <SectionHeader
-          icon={<UserCircleIcon className="size-4" />}
-          label={t("common.account")}
-          isCollapsed={isCollapsed}
-          isTextVisible={isTextVisible}
-        />
+        <SectionHeader label={t("common.account")} isCollapsed={isCollapsed} isTextVisible={isTextVisible} />
         {renderSection(accountItems)}
       </div>
     </div>


### PR DESCRIPTION
## What does this PR do?

Aligns the main navigation icon sizing with the settings navigation treatment. Main nav icons now render at the same inline `h-4 w-4` size as settings nav item icons, and settings section headings no longer render leading icons.

Fixes ENG-1003

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Open a workspace surveys page and confirm the main nav icons are visually the same height as their labels.
- Open Settings > Workspace > General and confirm settings nav item icons still use the inline/text-height style.
- Confirm settings section headings such as Workspace, Organization, and Account no longer show heading icons.
- Check that switching between the main nav and settings nav does not introduce layout shifts or clipped labels.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary

Before/After:

<table>
<tr>
<td>
<img width="235" height="436" alt="Screenshot 2026-05-28 at 17 55 55" src="https://github.com/user-attachments/assets/af30bde7-3e1e-4bf7-aa85-593aff22e108" />
</td>
<td>
<img width="234" height="418" alt="Screenshot 2026-05-28 at 17 55 45" src="https://github.com/user-attachments/assets/5985838b-20ab-4812-988e-50bc10771c7c" />
</td>
</tr>
</table>

<table>
<tr>
<td>
<img width="239" height="731" alt="Screenshot 2026-05-28 at 17 56 54" src="https://github.com/user-attachments/assets/ab2b15fd-b136-459f-bc6d-736ef87487b5" />

</td>
<td>
<img width="238" height="732" alt="Screenshot 2026-05-28 at 17 56 49" src="https://github.com/user-attachments/assets/d043ad8d-9b6c-40af-a851-3103e790d0d0" />

</td>
</tr>
</table>
