### PR TITLE
fix: preserve current workspace when navigating to org settings (ENG-1700)

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/lib/workspace.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/lib/workspace.test.ts
@@ -47,6 +47,7 @@ describe("Workspace", () => {
           id: true,
           name: true,
         },
+        orderBy: { createdAt: "asc" },
       });
       expect(result).toEqual(mockWorkspaces);
     });
@@ -77,6 +78,7 @@ describe("Workspace", () => {
           id: true,
           name: true,
         },
+        orderBy: { createdAt: "asc" },
       });
       expect(result).toEqual(mockWorkspaces);
     });
@@ -139,6 +141,7 @@ describe("Workspace", () => {
           id: true,
           name: true,
         },
+        orderBy: { createdAt: "asc" },
       });
       expect(result).toEqual(mockWorkspaces);
     });
@@ -184,6 +187,7 @@ describe("Workspace", () => {
           id: true,
           name: true,
         },
+        orderBy: { createdAt: "asc" },
       });
       expect(result).toEqual(mockWorkspaces);
     });
@@ -203,6 +207,7 @@ describe("Workspace", () => {
           id: true,
           name: true,
         },
+        orderBy: { createdAt: "asc" },
       });
       expect(result).toEqual(mockWorkspaces);
     });
@@ -234,6 +239,7 @@ describe("Workspace", () => {
           id: true,
           name: true,
         },
+        orderBy: { createdAt: "asc" },
       });
       expect(result).toEqual(mockWorkspaces);
     });

--- a/apps/web/app/(app)/workspaces/[workspaceId]/lib/workspace.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/lib/workspace.ts
@@ -42,6 +42,9 @@ const findWorkspacesForMembership = async (
         id: true,
         name: true,
       },
+      // Deterministic order so the org-settings fallback workspace (workspaces[0]) is stable
+      // rather than arbitrary DB order when no active-workspace cookie is present.
+      orderBy: { createdAt: "asc" },
     });
     return workspaces;
   } catch (error) {

--- a/apps/web/lib/localStorage.ts
+++ b/apps/web/lib/localStorage.ts
@@ -2,3 +2,8 @@ export const FORMBRICKS_SURVEYS_FILTERS_KEY_LS = "formbricks-surveys-filters";
 export const FORMBRICKS_ENVIRONMENT_ID_LS = "formbricks-environment-id";
 export const FORMBRICKS_WORKSPACE_ID_LS = "formbricks-workspace-id";
 export const FORMBRICKS_LOGGED_IN_WITH_LS = "formbricks-logged-in-with";
+
+// Server-readable mirror of the "last active workspace". The proxy sets this from the
+// /workspaces/[workspaceId] path so server components (e.g. the workspace-agnostic org-settings
+// shell) can resolve the current workspace during render — localStorage is browser-only.
+export const FORMBRICKS_WORKSPACE_ID_COOKIE = "formbricks-workspace-id";

--- a/apps/web/modules/settings/lib/navigation-data.test.ts
+++ b/apps/web/modules/settings/lib/navigation-data.test.ts
@@ -15,7 +15,12 @@ const mocks = {
   getAccessControlPermission: vi.fn(),
   getOrganizationWorkspacesLimit: vi.fn(),
   getPublicDomain: vi.fn(),
+  cookieGet: vi.fn(),
 };
+
+vi.mock("next/headers", () => ({
+  cookies: () => Promise.resolve({ get: (name: string) => mocks.cookieGet(name) }),
+}));
 
 vi.mock("@/modules/auth/lib/session", () => ({
   getSession: (...args: unknown[]) => mocks.getSession(...args),
@@ -57,6 +62,8 @@ const seedSuccess = () => {
   mocks.getOrganizationWorkspacesLimit.mockResolvedValue(3);
   mocks.getMonthlyOrganizationResponseCount.mockResolvedValue(42);
   mocks.getPublicDomain.mockReturnValue("https://app.formbricks.com");
+  // No active-workspace cookie by default.
+  mocks.cookieGet.mockReturnValue(undefined);
 };
 
 describe("getSettingsLayoutData", () => {
@@ -96,5 +103,29 @@ describe("getSettingsLayoutData", () => {
 
     expect(data?.currentWorkspace).toBeNull();
     expect(data?.backUrl).toBe("/");
+  });
+
+  test("uses the active-workspace cookie when it is in the accessible list", async () => {
+    seedSuccess();
+    mocks.getWorkspacesByUserId.mockResolvedValue([{ id: "ws-1" }, { id: "ws-2" }]);
+    mocks.getWorkspace.mockImplementation((id: string) => Promise.resolve({ id, name: "WS" }));
+    mocks.cookieGet.mockReturnValue({ value: "ws-2" });
+
+    const data = await getSettingsLayoutData("user-1", "org-1");
+
+    expect(data?.currentWorkspace?.id).toBe("ws-2");
+    expect(data?.backUrl).toBe("/workspaces/ws-2/surveys");
+  });
+
+  test("ignores the cookie and falls back to the first workspace when it is not accessible", async () => {
+    seedSuccess();
+    mocks.getWorkspacesByUserId.mockResolvedValue([{ id: "ws-1" }, { id: "ws-2" }]);
+    mocks.getWorkspace.mockImplementation((id: string) => Promise.resolve({ id, name: "WS" }));
+    mocks.cookieGet.mockReturnValue({ value: "ws-not-mine" });
+
+    const data = await getSettingsLayoutData("user-1", "org-1");
+
+    expect(data?.currentWorkspace?.id).toBe("ws-1");
+    expect(data?.backUrl).toBe("/workspaces/ws-1/surveys");
   });
 });

--- a/apps/web/modules/settings/lib/navigation-data.ts
+++ b/apps/web/modules/settings/lib/navigation-data.ts
@@ -1,4 +1,5 @@
 import "server-only";
+import { cookies } from "next/headers";
 import type { Session } from "@formbricks/types/auth";
 import type { TOrganizationRole } from "@formbricks/types/memberships";
 import type { TWorkspace } from "@formbricks/types/workspace";
@@ -6,6 +7,7 @@ import { getOrganizationsByUserId } from "@/app/(app)/workspaces/[workspaceId]/l
 import { getWorkspacesByUserId } from "@/app/(app)/workspaces/[workspaceId]/lib/workspace";
 import { IS_DEVELOPMENT, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getPublicDomain } from "@/lib/getPublicUrl";
+import { FORMBRICKS_WORKSPACE_ID_COOKIE } from "@/lib/localStorage";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getMonthlyOrganizationResponseCount, getOrganization } from "@/lib/organization/service";
 import { getUser } from "@/lib/user/service";
@@ -50,6 +52,11 @@ export interface TSettingsLayoutData {
  *
  * `organizationId` is optional — account settings don't carry one, so we default to the user's first
  * organization.
+ *
+ * The "current" workspace is resolved from the `formbricks-workspace-id` cookie (set by the proxy from
+ * the last visited `/workspaces/[workspaceId]` path), so navigating into the workspace-agnostic
+ * org-settings routes keeps the workspace you came from. If the cookie is missing or points at a
+ * workspace the user can't access, it falls back to the first accessible workspace.
  */
 export const getSettingsLayoutData = async (
   userId: string,
@@ -81,8 +88,18 @@ export const getSettingsLayoutData = async (
 
   const responseCount = IS_FORMBRICKS_CLOUD ? await getMonthlyOrganizationResponseCount(organization.id) : 0;
 
+  // Resolve the workspace to display in the shell. Prefer the last active workspace (from the
+  // formbricks-workspace-id cookie the proxy sets on /workspaces/[workspaceId] visits) when it
+  // belongs to the accessible list; otherwise fall back to the first accessible workspace so the
+  // shell always has something to show.
+  const cookieStore = await cookies();
+  const preferredWorkspaceId = cookieStore.get(FORMBRICKS_WORKSPACE_ID_COOKIE)?.value;
+  const resolvedWorkspaceId =
+    preferredWorkspaceId && workspaces.some((w) => w.id === preferredWorkspaceId)
+      ? preferredWorkspaceId
+      : workspaces[0]?.id;
   // Full workspace object (not just id/name) so the shell can supply the WorkspaceContext.
-  const currentWorkspace = workspaces[0] ? await getWorkspace(workspaces[0].id) : null;
+  const currentWorkspace = resolvedWorkspaceId ? await getWorkspace(resolvedWorkspaceId) : null;
   const isOwnerOrManager = membership.role === "owner" || membership.role === "manager";
 
   return {

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -107,4 +107,22 @@ describe("proxy", () => {
     expect(response.status).toBe(307);
     expect(response.headers.get("location")).toBe("http://localhost:3000/environments/test");
   });
+
+  test("sets the active-workspace cookie from a /workspaces/[workspaceId] path", async () => {
+    mockGetProxySession.mockResolvedValue(null);
+
+    const response = await proxy(new NextRequest("http://localhost:3000/workspaces/ws-123/surveys"));
+
+    expect(response.cookies.get("formbricks-workspace-id")?.value).toBe("ws-123");
+  });
+
+  test("does not set the active-workspace cookie on non-workspace paths", async () => {
+    mockGetProxySession.mockResolvedValue(null);
+
+    const response = await proxy(
+      new NextRequest("http://localhost:3000/organizations/org-1/settings/general")
+    );
+
+    expect(response.cookies.get("formbricks-workspace-id")).toBeUndefined();
+  });
 });

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -4,6 +4,7 @@ import { logger } from "@formbricks/logger";
 import { isPublicDomainConfigured, isRequestFromPublicDomain } from "@/app/middleware/domain-utils";
 import { isAuthProtectedRoute, isRouteAllowedForDomain } from "@/app/middleware/endpoint-validator";
 import { WEBAPP_URL } from "@/lib/constants";
+import { FORMBRICKS_WORKSPACE_ID_COOKIE } from "@/lib/localStorage";
 import { getValidatedCallbackUrl } from "@/lib/utils/url";
 import { getProxySession } from "@/modules/auth/lib/proxy-session";
 
@@ -80,6 +81,18 @@ export const proxy = async (originalRequest: NextRequest) => {
   // Handle authentication
   const authResponse = await handleAuth(request);
   if (authResponse) return authResponse;
+
+  // Remember the active workspace so the workspace-agnostic org-settings shell can resolve it
+  // server-side (localStorage is browser-only). Mirrors the /workspaces/[workspaceId] path segment.
+  const workspaceMatch = /^\/workspaces\/([^/]+)/.exec(request.nextUrl.pathname);
+  if (workspaceMatch?.[1]) {
+    nextResponseWithCustomHeader.cookies.set(FORMBRICKS_WORKSPACE_ID_COOKIE, workspaceMatch[1], {
+      path: "/",
+      sameSite: "lax",
+      httpOnly: true,
+      maxAge: 60 * 60 * 24 * 365,
+    });
+  }
 
   return nextResponseWithCustomHeader;
 };


### PR DESCRIPTION
## Problem

Navigating from a secondary workspace into any Organization settings page snapped the settings shell back to the first workspace in the org.

Organization settings live at a workspace-agnostic route (`/organizations/[organizationId]/settings/**`) — there is no `workspaceId` in the URL. The shell rebuilt its "current workspace" from `workspaces[0]`, and that list was queried with no `orderBy`, so the pick was arbitrary (in practice the oldest workspace). Result: the sidebar Workspace section, back button, and `WorkspaceContext` all flipped to the wrong workspace.

## Solution

Remember the active workspace in a `formbricks-workspace-id` cookie and resolve the shell's current workspace from it.

- **`proxy.ts`** sets the cookie from the `/workspaces/[workspaceId]` path segment on every matching request.
- **`getSettingsLayoutData`** reads the cookie via `cookies()` and uses it **only if** it belongs to the user's accessible workspaces; otherwise it falls back to the first workspace.
- **`workspace.ts`** now orders the workspace query by `createdAt asc`, so the fallback is deterministic instead of arbitrary DB order.

### Why a cookie (not the URL or localStorage)

- The settings **shell is a server component** (rendered by the layout). Next.js layouts do **not** receive `searchParams`, so a `?workspaceId=` query param can't drive it — and it wouldn't survive refresh/deep-link anyway.
- The app already tracks the last workspace in **localStorage**, but that's browser-only and unreadable during server render. A cookie is the same "last active workspace" signal, readable server-side with no flash of the wrong workspace.

## Testing

- `navigation-data.test.ts`: added cases for cookie-in-accessible-list (uses it) and cookie-not-accessible (falls back to first). 6/6 green.
- `proxy.test.ts`: added cases asserting the cookie is set on `/workspaces/[id]` paths and not on other paths.
- `workspace.test.ts`: updated `findMany` expectations for the new `orderBy`.
- `pnpm build --filter=@formbricks/web` green; typecheck + lint clean on touched files.

Fixes ENG-1700.