### PR TITLE
fix: use node for cube compose healthcheck

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -321,7 +321,13 @@ services:
       - ./cube/cube.js:/cube/conf/cube.js:ro
       - ./cube/schema:/cube/conf/model:ro
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:4000/readyz"]
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "require('http').get('http://127.0.0.1:4000/readyz', (res) => { res.resume(); process.exit(res.statusCode === 200 ? 0 : 1); }).on('error', () => process.exit(1));",
+        ]
       interval: 10s
       timeout: 5s
       retries: 12

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -243,6 +243,9 @@ Common upgrade issues:
 - **Missing `CUBEJS_API_SECRET`** (or unreachable Cube endpoint): the Formbricks app fails env validation
   at boot, or — if env vars are present but Cube is unreachable — dashboards and analysis queries fail
   while the rest of the app stays healthy
+- **Cube healthcheck fails with `wget: not found`**: older v5 Docker Compose files used `wget` for the
+  bundled Cube healthcheck, but `cubejs/cube:v1.6.6` does not include it. Sync the Cube healthcheck from the
+  current Docker Compose file so it checks `/readyz` with Node instead.
 
 If you need to roll back:
 


### PR DESCRIPTION
## Summary
- replace the Cube Docker Compose healthcheck `wget` call with a Node-based `/readyz` check
- document the existing-install symptom where older v5 compose files fail with `wget: not found`

## Testing
- `docker run --rm --entrypoint sh cubejs/cube:v1.6.6 -lc 'command -v node && ! command -v wget && ! command -v curl'`\n- Node healthcheck succeeds against a temporary `/readyz` server and fails when no server is listening\n- `HUB_API_KEY=test CUBEJS_API_SECRET=test docker compose -f docker/docker-compose.yml config >/tmp/formbricks-compose.yml`\n- `git diff --check -- docker/docker-compose.yml docs/self-hosting/advanced/migration.mdx`