### PR TITLE
feat(link-surveys): secure prefill-from-response links

### DIFF
--- a/apps/web/app/api/v1/management/responses/[responseId]/lib/authorize.ts
+++ b/apps/web/app/api/v1/management/responses/[responseId]/lib/authorize.ts
@@ -1,0 +1,36 @@
+import { responses } from "@/app/lib/api/response";
+import { TApiV1Authentication } from "@/app/lib/api/with-api-logging";
+import { getResponse } from "@/lib/response/service";
+import { getSurvey } from "@/lib/survey/service";
+import { hasPermission } from "@/modules/organization/settings/api-keys/lib/utils";
+
+/**
+ * Loads a response and its survey and verifies the caller's API key has the
+ * required permission on the survey's workspace. Shared by the response
+ * management endpoints (GET/PUT/DELETE) and the prefill-link endpoint.
+ */
+export async function fetchAndAuthorizeResponse(
+  responseId: string,
+  authentication: TApiV1Authentication | undefined,
+  requiredPermission: "GET" | "PUT" | "DELETE"
+) {
+  if (!authentication || !("apiKeyId" in authentication)) {
+    return { error: responses.notAuthenticatedResponse() };
+  }
+
+  const response = await getResponse(responseId);
+  if (!response) {
+    return { error: responses.notFoundResponse("Response", responseId) };
+  }
+
+  const survey = await getSurvey(response.surveyId);
+  if (!survey) {
+    return { error: responses.notFoundResponse("Survey", response.surveyId, true) };
+  }
+
+  if (!hasPermission(authentication.workspacePermissions, survey.workspaceId, requiredPermission)) {
+    return { error: responses.unauthorizedResponse() };
+  }
+
+  return { response, survey };
+}

--- a/apps/web/app/api/v1/management/responses/[responseId]/prefill-link/route.ts
+++ b/apps/web/app/api/v1/management/responses/[responseId]/prefill-link/route.ts
@@ -1,0 +1,66 @@
+import { handleErrorResponse } from "@/app/api/v1/auth";
+import { responses } from "@/app/lib/api/response";
+import { THandlerParams, withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
+import {
+  DEFAULT_PREFILL_LINK_EXPIRATION_DAYS,
+  getPrefillSurveyLink,
+} from "@/modules/survey/link/lib/prefill-survey-link";
+import { fetchAndAuthorizeResponse } from "../lib/authorize";
+
+/**
+ * GET /api/v1/management/responses/{responseId}/prefill-link
+ *
+ * Mints a signed, encrypted link that opens the response's survey prefilled with
+ * that response's answers. Requires an API key with read access to the survey's
+ * workspace, so only authorized callers can create a prefill link. Optional query
+ * param `expirationDays` (positive integer) overrides the default lifetime.
+ */
+export const GET = withV1ApiWrapper({
+  handler: async ({
+    req,
+    props,
+    authentication,
+  }: THandlerParams<{ params: Promise<{ responseId: string }> }>) => {
+    const params = await props.params;
+    try {
+      const result = await fetchAndAuthorizeResponse(params.responseId, authentication, "GET");
+      if (result.error) {
+        return { response: result.error };
+      }
+
+      if (result.survey.type !== "link") {
+        return {
+          response: responses.badRequestResponse("Prefill links are only available for link surveys"),
+        };
+      }
+
+      let expirationDays = DEFAULT_PREFILL_LINK_EXPIRATION_DAYS;
+      const expirationDaysParam = new URL(req.url).searchParams.get("expirationDays");
+      if (expirationDaysParam !== null) {
+        const parsed = Number(expirationDaysParam);
+        if (!Number.isInteger(parsed) || parsed <= 0) {
+          return {
+            response: responses.badRequestResponse("expirationDays must be a positive integer"),
+          };
+        }
+        expirationDays = parsed;
+      }
+
+      const linkResult = getPrefillSurveyLink(result.response.id, result.survey.id, expirationDays);
+      if (!linkResult.ok) {
+        return {
+          response: responses.internalServerErrorResponse(linkResult.error.message),
+        };
+      }
+
+      return {
+        response: responses.successResponse({
+          prefillSurveyUrl: linkResult.data,
+          expirationDays,
+        }),
+      };
+    } catch (error) {
+      return { response: handleErrorResponse(error) };
+    }
+  },
+});

--- a/apps/web/app/api/v1/management/responses/[responseId]/route.ts
+++ b/apps/web/app/api/v1/management/responses/[responseId]/route.ts
@@ -4,45 +4,18 @@ import { handleErrorResponse } from "@/app/api/v1/auth";
 import { RequestBodyTooLargeError, parseJsonBodyWithLimit } from "@/app/lib/api/request-body";
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
-import { TApiV1Authentication, THandlerParams, withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
+import { THandlerParams, withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
 import { sendToPipeline } from "@/app/lib/pipelines";
-import { deleteResponse, getResponse } from "@/lib/response/service";
-import { getSurvey } from "@/lib/survey/service";
+import { deleteResponse } from "@/lib/response/service";
 import { formatValidationErrorsForV1Api, validateResponseData } from "@/modules/api/lib/validation";
-import { hasPermission } from "@/modules/organization/settings/api-keys/lib/utils";
 import { resolveStorageUrlsInObject, validateFileUploads } from "@/modules/storage/utils";
+import { fetchAndAuthorizeResponse } from "./lib/authorize";
 import { updateResponseWithQuotaEvaluation } from "./lib/response";
 
 type TUncheckedResponseUpdate = Record<string, unknown> & {
   data: TResponseData;
   language?: string;
 };
-
-async function fetchAndAuthorizeResponse(
-  responseId: string,
-  authentication: TApiV1Authentication | undefined,
-  requiredPermission: "GET" | "PUT" | "DELETE"
-) {
-  if (!authentication || !("apiKeyId" in authentication)) {
-    return { error: responses.notAuthenticatedResponse() };
-  }
-
-  const response = await getResponse(responseId);
-  if (!response) {
-    return { error: responses.notFoundResponse("Response", responseId) };
-  }
-
-  const survey = await getSurvey(response.surveyId);
-  if (!survey) {
-    return { error: responses.notFoundResponse("Survey", response.surveyId, true) };
-  }
-
-  if (!hasPermission(authentication.workspacePermissions, survey.workspaceId, requiredPermission)) {
-    return { error: responses.unauthorizedResponse() };
-  }
-
-  return { response, survey };
-}
 
 export const GET = withV1ApiWrapper({
   handler: async ({ props, authentication }: THandlerParams<{ params: Promise<{ responseId: string }> }>) => {

--- a/apps/web/modules/survey/link/components/pin-screen.tsx
+++ b/apps/web/modules/survey/link/components/pin-screen.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Response, Workspace } from "@formbricks/database/prisma-browser";
+import { TResponseData } from "@formbricks/types/responses";
 import { getLinkSurveyCardMaxWidth } from "@formbricks/types/styling";
 import { TSurvey, TSurveyStyling } from "@formbricks/types/surveys/types";
 import { TWorkspaceStyling } from "@formbricks/types/workspace";
@@ -32,6 +33,7 @@ interface PinScreenProps {
   isSpamProtectionEnabled?: boolean;
   responseCount?: number;
   styling: TWorkspaceStyling | TSurveyStyling;
+  serverPrefillData?: TResponseData;
 }
 
 export const PinScreen = (props: PinScreenProps) => {
@@ -55,6 +57,7 @@ export const PinScreen = (props: PinScreenProps) => {
     isSpamProtectionEnabled = false,
     responseCount,
     styling,
+    serverPrefillData,
   } = props;
 
   const [localPinEntry, setLocalPinEntry] = useState<string>("");
@@ -149,6 +152,7 @@ export const PinScreen = (props: PinScreenProps) => {
       PRIVACY_URL={PRIVACY_URL}
       TERMS_URL={TERMS_URL}
       IS_FORMBRICKS_CLOUD={IS_FORMBRICKS_CLOUD}
+      serverPrefillData={serverPrefillData}
     />
   );
 };

--- a/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
+++ b/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
@@ -37,6 +37,7 @@ interface SurveyClientWrapperProps {
   PRIVACY_URL?: string;
   TERMS_URL?: string;
   IS_FORMBRICKS_CLOUD: boolean;
+  serverPrefillData?: TResponseData;
 }
 
 let setBlockId = (_: string) => {};
@@ -62,6 +63,7 @@ export const SurveyClientWrapper = ({
   PRIVACY_URL,
   TERMS_URL,
   IS_FORMBRICKS_CLOUD,
+  serverPrefillData,
 }: SurveyClientWrapperProps) => {
   const searchParams = useSearchParams();
   const { i18n } = useTranslation();
@@ -102,7 +104,9 @@ export const SurveyClientWrapper = ({
     return isValid;
   }, [welcomeCardEnabled, elements, startAt]);
 
-  const prefillValue = getPrefillValue(survey, searchParams, languageCode);
+  // A prefill token (resolved server-side) fully prefills the survey from a
+  // previous response and takes precedence over URL query-param prefill.
+  const prefillValue = serverPrefillData ?? getPrefillValue(survey, searchParams, languageCode);
   const [autoFocus, setAutoFocus] = useState(false);
 
   // Enable autofocus only when not in iframe

--- a/apps/web/modules/survey/link/components/survey-renderer.tsx
+++ b/apps/web/modules/survey/link/components/survey-renderer.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { type Response } from "@formbricks/database/prisma-browser";
+import { TResponseData } from "@formbricks/types/responses";
 import { TSurvey, TSurveyStyling } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
 import { TWorkspaceStyling } from "@formbricks/types/workspace";
@@ -35,6 +36,8 @@ interface SurveyRendererProps {
   workspaceContext: TWorkspaceContextForLinkSurvey;
   locale: TUserLocale;
   responseCount?: number;
+  // Response data resolved from a prefill token (server-side), used to prefill answers
+  prefillResponseData?: TResponseData;
 }
 
 /**
@@ -59,6 +62,7 @@ export const renderSurvey = async ({
   workspaceContext,
   locale,
   responseCount,
+  prefillResponseData,
 }: SurveyRendererProps) => {
   const langParam = searchParams.lang;
   const isEmbed = searchParams.embed === "true";
@@ -159,6 +163,7 @@ export const renderSurvey = async ({
         recaptchaSiteKey={RECAPTCHA_SITE_KEY}
         isSpamProtectionEnabled={isSpamProtectionEnabled}
         responseCount={responseCount}
+        serverPrefillData={prefillResponseData}
       />
     );
   }
@@ -185,6 +190,7 @@ export const renderSurvey = async ({
       PRIVACY_URL={PRIVACY_URL}
       TERMS_URL={TERMS_URL}
       IS_FORMBRICKS_CLOUD={IS_FORMBRICKS_CLOUD}
+      serverPrefillData={prefillResponseData}
     />
   );
 };

--- a/apps/web/modules/survey/link/lib/prefill-survey-link.test.ts
+++ b/apps/web/modules/survey/link/lib/prefill-survey-link.test.ts
@@ -1,0 +1,274 @@
+import jwt from "jsonwebtoken";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { TResponse } from "@formbricks/types/responses";
+import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/constants";
+import { TSurvey } from "@formbricks/types/surveys/types";
+import { ENCRYPTION_KEY } from "@/lib/constants";
+import * as crypto from "@/lib/crypto";
+import { getPublicDomain } from "@/lib/getPublicUrl";
+import { getResponse } from "@/lib/response/service";
+import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
+import * as prefillSurveyLink from "./prefill-survey-link";
+
+vi.mock("jsonwebtoken", () => ({
+  default: {
+    sign: vi.fn(),
+    verify: vi.fn(),
+    TokenExpiredError: class TokenExpiredError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = "TokenExpiredError";
+      }
+    },
+  },
+}));
+
+vi.mock("@/lib/constants", () => ({
+  ENCRYPTION_KEY: "test-encryption-key-32-chars-long!",
+}));
+
+vi.mock("@/lib/getPublicUrl", () => ({
+  getPublicDomain: vi.fn().mockReturnValue("https://test.formbricks.com"),
+}));
+
+vi.mock("@/lib/crypto", () => ({
+  symmetricEncrypt: vi.fn(),
+  symmetricDecrypt: vi.fn(),
+}));
+
+vi.mock("@/lib/response/service", () => ({
+  getResponse: vi.fn(),
+}));
+
+vi.mock("@/modules/survey/lib/client-utils", () => ({
+  getElementsFromBlocks: vi.fn(),
+}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+describe("Prefill Survey Link", () => {
+  const mockResponseId = "response-789";
+  const mockSurveyId = "survey-456";
+  const mockToken = "mock.jwt.token";
+  const mockEncryptedResponseId = "encrypted-response-id";
+  const mockEncryptedSurveyId = "encrypted-survey-id";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(getPublicDomain).mockReturnValue("https://test.formbricks.com");
+
+    vi.mocked(crypto.symmetricEncrypt).mockImplementation((value) =>
+      value === mockResponseId ? mockEncryptedResponseId : mockEncryptedSurveyId
+    );
+
+    vi.mocked(crypto.symmetricDecrypt).mockImplementation((value) => {
+      if (value === mockEncryptedResponseId) return mockResponseId;
+      if (value === mockEncryptedSurveyId) return mockSurveyId;
+      return value;
+    });
+
+    vi.mocked(jwt.sign).mockReturnValue(mockToken as any);
+
+    vi.mocked(jwt.verify).mockReturnValue({
+      responseId: mockEncryptedResponseId,
+      surveyId: mockEncryptedSurveyId,
+    } as any);
+  });
+
+  describe("getPrefillSurveyLink", () => {
+    test("creates a prefill link with encrypted response and survey IDs", () => {
+      const result = prefillSurveyLink.getPrefillSurveyLink(mockResponseId, mockSurveyId);
+
+      expect(crypto.symmetricEncrypt).toHaveBeenCalledWith(mockResponseId, ENCRYPTION_KEY);
+      expect(crypto.symmetricEncrypt).toHaveBeenCalledWith(mockSurveyId, ENCRYPTION_KEY);
+
+      // Default expiration is applied
+      expect(jwt.sign).toHaveBeenCalledWith(
+        {
+          responseId: mockEncryptedResponseId,
+          surveyId: mockEncryptedSurveyId,
+        },
+        ENCRYPTION_KEY,
+        { algorithm: "HS256", expiresIn: "7d" }
+      );
+
+      expect(result).toEqual({
+        ok: true,
+        data: `${getPublicDomain()}/s/${mockSurveyId}?prefillToken=${mockToken}`,
+      });
+    });
+
+    test("applies a custom expiration when provided", () => {
+      prefillSurveyLink.getPrefillSurveyLink(mockResponseId, mockSurveyId, 2);
+
+      expect(jwt.sign).toHaveBeenCalledWith(
+        {
+          responseId: mockEncryptedResponseId,
+          surveyId: mockEncryptedSurveyId,
+        },
+        ENCRYPTION_KEY,
+        { algorithm: "HS256", expiresIn: "2d" }
+      );
+    });
+
+    test("returns an error when ENCRYPTION_KEY is not available", async () => {
+      vi.resetModules();
+      vi.doMock("@/lib/constants", () => ({ ENCRYPTION_KEY: undefined }));
+      const { getPrefillSurveyLink } = await import("./prefill-survey-link");
+
+      const result = getPrefillSurveyLink(mockResponseId, mockSurveyId);
+      expect(result).toEqual({
+        ok: false,
+        error: {
+          type: "internal_server_error",
+          message: "Encryption key not found - cannot create prefill survey link",
+        },
+      });
+    });
+  });
+
+  describe("verifyPrefillSurveyToken", () => {
+    test("verifies with a pinned HS256 algorithm and decrypts the IDs", () => {
+      const result = prefillSurveyLink.verifyPrefillSurveyToken(mockToken);
+
+      expect(jwt.verify).toHaveBeenCalledWith(mockToken, ENCRYPTION_KEY, { algorithms: ["HS256"] });
+      expect(result).toEqual({
+        ok: true,
+        data: { responseId: mockResponseId, surveyId: mockSurveyId },
+      });
+    });
+
+    test("returns an error when verification fails", () => {
+      vi.mocked(jwt.verify).mockImplementation(() => {
+        throw new Error("Token verification failed");
+      });
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = prefillSurveyLink.verifyPrefillSurveyToken(mockToken);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toEqual({
+          type: "bad_request",
+          message: "Invalid prefill token",
+          details: [{ field: "token", issue: "invalid_token" }],
+        });
+      }
+    });
+
+    test("returns a token_expired error when the token is expired", () => {
+      vi.mocked(jwt.verify).mockImplementation(() => {
+        throw new jwt.TokenExpiredError("jwt expired", new Date());
+      });
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = prefillSurveyLink.verifyPrefillSurveyToken(mockToken);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toEqual({
+          type: "bad_request",
+          message: "Prefill link has expired",
+          details: [{ field: "token", issue: "token_expired" }],
+        });
+      }
+    });
+
+    test("returns an error when the token payload is incomplete", () => {
+      vi.mocked(jwt.verify).mockReturnValue({ responseId: mockEncryptedResponseId } as any);
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = prefillSurveyLink.verifyPrefillSurveyToken(mockToken);
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.type).toBe("bad_request");
+      }
+    });
+  });
+
+  describe("getPrefillDataFromResponse", () => {
+    test("strips file upload answers but keeps everything else", () => {
+      vi.mocked(getElementsFromBlocks).mockReturnValue([
+        { id: "openText", type: TSurveyElementTypeEnum.OpenText },
+        { id: "fileUpload", type: TSurveyElementTypeEnum.FileUpload },
+        { id: "address", type: TSurveyElementTypeEnum.Address },
+      ] as any);
+
+      const survey = { id: mockSurveyId, blocks: [] } as unknown as TSurvey;
+      const data = {
+        openText: "Hello",
+        fileUpload: ["https://storage/key.pdf"],
+        address: ["Main St", "", "Berlin", "", "10115", "Germany"],
+      };
+
+      const result = prefillSurveyLink.getPrefillDataFromResponse(survey, data);
+
+      expect(result).toEqual({
+        openText: "Hello",
+        address: ["Main St", "", "Berlin", "", "10115", "Germany"],
+      });
+    });
+  });
+
+  describe("getPrefillResponseDataFromToken", () => {
+    const survey = { id: mockSurveyId, blocks: [] } as unknown as TSurvey;
+
+    beforeEach(() => {
+      vi.mocked(getElementsFromBlocks).mockReturnValue([
+        { id: "openText", type: TSurveyElementTypeEnum.OpenText },
+      ] as any);
+    });
+
+    test("returns prefill data for a valid token and matching response", async () => {
+      vi.mocked(getResponse).mockResolvedValue({
+        id: mockResponseId,
+        surveyId: mockSurveyId,
+        data: { openText: "Hi" },
+      } as unknown as TResponse);
+
+      const result = await prefillSurveyLink.getPrefillResponseDataFromToken(mockToken, survey);
+      expect(getResponse).toHaveBeenCalledWith(mockResponseId);
+      expect(result).toEqual({ openText: "Hi" });
+    });
+
+    test("returns undefined when the token is invalid", async () => {
+      vi.mocked(jwt.verify).mockImplementation(() => {
+        throw new Error("invalid");
+      });
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const result = await prefillSurveyLink.getPrefillResponseDataFromToken(mockToken, survey);
+      expect(result).toBeUndefined();
+      expect(getResponse).not.toHaveBeenCalled();
+    });
+
+    test("returns undefined when the token targets a different survey", async () => {
+      const otherSurvey = { id: "other-survey", blocks: [] } as unknown as TSurvey;
+      const result = await prefillSurveyLink.getPrefillResponseDataFromToken(mockToken, otherSurvey);
+      expect(result).toBeUndefined();
+      expect(getResponse).not.toHaveBeenCalled();
+    });
+
+    test("returns undefined when the response no longer exists", async () => {
+      vi.mocked(getResponse).mockResolvedValue(null);
+
+      const result = await prefillSurveyLink.getPrefillResponseDataFromToken(mockToken, survey);
+      expect(result).toBeUndefined();
+    });
+
+    test("returns undefined when the response belongs to another survey", async () => {
+      vi.mocked(getResponse).mockResolvedValue({
+        id: mockResponseId,
+        surveyId: "another-survey",
+        data: { openText: "Hi" },
+      } as unknown as TResponse);
+
+      const result = await prefillSurveyLink.getPrefillResponseDataFromToken(mockToken, survey);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/apps/web/modules/survey/link/lib/prefill-survey-link.ts
+++ b/apps/web/modules/survey/link/lib/prefill-survey-link.ts
@@ -1,0 +1,181 @@
+import "server-only";
+import jwt from "jsonwebtoken";
+import { logger } from "@formbricks/logger";
+import { Result, err, ok } from "@formbricks/types/error-handlers";
+import { TResponseData } from "@formbricks/types/responses";
+import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/constants";
+import { TSurvey } from "@formbricks/types/surveys/types";
+import { ENCRYPTION_KEY } from "@/lib/constants";
+import { symmetricDecrypt, symmetricEncrypt } from "@/lib/crypto";
+import { getPublicDomain } from "@/lib/getPublicUrl";
+import { getResponse } from "@/lib/response/service";
+import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
+
+type TPrefillLinkError = {
+  type: "internal_server_error" | "bad_request";
+  message: string;
+  details?: { field: string; issue: string }[];
+};
+
+// Default lifetime for a prefill link. Prefill tokens grant read access to a
+// previous response's answers, so they are intentionally short-lived.
+export const DEFAULT_PREFILL_LINK_EXPIRATION_DAYS = 7;
+
+// Element types whose stored answer should never be prefilled from a previous
+// response. File uploads hold storage keys (not re-usable answers) and would
+// leak internal paths, so we strip them.
+const NON_PREFILLABLE_ELEMENT_TYPES: TSurveyElementTypeEnum[] = [TSurveyElementTypeEnum.FileUpload];
+
+/**
+ * Creates a signed, encrypted link that prefills a link survey from a previous
+ * response. The token carries the encrypted response and survey IDs, so the raw
+ * `responseId` never appears in the URL and the token cannot be forged without
+ * the server's `ENCRYPTION_KEY`. Because only holders of an API key can mint a
+ * token (via the management endpoint), this preserves the invariant that reading
+ * a response's data requires authorization.
+ */
+export const getPrefillSurveyLink = (
+  responseId: string,
+  surveyId: string,
+  expirationDays: number = DEFAULT_PREFILL_LINK_EXPIRATION_DAYS
+): Result<string, TPrefillLinkError> => {
+  if (!ENCRYPTION_KEY) {
+    return err({
+      type: "internal_server_error",
+      message: "Encryption key not found - cannot create prefill survey link",
+    });
+  }
+
+  const encryptedResponseId = symmetricEncrypt(responseId, ENCRYPTION_KEY);
+  const encryptedSurveyId = symmetricEncrypt(surveyId, ENCRYPTION_KEY);
+
+  const payload = {
+    responseId: encryptedResponseId,
+    surveyId: encryptedSurveyId,
+  };
+
+  const tokenOptions: jwt.SignOptions = { algorithm: "HS256" };
+  if (expirationDays > 0) {
+    tokenOptions.expiresIn = `${expirationDays}d`;
+  }
+
+  const token = jwt.sign(payload, ENCRYPTION_KEY, tokenOptions);
+
+  const surveyLink = new URL(`${getPublicDomain()}/s/${surveyId}`);
+  surveyLink.searchParams.set("prefillToken", token);
+
+  return ok(surveyLink.toString());
+};
+
+/**
+ * Verifies and decrypts a prefill token. The signing algorithm is pinned to
+ * HS256 to prevent algorithm-confusion attacks.
+ */
+export const verifyPrefillSurveyToken = (
+  token: string
+): Result<{ responseId: string; surveyId: string }, TPrefillLinkError> => {
+  if (!ENCRYPTION_KEY) {
+    return err({
+      type: "internal_server_error",
+      message: "Encryption key not found - cannot verify prefill token",
+    });
+  }
+
+  try {
+    const decoded = jwt.verify(token, ENCRYPTION_KEY, { algorithms: ["HS256"] }) as {
+      responseId: string;
+      surveyId: string;
+    };
+
+    if (!decoded || !decoded.responseId || !decoded.surveyId) {
+      throw new Error("Invalid token format");
+    }
+
+    const responseId = symmetricDecrypt(decoded.responseId, ENCRYPTION_KEY);
+    const surveyId = symmetricDecrypt(decoded.surveyId, ENCRYPTION_KEY);
+
+    return ok({ responseId, surveyId });
+  } catch (error) {
+    logger.error(
+      error instanceof Error ? error : new Error(String(error)),
+      "Error verifying prefill survey token"
+    );
+
+    if (error instanceof jwt.TokenExpiredError) {
+      return err({
+        type: "bad_request",
+        message: "Prefill link has expired",
+        details: [{ field: "token", issue: "token_expired" }],
+      });
+    }
+
+    return err({
+      type: "bad_request",
+      message: "Invalid prefill token",
+      details: [{ field: "token", issue: "invalid_token" }],
+    });
+  }
+};
+
+/**
+ * Builds prefill data from a stored response's `data`. Because the stored data is
+ * already in the internal `TResponseData` shape, every supported question type
+ * (including complex types like Address or Date that cannot be expressed as URL
+ * query params) is populated as-is. Non-prefillable answers (e.g. file uploads)
+ * are stripped.
+ */
+export const getPrefillDataFromResponse = (survey: TSurvey, data: TResponseData): TResponseData => {
+  const elements = getElementsFromBlocks(survey.blocks);
+  const nonPrefillableIds = new Set(
+    elements.filter((element) => NON_PREFILLABLE_ELEMENT_TYPES.includes(element.type)).map((el) => el.id)
+  );
+
+  const prefillData: TResponseData = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (nonPrefillableIds.has(key)) continue;
+    prefillData[key] = value;
+  }
+
+  return prefillData;
+};
+
+/**
+ * Resolves a prefill token into response data for a given survey. Best-effort:
+ * returns `undefined` (rendering an empty survey) when the token is invalid or
+ * expired, targets a different survey, or the response no longer exists. The
+ * survey passed in is authoritative for the URL being visited, so the token's
+ * survey and the response's survey must both match it.
+ */
+export const getPrefillResponseDataFromToken = async (
+  token: string,
+  survey: TSurvey
+): Promise<TResponseData | undefined> => {
+  const tokenResult = verifyPrefillSurveyToken(token);
+  if (!tokenResult.ok) {
+    return undefined;
+  }
+
+  const { responseId, surveyId } = tokenResult.data;
+
+  // The token must have been minted for the survey being visited.
+  if (surveyId !== survey.id) {
+    logger.warn({ surveyId, expectedSurveyId: survey.id }, "Prefill token survey mismatch");
+    return undefined;
+  }
+
+  const response = await getResponse(responseId);
+  if (!response) {
+    return undefined;
+  }
+
+  // Defense in depth: the response itself must belong to the visited survey.
+  if (response.surveyId !== survey.id) {
+    logger.warn(
+      { responseSurveyId: response.surveyId, expectedSurveyId: survey.id },
+      "Prefill response survey mismatch"
+    );
+    return undefined;
+  }
+
+  return getPrefillDataFromResponse(survey, response.data);
+};

--- a/apps/web/modules/survey/link/lib/types.ts
+++ b/apps/web/modules/survey/link/lib/types.ts
@@ -5,4 +5,5 @@ export type TLinkSurveySearchParams = {
   embed?: string;
   preview?: string;
   suToken?: string;
+  prefillToken?: string;
 } & Record<string, string | string[] | undefined>;

--- a/apps/web/modules/survey/link/page.tsx
+++ b/apps/web/modules/survey/link/page.tsx
@@ -9,6 +9,7 @@ import { SurveyInactive } from "@/modules/survey/link/components/survey-inactive
 import { renderSurvey } from "@/modules/survey/link/components/survey-renderer";
 import { getResponseBySingleUseId, getSurveyWithMetadata } from "@/modules/survey/link/lib/data";
 import { checkAndValidateSingleUseId } from "@/modules/survey/link/lib/helper";
+import { getPrefillResponseDataFromToken } from "@/modules/survey/link/lib/prefill-survey-link";
 import type { TLinkSurveySearchParams } from "@/modules/survey/link/lib/types";
 import { getWorkspaceContextForLinkSurvey } from "@/modules/survey/link/lib/workspace";
 import { getMetadataForLinkSurvey } from "@/modules/survey/link/metadata";
@@ -101,14 +102,19 @@ export const LinkSurveyPage = async (props: LinkSurveyPageProps) => {
     singleUseId = validatedSingleUseId;
   }
 
+  // Resolve prefill token (best-effort) alongside the other data fetches
+  const prefillToken = typeof searchParams.prefillToken === "string" ? searchParams.prefillToken : undefined;
+
   // Stage 2: Parallel fetch of all remaining data
-  const [workspaceContext, locale, singleUseResponse] = await Promise.all([
+  const [workspaceContext, locale, singleUseResponse, prefillResponseData] = await Promise.all([
     getWorkspaceContextForLinkSurvey(survey.workspaceId),
     findMatchingLocale(),
     // Only fetch single-use response if we have a validated ID
     isSingleUseSurvey && singleUseId
       ? getResponseBySingleUseId(survey.id, singleUseId)()
       : Promise.resolve(undefined),
+    // Only resolve prefill data if a prefill token is present
+    prefillToken ? getPrefillResponseDataFromToken(prefillToken, survey) : Promise.resolve(undefined),
   ]);
 
   // Fetch responseCount only if needed (depends on survey config)
@@ -127,5 +133,6 @@ export const LinkSurveyPage = async (props: LinkSurveyPageProps) => {
     workspaceContext,
     locale,
     responseCount,
+    prefillResponseData,
   });
 };


### PR DESCRIPTION
## What & why

Adds a way to open a link survey **prefilled from a previous response**, requested by a self-hosted customer whose flow is: fetch a user's latest response via the API → prefill a new survey with it → submit → delete the old one (a workaround for editing submitted registrations). URL prefill already exists, but it can't express complex question types (Address, Date, Ranking, Matrix, Contact Info, …), which is exactly what they need.

The naive version they suggested — `/s/{surveyId}?prefillFromResponse={responseId}` — would be a data leak: it turns a `responseId` (an identifier that legitimately appears in API payloads, webhooks, exports, and admin URLs, and would now travel in shareable URLs, proxy logs, and `Referer` headers) into an **unauthenticated bearer credential** for another person's full answers. Today, reading a response's `data` requires an API key (management API); there is no public read-by-id. This PR keeps that invariant.

## How it works

1. **Mint (authorized):** `GET /api/v1/management/responses/{responseId}/prefill-link` — API-key protected, reuses the same auth/permission check as the other response endpoints. Returns a link containing a signed, encrypted, expiring token (JWT over the **encrypted** `responseId` + `surveyId`, `HS256`). Optional `expirationDays` query param; defaults to **7 days**.
2. **Consume:** `/s/{surveyId}?prefillToken={jwt}` — the token is verified & decrypted **server-side**, the response is loaded, and the survey is prefilled from its stored `data`. The token's survey and the response's survey must both match the visited survey.

Because only an API-key holder can mint a token, only callers already authorized to read the response can create a prefill link. The raw `responseId` never appears in the URL, the token can't be forged without `ENCRYPTION_KEY`, and it expires.

This mirrors the existing **contact survey link** (`/c/{jwt}`) pattern; the token verify pins `algorithms: ["HS256"]` (a small hardening over the contact-link verifier).

### Example

```bash
curl -H "x-api-key: $KEY" \
  "https://app.example.com/api/v1/management/responses/$RESPONSE_ID/prefill-link?expirationDays=3"
# -> { "data": { "prefillSurveyUrl": "https://app.example.com/s/<surveyId>?prefillToken=<jwt>", "expirationDays": 3 } }
```

## Notes / behavior

- **Solves the complex-types problem for free:** because the stored response `data` is already in the internal format, *every* question type is prefilled — including the ones that can't be encoded as URL params.
- **File-upload answers are stripped** (they hold storage keys, not reusable answers).
- **Best-effort:** an invalid/expired/mismatched token silently renders the empty survey (logged server-side) rather than erroring.
- Works with the existing PIN and verify-email gates (threaded through `PinScreen`).
- A prefill token takes precedence over URL query-param prefill.
- Refactor: extracted the shared `fetchAndAuthorizeResponse` into `lib/authorize.ts` and reused it from the responses route and the new endpoint.

## Testing

- New unit tests for `prefill-survey-link.ts` (mint URL/expiry/missing-key, verify happy-path/pinned-algorithm/invalid/expired/incomplete, file-upload stripping, and token→data resolution incl. survey-mismatch / missing-response / cross-survey guards) — 13 tests, passing.
- `tsc` clean on all touched files; ESLint clean.

## Explicitly out of scope (possible follow-ups)

- **Edit-on-submit** (overwrite the original response instead of create-new + delete-old) — the bigger lift the customer would ultimately benefit from; the public `PUT` deliberately blocks finished responses.
- Auto-appending single-use `suId`/`suToken` to the minted link.
- Porting the endpoint to the v2 management API.
- Docs page for the feature.
