### PR TITLE
ci: bump sonarqube-scan-action to v8.2.0 (fix Java 17 deprecation)

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -52,11 +52,10 @@ jobs:
         run: |
           pnpm test:coverage
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@2500896589ef8f7247069a56136f8dc177c27ccf
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
         with:
           args: >
             -Dsonar.verbose=true
-            -Dsonar.scanner.skipJreProvisioning=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

SonarCloud stopped supporting Java 17, so the **`SonarQube` check now fails on every PR** at the scan step with *"The version of Java (17) used to run this analysis is deprecated … upgrade to Java 21 or later"* (exit 3). It's a repo-wide CI breakage — the quality gate itself is fine.

**Root cause:** the workflow sets up Java 21, but passes `-Dsonar.scanner.skipJreProvisioning=true`, so the scanner used the runner's **default `java` (17)** rather than `setup-java`'s `JAVA_HOME` (21).

**Fix:** bump `SonarSource/sonarqube-scan-action` to **v8.2.0** (pinned SHA) and **drop `skipJreProvisioning`**, so the action provisions its own Java-21 JRE. `setup-java 21` is left in place (harmless).

Surfaced while reviewing #8436 — its Sonar *gate* passes (98.9% coverage, 0 dup); the red check there is purely this scanner/Java issue, so it affects that PR and all others equally.

## How should this be tested?

This PR **verifies itself**: its own `SonarQube` check must go green. If it does, the fix holds for every PR. Nothing to run locally — it's a CI-only change.

## Checklist
### Required
- [x] Filled out the "How to test" section
- [x] Self-reviewed my own code
- [ ] Ran `pnpm build` — N/A: CI workflow change only
- [x] Checked for warnings, there are none
- [ ] Merged the latest changes from main — branched from current `main`
- [x] My changes don't cause any responsiveness issues — N/A
