### PR TITLE
fix(api-keys): stop truncating the org-access note in the API key modal (backport #8519 → 5.2)

### DIFF
--- a/apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx
+++ b/apps/web/modules/organization/settings/api-keys/components/add-api-key-modal.tsx
@@ -337,7 +337,7 @@ export const AddApiKeyModal = ({
                 </div>
               ))}
               {isFormbricksCloud && (
-                <Alert variant="info" size="small">
+                <Alert variant="info">
                   <AlertDescription>
                     {t("workspace.api_keys.organization_access_cloud_note")}
                   </AlertDescription>


### PR DESCRIPTION
## What does this PR do?

Backport of #8519 (ENG-1782) to `release/5.2`. Clean cherry-pick, no conflicts.

### Root cause
The Formbricks Cloud org-access note in the API key modal used `<Alert variant="info" size="small">`. The `small` size lays the alert out single-line and applies `truncate` to `AlertDescription` (`alert/index.tsx:119`), so the note was cut off ("…Team management still w...").

### Fix
Drop `size="small"` → default Alert variant wraps the text.

```diff
- <Alert variant="info" size="small">
+ <Alert variant="info">
```

### Backport notes
- Source-only, one-line change. No tests (nothing to strip per release-branch policy).

## How should this be tested?
Formbricks Cloud → Organization → Settings → API keys → Add API key → the blue info note displays in full (wraps) instead of truncating.