### PR TITLE
fix: reject scheme-relative callback URLs in login redirect [ENG-1636]

### DIFF
--- a/apps/web/lib/utils/url.test.ts
+++ b/apps/web/lib/utils/url.test.ts
@@ -92,6 +92,26 @@ describe("getValidatedCallbackUrl", () => {
   test("returns null for malformed URL", () => {
     expect(getValidatedCallbackUrl("not-a-valid-url", WEBAPP_URL)).toBeNull();
   });
+
+  test("rejects a same-origin URL with a scheme-relative (//) pathname", () => {
+    expect(
+      getValidatedCallbackUrl("https://webapp.example.com//evil.example/path?x=1#frag", WEBAPP_URL)
+    ).toBeNull();
+  });
+
+  test("rejects the dot-segment variant that normalizes to a // pathname", () => {
+    expect(getValidatedCallbackUrl("https://webapp.example.com/.//evil.example/path", WEBAPP_URL)).toBeNull();
+  });
+
+  test("rejects the backslash variant that normalizes to a // pathname", () => {
+    expect(getValidatedCallbackUrl("https://webapp.example.com/\\evil.example", WEBAPP_URL)).toBeNull();
+  });
+
+  test("still accepts a normal single-slash path", () => {
+    expect(getValidatedCallbackUrl("https://webapp.example.com/dashboard", WEBAPP_URL)).toBe(
+      "https://webapp.example.com/dashboard"
+    );
+  });
 });
 
 describe("isStringUrl", () => {

--- a/apps/web/lib/utils/url.ts
+++ b/apps/web/lib/utils/url.ts
@@ -69,6 +69,14 @@ export const getValidatedCallbackUrl = (
       return null;
     }
 
+    // A same-origin absolute URL can still carry a scheme-relative pathname ("//evil.example").
+    // Consumers that reduce the URL to pathname+search+hash (login's router.push) would then
+    // navigate off-origin. Reject it here so every consumer is protected. Backslash and
+    // dot-segment variants normalize to a "//" pathname before this check. (ENG-1636)
+    if (parsedUrl.pathname.startsWith("//")) {
+      return null;
+    }
+
     return parsedUrl.toString();
   } catch {
     return null;

--- a/apps/web/modules/auth/lib/callback-url.test.ts
+++ b/apps/web/modules/auth/lib/callback-url.test.ts
@@ -77,6 +77,12 @@ describe("auth callback URL helpers", () => {
     expect(getRelativeCallbackUrl("https://evil.example/x", WEBAPP_URL)).toBe("/");
   });
 
+  test("falls back to '/' for a same-origin URL with a scheme-relative (//) pathname", () => {
+    // Guards ENG-1636: without the validator fix this would return "//evil.example/path",
+    // which router.push resolves to an external origin.
+    expect(getRelativeCallbackUrl("http://localhost:3000//evil.example/path", WEBAPP_URL)).toBe("/");
+  });
+
   test("returns null invite token when the callback URL is invalid or has no token", () => {
     expect(getInviteTokenFromCallbackUrl("https://evil.example/invite?token=bad", WEBAPP_URL)).toBeNull();
     expect(


### PR DESCRIPTION
## What does this PR do?

Fixes a post-login open redirect in the email/password login flow (responsibly disclosed; [ENG-1636](https://linear.app/formbricks/issue/ENG-1636/security-post-login-open-redirect-via-callbackurl-in-formbricks-login)).

`getValidatedCallbackUrl` checks scheme, origin, and credentials, but a *same-origin absolute* URL whose pathname begins with `//` (e.g. `https://app.example.test//evil.example/path`) still passed validation — its origin is the app origin, its pathname is `//evil.example/path`. `getRelativeCallbackUrl` then reduced it to `pathname + search + hash`, producing a scheme-relative `//evil.example/path`. The login form passes that to `router.push(...)`, which the browser resolves against `location.href` and lands on an external origin — so a crafted login link redirects the victim off-site right after a successful login.

The fix rejects `//`-prefixed pathnames in the shared validator, right after the origin/credentials checks. I put it there (rather than at the `router.push` sink) on purpose: the validator is the single boundary every consumer already funnels through, so this also protects any future consumer that strips a URL down to its path. Because the check runs on the already-parsed `URL.pathname`, the WHATWG-normalized backslash (`/\evil.example`) and dot-segment (`/.//evil.example`) variants are covered by the same one-liner. Returning `null` needs no caller changes — login already falls back to `WEBAPP_URL`/`"/"`, and every other consumer already handles a `null` result by falling back to a safe origin.

Only the login `router.push` path was exploitable (it's the only consumer that strips the origin). The other consumers — the proxy redirect, SSO recovery, verification links, and Better Auth's own `callbackURL` — use the full validated URL, whose origin stays Formbricks, so a `//` pathname there was just a harmless same-origin path. One benign behavior change: the proxy now returns 400 for a `//`-pathname `callbackUrl` instead of redirecting to it (fail-closed, no legitimate flow produces such a URL).

## How should this be tested?

Unit tests cover the validator and the relative-path helper (this is pure edge-case logic, so it's covered at the unit layer):

```bash
cd apps/web
pnpm vitest run lib/utils/url.test.ts modules/auth/lib/callback-url.test.ts
```

The four new cases fail on `main` and pass with this change. To confirm the exploit is closed end-to-end on a running instance:

1. Open `/auth/login?callbackUrl=<origin>%2F%2Fevil.example%2Fpath` (URL-encoded `<origin>//evil.example/path`, substituting your instance origin and a host you control).
2. Sign in with a valid account.
3. Before this fix, the post-login navigation leaves for the external origin. After it, you land on the in-app default (`/`) instead.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
