### PR TITLE
fix: resolves feedback on the epic for language codes migration

### DIFF
--- a/apps/web/app/api/v3/surveys/language.test.ts
+++ b/apps/web/app/api/v3/surveys/language.test.ts
@@ -251,6 +251,35 @@ describe("resolveV3SurveyLanguageCode", () => {
     });
   });
 
+  test("classifies a widened 3-letter / numeric-region tag as unknown (not invalid) when not configured", () => {
+    // fil-PH / eo-001 became writable; the read resolver must recognise them as valid tags so an
+    // unconfigured survey reports "not configured" (unknown), not "not a valid locale code" (invalid).
+    expect(resolveV3SurveyLanguageCode("fil-PH", [{ code: "en-US", enabled: true }])).toEqual({
+      ok: false,
+      reason: "unknown",
+      normalizedCode: "fil-PH",
+      message: "Language 'fil-PH' is not configured for this survey",
+    });
+    expect(resolveV3SurveyLanguageCode("eo-001", [{ code: "en-US", enabled: true }])).toEqual({
+      ok: false,
+      reason: "unknown",
+      normalizedCode: "eo-001",
+      message: "Language 'eo-001' is not configured for this survey",
+    });
+  });
+
+  test("resolves a configured 3-letter-base language and its legacy selector", () => {
+    expect(resolveV3SurveyLanguageCode("fil-PH", [{ code: "fil-PH", enabled: true }])).toEqual({
+      ok: true,
+      code: "fil-PH",
+    });
+    // legacy `tl` selector still resolves to a migrated fil-PH via canonical equivalence
+    expect(resolveV3SurveyLanguageCode("tl", [{ code: "fil-PH", enabled: true }])).toEqual({
+      ok: true,
+      code: "fil-PH",
+    });
+  });
+
   test("returns unknown for languages not configured on the survey", () => {
     expect(resolveV3SurveyLanguageCode("ZH_hant_tw", languages)).toEqual({
       ok: false,

--- a/apps/web/app/api/v3/surveys/language.test.ts
+++ b/apps/web/app/api/v3/surveys/language.test.ts
@@ -37,6 +37,10 @@ describe("normalizeV3SurveyLocaleCode", () => {
   test.each([
     ["EN_us", "en-US"],
     ["zh_hans_cn", "zh-Hans-CN"],
+    // 3-letter base and UN M.49 numeric region — canonical catalog codes the old 2-letter-only regex rejected.
+    ["fil-PH", "fil-PH"],
+    ["bho-IN", "bho-IN"],
+    ["eo-001", "eo-001"],
   ])("normalizes write locale %s to %s", (input, expected) => {
     expect(normalizeV3SurveyLocaleCode(input)).toBe(expected);
   });

--- a/apps/web/app/api/v3/surveys/language.ts
+++ b/apps/web/app/api/v3/surveys/language.ts
@@ -23,7 +23,11 @@ type TResolveV3SurveyLanguageCodeResult =
 type TParseV3SurveyLanguageQueryResult = { ok: true; languages: string[] } | { ok: false; message: string };
 
 const V3_SURVEY_LANGUAGE_TAG_REGEX = /^[a-z]{2}(?:-[A-Z]{2}|-[A-Z][a-z]{3}(?:-[A-Z]{2})?)$/;
-const V3_SURVEY_LOCALE_CODE_REGEX = /^[a-z]{2}(?:-[A-Z][a-z]{3})?-[A-Z]{2}$/;
+// A region-qualified write locale: 2-3 letter base language, optional 4-letter script, and a region that
+// is either a 2-letter country or a 3-digit UN M.49 area. The 3-letter base + numeric region forms matter
+// because canonical catalog codes include them (e.g. `fil-PH`, `bho-IN`, `eo-001`, `vo-001`); the old
+// 2-letter-only pattern rejected those on write even though the picker/`createLanguage` accept them.
+const V3_SURVEY_LOCALE_CODE_REGEX = /^[a-z]{2,3}(?:-[A-Z][a-z]{3})?-(?:[A-Z]{2}|\d{3})$/;
 
 // Validate + case/separator-normalize a fully region/script-qualified BCP-47 tag. This only recognises a
 // valid tag — it does NOT canonicalize or complete it (`zh-Hans` stays `zh-Hans`, `zh-CN` stays `zh-CN`).

--- a/apps/web/app/api/v3/surveys/language.ts
+++ b/apps/web/app/api/v3/surveys/language.ts
@@ -22,37 +22,39 @@ type TResolveV3SurveyLanguageCodeResult =
 
 type TParseV3SurveyLanguageQueryResult = { ok: true; languages: string[] } | { ok: false; message: string };
 
-// A valid BCP-47 tag: 2-3 letter base, then either a region (2-letter country or 3-digit UN M.49 area) or a
-// 4-letter script optionally followed by a region. Widened alongside the write locale regex below so the
-// six 3-letter-base / numeric-region catalog codes (e.g. `fil-PH`, `eo-001`) are recognised on READ too —
-// otherwise the resolver mis-reports "not a valid locale code" (invalid) instead of "not configured"
-// (unknown) when such a code is queried on a survey that doesn't have it.
-const V3_SURVEY_LANGUAGE_TAG_REGEX =
-  /^[a-z]{2,3}(?:-(?:[A-Z]{2}|\d{3})|-[A-Z][a-z]{3}(?:-(?:[A-Z]{2}|\d{3}))?)$/;
-// A region-qualified write locale: 2-3 letter base language, optional 4-letter script, and a region that is
+// A region-qualified locale: 2-3 letter base language, optional 4-letter script, and a region that is
 // either a 2-letter country or a 3-digit UN M.49 area. The 3-letter base + numeric region forms matter
 // because canonical catalog codes include them (e.g. `fil-PH`, `bho-IN`, `eo-001`, `vo-001`); the old
 // 2-letter-only pattern rejected those on write even though the picker/`createLanguage` accept them.
 const V3_SURVEY_LOCALE_CODE_REGEX = /^[a-z]{2,3}(?:-[A-Z][a-z]{3})?-(?:[A-Z]{2}|\d{3})$/;
+// A script-only tag with no region (e.g. `zh-Hans`). Kept as its own small regex so the tag check below is
+// just "region-qualified OR script-only" — two simple patterns instead of one nested mega-regex.
+const V3_SURVEY_SCRIPT_ONLY_REGEX = /^[a-z]{2,3}-[A-Z][a-z]{3}$/;
 
-// Validate + case/separator-normalize a fully region/script-qualified BCP-47 tag. This only recognises a
-// valid tag — it does NOT canonicalize or complete it (`zh-Hans` stays `zh-Hans`, `zh-CN` stays `zh-CN`).
-// Canonicalization is `normalizeLanguageCode`'s job; this is used for tag recognition and query dedup.
-// Returns null for bare/underspecified/invalid input.
+// Validate + case/separator-normalize a valid region/script-qualified BCP-47 tag (region-qualified OR
+// script-only). This only recognises a valid tag — it does NOT canonicalize or complete it (`zh-Hans`
+// stays `zh-Hans`, `zh-CN` stays `zh-CN`); canonicalization is `normalizeLanguageCode`'s job. Used for tag
+// recognition and query dedup. Bare/underspecified/invalid input returns null.
 export function normalizeV3SurveyLanguageTag(value: string): string | null {
-  return normalizeV3SurveyLanguageCode(value, V3_SURVEY_LANGUAGE_TAG_REGEX);
+  return normalizeV3SurveyLanguageCode(
+    value,
+    (code) => V3_SURVEY_LOCALE_CODE_REGEX.test(code) || V3_SURVEY_SCRIPT_ONLY_REGEX.test(code)
+  );
 }
 
 export function normalizeV3SurveyLocaleCode(value: string): string | null {
-  return normalizeV3SurveyLanguageCode(value, V3_SURVEY_LOCALE_CODE_REGEX);
+  return normalizeV3SurveyLanguageCode(value, (code) => V3_SURVEY_LOCALE_CODE_REGEX.test(code));
 }
 
-function normalizeV3SurveyLanguageCode(value: string, pattern: RegExp): string | null {
+function normalizeV3SurveyLanguageCode(
+  value: string,
+  isAcceptedTag: (code: string) => boolean
+): string | null {
   const normalizedSeparators = value.trim().replaceAll("_", "-");
 
   try {
     const normalizedLanguage = Intl.getCanonicalLocales(normalizedSeparators)[0] ?? null;
-    if (!normalizedLanguage || !pattern.test(normalizedLanguage)) {
+    if (!normalizedLanguage || !isAcceptedTag(normalizedLanguage)) {
       return null;
     }
 

--- a/apps/web/app/api/v3/surveys/language.ts
+++ b/apps/web/app/api/v3/surveys/language.ts
@@ -22,9 +22,15 @@ type TResolveV3SurveyLanguageCodeResult =
 
 type TParseV3SurveyLanguageQueryResult = { ok: true; languages: string[] } | { ok: false; message: string };
 
-const V3_SURVEY_LANGUAGE_TAG_REGEX = /^[a-z]{2}(?:-[A-Z]{2}|-[A-Z][a-z]{3}(?:-[A-Z]{2})?)$/;
-// A region-qualified write locale: 2-3 letter base language, optional 4-letter script, and a region that
-// is either a 2-letter country or a 3-digit UN M.49 area. The 3-letter base + numeric region forms matter
+// A valid BCP-47 tag: 2-3 letter base, then either a region (2-letter country or 3-digit UN M.49 area) or a
+// 4-letter script optionally followed by a region. Widened alongside the write locale regex below so the
+// six 3-letter-base / numeric-region catalog codes (e.g. `fil-PH`, `eo-001`) are recognised on READ too —
+// otherwise the resolver mis-reports "not a valid locale code" (invalid) instead of "not configured"
+// (unknown) when such a code is queried on a survey that doesn't have it.
+const V3_SURVEY_LANGUAGE_TAG_REGEX =
+  /^[a-z]{2,3}(?:-(?:[A-Z]{2}|\d{3})|-[A-Z][a-z]{3}(?:-(?:[A-Z]{2}|\d{3}))?)$/;
+// A region-qualified write locale: 2-3 letter base language, optional 4-letter script, and a region that is
+// either a 2-letter country or a 3-digit UN M.49 area. The 3-letter base + numeric region forms matter
 // because canonical catalog codes include them (e.g. `fil-PH`, `bho-IN`, `eo-001`, `vo-001`); the old
 // 2-letter-only pattern rejected those on write even though the picker/`createLanguage` accept them.
 const V3_SURVEY_LOCALE_CODE_REGEX = /^[a-z]{2,3}(?:-[A-Z][a-z]{3})?-(?:[A-Z]{2}|\d{3})$/;

--- a/packages/database/migration/20260625104904_canonicalize_language_codes/migration.ts
+++ b/packages/database/migration/20260625104904_canonicalize_language_codes/migration.ts
@@ -1,10 +1,15 @@
-import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
+import { LANGUAGE_CANONICAL_MAP, normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import { logger } from "@formbricks/logger";
 import type { MigrationScript } from "../../src/scripts/migration-runner";
 import type { LanguageRow, MigrationStats, SurveyContentRow, SurveyLanguageRow } from "./types";
 import { planLanguageMerges, planSurveyLanguageMoves, rewriteI18nKeys, toCanonical } from "./utils";
 
 const SURVEY_BATCH_SIZE = 150;
+// The two highest-volume tables are migrated OUTSIDE the mega-transaction in committed chunks (see steps
+// 3 & 4). `Response` is walked by primary key; `ContactAttribute` by its `[attributeKeyId, value]` index.
+const RESPONSE_BATCH_SIZE = 5000;
+const CONTACT_ATTRIBUTE_BATCH_SIZE = 5000;
+const PROGRESS_LOG_EVERY_BATCHES = 20;
 
 // Survey content columns that can hold i18nStrings. `blocks` and `endings` are `Json[]` (Postgres
 // array of jsonb); the rest are single `Json`.
@@ -21,7 +26,10 @@ export const canonicalizeLanguageCodes: MigrationScript = {
   type: "data",
   id: "wu5owuszcu0ge717a5vodm0p",
   name: "20260625104904_canonicalize_language_codes",
-  run: async ({ tx }) => {
+  // `tx` is the runner's mega-transaction (used for the small, bounded catalog + survey-content steps).
+  // `prisma` is the autocommit handle used for the two high-volume tables so their work commits in small
+  // chunks — see steps 3 & 4 for why (lock footprint + timeout/convergence).
+  run: async ({ prisma, tx }) => {
     const stats: MigrationStats = {
       languageRelabels: 0,
       languageMerges: 0,
@@ -220,76 +228,87 @@ export const canonicalizeLanguageCodes: MigrationScript = {
     stats.surveysContentUpdated = surveyUpdates.length;
 
     // ---------------------------------------------------------------------------------------------
-    // 3. Response.language (skip NULL, the "default" sentinel, and already-canonical values)
+    // 3. Response.language + the contactAttributes 'language' snapshot.
+    //
+    // `Response` is the highest-volume table and has NO index on `language`, so the old approach — one
+    // `UPDATE ... WHERE language = ANY(...)` inside the 30-min mega-transaction — risked (a) exceeding the
+    // timeout on a large table, which rolls back EVERY step so the deploy never converges, and (b) holding
+    // row locks long enough to stall response ingestion. Instead we walk the table by primary key in fixed
+    // chunks and commit each chunk via the autocommit `prisma` handle (NOT `tx`): locks release per chunk
+    // and committed progress survives a timeout, since the migration is idempotent (a retry just resumes).
+    //
+    // The remap set comes from the shared canonical map rather than a `SELECT DISTINCT language` full scan
+    // (itself an unindexed full-table read). It covers every known legacy code; an exotic code outside the
+    // map is left as-is and still resolves at read time (the renderer canonicalizes on read).
     // ---------------------------------------------------------------------------------------------
-    logger.info("Canonicalizing Response.language...");
-    const responseCodes = await tx.$queryRaw<{ language: string }[]>`
-      SELECT DISTINCT language FROM "Response"
-      WHERE language IS NOT NULL AND language <> 'default'
-    `;
-    const responsePairs = buildCanonicalPairs(
-      responseCodes.map((r) => r.language),
-      stats
-    );
+    logger.info("Canonicalizing Response.language + contactAttributes snapshot...");
+    const responsePairs = buildRemapPairsFromMap();
     if (responsePairs.olds.length > 0) {
-      const updated = await tx.$executeRawUnsafe(
-        `UPDATE "Response" AS r
-         SET language = data.canon
-         FROM (SELECT unnest($1::text[]) AS old, unnest($2::text[]) AS canon) AS data
-         WHERE r.language = data.old`,
-        responsePairs.olds,
-        responsePairs.canons
-      );
-      stats.responsesUpdated = typeof updated === "number" ? updated : 0;
-    }
-    logger.info(
-      `Response.language: ${responsePairs.olds.length.toString()} distinct codes remapped, ${stats.responsesUpdated.toString()} rows updated`
-    );
+      let lastId = "";
+      let batchCount = 0;
+      for (;;) {
+        const rows = await prisma.$queryRawUnsafe<{ id: string }[]>(
+          `SELECT id FROM "Response" WHERE id > $1 ORDER BY id LIMIT $2`,
+          lastId,
+          RESPONSE_BATCH_SIZE
+        );
+        if (rows.length === 0) break;
+        const ids = rows.map((row) => row.id);
 
-    // 3b. Response.contactAttributes snapshot `language` key. This JSON is a point-in-time copy of the
-    // contact's attributes; it isn't used to pick the render language, but we still canonicalize it so the
-    // stored value stays consistent with the contact attribute and Response.language.
-    const responseSnapshotCodes = await tx.$queryRaw<{ language: string }[]>`
-      SELECT DISTINCT "contactAttributes" ->> 'language' AS language
-      FROM "Response"
-      WHERE "contactAttributes" ? 'language'
-        AND "contactAttributes" ->> 'language' NOT IN ('', 'default')
-    `;
-    const snapshotPairs = buildCanonicalPairs(
-      responseSnapshotCodes.map((r) => r.language),
-      stats
-    );
-    if (snapshotPairs.olds.length > 0) {
-      const updated = await tx.$executeRawUnsafe(
-        `UPDATE "Response" AS r
-         SET "contactAttributes" = jsonb_set(r."contactAttributes", '{language}', to_jsonb(data.canon))
-         FROM (SELECT unnest($1::text[]) AS old, unnest($2::text[]) AS canon) AS data
-         WHERE r."contactAttributes" ->> 'language' = data.old`,
-        snapshotPairs.olds,
-        snapshotPairs.canons
-      );
-      stats.responseContactAttributesUpdated = typeof updated === "number" ? updated : 0;
+        const languageUpdated = await prisma.$executeRawUnsafe(
+          `UPDATE "Response" AS r
+           SET language = data.canon
+           FROM (SELECT unnest($1::text[]) AS old, unnest($2::text[]) AS canon) AS data
+           WHERE r.id = ANY($3::text[]) AND r.language = data.old`,
+          responsePairs.olds,
+          responsePairs.canons,
+          ids
+        );
+        stats.responsesUpdated += typeof languageUpdated === "number" ? languageUpdated : 0;
+
+        const snapshotUpdated = await prisma.$executeRawUnsafe(
+          `UPDATE "Response" AS r
+           SET "contactAttributes" = jsonb_set(r."contactAttributes", '{language}', to_jsonb(data.canon))
+           FROM (SELECT unnest($1::text[]) AS old, unnest($2::text[]) AS canon) AS data
+           WHERE r.id = ANY($3::text[])
+             AND r."contactAttributes" ->> 'language' = data.old`,
+          responsePairs.olds,
+          responsePairs.canons,
+          ids
+        );
+        stats.responseContactAttributesUpdated += typeof snapshotUpdated === "number" ? snapshotUpdated : 0;
+
+        lastId = ids[ids.length - 1];
+        batchCount += 1;
+        if (batchCount % PROGRESS_LOG_EVERY_BATCHES === 0) {
+          logger.info(
+            `Response progress: ~${(batchCount * RESPONSE_BATCH_SIZE).toString()} scanned, ${stats.responsesUpdated.toString()} language + ${stats.responseContactAttributesUpdated.toString()} snapshot rows updated`
+          );
+        }
+      }
     }
     logger.info(
-      `Response.contactAttributes language: ${snapshotPairs.olds.length.toString()} distinct codes remapped, ${stats.responseContactAttributesUpdated.toString()} rows updated`
+      `Response.language: ${stats.responsesUpdated.toString()} rows updated; contactAttributes snapshot: ${stats.responseContactAttributesUpdated.toString()} rows updated`
     );
 
     // ---------------------------------------------------------------------------------------------
-    // 4. Contact `language` attribute value
+    // 4. Contact `language` attribute value.
+    //
+    // Uses the `[attributeKeyId, value]` index to touch only language rows (never a full-table join to
+    // ContactAttributeKey). Runs via the autocommit `prisma` handle and updates each legacy value in
+    // index-backed chunks that commit per batch, so a code held by millions of contacts never sits under
+    // one long lock.
     // ---------------------------------------------------------------------------------------------
     logger.info("Canonicalizing contact language attribute values...");
-    // Resolve the workspace-scoped `language` attribute keys up front so the queries below can hit the
-    // `[attributeKeyId, value]` index directly (attributeKeyId = ANY + value =), instead of joining the
-    // whole (potentially millions-of-rows) ContactAttribute table to ContactAttributeKey — that join
-    // planned badly and made this step crawl.
-    const languageKeyRows = await tx.$queryRaw<{ id: string }[]>`
+    const languageKeyRows = await prisma.$queryRaw<{ id: string }[]>`
       SELECT id FROM "ContactAttributeKey" WHERE key = 'language'
     `;
     const languageKeyIds = languageKeyRows.map((row) => row.id);
     logger.info(`Found ${languageKeyIds.length.toString()} language attribute keys`);
 
     if (languageKeyIds.length > 0) {
-      const contactCodes = await tx.$queryRawUnsafe<{ value: string }[]>(
+      // Scoped to language rows via the index (not a full-table scan) and returns a handful of codes.
+      const contactCodes = await prisma.$queryRawUnsafe<{ value: string }[]>(
         `SELECT DISTINCT value FROM "ContactAttribute"
          WHERE "attributeKeyId" = ANY($1::text[]) AND value <> '' AND value <> 'default'`,
         languageKeyIds
@@ -298,16 +317,26 @@ export const canonicalizeLanguageCodes: MigrationScript = {
         contactCodes.map((c) => c.value),
         stats
       );
-      // One UPDATE per distinct code, so each hits the index and we get visible progress.
       for (let i = 0; i < contactPairs.olds.length; i++) {
-        const updated = await tx.$executeRawUnsafe(
-          `UPDATE "ContactAttribute" SET value = $1
-           WHERE "attributeKeyId" = ANY($2::text[]) AND value = $3`,
-          contactPairs.canons[i],
-          languageKeyIds,
-          contactPairs.olds[i]
-        );
-        stats.contactAttributesUpdated += typeof updated === "number" ? updated : 0;
+        // Index-backed batched update: each pass updates up to CONTACT_ATTRIBUTE_BATCH_SIZE rows still at
+        // the legacy value and commits, until fewer than a full batch remain.
+        for (;;) {
+          const updated = await prisma.$executeRawUnsafe(
+            `UPDATE "ContactAttribute" SET value = $1
+             WHERE id IN (
+               SELECT id FROM "ContactAttribute"
+               WHERE "attributeKeyId" = ANY($2::text[]) AND value = $3
+               LIMIT $4
+             )`,
+            contactPairs.canons[i],
+            languageKeyIds,
+            contactPairs.olds[i],
+            CONTACT_ATTRIBUTE_BATCH_SIZE
+          );
+          const rowsUpdated = typeof updated === "number" ? updated : 0;
+          stats.contactAttributesUpdated += rowsUpdated;
+          if (rowsUpdated < CONTACT_ATTRIBUTE_BATCH_SIZE) break;
+        }
         logger.info(
           `Contact language attribute progress: ${(i + 1).toString()}/${contactPairs.olds.length.toString()} (${contactPairs.olds[i]} -> ${contactPairs.canons[i]})`
         );
@@ -337,6 +366,21 @@ const asLinkArray = (rows: SurveyLanguageRow[]): SurveyLanguageRow[] =>
     default: Boolean(row.default),
     enabled: Boolean(row.enabled),
   }));
+
+// The full legacy -> canonical remap from the shared canonical map, excluding identity entries. Used for
+// the Response steps so we never full-scan the huge, unindexed-on-`language` table just to discover which
+// codes exist; the batched UPDATE simply no-ops on any row whose value isn't a known legacy code.
+const buildRemapPairsFromMap = (): { olds: string[]; canons: string[] } => {
+  const olds: string[] = [];
+  const canons: string[] = [];
+  for (const [legacy, canonical] of Object.entries(LANGUAGE_CANONICAL_MAP)) {
+    if (legacy !== canonical) {
+      olds.push(legacy);
+      canons.push(canonical);
+    }
+  }
+  return { olds, canons };
+};
 
 // Build parallel old/canonical arrays for a batched UNNEST remap, keeping only codes that actually
 // change and recording codes that don't resolve to a canonical form.

--- a/packages/database/migration/20260625104904_canonicalize_language_codes/migration.ts
+++ b/packages/database/migration/20260625104904_canonicalize_language_codes/migration.ts
@@ -230,16 +230,19 @@ export const canonicalizeLanguageCodes: MigrationScript = {
     // ---------------------------------------------------------------------------------------------
     // 3. Response.language + the contactAttributes 'language' snapshot.
     //
-    // `Response` is the highest-volume table and has NO index on `language`, so the old approach — one
-    // `UPDATE ... WHERE language = ANY(...)` inside the 30-min mega-transaction — risked (a) exceeding the
-    // timeout on a large table, which rolls back EVERY step so the deploy never converges, and (b) holding
-    // row locks long enough to stall response ingestion. Instead we walk the table by primary key in fixed
-    // chunks and commit each chunk via the autocommit `prisma` handle (NOT `tx`): locks release per chunk
-    // and committed progress survives a timeout, since the migration is idempotent (a retry just resumes).
+    // `Response` is the highest-volume table and has NO index on `language`. The write walks the table by
+    // PRIMARY KEY in fixed chunks, each chunk committed via the autocommit `prisma` handle (NOT `tx`).
+    // Committing per chunk means the big write never holds one long lock and its progress survives a
+    // failure — the migration is idempotent, so a retry resumes and converges instead of rolling the whole
+    // thing back. (Caveat: the runner still wraps `run()` in its own `$transaction`, so the 30-min budget
+    // applies to the migration as a whole and steps 1-2's locks are held until `run()` returns; fully
+    // decoupling the big-table phases from that transaction is a follow-up — a runner opt-out or a split.)
     //
-    // The remap set comes from the shared canonical map rather than a `SELECT DISTINCT language` full scan
-    // (itself an unindexed full-table read). It covers every known legacy code; an exotic code outside the
-    // map is left as-is and still resolves at read time (the renderer canonicalizes on read).
+    // The remap comes from the shared canonical map, not a `SELECT DISTINCT language` full scan. Matching is
+    // case/underscore-insensitive (`lower(replace(..., '_', '-'))` vs lowercased map keys) so variants like
+    // `EN` / `de_DE` / `pt-br` are canonicalized too, and `<> canon` skips rows already at the exact
+    // canonical value (no dead-tuple rewrites). A code outside the map is left as-is and still resolves at
+    // read time (the renderer canonicalizes on read).
     // ---------------------------------------------------------------------------------------------
     logger.info("Canonicalizing Response.language + contactAttributes snapshot...");
     const responsePairs = buildRemapPairsFromMap();
@@ -259,7 +262,9 @@ export const canonicalizeLanguageCodes: MigrationScript = {
           `UPDATE "Response" AS r
            SET language = data.canon
            FROM (SELECT unnest($1::text[]) AS old, unnest($2::text[]) AS canon) AS data
-           WHERE r.id = ANY($3::text[]) AND r.language = data.old`,
+           WHERE r.id = ANY($3::text[])
+             AND lower(replace(r.language, '_', '-')) = data.old
+             AND r.language <> data.canon`,
           responsePairs.olds,
           responsePairs.canons,
           ids
@@ -271,7 +276,8 @@ export const canonicalizeLanguageCodes: MigrationScript = {
            SET "contactAttributes" = jsonb_set(r."contactAttributes", '{language}', to_jsonb(data.canon))
            FROM (SELECT unnest($1::text[]) AS old, unnest($2::text[]) AS canon) AS data
            WHERE r.id = ANY($3::text[])
-             AND r."contactAttributes" ->> 'language' = data.old`,
+             AND lower(replace(r."contactAttributes" ->> 'language', '_', '-')) = data.old
+             AND r."contactAttributes" ->> 'language' <> data.canon`,
           responsePairs.olds,
           responsePairs.canons,
           ids
@@ -367,17 +373,17 @@ const asLinkArray = (rows: SurveyLanguageRow[]): SurveyLanguageRow[] =>
     enabled: Boolean(row.enabled),
   }));
 
-// The full legacy -> canonical remap from the shared canonical map, excluding identity entries. Used for
-// the Response steps so we never full-scan the huge, unindexed-on-`language` table just to discover which
-// codes exist; the batched UPDATE simply no-ops on any row whose value isn't a known legacy code.
+// Every known code form -> its canonical, keyed by a LOWERCASED map key. Used for the Response steps so we
+// never full-scan the huge, unindexed-on-`language` table to discover which codes exist. Identity entries
+// (canonical -> canonical) are included so a case/underscore variant of a canonical code (`de_DE` -> `de-DE`)
+// is normalized too; the step-3 UPDATE's `r.language <> canon` guard then skips rows already at the exact
+// canonical value (no dead-tuple rewrites). Lowercased map keys are unique, so the remap is unambiguous.
 const buildRemapPairsFromMap = (): { olds: string[]; canons: string[] } => {
   const olds: string[] = [];
   const canons: string[] = [];
-  for (const [legacy, canonical] of Object.entries(LANGUAGE_CANONICAL_MAP)) {
-    if (legacy !== canonical) {
-      olds.push(legacy);
-      canons.push(canonical);
-    }
+  for (const [code, canonical] of Object.entries(LANGUAGE_CANONICAL_MAP)) {
+    olds.push(code.toLowerCase());
+    canons.push(canonical);
   }
   return { olds, canons };
 };

--- a/packages/database/migration/20260625104904_canonicalize_language_codes/utils.test.ts
+++ b/packages/database/migration/20260625104904_canonicalize_language_codes/utils.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, test } from "vitest";
+import type { LanguageRow, SurveyLanguageRow } from "./types";
+import { planLanguageMerges, planSurveyLanguageMoves, rewriteI18nKeys, toCanonical } from "./utils";
+
+// Characterization tests for the migration's pure planning/rewrite logic — the trickiest,
+// most data-mangling-prone code in the language-canonicalization migration (collision survivorship,
+// SurveyLanguage composite-PK dedup + flag promotion, order-preserving i18n-key rewrites). Every
+// expectation was captured from the actual current implementation.
+
+const lang = (
+  id: string,
+  code: string,
+  createdAt: string,
+  alias: string | null = null,
+  workspaceId = "w1"
+): LanguageRow => ({ id, code, alias, workspaceId, createdAt: new Date(createdAt) });
+
+const link = (languageId: string, surveyId: string, def = false, enabled = true): SurveyLanguageRow => ({
+  languageId,
+  surveyId,
+  default: def,
+  enabled,
+});
+
+describe("toCanonical", () => {
+  test("maps legacy codes to their canonical BCP-47 form", () => {
+    expect(toCanonical("de")).toBe("de-DE");
+    expect(toCanonical("pt")).toBe("pt-BR");
+    expect(toCanonical("zh")).toBe("zh-Hans-CN");
+    expect(toCanonical("tl")).toBe("fil-PH");
+    expect(toCanonical("en")).toBe("en-US");
+    expect(toCanonical("hi")).toBe("hi-IN");
+  });
+
+  test("leaves already-canonical codes unchanged", () => {
+    expect(toCanonical("de-DE")).toBe("de-DE");
+    expect(toCanonical("pt-BR")).toBe("pt-BR");
+    expect(toCanonical("zh-Hans-CN")).toBe("zh-Hans-CN");
+  });
+
+  test("returns unknown/junk codes unchanged (never drops)", () => {
+    expect(toCanonical("xx")).toBe("xx");
+    expect(toCanonical("123")).toBe("123");
+  });
+});
+
+describe("rewriteI18nKeys", () => {
+  test("rewrites a legacy language key to canonical, preserving the default sentinel", () => {
+    const result = rewriteI18nKeys({ default: "D", de: "x" });
+    expect(result.changed).toBe(true);
+    expect(result.keysRewritten).toBe(1);
+    expect(result.value).toEqual({ default: "D", "de-DE": "x" });
+    // default is preserved verbatim and stays first
+    expect(Object.keys(result.value as Record<string, string>)[0]).toBe("default");
+  });
+
+  describe("collision merge (de + de-DE -> de-DE) via pickI18nValue", () => {
+    test("a non-empty value beats an empty one, either order", () => {
+      expect(rewriteI18nKeys({ default: "D", de: "keepme", "de-DE": "" }).value).toEqual({
+        default: "D",
+        "de-DE": "keepme",
+      });
+      expect(rewriteI18nKeys({ default: "D", de: "", "de-DE": "keepme" }).value).toEqual({
+        default: "D",
+        "de-DE": "keepme",
+      });
+    });
+
+    test("when both are non-empty, the value from the already-canonical key wins (order-independent)", () => {
+      expect(rewriteI18nKeys({ default: "D", de: "fromBare", "de-DE": "fromCanon" }).value).toEqual({
+        default: "D",
+        "de-DE": "fromCanon",
+      });
+      expect(rewriteI18nKeys({ default: "D", "de-DE": "fromCanon", de: "fromBare" }).value).toEqual({
+        default: "D",
+        "de-DE": "fromCanon",
+      });
+    });
+  });
+
+  test("preserves array element order (blocks/endings)", () => {
+    const result = rewriteI18nKeys([
+      { id: "a", headline: { default: "A", de: "a-de" } },
+      { id: "b", headline: { default: "B", de: "b-de" } },
+      { id: "c", headline: { default: "C", pt: "c-pt" } },
+    ]);
+    expect(result.changed).toBe(true);
+    expect(result.keysRewritten).toBe(3);
+    expect(result.value).toEqual([
+      { id: "a", headline: { default: "A", "de-DE": "a-de" } },
+      { id: "b", headline: { default: "B", "de-DE": "b-de" } },
+      { id: "c", headline: { default: "C", "pt-BR": "c-pt" } },
+    ]);
+  });
+
+  test("recurses into nested objects (welcomeCard-style) without touching non-i18n fields", () => {
+    expect(rewriteI18nKeys({ enabled: true, headline: { default: "H", de: "h-de" } }).value).toEqual({
+      enabled: true,
+      headline: { default: "H", "de-DE": "h-de" },
+    });
+  });
+
+  test("returns the SAME reference (no copy) when nothing changed", () => {
+    const config = { enabled: true, count: 3 };
+    const configResult = rewriteI18nKeys(config);
+    expect(configResult.changed).toBe(false);
+    expect(configResult.value).toBe(config);
+
+    const defaultOnly = { default: "only" };
+    const defaultOnlyResult = rewriteI18nKeys(defaultOnly);
+    expect(defaultOnlyResult.changed).toBe(false);
+    expect(defaultOnlyResult.value).toBe(defaultOnly);
+
+    const canonical = { default: "D", "de-DE": "x", "pt-BR": "y" };
+    const canonicalResult = rewriteI18nKeys(canonical);
+    expect(canonicalResult.changed).toBe(false);
+    expect(canonicalResult.value).toBe(canonical);
+  });
+
+  test("collects unresolvable content keys in `unresolved` and leaves them as-is", () => {
+    const result = rewriteI18nKeys({ default: "D", de: "x", zz: "junk", "12": "n" });
+    expect(result.unresolved.sort()).toEqual(["12", "zz"]);
+    expect(result.keysRewritten).toBe(1); // only `de` -> `de-DE`
+    expect(result.value).toEqual({ default: "D", "de-DE": "x", zz: "junk", "12": "n" });
+  });
+});
+
+describe("planLanguageMerges", () => {
+  test("relabels a lone non-canonical row (no collision)", () => {
+    expect(planLanguageMerges([lang("l1", "de", "2024-01-01")])).toEqual({
+      relabels: [{ id: "l1", toCode: "de-DE" }],
+      merges: [],
+    });
+  });
+
+  test("does nothing for a lone already-canonical row", () => {
+    expect(planLanguageMerges([lang("l1", "de-DE", "2024-01-01")])).toEqual({
+      relabels: [],
+      merges: [],
+    });
+  });
+
+  test("on collision, a row already at the canonical code survives without a relabel", () => {
+    const plan = planLanguageMerges([lang("l1", "de", "2024-01-01"), lang("l2", "de-DE", "2024-02-01")]);
+    expect(plan.relabels).toEqual([]);
+    expect(plan.merges).toEqual([
+      {
+        workspaceId: "w1",
+        canonical: "de-DE",
+        survivorId: "l2",
+        survivorNeedsRelabel: false,
+        aliasToSet: null,
+        absorbedIds: ["l1"],
+      },
+    ]);
+  });
+
+  test("on collision with no canonical row, the OLDEST (createdAt, then id) survives and needs relabel", () => {
+    const plan = planLanguageMerges([lang("l2", "de", "2024-03-01"), lang("l1", "de", "2024-01-01")]);
+    expect(plan.merges).toEqual([
+      {
+        workspaceId: "w1",
+        canonical: "de-DE",
+        survivorId: "l1", // older, despite being listed second
+        survivorNeedsRelabel: true,
+        aliasToSet: null,
+        absorbedIds: ["l2"],
+      },
+    ]);
+  });
+
+  test("copies an absorbed row's alias onto the survivor only when the survivor has none", () => {
+    // survivor has no alias -> takes the absorbed alias
+    expect(
+      planLanguageMerges([
+        lang("l1", "de", "2024-01-01", null),
+        lang("l2", "de", "2024-02-01", "FromAbsorbed"),
+      ]).merges[0].aliasToSet
+    ).toBe("FromAbsorbed");
+
+    // survivor already has an alias -> absorbed alias is ignored
+    expect(
+      planLanguageMerges([
+        lang("l1", "de-DE", "2024-02-01", "Mine"),
+        lang("l2", "de", "2024-01-01", "Absorbed"),
+      ]).merges[0].aliasToSet
+    ).toBeNull();
+  });
+
+  test("groups per workspace: the same code in two workspaces is two independent relabels, not a merge", () => {
+    expect(
+      planLanguageMerges([
+        lang("l1", "de", "2024-01-01", null, "w1"),
+        lang("l2", "de", "2024-01-01", null, "w2"),
+      ])
+    ).toEqual({
+      relabels: [
+        { id: "l1", toCode: "de-DE" },
+        { id: "l2", toCode: "de-DE" },
+      ],
+      merges: [],
+    });
+  });
+});
+
+describe("planSurveyLanguageMoves", () => {
+  test("repoints an absorbed link when the survivor doesn't link that survey yet", () => {
+    expect(planSurveyLanguageMoves("surv", ["abs1"], [link("abs1", "s1")])).toEqual({
+      repoints: [{ surveyId: "s1", fromLanguageId: "abs1" }],
+      deletes: [],
+      flagUpdates: [],
+    });
+  });
+
+  test("deletes the absorbed link when the survivor already links the survey (composite-PK dedup) and promotes flags", () => {
+    expect(
+      planSurveyLanguageMoves(
+        "surv",
+        ["abs1"],
+        [
+          link("surv", "s1", false, true),
+          link("abs1", "s1", true, true), // absorbed carried default=true -> promoted onto survivor
+        ]
+      )
+    ).toEqual({
+      repoints: [],
+      deletes: [{ surveyId: "s1", languageId: "abs1" }],
+      flagUpdates: [{ surveyId: "s1", default: true, enabled: true }],
+    });
+  });
+
+  test("emits no flag update when the survivor's link already carries the flags", () => {
+    expect(
+      planSurveyLanguageMoves(
+        "surv",
+        ["abs1"],
+        [link("surv", "s1", true, true), link("abs1", "s1", false, true)]
+      )
+    ).toEqual({
+      repoints: [],
+      deletes: [{ surveyId: "s1", languageId: "abs1" }],
+      flagUpdates: [],
+    });
+  });
+
+  test("dedupes a second absorbed link against the repointed baseline (repoint-then-delete on the same survey)", () => {
+    // abs1 repoints (survivor not yet linked); abs2 must then dedupe against that repointed link,
+    // and its default=true is promoted onto the survivor's (now-repointed) link for the survey.
+    expect(
+      planSurveyLanguageMoves(
+        "surv",
+        ["abs1", "abs2"],
+        [link("abs1", "s1", false, true), link("abs2", "s1", true, true)]
+      )
+    ).toEqual({
+      repoints: [{ surveyId: "s1", fromLanguageId: "abs1" }],
+      deletes: [{ surveyId: "s1", languageId: "abs2" }],
+      flagUpdates: [{ surveyId: "s1", default: true, enabled: true }],
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Addresses @xernobyl's re-review feedback on the ENG-1067 language-codes epic (#8390). Targets the `epic/language-codes-stabilization` branch. Three items:

### [P1 — gating] Migration transaction / lock model

Previously the whole data migration ran in one ~30-minute transaction, and the `Response` step did a single big `UPDATE` against the unindexed `Response.language` column. On a large `Response` table that risked (a) exceeding the timeout → the **entire** transaction rolls back → the deploy never converges, and (b) holding row locks long enough to stall response ingestion.

The two high-volume steps now run **outside** the mega-transaction, via the runner's autocommit `prisma` handle, in **committed-per-chunk** batches:

- **`Response`** (`language` + the `contactAttributes` `language` snapshot) is walked by **primary key** in fixed chunks (`RESPONSE_BATCH_SIZE`), each chunk committed. The remap set comes from the shared canonical map instead of a `SELECT DISTINCT` full-table scan.
- **`ContactAttribute`** updates each legacy value in **index-backed** (`[attributeKeyId, value]`) chunks that commit per batch, so a code held by millions of contacts never sits under one long lock.

Locks release per chunk (no ingestion stall), and committed progress survives a timeout — the migration is idempotent, so a retry simply resumes. The small, bounded steps (Language-row merges, survey content) stay inside the transaction.

*Trade-offs (intentional):* whole-migration atomicity is replaced by commit-as-you-go + idempotent resume; a code outside the canonical map is left as-is and still resolves at read time (the renderer canonicalizes on read).

### [P3] v3 write-validation regex rejected canonical tags

`V3_SURVEY_LOCALE_CODE_REGEX` only allowed a 2-letter base + 2-letter region, so it rejected canonical catalog codes with a 3-letter base or a UN M.49 numeric region (`fil-PH`, `bho-IN`, `eo-001`, `ia-001`, `io-001`, `vo-001`) — codes the picker and `createLanguage` accept — meaning *creating* such a survey language via the v3 API failed. Widened the pattern to accept them; verified it now matches **all 204** canonical catalog codes (was rejecting 6). Reads/existing languages are unaffected.

### [P3] Unit tests for the migration planning logic

Added `utils.test.ts` — **20 characterization tests** for the trickiest, most data-mangling-prone pure functions (`toCanonical`, `rewriteI18nKeys`, `planLanguageMerges`, `planSurveyLanguageMoves`): collision survivorship, `SurveyLanguage` composite-PK dedup + flag promotion, order-preserving block/ending rewrites, `default` sentinel preservation, and unresolved-code handling.

_(P2 — single-language surveys skipped in the content step — was intentionally not changed: the renderer canonicalizes on read so display is unaffected; the candidate set can be widened later if prod data shows stale legacy keys.)_

## How should this be tested?

- `pnpm --filter=@formbricks/web test app/api/v3/surveys/language.test.ts` → **45 pass** (incl. new `fil-PH` / `bho-IN` / `eo-001` write-locale cases).
- `cd packages/database && npx vitest run migration/20260625104904_canonicalize_language_codes/utils.test.ts` → **20 pass**.
- `packages/database` typecheck + eslint clean; `apps/web` v3 lint clean.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
