### PR TITLE
feat: prioritize last used login method on login page

### DIFF
--- a/apps/web/modules/auth/lib/sort-auth-methods.test.ts
+++ b/apps/web/modules/auth/lib/sort-auth-methods.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import {
+  type AuthMethodId,
+  getAuthMethodButtonVariant,
+  sortAuthMethodsByLastUsed,
+} from "./sort-auth-methods";
+
+describe("sortAuthMethodsByLastUsed", () => {
+  const methods: AuthMethodId[] = ["Email", "Google", "Github", "Azure", "OpenID", "Saml"];
+
+  test("returns methods unchanged when last used is empty", () => {
+    expect(sortAuthMethodsByLastUsed(methods, "")).toEqual(methods);
+  });
+
+  test("returns methods unchanged when last used is not in the list", () => {
+    expect(sortAuthMethodsByLastUsed(methods, "Unknown")).toEqual(methods);
+  });
+
+  test("moves the last used method to the front", () => {
+    expect(sortAuthMethodsByLastUsed(methods, "Github")).toEqual([
+      "Github",
+      "Email",
+      "Google",
+      "Azure",
+      "OpenID",
+      "Saml",
+    ]);
+  });
+
+  test("preserves relative order of non-last-used methods", () => {
+    expect(sortAuthMethodsByLastUsed(["Google", "Email", "Azure"], "Azure")).toEqual([
+      "Azure",
+      "Google",
+      "Email",
+    ]);
+  });
+});
+
+describe("getAuthMethodButtonVariant", () => {
+  test("returns default for the last used method", () => {
+    expect(getAuthMethodButtonVariant("Google", "Google")).toBe("default");
+  });
+
+  test("returns secondary for other methods", () => {
+    expect(getAuthMethodButtonVariant("Email", "Google")).toBe("secondary");
+  });
+});

--- a/apps/web/modules/auth/lib/sort-auth-methods.ts
+++ b/apps/web/modules/auth/lib/sort-auth-methods.ts
@@ -1,0 +1,27 @@
+export const AUTH_METHOD_IDS = ["Email", "Google", "Github", "Azure", "OpenID", "Saml"] as const;
+
+export type AuthMethodId = (typeof AUTH_METHOD_IDS)[number];
+
+export const sortAuthMethodsByLastUsed = <T extends AuthMethodId>(
+  methods: T[],
+  lastLoggedInWith: string
+): T[] => {
+  if (!lastLoggedInWith) {
+    return methods;
+  }
+
+  const lastUsed = lastLoggedInWith as AuthMethodId;
+
+  if (!methods.includes(lastUsed as T)) {
+    return methods;
+  }
+
+  return [lastUsed as T, ...methods.filter((method) => method !== lastUsed)];
+};
+
+export const getAuthMethodButtonVariant = (
+  method: AuthMethodId,
+  lastLoggedInWith: string
+): "default" | "secondary" => {
+  return method === lastLoggedInWith ? "default" : "secondary";
+};

--- a/apps/web/modules/auth/login/components/login-form.tsx
+++ b/apps/web/modules/auth/login/components/login-form.tsx
@@ -13,8 +13,17 @@ import { cn } from "@/lib/cn";
 import { FORMBRICKS_LOGGED_IN_WITH_LS } from "@/lib/localStorage";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { createEmailTokenAction } from "@/modules/auth/actions";
+import {
+  type AuthMethodId,
+  getAuthMethodButtonVariant,
+  sortAuthMethodsByLastUsed,
+} from "@/modules/auth/lib/sort-auth-methods";
 import { buildVerificationRequestedPath } from "@/modules/auth/lib/verification-links";
-import { SSOOptions } from "@/modules/ee/sso/components/sso-options";
+import { AzureButton } from "@/modules/ee/sso/components/azure-button";
+import { GithubButton } from "@/modules/ee/sso/components/github-button";
+import { GoogleButton } from "@/modules/ee/sso/components/google-button";
+import { OpenIdButton } from "@/modules/ee/sso/components/open-id-button";
+import { SamlButton } from "@/modules/ee/sso/components/saml-button";
 import { TwoFactor } from "@/modules/ee/two-factor-auth/components/two-factor";
 import { TwoFactorBackup } from "@/modules/ee/two-factor-auth/components/two-factor-backup";
 import { Alert, AlertDescription, AlertTitle } from "@/modules/ui/components/alert";
@@ -177,6 +186,128 @@ export const LoginForm = ({
     return null;
   }, [form, totpBackup, totpLogin]);
 
+  const enabledAuthMethods = useMemo(() => {
+    const methods: AuthMethodId[] = [];
+
+    if (emailAuthEnabled) {
+      methods.push("Email");
+    }
+
+    if (isSsoEnabled) {
+      if (googleOAuthEnabled) {
+        methods.push("Google");
+      }
+      if (githubOAuthEnabled) {
+        methods.push("Github");
+      }
+      if (azureOAuthEnabled) {
+        methods.push("Azure");
+      }
+      if (oidcOAuthEnabled) {
+        methods.push("OpenID");
+      }
+      if (samlSsoEnabled) {
+        methods.push("Saml");
+      }
+    }
+
+    return sortAuthMethodsByLastUsed(methods, lastLoggedInWith);
+  }, [
+    emailAuthEnabled,
+    isSsoEnabled,
+    googleOAuthEnabled,
+    githubOAuthEnabled,
+    azureOAuthEnabled,
+    oidcOAuthEnabled,
+    samlSsoEnabled,
+    lastLoggedInWith,
+  ]);
+
+  const renderAuthMethodButton = (method: AuthMethodId) => {
+    const isLastUsed = lastLoggedInWith === method;
+    const variant = getAuthMethodButtonVariant(method, lastLoggedInWith);
+
+    switch (method) {
+      case "Email":
+        return (
+          <Button
+            key="Email"
+            type={showLogin ? "submit" : "button"}
+            onClick={
+              showLogin
+                ? undefined
+                : () => {
+                    setShowLogin(true);
+                    setTimeout(() => emailRef.current?.focus(), 100);
+                  }
+            }
+            variant={variant}
+            className="relative w-full justify-center"
+            loading={form.formState.isSubmitting}>
+            {totpLogin ? t("common.submit") : t("auth.login.login_with_email")}
+            {isLastUsed ? (
+              <span className="absolute right-3 text-xs opacity-50">{t("auth.last_used")}</span>
+            ) : null}
+          </Button>
+        );
+      case "Google":
+        return (
+          <GoogleButton
+            key="Google"
+            returnToUrl={resolvedCallbackUrl}
+            lastUsed={isLastUsed}
+            variant={variant}
+            source="signin"
+          />
+        );
+      case "Github":
+        return (
+          <GithubButton
+            key="Github"
+            returnToUrl={resolvedCallbackUrl}
+            lastUsed={isLastUsed}
+            variant={variant}
+            source="signin"
+          />
+        );
+      case "Azure":
+        return (
+          <AzureButton
+            key="Azure"
+            returnToUrl={resolvedCallbackUrl}
+            lastUsed={isLastUsed}
+            variant={variant}
+            source="signin"
+          />
+        );
+      case "OpenID":
+        return (
+          <OpenIdButton
+            key="OpenID"
+            returnToUrl={resolvedCallbackUrl}
+            lastUsed={isLastUsed}
+            variant={variant}
+            text={t("auth.continue_with_oidc", { oidcDisplayName })}
+            source="signin"
+          />
+        );
+      case "Saml":
+        return (
+          <SamlButton
+            key="Saml"
+            returnToUrl={resolvedCallbackUrl}
+            lastUsed={isLastUsed}
+            variant={variant}
+            samlTenant={samlTenant}
+            samlProduct={samlProduct}
+            source="signin"
+          />
+        );
+      default:
+        return null;
+    }
+  };
+
   return (
     <FormProvider {...form}>
       <div className="text-center">
@@ -255,41 +386,8 @@ export const LoginForm = ({
                 )}
               </div>
             )}
-            {emailAuthEnabled && (
-              <Button
-                type={showLogin ? "submit" : "button"}
-                onClick={
-                  showLogin
-                    ? undefined
-                    : () => {
-                        setShowLogin(true);
-                        // Add a slight delay before focusing the input field to ensure it's visible
-                        setTimeout(() => emailRef.current?.focus(), 100);
-                      }
-                }
-                className="relative w-full justify-center"
-                loading={form.formState.isSubmitting}>
-                {totpLogin ? t("common.submit") : t("auth.login.login_with_email")}
-                {lastLoggedInWith && lastLoggedInWith === "Email" ? (
-                  <span className="absolute right-3 text-xs opacity-50">{t("auth.last_used")}</span>
-                ) : null}
-              </Button>
-            )}
+            {enabledAuthMethods.map(renderAuthMethodButton)}
           </form>
-          {isSsoEnabled && (
-            <SSOOptions
-              googleOAuthEnabled={googleOAuthEnabled}
-              githubOAuthEnabled={githubOAuthEnabled}
-              azureOAuthEnabled={azureOAuthEnabled}
-              oidcOAuthEnabled={oidcOAuthEnabled}
-              oidcDisplayName={oidcDisplayName}
-              samlSsoEnabled={samlSsoEnabled}
-              samlTenant={samlTenant}
-              samlProduct={samlProduct}
-              returnToUrl={resolvedCallbackUrl}
-              source="signin"
-            />
-          )}
         </div>
 
         {publicSignUpEnabled && !totpLogin && isMultiOrgEnabled && (

--- a/apps/web/modules/auth/login/components/login-form.tsx
+++ b/apps/web/modules/auth/login/components/login-form.tsx
@@ -242,12 +242,10 @@ export const LoginForm = ({
                   }
             }
             variant={variant}
-            className="relative w-full justify-center"
+            className="w-full justify-center"
             loading={form.formState.isSubmitting}>
             {totpLogin ? t("common.submit") : t("auth.login.login_with_email")}
-            {isLastUsed ? (
-              <span className="absolute right-3 text-xs opacity-50">{t("auth.last_used")}</span>
-            ) : null}
+            {isLastUsed ? <span className="shrink-0 text-xs opacity-50">{t("auth.last_used")}</span> : null}
           </Button>
         );
       case "Google":

--- a/apps/web/modules/ee/sso/components/azure-button.tsx
+++ b/apps/web/modules/ee/sso/components/azure-button.tsx
@@ -43,10 +43,10 @@ export const AzureButton = ({
   }, [directRedirect, handleLogin]);
 
   return (
-    <Button type="button" onClick={handleLogin} variant={variant} className="relative w-full justify-center">
+    <Button type="button" onClick={handleLogin} variant={variant} className="w-full justify-center">
       {t("auth.continue_with_azure")}
       <MicrosoftIcon />
-      {lastUsed && <span className="absolute right-3 text-xs opacity-50">{t("auth.last_used")}</span>}
+      {lastUsed && <span className="shrink-0 text-xs opacity-50">{t("auth.last_used")}</span>}
     </Button>
   );
 };

--- a/apps/web/modules/ee/sso/components/azure-button.tsx
+++ b/apps/web/modules/ee/sso/components/azure-button.tsx
@@ -12,10 +12,17 @@ interface AzureButtonProps {
   returnToUrl?: string;
   directRedirect?: boolean;
   lastUsed?: boolean;
+  variant?: "default" | "secondary";
   source: "signin" | "signup";
 }
 
-export const AzureButton = ({ returnToUrl, directRedirect = false, lastUsed, source }: AzureButtonProps) => {
+export const AzureButton = ({
+  returnToUrl,
+  directRedirect = false,
+  lastUsed,
+  variant = "secondary",
+  source,
+}: AzureButtonProps) => {
   const { t } = useTranslation();
   const handleLogin = useCallback(async () => {
     if (typeof window !== "undefined") {
@@ -36,11 +43,7 @@ export const AzureButton = ({ returnToUrl, directRedirect = false, lastUsed, sou
   }, [directRedirect, handleLogin]);
 
   return (
-    <Button
-      type="button"
-      onClick={handleLogin}
-      variant="secondary"
-      className="relative w-full justify-center">
+    <Button type="button" onClick={handleLogin} variant={variant} className="relative w-full justify-center">
       {t("auth.continue_with_azure")}
       <MicrosoftIcon />
       {lastUsed && <span className="absolute right-3 text-xs opacity-50">{t("auth.last_used")}</span>}

--- a/apps/web/modules/ee/sso/components/azure-button.tsx
+++ b/apps/web/modules/ee/sso/components/azure-button.tsx
@@ -22,7 +22,7 @@ export const AzureButton = ({
   lastUsed,
   variant = "secondary",
   source,
-}: AzureButtonProps) => {
+}: Readonly<AzureButtonProps>) => {
   const { t } = useTranslation();
   const handleLogin = useCallback(async () => {
     if (typeof window !== "undefined") {

--- a/apps/web/modules/ee/sso/components/github-button.tsx
+++ b/apps/web/modules/ee/sso/components/github-button.tsx
@@ -34,10 +34,10 @@ export const GithubButton = ({
   };
 
   return (
-    <Button type="button" onClick={handleLogin} variant={variant} className="relative w-full justify-center">
+    <Button type="button" onClick={handleLogin} variant={variant} className="w-full justify-center">
       {t("auth.continue_with_github")}
       <GithubIcon />
-      {lastUsed && <span className="absolute right-3 text-xs opacity-50">{t("auth.last_used")}</span>}
+      {lastUsed && <span className="shrink-0 text-xs opacity-50">{t("auth.last_used")}</span>}
     </Button>
   );
 };

--- a/apps/web/modules/ee/sso/components/github-button.tsx
+++ b/apps/web/modules/ee/sso/components/github-button.tsx
@@ -14,7 +14,12 @@ interface GithubButtonProps {
   source: "signin" | "signup";
 }
 
-export const GithubButton = ({ returnToUrl, lastUsed, variant = "secondary", source }: GithubButtonProps) => {
+export const GithubButton = ({
+  returnToUrl,
+  lastUsed,
+  variant = "secondary",
+  source,
+}: Readonly<GithubButtonProps>) => {
   const { t } = useTranslation();
   const handleLogin = async () => {
     if (typeof window !== "undefined") {

--- a/apps/web/modules/ee/sso/components/github-button.tsx
+++ b/apps/web/modules/ee/sso/components/github-button.tsx
@@ -10,10 +10,11 @@ import { GithubIcon } from "@/modules/ui/components/icons";
 interface GithubButtonProps {
   returnToUrl?: string;
   lastUsed?: boolean;
+  variant?: "default" | "secondary";
   source: "signin" | "signup";
 }
 
-export const GithubButton = ({ returnToUrl, lastUsed, source }: GithubButtonProps) => {
+export const GithubButton = ({ returnToUrl, lastUsed, variant = "secondary", source }: GithubButtonProps) => {
   const { t } = useTranslation();
   const handleLogin = async () => {
     if (typeof window !== "undefined") {
@@ -28,11 +29,7 @@ export const GithubButton = ({ returnToUrl, lastUsed, source }: GithubButtonProp
   };
 
   return (
-    <Button
-      type="button"
-      onClick={handleLogin}
-      variant="secondary"
-      className="relative w-full justify-center">
+    <Button type="button" onClick={handleLogin} variant={variant} className="relative w-full justify-center">
       {t("auth.continue_with_github")}
       <GithubIcon />
       {lastUsed && <span className="absolute right-3 text-xs opacity-50">{t("auth.last_used")}</span>}

--- a/apps/web/modules/ee/sso/components/google-button.tsx
+++ b/apps/web/modules/ee/sso/components/google-button.tsx
@@ -10,10 +10,11 @@ import { GoogleIcon } from "@/modules/ui/components/icons";
 interface GoogleButtonProps {
   returnToUrl?: string;
   lastUsed?: boolean;
+  variant?: "default" | "secondary";
   source: "signin" | "signup";
 }
 
-export const GoogleButton = ({ returnToUrl, lastUsed, source }: GoogleButtonProps) => {
+export const GoogleButton = ({ returnToUrl, lastUsed, variant = "secondary", source }: GoogleButtonProps) => {
   const { t } = useTranslation();
   const handleLogin = async () => {
     if (typeof window !== "undefined") {
@@ -28,11 +29,7 @@ export const GoogleButton = ({ returnToUrl, lastUsed, source }: GoogleButtonProp
   };
 
   return (
-    <Button
-      type="button"
-      onClick={handleLogin}
-      variant="secondary"
-      className="relative w-full justify-center">
+    <Button type="button" onClick={handleLogin} variant={variant} className="relative w-full justify-center">
       {t("auth.continue_with_google")}
       <GoogleIcon />
       {lastUsed && <span className="absolute right-3 text-xs opacity-50">{t("auth.last_used")}</span>}

--- a/apps/web/modules/ee/sso/components/google-button.tsx
+++ b/apps/web/modules/ee/sso/components/google-button.tsx
@@ -34,10 +34,10 @@ export const GoogleButton = ({
   };
 
   return (
-    <Button type="button" onClick={handleLogin} variant={variant} className="relative w-full justify-center">
+    <Button type="button" onClick={handleLogin} variant={variant} className="w-full justify-center">
       {t("auth.continue_with_google")}
       <GoogleIcon />
-      {lastUsed && <span className="absolute right-3 text-xs opacity-50">{t("auth.last_used")}</span>}
+      {lastUsed && <span className="shrink-0 text-xs opacity-50">{t("auth.last_used")}</span>}
     </Button>
   );
 };

--- a/apps/web/modules/ee/sso/components/google-button.tsx
+++ b/apps/web/modules/ee/sso/components/google-button.tsx
@@ -14,7 +14,12 @@ interface GoogleButtonProps {
   source: "signin" | "signup";
 }
 
-export const GoogleButton = ({ returnToUrl, lastUsed, variant = "secondary", source }: GoogleButtonProps) => {
+export const GoogleButton = ({
+  returnToUrl,
+  lastUsed,
+  variant = "secondary",
+  source,
+}: Readonly<GoogleButtonProps>) => {
   const { t } = useTranslation();
   const handleLogin = async () => {
     if (typeof window !== "undefined") {

--- a/apps/web/modules/ee/sso/components/open-id-button.tsx
+++ b/apps/web/modules/ee/sso/components/open-id-button.tsx
@@ -23,7 +23,7 @@ export const OpenIdButton = ({
   directRedirect = false,
   text,
   source,
-}: OpenIdButtonProps) => {
+}: Readonly<OpenIdButtonProps>) => {
   const { t } = useTranslation();
   const handleLogin = useCallback(async () => {
     if (typeof window !== "undefined") {

--- a/apps/web/modules/ee/sso/components/open-id-button.tsx
+++ b/apps/web/modules/ee/sso/components/open-id-button.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/modules/ui/components/button";
 interface OpenIdButtonProps {
   returnToUrl?: string;
   lastUsed?: boolean;
+  variant?: "default" | "secondary";
   directRedirect?: boolean;
   text?: string;
   source: "signin" | "signup";
@@ -18,6 +19,7 @@ interface OpenIdButtonProps {
 export const OpenIdButton = ({
   returnToUrl,
   lastUsed,
+  variant = "secondary",
   directRedirect = false,
   text,
   source,
@@ -45,7 +47,7 @@ export const OpenIdButton = ({
     <Button
       type="button"
       onClick={handleLogin}
-      variant="secondary"
+      variant={variant}
       className="w-full items-center justify-center gap-2 px-2">
       <span className="truncate">{text || t("auth.continue_with_openid")}</span>
       {lastUsed && <span className="shrink-0 text-xs opacity-50">{t("auth.last_used")}</span>}

--- a/apps/web/modules/ee/sso/components/saml-button.tsx
+++ b/apps/web/modules/ee/sso/components/saml-button.tsx
@@ -13,12 +13,20 @@ import { Button } from "@/modules/ui/components/button";
 interface SamlButtonProps {
   returnToUrl?: string;
   lastUsed?: boolean;
+  variant?: "default" | "secondary";
   samlTenant: string;
   samlProduct: string;
   source: "signin" | "signup";
 }
 
-export const SamlButton = ({ returnToUrl, lastUsed, samlTenant, samlProduct, source }: SamlButtonProps) => {
+export const SamlButton = ({
+  returnToUrl,
+  lastUsed,
+  variant = "secondary",
+  samlTenant,
+  samlProduct,
+  source,
+}: SamlButtonProps) => {
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
 
@@ -53,7 +61,7 @@ export const SamlButton = ({ returnToUrl, lastUsed, samlTenant, samlProduct, sou
     <Button
       type="button"
       onClick={handleLogin}
-      variant="secondary"
+      variant={variant}
       className="relative w-full justify-center"
       loading={isLoading}>
       {t("auth.continue_with_saml")}

--- a/apps/web/modules/ee/sso/components/saml-button.tsx
+++ b/apps/web/modules/ee/sso/components/saml-button.tsx
@@ -26,7 +26,7 @@ export const SamlButton = ({
   samlTenant,
   samlProduct,
   source,
-}: SamlButtonProps) => {
+}: Readonly<SamlButtonProps>) => {
   const { t } = useTranslation();
   const [isLoading, setIsLoading] = useState(false);
 

--- a/apps/web/modules/ee/sso/components/saml-button.tsx
+++ b/apps/web/modules/ee/sso/components/saml-button.tsx
@@ -62,12 +62,12 @@ export const SamlButton = ({
       type="button"
       onClick={handleLogin}
       variant={variant}
-      className="relative w-full justify-center"
+      className="w-full justify-center"
       loading={isLoading}>
       {t("auth.continue_with_saml")}
 
       <LockIcon />
-      {lastUsed && <span className="absolute right-3 text-xs opacity-50">{t("auth.last_used")}</span>}
+      {lastUsed && <span className="shrink-0 text-xs opacity-50">{t("auth.last_used")}</span>}
     </Button>
   );
 };


### PR DESCRIPTION
## Observed user behaviour
SSO users signed up with email accidentally which caused confusion around access rights, etc. (its not a separate account)

## Solution
Linear does this cool thing where they not only indicate the last used but also changes the primary button and order, so this should do the same (not tested). Please get over finish line 🙏 

## What does this PR do?

On the login page, the auth method stored in `localStorage` as "last used" is now:

1. **Moved to the top** of the auth button list (email + all enabled SSO providers)
2. **Styled as the primary button** (`default` variant); all other methods use the secondary style

Previously, only a "Last used" label was shown on the matching button while order and styling stayed fixed (email first, then SSO providers).

### Implementation

- Added `sortAuthMethodsByLastUsed` and `getAuthMethodButtonVariant` helpers in `apps/web/modules/auth/lib/sort-auth-methods.ts`
- Refactored `LoginForm` to render email and SSO buttons in a single sorted list inside the form
- Extended SSO button components to accept an optional `variant` prop (signup flow unchanged)

## How should this be tested?

1. Log in with email, log out, return to `/auth/login` — email button should be first and primary with "Last used" label
2. Log in with Google (or another SSO provider), log out, return to login — that provider should be first and primary
3. Clear `localStorage` key `formbricks-logged-in-with` — buttons should keep default order with email first (when enabled) and all SSO buttons secondary
4. Verify signup page is unchanged (no reordering there)

```bash
pnpm vitest run modules/auth/lib/sort-auth-methods.test.ts
```

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Ran unit tests for new helper
- [x] My changes don't cause any responsiveness issues



