### PR TITLE
fix: update E2E tests for streamlined onboarding flow

### DIFF
--- a/apps/web/playwright/fixtures/users.ts
+++ b/apps/web/playwright/fixtures/users.ts
@@ -50,6 +50,7 @@ export type UsersFixture = {
     organizationName?: string;
     workspaceName?: string;
     withoutWorkspace?: boolean;
+    skipSurveySeed?: boolean;
   }) => Promise<UserFixture>;
   get: () => UserFixture[];
 };
@@ -66,6 +67,7 @@ export const createUsersFixture = (page: Page, workerInfo: TestInfo): UsersFixtu
       organizationName?: string;
       workspaceName?: string;
       withoutWorkspace?: boolean;
+      skipSurveySeed?: boolean;
     }) => {
       const uname = params?.name ?? `user-${workerInfo.workerIndex}-${Date.now()}`;
       const userEmail = params?.email ?? `${uname}@example.com`;
@@ -127,6 +129,18 @@ export const createUsersFixture = (page: Page, workerInfo: TestInfo): UsersFixtu
               workspaceId: workspace.id,
             })),
           });
+
+          if (!params?.skipSurveySeed) {
+            await prisma.survey.create({
+              data: {
+                workspaceId: workspace.id,
+                createdBy: user.id,
+                name: "E2E Seed Survey",
+                status: "draft",
+                type: "link",
+              },
+            });
+          }
 
           ids = { workspaceId: workspace.id };
         }

--- a/apps/web/playwright/onboarding.spec.ts
+++ b/apps/web/playwright/onboarding.spec.ts
@@ -3,7 +3,7 @@ import { test } from "./lib/fixtures";
 
 test.describe("Onboarding Flow Test", async () => {
   test("start from scratch", async ({ page, users }) => {
-    const user = await users.create({ withoutWorkspace: true });
+    const user = await users.create({ skipSurveySeed: true });
     await user.login();
 
     await page.waitForURL(/\/organizations\/[^/]+\/workspaces\/new\/survey/);
@@ -17,14 +17,14 @@ test.describe("Onboarding Flow Test", async () => {
   });
 
   test("use template", async ({ page, users }) => {
-    const user = await users.create({ withoutWorkspace: true });
+    const user = await users.create({ skipSurveySeed: true });
     await user.login();
 
     await page.waitForURL(/\/organizations\/[^/]+\/workspaces\/new\/survey/);
-    await page.getByRole("button", { name: "Use a quick template" }).click();
+    await page.getByRole("button", { name: "Use a template" }).click();
 
     await page.waitForURL(/\/organizations\/[^/]+\/workspaces\/new\/templates/);
-    await page.getByRole("button", { name: "NPS Net Promoter Score" }).click();
+    await page.getByRole("button", { name: "NPS" }).click();
 
     await page.waitForURL(/\/workspaces\/[^/]+\/surveys\/[^/]+\/edit(\?.*)mode=cx/);
     await page.getByRole("button", { name: "Save & Close" }).click();

--- a/apps/web/playwright/utils/helper.ts
+++ b/apps/web/playwright/utils/helper.ts
@@ -3,7 +3,6 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { Page } from "playwright";
 import { logger } from "@formbricks/logger";
-import { TWorkspaceConfigChannel } from "@formbricks/types/workspace";
 import { CreateSurveyParams, CreateSurveyWithLogicParams } from "@/playwright/utils/mock";
 
 const MOCK_STORAGE_UPLOAD_PATH = "/__playwright__/mock-storage-upload";
@@ -313,31 +312,14 @@ export const uploadImageChoicesForPictureSelection = async (page: Page) => {
   }
 };
 
-export const finishOnboarding = async (
-  page: Page,
-  workspaceChannel: TWorkspaceConfigChannel = "website"
-): Promise<void> => {
-  await page.waitForURL(/\/organizations\/[^/]+\/workspaces\/new\/mode/);
+export const finishOnboarding = async (page: Page): Promise<void> => {
+  await page.waitForURL(/\/organizations\/[^/]+\/workspaces\/new\/survey/);
+  await page.getByRole("button", { name: "Start from scratch" }).click();
 
-  await page.getByRole("button", { name: "Formbricks Surveys Multi-" }).click();
+  await page.waitForURL(/\/workspaces\/[^/]+\/surveys\/[^/]+\/edit(\?.*)mode=cx/);
+  await page.getByRole("button", { name: "Save & Close" }).click();
 
-  if (workspaceChannel === "app") {
-    await page.getByRole("button", { name: "In-product surveys" }).click();
-  } else {
-    await page.getByRole("button", { name: "Link & email surveys" }).click();
-  }
-
-  // await page.getByRole("button", { name: "Proven methods SaaS" }).click();
-  await page.getByPlaceholder("e.g. Formbricks").click();
-  await page.getByPlaceholder("e.g. Formbricks").fill("My Workspace");
-  await page.locator("#form-next-button").click();
-
-  if (workspaceChannel !== "link") {
-    await page.getByRole("button", { name: "I will do it later" }).click();
-  }
-
-  await page.waitForURL(/\/workspaces\/[^/]+\/surveys/);
-  await expect(page.getByText("My Workspace")).toBeVisible();
+  await page.waitForURL(/\/workspaces\/[^/]+\/surveys\/[^/]+\/summary(\?.*)?$/);
 };
 
 export const signupUsingInviteToken = async (page: Page, name: string, email: string, password: string) => {

--- a/apps/web/playwright/workspace-delete.spec.ts
+++ b/apps/web/playwright/workspace-delete.spec.ts
@@ -38,7 +38,7 @@ test("requires workspace name confirmation before deleting a workspace", async (
   await expect(dialog.getByRole("button", { name: "Delete", exact: true })).toBeEnabled();
   await dialog.getByRole("button", { name: "Delete", exact: true }).click();
 
-  await expect(page.getByText("Workspace deleted successfully", { exact: true })).toBeVisible();
+  await expect(page.getByText("Workspace deleted successfully", { exact: true }).first()).toBeVisible();
   await page.waitForURL(new RegExp(`/workspaces/${remainingWorkspace.id}`));
   await expect.poll(async () => prisma.workspace.findUnique({ where: { id: user.workspaceId! } })).toBeNull();
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PR #8239 streamlined onboarding so owners/managers with a workspace but no surveys are redirected to `/organizations/:id/workspaces/new/survey` instead of `/workspaces/:id/surveys`. This caused 36 E2E failures — mostly `page.waitForURL(/\/workspaces\/[^/]+\/surveys/)` timeouts in login helpers and specs.

## Solution

- Seed a default draft survey when creating Playwright users with a workspace (unless `skipSurveySeed: true`), so normal tests bypass onboarding after login.
- Update onboarding specs to use `skipSurveySeed: true` instead of `withoutWorkspace: true`, and fix button labels to match the new UI (`Use a template`, `NPS`).
- Refresh `finishOnboarding` helper for the new first-survey flow.
- Fix workspace delete spec strict-mode failure when duplicate success toasts are rendered.

## Test plan

- [ ] CI E2E suite on PR #8239 branch passes
- [ ] Onboarding specs still cover start-from-scratch and template paths
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c95a83ea-a9e4-40c8-a0cf-ec287365d578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c95a83ea-a9e4-40c8-a0cf-ec287365d578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

