### PR TITLE
feat(surveys): generate 20 AI example responses instead of 10

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.test.ts
@@ -216,8 +216,8 @@ describe("generateExampleResponseDataset", () => {
     expect(result.responses).toHaveLength(EXAMPLE_RESPONSE_COUNT);
     expect(result.displays).toHaveLength(EXAMPLE_IMPRESSION_ONLY_COUNT);
     expect(result.tagName).toBe(EXAMPLE_AI_GENERATED_TAG_NAME);
-    expect(Object.values(roleCounts)).toContain(4);
-    expect(Object.values(roleCounts)).not.toEqual([2, 2, 2, 2, 2]);
+    expect(Object.values(roleCounts)).toContain(8);
+    expect(Object.values(roleCounts)).not.toEqual([4, 4, 4, 4, 4]);
     expect(mocks.generateOrganizationAIObject).not.toHaveBeenCalled();
   });
 
@@ -230,8 +230,8 @@ describe("generateExampleResponseDataset", () => {
 
     const result = await generateExampleResponseDataset({ survey, organizationId: "org_1" });
 
-    expect(result.responses[2].data.q_text).toBe("Open text answer 2");
-    expect(result.responses[2].data.q_nps).toBeTypeOf("number");
+    expect(result.responses[4].data.q_text).toBe("Open text answer 4");
+    expect(result.responses[4].data.q_nps).toBeTypeOf("number");
     expect(mocks.generateOrganizationAIObject).toHaveBeenCalledTimes(1);
     const call = vi.mocked(mocks.generateOrganizationAIObject).mock.calls[0][0];
     expect(call.organizationId).toBe("org_1");
@@ -278,7 +278,7 @@ describe("generateExampleResponseDataset", () => {
 
     const result = await generateExampleResponseDataset({ survey, organizationId: "org_1" });
 
-    expect(mocks.generateOrganizationAIObject).toHaveBeenCalledTimes(2);
+    expect(mocks.generateOrganizationAIObject).toHaveBeenCalledTimes(4);
     expect(result.responses[2].data.q_text_1).toBe("AI row_2 q_text_1");
     expect(result.responses[7].data.q_text_1).not.toBe("AI row_7 q_text_1");
     expect(result.responses[7].data.q_text_1).toBeTypeOf("string");
@@ -358,8 +358,8 @@ describe("generateExampleResponseDataset", () => {
 
     expect(finished).toBeDefined();
     if (!finished) throw new Error("Expected at least one finished response");
-    expect(finished.data.q_addr).toEqual(["5 Sample Road", "", "London", "", "SW1A 1AA", "GB"]);
-    expect(finished.data.q_contact).toEqual(["Sam", "", "sam.rivers@example.com", "", "Sample Systems"]);
+    expect(finished.data.q_addr).toEqual(["9 Fictional Blvd", "", "Sydney", "", "2000", "AU"]);
+    expect(finished.data.q_contact).toEqual(["Jordan", "", "jordan.lee@example.com", "", "Placeholder Co"]);
     expect(mocks.generateOrganizationAIObject).not.toHaveBeenCalled();
   });
 
@@ -374,8 +374,8 @@ describe("generateExampleResponseDataset", () => {
     const finished = result.responses.filter((response) => response.finished);
     const dropped = result.responses.filter((response) => !response.finished);
 
-    expect(finished).toHaveLength(8);
-    expect(dropped).toHaveLength(2);
+    expect(finished).toHaveLength(16);
+    expect(dropped).toHaveLength(4);
     expect(result.displays).toHaveLength(EXAMPLE_IMPRESSION_ONLY_COUNT);
     for (const response of result.responses) {
       expect(response.meta.source).toBe("example-generation");

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/example-responses.ts
@@ -8,7 +8,7 @@ import { type TSurvey } from "@formbricks/types/surveys/types";
 import { generateOrganizationAIObject } from "@/lib/ai/service";
 import { getLocalizedValue } from "@/lib/i18n/utils";
 
-export const EXAMPLE_RESPONSE_COUNT = 10;
+export const EXAMPLE_RESPONSE_COUNT = 20;
 // Impression-only displays simulate respondents who saw the survey but didn't
 // submit. Combined with the response count, the dashboard's completion rate
 // lands around 62% — close to typical web survey benchmarks.


### PR DESCRIPTION
## What

Bumps `EXAMPLE_RESPONSE_COUNT` from **10 → 20** in `example-responses.ts`, so the **Generate example responses** action seeds a survey with a richer synthetic dataset for the summary dashboard.

## Why

10 rows leaves the analysis dashboard looking sparse (thin charts, few open-text quotes). Doubling to 20 gives a fuller, more representative preview of what a real response set looks like, at a modest extra LLM cost for the open-text answers.

## Changes

- `EXAMPLE_RESPONSE_COUNT = 20` (single constant; `EXAMPLE_IMPRESSION_ONLY_COUNT` unchanged at 6).
- Updated the deterministic-output unit tests to the new count:
  - drop-off split → **16 finished / 4 dropped** (`ceil(20 * 0.2)`)
  - lumpy single-select distribution → `[8, 6, 2, 2, 2]`
  - open-text batching now produces **4 chunks** (still ≤ 20 requested answers/chunk); the mid-batch failure path is unchanged
  - first-finished response maps to fixture index 4 (AU address / Jordan Lee contact)

## Note for reviewers — synthetic dashboard rates shift

Displays = responses + 6 impression-only, so the summary metrics move:

| Metric | Before (10) | After (20) |
| --- | --- | --- |
| Starts (`responses / displays`) | 10/16 ≈ **63%** | 20/26 ≈ **77%** |
| Completed (`finished / displays`) | 8/16 ≈ **50%** | 16/26 ≈ **62%** |

The `EXAMPLE_IMPRESSION_ONLY_COUNT` comment says the completion rate "lands around 62%" — after this change the dashboard's **Completed** card actually reads ~62%. Left the impression count (6) and the comment as-is. If we'd rather hold the *starts* rate near 62%, bumping impressions to ~12 would do it — happy to add that if preferred.

## Testing

`vitest` for `example-responses.test.ts` — 19/19 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
