### PR TITLE
fix: let MCP clients request surveys:write and correct validate_survey scope

### DIFF
--- a/apps/web/app/api/mcp/route.test.ts
+++ b/apps/web/app/api/mcp/route.test.ts
@@ -43,6 +43,7 @@ vi.mock("@formbricks/database", () => ({
 }));
 
 vi.mock("@/modules/auth/lib/oauth-urls", () => ({
+  MCP_RESOURCE_SCOPES: ["surveys:read", "surveys:write"],
   getAuthIssuerUrl: () => "http://localhost/api/auth",
   getMcpOrigin: () => "http://localhost",
   getMcpProtectedResourceMetadataUrl: () => "http://localhost/.well-known/oauth-protected-resource/api/mcp",
@@ -160,7 +161,7 @@ describe("POST /api/mcp", () => {
     expect(response.status).toBe(401);
     expect(response.headers.get("Content-Type")).toBe("application/problem+json");
     expect(response.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read"'
+      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read surveys:write"'
     );
     expect(applyIPRateLimit).toHaveBeenCalled();
   });
@@ -410,7 +411,7 @@ describe("POST /api/mcp", () => {
     expect(authenticateApiKeyFromHeaders).not.toHaveBeenCalled();
     expect(applyIPRateLimit).toHaveBeenCalled();
     expect(response.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read"'
+      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read surveys:write"'
     );
   });
 

--- a/apps/web/modules/auth/lib/mcp-oauth-dcr.test.ts
+++ b/apps/web/modules/auth/lib/mcp-oauth-dcr.test.ts
@@ -114,6 +114,33 @@ describe("MCP OAuth Dynamic Client Registration → authorize (real-client shape
     expect(registration.body.scope?.split(" ")).toEqual(expect.arrayContaining(advertisedScopes));
   });
 
+  test("default registration (no scope requested) grants read + write", async () => {
+    const auth = createAuthInstance();
+
+    // A client that registers without an explicit scope must receive write by default — otherwise the
+    // consent screen only offers "Read surveys" and every write tool 403s (the ENG-1055 QA regression:
+    // clients that key off the challenge/defaults rather than the PRM never requested write).
+    const response = await auth.handler(
+      new Request(`${BASE_URL}/api/auth/oauth2/register`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          client_name: "MCP DCR default-scope client",
+          redirect_uris: [REDIRECT_URI],
+          grant_types: ["authorization_code", "refresh_token"],
+          response_types: ["code"],
+          token_endpoint_auth_method: "none",
+        }),
+      })
+    );
+    const body = (await response.json()) as { scope?: string };
+
+    expect(response.status).toBe(200);
+    expect(body.scope?.split(" ")).toEqual(
+      expect.arrayContaining(["surveys:read", "surveys:write", "offline_access"])
+    );
+  });
+
   test("authorize accepts the PRM-advertised scopes for a DCR client (no invalid_scope)", async () => {
     const auth = createAuthInstance();
     const advertisedScopes = await fetchAdvertisedScopes();

--- a/apps/web/modules/auth/lib/mcp-oauth-provider-options.ts
+++ b/apps/web/modules/auth/lib/mcp-oauth-provider-options.ts
@@ -20,8 +20,18 @@ export const getMcpOauthProviderOptions = (): TOauthProviderOptions => ({
   validAudiences: [getMcpResourceUrl()],
   allowDynamicClientRegistration: true,
   allowUnauthenticatedClientRegistration: true,
-  clientRegistrationDefaultScopes: ["openid", "profile", "email", "offline_access", "surveys:read"],
-  clientRegistrationAllowedScopes: ["surveys:write"],
+  // Register MCP clients with read + write by default so the consent screen offers write and the
+  // write tools are reachable (clients derive their DCR/authorize scopes from what we advertise, and
+  // the plugin validates authorize against the client's registered scopes). Granting the write scope
+  // is safe: actual write access is still enforced downstream by the user's workspace permissions.
+  clientRegistrationDefaultScopes: [
+    "openid",
+    "profile",
+    "email",
+    "offline_access",
+    "surveys:read",
+    "surveys:write",
+  ],
   accessTokenExpiresIn: 15 * 60,
   refreshTokenExpiresIn: 30 * 24 * 60 * 60,
   scopeExpirations: {

--- a/apps/web/modules/mcp/auth.test.ts
+++ b/apps/web/modules/mcp/auth.test.ts
@@ -105,6 +105,9 @@ describe("authenticateMcpRequest", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.response.status).toBe(401);
+      // The challenge must advertise read + write so clients request write at consent and can reach
+      // the write tools (advertising only read is why write was unreachable — ENG-1055 QA).
+      expect(result.response.headers.get("WWW-Authenticate")).toContain('scope="surveys:read surveys:write"');
       expect(await result.response.json()).toMatchObject({
         code: "not_authenticated",
         detail: "API key or OAuth access token required",

--- a/apps/web/modules/mcp/auth.ts
+++ b/apps/web/modules/mcp/auth.ts
@@ -19,6 +19,7 @@ import { parseApiKeyV2 } from "@/lib/crypto";
 import { authenticateApiKeyFromHeaders, getBearerTokenFromHeaders } from "@/modules/api/lib/api-key-auth";
 import { auth } from "@/modules/auth/lib/auth";
 import {
+  MCP_RESOURCE_SCOPES,
   getAuthIssuerUrl,
   getMcpOrigin,
   getMcpProtectedResourceMetadataUrl,
@@ -36,7 +37,13 @@ const QUERY_CREDENTIAL_PARAMS = new Set([
   "authorization",
 ]);
 
+// Minimum scope required to authenticate against the MCP server at all.
 const DEFAULT_OAUTH_SCOPE = "surveys:read";
+// Scopes advertised in the 401 WWW-Authenticate challenge. Clients build their DCR + authorize
+// requests from this, so it must list every resource scope (read + write) or clients only ever
+// request read and can never reach the write tools. Actual write access is still gated downstream
+// by the user's workspace permissions in the v3 layer.
+const MCP_CHALLENGE_SCOPE = MCP_RESOURCE_SCOPES.join(" ");
 const oauthResourceClient = oauthProviderResourceClient(auth);
 
 export type TMcpAuthInfo = AuthInfo & {
@@ -198,7 +205,7 @@ export function withMcpResponseHeaders(response: Response, requestId: string): R
   });
 }
 
-function withOAuthChallenge(response: Response, scope = DEFAULT_OAUTH_SCOPE): Response {
+function withOAuthChallenge(response: Response, scope = MCP_CHALLENGE_SCOPE): Response {
   const headers = new Headers(response.headers);
   headers.set(
     "WWW-Authenticate",

--- a/apps/web/modules/mcp/tools/surveys.test.ts
+++ b/apps/web/modules/mcp/tools/surveys.test.ts
@@ -503,8 +503,11 @@ describe("registerSurveyTools", () => {
     });
   });
 
-  test("validate_survey rejects write validations for read-only OAuth scopes", async () => {
+  test("validate_survey allows patch validations for read-only OAuth scopes", async () => {
     const { tools } = createToolServer();
+    vi.mocked(validateV3SurveyFromRawInput).mockResolvedValue(
+      successResponse({ valid: true, operation: "patch", invalid_params: [] }, { requestId: "req_tool" })
+    );
 
     const result = await tools.get("validate_survey")!.handler(
       {
@@ -517,12 +520,10 @@ describe("registerSurveyTools", () => {
       { authInfo: readOnlyOAuthAuthInfo }
     );
 
-    expect(validateV3SurveyFromRawInput).not.toHaveBeenCalled();
-    expect(result.isError).toBe(true);
-    expect(result.structuredContent.error).toMatchObject({
-      status: 403,
-      code: "forbidden",
-      detail: "OAuth token does not include the required MCP scope",
+    expect(validateV3SurveyFromRawInput).toHaveBeenCalled();
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual({
+      data: { valid: true, operation: "patch", invalid_params: [] },
       requestId: "req_tool",
     });
   });

--- a/apps/web/modules/mcp/tools/surveys.ts
+++ b/apps/web/modules/mcp/tools/surveys.ts
@@ -215,10 +215,10 @@ export function registerSurveyTools(server: McpServer): void {
     },
     async (input: TMcpValidateSurveyInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
-      const requiredScopes =
-        input.operation === "patch" || input.operation === "create" ? ["surveys:write"] : ["surveys:read"];
-
-      const scopeError = await guardMcpScopes(extra.authInfo, requiredScopes, requestId);
+      // validate_survey never persists changes (readOnlyHint) — a dry-run validation of a create or
+      // patch payload only needs read access. The actual write permission is enforced by the v3 layer
+      // when create_survey / patch_survey run.
+      const scopeError = await guardMcpScopes(extra.authInfo, ["surveys:read"], requestId);
       if (scopeError) {
         return scopeError;
       }


### PR DESCRIPTION
## What does this PR do?

Fixes a scope mismatch found during 5.2 staging QA: connecting Claude (or any MCP client) to `/api/mcp` over OAuth only ever granted `surveys:read`, so every write tool (`create_survey`, `patch_survey`, `delete_survey`) failed with `403 "OAuth token does not include the required MCP scope"` and the consent screen offered only "Read surveys". Two separate root causes, fixed here:

**1. Write was never offered at consent.** The RFC 9728 protected-resource metadata already listed `surveys:write`, but the 401 `WWW-Authenticate` challenge advertised only `surveys:read` and `surveys:write` was not a default DCR scope. Clients that build their request from the challenge (rather than the PRM) therefore registered/authorized read-only and could never reach the write tools. Fixed with two changes that have to move together (change one without the other and you get `invalid_scope`, same failure mode as the earlier `offline_access` bug):

- The 401 challenge now advertises `surveys:read surveys:write` (built from `MCP_RESOURCE_SCOPES`, not hard-coded).
- `surveys:write` is now a **default** DCR scope, so clients are registered for it and the provider validates the write authorize request against their registration.

The minimum scope required to authenticate stays `surveys:read`. Granting the write scope is safe: actual write access is still enforced downstream by the user's workspace permission in the v3 layer (`requireV3WorkspaceAccess`), so a user without `write`/`manage` still gets a 403 there even with the scope.

**2. `validate_survey` was mis-scoped.** It is annotated `readOnlyHint` and described as validating "without writing survey changes", but it required `surveys:write` for create/patch payloads (the only two operations its schema allows), so a read-scoped client couldn't even dry-run a validation. It now requires only `surveys:read`. This makes the code match what the docs already state (overview.mdx lists `validate_survey` under `surveys:read`).

No schema/migration/env changes.

## How should this be tested?

Automated (from `apps/web`):

```
pnpm test -- modules/mcp modules/auth/lib app/.well-known app/api/mcp
```

242 tests pass, including a new DCR test asserting a default (no-scope) registration grants read + write, and updated challenge-scope assertions.

Manual / live (verified on a dev server off this branch):

1. `curl -X POST http://localhost:3000/api/mcp -i` → `WWW-Authenticate` advertises `scope="surveys:read surveys:write"`.
2. Register a client with no scope:
   `curl -X POST http://localhost:3000/api/auth/oauth2/register -H 'content-type: application/json' -d '{"client_name":"t","redirect_uris":["http://localhost:9999/cb"],"grant_types":["authorization_code","refresh_token"],"response_types":["code"],"token_endpoint_auth_method":"none"}'` → returned `scope` includes `surveys:write`.
3. Connect via `npx -y mcp-remote http://localhost:3000/api/mcp` (or Claude Code `/mcp`) → the consent screen shows **both** "Read surveys" and "Write surveys" → `create_survey` succeeds for a user with workspace write permission, and still 403s (at the v3 layer) for a user without it.
4. `validate_survey` with a read-only token now succeeds instead of 403.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [x] Updated the Formbricks Docs if changes were necessary (docs already described this behavior; code now matches)
