### PR TITLE
fix(follow-ups): pass explicit locale to getTranslate in worker

### DIFF
--- a/apps/web/app/lib/pipelines.test.ts
+++ b/apps/web/app/lib/pipelines.test.ts
@@ -18,6 +18,10 @@ vi.mock("@/lib/jobs/config", () => ({
   getJobsQueueingConfig: vi.fn(),
 }));
 
+vi.mock("@/lib/utils/locale", () => ({
+  findMatchingLocale: vi.fn(() => Promise.resolve("en-US")),
+}));
+
 vi.mock("@formbricks/logger", () => ({
   logger: {
     error: vi.fn(),
@@ -50,7 +54,7 @@ describe("sendToPipeline", () => {
     await sendToPipeline(testData);
 
     expect(getBackgroundJobProducer).toHaveBeenCalledTimes(1);
-    expect(mockEnqueueResponsePipeline).toHaveBeenCalledWith(testData);
+    expect(mockEnqueueResponsePipeline).toHaveBeenCalledWith({ ...testData, locale: "en-US" });
   });
 
   test("logs enqueue failures and rethrows", async () => {

--- a/apps/web/app/lib/pipelines.test.ts
+++ b/apps/web/app/lib/pipelines.test.ts
@@ -5,6 +5,7 @@ import { logger } from "@formbricks/logger";
 import { TResponse } from "@formbricks/types/responses";
 import { sendToPipeline } from "@/app/lib/pipelines";
 import { getJobsQueueingConfig } from "@/lib/jobs/config";
+import { findMatchingLocale } from "@/lib/utils/locale";
 
 const mockEnqueueResponsePipeline = vi.fn();
 
@@ -84,5 +85,31 @@ describe("sendToPipeline", () => {
       "BullMQ response pipeline queueing is not enabled"
     );
     expect(getBackgroundJobProducer).not.toHaveBeenCalled();
+  });
+
+  test("falls back to undefined locale when findMatchingLocale throws", async () => {
+    vi.mocked(findMatchingLocale).mockRejectedValueOnce(new Error("headers unavailable"));
+    mockEnqueueResponsePipeline.mockResolvedValue({
+      jobId: "job-1",
+      jobName: "response-pipeline.process",
+      queueName: "background-jobs",
+    });
+
+    await sendToPipeline(testData);
+
+    expect(mockEnqueueResponsePipeline).toHaveBeenCalledWith({ ...testData, locale: undefined });
+  });
+
+  test("preserves an existing job.locale instead of resolving it", async () => {
+    mockEnqueueResponsePipeline.mockResolvedValue({
+      jobId: "job-1",
+      jobName: "response-pipeline.process",
+      queueName: "background-jobs",
+    });
+
+    await sendToPipeline({ ...testData, locale: "de-DE" });
+
+    expect(findMatchingLocale).not.toHaveBeenCalled();
+    expect(mockEnqueueResponsePipeline).toHaveBeenCalledWith({ ...testData, locale: "de-DE" });
   });
 });

--- a/apps/web/app/lib/pipelines.ts
+++ b/apps/web/app/lib/pipelines.ts
@@ -1,6 +1,8 @@
 import { TResponsePipelineJobData, getBackgroundJobProducer } from "@formbricks/jobs";
 import { logger } from "@formbricks/logger";
+import type { TUserLocale } from "@formbricks/types/user";
 import { getJobsQueueingConfig } from "@/lib/jobs/config";
+import { findMatchingLocale } from "@/lib/utils/locale";
 
 export const sendToPipeline = async (job: TResponsePipelineJobData): Promise<void> => {
   try {
@@ -9,8 +11,19 @@ export const sendToPipeline = async (job: TResponsePipelineJobData): Promise<voi
       throw new Error("BullMQ response pipeline queueing is not enabled");
     }
 
+    // Resolve the locale here (request scope) so the worker can localize follow-up emails
+    // without calling headers()/cookies(), which are unavailable outside a request.
+    let locale: TUserLocale | undefined = job.locale;
+    if (!locale) {
+      try {
+        locale = await findMatchingLocale();
+      } catch {
+        locale = undefined;
+      }
+    }
+
     const producer = getBackgroundJobProducer();
-    await producer.enqueueResponsePipeline(job);
+    await producer.enqueueResponsePipeline({ ...job, locale });
   } catch (error) {
     logger.error(
       { error, event: job.event, surveyId: job.surveyId, workspaceId: job.workspaceId },

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
@@ -318,6 +318,7 @@ describe("processResponsePipelineJob", () => {
         {
           ...baseData,
           event: "responseFinished",
+          locale: "de-DE",
         },
         baseContext
       )
@@ -385,7 +386,7 @@ describe("processResponsePipelineJob", () => {
         ],
       },
     });
-    expect(mockSendFollowUpsForResponse).toHaveBeenCalledWith("response_123");
+    expect(mockSendFollowUpsForResponse).toHaveBeenCalledWith("response_123", "de-DE");
     expect(mockSendResponseFinishedEmail).toHaveBeenCalledWith(
       "owner@example.com",
       "en-US",
@@ -549,7 +550,7 @@ describe("processResponsePipelineJob", () => {
     ).resolves.toBeUndefined();
 
     expect(mockHandleIntegrations).toHaveBeenCalledTimes(1);
-    expect(mockSendFollowUpsForResponse).toHaveBeenCalledWith("response_123");
+    expect(mockSendFollowUpsForResponse).toHaveBeenCalledWith("response_123", undefined);
     expect(mockSendResponseFinishedEmail).toHaveBeenCalledTimes(1);
     expect(mockPrismaSurveyUpdate).toHaveBeenCalledTimes(1);
     expect(mockLoggerError).toHaveBeenCalledWith(

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
@@ -460,7 +460,7 @@ const handleFollowUpsSafely = async ({
   }
 
   try {
-    const followUpsResult = await sendFollowUpsForResponse(data.response.id);
+    const followUpsResult = await sendFollowUpsForResponse(data.response.id, data.locale);
     if (!followUpsResult.ok && followUpsResult.error.code !== FollowUpSendError.FOLLOW_UP_NOT_ALLOWED) {
       logger.error(
         {

--- a/apps/web/modules/survey/follow-ups/lib/email.ts
+++ b/apps/web/modules/survey/follow-ups/lib/email.ts
@@ -9,6 +9,7 @@ import { TResponse } from "@formbricks/types/responses";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurveyFollowUp } from "@formbricks/types/surveys/follow-up";
 import { TSurvey } from "@formbricks/types/surveys/types";
+import { TUserLocale } from "@formbricks/types/user";
 import { DEFAULT_LOCALE, IMPRINT_ADDRESS, IMPRINT_URL, PRIVACY_URL, TERMS_URL } from "@/lib/constants";
 import { getElementResponseMapping } from "@/lib/responses";
 import { parseRecallInfo } from "@/lib/utils/recall";
@@ -26,6 +27,7 @@ export const sendFollowUpEmail = async ({
   includeVariables = false,
   includeHiddenFields = false,
   logoUrl,
+  locale,
 }: {
   followUp: TSurveyFollowUp;
   to: string;
@@ -36,6 +38,7 @@ export const sendFollowUpEmail = async ({
   survey: TSurvey;
   response: TResponse;
   logoUrl?: string;
+  locale?: TUserLocale;
 }): Promise<void> => {
   const {
     action: {
@@ -44,7 +47,8 @@ export const sendFollowUpEmail = async ({
   } = followUp;
 
   // Worker context (no request scope) — pass explicit locale to skip headers()/cookies().
-  const t = await getTranslate(DEFAULT_LOCALE);
+  // Falls back to DEFAULT_LOCALE when the respondent locale wasn't captured at submission.
+  const t = await getTranslate(locale ?? DEFAULT_LOCALE);
 
   // Process body: parse recall tags and sanitize HTML
   const processedBody = sanitizeHtml(parseRecallInfo(body, response.data, response.variables), {

--- a/apps/web/modules/survey/follow-ups/lib/email.ts
+++ b/apps/web/modules/survey/follow-ups/lib/email.ts
@@ -9,7 +9,7 @@ import { TResponse } from "@formbricks/types/responses";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurveyFollowUp } from "@formbricks/types/surveys/follow-up";
 import { TSurvey } from "@formbricks/types/surveys/types";
-import { IMPRINT_ADDRESS, IMPRINT_URL, PRIVACY_URL, TERMS_URL } from "@/lib/constants";
+import { DEFAULT_LOCALE, IMPRINT_ADDRESS, IMPRINT_URL, PRIVACY_URL, TERMS_URL } from "@/lib/constants";
 import { getElementResponseMapping } from "@/lib/responses";
 import { parseRecallInfo } from "@/lib/utils/recall";
 import { getTranslate } from "@/lingodotdev/server";
@@ -43,7 +43,8 @@ export const sendFollowUpEmail = async ({
     },
   } = followUp;
 
-  const t = await getTranslate();
+  // Worker context (no request scope) — pass explicit locale to skip headers()/cookies().
+  const t = await getTranslate(DEFAULT_LOCALE);
 
   // Process body: parse recall tags and sanitize HTML
   const processedBody = sanitizeHtml(parseRecallInfo(body, response.data, response.variables), {

--- a/apps/web/modules/survey/follow-ups/lib/follow-ups.ts
+++ b/apps/web/modules/survey/follow-ups/lib/follow-ups.ts
@@ -7,6 +7,7 @@ import { TOrganization } from "@formbricks/types/organizations";
 import { TResponse } from "@formbricks/types/responses";
 import { TSurveyFollowUp } from "@formbricks/types/surveys/follow-up";
 import { TSurvey } from "@formbricks/types/surveys/types";
+import { TUserLocale } from "@formbricks/types/user";
 import { getOrganizationByWorkspaceId } from "@/lib/organization/service";
 import { getResponse } from "@/lib/response/service";
 import { getSurvey } from "@/lib/survey/service";
@@ -21,7 +22,8 @@ const evaluateFollowUp = async (
   followUp: TSurveyFollowUp,
   survey: TSurvey,
   response: TResponse,
-  organization: TOrganization
+  organization: TOrganization,
+  locale?: TUserLocale
 ): Promise<FollowUpResult> => {
   try {
     const { properties } = followUp.action;
@@ -43,6 +45,7 @@ const evaluateFollowUp = async (
         includeVariables: properties.includeVariables,
         includeHiddenFields: properties.includeHiddenFields,
         logoUrl,
+        locale,
       });
 
       return {
@@ -75,6 +78,7 @@ const evaluateFollowUp = async (
           attachResponseData: properties.attachResponseData,
           includeVariables: properties.includeVariables,
           includeHiddenFields: properties.includeHiddenFields,
+          locale,
         });
 
         return {
@@ -110,6 +114,7 @@ const evaluateFollowUp = async (
           attachResponseData: properties.attachResponseData,
           includeVariables: properties.includeVariables,
           includeHiddenFields: properties.includeHiddenFields,
+          locale,
         });
 
         return {
@@ -145,7 +150,8 @@ const evaluateFollowUp = async (
  * and only requires a response ID.
  */
 export const sendFollowUpsForResponse = async (
-  responseId: string
+  responseId: string,
+  locale?: TUserLocale
 ): Promise<
   Result<FollowUpResult[], { code: FollowUpSendError; message: string; meta?: Record<string, string> }>
 > => {
@@ -226,7 +232,7 @@ export const sendFollowUpsForResponse = async (
         }
       }
 
-      return evaluateFollowUp(followUp, survey, response, organization);
+      return evaluateFollowUp(followUp, survey, response, organization, locale);
     });
 
     const followUpResults = await Promise.all(followUpPromises);

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { ZResponse } from "@formbricks/types/responses";
 import { ZTag } from "@formbricks/types/tags";
+import { ZUserLocale } from "@formbricks/types/user";
 
 export const ZTestLogJobData = z.object({
   message: z.string().min(1),
@@ -30,6 +31,9 @@ export const ZResponsePipelineJobData = z.object({
   response: ZResponsePipelineJobResponse,
   workspaceId: z.cuid2(),
   surveyId: z.cuid2(),
+  // Respondent's resolved locale, captured in request scope (headers() is unavailable in the worker).
+  // Used to localize follow-up email chrome; falls back to DEFAULT_LOCALE when absent.
+  locale: ZUserLocale.optional(),
 });
 
 export type TResponsePipelineJobData = z.infer<typeof ZResponsePipelineJobData>;


### PR DESCRIPTION
## Summary

- Follow-up emails fail with \`headers was called outside a request scope\` when triggered from the BullMQ worker.
- \`sendFollowUpEmail\` calls \`getTranslate()\` with no arg → falls into \`getLocale()\` → \`getServerSession()\` + \`findMatchingLocale()\` → both use \`headers()\` / \`cookies()\` from \`next/headers\`, which only work inside a request lifecycle.
- The follow-up path now runs from the response-pipeline job (\`processResponsePipelineJob\` → \`handleFollowUpsSafely\` → \`sendFollowUpsForResponse\`), i.e. outside any request scope, so the call throws and the email never sends.
- Fix: pass \`DEFAULT_LOCALE\` explicitly to \`getTranslate\` in \`sendFollowUpEmail\`. \`getTranslate(locale?)\` already short-circuits \`getLocale()\` when a locale is provided.

## Stack trace observed

\`\`\`
ERROR Follow-up processing errors
    errors: [
      "FollowUp sko65uexiwfrk4t9osheuh45 failed: \`headers\` was called outside a request scope.
       Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context"
    ]
\`\`\`

## Follow-up

Localised follow-up emails (using the recipient's chosen survey language) can be threaded through later via \`response.language → TUserLocale\`. This PR only restores delivery; emails default to \`en-US\` for now.

## Test plan

- [ ] Trigger a survey with a follow-up configured. Submit a response. Confirm follow-up email arrives.
- [ ] Confirm no \`headers was called outside a request scope\` error in worker logs.