### PR TITLE
fix: enforce action-aware role checks on storage routes

### DIFF
--- a/apps/web/app/api/v1/management/storage/lib/utils.test.ts
+++ b/apps/web/app/api/v1/management/storage/lib/utils.test.ts
@@ -2,7 +2,7 @@ import { Session } from "next-auth";
 import { describe, expect, test, vi } from "vitest";
 import { TAuthenticationApiKey } from "@formbricks/types/auth";
 import { responses } from "@/app/lib/api/response";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { hasUserWorkspaceAccessForAction } from "@/lib/workspace/auth";
 import { hasPermission } from "@/modules/organization/settings/api-keys/lib/utils";
 import { checkAuth } from "./utils";
 
@@ -12,7 +12,7 @@ const mockNotAuthenticatedResponse = new Response("Not authenticated", { status:
 const mockUnauthorizedResponse = new Response("Unauthorized", { status: 401 });
 
 vi.mock("@/lib/workspace/auth", () => ({
-  hasUserWorkspaceAccess: vi.fn(),
+  hasUserWorkspaceAccessForAction: vi.fn(),
 }));
 
 vi.mock("@/modules/organization/settings/api-keys/lib/utils", () => ({
@@ -111,11 +111,11 @@ describe("checkAuth", () => {
       expires: "2024-12-31T23:59:59.999Z",
     };
 
-    vi.mocked(hasUserWorkspaceAccess).mockResolvedValue(false);
+    vi.mocked(hasUserWorkspaceAccessForAction).mockResolvedValue(false);
 
     const result = await checkAuth(mockSession, workspaceId);
 
-    expect(hasUserWorkspaceAccess).toHaveBeenCalledWith("user-123", workspaceId);
+    expect(hasUserWorkspaceAccessForAction).toHaveBeenCalledWith("user-123", workspaceId, "POST");
     expect(responses.unauthorizedResponse).toHaveBeenCalled();
     expect(result).toBe(mockUnauthorizedResponse);
   });
@@ -128,11 +128,11 @@ describe("checkAuth", () => {
       expires: "2024-12-31T23:59:59.999Z",
     };
 
-    vi.mocked(hasUserWorkspaceAccess).mockResolvedValue(true);
+    vi.mocked(hasUserWorkspaceAccessForAction).mockResolvedValue(true);
 
     const result = await checkAuth(mockSession, workspaceId);
 
-    expect(hasUserWorkspaceAccess).toHaveBeenCalledWith("user-123", workspaceId);
+    expect(hasUserWorkspaceAccessForAction).toHaveBeenCalledWith("user-123", workspaceId, "POST");
     expect(result).toBeUndefined();
   });
 

--- a/apps/web/app/api/v1/management/storage/lib/utils.ts
+++ b/apps/web/app/api/v1/management/storage/lib/utils.ts
@@ -1,6 +1,6 @@
 import { responses } from "@/app/lib/api/response";
 import { TApiV1Authentication } from "@/app/lib/api/with-api-logging";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { hasUserWorkspaceAccessForAction } from "@/lib/workspace/auth";
 import { hasPermission } from "@/modules/organization/settings/api-keys/lib/utils";
 
 export const checkAuth = async (authentication: TApiV1Authentication | undefined, workspaceId: string) => {
@@ -9,7 +9,11 @@ export const checkAuth = async (authentication: TApiV1Authentication | undefined
   }
 
   if ("user" in authentication) {
-    const isUserAuthorized = await hasUserWorkspaceAccess(authentication.user.id, workspaceId);
+    const isUserAuthorized = await hasUserWorkspaceAccessForAction(
+      authentication.user.id,
+      workspaceId,
+      "POST"
+    );
     if (!isUserAuthorized) {
       return responses.unauthorizedResponse();
     }

--- a/apps/web/app/storage/[workspaceId]/[accessType]/[...filePath]/lib/auth.ts
+++ b/apps/web/app/storage/[workspaceId]/[accessType]/[...filePath]/lib/auth.ts
@@ -2,7 +2,7 @@ import { getServerSession } from "next-auth";
 import { NextRequest } from "next/server";
 import { Result, err, ok } from "@formbricks/types/error-handlers";
 import { authenticateRequest } from "@/app/api/v1/auth";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { hasUserWorkspaceAccessForAction } from "@/lib/workspace/auth";
 import { authOptions } from "@/modules/auth/lib/authOptions";
 import { hasPermission } from "@/modules/organization/settings/api-keys/lib/utils";
 
@@ -21,7 +21,7 @@ export const authorizePrivateDownload = async (
   const session = await getServerSession(authOptions);
 
   if (session?.user) {
-    const isUserAuthorized = await hasUserWorkspaceAccess(session.user.id, workspaceId);
+    const isUserAuthorized = await hasUserWorkspaceAccessForAction(session.user.id, workspaceId, action);
     if (!isUserAuthorized) {
       return err({
         unauthorized: true,

--- a/apps/web/lib/workspace/auth.test.ts
+++ b/apps/web/lib/workspace/auth.test.ts
@@ -3,7 +3,7 @@ import { hasUserWorkspaceAccessForAction } from "./auth";
 
 const mocks = vi.hoisted(() => ({
   membershipFindFirst: vi.fn(),
-  workspaceTeamFindFirst: vi.fn(),
+  workspaceTeamFindMany: vi.fn(),
 }));
 
 vi.mock("@formbricks/database", () => ({
@@ -12,7 +12,7 @@ vi.mock("@formbricks/database", () => ({
       findFirst: mocks.membershipFindFirst,
     },
     workspaceTeam: {
-      findFirst: mocks.workspaceTeamFindFirst,
+      findMany: mocks.workspaceTeamFindMany,
     },
   },
 }));
@@ -27,13 +27,14 @@ describe("hasUserWorkspaceAccessForAction", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.workspaceTeamFindMany.mockResolvedValue([]);
   });
 
   test("returns false when the user has no organization membership for the workspace", async () => {
     mocks.membershipFindFirst.mockResolvedValue(null);
 
     expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(false);
-    expect(mocks.workspaceTeamFindFirst).not.toHaveBeenCalled();
+    expect(mocks.workspaceTeamFindMany).not.toHaveBeenCalled();
   });
 
   test.each(["GET", "POST", "PUT", "PATCH", "DELETE"] as const)(
@@ -42,7 +43,7 @@ describe("hasUserWorkspaceAccessForAction", () => {
       mocks.membershipFindFirst.mockResolvedValue({ role: "billing" });
 
       expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, action)).toBe(false);
-      expect(mocks.workspaceTeamFindFirst).not.toHaveBeenCalled();
+      expect(mocks.workspaceTeamFindMany).not.toHaveBeenCalled();
     }
   );
 
@@ -52,42 +53,63 @@ describe("hasUserWorkspaceAccessForAction", () => {
       mocks.membershipFindFirst.mockResolvedValue({ role });
 
       expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(true);
-      expect(mocks.workspaceTeamFindFirst).not.toHaveBeenCalled();
+      expect(mocks.workspaceTeamFindMany).not.toHaveBeenCalled();
     }
   );
 
   test("returns false for member role when no team grants workspace access", async () => {
     mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
-    mocks.workspaceTeamFindFirst.mockResolvedValue(null);
+    mocks.workspaceTeamFindMany.mockResolvedValue([]);
 
     expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(false);
   });
 
   test("member with read team permission can GET but cannot POST or DELETE", async () => {
     mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
-    mocks.workspaceTeamFindFirst.mockResolvedValue({ permission: "read" });
+    mocks.workspaceTeamFindMany.mockResolvedValue([{ permission: "read" }]);
 
     expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(true);
     expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "POST")).toBe(false);
     expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(false);
   });
 
-  test("member with readWrite team permission can GET and POST but cannot DELETE", async () => {
+  test("member with readWrite team permission can GET/POST/PUT/PATCH but cannot DELETE", async () => {
     mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
-    mocks.workspaceTeamFindFirst.mockResolvedValue({ permission: "readWrite" });
+    mocks.workspaceTeamFindMany.mockResolvedValue([{ permission: "readWrite" }]);
 
     expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(true);
     expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "POST")).toBe(true);
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "PUT")).toBe(true);
     expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "PATCH")).toBe(true);
     expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(false);
   });
 
   test("member with manage team permission can perform any action", async () => {
     mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
-    mocks.workspaceTeamFindFirst.mockResolvedValue({ permission: "manage" });
+    mocks.workspaceTeamFindMany.mockResolvedValue([{ permission: "manage" }]);
 
     expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(true);
     expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "POST")).toBe(true);
     expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(true);
+  });
+
+  test("member in multiple teams uses the highest permission across them", async () => {
+    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
+    mocks.workspaceTeamFindMany.mockResolvedValue([
+      { permission: "read" },
+      { permission: "manage" },
+      { permission: "readWrite" },
+    ]);
+
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(true);
+  });
+
+  test("member in multiple teams none of which grant sufficient permission is denied", async () => {
+    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
+    mocks.workspaceTeamFindMany.mockResolvedValue([{ permission: "read" }, { permission: "readWrite" }]);
+
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(true);
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "POST")).toBe(true);
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(false);
   });
 });

--- a/apps/web/lib/workspace/auth.test.ts
+++ b/apps/web/lib/workspace/auth.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { hasUserWorkspaceAccessForAction } from "./auth";
+
+const mocks = vi.hoisted(() => ({
+  membershipFindFirst: vi.fn(),
+  workspaceTeamFindFirst: vi.fn(),
+}));
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    membership: {
+      findFirst: mocks.membershipFindFirst,
+    },
+    workspaceTeam: {
+      findFirst: mocks.workspaceTeamFindFirst,
+    },
+  },
+}));
+
+vi.mock("../utils/validate", () => ({
+  validateInputs: vi.fn(),
+}));
+
+describe("hasUserWorkspaceAccessForAction", () => {
+  const userId = "00000000-0000-0000-0000-000000000001";
+  const workspaceId = "00000000-0000-0000-0000-000000000002";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns false when the user has no organization membership for the workspace", async () => {
+    mocks.membershipFindFirst.mockResolvedValue(null);
+
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(false);
+    expect(mocks.workspaceTeamFindFirst).not.toHaveBeenCalled();
+  });
+
+  test.each(["GET", "POST", "PUT", "PATCH", "DELETE"] as const)(
+    "returns false for billing role on %s",
+    async (action) => {
+      mocks.membershipFindFirst.mockResolvedValue({ role: "billing" });
+
+      expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, action)).toBe(false);
+      expect(mocks.workspaceTeamFindFirst).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each(["owner", "manager"] as const)(
+    "returns true for %s role on any action without consulting team permissions",
+    async (role) => {
+      mocks.membershipFindFirst.mockResolvedValue({ role });
+
+      expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(true);
+      expect(mocks.workspaceTeamFindFirst).not.toHaveBeenCalled();
+    }
+  );
+
+  test("returns false for member role when no team grants workspace access", async () => {
+    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
+    mocks.workspaceTeamFindFirst.mockResolvedValue(null);
+
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(false);
+  });
+
+  test("member with read team permission can GET but cannot POST or DELETE", async () => {
+    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
+    mocks.workspaceTeamFindFirst.mockResolvedValue({ permission: "read" });
+
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(true);
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "POST")).toBe(false);
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(false);
+  });
+
+  test("member with readWrite team permission can GET and POST but cannot DELETE", async () => {
+    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
+    mocks.workspaceTeamFindFirst.mockResolvedValue({ permission: "readWrite" });
+
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(true);
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "POST")).toBe(true);
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "PATCH")).toBe(true);
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(false);
+  });
+
+  test("member with manage team permission can perform any action", async () => {
+    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
+    mocks.workspaceTeamFindFirst.mockResolvedValue({ permission: "manage" });
+
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(true);
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "POST")).toBe(true);
+    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(true);
+  });
+});

--- a/apps/web/lib/workspace/auth.ts
+++ b/apps/web/lib/workspace/auth.ts
@@ -62,7 +62,7 @@ export const hasUserWorkspaceAccessForAction = async (
     if (orgMembership.role === "billing") return false;
     if (orgMembership.role === "owner" || orgMembership.role === "manager") return true;
 
-    const workspaceTeam = await prisma.workspaceTeam.findFirst({
+    const workspaceTeams = await prisma.workspaceTeam.findMany({
       where: {
         workspaceId,
         team: {
@@ -74,9 +74,18 @@ export const hasUserWorkspaceAccessForAction = async (
       select: { permission: true },
     });
 
-    if (!workspaceTeam) return false;
+    if (workspaceTeams.length === 0) return false;
 
-    return teamPermissionSatisfies(workspaceTeam.permission, ACTION_REQUIRED_PERMISSION[action]);
+    // A user can belong to multiple teams that each grant access to the same
+    // workspace at different permission levels (the WorkspaceTeam unique key
+    // is [workspaceId, teamId], not [workspaceId, userId]). Pick the highest
+    // level so a `read` team membership doesn't shadow a `manage` one.
+    const highestPermission = workspaceTeams.reduce<WorkspacePermissionLevel>(
+      (max, wt) => (PERMISSION_RANK[wt.permission] > PERMISSION_RANK[max] ? wt.permission : max),
+      workspaceTeams[0].permission
+    );
+
+    return teamPermissionSatisfies(highestPermission, ACTION_REQUIRED_PERMISSION[action]);
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       throw new DatabaseError(error.message);

--- a/apps/web/lib/workspace/auth.ts
+++ b/apps/web/lib/workspace/auth.ts
@@ -4,6 +4,87 @@ import { ZId } from "@formbricks/types/common";
 import { DatabaseError } from "@formbricks/types/errors";
 import { validateInputs } from "../utils/validate";
 
+export type WorkspaceAction = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+type WorkspacePermissionLevel = "read" | "readWrite" | "manage";
+
+const ACTION_REQUIRED_PERMISSION: Record<WorkspaceAction, WorkspacePermissionLevel> = {
+  GET: "read",
+  POST: "readWrite",
+  PUT: "readWrite",
+  PATCH: "readWrite",
+  DELETE: "manage",
+};
+
+const PERMISSION_RANK: Record<WorkspacePermissionLevel, number> = {
+  read: 0,
+  readWrite: 1,
+  manage: 2,
+};
+
+const teamPermissionSatisfies = (
+  teamPermission: WorkspacePermissionLevel,
+  required: WorkspacePermissionLevel
+): boolean => PERMISSION_RANK[teamPermission] >= PERMISSION_RANK[required];
+
+/**
+ * Action-aware workspace access check for session-authenticated users.
+ *
+ * - Billing role: never authorized — billing users are excluded from product data surfaces.
+ * - Owner / manager: always authorized.
+ * - Member: authorized only when a WorkspaceTeam grants a permission level that
+ *   meets or exceeds the action's required level (read for GET, readWrite for
+ *   POST/PUT/PATCH, manage for DELETE).
+ *
+ * The broader {@link hasUserWorkspaceAccess} helper does not gate by action and
+ * should not be used for routes that mutate or expose workspace data.
+ */
+export const hasUserWorkspaceAccessForAction = async (
+  userId: string,
+  workspaceId: string,
+  action: WorkspaceAction
+): Promise<boolean> => {
+  validateInputs([userId, ZId], [workspaceId, ZId]);
+
+  try {
+    const orgMembership = await prisma.membership.findFirst({
+      where: {
+        userId,
+        organization: {
+          workspaces: {
+            some: { id: workspaceId },
+          },
+        },
+      },
+    });
+
+    if (!orgMembership) return false;
+    if (orgMembership.role === "billing") return false;
+    if (orgMembership.role === "owner" || orgMembership.role === "manager") return true;
+
+    const workspaceTeam = await prisma.workspaceTeam.findFirst({
+      where: {
+        workspaceId,
+        team: {
+          teamUsers: {
+            some: { userId },
+          },
+        },
+      },
+      select: { permission: true },
+    });
+
+    if (!workspaceTeam) return false;
+
+    return teamPermissionSatisfies(workspaceTeam.permission, ACTION_REQUIRED_PERMISSION[action]);
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      throw new DatabaseError(error.message);
+    }
+    throw error;
+  }
+};
+
 export const hasUserWorkspaceAccess = async (userId: string, workspaceId: string) => {
   validateInputs([userId, ZId], [workspaceId, ZId]);
 


### PR DESCRIPTION
## What does this PR do?

Closes [ENG-1028](https://linear.app/formbricks/issue/ENG-1028/security-report-formbricks-billing-role-users-can-access-or-mutate).

The workspace storage routes used the broad `hasUserWorkspaceAccess` for session-authenticated callers, which treats the `billing` role identically to `owner`/`manager` and ignores `WorkspaceTeam.permission` for member-role users. Three operations were therefore reachable by billing users (who the rest of the product explicitly excludes from data surfaces):

- Private file download by known path — `apps/web/app/storage/[workspaceId]/[accessType]/[...filePath]/route.ts` (GET, `accessType === \"private\"`)
- Public and private file delete — same route (DELETE; auth runs unconditionally of `accessType`)
- Signed upload URL creation for public files — `apps/web/app/api/v1/management/storage/route.ts` (POST)

The API-key paths on the same routes already gate by action via `hasPermission`; the session path simply did not.

This PR adds an action-aware helper and switches those three entry points to it.

### `hasUserWorkspaceAccessForAction(userId, workspaceId, action)`

- `billing` role: always denied.
- `owner` / `manager`: always allowed.
- `member`: allowed only when a `WorkspaceTeam` row grants a permission level that meets the action's required level — `read` for GET, `readWrite` for POST/PUT/PATCH, `manage` for DELETE. The required-level table matches the existing `methodPermissionMap` used for API-key auth, so session and API-key auth now apply the same shape of rule.

The existing `hasUserWorkspaceAccess` is left in place for other callers (integration OAuth routes, the workspaces onboarding layout). Those callers have the same shape of issue and are flagged below for a follow-up — they're out of scope for this fix because each integration endpoint needs a per-route decision on what permission level the operation should require.

### Files changed

- `apps/web/lib/workspace/auth.ts` — new `hasUserWorkspaceAccessForAction` helper alongside the existing one.
- `apps/web/app/storage/[workspaceId]/[accessType]/[...filePath]/lib/auth.ts` — `authorizePrivateDownload` passes its `action` arg through on the session branch.
- `apps/web/app/api/v1/management/storage/lib/utils.ts` — `checkAuth` calls the new helper with `\"POST\"` on the session branch.
- `apps/web/app/api/v1/management/storage/lib/utils.test.ts` — mock updated for the new helper; assertions verify the `\"POST\"` action arg is passed.
- `apps/web/lib/workspace/auth.test.ts` — new test file covering: no membership, billing across all five HTTP methods, owner/manager bypass, member without a team, and member with each of `read` / `readWrite` / `manage` team permissions.

## How should this be tested?

Automated:

- \`pnpm --filter @formbricks/web exec vitest run lib/workspace/auth.test.ts app/api/v1/management/storage/lib/utils.test.ts\`

Manual regression smoke (cloud or self-hosted):

- Invite a user as **billing** role. With them signed in, hit:
  - GET \`/storage/<workspaceId>/private/<knownPath>\` → expect 401.
  - DELETE \`/storage/<workspaceId>/public/<knownPath>\` → expect 401.
  - DELETE \`/storage/<workspaceId>/private/<knownPath>\` → expect 401.
  - POST \`/api/v1/management/storage\` with a valid body → expect 401.
- Same calls as **owner**: still succeed.
- As a **member** on a team whose \`WorkspaceTeam.permission = read\`: GET succeeds, POST/DELETE → 401.
- As a **member** on a team whose permission is \`readWrite\`: GET/POST succeed, DELETE → 401.
- As a **member** on a team whose permission is \`manage\`: all four succeed.

## Out of scope (follow-up candidates)

The same broad `hasUserWorkspaceAccess` is used in several session-authenticated routes that have the same billing-role bypass:

- `apps/web/app/api/v1/integrations/{airtable,notion,slack}/...`
- `apps/web/app/(app)/(onboarding)/workspaces/[workspaceId]/layout.tsx`

These should be migrated to `hasUserWorkspaceAccessForAction` in a separate PR. They were excluded here because they aren't named in the security report and each needs a per-route choice of which permission level the operation requires.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran \`pnpm build\`
- [x] Checked for warnings, there are none
- [x] Removed all \`console.logs\`
- [x] Merged the latest changes from main onto my branch with \`git pull origin main\`
- [x] My changes don't cause any responsiveness issues