### PR TITLE
chore: move pnpm security overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,40 +81,5 @@
     "budgetPercentIncreaseRed": 20,
     "minimumChangeThreshold": 0,
     "showDetails": true
-  },
-  "pnpm": {
-    "overrides": {
-      "@hono/node-server": "1.19.13",
-      "@protobufjs/utf8": "1.1.1",
-      "@tootallnate/once": "3.0.1",
-      "@xmldom/xmldom": "0.9.10",
-      "ajv@6": "6.14.0",
-      "axios": "1.16.0",
-      "effect": "3.20.0",
-      "fast-uri": "3.1.2",
-      "fast-xml-parser": "5.7.0",
-      "hono": "4.12.18",
-      "ip-address": "10.1.1",
-      "js-cookie": "3.0.7",
-      "lodash": "4.18.1",
-      "minimatch@10": "10.2.5",
-      "node-forge": "1.4.0",
-      "postcss": "8.5.14",
-      "protobufjs@7": "7.5.8",
-      "protobufjs@8": "8.2.0",
-      "qs@6": "6.15.2",
-      "tar": "7.5.15",
-      "uuid@8": "11.1.1",
-      "uuid@9": "11.1.1",
-      "uuid@11": "11.1.1",
-      "ws@8": "8.21.0",
-      "yaml@2": "2.9.0"
-    },
-    "comments": {
-      "overrides": "Security fixes for transitive dependencies that still fail a no-override audit. Remove each override when its upstream chain adopts a patched version: @hono/node-server/hono via Prisma dev tooling | @protobufjs/utf8 (CVE overlong UTF-8) - awaiting @opentelemetry/otlp-transformer update | @tootallnate/once and tar via sqlite3/node-gyp chain | @xmldom/xmldom (XML injection/DoS CVEs) - awaiting @boxyhq/saml20 to pin to >=0.9.10 | axios, lodash, and node-forge via @boxyhq/saml-jackson | ajv@6 via webpack/eslint | effect (GHSA-38f7-945m-qr2g) - awaiting @prisma/config update | fast-uri (CVE-2025-48944/48945) - awaiting ajv/schema-utils update | fast-xml-parser via AWS SDK XML builder | ip-address (XSS in Address6) - awaiting mongodb/socks update | js-cookie (GHSA-qjx8-664m-686j prototype hijack) - awaiting react-use to bump to >=3.0.7 | minimatch@10 (CVE-2026-27904 / GHSA-23c5-xmqv-rm74, nested extglob ReDoS) - awaiting @rushstack/node-core-library (via vite-plugin-dts -> @microsoft/api-extractor) to bump to >=10.2.3 | postcss (CVE-2025-62695) - awaiting next.js to unpin postcss | protobufjs@7/8 (GHSA-xq3m-2v4x-88gg et al.) - awaiting @grpc/proto-loader/otlp-transformer update | qs@6 (GHSA-q8mj-m7cp-5q26 DoS) - awaiting @googleapis/admin via @boxyhq/saml-jackson update | uuid@8/9/11 (GHSA-w5hq-g745-h8pq buffer bounds, CVE-2025-61475) - awaiting @azure/msal-node, @sentry/webpack-plugin and typeorm updates | ws@8 (GHSA-58qx-3vcg-4xpx memory disclosure) - awaiting storybook and react-email/socket.io updates | yaml@2 (GHSA-48c2-rrv3-qjmp stack overflow) - awaiting lint-staged update"
-    },
-    "patchedDependencies": {
-      "next-auth@4.24.13": "patches/next-auth@4.24.13.patch"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,45 @@ packages:
   - "apps/*"
   - "packages/*"
 
+# Security overrides for transitive dependencies that still fail audit without a pin.
+# Remove each override once its upstream dependency chain adopts a patched version.
+overrides:
+  # Prisma dev tooling and @modelcontextprotocol/sdk chains.
+  "@hono/node-server": 1.19.13
+  hono: 4.12.18
+  # OpenTelemetry / protobuf chains.
+  "@protobufjs/utf8": 1.1.1
+  protobufjs@7: 7.5.8
+  protobufjs@8: 8.2.0
+  # sqlite3 / node-gyp chain.
+  "@tootallnate/once": 3.0.1
+  tar: 7.5.15
+  # SAML and XML processing chains.
+  "@xmldom/xmldom": 0.9.10
+  axios: 1.16.0
+  lodash: 4.18.1
+  node-forge: 1.4.0
+  qs@6: 6.15.2
+  # Webpack / linting / schema validation chains.
+  ajv@6: 6.14.0
+  fast-uri: 3.1.2
+  minimatch@10: 10.2.5
+  postcss: 8.5.14
+  # SDK and runtime transitive security pins.
+  effect: 3.20.0
+  fast-xml-parser: 5.7.0
+  ip-address: 10.1.1
+  js-cookie: 3.0.7
+  uuid@8: 11.1.1
+  uuid@9: 11.1.1
+  uuid@11: 11.1.1
+  # ENG-1111 / GHSA-58qx-3vcg-4xpx: ws is patched in 8.20.1+.
+  ws@8: 8.21.0
+  yaml@2: 2.9.0
+
+patchedDependencies:
+  next-auth@4.24.13: patches/next-auth@4.24.13.patch
+
 # Allow lifecycle scripts for packages that need to build native binaries
 # Required for pnpm v10+ which blocks scripts by default
 onlyBuiltDependencies:


### PR DESCRIPTION
## What does this PR do?

Moves pnpm security `overrides` and `patchedDependencies` from the ignored legacy `package.json#pnpm` block to top-level `pnpm-workspace.yaml`, so pnpm 10 honors the transitive security pins during installs and lockfile regeneration.

This keeps the existing patched resolutions durable for:

Fixes ENG-1108
Fixes ENG-1110
Fixes ENG-1111

No runtime code changes.

## How should this be tested?

- Run `pnpm install --lockfile-only`
  - Confirm it succeeds without the old ignored `package.json#pnpm` warning.
- Run `pnpm install --frozen-lockfile`
  - Confirm it succeeds without the old ignored `package.json#pnpm` warning.
- Run `pnpm audit --json`
  - Confirm `qs`, `uuid`, and `ws` advisories are not reported.
  - Note: audit still reports unrelated Hono advisories via `apps__web>@modelcontextprotocol/sdk>hono`.
- Confirm lockfile resolutions:
  - `qs` resolves to `6.15.2`
  - `uuid` resolves to `11.1.1` / `14.0.0`
  - `ws` resolves to `8.21.0`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary