### PR TITLE
fix(turbo): exclude .next/cache and .next/dev from web build outputs

### DIFF
--- a/apps/web/lib/turbo-build-outputs.test.ts
+++ b/apps/web/lib/turbo-build-outputs.test.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+// Guards the Turborepo output exclusions for the web build (see ENG-1805). The generic `build`
+// task must exclude `.next/cache/**` and `.next/dev/**` so Turbo never caches the transient
+// Next.js cache and dev directories — otherwise they fill local and CI disks (regression of the
+// ENG-1662 fix). Because `@formbricks/web` has no `#build` override today it inherits `build`,
+// but this test resolves outputs the same way Turbo does so a future package-specific override
+// cannot silently drop the exclusions again.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const turboJsonPath = path.resolve(here, "..", "..", "..", "turbo.json");
+
+const REQUIRED_EXCLUSIONS = ["!.next/cache/**", "!.next/dev/**"];
+
+describe("turbo.json web build excludes transient Next.js dirs", () => {
+  const turboJson = JSON.parse(fs.readFileSync(turboJsonPath, "utf-8")) as {
+    tasks: Record<string, { outputs?: string[] }>;
+  };
+
+  // Turbo uses the package-specific task when defined, otherwise the generic one.
+  const resolvedOutputs = turboJson.tasks["@formbricks/web#build"]?.outputs ?? turboJson.tasks.build.outputs ?? [];
+
+  test("resolved @formbricks/web#build outputs exclude .next/cache and .next/dev", () => {
+    const missing = REQUIRED_EXCLUSIONS.filter((exclusion) => !resolvedOutputs.includes(exclusion));
+    expect(
+      missing,
+      `@formbricks/web#build resolved outputs are missing exclusion(s): ${missing.join(", ")}. ` +
+        "Add them to the build task's `outputs` array so Turbo does not cache transient Next.js dirs (ENG-1805)."
+    ).toEqual([]);
+  });
+
+  test("still caches the deployable build artifacts", () => {
+    expect(resolvedOutputs).toContain(".next/**");
+    expect(resolvedOutputs).toContain("dist/**");
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -223,7 +223,7 @@
         "NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR",
         "NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE"
       ],
-      "outputs": ["dist/**", ".next/**"],
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**", "!.next/dev/**"],
       "passThroughEnv": [
         "AUDIT_LOG_ENABLED",
         "AUDIT_LOG_GET_USER_IP",


### PR DESCRIPTION
## What does this PR do?

Fixes [ENG-1805](https://linear.app/formbricks/issue/ENG-1805) — a 5.2 release blocker found during ENG-1759 QA.

The `.next/cache` and `.next/dev` directories were still eligible for Turbo caching on the web build, so they can keep filling local and CI disks — the regression of the ENG-1662 / PR #8448 fix.

**Root cause:** `@formbricks/web` inherits the generic `build` task, whose `outputs` were `["dist/**", ".next/**"]` with no exclusions. The resolved task therefore reported `excludedOutputs: null`.

**Fix:** add `"!.next/cache/**"` and `"!.next/dev/**"` to the `build` task `outputs`. Turbo still caches the deployable `.next/**` and `dist/**` artifacts but no longer caches the transient cache/dev dirs.

Also adds a regression test (`apps/web/lib/turbo-build-outputs.test.ts`, mirroring the existing `turbo-build-env.test.ts`) that resolves the web build outputs the same way Turbo does — using an `@formbricks/web#build` override if one ever exists, else the generic task — so a future package-specific override cannot silently drop the exclusions again.

## Verification

`pnpm turbo run build --filter=@formbricks/web --dry=json` resolved task, before → after:

```
before: {"outputs":[".next/**","dist/**"],"excludedOutputs":null}
after:  {"outputs":[".next/**","dist/**"],"excludedOutputs":[".next/cache/**",".next/dev/**"]}
```

- `pnpm exec vitest run lib/turbo-build-outputs.test.ts lib/turbo-build-env.test.ts` → 4 passed.
- `clean:cache` (`rimraf .turbo/cache apps/web/.next`) already removes Turbo + Next.js caches while preserving `node_modules` — unchanged.
- `cacheMaxSize: "10GB"` cap unchanged.

## Acceptance criteria

- [x] `@formbricks/web#build` resolved outputs exclude `.next/cache/**` and `.next/dev/**`
- [x] `--dry=json` proves the exclusions are active
- [x] Deployable `.next/**` + `dist/**` artifacts remain cached
- [x] `pnpm clean:cache` removes Turbo + Next.js caches, preserves `node_modules`
- [x] 10 GB Turbo cache cap remains effective
- [x] Regression assertion added for the resolved web task outputs
- [ ] Repeated unchanged build reports FULL TURBO — verify in CI / locally with a full build

## How should this be tested?

1. `pnpm turbo run build --filter=@formbricks/web --dry=json` → resolved `@formbricks/web#build` shows `excludedOutputs: [".next/cache/**", ".next/dev/**"]`.
2. Full `pnpm build --filter=@formbricks/web`, confirm standalone/static artifacts present and cached.
3. Re-run unchanged → cache hit / FULL TURBO, and `.next/cache` / `.next/dev` are not restored from cache.