### PR TITLE
feat: add docker qwen taxonomy setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,37 @@ HUB_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/hub?sslmode=disabl
 # EMBEDDING_MODEL=gemini-embedding-001
 # EMBEDDING_PROVIDER_API_KEY=
 
+##########################
+#  AI TAXONOMY (BETA)    #
+##########################
+# Optional. Enables the standalone taxonomy service in Docker Compose.
+# Docker/self-hosting users can enable it with COMPOSE_PROFILES=taxonomy.
+# Use COMPOSE_PROFILES=qwen,taxonomy when taxonomy should use the bundled
+# Qwen/vLLM service from this Compose stack.
+# TAXONOMY_SERVICE_URL=http://taxonomy:8000
+# TAXONOMY_SERVICE_TOKEN=<strong-random-secret>
+# HUB_INTERNAL_API_TOKEN=<strong-random-secret>
+# TAXONOMY_IMAGE_REF=:latest
+#
+# Taxonomy cluster labeling and tree generation use an OpenAI-compatible
+# chat-completions endpoint by default. The recommended self-hosted path is
+# Qwen served by vLLM through an OpenAI-compatible /v1 endpoint; the model must
+# reliably return strict JSON for 5-level taxonomy generation.
+# TAXONOMY_LLM_PROVIDER=openai-compatible
+# TAXONOMY_LLM_MODEL=qwen3-14b-awq
+# TAXONOMY_LLM_BASE_URL=http://vllm:8000/v1
+# TAXONOMY_LLM_API_KEY=<api-key-or-dummy-value>
+#
+# Advanced optional override. Defaults to 50000; prefer sizing CPU, memory, and
+# LLM capacity for production workloads instead of capping records by default.
+# TAXONOMY_MAX_RECORDS=50000
+#
+# Optional Bedrock provider instead of OpenAI-compatible:
+# TAXONOMY_LLM_PROVIDER=bedrock
+# TAXONOMY_LLM_MODEL=eu.anthropic.claude-sonnet-4-5-20250929-v1:0
+# AWS_REGION=eu-north-1
+# AWS_BEARER_TOKEN_BEDROCK=
+
 ####################
 #  CUBE ANALYTICS  #
 ####################
@@ -224,6 +255,9 @@ AZUREAD_TENANT_ID=
 
 # OpenAI-compatible provider (self-hosted Qwen on a vLLM OpenAI-compatible /v1 server)
 # Supported for self-hosted LLM GA v1: Qwen models served via vLLM only.
+#
+# Docker Compose users can either run their own endpoint and set AI_OPENAI_COMPATIBLE_BASE_URL
+# to that URL, or enable the bundled Qwen/vLLM service with COMPOSE_PROFILES=qwen and:
 # AI_PROVIDER=openai-compatible
 # AI_MODEL=qwen3-14b-awq
 # AI_OPENAI_COMPATIBLE_BASE_URL=http://vllm:8000/v1
@@ -232,6 +266,16 @@ AZUREAD_TENANT_ID=
 # AI_OPENAI_COMPATIBLE_SUPPORTS_STRUCTURED_OUTPUTS=1
 # AI_OPENAI_COMPATIBLE_HEADERS_JSON=
 # AI_OPENAI_COMPATIBLE_QUERY_PARAMS_JSON=
+#
+# Optional bundled Qwen/vLLM Docker Compose overrides.
+# QWEN_VLLM_IMAGE=vllm/vllm-openai:v0.14.0
+# QWEN_MODEL_ID=Qwen/Qwen3-14B-AWQ
+# QWEN_SERVED_MODEL_NAME=qwen3-14b-awq
+# QWEN_MAX_MODEL_LEN=8192
+# QWEN_MAX_NUM_SEQS=8
+# QWEN_GPU_MEMORY_UTILIZATION=0.9
+# QWEN_VLLM_HOST=127.0.0.1
+# QWEN_VLLM_PORT=8000
 
 # OpenID Connect (OIDC) configuration
 # OIDC_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -84,8 +84,8 @@ HUB_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/hub?sslmode=disabl
 # Use COMPOSE_PROFILES=qwen,taxonomy when taxonomy should use the bundled
 # Qwen/vLLM service from this Compose stack.
 # TAXONOMY_SERVICE_URL=http://taxonomy:8000
-# TAXONOMY_SERVICE_TOKEN=<strong-random-secret>
-# HUB_INTERNAL_API_TOKEN=<strong-random-secret>
+# TAXONOMY_SERVICE_TOKEN=<random-strong-secret>
+# HUB_INTERNAL_API_TOKEN=<random-strong-secret>
 # Pin a released taxonomy image in production, for example :v0.1.0.
 # TAXONOMY_IMAGE_REF=:v0.1.0
 #

--- a/.env.example
+++ b/.env.example
@@ -86,7 +86,8 @@ HUB_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/hub?sslmode=disabl
 # TAXONOMY_SERVICE_URL=http://taxonomy:8000
 # TAXONOMY_SERVICE_TOKEN=<strong-random-secret>
 # HUB_INTERNAL_API_TOKEN=<strong-random-secret>
-# TAXONOMY_IMAGE_REF=:latest
+# Pin a released taxonomy image in production, for example :v0.1.0.
+# TAXONOMY_IMAGE_REF=:v0.1.0
 #
 # Taxonomy cluster labeling and tree generation use an OpenAI-compatible
 # chat-completions endpoint by default. The recommended self-hosted path is

--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -180,6 +180,48 @@ jobs:
             fi
           done
 
+      - name: Validate taxonomy service env rendering
+        run: |
+          set -euo pipefail
+
+          values_file="$(mktemp)"
+          trap 'rm -f "$values_file"' EXIT
+
+          cat > "$values_file" <<'YAML'
+          formbricks:
+            webappUrl: https://qa.example.com
+
+          llm:
+            enabled: true
+
+          taxonomy:
+            enabled: true
+          YAML
+
+          rendered="$(helm template qa charts/formbricks \
+            -f "$values_file" \
+            --show-only templates/hub-deployment.yaml \
+            --show-only templates/taxonomy-secret.yaml \
+            --show-only templates/taxonomy-service.yaml \
+            --show-only templates/taxonomy-deployment.yaml)"
+
+          for expected in \
+            "name: formbricks-taxonomy" \
+            "image: \"ghcr.io/formbricks/taxonomy:v0.1.0\"" \
+            "name: TAXONOMY_SERVICE_URL" \
+            "value: \"http://formbricks-taxonomy:8000\"" \
+            "name: HUB_INTERNAL_API_URL" \
+            "value: \"http://formbricks-hub:8080\"" \
+            "name: TAXONOMY_LLM_BASE_URL" \
+            "value: \"http://qa-router-service:8000/v1\"" \
+            "key: TAXONOMY_SERVICE_TOKEN" \
+            "key: HUB_INTERNAL_API_TOKEN"; do
+            if ! grep -F "$expected" <<< "$rendered" >/dev/null; then
+              echo "Expected Helm render to contain: $expected"
+              exit 1
+            fi
+          done
+
       - name: Package Helm chart
         env:
           VERSION: ${{ env.VERSION }}

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -153,6 +153,50 @@ externalSecret:
             property: apiKey
 ```
 
+## AI Taxonomy Beta
+
+The chart can optionally deploy the standalone AI taxonomy service. It is disabled by default and remains internal
+to the cluster through a `ClusterIP` service.
+
+To deploy taxonomy and reuse the bundled Qwen/vLLM runtime:
+
+```yaml
+llm:
+  enabled: true
+
+taxonomy:
+  enabled: true
+```
+
+When `taxonomy.enabled=true`, the chart creates the taxonomy Deployment, Service, and Secret, then injects these
+Hub API env vars unless `taxonomy.autoConfigureHub=false`:
+
+```yaml
+TAXONOMY_SERVICE_URL: http://formbricks-taxonomy:8000
+TAXONOMY_SERVICE_TOKEN: <from taxonomy auth secret>
+HUB_INTERNAL_API_TOKEN: <from taxonomy auth secret>
+```
+
+If `llm.enabled=true` and `taxonomy.llm.baseUrl` is empty, taxonomy uses the bundled vLLM router at
+`http://<release-name>-router-service:8000/v1`. To use an external OpenAI-compatible LLM instead:
+
+```yaml
+taxonomy:
+  enabled: true
+  llm:
+    model: qwen3-14b-awq
+    baseUrl: http://my-llm-gateway:8000/v1
+    existingSecret: taxonomy-llm-secret
+```
+
+The taxonomy service exposes public `/health` only for Kubernetes probes. Use authenticated `/v1/preflight` as an
+operator check after install:
+
+```sh
+kubectl exec -n formbricks deploy/formbricks-taxonomy -- \
+  python -c 'import os, urllib.request; req = urllib.request.Request("http://127.0.0.1:8000/v1/preflight", headers={"Authorization": "Bearer " + os.environ["TAXONOMY_SERVICE_TOKEN"]}); print(urllib.request.urlopen(req, timeout=10).read().decode())'
+```
+
 ## Values
 
 | Key                                                                | Type   | Default                                                                     | Description                                               |
@@ -409,3 +453,12 @@ externalSecret:
 | serviceMonitor.endpoints[0].interval                               | string | `"5s"`                                                                      |                                                           |
 | serviceMonitor.endpoints[0].path                                   | string | `"/metrics"`                                                                |                                                           |
 | serviceMonitor.endpoints[0].port                                   | string | `"metrics"`                                                                 |                                                           |
+| taxonomy.autoConfigureHub                                          | bool   | `true`                                                                      | Inject taxonomy service env vars into Hub API when taxonomy is enabled. |
+| taxonomy.enabled                                                   | bool   | `false`                                                                     | Deploy the optional standalone taxonomy service.          |
+| taxonomy.image.repository                                          | string | `"ghcr.io/formbricks/taxonomy"`                                             | Taxonomy service image repository.                        |
+| taxonomy.image.tag                                                 | string | `"v0.1.0"`                                                                  | Taxonomy service image tag.                               |
+| taxonomy.llm.baseUrl                                               | string | `""`                                                                        | Defaults to bundled vLLM router URL when `llm.enabled=true`; set for external LLMs. |
+| taxonomy.llm.existingSecret                                        | string | `""`                                                                        | Existing secret containing `TAXONOMY_LLM_API_KEY`.        |
+| taxonomy.llm.model                                                 | string | `"qwen3-14b-awq"`                                                           | LLM model used by taxonomy labeling and tree generation.  |
+| taxonomy.llm.provider                                              | string | `"openai-compatible"`                                                       | Taxonomy LLM provider.                                    |
+| taxonomy.service.type                                              | string | `"ClusterIP"`                                                               | Internal taxonomy service type.                           |

--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -209,6 +209,134 @@ Hub worker resource name.
 {{- end }}
 
 {{/*
+Taxonomy service resource name.
+*/}}
+{{- define "formbricks.taxonomyName" -}}
+{{- $base := include "formbricks.name" . | trunc 54 | trimSuffix "-" }}
+{{- printf "%s-taxonomy" $base | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Taxonomy service image reference. A configured digest takes precedence over the tag.
+*/}}
+{{- define "formbricks.taxonomyImage" -}}
+{{- if .Values.taxonomy.image.digest -}}
+{{- printf "%s@%s" .Values.taxonomy.image.repository .Values.taxonomy.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.taxonomy.image.repository (.Values.taxonomy.image.tag | default "latest") -}}
+{{- end -}}
+{{- end }}
+
+{{- define "formbricks.taxonomyManagedSecretName" -}}
+{{- printf "%s-secret" (include "formbricks.taxonomyName" .) -}}
+{{- end }}
+
+{{- define "formbricks.taxonomyAuthSecretName" -}}
+{{- default (include "formbricks.taxonomyManagedSecretName" .) .Values.taxonomy.auth.existingSecret -}}
+{{- end }}
+
+{{- define "formbricks.taxonomyLlmSecretName" -}}
+{{- default (include "formbricks.taxonomyManagedSecretName" .) .Values.taxonomy.llm.existingSecret -}}
+{{- end }}
+
+{{- define "formbricks.taxonomyServiceUrl" -}}
+{{- printf "http://%s:%v" (include "formbricks.taxonomyName" .) (.Values.taxonomy.service.port | default .Values.taxonomy.port) -}}
+{{- end }}
+
+{{- define "formbricks.taxonomyLlmBaseUrl" -}}
+{{- if .Values.taxonomy.llm.baseUrl -}}
+{{- include "formbricks.tplvalues.render" (dict "value" .Values.taxonomy.llm.baseUrl "context" .) -}}
+{{- else if .Values.llm.enabled -}}
+{{- include "formbricks.llmBaseUrl" . -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end }}
+
+{{- define "formbricks.taxonomyServiceToken" -}}
+{{- $secretName := include "formbricks.taxonomyManagedSecretName" . }}
+{{- $secretKey := .Values.taxonomy.auth.serviceTokenKey | default "TAXONOMY_SERVICE_TOKEN" }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
+{{- $secretData := dig "data" dict $secret }}
+{{- if index $secretData $secretKey }}
+    {{- index $secretData $secretKey | b64dec -}}
+{{- else if .Values.taxonomy.auth.serviceToken }}
+    {{- .Values.taxonomy.auth.serviceToken -}}
+{{- else }}
+    {{- randAlphaNum 48 -}}
+{{- end -}}
+{{- end }}
+
+{{- define "formbricks.taxonomyHubInternalApiToken" -}}
+{{- $secretName := include "formbricks.taxonomyManagedSecretName" . }}
+{{- $secretKey := .Values.taxonomy.auth.hubInternalApiTokenKey | default "HUB_INTERNAL_API_TOKEN" }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
+{{- $secretData := dig "data" dict $secret }}
+{{- if index $secretData $secretKey }}
+    {{- index $secretData $secretKey | b64dec -}}
+{{- else if .Values.taxonomy.auth.hubInternalApiToken }}
+    {{- .Values.taxonomy.auth.hubInternalApiToken -}}
+{{- else }}
+    {{- randAlphaNum 48 -}}
+{{- end -}}
+{{- end }}
+
+{{- define "formbricks.taxonomyLlmApiKey" -}}
+{{- $secretName := include "formbricks.taxonomyManagedSecretName" . }}
+{{- $secretKey := .Values.taxonomy.llm.apiKeySecretKey | default "TAXONOMY_LLM_API_KEY" }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
+{{- $secretData := dig "data" dict $secret }}
+{{- if index $secretData $secretKey }}
+    {{- index $secretData $secretKey | b64dec -}}
+{{- else if .Values.taxonomy.llm.apiKey }}
+    {{- .Values.taxonomy.llm.apiKey -}}
+{{- else }}
+    {{- randAlphaNum 32 -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Hub env managed by taxonomy when the optional taxonomy service is enabled.
+*/}}
+{{- define "formbricks.taxonomyHubEnv" -}}
+{{- $root := .root -}}
+{{- if and $root.Values.taxonomy.enabled $root.Values.taxonomy.autoConfigureHub }}
+- name: TAXONOMY_SERVICE_URL
+  value: {{ include "formbricks.taxonomyServiceUrl" $root | quote }}
+- name: TAXONOMY_SERVICE_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "formbricks.taxonomyAuthSecretName" $root }}
+      key: {{ $root.Values.taxonomy.auth.serviceTokenKey | default "TAXONOMY_SERVICE_TOKEN" }}
+- name: HUB_INTERNAL_API_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "formbricks.taxonomyAuthSecretName" $root }}
+      key: {{ $root.Values.taxonomy.auth.hubInternalApiTokenKey | default "HUB_INTERNAL_API_TOKEN" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Returns true when an env var is managed by taxonomy auto-configuration and should not be rendered from hub.env.
+*/}}
+{{- define "formbricks.taxonomyHubEnvManaged" -}}
+{{- $key := .key -}}
+{{- if has $key (list "TAXONOMY_SERVICE_URL" "TAXONOMY_SERVICE_TOKEN" "HUB_INTERNAL_API_TOKEN") -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Returns true when an env var is managed by the taxonomy deployment and should not be rendered from taxonomy.env.
+*/}}
+{{- define "formbricks.taxonomyEnvManaged" -}}
+{{- $key := .key -}}
+{{- if has $key (list "APP_ENV" "HUB_INTERNAL_API_URL" "HUB_INTERNAL_API_TOKEN" "TAXONOMY_SERVICE_TOKEN" "TAXONOMY_LLM_PROVIDER" "TAXONOMY_LLM_MODEL" "TAXONOMY_LLM_BASE_URL" "TAXONOMY_LLM_API_KEY" "TAXONOMY_LLM_TEMPERATURE" "TAXONOMY_LLM_MAX_ATTEMPTS" "TAXONOMY_LLM_TIMEOUT_SECONDS" "HUB_CLIENT_TIMEOUT_SECONDS" "TAXONOMY_EMBEDDING_DIMENSION" "TAXONOMY_MIN_EMBEDDED_RECORDS" "TAXONOMY_MAX_RECORDS" "TAXONOMY_MAX_CLUSTERS" "TAXONOMY_RANDOM_SEED") -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
 Hub embeddings runtime resource name.
 */}}
 {{- define "formbricks.hubEmbeddingsName" -}}

--- a/charts/formbricks/templates/hub-deployment.yaml
+++ b/charts/formbricks/templates/hub-deployment.yaml
@@ -382,8 +382,9 @@ spec:
                   name: {{ include "formbricks.hubSecretName" . }}
                   key: HUB_API_KEY
             {{- include "formbricks.hubEmbeddingEnv" (dict "root" $ "env" .Values.hub.env) | nindent 12 }}
+            {{- include "formbricks.taxonomyHubEnv" (dict "root" $ "env" .Values.hub.env) | nindent 12 }}
             {{- range $key, $value := .Values.hub.env }}
-            {{- if not (and $.Values.hub.embeddings.enabled (include "formbricks.hubEmbeddingEnvManaged" (dict "key" $key))) }}
+            {{- if and (not (and $.Values.hub.embeddings.enabled (include "formbricks.hubEmbeddingEnvManaged" (dict "key" $key)))) (not (and $.Values.taxonomy.enabled $.Values.taxonomy.autoConfigureHub (include "formbricks.taxonomyHubEnvManaged" (dict "key" $key)))) }}
             {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
             {{- end }}

--- a/charts/formbricks/templates/hub-hpa.yaml
+++ b/charts/formbricks/templates/hub-hpa.yaml
@@ -100,3 +100,37 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+{{- if and .Values.taxonomy.enabled .Values.taxonomy.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "formbricks.taxonomyName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.taxonomyName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: taxonomy
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+    {{- with .Values.taxonomy.autoscaling.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.taxonomy.autoscaling.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "formbricks.taxonomyName" . }}
+  minReplicas: {{ .Values.taxonomy.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.taxonomy.autoscaling.maxReplicas }}
+  metrics:
+    {{- toYaml .Values.taxonomy.autoscaling.metrics | nindent 4 }}
+  {{- with .Values.taxonomy.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/formbricks/templates/hub-pdb.yaml
+++ b/charts/formbricks/templates/hub-pdb.yaml
@@ -127,3 +127,46 @@ spec:
       app.kubernetes.io/name: {{ include "formbricks.hubEmbeddingsName" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+{{- if and .Values.taxonomy.enabled .Values.taxonomy.pdb.enabled }}
+{{- $hasMinAvailable := not (kindIs "invalid" .Values.taxonomy.pdb.minAvailable) -}}
+{{- $hasMaxUnavailable := not (kindIs "invalid" .Values.taxonomy.pdb.maxUnavailable) -}}
+{{- if and $hasMinAvailable $hasMaxUnavailable }}
+  {{- fail "taxonomy.pdb.minAvailable and taxonomy.pdb.maxUnavailable are mutually exclusive; set only one" }}
+{{- end }}
+{{- if not (or $hasMinAvailable $hasMaxUnavailable) }}
+  {{- fail "taxonomy.pdb.enabled is true but neither taxonomy.pdb.minAvailable nor taxonomy.pdb.maxUnavailable is set; set exactly one" }}
+{{- end }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "formbricks.taxonomyName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.taxonomyName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: taxonomy
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+    {{- with .Values.taxonomy.pdb.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.taxonomy.pdb.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if $hasMinAvailable }}
+  minAvailable: {{ .Values.taxonomy.pdb.minAvailable }}
+  {{- end }}
+  {{- if $hasMaxUnavailable }}
+  maxUnavailable: {{ .Values.taxonomy.pdb.maxUnavailable }}
+  {{- end }}
+  {{- with .Values.taxonomy.pdb.unhealthyPodEvictionPolicy }}
+  unhealthyPodEvictionPolicy: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "formbricks.taxonomyName" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/formbricks/templates/taxonomy-deployment.yaml
+++ b/charts/formbricks/templates/taxonomy-deployment.yaml
@@ -1,0 +1,168 @@
+{{- if .Values.taxonomy.enabled }}
+{{- $provider := .Values.taxonomy.llm.provider | default "openai-compatible" -}}
+{{- if not (has $provider (list "openai-compatible" "bedrock")) }}
+  {{- fail "taxonomy.llm.provider must be 'openai-compatible' or 'bedrock'" }}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "formbricks.taxonomyName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.taxonomyName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: taxonomy
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+spec:
+  {{- if not .Values.taxonomy.autoscaling.enabled }}
+  replicas: {{ .Values.taxonomy.replicas | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "formbricks.taxonomyName" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "formbricks.taxonomyName" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: taxonomy
+        {{- with .Values.taxonomy.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.taxonomy.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.taxonomy.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.taxonomy.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.taxonomy.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.taxonomy.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.taxonomy.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.deployment.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: taxonomy
+          image: {{ include "formbricks.taxonomyImage" . | quote }}
+          imagePullPolicy: {{ .Values.taxonomy.image.pullPolicy }}
+          {{- with .Values.taxonomy.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.taxonomy.port }}
+              protocol: TCP
+          {{- with .Values.taxonomy.probes.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.taxonomy.probes.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.taxonomy.probes.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.taxonomy.envFrom }}
+          envFrom:
+            {{- range $value := .Values.taxonomy.envFrom }}
+            {{- if (eq .type "configmap") }}
+            - configMapRef:
+                {{- if .name }}
+                name: {{ include "formbricks.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
+                {{- else if .nameSuffix }}
+                name: {{ template "formbricks.name" $ }}-{{ include "formbricks.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
+                {{- else }}
+                name: {{ template "formbricks.name" $ }}
+                {{- end }}
+            {{- end }}
+            {{- if (eq .type "secret") }}
+            - secretRef:
+                {{- if .name }}
+                name: {{ include "formbricks.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
+                {{- else if .nameSuffix }}
+                name: {{ template "formbricks.name" $ }}-{{ include "formbricks.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
+                {{- else }}
+                name: {{ template "formbricks.name" $ }}
+                {{- end }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          env:
+            - name: APP_ENV
+              value: "production"
+            - name: HUB_INTERNAL_API_URL
+              value: {{ printf "http://%s:8080" (include "formbricks.hubname" .) | quote }}
+            - name: TAXONOMY_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "formbricks.taxonomyAuthSecretName" . }}
+                  key: {{ .Values.taxonomy.auth.serviceTokenKey | default "TAXONOMY_SERVICE_TOKEN" }}
+            - name: HUB_INTERNAL_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "formbricks.taxonomyAuthSecretName" . }}
+                  key: {{ .Values.taxonomy.auth.hubInternalApiTokenKey | default "HUB_INTERNAL_API_TOKEN" }}
+            - name: TAXONOMY_LLM_PROVIDER
+              value: {{ $provider | quote }}
+            - name: TAXONOMY_LLM_MODEL
+              value: {{ .Values.taxonomy.llm.model | quote }}
+            {{- if eq $provider "openai-compatible" }}
+            - name: TAXONOMY_LLM_BASE_URL
+              value: {{ include "formbricks.taxonomyLlmBaseUrl" . | quote }}
+            - name: TAXONOMY_LLM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "formbricks.taxonomyLlmSecretName" . }}
+                  key: {{ .Values.taxonomy.llm.apiKeySecretKey | default "TAXONOMY_LLM_API_KEY" }}
+            {{- end }}
+            - name: TAXONOMY_LLM_TEMPERATURE
+              value: {{ .Values.taxonomy.llm.temperature | quote }}
+            - name: TAXONOMY_LLM_MAX_ATTEMPTS
+              value: {{ .Values.taxonomy.llm.maxAttempts | quote }}
+            - name: TAXONOMY_LLM_TIMEOUT_SECONDS
+              value: {{ .Values.taxonomy.llm.timeoutSeconds | quote }}
+            - name: HUB_CLIENT_TIMEOUT_SECONDS
+              value: {{ .Values.taxonomy.hubClientTimeoutSeconds | quote }}
+            - name: TAXONOMY_EMBEDDING_DIMENSION
+              value: {{ .Values.taxonomy.embeddingDimension | quote }}
+            - name: TAXONOMY_MIN_EMBEDDED_RECORDS
+              value: {{ .Values.taxonomy.minEmbeddedRecords | quote }}
+            - name: TAXONOMY_MAX_RECORDS
+              value: {{ .Values.taxonomy.maxRecords | quote }}
+            - name: TAXONOMY_MAX_CLUSTERS
+              value: {{ .Values.taxonomy.maxClusters | quote }}
+            - name: TAXONOMY_RANDOM_SEED
+              value: {{ .Values.taxonomy.randomSeed | quote }}
+            {{- range $key, $value := .Values.taxonomy.env }}
+            {{- if not (include "formbricks.taxonomyEnvManaged" (dict "key" $key)) }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
+            {{- end }}
+            {{- end }}
+          {{- with .Values.taxonomy.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/formbricks/templates/taxonomy-secret.yaml
+++ b/charts/formbricks/templates/taxonomy-secret.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.taxonomy.enabled }}
+{{- if and .Values.taxonomy.auth.existingSecret (or .Values.taxonomy.auth.serviceToken .Values.taxonomy.auth.hubInternalApiToken) }}
+  {{- fail "taxonomy.auth.serviceToken and taxonomy.auth.hubInternalApiToken cannot be set when taxonomy.auth.existingSecret is set; put both token keys in the existing secret" }}
+{{- end }}
+{{- if and .Values.taxonomy.llm.existingSecret .Values.taxonomy.llm.apiKey }}
+  {{- fail "taxonomy.llm.apiKey cannot be set when taxonomy.llm.existingSecret is set; put TAXONOMY_LLM_API_KEY in the existing secret" }}
+{{- end }}
+{{- if or (not .Values.taxonomy.auth.existingSecret) (and (eq (.Values.taxonomy.llm.provider | default "openai-compatible") "openai-compatible") (not .Values.taxonomy.llm.existingSecret)) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "formbricks.taxonomyManagedSecretName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.taxonomyName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: taxonomy
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"
+type: Opaque
+data:
+  {{- if not .Values.taxonomy.auth.existingSecret }}
+  {{ .Values.taxonomy.auth.serviceTokenKey | default "TAXONOMY_SERVICE_TOKEN" | quote }}: {{ include "formbricks.taxonomyServiceToken" . | b64enc }}
+  {{ .Values.taxonomy.auth.hubInternalApiTokenKey | default "HUB_INTERNAL_API_TOKEN" | quote }}: {{ include "formbricks.taxonomyHubInternalApiToken" . | b64enc }}
+  {{- end }}
+  {{- if and (eq (.Values.taxonomy.llm.provider | default "openai-compatible") "openai-compatible") (not .Values.taxonomy.llm.existingSecret) }}
+  {{ .Values.taxonomy.llm.apiKeySecretKey | default "TAXONOMY_LLM_API_KEY" | quote }}: {{ include "formbricks.taxonomyLlmApiKey" . | b64enc }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/formbricks/templates/taxonomy-service.yaml
+++ b/charts/formbricks/templates/taxonomy-service.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.taxonomy.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "formbricks.taxonomyName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.taxonomyName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: taxonomy
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+    {{- with .Values.taxonomy.service.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.taxonomy.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.taxonomy.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "formbricks.taxonomyName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.taxonomy.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -308,6 +308,131 @@ llm:
         port: router-port
 
 ##########################################################
+# Optional AI taxonomy service
+##########################################################
+taxonomy:
+  # Deploy the standalone taxonomy service. Disabled by default.
+  enabled: false
+  replicas: 1
+
+  # When enabled, automatically points Hub API at the in-cluster taxonomy service.
+  # Disable only when you want to wire Hub manually through hub.env.
+  autoConfigureHub: true
+
+  image:
+    repository: "ghcr.io/formbricks/taxonomy"
+    tag: "v0.1.0"
+    digest: ""
+    pullPolicy: IfNotPresent
+
+  port: 8000
+
+  service:
+    type: ClusterIP
+    port: 8000
+    annotations: {}
+    additionalLabels: {}
+
+  auth:
+    # Existing secret must contain serviceTokenKey and hubInternalApiTokenKey.
+    existingSecret: ""
+    serviceTokenKey: TAXONOMY_SERVICE_TOKEN
+    hubInternalApiTokenKey: HUB_INTERNAL_API_TOKEN
+    serviceToken: ""
+    hubInternalApiToken: ""
+
+  llm:
+    provider: openai-compatible
+    model: qwen3-14b-awq
+    # Defaults to the bundled vLLM router URL when llm.enabled=true. Required otherwise.
+    baseUrl: ""
+    # Existing secret must contain apiKeySecretKey. When unset, the chart creates a non-empty dummy key.
+    existingSecret: ""
+    apiKeySecretKey: TAXONOMY_LLM_API_KEY
+    apiKey: ""
+    temperature: "0.1"
+    maxAttempts: "4"
+    timeoutSeconds: "60"
+
+  embeddingDimension: "768"
+  minEmbeddedRecords: "20"
+  maxRecords: "50000"
+  maxClusters: "80"
+  randomSeed: "42"
+  hubClientTimeoutSeconds: "120"
+
+  envFrom: []
+  env: {}
+
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      memory: 4Gi
+
+  autoscaling:
+    enabled: false
+    additionalLabels: {}
+    annotations: {}
+    minReplicas: 1
+    maxReplicas: 3
+    metrics:
+      - type: Resource
+        resource:
+          name: cpu
+          target:
+            type: Utilization
+            averageUtilization: 70
+      - type: Resource
+        resource:
+          name: memory
+          target:
+            type: Utilization
+            averageUtilization: 80
+    behavior: {}
+
+  # Disabled by default because the default taxonomy replica count is 1.
+  pdb:
+    enabled: false
+    additionalLabels: {}
+    annotations: {}
+    minAvailable: 1
+    # maxUnavailable: 1
+    # unhealthyPodEvictionPolicy: AlwaysAllow
+
+  probes:
+    startupProbe:
+      failureThreshold: 30
+      periodSeconds: 10
+      httpGet:
+        path: /health
+        port: http
+    readinessProbe:
+      failureThreshold: 6
+      periodSeconds: 10
+      timeoutSeconds: 5
+      httpGet:
+        path: /health
+        port: http
+    livenessProbe:
+      failureThreshold: 6
+      periodSeconds: 20
+      timeoutSeconds: 5
+      httpGet:
+        path: /health
+        port: http
+
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext: {}
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  topologySpreadConstraints: []
+
+##########################################################
 # Horizontal Pod Autoscaler (HPA)
 ##########################################################
 autoscaling:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -192,7 +192,13 @@ services:
   vllm:
     image: ${QWEN_VLLM_IMAGE:-vllm/vllm-openai:v0.14.0}
     profiles: ["qwen"]
-    gpus: all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     command:
       - vllm
       - serve
@@ -239,6 +245,15 @@ services:
     image: cubejs/cube:v1.6.6
     env_file:
       - apps/web/.env
+    command:
+      - sh
+      - -c
+      - |
+        if [ -z "$$CUBEJS_API_SECRET" ]; then
+          echo "CUBEJS_API_SECRET is required for Cube JWT authentication" >&2
+          exit 1
+        fi
+        exec cubejs server
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -139,6 +139,9 @@ services:
       EMBEDDING_GOOGLE_CLOUD_PROJECT: ${EMBEDDING_GOOGLE_CLOUD_PROJECT:-}
       EMBEDDING_GOOGLE_CLOUD_LOCATION: ${EMBEDDING_GOOGLE_CLOUD_LOCATION:-}
       GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-}
+      TAXONOMY_SERVICE_URL: ${TAXONOMY_SERVICE_URL:-}
+      TAXONOMY_SERVICE_TOKEN: ${TAXONOMY_SERVICE_TOKEN:-}
+      HUB_INTERNAL_API_TOKEN: ${HUB_INTERNAL_API_TOKEN:-}
 
   # Hub worker processes async jobs enqueued by the API, including embeddings.
   hub-worker:
@@ -153,6 +156,84 @@ services:
       disable: true
     environment:
       <<: *hub-runtime-environment
+
+  # Optional AI taxonomy beta service. Enable with COMPOSE_PROFILES=taxonomy.
+  taxonomy:
+    image: ghcr.io/formbricks/taxonomy${TAXONOMY_IMAGE_REF:-:latest}
+    profiles: ["taxonomy"]
+    depends_on:
+      hub:
+        condition: service_started
+    environment:
+      APP_ENV: production
+      TAXONOMY_SERVICE_TOKEN: ${TAXONOMY_SERVICE_TOKEN:-}
+      HUB_INTERNAL_API_URL: http://hub:8080
+      HUB_INTERNAL_API_TOKEN: ${HUB_INTERNAL_API_TOKEN:-}
+      TAXONOMY_LLM_PROVIDER: ${TAXONOMY_LLM_PROVIDER:-openai-compatible}
+      TAXONOMY_LLM_MODEL: ${TAXONOMY_LLM_MODEL:-}
+      TAXONOMY_LLM_BASE_URL: ${TAXONOMY_LLM_BASE_URL:-}
+      TAXONOMY_LLM_API_KEY: ${TAXONOMY_LLM_API_KEY:-}
+      AWS_REGION: ${AWS_REGION:-}
+      AWS_BEARER_TOKEN_BEDROCK: ${AWS_BEARER_TOKEN_BEDROCK:-}
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=5).read()",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  # Optional bundled Qwen/vLLM OpenAI-compatible runtime. Enable with COMPOSE_PROFILES=qwen.
+  vllm:
+    image: ${QWEN_VLLM_IMAGE:-vllm/vllm-openai:v0.14.0}
+    profiles: ["qwen"]
+    gpus: all
+    command:
+      - vllm
+      - serve
+      - ${QWEN_MODEL_ID:-Qwen/Qwen3-14B-AWQ}
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+      - --no-enable-prefix-caching
+      - --max-model-len
+      - ${QWEN_MAX_MODEL_LEN:-8192}
+      - --dtype
+      - ${QWEN_DTYPE:-float16}
+      - --tensor-parallel-size
+      - ${QWEN_TENSOR_PARALLEL_SIZE:-1}
+      - --max-num-seqs
+      - ${QWEN_MAX_NUM_SEQS:-8}
+      - --gpu_memory_utilization
+      - ${QWEN_GPU_MEMORY_UTILIZATION:-0.9}
+      - --served-model-name
+      - ${QWEN_SERVED_MODEL_NAME:-qwen3-14b-awq}
+      - --default-chat-template-kwargs
+      - '{"enable_thinking": false}'
+    environment:
+      HF_HOME: /data
+    volumes:
+      - qwen-model-cache:/data
+    ports:
+      - "${QWEN_VLLM_HOST:-127.0.0.1}:${QWEN_VLLM_PORT:-8000}:8000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python3",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=5).read()",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 40
+      start_period: 10m
 
   cube:
     image: cubejs/cube:v1.6.6
@@ -190,4 +271,6 @@ volumes:
   valkey-data:
     driver: local
   rustfs-data:
+    driver: local
+  qwen-model-cache:
     driver: local

--- a/docker/README.md
+++ b/docker/README.md
@@ -88,12 +88,14 @@ COMPOSE_PROFILES=qwen,taxonomy
 TAXONOMY_SERVICE_URL=http://taxonomy:8000
 TAXONOMY_SERVICE_TOKEN=<strong-random-secret>
 HUB_INTERNAL_API_TOKEN=<strong-random-secret>
-TAXONOMY_IMAGE_REF=:latest
+TAXONOMY_IMAGE_REF=:v0.1.0
 TAXONOMY_LLM_PROVIDER=openai-compatible
 TAXONOMY_LLM_MODEL=qwen3-14b-awq
 TAXONOMY_LLM_BASE_URL=http://vllm:8000/v1
 TAXONOMY_LLM_API_KEY=<api-key-or-dummy-value>
 ```
+
+Replace `:v0.1.0` with the current released `ghcr.io/formbricks/taxonomy` image tag for your Formbricks version. Production installs should pin a release tag instead of relying on `:latest`.
 
 If you run your own OpenAI-compatible endpoint, keep only the `taxonomy` profile and point `TAXONOMY_LLM_BASE_URL` at that `/v1` endpoint. The selected model must reliably return strict JSON because taxonomy generation validates an exact 5-level tree.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,8 +33,100 @@ That's it! After running the command and providing the required information, vis
 The stack includes the [Formbricks Hub](https://github.com/formbricks/hub) API (`ghcr.io/formbricks/hub`) and the bundled Cube service. Hub and Cube share the same database as Formbricks by default and both start as part of the baseline `docker compose up`.
 
 - **Migrations**: A `formbricks-migrate` service runs Formbricks Prisma migrations before `hub-migrate` writes Hub tables to the shared database. `hub-migrate` then runs Hub's database migrations (goose + river) before the Hub API starts. Both migration services run on every `docker compose up` and are idempotent.
-- **Production** (`docker/docker-compose.yml`): Set `HUB_API_KEY` and `CUBEJS_API_SECRET` (both required). Run `docker compose config >/dev/null` after creating `.env`; it fails if either value is missing or empty. `HUB_API_URL` defaults to `http://hub:8080` and `CUBEJS_API_URL` defaults to `http://cube:4000` so the Formbricks app reaches Hub and Cube inside the compose network. Cube JWT issuer/audience default to `formbricks-web` and `formbricks-cube`, and the bundled Cube service exposes only `meta,data` API scopes. Override `HUB_DATABASE_URL` and `CUBEJS_DB_*` only if Hub or Cube should use a separate database. The Hub image tracks `:latest` by default so `formbricks.sh update` advances Hub in lockstep with the app. `hub` and `hub-migrate` always resolve to the same image. To pin to an immutable reference, set `HUB_IMAGE_REF` in `docker/.env` to either a tag (e.g. `:0.3.0`) or a digest (e.g. `@sha256:14db7b3d...`).
+- **Production** (`docker/docker-compose.yml`): Set non-empty `HUB_API_KEY` and `CUBEJS_API_SECRET` in `.env` before starting the stack. `docker compose config >/dev/null` validates compose syntax, but missing secrets are reported by the service that needs them at startup. `HUB_API_URL` defaults to `http://hub:8080` and `CUBEJS_API_URL` defaults to `http://cube:4000` so the Formbricks app reaches Hub and Cube inside the compose network. Cube JWT issuer/audience default to `formbricks-web` and `formbricks-cube`, and the bundled Cube service exposes only `meta,data` API scopes. Override `HUB_DATABASE_URL` and `CUBEJS_DB_*` only if Hub or Cube should use a separate database. The Hub image tracks `:latest` by default so `formbricks.sh update` advances Hub in lockstep with the app. `hub` and `hub-migrate` always resolve to the same image. To pin to an immutable reference, set `HUB_IMAGE_REF` in `docker/.env` to either a tag (e.g. `:0.3.0`) or a digest (e.g. `@sha256:14db7b3d...`).
 - **Development** (`docker-compose.dev.yml`): Hub uses a dedicated local `hub` database and `HUB_API_KEY` defaults to `dev-api-key`. The dev stack starts `hub` plus `hub-worker`; set `EMBEDDING_PROVIDER`, `EMBEDDING_MODEL`, and any provider credentials in the repo root `.env` to enable Hub embeddings locally. See the [Hub embeddings environment reference](https://hub.formbricks.com/reference/environment-variables/#embeddings) for provider-specific values. Cube starts with the dev stack, `CUBEJS_API_URL` defaults to `http://localhost:4000`, and `pnpm dev:setup` generates `CUBEJS_API_SECRET` in the repo root `.env`. The Hub image is pinned to a semver tag (`hub`, `hub-worker`, and `hub-migrate` share the same value); override `HUB_IMAGE_TAG` in the repo root `.env` to test a specific Hub release.
+
+## Smart Functionality AI with Qwen/vLLM
+
+The Docker stack can optionally run Qwen through vLLM as an OpenAI-compatible `/v1` endpoint. Baseline installs are unchanged: `docker compose up -d` does not start the vLLM service and Formbricks can still run without AI.
+
+To use the bundled Qwen/vLLM service, add these values to `.env`:
+
+```bash
+COMPOSE_PROFILES=qwen
+AI_PROVIDER=openai-compatible
+AI_MODEL=qwen3-14b-awq
+AI_OPENAI_COMPATIBLE_BASE_URL=http://vllm:8000/v1
+AI_OPENAI_COMPATIBLE_PROVIDER_NAME=vllm
+AI_OPENAI_COMPATIBLE_SUPPORTS_STRUCTURED_OUTPUTS=1
+```
+
+Then start the stack with the profile:
+
+```bash
+COMPOSE_PROFILES=qwen docker compose up -d
+docker compose --profile qwen ps
+docker compose logs vllm formbricks
+```
+
+The vLLM service requires a GPU-capable Docker host with the NVIDIA Container Toolkit installed. It stores downloaded model files in the `qwen-model-cache` Docker volume and binds the OpenAI-compatible endpoint to `127.0.0.1:8000` by default for local checks.
+
+Use these optional overrides when needed:
+
+```bash
+QWEN_VLLM_IMAGE=vllm/vllm-openai:v0.14.0
+QWEN_MODEL_ID=Qwen/Qwen3-14B-AWQ
+QWEN_SERVED_MODEL_NAME=qwen3-14b-awq
+QWEN_MAX_MODEL_LEN=8192
+QWEN_MAX_NUM_SEQS=8
+QWEN_GPU_MEMORY_UTILIZATION=0.9
+QWEN_VLLM_PORT=8000
+```
+
+If you run your own Qwen/vLLM service, do not enable the `qwen` profile. Set `AI_PROVIDER=openai-compatible`, `AI_MODEL`, and `AI_OPENAI_COMPATIBLE_BASE_URL` to your endpoint instead.
+
+## AI Taxonomy Beta
+
+The standalone AI taxonomy service is included as an opt-in Docker Compose profile. Baseline installs are unchanged: `docker compose up -d` starts Formbricks, Hub, and Cube, but not taxonomy.
+
+To enable taxonomy in Docker Compose, add the required values to `.env`:
+
+```bash
+# Use COMPOSE_PROFILES=taxonomy when taxonomy points at your own LLM endpoint.
+# Use COMPOSE_PROFILES=qwen,taxonomy when taxonomy should share the bundled Qwen/vLLM service.
+COMPOSE_PROFILES=qwen,taxonomy
+TAXONOMY_SERVICE_URL=http://taxonomy:8000
+TAXONOMY_SERVICE_TOKEN=<strong-random-secret>
+HUB_INTERNAL_API_TOKEN=<strong-random-secret>
+TAXONOMY_IMAGE_REF=:latest
+TAXONOMY_LLM_PROVIDER=openai-compatible
+TAXONOMY_LLM_MODEL=qwen3-14b-awq
+TAXONOMY_LLM_BASE_URL=http://vllm:8000/v1
+TAXONOMY_LLM_API_KEY=<api-key-or-dummy-value>
+```
+
+If you run your own OpenAI-compatible endpoint, keep only the `taxonomy` profile and point `TAXONOMY_LLM_BASE_URL` at that `/v1` endpoint. The selected model must reliably return strict JSON because taxonomy generation validates an exact 5-level tree.
+
+Secret wiring is server-side only: Hub receives `TAXONOMY_SERVICE_URL`, `TAXONOMY_SERVICE_TOKEN`, and `HUB_INTERNAL_API_TOKEN`; taxonomy receives `TAXONOMY_SERVICE_TOKEN`, `HUB_INTERNAL_API_URL`, `HUB_INTERNAL_API_TOKEN`, and the LLM settings. Formbricks Web continues to call Hub with `HUB_API_KEY` and never receives taxonomy service credentials.
+
+To use Amazon Bedrock instead of an OpenAI-compatible endpoint, set:
+
+```bash
+TAXONOMY_LLM_PROVIDER=bedrock
+TAXONOMY_LLM_MODEL=eu.anthropic.claude-sonnet-4-5-20250929-v1:0
+AWS_REGION=eu-north-1
+AWS_BEARER_TOKEN_BEDROCK=<bedrock-api-key>
+```
+
+Then start the stack with the selected profile set:
+
+```bash
+COMPOSE_PROFILES=qwen,taxonomy docker compose up -d
+docker compose --profile qwen --profile taxonomy ps
+docker compose logs vllm taxonomy hub
+```
+
+Run the authenticated preflight after startup to verify Hub internal auth and LLM reachability:
+
+```bash
+docker compose --profile taxonomy exec taxonomy python -c 'import os, urllib.request; req = urllib.request.Request("http://127.0.0.1:8000/v1/preflight", headers={"Authorization": "Bearer " + os.environ["TAXONOMY_SERVICE_TOKEN"]}); print(urllib.request.urlopen(req, timeout=10).read().decode())'
+```
+
+The taxonomy service remains internal to the compose network by default. For production workloads, `TAXONOMY_MAX_RECORDS` defaults to `50000`. Override it only as an advanced safety limit after sizing CPU, memory, and LLM capacity.
+
+For local unreleased taxonomy testing, build the taxonomy image as `ghcr.io/formbricks/taxonomy:local`, set `TAXONOMY_IMAGE_REF=:local`, and start the stack with `COMPOSE_PROFILES=taxonomy`.
+
+The one-click installer does not prompt for taxonomy settings. One-click users can enable the beta later by editing `./formbricks/.env`, adding the variables above, and restarting with `COMPOSE_PROFILES=taxonomy docker compose up -d`.
 
 In development, Hub is exposed locally on port **8080** and Cube on **4000** (with the Cube playground on **4001**). In production Docker Compose, both stay internal to the compose network at `http://hub:8080` and `http://cube:4000`.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -86,8 +86,8 @@ To enable taxonomy in Docker Compose, add the required values to `.env`:
 # Use COMPOSE_PROFILES=qwen,taxonomy when taxonomy should share the bundled Qwen/vLLM service.
 COMPOSE_PROFILES=qwen,taxonomy
 TAXONOMY_SERVICE_URL=http://taxonomy:8000
-TAXONOMY_SERVICE_TOKEN=<strong-random-secret>
-HUB_INTERNAL_API_TOKEN=<strong-random-secret>
+TAXONOMY_SERVICE_TOKEN=<random-strong-secret>
+HUB_INTERNAL_API_TOKEN=<random-strong-secret>
 TAXONOMY_IMAGE_REF=:v0.1.0
 TAXONOMY_LLM_PROVIDER=openai-compatible
 TAXONOMY_LLM_MODEL=qwen3-14b-awq

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,7 +30,20 @@ x-environment: &environment
     REDIS_URL: redis://redis:6379
 
     # Formbricks Hub (port 8080): API key required. Use e.g. openssl rand -hex 32
-    HUB_API_KEY:
+    HUB_API_KEY: ${HUB_API_KEY:-}
+
+    # Taxonomy service credentials are consumed by Hub/taxonomy only. Keep these
+    # empty here so a shared docker/.env file cannot leak them into the web app.
+    TAXONOMY_SERVICE_URL: ""
+    TAXONOMY_SERVICE_TOKEN: ""
+    HUB_INTERNAL_API_TOKEN: ""
+    TAXONOMY_LLM_PROVIDER: ""
+    TAXONOMY_LLM_MODEL: ""
+    TAXONOMY_LLM_BASE_URL: ""
+    TAXONOMY_LLM_API_KEY: ""
+    TAXONOMY_BEDROCK_MODEL: ""
+    TAXONOMY_MAX_RECORDS: ""
+    AWS_BEARER_TOKEN_BEDROCK: ""
 
     # Base URL the Formbricks app uses to reach Hub. Defaults to the internal Hub service.
     HUB_API_URL: ${HUB_API_URL:-http://hub:8080}
@@ -40,7 +53,7 @@ x-environment: &environment
 
     # Cube semantic-layer API used by Formbricks analytics. Required.
     CUBEJS_API_URL: ${CUBEJS_API_URL:-http://cube:4000}
-    CUBEJS_API_SECRET: ${CUBEJS_API_SECRET:?CUBEJS_API_SECRET is required to run Cube}
+    CUBEJS_API_SECRET: ${CUBEJS_API_SECRET:-}
     CUBEJS_JWT_ISSUER: ${CUBEJS_JWT_ISSUER:-formbricks-web}
     CUBEJS_JWT_AUDIENCE: ${CUBEJS_JWT_AUDIENCE:-formbricks-cube}
 
@@ -267,6 +280,9 @@ services:
   formbricks:
     restart: always
     image: ghcr.io/formbricks/formbricks:latest
+    env_file:
+      - path: .env
+        required: false
     depends_on:
       postgres:
         condition: service_healthy
@@ -310,8 +326,91 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      API_KEY: ${HUB_API_KEY:?HUB_API_KEY is required to run Hub}
+      API_KEY: ${HUB_API_KEY:-}
       DATABASE_URL: ${HUB_DATABASE_URL:-postgresql://postgres:postgres@postgres:5432/formbricks?sslmode=disable}
+      TAXONOMY_SERVICE_URL: ${TAXONOMY_SERVICE_URL:-}
+      TAXONOMY_SERVICE_TOKEN: ${TAXONOMY_SERVICE_TOKEN:-}
+      HUB_INTERNAL_API_TOKEN: ${HUB_INTERNAL_API_TOKEN:-}
+
+  # Optional AI taxonomy beta service. Enable with COMPOSE_PROFILES=taxonomy.
+  taxonomy:
+    restart: always
+    profiles: ["taxonomy"]
+    image: ghcr.io/formbricks/taxonomy${TAXONOMY_IMAGE_REF:-:latest}
+    depends_on:
+      hub:
+        condition: service_started
+    environment:
+      APP_ENV: production
+      TAXONOMY_SERVICE_TOKEN: ${TAXONOMY_SERVICE_TOKEN:-}
+      HUB_INTERNAL_API_URL: http://hub:8080
+      HUB_INTERNAL_API_TOKEN: ${HUB_INTERNAL_API_TOKEN:-}
+      TAXONOMY_LLM_PROVIDER: ${TAXONOMY_LLM_PROVIDER:-openai-compatible}
+      TAXONOMY_LLM_MODEL: ${TAXONOMY_LLM_MODEL:-}
+      TAXONOMY_LLM_BASE_URL: ${TAXONOMY_LLM_BASE_URL:-}
+      TAXONOMY_LLM_API_KEY: ${TAXONOMY_LLM_API_KEY:-}
+      AWS_REGION: ${AWS_REGION:-}
+      AWS_BEARER_TOKEN_BEDROCK: ${AWS_BEARER_TOKEN_BEDROCK:-}
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=5).read()",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+
+  # Optional bundled Qwen/vLLM OpenAI-compatible runtime. Enable with COMPOSE_PROFILES=qwen.
+  vllm:
+    restart: always
+    profiles: ["qwen"]
+    image: ${QWEN_VLLM_IMAGE:-vllm/vllm-openai:v0.14.0}
+    gpus: all
+    command:
+      - vllm
+      - serve
+      - ${QWEN_MODEL_ID:-Qwen/Qwen3-14B-AWQ}
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+      - --no-enable-prefix-caching
+      - --max-model-len
+      - ${QWEN_MAX_MODEL_LEN:-8192}
+      - --dtype
+      - ${QWEN_DTYPE:-float16}
+      - --tensor-parallel-size
+      - ${QWEN_TENSOR_PARALLEL_SIZE:-1}
+      - --max-num-seqs
+      - ${QWEN_MAX_NUM_SEQS:-8}
+      - --gpu_memory_utilization
+      - ${QWEN_GPU_MEMORY_UTILIZATION:-0.9}
+      - --served-model-name
+      - ${QWEN_SERVED_MODEL_NAME:-qwen3-14b-awq}
+      - --default-chat-template-kwargs
+      - '{"enable_thinking": false}'
+    environment:
+      HF_HOME: /data
+    volumes:
+      - qwen-model-cache:/data
+    ports:
+      - "${QWEN_VLLM_HOST:-127.0.0.1}:${QWEN_VLLM_PORT:-8000}:8000"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "python3",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=5).read()",
+        ]
+      interval: 30s
+      timeout: 10s
+      retries: 40
+      start_period: 10m
 
   # Cube semantic-layer API used by Formbricks analytics dashboards.
   cube:
@@ -329,7 +428,7 @@ services:
       CUBEJS_DB_USER: ${CUBEJS_DB_USER:-postgres}
       CUBEJS_DB_PASS: ${CUBEJS_DB_PASS:-postgres}
       CUBEJS_DB_PORT: ${CUBEJS_DB_PORT:-5432}
-      CUBEJS_API_SECRET: ${CUBEJS_API_SECRET:?CUBEJS_API_SECRET is required to run Cube}
+      CUBEJS_API_SECRET: ${CUBEJS_API_SECRET:-}
       CUBEJS_JWT_ISSUER: ${CUBEJS_JWT_ISSUER:-formbricks-web}
       CUBEJS_JWT_AUDIENCE: ${CUBEJS_JWT_AUDIENCE:-formbricks-cube}
       CUBEJS_DEFAULT_API_SCOPES: meta,data
@@ -354,4 +453,6 @@ volumes:
   postgres:
     driver: local
   redis:
+    driver: local
+  qwen-model-cache:
     driver: local

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -369,7 +369,13 @@ services:
     restart: always
     profiles: ["qwen"]
     image: ${QWEN_VLLM_IMAGE:-vllm/vllm-openai:v0.14.0}
-    gpus: all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
     command:
       - vllm
       - serve
@@ -416,6 +422,15 @@ services:
   cube:
     restart: always
     image: cubejs/cube:v1.6.6
+    command:
+      - sh
+      - -c
+      - |
+        if [ -z "$$CUBEJS_API_SECRET" ]; then
+          echo "CUBEJS_API_SECRET is required for Cube JWT authentication" >&2
+          exit 1
+        fi
+        exec cubejs server
     depends_on:
       hub-migrate:
         condition: service_completed_successfully

--- a/docs/self-hosting/advanced/enterprise-features/ai-features.mdx
+++ b/docs/self-hosting/advanced/enterprise-features/ai-features.mdx
@@ -24,6 +24,23 @@ variables.
 Set `llm.autoConfigureApp=false` if you want the chart to deploy Qwen/vLLM but prefer to configure the app
 provider manually.
 
+## Docker Compose
+
+The Docker stack can deploy the same Qwen/vLLM runtime through an opt-in Compose profile. This path is disabled
+by default and requires a GPU-capable Docker host with the NVIDIA Container Toolkit installed.
+
+```bash
+COMPOSE_PROFILES=qwen
+AI_PROVIDER=openai-compatible
+AI_MODEL=qwen3-14b-awq
+AI_OPENAI_COMPATIBLE_BASE_URL=http://vllm:8000/v1
+AI_OPENAI_COMPATIBLE_PROVIDER_NAME=vllm
+AI_OPENAI_COMPATIBLE_SUPPORTS_STRUCTURED_OUTPUTS=1
+```
+
+If you use the optional taxonomy service and want it to share the bundled Qwen runtime, start Docker Compose with
+`COMPOSE_PROFILES=qwen,taxonomy` and point `TAXONOMY_LLM_BASE_URL` at `http://vllm:8000/v1`.
+
 ## External Providers
 
 Keep `llm.enabled=false` when you use Google Vertex, Azure, AWS Bedrock, or your own OpenAI-compatible runtime.

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -78,8 +78,10 @@ enterprise functionality.
   `AI_AZURE_RESOURCE_NAME`
 - `AI_PROVIDER=openai-compatible` requires `AI_OPENAI_COMPATIBLE_BASE_URL`; the LLM GA v1 self-hosted
   path is Qwen served by vLLM
-- Helm operators can set `llm.enabled: true` to deploy the bundled Qwen/vLLM runtime, or keep it disabled and
-  configure Google Vertex, Azure, AWS Bedrock, or an external OpenAI-compatible endpoint manually
+- Helm operators can set `llm.enabled: true` to deploy the bundled Qwen/vLLM runtime
+- Docker Compose operators can set `COMPOSE_PROFILES=qwen` to deploy the bundled Qwen/vLLM runtime
+- Keep the bundled runtime disabled when you configure Google Vertex, Azure, AWS Bedrock, or an external
+  OpenAI-compatible endpoint manually
 
 #### Cube
 

--- a/docs/self-hosting/configuration/environment-variables.mdx
+++ b/docs/self-hosting/configuration/environment-variables.mdx
@@ -15,7 +15,7 @@ These variables are present inside your machine's docker-compose file. Restart t
 
 For `AI_PROVIDER=google`, use a Gemini model ID such as `gemini-3.5-flash` together with Google Cloud credentials. `gemini-3.5-flash` must use `AI_GOOGLE_CLOUD_LOCATION=global`, `us`, or `eu`; keep regional locations such as `europe-west3` or `me-central2` only for models Google lists as supported there, such as `gemini-2.5-flash`. Formbricks uses Google Cloud naming here, even though the underlying SDK still talks to Vertex AI endpoints for Gemini model access.
 
-For `AI_PROVIDER=openai-compatible`, the LLM GA v1 self-hosted path is Qwen served by vLLM through an OpenAI-compatible `/v1` endpoint. Set only the variables for the provider you use; unused provider variables can be omitted.
+For `AI_PROVIDER=openai-compatible`, the LLM GA v1 self-hosted path is Qwen served by vLLM through an OpenAI-compatible `/v1` endpoint. Docker Compose users can enable the bundled Qwen/vLLM service with `COMPOSE_PROFILES=qwen`, or point `AI_OPENAI_COMPATIBLE_BASE_URL` at their own endpoint. Set only the variables for the provider you use; unused provider variables can be omitted.
 
 {/* prettier-ignore-start */}
 

--- a/docs/self-hosting/setup/docker.mdx
+++ b/docs/self-hosting/setup/docker.mdx
@@ -182,13 +182,16 @@ Make sure Docker and Docker Compose are installed on your system. These are usua
    TAXONOMY_SERVICE_URL=http://taxonomy:8000
    TAXONOMY_SERVICE_TOKEN=<strong-random-secret>
    HUB_INTERNAL_API_TOKEN=<strong-random-secret>
-   TAXONOMY_IMAGE_REF=:latest
+   TAXONOMY_IMAGE_REF=:v0.1.0
    TAXONOMY_LLM_PROVIDER=openai-compatible
    TAXONOMY_LLM_MODEL=qwen3-14b-awq
    TAXONOMY_LLM_BASE_URL=http://vllm:8000/v1
    TAXONOMY_LLM_API_KEY=<api-key-or-dummy-value>
    EOF
    ```
+
+   Replace `:v0.1.0` with the current released `ghcr.io/formbricks/taxonomy` image tag for your Formbricks
+   version. Production installs should pin a release tag instead of relying on `:latest`.
 
    If you run your own OpenAI-compatible endpoint, keep only the `taxonomy` profile and point
    `TAXONOMY_LLM_BASE_URL` at that `/v1` endpoint. The selected model must reliably return strict JSON because

--- a/docs/self-hosting/setup/docker.mdx
+++ b/docs/self-hosting/setup/docker.mdx
@@ -64,7 +64,8 @@ Make sure Docker and Docker Compose are installed on your system. These are usua
    docker compose config >/dev/null
    ```
 
-   This command fails if `HUB_API_KEY` or `CUBEJS_API_SECRET` is missing or empty in `.env`.
+   This command validates Docker Compose syntax. `HUB_API_KEY` and `CUBEJS_API_SECRET` are still required for
+   production startup, but missing secrets are reported by the service that needs them at runtime.
 
 1. **Generate NextAuth Secret**
 
@@ -137,6 +138,95 @@ Make sure Docker and Docker Compose are installed on your system. These are usua
      <code>HUB_API_KEY</code> available there as well.
    </Info>
 
+1. **Optional: Enable Bundled Qwen/vLLM For AI**
+
+   The Docker stack can optionally run Qwen through vLLM as an OpenAI-compatible `/v1` endpoint. Baseline
+   installs do not start vLLM and can still use Google Vertex, Azure, AWS Bedrock, or another
+   OpenAI-compatible endpoint.
+
+   The bundled Qwen/vLLM service requires a GPU-capable Docker host with the NVIDIA Container Toolkit
+   installed.
+
+   To use the bundled Qwen runtime, add these values to `.env`:
+
+   ```bash
+   cat <<EOF >> .env
+   COMPOSE_PROFILES=qwen
+   AI_PROVIDER=openai-compatible
+   AI_MODEL=qwen3-14b-awq
+   AI_OPENAI_COMPATIBLE_BASE_URL=http://vllm:8000/v1
+   AI_OPENAI_COMPATIBLE_PROVIDER_NAME=vllm
+   AI_OPENAI_COMPATIBLE_SUPPORTS_STRUCTURED_OUTPUTS=1
+   EOF
+   ```
+
+   The vLLM endpoint is available inside the Compose network at `http://vllm:8000/v1` and is bound to
+   `127.0.0.1:8000` by default for local checks. Model files are stored in the `qwen-model-cache` Docker
+   volume.
+
+   If you run your own Qwen/vLLM service, do not enable the `qwen` profile. Set `AI_PROVIDER`,
+   `AI_MODEL`, and `AI_OPENAI_COMPATIBLE_BASE_URL` to your external endpoint instead.
+
+1. **Optional: Enable AI Taxonomy Beta**
+
+   The Docker stack includes the standalone taxonomy service as an opt-in Compose profile. Baseline installs do
+   not start taxonomy and do not require taxonomy or LLM secrets.
+
+   To enable taxonomy, add these values to `.env`:
+
+   ```bash
+   cat <<EOF >> .env
+   # Use COMPOSE_PROFILES=taxonomy when taxonomy points at your own LLM endpoint.
+   # Use COMPOSE_PROFILES=qwen,taxonomy when taxonomy should share the bundled Qwen/vLLM service.
+   COMPOSE_PROFILES=qwen,taxonomy
+   TAXONOMY_SERVICE_URL=http://taxonomy:8000
+   TAXONOMY_SERVICE_TOKEN=<strong-random-secret>
+   HUB_INTERNAL_API_TOKEN=<strong-random-secret>
+   TAXONOMY_IMAGE_REF=:latest
+   TAXONOMY_LLM_PROVIDER=openai-compatible
+   TAXONOMY_LLM_MODEL=qwen3-14b-awq
+   TAXONOMY_LLM_BASE_URL=http://vllm:8000/v1
+   TAXONOMY_LLM_API_KEY=<api-key-or-dummy-value>
+   EOF
+   ```
+
+   If you run your own OpenAI-compatible endpoint, keep only the `taxonomy` profile and point
+   `TAXONOMY_LLM_BASE_URL` at that `/v1` endpoint. The selected model must reliably return strict JSON because
+   taxonomy generation validates an exact 5-level tree.
+
+   To use Amazon Bedrock instead of an OpenAI-compatible endpoint, set:
+
+   ```bash
+   TAXONOMY_LLM_PROVIDER=bedrock
+   TAXONOMY_LLM_MODEL=eu.anthropic.claude-sonnet-4-5-20250929-v1:0
+   AWS_REGION=eu-north-1
+   AWS_BEARER_TOKEN_BEDROCK=<bedrock-api-key>
+   ```
+
+   When you reach the start step below, start with the selected profile set:
+
+   ```bash
+   COMPOSE_PROFILES=qwen,taxonomy docker compose up -d
+   docker compose --profile qwen --profile taxonomy ps
+   docker compose logs vllm taxonomy hub
+   ```
+
+   Run the authenticated preflight after startup to verify Hub internal auth and LLM reachability:
+
+   ```bash
+   docker compose --profile taxonomy exec taxonomy python -c 'import os, urllib.request; req = urllib.request.Request("http://127.0.0.1:8000/v1/preflight", headers={"Authorization": "Bearer " + os.environ["TAXONOMY_SERVICE_TOKEN"]}); print(urllib.request.urlopen(req, timeout=10).read().decode())'
+   ```
+
+   The taxonomy service remains internal to the compose network by default. For production workloads,
+   `TAXONOMY_MAX_RECORDS` defaults to `50000`; override it only as an advanced safety limit after sizing CPU,
+   memory, and LLM capacity.
+
+   <Info>
+     The taxonomy service is internal to the Docker network. Formbricks Web still calls Hub with
+     <code>HUB_API_KEY</code>; Hub calls taxonomy with <code>TAXONOMY_SERVICE_TOKEN</code>; taxonomy calls Hub
+     internal APIs with <code>HUB_INTERNAL_API_TOKEN</code>.
+   </Info>
+
 1. **Start the Docker Setup**
 
    Now, you're ready to run Formbricks with Docker. Use the command below to start Formbricks together with
@@ -154,8 +244,15 @@ Make sure Docker and Docker Compose are installed on your system. These are usua
 
 <Note>
   The bundled Docker stack keeps Formbricks Hub and Cube internal to the compose network. The app reaches them
-  through `http://hub:8080` and `http://cube:4000`.
+  through `http://hub:8080` and `http://cube:4000`. When AI taxonomy beta is enabled, Hub reaches taxonomy
+  internally through `http://taxonomy:8000`.
 </Note>
+
+<Info>
+  The one-click installer does not prompt for AI taxonomy settings. One-click users can enable the beta later by
+  editing `./formbricks/.env`, adding the taxonomy variables above, and restarting with
+  `COMPOSE_PROFILES=taxonomy docker compose up -d`.
+</Info>
 
 <Info>
   If you use the one-click Traefik setup, FeedbackRecords are available on the Formbricks origin at

--- a/docs/self-hosting/setup/docker.mdx
+++ b/docs/self-hosting/setup/docker.mdx
@@ -180,8 +180,8 @@ Make sure Docker and Docker Compose are installed on your system. These are usua
    # Use COMPOSE_PROFILES=qwen,taxonomy when taxonomy should share the bundled Qwen/vLLM service.
    COMPOSE_PROFILES=qwen,taxonomy
    TAXONOMY_SERVICE_URL=http://taxonomy:8000
-   TAXONOMY_SERVICE_TOKEN=<strong-random-secret>
-   HUB_INTERNAL_API_TOKEN=<strong-random-secret>
+   TAXONOMY_SERVICE_TOKEN=<random-strong-secret>
+   HUB_INTERNAL_API_TOKEN=<random-strong-secret>
    TAXONOMY_IMAGE_REF=:v0.1.0
    TAXONOMY_LLM_PROVIDER=openai-compatible
    TAXONOMY_LLM_MODEL=qwen3-14b-awq
@@ -219,6 +219,9 @@ Make sure Docker and Docker Compose are installed on your system. These are usua
    ```bash
    docker compose --profile taxonomy exec taxonomy python -c 'import os, urllib.request; req = urllib.request.Request("http://127.0.0.1:8000/v1/preflight", headers={"Authorization": "Bearer " + os.environ["TAXONOMY_SERVICE_TOKEN"]}); print(urllib.request.urlopen(req, timeout=10).read().decode())'
    ```
+
+   This command runs inside the taxonomy container, so `127.0.0.1:8000` refers to the taxonomy service itself.
+   The preflight endpoint then checks Hub internal auth and LLM reachability from taxonomy.
 
    The taxonomy service remains internal to the compose network by default. For production workloads,
    `TAXONOMY_MAX_RECORDS` defaults to `50000`; override it only as an advanced safety limit after sizing CPU,

--- a/docs/self-hosting/setup/kubernetes.mdx
+++ b/docs/self-hosting/setup/kubernetes.mdx
@@ -145,6 +145,48 @@ llm:
 Keep `llm.enabled: false` when you use Google Vertex, Azure, AWS Bedrock, or an externally managed
 OpenAI-compatible endpoint. Configure those providers through `deployment.env`.
 
+### Optional AI Taxonomy Beta
+
+The Helm chart can optionally deploy the standalone taxonomy service. This is disabled by default and does not
+force the bundled Qwen/vLLM runtime.
+
+To deploy taxonomy and reuse the bundled Qwen/vLLM runtime:
+
+```yaml
+llm:
+  enabled: true
+
+taxonomy:
+  enabled: true
+```
+
+With this setup, taxonomy uses the in-cluster vLLM router for cluster labeling and 5-level taxonomy generation.
+The chart also injects `TAXONOMY_SERVICE_URL`, `TAXONOMY_SERVICE_TOKEN`, and `HUB_INTERNAL_API_TOKEN` into Hub API.
+
+To use your own OpenAI-compatible LLM endpoint instead, keep `llm.enabled: false` and set the taxonomy LLM values:
+
+```yaml
+taxonomy:
+  enabled: true
+  llm:
+    model: qwen3-14b-awq
+    baseUrl: http://my-llm-gateway:8000/v1
+    existingSecret: taxonomy-llm-secret
+```
+
+The `taxonomy-llm-secret` secret must contain `TAXONOMY_LLM_API_KEY`. If your endpoint does not enforce
+authentication, store a non-empty dummy value.
+
+After startup, run the authenticated preflight check from inside the taxonomy pod:
+
+```sh
+kubectl exec -n formbricks deploy/formbricks-taxonomy -- \
+  python -c 'import os, urllib.request; req = urllib.request.Request("http://127.0.0.1:8000/v1/preflight", headers={"Authorization": "Bearer " + os.environ["TAXONOMY_SERVICE_TOKEN"]}); print(urllib.request.urlopen(req, timeout=10).read().decode())'
+```
+
+The taxonomy service is internal-only by default. Kubernetes probes use public `/health`; `/v1/preflight` is for
+operator validation and requires the internal taxonomy bearer token.
+
 ## 4. Upgrade The Deployment
 
 For normal chart upgrades:
@@ -177,6 +219,7 @@ For a Formbricks 4.x to 5.0 migration, confirm the following before running the 
 | `envoyRedis.enabled`          | Deploys a dedicated Redis backend for Envoy rate limiting     |
 | `llm.enabled`                 | Deploys the optional bundled Qwen/vLLM runtime                |
 | `llm.autoConfigureApp`        | Injects Formbricks OpenAI-compatible env vars for bundled Qwen |
+| `taxonomy.enabled`            | Deploys the optional standalone AI taxonomy service           |
 | `postgresql.externalDatabaseUrl` | Uses an external PostgreSQL service instead of in-cluster |
 | `redis.externalRedisUrl`      | Uses an external Redis/Valkey service instead of in-cluster   |
 


### PR DESCRIPTION
## Summary

- add Docker Compose profiles for bundled Qwen/vLLM and the standalone taxonomy service
- document production env wiring for Qwen, taxonomy, and OpenAI-compatible LLM configuration
- relax Docker parse-time secret interpolation while keeping runtime secret requirements
- prevent shared `docker/.env` taxonomy secrets from leaking into the Formbricks web container

## Validation

- `docker compose -f docker/docker-compose.yml config`
- `docker compose --profile qwen --profile taxonomy -f docker/docker-compose.yml config`
- rendered config boundary check: Formbricks receives app AI env, Hub receives taxonomy service auth, taxonomy receives LLM auth, and Formbricks gets empty taxonomy secret values
- rebuilt local taxonomy image and verified authenticated `/v1/preflight` returns Hub + LLM `ok`

## Notes

Real vLLM startup could not be completed on this machine because Docker GPU allocation fails with `failed to discover GPU vendor from CDI: no known GPU vendor found`. The Compose wiring renders correctly; runtime verification needs a GPU-capable Docker host with NVIDIA Container Toolkit/CDI configured.
