### PR TITLE
fix: prevent manager privilege escalation via v2 organization-users API [ENG-1518]

### DIFF
--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/utils.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/utils.test.ts
@@ -4,6 +4,7 @@ import { buildCommonFilterQuery, pickCommonFilter } from "@/modules/api/v2/manag
 import { TGetUsersFilter } from "@/modules/api/v2/organizations/[organizationId]/users/types/users";
 import {
   canAssignOrganizationRole,
+  canModifyOrganizationMember,
   getApiKeyCreatorRole,
   getMembershipRoleByEmail,
   getUsersQuery,
@@ -177,5 +178,25 @@ describe("canAssignOrganizationRole", () => {
   test("an unresolved creator cannot assign any role", () => {
     expect(canAssignOrganizationRole(null, "member")).toBe(false);
     expect(canAssignOrganizationRole(null, "owner")).toBe(false);
+  });
+});
+
+describe("canModifyOrganizationMember", () => {
+  test("owner can modify any member, including another owner", () => {
+    expect(canModifyOrganizationMember("owner", "owner")).toBe(true);
+    expect(canModifyOrganizationMember("owner", "manager")).toBe(true);
+    expect(canModifyOrganizationMember("owner", "member")).toBe(true);
+  });
+
+  test("a non-owner cannot modify an existing owner", () => {
+    expect(canModifyOrganizationMember("manager", "owner")).toBe(false);
+    expect(canModifyOrganizationMember("member", "owner")).toBe(false);
+    expect(canModifyOrganizationMember(null, "owner")).toBe(false);
+  });
+
+  test("a non-owner can modify non-owner members", () => {
+    expect(canModifyOrganizationMember("manager", "manager")).toBe(true);
+    expect(canModifyOrganizationMember("manager", "member")).toBe(true);
+    expect(canModifyOrganizationMember("manager", null)).toBe(true);
   });
 });

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/utils.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/utils.test.ts
@@ -1,11 +1,29 @@
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
 import { buildCommonFilterQuery, pickCommonFilter } from "@/modules/api/v2/management/lib/utils";
 import { TGetUsersFilter } from "@/modules/api/v2/organizations/[organizationId]/users/types/users";
-import { getUsersQuery } from "../utils";
+import {
+  canAssignOrganizationRole,
+  getApiKeyCreatorRole,
+  getMembershipRoleByEmail,
+  getUsersQuery,
+} from "../utils";
 
 vi.mock("@/modules/api/v2/management/lib/utils", () => ({
   pickCommonFilter: vi.fn(),
   buildCommonFilterQuery: vi.fn(),
+}));
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    apiKey: {
+      findUnique: vi.fn(),
+    },
+    membership: {
+      findUnique: vi.fn(),
+      findFirst: vi.fn(),
+    },
+  },
 }));
 
 describe("getUsersQuery", () => {
@@ -41,5 +59,123 @@ describe("getUsersQuery", () => {
     >);
     getUsersQuery("org123", {} as TGetUsersFilter);
     expect(buildCommonFilterQuery).toHaveBeenCalled();
+  });
+});
+
+describe("getApiKeyCreatorRole", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.apiKey.findUnique).mockReset();
+    vi.mocked(prisma.membership.findUnique).mockReset();
+  });
+
+  test("returns the creator's role in the organization", async () => {
+    vi.mocked(prisma.apiKey.findUnique).mockResolvedValueOnce({ createdBy: "user123" } as any);
+    vi.mocked(prisma.membership.findUnique).mockResolvedValueOnce({ role: "manager" } as any);
+
+    const result = await getApiKeyCreatorRole("apiKey123", "org123");
+
+    expect(prisma.apiKey.findUnique).toHaveBeenCalledWith({
+      where: { id: "apiKey123" },
+      select: { createdBy: true },
+    });
+    expect(prisma.membership.findUnique).toHaveBeenCalledWith({
+      where: { userId_organizationId: { userId: "user123", organizationId: "org123" } },
+      select: { role: true },
+    });
+    expect(result).toBe("manager");
+  });
+
+  test("returns null when the api key does not exist", async () => {
+    vi.mocked(prisma.apiKey.findUnique).mockResolvedValueOnce(null as any);
+
+    const result = await getApiKeyCreatorRole("apiKey123", "org123");
+
+    expect(result).toBeNull();
+    expect(prisma.membership.findUnique).not.toHaveBeenCalled();
+  });
+
+  test("returns null when the api key has no creator (legacy key)", async () => {
+    vi.mocked(prisma.apiKey.findUnique).mockResolvedValueOnce({ createdBy: null } as any);
+
+    const result = await getApiKeyCreatorRole("apiKey123", "org123");
+
+    expect(result).toBeNull();
+    expect(prisma.membership.findUnique).not.toHaveBeenCalled();
+  });
+
+  test("returns null when the creator is no longer a member of the organization", async () => {
+    vi.mocked(prisma.apiKey.findUnique).mockResolvedValueOnce({ createdBy: "user123" } as any);
+    vi.mocked(prisma.membership.findUnique).mockResolvedValueOnce(null as any);
+
+    const result = await getApiKeyCreatorRole("apiKey123", "org123");
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("getMembershipRoleByEmail", () => {
+  beforeEach(() => {
+    vi.mocked(prisma.membership.findFirst).mockReset();
+  });
+
+  test("returns the target user's role in the organization", async () => {
+    vi.mocked(prisma.membership.findFirst).mockResolvedValueOnce({ role: "owner" } as any);
+
+    const result = await getMembershipRoleByEmail("owner@example.com", "org123");
+
+    expect(prisma.membership.findFirst).toHaveBeenCalledWith({
+      where: { organizationId: "org123", user: { email: "owner@example.com" } },
+      select: { role: true },
+    });
+    expect(result).toBe("owner");
+  });
+
+  test("returns null when the user has no membership in the organization", async () => {
+    vi.mocked(prisma.membership.findFirst).mockResolvedValueOnce(null as any);
+
+    const result = await getMembershipRoleByEmail("nobody@example.com", "org123");
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("canAssignOrganizationRole", () => {
+  test("owner can assign any role", () => {
+    expect(canAssignOrganizationRole("owner", "owner")).toBe(true);
+    expect(canAssignOrganizationRole("owner", "manager")).toBe(true);
+    expect(canAssignOrganizationRole("owner", "member")).toBe(true);
+  });
+
+  test("owner can change the role of an existing owner", () => {
+    expect(canAssignOrganizationRole("owner", "member", "owner")).toBe(true);
+    expect(canAssignOrganizationRole("owner", "manager", "owner")).toBe(true);
+  });
+
+  test("manager can only assign the member role", () => {
+    expect(canAssignOrganizationRole("manager", "member")).toBe(true);
+    expect(canAssignOrganizationRole("manager", "manager")).toBe(false);
+    expect(canAssignOrganizationRole("manager", "owner")).toBe(false);
+  });
+
+  test("manager cannot change the role of an existing owner", () => {
+    expect(canAssignOrganizationRole("manager", "member", "owner")).toBe(false);
+    expect(canAssignOrganizationRole("manager", "manager", "owner")).toBe(false);
+    expect(canAssignOrganizationRole("manager", "owner", "owner")).toBe(false);
+  });
+
+  test("manager can assign the member role to existing non-owners", () => {
+    expect(canAssignOrganizationRole("manager", "member", "member")).toBe(true);
+    expect(canAssignOrganizationRole("manager", "member", "manager")).toBe(true);
+    expect(canAssignOrganizationRole("manager", "member", null)).toBe(true);
+  });
+
+  test("member cannot assign any role", () => {
+    expect(canAssignOrganizationRole("member", "member")).toBe(false);
+    expect(canAssignOrganizationRole("member", "owner")).toBe(false);
+  });
+
+  test("an unresolved creator cannot assign any role", () => {
+    expect(canAssignOrganizationRole(null, "member")).toBe(false);
+    expect(canAssignOrganizationRole(null, "owner")).toBe(false);
   });
 });

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/utils.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/utils.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
+import { getUserManagementAccess } from "@/lib/membership/utils";
 import { buildCommonFilterQuery, pickCommonFilter } from "@/modules/api/v2/management/lib/utils";
 import { TGetUsersFilter } from "@/modules/api/v2/organizations/[organizationId]/users/types/users";
 import {
   canAssignOrganizationRole,
+  canManageOrganizationUsers,
   canModifyOrganizationMember,
   getApiKeyCreatorRole,
   getMembershipRoleByEmail,
@@ -13,6 +15,14 @@ import {
 vi.mock("@/modules/api/v2/management/lib/utils", () => ({
   pickCommonFilter: vi.fn(),
   buildCommonFilterQuery: vi.fn(),
+}));
+
+vi.mock("@/lib/constants", () => ({
+  USER_MANAGEMENT_MINIMUM_ROLE: "manager",
+}));
+
+vi.mock("@/lib/membership/utils", () => ({
+  getUserManagementAccess: vi.fn(),
 }));
 
 vi.mock("@formbricks/database", () => ({
@@ -198,5 +208,27 @@ describe("canModifyOrganizationMember", () => {
     expect(canModifyOrganizationMember("manager", "manager")).toBe(true);
     expect(canModifyOrganizationMember("manager", "member")).toBe(true);
     expect(canModifyOrganizationMember("manager", null)).toBe(true);
+  });
+});
+
+describe("canManageOrganizationUsers", () => {
+  beforeEach(() => {
+    vi.mocked(getUserManagementAccess).mockReset();
+  });
+
+  test("an unresolved creator (null) is denied without consulting the floor", () => {
+    expect(canManageOrganizationUsers(null)).toBe(false);
+    expect(getUserManagementAccess).not.toHaveBeenCalled();
+  });
+
+  test("delegates to getUserManagementAccess with the configured minimum role", () => {
+    vi.mocked(getUserManagementAccess).mockReturnValue(true);
+    expect(canManageOrganizationUsers("manager")).toBe(true);
+    expect(getUserManagementAccess).toHaveBeenCalledWith("manager", "manager");
+  });
+
+  test("denies when the creator's role is below the configured floor", () => {
+    vi.mocked(getUserManagementAccess).mockReturnValue(false);
+    expect(canManageOrganizationUsers("manager")).toBe(false);
   });
 });

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/utils.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/utils.ts
@@ -1,6 +1,8 @@
 import { prisma } from "@formbricks/database";
 import { OrganizationRole, Prisma } from "@formbricks/database/prisma";
 import { TOrganizationRole } from "@formbricks/types/memberships";
+import { USER_MANAGEMENT_MINIMUM_ROLE } from "@/lib/constants";
+import { getUserManagementAccess } from "@/lib/membership/utils";
 import { buildCommonFilterQuery, pickCommonFilter } from "@/modules/api/v2/management/lib/utils";
 import { TGetUsersFilter } from "@/modules/api/v2/organizations/[organizationId]/users/types/users";
 
@@ -125,4 +127,16 @@ export const canModifyOrganizationMember = (
 ): boolean => {
   if (assignerRole === OrganizationRole.owner) return true;
   return targetCurrentRole !== OrganizationRole.owner;
+};
+
+/**
+ * Whether the acting user (the API key creator) clears the org's user-management floor. The v2 API
+ * anchors this to the key creator's role so the `USER_MANAGEMENT_MINIMUM_ROLE` policy the
+ * settings/session path enforces (via `getUserManagementAccess`) is applied consistently here — an
+ * install that restricts user management to owners only, or disables it, isn't silently bypassed by
+ * a manager-created key. An unresolved creator (null) never clears the floor.
+ */
+export const canManageOrganizationUsers = (assignerRole: TOrganizationRole | null): boolean => {
+  if (!assignerRole) return false;
+  return getUserManagementAccess(assignerRole, USER_MANAGEMENT_MINIMUM_ROLE);
 };

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/utils.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/utils.ts
@@ -112,3 +112,17 @@ export const canAssignOrganizationRole = (
   if (assignerRole === OrganizationRole.manager) return targetRole === OrganizationRole.member;
   return false;
 };
+
+/**
+ * Whether the acting user (the API key creator) may modify the target membership at all. Only an
+ * owner may act on an existing owner: this guards not just the role, but every other membership
+ * field an update can touch (active state, email, teams). Without it a manager-scoped key could,
+ * for example, deactivate or lock out an owner even though it can't change their role.
+ */
+export const canModifyOrganizationMember = (
+  assignerRole: TOrganizationRole | null,
+  targetCurrentRole: TOrganizationRole | null
+): boolean => {
+  if (assignerRole === OrganizationRole.owner) return true;
+  return targetCurrentRole !== OrganizationRole.owner;
+};

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/utils.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/utils.ts
@@ -1,4 +1,6 @@
-import { Prisma } from "@formbricks/database/prisma";
+import { prisma } from "@formbricks/database";
+import { OrganizationRole, Prisma } from "@formbricks/database/prisma";
+import { TOrganizationRole } from "@formbricks/types/memberships";
 import { buildCommonFilterQuery, pickCommonFilter } from "@/modules/api/v2/management/lib/utils";
 import { TGetUsersFilter } from "@/modules/api/v2/organizations/[organizationId]/users/types/users";
 
@@ -39,4 +41,74 @@ export const getUsersQuery = (organizationId: string, params?: TGetUsersFilter) 
   }
 
   return query;
+};
+
+/**
+ * Resolves the organization role of the user who created the API key.
+ *
+ * Org-scoped API keys carry only read/write/manage access flags, not a role, so role-based
+ * authorization has to be anchored to the acting user — the key's creator. Returns null when the
+ * creator can't be resolved (a legacy key with no `createdBy`, a deleted creator, or a creator who
+ * is no longer a member of the organization) so callers fail safe.
+ */
+export const getApiKeyCreatorRole = async (
+  apiKeyId: string,
+  organizationId: string
+): Promise<TOrganizationRole | null> => {
+  const apiKey = await prisma.apiKey.findUnique({
+    where: { id: apiKeyId },
+    select: { createdBy: true },
+  });
+
+  if (!apiKey?.createdBy) return null;
+
+  const membership = await prisma.membership.findUnique({
+    where: {
+      userId_organizationId: {
+        userId: apiKey.createdBy,
+        organizationId,
+      },
+    },
+    select: { role: true },
+  });
+
+  return membership?.role ?? null;
+};
+
+/**
+ * Resolves the target user's current role in the organization by email. Returns null when the
+ * user doesn't exist or has no membership in the organization.
+ */
+export const getMembershipRoleByEmail = async (
+  email: string,
+  organizationId: string
+): Promise<TOrganizationRole | null> => {
+  const membership = await prisma.membership.findFirst({
+    where: {
+      organizationId,
+      user: { email },
+    },
+    select: { role: true },
+  });
+
+  return membership?.role ?? null;
+};
+
+/**
+ * Mirrors the role clamp enforced on the settings/session path
+ * (modules/ee/role-management/actions.ts): an owner may assign any role, a manager may only assign
+ * the member role and may not change the role of an existing owner (no demoting owners). Anyone
+ * else — including an unresolved creator — may not assign a role at all. This prevents privilege
+ * escalation (e.g. a manager promoting a user to owner) through the management API, matching the
+ * guard that the UI already applies.
+ */
+export const canAssignOrganizationRole = (
+  assignerRole: TOrganizationRole | null,
+  targetRole: TOrganizationRole,
+  targetCurrentRole?: TOrganizationRole | null
+): boolean => {
+  if (assignerRole === OrganizationRole.owner) return true;
+  if (targetCurrentRole === OrganizationRole.owner) return false;
+  if (assignerRole === OrganizationRole.manager) return targetRole === OrganizationRole.member;
+  return false;
 };

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/route.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/route.ts
@@ -14,6 +14,11 @@ import {
   updateUser,
 } from "@/modules/api/v2/organizations/[organizationId]/users/lib/users";
 import {
+  canAssignOrganizationRole,
+  getApiKeyCreatorRole,
+  getMembershipRoleByEmail,
+} from "@/modules/api/v2/organizations/[organizationId]/users/lib/utils";
+import {
   ZGetUsersFilter,
   ZUserInput,
   ZUserInputPatch,
@@ -86,6 +91,21 @@ export const POST = async (request: Request, props: { params: Promise<{ organiza
         );
       }
 
+      // Org API keys carry no role of their own, so clamp the assignable role to the role of the
+      // user who created the key. This mirrors the settings/session-path guard and stops a manager
+      // from escalating a user (or themselves) to owner through the management API.
+      const assignerRole = await getApiKeyCreatorRole(authentication.apiKeyId, authentication.organizationId);
+      if (!canAssignOrganizationRole(assignerRole, body!.role)) {
+        return handleApiError(
+          request,
+          {
+            type: "forbidden",
+            details: [{ field: "role", issue: "You are not allowed to assign this role" }],
+          },
+          auditLog
+        );
+      }
+
       const createUserResult = await createUser(body!, authentication.organizationId);
       if (!createUserResult.ok) {
         return handleApiError(request, createUserResult.error, auditLog);
@@ -144,6 +164,27 @@ export const PATCH = async (request: Request, props: { params: Promise<{ organiz
           },
           auditLog
         );
+      }
+
+      // Only a role change needs clamping; when no role is supplied the membership role is left
+      // untouched. Anchor the assignable role to the API key creator's role so a manager cannot
+      // promote a target above the member role — or demote an existing owner — through the
+      // management API.
+      if (body.role) {
+        const [assignerRole, targetCurrentRole] = await Promise.all([
+          getApiKeyCreatorRole(authentication.apiKeyId, authentication.organizationId),
+          getMembershipRoleByEmail(body.email, authentication.organizationId),
+        ]);
+        if (!canAssignOrganizationRole(assignerRole, body.role, targetCurrentRole)) {
+          return handleApiError(
+            request,
+            {
+              type: "forbidden",
+              details: [{ field: "role", issue: "You are not allowed to assign this role" }],
+            },
+            auditLog
+          );
+        }
       }
 
       let oldUserData: any = UNKNOWN_DATA;

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/route.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@/modules/api/v2/organizations/[organizationId]/users/lib/users";
 import {
   canAssignOrganizationRole,
+  canModifyOrganizationMember,
   getApiKeyCreatorRole,
   getMembershipRoleByEmail,
 } from "@/modules/api/v2/organizations/[organizationId]/users/lib/utils";
@@ -166,25 +167,26 @@ export const PATCH = async (request: Request, props: { params: Promise<{ organiz
         );
       }
 
-      // Only a role change needs clamping; when no role is supplied the membership role is left
-      // untouched. Anchor the assignable role to the API key creator's role so a manager cannot
-      // promote a target above the member role — or demote an existing owner — through the
-      // management API.
-      if (body.role) {
-        const [assignerRole, targetCurrentRole] = await Promise.all([
-          getApiKeyCreatorRole(authentication.apiKeyId, authentication.organizationId),
-          getMembershipRoleByEmail(body.email, authentication.organizationId),
-        ]);
-        if (!canAssignOrganizationRole(assignerRole, body.role, targetCurrentRole)) {
-          return handleApiError(
-            request,
-            {
-              type: "forbidden",
-              details: [{ field: "role", issue: "You are not allowed to assign this role" }],
-            },
-            auditLog
-          );
-        }
+      // Org API keys carry no role of their own, so anchor authorization to the API key creator's
+      // role. A non-owner may not touch an existing owner's membership at all (role, active state,
+      // email, or teams), and when a role change is requested it must not exceed what the creator
+      // may assign. This mirrors the settings/session-path guard.
+      const [assignerRole, targetCurrentRole] = await Promise.all([
+        getApiKeyCreatorRole(authentication.apiKeyId, authentication.organizationId),
+        getMembershipRoleByEmail(body.email, authentication.organizationId),
+      ]);
+      if (
+        !canModifyOrganizationMember(assignerRole, targetCurrentRole) ||
+        (body.role && !canAssignOrganizationRole(assignerRole, body.role, targetCurrentRole))
+      ) {
+        return handleApiError(
+          request,
+          {
+            type: "forbidden",
+            details: [{ field: "role", issue: "You are not allowed to modify this user" }],
+          },
+          auditLog
+        );
       }
 
       let oldUserData: any = UNKNOWN_DATA;

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/route.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@/modules/api/v2/organizations/[organizationId]/users/lib/users";
 import {
   canAssignOrganizationRole,
+  canManageOrganizationUsers,
   canModifyOrganizationMember,
   getApiKeyCreatorRole,
   getMembershipRoleByEmail,
@@ -92,10 +93,21 @@ export const POST = async (request: Request, props: { params: Promise<{ organiza
         );
       }
 
-      // Org API keys carry no role of their own, so clamp the assignable role to the role of the
-      // user who created the key. This mirrors the settings/session-path guard and stops a manager
+      // Org API keys carry no role of their own, so anchor authorization to the API key creator's
+      // role. First enforce the org's user-management floor (USER_MANAGEMENT_MINIMUM_ROLE), then
+      // clamp the assignable role. This mirrors the settings/session-path guard and stops a manager
       // from escalating a user (or themselves) to owner through the management API.
       const assignerRole = await getApiKeyCreatorRole(authentication.apiKeyId, authentication.organizationId);
+      if (!canManageOrganizationUsers(assignerRole)) {
+        return handleApiError(
+          request,
+          {
+            type: "forbidden",
+            details: [{ field: "user", issue: "You are not allowed to manage users in this organization" }],
+          },
+          auditLog
+        );
+      }
       if (!canAssignOrganizationRole(assignerRole, body!.role)) {
         return handleApiError(
           request,
@@ -168,13 +180,24 @@ export const PATCH = async (request: Request, props: { params: Promise<{ organiz
       }
 
       // Org API keys carry no role of their own, so anchor authorization to the API key creator's
-      // role. A non-owner may not touch an existing owner's membership at all (role, active state,
-      // email, or teams), and when a role change is requested it must not exceed what the creator
-      // may assign. This mirrors the settings/session-path guard.
+      // role. First enforce the org's user-management floor (USER_MANAGEMENT_MINIMUM_ROLE). Then a
+      // non-owner may not touch an existing owner's membership at all (role, active state, email, or
+      // teams), and when a role change is requested it must not exceed what the creator may assign.
+      // This mirrors the settings/session-path guard.
       const [assignerRole, targetCurrentRole] = await Promise.all([
         getApiKeyCreatorRole(authentication.apiKeyId, authentication.organizationId),
         getMembershipRoleByEmail(body.email, authentication.organizationId),
       ]);
+      if (!canManageOrganizationUsers(assignerRole)) {
+        return handleApiError(
+          request,
+          {
+            type: "forbidden",
+            details: [{ field: "user", issue: "You are not allowed to manage users in this organization" }],
+          },
+          auditLog
+        );
+      }
       if (
         !canModifyOrganizationMember(assignerRole, targetCurrentRole) ||
         (body.role && !canAssignOrganizationRole(assignerRole, body.role, targetCurrentRole))

--- a/apps/web/modules/ee/role-management/actions.ts
+++ b/apps/web/modules/ee/role-management/actions.ts
@@ -142,10 +142,7 @@ export const updateMembershipAction = authenticatedActionClient.inputSchema(ZUpd
 
     ctx.auditLoggingCtx.organizationId = parsedInput.organizationId;
     ctx.auditLoggingCtx.membershipId = `${parsedInput.userId}-${parsedInput.organizationId}`;
-    ctx.auditLoggingCtx.oldObject = await getMembershipByUserIdOrganizationId(
-      parsedInput.userId,
-      parsedInput.organizationId
-    );
+    ctx.auditLoggingCtx.oldObject = targetMembership;
     const result = await updateMembership(parsedInput.userId, parsedInput.organizationId, parsedInput.data);
     ctx.auditLoggingCtx.newObject = result;
     return result;

--- a/apps/web/modules/ee/role-management/actions.ts
+++ b/apps/web/modules/ee/role-management/actions.ts
@@ -130,6 +130,14 @@ export const updateMembershipAction = authenticatedActionClient.inputSchema(ZUpd
       throw new OperationNotAllowedError("Managers can only assign users to the member role");
     }
 
+    const targetMembership = await getMembershipByUserIdOrganizationId(
+      parsedInput.userId,
+      parsedInput.organizationId
+    );
+    if (currentUserMembership.role !== "owner" && targetMembership?.role === "owner") {
+      throw new OperationNotAllowedError("Only owners can change the role of an owner");
+    }
+
     await checkRoleManagementPermission(parsedInput.organizationId);
 
     ctx.auditLoggingCtx.organizationId = parsedInput.organizationId;


### PR DESCRIPTION
## What does this PR do?

Fixes a privilege-escalation issue in the v2 organization-users management API (**ENG-1518**, reported privately via `SECURITY.md`).

`POST`/`PATCH /api/v2/organizations/{orgId}/users` wrote the `role` from the request body straight onto the membership after only a write-access check — nothing verified that the caller was allowed to grant that role. On self-hosted, a manager can mint a write-scoped org API key, so a manager could:

- create a new **owner** (`POST` with `"role": "owner"`), or
- promote an existing member up to owner/manager (`PATCH`),

escalating themselves (or anyone) to full owner. The settings/session path already blocked this in `ee/role-management/actions.ts`; the API path had no equivalent clamp.

While closing that, the related gap where a **non-owner could demote an existing owner** is also fixed — on both the API path and the session/settings action (the UI already disabled it client-side, but the server didn't enforce it).

Self-hosted only — the endpoint bails on Cloud via `IS_FORMBRICKS_CLOUD`.

### Changes

Org API keys carry no role of their own, so authorization is anchored to the key's **creator**:

- `getApiKeyCreatorRole` — resolves the creating user's current org role; returns `null` for legacy keys with no `createdBy`, deleted users, or creators who are no longer members (callers fail safe).
- `getMembershipRoleByEmail` — resolves the target user's current role.
- `canAssignOrganizationRole(assignerRole, targetRole, targetCurrentRole?)` — an owner may assign any role; a non-owner may not change an existing owner's role; a manager may only assign `member`; anyone else (including an unresolved creator) may not assign a role at all.
- `canModifyOrganizationMember(assignerRole, targetCurrentRole)` — only an owner may modify an existing owner's membership at all. This guards every field a `PATCH` can touch (active state, email, teams), not just the role, so a manager-scoped key can't deactivate or lock out an owner via a non-role field.
- `canManageOrganizationUsers(assignerRole)` — enforces the org's `USER_MANAGEMENT_MINIMUM_ROLE` floor (via the shared `getUserManagementAccess`) on the API path, matching the settings/session path. An install that restricts user management to owners only (or disables it) is no longer bypassed by a manager-created key; an unresolved creator never clears the floor.
- `route.ts` — both `POST` and `PATCH` first enforce the user-management floor, then apply the role clamp. `PATCH` additionally blocks a non-owner from modifying an existing owner (any field). Violations return `403`.
- `ee/role-management/actions.ts` — `updateMembershipAction` now rejects a non-owner changing an owner's role, matching the API path and the existing UI behavior, and reuses the already-fetched target membership for the audit-log `oldObject` (drops a redundant read).

### ⚠️ Upgrade note (self-hosted)

Because org API keys carry no role, the assignable role is anchored to the key's **creator**. If that creator can't be resolved — a **legacy key created before `createdBy` was recorded**, a key whose **creator was deleted**, or a creator who is **no longer a member** — the fail-safe denies role assignment, so `POST` (role is required) and any role-changing `PATCH` on such a key return `403`. Non-role `PATCH`es on non-owner targets are unaffected. Self-hosted installs whose user-provisioning automation runs on a legacy/orphaned key should **regenerate the key** (so it has a resolvable creator with a sufficient role) after upgrading. Worth a line in the release notes / upgrade guide.

## How should this be tested?

Self-hosted instance, in an org where the API key was created by a **manager** (the key creator's role is what gets enforced). With `x-api-key` set to a manager-created, write-scoped key:

1. `GET  /api/v2/organizations/{orgId}/users` → `200`
2. `POST` `{"name":"...","email":"m@example.com","role":"member"}` → `201` (manager can add members)
3. `POST` `{"name":"...","email":"e@example.com","role":"owner"}` → `403` (escalation blocked)
4. `POST` `{"name":"...","email":"e2@example.com","role":"manager"}` → `403` (manager can only assign `member`)
5. `PATCH` `{"email":"<an existing owner>","role":"member"}` → `403` (owner demotion blocked)
6. `PATCH` `{"email":"<an existing owner>","isActive":false}` → `403` (non-owner can't deactivate an owner, even with no role change)

An **owner**-created key still assigns any role and can modify any member, so there's no regression for legitimate use. On `main` (pre-fix), step 3 returns `201` and the new user comes back with `"role":"owner"`.

Unit coverage added in `apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/utils.test.ts` (role-clamp matrix + creator/target resolution, incl. legacy/deleted-creator fail-safe).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
