### PR TITLE
fix: AI translation marks complete without populating field [ENG-1286]

### DIFF
--- a/apps/web/modules/survey/multi-language-surveys/components/manage-translations-modal.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/manage-translations-modal.tsx
@@ -195,7 +195,11 @@ export const ManageTranslationsModal = ({
   const handleSave = () => {
     const updatedSurvey = structuredClone(localSurvey);
     for (const s of strings) {
-      const val = draftTranslations[s.path] ?? "";
+      const draft = draftTranslations[s.path] ?? "";
+      // Rich-text editors keep an empty wrapper like "<p><br></p>" in the draft. That's
+      // visually empty but a non-empty string, so without normalization it would survive
+      // save and downstream checks would treat the field as translated.
+      const val = s.isRichText && getTextContent(draft).trim() === "" ? "" : draft;
       setTranslationAtPathMutable(updatedSurvey, s.path, languageCode, val);
     }
     setLocalSurvey(updatedSurvey);

--- a/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { TSurvey } from "@formbricks/types/surveys/types";
+import { getTextContent } from "@formbricks/types/surveys/validation";
 import { md } from "@/lib/markdownIt";
 import { Editor } from "@/modules/ui/components/editor";
 
@@ -30,7 +31,8 @@ export const RichTextTranslationInput = ({
   // only remount for the former.
   const lastWrittenRef = useRef(value);
   // Suppresses Lexical's mount-time empty listener fire which would otherwise clobber an
-  // externally-applied value back to "".
+  // externally-applied value back to empty. Lexical can serialize an empty editor as either
+  // "" or markup like "<p><br></p>", so we check by text content rather than literal equality.
   const initialContentSetRef = useRef(false);
 
   useEffect(() => {
@@ -52,7 +54,7 @@ export const RichTextTranslationInput = ({
         setFirstRender={setFirstRender}
         getText={() => md.render(value)}
         setText={(v: string) => {
-          if (!initialContentSetRef.current && v === "") return;
+          if (!initialContentSetRef.current && getTextContent(v).trim() === "") return;
           initialContentSetRef.current = true;
           lastWrittenRef.current = v;
           onChange(path, v);


### PR DESCRIPTION
Fixes: [ENG-1286](https://linear.app/formbricks/issue/ENG-1286/ai-translation-marks-complete-without-populating-field)

Follow-up to #8084.

## Summary
Two related rich-text translation bugs that only show up in production builds (reproduces with `pnpm build && pnpm start`, hidden in `pnpm dev` by Strict Mode).

### 1. Cleared rich-text fields stay blank on AI re-translate
When a user clears an already-translated rich-text field and re-runs **Translate with AI**, the rich-text editor stays blank.

**Root cause.** After the value-driven remount of `RichTextTranslationInput`, Lexical fires its update listener once with the freshly-mounted empty editor's serialization. #8084 added `if (!initialContentSetRef.current && v === "") return;` to drop that fire — that works for the **empty → AR** path because Lexical emits exactly `""` there. But once the user has cleared an existing translation, the stored draft is `<p><br></p>` (or another empty-but-not-`""` markup). On the next AI translate:
1. `useEffect` sees `value !== lastWrittenRef.current` → remount.
2. Lexical's mount-time fire produces the same empty markup (not literal `""`).
3. `v === ""` doesn't match → guard is skipped.
4. The empty markup writes back into `draftTranslations`, clobbering the AI-populated value.

**Fix.** Check the bail by *text content* instead of literal equality, so the guard catches both shapes Lexical can produce for an empty editor. Genuine user edits still flow through because `initialContentSetRef` flips to `true` on the first non-empty fire after remount, after which the guard is inert.

### 2. Save persists empty rich-text wrappers as real translations
A rich-text draft like `<p><br></p>` is visually empty but a non-empty string. `handleSave` was writing it through verbatim, so downstream code that just checks the saved value's truthiness treated the field as translated — even though the progress bar correctly showed it as missing (31/32, etc.).

**Fix.** Normalize text-empty rich-text drafts to `""` before persisting, so the saved state matches what `isDraftEmpty` already reports in the modal.

## Test plan
- [ ] `pnpm build && pnpm start` from `apps/web`
- [ ] Create a survey with a rich-text headline + a plain-text button label in a second language
- [ ] Run **Translate with AI** — both fields fill (as before)
- [ ] Clear the rich-text headline translation manually
- [ ] Click **Translate with AI** again — confirm the rich-text headline gets re-populated (was previously skipped)
- [ ] If the AI leaves one rich-text field empty, click **Save** and confirm that field is *not* counted as translated downstream (no leftover `<p><br></p>` wrapper persisted)
- [ ] Confirm typing into a rich-text row still saves normally (no regression on user edits once content has been entered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)