### PR TITLE
fix: fixes the environment and responses api for legacy sdks breaking

### DIFF
--- a/apps/web/app/api/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/client/[workspaceId]/responses/lib/response.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@formbricks/database/prisma";
 import type { TContactAttributes } from "@formbricks/types/contact-attribute";
 import type { TResponse } from "@formbricks/types/responses";
 import type { TTag } from "@formbricks/types/tags";
+import { normalizeResponseLanguage } from "@/lib/response/utils";
 import { evaluateResponseQuotas } from "@/modules/ee/quotas/lib/evaluation-service";
 
 type TQuotaEvaluationResponseInput = {
@@ -31,6 +32,9 @@ export const createResponseWithQuotaEvaluation = async <TInput extends TQuotaEva
   responseInput: TInput,
   createResponse: (responseInput: TInput, tx: Prisma.TransactionClient) => Promise<TResponse>
 ) => {
+  // Canonicalize once so quota evaluation uses the same code persisted on the response (createResponse
+  // canonicalizes the stored value via the same helper). Keeps a request internally consistent.
+  const canonicalLanguage = normalizeResponseLanguage(responseInput.language) ?? undefined;
   return await prisma.$transaction(async (tx: Prisma.TransactionClient) => {
     const response = await createResponse(responseInput, tx);
 
@@ -39,7 +43,7 @@ export const createResponseWithQuotaEvaluation = async <TInput extends TQuotaEva
       responseId: response.id,
       data: responseInput.data,
       variables: responseInput.variables,
-      language: responseInput.language,
+      language: canonicalLanguage,
       responseFinished: response.finished,
       tx,
     });

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.test.ts
@@ -34,7 +34,9 @@ vi.mock("@/lib/utils/helper", () => ({
   getOrganizationIdFromWorkspaceId: vi.fn(),
 }));
 
-vi.mock("@/lib/response/utils", () => ({
+vi.mock("@/lib/response/utils", async (importOriginal) => ({
+  // keep the real normalizeResponseLanguage; calculateTtcTotal stays mockable (tests configure it)
+  ...(await importOriginal<typeof import("@/lib/response/utils")>()),
   calculateTtcTotal: vi.fn((ttc) => ttc),
 }));
 
@@ -210,7 +212,7 @@ describe("createResponseWithQuotaEvaluation", () => {
       responseId: responseId,
       data: mockResponseInput.data,
       variables: mockResponseInput.variables,
-      language: mockResponseInput.language,
+      language: undefined, // null language is normalized to undefined for quota evaluation
       responseFinished: mockResponseInput.finished,
       tx: mockTx,
     });
@@ -264,7 +266,7 @@ describe("createResponseWithQuotaEvaluation", () => {
       responseId: responseId,
       data: mockResponseInput.data,
       variables: mockResponseInput.variables,
-      language: mockResponseInput.language,
+      language: undefined, // null language is normalized to undefined for quota evaluation
       responseFinished: mockResponseInput.finished,
       tx: mockTx,
     });

--- a/apps/web/app/api/v1/lib/utils.test.ts
+++ b/apps/web/app/api/v1/lib/utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { TResponseInput } from "@formbricks/types/responses";
+import { buildPrismaResponseData } from "./utils";
+
+const input = (language?: string): TResponseInput =>
+  ({ surveyId: "svy_1", finished: false, data: {}, language }) as unknown as TResponseInput;
+
+describe("buildPrismaResponseData — language canonicalization (ENG-1067)", () => {
+  test("canonicalizes a legacy language code", () => {
+    expect(buildPrismaResponseData(input("hi"), null, {}).language).toBe("hi-IN");
+  });
+
+  test("leaves an already-canonical code unchanged", () => {
+    expect(buildPrismaResponseData(input("hi-IN"), null, {}).language).toBe("hi-IN");
+  });
+
+  test("preserves the 'default' sentinel", () => {
+    expect(buildPrismaResponseData(input("default"), null, {}).language).toBe("default");
+  });
+
+  test("preserves an unresolvable value", () => {
+    expect(buildPrismaResponseData(input("123"), null, {}).language).toBe("123");
+  });
+
+  test("leaves undefined language as-is", () => {
+    expect(buildPrismaResponseData(input(undefined), null, {}).language).toBeUndefined();
+  });
+});

--- a/apps/web/app/api/v1/lib/utils.ts
+++ b/apps/web/app/api/v1/lib/utils.ts
@@ -1,4 +1,5 @@
 import { Prisma } from "@formbricks/database/prisma";
+import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
 import { TResponseInput } from "@formbricks/types/responses";
 
@@ -29,7 +30,10 @@ export const buildPrismaResponseData = (
     display: displayId ? { connect: { id: displayId } } : undefined,
     finished: finished,
     data: data,
-    language: language,
+    // Canonicalize on write (ENG-1067): stale SDK caches can submit a legacy code (e.g. "hi"); store
+    // its canonical BCP-47 form ("hi-IN") so the table stays canonical. "default" and unresolvable
+    // values are preserved (normalizeLanguageCode returns null → keep the original).
+    language: language ? (normalizeLanguageCode(language) ?? language) : language,
     ...(contact?.id && {
       contact: {
         connect: {

--- a/apps/web/app/api/v1/lib/utils.ts
+++ b/apps/web/app/api/v1/lib/utils.ts
@@ -1,7 +1,7 @@
 import { Prisma } from "@formbricks/database/prisma";
-import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
 import { TResponseInput } from "@formbricks/types/responses";
+import { normalizeResponseLanguage } from "@/lib/response/utils";
 
 export const buildPrismaResponseData = (
   responseInput: TResponseInput,
@@ -30,10 +30,7 @@ export const buildPrismaResponseData = (
     display: displayId ? { connect: { id: displayId } } : undefined,
     finished: finished,
     data: data,
-    // Canonicalize on write (ENG-1067): stale SDK caches can submit a legacy code (e.g. "hi"); store
-    // its canonical BCP-47 form ("hi-IN") so the table stays canonical. "default" and unresolvable
-    // values are preserved (normalizeLanguageCode returns null → keep the original).
-    language: language ? (normalizeLanguageCode(language) ?? language) : language,
+    language: normalizeResponseLanguage(language),
     ...(contact?.id && {
       contact: {
         connect: {

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
@@ -50,7 +50,11 @@ vi.mock("@/lib/constants", () => ({
 }));
 
 vi.mock("@/lib/organization/service");
-vi.mock("@/lib/response/utils");
+vi.mock("@/lib/response/utils", async (importOriginal) => ({
+  // keep the real normalizeResponseLanguage; calculateTtcTotal stays mockable (tests configure it)
+  ...(await importOriginal<typeof import("@/lib/response/utils")>()),
+  calculateTtcTotal: vi.fn(),
+}));
 vi.mock("@/lib/utils/helper");
 vi.mock("@/lib/utils/validate");
 vi.mock("@/modules/ee/quotas/lib/evaluation-service");
@@ -335,7 +339,7 @@ describe("createResponseWithQuotaEvaluation V2", () => {
       responseId: expectedResponse.id,
       data: mockResponseInput.data,
       variables: mockResponseInput.variables,
-      language: mockResponseInput.language,
+      language: "en-US", // canonicalized from "en"
       responseFinished: expectedResponse.finished,
       tx: mockTx,
     });
@@ -358,7 +362,7 @@ describe("createResponseWithQuotaEvaluation V2", () => {
       responseId: expectedResponse.id,
       data: mockResponseInput.data,
       variables: mockResponseInput.variables,
-      language: mockResponseInput.language,
+      language: "en-US", // canonicalized from "en"
       responseFinished: expectedResponse.finished,
       tx: mockTx,
     });

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
@@ -1,7 +1,6 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
-import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
 import {
   DatabaseError,
@@ -23,7 +22,7 @@ import { responseSelection } from "@/app/api/v1/client/[workspaceId]/responses/l
 import { TResponseInputV2 } from "@/app/api/v2/client/[workspaceId]/responses/types/response";
 import { assertDisplayOwnership } from "@/lib/display/service";
 import { getOrganization } from "@/lib/organization/service";
-import { calculateTtcTotal } from "@/lib/response/utils";
+import { calculateTtcTotal, normalizeResponseLanguage } from "@/lib/response/utils";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { validateInputs } from "@/lib/utils/validate";
 import { getContact } from "./contact";
@@ -50,9 +49,7 @@ const buildPrismaResponseData = (
     display: displayId ? { connect: { id: displayId } } : undefined,
     finished: finished,
     data: data,
-    // Canonicalize on write (ENG-1067): stale SDK caches can submit a legacy code (e.g. "hi"); store
-    // its canonical BCP-47 form ("hi-IN"). "default" and unresolvable values are preserved.
-    language: language ? (normalizeLanguageCode(language) ?? language) : language,
+    language: normalizeResponseLanguage(language),
     ...(contact?.id && {
       contact: {
         connect: {

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
+import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
 import {
   DatabaseError,
@@ -49,7 +50,9 @@ const buildPrismaResponseData = (
     display: displayId ? { connect: { id: displayId } } : undefined,
     finished: finished,
     data: data,
-    language: language,
+    // Canonicalize on write (ENG-1067): stale SDK caches can submit a legacy code (e.g. "hi"); store
+    // its canonical BCP-47 form ("hi-IN"). "default" and unresolvable values are preserved.
+    language: language ? (normalizeLanguageCode(language) ?? language) : language,
     ...(contact?.id && {
       contact: {
         connect: {

--- a/apps/web/lib/response/service.test.ts
+++ b/apps/web/lib/response/service.test.ts
@@ -64,6 +64,36 @@ describe("updateResponse", () => {
     vi.clearAllMocks();
   });
 
+  describe("language canonicalization (ENG-1067)", () => {
+    test("canonicalizes a legacy language code on update", async () => {
+      const currentResponse = createMockCurrentResponse();
+      vi.mocked(prisma.response.findUnique).mockResolvedValue(currentResponse as any);
+      vi.mocked(prisma.response.update).mockResolvedValue(currentResponse as any);
+
+      await updateResponse(mockResponseId, createMockResponseInput({ language: "hi" }));
+
+      expect(prisma.response.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ language: "hi-IN" }) })
+      );
+    });
+
+    test("preserves the 'default' sentinel and unresolvable codes", async () => {
+      const currentResponse = createMockCurrentResponse();
+      vi.mocked(prisma.response.findUnique).mockResolvedValue(currentResponse as any);
+      vi.mocked(prisma.response.update).mockResolvedValue(currentResponse as any);
+
+      await updateResponse(mockResponseId, createMockResponseInput({ language: "default" }));
+      expect(prisma.response.update).toHaveBeenLastCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ language: "default" }) })
+      );
+
+      await updateResponse(mockResponseId, createMockResponseInput({ language: "123" }));
+      expect(prisma.response.update).toHaveBeenLastCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ language: "123" }) })
+      );
+    });
+  });
+
   describe("TTC merging behavior", () => {
     test("should merge new TTC with existing TTC from previous blocks", async () => {
       const currentResponse = createMockCurrentResponse({

--- a/apps/web/lib/response/service.ts
+++ b/apps/web/lib/response/service.ts
@@ -39,6 +39,7 @@ import {
   getResponseMeta,
   getResponsesFileName,
   getResponsesJson,
+  normalizeResponseLanguage,
 } from "./utils";
 import { buildWhereClause } from "./where-clause";
 
@@ -538,7 +539,8 @@ export const updateResponse = async (
       : currentTtc;
     // Calculate total only when finished
     const ttc = responseInput.finished ? calculateTtcTotal(mergedTtc) : mergedTtc;
-    const language = responseInput.language;
+    // Canonicalize on write (ENG-1067), same as response creation — see normalizeResponseLanguage.
+    const language = normalizeResponseLanguage(responseInput.language);
     const variables = {
       ...currentResponse.variables,
       ...responseInput.variables,

--- a/apps/web/lib/response/utils.ts
+++ b/apps/web/lib/response/utils.ts
@@ -1,3 +1,4 @@
+import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import {
   TResponse,
   TResponseDataValue,
@@ -429,3 +430,12 @@ export const generateAllPermutationsOfSubsets = (array: string[]): string[][] =>
   findSubsets(0, []);
   return subsets;
 };
+
+/**
+ * Canonicalize a response's language code on write (ENG-1067). SDK clients — especially stale or
+ * anonymous caches — can submit a legacy code (e.g. "hi") at any point; storing its canonical BCP-47
+ * form ("hi-IN") keeps the Response table canonical. The "default" sentinel and unresolvable values
+ * are preserved (normalizeLanguageCode returns null → keep the original); null/undefined pass through.
+ */
+export const normalizeResponseLanguage = (language: string | null | undefined): string | null | undefined =>
+  language ? (normalizeLanguageCode(language) ?? language) : language;

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
@@ -5,6 +5,7 @@ import { Prisma, Response } from "@formbricks/database/prisma";
 import { PrismaErrorType } from "@formbricks/database/types/error";
 import { Result, err, ok } from "@formbricks/types/error-handlers";
 import { TResponse } from "@formbricks/types/responses";
+import { normalizeResponseLanguage } from "@/lib/response/utils";
 import { deleteDisplay } from "@/modules/api/v2/management/responses/[responseId]/lib/display";
 import { getSurveyQuestions } from "@/modules/api/v2/management/responses/[responseId]/lib/survey";
 import { findAndDeleteUploadedFilesInResponse } from "@/modules/api/v2/management/responses/[responseId]/lib/utils";
@@ -149,7 +150,8 @@ export const updateResponse = async (
       where: {
         id: responseId,
       },
-      data: responseInput,
+      // Canonicalize the language on write (ENG-1067) — see normalizeResponseLanguage.
+      data: { ...responseInput, language: normalizeResponseLanguage(responseInput.language) },
     });
 
     return ok(updatedResponse);

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
@@ -385,7 +385,7 @@ describe("Response Lib", () => {
       const result = await updateResponse(responseId, responseInput);
       expect(prisma.response.update).toHaveBeenCalledWith({
         where: { id: responseId },
-        data: responseInput,
+        data: { ...responseInput, language: "en-US" }, // language canonicalized on write
       });
 
       expect(result.ok).toBe(true);
@@ -401,7 +401,7 @@ describe("Response Lib", () => {
       const result = await updateResponse(responseId, responseInput);
       expect(prisma.response.update).toHaveBeenCalledWith({
         where: { id: responseId },
-        data: responseInput,
+        data: { ...responseInput, language: "en-US" }, // language canonicalized on write
       });
 
       expect(result.ok).toBe(true);
@@ -476,7 +476,7 @@ describe("Response Lib", () => {
 
       expect(mockTx.response.update).toHaveBeenCalledWith({
         where: { id: responseId },
-        data: responseInput,
+        data: { ...responseInput, language: "en-US" }, // language canonicalized on write
       });
       expect(evaluateResponseQuotas).toHaveBeenCalledWith({
         surveyId: response.surveyId,

--- a/apps/web/modules/api/v2/management/responses/lib/response.ts
+++ b/apps/web/modules/api/v2/management/responses/lib/response.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
 import { Prisma, Response } from "@formbricks/database/prisma";
+import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
 import { Result, err, ok } from "@formbricks/types/error-handlers";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
@@ -107,7 +108,9 @@ export const createResponse = async (
       }),
       finished,
       data,
-      language,
+      // Canonicalize on write (ENG-1067): store the canonical BCP-47 form ("hi" → "hi-IN"); "default"
+      // and unresolvable values are preserved (normalizeLanguageCode returns null → keep the original).
+      language: language ? (normalizeLanguageCode(language) ?? language) : language,
       meta,
       singleUseId,
       variables,

--- a/apps/web/modules/api/v2/management/responses/lib/response.ts
+++ b/apps/web/modules/api/v2/management/responses/lib/response.ts
@@ -157,6 +157,9 @@ export const createResponseWithQuotaEvaluation = async (
   workspaceId: string,
   responseInput: TResponseInput
 ): Promise<Result<Response, ApiErrorResponseV2>> => {
+  // Canonicalize once so quota evaluation uses the same code persisted on the response (createResponse
+  // canonicalizes the stored value via the same helper). Keeps a request internally consistent.
+  const canonicalLanguage = normalizeResponseLanguage(responseInput.language);
   const txResponse = await prisma.$transaction<Result<Response, ApiErrorResponseV2>>(async (tx) => {
     const responseResult = await createResponse(workspaceId, responseInput, tx);
     if (!responseResult.ok) {
@@ -170,7 +173,7 @@ export const createResponseWithQuotaEvaluation = async (
       responseId: response.id,
       data: responseInput.data,
       variables: responseInput.variables,
-      language: responseInput.language || "default",
+      language: canonicalLanguage || "default",
       responseFinished: response.finished,
       tx,
     });

--- a/apps/web/modules/api/v2/management/responses/lib/response.ts
+++ b/apps/web/modules/api/v2/management/responses/lib/response.ts
@@ -1,11 +1,10 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
 import { Prisma, Response } from "@formbricks/database/prisma";
-import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
 import { Result, err, ok } from "@formbricks/types/error-handlers";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
-import { calculateTtcTotal } from "@/lib/response/utils";
+import { calculateTtcTotal, normalizeResponseLanguage } from "@/lib/response/utils";
 import { getContactByUserId } from "@/modules/api/v2/management/responses/lib/contact";
 import {
   getMonthlyOrganizationResponseCount,
@@ -108,9 +107,7 @@ export const createResponse = async (
       }),
       finished,
       data,
-      // Canonicalize on write (ENG-1067): store the canonical BCP-47 form ("hi" → "hi-IN"); "default"
-      // and unresolvable values are preserved (normalizeLanguageCode returns null → keep the original).
-      language: language ? (normalizeLanguageCode(language) ?? language) : language,
+      language: normalizeResponseLanguage(language),
       meta,
       singleUseId,
       variables,

--- a/apps/web/playwright/api/management/response.spec.ts
+++ b/apps/web/playwright/api/management/response.spec.ts
@@ -180,7 +180,7 @@ test.describe("API Tests for Responses", () => {
         updatedAt: "2021-01-01T00:00:00.000Z",
         surveyId: surveyId,
         finished: true,
-        language: "en",
+        language: "en-US", // canonicalized on write from "en"
         data: {
           jpvm9b73u06xdrhzi11k2h76: "answer1",
         },
@@ -210,7 +210,7 @@ test.describe("API Tests for Responses", () => {
         updatedAt: "2021-01-02T00:00:00.000Z",
         surveyId: surveyId,
         finished: true,
-        language: "en",
+        language: "en-US", // canonicalized on write from "en"
         data: {
           jpvm9b73u06xdrhzi11k2h76: "answer2",
         },
@@ -373,7 +373,7 @@ test.describe("API Tests for Responses", () => {
         updatedAt: "2021-01-03T00:00:00.000Z",
         surveyId: surveyId,
         finished: false,
-        language: "fr",
+        language: "fr-FR", // canonicalized on write from "fr"
         endingId: null,
         contactId: null,
         contactAttributes: null,

--- a/packages/surveys/src/components/general/language-switch.tsx
+++ b/packages/surveys/src/components/general/language-switch.tsx
@@ -47,15 +47,20 @@ export function LanguageSwitch({
   })?.language.code;
 
   // Dedupe enabled languages by canonical code so the back-compat legacy aliases (e.g. "hi" sent
-  // alongside "hi-IN") don't show as duplicate options. Canonical entries come first, so they win.
-  const seenCanonicalCodes = new Set<string>();
-  const visibleLanguages = surveyLanguages.filter((surveyLanguage) => {
-    if (!surveyLanguage.enabled) return false;
-    const canonical = normalizeLanguageCode(surveyLanguage.language.code) ?? surveyLanguage.language.code;
-    if (seenCanonicalCodes.has(canonical)) return false;
-    seenCanonicalCodes.add(canonical);
-    return true;
-  });
+  // alongside "hi-IN") don't show as duplicate options. Prefer the canonical entry over a legacy alias
+  // regardless of order (an entry is canonical when its code equals its normalized form), so the
+  // dropdown always keeps the canonical code in state and label.
+  const languagesByCanonical = new Map<string, TSurveyLanguage>();
+  for (const surveyLanguage of surveyLanguages) {
+    if (!surveyLanguage.enabled) continue;
+    const code = surveyLanguage.language.code;
+    const canonical = normalizeLanguageCode(code) ?? code;
+    const existing = languagesByCanonical.get(canonical);
+    if (!existing || code === canonical) {
+      languagesByCanonical.set(canonical, surveyLanguage);
+    }
+  }
+  const visibleLanguages = [...languagesByCanonical.values()];
 
   const handleI18nLanguage = (languageCode: string) => {
     const calculatedLanguage = getI18nLanguage(languageCode, surveyLanguages);

--- a/packages/surveys/src/components/general/language-switch.tsx
+++ b/packages/surveys/src/components/general/language-switch.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "preact/hooks";
 import { useTranslation } from "react-i18next";
+import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import { TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { type TSurveyLanguage } from "@formbricks/types/surveys/types";
 import { LanguageIcon } from "@/components/icons/language-icon";
@@ -44,6 +45,17 @@ export function LanguageSwitch({
   const defaultLanguageCode = surveyLanguages.find((surveyLanguage) => {
     return surveyLanguage.default;
   })?.language.code;
+
+  // Dedupe enabled languages by canonical code so the back-compat legacy aliases (e.g. "hi" sent
+  // alongside "hi-IN") don't show as duplicate options. Canonical entries come first, so they win.
+  const seenCanonicalCodes = new Set<string>();
+  const visibleLanguages = surveyLanguages.filter((surveyLanguage) => {
+    if (!surveyLanguage.enabled) return false;
+    const canonical = normalizeLanguageCode(surveyLanguage.language.code) ?? surveyLanguage.language.code;
+    if (seenCanonicalCodes.has(canonical)) return false;
+    seenCanonicalCodes.add(canonical);
+    return true;
+  });
 
   const handleI18nLanguage = (languageCode: string) => {
     const calculatedLanguage = getI18nLanguage(languageCode, surveyLanguages);
@@ -102,8 +114,7 @@ export function LanguageSwitch({
             dir === "rtl" ? "left-8" : "right-8"
           )}
           ref={languageDropdownRef}>
-          {surveyLanguages.map((surveyLanguage) => {
-            if (!surveyLanguage.enabled) return;
+          {visibleLanguages.map((surveyLanguage) => {
             return (
               <button
                 key={surveyLanguage.language.id}

--- a/packages/surveys/src/index.ts
+++ b/packages/surveys/src/index.ts
@@ -26,6 +26,12 @@ export const renderSurvey = (props: SurveyContainerProps) => {
 
   const language = getI18nLanguage(languageCode, props.survey.languages);
 
+  // SDK clients may request a legacy code (e.g. "hi") that is no longer a survey content key after
+  // canonicalization (content is keyed "hi-IN"). Render the survey under the resolved canonical code so
+  // content lookups — and recall parsing, which indexes content directly — don't hit `undefined`. The
+  // "default" sentinel is preserved (content stores its value under the "default" key).
+  const surveyLanguageCode = languageCode === "default" ? languageCode : language;
+
   if (mode === "inline") {
     if (!containerId) {
       throw new Error("renderSurvey: containerId is required for inline mode");
@@ -46,6 +52,7 @@ export const renderSurvey = (props: SurveyContainerProps) => {
           { language },
           h(RenderSurvey, {
             ...surveyInlineProps,
+            languageCode: surveyLanguageCode,
           })
         ),
         element
@@ -60,6 +67,7 @@ export const renderSurvey = (props: SurveyContainerProps) => {
           { language },
           h(RenderSurvey, {
             ...surveyInlineProps,
+            languageCode: surveyLanguageCode,
           })
         ),
         element
@@ -76,6 +84,7 @@ export const renderSurvey = (props: SurveyContainerProps) => {
         { language },
         h(RenderSurvey, {
           ...props,
+          languageCode: surveyLanguageCode,
         })
       ),
       modalContainer

--- a/packages/surveys/src/lib/language-display-name.test.ts
+++ b/packages/surveys/src/lib/language-display-name.test.ts
@@ -29,6 +29,13 @@ describe("getLanguageDisplayName", () => {
     expect(getLanguageDisplayName("bo")).toBe("བོད་སྐད་");
   });
 
+  test("falls back to the bare/script native name for region-tagged canonical codes", () => {
+    // no exact entry for these canonical codes → fall back to language(+script)
+    expect(getLanguageDisplayName("hi-IN")).toBe("हिन्दी");
+    expect(getLanguageDisplayName("zh-Hans-CN")).toBe("简体中文");
+    expect(getLanguageDisplayName("da-DK")).toBe("Dansk");
+  });
+
   test("returns raw code for unknown codes", () => {
     expect(getLanguageDisplayName("xx")).toBe("Xx");
     expect(getLanguageDisplayName("unknown")).toBe("Unknown");

--- a/packages/surveys/src/lib/language-display-name.ts
+++ b/packages/surveys/src/lib/language-display-name.ts
@@ -231,10 +231,24 @@ const NATIVE_NAMES: Record<Iso639Code, string> = {
 
 /**
  * Returns the native display name for a language code (e.g. "de" → "Deutsch").
- * Falls back to the raw code if the code is not in the map.
+ *
+ * Canonical codes are region-tagged (`hi-IN`, `zh-Hans-CN`) and not every one has its own entry in
+ * NATIVE_NAMES, so we fall back from the exact code to its language+script form, then to the bare
+ * language: `hi-IN` → `hi` → "हिन्दी"; `zh-Hans-CN` → `zh-Hans` → "简体中文". Region-specific entries that
+ * do exist (e.g. `de-DE`, `de-AT`) are still preferred. Finally falls back to the raw code.
  */
 export function getLanguageDisplayName(code: string): string {
-  const name = NATIVE_NAMES[code as Iso639Code] ?? code;
+  let name = NATIVE_NAMES[code as Iso639Code];
+  if (!name) {
+    try {
+      const locale = new Intl.Locale(code);
+      const languageWithScript = [locale.language, locale.script].filter(Boolean).join("-");
+      name = NATIVE_NAMES[languageWithScript as Iso639Code] ?? NATIVE_NAMES[locale.language as Iso639Code];
+    } catch {
+      // malformed code — fall through to the raw code below
+    }
+  }
+  name = name ?? code;
   // Capitalize the first letter so names like "español" display as "Español"
   return name.charAt(0).toUpperCase() + name.slice(1);
 }

--- a/packages/surveys/src/lib/recall.test.ts
+++ b/packages/surveys/src/lib/recall.test.ts
@@ -184,6 +184,16 @@ describe("parseRecallInformation", () => {
     expect(result.headline.en).toBe(expectedHeadline);
   });
 
+  test("does not throw when the language code is not a content key", () => {
+    // After canonicalization, content is keyed "hi-IN"/"default"; an SDK may still request legacy "hi".
+    const question: TSurveyOpenTextElement = {
+      ...baseQuestion,
+      headline: { default: "Welcome!", "hi-IN": "स्वागत है" },
+      subheader: { default: "Subtitle", "hi-IN": "उपशीर्षक" },
+    };
+    expect(() => parseRecallInformation(question, "hi", responseData, variables)).not.toThrow();
+  });
+
   test("should replace recall info in subheader", () => {
     const question: TSurveyOpenTextElement = {
       ...baseQuestion,

--- a/packages/surveys/src/lib/recall.ts
+++ b/packages/surveys/src/lib/recall.ts
@@ -76,7 +76,9 @@ export const parseRecallInformation = (
   variables: TResponseVariables
 ): TSurveyElement => {
   const modifiedQuestion = JSON.parse(JSON.stringify(question));
-  if (question.headline[languageCode].includes("recall:")) {
+  // Use getLocalizedValue (falls back to the `default` key) instead of indexing by languageCode
+  // directly — a code that isn't a content key (e.g. a legacy SDK language) would otherwise throw.
+  if (getLocalizedValue(question.headline, languageCode).includes("recall:")) {
     modifiedQuestion.headline[languageCode] = replaceRecallInfo(
       getLocalizedValue(modifiedQuestion.headline, languageCode),
       responseData,
@@ -86,7 +88,7 @@ export const parseRecallInformation = (
   }
   if (
     question.subheader &&
-    question.subheader[languageCode].includes("recall:") &&
+    getLocalizedValue(question.subheader, languageCode).includes("recall:") &&
     modifiedQuestion.subheader
   ) {
     modifiedQuestion.subheader[languageCode] = replaceRecallInfo(


### PR DESCRIPTION
## What does this PR do?

Part of **ENG-1067** (standardize survey/app/translation language tags on BCP-47).

After language codes are canonicalized to region-tagged BCP-47 (`de` → `de-DE`, `hi` → `hi-IN`), SDK clients can still send **legacy, non-canonical codes** — most importantly anonymous clients, whose language lives only in local storage and never round-trips through the server (so it's never re-canonicalized), and older SDK versions. This PR makes the **survey renderer** and **responses API** resilient to those codes so nothing breaks and the data stays clean.

> Context: a survey's content i18n keys and `Language.code` are now canonical (`hi-IN`), but the SDK-facing environment back-compat still exposes the bare legacy code (`hi`) so older clients keep matching. That mismatch (`languages` has `hi`, content is keyed `hi-IN`) is what this PR handles end-to-end.

### Changes

**Survey renderer (`packages/surveys`)**
- `index.ts` — resolve the survey **content** language canonically before rendering (`getI18nLanguage`, preserving the `default` sentinel). A legacy/mismatched code (`hi`) now renders the correct `hi-IN` content (and responses record `hi-IN`) instead of silently falling back to the default language.
- `recall.ts` — `parseRecallInformation` now reads via `getLocalizedValue` (which falls back to the `default` key) instead of indexing `headline[languageCode]` / `subheader[languageCode]` directly. Fixes `Uncaught TypeError: Cannot read properties of undefined (reading 'includes')` when the active code isn't a content key.

**Responses API (v1 client, v2 client, v2 management)**
- Canonicalize `Response.language` **on write** (`hi` → `hi-IN`), preserving `default` and unresolvable values. Stale SDK caches can submit a legacy code at any time; normalizing server-side keeps the `Response` table canonical regardless of what the client sends.

**Language switcher (`packages/surveys`)**
- `language-switch.tsx` — dedupe the dropdown by canonical code, so the bare legacy aliases the environment back-compat adds (e.g. `hi` next to `hi-IN`) don't appear as duplicate options. The canonical entry is kept, so selecting it sets the correct content language.
- `language-display-name.ts` — fall back from the exact code → language+script → bare language for the native display name, so region-tagged canonical codes without their own entry render in-script: `hi-IN` → "हिन्दी", `zh-Hans-CN` → "简体中文", `da-DK` → "Dansk" (previously showed the raw code, e.g. "Hi-IN").

## How should this be tested?

- **Renderer / recall:** `pnpm --filter @formbricks/surveys exec vitest run src/lib/recall.test.ts` — incl. a regression for a language code that isn't a content key (no longer throws).
- **Labels:** `pnpm --filter @formbricks/surveys exec vitest run src/lib/language-display-name.test.ts` — region-tagged fallback (`hi-IN` → "हिन्दी", `zh-Hans-CN` → "简体中文").
- **Responses:** `pnpm --filter @formbricks/web exec vitest run app/api/v1/lib/utils.test.ts` — `language` canonicalized on write; `default`/unresolvable preserved.
- **Manual:** with an SDK still holding a legacy code (e.g. `hi`) against a migrated survey, track an action: the survey renders (in `hi-IN`), no recall crash, the switcher shows a single in-script entry, and the stored `Response.language` is `hi-IN`.

## Notes

- Complements the SDK-facing back-compat that exposes legacy language codes (environment "send-both" + user-state de-canonicalization) shipped separately; this PR is the runtime/data-integrity half.
- No DB or schema changes here.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from the epic onto my branch
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
