### PR TITLE
fix: color picker fills container in logo background-color toggle (ENG-977)

### DIFF
--- a/apps/web/modules/survey/editor/components/logo-settings-card.tsx
+++ b/apps/web/modules/survey/editor/components/logo-settings-card.tsx
@@ -231,7 +231,7 @@ export const LogoSettingsCard = ({
                     childrenContainerClass="overflow-visible"
                     disabled={disabled}>
                     {isBgColorEnabled && (
-                      <div className="px-2">
+                      <div className="w-full p-2">
                         <ColorPicker
                           color={logoBgColor || "#f8f8f8"}
                           onChange={handleBgColorChange}

--- a/apps/web/modules/workspaces/settings/look/components/edit-logo.tsx
+++ b/apps/web/modules/workspaces/settings/look/components/edit-logo.tsx
@@ -206,7 +206,7 @@ export const EditLogo = ({ workspace, workspaceId, isReadOnly, isStorageConfigur
               childrenContainerClass="overflow-visible"
               disabled={!isEditing}>
               {isBgColorEnabled && (
-                <div className="px-2">
+                <div className="w-full p-2">
                   <ColorPicker
                     color={logoBgColor || "#f8f8f8"}
                     onChange={setLogoBgColor}


### PR DESCRIPTION
## Summary
- Resolves [ENG-977](https://linear.app/formbricks/issue/ENG-977/broken-ui-in-look-and-feel-settings) — broken UI on the workspace **Look & Feel → Logo** settings.
- The "Add background color" toggle's child container is a `flex w-full items-center` row. The color-picker wrapper inside it had only `px-2` with no width, so it shrunk to the picker's intrinsic content width and the rest of the row stayed empty — making the layout look broken.
- Fix: give the wrapper `w-full` so the `ColorPicker` (which uses `w-full` internally) actually fills the available space, and use `p-2` for symmetric inset.
- Same broken pattern existed in `apps/web/modules/survey/editor/components/logo-settings-card.tsx` (survey editor → logo settings), fixed for consistency.

<img width="955" height="224" alt="Screenshot 2026-06-01 at 3 52 03 PM" src="https://github.com/user-attachments/assets/fde66e68-353b-46b0-b791-2b6f8613bc15" />


## Test plan
- [ ] Open **Workspace → Look & Feel → Logo**, upload a logo, click **Edit**, toggle **Add background color** on — verify the color picker now fills the gray container (no empty area on the right).
- [ ] Verify the same in **Survey editor → Survey logo settings** when toggling **Add background color**.
- [ ] Confirm the color picker still works (hex input + popover swatch).
- [ ] Confirm the toggle's disabled state still styles correctly.

> Note: applied as a CSS-class change diagnosed from the flex layout in `AdvancedOptionToggle`. I wasn't able to visually verify in a browser from this environment — please screenshot before/after when reviewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)