### PR TITLE
docs: update license table workspaces pricing to pay per workspace

### DIFF
--- a/docs/self-hosting/advanced/license.mdx
+++ b/docs/self-hosting/advanced/license.mdx
@@ -26,7 +26,7 @@ Additional to the AGPLv3 licensed Formbricks core, the Formbricks repository con
 | Unlimited responses                                           | ✅                | Pay per response  |
 | Unlimited surveys                                             | ✅                | ✅  |
 | Unlimited users                                               | ✅                | ✅  |
-| Workspaces                                                    | 1                 | Unlimited          |
+| Workspaces                                                    | 1                 | Pay per workspace  |
 | Use all [free features](#what-features-are-free%3F) | ✅                | ✅  |
 | Use [paid features](#what-features-are-free%3F)       | ❌                | Pay per feature                 |
 


### PR DESCRIPTION
## What does this PR do?

Updates the license comparison table on the self-hosting **License** docs page (`docs/self-hosting/advanced/license.mdx`).

In the **"When do I need an Enterprise License?"** table, the Enterprise Edition value for the **Workspaces** row was listed as `Unlimited`. Enterprise workspaces are billed per workspace, so this changes the cell to `Pay per workspace` to reflect the actual pricing model.

Docs-only change; no code, no functional impact.

```diff
- | Workspaces | 1 | Unlimited          |
+ | Workspaces | 1 | Pay per workspace  |
```

## How should this be tested?

- Open `docs/self-hosting/advanced/license.mdx` and confirm the **Workspaces** row in the "When do I need an Enterprise License?" table reads `Pay per workspace` under Enterprise Edition.
- Verify the rest of the table (responses, surveys, users rows) is unchanged and the Markdown table still renders correctly in the Mintlify docs.

## Checklist

### Required

- [x] Self-reviewed my own code
- [ ] Ran `pnpm build` (not applicable — docs-only Markdown change)

### Appreciated

- [x] Updated the Formbricks Docs