### PR TITLE
fix: prevent turbo cache from filling local disk space [ENG-1662]

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "agents:update": "npx @next/codemod@canary agents-md --output AGENTS.md",
     "clean:all": "turbo run clean && rimraf node_modules pnpm-lock.yaml .turbo coverage out",
     "clean": "turbo run clean && rimraf node_modules .turbo coverage out",
+    "clean:cache": "rimraf .turbo/cache apps/web/.next",
     "build": "turbo run build",
     "build:dev": "turbo run build:dev",
     "db:migrate:dev": "turbo run db:migrate:dev",

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turborepo.org/schema.json",
+  "cacheMaxSize": "10GB",
   "globalEnv": ["MIGRATE_DATABASE_URL", "SHADOW_DATABASE_URL"],
   "tasks": {
     "@formbricks/ai#build": {
@@ -360,11 +361,11 @@
         "PROMETHEUS_EXPORTER_PORT",
         "USER_MANAGEMENT_MINIMUM_ROLE"
       ],
-      "outputs": ["dist/**", ".next/**"]
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "!.next/dev/**"]
     },
     "build:dev": {
       "dependsOn": ["^build:dev"],
-      "outputs": ["dist/**", ".next/**"]
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "!.next/dev/**"]
     },
     "clean": {
       "cache": false,


### PR DESCRIPTION
## Summary
`pnpm build` was consuming disk space unboundedly until machines ran out of storage (reported on Javier's machine, `.next`/`.turbo` growing to tens of GB; `pnpm clean` was used as a workaround).

**Root cause**: the `build`/`build:dev` tasks in `turbo.json` cached the entire `.next` directory (`outputs: ["dist/**", ".next/**"]`) into `.turbo/cache` with no exclusions and no size cap. This swept in `.next/dev` (Next.js dev-server cache, grows unboundedly the more `pnpm dev` is used) and `.next/cache` on every build, producing multi-GB cache artifacts (up to 5.4GB each) that were never evicted. On this reproduction, `.turbo/cache` had grown to 63GB.

**Fix** (matches Turborepo's documented Next.js configuration):
- Exclude `.next/cache/**` and `.next/dev/**` from cached `build`/`build:dev` outputs
- Add `cacheMaxSize: "10GB"` as a backstop so the local cache can never grow unbounded again (Turborepo evicts oldest entries past the cap)
- Add a `clean:cache` script (`rimraf .turbo/cache apps/web/.next`) so devs can reclaim disk space without wiping `node_modules`, unlike `pnpm clean`

This is a config-only change; no source code is affected.

## Test plan
- [x] `pnpm build` succeeds from a clean cache
- [x] New web build cache artifact dropped from 5.4GB → 195MB
- [x] Rebuild with no changes hits `FULL TURBO` (cache hits still work correctly)
- [x] `pnpm clean:cache` clears `.turbo/cache` and `apps/web/.next` without touching `node_modules`; subsequent `pnpm build` works without reinstalling
- [x] Ran two distinct builds back-to-back (forcing new hashes) — cache grew by ~195MB per build (216MB → 429MB), not multi-GB, confirming bounded growth going forward

Fixes ENG-1662.

🤖 Generated with [Claude Code](https://claude.com/claude-code)