### PR TITLE
fix: stub @formbricks/survey-ui/styles?inline during vitest runs

### DIFF
--- a/packages/surveys/vite.config.mts
+++ b/packages/surveys/vite.config.mts
@@ -1,11 +1,37 @@
 import preact from "@preact/preset-vite";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { loadEnv } from "vite";
+import { loadEnv, type Plugin } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";
 import { copyCompiledAssetsPlugin } from "../vite-plugins/copy-compiled-assets";
 import { visualizer } from "rollup-plugin-visualizer";
+
+// Stubs the @formbricks/survey-ui/styles?inline import during vitest runs so that
+// tests do not require packages/survey-ui to be built first. The plugin only
+// activates when VITEST is set, leaving production builds untouched.
+const stubSurveyUiStylesForVitest = (): Plugin => {
+  const stubId = "\0virtual:survey-ui-styles-stub";
+  return {
+    name: "formbricks:stub-survey-ui-styles-in-tests",
+    enforce: "pre",
+    apply() {
+      return process.env.VITEST === "true";
+    },
+    resolveId(source) {
+      if (source === "@formbricks/survey-ui/styles?inline") {
+        return stubId;
+      }
+      return null;
+    },
+    load(id) {
+      if (id === stubId) {
+        return 'export default "";';
+      }
+      return null;
+    },
+  };
+};
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -100,6 +126,7 @@ const config = ({ mode }) => {
     },
     plugins: [
       ...sharedConfig.plugins,
+      stubSurveyUiStylesForVitest(),
       copyCompiledAssetsPlugin({ filename: "surveys", distDir: resolve(__dirname, "dist") }),
       process.env.ANALYZE === "true" && visualizer({ filename: resolve(__dirname, "stats.html"), open: false, gzipSize: true, brotliSize: true }),
     ],


### PR DESCRIPTION
## Summary

- `packages/surveys/src/lib/styles.ts` imports `@formbricks/survey-ui/styles?inline`, which points at the **built** CSS artifact (`packages/survey-ui/dist/survey-ui.css`) via the `@formbricks/survey-ui` package exports. Vite's `import-analysis` resolves that path statically at transform time, so neither `vi.mock` nor `vitestSetup.ts` can intercept it.
- On a fresh clone or after `pnpm clean` (no `packages/survey-ui/dist`), running `pnpm --filter @formbricks/surveys test` fails with an unresolved-import error that has nothing to do with the contributor's changes.
- Added an `enforce: 'pre'` Vite plugin to the surveys vite config that returns an empty string for `@formbricks/survey-ui/styles?inline` while `process.env.VITEST === "true"`. Production builds and dev are untouched.

Fixes [ENG-954](https://linear.app/formbricks/issue/ENG-954/bug-pnpm-filter-formbricks-surveys-test-fails-due-to-missing-survey-ui)

## Reproduction (on `main`, before this fix)

```bash
git checkout main
pnpm clean
pnpm i
pnpm --filter @formbricks/surveys test
```

Expected: `vite:import-analysis` error pointing at `packages/surveys/src/lib/styles.ts:2`, one test file fails to load, exit code 1.

## Test plan

- [x] Reproduce on `main` with the steps above
- [x] Same sequence on this branch: 24/24 files, 603/603 tests pass
- [x] With `packages/survey-ui/dist` restored on this branch — still 603/603 pass (no regression)
- [ ] Manual: `pnpm --filter @formbricks/surveys build` still emits the real CSS (plugin gated on `VITEST`)