### PR TITLE
fix(workflows): enable BullMQ retries for workflow-run.process [ENG-1228]

### DIFF
--- a/packages/jobs/src/queue.test.ts
+++ b/packages/jobs/src/queue.test.ts
@@ -181,15 +181,16 @@ describe("@formbricks/jobs queue helpers", () => {
     expect(mockQueueAdd).toHaveBeenCalledWith(JOB_NAMES.surveyScheduling, surveySchedulingJobData, undefined);
   });
 
-  test("enqueues the workflow run job with attempts:1 and a deterministic jobId", async () => {
+  test("enqueues the workflow run job with a deterministic jobId and the shared retry policy", async () => {
     const mockJob = { id: "job-workflow-run-1" };
     mockQueueAdd.mockResolvedValue(mockJob);
 
     const job = await enqueueWorkflowRunJob(workflowRunJobData, { jobId: workflowRunJobData.workflowRunId });
 
     expect(job).toBe(mockJob);
+    // No per-job attempts override: the job inherits attempts + backoff from the queue's
+    // defaultJobOptions (retries are safe now that execution is idempotent per step — ENG-1228).
     expect(mockQueueAdd).toHaveBeenCalledWith(JOB_NAMES.workflowRun, workflowRunJobData, {
-      attempts: 1,
       jobId: workflowRunJobData.workflowRunId,
     });
   });

--- a/packages/jobs/src/queue.ts
+++ b/packages/jobs/src/queue.ts
@@ -247,10 +247,11 @@ export const enqueueWorkflowRunJob = async (
   options?: { jobId: string }
 ): Promise<Job> => {
   try {
-    // Run-level retry/backoff is modelled on the WorkflowRun row, so override the BullMQ default of 3
-    // attempts to 1. A deterministic jobId (the run id) makes a re-enqueue idempotent (no duplicate job).
+    // Inherit the shared retry policy (attempts + backoff from the queue's defaultJobOptions): the
+    // executor is idempotent per step (claim-before-send + @@unique([runId, stepId]), ENG-1228), so a
+    // BullMQ retry resumes without re-sending. The deterministic jobId (the run id) keeps a re-enqueue
+    // idempotent (no duplicate job) — e.g. when the reconciler re-dispatches an orphaned run.
     return await enqueueBackgroundJob(JOB_NAMES.workflowRun, data, {
-      attempts: 1,
       ...(options?.jobId ? { jobId: options.jobId } : {}),
     });
   } catch (error) {


### PR DESCRIPTION
## What does this PR do?

Pairs with #8395 ([ENG-1228](https://linear.app/formbricks/issue/ENG-1228)), stacked on `epic/workflows-v1`. Now that `send_email` execution is idempotent per step (claim-before-send + `@@unique([runId, stepId])`, in #8395), this drops the `attempts: 1` override on `enqueueWorkflowRunJob` so `workflow-run.process` inherits the shared retry policy — `attempts: 3` + exponential backoff from the queue's `defaultJobOptions`, same as every other job.

**Why:** with `attempts: 1`, `maxAttempts` was always 1, so the executor's retry/resume machinery and its pool-exhaustion handling never actually fired (every attempt was "final") — a transient failure (SMTP blip, DB pool exhaustion, stalled redelivery) killed the run on the first try and could strand it. With retries enabled *and* the per-step idempotency from #8395, a transient failure now retries and resumes without re-sending. The deterministic `jobId` (the run id) keeps a re-enqueue idempotent (e.g. the ENG-1608 reconciler re-dispatching an orphan).

**⚠️ Merge ordering:** must merge **with or after #8395** — retries must never be enabled without the per-step send idempotency, or a retry could double-send. (#8395 is approved.)

## How should this be tested?

```bash
pnpm --filter @formbricks/jobs run test   # 59 pass
```

One-line behaviour change (drop the `attempts: 1` override). The `workflow-run` enqueue test now asserts **no** per-job `attempts` override, so the job inherits the shared `attempts: 3` + backoff policy — which itself is covered by the existing "creates the shared queue with the expected defaults" test. End-to-end (worker running): a `send_email` step that throws a transient error now retries up to 3× and resumes from the claimed-step log, instead of failing permanently on attempt 1.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits (the retry-policy inheritance + the #8395 pairing)
- [x] Ran the jobs test + typecheck + lint
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs` (none)
- [x] Branched off the current base (`epic/workflows-v1`)
- [x] My changes don't cause any responsiveness issues (backend job)
- [ ] First PR at Formbricks? — no

### Appreciated

- [ ] If a UI change was made: screenshots — N/A
- [ ] Updated the Formbricks Docs — N/A
