### PR TITLE
fix(surveys): keep "Generate responses" action visible but disabled when responses exist

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/SurveyAnalysisCTA.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/SurveyAnalysisCTA.tsx
@@ -193,6 +193,9 @@ export const SurveyAnalysisCTA = ({
     if (aiUnavailableReason === "instance_not_configured") {
       return t("workspace.surveys.summary.generate_example_responses_locked_instance");
     }
+    if (responseCount > 0) {
+      return t("workspace.surveys.summary.generate_example_responses_disabled_has_responses");
+    }
     return t("workspace.surveys.summary.generate_example_responses");
   })();
 
@@ -235,8 +238,8 @@ export const SurveyAnalysisCTA = ({
       icon: Wand2,
       tooltip: exampleResponsesTooltip,
       onClick: handleGenerateExampleResponses,
-      disabled: isGeneratingExamples || aiUnavailableReason !== null,
-      isVisible: !isReadOnly && responseCount === 0,
+      disabled: isGeneratingExamples || aiUnavailableReason !== null || responseCount > 0,
+      isVisible: !isReadOnly,
     },
     {
       icon: ListRestart,

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -3545,6 +3545,7 @@ checksums:
     workspace/surveys/summary/filtered_responses_csv: aad66a98be6a09cac8bef9e4db4a75cf
     workspace/surveys/summary/filtered_responses_excel: 06e57bae9e41979fd7fc4b8bfe3466f9
     workspace/surveys/summary/generate_example_responses: 4e353c295879b9d1fa91dd981474d536
+    workspace/surveys/summary/generate_example_responses_disabled_has_responses: fb66603fcd2ef7493b66f08959e1f497
     workspace/surveys/summary/generate_example_responses_locked_disabled: ba5de824cb89de7d3d0521bf112a46f2
     workspace/surveys/summary/generate_example_responses_locked_instance: 6deeb8aeaff3982d07e1d5a045e06d2d
     workspace/surveys/summary/generate_example_responses_locked_plan: 42f254b6243c859c7bd6f4f12f284b91

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "Gefilterte Antworten (CSV)",
         "filtered_responses_excel": "Gefilterte Antworten (Excel)",
         "generate_example_responses": "Beispielantworten generieren",
+        "generate_example_responses_disabled_has_responses": "Du kannst nur für Umfragen ohne Antworten Beispielantworten generieren. Setze die Umfrage zurück, um es auszuprobieren.",
         "generate_example_responses_locked_disabled": "KI-Beispielantworten sind für diese Organisation deaktiviert.",
         "generate_example_responses_locked_instance": "KI ist auf dieser Instanz nicht konfiguriert. Wende dich an deinen Administrator.",
         "generate_example_responses_locked_plan": "KI-Beispielantworten sind in deinem aktuellen Tarif nicht verfügbar.",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "Filtered responses (CSV)",
         "filtered_responses_excel": "Filtered responses (Excel)",
         "generate_example_responses": "Generate example responses",
+        "generate_example_responses_disabled_has_responses": "You can only generate example responses for surveys without responses. Reset survey to try.",
         "generate_example_responses_locked_disabled": "AI example responses are disabled for this organization.",
         "generate_example_responses_locked_instance": "AI is not configured on this instance. Contact your administrator.",
         "generate_example_responses_locked_plan": "AI example responses are not available on your current plan.",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "Respuestas filtradas (CSV)",
         "filtered_responses_excel": "Respuestas filtradas (Excel)",
         "generate_example_responses": "Generar respuestas de ejemplo",
+        "generate_example_responses_disabled_has_responses": "Solo puedes generar respuestas de ejemplo para encuestas sin respuestas. Restablece la encuesta para probarlo.",
         "generate_example_responses_locked_disabled": "Las respuestas de ejemplo con IA están deshabilitadas para esta organización.",
         "generate_example_responses_locked_instance": "La IA no está configurada en esta instancia. Contacta con tu administrador.",
         "generate_example_responses_locked_plan": "Las respuestas de ejemplo con IA no están disponibles en tu plan actual.",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "Réponses filtrées (CSV)",
         "filtered_responses_excel": "Réponses filtrées (Excel)",
         "generate_example_responses": "Générer des exemples de réponses",
+        "generate_example_responses_disabled_has_responses": "Tu ne peux générer des réponses d'exemple que pour les sondages sans réponses. Réinitialise le sondage pour essayer.",
         "generate_example_responses_locked_disabled": "Les réponses d'exemple générées par IA sont désactivées pour cette organisation.",
         "generate_example_responses_locked_instance": "L'IA n'est pas configurée sur cette instance. Contacte ton administrateur.",
         "generate_example_responses_locked_plan": "Les réponses d'exemple générées par IA ne sont pas disponibles avec ton forfait actuel.",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "Szűrt válaszok (CSV)",
         "filtered_responses_excel": "Szűrt válaszok (Excel)",
         "generate_example_responses": "Példaválaszok generálása",
+        "generate_example_responses_disabled_has_responses": "Csak olyan felmérésekhez hozhat létre példaválaszokat, amelyekhez még nincsenek válaszok. Állítsa vissza a felmérést a próbálkozáshoz.",
         "generate_example_responses_locked_disabled": "Az AI példaválaszok le vannak tiltva ennél a szervezetnél.",
         "generate_example_responses_locked_instance": "Az AI nincs konfigurálva ezen a példányon. Lépjen kapcsolatba a rendszergazdával.",
         "generate_example_responses_locked_plan": "Az AI példaválaszok nem érhetők el az Ön jelenlegi csomagjában.",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "フィルター済み回答 (CSV)",
         "filtered_responses_excel": "フィルター済み回答 (Excel)",
         "generate_example_responses": "サンプル回答を生成",
+        "generate_example_responses_disabled_has_responses": "サンプル回答を生成できるのは、回答のないアンケートのみです。試すにはアンケートをリセットしてください。",
         "generate_example_responses_locked_disabled": "この組織ではAIサンプル回答が無効になっています。",
         "generate_example_responses_locked_instance": "このインスタンスではAIが設定されていません。管理者に問い合わせてください。",
         "generate_example_responses_locked_plan": "現在のプランではAIサンプル回答をご利用いただけません。",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "Gefilterde reacties (CSV)",
         "filtered_responses_excel": "Gefilterde reacties (Excel)",
         "generate_example_responses": "Genereer voorbeeldreacties",
+        "generate_example_responses_disabled_has_responses": "Je kunt alleen voorbeeldantwoorden genereren voor enquêtes zonder antwoorden. Reset de enquête om het te proberen.",
         "generate_example_responses_locked_disabled": "AI-voorbeeldantwoorden zijn uitgeschakeld voor deze organisatie.",
         "generate_example_responses_locked_instance": "AI is niet geconfigureerd op deze instantie. Neem contact op met je beheerder.",
         "generate_example_responses_locked_plan": "AI-voorbeeldantwoorden zijn niet beschikbaar op je huidige abonnement.",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "Respostas filtradas (CSV)",
         "filtered_responses_excel": "Respostas filtradas (Excel)",
         "generate_example_responses": "Gerar respostas de exemplo",
+        "generate_example_responses_disabled_has_responses": "Você só pode gerar respostas de exemplo para pesquisas sem respostas. Redefina a pesquisa para testar.",
         "generate_example_responses_locked_disabled": "As respostas de exemplo geradas por IA estão desativadas para esta organização.",
         "generate_example_responses_locked_instance": "A IA não está configurada nesta instância. Entre em contato com seu administrador.",
         "generate_example_responses_locked_plan": "As respostas de exemplo geradas por IA não estão disponíveis no seu plano atual.",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "Respostas filtradas (CSV)",
         "filtered_responses_excel": "Respostas filtradas (Excel)",
         "generate_example_responses": "Gerar respostas de exemplo",
+        "generate_example_responses_disabled_has_responses": "Só podes gerar respostas de exemplo para inquéritos sem respostas. Repõe o inquérito para experimentar.",
         "generate_example_responses_locked_disabled": "As respostas de exemplo de IA estão desativadas para esta organização.",
         "generate_example_responses_locked_instance": "A IA não está configurada nesta instância. Contacta o teu administrador.",
         "generate_example_responses_locked_plan": "As respostas de exemplo de IA não estão disponíveis no teu plano atual.",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "Răspunsuri filtrate (CSV)",
         "filtered_responses_excel": "Răspunsuri filtrate (Excel)",
         "generate_example_responses": "Generează răspunsuri exemplu",
+        "generate_example_responses_disabled_has_responses": "Poți genera exemple de răspunsuri doar pentru sondaje fără răspunsuri. Resetează sondajul pentru a încerca.",
         "generate_example_responses_locked_disabled": "Răspunsurile exemplu AI sunt dezactivate pentru această organizație.",
         "generate_example_responses_locked_instance": "AI nu este configurat pe această instanță. Contactează administratorul.",
         "generate_example_responses_locked_plan": "Răspunsurile exemplu AI nu sunt disponibile în planul tău actual.",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "Отфильтрованные ответы (CSV)",
         "filtered_responses_excel": "Отфильтрованные ответы (Excel)",
         "generate_example_responses": "Создать примеры ответов",
+        "generate_example_responses_disabled_has_responses": "Вы можете сгенерировать примеры ответов только для опросов без ответов. Сбросьте опрос, чтобы попробовать.",
         "generate_example_responses_locked_disabled": "Примеры ответов с ИИ отключены для этой организации.",
         "generate_example_responses_locked_instance": "ИИ не настроен на этом сервере. Свяжитесь с администратором.",
         "generate_example_responses_locked_plan": "Примеры ответов с ИИ недоступны в вашем текущем тарифе.",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "Filtrerade svar (CSV)",
         "filtered_responses_excel": "Filtrerade svar (Excel)",
         "generate_example_responses": "Generera exempelsvar",
+        "generate_example_responses_disabled_has_responses": "Du kan bara generera exempelsvar för undersökningar utan svar. Återställ undersökningen för att prova.",
         "generate_example_responses_locked_disabled": "AI-exempelsvar är inaktiverade för den här organisationen.",
         "generate_example_responses_locked_instance": "AI är inte konfigurerat på den här instansen. Kontakta din administratör.",
         "generate_example_responses_locked_plan": "AI-exempelsvar är inte tillgängliga i din nuvarande plan.",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "Filtrelenmiş yanıtlar (CSV)",
         "filtered_responses_excel": "Filtrelenmiş yanıtlar (Excel)",
         "generate_example_responses": "Örnek yanıtlar oluştur",
+        "generate_example_responses_disabled_has_responses": "Yalnızca yanıt almamış anketler için örnek yanıtlar oluşturabilirsin. Denemek için anketi sıfırla.",
         "generate_example_responses_locked_disabled": "Bu organizasyon için AI örnek yanıtları devre dışı bırakılmış.",
         "generate_example_responses_locked_instance": "Bu örnekte AI yapılandırılmamış. Yöneticinizle iletişime geçin.",
         "generate_example_responses_locked_plan": "AI örnek yanıtları mevcut planınızda mevcut değil.",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "过滤 反馈 （CSV）",
         "filtered_responses_excel": "过滤 反馈 （Excel）",
         "generate_example_responses": "生成示例回复",
+        "generate_example_responses_disabled_has_responses": "只能为没有回复的调查生成示例回复。请重置调查后重试。",
         "generate_example_responses_locked_disabled": "此组织已禁用 AI 示例回复。",
         "generate_example_responses_locked_instance": "此实例未配置 AI。请联系你的管理员。",
         "generate_example_responses_locked_plan": "你当前的套餐不支持 AI 示例回复。",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -3694,6 +3694,7 @@
         "filtered_responses_csv": "篩選回應 (CSV)",
         "filtered_responses_excel": "篩選回應 (Excel)",
         "generate_example_responses": "產生範例回應",
+        "generate_example_responses_disabled_has_responses": "只能為沒有回應的問卷產生範例回應。請重設問卷後再試。",
         "generate_example_responses_locked_disabled": "此組織已停用 AI 範例回覆功能。",
         "generate_example_responses_locked_instance": "此實例尚未設定 AI 功能。請聯絡您的管理員。",
         "generate_example_responses_locked_plan": "您目前的方案不包含 AI 範例回覆功能。",


### PR DESCRIPTION
## What does this PR do?

On the survey **Summary** page, the ✨ _Generate responses_ action (the wand icon in the action bar) previously **disappeared** as soon as a survey had any responses. This PR keeps it **visible but disabled** once responses exist, with a tooltip that explains why and how to re-enable it.

Behavior:

- **Empty survey** → action enabled, tooltip _"Generate example responses"_ (unchanged).
- **Survey with responses** → action stays visible but **disabled**, tooltip: _"You can only generate example responses for empty surveys. Reset the survey to try it."_
- **AI unavailable** (plan / organization / instance) → still disabled with the existing locked reason, which takes precedence over the has-responses message.
- **Read-only users** → action remains hidden (unchanged).

The tooltip renders on the disabled button through the existing `TooltipRenderer` `<span>`-trigger pattern already used for the AI-unavailable state, so hovering works even while the button is disabled.

Adds a new i18n key `workspace.surveys.summary.generate_example_responses_disabled_has_responses` to **all 15 web locales** and the matching `i18n.lock` entry.

No linked issue.

## How should this be tested?

1. Open a survey's **Summary** page as an editor.
2. With **0 responses**: the wand ✨ action is enabled; hovering shows _"Generate example responses"_.
3. Collect/generate at least one response, then refresh.
4. With **responses present**: the wand action is now **still visible but disabled**; hovering shows _"You can only generate example responses for empty surveys. Reset the survey to try it."_
5. **Reset the survey** → the action becomes enabled again.
6. (Optional) With AI disabled/unavailable, confirm the existing locked-reason tooltip still shows and takes precedence.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits (n/a — no non-obvious logic added)
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

> Validation run: `scan-translations` translation gate passes (0 missing / 0 unused, all 15 locales complete, valid `i18n.lock`) and Prettier is clean on the changed files.

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
