### PR TITLE
fix: fixes update language code issue

### DIFF
--- a/apps/web/lib/language/service.ts
+++ b/apps/web/lib/language/service.ts
@@ -152,9 +152,14 @@ export const updateLanguage = async (
     validateInputs([languageId, ZId], [languageInput, ZLanguageUpdate], [workspaceId, ZId]);
     const workspace = await getWorkspace(workspaceId);
     if (!workspace) throw new ResourceNotFoundError("Workspace not found", workspaceId);
+    // Only the alias is mutable on update — the `code` is immutable, so `Language.code` stays canonical
+    // regardless of caller (createLanguage enforces the canonical catalog; a code change means delete +
+    // create). Write `alias` explicitly rather than spreading `languageInput`: a caller can pass a `code`
+    // in the runtime object even though the declared type is alias-only, and spreading it would persist an
+    // arbitrary, non-canonical code — the exact hole the create-side hardening closed.
     const prismaLanguage = await prisma.language.update({
       where: { id: languageId },
-      data: { ...languageInput, updatedAt: new Date() },
+      data: { alias: languageInput.alias, updatedAt: new Date() },
       select: { ...languageSelect, surveyLanguages: { select: { surveyId: true } } },
     });
 

--- a/apps/web/lib/language/tests/language.test.ts
+++ b/apps/web/lib/language/tests/language.test.ts
@@ -110,6 +110,24 @@ describe("updateLanguage", () => {
     expect(result).toEqual(mockUpdatedLanguage);
   });
 
+  test("never writes `code` — only alias is mutable (invariant regardless of caller)", async () => {
+    const mockUpdatedLanguageWithSurveyLanguage = {
+      ...mockUpdatedLanguage,
+      surveyLanguages: [{ id: "surveyLanguageId" }],
+    };
+    vi.mocked(prisma.language.update).mockResolvedValue(mockUpdatedLanguageWithSurveyLanguage);
+    // Sneak a `code` into the runtime object (its declared type is alias-only) — it must be ignored so
+    // Language.code can't drift to an arbitrary, non-canonical value on update.
+    await updateLanguage(mockWorkspaceId, mockLanguageId, {
+      code: "anything-non-canonical",
+      alias: "New alias",
+    } as unknown as typeof mockLanguageUpdate);
+
+    const updateArg = vi.mocked(prisma.language.update).mock.calls[0][0];
+    expect(updateArg.data).toEqual({ alias: "New alias", updatedAt: expect.any(Date) });
+    expect(updateArg.data).not.toHaveProperty("code");
+  });
+
   describe("sad path", () => {
     testInputValidation(updateLanguage, "bad-id", mockLanguageId, {});
 

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "Bist du sicher, dass du diese Sprache löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden.",
       "duplicate_language_or_language_id": "Doppelte Sprache oder Sprach-ID",
       "edit_languages": "Sprachen bearbeiten",
-      "identifier": "Kennung (ISO)",
+      "identifier": "Kennung (BCP-47)",
       "language": "Sprache",
       "language_deleted_successfully": "Sprache erfolgreich gelöscht",
       "languages_updated_successfully": "Sprachen erfolgreich aktualisiert",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "Are you sure you want to delete this language? This action cannot be undone.",
       "duplicate_language_or_language_id": "Duplicate language or language ID",
       "edit_languages": "Edit languages",
-      "identifier": "Identifier (ISO)",
+      "identifier": "Identifier (BCP-47)",
       "language": "Language",
       "language_deleted_successfully": "Language deleted successfully",
       "languages_updated_successfully": "Languages updated successfully",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "¿Estás seguro de que quieres eliminar este idioma? Esta acción no se puede deshacer.",
       "duplicate_language_or_language_id": "Idioma o ID de idioma duplicado",
       "edit_languages": "Editar idiomas",
-      "identifier": "Identificador (ISO)",
+      "identifier": "Identificador (BCP-47)",
       "language": "Idioma",
       "language_deleted_successfully": "Idioma eliminado correctamente",
       "languages_updated_successfully": "Idiomas actualizados correctamente",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "Êtes-vous sûr de vouloir supprimer cette langue ? Cette action ne peut pas être annulée.",
       "duplicate_language_or_language_id": "Langue ou identifiant de langue en double",
       "edit_languages": "Modifier les langues",
-      "identifier": "Identifiant (ISO)",
+      "identifier": "Identifiant (BCP-47)",
       "language": "Langue",
       "language_deleted_successfully": "Langue supprimée avec succès",
       "languages_updated_successfully": "Langues mises à jour avec succès",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "Biztosan törölni szeretné ezt a nyelvet? Ezt a műveletet nem lehet visszavonni.",
       "duplicate_language_or_language_id": "Kettőzött nyelv vagy nyelvazonosító",
       "edit_languages": "Nyelvek szerkesztése",
-      "identifier": "Azonosító (ISO)",
+      "identifier": "Azonosító (BCP-47)",
       "language": "Nyelv",
       "language_deleted_successfully": "A nyelv sikeresen törölve",
       "languages_updated_successfully": "A nyelvek sikeresen frissítve",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "この言語を削除してもよろしいですか？このアクションは元に戻せません。",
       "duplicate_language_or_language_id": "重複する言語または言語ID",
       "edit_languages": "言語を編集",
-      "identifier": "識別子（ISO）",
+      "identifier": "識別子（BCP-47）",
       "language": "言語",
       "language_deleted_successfully": "言語を正常に削除しました",
       "languages_updated_successfully": "言語を正常に更新しました",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "Weet je zeker dat je deze taal wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
       "duplicate_language_or_language_id": "Dubbele taal of taal-ID",
       "edit_languages": "Talen bewerken",
-      "identifier": "Identifier (ISO)",
+      "identifier": "Identifier (BCP-47)",
       "language": "Taal",
       "language_deleted_successfully": "Taal succesvol verwijderd",
       "languages_updated_successfully": "Talen succesvol bijgewerkt",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "Tem certeza de que deseja excluir este idioma? Essa ação não pode ser desfeita.",
       "duplicate_language_or_language_id": "Idioma ou ID de idioma duplicado",
       "edit_languages": "Editar idiomas",
-      "identifier": "Identificador (ISO)",
+      "identifier": "Identificador (BCP-47)",
       "language": "Idioma",
       "language_deleted_successfully": "Idioma excluído com sucesso",
       "languages_updated_successfully": "Idiomas atualizados com sucesso",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "Tem a certeza de que pretende eliminar este idioma? Esta ação não pode ser desfeita.",
       "duplicate_language_or_language_id": "Idioma ou ID de idioma duplicado",
       "edit_languages": "Editar idiomas",
-      "identifier": "Identificador (ISO)",
+      "identifier": "Identificador (BCP-47)",
       "language": "Idioma",
       "language_deleted_successfully": "Idioma eliminado com sucesso",
       "languages_updated_successfully": "Idiomas atualizados com sucesso",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "Sigur vrei să ștergi această limbă? Această acțiune nu poate fi anulată.",
       "duplicate_language_or_language_id": "Limbă sau ID de limbă duplicat",
       "edit_languages": "Editați limbile",
-      "identifier": "Identificator (ISO)",
+      "identifier": "Identificator (BCP-47)",
       "language": "Limba",
       "language_deleted_successfully": "Limba a fost ștearsă cu succes",
       "languages_updated_successfully": "Limbile au fost actualizate cu succes",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "Вы уверены, что хотите удалить этот язык? Это действие нельзя будет отменить.",
       "duplicate_language_or_language_id": "Дублирующийся язык или идентификатор языка",
       "edit_languages": "Редактировать языки",
-      "identifier": "Идентификатор (ISO)",
+      "identifier": "Идентификатор (BCP-47)",
       "language": "Язык",
       "language_deleted_successfully": "Язык успешно удалён",
       "languages_updated_successfully": "Языки успешно обновлены",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "Är du säker på att du vill ta bort detta språk? Denna åtgärd kan inte ångras.",
       "duplicate_language_or_language_id": "Duplicerat språk eller språk-ID",
       "edit_languages": "Redigera språk",
-      "identifier": "Identifierare (ISO)",
+      "identifier": "Identifierare (BCP-47)",
       "language": "Språk",
       "language_deleted_successfully": "Språket har tagits bort",
       "languages_updated_successfully": "Språken har uppdaterats",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "Bu dili silmek istediğinden emin misin? Bu işlem geri alınamaz.",
       "duplicate_language_or_language_id": "Tekrarlanan dil veya dil kimliği",
       "edit_languages": "Dilleri düzenle",
-      "identifier": "Tanımlayıcı (ISO)",
+      "identifier": "Tanımlayıcı (BCP-47)",
       "language": "Dil",
       "language_deleted_successfully": "Dil başarıyla silindi",
       "languages_updated_successfully": "Diller başarıyla güncellendi",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "确定要删除此语言吗？此操作无法撤销。",
       "duplicate_language_or_language_id": "语言或语言 ID 重复",
       "edit_languages": "编辑语言",
-      "identifier": "标识符（ISO）",
+      "identifier": "标识符（BCP-47）",
       "language": "语言",
       "language_deleted_successfully": "语言删除成功",
       "languages_updated_successfully": "语言更新成功",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -2089,7 +2089,7 @@
       "delete_language_confirmation": "確定要刪除此語言嗎？此操作無法復原。",
       "duplicate_language_or_language_id": "語言或語言 ID 重複",
       "edit_languages": "編輯語言",
-      "identifier": "識別碼（ISO）",
+      "identifier": "識別碼（BCP-47）",
       "language": "語言",
       "language_deleted_successfully": "語言已成功刪除",
       "languages_updated_successfully": "語言已成功更新",

--- a/apps/web/modules/survey/multi-language-surveys/components/edit-language.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/edit-language.tsx
@@ -175,7 +175,7 @@ export function EditLanguage({ workspace, locale, isReadOnly }: EditLanguageProp
           : updateLanguageAction({
               workspaceId: workspace.id,
               languageId: lang.id,
-              languageInput: { code: lang.code, alias: lang.alias },
+              languageInput: { alias: lang.alias },
             });
       })
     );

--- a/apps/web/modules/survey/multi-language-surveys/lib/actions.ts
+++ b/apps/web/modules/survey/multi-language-surveys/lib/actions.ts
@@ -2,7 +2,7 @@
 
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
-import { ZLanguageInput } from "@formbricks/types/workspace";
+import { ZLanguageInput, ZLanguageUpdate } from "@formbricks/types/workspace";
 import {
   createLanguage,
   deleteLanguage,
@@ -137,7 +137,9 @@ export const getSurveysUsingGivenLanguageAction = authenticatedActionClient
 const ZUpdateLanguageAction = z.object({
   workspaceId: ZId,
   languageId: ZId,
-  languageInput: ZLanguageInput,
+  // Alias-only: a language's `code` is immutable (it stays canonical). Using ZLanguageUpdate strips any
+  // `code` a caller sends before it reaches the service.
+  languageInput: ZLanguageUpdate,
 });
 
 export const updateLanguageAction = authenticatedActionClient.inputSchema(ZUpdateLanguageAction).action(
@@ -156,7 +158,7 @@ export const updateLanguageAction = authenticatedActionClient.inputSchema(ZUpdat
       access: [
         {
           type: "organization",
-          schema: ZLanguageInput,
+          schema: ZLanguageUpdate,
           data: parsedInput.languageInput,
           roles: ["owner", "manager"],
         },


### PR DESCRIPTION
## What does this PR do?

Two fixes on the ENG-1067 language-canonicalization epic (targets `epic/language-codes-stabilization`).

### 1. `Language.code` is now immutable on update — closes the last hole in the "code stays canonical regardless of caller" invariant

`createLanguage` was hardened earlier (normalize + `CANONICAL_LANGUAGE_CODES` allowlist), but the update path had neither guard: `updateLanguage` did `data: { ...languageInput, updatedAt }`, spreading a raw `code`, and `ZUpdateLanguageAction.languageInput` was `ZLanguageInput` (which carries `code`). So `updateLanguageAction({ …, languageInput: { code: "anything", alias } })` could write an arbitrary, non-canonical code to `Language.code` — exactly what the create-side hardening prevents. Normal UI flow was unaffected (it re-sends the existing code), but the invariant didn't hold "regardless of caller".

Fixed defense-in-depth:

- **Service (`updateLanguage`)**: writes only `alias` (no longer spreads `languageInput`), so `Language.code` is immutable regardless of caller. Changing a language means delete + create, which enforces the canonical catalog.
- **Action (`updateLanguageAction`)**: `languageInput` schema switched to the alias-only `ZLanguageUpdate`, so any `code` a caller sends is stripped at the boundary (the authorization check schema was updated to match).
- Added a service test locking the invariant (a `code` snuck into the runtime object is ignored).

Verified every `Language.code` write path afterwards: `createLanguage` (canonical + catalog check), `updateLanguage` (alias-only now), and the v3 `ensureV3WorkspaceLanguages` upsert (`update: {}` never touches an existing code; `create` uses a `normalizeV3SurveyWriteLanguageCode`-validated canonical code). So no API can change an existing code or write an arbitrary one.

### 2. Picker label "Identifier (ISO)" → "Identifier (BCP-47)"

The stored codes are now BCP-47 language tags (`de-DE`, `zh-Hans-CN`, `fil-PH`, `eo-001`), not plain ISO codes: BCP-47 is an IETF standard that composes ISO 639 / 15924 / 3166 subtags, and numeric regions like `001` are UN M.49, not ISO 3166 — so "(ISO)" is inaccurate. Relabeled the `identifier` field across all 15 locales (ASCII parens for most, CJK fullwidth parens preserved for `ja-JP` / `zh-Hans-CN` / `zh-Hant-TW`).

## How should this be tested?

- `pnpm --filter=@formbricks/web test lib/language` → **13 pass** (incl. the new "never writes `code`" invariant test).
- UI → workspace languages: the middle column now reads **"Identifier (BCP-47)"**.
- Edit a language's **alias** via the UI → works; the **code** cannot be changed.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
