### PR TITLE
fix(sso): stop requiring RFC 9207 issuer param for Azure (ENG-1800)

### DIFF
--- a/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
@@ -168,6 +168,9 @@ describe("better-auth SSO providers", () => {
         "https://login.microsoftonline.com/tenant-123/v2.0/.well-known/openid-configuration"
       );
       expect(azure.scopes).toEqual(["openid", "email", "profile"]);
+      // ENG-1800: Entra never returns the RFC 9207 response `iss`, so validation must stay off even
+      // with a fixed tenant — turning it on here is exactly what caused `error=issuer_missing`.
+      expect(azure.requireIssuerValidation).toBe(false);
     });
 
     test("Azure discovery URL falls back to the 'common' tenant when none is configured", async () => {
@@ -176,6 +179,7 @@ describe("better-auth SSO providers", () => {
       expect(azure?.discoveryUrl).toBe(
         "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"
       );
+      expect(azure?.requireIssuerValidation).toBe(false);
     });
 
     test("Azure mapProfileToUser resolves the display name through its fallback chain", async () => {

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.ts
@@ -93,11 +93,16 @@ export const ssoGenericOAuthConfig: GenericOAuthConfig[] = ENTERPRISE_LICENSE_KE
               discoveryUrl: `https://login.microsoftonline.com/${AZUREAD_TENANT_ID || "common"}/v2.0/.well-known/openid-configuration`,
               scopes: ["openid", "email", "profile"],
               pkce: true,
-              // RFC 9207 mix-up defense (parity with OIDC). Enabled only with a fixed tenant: a
-              // single-tenant discovery issuer is stable and matches the token's `iss`, whereas
-              // multi-tenant ("common") tokens carry the caller's home-tenant issuer, which a strict
-              // issuer check would reject.
-              requireIssuerValidation: !!AZUREAD_TENANT_ID,
+              // Must stay false for Azure. Better Auth's issuer check reads the RFC 9207
+              // authorization-RESPONSE `iss` query parameter, and Microsoft Entra does not implement
+              // RFC 9207 — its v2.0 metadata omits `authorization_response_iss_parameter_supported`
+              // and it never returns that param. So enabling this can only ever fail with
+              // `error=issuer_missing` (ENG-1800); it can never pass, regardless of tenant. The
+              // param's purpose (disambiguating which AS responded, to defend against mix-up) is
+              // already covered here structurally: the per-provider callback path pins the token
+              // endpoint to Azure's own, and PKCE (above) + state validation bind the exchange. OIDC
+              // (below) keeps the check on because a spec-compliant provider does return `iss`.
+              requireIssuerValidation: false,
               mapProfileToUser: (profile) => {
                 // Capture for verify-before-link recovery; name parity with the OIDC mapping.
                 captureSsoIdentity({ email: profile.email, providerAccountId: profile.sub });


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-1800 (High, Formbricks 5.2 QA): Microsoft/Azure SSO on **staging** bounces back to `…/auth/login?error=issuer_missing`, while **production** works.

**Root cause.** Better Auth's generic-OAuth callback validates the RFC 9207 authorization-**response** `iss` *query parameter* when a provider sets `requireIssuerValidation`. Microsoft Entra does **not** implement RFC 9207 — its v2.0 metadata omits `authorization_response_iss_parameter_supported` and it never returns that query param. Our config set `requireIssuerValidation: !!AZUREAD_TENANT_ID`, so any environment with a fixed `AZUREAD_TENANT_ID` (staging) fails **every** Azure login with `issuer_missing`, while `common`-tenant environments (prod, validation off) work. The prior comment conflated the ID-token `iss` *claim* (Entra does send it, in the token) with the authorization-response `iss` *query param* (it never sends).

**Fix.** Pin `requireIssuerValidation: false` for the `azuread` provider. The param only disambiguates *which* authorization server responded (mix-up defense); for a single fixed provider that's already handled structurally — the per-provider callback path (`/api/auth/oauth2/callback/azuread`) pins the token endpoint to Azure's own, plus PKCE (`pkce: true`) and state validation bind the exchange. This is the same effective posture prod runs today and the one Better Auth ships for its first-party Microsoft provider. OIDC (`openid`) keeps `requireIssuerValidation: true` — a spec-compliant provider does return the response `iss`. SAML is unaffected (no `discoveryUrl`, so the issuer branch is never entered).

No env, schema, or migration changes. `AZUREAD_TENANT_ID` stays meaningful — it still selects single- vs multi-tenant discovery.

## How should this be tested?

Automated (from `apps/web`):
```
pnpm test -- modules/ee/sso/lib/better-auth-providers.test.ts
```
Includes a regression assertion that `azuread.requireIssuerValidation` is `false` **even when a tenant is configured** — the exact regression that caused this bug — and that `openid` keeps it `true`.

Manual, on staging (post-deploy):
- "Continue with Microsoft" → complete the Entra prompt → land authenticated, no `error=issuer_missing`, for both a fresh SSO user and an existing linked one.
- Confirm OIDC login still works (issuer validation still on).

> Ops note: staging has `AZUREAD_TENANT_ID` set and prod does not — that env split is what singled staging out. After this change staging works regardless of the setting.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
