### PR TITLE
fix(unify): disable active write controls for read-only members on Feedback Data

### DIFF
--- a/apps/web/modules/ee/unify-feedback/components/feedback-records-table.tsx
+++ b/apps/web/modules/ee/unify-feedback/components/feedback-records-table.tsx
@@ -85,6 +85,7 @@ interface FeedbackRecordRowProps {
   contactId?: string;
   locale: string;
   t: TFunction;
+  canWrite: boolean;
   isSelected: boolean;
   onSelectChange: (checked: boolean) => void;
   onClick: () => void;
@@ -422,7 +423,7 @@ export const FeedbackRecordsTable = ({
           <div className="overflow-x-auto">
             <table className="w-full min-w-[1040px] table-fixed">
               <colgroup>
-                <col className="w-10" />
+                {canWrite && <col className="w-10" />}
                 <col className="w-40" />
                 <col className="w-40" />
                 <col className="w-40" />
@@ -433,13 +434,15 @@ export const FeedbackRecordsTable = ({
               </colgroup>
               <thead>
                 <tr className="border-b border-slate-200 text-left text-sm text-slate-900 [&>th]:font-semibold">
-                  <th className="w-10 px-4 py-3">
-                    <Checkbox
-                      aria-label={t("common.select_all")}
-                      checked={headerCheckboxChecked}
-                      onCheckedChange={(checked) => toggleAllOnPage(checked === true)}
-                    />
-                  </th>
+                  {canWrite && (
+                    <th className="w-10 px-4 py-3">
+                      <Checkbox
+                        aria-label={t("common.select_all")}
+                        checked={headerCheckboxChecked}
+                        onCheckedChange={(checked) => toggleAllOnPage(checked === true)}
+                      />
+                    </th>
+                  )}
                   <th className="px-4 py-3 whitespace-nowrap">{t("workspace.unify.collected_at")}</th>
                   <th className="px-4 py-3 whitespace-nowrap">{t("workspace.unify.source_type")}</th>
                   <th className="px-4 py-3 whitespace-nowrap">{t("workspace.unify.source_name")}</th>
@@ -452,7 +455,7 @@ export const FeedbackRecordsTable = ({
               {isEmpty ? (
                 <tbody>
                   <tr>
-                    <td colSpan={8}>
+                    <td colSpan={canWrite ? 8 : 7}>
                       <div className="flex h-32 items-center justify-center">
                         <p className="text-sm text-slate-500">{t("workspace.unify.no_feedback_records")}</p>
                       </div>
@@ -469,6 +472,7 @@ export const FeedbackRecordsTable = ({
                       contactId={record.user_id ? contactIdByUserId[record.user_id] : undefined}
                       locale={i18n.resolvedLanguage ?? i18n.language ?? "en-US"}
                       t={t}
+                      canWrite={canWrite}
                       isSelected={selectedIds.has(record.id)}
                       onSelectChange={(checked) => toggleOne(record.id, checked)}
                       onClick={() => openEditDrawer(record.id)}
@@ -537,6 +541,7 @@ const FeedbackRecordRow = ({
   contactId,
   locale,
   t,
+  canWrite,
   isSelected,
   onSelectChange,
   onClick,
@@ -562,16 +567,18 @@ const FeedbackRecordRow = ({
           onClick();
         }
       }}>
-      <td
-        className="w-10 px-4 py-3"
-        onClick={(event) => event.stopPropagation()}
-        onKeyDown={(event) => event.stopPropagation()}>
-        <Checkbox
-          aria-label={record.field_label ?? record.field_id}
-          checked={isSelected}
-          onCheckedChange={(checked) => onSelectChange(checked === true)}
-        />
-      </td>
+      {canWrite && (
+        <td
+          className="w-10 px-4 py-3"
+          onClick={(event) => event.stopPropagation()}
+          onKeyDown={(event) => event.stopPropagation()}>
+          <Checkbox
+            aria-label={record.field_label ?? record.field_id}
+            checked={isSelected}
+            onCheckedChange={(checked) => onSelectChange(checked === true)}
+          />
+        </td>
+      )}
       <td className="px-4 py-3 text-slate-500" title={collectedAt}>
         <span className="block min-w-0 truncate">{collectedAt}</span>
       </td>

--- a/apps/web/modules/ee/unify-feedback/sources/components/edit-feedback-source-modal.tsx
+++ b/apps/web/modules/ee/unify-feedback/sources/components/edit-feedback-source-modal.tsx
@@ -377,6 +377,7 @@ export const EditFeedbackSourceModal = ({
                   mappings={mappings}
                   onMappingsChange={setMappings}
                   feedbackSourceType={feedbackSource.type}
+                  disabled={isReadOnly}
                 />
               </fieldset>
             </>

--- a/apps/web/modules/ee/unify-feedback/sources/components/mapping-field.tsx
+++ b/apps/web/modules/ee/unify-feedback/sources/components/mapping-field.tsx
@@ -65,6 +65,7 @@ interface FormTargetFieldProps {
   autoMapState?: TAutoMapState;
   autoMapSourceColumn?: string;
   preview?: string;
+  disabled?: boolean;
 }
 
 export const FormTargetField = ({
@@ -77,6 +78,7 @@ export const FormTargetField = ({
   autoMapState,
   autoMapSourceColumn,
   preview,
+  disabled = false,
 }: FormTargetFieldProps) => {
   const { t } = useTranslation();
   const [isEditingFixed, setIsEditingFixed] = useState(false);
@@ -311,6 +313,7 @@ export const FormTargetField = ({
                 searchPlaceholder={t("common.search")}
                 emptyDropdownText={t("workspace.surveys.edit.no_option_found")}
                 showSearch
+                disabled={disabled}
                 comboboxClasses="h-9 w-full max-w-none [&_[role=combobox]]:h-9"
               />
             </div>
@@ -319,6 +322,7 @@ export const FormTargetField = ({
                 size="sm"
                 variant="secondary"
                 onClick={openFixedValueEditor}
+                disabled={disabled}
                 aria-label={t("workspace.unify.csv_fixed_value_action")}
                 className="shrink-0">
                 <PencilIcon className="size-3.5" />

--- a/apps/web/modules/ee/unify-feedback/sources/components/mapping-ui.tsx
+++ b/apps/web/modules/ee/unify-feedback/sources/components/mapping-ui.tsx
@@ -17,6 +17,8 @@ interface MappingUIProps {
   feedbackSourceType: TFeedbackSourceType;
   confidenceByTargetId?: Record<string, TMappingConfidence>;
   sampleRow?: Record<string, string>;
+  /** When true, all mapping controls render read-only (e.g. for viewers). */
+  disabled?: boolean;
 }
 
 const toAutoMapState = (confidence?: TMappingConfidence): TAutoMapState | undefined => {
@@ -31,6 +33,7 @@ export function MappingUI({
   feedbackSourceType,
   confidenceByTargetId,
   sampleRow,
+  disabled = false,
 }: MappingUIProps) {
   switch (feedbackSourceType) {
     case "csv":
@@ -41,6 +44,7 @@ export function MappingUI({
           onMappingsChange={onMappingsChange}
           confidenceByTargetId={confidenceByTargetId}
           sampleRow={sampleRow}
+          disabled={disabled}
         />
       );
     default:
@@ -54,6 +58,7 @@ interface CsvMappingFormProps {
   onMappingsChange: (mappings: TFieldMapping[]) => void;
   confidenceByTargetId?: Record<string, TMappingConfidence>;
   sampleRow?: Record<string, string>;
+  disabled?: boolean;
 }
 
 const CsvMappingForm = ({
@@ -62,6 +67,7 @@ const CsvMappingForm = ({
   onMappingsChange,
   confidenceByTargetId,
   sampleRow,
+  disabled = false,
 }: CsvMappingFormProps) => {
   const { t } = useTranslation();
   const [advancedOpen, setAdvancedOpen] = useState(false);
@@ -113,6 +119,7 @@ const CsvMappingForm = ({
         autoMapState={autoMapState}
         autoMapSourceColumn={sourceColumnName}
         preview={isResponseValue ? responseValuePreview : undefined}
+        disabled={disabled}
       />
     );
   };

--- a/apps/web/modules/ui/components/input-combo-box/index.tsx
+++ b/apps/web/modules/ui/components/input-combo-box/index.tsx
@@ -66,6 +66,7 @@ export interface InputComboboxProps {
   comboboxClasses?: string;
   emptyDropdownText?: string;
   iconClassName?: string;
+  disabled?: boolean;
 }
 
 // Helper to flatten all options and their children
@@ -146,6 +147,7 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
   comboboxClasses,
   emptyDropdownText,
   iconClassName = "h-5 w-5 text-slate-400",
+  disabled = false,
 }) => {
   const { t } = useTranslation();
   const resolvedSearchPlaceholder = searchPlaceholder ?? t("common.search");
@@ -274,12 +276,14 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
     <div
       className={cn(
         "group/icon flex max-w-[440px] min-w-0 overflow-hidden rounded-md border border-slate-300 hover:border-slate-400",
+        disabled && "cursor-not-allowed border-slate-200 bg-slate-100 opacity-60 hover:border-slate-200",
         comboboxClasses
       )}>
       {withInput && inputType !== "dropdown" && (
         <Input
           id={`${id}-input`}
           {...inputProps}
+          disabled={disabled || inputProps?.disabled}
           className={cn(
             "min-w-0 rounded-none border-0 border-r border-slate-300 bg-white focus:border-r-slate-400 focus-visible:ring-0 focus-visible:ring-offset-0",
             inputProps?.className
@@ -289,19 +293,21 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
         />
       )}
 
-      <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenu open={disabled ? false : open} onOpenChange={disabled ? undefined : setOpen}>
         <DropdownMenuTrigger asChild className="z-10 min-w-0 flex-1">
           <div
             id={id}
             role="combobox"
-            tabIndex={0}
+            tabIndex={disabled ? -1 : 0}
             aria-controls="options"
             aria-expanded={open}
+            aria-disabled={disabled || undefined}
             className={cn(
               "flex h-10 w-full min-w-0 cursor-pointer items-center overflow-hidden bg-white pr-2 text-sm",
               {
                 "w-10 shrink-0 justify-center pr-0": withInput && inputType !== "dropdown",
-                "pointer-events-none": isClearing,
+                "pointer-events-none": isClearing || disabled,
+                "cursor-not-allowed bg-transparent": disabled,
               }
             )}>
             {inputType === "dropdown" ? (


### PR DESCRIPTION
## What does this PR do?

Read-only (viewer) members could still see and interact with write-only controls on the **Feedback Data** (Unify) pages. The underlying server actions already reject the writes, but the UI looked active and either silently no-op'd or surfaced an error. This PR hides/disables that UI so viewers get a consistent read-only experience.

**Changes**

- **Feedback records table** — hide the per-row and select-all checkboxes (and therefore the bulk-delete toolbar) for read-only members. Selection only existed to drive bulk delete, which viewers can't perform. Clicking a row still opens the record in the read-only drawer. (`col`/`th`/`td` gated on `canWrite`, `colSpan` adjusted, `canWrite` threaded into the row.)
- **Edit source modal – CSV mapping** — the field-mapping dropdowns stayed active for viewers because they render `InputCombobox`, which is a `div[role="combobox"]` and therefore **not** disabled by the surrounding `<fieldset disabled>`. Added an optional `disabled` prop to `InputCombobox` (forces the menu closed, `pointer-events-none`, removes it from the tab order) and threaded it through `MappingUI → FormTargetField`, so the mapping dropdowns and the fixed-value edit button are inert in read-only mode.

The new `InputCombobox` `disabled` prop is additive and defaults to `false`, so its other usages are unaffected.

The rest of the Feedback Data surface (record drawer, source row menu, add-source button, survey suggestions, taxonomy edit controls) was already correctly gated and is unchanged.

## How should this be tested?

As a **read-only / viewer** member of a workspace that has a feedback directory, at least one **CSV** feedback source, and some feedback records:

- **Feedback Data → Feedback records**: the row checkboxes and the header select-all checkbox are no longer shown, so there is no way to reach the bulk-delete toolbar. Add / import controls remain hidden. Clicking a row opens the record drawer in read-only mode (all fields disabled, no Save/Delete).
- **Feedback Data → Sources**: click a CSV source to open the edit dialog. Every field-mapping dropdown is disabled and non-clickable; only **Close** is available.

As an **Owner / Manager / read-write** member, verify all of the above still work fully: row selection, bulk delete, editing CSV mappings, and saving.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none (lint + typecheck clean on changed files)
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
