### PR TITLE
ci: fix SonarQube scan failing on deprecated Java 17

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -29,12 +29,6 @@ jobs:
         with:
           node-version: 22.x
 
-      - name: Setup Java 21
-        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
-        with:
-          distribution: temurin
-          java-version: "21"
-
       - name: Install pnpm
         uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
@@ -56,7 +50,6 @@ jobs:
         with:
           args: >
             -Dsonar.verbose=true
-            -Dsonar.scanner.skipJreProvisioning=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Problem

The **SonarQube** workflow fails during analysis:

```
The version of Java (17) used to run this analysis is deprecated, and SonarQube Cloud no longer supports it. Please upgrade to Java 21 or later.
```

The scanner status payload confirms the analysis ran on Java 17 despite the workflow setting up Java 21 on the runner:

```json
"runtime":{"javaVersion":"17.0.13","javaVendor":"Eclipse Adoptium"}
```

## Root cause

`SonarSource/sonarqube-scan-action` is a **composite** action: it downloads the Scanner CLI onto the runner and hardcodes `SONAR_SCANNER_JRE` to the CLI's **bundled JRE** (Adoptium Temurin 17). Two lines added in #8217 combined to force the analysis onto that bundled Java 17:

- `-Dsonar.scanner.skipJreProvisioning=true` told the scanner **not** to download a JRE from SonarQube Cloud, so it fell back to the bundled Java 17.
- The runner-level `Setup Java 21` step only changes the runner's `JAVA_HOME` — the action ignores it because it points `SONAR_SCANNER_JRE` at its own bundled JRE. So it never affected the scan.

## Fix

- Remove `-Dsonar.scanner.skipJreProvisioning=true` so the scanner **provisions a supported JRE (Java 21+) from SonarQube Cloud** (its default behavior — SonarQube Cloud serves a currently-supported JRE version).
- Remove the now-unused `Setup Java 21` step, which never applied to the scan.

This effectively reverts the CI portion of #8217 that introduced the regression. The `harden-runner` egress policy is `audit` (not `block`) and the scanner already reaches `api.sonarcloud.io`, so JRE provisioning is unaffected.

## Verification

The scanner will report `runtime.javaVersion` as the provisioned 21+ JRE once this runs in CI. No local reproduction is possible (requires `SONAR_TOKEN` and SonarQube Cloud), so the check on this PR is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)