### PR TITLE
fix(a11y): respect prefers-reduced-motion globally in the web app

### DIFF
--- a/apps/web/modules/ui/globals.css
+++ b/apps/web/modules/ui/globals.css
@@ -357,3 +357,21 @@ input[type="range"]::-webkit-slider-thumb {
   -webkit-appearance: none;
   background: #0f172a;
 }
+
+/* Respect prefers-reduced-motion for all CSS animations and transitions (tailwindcss-animate
+   entry/exit classes included). Durations are collapsed to a near-zero value instead of
+   `animation: none` so animationend/transitionend still fire; Radix primitives rely on them
+   to unmount `animate-out` content. Kept unlayered so it wins over layered utilities. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  ::before,
+  ::after,
+  ::backdrop {
+    animation-duration: 0.01ms !important;
+    animation-delay: 0ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds a single global `@media (prefers-reduced-motion: reduce)` block to `apps/web/modules/ui/globals.css` so users with reduced motion enabled no longer get entry/exit animations or animated transitions anywhere in the web app.

- Collapses `animation-duration` / `transition-duration` to 0.01ms (and delays to 0, iteration count to 1, `scroll-behavior: auto`) instead of `animation: none`, so `animationend` / `transitionend` still fire and Radix `animate-out` content (dropdowns, dialogs, tooltips, popovers, toasts) unmounts correctly.
- Chosen over per-component `motion-reduce:*` classes: every app surface imports this one stylesheet, so the rule covers all shared UI components under `apps/web/modules/ui/components/`, CSS transitions in feature modules, and future components without per-call-site changes. It is kept unlayered so it wins over Tailwind's layered utilities.
- JS-driven animations already respect the preference: both framer-motion consumers (`preview-survey`, `theme-styling-preview-survey`) wrap in `MotionConfig reducedMotion="user"`, and `@formkit/auto-animate` respects it by default.
- Known tradeoff: infinite animations (`animate-spin` loaders, `animate-ping-slow`) freeze to a static frame under reduced motion, which is the standard behavior; the static icon still signals loading.

Fixes #(issue)

## How should this be tested?

- In Chrome DevTools, open the Rendering panel and set "Emulate CSS media feature prefers-reduced-motion" to "reduce" (or enable "Reduce motion" in the OS accessibility settings).
- Open a survey row "Open options" dropdown: it should appear instantly with no slide/fade, and close cleanly with no stuck overlay.
- Open a modal (e.g. the survey delete confirmation): overlay and content should appear without zoom/fade and dismiss instantly via Escape or Cancel, leaving the page interactive.
- Hover buttons and sidebar items: color/transform transitions should be instant.
- Switch the emulation back to "no-preference" and confirm all animations behave as before.

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [x] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
