### PR TITLE
fix(regression): disable video uploads on welcome card logo uploader

### DIFF
--- a/apps/web/modules/survey/editor/components/edit-welcome-card.tsx
+++ b/apps/web/modules/survey/editor/components/edit-welcome-card.tsx
@@ -126,20 +126,14 @@ export const EditWelcomeCard = ({
                 id="welcome-card-image"
                 allowedFileExtensions={["png", "jpeg", "jpg", "webp", "heic"]}
                 workspaceId={workspaceId}
-                onFileUpload={(url: string[] | undefined, fileType: "image" | "video") => {
+                onFileUpload={(url: string[] | undefined) => {
                   if (url?.length && url[0]) {
-                    const update =
-                      fileType === "video"
-                        ? { videoUrl: url[0], fileUrl: undefined }
-                        : { fileUrl: url[0], videoUrl: undefined };
-                    updateSurvey(update);
+                    updateSurvey({ fileUrl: url[0], videoUrl: undefined });
                   } else {
                     updateSurvey({ fileUrl: undefined, videoUrl: undefined });
                   }
                 }}
                 fileUrl={localSurvey?.welcomeCard?.fileUrl}
-                videoUrl={localSurvey?.welcomeCard?.videoUrl}
-                isVideoAllowed={true}
                 maxSizeInMB={5}
                 isStorageConfigured={isStorageConfigured}
               />

--- a/apps/web/modules/ui/components/file-input/index.tsx
+++ b/apps/web/modules/ui/components/file-input/index.tsx
@@ -68,6 +68,10 @@ export const FileInput = ({
   const [videoUrlTemp, setVideoUrlTemp] = useState(videoUrl ?? "");
   const fileType = isVideoAllowed && activeTab === "video" ? "video" : "image";
 
+  useEffect(() => {
+    setActiveTab(isVideoAllowed && videoUrl ? "video" : "image");
+  }, [isVideoAllowed, videoUrl]);
+
   const handleUpload = async (files: File[]) => {
     if (!isStorageConfigured) {
       showStorageNotConfiguredToast();

--- a/apps/web/modules/ui/components/file-input/index.tsx
+++ b/apps/web/modules/ui/components/file-input/index.tsx
@@ -63,9 +63,10 @@ export const FileInput = ({
   ];
   const [selectedFiles, setSelectedFiles] = useState<SelectedFile[]>([]);
   const [uploadedVideoUrl, setUploadedVideoUrl] = useState(videoUrl ?? "");
-  const [activeTab, setActiveTab] = useState(videoUrl ? "video" : "image");
+  const [activeTab, setActiveTab] = useState(isVideoAllowed && videoUrl ? "video" : "image");
   const [imageUrlTemp, setImageUrlTemp] = useState(fileUrl ?? "");
   const [videoUrlTemp, setVideoUrlTemp] = useState(videoUrl ?? "");
+  const fileType = isVideoAllowed && activeTab === "video" ? "video" : "image";
 
   const handleUpload = async (files: File[]) => {
     if (!isStorageConfigured) {
@@ -115,7 +116,7 @@ export const FileInput = ({
       return;
     }
 
-    onFileUpload(uploadedUrls, activeTab === "video" ? "video" : "image");
+    onFileUpload(uploadedUrls, fileType);
   };
 
   const handleDragOver = (e: React.DragEvent<HTMLLabelElement>) => {
@@ -134,7 +135,7 @@ export const FileInput = ({
 
   const handleRemove = async (idx: number) => {
     const newFileUrl = selectedFiles.filter((_, i) => i !== idx).map((file) => file.url);
-    onFileUpload(newFileUrl, activeTab === "video" ? "video" : "image");
+    onFileUpload(newFileUrl, fileType);
     setImageUrlTemp("");
   };
 
@@ -185,7 +186,7 @@ export const FileInput = ({
     });
 
     const prevUrls = Array.isArray(fileUrl) ? fileUrl : fileUrl ? [fileUrl] : [];
-    onFileUpload([...prevUrls, ...uploadedUrls], activeTab === "video" ? "video" : "image");
+    onFileUpload([...prevUrls, ...uploadedUrls], fileType);
   };
 
   useEffect(() => {
@@ -202,14 +203,14 @@ export const FileInput = ({
   }, [fileUrl]);
 
   useEffect(() => {
-    if (activeTab === "image" && typeof imageUrlTemp === "string") {
+    if (fileType === "image" && typeof imageUrlTemp === "string") {
       // Temporarily store the current video URL before switching tabs.
       setVideoUrlTemp(videoUrl ?? "");
 
       if (imageUrlTemp) {
         onFileUpload([imageUrlTemp], "image");
       }
-    } else if (activeTab === "video") {
+    } else if (fileType === "video") {
       // Temporarily store the current image URL before switching tabs.
       setImageUrlTemp(fileUrl ?? "");
 
@@ -217,8 +218,8 @@ export const FileInput = ({
         onFileUpload([videoUrlTemp], "video");
       }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only run when activeTab changes to avoid infinite loops
-  }, [activeTab]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Only run when file type changes to avoid loops
+  }, [fileType]);
 
   return (
     <div className="w-full cursor-default">
@@ -227,7 +228,7 @@ export const FileInput = ({
           <OptionsSwitch options={options} currentOption={activeTab} handleOptionChange={setActiveTab} />
         )}
         <div>
-          {activeTab === "video" && (
+          {fileType === "video" && (
             <div className={cn(isVideoAllowed && "rounded-b-lg border-x border-b border-slate-200 p-4")}>
               <VideoSettings
                 uploadedVideoUrl={uploadedVideoUrl}
@@ -239,7 +240,7 @@ export const FileInput = ({
             </div>
           )}
 
-          {activeTab === "image" && (
+          {fileType === "image" && (
             <div className={cn(isVideoAllowed && "rounded-b-lg border-x border-b border-slate-200 p-4")}>
               {selectedFiles.length > 0 ? (
                 multiple ? (


### PR DESCRIPTION
## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Removes the reverted video upload path from the Welcome Card company logo uploader in the survey editor. The logo uploader now stays image-only and clears any existing `videoUrl` when an image is uploaded or removed. The shared `FileInput` also now respects `isVideoAllowed` when deciding which media UI and file type to expose.

Fixes ENG-1027

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Open the survey editor, enable the Welcome Card, and inspect `Company logo`.
- Confirm the Welcome Card company logo uploader does not show the `Image | Video` segmented control.
- Confirm there is no video tab, video URL field, YouTube input, or video upload path for the Welcome Card company logo.
- Upload and remove an image logo and confirm the image-only flow still works.
- Confirm other media uploaders that allow video still expose the video option.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏


### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary

Welcome card does not include split image|youtube-url inputs anymore

<img width="785" height="425" alt="image" src="https://github.com/user-attachments/assets/3a3ac06c-0a6a-46d5-a1c1-d05f4705e462" />
