### PR TITLE
fix: update dead XM & Surveys link on platform introduction page

### DIFF
--- a/docs/platform/introduction.mdx
+++ b/docs/platform/introduction.mdx
@@ -13,7 +13,7 @@ This guide covers everything you need to set up, use, and develop with Formbrick
 
 <CardGroup cols={2}>
 
-  <Card title="XM & Surveys" icon="square-poll-vertical" href="/xm-and-surveys/overview">
+  <Card title="XM & Surveys" icon="square-poll-vertical" href="/surveys/overview">
     Learn how to use Formbricks' XM & Surveys to collect feedback from your customers, users, and employees.
   </Card>
   <Card href="/self-hosting/overview" title="Self Host" icon="server">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The **XM & Surveys** card on the platform introduction page (`/docs/platform/introduction`) links to `/xm-and-surveys/overview`, which is dead after the docs restructure.

## Solution

Update the card `href` to `/surveys/overview`.

Single-line change in `docs/platform/introduction.mdx`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51675942-6aaf-4b9e-a40d-121083385277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51675942-6aaf-4b9e-a40d-121083385277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

