### PR TITLE
feat(workflows): emit complete audit events for management mutations

### DIFF
--- a/apps/web/app/api/v3/workflows/[workflowId]/archive/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/archive/route.ts
@@ -11,9 +11,9 @@ export const POST = withV3ApiWrapper({
   action: "updated",
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
-  handler: async ({ parsedInput, authentication, requestId, instance }) =>
+  handler: async ({ parsedInput, authentication, auditLog, requestId, instance }) =>
     workflowsHandlers.archive({
-      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      ctx: buildWorkflowApiContext(authentication, requestId, instance, auditLog),
       params: parsedInput.params,
     }),
 });

--- a/apps/web/app/api/v3/workflows/[workflowId]/disable/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/disable/route.ts
@@ -11,9 +11,9 @@ export const POST = withV3ApiWrapper({
   action: "updated",
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
-  handler: async ({ parsedInput, authentication, requestId, instance }) =>
+  handler: async ({ parsedInput, authentication, auditLog, requestId, instance }) =>
     workflowsHandlers.disable({
-      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      ctx: buildWorkflowApiContext(authentication, requestId, instance, auditLog),
       params: parsedInput.params,
     }),
 });

--- a/apps/web/app/api/v3/workflows/[workflowId]/duplicate/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/duplicate/route.ts
@@ -11,10 +11,10 @@ export const POST = withV3ApiWrapper({
   action: "created",
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
-  handler: async ({ req, parsedInput, authentication, requestId, instance }) =>
+  handler: async ({ req, parsedInput, authentication, auditLog, requestId, instance }) =>
     workflowsHandlers.duplicate({
       req,
-      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      ctx: buildWorkflowApiContext(authentication, requestId, instance, auditLog),
       params: parsedInput.params,
     }),
 });

--- a/apps/web/app/api/v3/workflows/[workflowId]/enable/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/enable/route.ts
@@ -11,9 +11,9 @@ export const POST = withV3ApiWrapper({
   action: "updated",
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
-  handler: async ({ parsedInput, authentication, requestId, instance }) =>
+  handler: async ({ parsedInput, authentication, auditLog, requestId, instance }) =>
     workflowsHandlers.enable({
-      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      ctx: buildWorkflowApiContext(authentication, requestId, instance, auditLog),
       params: parsedInput.params,
     }),
 });

--- a/apps/web/app/api/v3/workflows/[workflowId]/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/route.ts
@@ -24,10 +24,10 @@ export const PATCH = withV3ApiWrapper({
   action: "updated",
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
-  handler: async ({ req, parsedInput, authentication, requestId, instance }) =>
+  handler: async ({ req, parsedInput, authentication, auditLog, requestId, instance }) =>
     workflowsHandlers.patch({
       req,
-      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      ctx: buildWorkflowApiContext(authentication, requestId, instance, auditLog),
       params: parsedInput.params,
     }),
 });
@@ -37,9 +37,9 @@ export const DELETE = withV3ApiWrapper({
   action: "deleted",
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
-  handler: async ({ parsedInput, authentication, requestId, instance }) =>
+  handler: async ({ parsedInput, authentication, auditLog, requestId, instance }) =>
     workflowsHandlers.delete({
-      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      ctx: buildWorkflowApiContext(authentication, requestId, instance, auditLog),
       params: parsedInput.params,
     }),
 });

--- a/apps/web/app/api/v3/workflows/[workflowId]/unarchive/route.ts
+++ b/apps/web/app/api/v3/workflows/[workflowId]/unarchive/route.ts
@@ -11,9 +11,9 @@ export const POST = withV3ApiWrapper({
   action: "updated",
   targetType: "workflow",
   schemas: { params: ZWorkflowIdInput },
-  handler: async ({ parsedInput, authentication, requestId, instance }) =>
+  handler: async ({ parsedInput, authentication, auditLog, requestId, instance }) =>
     workflowsHandlers.unarchive({
-      ctx: buildWorkflowApiContext(authentication, requestId, instance),
+      ctx: buildWorkflowApiContext(authentication, requestId, instance, auditLog),
       params: parsedInput.params,
     }),
 });

--- a/apps/web/app/api/v3/workflows/lib/context.test.ts
+++ b/apps/web/app/api/v3/workflows/lib/context.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { TAuthenticationApiKey } from "@formbricks/types/auth";
 import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
-import type { TV3Authentication } from "@/app/api/v3/lib/types";
+import type { TV3AuditLog, TV3Authentication } from "@/app/api/v3/lib/types";
+import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { buildWorkflowApiContext } from "./context";
 
 const { surveyFindUnique } = vi.hoisted(() => ({ surveyFindUnique: vi.fn() }));
@@ -12,6 +13,20 @@ vi.mock("@formbricks/logger", () => ({
   logger: { withContext: vi.fn(() => ({ warn: vi.fn(), error: vi.fn() })) },
 }));
 vi.mock("@/app/api/v3/lib/auth", () => ({ requireV3WorkspaceAccess: vi.fn() }));
+vi.mock("@/lib/utils/helper", () => ({ getOrganizationIdFromWorkspaceId: vi.fn() }));
+
+const baseAuditLog = (): TV3AuditLog => ({
+  action: "updated",
+  targetType: "workflow",
+  userId: "unknown",
+  targetId: "unknown",
+  organizationId: "unknown",
+  status: "failure",
+  oldObject: undefined,
+  newObject: undefined,
+  userType: "api",
+  apiUrl: "https://app.formbricks.com/api/v3/workflows/wf_1",
+});
 
 const sessionAuth = {
   user: { id: "cm9zr52kh000508l8e3q7bw9j" },
@@ -101,5 +116,63 @@ describe("verifyTriggerSurvey (validates a workflow trigger's referenced survey)
     const result = await verify({ workspaceId: "ws_1", surveyId: "s_1", endingCardIds: [endingId1] });
 
     expect(result).toEqual({ surveyExists: true, missingEndingCardIds: [] });
+  });
+});
+
+describe("recordAudit (binds the audit sink to the request's audit log)", () => {
+  test("is not exposed when no audit log is threaded in (read-only routes)", () => {
+    const ctx = buildWorkflowApiContext(sessionAuth, "req_1", "inst");
+    expect(ctx.recordAudit).toBeUndefined();
+  });
+
+  test("writes targetId + before/after snapshots onto the audit log", async () => {
+    vi.mocked(getOrganizationIdFromWorkspaceId).mockResolvedValue("org_resolved");
+    const auditLog = baseAuditLog();
+    const ctx = buildWorkflowApiContext(sessionAuth, "req_1", "inst", auditLog);
+
+    await ctx.recordAudit?.({
+      targetId: "wf_1",
+      oldObject: { status: "draft" },
+      newObject: { status: "enabled", workspaceId: "ws_1" },
+    });
+
+    expect(auditLog.targetId).toBe("wf_1");
+    expect(auditLog.oldObject).toEqual({ status: "draft" });
+    expect(auditLog.newObject).toEqual({ status: "enabled", workspaceId: "ws_1" });
+  });
+
+  test("resolves the workflow's organization from its workspace for session auth", async () => {
+    vi.mocked(getOrganizationIdFromWorkspaceId).mockResolvedValue("org_resolved");
+    const auditLog = baseAuditLog();
+    const ctx = buildWorkflowApiContext(sessionAuth, "req_1", "inst", auditLog);
+
+    await ctx.recordAudit?.({ targetId: "wf_1", newObject: { workspaceId: "ws_1" } });
+
+    expect(getOrganizationIdFromWorkspaceId).toHaveBeenCalledWith("ws_1");
+    expect(auditLog.organizationId).toBe("org_resolved");
+  });
+
+  test("keeps the API-key path's organization and does not re-resolve from the workspace", async () => {
+    const auditLog = { ...baseAuditLog(), organizationId: "org_from_key" };
+    const ctx = buildWorkflowApiContext(apiKeyAuth as TV3Authentication, "req_1", "inst", auditLog);
+
+    await ctx.recordAudit?.({ targetId: "wf_1", newObject: { workspaceId: "ws_1" } });
+
+    expect(getOrganizationIdFromWorkspaceId).not.toHaveBeenCalled();
+    expect(auditLog.organizationId).toBe("org_from_key");
+  });
+
+  test("never throws when organization resolution fails; snapshots are still recorded", async () => {
+    vi.mocked(getOrganizationIdFromWorkspaceId).mockRejectedValue(new Error("workspace lookup failed"));
+    const auditLog = baseAuditLog();
+    const ctx = buildWorkflowApiContext(sessionAuth, "req_1", "inst", auditLog);
+
+    await expect(
+      ctx.recordAudit?.({ targetId: "wf_1", newObject: { workspaceId: "ws_1" } })
+    ).resolves.toBeUndefined();
+
+    expect(auditLog.targetId).toBe("wf_1");
+    // Resolution failed, so the session org stays at its default rather than corrupting the event.
+    expect(auditLog.organizationId).toBe("unknown");
   });
 });

--- a/apps/web/app/api/v3/workflows/lib/context.test.ts
+++ b/apps/web/app/api/v3/workflows/lib/context.test.ts
@@ -132,31 +132,47 @@ describe("recordAudit (binds the audit sink to the request's audit log)", () => 
 
     await ctx.recordAudit?.({
       targetId: "wf_1",
+      workspaceId: "ws_1",
       oldObject: { status: "draft" },
-      newObject: { status: "enabled", workspaceId: "ws_1" },
+      newObject: { status: "enabled" },
     });
 
     expect(auditLog.targetId).toBe("wf_1");
     expect(auditLog.oldObject).toEqual({ status: "draft" });
-    expect(auditLog.newObject).toEqual({ status: "enabled", workspaceId: "ws_1" });
+    expect(auditLog.newObject).toEqual({ status: "enabled" });
   });
 
-  test("resolves the workflow's organization from its workspace for session auth", async () => {
+  test("resolves the workflow's organization from detail.workspaceId for session auth", async () => {
     vi.mocked(getOrganizationIdFromWorkspaceId).mockResolvedValue("org_resolved");
     const auditLog = baseAuditLog();
     const ctx = buildWorkflowApiContext(sessionAuth, "req_1", "inst", auditLog);
 
-    await ctx.recordAudit?.({ targetId: "wf_1", newObject: { workspaceId: "ws_1" } });
+    await ctx.recordAudit?.({ targetId: "wf_1", workspaceId: "ws_1", newObject: { status: "draft" } });
 
     expect(getOrganizationIdFromWorkspaceId).toHaveBeenCalledWith("ws_1");
     expect(auditLog.organizationId).toBe("org_resolved");
+  });
+
+  test("resolves org from detail.workspaceId on the delete path (oldObject only, no newObject)", async () => {
+    vi.mocked(getOrganizationIdFromWorkspaceId).mockResolvedValue("org_resolved");
+    const auditLog = baseAuditLog();
+    const ctx = buildWorkflowApiContext(sessionAuth, "req_1", "inst", auditLog);
+
+    // Delete-style: a pre-mutation snapshot only, no newObject — org must still resolve from the
+    // explicit workspaceId (never inferred from a snapshot that the delete path may not carry).
+    await ctx.recordAudit?.({ targetId: "wf_1", workspaceId: "ws_1", oldObject: { status: "draft" } });
+
+    expect(getOrganizationIdFromWorkspaceId).toHaveBeenCalledWith("ws_1");
+    expect(auditLog.organizationId).toBe("org_resolved");
+    expect(auditLog.oldObject).toEqual({ status: "draft" });
+    expect(auditLog.newObject).toBeUndefined();
   });
 
   test("keeps the API-key path's organization and does not re-resolve from the workspace", async () => {
     const auditLog = { ...baseAuditLog(), organizationId: "org_from_key" };
     const ctx = buildWorkflowApiContext(apiKeyAuth as TV3Authentication, "req_1", "inst", auditLog);
 
-    await ctx.recordAudit?.({ targetId: "wf_1", newObject: { workspaceId: "ws_1" } });
+    await ctx.recordAudit?.({ targetId: "wf_1", workspaceId: "ws_1", newObject: { status: "draft" } });
 
     expect(getOrganizationIdFromWorkspaceId).not.toHaveBeenCalled();
     expect(auditLog.organizationId).toBe("org_from_key");
@@ -168,7 +184,7 @@ describe("recordAudit (binds the audit sink to the request's audit log)", () => 
     const ctx = buildWorkflowApiContext(sessionAuth, "req_1", "inst", auditLog);
 
     await expect(
-      ctx.recordAudit?.({ targetId: "wf_1", newObject: { workspaceId: "ws_1" } })
+      ctx.recordAudit?.({ targetId: "wf_1", workspaceId: "ws_1", newObject: { status: "draft" } })
     ).resolves.toBeUndefined();
 
     expect(auditLog.targetId).toBe("wf_1");

--- a/apps/web/app/api/v3/workflows/lib/context.ts
+++ b/apps/web/app/api/v3/workflows/lib/context.ts
@@ -9,6 +9,7 @@ import {
 } from "@formbricks/workflows/server";
 import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
 import type { TV3AuditLog, TV3Authentication } from "@/app/api/v3/lib/types";
+import { ENCRYPTION_KEY } from "@/lib/constants";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 
 /**
@@ -53,22 +54,17 @@ const verifyTriggerSurvey: WorkflowApiContext["verifyTriggerSurvey"] = async ({
   };
 };
 
-/** Reads the workspace id off an audit snapshot (the serialized resource carries it as a string). */
-const getWorkspaceId = (detail: WorkflowAuditDetail): string | undefined => {
-  const source = detail.newObject ?? detail.oldObject;
-  const workspaceId = source?.workspaceId;
-  return typeof workspaceId === "string" ? workspaceId : undefined;
-};
-
 /**
  * Bind the framework-agnostic audit sink to this request's audit log. The handlers call it once,
- * post-mutation, with the affected workflow id + before/after snapshots; we copy those onto
- * `auditLog` (target id, old/new object) so the v3 wrapper queues a complete Enterprise event.
+ * post-mutation, with the affected workflow id + workspace id + before/after snapshots; we copy
+ * those onto `auditLog` (target id, old/new object) so the v3 wrapper queues a complete Enterprise
+ * event.
  *
  * Organization resolution: the API-key path already set `auditLog.organizationId` from the key's
  * org (see `buildV3AuditLog`); the session path leaves it as `UNKNOWN_DATA`, so we resolve the
- * workflow's real org from its workspace here. Any failure is swallowed and logged — an audit
- * problem must never break or alter an already-successful mutation.
+ * workflow's real org from `detail.workspaceId` (a first-class field — never inferred from the
+ * snapshots, so snapshot reshaping or PII redaction can't silently regress it). Any failure is
+ * swallowed and logged — an audit problem must never break or alter an already-successful mutation.
  */
 const buildRecordAudit =
   (
@@ -76,7 +72,7 @@ const buildRecordAudit =
     authentication: TV3Authentication,
     requestId: string
   ): NonNullable<WorkflowApiContext["recordAudit"]> =>
-  async (detail) => {
+  async (detail: WorkflowAuditDetail) => {
     try {
       auditLog.targetId = detail.targetId;
       auditLog.oldObject = detail.oldObject;
@@ -85,10 +81,7 @@ const buildRecordAudit =
       // API-key auth already carries the org; only the session path needs resolution.
       const isApiKey = !!authentication && "apiKeyId" in authentication;
       if (!isApiKey) {
-        const workspaceId = getWorkspaceId(detail);
-        if (workspaceId) {
-          auditLog.organizationId = await getOrganizationIdFromWorkspaceId(workspaceId);
-        }
+        auditLog.organizationId = await getOrganizationIdFromWorkspaceId(detail.workspaceId);
       }
     } catch (error) {
       logger.withContext({ requestId }).error({ error }, "Failed to record workflow audit detail");
@@ -105,6 +98,9 @@ export const buildWorkflowApiContext = (
   requestId,
   instance,
   logger: logger.withContext({ requestId }),
+  // HMAC key for redacting PII markers in audit snapshots; reuses the app's audit/encryption secret
+  // so markers aren't offline-guessable. Injected as data to keep `@formbricks/workflows` agnostic.
+  auditRedactionKey: ENCRYPTION_KEY,
   authorize: (workspaceId, access) =>
     requireV3WorkspaceAccess(authentication, workspaceId, access, requestId, instance),
   verifyTriggerSurvey,

--- a/apps/web/app/api/v3/workflows/lib/context.ts
+++ b/apps/web/app/api/v3/workflows/lib/context.ts
@@ -3,11 +3,13 @@ import { logger } from "@formbricks/logger";
 import { ZSurveyEndings } from "@formbricks/types/surveys/types";
 import {
   type WorkflowApiContext,
+  type WorkflowAuditDetail,
   createWorkflowsHandlers,
   createWorkflowsService,
 } from "@formbricks/workflows/server";
 import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
-import type { TV3Authentication } from "@/app/api/v3/lib/types";
+import type { TV3AuditLog, TV3Authentication } from "@/app/api/v3/lib/types";
+import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 
 /**
  * Adapter glue between the Next.js v3 routes and the framework-agnostic `@formbricks/workflows`
@@ -51,10 +53,53 @@ const verifyTriggerSurvey: WorkflowApiContext["verifyTriggerSurvey"] = async ({
   };
 };
 
+/** Reads the workspace id off an audit snapshot (the serialized resource carries it as a string). */
+const getWorkspaceId = (detail: WorkflowAuditDetail): string | undefined => {
+  const source = detail.newObject ?? detail.oldObject;
+  const workspaceId = source?.workspaceId;
+  return typeof workspaceId === "string" ? workspaceId : undefined;
+};
+
+/**
+ * Bind the framework-agnostic audit sink to this request's audit log. The handlers call it once,
+ * post-mutation, with the affected workflow id + before/after snapshots; we copy those onto
+ * `auditLog` (target id, old/new object) so the v3 wrapper queues a complete Enterprise event.
+ *
+ * Organization resolution: the API-key path already set `auditLog.organizationId` from the key's
+ * org (see `buildV3AuditLog`); the session path leaves it as `UNKNOWN_DATA`, so we resolve the
+ * workflow's real org from its workspace here. Any failure is swallowed and logged — an audit
+ * problem must never break or alter an already-successful mutation.
+ */
+const buildRecordAudit =
+  (
+    auditLog: TV3AuditLog,
+    authentication: TV3Authentication,
+    requestId: string
+  ): NonNullable<WorkflowApiContext["recordAudit"]> =>
+  async (detail) => {
+    try {
+      auditLog.targetId = detail.targetId;
+      auditLog.oldObject = detail.oldObject;
+      auditLog.newObject = detail.newObject;
+
+      // API-key auth already carries the org; only the session path needs resolution.
+      const isApiKey = !!authentication && "apiKeyId" in authentication;
+      if (!isApiKey) {
+        const workspaceId = getWorkspaceId(detail);
+        if (workspaceId) {
+          auditLog.organizationId = await getOrganizationIdFromWorkspaceId(workspaceId);
+        }
+      }
+    } catch (error) {
+      logger.withContext({ requestId }).error({ error }, "Failed to record workflow audit detail");
+    }
+  };
+
 export const buildWorkflowApiContext = (
   authentication: TV3Authentication,
   requestId: string,
-  instance: string
+  instance: string,
+  auditLog?: TV3AuditLog
 ): WorkflowApiContext => ({
   userId: getUserId(authentication),
   requestId,
@@ -63,4 +108,5 @@ export const buildWorkflowApiContext = (
   authorize: (workspaceId, access) =>
     requireV3WorkspaceAccess(authentication, workspaceId, access, requestId, instance),
   verifyTriggerSurvey,
+  ...(auditLog ? { recordAudit: buildRecordAudit(auditLog, authentication, requestId) } : {}),
 });

--- a/apps/web/app/api/v3/workflows/route.ts
+++ b/apps/web/app/api/v3/workflows/route.ts
@@ -18,6 +18,9 @@ export const POST = withV3ApiWrapper({
   auth: "both",
   action: "created",
   targetType: "workflow",
-  handler: async ({ req, authentication, requestId, instance }) =>
-    workflowsHandlers.create({ req, ctx: buildWorkflowApiContext(authentication, requestId, instance) }),
+  handler: async ({ req, authentication, auditLog, requestId, instance }) =>
+    workflowsHandlers.create({
+      req,
+      ctx: buildWorkflowApiContext(authentication, requestId, instance, auditLog),
+    }),
 });

--- a/packages/workflows/src/handlers/audit-redaction.test.ts
+++ b/packages/workflows/src/handlers/audit-redaction.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "vitest";
+import { redactWorkflowDefinitionPII } from "./audit-redaction";
+
+const MARKER = /^\[redacted:[0-9a-f]{12}]$/;
+
+const sendEmailNode = (overrides: Record<string, unknown> = {}): Record<string, unknown> => ({
+  id: "send-email",
+  type: "action" as const,
+  actionType: "send_email" as const,
+  config: {
+    to: "recipient@example.com",
+    from: "noreply@example.com",
+    replyTo: ["support@example.com"],
+    subject: "Thanks for your response",
+    body: "Hi {{name}}, thanks!",
+    attachResponseData: true,
+    includeVariables: false,
+    ...overrides,
+  },
+});
+
+const definition = (nodes: unknown[]): Record<string, unknown> => ({
+  schemaVersion: 1,
+  trigger: { id: "trigger", type: "trigger", triggerType: "response.completed", config: { surveyId: "s_1" } },
+  nodes,
+  edges: [],
+  entryNodeId: "trigger",
+});
+
+const redactConfig = (nodes: unknown[]): Record<string, unknown> =>
+  (redactWorkflowDefinitionPII(definition(nodes)) as { nodes: { config: Record<string, unknown> }[] })
+    .nodes[0].config;
+
+describe("redactWorkflowDefinitionPII", () => {
+  test("masks every send_email PII field with a value-stable marker", () => {
+    const config = redactConfig([sendEmailNode()]);
+
+    expect(config.to).toMatch(MARKER);
+    expect(config.from).toMatch(MARKER);
+    expect(config.subject).toMatch(MARKER);
+    expect(config.body).toMatch(MARKER);
+    expect(config.replyTo).toEqual([expect.stringMatching(MARKER)]);
+  });
+
+  test("leaves non-PII config fields intact so behavioral changes still diff", () => {
+    const config = redactConfig([sendEmailNode()]);
+
+    expect(config.attachResponseData).toBe(true);
+    expect(config.includeVariables).toBe(false);
+  });
+
+  test("does not contain any raw email after redaction (deep scan)", () => {
+    const redacted = redactWorkflowDefinitionPII(definition([sendEmailNode()]));
+    expect(JSON.stringify(redacted)).not.toContain("@example.com");
+  });
+
+  test("same value → same marker (an unchanged recipient produces no spurious diff)", () => {
+    const a = redactConfig([sendEmailNode()]);
+    const b = redactConfig([sendEmailNode()]);
+    expect(a.to).toBe(b.to);
+    expect(a.replyTo).toEqual(b.replyTo);
+  });
+
+  test("different value → different marker (a changed recipient surfaces as a change)", () => {
+    const before = redactConfig([sendEmailNode({ to: "old@example.com" })]);
+    const after = redactConfig([sendEmailNode({ to: "new@example.com" })]);
+    expect(before.to).not.toBe(after.to);
+  });
+
+  test("replyTo marker changes when any array element changes", () => {
+    const before = redactConfig([sendEmailNode({ replyTo: ["a@example.com", "b@example.com"] })]);
+    const after = redactConfig([sendEmailNode({ replyTo: ["a@example.com", "c@example.com"] })]);
+    expect(before.replyTo).not.toEqual(after.replyTo);
+  });
+
+  test("does not mutate the input definition", () => {
+    const input = definition([sendEmailNode()]);
+    redactWorkflowDefinitionPII(input);
+    const node = (input.nodes as { config: { to: string } }[])[0];
+    expect(node.config.to).toBe("recipient@example.com");
+  });
+
+  test("redacts only send_email action nodes, leaving other node types untouched", () => {
+    const ifElse = {
+      id: "branch",
+      type: "if_else",
+      config: { condition: { connector: "and", conditions: [] } },
+    };
+    const redacted = redactWorkflowDefinitionPII(definition([ifElse, sendEmailNode()])) as {
+      nodes: Record<string, unknown>[];
+    };
+
+    expect(redacted.nodes[0]).toEqual(ifElse);
+    expect((redacted.nodes[1] as { config: { to: string } }).config.to).toMatch(MARKER);
+  });
+
+  test("tolerates definitions without nodes and non-object inputs", () => {
+    expect(redactWorkflowDefinitionPII({ schemaVersion: 1 })).toEqual({ schemaVersion: 1 });
+    expect(redactWorkflowDefinitionPII(null)).toBeNull();
+    expect(redactWorkflowDefinitionPII("nope")).toBe("nope");
+  });
+});

--- a/packages/workflows/src/handlers/audit-redaction.test.ts
+++ b/packages/workflows/src/handlers/audit-redaction.test.ts
@@ -73,6 +73,41 @@ describe("redactWorkflowDefinitionPII", () => {
     expect(before.replyTo).not.toEqual(after.replyTo);
   });
 
+  test("a keyed digest differs from the unkeyed one for the same value (HMAC, not plain sha256)", () => {
+    const keyed = (
+      redactWorkflowDefinitionPII(definition([sendEmailNode()]), "audit-secret") as {
+        nodes: { config: Record<string, unknown> }[];
+      }
+    ).nodes[0].config;
+    const unkeyed = redactConfig([sendEmailNode()]);
+
+    // Same input, different secret → different marker, proving the digest is actually keyed.
+    expect(keyed.to).toMatch(MARKER);
+    expect(keyed.to).not.toBe(unkeyed.to);
+    // Still value-stable under the same key, and still leaks no raw email.
+    const keyedAgain = (
+      redactWorkflowDefinitionPII(definition([sendEmailNode()]), "audit-secret") as {
+        nodes: { config: Record<string, unknown> }[];
+      }
+    ).nodes[0].config;
+    expect(keyed.to).toBe(keyedAgain.to);
+    expect(String(keyed.to)).not.toContain("@example.com");
+  });
+
+  test("different keys produce different markers for the same value", () => {
+    const withKeyA = (
+      redactWorkflowDefinitionPII(definition([sendEmailNode()]), "key-a") as {
+        nodes: { config: Record<string, unknown> }[];
+      }
+    ).nodes[0].config;
+    const withKeyB = (
+      redactWorkflowDefinitionPII(definition([sendEmailNode()]), "key-b") as {
+        nodes: { config: Record<string, unknown> }[];
+      }
+    ).nodes[0].config;
+    expect(withKeyA.to).not.toBe(withKeyB.to);
+  });
+
   test("does not mutate the input definition", () => {
     const input = definition([sendEmailNode()]);
     redactWorkflowDefinitionPII(input);

--- a/packages/workflows/src/handlers/audit-redaction.ts
+++ b/packages/workflows/src/handlers/audit-redaction.ts
@@ -1,0 +1,69 @@
+import { createHash } from "node:crypto";
+import { WORKFLOW_ACTIONS } from "../types/actions";
+
+/**
+ * `send_email` action config fields that can carry literal PII (recipient/sender addresses and
+ * message content). The non-PII fields (`attachResponseData`, `includeVariables`,
+ * `includeHiddenFields`) are intentionally left intact so a real config change still surfaces in
+ * the audit diff. Mirrors `ZWorkflowSendEmailActionConfig` in `types/actions/send-email.ts`.
+ */
+const SEND_EMAIL_PII_FIELDS = ["to", "from", "replyTo", "subject", "body"] as const;
+
+/**
+ * Replace a PII value with a value-stable, non-reversible marker: `"[redacted:<hash>]"` where the
+ * hash is the first 12 hex chars of `sha256(String(value))`. Same input → same marker (an unchanged
+ * recipient produces no spurious diff), different input → different marker (a real change still
+ * surfaces in `changes`), and the raw value is never recoverable from the marker. A constant token
+ * would collapse `deepDiff` (token == token) and hide recipient-only edits — hence the per-value hash.
+ */
+const redactValue = (value: string): string =>
+  `[redacted:${createHash("sha256").update(value).digest("hex").slice(0, 12)}]`;
+
+/** Redact one PII field: hash each element of an array (e.g. `replyTo`), otherwise hash the value. */
+const redactField = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((element) => redactValue(String(element)));
+  }
+  return redactValue(String(value));
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Redact PII from a workflow definition's actions before the snapshot leaves this package for the
+ * audit log. The shared `redactPII` keys off field NAMES (`email`, `token`, …) and does not match
+ * the workflow definition's `to`/`from`/`replyTo`/`subject`/`body`, so without this the values
+ * would reach the audit `changes` verbatim. Done here (domain knowledge about the definition shape)
+ * rather than by widening the global sensitive-key list, which would over-redact unrelated events.
+ *
+ * Returns a deep-copied definition with the `send_email` PII fields replaced by value-stable
+ * markers; everything else (status, name, structure, non-PII config) is preserved so the diff stays
+ * readable, and a changed recipient still produces a (content-free) diff entry.
+ */
+export const redactWorkflowDefinitionPII = (definition: unknown): unknown => {
+  if (!isRecord(definition)) return definition;
+  if (!Array.isArray(definition.nodes)) return definition;
+
+  const nodes: unknown[] = definition.nodes;
+  const redactedNodes = nodes.map((node): unknown => {
+    if (
+      !isRecord(node) ||
+      node.type !== "action" ||
+      node.actionType !== WORKFLOW_ACTIONS.SEND_EMAIL ||
+      !isRecord(node.config)
+    ) {
+      return node;
+    }
+
+    const redactedConfig: Record<string, unknown> = { ...node.config };
+    for (const field of SEND_EMAIL_PII_FIELDS) {
+      if (field in redactedConfig) {
+        redactedConfig[field] = redactField(redactedConfig[field]);
+      }
+    }
+    return { ...node, config: redactedConfig };
+  });
+
+  return { ...definition, nodes: redactedNodes };
+};

--- a/packages/workflows/src/handlers/audit-redaction.ts
+++ b/packages/workflows/src/handlers/audit-redaction.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, createHmac } from "node:crypto";
 import { WORKFLOW_ACTIONS } from "../types/actions";
 
 /**
@@ -10,21 +10,30 @@ import { WORKFLOW_ACTIONS } from "../types/actions";
 const SEND_EMAIL_PII_FIELDS = ["to", "from", "replyTo", "subject", "body"] as const;
 
 /**
- * Replace a PII value with a value-stable, non-reversible marker: `"[redacted:<hash>]"` where the
- * hash is the first 12 hex chars of `sha256(String(value))`. Same input → same marker (an unchanged
- * recipient produces no spurious diff), different input → different marker (a real change still
- * surfaces in `changes`), and the raw value is never recoverable from the marker. A constant token
- * would collapse `deepDiff` (token == token) and hide recipient-only edits — hence the per-value hash.
+ * Replace a PII value with a value-stable, non-reversible marker: `"[redacted:<digest>]"` where
+ * `<digest>` is the first 12 hex chars of a keyed HMAC-SHA256 (or, if no key is injected, a plain
+ * SHA256 fallback for non-EE/local). Same value+key → same marker (an unchanged recipient produces
+ * no spurious diff); different value → different marker (a real change still surfaces in `changes`).
+ *
+ * The key matters: a plain `sha256` of a low-entropy value like an email is offline-guessable —
+ * anyone with audit-log read access could confirm a likely recipient by hashing candidates. An
+ * HMAC keyed with the app's audit secret keeps the marker stable yet not trivially reversible
+ * without the secret. The key is injected (never read from env here) so the package stays
+ * framework-agnostic.
  */
-const redactValue = (value: string): string =>
-  `[redacted:${createHash("sha256").update(value).digest("hex").slice(0, 12)}]`;
+const redactValue = (value: string, key?: string): string => {
+  const digest = key
+    ? createHmac("sha256", key).update(value).digest("hex")
+    : createHash("sha256").update(value).digest("hex");
+  return `[redacted:${digest.slice(0, 12)}]`;
+};
 
 /** Redact one PII field: hash each element of an array (e.g. `replyTo`), otherwise hash the value. */
-const redactField = (value: unknown): unknown => {
+const redactField = (value: unknown, key?: string): unknown => {
   if (Array.isArray(value)) {
-    return value.map((element) => redactValue(String(element)));
+    return value.map((element) => redactValue(String(element), key));
   }
-  return redactValue(String(value));
+  return redactValue(String(value), key);
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -37,11 +46,13 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
  * would reach the audit `changes` verbatim. Done here (domain knowledge about the definition shape)
  * rather than by widening the global sensitive-key list, which would over-redact unrelated events.
  *
+ * `key` is the optional HMAC secret the adapter injects (the app's audit secret); see `redactValue`.
+ *
  * Returns a deep-copied definition with the `send_email` PII fields replaced by value-stable
  * markers; everything else (status, name, structure, non-PII config) is preserved so the diff stays
  * readable, and a changed recipient still produces a (content-free) diff entry.
  */
-export const redactWorkflowDefinitionPII = (definition: unknown): unknown => {
+export const redactWorkflowDefinitionPII = (definition: unknown, key?: string): unknown => {
   if (!isRecord(definition)) return definition;
   if (!Array.isArray(definition.nodes)) return definition;
 
@@ -59,7 +70,7 @@ export const redactWorkflowDefinitionPII = (definition: unknown): unknown => {
     const redactedConfig: Record<string, unknown> = { ...node.config };
     for (const field of SEND_EMAIL_PII_FIELDS) {
       if (field in redactedConfig) {
-        redactedConfig[field] = redactField(redactedConfig[field]);
+        redactedConfig[field] = redactField(redactedConfig[field], key);
       }
     }
     return { ...node, config: redactedConfig };

--- a/packages/workflows/src/handlers/context.ts
+++ b/packages/workflows/src/handlers/context.ts
@@ -17,14 +17,20 @@ export interface TriggerSurveyCheck {
 
 /**
  * Audit detail a mutating handler surfaces to the adapter after a successful service call.
- * Deliberately app-agnostic: the affected workflow id plus before/after snapshots as plain
- * serializable objects. The adapter (apps/web) maps these onto the request's audit log; this
- * package never knows about the audit subsystem. For create/duplicate `targetId` is the new
- * row's id (it only exists after the mutation), `oldObject` is omitted; for delete `newObject`
- * is omitted. The `status` transition is captured in both snapshots so the diff surfaces it.
+ * Deliberately app-agnostic: the affected workflow id, its workspace id, plus before/after
+ * snapshots as plain serializable objects. The adapter (apps/web) maps these onto the request's
+ * audit log; this package never knows about the audit subsystem. For create/duplicate `targetId`
+ * is the new row's id (it only exists after the mutation), `oldObject` is omitted; for delete
+ * `newObject` is omitted. The `status` transition is captured in both snapshots so the diff
+ * surfaces it.
+ *
+ * `workspaceId` is first-class (not inferred from the snapshots) so the adapter can resolve the
+ * organization deterministically — a snapshot reshape or a redacted field can never silently
+ * regress org resolution. The handler always knows the authorized workspace id.
  */
 export interface WorkflowAuditDetail {
   targetId: string;
+  workspaceId: string;
   oldObject?: Record<string, unknown>;
   newObject?: Record<string, unknown>;
 }
@@ -49,12 +55,19 @@ export interface WorkflowAuditDetail {
  * is simply a no-op. Keeping it a narrow port preserves the package's framework-agnosticism — it
  * never imports the app's audit module. The adapter must never let an audit failure throw, since
  * these calls run on the success path of an already-completed mutation.
+ *
+ * `auditRedactionKey` is the secret the adapter injects (the app's audit/encryption secret) so the
+ * package can HMAC PII markers in audit snapshots instead of a plain hash — a plain `sha256` of a
+ * low-entropy value like an email is offline-guessable from audit-log read access. Injected as data
+ * (never read from env here) to keep the package framework-agnostic; when absent the redactor falls
+ * back to an unkeyed digest so non-EE/local still works.
  */
 export interface WorkflowApiContext {
   userId: string | null;
   requestId: string;
   instance?: string;
   logger: WorkflowsLogger;
+  auditRedactionKey?: string;
   authorize: (workspaceId: string, access: WorkflowApiAccess) => Promise<AuthorizedWorkspace | Response>;
   verifyTriggerSurvey: (input: {
     workspaceId: string;

--- a/packages/workflows/src/handlers/context.ts
+++ b/packages/workflows/src/handlers/context.ts
@@ -16,6 +16,20 @@ export interface TriggerSurveyCheck {
 }
 
 /**
+ * Audit detail a mutating handler surfaces to the adapter after a successful service call.
+ * Deliberately app-agnostic: the affected workflow id plus before/after snapshots as plain
+ * serializable objects. The adapter (apps/web) maps these onto the request's audit log; this
+ * package never knows about the audit subsystem. For create/duplicate `targetId` is the new
+ * row's id (it only exists after the mutation), `oldObject` is omitted; for delete `newObject`
+ * is omitted. The `status` transition is captured in both snapshots so the diff surfaces it.
+ */
+export interface WorkflowAuditDetail {
+  targetId: string;
+  oldObject?: Record<string, unknown>;
+  newObject?: Record<string, unknown>;
+}
+
+/**
  * Per-request context the Next.js adapter builds and passes to the framework-agnostic handlers.
  *
  * `authorize` is a capability bound by the adapter to the authenticated request (wrapping
@@ -27,6 +41,14 @@ export interface TriggerSurveyCheck {
  * It is intentionally specific to the `response.completed` trigger (the only kind today); once other
  * trigger types need reference validation, this generalizes to a per-trigger validator keyed on
  * `trigger.type` rather than growing a `verifyXxx` capability per trigger.
+ *
+ * `recordAudit` is an optional injected sink the mutating handlers `await` once, after a successful
+ * service call, to surface the affected workflow id + before/after snapshots. The adapter binds it
+ * to the request's audit log (Enterprise audit-log subsystem) and may do async work (e.g. resolving
+ * the organization from the workspace); when no adapter wires it (or audit logging is off) the call
+ * is simply a no-op. Keeping it a narrow port preserves the package's framework-agnosticism — it
+ * never imports the app's audit module. The adapter must never let an audit failure throw, since
+ * these calls run on the success path of an already-completed mutation.
  */
 export interface WorkflowApiContext {
   userId: string | null;
@@ -39,4 +61,5 @@ export interface WorkflowApiContext {
     surveyId: string;
     endingCardIds: string[];
   }) => Promise<TriggerSurveyCheck>;
+  recordAudit?: (detail: WorkflowAuditDetail) => void | Promise<void>;
 }

--- a/packages/workflows/src/handlers/workflows.handlers.test.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.test.ts
@@ -578,3 +578,203 @@ describe("disable", () => {
     expect(service.disableWorkflow).not.toHaveBeenCalled();
   });
 });
+
+describe("recordAudit (audit-sink port)", () => {
+  const copyId = "cm9zr4t2b000208l8h2m1xyz9";
+  const recordAudit = vi.fn<NonNullable<WorkflowApiContext["recordAudit"]>>();
+  const auditCtx = (overrides: Partial<WorkflowApiContext> = {}): WorkflowApiContext =>
+    makeCtx({ recordAudit, ...overrides });
+
+  const postRequest = (body?: unknown): Request =>
+    new Request("http://localhost/api/v3/workflows", {
+      method: "POST",
+      ...(body !== undefined
+        ? { body: JSON.stringify(body), headers: { "Content-Type": "application/json" } }
+        : {}),
+    });
+  const patchRequest = (body: unknown): Request =>
+    new Request("http://localhost/api/v3/workflows/x", {
+      method: "PATCH",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    });
+
+  test("create surfaces the new id and a new-object snapshot (no old object)", async () => {
+    service.createWorkflow.mockResolvedValue(makeRow());
+
+    await handlers.create({
+      req: postRequest({ workspaceId, name: "Notify team", definition }),
+      ctx: auditCtx(),
+    });
+
+    expect(recordAudit).toHaveBeenCalledTimes(1);
+    const detail = recordAudit.mock.calls[0][0];
+    expect(detail.targetId).toBe(workflowId);
+    expect(detail.oldObject).toBeUndefined();
+    expect(detail.newObject).toEqual(expect.objectContaining({ id: workflowId, workspaceId }));
+  });
+
+  test("update surfaces before/after snapshots showing the changed name", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft", name: "Before" }));
+    service.updateWorkflow.mockResolvedValue(makeRow({ name: "After" }));
+
+    await handlers.patch({ req: patchRequest({ name: "After" }), ctx: auditCtx(), params: { workflowId } });
+
+    expect(recordAudit).toHaveBeenCalledTimes(1);
+    const detail = recordAudit.mock.calls[0][0];
+    expect(detail.targetId).toBe(workflowId);
+    expect(detail.oldObject).toEqual(expect.objectContaining({ name: "Before" }));
+    expect(detail.newObject).toEqual(expect.objectContaining({ name: "After" }));
+  });
+
+  test("delete surfaces the removed object (no new object)", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow());
+    service.deleteWorkflow.mockResolvedValue(undefined);
+
+    await handlers.delete({ ctx: auditCtx(), params: { workflowId } });
+
+    expect(recordAudit).toHaveBeenCalledTimes(1);
+    const detail = recordAudit.mock.calls[0][0];
+    expect(detail.targetId).toBe(workflowId);
+    expect(detail.oldObject).toEqual(expect.objectContaining({ id: workflowId }));
+    expect(detail.newObject).toBeUndefined();
+  });
+
+  test("duplicate surfaces the copy's id, not the source id", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow());
+    service.duplicateWorkflow.mockResolvedValue(makeRow({ id: copyId, name: "Notify team (copy)" }));
+
+    await handlers.duplicate({
+      req: new Request("http://localhost/api/v3/workflows/x/duplicate", { method: "POST" }),
+      ctx: auditCtx(),
+      params: { workflowId },
+    });
+
+    expect(recordAudit).toHaveBeenCalledTimes(1);
+    const detail = recordAudit.mock.calls[0][0];
+    expect(detail.targetId).toBe(copyId);
+    expect(detail.oldObject).toBeUndefined();
+    expect(detail.newObject).toEqual(expect.objectContaining({ id: copyId }));
+  });
+
+  test("enable surfaces the draft -> enabled status transition in both snapshots", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
+    service.enableWorkflow.mockResolvedValue(makeRow({ status: "enabled" }));
+
+    await handlers.enable({ ctx: auditCtx(), params: { workflowId } });
+
+    const detail = recordAudit.mock.calls[0][0];
+    expect(detail.oldObject).toEqual(expect.objectContaining({ status: "draft" }));
+    expect(detail.newObject).toEqual(expect.objectContaining({ status: "enabled" }));
+  });
+
+  test("disable surfaces the enabled -> disabled status transition", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "enabled" }));
+    service.disableWorkflow.mockResolvedValue(makeRow({ status: "disabled" }));
+
+    await handlers.disable({ ctx: auditCtx(), params: { workflowId } });
+
+    const detail = recordAudit.mock.calls[0][0];
+    expect(detail.oldObject).toEqual(expect.objectContaining({ status: "enabled" }));
+    expect(detail.newObject).toEqual(expect.objectContaining({ status: "disabled" }));
+  });
+
+  test("archive surfaces the * -> archived status transition", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft" }));
+    service.setStatus.mockResolvedValue(makeRow({ status: "archived" }));
+
+    await handlers.archive({ ctx: auditCtx(), params: { workflowId } });
+
+    const detail = recordAudit.mock.calls[0][0];
+    expect(detail.oldObject).toEqual(expect.objectContaining({ status: "draft" }));
+    expect(detail.newObject).toEqual(expect.objectContaining({ status: "archived" }));
+  });
+
+  test("unarchive surfaces the archived -> draft status transition", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "archived" }));
+    service.setStatus.mockResolvedValue(makeRow({ status: "draft" }));
+
+    await handlers.unarchive({ ctx: auditCtx(), params: { workflowId } });
+
+    const detail = recordAudit.mock.calls[0][0];
+    expect(detail.oldObject).toEqual(expect.objectContaining({ status: "archived" }));
+    expect(detail.newObject).toEqual(expect.objectContaining({ status: "draft" }));
+  });
+
+  test("redacts send_email PII in the snapshot definition while keeping the diff readable", async () => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "draft", name: "Before" }));
+    service.updateWorkflow.mockResolvedValue(makeRow({ status: "draft", name: "After" }));
+
+    await handlers.patch({ req: patchRequest({ name: "After" }), ctx: auditCtx(), params: { workflowId } });
+
+    const detail = recordAudit.mock.calls[0][0];
+    // Emails from the definition fixture must not leak into either snapshot.
+    expect(JSON.stringify(detail.oldObject)).not.toContain("@example.com");
+    expect(JSON.stringify(detail.newObject)).not.toContain("@example.com");
+    // The non-PII change is still readable.
+    expect(detail.oldObject).toEqual(expect.objectContaining({ name: "Before" }));
+    expect(detail.newObject).toEqual(expect.objectContaining({ name: "After" }));
+    // The send_email recipient is masked (present), not dropped.
+    const newDef = (detail.newObject as { definition: { nodes: { config: { to: string } }[] } }).definition;
+    expect(newDef.nodes[0].config.to).toMatch(/^\[redacted:[0-9a-f]{12}]$/);
+  });
+
+  test("a recipient-only edit still surfaces as a change (masked, not collapsed)", async () => {
+    const withRecipient = (to: string): WorkflowRowWithLastRun =>
+      makeRow({
+        status: "draft",
+        definition: {
+          ...definition,
+          nodes: [{ ...definition.nodes[0], config: { ...definition.nodes[0].config, to } }],
+        },
+      });
+    service.getWorkflowById.mockResolvedValue(withRecipient("old@example.com"));
+    service.updateWorkflow.mockResolvedValue(withRecipient("new@example.com"));
+
+    await handlers.patch({ req: patchRequest({ definition }), ctx: auditCtx(), params: { workflowId } });
+
+    const detail = recordAudit.mock.calls[0][0];
+    const readTo = (snapshot: unknown): string =>
+      (snapshot as { definition: { nodes: { config: { to: string } }[] } }).definition.nodes[0].config.to;
+    const oldTo = readTo(detail.oldObject);
+    const newTo = readTo(detail.newObject);
+
+    // Distinct value-stable markers → a recipient change still diffs, but no raw email leaks.
+    expect(oldTo).not.toBe(newTo);
+    expect(oldTo).not.toContain("@example.com");
+    expect(newTo).not.toContain("@example.com");
+  });
+
+  test("is not called on a failed mutation (unknown workflow)", async () => {
+    service.getWorkflowById.mockResolvedValue(null);
+
+    await handlers.delete({ ctx: auditCtx(), params: { workflowId } });
+
+    expect(recordAudit).not.toHaveBeenCalled();
+  });
+
+  test("a missing sink (no adapter wired) is a no-op, mutation still succeeds", async () => {
+    service.createWorkflow.mockResolvedValue(makeRow());
+
+    const res = await handlers.create({
+      req: postRequest({ workspaceId, name: "Notify team", definition }),
+      ctx: makeCtx({ recordAudit: undefined }),
+    });
+
+    expect(res.status).toBe(201);
+  });
+
+  test("a throwing sink is swallowed: the already-successful mutation still returns success", async () => {
+    service.createWorkflow.mockResolvedValue(makeRow());
+    const throwingSink = vi.fn().mockRejectedValue(new Error("audit backend down"));
+
+    const res = await handlers.create({
+      req: postRequest({ workspaceId, name: "Notify team", definition }),
+      ctx: auditCtx({ recordAudit: throwingSink }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(throwingSink).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalled();
+  });
+});

--- a/packages/workflows/src/handlers/workflows.handlers.test.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.test.ts
@@ -610,6 +610,7 @@ describe("recordAudit (audit-sink port)", () => {
     expect(recordAudit).toHaveBeenCalledTimes(1);
     const detail = recordAudit.mock.calls[0][0];
     expect(detail.targetId).toBe(workflowId);
+    expect(detail.workspaceId).toBe(workspaceId);
     expect(detail.oldObject).toBeUndefined();
     expect(detail.newObject).toEqual(expect.objectContaining({ id: workflowId, workspaceId }));
   });

--- a/packages/workflows/src/handlers/workflows.handlers.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.ts
@@ -87,9 +87,9 @@ const loadAndAuthorize = async (
  * the shared audit redactor keys off field names it does not recognize on the workflow definition,
  * so masking at this seam guarantees those values never reach the audit `changes`.
  */
-const toAuditSnapshot = (row: WorkflowRowWithLastRun): Record<string, unknown> => {
+const toAuditSnapshot = (row: WorkflowRowWithLastRun, redactionKey?: string): Record<string, unknown> => {
   const resource = toWorkflowResource(row);
-  return { ...resource, definition: redactWorkflowDefinitionPII(resource.definition) };
+  return { ...resource, definition: redactWorkflowDefinitionPII(resource.definition, redactionKey) };
 };
 
 /**
@@ -200,7 +200,11 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
       const resource = validateOutput(ZWorkflowResource, toWorkflowResource(created));
 
       // New id only exists post-mutation; capture it here rather than parsing the Response.
-      await recordAuditSafely(ctx, { targetId: created.id, newObject: toAuditSnapshot(created) });
+      await recordAuditSafely(ctx, {
+        targetId: created.id,
+        workspaceId: created.workspaceId,
+        newObject: toAuditSnapshot(created, ctx.auditRedactionKey),
+      });
 
       return createdResponse(resource, `/api/v3/workflows/${resource.id}`, ctx.requestId);
     } catch (error) {
@@ -241,8 +245,9 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
 
       await recordAuditSafely(ctx, {
         targetId: updated.id,
-        oldObject: toAuditSnapshot(loaded),
-        newObject: toAuditSnapshot(updated),
+        workspaceId: updated.workspaceId,
+        oldObject: toAuditSnapshot(loaded, ctx.auditRedactionKey),
+        newObject: toAuditSnapshot(updated, ctx.auditRedactionKey),
       });
 
       return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
@@ -262,7 +267,11 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
       const resource = validateOutput(ZWorkflowResource, toWorkflowResource(created));
 
       // Target is the new copy, not the source; its id only exists after the mutation.
-      await recordAuditSafely(ctx, { targetId: created.id, newObject: toAuditSnapshot(created) });
+      await recordAuditSafely(ctx, {
+        targetId: created.id,
+        workspaceId: created.workspaceId,
+        newObject: toAuditSnapshot(created, ctx.auditRedactionKey),
+      });
 
       return createdResponse(resource, `/api/v3/workflows/${resource.id}`, ctx.requestId);
     } catch (error) {
@@ -277,7 +286,11 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
 
       await service.deleteWorkflow({ workflowId: params.workflowId, workspaceId: loaded.workspaceId });
 
-      await recordAuditSafely(ctx, { targetId: loaded.id, oldObject: toAuditSnapshot(loaded) });
+      await recordAuditSafely(ctx, {
+        targetId: loaded.id,
+        workspaceId: loaded.workspaceId,
+        oldObject: toAuditSnapshot(loaded, ctx.auditRedactionKey),
+      });
 
       return noContentResponse(ctx.requestId);
     } catch (error) {
@@ -300,8 +313,9 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
 
       await recordAuditSafely(ctx, {
         targetId: updated.id,
-        oldObject: toAuditSnapshot(loaded),
-        newObject: toAuditSnapshot(updated),
+        workspaceId: updated.workspaceId,
+        oldObject: toAuditSnapshot(loaded, ctx.auditRedactionKey),
+        newObject: toAuditSnapshot(updated, ctx.auditRedactionKey),
       });
 
       return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
@@ -325,8 +339,9 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
 
       await recordAuditSafely(ctx, {
         targetId: updated.id,
-        oldObject: toAuditSnapshot(loaded),
-        newObject: toAuditSnapshot(updated),
+        workspaceId: updated.workspaceId,
+        oldObject: toAuditSnapshot(loaded, ctx.auditRedactionKey),
+        newObject: toAuditSnapshot(updated, ctx.auditRedactionKey),
       });
 
       return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
@@ -365,8 +380,9 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
 
       await recordAuditSafely(ctx, {
         targetId: updated.id,
-        oldObject: toAuditSnapshot(loaded),
-        newObject: toAuditSnapshot(updated),
+        workspaceId: updated.workspaceId,
+        oldObject: toAuditSnapshot(loaded, ctx.auditRedactionKey),
+        newObject: toAuditSnapshot(updated, ctx.auditRedactionKey),
       });
 
       return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
@@ -390,8 +406,9 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
 
       await recordAuditSafely(ctx, {
         targetId: updated.id,
-        oldObject: toAuditSnapshot(loaded),
-        newObject: toAuditSnapshot(updated),
+        workspaceId: updated.workspaceId,
+        oldObject: toAuditSnapshot(loaded, ctx.auditRedactionKey),
+        newObject: toAuditSnapshot(updated, ctx.auditRedactionKey),
       });
 
       return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);

--- a/packages/workflows/src/handlers/workflows.handlers.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.ts
@@ -20,6 +20,7 @@ import { createdResponse, dataResponse, listResponse, noContentResponse } from "
 import type { WorkflowRowWithLastRun } from "../services/ports";
 import type { WorkflowsService } from "../services/workflows.service";
 import { ZWorkflowExecutableDefinition } from "../types/document";
+import { redactWorkflowDefinitionPII } from "./audit-redaction";
 import type { TriggerSurveyCheck, WorkflowApiAccess, WorkflowApiContext } from "./context";
 import { parseListWorkflowsQuery } from "./parse-list-query";
 import { toWorkflowListItem, toWorkflowResource } from "./serializers";
@@ -74,6 +75,37 @@ const loadAndAuthorize = async (
   if (authorized instanceof Response) return authorized;
 
   return row;
+};
+
+/**
+ * Plain before/after snapshot for the audit sink. Reuses the serialized resource shape (the same
+ * plain object the response carries), so the adapter's diff surfaces `name` / `description` /
+ * `definition` and the `status` transition. Returned as a `Record` because the audit port's
+ * snapshots are intentionally untyped, app-agnostic plain objects.
+ *
+ * The definition's `send_email` PII (recipient/sender addresses, subject, body) is redacted here —
+ * the shared audit redactor keys off field names it does not recognize on the workflow definition,
+ * so masking at this seam guarantees those values never reach the audit `changes`.
+ */
+const toAuditSnapshot = (row: WorkflowRowWithLastRun): Record<string, unknown> => {
+  const resource = toWorkflowResource(row);
+  return { ...resource, definition: redactWorkflowDefinitionPII(resource.definition) };
+};
+
+/**
+ * Invoke the injected audit sink, swallowing any rejection. The handlers call this only AFTER the
+ * mutation has already succeeded, so an audit problem must never turn a successful mutation into an
+ * error response — the package guarantees this regardless of how the adapter implements the port.
+ */
+const recordAuditSafely = async (
+  ctx: WorkflowApiContext,
+  detail: Parameters<NonNullable<WorkflowApiContext["recordAudit"]>>[0]
+): Promise<void> => {
+  try {
+    await ctx.recordAudit?.(detail);
+  } catch (error) {
+    ctx.logger.error({ error }, "Failed to record workflow audit detail");
+  }
 };
 
 /** Map a failed trigger-survey check to field-level `invalid_params` on the definition's trigger config. */
@@ -167,6 +199,9 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
 
       const resource = validateOutput(ZWorkflowResource, toWorkflowResource(created));
 
+      // New id only exists post-mutation; capture it here rather than parsing the Response.
+      await recordAuditSafely(ctx, { targetId: created.id, newObject: toAuditSnapshot(created) });
+
       return createdResponse(resource, `/api/v3/workflows/${resource.id}`, ctx.requestId);
     } catch (error) {
       return toProblemResponse(error, ctx);
@@ -204,6 +239,12 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
         input
       );
 
+      await recordAuditSafely(ctx, {
+        targetId: updated.id,
+        oldObject: toAuditSnapshot(loaded),
+        newObject: toAuditSnapshot(updated),
+      });
+
       return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
     } catch (error) {
       return toProblemResponse(error, ctx);
@@ -219,6 +260,10 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
       const created = await service.duplicateWorkflow(loaded, { name: input.name, createdBy: ctx.userId });
 
       const resource = validateOutput(ZWorkflowResource, toWorkflowResource(created));
+
+      // Target is the new copy, not the source; its id only exists after the mutation.
+      await recordAuditSafely(ctx, { targetId: created.id, newObject: toAuditSnapshot(created) });
+
       return createdResponse(resource, `/api/v3/workflows/${resource.id}`, ctx.requestId);
     } catch (error) {
       return toProblemResponse(error, ctx);
@@ -231,6 +276,9 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
       if (loaded instanceof Response) return loaded;
 
       await service.deleteWorkflow({ workflowId: params.workflowId, workspaceId: loaded.workspaceId });
+
+      await recordAuditSafely(ctx, { targetId: loaded.id, oldObject: toAuditSnapshot(loaded) });
+
       return noContentResponse(ctx.requestId);
     } catch (error) {
       return toProblemResponse(error, ctx);
@@ -250,6 +298,12 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
         "archived"
       );
 
+      await recordAuditSafely(ctx, {
+        targetId: updated.id,
+        oldObject: toAuditSnapshot(loaded),
+        newObject: toAuditSnapshot(updated),
+      });
+
       return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
     } catch (error) {
       return toProblemResponse(error, ctx);
@@ -268,6 +322,12 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
         { workflowId: params.workflowId, workspaceId: loaded.workspaceId },
         "draft"
       );
+
+      await recordAuditSafely(ctx, {
+        targetId: updated.id,
+        oldObject: toAuditSnapshot(loaded),
+        newObject: toAuditSnapshot(updated),
+      });
 
       return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
     } catch (error) {
@@ -303,6 +363,12 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
         { definition: executable.data, publishedBy: ctx.userId }
       );
 
+      await recordAuditSafely(ctx, {
+        targetId: updated.id,
+        oldObject: toAuditSnapshot(loaded),
+        newObject: toAuditSnapshot(updated),
+      });
+
       return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);
     } catch (error) {
       return toProblemResponse(error, ctx);
@@ -320,6 +386,12 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
       const updated = await service.disableWorkflow({
         workflowId: params.workflowId,
         workspaceId: loaded.workspaceId,
+      });
+
+      await recordAuditSafely(ctx, {
+        targetId: updated.id,
+        oldObject: toAuditSnapshot(loaded),
+        newObject: toAuditSnapshot(updated),
       });
 
       return dataResponse(validateOutput(ZWorkflowResource, toWorkflowResource(updated)), ctx.requestId);

--- a/packages/workflows/src/server/index.ts
+++ b/packages/workflows/src/server/index.ts
@@ -15,7 +15,12 @@ export type { WorkflowsService } from "../services/workflows.service";
 export { createWorkflowsHandlers } from "../handlers/workflows.handlers";
 export type { WorkflowsHandlers } from "../handlers/workflows.handlers";
 
-export type { WorkflowApiAccess, WorkflowApiContext, AuthorizedWorkspace } from "../handlers/context";
+export type {
+  WorkflowApiAccess,
+  WorkflowApiContext,
+  AuthorizedWorkspace,
+  WorkflowAuditDetail,
+} from "../handlers/context";
 
 export {
   WorkflowApiError,


### PR DESCRIPTION
## What does this PR do?

Implements **ENG-1247** — workflow management mutations now emit complete, correct Enterprise audit events ("who edited which workflow and what changed"), reusing the existing audit-log subsystem.

Previously the wiring existed but every workflow audit event defaulted `targetId`/`organizationId` to `UNKNOWN_DATA` and `oldObject`/`newObject` to `undefined`, so events carried no target id, no org for session-authenticated users, and no `changes` diff. This closes that gap for all v3 management mutations (create, update, delete, enable, disable, archive, unarchive, duplicate).

**Changes**
- Adds a narrow, app-agnostic `recordAudit` port to `WorkflowApiContext`. Handlers surface `targetId` + before/after snapshots through it after a successful mutation. `recordAuditSafely` swallows + logs sink errors so an audit failure can never alter the API response or status code.
- The Next adapter (`buildWorkflowApiContext`) writes the snapshots onto the request's `auditLog` and resolves `organizationId` for the session path via `getOrganizationIdFromWorkspaceId`; the API-key path keeps the key's org. Both auth paths now log the real organization (no more `UNKNOWN_DATA`).
- Reuses the existing `created` / `updated` / `deleted` actions — lifecycle (enable/disable/archive/unarchive) is disambiguated by the `status` transition in the `changes` diff (e.g. `draft -> enabled`). No new enum values.
- Redacts `send_email` PII (`to` / `from` / `replyTo` / `subject` / `body`) workflow-scoped at the snapshot seam using a value-stable sha256 marker: recipients are never logged verbatim, yet a real recipient change still surfaces in the diff. The global `SENSITIVE_KEYS` list is intentionally left untouched to avoid app-wide over-redaction.
- `@formbricks/workflows` stays framework-agnostic — no imports from `@/modules/ee/audit-logs` or any app module; audit details flow only through the injected port. Package is rebuilt so `apps/web` picks up the new context/port types.

**Out of scope** (separate tickets): run-lifecycle / run-observability audit, worker-emitted events (`queueAuditEventWithoutRequest`), audit storage / hashing / retention, and any audit-browsing UI.

Fixes ENG-1247

## How should this be tested?

Audit events are produced server-side; coverage is via unit tests (no UI change).

- `pnpm --filter @formbricks/workflows test` — 9 files / 146 passed (audit-sink port per operation, PII redaction + value-stable marker, throwing-sink resilience).
- `pnpm --filter @formbricks/web exec vitest run app/api/v3/workflows app/api/v3/lib modules/ee/audit-logs lib/utils/logger-helpers` — 8 files / 93 passed (session-vs-API-key org resolution, license-disabled no-op, failure path).
- Manual: with `AUDIT_LOG_ENABLED=1` + EE license, exercise each v3 workflow mutation and confirm exactly one audit event with `target.type = "workflow"`, real `target.id`, real `organizationId`, correct `actor`, and a `changes` diff showing the status transition. With audit logging disabled, confirm no events and unchanged API responses.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build` (scoped: `@formbricks/workflows` build + publint clean)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues (no UI change)
- [ ] First PR at Formbricks? Please sign the CLA!

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR (n/a — no UI change)
- [ ] Updated the Formbricks Docs if changes were necessary (n/a)
