### PR TITLE
chore: load root .env in lingo.dev i18n:generate scripts

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,7 +19,7 @@
     "generate-api-specs": "./scripts/openapi/generate.sh",
     "merge-client-endpoints": "tsx ./scripts/openapi/merge-client-endpoints.ts",
     "generate-and-merge-api-specs": "pnpm run generate-api-specs && pnpm run merge-client-endpoints",
-    "i18n:generate": "npx lingo.dev@latest run && npx lingo.dev@latest lockfile --force"
+    "i18n:generate": "dotenv -e ../../.env -- npx lingo.dev@latest run && dotenv -e ../../.env -- npx lingo.dev@latest lockfile --force"
   },
   "dependencies": {
     "@better-auth/oauth-provider": "1.6.18",

--- a/packages/surveys/package.json
+++ b/packages/surveys/package.json
@@ -41,7 +41,7 @@
     "clean": "rimraf .turbo node_modules dist",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "i18n:generate": "npx lingo.dev@latest run && npx lingo.dev@latest lockfile --force"
+    "i18n:generate": "dotenv -e ../../.env -- npx lingo.dev@latest run && dotenv -e ../../.env -- npx lingo.dev@latest lockfile --force"
   },
   "dependencies": {
     "@calcom/embed-snippet": "1.3.3",


### PR DESCRIPTION
## Problem

Running `pnpm i18n` executes lingo.dev once per package: first in `apps/web`, then in `packages/surveys` (this is intentional; each package has its own `i18n.json` and locale files, so it is not a duplicate run).

The second run consistently failed with an authentication error. The lingo.dev CLI only loads `.env` from its current working directory: `apps/web/.env` exists and contains `LINGODOTDEV_API_KEY`, but `packages/surveys` has no `.env`, so the surveys run was always unauthenticated.

Verified before the fix:

```
apps/web         $ npx lingo.dev@latest auth  ->  Authenticated
packages/surveys $ npx lingo.dev@latest auth  ->  Not authenticated
```

## Solution

Prefix both `i18n:generate` scripts with `dotenv -e ../../.env --` so lingo.dev always receives the API key from the repo root `.env`, matching the existing pattern already used by the `test` scripts in `apps/web`. The `dotenv` binary is provided by `dotenv-cli` (hoisted via `shamefullyHoist: true`), and it silently skips a missing `.env` file, so environments that set `LINGODOTDEV_API_KEY` directly are unaffected.

`apps/web` gets the same prefix for consistency, so the whole `pnpm i18n` chain relies on a single source of truth for the key.

## Verification

- `packages/surveys $ dotenv -e ../../.env -- npx lingo.dev@latest auth` -> Authenticated
- Full `pnpm i18n` run completes with no auth errors; all translation validations pass and no locale files changed.