### PR TITLE
feat(workflows): reconcile stuck running workflow runs [ENG-1656]

### DIFF
--- a/apps/web/modules/workflows/lib/runner/process-workflow-run-job.ts
+++ b/apps/web/modules/workflows/lib/runner/process-workflow-run-job.ts
@@ -333,7 +333,9 @@ const claimAndSendStep = async (
  * Sentinel: another live delivery (or a stalled prior attempt) owns this run. The current execution
  * must stop and leave the run `running` rather than finalize it — otherwise a second worker could
  * `complete` the run while the owner's in-flight send is still resolving (possibly to `failed`),
- * masking the failure. The owner finishes the run; a future orphan-reconciler recovers a truly stuck one.
+ * masking the failure. The owner finishes the run; a truly stuck one is recovered by the
+ * execution-side reconciler (`reconcile-stuck-running-runs.ts`), which fails the run and skips its
+ * orphaned steps.
  */
 const STEP_BAIL = Symbol("workflow-step-bail");
 

--- a/apps/web/modules/workflows/lib/runner/process-workflow-run-reconcile-job.test.ts
+++ b/apps/web/modules/workflows/lib/runner/process-workflow-run-reconcile-job.test.ts
@@ -1,14 +1,22 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { processWorkflowRunReconcileJob } from "./process-workflow-run-reconcile-job";
 
-const { reconcileOrphanedWorkflowRuns, dispatchWorkflowRunViaJobs, info, debug } = vi.hoisted(() => ({
+const {
+  reconcileOrphanedWorkflowRuns,
+  reconcileStuckRunningWorkflowRuns,
+  dispatchWorkflowRunViaJobs,
+  info,
+  debug,
+} = vi.hoisted(() => ({
   reconcileOrphanedWorkflowRuns: vi.fn(),
+  reconcileStuckRunningWorkflowRuns: vi.fn(),
   dispatchWorkflowRunViaJobs: vi.fn(),
   info: vi.fn(),
   debug: vi.fn(),
 }));
 
 vi.mock("./reconcile-orphaned-runs", () => ({ reconcileOrphanedWorkflowRuns }));
+vi.mock("./reconcile-stuck-running-runs", () => ({ reconcileStuckRunningWorkflowRuns }));
 vi.mock("./dispatch", () => ({ dispatchWorkflowRunViaJobs }));
 vi.mock("@formbricks/logger", () => ({ logger: { info, debug } }));
 
@@ -22,14 +30,17 @@ const context = {
 
 const data = { scope: "global" } as const;
 
+const noQueuedWork = { scanned: 0, redispatched: 0, agedOutFailed: 0 };
+const noStuckWork = { scanned: 0, recovered: 0, stepsSkipped: 0 };
+
 beforeEach(() => {
   vi.clearAllMocks();
+  reconcileOrphanedWorkflowRuns.mockResolvedValue(noQueuedWork);
+  reconcileStuckRunningWorkflowRuns.mockResolvedValue(noStuckWork);
 });
 
 describe("processWorkflowRunReconcileJob", () => {
-  test("runs the reconciler with the real dispatch port + clock and logs a summary when it re-dispatched", async () => {
-    reconcileOrphanedWorkflowRuns.mockResolvedValue({ scanned: 3, redispatched: 2, agedOutFailed: 0 });
-
+  test("runs both sweeps against one shared clock (queued sweep gets the real dispatch port)", async () => {
     await processWorkflowRunReconcileJob(data, context);
 
     expect(reconcileOrphanedWorkflowRuns).toHaveBeenCalledWith({
@@ -42,11 +53,33 @@ describe("processWorkflowRunReconcileJob", () => {
         scope: "global",
       }),
     });
+    expect(reconcileStuckRunningWorkflowRuns).toHaveBeenCalledWith({
+      now: expect.any(Date),
+      logContext: expect.objectContaining({ jobId: "job_1", scope: "global" }),
+    });
+    // Both sweeps share the same clock instance.
+    const queuedNow = reconcileOrphanedWorkflowRuns.mock.calls[0][0].now;
+    const stuckNow = reconcileStuckRunningWorkflowRuns.mock.calls[0][0].now;
+    expect(stuckNow).toBe(queuedNow);
+  });
+
+  test("logs at info when the queued sweep re-dispatched, carrying both sweep results", async () => {
+    reconcileOrphanedWorkflowRuns.mockResolvedValue({ scanned: 3, redispatched: 2, agedOutFailed: 0 });
+
+    await processWorkflowRunReconcileJob(data, context);
+
     expect(info).toHaveBeenCalledTimes(1);
+    expect(info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queued: { scanned: 3, redispatched: 2, agedOutFailed: 0 },
+        stuckRunning: noStuckWork,
+      }),
+      expect.any(String)
+    );
     expect(debug).not.toHaveBeenCalled();
   });
 
-  test("logs at info when only aged-out runs were failed", async () => {
+  test("logs at info when only aged-out (queued) runs were failed", async () => {
     reconcileOrphanedWorkflowRuns.mockResolvedValue({ scanned: 1, redispatched: 0, agedOutFailed: 1 });
 
     await processWorkflowRunReconcileJob(data, context);
@@ -55,9 +88,23 @@ describe("processWorkflowRunReconcileJob", () => {
     expect(debug).not.toHaveBeenCalled();
   });
 
-  test("logs at debug when the sweep found nothing", async () => {
-    reconcileOrphanedWorkflowRuns.mockResolvedValue({ scanned: 0, redispatched: 0, agedOutFailed: 0 });
+  test("logs at info when only the stuck-running sweep recovered", async () => {
+    reconcileStuckRunningWorkflowRuns.mockResolvedValue({ scanned: 1, recovered: 1, stepsSkipped: 2 });
 
+    await processWorkflowRunReconcileJob(data, context);
+
+    expect(info).toHaveBeenCalledTimes(1);
+    expect(info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queued: noQueuedWork,
+        stuckRunning: { scanned: 1, recovered: 1, stepsSkipped: 2 },
+      }),
+      expect.any(String)
+    );
+    expect(debug).not.toHaveBeenCalled();
+  });
+
+  test("logs at debug when both sweeps found nothing", async () => {
     await processWorkflowRunReconcileJob(data, context);
 
     expect(debug).toHaveBeenCalledTimes(1);

--- a/apps/web/modules/workflows/lib/runner/process-workflow-run-reconcile-job.ts
+++ b/apps/web/modules/workflows/lib/runner/process-workflow-run-reconcile-job.ts
@@ -28,26 +28,24 @@ export const processWorkflowRunReconcileJob: JobHandler<TWorkflowRunReconcileJob
 
   const now = new Date();
 
-  const queued = await reconcileOrphanedWorkflowRuns({
-    dispatch: dispatchWorkflowRunViaJobs,
-    now,
-    logContext,
-  });
-  const stuckRunning = await reconcileStuckRunningWorkflowRuns({ now, logContext });
+  // Independent sweeps (disjoint status sets: `queued` vs `running`), so run them concurrently. If one
+  // rejects the job fails and BullMQ retries; the sibling's work is not cancelled (its writes are
+  // idempotent/guarded, so a retried tick redoing them is harmless).
+  const [queued, stuckRunning] = await Promise.all([
+    reconcileOrphanedWorkflowRuns({ dispatch: dispatchWorkflowRunViaJobs, now, logContext }),
+    reconcileStuckRunningWorkflowRuns({ now, logContext }),
+  ]);
 
   const acted = queued.redispatched > 0 || queued.agedOutFailed > 0 || stuckRunning.recovered > 0;
 
   if (acted) {
-    // Neutral wording: a sweep may act without re-dispatching (aged-out or stuck-running recovery), so
-    // the message must not claim a re-dispatch — the per-sweep counts in the payload carry the specifics.
-    logger.info(
-      { ...logContext, queued, stuckRunning },
-      "Workflow run reconciliation acted on orphaned runs"
-    );
+    // Neutral wording: the action may be a re-dispatch, an age-out, or a stuck-running recovery — the
+    // per-sweep counts in the payload carry the specifics, so the message claims none of them.
+    logger.info({ ...logContext, queued, stuckRunning }, "Workflow run reconciliation acted");
   } else {
     logger.debug(
       { ...logContext, queued, stuckRunning },
-      "Workflow run reconciliation found no orphaned runs"
+      "Workflow run reconciliation found nothing to reconcile"
     );
   }
 };

--- a/apps/web/modules/workflows/lib/runner/process-workflow-run-reconcile-job.ts
+++ b/apps/web/modules/workflows/lib/runner/process-workflow-run-reconcile-job.ts
@@ -3,12 +3,15 @@ import { type JobHandler, type TWorkflowRunReconcileJobData } from "@formbricks/
 import { logger } from "@formbricks/logger";
 import { dispatchWorkflowRunViaJobs } from "./dispatch";
 import { reconcileOrphanedWorkflowRuns } from "./reconcile-orphaned-runs";
+import { reconcileStuckRunningWorkflowRuns } from "./reconcile-stuck-running-runs";
 
 /**
- * Apps/web handler for the recurring `workflow-run.reconcile` BullMQ job. Sweeps for producer-side
- * orphans (queued runs whose dispatch never landed) and re-dispatches them idempotently via the real
- * BullMQ dispatch port. Logs a summary only when it actually acted, to avoid noise from the (common)
- * empty sweep.
+ * Apps/web handler for the recurring `workflow-run.reconcile` BullMQ job. Runs both runner
+ * reconcilers against one shared clock: the **producer-side** sweep re-dispatches `queued` runs whose
+ * dispatch never landed (idempotent, via the real BullMQ port), and the **execution-side** sweep
+ * marks stale `running` runs `failed` (crash between step claim and send). Logs a summary only when it
+ * actually acted, to avoid noise from the (common) empty sweep. A thrown scan fails the job so BullMQ
+ * retries; the recurring schedule is the backstop.
  */
 export const processWorkflowRunReconcileJob: JobHandler<TWorkflowRunReconcileJobData> = async (
   data,
@@ -23,17 +26,28 @@ export const processWorkflowRunReconcileJob: JobHandler<TWorkflowRunReconcileJob
     scope: data.scope,
   };
 
-  const result = await reconcileOrphanedWorkflowRuns({
+  const now = new Date();
+
+  const queued = await reconcileOrphanedWorkflowRuns({
     dispatch: dispatchWorkflowRunViaJobs,
-    now: new Date(),
+    now,
     logContext,
   });
+  const stuckRunning = await reconcileStuckRunningWorkflowRuns({ now, logContext });
 
-  if (result.redispatched > 0 || result.agedOutFailed > 0) {
-    // Neutral wording: a ceiling-only sweep re-dispatches nothing, so the message must not claim a
-    // re-dispatch — the `redispatched` / `agedOutFailed` counts in the payload carry the specifics.
-    logger.info({ ...logContext, ...result }, "Workflow run reconciliation acted on orphaned runs");
+  const acted = queued.redispatched > 0 || queued.agedOutFailed > 0 || stuckRunning.recovered > 0;
+
+  if (acted) {
+    // Neutral wording: a sweep may act without re-dispatching (aged-out or stuck-running recovery), so
+    // the message must not claim a re-dispatch — the per-sweep counts in the payload carry the specifics.
+    logger.info(
+      { ...logContext, queued, stuckRunning },
+      "Workflow run reconciliation acted on orphaned runs"
+    );
   } else {
-    logger.debug({ ...logContext, ...result }, "Workflow run reconciliation found no orphaned runs");
+    logger.debug(
+      { ...logContext, queued, stuckRunning },
+      "Workflow run reconciliation found no orphaned runs"
+    );
   }
 };

--- a/apps/web/modules/workflows/lib/runner/reconcile-constants.ts
+++ b/apps/web/modules/workflows/lib/runner/reconcile-constants.ts
@@ -21,5 +21,12 @@ export const WORKFLOW_RUN_ORPHAN_MIN_AGE_MS = 2 * 60 * 1000;
  */
 export const WORKFLOW_RUN_ORPHAN_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * A run still `running` with no executor writes for this long is treated as abandoned mid-execution
+ * (crash between step claim and send) and recovered → `failed`. Healthy runs finish in seconds and the
+ * full retry/backoff window is ≲1 min, so 1h is generous enough that no live owner can be racing.
+ */
+export const WORKFLOW_RUN_STUCK_RUNNING_MAX_AGE_MS = 60 * 60 * 1000;
+
 /** Max orphans handled per tick. A larger backlog drains over subsequent ticks (re-dispatch is idempotent). */
 export const WORKFLOW_RUN_RECONCILE_BATCH_SIZE = 250;

--- a/apps/web/modules/workflows/lib/runner/reconcile-orphaned-runs.ts
+++ b/apps/web/modules/workflows/lib/runner/reconcile-orphaned-runs.ts
@@ -28,8 +28,9 @@ export interface ReconcileOrphanedWorkflowRunsResult {
  * re-dispatches them through the same idempotent port (`dispatchWorkflowRunViaJobs`, deterministic
  * `jobId = run.id`): a no-op if a job still exists, a genuine recovery if it was lost.
  *
- * - **Scope:** only real runs (`isDryRun: false`); `running` / `completed` / `failed` / `canceled` are
- *   never touched (execution-failure retry is the executor's concern, not the reconciler's).
+ * - **Scope:** only real runs (`isDryRun: false`); `running` is the sibling sweep's concern
+ *   (`reconcile-stuck-running-runs.ts`), and `completed` / `failed` / `canceled` are terminal and never
+ *   touched (execution-failure retry is the executor's concern, not the reconciler's).
  * - **Ceiling:** a run still `queued` past `WORKFLOW_RUN_ORPHAN_MAX_AGE_MS` is treated as permanently
  *   un-dispatchable and marked `failed` (bounds the loop; surfaces the stuck run) instead of being
  *   re-dispatched forever.

--- a/apps/web/modules/workflows/lib/runner/reconcile-stuck-running-runs.test.ts
+++ b/apps/web/modules/workflows/lib/runner/reconcile-stuck-running-runs.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { reconcileStuckRunningWorkflowRuns } from "./reconcile-stuck-running-runs";
+
+const { runFindMany, runUpdateMany, logUpdateMany } = vi.hoisted(() => ({
+  runFindMany: vi.fn(),
+  runUpdateMany: vi.fn(),
+  logUpdateMany: vi.fn(),
+}));
+const { warn, error } = vi.hoisted(() => ({ warn: vi.fn(), error: vi.fn() }));
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    workflowRun: { findMany: runFindMany, updateMany: runUpdateMany },
+    workflowRunLog: { updateMany: logUpdateMany },
+  },
+}));
+vi.mock("@formbricks/logger", () => ({ logger: { warn, error } }));
+
+const NOW = new Date("2026-07-01T12:00:00.000Z");
+// Stale threshold is 1h (see reconcile-constants). 2h since the last executor write → abandoned.
+const stale = new Date(NOW.getTime() - 2 * 60 * 60 * 1000);
+
+const runRow = (id: string, updatedAt: Date) => ({
+  id,
+  workflowId: `wf_${id}`,
+  workspaceId: `ws_${id}`,
+  startedAt: new Date(updatedAt.getTime() - 60 * 1000),
+  updatedAt,
+});
+
+const reconcile = () => reconcileStuckRunningWorkflowRuns({ now: NOW });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  runUpdateMany.mockResolvedValue({ count: 1 }); // claimed the run for failure
+  logUpdateMany.mockResolvedValue({ count: 2 }); // two orphaned steps skipped
+});
+
+describe("reconcileStuckRunningWorkflowRuns", () => {
+  test("scopes the scan to running, non-dry-run runs stale past the threshold, oldest first and bounded", async () => {
+    runFindMany.mockResolvedValue([]);
+
+    await reconcile();
+
+    const args = runFindMany.mock.calls[0][0];
+    expect(args.where).toMatchObject({ status: "running", isDryRun: false });
+    expect(args.where.updatedAt.lt).toEqual(new Date(NOW.getTime() - 60 * 60 * 1000));
+    expect(args.orderBy).toEqual({ updatedAt: "asc" });
+    expect(args.take).toBe(250);
+  });
+
+  test("recovers a stale run: marks it failed (status-guarded) and skips its orphaned running steps", async () => {
+    runFindMany.mockResolvedValue([runRow("run1", stale)]);
+
+    const result = await reconcile();
+
+    expect(runUpdateMany).toHaveBeenCalledWith({
+      where: { id: "run1", status: "running" },
+      data: expect.objectContaining({ status: "failed", lastErrorAt: NOW, finishedAt: NOW }),
+    });
+    expect(logUpdateMany).toHaveBeenCalledWith({
+      where: { runId: "run1", status: "running" },
+      data: expect.objectContaining({ status: "skipped", finishedAt: NOW }),
+    });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ scanned: 1, recovered: 1, stepsSkipped: 2 });
+  });
+
+  test("leaves a run that lost the status-guard race untouched (owner finalized it concurrently)", async () => {
+    runFindMany.mockResolvedValue([runRow("run1", stale)]);
+    runUpdateMany.mockResolvedValue({ count: 0 }); // run no longer `running`
+
+    const result = await reconcile();
+
+    expect(logUpdateMany).not.toHaveBeenCalled(); // never skip steps of a run we didn't claim
+    expect(warn).not.toHaveBeenCalled();
+    expect(result).toEqual({ scanned: 1, recovered: 0, stepsSkipped: 0 });
+  });
+
+  test("recovers a run that crashed before its first step was claimed (no running steps to skip)", async () => {
+    runFindMany.mockResolvedValue([runRow("run1", stale)]);
+    logUpdateMany.mockResolvedValue({ count: 0 });
+
+    const result = await reconcile();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ scanned: 1, recovered: 1, stepsSkipped: 0 });
+  });
+
+  test("isolates a per-run recovery failure and continues the sweep", async () => {
+    runFindMany.mockResolvedValue([runRow("bad", stale), runRow("good", stale)]);
+    runUpdateMany.mockRejectedValueOnce(new Error("db down")).mockResolvedValue({ count: 1 });
+    logUpdateMany.mockResolvedValue({ count: 1 });
+
+    const result = await reconcile();
+
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ scanned: 2, recovered: 1, stepsSkipped: 1 });
+  });
+
+  test("does nothing when there are no stuck running runs", async () => {
+    runFindMany.mockResolvedValue([]);
+
+    const result = await reconcile();
+
+    expect(runUpdateMany).not.toHaveBeenCalled();
+    expect(logUpdateMany).not.toHaveBeenCalled();
+    expect(result).toEqual({ scanned: 0, recovered: 0, stepsSkipped: 0 });
+  });
+});

--- a/apps/web/modules/workflows/lib/runner/reconcile-stuck-running-runs.test.ts
+++ b/apps/web/modules/workflows/lib/runner/reconcile-stuck-running-runs.test.ts
@@ -98,6 +98,19 @@ describe("reconcileStuckRunningWorkflowRuns", () => {
     expect(result).toEqual({ scanned: 2, recovered: 1, stepsSkipped: 1 });
   });
 
+  test("still counts the run as recovered when the step-skip write fails after a won claim", async () => {
+    // The documented cosmetic gap: run already marked failed, step flip dies. The failed run is
+    // unreachable (terminal-status guard), so the sweep just logs and moves on — no retry, no warn.
+    runFindMany.mockResolvedValue([runRow("run1", stale)]);
+    logUpdateMany.mockRejectedValueOnce(new Error("db down"));
+
+    const result = await reconcile();
+
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+    expect(result).toEqual({ scanned: 1, recovered: 1, stepsSkipped: 0 });
+  });
+
   test("does nothing when there are no stuck running runs", async () => {
     runFindMany.mockResolvedValue([]);
 

--- a/apps/web/modules/workflows/lib/runner/reconcile-stuck-running-runs.ts
+++ b/apps/web/modules/workflows/lib/runner/reconcile-stuck-running-runs.ts
@@ -1,0 +1,134 @@
+import { prisma } from "@formbricks/database";
+import { logger } from "@formbricks/logger";
+import {
+  WORKFLOW_RUN_RECONCILE_BATCH_SIZE,
+  WORKFLOW_RUN_STUCK_RUNNING_MAX_AGE_MS,
+} from "./reconcile-constants";
+
+interface ReconcileStuckRunningWorkflowRunsInput {
+  /** Injected clock for deterministic staleness-threshold tests; defaults to wall-clock. */
+  now?: Date;
+  logContext?: Record<string, unknown>;
+}
+
+export interface ReconcileStuckRunningWorkflowRunsResult {
+  scanned: number;
+  recovered: number;
+  stepsSkipped: number;
+}
+
+/**
+ * Periodic reconciler for the **execution-side orphan**: a `WorkflowRun` stuck `running` after the
+ * executor crashed/stalled between claiming a step (`WorkflowRunLog` row → `running`, written BEFORE
+ * the send) and recording its result. Once that happens the run is wedged: every BullMQ redelivery
+ * sees the `running` step row and bails (`STEP_BAIL`, at-most-once — never re-send), the job completes
+ * without error so no retry fires, and nothing moves the run to a terminal state. This is the
+ * "future orphan-reconciler" the executor defers to (see `process-workflow-run-job.ts`).
+ *
+ * - **Staleness by `updatedAt`, not `startedAt`:** the executor never touches the run row between the
+ *   claim and the terminal write, and a non-final failure bumps `updatedAt` while keeping status
+ *   `running`. So "`running` with no `updatedAt` movement for `WORKFLOW_RUN_STUCK_RUNNING_MAX_AGE_MS`"
+ *   means no executor activity at all — including no in-flight retry (the whole attempts×backoff
+ *   window is ≲1 min, far inside the 1h threshold), so no live owner can be racing.
+ * - **Recover, don't resume:** a stuck run cannot be re-run — its `running` step rows block every
+ *   claim path (a `running` step bails; after this sweep a `skipped` step matches no re-claim
+ *   condition either). The send may or may not have gone out, so we surface the failure rather than
+ *   guess. Recovery = mark the run `failed` (distinct error) so redeliveries no-op on the executor's
+ *   pre-claim terminal-status check.
+ * - **Steps → `skipped`, never `failed`:** the executor re-claims a `failed` step and re-sends it, so
+ *   `failed` here would re-arm a double-send and break at-most-once. `skipped` records "outcome
+ *   unknown, not retried" and matches no claim path.
+ * - **Run-first, then steps:** the run is claimed-for-failure with a status-guarded `updateMany`
+ *   (`status: "running"`); only when we win (`count > 0`) do we touch its steps — so we never skip
+ *   the steps of a run a live owner still holds. A crash between the two writes leaves a `failed` run
+ *   with `running` step rows: cosmetic only, since the terminal-status guard makes those steps
+ *   unreachable forever.
+ * - **Benign overwrite race:** `sendOwnedStep` finalizes a step with an unconditional write by
+ *   `(runId, stepId)`. If an impossibly-slow owner finalizes a step *after* we skipped it, its true
+ *   outcome overwrites our `skipped` — harmless, and combined with the guarded run terminal writes
+ *   (which reject clobbering a `failed` run) every interleaving still yields zero double-sends.
+ * - **`data.steps` mirror not reconstructed:** the run's denormalized step mirror is left as-is; the
+ *   authoritative per-step record is the `WorkflowRunLog` rows this sweep marks `skipped`.
+ * - **Bounded / isolated:** one batch per tick, oldest-first; one run's failure is logged and skipped
+ *   so it never aborts the sweep. Running-state cardinality is tiny, so a backlog is not expected.
+ */
+export const reconcileStuckRunningWorkflowRuns = async ({
+  now = new Date(),
+  logContext,
+}: ReconcileStuckRunningWorkflowRunsInput): Promise<ReconcileStuckRunningWorkflowRunsResult> => {
+  const staleThreshold = new Date(now.getTime() - WORKFLOW_RUN_STUCK_RUNNING_MAX_AGE_MS);
+
+  // Index-assisted by @@index([status, createdAt]) on the `status = 'running'` prefix; running-state
+  // cardinality is tiny (executions are seconds long), so the residual `updatedAt` filter + sort are
+  // cheap. Oldest first so the longest-stuck runs are surfaced first.
+  const stuck = await prisma.workflowRun.findMany({
+    where: {
+      status: "running",
+      isDryRun: false,
+      updatedAt: { lt: staleThreshold },
+    },
+    orderBy: { updatedAt: "asc" },
+    take: WORKFLOW_RUN_RECONCILE_BATCH_SIZE,
+    select: { id: true, workflowId: true, workspaceId: true, startedAt: true, updatedAt: true },
+  });
+
+  let recovered = 0;
+  let stepsSkipped = 0;
+
+  for (const run of stuck) {
+    const runLogContext = {
+      ...logContext,
+      workflowRunId: run.id,
+      workflowId: run.workflowId,
+      workspaceId: run.workspaceId,
+    };
+
+    try {
+      // Claim-for-failure, status-guarded: only a run still `running` is ours to recover. A 0-row
+      // result means the owner finalized it between the scan and here — leave its verdict alone.
+      const failed = await prisma.workflowRun.updateMany({
+        where: { id: run.id, status: "running" },
+        data: {
+          status: "failed",
+          error: "Workflow run was abandoned mid-execution (stale running) and recovered by the reconciler",
+          lastErrorAt: now,
+          finishedAt: now,
+        },
+      });
+
+      if (failed.count === 0) {
+        continue;
+      }
+
+      recovered += 1;
+
+      // Only after we own the failure: flip the orphaned in-flight steps to `skipped` (never `failed`,
+      // which the executor would re-claim and re-send). 0 is legitimate — a crash before the first
+      // step was ever claimed leaves no `running` step rows.
+      const skipped = await prisma.workflowRunLog.updateMany({
+        where: { runId: run.id, status: "running" },
+        data: {
+          status: "skipped",
+          error: "Step outcome unknown: run abandoned mid-execution; not retried (at-most-once)",
+          finishedAt: now,
+        },
+      });
+      stepsSkipped += skipped.count;
+
+      logger.warn(
+        {
+          ...runLogContext,
+          startedAt: run.startedAt,
+          updatedAt: run.updatedAt,
+          stepsSkipped: skipped.count,
+        },
+        "Stuck running workflow run recovered; marked failed"
+      );
+    } catch (error) {
+      // Isolate per run: a single recovery failure must not abort the sweep; the next tick retries.
+      logger.error({ ...runLogContext, err: error }, "Failed to recover stuck running workflow run");
+    }
+  }
+
+  return { scanned: stuck.length, recovered, stepsSkipped };
+};


### PR DESCRIPTION
## What does this PR do?

Closes [ENG-1656](https://linear.app/formbricks/issue/ENG-1656). **Stacked on `feat/ENG-1608_reconcile-orphaned-workflow-runs`** (#8403) — it extends that PR's `workflow-run.reconcile` job, so it's based on #8403's branch and will auto-retarget to `epic/workflows-v1` once #8403 merges. Review #8403 first.

Adds the **execution-side** half of the runner's crash recovery. The queued-orphan reconciler (#8403 / ENG-1608) only recovers runs that were never dispatched. This handles the other stuck state: a run wedged in `running` after the executor crashed/stalled *between* claiming a `send_email` step (the `WorkflowRunLog` row goes `running` **before** the send) and recording its result. Once that happens the run is stuck forever — every redelivery sees the `running` step row and bails (at-most-once, never re-send), the job completes without error so no retry fires, and nothing moves the run to a terminal state. The executor already anticipated this and deferred to "a future orphan-reconciler" (`process-workflow-run-job.ts`) — this is it.

New sweep `reconcileStuckRunningWorkflowRuns`, running in the same `workflow-run.reconcile` tick **concurrently** with the queued sweep (`Promise.all` — they operate on disjoint status sets, `queued` vs `running`, so there's nothing to serialize) and sharing one clock:

- Finds `running`, non-dry-run runs with **no executor activity for 1h** (`updatedAt`). Generous on purpose: healthy runs finish in seconds and the whole retry/backoff window is ≲1 min, so no live owner can be racing. It keys off `updatedAt` (not `startedAt`) because the executor doesn't touch the run row between the claim and the terminal write — but a non-final failure *does* bump `updatedAt` while staying `running`, so `updatedAt` is the true "last activity" signal.
- Marks the run `failed` via a **status-guarded** `updateMany` (`status: "running"`) so a concurrently-finishing owner always wins; only when we win do we flip the orphaned `running` `WorkflowRunLog` rows to **`skipped`** — never `failed`, which the executor would re-claim and re-send (breaking at-most-once). `skipped` matches no claim path, so a stray redelivery just bails.
- **Recover, don't resume:** the email may or may not have gone out — we surface the failure rather than guess and risk a double-send.

No schema/index change (the existing `@@index([status, createdAt])` prefix bounds the scan; `running`-state cardinality is tiny), and no `packages/jobs` or schedule change (same recurring job). Also fixes two now-stale comments (the executor's "future orphan-reconciler" note and the queued sweep's scope bullet).

## How should this be tested?

Unit-tested — no Redis, injected clock + mocked Prisma:

```bash
cd apps/web && pnpm exec vitest run modules/workflows/lib/runner instrumentation-jobs.test.ts   # 87 pass
```

`reconcile-stuck-running-runs.test.ts` covers: scan scoping (`running` / non-dry-run / `updatedAt < now − 1h`, oldest-first, bounded); recovery (run → `failed` status-guarded + steps → `skipped`, warn, counts); the status-guard race (owner finalized concurrently → skip, nothing touched); crash-before-first-step (0 steps skipped, still recovered); the won-claim-then-step-flip-failure path (run still counted recovered, error logged, no warn); per-run failure isolation; empty sweep. The handler test is extended to assert both sweeps run concurrently on one shared clock and the combined info/debug summary.

Manual (needs Redis + a worker): on a real run, `UPDATE "WorkflowRun" SET status='running', updated_at = now() - interval '2 hours'` plus a `running` `WorkflowRunLog` row → within ~3 min the reconciler marks the run `failed`, the step `skipped`, and logs a warn.

Verified locally: 87 runner/instrumentation tests pass, the new/changed files are 100% covered (line + branch), `@formbricks/web` typecheck 0 errors, ESLint clean.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits (the `skipped`-not-`failed` safety, the `updatedAt` staleness signal, the run-first ordering, the benign overwrite race)
- [x] Ran the affected tests + typecheck + lint
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs` (none added)
- [x] Branched off the current base (`feat/ENG-1608_reconcile-orphaned-workflow-runs`)
- [x] My changes don't cause any responsiveness issues (backend job, no UI)
- [ ] First PR at Formbricks? — no

### Appreciated

- [ ] If a UI change was made: screenshots — N/A, backend job
- [ ] Updated the Formbricks Docs — N/A (internal runner recovery)
