### PR TITLE
feat(dashboards): add duplicate action to dashboard widgets

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -1732,6 +1732,8 @@ checksums:
     workspace/analysis/charts/time_dimension_title: 9353ce9a075a0cc8c3ba7dfa9ef19a8d
     workspace/analysis/charts/time_dimension_toggle_description: 77251d8b3b564390bad8b76f56905190
     workspace/analysis/dashboards/add_count_charts: b4ee1f29efce0bb380a060e0bc5d64fa
+    workspace/analysis/dashboards/chart_duplicate_failed: 90d7166c85188b52f821c9d9f53ff8c4
+    workspace/analysis/dashboards/chart_duplicated: 52765f173bd6fd5382731f8e06e436e0
     workspace/analysis/dashboards/chart_remove_failed: 198f5c3bdd522b40b80cb7479d3051a1
     workspace/analysis/dashboards/chart_removed: 1ce20b8ee0b56bcd7d6fea2b5c1ae9fd
     workspace/analysis/dashboards/chart_restore_failed: 890c74046ed55df6f90c28cf905b7a30

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "{count} Diagramm(e) hinzufügen",
+        "chart_duplicate_failed": "Diagramm konnte nicht dupliziert werden",
+        "chart_duplicated": "Diagramm wurde dupliziert und zum Dashboard hinzugefügt",
         "chart_remove_failed": "Diagramm konnte nicht entfernt werden",
         "chart_removed": "Diagramm vom Dashboard entfernt",
         "chart_restore_failed": "Diagramm konnte nicht wiederhergestellt werden",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "Add {count} chart(s)",
+        "chart_duplicate_failed": "Failed to duplicate chart",
+        "chart_duplicated": "Chart duplicated and added to dashboard",
         "chart_remove_failed": "Failed to remove chart",
         "chart_removed": "Chart removed from dashboard",
         "chart_restore_failed": "Failed to restore chart",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "Añadir {count} gráfico(s)",
+        "chart_duplicate_failed": "No se pudo duplicar el gráfico",
+        "chart_duplicated": "Gráfico duplicado y añadido al panel",
         "chart_remove_failed": "No se pudo eliminar el gráfico",
         "chart_removed": "Gráfico eliminado del panel",
         "chart_restore_failed": "No se pudo restaurar el gráfico",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "Ajouter {count} graphique(s)",
+        "chart_duplicate_failed": "Échec de la duplication du graphique",
+        "chart_duplicated": "Graphique dupliqué et ajouté au tableau de bord",
         "chart_remove_failed": "Échec de la suppression du graphique",
         "chart_removed": "Graphique retiré du tableau de bord",
         "chart_restore_failed": "Échec de la restauration du graphique",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "{count} diagram hozzáadása",
+        "chart_duplicate_failed": "A diagram másolása sikertelen volt",
+        "chart_duplicated": "A diagram másolása megtörtént és hozzáadásra került a műszerfalhoz",
         "chart_remove_failed": "A diagram eltávolítása sikertelen volt",
         "chart_removed": "A diagram eltávolítva a vezérlőpultról",
         "chart_restore_failed": "A diagram visszaállítása sikertelen volt",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "{count}個のグラフを追加",
+        "chart_duplicate_failed": "グラフの複製に失敗しました",
+        "chart_duplicated": "グラフが複製されダッシュボードに追加されました",
         "chart_remove_failed": "チャートの削除に失敗しました",
         "chart_removed": "チャートがダッシュボードから削除されました",
         "chart_restore_failed": "チャートの復元に失敗しました",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "{count} grafiek(en) toevoegen",
+        "chart_duplicate_failed": "Dupliceren van grafiek mislukt",
+        "chart_duplicated": "Grafiek gedupliceerd en toegevoegd aan dashboard",
         "chart_remove_failed": "Grafiek verwijderen mislukt",
         "chart_removed": "Grafiek verwijderd van dashboard",
         "chart_restore_failed": "Grafiek herstellen mislukt",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "Adicionar {count} gráfico(s)",
+        "chart_duplicate_failed": "Falha ao duplicar gráfico",
+        "chart_duplicated": "Gráfico duplicado e adicionado ao painel",
         "chart_remove_failed": "Falha ao remover gráfico",
         "chart_removed": "Gráfico removido do painel",
         "chart_restore_failed": "Falha ao restaurar gráfico",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "Adicionar {count} gráfico(s)",
+        "chart_duplicate_failed": "Falha ao duplicar gráfico",
+        "chart_duplicated": "Gráfico duplicado e adicionado ao painel",
         "chart_remove_failed": "Falha ao remover gráfico",
         "chart_removed": "Gráfico removido do painel",
         "chart_restore_failed": "Falha ao restaurar gráfico",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "Adaugă {count} grafic(e)",
+        "chart_duplicate_failed": "Graficul nu a putut fi duplicat",
+        "chart_duplicated": "Graficul a fost duplicat și adăugat la tabloul de bord",
         "chart_remove_failed": "Ștergerea graficului a eșuat",
         "chart_removed": "Graficul a fost eliminat din tabloul de bord",
         "chart_restore_failed": "Restaurarea graficului a eșuat",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "Добавить {count} график(ов)",
+        "chart_duplicate_failed": "Не удалось создать копию графика",
+        "chart_duplicated": "График скопирован и добавлен на дашборд",
         "chart_remove_failed": "Не удалось удалить диаграмму",
         "chart_removed": "График удалён с панели",
         "chart_restore_failed": "Не удалось восстановить диаграмму",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "Lägg till {count} diagram",
+        "chart_duplicate_failed": "Misslyckades med att duplicera diagram",
+        "chart_duplicated": "Diagram duplicerat och tillagt på instrumentpanelen",
         "chart_remove_failed": "Misslyckades med att ta bort diagram",
         "chart_removed": "Diagram borttaget från instrumentpanelen",
         "chart_restore_failed": "Misslyckades med att återställa diagram",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "{count} grafik ekle",
+        "chart_duplicate_failed": "Grafik kopyalanamadı",
+        "chart_duplicated": "Grafik kopyalandı ve panoya eklendi",
         "chart_remove_failed": "Grafik kaldırılamadı",
         "chart_removed": "Grafik gösterge panosundan kaldırıldı",
         "chart_restore_failed": "Grafik geri yüklenemedi",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "添加 {count} 个图表",
+        "chart_duplicate_failed": "图表复制失败",
+        "chart_duplicated": "图表已复制并添加到仪表板",
         "chart_remove_failed": "删除图表失败",
         "chart_removed": "图表已从仪表板中移除",
         "chart_restore_failed": "恢复图表失败",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1797,6 +1797,8 @@
       },
       "dashboards": {
         "add_count_charts": "新增 {count} 個圖表",
+        "chart_duplicate_failed": "圖表複製失敗",
+        "chart_duplicated": "圖表已複製並新增至儀表板",
         "chart_remove_failed": "移除圖表失敗",
         "chart_removed": "圖表已從儀表板移除",
         "chart_restore_failed": "還原圖表失敗",

--- a/apps/web/modules/ee/analysis/dashboards/actions.ts
+++ b/apps/web/modules/ee/analysis/dashboards/actions.ts
@@ -23,6 +23,7 @@ import {
   updateDashboard,
   updateWidgetLayouts,
 } from "./lib/dashboards";
+import { duplicateChartAndAddWidget } from "./lib/duplicate-chart-and-add-widget";
 
 const checkDashboardsEnabled = async (organizationId: string) => {
   const isAllowed = await getIsDashboardsEnabled(organizationId);
@@ -327,6 +328,54 @@ export const addChartToDashboardAction = authenticatedActionClient
         ctx.auditLoggingCtx.workspaceId = workspaceId;
         ctx.auditLoggingCtx.dashboardWidgetId = widget.id;
         ctx.auditLoggingCtx.newObject = widget;
+        return widget;
+      }
+    )
+  );
+
+const ZDuplicateChartAndAddWidgetAction = z.object({
+  workspaceId: ZId,
+  dashboardId: ZId,
+  chartId: ZId,
+  layout: ZWidgetLayout.optional(),
+});
+
+export const duplicateChartAndAddWidgetAction = authenticatedActionClient
+  .inputSchema(ZDuplicateChartAndAddWidgetAction)
+  .action(
+    withAuditLogging(
+      "created",
+      "dashboardWidget",
+      async ({
+        ctx,
+        parsedInput,
+      }: {
+        ctx: AuthenticatedActionClientCtx;
+        parsedInput: z.infer<typeof ZDuplicateChartAndAddWidgetAction>;
+      }) => {
+        const { organizationId, workspaceId } = await checkWorkspaceAccess(
+          ctx.user.id,
+          parsedInput.workspaceId,
+          "readWrite"
+        );
+        await checkDashboardsEnabled(organizationId);
+
+        const { chart, widget } = await duplicateChartAndAddWidget({
+          dashboardId: parsedInput.dashboardId,
+          workspaceId,
+          chartId: parsedInput.chartId,
+          createdBy: ctx.user.id,
+          layout: parsedInput.layout,
+        });
+
+        revalidatePath(`/workspaces/${workspaceId}/dashboards/${parsedInput.dashboardId}`);
+        revalidatePath(`/workspaces/${workspaceId}/dashboards`);
+
+        ctx.auditLoggingCtx.organizationId = organizationId;
+        ctx.auditLoggingCtx.workspaceId = workspaceId;
+        ctx.auditLoggingCtx.chartId = chart.id;
+        ctx.auditLoggingCtx.dashboardWidgetId = widget.id;
+        ctx.auditLoggingCtx.newObject = { chart, widget };
         return widget;
       }
     )

--- a/apps/web/modules/ee/analysis/dashboards/components/dashboard-detail-client.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/components/dashboard-detail-client.tsx
@@ -23,6 +23,7 @@ import { GoBackButton } from "@/modules/ui/components/go-back-button";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import {
   addChartToDashboardAction,
+  duplicateChartAndAddWidgetAction,
   removeWidgetFromDashboardAction,
   updateDashboardAction,
   updateWidgetLayoutsAction,
@@ -129,6 +130,7 @@ const MemoizedWidgetItem = memo(function WidgetItem({
   isEditing,
   dataPromise,
   onEdit,
+  onDuplicate,
   onResize,
   onRemove,
 }: Readonly<{
@@ -136,6 +138,7 @@ const MemoizedWidgetItem = memo(function WidgetItem({
   isEditing: boolean;
   dataPromise?: Promise<{ data: TChartDataRow[]; query: TChartQuery } | { error: TDashboardWidgetError }>;
   onEdit?: () => void;
+  onDuplicate?: () => void;
   onResize?: () => void;
   onRemove?: () => void;
 }>) {
@@ -146,6 +149,7 @@ const MemoizedWidgetItem = memo(function WidgetItem({
       title={title}
       isEditing={isEditing}
       onEdit={onEdit}
+      onDuplicate={onDuplicate}
       onResize={onResize}
       onRemove={onRemove}>
       <MemoizedWidgetContent widget={widget} dataPromise={dataPromise} />
@@ -210,6 +214,28 @@ export function DashboardDetailClient({
   const handleEditChart = useCallback((chartId: string) => {
     setEditingChartId(chartId);
   }, []);
+
+  const handleDuplicateWidget = useCallback(
+    async (widget: TDashboardWidget) => {
+      try {
+        const result = await duplicateChartAndAddWidgetAction({
+          workspaceId,
+          dashboardId: dashboard.id,
+          chartId: widget.chartId,
+          layout: widget.layout,
+        });
+        if (!result?.data) {
+          toast.error(getFormattedErrorMessage(result));
+          return;
+        }
+        toast.success(t("workspace.analysis.dashboards.chart_duplicated"));
+        startTransition(() => router.refresh());
+      } catch {
+        toast.error(t("workspace.analysis.dashboards.chart_duplicate_failed"));
+      }
+    },
+    [workspaceId, dashboard.id, router, t, startTransition]
+  );
 
   const handleUndoRemoveWidget = useCallback(
     async (snapshot: TDashboardWidget) => {
@@ -418,6 +444,9 @@ export function DashboardDetailClient({
                       isEditing={isEditing}
                       dataPromise={widgetDataPromises.get(widget.id)}
                       onEdit={isReadOnly ? undefined : () => handleEditChart(widget.chartId)}
+                      // Duplicate is hidden in edit mode: saving edit-mode drafts removes any
+                      // widget not present in the draft, which would delete the fresh copy.
+                      onDuplicate={isReadOnly || isEditing ? undefined : () => handleDuplicateWidget(widget)}
                       onResize={isReadOnly ? undefined : handleEnterEditMode}
                       onRemove={isReadOnly ? undefined : () => handleRemoveWidgetFromMenu(widget.id)}
                     />

--- a/apps/web/modules/ee/analysis/dashboards/components/dashboard-widget.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/components/dashboard-widget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Maximize2Icon, MoreVerticalIcon, SquarePenIcon, TrashIcon } from "lucide-react";
+import { CopyIcon, Maximize2Icon, MoreVerticalIcon, SquarePenIcon, TrashIcon } from "lucide-react";
 import { ReactNode, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
@@ -16,6 +16,7 @@ interface DashboardWidgetProps {
   children: ReactNode;
   isEditing?: boolean;
   onEdit?: () => void;
+  onDuplicate?: () => void;
   onResize?: () => void;
   onRemove?: () => void;
 }
@@ -25,12 +26,13 @@ export function DashboardWidget({
   children,
   isEditing,
   onEdit,
+  onDuplicate,
   onResize,
   onRemove,
 }: Readonly<DashboardWidgetProps>) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
-  const hasMenuActions = Boolean(onEdit || onResize || onRemove);
+  const hasMenuActions = Boolean(onEdit || onDuplicate || onResize || onRemove);
 
   return (
     <div
@@ -65,6 +67,16 @@ export function DashboardWidget({
                   }}>
                   <SquarePenIcon className="mr-2 size-4" />
                   {t("common.edit")}
+                </DropdownMenuItem>
+              )}
+              {onDuplicate && (
+                <DropdownMenuItem
+                  onSelect={() => {
+                    setMenuOpen(false);
+                    onDuplicate();
+                  }}>
+                  <CopyIcon className="mr-2 size-4" />
+                  {t("common.duplicate")}
                 </DropdownMenuItem>
               )}
               {onResize && (

--- a/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.test.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { duplicateChart } from "@/modules/ee/analysis/charts/lib/charts";
+import { addChartToDashboard } from "./dashboards";
+import { duplicateChartAndAddWidget } from "./duplicate-chart-and-add-widget";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    dashboard: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/utils/validate", () => ({
+  validateInputs: vi.fn(),
+}));
+
+vi.mock("@/modules/ee/analysis/charts/lib/charts", () => ({
+  duplicateChart: vi.fn(),
+}));
+
+vi.mock("./dashboards", () => ({
+  addChartToDashboard: vi.fn(),
+}));
+
+const mockDashboardId = "dashboard-abc-123";
+const mockWorkspaceId = "workspace-abc-123";
+const mockUserId = "user-abc-123";
+const mockChartId = "chart-abc-123";
+const mockLayout = { x: 0, y: 0, w: 4, h: 3 };
+
+const mockDuplicatedChart = {
+  id: "chart-copy-123",
+  name: "Test Chart (copy)",
+  type: "bar",
+  query: { measures: ["Feedback.count"] },
+  config: {},
+  feedbackDirectoryId: "directory-abc-123",
+  createdAt: new Date("2025-01-01"),
+  updatedAt: new Date("2025-01-01"),
+};
+
+const mockWidget = {
+  id: "widget-new-123",
+  dashboardId: mockDashboardId,
+  chartId: mockDuplicatedChart.id,
+  layout: mockLayout,
+  order: 1,
+};
+
+const makePrismaError = (code: string) =>
+  new Prisma.PrismaClientKnownRequestError("mock error", { code, clientVersion: "5.0.0" });
+
+describe("duplicateChartAndAddWidget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("duplicates the chart and adds it as a widget on the same dashboard", async () => {
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId } as any);
+    vi.mocked(duplicateChart).mockResolvedValue(mockDuplicatedChart as any);
+    vi.mocked(addChartToDashboard).mockResolvedValue(mockWidget as any);
+
+    const result = await duplicateChartAndAddWidget({
+      dashboardId: mockDashboardId,
+      workspaceId: mockWorkspaceId,
+      chartId: mockChartId,
+      createdBy: mockUserId,
+      layout: mockLayout,
+    });
+
+    expect(result).toEqual({ chart: mockDuplicatedChart, widget: mockWidget });
+    expect(prisma.dashboard.findFirst).toHaveBeenCalledWith({
+      where: { id: mockDashboardId, workspaceId: mockWorkspaceId },
+      select: { id: true },
+    });
+    expect(duplicateChart).toHaveBeenCalledWith(mockChartId, mockWorkspaceId, mockUserId);
+    expect(addChartToDashboard).toHaveBeenCalledWith({
+      dashboardId: mockDashboardId,
+      chartId: mockDuplicatedChart.id,
+      workspaceId: mockWorkspaceId,
+      layout: mockLayout,
+    });
+  });
+
+  test("passes an undefined layout through so the widget gets the chart-type default", async () => {
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId } as any);
+    vi.mocked(duplicateChart).mockResolvedValue(mockDuplicatedChart as any);
+    vi.mocked(addChartToDashboard).mockResolvedValue(mockWidget as any);
+
+    await duplicateChartAndAddWidget({
+      dashboardId: mockDashboardId,
+      workspaceId: mockWorkspaceId,
+      chartId: mockChartId,
+      createdBy: mockUserId,
+    });
+
+    expect(addChartToDashboard).toHaveBeenCalledWith({
+      dashboardId: mockDashboardId,
+      chartId: mockDuplicatedChart.id,
+      workspaceId: mockWorkspaceId,
+      layout: undefined,
+    });
+  });
+
+  test("throws ResourceNotFoundError and does not duplicate when the dashboard is not in the workspace", async () => {
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue(null);
+
+    await expect(
+      duplicateChartAndAddWidget({
+        dashboardId: mockDashboardId,
+        workspaceId: mockWorkspaceId,
+        chartId: mockChartId,
+        createdBy: mockUserId,
+      })
+    ).rejects.toMatchObject({
+      name: "ResourceNotFoundError",
+      resourceType: "Dashboard",
+      resourceId: mockDashboardId,
+    });
+    expect(duplicateChart).not.toHaveBeenCalled();
+    expect(addChartToDashboard).not.toHaveBeenCalled();
+  });
+
+  test("propagates duplicateChart errors without adding a widget", async () => {
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId } as any);
+    vi.mocked(duplicateChart).mockRejectedValue(
+      Object.assign(new Error("Chart not found"), { name: "ResourceNotFoundError" })
+    );
+
+    await expect(
+      duplicateChartAndAddWidget({
+        dashboardId: mockDashboardId,
+        workspaceId: mockWorkspaceId,
+        chartId: mockChartId,
+        createdBy: mockUserId,
+      })
+    ).rejects.toMatchObject({ name: "ResourceNotFoundError" });
+    expect(addChartToDashboard).not.toHaveBeenCalled();
+  });
+
+  test("wraps Prisma errors from the dashboard lookup in DatabaseError", async () => {
+    vi.mocked(prisma.dashboard.findFirst).mockRejectedValue(makePrismaError("P9999"));
+
+    await expect(
+      duplicateChartAndAddWidget({
+        dashboardId: mockDashboardId,
+        workspaceId: mockWorkspaceId,
+        chartId: mockChartId,
+        createdBy: mockUserId,
+      })
+    ).rejects.toMatchObject({ name: "DatabaseError" });
+    expect(duplicateChart).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.ts
@@ -1,0 +1,62 @@
+import "server-only";
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { TWidgetLayout, ZWidgetLayout } from "@formbricks/types/analysis";
+import { ZId } from "@formbricks/types/common";
+import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { validateInputs } from "@/lib/utils/validate";
+import { duplicateChart } from "@/modules/ee/analysis/charts/lib/charts";
+import { addChartToDashboard } from "./dashboards";
+
+/**
+ * Deep-copies a chart (new UUID, "(copy)" name suffix, copied query/config) and adds the
+ * new chart as a widget on the given dashboard. The dashboard is verified first so a
+ * missing dashboard does not leave an orphaned chart copy behind.
+ */
+export const duplicateChartAndAddWidget = async ({
+  dashboardId,
+  workspaceId,
+  chartId,
+  createdBy,
+  layout,
+}: {
+  dashboardId: string;
+  workspaceId: string;
+  chartId: string;
+  createdBy: string;
+  layout?: TWidgetLayout;
+}) => {
+  validateInputs(
+    [dashboardId, ZId],
+    [workspaceId, ZId],
+    [chartId, ZId],
+    [createdBy, ZId],
+    [layout, ZWidgetLayout.optional()]
+  );
+
+  try {
+    const dashboard = await prisma.dashboard.findFirst({
+      where: { id: dashboardId, workspaceId },
+      select: { id: true },
+    });
+
+    if (!dashboard) {
+      throw new ResourceNotFoundError("Dashboard", dashboardId);
+    }
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      throw new DatabaseError(error.message);
+    }
+    throw error;
+  }
+
+  const chart = await duplicateChart(chartId, workspaceId, createdBy);
+  const widget = await addChartToDashboard({
+    dashboardId,
+    chartId: chart.id,
+    workspaceId,
+    layout,
+  });
+
+  return { chart, widget };
+};

--- a/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.ts
@@ -34,20 +34,21 @@ export const duplicateChartAndAddWidget = async ({
     [layout, ZWidgetLayout.optional()]
   );
 
+  let dashboard;
   try {
-    const dashboard = await prisma.dashboard.findFirst({
+    dashboard = await prisma.dashboard.findFirst({
       where: { id: dashboardId, workspaceId },
       select: { id: true },
     });
-
-    if (!dashboard) {
-      throw new ResourceNotFoundError("Dashboard", dashboardId);
-    }
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       throw new DatabaseError(error.message);
     }
     throw error;
+  }
+
+  if (!dashboard) {
+    throw new ResourceNotFoundError("Dashboard", dashboardId);
   }
 
   const chart = await duplicateChart(chartId, workspaceId, createdBy);


### PR DESCRIPTION
## What does this PR do?

Adds a **Duplicate** action to the dashboard widget dropdown menu (previously only Edit / Resize / Remove), as requested in release QA (ENG-1754).

Contributes to ENG-1796

Behavior (aligned with the existing chart-row duplicate):

- Deep-copies the underlying chart via the existing `duplicateChart` logic: new UUID, `"(copy)"` name suffix (with next-number increment on collisions), `createdBy` set to the current user, query/config deep-copied.
- Adds the new chart as a widget on the **same dashboard**, reusing the source widget's width/height and placing it below the existing widgets (via `addChartToDashboard`).
- Shows a success toast ("Chart duplicated and added to dashboard") and refreshes the page.

Implementation notes:

- New service `duplicateChartAndAddWidget` (`apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.ts`) composes the existing `duplicateChart` + `addChartToDashboard`; the dashboard is verified first so a missing dashboard doesn't leave an orphaned chart copy.
- New `duplicateChartAndAddWidgetAction` in `dashboards/actions.ts` following the module's patterns: `authenticatedActionClient`, Zod input schema, `checkWorkspaceAccess(..., "readWrite")`, dashboards-enabled license check, audit logging, `revalidatePath`.
- The Duplicate item is hidden in dashboard edit mode: saving edit-mode drafts removes any widget not present in the draft, which would immediately delete the fresh copy.
- New i18n keys (en-US only; other locales are machine-generated): `workspace.analysis.dashboards.chart_duplicated`, `workspace.analysis.dashboards.chart_duplicate_failed`. Menu label reuses `common.duplicate`.

## How should this be tested?

- Open a dashboard with at least one widget.
- Click the widget's ⋯ menu → **Duplicate**.
- A success toast appears and a new widget backed by a chart named `<original name> (copy)` shows up on the same dashboard (below existing widgets, same size as the source widget).
- Edit the copied chart (widget ⋯ → Edit, change query/type/name) — the original chart must remain unchanged.
- Duplicating again yields `(copy 2)`, etc.
- The copy also appears in the workspace Charts list with the current user as creator.
- In dashboard edit mode the Duplicate item is not offered (Edit/Resize/Remove still are); for read-only members the menu is hidden entirely.

Unit tests: `apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.test.ts` (success path incl. layout pass-through, dashboard-not-found without orphan chart, chart-duplication error propagation, Prisma error wrapping). Existing `charts.test.ts` and `dashboards.test.ts` pass unchanged (66 tests total).

```
Test Files  3 passed (3)
     Tests  66 passed (66)
```

ESLint clean on touched files; `tsc --noEmit` output is byte-identical to main (no new type errors). No full build / dev server run (scoped verification only).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
