### PR TITLE
docs: document RustFS server-level CORS for self-hosted file uploads

### DIFF
--- a/docs/self-hosting/configuration/file-uploads.mdx
+++ b/docs/self-hosting/configuration/file-uploads.mdx
@@ -334,12 +334,16 @@ Configure CORS on your S3 bucket with the following settings:
 
 - **AWS S3**: Navigate to your bucket → Permissions → Cross-origin resource sharing (CORS) → Edit → Paste the JSON configuration
 - **DigitalOcean Spaces**: Navigate to your Space → Settings → CORS Configurations → Add CORS configuration → Paste the JSON
-- **RustFS (self-hosted)**: RustFS configures CORS at the server level, not per bucket — see [RustFS CORS Configuration](#rustfs-cors-configuration) below.
+- **RustFS (self-hosted)**: configured automatically by the bundled setup, or via a server-level env var for standalone deployments — see [RustFS CORS Configuration](#rustfs-cors-configuration) below.
 - **Other S3-compatible providers**: Refer to your provider's documentation for CORS configuration
 
 ### RustFS CORS Configuration
 
-RustFS does **not** use a per-bucket CORS policy. It controls CORS at the server level through the `RUSTFS_CORS_ALLOWED_ORIGINS` environment variable, set on the **RustFS** container (not on Formbricks). Set it to the origin(s) you serve Formbricks from — your `WEBAPP_URL` — comma-separated for multiple values:
+RustFS supports CORS two ways: a **server-level** allow-list set via the `RUSTFS_CORS_ALLOWED_ORIGINS` environment variable on the RustFS server, and **per-bucket** CORS via the S3 `PutBucketCors` API (e.g. `mc cors set`).
+
+**Bundled Formbricks setup** (the [one-click script](/self-hosting/setup/one-click), driven by `docker/rustfs-init.sh`): CORS is configured for you. The bootstrap applies a per-bucket policy via `mc cors set`, scoped to your Formbricks domain — nothing else to do.
+
+**Standalone RustFS** (managed separately from Formbricks): set `RUSTFS_CORS_ALLOWED_ORIGINS` on the RustFS server to the origin(s) you serve Formbricks from — your `WEBAPP_URL` — comma-separated for multiple values:
 
 ```env
 # Set on the RustFS server, then restart RustFS
@@ -347,19 +351,18 @@ RUSTFS_CORS_ALLOWED_ORIGINS=https://app.yourdomain.com
 ```
 
 <Note>
-  When `RUSTFS_CORS_ALLOWED_ORIGINS` is unset, RustFS allows **all** origins; a non-empty value is treated as an
-  allow-list. So if browser uploads fail with a CORS error while the file still appears in RustFS, this variable
-  is most likely already set to a value that excludes your Formbricks origin — add your origin to it (or set it to
-  `*` to allow all). Use an explicit origin list in production.
+  When `RUSTFS_CORS_ALLOWED_ORIGINS` is unset, the RustFS server allows **all** origins; a non-empty value is
+  treated as an allow-list. So if browser uploads fail with a CORS error while the file still appears in RustFS,
+  this variable is most likely already set to a value that excludes your Formbricks origin — add your origin to it
+  (or set it to `*` to allow all). Use an explicit origin list in production.
 </Note>
 
 <Warning>
-  Avoid relying on per-bucket CORS for RustFS. RustFS's support for the S3 `PutBucketCors` API (used by tools such
-  as `mc cors set`) has varied across releases and can return "not implemented" on some builds. The
-  `RUSTFS_CORS_ALLOWED_ORIGINS` server variable above is the reliable mechanism.
+  For standalone deployments, prefer the server-level `RUSTFS_CORS_ALLOWED_ORIGINS` variable over manually applying
+  a per-bucket CORS policy: RustFS's support for the S3 `PutBucketCors` API has varied across releases and can
+  return "not implemented" on some builds. (The bundled bootstrap pins a RustFS version where per-bucket
+  `mc cors set` works.)
 </Warning>
-
-If you use the bundled RustFS setup (the [one-click script](/self-hosting/setup/one-click)), CORS is configured for you and scoped to your Formbricks domain.
 
 ### RustFS Security
 

--- a/docs/self-hosting/configuration/file-uploads.mdx
+++ b/docs/self-hosting/configuration/file-uploads.mdx
@@ -334,7 +334,32 @@ Configure CORS on your S3 bucket with the following settings:
 
 - **AWS S3**: Navigate to your bucket → Permissions → Cross-origin resource sharing (CORS) → Edit → Paste the JSON configuration
 - **DigitalOcean Spaces**: Navigate to your Space → Settings → CORS Configurations → Add CORS configuration → Paste the JSON
+- **RustFS (self-hosted)**: RustFS configures CORS at the server level, not per bucket — see [RustFS CORS Configuration](#rustfs-cors-configuration) below.
 - **Other S3-compatible providers**: Refer to your provider's documentation for CORS configuration
+
+### RustFS CORS Configuration
+
+RustFS does **not** use a per-bucket CORS policy. It controls CORS at the server level through the `RUSTFS_CORS_ALLOWED_ORIGINS` environment variable, set on the **RustFS** container (not on Formbricks). Set it to the origin(s) you serve Formbricks from — your `WEBAPP_URL` — comma-separated for multiple values:
+
+```env
+# Set on the RustFS server, then restart RustFS
+RUSTFS_CORS_ALLOWED_ORIGINS=https://app.yourdomain.com
+```
+
+<Note>
+  When `RUSTFS_CORS_ALLOWED_ORIGINS` is unset, RustFS allows **all** origins; a non-empty value is treated as an
+  allow-list. So if browser uploads fail with a CORS error while the file still appears in RustFS, this variable
+  is most likely already set to a value that excludes your Formbricks origin — add your origin to it (or set it to
+  `*` to allow all). Use an explicit origin list in production.
+</Note>
+
+<Warning>
+  Avoid relying on per-bucket CORS for RustFS. RustFS's support for the S3 `PutBucketCors` API (used by tools such
+  as `mc cors set`) has varied across releases and can return "not implemented" on some builds. The
+  `RUSTFS_CORS_ALLOWED_ORIGINS` server variable above is the reliable mechanism.
+</Warning>
+
+If you use the bundled RustFS setup (the [one-click script](/self-hosting/setup/one-click)), CORS is configured for you and scoped to your Formbricks domain.
 
 ### RustFS Security
 
@@ -365,6 +390,7 @@ When using bundled RustFS:
 5. We use S3 presigned URLs for uploads. Make sure your CORS policy allows presigned URL uploads; otherwise, uploads will fail.
    Some providers (e.g., Hetzner’s object storage) [require a specific CORS configuration](https://github.com/formbricks/formbricks/discussions/6641#discussioncomment-14574048).
    If you’re using the bundled RustFS setup, this is already configured for you.
+6. **The file appears in your storage but Formbricks still reports “upload failed.”** This is the classic CORS symptom — the browser uploaded the file successfully but could not read the response. For RustFS, set `RUSTFS_CORS_ALLOWED_ORIGINS` to include your Formbricks origin (see [RustFS CORS Configuration](#rustfs-cors-configuration)).
 
 **Images not displaying in surveys:**
 

--- a/docs/self-hosting/setup/cluster-setup.mdx
+++ b/docs/self-hosting/setup/cluster-setup.mdx
@@ -132,7 +132,7 @@ S3_FORCE_PATH_STYLE=1
 When using S3 in a cluster setup, ensure:
 
 - all replicas use the same bucket
-- the bucket has the required CORS settings
+- CORS allows your Formbricks origin (for RustFS, set `RUSTFS_CORS_ALLOWED_ORIGINS`; see [File Uploads](/self-hosting/configuration/file-uploads#rustfs-cors-configuration))
 - the credentials have read/write access for the assets you expect Formbricks to manage
 
 ## v5 Cluster Notes

--- a/docs/self-hosting/setup/docker.mdx
+++ b/docs/self-hosting/setup/docker.mdx
@@ -293,6 +293,9 @@ services:
       RUSTFS_ADDRESS: ":9000"
       RUSTFS_CONSOLE_ENABLE: "true"
       RUSTFS_CONSOLE_ADDRESS: ":9001"
+      # CORS for browser uploads: set to your Formbricks origin(s), comma-separated.
+      # Unset = allow all origins; a value is treated as an allow-list. See the File Uploads guide.
+      RUSTFS_CORS_ALLOWED_ORIGINS: "https://app.yourdomain.com"
     ports:
       - "9000:9000"
       - "9001:9001"


### PR DESCRIPTION
## What does this PR do?

Documents how to configure CORS for **RustFS** in self-hosted deployments, which was previously undocumented for standalone (non-bundled) RustFS setups.

The self-hosting docs framed CORS only as per-bucket S3 CORS and pointed standalone RustFS users to "your provider's documentation" — a dead end, since RustFS controls CORS at the **server level** via the `RUSTFS_CORS_ALLOWED_ORIGINS` env var, which appeared nowhere in our docs. The result is a confusing failure mode: the browser upload succeeds and the file lands in RustFS, but Formbricks reports "upload failed" because the browser can't read the cross-origin response.

Changes:

- **file-uploads.mdx**: new "RustFS CORS Configuration" section documenting `RUSTFS_CORS_ALLOWED_ORIGINS` (server-level — allows all origins when unset, enforces an allow-list when set), a note that per-bucket `PutBucketCors` is unreliable across RustFS versions, a RustFS entry in the CORS provider list, and a troubleshooting item for the "file lands but upload fails" symptom.
- **docker.mdx**: add `RUSTFS_CORS_ALLOWED_ORIGINS` to the manual `rustfs` service (previously had no CORS step).
- **cluster-setup.mdx**: make the vague "bucket has the required CORS settings" requirement actionable with a link to the new section.

Documentation-only change — no linked issue, no UI changes.

## How should this be tested?

- Preview the docs and confirm the new **RustFS CORS Configuration** section renders under File Uploads, and that the `#rustfs-cors-configuration` anchor links (from the CORS provider list and the new troubleshooting item) resolve correctly.
- Confirm `RUSTFS_CORS_ALLOWED_ORIGINS` renders in the `docker.mdx` compose snippet and the `cluster-setup.mdx` link points to the new section.
- The documented behavior was verified against `rustfs:1.0.0-alpha.93` (the pinned version):
  - unset `RUSTFS_CORS_ALLOWED_ORIGINS` → all origins allowed (origin reflected back)
  - set to specific origin(s) → enforced allow-list; disallowed origins receive no `Access-Control-Allow-Origin`
  - `*` → reflects the request origin, so it works with credentialed requests

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` — N/A (documentation-only change)
- [ ] Checked for warnings, there are none — N/A (documentation-only change)
- [ ] Removed all `console.logs` — N/A (documentation-only change)
- [x] Merged the latest changes from main onto my branch (branched from latest `origin/main`)
- [ ] My changes don't cause any responsiveness issues — N/A (documentation-only change)
- [ ] First PR at Formbricks? — N/A (not first PR)

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots — N/A (no UI changes)
- [x] Updated the Formbricks Docs if changes were necessary (this PR is the docs update)
