### PR TITLE
fix: prevent infinite re-render loop when authenticated actions refresh the route

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/components/GoogleSheetWrapper.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/components/GoogleSheetWrapper.tsx
@@ -41,13 +41,19 @@ export const GoogleSheetWrapper = ({
     (TIntegrationGoogleSheetsConfigData & { index: number }) | null
   >(null);
 
+  // Depend only on stable values (workspaceId is a primitive; isConnected is local state). The
+  // server-derived `googleSheetIntegration` object must NOT be a dependency: every authenticated
+  // server action re-sets the Better Auth session cookie, which refreshes the route and hands this
+  // component a new `googleSheetIntegration` reference — depending on it would re-fire the action in
+  // an infinite loop. `isConnected` already implies an integration exists, and the action only needs
+  // `workspaceId`, so the object isn't needed here.
   const validateConnection = useCallback(async () => {
-    if (!isConnected || !googleSheetIntegration) return;
+    if (!isConnected) return;
     const response = await validateGoogleSheetsConnectionAction({ workspaceId });
     if (response?.serverError === GOOGLE_SHEET_INTEGRATION_INVALID_GRANT) {
       setShowReconnectButton(true);
     }
-  }, [workspaceId, isConnected, googleSheetIntegration]);
+  }, [workspaceId, isConnected]);
 
   useEffect(() => {
     validateConnection();

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/SummaryPage.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/SummaryPage.tsx
@@ -202,13 +202,15 @@ export const SummaryPage = ({
         console.error(error);
         // Roll back the key on failure so re-selecting the same filter retries the fetch.
         lastFetchedFiltersKeyRef.current = null;
+        // fetchSummary throws an Error whose message is already the formatted server error.
+        toast.error(error instanceof Error ? error.message : t("common.something_went_wrong"));
       } finally {
         setIsLoading(false);
       }
     };
 
     fetchFilteredSummary();
-  }, [selectedFilter, dateRange, initialSurveySummary, fetchSummary, survey]);
+  }, [selectedFilter, dateRange, initialSurveySummary, fetchSummary, survey, t]);
 
   const surveyMemoized = useMemo(() => {
     return replaceHeadlineRecall(survey, "default");

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/SummaryPage.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/SummaryPage.tsx
@@ -158,17 +158,40 @@ export const SummaryPage = ({
     return registerAnalysisRefreshHandler(refreshSummary);
   }, [refreshSummary, registerAnalysisRefreshHandler]);
 
+  // Dedupe fetches by the actual filter VALUES. Every authenticated server action re-sets the
+  // Better Auth session cookie, and `cookies().set()` inside an action makes Next.js refresh the
+  // route; that refresh hands this component fresh `survey`/`initialSurveySummary`/`fetchSummary`
+  // references. Without this guard those new references re-fire the fetch effect → another action →
+  // another refresh, i.e. an infinite loop.
+  const lastFetchedFiltersKeyRef = useRef<string | null>(null);
+
   // Only fetch data when filters change or when there's no initial data
   useEffect(() => {
-    // If we have initial data and no filters are applied, don't fetch
-    const hasNoFilters =
-      (!selectedFilter || Object.keys(selectedFilter).length === 0 || selectedFilter.filter?.length === 0) &&
-      (!dateRange || (!dateRange.from && !dateRange.to));
+    // A default date range only sets `to` (today) with no `from`, which means "all time" and is
+    // NOT an active filter. Treat filters as active only when the user has actually narrowed the data.
+    const hasActiveFilters =
+      (selectedFilter?.filter?.length ?? 0) > 0 ||
+      (!!selectedFilter?.responseStatus && selectedFilter.responseStatus !== "all") ||
+      Boolean(dateRange?.from);
 
-    if (initialSurveySummary && hasNoFilters) {
+    // If we have server-provided initial data and no active filters, use it instead of refetching.
+    // (Also covers clearing filters: fall back to the unfiltered initial summary without a fetch.)
+    if (initialSurveySummary && !hasActiveFilters) {
+      lastFetchedFiltersKeyRef.current = null;
+      setSurveySummary(initialSurveySummary);
       setIsLoading(false);
       return;
     }
+
+    // Skip when only prop references changed (a route refresh) but the filter values are identical
+    // to the last fetch. getFormattedFilters is deterministic for fixed inputs.
+    const filtersKey = JSON.stringify(getFormattedFilters(survey, selectedFilter, dateRange));
+    if (filtersKey === lastFetchedFiltersKeyRef.current) {
+      return;
+    }
+    // Commit the key BEFORE awaiting so an action-triggered route refresh that re-runs this effect
+    // finds it already set and skips — this is what breaks the loop.
+    lastFetchedFiltersKeyRef.current = filtersKey;
 
     const fetchFilteredSummary = async () => {
       setIsLoading(true);
@@ -177,13 +200,15 @@ export const SummaryPage = ({
         await fetchSummary();
       } catch (error) {
         console.error(error);
+        // Roll back the key on failure so re-selecting the same filter retries the fetch.
+        lastFetchedFiltersKeyRef.current = null;
       } finally {
         setIsLoading(false);
       }
     };
 
     fetchFilteredSummary();
-  }, [selectedFilter, dateRange, initialSurveySummary, fetchSummary]);
+  }, [selectedFilter, dateRange, initialSurveySummary, fetchSummary, survey]);
 
   const surveyMemoized = useMemo(() => {
     return replaceHeadlineRecall(survey, "default");

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ResponseFilter.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/components/ResponseFilter.tsx
@@ -2,7 +2,7 @@
 
 import { useAutoAnimate } from "@formkit/auto-animate/react";
 import { ChevronDown, ChevronUp, Plus, TrashIcon } from "lucide-react";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TI18nString } from "@formbricks/types/i18n";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
@@ -86,29 +86,36 @@ export const ResponseFilter = ({ survey }: ResponseFilterProps) => {
     return typeof firstOption === "object" ? getLocalizedValue(firstOption, "default") : firstOption;
   };
 
+  // Keep the latest survey in a ref so the effect below can read it without listing `survey` (a
+  // server-derived object) as a dependency. Every authenticated server action re-sets the Better Auth
+  // session cookie → Next.js route refresh → new `survey` reference; depending on it here would re-fire
+  // getSurveyFilterDataAction on every refresh while the popover is open, i.e. an infinite loop.
+  const surveyRef = useRef(survey);
+  surveyRef.current = survey;
+
   useEffect(() => {
+    if (!isOpen) return;
     // Fetch the initial data for the filter and load it into the state
     const handleInitialData = async () => {
-      if (isOpen) {
-        const surveyFilterData = await getSurveyFilterDataAction({ surveyId: survey.id });
+      const survey = surveyRef.current;
+      const surveyFilterData = await getSurveyFilterDataAction({ surveyId: survey.id });
 
-        if (!surveyFilterData?.data) return;
+      if (!surveyFilterData?.data) return;
 
-        const { attributes, meta, environmentTags, hiddenFields, quotas } = surveyFilterData.data;
-        const { elementFilterOptions, elementOptions } = generateElementAndFilterOptions(
-          survey,
-          environmentTags,
-          attributes,
-          meta,
-          hiddenFields,
-          quotas
-        );
-        setSelectedOptions({ elementFilterOptions: elementFilterOptions, elementOptions: elementOptions });
-      }
+      const { attributes, meta, environmentTags, hiddenFields, quotas } = surveyFilterData.data;
+      const { elementFilterOptions, elementOptions } = generateElementAndFilterOptions(
+        survey,
+        environmentTags,
+        attributes,
+        meta,
+        hiddenFields,
+        quotas
+      );
+      setSelectedOptions({ elementFilterOptions: elementFilterOptions, elementOptions: elementOptions });
     };
 
     handleInitialData();
-  }, [isOpen, setSelectedOptions, survey]);
+  }, [isOpen, setSelectedOptions]);
 
   const handleOnChangeElementComboBoxValue = (value: ElementOption, index: number) => {
     const matchingFilterOption = selectedOptions.elementFilterOptions.find(

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -2906,11 +2906,6 @@ checksums:
     workspace/surveys/edit/checkbox_label: 12a07d6bdf38e283a2e95892ec49b7f8
     workspace/surveys/edit/choose_the_actions_which_trigger_the_survey: 773b311a148a112243f3b139506b9987
     workspace/surveys/edit/choose_the_first_question_on_your_block: bdece06ca04f89d0c445ba1554dd5b80
-    workspace/surveys/edit/element_category_input: c281c28cbb062bc3538cbd4a42d79cf6
-    workspace/surveys/edit/element_category_choice: 307101bb385166b538e9370428963461
-    workspace/surveys/edit/element_category_scoring: 29dbcaf797b1e9f985bbd7b5258749e4
-    workspace/surveys/edit/element_category_contact: 9afa39bc47019ee6dec6c74b6273967c
-    workspace/surveys/edit/element_category_content: 669b337031ef165af577f04f2b7fd54f
     workspace/surveys/edit/choose_where_to_run_the_survey: ad87bcae97c445f1fd9ac110ea24f117
     workspace/surveys/edit/city: 1831f32e1babbb29af27fac3053504a2
     workspace/surveys/edit/clear_close_on_date: 673ed6940f36b02cf871ffacf034e114
@@ -2962,6 +2957,11 @@ checksums:
     workspace/surveys/edit/duplicate_question: 910751de01fdd327165968214717711b
     workspace/surveys/edit/edit_link: 40ba9e15beac77a46c5baf30be84ac54
     workspace/surveys/edit/edit_recall: 38a4a7378d02453e35d06f2532eef318
+    workspace/surveys/edit/element_category_choice: 307101bb385166b538e9370428963461
+    workspace/surveys/edit/element_category_contact: 9afa39bc47019ee6dec6c74b6273967c
+    workspace/surveys/edit/element_category_content: 669b337031ef165af577f04f2b7fd54f
+    workspace/surveys/edit/element_category_input: c281c28cbb062bc3538cbd4a42d79cf6
+    workspace/surveys/edit/element_category_scoring: 29dbcaf797b1e9f985bbd7b5258749e4
     workspace/surveys/edit/element_not_found: 196777ff6811dd177971ffc8e27a72c1
     workspace/surveys/edit/enable_participants_to_switch_the_survey_language_at_any_point_during_the_survey: c70466147d49dcbb3686452f35c46428
     workspace/surveys/edit/enable_recaptcha_to_protect_your_survey_from_spam: 4483a5763718d201ac97caa1e1216e13


### PR DESCRIPTION
## What does this PR do?

Fixes an infinite re-render / refetch loop on the **survey summary page** (and, from the same root cause, the **Google Sheets integration** settings), where the client fired a server action + a full route refresh several times per second — pegging the dev server and spamming the network tab.

### Root cause

Every authenticated server action goes through `authenticatedActionClient`, whose middleware calls Better Auth `getSession()`. On the durable-read path this **re-sets the session cookie**, and `nextCookies()` writes it via `cookies().set()` _during the action_. In Next.js, `cookies().set()` inside a Server Action invalidates the router cache, so Next issues a follow-up **route refresh** that re-renders the server page.

That refresh hands the client component **fresh object references** for its server props (`survey`, `initialSurveySummary`, `googleSheetIntegration`). When a `useEffect` that calls the action also lists those references in its dependency array (directly or via a `useCallback`), React — which compares deps **by reference, not by value** — sees "deps changed" and re-runs the effect → another action → another refresh → **loop**.

```
effect → action → session cookie set → route refresh → new prop references
   → React thinks deps changed → effect re-runs → action → … 🔁
```

This trigger is **systemic** (any authenticated action can refresh its route), but it only bites components that _fetch inside an effect keyed on a server-derived object_. An app-wide scan found just the two touched here; most actions are event-handler-driven (a single, harmless refresh) or key their effects on primitives.

### Changes

- **`SummaryPage.tsx`** — the fetch effect now dedupes by the actual **filter values** (a serialized key kept in a ref) instead of re-firing on prop-reference churn from a route refresh. Also fixed a dead guard (`hasNoFilters` was always `false` because the default date range always sets `to: today`), so the server-provided initial summary is reused when no filters are active. The dedupe key is rolled back on fetch failure so re-selecting the same filter still retries.
- **`GoogleSheetWrapper.tsx`** — dropped the server-derived `googleSheetIntegration` object from `validateConnection`'s deps (now `[workspaceId, isConnected]`, both stable), mirroring the already-safe `SlackWrapper` pattern. The `!isConnected` guard already implies an integration exists, and the action only needs `workspaceId`.

### Follow-up (intentionally not in this PR)

The durable fix lives in the auth layer — avoid re-setting the session cookie on pure reads in `action-client` / `session.ts` — which would eliminate this whole class of loop app-wide. Left out here because it touches authentication globally and deserves its own reviewed change.

## How should this be tested?

**Survey summary page**
- Open a survey's **Summary** tab → Network tab should be quiet (one summary fetch; no repeating `POST` / `GET .../summary` pairs).
- Apply a date filter (e.g. **Last 7 days**) → exactly one refetch, no loop.
- Switch ranges, then **Clear all** → shows the unfiltered summary, no loop.
- Click the **Refresh** button → still refetches the current view.

**Google Sheets integration** (Workspace → Settings → Integrations → Google Sheets, with a connected account)
- Open the page → the connection is validated once; no repeating `validateGoogleSheetsConnection` calls.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
