### PR TITLE
fix(ai-translation): resolve empty translation results in production

### DIFF
--- a/apps/web/modules/ee/ai-translation/lib/translate-fields.test.ts
+++ b/apps/web/modules/ee/ai-translation/lib/translate-fields.test.ts
@@ -3,9 +3,13 @@ import { type TAITranslationField, translateFields } from "./translate-fields";
 
 vi.mock("server-only", () => ({}));
 
-const mockGenerateOrganizationAIText = vi.fn();
+const mockGenerateOrganizationAIObject = vi.fn();
 vi.mock("@/lib/ai/service", () => ({
-  generateOrganizationAIText: (...args: unknown[]) => mockGenerateOrganizationAIText(...args),
+  generateOrganizationAIObject: (...args: unknown[]) => mockGenerateOrganizationAIObject(...args),
+}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
 const baseInput = {
@@ -15,8 +19,8 @@ const baseInput = {
 };
 
 const fields: TAITranslationField[] = [
-  { path: "headline", defaultText: "Welcome", isRichText: false },
-  { path: "description", defaultText: "<p>Hello</p>", isRichText: true },
+  { path: "welcomeCard.headline.default", defaultText: "Welcome", isRichText: false },
+  { path: "questions.0.html.default", defaultText: "<p>Hello</p>", isRichText: true },
 ];
 
 describe("translateFields", () => {
@@ -24,47 +28,77 @@ describe("translateFields", () => {
     vi.clearAllMocks();
   });
 
-  test("returns translated fields from clean JSON response", async () => {
-    mockGenerateOrganizationAIText.mockResolvedValue({
-      text: JSON.stringify({ headline: "Willkommen", description: "<p>Hallo</p>" }),
+  test("returns translations keyed by original field paths", async () => {
+    mockGenerateOrganizationAIObject.mockResolvedValue({
+      object: { t0: "Willkommen", t1: "<p>Hallo</p>" },
     });
 
     const result = await translateFields({ ...baseInput, fields });
-    expect(result).toEqual({ headline: "Willkommen", description: "<p>Hallo</p>" });
+
+    expect(result).toEqual({
+      "welcomeCard.headline.default": "Willkommen",
+      "questions.0.html.default": "<p>Hallo</p>",
+    });
   });
 
-  test("strips markdown code fences", async () => {
-    mockGenerateOrganizationAIText.mockResolvedValue({
-      text: '```json\n{"headline": "Willkommen"}\n```',
+  test("sends opaque indexed IDs to the model, never the field paths", async () => {
+    mockGenerateOrganizationAIObject.mockResolvedValue({
+      object: { t0: "Willkommen", t1: "<p>Hallo</p>" },
     });
 
-    const result = await translateFields({ ...baseInput, fields });
-    expect(result).toEqual({ headline: "Willkommen" });
+    await translateFields({ ...baseInput, fields });
+
+    expect(mockGenerateOrganizationAIObject).toHaveBeenCalledTimes(1);
+    const callArg = mockGenerateOrganizationAIObject.mock.calls[0][0];
+    expect(callArg.prompt).not.toContain("welcomeCard.headline.default");
+    expect(callArg.prompt).not.toContain("questions.0.html.default");
+    const userPayload = JSON.parse(callArg.prompt);
+    expect(userPayload).toEqual([
+      { id: "t0", text: "Welcome", richText: false },
+      { id: "t1", text: "<p>Hello</p>", richText: true },
+    ]);
   });
 
-  test("extracts JSON from wrapper text", async () => {
-    mockGenerateOrganizationAIText.mockResolvedValue({
-      text: 'Here is the translation:\n{"headline": "Willkommen"}\nHope this helps!',
+  test("requests deterministic output (temperature: 0) for stable translations", async () => {
+    mockGenerateOrganizationAIObject.mockResolvedValue({
+      object: { t0: "Willkommen", t1: "<p>Hallo</p>" },
     });
 
-    const result = await translateFields({ ...baseInput, fields });
-    expect(result).toEqual({ headline: "Willkommen" });
+    await translateFields({ ...baseInput, fields });
+
+    expect(mockGenerateOrganizationAIObject.mock.calls[0][0].temperature).toBe(0);
   });
 
-  test("filters out unrequested keys and non-string values", async () => {
-    mockGenerateOrganizationAIText.mockResolvedValue({
-      text: JSON.stringify({ headline: "Willkommen", extra: "Nein", description: 42 }),
+  test("returns empty object without calling the model when no fields are provided", async () => {
+    const result = await translateFields({ ...baseInput, fields: [] });
+
+    expect(result).toEqual({});
+    expect(mockGenerateOrganizationAIObject).not.toHaveBeenCalled();
+  });
+
+  test("throws when the model omits any requested ID from the response", async () => {
+    mockGenerateOrganizationAIObject.mockResolvedValue({
+      object: { t0: "Willkommen" }, // t1 missing
     });
-
-    const result = await translateFields({ ...baseInput, fields });
-    expect(result).toEqual({ headline: "Willkommen" });
-  });
-
-  test("throws on unparseable response", async () => {
-    mockGenerateOrganizationAIText.mockResolvedValue({ text: "not json at all" });
 
     await expect(translateFields({ ...baseInput, fields })).rejects.toThrow(
-      "Failed to parse AI translation response"
+      "AI translation returned incomplete result"
     );
+  });
+
+  test("throws when the model returns an empty string for any ID", async () => {
+    mockGenerateOrganizationAIObject.mockResolvedValue({
+      object: { t0: "Willkommen", t1: "" }, // empty string treated as missing
+    });
+
+    await expect(translateFields({ ...baseInput, fields })).rejects.toThrow(
+      "AI translation returned incomplete result"
+    );
+  });
+
+  test("propagates errors thrown by the AI provider", async () => {
+    mockGenerateOrganizationAIObject.mockRejectedValue(new Error("provider failed"));
+
+    await expect(translateFields({ ...baseInput, fields })).rejects.toThrow("provider failed");
   });
 });

--- a/apps/web/modules/ee/ai-translation/lib/translate-fields.test.ts
+++ b/apps/web/modules/ee/ai-translation/lib/translate-fields.test.ts
@@ -101,4 +101,49 @@ describe("translateFields", () => {
 
     await expect(translateFields({ ...baseInput, fields })).rejects.toThrow("provider failed");
   });
+
+  test("echoes empty defaultText through without calling the model", async () => {
+    const allEmpty: TAITranslationField[] = [
+      { path: "welcomeCard.subheader.default", defaultText: "", isRichText: false },
+      { path: "endings.0.subheader.default", defaultText: "", isRichText: false },
+    ];
+
+    const result = await translateFields({ ...baseInput, fields: allEmpty });
+
+    expect(result).toEqual({
+      "welcomeCard.subheader.default": "",
+      "endings.0.subheader.default": "",
+    });
+    expect(mockGenerateOrganizationAIObject).not.toHaveBeenCalled();
+  });
+
+  test("translates non-empty fields and echoes empty ones in the same call", async () => {
+    const mixed: TAITranslationField[] = [
+      { path: "welcomeCard.headline.default", defaultText: "Welcome", isRichText: false },
+      { path: "welcomeCard.subheader.default", defaultText: "", isRichText: false },
+      { path: "questions.0.headline.default", defaultText: "How are you?", isRichText: false },
+    ];
+
+    // Empty fields are filtered out before indexing, so the model only sees
+    // the two non-empty entries as t0 and t1.
+    mockGenerateOrganizationAIObject.mockResolvedValue({
+      object: { t0: "Willkommen", t1: "Wie geht es dir?" },
+    });
+
+    const result = await translateFields({ ...baseInput, fields: mixed });
+
+    expect(result).toEqual({
+      "welcomeCard.headline.default": "Willkommen",
+      "welcomeCard.subheader.default": "",
+      "questions.0.headline.default": "Wie geht es dir?",
+    });
+
+    // Confirm the model never saw the empty field in the payload.
+    const callArg = mockGenerateOrganizationAIObject.mock.calls[0][0];
+    const userPayload = JSON.parse(callArg.prompt);
+    expect(userPayload).toEqual([
+      { id: "t0", text: "Welcome", richText: false },
+      { id: "t1", text: "How are you?", richText: false },
+    ]);
+  });
 });

--- a/apps/web/modules/ee/ai-translation/lib/translate-fields.ts
+++ b/apps/web/modules/ee/ai-translation/lib/translate-fields.ts
@@ -28,9 +28,27 @@ export const translateFields = async ({
     return {};
   }
 
+  // Empty defaultText is valid per the schema but has no meaningful translation.
+  // Echo it through unchanged so callers still see every requested path in the
+  // result, instead of aborting the whole batch when the model "fails" to
+  // translate an empty string.
+  const translatableFields: TAITranslationField[] = [];
+  const passthroughTranslations: Record<string, string> = {};
+  for (const field of fields) {
+    if (field.defaultText.length === 0) {
+      passthroughTranslations[field.path] = "";
+    } else {
+      translatableFields.push(field);
+    }
+  }
+
+  if (translatableFields.length === 0) {
+    return passthroughTranslations;
+  }
+
   // Indexed IDs insulate the LLM from user-supplied paths (dots, casing,
   // separator normalization). We map back to paths after generation.
-  const items = fields.map((f, i) => ({
+  const items = translatableFields.map((f, i) => ({
     id: `t${i}`,
     path: f.path,
     text: f.defaultText,
@@ -76,7 +94,7 @@ Rules:
         organizationId,
         sourceLanguage,
         targetLanguage,
-        requestedCount: fields.length,
+        requestedCount: translatableFields.length,
         returnedCount: Object.keys(translations).length,
         missingIds,
       },
@@ -85,5 +103,5 @@ Rules:
     throw new Error("AI translation returned incomplete result");
   }
 
-  return translations;
+  return { ...passthroughTranslations, ...translations };
 };

--- a/apps/web/modules/ee/ai-translation/lib/translate-fields.ts
+++ b/apps/web/modules/ee/ai-translation/lib/translate-fields.ts
@@ -75,7 +75,7 @@ Rules:
     temperature: 0,
   });
 
-  const translatedById = result.object as Record<string, string>;
+  const translatedById = result.object;
 
   const translations: Record<string, string> = {};
   const missingIds: string[] = [];

--- a/apps/web/modules/ee/ai-translation/lib/translate-fields.ts
+++ b/apps/web/modules/ee/ai-translation/lib/translate-fields.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { z } from "zod";
 import { logger } from "@formbricks/logger";
-import { generateOrganizationAIText } from "@/lib/ai/service";
+import { generateOrganizationAIObject } from "@/lib/ai/service";
 
 export const ZAITranslationField = z.object({
   path: z.string(),
@@ -24,57 +24,65 @@ export const translateFields = async ({
   sourceLanguage,
   targetLanguage,
 }: TranslateFieldsInput): Promise<Record<string, string>> => {
-  const items = fields.map((f) => ({
-    key: f.path,
+  if (fields.length === 0) {
+    return {};
+  }
+
+  // Indexed IDs insulate the LLM from user-supplied paths (dots, casing,
+  // separator normalization). We map back to paths after generation.
+  const items = fields.map((f, i) => ({
+    id: `t${i}`,
+    path: f.path,
     text: f.defaultText,
     richText: f.isRichText,
   }));
 
-  const systemPrompt = `You are a professional translator for survey content. Translate the provided survey fields from ${sourceLanguage} to ${targetLanguage}.
+  // Schema with explicit keys forces the provider to return exactly this set.
+  const schema = z.object(Object.fromEntries(items.map((item) => [item.id, z.string()])));
+
+  const systemPrompt = `You are a professional translator for survey content. Translate each item from ${sourceLanguage} to ${targetLanguage}.
 
 Rules:
-- Return ONLY a valid JSON object mapping each "key" to its translated text.
-- For rich text fields (richText: true), preserve all HTML tags exactly as they are. Only translate the text content within the tags.
-- Preserve any {{variable}} patterns exactly as they are — do not translate text inside double curly braces.
-- Do not add any explanation, markdown formatting, or extra text — return raw JSON only.`;
+- For rich text items (richText: true), preserve all HTML tags exactly. Only translate the text content within the tags.
+- Preserve any {{variable}} patterns exactly — do not translate text inside double curly braces.
+- Translate every item. Do not omit any keys.`;
 
-  const result = await generateOrganizationAIText({
+  const userPayload = JSON.stringify(items.map(({ id, text, richText }) => ({ id, text, richText })));
+
+  const result = await generateOrganizationAIObject({
     organizationId,
+    schema,
     system: systemPrompt,
-    prompt: JSON.stringify(items),
+    prompt: userPayload,
+    temperature: 0,
   });
 
-  // Parse AI response as JSON.
-  // 1. Strip markdown code fences if present, then try JSON.parse directly.
-  // 2. Fall back to extracting the first {...} block for wrapper text.
-  let parsed: Record<string, string>;
-  try {
-    const stripped = result.text.replaceAll(/^```(?:json)?\s*\n?|\n?```\s*$/g, "").trim();
-    try {
-      parsed = JSON.parse(stripped);
-    } catch {
-      const start = stripped.indexOf("{");
-      const end = stripped.lastIndexOf("}");
-      if (start === -1 || end === -1 || end <= start) {
-        throw new Error("No JSON object found in AI response");
-      }
-      parsed = JSON.parse(stripped.slice(start, end + 1));
+  const translatedById = result.object as Record<string, string>;
+
+  const translations: Record<string, string> = {};
+  const missingIds: string[] = [];
+  for (const item of items) {
+    const value = translatedById[item.id];
+    if (typeof value === "string" && value.length > 0) {
+      translations[item.path] = value;
+    } else {
+      missingIds.push(item.id);
     }
-  } catch (parseError) {
-    logger.error(
-      { rawResponse: result.text.slice(0, 500), parseError },
-      "Failed to parse AI translation response"
-    );
-    throw new Error("Failed to parse AI translation response");
   }
 
-  // Validate and filter to only requested keys
-  const validKeys = new Set(fields.map((f) => f.path));
-  const translations: Record<string, string> = {};
-  for (const [key, value] of Object.entries(parsed)) {
-    if (validKeys.has(key) && typeof value === "string") {
-      translations[key] = value;
-    }
+  if (missingIds.length > 0) {
+    logger.error(
+      {
+        organizationId,
+        sourceLanguage,
+        targetLanguage,
+        requestedCount: fields.length,
+        returnedCount: Object.keys(translations).length,
+        missingIds,
+      },
+      "AI translation returned incomplete result"
+    );
+    throw new Error("AI translation returned incomplete result");
   }
 
   return translations;

--- a/packages/ai/vite.config.ts
+++ b/packages/ai/vite.config.ts
@@ -1,4 +1,5 @@
 /// <reference types="vitest" />
+import { builtinModules } from "node:module";
 import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
@@ -17,6 +18,8 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        ...builtinModules,
+        ...builtinModules.map((m) => `node:${m}`),
         "ai",
         "@ai-sdk/amazon-bedrock",
         "@ai-sdk/azure",


### PR DESCRIPTION
Linear: [ENG-1217 — Investigate AI translations not working](https://linear.app/formbricks/issue/ENG-1217/investigate-ai-translations-not-working)

## Summary

Two independent fixes that together resolve the long-standing bug where AI translations returned an empty object in production, leaving input fields un-populated despite a green success toast.

### 1. `packages/ai/vite.config.ts` — Rollup build fix

`@formbricks/ai` is published as a Vite/Rollup-built ESM bundle. Its `rollupOptions.external` listed the heavy npm dependencies but did **not** include Node built-ins. Rollup then bundled `node:crypto` (and any other built-in) into the dist by emitting an empty-object stub:

```js
// dist/index.js (broken)
m = (a((e, t) => { t.exports = {}; }))(),
...
return t ? (0, m.createHash)("sha256")...   // <-- m has no .createHash
```

At runtime, the Google Vertex provider's `buildCacheKey` called `createHash(...)` on this empty stub and threw `TypeError: createHash is not a function` before any AI request was issued. The thrown error was wrapped by `next-safe-action` into a `serverError`, the client lost its `data.translations`, and the UI rendered as "translations are empty."

The fix lists `node:*` (both bare and prefixed forms) as external via `builtinModules`. After rebuild, `dist/index.js` emits a real `import { createHash } from "node:crypto"` that Node resolves correctly at runtime.

This explains the local-vs-prod asymmetry too: `next dev` (Turbopack) loads the package's TypeScript source directly via tsconfig paths, bypassing the broken dist entirely. Only `next build` + `next start` consumed `dist/index.js` and hit the bug — which is what production does.

### 2. `apps/web/modules/ee/ai-translation/lib/translate-fields.ts` — translation reliability

Even with the build fix above, the translation helper was structurally fragile. It asked the model to return free-form JSON keyed by user-supplied field paths like `questions.0.headline.default`, then post-filtered the response against the requested key set. When the model interpreted the dots as nested-object syntax — returning `{ questions: { "0": { headline: { default: "..." } } } }` — every top-level key failed the filter and the function returned `{}` with no error.

Two changes remove the failure mode:

- **Indexed IDs.** The model now sees opaque IDs (`t0`, `t1`, ...) instead of dotted paths. With no separator to interpret, the response stays flat. We map IDs back to real paths after the response returns.
- **Structured outputs.** Switched from `generateOrganizationAIText` (free-text JSON + ad-hoc parse + brace-matching fallback) to `generateOrganizationAIObject` with a Zod schema built from the indexed IDs. The provider enforces the response shape on its side; if the model deviates, we get a clear error instead of silent shape drift.

Additional hardening:
- Throw with a structured log when any ID is missing from the response, surfacing a real error to the UI instead of a misleading green toast.
- Early-return on empty input.
- `temperature: 0` for consistent output across runs.

Removed: the entire `JSON.parse` + markdown-fence strip + `lastIndexOf("}")` fallback chain. The schema-enforced path doesn't need it.

## Benchmark

Quick local benchmark (Vertex `gemini-2.5-flash`, English → German, 5 runs × 2 fixtures) — script lives at `apps/web/scripts/ai-translation-bench.ts` (not part of this PR, kept locally as a diagnostic).

| Fixture            | Fields | Approach | Success | Avg latency | Range          |
|--------------------|-------:|----------|--------:|------------:|----------------|
| small_flat         |      3 | old      |     5/5 |     1720ms | 1323–2104ms    |
| small_flat         |      3 | new      |     5/5 |     1998ms | 1784–2189ms    |
| realistic_nested   |     12 | old      |     5/5 |     4255ms | 1903–5608ms    |
| realistic_nested   |     12 | new      |     5/5 |     4026ms | 3926–4320ms    |

Both succeed in this small sample (the prod failure is intermittent and depends on survey size, target language, and model state — not reliably reproducible locally). The notable signal is **latency variance**: structured outputs produced a ~10× tighter latency range on the realistic fixture (394ms vs 3705ms). The reliability win is structural, not statistical — the new path can't fail in the way the old one was.

## Test plan

- [ ] `pnpm --filter @formbricks/ai build` succeeds and `dist/index.js` contains `import { createHash` (not a stub)
- [ ] `pnpm --filter @formbricks/web build && pnpm --filter @formbricks/web start` no longer throws `createHash is not a function`
- [ ] Trigger an AI translation in the UI; input fields populate with translated text
- [ ] Verify on a multi-question survey (12+ fields) with deep field paths
- [ ] Verify with at least one non-Latin target language (Japanese / Arabic / Chinese)
- [ ] On a forced failure (delete a key from the model's response in test), the UI surfaces an error instead of a silent empty result
