### PR TITLE
fix: header-only CSV crash in Unify source creation (ENG-1799)

### DIFF
--- a/apps/web/modules/ee/unify-feedback/sources/components/csv-import-modal.tsx
+++ b/apps/web/modules/ee/unify-feedback/sources/components/csv-import-modal.tsx
@@ -73,12 +73,12 @@ export function CsvImportModal({
 
       const missingMappedColumns = getMissingCsvMappedSourceColumns(
         fieldMappings,
-        Object.keys(result.data[0] ?? {})
+        Object.keys(result.data[0])
       );
       if (missingMappedColumns.length > 0) {
         const missingRequiredSourceColumns = getMissingRequiredCsvSourceColumns(
           fieldMappings,
-          Object.keys(result.data[0] ?? {})
+          Object.keys(result.data[0])
         );
         const missingSourceColumns =
           missingRequiredSourceColumns.length > 0

--- a/apps/web/modules/ee/unify-feedback/sources/csv-empty-guard.test.ts
+++ b/apps/web/modules/ee/unify-feedback/sources/csv-empty-guard.test.ts
@@ -1,0 +1,45 @@
+import { parse } from "csv-parse/sync";
+import type { TFunction } from "i18next";
+import { describe, expect, test } from "vitest";
+import { createFeedbackCSVDataSchema } from "./types";
+
+// ENG-1799: a header-only CSV (zero data rows) must surface the friendly CSV_AT_LEAST_ONE_ROW error,
+// NOT crash with a raw "Cannot convert undefined to object". The crash was inside the schema itself:
+// `createFeedbackCSVDataSchema`'s `.superRefine` dereferenced `Object.keys(rows[0])`, and zod runs the
+// refinement even when the preceding `.min(1)` fails — so an empty array threw a raw TypeError out of
+// `safeParse` (which is why callers saw it as a thrown error, not a validation failure). This drives the
+// real schema + csv-parse through the exact parse+validate chain both consumers use
+// (csv-feedback-source-ui.tsx, csv-import-modal.tsx) to prove empty input now fails validation cleanly.
+
+const t = ((key: string) => key) as unknown as TFunction;
+
+// Mirror the component's parse options exactly (csv-feedback-source-ui.tsx:136).
+const parseCsv = (csv: string) =>
+  parse(csv, { columns: true, relax_column_count: true, skip_empty_lines: true }) as Record<string, string>[];
+
+describe("createFeedbackCSVDataSchema — header-only CSV guard (ENG-1799)", () => {
+  test.each([
+    ["header + trailing newline", "submission_id,field_id,field_type,response_value\n"],
+    ["header, no trailing newline", "submission_id,field_id,field_type,response_value"],
+    ["header + blank lines", "submission_id,field_id,field_type,response_value\n\n\n"],
+  ])("%s → zero rows, validation fails cleanly instead of throwing", (_label, csv) => {
+    const records = parseCsv(csv);
+
+    // The precondition that made the refinement throw: rows[0] is undefined.
+    expect(records).toHaveLength(0);
+    expect(records[0]).toBeUndefined();
+
+    // safeParse must resolve to a failure (not throw) with the friendly message.
+    const result = createFeedbackCSVDataSchema(t).safeParse(records);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe("workspace.unify.csv_at_least_one_row");
+    }
+  });
+
+  test("a valid single-row CSV still passes (guard does not over-reject)", () => {
+    const records = parseCsv("submission_id,field_id,field_type,response_value\nsub-1,q1,text,hi");
+    expect(records).toHaveLength(1);
+    expect(createFeedbackCSVDataSchema(t).safeParse(records).success).toBe(true);
+  });
+});

--- a/apps/web/modules/ee/unify-feedback/sources/types.ts
+++ b/apps/web/modules/ee/unify-feedback/sources/types.ts
@@ -249,8 +249,15 @@ export const createFeedbackCSVDataSchema = (t: TFunction) =>
       }),
     })
     .superRefine((rows, ctx) => {
+      // `.min(1)` above already reports empty input, but zod still runs this refinement, so guard
+      // against `rows[0]` being undefined — otherwise `Object.keys(undefined)` throws a raw TypeError
+      // out of safeParse instead of surfacing the friendly CSV_AT_LEAST_ONE_ROW error (ENG-1799).
+      if (rows.length === 0) {
+        return;
+      }
       const localeSort = (a: string, b: string) => a.localeCompare(b);
-      const firstRowKeys = Object.keys(rows[0]).sort(localeSort).join(",");
+      const firstRowKeyList = Object.keys(rows[0]);
+      const firstRowKeys = [...firstRowKeyList].sort(localeSort).join(",");
 
       for (let i = 1; i < rows.length; i++) {
         const rowKeys = Object.keys(rows[i]).sort(localeSort).join(",");
@@ -263,7 +270,7 @@ export const createFeedbackCSVDataSchema = (t: TFunction) =>
         }
       }
 
-      const emptyHeaders = Object.keys(rows[0]).filter((k) => k.trim() === "");
+      const emptyHeaders = firstRowKeyList.filter((k) => k.trim() === "");
       if (emptyHeaders.length > 0) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,


### PR DESCRIPTION
## What does this PR do?

Fixes a header-only CSV (a file with a header row but zero data rows) crashing the Unify feedback **source creation** flow with a raw `TypeError: Cannot convert undefined to object` instead of the friendly "CSV must contain at least one data row." (`CSV_AT_LEAST_ONE_ROW`) message.

Root cause is in `createFeedbackCSVDataSchema` (`apps/web/modules/ee/unify-feedback/sources/types.ts`): the `.superRefine` dereferenced `Object.keys(rows[0])` unconditionally. Zod runs `.superRefine` **even when the preceding `.min(1)` fails**, so for an empty array `.min(1)` queued its friendly issue but the refinement still ran and `Object.keys(undefined)` threw. Because that's a thrown `TypeError` (not a `ZodError`), it escaped `safeParse` and surfaced raw in the UI.

The fix is a one-line early return in the refinement when `rows.length === 0` — `.min(1)` already reports empty input, and the cross-row / empty-header checks are meaningless on an empty array. Fixing it at the schema covers **both** consumers (the create flow and the re-import modal, which share the schema; the modal's `?? {}` guard runs *after* `safeParse`, so it didn't help).

Found during 5.2 QA.

Fixes ENG-1799

Note: `release/5.2` has the same bug — a backport will follow once this merges.

## How should this be tested?

Automated (added a regression test that drives the real schema + `csv-parse` through the exact component chain — it fails without the fix):

```
cd apps/web
npx vitest run modules/ee/unify-feedback/sources/csv-empty-guard.test.ts        # 4/4
npx vitest run modules/ee/unify-feedback/sources lib/feedback-source            # 283 pass, no regressions
```

Manual (Unify Feedback enabled, readWrite/owner):

1. Unify → Sources → Add source → CSV.
2. Upload a CSV with only a header row and no data rows (e.g. `submission_id,field_id,field_type,response_value\n`).
3. Expected: the friendly "CSV must contain at least one data row." error — **not** a raw "Cannot convert undefined to object".

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Removed all `console.logs`
- [ ] Ran `pnpm build` (ran targeted vitest + eslint + `tsc --noEmit` on the changed files instead — schema-only change)

### Appreciated

- [ ] No UI markup change (validation-path only), so no screen recording
