### PR TITLE
feat(mcp): add read + dry-run workflow tools [ENG-1592]

### DIFF
--- a/apps/web/app/api/mcp/route.test.ts
+++ b/apps/web/app/api/mcp/route.test.ts
@@ -165,6 +165,14 @@ describe("POST /api/mcp", () => {
       "list_workflow_runs",
       "get_workflow_run",
       "test_workflow",
+      "create_workflow",
+      "patch_workflow",
+      "duplicate_workflow",
+      "delete_workflow",
+      "enable_workflow",
+      "disable_workflow",
+      "archive_workflow",
+      "unarchive_workflow",
     ]);
     const tools = new Map(message.result.tools.map((tool: { name: string }) => [tool.name, tool]));
     expect(Object.keys((tools.get("create_survey") as any).inputSchema.properties)).toEqual(

--- a/apps/web/app/api/mcp/route.test.ts
+++ b/apps/web/app/api/mcp/route.test.ts
@@ -160,6 +160,11 @@ describe("POST /api/mcp", () => {
       "validate_survey",
       "patch_survey",
       "delete_survey",
+      "list_workflows",
+      "get_workflow",
+      "list_workflow_runs",
+      "get_workflow_run",
+      "test_workflow",
     ]);
     const tools = new Map(message.result.tools.map((tool: { name: string }) => [tool.name, tool]));
     expect(Object.keys((tools.get("create_survey") as any).inputSchema.properties)).toEqual(

--- a/apps/web/modules/mcp/auth.ts
+++ b/apps/web/modules/mcp/auth.ts
@@ -70,7 +70,7 @@ function isOriginAllowed(request: NextRequest): boolean {
 }
 
 function getMcpScopes(authentication: TAuthenticationApiKey): string[] {
-  const scopes = new Set(["surveys:read"]);
+  const scopes = new Set(["surveys:read", "workflows:read"]);
   if (
     authentication.workspacePermissions.some(
       (permission) => permission.permission === "write" || permission.permission === "manage"

--- a/apps/web/modules/mcp/auth.ts
+++ b/apps/web/modules/mcp/auth.ts
@@ -77,6 +77,7 @@ function getMcpScopes(authentication: TAuthenticationApiKey): string[] {
     )
   ) {
     scopes.add("surveys:write");
+    scopes.add("workflows:write");
   }
 
   return Array.from(scopes);

--- a/apps/web/modules/mcp/server.ts
+++ b/apps/web/modules/mcp/server.ts
@@ -2,10 +2,12 @@ import "server-only";
 import { createMcpHandler } from "mcp-handler";
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "./constants";
 import { registerSurveyTools } from "./tools/surveys";
+import { registerWorkflowTools } from "./tools/workflows";
 
 export const mcpHandler = createMcpHandler(
   (server) => {
     registerSurveyTools(server);
+    registerWorkflowTools(server);
   },
   {
     serverInfo: {

--- a/apps/web/modules/mcp/tools/workflow-schemas.ts
+++ b/apps/web/modules/mcp/tools/workflow-schemas.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
-import { ZWorkflowRunStatus, ZWorkflowSortBy, ZWorkflowStatus } from "@formbricks/workflows";
+import {
+  ZCreateWorkflowInput,
+  ZPatchWorkflowInput,
+  ZWorkflowRunStatus,
+  ZWorkflowSortBy,
+  ZWorkflowStatus,
+} from "@formbricks/workflows";
 
 export const ZMcpListWorkflowsInput = z.object({
   workspaceId: z.cuid2().describe("Workspace ID whose workflows should be listed."),
@@ -96,3 +102,35 @@ export const ZMcpTestWorkflowInput = z.object({
   workflowId: z.cuid2().describe("Workflow ID to dry-run (validate + mock execute, no side effects)."),
 });
 export type TMcpTestWorkflowInput = z.infer<typeof ZMcpTestWorkflowInput>;
+
+// --- Mutations ---
+
+// Reuse the v3 create contract verbatim: workspaceId, name, optional description, and the full
+// workflow definition graph. Workflows are always created as drafts (enable makes them live).
+export const ZMcpCreateWorkflowInput = ZCreateWorkflowInput;
+export type TMcpCreateWorkflowInput = z.infer<typeof ZMcpCreateWorkflowInput>;
+
+export const ZMcpPatchWorkflowInput = z.object({
+  workflowId: z.cuid2().describe("Workflow ID to update."),
+  data: ZPatchWorkflowInput.describe(
+    "Partial update. Provided top-level fields replace that whole subtree; definition edits are only accepted while draft or disabled."
+  ),
+});
+export type TMcpPatchWorkflowInput = z.infer<typeof ZMcpPatchWorkflowInput>;
+
+export const ZMcpDuplicateWorkflowInput = z.object({
+  workflowId: z.cuid2().describe("Workflow ID to duplicate as a new draft."),
+  name: z
+    .string()
+    .min(1)
+    .max(120)
+    .optional()
+    .describe("Optional name for the copy. If omitted, the server picks a non-conflicting name."),
+});
+export type TMcpDuplicateWorkflowInput = z.infer<typeof ZMcpDuplicateWorkflowInput>;
+
+// Shared shape for the id-only lifecycle mutations (delete / enable / disable / archive / unarchive).
+export const ZMcpWorkflowIdInput = z.object({
+  workflowId: z.cuid2().describe("Workflow ID."),
+});
+export type TMcpWorkflowIdInput = z.infer<typeof ZMcpWorkflowIdInput>;

--- a/apps/web/modules/mcp/tools/workflow-schemas.ts
+++ b/apps/web/modules/mcp/tools/workflow-schemas.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+import { ZWorkflowRunStatus, ZWorkflowSortBy, ZWorkflowStatus } from "@formbricks/workflows";
+
+export const ZMcpListWorkflowsInput = z.object({
+  workspaceId: z.cuid2().describe("Workspace ID whose workflows should be listed."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .describe("Maximum number of workflows to return. Defaults to 20.")
+    .default(20),
+  cursor: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Opaque pagination cursor from a previous list_workflows response."),
+  filter: z
+    .object({
+      name: z
+        .object({
+          contains: z
+            .string()
+            .min(1)
+            .max(512)
+            .optional()
+            .describe("Case-insensitive workflow name substring."),
+        })
+        .describe("Filter by workflow name.")
+        .optional(),
+      status: z
+        .object({
+          in: z
+            .array(ZWorkflowStatus)
+            .min(1)
+            .optional()
+            .describe("Workflow statuses to include. Omitting returns every status except archived."),
+        })
+        .describe("Filter by workflow status.")
+        .optional(),
+    })
+    .describe("Optional supported v3 workflow filters.")
+    .optional(),
+  sortBy: ZWorkflowSortBy.optional().describe(
+    "Sort field for pagination. Defaults to the v3 API default of updatedAt."
+  ),
+});
+export type TMcpListWorkflowsInput = z.infer<typeof ZMcpListWorkflowsInput>;
+
+export const ZMcpGetWorkflowInput = z.object({
+  workflowId: z.cuid2().describe("Workflow ID to fetch."),
+});
+export type TMcpGetWorkflowInput = z.infer<typeof ZMcpGetWorkflowInput>;
+
+export const ZMcpListWorkflowRunsInput = z.object({
+  workspaceId: z.cuid2().describe("Workspace ID whose workflow runs should be listed."),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .describe("Maximum number of runs to return. Defaults to 20.")
+    .default(20),
+  cursor: z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Opaque pagination cursor from a previous list_workflow_runs response."),
+  workflowId: z.cuid2().optional().describe("Return only runs of this workflow."),
+  responseId: z.cuid2().optional().describe("Return only runs triggered by this survey response."),
+  filter: z
+    .object({
+      status: z
+        .object({
+          in: z
+            .array(ZWorkflowRunStatus)
+            .min(1)
+            .optional()
+            .describe("Run statuses to include, for example queued or completed."),
+        })
+        .describe("Filter by run status.")
+        .optional(),
+      isDryRun: z.boolean().optional().describe("Filter by dry-run vs real runs. Omit to return both."),
+    })
+    .describe("Optional supported v3 workflow run filters.")
+    .optional(),
+});
+export type TMcpListWorkflowRunsInput = z.infer<typeof ZMcpListWorkflowRunsInput>;
+
+export const ZMcpGetWorkflowRunInput = z.object({
+  runId: z.cuid2().describe("Workflow run ID to fetch, including its ordered step logs."),
+});
+export type TMcpGetWorkflowRunInput = z.infer<typeof ZMcpGetWorkflowRunInput>;
+
+export const ZMcpTestWorkflowInput = z.object({
+  workflowId: z.cuid2().describe("Workflow ID to dry-run (validate + mock execute, no side effects)."),
+});
+export type TMcpTestWorkflowInput = z.infer<typeof ZMcpTestWorkflowInput>;

--- a/apps/web/modules/mcp/tools/workflows.test.ts
+++ b/apps/web/modules/mcp/tools/workflows.test.ts
@@ -142,6 +142,28 @@ describe("registerWorkflowTools", () => {
     });
   });
 
+  test("list_workflow_runs delegates to listRuns with a synthetic query request", async () => {
+    const { tools } = createToolServer();
+    vi.mocked(workflowsHandlers.listRuns).mockResolvedValue(
+      successListResponse([{ id: RUN_ID }], { limit: 20, nextCursor: null }, { requestId: "req_tool" })
+    );
+
+    const result = await tools
+      .get("list_workflow_runs")!
+      .handler({ workspaceId: WORKSPACE_ID, limit: 20, workflowId: WORKFLOW_ID }, { authInfo });
+
+    const callArg = vi.mocked(workflowsHandlers.listRuns).mock.calls[0][0];
+    expect(callArg.ctx).toEqual({ __ctx: true });
+    const params = new URL(callArg.req.url).searchParams;
+    expect(params.get("workspaceId")).toBe(WORKSPACE_ID);
+    expect(params.get("workflowId")).toBe(WORKFLOW_ID);
+    expect(result.structuredContent).toEqual({
+      data: [{ id: RUN_ID }],
+      meta: { limit: 20, nextCursor: null },
+      requestId: "req_tool",
+    });
+  });
+
   test("get_workflow delegates to the handler with params (no request)", async () => {
     const { tools } = createToolServer();
     vi.mocked(workflowsHandlers.get).mockResolvedValue(

--- a/apps/web/modules/mcp/tools/workflows.test.ts
+++ b/apps/web/modules/mcp/tools/workflows.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ApiKeyPermission } from "@formbricks/database/prisma";
-import { problemForbidden, successListResponse, successResponse } from "@/app/api/v3/lib/response";
+import { buildV3AuditLog, queueV3AuditLog } from "@/app/api/v3/lib/audit";
+import {
+  createdResponse,
+  noContentResponse,
+  problemForbidden,
+  successListResponse,
+  successResponse,
+} from "@/app/api/v3/lib/response";
 import { buildWorkflowApiContext, workflowsHandlers } from "@/app/api/v3/workflows/lib/context";
 import {
   buildListWorkflowRunsSearchParams,
@@ -16,7 +23,24 @@ vi.mock("@/app/api/v3/workflows/lib/context", () => ({
     listRuns: vi.fn(),
     getRun: vi.fn(),
     testWorkflow: vi.fn(),
+    create: vi.fn(),
+    patch: vi.fn(),
+    duplicate: vi.fn(),
+    delete: vi.fn(),
+    enable: vi.fn(),
+    disable: vi.fn(),
+    archive: vi.fn(),
+    unarchive: vi.fn(),
   },
+}));
+
+vi.mock("@/app/api/v3/lib/audit", () => ({
+  buildV3AuditLog: vi.fn(),
+  queueV3AuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: { withContext: vi.fn(() => ({ error: vi.fn(), warn: vi.fn() })) },
 }));
 
 const WORKSPACE_ID = "clxx1234567890123456789012";
@@ -102,12 +126,13 @@ describe("registerWorkflowTools", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(buildWorkflowApiContext).mockReturnValue({ __ctx: true } as any);
+    vi.mocked(queueV3AuditLog).mockResolvedValue(undefined);
   });
 
-  test("registers the five read/test tools with read-only annotations", () => {
+  test("registers all read + mutation tools with correct annotations", () => {
     const { server, tools } = createToolServer();
 
-    expect(server.registerTool).toHaveBeenCalledTimes(5);
+    expect(server.registerTool).toHaveBeenCalledTimes(13);
     for (const name of [
       "list_workflows",
       "get_workflow",
@@ -119,6 +144,22 @@ describe("registerWorkflowTools", () => {
         annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
       });
     }
+    // Mutations are not read-only; patch/delete/enable are the destructive ones.
+    expect(tools.get("create_workflow")?.config).toMatchObject({
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    });
+    expect(tools.get("patch_workflow")?.config).toMatchObject({
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    });
+    expect(tools.get("delete_workflow")?.config).toMatchObject({
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    });
+    expect(tools.get("enable_workflow")?.config).toMatchObject({
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    });
+    expect(tools.get("disable_workflow")?.config).toMatchObject({
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    });
   });
 
   test("list_workflows delegates to the handler with a synthetic query request", async () => {
@@ -221,5 +262,73 @@ describe("registerWorkflowTools", () => {
       code: "forbidden",
       requestId: "req_forbidden",
     });
+  });
+
+  test("create_workflow sends a body request and queues a success audit log", async () => {
+    const { tools } = createToolServer();
+    const auditLog: any = { status: "failure" };
+    vi.mocked(buildV3AuditLog).mockReturnValue(auditLog);
+    vi.mocked(workflowsHandlers.create).mockResolvedValue(
+      createdResponse({ id: WORKFLOW_ID }, { requestId: "req_tool", location: "/wf" })
+    );
+    const body = { workspaceId: WORKSPACE_ID, name: "WF", definition: { nodes: [], edges: [] } };
+
+    const result = await tools.get("create_workflow")!.handler(body, { authInfo });
+
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "created", "workflow", "/api/mcp");
+    expect(buildWorkflowApiContext).toHaveBeenCalledWith(apiKeyAuth, "req_tool", "/api/mcp", auditLog);
+    const callArg = vi.mocked(workflowsHandlers.create).mock.calls[0][0];
+    expect(callArg.ctx).toEqual({ __ctx: true });
+    expect(JSON.parse(await callArg.req.text())).toMatchObject({ workspaceId: WORKSPACE_ID, name: "WF" });
+    expect(auditLog.status).toBe("success");
+    expect(queueV3AuditLog).toHaveBeenCalledWith(auditLog, "req_tool", expect.any(Object));
+    expect(result.structuredContent).toEqual({ data: { id: WORKFLOW_ID }, requestId: "req_tool" });
+  });
+
+  test("enable_workflow delegates by id and queues an updated audit log", async () => {
+    const { tools } = createToolServer();
+    const auditLog: any = { status: "failure" };
+    vi.mocked(buildV3AuditLog).mockReturnValue(auditLog);
+    vi.mocked(workflowsHandlers.enable).mockResolvedValue(
+      successResponse({ id: WORKFLOW_ID, status: "enabled" }, { requestId: "req_tool" })
+    );
+
+    await tools.get("enable_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
+
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "workflow", "/api/mcp");
+    expect(workflowsHandlers.enable).toHaveBeenCalledWith({
+      ctx: { __ctx: true },
+      params: { workflowId: WORKFLOW_ID },
+    });
+    expect(auditLog.status).toBe("success");
+    expect(queueV3AuditLog).toHaveBeenCalledWith(auditLog, "req_tool", expect.any(Object));
+  });
+
+  test("delete_workflow queues a deleted audit log", async () => {
+    const { tools } = createToolServer();
+    const auditLog: any = { status: "failure" };
+    vi.mocked(buildV3AuditLog).mockReturnValue(auditLog);
+    vi.mocked(workflowsHandlers.delete).mockResolvedValue(noContentResponse({ requestId: "req_tool" }));
+
+    const result = await tools.get("delete_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
+
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "deleted", "workflow", "/api/mcp");
+    expect(auditLog.status).toBe("success");
+    expect(result.structuredContent).toEqual({ requestId: "req_tool" });
+  });
+
+  test("a failed mutation marks the audit eventId and returns an error (no leak)", async () => {
+    const { tools } = createToolServer();
+    const auditLog: any = { status: "failure" };
+    vi.mocked(buildV3AuditLog).mockReturnValue(auditLog);
+    vi.mocked(workflowsHandlers.enable).mockResolvedValue(
+      problemForbidden("req_forbidden", "You are not authorized to access this resource", "/api/mcp")
+    );
+
+    const result = await tools.get("enable_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
+
+    expect(result.isError).toBe(true);
+    expect(auditLog).toMatchObject({ status: "failure", eventId: "req_tool" });
+    expect(queueV3AuditLog).toHaveBeenCalledWith(auditLog, "req_tool", expect.any(Object));
   });
 });

--- a/apps/web/modules/mcp/tools/workflows.test.ts
+++ b/apps/web/modules/mcp/tools/workflows.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ApiKeyPermission } from "@formbricks/database/prisma";
+import { problemForbidden, successListResponse, successResponse } from "@/app/api/v3/lib/response";
+import { buildWorkflowApiContext, workflowsHandlers } from "@/app/api/v3/workflows/lib/context";
+import {
+  buildListWorkflowRunsSearchParams,
+  buildListWorkflowsSearchParams,
+  registerWorkflowTools,
+} from "./workflows";
+
+vi.mock("@/app/api/v3/workflows/lib/context", () => ({
+  buildWorkflowApiContext: vi.fn(() => ({ __ctx: true })),
+  workflowsHandlers: {
+    list: vi.fn(),
+    get: vi.fn(),
+    listRuns: vi.fn(),
+    getRun: vi.fn(),
+    testWorkflow: vi.fn(),
+  },
+}));
+
+const WORKSPACE_ID = "clxx1234567890123456789012";
+const WORKFLOW_ID = "wf1234567890123456789012ab";
+const RUN_ID = "run234567890123456789012ab";
+
+const apiKeyAuth = {
+  type: "apiKey" as const,
+  apiKeyId: "key_1",
+  organizationId: "org_1",
+  organizationAccess: { accessControl: { read: true, write: true } },
+  workspacePermissions: [
+    { workspaceId: WORKSPACE_ID, workspaceName: "Workspace", permission: ApiKeyPermission.read },
+  ],
+};
+
+const authInfo = {
+  token: "key_1",
+  clientId: "key_1",
+  scopes: ["workflows:read"],
+  extra: { formbricksAuthentication: apiKeyAuth, requestId: "req_tool" },
+};
+
+function createToolServer() {
+  const tools = new Map<
+    string,
+    { config: Record<string, unknown>; handler: (input: any, extra: any) => Promise<any> }
+  >();
+  const server = {
+    registerTool: vi.fn((name: string, config: Record<string, unknown>, handler: any) => {
+      tools.set(name, { config, handler });
+    }),
+  };
+  registerWorkflowTools(server as any);
+  return { server, tools };
+}
+
+describe("buildListWorkflowsSearchParams", () => {
+  test("applies defensive defaults", () => {
+    const params = buildListWorkflowsSearchParams({
+      workspaceId: WORKSPACE_ID,
+    } as unknown as Parameters<typeof buildListWorkflowsSearchParams>[0]);
+
+    expect(params.get("workspaceId")).toBe(WORKSPACE_ID);
+    expect(params.get("limit")).toBe("20");
+  });
+
+  test("maps structured MCP filters to v3 query parameters", () => {
+    const params = buildListWorkflowsSearchParams({
+      workspaceId: WORKSPACE_ID,
+      limit: 50,
+      cursor: "cursor_1",
+      sortBy: "name",
+      filter: { name: { contains: "Onboarding" }, status: { in: ["draft", "disabled"] } },
+    });
+
+    expect(params.get("limit")).toBe("50");
+    expect(params.get("cursor")).toBe("cursor_1");
+    expect(params.get("sortBy")).toBe("name");
+    expect(params.get("filter[name][contains]")).toBe("Onboarding");
+    expect(params.getAll("filter[status][in]")).toEqual(["draft", "disabled"]);
+  });
+});
+
+describe("buildListWorkflowRunsSearchParams", () => {
+  test("maps run filters including isDryRun to v3 query parameters", () => {
+    const params = buildListWorkflowRunsSearchParams({
+      workspaceId: WORKSPACE_ID,
+      limit: 20,
+      workflowId: WORKFLOW_ID,
+      responseId: "resp234567890123456789012a",
+      filter: { status: { in: ["completed"] }, isDryRun: false },
+    });
+
+    expect(params.get("workflowId")).toBe(WORKFLOW_ID);
+    expect(params.get("responseId")).toBe("resp234567890123456789012a");
+    expect(params.getAll("filter[status][in]")).toEqual(["completed"]);
+    expect(params.get("filter[isDryRun][eq]")).toBe("false");
+  });
+});
+
+describe("registerWorkflowTools", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(buildWorkflowApiContext).mockReturnValue({ __ctx: true } as any);
+  });
+
+  test("registers the five read/test tools with read-only annotations", () => {
+    const { server, tools } = createToolServer();
+
+    expect(server.registerTool).toHaveBeenCalledTimes(5);
+    for (const name of [
+      "list_workflows",
+      "get_workflow",
+      "list_workflow_runs",
+      "get_workflow_run",
+      "test_workflow",
+    ]) {
+      expect(tools.get(name)?.config).toMatchObject({
+        annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+      });
+    }
+  });
+
+  test("list_workflows delegates to the handler with a synthetic query request", async () => {
+    const { tools } = createToolServer();
+    vi.mocked(workflowsHandlers.list).mockResolvedValue(
+      successListResponse([{ id: WORKFLOW_ID }], { limit: 20, nextCursor: null }, { requestId: "req_tool" })
+    );
+
+    const result = await tools
+      .get("list_workflows")!
+      .handler({ workspaceId: WORKSPACE_ID, limit: 20 }, { authInfo });
+
+    expect(buildWorkflowApiContext).toHaveBeenCalledWith(apiKeyAuth, "req_tool", "/api/mcp");
+    const callArg = vi.mocked(workflowsHandlers.list).mock.calls[0][0];
+    expect(callArg.ctx).toEqual({ __ctx: true });
+    expect(new URL(callArg.req.url).searchParams.get("workspaceId")).toBe(WORKSPACE_ID);
+    expect(result.structuredContent).toEqual({
+      data: [{ id: WORKFLOW_ID }],
+      meta: { limit: 20, nextCursor: null },
+      requestId: "req_tool",
+    });
+  });
+
+  test("get_workflow delegates to the handler with params (no request)", async () => {
+    const { tools } = createToolServer();
+    vi.mocked(workflowsHandlers.get).mockResolvedValue(
+      successResponse({ id: WORKFLOW_ID }, { requestId: "req_tool" })
+    );
+
+    const result = await tools.get("get_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
+
+    expect(workflowsHandlers.get).toHaveBeenCalledWith({
+      ctx: { __ctx: true },
+      params: { workflowId: WORKFLOW_ID },
+    });
+    expect(result.structuredContent).toEqual({ data: { id: WORKFLOW_ID }, requestId: "req_tool" });
+  });
+
+  test("get_workflow_run delegates to getRun with the run id", async () => {
+    const { tools } = createToolServer();
+    vi.mocked(workflowsHandlers.getRun).mockResolvedValue(
+      successResponse({ id: RUN_ID }, { requestId: "req_tool" })
+    );
+
+    await tools.get("get_workflow_run")!.handler({ runId: RUN_ID }, { authInfo });
+
+    expect(workflowsHandlers.getRun).toHaveBeenCalledWith({
+      ctx: { __ctx: true },
+      params: { runId: RUN_ID },
+    });
+  });
+
+  test("test_workflow delegates to testWorkflow with the workflow id", async () => {
+    const { tools } = createToolServer();
+    vi.mocked(workflowsHandlers.testWorkflow).mockResolvedValue(
+      successResponse({ ok: true, problems: [] }, { requestId: "req_tool" })
+    );
+
+    await tools.get("test_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
+
+    expect(workflowsHandlers.testWorkflow).toHaveBeenCalledWith({
+      ctx: { __ctx: true },
+      params: { workflowId: WORKFLOW_ID },
+    });
+  });
+
+  test("maps v3 problem responses to MCP tool errors without leaking existence", async () => {
+    const { tools } = createToolServer();
+    vi.mocked(workflowsHandlers.get).mockResolvedValue(
+      problemForbidden("req_forbidden", "You are not authorized to access this resource", "/api/mcp")
+    );
+
+    const result = await tools.get("get_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
+
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.error).toMatchObject({
+      status: 403,
+      code: "forbidden",
+      requestId: "req_forbidden",
+    });
+  });
+});

--- a/apps/web/modules/mcp/tools/workflows.test.ts
+++ b/apps/web/modules/mcp/tools/workflows.test.ts
@@ -160,6 +160,13 @@ describe("registerWorkflowTools", () => {
     expect(tools.get("disable_workflow")?.config).toMatchObject({
       annotations: { readOnlyHint: false, destructiveHint: false },
     });
+    // Archive soft-deletes (hidden from default reads) -> destructive; unarchive restores.
+    expect(tools.get("archive_workflow")?.config).toMatchObject({
+      annotations: { readOnlyHint: false, destructiveHint: true },
+    });
+    expect(tools.get("unarchive_workflow")?.config).toMatchObject({
+      annotations: { readOnlyHint: false, destructiveHint: false },
+    });
   });
 
   test("list_workflows delegates to the handler with a synthetic query request", async () => {
@@ -328,7 +335,82 @@ describe("registerWorkflowTools", () => {
     const result = await tools.get("enable_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
 
     expect(result.isError).toBe(true);
+    // Audit defaults to "failure" (buildAuditLogBaseObject); only success flips it, so a failed
+    // mutation is queued with failure status + the requestId as eventId.
     expect(auditLog).toMatchObject({ status: "failure", eventId: "req_tool" });
     expect(queueV3AuditLog).toHaveBeenCalledWith(auditLog, "req_tool", expect.any(Object));
+  });
+
+  test("patch_workflow sends a body request with params and queues an updated audit log", async () => {
+    const { tools } = createToolServer();
+    const auditLog: any = { status: "failure" };
+    vi.mocked(buildV3AuditLog).mockReturnValue(auditLog);
+    vi.mocked(workflowsHandlers.patch).mockResolvedValue(
+      successResponse({ id: WORKFLOW_ID, name: "Renamed" }, { requestId: "req_tool" })
+    );
+
+    await tools
+      .get("patch_workflow")!
+      .handler({ workflowId: WORKFLOW_ID, data: { name: "Renamed" } }, { authInfo });
+
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "workflow", "/api/mcp");
+    const callArg = vi.mocked(workflowsHandlers.patch).mock.calls[0][0];
+    expect(callArg.params).toEqual({ workflowId: WORKFLOW_ID });
+    expect(JSON.parse(await callArg.req.text())).toEqual({ name: "Renamed" });
+    expect(auditLog.status).toBe("success");
+    expect(queueV3AuditLog).toHaveBeenCalledWith(auditLog, "req_tool", expect.any(Object));
+  });
+
+  test("duplicate_workflow sends the optional name body and queues a created audit log", async () => {
+    const { tools } = createToolServer();
+    const auditLog: any = { status: "failure" };
+    vi.mocked(buildV3AuditLog).mockReturnValue(auditLog);
+    vi.mocked(workflowsHandlers.duplicate).mockResolvedValue(
+      createdResponse({ id: "wf2222222222222222222222ab" }, { requestId: "req_tool", location: "/wf" })
+    );
+
+    await tools.get("duplicate_workflow")!.handler({ workflowId: WORKFLOW_ID, name: "Copy" }, { authInfo });
+
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "created", "workflow", "/api/mcp");
+    const callArg = vi.mocked(workflowsHandlers.duplicate).mock.calls[0][0];
+    expect(callArg.params).toEqual({ workflowId: WORKFLOW_ID });
+    expect(JSON.parse(await callArg.req.text())).toEqual({ name: "Copy" });
+    expect(auditLog.status).toBe("success");
+  });
+
+  test("archive_workflow delegates by id and queues an updated audit log", async () => {
+    const { tools } = createToolServer();
+    const auditLog: any = { status: "failure" };
+    vi.mocked(buildV3AuditLog).mockReturnValue(auditLog);
+    vi.mocked(workflowsHandlers.archive).mockResolvedValue(
+      successResponse({ id: WORKFLOW_ID, status: "archived" }, { requestId: "req_tool" })
+    );
+
+    await tools.get("archive_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
+
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "workflow", "/api/mcp");
+    expect(workflowsHandlers.archive).toHaveBeenCalledWith({
+      ctx: { __ctx: true },
+      params: { workflowId: WORKFLOW_ID },
+    });
+    expect(auditLog.status).toBe("success");
+  });
+
+  test("unarchive_workflow delegates by id and queues an updated audit log", async () => {
+    const { tools } = createToolServer();
+    const auditLog: any = { status: "failure" };
+    vi.mocked(buildV3AuditLog).mockReturnValue(auditLog);
+    vi.mocked(workflowsHandlers.unarchive).mockResolvedValue(
+      successResponse({ id: WORKFLOW_ID, status: "draft" }, { requestId: "req_tool" })
+    );
+
+    await tools.get("unarchive_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
+
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "workflow", "/api/mcp");
+    expect(workflowsHandlers.unarchive).toHaveBeenCalledWith({
+      ctx: { __ctx: true },
+      params: { workflowId: WORKFLOW_ID },
+    });
+    expect(auditLog.status).toBe("success");
   });
 });

--- a/apps/web/modules/mcp/tools/workflows.ts
+++ b/apps/web/modules/mcp/tools/workflows.ts
@@ -114,7 +114,7 @@ function buildWorkflowsBodyRequest(body: unknown): Request {
  * mark success/failure, and always queue it. Mirrors the survey mutation tools.
  */
 async function runWorkflowMutation(
-  extra: { authInfo?: Parameters<typeof getMcpAuthentication>[0] },
+  extra: { authInfo?: NonNullable<Parameters<typeof getMcpAuthentication>[0]> },
   action: Parameters<typeof buildV3AuditLog>[1],
   run: (ctx: WorkflowApiContext) => Promise<Response>
 ): Promise<CallToolResult> {

--- a/apps/web/modules/mcp/tools/workflows.ts
+++ b/apps/web/modules/mcp/tools/workflows.ts
@@ -1,20 +1,33 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { logger } from "@formbricks/logger";
+import { buildV3AuditLog, queueV3AuditLog } from "@/app/api/v3/lib/audit";
 import { buildWorkflowApiContext, workflowsHandlers } from "@/app/api/v3/workflows/lib/context";
 import { MCP_API_ROUTE } from "@/modules/mcp/constants";
 import { getMcpAuthentication, getMcpRequestId } from "../auth";
 import { responseToMcpToolResult } from "../errors";
 import {
+  type TMcpCreateWorkflowInput,
+  type TMcpDuplicateWorkflowInput,
   type TMcpGetWorkflowInput,
   type TMcpGetWorkflowRunInput,
   type TMcpListWorkflowRunsInput,
   type TMcpListWorkflowsInput,
+  type TMcpPatchWorkflowInput,
   type TMcpTestWorkflowInput,
+  type TMcpWorkflowIdInput,
+  ZMcpCreateWorkflowInput,
+  ZMcpDuplicateWorkflowInput,
   ZMcpGetWorkflowInput,
   ZMcpGetWorkflowRunInput,
   ZMcpListWorkflowRunsInput,
   ZMcpListWorkflowsInput,
+  ZMcpPatchWorkflowInput,
   ZMcpTestWorkflowInput,
+  ZMcpWorkflowIdInput,
 } from "./workflow-schemas";
+
+type WorkflowApiContext = ReturnType<typeof buildWorkflowApiContext>;
 
 export function buildListWorkflowsSearchParams(input: TMcpListWorkflowsInput): URLSearchParams {
   const searchParams = new URLSearchParams();
@@ -80,6 +93,58 @@ function buildWorkflowsListRequest(searchParams: URLSearchParams): Request {
   const url = new URL(MCP_API_ROUTE, "https://mcp.internal");
   url.search = searchParams.toString();
   return new Request(url);
+}
+
+/**
+ * The create/patch/duplicate handlers read + validate a JSON body off `req.text()`. Build a
+ * synthetic (never-dispatched) POST carrying the body; an empty object is sent for optional-body
+ * operations so the handler never sees an empty string.
+ */
+function buildWorkflowsBodyRequest(body: unknown): Request {
+  return new Request(new URL(MCP_API_ROUTE, "https://mcp.internal"), {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body ?? {}),
+  });
+}
+
+/**
+ * Run a workflow mutation with the same audit lifecycle the v3 route wrapper provides: build the
+ * audit log, inject it into the context (the handlers populate it via ctx.recordAudit post-mutation),
+ * mark success/failure, and always queue it. Mirrors the survey mutation tools.
+ */
+async function runWorkflowMutation(
+  extra: { authInfo?: Parameters<typeof getMcpAuthentication>[0] },
+  action: Parameters<typeof buildV3AuditLog>[1],
+  run: (ctx: WorkflowApiContext) => Promise<Response>
+): Promise<CallToolResult> {
+  const requestId = getMcpRequestId(extra.authInfo);
+  const authentication = getMcpAuthentication(extra.authInfo);
+  const log = logger.withContext({ requestId });
+  const auditLog = buildV3AuditLog(authentication, action, "workflow", MCP_API_ROUTE);
+
+  try {
+    const ctx = buildWorkflowApiContext(authentication, requestId, MCP_API_ROUTE, auditLog ?? undefined);
+    const response = await run(ctx);
+
+    if (auditLog) {
+      if (response.ok) {
+        auditLog.status = "success";
+      } else {
+        auditLog.eventId = requestId;
+      }
+    }
+
+    await queueV3AuditLog(auditLog, requestId, log);
+    return await responseToMcpToolResult(response, requestId);
+  } catch (error) {
+    if (auditLog) {
+      auditLog.eventId = requestId;
+      await queueV3AuditLog(auditLog, requestId, log);
+    }
+
+    throw error;
+  }
 }
 
 export function registerWorkflowTools(server: McpServer): void {
@@ -207,5 +272,175 @@ export function registerWorkflowTools(server: McpServer): void {
 
       return await responseToMcpToolResult(response, requestId);
     }
+  );
+
+  server.registerTool(
+    "create_workflow",
+    {
+      title: "Create workflow",
+      description: "Create a Formbricks workflow (always as a draft) using the v3 Workflows API contract.",
+      inputSchema: ZMcpCreateWorkflowInput.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (input: TMcpCreateWorkflowInput, extra) =>
+      runWorkflowMutation(extra, "created", (ctx) =>
+        workflowsHandlers.create({ req: buildWorkflowsBodyRequest(input), ctx })
+      )
+  );
+
+  server.registerTool(
+    "patch_workflow",
+    {
+      title: "Patch workflow",
+      description: [
+        "Update a Formbricks workflow using the v3 Workflows API patch contract.",
+        "Provided top-level fields replace that whole subtree; definition edits are only accepted while draft or disabled.",
+      ].join(" "),
+      inputSchema: ZMcpPatchWorkflowInput.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (input: TMcpPatchWorkflowInput, extra) =>
+      runWorkflowMutation(extra, "updated", (ctx) =>
+        workflowsHandlers.patch({
+          req: buildWorkflowsBodyRequest(input.data),
+          ctx,
+          params: { workflowId: input.workflowId },
+        })
+      )
+  );
+
+  server.registerTool(
+    "duplicate_workflow",
+    {
+      title: "Duplicate workflow",
+      description:
+        "Duplicate a Formbricks workflow as a new draft (empty run + version history) using the v3 Workflows API contract.",
+      inputSchema: ZMcpDuplicateWorkflowInput.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (input: TMcpDuplicateWorkflowInput, extra) =>
+      runWorkflowMutation(extra, "created", (ctx) =>
+        workflowsHandlers.duplicate({
+          req: buildWorkflowsBodyRequest(input.name ? { name: input.name } : {}),
+          ctx,
+          params: { workflowId: input.workflowId },
+        })
+      )
+  );
+
+  server.registerTool(
+    "delete_workflow",
+    {
+      title: "Delete workflow",
+      description: "Delete a Formbricks workflow using the v3 Workflows API contract.",
+      inputSchema: ZMcpWorkflowIdInput.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (input: TMcpWorkflowIdInput, extra) =>
+      runWorkflowMutation(extra, "deleted", (ctx) =>
+        workflowsHandlers.delete({ ctx, params: { workflowId: input.workflowId } })
+      )
+  );
+
+  server.registerTool(
+    "enable_workflow",
+    {
+      title: "Enable workflow",
+      description: [
+        "Enable a Formbricks workflow using the v3 Workflows API contract:",
+        "validate executability, snapshot an immutable version, and make it live.",
+        "Once live it runs on matching survey responses and can send emails.",
+      ].join(" "),
+      inputSchema: ZMcpWorkflowIdInput.shape,
+      annotations: {
+        readOnlyHint: false,
+        // Enabling activates a live, email-sending workflow — high impact.
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (input: TMcpWorkflowIdInput, extra) =>
+      runWorkflowMutation(extra, "updated", (ctx) =>
+        workflowsHandlers.enable({ ctx, params: { workflowId: input.workflowId } })
+      )
+  );
+
+  server.registerTool(
+    "disable_workflow",
+    {
+      title: "Disable workflow",
+      description:
+        "Disable a live Formbricks workflow (stops future runs) using the v3 Workflows API contract.",
+      inputSchema: ZMcpWorkflowIdInput.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (input: TMcpWorkflowIdInput, extra) =>
+      runWorkflowMutation(extra, "updated", (ctx) =>
+        workflowsHandlers.disable({ ctx, params: { workflowId: input.workflowId } })
+      )
+  );
+
+  server.registerTool(
+    "archive_workflow",
+    {
+      title: "Archive workflow",
+      description: "Archive a Formbricks workflow using the v3 Workflows API contract.",
+      inputSchema: ZMcpWorkflowIdInput.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (input: TMcpWorkflowIdInput, extra) =>
+      runWorkflowMutation(extra, "updated", (ctx) =>
+        workflowsHandlers.archive({ ctx, params: { workflowId: input.workflowId } })
+      )
+  );
+
+  server.registerTool(
+    "unarchive_workflow",
+    {
+      title: "Unarchive workflow",
+      description: "Unarchive a Formbricks workflow (back to draft) using the v3 Workflows API contract.",
+      inputSchema: ZMcpWorkflowIdInput.shape,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (input: TMcpWorkflowIdInput, extra) =>
+      runWorkflowMutation(extra, "updated", (ctx) =>
+        workflowsHandlers.unarchive({ ctx, params: { workflowId: input.workflowId } })
+      )
   );
 }

--- a/apps/web/modules/mcp/tools/workflows.ts
+++ b/apps/web/modules/mcp/tools/workflows.ts
@@ -72,11 +72,12 @@ export function buildListWorkflowRunsSearchParams(input: TMcpListWorkflowRunsInp
 
 /**
  * The framework-agnostic workflow list handlers read query params off a `Request` (via
- * `new URL(req.url).searchParams`). MCP has no incoming HTTP request, so build a synthetic one — the
- * handler only reads the search params, so the (absolute, required by `new URL`) host is irrelevant.
+ * `new URL(req.url).searchParams`). MCP has no incoming HTTP request, so build a synthetic one that
+ * is never dispatched — the handler only reads the search params, so the scheme/host are inert
+ * placeholders (an absolute base is required solely to satisfy `new URL`).
  */
 function buildWorkflowsListRequest(searchParams: URLSearchParams): Request {
-  const url = new URL(MCP_API_ROUTE, "http://mcp.internal");
+  const url = new URL(MCP_API_ROUTE, "https://mcp.internal");
   url.search = searchParams.toString();
   return new Request(url);
 }

--- a/apps/web/modules/mcp/tools/workflows.ts
+++ b/apps/web/modules/mcp/tools/workflows.ts
@@ -414,7 +414,8 @@ export function registerWorkflowTools(server: McpServer): void {
       inputSchema: ZMcpWorkflowIdInput.shape,
       annotations: {
         readOnlyHint: false,
-        destructiveHint: false,
+        // Archiving soft-deletes and excludes the workflow from default reads.
+        destructiveHint: true,
         idempotentHint: false,
         openWorldHint: true,
       },

--- a/apps/web/modules/mcp/tools/workflows.ts
+++ b/apps/web/modules/mcp/tools/workflows.ts
@@ -1,0 +1,210 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { buildWorkflowApiContext, workflowsHandlers } from "@/app/api/v3/workflows/lib/context";
+import { MCP_API_ROUTE } from "@/modules/mcp/constants";
+import { getMcpAuthentication, getMcpRequestId } from "../auth";
+import { responseToMcpToolResult } from "../errors";
+import {
+  type TMcpGetWorkflowInput,
+  type TMcpGetWorkflowRunInput,
+  type TMcpListWorkflowRunsInput,
+  type TMcpListWorkflowsInput,
+  type TMcpTestWorkflowInput,
+  ZMcpGetWorkflowInput,
+  ZMcpGetWorkflowRunInput,
+  ZMcpListWorkflowRunsInput,
+  ZMcpListWorkflowsInput,
+  ZMcpTestWorkflowInput,
+} from "./workflow-schemas";
+
+export function buildListWorkflowsSearchParams(input: TMcpListWorkflowsInput): URLSearchParams {
+  const searchParams = new URLSearchParams();
+
+  searchParams.set("workspaceId", input.workspaceId);
+  searchParams.set("limit", String(input.limit ?? 20));
+
+  if (input.cursor) {
+    searchParams.set("cursor", input.cursor);
+  }
+
+  if (input.sortBy) {
+    searchParams.set("sortBy", input.sortBy);
+  }
+
+  if (input.filter?.name?.contains) {
+    searchParams.set("filter[name][contains]", input.filter.name.contains);
+  }
+
+  input.filter?.status?.in?.forEach((status) => {
+    searchParams.append("filter[status][in]", status);
+  });
+
+  return searchParams;
+}
+
+export function buildListWorkflowRunsSearchParams(input: TMcpListWorkflowRunsInput): URLSearchParams {
+  const searchParams = new URLSearchParams();
+
+  searchParams.set("workspaceId", input.workspaceId);
+  searchParams.set("limit", String(input.limit ?? 20));
+
+  if (input.cursor) {
+    searchParams.set("cursor", input.cursor);
+  }
+
+  if (input.workflowId) {
+    searchParams.set("workflowId", input.workflowId);
+  }
+
+  if (input.responseId) {
+    searchParams.set("responseId", input.responseId);
+  }
+
+  input.filter?.status?.in?.forEach((status) => {
+    searchParams.append("filter[status][in]", status);
+  });
+
+  if (input.filter?.isDryRun !== undefined) {
+    searchParams.set("filter[isDryRun][eq]", String(input.filter.isDryRun));
+  }
+
+  return searchParams;
+}
+
+/**
+ * The framework-agnostic workflow list handlers read query params off a `Request` (via
+ * `new URL(req.url).searchParams`). MCP has no incoming HTTP request, so build a synthetic one — the
+ * handler only reads the search params, so the (absolute, required by `new URL`) host is irrelevant.
+ */
+function buildWorkflowsListRequest(searchParams: URLSearchParams): Request {
+  const url = new URL(MCP_API_ROUTE, "http://mcp.internal");
+  url.search = searchParams.toString();
+  return new Request(url);
+}
+
+export function registerWorkflowTools(server: McpServer): void {
+  server.registerTool(
+    "list_workflows",
+    {
+      title: "List workflows",
+      description: "List workflows in a Formbricks workspace using the v3 Workflows API contract.",
+      inputSchema: ZMcpListWorkflowsInput.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input: TMcpListWorkflowsInput, extra) => {
+      const requestId = getMcpRequestId(extra.authInfo);
+      const ctx = buildWorkflowApiContext(getMcpAuthentication(extra.authInfo), requestId, MCP_API_ROUTE);
+      const response = await workflowsHandlers.list({
+        req: buildWorkflowsListRequest(buildListWorkflowsSearchParams(input)),
+        ctx,
+      });
+
+      return await responseToMcpToolResult(response, requestId);
+    }
+  );
+
+  server.registerTool(
+    "get_workflow",
+    {
+      title: "Get workflow",
+      description: "Get one Formbricks workflow using the v3 Workflows API contract.",
+      inputSchema: ZMcpGetWorkflowInput.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input: TMcpGetWorkflowInput, extra) => {
+      const requestId = getMcpRequestId(extra.authInfo);
+      const ctx = buildWorkflowApiContext(getMcpAuthentication(extra.authInfo), requestId, MCP_API_ROUTE);
+      const response = await workflowsHandlers.get({ ctx, params: { workflowId: input.workflowId } });
+
+      return await responseToMcpToolResult(response, requestId);
+    }
+  );
+
+  server.registerTool(
+    "list_workflow_runs",
+    {
+      title: "List workflow runs",
+      description:
+        "List workflow runs for a Formbricks workspace (newest first) using the v3 Workflows API contract.",
+      inputSchema: ZMcpListWorkflowRunsInput.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input: TMcpListWorkflowRunsInput, extra) => {
+      const requestId = getMcpRequestId(extra.authInfo);
+      const ctx = buildWorkflowApiContext(getMcpAuthentication(extra.authInfo), requestId, MCP_API_ROUTE);
+      const response = await workflowsHandlers.listRuns({
+        req: buildWorkflowsListRequest(buildListWorkflowRunsSearchParams(input)),
+        ctx,
+      });
+
+      return await responseToMcpToolResult(response, requestId);
+    }
+  );
+
+  server.registerTool(
+    "get_workflow_run",
+    {
+      title: "Get workflow run",
+      description:
+        "Get one Formbricks workflow run with its ordered step logs using the v3 Workflows API contract.",
+      inputSchema: ZMcpGetWorkflowRunInput.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (input: TMcpGetWorkflowRunInput, extra) => {
+      const requestId = getMcpRequestId(extra.authInfo);
+      const ctx = buildWorkflowApiContext(getMcpAuthentication(extra.authInfo), requestId, MCP_API_ROUTE);
+      const response = await workflowsHandlers.getRun({ ctx, params: { runId: input.runId } });
+
+      return await responseToMcpToolResult(response, requestId);
+    }
+  );
+
+  server.registerTool(
+    "test_workflow",
+    {
+      title: "Test workflow (dry-run)",
+      description: [
+        "Dry-run a Formbricks workflow using the v3 Workflows API contract:",
+        "validate its live definition would execute and resolve the trigger's survey + ending cards.",
+        "No run is persisted and no side effects occur; the response reports { ok, problems }.",
+      ].join(" "),
+      annotations: {
+        // Dry-run: validates + mock-executes with all side effects suppressed, so no world mutation.
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+      inputSchema: ZMcpTestWorkflowInput.shape,
+    },
+    async (input: TMcpTestWorkflowInput, extra) => {
+      const requestId = getMcpRequestId(extra.authInfo);
+      const ctx = buildWorkflowApiContext(getMcpAuthentication(extra.authInfo), requestId, MCP_API_ROUTE);
+      const response = await workflowsHandlers.testWorkflow({
+        ctx,
+        params: { workflowId: input.workflowId },
+      });
+
+      return await responseToMcpToolResult(response, requestId);
+    }
+  );
+}


### PR DESCRIPTION
## What

Exposes the v3 Workflows API through the MCP server, mirroring the existing survey tools. **13 tools**:

**Read / dry-run**
- `list_workflows`, `get_workflow`, `list_workflow_runs`, `get_workflow_run`
- `test_workflow` — dry-run (validate + mock-execute, no side effects)

**Mutations** (audit-logged)
- `create_workflow`, `patch_workflow`, `duplicate_workflow`, `delete_workflow`
- `enable_workflow`, `disable_workflow`, `archive_workflow`, `unarchive_workflow`

## Why

M8 - MCP Server ([ENG-1592](https://linear.app/formbricks/issue/ENG-1592)). Full CRUD + lifecycle parity with the survey MCP tools so agents can inspect, dry-run, and manage workflows.

## How

- Tools wrap the framework-agnostic `@formbricks/workflows` handlers via `buildWorkflowApiContext` + `responseToMcpToolResult`, reusing the exact API-key auth, workspace authorization, audit logging, and error mapping the survey tools use.
- List tools build a synthetic (never-dispatched) `Request`; create/patch/duplicate build one with a JSON body.
- Mutations run the same audit lifecycle as the survey tools (build audit log → inject into ctx → mark success/failure → queue).
- `workflows:read` / `workflows:write` added to advertised scopes; write requires `write`/`manage` on the workspace.

## Scope note

Workflow **mutations are intentionally included** (product decision) — an earlier draft deferred them. `enable_workflow` is the high-impact one (makes a workflow live; it can send emails — [ENG-1235](https://linear.app/formbricks/issue/ENG-1235)); it is annotated destructive and gated by write scope + workspace authorization. Non-executable definitions are refused with `422 workflow_not_executable`.

## Testing

- `modules/mcp/tools/workflows.test.ts` (18 tests): search-param mapping, delegation, body-request building, audit success/failure lifecycle, annotations, forbidden no-leak.
- Full MCP suite green; changed files 0 typecheck errors, eslint clean.
- **Live-verified** against a dev server: full create → get → patch → archive → unarchive → enable (422 executability guard) → delete lifecycle, plus reads + 403 no-leak.

Docs: [#8401](https://github.com/formbricks/formbricks/pull/8401) (ENG-1593). Base is `epic/workflows-v1`.