### PR TITLE
fix: api/v3 - canonicalize survey language codes + legacy inbound back-compat (ENG-1067)

### DIFF
--- a/apps/web/app/api/v3/surveys/language.test.ts
+++ b/apps/web/app/api/v3/surveys/language.test.ts
@@ -57,8 +57,9 @@ describe("normalizeV3SurveyLanguageIdentifier", () => {
     expect(normalizeV3SurveyLanguageIdentifier(input)).toBe(expected);
   });
 
-  test("does not guess ambiguous legacy identifiers", () => {
-    expect(normalizeV3SurveyLanguageIdentifier("pt")).toBeNull();
+  test("resolves bare codes to their CLDR default region (ENG-1067 canonical)", () => {
+    expect(normalizeV3SurveyLanguageIdentifier("pt")).toBe("pt-BR");
+    expect(normalizeV3SurveyLanguageIdentifier("ar")).toBe("ar-EG");
   });
 });
 
@@ -73,6 +74,12 @@ describe("normalizeV3SurveyWriteLanguageCode", () => {
     expect(normalizeV3SurveyWriteLanguageCode("GU", ["gu", "en-US"])).toBe("gu");
     expect(normalizeV3SurveyWriteLanguageCode("hi", ["hi-IN", "en-US"])).toBe("hi-IN");
     expect(normalizeV3SurveyWriteLanguageCode("vi", ["en-US"])).toBeNull();
+  });
+
+  test("maps a legacy code to its canonical configured tag (post-migration inbound)", () => {
+    // After the migration flips a stored `gu` to `gu-IN`, a client still sending `gu` keeps working.
+    expect(normalizeV3SurveyWriteLanguageCode("gu", ["gu-IN", "en-US"])).toBe("gu-IN");
+    expect(normalizeV3SurveyWriteLanguageCode("GU", ["gu-IN", "en-US"])).toBe("gu-IN");
   });
 });
 

--- a/apps/web/app/api/v3/surveys/language.ts
+++ b/apps/web/app/api/v3/surveys/language.ts
@@ -1,3 +1,4 @@
+import { LANGUAGE_CANONICAL_MAP, normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import type { TSurvey as TInternalSurvey } from "@formbricks/types/surveys/types";
 
 export type TV3SurveyResolverLanguage = {
@@ -23,30 +24,43 @@ type TParseV3SurveyLanguageQueryResult = { ok: true; languages: string[] } | { o
 
 const V3_SURVEY_LANGUAGE_TAG_REGEX = /^[a-z]{2}(?:-[A-Z]{2}|-[A-Z][a-z]{3}(?:-[A-Z]{2})?)$/;
 const V3_SURVEY_LOCALE_CODE_REGEX = /^[a-z]{2}(?:-[A-Z][a-z]{3})?-[A-Z]{2}$/;
-const V3_LEGACY_LANGUAGE_CODE_MAP: Record<string, string> = {
-  ar: "ar-SA",
-  cs: "cs-CZ",
-  da: "da-DK",
-  de: "de-DE",
-  en: "en-US",
-  es: "es-ES",
-  fi: "fi-FI",
-  fr: "fr-FR",
-  he: "he-IL",
-  hi: "hi-IN",
-  hu: "hu-HU",
-  it: "it-IT",
-  ja: "ja-JP",
-  ko: "ko-KR",
-  nb: "nb-NO",
-  nl: "nl-NL",
-  no: "nb-NO",
-  pl: "pl-PL",
-  ro: "ro-RO",
-  ru: "ru-RU",
-  sv: "sv-SE",
-  tr: "tr-TR",
-};
+
+// Bare legacy codes v3 canonicalizes on read, with values sourced from the shared canonical map so v3
+// can't drift from the picker/DB/migration (this fixes the old `ar -> ar-SA` and adds `pt -> pt-BR`).
+// Codes OUTSIDE this set are deliberately preserved as-stored: an unrelated patch must not silently
+// migrate a survey's language (which would orphan its content keys). The ENG-1067 data migration
+// canonicalizes those remaining codes in one controlled pass.
+const V3_CANONICALIZABLE_BARE_CODES = [
+  "ar",
+  "cs",
+  "da",
+  "de",
+  "en",
+  "es",
+  "fi",
+  "fr",
+  "he",
+  "hi",
+  "hu",
+  "it",
+  "ja",
+  "ko",
+  "nb",
+  "nl",
+  "no",
+  "pl",
+  "pt",
+  "ro",
+  "ru",
+  "sv",
+  "tr",
+] as const;
+const V3_LEGACY_LANGUAGE_CODE_MAP: Record<string, string> = Object.fromEntries(
+  V3_CANONICALIZABLE_BARE_CODES.flatMap((code) => {
+    const canonicalCode = LANGUAGE_CANONICAL_MAP[code];
+    return canonicalCode ? [[code, canonicalCode]] : [];
+  })
+);
 
 export function normalizeV3SurveyLanguageTag(value: string): string | null {
   return normalizeV3SurveyLanguageCode(value, V3_SURVEY_LANGUAGE_TAG_REGEX);
@@ -72,6 +86,8 @@ function normalizeV3SurveyLanguageCode(value: string, pattern: RegExp): string |
 }
 
 export function normalizeV3SurveyLanguageIdentifier(value: string): string | null {
+  // Already region/script-qualified tag wins as-is; otherwise canonicalize a bare code via the curated
+  // map (values from the shared source). Un-mapped codes return null so callers preserve them as-stored.
   return (
     normalizeV3SurveyLanguageTag(value) ?? V3_LEGACY_LANGUAGE_CODE_MAP[value.trim().toLowerCase()] ?? null
   );
@@ -92,18 +108,28 @@ export function normalizeV3SurveyWriteLanguageCode(
 
   const requestedKey = value.trim().toLowerCase();
   const requestedIdentifier = normalizeV3SurveyLanguageIdentifier(value)?.toLowerCase() ?? null;
+  // Full CLDR canonical form of the request, covering codes outside the curated map (e.g. `gu`). This
+  // is the inbound back-compat path: once the data migration flips a stored code to its canonical tag
+  // (`gu` -> `gu-IN`), a client still sending the legacy `gu` keeps matching the now-canonical survey
+  // language instead of being rejected.
+  const requestedCanonical = normalizeLanguageCode(value)?.toLowerCase() ?? null;
 
   for (const allowedLanguageCode of allowedLanguageCodes) {
     const allowedKey = allowedLanguageCode.toLowerCase();
     const normalizedAllowedLanguageCode = normalizeV3SurveyLanguageIdentifier(allowedLanguageCode);
     const allowedIdentifier = normalizedAllowedLanguageCode?.toLowerCase() ?? null;
+    const allowedCanonical = normalizeLanguageCode(allowedLanguageCode)?.toLowerCase() ?? null;
 
     if (
       requestedKey === allowedKey ||
       (requestedIdentifier && requestedIdentifier === allowedKey) ||
-      (allowedIdentifier && (requestedKey === allowedIdentifier || requestedIdentifier === allowedIdentifier))
+      (allowedIdentifier &&
+        (requestedKey === allowedIdentifier || requestedIdentifier === allowedIdentifier)) ||
+      (requestedCanonical && requestedCanonical === allowedCanonical)
     ) {
-      // PATCH-only compatibility: preserve legacy stored codes that are not safely canonicalizable.
+      // PATCH-only compatibility: write to the survey's existing stored code as-is, falling back to its
+      // canonical form. Pre-migration this preserves a legacy code; post-migration it resolves to the
+      // canonical one the survey now stores.
       return normalizedAllowedLanguageCode ?? allowedLanguageCode;
     }
   }


### PR DESCRIPTION
## What does this PR do?

Relates to **ENG-1067** (language-tag standardization) — part of the phased series, building on the foundation `canonical.ts` already merged into this epic.

Brings the **v3 Surveys API** language handling in line with the single canonical BCP-47 source, so v3 can no longer disagree with the picker, the DB, and the upcoming data migration. Two changes, both in `app/api/v3/surveys/language.ts`:

1. **Canonicalization sourced from the shared map.** The hardcoded `V3_LEGACY_LANGUAGE_CODE_MAP` — which carried v3's own, drifting opinions (`ar → ar-SA`, `no → nb-NO`, and no `pt`/`zh`) — is now **derived from `LANGUAGE_CANONICAL_MAP`** for a curated set of bare codes. Net effect: `ar → ar-EG`, `pt → pt-BR` (added), `no → no-NO`, and the values can never drift from the shared source again.

2. **Inbound back-compat on write.** `normalizeV3SurveyWriteLanguageCode` now also matches a request against the full CLDR-canonical form of the survey's configured codes. So once the data migration flips a stored code to its canonical tag (`gu → gu-IN`), a client still sending the legacy `gu` keeps resolving to the configured `gu-IN` instead of being rejected.

**Deliberately conservative:** codes outside the curated set (e.g. `vi`, `gu`, script-only `zh-Hans`) are **preserved as-stored** on read, so an unrelated patch never silently migrates a survey's language (which would orphan its content keys). The ENG-1067 data migration canonicalizes those remaining codes in one controlled pass.

No change to: the tag/locale normalizers, the read resolver and its ambiguity detection, alias/base-language matching, or PATCH replacement semantics.

## How should this be tested?

```bash
cd apps/web && pnpm vitest run app/api/v3/surveys
```

- `normalizeV3SurveyLanguageIdentifier`: `de → de-DE`, `pt → pt-BR`, `ar → ar-EG`; un-mapped legacy codes (`vi`/`gu`) return null so callers preserve them as-stored.
- `normalizeV3SurveyWriteLanguageCode`: legacy `gu` resolves to a configured `gu-IN` (post-migration inbound), while strict locale validation otherwise still rejects unknown bare codes.
- `resolveV3SurveyLanguageCode`: ambiguity (`en` with `en-US`+`en-GB`), alias, base-language, and disabled-language reads are unchanged.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` — _scoped `pnpm vitest run app/api/v3/surveys` (274 pass), ESLint, and `tsc --noEmit` pass locally; full build deferred to CI._
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch — _N/A: stacked on `epic/language-codes-stabilization` by design._
- [x] My changes don't cause any responsiveness issues — _API-only change, no UI._
- [ ] First PR at Formbricks? CLA — _N/A._

### Appreciated

- [ ] If a UI change was made: screenshots — _N/A, no UI change._
- [ ] Updated the Formbricks Docs if changes were necessary — _N/A; the supported-languages docs land with the catalog/docs PR._
