### PR TITLE
feat: add route-agnostic workflows API operation contracts

### DIFF
--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -26,7 +26,9 @@
   "devDependencies": {
     "@formbricks/config-typescript": "workspace:*",
     "@formbricks/eslint-config": "workspace:*",
+    "@types/js-yaml": "4.0.9",
     "@vitest/coverage-v8": "4.1.6",
+    "js-yaml": "4.1.0",
     "publint": "0.3.21",
     "rimraf": "^6.1.2",
     "typescript": "^5.9.3",

--- a/packages/workflows/src/contracts/common.ts
+++ b/packages/workflows/src/contracts/common.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+export const ZIsoDateTime = z.iso.datetime({ offset: true });
+
+export const ZCursorPaginationMeta = z
+  .strictObject({
+    limit: z.number().int().min(1).max(100),
+    nextCursor: z
+      .string()
+      .min(1)
+      .nullable()
+      .describe("Opaque cursor for the next page. Null when there are no more results."),
+  })
+  .describe("Cursor pagination metadata returned by list operations.");
+export type TCursorPaginationMeta = z.infer<typeof ZCursorPaginationMeta>;
+
+export const zCursorPage = <TItem extends z.ZodType>(
+  item: TItem
+): z.ZodObject<{ data: z.ZodArray<TItem>; meta: typeof ZCursorPaginationMeta }> =>
+  z.object({
+    data: z.array(item),
+    meta: ZCursorPaginationMeta,
+  });
+export interface TCursorPage<TItem> {
+  data: TItem[];
+  meta: TCursorPaginationMeta;
+}
+
+export const ZWorkflowIdInput = z
+  .strictObject({
+    workflowId: z.cuid2(),
+  })
+  .describe("Identifies one workflow. Unknown or inaccessible ids are rejected as forbidden.");
+export type TWorkflowIdInput = z.infer<typeof ZWorkflowIdInput>;
+
+export const ZWorkflowRunIdInput = z
+  .strictObject({
+    runId: z.cuid2(),
+  })
+  .describe("Identifies one workflow run by globally unique id.");
+export type TWorkflowRunIdInput = z.infer<typeof ZWorkflowRunIdInput>;

--- a/packages/workflows/src/contracts/index.test.ts
+++ b/packages/workflows/src/contracts/index.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "vitest";
+import {
+  type TWorkflowRunResource,
+  WORKFLOW_API_OPERATIONS,
+  ZCreateWorkflowInput,
+  ZListWorkflowRunsInput,
+  ZListWorkflowsInput,
+  ZPatchWorkflowInput,
+  ZTestWorkflowInput,
+  ZWorkflowListItem,
+  ZWorkflowResource,
+  ZWorkflowRunLogResource,
+  ZWorkflowRunResource,
+  ZWorkflowRunSummary,
+} from ".";
+
+const workspaceId = "cm9zr4mps000008l8btfy1vtz";
+const surveyId = "cm9zr4q7i000108l84gozfggr";
+const workflowId = "cm9zr4t2b000208l8h2m1aq3c";
+const runId = "cm9zr4w9d000308l8c5n8xk7e";
+const responseId = "cm9zr4z1f000408l8a9p2mv5g";
+const userId = "cm9zr52kh000508l8e3q7bw9j";
+
+const definition = {
+  schemaVersion: 1,
+  trigger: {
+    id: "trigger",
+    type: "trigger",
+    triggerType: "response.completed",
+    config: { surveyId, endingCardIds: [] },
+  },
+  nodes: [
+    {
+      id: "send-email",
+      type: "action",
+      actionType: "send_email",
+      config: {
+        from: "noreply@example.com",
+        to: "support@example.com",
+        replyTo: ["support@example.com"],
+        subject: "Thanks",
+        body: "Thanks for your response.",
+        attachResponseData: true,
+      },
+    },
+  ],
+  edges: [{ id: "e1", source: "trigger", target: "send-email" }],
+  entryNodeId: "trigger",
+};
+
+const runSummary = {
+  id: runId,
+  workflowId,
+  workspaceId,
+  workflowVersionId: null,
+  status: "queued",
+  isDryRun: true,
+  triggerType: "response.completed",
+  surveyId,
+  responseId: null,
+  error: null,
+  attempt: 0,
+  createdAt: "2026-06-11T09:30:00.000Z",
+  updatedAt: "2026-06-11T09:30:00.000Z",
+  startedAt: null,
+  finishedAt: null,
+};
+
+const runResource: TWorkflowRunResource = {
+  ...ZWorkflowRunSummary.parse(runSummary),
+  triggerPayload: {
+    type: "response.completed",
+    workspaceId,
+    surveyId,
+    responseId,
+    triggeredAt: "2026-06-11T09:30:00.000Z",
+  },
+  data: { steps: [] },
+  logs: [],
+  idempotencyKey: null,
+  nextAttemptAt: null,
+  lastErrorAt: null,
+};
+
+describe("workflow operation inputs", () => {
+  test("accepts a minimal create input and rejects unknown status", () => {
+    expect(() => ZCreateWorkflowInput.parse({ workspaceId, name: "Notify team", definition })).not.toThrow();
+    expect(
+      ZCreateWorkflowInput.safeParse({ workspaceId, name: "x", definition, status: "enabled" }).success
+    ).toBe(false);
+  });
+
+  test("accepts a trigger-only draft definition on create", () => {
+    const triggerOnly = { ...definition, nodes: [], edges: [] };
+    expect(() =>
+      ZCreateWorkflowInput.parse({ workspaceId, name: "Draft", definition: triggerOnly })
+    ).not.toThrow();
+  });
+
+  test("rejects an empty patch", () => {
+    expect(ZPatchWorkflowInput.safeParse({}).success).toBe(false);
+    expect(ZPatchWorkflowInput.safeParse({ name: "Renamed" }).success).toBe(true);
+  });
+
+  test("list inputs apply defaults and bounds", () => {
+    const parsed = ZListWorkflowsInput.parse({ workspaceId });
+    expect(parsed.limit).toBe(20);
+    expect(parsed.sortBy).toBe("updatedAt");
+    expect(ZListWorkflowsInput.safeParse({ workspaceId, limit: 101 }).success).toBe(false);
+    expect(ZListWorkflowRunsInput.safeParse({ workspaceId, statusIn: [] }).success).toBe(false);
+  });
+
+  test("test input accepts replay and idempotency key", () => {
+    expect(() => ZTestWorkflowInput.parse({})).not.toThrow();
+    expect(() => ZTestWorkflowInput.parse({ responseId, idempotencyKey: "retry-1" })).not.toThrow();
+    expect(ZTestWorkflowInput.safeParse({ idempotencyKey: "" }).success).toBe(false);
+  });
+
+  test("inputs reject unknown fields instead of stripping them", () => {
+    expect(
+      ZCreateWorkflowInput.safeParse({ workspaceId, name: "Notify team", definition, unknownField: true })
+        .success
+    ).toBe(false);
+    expect(ZTestWorkflowInput.safeParse({ triggerPayload: {} }).success).toBe(false);
+    expect(ZPatchWorkflowInput.safeParse({ name: "Renamed", status: "enabled" }).success).toBe(false);
+  });
+});
+
+describe("workflow resources", () => {
+  const listItem = {
+    id: workflowId,
+    workspaceId,
+    name: "Notify team",
+    description: null,
+    status: "draft",
+    triggerType: "response.completed",
+    surveyId,
+    createdBy: userId,
+    createdAt: "2026-06-11T09:30:00.000Z",
+    updatedAt: "2026-06-11T09:30:00.000Z",
+    lastRun: null,
+  };
+
+  test("parses a workflow list item and full resource", () => {
+    expect(() => ZWorkflowListItem.parse(listItem)).not.toThrow();
+    expect(() => ZWorkflowResource.parse({ ...listItem, definition })).not.toThrow();
+  });
+
+  test("list item embeds a run summary as lastRun", () => {
+    expect(() => ZWorkflowListItem.parse({ ...listItem, lastRun: runSummary })).not.toThrow();
+  });
+
+  test("parses a queued dry-run resource with empty logs", () => {
+    expect(() => ZWorkflowRunResource.parse(runResource)).not.toThrow();
+  });
+
+  test("run resource requires explicit nullable fields", () => {
+    const { idempotencyKey: _omitted, ...withoutKey } = runResource;
+    expect(ZWorkflowRunResource.safeParse(withoutKey).success).toBe(false);
+  });
+
+  test("log resource entries emit every field explicitly", () => {
+    const logEntry = {
+      id: "cm9zr55mj000608l8g7r4cz2k",
+      runId,
+      sequence: 0,
+      stepId: "send-email",
+      stepType: "send_email",
+      status: "succeeded",
+      input: {},
+      output: { mocked: true },
+      error: null,
+      startedAt: "2026-06-11T09:30:01.000Z",
+      finishedAt: "2026-06-11T09:30:02.000Z",
+    };
+    expect(() => ZWorkflowRunLogResource.parse(logEntry)).not.toThrow();
+    expect(() => ZWorkflowRunResource.parse({ ...runResource, logs: [logEntry] })).not.toThrow();
+
+    const { error: _omittedError, ...withoutError } = logEntry;
+    expect(ZWorkflowRunLogResource.safeParse(withoutError).success).toBe(false);
+  });
+});
+
+describe("operations map", () => {
+  test("every operation defines an output or is the delete operation", () => {
+    for (const [operationId, operation] of Object.entries(WORKFLOW_API_OPERATIONS)) {
+      if (operationId === "deleteWorkflowV3") {
+        expect(operation.output).toBeNull();
+      } else {
+        expect(operation.output).not.toBeNull();
+      }
+    }
+  });
+
+  test("detail operations carry params and list operations carry inputs", () => {
+    expect(WORKFLOW_API_OPERATIONS.getWorkflowV3.params).not.toBeNull();
+    expect(WORKFLOW_API_OPERATIONS.getWorkflowRunV3.params).not.toBeNull();
+    expect(WORKFLOW_API_OPERATIONS.listWorkflowsV3.input).not.toBeNull();
+    expect(WORKFLOW_API_OPERATIONS.listWorkflowRunsV3.input).not.toBeNull();
+  });
+});

--- a/packages/workflows/src/contracts/index.ts
+++ b/packages/workflows/src/contracts/index.ts
@@ -1,0 +1,4 @@
+export * from "./common";
+export * from "./inputs";
+export * from "./operations";
+export * from "./resources";

--- a/packages/workflows/src/contracts/inputs.ts
+++ b/packages/workflows/src/contracts/inputs.ts
@@ -1,0 +1,114 @@
+import { z } from "zod";
+import { ZWorkflowStatus } from "../types/common";
+import { ZWorkflowDefinition } from "../types/document";
+import { ZWorkflowRunStatus } from "../types/runs";
+
+/**
+ * Route-agnostic operation inputs for the v3 Workflows API. HTTP concerns (the `filter[...]`
+ * query family, the `Idempotency-Key` header, path params) are parsed by the transport layer
+ * into these shapes; non-HTTP consumers can construct them directly.
+ */
+
+export const ZCreateWorkflowInput = z
+  .strictObject({
+    workspaceId: z.cuid2(),
+    name: z.string().min(1).max(120),
+    description: z.string().max(500).nullable().optional(),
+    status: z
+      .literal("draft")
+      .optional()
+      .describe("Workflows are always created as drafts; only enable can make them live."),
+    definition: ZWorkflowDefinition,
+  })
+  .describe("Creates a draft workflow.");
+export type TCreateWorkflowInput = z.infer<typeof ZCreateWorkflowInput>;
+
+export const ZPatchWorkflowInput = z
+  .strictObject({
+    name: z.string().min(1).max(120).optional(),
+    description: z.string().max(500).nullable().optional(),
+    definition: ZWorkflowDefinition.optional().describe(
+      "Only accepted while the workflow is draft or disabled; the live version of an enabled workflow is immutable."
+    ),
+  })
+  .refine((input) => Object.keys(input).length > 0, {
+    message: "At least one field must be provided",
+  })
+  .describe("Partial workflow update. Status is never patchable; use the lifecycle operations.");
+export type TPatchWorkflowInput = z.infer<typeof ZPatchWorkflowInput>;
+
+export const ZDuplicateWorkflowInput = z
+  .strictObject({
+    name: z
+      .string()
+      .min(1)
+      .max(120)
+      .optional()
+      .describe(
+        "Optional name for the duplicate. If omitted, the server chooses a non-conflicting copy name."
+      ),
+  })
+  .describe("Duplicates a workflow as a new draft with empty run and version history.");
+export type TDuplicateWorkflowInput = z.infer<typeof ZDuplicateWorkflowInput>;
+
+export const ZTestWorkflowInput = z
+  .strictObject({
+    responseId: z
+      .cuid2()
+      .optional()
+      .describe(
+        "Optional existing response (from the trigger's survey) to replay as dry-run sample data. When omitted, the server synthesizes a sample payload."
+      ),
+    idempotencyKey: z
+      .string()
+      .min(1)
+      .max(255)
+      .optional()
+      .describe(
+        "Route-agnostic form of the Idempotency-Key header. Unique per workflow; retries with the same key return the previously created run."
+      ),
+  })
+  .describe("Creates an asynchronous dry run that validates and mocks execution without side effects.");
+export type TTestWorkflowInput = z.infer<typeof ZTestWorkflowInput>;
+
+export const ZWorkflowSortBy = z.enum(["createdAt", "updatedAt", "name"]);
+export type TWorkflowSortBy = z.infer<typeof ZWorkflowSortBy>;
+
+export const ZListWorkflowsInput = z
+  .strictObject({
+    workspaceId: z.cuid2(),
+    limit: z.number().int().min(1).max(100).default(20),
+    cursor: z.string().min(1).optional().describe("Opaque cursor from the previous page's meta.nextCursor."),
+    statusIn: z
+      .array(ZWorkflowStatus)
+      .min(1)
+      .optional()
+      .describe("Parsed form of filter[status][in]. Omitting it returns every status except archived."),
+    nameContains: z
+      .string()
+      .min(1)
+      .max(512)
+      .optional()
+      .describe("Parsed form of filter[name][contains]; case-insensitive substring match."),
+    sortBy: ZWorkflowSortBy.default("updatedAt").describe(
+      "The cursor token is bound to the selected sort order."
+    ),
+  })
+  .describe("Lists workflow list items for a workspace.");
+export type TListWorkflowsInput = z.infer<typeof ZListWorkflowsInput>;
+
+export const ZListWorkflowRunsInput = z
+  .strictObject({
+    workspaceId: z.cuid2(),
+    limit: z.number().int().min(1).max(100).default(20),
+    cursor: z.string().min(1).optional().describe("Opaque cursor from the previous page's meta.nextCursor."),
+    workflowId: z.cuid2().optional().describe("Returns only runs of this workflow."),
+    responseId: z.cuid2().optional().describe("Returns only runs triggered by this survey response."),
+    statusIn: z.array(ZWorkflowRunStatus).min(1).optional().describe("Parsed form of filter[status][in]."),
+    isDryRun: z
+      .boolean()
+      .optional()
+      .describe("Parsed form of filter[isDryRun][eq]. Omit to return real and dry runs."),
+  })
+  .describe("Lists workflow run summaries for a workspace, newest first.");
+export type TListWorkflowRunsInput = z.infer<typeof ZListWorkflowRunsInput>;

--- a/packages/workflows/src/contracts/operations.ts
+++ b/packages/workflows/src/contracts/operations.ts
@@ -1,0 +1,127 @@
+import { type z } from "zod";
+import { ZWorkflowIdInput, ZWorkflowRunIdInput, zCursorPage } from "./common";
+import type { TCursorPage, TWorkflowIdInput, TWorkflowRunIdInput } from "./common";
+import {
+  ZCreateWorkflowInput,
+  ZDuplicateWorkflowInput,
+  ZListWorkflowRunsInput,
+  ZListWorkflowsInput,
+  ZPatchWorkflowInput,
+  ZTestWorkflowInput,
+} from "./inputs";
+import type {
+  TCreateWorkflowInput,
+  TDuplicateWorkflowInput,
+  TListWorkflowRunsInput,
+  TListWorkflowsInput,
+  TPatchWorkflowInput,
+  TTestWorkflowInput,
+} from "./inputs";
+import { ZWorkflowListItem, ZWorkflowResource, ZWorkflowRunResource, ZWorkflowRunSummary } from "./resources";
+import type {
+  TWorkflowListItem,
+  TWorkflowResource,
+  TWorkflowRunResource,
+  TWorkflowRunSummary,
+} from "./resources";
+
+/**
+ * Route-agnostic operation contracts for the v3 Workflows API (ENG-1101). Keys match the
+ * operationIds in docs/api-v3-reference (the OpenAPI representation of the same contract).
+ * HTTP handlers parse transport input into `params`/`input` and serialize `output`; other
+ * consumers (jobs, MCP tools, tests) can import the same shapes directly.
+ */
+export const WORKFLOW_API_OPERATIONS = {
+  listWorkflowsV3: {
+    params: null,
+    input: ZListWorkflowsInput,
+    output: zCursorPage(ZWorkflowListItem),
+  },
+  createWorkflowV3: {
+    params: null,
+    input: ZCreateWorkflowInput,
+    output: ZWorkflowResource,
+  },
+  getWorkflowV3: {
+    params: ZWorkflowIdInput,
+    input: null,
+    output: ZWorkflowResource,
+  },
+  patchWorkflowV3: {
+    params: ZWorkflowIdInput,
+    input: ZPatchWorkflowInput,
+    output: ZWorkflowResource,
+  },
+  deleteWorkflowV3: {
+    params: ZWorkflowIdInput,
+    input: null,
+    output: null,
+  },
+  duplicateWorkflowV3: {
+    params: ZWorkflowIdInput,
+    input: ZDuplicateWorkflowInput,
+    output: ZWorkflowResource,
+  },
+  enableWorkflowV3: {
+    params: ZWorkflowIdInput,
+    input: null,
+    output: ZWorkflowResource,
+  },
+  disableWorkflowV3: {
+    params: ZWorkflowIdInput,
+    input: null,
+    output: ZWorkflowResource,
+  },
+  archiveWorkflowV3: {
+    params: ZWorkflowIdInput,
+    input: null,
+    output: ZWorkflowResource,
+  },
+  unarchiveWorkflowV3: {
+    params: ZWorkflowIdInput,
+    input: null,
+    output: ZWorkflowResource,
+  },
+  testWorkflowV3: {
+    params: ZWorkflowIdInput,
+    input: ZTestWorkflowInput,
+    output: ZWorkflowRunResource,
+  },
+  listWorkflowRunsV3: {
+    params: null,
+    input: ZListWorkflowRunsInput,
+    output: zCursorPage(ZWorkflowRunSummary),
+  },
+  getWorkflowRunV3: {
+    params: ZWorkflowRunIdInput,
+    input: null,
+    output: ZWorkflowRunResource,
+  },
+} as const satisfies Record<
+  string,
+  { params: z.ZodType | null; input: z.ZodType | null; output: z.ZodType | null }
+>;
+
+export type TWorkflowApiOperationId = keyof typeof WORKFLOW_API_OPERATIONS;
+
+/**
+ * Implementation contract for the operations above. Route handlers and future service layers
+ * implement this; `deleteWorkflowV3` resolves to void (HTTP 204). Lifecycle, executability,
+ * and idempotency failures are thrown as domain errors and mapped to problem details by the
+ * transport layer.
+ */
+export interface TWorkflowsApiContract {
+  listWorkflows: (input: TListWorkflowsInput) => Promise<TCursorPage<TWorkflowListItem>>;
+  createWorkflow: (input: TCreateWorkflowInput) => Promise<TWorkflowResource>;
+  getWorkflow: (params: TWorkflowIdInput) => Promise<TWorkflowResource>;
+  patchWorkflow: (params: TWorkflowIdInput, input: TPatchWorkflowInput) => Promise<TWorkflowResource>;
+  deleteWorkflow: (params: TWorkflowIdInput) => Promise<void>;
+  duplicateWorkflow: (params: TWorkflowIdInput, input: TDuplicateWorkflowInput) => Promise<TWorkflowResource>;
+  enableWorkflow: (params: TWorkflowIdInput) => Promise<TWorkflowResource>;
+  disableWorkflow: (params: TWorkflowIdInput) => Promise<TWorkflowResource>;
+  archiveWorkflow: (params: TWorkflowIdInput) => Promise<TWorkflowResource>;
+  unarchiveWorkflow: (params: TWorkflowIdInput) => Promise<TWorkflowResource>;
+  testWorkflow: (params: TWorkflowIdInput, input: TTestWorkflowInput) => Promise<TWorkflowRunResource>;
+  listWorkflowRuns: (input: TListWorkflowRunsInput) => Promise<TCursorPage<TWorkflowRunSummary>>;
+  getWorkflowRun: (params: TWorkflowRunIdInput) => Promise<TWorkflowRunResource>;
+}

--- a/packages/workflows/src/contracts/resources.ts
+++ b/packages/workflows/src/contracts/resources.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import { ZWorkflowStatus } from "../types/common";
+import { ZWorkflowDefinition } from "../types/document";
+import {
+  ZWorkflowRunData,
+  ZWorkflowRunLog,
+  ZWorkflowRunStatus,
+  ZWorkflowTriggerRunPayload,
+} from "../types/runs";
+import { ZWorkflowTriggerType } from "../types/triggers";
+import { ZIsoDateTime } from "./common";
+
+/**
+ * API resource shapes returned by the v3 Workflows endpoints. These are the serializer outputs:
+ * dates are ISO 8601 strings, derived projections (`triggerType`, `surveyId`, `lastRun`) are
+ * always present, and nullable fields are emitted explicitly rather than omitted. They are
+ * intentionally distinct from row shapes in `@formbricks/database`.
+ */
+
+export const ZWorkflowRunSummary = z
+  .object({
+    id: z.cuid2(),
+    workflowId: z.cuid2(),
+    workspaceId: z.cuid2(),
+    workflowVersionId: z
+      .cuid2()
+      .nullable()
+      .describe(
+        "Immutable workflow version snapshot the run executes against. Null for dry runs of never-enabled workflows."
+      ),
+    status: ZWorkflowRunStatus,
+    isDryRun: z.boolean(),
+    triggerType: ZWorkflowTriggerType,
+    surveyId: z.cuid2().nullable(),
+    responseId: z
+      .cuid2()
+      .nullable()
+      .describe("Survey response that triggered the run. Null for synthesized dry-run data."),
+    error: z.string().nullable().describe("Terminal or most recent failure reason."),
+    attempt: z.number().int().nonnegative().describe("Retry attempt counter; retries never change status."),
+    createdAt: ZIsoDateTime,
+    updatedAt: ZIsoDateTime,
+    startedAt: ZIsoDateTime.nullable(),
+    finishedAt: ZIsoDateTime.nullable(),
+  })
+  .describe("Slim run shape returned by run lists and embedded as lastRun in workflow resources.");
+export type TWorkflowRunSummary = z.infer<typeof ZWorkflowRunSummary>;
+
+export const ZWorkflowRunLogResource = ZWorkflowRunLog.required({
+  input: true,
+  output: true,
+  error: true,
+  startedAt: true,
+  finishedAt: true,
+}).describe("Persisted trace entry for one run step, with every field emitted explicitly.");
+export type TWorkflowRunLogResource = z.infer<typeof ZWorkflowRunLogResource>;
+
+export const ZWorkflowRunResource = ZWorkflowRunSummary.extend({
+  triggerPayload: ZWorkflowTriggerRunPayload,
+  data: ZWorkflowRunData,
+  logs: z
+    .array(ZWorkflowRunLogResource)
+    .describe("Persisted step-by-step trace ordered by sequence. Empty while the run is queued."),
+  idempotencyKey: z.string().nullable().describe("Deduplication key for this run, unique per workflow."),
+  nextAttemptAt: ZIsoDateTime.nullable(),
+  lastErrorAt: ZIsoDateTime.nullable(),
+}).describe("Full debug-oriented run shape returned by run detail and dry-run creation.");
+export type TWorkflowRunResource = z.infer<typeof ZWorkflowRunResource>;
+
+export const ZWorkflowListItem = z
+  .object({
+    id: z.cuid2(),
+    workspaceId: z.cuid2(),
+    name: z.string().min(1),
+    description: z.string().nullable(),
+    status: ZWorkflowStatus,
+    triggerType: ZWorkflowTriggerType.describe("Derived from definition.trigger.triggerType."),
+    surveyId: z.cuid2().describe("Derived from definition.trigger.config.surveyId."),
+    createdBy: z.cuid2().nullable().describe("Null when the creating user was deleted."),
+    createdAt: ZIsoDateTime,
+    updatedAt: ZIsoDateTime,
+    lastRun: ZWorkflowRunSummary.nullable().describe(
+      "Most recent run summary (dry runs included). Null when the workflow has never run."
+    ),
+  })
+  .describe("Slim workflow shape returned by the workflow list. Excludes the definition.");
+export type TWorkflowListItem = z.infer<typeof ZWorkflowListItem>;
+
+export const ZWorkflowResource = ZWorkflowListItem.extend({
+  definition: ZWorkflowDefinition,
+}).describe("Full workflow shape returned by detail, create, update, duplicate, and lifecycle operations.");
+export type TWorkflowResource = z.infer<typeof ZWorkflowResource>;

--- a/packages/workflows/src/contracts/spec-drift.test.ts
+++ b/packages/workflows/src/contracts/spec-drift.test.ts
@@ -1,0 +1,129 @@
+import { readFile, readdir } from "node:fs/promises";
+import { describe, expect, test } from "vitest";
+import type { z } from "zod";
+import { ZWorkflowRunLogStatus, ZWorkflowRunStatus, ZWorkflowStatus } from "../types";
+import {
+  WORKFLOW_API_OPERATIONS,
+  ZCreateWorkflowInput,
+  ZCursorPaginationMeta,
+  ZWorkflowListItem,
+  ZWorkflowRunResource,
+  ZWorkflowRunSummary,
+} from "./index";
+
+/**
+ * Drift guard between these operation contracts and their OpenAPI representation in
+ * docs/api-v3-reference/src. The spec stays the source of truth for HTTP semantics (status
+ * codes, headers, filter syntax); these tests pin the parts both layers must agree on:
+ * operation coverage, status enums, resource property sets, and the spec's own examples.
+ * Full zod-openapi generation of the spec components is planned once the routes land.
+ */
+
+const SPEC_SRC_URL = new URL("../../../../docs/api-v3-reference/src/", import.meta.url);
+
+const loadYaml = async (relativePath: string): Promise<Record<string, unknown>> => {
+  // Dynamic import keeps js-yaml out of the static import block, where prettier's sort-imports
+  // grouping and eslint's import/order disagree about its position relative to node: builtins.
+  const { load } = await import("js-yaml");
+  const raw = await readFile(new URL(relativePath, SPEC_SRC_URL), "utf8");
+  return load(raw) as Record<string, unknown>;
+};
+
+const schemaKeys = (schema: z.ZodObject): string[] => Object.keys(schema.shape).sort();
+
+const yamlPropertyKeys = (yamlSchema: Record<string, unknown>): string[] =>
+  Object.keys((yamlSchema.properties as Record<string, unknown> | undefined) ?? {}).sort();
+
+describe("operation coverage", () => {
+  test("the contracts map covers exactly the workflow operations in the spec", async () => {
+    const pathFiles = await readdir(new URL("paths/", SPEC_SRC_URL));
+    const specOperationIds: string[] = [];
+
+    for (const pathFile of pathFiles) {
+      const pathItem = await loadYaml(`paths/${pathFile}`);
+      for (const operation of Object.values(pathItem)) {
+        const candidate = operation as { operationId?: string; tags?: string[] };
+        if (candidate.tags?.includes("V3 Workflows") && candidate.operationId) {
+          specOperationIds.push(candidate.operationId);
+        }
+      }
+    }
+
+    expect(specOperationIds.sort()).toEqual(Object.keys(WORKFLOW_API_OPERATIONS).sort());
+  });
+});
+
+describe("status enums", () => {
+  test.each([
+    ["WorkflowStatus", ZWorkflowStatus.options],
+    ["WorkflowRunStatus", ZWorkflowRunStatus.options],
+    ["WorkflowRunLogStatus", ZWorkflowRunLogStatus.options],
+  ])("%s enum matches the shared schema", async (schemaName, zodOptions) => {
+    const yamlSchema = await loadYaml(`components/schemas/${schemaName}.yml`);
+    expect(yamlSchema.enum).toEqual([...zodOptions]);
+  });
+});
+
+describe("resource shapes", () => {
+  test("WorkflowListItem properties match the contract shape", async () => {
+    const yamlSchema = await loadYaml("components/schemas/WorkflowListItem.yml");
+    expect(yamlPropertyKeys(yamlSchema)).toEqual(schemaKeys(ZWorkflowListItem));
+    expect([...((yamlSchema.required as string[] | undefined) ?? [])].sort()).toEqual(
+      schemaKeys(ZWorkflowListItem)
+    );
+  });
+
+  test("WorkflowRunSummary properties match the contract shape", async () => {
+    const yamlSchema = await loadYaml("components/schemas/WorkflowRunSummary.yml");
+    expect(yamlPropertyKeys(yamlSchema)).toEqual(schemaKeys(ZWorkflowRunSummary));
+    expect([...((yamlSchema.required as string[] | undefined) ?? [])].sort()).toEqual(
+      schemaKeys(ZWorkflowRunSummary)
+    );
+  });
+
+  test("WorkflowResource composes the list item with a definition", async () => {
+    const yamlSchema = await loadYaml("components/schemas/WorkflowResource.yml");
+    const [listItemRef, extension] = yamlSchema.allOf as [Record<string, string>, Record<string, unknown>];
+    expect(listItemRef.$ref).toContain("WorkflowListItem");
+    expect(yamlPropertyKeys(extension)).toEqual(["definition"]);
+  });
+
+  test("WorkflowRunResource extends the summary with the debug payload", async () => {
+    const yamlSchema = await loadYaml("components/schemas/WorkflowRunResource.yml");
+    const [summaryRef, extension] = yamlSchema.allOf as [Record<string, string>, Record<string, unknown>];
+    expect(summaryRef.$ref).toContain("WorkflowRunSummary");
+    const summaryKeys = schemaKeys(ZWorkflowRunSummary);
+    const extensionKeys = yamlPropertyKeys(extension);
+    expect([...summaryKeys, ...extensionKeys].sort()).toEqual(schemaKeys(ZWorkflowRunResource));
+  });
+
+  test("CursorPaginationMeta matches the contract shape", async () => {
+    const yamlSchema = await loadYaml("components/schemas/CursorPaginationMeta.yml");
+    expect(yamlPropertyKeys(yamlSchema)).toEqual(schemaKeys(ZCursorPaginationMeta));
+  });
+});
+
+describe("spec examples", () => {
+  test("the create example parses with ZCreateWorkflowInput", async () => {
+    const pathItem = await loadYaml("paths/api_v3_workflows.yml");
+    const post = pathItem.post as {
+      requestBody: {
+        content: Record<string, { examples: Record<string, { value: unknown }> }>;
+      };
+    };
+    const example = post.requestBody.content["application/json"].examples.responseCompletedEmail.value;
+    expect(() => ZCreateWorkflowInput.parse(example)).not.toThrow();
+  });
+
+  test("the queued dry-run example parses with ZWorkflowRunResource", async () => {
+    const pathItem = await loadYaml("paths/api_v3_workflows_{workflowId}_test.yml");
+    const post = pathItem.post as {
+      responses: Record<
+        string,
+        { content: Record<string, { examples: Record<string, { value: { data: unknown } }> }> }
+      >;
+    };
+    const example = post.responses["201"].content["application/json"].examples.queuedDryRun.value.data;
+    expect(() => ZWorkflowRunResource.parse(example)).not.toThrow();
+  });
+});

--- a/packages/workflows/src/index.ts
+++ b/packages/workflows/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./contracts";
 export * from "./types";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1186,9 +1186,15 @@ importers:
       '@formbricks/eslint-config':
         specifier: workspace:*
         version: link:../config-eslint
+      '@types/js-yaml':
+        specifier: 4.0.9
+        version: 4.0.9
       '@vitest/coverage-v8':
         specifier: 4.1.6
         version: 4.1.6(vitest@4.1.6)
+      js-yaml:
+        specifier: 4.1.0
+        version: 4.1.0
       publint:
         specifier: 0.3.21
         version: 0.3.21
@@ -6177,6 +6183,9 @@ packages:
   '@types/js-cookie@2.2.7':
     resolution: {integrity: sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -9183,10 +9192,6 @@ packages:
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
-    hasBin: true
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -14658,7 +14663,7 @@ snapshots:
       globals: 13.24.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.1.0
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -17459,7 +17464,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6
       js-levenshtein: 1.1.6
-      js-yaml: 4.1.1
+      js-yaml: 4.1.0
       minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -18894,6 +18899,8 @@ snapshots:
   '@types/heic-convert@2.1.0': {}
 
   '@types/js-cookie@2.2.7': {}
+
+  '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -21379,7 +21386,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.1.1
+      js-yaml: 4.1.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -22397,10 +22404,6 @@ snapshots:
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## What does this PR do?

Fixes [ENG-1101](https://linear.app/formbricks/issue/ENG-1101/define-workfows-api-contracts-and-openapi-specs)

Addresses the change request on #8268: the contracts now live **in code**, not only in YAML. This PR adds `packages/workflows/src/contracts/` — importable, route-agnostic operation contracts for the v3 Workflows API — plus drift tests that pin them to the OpenAPI source so the two representations cannot silently diverge.

Stacked on #8267 (spec split), which stacks on #8268 (the spec). Browser-safe: runtime dependency stays `zod` only (`js-yaml` is a test-only devDependency).

### What's in the module

- **`inputs.ts`** — operation inputs as strict Zod schemas: `ZCreateWorkflowInput`, `ZPatchWorkflowInput` (min one field), `ZDuplicateWorkflowInput`, `ZTestWorkflowInput`, `ZListWorkflowsInput` / `ZListWorkflowRunsInput`. These are the *parsed* forms: the `filter[...]` query family, path params, and the `Idempotency-Key` header are transport concerns mapped into these shapes by handlers; jobs/MCP/tests construct them directly. All inputs are `z.strictObject` — unknown fields are **rejected, not stripped**, matching the spec's `additionalProperties: false` and the v3 principle that unsupported fields fail with 400.
- **`resources.ts`** — serializer-shaped outputs, intentionally distinct from DB row shapes: `ZWorkflowListItem`, `ZWorkflowResource`, `ZWorkflowRunSummary`, `ZWorkflowRunResource`, `ZWorkflowRunLogResource`. ISO 8601 date strings, derived projections (`triggerType`, `surveyId`, `lastRun`) always present, nullables emitted explicitly. Built by reusing the existing shared schemas (`ZWorkflowDefinition`, `ZWorkflowRunData`, `ZWorkflowTriggerRunPayload`, `ZWorkflowRunLog`) rather than duplicating them.
- **`operations.ts`** — `WORKFLOW_API_OPERATIONS`: all 13 operations keyed by the spec operationIds, each with `params` / `input` / `output` schemas; plus the `TWorkflowsApiContract` interface (`createWorkflow(input): Promise<TWorkflowResource>`, …) for route handlers and future service layers to implement. Domain failures (lifecycle, executability, idempotency races) are thrown and mapped to problem details by the transport layer.
- **`common.ts`** — cursor pagination meta + generic page envelope, id param schemas.

### Drift gates (`spec-drift.test.ts`)

`pnpm test` now fails if the contracts and `docs/api-v3-reference/src/` disagree on:

- **Operation coverage** — the map must match exactly the `V3 Workflows` operationIds in the spec's path files (additions or removals on either side fail).
- **Status enums** — `WorkflowStatus`, `WorkflowRunStatus`, `WorkflowRunLogStatus`.
- **Resource shapes** — property sets and required sets for `WorkflowListItem` / `WorkflowRunSummary`, and the `allOf` compositions of `WorkflowResource` / `WorkflowRunResource`.
- **The spec's own examples** — the create request example and the queued dry-run response example must parse through the contract schemas.

Deliberately **not** drift-checked: input schemas vs request bodies (they diverge by design — `idempotencyKey` lives in the input, list inputs are parsed filter forms) and constraint-level details (minLength, formats, per-field nullability). Closing that last gap is the planned follow-up: generate the spec components from these schemas via `zod-openapi`, the same way v2's `generate-api-specs` works, once the routes land (ENG-1221+). These gates are the bridge until then.

### Open questions for review (shared-schema decisions, kept out of this PR)

1. Should `ZWorkflowDefinition` itself become strict? The spec marks the definition `additionalProperties: false`, but the shared schema currently strips unknown node fields.
2. `send_email` vs `response.completed` casing mix — cheap to align while nothing runtime depends on it.
3. `ZWorkflowTriggerPayload.responseId` is required, but synthesized dry-run payloads have no real response — make it optional, or synthesize an id?

## How should this be tested?

- `pnpm --filter @formbricks/workflows test` → 47 passed (11 are the spec-drift gates)
- `pnpm --filter @formbricks/workflows typecheck && pnpm --filter @formbricks/workflows lint` → clean
- `pnpm --filter @formbricks/workflows build` → vite build + publint pass
- Drift gate negative check: change any status enum value, an operationId, or a resource field on either side (contracts or `docs/api-v3-reference/src/`) → tests fail
- Strictness check: add an unknown field to a create/test/patch payload in a test → rejected, not stripped

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits (module headers explain the transport-vs-contract boundary; drift test header explains what is and isn't pinned)
- [ ] Ran `pnpm build` — ran the affected package's build (`@formbricks/workflows` vite build + publint); no app code changes
- [x] Checked for warnings, there are none (lint 0, typecheck 0)
- [x] Removed all `console.logs`
- [x] Based on the latest `docs/workflows_spec` (stacked; GitHub retargets when the base merges)
- [x] My changes don't cause any responsiveness issues (no UI changes)
- [ ] First PR at Formbricks? — N/A

### Appreciated

- [ ] If a UI change was made: screenshots — N/A
- [x] Updated the Formbricks Docs if changes were necessary — the OpenAPI spec remains the public documentation; this PR adds the code-level representation and the tests binding the two