### PR TITLE
fix: improve self-hosted AI generation stability

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts
@@ -72,6 +72,19 @@ const mockOpenTextAnswers = (survey: TSurvey): void => {
   });
 };
 
+const getOpenTextRowsFromPrompt = (
+  prompt: string
+): Array<{
+  rowId: string;
+  requestedOpenTextAnswers: Array<{ elementId: string }>;
+}> => {
+  const marker = "Survey context (JSON):\n";
+  const contextStart = prompt.indexOf(marker);
+  if (contextStart === -1) throw new Error("Expected survey context in prompt");
+
+  return JSON.parse(prompt.slice(contextStart + marker.length)).rows;
+};
+
 describe("buildExampleResponsesSchema", () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -228,6 +241,51 @@ describe("generateExampleResponseDataset", () => {
     expect(call.prompt).toContain("plannedAnswers");
     expect(call.prompt).toContain("hi");
     expect(call.prompt).not.toContain("Generate 10 diverse example responses");
+    expect(call.temperature).toBe(0);
+    expect(call.maxOutputTokens).toBe(4096);
+    expect(call.timeout).toBe(45_000);
+  });
+
+  test("chunks large open-text batches and falls back only for failed chunks", async () => {
+    const survey = makeSurvey(
+      Array.from({ length: 4 }, (_, index) => ({
+        ...baseQuestion,
+        id: `q_text_${index + 1}`,
+        type: TSurveyElementTypeEnum.OpenText,
+        headline: i18n(`Question ${index + 1}`),
+      })) as unknown as TSurvey["questions"]
+    );
+    const providerError = new Error("provider failed");
+    let callIndex = 0;
+
+    vi.mocked(mocks.generateOrganizationAIObject).mockImplementation(async (call) => {
+      callIndex += 1;
+      if (callIndex === 2) throw providerError;
+
+      const rows = getOpenTextRowsFromPrompt(String(call.prompt));
+      return {
+        object: {
+          responses: rows.map((row) => ({
+            rowId: row.rowId,
+            answers: row.requestedOpenTextAnswers.map(({ elementId }) => ({
+              elementId,
+              answer: `AI ${row.rowId} ${elementId}`,
+            })),
+          })),
+        },
+      };
+    });
+
+    const result = await generateExampleResponseDataset({ survey, organizationId: "org_1" });
+
+    expect(mocks.generateOrganizationAIObject).toHaveBeenCalledTimes(2);
+    expect(result.responses[2].data.q_text_1).toBe("AI row_2 q_text_1");
+    expect(result.responses[7].data.q_text_1).not.toBe("AI row_7 q_text_1");
+    expect(result.responses[7].data.q_text_1).toBeTypeOf("string");
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      { err: providerError, organizationId: "org_1" },
+      "Failed to generate open-text example responses with AI; using fallback answers"
+    );
   });
 
   test("uses question-aware fallback text when the LLM omits open-text answers", async () => {

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { z } from "zod";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { type TSurvey } from "@formbricks/types/surveys/types";
 import {
@@ -14,12 +15,19 @@ import {
 
 const mocks = vi.hoisted(() => ({
   generateOrganizationAIObject: vi.fn(),
+  loggerError: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
 
 vi.mock("@/lib/ai/service", () => ({
   generateOrganizationAIObject: mocks.generateOrganizationAIObject,
+}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: {
+    error: mocks.loggerError,
+  },
 }));
 
 const i18n = (s: string) => ({ default: s });
@@ -55,7 +63,10 @@ const mockOpenTextAnswers = (survey: TSurvey): void => {
     object: {
       responses: Array.from({ length: EXAMPLE_RESPONSE_COUNT }, (_, index) => ({
         rowId: `row_${index}`,
-        answers: Object.fromEntries(ctx.openTextElementIds.map((id) => [id, `Open text answer ${index}`])),
+        answers: ctx.openTextElementIds.map((id) => ({
+          elementId: id,
+          answer: `Open text answer ${index}`,
+        })),
       })),
     },
   });
@@ -93,10 +104,11 @@ describe("buildExampleResponsesSchema", () => {
       schema.safeParse({
         responses: Array.from({ length: EXAMPLE_RESPONSE_COUNT }, (_, index) => ({
           rowId: `row_${index}`,
-          answers: { q_text: `Answer ${index}` },
+          answers: [{ elementId: "q_text", answer: `Answer ${index}` }],
         })),
       }).success
     ).toBe(true);
+    expect(JSON.stringify(z.toJSONSchema(schema))).not.toContain("propertyNames");
   });
 
   test("reads legacy survey.questions when blocks are empty", () => {
@@ -243,7 +255,7 @@ describe("generateExampleResponseDataset", () => {
       object: {
         responses: Array.from({ length: EXAMPLE_RESPONSE_COUNT }, (_, index) => ({
           rowId: `row_${index}`,
-          answers: {},
+          answers: [],
         })),
       },
     });
@@ -317,14 +329,20 @@ describe("generateExampleResponseDataset", () => {
     }
   });
 
-  test("propagates errors from the open-text LLM call", async () => {
+  test("falls back to local open-text answers when the LLM call fails", async () => {
     const survey = makeSurvey([
       { ...baseQuestion, id: "q_text", type: TSurveyElementTypeEnum.OpenText },
     ] as unknown as TSurvey["questions"]);
-    vi.mocked(mocks.generateOrganizationAIObject).mockRejectedValue(new Error("ai_features_not_enabled"));
+    const error = new Error("provider failed");
+    vi.mocked(mocks.generateOrganizationAIObject).mockRejectedValue(error);
 
-    await expect(generateExampleResponseDataset({ survey, organizationId: "org_1" })).rejects.toThrow(
-      "ai_features_not_enabled"
+    const result = await generateExampleResponseDataset({ survey, organizationId: "org_1" });
+
+    expect(result.responses).toHaveLength(EXAMPLE_RESPONSE_COUNT);
+    expect(result.responses.some((response) => typeof response.data.q_text === "string")).toBe(true);
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      { err: error, organizationId: "org_1" },
+      "Failed to generate open-text example responses with AI; using fallback answers"
     );
   });
 
@@ -362,7 +380,7 @@ describe("generateExampleResponseDataset", () => {
       object: {
         responses: Array.from({ length: EXAMPLE_RESPONSE_COUNT }, (_, index) => ({
           rowId: `row_${index}`,
-          answers: {},
+          answers: [],
         })),
       },
     });
@@ -396,7 +414,7 @@ describe("generateExampleResponseDataset", () => {
       object: {
         responses: Array.from({ length: EXAMPLE_RESPONSE_COUNT }, (_, index) => ({
           rowId: `row_${index}`,
-          answers: {},
+          answers: [],
         })),
       },
     });

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { randomInt } from "node:crypto";
 import { z } from "zod";
+import { logger } from "@formbricks/logger";
 import { type TResponseData, type TResponseInput, type TResponseTtc } from "@formbricks/types/responses";
 import { type TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { type TSurvey } from "@formbricks/types/surveys/types";
@@ -18,6 +19,8 @@ export const EXAMPLE_AI_GENERATED_TAG_NAME = "AI-generated example response";
 // abandonment. The remaining ~80% are finished.
 const DROP_OFF_RATE = 0.2;
 const RESPONSE_TIME_SPREAD_DAYS = 10;
+const OPEN_TEXT_AI_TIMEOUT_MS = 45_000;
+const OPEN_TEXT_AI_MAX_OUTPUT_TOKENS = 4096;
 
 // Realistic distributions for synthetic response metadata. Weighted toward
 // common values so charts don't look uniformly random.
@@ -314,13 +317,34 @@ export type TExampleResponseSchemaContext = {
   openTextElementIds: string[];
 };
 
+type TOpenTextAIAnswer = {
+  elementId: string;
+  answer: string;
+};
+
+type TOpenTextAIResponse = {
+  rowId: string;
+  answers: TOpenTextAIAnswer[];
+};
+
+type TOpenTextAIResult = {
+  responses: TOpenTextAIResponse[];
+};
+
 const buildOpenTextResponsesSchema = (): z.ZodTypeAny =>
   z.object({
     responses: z
       .array(
         z.object({
           rowId: z.string().min(1),
-          answers: z.record(z.string(), z.string().min(1)),
+          answers: z
+            .array(
+              z.object({
+                elementId: z.string().min(1),
+                answer: z.string().min(1),
+              })
+            )
+            .default([]),
         })
       )
       .default([]),
@@ -440,7 +464,10 @@ Style:
 
 Example output shape:
 { "responses": [
-  { "rowId": "row_0", "answers": { "<elementId1>": "...", "<elementId2>": "..." } },
+  { "rowId": "row_0", "answers": [
+    { "elementId": "<elementId1>", "answer": "..." },
+    { "elementId": "<elementId2>", "answer": "..." }
+  ] },
   ...
 ] }`;
 
@@ -878,30 +905,45 @@ const fillOpenTextAnswers = async (
   if (rowsNeedingText.length === 0) return planRows;
   const elementsById = new Map(collectSurveyElements(survey).map((element) => [element.id, element]));
 
-  const { object } = await generateOrganizationAIObject<{
-    responses: Array<{ rowId: string; answers: Record<string, string> }>;
-  }>({
-    organizationId,
-    schema: buildOpenTextResponsesSchema() as z.ZodType<{
-      responses: Array<{ rowId: string; answers: Record<string, string> }>;
-    }>,
-    system: SYSTEM_PROMPT,
-    prompt: `Write one short answer for each requestedOpenTextAnswers entry in every row below. Every requested elementId must map to a non-empty string in your output. Stay grounded in the actual question headline for each elementId.
+  let object: TOpenTextAIResult;
+
+  try {
+    const result = await generateOrganizationAIObject<TOpenTextAIResult>({
+      organizationId,
+      schema: buildOpenTextResponsesSchema() as z.ZodType<TOpenTextAIResult>,
+      system: SYSTEM_PROMPT,
+      prompt: `Write one short answer for each requestedOpenTextAnswers entry in every row below. Every requested elementId must map to a non-empty string in your output. Stay grounded in the actual question headline for each elementId.
 
 Survey context (JSON):
 ${JSON.stringify(buildOpenTextLlmContext(survey, rowsNeedingText), null, 2)}`,
-  });
+      temperature: 0,
+      maxOutputTokens: OPEN_TEXT_AI_MAX_OUTPUT_TOKENS,
+      timeout: OPEN_TEXT_AI_TIMEOUT_MS,
+    });
+    object = result.object;
+  } catch (err) {
+    logger.error(
+      { err, organizationId },
+      "Failed to generate open-text example responses with AI; using fallback answers"
+    );
+    object = { responses: [] };
+  }
 
-  const answersByRowId = new Map(object.responses.map((response) => [response.rowId, response.answers]));
+  const answersByRowId = new Map(
+    object.responses.map((response) => [
+      response.rowId,
+      new Map(response.answers.map(({ elementId, answer }) => [elementId, answer])),
+    ])
+  );
 
   return planRows.map((row) => {
     if (row.openTextElementIds.length === 0) return row;
 
-    const llmAnswers = answersByRowId.get(row.rowId) ?? {};
+    const llmAnswers = answersByRowId.get(row.rowId);
     const openTextAnswers: Record<string, string> = {};
     for (const elementId of row.openTextElementIds) {
       openTextAnswers[elementId] =
-        llmAnswers[elementId] || buildFallbackOpenTextAnswer(row.profile, elementsById.get(elementId));
+        llmAnswers?.get(elementId) || buildFallbackOpenTextAnswer(row.profile, elementsById.get(elementId));
     }
 
     // Belt-and-suspenders: even with the prompt rules and varied fallbacks,

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.ts
@@ -21,6 +21,7 @@ const DROP_OFF_RATE = 0.2;
 const RESPONSE_TIME_SPREAD_DAYS = 10;
 const OPEN_TEXT_AI_TIMEOUT_MS = 45_000;
 const OPEN_TEXT_AI_MAX_OUTPUT_TOKENS = 4096;
+const OPEN_TEXT_AI_MAX_REQUESTED_ANSWERS_PER_CHUNK = 20;
 
 // Realistic distributions for synthetic response metadata. Weighted toward
 // common values so charts don't look uniformly random.
@@ -329,6 +330,34 @@ type TOpenTextAIResponse = {
 
 type TOpenTextAIResult = {
   responses: TOpenTextAIResponse[];
+};
+
+const chunkOpenTextRows = (rows: TExampleResponsePlanRow[]): TExampleResponsePlanRow[][] => {
+  const chunks: TExampleResponsePlanRow[][] = [];
+  let currentChunk: TExampleResponsePlanRow[] = [];
+  let currentRequestedAnswerCount = 0;
+
+  for (const row of rows) {
+    const rowRequestedAnswerCount = row.openTextElementIds.length;
+    const wouldExceedChunk =
+      currentChunk.length > 0 &&
+      currentRequestedAnswerCount + rowRequestedAnswerCount > OPEN_TEXT_AI_MAX_REQUESTED_ANSWERS_PER_CHUNK;
+
+    if (wouldExceedChunk) {
+      chunks.push(currentChunk);
+      currentChunk = [];
+      currentRequestedAnswerCount = 0;
+    }
+
+    currentChunk.push(row);
+    currentRequestedAnswerCount += rowRequestedAnswerCount;
+  }
+
+  if (currentChunk.length > 0) {
+    chunks.push(currentChunk);
+  }
+
+  return chunks;
 };
 
 const buildOpenTextResponsesSchema = (): z.ZodTypeAny =>
@@ -905,32 +934,33 @@ const fillOpenTextAnswers = async (
   if (rowsNeedingText.length === 0) return planRows;
   const elementsById = new Map(collectSurveyElements(survey).map((element) => [element.id, element]));
 
-  let object: TOpenTextAIResult;
+  const aiResponses: TOpenTextAIResponse[] = [];
 
-  try {
-    const result = await generateOrganizationAIObject<TOpenTextAIResult>({
-      organizationId,
-      schema: buildOpenTextResponsesSchema() as z.ZodType<TOpenTextAIResult>,
-      system: SYSTEM_PROMPT,
-      prompt: `Write one short answer for each requestedOpenTextAnswers entry in every row below. Every requested elementId must map to a non-empty string in your output. Stay grounded in the actual question headline for each elementId.
+  for (const rowsChunk of chunkOpenTextRows(rowsNeedingText)) {
+    try {
+      const result = await generateOrganizationAIObject<TOpenTextAIResult>({
+        organizationId,
+        schema: buildOpenTextResponsesSchema() as z.ZodType<TOpenTextAIResult>,
+        system: SYSTEM_PROMPT,
+        prompt: `Write one short answer for each requestedOpenTextAnswers entry in every row below. Every requested elementId must map to a non-empty string in your output. Stay grounded in the actual question headline for each elementId.
 
 Survey context (JSON):
-${JSON.stringify(buildOpenTextLlmContext(survey, rowsNeedingText), null, 2)}`,
-      temperature: 0,
-      maxOutputTokens: OPEN_TEXT_AI_MAX_OUTPUT_TOKENS,
-      timeout: OPEN_TEXT_AI_TIMEOUT_MS,
-    });
-    object = result.object;
-  } catch (err) {
-    logger.error(
-      { err, organizationId },
-      "Failed to generate open-text example responses with AI; using fallback answers"
-    );
-    object = { responses: [] };
+${JSON.stringify(buildOpenTextLlmContext(survey, rowsChunk), null, 2)}`,
+        temperature: 0,
+        maxOutputTokens: OPEN_TEXT_AI_MAX_OUTPUT_TOKENS,
+        timeout: OPEN_TEXT_AI_TIMEOUT_MS,
+      });
+      aiResponses.push(...result.object.responses);
+    } catch (err) {
+      logger.error(
+        { err, organizationId },
+        "Failed to generate open-text example responses with AI; using fallback answers"
+      );
+    }
   }
 
   const answersByRowId = new Map(
-    object.responses.map((response) => [
+    aiResponses.map((response) => [
       response.rowId,
       new Map(response.answers.map(({ elementId, answer }) => [elementId, answer])),
     ])

--- a/apps/web/app/api/v3/surveys/generate/service.test.ts
+++ b/apps/web/app/api/v3/surveys/generate/service.test.ts
@@ -157,6 +157,7 @@ describe("generateV3SurveyCreatePayloadFromPrompt", () => {
         schema: ZGeneratedSurveyDraftForAI,
         schemaName: "FormbricksSurveyDraft",
         temperature: 0.2,
+        timeout: 45_000,
       })
     );
     const generationOptions = vi.mocked(generateOrganizationAIObject).mock.calls[0][0];

--- a/apps/web/app/api/v3/surveys/generate/service.ts
+++ b/apps/web/app/api/v3/surveys/generate/service.ts
@@ -31,6 +31,8 @@ export type TV3SurveyGenerateResult = {
   validation: TV3SurveyGenerateValidation;
 };
 
+const V3_SURVEY_GENERATION_TIMEOUT_MS = 45_000;
+
 export class V3SurveyGeneratePromptError extends Error {
   invalidParams: InvalidParam[];
 
@@ -388,6 +390,7 @@ export async function generateV3SurveyCreatePayloadFromPrompt(params: {
     ),
     temperature: 0.2,
     maxOutputTokens: 3000,
+    timeout: V3_SURVEY_GENERATION_TIMEOUT_MS,
   });
 
   const generatedSurvey = ZGeneratedSurveyDraft.safeParse(generation.object);

--- a/apps/web/modules/ee/ai-translation/lib/translate-fields.test.ts
+++ b/apps/web/modules/ee/ai-translation/lib/translate-fields.test.ts
@@ -66,7 +66,11 @@ describe("translateFields", () => {
 
     await translateFields({ ...baseInput, fields });
 
-    expect(mockGenerateOrganizationAIObject.mock.calls[0][0].temperature).toBe(0);
+    expect(mockGenerateOrganizationAIObject.mock.calls[0][0]).toMatchObject({
+      temperature: 0,
+      maxOutputTokens: 1024,
+      timeout: 45000,
+    });
   });
 
   test("returns empty object without calling the model when no fields are provided", async () => {

--- a/apps/web/modules/ee/ai-translation/lib/translate-fields.test.ts
+++ b/apps/web/modules/ee/ai-translation/lib/translate-fields.test.ts
@@ -23,6 +23,19 @@ const fields: TAITranslationField[] = [
   { path: "questions.0.html.default", defaultText: "<p>Hello</p>", isRichText: true },
 ];
 
+const makeFields = (count: number): TAITranslationField[] =>
+  Array.from({ length: count }, (_, index) => ({
+    path: `questions.${index}.headline.default`,
+    defaultText: `Text ${index}`,
+    isRichText: false,
+  }));
+
+const mockTranslationsFor = (fieldList: TAITranslationField[]): void => {
+  mockGenerateOrganizationAIObject.mockResolvedValue({
+    object: Object.fromEntries(fieldList.map((_, index) => [`t${index}`, `Translated ${index}`])),
+  });
+};
+
 describe("translateFields", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -70,6 +83,28 @@ describe("translateFields", () => {
       temperature: 0,
       maxOutputTokens: 1024,
       timeout: 45000,
+    });
+  });
+
+  test("scales maxOutputTokens with field count in the mid-range", async () => {
+    const midRangeFields = makeFields(20);
+    mockTranslationsFor(midRangeFields);
+
+    await translateFields({ ...baseInput, fields: midRangeFields });
+
+    expect(mockGenerateOrganizationAIObject.mock.calls[0][0]).toMatchObject({
+      maxOutputTokens: 3200,
+    });
+  });
+
+  test("clamps maxOutputTokens to the maximum for large translation batches", async () => {
+    const largeBatchFields = makeFields(60);
+    mockTranslationsFor(largeBatchFields);
+
+    await translateFields({ ...baseInput, fields: largeBatchFields });
+
+    expect(mockGenerateOrganizationAIObject.mock.calls[0][0]).toMatchObject({
+      maxOutputTokens: 8192,
     });
   });
 

--- a/apps/web/modules/ee/ai-translation/lib/translate-fields.ts
+++ b/apps/web/modules/ee/ai-translation/lib/translate-fields.ts
@@ -11,6 +11,11 @@ export const ZAITranslationField = z.object({
 
 export type TAITranslationField = z.infer<typeof ZAITranslationField>;
 
+const AI_TRANSLATION_TIMEOUT_MS = 45_000;
+const AI_TRANSLATION_MIN_OUTPUT_TOKENS = 1024;
+const AI_TRANSLATION_MAX_OUTPUT_TOKENS = 8192;
+const AI_TRANSLATION_OUTPUT_TOKENS_PER_FIELD = 160;
+
 interface TranslateFieldsInput {
   organizationId: string;
   fields: TAITranslationField[];
@@ -73,6 +78,14 @@ Rules:
     system: systemPrompt,
     prompt: userPayload,
     temperature: 0,
+    maxOutputTokens: Math.min(
+      AI_TRANSLATION_MAX_OUTPUT_TOKENS,
+      Math.max(
+        AI_TRANSLATION_MIN_OUTPUT_TOKENS,
+        translatableFields.length * AI_TRANSLATION_OUTPUT_TOKENS_PER_FIELD
+      )
+    ),
+    timeout: AI_TRANSLATION_TIMEOUT_MS,
   });
 
   const translatedById = result.object;

--- a/apps/web/modules/ee/analysis/charts/actions.test.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.test.ts
@@ -198,4 +198,58 @@ describe("chart Cube actions", () => {
       source: "charts.generateAIChartAction",
     });
   });
+
+  test("generateAIChartAction removes nested nulls before validating and executing AI queries", async () => {
+    mocks.generateOrganizationAIObject.mockResolvedValue({
+      object: {
+        measures: ["FeedbackRecords.count"],
+        dimensions: null,
+        timeDimensions: [
+          {
+            dimension: "FeedbackRecords.createdAt",
+            granularity: null,
+            dateRange: null,
+          },
+        ],
+        chartType: "line",
+        filters: [
+          {
+            member: "FeedbackRecords.sourceType",
+            operator: "equals",
+            values: null,
+          },
+        ],
+      },
+    });
+
+    const result = await generateAIChartAction({
+      ctx,
+      parsedInput: {
+        workspaceId: "workspace-1",
+        prompt: "daily responses",
+        feedbackDirectoryId: "frd-1",
+      },
+    } as any);
+
+    expect(result).toMatchObject({
+      chartType: "line",
+      query: {
+        measures: ["FeedbackRecords.count"],
+        timeDimensions: [{ dimension: "FeedbackRecords.createdAt" }],
+        filters: [{ member: "FeedbackRecords.sourceType", operator: "equals" }],
+      },
+    });
+    expect(mocks.executeTenantScopedQuery).toHaveBeenCalledWith({
+      query: {
+        measures: ["FeedbackRecords.count"],
+        timeDimensions: [{ dimension: "FeedbackRecords.createdAt" }],
+        filters: [{ member: "FeedbackRecords.sourceType", operator: "equals" }],
+      },
+      feedbackDirectoryId: "frd-1",
+      workspaceId: "workspace-1",
+      organizationId: "organization-1",
+      userId: "user-1",
+      source: "charts.generateAIChartAction",
+    });
+  });
 });

--- a/apps/web/modules/ee/analysis/charts/actions.test.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.test.ts
@@ -11,10 +11,8 @@ const mocks = vi.hoisted(() => {
     checkFeedbackDirectoryAccess: vi.fn(),
     getIsDashboardsEnabled: vi.fn(),
     createChart: vi.fn(),
-    getAiModel: vi.fn(),
-    assertOrganizationAIConfigured: vi.fn(),
     executeTenantScopedQuery: vi.fn(),
-    generateText: vi.fn(),
+    generateOrganizationAIObject: vi.fn(),
     updateChart: vi.fn(),
   };
 });
@@ -65,27 +63,12 @@ vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
   withAuditLogging: vi.fn((_eventName, _objectType, fn) => fn),
 }));
 
-vi.mock("@formbricks/ai", () => ({
-  getAiModel: mocks.getAiModel,
-}));
-
 vi.mock("@/lib/ai/service", () => ({
-  assertOrganizationAIConfigured: mocks.assertOrganizationAIConfigured,
-}));
-
-vi.mock("@/lib/env", () => ({
-  env: {},
+  generateOrganizationAIObject: mocks.generateOrganizationAIObject,
 }));
 
 vi.mock("@/modules/ee/analysis/lib/ai-schema-context", () => ({
   generateSchemaContext: vi.fn(() => "schema context"),
-}));
-
-vi.mock("ai", () => ({
-  Output: {
-    object: vi.fn(({ schema }) => schema),
-  },
-  generateText: mocks.generateText,
 }));
 
 const ctx = {
@@ -106,8 +89,6 @@ describe("chart Cube actions", () => {
     mocks.checkFeedbackDirectoryAccess.mockResolvedValue({
       feedbackDirectoryId: "frd-1",
     });
-    mocks.assertOrganizationAIConfigured.mockResolvedValue(undefined);
-    mocks.getAiModel.mockReturnValue("model");
     mocks.createChart.mockResolvedValue({
       id: "chart-1",
       name: "Chart",
@@ -172,8 +153,8 @@ describe("chart Cube actions", () => {
   });
 
   test("generateAIChartAction delegates clean AI queries to the tenant-scoped Cube helper", async () => {
-    mocks.generateText.mockResolvedValue({
-      output: {
+    mocks.generateOrganizationAIObject.mockResolvedValue({
+      object: {
         measures: ["FeedbackRecords.count"],
         dimensions: ["FeedbackRecords.sourceType"],
         timeDimensions: null,
@@ -195,6 +176,16 @@ describe("chart Cube actions", () => {
       chartType: "bar",
       data: [{ "FeedbackRecords.count": 1 }],
     });
+    expect(mocks.generateOrganizationAIObject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organizationId: "organization-1",
+        system: "schema context",
+        prompt: 'User request: "responses by sentiment"',
+        temperature: 0,
+        maxOutputTokens: 1024,
+        timeout: 30000,
+      })
+    );
     expect(mocks.executeTenantScopedQuery).toHaveBeenCalledWith({
       query: {
         measures: ["FeedbackRecords.count"],

--- a/apps/web/modules/ee/analysis/charts/actions.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.ts
@@ -1,13 +1,10 @@
 "use server";
 
-import { Output, generateText } from "ai";
 import { z } from "zod";
-import { getAiModel } from "@formbricks/ai";
 import { type TChartQuery, ZChartQuery } from "@formbricks/types/analysis";
 import { ZId } from "@formbricks/types/common";
 import { OperationNotAllowedError } from "@formbricks/types/errors";
-import { assertOrganizationAIConfigured } from "@/lib/ai/service";
-import { env } from "@/lib/env";
+import { generateOrganizationAIObject } from "@/lib/ai/service";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { AuthenticatedActionClientCtx } from "@/lib/utils/action-client/types/context";
 import { executeTenantScopedQuery } from "@/modules/ee/analysis/api/lib/cube-client";
@@ -291,6 +288,8 @@ export const executeQueryAction = authenticatedActionClient
   );
 
 const CUBE_NAME = "FeedbackRecords";
+const AI_CHART_GENERATION_TIMEOUT_MS = 30_000;
+const AI_CHART_GENERATION_MAX_OUTPUT_TOKENS = 1024;
 
 const toEnumTuple = (values: readonly string[]): [string, ...string[]] => {
   if (values.length === 0) {
@@ -303,6 +302,17 @@ const ZMeasureId = z.enum(toEnumTuple(FEEDBACK_MEASURE_IDS));
 const ZDimensionId = z.enum(toEnumTuple(FEEDBACK_DIMENSION_IDS));
 const ZTimeDimensionId = z.enum(toEnumTuple(FEEDBACK_TIME_DIMENSION_IDS));
 const ZFilterMemberId = z.enum(toEnumTuple([...FEEDBACK_MEASURE_IDS, ...FEEDBACK_DIMENSION_IDS]));
+type TGenerateAIQueryFilter = {
+  member: string;
+  operator: string;
+  values: string[] | null;
+};
+
+type TGenerateAIQueryTimeDimension = {
+  dimension: string;
+  granularity: "hour" | "day" | "week" | "month" | "quarter" | "year" | null;
+  dateRange: string | null;
+};
 
 const ZGenerateAIQueryResponse = z.object({
   measures: z.array(ZMeasureId),
@@ -338,6 +348,13 @@ const ZGenerateAIQueryResponse = z.object({
     )
     .nullable(),
 });
+type TGenerateAIQueryResponse = {
+  measures: string[];
+  dimensions: string[] | null;
+  timeDimensions: TGenerateAIQueryTimeDimension[] | null;
+  chartType: z.infer<typeof ZChartType>;
+  filters: TGenerateAIQueryFilter[] | null;
+};
 
 const ZGenerateAIChartAction = z.object({
   workspaceId: ZId,
@@ -363,8 +380,6 @@ export const generateAIChartAction = authenticatedActionClient
 
       await checkDashboardsEnabled(organizationId);
 
-      await assertOrganizationAIConfigured(organizationId);
-
       const { feedbackDirectoryId } = await checkFeedbackDirectoryAccess({
         feedbackDirectoryId: parsedInput.feedbackDirectoryId,
         organizationId,
@@ -375,12 +390,14 @@ export const generateAIChartAction = authenticatedActionClient
 
       const schemaContext = generateSchemaContext();
 
-      const { output } = await generateText({
-        model: getAiModel(env),
-        output: Output.object({ schema: ZGenerateAIQueryResponse }),
+      const { object: output } = await generateOrganizationAIObject<TGenerateAIQueryResponse>({
+        organizationId,
+        schema: ZGenerateAIQueryResponse,
         system: schemaContext,
         prompt: `User request: "${parsedInput.prompt}"`,
         temperature: 0,
+        maxOutputTokens: AI_CHART_GENERATION_MAX_OUTPUT_TOKENS,
+        timeout: AI_CHART_GENERATION_TIMEOUT_MS,
       });
 
       const measures = output.measures.length > 0 ? output.measures : [`${CUBE_NAME}.count`];
@@ -393,19 +410,23 @@ export const generateAIChartAction = authenticatedActionClient
       }
 
       if (cubeQuery.filters?.length) {
-        cleanQuery.filters = cubeQuery.filters.map(({ member, operator, values }) => ({
-          member,
-          operator,
-          ...(values == null ? {} : { values }),
-        }));
+        cleanQuery.filters = cubeQuery.filters.map(
+          ({ member, operator, values }: TGenerateAIQueryFilter) => ({
+            member,
+            operator,
+            ...(values == null ? {} : { values }),
+          })
+        );
       }
 
       if (cubeQuery.timeDimensions?.length) {
-        cleanQuery.timeDimensions = cubeQuery.timeDimensions.map(({ dimension, granularity, dateRange }) => ({
-          dimension,
-          ...(granularity == null ? {} : { granularity }),
-          ...(dateRange == null ? {} : { dateRange }),
-        }));
+        cleanQuery.timeDimensions = cubeQuery.timeDimensions.map(
+          ({ dimension, granularity, dateRange }: TGenerateAIQueryTimeDimension) => ({
+            dimension,
+            ...(granularity == null ? {} : { granularity }),
+            ...(dateRange == null ? {} : { dateRange }),
+          })
+        );
       }
 
       const data = await executeTenantScopedQuery({

--- a/apps/web/modules/ee/analysis/charts/actions.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.ts
@@ -429,8 +429,10 @@ export const generateAIChartAction = authenticatedActionClient
         );
       }
 
+      const validatedQuery = ZChartQuery.parse(cleanQuery);
+
       const data = await executeTenantScopedQuery({
-        query: cleanQuery,
+        query: validatedQuery,
         feedbackDirectoryId,
         workspaceId,
         organizationId,
@@ -439,7 +441,7 @@ export const generateAIChartAction = authenticatedActionClient
       });
 
       return {
-        query: cleanQuery,
+        query: validatedQuery,
         chartType,
         data: Array.isArray(data) ? data : [],
       };


### PR DESCRIPTION
## Issue

Part of the LLM GA / self-hosted Qwen staging rollout. This addresses staging failures where OpenAI-compatible runtimes can reject schema shapes or spend too much latency budget on unconstrained generation.

## Summary

- Replace generated example-response open-text structured output from a dynamic record to an array shape that avoids `propertyNames` in JSON Schema.
- Chunk open-text AI generation into bounded requests and fall back per failed chunk instead of dropping all AI-filled answers.
- Log open-text AI failures and fall back to deterministic example answers so response generation can still complete.
- Route AI chart generation through the shared organization AI abstraction, validate AI-built Cube queries with `ZChartQuery`, and add bounded generation settings.
- Add bounded generation settings for AI translations and cover token-budget boundaries in tests.

## Why

Self-hosted OpenAI-compatible runtimes such as vLLM can reject schema features that Google accepts, and Qwen can spend too much latency budget on unconstrained generation. These changes keep the app-side behavior provider-agnostic while making the call sites fail closed or degrade gracefully.

## How should this be tested?

- Run `pnpm --filter @formbricks/ai test`.
- Run `pnpm --filter @formbricks/ai typecheck`.
- From `apps/web`, run `pnpm exec vitest run modules/ee/ai-translation/lib/translate-fields.test.ts modules/ee/analysis/charts/actions.test.ts 'app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts' --reporter=dot`.
- Smoke test AI translation, AI chart generation, generated example responses, and one survey smart-tools generation path on staging after deploy.

## Validation

- `git diff --check`
- `pnpm exec prettier --check apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.ts apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts apps/web/modules/ee/ai-translation/lib/translate-fields.ts apps/web/modules/ee/ai-translation/lib/translate-fields.test.ts apps/web/modules/ee/analysis/charts/actions.ts apps/web/modules/ee/analysis/charts/actions.test.ts`
- `pnpm --filter @formbricks/ai test`
- `pnpm --filter @formbricks/ai typecheck`
- `pnpm exec vitest run modules/ee/ai-translation/lib/translate-fields.test.ts modules/ee/analysis/charts/actions.test.ts 'app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts' --reporter=dot`

## Not Run / Known Local Blocker

- Broad web typecheck still exits non-zero in this checkout because generated package/Prisma artifacts are stale or missing, including `@formbricks/ai`, `@formbricks/database/prisma-browser`, and feedback-source Prisma types. A grep over the typecheck output showed no errors in the changed files.

## Checklist

- [x] Focused tests pass.
- [x] Formatting and whitespace checks pass.
- [x] No migrations.
- [x] No new environment variables.
