### PR TITLE
chore(pnpm): activate supply-chain release cooldown

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,10 +86,16 @@ enablePrePostScripts: true
 legacyPeerDeps: true
 nodeLinker: hoisted
 saveExact: true
-# Supply-chain release cooldown: refuse to resolve package versions published less than
+# Supply-chain release cooldown: refuse to install package versions published less than
 # 3 days (4320 minutes) ago, so compromised releases are usually detected/yanked before we
-# can pull them. Existing lockfile entries are unaffected; only new resolutions are gated.
+# can pull them. pnpm 11 already defaults to 1 day; we raise it to 3 days and pin it
+# explicitly. Note: with trustLockfile disabled (below), `pnpm install` re-verifies entries
+# already in the lockfile against this policy too — a lockfile bump younger than 3 days
+# (e.g. written by a bot) fails install until it ages or is excluded below. Intended.
 minimumReleaseAge: 4320
+# Keep the install-time re-verification of lockfile entries active (this is pnpm's default;
+# pinned explicitly so a future default flip can't silently weaken the cooldown).
+trustLockfile: false
 minimumReleaseAgeExclude:
   # First-party SDK (published by Formbricks' own CI) — exempt all versions from the release-age gate so
   # a fresh hub bump isn't blocked. Version-pinned scoped entries (e.g. '@formbricks/hub@0.9.0') are not

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,6 +86,10 @@ enablePrePostScripts: true
 legacyPeerDeps: true
 nodeLinker: hoisted
 saveExact: true
+# Supply-chain release cooldown: refuse to resolve package versions published less than
+# 3 days (4320 minutes) ago, so compromised releases are usually detected/yanked before we
+# can pull them. Existing lockfile entries are unaffected; only new resolutions are gated.
+minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   # First-party SDK (published by Formbricks' own CI) — exempt all versions from the release-age gate so
   # a fresh hub bump isn't blocked. Version-pinned scoped entries (e.g. '@formbricks/hub@0.9.0') are not


### PR DESCRIPTION
## Problem

`pnpm-workspace.yaml` declares a `minimumReleaseAgeExclude` for `@formbricks/hub` but never sets `minimumReleaseAge` itself. On pnpm 11 a **default 1-day cooldown** applies, but the effective policy was implicit, undocumented, and weaker than intended for a security-conscious repo — and nothing pinned it against upstream default changes.

*(Correction from review: the original description claimed the cooldown was fully inactive — that was true for pnpm 10 but not for pnpm 11, which defaults `minimumReleaseAge` to 1440 minutes. The PR now frames this accurately.)*

## Solution

- `minimumReleaseAge: 4320` (3 days) set explicitly — raising the implicit 1-day default; most npm supply-chain compromises are detected and yanked within 1–2 days.
- `trustLockfile: false` pinned explicitly (pnpm's current default): `pnpm install` **re-verifies entries already in the lockfile** against the cooldown, so a poisoned or bot-written lockfile bump younger than 3 days fails install until it ages or is excluded. Pinning it documents this as a deliberate choice and protects against a future upstream default flip.
- Comment block documents the real pnpm 11 semantics, including the operational consequence: dependency-bump PRs whose lockfile entries are younger than 3 days will fail CI install until the packages age (that is the feature working). The existing `@formbricks/hub` name-based exclusion (first-party, published by our own CI) is unchanged.

## Validation

- `pnpm install` ✅ and `pnpm install --frozen-lockfile` ✅ (exit 0) **with re-verification active** against the current lockfile
- `pnpm lint` ✅ exit 0
- `pnpm test` ✅ `Tasks: 21 successful, 21 total`

Fixes ENG-1675

🤖 Generated with [Claude Code](https://claude.com/claude-code)