### PR TITLE
fix: show failing env vars in validation errors

### DIFF
--- a/apps/web/lib/env-validation-error.test.ts
+++ b/apps/web/lib/env-validation-error.test.ts
@@ -53,14 +53,16 @@ describe("env validation error", () => {
 
   test("logs structured issues and throws the formatted validation error", () => {
     const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const issues: TEnvValidationIssue[] = [{ path: ["ENCRYPTION_KEY"], message: "Missing value" }];
+    const issues: (TEnvValidationIssue & { readonly input: string })[] = [
+      { path: ["ENCRYPTION_KEY"], message: "Missing value", input: "secret-value" },
+    ];
 
     expect(() => throwEnvValidationError(issues)).toThrow(
       ["Invalid environment variables:", "  - ENCRYPTION_KEY: Missing value"].join("\n")
     );
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       ["Invalid environment variables:", "  - ENCRYPTION_KEY: Missing value"].join("\n"),
-      { issues }
+      { issues: [{ path: "ENCRYPTION_KEY", message: "Missing value" }] }
     );
   });
 });

--- a/apps/web/lib/env-validation-error.test.ts
+++ b/apps/web/lib/env-validation-error.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  type TEnvValidationIssue,
+  formatEnvValidationErrorMessage,
+  formatEnvValidationIssue,
+  throwEnvValidationError,
+} from "./env-validation-error";
+
+describe("env validation error", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("formats a top-level env validation issue", () => {
+    const issue: TEnvValidationIssue = {
+      path: ["ENCRYPTION_KEY"],
+      message: "Invalid input: expected string, received undefined",
+    };
+
+    expect(formatEnvValidationIssue(issue)).toBe(
+      "ENCRYPTION_KEY: Invalid input: expected string, received undefined"
+    );
+  });
+
+  test("formats multiple env validation issues", () => {
+    const issues: TEnvValidationIssue[] = [
+      { path: ["ENCRYPTION_KEY"], message: "Invalid input: expected string, received undefined" },
+      { path: ["HUB_API_URL"], message: "Invalid URL" },
+    ];
+
+    expect(formatEnvValidationErrorMessage(issues)).toBe(
+      [
+        "Invalid environment variables:",
+        "  - ENCRYPTION_KEY: Invalid input: expected string, received undefined",
+        "  - HUB_API_URL: Invalid URL",
+      ].join("\n")
+    );
+  });
+
+  test("formats nested issue paths with dot notation", () => {
+    const issue: TEnvValidationIssue = {
+      path: ["AI", { key: "GOOGLE_CLOUD_CREDENTIALS_JSON" }],
+      message: "Invalid JSON object",
+    };
+
+    expect(formatEnvValidationIssue(issue)).toBe("AI.GOOGLE_CLOUD_CREDENTIALS_JSON: Invalid JSON object");
+  });
+
+  test("uses unknown when an issue has no path", () => {
+    expect(formatEnvValidationIssue({ message: "Invalid input" })).toBe("unknown: Invalid input");
+    expect(formatEnvValidationIssue({ path: [], message: "Invalid input" })).toBe("unknown: Invalid input");
+  });
+
+  test("logs structured issues and throws the formatted validation error", () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const issues: TEnvValidationIssue[] = [{ path: ["ENCRYPTION_KEY"], message: "Missing value" }];
+
+    expect(() => throwEnvValidationError(issues)).toThrow(
+      ["Invalid environment variables:", "  - ENCRYPTION_KEY: Missing value"].join("\n")
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      ["Invalid environment variables:", "  - ENCRYPTION_KEY: Missing value"].join("\n"),
+      { issues }
+    );
+  });
+});

--- a/apps/web/lib/env-validation-error.ts
+++ b/apps/web/lib/env-validation-error.ts
@@ -5,6 +5,11 @@ export type TEnvValidationIssue = {
   readonly path?: ReadonlyArray<TEnvValidationIssuePathSegment>;
 };
 
+type TEnvValidationIssueLogEntry = {
+  readonly path: string;
+  readonly message: string;
+};
+
 const formatPathSegment = (segment: TEnvValidationIssuePathSegment): string => {
   if (typeof segment === "object" && segment !== null && "key" in segment) {
     return String(segment.key);
@@ -13,10 +18,19 @@ const formatPathSegment = (segment: TEnvValidationIssuePathSegment): string => {
   return String(segment);
 };
 
-export const formatEnvValidationIssue = (issue: TEnvValidationIssue): string => {
-  const field = issue.path?.length ? issue.path.map(formatPathSegment).join(".") : "unknown";
+const getEnvValidationIssuePath = (issue: TEnvValidationIssue): string =>
+  issue.path?.length ? issue.path.map(formatPathSegment).join(".") : "unknown";
 
-  return `${field}: ${issue.message}`;
+const sanitizeEnvValidationIssuesForLogging = (
+  issues: readonly TEnvValidationIssue[]
+): TEnvValidationIssueLogEntry[] =>
+  issues.map((issue) => ({
+    path: getEnvValidationIssuePath(issue),
+    message: issue.message,
+  }));
+
+export const formatEnvValidationIssue = (issue: TEnvValidationIssue): string => {
+  return `${getEnvValidationIssuePath(issue)}: ${issue.message}`;
 };
 
 export const formatEnvValidationErrorMessage = (issues: readonly TEnvValidationIssue[]): string => {
@@ -28,6 +42,6 @@ export const formatEnvValidationErrorMessage = (issues: readonly TEnvValidationI
 export const throwEnvValidationError = (issues: readonly TEnvValidationIssue[]): never => {
   const message = formatEnvValidationErrorMessage(issues);
 
-  console.error(message, { issues });
+  console.error(message, { issues: sanitizeEnvValidationIssuesForLogging(issues) });
   throw new Error(message);
 };

--- a/apps/web/lib/env-validation-error.ts
+++ b/apps/web/lib/env-validation-error.ts
@@ -1,0 +1,33 @@
+type TEnvValidationIssuePathSegment = PropertyKey | { readonly key: PropertyKey };
+
+export type TEnvValidationIssue = {
+  readonly message: string;
+  readonly path?: ReadonlyArray<TEnvValidationIssuePathSegment>;
+};
+
+const formatPathSegment = (segment: TEnvValidationIssuePathSegment): string => {
+  if (typeof segment === "object" && segment !== null && "key" in segment) {
+    return String(segment.key);
+  }
+
+  return String(segment);
+};
+
+export const formatEnvValidationIssue = (issue: TEnvValidationIssue): string => {
+  const field = issue.path?.length ? issue.path.map(formatPathSegment).join(".") : "unknown";
+
+  return `${field}: ${issue.message}`;
+};
+
+export const formatEnvValidationErrorMessage = (issues: readonly TEnvValidationIssue[]): string => {
+  const formattedIssues = issues.map((issue) => `  - ${formatEnvValidationIssue(issue)}`).join("\n");
+
+  return `Invalid environment variables:\n${formattedIssues}`;
+};
+
+export const throwEnvValidationError = (issues: readonly TEnvValidationIssue[]): never => {
+  const message = formatEnvValidationErrorMessage(issues);
+
+  console.error(message, { issues });
+  throw new Error(message);
+};

--- a/apps/web/lib/env.test.ts
+++ b/apps/web/lib/env.test.ts
@@ -54,6 +54,14 @@ describe("env", () => {
     expect(env.PASSWORD_RESET_TOKEN_LIFETIME_MINUTES).toBe(45);
   });
 
+  test("includes the failing field name and validation message in thrown errors", async () => {
+    setTestEnv({
+      ENCRYPTION_KEY: undefined,
+    });
+
+    await expect(import("./env")).rejects.toThrow(/ENCRYPTION_KEY[\s\S]*expected string/);
+  });
+
   test("fails to load when the password reset token lifetime is not an integer", async () => {
     setTestEnv({
       PASSWORD_RESET_TOKEN_LIFETIME_MINUTES: "30minutes",

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -1,6 +1,7 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 import { AI_PROVIDERS } from "@formbricks/types/ai";
+import { throwEnvValidationError } from "./env-validation-error";
 
 const ZActiveAIProvider = z.enum(AI_PROVIDERS);
 
@@ -201,6 +202,7 @@ const emptyStringToUndefined = (value: unknown) =>
 const ZOptionalNonEmptyString = z.preprocess(emptyStringToUndefined, z.string().trim().min(1).optional());
 
 const parsedEnv = createEnv({
+  onValidationError: throwEnvValidationError,
   /*
    * Serverside Environment variables, not available on the client.
    * Will throw if you access these variables on the client.


### PR DESCRIPTION
## What does this PR do?

Fixes #8155, [ENG-1066](https://linear.app/formbricks/issue/ENG-1066/appsweblibenvts-validation-error-doesnt-name-the-failing-field)

This PR improves `apps/web/lib/env.ts` startup validation errors so they include the failing environment variable names and per-field validation messages instead of only throwing `Invalid environment variables`.

It adds a small env validation error helper to keep formatting/reporting separate from the env schema, wires it into `createEnv` via `onValidationError`, and preserves fail-fast startup behavior. Validation failures are still logged, now with both a readable formatted message and the structured issue list.

No UI changes.

## How should this be tested?

- `cd apps/web`
- `../../node_modules/.bin/vitest run lib/env-validation-error.test.ts lib/env.test.ts --coverage --coverage.include=lib/env-validation-error.ts`
- `../../node_modules/.bin/eslint lib/env-validation-error.ts lib/env-validation-error.test.ts lib/env.ts lib/env.test.ts`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary