### PR TITLE
chore: adds docs for flutter sdk support

### DIFF
--- a/docs/surveys/website-app-surveys/framework-guides.mdx
+++ b/docs/surveys/website-app-surveys/framework-guides.mdx
@@ -48,6 +48,10 @@ Integrate the **Formbricks App Survey SDK** into your app using multiple options
   SDK.
 </Card>
 
+<Card title="Flutter" icon="flutter" color="lightblue" href="#flutter">
+  Add surveys to your Flutter app on iOS and Android with our Dart SDK.
+</Card>
+
 </CardGroup>
 
 ## Prerequisites
@@ -500,6 +504,99 @@ Formbricks.logout()
 | workspace-id | string | Formbricks Workspace ID.               |
 | app-url        | string | URL of the hosted Formbricks instance. |
 
+## Flutter
+
+<Info>
+  **Platform Support:** The Formbricks Flutter SDK targets **iOS and Android only**. Flutter Web and desktop are not supported.
+</Info>
+
+Install the Formbricks Flutter SDK from [pub.dev](https://pub.dev/packages/formbricks):
+
+```bash
+flutter pub add formbricks
+```
+
+### Usage
+
+Mount the `Formbricks` widget once, high in your widget tree (e.g. alongside your app's home). It initializes the SDK on mount and renders any triggered survey in a modal overlay:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:formbricks/formbricks.dart';
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Stack(
+        children: [
+          const HomePage(),
+          // Initializes the SDK and hosts the survey overlay.
+          Formbricks(
+            appUrl: "<app-url>", // use PUBLIC_URL if you are using multi-domain setup, otherwise use WEBAPP_URL
+            workspaceId: "<workspace-id>",
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+Then drive the SDK through its static API from anywhere:
+
+```dart
+// 1. Trigger a code action — shows a matching, eligible survey.
+await Formbricks.track("button_clicked");
+
+// 2. Identify the current user.
+await Formbricks.setUserId("user_123");
+
+// 3. Set or add user attributes.
+await Formbricks.setAttribute("plan", "pro");
+await Formbricks.setAttributes({"plan": "pro", "mrr": 99, "signup_date": DateTime.now()});
+
+// 4. Set the survey language.
+await Formbricks.setLanguage("de");
+
+// 5. Reset to an anonymous session on sign-out.
+await Formbricks.logout();
+```
+
+<Note>
+  Prefer to initialize before any UI mounts? Call `Formbricks.setup(appUrl: ..., workspaceId: ...)` directly — the widget still needs to be in the tree to render surveys, but it won't re-run setup (setup is idempotent). All static methods are sequenced through an internal command queue, so calls run in submission order and return a `Future<Result<void, FormbricksError>>`.
+</Note>
+
+### Public API
+
+| Method                                              | Description                                                              |
+| --------------------------------------------------- | ------------------------------------------------------------------------ |
+| `Formbricks(appUrl:, workspaceId:, logLevel:)`      | Host widget — initializes the SDK and renders triggered surveys.         |
+| `Formbricks.setup({appUrl, workspaceId, logLevel})` | Imperative initialization. Idempotent.                                   |
+| `Formbricks.track(String name)`                     | Fire a code action; shows a matching eligible survey.                    |
+| `Formbricks.setUserId(String userId)`               | Identify the contact. Switching ids resets the prior user's state first. |
+| `Formbricks.setAttribute(String key, Object value)` | Set one attribute (`String` / `num` / `DateTime`).                       |
+| `Formbricks.setAttributes(Map<String, Object>)`     | Set several attributes at once.                                          |
+| `Formbricks.setLanguage(String language)`           | Set the survey language.                                                 |
+| `Formbricks.logout()`                               | Reset to an anonymous session.                                           |
+
+Attribute keys must be lowercase letters, numbers, and underscores, and start with a letter. `DateTime` values are sent as UTC ISO-8601 strings; numbers stay numbers. Identity and attribute changes are debounced (~500 ms) and coalesced into a single backend request.
+
+### Required Customizations
+
+| Name           | Type   | Description                            |
+| -------------- | ------ | -------------------------------------- |
+| workspace-id | string | Formbricks Workspace ID.               |
+| app-url        | string | URL of the hosted Formbricks instance. |
+
+<Note>
+  Surveys render by loading `{appUrl}/js/surveys.umd.cjs` in a WebView, so that URL must be reachable from the device. Formbricks Cloud and standard self-hosted instances serve this script automatically. Config is persisted with `shared_preferences` and is **not encrypted at rest** — avoid putting sensitive PII in attribute values.
+</Note>
+
+Now, visit the [Validate Your Setup](#validate-your-setup) section to verify your setup!
+
 ## Validate your setup
 
 Once you've completed the steps above, validate your setup by checking the Setup Checklist in the Settings. The widget status indicator should change from this:
@@ -513,7 +610,7 @@ To this:
 
 <Note>
   The debug mode is only available in the JavaScript SDK and works exclusively in the browser. It is not
-  supported in mobile SDKs such as React Native, iOS, or Android.
+  supported in mobile SDKs such as React Native, iOS, Android, or Flutter.
 </Note>
 
 Enabling debug mode in your browser can help troubleshoot issues with Formbricks. Here's how to activate it and what to look for in the logs.


### PR DESCRIPTION
Adds docs for the flutter sdk, which can be used to run formbricks surveys in a flutter app programmatically 🎉 
Closes ENG-1129

## How to test:
```
cd docs/
npx mintlify dev
```
to run the local docs server through mintlify, then check the framework guides section under Website and App surveys
https://formbricks.com/docs/surveys/website-app-surveys/framework-guides
