### PR TITLE
chore: forward translation enrichment env to Hub and document enrichment config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ HUB_API_URL=http://localhost:8080
 HUB_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/hub?sslmode=disable
 # Hub image tag used by docker-compose.dev.yml (hub + hub-migrate). Leave unset to use the
 # pinned default in the compose file; override here when testing a specific Hub release.
-# HUB_IMAGE_TAG=0.3.0
+# HUB_IMAGE_TAG=0.7.1
 
 # Hub embeddings are optional. Set a provider and model to enable semantic search embeddings in
 # the Hub API and hub-worker. For provider-specific settings, see:
@@ -75,6 +75,24 @@ HUB_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/hub?sslmode=disabl
 # EMBEDDING_PROVIDER=google
 # EMBEDDING_MODEL=gemini-embedding-001
 # EMBEDDING_PROVIDER_API_KEY=
+
+# Hub sentiment / emotion / translation enrichment (Hub >= 0.7.1) are optional and off unless a
+# provider + model is set. They run in the Hub API (enqueue) and hub-worker (classify), so both
+# need these — docker-compose.dev.yml forwards them to both. For provider-specific settings
+# (Vertex via *_GOOGLE_CLOUD_PROJECT/LOCATION, base URLs, concurrency), see:
+# https://hub.formbricks.com/reference/environment-variables
+# Examples with Google AI Studio (you can reuse the embeddings API key):
+# SENTIMENT_PROVIDER=google
+# SENTIMENT_MODEL=gemini-2.5-flash
+# SENTIMENT_PROVIDER_API_KEY=
+# EMOTIONS_PROVIDER=google
+# EMOTIONS_MODEL=gemini-2.5-flash
+# EMOTIONS_PROVIDER_API_KEY=
+# Translation additionally needs a target language (TRANSLATION_DEFAULT_LANGUAGE, or a per-tenant setting):
+# TRANSLATION_PROVIDER=google
+# TRANSLATION_MODEL=gemini-2.5-flash
+# TRANSLATION_PROVIDER_API_KEY=
+# TRANSLATION_DEFAULT_LANGUAGE=en-US
 
 ##########################
 #  AI TAXONOMY (BETA)    #

--- a/.env.example
+++ b/.env.example
@@ -78,8 +78,12 @@ HUB_DATABASE_URL=postgresql://postgres:postgres@postgres:5432/hub?sslmode=disabl
 
 # Hub sentiment / emotion / translation enrichment (Hub >= 0.7.1) are optional and off unless a
 # provider + model is set. They run in the Hub API (enqueue) and hub-worker (classify), so both
-# need these — docker-compose.dev.yml forwards them to both. For provider-specific settings
-# (Vertex via *_GOOGLE_CLOUD_PROJECT/LOCATION, base URLs, concurrency), see:
+# need these — docker-compose.dev.yml forwards them to both. Supported providers: openai,
+# google (AI Studio, needs *_PROVIDER_API_KEY), google-gemini (Vertex, needs
+# *_GOOGLE_CLOUD_PROJECT/LOCATION + Application Default Credentials instead of an API key).
+# NOTE: a provider set without its required credentials crash-loops both Hub containers on
+# startup (e.g. provider "google" without an API key) — it does not degrade gracefully.
+# For base URLs, concurrency and other provider-specific settings, see:
 # https://hub.formbricks.com/reference/environment-variables
 # Examples with Google AI Studio (you can reuse the embeddings API key):
 # SENTIMENT_PROVIDER=google

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -946,6 +946,18 @@ hub:
   existingSecret: ""
 
   # Optional env vars (non-secret). Use existingSecret for secret values such as DATABASE_URL and HUB_API_KEY.
+  # Applied to both the Hub API and hub-worker (the worker merges hub.env), so providers set here also
+  # reach the classify jobs. To enable sentiment/emotion/translation enrichment (Hub >= 0.7.1), set the
+  # provider + model here and supply the API key via existingSecret. See:
+  # https://hub.formbricks.com/reference/environment-variables
+  # env:
+  #   SENTIMENT_PROVIDER: google
+  #   SENTIMENT_MODEL: gemini-2.5-flash
+  #   EMOTIONS_PROVIDER: google
+  #   EMOTIONS_MODEL: gemini-2.5-flash
+  #   TRANSLATION_PROVIDER: google
+  #   TRANSLATION_MODEL: gemini-2.5-flash
+  #   TRANSLATION_DEFAULT_LANGUAGE: en-US
   env: {}
 
   # Optional autoscaling for the Hub API deployment.

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -948,7 +948,10 @@ hub:
   # Optional env vars (non-secret). Use existingSecret for secret values such as DATABASE_URL and HUB_API_KEY.
   # Applied to both the Hub API and hub-worker (the worker merges hub.env), so providers set here also
   # reach the classify jobs. To enable sentiment/emotion/translation enrichment (Hub >= 0.7.1), set the
-  # provider + model here and supply the API key via existingSecret. See:
+  # provider + model here and supply the API key via existingSecret. Supported providers: openai,
+  # google (AI Studio, needs *_PROVIDER_API_KEY), google-gemini (Vertex, needs
+  # *_GOOGLE_CLOUD_PROJECT/LOCATION + Application Default Credentials instead of an API key).
+  # A provider set without its required credentials crash-loops both Hub pods on startup. See:
   # https://hub.formbricks.com/reference/environment-variables
   # env:
   #   SENTIMENT_PROVIDER: google

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -139,9 +139,11 @@ services:
       EMBEDDING_GOOGLE_CLOUD_PROJECT: ${EMBEDDING_GOOGLE_CLOUD_PROJECT:-}
       EMBEDDING_GOOGLE_CLOUD_LOCATION: ${EMBEDDING_GOOGLE_CLOUD_LOCATION:-}
       GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-}
-      # Hub sentiment/emotion enrichment (0.7.x) are disabled unless the matching
-      # *_PROVIDER and *_MODEL pair is set. The anchor feeds both the API (enqueues)
-      # and the worker (classifies) — configuring only one side leaves jobs unprocessed.
+      # Hub sentiment/emotion/translation enrichment (0.7.x) are disabled unless the
+      # matching *_PROVIDER and *_MODEL pair is set (translation additionally needs a
+      # target language — TRANSLATION_DEFAULT_LANGUAGE, or a per-tenant setting). The
+      # anchor feeds both the API (enqueues) and the worker (classifies) — configuring
+      # only one side leaves jobs unprocessed.
       SENTIMENT_PROVIDER: ${SENTIMENT_PROVIDER:-}
       SENTIMENT_MODEL: ${SENTIMENT_MODEL:-}
       SENTIMENT_PROVIDER_API_KEY: ${SENTIMENT_PROVIDER_API_KEY:-}
@@ -152,6 +154,12 @@ services:
       EMOTIONS_PROVIDER_API_KEY: ${EMOTIONS_PROVIDER_API_KEY:-}
       EMOTIONS_GOOGLE_CLOUD_PROJECT: ${EMOTIONS_GOOGLE_CLOUD_PROJECT:-}
       EMOTIONS_GOOGLE_CLOUD_LOCATION: ${EMOTIONS_GOOGLE_CLOUD_LOCATION:-}
+      TRANSLATION_PROVIDER: ${TRANSLATION_PROVIDER:-}
+      TRANSLATION_MODEL: ${TRANSLATION_MODEL:-}
+      TRANSLATION_PROVIDER_API_KEY: ${TRANSLATION_PROVIDER_API_KEY:-}
+      TRANSLATION_DEFAULT_LANGUAGE: ${TRANSLATION_DEFAULT_LANGUAGE:-}
+      TRANSLATION_GOOGLE_CLOUD_PROJECT: ${TRANSLATION_GOOGLE_CLOUD_PROJECT:-}
+      TRANSLATION_GOOGLE_CLOUD_LOCATION: ${TRANSLATION_GOOGLE_CLOUD_LOCATION:-}
       TAXONOMY_SERVICE_URL: ${TAXONOMY_SERVICE_URL:-}
       TAXONOMY_SERVICE_TOKEN: ${TAXONOMY_SERVICE_TOKEN:-}
       HUB_INTERNAL_API_TOKEN: ${HUB_INTERNAL_API_TOKEN:-}


### PR DESCRIPTION
## What does this PR do?

Sentiment and emotion enrichment env already reach the Hub through `docker-compose.dev.yml` (added in #8436), but **translation was never plumbed through** — `TRANSLATION_*` in the environment silently had no effect because the Hub containers never received it. This completes the passthrough and documents the whole enrichment surface for self-hosters.

- **`docker-compose.dev.yml`** — add `TRANSLATION_*` (provider, model, API key, `TRANSLATION_DEFAULT_LANGUAGE`, Vertex project/location) to the shared `&hub-runtime-environment` anchor, so it reaches both the Hub API (enqueues) and `hub-worker` (classifies), exactly like sentiment/emotions.
- **`.env.example`** — the HUB section only documented embeddings; add commented `SENTIMENT_*` / `EMOTIONS_*` / `TRANSLATION_*` examples (noting translation needs a target language), and bump the stale `HUB_IMAGE_TAG=0.3.0` example to `0.7.1` (first release with the enrichment columns).
- **`charts/formbricks/values.yaml`** — a commented example under `hub.env`. No template change needed: `hub.env` already renders to both the API and worker (the worker merges `hub.env`), so it was purely undocumented.

Stacked on #8436 because the `TRANSLATION_*` lines sit alongside the `SENTIMENT_*`/`EMOTIONS_*` block that PR introduces; will retarget to `main` once #8436 merges. No app code — config + docs only.

## How should this be tested?

```bash
# With TRANSLATION_PROVIDER / TRANSLATION_MODEL / TRANSLATION_PROVIDER_API_KEY / TRANSLATION_DEFAULT_LANGUAGE in .env:
docker compose -f docker-compose.dev.yml config | grep TRANSLATION_PROVIDER
# → the resolved value now appears under BOTH the hub and hub-worker services (previously: nothing)
```

- `.env.example`: read the new HUB-section examples for clarity.
- Helm: uncomment the `hub.env` example in `values.yaml`, `helm template` → the vars appear on both the `hub` and `hub-worker` deployments.

## Checklist

### Required
- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` — N/A: config/docs only, no app code
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs` — N/A
- [ ] Merged the latest changes from main — stacked on #8436; retargets to `main` on merge
- [x] My changes don't cause any responsiveness issues — N/A: no UI
- [ ] First PR at Formbricks

### Appreciated
- [ ] If a UI change was made: screenshots — N/A
- [x] Updated the Formbricks Docs if changes were necessary — documents enrichment env in `.env.example` + `values.yaml`; hub-api-docs already lists these vars
