### PR TITLE
fix(ui): keep InputCombobox chevron right-aligned when the dropdown is empty (backport #8520 → 5.2)

### DIFF
--- a/apps/web/modules/ui/components/input-combo-box/index.tsx
+++ b/apps/web/modules/ui/components/input-combo-box/index.tsx
@@ -324,7 +324,15 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
                 }}
               />
             ) : (
-              <ChevronDownIcon className="size-5 shrink-0 text-slate-300 group-hover/icon:text-slate-400" />
+              <ChevronDownIcon
+                className={cn(
+                  "size-5 shrink-0 text-slate-300 group-hover/icon:text-slate-400",
+                  // Pin the chevron to the right even when there's no value/placeholder to render a
+                  // leading flex-1 element — otherwise it collapses to the left and looks broken.
+                  // Skip in the centered icon-only (withInput) variant so it stays centered.
+                  !(withInput && inputType !== "dropdown") && "ml-auto"
+                )}
+              />
             )}
           </div>
         </DropdownMenuTrigger>


### PR DESCRIPTION
## What does this PR do?

Backport of #8520 (ENG-1789) to `release/5.2`. Clean cherry-pick, no conflicts.

### Root cause
The `InputCombobox` trigger is a flex row where the leading value/placeholder element carries `flex-1`, which pushes the chevron to the right. When a combobox has no selected value AND no placeholder, that element isn't rendered, so the `ChevronDownIcon` becomes the only flex child and collapses to the **left** edge — looking broken. Seen in the survey conditional-logic action dropdowns, but it's a general `InputCombobox` issue affecting any empty dropdown app-wide.

### Fix
Pin the chevron with `ml-auto` so it stays right regardless of leading content; skipped in the centered icon-only (`withInput`) variant so that stays centered.

### Backport notes
- Source-only, single shared-component change. No tests (nothing to strip per release-branch policy).

## How should this be tested?
Survey editor → single-select question → Conditional Logic → Add logic → the empty "Then" action/target dropdowns show the chevron on the right. Spot-check other empty `InputCombobox` dropdowns app-wide; populated dropdowns and the icon-only search variant unchanged.