### PR TITLE
fix(web): stop infinite server-action refresh loop on survey analysis pages

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/SummaryPage.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/SummaryPage.tsx
@@ -160,12 +160,13 @@ export const SummaryPage = ({
 
   // Only fetch data when filters change or when there's no initial data
   useEffect(() => {
-    // If we have initial data and no filters are applied, don't fetch
-    const hasNoFilters =
-      (!selectedFilter || Object.keys(selectedFilter).length === 0 || selectedFilter.filter?.length === 0) &&
-      (!dateRange || (!dateRange.from && !dateRange.to));
+    // If we have initial data and no filters are applied, don't fetch. "No filters" must mirror
+    // getFormattedFilters: the default date range ({ from: undefined, to: today }) produces empty
+    // criteria, so checking dateRange fields directly would treat the pristine state as filtered.
+    const hasNoFilters = Object.keys(getFormattedFilters(survey, selectedFilter, dateRange)).length === 0;
 
     if (initialSurveySummary && hasNoFilters) {
+      setSurveySummary(initialSurveySummary);
       setIsLoading(false);
       return;
     }
@@ -183,7 +184,7 @@ export const SummaryPage = ({
     };
 
     fetchFilteredSummary();
-  }, [selectedFilter, dateRange, initialSurveySummary, fetchSummary]);
+  }, [survey, selectedFilter, dateRange, initialSurveySummary, fetchSummary]);
 
   const surveyMemoized = useMemo(() => {
     return replaceHeadlineRecall(survey, "default");

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -125,4 +125,26 @@ describe("proxy", () => {
 
     expect(response.cookies.get("formbricks-workspace-id")).toBeUndefined();
   });
+
+  test("does not re-set the active-workspace cookie when the request already carries the same value", async () => {
+    mockGetProxySession.mockResolvedValue(null);
+
+    const request = new NextRequest("http://localhost:3000/workspaces/ws-123/surveys");
+    request.cookies.set("formbricks-workspace-id", "ws-123");
+
+    const response = await proxy(request);
+
+    expect(response.cookies.get("formbricks-workspace-id")).toBeUndefined();
+  });
+
+  test("updates the active-workspace cookie when navigating to a different workspace", async () => {
+    mockGetProxySession.mockResolvedValue(null);
+
+    const request = new NextRequest("http://localhost:3000/workspaces/ws-456/surveys");
+    request.cookies.set("formbricks-workspace-id", "ws-123");
+
+    const response = await proxy(request);
+
+    expect(response.cookies.get("formbricks-workspace-id")?.value).toBe("ws-456");
+  });
 });

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -84,8 +84,14 @@ export const proxy = async (originalRequest: NextRequest) => {
 
   // Remember the active workspace so the workspace-agnostic org-settings shell can resolve it
   // server-side (localStorage is browser-only). Mirrors the /workspaces/[workspaceId] path segment.
+  // Only set the cookie when the value actually changes: a Set-Cookie on a server-action POST makes
+  // Next.js treat the action as revalidated, forcing a router refresh after every action — on pages
+  // that call an action on mount this becomes an infinite POST/refresh loop.
   const workspaceMatch = /^\/workspaces\/([^/]+)/.exec(request.nextUrl.pathname);
-  if (workspaceMatch?.[1]) {
+  if (
+    workspaceMatch?.[1] &&
+    request.cookies.get(FORMBRICKS_WORKSPACE_ID_COOKIE)?.value !== workspaceMatch[1]
+  ) {
     nextResponseWithCustomHeader.cookies.set(FORMBRICKS_WORKSPACE_ID_COOKIE, workspaceMatch[1], {
       path: "/",
       sameSite: "lax",


### PR DESCRIPTION
## What does this PR do?

Fixes an infinite POST/refresh loop on the survey summary page (`/workspaces/[workspaceId]/surveys/[surveyId]/summary`): the page endlessly alternates server-action POSTs and RSC refresh GETs (visible in the network tab), hammering the server and constantly re-rendering.

### Root cause

Two bugs compound:

1. **The proxy sets the `formbricks-workspace-id` cookie on every `/workspaces/*` request** — including server-action POSTs. When a cookie is set on a server-action response, Next.js marks the action as revalidated (`x-action-revalidated: 1`) and the client router refetches the page's RSC payload.
2. **`SummaryPage`'s "skip fetch when no filters" guard never matches.** The filter context's default date range is `{ from: undefined, to: getTodayDate() }`, and the guard checked `!dateRange.from && !dateRange.to` — always false. Meanwhile `getFormattedFilters` only applies a date filter when *both* `from` and `to` are set, so the pristine state actually produces empty criteria. Result: the summary effect always fetched on mount even though the page already server-renders `initialSurveySummary`.

The loop: mount effect fires `getSurveySummaryAction` → the middleware cookie write flags the action as revalidated → the router refetches the RSC page → new `survey` / `initialSurveySummary` object identities re-trigger the effect → another POST → another refresh → forever.

### Fix

- `apps/web/proxy.ts`: only set the workspace cookie when its value actually changes (first visit or workspace switch). No more cookie writes on every action POST → no spurious revalidation/refresh.
- `SummaryPage.tsx`: derive "no filters" from the actual `getFormattedFilters` output (empty criteria object) instead of the never-true date check, and restore `initialSurveySummary` when filters are cleared. This removes the redundant mount fetch entirely and keeps the page loop-proof even if some future middleware writes cookies again.
- `apps/web/proxy.test.ts`: cover the new cookie behavior (no re-set on same value, update on workspace switch).

## How should this be tested?

- Log in, open a survey summary page, and watch the network tab: no repeating POST + `?_rsc=` GET pairs; on mount there is no `getSurveySummaryAction` call at all (server-rendered data is used).
- Click the Refresh icon: exactly one `getSurveySummaryAction` POST, no cascade.
- Apply a date filter (e.g. "Last 7 days"): exactly one POST with `createdAt` criteria, no cascade. Reset back to "All time": summary returns to the unfiltered data.
- Repeat requests to `/workspaces/*` no longer carry a `set-cookie: formbricks-workspace-id=...` header (only the first visit / workspace switch does); the org-settings shell still resolves the active workspace.
- `pnpm exec vitest run proxy.test.ts` in `apps/web` (8 tests pass).

Verified locally in the browser (network trace before/after) plus lint and `pnpm typecheck` on `apps/web`.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary