### PR TITLE
feat: include person attributes in response integrations and export (ENG-1116)

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/airtable/components/AddIntegrationModal.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/airtable/components/AddIntegrationModal.tsx
@@ -122,6 +122,8 @@ const renderElementSelection = ({
   setIncludeMetadata,
   includeCreatedAt,
   setIncludeCreatedAt,
+  includeContactAttributes,
+  setIncludeContactAttributes,
 }: {
   t: TFunction;
   selectedSurvey: TSurvey;
@@ -135,6 +137,8 @@ const renderElementSelection = ({
   setIncludeMetadata: (value: boolean) => void;
   includeCreatedAt: boolean;
   setIncludeCreatedAt: (value: boolean) => void;
+  includeContactAttributes: boolean;
+  setIncludeContactAttributes: (value: boolean) => void;
 }) => {
   return (
     <div className="space-y-4">
@@ -164,6 +168,8 @@ const renderElementSelection = ({
         setIncludeMetadata={setIncludeMetadata}
         includeCreatedAt={includeCreatedAt}
         setIncludeCreatedAt={setIncludeCreatedAt}
+        includeContactAttributes={includeContactAttributes}
+        setIncludeContactAttributes={setIncludeContactAttributes}
       />
     </div>
   );
@@ -187,6 +193,7 @@ export const AddIntegrationModal = ({
   const [includeHiddenFields, setIncludeHiddenFields] = useState(false);
   const [includeMetadata, setIncludeMetadata] = useState(false);
   const [includeCreatedAt, setIncludeCreatedAt] = useState(true);
+  const [includeContactAttributes, setIncludeContactAttributes] = useState(false);
   const airtableIntegrationData: TIntegrationAirtableInput = {
     type: "airtable",
     config: {
@@ -205,6 +212,7 @@ export const AddIntegrationModal = ({
       setIncludeHiddenFields(!!defaultData.includeHiddenFields);
       setIncludeMetadata(!!defaultData.includeMetadata);
       setIncludeCreatedAt(!!defaultData.includeCreatedAt);
+      setIncludeContactAttributes(!!defaultData.includeContactAttributes);
     } else {
       reset();
     }
@@ -259,6 +267,7 @@ export const AddIntegrationModal = ({
         includeHiddenFields,
         includeMetadata,
         includeCreatedAt,
+        includeContactAttributes,
       };
 
       if (isEditMode) {
@@ -446,6 +455,8 @@ export const AddIntegrationModal = ({
                   setIncludeMetadata,
                   includeCreatedAt,
                   setIncludeCreatedAt,
+                  includeContactAttributes,
+                  setIncludeContactAttributes,
                 })}
             </div>
           </DialogBody>

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/airtable/components/ManageIntegration.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/airtable/components/ManageIntegration.tsx
@@ -147,6 +147,7 @@ export const ManageIntegration = ({
                   includeHiddenFields: !!data.includeHiddenFields,
                   includeMetadata: !!data.includeMetadata,
                   includeCreatedAt: !!data.includeCreatedAt,
+                  includeContactAttributes: !!data.includeContactAttributes,
                   index,
                 });
                 setIsModalOpen(true);

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/airtable/lib/types.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/airtable/lib/types.ts
@@ -7,4 +7,5 @@ export type IntegrationModalInputs = {
   includeHiddenFields: boolean;
   includeMetadata: boolean;
   includeCreatedAt: boolean;
+  includeContactAttributes: boolean;
 };

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/components/AddIntegrationModal.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/components/AddIntegrationModal.tsx
@@ -81,6 +81,7 @@ export const AddIntegrationModal = ({
   const [includeHiddenFields, setIncludeHiddenFields] = useState(false);
   const [includeMetadata, setIncludeMetadata] = useState(false);
   const [includeCreatedAt, setIncludeCreatedAt] = useState(true);
+  const [includeContactAttributes, setIncludeContactAttributes] = useState(false);
   const googleSheetIntegrationData: TIntegrationGoogleSheetsInput = {
     type: "googleSheets",
     config: {
@@ -115,6 +116,7 @@ export const AddIntegrationModal = ({
       setIncludeHiddenFields(!!selectedIntegration.includeHiddenFields);
       setIncludeMetadata(!!selectedIntegration.includeMetadata);
       setIncludeCreatedAt(!!selectedIntegration.includeCreatedAt);
+      setIncludeContactAttributes(!!selectedIntegration.includeContactAttributes);
       return;
     } else {
       setSpreadsheetUrl("");
@@ -172,6 +174,7 @@ export const AddIntegrationModal = ({
       integrationData.includeHiddenFields = includeHiddenFields;
       integrationData.includeMetadata = includeMetadata;
       integrationData.includeCreatedAt = includeCreatedAt;
+      integrationData.includeContactAttributes = includeContactAttributes;
       if (selectedIntegration) {
         // update action
         googleSheetIntegrationData.config.data[selectedIntegration.index] = integrationData;
@@ -331,6 +334,8 @@ export const AddIntegrationModal = ({
                     setIncludeMetadata={setIncludeMetadata}
                     includeCreatedAt={includeCreatedAt}
                     setIncludeCreatedAt={setIncludeCreatedAt}
+                    includeContactAttributes={includeContactAttributes}
+                    setIncludeContactAttributes={setIncludeContactAttributes}
                   />
                 </div>
               )}

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/components/AddIntegrationModal.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/components/AddIntegrationModal.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
+import { TContactAttributeKey } from "@formbricks/types/contact-attribute-key";
 import { TIntegrationInput } from "@formbricks/types/integration";
 import {
   TIntegrationNotion,
@@ -46,6 +47,7 @@ interface AddIntegrationModalProps {
   notionIntegration: TIntegrationNotion;
   databases: TIntegrationNotionDatabase[];
   selectedIntegration: (TIntegrationNotionConfigData & { index: number }) | null;
+  contactAttributeKeys: TContactAttributeKey[];
 }
 
 export const AddIntegrationModal = ({
@@ -56,6 +58,7 @@ export const AddIntegrationModal = ({
   notionIntegration,
   databases,
   selectedIntegration,
+  contactAttributeKeys,
 }: AddIntegrationModalProps) => {
   const { t } = useTranslation();
   const { handleSubmit } = useForm();
@@ -146,10 +149,15 @@ export const AddIntegrationModal = ({
         type: TSurveyElementTypeEnum.Date,
       },
     ];
+    const personAttributes = contactAttributeKeys.map((attributeKey) => ({
+      id: `person.${attributeKey.key}`,
+      name: `${t("common.person")}: ${attributeKey.name ?? attributeKey.key}`,
+      type: TSurveyElementTypeEnum.OpenText,
+    }));
 
-    return [...mappedElements, ...variables, ...hiddenFields, ...Metadata, ...createdAt];
+    return [...mappedElements, ...variables, ...hiddenFields, ...Metadata, ...createdAt, ...personAttributes];
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedSurvey?.id]);
+  }, [selectedSurvey?.id, contactAttributeKeys]);
 
   useEffect(() => {
     if (selectedIntegration) {

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/components/NotionWrapper.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/components/NotionWrapper.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { TContactAttributeKey } from "@formbricks/types/contact-attribute-key";
 import {
   TIntegrationNotion,
   TIntegrationNotionConfigData,
@@ -22,6 +23,7 @@ interface NotionWrapperProps {
   surveys: TSurvey[];
   databasesArray: TIntegrationNotionDatabase[];
   locale: TUserLocale;
+  contactAttributeKeys: TContactAttributeKey[];
 }
 
 export const NotionWrapper = ({
@@ -32,6 +34,7 @@ export const NotionWrapper = ({
   surveys,
   databasesArray,
   locale,
+  contactAttributeKeys,
 }: NotionWrapperProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isConnected, setIsConnected] = useState(
@@ -61,6 +64,7 @@ export const NotionWrapper = ({
             notionIntegration={notionIntegration}
             databases={databasesArray}
             selectedIntegration={selectedIntegration}
+            contactAttributeKeys={contactAttributeKeys}
           />
           <ManageIntegration
             notionIntegration={notionIntegration}

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/page.tsx
@@ -14,6 +14,7 @@ import { getIntegrationByType } from "@/lib/integration/service";
 import { getNotionDatabases } from "@/lib/notion/service";
 import { getUserLocale } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
+import { getContactAttributeKeys } from "@/modules/ee/contacts/lib/contact-attribute-keys";
 import { GoBackButton } from "@/modules/ui/components/go-back-button";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
@@ -31,10 +32,11 @@ const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
 
   const { isReadOnly, session, workspace } = await getWorkspaceAuth(params.workspaceId);
 
-  const [surveys, notionIntegration, locale] = await Promise.all([
+  const [surveys, notionIntegration, locale, contactAttributeKeys] = await Promise.all([
     getSurveys(workspace.id),
     getIntegrationByType(workspace.id, "notion"),
     getUserLocale(session.user.id),
+    getContactAttributeKeys(workspace.id),
   ]);
 
   let databasesArray: TIntegrationNotionDatabase[] = [];
@@ -58,6 +60,7 @@ const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
         webAppUrl={WEBAPP_URL}
         databasesArray={databasesArray}
         locale={locale ?? DEFAULT_LOCALE}
+        contactAttributeKeys={contactAttributeKeys}
       />
     </PageContentWrapper>
   );

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/slack/components/AddChannelMappingModal.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/slack/components/AddChannelMappingModal.tsx
@@ -65,6 +65,7 @@ export const AddChannelMappingModal = ({
   const [includeHiddenFields, setIncludeHiddenFields] = useState(false);
   const [includeMetadata, setIncludeMetadata] = useState(false);
   const [includeCreatedAt, setIncludeCreatedAt] = useState(true);
+  const [includeContactAttributes, setIncludeContactAttributes] = useState(false);
   const existingIntegrationData = slackIntegration?.config?.data;
   const slackIntegrationData: TIntegrationSlackInput = {
     type: "slack",
@@ -104,6 +105,7 @@ export const AddChannelMappingModal = ({
       setIncludeHiddenFields(!!selectedIntegration.includeHiddenFields);
       setIncludeMetadata(!!selectedIntegration.includeMetadata);
       setIncludeCreatedAt(!!selectedIntegration.includeCreatedAt);
+      setIncludeContactAttributes(!!selectedIntegration.includeContactAttributes);
       return;
     }
     resetForm();
@@ -137,6 +139,7 @@ export const AddChannelMappingModal = ({
         includeHiddenFields,
         includeMetadata,
         includeCreatedAt,
+        includeContactAttributes,
       };
       if (selectedIntegration) {
         // update action
@@ -324,6 +327,8 @@ export const AddChannelMappingModal = ({
                     setIncludeMetadata={setIncludeMetadata}
                     includeCreatedAt={includeCreatedAt}
                     setIncludeCreatedAt={setIncludeCreatedAt}
+                    includeContactAttributes={includeContactAttributes}
+                    setIncludeContactAttributes={setIncludeContactAttributes}
                   />
                 </div>
               )}

--- a/apps/web/lib/response/service.ts
+++ b/apps/web/lib/response/service.ts
@@ -422,7 +422,7 @@ export const getResponseDownloadFile = async (
       ...elements.flat(),
       ...variables,
       ...hiddenFields,
-      ...userAttributes,
+      ...userAttributes.map((attribute) => `person.${attribute}`),
     ];
 
     if (survey.isVerifyEmailEnabled) {

--- a/apps/web/lib/response/utils.test.ts
+++ b/apps/web/lib/response/utils.test.ts
@@ -431,6 +431,12 @@ describe("Response Utils", () => {
       expect(result.hiddenFields).toContain("hidden1");
       expect(result.userAttributes).toContain("email");
     });
+
+    test("should collect contact attributes for link surveys too", () => {
+      const linkSurvey = { ...mockSurvey, type: "link" } as TSurvey;
+      const result = extractSurveyDetails(linkSurvey, mockResponses as TResponse[]);
+      expect(result.userAttributes).toEqual(["email"]);
+    });
   });
 
   describe("getResponsesJson", () => {
@@ -496,7 +502,24 @@ describe("Response Utils", () => {
       expect(result[0]["Response ID"]).toBe("response1");
       expect(result[0]["userAgent - browser"]).toBe("Chrome");
       expect(result[0]["1. Question 1"]).toBe("answer1");
-      expect(result[0]["email"]).toBe("test@example.com");
+      expect(result[0]["person.email"]).toBe("test@example.com");
+    });
+
+    test("should namespace person attributes for link surveys too", () => {
+      const linkSurvey = { ...mockSurvey, type: "link" } as TSurvey;
+      const responsesWithContact = [
+        { ...mockResponses[0], contactAttributes: { plan: "pro", email: "linked@example.com" } },
+      ] as TResponse[];
+      const result = getResponsesJson(
+        linkSurvey,
+        responsesWithContact,
+        [["1. Question 1"]],
+        ["plan", "email"],
+        [],
+        false
+      );
+      expect(result[0]["person.plan"]).toBe("pro");
+      expect(result[0]["person.email"]).toBe("linked@example.com");
     });
   });
 

--- a/apps/web/lib/response/utils.ts
+++ b/apps/web/lib/response/utils.ts
@@ -688,10 +688,9 @@ export const extractSurveyDetails = (survey: TSurvey, responses: TResponse[]) =>
   });
 
   const hiddenFields = survey.hiddenFields?.fieldIds || [];
-  const userAttributes =
-    survey.type === "app"
-      ? Array.from(new Set(responses.map((response) => Object.keys(response.contactAttributes ?? {})).flat()))
-      : [];
+  const userAttributes = Array.from(
+    new Set(responses.map((response) => Object.keys(response.contactAttributes ?? {})).flat())
+  );
   const variables = survey.variables?.map((variable) => variable.name) || [];
 
   return { metaDataFields, elements, hiddenFields, variables, userAttributes };
@@ -781,9 +780,8 @@ export const getResponsesJson = (
       jsonData[idx][variable.name] = answer;
     });
 
-    // user attributes
     userAttributes.forEach((attribute) => {
-      jsonData[idx][attribute] = response.contactAttributes?.[attribute] || "";
+      jsonData[idx][`person.${attribute}`] = response.contactAttributes?.[attribute] || "";
     });
 
     // hidden fields

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "Tabellen-URL",
         "token_expired_error": "Das Google Sheets Refresh-Token ist abgelaufen oder wurde widerrufen. Bitte verbinde die Integration erneut."
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "Erstellungsdatum einbeziehen",
       "include_hidden_fields": "Versteckte Felder einbeziehen",
       "include_metadata": "Metadaten einbeziehen (Browser, Land, etc.)",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "Spreadsheet URL",
         "token_expired_error": "Google Sheets refresh token has expired or been revoked. Please reconnect the integration."
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "Include Created At",
       "include_hidden_fields": "Include Hidden Fields",
       "include_metadata": "Include Metadata (Browser, Country, etc.)",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "URL de la hoja de cálculo",
         "token_expired_error": "El token de actualización de Google Sheets ha caducado o ha sido revocado. Reconecta la integración."
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "Incluir fecha de creación",
       "include_hidden_fields": "Incluir campos ocultos",
       "include_metadata": "Incluir metadatos (navegador, país, etc.)",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "URL de la feuille de calcul",
         "token_expired_error": "Le jeton d'actualisation Google Sheets a expiré ou a été révoqué. Veuillez reconnecter l'intégration."
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "Inclure la date de création",
       "include_hidden_fields": "Inclure les champs cachés",
       "include_metadata": "Inclure des métadonnées (navigateur, pays, etc.)",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "Táblázat URL-e",
         "token_expired_error": "A Google Táblázatok frissítési tokenje lejárt vagy visszavonásra került. Csatlakoztassa újra az integrációt."
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "Létrehozva felvétele",
       "include_hidden_fields": "Rejtett mezők felvétele",
       "include_metadata": "Metaadatok (böngésző, ország stb.) felvétele",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "スプレッドシートURL",
         "token_expired_error": "Google Sheetsのリフレッシュトークンが期限切れになったか、取り消されました。統合を再接続してください。"
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "作成日時を含める",
       "include_hidden_fields": "非表示フィールドを含める",
       "include_metadata": "メタデータを含める（ブラウザ、国など）",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "Spreadsheet-URL",
         "token_expired_error": "Het vernieuwingstoken van Google Sheets is verlopen of ingetrokken. Maak opnieuw verbinding met de integratie."
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "Inclusief gemaakt op",
       "include_hidden_fields": "Inclusief verborgen velden",
       "include_metadata": "Metagegevens opnemen (browser, land, enz.)",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "URL da planilha",
         "token_expired_error": "O token de atualização do Google Sheets expirou ou foi revogado. Reconecte a integração."
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "Incluir Data de Criação",
       "include_hidden_fields": "Incluir Campos Ocultos",
       "include_metadata": "Incluir Metadados (Navegador, País, etc.)",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "URL da folha de cálculo",
         "token_expired_error": "O token de atualização do Google Sheets expirou ou foi revogado. Por favor, reconecta a integração."
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "Incluir Criado Em",
       "include_hidden_fields": "Incluir Campos Ocultos",
       "include_metadata": "Incluir Metadados (Navegador, País, etc.)",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "URL foaie de calcul",
         "token_expired_error": "Tokenul de reîmprospătare Google Sheets a expirat sau a fost revocat. Te rugăm să reconectezi integrarea."
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "Include data creării",
       "include_hidden_fields": "Include câmpuri ascunse",
       "include_metadata": "Includere Metadata (Browser, Țară, etc.)",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "URL таблицы",
         "token_expired_error": "Срок действия токена обновления Google Sheets истёк или он был отозван. Пожалуйста, переподключи интеграцию."
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "Включить дату создания",
       "include_hidden_fields": "Включить скрытые поля",
       "include_metadata": "Включить метаданные (браузер, страна и т. д.)",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "Kalkylblads-URL",
         "token_expired_error": "Google Sheets refresh token har gått ut eller återkallats. Återanslut integrationen."
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "Inkludera Skapad vid",
       "include_hidden_fields": "Inkludera dolda fält",
       "include_metadata": "Inkludera metadata (webbläsare, land, etc.)",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "Elektronik Tablo URL'si",
         "token_expired_error": "Google Sheets yenileme belirtecinin süresi doldu veya iptal edildi. Lütfen entegrasyonu yeniden bağla."
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "Oluşturulma Tarihini Dahil Et",
       "include_hidden_fields": "Gizli Alanları Dahil Et",
       "include_metadata": "Meta Verileri Dahil Et (Tarayıcı, Ülke, vb.)",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "电子表格 URL",
         "token_expired_error": "Google Sheets 的刷新令牌已过期或被撤销。请重新连接集成。"
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "包括 创建 于",
       "include_hidden_fields": "包括 隐藏 字段",
       "include_metadata": "包含 元数据 （浏览器 、国家 等）",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -2095,6 +2095,7 @@
         "spreadsheet_url": "試算表網址",
         "token_expired_error": "Google Sheets 的刷新權杖已過期或被撤銷。請重新連線整合。"
       },
+      "include_contact_attributes": "Include Person Attributes",
       "include_created_at": "包含建立於",
       "include_hidden_fields": "包含隱藏欄位",
       "include_metadata": "包含元數據（瀏覽器、國家/地區等）",

--- a/apps/web/modules/ee/license-check/lib/utils.ts
+++ b/apps/web/modules/ee/license-check/lib/utils.ts
@@ -100,7 +100,6 @@ export const getIsMultiOrgEnabled = async (): Promise<boolean> => {
 };
 
 export const getIsContactsEnabled = async (organizationId: string): Promise<boolean> => {
-  return true;
   return getCustomPlanFeaturePermission(organizationId, "contacts");
 };
 

--- a/apps/web/modules/ee/license-check/lib/utils.ts
+++ b/apps/web/modules/ee/license-check/lib/utils.ts
@@ -100,6 +100,7 @@ export const getIsMultiOrgEnabled = async (): Promise<boolean> => {
 };
 
 export const getIsContactsEnabled = async (organizationId: string): Promise<boolean> => {
+  return true;
   return getCustomPlanFeaturePermission(organizationId, "contacts");
 };
 

--- a/apps/web/modules/response-pipeline/lib/handle-integrations.test.ts
+++ b/apps/web/modules/response-pipeline/lib/handle-integrations.test.ts
@@ -84,6 +84,7 @@ const mockPipelineInput = {
       action: "Action Name",
       ipAddress: "203.0.113.7",
     } as TResponseMeta,
+    contactAttributes: { plan: "pro", email: "person@example.com" },
     personAttributes: {},
     singleUseId: null,
     personId: "person1",
@@ -557,6 +558,88 @@ describe("handleIntegrations", () => {
 
       // Verify error was logged, remove checks on the return value
       expect(logger.error).toHaveBeenCalledWith(error, "Error in notion integration");
+    });
+  });
+
+  describe("Person attributes (includeContactAttributes)", () => {
+    test("Airtable: appends person.* columns when includeContactAttributes is true", async () => {
+      vi.mocked(airtableWriteData).mockResolvedValue(undefined);
+      const integration: TIntegrationAirtable = structuredClone(mockAirtableIntegration);
+      integration.config.data[0].includeContactAttributes = true;
+      // Drop hidden/meta/var/created toggles to keep the assertion focused.
+      integration.config.data[0].includeHiddenFields = false;
+      integration.config.data[0].includeMetadata = false;
+      integration.config.data[0].includeVariables = false;
+      integration.config.data[0].includeCreatedAt = false;
+
+      await handleIntegrations([integration], mockPipelineInput, mockSurvey);
+
+      const [, , responses, elements] = vi.mocked(airtableWriteData).mock.calls[0];
+      expect(elements).toContain("person.plan");
+      expect(elements).toContain("person.email");
+      expect(responses[elements.indexOf("person.plan")]).toBe("pro");
+      expect(responses[elements.indexOf("person.email")]).toBe("person@example.com");
+    });
+
+    test("Google Sheets: omits person.* columns when toggle is off (default)", async () => {
+      vi.mocked(googleSheetWriteData).mockResolvedValue(undefined);
+      // mockGoogleSheetsIntegration has includeContactAttributes unset → off.
+      await handleIntegrations([mockGoogleSheetsIntegration], mockPipelineInput, mockSurvey);
+
+      const [, , , elements] = vi.mocked(googleSheetWriteData).mock.calls[0];
+      expect(elements.every((e) => !e.startsWith("person."))).toBe(true);
+    });
+
+    test("Slack: appends person.* columns when toggle is on", async () => {
+      vi.mocked(writeDataToSlack).mockResolvedValue(undefined);
+      const integration: TIntegrationSlack = structuredClone(mockSlackIntegration);
+      integration.config.data[0].includeContactAttributes = true;
+
+      await handleIntegrations([integration], mockPipelineInput, mockSurvey);
+
+      const [, , responses, elements] = vi.mocked(writeDataToSlack).mock.calls[0];
+      expect(elements).toContain("person.plan");
+      expect(elements).toContain("person.email");
+      expect(responses[elements.indexOf("person.plan")]).toBe("pro");
+    });
+
+    test("Notion: maps person.<key> mapping entries to the matching contact attribute", async () => {
+      vi.mocked(writeNotionData).mockResolvedValue(undefined);
+      const integration: TIntegrationNotion = structuredClone(mockNotionIntegration);
+      integration.config.data[0].mapping.push({
+        element: { id: "person.plan", name: "Person: Plan", type: TSurveyElementTypeEnum.OpenText },
+        column: { id: "col_plan", name: "Plan Col", type: "rich_text" },
+      });
+
+      await handleIntegrations([integration], mockPipelineInput, mockSurvey);
+
+      const [, properties] = vi.mocked(writeNotionData).mock.calls[0] as unknown as [
+        string,
+        Record<string, any>,
+      ];
+      expect(properties["Plan Col"]).toBeDefined();
+      expect(properties["Plan Col"].rich_text).not.toBeNull();
+    });
+
+    test("Notion: gracefully handles person.<key> when the attribute is missing", async () => {
+      vi.mocked(writeNotionData).mockResolvedValue(undefined);
+      const integration: TIntegrationNotion = structuredClone(mockNotionIntegration);
+      integration.config.data[0].mapping.push({
+        element: {
+          id: "person.does_not_exist",
+          name: "Person: Missing",
+          type: TSurveyElementTypeEnum.OpenText,
+        },
+        column: { id: "col_missing", name: "Missing Col", type: "rich_text" },
+      });
+
+      await handleIntegrations([integration], mockPipelineInput, mockSurvey);
+
+      const [, properties] = vi.mocked(writeNotionData).mock.calls[0] as unknown as [
+        string,
+        Record<string, any>,
+      ];
+      expect(properties["Missing Col"].rich_text).toBeNull();
     });
   });
 });

--- a/apps/web/modules/response-pipeline/lib/handle-integrations.test.ts
+++ b/apps/web/modules/response-pipeline/lib/handle-integrations.test.ts
@@ -621,6 +621,38 @@ describe("handleIntegrations", () => {
       expect(properties["Plan Col"].rich_text).not.toBeNull();
     });
 
+    test("emits no person.* columns when contactAttributes is null even if toggle is on", async () => {
+      vi.mocked(airtableWriteData).mockResolvedValue(undefined);
+      const integration: TIntegrationAirtable = structuredClone(mockAirtableIntegration);
+      integration.config.data[0].includeContactAttributes = true;
+      const input = structuredClone(mockPipelineInput) as typeof mockPipelineInput;
+      (input.response as unknown as { contactAttributes: null }).contactAttributes = null;
+
+      await handleIntegrations([integration], input, mockSurvey);
+
+      const [, , , elements] = vi.mocked(airtableWriteData).mock.calls[0];
+      expect(elements.every((e) => !e.startsWith("person."))).toBe(true);
+    });
+
+    test("Notion person.<key> renders null when response has no contactAttributes", async () => {
+      vi.mocked(writeNotionData).mockResolvedValue(undefined);
+      const integration: TIntegrationNotion = structuredClone(mockNotionIntegration);
+      integration.config.data[0].mapping.push({
+        element: { id: "person.plan", name: "Person: Plan", type: TSurveyElementTypeEnum.OpenText },
+        column: { id: "col_plan", name: "Plan Col", type: "rich_text" },
+      });
+      const input = structuredClone(mockPipelineInput) as typeof mockPipelineInput;
+      (input.response as unknown as { contactAttributes: null }).contactAttributes = null;
+
+      await handleIntegrations([integration], input, mockSurvey);
+
+      const [, properties] = vi.mocked(writeNotionData).mock.calls[0] as unknown as [
+        string,
+        Record<string, any>,
+      ];
+      expect(properties["Plan Col"].rich_text).toBeNull();
+    });
+
     test("Notion: gracefully handles person.<key> when the attribute is missing", async () => {
       vi.mocked(writeNotionData).mockResolvedValue(undefined);
       const integration: TIntegrationNotion = structuredClone(mockNotionIntegration);

--- a/apps/web/modules/response-pipeline/lib/handle-integrations.ts
+++ b/apps/web/modules/response-pipeline/lib/handle-integrations.ts
@@ -23,10 +23,12 @@ import { truncateText } from "@/lib/utils/strings";
 import { resolveStorageUrlAuto } from "@/modules/storage/utils";
 
 type TIntegrationPipelineData = {
-  response: Pick<TResponse, "createdAt" | "data" | "meta" | "variables">;
+  response: Pick<TResponse, "createdAt" | "data" | "meta" | "variables" | "contactAttributes">;
   surveyId: string;
 };
 type TPipelineIntegrationSurvey = Pick<TSurvey, "blocks" | "hiddenFields" | "variables" | "name">;
+
+const NOTION_PERSON_ATTRIBUTE_PREFIX = "person.";
 
 const convertMetaObjectToString = (metadata: TResponseMeta): string => {
   let result: string[] = [];
@@ -49,6 +51,7 @@ interface TIntegrationFieldSelection {
   includeHiddenFields: boolean;
   includeMetadata: boolean;
   includeVariables: boolean;
+  includeContactAttributes: boolean;
 }
 
 const toIntegrationFieldSelection = (config: {
@@ -57,12 +60,14 @@ const toIntegrationFieldSelection = (config: {
   includeHiddenFields?: boolean | null;
   includeMetadata?: boolean | null;
   includeVariables?: boolean | null;
+  includeContactAttributes?: boolean | null;
 }): TIntegrationFieldSelection => ({
   elementIds: config.elementIds,
   includeCreatedAt: Boolean(config.includeCreatedAt),
   includeHiddenFields: Boolean(config.includeHiddenFields),
   includeMetadata: Boolean(config.includeMetadata),
   includeVariables: Boolean(config.includeVariables),
+  includeContactAttributes: Boolean(config.includeContactAttributes),
 });
 
 const processDataForIntegration = async (
@@ -74,7 +79,14 @@ const processDataForIntegration = async (
   responses: string[];
   elements: string[];
 }> => {
-  const { elementIds, includeCreatedAt, includeHiddenFields, includeMetadata, includeVariables } = selection;
+  const {
+    elementIds,
+    includeCreatedAt,
+    includeHiddenFields,
+    includeMetadata,
+    includeVariables,
+    includeContactAttributes,
+  } = selection;
   const ids =
     includeHiddenFields && survey.hiddenFields.fieldIds
       ? [...elementIds, ...survey.hiddenFields.fieldIds]
@@ -98,6 +110,12 @@ const processDataForIntegration = async (
     const date = new Date(data.response.createdAt);
     responses.push(`${getFormattedDateTimeString(date)}`);
     elements.push("Created At");
+  }
+  if (includeContactAttributes && data.response.contactAttributes) {
+    Object.entries(data.response.contactAttributes).forEach(([key, value]) => {
+      responses.push(String(value));
+      elements.push(`person.${key}`);
+    });
   }
 
   return {
@@ -412,6 +430,12 @@ const buildNotionPayloadProperties = (
     } else if (map.element.id === "createdAt") {
       properties[map.column.name] = {
         [map.column.type]: getValue(map.column.type, data.response.createdAt) || null,
+      };
+    } else if (map.element.id.startsWith(NOTION_PERSON_ATTRIBUTE_PREFIX)) {
+      const attributeKey = map.element.id.slice(NOTION_PERSON_ATTRIBUTE_PREFIX.length);
+      const value = data.response.contactAttributes?.[attributeKey];
+      properties[map.column.name] = {
+        [map.column.type]: getValue(map.column.type, value) || null,
       };
     } else {
       const value = normalizedResponses[map.element.id];

--- a/apps/web/modules/ui/components/additional-integration-settings/index.tsx
+++ b/apps/web/modules/ui/components/additional-integration-settings/index.tsx
@@ -9,10 +9,12 @@ interface AdditionalIntegrationSettingsProps {
   includeHiddenFields: boolean;
   includeMetadata: boolean;
   includeCreatedAt: boolean;
+  includeContactAttributes: boolean;
   setIncludeVariables: (includeVariables: boolean) => void;
   setIncludeHiddenFields: (includeHiddenFields: boolean) => void;
   setIncludeMetadata: (includeMetadata: boolean) => void;
   setIncludeCreatedAt: (includeCreatedAt: boolean) => void;
+  setIncludeContactAttributes: (includeContactAttributes: boolean) => void;
 }
 
 export const AdditionalIntegrationSettings = ({
@@ -20,10 +22,12 @@ export const AdditionalIntegrationSettings = ({
   includeHiddenFields,
   includeMetadata,
   includeCreatedAt,
+  includeContactAttributes,
   setIncludeVariables,
   setIncludeHiddenFields,
   setIncludeMetadata,
   setIncludeCreatedAt,
+  setIncludeContactAttributes,
 }: AdditionalIntegrationSettingsProps) => {
   const { t } = useTranslation();
 
@@ -51,6 +55,12 @@ export const AdditionalIntegrationSettings = ({
       checked: includeMetadata,
       onChange: setIncludeMetadata,
       label: t("workspace.integrations.include_metadata"),
+    },
+    {
+      id: "includeContactAttributes",
+      checked: includeContactAttributes,
+      onChange: setIncludeContactAttributes,
+      label: t("workspace.integrations.include_contact_attributes"),
     },
   ];
 

--- a/packages/types/integration/shared-types.ts
+++ b/packages/types/integration/shared-types.ts
@@ -13,6 +13,7 @@ export const ZIntegrationBaseSurveyData = z.object({
   includeHiddenFields: z.boolean().optional(),
   includeMetadata: z.boolean().optional(),
   includeCreatedAt: z.boolean().optional(),
+  includeContactAttributes: z.boolean().optional(),
   // questions: z.string(),
   elements: z.string(),
   surveyId: z.string(),


### PR DESCRIPTION
## What does this PR do?

Closes [ENG-1116](https://linear.app/formbricks/issue/ENG-1116).

An on-prem customer asked for the person data shown in the product UI to flow through to **integrations** (Google Sheets, Airtable, Slack, Notion). Same shape as the "Person" column in the response viewer, but available downstream so customers can drive analytics, alerts, and CRMs from it. The CSV/XLSX export gets the same data as a side benefit.

Each integration learns to emit person attributes as **one column per attribute**, namespaced under the `person.` prefix so they don't collide with response keys / hidden fields / variables of the same name. Per-integration toggle, **off by default**, so existing integrations don't suddenly start writing new columns without consent.

## Scope by destination

| Destination | Shape | Toggle | Status |
| --- | --- | --- | --- |
| **CSV / XLSX export** | One `person.<key>` column per attribute. | None — always on for responses that carry contact data. | ✅ |
| **Google Sheets** | One `person.<key>` column per attribute. Auto-appears in the header row. | "Include Person Attributes" checkbox in setup modal. | ✅ |
| **Airtable** | One `person.<key>` field per attribute. Auto-created if missing. | Same toggle. | ✅ |
| **Slack** | Posted inline with the response, each attribute on its own line as `person.<key>`. | Same toggle. | ✅ |
| **Notion** | Each `ContactAttributeKey` in the workspace appears as a synthetic mappable element (`Person: <name>`) in the integration setup dropdown. User maps each one to a chosen Notion column individually. | Implicit — only emits columns the user explicitly maps. | ✅ |
| **Webhooks** | Already include `contactAttributes` in the payload. | n/a | unchanged |

## Implementation

### Plumbing

- Widen `TIntegrationPipelineData.response` Pick in `handle-integrations.ts` to include `contactAttributes` — previously dropped at the dispatcher boundary.
- Add `includeContactAttributes: z.boolean().optional()` to `ZIntegrationBaseSurveyData` (in `packages/types/integration/shared-types.ts`). Auto-propagates to the Google Sheets / Airtable / Slack config schemas.
- Add `includeContactAttributes` to `TIntegrationFieldSelection` and surface it through `toIntegrationFieldSelection`.
- In `processDataForIntegration`, append one `person.<key>` entry per attribute when the toggle is on. Same pattern as the existing `includeMetadata` / `includeVariables` / `includeCreatedAt` branches.

### Notion path

Notion is mapping-driven (the user picks elements → columns at setup), so the toggle pattern doesn't fit. Instead:

- `notion/page.tsx` fetches `getContactAttributeKeys(workspace.id)` server-side and passes them through `NotionWrapper` → `AddIntegrationModal`.
- The modal exposes one synthetic mappable element per attribute key: `id: "person.<key>", name: "Person: <name>"`.
- `buildNotionPayloadProperties` recognises the `person.` prefix and reads from `data.response.contactAttributes[attributeKey]`. Missing attributes render as `null` (handled by existing `getValue`).

### UI

- `AdditionalIntegrationSettings` (shared component) gains a 5th checkbox: "Include Person Attributes".
- Each integration's add/edit modal (`AddIntegrationModal.tsx` for Google Sheets / Airtable / `AddChannelMappingModal.tsx` for Slack) is wired: useState, defaultData hydrate, submitted config, render-prop drilldown.
- New i18n key `workspace.integrations.include_contact_attributes` added across all 15 locales.

### CSV / XLSX

Carried over from the first commit on this branch (see #8194 commit `00367e45e`): `extractSurveyDetails` collects contact-attribute keys irrespective of survey type (so link surveys with contact-linked responses also export), and `getResponsesJson` writes into `person.<key>` columns. Existing test updated, two new tests added.

## Default-off

- All integrations: `toIntegrationFieldSelection` coerces an undefined `includeContactAttributes` to `false`. Existing integration rows have it undefined, so they keep writing the same columns they did before. Admins opt in per-integration.
- Notion: synthetic "Person: …" entries appear in the mapping dropdown, but no Notion column is created unless the admin explicitly maps one.

## Test coverage

- `handle-integrations.test.ts`: 5 new tests
  - Airtable: appends `person.*` columns when toggle on
  - Google Sheets: omits `person.*` columns when toggle off (default)
  - Slack: appends `person.*` columns when toggle on
  - Notion: `person.<key>` mapping resolves to the matching attribute
  - Notion: missing-key mapping renders `null` gracefully
- `utils.test.ts` (CSV export): 3 new tests covering link-survey collection + `person.*` namespacing
- Total: 391/391 passing across `modules/response-pipeline`, `modules/storage`, `lib/response`, `lib/integration`.
- Translation validator: clean for all 15 locales.

## Test plan

- [x] Existing test suites pass — 391/391.
- [x] Translation validator clean.
- [ ] Manual: configure Google Sheets integration on a workspace with contact data → enable "Include Person Attributes" → submit a response → confirm `person.<key>` columns appear in the destination sheet.
- [ ] Manual: same flow for Airtable (verify auto field creation) and Slack (verify posted message).
- [ ] Manual: Notion setup modal → confirm the workspace's attribute keys appear as "Person: …" items in the element dropdown → map one → submit a response → confirm the value lands in the chosen column.
- [ ] Manual: CSV / XLSX export from the survey responses page includes `person.<key>` columns.

## Out of scope

- Column ordering — currently "first response that introduces each key wins" for CSV; integration order is preserved from `Object.entries(contactAttributes)`. Alphabetize if anyone asks.
- Deduplicating `person.userId` against the existing "User ID" column — harmless redundancy.
- Pre-rendering all known workspace attribute keys (even when the current response slice doesn't carry them). Current behavior is data-driven, keeps exports compact.