### PR TITLE
fix(api): reject publishing an app survey with zero triggers

### DIFF
--- a/apps/web/app/api/v3/surveys/patch.test.ts
+++ b/apps/web/app/api/v3/surveys/patch.test.ts
@@ -425,6 +425,29 @@ describe("patchV3Survey", () => {
     );
   });
 
+  test("rejects setting a non-draft status on an app survey with no triggers", async () => {
+    await expect(
+      executeV3SurveyPatch({
+        currentSurvey: { ...currentSurvey, type: "app", triggers: [] } as TSurvey,
+        document: {
+          name: currentSurvey.name,
+          status: "inProgress",
+          metadata: currentSurvey.metadata,
+          defaultLanguage: "en-US",
+          languages: [{ code: "en-US", enabled: true }],
+          welcomeCard: currentSurvey.welcomeCard,
+          blocks: currentSurvey.blocks,
+          endings: currentSurvey.endings,
+          hiddenFields: currentSurvey.hiddenFields,
+          variables: currentSurvey.variables,
+        } as unknown as Parameters<typeof executeV3SurveyPatch>[0]["document"],
+        languageRequests: [{ code: "en-US", default: true, enabled: true }],
+        requestId: "req_1",
+      })
+    ).rejects.toBeInstanceOf(V3SurveyReferenceValidationError);
+    expect(prisma.survey.update).not.toHaveBeenCalled();
+  });
+
   test("reconciles due survey schedules without refetching when no schedule transition persisted", async () => {
     vi.mocked(isSurveySchedulingDue).mockReturnValue(true);
     vi.mocked(reconcileDueSurveySchedules).mockResolvedValue({

--- a/apps/web/app/api/v3/surveys/patch.ts
+++ b/apps/web/app/api/v3/surveys/patch.ts
@@ -5,7 +5,12 @@ import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import type { TSurvey } from "@formbricks/types/surveys/types";
 import { getActionClasses } from "@/lib/actionClass/service";
 import { selectSurvey } from "@/lib/survey/service";
-import { stripIsDraftFromBlocks, transformPrismaSurvey } from "@/lib/survey/utils";
+import {
+  APP_SURVEY_TRIGGER_REQUIRED_MESSAGE,
+  isAppSurveyMissingTriggersToPublish,
+  stripIsDraftFromBlocks,
+  transformPrismaSurvey,
+} from "@/lib/survey/utils";
 import { handleTriggerUpdates } from "@/modules/survey/lib/trigger-updates";
 import {
   isSurveySchedulingDue,
@@ -172,6 +177,16 @@ export async function executeV3SurveyPatch(params: {
   const mediaInvalidParams = getV3SurveyMediaInvalidParams(document.blocks);
   if (mediaInvalidParams.length > 0) {
     throw new V3SurveyReferenceValidationError(mediaInvalidParams);
+  }
+
+  // An app survey can never be shown without a trigger, so reject setting a non-draft status with no
+  // effective triggers. Triggers only change when the patch carries a `distribution` (top-level
+  // replacement); otherwise the survey keeps its current triggers.
+  const effectiveTriggers = document.distribution ? document.distribution.triggers : currentSurvey.triggers;
+  if (isAppSurveyMissingTriggersToPublish(currentSurvey.type, document.status, effectiveTriggers)) {
+    throw new V3SurveyReferenceValidationError([
+      { name: "triggers", reason: APP_SURVEY_TRIGGER_REQUIRED_MESSAGE },
+    ]);
   }
 
   const languages = await ensureV3WorkspaceLanguages(currentSurvey.workspaceId, languageRequests, requestId);

--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -552,7 +552,7 @@ describe("Tests for createSurvey", () => {
     name: "Test Survey",
     type: "app" as const,
     createdBy: mockUserId,
-    status: "inProgress" as const,
+    status: "draft" as const,
     welcomeCard: {
       enabled: true,
       headline: { default: "Welcome" },
@@ -661,6 +661,13 @@ describe("Tests for createSurvey", () => {
       expect(prisma.survey.create).toHaveBeenCalled();
       expect(result.name).toEqual(mockSurveyOutput.name);
       expect(subscribeOrganizationMembersToSurveyResponses).toHaveBeenCalled();
+    });
+
+    test("throws InvalidInputError when creating a non-draft app survey with no triggers", async () => {
+      await expect(
+        createSurvey(mockWorkspaceId, { ...mockCreateSurveyInput, type: "app", status: "inProgress" })
+      ).rejects.toThrow(InvalidInputError);
+      expect(prisma.survey.create).not.toHaveBeenCalled();
     });
 
     test("creates a private segment for app surveys", async () => {

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -22,8 +22,10 @@ import { getActionClasses } from "../actionClass/service";
 import { ITEMS_PER_PAGE } from "../constants";
 import { validateInputs } from "../utils/validate";
 import {
+  APP_SURVEY_TRIGGER_REQUIRED_MESSAGE,
   checkForInvalidImagesInQuestions,
   checkForInvalidMediaInBlocks,
+  isAppSurveyMissingTriggersToPublish,
   stripIsDraftFromBlocks,
   transformPrismaSurvey,
   validateMediaAndPrepareBlocks,
@@ -293,6 +295,12 @@ export const updateSurveyInternal = async (
 
     if (!skipValidation) {
       checkForInvalidImagesInQuestions(questions);
+
+      // An app survey can never be shown without a trigger, so block publishing (non-draft status)
+      // one with zero triggers. The editor enforces this client-side only; mirror it server-side.
+      if (isAppSurveyMissingTriggersToPublish(type, updatedSurvey.status, triggers)) {
+        throw new InvalidInputError(APP_SURVEY_TRIGGER_REQUIRED_MESSAGE);
+      }
     }
 
     // Add blocks media validation. The validation error is already an InvalidInputError, so the
@@ -665,6 +673,18 @@ export const createSurvey = async (
     const { createdBy, languages, segment, followUps, styling, ...restSurveyBody } = parsedSurveyBody;
     assertSurveyLanguagesBelongToWorkspace(parsedWorkspaceId, languages);
     await assertSurveySegmentBelongsToWorkspace(parsedWorkspaceId, segment);
+
+    // An app survey can never be shown without a trigger, so block creating one directly in a
+    // non-draft status with zero triggers (mirrors the editor's publish guard).
+    if (
+      isAppSurveyMissingTriggersToPublish(
+        restSurveyBody.type ?? "link",
+        restSurveyBody.status ?? "draft",
+        restSurveyBody.triggers
+      )
+    ) {
+      throw new InvalidInputError(APP_SURVEY_TRIGGER_REQUIRED_MESSAGE);
+    }
     const normalizedCloseOn = restSurveyBody.closeOn instanceof Date ? restSurveyBody.closeOn : null;
     const normalizedPublishOn = restSurveyBody.publishOn instanceof Date ? restSurveyBody.publishOn : null;
     const surveyLanguagesCreateData: Prisma.SurveyLanguageCreateNestedManyWithoutSurveyInput | undefined =

--- a/apps/web/lib/survey/utils.test.ts
+++ b/apps/web/lib/survey/utils.test.ts
@@ -11,9 +11,27 @@ import {
   anySurveyHasFilters,
   checkForInvalidImagesInQuestions,
   checkForInvalidMediaInBlocks,
+  isAppSurveyMissingTriggersToPublish,
   transformPrismaSurvey,
   validateMediaAndPrepareBlocks,
 } from "./utils";
+
+describe("isAppSurveyMissingTriggersToPublish", () => {
+  test("flags a non-draft app survey with no triggers", () => {
+    expect(isAppSurveyMissingTriggersToPublish("app", "inProgress", [])).toBe(true);
+    expect(isAppSurveyMissingTriggersToPublish("app", "paused", null)).toBe(true);
+    expect(isAppSurveyMissingTriggersToPublish("app", "completed", undefined)).toBe(true);
+  });
+
+  test("allows a non-draft app survey that has at least one trigger", () => {
+    expect(isAppSurveyMissingTriggersToPublish("app", "inProgress", [{ actionClassId: "a" }])).toBe(false);
+  });
+
+  test("ignores draft app surveys and non-app surveys", () => {
+    expect(isAppSurveyMissingTriggersToPublish("app", "draft", [])).toBe(false);
+    expect(isAppSurveyMissingTriggersToPublish("link", "inProgress", [])).toBe(false);
+  });
+});
 
 describe("transformPrismaSurvey", () => {
   test("transforms prisma survey without segment", () => {

--- a/apps/web/lib/survey/utils.ts
+++ b/apps/web/lib/survey/utils.ts
@@ -10,9 +10,29 @@ import {
   TSurveyElementTypeEnum,
   TSurveyPictureChoice,
 } from "@formbricks/types/surveys/elements";
-import { TSurvey, TSurveyQuestion, TSurveyQuestionTypeEnum } from "@formbricks/types/surveys/types";
+import {
+  TSurvey,
+  TSurveyQuestion,
+  TSurveyQuestionTypeEnum,
+  TSurveyStatus,
+  TSurveyType,
+} from "@formbricks/types/surveys/types";
 import { isValidVideoUrl } from "@/lib/utils/video-upload";
 import { isValidImageFile } from "@/modules/storage/utils";
+
+/**
+ * A live (non-draft) app survey must have at least one trigger, otherwise it can never be displayed
+ * ("live but dormant"). The survey editor only enforces this client-side, so every server write path
+ * (create + update, including the v3 API) applies this check to keep the API in parity with the UI.
+ */
+export const APP_SURVEY_TRIGGER_REQUIRED_MESSAGE =
+  "An app survey must have at least one trigger to be set to a non-draft status.";
+
+export const isAppSurveyMissingTriggersToPublish = (
+  type: TSurveyType,
+  status: TSurveyStatus,
+  triggers: readonly unknown[] | null | undefined
+): boolean => type === "app" && status !== "draft" && (triggers?.length ?? 0) === 0;
 
 /**
  * Actionable hint appended to invalid-image messages. Names the supported formats and explains why


### PR DESCRIPTION
## What does this PR do?

Fixes an app survey being publishable (moved to a non-draft status like `inProgress`) with **zero triggers** through the API. Such a survey shows as "running" but can never be displayed — it has no action to trigger it. The survey editor forbids this, but the rule was enforced **client-side only**. Found during QA 5.2 §7 (ENG-1757).

Linear: ENG-1792

Enforces the invariant server-side: **an `app` survey in a non-draft status must have at least one trigger.**

> Note on placement: the ticket suggested enforcing this once in `updateSurveyInternal`. That alone is **insufficient** — the v3 Surveys API create/patch do their own `createSurvey` / `prisma.survey.update` and don't route through `updateSurveyInternal` (the exact repro is a v3 PATCH). So the check is applied at the three real write choke points via a shared predicate:

- **`isAppSurveyMissingTriggersToPublish(type, status, triggers)`** — shared helper in `apps/web/lib/survey/utils.ts`.
- **`createSurvey`** (all create paths incl. v3) → throws `InvalidInputError` → **400** (v3-create maps `InvalidInputError` to 400 via `mapV3SurveyCreateError`).
- **`updateSurveyInternal`** (v1/v2 management update + the app's `updateSurveyAction`) → `InvalidInputError` → **400** (gated by the existing `!skipValidation`, matching the other invariant checks).
- **`executeV3SurveyPatch`** (v3 PATCH) → `V3SurveyReferenceValidationError` → **422**. Effective triggers = the patch's `distribution.triggers` when present (top-level replacement), else the survey's current triggers.

Draft app surveys and link surveys are unaffected.

## How should this be tested?

Unit tests (133 pass; new: helper unit test, `createSurvey` reject test, v3-patch reject test):

```
pnpm --filter=@formbricks/web exec vitest run app/api/v3/surveys/patch.test.ts lib/survey/service.test.ts lib/survey/utils.test.ts app/api/v3/surveys/create.test.ts
```

Manual (v3 API, verified on localhost):

| step | before | after |
| --- | --- | --- |
| create app survey, no triggers (`status:"draft"`) | 201 | **201** |
| `PATCH /api/v3/surveys/{id}` `{"status":"inProgress"}` (no triggers) | 200 | **422** (`invalid_params: [{name:"triggers", reason:"An app survey must have at least one trigger…"}]`) |
| create app survey `status:"inProgress"` + no triggers | 201 | **400** |
| publish an app survey **with** ≥1 trigger | 200 | **200** (unchanged — guard only fires on empty triggers) |

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues (API/service-only, no UI change)
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks)

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR (N/A — no UI change)
- [ ] Updated the Formbricks Docs if changes were necessary
