### PR TITLE
fix(surveys): identify ending cards by id instead of label in selectors [ENG-990]

### DIFF
--- a/apps/web/modules/ui/components/input-combo-box/index.tsx
+++ b/apps/web/modules/ui/components/input-combo-box/index.tsx
@@ -278,7 +278,12 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
               {options && options.length > 0 && (
                 <CommandGroup className="p-0">
                   {options.map((opt) => (
-                    <CommandItem key={opt.value} onSelect={() => handleSelect(opt)} className="truncate px-2">
+                    <CommandItem
+                      key={opt.value}
+                      value={String(opt.value)}
+                      keywords={[opt.label]}
+                      onSelect={() => handleSelect(opt)}
+                      className="truncate px-2">
                       {showCheckIcon && isSelected(opt) && (
                         <CheckIcon className="size-4 text-slate-300 hover:text-slate-400" />
                       )}
@@ -299,7 +304,11 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
                     <div className="px-2 pb-2 text-xs font-medium text-slate-500">{group.label}</div>
                     {group.options.map((opt) =>
                       opt.children ? (
-                        <CommandItem key={opt.value} className="flex w-full items-center justify-center p-0">
+                        <CommandItem
+                          key={opt.value}
+                          value={String(opt.value)}
+                          keywords={[opt.label]}
+                          className="flex w-full items-center justify-center p-0">
                           <DropdownMenuSub key={opt.value}>
                             <DropdownMenuSubTrigger
                               className="w-full"
@@ -354,6 +363,8 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
                       ) : (
                         <CommandItem
                           key={opt.value}
+                          value={String(opt.value)}
+                          keywords={[opt.label]}
                           onSelect={() => handleSelect(opt)}
                           className="truncate px-2">
                           {showCheckIcon && isSelected(opt) && (


### PR DESCRIPTION
## What does this PR do?

Fixes [ENG-990](https://linear.app/formbricks/issue/ENG-990/thank-you-cards-with-duplicate-titles-use-label-instead-of-id) — "Thank you cards with duplicate titles use label instead of ID".

Selectors built on `InputCombobox` (most visibly the survey editor's conditional-logic **"Jump to ..."** action, whose targets include the survey's ending / thank you cards) render their options with cmdk's `CommandItem`. The items did not set a `value` prop, so cmdk fell back to deriving each item's identity from its rendered **text** (the label/headline). When two ending cards share the same title, they collapsed to a single cmdk item, so duplicate-titled thank you cards became ambiguous — they were effectively identified by label rather than by their unique id.

The fix passes the option's unique id as the `CommandItem` `value`, and the label via `keywords` so type-ahead search by label keeps working. This is applied to all three `CommandItem` render paths in the component (flat options, grouped leaf options, and grouped parent options), so every consumer of `InputCombobox` benefits.

There is no visual change: the dropdown looks identical. The fix is purely in how each item is identified internally (id instead of label).

## How should this be tested?

Reproduce in the survey editor:

- Create a survey with at least one block/question.
- Add a second ending card so the survey has **two ending cards with the same title** (e.g. both "Thank you!").
- On a block, open **Show Block settings → Add logic** and add a **"Jump to ..."** action.
- Open the action's target dropdown: both "Thank you!" endings appear and are now independently selectable; selecting the second one targets the second ending (not the first).

Automated check performed locally (throwaway Playwright run, not committed):

- Built the duplicate-title scenario above against a running instance and opened the "Jump to" dropdown.
- Asserted that the two `[cmdk-item]` nodes sharing the title "Thank you!" expose **distinct** `data-value` attributes, each equal to its ending's id (before the fix they shared one label-derived value). Passed deterministically across multiple runs, including the real-world case where the two endings differ at the storage level (plain vs. rich-text headline) but render the same visible label.

Also verified: `pnpm --filter @formbricks/web typecheck`, ESLint, and Prettier all pass on the changed file.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` (ran `typecheck` + `lint` + a throwaway Playwright e2e instead)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR (no visual change; only internal item identity)
- [ ] Updated the Formbricks Docs if changes were necessary (not necessary)
