### PR TITLE
fix(api): reject response updates on a closed survey (ENG-1654)

### DIFF
--- a/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.test.ts
@@ -108,6 +108,7 @@ const getBaseSurvey = () =>
   ({
     id: surveyId,
     workspaceId,
+    status: "inProgress",
     blocks: [],
     questions: [],
   }) as const;
@@ -313,6 +314,23 @@ describe("putResponseHandler", () => {
       message: "Response is already finished",
       // Stable, locale-independent marker the surveys client keys off (see isResponseAlreadyCompletedError)
       details: { code: RESPONSE_ALREADY_FINISHED_ERROR_CODE },
+    });
+    expect(mocks.updateResponseWithQuotaEvaluation).not.toHaveBeenCalled();
+  });
+
+  test("rejects updates when the survey is closed (not accepting submissions)", async () => {
+    mocks.getSurvey.mockResolvedValue({
+      ...getBaseSurvey(),
+      status: "completed",
+    });
+
+    const result = await putResponseHandler(createHandlerParams());
+
+    expect(result.response.status).toBe(403);
+    await expect(result.response.json()).resolves.toEqual({
+      code: "forbidden",
+      message: "Survey is not accepting submissions",
+      details: { surveyId },
     });
     expect(mocks.updateResponseWithQuotaEvaluation).not.toHaveBeenCalled();
   });

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.ts
@@ -135,6 +135,16 @@ const validateUpdateRequest = (
   responseUpdateInput: TResponseUpdateInput,
   workspaceId: string
 ): TRouteResult | undefined => {
+  // Mirror the POST endpoint: a closed survey accepts no submissions, including finalizing a partial
+  // response created while it was open (ENG-1654).
+  if (survey.status !== "inProgress") {
+    return {
+      response: responses.forbiddenResponse("Survey is not accepting submissions", true, {
+        surveyId: survey.id,
+      }),
+    };
+  }
+
   if (existingResponse.finished) {
     return {
       response: responses.badRequestResponse(


### PR DESCRIPTION
## Problem

The client `PUT /api/v1/client/{workspaceId}/responses/{responseId}` endpoint only checked whether the response was already finished — never the survey's status. A partial response created while a survey was open could be updated and marked `finished: true` after the survey closed. The POST endpoint already rejects submissions on a closed survey (403); PUT didn't.

Impact: late finishes on closed surveys, quota consumed after close, analytics with post-close timestamps.

## Fix

In `validateUpdateRequest`, reject with 403 when `survey.status !== "inProgress"`, mirroring the POST endpoint's check and message. The v2 client PUT re-exports this handler, so both v1 and v2 client PUT are covered.

## Scope — client vs management endpoints

Audited all response create/update endpoints:

| Endpoint | Survey-status gate |
| --- | --- |
| v1 client POST | already present |
| v1 client PUT | **fixed here** |
| v2 client POST | already present (`checkSurveyValidity`) |
| v2 client PUT | **fixed here** (re-exports the v1 handler) |
| v1/v2 management POST + PUT | intentionally not gated — see below |

The **management** (API-key) endpoints do **not** gate on survey status, and this PR deliberately leaves that unchanged. They're a different trust model: authenticated survey owners / their integrations, with legitimate reasons to write to a closed survey (imports, backfills, corrections). The client check exists precisely because respondents are untrusted. Restricting management writes on closed surveys would be a separate product decision, not part of this bug. Flagging for the team — happy to open a follow-up if we want to change that.

## Tests

- Unit: added a case asserting 403 `"Survey is not accepting submissions"` when the survey is closed; gave the base survey mock `status: "inProgress"`. `pnpm test put-response-handler` → 21 passed.
- Manual API (local dev): reproduced the exact issue flow —
  - POST partial (survey `inProgress`) → 200
  - close survey (`status = 'completed'`) → PUT finalize → **403** (was 200 before the fix)
  - reopen survey → PUT → 200 (happy path intact)

Closes ENG-1654