### PR TITLE
fix(api-keys): stop truncating the org-access note in the API key modal

### DIFF
--- a/apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx
+++ b/apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx
@@ -337,7 +337,7 @@ export const AddApiKeyModal = ({
                 </div>
               ))}
               {isFormbricksCloud && (
-                <Alert variant="info" size="small">
+                <Alert variant="info">
                   <AlertDescription>
                     {t("workspace.api_keys.organization_access_cloud_note")}
                   </AlertDescription>


### PR DESCRIPTION
## What does this PR do?

Fixes **ENG-1782** — the info note in the API key creation modal was getting cut off.

### Root cause
The Formbricks Cloud org-access note used `<Alert variant="info" size="small">`. The Alert `small` size lays the alert out single-line (`flex items-center`) and applies `truncate` to `AlertDescription` (`alert/index.tsx:119`), so the note was clipped to "…Team management still w...".

### Fix
Drop `size="small"` so the alert uses the **default** variant, which wraps the description across lines. One-line change per the issue's suggestion ("Replace with default variant of the alert component").

```diff
- <Alert variant="info" size="small">
+ <Alert variant="info">
```

## How should this be tested?
1. On Formbricks Cloud, open **Organization → Settings → API keys → Add API key**.
2. The blue info note ("On Formbricks Cloud, managing organization members via the API isn't available. Team management still works.") should now display in full, wrapping instead of truncating.

## Screenshots
Before: note truncated ("…still w..."). After: full text wraps. (Attach in Linear ENG-1782.)