### PR TITLE
feat(charts): backport chart and dashboard improvements [backport 5.2]

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -1731,6 +1731,8 @@ checksums:
     workspace/analysis/charts/time_dimension_title: 9353ce9a075a0cc8c3ba7dfa9ef19a8d
     workspace/analysis/charts/time_dimension_toggle_description: 77251d8b3b564390bad8b76f56905190
     workspace/analysis/dashboards/add_count_charts: b4ee1f29efce0bb380a060e0bc5d64fa
+    workspace/analysis/dashboards/chart_duplicate_failed: 90d7166c85188b52f821c9d9f53ff8c4
+    workspace/analysis/dashboards/chart_duplicated: 52765f173bd6fd5382731f8e06e436e0
     workspace/analysis/dashboards/chart_remove_failed: 198f5c3bdd522b40b80cb7479d3051a1
     workspace/analysis/dashboards/chart_removed: 1ce20b8ee0b56bcd7d6fea2b5c1ae9fd
     workspace/analysis/dashboards/chart_restore_failed: 890c74046ed55df6f90c28cf905b7a30

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -1594,6 +1594,7 @@ checksums:
     workspace/analysis/charts/dimensions_toggle_description: 31eb28f3c83c04bbe37799758ca9f595
     workspace/analysis/charts/edit_chart_description: 822890e4b6068096e2fe8b7b78b4474f
     workspace/analysis/charts/edit_chart_title: fd3e7f8c53280bfad8f4034c055f4c71
+    workspace/analysis/charts/edit_chart_title_named: 216b4226fb611b3694bc222026722845
     workspace/analysis/charts/emotion_value_anger: 4fd64fc804c247fc3fcbc7dc147b62fe
     workspace/analysis/charts/emotion_value_disgust: e5860fbfc609c8c8686db8a18cadf932
     workspace/analysis/charts/emotion_value_fear: b7621ac47c2543dff100f55f948df8cf

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "{count} Diagramm(e) hinzufügen",
+        "chart_duplicate_failed": "Diagramm konnte nicht dupliziert werden",
+        "chart_duplicated": "Diagramm wurde dupliziert und zum Dashboard hinzugefügt",
         "chart_remove_failed": "Diagramm konnte nicht entfernt werden",
         "chart_removed": "Diagramm vom Dashboard entfernt",
         "chart_restore_failed": "Diagramm konnte nicht wiederhergestellt werden",

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "Gruppiere Daten nach Stimmung, Fragetyp und anderen Dimensionen.",
         "edit_chart_description": "Sieh dir deine Diagrammkonfiguration an und bearbeite sie.",
         "edit_chart_title": "Diagramm bearbeiten",
+        "edit_chart_title_named": "„{name}“ bearbeiten",
         "emotion_value_anger": "Wut",
         "emotion_value_disgust": "Ekel",
         "emotion_value_fear": "Angst",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "Group data by sentiment, question type, and other dimensions.",
         "edit_chart_description": "View and edit your chart configuration.",
         "edit_chart_title": "Edit Chart",
+        "edit_chart_title_named": "Edit \"{name}\"",
         "emotion_value_anger": "Anger",
         "emotion_value_disgust": "Disgust",
         "emotion_value_fear": "Fear",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "Add {count} chart(s)",
+        "chart_duplicate_failed": "Failed to duplicate chart",
+        "chart_duplicated": "Chart duplicated and added to dashboard",
         "chart_remove_failed": "Failed to remove chart",
         "chart_removed": "Chart removed from dashboard",
         "chart_restore_failed": "Failed to restore chart",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "Añadir {count} gráfico(s)",
+        "chart_duplicate_failed": "No se pudo duplicar el gráfico",
+        "chart_duplicated": "Gráfico duplicado y añadido al panel",
         "chart_remove_failed": "No se pudo eliminar el gráfico",
         "chart_removed": "Gráfico eliminado del panel",
         "chart_restore_failed": "No se pudo restaurar el gráfico",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "Agrupa los datos por sentimiento, tipo de pregunta y otras dimensiones.",
         "edit_chart_description": "Visualiza y edita la configuración de tu gráfico.",
         "edit_chart_title": "Editar gráfico",
+        "edit_chart_title_named": "Editar \"{name}\"",
         "emotion_value_anger": "Enfado",
         "emotion_value_disgust": "Disgusto",
         "emotion_value_fear": "Miedo",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "Groupe les données par sentiment, type de question et autres dimensions.",
         "edit_chart_description": "Consultez et modifiez la configuration de votre graphique.",
         "edit_chart_title": "Modifier le graphique",
+        "edit_chart_title_named": "Modifier \"{name}\"",
         "emotion_value_anger": "Colère",
         "emotion_value_disgust": "Dégoût",
         "emotion_value_fear": "Peur",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "Ajouter {count} graphique(s)",
+        "chart_duplicate_failed": "Échec de la duplication du graphique",
+        "chart_duplicated": "Graphique dupliqué et ajouté au tableau de bord",
         "chart_remove_failed": "Échec de la suppression du graphique",
         "chart_removed": "Graphique retiré du tableau de bord",
         "chart_restore_failed": "Échec de la restauration du graphique",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "{count} diagram hozzáadása",
+        "chart_duplicate_failed": "A diagram másolása sikertelen volt",
+        "chart_duplicated": "A diagram másolása megtörtént és hozzáadásra került a műszerfalhoz",
         "chart_remove_failed": "A diagram eltávolítása sikertelen volt",
         "chart_removed": "A diagram eltávolítva a vezérlőpultról",
         "chart_restore_failed": "A diagram visszaállítása sikertelen volt",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "Adatok csoportosítása hangulat, kérdéstípus és egyéb dimenziók szerint.",
         "edit_chart_description": "Diagram beállításainak megtekintése és szerkesztése.",
         "edit_chart_title": "Diagram szerkesztése",
+        "edit_chart_title_named": "„{name}“ szerkesztése",
         "emotion_value_anger": "Düh",
         "emotion_value_disgust": "Undor",
         "emotion_value_fear": "Félelem",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "{count}個のグラフを追加",
+        "chart_duplicate_failed": "グラフの複製に失敗しました",
+        "chart_duplicated": "グラフが複製されダッシュボードに追加されました",
         "chart_remove_failed": "チャートの削除に失敗しました",
         "chart_removed": "チャートがダッシュボードから削除されました",
         "chart_restore_failed": "チャートの復元に失敗しました",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "センチメント、質問タイプ、その他のディメンションでデータをグループ化します。",
         "edit_chart_description": "チャート設定を表示および編集します。",
         "edit_chart_title": "チャートを編集",
+        "edit_chart_title_named": "「{name}」を編集",
         "emotion_value_anger": "怒り",
         "emotion_value_disgust": "嫌悪",
         "emotion_value_fear": "恐れ",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "Groepeer data op sentiment, vraagtype en andere dimensies.",
         "edit_chart_description": "Bekijk en bewerk je diagramconfiguratie.",
         "edit_chart_title": "Diagram bewerken",
+        "edit_chart_title_named": "Bewerk \"{name}\"",
         "emotion_value_anger": "Woede",
         "emotion_value_disgust": "Afkeer",
         "emotion_value_fear": "Angst",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "{count} grafiek(en) toevoegen",
+        "chart_duplicate_failed": "Dupliceren van grafiek mislukt",
+        "chart_duplicated": "Grafiek gedupliceerd en toegevoegd aan dashboard",
         "chart_remove_failed": "Grafiek verwijderen mislukt",
         "chart_removed": "Grafiek verwijderd van dashboard",
         "chart_restore_failed": "Grafiek herstellen mislukt",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "Agrupe dados por sentimento, tipo de pergunta e outras dimensões.",
         "edit_chart_description": "Visualize e edite a configuração do seu gráfico.",
         "edit_chart_title": "Editar gráfico",
+        "edit_chart_title_named": "Editar \"{name}\"",
         "emotion_value_anger": "Raiva",
         "emotion_value_disgust": "Nojo",
         "emotion_value_fear": "Medo",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "Adicionar {count} gráfico(s)",
+        "chart_duplicate_failed": "Falha ao duplicar gráfico",
+        "chart_duplicated": "Gráfico duplicado e adicionado ao painel",
         "chart_remove_failed": "Falha ao remover gráfico",
         "chart_removed": "Gráfico removido do painel",
         "chart_restore_failed": "Falha ao restaurar gráfico",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "Adicionar {count} gráfico(s)",
+        "chart_duplicate_failed": "Falha ao duplicar gráfico",
+        "chart_duplicated": "Gráfico duplicado e adicionado ao painel",
         "chart_remove_failed": "Falha ao remover gráfico",
         "chart_removed": "Gráfico removido do painel",
         "chart_restore_failed": "Falha ao restaurar gráfico",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "Agrupa dados por sentimento, tipo de pergunta e outras dimensões.",
         "edit_chart_description": "Visualize e edite a configuração do seu gráfico.",
         "edit_chart_title": "Editar gráfico",
+        "edit_chart_title_named": "Editar \"{name}\"",
         "emotion_value_anger": "Raiva",
         "emotion_value_disgust": "Repulsa",
         "emotion_value_fear": "Medo",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "Grupează datele după sentiment, tipul întrebării și alte dimensiuni.",
         "edit_chart_description": "Vezi și editează configurația graficului tău.",
         "edit_chart_title": "Editează graficul",
+        "edit_chart_title_named": "Editează \"{name}\"",
         "emotion_value_anger": "Furie",
         "emotion_value_disgust": "Dezgust",
         "emotion_value_fear": "Frică",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "Adaugă {count} grafic(e)",
+        "chart_duplicate_failed": "Graficul nu a putut fi duplicat",
+        "chart_duplicated": "Graficul a fost duplicat și adăugat la tabloul de bord",
         "chart_remove_failed": "Ștergerea graficului a eșuat",
         "chart_removed": "Graficul a fost eliminat din tabloul de bord",
         "chart_restore_failed": "Restaurarea graficului a eșuat",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "Группируйте данные по настроению, типу вопроса и другим измерениям.",
         "edit_chart_description": "Просмотри и измени настройки своего графика.",
         "edit_chart_title": "Редактировать график",
+        "edit_chart_title_named": "Редактировать «{name}»",
         "emotion_value_anger": "Гнев",
         "emotion_value_disgust": "Отвращение",
         "emotion_value_fear": "Страх",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "Добавить {count} график(ов)",
+        "chart_duplicate_failed": "Не удалось создать копию графика",
+        "chart_duplicated": "График скопирован и добавлен на дашборд",
         "chart_remove_failed": "Не удалось удалить диаграмму",
         "chart_removed": "График удалён с панели",
         "chart_restore_failed": "Не удалось восстановить диаграмму",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "Lägg till {count} diagram",
+        "chart_duplicate_failed": "Misslyckades med att duplicera diagram",
+        "chart_duplicated": "Diagram duplicerat och tillagt på instrumentpanelen",
         "chart_remove_failed": "Misslyckades med att ta bort diagram",
         "chart_removed": "Diagram borttaget från instrumentpanelen",
         "chart_restore_failed": "Misslyckades med att återställa diagram",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "Gruppera data efter sentiment, frågetyp och andra dimensioner.",
         "edit_chart_description": "Visa och redigera din diagramkonfiguration.",
         "edit_chart_title": "Redigera diagram",
+        "edit_chart_title_named": "Redigera \"{name}\"",
         "emotion_value_anger": "Ilska",
         "emotion_value_disgust": "Avsky",
         "emotion_value_fear": "Rädsla",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "{count} grafik ekle",
+        "chart_duplicate_failed": "Grafik kopyalanamadı",
+        "chart_duplicated": "Grafik kopyalandı ve panoya eklendi",
         "chart_remove_failed": "Grafik kaldırılamadı",
         "chart_removed": "Grafik gösterge panosundan kaldırıldı",
         "chart_restore_failed": "Grafik geri yüklenemedi",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "Verileri duygu durumu, soru türü ve diğer boyutlara göre grupla.",
         "edit_chart_description": "Grafik yapılandırmanı görüntüle ve düzenle.",
         "edit_chart_title": "Grafiği Düzenle",
+        "edit_chart_title_named": "\"{name}\" Düzenle",
         "emotion_value_anger": "Öfke",
         "emotion_value_disgust": "İğrenme",
         "emotion_value_fear": "Korku",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "添加 {count} 个图表",
+        "chart_duplicate_failed": "图表复制失败",
+        "chart_duplicated": "图表已复制并添加到仪表板",
         "chart_remove_failed": "删除图表失败",
         "chart_removed": "图表已从仪表板中移除",
         "chart_restore_failed": "恢复图表失败",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "按情感、问题类型和其他维度对数据进行分组。",
         "edit_chart_description": "查看并编辑你的图表配置。",
         "edit_chart_title": "编辑图表",
+        "edit_chart_title_named": "编辑“{name}”",
         "emotion_value_anger": "愤怒",
         "emotion_value_disgust": "厌恶",
         "emotion_value_fear": "恐惧",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1796,6 +1796,8 @@
       },
       "dashboards": {
         "add_count_charts": "新增 {count} 個圖表",
+        "chart_duplicate_failed": "圖表複製失敗",
+        "chart_duplicated": "圖表已複製並新增至儀表板",
         "chart_remove_failed": "移除圖表失敗",
         "chart_removed": "圖表已從儀表板移除",
         "chart_restore_failed": "還原圖表失敗",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -1657,6 +1657,7 @@
         "dimensions_toggle_description": "依情感、問題類型及其他維度分組資料。",
         "edit_chart_description": "檢視並編輯你的圖表設定。",
         "edit_chart_title": "編輯圖表",
+        "edit_chart_title_named": "編輯「{name}」",
         "emotion_value_anger": "憤怒",
         "emotion_value_disgust": "厭惡",
         "emotion_value_fear": "恐懼",

--- a/apps/web/modules/ee/analysis/charts/actions.test.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.test.ts
@@ -151,6 +151,7 @@ describe("chart Cube actions", () => {
         measures: ["FeedbackRecords.count"],
         dimensions: ["FeedbackRecords.sourceType"],
       },
+      name: "Responses by Source Type",
     });
 
     const result = await generateAIChartAction({
@@ -173,6 +174,7 @@ describe("chart Cube actions", () => {
         dimensions: ["FeedbackRecords.sourceType"],
       },
       data: [{ "FeedbackRecords.count": 1 }],
+      suggestedName: "Responses by Source Type",
     });
     expect(mocks.executeTenantScopedQuery).toHaveBeenCalledWith({
       query: {

--- a/apps/web/modules/ee/analysis/charts/actions.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.ts
@@ -321,7 +321,7 @@ export const generateAIChartAction = authenticatedActionClient
         source: "charts.generateAIChartAction",
       });
 
-      const { chartType, query } = await generateAIChartQuery({
+      const { chartType, query, name } = await generateAIChartQuery({
         organizationId,
         prompt: parsedInput.prompt,
       });
@@ -341,6 +341,8 @@ export const generateAIChartAction = authenticatedActionClient
         query: validatedQuery,
         chartType,
         data: Array.isArray(data) ? data : [],
+        // Prefills the chart-name input (only when the user hasn't typed a name).
+        suggestedName: name,
       };
     }
   );

--- a/apps/web/modules/ee/analysis/charts/components/cartesian-chart.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/cartesian-chart.tsx
@@ -26,6 +26,10 @@ export interface CartesianChartProps {
   /** False for measure-only charts with no real category: hides the meaningless x-axis tick and
    * tooltip header (which would otherwise show the fallback measure value, e.g. a stray "1"). */
   hasCategoryAxis?: boolean;
+  /** Overrides whether the tooltip header is hidden (defaults to `!hasCategoryAxis`). Pivoted
+   * measure charts keep their category axis but hide the header, since each tooltip row already
+   * carries the measure label and a header would just repeat it. */
+  tooltipHideLabel?: boolean;
 }
 
 const TARGET_TICK_COUNT = 5;
@@ -112,6 +116,7 @@ export function CartesianChart({
   zeroBaseline = false,
   xAxisTickFormatter,
   hasCategoryAxis = true,
+  tooltipHideLabel,
 }: Readonly<CartesianChartProps>) {
   const yScale = computeYAxis(data, dataKeys, zeroBaseline);
 
@@ -141,7 +146,10 @@ export function CartesianChart({
           />
           <ChartTooltip
             content={
-              <PolishedChartTooltip labelFormatter={xAxisTickFormatter} hideLabel={!hasCategoryAxis} />
+              <PolishedChartTooltip
+                labelFormatter={xAxisTickFormatter}
+                hideLabel={tooltipHideLabel ?? !hasCategoryAxis}
+              />
             }
             cursor={tooltipCursor}
             // Measure-only charts (no category) have one bar per measure, so a shared tooltip would

--- a/apps/web/modules/ee/analysis/charts/components/cartesian-chart.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/cartesian-chart.tsx
@@ -3,6 +3,7 @@
 import { type ElementType, type ReactNode } from "react";
 import { CartesianGrid, XAxis, YAxis } from "recharts";
 import { formatXAxisTick } from "@/modules/ee/analysis/charts/lib/chart-utils";
+import { computeYAxis } from "@/modules/ee/analysis/charts/lib/y-axis-scale";
 import type { TChartDataRow } from "@/modules/ee/analysis/types/analysis";
 import type { ChartConfig } from "@/modules/ui/components/chart";
 import { ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip } from "@/modules/ui/components/chart";
@@ -31,77 +32,6 @@ export interface CartesianChartProps {
    * carries the measure label and a header would just repeat it. */
   tooltipHideLabel?: boolean;
 }
-
-const TARGET_TICK_COUNT = 5;
-
-interface YAxisScale {
-  domain: [number, number];
-  ticks: number[];
-}
-
-// Round a value to a "nice" number (1/2/5/10 × 10ⁿ) — the family of steps people
-// expect on an axis. `round` snaps to the nearest nice number; otherwise it rounds
-// up so the value fully contains the range.
-const niceNum = (value: number, round: boolean): number => {
-  const exponent = Math.floor(Math.log10(value));
-  const fraction = value / 10 ** exponent;
-  let niceFraction: number;
-  if (round) {
-    if (fraction < 1.5) niceFraction = 1;
-    else if (fraction < 3) niceFraction = 2;
-    else if (fraction < 7) niceFraction = 5;
-    else niceFraction = 10;
-  } else if (fraction <= 1) niceFraction = 1;
-  else if (fraction <= 2) niceFraction = 2;
-  else if (fraction <= 5) niceFraction = 5;
-  else niceFraction = 10;
-  return niceFraction * 10 ** exponent;
-};
-
-const computeYAxis = (
-  data: TChartDataRow[],
-  dataKeys: string[],
-  zeroBaseline: boolean
-): YAxisScale | undefined => {
-  const values: number[] = [];
-  for (const row of data) {
-    for (const key of dataKeys) {
-      const raw = row[key];
-      if (raw === null || raw === undefined || raw === "") continue;
-      const num = Number(raw);
-      if (Number.isFinite(num)) values.push(num);
-    }
-  }
-  if (values.length === 0) return undefined;
-
-  const dataMin = Math.min(...values);
-  const dataMax = Math.max(...values);
-
-  // Baseline: bars and all-positive series sit on 0; only dip below zero when the
-  // data genuinely does, so we never draw a phantom negative axis (e.g. a -4 floor
-  // under a metric that bottoms out at 0).
-  const baselineLow = zeroBaseline ? Math.min(0, dataMin) : dataMin;
-  // Flat data has no range to scale, so give it a unit of headroom to render ticks.
-  const spanHigh = dataMax === baselineLow ? baselineLow + 1 : dataMax;
-
-  // Snap the axis to nice bounds and derive evenly spaced round ticks, so every
-  // gridline lands on a labelled value. (Recharts' auto-ticks are computed from a
-  // raw domain and can fall outside it, drawing extra gridlines with no label.)
-  const step = niceNum(niceNum(spanHigh - baselineLow, false) / (TARGET_TICK_COUNT - 1), true);
-  const niceMin = Math.floor(baselineLow / step) * step;
-  const niceMax = Math.ceil(spanHigh / step) * step;
-
-  // Clean up floating-point noise that decimal steps introduce (e.g. 0.30000000004).
-  const decimals = Math.max(0, -Math.floor(Math.log10(step)));
-  const round = (n: number) => Number(n.toFixed(decimals));
-
-  const ticks: number[] = [];
-  for (let tick = niceMin; tick <= niceMax + step / 2; tick += step) {
-    ticks.push(round(tick));
-  }
-
-  return { domain: [round(niceMin), round(niceMax)], ticks };
-};
 
 export function CartesianChart({
   data,

--- a/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
@@ -10,15 +10,20 @@ import {
   CHART_BRAND_DARK,
   CHART_MEASURE_COLORS,
   CHART_NOT_ENRICHED_COLOR,
+  PIVOTED_MEASURE_KEY,
+  PIVOTED_VALUE_KEY,
   formatCellValue,
   formatXAxisTick,
+  pivotMeasuresToCategories,
   preparePieData,
 } from "@/modules/ee/analysis/charts/lib/chart-utils";
 import {
   FEEDBACK_MEASURE_IDS,
   formatCubeColumnHeader,
+  getMeasureAxisLabel,
   getTranslatedDimensionValueLabel,
   isNotEnrichedDimensionValue,
+  sortMeasureIdsForCategoryAxis,
   sortRowsByEnumDimension,
 } from "@/modules/ee/analysis/lib/schema-definition";
 import type { TChartDataRow, TChartType } from "@/modules/ee/analysis/types/analysis";
@@ -185,6 +190,47 @@ export function ChartRenderer({ chartType, data, query }: Readonly<ChartRenderer
 
   switch (chartType) {
     case "bar": {
+      // Measure-only queries (no dimension or time grouping) return a single row with one
+      // column per measure. Rendered as N bar series that row forms a single category band
+      // that recharts centers in the plot, leaving a wide empty gap before the first bar
+      // (ENG-1796). Pivot the measures into categories so the bars fill the axis from the
+      // left like any other category bar chart, labelled by measure on the x-axis.
+      if (!hasCategoryAxis) {
+        // Sentiment measures pivot into the scale order the sentiment *dimension* axis uses,
+        // so this chart and a dimension-grouped one read in the same direction.
+        const axisKeys = sortMeasureIdsForCategoryAxis(dataKeys);
+        const measureData = pivotMeasuresToCategories(sortedData, axisKeys, (key) =>
+          formatCubeColumnHeader(key, t)
+        );
+        // Ticks use the short value label ("Very positive") — the full measure label is too
+        // wide, so recharts would thin the ticks and bars would lose their name. The tooltip
+        // keeps the full label via tooltipLabel.
+        const formatMeasureLabel = (value: unknown) =>
+          getMeasureAxisLabel(typeof value === "string" ? value : "", t);
+        return (
+          <CartesianChart
+            chart={BarChart}
+            data={measureData}
+            xAxisKey={PIVOTED_MEASURE_KEY}
+            dataKeys={[PIVOTED_VALUE_KEY]}
+            chartConfig={chartConfig}
+            tooltipCursor={false}
+            zeroBaseline
+            tooltipHideLabel
+            xAxisTickFormatter={formatMeasureLabel}>
+            <Bar dataKey={PIVOTED_VALUE_KEY} fill={CHART_BRAND_DARK} radius={4}>
+              <LabelList
+                dataKey={PIVOTED_VALUE_KEY}
+                position="top"
+                className="fill-foreground"
+                fontSize={11}
+                formatter={(value: unknown) => formatCellValue(value)}
+              />
+            </Bar>
+          </CartesianChart>
+        );
+      }
+
       // Setting `fill` on the data row (not via <Cell>) is what propagates
       // the per-bar colour into the tooltip payload as well as the SVG.
       const barData = isMultiMeasure

--- a/apps/web/modules/ee/analysis/charts/components/create-chart-view.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/create-chart-view.tsx
@@ -67,6 +67,7 @@ export function CreateChartView({
     chartLoadError,
     chartName,
     setChartName,
+    savedChartName,
     selectedChartType,
     handleChartTypeChange,
     handleChartGenerated,
@@ -121,18 +122,20 @@ export function CreateChartView({
   const chartType = selectedChartType ?? (isEditing ? (initialChart?.type ?? DEFAULT_CHART_TYPE) : undefined);
   const hasSelectedDirectory = !!selectedDirectoryId;
   const isAIQueryAvailable = isAIAvailable !== false;
+  const editChartTitle = savedChartName
+    ? t("workspace.analysis.charts.edit_chart_title_named", { name: savedChartName })
+    : t("workspace.analysis.charts.edit_chart_title");
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
       <DialogContent
         width="full"
         disableCloseOnOutsideClick={!isEditing}
+        closeOnEscape
         onOpenAutoFocus={(event) => event.preventDefault()}>
         <DialogHeader>
           <DialogTitle>
-            {isEditing
-              ? t("workspace.analysis.charts.edit_chart_title")
-              : t("workspace.analysis.charts.create_chart")}
+            {isEditing ? editChartTitle : t("workspace.analysis.charts.create_chart")}
           </DialogTitle>
           <DialogDescription>
             {isEditing

--- a/apps/web/modules/ee/analysis/charts/components/polished-tooltip.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/polished-tooltip.tsx
@@ -13,7 +13,7 @@ interface TooltipPayloadItem {
   name?: string | number;
   value?: unknown;
   color?: string;
-  payload?: { fill?: string };
+  payload?: { fill?: string; tooltipLabel?: string };
 }
 
 interface RechartsTooltipProps {
@@ -48,13 +48,16 @@ export const PolishedChartTooltip = ({
       <div className="flex flex-col gap-1.5">
         {payload.map((item) => {
           const key = item.dataKey ?? String(item.name ?? "");
+          // Rows pivoted from measures (see pivotMeasuresToCategories) carry their translated
+          // label on the row itself; otherwise the dataKey is a Cube column we can format.
+          const rowLabel = item.payload?.tooltipLabel ?? formatCubeColumnHeader(key, t);
           // payload.fill (per-row data.fill / pie <Cell>) wins over the Bar's series fallback.
           const indicatorColor = item.payload?.fill ?? item.color ?? CHART_BRAND_DARK;
           return (
             <div key={key} className="flex items-center justify-between gap-3">
               <div className="flex items-center gap-2">
                 <div className="size-2.5 shrink-0 rounded-full" style={{ backgroundColor: indicatorColor }} />
-                <span className="text-muted-foreground text-sm">{formatCubeColumnHeader(key, t)}</span>
+                <span className="text-muted-foreground text-sm">{rowLabel}</span>
               </div>
               <span className="text-foreground text-sm font-medium tabular-nums">
                 {formatCellValue(item.value)}

--- a/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.test.ts
+++ b/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.test.ts
@@ -368,6 +368,50 @@ describe("useChartDialog", () => {
       expect(result.current.chartName).toBe("Custom Chart");
     });
 
+    test("replaces a previously suggested name when the chart is regenerated", async () => {
+      const { result } = renderHook(() => useChartDialog(baseProps));
+
+      await act(async () => {
+        result.current.handleChartGenerated({
+          ...sampleChartData,
+          suggestedName: "Responses by Source",
+        });
+      });
+
+      await act(async () => {
+        result.current.handleChartGenerated({
+          ...sampleChartData,
+          suggestedName: "NPS by Week",
+        });
+      });
+
+      expect(result.current.chartName).toBe("NPS by Week");
+    });
+
+    test("keeps a user-edited name when the chart is regenerated", async () => {
+      const { result } = renderHook(() => useChartDialog(baseProps));
+
+      await act(async () => {
+        result.current.handleChartGenerated({
+          ...sampleChartData,
+          suggestedName: "Responses by Source",
+        });
+      });
+
+      await act(async () => {
+        result.current.setChartName("My Custom Name");
+      });
+
+      await act(async () => {
+        result.current.handleChartGenerated({
+          ...sampleChartData,
+          suggestedName: "NPS by Week",
+        });
+      });
+
+      expect(result.current.chartName).toBe("My Custom Name");
+    });
+
     test("preserves custom chart name when user types before delayed AI response completes", async () => {
       const { result } = renderHook(() => useChartDialog(baseProps));
 
@@ -377,6 +421,27 @@ describe("useChartDialog", () => {
 
       await act(async () => {
         result.current.handleChartGenerated({
+          ...sampleChartData,
+          suggestedName: "AI Generated Name",
+        });
+      });
+
+      expect(result.current.chartName).toBe("User Typed Name");
+    });
+
+    test("preserves the user's name even when invoked through a stale closure", async () => {
+      const { result } = renderHook(() => useChartDialog(baseProps));
+
+      // Captured before the user types — like a consumer holding the callback across renders
+      // while the AI request is in flight.
+      const staleHandleChartGenerated = result.current.handleChartGenerated;
+
+      await act(async () => {
+        result.current.setChartName("User Typed Name");
+      });
+
+      await act(async () => {
+        staleHandleChartGenerated({
           ...sampleChartData,
           suggestedName: "AI Generated Name",
         });

--- a/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.test.ts
+++ b/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.test.ts
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { AnalyticsResponse } from "@/modules/ee/analysis/types/analysis";
 
@@ -383,6 +383,71 @@ describe("useChartDialog", () => {
       });
 
       expect(result.current.chartName).toBe("User Typed Name");
+    });
+  });
+
+  describe("savedChartName", () => {
+    test("holds the loaded chart name and stays stable while the user renames", async () => {
+      mockGetChartAction.mockResolvedValue({
+        data: {
+          id: CHART_ID,
+          name: "Loaded Chart",
+          type: "bar",
+          query: sampleChartData.query,
+          feedbackDirectoryId: DIRECTORY_ID,
+        },
+      });
+      mockExecuteQueryAction.mockResolvedValue({ data: [] });
+
+      const { result } = renderHook(() => useChartDialog({ ...baseProps, chartId: CHART_ID }));
+
+      await waitFor(() => {
+        expect(result.current.savedChartName).toBe("Loaded Chart");
+      });
+      expect(result.current.chartName).toBe("Loaded Chart");
+
+      await act(async () => {
+        result.current.setChartName("Renamed Chart");
+      });
+
+      expect(result.current.chartName).toBe("Renamed Chart");
+      expect(result.current.savedChartName).toBe("Loaded Chart");
+    });
+
+    test("resets savedChartName when the dialog is closed without saving", async () => {
+      mockGetChartAction.mockResolvedValue({
+        data: {
+          id: CHART_ID,
+          name: "Loaded Chart",
+          type: "bar",
+          query: sampleChartData.query,
+          feedbackDirectoryId: DIRECTORY_ID,
+        },
+      });
+      mockExecuteQueryAction.mockResolvedValue({ data: [] });
+
+      const onOpenChange = vi.fn();
+      const { result } = renderHook(() => useChartDialog({ ...baseProps, onOpenChange, chartId: CHART_ID }));
+
+      await waitFor(() => {
+        expect(result.current.savedChartName).toBe("Loaded Chart");
+      });
+
+      await act(async () => {
+        result.current.handleClose();
+      });
+
+      expect(result.current.savedChartName).toBe("");
+      expect(result.current.chartName).toBe("");
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    test("keeps savedChartName empty when opening in create mode", async () => {
+      const { result } = renderHook(() => useChartDialog(baseProps));
+
+      await waitFor(() => {
+        expect(result.current.savedChartName).toBe("");
+      });
     });
   });
 

--- a/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.ts
+++ b/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
@@ -60,6 +60,9 @@ export function useChartDialog({
   const [chartLoadError, setChartLoadError] = useState<string | null>(null);
   const [currentChartId, setCurrentChartId] = useState<string | undefined>(chartId);
   const [selectedDirectoryId, setSelectedDirectoryId] = useState<string | null>(directories?.[0]?.id ?? null);
+  // Last name we prefilled from a suggestion; lets a regenerate replace its own
+  // stale suggestion without ever clobbering a name the user typed.
+  const lastSuggestedNameRef = useRef<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -87,6 +90,7 @@ export function useChartDialog({
       setChartData(null);
       setChartName("");
       setSavedChartName("");
+      lastSuggestedNameRef.current = null;
       setSelectedChartType(undefined);
       setCurrentChartId(undefined);
       setSelectedDirectoryId(directories?.[0]?.id ?? null);
@@ -169,8 +173,15 @@ export function useChartDialog({
   const handleChartGenerated = (data: AnalyticsResponse) => {
     setChartData(data);
     setSelectedChartType(data.chartType);
-    if (data.suggestedName) {
-      setChartName((prev) => (prev.trim() ? prev : data.suggestedName!));
+    const suggestedName = data.suggestedName?.trim();
+    if (suggestedName) {
+      // Functional updater: the AI response lands async, so a closure over chartName could be
+      // stale and clobber a name the user typed while the request was in flight.
+      setChartName((prev) => {
+        if (prev.trim() && prev !== lastSuggestedNameRef.current) return prev;
+        lastSuggestedNameRef.current = suggestedName;
+        return suggestedName;
+      });
     }
   };
 
@@ -367,6 +378,7 @@ export function useChartDialog({
       setChartData(null);
       setChartName("");
       setSavedChartName("");
+      lastSuggestedNameRef.current = null;
       setSelectedChartType(undefined);
       setCurrentChartId(undefined);
       setChartLoadError(null);

--- a/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.ts
+++ b/apps/web/modules/ee/analysis/charts/hooks/use-chart-dialog.ts
@@ -51,6 +51,8 @@ export function useChartDialog({
   const [chartData, setChartData] = useState<AnalyticsResponse | null>(null);
   const [isAddToDashboardDialogOpen, setIsAddToDashboardDialogOpen] = useState(false);
   const [chartName, setChartName] = useState("");
+  // Saved name of the chart being edited; unlike chartName it stays stable while the user types.
+  const [savedChartName, setSavedChartName] = useState("");
   const [dashboards, setDashboards] = useState<Array<{ id: string; name: string }>>([]);
   const [selectedDashboardId, setSelectedDashboardId] = useState<string | undefined>();
   const [isSaving, setIsSaving] = useState(false);
@@ -84,6 +86,7 @@ export function useChartDialog({
     if (!chartId) {
       setChartData(null);
       setChartName("");
+      setSavedChartName("");
       setSelectedChartType(undefined);
       setCurrentChartId(undefined);
       setSelectedDirectoryId(directories?.[0]?.id ?? null);
@@ -109,6 +112,7 @@ export function useChartDialog({
         if (cancelled) return;
 
         setChartName(chart.name);
+        setSavedChartName(chart.name);
         setSelectedChartType(resolveChartType(chart.type));
         setCurrentChartId(chart.id);
         setSelectedDirectoryId(chart.feedbackDirectoryId);
@@ -362,6 +366,7 @@ export function useChartDialog({
     if (!isSaving) {
       setChartData(null);
       setChartName("");
+      setSavedChartName("");
       setSelectedChartType(undefined);
       setCurrentChartId(undefined);
       setChartLoadError(null);
@@ -381,6 +386,7 @@ export function useChartDialog({
     chartData,
     chartName,
     setChartName,
+    savedChartName,
     selectedChartType,
     initialQuery,
     setSelectedChartType,

--- a/apps/web/modules/ee/analysis/charts/lib/ai-chart-query.server.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/ai-chart-query.server.ts
@@ -15,6 +15,8 @@ const CUBE_NAME = "FeedbackRecords";
 const DEFAULT_MEASURE = `${CUBE_NAME}.count`;
 const AI_CHART_GENERATION_TIMEOUT_MS = 30_000;
 const AI_CHART_GENERATION_MAX_OUTPUT_TOKENS = 1024;
+// Matches the maxLength of the chart-name input and the persisted chart name.
+const MAX_CHART_NAME_LENGTH = 255;
 
 const toEnumTuple = (values: readonly string[]): [string, ...string[]] => {
   if (values.length === 0) {
@@ -70,6 +72,10 @@ const ZFilter = z
   });
 
 export const ZAIQueryResponse = z.object({
+  name: z
+    .string()
+    .nullable()
+    .describe("Short, descriptive chart name reflecting the user's request (max 255 characters)"),
   measures: z.array(ZMeasureId),
   dimensions: z.array(ZDimensionId).nullable(),
   timeDimensions: z
@@ -90,6 +96,8 @@ type AIQueryResponse = z.infer<typeof ZAIQueryResponse>;
 export type AIChartQueryResult = {
   chartType: TChartType;
   query: TChartQuery;
+  /** AI-suggested chart name; omitted when the model returns none. */
+  name?: string;
 };
 
 type GenerateAIChartQueryInput = {
@@ -159,5 +167,12 @@ const normalizeChartQuery = (output: AIQueryResponse): AIChartQueryResult => {
     }));
   }
 
-  return { chartType: output.chartType, query };
+  const result: AIChartQueryResult = { chartType: output.chartType, query };
+
+  const name = output.name?.trim();
+  if (name) {
+    result.name = name.slice(0, MAX_CHART_NAME_LENGTH);
+  }
+
+  return result;
 };

--- a/apps/web/modules/ee/analysis/charts/lib/ai-chart-query.test.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/ai-chart-query.test.ts
@@ -30,6 +30,7 @@ describe("generateAIChartQuery", () => {
   test("returns the AI-generated chart type and normalized query for a clean response", async () => {
     mocks.generateOrganizationAIObject.mockResolvedValueOnce({
       object: {
+        name: "Responses by Source Type",
         measures: ["FeedbackRecords.count"],
         dimensions: ["FeedbackRecords.sourceType"],
         timeDimensions: null,
@@ -45,6 +46,7 @@ describe("generateAIChartQuery", () => {
 
     expect(result).toEqual({
       chartType: "bar",
+      name: "Responses by Source Type",
       query: {
         measures: ["FeedbackRecords.count"],
         dimensions: ["FeedbackRecords.sourceType"],
@@ -65,6 +67,7 @@ describe("generateAIChartQuery", () => {
   test("maps NPS score prompts to the NPS score measure", async () => {
     mocks.generateOrganizationAIObject.mockResolvedValueOnce({
       object: {
+        name: null,
         measures: ["FeedbackRecords.npsScore"],
         dimensions: null,
         timeDimensions: null,
@@ -87,6 +90,7 @@ describe("generateAIChartQuery", () => {
   test("falls back to the total count measure when the AI returns no measures", async () => {
     mocks.generateOrganizationAIObject.mockResolvedValueOnce({
       object: {
+        name: null,
         measures: [],
         dimensions: null,
         timeDimensions: null,
@@ -106,6 +110,7 @@ describe("generateAIChartQuery", () => {
   test("normalizes filters and time dimensions, dropping null-only optional fields", async () => {
     mocks.generateOrganizationAIObject.mockResolvedValueOnce({
       object: {
+        name: null,
         measures: ["FeedbackRecords.count"],
         dimensions: null,
         timeDimensions: [
@@ -137,6 +142,7 @@ describe("generateAIChartQuery", () => {
 
   test("rejects value-based filters without a non-empty values array", () => {
     const result = ZAIQueryResponse.safeParse({
+      name: null,
       measures: ["FeedbackRecords.count"],
       dimensions: null,
       timeDimensions: null,
@@ -153,6 +159,7 @@ describe("generateAIChartQuery", () => {
 
   test("rejects valueless filters that include values", () => {
     const result = ZAIQueryResponse.safeParse({
+      name: null,
       measures: ["FeedbackRecords.count"],
       dimensions: null,
       timeDimensions: null,
@@ -167,6 +174,7 @@ describe("generateAIChartQuery", () => {
 
   test("allows valueless filters with omitted values", () => {
     const result = ZAIQueryResponse.safeParse({
+      name: null,
       measures: ["FeedbackRecords.count"],
       dimensions: null,
       timeDimensions: null,
@@ -175,6 +183,46 @@ describe("generateAIChartQuery", () => {
     });
 
     expect(result.success).toBe(true);
+  });
+
+  test("trims the AI-suggested name and caps it at 255 characters", async () => {
+    mocks.generateOrganizationAIObject.mockResolvedValueOnce({
+      object: {
+        name: `  ${"a".repeat(300)}  `,
+        measures: ["FeedbackRecords.count"],
+        dimensions: null,
+        timeDimensions: null,
+        chartType: "bar",
+        filters: null,
+      },
+    });
+
+    const result = await generateAIChartQuery({
+      organizationId: "organization-1",
+      prompt: "responses",
+    });
+
+    expect(result.name).toBe("a".repeat(255));
+  });
+
+  test("omits the name when the AI returns a blank name", async () => {
+    mocks.generateOrganizationAIObject.mockResolvedValueOnce({
+      object: {
+        name: "   ",
+        measures: ["FeedbackRecords.count"],
+        dimensions: null,
+        timeDimensions: null,
+        chartType: "bar",
+        filters: null,
+      },
+    });
+
+    const result = await generateAIChartQuery({
+      organizationId: "organization-1",
+      prompt: "responses",
+    });
+
+    expect(result).not.toHaveProperty("name");
   });
 
   test("converts AI structured-output failures into a prompt error", async () => {

--- a/apps/web/modules/ee/analysis/charts/lib/chart-utils.test.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/chart-utils.test.ts
@@ -3,8 +3,11 @@ import {
   CHART_BRAND_DARK,
   CHART_MEASURE_COLORS,
   CHART_NOT_ENRICHED_COLOR,
+  PIVOTED_MEASURE_KEY,
+  PIVOTED_VALUE_KEY,
   formatCellValue,
   formatXAxisTick,
+  pivotMeasuresToCategories,
   preparePieData,
   resolveChartType,
 } from "./chart-utils";
@@ -138,6 +141,53 @@ describe("chart-utils", () => {
     test("converts boolean and bigint", () => {
       expect(formatCellValue(true)).toBe("true");
       expect(formatCellValue(123n)).toBe("123");
+    });
+  });
+
+  describe("pivotMeasuresToCategories", () => {
+    const label = (key: string) => `label:${key}`;
+
+    test("pivots a single measure row into one category row per measure", () => {
+      const data = [{ "F.veryPositiveCount": 3, "F.negativeCount": "1" }];
+      const result = pivotMeasuresToCategories(data, ["F.veryPositiveCount", "F.negativeCount"], label);
+      expect(result).toEqual([
+        {
+          [PIVOTED_MEASURE_KEY]: "F.veryPositiveCount",
+          [PIVOTED_VALUE_KEY]: 3,
+          tooltipLabel: "label:F.veryPositiveCount",
+          fill: CHART_MEASURE_COLORS[0],
+        },
+        {
+          [PIVOTED_MEASURE_KEY]: "F.negativeCount",
+          [PIVOTED_VALUE_KEY]: 1,
+          tooltipLabel: "label:F.negativeCount",
+          fill: CHART_MEASURE_COLORS[1],
+        },
+      ]);
+    });
+
+    test("keeps the given measure order so bars fill the axis from the left", () => {
+      const data = [{ b: 2, a: 1 }];
+      const result = pivotMeasuresToCategories(data, ["a", "b"], label);
+      expect(result.map((row) => row[PIVOTED_MEASURE_KEY])).toEqual(["a", "b"]);
+    });
+
+    test("renders missing, null, and non-numeric values as 0 so empty measures keep a slot", () => {
+      const data = [{ a: null, b: "n/a" }];
+      const result = pivotMeasuresToCategories(data, ["a", "b", "missing"], label);
+      expect(result.map((row) => row[PIVOTED_VALUE_KEY])).toEqual([0, 0, 0]);
+    });
+
+    test("emits one zero-value row per measure key when data is empty", () => {
+      const result = pivotMeasuresToCategories([], ["a"], label);
+      expect(result).toHaveLength(1);
+      expect(result[0][PIVOTED_VALUE_KEY]).toBe(0);
+    });
+
+    test("cycles the palette when there are more measures than colors", () => {
+      const keys = Array.from({ length: CHART_MEASURE_COLORS.length + 1 }, (_, i) => `m${i}`);
+      const result = pivotMeasuresToCategories([{}], keys, label);
+      expect(result.at(-1)?.fill).toBe(CHART_MEASURE_COLORS[0]);
     });
   });
 

--- a/apps/web/modules/ee/analysis/charts/lib/chart-utils.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/chart-utils.ts
@@ -71,6 +71,37 @@ export const preparePieData = (
   return { processedData, colors };
 };
 
+/** Category key for rows produced by {@link pivotMeasuresToCategories}. */
+export const PIVOTED_MEASURE_KEY = "measure";
+/** Value key for rows produced by {@link pivotMeasuresToCategories}. */
+export const PIVOTED_VALUE_KEY = "value";
+
+/**
+ * Pivot a measure-only result row (one row with one column per measure) into one category row
+ * per measure. Rendering the raw row as N bar series leaves recharts with a single category
+ * band centered in the plot — a wide empty gap before the first bar. Pivoted, the measures
+ * become ordinary categories that fill the x-axis from the left.
+ *
+ * Missing/non-numeric values become 0 so empty measures keep a visible, hoverable slot.
+ * `formatLabel` supplies the translated measure label stored as `tooltipLabel` on each row.
+ */
+export function pivotMeasuresToCategories(
+  data: TChartDataRow[],
+  measureKeys: string[],
+  formatLabel: (measureKey: string) => string
+): TChartDataRow[] {
+  const row = data[0] ?? {};
+  return measureKeys.map((key, index) => {
+    const num = Number(row[key]);
+    return {
+      [PIVOTED_MEASURE_KEY]: key,
+      [PIVOTED_VALUE_KEY]: Number.isFinite(num) ? num : 0,
+      tooltipLabel: formatLabel(key),
+      fill: CHART_MEASURE_COLORS[index % CHART_MEASURE_COLORS.length],
+    };
+  });
+}
+
 // parseISO accepts year-only inputs (e.g. "1000" → Jan 1, 1000); require a
 // full YYYY-MM-DD prefix so numeric category labels aren't formatted as dates.
 const ISO_DATE_PREFIX = /^\d{4}-\d{2}-\d{2}/;

--- a/apps/web/modules/ee/analysis/charts/lib/y-axis-scale.test.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/y-axis-scale.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "vitest";
+import { computeYAxis } from "./y-axis-scale";
+
+const RATING_AVG = "FeedbackRecords.ratingAverage";
+const CSAT_AVG = "FeedbackRecords.csatAverage";
+const CES_AVG = "FeedbackRecords.cesAverage";
+const NPS_AVG = "FeedbackRecords.npsAverage";
+const COUNT = "FeedbackRecords.count";
+
+describe("computeYAxis", () => {
+  describe("fixed-scale measures pin the axis to the question scale (ENG-1796)", () => {
+    test("rating average 3.33 on a 1-5 question renders a 0-5 axis, not a data-driven 0-4 one", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: 3.33 }], [RATING_AVG], true);
+      expect(scale).toEqual({ domain: [0, 5], ticks: [0, 1, 2, 3, 4, 5] });
+    });
+
+    test("rating average above 7 pins to the 10 scale with even ticks", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: 8.2 }], [RATING_AVG], true);
+      expect(scale).toEqual({ domain: [0, 10], ticks: [0, 2, 4, 6, 8, 10] });
+    });
+
+    test("rating average between 5 and 7 pins to the 7 scale (smallest standard scale containing the data)", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: 6.33 }], [RATING_AVG], true);
+      expect(scale).toEqual({ domain: [0, 7], ticks: [0, 1, 2, 3, 4, 5, 6, 7] });
+    });
+
+    test("CSAT average always pins to its fixed 1-5 scale", () => {
+      const scale = computeYAxis([{ [CSAT_AVG]: 2.4 }], [CSAT_AVG], true);
+      expect(scale).toEqual({ domain: [0, 5], ticks: [0, 1, 2, 3, 4, 5] });
+    });
+
+    test("CES average pins to 5 or 7 depending on the data", () => {
+      expect(computeYAxis([{ [CES_AVG]: 3 }], [CES_AVG], true)?.domain).toEqual([0, 5]);
+      expect(computeYAxis([{ [CES_AVG]: 6.5 }], [CES_AVG], true)?.domain).toEqual([0, 7]);
+    });
+
+    test("NPS average pins to its fixed 0-10 scale", () => {
+      const scale = computeYAxis([{ [NPS_AVG]: 6.33 }], [NPS_AVG], true);
+      expect(scale).toEqual({ domain: [0, 10], ticks: [0, 2, 4, 6, 8, 10] });
+    });
+
+    test("pins across category rows using the series max", () => {
+      const data = [{ [RATING_AVG]: 1.2 }, { [RATING_AVG]: 4.8 }, { [RATING_AVG]: 3.3 }];
+      expect(computeYAxis(data, [RATING_AVG], true)?.domain).toEqual([0, 5]);
+    });
+
+    test("pins line/area charts (no zero baseline flag) to the full 0-based scale too", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: 3.33 }, { [RATING_AVG]: 4.1 }], [RATING_AVG], false);
+      expect(scale?.domain).toEqual([0, 5]);
+    });
+
+    test("multi-measure charts of only fixed-scale measures pin to the largest needed scale", () => {
+      const data = [{ [RATING_AVG]: 6.3, [CSAT_AVG]: 4 }];
+      expect(computeYAxis(data, [RATING_AVG, CSAT_AVG], true)?.domain).toEqual([0, 7]);
+    });
+
+    test("a fixed-scale series with no values does not veto pinning by the other series", () => {
+      const data = [{ [RATING_AVG]: 3.2, [CSAT_AVG]: null }];
+      expect(computeYAxis(data, [RATING_AVG, CSAT_AVG], true)?.domain).toEqual([0, 5]);
+    });
+  });
+
+  describe("falls back to data-driven nice scaling", () => {
+    test("when the chart mixes fixed-scale and unbounded measures", () => {
+      const data = [{ [RATING_AVG]: 3.33, [COUNT]: 77 }];
+      const scale = computeYAxis(data, [RATING_AVG, COUNT], true);
+      expect(scale).toEqual({ domain: [0, 80], ticks: [0, 20, 40, 60, 80] });
+    });
+
+    test("when data exceeds the largest known scale (defensive: never clip real data)", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: 12 }], [RATING_AVG], true);
+      expect(scale?.domain[1]).toBeGreaterThanOrEqual(12);
+    });
+
+    test("when a fixed-scale series unexpectedly dips negative", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: -2 }, { [RATING_AVG]: 4 }], [RATING_AVG], false);
+      expect(scale?.domain[0]).toBeLessThanOrEqual(-2);
+    });
+
+    test("for unbounded measures (unchanged behavior)", () => {
+      const scale = computeYAxis([{ [COUNT]: 77 }], [COUNT], true);
+      expect(scale).toEqual({ domain: [0, 80], ticks: [0, 20, 40, 60, 80] });
+    });
+
+    test("keeps decimal precision for small unbounded values", () => {
+      const scale = computeYAxis([{ [COUNT]: 0.33 }], [COUNT], false);
+      expect(scale?.ticks.every((tick) => Number.isFinite(tick))).toBe(true);
+      expect(scale?.domain[1]).toBeGreaterThanOrEqual(0.33);
+    });
+  });
+
+  describe("edge cases", () => {
+    test("returns undefined for empty data or non-numeric values", () => {
+      expect(computeYAxis([], [COUNT], true)).toBeUndefined();
+      expect(computeYAxis([{ [COUNT]: null }, { [COUNT]: "" }], [COUNT], true)).toBeUndefined();
+    });
+
+    test("all-null fixed-scale data returns undefined instead of a pinned empty axis", () => {
+      expect(computeYAxis([{ [RATING_AVG]: null }], [RATING_AVG], true)).toBeUndefined();
+    });
+
+    test("flat zero data still renders a usable axis", () => {
+      const scale = computeYAxis([{ [COUNT]: 0 }], [COUNT], true);
+      expect(scale?.domain[1]).toBeGreaterThan(0);
+    });
+
+    test("coerces numeric strings (Cube can return numbers as strings)", () => {
+      const scale = computeYAxis([{ [RATING_AVG]: "3.33" }], [RATING_AVG], true);
+      expect(scale?.domain).toEqual([0, 5]);
+    });
+  });
+});

--- a/apps/web/modules/ee/analysis/charts/lib/y-axis-scale.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/y-axis-scale.ts
@@ -1,0 +1,129 @@
+import { getMeasureAxisMaxCandidates } from "@/modules/ee/analysis/lib/schema-definition";
+import type { TChartDataRow } from "@/modules/ee/analysis/types/analysis";
+
+const TARGET_TICK_COUNT = 5;
+// Pinned scales prefer the finest step that still keeps the axis readable; a 0-7 CES axis
+// labels every integer (8 ticks) rather than overshooting the scale to hit a "nice" bound.
+const MAX_PINNED_TICK_COUNT = 8;
+
+export interface YAxisScale {
+  domain: [number, number];
+  ticks: number[];
+}
+
+// Round a value to a "nice" number (1/2/5/10 × 10ⁿ) — the family of steps people
+// expect on an axis. `round` snaps to the nearest nice number; otherwise it rounds
+// up so the value fully contains the range.
+const niceNum = (value: number, round: boolean): number => {
+  const exponent = Math.floor(Math.log10(value));
+  const fraction = value / 10 ** exponent;
+  let niceFraction: number;
+  if (round) {
+    if (fraction < 1.5) niceFraction = 1;
+    else if (fraction < 3) niceFraction = 2;
+    else if (fraction < 7) niceFraction = 5;
+    else niceFraction = 10;
+  } else if (fraction <= 1) niceFraction = 1;
+  else if (fraction <= 2) niceFraction = 2;
+  else if (fraction <= 5) niceFraction = 5;
+  else niceFraction = 10;
+  return niceFraction * 10 ** exponent;
+};
+
+const collectNumericValues = (data: TChartDataRow[], keys: string[]): number[] => {
+  const values: number[] = [];
+  for (const row of data) {
+    for (const key of keys) {
+      const raw = row[key];
+      if (raw === null || raw === undefined || raw === "") continue;
+      const num = Number(raw);
+      if (Number.isFinite(num)) values.push(num);
+    }
+  }
+  return values;
+};
+
+/**
+ * Axis max for charts whose every series is a fixed-scale measure (rating/CSAT/CES/NPS
+ * averages): the largest of each series' smallest scale candidate that contains its data,
+ * so a 3.33 average on a 1-5 rating pins the axis to 5 instead of a data-driven 4 (ENG-1796).
+ * Returns undefined — falling back to nice scaling — when any series is not scale-pinned,
+ * dips negative, or exceeds its largest known scale.
+ */
+const computePinnedAxisMax = (data: TChartDataRow[], dataKeys: string[]): number | undefined => {
+  let pinnedMax = 0;
+  for (const key of dataKeys) {
+    const candidates = getMeasureAxisMaxCandidates(key);
+    if (!candidates || candidates.length === 0) return undefined;
+    const values = collectNumericValues(data, [key]);
+    if (values.length === 0) continue;
+    if (Math.min(...values) < 0) return undefined;
+    const keyMax = Math.max(...values);
+    const candidate = candidates.find((c) => c >= keyMax);
+    if (candidate === undefined) return undefined;
+    pinnedMax = Math.max(pinnedMax, candidate);
+  }
+  return pinnedMax > 0 ? pinnedMax : undefined;
+};
+
+// Integer ticks for a pinned [0, max] scale: the smallest 1/2/5×10ⁿ step that divides the
+// scale evenly without exceeding MAX_PINNED_TICK_COUNT ticks, so every gridline lands on a
+// value of the scale and the top tick is exactly the scale max (never overshoots it).
+const computePinnedTicks = (max: number): number[] => {
+  for (let exponent = 0; 10 ** exponent <= max; exponent++) {
+    for (const base of [1, 2, 5]) {
+      const step = base * 10 ** exponent;
+      if (max % step === 0 && max / step + 1 <= MAX_PINNED_TICK_COUNT) {
+        const ticks: number[] = [];
+        for (let tick = 0; tick <= max; tick += step) ticks.push(tick);
+        return ticks;
+      }
+    }
+  }
+  return [0, max];
+};
+
+export const computeYAxis = (
+  data: TChartDataRow[],
+  dataKeys: string[],
+  zeroBaseline: boolean
+): YAxisScale | undefined => {
+  const values = collectNumericValues(data, dataKeys);
+  if (values.length === 0) return undefined;
+
+  const dataMin = Math.min(...values);
+  const dataMax = Math.max(...values);
+
+  // Fixed-scale measures (rating/CSAT/CES/NPS averages) render against the question's full
+  // scale — 0 up to the pinned max — regardless of chart type, so bar heights and line
+  // positions read as "3.33 out of 5" rather than being stretched to a data-driven bound.
+  const pinnedMax = computePinnedAxisMax(data, dataKeys);
+  if (pinnedMax !== undefined) {
+    return { domain: [0, pinnedMax], ticks: computePinnedTicks(pinnedMax) };
+  }
+
+  // Baseline: bars and all-positive series sit on 0; only dip below zero when the
+  // data genuinely does, so we never draw a phantom negative axis (e.g. a -4 floor
+  // under a metric that bottoms out at 0).
+  const baselineLow = zeroBaseline ? Math.min(0, dataMin) : dataMin;
+  // Flat data has no range to scale, so give it a unit of headroom to render ticks.
+  const spanHigh = dataMax === baselineLow ? baselineLow + 1 : dataMax;
+
+  // Snap the axis to nice bounds and derive evenly spaced round ticks, so every
+  // gridline lands on a labelled value. (Recharts' auto-ticks are computed from a
+  // raw domain and can fall outside it, drawing extra gridlines with no label.)
+  const step = niceNum(niceNum(spanHigh - baselineLow, false) / (TARGET_TICK_COUNT - 1), true);
+  const niceMin = Math.floor(baselineLow / step) * step;
+  const niceMax = Math.ceil(spanHigh / step) * step;
+
+  // Clean up floating-point noise that decimal steps introduce (e.g. 0.30000000004).
+  const decimals = Math.max(0, -Math.floor(Math.log10(step)));
+  const round = (n: number) => Number(n.toFixed(decimals));
+
+  const ticks: number[] = [];
+  for (let tick = niceMin; tick <= niceMax + step / 2; tick += step) {
+    ticks.push(round(tick));
+  }
+
+  return { domain: [round(niceMin), round(niceMax)], ticks };
+};

--- a/apps/web/modules/ee/analysis/dashboards/actions.ts
+++ b/apps/web/modules/ee/analysis/dashboards/actions.ts
@@ -23,6 +23,7 @@ import {
   updateDashboard,
   updateWidgetLayouts,
 } from "./lib/dashboards";
+import { duplicateChartAndAddWidget } from "./lib/duplicate-chart-and-add-widget";
 
 const checkDashboardsEnabled = async (organizationId: string) => {
   const isAllowed = await getIsDashboardsEnabled(organizationId);
@@ -327,6 +328,54 @@ export const addChartToDashboardAction = authenticatedActionClient
         ctx.auditLoggingCtx.workspaceId = workspaceId;
         ctx.auditLoggingCtx.dashboardWidgetId = widget.id;
         ctx.auditLoggingCtx.newObject = widget;
+        return widget;
+      }
+    )
+  );
+
+const ZDuplicateChartAndAddWidgetAction = z.object({
+  workspaceId: ZId,
+  dashboardId: ZId,
+  chartId: ZId,
+  layout: ZWidgetLayout.optional(),
+});
+
+export const duplicateChartAndAddWidgetAction = authenticatedActionClient
+  .inputSchema(ZDuplicateChartAndAddWidgetAction)
+  .action(
+    withAuditLogging(
+      "created",
+      "dashboardWidget",
+      async ({
+        ctx,
+        parsedInput,
+      }: {
+        ctx: AuthenticatedActionClientCtx;
+        parsedInput: z.infer<typeof ZDuplicateChartAndAddWidgetAction>;
+      }) => {
+        const { organizationId, workspaceId } = await checkWorkspaceAccess(
+          ctx.user.id,
+          parsedInput.workspaceId,
+          "readWrite"
+        );
+        await checkDashboardsEnabled(organizationId);
+
+        const { chart, widget } = await duplicateChartAndAddWidget({
+          dashboardId: parsedInput.dashboardId,
+          workspaceId,
+          chartId: parsedInput.chartId,
+          createdBy: ctx.user.id,
+          layout: parsedInput.layout,
+        });
+
+        revalidatePath(`/workspaces/${workspaceId}/dashboards/${parsedInput.dashboardId}`);
+        revalidatePath(`/workspaces/${workspaceId}/dashboards`);
+
+        ctx.auditLoggingCtx.organizationId = organizationId;
+        ctx.auditLoggingCtx.workspaceId = workspaceId;
+        ctx.auditLoggingCtx.chartId = chart.id;
+        ctx.auditLoggingCtx.dashboardWidgetId = widget.id;
+        ctx.auditLoggingCtx.newObject = { chart, widget };
         return widget;
       }
     )

--- a/apps/web/modules/ee/analysis/dashboards/components/dashboard-detail-client.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/components/dashboard-detail-client.tsx
@@ -23,6 +23,7 @@ import { GoBackButton } from "@/modules/ui/components/go-back-button";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import {
   addChartToDashboardAction,
+  duplicateChartAndAddWidgetAction,
   removeWidgetFromDashboardAction,
   updateDashboardAction,
   updateWidgetLayoutsAction,
@@ -129,6 +130,7 @@ const MemoizedWidgetItem = memo(function WidgetItem({
   isEditing,
   dataPromise,
   onEdit,
+  onDuplicate,
   onResize,
   onRemove,
 }: Readonly<{
@@ -136,6 +138,7 @@ const MemoizedWidgetItem = memo(function WidgetItem({
   isEditing: boolean;
   dataPromise?: Promise<{ data: TChartDataRow[]; query: TChartQuery } | { error: TDashboardWidgetError }>;
   onEdit?: () => void;
+  onDuplicate?: () => void;
   onResize?: () => void;
   onRemove?: () => void;
 }>) {
@@ -146,6 +149,7 @@ const MemoizedWidgetItem = memo(function WidgetItem({
       title={title}
       isEditing={isEditing}
       onEdit={onEdit}
+      onDuplicate={onDuplicate}
       onResize={onResize}
       onRemove={onRemove}>
       <MemoizedWidgetContent widget={widget} dataPromise={dataPromise} />
@@ -210,6 +214,28 @@ export function DashboardDetailClient({
   const handleEditChart = useCallback((chartId: string) => {
     setEditingChartId(chartId);
   }, []);
+
+  const handleDuplicateWidget = useCallback(
+    async (widget: TDashboardWidget) => {
+      try {
+        const result = await duplicateChartAndAddWidgetAction({
+          workspaceId,
+          dashboardId: dashboard.id,
+          chartId: widget.chartId,
+          layout: widget.layout,
+        });
+        if (!result?.data) {
+          toast.error(getFormattedErrorMessage(result));
+          return;
+        }
+        toast.success(t("workspace.analysis.dashboards.chart_duplicated"));
+        startTransition(() => router.refresh());
+      } catch {
+        toast.error(t("workspace.analysis.dashboards.chart_duplicate_failed"));
+      }
+    },
+    [workspaceId, dashboard.id, router, t, startTransition]
+  );
 
   const handleUndoRemoveWidget = useCallback(
     async (snapshot: TDashboardWidget) => {
@@ -418,6 +444,9 @@ export function DashboardDetailClient({
                       isEditing={isEditing}
                       dataPromise={widgetDataPromises.get(widget.id)}
                       onEdit={isReadOnly ? undefined : () => handleEditChart(widget.chartId)}
+                      // Duplicate is hidden in edit mode: saving edit-mode drafts removes any
+                      // widget not present in the draft, which would delete the fresh copy.
+                      onDuplicate={isReadOnly || isEditing ? undefined : () => handleDuplicateWidget(widget)}
                       onResize={isReadOnly ? undefined : handleEnterEditMode}
                       onRemove={isReadOnly ? undefined : () => handleRemoveWidgetFromMenu(widget.id)}
                     />

--- a/apps/web/modules/ee/analysis/dashboards/components/dashboard-widget.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/components/dashboard-widget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Maximize2Icon, MoreVerticalIcon, SquarePenIcon, TrashIcon } from "lucide-react";
+import { CopyIcon, Maximize2Icon, MoreVerticalIcon, SquarePenIcon, TrashIcon } from "lucide-react";
 import { ReactNode, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
@@ -16,6 +16,7 @@ interface DashboardWidgetProps {
   children: ReactNode;
   isEditing?: boolean;
   onEdit?: () => void;
+  onDuplicate?: () => void;
   onResize?: () => void;
   onRemove?: () => void;
 }
@@ -25,12 +26,13 @@ export function DashboardWidget({
   children,
   isEditing,
   onEdit,
+  onDuplicate,
   onResize,
   onRemove,
 }: Readonly<DashboardWidgetProps>) {
   const { t } = useTranslation();
   const [menuOpen, setMenuOpen] = useState(false);
-  const hasMenuActions = Boolean(onEdit || onResize || onRemove);
+  const hasMenuActions = Boolean(onEdit || onDuplicate || onResize || onRemove);
 
   return (
     <div
@@ -65,6 +67,16 @@ export function DashboardWidget({
                   }}>
                   <SquarePenIcon className="mr-2 size-4" />
                   {t("common.edit")}
+                </DropdownMenuItem>
+              )}
+              {onDuplicate && (
+                <DropdownMenuItem
+                  onSelect={() => {
+                    setMenuOpen(false);
+                    onDuplicate();
+                  }}>
+                  <CopyIcon className="mr-2 size-4" />
+                  {t("common.duplicate")}
                 </DropdownMenuItem>
               )}
               {onResize && (

--- a/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.test.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { duplicateChart } from "@/modules/ee/analysis/charts/lib/charts";
+import { addChartToDashboard } from "./dashboards";
+import { duplicateChartAndAddWidget } from "./duplicate-chart-and-add-widget";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    dashboard: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@/lib/utils/validate", () => ({
+  validateInputs: vi.fn(),
+}));
+
+vi.mock("@/modules/ee/analysis/charts/lib/charts", () => ({
+  duplicateChart: vi.fn(),
+}));
+
+vi.mock("./dashboards", () => ({
+  addChartToDashboard: vi.fn(),
+}));
+
+const mockDashboardId = "dashboard-abc-123";
+const mockWorkspaceId = "workspace-abc-123";
+const mockUserId = "user-abc-123";
+const mockChartId = "chart-abc-123";
+const mockLayout = { x: 0, y: 0, w: 4, h: 3 };
+
+const mockDuplicatedChart = {
+  id: "chart-copy-123",
+  name: "Test Chart (copy)",
+  type: "bar",
+  query: { measures: ["Feedback.count"] },
+  config: {},
+  feedbackDirectoryId: "directory-abc-123",
+  createdAt: new Date("2025-01-01"),
+  updatedAt: new Date("2025-01-01"),
+};
+
+const mockWidget = {
+  id: "widget-new-123",
+  dashboardId: mockDashboardId,
+  chartId: mockDuplicatedChart.id,
+  layout: mockLayout,
+  order: 1,
+};
+
+const makePrismaError = (code: string) =>
+  new Prisma.PrismaClientKnownRequestError("mock error", { code, clientVersion: "5.0.0" });
+
+describe("duplicateChartAndAddWidget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("duplicates the chart and adds it as a widget on the same dashboard", async () => {
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId } as any);
+    vi.mocked(duplicateChart).mockResolvedValue(mockDuplicatedChart as any);
+    vi.mocked(addChartToDashboard).mockResolvedValue(mockWidget as any);
+
+    const result = await duplicateChartAndAddWidget({
+      dashboardId: mockDashboardId,
+      workspaceId: mockWorkspaceId,
+      chartId: mockChartId,
+      createdBy: mockUserId,
+      layout: mockLayout,
+    });
+
+    expect(result).toEqual({ chart: mockDuplicatedChart, widget: mockWidget });
+    expect(prisma.dashboard.findFirst).toHaveBeenCalledWith({
+      where: { id: mockDashboardId, workspaceId: mockWorkspaceId },
+      select: { id: true },
+    });
+    expect(duplicateChart).toHaveBeenCalledWith(mockChartId, mockWorkspaceId, mockUserId);
+    expect(addChartToDashboard).toHaveBeenCalledWith({
+      dashboardId: mockDashboardId,
+      chartId: mockDuplicatedChart.id,
+      workspaceId: mockWorkspaceId,
+      layout: mockLayout,
+    });
+  });
+
+  test("passes an undefined layout through so the widget gets the chart-type default", async () => {
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId } as any);
+    vi.mocked(duplicateChart).mockResolvedValue(mockDuplicatedChart as any);
+    vi.mocked(addChartToDashboard).mockResolvedValue(mockWidget as any);
+
+    await duplicateChartAndAddWidget({
+      dashboardId: mockDashboardId,
+      workspaceId: mockWorkspaceId,
+      chartId: mockChartId,
+      createdBy: mockUserId,
+    });
+
+    expect(addChartToDashboard).toHaveBeenCalledWith({
+      dashboardId: mockDashboardId,
+      chartId: mockDuplicatedChart.id,
+      workspaceId: mockWorkspaceId,
+      layout: undefined,
+    });
+  });
+
+  test("throws ResourceNotFoundError and does not duplicate when the dashboard is not in the workspace", async () => {
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue(null);
+
+    await expect(
+      duplicateChartAndAddWidget({
+        dashboardId: mockDashboardId,
+        workspaceId: mockWorkspaceId,
+        chartId: mockChartId,
+        createdBy: mockUserId,
+      })
+    ).rejects.toMatchObject({
+      name: "ResourceNotFoundError",
+      resourceType: "Dashboard",
+      resourceId: mockDashboardId,
+    });
+    expect(duplicateChart).not.toHaveBeenCalled();
+    expect(addChartToDashboard).not.toHaveBeenCalled();
+  });
+
+  test("propagates duplicateChart errors without adding a widget", async () => {
+    vi.mocked(prisma.dashboard.findFirst).mockResolvedValue({ id: mockDashboardId } as any);
+    vi.mocked(duplicateChart).mockRejectedValue(
+      Object.assign(new Error("Chart not found"), { name: "ResourceNotFoundError" })
+    );
+
+    await expect(
+      duplicateChartAndAddWidget({
+        dashboardId: mockDashboardId,
+        workspaceId: mockWorkspaceId,
+        chartId: mockChartId,
+        createdBy: mockUserId,
+      })
+    ).rejects.toMatchObject({ name: "ResourceNotFoundError" });
+    expect(addChartToDashboard).not.toHaveBeenCalled();
+  });
+
+  test("wraps Prisma errors from the dashboard lookup in DatabaseError", async () => {
+    vi.mocked(prisma.dashboard.findFirst).mockRejectedValue(makePrismaError("P9999"));
+
+    await expect(
+      duplicateChartAndAddWidget({
+        dashboardId: mockDashboardId,
+        workspaceId: mockWorkspaceId,
+        chartId: mockChartId,
+        createdBy: mockUserId,
+      })
+    ).rejects.toMatchObject({ name: "DatabaseError" });
+    expect(duplicateChart).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.ts
+++ b/apps/web/modules/ee/analysis/dashboards/lib/duplicate-chart-and-add-widget.ts
@@ -1,0 +1,63 @@
+import "server-only";
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { TWidgetLayout, ZWidgetLayout } from "@formbricks/types/analysis";
+import { ZId } from "@formbricks/types/common";
+import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { validateInputs } from "@/lib/utils/validate";
+import { duplicateChart } from "@/modules/ee/analysis/charts/lib/charts";
+import { addChartToDashboard } from "./dashboards";
+
+/**
+ * Deep-copies a chart (new UUID, "(copy)" name suffix, copied query/config) and adds the
+ * new chart as a widget on the given dashboard. The dashboard is verified first so a
+ * missing dashboard does not leave an orphaned chart copy behind.
+ */
+export const duplicateChartAndAddWidget = async ({
+  dashboardId,
+  workspaceId,
+  chartId,
+  createdBy,
+  layout,
+}: {
+  dashboardId: string;
+  workspaceId: string;
+  chartId: string;
+  createdBy: string;
+  layout?: TWidgetLayout;
+}) => {
+  validateInputs(
+    [dashboardId, ZId],
+    [workspaceId, ZId],
+    [chartId, ZId],
+    [createdBy, ZId],
+    [layout, ZWidgetLayout.optional()]
+  );
+
+  let dashboard;
+  try {
+    dashboard = await prisma.dashboard.findFirst({
+      where: { id: dashboardId, workspaceId },
+      select: { id: true },
+    });
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      throw new DatabaseError(error.message);
+    }
+    throw error;
+  }
+
+  if (!dashboard) {
+    throw new ResourceNotFoundError("Dashboard", dashboardId);
+  }
+
+  const chart = await duplicateChart(chartId, workspaceId, createdBy);
+  const widget = await addChartToDashboard({
+    dashboardId,
+    chartId: chart.id,
+    workspaceId,
+    layout,
+  });
+
+  return { chart, widget };
+};

--- a/apps/web/modules/ee/analysis/lib/schema-definition.test.ts
+++ b/apps/web/modules/ee/analysis/lib/schema-definition.test.ts
@@ -13,11 +13,13 @@ import {
   formatCubeColumnHeader,
   getFieldById,
   getFilterOperatorsForType,
+  getMeasureAxisLabel,
   getTranslatedDimensionValueLabel,
   getTranslatedFieldLabel,
   isEnrichmentDimensionId,
   isNotEnrichedDimensionValue,
   isSelectableValueDimension,
+  sortMeasureIdsForCategoryAxis,
   sortRowsByEnumDimension,
 } from "./schema-definition";
 
@@ -303,6 +305,81 @@ describe("schema-definition", () => {
     test("does not label empty values on non-enrichment dimensions", () => {
       expect(getTranslatedDimensionValueLabel("FeedbackRecords.sourceName", "", t)).toBeUndefined();
       expect(getTranslatedDimensionValueLabel("FeedbackRecords.sourceName", null, t)).toBeUndefined();
+    });
+  });
+
+  describe("sortMeasureIdsForCategoryAxis", () => {
+    test("sorts sentiment count measures into the sentiment scale order", () => {
+      const pickerOrder = [
+        "FeedbackRecords.veryPositiveCount",
+        "FeedbackRecords.positiveCount",
+        "FeedbackRecords.neutralCount",
+        "FeedbackRecords.negativeCount",
+        "FeedbackRecords.veryNegativeCount",
+        "FeedbackRecords.mixedCount",
+      ];
+      expect(sortMeasureIdsForCategoryAxis(pickerOrder)).toEqual([
+        "FeedbackRecords.veryNegativeCount",
+        "FeedbackRecords.negativeCount",
+        "FeedbackRecords.neutralCount",
+        "FeedbackRecords.positiveCount",
+        "FeedbackRecords.veryPositiveCount",
+        "FeedbackRecords.mixedCount",
+      ]);
+    });
+
+    test("keeps non-sentiment measures in their relative order, after sentiment ones", () => {
+      const ids = [
+        "FeedbackRecords.joyCount",
+        "FeedbackRecords.positiveCount",
+        "FeedbackRecords.count",
+        "FeedbackRecords.veryNegativeCount",
+      ];
+      expect(sortMeasureIdsForCategoryAxis(ids)).toEqual([
+        "FeedbackRecords.veryNegativeCount",
+        "FeedbackRecords.positiveCount",
+        "FeedbackRecords.joyCount",
+        "FeedbackRecords.count",
+      ]);
+    });
+
+    test("does not mutate the input array", () => {
+      const ids = ["FeedbackRecords.positiveCount", "FeedbackRecords.veryNegativeCount"];
+      sortMeasureIdsForCategoryAxis(ids);
+      expect(ids).toEqual(["FeedbackRecords.positiveCount", "FeedbackRecords.veryNegativeCount"]);
+    });
+  });
+
+  describe("getMeasureAxisLabel", () => {
+    const t = ((key: string) => key) as TFunction;
+
+    test("labels sentiment count measures with their short value label", () => {
+      expect(getMeasureAxisLabel("FeedbackRecords.veryPositiveCount", t)).toBe(
+        "workspace.analysis.charts.sentiment_value_very_positive"
+      );
+      expect(getMeasureAxisLabel("FeedbackRecords.mixedCount", t)).toBe(
+        "workspace.analysis.charts.sentiment_value_mixed"
+      );
+    });
+
+    test("labels emotion count measures with their short value label", () => {
+      expect(getMeasureAxisLabel("FeedbackRecords.joyCount", t)).toBe(
+        "workspace.analysis.charts.emotion_value_joy"
+      );
+      expect(getMeasureAxisLabel("FeedbackRecords.disgustCount", t)).toBe(
+        "workspace.analysis.charts.emotion_value_disgust"
+      );
+    });
+
+    test("falls back to the full column header for other measures", () => {
+      expect(getMeasureAxisLabel("FeedbackRecords.count", t)).toBe(
+        "workspace.analysis.charts.field_label_count"
+      );
+      // promoterCount is an NPS measure, not a sentiment/emotion enum measure
+      expect(getMeasureAxisLabel("FeedbackRecords.promoterCount", t)).toBe(
+        "workspace.analysis.charts.field_label_promoter_count"
+      );
+      expect(getMeasureAxisLabel("Some.unknownKey", t)).toBe("Unknown Key");
     });
   });
 

--- a/apps/web/modules/ee/analysis/lib/schema-definition.ts
+++ b/apps/web/modules/ee/analysis/lib/schema-definition.ts
@@ -437,6 +437,46 @@ export function getTranslatedDimensionValueLabel(
   return undefined;
 }
 
+// Sentiment count measure ids in the sentiment *scale* order (very_negative → very_positive,
+// mixed last) — the order the sentiment dimension axis uses.
+const SENTIMENT_COUNT_MEASURE_IDS_BY_SCALE: string[] = SENTIMENT_VALUE_ORDER.map(
+  (value) => `FeedbackRecords.${toCountMeasureId(value)}Count`
+);
+
+/**
+ * Sort measure ids for a per-measure category axis (measure-only bar charts, where each
+ * measure is its own bar). Sentiment count measures follow the sentiment scale order so the
+ * pivoted chart reads in the same direction (and with the same per-slot colors) as a chart
+ * grouped by the sentiment dimension — not the positive-first SENTIMENT_MEASURE_ORDER used
+ * for series/legend lists. Other measures keep their relative order after them.
+ */
+export function sortMeasureIdsForCategoryAxis(measureIds: string[]): string[] {
+  const rank = (id: string): number => {
+    const index = SENTIMENT_COUNT_MEASURE_IDS_BY_SCALE.indexOf(id);
+    return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+  };
+  return [...measureIds].sort((a, b) => rank(a) - rank(b));
+}
+
+/**
+ * Short x-axis label for a per-measure category axis (measure-only bar charts, where each
+ * measure is its own bar). Sentiment/emotion count measures reuse their enum value label
+ * ("Very positive") — the full measure label ("Sentiment: Very positive") is too wide for
+ * ticks, so recharts drops the overlapping ones and leaves bars unlabelled. Other measures
+ * fall back to their full column header.
+ */
+export function getMeasureAxisLabel(measureId: string, t: TFunction): string {
+  const sentiment = SENTIMENT_MEASURE_ORDER.find(
+    (value) => `FeedbackRecords.${toCountMeasureId(value)}Count` === measureId
+  );
+  const emotion = EMOTION_MEASURE_ORDER.find((value) => `FeedbackRecords.${value}Count` === measureId);
+  return (
+    (sentiment ? getTranslatedSentimentValueLabel(sentiment, t) : undefined) ??
+    (emotion ? getTranslatedEmotionValueLabel(emotion, t) : undefined) ??
+    formatCubeColumnHeader(measureId, t)
+  );
+}
+
 /**
  * Sort chart rows into the sentiment scale order (very_negative → very_positive, mixed
  * last) when the x-axis is the sentiment dimension. Unknown values keep their relative

--- a/apps/web/modules/ee/analysis/lib/schema-definition.ts
+++ b/apps/web/modules/ee/analysis/lib/schema-definition.ts
@@ -23,6 +23,14 @@ export interface MeasureDefinition {
   type: "count" | "number";
   group: TMeasureGroup;
   description?: string;
+  /**
+   * Candidate Y-axis maxima (ascending) for measures answered on a bounded rating scale. Charts pin
+   * the axis to the smallest candidate that contains the data (e.g. an average of 3.33 on a 1-5
+   * rating renders on a 0-5 axis, not a data-driven 0-4 one), so the bar height reads against the
+   * question's actual scale. The question's true scale is not stored on feedback records (see
+   * ratingAverage below), so multi-candidate lists are a best-effort inference from the data max.
+   */
+  axisMaxCandidates?: readonly number[];
 }
 
 /**
@@ -247,6 +255,7 @@ export const FEEDBACK_FIELDS = {
       type: "number",
       group: "average",
       description: "Average NPS rating (0-10)",
+      axisMaxCandidates: [10],
     },
     {
       id: "FeedbackRecords.promoterCount",
@@ -282,6 +291,7 @@ export const FEEDBACK_FIELDS = {
       type: "number",
       group: "average",
       description: "Average CSAT rating (1-5)",
+      axisMaxCandidates: [5],
     },
     {
       id: "FeedbackRecords.csatSatisfiedCount",
@@ -317,6 +327,7 @@ export const FEEDBACK_FIELDS = {
       type: "number",
       group: "average",
       description: "Average CES rating (scale is 1-5 or 1-7 depending on the question)",
+      axisMaxCandidates: [5, 7],
     },
     {
       id: "FeedbackRecords.cesCount",
@@ -331,6 +342,11 @@ export const FEEDBACK_FIELDS = {
       type: "number",
       group: "average",
       description: "Average rating value (scale depends on the question, e.g. 1-5 or 1-10)",
+      // Feedback records don't store the question's rating scale (transform.ts writes only
+      // value_number), so pin to the smallest standard rating scale that contains the data
+      // (ENG-1796). A 1-10 question whose averages stay <= 7 will render on a 0-7 axis until
+      // the scale is ingested as record metadata - see the measure docs on axisMaxCandidates.
+      axisMaxCandidates: [5, 7, 10],
     },
     {
       id: "FeedbackRecords.ratingCount",
@@ -353,6 +369,11 @@ export const FEEDBACK_FIELDS = {
 };
 
 export const FEEDBACK_MEASURE_IDS: string[] = FEEDBACK_FIELDS.measures.map((m) => m.id);
+
+/** Candidate Y-axis maxima for fixed-scale measures (see MeasureDefinition.axisMaxCandidates),
+ * or undefined for measures whose axis should stay data-driven. */
+export const getMeasureAxisMaxCandidates = (measureId: string): readonly number[] | undefined =>
+  FEEDBACK_FIELDS.measures.find((m) => m.id === measureId)?.axisMaxCandidates;
 
 export const FEEDBACK_DIMENSION_IDS: string[] = FEEDBACK_FIELDS.dimensions.map((d) => d.id);
 

--- a/apps/web/modules/ui/components/dialog/index.tsx
+++ b/apps/web/modules/ui/components/dialog/index.tsx
@@ -34,6 +34,8 @@ DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 interface DialogContentProps {
   hideCloseButton?: boolean;
   disableCloseOnOutsideClick?: boolean;
+  /** Keep Escape closing the dialog even when disableCloseOnOutsideClick is set. */
+  closeOnEscape?: boolean;
   width?: "default" | "wide" | "full" | "narrow";
   unconstrained?: boolean;
 }
@@ -61,6 +63,7 @@ const DialogContent = React.forwardRef<
       children,
       hideCloseButton,
       disableCloseOnOutsideClick,
+      closeOnEscape,
       width = "default",
       unconstrained = false,
       ...props
@@ -81,7 +84,9 @@ const DialogContent = React.forwardRef<
             className
           )}
           onPointerDownOutside={disableCloseOnOutsideClick ? (e) => e.preventDefault() : undefined}
-          onEscapeKeyDown={disableCloseOnOutsideClick ? (e) => e.preventDefault() : undefined}
+          onEscapeKeyDown={
+            disableCloseOnOutsideClick && !closeOnEscape ? (e) => e.preventDefault() : undefined
+          }
           {...props}>
           {children}
           {!hideCloseButton && (


### PR DESCRIPTION
## What does this PR do?

Backports the following PRs (already merged into `main`) to `release/5.2` via clean cherry-picks (no conflicts):

- #8542 — fix(charts): remove leading gap on category bar charts
- #8541 — feat(dashboards): add duplicate action to dashboard widgets
- #8540 — fix(charts): scale rating chart Y-axis to the question's scale
- #8544 — fix(charts): close chart dialog on Escape and show chart name in edit title
- #8545 — feat(charts): prefill chart name from AI-generated chart

Commits were cherry-picked in their original merge order.