### PR TITLE
refactor(survey-ui): strip inline styles for CSP compatibility

### DIFF
--- a/packages/survey-ui/src/components/elements/consent.tsx
+++ b/packages/survey-ui/src/components/elements/consent.tsx
@@ -92,10 +92,8 @@ function Consent({
             disabled={disabled}
             aria-invalid={Boolean(errorMessage)}
           />
-          {/* need to use style here because tailwind is not able to use css variables for font size and weight */}
           <span
-            className="font-input-weight text-input-text flex-1"
-            style={{ fontSize: "var(--fb-input-font-size)" }}
+            className="font-input-weight text-input-text flex-1 [font-size:var(--fb-input-font-size)]"
             dir={dir}>
             {checkboxLabel}
           </span>

--- a/packages/survey-ui/src/components/elements/file-upload.tsx
+++ b/packages/survey-ui/src/components/elements/file-upload.tsx
@@ -96,8 +96,7 @@ function UploadedFileItem({
       <div className="flex flex-col items-center justify-center p-2">
         <UploadIcon />
         <p
-          style={{ fontSize: "var(--fb-input-font-size)" }}
-          className="mt-1 w-full overflow-hidden px-2 text-center overflow-ellipsis whitespace-nowrap text-[var(--foreground)]"
+          className="mt-1 w-full overflow-hidden px-2 text-center [font-size:var(--fb-input-font-size)] text-ellipsis whitespace-nowrap text-(--foreground)"
           title={file.name}>
           {file.name}
         </p>
@@ -189,8 +188,7 @@ function UploadArea({
         aria-label="Upload files by clicking or dragging them here">
         <Upload className="text-input-text h-6" aria-hidden="true" />
         <span
-          className="text-input-text font-input-weight m-2"
-          style={{ fontSize: "var(--fb-input-font-size)" }}
+          className="text-input-text font-input-weight m-2 [font-size:var(--fb-input-font-size)]"
           id={`${inputId}-label`}>
           {placeholderText}
         </span>
@@ -306,9 +304,7 @@ function FileUpload({
           <div className="w-full">
             {isUploading ? (
               <div className="flex animate-pulse items-center justify-center rounded-lg py-4">
-                <p
-                  className="text-muted-foreground font-medium"
-                  style={{ fontSize: "var(--fb-input-font-size)" }}>
+                <p className="text-muted-foreground [font-size:var(--fb-input-font-size)] font-medium">
                   {uploadingText}
                 </p>
               </div>

--- a/packages/survey-ui/src/components/general/element-media.tsx
+++ b/packages/survey-ui/src/components/general/element-media.tsx
@@ -56,8 +56,7 @@ function ElementMedia({ imgUrl, videoUrl, altText = "Image" }: Readonly<ElementM
             <iframe
               src={videoUrlWithParams}
               title="Question video"
-              style={{ border: 0 }}
-              className={cn("aspect-video w-full rounded-md", isLoading ? "opacity-0" : "")}
+              className={cn("aspect-video w-full rounded-md border-0", isLoading ? "opacity-0" : "")}
               onLoad={() => {
                 setIsLoading(false);
               }}

--- a/packages/survey-ui/src/components/general/input.tsx
+++ b/packages/survey-ui/src/components/general/input.tsx
@@ -19,7 +19,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(function Input(
         type={type}
         dir={dir}
         data-slot="input"
-        style={{ fontSize: "var(--fb-input-font-size)" }}
         className={cn(
           // Layout and behavior
           "flex min-w-0 border transition-[color,box-shadow] outline-none",
@@ -27,7 +26,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(function Input(
           "w-input min-h-[var(--fb-input-height)]",
           "bg-input-bg border-input-border rounded-input",
           "font-input font-input-weight",
-          "text-input-text",
+          "text-input-text [font-size:var(--fb-input-font-size)]",
           "px-input-x py-input-y",
           "shadow-input",
           // Placeholder styling

--- a/packages/survey-ui/src/components/general/progress.tsx
+++ b/packages/survey-ui/src/components/general/progress.tsx
@@ -26,7 +26,7 @@ function Progress({ className, value, ...props }: Readonly<ProgressProps>): Reac
       <ProgressPrimitive.Indicator
         ref={indicatorRef}
         data-slot="progress-indicator"
-        className="progress-indicator h-full w-full flex-1 translate-x-(--fb-progress-translate-x,-100%) transition-all"
+        className="progress-indicator h-full w-full flex-1 translate-x-(--fb-progress-translate-x) transition-all"
       />
     </ProgressPrimitive.Root>
   );

--- a/packages/survey-ui/src/components/general/progress.tsx
+++ b/packages/survey-ui/src/components/general/progress.tsx
@@ -8,6 +8,15 @@ export interface ProgressProps extends Omit<React.ComponentProps<"div">, "childr
 
 function Progress({ className, value, ...props }: Readonly<ProgressProps>): React.JSX.Element {
   const progressValue: number = typeof value === "number" ? value : 0;
+  const indicatorRef = React.useRef<HTMLDivElement>(null);
+
+  // Setting the translate value via setProperty (CSSOM) rather than the
+  // `style` JSX prop keeps the HTML free of inline `style="..."` attributes,
+  // which the strictest Content Security Policies disallow.
+  React.useLayoutEffect(() => {
+    indicatorRef.current?.style.setProperty("--fb-progress-translate-x", `-${String(100 - progressValue)}%`);
+  }, [progressValue]);
+
   return (
     <ProgressPrimitive.Root
       data-slot="progress"
@@ -15,11 +24,9 @@ function Progress({ className, value, ...props }: Readonly<ProgressProps>): Reac
       className={cn("progress-track relative w-full overflow-hidden", className)}
       {...props}>
       <ProgressPrimitive.Indicator
+        ref={indicatorRef}
         data-slot="progress-indicator"
-        className="progress-indicator h-full w-full flex-1 transition-all"
-        style={{
-          transform: `translateX(-${String(100 - progressValue)}%)`,
-        }}
+        className="progress-indicator h-full w-full flex-1 translate-x-(--fb-progress-translate-x,-100%) transition-all"
       />
     </ProgressPrimitive.Root>
   );

--- a/packages/survey-ui/src/components/general/textarea.tsx
+++ b/packages/survey-ui/src/components/general/textarea.tsx
@@ -10,10 +10,9 @@ function Textarea({ className, dir = "auto", ...props }: TextareaProps): React.J
     <div className="relative space-y-2">
       <textarea
         data-slot="textarea"
-        style={{ fontSize: "var(--fb-input-font-size)" }}
         dir={dir}
         className={cn(
-          "w-input bg-input-bg border-input-border rounded-input font-input font-input-weight px-input-x py-input-y shadow-input placeholder:text-input-placeholder placeholder:opacity-input-placeholder focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive text-input text-input-text flex field-sizing-content min-h-16 border transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+          "w-input bg-input-bg border-input-border rounded-input font-input font-input-weight px-input-x py-input-y shadow-input placeholder:text-input-placeholder placeholder:opacity-input-placeholder focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 aria-invalid:border-destructive text-input-text flex field-sizing-content min-h-16 border [font-size:var(--fb-input-font-size)] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         {...props}

--- a/packages/survey-ui/src/styles/globals.css
+++ b/packages/survey-ui/src/styles/globals.css
@@ -213,6 +213,7 @@
 }
 
 #fbjs .progress-indicator {
+  --fb-progress-translate-x: -100%;
   background-color: var(--fb-progress-indicator-bg-color);
   border-radius: var(--fb-progress-indicator-border-radius);
 }


### PR DESCRIPTION
Closes [ENG-1078 — Strip inline CSS from survey-ui package](https://linear.app/formbricks/issue/ENG-1078/strip-inline-css-from-survey-ui-package)

## Summary

Strict Content Security Policies disallow inline `style="..."` attributes on rendered HTML. This PR removes every inline style prop from the `@formbricks/survey-ui` components and re-expresses them as Tailwind arbitrary-value classes (or, for the one dynamic case, as a CSS variable set via the CSSOM so the inline attribute never lands in the DOM).

No visual changes are intended — every replacement preserves the same computed style.

## Changes

- **`general/input.tsx`** — `style={{ fontSize: var(--fb-input-font-size) }}` → `[font-size:var(--fb-input-font-size)]`
- **`general/textarea.tsx`** — same swap as input
- **`general/element-media.tsx`** — `style={{ border: 0 }}` on the YouTube/Vimeo iframe → `border-0`
- **`general/progress.tsx`** — translate is now set via `setProperty("--fb-progress-translate-x", ...)` in a `useLayoutEffect`, and the indicator reads it with `translate-x-(--fb-progress-translate-x,-100%)`. This keeps the rendered HTML free of an inline `style` attribute while still allowing per-instance dynamic values.
- **`elements/consent.tsx`** — checkbox label font-size moved to arbitrary class
- **`elements/file-upload.tsx`** — three sites updated (uploaded-file name, upload-area placeholder, "uploading…" text); also normalises `overflow-ellipsis` → `text-ellipsis` and `text-[var(--foreground)]` → `text-(--foreground)` (Tailwind v4 syntax)

## Follow-up

Radix primitives (Popover, DropdownMenu, etc.) still emit inline `style` attributes from inside their own implementation and aren't covered here. Tracked in [ENG-1141 — Migrate Radix Popover and DropdownMenu to CSP-safe alternatives](https://linear.app/formbricks/issue/ENG-1141/migrate-radix-popover-and-dropdownmenu-to-csp-safe-alternatives-follow).

## Test plan

- [ ] Survey preview with custom look-and-feel font size renders at the configured size for: text input, textarea, consent checkbox label, file-upload placeholder, uploaded file name, "uploading…" text
- [ ] Long filename in file-upload truncates with an ellipsis and stays single-line
- [ ] Video question embed (YouTube / Vimeo) shows no visible iframe border
- [ ] Progress bar
  - [ ] Initial render shows correct fill (no flash of 0% or -100%)
  - [ ] Animates between question transitions
  - [ ] Renders correctly at 0% and 100% edges
- [ ] DOM inspector confirms no `style="..."` attributes on any of the touched elements
- [ ] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)