### PR TITLE
ci: cache the pnpm store and extend Turbo remote cache to all workflows

### DIFF
--- a/.github/actions/cache-build-web/action.yml
+++ b/.github/actions/cache-build-web/action.yml
@@ -38,14 +38,15 @@ runs:
       run: echo "cache-hit=${{ steps.cache-build.outputs.cache-hit }}" >> "$GITHUB_OUTPUT"
       shell: bash
 
+    - name: Install pnpm
+      uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      if: steps.cache-build.outputs.cache-hit != 'true'
+
     - name: Setup Node.js 22.x
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 22.x
-      if: steps.cache-build.outputs.cache-hit != 'true'
-
-    - name: Install pnpm
-      uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        cache: pnpm
       if: steps.cache-build.outputs.cache-hit != 'true'
 
     - name: Install dependencies

--- a/.github/workflows/api-v3-spec.yml
+++ b/.github/workflows/api-v3-spec.yml
@@ -29,13 +29,14 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
       - name: Setup Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+          cache: pnpm
 
       # Root importer only: installs the lockfile-pinned @redocly/cli (and other root devDeps)
       # without building the whole workspace. bundle.mjs falls back to pinned npx when absent.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,13 +56,14 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/dangerous-git-checkout
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
       - name: Setup Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --config.platform=linux --config.architecture=x64

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -88,15 +88,16 @@ jobs:
           fi
         shell: bash
 
+      - name: Install pnpm
+        if: steps.harness.outputs.present == 'true'
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
       - name: Setup Node.js 22.x
         if: steps.harness.outputs.present == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
-
-      - name: Install pnpm
-        if: steps.harness.outputs.present == 'true'
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+          cache: pnpm
 
       - name: Install dependencies
         if: steps.harness.outputs.present == 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ name: Lint
 on:
   workflow_call:
 
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
 permissions:
   contents: read
 
@@ -20,13 +24,14 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./.github/actions/dangerous-git-checkout
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
       - name: Setup Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --config.platform=linux --config.architecture=x64

--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   merge_group:
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
 permissions:
   contents: read
   pull-requests: read
@@ -24,19 +28,20 @@ jobs:
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
       - name: Setup Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
+          cache: pnpm
 
       - name: Setup Java 21
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: temurin
           java-version: "21"
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --config.platform=linux --config.architecture=x64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Tests
 on:
   workflow_call:
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+
 permissions:
   contents: read
 
@@ -21,13 +25,14 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/dangerous-git-checkout
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
       - name: Setup Node.js 22.x
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --config.platform=linux --config.architecture=x64

--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -40,15 +40,16 @@ jobs:
               - 'packages/i18n-utils/**'
               - '**/i18n.lock'
 
+      - name: Install pnpm
+        if: steps.changes.outputs.translations == 'true'
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
       - name: Setup Node.js 22.x
         if: steps.changes.outputs.translations == 'true'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
-
-      - name: Install pnpm
-        if: steps.changes.outputs.translations == 'true'
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+          cache: pnpm
 
       - name: Install dependencies
         if: steps.changes.outputs.translations == 'true'


### PR DESCRIPTION
## Problem

Two caching gaps burned CI minutes on every PR run:

1. **No pnpm store caching anywhere** — every job of every run did a cold `pnpm install --frozen-lockfile` over the full workspace.
2. **Turbo remote cache only partially wired** — `TURBO_TOKEN`/`TURBO_TEAM` were set in build/e2e/integration workflows but **not** in `test.yml`, `lint.yml`, or `sonarqube.yml`: the highest-frequency jobs always ran turbo cold.

## Solution

- `pnpm/action-setup` now runs **before** `actions/setup-node` (required — setup-node's cache resolution shells out to `pnpm store path`), and `cache: pnpm` is enabled in: **test, lint, sonarqube, integration-tests, translation-check, api-v3-spec, e2e**, and the **cache-build-web** composite action. `chromatic.yml` already had a manual store cache and is left unchanged.
- `TURBO_TOKEN`/`TURBO_TEAM` added at workflow level to **test, lint, sonarqube** (test/lint are reusable workflows called with `secrets: inherit` from `pr.yml`, so the secret flows through; sonarqube runs standalone with direct secret access).
- All `if:` step guards preserved (integration-tests/translation-check gate their setup steps — verified per file).
- Action SHA pins unchanged.

## Validation

- All 8 touched files pass **strict YAML validation** including a duplicate-key check.
- Ordering sanity-checked programmatically: pnpm-setup precedes setup-node in every touched file.
- `pnpm install` ✅ exit 0 · `pnpm lint` ✅ exit 0 · `pnpm test` ✅ `Tasks: 21 successful, 21 total — Time: 43.882s`
- The real proof is this PR's own CI run — the second run of any job should show the store cache being restored.

**Note:** this will conflict trivially with #8500 (ENG-1676) — both touch the setup-node blocks. Whichever merges second needs a one-line rebase (`node-version` → `node-version-file` alongside `cache: pnpm`).

Fixes ENG-1679

🤖 Generated with [Claude Code](https://claude.com/claude-code)