### PR TITLE
fix: rating and CSAT smiley misaligned in single response card

### DIFF
--- a/apps/web/modules/analysis/components/RatingSmiley/index.tsx
+++ b/apps/web/modules/analysis/components/RatingSmiley/index.tsx
@@ -26,17 +26,28 @@ const getSmileyColor = (range: number, idx: number) => {
   }
 };
 
+interface GetSmileyParams {
+  iconIdx: number;
+  idx: number;
+  range: number;
+  active: boolean;
+  addColors: boolean;
+  baseUrl?: string;
+  size?: number;
+  centered?: boolean;
+}
+
 // Helper function to get smiley image URL based on index and range
-const getSmiley = (
-  iconIdx: number,
-  idx: number,
-  range: number,
-  active: boolean,
-  addColors: boolean,
-  baseUrl?: string,
-  size: number = 24,
-  centered: boolean = false
-): JSX.Element => {
+const getSmiley = ({
+  iconIdx,
+  idx,
+  range,
+  active,
+  addColors,
+  baseUrl,
+  size = 24,
+  centered = false,
+}: GetSmileyParams): JSX.Element => {
   const activeColor = "bg-rating-fill";
   const inactiveColor = addColors ? getSmileyColor(range, idx) : "bg-fill-none";
 
@@ -105,5 +116,5 @@ export const RatingSmiley = ({
   else if (range === 4) iconsIdx = [4, 5, 6, 7];
   else if (range === 3) iconsIdx = [4, 5, 7];
 
-  return getSmiley(iconsIdx[idx], idx, range, active, addColors, baseUrl, size, centered);
+  return getSmiley({ iconIdx: iconsIdx[idx], idx, range, active, addColors, baseUrl, size, centered });
 };

--- a/apps/web/modules/analysis/components/RatingSmiley/index.tsx
+++ b/apps/web/modules/analysis/components/RatingSmiley/index.tsx
@@ -7,6 +7,7 @@ interface RatingSmileyProps {
   addColors?: boolean;
   baseUrl?: string;
   size?: number;
+  centered?: boolean;
 }
 
 const getSmileyColor = (range: number, idx: number) => {
@@ -33,7 +34,8 @@ const getSmiley = (
   active: boolean,
   addColors: boolean,
   baseUrl?: string,
-  size: number = 24
+  size: number = 24,
+  centered: boolean = false
 ): JSX.Element => {
   const activeColor = "bg-rating-fill";
   const inactiveColor = addColors ? getSmileyColor(range, idx) : "bg-fill-none";
@@ -73,8 +75,7 @@ const getSmiley = (
       style={{
         width: `${containerSize}px`,
         height: `${containerSize}px`,
-        marginLeft: "auto",
-        marginRight: "auto",
+        ...(centered ? { marginLeft: "auto", marginRight: "auto" } : {}),
       }}>
       {" "}
       {/* NOSONAR S5256 - Need table layout for email compatibility (gmail) */}
@@ -94,6 +95,7 @@ export const RatingSmiley = ({
   addColors = false,
   baseUrl,
   size,
+  centered = false,
 }: RatingSmileyProps): JSX.Element => {
   let iconsIdx: number[] = [];
   if (range === 10) iconsIdx = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
@@ -103,5 +105,5 @@ export const RatingSmiley = ({
   else if (range === 4) iconsIdx = [4, 5, 6, 7];
   else if (range === 3) iconsIdx = [4, 5, 7];
 
-  return getSmiley(iconsIdx[idx], idx, range, active, addColors, baseUrl, size);
+  return getSmiley(iconsIdx[idx], idx, range, active, addColors, baseUrl, size, centered);
 };

--- a/apps/web/modules/email/components/preview-email-template.tsx
+++ b/apps/web/modules/email/components/preview-email-template.tsx
@@ -111,6 +111,7 @@ const getRatingContent = (scale: string, i: number, range: number, isColorCoding
         addColors={isColorCodingEnabled}
         baseUrl={WEBAPP_URL}
         size={EMAIL_RATING_SMILEY_SIZE}
+        centered
       />
     );
   }


### PR DESCRIPTION
  ## What does this PR do?

Fixes ENG-1285

The shared `RatingSmiley` component had `marginLeft: auto` / `marginRight: auto` hardcoded onto its table (added in #8180 to center the smiley inside the email embed). Because the same component also renders inline in the `SingleResponseCard` (via `RatingResponse`'s `default` variant), those auto-margins pushed the rating/CSAT smiley to the far right, breaking the response card layout.

This PR makes the centering opt-in via a new `centered` prop (default `false`). The email template now passes `centered` to keep its layout intact, while the response card renders the smiley inline as expected.

Fixes the broken single-response-card UI for rating and CSAT questions.

Before:
<img width="1916" height="650" alt="image" src="https://github.com/user-attachments/assets/833b1d78-8896-42a7-986d-d0c48d4d0ea7" />

After:



<img width="590" height="551" alt="Screenshot 2026-06-10 at 11 39 47" src="https://github.com/user-attachments/assets/b8d6b1a7-be3e-4a8d-9839-f6ea803a3fba" />

## How should this be tested?

- Open a survey with rating (smiley scale) and CSAT questions, submit a response, and open the response in the Responses tab → smiley should render inline next to the answer, not pushed to the right.
- Open the email embed preview for a rating/CSAT question → smiley should still be horizontally centered within each option column (no regression from #8180).