### PR TITLE
fix: don't flag newly added survey questions as invalid on creation

### DIFF
--- a/apps/web/modules/survey/editor/components/elements-view.tsx
+++ b/apps/web/modules/survey/editor/components/elements-view.tsx
@@ -729,7 +729,8 @@ export const ElementsView = ({
       const currentInvalidSet = new Set(invalidElements);
       let hasChanges = false;
 
-      // Validate each element
+      // Live re-validation: clear errors as elements become valid (including
+      // drafts), but don't flag freshly added drafts — save/publish does that.
       elements.forEach((element) => {
         const isValid = validateElement(element, surveyLanguages);
         if (isValid) {
@@ -737,7 +738,7 @@ export const ElementsView = ({
             currentInvalidSet.delete(element.id);
             hasChanges = true;
           }
-        } else if (!currentInvalidSet.has(element.id)) {
+        } else if (!element.isDraft && !currentInvalidSet.has(element.id)) {
           currentInvalidSet.add(element.id);
           hasChanges = true;
         }

--- a/apps/web/modules/survey/editor/components/survey-editor.tsx
+++ b/apps/web/modules/survey/editor/components/survey-editor.tsx
@@ -84,7 +84,7 @@ export const SurveyEditor = ({
   const [activeView, setActiveView] = useState<TSurveyEditorTabs>("elements");
   const [activeElementId, setActiveElementId] = useState<string | null>(null);
   const [localSurvey, setLocalSurvey] = useState<TSurvey | null>(() => structuredClone(survey));
-  const [invalidElements, setInvalidElements] = useState<string[] | null>([]);
+  const [invalidElements, setInvalidElements] = useState<string[] | null>(null);
   const [hasIncompleteTranslations, setHasIncompleteTranslations] = useState(false);
 
   const [selectedLanguageCode, setSelectedLanguageCode] = useState<string>("default");


### PR DESCRIPTION
## What does this PR do?

Closes [ENG-1087](https://linear.app/formbricks/issue/ENG-1087/new-survey-questions-show-validation-errors-immediately).

Adding a new question in the survey editor immediately rendered the new block in a red error state with "Question text cannot be empty" — before any input. The Linear ticket points out this should only happen on Publish (drafts) or on Save (already-published surveys).

Two cumulative root causes:

1. **`survey-editor.tsx:87`** — `invalidElements` was initialized to `[]` rather than `null`. The live-validation `useEffect` at `elements-view.tsx:727` has an `if (!invalidElements) return;` guard intended to mean "user hasn't tried to publish yet, don't show errors live" — but `[]` is truthy, so the guard never fired on the first render and the freshly added empty question was classified invalid right away.

2. **`elements-view.tsx`** — even with the `null` fix, once `invalidElements` is populated by a real save/publish attempt, the live effect would re-validate *all* elements on every change and add newly added empty questions to the invalid set. We now skip the *add* path for elements tagged `isDraft: true` (both `addElement` and `addElementToBlock` already set this on creation). The *remove* path still runs for every element including drafts, so the red state clears immediately once the user fills in a valid value.

### Behavior matrix

| Scenario | Behavior |
|---|---|
| Fresh editor open, no save yet | `invalidElements` is `null` → live effect bails → no red. |
| Add new question, no save yet | Still `null` → no red. |
| Click Save / Publish, validation fails | `validateSurveyWithZod` populates `invalidElements` → red on the offenders. |
| Type into a red question (existing or just-added) | Live effect removes it from the set → red clears immediately. |
| Add another new question | Skipped from the add path (`isDraft: true`) → no red on the new one until next save/publish. |
| Clear an existing valid question | Live effect adds it (not a draft) → red appears live. |

The last two rows are mildly asymmetric — a freshly added empty question doesn't go red live, but emptying a previously valid question does. This matches the ticket's spirit ("validation only on publish / save"): we want to give the user a moment to type in a brand-new block, but silently emptying a working question is much more likely to be an unintentional mistake worth flagging. Easy to swap later if the team wants stricter symmetry.

## How should this be tested?

- Open an existing draft survey → click `Add Block` → pick `Single Select`. Expected: new block appears neutral, no red border, no error label. Same with `Rating`.
- Same on a published survey → `Add question to block` → pick any type. Expected: no red until you click `Save`.
- Trigger a real validation failure: leave a question empty → click `Publish` → red appears on that question. Type a valid headline → red clears live without needing another save.
- Existing question that was valid → clear its headline → red appears live (so genuine mistakes still surface immediately).
- Run the survey editor lib tests: \`pnpm --filter @formbricks/web exec vitest run modules/survey/editor/lib/validation.test.ts modules/survey/editor/lib/blocks.test.ts\` (156 pass).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran \`pnpm build\`
- [x] Checked for warnings, there are none
- [x] Removed all \`console.logs\`
- [x] Merged the latest changes from main onto my branch with \`git pull origin main\`
- [x] My changes don't cause any responsiveness issues