### PR TITLE
fix: normalize signup email token creation

### DIFF
--- a/apps/web/modules/auth/actions.test.ts
+++ b/apps/web/modules/auth/actions.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createEmailToken } from "@/lib/jwt";
+import { getUserByEmail } from "@/lib/user/service";
+import { createEmailTokenAction } from "./actions";
+
+vi.mock("@/lib/jwt", () => ({
+  createEmailToken: vi.fn(),
+}));
+
+vi.mock("@/lib/user/service", () => ({
+  getUserByEmail: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/action-client", () => ({
+  actionClient: {
+    inputSchema: vi.fn().mockReturnThis(),
+    action: vi.fn((fn) => fn),
+  },
+}));
+
+describe("createEmailTokenAction", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("normalizes mixed-case email lookup and mints a token for the stored email", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue({ email: "ada@example.com" } as never);
+    vi.mocked(createEmailToken).mockReturnValue("email-token");
+
+    const result = await createEmailTokenAction({
+      parsedInput: { email: "Ada@Example.com" },
+    } as never);
+
+    expect(getUserByEmail).toHaveBeenCalledWith("ada@example.com");
+    expect(createEmailToken).toHaveBeenCalledWith("ada@example.com");
+    expect(result).toBe("email-token");
+  });
+
+  test("rejects token creation when no matching user exists", async () => {
+    vi.mocked(getUserByEmail).mockResolvedValue(null);
+
+    await expect(
+      createEmailTokenAction({
+        parsedInput: { email: "Ada@Example.com" },
+      } as never)
+    ).rejects.toThrow("Invalid request");
+    expect(createEmailToken).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/modules/auth/actions.ts
+++ b/apps/web/modules/auth/actions.ts
@@ -2,26 +2,23 @@
 
 import { z } from "zod";
 import { InvalidInputError } from "@formbricks/types/errors";
+import { ZUserEmail } from "@formbricks/types/user";
 import { createEmailToken } from "@/lib/jwt";
 import { getUserByEmail } from "@/lib/user/service";
 import { actionClient } from "@/lib/utils/action-client";
 
 const ZCreateEmailTokenAction = z.object({
-  email: z
-    .email({
-      error: "Invalid email",
-    })
-    .min(5)
-    .max(255),
+  email: ZUserEmail,
 });
 
 export const createEmailTokenAction = actionClient
   .inputSchema(ZCreateEmailTokenAction)
   .action(async ({ parsedInput }) => {
-    const user = await getUserByEmail(parsedInput.email);
+    const normalizedEmail = parsedInput.email.toLowerCase();
+    const user = await getUserByEmail(normalizedEmail);
     if (!user) {
       throw new InvalidInputError("Invalid request");
     }
 
-    return createEmailToken(parsedInput.email);
+    return createEmailToken(user.email);
   });

--- a/apps/web/modules/auth/signup-without-verification-success/page.tsx
+++ b/apps/web/modules/auth/signup-without-verification-success/page.tsx
@@ -1,3 +1,4 @@
+import { logger } from "@formbricks/logger";
 import { getEmailFromEmailToken } from "@/lib/jwt";
 import { getTranslate } from "@/lingodotdev/server";
 import { BackToLoginButton } from "@/modules/auth/components/back-to-login-button";
@@ -6,15 +7,30 @@ import { FormWrapper } from "@/modules/auth/components/form-wrapper";
 export const SignupWithoutVerificationSuccessPage = async ({
   searchParams,
 }: {
-  searchParams: Promise<{ token: string }>;
+  searchParams: Promise<{ token?: string | string[] }>;
 }) => {
   const t = await getTranslate();
   const { token } = await searchParams;
-  const email = getEmailFromEmailToken(token);
+  let email: string;
+
+  try {
+    if (!token || Array.isArray(token)) {
+      throw new Error("Missing or invalid signup success token");
+    }
+
+    email = getEmailFromEmailToken(token);
+  } catch (error) {
+    logger.error(error, "Invalid signup success token");
+    return (
+      <FormWrapper>
+        <p className="text-center">{t("auth.verification-requested.invalid_token")}</p>
+      </FormWrapper>
+    );
+  }
 
   return (
     <FormWrapper>
-      <h1 className="leading-2 mb-4 text-center font-bold">
+      <h1 className="mb-4 text-center leading-2 font-bold">
         {t("auth.signup_without_verification_success.user_successfully_created")}
       </h1>
       <p className="text-center text-sm">

--- a/apps/web/modules/auth/signup-without-verification-success/page.tsx
+++ b/apps/web/modules/auth/signup-without-verification-success/page.tsx
@@ -6,9 +6,9 @@ import { FormWrapper } from "@/modules/auth/components/form-wrapper";
 
 export const SignupWithoutVerificationSuccessPage = async ({
   searchParams,
-}: {
+}: Readonly<{
   searchParams: Promise<{ token?: string | string[] }>;
-}) => {
+}>) => {
   const t = await getTranslate();
   const { token } = await searchParams;
   let email: string;
@@ -24,6 +24,8 @@ export const SignupWithoutVerificationSuccessPage = async ({
     return (
       <FormWrapper>
         <p className="text-center">{t("auth.verification-requested.invalid_token")}</p>
+        <hr className="my-4" />
+        <BackToLoginButton />
       </FormWrapper>
     );
   }

--- a/apps/web/modules/auth/signup/actions.test.ts
+++ b/apps/web/modules/auth/signup/actions.test.ts
@@ -8,6 +8,12 @@ import { getIsMultiOrgEnabled } from "@/modules/ee/license-check/lib/utils";
 import { subscribeUserToMailingList } from "@/modules/ee/mailing/lib/mailing-subscription";
 import { createUserAction } from "./actions";
 
+vi.mock("@formbricks/logger", () => ({
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
 vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyIPRateLimit: vi.fn() }));
 vi.mock("@/modules/core/rate-limit/rate-limit-configs", () => ({
   rateLimitConfigs: {
@@ -35,15 +41,12 @@ vi.mock("@/modules/ee/mailing/lib/mailing-subscription", () => ({ subscribeUserT
 vi.mock("@/modules/email", () => ({ sendInviteAcceptedEmail: vi.fn() }));
 vi.mock("@/modules/workspaces/settings/lib/workspace", () => ({ createWorkspace: vi.fn() }));
 
-vi.mock("@/lib/constants", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/lib/constants")>();
-  return {
-    ...actual,
-    WEBAPP_URL: "http://localhost:3000",
-    IS_FORMBRICKS_CLOUD: false,
-    IS_TURNSTILE_CONFIGURED: false,
-  };
-});
+vi.mock("@/lib/constants", () => ({
+  WEBAPP_URL: "http://localhost:3000",
+  IS_FORMBRICKS_CLOUD: false,
+  IS_TURNSTILE_CONFIGURED: false,
+  TURNSTILE_SECRET_KEY: undefined,
+}));
 
 vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
   withAuditLogging: vi.fn((_type: string, _object: string, fn: Function) => fn),

--- a/apps/web/modules/auth/signup/components/signup-form.tsx
+++ b/apps/web/modules/auth/signup/components/signup-form.tsx
@@ -112,9 +112,17 @@ export const SignupForm = ({
         throw new Error(t("auth.signup.please_verify_captcha"));
       }
 
+      const resetTurnstileIfConfigured = () => {
+        if (isTurnstileConfigured) {
+          setTurnstileToken(undefined);
+          turnstile.reset();
+        }
+      };
+      const normalizedEmail = data.email.toLowerCase();
+
       const createUserResponse = await createUserAction({
         name: data.name,
-        email: data.email,
+        email: normalizedEmail,
         password: data.password,
         userLocale,
         inviteToken: inviteToken ?? "",
@@ -123,37 +131,33 @@ export const SignupForm = ({
         subscribeToProductUpdates,
       });
 
-      const emailTokenActionResponse = await createEmailTokenAction({ email: data.email });
+      if (!createUserResponse?.data) {
+        resetTurnstileIfConfigured();
+
+        const errorMessage = getFormattedErrorMessage(createUserResponse);
+        toast.error(errorMessage);
+        return;
+      }
+
+      const emailTokenActionResponse = await createEmailTokenAction({ email: normalizedEmail });
       const token = emailTokenActionResponse?.data;
+
+      if (!token) {
+        resetTurnstileIfConfigured();
+
+        const errorMessage = getFormattedErrorMessage(emailTokenActionResponse);
+        toast.error(errorMessage);
+        return;
+      }
 
       const url = emailVerificationDisabled
         ? `/auth/signup-without-verification-success?token=${token}`
         : buildVerificationRequestedPath({
-            token: token ?? "",
+            token,
             callbackUrl: inviteToken ? returnToUrl : undefined,
           });
 
-      if (createUserResponse?.data) {
-        router.push(url);
-
-        if (!emailTokenActionResponse?.data) {
-          if (isTurnstileConfigured) {
-            setTurnstileToken(undefined);
-            turnstile.reset();
-          }
-
-          const errorMessage = getFormattedErrorMessage(emailTokenActionResponse);
-          toast.error(errorMessage);
-        }
-      } else {
-        if (isTurnstileConfigured) {
-          setTurnstileToken(undefined);
-          turnstile.reset();
-        }
-
-        const errorMessage = getFormattedErrorMessage(createUserResponse);
-        toast.error(errorMessage);
-      }
+      router.push(url);
     } catch (e: any) {
       toast.error(e.message);
     }

--- a/apps/web/playwright/signup.spec.ts
+++ b/apps/web/playwright/signup.spec.ts
@@ -3,6 +3,7 @@ import { test } from "./lib/fixtures";
 import { mockUsers } from "./utils/mock";
 
 const { name, email, password } = mockUsers.signup[0];
+const mixedCaseEmail = email.replace("signup", "SignUp");
 
 test.describe("Email Signup Flow Test", async () => {
   test.describe.configure({ mode: "serial" });
@@ -14,12 +15,14 @@ test.describe("Email Signup Flow Test", async () => {
   test("Valid User", async ({ page }) => {
     await page.fill('input[name="name"]', name);
     await page.getByPlaceholder("Full Name").press("Tab");
-    await page.fill('input[name="email"]', email);
+    await page.fill('input[name="email"]', mixedCaseEmail);
     await page.getByPlaceholder("work@email.com").press("Tab");
     await page.fill('input[name="password"]', password);
     await page.press('input[name="password"]', "Enter");
     await page.waitForURL(/\/auth\/signup-without-verification-success.*/);
     await expect(page).toHaveURL(/\/auth\/signup-without-verification-success.*/);
+    await expect(page).not.toHaveURL(/token=undefined/);
+    await expect(page.getByText(email)).toBeVisible();
   });
 
   test("No Name", async ({ page }) => {

--- a/apps/web/playwright/signup.spec.ts
+++ b/apps/web/playwright/signup.spec.ts
@@ -4,6 +4,7 @@ import { mockUsers } from "./utils/mock";
 
 const { name, email, password } = mockUsers.signup[0];
 const mixedCaseEmail = email.replace("signup", "SignUp");
+const normalizedEmailPattern = new RegExp(email.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
 
 test.describe("Email Signup Flow Test", async () => {
   test.describe.configure({ mode: "serial" });
@@ -22,7 +23,7 @@ test.describe("Email Signup Flow Test", async () => {
     await page.waitForURL(/\/auth\/signup-without-verification-success.*/);
     await expect(page).toHaveURL(/\/auth\/signup-without-verification-success.*/);
     await expect(page).not.toHaveURL(/token=undefined/);
-    await expect(page.getByText(email)).toBeVisible();
+    await expect(page.getByText(normalizedEmailPattern)).toBeVisible();
   });
 
   test("No Name", async ({ page }) => {


### PR DESCRIPTION
Fixes: ENG-1548

## What changed

- Normalize signup email token creation so mixed-case signup input is looked up with the canonical lowercase email.
- Mint legacy email tokens from the stored `user.email` value instead of the raw form input.
- Stop the signup form from routing to success/verification pages when token creation fails.
- Render an invalid-token state on the no-verification success page instead of throwing `jwt malformed`.
- Add unit coverage for `createEmailTokenAction` and update the signup Playwright happy path to use mixed-case email.

## Root cause

Signup creation lowercased the email before storing the user, but the client then requested an email token with the original mixed-case form value. The token action performed a case-sensitive lookup, failed to find the stored user, and the UI still navigated with `token=undefined`. The success page then tried to decode that value as a JWT and threw `jwt malformed`.

## Validation

- `pnpm exec vitest run modules/auth/actions.test.ts modules/auth/signup/actions.test.ts`
- `git diff --check`

Playwright signup was not run locally because the config expects an already-running app at `localhost:3000`, and no server was listening there during validation.