### PR TITLE
fix: sync Better Auth TwoFactor table so 2FA login works after enabling

### DIFF
--- a/apps/web/modules/auth/lib/after-auth-hooks.ts
+++ b/apps/web/modules/auth/lib/after-auth-hooks.ts
@@ -5,6 +5,7 @@ import {
   ssoRecoveryAfterHandler,
 } from "@/modules/ee/sso/lib/better-auth-hooks";
 import { auditFailedAuthAfter } from "./better-auth-observability";
+import { twoFactorBackfillAfterHandler } from "./better-auth-two-factor-backfill";
 
 /**
  * Composed Better Auth `hooks.after` chain. Ordering rationale: `auditFailedAuthAfter` runs before
@@ -19,5 +20,8 @@ import { auditFailedAuthAfter } from "./better-auth-observability";
 export const runAfterAuthHooks = async (ctx: AuthHookContext): Promise<void> => {
   await ssoRecoveryAfterHandler(ctx);
   await auditFailedAuthAfter(ctx);
+  // ENG-1824: heal legacy 2FA enrollments (no `TwoFactor` row) on successful password sign-in, before
+  // the 2FA challenge. Only touches `/sign-in/email`, so it's unaffected by the SSO-only redirect below.
+  await twoFactorBackfillAfterHandler(ctx);
   await blockedSignupDomainRedirectAfterHandler(ctx);
 };

--- a/apps/web/modules/auth/lib/better-auth-two-factor-backfill.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-two-factor-backfill.test.ts
@@ -1,0 +1,94 @@
+import { isAPIError } from "better-auth/api";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { buildReencodedTwoFactorData } from "@/modules/auth/lib/cutover/reencode-two-factor";
+import { twoFactorBackfillAfterHandler } from "./better-auth-two-factor-backfill";
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    user: { findUnique: vi.fn() },
+    twoFactor: { findUnique: vi.fn(), upsert: vi.fn() },
+  },
+}));
+
+vi.mock("better-auth/api", () => ({ isAPIError: vi.fn() }));
+
+vi.mock("@/modules/auth/lib/auth", () => ({
+  auth: { $context: Promise.resolve({ secretConfig: "ba-secret-config" }) },
+}));
+
+vi.mock("@/modules/auth/lib/cutover/reencode-two-factor", () => ({
+  buildReencodedTwoFactorData: vi.fn(),
+}));
+
+// Minimal AuthHookContext for a successful /sign-in/email of a legacy-2FA user.
+const ctx = (overrides: Record<string, unknown> = {}) =>
+  ({
+    path: "/sign-in/email",
+    body: { email: "user@example.com" },
+    context: { returned: { twoFactorRedirect: true } },
+    ...overrides,
+  }) as any;
+
+describe("twoFactorBackfillAfterHandler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isAPIError).mockReturnValue(false); // success by default
+    vi.mocked(buildReencodedTwoFactorData).mockResolvedValue({
+      secret: "ba-secret",
+      backupCodes: "ba-codes",
+    });
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "user123",
+      twoFactorEnabled: true,
+      twoFactorSecret: "encrypted_secret",
+      backupCodes: "encrypted_codes",
+    } as any);
+    vi.mocked(prisma.twoFactor.findUnique).mockResolvedValue(null); // no BA row yet
+  });
+
+  test("backfills the TwoFactor row for a legacy-enrolled user on successful sign-in", async () => {
+    await twoFactorBackfillAfterHandler(ctx());
+
+    expect(buildReencodedTwoFactorData).toHaveBeenCalledWith(
+      "encrypted_secret",
+      "encrypted_codes",
+      "ba-secret-config"
+    );
+    expect(prisma.twoFactor.upsert).toHaveBeenCalledWith({
+      where: { userId: "user123" },
+      update: { secret: "ba-secret", backupCodes: "ba-codes", verified: true },
+      create: { userId: "user123", secret: "ba-secret", backupCodes: "ba-codes", verified: true },
+    });
+  });
+
+  test("no-op on a non-sign-in path", async () => {
+    await twoFactorBackfillAfterHandler(ctx({ path: "/two-factor/verify-totp" }));
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(prisma.twoFactor.upsert).not.toHaveBeenCalled();
+  });
+
+  test("no-op on a failed sign-in (APIError) — never a pre-auth write", async () => {
+    vi.mocked(isAPIError).mockReturnValue(true);
+    await twoFactorBackfillAfterHandler(ctx({ context: { returned: { message: "bad password" } } }));
+    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(prisma.twoFactor.upsert).not.toHaveBeenCalled();
+  });
+
+  test("no-op when the user already has a TwoFactor row", async () => {
+    vi.mocked(prisma.twoFactor.findUnique).mockResolvedValue({ id: "tf1" } as any);
+    await twoFactorBackfillAfterHandler(ctx());
+    expect(prisma.twoFactor.upsert).not.toHaveBeenCalled();
+  });
+
+  test("no-op for a non-2FA / SSO user (no legacy secret or flag off)", async () => {
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      id: "sso1",
+      twoFactorEnabled: false,
+      twoFactorSecret: null,
+      backupCodes: null,
+    } as any);
+    await twoFactorBackfillAfterHandler(ctx());
+    expect(prisma.twoFactor.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/modules/auth/lib/better-auth-two-factor-backfill.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-two-factor-backfill.test.ts
@@ -2,6 +2,7 @@ import { isAPIError } from "better-auth/api";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { buildReencodedTwoFactorData } from "@/modules/auth/lib/cutover/reencode-two-factor";
+import type { AuthHookContext } from "@/modules/ee/sso/lib/better-auth-hooks";
 import { twoFactorBackfillAfterHandler } from "./better-auth-two-factor-backfill";
 
 vi.mock("@formbricks/database", () => ({
@@ -30,7 +31,7 @@ const ctx = (overrides: Record<string, unknown> = {}) =>
     body: { email: "user@example.com" },
     context: { returned: { twoFactorRedirect: true } },
     ...overrides,
-  }) as any;
+  }) as unknown as AuthHookContext;
 
 describe("twoFactorBackfillAfterHandler", () => {
   beforeEach(() => {

--- a/apps/web/modules/auth/lib/better-auth-two-factor-backfill.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-two-factor-backfill.test.ts
@@ -14,7 +14,7 @@ vi.mock("@formbricks/database", () => ({
 
 vi.mock("better-auth/api", () => ({ isAPIError: vi.fn() }));
 
-vi.mock("@formbricks/logger", () => ({ logger: { warn: vi.fn() } }));
+vi.mock("@formbricks/logger", () => ({ logger: { warn: vi.fn(), error: vi.fn() } }));
 
 vi.mock("@/modules/auth/lib/auth", () => ({
   auth: { $context: Promise.resolve({ secretConfig: "ba-secret-config" }) },

--- a/apps/web/modules/auth/lib/better-auth-two-factor-backfill.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-two-factor-backfill.test.ts
@@ -13,6 +13,8 @@ vi.mock("@formbricks/database", () => ({
 
 vi.mock("better-auth/api", () => ({ isAPIError: vi.fn() }));
 
+vi.mock("@formbricks/logger", () => ({ logger: { warn: vi.fn() } }));
+
 vi.mock("@/modules/auth/lib/auth", () => ({
   auth: { $context: Promise.resolve({ secretConfig: "ba-secret-config" }) },
 }));
@@ -90,5 +92,11 @@ describe("twoFactorBackfillAfterHandler", () => {
     } as any);
     await twoFactorBackfillAfterHandler(ctx());
     expect(prisma.twoFactor.upsert).not.toHaveBeenCalled();
+  });
+
+  test("a heal failure is swallowed and never blocks sign-in", async () => {
+    vi.mocked(prisma.twoFactor.upsert).mockRejectedValue(new Error("ON CONFLICT constraint missing"));
+    // Must resolve, not reject — the sign-in it runs inside must not 500.
+    await expect(twoFactorBackfillAfterHandler(ctx())).resolves.toBeUndefined();
   });
 });

--- a/apps/web/modules/auth/lib/better-auth-two-factor-backfill.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-two-factor-backfill.test.ts
@@ -6,7 +6,7 @@ import { twoFactorBackfillAfterHandler } from "./better-auth-two-factor-backfill
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
-    user: { findUnique: vi.fn() },
+    user: { findFirst: vi.fn() },
     twoFactor: { findUnique: vi.fn(), upsert: vi.fn() },
   },
 }));
@@ -38,7 +38,7 @@ describe("twoFactorBackfillAfterHandler", () => {
       secret: "ba-secret",
       backupCodes: "ba-codes",
     });
-    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+    vi.mocked(prisma.user.findFirst).mockResolvedValue({
       id: "user123",
       twoFactorEnabled: true,
       twoFactorSecret: "encrypted_secret",
@@ -64,14 +64,14 @@ describe("twoFactorBackfillAfterHandler", () => {
 
   test("no-op on a non-sign-in path", async () => {
     await twoFactorBackfillAfterHandler(ctx({ path: "/two-factor/verify-totp" }));
-    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(prisma.user.findFirst).not.toHaveBeenCalled();
     expect(prisma.twoFactor.upsert).not.toHaveBeenCalled();
   });
 
   test("no-op on a failed sign-in (APIError) — never a pre-auth write", async () => {
     vi.mocked(isAPIError).mockReturnValue(true);
     await twoFactorBackfillAfterHandler(ctx({ context: { returned: { message: "bad password" } } }));
-    expect(prisma.user.findUnique).not.toHaveBeenCalled();
+    expect(prisma.user.findFirst).not.toHaveBeenCalled();
     expect(prisma.twoFactor.upsert).not.toHaveBeenCalled();
   });
 
@@ -82,7 +82,7 @@ describe("twoFactorBackfillAfterHandler", () => {
   });
 
   test("no-op for a non-2FA / SSO user (no legacy secret or flag off)", async () => {
-    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+    vi.mocked(prisma.user.findFirst).mockResolvedValue({
       id: "sso1",
       twoFactorEnabled: false,
       twoFactorSecret: null,

--- a/apps/web/modules/auth/lib/better-auth-two-factor-backfill.ts
+++ b/apps/web/modules/auth/lib/better-auth-two-factor-backfill.ts
@@ -68,9 +68,12 @@ export const twoFactorBackfillAfterHandler = async (ctx: AuthHookContext): Promi
       create: { userId: user.id, ...twoFactorRow, verified: true },
     });
   } catch (error) {
-    logger.warn(
+    // Error level, not warn: the sign-in still succeeds (we swallow so login never 500s), but a failure
+    // here means the user is left in the exact broken state this heal exists to fix ("TOTP not
+    // enabled"). It must be loud enough to catch in QA/monitoring rather than hide in the noise.
+    logger.error(
       { error: error instanceof Error ? error.message : error },
-      "Two-factor credential backfill failed; continuing sign-in"
+      "Two-factor credential backfill failed; user will still see 'TOTP not enabled' until resolved"
     );
   }
 };

--- a/apps/web/modules/auth/lib/better-auth-two-factor-backfill.ts
+++ b/apps/web/modules/auth/lib/better-auth-two-factor-backfill.ts
@@ -68,6 +68,9 @@ export const twoFactorBackfillAfterHandler = async (ctx: AuthHookContext): Promi
       create: { userId: user.id, ...twoFactorRow, verified: true },
     });
   } catch (error) {
-    logger.warn({ error }, "Two-factor credential backfill failed; continuing sign-in");
+    logger.warn(
+      { error: error instanceof Error ? error.message : error },
+      "Two-factor credential backfill failed; continuing sign-in"
+    );
   }
 };

--- a/apps/web/modules/auth/lib/better-auth-two-factor-backfill.ts
+++ b/apps/web/modules/auth/lib/better-auth-two-factor-backfill.ts
@@ -1,0 +1,61 @@
+import "server-only";
+import { isAPIError } from "better-auth/api";
+import { prisma } from "@formbricks/database";
+import { buildReencodedTwoFactorData } from "@/modules/auth/lib/cutover/reencode-two-factor";
+import type { AuthHookContext } from "@/modules/ee/sso/lib/better-auth-hooks";
+
+/**
+ * ENG-1824 self-heal. The custom 2FA enable flow (`modules/ee/two-factor-auth`) historically wrote the
+ * secret only to the legacy `User.twoFactorSecret` column, but login verifies via Better Auth's
+ * `twoFactor` plugin, which reads the `TwoFactor` table. Users who enabled 2FA before the enable-path
+ * bridge landed have the legacy columns but no `TwoFactor` row, so login throws "TOTP not enabled".
+ *
+ * This lazily re-encodes their existing secret + backup codes into the `TwoFactor` table on their next
+ * successful password sign-in — no data migration, no re-enrollment — so the `/two-factor/verify-*`
+ * step that follows finds a row and succeeds. Idempotent (`TwoFactor.userId` is `@@unique`).
+ *
+ * Runs as a `hooks.after` on `/sign-in/email` and ONLY when that sign-in succeeded (password verified):
+ * a wrong-password attempt is a handled `APIError` on `ctx.context.returned`, which we skip. This keeps
+ * it from being an unauthenticated, email-guessable write. It materializes only the user's OWN existing
+ * secret, returns nothing to the client, and no-ops for SSO users, non-2FA users, and users who already
+ * have a `TwoFactor` row.
+ */
+export const twoFactorBackfillAfterHandler = async (ctx: AuthHookContext): Promise<void> => {
+  if (ctx.path !== "/sign-in/email") return;
+
+  // Only heal after a successful password step; a failed sign-in surfaces as an APIError response.
+  const returned = (ctx.context as { returned?: unknown }).returned;
+  if (isAPIError(returned)) return;
+
+  const body = ctx.body as { email?: unknown } | undefined;
+  const email = typeof body?.email === "string" ? body.email.trim().toLowerCase() : undefined;
+  if (!email) return;
+
+  const user = await prisma.user.findUnique({
+    where: { email },
+    select: { id: true, twoFactorEnabled: true, twoFactorSecret: true, backupCodes: true },
+  });
+  // Only a legacy-enrolled user (2FA on + legacy secret present) can be missing a BA row.
+  if (!user?.twoFactorEnabled || !user.twoFactorSecret) return;
+
+  const existing = await prisma.twoFactor.findUnique({
+    where: { userId: user.id },
+    select: { id: true },
+  });
+  if (existing) return;
+
+  // Lazy import: this module is loaded eagerly as part of the `hooks.after` chain in auth.ts, so a
+  // top-level `auth` import would be circular. We only need it once we're actually healing a row.
+  const { auth } = await import("@/modules/auth/lib/auth");
+  const { secretConfig } = await auth.$context;
+  const twoFactorRow = await buildReencodedTwoFactorData(
+    user.twoFactorSecret,
+    user.backupCodes,
+    secretConfig
+  );
+  await prisma.twoFactor.upsert({
+    where: { userId: user.id },
+    update: { ...twoFactorRow, verified: true },
+    create: { userId: user.id, ...twoFactorRow, verified: true },
+  });
+};

--- a/apps/web/modules/auth/lib/better-auth-two-factor-backfill.ts
+++ b/apps/web/modules/auth/lib/better-auth-two-factor-backfill.ts
@@ -28,11 +28,15 @@ export const twoFactorBackfillAfterHandler = async (ctx: AuthHookContext): Promi
   if (isAPIError(returned)) return;
 
   const body = ctx.body as { email?: unknown } | undefined;
-  const email = typeof body?.email === "string" ? body.email.trim().toLowerCase() : undefined;
+  const email = typeof body?.email === "string" ? body.email.trim() : undefined;
   if (!email) return;
 
-  const user = await prisma.user.findUnique({
-    where: { email },
+  // One indexed lookup on each successful password sign-in (a small, deliberate cost for this
+  // temporary heal shim — it can be removed together with the legacy `User.twoFactor*` columns once
+  // all enrollments are migrated). Case-insensitive so we match the same account the sign-in did,
+  // whatever the stored email case; emails are unique, so this resolves to exactly one user.
+  const user = await prisma.user.findFirst({
+    where: { email: { equals: email, mode: "insensitive" } },
     select: { id: true, twoFactorEnabled: true, twoFactorSecret: true, backupCodes: true },
   });
   // Only a legacy-enrolled user (2FA on + legacy secret present) can be missing a BA row.

--- a/apps/web/modules/auth/lib/better-auth-two-factor-backfill.ts
+++ b/apps/web/modules/auth/lib/better-auth-two-factor-backfill.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { isAPIError } from "better-auth/api";
 import { prisma } from "@formbricks/database";
+import { logger } from "@formbricks/logger";
 import { buildReencodedTwoFactorData } from "@/modules/auth/lib/cutover/reencode-two-factor";
 import type { AuthHookContext } from "@/modules/ee/sso/lib/better-auth-hooks";
 
@@ -31,35 +32,42 @@ export const twoFactorBackfillAfterHandler = async (ctx: AuthHookContext): Promi
   const email = typeof body?.email === "string" ? body.email.trim() : undefined;
   if (!email) return;
 
-  // One indexed lookup on each successful password sign-in (a small, deliberate cost for this
-  // temporary heal shim — it can be removed together with the legacy `User.twoFactor*` columns once
-  // all enrollments are migrated). Case-insensitive so we match the same account the sign-in did,
-  // whatever the stored email case; emails are unique, so this resolves to exactly one user.
-  const user = await prisma.user.findFirst({
-    where: { email: { equals: email, mode: "insensitive" } },
-    select: { id: true, twoFactorEnabled: true, twoFactorSecret: true, backupCodes: true },
-  });
-  // Only a legacy-enrolled user (2FA on + legacy secret present) can be missing a BA row.
-  if (!user?.twoFactorEnabled || !user.twoFactorSecret) return;
+  // Best-effort: this heal is a convenience, so a failure here (transient DB error, drift, etc.) must
+  // never break the sign-in it runs inside. Swallow and log; the user still reaches the 2FA prompt, and
+  // a persistent failure surfaces as the pre-existing "TOTP not enabled" rather than a 500.
+  try {
+    // One indexed lookup on each successful password sign-in (a small, deliberate cost for this
+    // temporary heal shim — it can be removed together with the legacy `User.twoFactor*` columns once
+    // all enrollments are migrated). Case-insensitive so we match the same account the sign-in did,
+    // whatever the stored email case; emails are unique, so this resolves to exactly one user.
+    const user = await prisma.user.findFirst({
+      where: { email: { equals: email, mode: "insensitive" } },
+      select: { id: true, twoFactorEnabled: true, twoFactorSecret: true, backupCodes: true },
+    });
+    // Only a legacy-enrolled user (2FA on + legacy secret present) can be missing a BA row.
+    if (!user?.twoFactorEnabled || !user.twoFactorSecret) return;
 
-  const existing = await prisma.twoFactor.findUnique({
-    where: { userId: user.id },
-    select: { id: true },
-  });
-  if (existing) return;
+    const existing = await prisma.twoFactor.findUnique({
+      where: { userId: user.id },
+      select: { id: true },
+    });
+    if (existing) return;
 
-  // Lazy import: this module is loaded eagerly as part of the `hooks.after` chain in auth.ts, so a
-  // top-level `auth` import would be circular. We only need it once we're actually healing a row.
-  const { auth } = await import("@/modules/auth/lib/auth");
-  const { secretConfig } = await auth.$context;
-  const twoFactorRow = await buildReencodedTwoFactorData(
-    user.twoFactorSecret,
-    user.backupCodes,
-    secretConfig
-  );
-  await prisma.twoFactor.upsert({
-    where: { userId: user.id },
-    update: { ...twoFactorRow, verified: true },
-    create: { userId: user.id, ...twoFactorRow, verified: true },
-  });
+    // Lazy import: this module is loaded eagerly as part of the `hooks.after` chain in auth.ts, so a
+    // top-level `auth` import would be circular. We only need it once we're actually healing a row.
+    const { auth } = await import("@/modules/auth/lib/auth");
+    const { secretConfig } = await auth.$context;
+    const twoFactorRow = await buildReencodedTwoFactorData(
+      user.twoFactorSecret,
+      user.backupCodes,
+      secretConfig
+    );
+    await prisma.twoFactor.upsert({
+      where: { userId: user.id },
+      update: { ...twoFactorRow, verified: true },
+      create: { userId: user.id, ...twoFactorRow, verified: true },
+    });
+  } catch (error) {
+    logger.warn({ error }, "Two-factor credential backfill failed; continuing sign-in");
+  }
 };

--- a/apps/web/modules/auth/lib/cutover/reencode-two-factor.integration.test.ts
+++ b/apps/web/modules/auth/lib/cutover/reencode-two-factor.integration.test.ts
@@ -164,4 +164,60 @@ describe("2FA secret re-encode (real Postgres)", () => {
     expect(second.skipped).toBe(1);
     expect(await prisma.twoFactor.count({ where: { userId: user.id } })).toBe(1);
   });
+
+  // ENG-1824: a user enrolled on the legacy flow has 2FA + a legacy backup code but NO `TwoFactor`
+  // row. On their next password sign-in the self-heal must materialize the row from their EXISTING
+  // (older) secret + backup codes — no migration run, no re-enrollment — so one of the codes they
+  // saved back then still verifies. Drives the real `hooks.after` heal (not a hand-written row) and
+  // the real BA verify-backup-code, end to end.
+  test("a legacy 2FA user's OLD backup code verifies after the sign-in self-heal (no pre-existing row)", async () => {
+    authenticator.options = { digits: 6, step: 30 };
+    const password = "Legacy-Heal1!";
+    const fbSecret = authenticator.generateSecret(20);
+    // Codes as the legacy setup stored them: bare 10-char hex, encrypted with ENCRYPTION_KEY.
+    const bareCodes = ["a1b2c3d4e5", "0f1e2d3c4b"];
+    const user = await prisma.user.create({
+      data: {
+        email: "legacy-heal-backup@example.com",
+        name: "LegacyHealBackup",
+        emailVerified: true,
+        password: await hashSecret(password),
+        twoFactorEnabled: true,
+        twoFactorSecret: symmetricEncrypt(fbSecret, ENCRYPTION_KEY),
+        backupCodes: symmetricEncrypt(JSON.stringify(bareCodes), ENCRYPTION_KEY),
+      },
+    });
+    await prisma.account.create({
+      data: {
+        userId: user.id,
+        type: "credential",
+        provider: "credential",
+        providerAccountId: user.id,
+        password: user.password!,
+      },
+    });
+
+    // No TwoFactor row yet — the heal is the only thing that can create it.
+    expect(await prisma.twoFactor.count({ where: { userId: user.id } })).toBe(0);
+
+    // Password step: BA returns the 2FA challenge (no session yet) and the after-hook heal runs.
+    const challenge = await auth.api.signInEmail({
+      body: { email: "legacy-heal-backup@example.com", password },
+      asResponse: true,
+    });
+    expect(challenge.status).toBe(200);
+    expect(await prisma.session.count()).toBe(0);
+
+    // The heal materialized a verified row from the legacy columns.
+    const healed = await prisma.twoFactor.findUnique({ where: { userId: user.id } });
+    expect(healed?.verified).toBe(true);
+
+    // The user enters an OLD backup code in the displayed hyphenated form; BA exact-matches it and
+    // promotes the partial session to a full one.
+    await auth.api.verifyBackupCode({
+      body: { code: "a1b2c-3d4e5" },
+      headers: { cookie: allCookies(challenge) },
+    });
+    expect(await prisma.session.count()).toBe(1);
+  });
 });

--- a/apps/web/modules/auth/lib/cutover/reencode-two-factor.integration.test.ts
+++ b/apps/web/modules/auth/lib/cutover/reencode-two-factor.integration.test.ts
@@ -220,4 +220,55 @@ describe("2FA secret re-encode (real Postgres)", () => {
     });
     expect(await prisma.session.count()).toBe(1);
   });
+
+  // ENG-1824 regression: the legacy login consumed a used backup code by nulling its slot in place
+  // (`backupCodes[i] = null`), so a real upgraded user who ever used one has `null` entries. The heal's
+  // re-encode must skip those (not crash on `null.slice(...)`), materialize a row from the REMAINING
+  // valid codes, and let one of them verify. Reproduces the actual upgrade failure that "TOTP not
+  // enabled" masked.
+  test("a legacy 2FA user with a CONSUMED (null) backup code still heals and a remaining code verifies", async () => {
+    authenticator.options = { digits: 6, step: 30 };
+    const password = "Legacy-Heal2!";
+    const fbSecret = authenticator.generateSecret(20);
+    // First slot nulled = the code the user already spent on the legacy app; second is still valid.
+    const storedCodes = [null, "0f1e2d3c4b"];
+    const user = await prisma.user.create({
+      data: {
+        email: "legacy-consumed-backup@example.com",
+        name: "LegacyConsumed",
+        emailVerified: true,
+        password: await hashSecret(password),
+        twoFactorEnabled: true,
+        twoFactorSecret: symmetricEncrypt(fbSecret, ENCRYPTION_KEY),
+        backupCodes: symmetricEncrypt(JSON.stringify(storedCodes), ENCRYPTION_KEY),
+      },
+    });
+    await prisma.account.create({
+      data: {
+        userId: user.id,
+        type: "credential",
+        provider: "credential",
+        providerAccountId: user.id,
+        password: user.password!,
+      },
+    });
+
+    expect(await prisma.twoFactor.count({ where: { userId: user.id } })).toBe(0);
+
+    // Sign-in heal must NOT throw on the null slot; it materializes a verified row from the survivors.
+    const challenge = await auth.api.signInEmail({
+      body: { email: "legacy-consumed-backup@example.com", password },
+      asResponse: true,
+    });
+    expect(challenge.status).toBe(200);
+    const healed = await prisma.twoFactor.findUnique({ where: { userId: user.id } });
+    expect(healed?.verified).toBe(true);
+
+    // The still-valid code verifies; the consumed one was dropped (not carried over as a broken entry).
+    await auth.api.verifyBackupCode({
+      body: { code: "0f1e2-d3c4b" },
+      headers: { cookie: allCookies(challenge) },
+    });
+    expect(await prisma.session.count()).toBe(1);
+  });
 });

--- a/apps/web/modules/auth/lib/cutover/reencode-two-factor.ts
+++ b/apps/web/modules/auth/lib/cutover/reencode-two-factor.ts
@@ -42,13 +42,24 @@ export const reencodeTwoFactorSecret = async (
  * the hyphenated `XXXXX-XXXXX` form (`display-backup-codes.tsx` formatBackupCode), and BA's
  * verify-backup-code does an EXACT match with no hyphen-stripping. So we store the displayed form — the
  * string the user will actually enter.
+ *
+ * The legacy login CONSUMED a used backup code by nulling its slot in place (`backupCodes[i] = null`),
+ * so a real user who ever used one has `null` entries in the stored array. We drop those — a consumed
+ * code is spent, and BA's model is that the stored array is just the still-valid codes. Without this
+ * filter the re-encode throws on `null.slice(...)`, which the sign-in heal swallows → no `TwoFactor`
+ * row → "TOTP not enabled" (ENG-1824).
  */
 export const reencodeTwoFactorBackupCodes = async (
   encryptedFormbricksBackupCodes: string,
   secretConfig: string | SecretConfig
 ): Promise<string> => {
-  const bareCodes = JSON.parse(symmetricDecrypt(encryptedFormbricksBackupCodes, ENCRYPTION_KEY)) as string[];
-  const displayedCodes = bareCodes.map((code) => `${code.slice(0, 5)}-${code.slice(5, 10)}`);
+  const storedCodes = JSON.parse(symmetricDecrypt(encryptedFormbricksBackupCodes, ENCRYPTION_KEY)) as (
+    | string
+    | null
+  )[];
+  const displayedCodes = storedCodes
+    .filter((code): code is string => typeof code === "string")
+    .map((code) => `${code.slice(0, 5)}-${code.slice(5, 10)}`);
   return symmetricEncrypt({ key: secretConfig, data: JSON.stringify(displayedCodes) });
 };
 

--- a/apps/web/modules/auth/lib/cutover/reencode-two-factor.ts
+++ b/apps/web/modules/auth/lib/cutover/reencode-two-factor.ts
@@ -52,6 +52,23 @@ export const reencodeTwoFactorBackupCodes = async (
   return symmetricEncrypt({ key: secretConfig, data: JSON.stringify(displayedCodes) });
 };
 
+/**
+ * Build a Better Auth `TwoFactor`-row payload (`{ secret, backupCodes }`) from a user's legacy
+ * `User.twoFactorSecret` / `User.backupCodes` (both `ENCRYPTION_KEY`-encrypted). Shared by the one-shot
+ * cutover batch below and the live enable / sign-in bridge (ENG-1824). A user with a secret but no
+ * stored backup codes gets an empty (encrypted) code list.
+ */
+export const buildReencodedTwoFactorData = async (
+  encryptedFormbricksSecret: string,
+  encryptedFormbricksBackupCodes: string | null,
+  secretConfig: string | SecretConfig
+): Promise<{ secret: string; backupCodes: string }> => ({
+  secret: await reencodeTwoFactorSecret(encryptedFormbricksSecret, secretConfig),
+  backupCodes: encryptedFormbricksBackupCodes
+    ? await reencodeTwoFactorBackupCodes(encryptedFormbricksBackupCodes, secretConfig)
+    : await symmetricEncrypt({ key: secretConfig, data: "[]" }),
+});
+
 interface TwoFactorUserRow {
   id: string;
   twoFactorSecret: string;
@@ -102,10 +119,7 @@ export const reencodeAllTwoFactorSecrets = async (
       await prisma.twoFactor.create({
         data: {
           userId: user.id,
-          secret: await reencodeTwoFactorSecret(user.twoFactorSecret, secretConfig),
-          backupCodes: user.backupCodes
-            ? await reencodeTwoFactorBackupCodes(user.backupCodes, secretConfig)
-            : await symmetricEncrypt({ key: secretConfig, data: "[]" }),
+          ...(await buildReencodedTwoFactorData(user.twoFactorSecret, user.backupCodes, secretConfig)),
         },
       });
       stats.migrated += 1;

--- a/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.test.ts
+++ b/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.test.ts
@@ -18,7 +18,7 @@ vi.mock("@formbricks/database", () => ({
       deleteMany: vi.fn(),
     },
     // Runs the passed prisma operations; the individual mocks above record their own calls.
-    $transaction: vi.fn((ops) => Promise.resolve(ops)),
+    $transaction: vi.fn((ops) => (Array.isArray(ops) ? Promise.all(ops) : Promise.resolve(ops))),
   },
 }));
 

--- a/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.test.ts
+++ b/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.test.ts
@@ -3,6 +3,7 @@ import { prisma } from "@formbricks/database";
 import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { symmetricDecrypt, symmetricEncrypt } from "@/lib/crypto";
 import { getCredentialPasswordHash, verifyUserPassword } from "@/lib/user/password";
+import { buildReencodedTwoFactorData } from "@/modules/auth/lib/cutover/reencode-two-factor";
 import { totpAuthenticatorCheck } from "@/modules/auth/lib/totp";
 import { disableTwoFactorAuth, enableTwoFactorAuth, setupTwoFactorAuth } from "./two-factor-auth";
 
@@ -12,6 +13,12 @@ vi.mock("@formbricks/database", () => ({
       findUnique: vi.fn(),
       update: vi.fn(),
     },
+    twoFactor: {
+      upsert: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    // Runs the passed prisma operations; the individual mocks above record their own calls.
+    $transaction: vi.fn((ops) => Promise.resolve(ops)),
   },
 }));
 
@@ -25,6 +32,14 @@ vi.mock("@/lib/user/password", () => ({
   verifyUserPassword: vi.fn(),
 }));
 
+vi.mock("@/modules/auth/lib/auth", () => ({
+  auth: { $context: Promise.resolve({ secretConfig: "ba-secret-config" }) },
+}));
+
+vi.mock("@/modules/auth/lib/cutover/reencode-two-factor", () => ({
+  buildReencodedTwoFactorData: vi.fn(),
+}));
+
 vi.mock("@/modules/auth/lib/totp", () => ({
   totpAuthenticatorCheck: vi.fn(),
 }));
@@ -36,6 +51,10 @@ describe("Two Factor Auth", () => {
     // password" tests override these.
     vi.mocked(getCredentialPasswordHash).mockResolvedValue("hashedPassword");
     vi.mocked(verifyUserPassword).mockResolvedValue(true);
+    vi.mocked(buildReencodedTwoFactorData).mockResolvedValue({
+      secret: "ba-secret",
+      backupCodes: "ba-codes",
+    });
   });
 
   afterEach(() => {
@@ -223,6 +242,18 @@ describe("Two Factor Auth", () => {
       where: { id: "user123" },
       data: { twoFactorEnabled: true },
     });
+    // ENG-1824: also materialize the Better Auth TwoFactor row (which login verifies against).
+    expect(buildReencodedTwoFactorData).toHaveBeenCalledWith(
+      "encrypted_secret",
+      undefined,
+      "ba-secret-config"
+    );
+    expect(prisma.twoFactor.upsert).toHaveBeenCalledWith({
+      where: { userId: "user123" },
+      update: { secret: "ba-secret", backupCodes: "ba-codes", verified: true },
+      create: { userId: "user123", secret: "ba-secret", backupCodes: "ba-codes", verified: true },
+    });
+    expect(prisma.$transaction).toHaveBeenCalled();
   });
 
   test("disableTwoFactorAuth should throw ResourceNotFoundError when user not found", async () => {
@@ -351,6 +382,9 @@ describe("Two Factor Auth", () => {
         twoFactorSecret: null,
       },
     });
+    // ENG-1824: also remove the Better Auth TwoFactor row so 2FA is fully off.
+    expect(prisma.twoFactor.deleteMany).toHaveBeenCalledWith({ where: { userId: "user123" } });
+    expect(prisma.$transaction).toHaveBeenCalled();
   });
 
   test("disableTwoFactorAuth should successfully disable 2FA with 2FA code", async () => {
@@ -378,5 +412,8 @@ describe("Two Factor Auth", () => {
         twoFactorSecret: null,
       },
     });
+    // ENG-1824: also remove the Better Auth TwoFactor row so 2FA is fully off.
+    expect(prisma.twoFactor.deleteMany).toHaveBeenCalledWith({ where: { userId: "user123" } });
+    expect(prisma.$transaction).toHaveBeenCalled();
   });
 });

--- a/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.ts
+++ b/apps/web/modules/ee/two-factor-auth/lib/two-factor-auth.ts
@@ -6,6 +6,8 @@ import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/erro
 import { ENCRYPTION_KEY } from "@/lib/constants";
 import { symmetricDecrypt, symmetricEncrypt } from "@/lib/crypto";
 import { getCredentialPasswordHash, verifyUserPassword } from "@/lib/user/password";
+import { auth } from "@/modules/auth/lib/auth";
+import { buildReencodedTwoFactorData } from "@/modules/auth/lib/cutover/reencode-two-factor";
 import { totpAuthenticatorCheck } from "@/modules/auth/lib/totp";
 
 export const setupTwoFactorAuth = async (
@@ -110,14 +112,25 @@ export const enableTwoFactorAuth = async (id: string, code: string) => {
     throw new InvalidInputError("Invalid code");
   }
 
-  await prisma.user.update({
-    where: {
-      id,
-    },
-    data: {
-      twoFactorEnabled: true,
-    },
-  });
+  // Better Auth's login-time TOTP/backup verification reads the `TwoFactor` table, not the legacy
+  // `User.twoFactorSecret` column this flow writes — so we re-encode the same (already TOTP-verified)
+  // secret + backup codes into that table, or login fails with "TOTP not enabled" (ENG-1824). `verified`
+  // defaults to true, which is correct: we only reach here after checking a live TOTP code. Both writes
+  // run in one transaction so the enabled flag and the BA row can't diverge.
+  const { secretConfig } = await auth.$context;
+  const twoFactorRow = await buildReencodedTwoFactorData(
+    user.twoFactorSecret,
+    user.backupCodes,
+    secretConfig
+  );
+  await prisma.$transaction([
+    prisma.user.update({ where: { id }, data: { twoFactorEnabled: true } }),
+    prisma.twoFactor.upsert({
+      where: { userId: id },
+      update: { ...twoFactorRow, verified: true },
+      create: { userId: id, ...twoFactorRow, verified: true },
+    }),
+  ]);
 
   return {
     message: "Two factor authentication enabled",
@@ -201,16 +214,15 @@ export const disableTwoFactorAuth = async (id: string, params: TDisableTwoFactor
     }
   }
 
-  await prisma.user.update({
-    where: {
-      id,
-    },
-    data: {
-      backupCodes: null,
-      twoFactorEnabled: false,
-      twoFactorSecret: null,
-    },
-  });
+  // Clear both stores together: the legacy User columns and Better Auth's `TwoFactor` row (which login
+  // reads). Leaving the BA row behind would keep 2FA effectively on at login (ENG-1824).
+  await prisma.$transaction([
+    prisma.user.update({
+      where: { id },
+      data: { backupCodes: null, twoFactorEnabled: false, twoFactorSecret: null },
+    }),
+    prisma.twoFactor.deleteMany({ where: { userId: id } }),
+  ]);
 
   return {
     message: "Two factor authentication disabled",


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-1824 (Urgent, 5.2 QA): after enabling 2FA, login rejected both the authenticator code and the backup code with Better Auth's **"TOTP not enabled."**

**Root cause.** There are two 2FA stores and enable wrote the one login doesn't read. The custom enable flow (`modules/ee/two-factor-auth`) wrote the secret + backup codes to the legacy `User.twoFactorSecret` / `User.backupCodes` columns, but login verifies via Better Auth's `twoFactor` plugin (`authClient.twoFactor.verifyTotp/verifyBackupCode`), which reads the **`TwoFactor` table**. BA's `verifyTOTP` does `findOne(TwoFactor,{userId})` → `throw TOTP_NOT_ENABLED` when there's no row. ENG-1054 migrated login-time verification + a one-time cutover re-encode into `TwoFactor`, but the enable/disable path was never migrated. #8532 (ENG-1772) unblocked the enable path for post-cutover users, which exposed this.

**Fix (bridge, no data migration):**
- `enableTwoFactorAuth` / `disableTwoFactorAuth` now keep BA's `TwoFactor` table in sync with the legacy columns — on enable, `upsert` a `verified: true` row (re-encoding the same, already-TOTP-verified secret + backup codes); on disable, delete it — each in a single `prisma.$transaction` so the enabled flag and the BA row can't diverge.
- A post-sign-in **self-heal** hook (`hooks.after` on `/sign-in/email`) lazily re-encodes an existing legacy secret into `TwoFactor` on the next **successful** password login, so accounts enrolled before this fix recover automatically — keeping their existing authenticator, with no migration and no re-enrollment. It runs only after a verified password step (never a pre-auth, email-guessable write) and is idempotent.
- Extracts a shared `buildReencodedTwoFactorData` helper reused by the cutover batch, enable, and the heal.

No schema/env changes.

## How should this be tested?

Automated (from `apps/web`):
```
pnpm test -- modules/ee/two-factor-auth/lib/two-factor-auth.test.ts modules/auth/lib/better-auth-two-factor-backfill.test.ts
```

Manual, on a fresh account:
1. Enable 2FA (scan QR, confirm code) → a `TwoFactor` row exists (`verified=true`); log out; log in with the **authenticator code**, then separately a **backup code** → both succeed. Disable → row deleted; re-enable → works.
2. Heal path (no migration): a user enrolled before this fix (`User.twoFactorSecret` set, **no** `TwoFactor` row) logs in with the correct password → the self-heal materializes the row → the same authenticator code logs them in, no re-enrollment. SSO / non-2FA users are unaffected.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
