### PR TITLE
fix(a11y): submit button steals keyboard tab order on every survey

### DIFF
--- a/packages/surveys/src/components/buttons/back-button.tsx
+++ b/packages/surveys/src/components/buttons/back-button.tsx
@@ -7,7 +7,7 @@ interface BackButtonProps {
   tabIndex?: number;
 }
 
-export function BackButton({ onClick, backButtonLabel, tabIndex = 2 }: Readonly<BackButtonProps>) {
+export function BackButton({ onClick, backButtonLabel, tabIndex = 0 }: Readonly<BackButtonProps>) {
   const { t } = useTranslation();
   return (
     <Button dir="auto" tabIndex={tabIndex} type="button" variant="ghost" onClick={onClick}>

--- a/packages/surveys/src/components/buttons/submit-button.tsx
+++ b/packages/surveys/src/components/buttons/submit-button.tsx
@@ -13,7 +13,7 @@ interface SubmitButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 export function SubmitButton({
   buttonLabel,
   isLastQuestion,
-  tabIndex = 1,
+  tabIndex = 0,
   focus = false,
   onClick,
   disabled,


### PR DESCRIPTION

<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes the keyboard tab order on every survey. `SubmitButton` shipped with a hardcoded `tabIndex={1}` and `BackButton` with `tabIndex={2}`. Because any positive `tabindex` is pulled to the front of the document's tab sequence, pressing Tab on a survey jumped straight to the Submit button before the actual question inputs, breaking natural keyboard navigation.

- Default `SubmitButton` `tabIndex` from `1` to `0`
- Default `BackButton` `tabIndex` from `2` to `0`
- Both buttons now participate in the natural DOM focus order instead of overriding it
- Minor repo housekeeping bundled in: `AGENTS.md` notes and `.gitignore` entries (fbr robots setup)

Fixes 1291

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- Open any survey with at least one input question (e.g. a link survey preview).
- From the top of the page, press Tab repeatedly and confirm focus moves through the question inputs in DOM order first, then reaches the Back/Submit buttons last — it should no longer jump to Submit first.
- On a later question (Back + Submit both present), confirm focus lands on Back before Submit at the end of the sequence.
- Press Shift+Tab and verify focus reverses through the same natural order.
- Check the first question (no Back button) to confirm Submit is reachable in order and not pulled to the front.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
