### PR TITLE
fix(auth): land invited users in the app after email verification [ENG-1527]

### DIFF
--- a/apps/web/modules/auth/signup/actions.ts
+++ b/apps/web/modules/auth/signup/actions.ts
@@ -10,7 +10,6 @@ import {
   IS_FORMBRICKS_CLOUD,
   IS_TURNSTILE_CONFIGURED,
   TURNSTILE_SECRET_KEY,
-  WEBAPP_URL,
 } from "@/lib/constants";
 import { verifyInviteToken } from "@/lib/jwt";
 import { createMembership } from "@/lib/membership/service";
@@ -228,19 +227,14 @@ async function handlePostUserCreation(
   }
 
   if (!EMAIL_VERIFICATION_DISABLED) {
-    let inviteCallbackUrl: string | undefined;
-
-    if (inviteToken) {
-      const inviteUrl = new URL("/invite", WEBAPP_URL);
-      inviteUrl.searchParams.set("token", inviteToken);
-      inviteCallbackUrl = inviteUrl.toString();
-    }
-
+    // Do NOT point the post-verification callback back at /invite for invite signups: the invite is
+    // already accepted and deleted in handleInviteAcceptance above, so /invite would render
+    // "Invite Not Found" (ENG-1527). Leaving callbackUrl undefined lands the freshly verified —
+    // and already provisioned — user on the app home instead.
     await sendVerificationEmail({
       id: user.id,
       email: user.email,
       locale: user.locale,
-      callbackUrl: inviteCallbackUrl,
     });
   }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the invite + email-verification flow where a newly invited user who signs up **lands on the "Invite Not Found" page after verifying their email**, even though they were already added to the team.

**Root cause:** during signup with an invite token, `handleInviteAcceptance` creates the membership and **deletes the invite**. The post-verification `callbackUrl` was still being set to `/invite?token=...`, so after the user verified their email they were redirected back to the invite page — whose invite no longer exists — and got "Invite Not Found."

**Fix:** drop the invite-specific `callbackUrl` in `handlePostUserCreation`. With it omitted, verification defaults to the app home, so the freshly verified (and already provisioned) user lands in the app instead of a dead invite page.

The login flow (an existing user accepting an invite, where the invite still exists when they return) is unaffected — only the signup-with-verification redirect changed.

## Steps to reproduce

1. Create an account.
2. Go to team settings and invite another email address to your organization.
3. From the other account, open the invite email and accept it.
4. Ensure email verification is enabled.
5. Click the email-verification link to confirm the address.
6. **Before:** the user is added to the team but lands on the "Invite Not Found" screen.
   **After:** the user is added to the team and lands in the app.

## How should this be tested?

- Run through the reproduction steps above with email verification enabled and confirm the verified user lands in the app (not "Invite Not Found").
- Regression check the existing-user invite flow: an already-registered user accepting an invite via the login path should still be taken back to `/invite` and onboarded correctly.
- `tsc --noEmit` clean; existing invite lib tests pass.

## Linear

ENG-1527 — https://linear.app/formbricks/issue/ENG-1527/after-verifying-the-verification-email-user-lands-on-invite-not-found
