### PR TITLE
docs: reduce Community Edition workspace limit to 1

### DIFF
--- a/docs/self-hosting/advanced/license.mdx
+++ b/docs/self-hosting/advanced/license.mdx
@@ -26,7 +26,7 @@ Additional to the AGPLv3 licensed Formbricks core, the Formbricks repository con
 | Unlimited responses                                           | ✅                | Pay per response  |
 | Unlimited surveys                                             | ✅                | ✅  |
 | Unlimited users                                               | ✅                | ✅  |
-| Workspaces                                                    | 3                 | Unlimited          |
+| Workspaces                                                    | 1                 | Unlimited          |
 | Use all [free features](#what-features-are-free%3F) | ✅                | ✅  |
 | Use [paid features](#what-features-are-free%3F)       | ❌                | Pay per feature                 |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the Community Edition workspace limit in the license documentation from 3 to 1.

## Changes

- `docs/self-hosting/advanced/license.mdx`: Changed the "Workspaces" row in the "When do I need an Enterprise License?" table from `3` to `1` for Community Edition.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57e86af7-9a98-442f-90d2-f2032d613d16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57e86af7-9a98-442f-90d2-f2032d613d16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

