### PR TITLE
fix(api/v2): scope organization user PATCH to authenticated org [ENG-1139]

### DIFF
--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
@@ -27,7 +27,7 @@ vi.mock("@formbricks/database", () => ({
     user: {
       findMany: vi.fn(),
       count: vi.fn(),
-      findUnique: vi.fn(),
+      findFirst: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
     },
@@ -153,10 +153,10 @@ describe("Users Lib", () => {
 
   describe("updateUser", () => {
     test("updates user and revalidates caches", async () => {
-      (prisma.user.findUnique as any).mockResolvedValueOnce(mockUser);
+      (prisma.user.findFirst as any).mockResolvedValueOnce(mockUser);
       (prisma.$transaction as any).mockResolvedValueOnce([{ ...mockUser, name: "Updated User" }]);
       const result = await updateUser({ email: mockUser.email, name: "Updated User" }, "org456");
-      expect(prisma.user.findUnique).toHaveBeenCalled();
+      expect(prisma.user.findFirst).toHaveBeenCalled();
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.data.name).toBe("Updated User");
@@ -168,7 +168,7 @@ describe("Users Lib", () => {
     });
 
     test("returns not_found if user doesn't exist", async () => {
-      (prisma.user.findUnique as any).mockResolvedValueOnce(null);
+      (prisma.user.findFirst as any).mockResolvedValueOnce(null);
       const result = await updateUser({ email: "unknown@example.com" }, "org456");
       expect(result.ok).toBe(false);
       if (!result.ok) {
@@ -176,8 +176,64 @@ describe("Users Lib", () => {
       }
     });
 
+    test("scopes the lookup to a membership in the authenticated organization", async () => {
+      (prisma.user.findFirst as any).mockResolvedValueOnce(null);
+
+      const result = await updateUser(
+        { email: "outsider@example.com", isActive: false, teams: [] },
+        "org456"
+      );
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe("not_found");
+      }
+
+      // The lookup MUST filter by both email and an organization membership; otherwise a
+      // caller could mutate a user that belongs only to another organization.
+      const lookupArgs = (prisma.user.findFirst as any).mock.calls[0]?.[0];
+      expect(lookupArgs?.where).toEqual({
+        email: "outsider@example.com",
+        memberships: { some: { organizationId: "org456" } },
+      });
+      // No write should happen when the user is not in the caller's organization.
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    test("only loads teamUsers for the authenticated organization", async () => {
+      (prisma.user.findFirst as any).mockResolvedValueOnce({
+        ...mockUser,
+        teamUsers: [],
+      });
+      (prisma.team.findMany as any).mockResolvedValueOnce([]);
+      (prisma.$transaction as any).mockResolvedValueOnce([{ ...mockUser, name: mockUser.name }]);
+
+      await updateUser({ email: mockUser.email, teams: [] }, "org456");
+
+      const lookupArgs = (prisma.user.findFirst as any).mock.calls[0]?.[0];
+      expect(lookupArgs?.include?.teamUsers).toMatchObject({
+        where: { team: { organizationId: "org456" } },
+      });
+    });
+
+    test("updates the user by id rather than email", async () => {
+      (prisma.user.findFirst as any).mockResolvedValueOnce({
+        ...mockUser,
+        teamUsers: [],
+      });
+      (prisma.team.findMany as any).mockResolvedValueOnce([]);
+      (prisma.$transaction as any).mockResolvedValueOnce([{ ...mockUser, name: "Renamed" }]);
+
+      await updateUser({ email: mockUser.email, name: "Renamed" }, "org456");
+
+      // Find the user.update call inside the transaction args.
+      expect(prisma.user.update).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: mockUser.id } })
+      );
+    });
+
     test("returns internal_server_error if update fails", async () => {
-      (prisma.user.findUnique as any).mockResolvedValueOnce(mockUser);
+      (prisma.user.findFirst as any).mockResolvedValueOnce(mockUser);
       (prisma.$transaction as any).mockRejectedValueOnce(new Error("Update error"));
       const result = await updateUser({ email: mockUser.email }, "org456");
       expect(result.ok).toBe(false);
@@ -209,7 +265,7 @@ describe("Users Lib", () => {
 
   describe("updateUser with team changes", () => {
     test("removes a team and adds new team", async () => {
-      (prisma.user.findUnique as any).mockResolvedValueOnce({
+      (prisma.user.findFirst as any).mockResolvedValueOnce({
         ...mockUser,
         teamUsers: [
           { team: { id: "team123", name: "OldTeam", workspaceTeams: [{ workspaceId: "proj789" }] } },
@@ -234,7 +290,7 @@ describe("Users Lib", () => {
         "org456"
       );
 
-      expect(prisma.user.findUnique).toHaveBeenCalled();
+      expect(prisma.user.findFirst).toHaveBeenCalled();
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.data.teams).toContain("NewTeam");

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
@@ -173,9 +173,15 @@ export const updateUser = async (
   let newTeams;
 
   try {
-    // First, fetch the existing user along with memberships and teamUsers.
-    const existingUser = await prisma.user.findUnique({
-      where: { email },
+    // Restrict the lookup to a user with a membership in the authenticated organization,
+    // and scope teamUsers to teams that belong to the same organization. Looking up by
+    // email alone would surface users from other organizations and allow mutations to
+    // their global fields and team memberships.
+    const existingUser = await prisma.user.findFirst({
+      where: {
+        email,
+        memberships: { some: { organizationId } },
+      },
       include: {
         memberships: {
           select: {
@@ -184,6 +190,7 @@ export const updateUser = async (
           },
         },
         teamUsers: {
+          where: { team: { organizationId } },
           include: {
             team: true,
           },
@@ -198,7 +205,7 @@ export const updateUser = async (
       });
     }
 
-    // Capture the existing team names for the user.
+    // Capture the existing team names for the user (within the authenticated organization).
     existingTeams = existingUser.teamUsers.map((teamUser) => teamUser.team.name);
 
     // Build an array of operations for deleting teamUsers that are not in the input.
@@ -272,9 +279,10 @@ export const updateUser = async (
       },
     };
 
-    // Build the user update operation.
+    // Update by id so the mutation is bound to the org-scoped lookup above. Email is
+    // a global unique key and using it here would defeat the membership check.
     const updateUserOp = prisma.user.update({
-      where: { email },
+      where: { id: existingUser.id },
       data: prismaData,
       include: {
         memberships: {


### PR DESCRIPTION
## Summary

`PATCH /api/v2/organizations/:organizationId/users` resolved the target user with `prisma.user.findUnique({ where: { email } })` and then mutated global User fields plus iterated the user's entire `TeamUser` collection. A caller authenticated for organization A could supply the email of a user that belongs only to organization B and:

- flip the global `isActive` flag on the target,
- rename or re-email the global `User` row,
- drop every `TeamUser` row for the target — including teams in other organizations — by sending `{ "teams": [] }`.

Membership-role updates were already scoped via `updateMany`; the user lookup and the `user.update` target were not.

## Changes

- `apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts`
  - Replace `findUnique({ where: { email } })` with `findFirst` that additionally requires `memberships: { some: { organizationId } }`. Non-members now yield `not_found`.
  - Filter the included `teamUsers` with `where: { team: { organizationId } }` so the delete loop only touches teams in the authenticated org.
  - Bind `prisma.user.update` to `where: { id: existingUser.id }` instead of the global email key, removing the find-by-global-key footgun.
- `apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts`
  - Rename existing `findUnique` mock + assertions to `findFirst`.
  - Add three regression tests: scoped lookup args, scoped teamUser include, id-based update target.

## Test plan

- [x] `pnpm exec vitest run modules/api/v2/organizations` — 46/46 pass (3 new).
- [ ] Manual: with two organizations A and B, an API key for A with `accessControl.write`, and a victim user with membership only in B:
  - `PATCH /api/v2/organizations/A/users` `{ "email": "<victim>", "isActive": false }` → expect `404 not_found`, victim's `isActive` unchanged.
  - Repeat with `{ "teams": [] }` → expect `404`, victim's team rows in B intact.
  - Confirm the existing flow still works when the target *is* a member of A.

Closes ENG-1139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)