### PR TITLE
fix(i18n): keep main-nav category names in English across all locales

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,9 @@ Always mark React component props as `Readonly<>` (e.g., `({ children }: Readonl
 
 - All user-facing text must use the `t()` function from `react-i18next`.
 - Key naming: use lowercase with dots for nesting (e.g., `common.welcome`).
-- Translations are in `apps/web/locales/`. Default is `en-US.json`.
-- Lingo.dev is automatically translating strings from en-US into other languages on commit. Run `pnpm i18n` to generate missing translations and validate keys.
+- Translations are in `apps/web/locales/`. `en-US.json` is the source of truth.
+- **Only ever add or edit strings in `en-US.json`.** Never hand-write, translate, or edit the other (non-English) locale files yourself — those are machine-generated from en-US by Lingo.dev.
+- After adding or changing an en-US string, run `pnpm i18n` to generate the translations for every other locale and validate keys. Lingo.dev also auto-translates from en-US on commit.
 
 ## Date and Time Rendering
 

--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
@@ -123,7 +123,8 @@ export const MainNavigation = ({
     () => [
       {
         id: "ask",
-        name: t("common.ask"),
+        // Product section (IA) label — intentionally not localized (kept in English across all locales)
+        name: "Ask",
         items: [
           {
             name: t("common.surveys"),
@@ -149,7 +150,8 @@ export const MainNavigation = ({
         id: "unify-feedback",
         name: (
           <span className="inline-flex items-center gap-2">
-            <span>{t("workspace.unify.unify_feedback")}</span>
+            {/* Product section (IA) label — intentionally not localized (kept in English across all locales) */}
+            <span>Unify</span>
             <Badge
               text="Beta"
               type="gray"

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -151,7 +151,6 @@ checksums:
     common/apply_filters: 6543c1e80038b3da0f4a42848d08d4d1
     common/archived: cf5127ecfd7e43a35466a1ba5fe16450
     common/are_you_sure: 6d5cd13628a7887711fd0c29f1123652
-    common/ask: 24150ae04c60dcd8688d93a8a3a2d238
     common/attributes: 86d0ae6fea0fbb119722ed3841f8385a
     common/authorized_apps: ffed21922e6e9c0975ddcde28e0a266b
     common/back: f541015a827e37cb3b1234e56bc2aa3c

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -180,7 +180,6 @@
     "apply_filters": "Filter anwenden",
     "archived": "Archiviert",
     "are_you_sure": "Bist du sicher?",
-    "ask": "Ask",
     "attributes": "Attribute",
     "authorized_apps": "Authorized Apps",
     "back": "Zurück",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -180,7 +180,6 @@
     "apply_filters": "Apply filters",
     "archived": "Archived",
     "are_you_sure": "Are you sure?",
-    "ask": "Ask",
     "attributes": "Attributes",
     "authorized_apps": "Authorized Apps",
     "back": "Back",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -180,7 +180,6 @@
     "apply_filters": "Aplicar filtros",
     "archived": "Archivado",
     "are_you_sure": "¿Estás seguro?",
-    "ask": "Ask",
     "attributes": "Atributos",
     "authorized_apps": "Authorized Apps",
     "back": "Atrás",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -180,7 +180,6 @@
     "apply_filters": "Appliquer des filtres",
     "archived": "Archivé",
     "are_you_sure": "Es-tu sûr ?",
-    "ask": "Ask",
     "attributes": "Attributs",
     "authorized_apps": "Authorized Apps",
     "back": "Retour",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -180,7 +180,6 @@
     "apply_filters": "Szűrők alkalmazása",
     "archived": "Archiválva",
     "are_you_sure": "Biztos benne?",
-    "ask": "Kérdés",
     "attributes": "Attribútumok",
     "authorized_apps": "Authorized Apps",
     "back": "Vissza",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -180,7 +180,6 @@
     "apply_filters": "フィルターを適用",
     "archived": "アーカイブ済み",
     "are_you_sure": "よろしいですか？",
-    "ask": "Ask",
     "attributes": "属性",
     "authorized_apps": "Authorized Apps",
     "back": "戻る",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -180,7 +180,6 @@
     "apply_filters": "Pas filters toe",
     "archived": "Gearchiveerd",
     "are_you_sure": "Weet je het zeker?",
-    "ask": "Ask",
     "attributes": "Kenmerken",
     "authorized_apps": "Authorized Apps",
     "back": "Rug",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -180,7 +180,6 @@
     "apply_filters": "Aplicar filtros",
     "archived": "Arquivado",
     "are_you_sure": "Certeza?",
-    "ask": "Ask",
     "attributes": "atributos",
     "authorized_apps": "Authorized Apps",
     "back": "Voltar",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -180,7 +180,6 @@
     "apply_filters": "Aplicar filtros",
     "archived": "Arquivado",
     "are_you_sure": "Tem a certeza?",
-    "ask": "Ask",
     "attributes": "Atributos",
     "authorized_apps": "Authorized Apps",
     "back": "Voltar",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -180,7 +180,6 @@
     "apply_filters": "Aplică filtre",
     "archived": "Arhivat",
     "are_you_sure": "Ești sigur?",
-    "ask": "Ask",
     "attributes": "Atribute",
     "authorized_apps": "Authorized Apps",
     "back": "Înapoi",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -180,7 +180,6 @@
     "apply_filters": "Применить фильтры",
     "archived": "Архивный",
     "are_you_sure": "Вы уверены?",
-    "ask": "Ask",
     "attributes": "Атрибуты",
     "authorized_apps": "Authorized Apps",
     "back": "Назад",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -180,7 +180,6 @@
     "apply_filters": "Tillämpa filter",
     "archived": "Arkiverad",
     "are_you_sure": "Är du säker?",
-    "ask": "Ask",
     "attributes": "Attribut",
     "authorized_apps": "Authorized Apps",
     "back": "Tillbaka",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -180,7 +180,6 @@
     "apply_filters": "Filtreleri uygula",
     "archived": "Arşivlenmiş",
     "are_you_sure": "Emin misiniz?",
-    "ask": "Ask",
     "attributes": "Öznitelikler",
     "authorized_apps": "Authorized Apps",
     "back": "Geri",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -180,7 +180,6 @@
     "apply_filters": "应用 筛选",
     "archived": "已归档",
     "are_you_sure": "你 确定 吗？",
-    "ask": "Ask",
     "attributes": "属性",
     "authorized_apps": "Authorized Apps",
     "back": "返回",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -180,7 +180,6 @@
     "apply_filters": "套用篩選器",
     "archived": "已封存",
     "are_you_sure": "您確定嗎？",
-    "ask": "詢問",
     "attributes": "屬性",
     "authorized_apps": "Authorized Apps",
     "back": "返回",


### PR DESCRIPTION
## Problem

The main-navigation section labels (**Ask**, **Unify**) were being localized by Lingo.dev, so non-English users saw translated section names (e.g. `Kérdés`, `Vereinheitlichen`, `統整`). These are product/IA section names — they should read the same in every language.

## Solution

Treat them as non-translatable brand/section labels — the same way the adjacent `<Badge text="Beta" />` is handled — instead of routing them through i18n:

- **Hardcode** the two labels in `MainNavigation.tsx` (`"Ask"`, `"Unify"`), with a comment so they aren't re-wrapped in `t()` later.
- **Remove the now-unused `common.ask` key** from all 15 locales and from `apps/web/i18n.lock`.
- **Keep `workspace.unify.unify_feedback`** with its existing translations — it's still used as an aria-label in the Unify settings nav, so only the visible main-nav label is hardcoded (screen-reader label stays localized).

This is durable: because the strings are no longer in the translation source, Lingo can't re-translate them.

## Also in this PR

Documents the workflow in `AGENTS.md`: **only add/edit strings in `en-US.json`**, let Lingo.dev generate the other locales via `pnpm i18n` — never hand-author non-English translations. To keep a brand/section name in English everywhere, hardcode it in the component rather than editing locale files.

## Scope / notes

- **`main` does not yet have the "Act → Workflows" section** shown in some newer builds/screenshots, and the Unify header here reads "Unify" (not "Unify Feedback"). This PR covers the two labels that exist in `main` today; apply the same hardcode treatment to **Act** whenever that nav lands.
- Wording is preserved exactly (still "Ask" / "Unify") — this is an i18n change, not a copy change.

## Verification

`pnpm run scan-translations` (the Translation Validation gate) passes: `0 missing · 0 unused · all 15 locales complete · lockfile valid`.

> Heads-up on CI: the **E2E** job is red on this PR due to a **pre-existing, `main`-wide failure** in the `survey-accessibility.spec.ts` axe-core WCAG suite (added in #8372) — the identical 6 failures reproduce on unrelated PRs today and are unrelated to this locale-only change. All other checks (Build, Unit, Linters, SonarQube/SonarCloud, Docker, CodeQL, Translation Keys) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
