### PR TITLE
fix: suppress Better Auth oauthAuthServerConfig warning

### DIFF
--- a/apps/web/modules/auth/lib/mcp-oauth-provider-options.ts
+++ b/apps/web/modules/auth/lib/mcp-oauth-provider-options.ts
@@ -45,6 +45,9 @@ export const getMcpOauthProviderOptions = (): TOauthProviderOptions => ({
     introspect: { window: 60, max: 60 },
     revoke: { window: 60, max: 30 },
   },
+  // Discovery is served by our Next.js catch-all at /.well-known/oauth-authorization-server/api/auth;
+  // Better Auth can't introspect the route, so this acks the (verified-correct) endpoint rather than
+  // masking a real problem. See PR #8447.
   silenceWarnings: {
     oauthAuthServerConfig: true,
   },

--- a/apps/web/modules/auth/lib/mcp-oauth-provider-options.ts
+++ b/apps/web/modules/auth/lib/mcp-oauth-provider-options.ts
@@ -45,4 +45,7 @@ export const getMcpOauthProviderOptions = (): TOauthProviderOptions => ({
     introspect: { window: 60, max: 60 },
     revoke: { window: 60, max: 30 },
   },
+  silenceWarnings: {
+    oauthAuthServerConfig: true,
+  },
 });


### PR DESCRIPTION
## What does this PR do?

Better Auth's oauth-provider plugin logs a `WARN` at startup when the auth handler isn't mounted at root — it asks you to confirm `/.well-known/oauth-authorization-server/api/auth` exists for RFC 8414 path-discovery clients. The route is already served by the `[[...issuer]]` catch-all, but Better Auth doesn't inspect the filesystem — it's a config-level check. The way to clear it is `silenceWarnings.oauthAuthServerConfig: true`, which this sets.

## How should this be tested?

1. `pnpm dev` — the `WARN [Better Auth]: Please ensure '/.well-known/oauth-authorization-server/api/auth' exists` message should be gone
2. `curl http://localhost:3000/.well-known/oauth-authorization-server/api/auth` should still return OAuth AS metadata

## Required

- [x] Self-reviewed
- [x] No warnings
- [x] Synced with main