### PR TITLE
fix: pin minimatch@10 to 10.2.5 to bypass ReDoS (ENG-1113)

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
       "hono": "4.12.18",
       "ip-address": "10.1.1",
       "lodash": "4.18.1",
+      "minimatch@10": "10.2.5",
       "node-forge": "1.4.0",
       "postcss": "8.5.14",
       "protobufjs@7": "7.5.8",
@@ -104,7 +105,7 @@
       "uuid@11": "11.1.1"
     },
     "comments": {
-      "overrides": "Security fixes for transitive dependencies that still fail a no-override audit. Remove each override when its upstream chain adopts a patched version: @hono/node-server/hono via Prisma dev tooling | @protobufjs/utf8 (CVE overlong UTF-8) - awaiting @opentelemetry/otlp-transformer update | @tootallnate/once and tar via sqlite3/node-gyp chain | @xmldom/xmldom (XML injection/DoS CVEs) - awaiting @boxyhq/saml20 to pin to >=0.9.10 | axios, lodash, and node-forge via @boxyhq/saml-jackson | ajv@6 via webpack/eslint | effect (GHSA-38f7-945m-qr2g) - awaiting @prisma/config update | fast-uri (CVE-2025-48944/48945) - awaiting ajv/schema-utils update | fast-xml-parser via AWS SDK XML builder | ip-address (XSS in Address6) - awaiting mongodb/socks update | postcss (CVE-2025-62695) - awaiting next.js to unpin postcss | protobufjs@7/8 (GHSA-xq3m-2v4x-88gg et al.) - awaiting @grpc/proto-loader/otlp-transformer update | uuid@11 (CVE-2025-61475) - awaiting typeorm update"
+      "overrides": "Security fixes for transitive dependencies that still fail a no-override audit. Remove each override when its upstream chain adopts a patched version: @hono/node-server/hono via Prisma dev tooling | @protobufjs/utf8 (CVE overlong UTF-8) - awaiting @opentelemetry/otlp-transformer update | @tootallnate/once and tar via sqlite3/node-gyp chain | @xmldom/xmldom (XML injection/DoS CVEs) - awaiting @boxyhq/saml20 to pin to >=0.9.10 | axios, lodash, and node-forge via @boxyhq/saml-jackson | ajv@6 via webpack/eslint | effect (GHSA-38f7-945m-qr2g) - awaiting @prisma/config update | fast-uri (CVE-2025-48944/48945) - awaiting ajv/schema-utils update | fast-xml-parser via AWS SDK XML builder | ip-address (XSS in Address6) - awaiting mongodb/socks update | minimatch@10 (CVE-2026-27904 / GHSA-23c5-xmqv-rm74, nested extglob ReDoS) - awaiting @rushstack/node-core-library (via vite-plugin-dts -> @microsoft/api-extractor) to bump to >=10.2.3 | postcss (CVE-2025-62695) - awaiting next.js to unpin postcss | protobufjs@7/8 (GHSA-xq3m-2v4x-88gg et al.) - awaiting @grpc/proto-loader/otlp-transformer update | uuid@11 (CVE-2025-61475) - awaiting typeorm update"
     },
     "patchedDependencies": {
       "next-auth@4.24.13": "patches/next-auth@4.24.13.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   hono: 4.12.18
   ip-address: 10.1.1
   lodash: 4.18.1
+  minimatch@10: 10.2.5
   node-forge: 1.4.0
   postcss: 8.5.14
   protobufjs@7: 7.5.8
@@ -9251,10 +9252,6 @@ packages:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
-  minimatch@10.2.1:
-    resolution: {integrity: sha512-MClCe8IL5nRRmawL6ib/eT4oLyeKMGCghibcDWK+J0hh0Q8kqSdia6BvbRMVk6mPa6WqUa5uR2oxt6C5jd533A==}
-    engines: {node: 20 || >=22}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -14554,7 +14551,7 @@ snapshots:
       '@rushstack/ts-command-line': 5.3.3(@types/node@25.4.0)
       diff: 8.0.4
       lodash: 4.18.1
-      minimatch: 10.2.1
+      minimatch: 10.2.5
       resolve: 1.22.11
       semver: 7.5.4
       source-map: 0.6.1
@@ -21911,10 +21908,6 @@ snapshots:
   min-indent@1.0.1: {}
 
   mini-svg-data-uri@1.4.4: {}
-
-  minimatch@10.2.1:
-    dependencies:
-      brace-expansion: 5.0.6
 
   minimatch@10.2.5:
     dependencies:


### PR DESCRIPTION
## Summary

Closes [ENG-1113](https://linear.app/formbricks/issue/ENG-1113) and Dependabot alerts [#294](https://github.com/formbricks/formbricks/security/dependabot/294) and [#297](https://github.com/formbricks/formbricks/security/dependabot/297) by pinning `minimatch@10` to `10.2.5` via a `pnpm.overrides` entry.

## Background — two separate alerts, one underlying release

`minimatch` 10.0.0 – 10.2.2 ships two genuinely distinct ReDoS bugs in different code paths. They were disclosed together and fixed in the same `10.2.3` release, so they show up as two Dependabot alerts on the same package + same vulnerable range, but each is its own CVE:

| Alert | CVE / GHSA | Code path | Trigger |
| --- | --- | --- | --- |
| **#294** | CVE-2026-27904 / GHSA-23c5-xmqv-rm74 | `AST.toRegExpSource()` (extglob compiler) | Nested `*()` or `+()` extglobs compile to regex with nested unbounded quantifiers (`(?:(?:a\|b)*)*`). A 12-byte pattern `*(*(*(a\|b)))` against an 18-char non-matching input stalls Node's event loop for ~7s; one more nesting level pushes that to minutes. |
| **#297** | CVE-2026-27903 / GHSA-7r86-cg39-jmmj | `matchOne()` (runtime matcher loop) | Multiple non-adjacent `**` (globstar) segments in a glob pattern make `matchOne()` recurse across the file path in a way that produces combinatorial backtracking. |

Both are **high severity**, both apply to `>= 10.0.0, < 10.2.3`, both are fixed in `10.2.3`. The PoC inputs (12-byte pattern, ~18-char input) easily fit inside any query string or request body, and the worst-case stalls are 60+ seconds with no CPU activity recoverable mid-call.

## Where does this affect us?

The vulnerable `minimatch@10.2.1` is pulled in transitively, **dev-time only**:

```
vite-plugin-dts → @microsoft/api-extractor → @rushstack/node-core-library → minimatch@10.2.1
```

`vite-plugin-dts` is a devDependency of `@formbricks/database`, `@formbricks/cache`, `@formbricks/survey-ui`, `@formbricks/jobs`, and `@formbricks/js-core`, used during `.d.ts` generation in builds. It never ships in any production bundle, never receives untrusted glob input, and the API extractor isn't reachable from the running app.

So the **practical exploitability against our running services is effectively zero**. The fix here is still worth shipping because:

- Dependabot won't stop nagging until the lockfile is clean of any vulnerable range, regardless of reachability.
- The same `minimatch` resolution path is what would be used if anyone reaches for it directly in app code in the future — fixing it at the override level future-proofs us.
- The advisory's vulnerable range is unambiguous and the upgrade is a patch-level move (`10.2.1 → 10.2.5`) with no breaking API changes.

## Approach — pnpm override, not a parent-package upgrade

Two ways to fix this:

1. **Upgrade the parent chain** (bump `vite-plugin-dts` / `@microsoft/api-extractor` / `@rushstack/node-core-library` until they pull a patched minimatch). Doesn't currently work — the latest published `@rushstack/node-core-library` still declares the vulnerable range. Would also drag in unrelated changes from those packages.
2. **`pnpm.overrides`** (what this PR does). One line, scoped to the 10.x major. Repo already has 14 similar entries for the same kind of transitive-CVE situation (`ajv@6`, `protobufjs@7`, `uuid@11`, etc.), so the pattern is established.

Going with option 2.

The `@10` suffix on the override key scopes the pin to the 10.x major line only. The other two minimatch majors present in the lockfile — `3.1.5` (used by older tooling) and `9.0.9` (used by mid-generation tooling) — are **not affected** by either CVE (the vulnerable range is `>= 10.0.0`) and stay untouched.

`10.2.5` was chosen over `10.2.3` because `10.2.5` is already in the lockfile from other resolution paths, so the override deduplicates rather than introducing a fourth installed version. Both versions are equally patched against the two CVEs.

## Diff

| File | Change |
| --- | --- |
| `package.json` | One-line entry `"minimatch@10": "10.2.5"` added to `pnpm.overrides`. The adjacent `pnpm.comments.overrides` string is extended with `minimatch@10 (CVE-2026-27904 / GHSA-23c5-xmqv-rm74, nested extglob ReDoS) - awaiting @rushstack/node-core-library (via vite-plugin-dts -> @microsoft/api-extractor) to bump to >=10.2.3` so future maintainers know when to remove the pin. (The same comment-as-removal-trigger pattern is used by every existing override in the block.) |
| `pnpm-lock.yaml` | Regenerated. `minimatch@10.2.1` is gone (verified: `grep "minimatch@10.2.1" pnpm-lock.yaml` returns zero matches). All 10.x consumers now resolve to `10.2.5`. |

Net: `+4 / −10` lines (the lockfile loses the now-orphaned `10.2.1` block).

## Verification

- `pnpm install` exits clean. No new package downloads beyond the dedup-driven swap.
- `grep "minimatch@10.2.1" pnpm-lock.yaml` → 0 matches.
- All `minimatch: 10.x` references in the lockfile resolve to `10.2.5`.
- `minimatch@3.1.5` and `minimatch@9.0.9` snapshots are unchanged.

## Test plan

- [x] Lockfile no longer contains the vulnerable version (verified locally).
- [ ] CI build passes.
- [ ] Dependabot alerts #294 and #297 auto-close after merge.

## Out of scope

- Upstream PR to `@rushstack/node-core-library` to bump its `minimatch` dep — would be the proper long-term fix, but unblocking our security audit shouldn't wait on it. Track separately if it hasn't moved by the next quarterly dependency sweep.
- Auditing application code for direct `minimatch` use against untrusted patterns — none today; this is purely a Dependabot-hygiene PR.