### PR TITLE
fix: restore backward compatibility for older mobile SDKs on the v5 client API

### DIFF
--- a/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.ts
@@ -182,8 +182,18 @@ export const getWorkspaceStateData = async (workspaceId: string): Promise<Worksp
         : null;
 
       const { segment: _segment, ...surveyWithoutSegment } = survey;
+
+      // Older SDKs (e.g. Android ≤ v1.2.0) decode `language.projectId` as a
+      // required field. The column was renamed to `workspaceId` in v5, so
+      // mirror its value under `projectId` to keep those clients deserializing.
+      const languagesWithProjectId = surveyWithoutSegment.languages?.map((sl) => ({
+        ...sl,
+        language: { ...sl.language, projectId: sl.language.workspaceId },
+      }));
+
       const transformed = transformPrismaSurvey<TJsWorkspaceStateSurvey>({
         ...surveyWithoutSegment,
+        languages: languagesWithProjectId,
         segment: null,
       });
 

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -70,7 +70,10 @@ interface VariableStackEntry {
 
 export function Survey({
   appUrl,
-  workspaceId,
+  workspaceId: workspaceIdProp,
+  // Legacy SDKs (e.g. Android ≤ v1.2.0) pass `environmentId` instead of
+  // `workspaceId`. Accept it as a fallback so their response submission works.
+  environmentId,
   isPreviewMode = false,
   userId,
   contactId,
@@ -112,6 +115,7 @@ export function Survey({
   offlineSupport = false,
   onOfflineStatusChange,
 }: SurveyContainerProps) {
+  const workspaceId = workspaceIdProp ?? environmentId;
   let apiClient: ApiClient | null = null;
 
   if (appUrl && workspaceId) {

--- a/packages/types/formbricks-surveys.ts
+++ b/packages/types/formbricks-surveys.ts
@@ -47,6 +47,8 @@ export interface SurveyModalProps extends SurveyBaseProps {
 export interface SurveyContainerProps extends Omit<SurveyBaseProps, "onFileUpload"> {
   appUrl?: string;
   workspaceId?: string;
+  /** Legacy alias for `workspaceId`, sent by old SDKs (e.g. Android ≤ v1.2.0). */
+  environmentId?: string;
   isPreviewMode?: boolean;
   userId?: string;
   contactId?: string;


### PR DESCRIPTION
  ## What does this PR do?

  After the v5 `projectId` → `workspaceId` rename, already-shipped mobile SDKs
  (notably Android ≤ v1.2.0) broke against the client API in two ways. Both are
  fixed here without requiring those SDKs to be updated, since installed app
  binaries are frozen in the field.
  
  **1. Survey load crash — `language.projectId` missing**
  The environment endpoint now returns `workspaceId` on each survey language
  object; it no longer returns `projectId`. Old SDKs decode `language.projectId`
  as a *required* field (kotlinx.serialization), so any multi-language survey
  crashed deserialization:
  
  > `Field 'projectId' is required for type with serial name '...LanguageDetail', but it was missing`

  Fix: mirror the `workspaceId` value back under a `projectId` key in the language
  elements of the environment response (`data.ts`). New SDKs ignore the extra key.

  **2. Response submission hangs forever (infinite spinner)**
  The webview loads the current `surveys.umd.cjs`, which builds its `ApiClient`
  only `if (appUrl && workspaceId)`. Old SDKs pass `environmentId` in the webview
  props, never `workspaceId`, so `apiClient` stayed `null` and submissions
  silently no-op'd.   

  Fix: the surveys package now falls back to `environmentId` when `workspaceId` is
  absent (`survey.tsx`), and `environmentId` is added as a legacy alias on
  `SurveyContainerProps` (`formbricks-surveys.ts`).
  
  ### Files changed
  - `apps/web/.../environment/lib/data.ts` — mirror `workspaceId` → `projectId` on survey languages
  - `packages/surveys/src/components/general/survey.tsx` — `workspaceId ?? environmentId` fallback
  - `packages/types/formbricks-surveys.ts` — add legacy `environmentId?` to `SurveyContainerProps`

  Both changes are additive and backward-compatible: current SDKs send
  `workspaceId` natively and ignore the duplicate `projectId` key, so their
  behaviour is unchanged.
  
  Fixes #(issue)

  ## How should this be tested?

  Reproduce with an older SDK build pointed at a v5 instance (verified locally
  with Android SDK v1.2.0 against a local server):

  - **Multi-language survey loads** — open a survey that has 2+ languages. Before:
    deserialization crash on the environment fetch. After: survey renders.
  - **Response submission** — submit a response from the survey webview. Before:
    spinner spins indefinitely, no response created. After: response is created
    (`onResponseCreated` fires, row appears in responses).
  - **Current SDK regression check** — with an up-to-date SDK (sends `workspaceId`),
    confirm load + submit still work and the extra `projectId` key is ignored.
  
  ## Checklist

  ### Required 

  - [x] Filled out the "How to test" section in this PR
  - [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
  - [x] Self-reviewed my own code
  - [x] Commented on my code in hard-to-understand bits
  - [x] Ran `pnpm build`
  - [x] Checked for warnings, there are none
  - [x] Removed all `console.logs`
  - [ ] Merged the latest changes from main onto my branch with `git pull origin main`
  - [x] My changes don't cause any responsiveness issues
  - [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks)

  ### Appreciated

  - [ ] If a UI change was made: Added a screen recording or screenshots to this PR
  - [ ] Updated the Formbricks Docs if changes were necessary