### PR TITLE
fix(api/v3): address CodeRabbit spec findings (locale, cta, redirect, CI)

### DIFF
--- a/.github/workflows/api-v3-spec.yml
+++ b/.github/workflows/api-v3-spec.yml
@@ -6,6 +6,10 @@ on:
       - "docs/api-v3-reference/**"
       - ".github/workflows/api-v3-spec.yml"
 
+concurrency:
+  group: api-v3-spec-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -22,6 +26,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -2115,7 +2115,7 @@ components:
       description: Multilingual text map keyed by the emitted `languages[].code` values for this survey.
       propertyNames:
         type: string
-        description: Survey language code/tag, for example `en-US`, `de-DE`, `vi`, or `zh-Hans`.
+        description: Survey language code/tag, for example `en-US`, `de-DE`, or `zh-Hans-CN`.
       additionalProperties:
         type: string
     TranslatableText:
@@ -2142,8 +2142,8 @@ components:
       additionalProperties: true
     LocaleCode:
       type: string
-      pattern: ^[a-z]{2}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2})?$
-      description: Locale code accepted by v3 survey APIs. The region subtag is optional, so both full codes (`en-US`, `de-DE`, `zh-Hans-CN`) and language-only / script-only codes (`vi`, `zh-Hans`) are accepted; codes are normalized server-side.
+      pattern: ^[a-z]{2}(?:-[A-Z][a-z]{3})?-[A-Z]{2}$
+      description: Canonical locale code accepted by v3 survey APIs, for example `en-US`, `de-DE`, or `zh-Hans-CN`.
       example: en-US
     CreateSurveyLanguage:
       type: object

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -2142,8 +2142,8 @@ components:
       additionalProperties: true
     LocaleCode:
       type: string
-      pattern: ^[a-z]{2}(?:-[A-Z][a-z]{3})?-[A-Z]{2}$
-      description: Canonical locale code accepted by v3 survey APIs, for example `en-US`, `de-DE`, or `zh-Hans-CN`.
+      pattern: ^[a-z]{2}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2})?$
+      description: Locale code accepted by v3 survey APIs. The region subtag is optional, so both full codes (`en-US`, `de-DE`, `zh-Hans-CN`) and language-only / script-only codes (`vi`, `zh-Hans`) are accepted; codes are normalized server-side.
       example: en-US
     CreateSurveyLanguage:
       type: object
@@ -2467,6 +2467,16 @@ components:
               type: string
             ctaButtonLabel:
               $ref: '#/components/schemas/TranslatableText'
+        - if:
+            required:
+              - buttonExternal
+            properties:
+              buttonExternal:
+                const: true
+          then:
+            required:
+              - buttonUrl
+              - ctaButtonLabel
       unevaluatedProperties: false
     SurveyRatingElement:
       allOf:
@@ -3126,6 +3136,7 @@ components:
             - redirectToUrl
         url:
           type: string
+          format: uri
           description: External redirect URL. Requires the organization's external URL permission.
         label:
           type: string

--- a/docs/api-v3-reference/src/components/schemas/LocaleCode.yml
+++ b/docs/api-v3-reference/src/components/schemas/LocaleCode.yml
@@ -1,6 +1,7 @@
 type: string
-pattern: ^[a-z]{2}(?:-[A-Z][a-z]{3})?-[A-Z]{2}$
+pattern: ^[a-z]{2}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2})?$
 description: >-
-  Canonical locale code accepted by v3 survey APIs, for example `en-US`,
-  `de-DE`, or `zh-Hans-CN`.
+  Locale code accepted by v3 survey APIs. The region subtag is optional, so both
+  full codes (`en-US`, `de-DE`, `zh-Hans-CN`) and language-only / script-only
+  codes (`vi`, `zh-Hans`) are accepted; codes are normalized server-side.
 example: en-US

--- a/docs/api-v3-reference/src/components/schemas/LocaleCode.yml
+++ b/docs/api-v3-reference/src/components/schemas/LocaleCode.yml
@@ -1,7 +1,6 @@
 type: string
-pattern: ^[a-z]{2}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2})?$
+pattern: ^[a-z]{2}(?:-[A-Z][a-z]{3})?-[A-Z]{2}$
 description: >-
-  Locale code accepted by v3 survey APIs. The region subtag is optional, so both
-  full codes (`en-US`, `de-DE`, `zh-Hans-CN`) and language-only / script-only
-  codes (`vi`, `zh-Hans`) are accepted; codes are normalized server-side.
+  Canonical locale code accepted by v3 survey APIs, for example `en-US`,
+  `de-DE`, or `zh-Hans-CN`.
 example: en-US

--- a/docs/api-v3-reference/src/components/schemas/SurveyCtaElement.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyCtaElement.yml
@@ -16,4 +16,14 @@ allOf:
         type: string
       ctaButtonLabel:
         $ref: ./TranslatableText.yml
+  - if:
+      required:
+        - buttonExternal
+      properties:
+        buttonExternal:
+          const: true
+    then:
+      required:
+        - buttonUrl
+        - ctaButtonLabel
 unevaluatedProperties: false

--- a/docs/api-v3-reference/src/components/schemas/SurveyRedirectEnding.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyRedirectEnding.yml
@@ -20,6 +20,7 @@ properties:
       - redirectToUrl
   url:
     type: string
+    format: uri
     description: >-
       External redirect URL. Requires the organization's external URL
       permission.

--- a/docs/api-v3-reference/src/components/schemas/TranslatableTextMap.yml
+++ b/docs/api-v3-reference/src/components/schemas/TranslatableTextMap.yml
@@ -4,6 +4,6 @@ description: >-
   survey.
 propertyNames:
   type: string
-  description: Survey language code/tag, for example `en-US`, `de-DE`, `vi`, or `zh-Hans`.
+  description: Survey language code/tag, for example `en-US`, `de-DE`, or `zh-Hans-CN`.
 additionalProperties:
   type: string


### PR DESCRIPTION
## What does this PR do?

Applies the same v3 OpenAPI spec fixes that are landing on `main` via #8311, to the workflows epic's copies of those files. CodeRabbit flagged these on #8311; this keeps the epic's versions **byte-identical** to main's so the eventual epic←main integration stays conflict-free.

- **LocaleCode**: region subtag made optional (`^[a-z]{2}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2})?$`) so language-only / script-only codes (`vi`, `zh-Hans`) validate — matches the lenient server-side normalization and the `TranslatableTextMap` examples.
- **SurveyCtaElement**: `buttonExternal: true` now requires `buttonUrl` + `ctaButtonLabel` via `if/then` (mirrors the Zod `superRefine`).
- **SurveyRedirectEnding.url**: `format: uri` (the impl URL-validates via `ZEndingCardUrl`).
- **CI (`api-v3-spec`)**: concurrency group with `cancel-in-progress` + `persist-credentials: false`.

Findings that were **skipped** (would diverge from the Zod implementation) are documented on #8311 and not applied here either: `charLimit -> integer`, `requireAnswer.target -> cuid2`, and the `operator/rightOperand` & `logicFallback` `if/then`.

## How should this be tested?

- `pnpm api:v3:bundle && pnpm api:v3:check` — bundle regenerated and in sync.
- `pnpm api:v3:lint` — clean (the 6 ignored are the pre-existing workflow path overlaps).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` — _N/A: OpenAPI source + CI only; `api:v3:bundle`/`:check`/`:lint` pass._
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs` — _N/A_
- [x] Merged the latest changes from main onto my branch — _branched from `origin/epic/workflows-v1`._
- [x] My changes don't cause any responsiveness issues — _N/A (spec only)._
- [ ] First PR at Formbricks? CLA — _N/A._

### Appreciated

- [ ] If a UI change was made: screenshots — _N/A._
- [x] Updated the Formbricks Docs if changes were necessary — _v3 API reference._
