### PR TITLE
fix(navigation): center icons in the collapsed sidebar

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/MainNavigation.tsx
@@ -397,7 +397,11 @@ export const MainNavigation = ({
             <div>
               {/* Logo and Toggle */}
 
-              <div className="flex items-center justify-between px-3 pb-4">
+              <div
+                className={cn(
+                  "flex items-center px-3 pb-4",
+                  isCollapsed ? "justify-center" : "justify-between"
+                )}>
                 {!isCollapsed && (
                   <Link
                     href={mainNavigationLink}

--- a/apps/web/app/(app)/workspaces/[workspaceId]/components/NavigationLink.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/components/NavigationLink.tsx
@@ -57,11 +57,13 @@ export const NavigationLink = ({
         <TooltipProvider delayDuration={0}>
           <Tooltip>
             <TooltipTrigger asChild>
-              <li className={cn("mb-1 ml-2 rounded-l-md py-2 pl-2 text-sm", collapsedColorClass)}>
+              <li className={cn("mb-1 ml-1 rounded-l-md py-2 text-sm", collapsedColorClass)}>
                 {disabled ? (
-                  <div className="flex items-center">{children}</div>
+                  <div className="flex items-center justify-center">{children}</div>
                 ) : (
-                  <Link href={href}>{children}</Link>
+                  <Link href={href} className="flex items-center justify-center">
+                    {children}
+                  </Link>
                 )}
               </li>
             </TooltipTrigger>


### PR DESCRIPTION
## What does this PR do?

In the collapsed main navigation, the three icon zones each used a different horizontal alignment in the 64px rail: the toggle button was left-aligned in its `justify-between` row (icon center ≈ 30px), nav links used fixed left spacing `ml-2 + pl-2` (icon center = 24px), and the bottom workspace/organization/user icons were centered (icon center = 32px). This made the collapsed rail look visibly misaligned.

This PR centers all collapsed icons on the same 32px axis:

- `NavigationLink` (collapsed): replaces the fixed left padding with `flex justify-center`; the outer `ml-2` becomes `ml-1` so the 4px left margin balances the 4px active `border-r-4` and the icon stays truly centered in active, inactive and disabled states.
- `MainNavigation`: the toggle row uses `justify-center` when collapsed and keeps `justify-between` when expanded, so the expanded layout (logo + toggle) is unchanged.

## How should this be tested?

- Log in and collapse the main sidebar via the panel toggle: the toggle, all nav icons (including the active item with its teal right border) and the bottom switcher icons should share one vertical axis.
- Expand the sidebar: logo row and nav items render exactly as before.
- Hover a disabled item (e.g. as billing-only role): icon stays centered and the tooltip still shows.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [x] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary

before
<img width="80" height="285" alt="image" src="https://github.com/user-attachments/assets/5235a1e6-a4a4-4ec6-af88-d0a33e8e57d5" />



after
<img width="75" height="277" alt="image" src="https://github.com/user-attachments/assets/c5ccfd3c-7275-4057-b569-b80c0d33d165" />
