### PR TITLE
fix: remediate container image vulnerabilities

### DIFF
--- a/.github/actions/build-and-push-docker/action.yml
+++ b/.github/actions/build-and-push-docker/action.yml
@@ -277,6 +277,7 @@ runs:
         context: ${{ inputs.context }}
         file: ${{ inputs.dockerfile }}
         platforms: linux/amd64,linux/arm64
+        pull: true
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ inputs.registry_type == 'ecr' && steps.ecr-tags.outputs.tags || (inputs.registry_type == 'ghcr' && inputs.experimental_mode == 'true' && steps.ghcr-meta-experimental.outputs.tags) || (inputs.registry_type == 'ghcr' && inputs.experimental_mode == 'false' && steps.ghcr-extra-tags.outputs.tags) || (inputs.registry_type == 'ghcr' && format('ghcr.io/{0}:{1}', inputs.ghcr_image_name, steps.version.outputs.version)) || (inputs.registry_type == 'ecr' && format('{0}/{1}:{2}', inputs.ecr_registry, inputs.ecr_repository, steps.version.outputs.version)) }}
         labels: ${{ inputs.registry_type == 'ghcr' && inputs.experimental_mode == 'true' && steps.ghcr-meta-experimental.outputs.labels || '' }}

--- a/.github/workflows/docker-security-scan.yml
+++ b/.github/workflows/docker-security-scan.yml
@@ -53,16 +53,17 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4 # v0.32.0
+        uses: aquasecurity/trivy-action@a9c7b0f06e461e9d4b4d1711f154ee024b8d7ab8 # v0.36.0
         with:
           image-ref: "ghcr.io/${{ github.repository }}:latest"
           format: "sarif"
           output: "trivy-results.sarif"
           severity: "CRITICAL,HIGH,MEDIUM,LOW"
+          version: "v0.71.2"
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@a4e1a019f5e24960714ff6296aee04b736cbc3cf # v3.29.6
-        if: ${{ always() }}
+        if: ${{ always() && hashFiles('trivy-results.sarif') != '' }}
         with:
           sarif_file: "trivy-results.sarif"
           ref: ${{ steps.gitref.outputs.ref }}

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -79,10 +79,10 @@ RUN --mount=type=secret,id=database_url \
 #
 FROM base AS runner
 
-# Upgrade Alpine system packages to pick up security patches, update npm to latest, then create user
-# Note: npm's bundled tar has a known vulnerability but npm is only used during build, not at runtime
+# Upgrade Alpine system packages to pick up security patches, update npm to the patched 11.x line, then create user
+# Note: npm is updated in the runtime image so any bundled transitive packages scanned from the base image are patched
 RUN apk update && apk upgrade --no-cache \
-    && npm install --ignore-scripts -g npm@11.15.0 \
+    && npm install --ignore-scripts -g npm@11.17.0 \
     && addgroup -S nextjs \
     && adduser -S -u 1001 -G nextjs nextjs
 


### PR DESCRIPTION
## What changed

- Force Depot Docker builds to pull referenced base images so production images pick up patched `node:24-alpine3.23` layers.
- Bump the final runtime image's global npm install from `11.15.0` to `11.17.0`, which brings the patched `tar@7.5.16` npm dependency line into the scanned runtime image.
- Update the Docker Security Scan workflow from `aquasecurity/trivy-action` `v0.32.0` to `v0.36.0`, explicitly pin Trivy `v0.71.2`, and skip SARIF upload when the scanner failed before producing the file.

## Why

AWS Inspector is reporting active ECR findings on the child manifests behind `formbricks/formbricks-com:prod` and `prod-migrate`. Current `main` already contains most app dependency remediations, but the image build path still allowed stale base layers and a vulnerable npm bundled dependency chain to persist. The scheduled Docker security scan was also failing during Trivy setup before producing SARIF.

## Validation

- `npx --no-install prettier --check .github/actions/build-and-push-docker/action.yml .github/workflows/docker-security-scan.yml`
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "#{file}: ok" }' .github/actions/build-and-push-docker/action.yml .github/workflows/docker-security-scan.yml`
- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest .github/workflows/docker-security-scan.yml`
- `docker run --rm node:24-alpine3.23 sh -lc 'npm install --ignore-scripts -g npm@11.17.0 >/tmp/npm-install.log && npm --version && node -p "process.version + \" openssl=\" + process.versions.openssl" && npm ls -g --depth=3 tar undici ip-address brace-expansion || true'`
- `node node_modules/lint-staged/bin/lint-staged.js` returned no matching staged files.

## Follow-up after merge

- Rebuild and push `prod` and `prod-migrate` images from `main`.
- Verify AWS Inspector findings by child image digest, not just the OCI image index tag.
- Delete stale untagged vulnerable child manifests only after confirming they are no longer referenced by active image indexes.
