### PR TITLE
feat(workflows): create, list, and get v3 API [ENG-1221]

### DIFF
--- a/apps/web/app/api/v3/workflows/[workflowId]/archive/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/archive/route.ts
@@ -1,0 +1,19 @@
+/**
+ * POST /api/v3/workflows/{workflowId}/archive — soft-delete (status → archived).
+ * Thin adapter delegating to the framework-agnostic handler in `@formbricks/workflows/server`.
+ */
+import { ZWorkflowIdInput } from "@formbricks/workflows";
+import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
+import { buildWorkflowApiContext, workflowsHandlers } from "../../lib/context";
+
+export const POST = withV3ApiWrapper({
+  auth: "both",
+  action: "updated",
+  targetType: "workflow",
+  schemas: { params: ZWorkflowIdInput },
+  handler: async ({ parsedInput, authentication, requestId, instance }) =>
+    workflowsHandlers.archive(
+      buildWorkflowApiContext(authentication, requestId, instance),
+      parsedInput.params
+    ),
+});

--- a/apps/web/app/api/v3/workflows/[workflowId]/archive/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/archive/route.ts
@@ -12,8 +12,8 @@ export const POST = withV3ApiWrapper({
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
   handler: async ({ parsedInput, authentication, requestId, instance }) =>
-    workflowsHandlers.archive(
-      buildWorkflowApiContext(authentication, requestId, instance),
-      parsedInput.params
-    ),
+    workflowsHandlers.archive({
+      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      params: parsedInput.params,
+    }),
 });

--- a/apps/web/app/api/v3/workflows/[workflowId]/disable/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/disable/route.ts
@@ -12,8 +12,8 @@ export const POST = withV3ApiWrapper({
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
   handler: async ({ parsedInput, authentication, requestId, instance }) =>
-    workflowsHandlers.disable(
-      buildWorkflowApiContext(authentication, requestId, instance),
-      parsedInput.params
-    ),
+    workflowsHandlers.disable({
+      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      params: parsedInput.params,
+    }),
 });

--- a/apps/web/app/api/v3/workflows/[workflowId]/disable/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/disable/route.ts
@@ -1,0 +1,19 @@
+/**
+ * POST /api/v3/workflows/{workflowId}/disable — move an enabled workflow to disabled.
+ * Thin adapter delegating to the framework-agnostic handler in @formbricks/workflows/server.
+ */
+import { ZWorkflowIdInput } from "@formbricks/workflows";
+import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
+import { buildWorkflowApiContext, workflowsHandlers } from "../../lib/context";
+
+export const POST = withV3ApiWrapper({
+  auth: "both",
+  action: "updated",
+  targetType: "workflow",
+  schemas: { params: ZWorkflowIdInput },
+  handler: async ({ parsedInput, authentication, requestId, instance }) =>
+    workflowsHandlers.disable(
+      buildWorkflowApiContext(authentication, requestId, instance),
+      parsedInput.params
+    ),
+});

--- a/apps/web/app/api/v3/workflows/[workflowId]/duplicate/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/duplicate/route.ts
@@ -1,0 +1,20 @@
+/**
+ * POST /api/v3/workflows/{workflowId}/duplicate — clone a workflow into a new draft.
+ * Thin adapter delegating to the framework-agnostic handler in `@formbricks/workflows/server`.
+ */
+import { ZWorkflowIdInput } from "@formbricks/workflows";
+import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
+import { buildWorkflowApiContext, workflowsHandlers } from "../../lib/context";
+
+export const POST = withV3ApiWrapper({
+  auth: "both",
+  action: "created",
+  targetType: "workflow",
+  schemas: { params: ZWorkflowIdInput },
+  handler: async ({ req, parsedInput, authentication, requestId, instance }) =>
+    workflowsHandlers.duplicate(
+      req,
+      buildWorkflowApiContext(authentication, requestId, instance),
+      parsedInput.params
+    ),
+});

--- a/apps/web/app/api/v3/workflows/[workflowId]/duplicate/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/duplicate/route.ts
@@ -12,9 +12,9 @@ export const POST = withV3ApiWrapper({
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
   handler: async ({ req, parsedInput, authentication, requestId, instance }) =>
-    workflowsHandlers.duplicate(
+    workflowsHandlers.duplicate({
       req,
-      buildWorkflowApiContext(authentication, requestId, instance),
-      parsedInput.params
-    ),
+      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      params: parsedInput.params,
+    }),
 });

--- a/apps/web/app/api/v3/workflows/[workflowId]/enable/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/enable/route.ts
@@ -12,8 +12,8 @@ export const POST = withV3ApiWrapper({
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
   handler: async ({ parsedInput, authentication, requestId, instance }) =>
-    workflowsHandlers.enable(
-      buildWorkflowApiContext(authentication, requestId, instance),
-      parsedInput.params
-    ),
+    workflowsHandlers.enable({
+      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      params: parsedInput.params,
+    }),
 });

--- a/apps/web/app/api/v3/workflows/[workflowId]/enable/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/enable/route.ts
@@ -1,0 +1,19 @@
+/**
+ * POST /api/v3/workflows/{workflowId}/enable — validate executability, snapshot an immutable
+ * version, and move the workflow to enabled. Thin adapter delegating to @formbricks/workflows/server.
+ */
+import { ZWorkflowIdInput } from "@formbricks/workflows";
+import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
+import { buildWorkflowApiContext, workflowsHandlers } from "../../lib/context";
+
+export const POST = withV3ApiWrapper({
+  auth: "both",
+  action: "updated",
+  targetType: "workflow",
+  schemas: { params: ZWorkflowIdInput },
+  handler: async ({ parsedInput, authentication, requestId, instance }) =>
+    workflowsHandlers.enable(
+      buildWorkflowApiContext(authentication, requestId, instance),
+      parsedInput.params
+    ),
+});

--- a/apps/web/app/api/v3/workflows/[workflowId]/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/route.ts
@@ -13,7 +13,10 @@ export const GET = withV3ApiWrapper({
   auth: "both",
   schemas: { params: ZWorkflowIdInput },
   handler: async ({ parsedInput, authentication, requestId, instance }) =>
-    workflowsHandlers.get(buildWorkflowApiContext(authentication, requestId, instance), parsedInput.params),
+    workflowsHandlers.get({
+      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      params: parsedInput.params,
+    }),
 });
 
 export const PATCH = withV3ApiWrapper({
@@ -22,11 +25,11 @@ export const PATCH = withV3ApiWrapper({
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
   handler: async ({ req, parsedInput, authentication, requestId, instance }) =>
-    workflowsHandlers.patch(
+    workflowsHandlers.patch({
       req,
-      buildWorkflowApiContext(authentication, requestId, instance),
-      parsedInput.params
-    ),
+      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      params: parsedInput.params,
+    }),
 });
 
 export const DELETE = withV3ApiWrapper({
@@ -35,8 +38,8 @@ export const DELETE = withV3ApiWrapper({
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
   handler: async ({ parsedInput, authentication, requestId, instance }) =>
-    workflowsHandlers.delete(
-      buildWorkflowApiContext(authentication, requestId, instance),
-      parsedInput.params
-    ),
+    workflowsHandlers.delete({
+      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      params: parsedInput.params,
+    }),
 });

--- a/apps/web/app/api/v3/workflows/[workflowId]/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/route.ts
@@ -1,0 +1,17 @@
+/**
+ * /api/v3/workflows/{workflowId} — retrieve a single workflow.
+ * Unknown / cross-workspace ids return 403 (not 404) to avoid leaking existence.
+ *
+ * Thin adapter: the wrapper validates the path param with the contract schema, then delegates to
+ * the framework-agnostic handler in `@formbricks/workflows/server`.
+ */
+import { ZWorkflowIdInput } from "@formbricks/workflows";
+import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
+import { buildWorkflowApiContext, workflowsHandlers } from "../lib/context";
+
+export const GET = withV3ApiWrapper({
+  auth: "both",
+  schemas: { params: ZWorkflowIdInput },
+  handler: async ({ parsedInput, authentication, requestId, instance }) =>
+    workflowsHandlers.get(buildWorkflowApiContext(authentication, requestId, instance), parsedInput.params),
+});

--- a/apps/web/app/api/v3/workflows/[workflowId]/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/route.ts
@@ -1,9 +1,9 @@
 /**
- * /api/v3/workflows/{workflowId} — retrieve a single workflow.
+ * /api/v3/workflows/{workflowId} — retrieve, update, and delete a single workflow.
  * Unknown / cross-workspace ids return 403 (not 404) to avoid leaking existence.
  *
- * Thin adapter: the wrapper validates the path param with the contract schema, then delegates to
- * the framework-agnostic handler in `@formbricks/workflows/server`.
+ * Thin adapters: the wrapper validates the path param with the contract schema, then delegates to
+ * the framework-agnostic handlers in `@formbricks/workflows/server`.
  */
 import { ZWorkflowIdInput } from "@formbricks/workflows";
 import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
@@ -14,4 +14,29 @@ export const GET = withV3ApiWrapper({
   schemas: { params: ZWorkflowIdInput },
   handler: async ({ parsedInput, authentication, requestId, instance }) =>
     workflowsHandlers.get(buildWorkflowApiContext(authentication, requestId, instance), parsedInput.params),
+});
+
+export const PATCH = withV3ApiWrapper({
+  auth: "both",
+  action: "updated",
+  targetType: "workflow",
+  schemas: { params: ZWorkflowIdInput },
+  handler: async ({ req, parsedInput, authentication, requestId, instance }) =>
+    workflowsHandlers.patch(
+      req,
+      buildWorkflowApiContext(authentication, requestId, instance),
+      parsedInput.params
+    ),
+});
+
+export const DELETE = withV3ApiWrapper({
+  auth: "both",
+  action: "deleted",
+  targetType: "workflow",
+  schemas: { params: ZWorkflowIdInput },
+  handler: async ({ parsedInput, authentication, requestId, instance }) =>
+    workflowsHandlers.delete(
+      buildWorkflowApiContext(authentication, requestId, instance),
+      parsedInput.params
+    ),
 });

--- a/apps/web/app/api/v3/workflows/[workflowId]/unarchive/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/unarchive/route.ts
@@ -1,0 +1,19 @@
+/**
+ * POST /api/v3/workflows/{workflowId}/unarchive — restore an archived workflow to draft.
+ * Thin adapter delegating to the framework-agnostic handler in `@formbricks/workflows/server`.
+ */
+import { ZWorkflowIdInput } from "@formbricks/workflows";
+import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
+import { buildWorkflowApiContext, workflowsHandlers } from "../../lib/context";
+
+export const POST = withV3ApiWrapper({
+  auth: "both",
+  action: "updated",
+  targetType: "workflow",
+  schemas: { params: ZWorkflowIdInput },
+  handler: async ({ parsedInput, authentication, requestId, instance }) =>
+    workflowsHandlers.unarchive(
+      buildWorkflowApiContext(authentication, requestId, instance),
+      parsedInput.params
+    ),
+});

--- a/apps/web/app/api/v3/workflows/[workflowId]/unarchive/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/unarchive/route.ts
@@ -12,8 +12,8 @@ export const POST = withV3ApiWrapper({
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
   handler: async ({ parsedInput, authentication, requestId, instance }) =>
-    workflowsHandlers.unarchive(
-      buildWorkflowApiContext(authentication, requestId, instance),
-      parsedInput.params
-    ),
+    workflowsHandlers.unarchive({
+      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      params: parsedInput.params,
+    }),
 });

--- a/apps/web/app/api/v3/workflows/lib/context.test.ts
+++ b/apps/web/app/api/v3/workflows/lib/context.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { TAuthenticationApiKey } from "@formbricks/types/auth";
+import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
+import type { TV3Authentication } from "@/app/api/v3/lib/types";
+import { buildWorkflowApiContext } from "./context";
+
+vi.mock("@formbricks/database", () => ({ prisma: { workflow: {} } }));
+vi.mock("@formbricks/logger", () => ({
+  logger: { withContext: vi.fn(() => ({ warn: vi.fn(), error: vi.fn() })) },
+}));
+vi.mock("@/app/api/v3/lib/auth", () => ({ requireV3WorkspaceAccess: vi.fn() }));
+
+const sessionAuth = {
+  user: { id: "cm9zr52kh000508l8e3q7bw9j" },
+  expires: "2026-12-01",
+} as unknown as TV3Authentication;
+const apiKeyAuth = {
+  type: "apiKey",
+  apiKeyId: "key_1",
+  organizationId: "org_1",
+  organizationAccess: { accessControl: { read: true, write: true } },
+  workspacePermissions: [],
+} as unknown as TAuthenticationApiKey;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("buildWorkflowApiContext", () => {
+  test("derives userId from a session", () => {
+    const ctx = buildWorkflowApiContext(sessionAuth, "req_1", "https://app.formbricks.com");
+    expect(ctx.userId).toBe("cm9zr52kh000508l8e3q7bw9j");
+  });
+
+  test("leaves userId null for API-key authentication", () => {
+    expect(buildWorkflowApiContext(apiKeyAuth, "req_1", "inst").userId).toBeNull();
+  });
+
+  test("leaves userId null for unauthenticated requests", () => {
+    expect(buildWorkflowApiContext(null, "req_1", "inst").userId).toBeNull();
+  });
+
+  test("authorize delegates to requireV3WorkspaceAccess and returns its result", async () => {
+    const resolved = { workspaceId: "ws_1", organizationId: "org_1" };
+    vi.mocked(requireV3WorkspaceAccess).mockResolvedValue(resolved);
+
+    const ctx = buildWorkflowApiContext(apiKeyAuth, "req_1", "https://app.formbricks.com");
+    const result = await ctx.authorize("ws_1", "readWrite");
+
+    expect(requireV3WorkspaceAccess).toHaveBeenCalledWith(
+      apiKeyAuth,
+      "ws_1",
+      "readWrite",
+      "req_1",
+      "https://app.formbricks.com"
+    );
+    expect(result).toEqual(resolved);
+  });
+});

--- a/apps/web/app/api/v3/workflows/lib/context.test.ts
+++ b/apps/web/app/api/v3/workflows/lib/context.test.ts
@@ -61,11 +61,11 @@ describe("buildWorkflowApiContext", () => {
   });
 });
 
-describe("verifyTriggerSurvey", () => {
+describe("verifyTriggerSurvey (validates a workflow trigger's referenced survey)", () => {
   const verify = (input: { workspaceId: string; surveyId: string; endingCardIds: string[] }) =>
     buildWorkflowApiContext(apiKeyAuth, "req_1", "inst").verifyTriggerSurvey(input);
 
-  test("reports the survey as absent when the lookup returns null", async () => {
+  test("rejects a workflow trigger whose survey no longer exists in the workspace", async () => {
     surveyFindUnique.mockResolvedValue(null);
 
     const result = await verify({ workspaceId: "ws_1", surveyId: "s_1", endingCardIds: ["e_1"] });
@@ -77,7 +77,7 @@ describe("verifyTriggerSurvey", () => {
     });
   });
 
-  test("flags ending card ids that are not on the survey", async () => {
+  test("flags the trigger's ending-card ids that are missing from the survey", async () => {
     surveyFindUnique.mockResolvedValue({ endings: [{ id: "e_1" }, { id: "e_2" }] });
 
     const result = await verify({
@@ -89,7 +89,7 @@ describe("verifyTriggerSurvey", () => {
     expect(result).toEqual({ surveyExists: true, missingEndingCardIds: ["e_missing"] });
   });
 
-  test("reports no missing ending cards when every referenced id is present", async () => {
+  test("accepts a workflow trigger whose survey and ending cards all exist", async () => {
     surveyFindUnique.mockResolvedValue({ endings: [{ id: "e_1" }] });
 
     const result = await verify({ workspaceId: "ws_1", surveyId: "s_1", endingCardIds: ["e_1"] });

--- a/apps/web/app/api/v3/workflows/lib/context.test.ts
+++ b/apps/web/app/api/v3/workflows/lib/context.test.ts
@@ -65,10 +65,16 @@ describe("verifyTriggerSurvey (validates a workflow trigger's referenced survey)
   const verify = (input: { workspaceId: string; surveyId: string; endingCardIds: string[] }) =>
     buildWorkflowApiContext(apiKeyAuth, "req_1", "inst").verifyTriggerSurvey(input);
 
+  // The adapter parses `survey.endings` with `ZSurveyEndings`, so mocked endings must be valid
+  // ending cards (cuid2 id + type), matching how the survey is stored.
+  const endingId1 = "cm9zr4q7i000108l84goze001";
+  const endingId2 = "cm9zr4q7i000108l84goze002";
+  const endScreen = (id: string) => ({ id, type: "endScreen" as const });
+
   test("rejects a workflow trigger whose survey no longer exists in the workspace", async () => {
     surveyFindUnique.mockResolvedValue(null);
 
-    const result = await verify({ workspaceId: "ws_1", surveyId: "s_1", endingCardIds: ["e_1"] });
+    const result = await verify({ workspaceId: "ws_1", surveyId: "s_1", endingCardIds: [endingId1] });
 
     expect(result).toEqual({ surveyExists: false, missingEndingCardIds: [] });
     expect(surveyFindUnique).toHaveBeenCalledWith({
@@ -78,21 +84,21 @@ describe("verifyTriggerSurvey (validates a workflow trigger's referenced survey)
   });
 
   test("flags the trigger's ending-card ids that are missing from the survey", async () => {
-    surveyFindUnique.mockResolvedValue({ endings: [{ id: "e_1" }, { id: "e_2" }] });
+    surveyFindUnique.mockResolvedValue({ endings: [endScreen(endingId1), endScreen(endingId2)] });
 
     const result = await verify({
       workspaceId: "ws_1",
       surveyId: "s_1",
-      endingCardIds: ["e_1", "e_missing"],
+      endingCardIds: [endingId1, "ending_missing"],
     });
 
-    expect(result).toEqual({ surveyExists: true, missingEndingCardIds: ["e_missing"] });
+    expect(result).toEqual({ surveyExists: true, missingEndingCardIds: ["ending_missing"] });
   });
 
   test("accepts a workflow trigger whose survey and ending cards all exist", async () => {
-    surveyFindUnique.mockResolvedValue({ endings: [{ id: "e_1" }] });
+    surveyFindUnique.mockResolvedValue({ endings: [endScreen(endingId1)] });
 
-    const result = await verify({ workspaceId: "ws_1", surveyId: "s_1", endingCardIds: ["e_1"] });
+    const result = await verify({ workspaceId: "ws_1", surveyId: "s_1", endingCardIds: [endingId1] });
 
     expect(result).toEqual({ surveyExists: true, missingEndingCardIds: [] });
   });

--- a/apps/web/app/api/v3/workflows/lib/context.test.ts
+++ b/apps/web/app/api/v3/workflows/lib/context.test.ts
@@ -4,7 +4,10 @@ import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
 import type { TV3Authentication } from "@/app/api/v3/lib/types";
 import { buildWorkflowApiContext } from "./context";
 
-vi.mock("@formbricks/database", () => ({ prisma: { workflow: {} } }));
+const { surveyFindUnique } = vi.hoisted(() => ({ surveyFindUnique: vi.fn() }));
+vi.mock("@formbricks/database", () => ({
+  prisma: { workflow: {}, survey: { findUnique: surveyFindUnique } },
+}));
 vi.mock("@formbricks/logger", () => ({
   logger: { withContext: vi.fn(() => ({ warn: vi.fn(), error: vi.fn() })) },
 }));
@@ -55,5 +58,42 @@ describe("buildWorkflowApiContext", () => {
       "https://app.formbricks.com"
     );
     expect(result).toEqual(resolved);
+  });
+});
+
+describe("verifyTriggerSurvey", () => {
+  const verify = (input: { workspaceId: string; surveyId: string; endingCardIds: string[] }) =>
+    buildWorkflowApiContext(apiKeyAuth, "req_1", "inst").verifyTriggerSurvey(input);
+
+  test("reports the survey as absent when the lookup returns null", async () => {
+    surveyFindUnique.mockResolvedValue(null);
+
+    const result = await verify({ workspaceId: "ws_1", surveyId: "s_1", endingCardIds: ["e_1"] });
+
+    expect(result).toEqual({ surveyExists: false, missingEndingCardIds: [] });
+    expect(surveyFindUnique).toHaveBeenCalledWith({
+      where: { id_workspaceId: { id: "s_1", workspaceId: "ws_1" } },
+      select: { endings: true },
+    });
+  });
+
+  test("flags ending card ids that are not on the survey", async () => {
+    surveyFindUnique.mockResolvedValue({ endings: [{ id: "e_1" }, { id: "e_2" }] });
+
+    const result = await verify({
+      workspaceId: "ws_1",
+      surveyId: "s_1",
+      endingCardIds: ["e_1", "e_missing"],
+    });
+
+    expect(result).toEqual({ surveyExists: true, missingEndingCardIds: ["e_missing"] });
+  });
+
+  test("reports no missing ending cards when every referenced id is present", async () => {
+    surveyFindUnique.mockResolvedValue({ endings: [{ id: "e_1" }] });
+
+    const result = await verify({ workspaceId: "ws_1", surveyId: "s_1", endingCardIds: ["e_1"] });
+
+    expect(result).toEqual({ surveyExists: true, missingEndingCardIds: [] });
   });
 });

--- a/apps/web/app/api/v3/workflows/lib/context.ts
+++ b/apps/web/app/api/v3/workflows/lib/context.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
+import { ZSurveyEndings } from "@formbricks/types/surveys/types";
 import {
   type WorkflowApiContext,
   createWorkflowsHandlers,
@@ -26,7 +27,8 @@ const getUserId = (authentication: TV3Authentication): string | null =>
 /**
  * Confirm a workflow trigger's referenced survey + ending cards exist in the workspace. Injected so
  * `@formbricks/workflows` stays survey-agnostic. Scoped by the survey's `(id, workspaceId)` composite
- * key; ending ids are read from the survey's `endings` JSON.
+ * key; ending ids come from the survey's `endings`, parsed through `ZSurveyEndings` so the JSON
+ * column is validated (not accessed untyped) before reading ids.
  */
 const verifyTriggerSurvey: WorkflowApiContext["verifyTriggerSurvey"] = async ({
   workspaceId,
@@ -42,7 +44,7 @@ const verifyTriggerSurvey: WorkflowApiContext["verifyTriggerSurvey"] = async ({
     return { surveyExists: false, missingEndingCardIds: [] };
   }
 
-  const endingIds = new Set(survey.endings.map((ending) => ending.id));
+  const endingIds = new Set(ZSurveyEndings.parse(survey.endings).map((ending) => ending.id));
   return {
     surveyExists: true,
     missingEndingCardIds: endingCardIds.filter((endingCardId) => !endingIds.has(endingCardId)),

--- a/apps/web/app/api/v3/workflows/lib/context.ts
+++ b/apps/web/app/api/v3/workflows/lib/context.ts
@@ -23,6 +23,32 @@ export const workflowsHandlers = createWorkflowsHandlers(service);
 const getUserId = (authentication: TV3Authentication): string | null =>
   authentication && "user" in authentication && authentication.user?.id ? authentication.user.id : null;
 
+/**
+ * Confirm a workflow trigger's referenced survey + ending cards exist in the workspace. Injected so
+ * `@formbricks/workflows` stays survey-agnostic. Scoped by the survey's `(id, workspaceId)` composite
+ * key; ending ids are read from the survey's `endings` JSON.
+ */
+const verifyTriggerSurvey: WorkflowApiContext["verifyTriggerSurvey"] = async ({
+  workspaceId,
+  surveyId,
+  endingCardIds,
+}) => {
+  const survey = await prisma.survey.findUnique({
+    where: { id_workspaceId: { id: surveyId, workspaceId } },
+    select: { endings: true },
+  });
+
+  if (!survey) {
+    return { surveyExists: false, missingEndingCardIds: [] };
+  }
+
+  const endingIds = new Set(survey.endings.map((ending) => ending.id));
+  return {
+    surveyExists: true,
+    missingEndingCardIds: endingCardIds.filter((endingCardId) => !endingIds.has(endingCardId)),
+  };
+};
+
 export const buildWorkflowApiContext = (
   authentication: TV3Authentication,
   requestId: string,
@@ -34,4 +60,5 @@ export const buildWorkflowApiContext = (
   logger: logger.withContext({ requestId }),
   authorize: (workspaceId, access) =>
     requireV3WorkspaceAccess(authentication, workspaceId, access, requestId, instance),
+  verifyTriggerSurvey,
 });

--- a/apps/web/app/api/v3/workflows/lib/context.ts
+++ b/apps/web/app/api/v3/workflows/lib/context.ts
@@ -1,0 +1,37 @@
+import { prisma } from "@formbricks/database";
+import { logger } from "@formbricks/logger";
+import {
+  type WorkflowApiContext,
+  createWorkflowsHandlers,
+  createWorkflowsService,
+} from "@formbricks/workflows/server";
+import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
+import type { TV3Authentication } from "@/app/api/v3/lib/types";
+
+/**
+ * Adapter glue between the Next.js v3 routes and the framework-agnostic `@formbricks/workflows`
+ * handlers. The package owns business logic, validation, serialization, and error mapping; this
+ * file injects the app's concrete `prisma`/`logger` and binds an `authorize` capability to the
+ * authenticated request. The real Prisma client structurally satisfies the package's narrow
+ * `WorkflowsDb` port, so no cast is needed; the package never imports `@formbricks/database`.
+ */
+const service = createWorkflowsService({ prisma });
+
+/** Singleton handlers; they are stateless and only close over the injected service. */
+export const workflowsHandlers = createWorkflowsHandlers(service);
+
+const getUserId = (authentication: TV3Authentication): string | null =>
+  authentication && "user" in authentication && authentication.user?.id ? authentication.user.id : null;
+
+export const buildWorkflowApiContext = (
+  authentication: TV3Authentication,
+  requestId: string,
+  instance: string
+): WorkflowApiContext => ({
+  userId: getUserId(authentication),
+  requestId,
+  instance,
+  logger: logger.withContext({ requestId }),
+  authorize: (workspaceId, access) =>
+    requireV3WorkspaceAccess(authentication, workspaceId, access, requestId, instance),
+});

--- a/apps/web/app/api/v3/workflows/route.ts
+++ b/apps/web/app/api/v3/workflows/route.ts
@@ -1,0 +1,23 @@
+/**
+ * /api/v3/workflows — list and create workflow management resources.
+ * Session cookie or x-api-key; scope by workspaceId only.
+ *
+ * Thin adapter: authenticate via the shared wrapper, build the workflow API context, and delegate
+ * to the framework-agnostic handlers in `@formbricks/workflows/server`.
+ */
+import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
+import { buildWorkflowApiContext, workflowsHandlers } from "./lib/context";
+
+export const GET = withV3ApiWrapper({
+  auth: "both",
+  handler: async ({ req, authentication, requestId, instance }) =>
+    workflowsHandlers.list(req, buildWorkflowApiContext(authentication, requestId, instance)),
+});
+
+export const POST = withV3ApiWrapper({
+  auth: "both",
+  action: "created",
+  targetType: "workflow",
+  handler: async ({ req, authentication, requestId, instance }) =>
+    workflowsHandlers.create(req, buildWorkflowApiContext(authentication, requestId, instance)),
+});

--- a/apps/web/app/api/v3/workflows/route.ts
+++ b/apps/web/app/api/v3/workflows/route.ts
@@ -11,7 +11,7 @@ import { buildWorkflowApiContext, workflowsHandlers } from "./lib/context";
 export const GET = withV3ApiWrapper({
   auth: "both",
   handler: async ({ req, authentication, requestId, instance }) =>
-    workflowsHandlers.list(req, buildWorkflowApiContext(authentication, requestId, instance)),
+    workflowsHandlers.list({ req, ctx: buildWorkflowApiContext(authentication, requestId, instance) }),
 });
 
 export const POST = withV3ApiWrapper({
@@ -19,5 +19,5 @@ export const POST = withV3ApiWrapper({
   action: "created",
   targetType: "workflow",
   handler: async ({ req, authentication, requestId, instance }) =>
-    workflowsHandlers.create(req, buildWorkflowApiContext(authentication, requestId, instance)),
+    workflowsHandlers.create({ req, ctx: buildWorkflowApiContext(authentication, requestId, instance) }),
 });

--- a/apps/web/modules/ee/audit-logs/types/audit-log.ts
+++ b/apps/web/modules/ee/audit-logs/types/audit-log.ts
@@ -6,6 +6,7 @@ export const UNKNOWN_DATA = "unknown";
 export const ZAuditTarget = z.enum([
   "segment",
   "survey",
+  "workflow",
   "webhook",
   "user",
   "contactAttributeKey",

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -82,7 +82,7 @@ const nextConfig = {
   },
   turbopack: {},
   experimental: {},
-  transpilePackages: ["@formbricks/database"],
+  transpilePackages: ["@formbricks/database", "@formbricks/workflows"],
   images: {
     // Optimize image processing to reduce CPU time and prevent timeouts
     deviceSizes: [640, 750, 828, 1080, 1200, 1920], // Removed 3840 to avoid processing huge images

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "@formbricks/storage": "workspace:*",
     "@formbricks/surveys": "workspace:*",
     "@formbricks/types": "workspace:*",
+    "@formbricks/workflows": "workspace:*",
     "@hookform/resolvers": "5.2.2",
     "@json2csv/node": "7.0.6",
     "@lexical/code": "0.41.0",

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -1541,8 +1541,7 @@ paths:
         can only be updated while the workflow is `draft` or `disabled`: the live version of an
         `enabled` workflow is an immutable snapshot, so definition changes require disabling (or
         moving to draft) first and re-enabling afterwards. Violations return **422** with code
-        `invalid_workflow_state`. Graph reference failures return **400** with structured
-        `invalid_params`, mirroring the survey identifier rules.
+        `invalid_workflow_state`. A structurally invalid definition returns **400** with structured `invalid_params`; the referenced survey and ending cards are not verified here — that existence check runs when the workflow is enabled.
       tags:
         - V3 Workflows
       parameters:

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -1700,7 +1700,7 @@ paths:
         reference that snapshot via `workflowVersionId`, so later draft edits never change what an
         enabled workflow executes. Validation failures return **422** with code
         `workflow_not_executable` and structured `invalid_params`; calling enable in a state other
-        than `draft` or `disabled` returns **422** with code `invalid_workflow_state`.
+        than `draft` or `disabled` returns **422** with code `invalid_workflow_state`. Two concurrent enable requests race to publish the next version; the loser is rejected with **409** code `conflict` and can safely retry.
       tags:
         - V3 Workflows
       parameters:
@@ -1714,6 +1714,8 @@ paths:
           $ref: '#/components/responses/V3Unauthorized'
         '403':
           $ref: '#/components/responses/V3Forbidden'
+        '409':
+          $ref: '#/components/responses/V3Conflict'
         '422':
           $ref: '#/components/responses/V3UnprocessableContent'
         '429':

--- a/docs/api-v3-reference/src/paths/api_v3_workflows_{workflowId}.yml
+++ b/docs/api-v3-reference/src/paths/api_v3_workflows_{workflowId}.yml
@@ -72,10 +72,9 @@ patch:
     moving to draft) first and re-enabling afterwards. Violations return **422**
     with code
 
-    `invalid_workflow_state`. Graph reference failures return **400** with
-    structured
-
-    `invalid_params`, mirroring the survey identifier rules.
+    `invalid_workflow_state`. A structurally invalid definition returns **400**
+    with structured `invalid_params`; the referenced survey and ending cards are
+    not verified here — that existence check runs when the workflow is enabled.
   tags:
     - V3 Workflows
   parameters:

--- a/docs/api-v3-reference/src/paths/api_v3_workflows_{workflowId}_enable.yml
+++ b/docs/api-v3-reference/src/paths/api_v3_workflows_{workflowId}_enable.yml
@@ -29,7 +29,9 @@ post:
     a state other
 
     than `draft` or `disabled` returns **422** with code
-    `invalid_workflow_state`.
+    `invalid_workflow_state`. Two concurrent enable requests race to publish the
+    next version; the loser is rejected with **409** code `conflict` and can
+    safely retry.
   tags:
     - V3 Workflows
   parameters:
@@ -43,6 +45,8 @@ post:
       $ref: ../components/responses/V3Unauthorized.yml
     '403':
       $ref: ../components/responses/V3Forbidden.yml
+    '409':
+      $ref: ../components/responses/V3Conflict.yml
     '422':
       $ref: ../components/responses/V3UnprocessableContent.yml
     '429':

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -8,6 +8,10 @@
     ".": {
       "types": "./dist/src/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./server": {
+      "types": "./dist/src/server/index.d.ts",
+      "import": "./dist/server.js"
     }
   },
   "main": "./dist/index.js",

--- a/packages/workflows/src/errors.ts
+++ b/packages/workflows/src/errors.ts
@@ -1,0 +1,187 @@
+import { ZodError, type z } from "zod";
+import { buildV3Headers } from "./http";
+import type { WorkflowsLogger } from "./services/ports";
+
+/**
+ * Typed domain errors thrown by the workflow service/handlers, plus a single mapper to
+ * RFC 9457 `application/problem+json` responses. The mapper is the one place that logs
+ * mapped errors (`.warn` for 4xx, `.error` for 5xx) so every error is logged exactly once,
+ * with the request-bound logger. Web-standard `Response` keeps this framework-agnostic.
+ *
+ * Codes and body shape mirror `apps/web/app/api/v3/lib/response.ts` so workflow problems are
+ * indistinguishable from the rest of the v3 API.
+ */
+
+export type WorkflowProblemCode =
+  | "bad_request"
+  | "forbidden"
+  | "conflict"
+  | "unprocessable_content"
+  | "internal_server_error";
+
+export interface WorkflowInvalidParam {
+  name: string;
+  reason: string;
+}
+
+const PROBLEM_JSON = "application/problem+json";
+
+const TITLE_BY_STATUS: Record<number, string> = {
+  400: "Bad Request",
+  403: "Forbidden",
+  409: "Conflict",
+  422: "Unprocessable Content",
+  500: "Internal Server Error",
+};
+
+/** Base class for all expected workflow API failures. */
+export abstract class WorkflowApiError extends Error {
+  abstract readonly status: number;
+  abstract readonly code: WorkflowProblemCode;
+  readonly invalidParams?: WorkflowInvalidParam[];
+
+  constructor(message: string, invalidParams?: WorkflowInvalidParam[]) {
+    super(message);
+    this.name = new.target.name;
+    this.invalidParams = invalidParams;
+  }
+}
+
+/** 403 for unknown / cross-workspace resources — deliberately not 404, to avoid leaking existence. */
+export class WorkflowForbiddenError extends WorkflowApiError {
+  readonly status = 403;
+  readonly code = "forbidden" as const;
+
+  constructor(message = "You are not authorized to access this resource") {
+    super(message);
+  }
+}
+
+/** 400 for malformed input or a definition that fails schema validation. */
+export class WorkflowInvalidInputError extends WorkflowApiError {
+  readonly status = 400;
+  readonly code = "bad_request" as const;
+}
+
+/**
+ * 409 for write conflicts (e.g. a future workspace-unique-name constraint). Not currently thrown in
+ * Scope 1 — the `Workflow` model has no unique constraint beyond `(id, workspaceId)` — but kept so
+ * ENG-1222/1223 reuse the same mapper.
+ */
+export class WorkflowConflictError extends WorkflowApiError {
+  readonly status = 409;
+  readonly code = "conflict" as const;
+
+  constructor(message = "The request conflicts with the current state of the resource") {
+    super(message);
+  }
+}
+
+/**
+ * 500 when a serialized response fails its own resource-schema validation — a server bug, never the
+ * caller's fault. The underlying `ZodError` is attached for logging; the client sees a generic 500.
+ */
+export class WorkflowSerializationError extends WorkflowApiError {
+  readonly status = 500;
+  readonly code = "internal_server_error" as const;
+  readonly cause: ZodError;
+
+  constructor(cause: ZodError) {
+    super("Workflow response failed output validation");
+    this.cause = cause;
+  }
+}
+
+/**
+ * Validate a serialized response against its resource schema before returning it. A mismatch is a
+ * server bug, not caller input, so it surfaces as a `WorkflowSerializationError` (→ logged 500).
+ */
+export const validateOutput = <S extends z.ZodType>(schema: S, value: unknown): z.infer<S> => {
+  const result = schema.safeParse(value);
+  if (!result.success) {
+    throw new WorkflowSerializationError(result.error);
+  }
+  return result.data;
+};
+
+const invalidParamsFromZodError = (error: ZodError): WorkflowInvalidParam[] =>
+  error.issues.map((issue) => ({
+    name: issue.path.map(String).join("."),
+    reason: issue.message,
+  }));
+
+const problemResponse = (
+  status: number,
+  detail: string,
+  options: {
+    requestId: string;
+    code: string;
+    instance?: string;
+    invalidParams?: WorkflowInvalidParam[];
+  }
+): Response => {
+  const body = {
+    title: TITLE_BY_STATUS[status] ?? "Error",
+    status,
+    detail,
+    requestId: options.requestId,
+    code: options.code,
+    ...(options.instance ? { instance: options.instance } : {}),
+    ...(options.invalidParams ? { invalid_params: options.invalidParams } : {}),
+  };
+
+  return Response.json(body, {
+    status,
+    headers: buildV3Headers(PROBLEM_JSON, options.requestId),
+  });
+};
+
+interface ProblemContext {
+  requestId: string;
+  instance?: string;
+  logger: WorkflowsLogger;
+}
+
+/**
+ * Map any thrown error to a problem response and log it. `ZodError` (e.g. from a contract
+ * `.parse`) becomes a 400 with `invalid_params`; known `WorkflowApiError`s use their own
+ * status/code; anything else is a logged 500 with a generic detail (no internals leaked).
+ */
+export const toProblemResponse = (error: unknown, ctx: ProblemContext): Response => {
+  if (error instanceof ZodError) {
+    const invalidParams = invalidParamsFromZodError(error);
+    ctx.logger.warn({ statusCode: 400, invalidParams }, "Workflow request validation failed");
+    return problemResponse(400, "The request payload is invalid.", {
+      requestId: ctx.requestId,
+      code: "bad_request",
+      instance: ctx.instance,
+      invalidParams,
+    });
+  }
+
+  if (error instanceof WorkflowApiError) {
+    if (error.status >= 500) {
+      // Log the real cause, but never leak internals (e.g. serialization issues) to the client.
+      ctx.logger.error({ error, statusCode: error.status }, error.message);
+      return problemResponse(error.status, "An unexpected error occurred.", {
+        requestId: ctx.requestId,
+        code: error.code,
+        instance: ctx.instance,
+      });
+    }
+    ctx.logger.warn({ statusCode: error.status, code: error.code }, error.message);
+    return problemResponse(error.status, error.message, {
+      requestId: ctx.requestId,
+      code: error.code,
+      instance: ctx.instance,
+      invalidParams: error.invalidParams,
+    });
+  }
+
+  ctx.logger.error({ error, statusCode: 500 }, "Unexpected workflow API error");
+  return problemResponse(500, "An unexpected error occurred.", {
+    requestId: ctx.requestId,
+    code: "internal_server_error",
+    instance: ctx.instance,
+  });
+};

--- a/packages/workflows/src/errors.ts
+++ b/packages/workflows/src/errors.ts
@@ -16,6 +16,8 @@ export type WorkflowProblemCode =
   | "bad_request"
   | "forbidden"
   | "conflict"
+  | "invalid_workflow_state"
+  | "workflow_not_executable"
   | "unprocessable_content"
   | "internal_server_error";
 
@@ -64,9 +66,9 @@ export class WorkflowInvalidInputError extends WorkflowApiError {
 }
 
 /**
- * 409 for write conflicts (e.g. a future workspace-unique-name constraint). Not currently thrown in
- * Scope 1 — the `Workflow` model has no unique constraint beyond `(id, workspaceId)` — but kept so
- * ENG-1222/1223 reuse the same mapper.
+ * 409 for write conflicts. Thrown when a concurrent enable loses the race to insert the next
+ * `WorkflowVersion` (`@@unique([workflowId, version])`): the transaction rolls back cleanly and the
+ * caller can safely retry. Also reusable for future unique constraints (e.g. a workspace-unique name).
  */
 export class WorkflowConflictError extends WorkflowApiError {
   readonly status = 409;
@@ -75,6 +77,16 @@ export class WorkflowConflictError extends WorkflowApiError {
   constructor(message = "The request conflicts with the current state of the resource") {
     super(message);
   }
+}
+
+/**
+ * 422 for an operation that is invalid for the workflow's current lifecycle state — e.g. patching
+ * the definition of an `enabled` workflow, or any write to an `archived` one. Distinct from a bad
+ * request (the payload is well-formed; the state machine forbids the transition).
+ */
+export class WorkflowInvalidStateError extends WorkflowApiError {
+  readonly status = 422;
+  readonly code = "invalid_workflow_state" as const;
 }
 
 /**
@@ -109,6 +121,25 @@ const invalidParamsFromZodError = (error: ZodError): WorkflowInvalidParam[] =>
     name: issue.path.map(String).join("."),
     reason: issue.message,
   }));
+
+/**
+ * 422 when a workflow cannot be enabled because its definition is not executable — the graph fails
+ * `ZWorkflowExecutableDefinition` (cycle, unreachable node, wrong trigger-edge count, if_else), or a
+ * referenced survey / ending card no longer exists. Carries field-level `invalidParams` so the
+ * caller (or an agent) can repair the exact node/edge/reference.
+ */
+export class WorkflowNotExecutableError extends WorkflowApiError {
+  readonly status = 422;
+  readonly code = "workflow_not_executable" as const;
+
+  constructor(invalidParams: WorkflowInvalidParam[], message = "The workflow definition is not executable.") {
+    super(message, invalidParams);
+  }
+
+  static fromZodError(error: ZodError): WorkflowNotExecutableError {
+    return new WorkflowNotExecutableError(invalidParamsFromZodError(error));
+  }
+}
 
 const problemResponse = (
   status: number,

--- a/packages/workflows/src/handlers/context.ts
+++ b/packages/workflows/src/handlers/context.ts
@@ -24,6 +24,9 @@ export interface TriggerSurveyCheck {
  *
  * `verifyTriggerSurvey` is an injected lookup (the adapter queries the Survey table) so the package
  * stays survey-agnostic; enable uses it to confirm the trigger's survey + ending cards still exist.
+ * It is intentionally specific to the `response.completed` trigger (the only kind today); once other
+ * trigger types need reference validation, this generalizes to a per-trigger validator keyed on
+ * `trigger.type` rather than growing a `verifyXxx` capability per trigger.
  */
 export interface WorkflowApiContext {
   userId: string | null;

--- a/packages/workflows/src/handlers/context.ts
+++ b/packages/workflows/src/handlers/context.ts
@@ -1,0 +1,24 @@
+import type { WorkflowsLogger } from "../services/ports";
+
+/** Permission level required for an operation, mirroring the v3 team-permission vocabulary. */
+export type WorkflowApiAccess = "read" | "readWrite" | "manage";
+
+/** Resolved internal workspace identity returned by a successful authorization. */
+export interface AuthorizedWorkspace {
+  workspaceId: string;
+  organizationId: string;
+}
+
+/**
+ * Per-request context the Next.js adapter builds and passes to the framework-agnostic handlers.
+ * `authorize` is a capability bound by the adapter to the authenticated request (wrapping
+ * `requireV3WorkspaceAccess`): it returns the resolved workspace on success, or a ready-to-return
+ * problem `Response` (401/403) on failure — so authorization logic never leaks into this package.
+ */
+export interface WorkflowApiContext {
+  userId: string | null;
+  requestId: string;
+  instance?: string;
+  logger: WorkflowsLogger;
+  authorize: (workspaceId: string, access: WorkflowApiAccess) => Promise<AuthorizedWorkspace | Response>;
+}

--- a/packages/workflows/src/handlers/context.ts
+++ b/packages/workflows/src/handlers/context.ts
@@ -9,11 +9,21 @@ export interface AuthorizedWorkspace {
   organizationId: string;
 }
 
+/** Result of checking that a trigger's referenced survey + ending cards exist in the workspace. */
+export interface TriggerSurveyCheck {
+  surveyExists: boolean;
+  missingEndingCardIds: string[];
+}
+
 /**
  * Per-request context the Next.js adapter builds and passes to the framework-agnostic handlers.
+ *
  * `authorize` is a capability bound by the adapter to the authenticated request (wrapping
  * `requireV3WorkspaceAccess`): it returns the resolved workspace on success, or a ready-to-return
  * problem `Response` (401/403) on failure — so authorization logic never leaks into this package.
+ *
+ * `verifyTriggerSurvey` is an injected lookup (the adapter queries the Survey table) so the package
+ * stays survey-agnostic; enable uses it to confirm the trigger's survey + ending cards still exist.
  */
 export interface WorkflowApiContext {
   userId: string | null;
@@ -21,4 +31,9 @@ export interface WorkflowApiContext {
   instance?: string;
   logger: WorkflowsLogger;
   authorize: (workspaceId: string, access: WorkflowApiAccess) => Promise<AuthorizedWorkspace | Response>;
+  verifyTriggerSurvey: (input: {
+    workspaceId: string;
+    surveyId: string;
+    endingCardIds: string[];
+  }) => Promise<TriggerSurveyCheck>;
 }

--- a/packages/workflows/src/handlers/cursor.test.ts
+++ b/packages/workflows/src/handlers/cursor.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { WorkflowInvalidInputError } from "../errors";
+import { buildNextWorkflowListCursor, decodeWorkflowListCursor, encodeWorkflowListCursor } from "./cursor";
+
+const row = {
+  id: "cm9zr4t2b000208l8h2m1aq3c",
+  createdAt: new Date("2026-06-11T09:30:00.000Z"),
+  updatedAt: new Date("2026-06-12T09:30:00.000Z"),
+  name: "Alpha workflow",
+};
+
+describe("workflow list cursor", () => {
+  test.each(["createdAt", "updatedAt", "name"] as const)("round-trips a %s cursor", (sortBy) => {
+    const cursor = buildNextWorkflowListCursor(row, sortBy);
+    const encoded = encodeWorkflowListCursor(cursor);
+    expect(decodeWorkflowListCursor(encoded, sortBy)).toEqual(cursor);
+  });
+
+  test("rejects a cursor issued for a different sort order", () => {
+    const encoded = encodeWorkflowListCursor(buildNextWorkflowListCursor(row, "name"));
+    expect(() => decodeWorkflowListCursor(encoded, "createdAt")).toThrow(WorkflowInvalidInputError);
+  });
+
+  test("rejects a malformed cursor", () => {
+    expect(() => decodeWorkflowListCursor("@@not-valid@@", "updatedAt")).toThrow(WorkflowInvalidInputError);
+  });
+});

--- a/packages/workflows/src/handlers/cursor.ts
+++ b/packages/workflows/src/handlers/cursor.ts
@@ -1,0 +1,83 @@
+import { z } from "zod";
+import type { TWorkflowSortBy } from "../contracts";
+import { WorkflowInvalidInputError } from "../errors";
+
+/**
+ * Opaque, sort-bound keyset cursor for the workflow list. Mirrors the survey approach
+ * (`apps/web/modules/survey/list/lib/survey-page.ts`): a base64url-encoded JSON token carrying
+ * `{ version, sortBy, value, id }`. The token is bound to the sort order it was issued for, so a
+ * client cannot page with a cursor from a different `sortBy`. Reimplemented here (not imported)
+ * to keep the package free of `apps/web` imports.
+ */
+
+const WORKFLOW_LIST_CURSOR_VERSION = 1;
+
+const ZDateCursor = z.object({
+  version: z.literal(WORKFLOW_LIST_CURSOR_VERSION),
+  sortBy: z.enum(["createdAt", "updatedAt"]),
+  value: z.iso.datetime({ offset: true }),
+  id: z.string().min(1),
+});
+
+const ZNameCursor = z.object({
+  version: z.literal(WORKFLOW_LIST_CURSOR_VERSION),
+  sortBy: z.literal("name"),
+  value: z.string(),
+  id: z.string().min(1),
+});
+
+const ZWorkflowListCursor = z.union([ZDateCursor, ZNameCursor]);
+export type TWorkflowListCursor = z.infer<typeof ZWorkflowListCursor>;
+
+export const encodeWorkflowListCursor = (cursor: TWorkflowListCursor): string =>
+  Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+
+/** Decode + validate a cursor, asserting it was issued for the requested sort order. */
+export const decodeWorkflowListCursor = (
+  encodedCursor: string,
+  sortBy: TWorkflowSortBy
+): TWorkflowListCursor => {
+  let parsed: TWorkflowListCursor;
+  try {
+    const decodedJson = Buffer.from(encodedCursor, "base64url").toString("utf8");
+    parsed = ZWorkflowListCursor.parse(JSON.parse(decodedJson));
+  } catch {
+    throw new WorkflowInvalidInputError("The cursor is invalid.", [
+      { name: "cursor", reason: "The cursor is invalid." },
+    ]);
+  }
+
+  if (parsed.sortBy !== sortBy) {
+    throw new WorkflowInvalidInputError("The cursor does not match the requested sort order.", [
+      { name: "cursor", reason: "The cursor does not match the requested sort order." },
+    ]);
+  }
+
+  return parsed;
+};
+
+/** Build the next-page cursor from the last row of the current page. */
+export const buildNextWorkflowListCursor = (
+  row: { id: string; createdAt: Date; updatedAt: Date; name: string },
+  sortBy: TWorkflowSortBy
+): TWorkflowListCursor => {
+  switch (sortBy) {
+    case "name":
+      return { version: WORKFLOW_LIST_CURSOR_VERSION, sortBy, value: row.name, id: row.id };
+    case "createdAt":
+      return {
+        version: WORKFLOW_LIST_CURSOR_VERSION,
+        sortBy,
+        value: row.createdAt.toISOString(),
+        id: row.id,
+      };
+    case "updatedAt":
+    default:
+      return {
+        version: WORKFLOW_LIST_CURSOR_VERSION,
+        sortBy,
+        value: row.updatedAt.toISOString(),
+        id: row.id,
+      };
+  }
+};

--- a/packages/workflows/src/handlers/parse-list-query.ts
+++ b/packages/workflows/src/handlers/parse-list-query.ts
@@ -1,0 +1,33 @@
+import { type TListWorkflowsInput, ZListWorkflowsInput } from "../contracts";
+
+/**
+ * Map the HTTP `filter[...]` query family to the contract's `ZListWorkflowsInput` shape, then
+ * validate. Multi-value filters accept repeated keys or comma-separated values
+ * (`filter[status][in]=draft&filter[status][in]=disabled` or `filter[status][in]=draft,disabled`),
+ * matching the v3 survey list. Validation (unknown params, bad enum/limit) throws a `ZodError` the
+ * handler maps to a 400.
+ */
+export const parseListWorkflowsQuery = (searchParams: URLSearchParams): TListWorkflowsInput => {
+  const multiValue = (key: string): string[] | undefined => {
+    const values = searchParams
+      .getAll(key)
+      .flatMap((value) => value.split(","))
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+    return values.length > 0 ? values : undefined;
+  };
+
+  const raw: Record<string, unknown> = {
+    workspaceId: searchParams.get("workspaceId") ?? undefined,
+    cursor: searchParams.get("cursor") ?? undefined,
+    statusIn: multiValue("filter[status][in]"),
+    nameContains: searchParams.get("filter[name][contains]") ?? undefined,
+    sortBy: searchParams.get("sortBy") ?? undefined,
+  };
+
+  if (searchParams.has("limit")) {
+    raw.limit = Number(searchParams.get("limit"));
+  }
+
+  return ZListWorkflowsInput.parse(raw);
+};

--- a/packages/workflows/src/handlers/serializers.test.ts
+++ b/packages/workflows/src/handlers/serializers.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "vitest";
+import type { WorkflowRowWithLastRun, WorkflowRunRow } from "../services/ports";
+import { toWorkflowListItem, toWorkflowResource, toWorkflowRunSummary } from "./serializers";
+
+const surveyId = "cm9zr4q7i000108l84gozfggr";
+const workflowId = "cm9zr4t2b000208l8h2m1aq3c";
+const workspaceId = "cm9zr4mps000008l8btfy1vtz";
+
+const definition = {
+  schemaVersion: 1 as const,
+  trigger: {
+    id: "trigger",
+    type: "trigger" as const,
+    triggerType: "response.completed" as const,
+    config: { surveyId, endingCardIds: [] },
+  },
+  nodes: [
+    {
+      id: "send-email",
+      type: "action" as const,
+      actionType: "send_email" as const,
+      config: {
+        from: "noreply@example.com",
+        to: "support@example.com",
+        replyTo: ["support@example.com"],
+        subject: "Thanks",
+        body: "Thanks for your response.",
+        attachResponseData: true,
+      },
+    },
+  ],
+  edges: [{ id: "e1", source: "trigger", target: "send-email" }],
+  entryNodeId: "trigger",
+};
+
+const run: WorkflowRunRow = {
+  id: "cm9zr4w9d000308l8c5n8xk7e",
+  createdAt: new Date("2026-06-12T10:00:00.000Z"),
+  updatedAt: new Date("2026-06-12T10:01:00.000Z"),
+  workflowId,
+  workspaceId,
+  workflowVersionId: null,
+  responseId: null,
+  status: "completed",
+  triggerType: "response.completed",
+  surveyId,
+  isDryRun: true,
+  attempt: 0,
+  error: null,
+  startedAt: new Date("2026-06-12T10:00:30.000Z"),
+  finishedAt: new Date("2026-06-12T10:01:00.000Z"),
+};
+
+const baseRow: WorkflowRowWithLastRun = {
+  id: workflowId,
+  createdAt: new Date("2026-06-11T09:30:00.000Z"),
+  updatedAt: new Date("2026-06-12T09:30:00.000Z"),
+  name: "Notify team",
+  description: null,
+  status: "draft",
+  workspaceId,
+  createdBy: "cm9zr52kh000508l8e3q7bw9j",
+  definition,
+  runs: [],
+};
+
+describe("serializers", () => {
+  test("derives triggerType and surveyId from the definition and emits ISO dates", () => {
+    const item = toWorkflowListItem(baseRow);
+    expect(item.triggerType).toBe("response.completed");
+    expect(item.surveyId).toBe(surveyId);
+    expect(item.createdAt).toBe("2026-06-11T09:30:00.000Z");
+    expect(item.lastRun).toBeNull();
+  });
+
+  test("embeds the most recent run as lastRun", () => {
+    const item = toWorkflowListItem({ ...baseRow, runs: [run] });
+    expect(item.lastRun?.id).toBe(run.id);
+    expect(item.lastRun?.startedAt).toBe("2026-06-12T10:00:30.000Z");
+  });
+
+  test("run summary maps nullable timestamps explicitly", () => {
+    const summary = toWorkflowRunSummary({ ...run, startedAt: null, finishedAt: null });
+    expect(summary.startedAt).toBeNull();
+    expect(summary.finishedAt).toBeNull();
+  });
+
+  test("the full resource includes the definition", () => {
+    const resource = toWorkflowResource(baseRow);
+    expect(resource.definition).toEqual(definition);
+    expect(resource.id).toBe(workflowId);
+  });
+});

--- a/packages/workflows/src/handlers/serializers.ts
+++ b/packages/workflows/src/handlers/serializers.ts
@@ -1,0 +1,52 @@
+import type { TWorkflowListItem, TWorkflowResource, TWorkflowRunSummary } from "../contracts";
+import type { WorkflowRowWithLastRun, WorkflowRunRow } from "../services/ports";
+
+/**
+ * Map Prisma rows to the public v3 resource shapes. Serializer output is validated against the
+ * Zod resource schemas at the handler boundary, so these functions stay simple: ISO date strings,
+ * explicit nulls, and derived `triggerType` / `surveyId` read from the (already-validated, typed)
+ * definition JSON. The definition is intentionally NOT re-parsed here.
+ */
+
+const toIso = (date: Date | null): string | null => (date ? date.toISOString() : null);
+
+export const toWorkflowRunSummary = (run: WorkflowRunRow): TWorkflowRunSummary => ({
+  id: run.id,
+  workflowId: run.workflowId,
+  workspaceId: run.workspaceId,
+  workflowVersionId: run.workflowVersionId,
+  status: run.status,
+  isDryRun: run.isDryRun,
+  triggerType: run.triggerType as TWorkflowRunSummary["triggerType"],
+  surveyId: run.surveyId,
+  responseId: run.responseId,
+  error: run.error,
+  attempt: run.attempt,
+  createdAt: run.createdAt.toISOString(),
+  updatedAt: run.updatedAt.toISOString(),
+  startedAt: toIso(run.startedAt),
+  finishedAt: toIso(run.finishedAt),
+});
+
+export const toWorkflowListItem = (row: WorkflowRowWithLastRun): TWorkflowListItem => {
+  const { trigger } = row.definition;
+
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    name: row.name,
+    description: row.description,
+    status: row.status,
+    triggerType: trigger.triggerType,
+    surveyId: trigger.config.surveyId,
+    createdBy: row.createdBy,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+    lastRun: row.runs[0] ? toWorkflowRunSummary(row.runs[0]) : null,
+  };
+};
+
+export const toWorkflowResource = (row: WorkflowRowWithLastRun): TWorkflowResource => ({
+  ...toWorkflowListItem(row),
+  definition: row.definition,
+});

--- a/packages/workflows/src/handlers/workflows.handlers.test.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.test.ts
@@ -97,7 +97,7 @@ describe("get", () => {
   test("returns 403 (not 404) when the workflow does not exist", async () => {
     service.getWorkflowById.mockResolvedValue(null);
 
-    const res = await handlers.get(makeCtx(), { workflowId });
+    const res = await handlers.get({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(403);
     expect(authorizeAllow).not.toHaveBeenCalled();
@@ -109,7 +109,7 @@ describe("get", () => {
     service.getWorkflowById.mockResolvedValue(makeRow());
     const ctx = makeCtx({ authorize: vi.fn().mockResolvedValue(deniedResponse()) });
 
-    const res = await handlers.get(ctx, { workflowId });
+    const res = await handlers.get({ ctx, params: { workflowId } });
 
     expect(res.status).toBe(403);
   });
@@ -117,7 +117,7 @@ describe("get", () => {
   test("returns 200 with the workflow resource on success", async () => {
     service.getWorkflowById.mockResolvedValue(makeRow());
 
-    const res = await handlers.get(makeCtx(), { workflowId });
+    const res = await handlers.get({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(200);
     expect(res.headers.get("X-Request-Id")).toBe("req_1");
@@ -136,7 +136,7 @@ describe("get", () => {
     });
     service.getWorkflowById.mockResolvedValue(badRow);
 
-    const res = await handlers.get(makeCtx(), { workflowId });
+    const res = await handlers.get({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(500);
     expect(logger.error).toHaveBeenCalled();
@@ -154,10 +154,10 @@ describe("create", () => {
   test("creates a draft and returns 201 with a Location header", async () => {
     service.createWorkflow.mockResolvedValue(makeRow());
 
-    const res = await handlers.create(
-      postRequest({ workspaceId, name: "Notify team", definition }),
-      makeCtx()
-    );
+    const res = await handlers.create({
+      req: postRequest({ workspaceId, name: "Notify team", definition }),
+      ctx: makeCtx(),
+    });
 
     expect(res.status).toBe(201);
     expect(res.headers.get("Location")).toBe(`/api/v3/workflows/${workflowId}`);
@@ -167,14 +167,14 @@ describe("create", () => {
   });
 
   test("rejects an invalid definition with 400 and invalid_params", async () => {
-    const res = await handlers.create(
-      postRequest({
+    const res = await handlers.create({
+      req: postRequest({
         workspaceId,
         name: "Broken",
         definition: { schemaVersion: 1, trigger: {}, nodes: [], edges: [], entryNodeId: "trigger" },
       }),
-      makeCtx()
-    );
+      ctx: makeCtx(),
+    });
 
     expect(res.status).toBe(400);
     const body = await readJson<{ code: string; invalid_params: unknown }>(res);
@@ -186,7 +186,10 @@ describe("create", () => {
   test("returns the denial response without creating when access is missing", async () => {
     const ctx = makeCtx({ authorize: vi.fn().mockResolvedValue(deniedResponse()) });
 
-    const res = await handlers.create(postRequest({ workspaceId, name: "Notify team", definition }), ctx);
+    const res = await handlers.create({
+      req: postRequest({ workspaceId, name: "Notify team", definition }),
+      ctx,
+    });
 
     expect(res.status).toBe(403);
     expect(service.createWorkflow).not.toHaveBeenCalled();
@@ -199,7 +202,7 @@ describe("create", () => {
       headers: { "Content-Type": "application/json" },
     });
 
-    const res = await handlers.create(req, makeCtx());
+    const res = await handlers.create({ req, ctx: makeCtx() });
 
     expect(res.status).toBe(400);
     expect(service.createWorkflow).not.toHaveBeenCalled();
@@ -208,10 +211,10 @@ describe("create", () => {
   test("rejects a body that exceeds the size limit with 400", async () => {
     const oversizedName = "x".repeat(2 * 1024 * 1024 + 1);
 
-    const res = await handlers.create(
-      postRequest({ workspaceId, name: oversizedName, definition }),
-      makeCtx()
-    );
+    const res = await handlers.create({
+      req: postRequest({ workspaceId, name: oversizedName, definition }),
+      ctx: makeCtx(),
+    });
 
     expect(res.status).toBe(400);
     expect(service.createWorkflow).not.toHaveBeenCalled();
@@ -224,7 +227,10 @@ describe("list", () => {
   test("returns 200 with a cursor-paginated envelope", async () => {
     service.listWorkflows.mockResolvedValue({ workflows: [makeRow()], nextCursor: null });
 
-    const res = await handlers.list(listRequest(`workspaceId=${workspaceId}&sortBy=name`), makeCtx());
+    const res = await handlers.list({
+      req: listRequest(`workspaceId=${workspaceId}&sortBy=name`),
+      ctx: makeCtx(),
+    });
 
     expect(res.status).toBe(200);
     const body = await readJson<{ data: unknown[]; meta: { limit: number; nextCursor: string | null } }>(res);
@@ -234,14 +240,17 @@ describe("list", () => {
   });
 
   test("rejects an out-of-range limit with 400", async () => {
-    const res = await handlers.list(listRequest(`workspaceId=${workspaceId}&limit=500`), makeCtx());
+    const res = await handlers.list({
+      req: listRequest(`workspaceId=${workspaceId}&limit=500`),
+      ctx: makeCtx(),
+    });
     expect(res.status).toBe(400);
     expect(service.listWorkflows).not.toHaveBeenCalled();
   });
 
   test("returns the denial response when access is missing", async () => {
     const ctx = makeCtx({ authorize: vi.fn().mockResolvedValue(deniedResponse()) });
-    const res = await handlers.list(listRequest(`workspaceId=${workspaceId}`), ctx);
+    const res = await handlers.list({ req: listRequest(`workspaceId=${workspaceId}`), ctx });
     expect(res.status).toBe(403);
     expect(service.listWorkflows).not.toHaveBeenCalled();
   });
@@ -259,7 +268,11 @@ describe("patch", () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
     service.updateWorkflow.mockResolvedValue(makeRow({ name: "Renamed" }));
 
-    const res = await handlers.patch(patchRequest({ name: "Renamed" }), makeCtx(), { workflowId });
+    const res = await handlers.patch({
+      req: patchRequest({ name: "Renamed" }),
+      ctx: makeCtx(),
+      params: { workflowId },
+    });
 
     expect(res.status).toBe(200);
     expect(service.updateWorkflow).toHaveBeenCalledWith({ workflowId, workspaceId }, { name: "Renamed" });
@@ -269,7 +282,11 @@ describe("patch", () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "enabled" }));
     service.updateWorkflow.mockResolvedValue(makeRow({ status: "enabled", description: "x" }));
 
-    const res = await handlers.patch(patchRequest({ description: "x" }), makeCtx(), { workflowId });
+    const res = await handlers.patch({
+      req: patchRequest({ description: "x" }),
+      ctx: makeCtx(),
+      params: { workflowId },
+    });
 
     expect(res.status).toBe(200);
     expect(service.updateWorkflow).toHaveBeenCalled();
@@ -278,7 +295,11 @@ describe("patch", () => {
   test("rejects a definition edit on an enabled workflow with 422", async () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "enabled" }));
 
-    const res = await handlers.patch(patchRequest({ definition }), makeCtx(), { workflowId });
+    const res = await handlers.patch({
+      req: patchRequest({ definition }),
+      ctx: makeCtx(),
+      params: { workflowId },
+    });
 
     expect(res.status).toBe(422);
     const body = await readJson<{ code: string }>(res);
@@ -289,7 +310,11 @@ describe("patch", () => {
   test("rejects any patch on an archived workflow with 422", async () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "archived" }));
 
-    const res = await handlers.patch(patchRequest({ name: "x" }), makeCtx(), { workflowId });
+    const res = await handlers.patch({
+      req: patchRequest({ name: "x" }),
+      ctx: makeCtx(),
+      params: { workflowId },
+    });
 
     expect(res.status).toBe(422);
     expect(service.updateWorkflow).not.toHaveBeenCalled();
@@ -298,7 +323,7 @@ describe("patch", () => {
   test("rejects an empty patch with 400", async () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
 
-    const res = await handlers.patch(patchRequest({}), makeCtx(), { workflowId });
+    const res = await handlers.patch({ req: patchRequest({}), ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(400);
     expect(service.updateWorkflow).not.toHaveBeenCalled();
@@ -307,7 +332,11 @@ describe("patch", () => {
   test("returns 403 for an unknown workflow", async () => {
     service.getWorkflowById.mockResolvedValue(null);
 
-    const res = await handlers.patch(patchRequest({ name: "x" }), makeCtx(), { workflowId });
+    const res = await handlers.patch({
+      req: patchRequest({ name: "x" }),
+      ctx: makeCtx(),
+      params: { workflowId },
+    });
 
     expect(res.status).toBe(403);
     expect(service.updateWorkflow).not.toHaveBeenCalled();
@@ -322,7 +351,7 @@ describe("duplicate", () => {
     service.getWorkflowById.mockResolvedValue(makeRow());
     service.duplicateWorkflow.mockResolvedValue(makeRow());
 
-    const res = await handlers.duplicate(emptyPost(), makeCtx(), { workflowId });
+    const res = await handlers.duplicate({ req: emptyPost(), ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(201);
     expect(res.headers.get("Location")).toBe(`/api/v3/workflows/${workflowId}`);
@@ -338,7 +367,7 @@ describe("delete", () => {
     service.getWorkflowById.mockResolvedValue(makeRow());
     service.deleteWorkflow.mockResolvedValue(undefined);
 
-    const res = await handlers.delete(makeCtx(), { workflowId });
+    const res = await handlers.delete({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(204);
     expect(service.deleteWorkflow).toHaveBeenCalledWith({ workflowId, workspaceId });
@@ -347,7 +376,7 @@ describe("delete", () => {
   test("returns 403 for an unknown workflow without deleting", async () => {
     service.getWorkflowById.mockResolvedValue(null);
 
-    const res = await handlers.delete(makeCtx(), { workflowId });
+    const res = await handlers.delete({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(403);
     expect(service.deleteWorkflow).not.toHaveBeenCalled();
@@ -359,7 +388,7 @@ describe("archive / unarchive", () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
     service.setStatus.mockResolvedValue(makeRow({ status: "archived" }));
 
-    const res = await handlers.archive(makeCtx(), { workflowId });
+    const res = await handlers.archive({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(200);
     expect(service.setStatus).toHaveBeenCalledWith({ workflowId, workspaceId }, "archived");
@@ -368,7 +397,7 @@ describe("archive / unarchive", () => {
   test("rejects archiving an already-archived workflow with 422", async () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "archived" }));
 
-    const res = await handlers.archive(makeCtx(), { workflowId });
+    const res = await handlers.archive({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(422);
     expect(service.setStatus).not.toHaveBeenCalled();
@@ -378,7 +407,7 @@ describe("archive / unarchive", () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "archived" }));
     service.setStatus.mockResolvedValue(makeRow({ status: "draft" }));
 
-    const res = await handlers.unarchive(makeCtx(), { workflowId });
+    const res = await handlers.unarchive({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(200);
     expect(service.setStatus).toHaveBeenCalledWith({ workflowId, workspaceId }, "draft");
@@ -387,7 +416,7 @@ describe("archive / unarchive", () => {
   test("rejects unarchiving a non-archived workflow with 422", async () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
 
-    const res = await handlers.unarchive(makeCtx(), { workflowId });
+    const res = await handlers.unarchive({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(422);
     expect(service.setStatus).not.toHaveBeenCalled();
@@ -399,7 +428,7 @@ describe("enable", () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
     service.enableWorkflow.mockResolvedValue(makeRow({ status: "enabled" }));
 
-    const res = await handlers.enable(makeCtx(), { workflowId });
+    const res = await handlers.enable({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(200);
     expect(verifyTriggerSurvey).toHaveBeenCalledWith({ workspaceId, surveyId, endingCardIds: [] });
@@ -415,7 +444,7 @@ describe("enable", () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "disabled" }));
     service.enableWorkflow.mockResolvedValue(makeRow({ status: "enabled" }));
 
-    const res = await handlers.enable(makeCtx(), { workflowId });
+    const res = await handlers.enable({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(200);
     expect(service.enableWorkflow).toHaveBeenCalled();
@@ -425,7 +454,7 @@ describe("enable", () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
     service.enableWorkflow.mockResolvedValue(makeRow({ status: "enabled" }));
 
-    await handlers.enable(makeCtx({ userId: null }), { workflowId });
+    await handlers.enable({ ctx: makeCtx({ userId: null }), params: { workflowId } });
 
     expect(service.enableWorkflow.mock.calls[0][1].publishedBy).toBeNull();
   });
@@ -433,7 +462,7 @@ describe("enable", () => {
   test("rejects enabling an already-enabled workflow with 422 invalid_workflow_state", async () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "enabled" }));
 
-    const res = await handlers.enable(makeCtx(), { workflowId });
+    const res = await handlers.enable({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(422);
     const body = await readJson<{ code: string }>(res);
@@ -444,7 +473,7 @@ describe("enable", () => {
   test("rejects enabling an archived workflow with 422 invalid_workflow_state", async () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "archived" }));
 
-    const res = await handlers.enable(makeCtx(), { workflowId });
+    const res = await handlers.enable({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(422);
     const body = await readJson<{ code: string }>(res);
@@ -457,7 +486,7 @@ describe("enable", () => {
       makeRow({ status: "draft", definition: { ...definition, nodes: [], edges: [] } })
     );
 
-    const res = await handlers.enable(makeCtx(), { workflowId });
+    const res = await handlers.enable({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(422);
     const body = await readJson<{ code: string; invalid_params: unknown[] }>(res);
@@ -472,7 +501,7 @@ describe("enable", () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
     verifyTriggerSurvey.mockResolvedValue({ surveyExists: false, missingEndingCardIds: [] });
 
-    const res = await handlers.enable(makeCtx(), { workflowId });
+    const res = await handlers.enable({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(422);
     const body = await readJson<{ code: string; invalid_params: { name: string }[] }>(res);
@@ -485,7 +514,7 @@ describe("enable", () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
     verifyTriggerSurvey.mockResolvedValue({ surveyExists: true, missingEndingCardIds: ["ec_missing"] });
 
-    const res = await handlers.enable(makeCtx(), { workflowId });
+    const res = await handlers.enable({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(422);
     const body = await readJson<{ code: string; invalid_params: { name: string }[] }>(res);
@@ -498,7 +527,7 @@ describe("enable", () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
     service.enableWorkflow.mockRejectedValue(new WorkflowConflictError());
 
-    const res = await handlers.enable(makeCtx(), { workflowId });
+    const res = await handlers.enable({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(409);
     const body = await readJson<{ code: string }>(res);
@@ -508,7 +537,7 @@ describe("enable", () => {
   test("returns 403 for an unknown workflow without enabling", async () => {
     service.getWorkflowById.mockResolvedValue(null);
 
-    const res = await handlers.enable(makeCtx(), { workflowId });
+    const res = await handlers.enable({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(403);
     expect(service.enableWorkflow).not.toHaveBeenCalled();
@@ -520,7 +549,7 @@ describe("disable", () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "enabled" }));
     service.disableWorkflow.mockResolvedValue(makeRow({ status: "disabled" }));
 
-    const res = await handlers.disable(makeCtx(), { workflowId });
+    const res = await handlers.disable({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(200);
     expect(service.disableWorkflow).toHaveBeenCalledWith({ workflowId, workspaceId });
@@ -531,7 +560,7 @@ describe("disable", () => {
   test("rejects disabling a draft workflow with 422 invalid_workflow_state", async () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
 
-    const res = await handlers.disable(makeCtx(), { workflowId });
+    const res = await handlers.disable({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(422);
     const body = await readJson<{ code: string }>(res);
@@ -542,7 +571,7 @@ describe("disable", () => {
   test("returns 403 for an unknown workflow without disabling", async () => {
     service.getWorkflowById.mockResolvedValue(null);
 
-    const res = await handlers.disable(makeCtx(), { workflowId });
+    const res = await handlers.disable({ ctx: makeCtx(), params: { workflowId } });
 
     expect(res.status).toBe(403);
     expect(service.disableWorkflow).not.toHaveBeenCalled();

--- a/packages/workflows/src/handlers/workflows.handlers.test.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { WorkflowRowWithLastRun, WorkflowsLogger } from "../services/ports";
+import type { WorkflowsService } from "../services/workflows.service";
+import type { AuthorizedWorkspace, WorkflowApiContext } from "./context";
+import { createWorkflowsHandlers } from "./workflows.handlers";
+
+const surveyId = "cm9zr4q7i000108l84gozfggr";
+const workspaceId = "cm9zr4mps000008l8btfy1vtz";
+const workflowId = "cm9zr4t2b000208l8h2m1aq3c";
+
+const definition = {
+  schemaVersion: 1 as const,
+  trigger: {
+    id: "trigger",
+    type: "trigger" as const,
+    triggerType: "response.completed" as const,
+    config: { surveyId, endingCardIds: [] },
+  },
+  nodes: [
+    {
+      id: "send-email",
+      type: "action" as const,
+      actionType: "send_email" as const,
+      config: {
+        from: "noreply@example.com",
+        to: "support@example.com",
+        replyTo: ["support@example.com"],
+        subject: "Thanks",
+        body: "Thanks for your response.",
+        attachResponseData: true,
+      },
+    },
+  ],
+  edges: [{ id: "e1", source: "trigger", target: "send-email" }],
+  entryNodeId: "trigger",
+};
+
+const makeRow = (overrides: Partial<WorkflowRowWithLastRun> = {}): WorkflowRowWithLastRun => ({
+  id: workflowId,
+  createdAt: new Date("2026-06-11T09:30:00.000Z"),
+  updatedAt: new Date("2026-06-12T09:30:00.000Z"),
+  name: "Notify team",
+  description: null,
+  status: "draft",
+  workspaceId,
+  createdBy: null,
+  definition,
+  runs: [],
+  ...overrides,
+});
+
+const service = {
+  listWorkflows: vi.fn<WorkflowsService["listWorkflows"]>(),
+  createWorkflow: vi.fn<WorkflowsService["createWorkflow"]>(),
+  getWorkflowById: vi.fn<WorkflowsService["getWorkflowById"]>(),
+};
+const handlers = createWorkflowsHandlers(service);
+
+const readJson = async <T>(res: Response): Promise<T> => (await res.json()) as T;
+
+const authorizeAllow = vi.fn<WorkflowApiContext["authorize"]>();
+const logger: WorkflowsLogger = { warn: vi.fn(), error: vi.fn() };
+
+const authorized: AuthorizedWorkspace = { workspaceId, organizationId: "cm9zr5org00000000000000000" };
+
+const makeCtx = (overrides: Partial<WorkflowApiContext> = {}): WorkflowApiContext => ({
+  userId: "cm9zr52kh000508l8e3q7bw9j",
+  requestId: "req_1",
+  instance: "https://app.formbricks.com",
+  logger,
+  authorize: authorizeAllow,
+  ...overrides,
+});
+
+const deniedResponse = (): Response =>
+  Response.json(
+    { title: "Forbidden", status: 403, detail: "denied", requestId: "req_1", code: "forbidden" },
+    { status: 403, headers: { "Content-Type": "application/problem+json" } }
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authorizeAllow.mockResolvedValue(authorized);
+});
+
+describe("get", () => {
+  test("returns 403 (not 404) when the workflow does not exist", async () => {
+    service.getWorkflowById.mockResolvedValue(null);
+
+    const res = await handlers.get(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(403);
+    expect(authorizeAllow).not.toHaveBeenCalled();
+    const body = await readJson<{ code: string }>(res);
+    expect(body.code).toBe("forbidden");
+  });
+
+  test("returns the denial response when the caller lacks workspace access", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow());
+    const ctx = makeCtx({ authorize: vi.fn().mockResolvedValue(deniedResponse()) });
+
+    const res = await handlers.get(ctx, { workflowId });
+
+    expect(res.status).toBe(403);
+  });
+
+  test("returns 200 with the workflow resource on success", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow());
+
+    const res = await handlers.get(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Request-Id")).toBe("req_1");
+    const body = await readJson<{ data: { id: string; triggerType: string; definition: unknown } }>(res);
+    expect(body.data.id).toBe(workflowId);
+    expect(body.data.triggerType).toBe("response.completed");
+    expect(body.data.definition).toBeDefined();
+  });
+
+  test("returns 500 when the serialized output fails its resource schema", async () => {
+    const badRow = makeRow({
+      definition: {
+        ...definition,
+        trigger: { ...definition.trigger, config: { surveyId: "not-a-cuid", endingCardIds: [] } },
+      },
+    });
+    service.getWorkflowById.mockResolvedValue(badRow);
+
+    const res = await handlers.get(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(500);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+describe("create", () => {
+  const postRequest = (body: unknown): Request =>
+    new Request("http://localhost/api/v3/workflows", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    });
+
+  test("creates a draft and returns 201 with a Location header", async () => {
+    service.createWorkflow.mockResolvedValue(makeRow());
+
+    const res = await handlers.create(
+      postRequest({ workspaceId, name: "Notify team", definition }),
+      makeCtx()
+    );
+
+    expect(res.status).toBe(201);
+    expect(res.headers.get("Location")).toBe(`/api/v3/workflows/${workflowId}`);
+    expect(service.createWorkflow).toHaveBeenCalledWith(expect.objectContaining({ workspaceId }), {
+      createdBy: "cm9zr52kh000508l8e3q7bw9j",
+    });
+  });
+
+  test("rejects an invalid definition with 400 and invalid_params", async () => {
+    const res = await handlers.create(
+      postRequest({
+        workspaceId,
+        name: "Broken",
+        definition: { schemaVersion: 1, trigger: {}, nodes: [], edges: [], entryNodeId: "trigger" },
+      }),
+      makeCtx()
+    );
+
+    expect(res.status).toBe(400);
+    const body = await readJson<{ code: string; invalid_params: unknown }>(res);
+    expect(body.code).toBe("bad_request");
+    expect(Array.isArray(body.invalid_params)).toBe(true);
+    expect(service.createWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("returns the denial response without creating when access is missing", async () => {
+    const ctx = makeCtx({ authorize: vi.fn().mockResolvedValue(deniedResponse()) });
+
+    const res = await handlers.create(postRequest({ workspaceId, name: "Notify team", definition }), ctx);
+
+    expect(res.status).toBe(403);
+    expect(service.createWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("rejects a malformed JSON body with 400", async () => {
+    const req = new Request("http://localhost/api/v3/workflows", {
+      method: "POST",
+      body: "{ not valid json",
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await handlers.create(req, makeCtx());
+
+    expect(res.status).toBe(400);
+    expect(service.createWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("rejects a body that exceeds the size limit with 400", async () => {
+    const oversizedName = "x".repeat(2 * 1024 * 1024 + 1);
+
+    const res = await handlers.create(
+      postRequest({ workspaceId, name: oversizedName, definition }),
+      makeCtx()
+    );
+
+    expect(res.status).toBe(400);
+    expect(service.createWorkflow).not.toHaveBeenCalled();
+  });
+});
+
+describe("list", () => {
+  const listRequest = (query: string): Request => new Request(`http://localhost/api/v3/workflows?${query}`);
+
+  test("returns 200 with a cursor-paginated envelope", async () => {
+    service.listWorkflows.mockResolvedValue({ workflows: [makeRow()], nextCursor: null });
+
+    const res = await handlers.list(listRequest(`workspaceId=${workspaceId}&sortBy=name`), makeCtx());
+
+    expect(res.status).toBe(200);
+    const body = await readJson<{ data: unknown[]; meta: { limit: number; nextCursor: string | null } }>(res);
+    expect(body.data).toHaveLength(1);
+    expect(body.meta.limit).toBe(20);
+    expect(body.meta.nextCursor).toBeNull();
+  });
+
+  test("rejects an out-of-range limit with 400", async () => {
+    const res = await handlers.list(listRequest(`workspaceId=${workspaceId}&limit=500`), makeCtx());
+    expect(res.status).toBe(400);
+    expect(service.listWorkflows).not.toHaveBeenCalled();
+  });
+
+  test("returns the denial response when access is missing", async () => {
+    const ctx = makeCtx({ authorize: vi.fn().mockResolvedValue(deniedResponse()) });
+    const res = await handlers.list(listRequest(`workspaceId=${workspaceId}`), ctx);
+    expect(res.status).toBe(403);
+    expect(service.listWorkflows).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workflows/src/handlers/workflows.handlers.test.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { WorkflowConflictError } from "../errors";
 import type { WorkflowRowWithLastRun, WorkflowsLogger } from "../services/ports";
 import type { WorkflowsService } from "../services/workflows.service";
 import type { AuthorizedWorkspace, WorkflowApiContext } from "./context";
@@ -53,12 +54,19 @@ const service = {
   listWorkflows: vi.fn<WorkflowsService["listWorkflows"]>(),
   createWorkflow: vi.fn<WorkflowsService["createWorkflow"]>(),
   getWorkflowById: vi.fn<WorkflowsService["getWorkflowById"]>(),
+  updateWorkflow: vi.fn<WorkflowsService["updateWorkflow"]>(),
+  duplicateWorkflow: vi.fn<WorkflowsService["duplicateWorkflow"]>(),
+  deleteWorkflow: vi.fn<WorkflowsService["deleteWorkflow"]>(),
+  setStatus: vi.fn<WorkflowsService["setStatus"]>(),
+  enableWorkflow: vi.fn<WorkflowsService["enableWorkflow"]>(),
+  disableWorkflow: vi.fn<WorkflowsService["disableWorkflow"]>(),
 };
 const handlers = createWorkflowsHandlers(service);
 
 const readJson = async <T>(res: Response): Promise<T> => (await res.json()) as T;
 
 const authorizeAllow = vi.fn<WorkflowApiContext["authorize"]>();
+const verifyTriggerSurvey = vi.fn<WorkflowApiContext["verifyTriggerSurvey"]>();
 const logger: WorkflowsLogger = { warn: vi.fn(), error: vi.fn() };
 
 const authorized: AuthorizedWorkspace = { workspaceId, organizationId: "cm9zr5org00000000000000000" };
@@ -69,6 +77,7 @@ const makeCtx = (overrides: Partial<WorkflowApiContext> = {}): WorkflowApiContex
   instance: "https://app.formbricks.com",
   logger,
   authorize: authorizeAllow,
+  verifyTriggerSurvey,
   ...overrides,
 });
 
@@ -81,6 +90,7 @@ const deniedResponse = (): Response =>
 beforeEach(() => {
   vi.clearAllMocks();
   authorizeAllow.mockResolvedValue(authorized);
+  verifyTriggerSurvey.mockResolvedValue({ surveyExists: true, missingEndingCardIds: [] });
 });
 
 describe("get", () => {
@@ -234,5 +244,307 @@ describe("list", () => {
     const res = await handlers.list(listRequest(`workspaceId=${workspaceId}`), ctx);
     expect(res.status).toBe(403);
     expect(service.listWorkflows).not.toHaveBeenCalled();
+  });
+});
+
+describe("patch", () => {
+  const patchRequest = (body: unknown): Request =>
+    new Request("http://localhost/api/v3/workflows/x", {
+      method: "PATCH",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    });
+
+  test("updates name on a draft workflow and returns 200", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
+    service.updateWorkflow.mockResolvedValue(makeRow({ name: "Renamed" }));
+
+    const res = await handlers.patch(patchRequest({ name: "Renamed" }), makeCtx(), { workflowId });
+
+    expect(res.status).toBe(200);
+    expect(service.updateWorkflow).toHaveBeenCalledWith({ workflowId, workspaceId }, { name: "Renamed" });
+  });
+
+  test("allows name/description edits on an enabled workflow", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "enabled" }));
+    service.updateWorkflow.mockResolvedValue(makeRow({ status: "enabled", description: "x" }));
+
+    const res = await handlers.patch(patchRequest({ description: "x" }), makeCtx(), { workflowId });
+
+    expect(res.status).toBe(200);
+    expect(service.updateWorkflow).toHaveBeenCalled();
+  });
+
+  test("rejects a definition edit on an enabled workflow with 422", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "enabled" }));
+
+    const res = await handlers.patch(patchRequest({ definition }), makeCtx(), { workflowId });
+
+    expect(res.status).toBe(422);
+    const body = await readJson<{ code: string }>(res);
+    expect(body.code).toBe("invalid_workflow_state");
+    expect(service.updateWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("rejects any patch on an archived workflow with 422", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "archived" }));
+
+    const res = await handlers.patch(patchRequest({ name: "x" }), makeCtx(), { workflowId });
+
+    expect(res.status).toBe(422);
+    expect(service.updateWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("rejects an empty patch with 400", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
+
+    const res = await handlers.patch(patchRequest({}), makeCtx(), { workflowId });
+
+    expect(res.status).toBe(400);
+    expect(service.updateWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("returns 403 for an unknown workflow", async () => {
+    service.getWorkflowById.mockResolvedValue(null);
+
+    const res = await handlers.patch(patchRequest({ name: "x" }), makeCtx(), { workflowId });
+
+    expect(res.status).toBe(403);
+    expect(service.updateWorkflow).not.toHaveBeenCalled();
+  });
+});
+
+describe("duplicate", () => {
+  const emptyPost = (): Request =>
+    new Request("http://localhost/api/v3/workflows/x/duplicate", { method: "POST" });
+
+  test("creates a copy and returns 201 with a Location header", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow());
+    service.duplicateWorkflow.mockResolvedValue(makeRow());
+
+    const res = await handlers.duplicate(emptyPost(), makeCtx(), { workflowId });
+
+    expect(res.status).toBe(201);
+    expect(res.headers.get("Location")).toBe(`/api/v3/workflows/${workflowId}`);
+    expect(service.duplicateWorkflow).toHaveBeenCalledWith(expect.objectContaining({ id: workflowId }), {
+      name: undefined,
+      createdBy: "cm9zr52kh000508l8e3q7bw9j",
+    });
+  });
+});
+
+describe("delete", () => {
+  test("hard-deletes and returns 204", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow());
+    service.deleteWorkflow.mockResolvedValue(undefined);
+
+    const res = await handlers.delete(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(204);
+    expect(service.deleteWorkflow).toHaveBeenCalledWith({ workflowId, workspaceId });
+  });
+
+  test("returns 403 for an unknown workflow without deleting", async () => {
+    service.getWorkflowById.mockResolvedValue(null);
+
+    const res = await handlers.delete(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(403);
+    expect(service.deleteWorkflow).not.toHaveBeenCalled();
+  });
+});
+
+describe("archive / unarchive", () => {
+  test("archives a draft workflow", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
+    service.setStatus.mockResolvedValue(makeRow({ status: "archived" }));
+
+    const res = await handlers.archive(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(200);
+    expect(service.setStatus).toHaveBeenCalledWith({ workflowId, workspaceId }, "archived");
+  });
+
+  test("rejects archiving an already-archived workflow with 422", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "archived" }));
+
+    const res = await handlers.archive(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(422);
+    expect(service.setStatus).not.toHaveBeenCalled();
+  });
+
+  test("unarchives an archived workflow back to draft", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "archived" }));
+    service.setStatus.mockResolvedValue(makeRow({ status: "draft" }));
+
+    const res = await handlers.unarchive(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(200);
+    expect(service.setStatus).toHaveBeenCalledWith({ workflowId, workspaceId }, "draft");
+  });
+
+  test("rejects unarchiving a non-archived workflow with 422", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
+
+    const res = await handlers.unarchive(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(422);
+    expect(service.setStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe("enable", () => {
+  test("snapshots a version and returns 200 when enabling a draft", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
+    service.enableWorkflow.mockResolvedValue(makeRow({ status: "enabled" }));
+
+    const res = await handlers.enable(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(200);
+    expect(verifyTriggerSurvey).toHaveBeenCalledWith({ workspaceId, surveyId, endingCardIds: [] });
+    expect(service.enableWorkflow).toHaveBeenCalledWith(
+      { workflowId, workspaceId },
+      expect.objectContaining({ publishedBy: "cm9zr52kh000508l8e3q7bw9j" })
+    );
+    const body = await readJson<{ data: { status: string } }>(res);
+    expect(body.data.status).toBe("enabled");
+  });
+
+  test("re-enables a disabled workflow", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "disabled" }));
+    service.enableWorkflow.mockResolvedValue(makeRow({ status: "enabled" }));
+
+    const res = await handlers.enable(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(200);
+    expect(service.enableWorkflow).toHaveBeenCalled();
+  });
+
+  test("records a null publishedBy for API-key callers", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
+    service.enableWorkflow.mockResolvedValue(makeRow({ status: "enabled" }));
+
+    await handlers.enable(makeCtx({ userId: null }), { workflowId });
+
+    expect(service.enableWorkflow.mock.calls[0][1].publishedBy).toBeNull();
+  });
+
+  test("rejects enabling an already-enabled workflow with 422 invalid_workflow_state", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "enabled" }));
+
+    const res = await handlers.enable(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(422);
+    const body = await readJson<{ code: string }>(res);
+    expect(body.code).toBe("invalid_workflow_state");
+    expect(service.enableWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("rejects enabling an archived workflow with 422 invalid_workflow_state", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "archived" }));
+
+    const res = await handlers.enable(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(422);
+    const body = await readJson<{ code: string }>(res);
+    expect(body.code).toBe("invalid_workflow_state");
+    expect(service.enableWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("rejects a non-executable (trigger-only) definition with 422 workflow_not_executable", async () => {
+    service.getWorkflowById.mockResolvedValue(
+      makeRow({ status: "draft", definition: { ...definition, nodes: [], edges: [] } })
+    );
+
+    const res = await handlers.enable(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(422);
+    const body = await readJson<{ code: string; invalid_params: unknown[] }>(res);
+    expect(body.code).toBe("workflow_not_executable");
+    expect(Array.isArray(body.invalid_params)).toBe(true);
+    expect(body.invalid_params.length).toBeGreaterThan(0);
+    expect(verifyTriggerSurvey).not.toHaveBeenCalled();
+    expect(service.enableWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("rejects a missing trigger survey with 422 workflow_not_executable", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
+    verifyTriggerSurvey.mockResolvedValue({ surveyExists: false, missingEndingCardIds: [] });
+
+    const res = await handlers.enable(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(422);
+    const body = await readJson<{ code: string; invalid_params: { name: string }[] }>(res);
+    expect(body.code).toBe("workflow_not_executable");
+    expect(body.invalid_params.map((p) => p.name)).toContain("definition.trigger.config.surveyId");
+    expect(service.enableWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("rejects a missing ending card with 422 workflow_not_executable", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
+    verifyTriggerSurvey.mockResolvedValue({ surveyExists: true, missingEndingCardIds: ["ec_missing"] });
+
+    const res = await handlers.enable(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(422);
+    const body = await readJson<{ code: string; invalid_params: { name: string }[] }>(res);
+    expect(body.code).toBe("workflow_not_executable");
+    expect(body.invalid_params.map((p) => p.name)).toContain("definition.trigger.config.endingCardIds");
+    expect(service.enableWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("maps a concurrent-enable conflict from the service to 409", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
+    service.enableWorkflow.mockRejectedValue(new WorkflowConflictError());
+
+    const res = await handlers.enable(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(409);
+    const body = await readJson<{ code: string }>(res);
+    expect(body.code).toBe("conflict");
+  });
+
+  test("returns 403 for an unknown workflow without enabling", async () => {
+    service.getWorkflowById.mockResolvedValue(null);
+
+    const res = await handlers.enable(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(403);
+    expect(service.enableWorkflow).not.toHaveBeenCalled();
+  });
+});
+
+describe("disable", () => {
+  test("disables an enabled workflow and returns 200", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "enabled" }));
+    service.disableWorkflow.mockResolvedValue(makeRow({ status: "disabled" }));
+
+    const res = await handlers.disable(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(200);
+    expect(service.disableWorkflow).toHaveBeenCalledWith({ workflowId, workspaceId });
+    const body = await readJson<{ data: { status: string } }>(res);
+    expect(body.data.status).toBe("disabled");
+  });
+
+  test("rejects disabling a draft workflow with 422 invalid_workflow_state", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
+
+    const res = await handlers.disable(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(422);
+    const body = await readJson<{ code: string }>(res);
+    expect(body.code).toBe("invalid_workflow_state");
+    expect(service.disableWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("returns 403 for an unknown workflow without disabling", async () => {
+    service.getWorkflowById.mockResolvedValue(null);
+
+    const res = await handlers.disable(makeCtx(), { workflowId });
+
+    expect(res.status).toBe(403);
+    expect(service.disableWorkflow).not.toHaveBeenCalled();
   });
 });

--- a/packages/workflows/src/handlers/workflows.handlers.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.ts
@@ -94,17 +94,35 @@ const buildSurveyInvalidParams = (check: TriggerSurveyCheck): WorkflowInvalidPar
   return invalidParams;
 };
 
+/**
+ * Handler argument shapes. Every handler takes a single object (never positional args) so call
+ * sites are uniform and self-documenting — mirroring the v3 API's single-object handler convention
+ * (e.g. `listV3Surveys({ searchParams, authentication, ... })`). Each shape carries only the fields
+ * its handler uses, so there are no unused parameters to thread through.
+ */
+interface WorkflowRequestArgs {
+  req: Request;
+  ctx: WorkflowApiContext;
+}
+interface WorkflowResourceArgs {
+  ctx: WorkflowApiContext;
+  params: TWorkflowIdInput;
+}
+interface WorkflowResourceBodyArgs extends WorkflowResourceArgs {
+  req: Request;
+}
+
 export interface WorkflowsHandlers {
-  list: (req: Request, ctx: WorkflowApiContext) => Promise<Response>;
-  create: (req: Request, ctx: WorkflowApiContext) => Promise<Response>;
-  get: (ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
-  patch: (req: Request, ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
-  duplicate: (req: Request, ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
-  delete: (ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
-  archive: (ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
-  unarchive: (ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
-  enable: (ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
-  disable: (ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
+  list: (args: WorkflowRequestArgs) => Promise<Response>;
+  create: (args: WorkflowRequestArgs) => Promise<Response>;
+  get: (args: WorkflowResourceArgs) => Promise<Response>;
+  patch: (args: WorkflowResourceBodyArgs) => Promise<Response>;
+  duplicate: (args: WorkflowResourceBodyArgs) => Promise<Response>;
+  delete: (args: WorkflowResourceArgs) => Promise<Response>;
+  archive: (args: WorkflowResourceArgs) => Promise<Response>;
+  unarchive: (args: WorkflowResourceArgs) => Promise<Response>;
+  enable: (args: WorkflowResourceArgs) => Promise<Response>;
+  disable: (args: WorkflowResourceArgs) => Promise<Response>;
 }
 
 /**
@@ -115,7 +133,7 @@ export interface WorkflowsHandlers {
  * `toProblemResponse`, so handlers never leak or swallow.
  */
 export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHandlers => ({
-  async list(req, ctx) {
+  async list({ req, ctx }) {
     try {
       const input = parseListWorkflowsQuery(new URL(req.url).searchParams);
 
@@ -135,7 +153,7 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
     }
   },
 
-  async create(req, ctx) {
+  async create({ req, ctx }) {
     try {
       const input = ZCreateWorkflowInput.parse(await readJsonBody(req));
 
@@ -155,7 +173,7 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
     }
   },
 
-  async get(ctx, params) {
+  async get({ ctx, params }) {
     try {
       const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "read");
       if (loaded instanceof Response) return loaded;
@@ -166,7 +184,7 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
     }
   },
 
-  async patch(req, ctx, params) {
+  async patch({ req, ctx, params }) {
     try {
       const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
       if (loaded instanceof Response) return loaded;
@@ -192,7 +210,7 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
     }
   },
 
-  async duplicate(req, ctx, params) {
+  async duplicate({ req, ctx, params }) {
     try {
       const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
       if (loaded instanceof Response) return loaded;
@@ -207,7 +225,7 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
     }
   },
 
-  async delete(ctx, params) {
+  async delete({ ctx, params }) {
     try {
       const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
       if (loaded instanceof Response) return loaded;
@@ -219,7 +237,7 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
     }
   },
 
-  async archive(ctx, params) {
+  async archive({ ctx, params }) {
     try {
       const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
       if (loaded instanceof Response) return loaded;
@@ -238,7 +256,7 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
     }
   },
 
-  async unarchive(ctx, params) {
+  async unarchive({ ctx, params }) {
     try {
       const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
       if (loaded instanceof Response) return loaded;
@@ -257,7 +275,7 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
     }
   },
 
-  async enable(ctx, params) {
+  async enable({ ctx, params }) {
     try {
       const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
       if (loaded instanceof Response) return loaded;
@@ -291,7 +309,7 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
     }
   },
 
-  async disable(ctx, params) {
+  async disable({ ctx, params }) {
     try {
       const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
       if (loaded instanceof Response) return loaded;

--- a/packages/workflows/src/handlers/workflows.handlers.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.ts
@@ -1,6 +1,8 @@
 import {
   type TWorkflowIdInput,
   ZCreateWorkflowInput,
+  ZDuplicateWorkflowInput,
+  ZPatchWorkflowInput,
   ZWorkflowListItem,
   ZWorkflowResource,
   zCursorPage,
@@ -8,12 +10,17 @@ import {
 import {
   WorkflowForbiddenError,
   WorkflowInvalidInputError,
+  type WorkflowInvalidParam,
+  WorkflowInvalidStateError,
+  WorkflowNotExecutableError,
   toProblemResponse,
   validateOutput,
 } from "../errors";
-import { createdResponse, dataResponse, listResponse } from "../responses";
+import { createdResponse, dataResponse, listResponse, noContentResponse } from "../responses";
+import type { WorkflowRowWithLastRun } from "../services/ports";
 import type { WorkflowsService } from "../services/workflows.service";
-import type { WorkflowApiContext } from "./context";
+import { ZWorkflowExecutableDefinition } from "../types/document";
+import type { TriggerSurveyCheck, WorkflowApiAccess, WorkflowApiContext } from "./context";
 import { parseListWorkflowsQuery } from "./parse-list-query";
 import { toWorkflowListItem, toWorkflowResource } from "./serializers";
 
@@ -22,7 +29,7 @@ const MAX_REQUEST_BODY_BYTES = 2 * 1024 * 1024;
 
 const ZWorkflowListPage = zCursorPage(ZWorkflowListItem);
 
-const readJsonBody = async (req: Request): Promise<unknown> => {
+const readJsonBody = async (req: Request, options?: { allowEmpty?: boolean }): Promise<unknown> => {
   // Reject oversized payloads up front via Content-Length so we never buffer them into memory.
   const contentLength = req.headers.get("content-length");
   if (contentLength && Number(contentLength) > MAX_REQUEST_BODY_BYTES) {
@@ -35,6 +42,12 @@ const readJsonBody = async (req: Request): Promise<unknown> => {
     throw new WorkflowInvalidInputError("Request body is too large.");
   }
 
+  // Optional-body operations (e.g. duplicate) treat an empty body as `{}`.
+  if (text.trim() === "") {
+    if (options?.allowEmpty) return {};
+    throw new WorkflowInvalidInputError("Malformed JSON body.");
+  }
+
   try {
     return JSON.parse(text) as unknown;
   } catch {
@@ -42,10 +55,56 @@ const readJsonBody = async (req: Request): Promise<unknown> => {
   }
 };
 
+/**
+ * Load a workflow by id and authorize the caller against its workspace. Returns the row on success,
+ * or a ready-to-return denial `Response`; throws `WorkflowForbiddenError` (→ 403) for unknown ids so
+ * existence is never leaked. Shared by every by-id operation (get, patch, duplicate, delete,
+ * archive, unarchive) — load once, authorize once, no double round-trip.
+ */
+const loadAndAuthorize = async (
+  service: WorkflowsService,
+  ctx: WorkflowApiContext,
+  workflowId: string,
+  access: WorkflowApiAccess
+): Promise<WorkflowRowWithLastRun | Response> => {
+  const row = await service.getWorkflowById(workflowId);
+  if (!row) throw new WorkflowForbiddenError();
+
+  const authorized = await ctx.authorize(row.workspaceId, access);
+  if (authorized instanceof Response) return authorized;
+
+  return row;
+};
+
+/** Map a failed trigger-survey check to field-level `invalid_params` on the definition's trigger config. */
+const buildSurveyInvalidParams = (check: TriggerSurveyCheck): WorkflowInvalidParam[] => {
+  const invalidParams: WorkflowInvalidParam[] = [];
+  if (!check.surveyExists) {
+    invalidParams.push({
+      name: "definition.trigger.config.surveyId",
+      reason: "The referenced survey does not exist in this workspace.",
+    });
+  }
+  for (const endingCardId of check.missingEndingCardIds) {
+    invalidParams.push({
+      name: "definition.trigger.config.endingCardIds",
+      reason: `Ending card ${endingCardId} does not exist on the survey.`,
+    });
+  }
+  return invalidParams;
+};
+
 export interface WorkflowsHandlers {
   list: (req: Request, ctx: WorkflowApiContext) => Promise<Response>;
   create: (req: Request, ctx: WorkflowApiContext) => Promise<Response>;
   get: (ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
+  patch: (req: Request, ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
+  duplicate: (req: Request, ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
+  delete: (ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
+  archive: (ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
+  unarchive: (ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
+  enable: (ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
+  disable: (ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
 }
 
 /**
@@ -98,16 +157,154 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
 
   async get(ctx, params) {
     try {
-      const row = await service.getWorkflowById(params.workflowId);
-      // 403 (not 404) for unknown ids so existence is never leaked across workspaces.
-      if (!row) throw new WorkflowForbiddenError();
+      const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "read");
+      if (loaded instanceof Response) return loaded;
 
-      const authorized = await ctx.authorize(row.workspaceId, "read");
-      if (authorized instanceof Response) return authorized;
+      return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(loaded)), ctx.requestId);
+    } catch (error) {
+      return toProblemResponse(error, ctx);
+    }
+  },
 
-      const resource = validateOutput(ZWorkflowResource, toWorkflowResource(row));
+  async patch(req, ctx, params) {
+    try {
+      const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
+      if (loaded instanceof Response) return loaded;
+      if (loaded.status === "archived") {
+        throw new WorkflowInvalidStateError("Archived workflows are read-only; unarchive before editing.");
+      }
 
-      return dataResponse(resource, ctx.requestId);
+      const input = ZPatchWorkflowInput.parse(await readJsonBody(req));
+      if (input.definition !== undefined && loaded.status === "enabled") {
+        throw new WorkflowInvalidStateError(
+          "A workflow's definition can only be updated while it is draft or disabled."
+        );
+      }
+
+      const updated = await service.updateWorkflow(
+        { workflowId: params.workflowId, workspaceId: loaded.workspaceId },
+        input
+      );
+
+      return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
+    } catch (error) {
+      return toProblemResponse(error, ctx);
+    }
+  },
+
+  async duplicate(req, ctx, params) {
+    try {
+      const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
+      if (loaded instanceof Response) return loaded;
+
+      const input = ZDuplicateWorkflowInput.parse(await readJsonBody(req, { allowEmpty: true }));
+      const created = await service.duplicateWorkflow(loaded, { name: input.name, createdBy: ctx.userId });
+
+      const resource = validateOutput(ZWorkflowResource, toWorkflowResource(created));
+      return createdResponse(resource, `/api/v3/workflows/${resource.id}`, ctx.requestId);
+    } catch (error) {
+      return toProblemResponse(error, ctx);
+    }
+  },
+
+  async delete(ctx, params) {
+    try {
+      const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
+      if (loaded instanceof Response) return loaded;
+
+      await service.deleteWorkflow({ workflowId: params.workflowId, workspaceId: loaded.workspaceId });
+      return noContentResponse(ctx.requestId);
+    } catch (error) {
+      return toProblemResponse(error, ctx);
+    }
+  },
+
+  async archive(ctx, params) {
+    try {
+      const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
+      if (loaded instanceof Response) return loaded;
+      if (loaded.status === "archived") {
+        throw new WorkflowInvalidStateError("Workflow is already archived.");
+      }
+
+      const updated = await service.setStatus(
+        { workflowId: params.workflowId, workspaceId: loaded.workspaceId },
+        "archived"
+      );
+
+      return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
+    } catch (error) {
+      return toProblemResponse(error, ctx);
+    }
+  },
+
+  async unarchive(ctx, params) {
+    try {
+      const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
+      if (loaded instanceof Response) return loaded;
+      if (loaded.status !== "archived") {
+        throw new WorkflowInvalidStateError("Only archived workflows can be unarchived.");
+      }
+
+      const updated = await service.setStatus(
+        { workflowId: params.workflowId, workspaceId: loaded.workspaceId },
+        "draft"
+      );
+
+      return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
+    } catch (error) {
+      return toProblemResponse(error, ctx);
+    }
+  },
+
+  async enable(ctx, params) {
+    try {
+      const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
+      if (loaded instanceof Response) return loaded;
+      if (loaded.status !== "draft" && loaded.status !== "disabled") {
+        throw new WorkflowInvalidStateError("Only draft or disabled workflows can be enabled.");
+      }
+
+      // safeParse (not parse): a non-executable definition is a 422 workflow_not_executable,
+      // not the generic 400 a thrown ZodError would map to.
+      const executable = ZWorkflowExecutableDefinition.safeParse(loaded.definition);
+      if (!executable.success) throw WorkflowNotExecutableError.fromZodError(executable.error);
+
+      const { surveyId, endingCardIds } = executable.data.trigger.config;
+      const surveyCheck = await ctx.verifyTriggerSurvey({
+        workspaceId: loaded.workspaceId,
+        surveyId,
+        endingCardIds,
+      });
+      if (!surveyCheck.surveyExists || surveyCheck.missingEndingCardIds.length > 0) {
+        throw new WorkflowNotExecutableError(buildSurveyInvalidParams(surveyCheck));
+      }
+
+      const updated = await service.enableWorkflow(
+        { workflowId: params.workflowId, workspaceId: loaded.workspaceId },
+        { definition: executable.data, publishedBy: ctx.userId }
+      );
+
+      return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
+    } catch (error) {
+      return toProblemResponse(error, ctx);
+    }
+  },
+
+  async disable(ctx, params) {
+    try {
+      const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
+      if (loaded instanceof Response) return loaded;
+      if (loaded.status !== "enabled") {
+        throw new WorkflowInvalidStateError("Only enabled workflows can be disabled.");
+      }
+
+      const updated = await service.disableWorkflow({
+        workflowId: params.workflowId,
+        workspaceId: loaded.workspaceId,
+      });
+
+      return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
     } catch (error) {
       return toProblemResponse(error, ctx);
     }

--- a/packages/workflows/src/handlers/workflows.handlers.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.ts
@@ -1,0 +1,115 @@
+import {
+  type TWorkflowIdInput,
+  ZCreateWorkflowInput,
+  ZWorkflowListItem,
+  ZWorkflowResource,
+  zCursorPage,
+} from "../contracts";
+import {
+  WorkflowForbiddenError,
+  WorkflowInvalidInputError,
+  toProblemResponse,
+  validateOutput,
+} from "../errors";
+import { createdResponse, dataResponse, listResponse } from "../responses";
+import type { WorkflowsService } from "../services/workflows.service";
+import type { WorkflowApiContext } from "./context";
+import { parseListWorkflowsQuery } from "./parse-list-query";
+import { toWorkflowListItem, toWorkflowResource } from "./serializers";
+
+// Matches the v3 API's default request-body limit (apps/web `request-body.ts`) for consistency.
+const MAX_REQUEST_BODY_BYTES = 2 * 1024 * 1024;
+
+const ZWorkflowListPage = zCursorPage(ZWorkflowListItem);
+
+const readJsonBody = async (req: Request): Promise<unknown> => {
+  // Reject oversized payloads up front via Content-Length so we never buffer them into memory.
+  const contentLength = req.headers.get("content-length");
+  if (contentLength && Number(contentLength) > MAX_REQUEST_BODY_BYTES) {
+    throw new WorkflowInvalidInputError("Request body is too large.");
+  }
+
+  const text = await req.text();
+  // Defense in depth: Content-Length may be absent (chunked) or understated.
+  if (Buffer.byteLength(text, "utf8") > MAX_REQUEST_BODY_BYTES) {
+    throw new WorkflowInvalidInputError("Request body is too large.");
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new WorkflowInvalidInputError("Malformed JSON body.");
+  }
+};
+
+export interface WorkflowsHandlers {
+  list: (req: Request, ctx: WorkflowApiContext) => Promise<Response>;
+  create: (req: Request, ctx: WorkflowApiContext) => Promise<Response>;
+  get: (ctx: WorkflowApiContext, params: TWorkflowIdInput) => Promise<Response>;
+}
+
+/**
+ * Web-standard, framework-agnostic handlers for the v3 Workflows CRUD surface. Each handler:
+ * parse/validate input with the contract schemas → authorize via the injected `ctx.authorize`
+ * capability → call the service → serialize → validate the serialized output against the resource
+ * schema → return the success envelope. Any thrown error is mapped (and logged) by
+ * `toProblemResponse`, so handlers never leak or swallow.
+ */
+export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHandlers => ({
+  async list(req, ctx) {
+    try {
+      const input = parseListWorkflowsQuery(new URL(req.url).searchParams);
+
+      const authorized = await ctx.authorize(input.workspaceId, "read");
+      if (authorized instanceof Response) return authorized;
+
+      const workflowPage = await service.listWorkflows({ ...input, workspaceId: authorized.workspaceId });
+
+      const page = validateOutput(ZWorkflowListPage, {
+        data: workflowPage.workflows.map(toWorkflowListItem),
+        meta: { limit: input.limit, nextCursor: workflowPage.nextCursor },
+      });
+
+      return listResponse(page.data, page.meta, ctx.requestId);
+    } catch (error) {
+      return toProblemResponse(error, ctx);
+    }
+  },
+
+  async create(req, ctx) {
+    try {
+      const input = ZCreateWorkflowInput.parse(await readJsonBody(req));
+
+      const authorized = await ctx.authorize(input.workspaceId, "readWrite");
+      if (authorized instanceof Response) return authorized;
+
+      const created = await service.createWorkflow(
+        { ...input, workspaceId: authorized.workspaceId },
+        { createdBy: ctx.userId }
+      );
+
+      const resource = validateOutput(ZWorkflowResource, toWorkflowResource(created));
+
+      return createdResponse(resource, `/api/v3/workflows/${resource.id}`, ctx.requestId);
+    } catch (error) {
+      return toProblemResponse(error, ctx);
+    }
+  },
+
+  async get(ctx, params) {
+    try {
+      const row = await service.getWorkflowById(params.workflowId);
+      // 403 (not 404) for unknown ids so existence is never leaked across workspaces.
+      if (!row) throw new WorkflowForbiddenError();
+
+      const authorized = await ctx.authorize(row.workspaceId, "read");
+      if (authorized instanceof Response) return authorized;
+
+      const resource = validateOutput(ZWorkflowResource, toWorkflowResource(row));
+
+      return dataResponse(resource, ctx.requestId);
+    } catch (error) {
+      return toProblemResponse(error, ctx);
+    }
+  },
+});

--- a/packages/workflows/src/http.ts
+++ b/packages/workflows/src/http.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared HTTP header helpers for v3 workflow responses (both success envelopes and problem
+ * details). Centralized so the cache directive and the standard header set are defined once.
+ * Mirrors the headers used by `apps/web/app/api/v3/lib/response.ts`.
+ */
+
+export const CACHE_CONTROL_NO_STORE = "private, no-store";
+
+export const buildV3Headers = (
+  contentType: string,
+  requestId: string,
+  extra?: Record<string, string>
+): Record<string, string> => ({
+  "Content-Type": contentType,
+  "Cache-Control": CACHE_CONTROL_NO_STORE,
+  "X-Request-Id": requestId,
+  ...extra,
+});

--- a/packages/workflows/src/responses.ts
+++ b/packages/workflows/src/responses.ts
@@ -1,5 +1,5 @@
 import type { TCursorPaginationMeta } from "./contracts";
-import { buildV3Headers } from "./http";
+import { CACHE_CONTROL_NO_STORE, buildV3Headers } from "./http";
 
 /**
  * Success envelope builders for the workflow handlers. Body shapes and headers mirror
@@ -20,3 +20,9 @@ export const createdResponse = <T>(data: T, location: string, requestId: string)
     { data },
     { status: 201, headers: buildV3Headers(JSON_CONTENT_TYPE, requestId, { Location: location }) }
   );
+
+export const noContentResponse = (requestId: string): Response =>
+  new Response(null, {
+    status: 204,
+    headers: { "Cache-Control": CACHE_CONTROL_NO_STORE, "X-Request-Id": requestId },
+  });

--- a/packages/workflows/src/responses.ts
+++ b/packages/workflows/src/responses.ts
@@ -1,0 +1,22 @@
+import type { TCursorPaginationMeta } from "./contracts";
+import { buildV3Headers } from "./http";
+
+/**
+ * Success envelope builders for the workflow handlers. Body shapes and headers mirror
+ * `apps/web/app/api/v3/lib/response.ts` (`{ data }`, `{ data, meta }`, 201 + Location). Web-standard
+ * `Response` keeps the package framework-agnostic.
+ */
+
+const JSON_CONTENT_TYPE = "application/json";
+
+export const dataResponse = <T>(data: T, requestId: string): Response =>
+  Response.json({ data }, { status: 200, headers: buildV3Headers(JSON_CONTENT_TYPE, requestId) });
+
+export const listResponse = <T>(data: T[], meta: TCursorPaginationMeta, requestId: string): Response =>
+  Response.json({ data, meta }, { status: 200, headers: buildV3Headers(JSON_CONTENT_TYPE, requestId) });
+
+export const createdResponse = <T>(data: T, location: string, requestId: string): Response =>
+  Response.json(
+    { data },
+    { status: 201, headers: buildV3Headers(JSON_CONTENT_TYPE, requestId, { Location: location }) }
+  );

--- a/packages/workflows/src/server/index.ts
+++ b/packages/workflows/src/server/index.ts
@@ -3,25 +3,19 @@
  * to an injected Prisma client and builds HTTP responses) and is deliberately kept out of the
  * browser-safe `.` entry, which exposes only contracts and types. The `apps/web` Next.js routes
  * import from here, inject `prisma`/`logger`/`authorize`, and delegate.
+ *
+ * The surface is intentionally minimal: the factories + context the adapter consumes, plus the
+ * typed domain errors and problem mapper that ENG-1222/1223 reuse. Serializers, ports, and row
+ * types stay internal (imported within the package via relative paths).
  */
 
 export { createWorkflowsService } from "../services/workflows.service";
-export type { WorkflowsService, WorkflowListPage } from "../services/workflows.service";
+export type { WorkflowsService } from "../services/workflows.service";
 
 export { createWorkflowsHandlers } from "../handlers/workflows.handlers";
 export type { WorkflowsHandlers } from "../handlers/workflows.handlers";
 
-export { toWorkflowListItem, toWorkflowResource, toWorkflowRunSummary } from "../handlers/serializers";
-
 export type { WorkflowApiAccess, WorkflowApiContext, AuthorizedWorkspace } from "../handlers/context";
-
-export type {
-  WorkflowsDb,
-  WorkflowsLogger,
-  WorkflowRow,
-  WorkflowRunRow,
-  WorkflowRowWithLastRun,
-} from "../services/ports";
 
 export {
   WorkflowApiError,

--- a/packages/workflows/src/server/index.ts
+++ b/packages/workflows/src/server/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Server entry point for `@formbricks/workflows/server`. Everything here is server-only (it talks
+ * to an injected Prisma client and builds HTTP responses) and is deliberately kept out of the
+ * browser-safe `.` entry, which exposes only contracts and types. The `apps/web` Next.js routes
+ * import from here, inject `prisma`/`logger`/`authorize`, and delegate.
+ */
+
+export { createWorkflowsService } from "../services/workflows.service";
+export type { WorkflowsService, WorkflowListPage } from "../services/workflows.service";
+
+export { createWorkflowsHandlers } from "../handlers/workflows.handlers";
+export type { WorkflowsHandlers } from "../handlers/workflows.handlers";
+
+export { toWorkflowListItem, toWorkflowResource, toWorkflowRunSummary } from "../handlers/serializers";
+
+export type { WorkflowApiAccess, WorkflowApiContext, AuthorizedWorkspace } from "../handlers/context";
+
+export type {
+  WorkflowsDb,
+  WorkflowsLogger,
+  WorkflowRow,
+  WorkflowRunRow,
+  WorkflowRowWithLastRun,
+} from "../services/ports";
+
+export {
+  WorkflowApiError,
+  WorkflowConflictError,
+  WorkflowForbiddenError,
+  WorkflowInvalidInputError,
+  WorkflowSerializationError,
+  toProblemResponse,
+} from "../errors";
+export type { WorkflowInvalidParam, WorkflowProblemCode } from "../errors";

--- a/packages/workflows/src/server/index.ts
+++ b/packages/workflows/src/server/index.ts
@@ -22,6 +22,8 @@ export {
   WorkflowConflictError,
   WorkflowForbiddenError,
   WorkflowInvalidInputError,
+  WorkflowInvalidStateError,
+  WorkflowNotExecutableError,
   WorkflowSerializationError,
   toProblemResponse,
 } from "../errors";

--- a/packages/workflows/src/services/ports.ts
+++ b/packages/workflows/src/services/ports.ts
@@ -108,6 +108,15 @@ export interface WorkflowDelegate {
     };
     include: LastRunInclude;
   }) => Promise<WorkflowRowWithLastRun>;
+  /**
+   * Conditional status transition. `enable` uses it inside its transaction to flip a draft/disabled
+   * row to enabled and assert exactly one row changed — the row lock serializes concurrent enables,
+   * so the guard can't be bypassed the way a pre-transaction status read could.
+   */
+  updateMany: (args: {
+    where: { id: string; workspaceId: string; status: { in: TWorkflowStatus[] } };
+    data: { status: TWorkflowStatus };
+  }) => Promise<{ count: number }>;
   delete: (args: {
     where: { id_workspaceId: { id: string; workspaceId: string } };
   }) => Promise<{ id: string }>;

--- a/packages/workflows/src/services/ports.ts
+++ b/packages/workflows/src/services/ports.ts
@@ -1,0 +1,114 @@
+import type { TWorkflowStatus } from "../types/common";
+import type { TWorkflowDefinition } from "../types/document";
+import type { TWorkflowRunStatus } from "../types/runs";
+
+/**
+ * Runtime ports the workflow server code depends on. They are injected by the adapter
+ * (`apps/web`) so this package stays framework-agnostic and carries no dependency on
+ * `@formbricks/database` — which itself imports `@formbricks/workflows`, so a hard edge back
+ * would create a package build cycle.
+ *
+ * The row and delegate shapes are hand-authored from our own domain types (the row's
+ * `definition`/`status` ARE our types) rather than imported from Prisma's generated client. This
+ * keeps the package a dependency-free leaf; the adapter bridges the real Prisma client to these
+ * ports (a single contained cast on the app side).
+ */
+
+/** A `Workflow` row, matching `packages/database/schema/workflows.prisma`. */
+export interface WorkflowRow {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  name: string;
+  description: string | null;
+  status: TWorkflowStatus;
+  workspaceId: string;
+  createdBy: string | null;
+  definition: TWorkflowDefinition;
+}
+
+/** The subset of `WorkflowRun` fields the list/detail serializers read for `lastRun`. */
+export interface WorkflowRunRow {
+  id: string;
+  createdAt: Date;
+  updatedAt: Date;
+  workflowId: string;
+  workspaceId: string;
+  workflowVersionId: string | null;
+  responseId: string | null;
+  status: TWorkflowRunStatus;
+  triggerType: string;
+  surveyId: string | null;
+  isDryRun: boolean;
+  attempt: number;
+  error: string | null;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+}
+
+/** A workflow row with its most recent run eagerly loaded (for `lastRun`). */
+export type WorkflowRowWithLastRun = WorkflowRow & { runs: WorkflowRunRow[] };
+
+/** Eager-load shape for the most recent run; matches the Prisma `include` the adapter satisfies. */
+export interface LastRunInclude {
+  runs: { take: number; orderBy: { createdAt: "desc" } };
+}
+
+/** Narrow `where` filter the service builds — a deliberately small slice of Prisma's WhereInput. */
+export interface WorkflowWhereInput {
+  workspaceId?: string;
+  status?: TWorkflowStatus | { in: TWorkflowStatus[] } | { not: TWorkflowStatus };
+  name?: { contains: string; mode: "insensitive" } | { gt: string } | string;
+  id?: { gt: string } | { lt: string };
+  createdAt?: { lt: Date } | Date;
+  updatedAt?: { lt: Date } | Date;
+  OR?: WorkflowWhereInput[];
+}
+
+export interface WorkflowOrderByInput {
+  id?: "asc" | "desc";
+  name?: "asc" | "desc";
+  createdAt?: "asc" | "desc";
+  updatedAt?: "asc" | "desc";
+}
+
+/**
+ * The slice of `prisma.workflow` the service calls. The real Prisma delegate is structurally
+ * broader; the adapter bridges it to this port.
+ */
+export interface WorkflowDelegate {
+  findMany: (args: {
+    where: WorkflowWhereInput;
+    orderBy: WorkflowOrderByInput[];
+    take: number;
+    include: LastRunInclude;
+  }) => Promise<WorkflowRowWithLastRun[]>;
+  findUnique: (args: {
+    where: { id: string };
+    include: LastRunInclude;
+  }) => Promise<WorkflowRowWithLastRun | null>;
+  create: (args: {
+    data: {
+      workspaceId: string;
+      name: string;
+      description: string | null;
+      status: TWorkflowStatus;
+      definition: TWorkflowDefinition;
+      createdBy: string | null;
+    };
+    include: LastRunInclude;
+  }) => Promise<WorkflowRowWithLastRun>;
+}
+
+export interface WorkflowsDb {
+  workflow: WorkflowDelegate;
+}
+
+/**
+ * Minimal structural logger port. Satisfied by a request-bound `@formbricks/logger` child
+ * (`logger.withContext({ requestId })`). The package never imports the logger package directly.
+ */
+export interface WorkflowsLogger {
+  warn: (obj: object, msg?: string) => void;
+  error: (obj: object, msg?: string) => void;
+}

--- a/packages/workflows/src/services/ports.ts
+++ b/packages/workflows/src/services/ports.ts
@@ -1,5 +1,5 @@
 import type { TWorkflowStatus } from "../types/common";
-import type { TWorkflowDefinition } from "../types/document";
+import type { TWorkflowDefinition, TWorkflowExecutableDefinition } from "../types/document";
 import type { TWorkflowRunStatus } from "../types/runs";
 
 /**
@@ -10,8 +10,8 @@ import type { TWorkflowRunStatus } from "../types/runs";
  *
  * The row and delegate shapes are hand-authored from our own domain types (the row's
  * `definition`/`status` ARE our types) rather than imported from Prisma's generated client. This
- * keeps the package a dependency-free leaf; the adapter bridges the real Prisma client to these
- * ports (a single contained cast on the app side).
+ * keeps the package a dependency-free leaf; the real Prisma client structurally satisfies these
+ * ports, so the adapter wires it in directly — no cast required.
  */
 
 /** A `Workflow` row, matching `packages/database/schema/workflows.prisma`. */
@@ -98,10 +98,61 @@ export interface WorkflowDelegate {
     };
     include: LastRunInclude;
   }) => Promise<WorkflowRowWithLastRun>;
+  update: (args: {
+    where: { id_workspaceId: { id: string; workspaceId: string } };
+    data: {
+      name?: string;
+      description?: string | null;
+      status?: TWorkflowStatus;
+      definition?: TWorkflowDefinition;
+    };
+    include: LastRunInclude;
+  }) => Promise<WorkflowRowWithLastRun>;
+  delete: (args: {
+    where: { id_workspaceId: { id: string; workspaceId: string } };
+  }) => Promise<{ id: string }>;
+}
+
+/** A `WorkflowVersion` row (immutable executable snapshot), matching the Prisma schema. */
+export interface WorkflowVersionRow {
+  id: string;
+  workflowId: string;
+  workspaceId: string;
+  version: number;
+  definition: TWorkflowExecutableDefinition;
+  publishedAt: Date;
+  publishedBy: string | null;
+}
+
+/** The slice of `prisma.workflowVersion` the enable transaction calls. */
+export interface WorkflowVersionDelegate {
+  findFirst: (args: {
+    where: { workflowId: string };
+    orderBy: { version: "desc" };
+    select: { version: true };
+  }) => Promise<{ version: number } | null>;
+  create: (args: {
+    data: {
+      workflowId: string;
+      workspaceId: string;
+      version: number;
+      definition: TWorkflowExecutableDefinition;
+      publishedBy: string | null;
+    };
+  }) => Promise<WorkflowVersionRow>;
+}
+
+/** Delegates available inside an interactive transaction (the subset enable needs to be atomic). */
+export interface WorkflowsTransaction {
+  workflow: WorkflowDelegate;
+  workflowVersion: WorkflowVersionDelegate;
 }
 
 export interface WorkflowsDb {
   workflow: WorkflowDelegate;
+  workflowVersion: WorkflowVersionDelegate;
+  /** Interactive transaction; the real Prisma client's `$transaction` satisfies this structurally. */
+  $transaction: <R>(fn: (tx: WorkflowsTransaction) => Promise<R>) => Promise<R>;
 }
 
 /**

--- a/packages/workflows/src/services/workflows.service.test.ts
+++ b/packages/workflows/src/services/workflows.service.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { WorkflowDelegate, WorkflowRowWithLastRun, WorkflowsDb } from "./ports";
+import { createWorkflowsService } from "./workflows.service";
+
+const surveyId = "cm9zr4q7i000108l84gozfggr";
+const workspaceId = "cm9zr4mps000008l8btfy1vtz";
+
+const definition = {
+  schemaVersion: 1 as const,
+  trigger: {
+    id: "trigger",
+    type: "trigger" as const,
+    triggerType: "response.completed" as const,
+    config: { surveyId, endingCardIds: [] },
+  },
+  nodes: [
+    {
+      id: "send-email",
+      type: "action" as const,
+      actionType: "send_email" as const,
+      config: {
+        from: "noreply@example.com",
+        to: "support@example.com",
+        replyTo: ["support@example.com"],
+        subject: "Thanks",
+        body: "Thanks for your response.",
+        attachResponseData: true,
+      },
+    },
+  ],
+  edges: [{ id: "e1", source: "trigger", target: "send-email" }],
+  entryNodeId: "trigger",
+};
+
+const makeRow = (overrides: Partial<WorkflowRowWithLastRun> = {}): WorkflowRowWithLastRun => ({
+  id: "cm9zr4t2b000208l8h2m1aq3c",
+  createdAt: new Date("2026-06-11T09:30:00.000Z"),
+  updatedAt: new Date("2026-06-12T09:30:00.000Z"),
+  name: "Notify team",
+  description: null,
+  status: "draft",
+  workspaceId,
+  createdBy: null,
+  definition,
+  runs: [],
+  ...overrides,
+});
+
+const findMany = vi.fn<WorkflowDelegate["findMany"]>();
+const findUnique = vi.fn<WorkflowDelegate["findUnique"]>();
+const create = vi.fn<WorkflowDelegate["create"]>();
+const prisma: WorkflowsDb = { workflow: { findMany, findUnique, create } };
+const service = createWorkflowsService({ prisma });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createWorkflow", () => {
+  test("persists a draft with createdBy from the caller", async () => {
+    const row = makeRow();
+    create.mockResolvedValue(row);
+
+    const result = await service.createWorkflow(
+      { workspaceId, name: "Notify team", definition },
+      { createdBy: "cm9zr52kh000508l8e3q7bw9j" }
+    );
+
+    const createArgs = create.mock.calls[0][0];
+    expect(createArgs.data).toMatchObject({
+      workspaceId,
+      name: "Notify team",
+      status: "draft",
+      createdBy: "cm9zr52kh000508l8e3q7bw9j",
+    });
+    expect(createArgs.include).toEqual({ runs: { take: 1, orderBy: { createdAt: "desc" } } });
+    expect(result).toBe(row);
+  });
+
+  test("stores createdBy as null for API-key callers", async () => {
+    create.mockResolvedValue(makeRow());
+    await service.createWorkflow({ workspaceId, name: "X", definition }, { createdBy: null });
+    expect(create.mock.calls[0][0].data.createdBy).toBeNull();
+  });
+});
+
+describe("listWorkflows", () => {
+  test("excludes archived workflows by default and over-fetches by one", async () => {
+    findMany.mockResolvedValue([makeRow()]);
+
+    const page = await service.listWorkflows({ workspaceId, limit: 20, sortBy: "updatedAt" });
+
+    const findManyArgs = findMany.mock.calls[0][0];
+    expect(findManyArgs.where).toMatchObject({ workspaceId, status: { not: "archived" } });
+    expect(findManyArgs.take).toBe(21);
+    expect(findManyArgs.orderBy).toEqual([{ updatedAt: "desc" }, { id: "desc" }]);
+    expect(page.nextCursor).toBeNull();
+    expect(page.workflows).toHaveLength(1);
+  });
+
+  test("honors an explicit status filter", async () => {
+    findMany.mockResolvedValue([]);
+    await service.listWorkflows({
+      workspaceId,
+      limit: 20,
+      sortBy: "updatedAt",
+      statusIn: ["draft", "disabled"],
+    });
+    expect(findMany.mock.calls[0][0].where).toMatchObject({ status: { in: ["draft", "disabled"] } });
+  });
+
+  test("applies a case-insensitive name filter", async () => {
+    findMany.mockResolvedValue([]);
+    await service.listWorkflows({ workspaceId, limit: 20, sortBy: "name", nameContains: "csat" });
+    const findManyArgs = findMany.mock.calls[0][0];
+    expect(findManyArgs.where).toMatchObject({ name: { contains: "csat", mode: "insensitive" } });
+    expect(findManyArgs.orderBy).toEqual([{ name: "asc" }, { id: "asc" }]);
+  });
+
+  test("returns a next cursor when there are more rows than the limit", async () => {
+    const rows = [
+      makeRow({ id: "cm9zr4t2b000208l8h2m1aq30", updatedAt: new Date("2026-06-12T09:30:00.000Z") }),
+      makeRow({ id: "cm9zr4t2b000208l8h2m1aq31", updatedAt: new Date("2026-06-11T09:30:00.000Z") }),
+      makeRow({ id: "cm9zr4t2b000208l8h2m1aq32", updatedAt: new Date("2026-06-10T09:30:00.000Z") }),
+    ];
+    findMany.mockResolvedValue(rows);
+
+    const page = await service.listWorkflows({ workspaceId, limit: 2, sortBy: "updatedAt" });
+
+    expect(page.workflows).toHaveLength(2);
+    expect(page.nextCursor).toEqual(expect.any(String));
+  });
+});
+
+describe("getWorkflowById", () => {
+  test("loads a single row by id with its last run", async () => {
+    const row = makeRow();
+    findUnique.mockResolvedValue(row);
+
+    expect(await service.getWorkflowById(row.id)).toBe(row);
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { id: row.id },
+      include: { runs: { take: 1, orderBy: { createdAt: "desc" } } },
+    });
+  });
+
+  test("returns null when the workflow does not exist", async () => {
+    findUnique.mockResolvedValue(null);
+    expect(await service.getWorkflowById("missing")).toBeNull();
+  });
+});

--- a/packages/workflows/src/services/workflows.service.test.ts
+++ b/packages/workflows/src/services/workflows.service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import type { WorkflowDelegate, WorkflowRowWithLastRun, WorkflowsDb } from "./ports";
+import { WorkflowConflictError } from "../errors";
+import type { WorkflowDelegate, WorkflowRowWithLastRun, WorkflowVersionDelegate, WorkflowsDb } from "./ports";
 import { createWorkflowsService } from "./workflows.service";
 
 const surveyId = "cm9zr4q7i000108l84gozfggr";
@@ -49,7 +50,17 @@ const makeRow = (overrides: Partial<WorkflowRowWithLastRun> = {}): WorkflowRowWi
 const findMany = vi.fn<WorkflowDelegate["findMany"]>();
 const findUnique = vi.fn<WorkflowDelegate["findUnique"]>();
 const create = vi.fn<WorkflowDelegate["create"]>();
-const prisma: WorkflowsDb = { workflow: { findMany, findUnique, create } };
+const update = vi.fn<WorkflowDelegate["update"]>();
+const deleteFn = vi.fn<WorkflowDelegate["delete"]>();
+const versionFindFirst = vi.fn<WorkflowVersionDelegate["findFirst"]>();
+const versionCreate = vi.fn<WorkflowVersionDelegate["create"]>();
+const workflow = { findMany, findUnique, create, update, delete: deleteFn };
+const workflowVersion = { findFirst: versionFindFirst, create: versionCreate };
+const prisma: WorkflowsDb = {
+  workflow,
+  workflowVersion,
+  $transaction: (fn) => fn({ workflow, workflowVersion }),
+};
 const service = createWorkflowsService({ prisma });
 
 beforeEach(() => {
@@ -147,5 +158,139 @@ describe("getWorkflowById", () => {
   test("returns null when the workflow does not exist", async () => {
     findUnique.mockResolvedValue(null);
     expect(await service.getWorkflowById("missing")).toBeNull();
+  });
+});
+
+describe("updateWorkflow", () => {
+  test("updates only the provided fields by composite key", async () => {
+    update.mockResolvedValue(makeRow({ name: "Renamed" }));
+
+    await service.updateWorkflow(
+      { workflowId: "cm9zr4t2b000208l8h2m1aq3c", workspaceId },
+      { name: "Renamed" }
+    );
+
+    const args = update.mock.calls[0][0];
+    expect(args.where).toEqual({
+      id_workspaceId: { id: "cm9zr4t2b000208l8h2m1aq3c", workspaceId },
+    });
+    expect(args.data).toEqual({ name: "Renamed" });
+  });
+
+  test("passes through an explicit null description but omits absent fields", async () => {
+    update.mockResolvedValue(makeRow());
+    await service.updateWorkflow(
+      { workflowId: "cm9zr4t2b000208l8h2m1aq3c", workspaceId },
+      { description: null }
+    );
+    expect(update.mock.calls[0][0].data).toEqual({ description: null });
+  });
+});
+
+describe("duplicateWorkflow", () => {
+  test("clones into a new draft with a default copy name", async () => {
+    create.mockResolvedValue(makeRow());
+    await service.duplicateWorkflow(makeRow({ name: "Original" }), { createdBy: "user_1" });
+
+    expect(create.mock.calls[0][0].data).toMatchObject({
+      workspaceId,
+      name: "Original (copy)",
+      status: "draft",
+      createdBy: "user_1",
+    });
+  });
+
+  test("honors an explicit duplicate name", async () => {
+    create.mockResolvedValue(makeRow());
+    await service.duplicateWorkflow(makeRow({ name: "Original" }), { name: "Custom", createdBy: null });
+    expect(create.mock.calls[0][0].data.name).toBe("Custom");
+  });
+});
+
+describe("deleteWorkflow", () => {
+  test("hard-deletes by composite key", async () => {
+    deleteFn.mockResolvedValue({ id: "cm9zr4t2b000208l8h2m1aq3c" });
+    await service.deleteWorkflow({ workflowId: "cm9zr4t2b000208l8h2m1aq3c", workspaceId });
+    expect(deleteFn).toHaveBeenCalledWith({
+      where: { id_workspaceId: { id: "cm9zr4t2b000208l8h2m1aq3c", workspaceId } },
+    });
+  });
+});
+
+describe("setStatus", () => {
+  test("updates status by composite key", async () => {
+    update.mockResolvedValue(makeRow({ status: "archived" }));
+    await service.setStatus({ workflowId: "cm9zr4t2b000208l8h2m1aq3c", workspaceId }, "archived");
+    const args = update.mock.calls[0][0];
+    expect(args.where).toEqual({ id_workspaceId: { id: "cm9zr4t2b000208l8h2m1aq3c", workspaceId } });
+    expect(args.data).toEqual({ status: "archived" });
+  });
+});
+
+describe("enableWorkflow", () => {
+  test("snapshots version max+1 and flips status to enabled in one transaction", async () => {
+    versionFindFirst.mockResolvedValue({ version: 3 });
+    update.mockResolvedValue(makeRow({ status: "enabled" }));
+
+    const result = await service.enableWorkflow(
+      { workflowId: "cm9zr4t2b000208l8h2m1aq3c", workspaceId },
+      { definition, publishedBy: "cm9zr52kh000508l8e3q7bw9j" }
+    );
+
+    expect(versionCreate.mock.calls[0][0].data).toMatchObject({
+      workflowId: "cm9zr4t2b000208l8h2m1aq3c",
+      workspaceId,
+      version: 4,
+      publishedBy: "cm9zr52kh000508l8e3q7bw9j",
+    });
+    expect(update.mock.calls[0][0].data).toEqual({ status: "enabled" });
+    expect(result.status).toBe("enabled");
+  });
+
+  test("uses version 1 when no prior version exists and stores null publishedBy", async () => {
+    versionFindFirst.mockResolvedValue(null);
+    update.mockResolvedValue(makeRow({ status: "enabled" }));
+
+    await service.enableWorkflow(
+      { workflowId: "cm9zr4t2b000208l8h2m1aq3c", workspaceId },
+      { definition, publishedBy: null }
+    );
+
+    expect(versionCreate.mock.calls[0][0].data.version).toBe(1);
+    expect(versionCreate.mock.calls[0][0].data.publishedBy).toBeNull();
+  });
+
+  test("maps a concurrent-enable unique violation (P2002) to a conflict error", async () => {
+    versionFindFirst.mockResolvedValue({ version: 1 });
+    versionCreate.mockRejectedValue(Object.assign(new Error("Unique constraint failed"), { code: "P2002" }));
+
+    await expect(
+      service.enableWorkflow(
+        { workflowId: "cm9zr4t2b000208l8h2m1aq3c", workspaceId },
+        { definition, publishedBy: null }
+      )
+    ).rejects.toBeInstanceOf(WorkflowConflictError);
+  });
+
+  test("rethrows non-unique transaction errors unchanged", async () => {
+    const boom = new Error("connection reset");
+    versionFindFirst.mockRejectedValue(boom);
+
+    await expect(
+      service.enableWorkflow(
+        { workflowId: "cm9zr4t2b000208l8h2m1aq3c", workspaceId },
+        { definition, publishedBy: null }
+      )
+    ).rejects.toBe(boom);
+  });
+});
+
+describe("disableWorkflow", () => {
+  test("sets status to disabled by composite key", async () => {
+    update.mockResolvedValue(makeRow({ status: "disabled" }));
+    await service.disableWorkflow({ workflowId: "cm9zr4t2b000208l8h2m1aq3c", workspaceId });
+    const args = update.mock.calls[0][0];
+    expect(args.where).toEqual({ id_workspaceId: { id: "cm9zr4t2b000208l8h2m1aq3c", workspaceId } });
+    expect(args.data).toEqual({ status: "disabled" });
   });
 });

--- a/packages/workflows/src/services/workflows.service.test.ts
+++ b/packages/workflows/src/services/workflows.service.test.ts
@@ -52,9 +52,10 @@ const findUnique = vi.fn<WorkflowDelegate["findUnique"]>();
 const create = vi.fn<WorkflowDelegate["create"]>();
 const update = vi.fn<WorkflowDelegate["update"]>();
 const deleteFn = vi.fn<WorkflowDelegate["delete"]>();
+const updateMany = vi.fn<WorkflowDelegate["updateMany"]>();
 const versionFindFirst = vi.fn<WorkflowVersionDelegate["findFirst"]>();
 const versionCreate = vi.fn<WorkflowVersionDelegate["create"]>();
-const workflow = { findMany, findUnique, create, update, delete: deleteFn };
+const workflow = { findMany, findUnique, create, update, delete: deleteFn, updateMany };
 const workflowVersion = { findFirst: versionFindFirst, create: versionCreate };
 const prisma: WorkflowsDb = {
   workflow,
@@ -228,28 +229,34 @@ describe("setStatus", () => {
 });
 
 describe("enableWorkflow", () => {
-  test("snapshots version max+1 and flips status to enabled in one transaction", async () => {
+  test("guards the transition then snapshots version max+1 in one transaction", async () => {
+    updateMany.mockResolvedValue({ count: 1 });
     versionFindFirst.mockResolvedValue({ version: 3 });
-    update.mockResolvedValue(makeRow({ status: "enabled" }));
+    findUnique.mockResolvedValue(makeRow({ status: "enabled" }));
 
     const result = await service.enableWorkflow(
       { workflowId: "cm9zr4t2b000208l8h2m1aq3c", workspaceId },
       { definition, publishedBy: "cm9zr52kh000508l8e3q7bw9j" }
     );
 
+    // The status guard runs inside the transaction, scoped to draft/disabled rows only.
+    expect(updateMany.mock.calls[0][0]).toEqual({
+      where: { id: "cm9zr4t2b000208l8h2m1aq3c", workspaceId, status: { in: ["draft", "disabled"] } },
+      data: { status: "enabled" },
+    });
     expect(versionCreate.mock.calls[0][0].data).toMatchObject({
       workflowId: "cm9zr4t2b000208l8h2m1aq3c",
       workspaceId,
       version: 4,
       publishedBy: "cm9zr52kh000508l8e3q7bw9j",
     });
-    expect(update.mock.calls[0][0].data).toEqual({ status: "enabled" });
     expect(result.status).toBe("enabled");
   });
 
   test("uses version 1 when no prior version exists and stores null publishedBy", async () => {
+    updateMany.mockResolvedValue({ count: 1 });
     versionFindFirst.mockResolvedValue(null);
-    update.mockResolvedValue(makeRow({ status: "enabled" }));
+    findUnique.mockResolvedValue(makeRow({ status: "enabled" }));
 
     await service.enableWorkflow(
       { workflowId: "cm9zr4t2b000208l8h2m1aq3c", workspaceId },
@@ -260,7 +267,20 @@ describe("enableWorkflow", () => {
     expect(versionCreate.mock.calls[0][0].data.publishedBy).toBeNull();
   });
 
-  test("maps a concurrent-enable unique violation (P2002) to a conflict error", async () => {
+  test("rejects with a conflict (and writes no version) when the guard matches no row", async () => {
+    updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      service.enableWorkflow(
+        { workflowId: "cm9zr4t2b000208l8h2m1aq3c", workspaceId },
+        { definition, publishedBy: null }
+      )
+    ).rejects.toBeInstanceOf(WorkflowConflictError);
+    expect(versionCreate).not.toHaveBeenCalled();
+  });
+
+  test("maps a simultaneous-enable unique violation (P2002) to a conflict error", async () => {
+    updateMany.mockResolvedValue({ count: 1 });
     versionFindFirst.mockResolvedValue({ version: 1 });
     versionCreate.mockRejectedValue(Object.assign(new Error("Unique constraint failed"), { code: "P2002" }));
 
@@ -273,6 +293,7 @@ describe("enableWorkflow", () => {
   });
 
   test("rethrows non-unique transaction errors unchanged", async () => {
+    updateMany.mockResolvedValue({ count: 1 });
     const boom = new Error("connection reset");
     versionFindFirst.mockRejectedValue(boom);
 

--- a/packages/workflows/src/services/workflows.service.ts
+++ b/packages/workflows/src/services/workflows.service.ts
@@ -1,0 +1,123 @@
+import type { TCreateWorkflowInput, TListWorkflowsInput, TWorkflowSortBy } from "../contracts";
+import {
+  type TWorkflowListCursor,
+  buildNextWorkflowListCursor,
+  decodeWorkflowListCursor,
+  encodeWorkflowListCursor,
+} from "../handlers/cursor";
+import type {
+  LastRunInclude,
+  WorkflowOrderByInput,
+  WorkflowRowWithLastRun,
+  WorkflowWhereInput,
+  WorkflowsDb,
+} from "./ports";
+
+/** Eagerly load the most recent run so the serializer can emit `lastRun` without an N+1. */
+const LAST_RUN_INCLUDE: LastRunInclude = {
+  runs: { take: 1, orderBy: { createdAt: "desc" } },
+};
+
+const getOrderBy = (sortBy: TWorkflowSortBy): WorkflowOrderByInput[] => {
+  switch (sortBy) {
+    case "name":
+      return [{ name: "asc" }, { id: "asc" }];
+    case "createdAt":
+      return [{ createdAt: "desc" }, { id: "desc" }];
+    case "updatedAt":
+    default:
+      return [{ updatedAt: "desc" }, { id: "desc" }];
+  }
+};
+
+const buildCursorWhere = (cursor: TWorkflowListCursor): WorkflowWhereInput => {
+  if (cursor.sortBy === "name") {
+    return {
+      OR: [{ name: { gt: cursor.value } }, { name: cursor.value, id: { gt: cursor.id } }],
+    };
+  }
+
+  // createdAt / updatedAt sort descending → page towards older rows.
+  const value = new Date(cursor.value);
+  if (cursor.sortBy === "createdAt") {
+    return { OR: [{ createdAt: { lt: value } }, { createdAt: value, id: { lt: cursor.id } }] };
+  }
+  return { OR: [{ updatedAt: { lt: value } }, { updatedAt: value, id: { lt: cursor.id } }] };
+};
+
+const buildListWhere = (
+  input: TListWorkflowsInput,
+  cursor: TWorkflowListCursor | null
+): WorkflowWhereInput => ({
+  workspaceId: input.workspaceId,
+  // Default-exclude archived workflows unless the caller explicitly filters on status.
+  ...(input.statusIn ? { status: { in: input.statusIn } } : { status: { not: "archived" } }),
+  ...(input.nameContains ? { name: { contains: input.nameContains, mode: "insensitive" } } : {}),
+  ...(cursor ? buildCursorWhere(cursor) : {}),
+});
+
+export interface WorkflowListPage {
+  workflows: WorkflowRowWithLastRun[];
+  nextCursor: string | null;
+}
+
+export interface WorkflowsService {
+  listWorkflows: (input: TListWorkflowsInput) => Promise<WorkflowListPage>;
+  createWorkflow: (
+    input: TCreateWorkflowInput,
+    options: { createdBy: string | null }
+  ) => Promise<WorkflowRowWithLastRun>;
+  getWorkflowById: (workflowId: string) => Promise<WorkflowRowWithLastRun | null>;
+}
+
+/**
+ * Data-access layer for the v3 Workflows API. Prisma is injected (see `ports.ts`) so the package
+ * carries no runtime dependency on `@formbricks/database`. Inputs are already validated by the
+ * contract schemas at the handler boundary, so the service does not re-parse them. DB errors are
+ * allowed to bubble to the handler's error mapper (logged there once, as a 500).
+ */
+export const createWorkflowsService = ({ prisma }: { prisma: WorkflowsDb }): WorkflowsService => ({
+  async listWorkflows(input) {
+    const cursor = input.cursor ? decodeWorkflowListCursor(input.cursor, input.sortBy) : null;
+
+    const rows = await prisma.workflow.findMany({
+      where: buildListWhere(input, cursor),
+      orderBy: getOrderBy(input.sortBy),
+      take: input.limit + 1,
+      include: LAST_RUN_INCLUDE,
+    });
+
+    const hasMore = rows.length > input.limit;
+    const workflows = hasMore ? rows.slice(0, input.limit) : rows;
+    const lastRow = workflows.at(-1);
+
+    return {
+      workflows,
+      nextCursor:
+        hasMore && lastRow
+          ? encodeWorkflowListCursor(buildNextWorkflowListCursor(lastRow, input.sortBy))
+          : null,
+    };
+  },
+
+  async createWorkflow(input, { createdBy }) {
+    return prisma.workflow.create({
+      data: {
+        workspaceId: input.workspaceId,
+        name: input.name,
+        description: input.description ?? null,
+        status: "draft",
+        definition: input.definition,
+        createdBy,
+      },
+      include: LAST_RUN_INCLUDE,
+    });
+  },
+
+  async getWorkflowById(workflowId) {
+    return prisma.workflow.findUnique({
+      where: { id: workflowId },
+      include: LAST_RUN_INCLUDE,
+    });
+  },
+});

--- a/packages/workflows/src/services/workflows.service.ts
+++ b/packages/workflows/src/services/workflows.service.ts
@@ -1,22 +1,67 @@
 import type { TCreateWorkflowInput, TListWorkflowsInput, TWorkflowSortBy } from "../contracts";
+import { WorkflowConflictError } from "../errors";
 import {
   type TWorkflowListCursor,
   buildNextWorkflowListCursor,
   decodeWorkflowListCursor,
   encodeWorkflowListCursor,
 } from "../handlers/cursor";
+import type { TWorkflowStatus } from "../types/common";
+import type { TWorkflowDefinition, TWorkflowExecutableDefinition } from "../types/document";
 import type {
   LastRunInclude,
+  WorkflowDelegate,
   WorkflowOrderByInput,
   WorkflowRowWithLastRun,
   WorkflowWhereInput,
   WorkflowsDb,
 } from "./ports";
 
+/** Identifies one workflow within its workspace, for composite-key (`id`, `workspaceId`) scoping. */
+export interface WorkflowScopedParams {
+  workflowId: string;
+  workspaceId: string;
+}
+
+/** Fields a patch may persist. `status` is changed only through the lifecycle methods, never here. */
+export interface WorkflowUpdateInput {
+  name?: string;
+  description?: string | null;
+  definition?: TWorkflowDefinition;
+}
+
 /** Eagerly load the most recent run so the serializer can emit `lastRun` without an N+1. */
 const LAST_RUN_INCLUDE: LastRunInclude = {
   runs: { take: 1, orderBy: { createdAt: "desc" } },
 };
+
+/** Every field a workflow update may set; mirrors the injected delegate's `update` data shape. */
+type WorkflowUpdateData = Parameters<WorkflowDelegate["update"]>[0]["data"];
+
+/**
+ * Single place that issues a workspace-scoped `workflow.update` with the standard last-run include.
+ * The delegate is passed explicitly so it serves both the base client and an interactive transaction.
+ */
+const updateWorkflowRow = (
+  workflow: WorkflowDelegate,
+  { workflowId, workspaceId }: WorkflowScopedParams,
+  data: WorkflowUpdateData
+): Promise<WorkflowRowWithLastRun> =>
+  workflow.update({
+    where: { id_workspaceId: { id: workflowId, workspaceId } },
+    data,
+    include: LAST_RUN_INCLUDE,
+  });
+
+// Prisma's unique-constraint violation code, mirroring `PrismaErrorType.UniqueConstraintViolation`
+// in `@formbricks/database` — which this leaf package can't import without recreating a build cycle.
+const PRISMA_UNIQUE_CONSTRAINT_VIOLATION = "P2002";
+
+/** Duck-typed P2002 detection — keeps the package free of a `@prisma/client` dependency. */
+const isUniqueConstraintError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (error as { code?: unknown }).code === PRISMA_UNIQUE_CONSTRAINT_VIOLATION;
 
 const getOrderBy = (sortBy: TWorkflowSortBy): WorkflowOrderByInput[] => {
   switch (sortBy) {
@@ -68,6 +113,21 @@ export interface WorkflowsService {
     options: { createdBy: string | null }
   ) => Promise<WorkflowRowWithLastRun>;
   getWorkflowById: (workflowId: string) => Promise<WorkflowRowWithLastRun | null>;
+  updateWorkflow: (
+    params: WorkflowScopedParams,
+    data: WorkflowUpdateInput
+  ) => Promise<WorkflowRowWithLastRun>;
+  duplicateWorkflow: (
+    source: WorkflowRowWithLastRun,
+    options: { name?: string; createdBy: string | null }
+  ) => Promise<WorkflowRowWithLastRun>;
+  deleteWorkflow: (params: WorkflowScopedParams) => Promise<void>;
+  setStatus: (params: WorkflowScopedParams, status: TWorkflowStatus) => Promise<WorkflowRowWithLastRun>;
+  enableWorkflow: (
+    params: WorkflowScopedParams,
+    options: { definition: TWorkflowExecutableDefinition; publishedBy: string | null }
+  ) => Promise<WorkflowRowWithLastRun>;
+  disableWorkflow: (params: WorkflowScopedParams) => Promise<WorkflowRowWithLastRun>;
 }
 
 /**
@@ -119,5 +179,73 @@ export const createWorkflowsService = ({ prisma }: { prisma: WorkflowsDb }): Wor
       where: { id: workflowId },
       include: LAST_RUN_INCLUDE,
     });
+  },
+
+  async updateWorkflow({ workflowId, workspaceId }, data) {
+    return updateWorkflowRow(
+      prisma.workflow,
+      { workflowId, workspaceId },
+      {
+        ...(data.name !== undefined ? { name: data.name } : {}),
+        ...(data.description !== undefined ? { description: data.description } : {}),
+        ...(data.definition !== undefined ? { definition: data.definition } : {}),
+      }
+    );
+  },
+
+  async duplicateWorkflow(source, { name, createdBy }) {
+    return prisma.workflow.create({
+      data: {
+        workspaceId: source.workspaceId,
+        name: name ?? `${source.name} (copy)`,
+        description: source.description,
+        status: "draft",
+        definition: source.definition,
+        createdBy,
+      },
+      include: LAST_RUN_INCLUDE,
+    });
+  },
+
+  async deleteWorkflow({ workflowId, workspaceId }) {
+    // Hard delete; Prisma `onDelete: Cascade` removes the workflow's runs + run logs (GDPR).
+    await prisma.workflow.delete({ where: { id_workspaceId: { id: workflowId, workspaceId } } });
+  },
+
+  async setStatus({ workflowId, workspaceId }, status) {
+    return updateWorkflowRow(prisma.workflow, { workflowId, workspaceId }, { status });
+  },
+
+  async enableWorkflow({ workflowId, workspaceId }, { definition, publishedBy }) {
+    // Atomic: snapshot an immutable version (version = max + 1) and flip status in one transaction,
+    // so an enabled workflow always has a live version to run against. The executable `definition`
+    // is validated by the handler; the service trusts it.
+    try {
+      return await prisma.$transaction(async (tx) => {
+        const latest = await tx.workflowVersion.findFirst({
+          where: { workflowId },
+          orderBy: { version: "desc" },
+          select: { version: true },
+        });
+
+        await tx.workflowVersion.create({
+          data: { workflowId, workspaceId, version: (latest?.version ?? 0) + 1, definition, publishedBy },
+        });
+
+        return updateWorkflowRow(tx.workflow, { workflowId, workspaceId }, { status: "enabled" });
+      });
+    } catch (error) {
+      // Concurrent enable: two requests read the same max version and both insert version+1; the
+      // loser violates @@unique([workflowId, version]). The transaction has already rolled back
+      // cleanly, so surface a retryable 409 instead of a generic 500.
+      if (isUniqueConstraintError(error)) {
+        throw new WorkflowConflictError("The workflow was just enabled by another request. Please retry.");
+      }
+      throw error;
+    }
+  },
+
+  async disableWorkflow({ workflowId, workspaceId }) {
+    return updateWorkflowRow(prisma.workflow, { workflowId, workspaceId }, { status: "disabled" });
   },
 });

--- a/packages/workflows/src/services/workflows.service.ts
+++ b/packages/workflows/src/services/workflows.service.ts
@@ -217,27 +217,44 @@ export const createWorkflowsService = ({ prisma }: { prisma: WorkflowsDb }): Wor
   },
 
   async enableWorkflow({ workflowId, workspaceId }, { definition, publishedBy }) {
-    // Atomic: snapshot an immutable version (version = max + 1) and flip status in one transaction,
-    // so an enabled workflow always has a live version to run against. The executable `definition`
-    // is validated by the handler; the service trusts it.
+    // Enable atomically. The state guard lives INSIDE the transaction: a conditional updateMany flips
+    // exactly one draft/disabled row to enabled. The row lock serializes concurrent enables, so a
+    // request that lost the race reads `count: 0` and is rejected here — a workflow can never be
+    // enabled twice (nor gain a duplicate version) by a check that passed before the transaction. The
+    // version snapshot (version = max + 1) is written in the same transaction, so an enabled workflow
+    // always has a live version. The executable `definition` is validated by the handler.
     try {
       return await prisma.$transaction(async (tx) => {
+        const { count } = await tx.workflow.updateMany({
+          where: { id: workflowId, workspaceId, status: { in: ["draft", "disabled"] } },
+          data: { status: "enabled" },
+        });
+        if (count !== 1) {
+          throw new WorkflowConflictError("The workflow is no longer in a state that can be enabled.");
+        }
+
         const latest = await tx.workflowVersion.findFirst({
           where: { workflowId },
           orderBy: { version: "desc" },
           select: { version: true },
         });
-
         await tx.workflowVersion.create({
           data: { workflowId, workspaceId, version: (latest?.version ?? 0) + 1, definition, publishedBy },
         });
 
-        return updateWorkflowRow(tx.workflow, { workflowId, workspaceId }, { status: "enabled" });
+        const enabled = await tx.workflow.findUnique({
+          where: { id: workflowId },
+          include: LAST_RUN_INCLUDE,
+        });
+        if (!enabled) {
+          throw new WorkflowConflictError("The workflow no longer exists.");
+        }
+        return enabled;
       });
     } catch (error) {
-      // Concurrent enable: two requests read the same max version and both insert version+1; the
-      // loser violates @@unique([workflowId, version]). The transaction has already rolled back
-      // cleanly, so surface a retryable 409 instead of a generic 500.
+      // Belt-and-suspenders for the simultaneous case: if two transactions read the same max version
+      // before either commits, the second `workflowVersion.create` violates @@unique([workflowId,
+      // version]). The transaction has rolled back cleanly, so surface a retryable 409.
       if (isUniqueConstraintError(error)) {
         throw new WorkflowConflictError("The workflow was just enabled by another request. Please retry.");
       }

--- a/packages/workflows/vite.config.ts
+++ b/packages/workflows/vite.config.ts
@@ -7,12 +7,18 @@ export default defineConfig({
   build: {
     minify: false,
     lib: {
-      entry: resolve(__dirname, "src/index.ts"),
-      fileName: "index",
+      // Two entries: the browser-safe contracts/types (`.`) and the server-only handlers/service
+      // (`./server`). Keeping them separate stops Prisma/runtime concerns from leaking into the
+      // browser bundle that the dashboard imports.
+      entry: {
+        index: resolve(__dirname, "src/index.ts"),
+        server: resolve(__dirname, "src/server/index.ts"),
+      },
       formats: ["es"],
     },
     rollupOptions: {
-      external: ["zod"],
+      // `@prisma/client` is type-only here and is provided by the host app at runtime; never bundle it.
+      external: ["zod", "@prisma/client", "server-only", /^node:/],
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       '@formbricks/types':
         specifier: workspace:*
         version: link:../../packages/types
+      '@formbricks/workflows':
+        specifier: workspace:*
+        version: link:../../packages/workflows
       '@hookform/resolvers':
         specifier: 5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.6))


### PR DESCRIPTION
## What does this PR do?

Closes [ENG-1221](https://linear.app/formbricks/issue/ENG-1221/api-create-list-and-get-workflows)

Implements the first v3 **Workflows** runtime endpoints — `createWorkflowV3`, `listWorkflowsV3`, `getWorkflowV3` — against the contract merged earlier. It also establishes the reusable package scaffolding (service, framework-agnostic handlers, context, serializers, error→problem mapper) that ENG-1222 (update/duplicate/delete) and ENG-1223 (enable/disable) build on. No runners, lifecycle transitions, or UI.

### Architecture (per the ticket)

Business logic **and** web-standard HTTP handlers live in `@formbricks/workflows` and stay framework-agnostic (no `apps/web`/Next imports); the Next routes are thin adapters that authenticate, build a context, and delegate.

- **`@formbricks/workflows/server`** (new subpath export; the `.` entry stays browser-safe/zod-only):
  - `services/workflows.service.ts` — `list` / `create` / `getById` (keyset pagination, `lastRun` include, composite-key scoping).
  - `handlers/` — `(req, ctx)` handlers, `context.ts` (`WorkflowApiContext`), `cursor.ts` (sort-bound base64url cursor), `parse-list-query.ts`, `serializers.ts`.
  - `errors.ts` — typed domain errors + one RFC 9457 problem mapper (+ `validateOutput`); `responses.ts` + `http.ts` — success envelopes/headers.
- **`apps/web/app/api/v3/workflows/`** — `route.ts` (GET list + POST create), `[workflowId]/route.ts` (GET); `lib/context.ts` injects `prisma`/`logger` and binds `authorize` to `requireV3WorkspaceAccess`. Adds `"workflow"` to `ZAuditTarget` and wires the dep + `transpilePackages`.

### Key decisions

- **Dependency injection over a `@formbricks/database` import.** `@formbricks/database` already imports `@formbricks/workflows`, so a runtime edge back would create a package build cycle. The service takes `prisma`/`logger` as injected ports (row/delegate types hand-authored from our own domain types), keeping the package a zero-dependency turbo leaf — **no `turbo.json` change, no `@prisma/client` dependency, no cycle**.
- **403, not 404**, for unknown/cross-workspace ids (no existence leak); `archived` excluded from list by default; **serialized output is validated against the resource schema** before returning (a serializer bug is a logged 500, never a malformed 200).
- The package owns its problem/envelope/cursor helpers because it can't import `apps/web`; a future shared `@formbricks/http-problem` package could de-duplicate that with the survey API (out of scope).

## How should this be tested?

- `pnpm --filter @formbricks/workflows test` → **74 passed** (service, handlers, cursor, serializers, contract/spec-drift).
- `pnpm --filter @formbricks/workflows typecheck && pnpm --filter @formbricks/workflows lint && pnpm --filter @formbricks/workflows build` → clean (publint OK; `dist/server.js` carries no Prisma).
- `pnpm turbo run typecheck --filter=@formbricks/web` → passes (adapter compiles against `/server`; no turbo cycle).
- `pnpm api:v3:check` → spec bundle in sync (contract unchanged, no drift).
- Manual (dev DB + `x-api-key`):
  - `POST /api/v3/workflows` → 201 + `Location`, `status: "draft"`, `createdBy` set; invalid `definition` → 400 with `invalid_params`.
  - `GET /api/v3/workflows?workspaceId=…&filter[status][in]=draft&sortBy=name` → paginates, excludes archived, `lastRun` populated.
  - `GET /api/v3/workflows/{id}` → 200; unknown/foreign id → 403; audit event queued on create.

> Note: `lib/survey/service.scheduling.test.ts` and `modules/survey/scheduling/lib/date-utils.test.ts` fail **locally on Node 26** (below the repo's supported engine range, a timezone-normalization issue). Confirmed pre-existing — they fail identically on the base branch with this PR's changes stashed, and are unrelated to workflows.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits (ports/DI rationale, cursor, error mapper, output validation)
- [ ] Ran `pnpm build` — ran `@formbricks/workflows` build + `@formbricks/web` typecheck; routes are thin adapters with no UI/build surface
- [x] Checked for warnings, there are none (package lint/typecheck clean)
- [x] Removed all `console.logs` (structured `@formbricks/logger` only)
- [x] Merged the latest changes from the base branch (`epic/workflows-v1`) onto my branch
- [x] My changes don't cause any responsiveness issues (no UI changes)
- [ ] First PR at Formbricks? — N/A

### Appreciated

- [ ] If a UI change was made: screenshots — N/A (API only)
- [x] Updated the Formbricks Docs if changes were necessary — OpenAPI contract already covers these endpoints (kept honest by `spec-drift.test.ts`); user-facing docs are ENG-1232
