### PR TITLE
fix: redirect legacy /app-connection path to settings page

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/app-connection/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/app-connection/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from "next/navigation";
+import { workspaceSettingsPath } from "@/modules/settings/lib/routes";
+
+// Legacy redirect: the app-connection page lives under settings, but older links (bookmarks,
+// external references, stale clients) point at the bare /workspaces/[workspaceId]/app-connection
+// path. Keep that URL working by redirecting it to the canonical settings location.
+const Page = async (props: Readonly<{ params: Promise<{ workspaceId: string }> }>) => {
+  const params = await props.params;
+  return redirect(workspaceSettingsPath(params.workspaceId, "app-connection"));
+};
+
+export default Page;


### PR DESCRIPTION
## What

Adds a redirect route so that the bare path `/workspaces/[workspaceId]/app-connection` always resolves to the canonical settings location `/workspaces/[workspaceId]/settings/workspace/app-connection`.

## Why

The app-connection page lives under **Settings**. Every in-app link already points to the correct settings path, but the bare `/workspaces/[workspaceId]/app-connection` URL (from bookmarks, external links, or stale clients) currently 404s. This makes that URL always land on the right page.

## How

New route at `app/(app)/workspaces/[workspaceId]/app-connection/page.tsx` that `redirect()`s to `workspaceSettingsPath(workspaceId, "app-connection")`, matching the existing redirect idiom used by `settings/page.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)