### PR TITLE
fix(web): only set workspace cookie on change to stop action refresh loop (backport #8513 → 5.2)

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -84,8 +84,14 @@ export const proxy = async (originalRequest: NextRequest) => {
 
   // Remember the active workspace so the workspace-agnostic org-settings shell can resolve it
   // server-side (localStorage is browser-only). Mirrors the /workspaces/[workspaceId] path segment.
+  // Only set the cookie when the value actually changes: a Set-Cookie on a server-action POST makes
+  // Next.js treat the action as revalidated, forcing a router refresh after every action — on pages
+  // that call an action on mount this becomes an infinite POST/refresh loop.
   const workspaceMatch = /^\/workspaces\/([^/]+)/.exec(request.nextUrl.pathname);
-  if (workspaceMatch?.[1]) {
+  if (
+    workspaceMatch?.[1] &&
+    request.cookies.get(FORMBRICKS_WORKSPACE_ID_COOKIE)?.value !== workspaceMatch[1]
+  ) {
     nextResponseWithCustomHeader.cookies.set(FORMBRICKS_WORKSPACE_ID_COOKIE, workspaceMatch[1], {
       path: "/",
       sameSite: "lax",


### PR DESCRIPTION
## What does this PR do?

Backport of the `proxy.ts` fix from #8513 into `release/5.2`.

### Root cause
`proxy.ts` sets the `formbricks-workspace-id` cookie on **every** `/workspaces/*` request — including server-action POSTs. A `Set-Cookie` on a server-action response makes Next.js flag the action as revalidated (`x-action-revalidated: 1`), so the client router refetches the page's RSC payload. On pages that fire an action on mount (e.g. the survey summary page) this becomes an infinite POST/refresh loop.

### Fix
Only set the cookie when its value actually changes (first visit / workspace switch). No cookie write on repeat `/workspaces/*` requests → no spurious revalidation/refresh.

### Backport notes
- Source change only. The `proxy.test.ts` additions from #8513 are **omitted** per release-branch backport policy (no new tests on release branches).
- The SummaryPage client-side dedupe (from #8507) is **not** part of this backport — it is a separate fix. If 5.2 still shows the loop after this, #8507's client fix may also need backporting.

## How should this be tested?
- Repeat requests to `/workspaces/*` no longer carry a `set-cookie: formbricks-workspace-id=...` header (only first visit / workspace switch does).
- Open a survey summary page: no repeating POST + `?_rsc=` GET pairs.
- The org-settings shell still resolves the active workspace.