### PR TITLE
fix(ui): contain Radix form-bubble inputs inside Switch and Checkbox roots

### DIFF
--- a/apps/web/modules/ui/components/checkbox/index.tsx
+++ b/apps/web/modules/ui/components/checkbox/index.tsx
@@ -10,7 +10,9 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxPrimitive.CheckboxPr
     <CheckboxPrimitive.Root
       ref={ref as React.Ref<HTMLButtonElement>}
       className={cn(
-        "peer h-5 w-5 shrink-0 rounded-md border border-slate-300 bg-white focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-600 dark:focus:ring-slate-400 dark:focus:ring-offset-slate-900",
+        // Same as Switch: keep Radix's absolutely-positioned form-bubble <input> contained in
+        // the root so it can't add scrollable overflow to the page inside forms.
+        "peer relative h-5 w-5 shrink-0 rounded-md border border-slate-300 bg-white focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-700 dark:text-slate-600 dark:focus:ring-slate-400 dark:focus:ring-offset-slate-900",
         className
       )}
       {...props}>

--- a/apps/web/modules/ui/components/switch/index.tsx
+++ b/apps/web/modules/ui/components/switch/index.tsx
@@ -10,7 +10,10 @@ const Switch: React.ComponentType<SwitchPrimitives.SwitchProps> = React.forwardR
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-[20px] w-[40px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-slate-900 data-[state=unchecked]:bg-slate-200",
+      // `relative` contains Radix's absolutely-positioned form-bubble <input> inside the root;
+      // without a positioned ancestor it resolves against the page and adds scrollable overflow
+      // (blank space) below/right of the content when the switch sits inside a <form>.
+      "peer relative inline-flex h-[20px] w-[40px] shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-slate-900 data-[state=unchecked]:bg-slate-200",
       className
     )}
     {...props}


### PR DESCRIPTION
## What does this PR do?

Fixes a subtle layout bug: any page with a `Switch` (or `Checkbox`) inside a `<form>` gets an empty blank band past the bottom of the content when scrolling all the way down.

<img width="3012" height="864" alt="image" src="https://github.com/user-attachments/assets/7472136c-fc65-464a-871d-86c2777be823" />


**Problem.** When these Radix controls sit inside a form, Radix renders a hidden `<input type="checkbox">` next to the control for native form bubbling:

```html
<input aria-hidden="true" type="checkbox" style="transform: translateX(-100%); position: absolute; ..." />
```

Our `Switch` and `Checkbox` roots were not positioned, so this absolutely positioned input resolved against the page instead of the control and extended the page's scrollable area.

**Fix.** Add `relative` to both Radix roots (`apps/web/modules/ui/components/switch`, `.../checkbox`) so the hidden input is contained inside the control's own box. We cannot style the input directly (Radix renders it with inline styles), so containing it is the equivalent of making it `sr-only`.

Fixes ENG-1615

## How should this be tested?

- Open any page that renders a `Switch` inside a `<form>` and scroll to the very bottom.
- Before: an empty blank band appears after the last content; the hidden checkbox input near the switch is the element extending the scroll area.
- After: the page ends at its real content; toggling switches and checkboxes (including inside forms) still works and submits the same values.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary