### PR TITLE
fix: correct survey language switcher dropdown background (ENG-1701)

### DIFF
--- a/packages/surveys/src/components/general/language-switch.tsx
+++ b/packages/surveys/src/components/general/language-switch.tsx
@@ -115,7 +115,7 @@ export function LanguageSwitch({
       {showLanguageDropdown ? (
         <div
           className={cn(
-            "bg-input-bg text-heading border-border absolute top-10 max-h-64 space-y-2 overflow-auto rounded-md border p-2 text-xs",
+            "bg-survey-bg text-heading border-border absolute top-10 max-h-64 space-y-2 overflow-auto rounded-md border p-2 text-xs shadow-lg",
             dir === "rtl" ? "left-8" : "right-8"
           )}
           ref={languageDropdownRef}>


### PR DESCRIPTION
## Problem

The survey language switcher dropdown (`packages/surveys/src/components/general/language-switch.tsx`, rendered in live surveys) styled its panel with `bg-input-bg` — the **input-field** background token. When a survey theme sets a distinct input background color, the dropdown picked up that color instead of the survey surface, so the menu rendered with the wrong background (reported while tweaking survey colors).

<img width="606" height="550" alt="Screenshot 2026-07-09 at 5 40 23 PM" src="https://github.com/user-attachments/assets/977dc509-eea1-498b-9614-63e061a92584" />


## Solution

Use `bg-survey-bg` (the survey card surface token) for the dropdown panel — the same surface the other floating survey elements use (e.g. the scroll-to-bottom control, stacked cards) — and add `shadow-lg` so the menu reads as a popover against the survey.

Scope is intentionally the background only; the trigger button is unchanged.

```diff
- "bg-input-bg text-heading border-border ... text-xs"
+ "bg-survey-bg text-heading border-border ... text-xs shadow-lg"
```

## Testing

- Rebuilt `@formbricks/surveys` (Vite UMD + ESM) with `--force`; bundle regenerated and copied to `apps/web/public/js` — build green.
- ESLint clean on the changed file.
- Respondent-facing component, covered by Playwright E2E per repo convention (no `.tsx` unit test added).

Fixes ENG-1701.