### PR TITLE
fix: harden response queue IndexedDB handling

### DIFF
--- a/packages/surveys/src/components/general/survey.test.tsx
+++ b/packages/surveys/src/components/general/survey.test.tsx
@@ -32,8 +32,11 @@ vi.mock("@/lib/api-client", () => ({
 vi.mock("@/lib/offline-storage", () => ({
   addPendingResponse: offlineStorageMocks.addPendingResponse,
   countPendingResponses: offlineStorageMocks.countPendingResponses,
+  countPendingResponsesStrict: offlineStorageMocks.countPendingResponses,
   getPendingResponses: offlineStorageMocks.getPendingResponses,
+  getPendingResponsesStrict: offlineStorageMocks.getPendingResponses,
   removePendingResponse: offlineStorageMocks.removePendingResponse,
+  removePendingResponseStrict: offlineStorageMocks.removePendingResponse,
   clearSurveyProgress: offlineStorageMocks.clearSurveyProgress,
   getSurveyProgress: offlineStorageMocks.getSurveyProgress,
   patchSurveyProgressSnapshot: offlineStorageMocks.patchSurveyProgressSnapshot,

--- a/packages/surveys/src/lib/offline-storage.ts
+++ b/packages/surveys/src/lib/offline-storage.ts
@@ -130,54 +130,66 @@ export const addPendingResponse = async (entry: Omit<PendingResponseEntry, "id">
   }
 };
 
+export const getPendingResponsesStrict = async (surveyId: string): Promise<PendingResponseEntry[]> => {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_PENDING_RESPONSES, "readonly");
+    const store = tx.objectStore(STORE_PENDING_RESPONSES);
+    const index = store.index("surveyId");
+    const request = index.getAll(surveyId);
+
+    request.onsuccess = () => {
+      const results = (request.result as PendingResponseEntry[]).sort((a, b) => a.createdAt - b.createdAt);
+      resolve(results);
+    };
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
+  });
+};
+
 export const getPendingResponses = async (surveyId: string): Promise<PendingResponseEntry[]> => {
   try {
-    const db = await openDb();
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_PENDING_RESPONSES, "readonly");
-      const store = tx.objectStore(STORE_PENDING_RESPONSES);
-      const index = store.index("surveyId");
-      const request = index.getAll(surveyId);
-
-      request.onsuccess = () => {
-        const results = (request.result as PendingResponseEntry[]).sort((a, b) => a.createdAt - b.createdAt);
-        resolve(results);
-      };
-      request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
-    });
+    return await getPendingResponsesStrict(surveyId);
   } catch (e) {
     console.warn("Formbricks: Failed to read pending responses from IndexedDB", e);
     return [];
   }
 };
 
+export const removePendingResponseStrict = async (id: number): Promise<void> => {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_PENDING_RESPONSES, "readwrite");
+    const store = tx.objectStore(STORE_PENDING_RESPONSES);
+    const request = store.delete(id);
+
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
+  });
+};
+
 export const removePendingResponse = async (id: number): Promise<void> => {
   try {
-    const db = await openDb();
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_PENDING_RESPONSES, "readwrite");
-      const store = tx.objectStore(STORE_PENDING_RESPONSES);
-      const request = store.delete(id);
-
-      request.onsuccess = () => resolve();
-      request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
-    });
+    return await removePendingResponseStrict(id);
   } catch (e) {
     console.warn("Formbricks: Failed to remove pending response from IndexedDB", e);
   }
 };
 
+export const countPendingResponsesStrict = async (surveyId: string): Promise<number> => {
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(STORE_PENDING_RESPONSES, "readonly");
+    const index = tx.objectStore(STORE_PENDING_RESPONSES).index("surveyId");
+    const request = index.count(IDBKeyRange.only(surveyId));
+
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
+  });
+};
+
 export const countPendingResponses = async (surveyId: string): Promise<number> => {
   try {
-    const db = await openDb();
-    return new Promise((resolve, reject) => {
-      const tx = db.transaction(STORE_PENDING_RESPONSES, "readonly");
-      const index = tx.objectStore(STORE_PENDING_RESPONSES).index("surveyId");
-      const request = index.count(IDBKeyRange.only(surveyId));
-
-      request.onsuccess = () => resolve(request.result);
-      request.onerror = () => reject(request.error ?? new Error("IndexedDB request failed"));
-    });
+    return await countPendingResponsesStrict(surveyId);
   } catch (e) {
     console.warn("Formbricks: Failed to count pending responses from IndexedDB", e);
     return 0;

--- a/packages/surveys/src/lib/response-queue.ts
+++ b/packages/surveys/src/lib/response-queue.ts
@@ -38,12 +38,14 @@ export const delay = (ms: number): Promise<void> => {
 // so that only one sync/send runs at a time per survey, even across instances.
 const syncingBySurvey = new Map<string, boolean>();
 const requestInProgressBySurvey = new Map<string, boolean>();
+const processedDbIdsPendingRemovalBySurvey = new Map<string, Set<number>>();
 
 /** @internal Exposed for tests only. */
 export const _syncLocks = {
   clear: () => {
     syncingBySurvey.clear();
     requestInProgressBySurvey.clear();
+    processedDbIdsPendingRemovalBySurvey.clear();
   },
   set: (surveyId: string, value: boolean) => syncingBySurvey.set(surveyId, value),
   get: (surveyId: string) => syncingBySurvey.get(surveyId) ?? false,
@@ -57,7 +59,7 @@ export class ResponseQueue {
   private surveyState: SurveyState;
   readonly api: ApiClient;
   private responseRecaptchaToken?: string;
-  // Maps in-memory queue index → IndexedDB id for cleanup after successful send
+  // Maps queued response objects to their IndexedDB ids for cleanup after successful sends.
   private readonly pendingDbIds: Map<TResponseUpdate, number> = new Map();
 
   constructor(config: QueueConfig, surveyState: SurveyState) {
@@ -105,6 +107,86 @@ export class ResponseQueue {
     };
   }
 
+  private logOfflinePersistenceError(message: string, error: unknown) {
+    console.error(`Formbricks: ${message}`, {
+      error,
+      surveyId: this.config.surveyId,
+    });
+  }
+
+  private processQueueInBackground(context: string) {
+    void this.processQueue().catch((error) => {
+      this.logOfflinePersistenceError(context, error);
+    });
+  }
+
+  private syncPersistedResponsesInBackground(context: string) {
+    void this.syncPersistedResponses().catch((error) => {
+      this.logOfflinePersistenceError(context, error);
+    });
+  }
+
+  private async countPersistedResponses(): Promise<number> {
+    if (!this.config.surveyId) return 0;
+
+    try {
+      const pendingCount = await countPendingResponses(this.config.surveyId);
+      return Math.max(0, pendingCount - this.getProcessedDbIdsPendingRemoval().size);
+    } catch (error) {
+      this.logOfflinePersistenceError("Failed to count pending responses in IndexedDB", error);
+      return 0;
+    }
+  }
+
+  private getProcessedDbIdsPendingRemoval(): Set<number> {
+    if (!this.config.surveyId) return new Set();
+
+    const existingIds = processedDbIdsPendingRemovalBySurvey.get(this.config.surveyId);
+    if (existingIds) return existingIds;
+
+    const ids = new Set<number>();
+    processedDbIdsPendingRemovalBySurvey.set(this.config.surveyId, ids);
+    return ids;
+  }
+
+  private removePendingDbId(dbId: number) {
+    for (const [responseUpdate, pendingDbId] of this.pendingDbIds.entries()) {
+      if (pendingDbId === dbId) {
+        this.pendingDbIds.delete(responseUpdate);
+        return;
+      }
+    }
+  }
+
+  private async removePendingResponseFromIndexedDB(dbId: number, context: string): Promise<boolean> {
+    try {
+      await removePendingResponse(dbId);
+      this.getProcessedDbIdsPendingRemoval().delete(dbId);
+      this.removePendingDbId(dbId);
+      return true;
+    } catch (error) {
+      this.getProcessedDbIdsPendingRemoval().add(dbId);
+      this.logOfflinePersistenceError(context, error);
+      return false;
+    }
+  }
+
+  private async retryProcessedDbIdCleanup() {
+    for (const dbId of Array.from(this.getProcessedDbIdsPendingRemoval())) {
+      await this.removePendingResponseFromIndexedDB(
+        dbId,
+        "Failed to remove processed response from IndexedDB"
+      );
+    }
+  }
+
+  private removeProcessedQueueItems(processedCount: number) {
+    const removed = this.queue.splice(0, processedCount);
+    for (const item of removed) {
+      this.pendingDbIds.delete(item);
+    }
+  }
+
   add(responseUpdate: TResponseUpdate) {
     // update survey state
     this.surveyState.accumulateResponse(responseUpdate);
@@ -122,14 +204,19 @@ export class ResponseQueue {
         responseUpdate,
         surveyStateSnapshot: this.serializeSurveyState(),
         createdAt: Date.now(),
-      }).then((dbId) => {
-        if (dbId > 0) {
-          this.pendingDbIds.set(responseUpdate, dbId);
-        }
-        this.processQueue();
-      });
+      })
+        .then((dbId) => {
+          if (dbId > 0) {
+            this.pendingDbIds.set(responseUpdate, dbId);
+          }
+          this.processQueueInBackground("Failed to process queue after persisting response");
+        })
+        .catch((error) => {
+          this.logOfflinePersistenceError("Failed to persist pending response to IndexedDB", error);
+          this.processQueueInBackground("Failed to process queue after IndexedDB persistence failure");
+        });
     } else {
-      this.processQueue();
+      this.processQueueInBackground("Failed to process queue after adding response");
     }
   }
 
@@ -153,7 +240,8 @@ export class ResponseQueue {
     // This prevents processQueue and syncPersistedResponses from racing to
     // create the same response concurrently (duplicate POSTs).
     if (this.config.persistOffline && this.config.surveyId) {
-      const pendingCount = await countPendingResponses(this.config.surveyId);
+      await this.retryProcessedDbIdCleanup();
+      const pendingCount = await this.countPersistedResponses();
 
       // Re-check after await — another processQueue/sync may have started during the yield
       if (this.isSyncing || this.isRequestInProgress || this.queue.length === 0) {
@@ -161,7 +249,7 @@ export class ResponseQueue {
       }
 
       if (pendingCount > 1) {
-        void this.syncPersistedResponses();
+        this.syncPersistedResponsesInBackground("Failed to sync persisted responses in background");
         return { success: false };
       }
     }
@@ -174,8 +262,7 @@ export class ResponseQueue {
       // Remove from IndexedDB on successful send
       const dbId = this.pendingDbIds.get(responseUpdate);
       if (dbId !== undefined) {
-        void removePendingResponse(dbId);
-        this.pendingDbIds.delete(responseUpdate);
+        await this.removePendingResponseFromIndexedDB(dbId, "Failed to remove sent response from IndexedDB");
       }
 
       this.handleSuccessfulResponse(responseUpdate, result.quotaFullResponse);
@@ -197,12 +284,14 @@ export class ResponseQueue {
    */
   async loadPersistedQueue(): Promise<number> {
     if (!this.config.persistOffline || !this.config.surveyId) return 0;
-    return countPendingResponses(this.config.surveyId);
+    await this.retryProcessedDbIdCleanup();
+    return this.countPersistedResponses();
   }
 
   async getPendingCount(): Promise<number> {
     if (!this.config.persistOffline || !this.config.surveyId) return 0;
-    return countPendingResponses(this.config.surveyId);
+    await this.retryProcessedDbIdCleanup();
+    return this.countPersistedResponses();
   }
 
   /**
@@ -229,17 +318,21 @@ export class ResponseQueue {
     if (this.isRequestInProgress) return { success: false, syncedCount: 0 };
 
     this.isSyncing = true;
+    let syncedCount = 0;
 
     try {
+      await this.retryProcessedDbIdCleanup();
       const entries = await getPendingResponses(this.config.surveyId);
-      if (entries.length === 0) return { success: true, syncedCount: 0 };
+      const entriesToSync = entries.filter((entry) => {
+        return entry.id === undefined || !this.getProcessedDbIdsPendingRemoval().has(entry.id);
+      });
+      if (entriesToSync.length === 0) return { success: true, syncedCount: 0 };
 
       // Snapshot queue length before sync — entries added during async sync must be preserved.
       const queueLengthBeforeSync = this.queue.length;
+      let processedQueueEntries = 0;
 
-      let syncedCount = 0;
-
-      for (const entry of entries) {
+      for (const entry of entriesToSync) {
         // Only restore responseId from snapshot when it was set at capture time.
         // Otherwise, let the responseId from the previous sendResponse carry forward
         // (i.e., a create response in the previous iteration sets the responseId for updates).
@@ -259,37 +352,63 @@ export class ResponseQueue {
           result = await this.sendResponse(entry.responseUpdate);
         }
 
-        if (entry.id !== undefined) {
-          if (result.ok) {
-            await removePendingResponse(entry.id);
-          } else if (result.error && result.error.status >= 400 && result.error.status < 500) {
+        if (result.ok) {
+          if (entry.id !== undefined) {
+            const removed = await this.removePendingResponseFromIndexedDB(
+              entry.id,
+              "Failed to remove synced response from IndexedDB"
+            );
+            processedQueueEntries++;
+            if (!removed) {
+              this.removeProcessedQueueItems(Math.min(processedQueueEntries, queueLengthBeforeSync));
+              return { success: false, syncedCount };
+            }
+          } else {
+            processedQueueEntries++;
+          }
+        } else {
+          if (
+            entry.id !== undefined &&
+            result.error &&
+            result.error.status >= 400 &&
+            result.error.status < 500
+          ) {
             // Client error (e.g., 409 "already completed") —
             // this entry is stale, remove it and continue with the next one.
-            await removePendingResponse(entry.id);
+            const removed = await this.removePendingResponseFromIndexedDB(
+              entry.id,
+              "Failed to remove stale response from IndexedDB"
+            );
+            processedQueueEntries++;
+            if (!removed) {
+              this.removeProcessedQueueItems(Math.min(processedQueueEntries, queueLengthBeforeSync));
+              return { success: false, syncedCount };
+            }
             continue;
-          } else {
-            // Server/network error — stop syncing, remaining entries stay for next attempt
-            return { success: false, syncedCount };
           }
+
+          // Server/network error — stop syncing, remaining entries stay for next attempt
+          this.removeProcessedQueueItems(Math.min(processedQueueEntries, queueLengthBeforeSync));
+          return { success: false, syncedCount };
         }
 
         syncedCount++;
-        onProgress?.(syncedCount, entries.length);
+        onProgress?.(syncedCount, entriesToSync.length);
       }
 
       // Only remove pre-sync entries from the in-memory queue.
       // Entries added by add() during the async sync loop must be preserved.
-      const removed = this.queue.splice(0, queueLengthBeforeSync);
-      for (const item of removed) {
-        this.pendingDbIds.delete(item);
-      }
+      this.removeProcessedQueueItems(Math.min(processedQueueEntries, queueLengthBeforeSync));
 
       // Kick off processQueue for any entries added during sync
       if (this.queue.length > 0) {
-        this.processQueue();
+        this.processQueueInBackground("Failed to process queue after persisted response sync");
       }
 
       return { success: true, syncedCount };
+    } catch (error) {
+      this.logOfflinePersistenceError("Failed to sync persisted responses from IndexedDB", error);
+      return { success: false, syncedCount };
     } finally {
       this.isSyncing = false;
     }
@@ -401,7 +520,7 @@ export class ResponseQueue {
       this.config.onQuotaFull?.(quotaFullResponse);
     }
 
-    this.processQueue(); // process the next item in the queue if any
+    this.processQueueInBackground("Failed to process next queued response");
   }
 
   private handleFailedResponse(responseUpdate: TResponseUpdate, isRecaptchaError?: boolean) {

--- a/packages/surveys/src/lib/response-queue.ts
+++ b/packages/surveys/src/lib/response-queue.ts
@@ -310,13 +310,7 @@ export class ResponseQueue {
    * Does NOT populate the in-memory queue — syncPersistedResponses reads directly from IndexedDB.
    */
   async loadPersistedQueue(): Promise<number> {
-    if (!this.config.persistOffline || !this.config.surveyId) return 0;
-    try {
-      await this.retryProcessedDbIdCleanup();
-      return await this.countPersistedResponses();
-    } catch {
-      return 0;
-    }
+    return this.getPendingCount();
   }
 
   async getPendingCount(): Promise<number> {

--- a/packages/surveys/src/lib/response-queue.ts
+++ b/packages/surveys/src/lib/response-queue.ts
@@ -8,9 +8,9 @@ import { ApiClient } from "./api-client";
 import {
   type SerializedSurveyState,
   addPendingResponse,
-  countPendingResponses,
-  getPendingResponses,
-  removePendingResponse,
+  countPendingResponsesStrict,
+  getPendingResponsesStrict,
+  removePendingResponseStrict,
 } from "./offline-storage";
 import { SurveyState } from "./survey-state";
 
@@ -130,7 +130,7 @@ export class ResponseQueue {
     if (!this.config.surveyId) return 0;
 
     try {
-      const pendingCount = await countPendingResponses(this.config.surveyId);
+      const pendingCount = await countPendingResponsesStrict(this.config.surveyId);
       return Math.max(0, pendingCount - this.getProcessedDbIdsPendingRemoval().size);
     } catch (error) {
       this.logOfflinePersistenceError("Failed to count pending responses in IndexedDB", error);
@@ -158,11 +158,17 @@ export class ResponseQueue {
     }
   }
 
-  private async removePendingResponseFromIndexedDB(dbId: number, context: string): Promise<boolean> {
+  private async removePendingResponseFromIndexedDB(
+    dbId: number,
+    context: string,
+    options: { removeTrackedDbIdOnSuccess?: boolean } = {}
+  ): Promise<boolean> {
     try {
-      await removePendingResponse(dbId);
+      await removePendingResponseStrict(dbId);
       this.getProcessedDbIdsPendingRemoval().delete(dbId);
-      this.removePendingDbId(dbId);
+      if (options.removeTrackedDbIdOnSuccess ?? true) {
+        this.removePendingDbId(dbId);
+      }
       return true;
     } catch (error) {
       this.getProcessedDbIdsPendingRemoval().add(dbId);
@@ -180,11 +186,27 @@ export class ResponseQueue {
     }
   }
 
-  private removeProcessedQueueItems(processedCount: number) {
-    const removed = this.queue.splice(0, processedCount);
-    for (const item of removed) {
-      this.pendingDbIds.delete(item);
+  private removeProcessedQueueItemsByDbId(processedDbIds: Set<number>) {
+    if (processedDbIds.size === 0) return;
+
+    for (let index = this.queue.length - 1; index >= 0; index--) {
+      const item = this.queue[index];
+      const pendingDbId = this.pendingDbIds.get(item);
+
+      if (pendingDbId !== undefined && processedDbIds.has(pendingDbId)) {
+        this.queue.splice(index, 1);
+      }
     }
+
+    for (const [item, pendingDbId] of this.pendingDbIds.entries()) {
+      if (processedDbIds.has(pendingDbId)) {
+        this.pendingDbIds.delete(item);
+      }
+    }
+  }
+
+  private isTerminalStaleResponseError(error: ApiErrorResponse): boolean {
+    return error.status === 409;
   }
 
   add(responseUpdate: TResponseUpdate) {
@@ -322,15 +344,13 @@ export class ResponseQueue {
 
     try {
       await this.retryProcessedDbIdCleanup();
-      const entries = await getPendingResponses(this.config.surveyId);
+      const entries = await getPendingResponsesStrict(this.config.surveyId);
       const entriesToSync = entries.filter((entry) => {
         return entry.id === undefined || !this.getProcessedDbIdsPendingRemoval().has(entry.id);
       });
       if (entriesToSync.length === 0) return { success: true, syncedCount: 0 };
 
-      // Snapshot queue length before sync — entries added during async sync must be preserved.
-      const queueLengthBeforeSync = this.queue.length;
-      let processedQueueEntries = 0;
+      const processedDbIds = new Set<number>();
 
       for (const entry of entriesToSync) {
         // Only restore responseId from snapshot when it was set at capture time.
@@ -356,39 +376,34 @@ export class ResponseQueue {
           if (entry.id !== undefined) {
             const removed = await this.removePendingResponseFromIndexedDB(
               entry.id,
-              "Failed to remove synced response from IndexedDB"
+              "Failed to remove synced response from IndexedDB",
+              { removeTrackedDbIdOnSuccess: false }
             );
-            processedQueueEntries++;
+            processedDbIds.add(entry.id);
             if (!removed) {
-              this.removeProcessedQueueItems(Math.min(processedQueueEntries, queueLengthBeforeSync));
+              this.removeProcessedQueueItemsByDbId(processedDbIds);
               return { success: false, syncedCount };
             }
-          } else {
-            processedQueueEntries++;
           }
         } else {
-          if (
-            entry.id !== undefined &&
-            result.error &&
-            result.error.status >= 400 &&
-            result.error.status < 500
-          ) {
+          if (entry.id !== undefined && result.error && this.isTerminalStaleResponseError(result.error)) {
             // Client error (e.g., 409 "already completed") —
             // this entry is stale, remove it and continue with the next one.
             const removed = await this.removePendingResponseFromIndexedDB(
               entry.id,
-              "Failed to remove stale response from IndexedDB"
+              "Failed to remove stale response from IndexedDB",
+              { removeTrackedDbIdOnSuccess: false }
             );
-            processedQueueEntries++;
+            processedDbIds.add(entry.id);
             if (!removed) {
-              this.removeProcessedQueueItems(Math.min(processedQueueEntries, queueLengthBeforeSync));
+              this.removeProcessedQueueItemsByDbId(processedDbIds);
               return { success: false, syncedCount };
             }
             continue;
           }
 
           // Server/network error — stop syncing, remaining entries stay for next attempt
-          this.removeProcessedQueueItems(Math.min(processedQueueEntries, queueLengthBeforeSync));
+          this.removeProcessedQueueItemsByDbId(processedDbIds);
           return { success: false, syncedCount };
         }
 
@@ -396,9 +411,7 @@ export class ResponseQueue {
         onProgress?.(syncedCount, entriesToSync.length);
       }
 
-      // Only remove pre-sync entries from the in-memory queue.
-      // Entries added by add() during the async sync loop must be preserved.
-      this.removeProcessedQueueItems(Math.min(processedQueueEntries, queueLengthBeforeSync));
+      this.removeProcessedQueueItemsByDbId(processedDbIds);
 
       // Kick off processQueue for any entries added during sync
       if (this.queue.length > 0) {

--- a/packages/surveys/src/lib/response-queue.ts
+++ b/packages/surveys/src/lib/response-queue.ts
@@ -134,7 +134,7 @@ export class ResponseQueue {
       return Math.max(0, pendingCount - this.getProcessedDbIdsPendingRemoval().size);
     } catch (error) {
       this.logOfflinePersistenceError("Failed to count pending responses in IndexedDB", error);
-      return 0;
+      throw error;
     }
   }
 
@@ -262,8 +262,13 @@ export class ResponseQueue {
     // This prevents processQueue and syncPersistedResponses from racing to
     // create the same response concurrently (duplicate POSTs).
     if (this.config.persistOffline && this.config.surveyId) {
-      await this.retryProcessedDbIdCleanup();
-      const pendingCount = await this.countPersistedResponses();
+      let pendingCount: number;
+      try {
+        await this.retryProcessedDbIdCleanup();
+        pendingCount = await this.countPersistedResponses();
+      } catch {
+        return { success: false };
+      }
 
       // Re-check after await — another processQueue/sync may have started during the yield
       if (this.isSyncing || this.isRequestInProgress || this.queue.length === 0) {
@@ -306,14 +311,22 @@ export class ResponseQueue {
    */
   async loadPersistedQueue(): Promise<number> {
     if (!this.config.persistOffline || !this.config.surveyId) return 0;
-    await this.retryProcessedDbIdCleanup();
-    return this.countPersistedResponses();
+    try {
+      await this.retryProcessedDbIdCleanup();
+      return await this.countPersistedResponses();
+    } catch {
+      return 0;
+    }
   }
 
   async getPendingCount(): Promise<number> {
     if (!this.config.persistOffline || !this.config.surveyId) return 0;
-    await this.retryProcessedDbIdCleanup();
-    return this.countPersistedResponses();
+    try {
+      await this.retryProcessedDbIdCleanup();
+      return await this.countPersistedResponses();
+    } catch {
+      return 0;
+    }
   }
 
   /**

--- a/packages/surveys/src/lib/response.queue.test.ts
+++ b/packages/surveys/src/lib/response.queue.test.ts
@@ -69,6 +69,8 @@ const responseUpdate: TResponseUpdate = {
   finished: true,
 };
 
+const flushPromises = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
 describe("delay", () => {
   test("resolves after specified ms", async () => {
     const start = Date.now();
@@ -347,6 +349,44 @@ describe("ResponseQueue", () => {
 
   // --- Offline persistence tests ---
 
+  test("add processes the in-memory queue when IndexedDB persistence rejects", async () => {
+    const { addPendingResponse } = await import("./offline-storage");
+    const error = new Error("quota exceeded");
+    vi.mocked(addPendingResponse).mockRejectedValueOnce(error);
+
+    const offlineQueue = new ResponseQueue(
+      getConfig({ persistOffline: true, surveyId: "s1" }),
+      getSurveyState()
+    );
+    const processSpy = vi.spyOn(offlineQueue, "processQueue").mockResolvedValue({ success: true });
+
+    offlineQueue.add(responseUpdate);
+    await flushPromises();
+
+    expect(processSpy).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Formbricks: Failed to persist pending response to IndexedDB",
+      expect.objectContaining({ error, surveyId: "s1" })
+    );
+  });
+
+  test("add processes the in-memory queue when IndexedDB persistence is unavailable", async () => {
+    const { addPendingResponse } = await import("./offline-storage");
+    vi.mocked(addPendingResponse).mockResolvedValueOnce(-1);
+
+    const offlineQueue = new ResponseQueue(
+      getConfig({ persistOffline: true, surveyId: "s1" }),
+      getSurveyState()
+    );
+    const processSpy = vi.spyOn(offlineQueue, "processQueue").mockResolvedValue({ success: true });
+
+    offlineQueue.add(responseUpdate);
+    await flushPromises();
+
+    expect(processSpy).toHaveBeenCalled();
+    expect(offlineQueue["pendingDbIds"].has(responseUpdate)).toBe(false);
+  });
+
   test("processQueue returns false when offline and persistOffline is enabled", async () => {
     const offlineQueue = new ResponseQueue(
       getConfig({ persistOffline: true, surveyId: "s1" }),
@@ -370,6 +410,27 @@ describe("ResponseQueue", () => {
     expect(result.success).toBe(false);
   });
 
+  test("processQueue sends from memory when counting IndexedDB entries rejects", async () => {
+    const { countPendingResponses } = await import("./offline-storage");
+    const error = new Error("count failed");
+    vi.mocked(countPendingResponses).mockRejectedValueOnce(error);
+
+    const offlineQueue = new ResponseQueue(
+      getConfig({ persistOffline: true, surveyId: "s1" }),
+      getSurveyState()
+    );
+    offlineQueue.queue.push(responseUpdate);
+    vi.spyOn(offlineQueue, "sendResponse").mockResolvedValue(ok(true));
+
+    const result = await offlineQueue.processQueue();
+
+    expect(result.success).toBe(true);
+    expect(console.error).toHaveBeenCalledWith(
+      "Formbricks: Failed to count pending responses in IndexedDB",
+      expect.objectContaining({ error, surveyId: "s1" })
+    );
+  });
+
   test("processQueue defers to sync when multiple IDB entries exist", async () => {
     const { countPendingResponses } = await import("./offline-storage");
     vi.mocked(countPendingResponses).mockResolvedValue(3);
@@ -389,6 +450,28 @@ describe("ResponseQueue", () => {
     expect(result.success).toBe(false);
     expect(syncSpy).toHaveBeenCalled();
     expect(_syncLocks.getRequestInProgress("s1")).toBe(false);
+  });
+
+  test("processQueue logs rejected background sync attempts", async () => {
+    const { countPendingResponses } = await import("./offline-storage");
+    const error = new Error("sync failed");
+    vi.mocked(countPendingResponses).mockResolvedValueOnce(3);
+
+    const offlineQueue = new ResponseQueue(
+      getConfig({ persistOffline: true, surveyId: "s1" }),
+      getSurveyState()
+    );
+    offlineQueue.queue.push({ data: { q1: "answer" }, finished: false });
+    vi.spyOn(offlineQueue, "syncPersistedResponses").mockRejectedValueOnce(error);
+
+    const result = await offlineQueue.processQueue();
+    await flushPromises();
+
+    expect(result.success).toBe(false);
+    expect(console.error).toHaveBeenCalledWith(
+      "Formbricks: Failed to sync persisted responses in background",
+      expect.objectContaining({ error, surveyId: "s1" })
+    );
   });
 
   test("processQueue bails out if syncPersistedResponses starts during countPendingResponses await", async () => {
@@ -423,10 +506,107 @@ describe("ResponseQueue", () => {
     );
     offlineQueue.queue.push({ data: { q1: "answer" }, finished: false });
 
-    vi.spyOn(offlineQueue as any, "sendResponseWithRetry").mockResolvedValue({ success: true });
+    vi.spyOn(offlineQueue as any, "sendResponseWithRetry").mockImplementation(async () => {
+      offlineQueue.queue.shift();
+      return { success: true };
+    });
 
     const result = await offlineQueue.processQueue();
     expect(result.success).toBe(true);
+  });
+
+  test("processQueue keeps pendingDbIds until IndexedDB removal resolves", async () => {
+    const { countPendingResponses, removePendingResponse } = await import("./offline-storage");
+    vi.mocked(countPendingResponses).mockResolvedValueOnce(1);
+
+    let resolveRemove!: () => void;
+    vi.mocked(removePendingResponse).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRemove = resolve;
+        })
+    );
+
+    const offlineQueue = new ResponseQueue(
+      getConfig({ persistOffline: true, surveyId: "s1" }),
+      getSurveyState()
+    );
+    offlineQueue.queue.push(responseUpdate);
+    offlineQueue["pendingDbIds"].set(responseUpdate, 10);
+    vi.spyOn(offlineQueue, "sendResponse").mockResolvedValue(ok(true));
+
+    const resultPromise = offlineQueue.processQueue();
+    await flushPromises();
+
+    expect(removePendingResponse).toHaveBeenCalledWith(10);
+    expect(offlineQueue["pendingDbIds"].has(responseUpdate)).toBe(true);
+
+    resolveRemove();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(true);
+    expect(offlineQueue["pendingDbIds"].has(responseUpdate)).toBe(false);
+  });
+
+  test("processQueue keeps pendingDbIds and clears request lock when IndexedDB removal rejects", async () => {
+    const { countPendingResponses, removePendingResponse } = await import("./offline-storage");
+    const error = new Error("delete failed");
+    vi.mocked(countPendingResponses).mockResolvedValueOnce(1);
+    vi.mocked(removePendingResponse).mockRejectedValueOnce(error);
+
+    const offlineQueue = new ResponseQueue(
+      getConfig({ persistOffline: true, surveyId: "s1" }),
+      getSurveyState()
+    );
+    offlineQueue.queue.push(responseUpdate);
+    offlineQueue["pendingDbIds"].set(responseUpdate, 10);
+    vi.spyOn(offlineQueue, "sendResponse").mockResolvedValue(ok(true));
+
+    const result = await offlineQueue.processQueue();
+
+    expect(result.success).toBe(true);
+    expect(offlineQueue["pendingDbIds"].has(responseUpdate)).toBe(true);
+    expect(_syncLocks.getRequestInProgress("s1")).toBe(false);
+    expect(console.error).toHaveBeenCalledWith(
+      "Formbricks: Failed to remove sent response from IndexedDB",
+      expect.objectContaining({ error, surveyId: "s1" })
+    );
+  });
+
+  test("processQueue ignores already-sent rows while IndexedDB cleanup is pending", async () => {
+    const { countPendingResponses, removePendingResponse } = await import("./offline-storage");
+    const firstUpdate = { ...responseUpdate, data: { step: "first" } };
+    const secondUpdate = { ...responseUpdate, data: { step: "second" } };
+    const error = new Error("delete failed");
+
+    vi.mocked(countPendingResponses).mockResolvedValueOnce(1).mockResolvedValueOnce(2);
+    vi.mocked(removePendingResponse)
+      .mockRejectedValueOnce(error)
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined);
+
+    const offlineQueue = new ResponseQueue(
+      getConfig({ persistOffline: true, surveyId: "s1" }),
+      getSurveyState()
+    );
+    const sendSpy = vi.spyOn(offlineQueue, "sendResponse").mockResolvedValue(ok(true));
+    const syncSpy = vi.spyOn(offlineQueue, "syncPersistedResponses");
+
+    offlineQueue.queue.push(firstUpdate);
+    offlineQueue["pendingDbIds"].set(firstUpdate, 10);
+    await offlineQueue.processQueue();
+
+    offlineQueue.queue.push(secondUpdate);
+    offlineQueue["pendingDbIds"].set(secondUpdate, 11);
+    const result = await offlineQueue.processQueue();
+
+    expect(result.success).toBe(true);
+    expect(syncSpy).not.toHaveBeenCalled();
+    expect(sendSpy).toHaveBeenCalledTimes(2);
+    expect(sendSpy).toHaveBeenNthCalledWith(1, firstUpdate);
+    expect(sendSpy).toHaveBeenNthCalledWith(2, secondUpdate);
+    expect(removePendingResponse).toHaveBeenNthCalledWith(2, 10);
+    expect(removePendingResponse).toHaveBeenNthCalledWith(3, 11);
   });
 
   test("loadPersistedQueue returns 0 when persistOffline is disabled", async () => {
@@ -444,6 +624,24 @@ describe("ResponseQueue", () => {
     const count = await offlineQueue.loadPersistedQueue();
     expect(count).toBe(3);
     expect(countPendingResponses).toHaveBeenCalledWith("s1");
+  });
+
+  test("getPendingCount returns 0 when counting IndexedDB entries rejects", async () => {
+    const { countPendingResponses } = await import("./offline-storage");
+    const error = new Error("count failed");
+    vi.mocked(countPendingResponses).mockRejectedValueOnce(error);
+    const offlineQueue = new ResponseQueue(
+      getConfig({ persistOffline: true, surveyId: "s1" }),
+      getSurveyState()
+    );
+
+    const count = await offlineQueue.getPendingCount();
+
+    expect(count).toBe(0);
+    expect(console.error).toHaveBeenCalledWith(
+      "Formbricks: Failed to count pending responses in IndexedDB",
+      expect.objectContaining({ error, surveyId: "s1" })
+    );
   });
 
   test("getPendingCount returns 0 when persistOffline is disabled", async () => {
@@ -488,6 +686,26 @@ describe("ResponseQueue", () => {
     expect(result).toEqual({ success: false, syncedCount: 0 });
   });
 
+  test("syncPersistedResponses returns failure when reading IndexedDB rejects", async () => {
+    const { getPendingResponses } = await import("./offline-storage");
+    const error = new Error("read failed");
+    vi.mocked(getPendingResponses).mockRejectedValueOnce(error);
+
+    const offlineQueue = new ResponseQueue(
+      getConfig({ persistOffline: true, surveyId: "s1" }),
+      getSurveyState()
+    );
+
+    const result = await offlineQueue.syncPersistedResponses();
+
+    expect(result).toEqual({ success: false, syncedCount: 0 });
+    expect(_syncLocks.get("s1")).toBe(false);
+    expect(console.error).toHaveBeenCalledWith(
+      "Formbricks: Failed to sync persisted responses from IndexedDB",
+      expect.objectContaining({ error, surveyId: "s1" })
+    );
+  });
+
   test("syncPersistedResponses sends entries and clears queue on success", async () => {
     const { getPendingResponses, removePendingResponse } = await import("./offline-storage");
     vi.mocked(getPendingResponses).mockResolvedValue([
@@ -519,6 +737,46 @@ describe("ResponseQueue", () => {
     expect(removePendingResponse).toHaveBeenCalledWith(10);
     expect(offlineQueue.queue.length).toBe(0);
     expect(_syncLocks.get("s1")).toBe(false);
+  });
+
+  test("syncPersistedResponses returns failure when removing a synced IndexedDB entry rejects", async () => {
+    const { getPendingResponses, removePendingResponse } = await import("./offline-storage");
+    const error = new Error("delete failed");
+    vi.mocked(getPendingResponses).mockResolvedValueOnce([
+      {
+        id: 10,
+        surveyId: "s1",
+        responseUpdate,
+        surveyStateSnapshot: {
+          responseId: null,
+          displayId: "d1",
+          surveyId: "s1",
+          singleUseId: null,
+          userId: null,
+          contactId: null,
+          responseAcc: { finished: false, data: {} },
+        },
+        createdAt: Date.now(),
+      },
+    ]);
+    vi.mocked(removePendingResponse).mockRejectedValueOnce(error);
+
+    const offlineQueue = new ResponseQueue(
+      getConfig({ persistOffline: true, surveyId: "s1" }),
+      getSurveyState()
+    );
+    offlineQueue.queue.push(responseUpdate);
+    vi.spyOn(offlineQueue, "sendResponse").mockResolvedValue(ok(true));
+
+    const result = await offlineQueue.syncPersistedResponses();
+
+    expect(result).toEqual({ success: false, syncedCount: 0 });
+    expect(offlineQueue.queue.length).toBe(0);
+    expect(_syncLocks.get("s1")).toBe(false);
+    expect(console.error).toHaveBeenCalledWith(
+      "Formbricks: Failed to remove synced response from IndexedDB",
+      expect.objectContaining({ error, surveyId: "s1" })
+    );
   });
 
   test("syncPersistedResponses stops on server error", async () => {

--- a/packages/surveys/src/lib/response.queue.test.ts
+++ b/packages/surveys/src/lib/response.queue.test.ts
@@ -17,9 +17,9 @@ afterAll(() => {
 
 vi.mock("./offline-storage", () => ({
   addPendingResponse: vi.fn().mockResolvedValue(1),
-  countPendingResponses: vi.fn().mockResolvedValue(0),
-  getPendingResponses: vi.fn().mockResolvedValue([]),
-  removePendingResponse: vi.fn().mockResolvedValue(undefined),
+  countPendingResponsesStrict: vi.fn().mockResolvedValue(0),
+  getPendingResponsesStrict: vi.fn().mockResolvedValue([]),
+  removePendingResponseStrict: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("./api-client", () => ({
@@ -128,7 +128,7 @@ describe("ResponseQueue", () => {
     queue.queue.push(responseUpdate);
     vi.spyOn(queue, "sendResponse").mockResolvedValue(ok(true));
     await queue.processQueue();
-    expect(queue.queue.length).toBe(0);
+    expect(queue.queue).toHaveLength(0);
     expect(queue["isRequestInProgress"]).toBe(false);
   });
 
@@ -281,7 +281,7 @@ describe("ResponseQueue", () => {
     vi.spyOn(queue, "sendResponse").mockResolvedValue(ok(true));
     const result = await queue.processQueue();
     expect(result.success).toBe(true);
-    expect(queue.queue.length).toBe(0);
+    expect(queue.queue).toHaveLength(0);
   });
 
   test("processQueueAsync returns success false after max attempts", async () => {
@@ -411,9 +411,9 @@ describe("ResponseQueue", () => {
   });
 
   test("processQueue sends from memory when counting IndexedDB entries rejects", async () => {
-    const { countPendingResponses } = await import("./offline-storage");
+    const { countPendingResponsesStrict } = await import("./offline-storage");
     const error = new Error("count failed");
-    vi.mocked(countPendingResponses).mockRejectedValueOnce(error);
+    vi.mocked(countPendingResponsesStrict).mockRejectedValueOnce(error);
 
     const offlineQueue = new ResponseQueue(
       getConfig({ persistOffline: true, surveyId: "s1" }),
@@ -432,8 +432,8 @@ describe("ResponseQueue", () => {
   });
 
   test("processQueue defers to sync when multiple IDB entries exist", async () => {
-    const { countPendingResponses } = await import("./offline-storage");
-    vi.mocked(countPendingResponses).mockResolvedValue(3);
+    const { countPendingResponsesStrict } = await import("./offline-storage");
+    vi.mocked(countPendingResponsesStrict).mockResolvedValue(3);
 
     const offlineQueue = new ResponseQueue(
       getConfig({ persistOffline: true, surveyId: "s1" }),
@@ -453,9 +453,9 @@ describe("ResponseQueue", () => {
   });
 
   test("processQueue logs rejected background sync attempts", async () => {
-    const { countPendingResponses } = await import("./offline-storage");
+    const { countPendingResponsesStrict } = await import("./offline-storage");
     const error = new Error("sync failed");
-    vi.mocked(countPendingResponses).mockResolvedValueOnce(3);
+    vi.mocked(countPendingResponsesStrict).mockResolvedValueOnce(3);
 
     const offlineQueue = new ResponseQueue(
       getConfig({ persistOffline: true, surveyId: "s1" }),
@@ -474,11 +474,11 @@ describe("ResponseQueue", () => {
     );
   });
 
-  test("processQueue bails out if syncPersistedResponses starts during countPendingResponses await", async () => {
-    const { countPendingResponses } = await import("./offline-storage");
+  test("processQueue bails out if syncPersistedResponses starts during countPendingResponsesStrict await", async () => {
+    const { countPendingResponsesStrict } = await import("./offline-storage");
     // Simulate syncPersistedResponses starting during the async gap
-    vi.mocked(countPendingResponses).mockImplementation(async () => {
-      // While countPendingResponses is resolving, isSyncing becomes true
+    vi.mocked(countPendingResponsesStrict).mockImplementation(async () => {
+      // While countPendingResponsesStrict is resolving, isSyncing becomes true
       _syncLocks.set("s1", true);
       return 1;
     });
@@ -497,8 +497,8 @@ describe("ResponseQueue", () => {
   });
 
   test("processQueue sends directly when it is the only IDB entry", async () => {
-    const { countPendingResponses } = await import("./offline-storage");
-    vi.mocked(countPendingResponses).mockResolvedValue(1);
+    const { countPendingResponsesStrict } = await import("./offline-storage");
+    vi.mocked(countPendingResponsesStrict).mockResolvedValue(1);
 
     const offlineQueue = new ResponseQueue(
       getConfig({ persistOffline: true, surveyId: "s1" }),
@@ -516,11 +516,11 @@ describe("ResponseQueue", () => {
   });
 
   test("processQueue keeps pendingDbIds until IndexedDB removal resolves", async () => {
-    const { countPendingResponses, removePendingResponse } = await import("./offline-storage");
-    vi.mocked(countPendingResponses).mockResolvedValueOnce(1);
+    const { countPendingResponsesStrict, removePendingResponseStrict } = await import("./offline-storage");
+    vi.mocked(countPendingResponsesStrict).mockResolvedValueOnce(1);
 
     let resolveRemove!: () => void;
-    vi.mocked(removePendingResponse).mockImplementationOnce(
+    vi.mocked(removePendingResponseStrict).mockImplementationOnce(
       () =>
         new Promise<void>((resolve) => {
           resolveRemove = resolve;
@@ -538,7 +538,7 @@ describe("ResponseQueue", () => {
     const resultPromise = offlineQueue.processQueue();
     await flushPromises();
 
-    expect(removePendingResponse).toHaveBeenCalledWith(10);
+    expect(removePendingResponseStrict).toHaveBeenCalledWith(10);
     expect(offlineQueue["pendingDbIds"].has(responseUpdate)).toBe(true);
 
     resolveRemove();
@@ -549,10 +549,10 @@ describe("ResponseQueue", () => {
   });
 
   test("processQueue keeps pendingDbIds and clears request lock when IndexedDB removal rejects", async () => {
-    const { countPendingResponses, removePendingResponse } = await import("./offline-storage");
+    const { countPendingResponsesStrict, removePendingResponseStrict } = await import("./offline-storage");
     const error = new Error("delete failed");
-    vi.mocked(countPendingResponses).mockResolvedValueOnce(1);
-    vi.mocked(removePendingResponse).mockRejectedValueOnce(error);
+    vi.mocked(countPendingResponsesStrict).mockResolvedValueOnce(1);
+    vi.mocked(removePendingResponseStrict).mockRejectedValueOnce(error);
 
     const offlineQueue = new ResponseQueue(
       getConfig({ persistOffline: true, surveyId: "s1" }),
@@ -574,13 +574,13 @@ describe("ResponseQueue", () => {
   });
 
   test("processQueue ignores already-sent rows while IndexedDB cleanup is pending", async () => {
-    const { countPendingResponses, removePendingResponse } = await import("./offline-storage");
+    const { countPendingResponsesStrict, removePendingResponseStrict } = await import("./offline-storage");
     const firstUpdate = { ...responseUpdate, data: { step: "first" } };
     const secondUpdate = { ...responseUpdate, data: { step: "second" } };
     const error = new Error("delete failed");
 
-    vi.mocked(countPendingResponses).mockResolvedValueOnce(1).mockResolvedValueOnce(2);
-    vi.mocked(removePendingResponse)
+    vi.mocked(countPendingResponsesStrict).mockResolvedValueOnce(1).mockResolvedValueOnce(2);
+    vi.mocked(removePendingResponseStrict)
       .mockRejectedValueOnce(error)
       .mockRejectedValueOnce(error)
       .mockResolvedValueOnce(undefined);
@@ -605,8 +605,8 @@ describe("ResponseQueue", () => {
     expect(sendSpy).toHaveBeenCalledTimes(2);
     expect(sendSpy).toHaveBeenNthCalledWith(1, firstUpdate);
     expect(sendSpy).toHaveBeenNthCalledWith(2, secondUpdate);
-    expect(removePendingResponse).toHaveBeenNthCalledWith(2, 10);
-    expect(removePendingResponse).toHaveBeenNthCalledWith(3, 11);
+    expect(removePendingResponseStrict).toHaveBeenNthCalledWith(2, 10);
+    expect(removePendingResponseStrict).toHaveBeenNthCalledWith(3, 11);
   });
 
   test("loadPersistedQueue returns 0 when persistOffline is disabled", async () => {
@@ -614,22 +614,22 @@ describe("ResponseQueue", () => {
     expect(count).toBe(0);
   });
 
-  test("loadPersistedQueue delegates to countPendingResponses", async () => {
-    const { countPendingResponses } = await import("./offline-storage");
-    vi.mocked(countPendingResponses).mockResolvedValue(3);
+  test("loadPersistedQueue delegates to countPendingResponsesStrict", async () => {
+    const { countPendingResponsesStrict } = await import("./offline-storage");
+    vi.mocked(countPendingResponsesStrict).mockResolvedValue(3);
     const offlineQueue = new ResponseQueue(
       getConfig({ persistOffline: true, surveyId: "s1" }),
       getSurveyState()
     );
     const count = await offlineQueue.loadPersistedQueue();
     expect(count).toBe(3);
-    expect(countPendingResponses).toHaveBeenCalledWith("s1");
+    expect(countPendingResponsesStrict).toHaveBeenCalledWith("s1");
   });
 
   test("getPendingCount returns 0 when counting IndexedDB entries rejects", async () => {
-    const { countPendingResponses } = await import("./offline-storage");
+    const { countPendingResponsesStrict } = await import("./offline-storage");
     const error = new Error("count failed");
-    vi.mocked(countPendingResponses).mockRejectedValueOnce(error);
+    vi.mocked(countPendingResponsesStrict).mockRejectedValueOnce(error);
     const offlineQueue = new ResponseQueue(
       getConfig({ persistOffline: true, surveyId: "s1" }),
       getSurveyState()
@@ -687,9 +687,9 @@ describe("ResponseQueue", () => {
   });
 
   test("syncPersistedResponses returns failure when reading IndexedDB rejects", async () => {
-    const { getPendingResponses } = await import("./offline-storage");
+    const { getPendingResponsesStrict } = await import("./offline-storage");
     const error = new Error("read failed");
-    vi.mocked(getPendingResponses).mockRejectedValueOnce(error);
+    vi.mocked(getPendingResponsesStrict).mockRejectedValueOnce(error);
 
     const offlineQueue = new ResponseQueue(
       getConfig({ persistOffline: true, surveyId: "s1" }),
@@ -707,8 +707,8 @@ describe("ResponseQueue", () => {
   });
 
   test("syncPersistedResponses sends entries and clears queue on success", async () => {
-    const { getPendingResponses, removePendingResponse } = await import("./offline-storage");
-    vi.mocked(getPendingResponses).mockResolvedValue([
+    const { getPendingResponsesStrict, removePendingResponseStrict } = await import("./offline-storage");
+    vi.mocked(getPendingResponsesStrict).mockResolvedValue([
       {
         id: 10,
         surveyId: "s1",
@@ -729,20 +729,62 @@ describe("ResponseQueue", () => {
     const offlineState = getSurveyState();
     const offlineQueue = new ResponseQueue(getConfig({ persistOffline: true, surveyId: "s1" }), offlineState);
     offlineQueue.queue.push(responseUpdate);
+    offlineQueue["pendingDbIds"].set(responseUpdate, 10);
 
     vi.spyOn(offlineQueue, "sendResponse").mockResolvedValue(ok(true));
 
     const result = await offlineQueue.syncPersistedResponses();
     expect(result).toEqual({ success: true, syncedCount: 1 });
-    expect(removePendingResponse).toHaveBeenCalledWith(10);
-    expect(offlineQueue.queue.length).toBe(0);
+    expect(removePendingResponseStrict).toHaveBeenCalledWith(10);
+    expect(offlineQueue.queue).toHaveLength(0);
     expect(_syncLocks.get("s1")).toBe(false);
   });
 
+  test("syncPersistedResponses removes synced queue items by IndexedDB id", async () => {
+    const { getPendingResponsesStrict, removePendingResponseStrict } = await import("./offline-storage");
+    const inFlightUpdate = { ...responseUpdate, data: { step: "in-flight" } };
+    const syncedUpdate = { ...responseUpdate, data: { step: "synced" } };
+
+    vi.mocked(getPendingResponsesStrict).mockResolvedValueOnce([
+      {
+        id: 10,
+        surveyId: "s1",
+        responseUpdate: syncedUpdate,
+        surveyStateSnapshot: {
+          responseId: null,
+          displayId: "d1",
+          surveyId: "s1",
+          singleUseId: null,
+          userId: null,
+          contactId: null,
+          responseAcc: { finished: false, data: {} },
+        },
+        createdAt: Date.now(),
+      },
+    ]);
+
+    const offlineQueue = new ResponseQueue(
+      getConfig({ persistOffline: true, surveyId: "s1" }),
+      getSurveyState()
+    );
+    offlineQueue.queue.push(inFlightUpdate, syncedUpdate);
+    offlineQueue["pendingDbIds"].set(syncedUpdate, 10);
+
+    vi.spyOn(offlineQueue, "sendResponse").mockResolvedValue(ok(true));
+    vi.spyOn(offlineQueue, "processQueue").mockResolvedValue({ success: false });
+
+    const result = await offlineQueue.syncPersistedResponses();
+
+    expect(result).toEqual({ success: true, syncedCount: 1 });
+    expect(removePendingResponseStrict).toHaveBeenCalledWith(10);
+    expect(offlineQueue.queue).toEqual([inFlightUpdate]);
+    expect(offlineQueue["pendingDbIds"].has(syncedUpdate)).toBe(false);
+  });
+
   test("syncPersistedResponses returns failure when removing a synced IndexedDB entry rejects", async () => {
-    const { getPendingResponses, removePendingResponse } = await import("./offline-storage");
+    const { getPendingResponsesStrict, removePendingResponseStrict } = await import("./offline-storage");
     const error = new Error("delete failed");
-    vi.mocked(getPendingResponses).mockResolvedValueOnce([
+    vi.mocked(getPendingResponsesStrict).mockResolvedValueOnce([
       {
         id: 10,
         surveyId: "s1",
@@ -759,19 +801,20 @@ describe("ResponseQueue", () => {
         createdAt: Date.now(),
       },
     ]);
-    vi.mocked(removePendingResponse).mockRejectedValueOnce(error);
+    vi.mocked(removePendingResponseStrict).mockRejectedValueOnce(error);
 
     const offlineQueue = new ResponseQueue(
       getConfig({ persistOffline: true, surveyId: "s1" }),
       getSurveyState()
     );
     offlineQueue.queue.push(responseUpdate);
+    offlineQueue["pendingDbIds"].set(responseUpdate, 10);
     vi.spyOn(offlineQueue, "sendResponse").mockResolvedValue(ok(true));
 
     const result = await offlineQueue.syncPersistedResponses();
 
     expect(result).toEqual({ success: false, syncedCount: 0 });
-    expect(offlineQueue.queue.length).toBe(0);
+    expect(offlineQueue.queue).toHaveLength(0);
     expect(_syncLocks.get("s1")).toBe(false);
     expect(console.error).toHaveBeenCalledWith(
       "Formbricks: Failed to remove synced response from IndexedDB",
@@ -780,8 +823,8 @@ describe("ResponseQueue", () => {
   });
 
   test("syncPersistedResponses stops on server error", async () => {
-    const { getPendingResponses } = await import("./offline-storage");
-    vi.mocked(getPendingResponses).mockResolvedValue([
+    const { getPendingResponsesStrict } = await import("./offline-storage");
+    vi.mocked(getPendingResponsesStrict).mockResolvedValue([
       {
         id: 10,
         surveyId: "s1",
@@ -813,8 +856,8 @@ describe("ResponseQueue", () => {
   });
 
   test("syncPersistedResponses retries 404 as createResponse by resetting responseId", async () => {
-    const { getPendingResponses, removePendingResponse } = await import("./offline-storage");
-    vi.mocked(getPendingResponses).mockResolvedValue([
+    const { getPendingResponsesStrict, removePendingResponseStrict } = await import("./offline-storage");
+    vi.mocked(getPendingResponsesStrict).mockResolvedValue([
       {
         id: 10,
         surveyId: "s1",
@@ -851,14 +894,14 @@ describe("ResponseQueue", () => {
     const result = await offlineQueue.syncPersistedResponses();
     expect(result).toEqual({ success: true, syncedCount: 1 });
     expect(offlineQueue.sendResponse).toHaveBeenCalledTimes(2);
-    expect(removePendingResponse).toHaveBeenCalledWith(10);
+    expect(removePendingResponseStrict).toHaveBeenCalledWith(10);
     // responseId should have been reset to null for the retry
     expect(offlineState.responseId).toBeNull();
   });
 
-  test("syncPersistedResponses removes non-404 4xx entries and continues", async () => {
-    const { getPendingResponses, removePendingResponse } = await import("./offline-storage");
-    vi.mocked(getPendingResponses).mockResolvedValue([
+  test("syncPersistedResponses removes terminal 409 entries and continues", async () => {
+    const { getPendingResponsesStrict, removePendingResponseStrict } = await import("./offline-storage");
+    vi.mocked(getPendingResponsesStrict).mockResolvedValue([
       {
         id: 10,
         surveyId: "s1",
@@ -901,7 +944,47 @@ describe("ResponseQueue", () => {
 
     const result = await offlineQueue.syncPersistedResponses();
     expect(result).toEqual({ success: true, syncedCount: 1 });
-    expect(removePendingResponse).toHaveBeenCalledWith(10);
-    expect(removePendingResponse).toHaveBeenCalledWith(11);
+    expect(removePendingResponseStrict).toHaveBeenCalledWith(10);
+    expect(removePendingResponseStrict).toHaveBeenCalledWith(11);
+  });
+
+  test("syncPersistedResponses keeps recoverable 4xx entries", async () => {
+    const { getPendingResponsesStrict, removePendingResponseStrict } = await import("./offline-storage");
+    vi.mocked(getPendingResponsesStrict).mockResolvedValueOnce([
+      {
+        id: 10,
+        surveyId: "s1",
+        responseUpdate,
+        surveyStateSnapshot: {
+          responseId: null,
+          displayId: "d1",
+          surveyId: "s1",
+          singleUseId: null,
+          userId: null,
+          contactId: null,
+          responseAcc: { finished: false, data: {} },
+        },
+        createdAt: Date.now(),
+      },
+    ]);
+
+    const offlineQueue = new ResponseQueue(
+      getConfig({ persistOffline: true, surveyId: "s1" }),
+      getSurveyState()
+    );
+    offlineQueue.queue.push(responseUpdate);
+    offlineQueue["pendingDbIds"].set(responseUpdate, 10);
+
+    vi.spyOn(offlineQueue, "sendResponse").mockResolvedValue(
+      err({ code: "unauthorized", message: "unauthorized", status: 401 })
+    );
+
+    const result = await offlineQueue.syncPersistedResponses();
+
+    expect(result).toEqual({ success: false, syncedCount: 0 });
+    expect(removePendingResponseStrict).not.toHaveBeenCalledWith(10);
+    expect(offlineQueue.queue).toEqual([responseUpdate]);
+    expect(offlineQueue["pendingDbIds"].get(responseUpdate)).toBe(10);
+    expect(_syncLocks.get("s1")).toBe(false);
   });
 });

--- a/packages/surveys/src/lib/response.queue.test.ts
+++ b/packages/surveys/src/lib/response.queue.test.ts
@@ -410,7 +410,7 @@ describe("ResponseQueue", () => {
     expect(result.success).toBe(false);
   });
 
-  test("processQueue sends from memory when counting IndexedDB entries rejects", async () => {
+  test("processQueue bails out when counting IndexedDB entries rejects", async () => {
     const { countPendingResponsesStrict } = await import("./offline-storage");
     const error = new Error("count failed");
     vi.mocked(countPendingResponsesStrict).mockRejectedValueOnce(error);
@@ -420,11 +420,12 @@ describe("ResponseQueue", () => {
       getSurveyState()
     );
     offlineQueue.queue.push(responseUpdate);
-    vi.spyOn(offlineQueue, "sendResponse").mockResolvedValue(ok(true));
+    const sendSpy = vi.spyOn(offlineQueue, "sendResponse").mockResolvedValue(ok(true));
 
     const result = await offlineQueue.processQueue();
 
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+    expect(sendSpy).not.toHaveBeenCalled();
     expect(console.error).toHaveBeenCalledWith(
       "Formbricks: Failed to count pending responses in IndexedDB",
       expect.objectContaining({ error, surveyId: "s1" })


### PR DESCRIPTION
Fixes: ENG-953

## What changed

- Hardened `ResponseQueue` background persistence/sync calls so IndexedDB failures are logged and do not strand the in-memory response queue.
- Await IndexedDB cleanup before dropping queue-to-DB mappings, and track already-processed DB rows whose cleanup failed so later sync/count paths do not resend them.
- Added regression coverage for rejected persistence, count failures, background sync rejection, delayed/failed cleanup, cleanup retry, and sync read/delete failures.

## Root cause

`ResponseQueue` treated several IndexedDB operations as fire-and-forget work. If persistence or cleanup rejected, responses could stop progressing silently or be re-read from IndexedDB and submitted again later.

Fixes #8029

## Validation

- `pnpm exec prettier --write packages/surveys/src/lib/response-queue.ts packages/surveys/src/lib/response.queue.test.ts`
- `cd packages/surveys && NODE_OPTIONS=--max-old-space-size=8192 pnpm exec vitest run src/lib/response.queue.test.ts --pool=forks --maxWorkers=1 --reporter=dot`
- `pnpm --filter @formbricks/surveys test -- src/lib/response.queue.test.ts`
- `pnpm --filter @formbricks/surveys typecheck`
- `rm -rf packages/surveys/dist apps/web/public/js/surveys.* node_modules/.cache/turbo && pnpm build --filter=@formbricks/surveys... --force`