### PR TITLE
fix(billing): refresh plan state after a successful upgrade (ENG-1790)

### DIFF
--- a/apps/web/app/(app)/billing-confirmation/components/ConfirmationPage.tsx
+++ b/apps/web/app/(app)/billing-confirmation/components/ConfirmationPage.tsx
@@ -2,15 +2,23 @@
 
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { waitForBillingPlanAction } from "@/modules/ee/billing/actions";
 import { Button } from "@/modules/ui/components/button";
 import { Confetti } from "@/modules/ui/components/confetti";
 
 const BILLING_CONFIRMATION_ORGANIZATION_ID_KEY = "billingConfirmationOrganizationId";
+const SYNCABLE_PLANS = ["pro", "scale"] as const;
+type TSyncablePlan = (typeof SYNCABLE_PLANS)[number];
+
+const isSyncablePlan = (plan: string | null): plan is TSyncablePlan =>
+  plan !== null && (SYNCABLE_PLANS as readonly string[]).includes(plan);
 
 export const ConfirmationPage = () => {
   const { t } = useTranslation();
   const [showConfetti, setShowConfetti] = useState(false);
   const [resolvedOrganizationId, setResolvedOrganizationId] = useState<string | null>(null);
+  // Block the back link until Stripe is synced, so returning to billing renders the new plan.
+  const [isSyncing, setIsSyncing] = useState(false);
 
   useEffect(() => {
     setShowConfetti(true);
@@ -21,7 +29,8 @@ export const ConfirmationPage = () => {
 
     // Prefer the organizationId Stripe appends to the return URL so the back link survives a
     // fresh tab / cleared session storage; fall back to session storage otherwise.
-    const urlOrganizationId = new URLSearchParams(globalThis.window.location.search).get("organizationId");
+    const params = new URLSearchParams(globalThis.window.location.search);
+    const urlOrganizationId = params.get("organizationId");
     const storedOrganizationId = globalThis.window.sessionStorage.getItem(
       BILLING_CONFIRMATION_ORGANIZATION_ID_KEY
     );
@@ -29,7 +38,31 @@ export const ConfirmationPage = () => {
     if (organizationId) {
       setResolvedOrganizationId(organizationId);
     }
+
+    // The read-through sync only refreshes a >5min-stale snapshot, so the fresh post-checkout snapshot
+    // still shows the old plan. Force a Stripe sync here (poll until the purchased plan lands) so the
+    // billing page renders the new plan on return.
+    const plan = params.get("plan");
+    if (!organizationId || !isSyncablePlan(plan)) {
+      return;
+    }
+
+    let cancelled = false;
+    setIsSyncing(true);
+    void waitForBillingPlanAction({ organizationId, targetPlan: plan }).finally(() => {
+      if (!cancelled) {
+        setIsSyncing(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
+
+  const billingHref = resolvedOrganizationId
+    ? `/organizations/${resolvedOrganizationId}/settings/billing`
+    : "/";
 
   return (
     <div className="h-full w-full">
@@ -43,15 +76,18 @@ export const ConfirmationPage = () => {
             {t("billing_confirmation.thanks_for_upgrading")}
           </p>
         </div>
-        <Button asChild className="w-full justify-center">
-          {/* Full-document navigation (not next/link): a client transition would serve the billing
-              page's prefetched RSC from before checkout, still showing the old plan. A full load
-              re-renders it fresh with the upgraded plan. */}
-          <a
-            href={resolvedOrganizationId ? `/organizations/${resolvedOrganizationId}/settings/billing` : "/"}>
+        {isSyncing ? (
+          <Button loading disabled className="w-full justify-center">
             {t("billing_confirmation.back_to_billing_overview")}
-          </a>
-        </Button>
+          </Button>
+        ) : (
+          <Button asChild className="w-full justify-center">
+            {/* Full-document navigation (not next/link): a client transition would serve the billing
+                page's prefetched RSC from before checkout, still showing the old plan. A full load
+                re-renders it fresh with the upgraded plan. */}
+            <a href={billingHref}>{t("billing_confirmation.back_to_billing_overview")}</a>
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/web/app/(app)/billing-confirmation/components/ConfirmationPage.tsx
+++ b/apps/web/app/(app)/billing-confirmation/components/ConfirmationPage.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/modules/ui/components/button";
@@ -45,10 +44,13 @@ export const ConfirmationPage = () => {
           </p>
         </div>
         <Button asChild className="w-full justify-center">
-          <Link
+          {/* Full-document navigation (not next/link): a client transition would serve the billing
+              page's prefetched RSC from before checkout, still showing the old plan. A full load
+              re-renders it fresh with the upgraded plan. */}
+          <a
             href={resolvedOrganizationId ? `/organizations/${resolvedOrganizationId}/settings/billing` : "/"}>
             {t("billing_confirmation.back_to_billing_overview")}
-          </Link>
+          </a>
         </Button>
       </div>
     </div>

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type Stripe as StripeJs, loadStripe } from "@stripe/stripe-js";
-import { CheckIcon } from "lucide-react";
+import { CheckIcon, LoaderCircleIcon } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import posthog from "posthog-js";
@@ -45,6 +45,14 @@ const BILLING_PENDING_UPGRADE_INTERVAL_KEY = "billingPendingUpgradeInterval";
 // Hands the post-upgrade success toast across the full reload the finalize path does to render the
 // synced plan.
 const BILLING_UPGRADE_RESULT_KEY = "billingUpgradeResult";
+
+// After checkout the plan lands in our DB via an async Stripe webhook (not instant). Poll a Stripe
+// force-sync until the plan reflects, so we can render the new plan without a manual refresh. Bounded
+// so a genuinely stuck upgrade doesn't spin forever.
+const UPGRADE_SYNC_POLL_INTERVAL_MS = 1500;
+const UPGRADE_SYNC_POLL_TIMEOUT_MS = 45000;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // Stripe.js is loaded lazily and memoized across renders (one publishable key per deploy).
 let stripeJsPromise: Promise<StripeJs | null> | null = null;
@@ -233,6 +241,7 @@ export const PricingTable = ({
   const router = useRouter();
   const searchParams = useSearchParams();
   const upgradeDriveRef = useRef(false);
+  const [isSyncingUpgrade, setIsSyncingUpgrade] = useState(false);
   const [isRetryingStripeSetup, setIsRetryingStripeSetup] = useState(false);
   const [isPlanActionPending, setIsPlanActionPending] = useState<string | null>(null);
   // Set when an immediate, in-place upgrade charge needs explicit confirmation before it runs.
@@ -403,49 +412,54 @@ export const PricingTable = ({
       "hobby"
     > | null;
 
+    // upgradeDriveRef guarantees this runs once; deliberately no `cancelled` cleanup flag — React
+    // StrictMode's mount→unmount→mount in dev would otherwise cancel the real run before it reaches
+    // the reload, leaving the page stale (the bug looks identical to no fix at all).
     upgradeDriveRef.current = true;
-    let cancelled = false;
-    const toastId = toast.loading(t("workspace.settings.billing.upgrade_checkout_pending"));
+    setIsSyncingUpgrade(true);
+    const billingUrl = `/organizations/${organizationId}/settings/billing`;
 
-    const finish = (
-      kind: "success" | "error",
-      plan: Exclude<TStandardPlan, "hobby"> | null,
-      message?: string,
-      planApplied = true
-    ) => {
-      toast.dismiss(toastId);
+    // Once the plan is confirmed in our DB, a full reload is the only reliable way to render it
+    // (router.refresh() did not consistently refetch the billing snapshot). Hand the toast across it.
+    const reloadWithToast = (plan: Exclude<TStandardPlan, "hobby"> | null, planApplied: boolean) => {
+      if (globalThis.window === undefined) return;
+      globalThis.window.sessionStorage.setItem(
+        BILLING_UPGRADE_RESULT_KEY,
+        JSON.stringify({ plan: plan ?? "pro", applied: planApplied })
+      );
+      globalThis.window.location.replace(billingUrl);
+    };
+
+    // Terminal state without a reload (error, or the poll timed out): clean the URL, stop the spinner,
+    // surface a message. The webhook will still land the plan; the user can refresh.
+    const settleWithoutReload = (message: string) => {
       clearUpgradeIntent();
-      const billingUrl = `/organizations/${organizationId}/settings/billing`;
-
-      if (kind === "success") {
-        // router.refresh() does not reliably refetch the billing snapshot on this return, so the page
-        // keeps showing the old plan. Do a full reload (what a manual refresh does) to render the synced
-        // plan, and hand the success toast across the reload via sessionStorage.
-        if (globalThis.window !== undefined) {
-          globalThis.window.sessionStorage.setItem(
-            BILLING_UPGRADE_RESULT_KEY,
-            JSON.stringify({ plan: plan ?? "pro", applied: planApplied })
-          );
-          globalThis.window.location.replace(billingUrl);
-        }
-        return;
-      }
-
-      // Error: surface the message and clean the URL without a reload so the toast stays visible.
-      toast.error(message ?? t("common.something_went_wrong_please_try_again"));
+      setIsSyncingUpgrade(false);
+      toast.error(message);
       if (globalThis.window !== undefined) {
         globalThis.window.history.replaceState(null, "", billingUrl);
       }
       router.refresh();
     };
 
+    // Poll a Stripe force-sync until the plan reflects in our DB (waitForBillingPlanAction syncs +
+    // invalidates the cache each call). Doesn't depend on the async webhook.
+    const pollUntilPlanApplied = async (targetPlan: Exclude<TStandardPlan, "hobby">): Promise<boolean> => {
+      const deadline = Date.now() + UPGRADE_SYNC_POLL_TIMEOUT_MS;
+      for (;;) {
+        const waitResult = await waitForBillingPlanAction({ organizationId, targetPlan });
+        if (waitResult?.data?.plan === targetPlan) return true;
+        if (Date.now() >= deadline) return false;
+        await sleep(UPGRADE_SYNC_POLL_INTERVAL_MS);
+      }
+    };
+
     const run = async () => {
       // Finalize attaches the card and applies the upgrade in one call, so it never races the webhook.
       const response = await finalizeSetupCheckoutUpgradeAction({ organizationId, checkoutSessionId });
-      if (cancelled) return;
 
       if (response?.serverError) {
-        finish("error", pendingPlan, getActionErrorMessage(response.serverError, t));
+        settleWithoutReload(getActionErrorMessage(response.serverError, t));
         return;
       }
 
@@ -454,28 +468,29 @@ export const PricingTable = ({
 
       if (response?.data) {
         const settled = await settleUpgradeConfirmation(response.data);
-        if (cancelled) return;
         if (!settled.applied) {
-          finish("error", resolvedPlan, settled.message ?? undefined);
+          settleWithoutReload(settled.message ?? t("common.something_went_wrong_please_try_again"));
           return;
         }
       }
 
-      let planApplied = true;
-      if (resolvedPlan) {
-        const waitResult = await waitForBillingPlanAction({ organizationId, targetPlan: resolvedPlan });
-        if (cancelled) return;
-        planApplied = waitResult?.data?.plan === resolvedPlan;
+      if (!resolvedPlan) {
+        // No target to verify against — best effort: reload so any applied change renders.
+        reloadWithToast(resolvedPlan, true);
+        return;
       }
-      finish("success", resolvedPlan, undefined, planApplied);
+
+      const planApplied = await pollUntilPlanApplied(resolvedPlan);
+
+      if (planApplied) {
+        reloadWithToast(resolvedPlan, true);
+      } else {
+        // Poll window elapsed without the plan reflecting; the webhook will still catch up.
+        settleWithoutReload(t("workspace.settings.billing.upgrade_checkout_pending"));
+      }
     };
 
     void run();
-
-    return () => {
-      cancelled = true;
-      toast.dismiss(toastId);
-    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams, router, t, organizationId]);
 
@@ -1122,6 +1137,12 @@ export const PricingTable = ({
   return (
     <main>
       <div className="flex max-w-6xl flex-col gap-4">
+        {isSyncingUpgrade && (
+          <div className="flex max-w-5xl items-center gap-2 rounded-md border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
+            <LoaderCircleIcon className="h-4 w-4 animate-spin" />
+            {t("workspace.settings.billing.upgrade_checkout_pending")}
+          </div>
+        )}
         {trialDaysRemaining !== null &&
           (hasPaymentMethod ? (
             <TrialAlert trialDaysRemaining={trialDaysRemaining} hasPaymentMethod className="max-w-5xl">

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { type Stripe as StripeJs, loadStripe } from "@stripe/stripe-js";
-import { CheckIcon, LoaderCircleIcon } from "lucide-react";
+import { CheckIcon } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import posthog from "posthog-js";
@@ -241,7 +241,6 @@ export const PricingTable = ({
   const router = useRouter();
   const searchParams = useSearchParams();
   const upgradeDriveRef = useRef(false);
-  const [isSyncingUpgrade, setIsSyncingUpgrade] = useState(false);
   const [isRetryingStripeSetup, setIsRetryingStripeSetup] = useState(false);
   const [isPlanActionPending, setIsPlanActionPending] = useState<string | null>(null);
   // Set when an immediate, in-place upgrade charge needs explicit confirmation before it runs.
@@ -416,7 +415,8 @@ export const PricingTable = ({
     // StrictMode's mount→unmount→mount in dev would otherwise cancel the real run before it reaches
     // the reload, leaving the page stale (the bug looks identical to no fix at all).
     upgradeDriveRef.current = true;
-    setIsSyncingUpgrade(true);
+    // Loading toast at the top of this first post-checkout page, shown while we poll for the plan.
+    const toastId = toast.loading(t("workspace.settings.billing.upgrade_checkout_pending"));
     const billingUrl = `/organizations/${organizationId}/settings/billing`;
 
     // Once the plan is confirmed in our DB, a full reload is the only reliable way to render it
@@ -430,11 +430,11 @@ export const PricingTable = ({
       globalThis.window.location.replace(billingUrl);
     };
 
-    // Terminal state without a reload (error, or the poll timed out): clean the URL, stop the spinner,
-    // surface a message. The webhook will still land the plan; the user can refresh.
+    // Terminal state without a reload (error, or the poll timed out): clean the URL, dismiss the
+    // loading toast, surface a message. The webhook will still land the plan; the user can refresh.
     const settleWithoutReload = (message: string) => {
       clearUpgradeIntent();
-      setIsSyncingUpgrade(false);
+      toast.dismiss(toastId);
       toast.error(message);
       if (globalThis.window !== undefined) {
         globalThis.window.history.replaceState(null, "", billingUrl);
@@ -1137,12 +1137,6 @@ export const PricingTable = ({
   return (
     <main>
       <div className="flex max-w-6xl flex-col gap-4">
-        {isSyncingUpgrade && (
-          <div className="flex max-w-5xl items-center gap-2 rounded-md border border-slate-200 bg-slate-50 p-3 text-sm text-slate-700">
-            <LoaderCircleIcon className="h-4 w-4 animate-spin" />
-            {t("workspace.settings.billing.upgrade_checkout_pending")}
-          </div>
-        )}
         {trialDaysRemaining !== null &&
           (hasPaymentMethod ? (
             <TrialAlert trialDaysRemaining={trialDaysRemaining} hasPaymentMethod className="max-w-5xl">

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -372,13 +372,11 @@ export const PricingTable = ({
     }
     globalThis.window.sessionStorage.removeItem(BILLING_UPGRADE_RESULT_KEY);
     try {
-      const { plan, applied } = JSON.parse(raw) as { plan: TStandardPlan; applied: boolean };
+      const { plan } = JSON.parse(raw) as { plan: TStandardPlan };
       toast.success(
-        applied
-          ? t("workspace.settings.billing.upgrade_checkout_success", {
-              plan: getCurrentCloudPlanLabel(plan ?? "pro", t),
-            })
-          : t("workspace.settings.billing.upgrade_checkout_pending")
+        t("workspace.settings.billing.upgrade_checkout_success", {
+          plan: getCurrentCloudPlanLabel(plan ?? "pro", t),
+        })
       );
     } catch {
       // Malformed handoff payload — nothing to show.
@@ -421,11 +419,11 @@ export const PricingTable = ({
 
     // Once the plan is confirmed in our DB, a full reload is the only reliable way to render it
     // (router.refresh() did not consistently refetch the billing snapshot). Hand the toast across it.
-    const reloadWithToast = (plan: Exclude<TStandardPlan, "hobby"> | null, planApplied: boolean) => {
+    const reloadWithToast = (plan: Exclude<TStandardPlan, "hobby"> | null) => {
       if (globalThis.window === undefined) return;
       globalThis.window.sessionStorage.setItem(
         BILLING_UPGRADE_RESULT_KEY,
-        JSON.stringify({ plan: plan ?? "pro", applied: planApplied })
+        JSON.stringify({ plan: plan ?? "pro" })
       );
       globalThis.window.location.replace(billingUrl);
     };
@@ -455,7 +453,8 @@ export const PricingTable = ({
     };
 
     const run = async () => {
-      // Finalize attaches the card and applies the upgrade in one call, so it never races the webhook.
+      // Finalize attaches the saved card and applies the upgrade; the plan then reflects in our DB
+      // asynchronously, which is what pollUntilPlanApplied waits for below.
       const response = await finalizeSetupCheckoutUpgradeAction({ organizationId, checkoutSessionId });
 
       if (response?.serverError) {
@@ -476,14 +475,12 @@ export const PricingTable = ({
 
       if (!resolvedPlan) {
         // No target to verify against — best effort: reload so any applied change renders.
-        reloadWithToast(resolvedPlan, true);
+        reloadWithToast(resolvedPlan);
         return;
       }
 
-      const planApplied = await pollUntilPlanApplied(resolvedPlan);
-
-      if (planApplied) {
-        reloadWithToast(resolvedPlan, true);
+      if (await pollUntilPlanApplied(resolvedPlan)) {
+        reloadWithToast(resolvedPlan);
       } else {
         // Poll window elapsed without the plan reflecting; the webhook will still catch up.
         settleWithoutReload(t("workspace.settings.billing.upgrade_checkout_pending"));

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -42,6 +42,9 @@ import { UsageCard } from "./usage-card";
 const BILLING_CONFIRMATION_ORGANIZATION_ID_KEY = "billingConfirmationOrganizationId";
 const BILLING_PENDING_UPGRADE_PLAN_KEY = "billingPendingUpgradePlan";
 const BILLING_PENDING_UPGRADE_INTERVAL_KEY = "billingPendingUpgradeInterval";
+// Hands the post-upgrade success toast across the full reload the finalize path does to render the
+// synced plan.
+const BILLING_UPGRADE_RESULT_KEY = "billingUpgradeResult";
 
 // Stripe.js is loaded lazily and memoized across renders (one publishable key per deploy).
 let stripeJsPromise: Promise<StripeJs | null> | null = null;
@@ -350,6 +353,30 @@ export const PricingTable = ({
     };
   };
 
+  // Show the success toast that the finalize path stashed before its full reload (see finish()).
+  useEffect(() => {
+    if (globalThis.window === undefined) {
+      return;
+    }
+    const raw = globalThis.window.sessionStorage.getItem(BILLING_UPGRADE_RESULT_KEY);
+    if (!raw) {
+      return;
+    }
+    globalThis.window.sessionStorage.removeItem(BILLING_UPGRADE_RESULT_KEY);
+    try {
+      const { plan, applied } = JSON.parse(raw) as { plan: TStandardPlan; applied: boolean };
+      toast.success(
+        applied
+          ? t("workspace.settings.billing.upgrade_checkout_success", {
+              plan: getCurrentCloudPlanLabel(plan ?? "pro", t),
+            })
+          : t("workspace.settings.billing.upgrade_checkout_pending")
+      );
+    } catch {
+      // Malformed handoff payload — nothing to show.
+    }
+  }, [t]);
+
   useEffect(() => {
     if (searchParams.get("checkout_success") !== "1") {
       return;
@@ -387,25 +414,27 @@ export const PricingTable = ({
       planApplied = true
     ) => {
       toast.dismiss(toastId);
-      if (kind === "success") {
-        // Only claim the plan is live once waitForBillingPlanAction actually observed it; otherwise the
-        // charge succeeded but Stripe hasn't reflected the plan within the poll window yet.
-        toast.success(
-          planApplied
-            ? t("workspace.settings.billing.upgrade_checkout_success", {
-                plan: getCurrentCloudPlanLabel(plan ?? "pro", t),
-              })
-            : t("workspace.settings.billing.upgrade_checkout_pending")
-        );
-      } else {
-        toast.error(message ?? t("common.something_went_wrong_please_try_again"));
-      }
       clearUpgradeIntent();
-      // Strip the one-time checkout query params without a router navigation — router.replace() to the
-      // bare URL can serve a stale prefetched RSC — then refetch the billing route so the synced plan
-      // renders.
+      const billingUrl = `/organizations/${organizationId}/settings/billing`;
+
+      if (kind === "success") {
+        // router.refresh() does not reliably refetch the billing snapshot on this return, so the page
+        // keeps showing the old plan. Do a full reload (what a manual refresh does) to render the synced
+        // plan, and hand the success toast across the reload via sessionStorage.
+        if (globalThis.window !== undefined) {
+          globalThis.window.sessionStorage.setItem(
+            BILLING_UPGRADE_RESULT_KEY,
+            JSON.stringify({ plan: plan ?? "pro", applied: planApplied })
+          );
+          globalThis.window.location.replace(billingUrl);
+        }
+        return;
+      }
+
+      // Error: surface the message and clean the URL without a reload so the toast stays visible.
+      toast.error(message ?? t("common.something_went_wrong_please_try_again"));
       if (globalThis.window !== undefined) {
-        globalThis.window.history.replaceState(null, "", `/organizations/${organizationId}/settings/billing`);
+        globalThis.window.history.replaceState(null, "", billingUrl);
       }
       router.refresh();
     };

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -383,20 +383,30 @@ export const PricingTable = ({
     const finish = (
       kind: "success" | "error",
       plan: Exclude<TStandardPlan, "hobby"> | null,
-      message?: string
+      message?: string,
+      planApplied = true
     ) => {
       toast.dismiss(toastId);
       if (kind === "success") {
+        // Only claim the plan is live once waitForBillingPlanAction actually observed it; otherwise the
+        // charge succeeded but Stripe hasn't reflected the plan within the poll window yet.
         toast.success(
-          t("workspace.settings.billing.upgrade_checkout_success", {
-            plan: getCurrentCloudPlanLabel(plan ?? "pro", t),
-          })
+          planApplied
+            ? t("workspace.settings.billing.upgrade_checkout_success", {
+                plan: getCurrentCloudPlanLabel(plan ?? "pro", t),
+              })
+            : t("workspace.settings.billing.upgrade_checkout_pending")
         );
       } else {
         toast.error(message ?? t("common.something_went_wrong_please_try_again"));
       }
       clearUpgradeIntent();
-      router.replace(`/organizations/${organizationId}/settings/billing`);
+      // Strip the one-time checkout query params without a router navigation — router.replace() to the
+      // bare URL can serve a stale prefetched RSC — then refetch the billing route so the synced plan
+      // renders.
+      if (globalThis.window !== undefined) {
+        globalThis.window.history.replaceState(null, "", `/organizations/${organizationId}/settings/billing`);
+      }
       router.refresh();
     };
 
@@ -422,11 +432,13 @@ export const PricingTable = ({
         }
       }
 
+      let planApplied = true;
       if (resolvedPlan) {
-        await waitForBillingPlanAction({ organizationId, targetPlan: resolvedPlan });
+        const waitResult = await waitForBillingPlanAction({ organizationId, targetPlan: resolvedPlan });
         if (cancelled) return;
+        planApplied = waitResult?.data?.plan === resolvedPlan;
       }
-      finish("success", resolvedPlan);
+      finish("success", resolvedPlan, undefined, planApplied);
     };
 
     void run();

--- a/apps/web/modules/ee/billing/lib/organization-billing.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.ts
@@ -590,7 +590,10 @@ export const createPaidPlanCheckoutSession = async (input: {
       address: "auto",
       name: "auto",
     },
-    success_url: `${WEBAPP_URL}/billing-confirmation?organizationId=${input.organizationId}&checkout_success=1`,
+    // Carry the purchased plan so the confirmation page can force a Stripe sync (the read-through
+    // sync only refreshes a >5min-stale snapshot, so a fresh post-checkout snapshot would otherwise
+    // keep serving the old plan) before returning to billing.
+    success_url: `${WEBAPP_URL}/billing-confirmation?organizationId=${input.organizationId}&checkout_success=1&plan=${input.plan}`,
     cancel_url: `${WEBAPP_URL}/organizations/${input.organizationId}/settings/billing`,
     metadata: {
       organizationId: input.organizationId,


### PR DESCRIPTION
## Problem

After a successful upgrade, the billing page kept showing the previous plan until a manual reload. The charge and plan change are applied correctly server-side — this is a client-refresh gap on the post-checkout return.

Two return paths were affected:

1. **Finalize path** (`pricing-table.tsx`): the success toast fired unconditionally (ignoring whether `waitForBillingPlanAction` actually observed the new plan), and `router.replace()` to the bare billing URL could serve a stale prefetched RSC even after `router.refresh()`.
2. **First-subscription path** (`ConfirmationPage.tsx`): the *Back to billing overview* button was a `next/link`, so it served the billing page's prefetched (pre-upgrade) RSC — no refresh.

## Solution

**Finalize path**
- Gate the success toast on the plan `waitForBillingPlanAction` actually observed. If Stripe hasn't reflected it within the poll window, show the existing `upgrade_checkout_pending` message instead of a false "You're now on the … plan."
- Strip the one-time checkout query params with `window.history.replaceState` (no router navigation → no stale prefetched RSC), then `router.refresh()` to refetch the billing route with the synced plan.

**First-subscription path**
- Use a full-document navigation (`<a>`) for the back button so the billing page re-renders fresh with the upgraded plan.

No new i18n keys. No server/action changes.

## Testing

No `.tsx` unit tests (per repo convention — React covered by E2E). Manual QA on staging: create org → upgrade to Pro via Stripe checkout on both paths → billing reflects Pro without a manual reload.

Closes ENG-1790