### PR TITLE
fix(survey-ui): scope Tailwind v4 global CSS to #fbjs to stop host-page pollution

### DIFF
--- a/packages/survey-ui/package.json
+++ b/packages/survey-ui/package.json
@@ -52,8 +52,8 @@
   },
   "scripts": {
     "dev": "vite build --watch --mode dev",
-    "build": "vite build",
-    "build:dev": "vite build --mode dev",
+    "build": "vite build && node scripts/assert-scoped-css.mjs",
+    "build:dev": "vite build --mode dev && node scripts/assert-scoped-css.mjs",
     "go": "vite build --watch --mode dev",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src --fix --ext .ts,.js,.tsx,.jsx",

--- a/packages/survey-ui/postcss.config.mjs
+++ b/packages/survey-ui/postcss.config.mjs
@@ -1,5 +1,14 @@
+import tailwindcss from "@tailwindcss/postcss";
+// Same three #fbjs-scoping plugins used by @formbricks/surveys. Tailwind v4
+// emits `@layer properties`, `@layer theme { :root, :host }` and
+// `@property --tw-*` globally (by spec), which leak into and break host-page
+// styles when the survey widget injects this bundle. These plugins confine
+// them to #fbjs. They MUST run after Tailwind has compiled, so the Tailwind
+// PostCSS plugin is processed here (not via @tailwindcss/vite) to guarantee
+// ordering. See packages/vite-plugins/postcss-scope-fbjs.cjs and
+// https://github.com/formbricks/js/issues/46.
+import scopeFbjs from "../vite-plugins/postcss-scope-fbjs.cjs";
+
 export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
-  },
+  plugins: [tailwindcss(), ...scopeFbjs.scopeFbjsPlugins()],
 };

--- a/packages/survey-ui/scripts/assert-scoped-css.mjs
+++ b/packages/survey-ui/scripts/assert-scoped-css.mjs
@@ -42,11 +42,11 @@ if (/@property\s+--tw-/.test(css)) {
 
 // Any :root/:host token not immediately preceded by a #fbjs scope on the same
 // compound selector. We scan selector preludes only (text before `{`, split on `}`).
-const selectorChunks = css.split("}").map((chunk) => chunk.slice(0, chunk.indexOf("{") + 1 || undefined));
 const globalSelector = /(^|[,\s>+~(])(:root|:host)(?![\w-])/;
-for (const chunk of selectorChunks) {
-  const prelude = chunk.includes("{") ? chunk.slice(0, chunk.indexOf("{")) : "";
-  if (!prelude) continue;
+for (const chunk of css.split("}")) {
+  const braceIndex = chunk.indexOf("{");
+  if (braceIndex === -1) continue;
+  const prelude = chunk.slice(0, braceIndex);
   for (const selector of prelude.split(",")) {
     if (globalSelector.test(selector) && !selector.includes("#fbjs")) {
       violations.push(`unscoped selector: \`${selector.trim().slice(0, 80)}\``);

--- a/packages/survey-ui/scripts/assert-scoped-css.mjs
+++ b/packages/survey-ui/scripts/assert-scoped-css.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Post-build guard for the standalone stylesheet (dist/survey-ui.css).
+ *
+ * The scoping PostCSS plugins (packages/vite-plugins/postcss-scope-fbjs.cjs) match
+ * Tailwind's CURRENT emission shapes exactly (`@layer properties`, bare `:root` /
+ * `:host` selectors). Their unit tests feed a frozen fixture, so a future Tailwind
+ * upgrade that changes the emitted shape (e.g. `:root:where(...)`) would slip past
+ * the plugins AND the tests. This script asserts against the real build artifact
+ * instead: if any forbidden global pattern survives into dist/survey-ui.css, the
+ * build fails — a dependency bump cannot silently reintroduce host-page pollution.
+ *
+ * Run automatically after `vite build` (see the package build script).
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const cssPath = resolve(import.meta.dirname, "../dist/survey-ui.css");
+
+let css;
+try {
+  css = readFileSync(cssPath, "utf8");
+} catch {
+  console.error(`[assert-scoped-css] ${cssPath} not found — run after vite build.`);
+  process.exit(1);
+}
+
+// Forbidden global patterns. Selector checks look for :root/:host used as the start
+// of a selector (optionally inside :where/:is or with chained pseudo-classes) rather
+// than requiring an exact bare match, so shape changes like `:root:where(...)` are
+// still caught. `#fbjs :root`-style descendants cannot occur (html can't nest), so
+// any occurrence outside a #fbjs-prefixed selector is a leak.
+const violations = [];
+
+if (css.includes("@layer properties")) {
+  violations.push("`@layer properties` block (Tailwind property registrations leak to the host page)");
+}
+
+if (/@property\s+--tw-/.test(css)) {
+  violations.push("`@property --tw-*` registration (global custom-property registration)");
+}
+
+// Any :root/:host token not immediately preceded by a #fbjs scope on the same
+// compound selector. We scan selector preludes only (text before `{`, split on `}`).
+const selectorChunks = css.split("}").map((chunk) => chunk.slice(0, chunk.indexOf("{") + 1 || undefined));
+const globalSelector = /(^|[,\s>+~(])(:root|:host)(?![\w-])/;
+for (const chunk of selectorChunks) {
+  const prelude = chunk.includes("{") ? chunk.slice(0, chunk.indexOf("{")) : "";
+  if (!prelude) continue;
+  for (const selector of prelude.split(",")) {
+    if (globalSelector.test(selector) && !selector.includes("#fbjs")) {
+      violations.push(`unscoped selector: \`${selector.trim().slice(0, 80)}\``);
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error("[assert-scoped-css] dist/survey-ui.css leaks global styles to the host page:");
+  for (const violation of violations) console.error(`  - ${violation}`);
+  console.error(
+    "[assert-scoped-css] The postcss-scope-fbjs plugins no longer match Tailwind's output shape — update packages/vite-plugins/postcss-scope-fbjs.cjs."
+  );
+  process.exit(1);
+}
+
+console.log("[assert-scoped-css] dist/survey-ui.css is fully #fbjs-scoped ✔");

--- a/packages/survey-ui/src/styles/scope-fbjs.test.ts
+++ b/packages/survey-ui/src/styles/scope-fbjs.test.ts
@@ -1,0 +1,92 @@
+import postcss from "postcss";
+import { describe, expect, test } from "vitest";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+import scopeFbjs from "../../../vite-plugins/postcss-scope-fbjs.cjs";
+
+/**
+ * Regression guard for ENG-1333 / formbricks/js#46.
+ *
+ * The survey widget injects @formbricks/survey-ui's compiled CSS into the host
+ * page's <head>. Tailwind v4 emits three constructs that are GLOBAL by spec and
+ * cannot be confined by `important: "#fbjs"` selector scoping:
+ *   1. @layer properties { *, :before, :after, ::backdrop { --tw-*: ... } }
+ *   2. @layer theme      { :root, :host { ... } }
+ *   3. @property --tw-*  { inherits: false; ... }
+ * If any of these reach the host page, they reset/override the host's own
+ * Tailwind custom properties and theme, breaking host UI (shadows, rings,
+ * transforms, gradients, colors).
+ *
+ * These tests run the shared scoping plugins over representative Tailwind v4
+ * output and assert nothing global survives.
+ */
+
+const run = (css: string): string =>
+  postcss(scopeFbjs.scopeFbjsPlugins()).process(css, { from: undefined }).css;
+
+// A faithful slice of real Tailwind v4 compiled output.
+const TAILWIND_V4_OUTPUT = `
+@layer properties {
+  @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) {
+    *, :before, :after, ::backdrop {
+      --tw-translate-x: 0;
+      --tw-border-style: solid;
+      --tw-ring-offset-color: #fff;
+    }
+  }
+}
+@layer theme {
+  :root, :host {
+    --color-red-500: oklch(63.7% .237 25.331);
+    --spacing: .25rem;
+  }
+}
+@property --tw-translate-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+@property --tw-ring-offset-color {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #fff;
+}
+#fbjs .flex {
+  display: flex !important;
+}
+`;
+
+describe("postcss-scope-fbjs", () => {
+  const out = run(TAILWIND_V4_OUTPUT);
+
+  test("removes the global @layer properties reset block", () => {
+    expect(out).not.toMatch(/@layer properties/);
+    // the bare universal reset selector must not survive anywhere
+    expect(out).not.toMatch(/(^|[^-\w])\*\s*,\s*:before/);
+  });
+
+  test("re-scopes @layer theme :root/:host to #fbjs", () => {
+    expect(out).toMatch(/@layer theme/);
+    // no bare :root / :host remain
+    expect(out).not.toMatch(/(^|[^#\w-]):root\b/);
+    expect(out).not.toMatch(/(^|[^#\w-]):host\b/);
+    // theme variables now live under #fbjs
+    expect(out.replace(/\s+/g, " ")).toMatch(/#fbjs[^{]*\{[^}]*--color-red-500/);
+  });
+
+  test("replaces global @property --tw-* with a #fbjs-scoped rule", () => {
+    expect(out).not.toMatch(/@property\s+--tw-/);
+    const flat = out.replace(/\s+/g, " ");
+    // initial values re-emitted, scoped to #fbjs
+    expect(flat).toMatch(/#fbjs[^{]*\{[^}]*--tw-translate-x: 0/);
+    expect(flat).toMatch(/--tw-ring-offset-color: #fff/);
+  });
+
+  test("preserves utility classes already scoped to #fbjs", () => {
+    expect(out).toMatch(/#fbjs \.flex/);
+  });
+
+  test("is a no-op when there is nothing global to scope", () => {
+    const plain = "#fbjs .button { color: red; }";
+    expect(run(plain).trim()).toBe(plain);
+  });
+});

--- a/packages/survey-ui/vite.config.mts
+++ b/packages/survey-ui/vite.config.mts
@@ -2,8 +2,11 @@
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 import tsconfigPaths from "vite-tsconfig-paths";
-import tailwindcss from "@tailwindcss/vite";
 import { rewriteNodeNextDtsSpecifiers } from "../vite-plugins/node-next-dts";
+
+// NOTE: Tailwind is compiled via PostCSS (postcss.config.mjs), NOT the
+// @tailwindcss/vite plugin. The #fbjs-scoping plugins must run after Tailwind
+// emits its CSS, and PostCSS guarantees that ordering. See postcss.config.mjs.
 
 /**
  * Plugin to strip "use client" directives from bundled dependencies.
@@ -55,7 +58,6 @@ export default defineConfig({
       exclude: ["**/*.stories.tsx", "**/*.test.ts", "**/story-helpers.tsx"],
       beforeWriteFile: rewriteNodeNextDtsSpecifiers,
     }),
-    tailwindcss(),
   ],
   test: {
     environment: "node",

--- a/packages/surveys/postcss.config.cjs
+++ b/packages/surveys/postcss.config.cjs
@@ -3,11 +3,7 @@
 // scoping logic stays identical across both CSS bundles that ship together in
 // the injected <style>. See packages/vite-plugins/postcss-scope-fbjs.cjs and
 // https://github.com/formbricks/js/issues/46.
-const {
-  stripLayerProperties,
-  scopeLayerTheme,
-  replaceAtPropertyWithScoped,
-} = require("../vite-plugins/postcss-scope-fbjs.cjs");
+const { scopeFbjsPlugins } = require("../vite-plugins/postcss-scope-fbjs.cjs");
 
 // Matches a CSS numeric value followed by "rem" — e.g. "1rem", "1.5rem", "16rem".
 // Single character-class + single quantifier: no nested quantifiers, no backtracking risk.
@@ -39,5 +35,5 @@ const remtoEm = (opts = {}) => {
 };
 
 module.exports = {
-  plugins: [require("@tailwindcss/postcss"), require("autoprefixer"), remtoEm(), stripLayerProperties(), scopeLayerTheme(), replaceAtPropertyWithScoped()],
+  plugins: [require("@tailwindcss/postcss"), require("autoprefixer"), remtoEm(), ...scopeFbjsPlugins()],
 };

--- a/packages/surveys/postcss.config.cjs
+++ b/packages/surveys/postcss.config.cjs
@@ -1,3 +1,14 @@
+// The three #fbjs-scoping plugins (stripLayerProperties, scopeLayerTheme,
+// replaceAtPropertyWithScoped) are shared with @formbricks/survey-ui so the
+// scoping logic stays identical across both CSS bundles that ship together in
+// the injected <style>. See packages/vite-plugins/postcss-scope-fbjs.cjs and
+// https://github.com/formbricks/js/issues/46.
+const {
+  stripLayerProperties,
+  scopeLayerTheme,
+  replaceAtPropertyWithScoped,
+} = require("../vite-plugins/postcss-scope-fbjs.cjs");
+
 // Matches a CSS numeric value followed by "rem" — e.g. "1rem", "1.5rem", "16rem".
 // Single character-class + single quantifier: no nested quantifiers, no backtracking risk.
 const REM_REGEX = /([\d.]+)(rem)/gi; // NOSONAR -- single character-class quantifier on trusted CSS input; no backtracking risk
@@ -26,107 +37,6 @@ const remtoEm = (opts = {}) => {
     },
   };
 };
-
-// Strips the `@layer properties { ... }` block that Tailwind v4 emits as a
-// browser-compatibility fallback for `@property` declarations.
-//
-// Problem: CSS `@layer` at-rules are globally scoped by spec — they cannot be
-// confined by a surrounding selector. Even though all other Formbricks survey
-// styles are correctly scoped to `#fbjs`, the `@layer properties` block
-// contains a bare `*, :before, :after, ::backdrop` selector that resets all
-// `--tw-*` CSS custom properties on every element of the host page. This
-// breaks shadows, rings, transforms, and other Tailwind utilities on any site
-// that uses Tailwind v4 alongside the Formbricks SDK.
-//
-// The `@property` declarations already present in the same stylesheet cover
-// the same browser-compatibility need for all supporting browsers, so removing
-// `@layer properties` does not affect survey rendering.
-//
-// See: https://github.com/formbricks/js/issues/46
-const stripLayerProperties = () => {
-  return {
-    postcssPlugin: "postcss-strip-layer-properties",
-    AtRule: {
-      layer: (atRule) => {
-        if (atRule.params === "properties") {
-          atRule.remove();
-        }
-      },
-    },
-  };
-};
-stripLayerProperties.postcss = true;
-
-// Re-scopes `:root` and `:host` selectors inside `@layer theme` to `#fbjs`.
-//
-// Problem: Tailwind v4 emits `@layer theme { :root, :host { --color-*; --spacing; ... } }`
-// which sets CSS custom properties globally. When the survey widget injects this
-// into the host page, it overrides the host site's own Tailwind theme variables,
-// causing buttons and other styled elements to change color/appearance.
-//
-// Fix: Replace `:root` / `:host` selectors with `#fbjs` so theme variables are
-// scoped to the survey widget. CSS custom properties inherit, so all survey
-// descendants still pick them up.
-const scopeLayerTheme = () => {
-  return {
-    postcssPlugin: "postcss-scope-layer-theme",
-    AtRule: {
-      layer: (atRule) => {
-        if (atRule.params !== "theme") return;
-        atRule.walkRules((rule) => {
-          rule.selectors = rule.selectors.map((sel) => {
-            if (sel === ":root" || sel === ":host") return "#fbjs";
-            return sel;
-          });
-        });
-      },
-    },
-  };
-};
-scopeLayerTheme.postcss = true;
-
-// Replaces global `@property --tw-*` declarations with a scoped `#fbjs` rule
-// that provides the same initial values.
-//
-// Problem: `@property` is globally scoped by spec and cannot be confined to
-// `#fbjs`. Tailwind v4 emits declarations like:
-//   @property --tw-gradient-to-position { syntax: "<length-percentage>"; inherits: false; initial-value: 100% }
-//
-// `inherits: false` breaks inheritance of `--tw-*` custom properties on the
-// host page, and the `syntax` constraint rejects host-page values that don't
-// match. Both cause host-page Tailwind v3 utilities to lose their styling.
-//
-// Fix: Collect each property's initial-value, remove the `@property` rule,
-// then emit a single `#fbjs, #fbjs *, #fbjs ::before, #fbjs ::after` rule
-// with the initial values. This gives the survey widget the defaults it needs
-// while keeping everything scoped.
-const replaceAtPropertyWithScoped = () => {
-  return {
-    postcssPlugin: "postcss-replace-at-property-with-scoped",
-    OnceExit(root) {
-      const collected = new Map();
-      root.walkAtRules("property", (atRule) => {
-        if (!atRule.params.startsWith("--tw-")) return;
-        const name = atRule.params;
-        atRule.walkDecls("initial-value", (decl) => {
-          collected.set(name, decl.value);
-        });
-        atRule.remove();
-      });
-
-      if (collected.size === 0) return;
-      const postcss = require("postcss");
-      const rule = postcss.rule({
-        selectors: ["#fbjs", "#fbjs *", "#fbjs ::before", "#fbjs ::after", "#fbjs ::backdrop"],
-      });
-      for (const [name, value] of collected) {
-        rule.append(postcss.decl({ prop: name, value }));
-      }
-      root.append(rule);
-    },
-  };
-};
-replaceAtPropertyWithScoped.postcss = true;
 
 module.exports = {
   plugins: [require("@tailwindcss/postcss"), require("autoprefixer"), remtoEm(), stripLayerProperties(), scopeLayerTheme(), replaceAtPropertyWithScoped()],

--- a/packages/vite-plugins/.eslintrc.cjs
+++ b/packages/vite-plugins/.eslintrc.cjs
@@ -1,5 +1,9 @@
 module.exports = {
   extends: ["@formbricks/eslint-config/library.js"],
+  // Test files are run by vitest (esbuild) and are excluded from tsconfig, so
+  // they are not type-checked and must not be type-aware-linted either. Matches
+  // the convention in packages/survey-ui/.eslintrc.cjs.
+  ignorePatterns: ["**/*.test.ts"],
   parserOptions: {
     project: "tsconfig.json",
     tsconfigRootDir: __dirname,

--- a/packages/vite-plugins/package.json
+++ b/packages/vite-plugins/package.json
@@ -13,11 +13,15 @@
   "scripts": {
     "clean": "rimraf .turbo node_modules dist",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint . --ext .ts,.js,.tsx,.jsx"
+    "lint": "eslint . --ext .ts,.js,.tsx,.jsx",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
     "@formbricks/config-typescript": "workspace:*",
     "@formbricks/eslint-config": "workspace:*",
-    "vite": "7.3.5"
+    "postcss": "8.5.14",
+    "vite": "7.3.5",
+    "vitest": "4.1.6"
   }
 }

--- a/packages/vite-plugins/postcss-scope-fbjs.cjs
+++ b/packages/vite-plugins/postcss-scope-fbjs.cjs
@@ -108,7 +108,16 @@ const replaceAtPropertyWithScoped = () => {
       for (const [name, value] of collected) {
         rule.append(postcss.decl({ prop: name, value }));
       }
-      root.append(rule);
+      // Emit the fallback inside the low-priority `theme` layer rather than as an
+      // unlayered author rule. `@property` initial values are defaults that any
+      // real declaration overrides; an unlayered rule, by contrast, wins over
+      // every Tailwind `@layer` (theme/base/components/utilities) and would reset
+      // `--tw-*` set by the survey's own utilities. `theme` is the lowest layer
+      // (see `@layer theme, base, components, utilities` in the globals), so
+      // utilities still win and the fallback only applies when nothing sets it.
+      const layer = postcss.atRule({ name: "layer", params: "theme" });
+      layer.append(rule);
+      root.append(layer);
     },
   };
 };

--- a/packages/vite-plugins/postcss-scope-fbjs.cjs
+++ b/packages/vite-plugins/postcss-scope-fbjs.cjs
@@ -1,0 +1,130 @@
+// Shared PostCSS plugins that confine Tailwind v4's globally-scoped emissions
+// to the Formbricks survey container (#fbjs), preventing host-page CSS
+// pollution. Consumed by both @formbricks/surveys and @formbricks/survey-ui so
+// the scoping logic cannot drift between the two CSS bundles that ship together
+// in the injected <style> element (see packages/surveys/src/lib/styles.ts).
+//
+// Tailwind v4 emits three constructs that are global by spec and therefore
+// cannot be confined by Tailwind's `important: "#fbjs"` selector scoping:
+//   1. @layer properties { *, :before, :after, ::backdrop { --tw-*: ... } }
+//   2. @layer theme      { :root, :host { --color-*, --spacing, ... } }
+//   3. @property --tw-*  { inherits: false; syntax: ...; initial-value: ... }
+// Each leaks into the host page and breaks host Tailwind utilities (shadows,
+// rings, transforms, gradients, theme variables).
+//
+// See: https://github.com/formbricks/js/issues/46
+
+// Strips the `@layer properties { ... }` block that Tailwind v4 emits as a
+// browser-compatibility fallback for `@property` declarations.
+//
+// Problem: CSS `@layer` at-rules are globally scoped by spec — they cannot be
+// confined by a surrounding selector. Even though all other Formbricks survey
+// styles are correctly scoped to `#fbjs`, the `@layer properties` block
+// contains a bare `*, :before, :after, ::backdrop` selector that resets all
+// `--tw-*` CSS custom properties on every element of the host page. This
+// breaks shadows, rings, transforms, and other Tailwind utilities on any site
+// that uses Tailwind v4 alongside the Formbricks SDK.
+//
+// The `@property` declarations already present in the same stylesheet cover
+// the same browser-compatibility need for all supporting browsers, so removing
+// `@layer properties` does not affect survey rendering.
+const stripLayerProperties = () => {
+  return {
+    postcssPlugin: "postcss-strip-layer-properties",
+    AtRule: {
+      layer: (atRule) => {
+        if (atRule.params === "properties") {
+          atRule.remove();
+        }
+      },
+    },
+  };
+};
+stripLayerProperties.postcss = true;
+
+// Re-scopes `:root` and `:host` selectors inside `@layer theme` to `#fbjs`.
+//
+// Problem: Tailwind v4 emits `@layer theme { :root, :host { --color-*; --spacing; ... } }`
+// which sets CSS custom properties globally. When the survey widget injects this
+// into the host page, it overrides the host site's own Tailwind theme variables,
+// causing buttons and other styled elements to change color/appearance.
+//
+// Fix: Replace `:root` / `:host` selectors with `#fbjs` so theme variables are
+// scoped to the survey widget. CSS custom properties inherit, so all survey
+// descendants still pick them up.
+const scopeLayerTheme = () => {
+  return {
+    postcssPlugin: "postcss-scope-layer-theme",
+    AtRule: {
+      layer: (atRule) => {
+        if (atRule.params !== "theme") return;
+        atRule.walkRules((rule) => {
+          rule.selectors = rule.selectors.map((sel) => {
+            if (sel === ":root" || sel === ":host") return "#fbjs";
+            return sel;
+          });
+        });
+      },
+    },
+  };
+};
+scopeLayerTheme.postcss = true;
+
+// Replaces global `@property --tw-*` declarations with a scoped `#fbjs` rule
+// that provides the same initial values.
+//
+// Problem: `@property` is globally scoped by spec and cannot be confined to
+// `#fbjs`. Tailwind v4 emits declarations like:
+//   @property --tw-gradient-to-position { syntax: "<length-percentage>"; inherits: false; initial-value: 100% }
+//
+// `inherits: false` breaks inheritance of `--tw-*` custom properties on the
+// host page, and the `syntax` constraint rejects host-page values that don't
+// match. Both cause host-page Tailwind v3 utilities to lose their styling.
+//
+// Fix: Collect each property's initial-value, remove the `@property` rule,
+// then emit a single `#fbjs, #fbjs *, #fbjs ::before, #fbjs ::after` rule
+// with the initial values. This gives the survey widget the defaults it needs
+// while keeping everything scoped. The `postcss` helper is provided by the
+// plugin runtime, so this module does not depend on `postcss` being resolvable
+// from its own directory.
+const replaceAtPropertyWithScoped = () => {
+  return {
+    postcssPlugin: "postcss-replace-at-property-with-scoped",
+    OnceExit(root, { postcss }) {
+      const collected = new Map();
+      root.walkAtRules("property", (atRule) => {
+        if (!atRule.params.startsWith("--tw-")) return;
+        const name = atRule.params;
+        atRule.walkDecls("initial-value", (decl) => {
+          collected.set(name, decl.value);
+        });
+        atRule.remove();
+      });
+
+      if (collected.size === 0) return;
+      const rule = postcss.rule({
+        selectors: ["#fbjs", "#fbjs *", "#fbjs ::before", "#fbjs ::after", "#fbjs ::backdrop"],
+      });
+      for (const [name, value] of collected) {
+        rule.append(postcss.decl({ prop: name, value }));
+      }
+      root.append(rule);
+    },
+  };
+};
+replaceAtPropertyWithScoped.postcss = true;
+
+// Returns the three scoping plugins as instances, in the order they must run
+// (after Tailwind has compiled). Spread into a PostCSS `plugins` array.
+const scopeFbjsPlugins = () => [
+  stripLayerProperties(),
+  scopeLayerTheme(),
+  replaceAtPropertyWithScoped(),
+];
+
+module.exports = {
+  stripLayerProperties,
+  scopeLayerTheme,
+  replaceAtPropertyWithScoped,
+  scopeFbjsPlugins,
+};

--- a/packages/vite-plugins/postcss-scope-fbjs.test.ts
+++ b/packages/vite-plugins/postcss-scope-fbjs.test.ts
@@ -1,25 +1,21 @@
 import postcss from "postcss";
 import { describe, expect, test } from "vitest";
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 import scopeFbjs from "./postcss-scope-fbjs.cjs";
 
-/**
- * Regression guard for ENG-1333 / formbricks/js#46.
- *
- * @formbricks/survey-ui's and @formbricks/surveys' compiled CSS is injected into
- * the host page's <head> by the survey widget. Tailwind v4 emits three
- * constructs that are GLOBAL by spec and cannot be confined by `important:
- * "#fbjs"` selector scoping:
- *   1. @layer properties { *, :before, :after, ::backdrop { --tw-*: ... } }
- *   2. @layer theme      { :root, :host { ... } }
- *   3. @property --tw-*  { inherits: false; ... }
- * If any reach the host page, they reset/override the host's own Tailwind
- * custom properties and theme, breaking host UI (shadows, rings, transforms,
- * gradients, colors).
- *
- * These tests run the shared scoping plugins over representative Tailwind v4
- * output and assert nothing global survives.
- */
+// Regression guard for ENG-1333 / formbricks/js#46.
+//
+// survey-ui's and surveys' compiled CSS is injected into the host page's <head>
+// by the survey widget. Tailwind v4 emits three constructs that are GLOBAL by
+// spec and cannot be confined by the `important: "#fbjs"` selector scoping:
+//   1. "@layer properties" with a bare `*, :before, :after, ::backdrop` reset
+//   2. "@layer theme" with `:root, :host` custom properties
+//   3. "@property --tw-*" registrations (inherits: false)
+// If any reach the host page, they reset/override the host's own Tailwind
+// custom properties and theme, breaking host UI (shadows, rings, transforms,
+// gradients, colors).
+//
+// These tests run the shared scoping plugins over representative Tailwind v4
+// output and assert nothing global survives.
 
 const run = (css: string): string =>
   postcss(scopeFbjs.scopeFbjsPlugins()).process(css, { from: undefined }).css;
@@ -63,14 +59,14 @@ describe("postcss-scope-fbjs", () => {
   test("removes the global @layer properties reset block", () => {
     expect(out).not.toMatch(/@layer properties/);
     // the bare universal reset selector must not survive anywhere
-    expect(out).not.toMatch(/(^|[^-\w])\*\s*,\s*:before/);
+    expect(out).not.toMatch(/(?:^|[^-\w])\*\s*,\s*:before/);
   });
 
   test("re-scopes @layer theme :root/:host to #fbjs", () => {
     expect(out).toMatch(/@layer theme/);
     // no bare :root / :host remain
-    expect(out).not.toMatch(/(^|[^#\w-]):root\b/);
-    expect(out).not.toMatch(/(^|[^#\w-]):host\b/);
+    expect(out).not.toMatch(/(?:^|[^#\w-]):root\b/);
+    expect(out).not.toMatch(/(?:^|[^#\w-]):host\b/);
     // theme variables now live under #fbjs
     expect(flat).toMatch(/#fbjs[^{]*\{[^}]*--color-red-500/);
   });

--- a/packages/vite-plugins/postcss-scope-fbjs.test.ts
+++ b/packages/vite-plugins/postcss-scope-fbjs.test.ts
@@ -1,20 +1,21 @@
 import postcss from "postcss";
 import { describe, expect, test } from "vitest";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-import scopeFbjs from "../../../vite-plugins/postcss-scope-fbjs.cjs";
+import scopeFbjs from "./postcss-scope-fbjs.cjs";
 
 /**
  * Regression guard for ENG-1333 / formbricks/js#46.
  *
- * The survey widget injects @formbricks/survey-ui's compiled CSS into the host
- * page's <head>. Tailwind v4 emits three constructs that are GLOBAL by spec and
- * cannot be confined by `important: "#fbjs"` selector scoping:
+ * @formbricks/survey-ui's and @formbricks/surveys' compiled CSS is injected into
+ * the host page's <head> by the survey widget. Tailwind v4 emits three
+ * constructs that are GLOBAL by spec and cannot be confined by `important:
+ * "#fbjs"` selector scoping:
  *   1. @layer properties { *, :before, :after, ::backdrop { --tw-*: ... } }
  *   2. @layer theme      { :root, :host { ... } }
  *   3. @property --tw-*  { inherits: false; ... }
- * If any of these reach the host page, they reset/override the host's own
- * Tailwind custom properties and theme, breaking host UI (shadows, rings,
- * transforms, gradients, colors).
+ * If any reach the host page, they reset/override the host's own Tailwind
+ * custom properties and theme, breaking host UI (shadows, rings, transforms,
+ * gradients, colors).
  *
  * These tests run the shared scoping plugins over representative Tailwind v4
  * output and assert nothing global survives.
@@ -57,6 +58,7 @@ const TAILWIND_V4_OUTPUT = `
 
 describe("postcss-scope-fbjs", () => {
   const out = run(TAILWIND_V4_OUTPUT);
+  const flat = out.replace(/\s+/g, " ");
 
   test("removes the global @layer properties reset block", () => {
     expect(out).not.toMatch(/@layer properties/);
@@ -70,15 +72,20 @@ describe("postcss-scope-fbjs", () => {
     expect(out).not.toMatch(/(^|[^#\w-]):root\b/);
     expect(out).not.toMatch(/(^|[^#\w-]):host\b/);
     // theme variables now live under #fbjs
-    expect(out.replace(/\s+/g, " ")).toMatch(/#fbjs[^{]*\{[^}]*--color-red-500/);
+    expect(flat).toMatch(/#fbjs[^{]*\{[^}]*--color-red-500/);
   });
 
   test("replaces global @property --tw-* with a #fbjs-scoped rule", () => {
     expect(out).not.toMatch(/@property\s+--tw-/);
-    const flat = out.replace(/\s+/g, " ");
     // initial values re-emitted, scoped to #fbjs
     expect(flat).toMatch(/#fbjs[^{]*\{[^}]*--tw-translate-x: 0/);
     expect(flat).toMatch(/--tw-ring-offset-color: #fff/);
+  });
+
+  test("emits the --tw-* fallback inside the low-priority theme layer", () => {
+    // The fallback must be layered so Tailwind's own utility/theme declarations
+    // win over it; an unlayered rule would reset --tw-* set by survey utilities.
+    expect(flat).toMatch(/@layer theme\s*\{[^}]*#fbjs[^}]*--tw-translate-x: 0/);
   });
 
   test("preserves utility classes already scoped to #fbjs", () => {

--- a/packages/vite-plugins/tsconfig.json
+++ b/packages/vite-plugins/tsconfig.json
@@ -1,3 +1,4 @@
 {
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
   "extends": "@formbricks/config-typescript/js-library.json"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1146,9 +1146,15 @@ importers:
       '@formbricks/eslint-config':
         specifier: workspace:*
         version: link:../config-eslint
+      postcss:
+        specifier: 8.5.14
+        version: 8.5.14
       vite:
         specifier: 7.3.5
         version: 7.3.5(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
+      vitest:
+        specifier: 4.1.6
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.5(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 


### PR DESCRIPTION
## TL;DR (plain words)

When a Formbricks survey loads on a site, it adds CSS to style the survey popup. That CSS is supposed to touch **only the survey** — but Tailwind v4 emits a few constructs that are **global by nature** and ignore any prefix:
- a `*` rule that resets a hidden variable on **every** element
- `:root` theme colors/spacing
- `@property` declarations

The widget bundle (`@formbricks/surveys`) already strips/scopes these since #7685 / #7805. **This PR fixes the artifact that was still shipping them — `@formbricks/survey-ui`'s standalone stylesheet (`dist/survey-ui.css`, the `./styles` npm export) — and hardens both packages against the leak ever coming back.**

> **Correction after review (thanks @itsjavi):** an earlier version of this description claimed the served widget bundle was leaking. Verified against fresh builds of `main`: the UMD (`surveys.umd.cjs`) was **already clean** — the `?inline` import of survey-ui styles goes through the surveys package's PostCSS chain, which runs the scoping plugins. The leak lives only in the standalone `dist/survey-ui.css` artifact. The customer-facing half of ENG-1333 was fixed by #7805 (Apr 22); a report reproducing after that date would point at a different vector (most likely a cached pre-#7805 SDK).

## Problem (detail)

Tailwind v4 emits three constructs that are **global by spec** and cannot be confined by Tailwind's `important: "#fbjs"` selector scoping:

- `@layer properties { *, :before, :after, ::backdrop { --tw-*: ... } }` — resets every `--tw-*` custom property on **every element of the host page**
- `@layer theme { :root, :host { --color-*, --spacing, ... } }` — overrides the host's own theme variables
- `@property --tw-* { inherits: false; ... }` — breaks `--tw-*` inheritance on the host and rejects host values via `syntax`

On any host app using Tailwind, these break shadows, rings, transforms, gradients, and theme colors. Reported in ENG-1333 (and previously formbricks/js#46); fixed for the widget bundle in #7685 / #7805.

`@formbricks/survey-ui` was built with only `@tailwindcss/postcss`, so its **standalone stylesheet** (`dist/survey-ui.css`, exported as `@formbricks/survey-ui/styles`) still contained all three. Nothing inside this monorepo serves that file to end users — the widget imports the styles through its own (scoped) build — but any direct npm consumer of the `./styles` export received leaking CSS, and the duplicated plugin logic meant the two builds could silently drift apart.

## Fix

- Extract the three scoping plugins (`stripLayerProperties`, `scopeLayerTheme`, `replaceAtPropertyWithScoped`) into `packages/vite-plugins/postcss-scope-fbjs.cjs`, **shared by both packages** so the logic can't drift again.
- `survey-ui` now compiles Tailwind via **PostCSS** (not `@tailwindcss/vite`) so the scoping plugins run *after* Tailwind emits its CSS.
- Regression test (`packages/survey-ui/src/styles/scope-fbjs.test.ts`) asserting no global `@layer properties` / `:root` / `:host` / `@property --tw-*` survive scoping.
- **New (review follow-up): post-build guard on the real artifact.** The plugins match Tailwind's *current* emission shapes and the unit tests use a frozen fixture, so a Tailwind upgrade could reintroduce the leak with tests green. `packages/survey-ui/scripts/assert-scoped-css.mjs` now runs after every `vite build` and fails the build if `dist/survey-ui.css` contains `@layer properties`, `@property --tw-*`, or any selector reaching `:root`/`:host` without a `#fbjs` scope (loose-matched, so future shapes like `:root:where(...)` are caught too).

## Verification

All measured on **fresh builds** (clean dist, `--force`):

| artifact | main | this branch |
|---|---|---|
| `packages/surveys/dist/index.umd.cjs` (served widget) | ✅ clean — 0 `@layer properties`, 0 `@property --tw-`, 0 bare `:root`/`:host`, 21 `#fbjs`-scoped rules | ✅ clean (unchanged) |
| `packages/survey-ui/dist/survey-ui.css` (npm `./styles` export) | ❌ 1 `@layer properties`, 71 `@property --tw-*`, bare `:root`/`:host` | ✅ **0 / 0 / 0** |

- `survey-ui` test suite: 65/65 pass (incl. 5 new).
- Post-build guard: passes on this branch; negative-tested by appending `@layer properties`, `@property --tw-foo`, `:root:where(.x)` and `:host` to the built CSS — all four flagged, build fails.
- Survey rendering unaffected — all `--tw-*` defaults preserved, scoped to `#fbjs`.

## Reproduce locally

**See the leak in the built file, main vs this branch:**
```bash
# broken (main):
git checkout main
pnpm --filter @formbricks/survey-ui build
grep -c '@layer properties' packages/survey-ui/dist/survey-ui.css   # 1  <- leak
grep -c '@property --tw-'   packages/survey-ui/dist/survey-ui.css   # 71 <- leak

# fixed (this branch):
git checkout dhruwang/eng-1333-scope-survey-ui-css-to-fbjs
pnpm --filter @formbricks/survey-ui build
grep -c '@layer properties' packages/survey-ui/dist/survey-ui.css   # 0
grep -c '@property --tw-'   packages/survey-ui/dist/survey-ui.css   # 0
```

**See what the leak does in a browser** — save as `repro.html`, open, click the button:
```html
<!doctype html><html><head>
<style>
  .box{ --tw-ring-shadow:0 0 0 6px green; box-shadow:var(--tw-ring-shadow);
        width:120px;height:120px;margin:40px }
</style></head><body>
  <div class="box"></div>
  <button onclick="leak()">inject survey-ui's global CSS</button>
  <script>function leak(){
    const s=document.createElement('style');
    s.textContent='@layer properties{*,:before,:after,::backdrop{--tw-ring-shadow:0 0 #0000}}';
    document.head.appendChild(s);   // green ring vanishes -- host element broke
  }</script>
</body></html>
```
Green ring before click → gone after. That one line is exactly the kind of rule `dist/survey-ui.css` shipped to `./styles` consumers. After the fix, that block never reaches the page (stripped), and the survey's own version is scoped to `#fbjs`.

## ENG-1333 status

The customer-facing widget leak was fixed by #7805 (2026-04-22). This PR closes the remaining unscoped artifact (`./styles` npm export) and adds two layers of drift protection (shared plugins + post-build guard). Before closing the ticket, worth confirming the original report predates #7805 — if a customer reproduced it later, the vector is elsewhere (likely a cached pre-#7805 SDK) and needs its own follow-up.
