### PR TITLE
fix: avoid undefined workspace redirect

### DIFF
--- a/apps/web/app/ClientWorkspaceRedirect.tsx
+++ b/apps/web/app/ClientWorkspaceRedirect.tsx
@@ -12,6 +12,10 @@ const ClientWorkspaceRedirect = ({ userWorkspaceIds }: ClientWorkspaceRedirectPr
   const router = useRouter();
 
   useEffect(() => {
+    if (userWorkspaceIds.length === 0) {
+      return;
+    }
+
     const lastWorkspaceId = localStorage.getItem(FORMBRICKS_WORKSPACE_ID_LS);
 
     if (lastWorkspaceId && userWorkspaceIds.includes(lastWorkspaceId)) {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -52,10 +52,6 @@ const Page = async () => {
 
   const { isManager, isOwner } = getAccessFlags(currentUserMembership?.role);
 
-  if (allWorkspaceIds.length === 0 && !isOwner && !isManager) {
-    return redirect(`/organizations/${userOrganizations[0].id}/landing`);
-  }
-
   if (isOwner || isManager) {
     const onboardingWorkspace = await getOnboardingWorkspace(session.user.id, userOrganizations[0].id);
     const onboardingRedirectPath = await getOnboardingRedirectPath({
@@ -66,6 +62,10 @@ const Page = async () => {
     if (onboardingRedirectPath) {
       return redirect(onboardingRedirectPath);
     }
+  }
+
+  if (allWorkspaceIds.length === 0) {
+    return redirect(`/organizations/${userOrganizations[0].id}/landing`);
   }
 
   return <ClientWorkspaceRedirect userWorkspaceIds={allWorkspaceIds} />;


### PR DESCRIPTION
Fixes: ENG-1463

## What changed

- Redirect authenticated users with no accessible workspace ids to their organization landing page before rendering `ClientWorkspaceRedirect`.
- Preserve the existing owner/manager onboarding redirect when an onboarding workspace exists.

## Why

Production logs showed successful Azure AD SSO sign-ins followed by requests to `/workspaces/undefined`. The root cause is that the root page could pass an empty `userWorkspaceIds` array into `ClientWorkspaceRedirect`, which then used `userWorkspaceIds[0]` to build the workspace URL.

## Impact

Users who have an organization membership but no accessible workspaces no longer get stuck on the workspace error page. They land on the existing no-workspaces organization page instead.

## Validation

- `git diff --check -- apps/web/app/page.tsx`
- `pnpm exec eslint apps/web/app/page.tsx --max-warnings=0`

Note: `pnpm install --frozen-lockfile` emitted a local Node engine warning because this shell is running Node v25 while the repo expects Node 20, 22, or 24; install and the scoped lint still completed successfully.