### PR TITLE
fix: persist endingId on natural survey finishes and create paths

### DIFF
--- a/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.test.ts
@@ -136,6 +136,24 @@ describe("createResponse", () => {
     );
   });
 
+  test("should persist endingId when provided", async () => {
+    await createResponse({ ...mockResponseInput, finished: true, endingId: "ending-card-id" }, prisma);
+    expect(prisma.response.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ finished: true, endingId: "ending-card-id" }),
+      })
+    );
+  });
+
+  test("should default endingId to null when not provided", async () => {
+    await createResponse(mockResponseInput, prisma);
+    expect(prisma.response.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ endingId: null }),
+      })
+    );
+  });
+
   test("should throw ResourceNotFoundError if organization not found", async () => {
     vi.mocked(getOrganization).mockResolvedValue(null);
     await expect(createResponse(mockResponseInput, prisma)).rejects.toThrow(ResourceNotFoundError);

--- a/apps/web/app/api/v1/lib/utils.ts
+++ b/apps/web/app/api/v1/lib/utils.ts
@@ -11,6 +11,7 @@ export const buildPrismaResponseData = (
     surveyId,
     displayId,
     finished,
+    endingId,
     data,
     language,
     meta,
@@ -28,6 +29,7 @@ export const buildPrismaResponseData = (
     },
     display: displayId ? { connect: { id: displayId } } : undefined,
     finished: finished,
+    endingId: endingId ?? null,
     data: data,
     language: language,
     ...(contact?.id && {

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
@@ -257,6 +257,34 @@ describe("createResponse V2", () => {
     expect(result.tags).toEqual([mockTag]);
   });
 
+  test("should persist endingId when provided", async () => {
+    await createResponse(
+      { ...mockResponseInput, finished: true, endingId: "ending-card-id" },
+      mockTx as unknown as Prisma.TransactionClient
+    );
+
+    expect(mockTx.response.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          finished: true,
+          endingId: "ending-card-id",
+        }),
+      })
+    );
+  });
+
+  test("should default endingId to null when not provided", async () => {
+    await createResponse(mockResponseInput, mockTx as unknown as Prisma.TransactionClient);
+
+    expect(mockTx.response.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          endingId: null,
+        }),
+      })
+    );
+  });
+
   test("should create response with contact when contact belongs to the workspace", async () => {
     const responseInputWithContact = {
       ...mockResponseInput,

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
@@ -38,7 +38,8 @@ const buildPrismaResponseData = (
   contact: { id: string; attributes: TContactAttributes } | null,
   ttc: Record<string, number>
 ): Prisma.ResponseCreateInput => {
-  const { surveyId, displayId, finished, data, language, meta, singleUseId, variables } = responseInput;
+  const { surveyId, displayId, finished, endingId, data, language, meta, singleUseId, variables } =
+    responseInput;
 
   return {
     survey: {
@@ -48,6 +49,7 @@ const buildPrismaResponseData = (
     },
     display: displayId ? { connect: { id: displayId } } : undefined,
     finished: finished,
+    endingId: endingId ?? null,
     data: data,
     language: language,
     ...(contact?.id && {

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
@@ -19,6 +19,7 @@ import {
   isSingleUseIdUniqueConstraintError,
 } from "@/app/api/client/[workspaceId]/responses/lib/response-error";
 import { responseSelection } from "@/app/api/v1/client/[workspaceId]/responses/lib/response";
+import { buildPrismaResponseData as buildV1PrismaResponseData } from "@/app/api/v1/lib/utils";
 import { TResponseInputV2 } from "@/app/api/v2/client/[workspaceId]/responses/types/response";
 import { assertDisplayOwnership } from "@/lib/display/service";
 import { getOrganization } from "@/lib/organization/service";
@@ -38,32 +39,12 @@ const buildPrismaResponseData = (
   contact: { id: string; attributes: TContactAttributes } | null,
   ttc: Record<string, number>
 ): Prisma.ResponseCreateInput => {
-  const { surveyId, displayId, finished, endingId, data, language, meta, singleUseId, variables } =
-    responseInput;
-
+  // Reuses the v1 builder but drops caller-supplied timestamps: unlike the v1 management create,
+  // the public client create must not let respondents backdate responses
   return {
-    survey: {
-      connect: {
-        id: surveyId,
-      },
-    },
-    display: displayId ? { connect: { id: displayId } } : undefined,
-    finished: finished,
-    endingId: endingId ?? null,
-    data: data,
-    language: language,
-    ...(contact?.id && {
-      contact: {
-        connect: {
-          id: contact.id,
-        },
-      },
-      contactAttributes: contact.attributes,
-    }),
-    ...(meta && ({ meta } as Prisma.JsonObject)),
-    singleUseId,
-    ...(variables && { variables }),
-    ttc: ttc,
+    ...buildV1PrismaResponseData(responseInput, contact, ttc),
+    createdAt: undefined,
+    updatedAt: undefined,
   };
 };
 

--- a/packages/surveys/src/components/general/survey.test.tsx
+++ b/packages/surveys/src/components/general/survey.test.tsx
@@ -340,6 +340,23 @@ describe("Survey offline restore", () => {
     });
   });
 
+  test("sends the first ending id when the survey falls off the last block without a jump target", async () => {
+    offlineStorageMocks.getSurveyProgress.mockResolvedValue(makeProgress());
+
+    renderSurvey();
+
+    fireEvent.click(await screen.findByTestId("submit-block-2"));
+
+    await waitFor(() => {
+      expect(apiClientMocks.createResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          finished: true,
+          endingId: "ending-1",
+        })
+      );
+    });
+  });
+
   test("skips responseId recovery while pending offline entries exist", async () => {
     offlineStorageMocks.getSurveyProgress.mockResolvedValue(makeProgress());
     offlineStorageMocks.countPendingResponses.mockResolvedValue(2);

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -948,7 +948,14 @@ export function Survey({
 
     pushVariableState(firstRespondedElementId);
 
-    const { nextBlockId, calculatedVariables } = evaluateLogicAndGetNextBlockId(surveyResponseData);
+    const { nextBlockId: rawNextBlockId, calculatedVariables } =
+      evaluateLogicAndGetNextBlockId(surveyResponseData);
+    // A jump target may reference a deleted block or ending; treat such stale ids as "no target"
+    // so the shown ending and the persisted endingId stay in sync
+    const targetIsBlock = localSurvey.blocks.some((block) => block.id === rawNextBlockId);
+    const targetIsEnding = localSurvey.endings.some((ending) => ending.id === rawNextBlockId);
+    const isValidTarget = targetIsBlock || targetIsEnding;
+    const nextBlockId = isValidTarget ? rawNextBlockId : undefined;
     const finished =
       nextBlockId === undefined || !localSurvey.blocks.map((block) => block.id).includes(nextBlockId);
 

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -954,8 +954,10 @@ export function Survey({
 
     setIsSurveyFinished(finished);
 
-    const endingId = nextBlockId
-      ? localSurvey.endings.find((ending) => ending.id === nextBlockId)?.id
+    // The ending that will be shown: an explicit jump target, or the first ending when the survey
+    // falls off the last block (mirrors the display fallback below so the persisted endingId matches it)
+    const endingId = finished
+      ? (localSurvey.endings.find((ending) => ending.id === nextBlockId)?.id ?? localSurvey.endings[0]?.id)
       : undefined;
 
     onChange(surveyResponseData);


### PR DESCRIPTION
## What does this PR do?

Responses that finished a survey "naturally" (submitting the last block without an explicit jump to an ending) were saved with `endingId = NULL`, so anything gated on the reached ending, survey follow-ups today and workflow triggers next, was silently skipped.

- Widget (`packages/surveys`): on finish, resolve `endingId` with the same `endings[0]` fallback the UI already uses to render the ending card, so the persisted value always matches what the respondent saw. Stale jump targets (pointing at a deleted block or ending) are normalized to "no target" so the shown ending and the saved `endingId` cannot diverge.
- API: the v1 and v2 client response create builders now persist `endingId` (previously only `updateResponse` did). This covers surveys that finish on their first submitted block, e.g. single-block NPS/CSAT or a first block jumping straight to an ending. The v1 builder is shared with the v1 management create, which gains the field too.
- Unit tests for both halves: the widget payload and the Prisma create persistence.

Behavior note: survey follow-ups scoped to specific endings gate on `Response.endingId` the same way. Once this ships, follow-ups configured for an ending will start firing for natural finishes that were previously skipped; that is the intended behavior (it matches the ending shown to the respondent), but it is a visible change for existing follow-ups.

## How should this be tested?

- Complete a multi-block link survey whose last block has no jump logic; the response row should have `endingId` set to the first ending (was `NULL` before).
- Complete a single-block survey (finish on the first submit, exercises the create path); `endingId` should be persisted as well.
- Configure a survey follow-up scoped to the survey's ending and complete the survey naturally; the follow-up should now fire.
- Point a block's jump logic at a deleted block or ending and finish the survey; the shown ending card and the persisted `endingId` should both resolve to the first ending.
- Run `pnpm --filter @formbricks/surveys test` and the vitest suites under `apps/web/app/api/v1/client/[workspaceId]/responses/lib` and `apps/web/app/api/v2/client/[workspaceId]/responses/lib`.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
