### PR TITLE
fix: point Connect Your App "Learn more" to the correct docs URL (ENG-1136)

### DIFF
--- a/apps/web/modules/workspaces/settings/(setup)/app-connection/page.tsx
+++ b/apps/web/modules/workspaces/settings/(setup)/app-connection/page.tsx
@@ -14,8 +14,7 @@ import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
 export const AppConnectionPage = async ({ params }: { params: Promise<{ workspaceId: string }> }) => {
   const t = await getTranslate();
   const { workspaceId } = await params;
-  const frameworkGuidesUrl =
-    "https://formbricks.com/docs/xm-and-surveys/surveys/website-app-surveys/framework-guides";
+  const frameworkGuidesUrl = "https://formbricks.com/docs/surveys/website-app-surveys/framework-guides";
   const workspaceIdMigrationUrl =
     "https://formbricks.com/docs/surveys/website-app-surveys/workspace-id-migration";
 


### PR DESCRIPTION
## Summary
- The "Learn more" button on Settings → Connect Your App pointed at a stale `/docs/xm-and-surveys/...` path. The docs site's redirect rule for that source no longer resolves cleanly — visitors land on the docs home (`/docs/platform/introduction`) instead of the framework guides.
- Updated `frameworkGuidesUrl` to the canonical path: `https://formbricks.com/docs/surveys/website-app-surveys/framework-guides` (returns 200, matches the redirect destination already defined in `docs/docs.json`).

Closes ENG-1136

## Out of scope (flagged for follow-up)
A wider grep shows ~25 other `/docs/xm-and-surveys/...` URLs across `apps/web` (integrations page, enterprise feature table, etc.) that may have the same problem. Not fixing them here to keep this PR focused on the reported bug — happy to open a follow-up sweep.

## Test plan
- [ ] Open Settings → Connect Your App on an unconnected workspace
- [ ] Click "Learn more" in the info alert
- [ ] Confirm the new tab lands on the website/app surveys framework guides page (not docs home)

🤖 Generated with [Claude Code](https://claude.com/claude-code)