### PR TITLE
fix: S3 internal server error for older images (backport to release/5.0)

### DIFF
--- a/packages/storage/src/service.ts
+++ b/packages/storage/src/service.ts
@@ -191,7 +191,9 @@ export const getFileStream = async (fileKey: string): Promise<Result<FileStreamR
       contentLength: response.ContentLength ?? 0,
     });
   } catch (error) {
-    if ((error as { name?: string }).name === "NoSuchKey") {
+    const errName = (error as { name?: string }).name;
+    const httpStatusCode = (error as { $metadata?: { httpStatusCode?: number } }).$metadata?.httpStatusCode;
+    if (errName === "NoSuchKey" || errName === "NotFound" || httpStatusCode === 404) {
       return err({
         code: StorageErrorCode.FileNotFoundError,
       });


### PR DESCRIPTION
Backports #8195 to \`release/5.0\` (commit \`6a7f56188\`). Production hunk only — test additions deliberately omitted per backport policy.

## Why this matters on 5.0

Legacy files (uploaded under the \`environmentId/...\` S3 key before the workspace migration) were returning \`internal_server_error\` 500 in production. Root cause: AWS SDK v3 raises \`NotFound\` (and/or \`\$metadata.httpStatusCode === 404\`) for missing keys in some configurations, not \`NoSuchKey\`. \`getFileStream\` only mapped \`NoSuchKey\` to \`FileNotFoundError\`, so the actual 404 fell through to \`StorageErrorCode.Unknown\`, the fallback in \`getFileStreamForDownload\` never fired, and the route returned 500.

The fix broadens 404 detection so the existing legacy-key fallback works for these files.

## Diff

One file, one block:

\`\`\`diff
   } catch (error) {
-    if ((error as { name?: string }).name === \"NoSuchKey\") {
+    const errName = (error as { name?: string }).name;
+    const httpStatusCode = (error as { \$metadata?: { httpStatusCode?: number } }).\$metadata?.httpStatusCode;
+    if (errName === \"NoSuchKey\" || errName === \"NotFound\" || httpStatusCode === 404) {
       return err({
         code: StorageErrorCode.FileNotFoundError,
       });
\`\`\`

## Test plan

- Tests on the source PR (#8195) cover \`name === \"NotFound\"\` and \`\$metadata.httpStatusCode === 404\`; they're omitted from this backport per policy but the underlying behavior is unchanged.
- Manual: open a legacy file URL of the shape \`/storage/<envId>/private/<filename>.pdf\` on a 5.0 prod-shaped environment and confirm the response is the file content, not a 500.