### PR TITLE
fix: validate userId length before tearing down existing user

### DIFF
--- a/packages/js-core/src/lib/user/tests/user.test.ts
+++ b/packages/js-core/src/lib/user/tests/user.test.ts
@@ -185,6 +185,41 @@ describe("user.ts", () => {
       expect(mockUpdateQueue.updateUserId).not.toHaveBeenCalled();
       expect(mockUpdateQueue.processUpdates).not.toHaveBeenCalled();
     });
+
+    test("does not tear down the existing user when the replacement userId is too long", async () => {
+      const mockConfig = {
+        get: vi.fn().mockReturnValue({
+          user: {
+            data: {
+              userId: "existing-user",
+            },
+          },
+        }),
+      };
+
+      const mockLogger = {
+        debug: vi.fn(),
+        error: vi.fn(),
+      };
+
+      const mockUpdateQueue = {
+        updateUserId: vi.fn(),
+        processUpdates: vi.fn(),
+      };
+
+      getInstanceConfigMock.mockReturnValue(mockConfig as unknown as Config);
+      getInstanceLoggerMock.mockReturnValue(mockLogger as unknown as Logger);
+      getInstanceUpdateQueueMock.mockReturnValue(mockUpdateQueue as unknown as UpdateQueue);
+
+      const longId = "a".repeat(256);
+      const result = await setUserId(longId);
+
+      expect(result.ok).toBe(true);
+      expect(mockLogger.error).toHaveBeenCalledWith("UserId exceeds maximum length of 255 characters");
+      expect(tearDown).not.toHaveBeenCalled();
+      expect(mockUpdateQueue.updateUserId).not.toHaveBeenCalled();
+      expect(mockUpdateQueue.processUpdates).not.toHaveBeenCalled();
+    });
   });
 
   describe("logout", () => {

--- a/packages/js-core/src/lib/user/user.ts
+++ b/packages/js-core/src/lib/user/user.ts
@@ -4,6 +4,8 @@ import { tearDown } from "@/lib/common/setup";
 import { UpdateQueue } from "@/lib/user/update-queue";
 import { type ApiErrorResponse, type Result, okVoid } from "@/types/error";
 
+const MAX_USER_ID_LENGTH = 255;
+
 // eslint-disable-next-line @typescript-eslint/require-await -- we want to use promises here
 export const setUserId = async (userId: string): Promise<Result<void, ApiErrorResponse>> => {
   const appConfig = Config.getInstance();
@@ -16,7 +18,6 @@ export const setUserId = async (userId: string): Promise<Result<void, ApiErrorRe
 
   // Validate the new userId before mutating any state, so an invalid replacement
   // does not tear down the existing valid user.
-  const MAX_USER_ID_LENGTH = 255;
   if (userId.length > MAX_USER_ID_LENGTH) {
     logger.error(`UserId exceeds maximum length of ${String(MAX_USER_ID_LENGTH)} characters`);
     return okVoid();

--- a/packages/js-core/src/lib/user/user.ts
+++ b/packages/js-core/src/lib/user/user.ts
@@ -14,6 +14,14 @@ export const setUserId = async (userId: string): Promise<Result<void, ApiErrorRe
     data: { userId: currentUserId },
   } = appConfig.get().user;
 
+  // Validate the new userId before mutating any state, so an invalid replacement
+  // does not tear down the existing valid user.
+  const MAX_USER_ID_LENGTH = 255;
+  if (userId.length > MAX_USER_ID_LENGTH) {
+    logger.error(`UserId exceeds maximum length of ${String(MAX_USER_ID_LENGTH)} characters`);
+    return okVoid();
+  }
+
   // If the same userId is already set, no-op
   if (currentUserId === userId) {
     logger.debug("UserId is already set to the same value, skipping");
@@ -24,12 +32,6 @@ export const setUserId = async (userId: string): Promise<Result<void, ApiErrorRe
   if (currentUserId) {
     logger.debug("Different userId is being set, cleaning up previous user state");
     tearDown();
-  }
-
-  const MAX_USER_ID_LENGTH = 255;
-  if (userId.length > MAX_USER_ID_LENGTH) {
-    logger.error(`UserId exceeds maximum length of ${String(MAX_USER_ID_LENGTH)} characters`);
-    return okVoid();
   }
 
   updateQueue.updateUserId(userId);


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

`setUserId` in `packages/js-core` validated the replacement `userId` length **after** tearing down the existing user state. So calling `setUserId` with an oversized (> 255 chars) userId while a valid user was already set would tear the current user down and *then* reject the new value — leaving the SDK with no user at all.

This PR moves the `MAX_USER_ID_LENGTH` validation to the start of `setUserId`, before any state is mutated. An invalid replacement `userId` is now rejected up front without clearing the existing valid user. Behavior for valid userIds is unchanged.

Fixes #8288

<!-- Please provide a screenshots or a loom video for visual changes to speed up reviews
 Loom Video: https://www.loom.com/
-->

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

Added a regression test in `packages/js-core/src/lib/user/tests/user.test.ts` for the exact scenario: an existing user is set, then `setUserId` is called with a 256-character userId — `tearDown` must not be called and no updates are queued.

- `cd packages/js-core && CI=true pnpm test -- --run src/lib/user/tests/user.test.ts` — all user tests pass
- Verified the new test fails against the pre-fix source (at `expect(tearDown).not.toHaveBeenCalled()`) and passes with the fix
- `pnpm lint` on the touched files is clean

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
