### PR TITLE
fix(ui): keep InputCombobox chevron right-aligned when the dropdown is empty

### DIFF
--- a/apps/web/modules/ui/components/input-combo-box/index.tsx
+++ b/apps/web/modules/ui/components/input-combo-box/index.tsx
@@ -324,7 +324,15 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
                 }}
               />
             ) : (
-              <ChevronDownIcon className="size-5 shrink-0 text-slate-300 group-hover/icon:text-slate-400" />
+              <ChevronDownIcon
+                className={cn(
+                  "size-5 shrink-0 text-slate-300 group-hover/icon:text-slate-400",
+                  // Pin the chevron to the right even when there's no value/placeholder to render a
+                  // leading flex-1 element — otherwise it collapses to the left and looks broken.
+                  // Skip in the centered icon-only (withInput) variant so it stays centered.
+                  !(withInput && inputType !== "dropdown") && "ml-auto"
+                )}
+              />
             )}
           </div>
         </DropdownMenuTrigger>


### PR DESCRIPTION
## What does this PR do?

Fixes **ENG-1789** — dropdowns render with the chevron collapsed to the **left** edge (looks broken). Seen in the survey conditional-logic "Then" action dropdowns, but it's a **general `InputCombobox` issue** affecting any empty dropdown across the app.

<img width="1253" height="303" alt="Screenshot 2026-07-14 at 4 29 06 PM" src="https://github.com/user-attachments/assets/c28718cd-9083-4f7c-97a1-97febfd9eb8b" />


### Root cause
The trigger is a flex row (`input-combo-box/index.tsx:300-329`). The leading value/placeholder element carries `flex-1`, which is what pushes the chevron to the right. When a combobox has **no selected value AND no placeholder**, that leading element isn't rendered — so the `ChevronDownIcon` becomes the only flex child and sits at the **left** (flex-start).

### Fix
Pin the chevron with `ml-auto` so it stays right regardless of leading content. Skipped in the centered icon-only (`withInput`) variant so that keeps centering.

```diff
- <ChevronDownIcon className="size-5 shrink-0 text-slate-300 group-hover/icon:text-slate-400" />
+ <ChevronDownIcon
+   className={cn(
+     "size-5 shrink-0 text-slate-300 group-hover/icon:text-slate-400",
+     !(withInput && inputType !== "dropdown") && "ml-auto"
+   )}
+ />
```

One shared-component change — no per-screen patching, no placeholder/i18n changes. (Earlier revision of this PR added placeholders to the logic editor; that was the wrong layer and has been dropped.)

## How should this be tested?
1. Survey editor → single-select question → **Conditional Logic** → **Add logic**. Under **Then**, the empty action/target dropdowns show the chevron on the **right**, aligned with the populated ones.
2. Spot-check other `InputCombobox` dropdowns app-wide (chart builder, integrations, logic conditions) — empty ones now have a right chevron; populated ones and the icon-only search variant are unchanged.