### PR TITLE
fix: let MCP clients request surveys:write and correct validate_survey scope (5.2 backport)

### DIFF
--- a/apps/web/app/api/mcp/route.test.ts
+++ b/apps/web/app/api/mcp/route.test.ts
@@ -43,6 +43,7 @@ vi.mock("@formbricks/database", () => ({
 }));
 
 vi.mock("@/modules/auth/lib/oauth-urls", () => ({
+  MCP_RESOURCE_SCOPES: ["surveys:read", "surveys:write"],
   getAuthIssuerUrl: () => "http://localhost/api/auth",
   getMcpOrigin: () => "http://localhost",
   getMcpProtectedResourceMetadataUrl: () => "http://localhost/.well-known/oauth-protected-resource/api/mcp",
@@ -160,7 +161,7 @@ describe("POST /api/mcp", () => {
     expect(response.status).toBe(401);
     expect(response.headers.get("Content-Type")).toBe("application/problem+json");
     expect(response.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read"'
+      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read surveys:write"'
     );
     expect(applyIPRateLimit).toHaveBeenCalled();
   });
@@ -410,7 +411,7 @@ describe("POST /api/mcp", () => {
     expect(authenticateApiKeyFromHeaders).not.toHaveBeenCalled();
     expect(applyIPRateLimit).toHaveBeenCalled();
     expect(response.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read"'
+      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read surveys:write"'
     );
   });
 

--- a/apps/web/modules/auth/lib/mcp-oauth-provider-options.ts
+++ b/apps/web/modules/auth/lib/mcp-oauth-provider-options.ts
@@ -20,8 +20,18 @@ export const getMcpOauthProviderOptions = (): TOauthProviderOptions => ({
   validAudiences: [getMcpResourceUrl()],
   allowDynamicClientRegistration: true,
   allowUnauthenticatedClientRegistration: true,
-  clientRegistrationDefaultScopes: ["openid", "profile", "email", "offline_access", "surveys:read"],
-  clientRegistrationAllowedScopes: ["surveys:write"],
+  // Register MCP clients with read + write by default so the consent screen offers write and the
+  // write tools are reachable (clients derive their DCR/authorize scopes from what we advertise, and
+  // the plugin validates authorize against the client's registered scopes). Granting the write scope
+  // is safe: actual write access is still enforced downstream by the user's workspace permissions.
+  clientRegistrationDefaultScopes: [
+    "openid",
+    "profile",
+    "email",
+    "offline_access",
+    "surveys:read",
+    "surveys:write",
+  ],
   accessTokenExpiresIn: 15 * 60,
   refreshTokenExpiresIn: 30 * 24 * 60 * 60,
   scopeExpirations: {

--- a/apps/web/modules/mcp/auth.ts
+++ b/apps/web/modules/mcp/auth.ts
@@ -19,6 +19,7 @@ import { parseApiKeyV2 } from "@/lib/crypto";
 import { authenticateApiKeyFromHeaders, getBearerTokenFromHeaders } from "@/modules/api/lib/api-key-auth";
 import { auth } from "@/modules/auth/lib/auth";
 import {
+  MCP_RESOURCE_SCOPES,
   getAuthIssuerUrl,
   getMcpOrigin,
   getMcpProtectedResourceMetadataUrl,
@@ -36,7 +37,13 @@ const QUERY_CREDENTIAL_PARAMS = new Set([
   "authorization",
 ]);
 
+// Minimum scope required to authenticate against the MCP server at all.
 const DEFAULT_OAUTH_SCOPE = "surveys:read";
+// Scopes advertised in the 401 WWW-Authenticate challenge. Clients build their DCR + authorize
+// requests from this, so it must list every resource scope (read + write) or clients only ever
+// request read and can never reach the write tools. Actual write access is still gated downstream
+// by the user's workspace permissions in the v3 layer.
+const MCP_CHALLENGE_SCOPE = MCP_RESOURCE_SCOPES.join(" ");
 const oauthResourceClient = oauthProviderResourceClient(auth);
 
 export type TMcpAuthInfo = AuthInfo & {
@@ -198,7 +205,7 @@ export function withMcpResponseHeaders(response: Response, requestId: string): R
   });
 }
 
-function withOAuthChallenge(response: Response, scope = DEFAULT_OAUTH_SCOPE): Response {
+function withOAuthChallenge(response: Response, scope = MCP_CHALLENGE_SCOPE): Response {
   const headers = new Headers(response.headers);
   headers.set(
     "WWW-Authenticate",

--- a/apps/web/modules/mcp/tools/surveys.test.ts
+++ b/apps/web/modules/mcp/tools/surveys.test.ts
@@ -503,8 +503,11 @@ describe("registerSurveyTools", () => {
     });
   });
 
-  test("validate_survey rejects write validations for read-only OAuth scopes", async () => {
+  test("validate_survey allows patch validations for read-only OAuth scopes", async () => {
     const { tools } = createToolServer();
+    vi.mocked(validateV3SurveyFromRawInput).mockResolvedValue(
+      successResponse({ valid: true, operation: "patch", invalid_params: [] }, { requestId: "req_tool" })
+    );
 
     const result = await tools.get("validate_survey")!.handler(
       {
@@ -517,12 +520,10 @@ describe("registerSurveyTools", () => {
       { authInfo: readOnlyOAuthAuthInfo }
     );
 
-    expect(validateV3SurveyFromRawInput).not.toHaveBeenCalled();
-    expect(result.isError).toBe(true);
-    expect(result.structuredContent.error).toMatchObject({
-      status: 403,
-      code: "forbidden",
-      detail: "OAuth token does not include the required MCP scope",
+    expect(validateV3SurveyFromRawInput).toHaveBeenCalled();
+    expect(result.isError).toBeFalsy();
+    expect(result.structuredContent).toEqual({
+      data: { valid: true, operation: "patch", invalid_params: [] },
       requestId: "req_tool",
     });
   });

--- a/apps/web/modules/mcp/tools/surveys.ts
+++ b/apps/web/modules/mcp/tools/surveys.ts
@@ -215,10 +215,10 @@ export function registerSurveyTools(server: McpServer): void {
     },
     async (input: TMcpValidateSurveyInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
-      const requiredScopes =
-        input.operation === "patch" || input.operation === "create" ? ["surveys:write"] : ["surveys:read"];
-
-      const scopeError = await guardMcpScopes(extra.authInfo, requiredScopes, requestId);
+      // validate_survey never persists changes (readOnlyHint) — a dry-run validation of a create or
+      // patch payload only needs read access. The actual write permission is enforced by the v3 layer
+      // when create_survey / patch_survey run.
+      const scopeError = await guardMcpScopes(extra.authInfo, ["surveys:read"], requestId);
       if (scopeError) {
         return scopeError;
       }


### PR DESCRIPTION
## What does this PR do?

Backport of #8509 to `release/5.2` — 5.2 is the first release that ships MCP OAuth (ENG-1055), so the QA fix has to ride along.

Fixes a scope mismatch found in 5.2 staging QA: connecting an MCP client to `/api/mcp` over OAuth only ever granted `surveys:read`, so every write tool (`create_survey`, `patch_survey`, `delete_survey`) failed with `403 "OAuth token does not include the required MCP scope"` and the consent screen offered only "Read surveys". Two root causes:

1. **Write was never offered at consent.** The 401 `WWW-Authenticate` challenge advertised only `surveys:read` and `surveys:write` wasn't a default DCR scope, so clients registered/authorized read-only and could never reach the write tools. Now the challenge advertises `surveys:read surveys:write` (built from `MCP_RESOURCE_SCOPES`) **and** `surveys:write` is a default DCR scope. The minimum scope to authenticate stays `surveys:read`. Safe because real write access is still enforced downstream by the user's workspace permission in the v3 layer.
2. **`validate_survey` was mis-scoped** — annotated `readOnlyHint` / "without writing survey changes" but required `surveys:write`; now requires only `surveys:read`.

**Source-only backport:** the test changes from #8509 are intentionally omitted per our backport convention. Note this means the existing MCP tests on `release/5.2` still assert the pre-fix behavior (challenge scope, validate-requires-write) and will be red until re-cut — expected for a backport; merge accordingly.

## How should this be tested?

Verified on `main` (#8509) via unit tests (242 passing) and a live `mcp-remote` run against a dev server, and confirmed locally by @xernobyl: the consent screen shows **both "Read surveys" and "Write surveys"**, and `create_survey` / `validate_survey` succeed for a user with workspace write permission (and still 403 at the v3 layer without it).

On 5.2:
1. `curl -X POST <origin>/api/mcp -i` → `WWW-Authenticate` advertises `scope="surveys:read surveys:write"`.
2. Register a client with no scope → returned `scope` includes `surveys:write`.
3. Connect via `mcp-remote` → consent offers write → write tools work (subject to workspace permission).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
