### PR TITLE
fix(ai-translation): use structured output to stop empty-translation responses

### DIFF
--- a/apps/web/lib/ai/service.ts
+++ b/apps/web/lib/ai/service.ts
@@ -1,5 +1,12 @@
 import "server-only";
-import { AIConfigurationError, generateText, isAiConfigured } from "@formbricks/ai";
+import {
+  AIConfigurationError,
+  type TGenerateObjectOptions,
+  type TGenerateObjectResult,
+  generateObject,
+  generateText,
+  isAiConfigured,
+} from "@formbricks/ai";
 import { logger } from "@formbricks/logger";
 import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { env } from "@/lib/env";
@@ -92,6 +99,32 @@ export const generateOrganizationAIText = async ({
         err: error,
       },
       "Failed to generate organization AI text"
+    );
+    throw error;
+  }
+};
+
+type TGenerateOrganizationAIObjectInput<T> = {
+  organizationId: string;
+} & TGenerateObjectOptions<T>;
+
+export const generateOrganizationAIObject = async <T>({
+  organizationId,
+  ...options
+}: TGenerateOrganizationAIObjectInput<T>): Promise<TGenerateObjectResult<T>> => {
+  const aiConfig = await assertOrganizationAIConfigured(organizationId);
+
+  try {
+    return await generateObject<T>(options, env);
+  } catch (error) {
+    logger.error(
+      {
+        organizationId,
+        isInstanceConfigured: aiConfig.isInstanceConfigured,
+        errorCode: error instanceof AIConfigurationError ? error.code : undefined,
+        err: error,
+      },
+      "Failed to generate organization AI object"
     );
     throw error;
   }

--- a/apps/web/modules/ee/ai-translation/lib/translate-fields.test.ts
+++ b/apps/web/modules/ee/ai-translation/lib/translate-fields.test.ts
@@ -3,9 +3,9 @@ import { type TAITranslationField, translateFields } from "./translate-fields";
 
 vi.mock("server-only", () => ({}));
 
-const mockGenerateOrganizationAIText = vi.fn();
+const mockGenerateOrganizationAIObject = vi.fn();
 vi.mock("@/lib/ai/service", () => ({
-  generateOrganizationAIText: (...args: unknown[]) => mockGenerateOrganizationAIText(...args),
+  generateOrganizationAIObject: (...args: unknown[]) => mockGenerateOrganizationAIObject(...args),
 }));
 
 const baseInput = {
@@ -24,47 +24,48 @@ describe("translateFields", () => {
     vi.clearAllMocks();
   });
 
-  test("returns translated fields from clean JSON response", async () => {
-    mockGenerateOrganizationAIText.mockResolvedValue({
-      text: JSON.stringify({ headline: "Willkommen", description: "<p>Hallo</p>" }),
+  test("returns translated fields from structured response", async () => {
+    mockGenerateOrganizationAIObject.mockResolvedValue({
+      object: { translations: { headline: "Willkommen", description: "<p>Hallo</p>" } },
     });
 
     const result = await translateFields({ ...baseInput, fields });
     expect(result).toEqual({ headline: "Willkommen", description: "<p>Hallo</p>" });
   });
 
-  test("strips markdown code fences", async () => {
-    mockGenerateOrganizationAIText.mockResolvedValue({
-      text: '```json\n{"headline": "Willkommen"}\n```',
+  test("filters out unrequested keys", async () => {
+    mockGenerateOrganizationAIObject.mockResolvedValue({
+      object: { translations: { headline: "Willkommen", extra: "Nein" } },
     });
 
     const result = await translateFields({ ...baseInput, fields });
     expect(result).toEqual({ headline: "Willkommen" });
   });
 
-  test("extracts JSON from wrapper text", async () => {
-    mockGenerateOrganizationAIText.mockResolvedValue({
-      text: 'Here is the translation:\n{"headline": "Willkommen"}\nHope this helps!',
+  test("throws when no key matches the requested fields", async () => {
+    mockGenerateOrganizationAIObject.mockResolvedValue({
+      object: { translations: { unrelatedKey: "Etwas" } },
     });
-
-    const result = await translateFields({ ...baseInput, fields });
-    expect(result).toEqual({ headline: "Willkommen" });
-  });
-
-  test("filters out unrequested keys and non-string values", async () => {
-    mockGenerateOrganizationAIText.mockResolvedValue({
-      text: JSON.stringify({ headline: "Willkommen", extra: "Nein", description: 42 }),
-    });
-
-    const result = await translateFields({ ...baseInput, fields });
-    expect(result).toEqual({ headline: "Willkommen" });
-  });
-
-  test("throws on unparseable response", async () => {
-    mockGenerateOrganizationAIText.mockResolvedValue({ text: "not json at all" });
 
     await expect(translateFields({ ...baseInput, fields })).rejects.toThrow(
-      "Failed to parse AI translation response"
+      "AI translation response had no usable translations"
     );
+  });
+
+  test("passes a schema and explicit prompt to the AI helper", async () => {
+    mockGenerateOrganizationAIObject.mockResolvedValue({
+      object: { translations: { headline: "Willkommen" } },
+    });
+
+    await translateFields({ ...baseInput, fields });
+
+    const call = mockGenerateOrganizationAIObject.mock.calls[0][0];
+    expect(call.organizationId).toBe("org-1");
+    expect(call.schema).toBeDefined();
+    expect(call.system).toContain("EXACTLY");
+    expect(call.system).toContain("translations");
+    // Each input item's path must be in the serialized prompt.
+    expect(call.prompt).toContain('"key":"headline"');
+    expect(call.prompt).toContain('"key":"description"');
   });
 });

--- a/apps/web/modules/ee/ai-translation/lib/translate-fields.ts
+++ b/apps/web/modules/ee/ai-translation/lib/translate-fields.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { z } from "zod";
 import { logger } from "@formbricks/logger";
-import { generateOrganizationAIText } from "@/lib/ai/service";
+import { generateOrganizationAIObject } from "@/lib/ai/service";
 
 export const ZAITranslationField = z.object({
   path: z.string(),
@@ -18,6 +18,11 @@ interface TranslateFieldsInput {
   targetLanguage: string;
 }
 
+const ZTranslationResponse = z.object({
+  translations: z.record(z.string(), z.string()),
+});
+type TTranslationResponse = z.infer<typeof ZTranslationResponse>;
+
 export const translateFields = async ({
   organizationId,
   fields,
@@ -33,48 +38,36 @@ export const translateFields = async ({
   const systemPrompt = `You are a professional translator for survey content. Translate the provided survey fields from ${sourceLanguage} to ${targetLanguage}.
 
 Rules:
-- Return ONLY a valid JSON object mapping each "key" to its translated text.
-- For rich text fields (richText: true), preserve all HTML tags exactly as they are. Only translate the text content within the tags.
-- Preserve any {{variable}} patterns exactly as they are — do not translate text inside double curly braces.
-- Do not add any explanation, markdown formatting, or extra text — return raw JSON only.`;
+- The response MUST be an object of the form { "translations": { <key>: <translated text>, ... } }.
+- Use the "key" field from each input item EXACTLY as the key in the translations object. Do not modify, escape, nest, or rewrite the key in any way — keys like "blocks.0.elements.0.headline" must appear verbatim, NOT as nested objects.
+- Include one entry per input item; do not invent, drop, or merge keys.
+- For rich text fields (richText: true), preserve all HTML tags exactly. Only translate the text content within the tags.
+- Preserve any {{variable}} patterns exactly — never translate text inside double curly braces.`;
 
-  const result = await generateOrganizationAIText({
+  const { object } = await generateOrganizationAIObject<TTranslationResponse>({
     organizationId,
+    schema: ZTranslationResponse,
     system: systemPrompt,
     prompt: JSON.stringify(items),
   });
 
-  // Parse AI response as JSON.
-  // 1. Strip markdown code fences if present, then try JSON.parse directly.
-  // 2. Fall back to extracting the first {...} block for wrapper text.
-  let parsed: Record<string, string>;
-  try {
-    const stripped = result.text.replaceAll(/^```(?:json)?\s*\n?|\n?```\s*$/g, "").trim();
-    try {
-      parsed = JSON.parse(stripped);
-    } catch {
-      const start = stripped.indexOf("{");
-      const end = stripped.lastIndexOf("}");
-      if (start === -1 || end === -1 || end <= start) {
-        throw new Error("No JSON object found in AI response");
-      }
-      parsed = JSON.parse(stripped.slice(start, end + 1));
-    }
-  } catch (parseError) {
-    logger.error(
-      { rawResponse: result.text.slice(0, 500), parseError },
-      "Failed to parse AI translation response"
-    );
-    throw new Error("Failed to parse AI translation response");
-  }
-
-  // Validate and filter to only requested keys
   const validKeys = new Set(fields.map((f) => f.path));
   const translations: Record<string, string> = {};
-  for (const [key, value] of Object.entries(parsed)) {
-    if (validKeys.has(key) && typeof value === "string") {
+  for (const [key, value] of Object.entries(object.translations)) {
+    if (validKeys.has(key)) {
       translations[key] = value;
     }
+  }
+
+  if (Object.keys(translations).length === 0) {
+    logger.error(
+      {
+        requestedKeys: fields.map((f) => f.path),
+        returnedKeys: Object.keys(object.translations),
+      },
+      "AI translation response had no keys matching the requested fields"
+    );
+    throw new Error("AI translation response had no usable translations");
   }
 
   return translations;

--- a/apps/web/modules/survey/multi-language-surveys/components/manage-translations-modal.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/manage-translations-modal.tsx
@@ -173,7 +173,9 @@ export const ManageTranslationsModal = ({
         targetLanguage: languageName,
       });
 
-      if (!result?.data?.translations) {
+      // Empty object is truthy in JS — guard explicitly so a zero-translation
+      // response doesn't slip through as a fake success toast.
+      if (!result?.data?.translations || Object.keys(result.data.translations).length === 0) {
         const errorMessage = getFormattedErrorMessage(result);
         toast.error(
           errorMessage ? getAIErrorMessage(errorMessage) : t("workspace.surveys.edit.ai_translation_failed"),

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -8,6 +8,8 @@ export {
   resetLanguageModelCache,
 } from "./provider";
 export { generateText } from "./text";
+export { generateObject } from "./object";
+export type { TGenerateObjectOptions, TGenerateObjectResult } from "./object";
 export type { TAIProvider } from "@formbricks/types/ai";
 export type {
   AIConfigurationStatus,

--- a/packages/ai/src/object.ts
+++ b/packages/ai/src/object.ts
@@ -1,0 +1,34 @@
+import {
+  type GenerateObjectResult,
+  type generateObject as generateObjectFromSdk,
+  generateObject as generateObjectWithConfiguredModel,
+} from "ai";
+import { getAiModel } from "./provider";
+import type { AIEnvironment } from "./types";
+
+// `T` parameterises the wrapper so callers can declare the inferred object
+// shape on the consuming side; the SDK options themselves stay schema-agnostic.
+export type TGenerateObjectOptions<_T = unknown> = Omit<
+  Parameters<typeof generateObjectFromSdk>[0],
+  "model"
+> & { schema?: unknown };
+
+export type TGenerateObjectResult<T> = GenerateObjectResult<T>;
+
+/**
+ * Wrapper around the AI SDK's `generateObject` that forces the active model.
+ * Use this when the LLM output needs to conform to a schema — Gemini and
+ * other models follow JSON-shape instructions much more reliably under
+ * structured-output mode than via free-form `generateText` prompts.
+ */
+export const generateObject = async <T>(
+  options: TGenerateObjectOptions<T>,
+  environment?: AIEnvironment
+): Promise<TGenerateObjectResult<T>> => {
+  const request = {
+    ...options,
+    model: getAiModel(environment),
+  } as Parameters<typeof generateObjectWithConfiguredModel>[0];
+
+  return (await generateObjectWithConfiguredModel(request)) as TGenerateObjectResult<T>;
+};


### PR DESCRIPTION
## Summary

When the **Manage Translations → Translate with AI** flow ran, users sometimes hit a silent failure: the request succeeded, the success toast appeared, but no translations actually populated. Real failing request observed on staging:

```
request:  fields=[blocks.0.buttonLabel, blocks.0.elements.0.headline, endings.0.headline, ...]
response: {"data":{"translations":{}}}
```

## Root cause

The translation action calls `generateOrganizationAIText` (free-form text) and parses the result manually. With **Gemini 3.5 Flash** that gives the model freedom to choose any JSON shape, and Flash specifically tends to:

- **Nest dot-paths** into actual objects — `blocks.0.buttonLabel` ➝ `{blocks: {0: {buttonLabel: "Weiter"}}}`. Parses fine, but every top-level key (`blocks`, `endings`) is filtered out by the `validKeys` check, leaving an empty object.
- **Wrap the response** as `{translations: {...}}` or `{result: {...}}`.
- **Return an array** of `{key, value}` pairs instead of an object.

All three pass `JSON.parse`, all three result in `translations: {}`, and the UI's check `if (!result?.data?.translations)` doesn't trip because `{}` is truthy.

## Fix

Three layers:

1. **`packages/ai/src/object.ts`** *(new)* — adds `generateObject` wrapper mirroring the existing `generateText` wrapper. Attaches the configured AI model the same way.
2. **`apps/web/lib/ai/service.ts`** — adds `generateOrganizationAIObject` with the same `assertOrganizationAIConfigured` gate as the text variant.
3. **`apps/web/modules/ee/ai-translation/lib/translate-fields.ts`** — rewrites the call path. Now uses `generateOrganizationAIObject` with a Zod schema `z.object({ translations: z.record(z.string(), z.string()) })`. The AI SDK forces the model into that shape via structured-output mode (Gemini's `responseSchema`, OpenAI's `response_format: json_schema`, etc.) — all three failure modes above become structurally impossible.

Also strengthens the prompt with explicit "use the key EXACTLY as provided, do not nest or rewrite" guidance, and adds a server-side throw when the returned translations contain zero keys matching the requested paths so the UI shows an error toast (with the raw LLM response logged) instead of fake success.

**UI side**: tightened `if (!result?.data?.translations)` to also treat `{}` as a failure — defense in depth in case the server still ever produces an empty object.

## Test plan

- [x] `pnpm vitest run modules/ee/ai-translation/lib/translate-fields.test.ts` — 4 / 4 pass
- [ ] On staging: trigger Manage Translations → Translate with AI on a multi-field survey, verify translations populate consistently across at least 5 attempts (was intermittently empty before).
- [ ] Failing case (e.g. forcing the model into a bad mood): UI now shows an error toast with the AI service error, server logs the raw response for debugging.
- [ ] Existing `getOrganizationAIConfig` / entitlement gating still applies — no regression on the AI-not-configured / no-plan paths.

## Notes

- `generateObject` is now available to other modules that need shape-guaranteed LLM output (chart generation, example responses, etc. — separate PRs).
- Underlying root cause (dot-paths in keys confusing Gemini) is the same class of issue we saw in the chart-builder example-response generator: model fidelity drops on Flash-tier models when free-form output is used. Structured output is the right abstraction for any LLM call where the consumer needs a specific JSON shape.