### PR TITLE
chore(vitest): remove dead environmentMatchGlobs, adopt projects layout

### DIFF
--- a/apps/web/modules/auth/hooks/use-sign-out.test.tsx
+++ b/apps/web/modules/auth/hooks/use-sign-out.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { FORMBRICKS_ENVIRONMENT_ID_LS, FORMBRICKS_WORKSPACE_ID_LS } from "@/lib/localStorage";
 import { logSignOutAction } from "@/modules/auth/actions/sign-out";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -160,6 +160,7 @@
     "@vitest/coverage-v8": "4.1.6",
     "cross-env": "10.1.0",
     "dotenv": "17.3.1",
+    "jsdom": "29.1.1",
     "postcss": "8.5.14",
     "resize-observer-polyfill": "1.5.1",
     "tailwindcss-animate": "1.0.7",

--- a/apps/web/vite.config.mts
+++ b/apps/web/vite.config.mts
@@ -6,13 +6,38 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    environment: "node",
-    environmentMatchGlobs: [["**/*.test.tsx", "jsdom"]],
     // Integration tests run only via `pnpm test:integration` (vitest.integration.config.mts) against a
     // real Postgres + Redis; the unit config mocks the DB, so they must be excluded here (ENG-1054).
     exclude: ["playwright/**", "node_modules/**", ".next/**", "**/*.integration.test.ts"],
     setupFiles: ["./vitestSetup.ts"],
     env: loadEnv("", process.cwd(), ""),
+    // Environment selection (ENG-1680): Vitest 4 removed `environmentMatchGlobs`, so environments
+    // are assigned via projects. *.test.ts run in node; *.test.tsx (component tests) run in jsdom
+    // automatically - no `@vitest-environment` pragma needed.
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "unit",
+          environment: "node",
+          exclude: [
+            "playwright/**",
+            "node_modules/**",
+            ".next/**",
+            "**/*.integration.test.ts",
+            "**/*.test.tsx",
+          ],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "components",
+          environment: "jsdom",
+          include: ["**/*.test.tsx"],
+        },
+      },
+    ],
     coverage: {
       provider: "v8", // Use V8 as the coverage provider
       reporter: ["text", "html", "lcov"], // Generate text summary and HTML reports

--- a/packages/surveys/src/components/general/survey.test.tsx
+++ b/packages/surveys/src/components/general/survey.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { TJsWorkspaceStateSurvey } from "@formbricks/types/js";

--- a/packages/surveys/src/lib/use-focus-trap.test.tsx
+++ b/packages/surveys/src/lib/use-focus-trap.test.tsx
@@ -1,4 +1,3 @@
-// @vitest-environment happy-dom
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { type ComponentChildren } from "preact";
 import { afterEach, describe, expect, test, vi } from "vitest";

--- a/packages/surveys/vite.config.mts
+++ b/packages/surveys/vite.config.mts
@@ -86,16 +86,33 @@ const config = ({ mode }) => {
   return defineConfig({
     ...sharedConfig,
     test: {
-      name: "surveys",
-      environment: "node",
-      environmentMatchGlobs: [
-        ["**/*.test.tsx", "jsdom"],
-        ["**/lib/**/*.test.ts", "jsdom"],
-      ],
       setupFiles: ["./vitestSetup.ts"],
-      include: ["**/*.test.ts", "**/*.test.tsx"],
       exclude: ["dist/**", "node_modules/**"],
       env: env,
+      // Environment selection (ENG-1680): Vitest 4 removed `environmentMatchGlobs`, so environments
+      // are assigned via projects. *.test.tsx (component tests) run in happy-dom automatically;
+      // *.test.ts default to node — the few DOM-dependent .ts tests keep their per-file
+      // `@vitest-environment happy-dom` pragma.
+      projects: [
+        {
+          extends: true,
+          test: {
+            name: "surveys-unit",
+            environment: "node",
+            include: ["**/*.test.ts"],
+            exclude: ["dist/**", "node_modules/**"],
+          },
+        },
+        {
+          extends: true,
+          test: {
+            name: "surveys-components",
+            environment: "happy-dom",
+            include: ["**/*.test.tsx"],
+            exclude: ["dist/**", "node_modules/**"],
+          },
+        },
+      ],
       coverage: {
         provider: "v8",
         reporter: ["text", "html", "lcov"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -539,6 +539,9 @@ importers:
       dotenv:
         specifier: 17.3.1
         version: 17.3.1
+      jsdom:
+        specifier: 29.1.1
+        version: 29.1.1(@noble/hashes@2.0.1)
       postcss:
         specifier: 8.5.14
         version: 8.5.14
@@ -9374,10 +9377,6 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
-
-  lru-cache@11.2.6:
-    resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
-    engines: {node: 20 || >=22}
 
   lru-cache@11.3.6:
     resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
@@ -19172,7 +19171,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.16(@types/node@25.4.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.5(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.17(@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)(vitest@4.1.6)':
     dependencies:
@@ -22401,8 +22400,6 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.2.6: {}
-
   lru-cache@11.3.6: {}
 
   lru-cache@5.1.1:
@@ -23149,7 +23146,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.2.6
+      lru-cache: 11.3.6
       minipass: 7.1.3
 
   path-to-regexp@8.4.2: {}

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,1 +1,0 @@
-export default ["packages/*/vite.config.{ts,mts}", "apps/**/vite.config.{ts,mts}"];


### PR DESCRIPTION
## Problem

`environmentMatchGlobs` was **removed in Vitest 4**, but is still configured in `apps/web/vite.config.mts` and `packages/surveys/vite.config.mts` — silently ignored. Component tests only pass because each file carries a `// @vitest-environment` pragma (the surveys config even references `jsdom`, which isn't installed there — proof it never ran under v4). The next `.test.tsx` added without a pragma runs in a node environment and fails with confusing `document is not defined` errors. The root `vitest.workspace.ts` also used the deprecated workspace-file approach.

## Solution

- **apps/web**: `unit` (node) + `components` (jsdom) projects. `*.test.tsx` get jsdom automatically — pragma removed from `use-sign-out.test.tsx` to prove it.
- **packages/surveys**: `surveys-unit` (node) + `surveys-components` (happy-dom) projects, mirroring the effective pragma reality. Pragmas removed from both `.test.tsx` files; the handful of DOM-dependent `.ts` tests keep their per-file pragma.
- **jsdom** added as an explicit `apps/web` devDependency — it was a phantom dep resolved only via hoisting (ENG-1681's sibling problem).
- **Root `vitest.workspace.ts` deleted, deliberately without a root replacement.** I verified empirically that a root `projects` list referencing package configs **silently discards their nested project definitions** — the jsdom test ran in node from the root (`environment 0ms`) while passing per-package. A root config would therefore be a trap that mis-runs web/surveys tests. Nothing uses root-level vitest: CI and dev run per package via `turbo run test`, and IDE extensions auto-discover per-package configs (where the projects work correctly). Deviation from the issue's AC noted here for review.

## Validation

- Per-package: `packages/surveys` → 26 files / 650 tests ✅; `apps/web` → 503 files ✅ (identical counts to before — no tests lost by the include/exclude split)
- De-pragma'd jsdom/happy-dom tests pass via project env selection ✅
- `pnpm install` ✅ exit 0 · `pnpm lint` ✅ exit 0 · `pnpm test` ✅ `Tasks: 21 successful, 21 total — Time: 42.101s`

Fixes ENG-1680

🤖 Generated with [Claude Code](https://claude.com/claude-code)