### PR TITLE
feat(workflows): v3 read API for workflow runs (list + detail)

### DIFF
--- a/apps/web/app/api/v3/workflows/runs/[runId]/route.ts
+++ b/apps/web/app/api/v3/workflows/runs/[runId]/route.ts
@@ -1,0 +1,20 @@
+/**
+ * /api/v3/workflows/runs/{runId} — retrieve a single workflow run with its ordered step logs.
+ * Unknown / cross-workspace run ids return 403 (not 404) to avoid leaking existence.
+ *
+ * Thin adapter: the wrapper validates the path param with the contract schema, then delegates to
+ * the framework-agnostic handler in `@formbricks/workflows/server`.
+ */
+import { ZWorkflowRunIdInput } from "@formbricks/workflows";
+import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
+import { buildWorkflowApiContext, workflowsHandlers } from "../../lib/context";
+
+export const GET = withV3ApiWrapper({
+  auth: "both",
+  schemas: { params: ZWorkflowRunIdInput },
+  handler: async ({ parsedInput, authentication, requestId, instance }) =>
+    workflowsHandlers.getRun({
+      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      params: parsedInput.params,
+    }),
+});

--- a/apps/web/app/api/v3/workflows/runs/route.ts
+++ b/apps/web/app/api/v3/workflows/runs/route.ts
@@ -1,0 +1,17 @@
+/**
+ * /api/v3/workflows/runs — list workflow runs for a workspace (newest first).
+ * Session cookie or x-api-key; scoped by the required `workspaceId` query param, with optional
+ * `workflowId` / `responseId` / `filter[status][in]` / `filter[isDryRun][eq]` filters. A static
+ * `runs` segment, so it never collides with `/api/v3/workflows/{workflowId}`.
+ *
+ * Thin adapter: authenticate via the shared wrapper, build the workflow API context, and delegate
+ * to the framework-agnostic handlers in `@formbricks/workflows/server`.
+ */
+import { withV3ApiWrapper } from "@/app/api/v3/lib/api-wrapper";
+import { buildWorkflowApiContext, workflowsHandlers } from "../lib/context";
+
+export const GET = withV3ApiWrapper({
+  auth: "both",
+  handler: async ({ req, authentication, requestId, instance }) =>
+    workflowsHandlers.listRuns({ req, ctx: buildWorkflowApiContext(authentication, requestId, instance) }),
+});

--- a/apps/web/modules/workflows/lib/api-client.test.ts
+++ b/apps/web/modules/workflows/lib/api-client.test.ts
@@ -7,12 +7,15 @@ import { V3ApiError } from "@/modules/api/lib/v3-client";
 import {
   archiveWorkflow,
   buildWorkflowListSearchParams,
+  buildWorkflowRunListSearchParams,
   createWorkflow,
   deleteWorkflow,
   disableWorkflow,
   duplicateWorkflow,
   enableWorkflow,
   getWorkflow,
+  getWorkflowRun,
+  listWorkflowRuns,
   listWorkflows,
   unarchiveWorkflow,
   updateWorkflow,
@@ -262,5 +265,119 @@ describe("workflows api-client requests", () => {
       code: "bad_request",
       message: "The request payload is invalid.",
     });
+  });
+});
+
+describe("buildWorkflowRunListSearchParams", () => {
+  test("encodes workspace, limit, cursor and the run filter family", () => {
+    const params = buildWorkflowRunListSearchParams({
+      workspaceId: "ws_1",
+      limit: 25,
+      cursor: "cursor_1",
+      filters: {
+        workflowId: "wf_1",
+        responseId: "rsp_1",
+        statusIn: ["failed", "completed"],
+        isDryRun: false,
+      },
+    });
+
+    expect(params.get("workspaceId")).toBe("ws_1");
+    expect(params.get("limit")).toBe("25");
+    expect(params.get("cursor")).toBe("cursor_1");
+    expect(params.get("workflowId")).toBe("wf_1");
+    expect(params.get("responseId")).toBe("rsp_1");
+    expect(params.get("filter[isDryRun][eq]")).toBe("false");
+    expect(params.getAll("filter[status][in]")).toEqual(["failed", "completed"]);
+  });
+
+  test("omits cursor and filters when not provided", () => {
+    const params = buildWorkflowRunListSearchParams({ workspaceId: "ws_1", limit: 20 });
+
+    expect(params.has("cursor")).toBe(false);
+    expect(params.has("workflowId")).toBe(false);
+    expect(params.has("responseId")).toBe(false);
+    expect(params.has("filter[isDryRun][eq]")).toBe(false);
+    expect(params.has("filter[status][in]")).toBe(false);
+  });
+});
+
+describe("workflow runs api-client requests", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("listWorkflowRuns requests the runs endpoint and returns the cursor page unchanged", async () => {
+    const page = { data: [{ id: "run_1" }], meta: { limit: 20, nextCursor: null } };
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse(page));
+
+    const result = await listWorkflowRuns({
+      workspaceId: "ws_1",
+      limit: 20,
+      filters: { workflowId: "wf_1" },
+    });
+
+    expect(result).toEqual(page);
+    const [url, init] = vi.mocked(global.fetch).mock.calls[0]!;
+    expect(url).toBe("/api/v3/workflows/runs?workspaceId=ws_1&limit=20&workflowId=wf_1");
+    expect(init).toMatchObject({ method: "GET", cache: "no-store" });
+  });
+
+  test("getWorkflowRun GETs the run-detail endpoint and unwraps the resource", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ data: { id: "run_1", logs: [] } }));
+
+    const result = await getWorkflowRun("run_1");
+
+    expect(result).toEqual({ id: "run_1", logs: [] });
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/v3/workflows/runs/run_1",
+      expect.objectContaining({ method: "GET", cache: "no-store" })
+    );
+  });
+
+  test("getWorkflowRun preserves nullable timestamp fields through the round-trip", async () => {
+    const resource = {
+      id: "run_1",
+      logs: [],
+      nextAttemptAt: "2026-06-12T11:00:00.000Z",
+      lastErrorAt: null,
+    };
+    vi.mocked(global.fetch).mockResolvedValueOnce(jsonResponse({ data: resource }));
+
+    const result = await getWorkflowRun("run_1");
+
+    expect(result).toEqual(resource);
+  });
+
+  test("listWorkflowRuns maps a problem response to a V3ApiError", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      problemResponse(403, {
+        title: "Forbidden",
+        status: 403,
+        detail: "denied",
+        code: "forbidden",
+        requestId: "req_1",
+      })
+    );
+
+    await expect(listWorkflowRuns({ workspaceId: "ws_1", limit: 20 })).rejects.toBeInstanceOf(V3ApiError);
+  });
+
+  test("getWorkflowRun maps a 403 problem response to a V3ApiError", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      problemResponse(403, {
+        title: "Forbidden",
+        status: 403,
+        detail: "denied",
+        code: "forbidden",
+        requestId: "req_1",
+      })
+    );
+
+    await expect(getWorkflowRun("run_x")).rejects.toBeInstanceOf(V3ApiError);
   });
 });

--- a/apps/web/modules/workflows/lib/api-client.ts
+++ b/apps/web/modules/workflows/lib/api-client.ts
@@ -3,6 +3,9 @@ import type {
   TPatchWorkflowInput,
   TWorkflowListItem,
   TWorkflowResource,
+  TWorkflowRunResource,
+  TWorkflowRunStatus,
+  TWorkflowRunSummary,
   TWorkflowSortBy,
   TWorkflowStatus,
 } from "@formbricks/workflows";
@@ -183,4 +186,102 @@ export async function deleteWorkflow(workflowId: string): Promise<void> {
   if (!response.ok) {
     throw await parseV3ApiError(response);
   }
+}
+
+export interface TWorkflowRunListPage {
+  data: TWorkflowRunSummary[];
+  meta: {
+    limit: number;
+    nextCursor: string | null;
+  };
+}
+
+export interface TWorkflowRunListFilters {
+  workflowId?: string;
+  responseId?: string;
+  statusIn?: TWorkflowRunStatus[];
+  isDryRun?: boolean;
+}
+
+export function buildWorkflowRunListSearchParams({
+  workspaceId,
+  limit,
+  cursor,
+  filters,
+}: {
+  workspaceId: string;
+  limit: number;
+  cursor?: string | null;
+  filters?: TWorkflowRunListFilters;
+}): URLSearchParams {
+  const searchParams = new URLSearchParams();
+
+  searchParams.set("workspaceId", workspaceId);
+  searchParams.set("limit", String(limit));
+
+  if (cursor) {
+    searchParams.set("cursor", cursor);
+  }
+
+  if (filters?.workflowId) {
+    searchParams.set("workflowId", filters.workflowId);
+  }
+
+  if (filters?.responseId) {
+    searchParams.set("responseId", filters.responseId);
+  }
+
+  if (filters?.isDryRun !== undefined) {
+    searchParams.set("filter[isDryRun][eq]", String(filters.isDryRun));
+  }
+
+  filters?.statusIn?.forEach((status) => {
+    searchParams.append("filter[status][in]", status);
+  });
+
+  return searchParams;
+}
+
+export async function listWorkflowRuns({
+  workspaceId,
+  limit,
+  cursor,
+  filters,
+  signal,
+}: {
+  workspaceId: string;
+  limit: number;
+  cursor?: string | null;
+  filters?: TWorkflowRunListFilters;
+  signal?: AbortSignal;
+}): Promise<TWorkflowRunListPage> {
+  const response = await fetch(
+    `/api/v3/workflows/runs?${buildWorkflowRunListSearchParams({ workspaceId, limit, cursor, filters }).toString()}`,
+    {
+      method: "GET",
+      cache: "no-store",
+      signal,
+    }
+  );
+
+  if (!response.ok) {
+    throw await parseV3ApiError(response);
+  }
+
+  return (await response.json()) as TWorkflowRunListPage;
+}
+
+export async function getWorkflowRun(runId: string, signal?: AbortSignal): Promise<TWorkflowRunResource> {
+  const response = await fetch(`/api/v3/workflows/runs/${runId}`, {
+    method: "GET",
+    cache: "no-store",
+    signal,
+  });
+
+  if (!response.ok) {
+    throw await parseV3ApiError(response);
+  }
+
+  const body = (await response.json()) as { data: TWorkflowRunResource };
+  return body.data;
 }

--- a/packages/workflows/src/handlers/parse-list-query.ts
+++ b/packages/workflows/src/handlers/parse-list-query.ts
@@ -32,8 +32,10 @@ const parseBooleanParam = (value: string | null): boolean | string | undefined =
 };
 
 /**
- * Map the HTTP query family to the contract's `ZListWorkflowsInput` shape, then validate. Validation
- * (unknown params, bad enum/limit) throws a `ZodError` the handler maps to a 400.
+ * Map the HTTP query family to the contract's `ZListWorkflowsInput` shape, then validate. Only the
+ * recognized keys are read; unrecognized query params are ignored (lenient, matching the v3 survey
+ * list, so third-party callers can append their own params). A bad value (enum/limit/cursor) throws
+ * a `ZodError` the handler maps to a 400.
  */
 export const parseListWorkflowsQuery = (searchParams: URLSearchParams): TListWorkflowsInput => {
   const raw: Record<string, unknown> = {
@@ -54,7 +56,8 @@ export const parseListWorkflowsQuery = (searchParams: URLSearchParams): TListWor
 /**
  * Map the HTTP query family to the contract's `ZListWorkflowRunsInput` shape, then validate. Runs are
  * always newest-first (no `sortBy`); the supported filters are `workflowId`, `responseId`,
- * `filter[status][in]`, and `filter[isDryRun][eq]`. A bad value throws a `ZodError` (→ 400).
+ * `filter[status][in]`, and `filter[isDryRun][eq]`. Unrecognized query params are ignored (lenient,
+ * as above); a bad value throws a `ZodError` (→ 400).
  */
 export const parseListWorkflowRunsQuery = (searchParams: URLSearchParams): TListWorkflowRunsInput => {
   const raw: Record<string, unknown> = {

--- a/packages/workflows/src/handlers/parse-list-query.ts
+++ b/packages/workflows/src/handlers/parse-list-query.ts
@@ -1,26 +1,45 @@
-import { type TListWorkflowsInput, ZListWorkflowsInput } from "../contracts";
+import {
+  type TListWorkflowRunsInput,
+  type TListWorkflowsInput,
+  ZListWorkflowRunsInput,
+  ZListWorkflowsInput,
+} from "../contracts";
 
 /**
- * Map the HTTP `filter[...]` query family to the contract's `ZListWorkflowsInput` shape, then
- * validate. Multi-value filters accept repeated keys or comma-separated values
+ * Multi-value filters accept repeated keys or comma-separated values
  * (`filter[status][in]=draft&filter[status][in]=disabled` or `filter[status][in]=draft,disabled`),
- * matching the v3 survey list. Validation (unknown params, bad enum/limit) throws a `ZodError` the
- * handler maps to a 400.
+ * matching the v3 survey list. Returns `undefined` when absent so Zod applies its default/optional.
+ */
+const multiValue = (searchParams: URLSearchParams, key: string): string[] | undefined => {
+  const values = searchParams
+    .getAll(key)
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  return values.length > 0 ? values : undefined;
+};
+
+/**
+ * Map the literal `filter[isDryRun][eq]` query value to a boolean. `"true"`/`"false"` map to the
+ * boolean; absent maps to `undefined` (omit → both real and dry runs); any other value is passed
+ * through verbatim so Zod rejects it with a 400 rather than silently coercing.
+ */
+const parseBooleanParam = (value: string | null): boolean | string | undefined => {
+  if (value === null) return undefined;
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return value;
+};
+
+/**
+ * Map the HTTP query family to the contract's `ZListWorkflowsInput` shape, then validate. Validation
+ * (unknown params, bad enum/limit) throws a `ZodError` the handler maps to a 400.
  */
 export const parseListWorkflowsQuery = (searchParams: URLSearchParams): TListWorkflowsInput => {
-  const multiValue = (key: string): string[] | undefined => {
-    const values = searchParams
-      .getAll(key)
-      .flatMap((value) => value.split(","))
-      .map((value) => value.trim())
-      .filter((value) => value.length > 0);
-    return values.length > 0 ? values : undefined;
-  };
-
   const raw: Record<string, unknown> = {
     workspaceId: searchParams.get("workspaceId") ?? undefined,
     cursor: searchParams.get("cursor") ?? undefined,
-    statusIn: multiValue("filter[status][in]"),
+    statusIn: multiValue(searchParams, "filter[status][in]"),
     nameContains: searchParams.get("filter[name][contains]") ?? undefined,
     sortBy: searchParams.get("sortBy") ?? undefined,
   };
@@ -30,4 +49,26 @@ export const parseListWorkflowsQuery = (searchParams: URLSearchParams): TListWor
   }
 
   return ZListWorkflowsInput.parse(raw);
+};
+
+/**
+ * Map the HTTP query family to the contract's `ZListWorkflowRunsInput` shape, then validate. Runs are
+ * always newest-first (no `sortBy`); the supported filters are `workflowId`, `responseId`,
+ * `filter[status][in]`, and `filter[isDryRun][eq]`. A bad value throws a `ZodError` (→ 400).
+ */
+export const parseListWorkflowRunsQuery = (searchParams: URLSearchParams): TListWorkflowRunsInput => {
+  const raw: Record<string, unknown> = {
+    workspaceId: searchParams.get("workspaceId") ?? undefined,
+    cursor: searchParams.get("cursor") ?? undefined,
+    workflowId: searchParams.get("workflowId") ?? undefined,
+    responseId: searchParams.get("responseId") ?? undefined,
+    statusIn: multiValue(searchParams, "filter[status][in]"),
+    isDryRun: parseBooleanParam(searchParams.get("filter[isDryRun][eq]")),
+  };
+
+  if (searchParams.has("limit")) {
+    raw.limit = Number(searchParams.get("limit"));
+  }
+
+  return ZListWorkflowRunsInput.parse(raw);
 };

--- a/packages/workflows/src/handlers/runs-cursor.test.ts
+++ b/packages/workflows/src/handlers/runs-cursor.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+import { WorkflowInvalidInputError } from "../errors";
+import {
+  buildNextWorkflowRunListCursor,
+  decodeWorkflowRunListCursor,
+  encodeWorkflowRunListCursor,
+} from "./runs-cursor";
+
+const runId = "cm9zr4w9d000308l8c5n8xk7e";
+const createdAt = new Date("2026-06-12T10:00:00.000Z");
+
+describe("runs-cursor", () => {
+  test("round-trips a cursor through encode/decode", () => {
+    const cursor = buildNextWorkflowRunListCursor({ id: runId, createdAt });
+    const decoded = decodeWorkflowRunListCursor(encodeWorkflowRunListCursor(cursor));
+    expect(decoded).toEqual({ version: 1, value: "2026-06-12T10:00:00.000Z", id: runId });
+  });
+
+  test("buildNext uses the row createdAt ISO string and id", () => {
+    expect(buildNextWorkflowRunListCursor({ id: runId, createdAt })).toEqual({
+      version: 1,
+      value: "2026-06-12T10:00:00.000Z",
+      id: runId,
+    });
+  });
+
+  test("the encoded cursor is an opaque base64url token (no plain query state)", () => {
+    const encoded = encodeWorkflowRunListCursor({ version: 1, value: createdAt.toISOString(), id: runId });
+    expect(encoded).not.toContain(runId);
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test("rejects a malformed cursor with a 400 WorkflowInvalidInputError", () => {
+    expect(() => decodeWorkflowRunListCursor("not-base64url-json")).toThrow(WorkflowInvalidInputError);
+  });
+
+  test("rejects a structurally invalid cursor (missing id)", () => {
+    const bad = Buffer.from(JSON.stringify({ version: 1, value: createdAt.toISOString() }), "utf8").toString(
+      "base64url"
+    );
+    expect(() => decodeWorkflowRunListCursor(bad)).toThrow(WorkflowInvalidInputError);
+  });
+
+  test("rejects a cursor with a non-ISO value", () => {
+    const bad = Buffer.from(JSON.stringify({ version: 1, value: "nope", id: runId }), "utf8").toString(
+      "base64url"
+    );
+    expect(() => decodeWorkflowRunListCursor(bad)).toThrow(WorkflowInvalidInputError);
+  });
+
+  test("rejects a cursor from an unknown version", () => {
+    const bad = Buffer.from(
+      JSON.stringify({ version: 2, value: createdAt.toISOString(), id: runId }),
+      "utf8"
+    ).toString("base64url");
+    expect(() => decodeWorkflowRunListCursor(bad)).toThrow(WorkflowInvalidInputError);
+  });
+});

--- a/packages/workflows/src/handlers/runs-cursor.ts
+++ b/packages/workflows/src/handlers/runs-cursor.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+import { WorkflowInvalidInputError } from "../errors";
+
+/**
+ * Opaque keyset cursor for the workflow run list. The run list has a single, fixed order — newest
+ * first (`createdAt desc`, `id desc` as a stable tie-breaker) — so unlike the workflow-list cursor
+ * it carries no `sortBy`. The token is a base64url-encoded JSON `{ version, value, id }` where
+ * `value` is the last row's `createdAt` ISO string and `id` is its id. Reimplemented here (not
+ * imported from `apps/web`) to keep the package a dependency-free leaf.
+ */
+
+const WORKFLOW_RUN_LIST_CURSOR_VERSION = 1;
+
+const ZWorkflowRunListCursor = z.object({
+  version: z.literal(WORKFLOW_RUN_LIST_CURSOR_VERSION),
+  value: z.iso.datetime({ offset: true }),
+  id: z.string().min(1),
+});
+export type TWorkflowRunListCursor = z.infer<typeof ZWorkflowRunListCursor>;
+
+export const encodeWorkflowRunListCursor = (cursor: TWorkflowRunListCursor): string =>
+  Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
+
+/** Decode + validate a run-list cursor; a malformed token is a 400 (never a 500). */
+export const decodeWorkflowRunListCursor = (encodedCursor: string): TWorkflowRunListCursor => {
+  try {
+    const decodedJson = Buffer.from(encodedCursor, "base64url").toString("utf8");
+    return ZWorkflowRunListCursor.parse(JSON.parse(decodedJson));
+  } catch {
+    throw new WorkflowInvalidInputError("The cursor is invalid.", [
+      { name: "cursor", reason: "The cursor is invalid." },
+    ]);
+  }
+};
+
+/** Build the next-page cursor from the last row of the current page. */
+export const buildNextWorkflowRunListCursor = (row: {
+  id: string;
+  createdAt: Date;
+}): TWorkflowRunListCursor => ({
+  version: WORKFLOW_RUN_LIST_CURSOR_VERSION,
+  value: row.createdAt.toISOString(),
+  id: row.id,
+});

--- a/packages/workflows/src/handlers/serializers.test.ts
+++ b/packages/workflows/src/handlers/serializers.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, test } from "vitest";
-import type { WorkflowRowWithLastRun, WorkflowRunRow } from "../services/ports";
-import { toWorkflowListItem, toWorkflowResource, toWorkflowRunSummary } from "./serializers";
+import type {
+  WorkflowRowWithLastRun,
+  WorkflowRunLogRow,
+  WorkflowRunRow,
+  WorkflowRunWithLogsRow,
+} from "../services/ports";
+import type { TWorkflowTriggerRunPayload } from "../types/runs";
+import {
+  toWorkflowListItem,
+  toWorkflowResource,
+  toWorkflowRunLogResource,
+  toWorkflowRunResource,
+  toWorkflowRunSummary,
+} from "./serializers";
 
 const surveyId = "cm9zr4q7i000108l84gozfggr";
 const workflowId = "cm9zr4t2b000208l8h2m1aq3c";
@@ -96,5 +108,88 @@ describe("serializers", () => {
     const resource = toWorkflowResource(baseRow);
     expect(resource.definition).toEqual(definition);
     expect(resource.id).toBe(workflowId);
+  });
+});
+
+const triggerPayload = {
+  triggerType: "response.completed",
+  config: { surveyId, endingCardIds: [] },
+  surveyId,
+  responseId: "cm9zr5resp0000000000000000",
+  finishedEndingId: null,
+  triggeredAt: "2026-06-12T10:00:00.000Z",
+} as unknown as TWorkflowTriggerRunPayload;
+
+const logA: WorkflowRunLogRow = {
+  id: "cm9zr5log0000000000000000a",
+  runId: run.id,
+  sequence: 0,
+  stepId: "send-email",
+  stepType: "send_email",
+  status: "succeeded",
+  input: { to: "support@example.com" },
+  output: { messageId: "msg_1" },
+  error: null,
+  startedAt: new Date("2026-06-12T10:00:30.000Z"),
+  finishedAt: new Date("2026-06-12T10:00:31.000Z"),
+};
+
+const detailRun: WorkflowRunWithLogsRow = {
+  ...run,
+  triggerPayload,
+  data: { steps: [] },
+  idempotencyKey: "idem-1",
+  nextAttemptAt: null,
+  lastErrorAt: null,
+  logs: [logA],
+};
+
+describe("run serializers", () => {
+  test("run log resource emits every field explicitly, including null error/timestamps", () => {
+    const resource = toWorkflowRunLogResource({
+      ...logA,
+      error: null,
+      startedAt: null,
+      finishedAt: null,
+    });
+    expect(resource).toEqual({
+      id: logA.id,
+      runId: run.id,
+      sequence: 0,
+      stepId: "send-email",
+      stepType: "send_email",
+      status: "succeeded",
+      input: { to: "support@example.com" },
+      output: { messageId: "msg_1" },
+      error: null,
+      startedAt: null,
+      finishedAt: null,
+    });
+  });
+
+  test("run resource carries summary fields, triggerPayload, data, and serialized logs", () => {
+    const resource = toWorkflowRunResource(detailRun);
+
+    expect(resource.id).toBe(run.id);
+    expect(resource.status).toBe("completed");
+    expect(resource.triggerPayload).toEqual(triggerPayload);
+    expect(resource.data).toEqual({ steps: [] });
+    expect(resource.idempotencyKey).toBe("idem-1");
+    expect(resource.nextAttemptAt).toBeNull();
+    expect(resource.lastErrorAt).toBeNull();
+    expect(resource.logs).toHaveLength(1);
+    expect(resource.logs[0]).toMatchObject({ id: logA.id, sequence: 0, status: "succeeded" });
+    expect(resource.logs[0].startedAt).toBe("2026-06-12T10:00:30.000Z");
+  });
+
+  test("serializes non-null nextAttemptAt / lastErrorAt as ISO strings", () => {
+    const resource = toWorkflowRunResource({
+      ...detailRun,
+      nextAttemptAt: new Date("2026-06-12T11:00:00.000Z"),
+      lastErrorAt: new Date("2026-06-12T10:30:00.000Z"),
+    });
+
+    expect(resource.nextAttemptAt).toBe("2026-06-12T11:00:00.000Z");
+    expect(resource.lastErrorAt).toBe("2026-06-12T10:30:00.000Z");
   });
 });

--- a/packages/workflows/src/handlers/serializers.ts
+++ b/packages/workflows/src/handlers/serializers.ts
@@ -1,5 +1,16 @@
-import type { TWorkflowListItem, TWorkflowResource, TWorkflowRunSummary } from "../contracts";
-import type { WorkflowRowWithLastRun, WorkflowRunRow } from "../services/ports";
+import type {
+  TWorkflowListItem,
+  TWorkflowResource,
+  TWorkflowRunLogResource,
+  TWorkflowRunResource,
+  TWorkflowRunSummary,
+} from "../contracts";
+import type {
+  WorkflowRowWithLastRun,
+  WorkflowRunLogRow,
+  WorkflowRunRow,
+  WorkflowRunWithLogsRow,
+} from "../services/ports";
 
 /**
  * Map Prisma rows to the public v3 resource shapes. Serializer output is validated against the
@@ -17,6 +28,8 @@ export const toWorkflowRunSummary = (run: WorkflowRunRow): TWorkflowRunSummary =
   workflowVersionId: run.workflowVersionId,
   status: run.status,
   isDryRun: run.isDryRun,
+  // `triggerType` is a `String` column (see WorkflowRunRow in ports.ts); the union is enforced by
+  // `validateOutput(ZWorkflowRunSummary, …)` at the handler boundary, so this narrowing cast is safe.
   triggerType: run.triggerType as TWorkflowRunSummary["triggerType"],
   surveyId: run.surveyId,
   responseId: run.responseId,
@@ -26,6 +39,30 @@ export const toWorkflowRunSummary = (run: WorkflowRunRow): TWorkflowRunSummary =
   updatedAt: run.updatedAt.toISOString(),
   startedAt: toIso(run.startedAt),
   finishedAt: toIso(run.finishedAt),
+});
+
+export const toWorkflowRunLogResource = (log: WorkflowRunLogRow): TWorkflowRunLogResource => ({
+  id: log.id,
+  runId: log.runId,
+  sequence: log.sequence,
+  stepId: log.stepId,
+  stepType: log.stepType,
+  status: log.status,
+  input: log.input,
+  output: log.output,
+  error: log.error,
+  startedAt: toIso(log.startedAt),
+  finishedAt: toIso(log.finishedAt),
+});
+
+export const toWorkflowRunResource = (run: WorkflowRunWithLogsRow): TWorkflowRunResource => ({
+  ...toWorkflowRunSummary(run),
+  triggerPayload: run.triggerPayload,
+  data: run.data,
+  logs: run.logs.map(toWorkflowRunLogResource),
+  idempotencyKey: run.idempotencyKey,
+  nextAttemptAt: toIso(run.nextAttemptAt),
+  lastErrorAt: toIso(run.lastErrorAt),
 });
 
 export const toWorkflowListItem = (row: WorkflowRowWithLastRun): TWorkflowListItem => {

--- a/packages/workflows/src/handlers/workflows.handlers.test.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.test.ts
@@ -1,7 +1,13 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { WorkflowConflictError } from "../errors";
-import type { WorkflowRowWithLastRun, WorkflowsLogger } from "../services/ports";
+import { WorkflowConflictError, WorkflowInvalidInputError } from "../errors";
+import type {
+  WorkflowRowWithLastRun,
+  WorkflowRunRow,
+  WorkflowRunWithLogsRow,
+  WorkflowsLogger,
+} from "../services/ports";
 import type { WorkflowsService } from "../services/workflows.service";
+import type { TWorkflowTriggerRunPayload } from "../types/runs";
 import type { AuthorizedWorkspace, WorkflowApiContext } from "./context";
 import { createWorkflowsHandlers } from "./workflows.handlers";
 
@@ -61,6 +67,8 @@ const service = {
   setStatus: vi.fn<WorkflowsService["setStatus"]>(),
   enableWorkflow: vi.fn<WorkflowsService["enableWorkflow"]>(),
   disableWorkflow: vi.fn<WorkflowsService["disableWorkflow"]>(),
+  listWorkflowRuns: vi.fn<WorkflowsService["listWorkflowRuns"]>(),
+  getWorkflowRun: vi.fn<WorkflowsService["getWorkflowRun"]>(),
 };
 const handlers = createWorkflowsHandlers(service);
 
@@ -576,5 +584,230 @@ describe("disable", () => {
 
     expect(res.status).toBe(403);
     expect(service.disableWorkflow).not.toHaveBeenCalled();
+  });
+});
+
+const runId = "cm9zr4w9d000308l8c5n8xk7e";
+
+const makeRunRow = (overrides: Partial<WorkflowRunRow> = {}): WorkflowRunRow => ({
+  id: runId,
+  createdAt: new Date("2026-06-12T10:00:00.000Z"),
+  updatedAt: new Date("2026-06-12T10:01:00.000Z"),
+  workflowId,
+  workspaceId,
+  workflowVersionId: null,
+  responseId: null,
+  status: "completed",
+  triggerType: "response.completed",
+  surveyId,
+  isDryRun: false,
+  attempt: 0,
+  error: null,
+  startedAt: new Date("2026-06-12T10:00:30.000Z"),
+  finishedAt: new Date("2026-06-12T10:01:00.000Z"),
+  ...overrides,
+});
+
+// Mirrors the canonical run-data fixture's trigger payload (a valid TWorkflowTriggerRunPayload), so
+// the handler's output validation against ZWorkflowRunResource passes.
+const validTriggerPayload = {
+  type: "response.completed",
+  surveyId,
+  responseId: "cm9zr4rsp000708l8bqccpfrx",
+  endingCardId: "cm9zr4q7i000108l84gozfggr",
+  workspaceId,
+  data: { response: { email: "jane@example.com", score: 9 } },
+  triggeredAt: "2026-06-09T12:01:00.000Z",
+} as unknown as TWorkflowTriggerRunPayload;
+
+const makeRunDetail = (overrides: Partial<WorkflowRunWithLogsRow> = {}): WorkflowRunWithLogsRow => ({
+  ...makeRunRow(),
+  triggerPayload: validTriggerPayload,
+  data: { steps: [] },
+  idempotencyKey: null,
+  nextAttemptAt: null,
+  lastErrorAt: null,
+  logs: [
+    {
+      id: "cm9zr5log0000000000000000a",
+      runId,
+      sequence: 0,
+      stepId: "send-email",
+      stepType: "send_email",
+      status: "succeeded",
+      input: { to: "jane@example.com" },
+      output: { messageId: "msg_1" },
+      error: null,
+      startedAt: new Date("2026-06-12T10:00:30.000Z"),
+      finishedAt: new Date("2026-06-12T10:00:31.000Z"),
+    },
+  ],
+  ...overrides,
+});
+
+describe("listRuns", () => {
+  const runsRequest = (query: string): Request =>
+    new Request(`http://localhost/api/v3/workflows/runs?${query}`);
+
+  test("returns 200 with a cursor-paginated envelope of run summaries", async () => {
+    service.listWorkflowRuns.mockResolvedValue({ runs: [makeRunRow()], nextCursor: null });
+
+    const res = await handlers.listRuns({ req: runsRequest(`workspaceId=${workspaceId}`), ctx: makeCtx() });
+
+    expect(res.status).toBe(200);
+    const body = await readJson<{
+      data: { id: string }[];
+      meta: { limit: number; nextCursor: string | null };
+    }>(res);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].id).toBe(runId);
+    expect(body.meta.limit).toBe(20);
+    expect(body.meta.nextCursor).toBeNull();
+    expect(authorizeAllow).toHaveBeenCalledWith(workspaceId, "read");
+  });
+
+  test("forwards workflowId / responseId / status / isDryRun filters to the service", async () => {
+    service.listWorkflowRuns.mockResolvedValue({ runs: [], nextCursor: null });
+
+    await handlers.listRuns({
+      req: runsRequest(
+        `workspaceId=${workspaceId}&workflowId=${workflowId}&filter[status][in]=failed,completed&filter[isDryRun][eq]=true`
+      ),
+      ctx: makeCtx(),
+    });
+
+    expect(service.listWorkflowRuns).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId,
+        workflowId,
+        statusIn: ["failed", "completed"],
+        isDryRun: true,
+      })
+    );
+  });
+
+  test("forwards isDryRun=false alongside a status filter (falsy boolean not dropped)", async () => {
+    service.listWorkflowRuns.mockResolvedValue({ runs: [], nextCursor: null });
+
+    await handlers.listRuns({
+      req: runsRequest(`workspaceId=${workspaceId}&filter[isDryRun][eq]=false&filter[status][in]=failed`),
+      ctx: makeCtx(),
+    });
+
+    expect(service.listWorkflowRuns).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceId, isDryRun: false, statusIn: ["failed"] })
+    );
+  });
+
+  test("returns an empty data array and null nextCursor for an empty page", async () => {
+    service.listWorkflowRuns.mockResolvedValue({ runs: [], nextCursor: null });
+
+    const res = await handlers.listRuns({ req: runsRequest(`workspaceId=${workspaceId}`), ctx: makeCtx() });
+
+    expect(res.status).toBe(200);
+    const body = await readJson<{ data: unknown[]; meta: { nextCursor: string | null } }>(res);
+    expect(body.data).toEqual([]);
+    expect(body.meta.nextCursor).toBeNull();
+  });
+
+  test("maps a WorkflowInvalidInputError from the service (e.g. malformed cursor) to 400", async () => {
+    service.listWorkflowRuns.mockRejectedValue(new WorkflowInvalidInputError("malformed cursor"));
+
+    const res = await handlers.listRuns({
+      req: runsRequest(`workspaceId=${workspaceId}&cursor=not-base64url-json`),
+      ctx: makeCtx(),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await readJson<{ code: string }>(res);
+    expect(body.code).toBe("bad_request");
+  });
+
+  test("rejects a missing workspaceId with 400 and never calls the service", async () => {
+    const res = await handlers.listRuns({ req: runsRequest("limit=20"), ctx: makeCtx() });
+
+    expect(res.status).toBe(400);
+    expect(service.listWorkflowRuns).not.toHaveBeenCalled();
+  });
+
+  test("rejects an out-of-range limit with 400", async () => {
+    const res = await handlers.listRuns({
+      req: runsRequest(`workspaceId=${workspaceId}&limit=500`),
+      ctx: makeCtx(),
+    });
+
+    expect(res.status).toBe(400);
+    expect(service.listWorkflowRuns).not.toHaveBeenCalled();
+  });
+
+  test("rejects limit below the minimum (limit=0) with 400", async () => {
+    const res = await handlers.listRuns({
+      req: runsRequest(`workspaceId=${workspaceId}&limit=0`),
+      ctx: makeCtx(),
+    });
+
+    expect(res.status).toBe(400);
+    expect(service.listWorkflowRuns).not.toHaveBeenCalled();
+  });
+
+  test("accepts the minimum limit (limit=1)", async () => {
+    service.listWorkflowRuns.mockResolvedValue({ runs: [makeRunRow()], nextCursor: null });
+
+    const res = await handlers.listRuns({
+      req: runsRequest(`workspaceId=${workspaceId}&limit=1`),
+      ctx: makeCtx(),
+    });
+
+    expect(res.status).toBe(200);
+    expect(service.listWorkflowRuns).toHaveBeenCalledWith(expect.objectContaining({ limit: 1 }));
+  });
+
+  test("returns the authorize denial (403) and never calls the service", async () => {
+    authorizeAllow.mockResolvedValue(deniedResponse());
+
+    const res = await handlers.listRuns({ req: runsRequest(`workspaceId=${workspaceId}`), ctx: makeCtx() });
+
+    expect(res.status).toBe(403);
+    expect(service.listWorkflowRuns).not.toHaveBeenCalled();
+  });
+});
+
+describe("getRun", () => {
+  test("returns 200 with the full run resource including ordered logs", async () => {
+    service.getWorkflowRun.mockResolvedValue(makeRunDetail());
+
+    const res = await handlers.getRun({ ctx: makeCtx(), params: { runId } });
+
+    expect(res.status).toBe(200);
+    const body = await readJson<{ data: { id: string; logs: { id: string }[]; triggerPayload: unknown } }>(
+      res
+    );
+    expect(body.data.id).toBe(runId);
+    expect(body.data.logs).toHaveLength(1);
+    expect(body.data.triggerPayload).toMatchObject({ type: "response.completed", surveyId });
+    expect(authorizeAllow).toHaveBeenCalledWith(workspaceId, "read");
+  });
+
+  test("returns 403 (not 404) when the run does not exist, without authorizing", async () => {
+    service.getWorkflowRun.mockResolvedValue(null);
+
+    const res = await handlers.getRun({ ctx: makeCtx(), params: { runId } });
+
+    expect(res.status).toBe(403);
+    expect(authorizeAllow).not.toHaveBeenCalled();
+    const body = await readJson<{ code: string }>(res);
+    expect(body.code).toBe("forbidden");
+  });
+
+  test("authorizes against the loaded run's workspace and returns its denial on mismatch", async () => {
+    service.getWorkflowRun.mockResolvedValue(makeRunDetail({ workspaceId: "cm9zr4other00000000000000x" }));
+    authorizeAllow.mockResolvedValue(deniedResponse());
+
+    const res = await handlers.getRun({ ctx: makeCtx(), params: { runId } });
+
+    expect(res.status).toBe(403);
+    expect(authorizeAllow).toHaveBeenCalledWith("cm9zr4other00000000000000x", "read");
+    const body = await readJson<{ code: string }>(res);
+    expect(body.code).toBe("forbidden");
   });
 });

--- a/packages/workflows/src/handlers/workflows.handlers.test.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.test.ts
@@ -14,6 +14,7 @@ import { createWorkflowsHandlers } from "./workflows.handlers";
 const surveyId = "cm9zr4q7i000108l84gozfggr";
 const workspaceId = "cm9zr4mps000008l8btfy1vtz";
 const workflowId = "cm9zr4t2b000208l8h2m1aq3c";
+const responseId = "cm9zr4rsp000708l8bqccpfrx";
 
 const definition = {
   schemaVersion: 1 as const,
@@ -671,7 +672,7 @@ describe("listRuns", () => {
 
     await handlers.listRuns({
       req: runsRequest(
-        `workspaceId=${workspaceId}&workflowId=${workflowId}&filter[status][in]=failed,completed&filter[isDryRun][eq]=true`
+        `workspaceId=${workspaceId}&workflowId=${workflowId}&responseId=${responseId}&filter[status][in]=failed,completed&filter[isDryRun][eq]=true`
       ),
       ctx: makeCtx(),
     });
@@ -680,6 +681,7 @@ describe("listRuns", () => {
       expect.objectContaining({
         workspaceId,
         workflowId,
+        responseId,
         statusIn: ["failed", "completed"],
         isDryRun: true,
       })

--- a/packages/workflows/src/handlers/workflows.handlers.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.ts
@@ -1,10 +1,13 @@
 import {
   type TWorkflowIdInput,
+  type TWorkflowRunIdInput,
   ZCreateWorkflowInput,
   ZDuplicateWorkflowInput,
   ZPatchWorkflowInput,
   ZWorkflowListItem,
   ZWorkflowResource,
+  ZWorkflowRunResource,
+  ZWorkflowRunSummary,
   zCursorPage,
 } from "../contracts";
 import {
@@ -21,13 +24,19 @@ import type { WorkflowRowWithLastRun } from "../services/ports";
 import type { WorkflowsService } from "../services/workflows.service";
 import { ZWorkflowExecutableDefinition } from "../types/document";
 import type { TriggerSurveyCheck, WorkflowApiAccess, WorkflowApiContext } from "./context";
-import { parseListWorkflowsQuery } from "./parse-list-query";
-import { toWorkflowListItem, toWorkflowResource } from "./serializers";
+import { parseListWorkflowRunsQuery, parseListWorkflowsQuery } from "./parse-list-query";
+import {
+  toWorkflowListItem,
+  toWorkflowResource,
+  toWorkflowRunResource,
+  toWorkflowRunSummary,
+} from "./serializers";
 
 // Matches the v3 API's default request-body limit (apps/web `request-body.ts`) for consistency.
 const MAX_REQUEST_BODY_BYTES = 2 * 1024 * 1024;
 
 const ZWorkflowListPage = zCursorPage(ZWorkflowListItem);
+const ZWorkflowRunListPage = zCursorPage(ZWorkflowRunSummary);
 
 const readJsonBody = async (req: Request, options?: { allowEmpty?: boolean }): Promise<unknown> => {
   // Reject oversized payloads up front via Content-Length so we never buffer them into memory.
@@ -111,6 +120,10 @@ interface WorkflowResourceArgs {
 interface WorkflowResourceBodyArgs extends WorkflowResourceArgs {
   req: Request;
 }
+interface WorkflowRunResourceArgs {
+  ctx: WorkflowApiContext;
+  params: TWorkflowRunIdInput;
+}
 
 export interface WorkflowsHandlers {
   list: (args: WorkflowRequestArgs) => Promise<Response>;
@@ -123,6 +136,8 @@ export interface WorkflowsHandlers {
   unarchive: (args: WorkflowResourceArgs) => Promise<Response>;
   enable: (args: WorkflowResourceArgs) => Promise<Response>;
   disable: (args: WorkflowResourceArgs) => Promise<Response>;
+  listRuns: (args: WorkflowRequestArgs) => Promise<Response>;
+  getRun: (args: WorkflowRunResourceArgs) => Promise<Response>;
 }
 
 /**
@@ -323,6 +338,43 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
       });
 
       return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
+    } catch (error) {
+      return toProblemResponse(error, ctx);
+    }
+  },
+
+  async listRuns({ req, ctx }) {
+    try {
+      const input = parseListWorkflowRunsQuery(new URL(req.url).searchParams);
+
+      const authorized = await ctx.authorize(input.workspaceId, "read");
+      if (authorized instanceof Response) return authorized;
+
+      const runPage = await service.listWorkflowRuns({ ...input, workspaceId: authorized.workspaceId });
+
+      const page = validateOutput(ZWorkflowRunListPage, {
+        data: runPage.runs.map(toWorkflowRunSummary),
+        meta: { limit: input.limit, nextCursor: runPage.nextCursor },
+      });
+
+      return listResponse(page.data, page.meta, ctx.requestId);
+    } catch (error) {
+      return toProblemResponse(error, ctx);
+    }
+  },
+
+  async getRun({ ctx, params }) {
+    try {
+      // Load by id, then authorize against the run's workspace — an unknown / cross-workspace runId
+      // is rejected with 403 (never 404), matching the by-id workflow handlers and never leaking
+      // existence. The detail read carries the full run + ordered step logs.
+      const run = await service.getWorkflowRun(params.runId);
+      if (!run) throw new WorkflowForbiddenError();
+
+      const authorized = await ctx.authorize(run.workspaceId, "read");
+      if (authorized instanceof Response) return authorized;
+
+      return dataResponse(validateOutput(ZWorkflowRunResource, toWorkflowRunResource(run)), ctx.requestId);
     } catch (error) {
       return toProblemResponse(error, ctx);
     }

--- a/packages/workflows/src/services/ports.ts
+++ b/packages/workflows/src/services/ports.ts
@@ -1,6 +1,13 @@
 import type { TWorkflowStatus } from "../types/common";
 import type { TWorkflowDefinition, TWorkflowExecutableDefinition } from "../types/document";
-import type { TWorkflowRunStatus } from "../types/runs";
+import type {
+  TWorkflowRunData,
+  TWorkflowRunLogInput,
+  TWorkflowRunLogOutput,
+  TWorkflowRunLogStatus,
+  TWorkflowRunStatus,
+  TWorkflowTriggerRunPayload,
+} from "../types/runs";
 
 /**
  * Runtime ports the workflow server code depends on. They are injected by the adapter
@@ -38,6 +45,11 @@ export interface WorkflowRunRow {
   workflowVersionId: string | null;
   responseId: string | null;
   status: TWorkflowRunStatus;
+  // `triggerType` is a free-form `String` column in Prisma (unlike `status`, which is a
+  // `WorkflowRunStatus` enum), so the port mirrors it as `string`. Do NOT narrow this to the
+  // `ZWorkflowTriggerType` union here: the real Prisma row yields `string`, which would then fail
+  // to satisfy this port and break the adapter's structural wiring. The serializer narrows it and
+  // `validateOutput` enforces the union at the response boundary instead.
   triggerType: string;
   surveyId: string | null;
   isDryRun: boolean;
@@ -163,9 +175,78 @@ export interface WorkflowsTransaction {
   workflowVersion: WorkflowVersionDelegate;
 }
 
+/** A persisted `WorkflowRunLog` step trace row, matching `packages/database/schema/workflows.prisma`. */
+export interface WorkflowRunLogRow {
+  id: string;
+  runId: string;
+  sequence: number;
+  stepId: string;
+  stepType: string;
+  status: TWorkflowRunLogStatus;
+  input: TWorkflowRunLogInput;
+  output: TWorkflowRunLogOutput;
+  error: string | null;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+}
+
+/**
+ * The full `WorkflowRun` row plus its ordered step logs, returned by the run-detail read. Extends the
+ * slim `WorkflowRunRow` (the list/lastRun shape) with the debug-oriented fields the detail resource
+ * exposes. The JSON columns (`triggerPayload`, `data`) are typed via the schema's
+ * prisma-json-types-generator annotations, so the real Prisma row satisfies this without a cast.
+ */
+export interface WorkflowRunWithLogsRow extends WorkflowRunRow {
+  triggerPayload: TWorkflowTriggerRunPayload;
+  data: TWorkflowRunData;
+  idempotencyKey: string | null;
+  nextAttemptAt: Date | null;
+  lastErrorAt: Date | null;
+  logs: WorkflowRunLogRow[];
+}
+
+/** Narrow `where` filter the run list builds — a deliberately small slice of Prisma's WhereInput. */
+export interface WorkflowRunWhereInput {
+  workspaceId?: string;
+  workflowId?: string;
+  responseId?: string;
+  status?: { in: TWorkflowRunStatus[] };
+  isDryRun?: boolean;
+  createdAt?: { lt: Date } | Date;
+  id?: { lt: string };
+  OR?: WorkflowRunWhereInput[];
+}
+
+export interface WorkflowRunOrderByInput {
+  createdAt?: "asc" | "desc";
+  id?: "asc" | "desc";
+}
+
+/** Eager-load shape for a run's step logs, ordered by sequence; matches the Prisma `include`. */
+export interface WorkflowRunLogInclude {
+  logs: { orderBy: { sequence: "asc" } };
+}
+
+/**
+ * The slice of `prisma.workflowRun` the runs read API calls. `findMany` returns slim summary rows
+ * (newest-first, keyset-paginated); `findUnique` returns the full row with ordered logs for detail.
+ */
+export interface WorkflowRunDelegate {
+  findMany: (args: {
+    where: WorkflowRunWhereInput;
+    orderBy: WorkflowRunOrderByInput[];
+    take: number;
+  }) => Promise<WorkflowRunRow[]>;
+  findUnique: (args: {
+    where: { id: string };
+    include: WorkflowRunLogInclude;
+  }) => Promise<WorkflowRunWithLogsRow | null>;
+}
+
 export interface WorkflowsDb {
   workflow: WorkflowDelegate;
   workflowVersion: WorkflowVersionDelegate;
+  workflowRun: WorkflowRunDelegate;
   /** Interactive transaction; the real Prisma client's `$transaction` satisfies this structurally. */
   $transaction: <R>(fn: (tx: WorkflowsTransaction) => Promise<R>) => Promise<R>;
 }

--- a/packages/workflows/src/services/ports.ts
+++ b/packages/workflows/src/services/ports.ts
@@ -236,6 +236,10 @@ export interface WorkflowRunDelegate {
     where: WorkflowRunWhereInput;
     orderBy: WorkflowRunOrderByInput[];
     take: number;
+    // The list emits only the slim `WorkflowRunRow` scalars, so omit the large JSON columns
+    // (`triggerPayload`, `data`) to avoid reading/shipping up to 100 big blobs per page for nothing.
+    // The detail `findUnique` keeps them. Optional so the port stays a faithful subset of Prisma's args.
+    omit?: { triggerPayload?: true; data?: true };
   }) => Promise<WorkflowRunRow[]>;
   findUnique: (args: {
     where: { id: string };

--- a/packages/workflows/src/services/workflows.service.test.ts
+++ b/packages/workflows/src/services/workflows.service.test.ts
@@ -1,6 +1,15 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { WorkflowConflictError } from "../errors";
-import type { WorkflowDelegate, WorkflowRowWithLastRun, WorkflowVersionDelegate, WorkflowsDb } from "./ports";
+import type { TWorkflowTriggerRunPayload } from "../types/runs";
+import type {
+  WorkflowDelegate,
+  WorkflowRowWithLastRun,
+  WorkflowRunDelegate,
+  WorkflowRunRow,
+  WorkflowRunWithLogsRow,
+  WorkflowVersionDelegate,
+  WorkflowsDb,
+} from "./ports";
 import { createWorkflowsService } from "./workflows.service";
 
 const surveyId = "cm9zr4q7i000108l84gozfggr";
@@ -56,14 +65,50 @@ const deleteFn = vi.fn<WorkflowDelegate["delete"]>();
 const updateMany = vi.fn<WorkflowDelegate["updateMany"]>();
 const versionFindFirst = vi.fn<WorkflowVersionDelegate["findFirst"]>();
 const versionCreate = vi.fn<WorkflowVersionDelegate["create"]>();
+const runFindMany = vi.fn<WorkflowRunDelegate["findMany"]>();
+const runFindUnique = vi.fn<WorkflowRunDelegate["findUnique"]>();
 const workflow = { findMany, findUnique, create, update, delete: deleteFn, updateMany };
 const workflowVersion = { findFirst: versionFindFirst, create: versionCreate };
+const workflowRun = { findMany: runFindMany, findUnique: runFindUnique };
 const prisma: WorkflowsDb = {
   workflow,
   workflowVersion,
+  workflowRun,
   $transaction: (fn) => fn({ workflow, workflowVersion }),
 };
 const service = createWorkflowsService({ prisma });
+
+const runId = "cm9zr4w9d000308l8c5n8xk7e";
+
+const makeRunRow = (overrides: Partial<WorkflowRunRow> = {}): WorkflowRunRow => ({
+  id: runId,
+  createdAt: new Date("2026-06-12T10:00:00.000Z"),
+  updatedAt: new Date("2026-06-12T10:01:00.000Z"),
+  workflowId: "cm9zr4t2b000208l8h2m1aq3c",
+  workspaceId,
+  workflowVersionId: null,
+  responseId: null,
+  status: "completed",
+  triggerType: "response.completed",
+  surveyId,
+  isDryRun: false,
+  attempt: 0,
+  error: null,
+  startedAt: null,
+  finishedAt: null,
+  ...overrides,
+});
+
+const makeRunDetail = (overrides: Partial<WorkflowRunWithLogsRow> = {}): WorkflowRunWithLogsRow => ({
+  ...makeRunRow(),
+  triggerPayload: { triggeredAt: "2026-06-12T10:00:00.000Z" } as unknown as TWorkflowTriggerRunPayload,
+  data: { steps: [] },
+  idempotencyKey: null,
+  nextAttemptAt: null,
+  lastErrorAt: null,
+  logs: [],
+  ...overrides,
+});
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -363,5 +408,155 @@ describe("disableWorkflow", () => {
     const args = update.mock.calls[0][0];
     expect(args.where).toEqual({ id_workspaceId: { id: "cm9zr4t2b000208l8h2m1aq3c", workspaceId } });
     expect(args.data).toEqual({ status: "disabled" });
+  });
+});
+
+describe("listWorkflowRuns", () => {
+  test("scopes to the workspace, orders newest-first with an id tie-breaker, and over-fetches by one", async () => {
+    runFindMany.mockResolvedValue([makeRunRow()]);
+
+    await service.listWorkflowRuns({ workspaceId, limit: 20 });
+
+    const args = runFindMany.mock.calls[0][0];
+    expect(args.where).toEqual({ workspaceId });
+    expect(args.orderBy).toEqual([{ createdAt: "desc" }, { id: "desc" }]);
+    expect(args.take).toBe(21);
+  });
+
+  test("applies workflowId, responseId, statusIn, and isDryRun filters", async () => {
+    runFindMany.mockResolvedValue([]);
+
+    await service.listWorkflowRuns({
+      workspaceId,
+      limit: 20,
+      workflowId: "cm9zr4t2b000208l8h2m1aq3c",
+      responseId: "cm9zr5resp0000000000000000",
+      statusIn: ["failed", "completed"],
+      isDryRun: true,
+    });
+
+    expect(runFindMany.mock.calls[0][0].where).toEqual({
+      workspaceId,
+      workflowId: "cm9zr4t2b000208l8h2m1aq3c",
+      responseId: "cm9zr5resp0000000000000000",
+      status: { in: ["failed", "completed"] },
+      isDryRun: true,
+    });
+  });
+
+  test("isDryRun: false is forwarded (excludes dry runs), not dropped", async () => {
+    runFindMany.mockResolvedValue([]);
+    await service.listWorkflowRuns({ workspaceId, limit: 20, isDryRun: false });
+    expect(runFindMany.mock.calls[0][0].where.isDryRun).toBe(false);
+  });
+
+  test("combines responseId with isDryRun: false (both forwarded)", async () => {
+    runFindMany.mockResolvedValue([]);
+    await service.listWorkflowRuns({
+      workspaceId,
+      limit: 20,
+      responseId: "cm9zr5resp0000000000000000",
+      isDryRun: false,
+    });
+    expect(runFindMany.mock.calls[0][0].where).toEqual({
+      workspaceId,
+      responseId: "cm9zr5resp0000000000000000",
+      isDryRun: false,
+    });
+  });
+
+  test("returns no cursor when the page is not full", async () => {
+    runFindMany.mockResolvedValue([makeRunRow()]);
+    const page = await service.listWorkflowRuns({ workspaceId, limit: 20 });
+    expect(page.runs).toHaveLength(1);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  test("trims the over-fetched row and emits a next cursor from the last returned row", async () => {
+    const older = makeRunRow({
+      id: "cm9zr5b0000000000000000001",
+      createdAt: new Date("2026-06-12T09:00:00.000Z"),
+    });
+    const newest = makeRunRow({
+      id: "cm9zr5a0000000000000000002",
+      createdAt: new Date("2026-06-12T10:00:00.000Z"),
+    });
+    // limit 1 → service over-fetches 2; only the first is returned, cursor points at it.
+    runFindMany.mockResolvedValue([newest, older]);
+
+    const page = await service.listWorkflowRuns({ workspaceId, limit: 1 });
+
+    expect(page.runs).toHaveLength(1);
+    expect(page.runs[0].id).toBe(newest.id);
+    expect(page.nextCursor).not.toBeNull();
+    const decoded = JSON.parse(Buffer.from(page.nextCursor!, "base64url").toString("utf8")) as {
+      value: string;
+      id: string;
+    };
+    expect(decoded).toEqual({ version: 1, value: "2026-06-12T10:00:00.000Z", id: newest.id });
+  });
+
+  test("at the page-size boundary (limit+1 rows) trims the extra row and points the cursor at the last kept row", async () => {
+    const rows = [
+      makeRunRow({ id: "cm9zr5c0000000000000000003", createdAt: new Date("2026-06-12T10:00:00.000Z") }),
+      makeRunRow({ id: "cm9zr5c0000000000000000002", createdAt: new Date("2026-06-12T09:00:00.000Z") }),
+      makeRunRow({ id: "cm9zr5c0000000000000000001", createdAt: new Date("2026-06-12T08:00:00.000Z") }),
+    ];
+    // limit 2 → service over-fetches 3; exactly `limit` rows are returned and hasMore is true.
+    runFindMany.mockResolvedValue(rows);
+
+    const page = await service.listWorkflowRuns({ workspaceId, limit: 2 });
+
+    expect(page.runs).toHaveLength(2);
+    expect(page.runs.map((r) => r.id)).toEqual([rows[0].id, rows[1].id]);
+    expect(page.nextCursor).not.toBeNull();
+    const decoded = JSON.parse(Buffer.from(page.nextCursor!, "base64url").toString("utf8")) as {
+      value: string;
+      id: string;
+    };
+    expect(decoded).toEqual({ version: 1, value: "2026-06-12T09:00:00.000Z", id: rows[1].id });
+  });
+
+  test("decodes an incoming cursor into a keyset where-clause (older rows only)", async () => {
+    runFindMany.mockResolvedValue([]);
+    const cursor = Buffer.from(
+      JSON.stringify({ version: 1, value: "2026-06-12T10:00:00.000Z", id: "cm9zr5a0000000000000000002" }),
+      "utf8"
+    ).toString("base64url");
+
+    await service.listWorkflowRuns({ workspaceId, limit: 20, cursor });
+
+    expect(runFindMany.mock.calls[0][0].where).toEqual({
+      workspaceId,
+      OR: [
+        { createdAt: { lt: new Date("2026-06-12T10:00:00.000Z") } },
+        { createdAt: new Date("2026-06-12T10:00:00.000Z"), id: { lt: "cm9zr5a0000000000000000002" } },
+      ],
+    });
+  });
+
+  test("rejects a malformed cursor before hitting the database", async () => {
+    await expect(service.listWorkflowRuns({ workspaceId, limit: 20, cursor: "garbage" })).rejects.toThrow();
+    expect(runFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("getWorkflowRun", () => {
+  test("loads a run by id and eager-loads its logs ordered by sequence", async () => {
+    const detail = makeRunDetail({ logs: [] });
+    runFindUnique.mockResolvedValue(detail);
+
+    const result = await service.getWorkflowRun(runId);
+
+    expect(runFindUnique.mock.calls[0][0]).toEqual({
+      where: { id: runId },
+      include: { logs: { orderBy: { sequence: "asc" } } },
+    });
+    expect(result).toBe(detail);
+  });
+
+  test("returns null when the run does not exist", async () => {
+    runFindUnique.mockResolvedValue(null);
+    expect(await service.getWorkflowRun(runId)).toBeNull();
   });
 });

--- a/packages/workflows/src/services/workflows.service.test.ts
+++ b/packages/workflows/src/services/workflows.service.test.ts
@@ -489,7 +489,7 @@ describe("listWorkflowRuns", () => {
     expect(page.runs).toHaveLength(1);
     expect(page.runs[0].id).toBe(newest.id);
     expect(page.nextCursor).not.toBeNull();
-    const decoded = JSON.parse(Buffer.from(page.nextCursor!, "base64url").toString("utf8")) as {
+    const decoded = JSON.parse(Buffer.from(String(page.nextCursor), "base64url").toString("utf8")) as {
       value: string;
       id: string;
     };
@@ -510,7 +510,7 @@ describe("listWorkflowRuns", () => {
     expect(page.runs).toHaveLength(2);
     expect(page.runs.map((r) => r.id)).toEqual([rows[0].id, rows[1].id]);
     expect(page.nextCursor).not.toBeNull();
-    const decoded = JSON.parse(Buffer.from(page.nextCursor!, "base64url").toString("utf8")) as {
+    const decoded = JSON.parse(Buffer.from(String(page.nextCursor), "base64url").toString("utf8")) as {
       value: string;
       id: string;
     };

--- a/packages/workflows/src/services/workflows.service.test.ts
+++ b/packages/workflows/src/services/workflows.service.test.ts
@@ -488,8 +488,11 @@ describe("listWorkflowRuns", () => {
 
     expect(page.runs).toHaveLength(1);
     expect(page.runs[0].id).toBe(newest.id);
-    expect(page.nextCursor).not.toBeNull();
-    const decoded = JSON.parse(Buffer.from(String(page.nextCursor), "base64url").toString("utf8")) as {
+    const { nextCursor } = page;
+    if (nextCursor === null) {
+      throw new Error("expected nextCursor to be present");
+    }
+    const decoded = JSON.parse(Buffer.from(nextCursor, "base64url").toString("utf8")) as {
       value: string;
       id: string;
     };
@@ -509,8 +512,11 @@ describe("listWorkflowRuns", () => {
 
     expect(page.runs).toHaveLength(2);
     expect(page.runs.map((r) => r.id)).toEqual([rows[0].id, rows[1].id]);
-    expect(page.nextCursor).not.toBeNull();
-    const decoded = JSON.parse(Buffer.from(String(page.nextCursor), "base64url").toString("utf8")) as {
+    const { nextCursor } = page;
+    if (nextCursor === null) {
+      throw new Error("expected nextCursor to be present");
+    }
+    const decoded = JSON.parse(Buffer.from(nextCursor, "base64url").toString("utf8")) as {
       value: string;
       id: string;
     };

--- a/packages/workflows/src/services/workflows.service.ts
+++ b/packages/workflows/src/services/workflows.service.ts
@@ -338,6 +338,9 @@ export const createWorkflowsService = ({ prisma }: { prisma: WorkflowsDb }): Wor
       where: buildRunListWhere(input, cursor),
       orderBy: [{ createdAt: "desc" }, { id: "desc" }],
       take: input.limit + 1,
+      // List summaries never use these large JSON columns; skip them so PG doesn't read/ship
+      // up to 100 big blobs per page. The detail `findUnique` still loads them.
+      omit: { triggerPayload: true, data: true },
     });
 
     const hasMore = rows.length > input.limit;

--- a/packages/workflows/src/services/workflows.service.ts
+++ b/packages/workflows/src/services/workflows.service.ts
@@ -1,4 +1,9 @@
-import type { TCreateWorkflowInput, TListWorkflowsInput, TWorkflowSortBy } from "../contracts";
+import type {
+  TCreateWorkflowInput,
+  TListWorkflowRunsInput,
+  TListWorkflowsInput,
+  TWorkflowSortBy,
+} from "../contracts";
 import { WorkflowConflictError, isUniqueConstraintViolation } from "../errors";
 import {
   type TWorkflowListCursor,
@@ -6,6 +11,12 @@ import {
   decodeWorkflowListCursor,
   encodeWorkflowListCursor,
 } from "../handlers/cursor";
+import {
+  type TWorkflowRunListCursor,
+  buildNextWorkflowRunListCursor,
+  decodeWorkflowRunListCursor,
+  encodeWorkflowRunListCursor,
+} from "../handlers/runs-cursor";
 import type { TWorkflowStatus } from "../types/common";
 import type { TWorkflowDefinition, TWorkflowExecutableDefinition } from "../types/document";
 import type {
@@ -13,6 +24,9 @@ import type {
   WorkflowDelegate,
   WorkflowOrderByInput,
   WorkflowRowWithLastRun,
+  WorkflowRunRow,
+  WorkflowRunWhereInput,
+  WorkflowRunWithLogsRow,
   WorkflowWhereInput,
   WorkflowsDb,
 } from "./ports";
@@ -107,6 +121,32 @@ export interface WorkflowListPage {
   nextCursor: string | null;
 }
 
+/** Eager-load shape for a run's step logs, ordered by sequence; mirrors the injected delegate. */
+const RUN_LOG_INCLUDE = { logs: { orderBy: { sequence: "asc" } } } as const;
+
+/** Keyset page for newest-first run listing (`createdAt desc`, `id desc` tie-breaker). */
+const buildRunCursorWhere = (cursor: TWorkflowRunListCursor): WorkflowRunWhereInput => {
+  const value = new Date(cursor.value);
+  return { OR: [{ createdAt: { lt: value } }, { createdAt: value, id: { lt: cursor.id } }] };
+};
+
+const buildRunListWhere = (
+  input: TListWorkflowRunsInput,
+  cursor: TWorkflowRunListCursor | null
+): WorkflowRunWhereInput => ({
+  workspaceId: input.workspaceId,
+  ...(input.workflowId ? { workflowId: input.workflowId } : {}),
+  ...(input.responseId ? { responseId: input.responseId } : {}),
+  ...(input.statusIn ? { status: { in: input.statusIn } } : {}),
+  ...(input.isDryRun !== undefined ? { isDryRun: input.isDryRun } : {}),
+  ...(cursor ? buildRunCursorWhere(cursor) : {}),
+});
+
+export interface WorkflowRunListPage {
+  runs: WorkflowRunRow[];
+  nextCursor: string | null;
+}
+
 export interface WorkflowsService {
   listWorkflows: (input: TListWorkflowsInput) => Promise<WorkflowListPage>;
   createWorkflow: (
@@ -129,6 +169,8 @@ export interface WorkflowsService {
     options: { definition: TWorkflowExecutableDefinition; publishedBy: string | null }
   ) => Promise<WorkflowRowWithLastRun>;
   disableWorkflow: (params: WorkflowScopedParams) => Promise<WorkflowRowWithLastRun>;
+  listWorkflowRuns: (input: TListWorkflowRunsInput) => Promise<WorkflowRunListPage>;
+  getWorkflowRun: (runId: string) => Promise<WorkflowRunWithLogsRow | null>;
 }
 
 /**
@@ -287,5 +329,31 @@ export const createWorkflowsService = ({ prisma }: { prisma: WorkflowsDb }): Wor
 
   async disableWorkflow({ workflowId, workspaceId }) {
     return updateWorkflowRow(prisma.workflow, { workflowId, workspaceId }, { status: "disabled" });
+  },
+
+  async listWorkflowRuns(input) {
+    const cursor = input.cursor ? decodeWorkflowRunListCursor(input.cursor) : null;
+
+    const rows = await prisma.workflowRun.findMany({
+      where: buildRunListWhere(input, cursor),
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: input.limit + 1,
+    });
+
+    const hasMore = rows.length > input.limit;
+    const runs = hasMore ? rows.slice(0, input.limit) : rows;
+    const lastRow = runs.at(-1);
+
+    return {
+      runs,
+      nextCursor:
+        hasMore && lastRow ? encodeWorkflowRunListCursor(buildNextWorkflowRunListCursor(lastRow)) : null,
+    };
+  },
+
+  async getWorkflowRun(runId) {
+    // Workspace scoping is enforced by the handler: it authorizes against the loaded run's
+    // workspaceId (a cross-workspace runId surfaces as 403), mirroring getWorkflowById.
+    return prisma.workflowRun.findUnique({ where: { id: runId }, include: RUN_LOG_INCLUDE });
   },
 });


### PR DESCRIPTION
## Summary

Adds the production read API for **workflow runs** in `@formbricks/workflows` + the v3 Next routes, ahead of the runs-list UI (ENG-1230). Two endpoints:

- `GET /api/v3/workflows/runs` — cursor-paginated list of run **summaries** for a workspace, newest-first.
- `GET /api/v3/workflows/runs/{runId}` — full run **resource** (trigger payload, run data, idempotency/retry fields) with its step logs ordered by sequence.

## Endpoints

**List** — `GET /api/v3/workflows/runs`
- Required: `workspaceId`. Optional: `workflowId`, `responseId`, `filter[status][in]=…`, `filter[isDryRun][eq]=true|false`, `limit` (1–250), `cursor`.
- Returns `{ data: WorkflowRunSummary[], meta: { limit, nextCursor } }`, ordered `createdAt desc, id desc`.

**Detail** — `GET /api/v3/workflows/runs/{runId}`
- Returns the full `WorkflowRunResource` including `triggerPayload`, `data`, `logs[]` (ordered by `sequence`), `idempotencyKey`, `nextAttemptAt`, `lastErrorAt`.

## Architecture

Mirrors the existing v3 workflows endpoints:

- **Route** (`apps/web/app/api/v3/workflows/runs/**`) — thin Next adapter via `withV3ApiWrapper`, builds the API context, delegates.
- **Handlers** (`@formbricks/workflows`) — `listRuns` / `getRun`: parse query, authorize, call the service, validate output against the Zod contracts, shape the response.
- **Service** — `listWorkflowRuns` / `getWorkflowRun`, talking to the injected `prisma` through the narrow `WorkflowsDb` port. The package keeps no dependency on `@formbricks/database`.
- **Cursor** — opaque base64url keyset cursor over `(createdAt, id)`; over-fetch by one to compute `nextCursor`. Malformed cursors are rejected as `400`.

## Authorization & safety

- The detail endpoint loads a run by id, then authorizes against **that run's workspace**, returning **403 (never 404)** for unknown or cross-workspace runs so existence is not leaked — matching the by-id workflow handlers.
- The list endpoint is scoped to the authorized `workspaceId`; a workspace the caller can't access is denied with 403.
- `triggerType` is kept as `string` in the port (the column is a free-form `String`, not an enum) and narrowed at the response boundary by `validateOutput`; documented inline so it isn't "tightened" in a way that breaks the structural Prisma wiring.

## Testing

- **Unit** — cursor encode/decode (incl. tamper/forgery → 400), serializers (summary/resource/log, null + non-null timestamp round-trips), service (filters, keyset where-clause, page-size boundary, malformed cursor), handlers (filters incl. `isDryRun=false`, empty page, limit bounds, cross-workspace 403, malformed cursor → 400), and the web api-client.
- **End-to-end (HTTP)** — verified the auth gate, every filter and combination, cursor pagination across pages (no overlap), the detail payload + ordered logs, cross-workspace and unknown-run **403**, and malformed-cursor / out-of-range-limit **400**s against a seeded local workspace.

## Out of scope

- **Run creation** is intentionally not here. Real runs are written by the workflow engine when the trigger fires; the manual/dry-run path is `POST /api/v3/workflows/{workflowId}/test` (ENG-1229), which lives under the workflow resource, not the `/runs` collection.
- Runs-list UI (next, ENG-1230).