### PR TITLE
fix: verify password against the credential account for email change and 2FA

### DIFF
--- a/apps/web/lib/user/password.test.ts
+++ b/apps/web/lib/user/password.test.ts
@@ -1,14 +1,11 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
-import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { InvalidInputError } from "@formbricks/types/errors";
 import { verifyPassword } from "@/modules/auth/lib/utils";
-import { getCredentialPasswordHash, getUserAuthenticationData, verifyUserPassword } from "./password";
+import { getCredentialPasswordHash, verifyUserPassword } from "./password";
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
-    user: {
-      findUnique: vi.fn(),
-    },
     account: {
       findUnique: vi.fn(),
     },
@@ -19,43 +16,12 @@ vi.mock("@/modules/auth/lib/utils", () => ({
   verifyPassword: vi.fn(),
 }));
 
-const mockPrismaUserFindUnique = vi.mocked(prisma.user.findUnique);
 const mockPrismaAccountFindUnique = vi.mocked(prisma.account.findUnique);
 const mockVerifyPassword = vi.mocked(verifyPassword);
 
 describe("user password helpers", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-  });
-
-  test("returns authentication data for an existing user", async () => {
-    const user = {
-      email: "user@example.com",
-      identityProvider: "email",
-      identityProviderAccountId: null,
-      password: "hashed-password",
-    };
-    mockPrismaUserFindUnique.mockResolvedValue(user as any);
-
-    await expect(getUserAuthenticationData("user-with-password")).resolves.toEqual(user);
-
-    expect(mockPrismaUserFindUnique).toHaveBeenCalledWith({
-      where: {
-        id: "user-with-password",
-      },
-      select: {
-        email: true,
-        password: true,
-        identityProvider: true,
-        identityProviderAccountId: true,
-      },
-    });
-  });
-
-  test("throws when authentication data is missing", async () => {
-    mockPrismaUserFindUnique.mockResolvedValue(null);
-
-    await expect(getUserAuthenticationData("missing-user")).rejects.toThrow(ResourceNotFoundError);
   });
 
   test("getCredentialPasswordHash reads the credential Account scoped to the user", async () => {

--- a/apps/web/lib/user/password.test.ts
+++ b/apps/web/lib/user/password.test.ts
@@ -2,11 +2,14 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { verifyPassword } from "@/modules/auth/lib/utils";
-import { getUserAuthenticationData, verifyUserPassword } from "./password";
+import { getCredentialPasswordHash, getUserAuthenticationData, verifyUserPassword } from "./password";
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
     user: {
+      findUnique: vi.fn(),
+    },
+    account: {
       findUnique: vi.fn(),
     },
   },
@@ -17,6 +20,7 @@ vi.mock("@/modules/auth/lib/utils", () => ({
 }));
 
 const mockPrismaUserFindUnique = vi.mocked(prisma.user.findUnique);
+const mockPrismaAccountFindUnique = vi.mocked(prisma.account.findUnique);
 const mockVerifyPassword = vi.mocked(verifyPassword);
 
 describe("user password helpers", () => {
@@ -54,13 +58,33 @@ describe("user password helpers", () => {
     await expect(getUserAuthenticationData("missing-user")).rejects.toThrow(ResourceNotFoundError);
   });
 
-  test("verifies a password against the stored hash", async () => {
-    mockPrismaUserFindUnique.mockResolvedValue({
-      email: "password-user@example.com",
-      identityProvider: "email",
-      identityProviderAccountId: null,
-      password: "hashed-password",
-    } as any);
+  test("getCredentialPasswordHash reads the credential Account scoped to the user", async () => {
+    mockPrismaAccountFindUnique.mockResolvedValue({ password: "hashed-password" } as any);
+
+    await expect(getCredentialPasswordHash("user-1")).resolves.toBe("hashed-password");
+
+    expect(mockPrismaAccountFindUnique).toHaveBeenCalledWith({
+      where: {
+        provider_providerAccountId: { provider: "credential", providerAccountId: "user-1" },
+      },
+      select: { password: true },
+    });
+  });
+
+  test("getCredentialPasswordHash returns null when there is no credential Account", async () => {
+    mockPrismaAccountFindUnique.mockResolvedValue(null);
+
+    await expect(getCredentialPasswordHash("sso-user")).resolves.toBeNull();
+  });
+
+  test("getCredentialPasswordHash returns null when the credential Account has no password", async () => {
+    mockPrismaAccountFindUnique.mockResolvedValue({ password: null } as any);
+
+    await expect(getCredentialPasswordHash("user-without-hash")).resolves.toBeNull();
+  });
+
+  test("verifies a password against the credential Account hash", async () => {
+    mockPrismaAccountFindUnique.mockResolvedValue({ password: "hashed-password" } as any);
     mockVerifyPassword.mockResolvedValue(true);
 
     await expect(verifyUserPassword("password-user", "plain-password")).resolves.toBe(true);
@@ -68,13 +92,8 @@ describe("user password helpers", () => {
     expect(mockVerifyPassword).toHaveBeenCalledWith("plain-password", "hashed-password");
   });
 
-  test("returns false when the password does not match the stored hash", async () => {
-    mockPrismaUserFindUnique.mockResolvedValue({
-      email: "password-user@example.com",
-      identityProvider: "email",
-      identityProviderAccountId: null,
-      password: "hashed-password",
-    } as any);
+  test("returns false when the password does not match the credential Account hash", async () => {
+    mockPrismaAccountFindUnique.mockResolvedValue({ password: "hashed-password" } as any);
     mockVerifyPassword.mockResolvedValue(false);
 
     await expect(verifyUserPassword("password-user", "wrong-password")).resolves.toBe(false);
@@ -82,13 +101,8 @@ describe("user password helpers", () => {
     expect(mockVerifyPassword).toHaveBeenCalledWith("wrong-password", "hashed-password");
   });
 
-  test("rejects password verification for users without a password", async () => {
-    mockPrismaUserFindUnique.mockResolvedValue({
-      email: "sso-user@example.com",
-      identityProvider: "google",
-      identityProviderAccountId: "google-account-id",
-      password: null,
-    } as any);
+  test("fails closed when the user has no credential Account (no password to verify)", async () => {
+    mockPrismaAccountFindUnique.mockResolvedValue(null);
 
     await expect(verifyUserPassword("sso-user", "plain-password")).rejects.toThrow(InvalidInputError);
 

--- a/apps/web/lib/user/password.ts
+++ b/apps/web/lib/user/password.ts
@@ -1,33 +1,8 @@
 import "server-only";
 import { cache as reactCache } from "react";
 import { prisma } from "@formbricks/database";
-import { User } from "@formbricks/database/prisma";
-import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { InvalidInputError } from "@formbricks/types/errors";
 import { verifyPassword } from "@/modules/auth/lib/utils";
-
-export const getUserAuthenticationData = reactCache(
-  async (
-    userId: string
-  ): Promise<Pick<User, "email" | "password" | "identityProvider" | "identityProviderAccountId">> => {
-    const user = await prisma.user.findUnique({
-      where: {
-        id: userId,
-      },
-      select: {
-        email: true,
-        password: true,
-        identityProvider: true,
-        identityProviderAccountId: true,
-      },
-    });
-
-    if (!user) {
-      throw new ResourceNotFoundError("user", userId);
-    }
-
-    return user;
-  }
-);
 
 /**
  * Returns the bcrypt password hash on the user's Better Auth `credential` Account

--- a/apps/web/lib/user/password.ts
+++ b/apps/web/lib/user/password.ts
@@ -29,12 +29,31 @@ export const getUserAuthenticationData = reactCache(
   }
 );
 
-export const verifyUserPassword = async (userId: string, password: string): Promise<boolean> => {
-  const user = await getUserAuthenticationData(userId);
+/**
+ * Returns the bcrypt password hash on the user's Better Auth `credential` Account
+ * (provider = "credential", providerAccountId = userId), or null when the user has no credential
+ * account (e.g. SSO-only users). Post-ENG-1054 the password lives here, NOT on `User.password`
+ * (which is null for accounts created after the cutover). Scoped strictly to the given user id.
+ */
+export const getCredentialPasswordHash = reactCache(async (userId: string): Promise<string | null> => {
+  const account = await prisma.account.findUnique({
+    where: {
+      provider_providerAccountId: { provider: "credential", providerAccountId: userId },
+    },
+    select: { password: true },
+  });
 
-  if (!user.password) {
+  return account?.password ?? null;
+});
+
+export const verifyUserPassword = async (userId: string, password: string): Promise<boolean> => {
+  const passwordHash = await getCredentialPasswordHash(userId);
+
+  // Fail closed: no credential account (e.g. SSO-only user) means there is no password to verify
+  // against, so the operation must be rejected — never treated as a successful verification.
+  if (!passwordHash) {
     throw new InvalidInputError("Password is not set for this user");
   }
 
-  return await verifyPassword(password, user.password);
+  return await verifyPassword(password, passwordHash);
 };

--- a/apps/web/modules/ee/two-factor-auth/components/confirm-password-form.tsx
+++ b/apps/web/modules/ee/two-factor-auth/components/confirm-password-form.tsx
@@ -50,8 +50,10 @@ export const ConfirmPasswordForm = ({
       setSecret(secret);
       setCurrentStep("scanQRCode");
     } else {
+      // Always surface something: getFormattedErrorMessage can resolve to an empty string for some
+      // action errors, which would show a blank toast (the "spinner then nothing" symptom).
       const errorMessage = getFormattedErrorMessage(setupTwoFactorAuthResponse);
-      toast.error(errorMessage);
+      toast.error(errorMessage || t("common.something_went_wrong_please_try_again"));
     }
   };
 

--- a/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.test.ts
+++ b/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { symmetricDecrypt, symmetricEncrypt } from "@/lib/crypto";
+import { getCredentialPasswordHash } from "@/lib/user/password";
 import { totpAuthenticatorCheck } from "@/modules/auth/lib/totp";
 import { verifyPassword } from "@/modules/auth/lib/utils";
 import { disableTwoFactorAuth, enableTwoFactorAuth, setupTwoFactorAuth } from "./two-factor-auth";
@@ -20,6 +21,10 @@ vi.mock("@/lib/crypto", () => ({
   symmetricDecrypt: vi.fn(),
 }));
 
+vi.mock("@/lib/user/password", () => ({
+  getCredentialPasswordHash: vi.fn(),
+}));
+
 vi.mock("@/modules/auth/lib/utils", () => ({
   verifyPassword: vi.fn(),
 }));
@@ -29,6 +34,12 @@ vi.mock("@/modules/auth/lib/totp", () => ({
 }));
 
 describe("Two Factor Auth", () => {
+  beforeEach(() => {
+    // Default: the user has a credential-account password hash. Individual "no password" tests
+    // override this with null. (Password now lives on the credential Account, not User.password.)
+    vi.mocked(getCredentialPasswordHash).mockResolvedValue("hashedPassword");
+  });
+
   afterEach(() => {
     vi.clearAllMocks();
   });
@@ -45,9 +56,9 @@ describe("Two Factor Auth", () => {
   test("setupTwoFactorAuth should throw InvalidInputError when user has no password", async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue({
       id: "user123",
-      password: null,
       identityProvider: "email",
     } as any);
+    vi.mocked(getCredentialPasswordHash).mockResolvedValue(null);
 
     await expect(setupTwoFactorAuth("user123", "password123")).rejects.toThrow(
       new InvalidInputError("User does not have a password set")
@@ -113,9 +124,9 @@ describe("Two Factor Auth", () => {
   test("enableTwoFactorAuth should throw InvalidInputError when user has no password", async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue({
       id: "user123",
-      password: null,
       identityProvider: "email",
     } as any);
+    vi.mocked(getCredentialPasswordHash).mockResolvedValue(null);
 
     await expect(enableTwoFactorAuth("user123", "123456")).rejects.toThrow(
       new InvalidInputError("User does not have a password set")
@@ -228,9 +239,10 @@ describe("Two Factor Auth", () => {
   test("disableTwoFactorAuth should throw InvalidInputError when user has no password", async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue({
       id: "user123",
-      password: null,
       identityProvider: "email",
+      twoFactorEnabled: true,
     } as any);
+    vi.mocked(getCredentialPasswordHash).mockResolvedValue(null);
 
     await expect(disableTwoFactorAuth("user123", { password: "password123" })).rejects.toThrow(
       new InvalidInputError("User does not have a password set")

--- a/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.test.ts
+++ b/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.test.ts
@@ -2,9 +2,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { symmetricDecrypt, symmetricEncrypt } from "@/lib/crypto";
-import { getCredentialPasswordHash } from "@/lib/user/password";
+import { getCredentialPasswordHash, verifyUserPassword } from "@/lib/user/password";
 import { totpAuthenticatorCheck } from "@/modules/auth/lib/totp";
-import { verifyPassword } from "@/modules/auth/lib/utils";
 import { disableTwoFactorAuth, enableTwoFactorAuth, setupTwoFactorAuth } from "./two-factor-auth";
 
 vi.mock("@formbricks/database", () => ({
@@ -23,10 +22,7 @@ vi.mock("@/lib/crypto", () => ({
 
 vi.mock("@/lib/user/password", () => ({
   getCredentialPasswordHash: vi.fn(),
-}));
-
-vi.mock("@/modules/auth/lib/utils", () => ({
-  verifyPassword: vi.fn(),
+  verifyUserPassword: vi.fn(),
 }));
 
 vi.mock("@/modules/auth/lib/totp", () => ({
@@ -35,9 +31,11 @@ vi.mock("@/modules/auth/lib/totp", () => ({
 
 describe("Two Factor Auth", () => {
   beforeEach(() => {
-    // Default: the user has a credential-account password hash. Individual "no password" tests
-    // override this with null. (Password now lives on the credential Account, not User.password.)
+    // Happy-path defaults: enable checks credential presence (getCredentialPasswordHash); setup and
+    // disable delegate password verification to verifyUserPassword. "No password" / "incorrect
+    // password" tests override these.
     vi.mocked(getCredentialPasswordHash).mockResolvedValue("hashedPassword");
+    vi.mocked(verifyUserPassword).mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -53,15 +51,17 @@ describe("Two Factor Auth", () => {
     });
   });
 
-  test("setupTwoFactorAuth should throw InvalidInputError when user has no password", async () => {
+  test("setupTwoFactorAuth should reject when the user has no password (via verifyUserPassword)", async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue({
       id: "user123",
       identityProvider: "email",
     } as any);
-    vi.mocked(getCredentialPasswordHash).mockResolvedValue(null);
+    vi.mocked(verifyUserPassword).mockRejectedValue(
+      new InvalidInputError("Password is not set for this user")
+    );
 
     await expect(setupTwoFactorAuth("user123", "password123")).rejects.toThrow(
-      new InvalidInputError("User does not have a password set")
+      new InvalidInputError("Password is not set for this user")
     );
   });
 
@@ -83,7 +83,7 @@ describe("Two Factor Auth", () => {
       password: "hashedPassword",
       identityProvider: "email",
     } as any);
-    vi.mocked(verifyPassword).mockResolvedValue(false);
+    vi.mocked(verifyUserPassword).mockResolvedValue(false);
 
     await expect(setupTwoFactorAuth("user123", "wrongPassword")).rejects.toThrow(
       new InvalidInputError("Incorrect password")
@@ -98,7 +98,7 @@ describe("Two Factor Auth", () => {
       email: "test@example.com",
     };
     vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any);
-    vi.mocked(verifyPassword).mockResolvedValue(true);
+    vi.mocked(verifyUserPassword).mockResolvedValue(true);
     vi.mocked(symmetricEncrypt).mockImplementation((data) => `encrypted_${data}`);
     vi.mocked(prisma.user.update).mockResolvedValue(mockUser as any);
 
@@ -236,16 +236,18 @@ describe("Two Factor Auth", () => {
     });
   });
 
-  test("disableTwoFactorAuth should throw InvalidInputError when user has no password", async () => {
+  test("disableTwoFactorAuth should reject when the user has no password (via verifyUserPassword)", async () => {
     vi.mocked(prisma.user.findUnique).mockResolvedValue({
       id: "user123",
       identityProvider: "email",
       twoFactorEnabled: true,
     } as any);
-    vi.mocked(getCredentialPasswordHash).mockResolvedValue(null);
+    vi.mocked(verifyUserPassword).mockRejectedValue(
+      new InvalidInputError("Password is not set for this user")
+    );
 
     await expect(disableTwoFactorAuth("user123", { password: "password123" })).rejects.toThrow(
-      new InvalidInputError("User does not have a password set")
+      new InvalidInputError("Password is not set for this user")
     );
   });
 
@@ -282,7 +284,7 @@ describe("Two Factor Auth", () => {
       identityProvider: "email",
       twoFactorEnabled: true,
     } as any);
-    vi.mocked(verifyPassword).mockResolvedValue(false);
+    vi.mocked(verifyUserPassword).mockResolvedValue(false);
 
     await expect(disableTwoFactorAuth("user123", { password: "wrongPassword" })).rejects.toThrow(
       new InvalidInputError("Incorrect password")
@@ -297,7 +299,7 @@ describe("Two Factor Auth", () => {
       twoFactorEnabled: true,
       backupCodes: "encrypted_backup_codes",
     } as any);
-    vi.mocked(verifyPassword).mockResolvedValue(true);
+    vi.mocked(verifyUserPassword).mockResolvedValue(true);
     vi.mocked(symmetricDecrypt).mockReturnValue(JSON.stringify(["code1", "code2"]));
 
     await expect(
@@ -313,7 +315,7 @@ describe("Two Factor Auth", () => {
       twoFactorEnabled: true,
       twoFactorSecret: "encrypted_secret",
     } as any);
-    vi.mocked(verifyPassword).mockResolvedValue(true);
+    vi.mocked(verifyUserPassword).mockResolvedValue(true);
     vi.mocked(symmetricDecrypt).mockReturnValue("12345678901234567890123456789012");
     vi.mocked(totpAuthenticatorCheck).mockReturnValue(false);
 
@@ -331,7 +333,7 @@ describe("Two Factor Auth", () => {
       backupCodes: "encrypted_backup_codes",
     };
     vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any);
-    vi.mocked(verifyPassword).mockResolvedValue(true);
+    vi.mocked(verifyUserPassword).mockResolvedValue(true);
     vi.mocked(symmetricDecrypt).mockReturnValue(JSON.stringify(["validcode", "code2"]));
     vi.mocked(prisma.user.update).mockResolvedValue(mockUser as any);
 
@@ -360,7 +362,7 @@ describe("Two Factor Auth", () => {
       twoFactorSecret: "encrypted_secret",
     };
     vi.mocked(prisma.user.findUnique).mockResolvedValue(mockUser as any);
-    vi.mocked(verifyPassword).mockResolvedValue(true);
+    vi.mocked(verifyUserPassword).mockResolvedValue(true);
     vi.mocked(symmetricDecrypt).mockReturnValue("12345678901234567890123456789012");
     vi.mocked(totpAuthenticatorCheck).mockReturnValue(true);
     vi.mocked(prisma.user.update).mockResolvedValue(mockUser as any);

--- a/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.ts
+++ b/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.ts
@@ -5,6 +5,7 @@ import { prisma } from "@formbricks/database";
 import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { ENCRYPTION_KEY } from "@/lib/constants";
 import { symmetricDecrypt, symmetricEncrypt } from "@/lib/crypto";
+import { getCredentialPasswordHash } from "@/lib/user/password";
 import { totpAuthenticatorCheck } from "@/modules/auth/lib/totp";
 import { verifyPassword } from "@/modules/auth/lib/utils";
 
@@ -34,15 +35,18 @@ export const setupTwoFactorAuth = async (
     throw new ResourceNotFoundError("user", userId);
   }
 
-  if (!user.password) {
-    throw new InvalidInputError("User does not have a password set");
-  }
-
   if (user.identityProvider !== "email") {
     throw new InvalidInputError("Third party login is already enabled");
   }
 
-  const isCorrectPassword = await verifyPassword(password, user.password);
+  // Post-ENG-1054 the password hash lives on the credential Account, not User.password.
+  // Fail closed: no credential hash → reject (never treat a missing hash as verified).
+  const passwordHash = await getCredentialPasswordHash(userId);
+  if (!passwordHash) {
+    throw new InvalidInputError("User does not have a password set");
+  }
+
+  const isCorrectPassword = await verifyPassword(password, passwordHash);
 
   if (!isCorrectPassword) {
     throw new InvalidInputError("Incorrect password");
@@ -81,12 +85,14 @@ export const enableTwoFactorAuth = async (id: string, code: string) => {
     throw new ResourceNotFoundError("user", id);
   }
 
-  if (!user.password) {
-    throw new InvalidInputError("User does not have a password set");
-  }
-
   if (user.identityProvider !== "email") {
     throw new InvalidInputError("Third party login is already enabled");
+  }
+
+  // Requires a credential account (password lives there post-ENG-1054, not on User.password).
+  const passwordHash = await getCredentialPasswordHash(id);
+  if (!passwordHash) {
+    throw new InvalidInputError("User does not have a password set");
   }
 
   if (user.twoFactorEnabled) {
@@ -142,10 +148,6 @@ export const disableTwoFactorAuth = async (id: string, params: TDisableTwoFactor
     throw new ResourceNotFoundError("user", id);
   }
 
-  if (!user.password) {
-    throw new InvalidInputError("User does not have a password set");
-  }
-
   if (!user.twoFactorEnabled) {
     throw new InvalidInputError("Two factor authentication is not enabled");
   }
@@ -154,8 +156,15 @@ export const disableTwoFactorAuth = async (id: string, params: TDisableTwoFactor
     throw new InvalidInputError("Third party login is already enabled");
   }
 
+  // Post-ENG-1054 the password hash lives on the credential Account, not User.password.
+  // Fail closed: no credential hash → reject (never treat a missing hash as verified).
+  const passwordHash = await getCredentialPasswordHash(id);
+  if (!passwordHash) {
+    throw new InvalidInputError("User does not have a password set");
+  }
+
   const { code, password, backupCode } = params;
-  const isCorrectPassword = await verifyPassword(password, user.password);
+  const isCorrectPassword = await verifyPassword(password, passwordHash);
 
   if (!isCorrectPassword) {
     throw new InvalidInputError("Incorrect password");

--- a/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.ts
+++ b/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.ts
@@ -5,9 +5,8 @@ import { prisma } from "@formbricks/database";
 import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { ENCRYPTION_KEY } from "@/lib/constants";
 import { symmetricDecrypt, symmetricEncrypt } from "@/lib/crypto";
-import { getCredentialPasswordHash } from "@/lib/user/password";
+import { getCredentialPasswordHash, verifyUserPassword } from "@/lib/user/password";
 import { totpAuthenticatorCheck } from "@/modules/auth/lib/totp";
-import { verifyPassword } from "@/modules/auth/lib/utils";
 
 export const setupTwoFactorAuth = async (
   userId: string,
@@ -39,15 +38,9 @@ export const setupTwoFactorAuth = async (
     throw new InvalidInputError("Third party login is already enabled");
   }
 
-  // Post-ENG-1054 the password hash lives on the credential Account, not User.password.
-  // Fail closed: no credential hash → reject (never treat a missing hash as verified).
-  const passwordHash = await getCredentialPasswordHash(userId);
-  if (!passwordHash) {
-    throw new InvalidInputError("User does not have a password set");
-  }
-
-  const isCorrectPassword = await verifyPassword(password, passwordHash);
-
+  // Password verification — the credential-account lookup and fail-closed "no password" handling —
+  // is owned by verifyUserPassword; 2FA setup just needs the yes/no answer.
+  const isCorrectPassword = await verifyUserPassword(userId, password);
   if (!isCorrectPassword) {
     throw new InvalidInputError("Incorrect password");
   }
@@ -156,16 +149,9 @@ export const disableTwoFactorAuth = async (id: string, params: TDisableTwoFactor
     throw new InvalidInputError("Third party login is already enabled");
   }
 
-  // Post-ENG-1054 the password hash lives on the credential Account, not User.password.
-  // Fail closed: no credential hash → reject (never treat a missing hash as verified).
-  const passwordHash = await getCredentialPasswordHash(id);
-  if (!passwordHash) {
-    throw new InvalidInputError("User does not have a password set");
-  }
-
   const { code, password, backupCode } = params;
-  const isCorrectPassword = await verifyPassword(password, passwordHash);
-
+  // Delegate password verification (credential lookup + fail-closed) to verifyUserPassword.
+  const isCorrectPassword = await verifyUserPassword(id, password);
   if (!isCorrectPassword) {
     throw new InvalidInputError("Incorrect password");
   }


### PR DESCRIPTION
## What does this PR do?

Fixes two 5.2 staging-QA bugs that share one root cause.

Closes ENG-1774 (can't change email — "password is not stored" toast with the correct password) and ENG-1772 (enabling 2FA spins then silently does nothing).

After the ENG-1054 NextAuth → Better Auth migration, the password hash lives on the `credential` `Account` row (`provider = "credential"`, `providerAccountId = userId`), not on `User.password`. Signup (`auth.api.signUpEmail`) never writes `User.password`, so it's `null` for any account created after the cutover. But two password re-verification paths were missed in the migration and still read `User.password`:

- **Email change** — `verifyUserPassword` (`apps/web/lib/user/password.ts`) threw "Password is not set for this user".
- **2FA** — `setupTwoFactorAuth` / `enableTwoFactorAuth` / `disableTwoFactorAuth` all guarded/verified on `user.password`.

Migrated (pre-cutover) users still have `User.password` populated (the backfill copied it to the Account but didn't null the column), which is why this only reproduced on freshly created accounts.

Changes:

- Add a shared `getCredentialPasswordHash(userId)` helper that reads the credential Account, scoped to the given user id, and reuse it in `verifyUserPassword` and the three 2FA functions.
- **Fail closed:** a missing credential hash always rejects — verification is never short-circuited to success when there's no hash. The `identityProvider === "email"` SSO guards are unchanged.
- 2FA confirm form: fall back to a generic message so a genuine action error can't render as an empty toast (the "spinner then nothing" half of ENG-1772).

No schema/migration/env changes. Real write access remains gated downstream by workspace permissions.

## How should this be tested?

Automated (from `apps/web`):

```
pnpm test -- lib/user/password.test.ts modules/ee/two-factor-auth/lib/two-factor-auth.test.ts
```

30 tests pass, including the fail-closed case (no credential account → reject, `verifyPassword` never called) and verification against the credential-account hash.

Manual, on a **freshly created** account (the repro case):

1. Sign up a new user, then confirm in the DB that `User.password` is `null` and a `credential` `Account` row exists with a bcrypt `password`.
2. Account settings → change email with the correct password → advances / sends verification (wrong password → "incorrect credentials", not "password not stored").
3. Enable 2FA → password step advances to the QR code (wrong password → a visible error, not a silent spinner) → disable 2FA works.
4. Regression: a migrated (pre-cutover) account still changes email and toggles 2FA.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
