### PR TITLE
fix(helm): wait for PostgreSQL before migrations [QA 5.2]

### DIFF
--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up Helm
         uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
@@ -45,6 +47,7 @@ jobs:
           test "$(grep -c '^          image: ' "$render_dir/default.yaml")" -eq 2
           test "$(grep '^          image: ' "$render_dir/default.yaml" | sort -u | wc -l | tr -d ' ')" -eq 1
           test "$(grep -c 'name: formbricks-app-secrets' "$render_dir/default.yaml")" -eq 2
+          ! grep -q '^          env:$' "$render_dir/default.yaml"
 
           helm template qa "$chart" \
             --set formbricks.webappUrl=https://qa.example.com \
@@ -65,6 +68,7 @@ jobs:
             --set-string deployment.env.MIGRATE_DATABASE_URL=postgresql://user:password@migrate-postgresql:5432/formbricks \
             --show-only templates/migration-job.yaml > "$render_dir/migrate-url.yaml"
           test "$(grep -c 'name: MIGRATE_DATABASE_URL' "$render_dir/migrate-url.yaml")" -eq 2
+          test "$(grep -c '^          env:' "$render_dir/migrate-url.yaml")" -eq 2
 
           helm template qa "$chart" \
             --set formbricks.webappUrl=https://qa.example.com \

--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -1,0 +1,72 @@
+name: Helm Chart Validation
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
+        with:
+          version: v3.15.4
+
+      - name: Validate chart renders
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          chart="charts/formbricks"
+          render_dir="$(mktemp -d)"
+          trap 'rm -rf "$render_dir"' EXIT
+
+          helm lint "$chart" --set formbricks.webappUrl=https://qa.example.com
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --show-only templates/migration-job.yaml > "$render_dir/default.yaml"
+
+          grep -q 'packages/database/dist/scripts/wait-for-database.js' "$render_dir/default.yaml"
+          grep -q 'packages/database/dist/scripts/apply-migrations.js' "$render_dir/default.yaml"
+          grep -q 'argocd.argoproj.io/sync-wave: "-1"' "$render_dir/default.yaml"
+          test "$(grep -c '^          image: ' "$render_dir/default.yaml")" -eq 2
+          test "$(grep '^          image: ' "$render_dir/default.yaml" | sort -u | wc -l | tr -d ' ')" -eq 1
+          test "$(grep -c 'name: formbricks-app-secrets' "$render_dir/default.yaml")" -eq 2
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set migration.waitForDatabase.enabled=false \
+            --show-only templates/migration-job.yaml > "$render_dir/disabled.yaml"
+          ! grep -q 'wait-for-database' "$render_dir/disabled.yaml"
+          grep -q 'packages/database/dist/scripts/apply-migrations.js' "$render_dir/disabled.yaml"
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set postgresql.enabled=false \
+            --set-string postgresql.externalDatabaseUrl=postgresql://user:password@external-postgresql:5432/formbricks \
+            --show-only templates/migration-job.yaml > "$render_dir/external.yaml"
+          grep -q 'packages/database/dist/scripts/wait-for-database.js' "$render_dir/external.yaml"
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set-string deployment.env.MIGRATE_DATABASE_URL=postgresql://user:password@migrate-postgresql:5432/formbricks \
+            --show-only templates/migration-job.yaml > "$render_dir/migrate-url.yaml"
+          test "$(grep -c 'name: MIGRATE_DATABASE_URL' "$render_dir/migrate-url.yaml")" -eq 2
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --show-only charts/postgresql/templates/primary/statefulset.yaml > "$render_dir/postgresql.yaml"
+          grep -q 'argocd.argoproj.io/sync-wave: "-2"' "$render_dir/postgresql.yaml"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,6 +33,10 @@ jobs:
     uses: ./.github/workflows/build-web.yml
     secrets: inherit
 
+  helm-chart-validation:
+    name: Validate Helm Chart
+    uses: ./.github/workflows/helm-chart-validation.yml
+
   e2e-test:
     name: Run E2E Tests
     uses: ./.github/workflows/e2e.yml
@@ -40,7 +44,7 @@ jobs:
 
   required:
     name: PR Check Summary
-    needs: [lint, test, build, e2e-test]
+    needs: [lint, test, build, helm-chart-validation, e2e-test]
     if: always()
     runs-on: ubuntu-latest
     permissions:

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -69,7 +69,9 @@ The chart deploys Hub API and, by default, a `hub-worker` deployment. Hub API is
 When the Formbricks migration job is enabled, Hub waits for the `formbricks-migration` Job to complete before its own goose/river init migrations run. This keeps fresh shared-database installs from creating Hub tables before Prisma has initialized the Formbricks schema.
 If the Job has already been cleaned up, Hub only continues after all expected Prisma and data migration success markers are present in the database.
 
-When deployed with Argo CD, chart-managed Secrets and ExternalSecrets render in sync wave `-2`, and the Formbricks and Hub migration hooks run in sync wave `-1`. This lets app and Hub secrets exist before migration jobs start.
+Before migrations start, the migration Job waits for the effective PostgreSQL endpoint to accept TCP connections. `MIGRATE_DATABASE_URL` takes precedence over `DATABASE_URL`, matching the migration runner. Configure the timeout and retry interval under `migration.waitForDatabase`, or disable the readiness check for deployments that provide their own gate.
+
+When deployed with Argo CD, chart-managed Secrets, ExternalSecrets, and bundled PostgreSQL render in sync wave `-2`, and the Formbricks and Hub migration hooks run in sync wave `-1`. This lets app and Hub secrets exist and PostgreSQL become healthy before migration jobs start.
 
 Self-hosted embeddings are disabled by default. Set `hub.embeddings.enabled=true` to deploy an internal Hugging Face Text Embeddings Inference (TEI) service and wire Hub API plus Hub worker to it through the OpenAI-compatible endpoint added in Hub:
 
@@ -433,6 +435,10 @@ JSON that can call Vertex AI.
 | migration.resources.requests.cpu                                   | string | `"100m"`                                                                    |                                                           |
 | migration.resources.requests.memory                                | string | `"256Mi"`                                                                   |                                                           |
 | migration.ttlSecondsAfterFinished                                  | int    | `300`                                                                       |                                                           |
+| migration.waitForDatabase.connectionTimeoutSeconds                 | int    | `5`                                                                         | Per-attempt TCP connection timeout.                       |
+| migration.waitForDatabase.enabled                                  | bool   | `true`                                                                      | Wait for PostgreSQL before starting migrations.           |
+| migration.waitForDatabase.intervalSeconds                          | int    | `5`                                                                         | Delay between readiness attempts.                         |
+| migration.waitForDatabase.timeoutSeconds                           | int    | `900`                                                                       | Overall readiness timeout for each Job attempt.           |
 | nameOverride                                                       | string | `""`                                                                        |                                                           |
 | partOfOverride                                                     | string | `""`                                                                        |                                                           |
 | pdb.additionalLabels                                               | object | `{}`                                                                        |                                                           |
@@ -444,6 +450,7 @@ JSON that can call Vertex AI.
 | postgresql.auth.secretKeys.adminPasswordKey                        | string | `"POSTGRES_ADMIN_PASSWORD"`                                                 |                                                           |
 | postgresql.auth.secretKeys.userPasswordKey                         | string | `"POSTGRES_USER_PASSWORD"`                                                  |                                                           |
 | postgresql.auth.username                                           | string | `"formbricks"`                                                              |                                                           |
+| postgresql.commonAnnotations                                       | object | `{"argocd.argoproj.io/sync-wave":"-2"}`                                   | Order bundled PostgreSQL before migration hooks in Argo.  |
 | postgresql.enabled                                                 | bool   | `true`                                                                      |                                                           |
 | postgresql.externalDatabaseUrl                                     | string | `""`                                                                        |                                                           |
 | postgresql.fullnameOverride                                        | string | `"formbricks-postgresql"`                                                   |                                                           |

--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -169,6 +169,46 @@ If `namespaceOverride` is provided, it will be used; otherwise, it defaults to `
 {{- end }}
 
 {{/*
+Render the database environment shared by the migration readiness and migration containers.
+Keeping this in one helper ensures both containers resolve DATABASE_URL and MIGRATE_DATABASE_URL identically.
+*/}}
+{{- define "formbricks.migrationEnvironment" -}}
+{{- if or .Values.deployment.envFrom (or (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) .Values.secret.enabled) }}
+envFrom:
+{{- if or .Values.secret.enabled (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) }}
+  - secretRef:
+      name: {{ template "formbricks.name" . }}-app-secrets
+{{- end }}
+{{- range $value := .Values.deployment.envFrom }}
+{{- if (eq .type "configmap") }}
+  - configMapRef:
+      {{- if .name }}
+      name: {{ include "formbricks.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
+      {{- else if .nameSuffix }}
+      name: {{ template "formbricks.name" $ }}-{{ include "formbricks.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
+      {{- else }}
+      name: {{ template "formbricks.name" $ }}
+      {{- end }}
+{{- end }}
+{{- if (eq .type "secret") }}
+  - secretRef:
+      {{- if .name }}
+      name: {{ include "formbricks.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
+      {{- else if .nameSuffix }}
+      name: {{ template "formbricks.name" $ }}-{{ include "formbricks.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
+      {{- else }}
+      name: {{ template "formbricks.name" $ }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+env:
+{{- range $key, $value := .Values.deployment.env }}
+  {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
 Formbricks application image reference. A configured digest takes precedence over the tag.
 */}}
 {{- define "formbricks.deploymentImage" -}}

--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -202,9 +202,11 @@ envFrom:
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if .Values.deployment.env }}
 env:
 {{- range $key, $value := .Values.deployment.env }}
   {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 2 }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/formbricks/templates/migration-job.yaml
+++ b/charts/formbricks/templates/migration-job.yaml
@@ -45,6 +45,27 @@ spec:
       securityContext:
         {{- toYaml .Values.deployment.securityContext | nindent 8 }}
       {{- end }}
+      {{- if .Values.migration.waitForDatabase.enabled }}
+      initContainers:
+        - name: wait-for-database
+          image: {{ include "formbricks.deploymentImage" . }}
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+          command:
+            - node
+            - packages/database/dist/scripts/wait-for-database.js
+          args:
+            - --timeout-seconds
+            - {{ .Values.migration.waitForDatabase.timeoutSeconds | quote }}
+            - --interval-seconds
+            - {{ .Values.migration.waitForDatabase.intervalSeconds | quote }}
+            - --connection-timeout-seconds
+            - {{ .Values.migration.waitForDatabase.connectionTimeoutSeconds | quote }}
+          {{- include "formbricks.migrationEnvironment" . | nindent 10 }}
+          {{- if .Values.migration.resources }}
+          resources:
+            {{- toYaml .Values.migration.resources | nindent 12 }}
+          {{- end }}
+      {{- end }}
       containers:
         - name: migration
           image: {{ include "formbricks.deploymentImage" . }}
@@ -52,39 +73,7 @@ spec:
           command:
             - node
             - packages/database/dist/scripts/apply-migrations.js
-          {{- if or .Values.deployment.envFrom (or (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) .Values.secret.enabled) }}
-          envFrom:
-          {{- if or .Values.secret.enabled (and .Values.externalSecret.enabled (index .Values.externalSecret.files "app-secrets")) }}
-          - secretRef:
-              name: {{ template "formbricks.name" . }}-app-secrets
-          {{- end }}
-          {{- range $value := .Values.deployment.envFrom }}
-          {{- if (eq .type "configmap") }}
-          - configMapRef:
-              {{- if .name }}
-              name: {{ include "formbricks.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
-              {{- else if .nameSuffix }}
-              name: {{ template "formbricks.name" $ }}-{{ include "formbricks.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
-              {{- else }}
-              name: {{ template "formbricks.name" $ }}
-              {{- end }}
-          {{- end }}
-          {{- if (eq .type "secret") }}
-          - secretRef:
-              {{- if .name }}
-              name: {{ include "formbricks.tplvalues.render" ( dict "value" $value.name "context" $ ) }}
-              {{- else if .nameSuffix }}
-              name: {{ template "formbricks.name" $ }}-{{ include "formbricks.tplvalues.render" ( dict "value" $value.nameSuffix "context" $ ) }}
-              {{- else }}
-              name: {{ template "formbricks.name" $ }}
-              {{- end }}
-          {{- end }}
-          {{- end }}
-          {{- end }}
-          env:
-            {{- range $key, $value := .Values.deployment.env }}
-            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
-            {{- end }}
+          {{- include "formbricks.migrationEnvironment" . | nindent 10 }}
           {{- if .Values.migration.resources }}
           resources:
             {{- toYaml .Values.migration.resources | nindent 12 }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -32,9 +32,9 @@ enterprise:
 # Database Migration Job Configuration Helm
 ##########################################################
 migration:
-  # Enable migration job for ArgoCD deployments
-  # When enabled, migrations run as a PreSync hook before the deployment
-  # and the startup migration in the container is skipped
+  # Enable the migration job. In Argo CD, it runs as a Sync hook in wave -1
+  # after chart-managed secrets and bundled PostgreSQL are healthy. When enabled,
+  # the startup migration in the application container is skipped.
   enabled: true
 
   # Additional annotations for the migration job
@@ -45,6 +45,14 @@ migration:
 
   # Number of retries before marking the job as failed
   backoffLimit: 3
+
+  # Wait for the effective migration database endpoint before starting migrations.
+  # MIGRATE_DATABASE_URL takes precedence over DATABASE_URL, matching the migration runner.
+  waitForDatabase:
+    enabled: true
+    timeoutSeconds: 900
+    intervalSeconds: 5
+    connectionTimeoutSeconds: 5
 
   # Resource requests and limits for the migration job
   resources:
@@ -1238,6 +1246,9 @@ hub:
 postgresql:
   enabled: true # Enable/disable PostgreSQL
   externalDatabaseUrl: ""
+  # Argo CD waits for bundled PostgreSQL before running migration hooks in wave -1.
+  commonAnnotations:
+    argocd.argoproj.io/sync-wave: "-2"
   global:
     security:
       allowInsecureImages: true

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -59,6 +59,7 @@
     "generate": "node ./src/scripts/clean-generated-prisma.mjs && prisma generate",
     "lint": "eslint ./src --fix",
     "generate-data-migration": "tsx ./src/scripts/generate-data-migration.ts",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "create-migration": "dotenv -e ../../.env -- tsx ./src/scripts/create-migration.ts"
   },

--- a/packages/database/src/scripts/wait-for-database.test.ts
+++ b/packages/database/src/scripts/wait-for-database.test.ts
@@ -1,6 +1,5 @@
 import { once } from "node:events";
-import { Socket, createServer } from "node:net";
-import type { AddressInfo } from "node:net";
+import * as NodeNet from "node:net";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   checkDatabaseTcpConnection,
@@ -15,7 +14,7 @@ const { createConnectionMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("node:net", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:net")>();
+  const actual = await importOriginal<typeof NodeNet>();
   createConnectionMock.mockImplementation(actual.createConnection);
 
   return {
@@ -24,7 +23,7 @@ vi.mock("node:net", async (importOriginal) => {
   };
 });
 
-const servers: ReturnType<typeof createServer>[] = [];
+const servers: ReturnType<typeof NodeNet.createServer>[] = [];
 
 afterEach(async () => {
   await Promise.all(
@@ -175,8 +174,8 @@ describe("waitForDatabase", () => {
 
 describe("checkDatabaseTcpConnection", () => {
   test("closes the socket after a successful readiness check", async () => {
-    const serverSockets = new Set<Socket>();
-    const server = createServer((socket) => {
+    const serverSockets = new Set<NodeNet.Socket>();
+    const server = NodeNet.createServer((socket) => {
       serverSockets.add(socket);
       socket.once("close", () => {
         serverSockets.delete(socket);
@@ -185,7 +184,7 @@ describe("checkDatabaseTcpConnection", () => {
     servers.push(server);
     server.listen(0, "127.0.0.1");
     await once(server, "listening");
-    const address = server.address() as AddressInfo;
+    const address = server.address() as NodeNet.AddressInfo;
 
     await checkDatabaseTcpConnection({ host: "127.0.0.1", port: address.port }, 1_000);
 
@@ -195,7 +194,7 @@ describe("checkDatabaseTcpConnection", () => {
   });
 
   test("handles errors emitted after timeout cleanup", async () => {
-    const socket = new Socket();
+    const socket = new NodeNet.Socket();
     const lateError = Object.assign(new Error("connection cancelled"), { code: "ECANCELED" });
     const destroySpy = vi.spyOn(socket, "destroy").mockImplementation(() => {
       queueMicrotask(() => {
@@ -209,7 +208,9 @@ describe("checkDatabaseTcpConnection", () => {
     socket.emit("timeout");
 
     await expect(connection).rejects.toMatchObject({ code: "ETIMEDOUT" });
-    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
     expect(destroySpy).toHaveBeenCalledOnce();
   });
 });

--- a/packages/database/src/scripts/wait-for-database.test.ts
+++ b/packages/database/src/scripts/wait-for-database.test.ts
@@ -1,0 +1,182 @@
+import { once } from "node:events";
+import { createServer } from "node:net";
+import type { AddressInfo, Socket } from "node:net";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  checkDatabaseTcpConnection,
+  getMigrationDatabaseUrl,
+  parseCliOptions,
+  parseDatabaseEndpoint,
+  waitForDatabase,
+} from "./wait-for-database";
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => {
+            resolve();
+          });
+        })
+    )
+  );
+});
+
+describe("getMigrationDatabaseUrl", () => {
+  test("prefers a non-empty MIGRATE_DATABASE_URL", () => {
+    expect(
+      getMigrationDatabaseUrl({
+        DATABASE_URL: "postgresql://app:secret@app-db/formbricks",
+        MIGRATE_DATABASE_URL: " postgresql://migrate:secret@migrate-db/formbricks ",
+      })
+    ).toBe("postgresql://migrate:secret@migrate-db/formbricks");
+  });
+
+  test("falls back to DATABASE_URL", () => {
+    expect(
+      getMigrationDatabaseUrl({
+        DATABASE_URL: "postgresql://app:secret@app-db/formbricks",
+        MIGRATE_DATABASE_URL: " ",
+      })
+    ).toBe("postgresql://app:secret@app-db/formbricks");
+  });
+
+  test("fails when neither URL is configured", () => {
+    expect(() => getMigrationDatabaseUrl({})).toThrow("MIGRATE_DATABASE_URL or DATABASE_URL is required");
+  });
+});
+
+describe("parseDatabaseEndpoint", () => {
+  test.each([
+    ["postgresql://user:secret@database/formbricks", { host: "database", port: 5432 }],
+    ["postgres://user:secret@database:6432/formbricks", { host: "database", port: 6432 }],
+    ["postgresql://user:secret@[2001:db8::1]:7432/formbricks", { host: "2001:db8::1", port: 7432 }],
+  ])("parses %s", (databaseUrl, expectedEndpoint) => {
+    expect(parseDatabaseEndpoint(databaseUrl)).toEqual(expectedEndpoint);
+  });
+
+  test("rejects non-PostgreSQL URLs without echoing the value", () => {
+    const secretUrl = "mysql://admin:super-secret@database/formbricks";
+
+    try {
+      parseDatabaseEndpoint(secretUrl);
+      expect.unreachable("Expected URL parsing to fail");
+    } catch (error) {
+      expect(String(error)).toContain("must use the postgres or postgresql protocol");
+      expect(String(error)).not.toContain("admin");
+      expect(String(error)).not.toContain("super-secret");
+    }
+  });
+});
+
+describe("parseCliOptions", () => {
+  test("uses safe defaults", () => {
+    expect(parseCliOptions([])).toEqual({
+      connectionTimeoutSeconds: 5,
+      intervalSeconds: 5,
+      timeoutSeconds: 900,
+    });
+  });
+
+  test("accepts positive overrides", () => {
+    expect(
+      parseCliOptions([
+        "--timeout-seconds",
+        "60",
+        "--interval-seconds",
+        "2",
+        "--connection-timeout-seconds",
+        "3",
+      ])
+    ).toEqual({ connectionTimeoutSeconds: 3, intervalSeconds: 2, timeoutSeconds: 60 });
+  });
+});
+
+describe("waitForDatabase", () => {
+  test("retries delayed availability without failing the caller", async () => {
+    let currentTimeMs = 0;
+    const checkConnection = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(Object.assign(new Error("refused"), { code: "ECONNREFUSED" }))
+      .mockRejectedValueOnce(Object.assign(new Error("refused"), { code: "ECONNREFUSED" }))
+      .mockResolvedValue(undefined);
+
+    await waitForDatabase(
+      {
+        connectionTimeoutSeconds: 1,
+        endpoint: { host: "database", port: 5432 },
+        intervalSeconds: 2,
+        timeoutSeconds: 10,
+      },
+      {
+        checkConnection,
+        log: vi.fn(),
+        now: () => currentTimeMs,
+        sleep: (durationMs) => {
+          currentTimeMs += durationMs;
+          return Promise.resolve();
+        },
+      }
+    );
+
+    expect(checkConnection).toHaveBeenCalledTimes(3);
+  });
+
+  test("times out with a safe error code", async () => {
+    let currentTimeMs = 0;
+    const logs: string[] = [];
+
+    await expect(
+      waitForDatabase(
+        {
+          connectionTimeoutSeconds: 1,
+          endpoint: { host: "database", port: 5432 },
+          intervalSeconds: 5,
+          timeoutSeconds: 10,
+        },
+        {
+          checkConnection: () =>
+            Promise.reject(
+              Object.assign(new Error("postgresql://admin:super-secret@database/formbricks"), {
+                code: "ECONNREFUSED",
+              })
+            ),
+          log: (message) => logs.push(message),
+          now: () => currentTimeMs,
+          sleep: (durationMs) => {
+            currentTimeMs += durationMs;
+            return Promise.resolve();
+          },
+        }
+      )
+    ).rejects.toThrow("last error code: ECONNREFUSED");
+
+    expect(logs.join("\n")).not.toContain("admin");
+    expect(logs.join("\n")).not.toContain("super-secret");
+  });
+});
+
+describe("checkDatabaseTcpConnection", () => {
+  test("closes the socket after a successful readiness check", async () => {
+    const serverSockets = new Set<Socket>();
+    const server = createServer((socket) => {
+      serverSockets.add(socket);
+      socket.once("close", () => {
+        serverSockets.delete(socket);
+      });
+    });
+    servers.push(server);
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address() as AddressInfo;
+
+    await checkDatabaseTcpConnection({ host: "127.0.0.1", port: address.port }, 1_000);
+
+    await vi.waitFor(() => {
+      expect(serverSockets.size).toBe(0);
+    });
+  });
+});

--- a/packages/database/src/scripts/wait-for-database.test.ts
+++ b/packages/database/src/scripts/wait-for-database.test.ts
@@ -1,6 +1,6 @@
 import { once } from "node:events";
-import { createServer } from "node:net";
-import type { AddressInfo, Socket } from "node:net";
+import { Socket, createServer } from "node:net";
+import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   checkDatabaseTcpConnection,
@@ -9,6 +9,20 @@ import {
   parseDatabaseEndpoint,
   waitForDatabase,
 } from "./wait-for-database";
+
+const { createConnectionMock } = vi.hoisted(() => ({
+  createConnectionMock: vi.fn(),
+}));
+
+vi.mock("node:net", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:net")>();
+  createConnectionMock.mockImplementation(actual.createConnection);
+
+  return {
+    ...actual,
+    createConnection: createConnectionMock,
+  };
+});
 
 const servers: ReturnType<typeof createServer>[] = [];
 
@@ -178,5 +192,24 @@ describe("checkDatabaseTcpConnection", () => {
     await vi.waitFor(() => {
       expect(serverSockets.size).toBe(0);
     });
+  });
+
+  test("handles errors emitted after timeout cleanup", async () => {
+    const socket = new Socket();
+    const lateError = Object.assign(new Error("connection cancelled"), { code: "ECANCELED" });
+    const destroySpy = vi.spyOn(socket, "destroy").mockImplementation(() => {
+      queueMicrotask(() => {
+        socket.emit("error", lateError);
+      });
+      return socket;
+    });
+    createConnectionMock.mockReturnValueOnce(socket);
+
+    const connection = checkDatabaseTcpConnection({ host: "database", port: 5432 }, 1_000);
+    socket.emit("timeout");
+
+    await expect(connection).rejects.toMatchObject({ code: "ETIMEDOUT" });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(destroySpy).toHaveBeenCalledOnce();
   });
 });

--- a/packages/database/src/scripts/wait-for-database.ts
+++ b/packages/database/src/scripts/wait-for-database.ts
@@ -109,7 +109,6 @@ export const checkDatabaseTcpConnection = async (
     const finish = (error?: Error): void => {
       if (settled) return;
       settled = true;
-      socket.removeAllListeners();
       socket.destroy();
 
       if (error) {
@@ -124,7 +123,7 @@ export const checkDatabaseTcpConnection = async (
     socket.once("connect", () => {
       finish();
     });
-    socket.once("error", (error) => {
+    socket.on("error", (error) => {
       finish(error);
     });
     socket.once("timeout", () => {

--- a/packages/database/src/scripts/wait-for-database.ts
+++ b/packages/database/src/scripts/wait-for-database.ts
@@ -1,0 +1,243 @@
+import { createConnection } from "node:net";
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_TIMEOUT_SECONDS = 900;
+const DEFAULT_INTERVAL_SECONDS = 5;
+const DEFAULT_CONNECTION_TIMEOUT_SECONDS = 5;
+
+export interface TDatabaseEndpoint {
+  host: string;
+  port: number;
+}
+
+interface TWaitForDatabaseOptions {
+  connectionTimeoutSeconds: number;
+  endpoint: TDatabaseEndpoint;
+  intervalSeconds: number;
+  timeoutSeconds: number;
+}
+
+interface TWaitForDatabaseDependencies {
+  checkConnection?: (endpoint: TDatabaseEndpoint, timeoutMs: number) => Promise<void>;
+  log?: (message: string) => void;
+  now?: () => number;
+  sleep?: (durationMs: number) => Promise<void>;
+}
+
+interface TWaitForDatabaseCliOptions {
+  connectionTimeoutSeconds: number;
+  intervalSeconds: number;
+  timeoutSeconds: number;
+}
+
+const sleep = async (durationMs: number): Promise<void> => {
+  await new Promise((resolve) => {
+    setTimeout(resolve, durationMs);
+  });
+};
+
+const toPositiveNumber = (value: string, optionName: string): number => {
+  const parsedValue = Number(value);
+
+  if (!Number.isFinite(parsedValue) || parsedValue <= 0) {
+    throw new Error(`${optionName} must be a positive number.`);
+  }
+
+  return parsedValue;
+};
+
+const getSafeErrorCode = (error: unknown): string => {
+  if (typeof error === "object" && error !== null && "code" in error) {
+    const code = String(error.code);
+    return code.length > 0 ? code : "UNKNOWN";
+  }
+
+  return error instanceof Error && error.name.length > 0 ? error.name : "UNKNOWN";
+};
+
+export const getMigrationDatabaseUrl = (
+  environment: { DATABASE_URL?: string; MIGRATE_DATABASE_URL?: string } = process.env
+): string => {
+  const migrateDatabaseUrl = environment.MIGRATE_DATABASE_URL?.trim();
+  if (migrateDatabaseUrl) {
+    return migrateDatabaseUrl;
+  }
+
+  const databaseUrl = environment.DATABASE_URL?.trim();
+  if (databaseUrl) {
+    return databaseUrl;
+  }
+
+  throw new Error("MIGRATE_DATABASE_URL or DATABASE_URL is required to wait for PostgreSQL.");
+};
+
+export const parseDatabaseEndpoint = (databaseUrl: string): TDatabaseEndpoint => {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(databaseUrl);
+  } catch {
+    throw new Error("The migration database URL must be a valid PostgreSQL URL.");
+  }
+
+  if (parsedUrl.protocol !== "postgres:" && parsedUrl.protocol !== "postgresql:") {
+    throw new Error("The migration database URL must use the postgres or postgresql protocol.");
+  }
+
+  if (!parsedUrl.hostname) {
+    throw new Error("The migration database URL must include a hostname.");
+  }
+
+  const port = parsedUrl.port ? Number(parsedUrl.port) : 5432;
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("The migration database URL must include a valid TCP port.");
+  }
+
+  const host = parsedUrl.hostname.startsWith("[") ? parsedUrl.hostname.slice(1, -1) : parsedUrl.hostname;
+
+  return { host, port };
+};
+
+export const checkDatabaseTcpConnection = async (
+  endpoint: TDatabaseEndpoint,
+  timeoutMs: number
+): Promise<void> => {
+  await new Promise<void>((resolve, reject) => {
+    const socket = createConnection({ host: endpoint.host, port: endpoint.port });
+    let settled = false;
+
+    const finish = (error?: Error): void => {
+      if (settled) return;
+      settled = true;
+      socket.removeAllListeners();
+      socket.destroy();
+
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve();
+    };
+
+    socket.setTimeout(timeoutMs);
+    socket.once("connect", () => {
+      finish();
+    });
+    socket.once("error", (error) => {
+      finish(error);
+    });
+    socket.once("timeout", () => {
+      const timeoutError = Object.assign(new Error("PostgreSQL TCP connection timed out."), {
+        code: "ETIMEDOUT",
+      });
+      finish(timeoutError);
+    });
+  });
+};
+
+export const waitForDatabase = async (
+  options: TWaitForDatabaseOptions,
+  dependencies: TWaitForDatabaseDependencies = {}
+): Promise<void> => {
+  const checkConnection = dependencies.checkConnection ?? checkDatabaseTcpConnection;
+  const log = dependencies.log ?? console.log;
+  const now = dependencies.now ?? Date.now;
+  const wait = dependencies.sleep ?? sleep;
+  const timeoutMs = options.timeoutSeconds * 1000;
+  const intervalMs = options.intervalSeconds * 1000;
+  const connectionTimeoutMs = options.connectionTimeoutSeconds * 1000;
+  const startedAt = now();
+  let attempt = 0;
+  let lastErrorCode = "UNKNOWN";
+
+  while (now() - startedAt < timeoutMs) {
+    const remainingMs = timeoutMs - (now() - startedAt);
+
+    if (remainingMs <= 0) {
+      throw new Error(
+        `PostgreSQL did not become reachable within ${options.timeoutSeconds.toString()} seconds (last error code: ${lastErrorCode}).`
+      );
+    }
+
+    attempt += 1;
+
+    try {
+      await checkConnection(options.endpoint, Math.min(connectionTimeoutMs, remainingMs));
+      log(`PostgreSQL is reachable after ${attempt.toString()} attempt(s).`);
+      return;
+    } catch (error) {
+      lastErrorCode = getSafeErrorCode(error);
+      const remainingAfterAttemptMs = timeoutMs - (now() - startedAt);
+
+      if (remainingAfterAttemptMs <= 0) {
+        throw new Error(
+          `PostgreSQL did not become reachable within ${options.timeoutSeconds.toString()} seconds (last error code: ${lastErrorCode}).`
+        );
+      }
+
+      const delayMs = Math.min(intervalMs, remainingAfterAttemptMs);
+      log(
+        `PostgreSQL is not reachable yet (attempt ${attempt.toString()}, error code: ${lastErrorCode}); retrying in ${(delayMs / 1000).toString()} second(s).`
+      );
+      await wait(delayMs);
+    }
+  }
+
+  throw new Error(
+    `PostgreSQL did not become reachable within ${options.timeoutSeconds.toString()} seconds (last error code: ${lastErrorCode}).`
+  );
+};
+
+export const parseCliOptions = (args: string[]): TWaitForDatabaseCliOptions => {
+  const options: TWaitForDatabaseCliOptions = {
+    connectionTimeoutSeconds: DEFAULT_CONNECTION_TIMEOUT_SECONDS,
+    intervalSeconds: DEFAULT_INTERVAL_SECONDS,
+    timeoutSeconds: DEFAULT_TIMEOUT_SECONDS,
+  };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const optionName = args[index];
+    const optionValue = args[index + 1];
+
+    if (!optionValue) {
+      throw new Error(`${optionName} requires a value.`);
+    }
+
+    switch (optionName) {
+      case "--connection-timeout-seconds":
+        options.connectionTimeoutSeconds = toPositiveNumber(optionValue, optionName);
+        break;
+      case "--interval-seconds":
+        options.intervalSeconds = toPositiveNumber(optionValue, optionName);
+        break;
+      case "--timeout-seconds":
+        options.timeoutSeconds = toPositiveNumber(optionValue, optionName);
+        break;
+      default:
+        throw new Error(`Unknown option: ${optionName}`);
+    }
+
+    index += 1;
+  }
+
+  return options;
+};
+
+const main = async (): Promise<void> => {
+  const databaseUrl = getMigrationDatabaseUrl();
+  const endpoint = parseDatabaseEndpoint(databaseUrl);
+  const options = parseCliOptions(process.argv.slice(2));
+
+  await waitForDatabase({ endpoint, ...options });
+};
+
+const isDirectExecution = process.argv[1] ? import.meta.url === pathToFileURL(process.argv[1]).href : false;
+
+if (isDirectExecution) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : "PostgreSQL readiness check failed.";
+    console.error(message);
+    process.exit(1);
+  });
+}

--- a/packages/database/vite.config.ts
+++ b/packages/database/vite.config.ts
@@ -48,6 +48,7 @@ export default defineConfig(async (): Promise<UserConfig> => {
           "scripts/apply-migrations": resolve(__dirname, "src/scripts/apply-migrations.ts"),
           "scripts/create-saml-database": resolve(__dirname, "src/scripts/create-saml-database.ts"),
           "scripts/migration-runner": resolve(__dirname, "src/scripts/migration-runner.ts"),
+          "scripts/wait-for-database": resolve(__dirname, "src/scripts/wait-for-database.ts"),
           "scripts/backfill-attribute-values": resolve(__dirname, "src/scripts/backfill-attribute-values.ts"),
           ...migrationEntries,
         },


### PR DESCRIPTION
## Problem

On fresh Helm installs, the migration Job can start before PostgreSQL is accepting connections. The migration then fails immediately and consumes the existing Job retry budget even though the database is still starting.

Fixes [ENG-1807](https://linear.app/formbricks/issue/ENG-1807/52-blocker-wait-for-postgresql-readiness-before-running-the-helm).

## What changed

- Added a small `@formbricks/database` readiness CLI that:
  - prefers `MIGRATE_DATABASE_URL` over `DATABASE_URL`
  - validates PostgreSQL TCP URLs, including explicit/default ports and IPv6
  - retries TCP connection checks with configurable timeouts
  - logs only endpoint-safe status and error codes, never credentials or complete URLs
- Added a `wait-for-database` init container to the migration Job.
  - It uses the same Formbricks image, environment sources, resources, pod scheduling, and security configuration as the migration container.
  - The migration command and `backoffLimit` remain unchanged.
- Added the `migration.waitForDatabase` chart interface, enabled by default with a 900-second overall timeout and 5-second intervals.
- Assigned bundled PostgreSQL resources to Argo CD sync wave `-2`, while keeping the migration hook at wave `-1`.
- Added required PR-time Helm validation for default, external-database, and readiness-disabled renders.
- Documented database URL precedence, readiness configuration, and Argo ordering.

## Impact

Fresh bundled and external PostgreSQL deployments now wait for the database endpoint to become reachable before Prisma migrations start. Authentication, TLS, and migration errors still fail through the normal migration path. Deployments with their own readiness gate can disable the init container.

Hub's existing wait-for-Formbricks-migration behavior is unchanged.

## Validation

- `pnpm --filter @formbricks/database test` — 34 tests passed
- `pnpm --filter @formbricks/database typecheck`
- Database package build and compiled CLI verification
- Full production Docker image build and secret-safe CLI smoke test
- `helm lint charts/formbricks`
- Default, external-database, readiness-disabled, environment-parity, and Argo-wave render checks
- Kubernetes server-side dry-run of the migration Job
- Clean minikube install with an empty PostgreSQL image cache:
  - readiness retried during the cold PostgreSQL pull
  - one migration pod, zero restarts, and no failed Job attempts
  - migrations completed, Hub and worker became ready, and `/health` returned 200
- Delayed external PostgreSQL test completed after the endpoint became available
- A second Helm upgrade completed successfully
- Readiness-disabled escape hatch started migrations directly as expected