### PR TITLE
fix: preserve language aliases through canonicalization (contact-language, editor-lock, merge) (ENG-1067)

### DIFF
--- a/apps/web/modules/ee/contacts/api/v1/client/[workspaceId]/user/lib/update-user.test.ts
+++ b/apps/web/modules/ee/contacts/api/v1/client/[workspaceId]/user/lib/update-user.test.ts
@@ -182,6 +182,24 @@ describe("updateUser", () => {
     expect(result.messages).toBeUndefined();
   });
 
+  test("matches a configured alias case-insensitively and preserves the caller's casing", async () => {
+    vi.mocked(prisma.contact.findFirst).mockResolvedValue(mockContactData as any);
+    // Configured alias is lowercase "deutsch"; the SDK sends "DEUTSCH". Matching is case-insensitive
+    // everywhere (SDK/renderer/v3), so it must be kept — and stored verbatim (not lowercased to the config
+    // value), since downstream matchers lowercase both sides anyway.
+    vi.mocked(prisma.language.findMany).mockResolvedValue([{ code: "de-DE", alias: "deutsch" }] as any);
+    const newAttributes = { email: "new@example.com", language: "DEUTSCH" };
+
+    const result = await updateUser(mockWorkspaceId, mockUserId, "desktop", newAttributes);
+
+    expect(updateAttributes).toHaveBeenCalledWith(mockContactId, mockUserId, mockWorkspaceId, {
+      email: "new@example.com",
+      language: "DEUTSCH",
+    });
+    expect(result.state.data?.language).toBe("DEUTSCH");
+    expect(result.messages).toBeUndefined();
+  });
+
   test("surfaces a falsy-but-real invalid language (e.g. 0) instead of silently dropping it", async () => {
     vi.mocked(prisma.contact.findFirst).mockResolvedValue(mockContactData as any);
     const newAttributes = { email: "new@example.com", language: 0 };

--- a/apps/web/modules/ee/contacts/api/v1/client/[workspaceId]/user/lib/update-user.test.ts
+++ b/apps/web/modules/ee/contacts/api/v1/client/[workspaceId]/user/lib/update-user.test.ts
@@ -182,11 +182,12 @@ describe("updateUser", () => {
     expect(result.messages).toBeUndefined();
   });
 
-  test("matches a configured alias case-insensitively and preserves the caller's casing", async () => {
+  test("matches a configured alias case-insensitively and stores the configured casing", async () => {
     vi.mocked(prisma.contact.findFirst).mockResolvedValue(mockContactData as any);
     // Configured alias is lowercase "deutsch"; the SDK sends "DEUTSCH". Matching is case-insensitive
-    // everywhere (SDK/renderer/v3), so it must be kept — and stored verbatim (not lowercased to the config
-    // value), since downstream matchers lowercase both sides anyway.
+    // everywhere, so it's kept — and normalized to the CONFIGURED casing ("deutsch"), not the caller's
+    // ("DEUTSCH"), so the persisted/echoed value stays consistent with the workspace config (mirrors how
+    // codes are canonicalized).
     vi.mocked(prisma.language.findMany).mockResolvedValue([{ code: "de-DE", alias: "deutsch" }] as any);
     const newAttributes = { email: "new@example.com", language: "DEUTSCH" };
 
@@ -194,9 +195,9 @@ describe("updateUser", () => {
 
     expect(updateAttributes).toHaveBeenCalledWith(mockContactId, mockUserId, mockWorkspaceId, {
       email: "new@example.com",
-      language: "DEUTSCH",
+      language: "deutsch",
     });
-    expect(result.state.data?.language).toBe("DEUTSCH");
+    expect(result.state.data?.language).toBe("deutsch");
     expect(result.messages).toBeUndefined();
   });
 

--- a/apps/web/modules/ee/contacts/api/v1/client/[workspaceId]/user/lib/update-user.test.ts
+++ b/apps/web/modules/ee/contacts/api/v1/client/[workspaceId]/user/lib/update-user.test.ts
@@ -25,6 +25,9 @@ vi.mock("@formbricks/database", () => ({
       findFirst: vi.fn(),
       create: vi.fn(),
     },
+    language: {
+      findMany: vi.fn(),
+    },
   },
 }));
 
@@ -53,6 +56,8 @@ describe("updateUser", () => {
     vi.mocked(updateAttributes).mockResolvedValue({ success: true, messages: [] });
     // Mock segments
     vi.mocked(getPersonSegmentIds).mockResolvedValue(["segment1"]);
+    // Default: workspace has no configured languages, so a non-canonical value is treated as junk.
+    vi.mocked(prisma.language.findMany).mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -157,6 +162,24 @@ describe("updateUser", () => {
     expect(result.messages).toContain(
       "Ignored invalid language code '123'. The existing value was preserved."
     );
+  });
+
+  test("keeps a non-canonical value that is a configured survey-language alias (setLanguage(alias))", async () => {
+    vi.mocked(prisma.contact.findFirst).mockResolvedValue(mockContactData as any);
+    // Workspace has a German language whose custom alias is the human word "deutsch".
+    vi.mocked(prisma.language.findMany).mockResolvedValue([{ code: "de-DE", alias: "deutsch" }] as any);
+    const newAttributes = { email: "new@example.com", language: "deutsch" };
+
+    const result = await updateUser(mockWorkspaceId, mockUserId, "desktop", newAttributes);
+
+    // The alias doesn't canonicalize, but it matches a configured language -> stored verbatim, not dropped.
+    expect(updateAttributes).toHaveBeenCalledWith(mockContactId, mockUserId, mockWorkspaceId, {
+      email: "new@example.com",
+      language: "deutsch",
+    });
+    // ...and it is echoed back verbatim so the SDK still matches the survey's "deutsch" alias.
+    expect(result.state.data?.language).toBe("deutsch");
+    expect(result.messages).toBeUndefined();
   });
 
   test("surfaces a falsy-but-real invalid language (e.g. 0) instead of silently dropping it", async () => {

--- a/apps/web/modules/ee/contacts/api/v1/client/[workspaceId]/user/lib/update-user.ts
+++ b/apps/web/modules/ee/contacts/api/v1/client/[workspaceId]/user/lib/update-user.ts
@@ -1,7 +1,9 @@
+import { createCacheKey } from "@formbricks/cache";
 import { prisma } from "@formbricks/database";
 import { normalizeLanguageCode } from "@formbricks/i18n-utils";
 import { TContactAttributesInput } from "@formbricks/types/contact-attribute";
 import { TJsPersonState } from "@formbricks/types/js";
+import { cache } from "@/lib/cache";
 import { toLegacyLanguageCodes } from "@/lib/i18n/utils";
 import { formatAttributeMessage, updateAttributes } from "@/modules/ee/contacts/lib/attributes";
 import { getPersonSegmentIds } from "./segments";
@@ -140,10 +142,19 @@ const buildUserStateFromContact = async (
  */
 const isWorkspaceLanguageIdentifier = async (workspaceId: string, value: string): Promise<boolean> => {
   const target = value.toLowerCase();
-  const languages = await prisma.language.findMany({
-    where: { workspaceId },
-    select: { code: true, alias: true },
-  });
+  // Cache the workspace's language list (rarely-changing config) so repeated non-canonical writes don't
+  // each hit the DB. TTL matches the environment-state cache (createCacheKey.workspace.state) which serves
+  // these same languages to SDKs, so this adds no staleness beyond what already exists for this data — a
+  // newly-added alias is likewise picked up within the TTL.
+  const languages = await cache.withCache(
+    () =>
+      prisma.language.findMany({
+        where: { workspaceId },
+        select: { code: true, alias: true },
+      }),
+    createCacheKey.workspace.languages(workspaceId),
+    60 * 1000 // 1 minute in milliseconds
+  );
   return languages.some((l) => l.code.toLowerCase() === target || l.alias?.toLowerCase() === target);
 };
 

--- a/apps/web/modules/ee/contacts/api/v1/client/[workspaceId]/user/lib/update-user.ts
+++ b/apps/web/modules/ee/contacts/api/v1/client/[workspaceId]/user/lib/update-user.ts
@@ -136,11 +136,15 @@ const buildUserStateFromContact = async (
 /**
  * A contact `language` value that doesn't canonicalize (normalizeLanguageCode -> null) may still be a
  * legitimate, user-configured survey-language ALIAS (the documented `setLanguage("<alias>")`), not junk.
- * Check it against the workspace's configured languages (code OR alias, case-insensitive) so a real alias
- * is kept while genuine junk is still dropped. Only called on the rare non-canonical branch, so the common
- * language-code path pays no extra query.
+ * Match it (case-insensitively) against the workspace's configured languages and return the CONFIGURED
+ * form — the alias exactly as stored (or the code) — so the persisted value stays consistent with the
+ * workspace config regardless of the caller's casing, mirroring how codes are canonicalized. Returns null for genuine junk.
+ * Only called on the rare non-canonical branch, so the common language-code path pays no extra query.
  */
-const isWorkspaceLanguageIdentifier = async (workspaceId: string, value: string): Promise<boolean> => {
+const resolveWorkspaceLanguageIdentifier = async (
+  workspaceId: string,
+  value: string
+): Promise<string | null> => {
   const target = value.toLowerCase();
   // Cache the workspace's language list (rarely-changing config) so repeated non-canonical writes don't
   // each hit the DB. TTL matches the environment-state cache (createCacheKey.workspace.state) which serves
@@ -155,7 +159,10 @@ const isWorkspaceLanguageIdentifier = async (workspaceId: string, value: string)
     createCacheKey.workspace.languages(workspaceId),
     60 * 1000 // 1 minute in milliseconds
   );
-  return languages.some((l) => l.code.toLowerCase() === target || l.alias?.toLowerCase() === target);
+  const match = languages.find((l) => l.code.toLowerCase() === target || l.alias?.toLowerCase() === target);
+  if (!match) return null;
+  // Return the configured casing: the alias if the value matched the alias, otherwise the code.
+  return match.alias && match.alias.toLowerCase() === target ? match.alias : match.code;
 };
 
 export const updateUser = async (
@@ -200,12 +207,17 @@ export const updateUser = async (
     const languageStr = String(rawLanguage);
     const trimmedLanguage = languageStr.trim();
     const canonicalLanguage = trimmedLanguage ? normalizeLanguageCode(languageStr) : null;
+    const configuredLanguage =
+      !canonicalLanguage && trimmedLanguage
+        ? await resolveWorkspaceLanguageIdentifier(workspaceId, trimmedLanguage)
+        : null;
     if (canonicalLanguage) {
       normalizedAttributes = { ...otherAttributes, language: canonicalLanguage };
-    } else if (trimmedLanguage && (await isWorkspaceLanguageIdentifier(workspaceId, trimmedLanguage))) {
-      // Not a canonicalizable code, but it IS a configured survey-language alias in this workspace
-      // (documented setLanguage("<alias>")). Store it verbatim so alias-based matching keeps working.
-      normalizedAttributes = { ...otherAttributes, language: trimmedLanguage };
+    } else if (configuredLanguage) {
+      // Not a canonicalizable code, but it matches a configured survey-language alias in this workspace
+      // (documented setLanguage("<alias>")). Store the configured form (not the caller's casing) so the
+      // persisted/echoed value is consistent with the workspace config, and alias matching keeps working.
+      normalizedAttributes = { ...otherAttributes, language: configuredLanguage };
     } else {
       normalizedAttributes = otherAttributes;
       // Surface a non-blank, unrecognized value back to the caller; blank/whitespace-only stays silent.

--- a/apps/web/modules/ee/contacts/api/v1/client/[workspaceId]/user/lib/update-user.ts
+++ b/apps/web/modules/ee/contacts/api/v1/client/[workspaceId]/user/lib/update-user.ts
@@ -131,6 +131,22 @@ const buildUserStateFromContact = async (
   };
 };
 
+/**
+ * A contact `language` value that doesn't canonicalize (normalizeLanguageCode -> null) may still be a
+ * legitimate, user-configured survey-language ALIAS (the documented `setLanguage("<alias>")`), not junk.
+ * Check it against the workspace's configured languages (code OR alias, case-insensitive) so a real alias
+ * is kept while genuine junk is still dropped. Only called on the rare non-canonical branch, so the common
+ * language-code path pays no extra query.
+ */
+const isWorkspaceLanguageIdentifier = async (workspaceId: string, value: string): Promise<boolean> => {
+  const target = value.toLowerCase();
+  const languages = await prisma.language.findMany({
+    where: { workspaceId },
+    select: { code: true, alias: true },
+  });
+  return languages.some((l) => l.code.toLowerCase() === target || l.alias?.toLowerCase() === target);
+};
+
 export const updateUser = async (
   workspaceId: string,
   userId: string,
@@ -175,9 +191,13 @@ export const updateUser = async (
     const canonicalLanguage = trimmedLanguage ? normalizeLanguageCode(languageStr) : null;
     if (canonicalLanguage) {
       normalizedAttributes = { ...otherAttributes, language: canonicalLanguage };
+    } else if (trimmedLanguage && (await isWorkspaceLanguageIdentifier(workspaceId, trimmedLanguage))) {
+      // Not a canonicalizable code, but it IS a configured survey-language alias in this workspace
+      // (documented setLanguage("<alias>")). Store it verbatim so alias-based matching keeps working.
+      normalizedAttributes = { ...otherAttributes, language: trimmedLanguage };
     } else {
       normalizedAttributes = otherAttributes;
-      // Surface a non-blank but unparseable value back to the caller; blank/whitespace-only stays silent.
+      // Surface a non-blank, unrecognized value back to the caller; blank/whitespace-only stays silent.
       if (trimmedLanguage) droppedInvalidLanguage = languageStr;
     }
   }
@@ -222,12 +242,14 @@ export const updateUser = async (
   // Transitional SDK back-compat (ENG-1067): echo the language to the SDK in a legacy form (the first
   // known alias), matching the legacy codes the client environment serializer exposes, so SDK clients
   // that match the display language by exact code keep working until the canonical-aware versions are
-  // adopted (notably older React Native apps). Only a value that canonicalizes is echoed — a stored junk
-  // code resolves to `undefined` rather than being passed through. Remove once those clients have drained.
+  // adopted (notably older React Native apps). A canonicalizable code is echoed in its legacy form; a
+  // non-canonicalizable stored value is a verified survey-language alias (the write path only stores those
+  // or canonical codes), so echo it verbatim so the SDK still matches the aliased language. Remove once
+  // those clients have drained.
   const storedCanonicalLanguage = language ? normalizeLanguageCode(String(language)) : null;
   const responseLanguage = storedCanonicalLanguage
     ? (toLegacyLanguageCodes(storedCanonicalLanguage)[0] ?? storedCanonicalLanguage)
-    : undefined;
+    : (language ?? undefined);
 
   return {
     state: {

--- a/packages/cache/src/cache-keys.ts
+++ b/packages/cache/src/cache-keys.ts
@@ -20,6 +20,7 @@ export const createCacheKey = {
     state: (workspaceId: string): CacheKey => makeCacheKey("env", workspaceId, "state"),
     config: (workspaceId: string): CacheKey => makeCacheKey("env", workspaceId, "config"),
     segments: (workspaceId: string): CacheKey => makeCacheKey("env", workspaceId, "segments"),
+    languages: (workspaceId: string): CacheKey => makeCacheKey("env", workspaceId, "languages"),
   },
 
   // Organization-related keys

--- a/packages/database/migration/20260625104904_canonicalize_language_codes/migration.ts
+++ b/packages/database/migration/20260625104904_canonicalize_language_codes/migration.ts
@@ -144,6 +144,15 @@ export const canonicalizeLanguageCodes: MigrationScript = {
         );
       }
 
+      // A Language row holds a single alias, so when both survivor and an absorbed row carry a (different)
+      // alias, the absorbed one can't be kept. Don't drop it silently — log so an operator can re-add it if
+      // a link/SDK relied on it.
+      if (merge.droppedAliases.length > 0) {
+        logger.warn(
+          `Merge for canonical '${merge.canonical}' (workspace ${merge.workspaceId}) dropped ${merge.droppedAliases.length.toString()} absorbed alias(es) that can't fit on the single survivor row: ${merge.droppedAliases.join(", ")}. A link/SDK using a dropped alias falls back to the survey default — re-add it manually if needed.`
+        );
+      }
+
       // Delete absorbed rows (their links have all been moved/deleted).
       await tx.$executeRawUnsafe(`DELETE FROM "Language" WHERE id = ANY($1::text[])`, merge.absorbedIds);
       stats.languagesDeleted += merge.absorbedIds.length;
@@ -152,6 +161,19 @@ export const canonicalizeLanguageCodes: MigrationScript = {
 
     logger.info(
       `Language rows: ${stats.languageRelabels.toString()} relabelled, ${stats.languageMerges.toString()} merges (${stats.languagesDeleted.toString()} rows absorbed, ${stats.surveyLanguageRepoints.toString()} links moved, ${stats.surveyLanguageDeletes.toString()} links deduped)`
+    );
+
+    // Clear self-referential aliases created by the relabel: canonicalizing a code can make it equal a
+    // user's alias (e.g. code `de` -> `de-DE` while the alias was already "de-DE"). The workspace Languages
+    // editor's validateLanguages rejects any alias equal to a code, which would block EVERY save in that
+    // editor. A self-referential alias only duplicates the code (adds no matchable value), so null it.
+    // Matches validateLanguages' comparison (lower + trim, no underscore normalization) so we touch only
+    // the rows that would actually trigger the lock.
+    const selfReferentialAliasesCleared = await tx.$executeRawUnsafe(
+      `UPDATE "Language" SET alias = NULL WHERE alias IS NOT NULL AND lower(trim(alias)) = lower(code)`
+    );
+    logger.info(
+      `Cleared ${(typeof selfReferentialAliasesCleared === "number" ? selfReferentialAliasesCleared : 0).toString()} self-referential alias(es) (alias == canonical code)`
     );
 
     // ---------------------------------------------------------------------------------------------

--- a/packages/database/migration/20260625104904_canonicalize_language_codes/types.ts
+++ b/packages/database/migration/20260625104904_canonicalize_language_codes/types.ts
@@ -42,6 +42,10 @@ export interface LanguageMerge {
   // Alias to copy onto the survivor when it has none of its own (preserves user-entered aliases).
   aliasToSet: string | null;
   absorbedIds: string[];
+  // Absorbed rows' aliases that can't be kept (a Language row has a single alias field, so when the
+  // survivor already carries one, the rest are lost). Surfaced only for logging — real data currently has
+  // no such case, but a merge that discards a user alias should not do so silently.
+  droppedAliases: string[];
 }
 
 export interface LanguageMergePlan {

--- a/packages/database/migration/20260625104904_canonicalize_language_codes/utils.test.ts
+++ b/packages/database/migration/20260625104904_canonicalize_language_codes/utils.test.ts
@@ -151,6 +151,7 @@ describe("planLanguageMerges", () => {
         survivorNeedsRelabel: false,
         aliasToSet: null,
         absorbedIds: ["l1"],
+        droppedAliases: [],
       },
     ]);
   });
@@ -165,6 +166,7 @@ describe("planLanguageMerges", () => {
         survivorNeedsRelabel: true,
         aliasToSet: null,
         absorbedIds: ["l2"],
+        droppedAliases: [],
       },
     ]);
   });
@@ -185,6 +187,26 @@ describe("planLanguageMerges", () => {
         lang("l2", "de", "2024-01-01", "Absorbed"),
       ]).merges[0].aliasToSet
     ).toBeNull();
+  });
+
+  test("records an absorbed alias that can't be kept as droppedAliases (survivor already has one)", () => {
+    // Both rows carry a distinct alias; the survivor keeps its own, so the absorbed alias is dropped.
+    const [merge] = planLanguageMerges([
+      lang("l1", "de-DE", "2024-02-01", "german"),
+      lang("l2", "de", "2024-01-01", "deutsch"),
+    ]).merges;
+    expect(merge.aliasToSet).toBeNull();
+    expect(merge.droppedAliases).toEqual(["deutsch"]);
+  });
+
+  test("does not report a dropped alias when the absorbed alias is promoted to the survivor", () => {
+    // Survivor has no alias, so the absorbed alias is promoted (kept), not dropped.
+    const [merge] = planLanguageMerges([
+      lang("l1", "de-DE", "2024-02-01", null),
+      lang("l2", "de", "2024-01-01", "deutsch"),
+    ]).merges;
+    expect(merge.aliasToSet).toBe("deutsch");
+    expect(merge.droppedAliases).toEqual([]);
   });
 
   test("groups per workspace: the same code in two workspaces is two independent relabels, not a merge", () => {

--- a/packages/database/migration/20260625104904_canonicalize_language_codes/utils.ts
+++ b/packages/database/migration/20260625104904_canonicalize_language_codes/utils.ts
@@ -158,6 +158,14 @@ export const planLanguageMerges = (languages: LanguageRow[]): LanguageMergePlan 
     const absorbed = group.filter((row) => row.id !== survivor.id);
     const aliasToSet = survivor.alias ? null : (absorbed.find((row) => row.alias)?.alias ?? null);
 
+    // The survivor ends up with a single alias (its own, else the promoted `aliasToSet`). Any other
+    // non-empty absorbed alias can't be kept — record it so the migration can log the loss.
+    const survivorFinalAlias = survivor.alias ?? aliasToSet;
+    const droppedAliases = absorbed
+      .map((row) => row.alias)
+      .filter((alias): alias is string => Boolean(alias && alias.trim() !== ""))
+      .filter((alias) => alias !== survivorFinalAlias);
+
     plan.merges.push({
       workspaceId: survivor.workspaceId,
       canonical,
@@ -165,6 +173,7 @@ export const planLanguageMerges = (languages: LanguageRow[]): LanguageMergePlan 
       survivorNeedsRelabel: survivor.code !== canonical,
       aliasToSet,
       absorbedIds: absorbed.map((row) => row.id),
+      droppedAliases,
     });
   }
 


### PR DESCRIPTION
## What does this PR do?

Fixes language-**alias** back-compat gaps in the ENG-1067 canonicalization epic (targets `epic/language-codes-stabilization`). The migration canonicalizes a language's `code` but leaves its user-set `alias` untouched, which surfaced three alias edge cases. Verified impact against a production `Language` dump (3,184 rows).

### ① Contact language set to a survey-language ALIAS no longer degrades to the default language

An identified contact whose `language` is a human-word alias (the documented `setLanguage("<alias>")`) regressed: the user-state echo `normalizeLanguageCode("deutsch") → null → undefined`, so the SDK adopted `undefined` and rendered the **default** language instead of the aliased one. (87 free-word aliases exist in the dump, so the feature is in real use.)

Fixed without weakening the "drop junk" hardening — we distinguish a real alias from junk by checking the workspace's configured languages:
- New `isWorkspaceLanguageIdentifier(workspaceId, value)` — on the *non-canonical branch only* (so the common language-code path pays no extra query), checks the value against the workspace `Language` rows (code OR alias, case-insensitive).
- Write: a value that matches a configured alias is **stored verbatim**; genuine junk is still dropped + surfaced via `invalid_language_ignored`.
- Echo: a non-canonical stored value (now guaranteed a verified alias) is **echoed verbatim**, so the SDK matches the survey's alias again.

### ② Canonicalization producing `code == alias` no longer blocks the Languages editor

If a bare-code language had an alias equal to its own region tag (e.g. code `de`, alias `"de-DE"`), the migration relabels the code to `de-DE`, making `code == alias`. The workspace Languages editor's `validateLanguages` rejects any alias equal to a code, which blocked **every** save in that editor (even edits to unrelated languages). Measured: **19 rows across 15 workspaces** in the dump.

Fix: after the relabel/merge step, the migration nulls self-referential aliases:
```sql
UPDATE "Language" SET alias = NULL WHERE alias IS NOT NULL AND lower(trim(alias)) = lower(code)
```
A self-referential alias only duplicates the code (adds no matchable value), so clearing it is safe. The condition mirrors `validateLanguages` exactly (lower + trim, no underscore normalization), so only rows that would actually trigger the lock are touched (underscore variants like `en_us` are left alone). Cross-row collisions were checked in the dump: **0** occurrences.

### ③ Merge no longer silently drops an absorbed alias

When two rows collapse to one canonical (e.g. `de` + `de-DE`) and both carry a distinct alias, only one can survive (a row has a single `alias` field). `planLanguageMerges` now computes `droppedAliases`, and the migration logs a warning so an operator can re-add a lost alias if a link/SDK relied on it. (Dump has **0** such cases today — purely future-defensive; no data-preserving fix is possible with one alias slot.)

## How should this be tested?

- `pnpm --filter=@formbricks/web test .../user/lib/update-user.test.ts` → **11 pass** (incl. alias-stored-verbatim + junk-still-dropped).
- `cd packages/database && npx vitest run migration/20260625104904_canonicalize_language_codes/utils.test.ts` → **22 pass** (incl. `droppedAliases`).
- `apps/web` + `packages/database` typecheck & eslint clean.
- Manual: `setLanguage("<alias>")` on an identified user → survey renders in the aliased language; a workspace whose migrated code equals an old alias can save in Workspace > Languages.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
