### PR TITLE
feat(surveys): add a default survey language per workspace

### DIFF
--- a/apps/web/app/api/v3/surveys/templates/lib/resolve-default-language.test.ts
+++ b/apps/web/app/api/v3/surveys/templates/lib/resolve-default-language.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest";
+import { resolveSurveyDefaultLanguage } from "./resolve-default-language";
+
+describe("resolveSurveyDefaultLanguage", () => {
+  test("falls back to the creator's UI locale when no workspace default is set", () => {
+    expect(
+      resolveSurveyDefaultLanguage({
+        requestLocale: "en-US",
+        workspaceDefaultLanguageCode: null,
+        workspaceLanguageCodes: ["en-US", "de-DE"],
+      })
+    ).toEqual({ surveyDefaultLanguageCode: "en-US", translationLocale: "en-US" });
+  });
+
+  test("falls back to the creator's UI locale when the workspace default is undefined", () => {
+    expect(
+      resolveSurveyDefaultLanguage({
+        requestLocale: "fr-FR",
+        workspaceLanguageCodes: ["fr-FR"],
+      })
+    ).toEqual({ surveyDefaultLanguageCode: "fr-FR", translationLocale: "fr-FR" });
+  });
+
+  test("uses a configured, translatable workspace default for both the survey default and the copy", () => {
+    // English admin (en-US UI) in a German workspace: the survey defaults to German AND the copy is German.
+    expect(
+      resolveSurveyDefaultLanguage({
+        requestLocale: "en-US",
+        workspaceDefaultLanguageCode: "de-DE",
+        workspaceLanguageCodes: ["en-US", "de-DE"],
+      })
+    ).toEqual({ surveyDefaultLanguageCode: "de-DE", translationLocale: "de-DE" });
+  });
+
+  test("keeps the copy in the creator's UI locale when the workspace default is not a shipped UI locale", () => {
+    // Italian is a valid survey language but Formbricks ships no Italian UI translations, so the copy
+    // stays in the creator's locale while the survey default language still becomes Italian.
+    expect(
+      resolveSurveyDefaultLanguage({
+        requestLocale: "en-US",
+        workspaceDefaultLanguageCode: "it-IT",
+        workspaceLanguageCodes: ["en-US", "it-IT"],
+      })
+    ).toEqual({ surveyDefaultLanguageCode: "it-IT", translationLocale: "en-US" });
+  });
+
+  test("matches the workspace default against configured languages on the canonical tag", () => {
+    // Default stored as legacy "de"; the configured language is canonical "de-DE" — they must match, and
+    // the resolved code is canonical.
+    expect(
+      resolveSurveyDefaultLanguage({
+        requestLocale: "en-US",
+        workspaceDefaultLanguageCode: "de",
+        workspaceLanguageCodes: ["de-DE"],
+      })
+    ).toEqual({ surveyDefaultLanguageCode: "de-DE", translationLocale: "de-DE" });
+  });
+
+  test("ignores a stale default that is no longer a configured workspace language", () => {
+    expect(
+      resolveSurveyDefaultLanguage({
+        requestLocale: "en-US",
+        workspaceDefaultLanguageCode: "de-DE",
+        workspaceLanguageCodes: ["en-US"],
+      })
+    ).toEqual({ surveyDefaultLanguageCode: "en-US", translationLocale: "en-US" });
+  });
+
+  test("ignores an unparseable default code", () => {
+    expect(
+      resolveSurveyDefaultLanguage({
+        requestLocale: "en-US",
+        workspaceDefaultLanguageCode: "not-a-language",
+        workspaceLanguageCodes: ["en-US"],
+      })
+    ).toEqual({ surveyDefaultLanguageCode: "en-US", translationLocale: "en-US" });
+  });
+});

--- a/apps/web/app/api/v3/surveys/templates/lib/resolve-default-language.ts
+++ b/apps/web/app/api/v3/surveys/templates/lib/resolve-default-language.ts
@@ -1,0 +1,49 @@
+import { normalizeLanguageCode } from "@formbricks/i18n-utils";
+import { type TUserLocale, ZUserLocale } from "@formbricks/types/user";
+
+// The UI locales Formbricks ships translations for. When the workspace default is one of these, the
+// template's built-in copy is authored in it; otherwise the copy stays in the creator's UI locale.
+const UI_LOCALES = ZUserLocale.options as readonly string[];
+
+export type TResolvedSurveyDefaultLanguage = {
+  // Code stored as the new survey's default language (canonical BCP-47).
+  surveyDefaultLanguageCode: string;
+  // UI locale used to translate the template's built-in copy — always a supported UI locale.
+  translationLocale: TUserLocale;
+};
+
+/**
+ * Decide the default language for a survey created from a template.
+ *
+ * - No (or stale) workspace default → preserve the historical behavior: the creator's UI locale becomes
+ *   both the survey's default language and the copy language.
+ * - A configured workspace default that is also a translatable UI locale → author the copy in it, so
+ *   built-in labels (nav buttons, placeholders) render in that language, and set it as the default.
+ * - A configured workspace default that is NOT a UI locale → set it as the survey's default language but
+ *   keep the copy in the creator's UI locale (authors translate the copy afterwards).
+ */
+export function resolveSurveyDefaultLanguage(params: {
+  requestLocale: TUserLocale;
+  workspaceDefaultLanguageCode?: string | null;
+  workspaceLanguageCodes: string[];
+}): TResolvedSurveyDefaultLanguage {
+  const { requestLocale, workspaceDefaultLanguageCode, workspaceLanguageCodes } = params;
+
+  const normalizedDefault = workspaceDefaultLanguageCode
+    ? normalizeLanguageCode(workspaceDefaultLanguageCode)
+    : null;
+
+  const isConfigured =
+    normalizedDefault !== null &&
+    workspaceLanguageCodes.some((code) => (normalizeLanguageCode(code) ?? code) === normalizedDefault);
+
+  if (!normalizedDefault || !isConfigured) {
+    return { surveyDefaultLanguageCode: requestLocale, translationLocale: requestLocale };
+  }
+
+  const translationLocale = UI_LOCALES.includes(normalizedDefault)
+    ? (normalizedDefault as TUserLocale)
+    : requestLocale;
+
+  return { surveyDefaultLanguageCode: normalizedDefault, translationLocale };
+}

--- a/apps/web/app/api/v3/surveys/templates/lib/template-create.test.ts
+++ b/apps/web/app/api/v3/surveys/templates/lib/template-create.test.ts
@@ -96,6 +96,64 @@ describe("createTrustedTemplateSurveyResponse", () => {
     );
   });
 
+  test("applies a configured, translatable workspace default language to the new survey and its copy", async () => {
+    vi.mocked(getWorkspace).mockResolvedValue({
+      ...workspace,
+      defaultLanguageCode: "de-DE",
+      languages: [{ code: "de-DE" }],
+    } as any);
+
+    await createTrustedTemplateSurveyResponse({
+      body: {
+        workspaceId,
+        templateId: "product-market-fit-superhuman",
+        source: "catalog",
+        surveyType: "app",
+        defaultLanguage: "en-US",
+      },
+      authentication,
+      requestId,
+      instance,
+    });
+
+    // Copy is authored in the workspace default (German), and the survey default language is German too.
+    expect(getTranslate).toHaveBeenCalledWith("de-DE");
+    expect(createV3SurveyResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ defaultLanguage: "de-DE" }),
+      })
+    );
+  });
+
+  test("sets a non-UI-locale workspace default as the survey default but keeps the copy in the creator's locale", async () => {
+    vi.mocked(getWorkspace).mockResolvedValue({
+      ...workspace,
+      defaultLanguageCode: "it-IT",
+      languages: [{ code: "it-IT" }],
+    } as any);
+
+    await createTrustedTemplateSurveyResponse({
+      body: {
+        workspaceId,
+        templateId: "product-market-fit-superhuman",
+        source: "catalog",
+        surveyType: "app",
+        defaultLanguage: "en-US",
+      },
+      authentication,
+      requestId,
+      instance,
+    });
+
+    // No Italian UI translations ship, so the copy stays English while the survey default becomes Italian.
+    expect(getTranslate).toHaveBeenCalledWith("en-US");
+    expect(createV3SurveyResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ defaultLanguage: "it-IT" }),
+      })
+    );
+  });
+
   test("creates blank custom templates with created_from blank", async () => {
     await createTrustedTemplateSurveyResponse({
       body: {

--- a/apps/web/app/api/v3/surveys/templates/lib/template-create.ts
+++ b/apps/web/app/api/v3/surveys/templates/lib/template-create.ts
@@ -14,6 +14,7 @@ import { getWorkspace } from "@/lib/workspace/service";
 import { getTranslate } from "@/lingodotdev/server";
 import { createV3SurveyResponse } from "../../lib/operations";
 import { ZV3CreateSurveyBody, formatV3ZodInvalidParams } from "../../schemas";
+import { resolveSurveyDefaultLanguage } from "./resolve-default-language";
 import { buildV3SurveyCreatePayloadFromTemplate } from "./template-to-v3";
 
 export const ZV3TrustedTemplateCreateBody = z.object({
@@ -30,17 +31,27 @@ type TCreatedFrom = "blank" | "template" | "xm-template";
 type TResolvedTemplate = {
   template: TTemplate;
   createdFrom: TCreatedFrom;
+  // Canonical BCP-47 code the new survey adopts as its default language (workspace default, or the
+  // creator's UI locale when the workspace has no configured default).
+  surveyDefaultLanguageCode: string;
 };
 
 async function resolveTrustedTemplate(body: TTrustedTemplateCreateBody): Promise<TResolvedTemplate | null> {
-  const [workspace, t] = await Promise.all([
-    getWorkspace(body.workspaceId),
-    getTranslate(body.defaultLanguage),
-  ]);
+  const workspace = await getWorkspace(body.workspaceId);
 
   if (!workspace) {
     return null;
   }
+
+  // The workspace default language wins over the creator's UI locale; `translationLocale` is the UI
+  // locale the template copy is authored in (so built-in labels render in the right language).
+  const { surveyDefaultLanguageCode, translationLocale } = resolveSurveyDefaultLanguage({
+    requestLocale: body.defaultLanguage,
+    workspaceDefaultLanguageCode: workspace.defaultLanguageCode,
+    workspaceLanguageCodes: (workspace.languages ?? []).map((language) => language.code),
+  });
+
+  const t = await getTranslate(translationLocale);
 
   if (body.source === "custom" && body.templateId !== CUSTOM_SURVEY_TEMPLATE_ID) {
     return null;
@@ -63,6 +74,7 @@ async function resolveTrustedTemplate(body: TTrustedTemplateCreateBody): Promise
   return {
     template: replacePresetPlaceholders(template, workspace),
     createdFrom: body.source === "custom" ? "blank" : body.source === "xm" ? "xm-template" : "template",
+    surveyDefaultLanguageCode,
   };
 }
 
@@ -109,7 +121,7 @@ export async function createTrustedTemplateSurveyResponse({
         template: resolvedTemplate.template,
         workspaceId: authResult.workspaceId,
         surveyType: body.surveyType,
-        defaultLanguage: body.defaultLanguage,
+        defaultLanguage: resolvedTemplate.surveyDefaultLanguageCode,
       })
     );
 

--- a/apps/web/app/api/v3/surveys/templates/lib/template-to-v3.ts
+++ b/apps/web/app/api/v3/surveys/templates/lib/template-to-v3.ts
@@ -1,7 +1,6 @@
 import "server-only";
 import type { TSurveyType } from "@formbricks/types/surveys/types";
 import type { TTemplate } from "@formbricks/types/templates";
-import type { TUserLocale } from "@formbricks/types/user";
 import { isInternalI18nString, isPlainObject } from "../../guards";
 
 export type TV3TemplateSurveyCreatePayload = {
@@ -9,7 +8,9 @@ export type TV3TemplateSurveyCreatePayload = {
   name: string;
   type: TSurveyType;
   status: "draft";
-  defaultLanguage: TUserLocale;
+  // Canonical BCP-47 code of the survey's default language. Usually the creator's UI locale, but the
+  // workspace default language (which may be any configured survey language) takes precedence.
+  defaultLanguage: string;
   languages: [];
   metadata: unknown;
   welcomeCard: unknown;
@@ -19,16 +20,13 @@ export type TV3TemplateSurveyCreatePayload = {
   variables: unknown[];
 };
 
-function toPublicLocaleMap(
-  value: Record<string, string>,
-  defaultLanguage: TUserLocale
-): Record<string, string> {
+function toPublicLocaleMap(value: Record<string, string>, defaultLanguage: string): Record<string, string> {
   return {
     [defaultLanguage]: value.default,
   };
 }
 
-function toV3PublicValue(value: unknown, defaultLanguage: TUserLocale): unknown {
+function toV3PublicValue(value: unknown, defaultLanguage: string): unknown {
   if (isInternalI18nString(value)) {
     return toPublicLocaleMap(value, defaultLanguage);
   }
@@ -57,7 +55,7 @@ export function buildV3SurveyCreatePayloadFromTemplate({
   template: TTemplate;
   workspaceId: string;
   surveyType: TSurveyType;
-  defaultLanguage: TUserLocale;
+  defaultLanguage: string;
 }): TV3TemplateSurveyCreatePayload {
   return {
     workspaceId,

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -2074,6 +2074,8 @@ checksums:
     workspace/languages/cannot_remove_language_warning: 24f18b6c2e127b5d967f36229f983089
     workspace/languages/conflict_between_identifier_and_alias: e1ebeb085c7f336bb17717765392cd9f
     workspace/languages/conflict_between_selected_alias_and_another_language: 3df7377a54909e439e38ec76514e5439
+    workspace/languages/default: d9c6dc5c412fe94143dfd1d332ec81d4
+    workspace/languages/default_language_tooltip: 6bd4e9ad624a458ecc7206cd4ba00a33
     workspace/languages/delete_language_confirmation: 4f83321fed95d689f7ff3aa47a82ce68
     workspace/languages/duplicate_language_or_language_id: 0e17e3794b24e2428ca6ffadae0d08f3
     workspace/languages/edit_languages: c9d36f6b28557cc7d54e87c37dc18fdd
@@ -2088,6 +2090,7 @@ checksums:
     workspace/languages/remove_language: 1a64563b0f37109f97b78eddd493e381
     workspace/languages/remove_language_from_surveys_to_remove_it_from_workspace: 61bc96f9db31a29a649cc9ecd684bc39
     workspace/languages/search_items: b54b751c8b075200be579d6c8e58096b
+    workspace/languages/set_as_default: 5da44c397db07d6ed10c2c5ff14aa1d9
     workspace/look/add_background_color: 9be512ee1246e32d3958c56097d202d9
     workspace/look/add_background_color_description: adb6fcb392862b3d0e9420d9b5405ddb
     workspace/look/advanced_styling_field_border_radius: 63b8f3541a9792d705e67d5aca7b6451

--- a/apps/web/lib/language/service.ts
+++ b/apps/web/lib/language/service.ts
@@ -130,6 +130,19 @@ export const deleteLanguage = async (languageId: string, workspaceId: string): P
       select: { ...languageSelect, surveyLanguages: { select: { surveyId: true } } },
     });
 
+    // Clear the workspace default when the deleted language was it, so a dangling code can't linger and
+    // silently apply to new surveys as an (unlisted) default.
+    if (
+      workspace.defaultLanguageCode &&
+      (normalizeLanguageCode(prismaLanguage.code) ?? prismaLanguage.code) ===
+        (normalizeLanguageCode(workspace.defaultLanguageCode) ?? workspace.defaultLanguageCode)
+    ) {
+      await prisma.workspace.update({
+        where: { id: workspaceId },
+        data: { defaultLanguageCode: null },
+      });
+    }
+
     // delete unused surveyLanguages
     const language = { ...prismaLanguage, surveyLanguages: undefined };
 
@@ -170,6 +183,51 @@ export const updateLanguage = async (
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       logger.error(error, "Error updating language");
+      throw new DatabaseError(error.message);
+    }
+    throw error;
+  }
+};
+
+/**
+ * Set (or clear, with `null`) the workspace's default survey language. The code must match one of the
+ * workspace's configured languages — comparison is on the canonical BCP-47 tag so a legacy-stored code
+ * (e.g. `de`) still matches its canonical form (`de-DE`). The stored value is always canonical.
+ */
+export const setWorkspaceDefaultLanguage = async (
+  workspaceId: string,
+  languageCode: string | null
+): Promise<string | null> => {
+  try {
+    validateInputs([workspaceId, ZId]);
+    const workspace = await getWorkspace(workspaceId);
+    if (!workspace) throw new ResourceNotFoundError("Workspace not found", workspaceId);
+
+    let normalizedCode: string | null = null;
+    if (languageCode !== null) {
+      normalizedCode = normalizeLanguageCode(languageCode);
+      if (!normalizedCode) {
+        throw new ValidationError(`Invalid language code: '${languageCode}'`);
+      }
+      const isConfigured = workspace.languages.some(
+        (language) => (normalizeLanguageCode(language.code) ?? language.code) === normalizedCode
+      );
+      if (!isConfigured) {
+        throw new ValidationError(`Language '${languageCode}' is not configured for this workspace`);
+      }
+    }
+
+    await prisma.workspace.update({
+      where: { id: workspaceId },
+      data: { defaultLanguageCode: normalizedCode },
+    });
+
+    // Return the canonical code that was persisted so callers can report the new value without re-reading
+    // through the request-cached `getWorkspace` (which would still hold the pre-update snapshot).
+    return normalizedCode;
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      logger.error(error, "Error setting workspace default language");
       throw new DatabaseError(error.message);
     }
     throw error;

--- a/apps/web/lib/language/tests/language.test.ts
+++ b/apps/web/lib/language/tests/language.test.ts
@@ -9,10 +9,10 @@ import {
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
-import { DatabaseError, ValidationError } from "@formbricks/types/errors";
+import { DatabaseError, ResourceNotFoundError, ValidationError } from "@formbricks/types/errors";
 import { TWorkspace } from "@formbricks/types/workspace";
 import { getWorkspace } from "@/lib/workspace/service";
-import { createLanguage, deleteLanguage, updateLanguage } from "../service";
+import { createLanguage, deleteLanguage, setWorkspaceDefaultLanguage, updateLanguage } from "../service";
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
@@ -20,6 +20,9 @@ vi.mock("@formbricks/database", () => ({
       create: vi.fn(),
       update: vi.fn(),
       delete: vi.fn(),
+    },
+    workspace: {
+      update: vi.fn(),
     },
   },
 }));
@@ -155,6 +158,34 @@ describe("deleteLanguage", () => {
     expect(result).toEqual(mockLanguage);
   });
 
+  test("clears the workspace default when the deleted language was it (matching on canonical tag)", async () => {
+    // Workspace default stored as legacy "de", deleted language is canonical "de-DE" — they must match.
+    vi.mocked(getWorkspace).mockResolvedValue({
+      ...fakeWorkspace,
+      defaultLanguageCode: "de",
+    } as TWorkspace);
+    vi.mocked(prisma.language.delete).mockResolvedValue({ ...mockLanguage, code: "de-DE" });
+
+    await deleteLanguage(mockLanguageId, mockWorkspaceId);
+
+    expect(prisma.workspace.update).toHaveBeenCalledWith({
+      where: { id: mockWorkspaceId },
+      data: { defaultLanguageCode: null },
+    });
+  });
+
+  test("leaves the workspace default untouched when a different language is deleted", async () => {
+    vi.mocked(getWorkspace).mockResolvedValue({
+      ...fakeWorkspace,
+      defaultLanguageCode: "fr-FR",
+    } as TWorkspace);
+    vi.mocked(prisma.language.delete).mockResolvedValue({ ...mockLanguage, code: "de-DE" });
+
+    await deleteLanguage(mockLanguageId, mockWorkspaceId);
+
+    expect(prisma.workspace.update).not.toHaveBeenCalled();
+  });
+
   describe("sad path", () => {
     testInputValidation(deleteLanguage, "bad-id", mockWorkspaceId);
 
@@ -165,6 +196,74 @@ describe("deleteLanguage", () => {
       });
       vi.mocked(prisma.language.delete).mockRejectedValue(err);
       await expect(deleteLanguage(mockLanguageId, mockWorkspaceId)).rejects.toThrow(DatabaseError);
+    });
+  });
+});
+
+describe("setWorkspaceDefaultLanguage", () => {
+  const workspaceWithLanguages = {
+    ...fakeWorkspace,
+    languages: [
+      { ...mockLanguage, code: "en-US" },
+      { ...mockLanguage, id: "lang_de", code: "de-DE" },
+    ],
+  } as TWorkspace;
+
+  beforeEach(() => {
+    vi.mocked(getWorkspace).mockResolvedValue(workspaceWithLanguages);
+  });
+
+  test("persists the canonical default when the code is a configured language", async () => {
+    await setWorkspaceDefaultLanguage(mockWorkspaceId, "de-DE");
+    expect(prisma.workspace.update).toHaveBeenCalledWith({
+      where: { id: mockWorkspaceId },
+      data: { defaultLanguageCode: "de-DE" },
+    });
+  });
+
+  test("normalizes a legacy code before matching and persisting", async () => {
+    await setWorkspaceDefaultLanguage(mockWorkspaceId, "de");
+    expect(prisma.workspace.update).toHaveBeenCalledWith({
+      where: { id: mockWorkspaceId },
+      data: { defaultLanguageCode: "de-DE" },
+    });
+  });
+
+  test("clears the default when passed null", async () => {
+    await setWorkspaceDefaultLanguage(mockWorkspaceId, null);
+    expect(prisma.workspace.update).toHaveBeenCalledWith({
+      where: { id: mockWorkspaceId },
+      data: { defaultLanguageCode: null },
+    });
+  });
+
+  describe("sad path", () => {
+    test("throws ValidationError when the code is not configured for the workspace", async () => {
+      await expect(setWorkspaceDefaultLanguage(mockWorkspaceId, "fr-FR")).rejects.toThrow(ValidationError);
+      expect(prisma.workspace.update).not.toHaveBeenCalled();
+    });
+
+    test("throws ValidationError on an unparseable code", async () => {
+      await expect(setWorkspaceDefaultLanguage(mockWorkspaceId, "not a language")).rejects.toThrow(
+        ValidationError
+      );
+      expect(prisma.workspace.update).not.toHaveBeenCalled();
+    });
+
+    test("throws ResourceNotFoundError when the workspace does not exist", async () => {
+      vi.mocked(getWorkspace).mockResolvedValue(null);
+      await expect(setWorkspaceDefaultLanguage(mockWorkspaceId, "de-DE")).rejects.toThrow(
+        ResourceNotFoundError
+      );
+    });
+
+    test("throws DatabaseError on PrismaKnownRequestError", async () => {
+      const err = new Prisma.PrismaClientKnownRequestError("boom", {
+        code: "P2002",
+        clientVersion: "1",
+      });
+      vi.mocked(prisma.workspace.update).mockRejectedValue(err);
+      await expect(setWorkspaceDefaultLanguage(mockWorkspaceId, "de-DE")).rejects.toThrow(DatabaseError);
     });
   });
 });

--- a/apps/web/lib/workspace/service.ts
+++ b/apps/web/lib/workspace/service.ts
@@ -16,6 +16,7 @@ const selectWorkspace = {
   name: true,
   organizationId: true,
   languages: true,
+  defaultLanguageCode: true,
   recontactDays: true,
   linkSurveyBranding: true,
   inAppSurveyBranding: true,

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "Du kannst diese Sprache nicht entfernen, da sie noch in diesen Umfragen verwendet wird:",
       "conflict_between_identifier_and_alias": "Es gibt einen Konflikt zwischen der Kennung einer hinzugefügten Sprache und einem deiner Aliase. Aliase und Kennungen dürfen nicht identisch sein.",
       "conflict_between_selected_alias_and_another_language": "Es gibt einen Konflikt zwischen dem ausgewählten Alias und einer anderen Sprache, die diese Kennung hat. Bitte füge stattdessen die Sprache mit dieser Kennung zu deinem Workspace hinzu, um Inkonsistenzen zu vermeiden.",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "Bist du sicher, dass du diese Sprache löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden.",
       "duplicate_language_or_language_id": "Doppelte Sprache oder Sprach-ID",
       "edit_languages": "Sprachen bearbeiten",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "Bitte wähle eine Sprache aus",
       "remove_language": "Sprache entfernen",
       "remove_language_from_surveys_to_remove_it_from_workspace": "Bitte entferne die Sprache aus diesen Umfragen, um sie aus dem Workspace zu entfernen.",
-      "search_items": "Elemente suchen"
+      "search_items": "Elemente suchen",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "Hintergrundfarbe hinzufügen",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "You cannot remove this language since it is still used in these surveys:",
       "conflict_between_identifier_and_alias": "There is a conflict between the identifier of an added language and one for your aliases. Aliases and identifiers cannot be identical.",
       "conflict_between_selected_alias_and_another_language": "There is a conflict between the selected alias and another language that has this identifier. Please add the language with this identifier to your workspace instead to avoid inconsistencies.",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "Are you sure you want to delete this language? This action cannot be undone.",
       "duplicate_language_or_language_id": "Duplicate language or language ID",
       "edit_languages": "Edit languages",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "Please select a language",
       "remove_language": "Remove Language",
       "remove_language_from_surveys_to_remove_it_from_workspace": "Please remove the language from these surveys in order to remove it from the workspace.",
-      "search_items": "Search items"
+      "search_items": "Search items",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "Add background color",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "No puedes eliminar este idioma porque todavía se usa en estas encuestas:",
       "conflict_between_identifier_and_alias": "Hay un conflicto entre el identificador de un idioma añadido y uno de tus alias. Los alias y los identificadores no pueden ser idénticos.",
       "conflict_between_selected_alias_and_another_language": "Hay un conflicto entre el alias seleccionado y otro idioma que tiene este identificador. Por favor, añade el idioma con este identificador a tu espacio de trabajo para evitar inconsistencias.",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "¿Estás seguro de que quieres eliminar este idioma? Esta acción no se puede deshacer.",
       "duplicate_language_or_language_id": "Idioma o ID de idioma duplicado",
       "edit_languages": "Editar idiomas",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "Por favor, selecciona un idioma",
       "remove_language": "Eliminar idioma",
       "remove_language_from_surveys_to_remove_it_from_workspace": "Por favor, elimina el idioma de estas encuestas para poder eliminarlo del espacio de trabajo.",
-      "search_items": "Buscar elementos"
+      "search_items": "Buscar elementos",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "Añadir color de fondo",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "Vous ne pouvez pas supprimer cette langue car elle est encore utilisée dans ces enquêtes :",
       "conflict_between_identifier_and_alias": "Il y a un conflit entre l'identifiant d'une langue ajoutée et l'un de vos alias. Les alias et les identifiants ne peuvent pas être identiques.",
       "conflict_between_selected_alias_and_another_language": "Il y a un conflit entre l'alias sélectionné et une autre langue qui possède cet identifiant. Ajoute plutôt la langue avec cet identifiant à ton espace de travail pour éviter les incohérences.",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "Êtes-vous sûr de vouloir supprimer cette langue ? Cette action ne peut pas être annulée.",
       "duplicate_language_or_language_id": "Langue ou identifiant de langue en double",
       "edit_languages": "Modifier les langues",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "Veuillez sélectionner une langue",
       "remove_language": "Supprimer la langue",
       "remove_language_from_surveys_to_remove_it_from_workspace": "Veuillez supprimer la langue de ces sondages afin de la retirer de l'espace de travail.",
-      "search_items": "Rechercher des éléments"
+      "search_items": "Rechercher des éléments",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "Ajouter une couleur d'arrière-plan",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "Nem tudja eltávolítani ezt a nyelvet, mert még mindig használatban van ezekben a kérdőívekben:",
       "conflict_between_identifier_and_alias": "Ütközés van egy hozzáadott nyelv azonosítója és az álnevei egyike között. Az álnevek és az azonosítók nem lehetnek azonosak.",
       "conflict_between_selected_alias_and_another_language": "Ütközés van a kiválasztott álnév és egy másik, ezzel az azonosítóval rendelkező nyelv között. A következetlenségek elkerülése érdekében ezzel az azonosítóval adja hozzá a nyelvet a munkaterületéhez.",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "Biztosan törölni szeretné ezt a nyelvet? Ezt a műveletet nem lehet visszavonni.",
       "duplicate_language_or_language_id": "Kettőzött nyelv vagy nyelvazonosító",
       "edit_languages": "Nyelvek szerkesztése",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "Válasszon egy nyelvet",
       "remove_language": "Nyelv eltávolítása",
       "remove_language_from_surveys_to_remove_it_from_workspace": "Távolítsa el a nyelvet ezekből a kérdőívekből, hogy eltávolítsa azt a munkaterületről.",
-      "search_items": "Elemek keresése"
+      "search_items": "Elemek keresése",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "Háttérszín hozzáadása",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "この言語は以下のフォームで使用されているため、削除できません：",
       "conflict_between_identifier_and_alias": "追加された言語の識別子とエイリアスの間に競合があります。エイリアスと識別子を同一にすることはできません。",
       "conflict_between_selected_alias_and_another_language": "選択されたエイリアスと、この識別子を持つ別の言語との間に競合があります。不整合を避けるため、この識別子を持つ言語をワークスペースに追加してください。",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "この言語を削除してもよろしいですか？このアクションは元に戻せません。",
       "duplicate_language_or_language_id": "重複する言語または言語ID",
       "edit_languages": "言語を編集",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "言語を選択してください",
       "remove_language": "言語を削除",
       "remove_language_from_surveys_to_remove_it_from_workspace": "ワークスペースから削除するには、これらのフォームから言語を削除してください。",
-      "search_items": "アイテムを検索"
+      "search_items": "アイテムを検索",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "背景色を追加",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "Je kunt deze taal niet verwijderen omdat deze nog wordt gebruikt in deze enquêtes:",
       "conflict_between_identifier_and_alias": "Er is een conflict tussen de identifier van een toegevoegde taal en een van je aliassen. Aliassen en identifiers kunnen niet identiek zijn.",
       "conflict_between_selected_alias_and_another_language": "Er is een conflict tussen de geselecteerde alias en een andere taal die deze identifier heeft. Voeg in plaats daarvan de taal met deze identifier toe aan je werkruimte om inconsistenties te voorkomen.",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "Weet je zeker dat je deze taal wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
       "duplicate_language_or_language_id": "Dubbele taal of taal-ID",
       "edit_languages": "Talen bewerken",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "Selecteer een taal",
       "remove_language": "Taal verwijderen",
       "remove_language_from_surveys_to_remove_it_from_workspace": "Verwijder de taal uit deze enquêtes om deze uit de werkruimte te verwijderen.",
-      "search_items": "Items zoeken"
+      "search_items": "Items zoeken",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "Achtergrondkleur toevoegen",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "Você não pode remover este idioma, pois ele ainda está sendo usado nestas pesquisas:",
       "conflict_between_identifier_and_alias": "Há um conflito entre o identificador de um idioma adicionado e um dos seus aliases. Aliases e identificadores não podem ser idênticos.",
       "conflict_between_selected_alias_and_another_language": "Há um conflito entre o alias selecionado e outro idioma que possui este identificador. Por favor, adicione o idioma com este identificador ao seu workspace para evitar inconsistências.",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "Tem certeza de que deseja excluir este idioma? Essa ação não pode ser desfeita.",
       "duplicate_language_or_language_id": "Idioma ou ID de idioma duplicado",
       "edit_languages": "Editar idiomas",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "Por favor, selecione um idioma",
       "remove_language": "Remover idioma",
       "remove_language_from_surveys_to_remove_it_from_workspace": "Por favor, remova o idioma dessas pesquisas para removê-lo do workspace.",
-      "search_items": "Buscar itens"
+      "search_items": "Buscar itens",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "Adicionar cor de fundo",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "Não pode remover este idioma porque ainda está a ser utilizado nestes inquéritos:",
       "conflict_between_identifier_and_alias": "Existe um conflito entre o identificador de um idioma adicionado e um dos seus aliases. Aliases e identificadores não podem ser idênticos.",
       "conflict_between_selected_alias_and_another_language": "Existe um conflito entre o alias selecionado e outro idioma que possui este identificador. Por favor, adiciona o idioma com este identificador ao teu espaço de trabalho para evitar inconsistências.",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "Tem a certeza de que pretende eliminar este idioma? Esta ação não pode ser desfeita.",
       "duplicate_language_or_language_id": "Idioma ou ID de idioma duplicado",
       "edit_languages": "Editar idiomas",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "Por favor, selecione um idioma",
       "remove_language": "Remover idioma",
       "remove_language_from_surveys_to_remove_it_from_workspace": "Por favor, remova o idioma destes inquéritos para o poder remover do espaço de trabalho.",
-      "search_items": "Pesquisar itens"
+      "search_items": "Pesquisar itens",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "Adicionar cor de fundo",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "Nu poți elimina această limbă deoarece este încă folosită în următoarele sondaje:",
       "conflict_between_identifier_and_alias": "Există un conflict între identificatorul unei limbi adăugate și unul dintre aliasurile tale. Aliasurile și identificatorii nu pot fi identici.",
       "conflict_between_selected_alias_and_another_language": "Există un conflict între aliasul selectat și o altă limbă care are acest identificator. Te rugăm să adaugi în schimb limba cu acest identificator în spațiul tău de lucru pentru a evita inconsistențele.",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "Sigur vrei să ștergi această limbă? Această acțiune nu poate fi anulată.",
       "duplicate_language_or_language_id": "Limbă sau ID de limbă duplicat",
       "edit_languages": "Editați limbile",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "Vă rugăm să selectați o limbă",
       "remove_language": "Eliminați limba",
       "remove_language_from_surveys_to_remove_it_from_workspace": "Vă rugăm să eliminați limba din aceste sondaje pentru a o elimina din spațiul de lucru.",
-      "search_items": "Căutați elemente"
+      "search_items": "Căutați elemente",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "Adăugați culoare de fundal",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "Вы не можете удалить этот язык, так как он всё ещё используется в следующих опросах:",
       "conflict_between_identifier_and_alias": "Обнаружен конфликт между идентификатором добавленного языка и одним из ваших псевдонимов. Псевдонимы и идентификаторы не могут совпадать.",
       "conflict_between_selected_alias_and_another_language": "Обнаружен конфликт между выбранным псевдонимом и другим языком, который использует этот идентификатор. Пожалуйста, добавьте язык с этим идентификатором в рабочую область, чтобы избежать несоответствий.",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "Вы уверены, что хотите удалить этот язык? Это действие нельзя будет отменить.",
       "duplicate_language_or_language_id": "Дублирующийся язык или идентификатор языка",
       "edit_languages": "Редактировать языки",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "Пожалуйста, выберите язык",
       "remove_language": "Удалить язык",
       "remove_language_from_surveys_to_remove_it_from_workspace": "Пожалуйста, удалите язык из этих опросов, чтобы удалить его из рабочей области.",
-      "search_items": "Поиск элементов"
+      "search_items": "Поиск элементов",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "Добавить цвет фона",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "Du kan inte ta bort detta språk eftersom det fortfarande används i dessa enkäter:",
       "conflict_between_identifier_and_alias": "Det finns en konflikt mellan identifieraren för ett tillagt språk och en av dina alias. Alias och identifierare kan inte vara identiska.",
       "conflict_between_selected_alias_and_another_language": "Det finns en konflikt mellan det valda aliaset och ett annat språk som har denna identifierare. Lägg istället till språket med denna identifierare i din arbetsyta för att undvika inkonsekvenser.",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "Är du säker på att du vill ta bort detta språk? Denna åtgärd kan inte ångras.",
       "duplicate_language_or_language_id": "Duplicerat språk eller språk-ID",
       "edit_languages": "Redigera språk",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "Vänligen välj ett språk",
       "remove_language": "Ta bort språk",
       "remove_language_from_surveys_to_remove_it_from_workspace": "Ta bort språket från dessa enkäter för att kunna ta bort det från arbetsytan.",
-      "search_items": "Sök objekt"
+      "search_items": "Sök objekt",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "Lägg till bakgrundsfärg",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "Bu dili kaldıramazsın çünkü şu anketlerde hala kullanılıyor:",
       "conflict_between_identifier_and_alias": "Eklenen bir dilin tanımlayıcısı ile takma adlarından biri arasında çakışma var. Takma adlar ve tanımlayıcılar aynı olamaz.",
       "conflict_between_selected_alias_and_another_language": "Seçilen takma ad ile bu tanımlayıcıya sahip başka bir dil arasında çakışma var. Tutarsızlıkları önlemek için lütfen bunun yerine bu tanımlayıcıya sahip dili çalışma alanına ekle.",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "Bu dili silmek istediğinden emin misin? Bu işlem geri alınamaz.",
       "duplicate_language_or_language_id": "Tekrarlanan dil veya dil kimliği",
       "edit_languages": "Dilleri düzenle",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "Lütfen bir dil seç",
       "remove_language": "Dili Kaldır",
       "remove_language_from_surveys_to_remove_it_from_workspace": "Çalışma alanından kaldırmak için lütfen önce bu dili anketlerden kaldır.",
-      "search_items": "Öğeleri ara"
+      "search_items": "Öğeleri ara",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "Arka plan rengi ekle",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "无法移除该语言，因为它仍在以下调查中使用：",
       "conflict_between_identifier_and_alias": "已添加语言的标识符与某个别名存在冲突。别名和标识符不能相同。",
       "conflict_between_selected_alias_and_another_language": "所选别名与另一个具有该标识符的语言存在冲突。请将该标识符的语言添加到您的工作区，以避免不一致。",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "确定要删除此语言吗？此操作无法撤销。",
       "duplicate_language_or_language_id": "语言或语言 ID 重复",
       "edit_languages": "编辑语言",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "请选择一种语言",
       "remove_language": "移除语言",
       "remove_language_from_surveys_to_remove_it_from_workspace": "请先从这些调查中移除该语言，然后才能从工作区中删除。",
-      "search_items": "搜索项目"
+      "search_items": "搜索项目",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "添加背景色",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -2162,6 +2162,8 @@
       "cannot_remove_language_warning": "您無法移除此語言，因為它仍用於以下問卷：",
       "conflict_between_identifier_and_alias": "已新增語言的識別碼與您的別名發生衝突。別名與識別碼不可相同。",
       "conflict_between_selected_alias_and_another_language": "所選別名與另一個語言的識別碼發生衝突。請改為將此識別碼的語言新增至您的工作區，以避免不一致。",
+      "default": "Default",
+      "default_language_tooltip": "Newly created surveys in this workspace use this language as their default, so built-in labels like buttons start in it instead of English.",
       "delete_language_confirmation": "確定要刪除此語言嗎？此操作無法復原。",
       "duplicate_language_or_language_id": "語言或語言 ID 重複",
       "edit_languages": "編輯語言",
@@ -2175,7 +2177,8 @@
       "please_select_a_language": "請選擇一種語言",
       "remove_language": "移除語言",
       "remove_language_from_surveys_to_remove_it_from_workspace": "請先從這些問卷中移除此語言，才能從工作區移除。",
-      "search_items": "搜尋項目"
+      "search_items": "搜尋項目",
+      "set_as_default": "Set as default language"
     },
     "look": {
       "add_background_color": "新增背景顏色",

--- a/apps/web/modules/survey/multi-language-surveys/components/edit-language.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/edit-language.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { Language } from "@formbricks/database/prisma-browser";
+import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
 import { iso639Languages } from "@formbricks/i18n-utils/src/utils";
 import { TUserLocale } from "@formbricks/types/user";
 import type { TWorkspace } from "@formbricks/types/workspace";
@@ -18,6 +19,7 @@ import {
   deleteLanguageAction,
   getSurveysUsingGivenLanguageAction,
   updateLanguageAction,
+  updateWorkspaceDefaultLanguageAction,
 } from "../lib/actions";
 import { AddLanguageButton } from "./add-language-button";
 import { LanguageLabels } from "./language-labels";
@@ -31,6 +33,12 @@ interface EditLanguageProps {
 
 const checkIfDuplicateExists = (arr: string[]) => {
   return new Set(arr).size !== arr.length;
+};
+
+// Compare on the canonical tag so a legacy-stored default (e.g. `de`) still matches its row (`de-DE`).
+const isSameLanguageCode = (a: string | null, b: string | null): boolean => {
+  if (!a || !b) return false;
+  return (normalizeLanguageCode(a) ?? a) === (normalizeLanguageCode(b) ?? b);
 };
 
 const validateLanguages = (languages: Language[], t: TFunction) => {
@@ -77,6 +85,9 @@ const validateLanguages = (languages: Language[], t: TFunction) => {
 export function EditLanguage({ workspace, locale, isReadOnly }: EditLanguageProps) {
   const { t } = useTranslation();
   const [languages, setLanguages] = useState<Language[]>(workspace.languages);
+  const [defaultLanguageCode, setDefaultLanguageCode] = useState<string | null>(
+    workspace.defaultLanguageCode ?? null
+  );
   const [isEditing, setIsEditing] = useState(false);
   const [confirmationModal, setConfirmationModal] = useState({
     isOpen: false,
@@ -87,7 +98,8 @@ export function EditLanguage({ workspace, locale, isReadOnly }: EditLanguageProp
 
   useEffect(() => {
     setLanguages(workspace.languages);
-  }, [workspace.languages]);
+    setDefaultLanguageCode(workspace.defaultLanguageCode ?? null);
+  }, [workspace.languages, workspace.defaultLanguageCode]);
 
   const router = useRouter();
 
@@ -148,6 +160,11 @@ export function EditLanguage({ workspace, locale, isReadOnly }: EditLanguageProp
         setConfirmationModal((prev) => ({ ...prev, isOpen: false }));
         return;
       }
+      const deletedLanguage = languages.find((lang) => lang.id === languageId);
+      if (deletedLanguage && isSameLanguageCode(deletedLanguage.code, defaultLanguageCode)) {
+        // The service clears the persisted default when its language is deleted; mirror that locally.
+        setDefaultLanguageCode(null);
+      }
       setLanguages((prev) => prev.filter((lang) => lang.id !== languageId));
       toast.success(t("workspace.languages.language_deleted_successfully"));
       // Close the modal after deletion
@@ -160,6 +177,7 @@ export function EditLanguage({ workspace, locale, isReadOnly }: EditLanguageProp
 
   const handleCancelChanges = async () => {
     setLanguages(workspace.languages);
+    setDefaultLanguageCode(workspace.defaultLanguageCode ?? null);
     setIsEditing(false);
   };
 
@@ -184,6 +202,24 @@ export function EditLanguage({ workspace, locale, isReadOnly }: EditLanguageProp
       toast.error(getFormattedErrorMessage(errorResult));
       return;
     }
+
+    // Persist the default only when it changed (null↔null counts as unchanged). Runs after language
+    // create/update so a brand-new language marked as default already exists when the service validates it.
+    const originalDefault = workspace.defaultLanguageCode ?? null;
+    const defaultChanged = defaultLanguageCode
+      ? !isSameLanguageCode(defaultLanguageCode, originalDefault)
+      : originalDefault !== null;
+    if (defaultChanged) {
+      const defaultResult = await updateWorkspaceDefaultLanguageAction({
+        workspaceId: workspace.id,
+        languageCode: defaultLanguageCode,
+      });
+      if (defaultResult?.serverError) {
+        toast.error(getFormattedErrorMessage(defaultResult));
+        return;
+      }
+    }
+
     toast.success(t("workspace.languages.languages_updated_successfully"));
     router.refresh();
     setIsEditing(false);
@@ -198,10 +234,12 @@ export function EditLanguage({ workspace, locale, isReadOnly }: EditLanguageProp
             {languages.map((language, index) => (
               <LanguageRow
                 isEditing={isEditing}
+                isDefault={isSameLanguageCode(language.code, defaultLanguageCode)}
                 key={language.id}
                 language={language}
                 locale={locale}
                 onDelete={() => handleDeleteLanguage(language.id)}
+                onSetDefault={() => setDefaultLanguageCode(language.code)}
                 onLanguageChange={(newLanguage: Language) => {
                   const updatedLanguages = [...languages];
                   updatedLanguages[index] = newLanguage;

--- a/apps/web/modules/survey/multi-language-surveys/components/language-labels.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/language-labels.tsx
@@ -9,7 +9,10 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/modu
 export function LanguageLabels() {
   const { t } = useTranslation();
   return (
-    <div className="mb-2 grid w-full grid-cols-4 gap-4">
+    <div className="mb-2 grid w-full grid-cols-5 gap-4">
+      <Label className="flex items-center gap-x-2">
+        <span>{t("workspace.languages.default")}</span> <DefaultTooltip t={t} />
+      </Label>
       <Label htmlFor="languagesId">{t("workspace.languages.language")}</Label>
       <Label htmlFor="languagesId">{t("workspace.languages.identifier")}</Label>
       <Label className="flex items-center gap-x-2" htmlFor="Alias">
@@ -29,6 +32,21 @@ function AliasTooltip({ t }: Readonly<{ t: TFunction }>) {
           </div>
         </TooltipTrigger>
         <TooltipContent>{t("workspace.languages.alias_tooltip")}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function DefaultTooltip({ t }: Readonly<{ t: TFunction }>) {
+  return (
+    <TooltipProvider delayDuration={80}>
+      <Tooltip>
+        <TooltipTrigger tabIndex={-1}>
+          <div>
+            <InfoIcon className="size-4 text-slate-400" />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent>{t("workspace.languages.default_language_tooltip")}</TooltipContent>
       </Tooltip>
     </TooltipProvider>
   );

--- a/apps/web/modules/survey/multi-language-surveys/components/language-row.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/language-row.tsx
@@ -10,15 +10,36 @@ import { LanguageSelect } from "./language-select";
 interface LanguageRowProps {
   language: Language;
   isEditing: boolean;
+  isDefault: boolean;
   onLanguageChange: (newLanguage: Language) => void;
+  onSetDefault: () => void;
   onDelete: () => void;
   locale: TUserLocale;
 }
 
-export function LanguageRow({ language, isEditing, onLanguageChange, onDelete, locale }: LanguageRowProps) {
+export function LanguageRow({
+  language,
+  isEditing,
+  isDefault,
+  onLanguageChange,
+  onSetDefault,
+  onDelete,
+  locale,
+}: LanguageRowProps) {
   const { t } = useTranslation();
   return (
-    <div className="my-3 grid grid-cols-4 gap-4">
+    <div className="my-3 grid grid-cols-5 items-center gap-4">
+      <div className="flex justify-center">
+        <input
+          type="radio"
+          name="workspace-default-language"
+          className="size-4 cursor-pointer accent-brand-dark disabled:cursor-not-allowed"
+          aria-label={t("workspace.languages.set_as_default")}
+          checked={isDefault}
+          disabled={!isEditing || !language.code}
+          onChange={onSetDefault}
+        />
+      </div>
       <LanguageSelect
         disabled={language.id !== "new"}
         language={language}

--- a/apps/web/modules/survey/multi-language-surveys/lib/actions.test.ts
+++ b/apps/web/modules/survey/multi-language-surveys/lib/actions.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { updateWorkspaceDefaultLanguageAction } from "./actions";
+
+const mocks = vi.hoisted(() => ({
+  checkAuthorizationUpdated: vi.fn(),
+  setWorkspaceDefaultLanguage: vi.fn(),
+  getWorkspace: vi.fn(),
+  capturePostHogEvent: vi.fn(),
+  getOrganizationIdFromWorkspaceId: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/action-client", () => ({
+  authenticatedActionClient: {
+    inputSchema: vi.fn(() => ({
+      action: vi.fn((fn) => fn),
+    })),
+  },
+}));
+
+vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
+  checkAuthorizationUpdated: mocks.checkAuthorizationUpdated,
+}));
+
+vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
+  withAuditLogging: vi.fn((_action, _target, fn) => fn),
+}));
+
+vi.mock("@/lib/language/service", () => ({
+  createLanguage: vi.fn(),
+  deleteLanguage: vi.fn(),
+  getLanguage: vi.fn(),
+  getSurveysUsingGivenLanguage: vi.fn(),
+  setWorkspaceDefaultLanguage: mocks.setWorkspaceDefaultLanguage,
+  updateLanguage: vi.fn(),
+}));
+
+vi.mock("@/lib/workspace/service", () => ({
+  getWorkspace: mocks.getWorkspace,
+}));
+
+vi.mock("@/lib/posthog", () => ({
+  capturePostHogEvent: mocks.capturePostHogEvent,
+}));
+
+vi.mock("@/lib/utils/helper", () => ({
+  getOrganizationIdFromLanguageId: vi.fn(),
+  getOrganizationIdFromWorkspaceId: mocks.getOrganizationIdFromWorkspaceId,
+  getWorkspaceIdFromLanguageId: vi.fn(),
+}));
+
+const workspaceId = "clt2h1ant000f08l36qmx2dy2";
+const organizationId = "cm9gptbhg0000192zceq9ayuc";
+
+describe("updateWorkspaceDefaultLanguageAction", () => {
+  beforeEach(() => {
+    mocks.getOrganizationIdFromWorkspaceId.mockResolvedValue(organizationId);
+    mocks.checkAuthorizationUpdated.mockResolvedValue(undefined);
+    mocks.setWorkspaceDefaultLanguage.mockResolvedValue("de-DE");
+    mocks.getWorkspace.mockResolvedValue({ id: workspaceId, defaultLanguageCode: null });
+  });
+
+  test("authorizes, sets the default language, and records audit + analytics", async () => {
+    const ctx = { user: { id: "user_1" }, auditLoggingCtx: {} };
+    const parsedInput = { workspaceId, languageCode: "de-DE" };
+
+    await updateWorkspaceDefaultLanguageAction({ ctx, parsedInput } as any);
+
+    expect(mocks.checkAuthorizationUpdated).toHaveBeenCalledWith({
+      userId: "user_1",
+      organizationId,
+      access: [
+        { type: "organization", roles: ["owner", "manager"] },
+        { type: "workspaceTeam", workspaceId, minPermission: "manage" },
+      ],
+    });
+    expect(mocks.setWorkspaceDefaultLanguage).toHaveBeenCalledWith(workspaceId, "de-DE");
+    expect(ctx.auditLoggingCtx).toMatchObject({
+      organizationId,
+      workspaceId,
+      oldObject: { id: workspaceId, defaultLanguageCode: null },
+      newObject: { id: workspaceId, defaultLanguageCode: "de-DE" },
+    });
+    expect(mocks.capturePostHogEvent).toHaveBeenCalledWith(
+      "user_1",
+      "workspace_default_language_set",
+      expect.objectContaining({
+        organization_id: organizationId,
+        workspace_id: workspaceId,
+        language_code: "de-DE",
+      }),
+      { organizationId, workspaceId }
+    );
+  });
+
+  test("passes a null languageCode through to clear the default", async () => {
+    const ctx = { user: { id: "user_1" }, auditLoggingCtx: {} };
+    const parsedInput = { workspaceId, languageCode: null };
+
+    await updateWorkspaceDefaultLanguageAction({ ctx, parsedInput } as any);
+
+    expect(mocks.setWorkspaceDefaultLanguage).toHaveBeenCalledWith(workspaceId, null);
+  });
+});

--- a/apps/web/modules/survey/multi-language-surveys/lib/actions.ts
+++ b/apps/web/modules/survey/multi-language-surveys/lib/actions.ts
@@ -8,6 +8,7 @@ import {
   deleteLanguage,
   getLanguage,
   getSurveysUsingGivenLanguage,
+  setWorkspaceDefaultLanguage,
   updateLanguage,
 } from "@/lib/language/service";
 import { capturePostHogEvent } from "@/lib/posthog";
@@ -18,6 +19,7 @@ import {
   getOrganizationIdFromWorkspaceId,
   getWorkspaceIdFromLanguageId,
 } from "@/lib/utils/helper";
+import { getWorkspace } from "@/lib/workspace/service";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 
 const ZCreateLanguageAction = z.object({
@@ -182,3 +184,57 @@ export const updateLanguageAction = authenticatedActionClient.inputSchema(ZUpdat
     return result;
   })
 );
+
+const ZUpdateWorkspaceDefaultLanguageAction = z.object({
+  workspaceId: ZId,
+  // null clears the default (new surveys fall back to the creator's UI locale).
+  languageCode: z.string().nullable(),
+});
+
+export const updateWorkspaceDefaultLanguageAction = authenticatedActionClient
+  .inputSchema(ZUpdateWorkspaceDefaultLanguageAction)
+  .action(
+    withAuditLogging("updated", "workspace", async ({ ctx, parsedInput }) => {
+      const organizationId = await getOrganizationIdFromWorkspaceId(parsedInput.workspaceId);
+
+      await checkAuthorizationUpdated({
+        userId: ctx.user.id,
+        organizationId,
+        access: [
+          {
+            type: "organization",
+            roles: ["owner", "manager"],
+          },
+          {
+            type: "workspaceTeam",
+            workspaceId: parsedInput.workspaceId,
+            minPermission: "manage",
+          },
+        ],
+      });
+
+      const oldObject = await getWorkspace(parsedInput.workspaceId);
+      const defaultLanguageCode = await setWorkspaceDefaultLanguage(
+        parsedInput.workspaceId,
+        parsedInput.languageCode
+      );
+
+      ctx.auditLoggingCtx.organizationId = organizationId;
+      ctx.auditLoggingCtx.workspaceId = parsedInput.workspaceId;
+      ctx.auditLoggingCtx.oldObject = oldObject;
+      // Build the new snapshot from the persisted code — re-reading here would return the request-cached
+      // pre-update workspace.
+      ctx.auditLoggingCtx.newObject = oldObject ? { ...oldObject, defaultLanguageCode } : null;
+
+      capturePostHogEvent(
+        ctx.user.id,
+        "workspace_default_language_set",
+        {
+          organization_id: organizationId,
+          workspace_id: parsedInput.workspaceId,
+          language_code: parsedInput.languageCode,
+        },
+        { organizationId, workspaceId: parsedInput.workspaceId }
+      );
+    })
+  );

--- a/apps/web/modules/workspaces/settings/lib/workspace.ts
+++ b/apps/web/modules/workspaces/settings/lib/workspace.ts
@@ -59,6 +59,7 @@ const selectWorkspace = {
   name: true,
   organizationId: true,
   languages: true,
+  defaultLanguageCode: true,
   recontactDays: true,
   linkSurveyBranding: true,
   inAppSurveyBranding: true,

--- a/packages/database/migration/20260710120000_add_workspace_default_language_code/migration.sql
+++ b/packages/database/migration/20260710120000_add_workspace_default_language_code/migration.sql
@@ -1,0 +1,8 @@
+-- Workspace-level default survey language (ENG: workspace default language).
+-- Newly created surveys adopt this language as their default so teams whose surveys are authored in a
+-- non-English language no longer start every survey in English. Nullable: an unset workspace keeps the
+-- previous behavior (the creator's UI locale becomes the survey default). Stores a canonical BCP-47
+-- code that mirrors one of the workspace's Language.code values; resolution guards against a stale code.
+
+-- AlterTable
+ALTER TABLE "Workspace" ADD COLUMN "defaultLanguageCode" TEXT;

--- a/packages/database/schema.prisma
+++ b/packages/database/schema.prisma
@@ -614,6 +614,10 @@ model Workspace {
   clickOutsideClose           Boolean                      @default(true)
   overlay                     SurveyOverlay                @default(none)
   languages                   Language[]
+  /// Canonical BCP-47 code of the workspace's default survey language. Newly created surveys adopt it
+  /// as their default language. References a `Language.code` on this workspace (not a hard FK, so a code
+  /// can be re-added after deletion); resolution guards against a stale/removed code.
+  defaultLanguageCode         String?
   /// [Logo]
   logo                        Json?
   workspaceTeams              WorkspaceTeam[]

--- a/packages/types/workspace.ts
+++ b/packages/types/workspace.ts
@@ -72,6 +72,9 @@ export const ZWorkspace = z.object({
   clickOutsideClose: z.boolean(),
   overlay: ZOverlay,
   languages: z.array(ZLanguage),
+  // Canonical BCP-47 code of the workspace's default survey language (mirrors one of `languages[].code`).
+  // Newly created surveys adopt it as their default language. Null/undefined = fall back to the creator's UI locale.
+  defaultLanguageCode: z.string().nullish(),
   appSetupCompleted: z.boolean(),
   logo: ZLogo.nullish(),
   customHeadScripts: z.string().nullish(),


### PR DESCRIPTION
## Problem

When a team enables multi-language on a survey and adds, say, German, the survey's **built-in labels still default to English** (nav buttons, placeholders). There was no way to change this — the default language of every new survey was silently the *creator's UI locale*, so an English-speaking admin working for a German company got English surveys with no obvious fix. This came directly from user feedback:

> „Ein Fallstrick ist, dass … die Buttons standardmäßig englisch sind. Kann man die Defaultsprache ändern?“ → previous answer: *Geht nicht.*

## Solution

Introduce a **default survey language per workspace**, configured in **Language settings**, and apply it automatically to newly created surveys.

- **Language settings** gains a `Default` radio per language row. Pick any configured workspace language as the default (or leave none).
- **New surveys** created from templates (catalog, blank/scratch, XM, onboarding) adopt that language as their default instead of the creator's UI locale.
- When the chosen default is one of the **shipped UI locales** (e.g. German), the template copy is authored in it too — so buttons/placeholders start localized. For a survey language without shipped UI translations, the survey's default language is still set correctly and authors translate the copy afterward. With no workspace default set, behavior is unchanged (creator's UI locale).

All template-based creation flows through one server endpoint (`/api/v3/surveys/templates`), so the resolution is applied server-side in a single place and every entry point benefits.

## How it works

- **Schema**: new nullable `Workspace.defaultLanguageCode` (canonical BCP-47; mirrors one of the workspace's `Language.code`s). Not a hard FK — resolution guards a stale/removed code, and `deleteLanguage` clears the workspace default when its language is deleted.
- **Resolution**: `resolveSurveyDefaultLanguage()` centralizes precedence (workspace default > creator locale) and the copy-locale rule; unit-tested in isolation.
- **Persistence**: `updateWorkspaceDefaultLanguageAction` → `setWorkspaceDefaultLanguage` (validates the code belongs to the workspace; stores the canonical tag).

## Migration

Adds one nullable column:
```sql
ALTER TABLE "Workspace" ADD COLUMN "defaultLanguageCode" TEXT;
```
No backfill; existing workspaces keep today's behavior until a default is chosen.

## i18n

Added 3 keys to `en-US.json` (`workspace.languages.default`, `default_language_tooltip`, `set_as_default`) and updated `i18n.lock`. The other locale files carry English placeholders for now — **Lingo.dev localizes them from en-US on merge**.

## Testing

- `pnpm scan-translations` ✅ (exit 0, all locales complete, lock in sync)
- Vitest — 44 tests across the touched suites ✅ (new `resolve-default-language.test.ts`, `actions.test.ts`; extended `language.test.ts`, `template-create.test.ts`)
- `eslint` on all changed files ✅
- `tsc` — changed files type-clean ✅ (remaining errors in the tree are the pre-existing `@/images/*` module-resolution noise)
- Migration SQL applied + reverted against the local DB to validate it ✅
- ⚠️ The Language-settings UI and end-to-end survey creation are best verified with **manual QA on a live instance** (empty local DB here); UI is normally covered by Playwright E2E.

## Out of scope

- AI-generated surveys (`Create with AI`) still generate in the creator's UI locale — could adopt the workspace default in a follow-up, but it needs care around the LLM generation language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)