### PR TITLE
fix(account): redirect SSO account deletion to the post-deletion survey (ENG-1780)

### DIFF
--- a/apps/web/modules/account/lib/better-auth-account-deletion-request.integration.test.ts
+++ b/apps/web/modules/account/lib/better-auth-account-deletion-request.integration.test.ts
@@ -65,7 +65,8 @@ describe("requestSsoAccountDeletionEmail (real Postgres)", () => {
     const mailArgs = sendDeleteAccountConfirmationEmailMock.mock.calls[0][0];
     expect(mailArgs.email).toBe(email);
     expect(mailArgs.deleteLink).toContain("/api/auth/delete-user/callback?token=");
-    expect(mailArgs.deleteLink).toContain("callbackURL=/");
+    // Self-hosted (IS_FORMBRICKS_CLOUD is false under test): the callback returns to the login page.
+    expect(mailArgs.deleteLink).toContain(`callbackURL=${encodeURIComponent("/auth/login")}`);
     const token = new URL(mailArgs.deleteLink).searchParams.get("token");
     expect(token).toBeTruthy();
 

--- a/apps/web/modules/account/lib/better-auth-account-deletion-request.integration.test.ts
+++ b/apps/web/modules/account/lib/better-auth-account-deletion-request.integration.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { resetDb } from "@/integration/reset-db";
+import { FORMBRICKS_CLOUD_ACCOUNT_DELETION_SURVEY_URL } from "@/modules/account/constants";
 import { auth } from "@/modules/auth/lib/auth";
 import { sendDeleteAccountConfirmationEmail } from "@/modules/email";
 import { requestSsoAccountDeletionEmail } from "./better-auth-account-deletion-request";
@@ -10,6 +11,20 @@ import { requestSsoAccountDeletionEmail } from "./better-auth-account-deletion-r
 // (the parts actually under test) run against the real Postgres untouched.
 const { getSessionMock } = vi.hoisted(() => ({ getSessionMock: vi.fn() }));
 vi.mock("@/modules/auth/lib/session", () => ({ getSession: getSessionMock }));
+
+// Toggle IS_FORMBRICKS_CLOUD per test to cover both post-deletion redirect targets; every other
+// constant (WEBAPP_URL, etc.) stays real so the Better Auth harness is untouched (auth.ts does not
+// read IS_FORMBRICKS_CLOUD).
+const { constantsOverrides } = vi.hoisted(() => ({ constantsOverrides: { isFormbricksCloud: false } }));
+vi.mock("@/lib/constants", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/constants")>();
+  return {
+    ...actual,
+    get IS_FORMBRICKS_CLOUD() {
+      return constantsOverrides.isFormbricksCloud;
+    },
+  };
+});
 
 // @/modules/email is mocked in integration/setup.ts (captures mail instead of hitting SMTP); grab the
 // auto-mocked sendDeleteAccountConfirmationEmail to assert the action calls it with the callback link.
@@ -39,6 +54,7 @@ const createVerifiedUser = async (email: string, password: string): Promise<stri
 beforeEach(async () => {
   await resetDb();
   vi.clearAllMocks();
+  constantsOverrides.isFormbricksCloud = false;
 });
 
 describe("requestSsoAccountDeletionEmail (real Postgres)", () => {
@@ -86,6 +102,23 @@ describe("requestSsoAccountDeletionEmail (real Postgres)", () => {
     });
 
     expect(await prisma.user.findUnique({ where: { id: userId } })).toBeNull();
+  });
+
+  test("on Formbricks Cloud, the emailed link returns to the account-deletion survey (ENG-1780)", async () => {
+    constantsOverrides.isFormbricksCloud = true;
+    const email = "ssocloud@example.com";
+    const userId = await createVerifiedUser(email, "Passw0rd!");
+    await prisma.user.update({ where: { id: userId }, data: { identityProvider: "google" } });
+    getSessionMock.mockResolvedValue({ user: { id: userId, email } });
+
+    await requestSsoAccountDeletionEmail();
+
+    expect(sendDeleteAccountConfirmationEmailMock).toHaveBeenCalledTimes(1);
+    const mailArgs = sendDeleteAccountConfirmationEmailMock.mock.calls[0][0];
+    // Cloud: the callback redirects to the offboarding survey instead of the login page.
+    expect(mailArgs.deleteLink).toContain(
+      `callbackURL=${encodeURIComponent(FORMBRICKS_CLOUD_ACCOUNT_DELETION_SURVEY_URL)}`
+    );
   });
 
   test("rejects a credential (email-identity) user — they must confirm with their password", async () => {

--- a/apps/web/modules/account/lib/better-auth-account-deletion-request.ts
+++ b/apps/web/modules/account/lib/better-auth-account-deletion-request.ts
@@ -3,7 +3,8 @@ import crypto from "node:crypto";
 import { prisma } from "@formbricks/database";
 import { AuthenticationError, AuthorizationError } from "@formbricks/types/errors";
 import type { TUserLocale } from "@formbricks/types/user";
-import { WEBAPP_URL } from "@/lib/constants";
+import { IS_FORMBRICKS_CLOUD, WEBAPP_URL } from "@/lib/constants";
+import { FORMBRICKS_CLOUD_ACCOUNT_DELETION_SURVEY_URL } from "@/modules/account/constants";
 import { requiresPasswordConfirmationForAccountDeletion } from "@/modules/account/lib/account-deletion-auth";
 import { auth } from "@/modules/auth/lib/auth";
 import { getSession } from "@/modules/auth/lib/session";
@@ -66,7 +67,13 @@ export const requestSsoAccountDeletionEmail = async (): Promise<void> => {
     expiresAt: new Date(Date.now() + DELETE_ACCOUNT_LINK_VALIDITY_MS),
   });
 
-  const deleteLink = `${WEBAPP_URL}/api/auth/delete-user/callback?token=${token}&callbackURL=/`;
+  // Match the credential delete path's post-deletion redirect (DeleteAccountModal): survey on
+  // Formbricks Cloud, /auth/login otherwise. Better Auth's delete-user/callback only accepts
+  // same-origin callbackURLs (trustedOrigins); the survey is served from the Cloud app's own origin,
+  // so it passes there. (It is rejected when WEBAPP_URL differs from the survey origin — e.g. a local
+  // build with the Cloud flag forced on.)
+  const callbackURL = IS_FORMBRICKS_CLOUD ? FORMBRICKS_CLOUD_ACCOUNT_DELETION_SURVEY_URL : "/auth/login";
+  const deleteLink = `${WEBAPP_URL}/api/auth/delete-user/callback?token=${token}&callbackURL=${encodeURIComponent(callbackURL)}`;
 
   await sendDeleteAccountConfirmationEmail({
     email,


### PR DESCRIPTION
## Problem

SSO (email-link) account deletion always redirected to app home `/`, ignoring the post-deletion redirect the credential delete path applies. The link in `better-auth-account-deletion-request.ts` hardcoded `callbackURL=/`.

Credential deletes already branch the redirect in `DeleteAccountModal` (survey on Formbricks Cloud, `/auth/login` otherwise). The SSO path skipped that branch — a regression from the Better Auth migration (ENG-1054).

## Solution

Set `callbackURL` conditionally in the SSO deletion request, matching the credential path:

```ts
const callbackURL = IS_FORMBRICKS_CLOUD ? FORMBRICKS_CLOUD_ACCOUNT_DELETION_SURVEY_URL : "/auth/login";
```

The survey is served from the app's own origin, so on Formbricks Cloud it satisfies Better Auth's same-origin `trustedOrigins` check on `delete-user/callback`. The value is URL-encoded.

## QA note

Better Auth rejects **cross-origin** `callbackURL`s (`INVALID_CALLBACK_URL`). This only bites in a local build with the Cloud flag forced on (`WEBAPP_URL=localhost` ≠ survey origin). In production Cloud the origins match. To verify the survey redirect end-to-end, test where `WEBAPP_URL` shares the survey's origin.

## Tests

Updated `better-auth-account-deletion-request.integration.test.ts` to assert the self-hosted callback (`/auth/login`, since the Cloud flag is off under test).

Closes ENG-1780