### PR TITLE
chore: Add email confirmed posthog event

### DIFF
--- a/apps/web/modules/auth/lib/auth-email-verification.integration.test.ts
+++ b/apps/web/modules/auth/lib/auth-email-verification.integration.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { resetDb } from "@/integration/reset-db";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { auth } from "@/modules/auth/lib/auth";
 import * as brevo from "@/modules/auth/lib/brevo";
 import {
@@ -14,6 +15,11 @@ vi.mock("@/modules/auth/lib/brevo", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/modules/auth/lib/brevo")>();
   return { ...actual, createBrevoCustomer: vi.fn().mockResolvedValue(undefined) };
 });
+
+// Spy capturePostHogEvent (the other afterEmailVerification side effect) without hitting PostHog.
+vi.mock("@/lib/posthog", () => ({
+  capturePostHogEvent: vi.fn(),
+}));
 
 /**
  * Integration coverage for email verification + password reset (ENG-1054) against a real Postgres.
@@ -57,11 +63,15 @@ describe("Better Auth email verification (real Postgres)", () => {
       id: verifiedUser?.id,
       email: "verify@example.com",
     });
+    // ...and captures the analytics event for the confirmation
+    expect(capturePostHogEvent).toHaveBeenCalledWith(verifiedUser?.id, "user_email_confirmed");
 
     // verify-email is a stateless signed JWT (no getAndDelete), so re-verifying is idempotent:
     // the already-verified branch returns { status: true, user: null }
     const replay = await auth.api.verifyEmail({ query: { token } });
     expect(replay).toMatchObject({ status: true, user: null });
+    // afterEmailVerification fires once per user — the replay must NOT re-emit the event
+    expect(capturePostHogEvent).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/modules/auth/lib/better-auth-email-verification.ts
+++ b/apps/web/modules/auth/lib/better-auth-email-verification.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { logger } from "@formbricks/logger";
+import { capturePostHogEvent } from "@/lib/posthog";
 import { createBrevoCustomer } from "@/modules/auth/lib/brevo";
 
 /**
@@ -14,6 +15,8 @@ export const createBrevoCustomerAfterEmailVerification = async (user: {
   id: string;
   email: string;
 }): Promise<void> => {
+  capturePostHogEvent(user.id, "user_email_confirmed", { email: user.email });
+
   void createBrevoCustomer({ id: user.id, email: user.email }).catch((err) =>
     logger.error(err, "Failed to create Brevo customer after email verification")
   );

--- a/apps/web/modules/auth/lib/better-auth-email-verification.ts
+++ b/apps/web/modules/auth/lib/better-auth-email-verification.ts
@@ -15,7 +15,7 @@ export const createBrevoCustomerAfterEmailVerification = async (user: {
   id: string;
   email: string;
 }): Promise<void> => {
-  capturePostHogEvent(user.id, "user_email_confirmed", { email: user.email });
+  capturePostHogEvent(user.id, "user_email_confirmed");
 
   void createBrevoCustomer({ id: user.id, email: user.email }).catch((err) =>
     logger.error(err, "Failed to create Brevo customer after email verification")


### PR DESCRIPTION
## Description

Adds a server-side PostHog event, `user_email_confirmed`, that fires when a user confirms their email address for the first time. The event is captured inside the Better Auth `afterEmailVerification` hook (`createBrevoCustomerAfterEmailVerification`), which Better Auth guarantees fires exactly once per user, alongside the existing Brevo CRM side effect.

## Motivation and Context

We had no analytics signal for email confirmation, leaving a gap in the signup → activation funnel. This event lets us measure how many signups verify their email and how confirmation correlates with downstream activation.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Changes

- Capture `user_email_confirmed` in `createBrevoCustomerAfterEmailVerification` with `user.id` as the `distinctId` and `{ email }` as an event property.
- Import `capturePostHogEvent` from `@/lib/posthog` (already `server-only`, no-ops when PostHog is not configured).

## How Has This Been Tested?

- [ ] Manual QA: signed up a new user, confirmed the email via the verification link, and verified the `user_email_confirmed` event appears in PostHog with the correct `distinctId` and `email`.
- [ ] Confirmed the event does not re-fire on subsequent logins (Better Auth blocks re-verification).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Notes

- Scope is first-time signup confirmation only. The email-*change* flow (`modules/auth/verify-email-change/actions.ts`) is not covered by this event.
