### PR TITLE
fix(survey-ui): meet WCAG AA contrast on date picker today cell

### DIFF
--- a/packages/survey-ui/src/components/general/calendar.tsx
+++ b/packages/survey-ui/src/components/general/calendar.tsx
@@ -176,7 +176,7 @@ function Calendar({
         range_middle: cn("rounded-none", defaultClassNames.range_middle),
         range_end: cn("rounded-r-md bg-accent", defaultClassNames.range_end),
         today: cn(
-          "bg-accent text-brand-foreground rounded-md data-[selected=true]:rounded-none bg-brand opacity-50",
+          "border-2 border-brand rounded-md data-[selected=true]:rounded-none",
           defaultClassNames.today
         ),
         outside: cn(


### PR DESCRIPTION
## What

The calendar's `today` cell rendered with `bg-brand opacity-50`. The 50% opacity dropped the brand background's effective contrast against the surface below the WCAG AA **4.5:1** threshold — worst in dark mode — which `axe-core` flags on the survey accessibility walk (`apps/web/playwright/survey-accessibility.spec.ts`).

The unselected today cell is the only day carrying these classes, so the violation surfaced **date-dependently**: it only appears when today is not the day the walker happens to select. That's why it showed up on an unrelated PR's CI run rather than consistently.

<img width="488" height="423" alt="Screenshot 2026-07-10 at 10 38 00 AM" src="https://github.com/user-attachments/assets/4037a3fd-4ac2-4268-9462-93866e216063" />


## Fix

`packages/survey-ui/src/components/general/calendar.tsx` — `today` class list.

Mark today with a full-opacity **brand border** instead of a translucent fill. This:

- Removes the low-contrast `opacity-50` blend that failed axe.
- Keeps today **visually distinct from the selected day**, which stays a solid brand fill. (Previously a full-opacity fill for today would have been indistinguishable from the selected day — both solid brand.)
- Passes contrast: the border is a non-text UI element (3:1), and the day label keeps the default day-cell color, which already passes.

```diff
 today: cn(
-  "bg-accent text-brand-foreground rounded-md data-[selected=true]:rounded-none bg-brand opacity-50",
+  "border-2 border-brand rounded-md data-[selected=true]:rounded-none",
   defaultClassNames.today
 ),
```

## Notes

- Pre-existing issue on `main`; not introduced by any recent survey change.
- Selected day styling is unchanged (solid brand fill). Today is now an outline; when today is also the selected day, it shows the fill plus the border.