### PR TITLE
fix(auth): read the correct field from the OAuth consent response (MCP)

### DIFF
--- a/apps/web/app/(app)/account/authorize/components/OAuthConsentActions.tsx
+++ b/apps/web/app/(app)/account/authorize/components/OAuthConsentActions.tsx
@@ -5,6 +5,7 @@ import { toast } from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { authClient } from "@/modules/auth/lib/auth-client";
 import { Button } from "@/modules/ui/components/button";
+import { resolveConsentRedirectUrl } from "../lib/consent-redirect";
 
 export const OAuthConsentActions = () => {
   const { t } = useTranslation();
@@ -21,21 +22,14 @@ export const OAuthConsentActions = () => {
         return;
       }
 
-      const redirectUri =
-        response.data &&
-        typeof response.data === "object" &&
-        "redirect_uri" in response.data &&
-        typeof response.data.redirect_uri === "string" &&
-        response.data.redirect_uri.length > 0
-          ? response.data.redirect_uri
-          : null;
-
-      if (!redirectUri) {
+      // Better Auth returns { redirect: true, url } (both accept and deny) — not { redirect_uri }.
+      const redirectUrl = resolveConsentRedirectUrl(response.data);
+      if (!redirectUrl) {
         toast.error(t("auth.oauth.consent_failed"));
         return;
       }
 
-      window.location.href = redirectUri;
+      window.location.href = redirectUrl;
     } catch {
       toast.error(t("auth.oauth.consent_failed"));
     } finally {

--- a/apps/web/app/(app)/account/authorize/lib/consent-redirect.test.ts
+++ b/apps/web/app/(app)/account/authorize/lib/consent-redirect.test.ts
@@ -51,8 +51,18 @@ describe("resolveConsentRedirectUrl", () => {
   test("rejects dangerous schemes (XSS guard for the location.href sink)", () => {
     expect(resolveConsentRedirectUrl({ url: "javascript:alert(1)" })).toBeNull();
     expect(resolveConsentRedirectUrl({ url: "  JavaScript:alert(1)" })).toBeNull();
+    // URL parsing normalizes control-char-obfuscated schemes, so this is caught too.
+    expect(resolveConsentRedirectUrl({ url: "java\tscript:alert(1)" })).toBeNull();
     expect(resolveConsentRedirectUrl({ url: "data:text/html,<script>alert(1)</script>" })).toBeNull();
+    expect(resolveConsentRedirectUrl({ url: "file:///etc/passwd" })).toBeNull();
+    expect(resolveConsentRedirectUrl({ url: "blob:https://x/1" })).toBeNull();
     // falls through to the fallback, which is also dangerous → null
     expect(resolveConsentRedirectUrl({ url: "javascript:1", redirect_uri: "data:x" })).toBeNull();
+  });
+
+  test("rejects malformed / protocol-relative values (not a well-formed absolute URL)", () => {
+    expect(resolveConsentRedirectUrl({ url: "//evil.com/path" })).toBeNull();
+    expect(resolveConsentRedirectUrl({ url: "not a url" })).toBeNull();
+    expect(resolveConsentRedirectUrl({ url: "/relative/path" })).toBeNull();
   });
 });

--- a/apps/web/app/(app)/account/authorize/lib/consent-redirect.test.ts
+++ b/apps/web/app/(app)/account/authorize/lib/consent-redirect.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+import { resolveConsentRedirectUrl } from "./consent-redirect";
+
+describe("resolveConsentRedirectUrl", () => {
+  test("reads `url` from the real accept shape ({ redirect: true, url })", () => {
+    expect(
+      resolveConsentRedirectUrl({ redirect: true, url: "https://client.example/callback?code=abc&state=xyz" })
+    ).toBe("https://client.example/callback?code=abc&state=xyz");
+  });
+
+  test("reads the error `url` from the deny shape", () => {
+    expect(
+      resolveConsentRedirectUrl({
+        redirect: true,
+        url: "https://client.example/callback?error=access_denied",
+      })
+    ).toBe("https://client.example/callback?error=access_denied");
+  });
+
+  test("allows loopback and custom-scheme redirect targets (native MCP clients)", () => {
+    expect(resolveConsentRedirectUrl({ url: "http://127.0.0.1:52765/callback?code=abc" })).toBe(
+      "http://127.0.0.1:52765/callback?code=abc"
+    );
+    expect(resolveConsentRedirectUrl({ url: "cursor://anysphere.cursor-mcp/callback?code=abc" })).toBe(
+      "cursor://anysphere.cursor-mcp/callback?code=abc"
+    );
+  });
+
+  test("falls back to `redirect_uri` when only that is present (documented/legacy shape)", () => {
+    expect(resolveConsentRedirectUrl({ redirect_uri: "https://client.example/cb?code=abc" })).toBe(
+      "https://client.example/cb?code=abc"
+    );
+  });
+
+  test("prefers `url` over `redirect_uri` when both are present", () => {
+    expect(
+      resolveConsentRedirectUrl({ url: "https://a.example/cb", redirect_uri: "https://b.example/cb" })
+    ).toBe("https://a.example/cb");
+  });
+
+  test("returns null for missing/empty/non-object/non-string values (→ toast)", () => {
+    expect(resolveConsentRedirectUrl({})).toBeNull();
+    expect(resolveConsentRedirectUrl({ url: "" })).toBeNull();
+    expect(resolveConsentRedirectUrl({ url: "   " })).toBeNull();
+    expect(resolveConsentRedirectUrl({ url: 123 })).toBeNull();
+    expect(resolveConsentRedirectUrl(null)).toBeNull();
+    expect(resolveConsentRedirectUrl(undefined)).toBeNull();
+    expect(resolveConsentRedirectUrl("https://client.example/cb")).toBeNull();
+  });
+
+  test("rejects dangerous schemes (XSS guard for the location.href sink)", () => {
+    expect(resolveConsentRedirectUrl({ url: "javascript:alert(1)" })).toBeNull();
+    expect(resolveConsentRedirectUrl({ url: "  JavaScript:alert(1)" })).toBeNull();
+    expect(resolveConsentRedirectUrl({ url: "data:text/html,<script>alert(1)</script>" })).toBeNull();
+    // falls through to the fallback, which is also dangerous → null
+    expect(resolveConsentRedirectUrl({ url: "javascript:1", redirect_uri: "data:x" })).toBeNull();
+  });
+});

--- a/apps/web/app/(app)/account/authorize/lib/consent-redirect.ts
+++ b/apps/web/app/(app)/account/authorize/lib/consent-redirect.ts
@@ -7,19 +7,26 @@
  * the runtime field is `url`. Deny returns the same shape with an `error=access_denied` URL. We read
  * `url` first, and keep `redirect_uri` as a defensive fallback for the documented/legacy shape.
  *
- * Security: the returned string is fed to `window.location.href`, so we reject `javascript:`/`data:`
- * URLs (never valid OAuth redirect targets; the XSS vector for a location sink). We do NOT restrict to
- * http/https — native MCP clients use loopback (`http://127.0.0.1:PORT`) and custom app schemes, and the
- * oauth-provider already validated the target `redirect_uri` against the registered client at
- * `/authorize`. The value here always originates from that pre-validated callback.
+ * Security: the returned string is fed to `window.location.href`, so we reject XSS-capable schemes.
+ * We parse with the `URL` constructor and deny the dangerous protocols rather than allowlisting — native
+ * MCP clients use arbitrary custom/loopback schemes (`cursor://`, `vscode://`, `http://127.0.0.1:PORT`),
+ * so the safe set can't be enumerated, and the oauth-provider already validated the target `redirect_uri`
+ * against the registered client at `/authorize`. Parsing (vs a regex) also normalizes obfuscated schemes
+ * like `java\tscript:` and rejects malformed / protocol-relative values.
  */
-const DANGEROUS_SCHEME = /^\s*(?:javascript|data|vbscript):/i;
+const DANGEROUS_PROTOCOLS = new Set(["javascript:", "data:", "vbscript:", "file:", "blob:"]);
 
 const asRedirectString = (value: unknown): string | null => {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   if (trimmed.length === 0) return null;
-  if (DANGEROUS_SCHEME.test(trimmed)) return null;
+  let protocol: string;
+  try {
+    protocol = new URL(trimmed).protocol;
+  } catch {
+    return null; // not a well-formed absolute URL
+  }
+  if (DANGEROUS_PROTOCOLS.has(protocol.toLowerCase())) return null;
   return trimmed;
 };
 

--- a/apps/web/app/(app)/account/authorize/lib/consent-redirect.ts
+++ b/apps/web/app/(app)/account/authorize/lib/consent-redirect.ts
@@ -1,0 +1,30 @@
+/**
+ * Extract the post-consent redirect URL from a Better Auth `oauth2.consent` response.
+ *
+ * On accept, `@better-auth/oauth-provider` delegates to its authorize handler, which for a fetch/JSON
+ * request returns `{ redirect: true, url: "<callback?code=…>" }` (see `handleRedirect` in the plugin) —
+ * NOT `{ redirect_uri }`. The plugin's OpenAPI schema documents `redirect_uri`, which is misleading;
+ * the runtime field is `url`. Deny returns the same shape with an `error=access_denied` URL. We read
+ * `url` first, and keep `redirect_uri` as a defensive fallback for the documented/legacy shape.
+ *
+ * Security: the returned string is fed to `window.location.href`, so we reject `javascript:`/`data:`
+ * URLs (never valid OAuth redirect targets; the XSS vector for a location sink). We do NOT restrict to
+ * http/https — native MCP clients use loopback (`http://127.0.0.1:PORT`) and custom app schemes, and the
+ * oauth-provider already validated the target `redirect_uri` against the registered client at
+ * `/authorize`. The value here always originates from that pre-validated callback.
+ */
+const DANGEROUS_SCHEME = /^\s*(?:javascript|data|vbscript):/i;
+
+const asRedirectString = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  if (DANGEROUS_SCHEME.test(trimmed)) return null;
+  return trimmed;
+};
+
+export const resolveConsentRedirectUrl = (data: unknown): string | null => {
+  if (typeof data !== "object" || data === null) return null;
+  const record = data as Record<string, unknown>;
+  return asRedirectString(record.url) ?? asRedirectString(record.redirect_uri);
+};


### PR DESCRIPTION
## What does this PR do?

Fixes the OAuth consent page always showing the toast **"OAuth consent failed. Please try again."** even when consent succeeds and the MCP client connects (Formbricks-as-OAuth-provider, ENG-1055). Found during 5.2 QA.

**Root cause.** Better Auth's `oauth2.consent` doesn't return `{ redirect_uri }`. On accept it delegates to the authorize handler, which for a fetch/JSON request returns `{ redirect: true, url: "<callback?code=…>" }` (`handleRedirect` in `@better-auth/oauth-provider`). The plugin's OpenAPI schema documents `redirect_uri`, but the runtime field is `url`. The component read `response.data.redirect_uri`, which is always `undefined`, so it fired the error toast and skipped its own `window.location` redirect. The connection still completed only because the consent row is persisted server-side and the client's `/authorize` retry then finds consent granted (the "works after 2–3s" symptom).

**Fix.** Extract `resolveConsentRedirectUrl()` (reads `url`, falls back to `redirect_uri` for the documented/legacy shape) and use it in `OAuthConsentActions`. This also fixes the **deny** path, which returns the same `{ redirect, url }` shape with `error=access_denied` and previously toasted instead of redirecting the error back to the client.

**Security.** The URL feeds `window.location.href`, so the helper rejects `javascript:`/`data:` schemes (XSS guard for the location sink). It intentionally does **not** restrict to http/https — native MCP clients use loopback (`http://127.0.0.1:PORT`) and custom app schemes, and the oauth-provider already validated the target `redirect_uri` against the registered client at `/authorize` (BA `SafeUrlSchema`). No server/schema/env changes.

## How should this be tested?

Automated (from `apps/web`):
```
pnpm test -- "app/(app)/account/authorize/lib/consent-redirect.test.ts"
```
Covers the real accept shape (`{ redirect, url }`), the deny/error `url`, loopback + custom-scheme targets, the `redirect_uri` fallback, `url` precedence, null/empty/non-object inputs, and `javascript:`/`data:` rejection.

Manual (the real repro):
1. Connect an MCP client (e.g. Claude Code `/mcp`) through the Formbricks OAuth flow → reach `/account/authorize` → click **Allow** → lands back at the client authenticated, **no error toast**, redirect is immediate.
2. Retry and click **Deny** → redirected back with `error=access_denied`, no stuck page/toast.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
