### PR TITLE
fix(security): pin form-data to patched 4.0.5 (ENG-1513)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ overrides:
   '@opentelemetry/core': 2.8.0
   dompurify: 3.4.9
   esbuild: 0.28.1
+  form-data@4: 4.0.5
 
 patchedDependencies:
   next-auth@4.24.13: 6b21102fce2caaca35f5e4e93ea07a0b4ff486cbf3d3b09a4173ad45977d5798
@@ -7999,10 +8000,6 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-
-  form-data@4.0.0:
-    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
-    engines: {node: '>= 6'}
 
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -16762,7 +16759,7 @@ snapshots:
       concat-stream: 2.0.0
       cookie: 0.7.2
       dotenv: 16.4.5
-      form-data: 4.0.0
+      form-data: 4.0.5
       jest-diff: 29.7.0
       jest-matcher-utils: 29.7.0
       js-yaml: 4.1.0
@@ -20822,12 +20819,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  form-data@4.0.0:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
 
   form-data@4.0.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,6 +59,9 @@ overrides:
   "@opentelemetry/core": 2.8.0 # ENG-1355 / GHSA-8988-4f7v-96qf
   dompurify: 3.4.9 # ENG-1359 + GHSA-vxr8-fq34-vvx9 / GHSA-gvmj-g25r-r7wr (audit: <3.4.9)
   esbuild: 0.28.1 # ENG-1327 / GHSA-g7r4-m6w7-qqqr
+  # ENG-1513 / GHSA-fjxv-7rqg-78g4: form-data <4.0.4 uses an unsafe random function for the
+  # multipart boundary. @redocly/respect-core pins 4.0.0; patched in 4.0.4+.
+  form-data@4: 4.0.5
 
 patchedDependencies:
   next-auth@4.24.13: patches/next-auth@4.24.13.patch


### PR DESCRIPTION
## What

Dependabot flagged [ENG-1513](https://linear.app/formbricks/issue/ENG-1513) — `form-data` <4.0.4 uses an unsafe random function for the multipart boundary ([GHSA-fjxv-7rqg-78g4](https://github.com/advisories/GHSA-fjxv-7rqg-78g4)).

`@redocly/respect-core@1.34.3` (transitive via `@redocly/cli`) pins the vulnerable `form-data@4.0.0`. Added a pnpm override forcing `form-data@4` to the patched `4.0.5`, matching the existing security-override pattern in `pnpm-workspace.yaml`.

## Changes

- `pnpm-workspace.yaml`: add `form-data@4: 4.0.5` override with ENG/GHSA comment
- `pnpm-lock.yaml`: regenerated — vulnerable `form-data@4.0.0` removed, whole tree resolves to `4.0.5`

## Verification

- `grep form-data@4.0.0 pnpm-lock.yaml` → no matches
- Lockfile passes supply-chain policy check

🤖 Generated with [Claude Code](https://claude.com/claude-code)