### PR TITLE
fix: order Argo migrations after external secrets

### DIFF
--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -69,6 +69,8 @@ The chart deploys Hub API and, by default, a `hub-worker` deployment. Hub API is
 When the Formbricks migration job is enabled, Hub waits for the `formbricks-migration` Job to complete before its own goose/river init migrations run. This keeps fresh shared-database installs from creating Hub tables before Prisma has initialized the Formbricks schema.
 If the Job has already been cleaned up, Hub only continues after all expected Prisma and data migration success markers are present in the database.
 
+When deployed with Argo CD, chart-managed Secrets and ExternalSecrets render in sync wave `-2`, and the Formbricks and Hub migration hooks run in sync wave `-1`. This lets app and Hub secrets exist before migration jobs start.
+
 Self-hosted embeddings are disabled by default. Set `hub.embeddings.enabled=true` to deploy an internal Hugging Face Text Embeddings Inference (TEI) service and wire Hub API plus Hub worker to it through the OpenAI-compatible endpoint added in Hub:
 
 ```yaml

--- a/charts/formbricks/templates/externalsecrets.yaml
+++ b/charts/formbricks/templates/externalsecrets.yaml
@@ -12,6 +12,8 @@ metadata:
   name: {{ template "formbricks.name" $ }}-{{ $nameSuffix }}
   labels:
   {{- include "formbricks.labels" $ | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
 spec:
   refreshInterval: {{ $.Values.externalSecret.refreshInterval }}
 {{- if and (not $data.data) (not $data.dataFrom) }}

--- a/charts/formbricks/templates/hub-embeddings-secret.yaml
+++ b/charts/formbricks/templates/hub-embeddings-secret.yaml
@@ -11,6 +11,8 @@ metadata:
     app.kubernetes.io/component: hub-embeddings
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
 type: Opaque
 data:
   {{ .Values.hub.embeddings.auth.secretKey | default "EMBEDDING_PROVIDER_API_KEY" | quote }}: {{ include "formbricks.hubEmbeddingsApiKey" . | b64enc }}

--- a/charts/formbricks/templates/hub-migration-job.yaml
+++ b/charts/formbricks/templates/hub-migration-job.yaml
@@ -13,6 +13,11 @@ metadata:
     app.kubernetes.io/component: hub-migration
     app.kubernetes.io/managed-by: {{ .Release.Service }}
   annotations:
+    # Argo CD sync hook: run after lower-wave managed resources such as
+    # ExternalSecrets have been applied and reported healthy.
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    argocd.argoproj.io/sync-wave: "-1"
     helm.sh/hook: pre-upgrade
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded

--- a/charts/formbricks/templates/migration-job.yaml
+++ b/charts/formbricks/templates/migration-job.yaml
@@ -7,8 +7,9 @@ metadata:
   labels:
     {{- include "formbricks.labels" . | nindent 4 }}
   annotations:
-    # ArgoCD sync hooks
-    argocd.argoproj.io/hook: PreSync
+    # Argo CD sync hook: keep this in Sync phase so lower-wave managed
+    # resources such as ExternalSecrets are applied before migrations run.
+    argocd.argoproj.io/hook: Sync
     argocd.argoproj.io/hook-delete-policy: HookSucceeded
     argocd.argoproj.io/sync-wave: "-1"
     {{- if .Values.migration.annotations }}

--- a/charts/formbricks/templates/secrets.yaml
+++ b/charts/formbricks/templates/secrets.yaml
@@ -16,6 +16,8 @@ metadata:
   name: {{ include "formbricks.appSecretName" . }}
   labels:
     {{- include "formbricks.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
 data:
   # Formbricks application URLs
   WEBAPP_URL: {{ $webappUrl | b64enc }}


### PR DESCRIPTION
## Summary
- render chart-managed ExternalSecrets in Argo CD sync wave `-2`
- move Formbricks migration and Hub migration jobs to Argo `Sync` hooks in wave `-1`
- document the Argo ordering so ExternalSecrets exist before migration jobs run

## Validation
- `helm lint charts/formbricks`
- rendered `charts/formbricks` with ExternalSecrets enabled and verified ExternalSecrets render at wave `-2` while migration jobs render as `Sync` hooks at wave `-1`
- rendered EU and KSA GitOps prod values against the patched local chart

## Notes
- This avoids the KSA v5 failure mode where the Hub migration hook started before `formbricks-hub-secrets` had been created/synced.