### PR TITLE
fix: let self-host boot without CUBEJS_API_* and HUB_API_* (ENG-1064)

### DIFF
--- a/apps/web/lib/env.test.ts
+++ b/apps/web/lib/env.test.ts
@@ -129,45 +129,49 @@ describe("env", () => {
     expect(env.CUBEJS_JWT_ISSUER).toBe("formbricks-web");
   });
 
-  test("fails to load when the Cube API secret is missing", async () => {
-    setTestEnv({
-      CUBEJS_API_SECRET: undefined,
-    });
-
-    await expect(import("./env")).rejects.toThrow("Invalid environment variables");
+  test("falls back to the Cube API secret placeholder when missing", async () => {
+    setTestEnv({ CUBEJS_API_SECRET: undefined });
+    const { env } = await import("./env");
+    expect(env.CUBEJS_API_SECRET).toBe("cubejs-not-configured");
   });
 
-  test("fails to load when the Cube API secret is empty", async () => {
-    setTestEnv({
-      CUBEJS_API_SECRET: "",
-    });
-
-    await expect(import("./env")).rejects.toThrow("Invalid environment variables");
+  test("falls back to the Cube API secret placeholder when empty", async () => {
+    setTestEnv({ CUBEJS_API_SECRET: "" });
+    const { env } = await import("./env");
+    expect(env.CUBEJS_API_SECRET).toBe("cubejs-not-configured");
   });
 
-  test("fails to load when the Cube API URL is missing", async () => {
-    setTestEnv({
-      CUBEJS_API_URL: undefined,
-    });
-
-    await expect(import("./env")).rejects.toThrow("Invalid environment variables");
+  test("falls back to the Cube API URL placeholder when missing", async () => {
+    setTestEnv({ CUBEJS_API_URL: undefined });
+    const { env } = await import("./env");
+    expect(env.CUBEJS_API_URL).toBe("http://cubejs-not-configured.invalid");
   });
 
-  test("fails to load when the Cube API URL is empty", async () => {
-    setTestEnv({
-      CUBEJS_API_URL: "",
-    });
-
-    await expect(import("./env")).rejects.toThrow("Invalid environment variables");
+  test("falls back to the Cube API URL placeholder when empty", async () => {
+    setTestEnv({ CUBEJS_API_URL: "" });
+    const { env } = await import("./env");
+    expect(env.CUBEJS_API_URL).toBe("http://cubejs-not-configured.invalid");
   });
 
-  test("fails to load when the Cube API URL is invalid", async () => {
+  test("fails to load when the Cube API URL is malformed", async () => {
     setTestEnv({
       CUBEJS_API_URL: "not-a-url",
       CUBEJS_API_SECRET: "cube-secret",
     });
 
     await expect(import("./env")).rejects.toThrow("Invalid environment variables");
+  });
+
+  test("leaves HUB_API_KEY undefined when missing or empty so callers can gate on it", async () => {
+    setTestEnv({ HUB_API_KEY: "" });
+    const { env } = await import("./env");
+    expect(env.HUB_API_KEY).toBeUndefined();
+  });
+
+  test("falls back to the Hub API URL placeholder when missing", async () => {
+    setTestEnv({ HUB_API_URL: undefined });
+    const { env } = await import("./env");
+    expect(env.HUB_API_URL).toBe("http://hub-not-configured.invalid");
   });
 
   test("uses the default survey scheduling configuration when env vars are not set", async () => {

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -190,14 +190,27 @@ const parsedEnv = createEnv({
     AI_AZURE_API_KEY: z.string().optional(),
     AI_AZURE_API_VERSION: z.string().optional(),
     AI_AZURE_RESOURCE_NAME: z.string().optional(),
-    CUBEJS_API_SECRET: z.string().trim().min(1),
-    CUBEJS_API_URL: z.url(),
+    // CUBEJS_* and HUB_API_* point at Cloud-only services (the EE analysis
+    // module and the Formbricks Hub respectively). Self-hosted installs that
+    // don't enable analysis or ship telemetry must still boot, so we fall back
+    // to sentinel placeholders. Hub callers gate on HUB_API_KEY being set,
+    // making the URL placeholder unreachable; Cube callers use the values
+    // directly and will fail loudly at the network call if invoked without
+    // real config. Malformed non-empty values still reject at boot.
+    CUBEJS_API_SECRET: z.preprocess(
+      emptyStringToUndefined,
+      z.string().trim().min(1).default("cubejs-not-configured")
+    ),
+    CUBEJS_API_URL: z.preprocess(
+      emptyStringToUndefined,
+      z.url().default("http://cubejs-not-configured.invalid")
+    ),
     CUBEJS_JWT_AUDIENCE: ZOptionalNonEmptyString,
     CUBEJS_JWT_ISSUER: ZOptionalNonEmptyString,
     HTTP_PROXY: z.url().optional(),
     HTTPS_PROXY: z.url().optional(),
-    HUB_API_URL: z.url(),
-    HUB_API_KEY: z.string().trim().min(1),
+    HUB_API_URL: z.preprocess(emptyStringToUndefined, z.url().default("http://hub-not-configured.invalid")),
+    HUB_API_KEY: ZOptionalNonEmptyString,
     IMPRINT_URL: z
       .url()
       .optional()

--- a/apps/web/modules/ee/analysis/api/lib/cube-config.test.ts
+++ b/apps/web/modules/ee/analysis/api/lib/cube-config.test.ts
@@ -97,27 +97,30 @@ describe("cube-config", () => {
     expect(getCubeApiCredentials().apiUrl).toBe("https://cube.formbricks.local/cubejs-api/v1");
   });
 
-  test("fails at env validation when CUBEJS_API_URL is missing", async () => {
+  test("falls back to the Cube API URL placeholder when missing so self-host can boot", async () => {
     setTestEnv({
       CUBEJS_API_URL: undefined,
     });
 
-    await expect(import("./cube-config")).rejects.toThrow("Invalid environment variables");
+    const { getCubeApiCredentials } = await import("./cube-config");
+    expect(getCubeApiCredentials().apiUrl).toBe("http://cubejs-not-configured.invalid/cubejs-api/v1");
   });
 
-  test("fails at env validation when CUBEJS_API_SECRET is missing", async () => {
+  test("falls back to the Cube API secret placeholder when missing so self-host can boot", async () => {
     setTestEnv({
       CUBEJS_API_SECRET: undefined,
     });
 
-    await expect(import("./cube-config")).rejects.toThrow("Invalid environment variables");
+    const { getCubeApiCredentials } = await import("./cube-config");
+    expect(getCubeApiCredentials().apiSecret).toBe("cubejs-not-configured");
   });
 
-  test("fails at env validation when CUBEJS_API_SECRET is an empty string", async () => {
+  test("falls back to the Cube API secret placeholder when set to an empty string", async () => {
     setTestEnv({
       CUBEJS_API_SECRET: "",
     });
 
-    await expect(import("./cube-config")).rejects.toThrow("Invalid environment variables");
+    const { getCubeApiCredentials } = await import("./cube-config");
+    expect(getCubeApiCredentials().apiSecret).toBe("cubejs-not-configured");
   });
 });


### PR DESCRIPTION
## Summary
Closes [ENG-1064](https://linear.app/formbricks/issue/ENG-1064). Self-hosted installs that don't enable the EE analysis module and don't ship telemetry to the Formbricks Hub still had to set all four of `CUBEJS_API_SECRET`, `CUBEJS_API_URL`, `HUB_API_URL`, `HUB_API_KEY` to some non-empty value to get past `createEnv` at boot. They were declared as required-non-empty in `apps/web/lib/env.ts:193-200` with no default.

## Fix
Each of the four vars is now wrapped in `z.preprocess(emptyStringToUndefined, ...)` so unset and empty both fall through. Then:

| Var | New shape | Why |
|---|---|---|
| `HUB_API_KEY` | `ZOptionalNonEmptyString` (`string \| undefined`) | `getHubClient` already does `if (!apiKey) return null;` — keeping the type optional preserves that kill-switch |
| `HUB_API_URL` | `z.url().default("http://hub-not-configured.invalid")` | Only read after the `HUB_API_KEY` gate, so the value is unreachable on unconfigured installs |
| `CUBEJS_API_URL` | `z.url().default("http://cubejs-not-configured.invalid")` | Consumer (`cube-config.ts`) uses it directly. A misconfigured install fails loudly at the network call instead of silently at boot |
| `CUBEJS_API_SECRET` | `z.string().trim().min(1).default("cubejs-not-configured")` | Same reasoning |

Malformed non-empty values (e.g. `CUBEJS_API_URL=not-a-url`) still reject at boot because `z.url()` runs after the preprocess.

## Files
- `apps/web/lib/env.ts` — the four schema entries
- `apps/web/lib/env.test.ts` — replaced the four \"fails to load when missing/empty\" tests with their new fallback equivalents; kept the \"fails when malformed\" test
- `apps/web/modules/ee/analysis/api/lib/cube-config.test.ts` — same: three boot-failure tests → three fallback tests asserting `getCubeApiCredentials()` returns the placeholder

33/33 tests pass in the three affected files.

## Test plan
- [ ] Self-host: clone, unset all `CUBEJS_*` and `HUB_API_*` in `.env`, `pnpm dev` — should boot
- [ ] Self-host with `HUB_API_KEY` set but `HUB_API_URL` unset: `getHubClient()` returns a client pointing at the sentinel URL; Hub calls fail clearly (regression check)
- [ ] Cloud: set all four to real values — behaves identically to before
- [ ] Set `CUBEJS_API_URL=not-a-url` — boot still fails with a validation error (regression check)