### PR TITLE
fix(surveys): visual a11y polish for the survey player

### DIFF
--- a/apps/web/modules/survey/link/components/verify-email.tsx
+++ b/apps/web/modules/survey/link/components/verify-email.tsx
@@ -176,7 +176,11 @@ export const VerifyEmail = ({
                               placeholder="engineering@acme.com"
                               className="h-10 bg-white"
                             />
-                            <Button type="submit" size="sm" loading={isSubmitting}>
+                            <Button
+                              type="submit"
+                              size="tall"
+                              loading={isSubmitting}
+                              className="focus-visible:ring-2 focus-visible:ring-slate-900 focus-visible:ring-offset-2">
                               {t("s.verify_email_before_submission_button")}
                             </Button>
                           </div>

--- a/packages/survey-ui/src/components/elements/file-upload.tsx
+++ b/packages/survey-ui/src/components/elements/file-upload.tsx
@@ -190,7 +190,7 @@ function UploadArea({
       )}>
       <Upload className="text-input-text h-6" aria-hidden="true" />
       <span
-        className="text-input-text font-input-weight m-2 [font-size:var(--fb-input-font-size)]"
+        className="text-input-text font-input-weight m-2 text-center [font-size:var(--fb-input-font-size)]"
         id={`${inputId}-label`}>
         {placeholderText}
       </span>

--- a/packages/survey-ui/src/styles/globals.css
+++ b/packages/survey-ui/src/styles/globals.css
@@ -156,6 +156,13 @@
   --fb-option-font-family: inherit;
   --fb-option-font-size: 14px;
   --fb-option-font-weight: 400;
+
+  /* ── Page backdrop ─────────────────────────────────────────────────── */
+  /* The gray the link-survey shell paints behind the widget when no survey
+     background is configured (MediaBackground's default, slate-200). The
+     cardless layout blends its scroll fades and scroll-to-bottom button into
+     it; the shell can override this token if its default ever changes. */
+  --fb-page-bg-color: #e2e8f0;
 }
 
 #fbjs .button-custom {

--- a/packages/surveys/src/components/wrappers/cardless-survey-layout.tsx
+++ b/packages/surveys/src/components/wrappers/cardless-survey-layout.tsx
@@ -43,9 +43,17 @@ export function CardlessSurveyLayout({
     if (isSolidColorBackground && styling.background?.bg) {
       return styling.background.bg;
     }
+    if (styling.background?.bgType === "color") {
+      // Explicit color background without a value renders white (see MediaBackground).
+      return "#ffffff";
+    }
 
-    return "#ffffff";
-  }, [isSolidColorBackground, styling.background?.bg]);
+    // No background configured: the link-survey shell paints its default page
+    // gray, so the fades and the scroll-to-bottom button must match it instead
+    // of floating as white shapes on the gray page. The color itself lives in
+    // the stylesheet (survey-ui globals) so themes/shells can override it.
+    return "var(--fb-page-bg-color)";
+  }, [isSolidColorBackground, styling.background?.bg, styling.background?.bgType]);
 
   const checkScroll = useCallback(() => {
     if (!scrollRef.current) return;


### PR DESCRIPTION
## What does this PR do?

Visual a11y polish for the survey player from the ENG-1779 audit (findings 4, 7, 8):

- **File-upload placeholder centered** (finding 4): multi-line placeholders (e.g. the German upload hint) wrapped left-aligned inside the centered dropzone.
- **Scroll-to-bottom indicator matches the page background** (finding 8): with no survey background configured, the link-survey shell paints its default gray (slate-200) while the cardless layout's scroll button and fade gradients fell back to white — white shapes floating on the gray page. The fallback now mirrors the shell's defaults via a new `--fb-page-bg-color` token (defined in the survey-ui stylesheet, overridable by themes/shells); the dark chevron keeps ≥3:1 contrast (WCAG 1.4.11).
- **Verify-email button** (finding 7 / ENG-1778): the Verify button (`size="sm"`, h-8) sat shorter than the h-10 email input, and its focus ring resolved to the near-white `--ring` token — invisible on the white card. It now uses the `tall` (h-10) size and an explicit dark `focus-visible` ring with offset.

Fixes ENG-1779
Fixes ENG-1778

## How should this be tested?

- File upload question with a long placeholder (or a translated locale) → the hint wraps centered.
- Link survey with **no** background set + cardless card arrangement, tall enough to scroll → the bottom fade and the scroll-to-bottom circle blend into the gray page instead of rendering white (computed button background resolves `var(--fb-page-bg-color)` → `rgb(226, 232, 240)`).
- Link survey with "verify email before submission" enabled → the Verify button is the same height as the input; Tab onto it shows a clear dark focus ring.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
