### PR TITLE
fix: create survey button overflows card boundary on survey creation page

### DIFF
--- a/apps/web/modules/survey/components/template-list/components/start-from-scratch-template.tsx
+++ b/apps/web/modules/survey/components/template-list/components/start-from-scratch-template.tsx
@@ -57,11 +57,12 @@ export const StartFromScratchTemplate = ({
       {showCreateSurveyButton && (
         <div className="text-left">
           <Button
-            className="mt-6 px-6 py-3"
+            className="mt-6 max-w-full px-6 py-3"
             disabled={activeTemplate === null}
             loading={loading}
+            aria-label={t("common.create_survey")}
             onClick={() => createSurvey(activeTemplate)}>
-            {t("common.create_survey")}
+            <span className="truncate">{t("common.create_survey")}</span>
           </Button>
         </div>
       )}

--- a/apps/web/modules/survey/components/template-list/components/template.tsx
+++ b/apps/web/modules/survey/components/template-list/components/template.tsx
@@ -58,11 +58,12 @@ export const Template = ({
       {showCreateSurveyButton && (
         <div className="flex justify-start">
           <Button
-            className="mt-6 px-6 py-3"
+            className="mt-6 max-w-full px-6 py-3"
             disabled={activeTemplate === null}
             loading={loading}
+            aria-label={t("workspace.surveys.templates.use_this_template")}
             onClick={() => createSurvey(activeTemplate)}>
-            {t("workspace.surveys.templates.use_this_template")}
+            <span className="truncate">{t("workspace.surveys.templates.use_this_template")}</span>
           </Button>
         </div>
       )}


### PR DESCRIPTION
## What does this PR do?

Fixes #8032

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

- Go to the create survey page
- Resize the viewport to 880px or less
- Check the buttons to start from scratch or from a template

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary

<img width="892" height="693" alt="Screenshot 2026-06-16 at 12 51 52" src="https://github.com/user-attachments/assets/47a8c6ba-eb0b-4a9f-a10c-bde86b0a66bb" />
<img width="889" height="719" alt="Screenshot 2026-06-16 at 12 52 00" src="https://github.com/user-attachments/assets/f9c55505-848c-4bb6-8f65-9057e4831db5" />
