### PR TITLE
fix(database): seed Better Auth credential accounts so seed users can log in

### DIFF
--- a/packages/database/src/seed.ts
+++ b/packages/database/src/seed.ts
@@ -382,62 +382,64 @@ async function main(): Promise<void> {
   // Users
   const passwordHash = await hashPassword(SEED_CREDENTIALS.ADMIN.password, 10);
 
-  await prisma.user.upsert({
-    where: { id: SEED_IDS.USER_ADMIN },
-    update: {},
-    create: {
+  const seedUsers = [
+    {
       id: SEED_IDS.USER_ADMIN,
       name: "Admin User",
       email: SEED_CREDENTIALS.ADMIN.email,
-      password: passwordHash,
-      emailVerified: true,
-      memberships: {
-        create: {
-          organizationId: organization.id,
-          role: "owner",
-          accepted: true,
-        },
-      },
+      role: "owner",
     },
-  });
-
-  await prisma.user.upsert({
-    where: { id: SEED_IDS.USER_MANAGER },
-    update: {},
-    create: {
+    {
       id: SEED_IDS.USER_MANAGER,
       name: "Manager User",
       email: SEED_CREDENTIALS.MANAGER.email,
-      password: passwordHash,
-      emailVerified: true,
-      memberships: {
-        create: {
-          organizationId: organization.id,
-          role: "manager",
-          accepted: true,
-        },
-      },
+      role: "manager",
     },
-  });
-
-  await prisma.user.upsert({
-    where: { id: SEED_IDS.USER_MEMBER },
-    update: {},
-    create: {
+    {
       id: SEED_IDS.USER_MEMBER,
       name: "Member User",
       email: SEED_CREDENTIALS.MEMBER.email,
-      password: passwordHash,
-      emailVerified: true,
-      memberships: {
-        create: {
-          organizationId: organization.id,
-          role: "member",
-          accepted: true,
+      role: "member",
+    },
+  ] as const;
+
+  for (const { id, name, email, role } of seedUsers) {
+    await prisma.user.upsert({
+      where: { id },
+      update: {},
+      create: {
+        id,
+        name,
+        email,
+        password: passwordHash,
+        emailVerified: true,
+        memberships: {
+          create: {
+            organizationId: organization.id,
+            role,
+            accepted: true,
+          },
         },
       },
-    },
-  });
+    });
+
+    // Better Auth verifies email/password sign-in against a "credential" Account row
+    // (providerAccountId = user id), not User.password — same shape as the ENG-1054
+    // credential-account backfill migration.
+    await prisma.account.upsert({
+      where: {
+        provider_providerAccountId: { provider: "credential", providerAccountId: id },
+      },
+      update: { password: passwordHash },
+      create: {
+        userId: id,
+        type: "credential",
+        provider: "credential",
+        providerAccountId: id,
+        password: passwordHash,
+      },
+    });
+  }
 
   // Workspace
   const workspace = await prisma.workspace.upsert({


### PR DESCRIPTION
## What does this PR do?

Fixes email/password login for seeded users on fresh installs.

`packages/database/src/seed.ts` was missed in the NextAuth → Better Auth migration (ENG-1054): it still wrote the bcrypt hash to `User.password` only. Better Auth verifies credential sign-in against a `credential` `Account` row (`provider = "credential"`, `providerAccountId = <userId>`, password hash on `Account.password`), so logging in with any seed user failed with `Credential account not found`.

The ENG-1054 backfill migration (`20260619120000_eng_1054_credential_account_backfill`) doesn't cover this case: on a fresh install migrations run *before* the seed, so it runs against an empty `User` table and is then marked as applied.

Changes:

- The seed now upserts a `credential` Account row per seed user (same shape as the backfill migration), so Better Auth login works. Re-running the seed on an already-seeded broken DB also repairs it, since the Account upsert runs even when the user already exists.
- The three copy-pasted user upserts are folded into a single loop over a seed-user list.

Note: `User.email_verified_at` being `NULL` on seeded users is expected — it's a rollback-safety temp column from the ENG-1054 cutover migration, not read by anything; the real field is the `email_verified` boolean, which the seed sets to `true`.

## How should this be tested?

- On a fresh DB: `pnpm db:migrate:dev`, then `pnpm db:seed` (in `packages/database`).
- Verify three `Account` rows exist with `provider = 'credential'`, `providerAccountId` = the seed user ids, and a bcrypt hash in `password`.
- Start the app (`pnpm dev`) and log in at `/auth/login` with `admin@formbricks.com` / the password from `packages/database/src/seed/constants.ts` — you should land on the Surveys dashboard. Same for the manager and member users.

Verified locally: re-ran the seed against an existing broken DB, confirmed the Account rows via Prisma, and logged in through the browser as the admin user successfully.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary