### PR TITLE
fix: enforce surveys-exist guard on plan onboarding route [ENG-1290] (backport 5.1)

### DIFF
--- a/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/plan/page.tsx
+++ b/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/workspaces/new/plan/page.tsx
@@ -1,5 +1,7 @@
 import { redirect } from "next/navigation";
 import { TCloudBillingPlan } from "@formbricks/types/organizations";
+import { getOnboardingWorkspace } from "@/app/(app)/(onboarding)/lib/onboarding-workspace";
+import { redirectIfOnboardingComplete } from "@/app/(app)/(onboarding)/lib/redirect-if-onboarding-complete";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getPostHogFeatureFlag } from "@/lib/posthog/get-feature-flag";
 import { getOrganizationBillingWithReadThroughSync } from "@/modules/ee/billing/lib/organization-billing";
@@ -25,6 +27,11 @@ const Page = async (props: PlanPageProps) => {
 
   if (!session?.user) {
     return redirect(`/auth/login`);
+  }
+
+  const workspace = await getOnboardingWorkspace(session.user.id, params.organizationId);
+  if (workspace) {
+    await redirectIfOnboardingComplete(workspace.id);
   }
 
   // Users with an existing paid/trial subscription should not be shown the trial page.


### PR DESCRIPTION
## What does this PR do?

Backport of #8260 to `release/5.1`.

Fixes [ENG-1290](https://linear.app/formbricks/issue/ENG-1290): `/organizations/[organizationId]/workspaces/new/plan` was missing the surveys-exist guard, so a Hobby org with existing surveys could re-reach the trial screen by URL. `/survey`, `/templates`, and `/ai` already call `redirectIfOnboardingComplete`; `/plan` never did.

- Resolves the onboarding workspace after the session check and calls `redirectIfOnboardingComplete(workspace.id)` before any billing/feature-flag work
- Uses `getOnboardingWorkspace` (not `getOnboardingWorkspaceContext`) intentionally: the full context helper also asserts owner/manager role and mutates org AI settings — using it would change who can view `/plan`, which is out of scope for this guard fix

Clean cherry-pick of 22e1c492570e31eea42529778f0afa1f8dfafd5c; no test files touched.

## How should this be tested?

Manual (needs cloud mode, e.g. staging): log into an org that already has surveys and open `/organizations/<orgId>/workspaces/new/plan` — it should redirect to the workspace instead of rendering the trial screen.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)