### PR TITLE
docs: add user-facing MCP OAuth setup guides for Claude and Codex

### DIFF
--- a/docs/development/technical-handbook/mcp-server.mdx
+++ b/docs/development/technical-handbook/mcp-server.mdx
@@ -15,6 +15,11 @@ rate limiting, response handling, and audit logging paths as the REST routes.
   backwards-compatible fallback for local development, self-hosters, and clients that do not support MCP OAuth yet.
 </Note>
 
+<Note>
+  Looking for step-by-step setup guides for Claude Code, the Claude apps, and Codex? See
+  [Connect AI agents (MCP)](/platform/mcp/overview). This handbook covers the technical internals.
+</Note>
+
 ## Endpoint
 
 Use the streamable HTTP MCP endpoint on the Formbricks app:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,6 +86,11 @@
                   "platform/features/user-management/two-factor-auth"
                 ]
               },
+              {
+                "group": "MCP",
+                "icon": "robot",
+                "pages": ["platform/mcp/overview", "platform/mcp/setup"]
+              },
               "platform/features/styling-theme",
               "platform/features/email-customization"
             ]

--- a/docs/platform/mcp/overview.mdx
+++ b/docs/platform/mcp/overview.mdx
@@ -1,0 +1,74 @@
+---
+title: "Connect AI Agents (MCP)"
+description: "Let AI assistants like Claude and Codex read and manage your Formbricks surveys through the Model Context Protocol (MCP), authorized securely with your own login."
+icon: "robot"
+---
+
+Formbricks ships a **Model Context Protocol (MCP) server** that lets AI assistants — Claude Code, the Claude apps, Codex, and other MCP-capable clients — work with the surveys in your workspace: list and read surveys, create link surveys, and update or delete them. The agent calls the same v3 Surveys API you use in the app, so it always respects your permissions.
+
+You connect a client **with your own Formbricks login over OAuth 2.1** — there are no API keys to generate, copy, or paste. You approve the connection once on a consent screen, and you can revoke it at any time.
+
+<Note>
+  Prefer to use a long-lived token instead (for scripts, CI, or a client that doesn't support OAuth
+  yet)? Formbricks API keys still work as a fallback — see the
+  [MCP server technical handbook](/development/technical-handbook/mcp-server).
+</Note>
+
+## The MCP server URL
+
+Point your client at your Formbricks app's `/api/mcp` endpoint:
+
+| Instance | MCP server URL |
+| --- | --- |
+| Formbricks Cloud | `https://app.formbricks.com/api/mcp` |
+| Self-hosted | `https://<your-formbricks-domain>/api/mcp` |
+
+## How the connection works
+
+You don't need to understand the details to connect, but here's what happens under the hood when you add the server to a client:
+
+1. **Discovery** — the client reads the server's OAuth metadata to find where to sign in.
+2. **Registration** — the client registers itself automatically using Dynamic Client Registration (DCR). There's no client ID or secret for you to manage.
+3. **Sign in & consent** — your browser opens to Formbricks. You log in (if you aren't already) and **approve** the requested access on a consent screen.
+4. **Token** — the client receives a short-lived access token it sends on every request, plus a refresh token so it can stay connected without asking you to sign in again.
+
+The whole flow uses Authorization Code + PKCE, the standard the [MCP authorization spec](https://modelcontextprotocol.io/specification/draft/basic/authorization) requires.
+
+## What the agent can do
+
+The MCP server exposes six survey tools, grouped into two scopes you approve on the consent screen:
+
+| Scope | Tools | What it allows |
+| --- | --- | --- |
+| `surveys:read` | `list_surveys`, `get_survey`, `validate_survey` | Read surveys and validate survey documents |
+| `surveys:write` | `create_survey`, `patch_survey`, `delete_survey` | Create, update, and delete surveys |
+
+<Warning>
+  Scopes are only a coarse gate. **Access is always bounded by your Formbricks workspace role**: even
+  if a client holds `surveys:write`, a call only succeeds if you have write/manage permission on the
+  target workspace. An agent can never do more than you can.
+</Warning>
+
+## Prerequisites
+
+- A **Formbricks account** with access to the workspace whose surveys you want to work with. Read-only tasks need `read`; creating or editing surveys needs `write` or `manage`.
+- The **MCP server URL** for your instance (see the table above).
+- An **MCP client** that supports remote HTTP servers with OAuth — see the [setup guides](/platform/mcp/setup) for Claude Code, the Claude apps, and Codex.
+
+<Note>
+  **Self-hosting?** The OAuth provider is built in and enabled automatically — there's nothing extra
+  to turn on. It just needs your instance to be served from a correct, public **HTTPS** base URL
+  (set via `WEBAPP_URL` / `BETTER_AUTH_URL`). The discovery metadata and browser redirects are built
+  from that URL, so an `http://localhost` or misconfigured origin will break the OAuth flow for
+  remote clients. See the [self-hosting configuration](/self-hosting/configuration/environment-variables).
+</Note>
+
+## Next steps
+
+<Card title="Set up your MCP client" icon="plug" href="/platform/mcp/setup">
+  Copy-paste guides for Claude Code, the Claude apps (custom connectors), and Codex — plus how to
+  manage and revoke access.
+</Card>
+
+For the tool schemas, response formats, discovery endpoints, and the API-key fallback, see the
+[MCP server technical handbook](/development/technical-handbook/mcp-server).

--- a/docs/platform/mcp/overview.mdx
+++ b/docs/platform/mcp/overview.mdx
@@ -71,4 +71,5 @@ The MCP server exposes six survey tools, grouped into two scopes you approve on 
 </Card>
 
 For the tool schemas, response formats, discovery endpoints, and the API-key fallback, see the
-[MCP server technical handbook](/development/technical-handbook/mcp-server).
+[MCP server technical handbook](/development/technical-handbook/mcp-server). Each tool maps to the
+[v3 Surveys API](/development/technical-handbook/mcp-server#relationship-to-v3-surveys-api) it wraps.

--- a/docs/platform/mcp/setup.mdx
+++ b/docs/platform/mcp/setup.mdx
@@ -1,0 +1,160 @@
+---
+title: "Set Up Your MCP Client"
+description: "Connect Claude Code, the Claude apps, or Codex to the Formbricks MCP server over OAuth — plus how to manage and revoke access."
+icon: "plug"
+---
+
+These guides connect your MCP client to Formbricks using OAuth (no API keys). They use the Formbricks Cloud URL `https://app.formbricks.com/api/mcp`; if you self-host, swap in your own `https://<your-formbricks-domain>/api/mcp`. For how the flow works and prerequisites, see [Connect AI agents (MCP)](/platform/mcp/overview).
+
+## Claude Code
+
+Claude Code runs on your machine and performs the OAuth handshake itself.
+
+<Steps>
+  <Step title="Add the server">
+    ```bash
+    claude mcp add --transport http formbricks https://app.formbricks.com/api/mcp
+    ```
+  </Step>
+  <Step title="Authenticate">
+    In a Claude Code session, run `/mcp`, select **formbricks**, and choose **Authenticate**. Your
+    browser opens to Formbricks; sign in if needed and **approve** the requested access on the consent
+    screen. Claude Code registers itself automatically and stores the token — there's no scope to type
+    in.
+  </Step>
+  <Step title="Verify">
+    ```bash
+    claude mcp list
+    claude mcp get formbricks
+    ```
+    Then ask Claude to use it, e.g. *"Use the formbricks MCP server to list my surveys."*
+  </Step>
+</Steps>
+
+To share the server definition with a project (no credentials committed), add it to `.mcp.json` at the repo root and authenticate with `/mcp` on first use:
+
+```json
+{
+  "mcpServers": {
+    "formbricks": {
+      "type": "http",
+      "url": "https://app.formbricks.com/api/mcp"
+    }
+  }
+}
+```
+
+## Claude apps (custom connectors)
+
+Use this for **claude.ai** and **Claude Desktop**, where Formbricks is added as a custom connector.
+
+<Steps>
+  <Step title="Open the connectors settings">
+    Go to **Settings → Connectors** (**Customize → Connectors**) and click **Add custom connector**.
+  </Step>
+  <Step title="Add the server URL">
+    Enter `https://app.formbricks.com/api/mcp` and confirm. Leave the optional OAuth client fields
+    blank — Formbricks registers the connector automatically.
+  </Step>
+  <Step title="Approve access">
+    Claude opens Formbricks in your browser. Sign in and **approve** the requested access. The
+    connector then shows as connected, and you can enable it per chat from the **+** menu.
+  </Step>
+</Steps>
+
+<Warning>
+  **Two things to know about the Claude apps:**
+
+  - **Custom connectors are a paid-plan feature.** On **Team/Enterprise**, an **organization owner**
+    must add the connector under **Organization settings → Connectors** first; members then connect
+    to it individually.
+  - **The connection runs from Anthropic's servers, not your machine.** A custom connector therefore
+    **cannot reach a `localhost` server** — the MCP URL must be a **public HTTPS** address. Formbricks
+    Cloud works out of the box; if you self-host, expose your instance on a public HTTPS domain (a
+    tunnel such as ngrok/cloudflared works for testing). To connect a local dev server, use **Claude
+    Code** instead — it runs locally.
+</Warning>
+
+## Codex
+
+<Steps>
+  <Step title="Add the server">
+    Include `--oauth-resource` so the access token is audience-bound to the MCP resource:
+    ```bash
+    codex mcp add formbricks \
+      --url https://app.formbricks.com/api/mcp \
+      --oauth-resource https://app.formbricks.com/api/mcp
+    ```
+  </Step>
+  <Step title="Authenticate">
+    ```bash
+    codex mcp login formbricks
+    ```
+    Codex opens the browser to Formbricks, registers itself, and you **approve** on the consent
+    screen. For read-only access, restrict the scopes:
+    ```bash
+    codex mcp login formbricks --scopes surveys:read,offline_access
+    ```
+  </Step>
+  <Step title="Verify">
+    ```bash
+    codex mcp list
+    codex mcp get formbricks
+    ```
+  </Step>
+</Steps>
+
+The equivalent `~/.codex/config.toml` entry:
+
+```toml
+[mcp_servers.formbricks]
+url = "https://app.formbricks.com/api/mcp"
+oauth_resource = "https://app.formbricks.com/api/mcp"
+```
+
+## Manage and revoke access
+
+Every client you authorize appears under **Account settings → Authorized apps**
+(`/account/settings/authorized-apps`), showing the client name, granted scopes, and when it was
+approved. Click **Revoke** to immediately cut off a client's access; it will need to be re-authorized
+to connect again.
+
+Tokens are short-lived by design: an access token lasts **15 minutes** and the client refreshes it
+silently in the background for up to **30 days** (the refresh window). After that — or after you
+revoke — the client re-runs the sign-in and consent flow. Approving `surveys:write` is re-confirmed
+periodically for safety.
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="claude.ai says it couldn't register / connect">
+    Custom connectors connect from Anthropic's cloud, which can't reach `localhost` or a private
+    network. Use a **public HTTPS** MCP URL (Formbricks Cloud, or a tunnel to a self-hosted instance),
+    or connect a local server with **Claude Code** instead.
+  </Accordion>
+  <Accordion title="invalid_client or a stale-registration error after reconnecting">
+    The client cached a registration that no longer exists on the server (e.g. the server data was
+    reset). Clear the client's stored credentials for the server and re-authenticate — in Claude Code,
+    remove and re-add the server (`claude mcp remove formbricks` then `claude mcp add …`) and run
+    `/mcp` again.
+  </Accordion>
+  <Accordion title="invalid_scope during sign-in">
+    The client requested a scope it isn't registered for. Reconnect from scratch so it re-registers
+    with the scopes the server advertises (`surveys:read`, `surveys:write`, `offline_access`).
+  </Accordion>
+  <Accordion title="A tool call fails even though you're connected">
+    Scopes don't override your workspace role. Creating, editing, or deleting surveys requires
+    `write` or `manage` permission on that workspace — ask a workspace owner/manager to grant it.
+  </Accordion>
+  <Accordion title="Self-hosted: the browser can't complete sign-in / redirects fail">
+    OAuth discovery and redirects are built from your configured base URL. Serve Formbricks from a
+    correct, public **HTTPS** origin and set `WEBAPP_URL` (and `BETTER_AUTH_URL`) to it. An
+    `http://localhost` or mismatched origin breaks the flow for remote clients. See the
+    [environment variables](/self-hosting/configuration/environment-variables) reference.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+Need the tool schemas, response shapes, or the API-key fallback? See the
+[MCP server technical handbook](/development/technical-handbook/mcp-server).

--- a/docs/platform/mcp/setup.mdx
+++ b/docs/platform/mcp/setup.mdx
@@ -65,9 +65,10 @@ Use this for **claude.ai** and **Claude Desktop**, where Formbricks is added as 
 <Warning>
   **Two things to know about the Claude apps:**
 
-  - **Custom connectors are a paid-plan feature.** On **Team/Enterprise**, an **organization owner**
-    must add the connector under **Organization settings → Connectors** first; members then connect
-    to it individually.
+  - **Custom connectors depend on your Claude plan.** They're available on Free, Pro, Max, Team, and
+    Enterprise, but the Free plan is limited to a single connector. On **Team/Enterprise**, an
+    **organization owner** must add the connector under **Organization settings → Connectors** first;
+    members then connect to it individually.
   - **The connection runs from Anthropic's servers, not your machine.** A custom connector therefore
     **cannot reach a `localhost` server** — the MCP URL must be a **public HTTPS** address. Formbricks
     Cloud works out of the box; if you self-host, expose your instance on a public HTTPS domain (a

--- a/docs/platform/mcp/setup.mdx
+++ b/docs/platform/mcp/setup.mdx
@@ -143,6 +143,13 @@ periodically for safety.
     The client requested a scope it isn't registered for. Reconnect from scratch so it re-registers
     with the scopes the server advertises (`surveys:read`, `surveys:write`, `offline_access`).
   </Accordion>
+  <Accordion title="Stuck in a consent loop / keeps asking you to sign in">
+    Usually a cookie or stale-session issue. Make sure you're signed in to Formbricks in the same
+    browser the client opens, and that third-party-cookie blocking or a private window isn't
+    discarding the session. If it persists, revoke the app under **Account settings → Authorized
+    apps**, clear the client's stored credentials for the server, and reconnect. Self-hosters: an
+    incorrect base URL (see below) also causes repeated redirects.
+  </Accordion>
   <Accordion title="A tool call fails even though you're connected">
     Scopes don't override your workspace role. Creating, editing, or deleting surveys requires
     `write` or `manage` permission on that workspace — ask a workspace owner/manager to grant it.


### PR DESCRIPTION
## What does this PR do?

Adds user-facing docs for connecting an MCP client to the Formbricks v3 Surveys MCP server over **OAuth 2.1** — the setup guides ENG-1589 asks for, now that Formbricks acts as the OAuth provider (ENG-1055, #8406, merged).

Today the only MCP OAuth docs live in the developer handbook (`development/technical-handbook/mcp-server.mdx`), which is technical and tucked under the Development tab — not where a user setting up their agent would look. This adds a dedicated **MCP** section under the **Platform** tab with two pages:

- **`platform/mcp/overview.mdx`** — what the MCP server is, a plain-English walk-through of how the OAuth connection works (discovery → automatic client registration → sign-in + consent → token + silent refresh), prerequisites, the tools/scopes table, and the important caveat that access is always bounded by your workspace role (scopes are only a coarse gate).
- **`platform/mcp/setup.mdx`** — copy-paste setup for **Claude Code**, the **Claude apps** (custom connectors), and **Codex**, plus managing/revoking access (`/account/settings/authorized-apps`), token expiry/refresh, and troubleshooting.

Two things I made sure to call out in the guides because they cost me real time while testing the flow end-to-end:
- Claude.ai/Desktop **custom connectors run from Anthropic's cloud**, so they can't reach a `localhost` server — a public HTTPS URL is required (and on Team/Enterprise an org owner has to add the connector first). For local dev, use Claude Code, which runs locally.
- Self-hosters need a correct **public HTTPS base URL** (`WEBAPP_URL`/`BETTER_AUTH_URL`) or OAuth discovery/redirects break.

Design choices:
- **Left the developer handbook as the technical reference** (per discussion) rather than moving content — the new guides cross-link to it, and it now has a one-line pointer back to them. Some overlap on the core commands is intentional so each page stands alone.
- **Commands reuse the verified handbook commands** rather than anything speculative; endpoints, scopes (`surveys:read`/`surveys:write`/`offline_access`), and token lifetimes (15 min access / 30 day refresh) are all cross-checked against the shipped `oauth-urls.ts` + `mcp-oauth-provider-options.ts`.

Docs-only change (`docs/**`), no app code.

**Scope note (ENG-1589):** all four documentation areas are covered — conceptual intro, prerequisites, per-client guides, and managing-access + troubleshooting (including consent loops). One ticket item is intentionally deferred: a dedicated cross-link *from the v3 Surveys API reference*. That reference isn't registered in the docs nav yet, so these pages link to the handbook's "Relationship to V3 Surveys API" section as an interim; the bidirectional link should be added when the v3 reference is published (separate work).

Linear: https://linear.app/formbricks/issue/ENG-1589

## How should this be tested?

It's a docs change, so "testing" is rendering + link correctness + factual accuracy:

- **Render**: `cd docs && npx mint dev` (needs a Node LTS — the CLI refuses Node 25+), or rely on the **Mintlify Deployment** preview on this PR. Confirm a new **MCP** group appears under **Platform → Platform Features** with **Connect AI Agents (MCP)** and **Set Up Your MCP Client**, and that the `<Steps>`/`<Accordion>`/`<Card>` callouts render.
- **Links**: the **Mintlify link-rot** check should stay green. All internal targets were verified to exist (`/development/technical-handbook/mcp-server`, `/platform/mcp/*`, `/self-hosting/configuration/environment-variables`).
- **Accuracy** (optional, against a running dev server): the documented flows match what actually works — `claude mcp add --transport http formbricks <url>` → `/mcp` → consent; `codex mcp add … --oauth-resource …` → `codex mcp login`; revoke under Account settings → Authorized apps. Figures are sourced from `apps/web/modules/auth/lib/{oauth-urls,mcp-oauth-provider-options}.ts`.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` (docs-only; no app build affected)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main` (branched fresh off `origin/main`)
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? Please sign the CLA!

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary

