### PR TITLE
feat(workflows): enqueue workflow runs on completed responses [ENG-1226]

### DIFF
--- a/apps/web/lib/jobs/pool-exhaustion.test.ts
+++ b/apps/web/lib/jobs/pool-exhaustion.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "vitest";
+import { Prisma } from "@formbricks/database/prisma";
+import { DatabaseError } from "@formbricks/types/errors";
+import { isDatabasePoolExhaustionError } from "./pool-exhaustion";
+
+describe("isDatabasePoolExhaustionError", () => {
+  test("is true for the Prisma P2024 pool-timeout code", () => {
+    const error = new Prisma.PrismaClientKnownRequestError("pool timeout", {
+      code: "P2024",
+      clientVersion: "test",
+    });
+    expect(isDatabasePoolExhaustionError(error)).toBe(true);
+  });
+
+  test("is true for a connection-pool timeout message (plain Error or DatabaseError)", () => {
+    expect(
+      isDatabasePoolExhaustionError(new Error("Timed out fetching a new connection from the connection pool"))
+    ).toBe(true);
+    expect(isDatabasePoolExhaustionError(new DatabaseError("connection pool timeout while querying"))).toBe(
+      true
+    );
+  });
+
+  test("is false for other Prisma codes, unrelated messages, and non-errors", () => {
+    const notFound = new Prisma.PrismaClientKnownRequestError("not found", {
+      code: "P2025",
+      clientVersion: "test",
+    });
+    expect(isDatabasePoolExhaustionError(notFound)).toBe(false);
+    expect(isDatabasePoolExhaustionError(new Error("something unrelated"))).toBe(false);
+    expect(isDatabasePoolExhaustionError("nope")).toBe(false);
+    expect(isDatabasePoolExhaustionError(null)).toBe(false);
+    expect(isDatabasePoolExhaustionError(undefined)).toBe(false);
+  });
+});

--- a/apps/web/lib/jobs/pool-exhaustion.ts
+++ b/apps/web/lib/jobs/pool-exhaustion.ts
@@ -1,0 +1,24 @@
+import { Prisma } from "@formbricks/database/prisma";
+import { DatabaseError } from "@formbricks/types/errors";
+
+/**
+ * True when an error is a transient database connection-pool exhaustion (Prisma `P2024`, or a
+ * connection-pool timeout surfaced as a message). These are retryable: a background job that hits
+ * one should propagate the error so it is retried, rather than swallow it and silently drop work.
+ *
+ * Shared by the response-pipeline job and the workflow runner enqueue so both classify retryable
+ * DB exhaustion the same way (and so the runner can rethrow it without importing the pipeline).
+ */
+export const isDatabasePoolExhaustionError = (error: unknown): boolean => {
+  if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2024") {
+    return true;
+  }
+
+  if (error instanceof DatabaseError || error instanceof Error) {
+    return /Timed out fetching a new connection from the connection pool|connection pool timeout/i.test(
+      error.message
+    );
+  }
+
+  return false;
+};

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
@@ -8,6 +8,7 @@ const {
   mockCaptureSurveyResponsePostHogEvent,
   mockCreatePinnedDispatcher,
   mockDispatcherDestroy,
+  mockEnqueueResponseCompletedWorkflowRuns,
   mockGetIntegrations,
   mockGetResponseCountBySurveyId,
   mockHandleIntegrations,
@@ -33,6 +34,7 @@ const {
     mockCaptureSurveyResponsePostHogEvent: vi.fn(),
     mockCreatePinnedDispatcher: vi.fn(() => ({ destroy: dispatcherDestroy })),
     mockDispatcherDestroy: dispatcherDestroy,
+    mockEnqueueResponseCompletedWorkflowRuns: vi.fn(),
     mockGetIntegrations: vi.fn(),
     mockGetResponseCountBySurveyId: vi.fn(),
     mockHandleIntegrations: vi.fn(),
@@ -130,6 +132,14 @@ vi.mock("@/modules/survey/follow-ups/lib/follow-ups", () => ({
   sendFollowUpsForResponse: mockSendFollowUpsForResponse,
 }));
 
+vi.mock("@/modules/workflows/lib/runner/enqueue-response-completed-runs", () => ({
+  enqueueResponseCompletedWorkflowRuns: mockEnqueueResponseCompletedWorkflowRuns,
+}));
+
+vi.mock("@/modules/workflows/lib/runner/dispatch", () => ({
+  dispatchWorkflowRunViaJobs: vi.fn(),
+}));
+
 vi.mock("@formbricks/logger", () => ({
   logger: {
     debug: vi.fn(),
@@ -219,6 +229,7 @@ describe("processResponsePipelineJob", () => {
     mockRecordResponseCreatedMeterEvent.mockResolvedValue(undefined);
     mockSendResponseFinishedEmail.mockResolvedValue(undefined);
     mockSendFollowUpsForResponse.mockResolvedValue({ ok: true, data: [] });
+    mockEnqueueResponseCompletedWorkflowRuns.mockResolvedValue(undefined);
     mockSendTelemetryEvents.mockResolvedValue(undefined);
     mockPrismaSurveyUpdate.mockResolvedValue(undefined);
     mockFetch.mockResolvedValue({
@@ -231,6 +242,38 @@ describe("processResponsePipelineJob", () => {
   afterEach(() => {
     global.fetch = originalFetch;
     mockFetch.mockReset();
+  });
+
+  test("invokes the workflow runner on responseFinished", async () => {
+    await expect(
+      processResponsePipelineJob({ ...baseData, event: "responseFinished" }, baseContext)
+    ).resolves.toBeUndefined();
+
+    expect(mockEnqueueResponseCompletedWorkflowRuns).toHaveBeenCalledTimes(1);
+    expect(mockEnqueueResponseCompletedWorkflowRuns).toHaveBeenCalledWith(
+      expect.objectContaining({
+        response: expect.objectContaining({ id: "response_123" }),
+        workspaceId: "workspace_123",
+      })
+    );
+  });
+
+  test("does not invoke the workflow runner on responseCreated", async () => {
+    await expect(processResponsePipelineJob(baseData, baseContext)).resolves.toBeUndefined();
+    expect(mockEnqueueResponseCompletedWorkflowRuns).not.toHaveBeenCalled();
+  });
+
+  test("isolates a workflow runner failure from the response pipeline", async () => {
+    mockEnqueueResponseCompletedWorkflowRuns.mockRejectedValue(new Error("runner boom"));
+
+    await expect(
+      processResponsePipelineJob({ ...baseData, event: "responseFinished" }, baseContext)
+    ).resolves.toBeUndefined();
+
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      "Response pipeline workflow run enqueue failed"
+    );
   });
 
   test("processes responseCreated jobs with webhook, metering, and telemetry side effects", async () => {

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
@@ -263,6 +263,16 @@ describe("processResponsePipelineJob", () => {
     expect(mockEnqueueResponseCompletedWorkflowRuns).not.toHaveBeenCalled();
   });
 
+  test("rethrows a transient DB pool-exhaustion error from the workflow runner so the job retries", async () => {
+    mockEnqueueResponseCompletedWorkflowRuns.mockRejectedValue(
+      new Error("Timed out fetching a new connection from the connection pool")
+    );
+
+    await expect(
+      processResponsePipelineJob({ ...baseData, event: "responseFinished" }, baseContext)
+    ).rejects.toThrow(/connection pool/i);
+  });
+
   test("isolates a workflow runner failure from the response pipeline", async () => {
     mockEnqueueResponseCompletedWorkflowRuns.mockRejectedValue(new Error("runner boom"));
 

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
@@ -20,6 +20,8 @@ import { captureSurveyResponsePostHogEvent } from "@/modules/response-pipeline/l
 import { resolveStorageUrlsInObject } from "@/modules/storage/utils";
 import { sendFollowUpsForResponse } from "@/modules/survey/follow-ups/lib/follow-ups";
 import { FollowUpSendError } from "@/modules/survey/follow-ups/types/follow-up";
+import { dispatchWorkflowRunViaJobs } from "@/modules/workflows/lib/runner/dispatch";
+import { enqueueResponseCompletedWorkflowRuns } from "@/modules/workflows/lib/runner/enqueue-response-completed-runs";
 import { handleIntegrations } from "./handle-integrations";
 import { sendTelemetryEvents } from "./telemetry";
 
@@ -688,6 +690,19 @@ const runResponseFinishedSideEffects = async ({
     responseCount,
     survey,
   });
+
+  // Workflow runner (producer): enqueue runs for matching enabled workflows. Isolated so a runner
+  // failure never breaks the response pipeline job, its retries, or the other side-effects above.
+  try {
+    await enqueueResponseCompletedWorkflowRuns({
+      response: data.response,
+      workspaceId,
+      dispatch: dispatchWorkflowRunViaJobs,
+      logContext,
+    });
+  } catch (error) {
+    logger.error({ ...logContext, err: error }, "Response pipeline workflow run enqueue failed");
+  }
 };
 
 const runResponseCreatedSideEffects = async ({

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
@@ -4,12 +4,12 @@ import { prisma } from "@formbricks/database";
 import { PipelineTriggers, Prisma, type Webhook } from "@formbricks/database/prisma";
 import { type JobHandler, type TResponsePipelineJobData, UnrecoverableError } from "@formbricks/jobs";
 import { logger } from "@formbricks/logger";
-import { DatabaseError } from "@formbricks/types/errors";
 import { type TUserLocale, ZUserLocale } from "@formbricks/types/user";
 import { DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS, POSTHOG_KEY } from "@/lib/constants";
 import { generateStandardWebhookSignature } from "@/lib/crypto";
 import { handleFeedbackSourcePipeline } from "@/lib/feedback-source/pipeline-handler";
 import { getIntegrations } from "@/lib/integration/service";
+import { isDatabasePoolExhaustionError } from "@/lib/jobs/pool-exhaustion";
 import { getResponseCountBySurveyId } from "@/lib/response/service";
 import { createPinnedDispatcher, validateAndResolveWebhookUrl } from "@/lib/utils/validate-webhook-url";
 import { queueAuditEventWithoutRequest } from "@/modules/ee/audit-logs/lib/handler";
@@ -112,20 +112,6 @@ const toError = (error: unknown, fallbackMessage: string): Error =>
 const toUserLocale = (locale: string): TUserLocale => {
   const parsedLocale = ZUserLocale.safeParse(locale);
   return parsedLocale.success ? parsedLocale.data : DEFAULT_NOTIFICATION_LOCALE;
-};
-
-export const isPipelinePoolExhaustionError = (error: unknown): boolean => {
-  if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2024") {
-    return true;
-  }
-
-  if (error instanceof DatabaseError || error instanceof Error) {
-    return /Timed out fetching a new connection from the connection pool|connection pool timeout/i.test(
-      error.message
-    );
-  }
-
-  return false;
 };
 
 const createWebhookMessageId = ({
@@ -701,6 +687,12 @@ const runResponseFinishedSideEffects = async ({
       logContext,
     });
   } catch (error) {
+    // Transient DB pool exhaustion must propagate so the job retries (same contract as the outer
+    // pipeline catch); otherwise a completed-response trigger is silently lost. Only non-retryable
+    // failures are swallowed, so they never break the other responseFinished side-effects above.
+    if (isDatabasePoolExhaustionError(error)) {
+      throw error;
+    }
     logger.error({ ...logContext, err: error }, "Response pipeline workflow run enqueue failed");
   }
 };
@@ -819,7 +811,7 @@ export const processResponsePipelineJob: JobHandler<TResponsePipelineJobData> = 
       });
     }
   } catch (error) {
-    if (isPipelinePoolExhaustionError(error)) {
+    if (isDatabasePoolExhaustionError(error)) {
       logger.warn(
         {
           ...logContext,

--- a/apps/web/modules/workflows/lib/runner/dispatch.test.ts
+++ b/apps/web/modules/workflows/lib/runner/dispatch.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test, vi } from "vitest";
+import { dispatchWorkflowRunViaJobs } from "./dispatch";
+
+const { enqueueWorkflowRunJob } = vi.hoisted(() => ({ enqueueWorkflowRunJob: vi.fn() }));
+vi.mock("@formbricks/jobs", () => ({ enqueueWorkflowRunJob }));
+
+describe("dispatchWorkflowRunViaJobs", () => {
+  test("enqueues the run with a deterministic jobId equal to the run id", async () => {
+    enqueueWorkflowRunJob.mockResolvedValue({ id: "job_1" });
+
+    await dispatchWorkflowRunViaJobs({ workflowRunId: "run_1", workflowId: "wf_1", workspaceId: "ws_1" });
+
+    expect(enqueueWorkflowRunJob).toHaveBeenCalledWith(
+      { workflowRunId: "run_1", workflowId: "wf_1", workspaceId: "ws_1" },
+      { jobId: "run_1" }
+    );
+  });
+});

--- a/apps/web/modules/workflows/lib/runner/dispatch.ts
+++ b/apps/web/modules/workflows/lib/runner/dispatch.ts
@@ -1,0 +1,22 @@
+import { enqueueWorkflowRunJob } from "@formbricks/jobs";
+
+export interface WorkflowRunDispatch {
+  workflowRunId: string;
+  workflowId: string;
+  workspaceId: string;
+}
+
+/**
+ * Hands a persisted, `queued` WorkflowRun off to the task backend for processing. The runner depends
+ * only on this port — the WorkflowRun row is the durable, backend-neutral source of truth — so moving
+ * off BullMQ to another backend is a one-file change here, not a rewrite of matching/run-creation.
+ */
+export type DispatchWorkflowRun = (input: WorkflowRunDispatch) => Promise<void>;
+
+/**
+ * BullMQ-backed dispatcher: enqueues `workflow-run.process` with a deterministic `jobId` (the run id)
+ * so a replayed enqueue is idempotent at the queue level (no duplicate job).
+ */
+export const dispatchWorkflowRunViaJobs: DispatchWorkflowRun = async (input) => {
+  await enqueueWorkflowRunJob(input, { jobId: input.workflowRunId });
+};

--- a/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.test.ts
+++ b/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.test.ts
@@ -138,7 +138,7 @@ describe("enqueueResponseCompletedWorkflowRuns", () => {
     expect(error).not.toHaveBeenCalled();
   });
 
-  test("on a unique violation with no findable existing run, neither dispatches nor throws", async () => {
+  test("on a unique violation with no findable existing run, surfaces an error and does not dispatch", async () => {
     findMany.mockResolvedValue([enabledWorkflow("wf_1", "ver_1")]);
     create.mockRejectedValue(
       new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
@@ -150,6 +150,24 @@ describe("enqueueResponseCompletedWorkflowRuns", () => {
 
     await expect(run()).resolves.toBeUndefined();
 
+    expect(dispatch).not.toHaveBeenCalled();
+    // A unique violation with no recoverable run is a contradictory state; surface it, don't hide it.
+    expect(error).toHaveBeenCalled();
+  });
+
+  test("propagates a database error raised during candidate load (does not swallow it before matching)", async () => {
+    findMany.mockRejectedValue(new Error("Timed out fetching a new connection from the connection pool"));
+
+    await expect(run()).rejects.toThrow(/connection pool/i);
+    expect(create).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  test("rethrows a transient pool-exhaustion error raised during run creation so the pipeline can retry", async () => {
+    findMany.mockResolvedValue([enabledWorkflow("wf_1", "ver_1")]);
+    create.mockRejectedValue(new Error("Timed out fetching a new connection from the connection pool"));
+
+    await expect(run()).rejects.toThrow(/connection pool/i);
     expect(dispatch).not.toHaveBeenCalled();
     expect(error).not.toHaveBeenCalled();
   });

--- a/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.test.ts
+++ b/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.test.ts
@@ -138,6 +138,22 @@ describe("enqueueResponseCompletedWorkflowRuns", () => {
     expect(error).not.toHaveBeenCalled();
   });
 
+  test("on a unique violation with no findable existing run, neither dispatches nor throws", async () => {
+    findMany.mockResolvedValue([enabledWorkflow("wf_1", "ver_1")]);
+    create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "test",
+      })
+    );
+    findUnique.mockResolvedValue(null);
+
+    await expect(run()).resolves.toBeUndefined();
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(error).not.toHaveBeenCalled();
+  });
+
   test("isolates a non-unique create failure (logs, does not throw, continues fan-out)", async () => {
     findMany.mockResolvedValue([enabledWorkflow("wf_1", "ver_1"), enabledWorkflow("wf_2", "ver_2")]);
     create.mockRejectedValueOnce(new Error("db down")).mockResolvedValueOnce({ id: "run_2" });

--- a/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.test.ts
+++ b/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.test.ts
@@ -196,4 +196,31 @@ describe("enqueueResponseCompletedWorkflowRuns", () => {
     expect(create).not.toHaveBeenCalled();
     expect(dispatch).not.toHaveBeenCalled();
   });
+
+  test("skips (and logs) a published version with a malformed trigger, still processing the others", async () => {
+    findMany.mockResolvedValue([
+      // No trigger at all — a malformed/corrupt published snapshot.
+      { id: "wf_bad", versions: [{ id: "ver_bad", definition: { schemaVersion: 1, nodes: [], edges: [] } }] },
+      enabledWorkflow("wf_ok", "ver_ok"),
+    ]);
+    create.mockResolvedValue({ id: "run_ok" });
+
+    await run();
+
+    expect(warn).toHaveBeenCalled();
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith({ workflowRunId: "run_ok", workflowId: "wf_ok", workspaceId });
+  });
+
+  test("logs an orphan and does not throw when dispatch fails after the run is persisted", async () => {
+    findMany.mockResolvedValue([enabledWorkflow("wf_1", "ver_1")]);
+    create.mockResolvedValue({ id: "run_1" });
+    dispatch.mockRejectedValue(new Error("redis unavailable"));
+
+    await expect(run()).resolves.toBeUndefined();
+
+    // Attempted once (not retried here), the persisted run is surfaced as an orphan for the reconciler.
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalled();
+  });
 });

--- a/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.test.ts
+++ b/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { Prisma } from "@formbricks/database/prisma";
+import { enqueueResponseCompletedWorkflowRuns } from "./enqueue-response-completed-runs";
+
+const { findMany, create, findUnique } = vi.hoisted(() => ({
+  findMany: vi.fn(),
+  create: vi.fn(),
+  findUnique: vi.fn(),
+}));
+const { warn, error } = vi.hoisted(() => ({ warn: vi.fn(), error: vi.fn() }));
+
+vi.mock("@formbricks/database", () => ({
+  prisma: { workflow: { findMany }, workflowRun: { create, findUnique } },
+}));
+vi.mock("@formbricks/logger", () => ({ logger: { warn, error } }));
+
+const workspaceId = "cm9zr4mps000008l8btfy1vtz";
+const surveyId = "cm9zr4q7i000108l84gozfggr";
+const responseId = "cm9zr4resp0000000000000a1";
+const endingId = "cm9zr4q7i000108l84goze001";
+
+const response = {
+  id: responseId,
+  surveyId,
+  finished: true,
+  endingId,
+  updatedAt: new Date("2026-06-12T09:30:00.000Z"),
+  data: { q1: "answer" },
+};
+
+const definition = (config: { surveyId: string; endingCardIds: string[] }) => ({
+  schemaVersion: 1,
+  trigger: { id: "trigger", type: "trigger", triggerType: "response.completed", config },
+  nodes: [],
+  edges: [],
+  entryNodeId: "trigger",
+});
+
+// One enabled workflow whose published version targets the response's survey (any ending).
+const enabledWorkflow = (workflowId: string, versionId: string, endingCardIds: string[] = []) => ({
+  id: workflowId,
+  versions: [{ id: versionId, definition: definition({ surveyId, endingCardIds }) }],
+});
+
+const dispatch =
+  vi.fn<(input: { workflowRunId: string; workflowId: string; workspaceId: string }) => Promise<void>>();
+
+const run = (input = { response, workspaceId, dispatch }) => enqueueResponseCompletedWorkflowRuns(input);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dispatch.mockResolvedValue(undefined);
+});
+
+describe("enqueueResponseCompletedWorkflowRuns", () => {
+  test("creates a queued run bound to the published version and dispatches it", async () => {
+    findMany.mockResolvedValue([enabledWorkflow("wf_1", "ver_1")]);
+    create.mockResolvedValue({ id: "run_1" });
+
+    await run();
+
+    const data = create.mock.calls[0][0].data;
+    expect(data).toMatchObject({
+      workflowId: "wf_1",
+      workspaceId,
+      workflowVersionId: "ver_1",
+      status: "queued",
+      triggerType: "response.completed",
+      surveyId,
+      responseId,
+      isDryRun: false,
+      attempt: 0,
+      idempotencyKey: responseId,
+    });
+    expect(data.triggerPayload).toMatchObject({
+      type: "response.completed",
+      surveyId,
+      responseId,
+      endingCardId: endingId,
+      triggeredAt: response.updatedAt.toISOString(),
+    });
+    expect(dispatch).toHaveBeenCalledWith({ workflowRunId: "run_1", workflowId: "wf_1", workspaceId });
+  });
+
+  test("does nothing for an unfinished response", async () => {
+    await run({ response: { ...response, finished: false }, workspaceId, dispatch });
+    expect(findMany).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  test("does nothing when no ending card was reached", async () => {
+    await run({ response: { ...response, endingId: null }, workspaceId, dispatch });
+    expect(findMany).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  test("respects the ending-card filter (specific list, miss → no run)", async () => {
+    findMany.mockResolvedValue([enabledWorkflow("wf_1", "ver_1", ["cm9zr4q7i000108l84goze999"])]);
+    await run();
+    expect(create).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  test("skips (and logs) an enabled workflow with no published version", async () => {
+    findMany.mockResolvedValue([{ id: "wf_1", versions: [] }]);
+    await run();
+    expect(warn).toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  test("fans out to every matching workflow", async () => {
+    findMany.mockResolvedValue([enabledWorkflow("wf_1", "ver_1"), enabledWorkflow("wf_2", "ver_2")]);
+    create.mockResolvedValueOnce({ id: "run_1" }).mockResolvedValueOnce({ id: "run_2" });
+
+    await run();
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenCalledWith({ workflowRunId: "run_1", workflowId: "wf_1", workspaceId });
+    expect(dispatch).toHaveBeenCalledWith({ workflowRunId: "run_2", workflowId: "wf_2", workspaceId });
+  });
+
+  test("is idempotent on a unique-constraint violation (replayed pipeline): re-dispatches the existing run", async () => {
+    findMany.mockResolvedValue([enabledWorkflow("wf_1", "ver_1")]);
+    create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "test",
+      })
+    );
+    findUnique.mockResolvedValue({ id: "existing_run" });
+
+    await run();
+
+    expect(dispatch).toHaveBeenCalledWith({ workflowRunId: "existing_run", workflowId: "wf_1", workspaceId });
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  test("isolates a non-unique create failure (logs, does not throw, continues fan-out)", async () => {
+    findMany.mockResolvedValue([enabledWorkflow("wf_1", "ver_1"), enabledWorkflow("wf_2", "ver_2")]);
+    create.mockRejectedValueOnce(new Error("db down")).mockResolvedValueOnce({ id: "run_2" });
+
+    await expect(run()).resolves.toBeUndefined();
+
+    expect(error).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith({ workflowRunId: "run_2", workflowId: "wf_2", workspaceId });
+  });
+
+  test("creates nothing when no workflow matches the survey", async () => {
+    findMany.mockResolvedValue([
+      {
+        id: "wf_other",
+        versions: [
+          { id: "v", definition: definition({ surveyId: "cm9zr4q7i000108l84gozzzzz", endingCardIds: [] }) },
+        ],
+      },
+    ]);
+    await run();
+    expect(create).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.ts
+++ b/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.ts
@@ -1,0 +1,134 @@
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { PrismaErrorType } from "@formbricks/database/types/error";
+import { logger } from "@formbricks/logger";
+import { ZWorkflowTriggerRunPayload } from "@formbricks/workflows";
+import { type DispatchWorkflowRun } from "./dispatch";
+import { type WorkflowMatchCandidate, matchWorkflowsForResponse } from "./match-workflows";
+
+/** The subset of a completed response the runner needs. Structurally satisfied by the response-pipeline payload. */
+interface RunnerResponse {
+  id: string;
+  surveyId: string;
+  finished: boolean;
+  endingId?: string | null;
+  updatedAt: Date;
+  data: Record<string, unknown>;
+}
+
+interface EnqueueResponseCompletedWorkflowRunsInput {
+  response: RunnerResponse;
+  workspaceId: string;
+  dispatch: DispatchWorkflowRun;
+  logContext?: Record<string, unknown>;
+}
+
+const isUniqueConstraintError = (error: unknown): boolean =>
+  error instanceof Prisma.PrismaClientKnownRequestError &&
+  error.code === PrismaErrorType.UniqueConstraintViolation;
+
+/**
+ * Producer half of the workflow runner. On a completed response that reached an ending card, find the
+ * enabled workflows whose current published version targets this survey/ending, persist one `queued`
+ * `WorkflowRun` per match (bound to that published version), and hand each to the injected dispatcher.
+ *
+ * Idempotent: `idempotencyKey = responseId` + `@@unique([workflowId, idempotencyKey])` plus a
+ * deterministic dispatch `jobId` mean a replayed `responseFinished` creates no duplicate runs or jobs.
+ * Each match is isolated so one workflow's failure never blocks the others. The caller wraps the whole
+ * call so a runner failure never affects the response pipeline.
+ */
+export const enqueueResponseCompletedWorkflowRuns = async ({
+  response,
+  workspaceId,
+  dispatch,
+  logContext,
+}: EnqueueResponseCompletedWorkflowRunsInput): Promise<void> => {
+  // Only completed responses that reached an ending card enqueue runs.
+  if (!response.finished || !response.endingId) {
+    return;
+  }
+  const endingId = response.endingId;
+
+  const workflows = await prisma.workflow.findMany({
+    where: { workspaceId, status: "enabled" },
+    select: {
+      id: true,
+      versions: { orderBy: { version: "desc" }, take: 1, select: { id: true, definition: true } },
+    },
+  });
+
+  const candidates: WorkflowMatchCandidate[] = [];
+  for (const workflow of workflows) {
+    const publishedVersion = workflow.versions[0];
+    if (!publishedVersion) {
+      // Enable always publishes a version, so this is a data-integrity guard: never enqueue an
+      // unrunnable run for an enabled workflow that somehow has no published version.
+      logger.warn(
+        { ...logContext, workflowId: workflow.id, workspaceId },
+        "Enabled workflow has no published version; skipping workflow run enqueue"
+      );
+      continue;
+    }
+    candidates.push({
+      workflowId: workflow.id,
+      publishedVersionId: publishedVersion.id,
+      definition: publishedVersion.definition,
+    });
+  }
+
+  const matches = matchWorkflowsForResponse(candidates, { surveyId: response.surveyId, endingId });
+  if (matches.length === 0) {
+    return;
+  }
+
+  // One trigger payload for every matched workflow. `triggeredAt` is derived from `response.updatedAt`
+  // (not wall-clock) so a pipeline retry rebuilds a byte-identical payload.
+  const triggerPayload = ZWorkflowTriggerRunPayload.parse({
+    type: "response.completed",
+    workspaceId,
+    surveyId: response.surveyId,
+    responseId: response.id,
+    endingCardId: endingId,
+    data: response.data,
+    triggeredAt: response.updatedAt.toISOString(),
+  });
+
+  for (const match of matches) {
+    try {
+      const run = await prisma.workflowRun.create({
+        data: {
+          workflowId: match.workflowId,
+          workspaceId,
+          workflowVersionId: match.publishedVersionId,
+          status: "queued",
+          triggerType: "response.completed",
+          surveyId: response.surveyId,
+          responseId: response.id,
+          isDryRun: false,
+          attempt: 0,
+          idempotencyKey: response.id,
+          triggerPayload,
+        },
+        select: { id: true },
+      });
+      await dispatch({ workflowRunId: run.id, workflowId: match.workflowId, workspaceId });
+    } catch (error) {
+      if (isUniqueConstraintError(error)) {
+        // The run already exists from an earlier pipeline pass. Re-dispatch (idempotent via jobId) in
+        // case that pass created the run but failed to enqueue — no duplicate run, no duplicate job.
+        const existing = await prisma.workflowRun.findUnique({
+          where: { workflowId_idempotencyKey: { workflowId: match.workflowId, idempotencyKey: response.id } },
+          select: { id: true },
+        });
+        if (existing) {
+          await dispatch({ workflowRunId: existing.id, workflowId: match.workflowId, workspaceId });
+        }
+        continue;
+      }
+      logger.error(
+        { ...logContext, workflowId: match.workflowId, workspaceId, responseId: response.id, err: error },
+        "Failed to create or dispatch workflow run"
+      );
+    }
+  }
+};

--- a/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.ts
+++ b/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.ts
@@ -2,10 +2,14 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { PrismaErrorType } from "@formbricks/database/types/error";
 import { logger } from "@formbricks/logger";
-import { ZWorkflowTriggerRunPayload } from "@formbricks/workflows";
+import { type TWorkflowTriggerRunPayload, ZWorkflowTriggerRunPayload } from "@formbricks/workflows";
 import { isDatabasePoolExhaustionError } from "@/lib/jobs/pool-exhaustion";
 import { type DispatchWorkflowRun } from "./dispatch";
-import { type WorkflowMatchCandidate, matchWorkflowsForResponse } from "./match-workflows";
+import {
+  type WorkflowMatch,
+  type WorkflowMatchCandidate,
+  matchWorkflowsForResponse,
+} from "./match-workflows";
 
 /** The subset of a completed response the runner needs. Structurally satisfied by the response-pipeline payload. */
 interface RunnerResponse {
@@ -29,6 +33,114 @@ const isUniqueConstraintError = (error: unknown): boolean =>
   error.code === PrismaErrorType.UniqueConstraintViolation;
 
 /**
+ * Load the enabled workflows for a workspace as match candidates, each carrying its current published
+ * version (highest `version`). Enabled workflows with no published version are logged and skipped —
+ * a data-integrity guard, since enable always publishes a version — so we never build an unrunnable run.
+ */
+const loadEnabledWorkflowCandidates = async (
+  workspaceId: string,
+  logContext?: Record<string, unknown>
+): Promise<WorkflowMatchCandidate[]> => {
+  const workflows = await prisma.workflow.findMany({
+    where: { workspaceId, status: "enabled" },
+    select: {
+      id: true,
+      versions: { orderBy: { version: "desc" }, take: 1, select: { id: true, definition: true } },
+    },
+  });
+
+  const candidates: WorkflowMatchCandidate[] = [];
+  for (const workflow of workflows) {
+    const publishedVersion = workflow.versions[0];
+    if (!publishedVersion) {
+      logger.warn(
+        { ...logContext, workflowId: workflow.id, workspaceId },
+        "Enabled workflow has no published version; skipping workflow run enqueue"
+      );
+      continue;
+    }
+    candidates.push({
+      workflowId: workflow.id,
+      publishedVersionId: publishedVersion.id,
+      definition: publishedVersion.definition,
+    });
+  }
+
+  return candidates;
+};
+
+/**
+ * Persist one `queued` `WorkflowRun` for a matched workflow (bound to its published version) and hand it
+ * to the dispatcher. Idempotent: on the `@@unique([workflowId, idempotencyKey])` violation from a
+ * replayed pipeline pass, re-dispatch the existing run (covers "created but not enqueued"); a unique
+ * violation with no findable run is surfaced as a contradictory state. Transient DB pool exhaustion is
+ * rethrown so the pipeline retries the whole (idempotent) enqueue; any other failure is isolated per
+ * workflow (logged, so one bad workflow never blocks the rest).
+ */
+const createAndDispatchWorkflowRun = async ({
+  match,
+  response,
+  workspaceId,
+  triggerPayload,
+  dispatch,
+  logContext,
+}: {
+  match: WorkflowMatch;
+  response: RunnerResponse;
+  workspaceId: string;
+  triggerPayload: TWorkflowTriggerRunPayload;
+  dispatch: DispatchWorkflowRun;
+  logContext?: Record<string, unknown>;
+}): Promise<void> => {
+  try {
+    const run = await prisma.workflowRun.create({
+      data: {
+        workflowId: match.workflowId,
+        workspaceId,
+        workflowVersionId: match.publishedVersionId,
+        status: "queued",
+        triggerType: "response.completed",
+        surveyId: response.surveyId,
+        responseId: response.id,
+        isDryRun: false,
+        attempt: 0,
+        idempotencyKey: response.id,
+        triggerPayload,
+      },
+      select: { id: true },
+    });
+    await dispatch({ workflowRunId: run.id, workflowId: match.workflowId, workspaceId });
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      const existing = await prisma.workflowRun.findUnique({
+        where: { workflowId_idempotencyKey: { workflowId: match.workflowId, idempotencyKey: response.id } },
+        select: { id: true },
+      });
+      if (existing) {
+        await dispatch({ workflowRunId: existing.id, workflowId: match.workflowId, workspaceId });
+      } else {
+        // The unique violation says a run exists, but we can't find it by its idempotency key — a
+        // contradictory state with no run id to dispatch. Surface it rather than silently drop it.
+        logger.error(
+          { ...logContext, workflowId: match.workflowId, workspaceId, responseId: response.id },
+          "Workflow run unique-constraint violation but no existing run found to re-dispatch"
+        );
+      }
+      return;
+    }
+    if (isDatabasePoolExhaustionError(error)) {
+      // Transient DB pool exhaustion: propagate so the pipeline retries the whole (idempotent)
+      // enqueue rather than swallow it and silently drop this workflow's run.
+      throw error;
+    }
+    logger.error(
+      { ...logContext, workflowId: match.workflowId, workspaceId, responseId: response.id, err: error },
+      "Failed to create or dispatch workflow run"
+    );
+  }
+};
+
+/**
  * Producer half of the workflow runner. On a completed response that reached an ending card, find the
  * enabled workflows whose current published version targets this survey/ending, persist one `queued`
  * `WorkflowRun` per match (bound to that published version), and hand each to the injected dispatcher.
@@ -50,33 +162,7 @@ export const enqueueResponseCompletedWorkflowRuns = async ({
   }
   const endingId = response.endingId;
 
-  const workflows = await prisma.workflow.findMany({
-    where: { workspaceId, status: "enabled" },
-    select: {
-      id: true,
-      versions: { orderBy: { version: "desc" }, take: 1, select: { id: true, definition: true } },
-    },
-  });
-
-  const candidates: WorkflowMatchCandidate[] = [];
-  for (const workflow of workflows) {
-    const publishedVersion = workflow.versions[0];
-    if (!publishedVersion) {
-      // Enable always publishes a version, so this is a data-integrity guard: never enqueue an
-      // unrunnable run for an enabled workflow that somehow has no published version.
-      logger.warn(
-        { ...logContext, workflowId: workflow.id, workspaceId },
-        "Enabled workflow has no published version; skipping workflow run enqueue"
-      );
-      continue;
-    }
-    candidates.push({
-      workflowId: workflow.id,
-      publishedVersionId: publishedVersion.id,
-      definition: publishedVersion.definition,
-    });
-  }
-
+  const candidates = await loadEnabledWorkflowCandidates(workspaceId, logContext);
   const matches = matchWorkflowsForResponse(candidates, { surveyId: response.surveyId, endingId });
   if (matches.length === 0) {
     return;
@@ -95,53 +181,13 @@ export const enqueueResponseCompletedWorkflowRuns = async ({
   });
 
   for (const match of matches) {
-    try {
-      const run = await prisma.workflowRun.create({
-        data: {
-          workflowId: match.workflowId,
-          workspaceId,
-          workflowVersionId: match.publishedVersionId,
-          status: "queued",
-          triggerType: "response.completed",
-          surveyId: response.surveyId,
-          responseId: response.id,
-          isDryRun: false,
-          attempt: 0,
-          idempotencyKey: response.id,
-          triggerPayload,
-        },
-        select: { id: true },
-      });
-      await dispatch({ workflowRunId: run.id, workflowId: match.workflowId, workspaceId });
-    } catch (error) {
-      if (isUniqueConstraintError(error)) {
-        // The run already exists from an earlier pipeline pass. Re-dispatch (idempotent via jobId) in
-        // case that pass created the run but failed to enqueue — no duplicate run, no duplicate job.
-        const existing = await prisma.workflowRun.findUnique({
-          where: { workflowId_idempotencyKey: { workflowId: match.workflowId, idempotencyKey: response.id } },
-          select: { id: true },
-        });
-        if (existing) {
-          await dispatch({ workflowRunId: existing.id, workflowId: match.workflowId, workspaceId });
-        } else {
-          // The unique violation says a run exists, but we can't find it by its idempotency key — a
-          // contradictory state with no run id to dispatch. Surface it rather than silently drop it.
-          logger.error(
-            { ...logContext, workflowId: match.workflowId, workspaceId, responseId: response.id },
-            "Workflow run unique-constraint violation but no existing run found to re-dispatch"
-          );
-        }
-        continue;
-      }
-      if (isDatabasePoolExhaustionError(error)) {
-        // Transient DB pool exhaustion: propagate so the pipeline retries the whole (idempotent)
-        // enqueue rather than swallow it and silently drop this workflow's run.
-        throw error;
-      }
-      logger.error(
-        { ...logContext, workflowId: match.workflowId, workspaceId, responseId: response.id, err: error },
-        "Failed to create or dispatch workflow run"
-      );
-    }
+    await createAndDispatchWorkflowRun({
+      match,
+      response,
+      workspaceId,
+      triggerPayload,
+      dispatch,
+      logContext,
+    });
   }
 };

--- a/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.ts
+++ b/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.ts
@@ -9,6 +9,7 @@ import {
   type WorkflowMatch,
   type WorkflowMatchCandidate,
   matchWorkflowsForResponse,
+  readResponseCompletedTriggerConfig,
 } from "./match-workflows";
 
 /** The subset of a completed response the runner needs. Structurally satisfied by the response-pipeline payload. */
@@ -34,8 +35,10 @@ const isUniqueConstraintError = (error: unknown): boolean =>
 
 /**
  * Load the enabled workflows for a workspace as match candidates, each carrying its current published
- * version (highest `version`). Enabled workflows with no published version are logged and skipped —
- * a data-integrity guard, since enable always publishes a version — so we never build an unrunnable run.
+ * version (highest `version`). Skips (and logs) two unrunnable cases so they never reach matching:
+ * an enabled workflow with no published version (enable always publishes one — a data-integrity guard),
+ * and a published version whose definition has no usable `response.completed` trigger (a malformed or
+ * corrupt snapshot — the definition is unvalidated DB JSON).
  */
 const loadEnabledWorkflowCandidates = async (
   workspaceId: string,
@@ -59,6 +62,13 @@ const loadEnabledWorkflowCandidates = async (
       );
       continue;
     }
+    if (!readResponseCompletedTriggerConfig(publishedVersion.definition)) {
+      logger.warn(
+        { ...logContext, workflowId: workflow.id, workspaceId, workflowVersionId: publishedVersion.id },
+        "Published workflow version has no usable response.completed trigger; skipping workflow run enqueue"
+      );
+      continue;
+    }
     candidates.push({
       workflowId: workflow.id,
       publishedVersionId: publishedVersion.id,
@@ -70,28 +80,25 @@ const loadEnabledWorkflowCandidates = async (
 };
 
 /**
- * Persist one `queued` `WorkflowRun` for a matched workflow (bound to its published version) and hand it
- * to the dispatcher. Idempotent: on the `@@unique([workflowId, idempotencyKey])` violation from a
- * replayed pipeline pass, re-dispatch the existing run (covers "created but not enqueued"); a unique
- * violation with no findable run is surfaced as a contradictory state. Transient DB pool exhaustion is
- * rethrown so the pipeline retries the whole (idempotent) enqueue; any other failure is isolated per
- * workflow (logged, so one bad workflow never blocks the rest).
+ * Persist one `queued` `WorkflowRun` for a matched workflow (bound to its published version) and return
+ * its id. Idempotent: on the `@@unique([workflowId, idempotencyKey])` violation from a replayed pipeline
+ * pass, returns the run already created on an earlier pass; a unique violation with no findable run is a
+ * contradictory state and is surfaced. Transient DB pool exhaustion is rethrown so the pipeline retries
+ * the whole (idempotent) enqueue; any other create failure is isolated per workflow (logged → null).
  */
-const createAndDispatchWorkflowRun = async ({
+const persistQueuedRun = async ({
   match,
   response,
   workspaceId,
   triggerPayload,
-  dispatch,
   logContext,
 }: {
   match: WorkflowMatch;
   response: RunnerResponse;
   workspaceId: string;
   triggerPayload: TWorkflowTriggerRunPayload;
-  dispatch: DispatchWorkflowRun;
   logContext?: Record<string, unknown>;
-}): Promise<void> => {
+}): Promise<string | null> => {
   try {
     const run = await prisma.workflowRun.create({
       data: {
@@ -109,33 +116,76 @@ const createAndDispatchWorkflowRun = async ({
       },
       select: { id: true },
     });
-    await dispatch({ workflowRunId: run.id, workflowId: match.workflowId, workspaceId });
+    return run.id;
   } catch (error) {
     if (isUniqueConstraintError(error)) {
       const existing = await prisma.workflowRun.findUnique({
         where: { workflowId_idempotencyKey: { workflowId: match.workflowId, idempotencyKey: response.id } },
         select: { id: true },
       });
-      if (existing) {
-        await dispatch({ workflowRunId: existing.id, workflowId: match.workflowId, workspaceId });
-      } else {
-        // The unique violation says a run exists, but we can't find it by its idempotency key — a
-        // contradictory state with no run id to dispatch. Surface it rather than silently drop it.
-        logger.error(
-          { ...logContext, workflowId: match.workflowId, workspaceId, responseId: response.id },
-          "Workflow run unique-constraint violation but no existing run found to re-dispatch"
-        );
-      }
-      return;
+      if (existing) return existing.id;
+      // The unique violation says a run exists, but we can't find it by its idempotency key — a
+      // contradictory state with no run id to dispatch. Surface it rather than silently drop it.
+      logger.error(
+        { ...logContext, workflowId: match.workflowId, workspaceId, responseId: response.id },
+        "Workflow run unique-constraint violation but no existing run found to re-dispatch"
+      );
+      return null;
     }
     if (isDatabasePoolExhaustionError(error)) {
-      // Transient DB pool exhaustion: propagate so the pipeline retries the whole (idempotent)
-      // enqueue rather than swallow it and silently drop this workflow's run.
+      // Transient DB pool exhaustion: propagate so the pipeline retries the whole (idempotent) enqueue.
       throw error;
     }
     logger.error(
       { ...logContext, workflowId: match.workflowId, workspaceId, responseId: response.id, err: error },
-      "Failed to create or dispatch workflow run"
+      "Failed to persist workflow run"
+    );
+    return null;
+  }
+};
+
+/**
+ * Persist a `queued` `WorkflowRun` for a matched workflow and hand it to the dispatcher.
+ *
+ * If `dispatch` fails after the row is persisted, the run is left `queued` with no backing job — an
+ * orphan. We log it distinctly (so it is alertable) and swallow rather than rethrow: rethrowing would
+ * retry the whole response-pipeline job and re-run its other side-effects (webhooks, follow-ups,
+ * notifications). The durable run row plus the `status` / `nextAttemptAt` indexes exist precisely so a
+ * reconciler can re-dispatch orphaned runs; that reconciler is tracked separately (out of scope here).
+ */
+const createAndDispatchWorkflowRun = async ({
+  match,
+  response,
+  workspaceId,
+  triggerPayload,
+  dispatch,
+  logContext,
+}: {
+  match: WorkflowMatch;
+  response: RunnerResponse;
+  workspaceId: string;
+  triggerPayload: TWorkflowTriggerRunPayload;
+  dispatch: DispatchWorkflowRun;
+  logContext?: Record<string, unknown>;
+}): Promise<void> => {
+  const workflowRunId = await persistQueuedRun({ match, response, workspaceId, triggerPayload, logContext });
+  if (!workflowRunId) {
+    return;
+  }
+
+  try {
+    await dispatch({ workflowRunId, workflowId: match.workflowId, workspaceId });
+  } catch (error) {
+    logger.error(
+      {
+        ...logContext,
+        workflowId: match.workflowId,
+        workspaceId,
+        responseId: response.id,
+        workflowRunId,
+        err: error,
+      },
+      "Workflow run persisted but dispatch failed; queued run is orphaned until the reconciler re-dispatches it"
     );
   }
 };

--- a/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.ts
+++ b/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@formbricks/database/prisma";
 import { PrismaErrorType } from "@formbricks/database/types/error";
 import { logger } from "@formbricks/logger";
 import { ZWorkflowTriggerRunPayload } from "@formbricks/workflows";
+import { isDatabasePoolExhaustionError } from "@/lib/jobs/pool-exhaustion";
 import { type DispatchWorkflowRun } from "./dispatch";
 import { type WorkflowMatchCandidate, matchWorkflowsForResponse } from "./match-workflows";
 
@@ -122,8 +123,20 @@ export const enqueueResponseCompletedWorkflowRuns = async ({
         });
         if (existing) {
           await dispatch({ workflowRunId: existing.id, workflowId: match.workflowId, workspaceId });
+        } else {
+          // The unique violation says a run exists, but we can't find it by its idempotency key — a
+          // contradictory state with no run id to dispatch. Surface it rather than silently drop it.
+          logger.error(
+            { ...logContext, workflowId: match.workflowId, workspaceId, responseId: response.id },
+            "Workflow run unique-constraint violation but no existing run found to re-dispatch"
+          );
         }
         continue;
+      }
+      if (isDatabasePoolExhaustionError(error)) {
+        // Transient DB pool exhaustion: propagate so the pipeline retries the whole (idempotent)
+        // enqueue rather than swallow it and silently drop this workflow's run.
+        throw error;
       }
       logger.error(
         { ...logContext, workflowId: match.workflowId, workspaceId, responseId: response.id, err: error },

--- a/apps/web/modules/workflows/lib/runner/match-workflows.test.ts
+++ b/apps/web/modules/workflows/lib/runner/match-workflows.test.ts
@@ -61,4 +61,39 @@ describe("matchWorkflowsForResponse", () => {
   test("returns nothing for no candidates", () => {
     expect(matchWorkflowsForResponse([], { surveyId: SURVEY, endingId: ENDING_A })).toEqual([]);
   });
+
+  test("does not match (and does not throw) a malformed definition with no trigger", () => {
+    const candidate = {
+      workflowId: "wf_bad",
+      publishedVersionId: "v",
+      definition: { schemaVersion: 1, nodes: [], edges: [] } as unknown as TWorkflowExecutableDefinition,
+    };
+    expect(matchWorkflowsForResponse([candidate], { surveyId: SURVEY, endingId: ENDING_A })).toEqual([]);
+  });
+
+  test("does not match (and does not throw) a trigger missing its config", () => {
+    const candidate = {
+      workflowId: "wf_bad",
+      publishedVersionId: "v",
+      definition: {
+        schemaVersion: 1,
+        trigger: { id: "t", type: "trigger", triggerType: "response.completed" },
+        nodes: [],
+        edges: [],
+        entryNodeId: "t",
+      } as unknown as TWorkflowExecutableDefinition,
+    };
+    expect(matchWorkflowsForResponse([candidate], { surveyId: SURVEY, endingId: ENDING_A })).toEqual([]);
+  });
+
+  test("a malformed candidate never blocks matching of a valid one", () => {
+    const malformed = {
+      workflowId: "wf_bad",
+      publishedVersionId: "vb",
+      definition: {} as unknown as TWorkflowExecutableDefinition,
+    };
+    const valid = makeCandidate("wf_ok", { surveyId: SURVEY, endingCardIds: [] });
+    const result = matchWorkflowsForResponse([malformed, valid], { surveyId: SURVEY, endingId: ENDING_A });
+    expect(result.map((m) => m.workflowId)).toEqual(["wf_ok"]);
+  });
 });

--- a/apps/web/modules/workflows/lib/runner/match-workflows.test.ts
+++ b/apps/web/modules/workflows/lib/runner/match-workflows.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import type { TWorkflowExecutableDefinition } from "@formbricks/workflows";
+import { type WorkflowMatchCandidate, matchWorkflowsForResponse } from "./match-workflows";
+
+const SURVEY = "cm9zr4q7i000108l84gozfggr";
+const OTHER_SURVEY = "cm9zr4q7i000108l84gozzzzz";
+const ENDING_A = "cm9zr4q7i000108l84goze001";
+const ENDING_B = "cm9zr4q7i000108l84goze002";
+
+const makeCandidate = (
+  workflowId: string,
+  config: { surveyId: string; endingCardIds: string[] }
+): WorkflowMatchCandidate => ({
+  workflowId,
+  publishedVersionId: `${workflowId}-v`,
+  definition: {
+    schemaVersion: 1,
+    trigger: { id: "trigger", type: "trigger", triggerType: "response.completed", config },
+    nodes: [],
+    edges: [],
+    entryNodeId: "trigger",
+  } as TWorkflowExecutableDefinition,
+});
+
+describe("matchWorkflowsForResponse", () => {
+  test("empty endingCardIds matches any ending of the same survey", () => {
+    const candidate = makeCandidate("wf_any", { surveyId: SURVEY, endingCardIds: [] });
+    const result = matchWorkflowsForResponse([candidate], { surveyId: SURVEY, endingId: ENDING_A });
+    expect(result).toEqual([{ workflowId: "wf_any", publishedVersionId: "wf_any-v" }]);
+  });
+
+  test("specific endingCardIds match only when the reached ending is listed", () => {
+    const candidate = makeCandidate("wf_specific", { surveyId: SURVEY, endingCardIds: [ENDING_A] });
+    expect(matchWorkflowsForResponse([candidate], { surveyId: SURVEY, endingId: ENDING_A })).toHaveLength(1);
+    expect(matchWorkflowsForResponse([candidate], { surveyId: SURVEY, endingId: ENDING_B })).toHaveLength(0);
+  });
+
+  test("does not match a different survey", () => {
+    const candidate = makeCandidate("wf", { surveyId: OTHER_SURVEY, endingCardIds: [] });
+    expect(matchWorkflowsForResponse([candidate], { surveyId: SURVEY, endingId: ENDING_A })).toHaveLength(0);
+  });
+
+  test("does not match a non-response.completed trigger (future trigger types)", () => {
+    const candidate = makeCandidate("wf", { surveyId: SURVEY, endingCardIds: [] });
+    // Force a different triggerType to exercise the guard (only response.completed exists today).
+    (candidate.definition.trigger as { triggerType: string }).triggerType = "other.trigger";
+    expect(matchWorkflowsForResponse([candidate], { surveyId: SURVEY, endingId: ENDING_A })).toHaveLength(0);
+  });
+
+  test("fans out to every matching workflow and skips the non-matching ones", () => {
+    const candidates = [
+      makeCandidate("wf_any", { surveyId: SURVEY, endingCardIds: [] }),
+      makeCandidate("wf_hit", { surveyId: SURVEY, endingCardIds: [ENDING_A] }),
+      makeCandidate("wf_miss", { surveyId: SURVEY, endingCardIds: [ENDING_B] }),
+      makeCandidate("wf_other_survey", { surveyId: OTHER_SURVEY, endingCardIds: [] }),
+    ];
+    const result = matchWorkflowsForResponse(candidates, { surveyId: SURVEY, endingId: ENDING_A });
+    expect(result.map((m) => m.workflowId)).toEqual(["wf_any", "wf_hit"]);
+  });
+
+  test("returns nothing for no candidates", () => {
+    expect(matchWorkflowsForResponse([], { surveyId: SURVEY, endingId: ENDING_A })).toEqual([]);
+  });
+});

--- a/apps/web/modules/workflows/lib/runner/match-workflows.ts
+++ b/apps/web/modules/workflows/lib/runner/match-workflows.ts
@@ -18,12 +18,40 @@ export interface ResponseMatchInput {
   endingId: string;
 }
 
+/** Loose view of a trigger node: the published definition is persisted DB JSON, branded as
+ * `TWorkflowExecutableDefinition` but never parsed on read, so it must be treated as untrusted. */
+interface LooseTriggerNode {
+  triggerType?: string;
+  config?: { surveyId?: unknown; endingCardIds?: unknown };
+}
+
+/**
+ * Reads the `response.completed` trigger config from a published definition. Because the definition is
+ * unvalidated DB JSON, this is **total**: it returns `null` (never throws) when the snapshot is
+ * malformed or isn't a `response.completed` trigger, so a single bad version skips its own workflow
+ * instead of throwing and aborting matching for every workflow on the response.
+ */
+export const readResponseCompletedTriggerConfig = (
+  definition: TWorkflowExecutableDefinition
+): { surveyId: string; endingCardIds: string[] } | null => {
+  const trigger = (definition as { trigger?: LooseTriggerNode }).trigger;
+  if (trigger?.triggerType !== WORKFLOW_TRIGGERS.RESPONSE_COMPLETED) return null;
+
+  const surveyId = trigger.config?.surveyId;
+  const endingCardIds = trigger.config?.endingCardIds;
+  if (typeof surveyId !== "string" || !Array.isArray(endingCardIds)) return null;
+  if (!endingCardIds.every((id): id is string => typeof id === "string")) return null;
+
+  return { surveyId, endingCardIds };
+};
+
 /**
  * Pure matcher: from the candidate enabled workflows (each carrying its current published version's
  * definition), return those whose `response.completed` trigger fires for this completed response —
  * the trigger targets the response's survey and its ending filter passes (empty `endingCardIds` means
  * "any ending", otherwise the reached `endingId` must be listed). No I/O, so it's exhaustively
- * table-testable. Matching reads the published snapshot, never the mutable draft.
+ * table-testable. Reads the published snapshot (never the mutable draft) and is total over malformed
+ * definitions (a bad one simply doesn't match).
  */
 export const matchWorkflowsForResponse = (
   candidates: WorkflowMatchCandidate[],
@@ -31,12 +59,8 @@ export const matchWorkflowsForResponse = (
 ): WorkflowMatch[] =>
   candidates
     .filter(({ definition }) => {
-      const { trigger } = definition;
-      if (trigger.triggerType !== WORKFLOW_TRIGGERS.RESPONSE_COMPLETED) return false;
-
-      const { surveyId: triggerSurveyId, endingCardIds } = trigger.config;
-      if (triggerSurveyId !== surveyId) return false;
-
-      return endingCardIds.length === 0 || endingCardIds.includes(endingId);
+      const config = readResponseCompletedTriggerConfig(definition);
+      if (!config || config.surveyId !== surveyId) return false;
+      return config.endingCardIds.length === 0 || config.endingCardIds.includes(endingId);
     })
     .map(({ workflowId, publishedVersionId }) => ({ workflowId, publishedVersionId }));

--- a/apps/web/modules/workflows/lib/runner/match-workflows.ts
+++ b/apps/web/modules/workflows/lib/runner/match-workflows.ts
@@ -60,7 +60,8 @@ export const matchWorkflowsForResponse = (
   candidates
     .filter(({ definition }) => {
       const config = readResponseCompletedTriggerConfig(definition);
-      if (!config || config.surveyId !== surveyId) return false;
+      if (!config) return false;
+      if (config.surveyId !== surveyId) return false;
       return config.endingCardIds.length === 0 || config.endingCardIds.includes(endingId);
     })
     .map(({ workflowId, publishedVersionId }) => ({ workflowId, publishedVersionId }));

--- a/apps/web/modules/workflows/lib/runner/match-workflows.ts
+++ b/apps/web/modules/workflows/lib/runner/match-workflows.ts
@@ -1,0 +1,42 @@
+import { WORKFLOW_TRIGGERS } from "@formbricks/workflows";
+import type { TWorkflowExecutableDefinition } from "@formbricks/workflows";
+
+/** An enabled workflow with its current published version's executable definition. */
+export interface WorkflowMatchCandidate {
+  workflowId: string;
+  publishedVersionId: string;
+  definition: TWorkflowExecutableDefinition;
+}
+
+export interface WorkflowMatch {
+  workflowId: string;
+  publishedVersionId: string;
+}
+
+export interface ResponseMatchInput {
+  surveyId: string;
+  endingId: string;
+}
+
+/**
+ * Pure matcher: from the candidate enabled workflows (each carrying its current published version's
+ * definition), return those whose `response.completed` trigger fires for this completed response —
+ * the trigger targets the response's survey and its ending filter passes (empty `endingCardIds` means
+ * "any ending", otherwise the reached `endingId` must be listed). No I/O, so it's exhaustively
+ * table-testable. Matching reads the published snapshot, never the mutable draft.
+ */
+export const matchWorkflowsForResponse = (
+  candidates: WorkflowMatchCandidate[],
+  { surveyId, endingId }: ResponseMatchInput
+): WorkflowMatch[] =>
+  candidates
+    .filter(({ definition }) => {
+      const { trigger } = definition;
+      if (trigger.triggerType !== WORKFLOW_TRIGGERS.RESPONSE_COMPLETED) return false;
+
+      const { surveyId: triggerSurveyId, endingCardIds } = trigger.config;
+      if (triggerSurveyId !== surveyId) return false;
+
+      return endingCardIds.length === 0 || endingCardIds.includes(endingId);
+    })
+    .map(({ workflowId, publishedVersionId }) => ({ workflowId, publishedVersionId }));

--- a/packages/jobs/src/constants.ts
+++ b/packages/jobs/src/constants.ts
@@ -7,6 +7,7 @@ export const JOB_NAMES = {
   testLog: "system.test-log",
   responsePipeline: "response-pipeline.process",
   surveyScheduling: "survey-scheduling.reconcile",
+  workflowRun: "workflow-run.process",
 } as const;
 
 const JOBS_DEFAULT_BACKOFF = Object.freeze({

--- a/packages/jobs/src/contracts.ts
+++ b/packages/jobs/src/contracts.ts
@@ -4,7 +4,12 @@ import type {
   TRecurringBackgroundJobSchedule,
   TRunAtBackgroundJobSchedule,
 } from "@/src/schedules";
-import type { TResponsePipelineJobData, TSurveySchedulingJobData, TTestLogJobData } from "@/src/types";
+import type {
+  TResponsePipelineJobData,
+  TSurveySchedulingJobData,
+  TTestLogJobData,
+  TWorkflowRunJobData,
+} from "@/src/types";
 
 export interface JobExecutionContext {
   attempt: number;
@@ -55,6 +60,7 @@ export interface BackgroundJobProducer {
   enqueueResponsePipeline: (data: TResponsePipelineJobData) => Promise<EnqueuedJob>;
   enqueueSurveyScheduling: (data: TSurveySchedulingJobData) => Promise<EnqueuedJob>;
   enqueueTestLog: (data: TTestLogJobData) => Promise<EnqueuedJob>;
+  enqueueWorkflowRun: (data: TWorkflowRunJobData, options?: { jobId: string }) => Promise<EnqueuedJob>;
   scheduleResponsePipelineAt: (
     schedule: TRunAtBackgroundJobSchedule,
     data: TResponsePipelineJobData

--- a/packages/jobs/src/definitions.ts
+++ b/packages/jobs/src/definitions.ts
@@ -3,7 +3,13 @@ import { type AnyBackgroundJobDefinition, toAnyBackgroundJobDefinition } from "@
 import { processResponsePipelineJob } from "@/src/processors/response-pipeline";
 import { processSurveySchedulingJob } from "@/src/processors/survey-scheduling";
 import { processTestLogJob } from "@/src/processors/test-log";
-import { ZResponsePipelineJobData, ZSurveySchedulingJobData, ZTestLogJobData } from "@/src/types";
+import { processWorkflowRunJob } from "@/src/processors/workflow-run";
+import {
+  ZResponsePipelineJobData,
+  ZSurveySchedulingJobData,
+  ZTestLogJobData,
+  ZWorkflowRunJobData,
+} from "@/src/types";
 
 export const backgroundJobDefinitions = {
   [JOB_NAMES.responsePipeline]: toAnyBackgroundJobDefinition({
@@ -20,6 +26,11 @@ export const backgroundJobDefinitions = {
     handle: processTestLogJob,
     name: JOB_NAMES.testLog,
     schema: ZTestLogJobData,
+  }),
+  [JOB_NAMES.workflowRun]: toAnyBackgroundJobDefinition({
+    handle: processWorkflowRunJob,
+    name: JOB_NAMES.workflowRun,
+    schema: ZWorkflowRunJobData,
   }),
 } as const satisfies Record<string, AnyBackgroundJobDefinition>;
 

--- a/packages/jobs/src/index.ts
+++ b/packages/jobs/src/index.ts
@@ -12,6 +12,7 @@ export {
   enqueueResponsePipelineJob,
   enqueueSurveySchedulingJob,
   enqueueTestLogJob,
+  enqueueWorkflowRunJob,
   getBackgroundJobProducer,
   removeRecurringSurveySchedulingJobSchedule,
   scheduleResponsePipelineJobAt,
@@ -22,6 +23,7 @@ export {
   upsertRecurringTestLogJobSchedule,
 } from "./queue";
 export { processResponsePipelineJob } from "./processors/response-pipeline";
+export { processWorkflowRunJob } from "./processors/workflow-run";
 export { processSurveySchedulingJob } from "./processors/survey-scheduling";
 export { processTestLogJob } from "./processors/test-log";
 export { startJobsRuntime } from "./runtime";
@@ -49,11 +51,13 @@ export {
   ZResponsePipelineJobData,
   ZSurveySchedulingJobData,
   ZTestLogJobData,
+  ZWorkflowRunJobData,
 } from "./types";
 export type {
   TResponsePipelineEvent,
   TResponsePipelineJobData,
   TSurveySchedulingJobData,
   TTestLogJobData,
+  TWorkflowRunJobData,
 } from "./types";
 /* v8 ignore stop */

--- a/packages/jobs/src/processors.test.ts
+++ b/packages/jobs/src/processors.test.ts
@@ -27,6 +27,7 @@ describe("@formbricks/jobs processor registry", () => {
     expect(getJobProcessor(JOB_NAMES.testLog)).toBeDefined();
     expect(getJobProcessor(JOB_NAMES.responsePipeline)).toBeDefined();
     expect(getJobProcessor(JOB_NAMES.surveyScheduling)).toBeDefined();
+    expect(getJobProcessor(JOB_NAMES.workflowRun)).toBeDefined();
     expect(getBackgroundJobDefinition(JOB_NAMES.testLog)).toBeDefined();
   });
 
@@ -91,6 +92,34 @@ describe("@formbricks/jobs processor registry", () => {
         surveyId: "cm8cmpnjj000108jfdr9dfqe7",
       }),
       "BullMQ response pipeline processor override is not registered"
+    );
+  });
+
+  test("fails fast for the unimplemented workflow run processor", async () => {
+    await expect(
+      processJob({
+        attemptsMade: 0,
+        data: {
+          workflowRunId: "cm8cmpnjj000108jfdr9wrun1",
+          workflowId: "cm8cmpnjj000108jfdr9wflo1",
+          workspaceId: "cm8cmpnjj000108jfdr9wksp1",
+        },
+        id: "job-wf",
+        name: JOB_NAMES.workflowRun,
+        opts: { attempts: 1 },
+        queueName: "background-jobs",
+      } as never)
+    ).rejects.toThrow("BullMQ workflow run processor override missing");
+
+    expect(mockError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowRunId: "cm8cmpnjj000108jfdr9wrun1",
+        workflowId: "cm8cmpnjj000108jfdr9wflo1",
+        workspaceId: "cm8cmpnjj000108jfdr9wksp1",
+        jobId: "job-wf",
+        jobName: JOB_NAMES.workflowRun,
+      }),
+      "BullMQ workflow run processor override is not registered"
     );
   });
 

--- a/packages/jobs/src/processors/workflow-run.ts
+++ b/packages/jobs/src/processors/workflow-run.ts
@@ -1,0 +1,27 @@
+import { logger } from "@formbricks/logger";
+import type { JobHandler } from "@/src/contracts";
+import type { TWorkflowRunJobData } from "@/src/types";
+
+/**
+ * Default handle for `workflow-run.process`. Run execution lives in `apps/web` and is registered as a
+ * runtime override (ENG-1228); this fallback only runs when no override is wired, so it logs and
+ * throws rather than silently dropping the run. Mirrors the response-pipeline fallback processor.
+ */
+export const processWorkflowRunJob: JobHandler<TWorkflowRunJobData> = (data, context) => {
+  logger.error(
+    {
+      attempt: context.attempt,
+      workflowRunId: data.workflowRunId,
+      workflowId: data.workflowId,
+      workspaceId: data.workspaceId,
+      jobId: context.jobId,
+      jobName: context.jobName,
+      queueName: context.queueName,
+    },
+    "BullMQ workflow run processor override is not registered"
+  );
+
+  throw new Error(
+    `BullMQ workflow run processor override missing for job ${context.jobId} (${data.workspaceId}/${data.workflowRunId})`
+  );
+};

--- a/packages/jobs/src/queue.test.ts
+++ b/packages/jobs/src/queue.test.ts
@@ -13,6 +13,7 @@ import {
   enqueueResponsePipelineJob,
   enqueueSurveySchedulingJob,
   enqueueTestLogJob,
+  enqueueWorkflowRunJob,
   getBackgroundJobProducer,
   getJobsQueue,
   removeRecurringSurveySchedulingJobSchedule,
@@ -76,6 +77,12 @@ const responsePipelineJobData = {
 
 const surveySchedulingJobData = {
   scope: "global" as const,
+};
+
+const workflowRunJobData = {
+  workflowRunId: "cm8cmpnjj000108jfdr9wrun1",
+  workflowId: "cm8cmpnjj000108jfdr9wflo1",
+  workspaceId: "cm8cmpnjj000108jfdr9wksp1",
 };
 
 vi.mock("@formbricks/logger", () => ({
@@ -172,6 +179,19 @@ describe("@formbricks/jobs queue helpers", () => {
 
     expect(job).toBe(mockJob);
     expect(mockQueueAdd).toHaveBeenCalledWith(JOB_NAMES.surveyScheduling, surveySchedulingJobData, undefined);
+  });
+
+  test("enqueues the workflow run job with attempts:1 and a deterministic jobId", async () => {
+    const mockJob = { id: "job-workflow-run-1" };
+    mockQueueAdd.mockResolvedValue(mockJob);
+
+    const job = await enqueueWorkflowRunJob(workflowRunJobData, { jobId: workflowRunJobData.workflowRunId });
+
+    expect(job).toBe(mockJob);
+    expect(mockQueueAdd).toHaveBeenCalledWith(JOB_NAMES.workflowRun, workflowRunJobData, {
+      attempts: 1,
+      jobId: workflowRunJobData.workflowRunId,
+    });
   });
 
   test("exposes an engine-neutral producer interface", async () => {

--- a/packages/jobs/src/queue.ts
+++ b/packages/jobs/src/queue.ts
@@ -23,6 +23,7 @@ import {
   type TResponsePipelineJobData,
   type TSurveySchedulingJobData,
   type TTestLogJobData,
+  type TWorkflowRunJobData,
 } from "@/src/types";
 
 export interface JobsQueueHandle {
@@ -241,6 +242,26 @@ export const enqueueSurveySchedulingJob = async (data: TSurveySchedulingJobData)
   }
 };
 
+export const enqueueWorkflowRunJob = async (
+  data: TWorkflowRunJobData,
+  options?: { jobId: string }
+): Promise<Job> => {
+  try {
+    // Run-level retry/backoff is modelled on the WorkflowRun row, so override the BullMQ default of 3
+    // attempts to 1. A deterministic jobId (the run id) makes a re-enqueue idempotent (no duplicate job).
+    return await enqueueBackgroundJob(JOB_NAMES.workflowRun, data, {
+      attempts: 1,
+      ...(options?.jobId ? { jobId: options.jobId } : {}),
+    });
+  } catch (error) {
+    logger.error(
+      { err: error, jobName: JOB_NAMES.workflowRun, workflowRunId: data.workflowRunId },
+      "Failed to enqueue BullMQ workflow run job"
+    );
+    throw error;
+  }
+};
+
 export const scheduleTestLogJobAt = async (
   schedule: TRunAtBackgroundJobSchedule,
   data: TTestLogJobData
@@ -375,6 +396,7 @@ export const getBackgroundJobProducer = (): BackgroundJobProducer => ({
   enqueueResponsePipeline: async (data) => toEnqueuedJob(await enqueueResponsePipelineJob(data)),
   enqueueSurveyScheduling: async (data) => toEnqueuedJob(await enqueueSurveySchedulingJob(data)),
   enqueueTestLog: async (data) => toEnqueuedJob(await enqueueTestLogJob(data)),
+  enqueueWorkflowRun: async (data, options) => toEnqueuedJob(await enqueueWorkflowRunJob(data, options)),
   scheduleResponsePipelineAt: async (schedule, data) =>
     toEnqueuedJob(await scheduleResponsePipelineJobAt(schedule, data)),
   scheduleSurveySchedulingAt: async (schedule, data) =>

--- a/packages/jobs/src/types.ts
+++ b/packages/jobs/src/types.ts
@@ -43,3 +43,11 @@ export const ZSurveySchedulingJobData = z.object({
 });
 
 export type TSurveySchedulingJobData = z.infer<typeof ZSurveySchedulingJobData>;
+
+export const ZWorkflowRunJobData = z.object({
+  workflowRunId: z.cuid2(),
+  workflowId: z.cuid2(),
+  workspaceId: z.cuid2(),
+});
+
+export type TWorkflowRunJobData = z.infer<typeof ZWorkflowRunJobData>;


### PR DESCRIPTION
## What does this PR do?

Wires the **producer half** of the workflows Runner into the response pipeline, so completing a survey response actually starts the configured workflows. The foundation already exists on `epic/workflows-v1` (DB models, the `response.completed` trigger, enable→`WorkflowVersion` snapshots, the runs table UI) but nothing connected a completed response to its workflows — this is that connection.

Ticket: https://linear.app/formbricks/issue/ENG-1226

> Stacked on `epic/workflows-v1` (not `main`).

Three layers, one per commit:

1. **`packages/jobs` — the `workflow-run.process` background job.** Mirrors the existing `response-pipeline.process` wiring: `JOB_NAMES.workflowRun`, a Zod-validated `ZWorkflowRunJobData`, an `enqueueWorkflowRunJob` producer, and a default handler that is a **throwing stub** (logs + throws "override not registered"). Real execution is registered by ENG-1228 as an apps/web override; until then the stub failing loudly is the intended behavior.
2. **`apps/web/modules/workflows/lib/runner/` (new) — match, dispatch, orchestrate.**
   - `match-workflows.ts` — pure, no I/O: given a completed response (`surveyId` + `endingId`) and candidate published versions, returns which workflows fire. Trigger-type guard + `surveyId` match + ending-card filter (empty = any). Exhaustively table-tested.
   - `dispatch.ts` — a backend-agnostic `DispatchWorkflowRun` **port** plus the one BullMQ adapter (`dispatchWorkflowRunViaJobs`). This is the *only* file that imports `@formbricks/jobs`.
   - `enqueue-response-completed-runs.ts` — loads enabled workflows for the workspace, matches by **published** `WorkflowVersion` (not the draft), and creates a `queued` `WorkflowRun` bound to that version, then dispatches.
3. **Response pipeline hook** (`process-response-pipeline-job.ts`) — on `responseFinished` + an ending card reached, calls the orchestrator alongside the other side-effects.

**Design decisions worth a look:**
- **Backend-agnostic by isolation, not abstraction.** `WorkflowRun` is the durable source of truth; the queue is just a hand-off. Swapping BullMQ for something else (River/SQS/DB-poller) means replacing the adapter + `packages/jobs` wiring — the matcher, run-creation, and pipeline hook don't change.
- **Idempotent.** The run is created with `idempotencyKey = responseId` (`@@unique([workflowId, idempotencyKey])`); on P2002 we look up the existing run and re-dispatch. The job uses a deterministic `jobId = runId`, so a pipeline replay produces **0 new runs and 0 duplicate jobs**, and a "created-but-not-dispatched" run gets re-dispatched.
- **Failure-isolated.** Per-workflow try/catch (one bad workflow doesn't skip the rest) inside an outer try/catch (the runner never fails the response pipeline job or its other side-effects).
- **`attempts: 1`** for the job (not the default 3) — run-level retry is row-modelled and belongs to ENG-1228, not BullMQ.

**Out of scope (explicitly):** run *execution* — worker, actions, emails, run logs. That's **ENG-1228**, which this PR blocks. Also out of scope: dry-runs, triggers other than `response.completed`, and a reconciler for orphaned `queued` runs (the `status`/`nextAttemptAt` indexes already exist for a future sweeper).

## How should this be tested?

Automated (what I ran, all green):

```bash
# rebuild deps so apps/web picks up the new job types
pnpm --filter @formbricks/database build   # prisma generate
pnpm --filter @formbricks/jobs build
pnpm --filter @formbricks/workflows build

pnpm --filter @formbricks/jobs run test typecheck lint
pnpm turbo run typecheck --filter=@formbricks/web
# the ~17 new apps/web tests:
cd apps/web && npx vitest run modules/workflows/lib/runner modules/response-pipeline/lib/process-response-pipeline-job.test.ts
```

Manual local smoke (no worker yet):
1. Create a survey, attach a workflow, and **enable** it (this snapshots a published `WorkflowVersion`).
2. Complete a response on that survey through to a thank-you/ending card.
3. Expect a `queued` `WorkflowRun` with `workflowVersionId` set and a `workflow-run.process` job enqueued.
4. Replay the response-pipeline job → **no duplicate run, no duplicate job** (idempotency).
5. The job itself will throw "override not registered" — expected until ENG-1228 registers the executor.

Edge behavior covered by tests: not-finished / no-ending-card → 0 runs; ending-card filter (empty = any, specific list hits/misses); fires from the **published** version even after the draft is edited; enabled-but-no-published-version → log + skip; draft/disabled/archived/other-workspace/non-matching-survey → never fire; fan-out (N matches → N runs/jobs); malformed published definition → per-workflow skip, others continue.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build` (affected packages: database, jobs, workflows, web typecheck)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch — N/A, this is stacked on `epic/workflows-v1`
- [x] My changes don't cause any responsiveness issues (backend-only, no UI)
- [ ] First PR at Formbricks? — no

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots — N/A, backend-only
- [ ] Updated the Formbricks Docs — docs are tracked separately in the M5 milestone (ENG-1232)
