### PR TITLE
fix(api): allow displayLimit recontact + independent displayPercentage in v3 surveys

### DIFF
--- a/apps/web/app/api/v3/surveys/schemas.test.ts
+++ b/apps/web/app/api/v3/surveys/schemas.test.ts
@@ -405,43 +405,55 @@ describe("ZV3CreateSurveyBody", () => {
     }
   });
 
-  test("requires displayPercentage when displayOption is displaySome", () => {
+  test("accepts displaySome with displayLimit (show at most N times)", () => {
     const result = ZV3CreateSurveyBody.safeParse({
+      ...validCreateBody,
+      type: "app",
+      distribution: { displayOption: "displaySome", displayLimit: 3 },
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.distribution).toMatchObject({ displayOption: "displaySome", displayLimit: 3 });
+    }
+  });
+
+  test("requires displayLimit >= 1 when displayOption is displaySome", () => {
+    const noLimit = ZV3CreateSurveyBody.safeParse({
       ...validCreateBody,
       type: "app",
       distribution: { displayOption: "displaySome" },
     });
-
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(formatV3ZodInvalidParams(result.error, "body")).toEqual(
+    expect(noLimit.success).toBe(false);
+    if (!noLimit.success) {
+      expect(formatV3ZodInvalidParams(noLimit.error, "body")).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            name: "distribution.displayPercentage",
+            name: "distribution.displayLimit",
             code: "missing_required_field",
           }),
         ])
       );
     }
+
+    const zeroLimit = ZV3CreateSurveyBody.safeParse({
+      ...validCreateBody,
+      type: "app",
+      distribution: { displayOption: "displaySome", displayLimit: 0 },
+    });
+    expect(zeroLimit.success).toBe(false);
   });
 
-  test("rejects displayPercentage when displayOption is not displaySome", () => {
+  test("accepts displayPercentage with any displayOption (independent throttle)", () => {
     const result = ZV3CreateSurveyBody.safeParse({
       ...validCreateBody,
       type: "app",
       distribution: { displayOption: "displayOnce", displayPercentage: 50 },
     });
 
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(formatV3ZodInvalidParams(result.error, "body")).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            name: "distribution.displayPercentage",
-            code: "unsupported_field",
-          }),
-        ])
-      );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.distribution).toMatchObject({ displayOption: "displayOnce", displayPercentage: 50 });
     }
   });
 

--- a/apps/web/app/api/v3/surveys/schemas.ts
+++ b/apps/web/app/api/v3/surveys/schemas.ts
@@ -1118,9 +1118,11 @@ const ZV3SurveyDistribution = z
 const ZV3SurveyTargeting = z.object({ filters: ZSegmentFilters }).strict();
 
 /**
- * Body-level validation for app-survey distribution/targeting. `distribution`/`targeting` are
- * rejected for explicit `link` surveys; for `app` (or when the type is unknown, e.g. the generic
- * patch schema) the displayOption ↔ displayPercentage coupling is enforced.
+ * Body-level validation for app-survey distribution/targeting: `distribution`/`targeting` are
+ * app-only, so reject them on explicit `link` surveys. Within `distribution`, `displaySome` ("show a
+ * limited number of times") must carry a `displayLimit` >= 1 (mirrors the editor's required "show
+ * maximum of N times" input). `displayPercentage` is an INDEPENDENT throttle valid with ANY
+ * `displayOption` — never coupled to `displaySome` — matching `ZSurvey` and the js-core runtime.
  */
 function addAppDistributionIssues(
   survey: {
@@ -1150,26 +1152,20 @@ function addAppDistributionIssues(
     return;
   }
 
+  // "displaySome" is capped by displayLimit, so a "limited" survey must specify a real limit (>= 1),
+  // mirroring the editor. displayPercentage stays independent and is validated by the field schema.
   const distribution = survey.distribution;
-  if (!distribution) {
-    return;
-  }
-
-  if (distribution.displayOption === "displaySome") {
-    if (distribution.displayPercentage === null || distribution.displayPercentage === undefined) {
-      ctx.addIssue({
-        code: "custom",
-        message: "displayPercentage is required when displayOption is 'displaySome'",
-        params: { code: "missing_required_field" },
-        path: ["distribution", "displayPercentage"],
-      });
-    }
-  } else if (distribution.displayPercentage !== null && distribution.displayPercentage !== undefined) {
+  if (
+    distribution?.displayOption === "displaySome" &&
+    (distribution.displayLimit === null ||
+      distribution.displayLimit === undefined ||
+      distribution.displayLimit < 1)
+  ) {
     ctx.addIssue({
       code: "custom",
-      message: "displayPercentage is only allowed when displayOption is 'displaySome'",
-      params: { code: "unsupported_field" },
-      path: ["distribution", "displayPercentage"],
+      message: "displayLimit must be at least 1 when displayOption is 'displaySome'",
+      params: { code: "missing_required_field" },
+      path: ["distribution", "displayLimit"],
     });
   }
 }

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -416,7 +416,7 @@ paths:
                     $ref: '#/components/schemas/SurveyResource'
         '400':
           description: |
-            Bad Request — the document failed schema validation, i.e. any rule checkable from the request body alone, without consulting stored state. Covers: invalid JSON; unknown or unsupported fields (including `distribution`/`targeting` sent on a `link` survey, which are `app`-only); missing required fields; wrong types or out-of-range values; bad enum values; malformed multilingual maps; and intra-document field-combination rules — notably `displayPercentage` is required when `displayOption` is `displaySome` and forbidden otherwise. Cross-reference failures that need stored state to detect return **422** instead. Every offending field is itemized in `invalid_params`. Unknown, forbidden, or wrongly-combined fields carry `code: unsupported_field` (e.g. `distribution` on a link survey, or `displayPercentage` without `displayOption: displaySome`); omissions carry `code: missing_required_field` (e.g. `displayPercentage` when `displayOption` is `displaySome`). Bare type, range, enum, and malformed-locale-map violations report the field `name` with a human-readable `reason` and no machine `code`.
+            Bad Request — the document failed schema validation, i.e. any rule checkable from the request body alone, without consulting stored state. Covers: invalid JSON; unknown or unsupported fields (including `distribution`/`targeting` sent on a `link` survey, which are `app`-only); missing required fields; wrong types or out-of-range values; bad enum values; malformed multilingual maps; and intra-document field-combination rules — notably `displayLimit` is required (must be >= 1) when `displayOption` is `displaySome`. Cross-reference failures that need stored state to detect return **422** instead. Every offending field is itemized in `invalid_params`. Unknown or forbidden fields carry `code: unsupported_field` (e.g. `distribution` on a link survey); omissions carry `code: missing_required_field` (e.g. `displayLimit` when `displayOption` is `displaySome`). Bare type, range, enum, and malformed-locale-map violations report the field `name` with a human-readable `reason` and no machine `code`.
           content:
             application/problem+json:
               schema:
@@ -1012,7 +1012,7 @@ paths:
                     $ref: '#/components/schemas/SurveyResource'
         '400':
           description: |
-            Bad Request — the patch failed schema validation, i.e. any rule checkable from the request body alone, without consulting stored state. Covers: malformed JSON; an unsupported query parameter; unknown, unsupported, or immutable fields (`type` cannot be changed after creation, and `distribution`/`targeting` are `app`-only — sending them when patching a `link` survey is rejected); wrong types or out-of-range values; bad enum values; malformed multilingual maps; and intra-document field-combination rules — notably `displayPercentage` is required when `displayOption` is `displaySome` and forbidden otherwise. Cross-reference failures that need stored state to detect return **422** instead. Every offending field is itemized in `invalid_params`. Unknown, forbidden, immutable, or wrongly-combined fields carry `code: unsupported_field` (e.g. `type`, or `distribution`/`targeting` on a link survey); omissions carry `code: missing_required_field`. Bare type, range, enum, and malformed-locale-map violations report the field `name` with a human-readable `reason` and no machine `code`.
+            Bad Request — the patch failed schema validation, i.e. any rule checkable from the request body alone, without consulting stored state. Covers: malformed JSON; an unsupported query parameter; unknown, unsupported, or immutable fields (`type` cannot be changed after creation, and `distribution`/`targeting` are `app`-only — sending them when patching a `link` survey is rejected); wrong types or out-of-range values; bad enum values; malformed multilingual maps; and intra-document field-combination rules — notably `displayLimit` is required (must be >= 1) when `displayOption` is `displaySome`. Cross-reference failures that need stored state to detect return **422** instead. Every offending field is itemized in `invalid_params`. Unknown, forbidden, immutable, or wrongly-combined fields carry `code: unsupported_field` (e.g. `type`, or `distribution`/`targeting` on a link survey); omissions carry `code: missing_required_field`. Bare type, range, enum, and malformed-locale-map violations report the field `name` with a human-readable `reason` and no machine `code`.
           content:
             application/problem+json:
               schema:
@@ -2572,7 +2572,7 @@ components:
             - displaySome
           default: displayOnce
           description: |
-            How often the survey may be shown to a contact. `displaySome` shows it to `displayPercentage` of contacts.
+            How often the survey may be shown to a contact. `displaySome` shows it up to `displayLimit` times (or until the contact responds, whichever comes first).
         displayPercentage:
           type:
             - number
@@ -2581,14 +2581,15 @@ components:
           maximum: 100
           default: null
           description: |
-            Percentage of contacts to show the survey to. Required when `displayOption` is `displaySome`; must be null/omitted otherwise.
+            Independent throttle: show the survey to only this percentage of triggered contacts. Optional and valid with any `displayOption`; null/omitted means no throttle (shown to everyone).
         displayLimit:
           type:
             - integer
             - 'null'
           minimum: 0
           default: null
-          description: Maximum number of times the survey is shown to a single contact.
+          description: |
+            Maximum number of times the survey is shown to a single contact. Required (must be >= 1) when `displayOption` is `displaySome`; otherwise optional.
         recontactDays:
           type:
             - integer
@@ -2625,8 +2626,8 @@ components:
       additionalProperties: false
       example:
         displayOption: displaySome
-        displayPercentage: 50
-        displayLimit: null
+        displayLimit: 3
+        displayPercentage: null
         recontactDays: 7
         autoClose: null
         autoComplete: null

--- a/docs/api-v3-reference/src/components/schemas/SurveyDistribution.yml
+++ b/docs/api-v3-reference/src/components/schemas/SurveyDistribution.yml
@@ -17,8 +17,8 @@ properties:
       - displaySome
     default: displayOnce
     description: >
-      How often the survey may be shown to a contact. `displaySome` shows it to `displayPercentage`
-      of contacts.
+      How often the survey may be shown to a contact. `displaySome` shows it up to `displayLimit`
+      times (or until the contact responds, whichever comes first).
   displayPercentage:
     type:
       - number
@@ -27,15 +27,17 @@ properties:
     maximum: 100
     default: null
     description: >
-      Percentage of contacts to show the survey to. Required when `displayOption` is `displaySome`;
-      must be null/omitted otherwise.
+      Independent throttle: show the survey to only this percentage of triggered contacts. Optional
+      and valid with any `displayOption`; null/omitted means no throttle (shown to everyone).
   displayLimit:
     type:
       - integer
       - "null"
     minimum: 0
     default: null
-    description: Maximum number of times the survey is shown to a single contact.
+    description: >
+      Maximum number of times the survey is shown to a single contact. Required (must be >= 1) when
+      `displayOption` is `displaySome`; otherwise optional.
   recontactDays:
     type:
       - integer
@@ -73,11 +75,11 @@ properties:
       removes all existing triggers.
 additionalProperties: false
 example:
-  # `displaySome` requires `displayPercentage` (shown to that % of contacts); any other displayOption
-  # requires `displayPercentage` to be null/omitted.
+  # `displaySome` ("show a limited number of times") is capped by `displayLimit` (must be >= 1).
+  # `displayPercentage` is an independent, optional throttle valid with any `displayOption`.
   displayOption: displaySome
-  displayPercentage: 50
-  displayLimit: null
+  displayLimit: 3
+  displayPercentage: null
   recontactDays: 7
   autoClose: null
   autoComplete: null

--- a/docs/api-v3-reference/src/paths/api_v3_surveys.yml
+++ b/docs/api-v3-reference/src/paths/api_v3_surveys.yml
@@ -413,12 +413,11 @@ post:
         unsupported fields (including `distribution`/`targeting` sent on a `link` survey, which are
         `app`-only); missing required fields; wrong types or out-of-range values; bad enum values;
         malformed multilingual maps; and intra-document field-combination rules — notably
-        `displayPercentage` is required when `displayOption` is `displaySome` and forbidden
-        otherwise. Cross-reference failures that need stored state to detect return **422** instead.
-        Every offending field is itemized in `invalid_params`. Unknown, forbidden, or wrongly-combined
-        fields carry `code: unsupported_field` (e.g. `distribution` on a link survey, or
-        `displayPercentage` without `displayOption: displaySome`); omissions carry
-        `code: missing_required_field` (e.g. `displayPercentage` when `displayOption` is `displaySome`).
+        `displayLimit` is required (must be >= 1) when `displayOption` is `displaySome`.
+        Cross-reference failures that need stored state to detect return **422** instead.
+        Every offending field is itemized in `invalid_params`. Unknown or forbidden fields carry
+        `code: unsupported_field` (e.g. `distribution` on a link survey); omissions carry
+        `code: missing_required_field` (e.g. `displayLimit` when `displayOption` is `displaySome`).
         Bare type, range, enum, and malformed-locale-map violations report the field `name` with a
         human-readable `reason` and no machine `code`.
       content:

--- a/docs/api-v3-reference/src/paths/api_v3_surveys_{surveyId}.yml
+++ b/docs/api-v3-reference/src/paths/api_v3_surveys_{surveyId}.yml
@@ -295,8 +295,8 @@ patch:
         parameter; unknown, unsupported, or immutable fields (`type` cannot be changed after creation,
         and `distribution`/`targeting` are `app`-only — sending them when patching a `link` survey is
         rejected); wrong types or out-of-range values; bad enum values; malformed multilingual maps;
-        and intra-document field-combination rules — notably `displayPercentage` is required when
-        `displayOption` is `displaySome` and forbidden otherwise. Cross-reference failures that need
+        and intra-document field-combination rules — notably `displayLimit` is required (must be >= 1)
+        when `displayOption` is `displaySome`. Cross-reference failures that need
         stored state to detect return **422** instead. Every offending field is itemized in
         `invalid_params`. Unknown, forbidden, immutable, or wrongly-combined fields carry
         `code: unsupported_field` (e.g. `type`, or `distribution`/`targeting` on a link survey);


### PR DESCRIPTION
## What does this PR do?

Fixes the v3 Surveys API app-survey `distribution` validation, which wrongly coupled `displayOption: "displaySome"` to `displayPercentage`. Found during QA 5.2 §7 (ENG-1757).

Linear: ENG-1794

**Before:**
- `displaySome` ("show a limited number of times") **required** `displayPercentage`, so the natural payload for it — `{"displayOption":"displaySome","displayLimit":3}` — returned **400** (`missing_required_field` on `distribution.displayPercentage`). You couldn't configure the "show at most N times" recontact option via the API.
- `displayPercentage` was **rejected** (`unsupported_field`) on every other option (`displayOnce`/`displayMultiple`/`respondMultiple`).

This contradicted the source of truth: in `ZSurvey` (`packages/types/surveys/types.ts`) and the js-core runtime (`packages/js-core/src/lib/common/utils.ts`), `displaySome` is capped by **`displayLimit`**, and `displayPercentage` is an **independent** throttle applied regardless of `displayOption`. The editor (`recontact-options-card.tsx`) reflects this too.

**Change** — `apps/web/app/api/v3/surveys/schemas.ts` → `addAppDistributionIssues`:
- Removed the `displaySome ⇄ displayPercentage` coupling. `displayPercentage` (0.01–100 or null) is now accepted with **any** `displayOption`.
- Added a guard: `displayOption: "displaySome"` now requires `displayLimit >= 1`, mirroring the editor's "show survey maximum of N times" input (so a "limited" survey can't be created without a real limit).
- Link surveys still reject `distribution`/`targeting`; all per-field constraints (enum, ranges) are unchanged.

## How should this be tested?

Unit tests (77 pass, incl. new cases for the fixed + guarded behavior):

```
pnpm --filter=@formbricks/web exec vitest run app/api/v3/surveys/schemas.test.ts app/api/v3/surveys/distribution.test.ts app/api/v3/surveys/patch.test.ts app/api/v3/surveys/create.test.ts
```

Manual (`POST /api/v3/surveys`, `type: "app"`), verified on localhost:

| body `distribution` | before | after |
| --- | --- | --- |
| `{"displayOption":"displaySome","displayLimit":3}` | 400 | **201** |
| `{"displayOption":"displayOnce","displayPercentage":50}` | 400 | **201** |
| `{"displayOption":"displaySome","displayLimit":3,"displayPercentage":75}` | 400 | **201** |
| `{"displayOption":"displaySome"}` (no limit) | 400 | **400** (`missing_required_field` on `distribution.displayLimit`) |
| `{"displayOption":"displayOnce"}` on a `link` survey | 400 | **400** (unchanged) |
| `{"displayOption":"displayOnce","displayPercentage":150}` | 400 | **400** (range, unchanged) |

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues (API-only, no UI change)
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks)

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR (N/A — API-only)
- [ ] Updated the Formbricks Docs if changes were necessary
