### PR TITLE
fix(deps): bump axios to 1.16.0 — closes ENG-1249, ENG-1250

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
       "@tootallnate/once": "3.0.1",
       "@xmldom/xmldom": "0.9.10",
       "ajv@6": "6.14.0",
-      "axios": "1.15.2",
+      "axios": "1.16.0",
       "effect": "3.20.0",
       "fast-uri": "3.1.2",
       "fast-xml-parser": "5.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   '@tootallnate/once': 3.0.1
   '@xmldom/xmldom': 0.9.10
   ajv@6: 6.14.0
-  axios: 1.15.2
+  axios: 1.16.0
   effect: 3.20.0
   fast-uri: 3.1.2
   fast-xml-parser: 5.7.0
@@ -6840,8 +6840,8 @@ packages:
     resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
     engines: {node: '>=4'}
 
-  axios@1.15.2:
-    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -13691,7 +13691,7 @@ snapshots:
       '@boxyhq/metrics': 0.2.12
       '@boxyhq/saml20': 1.13.2
       '@googleapis/admin': 30.3.0
-      axios: 1.15.2
+      axios: 1.16.0
       better-sqlite3: 12.8.0
       encoding: 0.1.13
       ipaddr.js: 2.3.0
@@ -19278,7 +19278,7 @@ snapshots:
 
   axe-core@4.11.0: {}
 
-  axios@1.15.2:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5


### PR DESCRIPTION
## Summary

Bumps `axios` from **1.15.2 → 1.16.0** to close two high-severity Dependabot alerts. Both vulnerabilities affect `>= 1.0.0, < 1.16.0` and are patched in `1.16.0`.

Closes [ENG-1249](https://linear.app/formbricks/issue/ENG-1249/dependabot-506-axios-axios-vulnerable-to-full-man-in-the-middle-via)
Closes [ENG-1250](https://linear.app/formbricks/issue/ENG-1250/dependabot-505-axios-axioss-shouldbypassproxy-does-not-recognize-ipv4)

## Vulnerabilities patched

| Linear | CVE | Advisory | Severity | Issue |
| --- | --- | --- | --- | --- |
| [ENG-1249](https://linear.app/formbricks/issue/ENG-1249) | CVE-2026-44494 | [GHSA-35jp-ww65-95wh](https://github.com/advisories/GHSA-35jp-ww65-95wh) | high (CVSS 9.4) | Prototype-pollution gadget in `config.proxy` enables a full MITM if any dependency pollutes `Object.prototype`. |
| [ENG-1250](https://linear.app/formbricks/issue/ENG-1250) | CVE-2026-44492 | [GHSA-pjwm-pj3p-43mv](https://github.com/advisories/GHSA-pjwm-pj3p-43mv) | high | `shouldBypassProxy` does not normalise IPv4-mapped IPv6 hostnames (e.g. `::ffff:7f00:1`), so NO_PROXY entries can be bypassed via the v6-mapped form. Cloud metadata SSRF risk. |

## Scope

Axios is pinned in this repo only via `pnpm.overrides` — **no direct imports anywhere in the source tree**. The bump is therefore a pure security patch with **zero application-code changes**.

```diff
   "pnpm": {
     "overrides": {
       ...
-      "axios": "1.15.2",
+      "axios": "1.16.0",
```

The lockfile updates reflect the new version wherever it resolves, including the one transitive direct consumer (`@boxyhq/saml-jackson`).

## Test plan

- [x] `pnpm install` succeeds, lockfile regenerated.
- [x] Verified `axios` is not imported by any package in the repo (`pnpm.overrides`-only).
- [ ] CI passes (build, typecheck, tests).
- [ ] Smoke test: SAML/SSO login flow (uses `@boxyhq/saml-jackson` which is the largest transitive consumer of axios in this repo).
- [ ] Smoke test: any other integration that ultimately hits axios via a transitive (webhooks, AI providers, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)