### PR TITLE
fix: S3 internal server error for older images

### DIFF
--- a/packages/storage/src/service.test.ts
+++ b/packages/storage/src/service.test.ts
@@ -565,6 +565,55 @@ describe("service.ts", () => {
       }
     });
 
+    test("returns file not found when S3 reports NotFound", async () => {
+      vi.doMock("./constants", () => mockConstants);
+
+      const notFoundError = new Error("not found");
+      notFoundError.name = "NotFound";
+      const mockS3Client = {
+        send: vi.fn().mockRejectedValueOnce(notFoundError),
+      };
+
+      vi.doMock("./client", () => ({
+        createS3Client: vi.fn(() => mockS3Client),
+      }));
+
+      const { getFileStream } = await import("./service");
+
+      const result = await getFileStream("responses/missing.pdf");
+
+      expect(result.ok).toBe(false);
+
+      if (!result.ok) {
+        expect(result.error.code).toBe("file_not_found_error");
+      }
+    });
+
+    test("returns file not found when S3 error carries a 404 status code", async () => {
+      vi.doMock("./constants", () => mockConstants);
+
+      const s3Error = Object.assign(new Error("not found"), {
+        $metadata: { httpStatusCode: 404 },
+      });
+      const mockS3Client = {
+        send: vi.fn().mockRejectedValueOnce(s3Error),
+      };
+
+      vi.doMock("./client", () => ({
+        createS3Client: vi.fn(() => mockS3Client),
+      }));
+
+      const { getFileStream } = await import("./service");
+
+      const result = await getFileStream("responses/missing.pdf");
+
+      expect(result.ok).toBe(false);
+
+      if (!result.ok) {
+        expect(result.error.code).toBe("file_not_found_error");
+      }
+    });
+
     test("logs and returns unknown when streaming fails unexpectedly", async () => {
       vi.doMock("./constants", () => mockConstants);
 

--- a/packages/storage/src/service.ts
+++ b/packages/storage/src/service.ts
@@ -191,7 +191,9 @@ export const getFileStream = async (fileKey: string): Promise<Result<FileStreamR
       contentLength: response.ContentLength ?? 0,
     });
   } catch (error) {
-    if ((error as { name?: string }).name === "NoSuchKey") {
+    const errName = (error as { name?: string }).name;
+    const httpStatusCode = (error as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode;
+    if (errName === "NoSuchKey" || errName === "NotFound" || httpStatusCode === 404) {
       return err({
         code: StorageErrorCode.FileNotFoundError,
       });


### PR DESCRIPTION
## What

  Fix legacy (environmentId-prefixed) storage files returning `500` instead of falling back to the legacy S3 key.
Fixes https://linear.app/formbricks/issue/ENG-1118/downloading-response-files-returns-internal-server-error

  ## Why

  After the `environmentId` → `workspaceId` migration (v5), old uploads still live under the legacy `environmentId/...` S3
  key. The storage route resolves the URL ID to the current `workspaceId`, requests `workspaceId/...` first, and is meant to
  fall back to the legacy key on a miss.

  That fallback in `getFileStreamForDownload` only fires when the primary lookup returns `FileNotFoundError`:

  ```ts
  if (!streamResult.ok && streamResult.error.code === StorageErrorCode.FileNotFoundError && fallbackId) {
    // retry legacy key
  }
```

  But getFileStream's catch only mapped name === "NoSuchKey" to FileNotFoundError. The actual S3 404 here arrives as
  NotFound / $metadata.httpStatusCode === 404, so it fell through to StorageErrorCode.Unknown. Result: the fallback never
  ran, and the route returned internal_server_error (500) for every legacy image.

  The sibling getSignedDownloadUrl already detected 404 correctly — getFileStream was the only path with the gap.

## Change
Broaden 404 detection in getFileStream (packages/storage/src/service.ts) to also match NotFound and $metadata.httpStatusCode === 404, mirroring getSignedDownloadUrl. The S3 404 now maps to FileNotFoundError, so the existing fallback retries the legacy environmentId key where the object actually lives.

## Tests
Added two getFileStream cases — NotFound error name and a $metadata.httpStatusCode === 404 error