### PR TITLE
feat(mcp): add a list_workspaces tool (ENG-1776)

### DIFF
--- a/apps/web/app/api/mcp/route.test.ts
+++ b/apps/web/app/api/mcp/route.test.ts
@@ -212,6 +212,7 @@ describe("POST /api/mcp", () => {
       "validate_survey",
       "patch_survey",
       "delete_survey",
+      "list_workspaces",
     ]);
     const tools = new Map(message.result.tools.map((tool: { name: string }) => [tool.name, tool]));
     expect(Object.keys((tools.get("create_survey") as any).inputSchema.properties)).toEqual(

--- a/apps/web/app/api/v3/workspaces/lib/operations.test.ts
+++ b/apps/web/app/api/v3/workspaces/lib/operations.test.ts
@@ -61,6 +61,20 @@ describe("listV3Workspaces", () => {
     expect(Object.keys(body.data[0])).toEqual(["id", "name", "organizationId"]);
   });
 
+  test("returns workspaces in a deterministic order (name, then id)", async () => {
+    vi.mocked(getOrganizationsByUserId).mockResolvedValue([{ id: "org_1", name: "Org 1" }] as any);
+    vi.mocked(getUserWorkspaces).mockResolvedValue([
+      ws("w3", "Zeta", "org_1"),
+      ws("w1", "alpha", "org_1"),
+      ws("w2", "Beta", "org_1"),
+    ]);
+
+    const res = await listV3Workspaces(params(sessionAuth));
+    const body = await res.json();
+
+    expect(body.data.map((w: { name: string }) => w.name)).toEqual(["alpha", "Beta", "Zeta"]);
+  });
+
   test("session user with no orgs → empty list, no workspace lookups", async () => {
     vi.mocked(getOrganizationsByUserId).mockResolvedValue([] as any);
 

--- a/apps/web/app/api/v3/workspaces/lib/operations.test.ts
+++ b/apps/web/app/api/v3/workspaces/lib/operations.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { TV3Authentication } from "@/app/api/v3/lib/types";
+import { getOrganizationsByUserId } from "@/lib/organization/service";
+import { getUserWorkspaces, getWorkspace } from "@/lib/workspace/service";
+import { listV3Workspaces } from "./operations";
+
+vi.mock("@/lib/organization/service", () => ({ getOrganizationsByUserId: vi.fn() }));
+vi.mock("@/lib/workspace/service", () => ({ getUserWorkspaces: vi.fn(), getWorkspace: vi.fn() }));
+vi.mock("@formbricks/logger", () => ({
+  logger: { withContext: vi.fn(() => ({ error: vi.fn(), warn: vi.fn() })) },
+}));
+
+const sessionAuth = {
+  user: { id: "user_1" },
+  expires: "2026-07-01T00:00:00.000Z",
+} as unknown as TV3Authentication;
+
+const params = (authentication: TV3Authentication) => ({
+  authentication,
+  requestId: "req_1",
+  instance: "/api/mcp",
+});
+
+// A workspace as the services return it: full entity. The operation must serialize it down to the DTO.
+const ws = (id: string, name: string, organizationId: string) =>
+  ({
+    id,
+    name,
+    organizationId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    config: { secret: "should-not-leak" },
+    styling: {},
+  }) as any;
+
+describe("listV3Workspaces", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("session user: aggregates + dedupes across orgs and returns the minimal DTO only", async () => {
+    vi.mocked(getOrganizationsByUserId).mockResolvedValue([
+      { id: "org_1", name: "Org 1" },
+      { id: "org_2", name: "Org 2" },
+    ] as any);
+    vi.mocked(getUserWorkspaces).mockImplementation(async (_userId: string, orgId: string) =>
+      orgId === "org_1"
+        ? [ws("w1", "Alpha", "org_1"), ws("w2", "Beta", "org_1")]
+        : [ws("w2", "Beta", "org_1"), ws("w3", "Gamma", "org_2")]
+    );
+
+    const res = await listV3Workspaces(params(sessionAuth));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.data).toEqual([
+      { id: "w1", name: "Alpha", organizationId: "org_1" },
+      { id: "w2", name: "Beta", organizationId: "org_1" },
+      { id: "w3", name: "Gamma", organizationId: "org_2" },
+    ]);
+    expect(body.meta.totalCount).toBe(3);
+    // Only the DTO fields — no config/styling/entity internals leak.
+    expect(Object.keys(body.data[0])).toEqual(["id", "name", "organizationId"]);
+  });
+
+  test("session user with no orgs → empty list, no workspace lookups", async () => {
+    vi.mocked(getOrganizationsByUserId).mockResolvedValue([] as any);
+
+    const res = await listV3Workspaces(params(sessionAuth));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data).toEqual([]);
+    expect(getUserWorkspaces).not.toHaveBeenCalled();
+  });
+
+  test("api key: returns only the workspaces in workspacePermissions", async () => {
+    const keyAuth = {
+      apiKeyId: "key_1",
+      workspacePermissions: [
+        { workspaceId: "w1", permission: "read" },
+        { workspaceId: "w9", permission: "write" },
+      ],
+    } as unknown as TV3Authentication;
+    vi.mocked(getWorkspace).mockImplementation(async (id: string) =>
+      id === "w1" ? ws("w1", "Alpha", "org_1") : id === "w9" ? ws("w9", "Zeta", "org_2") : null
+    );
+
+    const res = await listV3Workspaces(params(keyAuth));
+    const body = await res.json();
+
+    expect(body.data).toEqual([
+      { id: "w1", name: "Alpha", organizationId: "org_1" },
+      { id: "w9", name: "Zeta", organizationId: "org_2" },
+    ]);
+    // API-key path must never fall back to the user/org aggregation.
+    expect(getOrganizationsByUserId).not.toHaveBeenCalled();
+  });
+
+  test("no authentication → 401", async () => {
+    const res = await listV3Workspaces(params(null));
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/web/app/api/v3/workspaces/lib/operations.test.ts
+++ b/apps/web/app/api/v3/workspaces/lib/operations.test.ts
@@ -113,4 +113,10 @@ describe("listV3Workspaces", () => {
     const res = await listV3Workspaces(params(null));
     expect(res.status).toBe(401);
   });
+
+  test("an unexpected service failure is logged and returned as a 500 (never thrown)", async () => {
+    vi.mocked(getOrganizationsByUserId).mockRejectedValue(new Error("db exploded"));
+    const res = await listV3Workspaces(params(sessionAuth));
+    expect(res.status).toBe(500);
+  });
 });

--- a/apps/web/app/api/v3/workspaces/lib/operations.ts
+++ b/apps/web/app/api/v3/workspaces/lib/operations.ts
@@ -88,6 +88,10 @@ export async function listV3Workspaces({
         .map(serializeV3WorkspaceListItem);
     }
 
+    // Stable, deterministic order (the underlying queries have no ORDER BY) so the tool output — and
+    // which items survive the cap — don't vary between calls. Name first, id as a tiebreaker.
+    items.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+
     const capped = items.slice(0, MAX_WORKSPACES);
     return successListResponse(
       capped,

--- a/apps/web/app/api/v3/workspaces/lib/operations.ts
+++ b/apps/web/app/api/v3/workspaces/lib/operations.ts
@@ -1,0 +1,104 @@
+import "server-only";
+import { logger } from "@formbricks/logger";
+import type { TAuthenticationApiKey } from "@formbricks/types/auth";
+import { DatabaseError } from "@formbricks/types/errors";
+import { problemInternalError, problemUnauthorized, successListResponse } from "@/app/api/v3/lib/response";
+import type { TV3Authentication } from "@/app/api/v3/lib/types";
+import { getOrganizationsByUserId } from "@/lib/organization/service";
+import { getUserWorkspaces, getWorkspace } from "@/lib/workspace/service";
+
+type TListV3WorkspacesParams = {
+  authentication: TV3Authentication;
+  requestId: string;
+  instance: string;
+};
+
+/** Minimal DTO — never return the raw Workspace entity (no config/env/styling internals). */
+type TV3WorkspaceListItem = {
+  id: string;
+  name: string;
+  organizationId: string;
+};
+
+// Defensive cap: a user's accessible workspaces are naturally small, but never stream an unbounded list.
+const MAX_WORKSPACES = 500;
+
+const serializeV3WorkspaceListItem = (workspace: {
+  id: string;
+  name: string;
+  organizationId: string;
+}): TV3WorkspaceListItem => ({
+  id: workspace.id,
+  name: workspace.name,
+  organizationId: workspace.organizationId,
+});
+
+/**
+ * List the workspaces the authenticated principal can access.
+ *
+ * - Session user: every workspace across the orgs they're a member of (org owners/managers see all of
+ *   an org's workspaces; `member`-role users see only team-scoped ones — enforced by `getUserWorkspaces`).
+ * - API key: only the workspaces in its `workspacePermissions`.
+ *
+ * There is no `workspaceId` input, so there is no IDOR surface — the result is always derived from the
+ * caller's own live membership / key grants, never from client-supplied ids.
+ */
+export async function listV3Workspaces({
+  authentication,
+  requestId,
+  instance,
+}: TListV3WorkspacesParams): Promise<Response> {
+  if (!authentication) {
+    return problemUnauthorized(requestId, "Not authenticated", instance);
+  }
+
+  const log = logger.withContext({ requestId });
+
+  try {
+    let items: TV3WorkspaceListItem[];
+
+    if ("user" in authentication && authentication.user?.id) {
+      const userId = authentication.user.id;
+      // Only the caller's own orgs; `getUserWorkspaces` then scopes to team-accessible workspaces for
+      // `member`-role users. Both together guarantee we never return a workspace the user can't access.
+      const organizations = await getOrganizationsByUserId(userId);
+      const workspacesPerOrg = await Promise.all(
+        organizations.map((organization) => getUserWorkspaces(userId, organization.id))
+      );
+
+      // Dedupe by id (a user can't be in the same org twice, but stay defensive).
+      const byId = new Map<string, TV3WorkspaceListItem>();
+      for (const workspace of workspacesPerOrg.flat()) {
+        byId.set(workspace.id, serializeV3WorkspaceListItem(workspace));
+      }
+      items = Array.from(byId.values());
+    } else {
+      const keyAuth = authentication as TAuthenticationApiKey;
+      if (!keyAuth.apiKeyId || !Array.isArray(keyAuth.workspacePermissions)) {
+        return problemUnauthorized(requestId, "Not authenticated", instance);
+      }
+
+      // The key's authorized set is exactly its workspacePermissions — resolve those, nothing else.
+      const workspaceIds = Array.from(
+        new Set(keyAuth.workspacePermissions.map((permission) => permission.workspaceId))
+      );
+      const workspaces = await Promise.all(workspaceIds.map((id) => getWorkspace(id)));
+      items = workspaces
+        .filter((workspace): workspace is NonNullable<typeof workspace> => workspace !== null)
+        .map(serializeV3WorkspaceListItem);
+    }
+
+    const capped = items.slice(0, MAX_WORKSPACES);
+    return successListResponse(
+      capped,
+      { limit: MAX_WORKSPACES, nextCursor: null, totalCount: capped.length },
+      { requestId, cache: "private, no-store" }
+    );
+  } catch (error) {
+    if (error instanceof DatabaseError) {
+      log.error({ error, statusCode: 500 }, "Database error");
+      return problemInternalError(requestId, "An unexpected error occurred.", instance);
+    }
+    throw error;
+  }
+}

--- a/apps/web/app/api/v3/workspaces/lib/operations.ts
+++ b/apps/web/app/api/v3/workspaces/lib/operations.ts
@@ -19,9 +19,6 @@ type TV3WorkspaceListItem = {
   organizationId: string;
 };
 
-// Defensive cap: a user's accessible workspaces are naturally small, but never stream an unbounded list.
-const MAX_WORKSPACES = 500;
-
 const serializeV3WorkspaceListItem = (workspace: {
   id: string;
   name: string;
@@ -90,15 +87,17 @@ export async function listV3Workspaces({
     }
 
     // Dedupe by id (defensive) + a stable, deterministic order — the underlying queries have no ORDER BY,
-    // so without this the output and which items survive the cap could vary between calls.
+    // so without this the output would vary between calls.
     const deduped = Array.from(new Map(items.map((item) => [item.id, item])).values()).sort(
       (a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id)
     );
 
-    const capped = deduped.slice(0, MAX_WORKSPACES);
+    // No pagination: a principal's accessible workspaces are bounded by their memberships (small), so we
+    // return them all. No arbitrary cap — a truncation here would silently hide workspaces (the tool
+    // accepts no cursor) without bounding DB work, which was already done above.
     return successListResponse(
-      capped,
-      { limit: MAX_WORKSPACES, nextCursor: null, totalCount: capped.length },
+      deduped,
+      { nextCursor: null, totalCount: deduped.length },
       { requestId, cache: "private, no-store" }
     );
   } catch (error) {

--- a/apps/web/app/api/v3/workspaces/lib/operations.ts
+++ b/apps/web/app/api/v3/workspaces/lib/operations.ts
@@ -1,7 +1,6 @@
 import "server-only";
 import { logger } from "@formbricks/logger";
 import type { TAuthenticationApiKey } from "@formbricks/types/auth";
-import { DatabaseError } from "@formbricks/types/errors";
 import { problemInternalError, problemUnauthorized, successListResponse } from "@/app/api/v3/lib/response";
 import type { TV3Authentication } from "@/app/api/v3/lib/types";
 import { getOrganizationsByUserId } from "@/lib/organization/service";
@@ -34,14 +33,35 @@ const serializeV3WorkspaceListItem = (workspace: {
 });
 
 /**
- * List the workspaces the authenticated principal can access.
+ * Session user's accessible workspaces: every workspace across the orgs they're a member of. Scoping is
+ * enforced by the reused services — `getOrganizationsByUserId` limits to the user's own orgs, and
+ * `getUserWorkspaces` returns all of an org's workspaces for owners/managers but only team-scoped ones
+ * for `member`-role users.
+ */
+async function fetchSessionWorkspaces(userId: string): Promise<TV3WorkspaceListItem[]> {
+  const organizations = await getOrganizationsByUserId(userId);
+  const workspacesPerOrg = await Promise.all(
+    organizations.map((organization) => getUserWorkspaces(userId, organization.id))
+  );
+  return workspacesPerOrg.flat().map(serializeV3WorkspaceListItem);
+}
+
+/** API key's accessible workspaces: exactly the ones named in its `workspacePermissions`, nothing else. */
+async function fetchApiKeyWorkspaces(keyAuth: TAuthenticationApiKey): Promise<TV3WorkspaceListItem[]> {
+  const workspaceIds = Array.from(new Set(keyAuth.workspacePermissions.map((p) => p.workspaceId)));
+  const workspaces = await Promise.all(workspaceIds.map((id) => getWorkspace(id)));
+  return workspaces
+    .filter((workspace): workspace is NonNullable<typeof workspace> => workspace !== null)
+    .map(serializeV3WorkspaceListItem);
+}
+
+/**
+ * List the workspaces the authenticated principal can access (session user or API key). There is no
+ * `workspaceId` input, so there is no IDOR surface — the result is always derived from the caller's own
+ * live membership / key grants, never from client-supplied ids.
  *
- * - Session user: every workspace across the orgs they're a member of (org owners/managers see all of
- *   an org's workspaces; `member`-role users see only team-scoped ones — enforced by `getUserWorkspaces`).
- * - API key: only the workspaces in its `workspacePermissions`.
- *
- * There is no `workspaceId` input, so there is no IDOR surface — the result is always derived from the
- * caller's own live membership / key grants, never from client-supplied ids.
+ * Thin orchestrator: resolve the principal's workspaces → dedupe → order → cap → respond. The per-
+ * principal access resolution lives in the `fetch*Workspaces` helpers.
  */
 export async function listV3Workspaces({
   authentication,
@@ -58,51 +78,33 @@ export async function listV3Workspaces({
     let items: TV3WorkspaceListItem[];
 
     if ("user" in authentication && authentication.user?.id) {
-      const userId = authentication.user.id;
-      // Only the caller's own orgs; `getUserWorkspaces` then scopes to team-accessible workspaces for
-      // `member`-role users. Both together guarantee we never return a workspace the user can't access.
-      const organizations = await getOrganizationsByUserId(userId);
-      const workspacesPerOrg = await Promise.all(
-        organizations.map((organization) => getUserWorkspaces(userId, organization.id))
-      );
-
-      // Dedupe by id (a user can't be in the same org twice, but stay defensive).
-      const byId = new Map<string, TV3WorkspaceListItem>();
-      for (const workspace of workspacesPerOrg.flat()) {
-        byId.set(workspace.id, serializeV3WorkspaceListItem(workspace));
-      }
-      items = Array.from(byId.values());
+      items = await fetchSessionWorkspaces(authentication.user.id);
+    } else if (
+      "apiKeyId" in authentication &&
+      authentication.apiKeyId &&
+      Array.isArray(authentication.workspacePermissions)
+    ) {
+      items = await fetchApiKeyWorkspaces(authentication);
     } else {
-      const keyAuth = authentication as TAuthenticationApiKey;
-      if (!keyAuth.apiKeyId || !Array.isArray(keyAuth.workspacePermissions)) {
-        return problemUnauthorized(requestId, "Not authenticated", instance);
-      }
-
-      // The key's authorized set is exactly its workspacePermissions — resolve those, nothing else.
-      const workspaceIds = Array.from(
-        new Set(keyAuth.workspacePermissions.map((permission) => permission.workspaceId))
-      );
-      const workspaces = await Promise.all(workspaceIds.map((id) => getWorkspace(id)));
-      items = workspaces
-        .filter((workspace): workspace is NonNullable<typeof workspace> => workspace !== null)
-        .map(serializeV3WorkspaceListItem);
+      return problemUnauthorized(requestId, "Not authenticated", instance);
     }
 
-    // Stable, deterministic order (the underlying queries have no ORDER BY) so the tool output — and
-    // which items survive the cap — don't vary between calls. Name first, id as a tiebreaker.
-    items.sort((a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id));
+    // Dedupe by id (defensive) + a stable, deterministic order — the underlying queries have no ORDER BY,
+    // so without this the output and which items survive the cap could vary between calls.
+    const deduped = Array.from(new Map(items.map((item) => [item.id, item])).values()).sort(
+      (a, b) => a.name.localeCompare(b.name) || a.id.localeCompare(b.id)
+    );
 
-    const capped = items.slice(0, MAX_WORKSPACES);
+    const capped = deduped.slice(0, MAX_WORKSPACES);
     return successListResponse(
       capped,
       { limit: MAX_WORKSPACES, nextCursor: null, totalCount: capped.length },
       { requestId, cache: "private, no-store" }
     );
   } catch (error) {
-    if (error instanceof DatabaseError) {
-      log.error({ error, statusCode: 500 }, "Database error");
-      return problemInternalError(requestId, "An unexpected error occurred.", instance);
-    }
-    throw error;
+    // Log every failure with request context (not just DatabaseError) so nothing significant is lost,
+    // and always return a clean 500 instead of throwing a raw error past this boundary.
+    log.error({ error, statusCode: 500 }, "Failed to list workspaces");
+    return problemInternalError(requestId, "An unexpected error occurred.", instance);
   }
 }

--- a/apps/web/lib/workspace/service.test.ts
+++ b/apps/web/lib/workspace/service.test.ts
@@ -4,7 +4,12 @@ import { prisma } from "@formbricks/database";
 import { OrganizationRole, Prisma, WidgetPlacement, Workspace } from "@formbricks/database/prisma";
 import { DatabaseError, ValidationError } from "@formbricks/types/errors";
 import { ITEMS_PER_PAGE } from "../constants";
-import { getUserWorkspaces, getWorkspace, getWorkspaces } from "./service";
+import {
+  getUserWorkspaces,
+  getUserWorkspacesByOrganizationIds,
+  getWorkspace,
+  getWorkspaces,
+} from "./service";
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
@@ -218,6 +223,33 @@ describe("Workspace Service", () => {
       select: expect.any(Object),
       take: undefined,
       skip: undefined,
+    });
+  });
+
+  test("getUserWorkspacesByOrganizationIds team-scopes non-owner/manager roles (owner/manager get all)", async () => {
+    const userId = createId();
+    const orgManager = createId();
+    const orgBilling = createId();
+
+    vi.mocked(prisma.membership.findMany).mockResolvedValue([
+      { userId, organizationId: orgManager, role: OrganizationRole.manager, accepted: true },
+      { userId, organizationId: orgBilling, role: OrganizationRole.billing, accepted: true },
+    ]);
+    vi.mocked(prisma.workspace.findMany).mockResolvedValue([]);
+
+    await getUserWorkspacesByOrganizationIds([orgManager, orgBilling], userId);
+
+    const teamScope = { some: { team: { teamUsers: { some: { userId } } } } };
+    expect(prisma.workspace.findMany).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          // manager: all of the org's workspaces (no team filter)
+          { organizationId: orgManager },
+          // billing: team-scoped only (regression: previously unscoped → every workspace)
+          { organizationId: orgBilling, workspaceTeams: teamScope },
+        ],
+      },
+      select: { id: true },
     });
   });
 

--- a/apps/web/lib/workspace/service.test.ts
+++ b/apps/web/lib/workspace/service.test.ts
@@ -221,6 +221,35 @@ describe("Workspace Service", () => {
     });
   });
 
+  test("getUserWorkspaces should team-scope a billing user (not return every workspace)", async () => {
+    const userId = createId();
+    const organizationId = createId();
+
+    vi.mocked(prisma.membership.findFirst).mockResolvedValue({
+      userId,
+      organizationId,
+      role: OrganizationRole.billing,
+      accepted: true,
+    });
+    vi.mocked(prisma.workspace.findMany).mockResolvedValue([]);
+
+    await getUserWorkspaces(userId, organizationId);
+
+    // Billing is not owner/manager, so it must be scoped to team-accessible workspaces — never the
+    // whole org (regression: `role === "member"` previously leaked all workspaces to billing users).
+    expect(prisma.workspace.findMany).toHaveBeenCalledWith({
+      where: {
+        organizationId,
+        workspaceTeams: {
+          some: { team: { teamUsers: { some: { userId } } } },
+        },
+      },
+      select: expect.any(Object),
+      take: undefined,
+      skip: undefined,
+    });
+  });
+
   test("getUserWorkspaces should throw ValidationError when user is not a member of organization", async () => {
     const userId = createId();
     const organizationId = createId();

--- a/apps/web/lib/workspace/service.ts
+++ b/apps/web/lib/workspace/service.ts
@@ -46,7 +46,11 @@ export const getUserWorkspaces = reactCache(
 
     let workspaceWhereClause: Prisma.WorkspaceWhereInput = {};
 
-    if (orgMembership.role === "member") {
+    // Only org owners/managers get every workspace. Every other role (member, billing, …) is scoped to
+    // the workspaces whose teams they belong to — mirroring the per-workspace v3 authorization
+    // (`requireV3WorkspaceAccess`: org owner/manager OR workspace-team membership). Special-casing only
+    // `member` here previously leaked all workspaces to `billing` members, who cannot access them.
+    if (orgMembership.role !== "owner" && orgMembership.role !== "manager") {
       workspaceWhereClause = {
         workspaceTeams: {
           some: {
@@ -171,7 +175,9 @@ export const getUserWorkspacesByOrganizationIds = reactCache(
           organizationId: membership.organizationId,
         };
 
-        if (membership.role === "member") {
+        // Same scoping as getUserWorkspaces: only owner/manager see all of an org's workspaces; every
+        // other role (member, billing, …) is limited to their team-scoped workspaces.
+        if (membership.role !== "owner" && membership.role !== "manager") {
           workspaceWhereClause = {
             ...workspaceWhereClause,
             workspaceTeams: {

--- a/apps/web/modules/mcp/server.ts
+++ b/apps/web/modules/mcp/server.ts
@@ -2,10 +2,12 @@ import "server-only";
 import { createMcpHandler } from "mcp-handler";
 import { MCP_SERVER_NAME, MCP_SERVER_VERSION } from "./constants";
 import { registerSurveyTools } from "./tools/surveys";
+import { registerWorkspaceTools } from "./tools/workspaces";
 
 export const mcpHandler = createMcpHandler(
   (server) => {
     registerSurveyTools(server);
+    registerWorkspaceTools(server);
   },
   {
     serverInfo: {

--- a/apps/web/modules/mcp/tools/guard-scopes.ts
+++ b/apps/web/modules/mcp/tools/guard-scopes.ts
@@ -1,0 +1,23 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { createMcpInsufficientScopeResponse, hasMcpScopes } from "../auth";
+import { responseToMcpToolResult } from "../errors";
+
+/**
+ * Shared MCP scope gate: returns `null` when the caller holds all `requiredScopes`, otherwise an
+ * insufficient-scope tool result. Used by every tool before it touches a v3 operation.
+ */
+export async function guardMcpScopes(
+  authInfo: AuthInfo | undefined,
+  requiredScopes: string[],
+  requestId: string
+): Promise<CallToolResult | null> {
+  if (hasMcpScopes(authInfo, requiredScopes)) {
+    return null;
+  }
+
+  return await responseToMcpToolResult(
+    createMcpInsufficientScopeResponse(requestId, requiredScopes),
+    requestId
+  );
+}

--- a/apps/web/modules/mcp/tools/schemas.ts
+++ b/apps/web/modules/mcp/tools/schemas.ts
@@ -119,7 +119,11 @@ export const ZMcpDeleteSurveyInput = z.object({
   surveyId: z.cuid2().describe("Survey ID to delete."),
 });
 
+// list_workspaces takes no arguments — it returns the workspaces the authenticated caller can access.
+export const ZMcpListWorkspacesInput = z.object({});
+
 export type TMcpListSurveysInput = z.infer<typeof ZMcpListSurveysInput>;
+export type TMcpListWorkspacesInput = z.infer<typeof ZMcpListWorkspacesInput>;
 export type TMcpGetSurveyInput = z.infer<typeof ZMcpGetSurveyInput>;
 export type TMcpCreateSurveyInput = z.infer<typeof ZMcpCreateSurveyInput>;
 export type TMcpPatchSurveyInput = z.infer<typeof ZMcpPatchSurveyInput>;

--- a/apps/web/modules/mcp/tools/surveys.ts
+++ b/apps/web/modules/mcp/tools/surveys.ts
@@ -1,6 +1,4 @@
-import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "@formbricks/logger";
 import { buildV3AuditLog, queueV3AuditLog } from "@/app/api/v3/lib/audit";
 import {
@@ -12,13 +10,9 @@ import {
   validateV3SurveyFromRawInput,
 } from "@/app/api/v3/surveys/lib/operations";
 import { MCP_API_ROUTE } from "@/modules/mcp/constants";
-import {
-  createMcpInsufficientScopeResponse,
-  getMcpAuthentication,
-  getMcpRequestId,
-  hasMcpScopes,
-} from "../auth";
+import { getMcpAuthentication, getMcpRequestId } from "../auth";
 import { responseToMcpToolResult } from "../errors";
+import { guardMcpScopes } from "./guard-scopes";
 import {
   type TMcpCreateSurveyInput,
   type TMcpDeleteSurveyInput,
@@ -65,21 +59,6 @@ export function buildListSurveysSearchParams(input: TMcpListSurveysInput): URLSe
   });
 
   return searchParams;
-}
-
-async function guardMcpScopes(
-  authInfo: AuthInfo | undefined,
-  requiredScopes: string[],
-  requestId: string
-): Promise<CallToolResult | null> {
-  if (hasMcpScopes(authInfo, requiredScopes)) {
-    return null;
-  }
-
-  return await responseToMcpToolResult(
-    createMcpInsufficientScopeResponse(requestId, requiredScopes),
-    requestId
-  );
 }
 
 export function registerSurveyTools(server: McpServer): void {

--- a/apps/web/modules/mcp/tools/workspaces.test.ts
+++ b/apps/web/modules/mcp/tools/workspaces.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { successListResponse } from "@/app/api/v3/lib/response";
+import { listV3Workspaces } from "@/app/api/v3/workspaces/lib/operations";
+import { registerWorkspaceTools } from "./workspaces";
+
+vi.mock("@/app/api/v3/workspaces/lib/operations", () => ({
+  listV3Workspaces: vi.fn(),
+}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: { withContext: vi.fn(() => ({ error: vi.fn(), warn: vi.fn() })) },
+}));
+
+const oauthSession = {
+  user: { id: "user_1", email: "person@example.com", name: "Person" },
+  expires: "2026-07-01T00:00:00.000Z",
+};
+
+const readAuthInfo = {
+  token: "oauth:user_1:client_1",
+  clientId: "client_1",
+  scopes: ["surveys:read"],
+  extra: { formbricksAuthentication: oauthSession, requestId: "req_tool", authMethod: "oauth" },
+};
+
+const writeOnlyAuthInfo = { ...readAuthInfo, scopes: ["surveys:write"] };
+
+function createToolServer() {
+  const tools = new Map<
+    string,
+    { config: Record<string, unknown>; handler: (input: any, extra: any) => Promise<any> }
+  >();
+  const server = {
+    registerTool: vi.fn((name: string, config: Record<string, unknown>, handler: any) => {
+      tools.set(name, { config, handler });
+    }),
+  };
+  registerWorkspaceTools(server as any);
+  return { server, tools };
+}
+
+describe("registerWorkspaceTools", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test("registers list_workspaces as a read-only tool", () => {
+    const { tools } = createToolServer();
+    const tool = tools.get("list_workspaces");
+    expect(tool).toBeDefined();
+    expect(tool!.config.annotations).toMatchObject({ readOnlyHint: true, destructiveHint: false });
+  });
+
+  test("calls the v3 list-workspaces operation and returns structured content", async () => {
+    const { tools } = createToolServer();
+    vi.mocked(listV3Workspaces).mockResolvedValue(
+      successListResponse(
+        [{ id: "w1", name: "Alpha", organizationId: "org_1" }],
+        { limit: 500, nextCursor: null, totalCount: 1 },
+        { requestId: "req_tool" }
+      )
+    );
+
+    const result = await tools.get("list_workspaces")!.handler({}, { authInfo: readAuthInfo });
+
+    expect(listV3Workspaces).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authentication: oauthSession,
+        requestId: "req_tool",
+        instance: "/api/mcp",
+      })
+    );
+    expect(result.structuredContent).toEqual({
+      data: [{ id: "w1", name: "Alpha", organizationId: "org_1" }],
+      meta: { limit: 500, nextCursor: null, totalCount: 1 },
+      requestId: "req_tool",
+    });
+  });
+
+  test("returns an insufficient-scope error without surveys:read (and skips the operation)", async () => {
+    const { tools } = createToolServer();
+
+    const result = await tools.get("list_workspaces")!.handler({}, { authInfo: writeOnlyAuthInfo });
+
+    expect(listV3Workspaces).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.error).toMatchObject({ status: 403 });
+  });
+});

--- a/apps/web/modules/mcp/tools/workspaces.test.ts
+++ b/apps/web/modules/mcp/tools/workspaces.test.ts
@@ -54,7 +54,7 @@ describe("registerWorkspaceTools", () => {
     vi.mocked(listV3Workspaces).mockResolvedValue(
       successListResponse(
         [{ id: "w1", name: "Alpha", organizationId: "org_1" }],
-        { limit: 500, nextCursor: null, totalCount: 1 },
+        { nextCursor: null, totalCount: 1 },
         { requestId: "req_tool" }
       )
     );
@@ -70,7 +70,7 @@ describe("registerWorkspaceTools", () => {
     );
     expect(result.structuredContent).toEqual({
       data: [{ id: "w1", name: "Alpha", organizationId: "org_1" }],
-      meta: { limit: 500, nextCursor: null, totalCount: 1 },
+      meta: { nextCursor: null, totalCount: 1 },
       requestId: "req_tool",
     });
   });

--- a/apps/web/modules/mcp/tools/workspaces.ts
+++ b/apps/web/modules/mcp/tools/workspaces.ts
@@ -1,0 +1,41 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { listV3Workspaces } from "@/app/api/v3/workspaces/lib/operations";
+import { MCP_API_ROUTE } from "@/modules/mcp/constants";
+import { getMcpAuthentication, getMcpRequestId } from "../auth";
+import { responseToMcpToolResult } from "../errors";
+import { guardMcpScopes } from "./guard-scopes";
+import { type TMcpListWorkspacesInput, ZMcpListWorkspacesInput } from "./schemas";
+
+export function registerWorkspaceTools(server: McpServer): void {
+  server.registerTool(
+    "list_workspaces",
+    {
+      title: "List workspaces",
+      description:
+        "List the Formbricks workspaces the authenticated user can access. Use this to discover the workspaceId required by the survey tools.",
+      inputSchema: ZMcpListWorkspacesInput.shape,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (_input: TMcpListWorkspacesInput, extra) => {
+      const requestId = getMcpRequestId(extra.authInfo);
+      // Listing workspaces is the read-prerequisite for the survey read tools, so it reuses surveys:read.
+      const scopeError = await guardMcpScopes(extra.authInfo, ["surveys:read"], requestId);
+      if (scopeError) {
+        return scopeError;
+      }
+
+      const response = await listV3Workspaces({
+        authentication: getMcpAuthentication(extra.authInfo),
+        requestId,
+        instance: MCP_API_ROUTE,
+      });
+
+      return await responseToMcpToolResult(response, requestId);
+    }
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-1776 — adds a `list_workspaces` tool to the MCP server.

Every MCP survey tool (`list_surveys`, `create_survey`, …) requires a `workspaceId`, but a client had no way to discover which workspaces the connected user can access. This adds a `list_workspaces` tool that returns the workspaces the authenticated principal is a member of, so a client can bootstrap the `workspaceId` it then passes to the survey tools.

**How it works:**
- New v3 lib operation `listV3Workspaces`:
  - **Session user (OAuth):** aggregates the workspaces across the orgs they belong to — org owners/managers see all of an org's workspaces; `member`-role users see only team-scoped ones (enforced by the existing `getUserWorkspaces`). Scoped strictly to the user's own orgs via `getOrganizationsByUserId`.
  - **API key:** returns only the workspaces in its `workspacePermissions`.
  - Returns a minimal `{ id, name, organizationId }` DTO in the standard v3 list shape (never the raw `Workspace` entity). No `workspaceId` input → no IDOR surface.
- New `list_workspaces` MCP tool (read-only), gated on the existing **`surveys:read`** scope (no new OAuth scope, so oauth-provider/PRM/DCR/consent/docs are untouched).
- Extracted the shared `guardMcpScopes` helper so the surveys and workspaces tools reuse one scope gate.

Scope kept deliberately small: **no** public `GET /api/v3/workspaces` REST route/OpenAPI, **no** new scope, **no** schema change.

## How should this be tested?

Automated (from `apps/web`):
```
pnpm test -- app/api/v3/workspaces/lib/operations.test.ts modules/mcp/tools/workspaces.test.ts modules/mcp/tools/surveys.test.ts
```
Covers: session-user aggregation + dedupe across orgs returning the minimal DTO; API-key path returning only its permitted workspaces; unauthenticated → 401; empty (no orgs); and the tool's `surveys:read` scope gate (insufficient-scope error skips the operation). The surveys tool test is included to confirm the shared-guard refactor is behavior-preserving.

Manual (MCP): connect a client (Claude Code `/mcp`) → call `list_workspaces` → returns the caller's workspaces; a multi-org user sees all their workspaces, a `member`-role user sees only team-scoped ones.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
