### PR TITLE
ci(auth): skip Better Auth integration suite when the harness is absent

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -72,25 +72,46 @@ jobs:
           persist-credentials: false # no later step needs git auth (dangerous-git-checkout re-auths)
       - uses: ./.github/actions/dangerous-git-checkout
 
+      # Branches that predate the Better Auth cutover (#8384) don't contain the integration harness,
+      # yet this workflow — now on main — still triggers for their PRs (the definition is resolved from
+      # the base branch) and dangerous-git-checkout checks out the PR *head*. Detect whether the harness
+      # is actually present on the checked-out ref so the steps below can skip instead of hard-failing on
+      # a missing file. hashFiles/`-f` run post-checkout, so this correctly reflects the head's contents.
+      - name: Detect Better Auth integration harness
+        id: harness
+        run: |
+          if [ -f apps/web/integration/ba-test-schema-shape.sql ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Better Auth integration harness absent on this ref (branch predates #8384) — skipping the integration suite."
+          fi
+        shell: bash
+
       - name: Setup Node.js 22.x
+        if: steps.harness.outputs.present == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
 
       - name: Install pnpm
+        if: steps.harness.outputs.present == 'true'
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - name: Install dependencies
+        if: steps.harness.outputs.present == 'true'
         run: pnpm install --frozen-lockfile --config.platform=linux --config.architecture=x64
         shell: bash
 
       # Build the workspace packages the tests import (@formbricks/logger, cache, types, email, …) so
       # vite can resolve their package.json `exports` → dist. Deps only (`^...`), not the Next app.
       - name: Build workspace package dependencies
+        if: steps.harness.outputs.present == 'true'
         run: pnpm build --filter=@formbricks/web^...
         shell: bash
 
       - name: Create .env
+        if: steps.harness.outputs.present == 'true'
         run: pnpm dev:setup
         shell: bash
 
@@ -98,26 +119,31 @@ jobs:
       # directly, so it doesn't need a real ENTERPRISE_LICENSE_KEY (verified: the suite is green with it
       # empty). Only point the DB + Redis at the CI services.
       - name: Point .env at the CI services + test database
+        if: steps.harness.outputs.present == 'true'
         run: |
           sed -i "s|REDIS_URL=.*|REDIS_URL=redis://localhost:6379|" .env
           sed -i "s|DATABASE_URL=.*|DATABASE_URL=postgresql://postgres:postgres@localhost:5432/formbricks_ba_test?schema=public|" .env
         shell: bash
 
       - name: Create the test database
+        if: steps.harness.outputs.present == 'true'
         run: psql "postgresql://postgres:postgres@localhost:5432/postgres" -v ON_ERROR_STOP=1 -c 'CREATE DATABASE formbricks_ba_test;'
         shell: bash
 
       - name: Apply schema + data migrations to the test database
+        if: steps.harness.outputs.present == 'true'
         run: pnpm db:migrate:dev
         shell: bash
 
       # Shared with apps/web/integration/global-setup.ts (the local harness applies the same file) so
       # CI and local provision an identical Better Auth schema shape.
       - name: Shape the schema for Better Auth (emailVerified boolean, Account.type nullable)
+        if: steps.harness.outputs.present == 'true'
         run: psql "postgresql://postgres:postgres@localhost:5432/formbricks_ba_test" -v ON_ERROR_STOP=1 -f apps/web/integration/ba-test-schema-shape.sql
         shell: bash
 
       - name: Run Better Auth integration tests
+        if: steps.harness.outputs.present == 'true'
         # The DB is provisioned above, so global-setup skips its docker-exec clone (TEST_DB_PROVISIONED).
         run: cd apps/web && pnpm test:integration
         env:


### PR DESCRIPTION
## What does this PR do?

Stops the **Better Auth integration-test** workflow from red-failing on branches that predate the Better Auth cutover (#8384).

Since #8384 landed `integration-tests.yml` on `main`, GitHub resolves the workflow definition from the base branch, so the job now triggers for *every* PR whose paths match — including branches that forked before the cutover. `dangerous-git-checkout` checks out the PR **head**, which on those branches contains neither the workflow nor `apps/web/integration/ba-test-schema-shape.sql`, so the "Shape the schema" step fails with:

```
psql: error: apps/web/integration/ba-test-schema-shape.sql: No such file or directory
```

Seen e.g. on `epic/language-codes-stabilization`. It's noise (the check isn't required, so it doesn't block merges), but it nags every stale PR that touches the path filter.

**Fix:** a `Detect Better Auth integration harness` step checks whether the harness is present on the checked-out ref, and the harness-dependent steps are gated on `steps.harness.outputs.present == 'true'`. Branches without the harness now **skip cleanly (green)** instead of hard-failing on the missing file — and don't burn ~5 min of setup either. Branches that have the harness run the suite unchanged.

Workflow-only change; no product code touched.

## How should this be tested?

- This PR's own `Integration Tests` run (this branch **has** the harness) must run the full suite and pass — proving the guard doesn't skip when the files are present.
- After merge, re-run CI on a pre-cutover branch (e.g. `epic/language-codes-stabilization`): the job should now **skip** the harness steps and go green, with the `::notice::` explaining why.

## Checklist
- [x] Filled out the "How to test" section
- [x] Self-reviewed
