### PR TITLE
fix(api): reject publishing an app survey with zero triggers (5.2 backport) (#8547)

### DIFF
--- a/apps/web/app/api/v3/surveys/patch.ts
+++ b/apps/web/app/api/v3/surveys/patch.ts
@@ -5,7 +5,12 @@ import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import type { TSurvey } from "@formbricks/types/surveys/types";
 import { getActionClasses } from "@/lib/actionClass/service";
 import { selectSurvey } from "@/lib/survey/service";
-import { stripIsDraftFromBlocks, transformPrismaSurvey } from "@/lib/survey/utils";
+import {
+  APP_SURVEY_TRIGGER_REQUIRED_MESSAGE,
+  isAppSurveyMissingTriggersToPublish,
+  stripIsDraftFromBlocks,
+  transformPrismaSurvey,
+} from "@/lib/survey/utils";
 import { handleTriggerUpdates } from "@/modules/survey/lib/trigger-updates";
 import {
   isSurveySchedulingDue,
@@ -172,6 +177,16 @@ export async function executeV3SurveyPatch(params: {
   const mediaInvalidParams = getV3SurveyMediaInvalidParams(document.blocks);
   if (mediaInvalidParams.length > 0) {
     throw new V3SurveyReferenceValidationError(mediaInvalidParams);
+  }
+
+  // An app survey can never be shown without a trigger, so reject setting a non-draft status with no
+  // effective triggers. Triggers only change when the patch carries a `distribution` (top-level
+  // replacement); otherwise the survey keeps its current triggers.
+  const effectiveTriggers = document.distribution ? document.distribution.triggers : currentSurvey.triggers;
+  if (isAppSurveyMissingTriggersToPublish(currentSurvey.type, document.status, effectiveTriggers)) {
+    throw new V3SurveyReferenceValidationError([
+      { name: "triggers", reason: APP_SURVEY_TRIGGER_REQUIRED_MESSAGE },
+    ]);
   }
 
   const languages = await ensureV3WorkspaceLanguages(currentSurvey.workspaceId, languageRequests, requestId);

--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -552,7 +552,7 @@ describe("Tests for createSurvey", () => {
     name: "Test Survey",
     type: "app" as const,
     createdBy: mockUserId,
-    status: "inProgress" as const,
+    status: "draft" as const,
     welcomeCard: {
       enabled: true,
       headline: { default: "Welcome" },

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -22,8 +22,10 @@ import { getActionClasses } from "../actionClass/service";
 import { ITEMS_PER_PAGE } from "../constants";
 import { validateInputs } from "../utils/validate";
 import {
+  APP_SURVEY_TRIGGER_REQUIRED_MESSAGE,
   checkForInvalidImagesInQuestions,
   checkForInvalidMediaInBlocks,
+  isAppSurveyMissingTriggersToPublish,
   stripIsDraftFromBlocks,
   transformPrismaSurvey,
   validateMediaAndPrepareBlocks,
@@ -293,6 +295,12 @@ export const updateSurveyInternal = async (
 
     if (!skipValidation) {
       checkForInvalidImagesInQuestions(questions);
+
+      // An app survey can never be shown without a trigger, so block publishing (non-draft status)
+      // one with zero triggers. The editor enforces this client-side only; mirror it server-side.
+      if (isAppSurveyMissingTriggersToPublish(type, updatedSurvey.status, triggers)) {
+        throw new InvalidInputError(APP_SURVEY_TRIGGER_REQUIRED_MESSAGE);
+      }
     }
 
     // Add blocks media validation. The validation error is already an InvalidInputError, so the
@@ -665,6 +673,18 @@ export const createSurvey = async (
     const { createdBy, languages, segment, followUps, styling, ...restSurveyBody } = parsedSurveyBody;
     assertSurveyLanguagesBelongToWorkspace(parsedWorkspaceId, languages);
     await assertSurveySegmentBelongsToWorkspace(parsedWorkspaceId, segment);
+
+    // An app survey can never be shown without a trigger, so block creating one directly in a
+    // non-draft status with zero triggers (mirrors the editor's publish guard).
+    if (
+      isAppSurveyMissingTriggersToPublish(
+        restSurveyBody.type ?? "link",
+        restSurveyBody.status ?? "draft",
+        restSurveyBody.triggers
+      )
+    ) {
+      throw new InvalidInputError(APP_SURVEY_TRIGGER_REQUIRED_MESSAGE);
+    }
     const normalizedCloseOn = restSurveyBody.closeOn instanceof Date ? restSurveyBody.closeOn : null;
     const normalizedPublishOn = restSurveyBody.publishOn instanceof Date ? restSurveyBody.publishOn : null;
     const surveyLanguagesCreateData: Prisma.SurveyLanguageCreateNestedManyWithoutSurveyInput | undefined =

--- a/apps/web/lib/survey/utils.ts
+++ b/apps/web/lib/survey/utils.ts
@@ -10,9 +10,29 @@ import {
   TSurveyElementTypeEnum,
   TSurveyPictureChoice,
 } from "@formbricks/types/surveys/elements";
-import { TSurvey, TSurveyQuestion, TSurveyQuestionTypeEnum } from "@formbricks/types/surveys/types";
+import {
+  TSurvey,
+  TSurveyQuestion,
+  TSurveyQuestionTypeEnum,
+  TSurveyStatus,
+  TSurveyType,
+} from "@formbricks/types/surveys/types";
 import { isValidVideoUrl } from "@/lib/utils/video-upload";
 import { isValidImageFile } from "@/modules/storage/utils";
+
+/**
+ * A live (non-draft) app survey must have at least one trigger, otherwise it can never be displayed
+ * ("live but dormant"). The survey editor only enforces this client-side, so every server write path
+ * (create + update, including the v3 API) applies this check to keep the API in parity with the UI.
+ */
+export const APP_SURVEY_TRIGGER_REQUIRED_MESSAGE =
+  "An app survey must have at least one trigger to be set to a non-draft status.";
+
+export const isAppSurveyMissingTriggersToPublish = (
+  type: TSurveyType,
+  status: TSurveyStatus,
+  triggers: readonly unknown[] | null | undefined
+): boolean => type === "app" && status !== "draft" && (triggers?.length ?? 0) === 0;
 
 /**
  * Actionable hint appended to invalid-image messages. Names the supported formats and explains why


### PR DESCRIPTION
## Backport of #8547 to `release/5.2`

Cherry-pick of the fix from #8547 (`fix(api): reject publishing an app survey with zero triggers`).

### Problem
An app survey could be published / moved to a non-draft status (`inProgress`, `paused`, `completed`) with zero triggers, which is invalid.

### Solution
- Add `isAppSurveyMissingTriggersToPublish` helper (`lib/survey/utils.ts`) and enforce it in:
  - `lib/survey/service.ts` → `createSurvey` throws `InvalidInputError`
  - `app/api/v3/surveys/patch.ts` → rejects with `V3SurveyReferenceValidationError`

### Backport notes
Per our backport convention, new tests added in the original PR were dropped to keep the diff minimal. The one **existing** test modification needed to keep the suite green is retained:
- `lib/survey/service.test.ts`: `createSurvey` fixture default status changed `inProgress` → `draft` (an `inProgress` app survey with no triggers now throws).

### Verification
`pnpm exec vitest run` on the affected files — **114 tests passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)