### PR TITLE
feat(surveys): choose how many example responses to generate

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/actions.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/actions.ts
@@ -5,7 +5,9 @@ import { prisma } from "@formbricks/database";
 import { ZId } from "@formbricks/types/common";
 import { InvalidInputError, OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { getEmailTemplateHtml } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/emailTemplate";
+import { DEFAULT_EXAMPLE_RESPONSE_COUNT } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-response-options";
 import {
+  ZExampleResponseCount,
   generateExampleResponseDataset,
   toExampleResponseInput,
 } from "@/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses";
@@ -123,10 +125,14 @@ export const resetSurveyAction = authenticatedActionClient.inputSchema(ZResetSur
 
 const ZGenerateExampleResponsesAction = z.object({
   surveyId: ZId,
+  // How many example responses to create. Restricted to the fixed options the
+  // popover offers so a crafted request can't drive up LLM/DB cost arbitrarily.
+  count: ZExampleResponseCount.default(DEFAULT_EXAMPLE_RESPONSE_COUNT),
 });
 
-// Generates a small set of LLM-authored example responses for a survey that
-// has no real responses yet. Server-side gates: caller must have write access,
+// Generates a user-chosen number (see ZExampleResponseCount) of LLM-authored
+// example responses for a survey that has no real responses yet. Server-side
+// gates: caller must have write access,
 // the org's AI smart-tools feature must be enabled and entitled, and the
 // survey must currently have zero responses (button is also hidden client-side
 // when responseCount > 0, but we re-check here so a stale tab can't insert
@@ -175,7 +181,11 @@ export const generateExampleResponsesAction = authenticatedActionClient
       );
     }
 
-    const generatedDataset = await generateExampleResponseDataset({ survey, organizationId });
+    const generatedDataset = await generateExampleResponseDataset({
+      survey,
+      organizationId,
+      count: parsedInput.count,
+    });
     if (generatedDataset.responses.length === 0) {
       throw new InvalidInputError(
         "This survey doesn't contain any question types we can synthesize answers for yet."

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/SurveyAnalysisCTA.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/SurveyAnalysisCTA.tsx
@@ -22,6 +22,10 @@ import { Button } from "@/modules/ui/components/button";
 import { ConfirmationModal } from "@/modules/ui/components/confirmation-modal";
 import { IconBar } from "@/modules/ui/components/iconbar";
 import { generateExampleResponsesAction, resetSurveyAction } from "../actions";
+import {
+  DEFAULT_EXAMPLE_RESPONSE_COUNT,
+  EXAMPLE_RESPONSE_COUNT_OPTIONS,
+} from "../lib/example-response-options";
 
 interface SurveyAnalysisCTAProps {
   isReadOnly: boolean;
@@ -66,6 +70,8 @@ export const SurveyAnalysisCTA = ({
   const [isResetting, setIsResetting] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isGeneratingExamples, setIsGeneratingExamples] = useState(false);
+  const [isExamplePopoverOpen, setIsExamplePopoverOpen] = useState(false);
+  const [selectedExampleCount, setSelectedExampleCount] = useState<number>(DEFAULT_EXAMPLE_RESPONSE_COUNT);
 
   const { workspace } = useWorkspaceContext();
   const { survey } = useSurvey();
@@ -155,12 +161,12 @@ export const SurveyAnalysisCTA = ({
     setIsResetModalOpen(false);
   };
 
-  const handleGenerateExampleResponses = async () => {
+  const handleGenerateExampleResponses = async (count: number) => {
     if (isGeneratingExamples) return;
     setIsGeneratingExamples(true);
     const loadingToastId = toast.loading(t("workspace.surveys.summary.generating_example_responses"));
     try {
-      const result = await generateExampleResponsesAction({ surveyId: survey.id });
+      const result = await generateExampleResponsesAction({ surveyId: survey.id, count });
       if (result?.data) {
         toast.success(
           t("workspace.surveys.summary.example_responses_generated_successfully", {
@@ -168,6 +174,7 @@ export const SurveyAnalysisCTA = ({
           }),
           { id: loadingToastId }
         );
+        setIsExamplePopoverOpen(false);
         router.refresh();
       } else {
         const errorMessage = getFormattedErrorMessage(result);
@@ -195,6 +202,44 @@ export const SurveyAnalysisCTA = ({
     }
     return t("workspace.surveys.summary.generate_example_responses");
   })();
+
+  const exampleResponsesPopover = (
+    <div className="flex flex-col gap-3">
+      <p className="text-sm font-medium text-slate-900">
+        {t("workspace.surveys.summary.how_many_example_responses")}
+      </p>
+      <div className="flex gap-2">
+        {EXAMPLE_RESPONSE_COUNT_OPTIONS.map((count) => (
+          <Button
+            key={count}
+            variant={selectedExampleCount === count ? "default" : "outline"}
+            size="sm"
+            className="flex-1"
+            disabled={isGeneratingExamples}
+            aria-pressed={selectedExampleCount === count}
+            onClick={() => setSelectedExampleCount(count)}>
+            {count}
+          </Button>
+        ))}
+      </div>
+      <div className="flex justify-between gap-2">
+        <Button
+          variant="secondary"
+          size="sm"
+          disabled={isGeneratingExamples}
+          onClick={() => setIsExamplePopoverOpen(false)}>
+          {t("common.cancel")}
+        </Button>
+        <Button
+          variant="default"
+          size="sm"
+          loading={isGeneratingExamples}
+          onClick={() => handleGenerateExampleResponses(selectedExampleCount)}>
+          {t("common.generate")}
+        </Button>
+      </div>
+    </div>
+  );
 
   const iconActions = [
     {
@@ -234,9 +279,11 @@ export const SurveyAnalysisCTA = ({
     {
       icon: Wand2,
       tooltip: exampleResponsesTooltip,
-      onClick: handleGenerateExampleResponses,
-      disabled: isGeneratingExamples || aiUnavailableReason !== null,
+      disabled: aiUnavailableReason !== null,
       isVisible: !isReadOnly && responseCount === 0,
+      popoverContent: exampleResponsesPopover,
+      popoverOpen: isExamplePopoverOpen,
+      onPopoverOpenChange: setIsExamplePopoverOpen,
     },
     {
       icon: ListRestart,

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-response-options.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-response-options.ts
@@ -1,0 +1,10 @@
+// Counts offered in the "Generate example responses" popover and accepted by the
+// generate-example-responses server action. Kept in one client-safe module (no
+// "server-only", no heavy imports) so the popover's selectable options and the
+// server-side validation can never drift apart.
+export const EXAMPLE_RESPONSE_COUNT_OPTIONS = [10, 25, 50] as const;
+
+export type TExampleResponseCount = (typeof EXAMPLE_RESPONSE_COUNT_OPTIONS)[number];
+
+// Pre-selected option and the fallback used when no count is supplied.
+export const DEFAULT_EXAMPLE_RESPONSE_COUNT: TExampleResponseCount = 10;

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts
@@ -6,6 +6,7 @@ import {
   EXAMPLE_AI_GENERATED_TAG_NAME,
   EXAMPLE_IMPRESSION_ONLY_COUNT,
   EXAMPLE_RESPONSE_COUNT,
+  ZExampleResponseCount,
   buildExampleImpressionTimestamps,
   buildExampleResponsesSchema,
   generateExampleResponseDataset,
@@ -554,6 +555,19 @@ describe("generateExampleResponseDataset", () => {
     expect(mocks.generateOrganizationAIObject).not.toHaveBeenCalled();
   });
 
+  test("scales responses and impression-only displays to a requested count", async () => {
+    const survey = makeSurvey([
+      { ...baseQuestion, id: "q_rating", type: TSurveyElementTypeEnum.Rating, scale: "number", range: 5 },
+    ] as unknown as TSurvey["questions"]);
+
+    const result = await generateExampleResponseDataset({ survey, organizationId: "org_1", count: 25 });
+
+    expect(result.responses).toHaveLength(25);
+    // ~0.6 impression-only displays per response keeps the completion rate realistic.
+    expect(result.displays).toHaveLength(15);
+    expect(mocks.generateOrganizationAIObject).not.toHaveBeenCalled();
+  });
+
   test("generateExampleResponses returns only the response rows for compatibility", async () => {
     const survey = makeSurvey([
       { ...baseQuestion, id: "q_rating", type: TSurveyElementTypeEnum.Rating, scale: "number", range: 5 },
@@ -562,6 +576,20 @@ describe("generateExampleResponseDataset", () => {
     const result = await generateExampleResponses({ survey, organizationId: "org_1" });
 
     expect(result).toHaveLength(EXAMPLE_RESPONSE_COUNT);
+  });
+});
+
+describe("ZExampleResponseCount", () => {
+  test.each([10, 25, 50])("accepts the allowed option %i", (value) => {
+    expect(ZExampleResponseCount.safeParse(value).success).toBe(true);
+  });
+
+  test.each([0, 5, 11, 24, 100, -10, 10.5])("rejects the disallowed value %p", (value) => {
+    expect(ZExampleResponseCount.safeParse(value).success).toBe(false);
+  });
+
+  test("rejects non-numeric input", () => {
+    expect(ZExampleResponseCount.safeParse("25").success).toBe(false);
   });
 });
 

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.ts
@@ -7,13 +7,33 @@ import { type TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/s
 import { type TSurvey } from "@formbricks/types/surveys/types";
 import { generateOrganizationAIObject } from "@/lib/ai/service";
 import { getLocalizedValue } from "@/lib/i18n/utils";
+import {
+  DEFAULT_EXAMPLE_RESPONSE_COUNT,
+  EXAMPLE_RESPONSE_COUNT_OPTIONS,
+  type TExampleResponseCount,
+} from "./example-response-options";
 
-export const EXAMPLE_RESPONSE_COUNT = 10;
+// Default number of example responses when a caller doesn't request a specific
+// count. The summary popover lets users pick from EXAMPLE_RESPONSE_COUNT_OPTIONS.
+export const EXAMPLE_RESPONSE_COUNT = DEFAULT_EXAMPLE_RESPONSE_COUNT;
 // Impression-only displays simulate respondents who saw the survey but didn't
-// submit. Combined with the response count, the dashboard's completion rate
-// lands around 62% — close to typical web survey benchmarks.
-export const EXAMPLE_IMPRESSION_ONLY_COUNT = 6;
+// submit. We scale them at ~0.6 per response so that, combined with the response
+// count, the dashboard's completion rate lands around 62% — close to typical web
+// survey benchmarks — no matter how many responses the user asked for.
+const EXAMPLE_IMPRESSION_ONLY_RATIO = 0.6;
+const getImpressionOnlyCount = (responseCount: number): number =>
+  Math.round(responseCount * EXAMPLE_IMPRESSION_ONLY_RATIO);
+export const EXAMPLE_IMPRESSION_ONLY_COUNT = getImpressionOnlyCount(EXAMPLE_RESPONSE_COUNT);
 export const EXAMPLE_AI_GENERATED_TAG_NAME = "AI-generated example response";
+
+// Validates a caller-requested response count against the allowed options. Lives
+// in this (already-tested) module and is consumed by the server action's input
+// schema so the count can't be spoofed past the UI's fixed choices.
+export const ZExampleResponseCount = z
+  .number()
+  .refine((value): value is TExampleResponseCount =>
+    (EXAMPLE_RESPONSE_COUNT_OPTIONS as readonly number[]).includes(value)
+  );
 
 // ~20% of synthetic responses are partial drop-offs to mirror typical survey
 // abandonment. The remaining ~80% are finished.
@@ -503,6 +523,8 @@ Example output shape:
 export type TGenerateExampleResponsesArgs = {
   survey: TSurvey;
   organizationId: string;
+  // Number of example responses to synthesize. Defaults to EXAMPLE_RESPONSE_COUNT.
+  count?: number;
 };
 
 export type TGeneratedExampleResponse = {
@@ -723,7 +745,7 @@ const applyDropOffToPlanRow = (
   };
 };
 
-const buildExampleResponsePlan = (survey: TSurvey): TExampleResponsePlanRow[] => {
+const buildExampleResponsePlan = (survey: TSurvey, count: number): TExampleResponsePlanRow[] => {
   const { ctx } = buildExampleResponsesSchema(survey);
   if (ctx.supportedElementIds.length === 0) {
     return [];
@@ -731,7 +753,7 @@ const buildExampleResponsePlan = (survey: TSurvey): TExampleResponsePlanRow[] =>
 
   const elementsById = new Map(collectSurveyElements(survey).map((el) => [el.id, el]));
   const finishedEndingId = survey.endings?.[0]?.id ?? null;
-  const profiles = buildRespondentProfiles(EXAMPLE_RESPONSE_COUNT);
+  const profiles = buildRespondentProfiles(count);
 
   return profiles.map((profile, index) => {
     const data: TResponseData = {};
@@ -755,7 +777,7 @@ const buildExampleResponsePlan = (survey: TSurvey): TExampleResponsePlanRow[] =>
       ttc[id] = ttcForElement(element);
     }
 
-    const isFinished = index >= Math.ceil(EXAMPLE_RESPONSE_COUNT * DROP_OFF_RATE);
+    const isFinished = index >= Math.ceil(count * DROP_OFF_RATE);
     const row: TExampleResponsePlanRow = {
       rowId: `row_${index}`,
       profile,
@@ -1010,8 +1032,9 @@ const toGeneratedResponse = (row: TExampleResponsePlanRow): TGeneratedExampleRes
 export const generateExampleResponseDataset = async ({
   survey,
   organizationId,
+  count = EXAMPLE_RESPONSE_COUNT,
 }: TGenerateExampleResponsesArgs): Promise<TGeneratedExampleDataset> => {
-  const planRows = buildExampleResponsePlan(survey);
+  const planRows = buildExampleResponsePlan(survey, count);
   if (planRows.length === 0) {
     return { responses: [], displays: [], tagName: EXAMPLE_AI_GENERATED_TAG_NAME };
   }
@@ -1020,7 +1043,7 @@ export const generateExampleResponseDataset = async ({
 
   return {
     responses: rowsWithText.map(toGeneratedResponse),
-    displays: buildExampleImpressionTimestamps(EXAMPLE_IMPRESSION_ONLY_COUNT).map((createdAt) => ({
+    displays: buildExampleImpressionTimestamps(getImpressionOnlyCount(count)).map((createdAt) => ({
       createdAt,
     })),
     tagName: EXAMPLE_AI_GENERATED_TAG_NAME,

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -3466,6 +3466,7 @@ checksums:
     workspace/surveys/summary/generate_example_responses_locked_plan: 42f254b6243c859c7bd6f4f12f284b91
     workspace/surveys/summary/generating_example_responses: 49e68bed3aae7d2b51e5bbab69ccd2aa
     workspace/surveys/summary/generating_qr_code: 5026d4a76f995db458195e5215d9bbd9
+    workspace/surveys/summary/how_many_example_responses: 470da27b013730a563ccdcc0ac7cdd99
     workspace/surveys/summary/impressions: 7fe38d42d68a64d3fd8436a063751584
     workspace/surveys/summary/impressions_identified_only: 10f8c491463c73b8e6534314ee00d165
     workspace/surveys/summary/impressions_tooltip: 4d0823cbf360304770c7c5913e33fdc8

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "KI-Beispielantworten sind in deinem aktuellen Tarif nicht verfügbar.",
         "generating_example_responses": "Beispielantworten werden generiert…",
         "generating_qr_code": "QR-Code wird erstellt",
+        "how_many_example_responses": "Wie viele Antworten brauchst du?",
         "impressions": "Impressionen",
         "impressions_identified_only": "Es werden nur Impressionen von identifizierten Kontakten angezeigt",
         "impressions_tooltip": "Anzahl der Male, wie oft die Umfrage angesehen wurde.",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "AI example responses are not available on your current plan.",
         "generating_example_responses": "Generating example responses…",
         "generating_qr_code": "Generating QR code",
+        "how_many_example_responses": "How many responses do you need?",
         "impressions": "Impressions",
         "impressions_identified_only": "Only showing impressions from identified contacts",
         "impressions_tooltip": "Number of times the survey has been viewed.",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "Las respuestas de ejemplo con IA no están disponibles en tu plan actual.",
         "generating_example_responses": "Generando respuestas de ejemplo…",
         "generating_qr_code": "Generando código QR",
+        "how_many_example_responses": "¿Cuántas respuestas necesitas?",
         "impressions": "Impresiones",
         "impressions_identified_only": "Solo se muestran impresiones de contactos identificados",
         "impressions_tooltip": "Número de veces que se ha visto la encuesta.",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "Les réponses d'exemple générées par IA ne sont pas disponibles avec ton forfait actuel.",
         "generating_example_responses": "Génération des exemples de réponses en cours…",
         "generating_qr_code": "Génération du code QR",
+        "how_many_example_responses": "De combien de réponses avez-vous besoin ?",
         "impressions": "Impressions",
         "impressions_identified_only": "Affichage uniquement des impressions des contacts identifiés",
         "impressions_tooltip": "Nombre de fois que l'enquête a été consultée.",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "Az AI példaválaszok nem érhetők el az Ön jelenlegi csomagjában.",
         "generating_example_responses": "Példaválaszok generálása folyamatban…",
         "generating_qr_code": "QR-kód előállítása",
+        "how_many_example_responses": "Hány válaszra van szüksége?",
         "impressions": "Megtekintések",
         "impressions_identified_only": "Csak azonosított partnerektől származó megtekintések megjelenítése",
         "impressions_tooltip": "A kérdőív megtekintési alkalmainak száma.",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "現在のプランではAIサンプル回答をご利用いただけません。",
         "generating_example_responses": "サンプル回答を生成中…",
         "generating_qr_code": "QRコードを生成中",
+        "how_many_example_responses": "回答は何件必要ですか？",
         "impressions": "表示回数",
         "impressions_identified_only": "識別済みコンタクトからのインプレッションのみを表示しています",
         "impressions_tooltip": "フォームが表示された回数。",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "AI-voorbeeldantwoorden zijn niet beschikbaar op je huidige abonnement.",
         "generating_example_responses": "Voorbeeldreacties genereren…",
         "generating_qr_code": "QR-code genereren",
+        "how_many_example_responses": "Hoeveel reacties heb je nodig?",
         "impressions": "Indrukken",
         "impressions_identified_only": "Alleen weergaven van geïdentificeerde contacten worden getoond",
         "impressions_tooltip": "Aantal keren dat de enquête is bekeken.",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "As respostas de exemplo geradas por IA não estão disponíveis no seu plano atual.",
         "generating_example_responses": "Gerando respostas de exemplo…",
         "generating_qr_code": "Gerando código QR",
+        "how_many_example_responses": "De quantas respostas você precisa?",
         "impressions": "Impressões",
         "impressions_identified_only": "Mostrando apenas impressões de contatos identificados",
         "impressions_tooltip": "Número de vezes que a pesquisa foi visualizada.",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "As respostas de exemplo de IA não estão disponíveis no teu plano atual.",
         "generating_example_responses": "A gerar respostas de exemplo…",
         "generating_qr_code": "A gerar código QR",
+        "how_many_example_responses": "De quantas respostas precisas?",
         "impressions": "Impressões",
         "impressions_identified_only": "A mostrar apenas impressões de contactos identificados",
         "impressions_tooltip": "Número de vezes que o inquérito foi visualizado.",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "Răspunsurile exemplu AI nu sunt disponibile în planul tău actual.",
         "generating_example_responses": "Se generează răspunsuri exemplu…",
         "generating_qr_code": "Se generează codul QR",
+        "how_many_example_responses": "De câte răspunsuri ai nevoie?",
         "impressions": "Impresii",
         "impressions_identified_only": "Se afișează doar impresiile de la contactele identificate",
         "impressions_tooltip": "Număr de ori când sondajul a fost vizualizat.",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "Примеры ответов с ИИ недоступны в вашем текущем тарифе.",
         "generating_example_responses": "Создаём примеры ответов…",
         "generating_qr_code": "Генерация QR-кода",
+        "how_many_example_responses": "Сколько ответов тебе нужно?",
         "impressions": "Просмотры",
         "impressions_identified_only": "Показаны только показы от идентифицированных контактов",
         "impressions_tooltip": "Количество раз, когда опрос был просмотрен.",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "AI-exempelsvar är inte tillgängliga i din nuvarande plan.",
         "generating_example_responses": "Genererar exempelsvar…",
         "generating_qr_code": "Genererar QR-kod",
+        "how_many_example_responses": "Hur många svar behöver du?",
         "impressions": "Visningar",
         "impressions_identified_only": "Visar bara visningar från identifierade kontakter",
         "impressions_tooltip": "Antal gånger enkäten har visats.",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "AI örnek yanıtları mevcut planınızda mevcut değil.",
         "generating_example_responses": "Örnek yanıtlar oluşturuluyor…",
         "generating_qr_code": "QR kodu oluşturuluyor",
+        "how_many_example_responses": "Kaç yanıta ihtiyacınız var?",
         "impressions": "Görüntülenmeler",
         "impressions_identified_only": "Yalnızca tanımlanan kişilerden gelen görüntülenmeler gösteriliyor",
         "impressions_tooltip": "Anketin görüntülenme sayısı.",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "你当前的套餐不支持 AI 示例回复。",
         "generating_example_responses": "正在生成示例回复…",
         "generating_qr_code": "正在生成二维码",
+        "how_many_example_responses": "您需要多少个回复？",
         "impressions": "印象",
         "impressions_identified_only": "仅显示已识别联系人的展示次数",
         "impressions_tooltip": "调查 被 查看 的 次数",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -3615,6 +3615,7 @@
         "generate_example_responses_locked_plan": "您目前的方案不包含 AI 範例回覆功能。",
         "generating_example_responses": "正在產生範例回應…",
         "generating_qr_code": "正在生成 QR code",
+        "how_many_example_responses": "您需要多少則回應？",
         "impressions": "曝光數",
         "impressions_identified_only": "僅顯示已識別聯絡人的曝光次數",
         "impressions_tooltip": "問卷已檢視的次數。",

--- a/apps/web/modules/ui/components/iconbar/index.tsx
+++ b/apps/web/modules/ui/components/iconbar/index.tsx
@@ -1,4 +1,6 @@
 import { LucideIcon } from "lucide-react";
+import { type ReactNode } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/modules/ui/components/popover";
 import { TooltipRenderer } from "@/modules/ui/components/tooltip";
 import { Button } from "../button";
 
@@ -10,6 +12,13 @@ interface IconAction {
   disabled?: boolean;
   isLoading?: boolean;
   iconClassName?: string;
+  // When provided, clicking the button opens a popover anchored to it instead of
+  // (or in addition to) firing onClick. The open state is controlled by the
+  // caller via popoverOpen/onPopoverOpenChange.
+  popoverContent?: ReactNode;
+  popoverOpen?: boolean;
+  onPopoverOpenChange?: (open: boolean) => void;
+  popoverAlign?: "start" | "center" | "end";
 }
 
 interface IconBarProps {
@@ -26,22 +35,36 @@ export const IconBar = ({ actions }: IconBarProps) => {
       className="flex items-center justify-center divide-x rounded-md border border-slate-300 bg-white"
       role="toolbar"
       aria-label="Action buttons">
-      {visibleActions.map((action, index) => (
-        <span key={`${action.tooltip}-${index}`}>
-          <TooltipRenderer tooltipContent={action.tooltip}>
-            <Button
-              variant="ghost"
-              className="border-none hover:bg-slate-50"
-              size="icon"
-              onClick={action.onClick}
-              disabled={action.disabled}
-              loading={action.isLoading}
-              aria-label={action.tooltip}>
-              {action.icon ? <action.icon className={action.iconClassName} /> : null}
-            </Button>
-          </TooltipRenderer>
-        </span>
-      ))}
+      {visibleActions.map((action, index) => {
+        const button = (
+          <Button
+            variant="ghost"
+            className="border-none hover:bg-slate-50"
+            size="icon"
+            onClick={action.onClick}
+            disabled={action.disabled}
+            loading={action.isLoading}
+            aria-label={action.tooltip}>
+            {action.icon ? <action.icon className={action.iconClassName} /> : null}
+          </Button>
+        );
+
+        return (
+          <span key={`${action.tooltip}-${index}`}>
+            {action.popoverContent ? (
+              <Popover open={action.popoverOpen} onOpenChange={action.onPopoverOpenChange}>
+                {/* Suppress the tooltip while the popover is open so the two don't overlap. */}
+                <TooltipRenderer tooltipContent={action.tooltip} shouldRender={!action.popoverOpen}>
+                  <PopoverTrigger asChild>{button}</PopoverTrigger>
+                </TooltipRenderer>
+                <PopoverContent align={action.popoverAlign ?? "end"}>{action.popoverContent}</PopoverContent>
+              </Popover>
+            ) : (
+              <TooltipRenderer tooltipContent={action.tooltip}>{button}</TooltipRenderer>
+            )}
+          </span>
+        );
+      })}
     </div>
   );
 };


### PR DESCRIPTION
## What & why

The **Generate example responses** wand button used to generate a fixed **10** responses on a single click. This adds a popover so users choose how many to generate.

- Click the wand → popover with **"How many responses do you need?"**, options **10 / 25 / 50** in one row, and **Cancel** (secondary, left) + **Generate** (primary, right) CTAs.
- The selected count is sent to `generateExampleResponsesAction`, validated server-side against the allowed set (`ZExampleResponseCount`), and threaded through `generateExampleResponseDataset`.
- Impression-only displays now scale with the count (`round(count × 0.6)`) so the simulated completion rate (~62%) holds at 10, 25 or 50.

## Screenshots

> ℹ️ Rendered from the component's actual Tailwind classes, design tokens and lucide icons — no live instance was available in this dev environment to capture from.

**Default (10 pre-selected)**

![Generate example responses popover, 10 selected](https://raw.githubusercontent.com/formbricks/formbricks/example-responses-popover-assets/popover-default.png)

**25 selected**

![Generate example responses popover, 25 selected](https://raw.githubusercontent.com/formbricks/formbricks/example-responses-popover-assets/popover-25-selected.png)

## Changes

- **`SurveyAnalysisCTA.tsx`** — the wand action opens a controlled popover; `handleGenerateExampleResponses(count)` sends the chosen count and closes the popover on success.
- **`IconBar`** — new optional `popoverContent` / `popoverOpen` / `onPopoverOpenChange` / `popoverAlign` props; anchors a Radix popover to the button when provided (backward compatible — existing usages unchanged).
- **`example-response-options.ts`** *(new)* — shared, client-safe `EXAMPLE_RESPONSE_COUNT_OPTIONS = [10, 25, 50]` + default, so the UI options and the server-side validation can't drift.
- **`example-responses.ts`** — `count` param (default 10) through `generateExampleResponseDataset` / `buildExampleResponsePlan`; impressions scale as `round(count × 0.6)`; exported `ZExampleResponseCount` validator.
- **`actions.ts`** — `count` added to the action input schema (validated to the allowed options, defaults to 10).
- **i18n** — one new key `workspace.surveys.summary.how_many_example_responses` added to all 15 web locales + `i18n.lock`. Reuses existing `common.cancel` / `common.generate`.
- **Tests** — count-scaling and `ZExampleResponseCount` cases in `example-responses.test.ts`.

## Behavior notes

- The wand stays disabled (with the existing "AI unavailable" tooltips) when AI isn't configured, so the popover can't open in that state.
- The per-user rate limit (1/min) and the "survey must have zero responses" server check are unchanged. The validated maximum is 50, so LLM/DB cost stays bounded.

## Testing

- ✅ `scan-translations` (translation-check gate) passes — all 15 locales complete, `i18n.lock` valid (hash verified against an existing entry).
- ✅ `ZExampleResponseCount` verified standalone (10/25/50 accepted; `11`, `0`, `-5`, `100`, `10.5`, `"25"` rejected; `.default(10)` applies).
- ✅ Prettier clean on all changed files.
- ⚠️ `vitest` / `tsc` could not run in this worktree — workspace deps aren't installed there so `@formbricks/*` don't resolve (a pre-existing, unrelated test fails identically). The added tests and type changes should be confirmed by CI.

<sub>Screenshots are hosted on a throwaway `example-responses-popover-assets` branch — safe to delete after review (GitHub caches embedded images).</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
