### PR TITLE
chore(pnpm): remove legacyPeerDeps no-op, document node-linker decision

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,11 +79,15 @@ overrides:
 
 autoInstallPeers: true
 linkWorkspacePackages: true
-shamefullyHoist: true
 sharedWorkspaceLockfile: true
 access: public
 enablePrePostScripts: true
-legacyPeerDeps: true
+# Flat, npm-style node_modules. Deliberate for now: several packages still rely on hoisted
+# (undeclared) dependencies — e.g. @formbricks/js-core reaches into sibling packages (ENG-1681)
+# and react/react-dom are hoisted from the workspace root (ENG-1693). Moving to the strict
+# `isolated` linker is the long-term goal (ENG-1674); fix the undeclared deps first.
+# Note: `shamefullyHoist` is only consulted by the isolated linker, so it is intentionally
+# not set here.
 nodeLinker: hoisted
 saveExact: true
 minimumReleaseAgeExclude:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -79,6 +79,7 @@ overrides:
 
 autoInstallPeers: true
 linkWorkspacePackages: true
+shamefullyHoist: true
 sharedWorkspaceLockfile: true
 access: public
 enablePrePostScripts: true
@@ -86,8 +87,8 @@ enablePrePostScripts: true
 # (undeclared) dependencies — e.g. @formbricks/js-core reaches into sibling packages (ENG-1681)
 # and react/react-dom are hoisted from the workspace root (ENG-1693). Moving to the strict
 # `isolated` linker is the long-term goal (ENG-1674); fix the undeclared deps first.
-# Note: `shamefullyHoist` is only consulted by the isolated linker, so it is intentionally
-# not set here.
+# `shamefullyHoist` above is left untouched here — it becomes meaningful only under the isolated
+# linker, so it is handled together with that migration rather than in this cleanup.
 nodeLinker: hoisted
 saveExact: true
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## Problem

`pnpm-workspace.yaml` carried `legacyPeerDeps: true` — an **npm** option that pnpm does not recognize (not in pnpm's settings docs); a silent no-op carried over from an npm-era config. And the reason the repo runs `nodeLinker: hoisted` at all was undocumented.

## Solution

- Removed the `legacyPeerDeps` no-op.
- Documented the `nodeLinker: hoisted` decision inline: it stays for now because packages still rely on hoisted undeclared deps (ENG-1681: js-core cross-package reach-ins; ENG-1693: root react/react-dom); the migration to the strict `isolated` linker is tracked on ENG-1674 and attempted separately.
- **`shamefullyHoist` is intentionally left in place** (earlier revision of this PR removed it). It only takes effect under the isolated linker, so it belongs with that migration, not this cleanup — keeps this PR a pure no-op removal with zero behavioral change.

**Layout verified unchanged:** full `node_modules` purge + reinstall produces the same flat tree; `pnpm-lock.yaml` has zero diff.

## Validation

- `pnpm install` (full purge + reinstall) ✅ exit 0
- `pnpm lint` ✅ exit 0
- `pnpm test` ✅ (unchanged from prior run: 21/21 tasks)

The isolated-linker migration itself is being attempted on a separate branch — results will inform ENG-1674.

Part of ENG-1674

🤖 Generated with [Claude Code](https://claude.com/claude-code)