### PR TITLE
fix: always suggest white card background on Suggest colors

### DIFF
--- a/apps/web/lib/styling/constants.test.ts
+++ b/apps/web/lib/styling/constants.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "vitest";
+import { getSuggestedColors } from "./constants";
+
+describe("getSuggestedColors", () => {
+  test("always suggests white for card background color", () => {
+    const greenBrand = getSuggestedColors("#00ab3b");
+    const roseBrand = getSuggestedColors("#e11d48");
+
+    expect(greenBrand["cardBackgroundColor.light"]).toBe("#ffffff");
+    expect(roseBrand["cardBackgroundColor.light"]).toBe("#ffffff");
+  });
+});

--- a/apps/web/lib/styling/constants.ts
+++ b/apps/web/lib/styling/constants.ts
@@ -31,7 +31,7 @@ export const getSuggestedColors = (brandColor: string = DEFAULT_BRAND_COLOR) => 
   // Input border: visible brand-tinted border
   const inputBorder = mixColor(brandColor, "#ffffff", 0.6);
   // Card tones
-  const cardBg = mixColor(brandColor, "#ffffff", 0.97);
+  const cardBg = "#ffffff";
   const cardBorder = mixColor(brandColor, "#ffffff", 0.8);
   // Page background
   const pageBg = mixColor(brandColor, "#ffffff", 0.855);

--- a/apps/web/playwright/survey-styling.spec.ts
+++ b/apps/web/playwright/survey-styling.spec.ts
@@ -230,9 +230,8 @@ test.describe("Survey Styling", async () => {
     expect(css).toContain("--fb-input-background-color:");
     expect(css).not.toContain("--fb-input-background-color: #ffffff");
 
-    // Card/survey background should be brand-tinted, NOT hardcoded #ffffff
-    expect(css).toContain("--fb-survey-background-color:");
-    expect(css).not.toContain("--fb-survey-background-color: #ffffff");
+    // Card/survey background should always be white
+    expect(css).toContain("--fb-survey-background-color: #ffffff");
 
     // Question/heading color should be derived, NOT the old hardcoded #2b2524
     expect(css).toContain("--fb-heading-color:");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What does this PR do?

Changes the "Suggest colors" flow so the generated **Card background color** is always white (`#ffffff`) instead of a watered-down tint of the brand color.

The change is made in `getSuggestedColors()`, which powers both workspace appearance settings and per-survey styling.

## How should this be tested?

1. Go to **Workspace → Settings → Look** (or a survey's **Styling** tab).
2. Set a distinctive brand color (e.g. `#00ab3b` or `#e11d48`).
3. Click **Suggest colors** → **Generate**.
4. Open **Card styling** and confirm **Card background color** is `#ffffff`.
5. Verify other suggested colors (inputs, borders, headings) are still derived from the brand color.

**Automated tests:**
- `pnpm vitest run lib/styling/constants.test.ts` (in `apps/web`)
- E2E: `survey-styling.spec.ts` — "Suggest Colors derives all colors from brand color without changing non-color properties"
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c059304c-b897-46d0-8203-257e236a55a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c059304c-b897-46d0-8203-257e236a55a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

