### PR TITLE
fix: restore Manage billing details button for custom and scale plans [ENG-1330] [backport 5.1]

### DIFF
--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -721,7 +721,7 @@ export const PricingTable = ({
           title={t("workspace.settings.billing.subscription")}
           description={t("workspace.settings.billing.subscription_description")}
           buttonInfo={
-            canShowSubscriptionButton && hasPaymentMethod
+            canShowSubscriptionButton
               ? {
                   text: t("workspace.settings.billing.manage_billing_details"),
                   onClick: () => void openBillingPortal(),


### PR DESCRIPTION
Backport of #8287 to \`release/5.1\`.

## Scope

Only the flag change in \`pricing-table.tsx\` (\`canShowSubscriptionButton && hasPaymentMethod\` → \`canShowSubscriptionButton\`). Translation/i18n refactor and locale files intentionally excluded — 5.1 doesn't need those.

## Summary

- "Manage billing details" button disappeared for Custom and Scale orgs, blocking them from updating their card.
- Root cause: the button was gated on \`hasPaymentMethod\`, which only reads \`subscription.default_payment_method\`. That field is \`null\` whenever the payment method lives at the customer level (\`invoice_settings.default_payment_method\`) — typical for invoiced Custom plans and for Scale users who added their card via the portal.
- Fix: show the button whenever \`canShowSubscriptionButton\` (billing rights + \`stripeCustomerId\`).

## Test plan

- [ ] Custom-plan org: Billing page shows "Manage billing details" → opens the Stripe billing portal.
- [ ] Scale org with payment method at customer level: same.
- [ ] Trialing-without-payment org: button still hidden (no \`stripeCustomerId\`).
- [ ] Member (non-billing-rights) user: button stays hidden.

Linear: [ENG-1330](https://linear.app/formbricks/issue/ENG-1330/custom-plans-cannot-manage-billing-card-details)