### PR TITLE
fix: avoid undefined workspace redirect (Backport) [ENG-1463] (#8300)

### DIFF
--- a/apps/web/app/ClientWorkspaceRedirect.tsx
+++ b/apps/web/app/ClientWorkspaceRedirect.tsx
@@ -12,6 +12,10 @@ const ClientWorkspaceRedirect = ({ userWorkspaceIds }: ClientWorkspaceRedirectPr
   const router = useRouter();
 
   useEffect(() => {
+    if (userWorkspaceIds.length === 0) {
+      return;
+    }
+
     const lastWorkspaceId = localStorage.getItem(FORMBRICKS_WORKSPACE_ID_LS);
 
     if (lastWorkspaceId && userWorkspaceIds.includes(lastWorkspaceId)) {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -52,10 +52,6 @@ const Page = async () => {
 
   const { isManager, isOwner } = getAccessFlags(currentUserMembership?.role);
 
-  if (allWorkspaceIds.length === 0 && !isOwner && !isManager) {
-    return redirect(`/organizations/${userOrganizations[0].id}/landing`);
-  }
-
   if (isOwner || isManager) {
     const onboardingWorkspace = await getOnboardingWorkspace(session.user.id, userOrganizations[0].id);
     const onboardingRedirectPath = await getOnboardingRedirectPath({
@@ -66,6 +62,10 @@ const Page = async () => {
     if (onboardingRedirectPath) {
       return redirect(onboardingRedirectPath);
     }
+  }
+
+  if (allWorkspaceIds.length === 0) {
+    return redirect(`/organizations/${userOrganizations[0].id}/landing`);
   }
 
   return <ClientWorkspaceRedirect userWorkspaceIds={allWorkspaceIds} />;


### PR DESCRIPTION
Backport of #8300 to `release/5.1`.

## Summary

Cherry-picks `8b0f5ba` from `main`:

- Redirect authenticated users with no accessible workspace ids to their organization landing page before rendering `ClientWorkspaceRedirect`.
- Preserve the existing owner/manager onboarding redirect when an onboarding workspace exists.
- Guard `ClientWorkspaceRedirect` against an empty workspace list.

## Why

Production logs showed successful Azure AD SSO sign-ins followed by requests to `/workspaces/undefined`. The root page passed an empty `userWorkspaceIds` array into `ClientWorkspaceRedirect`, which then built the URL from `userWorkspaceIds[0]`.

## Linear

- ENG-1463

## Test plan

- [ ] Authenticated user with no accessible workspaces lands on the no-workspaces organization page, not `/workspaces/undefined`.
- [ ] Owner/manager with an onboarding workspace still hits the onboarding redirect.