### PR TITLE
fix: harden server-side validation on survey response submission

### DIFF
--- a/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/validated-response-update-input.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/validated-response-update-input.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { MAX_RESPONSE_TTC } from "@formbricks/types/responses";
 import { getValidatedResponseUpdateInput } from "./validated-response-update-input";
 
 describe("getValidatedResponseUpdateInput", () => {
@@ -80,5 +81,32 @@ describe("getValidatedResponseUpdateInput", () => {
         }),
       })
     );
+  });
+
+  test("clamps out-of-range ttc values instead of rejecting the response", async () => {
+    const request = new Request("http://localhost/api/v1/client/test/responses/response-id", {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        finished: true,
+        ttc: { q1: -5, q2: 9_000_000_000_000, q3: 1234 },
+      }),
+    });
+
+    const result = await getValidatedResponseUpdateInput(request);
+
+    expect("responseUpdateInput" in result).toBe(true);
+    if (!("responseUpdateInput" in result)) {
+      throw new Error("Expected a parsed responseUpdateInput");
+    }
+
+    // Bogus timing telemetry is sanitized at the boundary, not rejected.
+    expect(result.responseUpdateInput.ttc).toEqual({
+      q1: 0,
+      q2: MAX_RESPONSE_TTC,
+      q3: 1234,
+    });
   });
 });

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/types/response.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/types/response.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { MAX_RESPONSE_TTC } from "@formbricks/types/responses";
+import { ZResponseInputV2 } from "./response";
+
+describe("ZResponseInputV2 ttc sanitization", () => {
+  const base = {
+    workspaceId: "cm8f4x9mm0001gx9h5b7d7h3q",
+    surveyId: "cm8f4x9mm0002gx9h5b7d7h3q",
+    finished: true,
+    data: {},
+  };
+
+  test("clamps negative and absurdly large ttc values into [0, MAX_RESPONSE_TTC]", () => {
+    const result = ZResponseInputV2.safeParse({
+      ...base,
+      ttc: { q1: -1, q2: 1e15, q3: 5000 },
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    // Out-of-range telemetry is clamped, not rejected: the response is still accepted.
+    expect(result.data.ttc).toEqual({ q1: 0, q2: MAX_RESPONSE_TTC, q3: 5000 });
+  });
+
+  test("leaves in-range ttc values untouched", () => {
+    const result = ZResponseInputV2.safeParse({ ...base, ttc: { q1: 0, q2: 42_000 } });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+
+    expect(result.data.ttc).toEqual({ q1: 0, q2: 42_000 });
+  });
+});

--- a/packages/surveys/src/lib/validation/evaluator.test.ts
+++ b/packages/surveys/src/lib/validation/evaluator.test.ts
@@ -194,11 +194,94 @@ describe("validateElementResponse", () => {
         type: TSurveyElementTypeEnum.MultipleChoiceMulti,
         headline: { default: "Pick" },
         required: true,
-        choices: [{ id: "opt1", label: { default: "Option 1" } }],
+        // The Other option is what makes the trailing free-text value ("custom") legitimate;
+        // legacy clients send it without the "" sentinel.
+        choices: [
+          { id: "opt1", label: { default: "Option 1" } },
+          { id: "other", label: { default: "Other" } },
+        ],
       } as unknown as TSurveyElement;
 
       const result = validateElementResponse(element, ["opt1", "custom"], "en");
       expect(result.valid).toBe(true);
+    });
+
+    test("should reject single-select value that is not a configured option (no Other option)", () => {
+      const element = {
+        id: "single1",
+        type: TSurveyElementTypeEnum.MultipleChoiceSingle,
+        headline: { default: "Pick" },
+        required: true,
+        choices: [
+          { id: "yes", label: { default: "Yes" } },
+          { id: "no", label: { default: "No" } },
+        ],
+      } as unknown as TSurveyElement;
+
+      const result = validateElementResponse(element, "ARBITRARY_VALUE", "en");
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].ruleId).toBe("invalidOption");
+    });
+
+    test("should accept single-select value matching a configured option by id or label", () => {
+      const element = {
+        id: "single1",
+        type: TSurveyElementTypeEnum.MultipleChoiceSingle,
+        headline: { default: "Pick" },
+        required: true,
+        choices: [
+          { id: "yes", label: { default: "Yes" } },
+          { id: "no", label: { default: "No" } },
+        ],
+      } as unknown as TSurveyElement;
+
+      expect(validateElementResponse(element, "yes", "en").valid).toBe(true); // by id
+      expect(validateElementResponse(element, "No", "en").valid).toBe(true); // by label
+    });
+
+    test("should reject multi-select values that are not configured options (no Other option)", () => {
+      const element = {
+        id: "mc1",
+        type: TSurveyElementTypeEnum.MultipleChoiceMulti,
+        headline: { default: "Pick" },
+        required: true,
+        choices: [
+          { id: "opt1", label: { default: "Option 1" } },
+          { id: "opt2", label: { default: "Option 2" } },
+        ],
+      } as unknown as TSurveyElement;
+
+      const result = validateElementResponse(element, ["Option 1", "injected"], "en");
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].ruleId).toBe("invalidOption");
+    });
+
+    test("should accept arbitrary free text for a single-select with an Other option", () => {
+      const element = {
+        id: "single1",
+        type: TSurveyElementTypeEnum.MultipleChoiceSingle,
+        headline: { default: "Pick" },
+        required: true,
+        choices: [
+          { id: "opt1", label: { default: "Option 1" } },
+          { id: "other", label: { default: "Other" } },
+        ],
+      } as unknown as TSurveyElement;
+
+      const result = validateElementResponse(element, "some free text", "en");
+      expect(result.valid).toBe(true);
+    });
+
+    test("should not throw for a malformed choice element missing choices", () => {
+      const element = {
+        id: "mc1",
+        type: TSurveyElementTypeEnum.MultipleChoiceSingle,
+        headline: { default: "Pick" },
+        required: false,
+      } as unknown as TSurveyElement; // choices intentionally absent
+
+      expect(() => validateElementResponse(element, "anything", "en")).not.toThrow();
+      expect(validateElementResponse(element, "anything", "en").valid).toBe(true);
     });
 
     test("should handle required ranking element - at least one ranked", () => {

--- a/packages/surveys/src/lib/validation/evaluator.ts
+++ b/packages/surveys/src/lib/validation/evaluator.ts
@@ -38,6 +38,17 @@ const createRequiredError = (t: TFunction): TValidationError => {
 };
 
 /**
+ * Create an invalid-option error (value not among a choice element's configured options)
+ */
+const createInvalidOptionError = (t: TFunction): TValidationError => {
+  return {
+    ruleId: "invalidOption",
+    ruleType: "minLength", // Structural field only - choice membership is not a configurable rule
+    message: t("errors.invalid_format"),
+  } as TValidationError;
+};
+
+/**
  * Get field label for address/contact info elements
  */
 const getFieldLabel = (
@@ -181,6 +192,62 @@ const validateSingleSelectOtherValue = (
 
   if (value.trim() === "") {
     return createRequiredError(t);
+  }
+
+  return null;
+};
+
+/**
+ * Reject answer values that are not among a choice element's configured options.
+ *
+ * Choice elements that expose an "Other" option intentionally accept free text, so this
+ * check only applies when the element has NO "Other" option — there a legitimate client can
+ * only ever submit a configured choice (by id or localized label), so any other value is
+ * tampered/garbage input submitted directly to the API. Empty values are deferred to the
+ * required check.
+ */
+const validateChoiceMembership = (
+  element: TSurveyElement,
+  value: TResponseDataValue,
+  languageCode: string,
+  t: TFunction
+): TValidationError | null => {
+  if (
+    element.type !== TSurveyElementTypeEnum.MultipleChoiceSingle &&
+    element.type !== TSurveyElementTypeEnum.MultipleChoiceMulti
+  ) {
+    return null;
+  }
+
+  // Defensive: a malformed survey element could be missing `choices` at runtime; match the
+  // other choice validators and bail rather than throw.
+  if (!("choices" in element) || !Array.isArray(element.choices)) {
+    return null;
+  }
+
+  const hasOtherOption = element.choices.some((choice) => choice.id === "other");
+  if (hasOtherOption || isEmpty(value)) {
+    return null;
+  }
+
+  const knownValues = new Set<string>();
+  for (const choice of element.choices) {
+    knownValues.add(choice.id);
+    const label = getLocalizedValue(choice.label, languageCode);
+    if (label) {
+      knownValues.add(label);
+    }
+  }
+
+  const submittedValues = Array.isArray(value) ? value : [value];
+  for (const submitted of submittedValues) {
+    // Tolerate stray empty/sentinel entries; emptiness is the required check's concern.
+    if (submitted === "") {
+      continue;
+    }
+    if (typeof submitted !== "string" || !knownValues.has(submitted)) {
+      return createInvalidOptionError(t);
+    }
   }
 
   return null;
@@ -436,6 +503,11 @@ export const validateElementResponse = (
   const multiSelectOtherError = validateMultiSelectOtherValue(element, value, t);
   if (multiSelectOtherError) {
     errors.push(multiSelectOtherError);
+  }
+
+  const invalidOptionError = validateChoiceMembership(element, value, languageCode, t);
+  if (invalidOptionError) {
+    errors.push(invalidOptionError);
   }
 
   // Validation rules apply to matrix elements regardless of required status

--- a/packages/types/responses.ts
+++ b/packages/types/responses.ts
@@ -51,6 +51,23 @@ export const ZResponseTtc = z.record(z.string(), z.number());
 
 export type TResponseTtc = z.infer<typeof ZResponseTtc>;
 
+// Per-element time-to-complete (ttc, in ms) is attacker-controlled telemetry on the public
+// response endpoints. We sanitize each measurement at the schema boundary: z.number() already
+// rejects NaN/Infinity, and we clamp the remaining finite values into [0, MAX_RESPONSE_TTC] so
+// negative or absurdly large numbers can no longer skew analytics or overflow the summed
+// `_total`. Clamping rather than rejecting means a real submission is never dropped over a
+// noisy timing value — a question is only briefly "active", so anything past a day is
+// meaningless rather than a reason to reject the response. Stored/returned responses keep the
+// unbounded ZResponseTtc so historical data still parses.
+export const MAX_RESPONSE_TTC = 1000 * 60 * 60 * 24; // 24 hours per element
+
+export const ZResponseTtcInput = z.record(
+  z.string(),
+  z.number().transform((value) => Math.min(Math.max(value, 0), MAX_RESPONSE_TTC))
+);
+
+export type TResponseTtcInput = z.infer<typeof ZResponseTtcInput>;
+
 export const ZResponseContactAttributes = z.record(z.string(), z.string()).nullable();
 
 export type TResponseContactAttributes = z.infer<typeof ZResponseContactAttributes>;
@@ -352,7 +369,7 @@ export const ZResponseInput = z.object({
   language: z.string().optional(),
   data: ZResponseData,
   variables: ZResponseVariables.optional(),
-  ttc: ZResponseTtc.optional(),
+  ttc: ZResponseTtcInput.optional(),
   meta: z
     .object({
       source: z.string().optional(),
@@ -378,7 +395,7 @@ export const ZResponseUpdateInput = z.object({
   endingId: z.string().nullish(),
   data: ZResponseData.optional(),
   variables: ZResponseVariables.optional(),
-  ttc: ZResponseTtc.optional(),
+  ttc: ZResponseTtcInput.optional(),
   language: z.string().optional(),
 });
 
@@ -401,7 +418,7 @@ export const ZResponseUpdate = z.object({
   data: ZResponseData,
   language: z.string().optional(),
   variables: ZResponseVariables.optional(),
-  ttc: ZResponseTtc.optional(),
+  ttc: ZResponseTtcInput.optional(),
   meta: z
     .object({
       url: z.string().optional(),


### PR DESCRIPTION
## What does this PR do?

Security report [ENG-1083](https://linear.app/formbricks/issue/ENG-1083) (via security@) flagged that the survey response submission API relies on client-side validation. Most of it no longer reproduces — the response path now runs real server-side validation — but two gaps were genuine, and this hardens them at the right layers. (Full per-claim breakdown is on the Linear ticket.)

**ttc bounds** — `ttc` (per-question time-to-complete) was an unbounded `z.number()`, so negative or absurdly large values went straight into storage and the summed `_total`, skewing analytics. It's now clamped per-element into `[0, 24h]` at the schema boundary, on the untrusted input schemas only. I went with clamping rather than rejecting on purpose: ttc is noisy telemetry, and I'd rather sanitize a bad timing number than drop an otherwise-valid response over it. The stored/returned schema stays unbounded so historical data still parses, and the authenticated management-create endpoint keeps its own unbounded schema (trusted imports shouldn't be silently clamped).

**Choice membership** — single/multiple-choice questions *without* an "Other" option accepted any arbitrary value (e.g. submitting a made-up value for a Yes/No question). Validation only length-checked unknown values as potential "Other" text, never as membership. Now, for a choice element with no "Other" option, the value must match a configured choice (by id or localized label) or it's rejected. Elements that *do* expose an "Other" option still accept free text, so legacy "Other"-without-sentinel submissions are unaffected. The check lives in the shared validation evaluator, so the management response endpoints get it too (defense in depth).

**Deliberately not fixed (claims 1/2/5 — required-on-finish):** the report also asked the server to reject `finished: true` when required questions are unanswered. I'm leaving that out on purpose — a response legitimately finishes incomplete via quota early-termination, branching/jump-to-ending logic, and redirect endings, so a server gate would false-reject real completed responses (i.e. data loss, which is worse than the low-severity integrity gain). Completeness is enforced client-side; server-side, "finished" is driven by quotas/logic/endings (`endingId` records why). Rationale + evidence are on the ticket.

**Scope note:** membership covers MultipleChoice single/multi (the reported case). PictureSelection is the same class but has a different choice shape (id + imageUrl, no label) — left as a possible follow-up.

## How should this be tested?

- **Choice membership** — `pnpm --filter @formbricks/surveys test src/lib/validation/evaluator.test.ts`: a no-"Other" choice rejects an unconfigured value (`invalidOption`), accepts a configured value by id or label, an "Other"-enabled element still accepts free text, and a malformed element with no `choices` doesn't throw.
- **ttc** — `cd apps/web && pnpm test "responses/types/response.test" validated-response-update-input`: out-of-range ttc is clamped into `[0, 24h]` on both the POST (v2) and PUT (v1) client boundaries, in-range values are untouched.
- **Manual** — against `POST /api/v2/client/{workspaceId}/responses`:
  - `data: { <singleChoiceQuestionId>: "NOT_AN_OPTION" }` for a Yes/No question → `400` "Validation failed".
  - `ttc: { q1: -5, q2: 9000000000000 }` → accepted, stored as `{ q1: 0, q2: 86400000 }`.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` (package builds + targeted vitest + eslint run locally; full app build left to CI)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch (rebased onto `main`)
- [x] My changes don't cause any responsiveness issues (no UI changes)
- [ ] First PR at Formbricks?

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
