### PR TITLE
fix(deps): bump @tootallnate/once to fix GHSA-vpq2-c234-7xj6 (ENG-1379)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   hono: 4.12.25
   protobufjs@7: 7.6.3
   protobufjs@8: 8.6.3
+  '@tootallnate/once': 2.0.1
   '@xmldom/xmldom': 0.9.10
   axios: 1.16.0
   lodash: 4.18.1
@@ -5810,9 +5811,9 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tootallnate/once@1.1.2':
-    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
-    engines: {node: '>= 6'}
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
+    engines: {node: '>= 10'}
 
   '@trivago/prettier-plugin-sort-imports@6.0.2':
     resolution: {integrity: sha512-3DgfkukFyC/sE/VuYjaUUWoFfuVjPK55vOFDsxD56XXynFMCZDYFogH2l/hDfOsQAm1myoU/1xByJ3tWqtulXA==}
@@ -18435,7 +18436,7 @@ snapshots:
     dependencies:
       '@testing-library/dom': 8.20.1
 
-  '@tootallnate/once@1.1.2':
+  '@tootallnate/once@2.0.1':
     optional: true
 
   '@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.8.3)':
@@ -21655,7 +21656,7 @@ snapshots:
 
   http-proxy-agent@4.0.1:
     dependencies:
-      '@tootallnate/once': 1.1.2
+      '@tootallnate/once': 2.0.1
       agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -25439,7 +25440,7 @@ snapshots:
       std-env: 4.1.0
       tinybench: 2.9.0
       tinyexec: 1.1.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@25.4.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,10 @@ overrides:
   # sqlite3 / node-gyp chain: tar advisory pins are safe here because sqlite3 is pulled in
   # transitively by typeorm but the project uses postgres; sqlite3 is never built at runtime.
   # Therefore node-gyp@8 / http-proxy-agent@4 compatibility is not a concern.
-  # `@tootallnate/once` advisory (ENG-1456/1396/1379) remains Low and is not pinned.
+  # ENG-1379 / GHSA-vpq2-c234-7xj6 (CVE-2026-3449): @tootallnate/once <2.0.1 leaves the promise
+  # permanently pending after an AbortSignal abort; http-proxy-agent@4 pins ^1, so an override is
+  # required. Pinned to the minimal patched version (2.0.1) to stay CJS-compatible with http-proxy-agent@4.
+  "@tootallnate/once": 2.0.1
   # SAML and XML processing chains.
   "@xmldom/xmldom": 0.9.10 # load-bearing: 0.8.x/0.9.8 vulnerable (GHSA-2v35-w6hq-6mfw + 4 more)
   axios: 1.16.0


### PR DESCRIPTION
## Summary

Fixes [ENG-1379](https://linear.app/formbricks/issue/ENG-1379/dependabot-568-tootallnateonce-tootallnateonce-vulnerable-to-incorrect) / [Dependabot alert #568](https://github.com/formbricks/formbricks/security/dependabot/568).

- **Advisory:** [GHSA-vpq2-c234-7xj6](https://github.com/advisories/GHSA-vpq2-c234-7xj6) (CVE-2026-3449), severity low
- **Vulnerability:** In `@tootallnate/once` < 2.0.1, when the passed `AbortSignal` aborts, the returned promise stays permanently pending instead of rejecting (Incorrect Control Flow Scoping), which can hang consumers awaiting it.

## Fix approach

`@tootallnate/once@1.1.2` is pulled in transitively via `@formbricks/web` → `@boxyhq/saml-jackson` → `typeorm` → `sqlite3` → `node-gyp@8` → `make-fetch-happen@9` → `http-proxy-agent@4.0.1`, which pins `^1` — so a normal lockfile update cannot reach the patched release. Added a pnpm override in `pnpm-workspace.yaml` (where this repo keeps its security pins) forcing `@tootallnate/once@2.0.1`, the minimal patched version, and regenerated the lockfile.

## Verification

- `grep @tootallnate/once pnpm-lock.yaml` shows only 2.0.1 remains (was 1.1.2)
- `pnpm why @tootallnate/once -r` resolves 2.0.1 for the single consumer (`http-proxy-agent@4.0.1`)
- Full `pnpm install` succeeds, including the `sqlite3` build through the affected `node-gyp` chain