### PR TITLE
fix(sso): stop requiring RFC 9207 issuer param for Azure (ENG-1800) [backport 5.2]

### DIFF
--- a/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.test.ts
@@ -168,6 +168,9 @@ describe("better-auth SSO providers", () => {
         "https://login.microsoftonline.com/tenant-123/v2.0/.well-known/openid-configuration"
       );
       expect(azure.scopes).toEqual(["openid", "email", "profile"]);
+      // ENG-1800: Entra never returns the RFC 9207 response `iss`, so validation must stay off even
+      // with a fixed tenant — turning it on here is exactly what caused `error=issuer_missing`.
+      expect(azure.requireIssuerValidation).toBe(false);
     });
 
     test("Azure discovery URL falls back to the 'common' tenant when none is configured", async () => {
@@ -176,6 +179,7 @@ describe("better-auth SSO providers", () => {
       expect(azure?.discoveryUrl).toBe(
         "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"
       );
+      expect(azure?.requireIssuerValidation).toBe(false);
     });
 
     test("Azure mapProfileToUser resolves the display name through its fallback chain", async () => {

--- a/apps/web/modules/ee/sso/lib/better-auth-providers.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-providers.ts
@@ -93,11 +93,16 @@ export const ssoGenericOAuthConfig: GenericOAuthConfig[] = ENTERPRISE_LICENSE_KE
               discoveryUrl: `https://login.microsoftonline.com/${AZUREAD_TENANT_ID || "common"}/v2.0/.well-known/openid-configuration`,
               scopes: ["openid", "email", "profile"],
               pkce: true,
-              // RFC 9207 mix-up defense (parity with OIDC). Enabled only with a fixed tenant: a
-              // single-tenant discovery issuer is stable and matches the token's `iss`, whereas
-              // multi-tenant ("common") tokens carry the caller's home-tenant issuer, which a strict
-              // issuer check would reject.
-              requireIssuerValidation: !!AZUREAD_TENANT_ID,
+              // Must stay false for Azure. Better Auth's issuer check reads the RFC 9207
+              // authorization-RESPONSE `iss` query parameter, and Microsoft Entra does not implement
+              // RFC 9207 — its v2.0 metadata omits `authorization_response_iss_parameter_supported`
+              // and it never returns that param. So enabling this can only ever fail with
+              // `error=issuer_missing` (ENG-1800); it can never pass, regardless of tenant. The
+              // param's purpose (disambiguating which AS responded, to defend against mix-up) is
+              // already covered here structurally: the per-provider callback path pins the token
+              // endpoint to Azure's own, and PKCE (above) + state validation bind the exchange. OIDC
+              // (below) keeps the check on because a spec-compliant provider does return `iss`.
+              requireIssuerValidation: false,
               mapProfileToUser: (profile) => {
                 // Capture for verify-before-link recovery; name parity with the OIDC mapping.
                 captureSsoIdentity({ email: profile.email, providerAccountId: profile.sub });


### PR DESCRIPTION
## What does this PR do?

Backport of #8561 to `release/5.2` (clean single-commit cherry-pick — source + test only, no schema/env/migration).

Fixes ENG-1800 (High, 5.2 QA): Microsoft/Azure SSO on staging bounces to `…/auth/login?error=issuer_missing`.

**Root cause.** Better Auth's generic-OAuth callback validates the RFC 9207 authorization-**response** `iss` *query parameter* when a provider sets `requireIssuerValidation`. Microsoft Entra does **not** implement RFC 9207 (its v2.0 metadata omits `authorization_response_iss_parameter_supported` and it never returns that param). Our config set `requireIssuerValidation: !!AZUREAD_TENANT_ID`, so any environment with a fixed `AZUREAD_TENANT_ID` (staging) fails every Azure login with `issuer_missing`, while `common`-tenant environments (prod) work.

**Fix.** Pin `requireIssuerValidation: false` for `azuread`. Mix-up defense is already covered structurally for a single fixed provider (per-provider callback path pins the token endpoint to Azure's own, plus PKCE + state validation). OIDC keeps validation on; SAML is unaffected (no `discoveryUrl`).

> ⚠️ Do not merge until the base PR #8561 lands on `main`.

## How should this be tested?

Automated (from `apps/web`):
```
pnpm test -- modules/ee/sso/lib/better-auth-providers.test.ts
```
Regression assertion: `azuread.requireIssuerValidation` is `false` even with a tenant configured; `openid` keeps it `true`. The two changed files are byte-identical to #8561 and the cherry-pick applied with no conflicts.

Manual, on staging (post-deploy): "Continue with Microsoft" → complete the Entra prompt → land authenticated, no `error=issuer_missing`. OIDC login still works.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
