### PR TITLE
fix(charts): remove leading gap on category bar charts

### DIFF
--- a/apps/web/modules/ee/analysis/charts/components/cartesian-chart.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/cartesian-chart.tsx
@@ -26,6 +26,10 @@ export interface CartesianChartProps {
   /** False for measure-only charts with no real category: hides the meaningless x-axis tick and
    * tooltip header (which would otherwise show the fallback measure value, e.g. a stray "1"). */
   hasCategoryAxis?: boolean;
+  /** Overrides whether the tooltip header is hidden (defaults to `!hasCategoryAxis`). Pivoted
+   * measure charts keep their category axis but hide the header, since each tooltip row already
+   * carries the measure label and a header would just repeat it. */
+  tooltipHideLabel?: boolean;
 }
 
 const TARGET_TICK_COUNT = 5;
@@ -112,6 +116,7 @@ export function CartesianChart({
   zeroBaseline = false,
   xAxisTickFormatter,
   hasCategoryAxis = true,
+  tooltipHideLabel,
 }: Readonly<CartesianChartProps>) {
   const yScale = computeYAxis(data, dataKeys, zeroBaseline);
 
@@ -141,7 +146,10 @@ export function CartesianChart({
           />
           <ChartTooltip
             content={
-              <PolishedChartTooltip labelFormatter={xAxisTickFormatter} hideLabel={!hasCategoryAxis} />
+              <PolishedChartTooltip
+                labelFormatter={xAxisTickFormatter}
+                hideLabel={tooltipHideLabel ?? !hasCategoryAxis}
+              />
             }
             cursor={tooltipCursor}
             // Measure-only charts (no category) have one bar per measure, so a shared tooltip would

--- a/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
@@ -197,7 +197,8 @@ export function ChartRenderer({ chartType, data, query }: Readonly<ChartRenderer
         const measureData = pivotMeasuresToCategories(sortedData, dataKeys, (key) =>
           formatCubeColumnHeader(key, t)
         );
-        const formatMeasureLabel = (value: unknown) => formatCubeColumnHeader(String(value ?? ""), t);
+        const formatMeasureLabel = (value: unknown) =>
+          formatCubeColumnHeader(typeof value === "string" ? value : "", t);
         return (
           <CartesianChart
             chart={BarChart}

--- a/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
@@ -23,6 +23,7 @@ import {
   getMeasureAxisLabel,
   getTranslatedDimensionValueLabel,
   isNotEnrichedDimensionValue,
+  sortMeasureIdsForCategoryAxis,
   sortRowsByEnumDimension,
 } from "@/modules/ee/analysis/lib/schema-definition";
 import type { TChartDataRow, TChartType } from "@/modules/ee/analysis/types/analysis";
@@ -195,7 +196,10 @@ export function ChartRenderer({ chartType, data, query }: Readonly<ChartRenderer
       // (ENG-1796). Pivot the measures into categories so the bars fill the axis from the
       // left like any other category bar chart, labelled by measure on the x-axis.
       if (!hasCategoryAxis) {
-        const measureData = pivotMeasuresToCategories(sortedData, dataKeys, (key) =>
+        // Sentiment measures pivot into the scale order the sentiment *dimension* axis uses,
+        // so this chart and a dimension-grouped one read in the same direction.
+        const axisKeys = sortMeasureIdsForCategoryAxis(dataKeys);
+        const measureData = pivotMeasuresToCategories(sortedData, axisKeys, (key) =>
           formatCubeColumnHeader(key, t)
         );
         // Ticks use the short value label ("Very positive") — the full measure label is too

--- a/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
@@ -10,8 +10,11 @@ import {
   CHART_BRAND_DARK,
   CHART_MEASURE_COLORS,
   CHART_NOT_ENRICHED_COLOR,
+  PIVOTED_MEASURE_KEY,
+  PIVOTED_VALUE_KEY,
   formatCellValue,
   formatXAxisTick,
+  pivotMeasuresToCategories,
   preparePieData,
 } from "@/modules/ee/analysis/charts/lib/chart-utils";
 import {
@@ -185,6 +188,40 @@ export function ChartRenderer({ chartType, data, query }: Readonly<ChartRenderer
 
   switch (chartType) {
     case "bar": {
+      // Measure-only queries (no dimension or time grouping) return a single row with one
+      // column per measure. Rendered as N bar series that row forms a single category band
+      // that recharts centers in the plot, leaving a wide empty gap before the first bar
+      // (ENG-1796). Pivot the measures into categories so the bars fill the axis from the
+      // left like any other category bar chart, labelled by measure on the x-axis.
+      if (!hasCategoryAxis) {
+        const measureData = pivotMeasuresToCategories(sortedData, dataKeys, (key) =>
+          formatCubeColumnHeader(key, t)
+        );
+        const formatMeasureLabel = (value: unknown) => formatCubeColumnHeader(String(value ?? ""), t);
+        return (
+          <CartesianChart
+            chart={BarChart}
+            data={measureData}
+            xAxisKey={PIVOTED_MEASURE_KEY}
+            dataKeys={[PIVOTED_VALUE_KEY]}
+            chartConfig={chartConfig}
+            tooltipCursor={false}
+            zeroBaseline
+            tooltipHideLabel
+            xAxisTickFormatter={formatMeasureLabel}>
+            <Bar dataKey={PIVOTED_VALUE_KEY} fill={CHART_BRAND_DARK} radius={4}>
+              <LabelList
+                dataKey={PIVOTED_VALUE_KEY}
+                position="top"
+                className="fill-foreground"
+                fontSize={11}
+                formatter={(value: unknown) => formatCellValue(value)}
+              />
+            </Bar>
+          </CartesianChart>
+        );
+      }
+
       // Setting `fill` on the data row (not via <Cell>) is what propagates
       // the per-bar colour into the tooltip payload as well as the SVG.
       const barData = isMultiMeasure

--- a/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
@@ -20,6 +20,7 @@ import {
 import {
   FEEDBACK_MEASURE_IDS,
   formatCubeColumnHeader,
+  getMeasureAxisLabel,
   getTranslatedDimensionValueLabel,
   isNotEnrichedDimensionValue,
   sortRowsByEnumDimension,
@@ -197,8 +198,11 @@ export function ChartRenderer({ chartType, data, query }: Readonly<ChartRenderer
         const measureData = pivotMeasuresToCategories(sortedData, dataKeys, (key) =>
           formatCubeColumnHeader(key, t)
         );
+        // Ticks use the short value label ("Very positive") — the full measure label is too
+        // wide, so recharts would thin the ticks and bars would lose their name. The tooltip
+        // keeps the full label via tooltipLabel.
         const formatMeasureLabel = (value: unknown) =>
-          formatCubeColumnHeader(typeof value === "string" ? value : "", t);
+          getMeasureAxisLabel(typeof value === "string" ? value : "", t);
         return (
           <CartesianChart
             chart={BarChart}

--- a/apps/web/modules/ee/analysis/charts/components/polished-tooltip.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/polished-tooltip.tsx
@@ -13,7 +13,7 @@ interface TooltipPayloadItem {
   name?: string | number;
   value?: unknown;
   color?: string;
-  payload?: { fill?: string };
+  payload?: { fill?: string; tooltipLabel?: string };
 }
 
 interface RechartsTooltipProps {
@@ -48,13 +48,16 @@ export const PolishedChartTooltip = ({
       <div className="flex flex-col gap-1.5">
         {payload.map((item) => {
           const key = item.dataKey ?? String(item.name ?? "");
+          // Rows pivoted from measures (see pivotMeasuresToCategories) carry their translated
+          // label on the row itself; otherwise the dataKey is a Cube column we can format.
+          const rowLabel = item.payload?.tooltipLabel ?? formatCubeColumnHeader(key, t);
           // payload.fill (per-row data.fill / pie <Cell>) wins over the Bar's series fallback.
           const indicatorColor = item.payload?.fill ?? item.color ?? CHART_BRAND_DARK;
           return (
             <div key={key} className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2">
                 <div className="size-2.5 shrink-0 rounded-full" style={{ backgroundColor: indicatorColor }} />
-                <span className="text-muted-foreground text-sm">{formatCubeColumnHeader(key, t)}</span>
+                <span className="text-muted-foreground text-sm">{rowLabel}</span>
               </div>
               <span className="text-foreground text-sm font-medium tabular-nums">
                 {formatCellValue(item.value)}

--- a/apps/web/modules/ee/analysis/charts/lib/chart-utils.test.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/chart-utils.test.ts
@@ -3,8 +3,11 @@ import {
   CHART_BRAND_DARK,
   CHART_MEASURE_COLORS,
   CHART_NOT_ENRICHED_COLOR,
+  PIVOTED_MEASURE_KEY,
+  PIVOTED_VALUE_KEY,
   formatCellValue,
   formatXAxisTick,
+  pivotMeasuresToCategories,
   preparePieData,
   resolveChartType,
 } from "./chart-utils";
@@ -138,6 +141,53 @@ describe("chart-utils", () => {
     test("converts boolean and bigint", () => {
       expect(formatCellValue(true)).toBe("true");
       expect(formatCellValue(123n)).toBe("123");
+    });
+  });
+
+  describe("pivotMeasuresToCategories", () => {
+    const label = (key: string) => `label:${key}`;
+
+    test("pivots a single measure row into one category row per measure", () => {
+      const data = [{ "F.veryPositiveCount": 3, "F.negativeCount": "1" }];
+      const result = pivotMeasuresToCategories(data, ["F.veryPositiveCount", "F.negativeCount"], label);
+      expect(result).toEqual([
+        {
+          [PIVOTED_MEASURE_KEY]: "F.veryPositiveCount",
+          [PIVOTED_VALUE_KEY]: 3,
+          tooltipLabel: "label:F.veryPositiveCount",
+          fill: CHART_MEASURE_COLORS[0],
+        },
+        {
+          [PIVOTED_MEASURE_KEY]: "F.negativeCount",
+          [PIVOTED_VALUE_KEY]: 1,
+          tooltipLabel: "label:F.negativeCount",
+          fill: CHART_MEASURE_COLORS[1],
+        },
+      ]);
+    });
+
+    test("keeps the given measure order so bars fill the axis from the left", () => {
+      const data = [{ b: 2, a: 1 }];
+      const result = pivotMeasuresToCategories(data, ["a", "b"], label);
+      expect(result.map((row) => row[PIVOTED_MEASURE_KEY])).toEqual(["a", "b"]);
+    });
+
+    test("renders missing, null, and non-numeric values as 0 so empty measures keep a slot", () => {
+      const data = [{ a: null, b: "n/a" }];
+      const result = pivotMeasuresToCategories(data, ["a", "b", "missing"], label);
+      expect(result.map((row) => row[PIVOTED_VALUE_KEY])).toEqual([0, 0, 0]);
+    });
+
+    test("handles empty data by emitting zero rows per measure", () => {
+      const result = pivotMeasuresToCategories([], ["a"], label);
+      expect(result).toHaveLength(1);
+      expect(result[0][PIVOTED_VALUE_KEY]).toBe(0);
+    });
+
+    test("cycles the palette when there are more measures than colors", () => {
+      const keys = Array.from({ length: CHART_MEASURE_COLORS.length + 1 }, (_, i) => `m${i}`);
+      const result = pivotMeasuresToCategories([{}], keys, label);
+      expect(result.at(-1)?.fill).toBe(CHART_MEASURE_COLORS[0]);
     });
   });
 

--- a/apps/web/modules/ee/analysis/charts/lib/chart-utils.test.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/chart-utils.test.ts
@@ -178,7 +178,7 @@ describe("chart-utils", () => {
       expect(result.map((row) => row[PIVOTED_VALUE_KEY])).toEqual([0, 0, 0]);
     });
 
-    test("handles empty data by emitting zero rows per measure", () => {
+    test("emits one zero-value row per measure key when data is empty", () => {
       const result = pivotMeasuresToCategories([], ["a"], label);
       expect(result).toHaveLength(1);
       expect(result[0][PIVOTED_VALUE_KEY]).toBe(0);

--- a/apps/web/modules/ee/analysis/charts/lib/chart-utils.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/chart-utils.ts
@@ -71,6 +71,37 @@ export const preparePieData = (
   return { processedData, colors };
 };
 
+/** Category key for rows produced by {@link pivotMeasuresToCategories}. */
+export const PIVOTED_MEASURE_KEY = "measure";
+/** Value key for rows produced by {@link pivotMeasuresToCategories}. */
+export const PIVOTED_VALUE_KEY = "value";
+
+/**
+ * Pivot a measure-only result row (one row with one column per measure) into one category row
+ * per measure. Rendering the raw row as N bar series leaves recharts with a single category
+ * band centered in the plot — a wide empty gap before the first bar. Pivoted, the measures
+ * become ordinary categories that fill the x-axis from the left.
+ *
+ * Missing/non-numeric values become 0 so empty measures keep a visible, hoverable slot.
+ * `formatLabel` supplies the translated measure label stored as `tooltipLabel` on each row.
+ */
+export function pivotMeasuresToCategories(
+  data: TChartDataRow[],
+  measureKeys: string[],
+  formatLabel: (measureKey: string) => string
+): TChartDataRow[] {
+  const row = data[0] ?? {};
+  return measureKeys.map((key, index) => {
+    const num = Number(row[key]);
+    return {
+      [PIVOTED_MEASURE_KEY]: key,
+      [PIVOTED_VALUE_KEY]: Number.isFinite(num) ? num : 0,
+      tooltipLabel: formatLabel(key),
+      fill: CHART_MEASURE_COLORS[index % CHART_MEASURE_COLORS.length],
+    };
+  });
+}
+
 // parseISO accepts year-only inputs (e.g. "1000" → Jan 1, 1000); require a
 // full YYYY-MM-DD prefix so numeric category labels aren't formatted as dates.
 const ISO_DATE_PREFIX = /^\d{4}-\d{2}-\d{2}/;

--- a/apps/web/modules/ee/analysis/lib/schema-definition.test.ts
+++ b/apps/web/modules/ee/analysis/lib/schema-definition.test.ts
@@ -19,6 +19,7 @@ import {
   isEnrichmentDimensionId,
   isNotEnrichedDimensionValue,
   isSelectableValueDimension,
+  sortMeasureIdsForCategoryAxis,
   sortRowsByEnumDimension,
 } from "./schema-definition";
 
@@ -304,6 +305,48 @@ describe("schema-definition", () => {
     test("does not label empty values on non-enrichment dimensions", () => {
       expect(getTranslatedDimensionValueLabel("FeedbackRecords.sourceName", "", t)).toBeUndefined();
       expect(getTranslatedDimensionValueLabel("FeedbackRecords.sourceName", null, t)).toBeUndefined();
+    });
+  });
+
+  describe("sortMeasureIdsForCategoryAxis", () => {
+    test("sorts sentiment count measures into the sentiment scale order", () => {
+      const pickerOrder = [
+        "FeedbackRecords.veryPositiveCount",
+        "FeedbackRecords.positiveCount",
+        "FeedbackRecords.neutralCount",
+        "FeedbackRecords.negativeCount",
+        "FeedbackRecords.veryNegativeCount",
+        "FeedbackRecords.mixedCount",
+      ];
+      expect(sortMeasureIdsForCategoryAxis(pickerOrder)).toEqual([
+        "FeedbackRecords.veryNegativeCount",
+        "FeedbackRecords.negativeCount",
+        "FeedbackRecords.neutralCount",
+        "FeedbackRecords.positiveCount",
+        "FeedbackRecords.veryPositiveCount",
+        "FeedbackRecords.mixedCount",
+      ]);
+    });
+
+    test("keeps non-sentiment measures in their relative order, after sentiment ones", () => {
+      const ids = [
+        "FeedbackRecords.joyCount",
+        "FeedbackRecords.positiveCount",
+        "FeedbackRecords.count",
+        "FeedbackRecords.veryNegativeCount",
+      ];
+      expect(sortMeasureIdsForCategoryAxis(ids)).toEqual([
+        "FeedbackRecords.veryNegativeCount",
+        "FeedbackRecords.positiveCount",
+        "FeedbackRecords.joyCount",
+        "FeedbackRecords.count",
+      ]);
+    });
+
+    test("does not mutate the input array", () => {
+      const ids = ["FeedbackRecords.positiveCount", "FeedbackRecords.veryNegativeCount"];
+      sortMeasureIdsForCategoryAxis(ids);
+      expect(ids).toEqual(["FeedbackRecords.positiveCount", "FeedbackRecords.veryNegativeCount"]);
     });
   });
 

--- a/apps/web/modules/ee/analysis/lib/schema-definition.test.ts
+++ b/apps/web/modules/ee/analysis/lib/schema-definition.test.ts
@@ -13,6 +13,7 @@ import {
   formatCubeColumnHeader,
   getFieldById,
   getFilterOperatorsForType,
+  getMeasureAxisLabel,
   getTranslatedDimensionValueLabel,
   getTranslatedFieldLabel,
   isEnrichmentDimensionId,
@@ -303,6 +304,39 @@ describe("schema-definition", () => {
     test("does not label empty values on non-enrichment dimensions", () => {
       expect(getTranslatedDimensionValueLabel("FeedbackRecords.sourceName", "", t)).toBeUndefined();
       expect(getTranslatedDimensionValueLabel("FeedbackRecords.sourceName", null, t)).toBeUndefined();
+    });
+  });
+
+  describe("getMeasureAxisLabel", () => {
+    const t = ((key: string) => key) as TFunction;
+
+    test("labels sentiment count measures with their short value label", () => {
+      expect(getMeasureAxisLabel("FeedbackRecords.veryPositiveCount", t)).toBe(
+        "workspace.analysis.charts.sentiment_value_very_positive"
+      );
+      expect(getMeasureAxisLabel("FeedbackRecords.mixedCount", t)).toBe(
+        "workspace.analysis.charts.sentiment_value_mixed"
+      );
+    });
+
+    test("labels emotion count measures with their short value label", () => {
+      expect(getMeasureAxisLabel("FeedbackRecords.joyCount", t)).toBe(
+        "workspace.analysis.charts.emotion_value_joy"
+      );
+      expect(getMeasureAxisLabel("FeedbackRecords.disgustCount", t)).toBe(
+        "workspace.analysis.charts.emotion_value_disgust"
+      );
+    });
+
+    test("falls back to the full column header for other measures", () => {
+      expect(getMeasureAxisLabel("FeedbackRecords.count", t)).toBe(
+        "workspace.analysis.charts.field_label_count"
+      );
+      // promoterCount is an NPS measure, not a sentiment/emotion enum measure
+      expect(getMeasureAxisLabel("FeedbackRecords.promoterCount", t)).toBe(
+        "workspace.analysis.charts.field_label_promoter_count"
+      );
+      expect(getMeasureAxisLabel("Some.unknownKey", t)).toBe("Unknown Key");
     });
   });
 

--- a/apps/web/modules/ee/analysis/lib/schema-definition.ts
+++ b/apps/web/modules/ee/analysis/lib/schema-definition.ts
@@ -438,6 +438,25 @@ export function getTranslatedDimensionValueLabel(
 }
 
 /**
+ * Short x-axis label for a per-measure category axis (measure-only bar charts, where each
+ * measure is its own bar). Sentiment/emotion count measures reuse their enum value label
+ * ("Very positive") — the full measure label ("Sentiment: Very positive") is too wide for
+ * ticks, so recharts drops the overlapping ones and leaves bars unlabelled. Other measures
+ * fall back to their full column header.
+ */
+export function getMeasureAxisLabel(measureId: string, t: TFunction): string {
+  const sentiment = SENTIMENT_MEASURE_ORDER.find(
+    (value) => `FeedbackRecords.${toCountMeasureId(value)}Count` === measureId
+  );
+  const emotion = EMOTION_MEASURE_ORDER.find((value) => `FeedbackRecords.${value}Count` === measureId);
+  return (
+    (sentiment ? getTranslatedSentimentValueLabel(sentiment, t) : undefined) ??
+    (emotion ? getTranslatedEmotionValueLabel(emotion, t) : undefined) ??
+    formatCubeColumnHeader(measureId, t)
+  );
+}
+
+/**
  * Sort chart rows into the sentiment scale order (very_negative → very_positive, mixed
  * last) when the x-axis is the sentiment dimension. Unknown values keep their relative
  * position at the end; other dimensions are returned unchanged.

--- a/apps/web/modules/ee/analysis/lib/schema-definition.ts
+++ b/apps/web/modules/ee/analysis/lib/schema-definition.ts
@@ -437,6 +437,27 @@ export function getTranslatedDimensionValueLabel(
   return undefined;
 }
 
+// Sentiment count measure ids in the sentiment *scale* order (very_negative → very_positive,
+// mixed last) — the order the sentiment dimension axis uses.
+const SENTIMENT_COUNT_MEASURE_IDS_BY_SCALE: string[] = SENTIMENT_VALUE_ORDER.map(
+  (value) => `FeedbackRecords.${toCountMeasureId(value)}Count`
+);
+
+/**
+ * Sort measure ids for a per-measure category axis (measure-only bar charts, where each
+ * measure is its own bar). Sentiment count measures follow the sentiment scale order so the
+ * pivoted chart reads in the same direction (and with the same per-slot colors) as a chart
+ * grouped by the sentiment dimension — not the positive-first SENTIMENT_MEASURE_ORDER used
+ * for series/legend lists. Other measures keep their relative order after them.
+ */
+export function sortMeasureIdsForCategoryAxis(measureIds: string[]): string[] {
+  const rank = (id: string): number => {
+    const index = SENTIMENT_COUNT_MEASURE_IDS_BY_SCALE.indexOf(id);
+    return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+  };
+  return [...measureIds].sort((a, b) => rank(a) - rank(b));
+}
+
 /**
  * Short x-axis label for a per-measure category axis (measure-only bar charts, where each
  * measure is its own bar). Sentiment/emotion count measures reuse their enum value label


### PR DESCRIPTION
## What does this PR do?

Contributes to ENG-1796

Bar charts built from measures only (e.g. the 6 "Sentiment: …" or "Emotion: …" count measures with no grouping) rendered with a large empty gap before the first bar — the bars looked centered instead of starting at the left, as flagged in release QA (ENG-1754).

**Root cause:** a measure-only query (no dimension and no time grouping) returns a single result row with one column per measure. `ChartRenderer` rendered that row as N `<Bar>` series, so Recharts saw a single category band with N grouped bars and centered the band in the plot area — the "gap" is the empty left half of the lone category slot, and it grows with chart width.

**Fix:** for the measure-only case, pivot the measures into categories (`pivotMeasuresToCategories` in `chart-utils.ts`, colocated unit tests added). Each measure becomes its own category row (`{ measure, value, fill, tooltipLabel }`), rendered as a single-series bar chart, so the bars fill the x-axis from the left like any standard category bar chart. As a side effect this also resolves the PM's secondary asks from the ticket:

- Each bar is labelled by its (translated) measure name on the x-axis.
- Each bar shows its value on top via `LabelList` — zero-count measures display a visible "0".
- The tooltip is shared per category column, so hovering the slot of a zero-height bar still shows e.g. "Very positive — 0" (no ghost divs needed).
- Sentiment are not consistently sorted in the charts (see the "before" and "after" screenshots)

Charts **with** a dimension (e.g. Responses grouped by Sentiment) and multi-measure charts **with** a dimension (grouped series + legend) go through the untouched code path and are unchanged. Line/area/pie/big-number are unchanged.

Support changes:

- `CartesianChart`: new optional `tooltipHideLabel` prop to decouple the tooltip header from `hasCategoryAxis` (the pivoted chart has a real category axis but hides the redundant header, since each tooltip row carries the measure label).
- `PolishedChartTooltip`: a row-level `tooltipLabel` on the payload now takes precedence over deriving the label from the Cube column key (needed because the pivoted series' dataKey is the generic `value`).

> Note: I could not run the app in this environment — before/after screenshots need to be added by a human reviewer.

## How should this be tested?

1. Analysis → Charts → create a **bar** chart.
2. Add the 6 **Sentiment: …** count measures ("Sentiment: Very negative" … "Sentiment: Very positive", "Sentiment: Mixed"). Add **no** grouping (no dimension, no time grouping).
   - Expected: 6 bars starting at the **left** edge of the plot, one per measure, x-axis ticks showing the measure names, value labels on top of each bar (including "0" for empty ones), and hovering a zero-count column shows a tooltip like "Very positive — 0".
3. Repeat with the 6 **Emotion: …** count measures — same expectations.
4. Regression — chart **with** a dimension: bar chart with "Responses" grouped by **Sentiment**. Expected: unchanged rendering (per-category coloured bars, enum ordering, "Not enriched" gray bucket, value labels on top).
5. Regression — multi-measure **with** a dimension (e.g. two count measures grouped by Source Name): unchanged grouped bars with legend.
6. Single measure with no grouping (e.g. just "Responses") as a bar chart: now renders one left-aligned bar labelled with the measure name instead of a lone centered bar.

Verification run locally (scoped):

- `pnpm exec vitest run modules/ee/analysis` → 22 files, 284 tests passed (includes 5 new `pivotMeasuresToCategories` tests).
- `pnpm exec eslint` on all 5 touched files → clean.
- `pnpm typecheck` → no errors in touched files (remaining errors are pre-existing unbuilt-workspace-package resolution noise in a fresh worktree).
- `pnpm exec prettier --check` on touched files → clean.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary

before:
<img width="1174" height="637" alt="Screenshot 2026-07-15 at 18 53 20" src="https://github.com/user-attachments/assets/7e34a483-adee-4f7f-8d3f-128d95b3c017" />

after:
<img width="1158" height="712" alt="image" src="https://github.com/user-attachments/assets/7c25553e-cf3d-4ac1-98c7-60aff0d6ecea" />


