### PR TITLE
ci(auth): run the Better Auth integration suite in CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,6 +65,12 @@ jobs:
         run: pnpm install --frozen-lockfile --config.platform=linux --config.architecture=x64
         shell: bash
 
+      # Build the workspace packages the tests import (@formbricks/logger, cache, types, email, …) so
+      # vite can resolve their package.json `exports` → dist. Deps only (`^...`), not the Next app.
+      - name: Build workspace package dependencies
+        run: pnpm build --filter=@formbricks/web^...
+        shell: bash
+
       - name: Create .env
         run: pnpm dev:setup
         shell: bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,103 @@
+name: Integration Tests
+
+# Runs the Better Auth integration harness (apps/web/integration + the *.integration.test.ts files)
+# against a real Postgres + Valkey — the only runtime validation of the BA↔Formbricks boundary
+# (no DB mocks). The unit suite (`pnpm test`) mocks @formbricks/database, so these would otherwise
+# only run locally. Services + .env setup mirror e2e.yml.
+
+on:
+  pull_request:
+    paths:
+      - "apps/web/**"
+      - "packages/database/**"
+      - "packages/cache/**"
+      - ".github/workflows/integration-tests.yml"
+  workflow_dispatch:
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
+permissions:
+  contents: read
+
+jobs:
+  integration:
+    name: Better Auth integration tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: pgvector/pgvector@sha256:9ae02a756ba16a2d69dd78058e25915e36e189bb36ddf01ceae86390d7ed786a
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+      valkey:
+        image: valkey/valkey@sha256:12ba4f45a7c3e1d0f076acd616cb230834e75a77e8516dde382720af32832d6d
+        ports:
+          - 6379:6379
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/dangerous-git-checkout
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22.x
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --config.platform=linux --config.architecture=x64
+        shell: bash
+
+      - name: Create .env
+        run: pnpm dev:setup
+        shell: bash
+
+      - name: Point .env at the CI services + test database
+        run: |
+          sed -i "s|REDIS_URL=.*|REDIS_URL=redis://localhost:6379|" .env
+          sed -i "s|DATABASE_URL=.*|DATABASE_URL=postgresql://postgres:postgres@localhost:5432/formbricks_ba_test?schema=public|" .env
+          sed -i "s/ENTERPRISE_LICENSE_KEY=.*/ENTERPRISE_LICENSE_KEY=${{ secrets.ENTERPRISE_LICENSE_KEY }}/" .env
+        shell: bash
+
+      - name: Create the test database
+        run: psql "postgresql://postgres:postgres@localhost:5432/postgres" -v ON_ERROR_STOP=1 -c 'CREATE DATABASE formbricks_ba_test;'
+        shell: bash
+
+      - name: Apply schema + data migrations to the test database
+        run: pnpm db:migrate:dev
+        shell: bash
+
+      - name: Shape the schema for Better Auth (emailVerified boolean, Account.type nullable)
+        run: |
+          psql "postgresql://postgres:postgres@localhost:5432/formbricks_ba_test" -v ON_ERROR_STOP=1 <<'SQL'
+          ALTER TABLE "User" ALTER COLUMN email_verified DROP DEFAULT;
+          ALTER TABLE "User" ALTER COLUMN email_verified TYPE boolean USING (email_verified IS NOT NULL);
+          ALTER TABLE "User" ALTER COLUMN email_verified SET DEFAULT false;
+          ALTER TABLE "User" ALTER COLUMN email_verified SET NOT NULL;
+          ALTER TABLE "Account" ALTER COLUMN type DROP NOT NULL;
+          SQL
+        shell: bash
+
+      - name: Run Better Auth integration tests
+        # The DB is provisioned above, so global-setup skips its docker-exec clone (TEST_DB_PROVISIONED).
+        run: cd apps/web && pnpm test:integration
+        env:
+          TEST_DB_PROVISIONED: "1"
+        shell: bash

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -9,11 +9,21 @@ on:
   pull_request:
     # apps/web holds the auth code under test; packages/** because the harness transitively imports
     # several workspace packages (@formbricks/logger, cache, types, email, database) whose changes
-    # can affect the BA boundary.
+    # can affect the BA boundary. The dependency/toolchain files are included because a lockfile-only
+    # Better Auth/Prisma transitive bump, a workspace/root-manifest change, or an edit to the shared
+    # checkout action can all alter this job's behavior without touching apps/web or packages/**.
     paths:
       - "apps/web/**"
       - "packages/**"
+      - "pnpm-lock.yaml"
+      - "package.json"
+      - "pnpm-workspace.yaml"
+      - ".github/actions/dangerous-git-checkout/action.yml"
       - ".github/workflows/integration-tests.yml"
+  # Also run in the merge queue (matches pr.yml / docker-build-validation.yml) so this suite can be
+  # promoted to a required check that actually gates merges. merge_group events ignore `paths`, so the
+  # job always runs in the queue regardless of the PR-event filter above.
+  merge_group:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -51,6 +51,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false # no later step needs git auth (dangerous-git-checkout re-auths)
       - uses: ./.github/actions/dangerous-git-checkout
 
       - name: Setup Node.js 22.x
@@ -75,11 +77,13 @@ jobs:
         run: pnpm dev:setup
         shell: bash
 
+      # The harness exercises enterprise-gated flows (e.g. SSO provisioning) by calling the functions
+      # directly, so it doesn't need a real ENTERPRISE_LICENSE_KEY (verified: the suite is green with it
+      # empty). Only point the DB + Redis at the CI services.
       - name: Point .env at the CI services + test database
         run: |
           sed -i "s|REDIS_URL=.*|REDIS_URL=redis://localhost:6379|" .env
           sed -i "s|DATABASE_URL=.*|DATABASE_URL=postgresql://postgres:postgres@localhost:5432/formbricks_ba_test?schema=public|" .env
-          sed -i "s/ENTERPRISE_LICENSE_KEY=.*/ENTERPRISE_LICENSE_KEY=${{ secrets.ENTERPRISE_LICENSE_KEY }}/" .env
         shell: bash
 
       - name: Create the test database
@@ -90,15 +94,10 @@ jobs:
         run: pnpm db:migrate:dev
         shell: bash
 
+      # Shared with apps/web/integration/global-setup.ts (the local harness applies the same file) so
+      # CI and local provision an identical Better Auth schema shape.
       - name: Shape the schema for Better Auth (emailVerified boolean, Account.type nullable)
-        run: |
-          psql "postgresql://postgres:postgres@localhost:5432/formbricks_ba_test" -v ON_ERROR_STOP=1 <<'SQL'
-          ALTER TABLE "User" ALTER COLUMN email_verified DROP DEFAULT;
-          ALTER TABLE "User" ALTER COLUMN email_verified TYPE boolean USING (email_verified IS NOT NULL);
-          ALTER TABLE "User" ALTER COLUMN email_verified SET DEFAULT false;
-          ALTER TABLE "User" ALTER COLUMN email_verified SET NOT NULL;
-          ALTER TABLE "Account" ALTER COLUMN type DROP NOT NULL;
-          SQL
+        run: psql "postgresql://postgres:postgres@localhost:5432/formbricks_ba_test" -v ON_ERROR_STOP=1 -f apps/web/integration/ba-test-schema-shape.sql
         shell: bash
 
       - name: Run Better Auth integration tests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -7,16 +7,23 @@ name: Integration Tests
 
 on:
   pull_request:
+    # apps/web holds the auth code under test; packages/** because the harness transitively imports
+    # several workspace packages (@formbricks/logger, cache, types, email, database) whose changes
+    # can affect the BA boundary.
     paths:
       - "apps/web/**"
-      - "packages/database/**"
-      - "packages/cache/**"
+      - "packages/**"
       - ".github/workflows/integration-tests.yml"
   workflow_dispatch:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
+# Cancel superseded runs on the same PR/ref (matches pr.yml).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/apps/web/integration/ba-test-schema-shape.sql
+++ b/apps/web/integration/ba-test-schema-shape.sql
@@ -1,0 +1,14 @@
+-- Better Auth integration test-schema shape (ENG-1054).
+--
+-- The dev/migrated schema stores emailVerified as a nullable timestamp and Account.type as NOT NULL;
+-- Better Auth needs emailVerified as a non-null boolean and an optional Account.type (the cutover
+-- conversion). This patch is applied to the throwaway integration database (formbricks_ba_test) by
+-- BOTH callers so they always provision the identical shape:
+--   - local:  apps/web/integration/global-setup.ts (after the docker schema clone)
+--   - CI:     .github/workflows/integration-tests.yml (after `db:migrate:dev`)
+-- Keep this the single source of truth — do not inline these ALTERs in either caller.
+ALTER TABLE "User" ALTER COLUMN email_verified DROP DEFAULT;
+ALTER TABLE "User" ALTER COLUMN email_verified TYPE boolean USING (email_verified IS NOT NULL);
+ALTER TABLE "User" ALTER COLUMN email_verified SET DEFAULT false;
+ALTER TABLE "User" ALTER COLUMN email_verified SET NOT NULL;
+ALTER TABLE "Account" ALTER COLUMN type DROP NOT NULL;

--- a/apps/web/integration/ba-test-schema-shape.sql
+++ b/apps/web/integration/ba-test-schema-shape.sql
@@ -1,12 +1,13 @@
 -- Better Auth integration test-schema shape (ENG-1054).
 --
--- The dev/migrated schema stores emailVerified as a nullable timestamp and Account.type as NOT NULL;
--- Better Auth needs emailVerified as a non-null boolean and an optional Account.type (the cutover
--- conversion). This patch is applied to the throwaway integration database (formbricks_ba_test) by
--- BOTH callers so they always provision the identical shape:
---   - local:  apps/web/integration/global-setup.ts (after the docker schema clone)
---   - CI:     .github/workflows/integration-tests.yml (after `db:migrate:dev`)
--- Keep this the single source of truth — do not inline these ALTERs in either caller.
+-- In the dev/migrated schema the emailVerified column is a nullable timestamp and the Account type
+-- column is required. Better Auth instead expects a non-null boolean emailVerified and an optional
+-- Account type (the cutover conversion). This file is the single source of truth for that shape and is
+-- applied to the throwaway integration database (formbricks_ba_test) by both callers, so local and CI
+-- provision it identically:
+--   local: apps/web/integration/global-setup.ts (after the docker schema clone)
+--   CI: .github/workflows/integration-tests.yml (after the db migrate step)
+-- Do not duplicate the statements below in either caller.
 ALTER TABLE "User" ALTER COLUMN email_verified DROP DEFAULT;
 ALTER TABLE "User" ALTER COLUMN email_verified TYPE boolean USING (email_verified IS NOT NULL);
 ALTER TABLE "User" ALTER COLUMN email_verified SET DEFAULT false;

--- a/apps/web/integration/gen-boolean-client.mjs
+++ b/apps/web/integration/gen-boolean-client.mjs
@@ -3,7 +3,7 @@
 // @formbricks/database to a shim backed by this client so BA's real user/account creation works
 // against a real Postgres before the live schema is flipped. Derived from schema.prisma so it never
 // drifts. Output (generated/prisma-test) is gitignored. Run via `pnpm test:integration`.
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -45,5 +45,9 @@ if (schema === before) {
 writeFileSync(testSchema, schema);
 console.log("[gen-boolean-client] derived", testSchema);
 
-execSync(`pnpm -C ${dbDir} exec prisma generate --schema ${testSchema}`, { stdio: "inherit" });
+// execFileSync (no shell) passes dbDir/testSchema as literal argv — avoids building a shell command
+// string from import.meta.url-derived absolute paths (CodeQL: shell command from environment values).
+execFileSync("pnpm", ["-C", dbDir, "exec", "prisma", "generate", "--schema", testSchema], {
+  stdio: "inherit",
+});
 console.log("[gen-boolean-client] generated → packages/database/generated/prisma-test");

--- a/apps/web/integration/gen-boolean-client.mjs
+++ b/apps/web/integration/gen-boolean-client.mjs
@@ -5,7 +5,8 @@
 // drifts. Output (generated/prisma-test) is gitignored. Run via `pnpm test:integration`.
 import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { createRequire } from "node:module";
+import { delimiter, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -45,9 +46,25 @@ if (schema === before) {
 writeFileSync(testSchema, schema);
 console.log("[gen-boolean-client] derived", testSchema);
 
-// execFileSync (no shell) passes dbDir/testSchema as literal argv — avoids building a shell command
-// string from import.meta.url-derived absolute paths (CodeQL: shell command from environment values).
-execFileSync("pnpm", ["-C", dbDir, "exec", "prisma", "generate", "--schema", testSchema], {
+// Invoke the Prisma CLI directly through Node by ABSOLUTE path, rather than `pnpm exec prisma`:
+// - process.execPath is a fixed, unwriteable path to the running Node binary, and the CLI path is
+//   resolved from node_modules — so the command itself is never looked up via $PATH (Sonar S4036: a
+//   planted `pnpm`/`prisma` on a writable $PATH entry can't be executed).
+// - execFileSync (no shell) still passes every path as literal argv (CodeQL: no shell command built
+//   from import.meta.url-derived values).
+// Prisma spawns the schema's custom generators (e.g. prisma-json-types-generator) by bare name, which
+// it resolves via $PATH, so the child still needs node_modules/.bin — the .bin dir alongside the
+// resolved prisma package, a fixed project-owned directory (this is what `pnpm exec` set up before).
+const require = createRequire(import.meta.url);
+const prismaPkgJson = require.resolve("prisma/package.json");
+const prismaPkg = JSON.parse(readFileSync(prismaPkgJson, "utf8"));
+const prismaBin = typeof prismaPkg.bin === "string" ? prismaPkg.bin : prismaPkg.bin.prisma;
+const prismaDir = dirname(prismaPkgJson);
+const prismaCli = resolve(prismaDir, prismaBin);
+const nodeModulesBin = resolve(prismaDir, "../.bin");
+execFileSync(process.execPath, [prismaCli, "generate", "--schema", testSchema], {
+  cwd: dbDir,
   stdio: "inherit",
+  env: { ...process.env, PATH: `${nodeModulesBin}${delimiter}${process.env.PATH ?? ""}` },
 });
 console.log("[gen-boolean-client] generated → packages/database/generated/prisma-test");

--- a/apps/web/integration/global-setup.ts
+++ b/apps/web/integration/global-setup.ts
@@ -41,6 +41,13 @@ const REDIS_TEST_DB = safeEnv(process.env.TEST_REDIS_DB ?? "15", /^\d+$/, "TEST_
 const sh = (cmd: string): string => execSync(cmd, { stdio: "pipe" }).toString();
 
 export default function setup(): void {
+  // CI provisions formbricks_ba_test out-of-band (the workflow creates the DB, runs the migrations,
+  // and applies the two ALTERs below) because GitHub Actions service containers aren't reachable via
+  // `docker exec`. When that's already done, skip the docker-based clone + redis flush; per-test
+  // isolation still comes from resetDb (TRUNCATE), and a fresh CI Valkey starts empty. Local dev (flag
+  // unset) is unchanged.
+  if (process.env.TEST_DB_PROVISIONED === "1") return;
+
   const adminPsql = (sql: string) =>
     sh(`docker exec ${CONTAINER} psql -U postgres -q -c ${JSON.stringify(sql)}`);
   const testPsql = (sql: string) =>

--- a/apps/web/integration/global-setup.ts
+++ b/apps/web/integration/global-setup.ts
@@ -53,8 +53,6 @@ export default function setup(): void {
 
   const adminPsql = (sql: string) =>
     sh(`docker exec ${CONTAINER} psql -U postgres -q -c ${JSON.stringify(sql)}`);
-  const testPsql = (sql: string) =>
-    sh(`docker exec ${CONTAINER} psql -U postgres -q -d ${TEST_DB} -c ${JSON.stringify(sql)}`);
 
   adminPsql(`DROP DATABASE IF EXISTS ${TEST_DB} WITH (FORCE);`);
   adminPsql(`CREATE DATABASE ${TEST_DB};`);
@@ -67,18 +65,27 @@ export default function setup(): void {
         `psql -U postgres -q -v ON_ERROR_STOP=1 -d ${TEST_DB} -f /tmp/ba_test_schema.sql`
     )}`
   );
-  // Single source of truth for the Better Auth schema shape, shared with the CI workflow (which runs
-  // it via `psql -f`) so local and CI provision the same database — see ba-test-schema-shape.sql.
+  // Single source of truth for the Better Auth schema shape, shared with the CI workflow — see
+  // ba-test-schema-shape.sql. Apply it exactly the way CI does (`psql -v ON_ERROR_STOP=1 -f`) by
+  // piping the file to psql's stdin: with `-f`, a failed ALTER exits non-zero so execSync throws and
+  // the harness aborts loudly. (Passing the multi-statement SQL via `psql -c "<...>"` instead would
+  // run the good statements but swallow a mid-file failure — exit 0 — leaving a half-shaped DB that
+  // silently passes, the same trap the dump/restore step above guards against.)
   const schemaShapeSql = readFileSync(
     join(dirname(fileURLToPath(import.meta.url)), "ba-test-schema-shape.sql"),
     "utf8"
   );
-  testPsql(schemaShapeSql);
+  execSync(`docker exec -i ${CONTAINER} psql -U postgres -q -v ON_ERROR_STOP=1 -d ${TEST_DB} -f -`, {
+    stdio: "pipe",
+    input: schemaShapeSql,
+  });
 
   // Isolate Better Auth's Redis secondary storage (db 15) from the dev cache (db 0).
   try {
     sh(`docker exec ${REDIS_CONTAINER} redis-cli -n ${REDIS_TEST_DB} flushdb`);
-  } catch {
-    // redis-cli may be unavailable under that container name; the DB-backed assertions don't need it.
+  } catch (error) {
+    // redis-cli may be unavailable under that container name; the DB-backed assertions don't need it,
+    // so this is non-fatal — but surface it so a genuinely failing flush isn't silently swallowed.
+    console.warn(`[integration] skipped Redis flush (db ${REDIS_TEST_DB}): ${String(error)}`);
   }
 }

--- a/apps/web/integration/global-setup.ts
+++ b/apps/web/integration/global-setup.ts
@@ -1,5 +1,8 @@
 /* eslint-disable turbo/no-undeclared-env-vars -- harness-only env overrides (TEST_*), not app config */
 import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /**
  * Vitest globalSetup for the Better Auth integration harness (ENG-1054).
@@ -64,13 +67,13 @@ export default function setup(): void {
         `psql -U postgres -q -v ON_ERROR_STOP=1 -d ${TEST_DB} -f /tmp/ba_test_schema.sql`
     )}`
   );
-  testPsql(
-    `ALTER TABLE "User" ALTER COLUMN email_verified DROP DEFAULT;` +
-      `ALTER TABLE "User" ALTER COLUMN email_verified TYPE boolean USING (email_verified IS NOT NULL);` +
-      `ALTER TABLE "User" ALTER COLUMN email_verified SET DEFAULT false;` +
-      `ALTER TABLE "User" ALTER COLUMN email_verified SET NOT NULL;` +
-      `ALTER TABLE "Account" ALTER COLUMN type DROP NOT NULL;`
+  // Single source of truth for the Better Auth schema shape, shared with the CI workflow (which runs
+  // it via `psql -f`) so local and CI provision the same database — see ba-test-schema-shape.sql.
+  const schemaShapeSql = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), "ba-test-schema-shape.sql"),
+    "utf8"
   );
+  testPsql(schemaShapeSql);
 
   // Isolate Better Auth's Redis secondary storage (db 15) from the dev cache (db 0).
   try {

--- a/apps/web/modules/auth/lib/auth-two-factor.integration.test.ts
+++ b/apps/web/modules/auth/lib/auth-two-factor.integration.test.ts
@@ -50,9 +50,9 @@ describe("Better Auth two-factor (real Postgres)", () => {
 
     await auth.api.verifyTOTP({ body: { code: totp(secretFromUri(totpURI)) }, headers: { cookie } });
 
-    const user = await prisma.user.findUnique({ where: { id: userId }, include: { twoFactors: true } });
+    const user = await prisma.user.findUnique({ where: { id: userId }, include: { twoFactor: true } });
     expect(user?.twoFactorEnabled).toBe(true);
-    expect(user?.twoFactors).toHaveLength(1);
+    expect(user?.twoFactor).not.toBeNull(); // one TwoFactor row per user (one-to-one, @@unique(userId))
   });
 
   test("an enabled second factor gates sign-in: password yields a challenge, TOTP issues the session", async () => {


### PR DESCRIPTION
## What does this PR do?

Wires the **Better Auth integration suite** (`apps/web/integration/*` + the `*.integration.test.ts` files) into CI. That harness is the only runtime validation of the Better Auth ↔ Formbricks boundary — it drives the real Better Auth handler against a real Postgres + Redis (no DB mocks), covering sign-up/in/out, email verification + password reset, 2FA, SSO provisioning, account deletion, the forward-auth proxy session read, and the recent security guards (password-less delete-user + inactive-user sign-in). Until now **no workflow ran it**: `pnpm test` mocks `@formbricks/database` and the e2e job is Playwright, so these ~35 tests only ran when someone ran them locally.

Changes:
- **New `.github/workflows/integration-tests.yml`** — stands up Postgres (pgvector) + Valkey services, provisions a fresh `formbricks_ba_test` (migrate + the two Better-Auth-shape ALTERs: `email_verified` → boolean, `Account.type` nullable), and runs `pnpm test:integration`. Services / Node / pnpm / `.env` setup mirror `e2e.yml`.
- **`global-setup.ts` — a `TEST_DB_PROVISIONED` escape hatch.** The harness normally provisions the test DB via `docker exec <container> pg_dump|psql`, which can't run against GitHub Actions service containers (reached over `localhost`, not `docker exec`-able by name). When `TEST_DB_PROVISIONED=1`, global-setup trusts the workflow's out-of-band provisioning and skips the docker clone (per-test isolation still comes from `resetDb`). **Local dev behavior is unchanged** when the flag is unset.
- **`fix(test)`: the 2FA integration test was already broken on the epic** — it queried the old plural `twoFactors` relation and asserted `.toHaveLength(1)`, but `51a770cdb` made `TwoFactor` one-per-user (`User.twoFactor TwoFactor?`, `@@unique(userId)`). It went unnoticed precisely because the suite wasn't in CI. Fixed to the singular relation. (This is the first thing the new CI gate caught.)

Base: `epic/better-auth-migration` (the harness lives on the epic, not `main`, so the workflow has to land where it can run).

## How should this be tested?

Verified locally against the dev Postgres + Valkey, both provisioning paths:

- **Escape-hatch / CI path (exact):** fresh `formbricks_ba_test` → migrated from scratch (confirmed `TwoFactor_userId_key` unique index) → the two ALTERs (`email_verified` confirmed `boolean`) → `TEST_DB_PROVISIONED=1 pnpm test:integration` → **35/35 pass**.
- **Local docker path (flag unset):** `pnpm test:integration` → global-setup's docker clone still runs → **35/35 pass** (no regression to local dev).
- Authoritative check: the new **Integration Tests** job on this PR.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits (the escape hatch + the workflow's provisioning steps)
- [x] Ran `pnpm build` (the `@formbricks/database` package, for the migration runner)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs` (none added)
- [ ] Merged the latest changes from main — N/A: this targets `epic/better-auth-migration` and is branched off its current head
- [x] My changes don't cause any responsiveness issues (no UI changes)
- [ ] First PR at Formbricks? — no

### Appreciated

- [ ] If a UI change was made — N/A
- [ ] Updated the Formbricks Docs — N/A
