### PR TITLE
fix: adds questions and blocks both to v1 api

### DIFF
--- a/apps/web/app/api/v1/management/surveys/[surveyId]/route.ts
+++ b/apps/web/app/api/v1/management/surveys/[surveyId]/route.ts
@@ -12,9 +12,9 @@ import {
 import { RequestBodyTooLargeError, parseJsonBodyWithLimit } from "@/app/lib/api/request-body";
 import { responses } from "@/app/lib/api/response";
 import {
-  transformBlocksToQuestions,
   transformQuestionsToBlocks,
   validateSurveyInput,
+  withDerivedQuestions,
 } from "@/app/lib/api/survey-transformation";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
 import { THandlerParams, withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
@@ -61,28 +61,11 @@ export const GET = withV1ApiWrapper({
         };
       }
 
-      const shouldTransformToQuestions =
-        result.survey.blocks &&
-        result.survey.blocks.length > 0 &&
-        result.survey.blocks.every((block) => block.elements.length === 1);
-
-      if (shouldTransformToQuestions) {
-        return {
-          response: responses.successResponse(
-            addLegacyProjectOverwrites(
-              resolveStorageUrlsInObject({
-                ...result.survey,
-                questions: transformBlocksToQuestions(result.survey.blocks, result.survey.endings),
-                blocks: [],
-              })
-            )
-          ),
-        };
-      }
-
+      // Always expose `questions` (derived from blocks) alongside `blocks` so API v1
+      // consumers get a consistent shape regardless of how the survey was built.
       return {
         response: responses.successResponse(
-          addLegacyProjectOverwrites(resolveStorageUrlsInObject(result.survey))
+          addLegacyProjectOverwrites(resolveStorageUrlsInObject(withDerivedQuestions(result.survey)))
         ),
       };
     } catch (error) {
@@ -238,23 +221,9 @@ export const PUT = withV1ApiWrapper({
           auditLog.newObject = updatedSurvey;
         }
 
-        if (hasQuestions) {
-          const surveyWithQuestions = {
-            ...updatedSurvey,
-            questions: transformBlocksToQuestions(updatedSurvey.blocks, updatedSurvey.endings),
-            blocks: [],
-          };
-
-          return {
-            response: responses.successResponse(
-              addLegacyProjectOverwrites(resolveStorageUrlsInObject(surveyWithQuestions))
-            ),
-          };
-        }
-
         return {
           response: responses.successResponse(
-            addLegacyProjectOverwrites(resolveStorageUrlsInObject(updatedSurvey))
+            addLegacyProjectOverwrites(resolveStorageUrlsInObject(withDerivedQuestions(updatedSurvey)))
           ),
         };
       } catch (error) {

--- a/apps/web/app/api/v1/management/surveys/route.ts
+++ b/apps/web/app/api/v1/management/surveys/route.ts
@@ -151,7 +151,9 @@ export const POST = withV1ApiWrapper({
       }
 
       return {
-        response: responses.successResponse(addLegacyProjectOverwrites(withDerivedQuestions(survey))),
+        response: responses.successResponse(
+          addLegacyProjectOverwrites(resolveStorageUrlsInObject(withDerivedQuestions(survey)))
+        ),
       };
     } catch (error) {
       if (error instanceof DatabaseError) {

--- a/apps/web/app/api/v1/management/surveys/route.ts
+++ b/apps/web/app/api/v1/management/surveys/route.ts
@@ -11,9 +11,9 @@ import {
 import { RequestBodyTooLargeError, parseJsonBodyWithLimit } from "@/app/lib/api/request-body";
 import { responses } from "@/app/lib/api/response";
 import {
-  transformBlocksToQuestions,
   transformQuestionsToBlocks,
   validateSurveyInput,
+  withDerivedQuestions,
 } from "@/app/lib/api/survey-transformation";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
 import { withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
@@ -41,24 +41,9 @@ export const GET = withV1ApiWrapper({
 
       const surveys = await getSurveys(workspaceIds, limit, offset);
 
-      const surveysWithQuestions = surveys.map((survey) => {
-        // If the survey has blocks and each block has ONLY ONE element, we can transform the blocks to questions
-        // This is only for backwards compatibility with the older surveys
-        const shouldTransformToQuestions =
-          survey.blocks &&
-          survey.blocks.length > 0 &&
-          survey.blocks.every((block) => block.elements.length === 1);
-
-        if (shouldTransformToQuestions) {
-          return {
-            ...survey,
-            questions: transformBlocksToQuestions(survey.blocks, survey.endings),
-            blocks: [],
-          };
-        }
-
-        return survey;
-      });
+      // Always expose `questions` (derived from blocks) alongside `blocks` so API v1
+      // consumers get a consistent shape regardless of how the survey was built.
+      const surveysWithQuestions = surveys.map((survey) => withDerivedQuestions(survey));
 
       return {
         response: responses.successResponse(
@@ -165,20 +150,8 @@ export const POST = withV1ApiWrapper({
         auditLog.newObject = survey;
       }
 
-      if (hasQuestions) {
-        const surveyWithQuestions = {
-          ...survey,
-          questions: transformBlocksToQuestions(survey.blocks, survey.endings),
-          blocks: [],
-        };
-
-        return {
-          response: responses.successResponse(addLegacyProjectOverwrites(surveyWithQuestions)),
-        };
-      }
-
       return {
-        response: responses.successResponse(addLegacyProjectOverwrites(survey)),
+        response: responses.successResponse(addLegacyProjectOverwrites(withDerivedQuestions(survey))),
       };
     } catch (error) {
       if (error instanceof DatabaseError) {

--- a/apps/web/app/lib/api/survey-transformation.test.ts
+++ b/apps/web/app/lib/api/survey-transformation.test.ts
@@ -598,6 +598,42 @@ describe("transformBlocksToQuestions", () => {
     expect(questions[0].id).toBe("q1");
     expect(questions[1].id).toBe("q2");
   });
+
+  test("should resolve CTA buttonLabel for a non-last element in a multi-element block", () => {
+    const blocks = [
+      {
+        id: "b1",
+        name: "Block 1",
+        buttonLabel: { default: "Block next" },
+        elements: [
+          {
+            id: "q1",
+            type: "cta",
+            headline: { default: "CTA element" },
+            required: false,
+            ctaButtonLabel: { default: "Click me" },
+          },
+          {
+            id: "q2",
+            type: "text",
+            headline: { default: "Last element" },
+            required: false,
+            inputType: "text",
+          },
+        ],
+      },
+    ] as unknown as TSurveyBlock[];
+
+    const questions = transformBlocksToQuestions(blocks, []);
+
+    expect(questions).toHaveLength(2);
+    // Non-last CTA element keeps its own button label (block attrs are not applied to it)
+    expect(questions[0].id).toBe("q1");
+    expect(questions[0].buttonLabel).toEqual({ default: "Click me" });
+    // Block-level button label applies to the last element only
+    expect(questions[1].id).toBe("q2");
+    expect(questions[1].buttonLabel).toEqual({ default: "Block next" });
+  });
 });
 
 describe("CTA Logic Cleaning", () => {

--- a/apps/web/app/lib/api/survey-transformation.test.ts
+++ b/apps/web/app/lib/api/survey-transformation.test.ts
@@ -568,7 +568,7 @@ describe("transformBlocksToQuestions", () => {
     expect(questions[0].backButtonLabel).toEqual({ default: "Back" });
   });
 
-  test("should handle blocks with multiple elements by taking the first element", () => {
+  test("should flatten blocks with multiple elements into one question per element", () => {
     const blocks = [
       {
         id: "b1",
@@ -594,8 +594,9 @@ describe("transformBlocksToQuestions", () => {
 
     const questions = transformBlocksToQuestions(blocks, []);
 
-    expect(questions).toHaveLength(1);
+    expect(questions).toHaveLength(2);
     expect(questions[0].id).toBe("q1");
+    expect(questions[1].id).toBe("q2");
   });
 });
 

--- a/apps/web/app/lib/api/survey-transformation.ts
+++ b/apps/web/app/lib/api/survey-transformation.ts
@@ -439,15 +439,19 @@ const transformBlockLogicToQuestionLogic = (
   });
 };
 
+const applyCtaButtonLabel = (element: Record<string, unknown>): void => {
+  if (element.type === "cta" && element.ctaButtonLabel) {
+    element.buttonLabel = element.ctaButtonLabel;
+  }
+};
+
 const applyBlockAttributesToElement = (
   element: Record<string, unknown>,
   block: TSurveyBlock,
   blockIdToQuestionId: Map<string, string>,
   endingIds: Set<string>
 ): void => {
-  if (element.type === "cta" && element.ctaButtonLabel) {
-    element.buttonLabel = element.ctaButtonLabel;
-  }
+  applyCtaButtonLabel(element);
 
   if (Array.isArray(block.logic) && block.logic.length > 0) {
     element.logic = transformBlockLogicToQuestionLogic(block.logic, blockIdToQuestionId, endingIds);
@@ -477,6 +481,7 @@ export const transformBlocksToQuestions = (
   const endingIds = new Set<string>(endings.map((ending) => ending.id));
   const questions: Record<string, unknown>[] = [];
 
+  // Jump targets resolve to a block; map them to the block's first element (its entry point).
   const blockIdToQuestionId = blocks.reduce((acc, block) => {
     if (block.elements.length === 0) return acc;
     acc.set(block.id, block.elements[0].id);
@@ -486,14 +491,45 @@ export const transformBlocksToQuestions = (
   for (const block of blocks) {
     if (block.elements.length === 0) continue;
 
-    const element = { ...block.elements[0] };
+    block.elements.forEach((blockElement, index) => {
+      const element = { ...blockElement };
+      const isLastElement = index === block.elements.length - 1;
 
-    applyBlockAttributesToElement(element, block, blockIdToQuestionId, endingIds);
+      // Block-level logic/labels describe the transition AFTER the whole block,
+      // so they only apply to the last element. Earlier elements keep default
+      // (next) behaviour and only need their own CTA button label resolved.
+      if (isLastElement) {
+        applyBlockAttributesToElement(element, block, blockIdToQuestionId, endingIds);
+      } else {
+        applyCtaButtonLabel(element);
+      }
 
-    questions.push(element);
+      questions.push(element);
+    });
   }
 
   return questions as TSurveyQuestion[];
+};
+
+/**
+ * Returns the survey with a `questions` array derived from `blocks` for API v1
+ * backwards compatibility, while keeping `blocks` intact so newer block-based
+ * surveys remain fully represented. Surveys that still store legacy `questions`
+ * (no blocks yet) are returned unchanged.
+ */
+export const withDerivedQuestions = <
+  T extends { blocks?: TSurveyBlock[]; questions?: TSurveyQuestion[]; endings?: TSurveyEnding[] },
+>(
+  survey: T
+): T => {
+  if (!survey.blocks || survey.blocks.length === 0) {
+    return survey;
+  }
+
+  return {
+    ...survey,
+    questions: transformBlocksToQuestions(survey.blocks, survey.endings ?? []),
+  };
 };
 
 export const validateSurveyInput = (input: {


### PR DESCRIPTION
  ## What does this PR do?

  API v1 surveys endpoints (`/api/v1/management/surveys` + `/[surveyId]`) returned an inconsistent shape: surveys built with the new blocks editor came back under `questions` **only when** every block
  had exactly one element, and under `blocks` otherwise. Surveys with multi-element blocks never exposed `questions`, breaking integrations that fetch questions by reading the `questions` array.

  This PR makes the v1 API always return **both** `questions` and `blocks`:

  - `questions` is now always derived from `blocks` (kept for backwards compatibility), while `blocks` stays intact in the response.
  - Removed the `blocks.every(b => b.elements.length === 1)` guard and the `blocks: []` blanking from GET (list + single), POST, and PUT responses.
  - Fixed `transformBlocksToQuestions` to flatten **every** element into one question each (previously it dropped all but `elements[0]`). Block-level `logic`/`logicFallback`/`buttonLabel` attach to the
  block's last element (the post-block transition point); `jumpToBlock` targets resolve to the block's first element id.
  - Legacy surveys that still store `questions` (no `blocks` yet) are returned unchanged.

  Resulting response shape:

  | Survey | Before | After |
  |---|---|---|
  | legacy (questions only) | `questions` ✓, `blocks` [] | `questions` ✓, `blocks` [] |
  | blocks, 1 elem/block | `questions` ✓, `blocks` [] | `questions` ✓, `blocks` ✓ |
  | blocks, multi-elem | `questions` [], `blocks` ✓ | `questions` ✓, `blocks` ✓ |

  Note: `questions` is a read-only derivation. Round-tripping derived questions back via PUT collapses multi-element blocks into one-block-per-question (pre-existing behavior of the questions↔blocks
  bridge, not changed here).

  Fixes #(issue)

  ## How should this be tested?

  - `GET /api/v1/management/surveys/{surveyId}` for a survey with **multi-element blocks** → response contains both a populated `questions` array (one entry per element) and the original `blocks`.
  - `GET /api/v1/management/surveys` (list) → every survey returns both `questions` and `blocks`.
  - `GET` a **legacy** survey (questions only, no blocks) → returns `questions` populated, `blocks: []` (unchanged).
  - Verify conditional logic survives the transform: `jumpToBlock` actions become `jumpToQuestion` targeting the block's first element; condition operands keep their element/question ids.
  - `pnpm --filter web test app/lib/api/survey-transformation.test.ts` → all transform tests pass.

  ## Checklist

  ### Required

  - [x] Filled out the "How to test" section in this PR
  - [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
  - [x] Self-reviewed my own code
  - [x] Commented on my code in hard-to-understand bits
  - [ ] Ran `pnpm build`
  - [x] Checked for warnings, there are none
  - [x] Removed all `console.logs`
  - [ ] Merged the latest changes from main onto my branch with `git pull origin main`
  - [x] My changes don't cause any responsiveness issues
  - [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

  ### Appreciated

  - [ ] If a UI change was made: Added a screen recording or screenshots to this PR
  - [ ] Updated the Formbricks Docs if changes were necessary