### PR TITLE
docs: update Docker self-hosting setup guide

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -51,12 +51,13 @@ AI_OPENAI_COMPATIBLE_PROVIDER_NAME=vllm
 AI_OPENAI_COMPATIBLE_SUPPORTS_STRUCTURED_OUTPUTS=1
 ```
 
-Then start the stack with the profile:
+Then start the stack after updating `.env`:
 
 ```bash
-COMPOSE_PROFILES=qwen docker compose up -d
-docker compose --profile qwen ps
+docker compose up -d
+docker compose ps
 docker compose logs vllm formbricks
+curl -fsS http://127.0.0.1:8000/health
 ```
 
 The vLLM service requires a GPU-capable Docker host with the NVIDIA Container Toolkit installed. It stores downloaded model files in the `qwen-model-cache` Docker volume and binds the OpenAI-compatible endpoint to `127.0.0.1:8000` by default for local checks.
@@ -120,25 +121,27 @@ TAXONOMY_VERTEX_LOCATION=<vertex-location>
 TAXONOMY_GOOGLE_CLOUD_CREDENTIALS_JSON=<service-account-json>
 ```
 
-Then start the stack with the selected profile set:
+Then start the stack after updating `.env`:
 
 ```bash
-COMPOSE_PROFILES=qwen,taxonomy docker compose up -d
-docker compose --profile qwen --profile taxonomy ps
-docker compose logs vllm taxonomy hub
+docker compose up -d
+docker compose ps
+docker compose logs taxonomy hub
 ```
+
+If you enabled the bundled Qwen profile, also check `docker compose logs vllm`.
 
 Run the authenticated preflight after startup to verify Hub internal auth and LLM reachability:
 
 ```bash
-docker compose --profile taxonomy exec taxonomy python -c 'import os, urllib.request; req = urllib.request.Request("http://127.0.0.1:8000/v1/preflight", headers={"Authorization": "Bearer " + os.environ["TAXONOMY_SERVICE_TOKEN"]}); print(urllib.request.urlopen(req, timeout=10).read().decode())'
+docker compose --profile taxonomy exec -T taxonomy python -c 'import os, urllib.request; req = urllib.request.Request("http://127.0.0.1:8000/v1/preflight", headers={"Authorization": "Bearer " + os.environ["TAXONOMY_SERVICE_TOKEN"]}); print(urllib.request.urlopen(req, timeout=10).read().decode())'
 ```
 
 The taxonomy service remains internal to the compose network by default. For production workloads, `TAXONOMY_MAX_RECORDS` defaults to `50000`. Override it only as an advanced safety limit after sizing CPU, memory, and LLM capacity.
 
-For local unreleased taxonomy testing, build the taxonomy image as `ghcr.io/formbricks/taxonomy:local`, set `TAXONOMY_IMAGE_REF=:local`, and start the stack with `COMPOSE_PROFILES=taxonomy`.
+For local unreleased taxonomy testing, build the taxonomy image as `ghcr.io/formbricks/taxonomy:local`, set `TAXONOMY_IMAGE_REF=:local` and `COMPOSE_PROFILES=taxonomy` in `.env`, and start the stack.
 
-The one-click installer does not prompt for taxonomy settings. One-click users can enable the beta later by editing `./formbricks/.env`, adding the variables above, and restarting with `COMPOSE_PROFILES=taxonomy docker compose up -d`.
+The one-click installer does not prompt for taxonomy settings. One-click users can enable the beta later by editing `./formbricks/.env`, adding the variables above, and restarting with `docker compose up -d`.
 
 In development, Hub is exposed locally on port **8080** and Cube on **4000** (with the Cube playground on **4001**). In production Docker Compose, both stay internal to the compose network at `http://hub:8080` and `http://cube:4000`.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -57,8 +57,11 @@ Then start the stack after updating `.env`:
 docker compose up -d
 docker compose ps
 docker compose logs vllm formbricks
-curl -fsS http://127.0.0.1:8000/health
+curl -fsS "http://127.0.0.1:${QWEN_VLLM_PORT:-8000}/health"
 ```
+
+If you set `QWEN_VLLM_PORT` only in `.env`, replace the port in the health check with that value or export it
+in your shell first.
 
 The vLLM service requires a GPU-capable Docker host with the NVIDIA Container Toolkit installed. It stores downloaded model files in the `qwen-model-cache` Docker volume and binds the OpenAI-compatible endpoint to `127.0.0.1:8000` by default for local checks.
 

--- a/docs/self-hosting/setup/docker.mdx
+++ b/docs/self-hosting/setup/docker.mdx
@@ -4,22 +4,37 @@ description: "Set up Formbricks quickly using our ready-to-use Docker image."
 icon: "docker"
 ---
 
-The image is pre-built and requires minimal setup—just download it and start the container.
+Use this guide for a manual Docker Compose setup. It downloads the production Compose file and starts the
+baseline Formbricks stack: Formbricks Web, PostgreSQL, Redis/Valkey, Formbricks Hub, and Cube. Optional
+services such as Qwen/vLLM, AI taxonomy, and RustFS are documented after the baseline stack is running.
 
 ### Requirements
 
-Make sure Docker and Docker Compose are installed on your system. These are usually included in tools like Docker Desktop and Rancher Desktop.
+Make sure the following tools are installed:
+
+- Docker Engine with Docker Compose V2 (`docker compose`)
+- `curl`
+- `openssl`
+- A POSIX-compatible shell such as `sh`, `bash`, or `zsh`
+
+Docker and Docker Compose are usually included in tools like Docker Desktop and Rancher Desktop.
 
 <Note>
   `docker compose` without the hyphen is now the primary method of using docker-compose, according to the
   Docker documentation.
 </Note>
 
+## Choose Your Setup Path
+
+- Use this manual Docker Compose guide for local installs, custom servers, or custom reverse-proxy setups.
+- Use the [one-click setup script](/self-hosting/setup/one-click) for production Ubuntu servers where you want
+  Traefik, HTTPS certificates, and optional RustFS automation.
+- Use the [migration guide](/self-hosting/advanced/migration#v5) before updating an existing Formbricks 4.x
+  install or an older v5 compose file.
+
 <Info>
   Starting with Formbricks v5, the production Docker Compose stack includes Formbricks Hub and Cube as part of
-  the baseline. Generate `HUB_API_KEY` and `CUBEJS_API_SECRET` during setup, keep `HUB_API_URL` at its
-  internal default unless Hub runs elsewhere, and use the [migration
-  guide](/self-hosting/advanced/migration#v5) when upgrading an existing 4.x instance.
+  the baseline. Keep `HUB_API_URL` at its internal default unless Hub runs elsewhere.
 </Info>
 
 ## Start
@@ -38,214 +53,48 @@ Make sure Docker and Docker Compose are installed on your system. These are usua
 
    ```bash
    mkdir -p cube/schema
-   curl -o docker-compose.yml https://raw.githubusercontent.com/formbricks/formbricks/stable/docker/docker-compose.yml
-   curl -o cube/cube.js https://raw.githubusercontent.com/formbricks/formbricks/stable/docker/cube/cube.js
-   curl -o cube/schema/FeedbackRecords.js https://raw.githubusercontent.com/formbricks/formbricks/stable/docker/cube/schema/FeedbackRecords.js
+   curl -fsSL \
+     -o docker-compose.yml \
+     https://raw.githubusercontent.com/formbricks/formbricks/stable/docker/docker-compose.yml
+   curl -fsSL \
+     -o cube/cube.js \
+     https://raw.githubusercontent.com/formbricks/formbricks/stable/docker/cube/cube.js
+   curl -fsSL \
+     -o cube/schema/FeedbackRecords.js \
+     https://raw.githubusercontent.com/formbricks/formbricks/stable/docker/cube/schema/FeedbackRecords.js
    ```
 
-1. **Generate Hub and Cube Secrets**
+1. **Create the Environment File**
 
-   Formbricks Hub and Cube each require a shared secret. Create `.env` with both:
+   Store your configuration in `.env`. Docker Compose reads this file for variable interpolation, and the
+   Formbricks container also loads it at startup. For a local install, use `http://localhost:3000`. For a server
+   install, replace both URL values with your public HTTPS URL before starting the stack.
 
    ```bash
    cat <<EOF > .env
+   WEBAPP_URL=http://localhost:3000
+   NEXTAUTH_URL=http://localhost:3000
+   NEXTAUTH_SECRET=$(openssl rand -hex 32)
+   ENCRYPTION_KEY=$(openssl rand -hex 32)
+   CRON_SECRET=$(openssl rand -hex 32)
    HUB_API_KEY=$(openssl rand -hex 32)
    CUBEJS_API_SECRET=$(openssl rand -hex 32)
    CUBEJS_JWT_ISSUER=formbricks-web
    CUBEJS_JWT_AUDIENCE=formbricks-cube
    EOF
+   chmod 600 .env
    ```
 
 1. **Validate the Docker Compose Configuration**
 
-   Confirm Docker Compose can resolve the required Hub and Cube variables before starting the stack:
+   Validate the Compose file after `.env` contains the required values:
 
    ```bash
    docker compose config >/dev/null
    ```
 
-   This command validates Docker Compose syntax. `HUB_API_KEY` and `CUBEJS_API_SECRET` are still required for
-   production startup, but missing secrets are reported by the service that needs them at runtime.
-
-1. **Generate NextAuth Secret**
-
-   You need a NextAuth secret for session signing and encryption. Run one of the commands below based on your operating system:
-
-   For Linux:
-
-   ```bash
-   sed -i "/NEXTAUTH_SECRET:$/s/NEXTAUTH_SECRET:.*/NEXTAUTH_SECRET: $(openssl rand -hex 32)/" docker-compose.yml
-   ```
-
-   For macOS:
-
-   ```bash
-   sed -i '' "s/NEXTAUTH_SECRET:.*/NEXTAUTH_SECRET: $(openssl rand -hex 32)/" docker-compose.yml
-   ```
-
-1. **Generate Encryption Key**
-
-   Next, you need to generate an Encryption Key. This will be used for authenticating and verifying 2 Factor Authentication. Run one of the commands below based on your operating system:
-
-   For Linux:
-
-   ```bash
-   sed -i "/ENCRYPTION_KEY:$/s/ENCRYPTION_KEY:.*/ENCRYPTION_KEY: $(openssl rand -hex 32)/" docker-compose.yml
-   ```
-
-   For macOS:
-
-   ```bash
-   sed -i '' "s/ENCRYPTION_KEY:.*/ENCRYPTION_KEY: $(openssl rand -hex 32)/" docker-compose.yml
-   ```
-
-1. **Generate Cron Secret**
-
-   You require a Cron secret to secure API access for running cron jobs. Run one of the commands below based on your operating system:
-
-   For Linux:
-
-   ```bash
-   sed -i "/CRON_SECRET:$/s/CRON_SECRET:.*/CRON_SECRET: $(openssl rand -hex 32)/" docker-compose.yml
-   ```
-
-   For macOS:
-
-   ```bash
-   sed -i '' "s/CRON_SECRET:.*/CRON_SECRET: $(openssl rand -hex 32)/" docker-compose.yml
-   ```
-
-1. **Generate Hub API Key**
-
-   Formbricks v5 requires a Hub API key for the bundled Hub service.
-
-   For Linux:
-
-   ```bash
-   sed -i "/HUB_API_KEY:$/s/HUB_API_KEY:.*/HUB_API_KEY: $(openssl rand -hex 32)/" docker-compose.yml
-   ```
-
-   For macOS:
-
-   ```bash
-   sed -i '' "s/HUB_API_KEY:.*/HUB_API_KEY: $(openssl rand -hex 32)/" docker-compose.yml
-   ```
-
-   <Info>
-     The bundled production stack already sets <code>HUB_API_URL</code> to <code>http://hub:8080</code>. Only
-     change that value if your Formbricks app needs to reach Hub at a different address. If your deployment
-     also resolves Compose variables from a shell environment or <code>.env</code> file, keep the same
-     <code>HUB_API_KEY</code> available there as well.
-   </Info>
-
-1. **Optional: Enable Bundled Qwen/vLLM For AI**
-
-   The Docker stack can optionally run Qwen through vLLM as an OpenAI-compatible `/v1` endpoint. Baseline
-   installs do not start vLLM and can still use Google Vertex, Azure, AWS Bedrock, or another
-   OpenAI-compatible endpoint.
-
-   The bundled Qwen/vLLM service requires a GPU-capable Docker host with the NVIDIA Container Toolkit
-   installed.
-
-   To use the bundled Qwen runtime, add these values to `.env`:
-
-   ```bash
-   cat <<EOF >> .env
-   COMPOSE_PROFILES=qwen
-   AI_PROVIDER=openai-compatible
-   AI_MODEL=qwen3-14b-awq
-   AI_OPENAI_COMPATIBLE_BASE_URL=http://vllm:8000/v1
-   AI_OPENAI_COMPATIBLE_PROVIDER_NAME=vllm
-   AI_OPENAI_COMPATIBLE_SUPPORTS_STRUCTURED_OUTPUTS=1
-   EOF
-   ```
-
-   The vLLM endpoint is available inside the Compose network at `http://vllm:8000/v1` and is bound to
-   `127.0.0.1:8000` by default for local checks. Model files are stored in the `qwen-model-cache` Docker
-   volume.
-
-   If you run your own Qwen/vLLM service, do not enable the `qwen` profile. Set `AI_PROVIDER`,
-   `AI_MODEL`, and `AI_OPENAI_COMPATIBLE_BASE_URL` to your external endpoint instead.
-
-1. **Optional: Enable AI Taxonomy Beta**
-
-   The Docker stack includes the standalone taxonomy service as an opt-in Compose profile. Baseline installs do
-   not start taxonomy and do not require taxonomy or LLM secrets.
-
-   To enable taxonomy, add these values to `.env`:
-
-   ```bash
-   cat <<EOF >> .env
-   # Use COMPOSE_PROFILES=taxonomy when taxonomy points at your own LLM endpoint.
-   # Use COMPOSE_PROFILES=qwen,taxonomy when taxonomy should share the bundled Qwen/vLLM service.
-   COMPOSE_PROFILES=qwen,taxonomy
-   TAXONOMY_SERVICE_URL=http://taxonomy:8000
-   TAXONOMY_SERVICE_TOKEN=<random-strong-secret>
-   HUB_INTERNAL_API_TOKEN=<random-strong-secret>
-   TAXONOMY_IMAGE_REF=:v0.1.0
-   TAXONOMY_LLM_PROVIDER=openai-compatible
-   TAXONOMY_LLM_MODEL=qwen3-14b-awq
-   TAXONOMY_LLM_BASE_URL=http://vllm:8000/v1
-   TAXONOMY_LLM_API_KEY=<api-key-or-dummy-value>
-   EOF
-   ```
-
-   Replace `:v0.1.0` with the current released `ghcr.io/formbricks/taxonomy` image tag for your Formbricks
-   version. Production installs should pin a release tag instead of relying on `:latest`.
-
-   If you run your own OpenAI-compatible endpoint, keep only the `taxonomy` profile and point
-   `TAXONOMY_LLM_BASE_URL` at that `/v1` endpoint. The selected model must reliably return strict JSON because
-   taxonomy generation validates an exact 5-level tree.
-
-   To use Amazon Bedrock instead of an OpenAI-compatible endpoint, set:
-
-   ```bash
-   TAXONOMY_LLM_PROVIDER=bedrock
-   TAXONOMY_LLM_MODEL=eu.anthropic.claude-sonnet-4-5-20250929-v1:0
-   AWS_REGION=eu-north-1
-   AWS_BEARER_TOKEN_BEDROCK=<bedrock-api-key>
-   ```
-
-   To use Gemini on Vertex AI instead, set:
-
-   <Info>
-
-   ```bash
-   TAXONOMY_LLM_PROVIDER=vertex-gemini
-   TAXONOMY_LLM_MODEL=gemini-2.5-flash
-   TAXONOMY_VERTEX_PROJECT=<google-cloud-project>
-   TAXONOMY_VERTEX_LOCATION=<vertex-location>
-   TAXONOMY_GOOGLE_CLOUD_CREDENTIALS_JSON=<service-account-json>
-   ```
-
-   </Info>
-
-   When you reach the start step below, start with the selected profile set:
-
-   ```bash
-   COMPOSE_PROFILES=qwen,taxonomy docker compose up -d
-   docker compose --profile qwen --profile taxonomy ps
-   docker compose logs vllm taxonomy hub
-   ```
-
-   Run the authenticated preflight after startup to verify Hub internal auth and LLM reachability:
-
-   ```bash
-   docker compose --profile taxonomy exec taxonomy python -c 'import os, urllib.request; req = urllib.request.Request("http://127.0.0.1:8000/v1/preflight", headers={"Authorization": "Bearer " + os.environ["TAXONOMY_SERVICE_TOKEN"]}); print(urllib.request.urlopen(req, timeout=10).read().decode())'
-   ```
-
-   This command runs inside the taxonomy container, so `127.0.0.1:8000` refers to the taxonomy service itself.
-   The preflight endpoint then checks Hub internal auth and LLM reachability from taxonomy.
-
-   The taxonomy service remains internal to the compose network by default. For production workloads,
-   `TAXONOMY_MAX_RECORDS` defaults to `50000`; override it only as an advanced safety limit after sizing CPU,
-   memory, and LLM capacity.
-
-   <Info>
-     The taxonomy service is internal to the Docker network. Formbricks Web still calls Hub with
-     <code>HUB_API_KEY</code>; Hub calls taxonomy with <code>TAXONOMY_SERVICE_TOKEN</code>; taxonomy calls Hub
-     internal APIs with <code>HUB_INTERNAL_API_TOKEN</code>.
-   </Info>
+   If validation fails, check that `.env` contains the required values and that `docker-compose.yml` has valid
+   syntax.
 
 1. **Start the Docker Setup**
 
@@ -258,9 +107,24 @@ Make sure Docker and Docker Compose are installed on your system. These are usua
 
    The `-d` flag runs the containers in the background, so they keep running even after you close the terminal.
 
+1. **Verify the Stack**
+
+   Confirm the baseline services started and the Formbricks health endpoint responds:
+
+   ```bash
+   docker compose ps -a
+   curl -fsS http://localhost:3000/health
+   docker compose logs --tail=100 formbricks-migrate hub-migrate formbricks hub cube
+   ```
+
+   `formbricks-migrate` and `hub-migrate` should complete successfully. `postgres`, `redis`, `cube`,
+   `hub`, and `formbricks` should be running or healthy.
+
 1. **Open Formbricks in Your Browser**
 
-   Once the setup is running, open [**http://localhost:3000**](http://localhost:3000) in your browser to access Formbricks. The first time you visit, you'll see a setup wizard. Follow the steps to create your first user and start using Formbricks.
+   Once the setup is running, open [**http://localhost:3000**](http://localhost:3000) in your browser to access
+   Formbricks. The first time you visit, you'll see a setup wizard. Follow the steps to create your first user
+   and start using Formbricks.
 
 <Note>
   The bundled Docker stack keeps Formbricks Hub and Cube internal to the compose network. The app reaches them
@@ -268,10 +132,146 @@ Make sure Docker and Docker Compose are installed on your system. These are usua
   internally through `http://taxonomy:8000`.
 </Note>
 
+## Optional Services
+
+Start and verify the baseline stack before enabling optional services.
+
+<Note>
+  If `.env` already contains a `COMPOSE_PROFILES` line, update that line instead of adding a second one.
+</Note>
+
+### Enable Bundled Qwen/vLLM For AI
+
+The Docker stack can optionally run Qwen through vLLM as an OpenAI-compatible `/v1` endpoint. Baseline
+installs do not start vLLM and can still use Google Vertex, Azure, AWS Bedrock, or another OpenAI-compatible
+endpoint.
+
+The bundled Qwen/vLLM service requires a GPU-capable Docker host with the NVIDIA Container Toolkit installed.
+Model files are stored in the `qwen-model-cache` Docker volume. Startup can take several minutes while vLLM
+downloads and loads the model.
+
+To use the bundled Qwen runtime, add these values to `.env`:
+
+```bash
+cat <<EOF >> .env
+COMPOSE_PROFILES=qwen
+AI_PROVIDER=openai-compatible
+AI_MODEL=qwen3-14b-awq
+AI_OPENAI_COMPATIBLE_BASE_URL=http://vllm:8000/v1
+AI_OPENAI_COMPATIBLE_PROVIDER_NAME=vllm
+AI_OPENAI_COMPATIBLE_SUPPORTS_STRUCTURED_OUTPUTS=1
+EOF
+```
+
+Then start the stack with the profile and check vLLM:
+
+```bash
+docker compose --profile qwen up -d
+docker compose --profile qwen ps
+docker compose logs --tail=100 vllm formbricks
+curl -fsS http://127.0.0.1:8000/health
+```
+
+The vLLM endpoint is available inside the Compose network at `http://vllm:8000/v1` and is bound to
+`127.0.0.1:8000` by default for local checks.
+
+If you run your own Qwen/vLLM service, do not enable the `qwen` profile. Set `AI_PROVIDER`, `AI_MODEL`, and
+`AI_OPENAI_COMPATIBLE_BASE_URL` to your external endpoint instead.
+
+### Enable AI Taxonomy Beta
+
+The standalone AI taxonomy service is included as an opt-in Docker Compose profile. Baseline installs do not
+start taxonomy and do not require taxonomy or LLM secrets.
+
+To enable taxonomy with the bundled Qwen runtime, add these values to `.env`:
+
+```bash
+cat <<EOF >> .env
+COMPOSE_PROFILES=qwen,taxonomy
+TAXONOMY_SERVICE_URL=http://taxonomy:8000
+TAXONOMY_SERVICE_TOKEN=$(openssl rand -hex 32)
+HUB_INTERNAL_API_TOKEN=$(openssl rand -hex 32)
+TAXONOMY_IMAGE_REF=:v0.1.0
+TAXONOMY_LLM_PROVIDER=openai-compatible
+TAXONOMY_LLM_MODEL=qwen3-14b-awq
+TAXONOMY_LLM_BASE_URL=http://vllm:8000/v1
+TAXONOMY_LLM_API_KEY=not-used
+EOF
+```
+
+Replace `:v0.1.0` with the current released `ghcr.io/formbricks/taxonomy` image tag for your Formbricks
+version. Production installs should pin a release tag instead of relying on `:latest`.
+
+If you run your own OpenAI-compatible endpoint, use `COMPOSE_PROFILES=taxonomy` instead and point
+`TAXONOMY_LLM_BASE_URL` at that `/v1` endpoint. The selected model must reliably return strict JSON because
+taxonomy generation validates an exact 5-level tree.
+
+To use Amazon Bedrock instead of an OpenAI-compatible endpoint, replace the taxonomy LLM values with:
+
+```bash
+TAXONOMY_LLM_PROVIDER=bedrock
+TAXONOMY_LLM_MODEL=eu.anthropic.claude-sonnet-4-5-20250929-v1:0
+AWS_REGION=eu-north-1
+AWS_BEARER_TOKEN_BEDROCK=<bedrock-api-key>
+```
+
+To use Gemini on Vertex AI instead, replace the taxonomy LLM values with:
+
+```bash
+TAXONOMY_LLM_PROVIDER=vertex-gemini
+TAXONOMY_LLM_MODEL=gemini-2.5-flash
+TAXONOMY_VERTEX_PROJECT=<google-cloud-project>
+TAXONOMY_VERTEX_LOCATION=<vertex-location>
+TAXONOMY_GOOGLE_CLOUD_CREDENTIALS_JSON=<service-account-json>
+```
+
+Start the stack after updating `.env`. Compose reads `COMPOSE_PROFILES` from `.env`, so the same command works
+for `taxonomy` and `qwen,taxonomy` setups:
+
+```bash
+docker compose up -d
+docker compose ps
+docker compose logs --tail=100 taxonomy hub
+```
+
+If you enabled the bundled Qwen profile, also check vLLM:
+
+```bash
+docker compose logs --tail=100 vllm
+```
+
+Run the authenticated preflight after startup to verify Hub internal auth and LLM reachability:
+
+```bash
+docker compose --profile taxonomy exec -T taxonomy python - <<'PY'
+import os
+import urllib.request
+
+request = urllib.request.Request(
+    "http://127.0.0.1:8000/v1/preflight",
+    headers={"Authorization": "Bearer " + os.environ["TAXONOMY_SERVICE_TOKEN"]},
+)
+print(urllib.request.urlopen(request, timeout=10).read().decode())
+PY
+```
+
+This command runs inside the taxonomy container, so `127.0.0.1:8000` refers to the taxonomy service itself.
+The preflight endpoint then checks Hub internal auth and LLM reachability from taxonomy.
+
+The taxonomy service remains internal to the compose network by default. For production workloads,
+`TAXONOMY_MAX_RECORDS` defaults to `50000`; override it only as an advanced safety limit after sizing CPU,
+memory, and LLM capacity.
+
 <Info>
-  The one-click installer does not prompt for AI taxonomy settings. One-click users can enable the beta later by
-  editing `./formbricks/.env`, adding the taxonomy variables above, and restarting with
-  `COMPOSE_PROFILES=taxonomy docker compose up -d`.
+  The taxonomy service is internal to the Docker network. Formbricks Web still calls Hub with
+  <code>HUB_API_KEY</code>; Hub calls taxonomy with <code>TAXONOMY_SERVICE_TOKEN</code>; taxonomy calls Hub
+  internal APIs with <code>HUB_INTERNAL_API_TOKEN</code>.
+</Info>
+
+<Info>
+  The one-click installer does not prompt for AI taxonomy settings. One-click users can enable the beta later
+  by editing `./formbricks/.env`, adding the taxonomy variables above, ensuring `COMPOSE_PROFILES=taxonomy` is
+  set, and restarting with `docker compose up -d`.
 </Info>
 
 <Info>
@@ -283,7 +283,7 @@ Make sure Docker and Docker Compose are installed on your system. These are usua
 
 ## Update
 
-Please take a look at our [migration guide](/self-hosting/advanced/migration) for version specific steps to update Formbricks.
+See our [migration guide](/self-hosting/advanced/migration) for version-specific steps to update Formbricks.
 
 <Info>
   For a major migration such as Formbricks 4.x to 5.0, update your compose structure and configuration first.
@@ -309,11 +309,11 @@ Please take a look at our [migration guide](/self-hosting/advanced/migration) fo
    docker compose up -d
    ```
 
-## Optional: Adding RustFS for File Storage
+## Optional: Add RustFS for File Storage
 
-RustFS provides S3-compatible object storage for file uploads in Formbricks. If you want to enable features
-like image uploads, survey file uploads, or custom logos, you can run RustFS alongside Formbricks while
-keeping the existing `S3_*` environment variables.
+RustFS provides S3-compatible object storage for file uploads in Formbricks. It is not required for the
+baseline Docker setup. Add it only when you want features like image uploads, survey file uploads, or custom
+logos.
 
 <Note>
   For a broader overview of file storage options and required environment variables, see our [File Uploads
@@ -334,10 +334,15 @@ keeping the existing `S3_*` environment variables.
   object storage or run a dedicated RustFS deployment separately.
 </Warning>
 
-### Quick Start: Using docker-compose.dev.yml
+### Quick Start: Repository Development Stack
 
-The fastest way to test file uploads locally is to use the included `docker-compose.dev.yml`, which already
-starts RustFS and auto-creates the `formbricks` bucket.
+If you cloned the Formbricks repository, the fastest way to test file uploads locally is to use the included
+`docker-compose.dev.yml`, which already starts RustFS and auto-creates the `formbricks` bucket.
+
+<Note>
+  This development compose file is not downloaded by the manual production quickstart above. If you only
+  downloaded `docker-compose.yml`, use the manual RustFS setup below or the one-click production setup.
+</Note>
 
 1. **Start the local stack**
 
@@ -505,7 +510,8 @@ Start the stack:
 docker compose up -d
 ```
 
-The bucket and service account are created automatically by the `rustfs-init` job defined above, so no manual RustFS console step is required.
+The bucket and service account are created automatically by the `rustfs-init` job defined above, so no manual
+RustFS console step is required.
 
 <Note>
   Restrict the `.env` file to `0600` and do not commit it to source control. For production, prefer the
@@ -557,54 +563,39 @@ adds the reverse proxy wiring and bootstrap automation needed for long-lived dep
 
 ## Debug
 
-If you encounter any issues, you can check the logs of the container with this command:
+If startup fails, first check the resolved configuration and container state:
 
 ```bash
-docker compose logs -f
+docker compose config >/dev/null
+docker compose ps -a
 ```
 
-In an ideal case, you should see this:
+Then inspect the services that commonly explain startup issues:
 
 ```bash
-[+] Running 9/16
-⠹ formbricks 15 layers [⣿⣤⣿⣿⣿⣿⣿⣿⣿⣿⠀⠀⠀⠀⠀] 29.78MB/47.76MB Pulling                                                           13.3s
-✔ 7264a8db6415 Already exists                                                                                                 0.0s
-⠋ 751194035c36 Downloading    [===============================>                   ]  29.78MB/47.76...                         8.1s
-✔ eff5dce73b38 Download complete                                                                                              1.7s
-✔ c8ce5be43019 Download complete                                                                                              1.2s
-✔ a2f33c630af5 Download complete                                                                                              5.1s
-✔ e3b64e437860 Download complete                                                                                              3.3s
-✔ a6551ac5f976 Download complete                                                                                              4.9s
-✔ 4f4fb700ef54 Download complete                                                                                              6.0s
-✔ 22163889e16b Download complete                                                                                              6.7s
-✔ dc647bb9eb13 Download complete                                                                                              7.8s
-⠋ 49c2ad494720 Waiting                                                                                                        8.1s
-⠋ 5c797a842dcb Waiting                                                                                                        8.1s
-⠋ 1f231213db04 Waiting                                                                                                        8.1s
-⠋ e407294bdcda Waiting                                                                                                        8.1s
-⠋ 6fd8358dca47 Pulling fs layer                                                                                               8.1s
-
-[+] Running 2/2
-✔ Container formbricks-quickstart-postgres-1    Created                                                                       0.0s
-✔ Container formbricks-quickstart-formbricks-1  Created                                                                       0.0s
+docker compose logs --tail=200 formbricks-migrate hub-migrate formbricks hub cube
+docker compose logs --tail=200 postgres redis
 ```
 
-And at the tail of the output, you should see this:
+Common checks:
 
-```bash
-formbricks-quickstart-formbricks-1  | All migrations have been successfully applied.
-formbricks-quickstart-formbricks-1  |
-formbricks-quickstart-formbricks-1  | - info Loaded env from /home/nextjs/apps/web/.env
-formbricks-quickstart-formbricks-1  | Listening on port 3000 url: http://<random-string>:3000
-```
-
-You can close the logs again by hitting `CTRL + C`.
+- **Missing or empty secrets**: Confirm `.env` contains `NEXTAUTH_SECRET`, `ENCRYPTION_KEY`, `CRON_SECRET`,
+  `HUB_API_KEY`, and `CUBEJS_API_SECRET`.
+- **Migration failures**: Check `formbricks-migrate`, `hub-migrate`, and `postgres` logs. Do not remove Docker
+  volumes on an existing install unless you intend to delete its data.
+- **Cube is unhealthy**: Confirm `cube/cube.js`, `cube/schema/FeedbackRecords.js`, and `CUBEJS_API_SECRET`
+  exist, then inspect `docker compose logs cube`.
+- **Hub auth errors**: Confirm the same `HUB_API_KEY` from `.env` is used by Formbricks Web and the Hub
+  service.
+- **Port conflicts**: Confirm ports `3000`, `6379`, and any optional service ports you enabled are not already
+  in use on the host.
+- **Optional Qwen/vLLM issues**: Check GPU availability, NVIDIA Container Toolkit installation, and
+  `docker compose --profile qwen logs --tail=200 vllm`.
 
 <Note>
-  **Customizing environment variables**
-
-To edit any of the available environment variables, check out our [Configuration](/self-hosting/configuration/environment-variables) section!
-
+  To edit any of the available environment variables, check out our
+  [Configuration](/self-hosting/configuration/environment-variables) section.
 </Note>
 
-If you have any questions or require help, feel free to reach out to us on [**GitHub Discussions**](https://github.com/formbricks/formbricks/discussions). 😃
+If you have any questions or require help, reach out on
+[**GitHub Discussions**](https://github.com/formbricks/formbricks/discussions).


### PR DESCRIPTION
## Summary

- Rewrite the public Docker self-hosting guide around a baseline `.env`-first install path.
- Move Qwen/vLLM, AI taxonomy beta, and RustFS guidance behind the verified baseline setup.
- Align `docker/README.md` optional-service commands with the same `.env`-driven `COMPOSE_PROFILES` model.

## Why

The existing guide asked users to mutate `docker-compose.yml` with `sed` for runtime secrets. That made setup brittle, especially for `HUB_API_KEY`, where compose interpolation could be corrupted. This update makes `.env` the single user-editable configuration surface and gives users clear validation/debugging commands before optional services are introduced.

## Validation

- `docker compose --env-file "$tmpenv" -f docker/docker-compose.yml config >/tmp/formbricks-compose-prod-default.yml`
- `COMPOSE_PROFILES=qwen docker compose --env-file "$tmpenv" -f docker/docker-compose.yml config >/tmp/formbricks-compose-prod-qwen.yml`
- `COMPOSE_PROFILES=taxonomy docker compose --env-file "$tmpenv" -f docker/docker-compose.yml config >/tmp/formbricks-compose-prod-taxonomy.yml`
- `COMPOSE_PROFILES=qwen,taxonomy docker compose --env-file "$tmpenv" -f docker/docker-compose.yml config >/tmp/formbricks-compose-prod-qwen-taxonomy.yml`
- Reproduced the documented temp-directory download flow against live `stable` files and ran `docker compose config` successfully.
- `PATH=/Users/bhagya/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH ./node_modules/.bin/prettier --check docs/self-hosting/setup/docker.mdx docker/README.md`
- `git diff --check`