### PR TITLE
docs: add LLM copy options

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -5,6 +5,9 @@
     "light": "#00C4B8",
     "primary": "#00C4B8"
   },
+  "contextual": {
+    "options": ["copy", "view", "chatgpt", "claude", "perplexity"]
+  },
   "errors": {
     "404": {
       "redirect": true


### PR DESCRIPTION
## What does this PR do?

Adds a contextual menu to the Formbricks docs so users can copy page content or open it directly in popular AI tools.

Enabled options: **Copy page**, **View as Markdown**, **Open in ChatGPT**, **Open in Claude**, **Open in Perplexity**.

## How should this be tested?

- Open any page on the Formbricks docs site
- Click the contextual menu button in the page header
- Verify all five options appear: Copy page, View as Markdown, Open in ChatGPT, Open in Claude, Open in Perplexity
- Click **Copy page** — page content should be copied as Markdown
- Click **View as Markdown** — page should open as raw Markdown
- Click **Open in ChatGPT / Claude / Perplexity** — should open the respective tool with the current page as context
