### PR TITLE
fix: missing turbo config for db env var

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -39,6 +39,7 @@
     },
     "@formbricks/database#build": {
       "dependsOn": ["^build"],
+      "env": ["DATABASE_URL"],
       "outputs": ["dist/**", "generated/prisma/**"]
     },
     "@formbricks/database#lint": {


### PR DESCRIPTION
Fixes an issue of missing DATABASE_URL env var in turbo.json when building the database pkg in Dockerfile.

Checked, and built locally to verify it works.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [ ] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [ ] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [ ] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
