### PR TITLE
fix: "Add logo" link 404 [ENG-1281]

### DIFF
--- a/apps/web/modules/survey/link/components/link-survey-wrapper.tsx
+++ b/apps/web/modules/survey/link/components/link-survey-wrapper.tsx
@@ -13,6 +13,7 @@ import { ResetProgressButton } from "@/modules/ui/components/reset-progress-butt
 interface LinkSurveyWrapperProps {
   children: JSX.Element;
   workspace: Pick<Workspace, "styling" | "logo" | "linkSurveyBranding">;
+  workspaceId: string;
   isWelcomeCardEnabled: boolean;
   surveyId: string;
   surveyType: SurveyType;
@@ -32,6 +33,7 @@ interface LinkSurveyWrapperProps {
 export const LinkSurveyWrapper = ({
   children,
   workspace,
+  workspaceId,
   isWelcomeCardEnabled,
   surveyType,
   surveyId,
@@ -86,7 +88,12 @@ export const LinkSurveyWrapper = ({
           onBackgroundLoaded={handleBackgroundLoaded}>
           <div className="flex max-h-dvh min-h-dvh items-center justify-center overflow-clip">
             {!styling.isLogoHidden && (workspace.logo?.url || styling.logo?.url) && (
-              <ClientLogo workspaceLogo={workspace.logo} surveyLogo={styling.logo} dir={dir} />
+              <ClientLogo
+                workspaceLogo={workspace.logo}
+                workspaceId={workspaceId}
+                surveyLogo={styling.logo}
+                dir={dir}
+              />
             )}
             <div className="h-full w-full max-w-4xl space-y-6 px-1.5">
               {isPreview && (

--- a/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
+++ b/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
@@ -170,6 +170,7 @@ export const SurveyClientWrapper = ({
       )}
       <LinkSurveyWrapper
         workspace={workspace}
+        workspaceId={survey.workspaceId}
         surveyId={survey.id}
         isWelcomeCardEnabled={survey.welcomeCard.enabled}
         isPreview={isPreview}

--- a/apps/web/modules/ui/components/client-logo/index.tsx
+++ b/apps/web/modules/ui/components/client-logo/index.tsx
@@ -42,7 +42,7 @@ export const ClientLogo = ({
       style={{ backgroundColor: logoToUse?.bgColor }}>
       {previewSurvey && workspaceBasePath && (
         <Link
-          href={`${workspaceBasePath}/look`}
+          href={`${workspaceBasePath}/settings/workspace/look`}
           className="group/link absolute h-full w-full hover:cursor-pointer"
           target="_blank">
           <ArrowUpRight
@@ -64,7 +64,7 @@ export const ClientLogo = ({
         />
       ) : (
         <Link
-          href={workspaceBasePath ? `${workspaceBasePath}/look` : "#"}
+          href={workspaceBasePath ? `${workspaceBasePath}/settings/workspace/look` : "#"}
           onClick={(e) => {
             if (!workspaceBasePath) {
               e.preventDefault();

--- a/apps/web/modules/ui/components/client-logo/index.tsx
+++ b/apps/web/modules/ui/components/client-logo/index.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/cn";
 
 interface ClientLogoProps {
   workspaceLogo: Workspace["logo"] | null;
-  workspaceId?: string;
+  workspaceId: string;
   surveyLogo?: TLogo | null;
   previewSurvey?: boolean;
   dir?: "ltr" | "rtl" | "auto";
@@ -25,7 +25,7 @@ export const ClientLogo = ({
 }: ClientLogoProps) => {
   const { t } = useTranslation();
   const logoToUse = surveyLogo?.url ? surveyLogo : workspaceLogo;
-  const lookSettingsHref = workspaceId ? `/workspaces/${workspaceId}/settings/workspace/look` : null;
+  const lookSettingsHref = `/workspaces/${workspaceId}/settings/workspace/look`;
 
   let positionClasses = "";
   if (!previewSurvey) {
@@ -40,7 +40,7 @@ export const ClientLogo = ({
     <div
       className={cn(positionClasses, "group absolute z-0 rounded-lg")}
       style={{ backgroundColor: logoToUse?.bgColor }}>
-      {previewSurvey && lookSettingsHref && (
+      {previewSurvey && (
         <Link
           href={lookSettingsHref}
           className="group/link absolute h-full w-full hover:cursor-pointer"
@@ -64,12 +64,7 @@ export const ClientLogo = ({
         />
       ) : (
         <Link
-          href={lookSettingsHref ?? "#"}
-          onClick={(e) => {
-            if (!lookSettingsHref) {
-              e.preventDefault();
-            }
-          }}
+          href={lookSettingsHref}
           className="whitespace-nowrap rounded-md border border-dashed border-slate-400 bg-slate-200 px-6 py-3 text-xs text-slate-900 opacity-50 backdrop-blur-sm hover:cursor-pointer hover:border-slate-600"
           target="_blank">
           {t("common.add_logo")}

--- a/apps/web/modules/ui/components/client-logo/index.tsx
+++ b/apps/web/modules/ui/components/client-logo/index.tsx
@@ -6,11 +6,11 @@ import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import { Workspace } from "@formbricks/database/prisma-browser";
 import { TLogo } from "@formbricks/types/styling";
-import { useWorkspace } from "@/app/(app)/workspaces/[workspaceId]/context/workspace-context";
 import { cn } from "@/lib/cn";
 
 interface ClientLogoProps {
   workspaceLogo: Workspace["logo"] | null;
+  workspaceId?: string;
   surveyLogo?: TLogo | null;
   previewSurvey?: boolean;
   dir?: "ltr" | "rtl" | "auto";
@@ -18,14 +18,14 @@ interface ClientLogoProps {
 
 export const ClientLogo = ({
   workspaceLogo,
+  workspaceId,
   surveyLogo,
   previewSurvey = false,
   dir = "auto",
 }: ClientLogoProps) => {
-  const { workspace } = useWorkspace();
-  const workspaceBasePath = `/workspaces/${workspace?.id}`;
   const { t } = useTranslation();
   const logoToUse = surveyLogo?.url ? surveyLogo : workspaceLogo;
+  const lookSettingsHref = workspaceId ? `/workspaces/${workspaceId}/settings/workspace/look` : null;
 
   let positionClasses = "";
   if (!previewSurvey) {
@@ -40,9 +40,9 @@ export const ClientLogo = ({
     <div
       className={cn(positionClasses, "group absolute z-0 rounded-lg")}
       style={{ backgroundColor: logoToUse?.bgColor }}>
-      {previewSurvey && workspaceBasePath && (
+      {previewSurvey && lookSettingsHref && (
         <Link
-          href={`${workspaceBasePath}/settings/workspace/look`}
+          href={lookSettingsHref}
           className="group/link absolute h-full w-full hover:cursor-pointer"
           target="_blank">
           <ArrowUpRight
@@ -64,9 +64,9 @@ export const ClientLogo = ({
         />
       ) : (
         <Link
-          href={workspaceBasePath ? `${workspaceBasePath}/settings/workspace/look` : "#"}
+          href={lookSettingsHref ?? "#"}
           onClick={(e) => {
-            if (!workspaceBasePath) {
+            if (!lookSettingsHref) {
               e.preventDefault();
             }
           }}

--- a/apps/web/modules/ui/components/preview-survey/index.tsx
+++ b/apps/web/modules/ui/components/preview-survey/index.tsx
@@ -289,7 +289,12 @@ export const PreviewSurvey = ({
                   <div className="flex h-full w-full flex-col justify-center px-1">
                     <div className="absolute left-5 top-5">
                       {!styling.isLogoHidden && (
-                        <ClientLogo workspaceLogo={workspace.logo} surveyLogo={styling.logo} previewSurvey />
+                        <ClientLogo
+                          workspaceLogo={workspace.logo}
+                          workspaceId={workspace.id}
+                          surveyLogo={styling.logo}
+                          previewSurvey
+                        />
                       )}
                     </div>
                     <div className="z-10 w-full rounded-lg border border-transparent">
@@ -403,7 +408,12 @@ export const PreviewSurvey = ({
                   isEditorView>
                   <div className="absolute left-5 top-5">
                     {!styling.isLogoHidden && (
-                      <ClientLogo workspaceLogo={workspace.logo} surveyLogo={styling.logo} previewSurvey />
+                      <ClientLogo
+                        workspaceLogo={workspace.logo}
+                        workspaceId={workspace.id}
+                        surveyLogo={styling.logo}
+                        previewSurvey
+                      />
                     )}
                   </div>
                   <div className="z-0 w-full max-w-4xl rounded-lg border-transparent">

--- a/apps/web/modules/ui/components/theme-styling-preview-survey/index.tsx
+++ b/apps/web/modules/ui/components/theme-styling-preview-survey/index.tsx
@@ -198,7 +198,11 @@ export const ThemeStylingPreviewSurvey = ({
                 isEditorView>
                 {!workspace.styling?.isLogoHidden && (
                   <button type="button" className="absolute left-5 top-5" onClick={scrollToEditLogoSection}>
-                    <ClientLogo workspaceLogo={workspace.logo ?? null} previewSurvey />
+                    <ClientLogo
+                      workspaceLogo={workspace.logo ?? null}
+                      workspaceId={workspace.id}
+                      previewSurvey
+                    />
                   </button>
                 )}
                 <div


### PR DESCRIPTION
## Summary
- The "Add logo" button on the survey preview pointed to `/workspaces/{id}/look`, which 404s. The route was moved to `/workspaces/{id}/settings/workspace/look`.
- Fix both the preview overlay link and the empty-state "Add logo" link in `ClientLogo` to use the correct path.

Fixes [ENG-1281](https://linear.app/formbricks/issue/ENG-1281).

## Test plan
- [ ] In a workspace with no logo set, open a survey preview and click the "Add logo" link — confirm it opens the workspace look settings page.
- [ ] In a workspace with a logo set, hover the logo in the preview and click — confirm it opens the workspace look settings page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)