### PR TITLE
fix: resolve hydration errors in RatingSmiley table markup

### DIFF
--- a/apps/web/modules/analysis/components/RatingSmiley/index.tsx
+++ b/apps/web/modules/analysis/components/RatingSmiley/index.tsx
@@ -82,19 +82,19 @@ const getSmiley = ({
   );
 
   return (
-    <table
+    <table // NOSONAR S5256 - Need table layout for email compatibility (gmail)
       style={{
         width: `${containerSize}px`,
         height: `${containerSize}px`,
         ...(centered ? { marginLeft: "auto", marginRight: "auto" } : {}),
       }}>
-      {" "}
-      {/* NOSONAR S5256 - Need table layout for email compatibility (gmail) */}
-      <tr>
-        <td align="center" valign="middle">
-          {icon}
-        </td>
-      </tr>
+      <tbody>
+        <tr>
+          <td align="center" valign="middle">
+            {icon}
+          </td>
+        </tr>
+      </tbody>
     </table>
   );
 };


### PR DESCRIPTION
## Problem

On survey summary pages with a rating question, React 19 / Next 16 reports two hydration errors in dev:

- `In HTML, whitespace text nodes cannot be a child of <table>`
- `In HTML, <tr> cannot be a child of <table>`

The `RatingSmiley` component rendered a `<table>` with an explicit `{" "}` text node and a comment expression as direct children, and a `<tr>` not wrapped in `<tbody>`. The browser's HTML parser corrects this markup, so the server-rendered HTML no longer matches what React expects on the client.

## Solution

- Wrap the `<tr>` in `<tbody>` (universally supported by email clients incl. Gmail — browsers auto-insert it anyway, which is exactly what caused the mismatch).
- Remove the explicit whitespace/comment text nodes inside `<table>`; the `NOSONAR S5256` suppression moved onto the `<table>` line itself so SonarQube's same-line suppression still applies.

The table layout is kept as-is for email compatibility.

## Verification

- Loaded a seeded CSAT survey summary page in dev: no hydration errors in the console on fresh loads, rating chart with smileys renders correctly.
- Checked Share survey → Email embed preview (`preview-email-template.tsx` reuses `RatingSmiley`): the five smiley faces render correctly.
- `prettier` clean; no other usages of the component affected (`rating-response`, `preview-email-template`).