### PR TITLE
fix: [Backport] AI translation marks complete without populating field [ENG-1286]

### DIFF
--- a/apps/web/modules/survey/multi-language-surveys/components/manage-translations-modal.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/manage-translations-modal.tsx
@@ -195,7 +195,11 @@ export const ManageTranslationsModal = ({
   const handleSave = () => {
     const updatedSurvey = structuredClone(localSurvey);
     for (const s of strings) {
-      const val = draftTranslations[s.path] ?? "";
+      const draft = draftTranslations[s.path] ?? "";
+      // Rich-text editors keep an empty wrapper like "<p><br></p>" in the draft. That's
+      // visually empty but a non-empty string, so without normalization it would survive
+      // save and downstream checks would treat the field as translated.
+      const val = s.isRichText && getTextContent(draft).trim() === "" ? "" : draft;
       setTranslationAtPathMutable(updatedSurvey, s.path, languageCode, val);
     }
     setLocalSurvey(updatedSurvey);

--- a/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/rich-text-translation-input.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { TSurvey } from "@formbricks/types/surveys/types";
+import { getTextContent } from "@formbricks/types/surveys/validation";
 import { md } from "@/lib/markdownIt";
 import { Editor } from "@/modules/ui/components/editor";
 
@@ -30,7 +31,8 @@ export const RichTextTranslationInput = ({
   // only remount for the former.
   const lastWrittenRef = useRef(value);
   // Suppresses Lexical's mount-time empty listener fire which would otherwise clobber an
-  // externally-applied value back to "".
+  // externally-applied value back to empty. Lexical can serialize an empty editor as either
+  // "" or markup like "<p><br></p>", so we check by text content rather than literal equality.
   const initialContentSetRef = useRef(false);
 
   useEffect(() => {
@@ -52,7 +54,7 @@ export const RichTextTranslationInput = ({
         setFirstRender={setFirstRender}
         getText={() => md.render(value)}
         setText={(v: string) => {
-          if (!initialContentSetRef.current && v === "") return;
+          if (!initialContentSetRef.current && getTextContent(v).trim() === "") return;
           initialContentSetRef.current = true;
           lastWrittenRef.current = v;
           onChange(path, v);


### PR DESCRIPTION
Backport of #8253 into `release/5.1`.

Fixes [ENG-1286](https://linear.app/formbricks/issue/ENG-1286/ai-translation-marks-complete-without-populating-field).

## Summary
Two related rich-text translation bugs (both prod-only, hidden in dev by Strict Mode):

1. **Cleared rich-text fields stay blank on AI re-translate.** The mount-time empty-fire guard from #8084 only matched `v === ""`. When a previously-translated rich-text field is cleared, the stored draft is `<p><br></p>` — not literal `""` — and the guard let it through, clobbering the AI value. Now we check by text content so both empty shapes Lexical emits are caught.

2. **Save persists empty rich-text wrappers as real translations.** `handleSave` was writing `<p><br></p>` verbatim, so downstream code that just checked truthiness treated the field as translated even though the modal's progress bar correctly showed it missing. Now we normalize text-empty rich-text drafts to `""` before persisting.

## Test plan
- [ ] `pnpm build && pnpm start` from `apps/web`
- [ ] Create a survey with a rich-text headline + a plain-text button label in a second language
- [ ] Run **Translate with AI** — both fields fill
- [ ] Clear the rich-text headline translation manually
- [ ] Click **Translate with AI** again — confirm the rich-text headline gets re-populated
- [ ] If the AI leaves a rich-text field empty, click **Save** and confirm that field is *not* counted as translated downstream (no leftover `<p><br></p>` wrapper persisted)
- [ ] Confirm typing into a rich-text row still saves normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)