### PR TITLE
fix: place Traefik labels on Formbricks service

### DIFF
--- a/docker/__tests__/formbricks-script.test.ts
+++ b/docker/__tests__/formbricks-script.test.ts
@@ -5,10 +5,8 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, test } from "vitest";
 
-const formbricksScriptPath = fileURLToPath(new URL("../../../docker/formbricks.sh", import.meta.url));
-const dockerComposeTemplatePath = fileURLToPath(
-  new URL("../../../docker/docker-compose.yml", import.meta.url)
-);
+const formbricksScriptPath = fileURLToPath(new URL("../formbricks.sh", import.meta.url));
+const dockerComposeTemplatePath = fileURLToPath(new URL("../docker-compose.yml", import.meta.url));
 
 const tempDirs: string[] = [];
 
@@ -18,16 +16,21 @@ const createTempDir = (): string => {
   return tempDir;
 };
 
-const addFormbricksTraefikLabels = (composePath: string, hstsEnabled: "y" | "n"): void => {
+const addFormbricksTraefikLabels = (
+  composePath: string,
+  hstsEnabled: "y" | "n",
+  httpsSetup: "y" | "n"
+): void => {
   execFileSync(
     "bash",
     [
       "-lc",
-      'source "$1"; add_formbricks_traefik_labels "$2" "example.com" "$3"',
+      'source "$1"; add_formbricks_traefik_labels "$2" "example.com" "$3" "$4"',
       "bash",
       formbricksScriptPath,
       composePath,
       hstsEnabled,
+      httpsSetup,
     ],
     { encoding: "utf8" }
   );
@@ -63,7 +66,7 @@ describe("docker/formbricks.sh Traefik label injection", () => {
   test("adds HTTPS Traefik labels to the formbricks service only", () => {
     const composePath = writeDockerComposeTemplate();
 
-    addFormbricksTraefikLabels(composePath, "y");
+    addFormbricksTraefikLabels(composePath, "y", "y");
 
     const composeContents = readFileSync(composePath, "utf8");
     const formbricksMigrateBlock = getServiceBlock(composeContents, "formbricks-migrate");
@@ -75,18 +78,35 @@ describe("docker/formbricks.sh Traefik label injection", () => {
     expect(formbricksBlock.indexOf("    labels:")).toBeLessThan(formbricksBlock.indexOf("    environment:"));
     expect(formbricksBlock).toContain("traefik.http.routers.formbricks.rule=Host(`example.com`)");
     expect(formbricksBlock).toContain("traefik.http.routers.formbricks.entrypoints=websecure");
+    expect(formbricksBlock).toContain("traefik.http.routers.formbricks.tls.certresolver=default");
     expect(formbricksBlock).toContain("traefik.http.services.formbricks.loadbalancer.server.port=3000");
     expect(formbricksBlock).toContain(
       "traefik.http.routers.feedback-records-token.rule=Host(`example.com`) && Path(`/api/v3/feedbackRecords/token`)"
     );
+    expect(formbricksBlock).toContain("traefik.http.routers.feedback-records-token.tls.certresolver=default");
     expect(formbricksBlock).toContain("traefik.http.middlewares.hstsHeader.headers.stsSeconds=31536000");
     expect(formbricksBlock).not.toContain("traefik.http.routers.formbricks_http.entrypoints=web");
+  });
+
+  test("omits ACME certresolver labels when HTTPS setup is disabled", () => {
+    const composePath = writeDockerComposeTemplate();
+
+    addFormbricksTraefikLabels(composePath, "y", "n");
+
+    const composeContents = readFileSync(composePath, "utf8");
+    const formbricksBlock = getServiceBlock(composeContents, "formbricks");
+
+    expect(formbricksBlock).toContain("traefik.http.routers.formbricks.entrypoints=websecure");
+    expect(formbricksBlock).toContain("traefik.http.routers.formbricks.tls=true");
+    expect(formbricksBlock).toContain("traefik.http.routers.feedback-records-token.tls=true");
+    expect(formbricksBlock).toContain("traefik.http.middlewares.hstsHeader.headers.stsSeconds=31536000");
+    expect(formbricksBlock).not.toContain("tls.certresolver=default");
   });
 
   test("adds HTTP fallback labels when HSTS is disabled", () => {
     const composePath = writeDockerComposeTemplate();
 
-    addFormbricksTraefikLabels(composePath, "n");
+    addFormbricksTraefikLabels(composePath, "n", "n");
 
     const composeContents = readFileSync(composePath, "utf8");
     const formbricksMigrateBlock = getServiceBlock(composeContents, "formbricks-migrate");
@@ -99,6 +119,7 @@ describe("docker/formbricks.sh Traefik label injection", () => {
     expect(formbricksBlock).toContain(
       "traefik.http.routers.feedback-records-token-http.rule=Host(`example.com`) && Path(`/api/v3/feedbackRecords/token`)"
     );
+    expect(formbricksBlock).not.toContain("tls.certresolver=default");
     expect(formbricksBlock).not.toContain("traefik.http.middlewares.hstsHeader.headers.stsSeconds=31536000");
   });
 
@@ -115,7 +136,7 @@ describe("docker/formbricks.sh Traefik label injection", () => {
     );
 
     expect(() => {
-      addFormbricksTraefikLabels(composePath, "y");
+      addFormbricksTraefikLabels(composePath, "y", "y");
     }).toThrow();
     expect(existsSync(`${composePath}.tmp`)).toBe(false);
   });

--- a/docker/formbricks.sh
+++ b/docker/formbricks.sh
@@ -167,9 +167,10 @@ add_formbricks_traefik_labels() {
   local compose_file="${1:-docker-compose.yml}"
   local formbricks_domain_name="$2"
   local formbricks_hsts_enabled="$3"
+  local formbricks_https_setup="$4"
   local tmp_file="${compose_file}.tmp"
 
-  if ! awk -v domain_name="$formbricks_domain_name" -v hsts_enabled="$formbricks_hsts_enabled" '
+  if ! awk -v domain_name="$formbricks_domain_name" -v hsts_enabled="$formbricks_hsts_enabled" -v https_setup="$formbricks_https_setup" '
 BEGIN { in_formbricks = 0; inserted = 0 }
 /^  formbricks:$/ { in_formbricks = 1 }
 in_formbricks && /^  [A-Za-z0-9_-]+:/ && !/^  formbricks:$/ { in_formbricks = 0 }
@@ -180,12 +181,16 @@ in_formbricks && /^  [A-Za-z0-9_-]+:/ && !/^  formbricks:$/ { in_formbricks = 0 
         print "      - \"traefik.http.routers.formbricks.rule=Host(`" domain_name "`)\""
         print "      - \"traefik.http.routers.formbricks.entrypoints=websecure\""
         print "      - \"traefik.http.routers.formbricks.tls=true\""
-        print "      - \"traefik.http.routers.formbricks.tls.certresolver=default\""
+        if (https_setup == "y") {
+            print "      - \"traefik.http.routers.formbricks.tls.certresolver=default\""
+        }
         print "      - \"traefik.http.services.formbricks.loadbalancer.server.port=3000\""
         print "      - \"traefik.http.routers.feedback-records-token.rule=Host(`" domain_name "`) && Path(`/api/v3/feedbackRecords/token`)\""
         print "      - \"traefik.http.routers.feedback-records-token.entrypoints=websecure\""
         print "      - \"traefik.http.routers.feedback-records-token.tls=true\""
-        print "      - \"traefik.http.routers.feedback-records-token.tls.certresolver=default\""
+        if (https_setup == "y") {
+            print "      - \"traefik.http.routers.feedback-records-token.tls.certresolver=default\""
+        }
         print "      - \"traefik.http.routers.feedback-records-token.service=formbricks\""
         print "      - \"traefik.http.routers.feedback-records-token.priority=200\""
         if (hsts_enabled == "y") {
@@ -634,10 +639,12 @@ EOF
   fi
 
   # Step 1: Add Traefik labels to formbricks service
-  add_formbricks_traefik_labels "docker-compose.yml" "$domain_name" "$hsts_enabled"
+  if ! add_formbricks_traefik_labels "docker-compose.yml" "$domain_name" "$hsts_enabled" "$https_setup"; then
+    exit 1
+  fi
 
   # Step 1b: Add FeedbackRecords gateway labels to the Hub service.
-  awk -v domain_name="$domain_name" -v hsts_enabled="$hsts_enabled" '
+  awk -v domain_name="$domain_name" -v hsts_enabled="$hsts_enabled" -v https_setup="$https_setup" '
 BEGIN { in_hub = 0; inserted = 0 }
 /^  hub:/ { in_hub = 1 }
 in_hub && /^  [A-Za-z0-9_-]+:/ && !/^  hub:/ { in_hub = 0 }
@@ -649,14 +656,18 @@ in_hub && /^  [A-Za-z0-9_-]+:/ && !/^  hub:/ { in_hub = 0 }
         print "      - \"traefik.http.routers.feedback-records-v3.rule=Host(`" domain_name "`) && PathPrefix(`/api/v3/feedbackRecords`)\""
         print "      - \"traefik.http.routers.feedback-records-v3.entrypoints=websecure\""
         print "      - \"traefik.http.routers.feedback-records-v3.tls=true\""
-        print "      - \"traefik.http.routers.feedback-records-v3.tls.certresolver=default\""
+        if (https_setup == "y") {
+            print "      - \"traefik.http.routers.feedback-records-v3.tls.certresolver=default\""
+        }
         print "      - \"traefik.http.routers.feedback-records-v3.service=feedback-records-hub\""
         print "      - \"traefik.http.routers.feedback-records-v3.priority=100\""
         print "      - \"traefik.http.routers.feedback-records-v3.middlewares=feedback-records-auth,feedback-records-v3-rewrite,feedback-records-hub-headers\""
         print "      - \"traefik.http.routers.feedback-records-sdk.rule=Host(`" domain_name "`) && PathPrefix(`/v1/feedback-records`)\""
         print "      - \"traefik.http.routers.feedback-records-sdk.entrypoints=websecure\""
         print "      - \"traefik.http.routers.feedback-records-sdk.tls=true\""
-        print "      - \"traefik.http.routers.feedback-records-sdk.tls.certresolver=default\""
+        if (https_setup == "y") {
+            print "      - \"traefik.http.routers.feedback-records-sdk.tls.certresolver=default\""
+        }
         print "      - \"traefik.http.routers.feedback-records-sdk.service=feedback-records-hub\""
         print "      - \"traefik.http.routers.feedback-records-sdk.priority=100\""
         print "      - \"traefik.http.routers.feedback-records-sdk.middlewares=feedback-records-auth,feedback-records-hub-headers\""

--- a/docker/formbricks.sh
+++ b/docker/formbricks.sh
@@ -163,6 +163,62 @@ write_rustfs_env_file() {
   upsert_dotenv_var "FORMBRICKS_RUSTFS_REGION" "us-east-1" "$env_file"
 }
 
+add_formbricks_traefik_labels() {
+  local compose_file="${1:-docker-compose.yml}"
+  local formbricks_domain_name="$2"
+  local formbricks_hsts_enabled="$3"
+  local tmp_file="${compose_file}.tmp"
+
+  if ! awk -v domain_name="$formbricks_domain_name" -v hsts_enabled="$formbricks_hsts_enabled" '
+BEGIN { in_formbricks = 0; inserted = 0 }
+/^  formbricks:$/ { in_formbricks = 1 }
+in_formbricks && /^  [A-Za-z0-9_-]+:/ && !/^  formbricks:$/ { in_formbricks = 0 }
+{
+    if (in_formbricks && !inserted && $0 ~ /^    environment:$/) {
+        print "    labels:"
+        print "      - \"traefik.enable=true\""
+        print "      - \"traefik.http.routers.formbricks.rule=Host(`" domain_name "`)\""
+        print "      - \"traefik.http.routers.formbricks.entrypoints=websecure\""
+        print "      - \"traefik.http.routers.formbricks.tls=true\""
+        print "      - \"traefik.http.routers.formbricks.tls.certresolver=default\""
+        print "      - \"traefik.http.services.formbricks.loadbalancer.server.port=3000\""
+        print "      - \"traefik.http.routers.feedback-records-token.rule=Host(`" domain_name "`) && Path(`/api/v3/feedbackRecords/token`)\""
+        print "      - \"traefik.http.routers.feedback-records-token.entrypoints=websecure\""
+        print "      - \"traefik.http.routers.feedback-records-token.tls=true\""
+        print "      - \"traefik.http.routers.feedback-records-token.tls.certresolver=default\""
+        print "      - \"traefik.http.routers.feedback-records-token.service=formbricks\""
+        print "      - \"traefik.http.routers.feedback-records-token.priority=200\""
+        if (hsts_enabled == "y") {
+            print "      - \"traefik.http.middlewares.hstsHeader.headers.stsSeconds=31536000\""
+            print "      - \"traefik.http.middlewares.hstsHeader.headers.forceSTSHeader=true\""
+            print "      - \"traefik.http.middlewares.hstsHeader.headers.stsPreload=true\""
+            print "      - \"traefik.http.middlewares.hstsHeader.headers.stsIncludeSubdomains=true\""
+        } else {
+            print "      - \"traefik.http.routers.formbricks_http.entrypoints=web\""
+            print "      - \"traefik.http.routers.formbricks_http.rule=Host(`" domain_name "`)\""
+            print "      - \"traefik.http.routers.feedback-records-token-http.rule=Host(`" domain_name "`) && Path(`/api/v3/feedbackRecords/token`)\""
+            print "      - \"traefik.http.routers.feedback-records-token-http.entrypoints=web\""
+            print "      - \"traefik.http.routers.feedback-records-token-http.service=formbricks\""
+            print "      - \"traefik.http.routers.feedback-records-token-http.priority=200\""
+        }
+        inserted = 1
+    }
+    print
+}
+END {
+    if (!inserted) {
+        exit 1
+    }
+}
+' "$compose_file" >"$tmp_file"; then
+    rm -f "$tmp_file"
+    echo "❌ Failed to add Traefik labels to the formbricks service."
+    return 1
+  fi
+
+  mv "$tmp_file" "$compose_file"
+}
+
 install_formbricks() {
   # Friendly welcome
   echo "🧱 Welcome to the Formbricks Setup Script"
@@ -577,46 +633,8 @@ EOF
     echo "🚗 RustFS S3 configuration updated successfully!"
   fi
 
-  # SUPER SIMPLE: Use multiple simple operations instead of complex AWK
-
   # Step 1: Add Traefik labels to formbricks service
-  awk -v domain_name="$domain_name" -v hsts_enabled="$hsts_enabled" '
-/formbricks:/,/^ *$/ {
-    if ($0 ~ /<<: \*environment$/) {
-        print "    labels:"
-        print "      - \"traefik.enable=true\""
-        print "      - \"traefik.http.routers.formbricks.rule=Host(`" domain_name "`)\""
-        print "      - \"traefik.http.routers.formbricks.entrypoints=websecure\""
-        print "      - \"traefik.http.routers.formbricks.tls=true\""
-        print "      - \"traefik.http.routers.formbricks.tls.certresolver=default\""
-        print "      - \"traefik.http.services.formbricks.loadbalancer.server.port=3000\""
-        print "      - \"traefik.http.routers.feedback-records-token.rule=Host(`" domain_name "`) && Path(`/api/v3/feedbackRecords/token`)\""
-        print "      - \"traefik.http.routers.feedback-records-token.entrypoints=websecure\""
-        print "      - \"traefik.http.routers.feedback-records-token.tls=true\""
-        print "      - \"traefik.http.routers.feedback-records-token.tls.certresolver=default\""
-        print "      - \"traefik.http.routers.feedback-records-token.service=formbricks\""
-        print "      - \"traefik.http.routers.feedback-records-token.priority=200\""
-        if (hsts_enabled == "y") {
-            print "      - \"traefik.http.middlewares.hstsHeader.headers.stsSeconds=31536000\""
-            print "      - \"traefik.http.middlewares.hstsHeader.headers.forceSTSHeader=true\""
-            print "      - \"traefik.http.middlewares.hstsHeader.headers.stsPreload=true\""
-            print "      - \"traefik.http.middlewares.hstsHeader.headers.stsIncludeSubdomains=true\""
-        } else {
-            print "      - \"traefik.http.routers.formbricks_http.entrypoints=web\""
-            print "      - \"traefik.http.routers.formbricks_http.rule=Host(`" domain_name "`)\""
-            print "      - \"traefik.http.routers.feedback-records-token-http.rule=Host(`" domain_name "`) && Path(`/api/v3/feedbackRecords/token`)\""
-            print "      - \"traefik.http.routers.feedback-records-token-http.entrypoints=web\""
-            print "      - \"traefik.http.routers.feedback-records-token-http.service=formbricks\""
-            print "      - \"traefik.http.routers.feedback-records-token-http.priority=200\""
-        }
-        print $0
-    } else {
-        print $0
-    }
-    next
-}
-{ print }
-' docker-compose.yml >tmp.yml && mv tmp.yml docker-compose.yml
+  add_formbricks_traefik_labels "docker-compose.yml" "$domain_name" "$hsts_enabled"
 
   # Step 1b: Add FeedbackRecords gateway labels to the Hub service.
   awk -v domain_name="$domain_name" -v hsts_enabled="$hsts_enabled" '

--- a/docker/package.json
+++ b/docker/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@formbricks/docker",
   "private": true,
-  "type": "module",
   "scripts": {
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"

--- a/docker/package.json
+++ b/docker/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@formbricks/docker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "4.1.6",
+    "vite": "7.3.5",
+    "vitest": "4.1.6"
+  }
+}

--- a/packages/storage/src/formbricks-script.test.ts
+++ b/packages/storage/src/formbricks-script.test.ts
@@ -1,0 +1,122 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, test } from "vitest";
+
+const formbricksScriptPath = fileURLToPath(new URL("../../../docker/formbricks.sh", import.meta.url));
+const dockerComposeTemplatePath = fileURLToPath(
+  new URL("../../../docker/docker-compose.yml", import.meta.url)
+);
+
+const tempDirs: string[] = [];
+
+const createTempDir = (): string => {
+  const tempDir = mkdtempSync(join(tmpdir(), "formbricks-script-"));
+  tempDirs.push(tempDir);
+  return tempDir;
+};
+
+const addFormbricksTraefikLabels = (composePath: string, hstsEnabled: "y" | "n"): void => {
+  execFileSync(
+    "bash",
+    [
+      "-lc",
+      'source "$1"; add_formbricks_traefik_labels "$2" "example.com" "$3"',
+      "bash",
+      formbricksScriptPath,
+      composePath,
+      hstsEnabled,
+    ],
+    { encoding: "utf8" }
+  );
+};
+
+const writeDockerComposeTemplate = (): string => {
+  const tempDir = createTempDir();
+  const composePath = join(tempDir, "docker-compose.yml");
+
+  writeFileSync(composePath, readFileSync(dockerComposeTemplatePath, "utf8"));
+
+  return composePath;
+};
+
+const getServiceBlock = (composeContents: string, serviceName: string): string => {
+  const lines = composeContents.split("\n");
+  const startIndex = lines.findIndex((line) => line === `  ${serviceName}:`);
+
+  expect(startIndex).toBeGreaterThanOrEqual(0);
+
+  const endIndex = lines.findIndex((line, index) => index > startIndex && /^ {2}[A-Za-z0-9_-]+:/.test(line));
+
+  return lines.slice(startIndex, endIndex === -1 ? undefined : endIndex).join("\n");
+};
+
+afterEach(() => {
+  for (const tempDir of tempDirs.splice(0)) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("docker/formbricks.sh Traefik label injection", () => {
+  test("adds HTTPS Traefik labels to the formbricks service only", () => {
+    const composePath = writeDockerComposeTemplate();
+
+    addFormbricksTraefikLabels(composePath, "y");
+
+    const composeContents = readFileSync(composePath, "utf8");
+    const formbricksMigrateBlock = getServiceBlock(composeContents, "formbricks-migrate");
+    const formbricksBlock = getServiceBlock(composeContents, "formbricks");
+
+    expect(formbricksMigrateBlock).not.toContain("    labels:");
+    expect(formbricksMigrateBlock).not.toContain("traefik.enable=true");
+    expect(formbricksBlock).toContain("    labels:");
+    expect(formbricksBlock.indexOf("    labels:")).toBeLessThan(formbricksBlock.indexOf("    environment:"));
+    expect(formbricksBlock).toContain("traefik.http.routers.formbricks.rule=Host(`example.com`)");
+    expect(formbricksBlock).toContain("traefik.http.routers.formbricks.entrypoints=websecure");
+    expect(formbricksBlock).toContain("traefik.http.services.formbricks.loadbalancer.server.port=3000");
+    expect(formbricksBlock).toContain(
+      "traefik.http.routers.feedback-records-token.rule=Host(`example.com`) && Path(`/api/v3/feedbackRecords/token`)"
+    );
+    expect(formbricksBlock).toContain("traefik.http.middlewares.hstsHeader.headers.stsSeconds=31536000");
+    expect(formbricksBlock).not.toContain("traefik.http.routers.formbricks_http.entrypoints=web");
+  });
+
+  test("adds HTTP fallback labels when HSTS is disabled", () => {
+    const composePath = writeDockerComposeTemplate();
+
+    addFormbricksTraefikLabels(composePath, "n");
+
+    const composeContents = readFileSync(composePath, "utf8");
+    const formbricksMigrateBlock = getServiceBlock(composeContents, "formbricks-migrate");
+    const formbricksBlock = getServiceBlock(composeContents, "formbricks");
+
+    expect(formbricksMigrateBlock).not.toContain("    labels:");
+    expect(formbricksBlock).toContain("    labels:");
+    expect(formbricksBlock).toContain("traefik.http.routers.formbricks_http.entrypoints=web");
+    expect(formbricksBlock).toContain("traefik.http.routers.formbricks_http.rule=Host(`example.com`)");
+    expect(formbricksBlock).toContain(
+      "traefik.http.routers.feedback-records-token-http.rule=Host(`example.com`) && Path(`/api/v3/feedbackRecords/token`)"
+    );
+    expect(formbricksBlock).not.toContain("traefik.http.middlewares.hstsHeader.headers.stsSeconds=31536000");
+  });
+
+  test("fails when the formbricks service insertion point is missing", () => {
+    const tempDir = createTempDir();
+    const composePath = join(tempDir, "docker-compose.yml");
+
+    writeFileSync(
+      composePath,
+      `services:
+  formbricks:
+    image: ghcr.io/formbricks/formbricks:latest
+`
+    );
+
+    expect(() => {
+      addFormbricksTraefikLabels(composePath, "y");
+    }).toThrow();
+    expect(existsSync(`${composePath}.tmp`)).toBe(false);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -547,6 +547,18 @@ importers:
         specifier: 3.1.1
         version: 3.1.1(typescript@5.9.3)(vitest@4.1.6)
 
+  docker:
+    devDependencies:
+      '@vitest/coverage-v8':
+        specifier: 4.1.6
+        version: 4.1.6(vitest@4.1.6)
+      vite:
+        specifier: 7.3.5
+        version: 7.3.5(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
+      vitest:
+        specifier: 4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.5(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+
   packages/ai:
     dependencies:
       '@ai-sdk/amazon-bedrock':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "apps/*"
+  - "docker"
   - "packages/*"
 
 allowBuilds:


### PR DESCRIPTION
## What changed

- Replaced the broad one-click installer awk range with `add_formbricks_traefik_labels`, which only targets the exact `formbricks` service.
- Inserted Traefik labels before the web service `environment:` block so labels no longer land on `formbricks-migrate`.
- Added focused regression coverage for HTTPS/HSTS, HTTP fallback labels, and a missing insertion-point failure.

## Why

Discussion #8340 reported that one-click installs could route Traefik to the migration container instead of the web app. The reproduced root cause was the old awk range starting on the migration service image line and inserting labels at the migration service `<<: *environment` anchor.

## Self-review

- No breaking issues found after review.
- One code-quality issue was fixed before publishing: the new installer regression tests were moved out of the RustFS-specific test file into a dedicated `formbricks-script.test.ts`.
- Live one-click installs still depend on the `stable` tag moving during a latest non-prerelease release.

## Validation

- `bash -n docker/formbricks.sh`
- `git diff --check HEAD~1..HEAD`
- `pnpm --filter @formbricks/storage test`
- `pnpm --filter @formbricks/storage lint`
- `pnpm exec prettier --check packages/storage/src/formbricks-script.test.ts`
- Temp compose transform plus `docker compose config`, including verification that `formbricks-migrate` has no Traefik labels