### PR TITLE
fix: return 409 for duplicate creates under the Prisma 7 driver adapter (ENG-1801) [5.2 backport]

### DIFF
--- a/apps/web/app/api/client/[workspaceId]/responses/lib/response-error.test.ts
+++ b/apps/web/app/api/client/[workspaceId]/responses/lib/response-error.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import { Prisma } from "@formbricks/database/prisma";
+import { DatabaseError, InvalidInputError, UniqueConstraintError } from "@formbricks/types/errors";
+import { handleClientResponseCreateError } from "./response-error";
+
+// Real Prisma 7 + adapter-pg P2002 shape (no meta.target; columns nested under the driver adapter).
+const uniqueViolation = (fields: string[]): Prisma.PrismaClientKnownRequestError =>
+  new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+    code: "P2002",
+    clientVersion: "test",
+    meta: { driverAdapterError: { cause: { constraint: { fields } } } },
+  });
+
+describe("handleClientResponseCreateError", () => {
+  test("maps a displayId unique violation to InvalidInputError (with the display id)", () => {
+    expect(() => handleClientResponseCreateError(uniqueViolation(["displayId"]), "disp_123")).toThrow(
+      new InvalidInputError("Display disp_123 is already linked to a response")
+    );
+  });
+
+  test("maps a singleUseId unique violation to UniqueConstraintError", () => {
+    expect(() => handleClientResponseCreateError(uniqueViolation(["surveyId", "singleUseId"]))).toThrow(
+      UniqueConstraintError
+    );
+  });
+
+  test("maps any other known Prisma error to DatabaseError carrying its message", () => {
+    const error = new Prisma.PrismaClientKnownRequestError("boom", { code: "P2025", clientVersion: "test" });
+    expect(() => handleClientResponseCreateError(error)).toThrow(new DatabaseError("boom"));
+  });
+
+  test("re-throws a non-Prisma error unchanged", () => {
+    const error = new Error("plain");
+    expect(() => handleClientResponseCreateError(error)).toThrow(error);
+  });
+});

--- a/apps/web/app/api/client/[workspaceId]/responses/lib/response-error.ts
+++ b/apps/web/app/api/client/[workspaceId]/responses/lib/response-error.ts
@@ -1,14 +1,12 @@
 import { Prisma } from "@formbricks/database/prisma";
 import type { PrismaClientKnownRequestError } from "@formbricks/database/prisma";
-import { PrismaErrorType } from "@formbricks/database/types/error";
+import { getUniqueConstraintFields, isUniqueConstraintError } from "@/lib/utils/prisma-constraint";
 
 export const isPrismaKnownRequestError = (error: unknown): error is PrismaClientKnownRequestError =>
   error instanceof Prisma.PrismaClientKnownRequestError;
 
-export const isSingleUseIdUniqueConstraintError = (error: PrismaClientKnownRequestError): boolean => {
-  if (error.code !== PrismaErrorType.UniqueConstraintViolation) {
-    return false;
-  }
+export const isSingleUseIdUniqueConstraintError = (error: PrismaClientKnownRequestError): boolean =>
+  isUniqueConstraintError(error) && getUniqueConstraintFields(error).includes("singleUseId");
 
-  return Array.isArray(error.meta?.target) && error.meta.target.includes("singleUseId");
-};
+export const isDisplayIdUniqueConstraintError = (error: PrismaClientKnownRequestError): boolean =>
+  isUniqueConstraintError(error) && getUniqueConstraintFields(error).includes("displayId");

--- a/apps/web/app/api/client/[workspaceId]/responses/lib/response-error.ts
+++ b/apps/web/app/api/client/[workspaceId]/responses/lib/response-error.ts
@@ -1,5 +1,6 @@
 import { Prisma } from "@formbricks/database/prisma";
 import type { PrismaClientKnownRequestError } from "@formbricks/database/prisma";
+import { DatabaseError, InvalidInputError, UniqueConstraintError } from "@formbricks/types/errors";
 import { getUniqueConstraintFields, isUniqueConstraintError } from "@/lib/utils/prisma-constraint";
 
 export const isPrismaKnownRequestError = (error: unknown): error is PrismaClientKnownRequestError =>
@@ -10,3 +11,21 @@ export const isSingleUseIdUniqueConstraintError = (error: PrismaClientKnownReque
 
 export const isDisplayIdUniqueConstraintError = (error: PrismaClientKnownRequestError): boolean =>
   isUniqueConstraintError(error) && getUniqueConstraintFields(error).includes("displayId");
+
+/**
+ * Maps a Prisma error thrown while creating a client response to its domain error. The v1 and v2
+ * client-response create paths share this exact mapping, so it lives here alongside the guards it
+ * uses. Always throws — either a mapped domain error or the original error re-thrown.
+ */
+export const handleClientResponseCreateError = (error: unknown, displayId?: string | null): never => {
+  if (isPrismaKnownRequestError(error)) {
+    if (isDisplayIdUniqueConstraintError(error)) {
+      throw new InvalidInputError(`Display ${displayId} is already linked to a response`);
+    }
+    if (isSingleUseIdUniqueConstraintError(error)) {
+      throw new UniqueConstraintError("Response already submitted for this single-use link");
+    }
+    throw new DatabaseError(error.message);
+  }
+  throw error;
+};

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.test.ts
@@ -174,7 +174,7 @@ describe("createResponse", () => {
     const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
       code: "P2002",
       clientVersion: "test",
-      meta: { target: ["surveyId", "singleUseId"] },
+      meta: { driverAdapterError: { cause: { constraint: { fields: ["surveyId", "singleUseId"] } } } },
     });
     vi.mocked(prisma.response.create).mockRejectedValue(prismaError);
     await expect(createResponse(mockResponseInput, prisma)).rejects.toThrow(UniqueConstraintError);
@@ -184,7 +184,7 @@ describe("createResponse", () => {
     const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
       code: "P2002",
       clientVersion: "test",
-      meta: { target: ["displayId"] },
+      meta: { driverAdapterError: { cause: { constraint: { fields: ["displayId"] } } } },
     });
     vi.mocked(prisma.response.create).mockRejectedValue(prismaError);
     await expect(createResponse(mockResponseInput, prisma)).rejects.toThrow(InvalidInputError);

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.ts
@@ -15,6 +15,7 @@ import {
   createResponseWithQuotaEvaluation as createClientResponseWithQuotaEvaluation,
 } from "@/app/api/client/[workspaceId]/responses/lib/response";
 import {
+  isDisplayIdUniqueConstraintError,
   isPrismaKnownRequestError,
   isSingleUseIdUniqueConstraintError,
 } from "@/app/api/client/[workspaceId]/responses/lib/response-error";
@@ -119,11 +120,7 @@ export const createResponse = async (
     return buildClientResponse(responsePrisma, contact);
   } catch (error) {
     if (isPrismaKnownRequestError(error)) {
-      if (
-        error.code === "P2002" &&
-        Array.isArray(error.meta?.target) &&
-        error.meta.target.includes("displayId")
-      ) {
+      if (isDisplayIdUniqueConstraintError(error)) {
         throw new InvalidInputError(`Display ${responseInput.displayId} is already linked to a response`);
       }
       if (isSingleUseIdUniqueConstraintError(error)) {

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/lib/response.ts
@@ -2,23 +2,14 @@ import "server-only";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
-import {
-  DatabaseError,
-  InvalidInputError,
-  ResourceNotFoundError,
-  UniqueConstraintError,
-} from "@formbricks/types/errors";
+import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { TResponseWithQuotaFull } from "@formbricks/types/quota";
 import { TResponse, TResponseInput, ZResponseInput } from "@formbricks/types/responses";
 import {
   buildClientResponse,
   createResponseWithQuotaEvaluation as createClientResponseWithQuotaEvaluation,
 } from "@/app/api/client/[workspaceId]/responses/lib/response";
-import {
-  isDisplayIdUniqueConstraintError,
-  isPrismaKnownRequestError,
-  isSingleUseIdUniqueConstraintError,
-} from "@/app/api/client/[workspaceId]/responses/lib/response-error";
+import { handleClientResponseCreateError } from "@/app/api/client/[workspaceId]/responses/lib/response-error";
 import { buildPrismaResponseData } from "@/app/api/v1/lib/utils";
 import { assertDisplayOwnership } from "@/lib/display/service";
 import { getOrganization } from "@/lib/organization/service";
@@ -119,17 +110,6 @@ export const createResponse = async (
 
     return buildClientResponse(responsePrisma, contact);
   } catch (error) {
-    if (isPrismaKnownRequestError(error)) {
-      if (isDisplayIdUniqueConstraintError(error)) {
-        throw new InvalidInputError(`Display ${responseInput.displayId} is already linked to a response`);
-      }
-      if (isSingleUseIdUniqueConstraintError(error)) {
-        throw new UniqueConstraintError("Response already submitted for this single-use link");
-      }
-
-      throw new DatabaseError(error.message);
-    }
-
-    throw error;
+    return handleClientResponseCreateError(error, responseInput.displayId);
   }
 };

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.test.ts
@@ -192,7 +192,7 @@ describe("createResponse V2", () => {
     const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
       code: "P2002",
       clientVersion: "test",
-      meta: { target: ["surveyId", "singleUseId"] },
+      meta: { driverAdapterError: { cause: { constraint: { fields: ["surveyId", "singleUseId"] } } } },
     });
     vi.mocked(mockTx.response.create).mockRejectedValue(prismaError);
     await expect(
@@ -204,7 +204,7 @@ describe("createResponse V2", () => {
     const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
       code: "P2002",
       clientVersion: "test",
-      meta: { target: ["someOtherField"] },
+      meta: { driverAdapterError: { cause: { constraint: { fields: ["someOtherField"] } } } },
     });
     vi.mocked(mockTx.response.create).mockRejectedValue(prismaError);
     await expect(
@@ -216,7 +216,7 @@ describe("createResponse V2", () => {
     const prismaError = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
       code: "P2002",
       clientVersion: "test",
-      meta: { target: ["displayId"] },
+      meta: { driverAdapterError: { cause: { constraint: { fields: ["displayId"] } } } },
     });
     vi.mocked(mockTx.response.create).mockRejectedValue(prismaError);
     await expect(

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
@@ -15,6 +15,7 @@ import {
   createResponseWithQuotaEvaluation as createClientResponseWithQuotaEvaluation,
 } from "@/app/api/client/[workspaceId]/responses/lib/response";
 import {
+  isDisplayIdUniqueConstraintError,
   isPrismaKnownRequestError,
   isSingleUseIdUniqueConstraintError,
 } from "@/app/api/client/[workspaceId]/responses/lib/response-error";
@@ -93,11 +94,7 @@ export const createResponse = async (
     return buildClientResponse(responsePrisma, contact);
   } catch (error) {
     if (isPrismaKnownRequestError(error)) {
-      if (
-        error.code === "P2002" &&
-        Array.isArray(error.meta?.target) &&
-        error.meta.target.includes("displayId")
-      ) {
+      if (isDisplayIdUniqueConstraintError(error)) {
         throw new InvalidInputError(`Display ${responseInput.displayId} is already linked to a response`);
       }
       if (isSingleUseIdUniqueConstraintError(error)) {

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/response.ts
@@ -2,23 +2,14 @@ import "server-only";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { TContactAttributes } from "@formbricks/types/contact-attribute";
-import {
-  DatabaseError,
-  InvalidInputError,
-  ResourceNotFoundError,
-  UniqueConstraintError,
-} from "@formbricks/types/errors";
+import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { TResponseWithQuotaFull } from "@formbricks/types/quota";
 import { TResponse, ZResponseInput } from "@formbricks/types/responses";
 import {
   buildClientResponse,
   createResponseWithQuotaEvaluation as createClientResponseWithQuotaEvaluation,
 } from "@/app/api/client/[workspaceId]/responses/lib/response";
-import {
-  isDisplayIdUniqueConstraintError,
-  isPrismaKnownRequestError,
-  isSingleUseIdUniqueConstraintError,
-} from "@/app/api/client/[workspaceId]/responses/lib/response-error";
+import { handleClientResponseCreateError } from "@/app/api/client/[workspaceId]/responses/lib/response-error";
 import { responseSelection } from "@/app/api/v1/client/[workspaceId]/responses/lib/response";
 import { buildPrismaResponseData as buildV1PrismaResponseData } from "@/app/api/v1/lib/utils";
 import { TResponseInputV2 } from "@/app/api/v2/client/[workspaceId]/responses/types/response";
@@ -93,17 +84,6 @@ export const createResponse = async (
 
     return buildClientResponse(responsePrisma, contact);
   } catch (error) {
-    if (isPrismaKnownRequestError(error)) {
-      if (isDisplayIdUniqueConstraintError(error)) {
-        throw new InvalidInputError(`Display ${responseInput.displayId} is already linked to a response`);
-      }
-      if (isSingleUseIdUniqueConstraintError(error)) {
-        throw new UniqueConstraintError("Response already submitted for this single-use link");
-      }
-
-      throw new DatabaseError(error.message);
-    }
-
-    throw error;
+    return handleClientResponseCreateError(error, responseInput.displayId);
   }
 };

--- a/apps/web/lib/actionClass/service.ts
+++ b/apps/web/lib/actionClass/service.ts
@@ -4,11 +4,11 @@ import "server-only";
 import { cache as reactCache } from "react";
 import { prisma } from "@formbricks/database";
 import { ActionClass, Prisma } from "@formbricks/database/prisma";
-import { PrismaErrorType } from "@formbricks/database/types/error";
 import { TActionClass, TActionClassInput, ZActionClassInput } from "@formbricks/types/action-classes";
 import { ZId, ZOptionalNumber, ZString } from "@formbricks/types/common";
 import { DatabaseError, ResourceNotFoundError, UniqueConstraintError } from "@formbricks/types/errors";
 import { ITEMS_PER_PAGE } from "../constants";
+import { getUniqueConstraintFields, isUniqueConstraintError } from "../utils/prisma-constraint";
 import { validateInputs } from "../utils/validate";
 
 const selectActionClass = {
@@ -127,11 +127,8 @@ export const createActionClass = async (actionClass: TActionClassInput): Promise
 
     return actionClassPrisma;
   } catch (error) {
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === PrismaErrorType.UniqueConstraintViolation
-    ) {
-      const targetField = (error.meta?.target as string[] | undefined)?.[0];
+    if (isUniqueConstraintError(error)) {
+      const targetField = getUniqueConstraintFields(error)[0];
       throw new UniqueConstraintError(
         `Action with ${targetField} ${targetField ? (actionClass as Record<string, unknown>)[targetField] : ""} already exists`
       );
@@ -176,11 +173,8 @@ export const updateActionClass = async (
 
     return result;
   } catch (error) {
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === PrismaErrorType.UniqueConstraintViolation
-    ) {
-      const targetField = (error.meta?.target as string[] | undefined)?.[0];
+    if (isUniqueConstraintError(error)) {
+      const targetField = getUniqueConstraintFields(error)[0];
       throw new UniqueConstraintError(
         `Action with ${targetField} ${targetField ? (inputActionClass as Record<string, unknown>)[targetField] : ""} already exists`
       );

--- a/apps/web/lib/feedback-source/service.test.ts
+++ b/apps/web/lib/feedback-source/service.test.ts
@@ -426,7 +426,9 @@ describe("createFeedbackSourceWithMappings", () => {
       new Prisma.PrismaClientKnownRequestError("Unique constraint", {
         code: "P2002",
         clientVersion: "5.0.0",
-        meta: { target: ["workspaceId", "name"] },
+        meta: {
+          driverAdapterError: { cause: { constraint: { fields: ["workspaceId", "name"] } } },
+        },
       })
     );
 
@@ -444,7 +446,11 @@ describe("createFeedbackSourceWithMappings", () => {
       new Prisma.PrismaClientKnownRequestError("Unique constraint", {
         code: "P2002",
         clientVersion: "5.0.0",
-        meta: { target: ["workspaceId", "feedbackSourceId", "surveyId", "elementId"] },
+        meta: {
+          driverAdapterError: {
+            cause: { constraint: { fields: ["workspaceId", "feedbackSourceId", "surveyId", "elementId"] } },
+          },
+        },
       })
     );
 
@@ -462,7 +468,17 @@ describe("createFeedbackSourceWithMappings", () => {
       new Prisma.PrismaClientKnownRequestError("Unique constraint", {
         code: "P2002",
         clientVersion: "5.0.0",
-        meta: { target: ["workspaceId", "feedbackSourceId", "sourceFieldId", "targetFieldId"] },
+        // Real Prisma 7 + adapter-pg shape: no meta.target, and columns are the @map()-ed DB names
+        // (source_field_id / target_field_id) — verifies the helper's mapped-column handling.
+        meta: {
+          driverAdapterError: {
+            cause: {
+              constraint: {
+                fields: ["workspaceId", "feedbackSourceId", "source_field_id", "target_field_id"],
+              },
+            },
+          },
+        },
       })
     );
 
@@ -651,7 +667,9 @@ describe("updateFeedbackSourceWithMappings", () => {
       new Prisma.PrismaClientKnownRequestError("Unique constraint", {
         code: "P2002",
         clientVersion: "5.0.0",
-        meta: { target: ["workspaceId", "name"] },
+        meta: {
+          driverAdapterError: { cause: { constraint: { fields: ["workspaceId", "name"] } } },
+        },
       })
     );
 
@@ -665,7 +683,11 @@ describe("updateFeedbackSourceWithMappings", () => {
       new Prisma.PrismaClientKnownRequestError("Unique constraint", {
         code: "P2002",
         clientVersion: "5.0.0",
-        meta: { target: ["workspaceId", "feedbackSourceId", "surveyId", "elementId"] },
+        meta: {
+          driverAdapterError: {
+            cause: { constraint: { fields: ["workspaceId", "feedbackSourceId", "surveyId", "elementId"] } },
+          },
+        },
       })
     );
 
@@ -679,7 +701,17 @@ describe("updateFeedbackSourceWithMappings", () => {
       new Prisma.PrismaClientKnownRequestError("Unique constraint", {
         code: "P2002",
         clientVersion: "5.0.0",
-        meta: { target: ["workspaceId", "feedbackSourceId", "sourceFieldId", "targetFieldId"] },
+        // Real Prisma 7 + adapter-pg shape: no meta.target, and columns are the @map()-ed DB names
+        // (source_field_id / target_field_id) — verifies the helper's mapped-column handling.
+        meta: {
+          driverAdapterError: {
+            cause: {
+              constraint: {
+                fields: ["workspaceId", "feedbackSourceId", "source_field_id", "target_field_id"],
+              },
+            },
+          },
+        },
       })
     );
 

--- a/apps/web/lib/feedback-source/service.ts
+++ b/apps/web/lib/feedback-source/service.ts
@@ -18,6 +18,7 @@ import {
   ZFeedbackSourceUpdateInput,
 } from "@formbricks/types/feedback-source";
 import { ITEMS_PER_PAGE } from "../constants";
+import { getUniqueConstraintFields } from "../utils/prisma-constraint";
 import { validateInputs } from "../utils/validate";
 
 const selectFeedbackSourceWithMappings = {
@@ -222,12 +223,15 @@ export const deleteFeedbackSource = async (
 // -- Composite functions --
 
 const mapUniqueConstraintError = (error: PrismaClientKnownRequestError): InvalidInputError => {
-  const target = error.meta?.target;
-  const targetFields = Array.isArray(target) ? (target as string[]) : [];
-  if (targetFields.includes("elementId") || targetFields.includes("surveyId")) {
+  const fields = getUniqueConstraintFields(error);
+  // The driver adapter reports the underlying DB column names, so match the Prisma field name AND
+  // its @map()-ed column name for mapped fields (sourceFieldId/targetFieldId). Unmapped fields
+  // (elementId/surveyId) match by their identical column name.
+  const has = (...names: string[]): boolean => names.some((name) => fields.includes(name));
+  if (has("elementId", "surveyId")) {
     return new InvalidInputError("FEEDBACK_SOURCE_FORMBRICKS_MAPPING_DUPLICATE");
   }
-  if (targetFields.includes("sourceFieldId") || targetFields.includes("targetFieldId")) {
+  if (has("sourceFieldId", "source_field_id", "targetFieldId", "target_field_id")) {
     return new InvalidInputError("FEEDBACK_SOURCE_FIELD_MAPPING_DUPLICATE");
   }
   return new InvalidInputError("FEEDBACK_SOURCE_NAME_DUPLICATE");

--- a/apps/web/lib/tagOnResponse/service.test.ts
+++ b/apps/web/lib/tagOnResponse/service.test.ts
@@ -140,7 +140,7 @@ describe("TagOnResponse Service", () => {
       {
         code: "P2002",
         clientVersion: "5.0.0",
-        meta: { target: ["responseId", "tagId"] },
+        meta: { driverAdapterError: { cause: { constraint: { fields: ["responseId", "tagId"] } } } },
       }
     );
     vi.mocked(prisma.tagsOnResponses.create).mockRejectedValue(prismaError);
@@ -164,7 +164,7 @@ describe("TagOnResponse Service", () => {
       {
         code: "P2002",
         clientVersion: "5.0.0",
-        meta: { target: ["responseId", "tagId"] },
+        meta: { driverAdapterError: { cause: { constraint: { fields: ["responseId", "tagId"] } } } },
       }
     );
 
@@ -195,7 +195,7 @@ describe("TagOnResponse Service", () => {
       {
         code: "P2002",
         clientVersion: "5.0.0",
-        meta: { target: ["someOtherField"] },
+        meta: { driverAdapterError: { cause: { constraint: { fields: ["someOtherField"] } } } },
       }
     );
     vi.mocked(prisma.tagsOnResponses.create).mockRejectedValue(prismaError);

--- a/apps/web/lib/tagOnResponse/service.ts
+++ b/apps/web/lib/tagOnResponse/service.ts
@@ -5,6 +5,7 @@ import { Prisma } from "@formbricks/database/prisma";
 import { ZId } from "@formbricks/types/common";
 import { DatabaseError } from "@formbricks/types/errors";
 import { TTagsCount, TTagsOnResponses } from "@formbricks/types/tags";
+import { getUniqueConstraintFields, isUniqueConstraintError } from "../utils/prisma-constraint";
 import { validateInputs } from "../utils/validate";
 
 const selectTagsOnResponse = {
@@ -30,17 +31,17 @@ export const addTagToRespone = async (responseId: string, tagId: string): Promis
       tagId,
     };
   } catch (error) {
-    if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      const target = error.meta?.target;
-      const isTagsOnResponsesUniqueViolation =
-        Array.isArray(target) && target.includes("responseId") && target.includes("tagId");
-
-      if (error.code === "P2002" && isTagsOnResponsesUniqueViolation) {
+    if (isUniqueConstraintError(error)) {
+      const fields = getUniqueConstraintFields(error);
+      if (fields.includes("responseId") && fields.includes("tagId")) {
+        // Idempotent: the tag is already on the response.
         return {
           responseId,
           tagId,
         };
       }
+    }
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
       throw new DatabaseError(error.message);
     }
 

--- a/apps/web/lib/utils/prisma-constraint.integration.test.ts
+++ b/apps/web/lib/utils/prisma-constraint.integration.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import { resetDb } from "@/integration/reset-db";
+import { getUniqueConstraintFields } from "@/lib/utils/prisma-constraint";
+
+/**
+ * Locks the P2002 error shape against the REAL Prisma 7 + @prisma/adapter-pg stack (ENG-1801).
+ *
+ * The regression that motivated this shipped because the unit tests mocked a synthetic
+ * `{ meta: { target: [...] } }` shape that the driver adapter never actually produces. This drives
+ * genuine unique-constraint violations against real Postgres so a future Prisma/adapter upgrade that
+ * changes the meta shape fails HERE instead of silently returning 500s in production.
+ *
+ * `getUniqueConstraintFields` reads `error.meta` structurally, so it is unaffected by which generated
+ * client (the harness uses a separate test client) threw the error.
+ */
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("getUniqueConstraintFields vs real Prisma 7 + adapter-pg (ENG-1801)", () => {
+  test("recovers the column of an unmapped unique field (User.email) — and meta.target is absent", async () => {
+    const email = "eng1801-integration@example.com";
+    await prisma.user.create({ data: { name: "First", email } });
+
+    const error = await prisma.user.create({ data: { name: "Second", email } }).catch((e) => e);
+
+    expect(error?.code).toBe("P2002");
+    // The regression premise: the driver adapter no longer populates meta.target.
+    expect((error?.meta as { target?: unknown })?.target).toBeUndefined();
+    expect(getUniqueConstraintFields(error)).toEqual(["email"]);
+  });
+
+  test("recovers the @map()-ed DB column name for a mapped unique field (PasswordResetToken.token_hash)", async () => {
+    const [userA, userB] = await Promise.all([
+      prisma.user.create({ data: { name: "A", email: "eng1801-a@example.com" } }),
+      prisma.user.create({ data: { name: "B", email: "eng1801-b@example.com" } }),
+    ]);
+    const tokenHash = "eng1801-shared-token-hash";
+    const expiresAt = new Date(Date.now() + 3_600_000);
+    await prisma.passwordResetToken.create({ data: { userId: userA.id, tokenHash, expiresAt } });
+
+    const error = await prisma.passwordResetToken
+      .create({ data: { userId: userB.id, tokenHash, expiresAt } })
+      .catch((e) => e);
+
+    expect(error?.code).toBe("P2002");
+    // The adapter reports the DB column name (`token_hash`), not the Prisma field name (`tokenHash`).
+    expect(getUniqueConstraintFields(error)).toEqual(["token_hash"]);
+  });
+});

--- a/apps/web/lib/utils/prisma-constraint.test.ts
+++ b/apps/web/lib/utils/prisma-constraint.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import { Prisma } from "@formbricks/database/prisma";
+import { getUniqueConstraintFields, isUniqueConstraintError } from "./prisma-constraint";
+
+const knownError = (code: string, meta?: Record<string, unknown>): Prisma.PrismaClientKnownRequestError =>
+  new Prisma.PrismaClientKnownRequestError("boom", { code, clientVersion: "test", meta });
+
+// The shape Prisma 7 + @prisma/adapter-pg actually produces (verified against a real P2002): no
+// top-level `target`; the columns are nested under driverAdapterError.cause.constraint.fields.
+const adapterP2002 = (fields: string[]): Prisma.PrismaClientKnownRequestError =>
+  knownError("P2002", {
+    modelName: "User",
+    driverAdapterError: {
+      name: "DriverAdapterError",
+      cause: {
+        kind: "UniqueConstraintViolation",
+        originalCode: "23505",
+        originalMessage: `duplicate key value violates unique constraint "User_${fields.join("_")}_key"`,
+        constraint: { fields },
+      },
+    },
+  });
+
+// The legacy / library-engine shape (top-level target). Still supported as a fallback.
+const legacyP2002 = (target: string[]): Prisma.PrismaClientKnownRequestError =>
+  knownError("P2002", { target });
+
+describe("isUniqueConstraintError", () => {
+  test("is true only for P2002", () => {
+    expect(isUniqueConstraintError(adapterP2002(["email"]))).toBe(true);
+    expect(isUniqueConstraintError(knownError("P2025"))).toBe(false);
+    expect(isUniqueConstraintError(new Error("plain"))).toBe(false);
+    expect(isUniqueConstraintError({ code: "P2002" })).toBe(false);
+    expect(isUniqueConstraintError(null)).toBe(false);
+  });
+});
+
+describe("getUniqueConstraintFields", () => {
+  test("extracts columns from the Prisma 7 driver-adapter shape (no meta.target)", () => {
+    expect(adapterP2002(["email"]).meta?.target).toBeUndefined(); // guards the premise of the bug
+    expect(getUniqueConstraintFields(adapterP2002(["email"]))).toEqual(["email"]);
+    expect(getUniqueConstraintFields(adapterP2002(["responseId", "tagId"]))).toEqual(["responseId", "tagId"]);
+  });
+
+  test("extracts columns from the legacy top-level meta.target shape", () => {
+    expect(getUniqueConstraintFields(legacyP2002(["email"]))).toEqual(["email"]);
+  });
+
+  test("returns [] when neither shape is present (callers must still map to conflict, not 500)", () => {
+    expect(getUniqueConstraintFields(knownError("P2002"))).toEqual([]);
+    expect(getUniqueConstraintFields(knownError("P2002", { modelName: "User" }))).toEqual([]);
+  });
+
+  test("filters out non-string entries defensively", () => {
+    expect(getUniqueConstraintFields(legacyP2002(["email", null as unknown as string]))).toEqual(["email"]);
+  });
+});

--- a/apps/web/lib/utils/prisma-constraint.ts
+++ b/apps/web/lib/utils/prisma-constraint.ts
@@ -1,0 +1,54 @@
+import { Prisma } from "@formbricks/database/prisma";
+import type { PrismaClientKnownRequestError } from "@formbricks/database/prisma";
+
+/** Prisma unique-constraint violation code. */
+const UNIQUE_CONSTRAINT_VIOLATION = "P2002";
+
+/**
+ * Type guard for a Prisma P2002 unique-constraint violation.
+ *
+ * Matches on the stable `error.code`, never on `error.meta` (which is not public API — see
+ * `getUniqueConstraintFields`). Uses the *named* `PrismaClientKnownRequestError` type for the
+ * predicate so the negative branch of the guard doesn't collapse to `never`.
+ */
+export const isUniqueConstraintError = (error: unknown): error is PrismaClientKnownRequestError =>
+  error instanceof Prisma.PrismaClientKnownRequestError && error.code === UNIQUE_CONSTRAINT_VIOLATION;
+
+/**
+ * Returns the column names involved in a P2002 unique-constraint violation.
+ *
+ * Prisma's `error.meta` shape is explicitly NOT public API (prisma#28953) and differs by engine:
+ *  - library / legacy query engine: `meta.target` is a `string[]`
+ *  - Prisma 7 + `@prisma/adapter-pg` (this repo): `meta.target` is absent; the columns live at
+ *    `meta.driverAdapterError.cause.constraint.fields`
+ *
+ * We read both, in that order — this is the ONLY place in the codebase that touches the unstable
+ * shape. Returns `[]` when neither is present (callers must still map P2002 to a conflict/domain
+ * error, never a 500).
+ *
+ * Security: only the structured column names are returned. Never surface `originalMessage`, the
+ * constraint name, or any other raw `driverAdapterError.cause` string to a response or log — the
+ * underlying Postgres unique-violation detail can contain the offending value (PII).
+ */
+export const getUniqueConstraintFields = (error: PrismaClientKnownRequestError): string[] => {
+  const meta = error.meta as
+    | {
+        target?: unknown;
+        driverAdapterError?: { cause?: { constraint?: { fields?: unknown } } };
+      }
+    | undefined;
+
+  // Legacy / library-engine shape.
+  const legacyTarget = meta?.target;
+  if (Array.isArray(legacyTarget)) {
+    return legacyTarget.filter((field): field is string => typeof field === "string");
+  }
+
+  // Prisma 7 driver-adapter shape.
+  const adapterFields = meta?.driverAdapterError?.cause?.constraint?.fields;
+  if (Array.isArray(adapterFields)) {
+    return adapterFields.filter((field): field is string => typeof field === "string");
+  }
+
+  return [];
+};

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.integration.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.integration.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import { resetDb } from "@/integration/reset-db";
+import type { TUserInput } from "../../types/users";
+import { createUser } from "../users";
+
+/**
+ * End-to-end (service + real Postgres) smoke test for the ENG-1801 regression: a duplicate-email
+ * create must return a 409 `conflict`, NOT a 500. This drives the exact bug path — real
+ * `prisma.user.create` → real P2002 from adapter-pg → `isUniqueConstraintError` → conflict — with no
+ * mocks, so it also confirms the `instanceof` guard works against a genuinely-thrown error.
+ */
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("createUser duplicate handling vs real Postgres (ENG-1801)", () => {
+  test("returns 409 conflict (not 500) on a real duplicate-email unique violation", async () => {
+    const org = await prisma.organization.create({ data: { name: "ENG-1801 Org" } });
+    const email = "eng1801-service@example.com";
+
+    const first = await createUser({ name: "First", email, role: "owner" } as TUserInput, org.id);
+    expect(first.ok).toBe(true);
+
+    const second = await createUser({ name: "Second", email, role: "member" } as TUserInput, org.id);
+    expect(second.ok).toBe(false);
+    if (!second.ok) {
+      expect(second.error.type).toBe("conflict");
+      expect(second.error.details).toEqual([
+        { field: "email", issue: "A user with this email already exists" },
+      ]);
+    }
+  });
+});

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
@@ -109,11 +109,19 @@ describe("Users Lib", () => {
     });
 
     test("returns conflict error if user with email already exists", async () => {
+      // Real Prisma 7 + adapter-pg P2002 shape: NO meta.target; columns nested under
+      // driverAdapterError.cause.constraint.fields. This is the shape that shipped the 500 bug.
       (prisma.user.create as any).mockRejectedValueOnce(
-        new Prisma.PrismaClientKnownRequestError("Unique constraint failed on the fields: (`email`)", {
+        new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
           code: PrismaErrorType.UniqueConstraintViolation,
           clientVersion: "1.0.0",
-          meta: { target: ["email"] },
+          meta: {
+            modelName: "User",
+            driverAdapterError: {
+              name: "DriverAdapterError",
+              cause: { kind: "UniqueConstraintViolation", constraint: { fields: ["email"] } },
+            },
+          },
         })
       );
       const result = await createUser(
@@ -129,16 +137,15 @@ describe("Users Lib", () => {
       }
     });
 
-    test("returns internal_server_error if unique constraint violation is not on email", async () => {
+    test("maps a driver-adapter P2002 with no recoverable fields to conflict, never 500 (ENG-1801)", async () => {
+      // Degrade-safe: even when neither meta.target nor constraint.fields is present, a P2002 on
+      // this create (email is the only unique key) must return 409, not fall through to a 500.
       (prisma.user.create as any).mockRejectedValueOnce(
-        new Prisma.PrismaClientKnownRequestError(
-          "Unique constraint failed on the fields: (`organizationId`,`email`)",
-          {
-            code: PrismaErrorType.UniqueConstraintViolation,
-            clientVersion: "1.0.0",
-            meta: { target: ["organizationId"] },
-          }
-        )
+        new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+          code: PrismaErrorType.UniqueConstraintViolation,
+          clientVersion: "1.0.0",
+          meta: { modelName: "User", driverAdapterError: { cause: { kind: "UniqueConstraintViolation" } } },
+        })
       );
       const result = await createUser(
         { name: "Duplicate", email: "test@example.com", role: "member" },
@@ -146,7 +153,7 @@ describe("Users Lib", () => {
       );
       expect(result.ok).toBe(false);
       if (!result.ok) {
-        expect(result.error.type).toBe("internal_server_error");
+        expect(result.error.type).toBe("conflict");
       }
     });
   });

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
@@ -1,8 +1,8 @@
 import { prisma } from "@formbricks/database";
 import { OrganizationRole, Prisma, TeamUserRole } from "@formbricks/database/prisma";
-import { PrismaErrorType } from "@formbricks/database/types/error";
 import { TUser } from "@formbricks/database/zod/users";
 import { Result, err, ok } from "@formbricks/types/error-handlers";
+import { isUniqueConstraintError } from "@/lib/utils/prisma-constraint";
 import { getUsersQuery } from "@/modules/api/v2/organizations/[organizationId]/users/lib/utils";
 import {
   TGetUsersFilter,
@@ -143,18 +143,13 @@ export const createUser = async (
 
     return ok(returnedUser);
   } catch (error) {
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === PrismaErrorType.UniqueConstraintViolation
-    ) {
-      const target = error.meta?.target as string[] | undefined;
-
-      if (target?.includes("email")) {
-        return err({
-          type: "conflict",
-          details: [{ field: "email", issue: "A user with this email already exists" }],
-        });
-      }
+    if (isUniqueConstraintError(error)) {
+      // `email` is the only user-facing unique constraint on this create, so map any P2002 to a
+      // conflict rather than gating on the (adapter-dependent) field list — this can never 500.
+      return err({
+        type: "conflict",
+        details: [{ field: "email", issue: "A user with this email already exists" }],
+      });
     }
 
     return err({

--- a/apps/web/modules/survey/editor/lib/action-class.test.ts
+++ b/apps/web/modules/survey/editor/lib/action-class.test.ts
@@ -105,7 +105,7 @@ describe("createActionClass", () => {
         code: PrismaErrorType.UniqueConstraintViolation,
         clientVersion: "test",
       }),
-      { meta: { target: ["name"] } }
+      { meta: { driverAdapterError: { cause: { constraint: { fields: ["name"] } } } } }
     );
     vi.mocked(prisma.actionClass.create).mockRejectedValue(prismaError);
 

--- a/apps/web/modules/survey/editor/lib/action-class.ts
+++ b/apps/web/modules/survey/editor/lib/action-class.ts
@@ -1,8 +1,8 @@
 import { prisma } from "@formbricks/database";
-import { ActionClass, Prisma } from "@formbricks/database/prisma";
-import { PrismaErrorType } from "@formbricks/database/types/error";
+import { ActionClass } from "@formbricks/database/prisma";
 import { TActionClassInput } from "@formbricks/types/action-classes";
 import { DatabaseError, UniqueConstraintError } from "@formbricks/types/errors";
+import { getUniqueConstraintFields, isUniqueConstraintError } from "@/lib/utils/prisma-constraint";
 
 export const createActionClass = async (
   workspaceId: string,
@@ -27,11 +27,8 @@ export const createActionClass = async (
 
     return actionClassPrisma;
   } catch (error) {
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === PrismaErrorType.UniqueConstraintViolation
-    ) {
-      const targetField = (error.meta?.target as string[] | undefined)?.[0];
+    if (isUniqueConstraintError(error)) {
+      const targetField = getUniqueConstraintFields(error)[0];
       throw new UniqueConstraintError(
         `Action with ${targetField} ${targetField ? (actionClass as Record<string, unknown>)[targetField] : ""} already exists`
       );


### PR DESCRIPTION
## What does this PR do?

**5.2 backport of #8565** (ENG-1801) — the Prisma 7 driver-adapter P2002 regression fix. Since this is a **5.2 regression**, it needs to land on `release/5.2` as well as `main`.

Under **Prisma 7.8.0 + `@prisma/adapter-pg`**, a P2002 unique-constraint error no longer carries `error.meta.target` (the columns moved to `meta.driverAdapterError.cause.constraint.fields`, reported as DB column names), so every site mapping a duplicate to 409 by reading `meta.target` fell through to **HTTP 500** — violating the §7 "no 500s" rule (confirmed on `POST /api/v2/organizations/{orgId}/users`).

The fix: a single adapter-aware helper (`apps/web/lib/utils/prisma-constraint.ts` — `isUniqueConstraintError` detects P2002 by stable `code`; `getUniqueConstraintFields` reads the columns from whichever `meta` shape is present, the one place touching the unstable shape), with all ~7 affected sites routed through it. `@map`ped fields handled (feedback-source matches both the field name and the mapped column). Tests use the real adapter shape + a real-Postgres integration test that locks it.

**This is a clean cherry-pick of #8565** — the 3 commits applied to `release/5.2` with **no conflicts**, and the `apps/web` diff is byte-identical to the main PR (patch-id verified).

## How should this be tested?

Same as #8565:
- `pnpm --filter @formbricks/web exec vitest run lib/utils/prisma-constraint.test.ts` + the affected site suites.
- `pnpm --filter @formbricks/web test:integration prisma-constraint.integration.test.ts users.integration.test.ts` (real Postgres).
- Manual (self-host): `POST /api/v2/organizations/{orgId}/users` twice with the same email → first `201`, second **`409`** `{field:"email","A user with this email already exists"}`. Verified live on the main-based branch (201 → 409).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Backport of #8565 (main); cherry-picked cleanly onto release/5.2
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] No UI change
- [ ] No docs change necessary
