### PR TITLE
chore: document SIGNUP_DOMAIN_CHECK_ON_INVITES in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -215,6 +215,9 @@ PASSWORD_RESET_DISABLED=1
 # Organization Invite. Disable the ability for invited users to create an account.
 # INVITE_DISABLED=1
 
+# Also apply the signup email-domain check to invited users. "1" to enable.
+# SIGNUP_DOMAIN_CHECK_ON_INVITES=1
+
 ##########
 # Other  #
 ##########


### PR DESCRIPTION
## Problem

`SIGNUP_DOMAIN_CHECK_ON_INVITES` is defined in `apps/web/lib/env.ts` and consumed in `apps/web/lib/constants.ts`, but missing from `.env.example`.

## Solution

Add a commented entry next to `INVITE_DISABLED`. Optional, defaults off — absence changes no behavior. When set to `1`, the signup email-domain check also applies to invited users; otherwise invited users are exempt.

No code changes.