### PR TITLE
fix: canonicalize v3 survey language read/write + simplify resolver (ENG-1067)

### DIFF
--- a/apps/web/app/api/v1/management/responses/lib/response.ts
+++ b/apps/web/app/api/v1/management/responses/lib/response.ts
@@ -11,7 +11,7 @@ import { TTag } from "@formbricks/types/tags";
 import { buildPrismaResponseData } from "@/app/api/v1/lib/utils";
 import { RESPONSES_PER_PAGE } from "@/lib/constants";
 import { getResponseContact } from "@/lib/response/service";
-import { calculateTtcTotal, normalizeResponseLanguage } from "@/lib/response/utils";
+import { calculateTtcTotal } from "@/lib/response/utils";
 import { getSurvey } from "@/lib/survey/service";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { validateInputs } from "@/lib/utils/validate";
@@ -59,20 +59,18 @@ export const responseSelection = {
 export const createResponseWithQuotaEvaluation = async (
   responseInput: TResponseInput
 ): Promise<TResponse> => {
-  // Quota evaluation must see the SAME canonical language that gets persisted on the response
-  // (buildPrismaResponseData canonicalizes it), so a legacy code from a stale client still matches
-  // language-scoped quotas. Mirrors the v2/management path.
-  const canonicalLanguage = normalizeResponseLanguage(responseInput.language);
-
   const txResponse = await prisma.$transaction(async (tx) => {
     const response = await createResponse(responseInput, tx);
 
+    // Feed quota evaluation the language actually PERSISTED on the response (createResponse ->
+    // buildPrismaResponseData canonicalizes it), so the stored value is the single source of truth and a
+    // legacy code from a stale client still matches language-scoped quotas. Mirrors the v2/management path.
     const quotaResult = await evaluateResponseQuotas({
       surveyId: responseInput.surveyId,
       responseId: response.id,
       data: responseInput.data,
       variables: responseInput.variables,
-      language: canonicalLanguage || "default",
+      language: response.language || "default",
       responseFinished: response.finished,
       tx,
     });

--- a/apps/web/app/api/v1/management/responses/lib/response.ts
+++ b/apps/web/app/api/v1/management/responses/lib/response.ts
@@ -11,7 +11,7 @@ import { TTag } from "@formbricks/types/tags";
 import { buildPrismaResponseData } from "@/app/api/v1/lib/utils";
 import { RESPONSES_PER_PAGE } from "@/lib/constants";
 import { getResponseContact } from "@/lib/response/service";
-import { calculateTtcTotal } from "@/lib/response/utils";
+import { calculateTtcTotal, normalizeResponseLanguage } from "@/lib/response/utils";
 import { getSurvey } from "@/lib/survey/service";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { validateInputs } from "@/lib/utils/validate";
@@ -59,6 +59,11 @@ export const responseSelection = {
 export const createResponseWithQuotaEvaluation = async (
   responseInput: TResponseInput
 ): Promise<TResponse> => {
+  // Quota evaluation must see the SAME canonical language that gets persisted on the response
+  // (buildPrismaResponseData canonicalizes it), so a legacy code from a stale client still matches
+  // language-scoped quotas. Mirrors the v2/management path.
+  const canonicalLanguage = normalizeResponseLanguage(responseInput.language);
+
   const txResponse = await prisma.$transaction(async (tx) => {
     const response = await createResponse(responseInput, tx);
 
@@ -67,7 +72,7 @@ export const createResponseWithQuotaEvaluation = async (
       responseId: response.id,
       data: responseInput.data,
       variables: responseInput.variables,
-      language: responseInput.language,
+      language: canonicalLanguage || "default",
       responseFinished: response.finished,
       tx,
     });

--- a/apps/web/app/api/v3/surveys/generate/schemas.test.ts
+++ b/apps/web/app/api/v3/surveys/generate/schemas.test.ts
@@ -383,13 +383,17 @@ describe("ZV3SurveyGenerateBody", () => {
     expect(result.success).toBe(false);
   });
 
-  test("rejects incomplete locale tags that cannot normalize to an allowed locale", () => {
+  test("normalizes an incomplete script tag to its allowed canonical locale", () => {
+    // `zh-Hans` (script, no region) canonicalizes to the allowed `zh-Hans-CN`, so it is accepted.
     const result = ZV3SurveyGenerateBody.safeParse({
       workspaceId: "clxx1234567890123456789012",
       prompt: "Measure onboarding completion for new users.",
       language: "zh-Hans",
     });
 
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.language).toBe("zh-Hans-CN");
+    }
   });
 });

--- a/apps/web/app/api/v3/surveys/generate/schemas.ts
+++ b/apps/web/app/api/v3/surveys/generate/schemas.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
+import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import { ZUserLocale } from "@formbricks/types/user";
-import { normalizeV3SurveyLanguageIdentifier } from "../language";
 import {
   GENERATED_SURVEY_ELEMENT_TYPES,
   GENERATED_SURVEY_MAX_BLOCKS,
@@ -20,7 +20,7 @@ const ALLOWED_GENERATE_LOCALE_LOOKUP = new Map<string, TV3SurveyGenerateAllowedL
 );
 
 export function normalizeV3SurveyGenerateLocale(value: string): TV3SurveyGenerateAllowedLocale | null {
-  const normalizedLanguage = normalizeV3SurveyLanguageIdentifier(value);
+  const normalizedLanguage = normalizeLanguageCode(value);
 
   if (!normalizedLanguage) {
     return null;

--- a/apps/web/app/api/v3/surveys/language.test.ts
+++ b/apps/web/app/api/v3/surveys/language.test.ts
@@ -212,6 +212,16 @@ describe("resolveV3SurveyLanguageCode", () => {
     });
   });
 
+  test("an exact alias match wins over the bare-selector ambiguity heuristic", () => {
+    // en-US carries the alias "en" and en-GB shares the base; the exact alias match must win, not 400.
+    expect(
+      resolveV3SurveyLanguageCode("en", [
+        { code: "en-US", enabled: true, alias: "en" },
+        { code: "en-GB", enabled: true },
+      ])
+    ).toEqual({ ok: true, code: "en-US" });
+  });
+
   test("reports the user's input rather than a guessed locale when unknown", () => {
     expect(resolveV3SurveyLanguageCode("en", [{ code: "de-DE", enabled: true }])).toEqual({
       ok: false,

--- a/apps/web/app/api/v3/surveys/language.test.ts
+++ b/apps/web/app/api/v3/surveys/language.test.ts
@@ -82,6 +82,28 @@ describe("normalizeV3SurveyWriteLanguageCode", () => {
     expect(normalizeV3SurveyWriteLanguageCode("GU", ["gu-IN", "en-US"])).toBe("gu-IN");
   });
 
+  test("canonicalizes a script-incomplete locale on create (ENG-1067)", () => {
+    // A new survey language given a region-only Chinese tag is stored script-complete/canonical.
+    expect(normalizeV3SurveyWriteLanguageCode("zh-CN")).toBe("zh-Hans-CN");
+    expect(normalizeV3SurveyWriteLanguageCode("zh-TW")).toBe("zh-Hant-TW");
+  });
+
+  test("preserves legitimate non-default regions on create", () => {
+    expect(normalizeV3SurveyWriteLanguageCode("de-AT")).toBe("de-AT");
+    expect(normalizeV3SurveyWriteLanguageCode("en-GB")).toBe("en-GB");
+  });
+
+  test("preserves a survey's stored legacy code on patch even when the canonical/script form is sent", () => {
+    // Survey stores legacy zh-CN (content keyed by zh-CN); sending canonical zh-Hans-CN must still write
+    // the stored zh-CN so the existing content keys are not orphaned.
+    expect(normalizeV3SurveyWriteLanguageCode("zh-Hans-CN", ["zh-CN", "en-US"])).toBe("zh-CN");
+    expect(normalizeV3SurveyWriteLanguageCode("zh-CN", ["zh-CN", "en-US"])).toBe("zh-CN");
+  });
+
+  test("writes the canonical stored code on patch when the survey is already canonical", () => {
+    expect(normalizeV3SurveyWriteLanguageCode("zh-CN", ["zh-Hans-CN", "en-US"])).toBe("zh-Hans-CN");
+  });
+
   test("returns the survey's stored legacy code on match, not its canonical form (pre-migration)", () => {
     // `pt` and `hi` are in the curated map, so the identifier resolves to `pt-BR`/`hi-IN`. A survey that
     // still stores the bare code (not yet migrated) keys its content by `pt`/`hi`, so the write must
@@ -172,6 +194,25 @@ describe("resolveV3SurveyLanguageCode", () => {
     expect(resolveV3SurveyLanguageCode("hi", legacyLanguages)).toEqual({ ok: true, code: "hi-IN" });
     expect(resolveV3SurveyLanguageCode("hi-IN", legacyLanguages)).toEqual({ ok: true, code: "hi-IN" });
     expect(resolveV3SurveyLanguageCode("HI_in", legacyLanguages)).toEqual({ ok: true, code: "hi-IN" });
+  });
+
+  test("resolves legacy/script Chinese selectors to a migrated canonical survey language (ENG-1067)", () => {
+    // Survey stored zh-Hans-CN post-migration. A client still sending the legacy script/region tag must
+    // keep resolving (was HTTP 400 before the canonical-equivalence fallback).
+    const migrated = [{ code: "zh-Hans-CN", enabled: true }];
+    expect(resolveV3SurveyLanguageCode("zh-Hans", migrated)).toEqual({ ok: true, code: "zh-Hans-CN" });
+    expect(resolveV3SurveyLanguageCode("zh_Hans", migrated)).toEqual({ ok: true, code: "zh-Hans-CN" });
+    expect(resolveV3SurveyLanguageCode("zh-CN", migrated)).toEqual({ ok: true, code: "zh-Hans-CN" });
+    expect(resolveV3SurveyLanguageCode("zh-Hans-CN", migrated)).toEqual({ ok: true, code: "zh-Hans-CN" });
+  });
+
+  test("keeps Simplified and Traditional Chinese distinct through canonical equivalence", () => {
+    const both = [
+      { code: "zh-Hans-CN", enabled: true },
+      { code: "zh-Hant-TW", enabled: true },
+    ];
+    expect(resolveV3SurveyLanguageCode("zh-CN", both)).toEqual({ ok: true, code: "zh-Hans-CN" });
+    expect(resolveV3SurveyLanguageCode("zh-TW", both)).toEqual({ ok: true, code: "zh-Hant-TW" });
   });
 
   test("resolves configured language aliases", () => {

--- a/apps/web/app/api/v3/surveys/language.test.ts
+++ b/apps/web/app/api/v3/surveys/language.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "vitest";
 import {
-  normalizeV3SurveyLanguageIdentifier,
   normalizeV3SurveyLanguageTag,
   normalizeV3SurveyLocaleCode,
   normalizeV3SurveyWriteLanguageCode,
@@ -44,22 +43,6 @@ describe("normalizeV3SurveyLocaleCode", () => {
 
   test.each(["de", "zh_Hans", "not a locale"])("rejects non-region-qualified write locale %s", (input) => {
     expect(normalizeV3SurveyLocaleCode(input)).toBeNull();
-  });
-});
-
-describe("normalizeV3SurveyLanguageIdentifier", () => {
-  test.each([
-    ["hi", "hi-IN"],
-    ["HI", "hi-IN"],
-    ["de", "de-DE"],
-    ["hi_in", "hi-IN"],
-  ])("normalizes legacy identifier %s to %s", (input, expected) => {
-    expect(normalizeV3SurveyLanguageIdentifier(input)).toBe(expected);
-  });
-
-  test("resolves bare codes to their CLDR default region (ENG-1067 canonical)", () => {
-    expect(normalizeV3SurveyLanguageIdentifier("pt")).toBe("pt-BR");
-    expect(normalizeV3SurveyLanguageIdentifier("ar")).toBe("ar-EG");
   });
 });
 
@@ -177,23 +160,18 @@ describe("resolveV3SurveyLanguageCode", () => {
     });
   });
 
-  test("matches configured script-only languages case-insensitively and normalizes underscores", () => {
-    expect(resolveV3SurveyLanguageCode("ZH_hans", [{ code: "zh-Hans", enabled: true }])).toEqual({
-      ok: true,
-      code: "zh-Hans",
-    });
-  });
-
   test("resolves disabled configured languages for management reads", () => {
     expect(resolveV3SurveyLanguageCode("fr-FR", languages)).toEqual({ ok: true, code: "fr-FR" });
   });
 
-  test("resolves legacy stored language codes and canonical selectors", () => {
-    const legacyLanguages = [{ code: "hi", enabled: true, alias: null }];
+  test("resolves legacy and canonical selectors to the canonical survey language", () => {
+    // Post-migration the survey stores the canonical tag; a client sending the legacy bare code, the
+    // canonical tag, or an underscore variant all resolve to the stored code.
+    const languages = [{ code: "hi-IN", enabled: true, alias: null }];
 
-    expect(resolveV3SurveyLanguageCode("hi", legacyLanguages)).toEqual({ ok: true, code: "hi-IN" });
-    expect(resolveV3SurveyLanguageCode("hi-IN", legacyLanguages)).toEqual({ ok: true, code: "hi-IN" });
-    expect(resolveV3SurveyLanguageCode("HI_in", legacyLanguages)).toEqual({ ok: true, code: "hi-IN" });
+    expect(resolveV3SurveyLanguageCode("hi", languages)).toEqual({ ok: true, code: "hi-IN" });
+    expect(resolveV3SurveyLanguageCode("hi-IN", languages)).toEqual({ ok: true, code: "hi-IN" });
+    expect(resolveV3SurveyLanguageCode("HI_in", languages)).toEqual({ ok: true, code: "hi-IN" });
   });
 
   test("resolves legacy/script Chinese selectors to a migrated canonical survey language (ENG-1067)", () => {

--- a/apps/web/app/api/v3/surveys/language.ts
+++ b/apps/web/app/api/v3/surveys/language.ts
@@ -97,42 +97,42 @@ export function normalizeV3SurveyWriteLanguageCode(
   value: string,
   allowedLanguageCodes?: Iterable<string>
 ): string | null {
+  // PATCH: if the request resolves to a language ALREADY configured on the survey, write that survey's
+  // STORED code as-is — its content i18n keys are keyed by exactly that code. Pre-migration this preserves
+  // a legacy code (e.g. "pt"/"zh-CN"); post-migration the stored code is already canonical. Never rewrite
+  // it here (even when the client sends the canonical/script-complete form), or the write would orphan the
+  // survey's existing content keys. This match runs BEFORE canonicalization so the preserve rule wins.
+  if (allowedLanguageCodes) {
+    const requestedKey = value.trim().toLowerCase();
+    const requestedIdentifier = normalizeV3SurveyLanguageIdentifier(value)?.toLowerCase() ?? null;
+    // Full CLDR canonical form of the request, covering codes outside the curated map (e.g. `gu`), so a
+    // client still sending a legacy code keeps matching the now-canonical stored survey language.
+    const requestedCanonical = normalizeLanguageCode(value)?.toLowerCase() ?? null;
+
+    for (const allowedLanguageCode of allowedLanguageCodes) {
+      const allowedKey = allowedLanguageCode.toLowerCase();
+      const allowedIdentifier =
+        normalizeV3SurveyLanguageIdentifier(allowedLanguageCode)?.toLowerCase() ?? null;
+      const allowedCanonical = normalizeLanguageCode(allowedLanguageCode)?.toLowerCase() ?? null;
+
+      if (
+        requestedKey === allowedKey ||
+        (requestedIdentifier && requestedIdentifier === allowedKey) ||
+        (allowedIdentifier &&
+          (requestedKey === allowedIdentifier || requestedIdentifier === allowedIdentifier)) ||
+        (requestedCanonical && requestedCanonical === allowedCanonical)
+      ) {
+        return allowedLanguageCode;
+      }
+    }
+  }
+
+  // CREATE (or a genuinely new language added via PATCH): accept a full locale and CANONICALIZE it, so a
+  // newly stored code is always canonical (`zh-CN` -> `zh-Hans-CN`) while legitimate non-default regions
+  // are preserved (`de-AT` stays `de-AT`, `en-GB` stays `en-GB`). Bare/invalid codes stay rejected (null).
   const normalizedLocale = normalizeV3SurveyLocaleCode(value);
   if (normalizedLocale) {
-    return normalizedLocale;
-  }
-
-  if (!allowedLanguageCodes) {
-    return null;
-  }
-
-  const requestedKey = value.trim().toLowerCase();
-  const requestedIdentifier = normalizeV3SurveyLanguageIdentifier(value)?.toLowerCase() ?? null;
-  // Full CLDR canonical form of the request, covering codes outside the curated map (e.g. `gu`). This
-  // is the inbound back-compat path: once the data migration flips a stored code to its canonical tag
-  // (`gu` -> `gu-IN`), a client still sending the legacy `gu` keeps matching the now-canonical survey
-  // language instead of being rejected.
-  const requestedCanonical = normalizeLanguageCode(value)?.toLowerCase() ?? null;
-
-  for (const allowedLanguageCode of allowedLanguageCodes) {
-    const allowedKey = allowedLanguageCode.toLowerCase();
-    const normalizedAllowedLanguageCode = normalizeV3SurveyLanguageIdentifier(allowedLanguageCode);
-    const allowedIdentifier = normalizedAllowedLanguageCode?.toLowerCase() ?? null;
-    const allowedCanonical = normalizeLanguageCode(allowedLanguageCode)?.toLowerCase() ?? null;
-
-    if (
-      requestedKey === allowedKey ||
-      (requestedIdentifier && requestedIdentifier === allowedKey) ||
-      (allowedIdentifier &&
-        (requestedKey === allowedIdentifier || requestedIdentifier === allowedIdentifier)) ||
-      (requestedCanonical && requestedCanonical === allowedCanonical)
-    ) {
-      // PATCH-only compatibility: write to the survey's existing stored code as-is — its content i18n
-      // keys are keyed by exactly this code. Pre-migration this preserves a legacy code (e.g. "pt"/"hi");
-      // post-migration the stored code is already canonical. Never rewrite it to the canonical form here,
-      // or a pre-migration survey would get a new key that doesn't match its content.
-      return allowedLanguageCode;
-    }
+    return normalizeLanguageCode(normalizedLocale) ?? normalizedLocale;
   }
 
   return null;
@@ -254,6 +254,21 @@ export function resolveV3SurveyLanguageCode(
         (language.code.toLowerCase() === normalizedRequestedLanguage.toLowerCase() ||
           language.normalizedAlias?.toLowerCase() === normalizedRequestedLanguage.toLowerCase()))
   );
+
+  // Canonical-equivalence fallback (ENG-1067): only when nothing matched by exact code/alias/tag, resolve a
+  // request whose canonical BCP-47 form equals a configured language's canonical form. Mirrors the write
+  // path (normalizeV3SurveyWriteLanguageCode) so a legacy/script selector still hits a MIGRATED survey
+  // language — e.g. ?lang=zh-Hans or ?lang=zh-CN against a stored zh-Hans-CN. Runs only on zero exact
+  // matches, so an exact stored-code match always wins (no regression, no broadened ambiguity for exact hits).
+  if (matches.length === 0) {
+    const requestedCanonical =
+      normalizeLanguageCode(normalizedRequestedLanguage ?? requestedLanguageValue)?.toLowerCase() ?? null;
+    if (requestedCanonical) {
+      matches = normalizedLanguages.filter(
+        (language) => normalizeLanguageCode(language.originalCode)?.toLowerCase() === requestedCanonical
+      );
+    }
+  }
 
   if (matches.length === 0 && isLanguageOnlySelector(requestedLanguageValue) && requestedLanguageBase) {
     matches = normalizedLanguages.filter(

--- a/apps/web/app/api/v3/surveys/language.ts
+++ b/apps/web/app/api/v3/surveys/language.ts
@@ -1,4 +1,4 @@
-import { LANGUAGE_CANONICAL_MAP, normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
+import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import type { TSurvey as TInternalSurvey } from "@formbricks/types/surveys/types";
 
 export type TV3SurveyResolverLanguage = {
@@ -25,43 +25,10 @@ type TParseV3SurveyLanguageQueryResult = { ok: true; languages: string[] } | { o
 const V3_SURVEY_LANGUAGE_TAG_REGEX = /^[a-z]{2}(?:-[A-Z]{2}|-[A-Z][a-z]{3}(?:-[A-Z]{2})?)$/;
 const V3_SURVEY_LOCALE_CODE_REGEX = /^[a-z]{2}(?:-[A-Z][a-z]{3})?-[A-Z]{2}$/;
 
-// Bare legacy codes v3 canonicalizes on read, with values sourced from the shared canonical map so v3
-// can't drift from the picker/DB/migration (this fixes the old `ar -> ar-SA` and adds `pt -> pt-BR`).
-// Codes OUTSIDE this set are deliberately preserved as-stored: an unrelated patch must not silently
-// migrate a survey's language (which would orphan its content keys). The ENG-1067 data migration
-// canonicalizes those remaining codes in one controlled pass.
-const V3_CANONICALIZABLE_BARE_CODES = [
-  "ar",
-  "cs",
-  "da",
-  "de",
-  "en",
-  "es",
-  "fi",
-  "fr",
-  "he",
-  "hi",
-  "hu",
-  "it",
-  "ja",
-  "ko",
-  "nb",
-  "nl",
-  "no",
-  "pl",
-  "pt",
-  "ro",
-  "ru",
-  "sv",
-  "tr",
-] as const;
-const V3_LEGACY_LANGUAGE_CODE_MAP: Record<string, string> = Object.fromEntries(
-  V3_CANONICALIZABLE_BARE_CODES.flatMap((code) => {
-    const canonicalCode = LANGUAGE_CANONICAL_MAP[code];
-    return canonicalCode ? [[code, canonicalCode]] : [];
-  })
-);
-
+// Validate + case/separator-normalize a fully region/script-qualified BCP-47 tag. This only recognises a
+// valid tag — it does NOT canonicalize or complete it (`zh-Hans` stays `zh-Hans`, `zh-CN` stays `zh-CN`).
+// Canonicalization is `normalizeLanguageCode`'s job; this is used for tag recognition and query dedup.
+// Returns null for bare/underspecified/invalid input.
 export function normalizeV3SurveyLanguageTag(value: string): string | null {
   return normalizeV3SurveyLanguageCode(value, V3_SURVEY_LANGUAGE_TAG_REGEX);
 }
@@ -85,49 +52,32 @@ function normalizeV3SurveyLanguageCode(value: string, pattern: RegExp): string |
   }
 }
 
-export function normalizeV3SurveyLanguageIdentifier(value: string): string | null {
-  // Already region/script-qualified tag wins as-is; otherwise canonicalize a bare code via the curated
-  // map (values from the shared source). Un-mapped codes return null so callers preserve them as-stored.
-  return (
-    normalizeV3SurveyLanguageTag(value) ?? V3_LEGACY_LANGUAGE_CODE_MAP[value.trim().toLowerCase()] ?? null
-  );
-}
+const canonicalKey = (value: string): string | null => normalizeLanguageCode(value)?.toLowerCase() ?? null;
 
 export function normalizeV3SurveyWriteLanguageCode(
   value: string,
   allowedLanguageCodes?: Iterable<string>
 ): string | null {
   // PATCH: if the request resolves to a language ALREADY configured on the survey, write that survey's
-  // STORED code as-is — its content i18n keys are keyed by exactly that code. Pre-migration this preserves
-  // a legacy code (e.g. "pt"/"zh-CN"); post-migration the stored code is already canonical. Never rewrite
-  // it here (even when the client sends the canonical/script-complete form), or the write would orphan the
-  // survey's existing content keys. This match runs BEFORE canonicalization so the preserve rule wins.
+  // STORED code as-is — its content i18n keys are keyed by exactly that code. Post-migration the stored
+  // code is already canonical; a client still sending a legacy/script form matches by canonical
+  // equivalence. Never rewrite it here (even for a canonical/script-complete input), or the write would
+  // orphan the survey's existing content keys. This match runs BEFORE canonicalization so preserve wins.
   if (allowedLanguageCodes) {
     const requestedKey = value.trim().toLowerCase();
-    const requestedIdentifier = normalizeV3SurveyLanguageIdentifier(value)?.toLowerCase() ?? null;
-    // Full CLDR canonical form of the request, covering codes outside the curated map (e.g. `gu`), so a
-    // client still sending a legacy code keeps matching the now-canonical stored survey language.
-    const requestedCanonical = normalizeLanguageCode(value)?.toLowerCase() ?? null;
+    const requestedCanonical = canonicalKey(value);
 
     for (const allowedLanguageCode of allowedLanguageCodes) {
-      const allowedKey = allowedLanguageCode.toLowerCase();
-      const allowedIdentifier =
-        normalizeV3SurveyLanguageIdentifier(allowedLanguageCode)?.toLowerCase() ?? null;
-      const allowedCanonical = normalizeLanguageCode(allowedLanguageCode)?.toLowerCase() ?? null;
-
       if (
-        requestedKey === allowedKey ||
-        (requestedIdentifier && requestedIdentifier === allowedKey) ||
-        (allowedIdentifier &&
-          (requestedKey === allowedIdentifier || requestedIdentifier === allowedIdentifier)) ||
-        (requestedCanonical && requestedCanonical === allowedCanonical)
+        requestedKey === allowedLanguageCode.toLowerCase() ||
+        (requestedCanonical && requestedCanonical === canonicalKey(allowedLanguageCode))
       ) {
         return allowedLanguageCode;
       }
     }
   }
 
-  // CREATE (or a genuinely new language added via PATCH): accept a full locale and CANONICALIZE it, so a
+  // CREATE (or a genuinely new language added via PATCH): accept a full locale and canonicalize it, so a
   // newly stored code is always canonical (`zh-CN` -> `zh-Hans-CN`) while legitimate non-default regions
   // are preserved (`de-AT` stays `de-AT`, `en-GB` stays `en-GB`). Bare/invalid codes stay rejected (null).
   const normalizedLocale = normalizeV3SurveyLocaleCode(value);
@@ -171,31 +121,15 @@ export function parseV3SurveyLanguageQuery(
   return { ok: true, languages };
 }
 
+// Base language subtag (`de-AT` -> `de`, `zh-Hans-CN` -> `zh`), or null when there's no valid 2-3 letter
+// base. Map-independent: only used to resolve/deduplicate bare language selectors.
 function getLanguageBase(code: string): string | null {
-  const normalizedCode = normalizeV3SurveyLanguageIdentifier(code);
-
-  if (normalizedCode) {
-    return normalizedCode.split("-")[0].toLowerCase();
-  }
-
-  return /^[a-z]{2,3}$/i.test(code) ? code.toLowerCase() : null;
+  const base = code.trim().toLowerCase().split(/[-_]/)[0];
+  return /^[a-z]{2,3}$/.test(base) ? base : null;
 }
 
 function isLanguageOnlySelector(code: string): boolean {
   return /^[a-z]{2,3}$/i.test(code);
-}
-
-function getNormalizedLanguage(language: TV3SurveyResolverLanguage) {
-  const code = normalizeV3SurveyLanguageIdentifier(language.code) ?? language.code;
-  const alias = getV3SurveyLanguageAlias(language.alias);
-
-  return {
-    ...language,
-    code,
-    originalCode: language.code,
-    alias,
-    normalizedAlias: alias ? normalizeV3SurveyLanguageIdentifier(alias) : null,
-  };
 }
 
 function getV3SurveyLanguageAlias(alias: string | null | undefined): string | null {
@@ -224,14 +158,13 @@ export function resolveV3SurveyLanguageCode(
   const requestedLanguageValue = requestedLanguage.trim();
   const requestedLanguageKey = requestedLanguageValue.toLowerCase();
   const normalizedRequestedLanguage = normalizeV3SurveyLanguageTag(requestedLanguageValue);
-
-  const normalizedLanguages = languages.map(getNormalizedLanguage);
   const requestedLanguageBase = getLanguageBase(requestedLanguageValue);
 
+  // A bare language selector that matches more than one configured region/script is ambiguous.
   if (isLanguageOnlySelector(requestedLanguageValue) && requestedLanguageBase) {
     const baseMatchCodes = Array.from(
       new Set(
-        normalizedLanguages
+        languages
           .filter((language) => getLanguageBase(language.code) === requestedLanguageBase)
           .map((language) => language.code)
       )
@@ -246,36 +179,37 @@ export function resolveV3SurveyLanguageCode(
     }
   }
 
-  let matches = normalizedLanguages.filter(
+  // 1. Exact stored code or alias (case-insensitive) — always wins.
+  let matches = languages.filter(
     (language) =>
-      language.originalCode.toLowerCase() === requestedLanguageKey ||
-      language.alias?.toLowerCase() === requestedLanguageKey ||
-      (normalizedRequestedLanguage &&
-        (language.code.toLowerCase() === normalizedRequestedLanguage.toLowerCase() ||
-          language.normalizedAlias?.toLowerCase() === normalizedRequestedLanguage.toLowerCase()))
+      language.code.toLowerCase() === requestedLanguageKey ||
+      getV3SurveyLanguageAlias(language.alias)?.toLowerCase() === requestedLanguageKey
   );
 
-  // Canonical-equivalence fallback (ENG-1067): only when nothing matched by exact code/alias/tag, resolve a
-  // request whose canonical BCP-47 form equals a configured language's canonical form. Mirrors the write
-  // path (normalizeV3SurveyWriteLanguageCode) so a legacy/script selector still hits a MIGRATED survey
-  // language — e.g. ?lang=zh-Hans or ?lang=zh-CN against a stored zh-Hans-CN. Runs only on zero exact
-  // matches, so an exact stored-code match always wins (no regression, no broadened ambiguity for exact hits).
+  // 2. Canonical equivalence — a legacy/script/region/underscore selector resolves to the language whose
+  // canonical BCP-47 form matches (`?lang=zh-Hans` or `?lang=zh-CN` -> a stored `zh-Hans-CN`; `?lang=DE_de`
+  // -> `de-DE`). Runs only on zero exact matches, so an exact stored-code match always wins.
   if (matches.length === 0) {
-    const requestedCanonical =
-      normalizeLanguageCode(normalizedRequestedLanguage ?? requestedLanguageValue)?.toLowerCase() ?? null;
+    const requestedCanonical = canonicalKey(normalizedRequestedLanguage ?? requestedLanguageValue);
     if (requestedCanonical) {
-      matches = normalizedLanguages.filter(
-        (language) => normalizeLanguageCode(language.originalCode)?.toLowerCase() === requestedCanonical
-      );
+      matches = languages.filter((language) => {
+        const alias = getV3SurveyLanguageAlias(language.alias);
+        return (
+          canonicalKey(language.code) === requestedCanonical ||
+          (alias ? canonicalKey(alias) === requestedCanonical : false)
+        );
+      });
     }
   }
 
+  // 3. Base-language fallback for a bare selector (`?lang=pt` -> the single `pt-*` language).
   if (matches.length === 0 && isLanguageOnlySelector(requestedLanguageValue) && requestedLanguageBase) {
-    matches = normalizedLanguages.filter(
-      (language) => getLanguageBase(language.code) === requestedLanguageBase
-    );
+    matches = languages.filter((language) => getLanguageBase(language.code) === requestedLanguageBase);
   }
 
+  // Return the survey's STORED code (canonical post-migration) so it lines up exactly with its content
+  // i18n keys. Matching above already canonicalized the request; we only rewrite what we store, never
+  // what we hand back for an existing survey.
   const matchCodes = Array.from(new Set(matches.map((language) => language.code)));
 
   if (matchCodes.length === 1) {
@@ -315,16 +249,12 @@ export function getV3SurveyLanguages(
   survey: Pick<TInternalSurvey, "languages">,
   fallbackLanguage: string
 ): TV3SurveyLanguage[] {
-  const languages = (survey.languages ?? []).map((surveyLanguage) => {
-    const alias = getV3SurveyLanguageAlias(surveyLanguage.language.alias);
-
-    return {
-      code: normalizeV3SurveyLanguageIdentifier(surveyLanguage.language.code) ?? surveyLanguage.language.code,
-      default: surveyLanguage.default,
-      enabled: surveyLanguage.enabled,
-      alias,
-    };
-  });
+  const languages = (survey.languages ?? []).map((surveyLanguage) => ({
+    code: surveyLanguage.language.code,
+    default: surveyLanguage.default,
+    enabled: surveyLanguage.enabled,
+    alias: getV3SurveyLanguageAlias(surveyLanguage.language.alias),
+  }));
 
   if (languages.length === 0) {
     return [{ code: fallbackLanguage, default: true, enabled: true }];
@@ -338,7 +268,7 @@ export function getV3SurveyResolverLanguages(
   fallbackLanguage: string
 ): TV3SurveyResolverLanguage[] {
   const languages = (survey.languages ?? []).map((surveyLanguage) => ({
-    code: normalizeV3SurveyLanguageIdentifier(surveyLanguage.language.code) ?? surveyLanguage.language.code,
+    code: surveyLanguage.language.code,
     enabled: surveyLanguage.enabled,
     alias: getV3SurveyLanguageAlias(surveyLanguage.language.alias),
   }));
@@ -357,7 +287,5 @@ export function getV3SurveyDefaultLanguage(
   const defaultLanguageCode = survey.languages?.find((surveyLanguage) => surveyLanguage.default)?.language
     .code;
 
-  return defaultLanguageCode
-    ? (normalizeV3SurveyLanguageIdentifier(defaultLanguageCode) ?? defaultLanguageCode)
-    : fallbackLanguage;
+  return defaultLanguageCode ?? fallbackLanguage;
 }

--- a/apps/web/app/api/v3/surveys/language.ts
+++ b/apps/web/app/api/v3/surveys/language.ts
@@ -160,8 +160,17 @@ export function resolveV3SurveyLanguageCode(
   const normalizedRequestedLanguage = normalizeV3SurveyLanguageTag(requestedLanguageValue);
   const requestedLanguageBase = getLanguageBase(requestedLanguageValue);
 
-  // A bare language selector that matches more than one configured region/script is ambiguous.
-  if (isLanguageOnlySelector(requestedLanguageValue) && requestedLanguageBase) {
+  // 1. Exact stored code or alias (case-insensitive) — always wins, even over the ambiguity heuristic below.
+  let matches = languages.filter(
+    (language) =>
+      language.code.toLowerCase() === requestedLanguageKey ||
+      getV3SurveyLanguageAlias(language.alias)?.toLowerCase() === requestedLanguageKey
+  );
+
+  // 2. No exact hit: a bare language selector matching more than one configured region/script is ambiguous
+  // (`?lang=en` against both `en-US` and `en-GB`). Runs AFTER the exact/alias match so an exact stored code
+  // or a configured alias (e.g. `en-US` aliased `en`) is never short-circuited by this heuristic.
+  if (matches.length === 0 && isLanguageOnlySelector(requestedLanguageValue) && requestedLanguageBase) {
     const baseMatchCodes = Array.from(
       new Set(
         languages
@@ -179,14 +188,7 @@ export function resolveV3SurveyLanguageCode(
     }
   }
 
-  // 1. Exact stored code or alias (case-insensitive) — always wins.
-  let matches = languages.filter(
-    (language) =>
-      language.code.toLowerCase() === requestedLanguageKey ||
-      getV3SurveyLanguageAlias(language.alias)?.toLowerCase() === requestedLanguageKey
-  );
-
-  // 2. Canonical equivalence — a legacy/script/region/underscore selector resolves to the language whose
+  // 3. Canonical equivalence — a legacy/script/region/underscore selector resolves to the language whose
   // canonical BCP-47 form matches (`?lang=zh-Hans` or `?lang=zh-CN` -> a stored `zh-Hans-CN`; `?lang=DE_de`
   // -> `de-DE`). Runs only on zero exact matches, so an exact stored-code match always wins.
   if (matches.length === 0) {
@@ -202,7 +204,7 @@ export function resolveV3SurveyLanguageCode(
     }
   }
 
-  // 3. Base-language fallback for a bare selector (`?lang=pt` -> the single `pt-*` language).
+  // 4. Base-language fallback for a bare selector (`?lang=pt` -> the single `pt-*` language).
   if (matches.length === 0 && isLanguageOnlySelector(requestedLanguageValue) && requestedLanguageBase) {
     matches = languages.filter((language) => getLanguageBase(language.code) === requestedLanguageBase);
   }

--- a/apps/web/app/api/v3/surveys/prepare.test.ts
+++ b/apps/web/app/api/v3/surveys/prepare.test.ts
@@ -418,11 +418,11 @@ describe("v3 survey preparation", () => {
     );
   });
 
-  test("normalizes existing known legacy translation keys during patch preparation", () => {
+  test("preserves canonical translation keys during patch preparation", () => {
     const preparation = prepareV3SurveyPatchInput(
-      createLegacyLanguageSurvey("hi", { defaultLanguage: "en-US" }),
+      createLegacyLanguageSurvey("hi-IN", { defaultLanguage: "en-US" }),
       {
-        name: "Updated legacy hi survey",
+        name: "Updated hi-IN survey",
       }
     );
 

--- a/apps/web/app/api/v3/surveys/serializers.test.ts
+++ b/apps/web/app/api/v3/surveys/serializers.test.ts
@@ -63,7 +63,7 @@ const baseSurvey = {
   variables: [],
 } as unknown as TSurvey;
 
-const createLegacyHindiSurvey = (overrides: Partial<TSurvey> = {}) =>
+const createHindiSurvey = (overrides: Partial<TSurvey> = {}) =>
   ({
     ...baseSurvey,
     languages: [
@@ -72,7 +72,7 @@ const createLegacyHindiSurvey = (overrides: Partial<TSurvey> = {}) =>
         enabled: true,
         language: {
           id: "lang_1",
-          code: "en",
+          code: "en-US",
           alias: null,
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -83,7 +83,7 @@ const createLegacyHindiSurvey = (overrides: Partial<TSurvey> = {}) =>
         enabled: true,
         language: {
           id: "lang_2",
-          code: "hi",
+          code: "hi-IN",
           alias: "hi-in",
           createdAt: new Date(),
           updatedAt: new Date(),
@@ -92,7 +92,7 @@ const createLegacyHindiSurvey = (overrides: Partial<TSurvey> = {}) =>
     ],
     welcomeCard: {
       enabled: true,
-      headline: { default: "Welcome", hi: "स्वागत है" },
+      headline: { default: "Welcome", "hi-IN": "स्वागत है" },
     },
     ...overrides,
   }) as unknown as TSurvey;
@@ -458,8 +458,8 @@ describe("serializeV3SurveyResource", () => {
     });
   });
 
-  test("maps known legacy stored language codes and translation keys to emitted response codes", () => {
-    const survey = createLegacyHindiSurvey({
+  test("emits canonical language codes and translation keys", () => {
+    const survey = createHindiSurvey({
       blocks: [
         {
           id: "block_1",
@@ -468,7 +468,7 @@ describe("serializeV3SurveyResource", () => {
             {
               id: "satisfaction",
               type: "openText",
-              headline: { default: "What should we improve?", hi: "हमें क्या सुधारना चाहिए?" },
+              headline: { default: "What should we improve?", "hi-IN": "हमें क्या सुधारना चाहिए?" },
               required: true,
             },
           ],
@@ -497,8 +497,8 @@ describe("serializeV3SurveyResource", () => {
     });
   });
 
-  test("filters legacy stored language codes by legacy code and alias", () => {
-    const survey = createLegacyHindiSurvey();
+  test("resolves a survey language by legacy code and alias selectors", () => {
+    const survey = createHindiSurvey();
 
     expect(serializeV3SurveyResource(survey, { lang: ["hi"] })).toMatchObject({
       welcomeCard: { headline: { "hi-IN": "स्वागत है" } },

--- a/apps/web/app/api/v3/surveys/serializers.ts
+++ b/apps/web/app/api/v3/surveys/serializers.ts
@@ -1,3 +1,4 @@
+import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import type { TSurvey as TInternalSurvey } from "@formbricks/types/surveys/types";
 import type { TSurvey as TSurveyListRecord } from "@/modules/survey/list/types/surveys";
 import { surveyToV3Distribution, surveyToV3Targeting } from "./distribution";
@@ -7,7 +8,6 @@ import {
   getV3SurveyDefaultLanguage,
   getV3SurveyLanguages,
   getV3SurveyResolverLanguages,
-  normalizeV3SurveyLanguageIdentifier,
   resolveV3SurveyLanguageCode,
 } from "./language";
 import { V3_SURVEY_TRANSLATABLE_METADATA_KEYS } from "./translation-fields";
@@ -97,7 +97,7 @@ function getI18nValueForLanguage(value: Record<string, string>, languageCode: st
   }
 
   const matchingKey = Object.keys(value).find(
-    (key) => normalizeV3SurveyLanguageIdentifier(key)?.toLowerCase() === languageCode.toLowerCase()
+    (key) => normalizeLanguageCode(key)?.toLowerCase() === languageCode.toLowerCase()
   );
   return matchingKey ? value[matchingKey] : undefined;
 }


### PR DESCRIPTION
## What does this PR do?

Part of the **ENG-1067** language-code canonicalization epic (targets the `epic/language-codes-stabilization` branch). It makes the **v3 survey APIs** consistently canonical for language codes, fixes a migration-triggered read-contract break, and simplifies the v3 language module.

### Read — `GET /api/v3/surveys/{id}?lang=…`

The `?lang=` resolver is now **canonical-aware**: a legacy / script / region selector resolves to the matching migrated survey language by canonical equivalence. For example, against a survey whose language was migrated to `zh-Hans-CN`, `?lang=zh-Hans` and `?lang=zh-CN` now resolve to it instead of returning **HTTP 400**. An exact stored-code match still always wins, so there is no broadened ambiguity. (The write path already did this — the read resolver was the asymmetric miss that the data migration would otherwise have turned into a 400.)

### Write — create / patch

- **Create** canonicalizes a new language on write, so newly stored codes are always canonical (`zh-CN` → `zh-Hans-CN`) while legitimate non-default regions are preserved (`de-AT` stays `de-AT`, `en-GB` stays `en-GB`).
- **Patch** matches the request against the survey's existing languages and writes the **stored code as-is** — never rewriting it, even when the client sends the canonical/script-complete form — so a survey's existing content i18n keys are never orphaned.

### Quota evaluation

The v1/management response-create path now passes the **canonical** language to quota evaluation (it was passing the raw request code). This matches every other response path and keeps language-scoped quotas consistent with the value actually persisted on the response.

### Simplification / refactor

Removed the bespoke v3 curated legacy map (`V3_LEGACY_LANGUAGE_CODE_MAP` / `V3_CANONICALIZABLE_BARE_CODES`) and `normalizeV3SurveyLanguageIdentifier`, unifying all matching and normalization on the shared `normalizeLanguageCode`. Read/resolve now return the survey's **stored code as-is** (already canonical post-migration); canonicalization happens only on write and for input matching. Net **−29 lines** with behavior preserved for all post-migration data (verified OLD-vs-NEW across the resolver, write, serializer and generate paths).

## How should this be tested?

- `pnpm --filter=@formbricks/web test app/api/v3/surveys` — **275 tests pass** (resolver, write-validation, serializers, patch-prepare, AI-generate). Typecheck and lint are clean.
- **Read back-compat:** `GET /api/v3/surveys/{id}?lang=zh-Hans` (also `zh-CN`, `de`, `hi`) against a migrated multi-language survey → resolves to the canonical survey language and returns its content (previously **400** for the script/region Chinese selectors).
- **Write:** `POST`/`PATCH` a survey language `zh-CN` → stored as `zh-Hans-CN`; patching a survey that already stores a code preserves that stored code (no orphaned content keys).
- **Quota:** submit a response via the v1/management responses API with a legacy language code → language-scoped quotas evaluate against the canonical code.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
