### PR TITLE
fix: show clear error when default survey label is missing

### DIFF
--- a/apps/web/modules/survey/editor/lib/validation.test.ts
+++ b/apps/web/modules/survey/editor/lib/validation.test.ts
@@ -24,7 +24,11 @@ import {
   TSurveyRedirectUrlCard,
   TSurveyWelcomeCard,
 } from "@formbricks/types/surveys/types";
-import { TValidateIdErrorCode, validateQuestionLabels } from "@formbricks/types/surveys/validation";
+import {
+  TValidateIdErrorCode,
+  validateCardFieldsForAllLanguages,
+  validateQuestionLabels,
+} from "@formbricks/types/surveys/validation";
 import { checkForEmptyFallBackValue } from "@/lib/utils/recall";
 import * as validation from "./validation";
 
@@ -122,7 +126,125 @@ const surveyLanguagesWithDisabled: TSurveyLanguage[] = [
   },
 ];
 
+const surveyLanguagesMultipleEnabled: TSurveyLanguage[] = [
+  {
+    language: {
+      id: "1",
+      code: "en",
+      alias: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      workspaceId: "proj1",
+    },
+    default: true,
+    enabled: true,
+  },
+  {
+    language: {
+      id: "2",
+      code: "de",
+      alias: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      workspaceId: "proj1",
+    },
+    default: false,
+    enabled: true,
+  },
+  {
+    language: {
+      id: "3",
+      code: "fr",
+      alias: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      workspaceId: "proj1",
+    },
+    default: false,
+    enabled: true,
+  },
+  {
+    language: {
+      id: "4",
+      code: "es",
+      alias: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      workspaceId: "proj1",
+    },
+    default: false,
+    enabled: true,
+  },
+];
+
 describe("survey schema multilingual label validation", () => {
+  test("returns a card issue when the welcome card default headline is missing but translations are present", () => {
+    const issue = validateCardFieldsForAllLanguages(
+      "cardHeadline",
+      { default: "", en: "Welcome", de: "Willkommen" },
+      surveyLanguagesEnabled,
+      "welcome"
+    );
+
+    expect(issue).toMatchObject({
+      code: "custom",
+      message: "The note on the Welcome card is missing",
+      path: ["welcomeCard", "cardHeadline"],
+    });
+    expect(issue?.params).toBeUndefined();
+  });
+
+  test("returns language params when only a translated welcome card headline is missing", () => {
+    const issue = validateCardFieldsForAllLanguages(
+      "cardHeadline",
+      { default: "Welcome", en: "Welcome", de: "" },
+      surveyLanguagesEnabled,
+      "welcome"
+    );
+
+    expect(issue).toMatchObject({
+      code: "custom",
+      message: "The note on the Welcome card is missing for the following languages:  -fLang- de",
+      path: ["welcomeCard", "cardHeadline"],
+      params: { invalidLanguageCodes: ["de"] },
+    });
+  });
+
+  test("returns a card issue without params when the ending card default headline and translations are missing", () => {
+    const issue = validateCardFieldsForAllLanguages(
+      "cardHeadline",
+      { default: "", en: "", de: "" },
+      surveyLanguagesEnabled,
+      "end",
+      2
+    );
+
+    expect(issue).toMatchObject({
+      code: "custom",
+      message: "The note on the Ending card 3 is missing",
+      path: ["endings", 2, "cardHeadline"],
+    });
+    expect(issue?.params).toBeUndefined();
+  });
+
+  test("returns all invalid language params for mixed valid and invalid ending card translations", () => {
+    const issue = validateCardFieldsForAllLanguages(
+      "endingCardButtonLabel",
+      { default: "Done", en: "Done", de: "", fr: " ", es: "Listo" },
+      surveyLanguagesMultipleEnabled,
+      "end",
+      1
+    );
+
+    expect(issue).toMatchObject({
+      code: "custom",
+      message:
+        "The button label on the Ending card 2 is missing for the following languages:  -fLang- de, fr",
+      path: ["endings", 1, "endingCardButtonLabel"],
+      params: { invalidLanguageCodes: ["de", "fr"] },
+    });
+  });
+
   test("returns a block-editor issue when a block element default headline is missing", () => {
     const issue = validateElementLabels(
       "headline",

--- a/apps/web/modules/survey/editor/lib/validation.test.ts
+++ b/apps/web/modules/survey/editor/lib/validation.test.ts
@@ -16,6 +16,7 @@ import {
   TSurveyPictureSelectionElement,
   TSurveyRatingElement,
 } from "@formbricks/types/surveys/elements";
+import { validateElementLabels } from "@formbricks/types/surveys/elements-validation";
 import {
   TSurvey,
   TSurveyEndScreenCard,
@@ -23,7 +24,7 @@ import {
   TSurveyRedirectUrlCard,
   TSurveyWelcomeCard,
 } from "@formbricks/types/surveys/types";
-import { TValidateIdErrorCode } from "@formbricks/types/surveys/validation";
+import { TValidateIdErrorCode, validateQuestionLabels } from "@formbricks/types/surveys/validation";
 import { checkForEmptyFallBackValue } from "@/lib/utils/recall";
 import * as validation from "./validation";
 
@@ -120,6 +121,55 @@ const surveyLanguagesWithDisabled: TSurveyLanguage[] = [
     enabled: false,
   },
 ];
+
+describe("survey schema multilingual label validation", () => {
+  test("returns a block-editor issue when a block element default headline is missing", () => {
+    const issue = validateElementLabels(
+      "headline",
+      { default: "", en: "", de: "" },
+      surveyLanguagesEnabled,
+      1,
+      0
+    );
+
+    expect(issue).toMatchObject({
+      message: "The question in question 1 of block 2 is missing",
+      path: ["blocks", 1, "elements", 0, "headline"],
+    });
+    expect(issue?.params).toBeUndefined();
+  });
+
+  test("returns a block-editor issue when a question default headline is missing", () => {
+    const issue = validateQuestionLabels(
+      "headline",
+      { default: "", en: "", de: "" },
+      surveyLanguagesEnabled,
+      0
+    );
+
+    expect(issue).toMatchObject({
+      message: "The question in question 1 is missing",
+      path: ["questions", 0, "headline"],
+    });
+    expect(issue?.params).toBeUndefined();
+  });
+
+  test("returns language params when only a translated block element headline is missing", () => {
+    const issue = validateElementLabels(
+      "headline",
+      { default: "Question", en: "Question", de: "" },
+      surveyLanguagesEnabled,
+      1,
+      0
+    );
+
+    expect(issue).toMatchObject({
+      message: "The question in question 1 of block 2 is missing for the following languages:  -fLang- de",
+      path: ["blocks", 1, "elements", 0, "headline"],
+      params: { invalidLanguageCodes: ["de"] },
+    });
+  });
+});
 
 describe("validation.isLabelValidForAllLanguages", () => {
   test("should return true if all enabled languages have non-empty labels", () => {

--- a/packages/types/surveys/elements-validation.ts
+++ b/packages/types/surveys/elements-validation.ts
@@ -24,13 +24,7 @@ const validateLabelForAllLanguages = (label: TI18nString, surveyLanguages: TSurv
     return textContent.length === 0;
   });
 
-  return invalidLanguageCodes.map((invalidLanguageCode) => {
-    if (invalidLanguageCode === "default") {
-      return surveyLanguages.find((lang) => lang.default)?.language.code ?? "default";
-    }
-
-    return invalidLanguageCode;
-  });
+  return invalidLanguageCodes;
 };
 
 // Map for element field names to user-friendly labels
@@ -52,6 +46,26 @@ export const validateElementLabels = (
   elementIndex: number,
   skipArticle = false
 ): z.core.$ZodRawIssue | null => {
+  const invalidLanguageCodes = validateLabelForAllLanguages(fieldLabel, languages);
+  const isDefaultMissing = invalidLanguageCodes.includes("default");
+
+  const messagePrefix = skipArticle ? "" : "The ";
+  const messageField = ELEMENT_FIELD_TO_LABEL_MAP[field] ? ELEMENT_FIELD_TO_LABEL_MAP[field] : field;
+  const messageSuffix = isDefaultMissing ? " is missing" : " is missing for the following languages: ";
+
+  const message = isDefaultMissing
+    ? `${messagePrefix}${messageField} in question ${String(elementIndex + 1)} of block ${String(blockIndex + 1)}${messageSuffix}`
+    : `${messagePrefix}${messageField} in question ${String(elementIndex + 1)} of block ${String(blockIndex + 1)}${messageSuffix} -fLang- ${invalidLanguageCodes.join()}`;
+
+  if (isDefaultMissing) {
+    return {
+      code: "custom",
+      input: fieldLabel,
+      message,
+      path: ["blocks", blockIndex, "elements", elementIndex, field],
+    };
+  }
+
   // fieldLabel should contain all the keys present in languages
   for (const language of languages) {
     if (
@@ -68,24 +82,13 @@ export const validateElementLabels = (
     }
   }
 
-  const invalidLanguageCodes = validateLabelForAllLanguages(fieldLabel, languages);
-  const isDefaultOnly = invalidLanguageCodes.length === 1 && invalidLanguageCodes[0] === "default";
-
-  const messagePrefix = skipArticle ? "" : "The ";
-  const messageField = ELEMENT_FIELD_TO_LABEL_MAP[field] ? ELEMENT_FIELD_TO_LABEL_MAP[field] : field;
-  const messageSuffix = isDefaultOnly ? " is missing" : " is missing for the following languages: ";
-
-  const message = isDefaultOnly
-    ? `${messagePrefix}${messageField} in question ${String(elementIndex + 1)} of block ${String(blockIndex + 1)}${messageSuffix}`
-    : `${messagePrefix}${messageField} in question ${String(elementIndex + 1)} of block ${String(blockIndex + 1)}${messageSuffix} -fLang- ${invalidLanguageCodes.join()}`;
-
   if (invalidLanguageCodes.length) {
     return {
       code: "custom",
       input: fieldLabel,
       message,
       path: ["blocks", blockIndex, "elements", elementIndex, field],
-      params: isDefaultOnly ? undefined : { invalidLanguageCodes },
+      params: { invalidLanguageCodes },
     };
   }
 

--- a/packages/types/surveys/validation.ts
+++ b/packages/types/surveys/validation.ts
@@ -103,13 +103,7 @@ const validateLabelForAllLanguages = (label: TI18nString, surveyLanguages: TSurv
     return textContent.length === 0;
   });
 
-  return invalidLanguageCodes.map((invalidLanguageCode) => {
-    if (invalidLanguageCode === "default") {
-      return surveyLanguages.find((lang) => lang.default)?.language.code ?? "default";
-    }
-
-    return invalidLanguageCode;
-  });
+  return invalidLanguageCodes;
 };
 
 export const validateQuestionLabels = (
@@ -119,6 +113,26 @@ export const validateQuestionLabels = (
   questionIndex: number,
   skipArticle = false
 ): z.core.$ZodRawIssue | null => {
+  const invalidLanguageCodes = validateLabelForAllLanguages(fieldLabel, languages);
+  const isDefaultMissing = invalidLanguageCodes.includes("default");
+
+  const messagePrefix = skipArticle ? "" : "The ";
+  const messageField = FIELD_TO_LABEL_MAP[field] ? FIELD_TO_LABEL_MAP[field] : field;
+  const messageSuffix = isDefaultMissing ? " is missing" : " is missing for the following languages: ";
+
+  const message = isDefaultMissing
+    ? `${messagePrefix}${messageField} in question ${String(questionIndex + 1)}${messageSuffix}`
+    : `${messagePrefix}${messageField} in question ${String(questionIndex + 1)}${messageSuffix} -fLang- ${invalidLanguageCodes.join()}`;
+
+  if (isDefaultMissing) {
+    return {
+      code: "custom",
+      input: fieldLabel,
+      message,
+      path: ["questions", questionIndex, field],
+    };
+  }
+
   // fieldLabel should contain all the keys present in languages
   // even if one of the keys is an empty string, its okay but it shouldn't be undefined
 
@@ -137,24 +151,13 @@ export const validateQuestionLabels = (
     }
   }
 
-  const invalidLanguageCodes = validateLabelForAllLanguages(fieldLabel, languages);
-  const isDefaultOnly = invalidLanguageCodes.length === 1 && invalidLanguageCodes[0] === "default";
-
-  const messagePrefix = skipArticle ? "" : "The ";
-  const messageField = FIELD_TO_LABEL_MAP[field] ? FIELD_TO_LABEL_MAP[field] : field;
-  const messageSuffix = isDefaultOnly ? " is missing" : " is missing for the following languages: ";
-
-  const message = isDefaultOnly
-    ? `${messagePrefix}${messageField} in question ${String(questionIndex + 1)}${messageSuffix}`
-    : `${messagePrefix}${messageField} in question ${String(questionIndex + 1)}${messageSuffix} -fLang- ${invalidLanguageCodes.join()}`;
-
   if (invalidLanguageCodes.length) {
     return {
       code: "custom",
       input: fieldLabel,
       message,
       path: ["questions", questionIndex, field],
-      params: isDefaultOnly ? undefined : { invalidLanguageCodes },
+      params: { invalidLanguageCodes },
     };
   }
 
@@ -169,13 +172,33 @@ export const validateCardFieldsForAllLanguages = (
   endingCardIndex?: number,
   skipArticle = false
 ): z.core.$ZodRawIssue | null => {
-  // fieldLabel should contain all the keys present in languages
-  // even if one of the keys is an empty string, its okay but it shouldn't be undefined
-
   const cardTypeLabel =
     cardType === "welcome" ? "Welcome card" : `Ending card ${((endingCardIndex ?? -1) + 1).toString()}`; // Ensure 1-based indexing
 
   const path = cardType === "welcome" ? ["welcomeCard", field] : ["endings", endingCardIndex ?? -1, field];
+
+  const invalidLanguageCodes = validateLabelForAllLanguages(fieldLabel, languages);
+  const isDefaultMissing = invalidLanguageCodes.includes("default");
+
+  const messagePrefix = skipArticle ? "" : "The ";
+  const messageField = FIELD_TO_LABEL_MAP[field] ? FIELD_TO_LABEL_MAP[field] : field;
+  const messageSuffix = isDefaultMissing ? " is missing" : " is missing for the following languages: ";
+
+  const message = isDefaultMissing
+    ? `${messagePrefix}${messageField} on the ${cardTypeLabel}${messageSuffix}`
+    : `${messagePrefix}${messageField} on the ${cardTypeLabel}${messageSuffix} -fLang- ${invalidLanguageCodes.join(", ")}`;
+
+  if (isDefaultMissing) {
+    return {
+      code: "custom",
+      input: fieldLabel,
+      message,
+      path,
+    };
+  }
+
+  // fieldLabel should contain all the keys present in languages
+  // even if one of the keys is an empty string, its okay but it shouldn't be undefined
 
   for (const language of languages) {
     if (
@@ -192,24 +215,13 @@ export const validateCardFieldsForAllLanguages = (
     }
   }
 
-  const invalidLanguageCodes = validateLabelForAllLanguages(fieldLabel, languages);
-  const isDefaultOnly = invalidLanguageCodes.length === 1 && invalidLanguageCodes[0] === "default";
-
-  const messagePrefix = skipArticle ? "" : "The ";
-  const messageField = FIELD_TO_LABEL_MAP[field] ? FIELD_TO_LABEL_MAP[field] : field;
-  const messageSuffix = isDefaultOnly ? " is missing" : " is missing for the following languages: ";
-
-  const message = isDefaultOnly
-    ? `${messagePrefix}${messageField} on the ${cardTypeLabel}${messageSuffix}`
-    : `${messagePrefix}${messageField} on the ${cardTypeLabel}${messageSuffix} -fLang- ${invalidLanguageCodes.join(", ")}`;
-
   if (invalidLanguageCodes.length) {
     return {
       code: "custom",
       input: fieldLabel,
       message,
       path,
-      params: isDefaultOnly ? undefined : { invalidLanguageCodes },
+      params: { invalidLanguageCodes },
     };
   }
 


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Updates multilingual survey label validation so a missing default-language value reports a plain “is missing” error instead of listing translated languages.
- Applies the default-missing branch before per-language validation for question, block element, welcome card, and ending card labels.
- Keeps translated-language errors scoped to `params.invalidLanguageCodes` when the default value is present.
- Adds regression coverage for the updated multilingual validation issue shapes.

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

Fixes ENG-985

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Run `pnpm -F @formbricks/web run test -- modules/survey/editor/lib/validation.test.ts`.
- In a multilingual survey, leave the default question headline empty while translations are enabled and verify the publish validation says the question is missing without listing translation languages.
- With a default question headline present, leave a translated headline empty and verify the validation lists only the missing translated language.
- Repeat the same default-missing and translation-missing checks for welcome and ending card labels.
- Verify block editor element validation still points to the expected `blocks[index].elements[index]` path.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary

<img width="395" height="161" alt="image" src="https://github.com/user-attachments/assets/2fda3113-caf6-4dfe-925b-cf127ce2c399" />

