### PR TITLE
fix(surveys): allow pinch-zoom on mobile link surveys (WCAG 1.4.4) [ENG-1294]

### DIFF
--- a/apps/web/modules/survey/link/layout.tsx
+++ b/apps/web/modules/survey/link/layout.tsx
@@ -3,8 +3,6 @@ import { Viewport } from "next";
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1.0,
-  maximumScale: 1.0,
-  userScalable: false,
   viewportFit: "contain",
 };
 


### PR DESCRIPTION
## What does this PR do?

The link-survey viewport config set `maximumScale: 1.0` and `userScalable: false` (`apps/web/modules/survey/link/layout.tsx`), which completely disables pinch-zoom. Low-vision respondents on phones cannot enlarge survey text at all.

- Affects **every link survey** opened on a mobile device.
- iOS Safari ignores `user-scalable=no`, but **Android Chrome and in-app webviews honor it**, so the restriction is real for a large share of respondents.
- axe-core `meta-viewport` rule violation; **WCAG 1.4.4 (Resize Text)** AA failure.

This PR removes `maximumScale` and `userScalable` from the viewport export, keeping `width: "device-width"`, `initialScale: 1.0`, and `viewportFit: "contain"`. Pinch-zoom is restored without changing the default layout.

The rendered meta tag changes from:

```
width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=contain
```

to:

```
width=device-width, initial-scale=1, viewport-fit=contain
```

Fixes [ENG-1294](https://linear.app/formbricks/issue/ENG-1294/link-surveys-block-pinch-zoom-on-mobile-userscalable-false-wcag-144)

## How should this be tested?

Verified end-to-end against a running stack on a Pixel 5 (Android Chrome) emulated viewport, loading a link survey at `/s/<surveyId>`:

- **Rendered viewport meta tag** no longer contains `user-scalable=no` or `maximum-scale` — it is now `width=device-width, initial-scale=1, viewport-fit=contain`.
- **axe-core 4.11 `meta-viewport` rule** (the same audit that filed the issue) reports **0 violations** on the link-survey page.
- **Layout sanity check**: captured the survey card at default scale and at a simulated 2× pinch-zoom — text enlarges correctly and the card layout does not break or overflow.

To reproduce manually:

1. Open any link survey (`/s/<surveyId>`) on an Android phone or Android Chrome device emulation.
2. Pinch to zoom — the page now magnifies instead of being locked at 1×.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
