### PR TITLE
fix: prevent auth-action route-refresh loop in chart edit and feedback record modals

### DIFF
--- a/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.ts
+++ b/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.ts
@@ -155,8 +155,12 @@ export function useChartDialog({
     return () => {
       cancelled = true;
     };
+    // Key on initialChart?.id, NOT the object reference. Every authenticated action here
+    // (getChartAction / executeQueryAction) re-sets the Better Auth session cookie → Next.js route
+    // refresh → new `initialChart` reference; depending on the object would re-fire executeQueryAction on
+    // every refresh → infinite loop. The id is the stable identity; content is unchanged across refreshes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, chartId, workspaceId, initialChart]);
+  }, [open, chartId, workspaceId, initialChart?.id]);
 
   const handleChartGenerated = (data: AnalyticsResponse) => {
     setChartData(data);

--- a/apps/web/modules/ee/unify-feedback/components/feedback-record-form-drawer.tsx
+++ b/apps/web/modules/ee/unify-feedback/components/feedback-record-form-drawer.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { FingerprintIcon, LanguagesIcon, PlusIcon, SparklesIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFieldArray, useForm } from "react-hook-form";
 import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
@@ -154,11 +154,18 @@ export const FeedbackRecordFormDrawer = ({
     setCustomSourceType("");
   }, [directories, form]);
 
+  // resetForCreate depends on `directories`, which is derived from a server prop (frdMap) that gets a
+  // fresh reference on every route refresh. Every authenticated action here (retrieveFeedbackRecordAction)
+  // re-sets the Better Auth session cookie → route refresh → new resetForCreate ref → this effect would
+  // re-fire the action → infinite loop. Read it through a ref so it isn't an effect trigger.
+  const resetForCreateRef = useRef(resetForCreate);
+  resetForCreateRef.current = resetForCreate;
+
   useEffect(() => {
     if (!open) return;
 
     if (mode === "create") {
-      resetForCreate();
+      resetForCreateRef.current();
       return;
     }
 
@@ -184,7 +191,7 @@ export const FeedbackRecordFormDrawer = ({
     };
 
     void loadRecord();
-  }, [form, mode, onOpenChange, open, recordId, resetForCreate, t, workspaceId]);
+  }, [form, mode, onOpenChange, open, recordId, t, workspaceId]);
 
   const requestClose = useCallback(() => {
     if (form.formState.isDirty && !isSubmitting) {


### PR DESCRIPTION
## What does this PR do?

Fixes the infinite re-render / refetch loop (repeating `POST` + `GET …?_rsc` pairs in the network tab) on two more surfaces:

- **Edit Chart modal** (`workspaces/[workspaceId]/unify/…` charts) — loops on opening an existing chart.
- **Single feedback-record drawer** (`unify/feedback-records`) — loops on clicking a record row.

These are the same class as the survey-summary loop already fixed in #8507: a client `useEffect` calls an **authenticated server action** and lists a **server-derived value** in its dependency array. Every authenticated server action returns a `Set-Cookie` on its POST response, which makes Next.js flag the action as revalidated (`x-action-revalidated`) and refetch the route's RSC payload. That refresh hands the component **fresh object references** for its server props, and because React compares deps by reference, the effect re-fires → another action → another refresh → loop.

> The shared **root cause** (a per-request `Set-Cookie` in `proxy.ts` revalidating every action) is fixed systemically in **#8513**. This PR is complementary component-level hardening: it makes these two effects immune to prop-reference churn (defense-in-depth) and also removes a redundant fetch. Both together keep these surfaces loop-proof even if some future middleware writes a cookie again.

### Changes

- **`modules/ee/analysis/charts/hooks/use-chart-dialog.ts`** — the chart-load effect keyed on the `initialChart` **object**, which gets a new reference on every route refresh → re-fired `executeQueryAction`. Keyed it on the stable `initialChart?.id` instead (content is unchanged across refreshes).
- **`modules/ee/unify-feedback/components/feedback-record-form-drawer.tsx`** — the record-load effect depended on `resetForCreate`, whose identity churns (via `directories` ← the `frdMap` server prop) → re-fired `retrieveFeedbackRecordAction`. Read `resetForCreate` through a ref so it is no longer an effect trigger; deps are now stable.

No behaviour change for users beyond the loop being gone: opening a chart / feedback record fetches its data exactly once.

## How should this be tested?

**Edit Chart modal**
- Open an existing chart (Analysis → Charts → open a saved chart). The preview loads once; the network tab shows no repeating `POST charts` + `GET charts?_rsc` pairs.
- Change chart type / measures — behaves normally.

**Feedback record drawer**
- Open Unify → Feedback Records, click a record row. The drawer loads the record once; no repeating `POST feedback-records` + `GET feedback-records?_rsc` pairs.
- Edit and save a record — behaves normally; create-a-new-record still resets the form correctly.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
