### PR TITLE
fix(onboarding): let org owners create their first workspace from the landing page

### DIFF
--- a/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/landing/components/create-first-workspace-button.tsx
+++ b/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/landing/components/create-first-workspace-button.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { PlusIcon } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/modules/ui/components/button";
+import { CreateWorkspaceModal } from "@/modules/workspaces/components/create-workspace-modal";
+
+interface CreateFirstWorkspaceButtonProps {
+  organizationId: string;
+  isAccessControlAllowed: boolean;
+}
+
+// Escape hatch for an org owner/manager who landed here with zero workspaces: the server action
+// behind the modal enforces the real workspace limit, so no client-side limit gating is needed.
+export const CreateFirstWorkspaceButton = ({
+  organizationId,
+  isAccessControlAllowed,
+}: Readonly<CreateFirstWorkspaceButtonProps>) => {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button type="button" onClick={() => setOpen(true)}>
+        <PlusIcon />
+        {t("common.create_workspace")}
+      </Button>
+      {open && (
+        <CreateWorkspaceModal
+          open={open}
+          setOpen={setOpen}
+          organizationId={organizationId}
+          isAccessControlAllowed={isAccessControlAllowed}
+        />
+      )}
+    </>
+  );
+};

--- a/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/landing/page.tsx
+++ b/apps/web/app/(app)/(onboarding)/organizations/[organizationId]/landing/page.tsx
@@ -1,11 +1,13 @@
 import { notFound, redirect } from "next/navigation";
+import { CreateFirstWorkspaceButton } from "@/app/(app)/(onboarding)/organizations/[organizationId]/landing/components/create-first-workspace-button";
 import { LandingSidebar } from "@/app/(app)/(onboarding)/organizations/[organizationId]/landing/components/landing-sidebar";
 import { WorkspaceAndOrgSwitch } from "@/app/(app)/workspaces/[workspaceId]/components/workspace-and-org-switch";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
+import { getAccessFlags } from "@/lib/membership/utils";
 import { getUser } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
-import { getIsMultiOrgEnabled } from "@/modules/ee/license-check/lib/utils";
+import { getAccessControlPermission, getIsMultiOrgEnabled } from "@/modules/ee/license-check/lib/utils";
 import { getOrganizationAuth } from "@/modules/organization/lib/utils";
 import { Header } from "@/modules/ui/components/header";
 
@@ -26,6 +28,9 @@ const Page = async (props: { params: Promise<{ organizationId: string }> }) => {
 
   const membership = await getMembershipByUserIdOrganizationId(session.user.id, organization.id);
   const isMembershipPending = membership?.role === undefined;
+  const { isOwner, isManager } = getAccessFlags(membership?.role);
+  const isOwnerOrManager = isOwner || isManager;
+  const isAccessControlAllowed = isOwnerOrManager ? await getAccessControlPermission(organization.id) : false;
 
   return (
     <div className="flex min-h-full min-w-full flex-row">
@@ -51,6 +56,12 @@ const Page = async (props: { params: Promise<{ organizationId: string }> }) => {
               title={t("organizations.landing.no_workspaces_warning_title")}
               subtitle={t("organizations.landing.no_workspaces_warning_subtitle")}
             />
+            {isOwnerOrManager && (
+              <CreateFirstWorkspaceButton
+                organizationId={organization.id}
+                isAccessControlAllowed={isAccessControlAllowed}
+              />
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What

An organization with **zero workspaces** routed its owner to the org landing page (`/organizations/[organizationId]/landing`), which offered no way to create a workspace. Every existing "create workspace" affordance lives *inside* an existing workspace (sidebar / breadcrumb), so an owner with no workspace was stuck with no path forward.

This adds a **Create workspace** call-to-action on the landing page, shown to organization **owners and managers**.


https://github.com/user-attachments/assets/e4a9cf24-3323-4d32-8680-3b2d47158a98



## How

- `landing/page.tsx` now derives the viewer's role from their organization membership (`getAccessFlags`) and, for owners/managers, resolves `getAccessControlPermission` for the team-assignment field.
- New client component `create-first-workspace-button.tsx` renders the CTA and opens the existing `CreateWorkspaceModal`.
- No client-side limit gating is added — `createWorkspaceAction` already enforces the workspace limit and owner/manager authorization server-side. (The breadcrumb's "Add new workspace" path was unsuitable here because it trips a limit modal when the workspace limit prop is `0`, which the landing page can't cheaply supply.)

## Behavior

- **Owner / Manager:** sees the "Create workspace" CTA → opens modal → on success redirects to the new workspace's surveys page.
- **Member / Billing:** no CTA (unchanged) — they should request access from the owner, matching the existing landing copy.

## Testing

- `tsc --noEmit` clean.
- Manual: org owner with no workspaces can now create one and is unblocked.

## Linear

Fixes [ENG-1528](https://linear.app/formbricks/issue/ENG-1528) — *Organization created with no workspaces*