### PR TITLE
fix(tags): treat duplicate tag-on-response as no-op [ENG-1272]

### DIFF
--- a/apps/web/lib/tagOnResponse/service.test.ts
+++ b/apps/web/lib/tagOnResponse/service.test.ts
@@ -134,9 +134,52 @@ describe("TagOnResponse Service", () => {
     });
   });
 
-  test("should throw DatabaseError when prisma operation fails", async () => {
+  test("addTagToRespone should be a no-op when the tag is already on the response (P2002)", async () => {
+    const prismaError = new Prisma.PrismaClientKnownRequestError(
+      "Unique constraint failed on the fields: (`responseId`,`tagId`)",
+      {
+        code: "P2002",
+        clientVersion: "5.0.0",
+      }
+    );
+    vi.mocked(prisma.tagsOnResponses.create).mockRejectedValue(prismaError);
+
+    const result = await addTagToRespone("response1", "tag1");
+
+    expect(result).toEqual({
+      responseId: "response1",
+      tagId: "tag1",
+    });
+  });
+
+  test("addTagToRespone should not throw when called twice with the same (responseId, tagId)", async () => {
+    const mockTagOnResponse = {
+      tag: {
+        workspaceId: "workspace1",
+      },
+    };
+    const prismaError = new Prisma.PrismaClientKnownRequestError(
+      "Unique constraint failed on the fields: (`responseId`,`tagId`)",
+      {
+        code: "P2002",
+        clientVersion: "5.0.0",
+      }
+    );
+
+    vi.mocked(prisma.tagsOnResponses.create)
+      .mockResolvedValueOnce(mockTagOnResponse as any)
+      .mockRejectedValueOnce(prismaError);
+
+    const first = await addTagToRespone("response1", "tag1");
+    const second = await addTagToRespone("response1", "tag1");
+
+    expect(first).toEqual({ responseId: "response1", tagId: "tag1" });
+    expect(second).toEqual({ responseId: "response1", tagId: "tag1" });
+  });
+
+  test("addTagToRespone should throw DatabaseError for non-P2002 prisma errors", async () => {
     const prismaError = new Prisma.PrismaClientKnownRequestError("Database error", {
-      code: "P2002",
+      code: "P2025",
       clientVersion: "5.0.0",
     });
     vi.mocked(prisma.tagsOnResponses.create).mockRejectedValue(prismaError);

--- a/apps/web/lib/tagOnResponse/service.test.ts
+++ b/apps/web/lib/tagOnResponse/service.test.ts
@@ -140,6 +140,7 @@ describe("TagOnResponse Service", () => {
       {
         code: "P2002",
         clientVersion: "5.0.0",
+        meta: { target: ["responseId", "tagId"] },
       }
     );
     vi.mocked(prisma.tagsOnResponses.create).mockRejectedValue(prismaError);
@@ -163,6 +164,7 @@ describe("TagOnResponse Service", () => {
       {
         code: "P2002",
         clientVersion: "5.0.0",
+        meta: { target: ["responseId", "tagId"] },
       }
     );
 
@@ -180,6 +182,30 @@ describe("TagOnResponse Service", () => {
   test("addTagToRespone should throw DatabaseError for non-P2002 prisma errors", async () => {
     const prismaError = new Prisma.PrismaClientKnownRequestError("Database error", {
       code: "P2025",
+      clientVersion: "5.0.0",
+    });
+    vi.mocked(prisma.tagsOnResponses.create).mockRejectedValue(prismaError);
+
+    await expect(addTagToRespone("response1", "tag1")).rejects.toThrow(DatabaseError);
+  });
+
+  test("addTagToRespone should throw DatabaseError for P2002 on a different target", async () => {
+    const prismaError = new Prisma.PrismaClientKnownRequestError(
+      "Unique constraint failed on the fields: (`someOtherField`)",
+      {
+        code: "P2002",
+        clientVersion: "5.0.0",
+        meta: { target: ["someOtherField"] },
+      }
+    );
+    vi.mocked(prisma.tagsOnResponses.create).mockRejectedValue(prismaError);
+
+    await expect(addTagToRespone("response1", "tag1")).rejects.toThrow(DatabaseError);
+  });
+
+  test("addTagToRespone should throw DatabaseError for P2002 without meta.target", async () => {
+    const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+      code: "P2002",
       clientVersion: "5.0.0",
     });
     vi.mocked(prisma.tagsOnResponses.create).mockRejectedValue(prismaError);

--- a/apps/web/lib/tagOnResponse/service.ts
+++ b/apps/web/lib/tagOnResponse/service.ts
@@ -31,6 +31,12 @@ export const addTagToRespone = async (responseId: string, tagId: string): Promis
     };
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error.code === "P2002") {
+        return {
+          responseId,
+          tagId,
+        };
+      }
       throw new DatabaseError(error.message);
     }
 

--- a/apps/web/lib/tagOnResponse/service.ts
+++ b/apps/web/lib/tagOnResponse/service.ts
@@ -31,7 +31,7 @@ export const addTagToRespone = async (responseId: string, tagId: string): Promis
     };
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      if (error.code === "P2002") {
+      if (error.code === "P2002" && isTagsOnResponsesUniqueViolation(error)) {
         return {
           responseId,
           tagId,
@@ -42,6 +42,12 @@ export const addTagToRespone = async (responseId: string, tagId: string): Promis
 
     throw error;
   }
+};
+
+const isTagsOnResponsesUniqueViolation = (error: Prisma.PrismaClientKnownRequestError): boolean => {
+  const target = error.meta?.target;
+  if (!Array.isArray(target)) return false;
+  return target.includes("responseId") && target.includes("tagId");
 };
 
 export const deleteTagOnResponse = async (responseId: string, tagId: string): Promise<TTagsOnResponses> => {

--- a/apps/web/lib/tagOnResponse/service.ts
+++ b/apps/web/lib/tagOnResponse/service.ts
@@ -31,7 +31,11 @@ export const addTagToRespone = async (responseId: string, tagId: string): Promis
     };
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      if (error.code === "P2002" && isTagsOnResponsesUniqueViolation(error)) {
+      const target = error.meta?.target;
+      const isTagsOnResponsesUniqueViolation =
+        Array.isArray(target) && target.includes("responseId") && target.includes("tagId");
+
+      if (error.code === "P2002" && isTagsOnResponsesUniqueViolation) {
         return {
           responseId,
           tagId,
@@ -42,12 +46,6 @@ export const addTagToRespone = async (responseId: string, tagId: string): Promis
 
     throw error;
   }
-};
-
-const isTagsOnResponsesUniqueViolation = (error: Prisma.PrismaClientKnownRequestError): boolean => {
-  const target = error.meta?.target;
-  if (!Array.isArray(target)) return false;
-  return target.includes("responseId") && target.includes("tagId");
 };
 
 export const deleteTagOnResponse = async (responseId: string, tagId: string): Promise<TTagsOnResponses> => {


### PR DESCRIPTION
## Summary
- `addTagToRespone` in `apps/web/lib/tagOnResponse/service.ts` used `prisma.tagsOnResponses.create()` with no guard against an existing `(responseId, tagId)` pair. A double-click or optimistic-UI race triggered Prisma's `P2002` unique-constraint error, which the catch block blindly re-wrapped as `DatabaseError` — surfacing a benign "already tagged" no-op as an unhandled error in the UI and in Sentry (`FORMBRICKS-13W`).
- Catch `P2002` explicitly and return the `(responseId, tagId)` pair as a no-op. Other `PrismaClientKnownRequestError` codes continue to throw `DatabaseError`.

## Linear
- [ENG-1272](https://linear.app/formbricks/issue/ENG-1272)

## Test plan
- [x] New unit test: P2002 → no-op return, no throw
- [x] New unit test: two consecutive `addTagToRespone` calls with same `(responseId, tagId)` → both resolve without throwing
- [x] Existing test rewritten to use `P2025` so it still asserts the non-duplicate Prisma error path throws `DatabaseError`
- [x] `pnpm vitest run lib/tagOnResponse/service.test.ts` → 6/6 pass
- [ ] Manual: rapid double-click "add tag" on a response → no error toast, no new Sentry event