### PR TITLE
fix(charts): scale rating chart Y-axis to the question's scale

### DIFF
--- a/apps/web/modules/ee/analysis/charts/components/cartesian-chart.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/cartesian-chart.tsx
@@ -3,6 +3,7 @@
 import { type ElementType, type ReactNode } from "react";
 import { CartesianGrid, XAxis, YAxis } from "recharts";
 import { formatXAxisTick } from "@/modules/ee/analysis/charts/lib/chart-utils";
+import { computeYAxis } from "@/modules/ee/analysis/charts/lib/y-axis-scale";
 import type { TChartDataRow } from "@/modules/ee/analysis/types/analysis";
 import type { ChartConfig } from "@/modules/ui/components/chart";
 import { ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip } from "@/modules/ui/components/chart";
@@ -27,77 +28,6 @@ export interface CartesianChartProps {
    * tooltip header (which would otherwise show the fallback measure value, e.g. a stray "1"). */
   hasCategoryAxis?: boolean;
 }
-
-const TARGET_TICK_COUNT = 5;
-
-interface YAxisScale {
-  domain: [number, number];
-  ticks: number[];
-}
-
-// Round a value to a "nice" number (1/2/5/10 × 10ⁿ) — the family of steps people
-// expect on an axis. `round` snaps to the nearest nice number; otherwise it rounds
-// up so the value fully contains the range.
-const niceNum = (value: number, round: boolean): number => {
-  const exponent = Math.floor(Math.log10(value));
-  const fraction = value / 10 ** exponent;
-  let niceFraction: number;
-  if (round) {
-    if (fraction < 1.5) niceFraction = 1;
-    else if (fraction < 3) niceFraction = 2;
-    else if (fraction < 7) niceFraction = 5;
-    else niceFraction = 10;
-  } else if (fraction <= 1) niceFraction = 1;
-  else if (fraction <= 2) niceFraction = 2;
-  else if (fraction <= 5) niceFraction = 5;
-  else niceFraction = 10;
-  return niceFraction * 10 ** exponent;
-};
-
-const computeYAxis = (
-  data: TChartDataRow[],
-  dataKeys: string[],
-  zeroBaseline: boolean
-): YAxisScale | undefined => {
-  const values: number[] = [];
-  for (const row of data) {
-    for (const key of dataKeys) {
-      const raw = row[key];
-      if (raw === null || raw === undefined || raw === "") continue;
-      const num = Number(raw);
-      if (Number.isFinite(num)) values.push(num);
-    }
-  }
-  if (values.length === 0) return undefined;
-
-  const dataMin = Math.min(...values);
-  const dataMax = Math.max(...values);
-
-  // Baseline: bars and all-positive series sit on 0; only dip below zero when the
-  // data genuinely does, so we never draw a phantom negative axis (e.g. a -4 floor
-  // under a metric that bottoms out at 0).
-  const baselineLow = zeroBaseline ? Math.min(0, dataMin) : dataMin;
-  // Flat data has no range to scale, so give it a unit of headroom to render ticks.
-  const spanHigh = dataMax === baselineLow ? baselineLow + 1 : dataMax;
-
-  // Snap the axis to nice bounds and derive evenly spaced round ticks, so every
-  // gridline lands on a labelled value. (Recharts' auto-ticks are computed from a
-  // raw domain and can fall outside it, drawing extra gridlines with no label.)
-  const step = niceNum(niceNum(spanHigh - baselineLow, false) / (TARGET_TICK_COUNT - 1), true);
-  const niceMin = Math.floor(baselineLow / step) * step;
-  const niceMax = Math.ceil(spanHigh / step) * step;
-
-  // Clean up floating-point noise that decimal steps introduce (e.g. 0.30000000004).
-  const decimals = Math.max(0, -Math.floor(Math.log10(step)));
-  const round = (n: number) => Number(n.toFixed(decimals));
-
-  const ticks: number[] = [];
-  for (let tick = niceMin; tick <= niceMax + step / 2; tick += step) {
-    ticks.push(round(tick));
-  }
-
-  return { domain: [round(niceMin), round(niceMax)], ticks };
-};
 
 export function CartesianChart({
   data,

--- a/apps/web/modules/ee/analysis/charts/lib/y-axis-scale.test.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/y-axis-scale.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+import { computeYAxis } from "./y-axis-scale";
+
+const RATING_AVG = "FeedbackRecords.ratingAverage";
+const CSAT_AVG = "FeedbackRecords.csatAverage";
+const CES_AVG = "FeedbackRecords.cesAverage";
+const NPS_AVG = "FeedbackRecords.npsAverage";
+const COUNT = "FeedbackRecords.count";
+
+describe("computeYAxis", () => {
+  describe("fixed-scale measures pin the axis to the question scale (ENG-1796)", () => {
+    test("rating average 3.33 on a 1-5 question renders a 0-5 axis, not a data-driven 0-4 one", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: 3.33 }], [RATING_AVG], true);
+      expect(scale).toEqual({ domain: [0, 5], ticks: [0, 1, 2, 3, 4, 5] });
+    });
+
+    test("rating average above 7 pins to the 10 scale with even ticks", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: 8.2 }], [RATING_AVG], true);
+      expect(scale).toEqual({ domain: [0, 10], ticks: [0, 2, 4, 6, 8, 10] });
+    });
+
+    test("rating average between 5 and 7 pins to the 7 scale (smallest standard scale containing the data)", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: 6.33 }], [RATING_AVG], true);
+      expect(scale).toEqual({ domain: [0, 7], ticks: [0, 1, 2, 3, 4, 5, 6, 7] });
+    });
+
+    test("CSAT average always pins to its fixed 1-5 scale", () => {
+      const scale = computeYAxis([{ [CSAT_AVG]: 2.4 }], [CSAT_AVG], true);
+      expect(scale).toEqual({ domain: [0, 5], ticks: [0, 1, 2, 3, 4, 5] });
+    });
+
+    test("CES average pins to 5 or 7 depending on the data", () => {
+      expect(computeYAxis([{ [CES_AVG]: 3 }], [CES_AVG], true)?.domain).toEqual([0, 5]);
+      expect(computeYAxis([{ [CES_AVG]: 6.5 }], [CES_AVG], true)?.domain).toEqual([0, 7]);
+    });
+
+    test("NPS average pins to its fixed 0-10 scale", () => {
+      const scale = computeYAxis([{ [NPS_AVG]: 6.33 }], [NPS_AVG], true);
+      expect(scale).toEqual({ domain: [0, 10], ticks: [0, 2, 4, 6, 8, 10] });
+    });
+
+    test("pins across category rows using the series max", () => {
+      const data = [{ [RATING_AVG]: 1.2 }, { [RATING_AVG]: 4.8 }, { [RATING_AVG]: 3.3 }];
+      expect(computeYAxis(data, [RATING_AVG], true)?.domain).toEqual([0, 5]);
+    });
+
+    test("pins line/area charts (no zero baseline flag) to the full 0-based scale too", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: 3.33 }, { [RATING_AVG]: 4.1 }], [RATING_AVG], false);
+      expect(scale?.domain).toEqual([0, 5]);
+    });
+
+    test("multi-measure charts of only fixed-scale measures pin to the largest needed scale", () => {
+      const data = [{ [RATING_AVG]: 6.3, [CSAT_AVG]: 4 }];
+      expect(computeYAxis(data, [RATING_AVG, CSAT_AVG], true)?.domain).toEqual([0, 7]);
+    });
+
+    test("a fixed-scale series with no values does not veto pinning by the other series", () => {
+      const data = [{ [RATING_AVG]: 3.2, [CSAT_AVG]: null }];
+      expect(computeYAxis(data, [RATING_AVG, CSAT_AVG], true)?.domain).toEqual([0, 5]);
+    });
+  });
+
+  describe("falls back to data-driven nice scaling", () => {
+    test("when the chart mixes fixed-scale and unbounded measures", () => {
+      const data = [{ [RATING_AVG]: 3.33, [COUNT]: 77 }];
+      const scale = computeYAxis(data, [RATING_AVG, COUNT], true);
+      expect(scale).toEqual({ domain: [0, 80], ticks: [0, 20, 40, 60, 80] });
+    });
+
+    test("when data exceeds the largest known scale (defensive: never clip real data)", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: 12 }], [RATING_AVG], true);
+      expect(scale?.domain[1]).toBeGreaterThanOrEqual(12);
+    });
+
+    test("when a fixed-scale series unexpectedly dips negative", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: -2 }, { [RATING_AVG]: 4 }], [RATING_AVG], false);
+      expect(scale?.domain[0]).toBeLessThanOrEqual(-2);
+    });
+
+    test("for unbounded measures (unchanged behavior)", () => {
+      const scale = computeYAxis([{ [COUNT]: 77 }], [COUNT], true);
+      expect(scale).toEqual({ domain: [0, 80], ticks: [0, 20, 40, 60, 80] });
+    });
+
+    test("keeps decimal precision for small unbounded values", () => {
+      const scale = computeYAxis([{ [COUNT]: 0.33 }], [COUNT], false);
+      expect(scale?.ticks.every((tick) => Number.isFinite(tick))).toBe(true);
+      expect(scale?.domain[1]).toBeGreaterThanOrEqual(0.33);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("returns undefined for empty data or non-numeric values", () => {
+      expect(computeYAxis([], [COUNT], true)).toBeUndefined();
+      expect(computeYAxis([{ [COUNT]: null }, { [COUNT]: "" }], [COUNT], true)).toBeUndefined();
+    });
+
+    test("all-null fixed-scale data returns undefined instead of a pinned empty axis", () => {
+      expect(computeYAxis([{ [RATING_AVG]: null }], [RATING_AVG], true)).toBeUndefined();
+    });
+
+    test("flat zero data still renders a usable axis", () => {
+      const scale = computeYAxis([{ [COUNT]: 0 }], [COUNT], true);
+      expect(scale?.domain[1]).toBeGreaterThan(0);
+    });
+
+    test("coerces numeric strings (Cube can return numbers as strings)", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: "3.33" }], [RATING_AVG], true);
+      expect(scale?.domain).toEqual([0, 5]);
+    });
+  });
+});

--- a/apps/web/modules/ee/analysis/charts/lib/y-axis-scale.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/y-axis-scale.ts
@@ -1,0 +1,129 @@
+import { getMeasureAxisMaxCandidates } from "@/modules/ee/analysis/lib/schema-definition";
+import type { TChartDataRow } from "@/modules/ee/analysis/types/analysis";
+
+const TARGET_TICK_COUNT = 5;
+// Pinned scales prefer the finest step that still keeps the axis readable; a 0-7 CES axis
+// labels every integer (8 ticks) rather than overshooting the scale to hit a "nice" bound.
+const MAX_PINNED_TICK_COUNT = 8;
+
+export interface YAxisScale {
+  domain: [number, number];
+  ticks: number[];
+}
+
+// Round a value to a "nice" number (1/2/5/10 × 10ⁿ) — the family of steps people
+// expect on an axis. `round` snaps to the nearest nice number; otherwise it rounds
+// up so the value fully contains the range.
+const niceNum = (value: number, round: boolean): number => {
+  const exponent = Math.floor(Math.log10(value));
+  const fraction = value / 10 ** exponent;
+  let niceFraction: number;
+  if (round) {
+    if (fraction < 1.5) niceFraction = 1;
+    else if (fraction < 3) niceFraction = 2;
+    else if (fraction < 7) niceFraction = 5;
+    else niceFraction = 10;
+  } else if (fraction <= 1) niceFraction = 1;
+  else if (fraction <= 2) niceFraction = 2;
+  else if (fraction <= 5) niceFraction = 5;
+  else niceFraction = 10;
+  return niceFraction * 10 ** exponent;
+};
+
+const collectNumericValues = (data: TChartDataRow[], keys: string[]): number[] => {
+  const values: number[] = [];
+  for (const row of data) {
+    for (const key of keys) {
+      const raw = row[key];
+      if (raw === null || raw === undefined || raw === "") continue;
+      const num = Number(raw);
+      if (Number.isFinite(num)) values.push(num);
+    }
+  }
+  return values;
+};
+
+/**
+ * Axis max for charts whose every series is a fixed-scale measure (rating/CSAT/CES/NPS
+ * averages): the largest of each series' smallest scale candidate that contains its data,
+ * so a 3.33 average on a 1-5 rating pins the axis to 5 instead of a data-driven 4 (ENG-1796).
+ * Returns undefined — falling back to nice scaling — when any series is not scale-pinned,
+ * dips negative, or exceeds its largest known scale.
+ */
+const computePinnedAxisMax = (data: TChartDataRow[], dataKeys: string[]): number | undefined => {
+  let pinnedMax = 0;
+  for (const key of dataKeys) {
+    const candidates = getMeasureAxisMaxCandidates(key);
+    if (!candidates || candidates.length === 0) return undefined;
+    const values = collectNumericValues(data, [key]);
+    if (values.length === 0) continue;
+    if (Math.min(...values) < 0) return undefined;
+    const keyMax = Math.max(...values);
+    const candidate = candidates.find((c) => c >= keyMax);
+    if (candidate === undefined) return undefined;
+    pinnedMax = Math.max(pinnedMax, candidate);
+  }
+  return pinnedMax > 0 ? pinnedMax : undefined;
+};
+
+// Integer ticks for a pinned [0, max] scale: the smallest 1/2/5×10ⁿ step that divides the
+// scale evenly without exceeding MAX_PINNED_TICK_COUNT ticks, so every gridline lands on a
+// value of the scale and the top tick is exactly the scale max (never overshoots it).
+const computePinnedTicks = (max: number): number[] => {
+  for (let exponent = 0; 10 ** exponent <= max; exponent++) {
+    for (const base of [1, 2, 5]) {
+      const step = base * 10 ** exponent;
+      if (max % step === 0 && max / step + 1 <= MAX_PINNED_TICK_COUNT) {
+        const ticks: number[] = [];
+        for (let tick = 0; tick <= max; tick += step) ticks.push(tick);
+        return ticks;
+      }
+    }
+  }
+  return [0, max];
+};
+
+export const computeYAxis = (
+  data: TChartDataRow[],
+  dataKeys: string[],
+  zeroBaseline: boolean
+): YAxisScale | undefined => {
+  const values = collectNumericValues(data, dataKeys);
+  if (values.length === 0) return undefined;
+
+  const dataMin = Math.min(...values);
+  const dataMax = Math.max(...values);
+
+  // Fixed-scale measures (rating/CSAT/CES/NPS averages) render against the question's full
+  // scale — 0 up to the pinned max — regardless of chart type, so bar heights and line
+  // positions read as "3.33 out of 5" rather than being stretched to a data-driven bound.
+  const pinnedMax = computePinnedAxisMax(data, dataKeys);
+  if (pinnedMax !== undefined) {
+    return { domain: [0, pinnedMax], ticks: computePinnedTicks(pinnedMax) };
+  }
+
+  // Baseline: bars and all-positive series sit on 0; only dip below zero when the
+  // data genuinely does, so we never draw a phantom negative axis (e.g. a -4 floor
+  // under a metric that bottoms out at 0).
+  const baselineLow = zeroBaseline ? Math.min(0, dataMin) : dataMin;
+  // Flat data has no range to scale, so give it a unit of headroom to render ticks.
+  const spanHigh = dataMax === baselineLow ? baselineLow + 1 : dataMax;
+
+  // Snap the axis to nice bounds and derive evenly spaced round ticks, so every
+  // gridline lands on a labelled value. (Recharts' auto-ticks are computed from a
+  // raw domain and can fall outside it, drawing extra gridlines with no label.)
+  const step = niceNum(niceNum(spanHigh - baselineLow, false) / (TARGET_TICK_COUNT - 1), true);
+  const niceMin = Math.floor(baselineLow / step) * step;
+  const niceMax = Math.ceil(spanHigh / step) * step;
+
+  // Clean up floating-point noise that decimal steps introduce (e.g. 0.30000000004).
+  const decimals = Math.max(0, -Math.floor(Math.log10(step)));
+  const round = (n: number) => Number(n.toFixed(decimals));
+
+  const ticks: number[] = [];
+  for (let tick = niceMin; tick <= niceMax + step / 2; tick += step) {
+    ticks.push(round(tick));
+  }
+
+  return { domain: [round(niceMin), round(niceMax)], ticks };
+};

--- a/apps/web/modules/ee/analysis/lib/schema-definition.ts
+++ b/apps/web/modules/ee/analysis/lib/schema-definition.ts
@@ -23,6 +23,14 @@ export interface MeasureDefinition {
   type: "count" | "number";
   group: TMeasureGroup;
   description?: string;
+  /**
+   * Candidate Y-axis maxima (ascending) for measures answered on a bounded rating scale. Charts pin
+   * the axis to the smallest candidate that contains the data (e.g. an average of 3.33 on a 1-5
+   * rating renders on a 0-5 axis, not a data-driven 0-4 one), so the bar height reads against the
+   * question's actual scale. The question's true scale is not stored on feedback records (see
+   * ratingAverage below), so multi-candidate lists are a best-effort inference from the data max.
+   */
+  axisMaxCandidates?: readonly number[];
 }
 
 /**
@@ -247,6 +255,7 @@ export const FEEDBACK_FIELDS = {
       type: "number",
       group: "average",
       description: "Average NPS rating (0-10)",
+      axisMaxCandidates: [10],
     },
     {
       id: "FeedbackRecords.promoterCount",
@@ -282,6 +291,7 @@ export const FEEDBACK_FIELDS = {
       type: "number",
       group: "average",
       description: "Average CSAT rating (1-5)",
+      axisMaxCandidates: [5],
     },
     {
       id: "FeedbackRecords.csatSatisfiedCount",
@@ -317,6 +327,7 @@ export const FEEDBACK_FIELDS = {
       type: "number",
       group: "average",
       description: "Average CES rating (scale is 1-5 or 1-7 depending on the question)",
+      axisMaxCandidates: [5, 7],
     },
     {
       id: "FeedbackRecords.cesCount",
@@ -331,6 +342,11 @@ export const FEEDBACK_FIELDS = {
       type: "number",
       group: "average",
       description: "Average rating value (scale depends on the question, e.g. 1-5 or 1-10)",
+      // Feedback records don't store the question's rating scale (transform.ts writes only
+      // value_number), so pin to the smallest standard rating scale that contains the data
+      // (ENG-1796). A 1-10 question whose averages stay <= 7 will render on a 0-7 axis until
+      // the scale is ingested as record metadata - see the measure docs on axisMaxCandidates.
+      axisMaxCandidates: [5, 7, 10],
     },
     {
       id: "FeedbackRecords.ratingCount",
@@ -353,6 +369,11 @@ export const FEEDBACK_FIELDS = {
 };
 
 export const FEEDBACK_MEASURE_IDS: string[] = FEEDBACK_FIELDS.measures.map((m) => m.id);
+
+/** Candidate Y-axis maxima for fixed-scale measures (see MeasureDefinition.axisMaxCandidates),
+ * or undefined for measures whose axis should stay data-driven. */
+export const getMeasureAxisMaxCandidates = (measureId: string): readonly number[] | undefined =>
+  FEEDBACK_FIELDS.measures.find((m) => m.id === measureId)?.axisMaxCandidates;
 
 export const FEEDBACK_DIMENSION_IDS: string[] = FEEDBACK_FIELDS.dimensions.map((d) => d.id);
 


### PR DESCRIPTION
## What does this PR do?

Contributes to ENG-1796

Rating-scale charts (Rating/CSAT/CES/NPS averages) currently get a data-driven "nice" Y-axis, so the axis top lands on an arbitrary value instead of the question's scale. QA on ENG-1754 (TC2) observed:

| Chart | Value | Axis before | Axis after |
| --- | --- | --- | --- |
| Rating: Average, 1–5 question | 3.33 | 0–4 | **0–5** |
| Rating: Average, 1–10 question | 6.33 | 0–8 | **0–7** (see decision below — the true 1–10 scale is not stored) |
| CSAT: Average | 2.4 | 0–3 | **0–5** |
| NPS: Average | 6.33 | 0–8 | **0–10** |

Changes:

- `schema-definition.ts`: new optional `axisMaxCandidates` on `MeasureDefinition` — the candidate axis maxima for measures answered on a bounded scale: `ratingAverage: [5, 7, 10]`, `cesAverage: [5, 7]`, `csatAverage: [5]`, `npsAverage: [10]` — plus a `getMeasureAxisMaxCandidates` lookup.
- `y-axis-scale.ts` (new): the Y-axis domain/tick logic extracted from `cartesian-chart.tsx` into a pure `.ts` module (so it can be unit-tested per our testing rules). When **every** series in a chart is a fixed-scale measure, the axis pins to `[0, smallest candidate ≥ each series' max]` with integer ticks that end exactly on the scale max (0–5 → step 1, 0–7 → step 1, 0–10 → step 2). Everything else keeps the existing nice scaling byte-for-byte, and pinning defensively falls back to nice scaling if data is negative or exceeds the largest known scale (never clips real data).
- `cartesian-chart.tsx`: now imports `computeYAxis` from the new module; no behavioral change of its own.

Non-goals / unchanged: counts, NPS: Score (−100..100), Sentiment: Average (−1..1, needs a pinned *negative* min so it's a different mechanism — left as data-driven, which QA TC7 showed renders −1..1 correctly already), pie/big-number (no axis), and mixed charts (e.g. Rating Average + Responses) which keep nice scaling so a 5-cap never squashes a count series.

## Decision needed (@dhruwang)

**Where does the question's scale come from?** I investigated and it is currently **not stored anywhere the charts can reach**:

- Ingestion (`apps/web/lib/feedback-source/transform.ts`) writes rating answers as bare `value_number`; the survey element's `range` (3/4/5/6/7/10 in `@formbricks/types`) is dropped. `metadata` is only populated for matrix/ranking.
- The Cube schema (`FeedbackRecords.js`) consequently has no scale dimension/measure.

**Chosen approach (heuristic, chart-side only):** pin the axis max to the smallest *standard* scale (5, 7, 10) that contains the series max. Monotone, never clips, and fixes the reported cases without touching ingestion, Cube (both schema copies stay identical), or needing a backfill.

Known limitation: a 1–10 question whose average sits in (5, 7] renders a 0–7 axis (the ENG-1796 staging fixture with avg 6.33 shows 0–7, not the ticket's ideal 0–10), and low-scoring 1–10 questions render 0–5. The heuristic cannot distinguish these without the real scale.

**Alternatives rejected:**

1. **Store the scale at ingestion** (e.g. `metadata.scale_max` from the element `range`) **+ a Cube `MAX(scale)` measure + query/chart plumbing** — the *correct* long-term fix, but it spans transform.ts, both byte-identical Cube schema copies, query building, and needs a backfill for all existing records (staging/prod data would still misrender). Happy to do as a follow-up if you prefer; the chart-side candidate mechanism here would then consume the real scale instead of guessing.
2. **Drop 7 from the rating candidates (`[5, 10]`)** so the staging 6.33 case shows 0–10 — but Formbricks rating questions support a 1–7 range, which would then render on a misleading 0–10 axis. Trivial one-line change if you'd rather match the ticket examples exactly.
3. **Pin only `ratingAverage`** — CSAT (fixed 1–5) and NPS average (fixed 0–10) have *known* scales, so pinning them is strictly correct rather than heuristic; leaving them data-driven would keep the same QA smell on their charts. Included them deliberately; shout if you want the scope narrower.

## How should this be tested?

1. Workspace → Analysis → create a chart: measure **Rating: Average**, filter to a 1–5 rating question (e.g. via Field ID), bar chart. With an average of ~3.33 the Y-axis must top out at **5** with ticks 0,1,2,3,4,5 (before: 4).
2. Same with a 1–10 question averaging > 7: axis tops at **10** with ticks 0,2,4,6,8,10 (an average ≤ 7 pins to 7 — see decision above).
3. **CSAT: Average** chart: axis always 0–5. **NPS: Average**: axis always 0–10.
4. Mixed chart (Rating: Average + Responses): unchanged nice scaling driven by the count.
5. Counts/`NPS: Score`/`Sentiment: Average` charts: axis behavior unchanged.
6. Unit tests: `cd apps/web && pnpm exec vitest run modules/ee/analysis/charts/lib/y-axis-scale.test.ts` (19 tests: pinning per measure, multi-measure, fallbacks, edge cases).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary

Verification run: `vitest run` on `y-axis-scale.test.ts` + `schema-definition.test.ts` → 56 passed; `eslint` + `prettier --check` clean on all 4 touched files; `tsc --noEmit` introduces no new errors (the 3 pre-existing `schema-definition.test.ts` `group` errors exist on main too). No full build / dev server run (scoped verification only).

<img width="1212" height="565" alt="Screenshot 2026-07-15 at 20 19 43" src="https://github.com/user-attachments/assets/54df20e0-006c-4238-b6bd-79e90d40af22" />
<img width="1227" height="666" alt="Screenshot 2026-07-15 at 20 19 59" src="https://github.com/user-attachments/assets/47217670-2e8e-4e7b-ba4c-a0b89b04f6fe" />
<img width="1224" height="640" alt="Screenshot 2026-07-15 at 20 20 18" src="https://github.com/user-attachments/assets/957fdb02-42ed-4324-9cf9-87aef036ba71" />

