### PR TITLE
fix(charts): close chart dialog on Escape and show chart name in edit title

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -1595,7 +1595,7 @@ checksums:
     workspace/analysis/charts/dimensions_toggle_description: 31eb28f3c83c04bbe37799758ca9f595
     workspace/analysis/charts/edit_chart_description: 822890e4b6068096e2fe8b7b78b4474f
     workspace/analysis/charts/edit_chart_title: fd3e7f8c53280bfad8f4034c055f4c71
-    workspace/analysis/charts/edit_chart_title_named: 0fc586f9782afaccd816159be672860c
+    workspace/analysis/charts/edit_chart_title_named: 216b4226fb611b3694bc222026722845
     workspace/analysis/charts/emotion_value_anger: 4fd64fc804c247fc3fcbc7dc147b62fe
     workspace/analysis/charts/emotion_value_disgust: e5860fbfc609c8c8686db8a18cadf932
     workspace/analysis/charts/emotion_value_fear: b7621ac47c2543dff100f55f948df8cf

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -1595,6 +1595,7 @@ checksums:
     workspace/analysis/charts/dimensions_toggle_description: 31eb28f3c83c04bbe37799758ca9f595
     workspace/analysis/charts/edit_chart_description: 822890e4b6068096e2fe8b7b78b4474f
     workspace/analysis/charts/edit_chart_title: fd3e7f8c53280bfad8f4034c055f4c71
+    workspace/analysis/charts/edit_chart_title_named: 0fc586f9782afaccd816159be672860c
     workspace/analysis/charts/emotion_value_anger: 4fd64fc804c247fc3fcbc7dc147b62fe
     workspace/analysis/charts/emotion_value_disgust: e5860fbfc609c8c8686db8a18cadf932
     workspace/analysis/charts/emotion_value_fear: b7621ac47c2543dff100f55f948df8cf

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "Gruppiere Daten nach Stimmung, Fragetyp und anderen Dimensionen.",
         "edit_chart_description": "Sieh dir deine Diagrammkonfiguration an und bearbeite sie.",
         "edit_chart_title": "Diagramm bearbeiten",
-        "edit_chart_title_named": "Diagramm \"{{name}}\" bearbeiten",
+        "edit_chart_title_named": "„{name}“ bearbeiten",
         "emotion_value_anger": "Wut",
         "emotion_value_disgust": "Ekel",
         "emotion_value_fear": "Angst",

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "Gruppiere Daten nach Stimmung, Fragetyp und anderen Dimensionen.",
         "edit_chart_description": "Sieh dir deine Diagrammkonfiguration an und bearbeite sie.",
         "edit_chart_title": "Diagramm bearbeiten",
+        "edit_chart_title_named": "Diagramm \"{{name}}\" bearbeiten",
         "emotion_value_anger": "Wut",
         "emotion_value_disgust": "Ekel",
         "emotion_value_fear": "Angst",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "Group data by sentiment, question type, and other dimensions.",
         "edit_chart_description": "View and edit your chart configuration.",
         "edit_chart_title": "Edit Chart",
-        "edit_chart_title_named": "Edit \"{{name}}\" Chart",
+        "edit_chart_title_named": "Edit \"{name}\"",
         "emotion_value_anger": "Anger",
         "emotion_value_disgust": "Disgust",
         "emotion_value_fear": "Fear",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "Group data by sentiment, question type, and other dimensions.",
         "edit_chart_description": "View and edit your chart configuration.",
         "edit_chart_title": "Edit Chart",
+        "edit_chart_title_named": "Edit \"{{name}}\" Chart",
         "emotion_value_anger": "Anger",
         "emotion_value_disgust": "Disgust",
         "emotion_value_fear": "Fear",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "Agrupa los datos por sentimiento, tipo de pregunta y otras dimensiones.",
         "edit_chart_description": "Visualiza y edita la configuración de tu gráfico.",
         "edit_chart_title": "Editar gráfico",
+        "edit_chart_title_named": "Editar gráfico \"{{name}}\"",
         "emotion_value_anger": "Enfado",
         "emotion_value_disgust": "Disgusto",
         "emotion_value_fear": "Miedo",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "Agrupa los datos por sentimiento, tipo de pregunta y otras dimensiones.",
         "edit_chart_description": "Visualiza y edita la configuración de tu gráfico.",
         "edit_chart_title": "Editar gráfico",
-        "edit_chart_title_named": "Editar gráfico \"{{name}}\"",
+        "edit_chart_title_named": "Editar \"{name}\"",
         "emotion_value_anger": "Enfado",
         "emotion_value_disgust": "Disgusto",
         "emotion_value_fear": "Miedo",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "Groupe les données par sentiment, type de question et autres dimensions.",
         "edit_chart_description": "Consultez et modifiez la configuration de votre graphique.",
         "edit_chart_title": "Modifier le graphique",
+        "edit_chart_title_named": "Modifier le graphique \"{{name}}\"",
         "emotion_value_anger": "Colère",
         "emotion_value_disgust": "Dégoût",
         "emotion_value_fear": "Peur",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "Groupe les données par sentiment, type de question et autres dimensions.",
         "edit_chart_description": "Consultez et modifiez la configuration de votre graphique.",
         "edit_chart_title": "Modifier le graphique",
-        "edit_chart_title_named": "Modifier le graphique \"{{name}}\"",
+        "edit_chart_title_named": "Modifier \"{name}\"",
         "emotion_value_anger": "Colère",
         "emotion_value_disgust": "Dégoût",
         "emotion_value_fear": "Peur",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "Adatok csoportosítása hangulat, kérdéstípus és egyéb dimenziók szerint.",
         "edit_chart_description": "Diagram beállításainak megtekintése és szerkesztése.",
         "edit_chart_title": "Diagram szerkesztése",
-        "edit_chart_title_named": "\"{{name}}\" diagram szerkesztése",
+        "edit_chart_title_named": "„{name}“ szerkesztése",
         "emotion_value_anger": "Düh",
         "emotion_value_disgust": "Undor",
         "emotion_value_fear": "Félelem",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "Adatok csoportosítása hangulat, kérdéstípus és egyéb dimenziók szerint.",
         "edit_chart_description": "Diagram beállításainak megtekintése és szerkesztése.",
         "edit_chart_title": "Diagram szerkesztése",
+        "edit_chart_title_named": "\"{{name}}\" diagram szerkesztése",
         "emotion_value_anger": "Düh",
         "emotion_value_disgust": "Undor",
         "emotion_value_fear": "Félelem",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "センチメント、質問タイプ、その他のディメンションでデータをグループ化します。",
         "edit_chart_description": "チャート設定を表示および編集します。",
         "edit_chart_title": "チャートを編集",
-        "edit_chart_title_named": "「{{name}}」チャートを編集",
+        "edit_chart_title_named": "「{name}」を編集",
         "emotion_value_anger": "怒り",
         "emotion_value_disgust": "嫌悪",
         "emotion_value_fear": "恐れ",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "センチメント、質問タイプ、その他のディメンションでデータをグループ化します。",
         "edit_chart_description": "チャート設定を表示および編集します。",
         "edit_chart_title": "チャートを編集",
+        "edit_chart_title_named": "「{{name}}」チャートを編集",
         "emotion_value_anger": "怒り",
         "emotion_value_disgust": "嫌悪",
         "emotion_value_fear": "恐れ",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "Groepeer data op sentiment, vraagtype en andere dimensies.",
         "edit_chart_description": "Bekijk en bewerk je diagramconfiguratie.",
         "edit_chart_title": "Diagram bewerken",
+        "edit_chart_title_named": "Grafiek \"{{name}}\" bewerken",
         "emotion_value_anger": "Woede",
         "emotion_value_disgust": "Afkeer",
         "emotion_value_fear": "Angst",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "Groepeer data op sentiment, vraagtype en andere dimensies.",
         "edit_chart_description": "Bekijk en bewerk je diagramconfiguratie.",
         "edit_chart_title": "Diagram bewerken",
-        "edit_chart_title_named": "Grafiek \"{{name}}\" bewerken",
+        "edit_chart_title_named": "Bewerk \"{name}\"",
         "emotion_value_anger": "Woede",
         "emotion_value_disgust": "Afkeer",
         "emotion_value_fear": "Angst",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "Agrupe dados por sentimento, tipo de pergunta e outras dimensões.",
         "edit_chart_description": "Visualize e edite a configuração do seu gráfico.",
         "edit_chart_title": "Editar gráfico",
+        "edit_chart_title_named": "Editar Gráfico \"{{name}}\"",
         "emotion_value_anger": "Raiva",
         "emotion_value_disgust": "Nojo",
         "emotion_value_fear": "Medo",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "Agrupe dados por sentimento, tipo de pergunta e outras dimensões.",
         "edit_chart_description": "Visualize e edite a configuração do seu gráfico.",
         "edit_chart_title": "Editar gráfico",
-        "edit_chart_title_named": "Editar Gráfico \"{{name}}\"",
+        "edit_chart_title_named": "Editar \"{name}\"",
         "emotion_value_anger": "Raiva",
         "emotion_value_disgust": "Nojo",
         "emotion_value_fear": "Medo",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "Agrupa dados por sentimento, tipo de pergunta e outras dimensões.",
         "edit_chart_description": "Visualize e edite a configuração do seu gráfico.",
         "edit_chart_title": "Editar gráfico",
-        "edit_chart_title_named": "Editar Gráfico \"{{name}}\"",
+        "edit_chart_title_named": "Editar \"{name}\"",
         "emotion_value_anger": "Raiva",
         "emotion_value_disgust": "Repulsa",
         "emotion_value_fear": "Medo",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "Agrupa dados por sentimento, tipo de pergunta e outras dimensões.",
         "edit_chart_description": "Visualize e edite a configuração do seu gráfico.",
         "edit_chart_title": "Editar gráfico",
+        "edit_chart_title_named": "Editar Gráfico \"{{name}}\"",
         "emotion_value_anger": "Raiva",
         "emotion_value_disgust": "Repulsa",
         "emotion_value_fear": "Medo",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "Grupează datele după sentiment, tipul întrebării și alte dimensiuni.",
         "edit_chart_description": "Vezi și editează configurația graficului tău.",
         "edit_chart_title": "Editează graficul",
+        "edit_chart_title_named": "Editează Graficul \"{{name}}\"",
         "emotion_value_anger": "Furie",
         "emotion_value_disgust": "Dezgust",
         "emotion_value_fear": "Frică",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "Grupează datele după sentiment, tipul întrebării și alte dimensiuni.",
         "edit_chart_description": "Vezi și editează configurația graficului tău.",
         "edit_chart_title": "Editează graficul",
-        "edit_chart_title_named": "Editează Graficul \"{{name}}\"",
+        "edit_chart_title_named": "Editează \"{name}\"",
         "emotion_value_anger": "Furie",
         "emotion_value_disgust": "Dezgust",
         "emotion_value_fear": "Frică",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "Группируйте данные по настроению, типу вопроса и другим измерениям.",
         "edit_chart_description": "Просмотри и измени настройки своего графика.",
         "edit_chart_title": "Редактировать график",
+        "edit_chart_title_named": "Редактировать график \"{{name}}\"",
         "emotion_value_anger": "Гнев",
         "emotion_value_disgust": "Отвращение",
         "emotion_value_fear": "Страх",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "Группируйте данные по настроению, типу вопроса и другим измерениям.",
         "edit_chart_description": "Просмотри и измени настройки своего графика.",
         "edit_chart_title": "Редактировать график",
-        "edit_chart_title_named": "Редактировать график \"{{name}}\"",
+        "edit_chart_title_named": "Редактировать «{name}»",
         "emotion_value_anger": "Гнев",
         "emotion_value_disgust": "Отвращение",
         "emotion_value_fear": "Страх",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "Gruppera data efter sentiment, frågetyp och andra dimensioner.",
         "edit_chart_description": "Visa och redigera din diagramkonfiguration.",
         "edit_chart_title": "Redigera diagram",
-        "edit_chart_title_named": "Redigera diagram \"{{name}}\"",
+        "edit_chart_title_named": "Redigera \"{name}\"",
         "emotion_value_anger": "Ilska",
         "emotion_value_disgust": "Avsky",
         "emotion_value_fear": "Rädsla",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "Gruppera data efter sentiment, frågetyp och andra dimensioner.",
         "edit_chart_description": "Visa och redigera din diagramkonfiguration.",
         "edit_chart_title": "Redigera diagram",
+        "edit_chart_title_named": "Redigera diagram \"{{name}}\"",
         "emotion_value_anger": "Ilska",
         "emotion_value_disgust": "Avsky",
         "emotion_value_fear": "Rädsla",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "Verileri duygu durumu, soru türü ve diğer boyutlara göre grupla.",
         "edit_chart_description": "Grafik yapılandırmanı görüntüle ve düzenle.",
         "edit_chart_title": "Grafiği Düzenle",
-        "edit_chart_title_named": "\"{{name}}\" Grafiğini Düzenle",
+        "edit_chart_title_named": "\"{name}\" Düzenle",
         "emotion_value_anger": "Öfke",
         "emotion_value_disgust": "İğrenme",
         "emotion_value_fear": "Korku",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "Verileri duygu durumu, soru türü ve diğer boyutlara göre grupla.",
         "edit_chart_description": "Grafik yapılandırmanı görüntüle ve düzenle.",
         "edit_chart_title": "Grafiği Düzenle",
+        "edit_chart_title_named": "\"{{name}}\" Grafiğini Düzenle",
         "emotion_value_anger": "Öfke",
         "emotion_value_disgust": "İğrenme",
         "emotion_value_fear": "Korku",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "按情感、问题类型和其他维度对数据进行分组。",
         "edit_chart_description": "查看并编辑你的图表配置。",
         "edit_chart_title": "编辑图表",
-        "edit_chart_title_named": "编辑“{{name}}”图表",
+        "edit_chart_title_named": "编辑“{name}”",
         "emotion_value_anger": "愤怒",
         "emotion_value_disgust": "厌恶",
         "emotion_value_fear": "恐惧",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "按情感、问题类型和其他维度对数据进行分组。",
         "edit_chart_description": "查看并编辑你的图表配置。",
         "edit_chart_title": "编辑图表",
+        "edit_chart_title_named": "编辑“{{name}}”图表",
         "emotion_value_anger": "愤怒",
         "emotion_value_disgust": "厌恶",
         "emotion_value_fear": "恐惧",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1658,6 +1658,7 @@
         "dimensions_toggle_description": "依情感、問題類型及其他維度分組資料。",
         "edit_chart_description": "檢視並編輯你的圖表設定。",
         "edit_chart_title": "編輯圖表",
+        "edit_chart_title_named": "編輯「{{name}}」圖表",
         "emotion_value_anger": "憤怒",
         "emotion_value_disgust": "厭惡",
         "emotion_value_fear": "恐懼",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1658,7 +1658,7 @@
         "dimensions_toggle_description": "依情感、問題類型及其他維度分組資料。",
         "edit_chart_description": "檢視並編輯你的圖表設定。",
         "edit_chart_title": "編輯圖表",
-        "edit_chart_title_named": "編輯「{{name}}」圖表",
+        "edit_chart_title_named": "編輯「{name}」",
         "emotion_value_anger": "憤怒",
         "emotion_value_disgust": "厭惡",
         "emotion_value_fear": "恐懼",

--- a/apps/web/modules/ee/analysis/charts/components/create-chart-view.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/create-chart-view.tsx
@@ -67,6 +67,7 @@ export function CreateChartView({
     chartLoadError,
     chartName,
     setChartName,
+    savedChartName,
     selectedChartType,
     handleChartTypeChange,
     handleChartGenerated,
@@ -121,18 +122,20 @@ export function CreateChartView({
   const chartType = selectedChartType ?? (isEditing ? (initialChart?.type ?? DEFAULT_CHART_TYPE) : undefined);
   const hasSelectedDirectory = !!selectedDirectoryId;
   const isAIQueryAvailable = isAIAvailable !== false;
+  const editChartTitle = savedChartName
+    ? t("workspace.analysis.charts.edit_chart_title_named", { name: savedChartName })
+    : t("workspace.analysis.charts.edit_chart_title");
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
       <DialogContent
         width="full"
         disableCloseOnOutsideClick={!isEditing}
+        closeOnEscape
         onOpenAutoFocus={(event) => event.preventDefault()}>
         <DialogHeader>
           <DialogTitle>
-            {isEditing
-              ? t("workspace.analysis.charts.edit_chart_title")
-              : t("workspace.analysis.charts.create_chart")}
+            {isEditing ? editChartTitle : t("workspace.analysis.charts.create_chart")}
           </DialogTitle>
           <DialogDescription>
             {isEditing

--- a/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.test.ts
+++ b/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { AnalyticsResponse } from "@/modules/ee/analysis/types/analysis";
 
@@ -383,6 +383,35 @@ describe("useChartDialog", () => {
       });
 
       expect(result.current.chartName).toBe("User Typed Name");
+    });
+  });
+
+  describe("savedChartName", () => {
+    test("holds the loaded chart name and stays stable while the user renames", async () => {
+      mockGetChartAction.mockResolvedValue({
+        data: {
+          id: CHART_ID,
+          name: "Loaded Chart",
+          type: "bar",
+          query: sampleChartData.query,
+          feedbackDirectoryId: DIRECTORY_ID,
+        },
+      });
+      mockExecuteQueryAction.mockResolvedValue({ data: [] });
+
+      const { result } = renderHook(() => useChartDialog({ ...baseProps, chartId: CHART_ID }));
+
+      await waitFor(() => {
+        expect(result.current.savedChartName).toBe("Loaded Chart");
+      });
+      expect(result.current.chartName).toBe("Loaded Chart");
+
+      await act(async () => {
+        result.current.setChartName("Renamed Chart");
+      });
+
+      expect(result.current.chartName).toBe("Renamed Chart");
+      expect(result.current.savedChartName).toBe("Loaded Chart");
     });
   });
 

--- a/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.test.ts
+++ b/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.test.ts
@@ -413,6 +413,42 @@ describe("useChartDialog", () => {
       expect(result.current.chartName).toBe("Renamed Chart");
       expect(result.current.savedChartName).toBe("Loaded Chart");
     });
+
+    test("resets savedChartName when the dialog is closed without saving", async () => {
+      mockGetChartAction.mockResolvedValue({
+        data: {
+          id: CHART_ID,
+          name: "Loaded Chart",
+          type: "bar",
+          query: sampleChartData.query,
+          feedbackDirectoryId: DIRECTORY_ID,
+        },
+      });
+      mockExecuteQueryAction.mockResolvedValue({ data: [] });
+
+      const onOpenChange = vi.fn();
+      const { result } = renderHook(() => useChartDialog({ ...baseProps, onOpenChange, chartId: CHART_ID }));
+
+      await waitFor(() => {
+        expect(result.current.savedChartName).toBe("Loaded Chart");
+      });
+
+      await act(async () => {
+        result.current.handleClose();
+      });
+
+      expect(result.current.savedChartName).toBe("");
+      expect(result.current.chartName).toBe("");
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    test("keeps savedChartName empty when opening in create mode", async () => {
+      const { result } = renderHook(() => useChartDialog(baseProps));
+
+      await waitFor(() => {
+        expect(result.current.savedChartName).toBe("");
+      });
+    });
   });
 
   describe("handleSaveChart - validation + error paths", () => {

--- a/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.ts
+++ b/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.ts
@@ -51,6 +51,8 @@ export function useChartDialog({
   const [chartData, setChartData] = useState<AnalyticsResponse | null>(null);
   const [isAddToDashboardDialogOpen, setIsAddToDashboardDialogOpen] = useState(false);
   const [chartName, setChartName] = useState("");
+  // Saved name of the chart being edited; unlike chartName it stays stable while the user types.
+  const [savedChartName, setSavedChartName] = useState("");
   const [dashboards, setDashboards] = useState<Array<{ id: string; name: string }>>([]);
   const [selectedDashboardId, setSelectedDashboardId] = useState<string | undefined>();
   const [isSaving, setIsSaving] = useState(false);
@@ -84,6 +86,7 @@ export function useChartDialog({
     if (!chartId) {
       setChartData(null);
       setChartName("");
+      setSavedChartName("");
       setSelectedChartType(undefined);
       setCurrentChartId(undefined);
       setSelectedDirectoryId(directories?.[0]?.id ?? null);
@@ -109,6 +112,7 @@ export function useChartDialog({
         if (cancelled) return;
 
         setChartName(chart.name);
+        setSavedChartName(chart.name);
         setSelectedChartType(resolveChartType(chart.type));
         setCurrentChartId(chart.id);
         setSelectedDirectoryId(chart.feedbackDirectoryId);
@@ -362,6 +366,7 @@ export function useChartDialog({
     if (!isSaving) {
       setChartData(null);
       setChartName("");
+      setSavedChartName("");
       setSelectedChartType(undefined);
       setCurrentChartId(undefined);
       setChartLoadError(null);
@@ -381,6 +386,7 @@ export function useChartDialog({
     chartData,
     chartName,
     setChartName,
+    savedChartName,
     selectedChartType,
     initialQuery,
     setSelectedChartType,

--- a/apps/web/modules/ui/components/dialog/index.tsx
+++ b/apps/web/modules/ui/components/dialog/index.tsx
@@ -34,6 +34,8 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 interface DialogContentProps {
   hideCloseButton?: boolean;
   disableCloseOnOutsideClick?: boolean;
+  /** Keep Escape closing the dialog even when disableCloseOnOutsideClick is set. */
+  closeOnEscape?: boolean;
   width?: "default" | "wide" | "full" | "narrow";
   unconstrained?: boolean;
 }
@@ -61,6 +63,7 @@ const DialogContent = React.forwardRef<
       children,
       hideCloseButton,
       disableCloseOnOutsideClick,
+      closeOnEscape,
       width = "default",
       unconstrained = false,
       ...props
@@ -81,7 +84,9 @@ const DialogContent = React.forwardRef<
             className
           )}
           onPointerDownOutside={disableCloseOnOutsideClick ? (e) => e.preventDefault() : undefined}
-          onEscapeKeyDown={disableCloseOnOutsideClick ? (e) => e.preventDefault() : undefined}
+          onEscapeKeyDown={
+            disableCloseOnOutsideClick && !closeOnEscape ? (e) => e.preventDefault() : undefined
+          }
           {...props}>
           {children}
           {!hideCloseButton && (


### PR DESCRIPTION
## What does this PR do?

Contributes to ENG-1796

Two dialog-UX fixes for the chart create/edit dialog (release QA ENG-1754):

**1. Escape now closes the chart dialog.**

Root cause: the shared `DialogContent` (`apps/web/modules/ui/components/dialog/index.tsx`) wired `disableCloseOnOutsideClick` to *both* Radix callbacks:

```tsx
onPointerDownOutside={disableCloseOnOutsideClick ? (e) => e.preventDefault() : undefined}
onEscapeKeyDown={disableCloseOnOutsideClick ? (e) => e.preventDefault() : undefined}
```

So any dialog that opted out of close-on-outside-click also silently swallowed Escape. The chart dialog passes `disableCloseOnOutsideClick={!isEditing}`, which is why Escape did nothing in create mode.

Fix: a new opt-in `closeOnEscape` prop on `DialogContent` that keeps Escape closing the dialog while outside-click stays disabled. Defaults preserve today's behavior for the ~15 other dialogs that use `disableCloseOnOutsideClick` (they keep swallowing Escape as before). The chart dialog sets `closeOnEscape`.

Nested Radix layers (selects, popovers, cmdk pickers) are unaffected: Radix dispatches Escape to the topmost `DismissableLayer` only, so an open picker still consumes its own Escape press and the dialog stays open.

**2. Edit dialog title now names the chart.**

`Edit Chart` → `Edit "NAME" Chart` via a new i18n key `workspace.analysis.charts.edit_chart_title_named` (`Edit "{{name}}" Chart`). The name comes from a new `savedChartName` value in `useChartDialog` — it holds the persisted chart name (from `initialChart` or the `getChartAction` fetch), so the title stays stable while the user retypes the name field. Falls back to the plain `edit_chart_title` while the chart is still loading. Only `en-US.json` was touched; other locales are machine-generated by Lingo.dev.

## How should this be tested?

- Open the create chart dialog → press Escape → dialog closes. Clicking outside still does **not** close it.
- Inside the dialog, open a picker (chart type select / dimension combobox) → press Escape → only the picker closes; press Escape again → dialog closes.
- Edit an existing chart (from the charts list and from a dashboard widget) → title reads `Edit "NAME" Chart`; while the chart is loading the title falls back to `Edit Chart`; retyping the name field does not change the title.
- Other dialogs using `disableCloseOnOutsideClick` (e.g. delete dialog, invite member modal) still ignore Escape — unchanged.

Verification run:

- `pnpm vitest run modules/ee/analysis/charts/hooks/use-chart-dialog.test.ts` — 17/17 passed (includes a new `savedChartName` test)
- `eslint` on the 4 touched TS/TSX files — clean
- `prettier --check` on all touched files — clean

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
