### PR TITLE
fix(security): bump undici to 7.28.0 (ENG-1509, ENG-1505)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -133,7 +133,7 @@
     "tailwind-merge": "3.5.0",
     "tailwindcss": "3.4.19",
     "ua-parser-js": "2.0.10",
-    "undici": "7.24.8",
+    "undici": "7.28.0",
     "uuid": "14.0.0",
     "xlsx": "file:vendor/xlsx-0.20.3.tgz",
     "zod": "4.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,7 @@ overrides:
   '@opentelemetry/core': 2.8.0
   dompurify: 3.4.9
   esbuild: 0.28.1
+  undici@7: 7.28.0
   form-data@4: 4.0.5
 
 patchedDependencies:
@@ -462,8 +463,8 @@ importers:
         specifier: 2.0.10
         version: 2.0.10
       undici:
-        specifier: 7.24.8
-        version: 7.24.8
+        specifier: 7.28.0
+        version: 7.28.0
       uuid:
         specifier: 14.0.0
         version: 14.0.0
@@ -11617,12 +11618,8 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
-  undici@7.24.8:
-    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
-    engines: {node: '>=20.18.1'}
-
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unique-filename@1.1.1:
@@ -21631,7 +21628,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -24718,9 +24715,7 @@ snapshots:
 
   undici@6.27.0: {}
 
-  undici@7.24.8: {}
-
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unique-filename@1.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,6 +59,9 @@ overrides:
   "@opentelemetry/core": 2.8.0 # ENG-1355 / GHSA-8988-4f7v-96qf
   dompurify: 3.4.9 # ENG-1359 + GHSA-vxr8-fq34-vvx9 / GHSA-gvmj-g25r-r7wr (audit: <3.4.9)
   esbuild: 0.28.1 # ENG-1327 / GHSA-g7r4-m6w7-qqqr
+  # ENG-1509 / ENG-1505 / GHSA-vmh5-mc38-953g: undici 7.x TLS certificate
+  # validation bypass, patched in 7.28.0 (covers the jsdom transitive 7.25.0).
+  undici@7: 7.28.0
   # ENG-1513 / GHSA-fjxv-7rqg-78g4: form-data <4.0.4 uses an unsafe random function for the
   # multipart boundary. @redocly/respect-core pins 4.0.0; patched in 4.0.4+.
   form-data@4: 4.0.5


### PR DESCRIPTION
## What

Resolves [ENG-1509](https://linear.app/formbricks/issue/ENG-1509) and [ENG-1505](https://linear.app/formbricks/issue/ENG-1505) — both flag the same undici advisory.

undici `7.x` before `7.28.0` is vulnerable to [GHSA-vmh5-mc38-953g](https://github.com/advisories/GHSA-vmh5-mc38-953g): a TLS certificate validation bypass. First patched in `7.28.0`.

## Changes

- `apps/web`: bump `undici` `7.24.8` → `7.28.0`.
- `pnpm-workspace.yaml`: add an `undici@7: 7.28.0` override so the jsdom transitive (`7.25.0`) also resolves to the patched release.
- Refresh `pnpm-lock.yaml`.

## Verification

- `pnpm turbo run build --filter=@formbricks/web` — production build + typecheck pass.
- Lockfile resolves a single `undici@7.28.0` for all 7.x consumers (the unrelated `6.27.0` is outside this advisory's affected range).