### PR TITLE
fix: fixes openapi example and adds both questions and blocks to v1 api example

### DIFF
--- a/docs/api-reference/openapi.json
+++ b/docs/api-reference/openapi.json
@@ -4450,7 +4450,7 @@
     },
     "/api/v1/management/surveys": {
       "get": {
-        "description": "Fetches all existing surveys",
+        "description": "Fetches all existing surveys. Each survey includes both `questions` (the legacy structure) and `blocks` (the newer structure). `questions` is always derived from `blocks` for backwards compatibility, so integrations may read either field.",
         "parameters": [
           {
             "example": "{{apiKey}}",
@@ -4471,6 +4471,64 @@
                     {
                       "autoClose": null,
                       "autoComplete": null,
+                      "blocks": [
+                        {
+                          "elements": [
+                            {
+                              "headline": {
+                                "default": "What would you like to know?"
+                              },
+                              "id": "ovpy6va1hab7fl12n913zua0",
+                              "inputType": "text",
+                              "placeholder": {
+                                "default": "Type your answer here..."
+                              },
+                              "required": true,
+                              "subheader": {
+                                "default": "This is an example survey."
+                              },
+                              "type": "openText"
+                            }
+                          ],
+                          "id": "qp8j2k0fx3m9wd1c7b5n4tva",
+                          "name": "Block 1"
+                        },
+                        {
+                          "elements": [
+                            {
+                              "choices": [
+                                {
+                                  "id": "xpoxuu3sifk1ee8he67ctf5i",
+                                  "label": {
+                                    "default": "Sun ☀️"
+                                  }
+                                },
+                                {
+                                  "id": "hnsovcdmxtcbly6tig1az3qc",
+                                  "label": {
+                                    "default": "Ocean 🌊"
+                                  }
+                                },
+                                {
+                                  "id": "kcnelzdxknvwo8fq20d3nrr5",
+                                  "label": {
+                                    "default": "Palms 🌴"
+                                  }
+                                }
+                              ],
+                              "headline": {
+                                "default": "What's important on vacay?"
+                              },
+                              "id": "awkn2llljy7a4oulp5t15yec",
+                              "required": true,
+                              "shuffleOption": "none",
+                              "type": "multipleChoiceMulti"
+                            }
+                          ],
+                          "id": "rk4v9m2dqz7n0fyt8c3b1xws",
+                          "name": "Block 2"
+                        }
+                      ],
                       "createdAt": "2024-08-05T11:08:27.042Z",
                       "createdBy": "clfv1zvij0000ru0gunwpy43a",
                       "delay": 0,
@@ -4875,6 +4933,64 @@
                   "data": {
                     "autoClose": null,
                     "autoComplete": null,
+                    "blocks": [
+                      {
+                        "elements": [
+                          {
+                            "headline": {
+                              "default": "What would you like to know?"
+                            },
+                            "id": "ovpy6va1hab7fl12n913zua0",
+                            "inputType": "text",
+                            "placeholder": {
+                              "default": "Type your answer here..."
+                            },
+                            "required": true,
+                            "subheader": {
+                              "default": "This is an example survey."
+                            },
+                            "type": "openText"
+                          }
+                        ],
+                        "id": "qp8j2k0fx3m9wd1c7b5n4tva",
+                        "name": "Block 1"
+                      },
+                      {
+                        "elements": [
+                          {
+                            "choices": [
+                              {
+                                "id": "xpoxuu3sifk1ee8he67ctf5i",
+                                "label": {
+                                  "default": "Sun ☀️"
+                                }
+                              },
+                              {
+                                "id": "hnsovcdmxtcbly6tig1az3qc",
+                                "label": {
+                                  "default": "Ocean 🌊"
+                                }
+                              },
+                              {
+                                "id": "kcnelzdxknvwo8fq20d3nrr5",
+                                "label": {
+                                  "default": "Palms 🌴"
+                                }
+                              }
+                            ],
+                            "headline": {
+                              "default": "What's important on vacay?"
+                            },
+                            "id": "awkn2llljy7a4oulp5t15yec",
+                            "required": true,
+                            "shuffleOption": "none",
+                            "type": "multipleChoiceMulti"
+                          }
+                        ],
+                        "id": "rk4v9m2dqz7n0fyt8c3b1xws",
+                        "name": "Block 2"
+                      }
+                    ],
                     "createdAt": "2024-08-05T11:08:27.042Z",
                     "createdBy": "clfv1zvij0000ru0gunwpy43a",
                     "delay": 0,
@@ -5141,6 +5257,64 @@
                   "data": {
                     "autoClose": null,
                     "autoComplete": null,
+                    "blocks": [
+                      {
+                        "elements": [
+                          {
+                            "headline": {
+                              "default": "What would you like to know?"
+                            },
+                            "id": "ovpy6va1hab7fl12n913zua0",
+                            "inputType": "text",
+                            "placeholder": {
+                              "default": "Type your answer here..."
+                            },
+                            "required": true,
+                            "subheader": {
+                              "default": "This is an example survey."
+                            },
+                            "type": "openText"
+                          }
+                        ],
+                        "id": "qp8j2k0fx3m9wd1c7b5n4tva",
+                        "name": "Block 1"
+                      },
+                      {
+                        "elements": [
+                          {
+                            "choices": [
+                              {
+                                "id": "xpoxuu3sifk1ee8he67ctf5i",
+                                "label": {
+                                  "default": "Sun ☀️"
+                                }
+                              },
+                              {
+                                "id": "hnsovcdmxtcbly6tig1az3qc",
+                                "label": {
+                                  "default": "Ocean 🌊"
+                                }
+                              },
+                              {
+                                "id": "kcnelzdxknvwo8fq20d3nrr5",
+                                "label": {
+                                  "default": "Palms 🌴"
+                                }
+                              }
+                            ],
+                            "headline": {
+                              "default": "What's important on vacay?"
+                            },
+                            "id": "awkn2llljy7a4oulp5t15yec",
+                            "required": true,
+                            "shuffleOption": "none",
+                            "type": "multipleChoiceMulti"
+                          }
+                        ],
+                        "id": "rk4v9m2dqz7n0fyt8c3b1xws",
+                        "name": "Block 2"
+                      }
+                    ],
                     "createdAt": "2024-08-05T11:08:27.042Z",
                     "createdBy": "clfv1zvij0000ru0gunwpy43a",
                     "delay": 0,
@@ -5366,7 +5540,7 @@
         "tags": ["Management API - Survey"]
       },
       "get": {
-        "description": "Fetch a survey object based on its ID",
+        "description": "Fetch a survey object based on its ID. The response includes both `questions` (the legacy structure) and `blocks` (the newer structure). `questions` is always derived from `blocks` for backwards compatibility, so integrations may read either field.",
         "parameters": [
           {
             "example": "{{apiKey}}",
@@ -5394,6 +5568,64 @@
                   "data": {
                     "autoClose": null,
                     "autoComplete": null,
+                    "blocks": [
+                      {
+                        "elements": [
+                          {
+                            "headline": {
+                              "default": "What would you like to know?"
+                            },
+                            "id": "ovpy6va1hab7fl12n913zua0",
+                            "inputType": "text",
+                            "placeholder": {
+                              "default": "Type your answer here..."
+                            },
+                            "required": true,
+                            "subheader": {
+                              "default": "This is an example survey."
+                            },
+                            "type": "openText"
+                          }
+                        ],
+                        "id": "qp8j2k0fx3m9wd1c7b5n4tva",
+                        "name": "Block 1"
+                      },
+                      {
+                        "elements": [
+                          {
+                            "choices": [
+                              {
+                                "id": "xpoxuu3sifk1ee8he67ctf5i",
+                                "label": {
+                                  "default": "Sun ☀️"
+                                }
+                              },
+                              {
+                                "id": "hnsovcdmxtcbly6tig1az3qc",
+                                "label": {
+                                  "default": "Ocean 🌊"
+                                }
+                              },
+                              {
+                                "id": "kcnelzdxknvwo8fq20d3nrr5",
+                                "label": {
+                                  "default": "Palms 🌴"
+                                }
+                              }
+                            ],
+                            "headline": {
+                              "default": "What's important on vacay?"
+                            },
+                            "id": "awkn2llljy7a4oulp5t15yec",
+                            "required": true,
+                            "shuffleOption": "none",
+                            "type": "multipleChoiceMulti"
+                          }
+                        ],
+                        "id": "rk4v9m2dqz7n0fyt8c3b1xws",
+                        "name": "Block 2"
+                      }
+                    ],
                     "createdAt": "2024-08-05T11:08:27.042Z",
                     "createdBy": "clfv1zvij0000ru0gunwpy43a",
                     "delay": 0,
@@ -5597,6 +5829,64 @@
                   "data": {
                     "autoClose": null,
                     "autoComplete": null,
+                    "blocks": [
+                      {
+                        "elements": [
+                          {
+                            "headline": {
+                              "default": "What would you like to know?"
+                            },
+                            "id": "ovpy6va1hab7fl12n913zua0",
+                            "inputType": "text",
+                            "placeholder": {
+                              "default": "Type your answer here..."
+                            },
+                            "required": true,
+                            "subheader": {
+                              "default": "This is an example survey."
+                            },
+                            "type": "openText"
+                          }
+                        ],
+                        "id": "qp8j2k0fx3m9wd1c7b5n4tva",
+                        "name": "Block 1"
+                      },
+                      {
+                        "elements": [
+                          {
+                            "choices": [
+                              {
+                                "id": "xpoxuu3sifk1ee8he67ctf5i",
+                                "label": {
+                                  "default": "Sun ☀️"
+                                }
+                              },
+                              {
+                                "id": "hnsovcdmxtcbly6tig1az3qc",
+                                "label": {
+                                  "default": "Ocean 🌊"
+                                }
+                              },
+                              {
+                                "id": "kcnelzdxknvwo8fq20d3nrr5",
+                                "label": {
+                                  "default": "Palms 🌴"
+                                }
+                              }
+                            ],
+                            "headline": {
+                              "default": "What's important on vacay?"
+                            },
+                            "id": "awkn2llljy7a4oulp5t15yec",
+                            "required": true,
+                            "shuffleOption": "none",
+                            "type": "multipleChoiceMulti"
+                          }
+                        ],
+                        "id": "rk4v9m2dqz7n0fyt8c3b1xws",
+                        "name": "Block 2"
+                      }
+                    ],
                     "createdAt": "2024-08-05T11:08:27.042Z",
                     "createdBy": "clfv1zvij0000ru0gunwpy43a",
                     "delay": 0,


### PR DESCRIPTION
## What does this PR do?

  Updates the **API v1 management Survey** reference docs (`docs/api-reference/openapi.json`) to reflect the current API behavior shipped in the questions/blocks PR.

  The endpoints now always return **both** `questions` and `blocks` (`questions` is derived from `blocks` for backwards compatibility), but the docs only showed a `questions` array —
  implying that's the only structure returned. This left the [Get Survey by ID](https://formbricks.com/docs/api-reference/management-api--survey/get-survey-by-id) example (and the other
  survey responses) outdated.

  Changes:
  - Added a `blocks` array to all **5 survey response examples** — GET `/surveys` (list), GET `/surveys/{surveyId}`, POST `/surveys`, PUT `/surveys/{surveyId}`, and the DELETE response.
  The blocks mirror each example's questions (same element IDs), matching the real "both returned" payload.
  - Left the POST **request body** example as `questions`-only — survey creation rejects both fields at once, so showing both as input would be misleading.
  - Clarified the GET (list + by-ID) descriptions: the response includes both `questions` (legacy structure) and `blocks` (newer structure); `questions` is always derived from `blocks`, so
  integrations may read either field.

  No code changes — docs only. The v2 reference (`docs/api-v2-reference/openapi.yml`) is generated from Zod schemas where `ZSurveyWithoutQuestionType` already includes both fields, so it
  needs no manual change.

  Fixes #(issue)

  ## How should this be tested?

  - Open the [Get Survey by ID](https://formbricks.com/docs/api-reference/management-api--survey/get-survey-by-id) docs page (and the list/create/update pages) and confirm each survey
  response example now shows both a `questions` array and a `blocks` array.
  - Confirm the POST request body example still shows `questions` only.
  - Confirm the GET descriptions mention that both `questions` and `blocks` are returned.
  - `node -e 'JSON.parse(require("fs").readFileSync("docs/api-reference/openapi.json","utf8"))'` → file is still valid JSON.

  ## Checklist

  ### Required

  - [x] Filled out the "How to test" section in this PR
  - [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
  - [x] Self-reviewed my own code
  - [x] Commented on my code in hard-to-understand bits
  - [ ] Ran `pnpm build`
  - [x] Checked for warnings, there are none
  - [ ] Removed all `console.logs`
  - [ ] Merged the latest changes from main onto my branch with `git pull origin main`
  - [x] My changes don't cause any responsiveness issues
  - [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

  ### Appreciated

  - [ ] If a UI change was made: Added a screen recording or screenshots to this PR
  - [x] Updated the Formbricks Docs if changes were necessary