### PR TITLE
test: add taxonomy permission action coverage

### DIFF
--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/actions.test.ts
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/actions.test.ts
@@ -69,6 +69,40 @@ const ctx = {
   user: { id: "user_1" },
 };
 
+type MockedActionCall<TInput, TResult> = (args: { ctx: typeof ctx; parsedInput: TInput }) => Promise<TResult>;
+
+const callAction = <TInput, TResult>(
+  action: (input: TInput) => Promise<TResult>,
+  parsedInput: TInput
+): Promise<TResult> => {
+  const handler = action as unknown as MockedActionCall<TInput, TResult>;
+  return handler({ ctx, parsedInput });
+};
+
+const callGetTaxonomyFieldsAction = (parsedInput: Parameters<typeof getTaxonomyFieldsAction>[0]) =>
+  callAction(getTaxonomyFieldsAction, parsedInput);
+
+const callGetTaxonomyStateAction = (parsedInput: Parameters<typeof getTaxonomyStateAction>[0]) =>
+  callAction(getTaxonomyStateAction, parsedInput);
+
+const callGetTaxonomyRunAction = (parsedInput: Parameters<typeof getTaxonomyRunAction>[0]) =>
+  callAction(getTaxonomyRunAction, parsedInput);
+
+const callGetTaxonomyTreeAction = (parsedInput: Parameters<typeof getTaxonomyTreeAction>[0]) =>
+  callAction(getTaxonomyTreeAction, parsedInput);
+
+const callGetTaxonomyNodeRecordsAction = (parsedInput: Parameters<typeof getTaxonomyNodeRecordsAction>[0]) =>
+  callAction(getTaxonomyNodeRecordsAction, parsedInput);
+
+const callTriggerTaxonomyRunAction = (parsedInput: Parameters<typeof triggerTaxonomyRunAction>[0]) =>
+  callAction(triggerTaxonomyRunAction, parsedInput);
+
+const callRenameTaxonomyNodeAction = (parsedInput: Parameters<typeof renameTaxonomyNodeAction>[0]) =>
+  callAction(renameTaxonomyNodeAction, parsedInput);
+
+const callRemoveTaxonomyNodeAction = (parsedInput: Parameters<typeof removeTaxonomyNodeAction>[0]) =>
+  callAction(removeTaxonomyNodeAction, parsedInput);
+
 const organizationId = "org_1";
 const workspaceId = "workspace_1";
 const tenantId = "tenant_1";
@@ -106,6 +140,7 @@ const taxonomyNode = {
 };
 
 const expectAuthorization = (minPermission: "read" | "readWrite") => {
+  expect(mocks.checkAuthorizationUpdated).toHaveBeenCalledTimes(1);
   expect(mocks.checkAuthorizationUpdated).toHaveBeenCalledWith({
     userId: ctx.user.id,
     organizationId,
@@ -121,6 +156,11 @@ const expectAuthorization = (minPermission: "read" | "readWrite") => {
       },
     ],
   });
+};
+
+const expectDirectoryAccess = () => {
+  expect(mocks.getFeedbackDirectoriesByWorkspaceId).toHaveBeenCalledTimes(1);
+  expect(mocks.getFeedbackDirectoriesByWorkspaceId).toHaveBeenCalledWith(workspaceId);
 };
 
 const expectNoHubCalls = () => {
@@ -169,131 +209,234 @@ describe("taxonomy topics server actions", () => {
     });
   });
 
-  test("allows read actions with workspace read access and assigned feedback directory", async () => {
+  test("allows taxonomy field reads with workspace read access and assigned feedback directory", async () => {
+    await expect(callGetTaxonomyFieldsAction({ workspaceId, directoryId: tenantId })).resolves.toMatchObject({
+      unavailable: false,
+    });
+
+    expectAuthorization("read");
+    expectDirectoryAccess();
+    expect(mocks.listTaxonomyFields).toHaveBeenCalledTimes(1);
+    expect(mocks.listTaxonomyFields).toHaveBeenCalledWith(tenantId);
+  });
+
+  test("allows taxonomy state reads with workspace read access and assigned feedback directory", async () => {
+    await expect(callGetTaxonomyStateAction({ workspaceId, scope })).resolves.toMatchObject({
+      activeTree: { run: taxonomyRun },
+      runs: [taxonomyRun],
+      unavailable: false,
+    });
+
+    expectAuthorization("read");
+    expectDirectoryAccess();
+    expect(mocks.getActiveTaxonomyTree).toHaveBeenCalledTimes(1);
+    expect(mocks.getActiveTaxonomyTree).toHaveBeenCalledWith(scope);
+    expect(mocks.listTaxonomyRuns).toHaveBeenCalledTimes(1);
+    expect(mocks.listTaxonomyRuns).toHaveBeenCalledWith({ ...scope, limit: 5 });
+  });
+
+  test("allows taxonomy run reads with workspace read access and assigned feedback directory", async () => {
+    await expect(callGetTaxonomyRunAction({ workspaceId, scope, runId })).resolves.toEqual(taxonomyRun);
+
+    expectAuthorization("read");
+    expectDirectoryAccess();
+    expect(mocks.getTaxonomyRun).toHaveBeenCalledTimes(1);
+    expect(mocks.getTaxonomyRun).toHaveBeenCalledWith(runId, tenantId);
+  });
+
+  test("allows taxonomy tree reads with workspace read access and assigned feedback directory", async () => {
+    await expect(callGetTaxonomyTreeAction({ workspaceId, scope, runId })).resolves.toMatchObject({
+      run: taxonomyRun,
+      root: taxonomyNode,
+    });
+
+    expectAuthorization("read");
+    expectDirectoryAccess();
+    expect(mocks.getTaxonomyTree).toHaveBeenCalledTimes(1);
+    expect(mocks.getTaxonomyTree).toHaveBeenCalledWith(runId, tenantId);
+  });
+
+  test("allows taxonomy node record reads with workspace read access and assigned feedback directory", async () => {
     await expect(
-      getTaxonomyFieldsAction({ ctx, parsedInput: { workspaceId, directoryId: tenantId } } as any)
-    ).resolves.toMatchObject({ unavailable: false });
-    await expect(
-      getTaxonomyStateAction({ ctx, parsedInput: { workspaceId, scope } } as any)
-    ).resolves.toMatchObject({ activeTree: { run: taxonomyRun }, runs: [taxonomyRun], unavailable: false });
-    await expect(
-      getTaxonomyRunAction({ ctx, parsedInput: { workspaceId, scope, runId } } as any)
-    ).resolves.toEqual(taxonomyRun);
-    await expect(
-      getTaxonomyTreeAction({ ctx, parsedInput: { workspaceId, scope, runId } } as any)
-    ).resolves.toMatchObject({ run: taxonomyRun, root: taxonomyNode });
-    await expect(
-      getTaxonomyNodeRecordsAction({
-        ctx,
-        parsedInput: { workspaceId, tenantId, nodeId, limit: 25 },
-      } as any)
+      callGetTaxonomyNodeRecordsAction({ workspaceId, tenantId, nodeId, limit: 25 })
     ).resolves.toEqual({ data: [], limit: 25 });
 
     expectAuthorization("read");
-    expect(mocks.listTaxonomyFields).toHaveBeenCalledWith(tenantId);
-    expect(mocks.getActiveTaxonomyTree).toHaveBeenCalledWith(scope);
-    expect(mocks.listTaxonomyRuns).toHaveBeenCalledWith({ ...scope, limit: 5 });
-    expect(mocks.getTaxonomyRun).toHaveBeenCalledWith(runId, tenantId);
-    expect(mocks.getTaxonomyTree).toHaveBeenCalledWith(runId, tenantId);
+    expectDirectoryAccess();
+    expect(mocks.listTaxonomyNodeRecords).toHaveBeenCalledTimes(1);
     expect(mocks.listTaxonomyNodeRecords).toHaveBeenCalledWith(nodeId, { tenant_id: tenantId, limit: 25 });
   });
 
-  test("blocks read actions when the user has no workspace access", async () => {
-    mocks.checkAuthorizationUpdated.mockRejectedValueOnce(new AuthorizationError("Not authorized"));
-
+  test("allows taxonomy generation with workspace write access and assigned feedback directory", async () => {
     await expect(
-      getTaxonomyFieldsAction({ ctx, parsedInput: { workspaceId, directoryId: tenantId } } as any)
-    ).rejects.toThrow(AuthorizationError);
-
-    expectAuthorization("read");
-    expect(mocks.getFeedbackDirectoriesByWorkspaceId).not.toHaveBeenCalled();
-    expectNoHubCalls();
-  });
-
-  test("blocks taxonomy actions when Unify Feedback is not enabled", async () => {
-    mocks.getIsFeedbackDirectoriesEnabled.mockResolvedValueOnce(false);
-
-    await expect(
-      getTaxonomyFieldsAction({ ctx, parsedInput: { workspaceId, directoryId: tenantId } } as any)
-    ).rejects.toThrow(OperationNotAllowedError);
-
-    expect(mocks.checkAuthorizationUpdated).not.toHaveBeenCalled();
-    expect(mocks.getFeedbackDirectoriesByWorkspaceId).not.toHaveBeenCalled();
-    expectNoHubCalls();
-  });
-
-  test("blocks cross-directory taxonomy reads before calling Hub", async () => {
-    await expect(
-      getTaxonomyStateAction({
-        ctx,
-        parsedInput: { workspaceId, scope: { ...scope, tenant_id: otherTenantId } },
-      } as any)
-    ).rejects.toThrow(OperationNotAllowedError);
-
-    expectAuthorization("read");
-    expect(mocks.getFeedbackDirectoriesByWorkspaceId).toHaveBeenCalledWith(workspaceId);
-    expectNoHubCalls();
-  });
-
-  test("allows generation, rename, and remove only with write permission", async () => {
-    await expect(
-      triggerTaxonomyRunAction({
-        ctx,
-        parsedInput: { workspaceId, scope, fieldLabel: "What do you think?" },
-      } as any)
+      callTriggerTaxonomyRunAction({ workspaceId, scope, fieldLabel: "What do you think?" })
     ).resolves.toEqual({ run: taxonomyRun, inProgress: false });
-    await expect(
-      renameTaxonomyNodeAction({
-        ctx,
-        parsedInput: { workspaceId, tenantId, nodeId, label: "Renamed topic" },
-      } as any)
-    ).resolves.toMatchObject({ label: "Renamed topic" });
-    await expect(
-      removeTaxonomyNodeAction({ ctx, parsedInput: { workspaceId, tenantId, nodeId } } as any)
-    ).resolves.toMatchObject({ removed_at: "2026-06-29T00:00:00.000Z" });
 
     expectAuthorization("readWrite");
+    expectDirectoryAccess();
+    expect(mocks.createTaxonomyRun).toHaveBeenCalledTimes(1);
     expect(mocks.createTaxonomyRun).toHaveBeenCalledWith({
       ...scope,
       field_label: "What do you think?",
       actor_id: ctx.user.id,
     });
+  });
+
+  test("allows taxonomy node renames with workspace write access and assigned feedback directory", async () => {
+    await expect(
+      callRenameTaxonomyNodeAction({ workspaceId, tenantId, nodeId, label: "Renamed topic" })
+    ).resolves.toMatchObject({ label: "Renamed topic" });
+
+    expectAuthorization("readWrite");
+    expectDirectoryAccess();
+    expect(mocks.renameTaxonomyNode).toHaveBeenCalledTimes(1);
     expect(mocks.renameTaxonomyNode).toHaveBeenCalledWith(nodeId, {
       tenant_id: tenantId,
       actor_id: ctx.user.id,
       label: "Renamed topic",
     });
+  });
+
+  test("allows taxonomy node removals with workspace write access and assigned feedback directory", async () => {
+    await expect(callRemoveTaxonomyNodeAction({ workspaceId, tenantId, nodeId })).resolves.toMatchObject({
+      removed_at: "2026-06-29T00:00:00.000Z",
+    });
+
+    expectAuthorization("readWrite");
+    expectDirectoryAccess();
+    expect(mocks.removeTaxonomyNode).toHaveBeenCalledTimes(1);
     expect(mocks.removeTaxonomyNode).toHaveBeenCalledWith(nodeId, {
       tenant_id: tenantId,
       actor_id: ctx.user.id,
     });
   });
 
-  test("blocks write actions for read-only users before calling Hub", async () => {
-    mocks.checkAuthorizationUpdated.mockRejectedValueOnce(new AuthorizationError("Not authorized"));
+  test("blocks taxonomy actions when Unify Feedback is not enabled", async () => {
+    mocks.getIsFeedbackDirectoriesEnabled.mockResolvedValueOnce(false);
 
-    await expect(
-      triggerTaxonomyRunAction({
-        ctx,
-        parsedInput: { workspaceId, scope, fieldLabel: "What do you think?" },
-      } as any)
-    ).rejects.toThrow(AuthorizationError);
+    await expect(callGetTaxonomyFieldsAction({ workspaceId, directoryId: tenantId })).rejects.toThrow(
+      OperationNotAllowedError
+    );
 
-    expectAuthorization("readWrite");
+    expect(mocks.checkAuthorizationUpdated).not.toHaveBeenCalled();
     expect(mocks.getFeedbackDirectoriesByWorkspaceId).not.toHaveBeenCalled();
     expectNoHubCalls();
   });
 
-  test("blocks write actions for unassigned feedback directories before calling Hub", async () => {
-    await expect(
-      renameTaxonomyNodeAction({
-        ctx,
-        parsedInput: { workspaceId, tenantId: otherTenantId, nodeId, label: "Renamed topic" },
-      } as any)
-    ).rejects.toThrow(OperationNotAllowedError);
+  test.each([
+    {
+      name: "getTaxonomyFieldsAction",
+      minPermission: "read" as const,
+      run: () => callGetTaxonomyFieldsAction({ workspaceId, directoryId: tenantId }),
+    },
+    {
+      name: "getTaxonomyStateAction",
+      minPermission: "read" as const,
+      run: () => callGetTaxonomyStateAction({ workspaceId, scope }),
+    },
+    {
+      name: "getTaxonomyRunAction",
+      minPermission: "read" as const,
+      run: () => callGetTaxonomyRunAction({ workspaceId, scope, runId }),
+    },
+    {
+      name: "getTaxonomyTreeAction",
+      minPermission: "read" as const,
+      run: () => callGetTaxonomyTreeAction({ workspaceId, scope, runId }),
+    },
+    {
+      name: "getTaxonomyNodeRecordsAction",
+      minPermission: "read" as const,
+      run: () => callGetTaxonomyNodeRecordsAction({ workspaceId, tenantId, nodeId, limit: 25 }),
+    },
+    {
+      name: "triggerTaxonomyRunAction",
+      minPermission: "readWrite" as const,
+      run: () => callTriggerTaxonomyRunAction({ workspaceId, scope, fieldLabel: "What do you think?" }),
+    },
+    {
+      name: "renameTaxonomyNodeAction",
+      minPermission: "readWrite" as const,
+      run: () => callRenameTaxonomyNodeAction({ workspaceId, tenantId, nodeId, label: "Renamed topic" }),
+    },
+    {
+      name: "removeTaxonomyNodeAction",
+      minPermission: "readWrite" as const,
+      run: () => callRemoveTaxonomyNodeAction({ workspaceId, tenantId, nodeId }),
+    },
+  ])("blocks $name when the user has no workspace access", async ({ minPermission, run }) => {
+    mocks.checkAuthorizationUpdated.mockRejectedValueOnce(new AuthorizationError("Not authorized"));
 
-    expectAuthorization("readWrite");
-    expect(mocks.getFeedbackDirectoriesByWorkspaceId).toHaveBeenCalledWith(workspaceId);
+    await expect(run()).rejects.toThrow(AuthorizationError);
+
+    expectAuthorization(minPermission);
+    expect(mocks.getFeedbackDirectoriesByWorkspaceId).not.toHaveBeenCalled();
     expectNoHubCalls();
   });
+
+  test.each([
+    {
+      name: "getTaxonomyFieldsAction",
+      minPermission: "read" as const,
+      run: () => callGetTaxonomyFieldsAction({ workspaceId, directoryId: otherTenantId }),
+    },
+    {
+      name: "getTaxonomyStateAction",
+      minPermission: "read" as const,
+      run: () => callGetTaxonomyStateAction({ workspaceId, scope: { ...scope, tenant_id: otherTenantId } }),
+    },
+    {
+      name: "getTaxonomyRunAction",
+      minPermission: "read" as const,
+      run: () =>
+        callGetTaxonomyRunAction({ workspaceId, scope: { ...scope, tenant_id: otherTenantId }, runId }),
+    },
+    {
+      name: "getTaxonomyTreeAction",
+      minPermission: "read" as const,
+      run: () =>
+        callGetTaxonomyTreeAction({ workspaceId, scope: { ...scope, tenant_id: otherTenantId }, runId }),
+    },
+    {
+      name: "getTaxonomyNodeRecordsAction",
+      minPermission: "read" as const,
+      run: () =>
+        callGetTaxonomyNodeRecordsAction({ workspaceId, tenantId: otherTenantId, nodeId, limit: 25 }),
+    },
+    {
+      name: "triggerTaxonomyRunAction",
+      minPermission: "readWrite" as const,
+      run: () =>
+        callTriggerTaxonomyRunAction({
+          workspaceId,
+          scope: { ...scope, tenant_id: otherTenantId },
+          fieldLabel: "What do you think?",
+        }),
+    },
+    {
+      name: "renameTaxonomyNodeAction",
+      minPermission: "readWrite" as const,
+      run: () =>
+        callRenameTaxonomyNodeAction({
+          workspaceId,
+          tenantId: otherTenantId,
+          nodeId,
+          label: "Renamed topic",
+        }),
+    },
+    {
+      name: "removeTaxonomyNodeAction",
+      minPermission: "readWrite" as const,
+      run: () => callRemoveTaxonomyNodeAction({ workspaceId, tenantId: otherTenantId, nodeId }),
+    },
+  ])(
+    "blocks $name for unassigned feedback directories before calling Hub",
+    async ({ minPermission, run }) => {
+      await expect(run()).rejects.toThrow(OperationNotAllowedError);
+
+      expectAuthorization(minPermission);
+      expectDirectoryAccess();
+      expectNoHubCalls();
+    }
+  );
 });

--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/actions.test.ts
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/actions.test.ts
@@ -1,0 +1,299 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AuthorizationError, OperationNotAllowedError } from "@formbricks/types/errors";
+import {
+  getTaxonomyFieldsAction,
+  getTaxonomyNodeRecordsAction,
+  getTaxonomyRunAction,
+  getTaxonomyStateAction,
+  getTaxonomyTreeAction,
+  removeTaxonomyNodeAction,
+  renameTaxonomyNodeAction,
+  triggerTaxonomyRunAction,
+} from "./actions";
+
+const mocks = vi.hoisted(() => ({
+  checkAuthorizationUpdated: vi.fn(),
+  createTaxonomyRun: vi.fn(),
+  getActiveTaxonomyTree: vi.fn(),
+  getFeedbackDirectoriesByWorkspaceId: vi.fn(),
+  getIsFeedbackDirectoriesEnabled: vi.fn(),
+  getOrganizationIdFromWorkspaceId: vi.fn(),
+  getTaxonomyRun: vi.fn(),
+  getTaxonomyTree: vi.fn(),
+  listTaxonomyFields: vi.fn(),
+  listTaxonomyNodeRecords: vi.fn(),
+  listTaxonomyRuns: vi.fn(),
+  removeTaxonomyNode: vi.fn(),
+  renameTaxonomyNode: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/utils/action-client", () => ({
+  authenticatedActionClient: {
+    inputSchema: vi.fn(() => ({
+      action: vi.fn((fn) => fn),
+    })),
+  },
+}));
+
+vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
+  checkAuthorizationUpdated: mocks.checkAuthorizationUpdated,
+}));
+
+vi.mock("@/lib/utils/helper", () => ({
+  getOrganizationIdFromWorkspaceId: mocks.getOrganizationIdFromWorkspaceId,
+}));
+
+vi.mock("@/modules/ee/feedback-directory/lib/feedback-directory", () => ({
+  getFeedbackDirectoriesByWorkspaceId: mocks.getFeedbackDirectoriesByWorkspaceId,
+}));
+
+vi.mock("@/modules/ee/license-check/lib/utils", () => ({
+  getIsFeedbackDirectoriesEnabled: mocks.getIsFeedbackDirectoriesEnabled,
+}));
+
+vi.mock("@/modules/hub/service", () => ({
+  createTaxonomyRun: mocks.createTaxonomyRun,
+  getActiveTaxonomyTree: mocks.getActiveTaxonomyTree,
+  getTaxonomyRun: mocks.getTaxonomyRun,
+  getTaxonomyTree: mocks.getTaxonomyTree,
+  listTaxonomyFields: mocks.listTaxonomyFields,
+  listTaxonomyNodeRecords: mocks.listTaxonomyNodeRecords,
+  listTaxonomyRuns: mocks.listTaxonomyRuns,
+  removeTaxonomyNode: mocks.removeTaxonomyNode,
+  renameTaxonomyNode: mocks.renameTaxonomyNode,
+}));
+
+const ctx = {
+  user: { id: "user_1" },
+};
+
+const organizationId = "org_1";
+const workspaceId = "workspace_1";
+const tenantId = "tenant_1";
+const otherTenantId = "tenant_2";
+const runId = "0c01906b-1e2a-7c80-b4fe-a4e5d1184526";
+const nodeId = "0c01906b-1e2a-7c80-b4fe-a4e5d1184527";
+const scope = {
+  tenant_id: tenantId,
+  source_type: "formbricks_survey",
+  source_id: "survey_1",
+  field_id: "question_1",
+};
+
+const taxonomyRun = {
+  ...scope,
+  id: runId,
+  status: "succeeded",
+  record_count: 20,
+  embedding_count: 20,
+  cluster_count: 3,
+  node_count: 5,
+  created_at: "2026-06-29T00:00:00.000Z",
+  updated_at: "2026-06-29T00:00:00.000Z",
+};
+
+const taxonomyNode = {
+  id: nodeId,
+  run_id: runId,
+  node_type: "leaf",
+  label: "Support feedback",
+  level: 4,
+  sort_order: 0,
+  created_at: "2026-06-29T00:00:00.000Z",
+  updated_at: "2026-06-29T00:00:00.000Z",
+};
+
+const expectAuthorization = (minPermission: "read" | "readWrite") => {
+  expect(mocks.checkAuthorizationUpdated).toHaveBeenCalledWith({
+    userId: ctx.user.id,
+    organizationId,
+    access: [
+      {
+        type: "organization",
+        roles: ["owner", "manager"],
+      },
+      {
+        type: "workspaceTeam",
+        minPermission,
+        workspaceId,
+      },
+    ],
+  });
+};
+
+const expectNoHubCalls = () => {
+  expect(mocks.createTaxonomyRun).not.toHaveBeenCalled();
+  expect(mocks.getActiveTaxonomyTree).not.toHaveBeenCalled();
+  expect(mocks.getTaxonomyRun).not.toHaveBeenCalled();
+  expect(mocks.getTaxonomyTree).not.toHaveBeenCalled();
+  expect(mocks.listTaxonomyFields).not.toHaveBeenCalled();
+  expect(mocks.listTaxonomyNodeRecords).not.toHaveBeenCalled();
+  expect(mocks.listTaxonomyRuns).not.toHaveBeenCalled();
+  expect(mocks.removeTaxonomyNode).not.toHaveBeenCalled();
+  expect(mocks.renameTaxonomyNode).not.toHaveBeenCalled();
+};
+
+describe("taxonomy topics server actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.checkAuthorizationUpdated.mockResolvedValue(undefined);
+    mocks.getOrganizationIdFromWorkspaceId.mockResolvedValue(organizationId);
+    mocks.getIsFeedbackDirectoriesEnabled.mockResolvedValue(true);
+    mocks.getFeedbackDirectoriesByWorkspaceId.mockResolvedValue([{ id: tenantId, name: "Seed directory" }]);
+
+    mocks.listTaxonomyFields.mockResolvedValue({
+      data: {
+        data: [
+          {
+            ...scope,
+            source_name: "Kitchen Sink Survey",
+            field_label: "What do you think?",
+            record_count: 20,
+            embedding_count: 20,
+          },
+        ],
+      },
+    });
+    mocks.getActiveTaxonomyTree.mockResolvedValue({ data: { run: taxonomyRun, root: taxonomyNode } });
+    mocks.listTaxonomyRuns.mockResolvedValue({ data: { data: [taxonomyRun] } });
+    mocks.createTaxonomyRun.mockResolvedValue({ data: { run: taxonomyRun, in_progress: false } });
+    mocks.getTaxonomyRun.mockResolvedValue({ data: taxonomyRun });
+    mocks.getTaxonomyTree.mockResolvedValue({ data: { run: taxonomyRun, root: taxonomyNode } });
+    mocks.listTaxonomyNodeRecords.mockResolvedValue({ data: { data: [], limit: 25 } });
+    mocks.renameTaxonomyNode.mockResolvedValue({ data: { ...taxonomyNode, label: "Renamed topic" } });
+    mocks.removeTaxonomyNode.mockResolvedValue({
+      data: { ...taxonomyNode, removed_at: "2026-06-29T00:00:00.000Z" },
+    });
+  });
+
+  test("allows read actions with workspace read access and assigned feedback directory", async () => {
+    await expect(
+      getTaxonomyFieldsAction({ ctx, parsedInput: { workspaceId, directoryId: tenantId } } as any)
+    ).resolves.toMatchObject({ unavailable: false });
+    await expect(
+      getTaxonomyStateAction({ ctx, parsedInput: { workspaceId, scope } } as any)
+    ).resolves.toMatchObject({ activeTree: { run: taxonomyRun }, runs: [taxonomyRun], unavailable: false });
+    await expect(
+      getTaxonomyRunAction({ ctx, parsedInput: { workspaceId, scope, runId } } as any)
+    ).resolves.toEqual(taxonomyRun);
+    await expect(
+      getTaxonomyTreeAction({ ctx, parsedInput: { workspaceId, scope, runId } } as any)
+    ).resolves.toMatchObject({ run: taxonomyRun, root: taxonomyNode });
+    await expect(
+      getTaxonomyNodeRecordsAction({
+        ctx,
+        parsedInput: { workspaceId, tenantId, nodeId, limit: 25 },
+      } as any)
+    ).resolves.toEqual({ data: [], limit: 25 });
+
+    expectAuthorization("read");
+    expect(mocks.listTaxonomyFields).toHaveBeenCalledWith(tenantId);
+    expect(mocks.getActiveTaxonomyTree).toHaveBeenCalledWith(scope);
+    expect(mocks.listTaxonomyRuns).toHaveBeenCalledWith({ ...scope, limit: 5 });
+    expect(mocks.getTaxonomyRun).toHaveBeenCalledWith(runId, tenantId);
+    expect(mocks.getTaxonomyTree).toHaveBeenCalledWith(runId, tenantId);
+    expect(mocks.listTaxonomyNodeRecords).toHaveBeenCalledWith(nodeId, { tenant_id: tenantId, limit: 25 });
+  });
+
+  test("blocks read actions when the user has no workspace access", async () => {
+    mocks.checkAuthorizationUpdated.mockRejectedValueOnce(new AuthorizationError("Not authorized"));
+
+    await expect(
+      getTaxonomyFieldsAction({ ctx, parsedInput: { workspaceId, directoryId: tenantId } } as any)
+    ).rejects.toThrow(AuthorizationError);
+
+    expectAuthorization("read");
+    expect(mocks.getFeedbackDirectoriesByWorkspaceId).not.toHaveBeenCalled();
+    expectNoHubCalls();
+  });
+
+  test("blocks taxonomy actions when Unify Feedback is not enabled", async () => {
+    mocks.getIsFeedbackDirectoriesEnabled.mockResolvedValueOnce(false);
+
+    await expect(
+      getTaxonomyFieldsAction({ ctx, parsedInput: { workspaceId, directoryId: tenantId } } as any)
+    ).rejects.toThrow(OperationNotAllowedError);
+
+    expect(mocks.checkAuthorizationUpdated).not.toHaveBeenCalled();
+    expect(mocks.getFeedbackDirectoriesByWorkspaceId).not.toHaveBeenCalled();
+    expectNoHubCalls();
+  });
+
+  test("blocks cross-directory taxonomy reads before calling Hub", async () => {
+    await expect(
+      getTaxonomyStateAction({
+        ctx,
+        parsedInput: { workspaceId, scope: { ...scope, tenant_id: otherTenantId } },
+      } as any)
+    ).rejects.toThrow(OperationNotAllowedError);
+
+    expectAuthorization("read");
+    expect(mocks.getFeedbackDirectoriesByWorkspaceId).toHaveBeenCalledWith(workspaceId);
+    expectNoHubCalls();
+  });
+
+  test("allows generation, rename, and remove only with write permission", async () => {
+    await expect(
+      triggerTaxonomyRunAction({
+        ctx,
+        parsedInput: { workspaceId, scope, fieldLabel: "What do you think?" },
+      } as any)
+    ).resolves.toEqual({ run: taxonomyRun, inProgress: false });
+    await expect(
+      renameTaxonomyNodeAction({
+        ctx,
+        parsedInput: { workspaceId, tenantId, nodeId, label: "Renamed topic" },
+      } as any)
+    ).resolves.toMatchObject({ label: "Renamed topic" });
+    await expect(
+      removeTaxonomyNodeAction({ ctx, parsedInput: { workspaceId, tenantId, nodeId } } as any)
+    ).resolves.toMatchObject({ removed_at: "2026-06-29T00:00:00.000Z" });
+
+    expectAuthorization("readWrite");
+    expect(mocks.createTaxonomyRun).toHaveBeenCalledWith({
+      ...scope,
+      field_label: "What do you think?",
+      actor_id: ctx.user.id,
+    });
+    expect(mocks.renameTaxonomyNode).toHaveBeenCalledWith(nodeId, {
+      tenant_id: tenantId,
+      actor_id: ctx.user.id,
+      label: "Renamed topic",
+    });
+    expect(mocks.removeTaxonomyNode).toHaveBeenCalledWith(nodeId, {
+      tenant_id: tenantId,
+      actor_id: ctx.user.id,
+    });
+  });
+
+  test("blocks write actions for read-only users before calling Hub", async () => {
+    mocks.checkAuthorizationUpdated.mockRejectedValueOnce(new AuthorizationError("Not authorized"));
+
+    await expect(
+      triggerTaxonomyRunAction({
+        ctx,
+        parsedInput: { workspaceId, scope, fieldLabel: "What do you think?" },
+      } as any)
+    ).rejects.toThrow(AuthorizationError);
+
+    expectAuthorization("readWrite");
+    expect(mocks.getFeedbackDirectoriesByWorkspaceId).not.toHaveBeenCalled();
+    expectNoHubCalls();
+  });
+
+  test("blocks write actions for unassigned feedback directories before calling Hub", async () => {
+    await expect(
+      renameTaxonomyNodeAction({
+        ctx,
+        parsedInput: { workspaceId, tenantId: otherTenantId, nodeId, label: "Renamed topic" },
+      } as any)
+    ).rejects.toThrow(OperationNotAllowedError);
+
+    expectAuthorization("readWrite");
+    expect(mocks.getFeedbackDirectoriesByWorkspaceId).toHaveBeenCalledWith(workspaceId);
+    expectNoHubCalls();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds focused server-action tests for taxonomy permission checks in Unify Feedback topics/subtopics. The coverage now verifies each read and write action independently, including authorization, feedback-directory assignment, entitlement-disabled, no-access, and cross-directory rejection paths.

No manual activation permission path is required for beta because the latest successful generation is auto-active.

Fixes #N/A

Linear: ENG-1191

## How should this be tested?

- From `apps/web`: `pnpm exec vitest run modules/ee/unify-feedback/topics-subtopics/actions.test.ts`
- From the repo root: `pnpm exec eslint apps/web/modules/ee/unify-feedback/topics-subtopics/actions.test.ts`
- From the repo root: `pnpm exec prettier --check apps/web/modules/ee/unify-feedback/topics-subtopics/actions.test.ts`

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits, or confirmed no extra comments were needed
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
