### PR TITLE
fix: auto-login after email verification (ENG-1746)

### DIFF
--- a/apps/web/modules/auth/lib/auth-email-verification.integration.test.ts
+++ b/apps/web/modules/auth/lib/auth-email-verification.integration.test.ts
@@ -54,10 +54,16 @@ describe("Better Auth email verification (real Postgres)", () => {
     const token = tokenFromLink(vi.mocked(sendVerificationLinkEmail).mock.calls[0][0].verifyLink);
     expect(token).toBeTruthy();
 
+    // autoSignIn is off, so sign-up creates no session (verification is still pending).
+    expect(await prisma.session.count()).toBe(0);
+
     await auth.api.verifyEmail({ query: { token } });
 
     const verifiedUser = await prisma.user.findUnique({ where: { email: "verify@example.com" } });
     expect(verifiedUser?.emailVerified).toBe(true);
+    // autoSignInAfterVerification (ENG-1746): consuming the link establishes a session so the user
+    // lands in the app already logged in instead of bouncing to /auth/login.
+    expect(await prisma.session.count()).toBe(1);
     // afterEmailVerification re-homes the createBrevoCustomer side effect (fire-and-forget)
     expect(brevo.createBrevoCustomer).toHaveBeenCalledWith({
       id: verifiedUser?.id,
@@ -67,9 +73,10 @@ describe("Better Auth email verification (real Postgres)", () => {
     expect(capturePostHogEvent).toHaveBeenCalledWith(verifiedUser?.id, "user_email_confirmed");
 
     // verify-email is a stateless signed JWT (no getAndDelete), so re-verifying is idempotent:
-    // the already-verified branch returns { status: true, user: null }
+    // the already-verified branch returns { status: true, user: null } and creates no second session
     const replay = await auth.api.verifyEmail({ query: { token } });
     expect(replay).toMatchObject({ status: true, user: null });
+    expect(await prisma.session.count()).toBe(1);
     // afterEmailVerification fires once per user — the replay must NOT re-emit the event
     expect(capturePostHogEvent).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/modules/auth/lib/auth-email-verification.integration.test.ts
+++ b/apps/web/modules/auth/lib/auth-email-verification.integration.test.ts
@@ -4,6 +4,7 @@ import { resetDb } from "@/integration/reset-db";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { auth } from "@/modules/auth/lib/auth";
 import * as brevo from "@/modules/auth/lib/brevo";
+import { queueAuditEventBackground } from "@/modules/ee/audit-logs/lib/handler";
 import {
   sendPasswordResetLinkEmail,
   sendPasswordResetNotifyEmail,
@@ -14,6 +15,13 @@ import {
 vi.mock("@/modules/auth/lib/brevo", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/modules/auth/lib/brevo")>();
   return { ...actual, createBrevoCustomer: vi.fn().mockResolvedValue(undefined) };
+});
+
+// Spy queueAuditEventBackground (the session.create.after `signedIn` audit) so the auto-login-after-
+// verification path can be asserted without depending on the real setImmediate/headers() emission.
+vi.mock("@/modules/ee/audit-logs/lib/handler", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/modules/ee/audit-logs/lib/handler")>();
+  return { ...actual, queueAuditEventBackground: vi.fn().mockResolvedValue(undefined) };
 });
 
 // Spy capturePostHogEvent (the other afterEmailVerification side effect) without hitting PostHog.
@@ -54,16 +62,28 @@ describe("Better Auth email verification (real Postgres)", () => {
     const token = tokenFromLink(vi.mocked(sendVerificationLinkEmail).mock.calls[0][0].verifyLink);
     expect(token).toBeTruthy();
 
-    // autoSignIn is off, so sign-up creates no session (verification is still pending).
+    // autoSignIn is off, so sign-up creates no session (verification is still pending) and emits
+    // no signedIn audit.
     expect(await prisma.session.count()).toBe(0);
+    expect(queueAuditEventBackground).not.toHaveBeenCalled();
 
     await auth.api.verifyEmail({ query: { token } });
 
     const verifiedUser = await prisma.user.findUnique({ where: { email: "verify@example.com" } });
     expect(verifiedUser?.emailVerified).toBe(true);
     // autoSignInAfterVerification (ENG-1746): consuming the link establishes a session so the user
-    // lands in the app already logged in instead of bouncing to /auth/login.
+    // lands in the app already logged in instead of bouncing to /auth/login...
     expect(await prisma.session.count()).toBe(1);
+    // ...and that session is captured in the signedIn audit trail, tagged as a credential-account
+    // ("password") sign-in via the /verify-email allow-list entry in getSignInAuthMethod.
+    expect(queueAuditEventBackground).toHaveBeenCalledTimes(1);
+    expect(queueAuditEventBackground).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "signedIn",
+        userId: verifiedUser?.id,
+        newObject: expect.objectContaining({ authMethod: "password" }),
+      })
+    );
     // afterEmailVerification re-homes the createBrevoCustomer side effect (fire-and-forget)
     expect(brevo.createBrevoCustomer).toHaveBeenCalledWith({
       id: verifiedUser?.id,
@@ -77,8 +97,9 @@ describe("Better Auth email verification (real Postgres)", () => {
     const replay = await auth.api.verifyEmail({ query: { token } });
     expect(replay).toMatchObject({ status: true, user: null });
     expect(await prisma.session.count()).toBe(1);
-    // afterEmailVerification fires once per user — the replay must NOT re-emit the event
+    // afterEmailVerification fires once per user — the replay must NOT re-emit the event or the audit
     expect(capturePostHogEvent).toHaveBeenCalledTimes(1);
+    expect(queueAuditEventBackground).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/modules/auth/lib/auth.ts
+++ b/apps/web/modules/auth/lib/auth.ts
@@ -146,7 +146,11 @@ export const auth = betterAuth({
     // this flag BA would throw EMAIL_NOT_VERIFIED without sending anything, leaving no recovery path
     // and making that message untrue. (ENG-1054)
     sendOnSignIn: true,
-    autoSignInAfterVerification: false,
+    // Establish the session on a successful verification so the user lands in the app instead of
+    // bouncing to /auth/login (ENG-1746). Safe — clicking the signed link proves email ownership.
+    // Distinct from the sibling `autoSignIn: false` above, which stays off (no auto-login at sign-up,
+    // before ownership is proven; also enumeration-safe).
+    autoSignInAfterVerification: true,
     expiresIn: 60 * 60, // 1 hour
     sendVerificationEmail: async ({ user, url }) => {
       const { sendVerificationLinkEmail } = await import("@/modules/email");

--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -32,6 +32,7 @@ vi.mock("./utils", () => ({
 describe("getSignInAuthMethod (signedIn audit allow-list)", () => {
   test.each([
     ["/sign-in/email", "password"],
+    ["/verify-email", "password"], // auto-login after email verification (ENG-1746)
     ["/two-factor/verify-totp", "password"],
     ["/two-factor/verify-backup-code", "password"],
     ["/callback/google", "sso"],

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -37,6 +37,10 @@ export const getSignInAuthMethod = (path: string | undefined): string | null => 
   // /callback/:id (social) and /oauth2/callback/:providerId (generic OAuth/SAML) both contain /callback/
   if (path.includes("/callback/")) return "sso";
   if (path === "/sign-in/email") return "password";
+  // Auto-login after email verification (autoSignInAfterVerification, ENG-1746) creates a session for
+  // a credential/email-password account, so audit it as "password". Idempotent replays of an
+  // already-verified token don't create a session, so this fires once, on the genuine first verify.
+  if (path === "/verify-email") return "password";
   // The 2FA challenge completes the credentials sign-in → "password" (matches NextAuth). Deliberately
   // NOT /two-factor/verify-otp (also the first-time-enable path) nor /two-factor/disable|enable.
   if (path === "/two-factor/verify-totp" || path === "/two-factor/verify-backup-code") return "password";
@@ -49,8 +53,9 @@ export const getSignInAuthMethod = (path: string | undefined): string | null => 
 /**
  * Emit the `signedIn` success audit on session creation — parity with the NextAuth route's
  * `events.signIn`. Guarded to genuine sign-in completions (see getSignInAuthMethod) so non-sign-in
- * session re-issues don't produce spurious events. `autoSignIn` is off, so sign-up/verification don't
- * create a session either. Failures create no session, so they're audited separately by
+ * session re-issues don't produce spurious events. `autoSignIn` is off, so sign-up doesn't create a
+ * session; email verification does (autoSignInAfterVerification, ENG-1746) and is allow-listed above.
+ * Failures create no session, so they're audited separately by
  * `auditFailedAuthAfter` below (which inspects the returned error in `hooks.after`).
  */
 export const signInAuditDatabaseHook: NonNullable<


### PR DESCRIPTION
## What does this PR do?

When email verification is enabled, a newly signed-up user who clicked their verification link was **not** logged in: `GET /api/auth/verify-email` flipped `emailVerified` to `true` and redirected to `/`, but set no session cookie, so the app bounced them straight to `/auth/login`. They could log in manually and the account worked, but the expected UX is to land in the app already authenticated.

Root cause was `autoSignInAfterVerification: false` in `apps/web/modules/auth/lib/auth.ts`. That value was NextAuth parity carried over during the ENG-1054 Better Auth migration — not a security decision. Clicking the signed verification link already proves email ownership, so establishing the session there is safe. This flips it to `true` (applies to both Cloud and self-hosted).

The sibling `autoSignIn: false` (no auto-login at *sign-up*, before ownership is proven) stays `false` on purpose — it's the enumeration-safe one.

Second change: flipping the flag turns `/verify-email` into a new session-creating sign-in path. The `signedIn` audit hook (`better-auth-observability.ts`) only fires for allow-listed paths, and its own doc says the list "MUST grow if a new session-creating sign-in is enabled" — so `/verify-email` is added to `getSignInAuthMethod` (as `"password"`, since the auto-logged-in user is a credential account). Without this the auto-login session would create no audit event and skip the `lastLoginAt` / analytics update. Idempotent replays of an already-verified token don't create a session, so the event fires exactly once.

Surfaced during the ENG-1582 review (Dhru's self-hosted manual test).

Linear: https://linear.app/formbricks/issue/ENG-1746

## How should this be tested?

Automated:

- `pnpm --filter=@formbricks/web test:integration auth-email-verification` — the real-Postgres integration test now asserts session count `0` before verify → `1` after (auto-login establishes a session) and stays `1` on an idempotent replay.
- `pnpm --filter=@formbricks/web test modules/auth/lib/better-auth-observability.test.ts` — `/verify-email` added to the audit allow-list `test.each`.

Manual QA (self-hosted, `IS_FORMBRICKS_CLOUD=0`, email verification enabled — matches the original repro):

1. Sign up with a fresh email → verification email sent, no session yet.
2. Click the verification link → you land on `/` **already logged in** (no bounce to `/auth/login`).
3. Confirm a `signedIn` audit event was recorded and `lastLoginAt` was updated for the user.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
