### PR TITLE
fix: correct framework-guide field names and pnpm shared-lockfile key

### DIFF
--- a/docs/surveys/website-app-surveys/framework-guides.mdx
+++ b/docs/surveys/website-app-surveys/framework-guides.mdx
@@ -81,8 +81,8 @@ var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src
 
 | Name           | Type   | Description                            |
 | -------------- | ------ | -------------------------------------- |
-| workspace-id | string | Formbricks Workspace ID.               |
-| app-url        | string | URL of the hosted Formbricks instance. |
+| workspaceId    | string | Formbricks Workspace ID.               |
+| appUrl         | string | URL of the hosted Formbricks instance. |
 
 Now, visit the [Validate Your Setup](#validate-your-setup) section to verify your setup!
 
@@ -127,8 +127,8 @@ export default App;
 
 | Name           | Type   | Description                            |
 | -------------- | ------ | -------------------------------------- |
-| workspace-id | string | Formbricks Workspace ID.               |
-| app-url        | string | URL of the hosted Formbricks instance. |
+| workspaceId    | string | Formbricks Workspace ID.               |
+| appUrl         | string | URL of the hosted Formbricks instance. |
 
 Now, visit the [Validate Your Setup](#validate-your-setup) section to verify your setup!
 
@@ -238,8 +238,8 @@ export default function App({ Component, pageProps }: AppProps) {
 
 | Name           | Type   | Description                            |
 | -------------- | ------ | -------------------------------------- |
-| workspace-id | string | Formbricks Workspace ID.               |
-| app-url        | string | URL of the hosted Formbricks instance. |
+| workspaceId    | string | Formbricks Workspace ID.               |
+| appUrl         | string | URL of the hosted Formbricks instance. |
 
 First, initialize the Formbricks SDK to run only on the client side. To track page changes, register the route change event with the Next.js router.
 
@@ -295,8 +295,8 @@ router.afterEach((to, from) => {
 
 | Name           | Type   | Description                            |
 | -------------- | ------ | -------------------------------------- |
-| workspace-id | string | Formbricks Workspace ID.               |
-| app-url        | string | URL of the hosted Formbricks instance. |
+| workspaceId    | string | Formbricks Workspace ID.               |
+| appUrl         | string | URL of the hosted Formbricks instance. |
 
 Now, visit the [Validate Your Setup](#validate-your-setup) section to verify your setup!
 
@@ -341,8 +341,8 @@ export default function App() {
 
 | Name           | Type   | Description                            |
 | -------------- | ------ | -------------------------------------- |
-| workspace-id | string | Formbricks Workspace ID.               |
-| app-url        | string | URL of the hosted Formbricks instance. |
+| workspaceId    | string | Formbricks Workspace ID.               |
+| appUrl         | string | URL of the hosted Formbricks instance. |
 
 Now, visit the [Validate Your Setup](#validate-your-setup) section to verify your setup!
 
@@ -427,8 +427,8 @@ Formbricks.cleanup(waitForOperations: true) {
 
 | Name           | Type   | Description                            |
 | -------------- | ------ | -------------------------------------- |
-| workspace-id | string | Formbricks Workspace ID.               |
-| app-url        | string | URL of the hosted Formbricks instance. |
+| workspaceId    | string | Formbricks Workspace ID.               |
+| appUrl         | string | URL of the hosted Formbricks instance. |
 
 Now, visit the [Validate Your Setup](#validate-your-setup) section to verify your setup!
 
@@ -501,8 +501,8 @@ Formbricks.logout()
 
 | Name           | Type   | Description                            |
 | -------------- | ------ | -------------------------------------- |
-| workspace-id | string | Formbricks Workspace ID.               |
-| app-url        | string | URL of the hosted Formbricks instance. |
+| workspaceId    | string | Formbricks Workspace ID.               |
+| appUrl         | string | URL of the hosted Formbricks instance. |
 
 ## Flutter
 
@@ -588,8 +588,8 @@ Attribute keys must be lowercase letters, numbers, and underscores, and start wi
 
 | Name           | Type   | Description                            |
 | -------------- | ------ | -------------------------------------- |
-| workspace-id | string | Formbricks Workspace ID.               |
-| app-url        | string | URL of the hosted Formbricks instance. |
+| workspaceId    | string | Formbricks Workspace ID.               |
+| appUrl         | string | URL of the hosted Formbricks instance. |
 
 <Note>
   Surveys render by loading `{appUrl}/js/surveys.umd.cjs` in a WebView, so that URL must be reachable from the device. Formbricks Cloud and standard self-hosted instances serve this script automatically. Config is persisted with `shared_preferences` and is **not encrypted at rest** — avoid putting sensitive PII in attribute values.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -66,7 +66,7 @@ patchedDependencies:
 autoInstallPeers: true
 linkWorkspacePackages: true
 shamefullyHoist: true
-sharedWorkspaceShrinkwrap: true
+sharedWorkspaceLockfile: true
 access: public
 enablePrePostScripts: true
 legacyPeerDeps: true


### PR DESCRIPTION
## What does this PR do?

Two minor corrections surfaced during the #8316 review (both pre-existing on `main`, unrelated to each other):

- **Docs — `framework-guides.mdx`:** the "Required Customizations" tables in **all 8 SDK sections** listed `workspace-id` / `app-url`, but the SDK API and every code example in the same doc use `workspaceId` / `appUrl`. Copying the table values literally would misconfigure the SDK. Aligned all 8 tables to the camelCase API names. (Placeholder *values* like `"<workspace-id>"` inside code blocks are conventional and left untouched.)
- **`pnpm-workspace.yaml`:** `sharedWorkspaceShrinkwrap` is a long-deprecated alias (npm-shrinkwrap era) that pnpm 11 ignores. Renamed to the current `sharedWorkspaceLockfile: true` — same behavior (single root lockfile, which the repo already uses), just the recognized key.

## How should this be tested?

- **Docs:** render `framework-guides.mdx`; the Required Customizations tables now read `workspaceId` / `appUrl`, matching the code examples and the SDK API in the same page.
- **pnpm:** `pnpm install` still resolves to the single root `pnpm-lock.yaml` (no lockfile change); CI's install + build confirms no resolution change.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Removed all `console.logs` (docs/config only — none)
- [x] My changes don't cause any responsiveness issues (no UI/app changes)
