### PR TITLE
feat(workflows): record WorkflowRun dispatchedAt as a recovery DB fact [ENG-1658]

### DIFF
--- a/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.test.ts
+++ b/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.test.ts
@@ -8,11 +8,13 @@ const { findMany, create, findUnique } = vi.hoisted(() => ({
   findUnique: vi.fn(),
 }));
 const { warn, error } = vi.hoisted(() => ({ warn: vi.fn(), error: vi.fn() }));
+const { markDispatched } = vi.hoisted(() => ({ markDispatched: vi.fn() }));
 
 vi.mock("@formbricks/database", () => ({
   prisma: { workflow: { findMany }, workflowRun: { create, findUnique } },
 }));
 vi.mock("@formbricks/logger", () => ({ logger: { warn, error } }));
+vi.mock("./mark-dispatched", () => ({ markWorkflowRunDispatched: markDispatched }));
 
 const workspaceId = "cm9zr4mps000008l8btfy1vtz";
 const surveyId = "cm9zr4q7i000108l84gozfggr";
@@ -81,6 +83,12 @@ describe("enqueueResponseCompletedWorkflowRuns", () => {
       triggeredAt: response.updatedAt.toISOString(),
     });
     expect(dispatch).toHaveBeenCalledWith({ workflowRunId: "run_1", workflowId: "wf_1", workspaceId });
+    // Dispatch landed → recorded as a durable DB fact (ENG-1658).
+    expect(markDispatched).toHaveBeenCalledWith(
+      "run_1",
+      expect.any(Date),
+      expect.objectContaining({ workflowId: "wf_1" })
+    );
   });
 
   test("does nothing for an unfinished response", async () => {
@@ -239,5 +247,7 @@ describe("enqueueResponseCompletedWorkflowRuns", () => {
     // Attempted once (not retried here), the persisted run is surfaced as an orphan for the reconciler.
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(error).toHaveBeenCalled();
+    // Dispatch failed → the run is left unmarked (dispatchedAt stays null) for the reconciler to recover.
+    expect(markDispatched).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.test.ts
+++ b/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.test.ts
@@ -83,9 +83,10 @@ describe("enqueueResponseCompletedWorkflowRuns", () => {
       triggeredAt: response.updatedAt.toISOString(),
     });
     expect(dispatch).toHaveBeenCalledWith({ workflowRunId: "run_1", workflowId: "wf_1", workspaceId });
-    // Dispatch landed → recorded as a durable DB fact (ENG-1658).
+    // Dispatch landed → recorded as a durable DB fact (ENG-1658), tenant-scoped by workspaceId.
     expect(markDispatched).toHaveBeenCalledWith(
       "run_1",
+      workspaceId,
       expect.any(Date),
       expect.objectContaining({ workflowId: "wf_1" })
     );

--- a/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.ts
+++ b/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.ts
@@ -5,6 +5,7 @@ import { logger } from "@formbricks/logger";
 import { type TWorkflowTriggerRunPayload, ZWorkflowTriggerRunPayload } from "@formbricks/workflows";
 import { isDatabasePoolExhaustionError } from "@/lib/jobs/pool-exhaustion";
 import { type DispatchWorkflowRun } from "./dispatch";
+import { markWorkflowRunDispatched } from "./mark-dispatched";
 import {
   type WorkflowMatch,
   type WorkflowMatchCandidate,
@@ -187,7 +188,18 @@ const createAndDispatchWorkflowRun = async ({
       },
       "Workflow run persisted but dispatch failed; queued run is orphaned until the reconciler re-dispatches it"
     );
+    return;
   }
+
+  // Dispatch landed — record it as a durable DB fact (ENG-1658) so recovery can tell a genuine
+  // never-dispatched orphan (dispatchedAt IS NULL) from a dispatched-but-lagging run. Best-effort:
+  // a missed stamp self-heals on the next reconcile tick.
+  await markWorkflowRunDispatched(workflowRunId, new Date(), {
+    ...logContext,
+    workflowId: match.workflowId,
+    workspaceId,
+    responseId: response.id,
+  });
 };
 
 /**

--- a/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.ts
+++ b/apps/web/modules/workflows/lib/runner/enqueue-response-completed-runs.ts
@@ -194,10 +194,9 @@ const createAndDispatchWorkflowRun = async ({
   // Dispatch landed — record it as a durable DB fact (ENG-1658) so recovery can tell a genuine
   // never-dispatched orphan (dispatchedAt IS NULL) from a dispatched-but-lagging run. Best-effort:
   // a missed stamp self-heals on the next reconcile tick.
-  await markWorkflowRunDispatched(workflowRunId, new Date(), {
+  await markWorkflowRunDispatched(workflowRunId, workspaceId, new Date(), {
     ...logContext,
     workflowId: match.workflowId,
-    workspaceId,
     responseId: response.id,
   });
 };

--- a/apps/web/modules/workflows/lib/runner/mark-dispatched.test.ts
+++ b/apps/web/modules/workflows/lib/runner/mark-dispatched.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { markWorkflowRunDispatched } from "./mark-dispatched";
+
+const { update } = vi.hoisted(() => ({ update: vi.fn() }));
+const { error } = vi.hoisted(() => ({ error: vi.fn() }));
+
+vi.mock("@formbricks/database", () => ({ prisma: { workflowRun: { update } } }));
+vi.mock("@formbricks/logger", () => ({ logger: { error } }));
+
+const AT = new Date("2026-07-01T12:00:00.000Z");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  update.mockResolvedValue({});
+});
+
+describe("markWorkflowRunDispatched", () => {
+  test("stamps dispatchedAt on the run by id", async () => {
+    await markWorkflowRunDispatched("run_1", AT);
+
+    expect(update).toHaveBeenCalledWith({ where: { id: "run_1" }, data: { dispatchedAt: AT } });
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  test("swallows a write failure and logs it (best-effort; never throws)", async () => {
+    update.mockRejectedValueOnce(new Error("db down"));
+
+    await expect(markWorkflowRunDispatched("run_1", AT, { jobId: "j1" })).resolves.toBeUndefined();
+
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowRunId: "run_1", jobId: "j1" }),
+      expect.any(String)
+    );
+  });
+});

--- a/apps/web/modules/workflows/lib/runner/mark-dispatched.test.ts
+++ b/apps/web/modules/workflows/lib/runner/mark-dispatched.test.ts
@@ -1,35 +1,38 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { markWorkflowRunDispatched } from "./mark-dispatched";
 
-const { update } = vi.hoisted(() => ({ update: vi.fn() }));
+const { updateMany } = vi.hoisted(() => ({ updateMany: vi.fn() }));
 const { error } = vi.hoisted(() => ({ error: vi.fn() }));
 
-vi.mock("@formbricks/database", () => ({ prisma: { workflowRun: { update } } }));
+vi.mock("@formbricks/database", () => ({ prisma: { workflowRun: { updateMany } } }));
 vi.mock("@formbricks/logger", () => ({ logger: { error } }));
 
 const AT = new Date("2026-07-01T12:00:00.000Z");
 
 beforeEach(() => {
   vi.clearAllMocks();
-  update.mockResolvedValue({});
+  updateMany.mockResolvedValue({ count: 1 });
 });
 
 describe("markWorkflowRunDispatched", () => {
-  test("stamps dispatchedAt on the run by id", async () => {
-    await markWorkflowRunDispatched("run_1", AT);
+  test("stamps dispatchedAt on the run, tenant-scoped by workspaceId", async () => {
+    await markWorkflowRunDispatched("run_1", "ws_1", AT);
 
-    expect(update).toHaveBeenCalledWith({ where: { id: "run_1" }, data: { dispatchedAt: AT } });
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { id: "run_1", workspaceId: "ws_1" },
+      data: { dispatchedAt: AT },
+    });
     expect(error).not.toHaveBeenCalled();
   });
 
   test("swallows a write failure and logs it (best-effort; never throws)", async () => {
-    update.mockRejectedValueOnce(new Error("db down"));
+    updateMany.mockRejectedValueOnce(new Error("db down"));
 
-    await expect(markWorkflowRunDispatched("run_1", AT, { jobId: "j1" })).resolves.toBeUndefined();
+    await expect(markWorkflowRunDispatched("run_1", "ws_1", AT, { jobId: "j1" })).resolves.toBeUndefined();
 
     expect(error).toHaveBeenCalledTimes(1);
     expect(error).toHaveBeenCalledWith(
-      expect.objectContaining({ workflowRunId: "run_1", jobId: "j1" }),
+      expect.objectContaining({ workflowRunId: "run_1", workspaceId: "ws_1", jobId: "j1" }),
       expect.any(String)
     );
   });

--- a/apps/web/modules/workflows/lib/runner/mark-dispatched.ts
+++ b/apps/web/modules/workflows/lib/runner/mark-dispatched.ts
@@ -1,0 +1,31 @@
+import { prisma } from "@formbricks/database";
+import { logger } from "@formbricks/logger";
+
+/**
+ * Records that a `WorkflowRun` was handed off to the task backend, as a durable DB fact (ENG-1658).
+ * Stamped by the producer and the reconciler right after a successful dispatch — never inside the
+ * backend-specific dispatch port — so recovery can distinguish a genuine never-dispatched producer
+ * orphan (`dispatchedAt IS NULL`) from a dispatched-but-still-queued run, without inferring it from the
+ * queue's jobId-dedup semantics.
+ *
+ * Best-effort by design: the dispatch has already succeeded, so a failed marker write must not surface
+ * as a dispatch failure or abort a fan-out / sweep. A missed stamp self-heals on the next reconcile
+ * tick, which re-stamps after its own idempotent re-dispatch. Errors are logged, never thrown.
+ */
+export const markWorkflowRunDispatched = async (
+  workflowRunId: string,
+  dispatchedAt: Date,
+  logContext?: Record<string, unknown>
+): Promise<void> => {
+  try {
+    await prisma.workflowRun.update({
+      where: { id: workflowRunId },
+      data: { dispatchedAt },
+    });
+  } catch (error) {
+    logger.error(
+      { ...logContext, workflowRunId, err: error },
+      "Workflow run dispatched but recording dispatchedAt failed; the reconciler will heal the marker"
+    );
+  }
+};

--- a/apps/web/modules/workflows/lib/runner/mark-dispatched.ts
+++ b/apps/web/modules/workflows/lib/runner/mark-dispatched.ts
@@ -11,20 +11,25 @@ import { logger } from "@formbricks/logger";
  * Best-effort by design: the dispatch has already succeeded, so a failed marker write must not surface
  * as a dispatch failure or abort a fan-out / sweep. A missed stamp self-heals on the next reconcile
  * tick, which re-stamps after its own idempotent re-dispatch. Errors are logged, never thrown.
+ *
+ * Tenant-scoped (`updateMany where { id, workspaceId }`), mirroring the executor's terminal writes: the
+ * `id` PK already pins the row, so this is defense-in-depth, and `updateMany` means a benign no-match
+ * (row cascade-deleted between dispatch and stamp) is a silent 0-row result rather than a thrown P2025.
  */
 export const markWorkflowRunDispatched = async (
   workflowRunId: string,
+  workspaceId: string,
   dispatchedAt: Date,
   logContext?: Record<string, unknown>
 ): Promise<void> => {
   try {
-    await prisma.workflowRun.update({
-      where: { id: workflowRunId },
+    await prisma.workflowRun.updateMany({
+      where: { id: workflowRunId, workspaceId },
       data: { dispatchedAt },
     });
   } catch (error) {
     logger.error(
-      { ...logContext, workflowRunId, err: error },
+      { ...logContext, workflowRunId, workspaceId, err: error },
       "Workflow run dispatched but recording dispatchedAt failed; the reconciler will heal the marker"
     );
   }

--- a/apps/web/modules/workflows/lib/runner/reconcile-orphaned-runs.test.ts
+++ b/apps/web/modules/workflows/lib/runner/reconcile-orphaned-runs.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { reconcileOrphanedWorkflowRuns } from "./reconcile-orphaned-runs";
 
 const { findMany, updateMany } = vi.hoisted(() => ({ findMany: vi.fn(), updateMany: vi.fn() }));
+const { markDispatched } = vi.hoisted(() => ({ markDispatched: vi.fn() }));
 const { warn, error, info, debug } = vi.hoisted(() => ({
   warn: vi.fn(),
   error: vi.fn(),
@@ -13,6 +14,7 @@ vi.mock("@formbricks/database", () => ({
   prisma: { workflowRun: { findMany, updateMany } },
 }));
 vi.mock("@formbricks/logger", () => ({ logger: { warn, error, info, debug } }));
+vi.mock("./mark-dispatched", () => ({ markWorkflowRunDispatched: markDispatched }));
 
 const NOW = new Date("2026-07-01T12:00:00.000Z");
 // Grace window is 2 min, ceiling is 24 h (see reconcile-constants).
@@ -22,11 +24,13 @@ const ancient = new Date(NOW.getTime() - 25 * 60 * 60 * 1000); // 25 h old → p
 const dispatch =
   vi.fn<(input: { workflowRunId: string; workflowId: string; workspaceId: string }) => Promise<void>>();
 
-const runRow = (id: string, createdAt: Date) => ({
+// dispatchedAt defaults to null: a genuine never-handed-off producer orphan.
+const runRow = (id: string, createdAt: Date, dispatchedAt: Date | null = null) => ({
   id,
   workflowId: `wf_${id}`,
   workspaceId: `ws_${id}`,
   createdAt,
+  dispatchedAt,
 });
 
 const reconcile = () => reconcileOrphanedWorkflowRuns({ dispatch, now: NOW });
@@ -35,10 +39,11 @@ beforeEach(() => {
   vi.clearAllMocks();
   dispatch.mockResolvedValue(undefined);
   updateMany.mockResolvedValue({ count: 1 });
+  markDispatched.mockResolvedValue(undefined);
 });
 
 describe("reconcileOrphanedWorkflowRuns", () => {
-  test("re-dispatches queued orphans older than the grace window", async () => {
+  test("re-dispatches queued orphans older than the grace window and stamps the never-dispatched ones", async () => {
     findMany.mockResolvedValue([runRow("run1", orphaned), runRow("run2", orphaned)]);
 
     const result = await reconcile();
@@ -49,11 +54,28 @@ describe("reconcileOrphanedWorkflowRuns", () => {
       workflowId: "wf_run1",
       workspaceId: "ws_run1",
     });
+    // Both were dispatchedAt: null → genuine orphans → stamped with the injected clock.
+    expect(markDispatched).toHaveBeenCalledTimes(2);
+    expect(markDispatched).toHaveBeenCalledWith(
+      "run1",
+      NOW,
+      expect.objectContaining({ workflowRunId: "run1" })
+    );
     expect(updateMany).not.toHaveBeenCalled();
-    expect(result).toEqual({ scanned: 2, redispatched: 2, agedOutFailed: 0 });
+    expect(result).toEqual({ scanned: 2, redispatched: 2, agedOutFailed: 0, neverDispatched: 2 });
   });
 
-  test("scopes the scan to queued, non-dry-run runs past the grace window, oldest first and bounded", async () => {
+  test("re-dispatches an already-dispatched-but-still-queued run without counting or re-stamping it", async () => {
+    findMany.mockResolvedValue([runRow("lagging", orphaned, new Date(NOW.getTime() - 5 * 60 * 1000))]);
+
+    const result = await reconcile();
+
+    expect(dispatch).toHaveBeenCalledTimes(1); // still re-dispatched (idempotent, preserves Redis-loss recovery)
+    expect(markDispatched).not.toHaveBeenCalled(); // dispatchedAt already set → no churn on the marker
+    expect(result).toEqual({ scanned: 1, redispatched: 1, agedOutFailed: 0, neverDispatched: 0 });
+  });
+
+  test("scopes the scan to queued, non-dry-run runs past the grace window, selecting dispatchedAt, oldest first and bounded", async () => {
     findMany.mockResolvedValue([]);
 
     await reconcile();
@@ -61,6 +83,7 @@ describe("reconcileOrphanedWorkflowRuns", () => {
     const args = findMany.mock.calls[0][0];
     expect(args.where).toMatchObject({ status: "queued", isDryRun: false });
     expect(args.where.createdAt.lt).toEqual(new Date(NOW.getTime() - 2 * 60 * 1000));
+    expect(args.select).toMatchObject({ dispatchedAt: true });
     expect(args.orderBy).toEqual({ createdAt: "asc" });
     expect(args.take).toBe(250);
   });
@@ -71,11 +94,12 @@ describe("reconcileOrphanedWorkflowRuns", () => {
     const result = await reconcile();
 
     expect(dispatch).not.toHaveBeenCalled();
+    expect(markDispatched).not.toHaveBeenCalled();
     expect(updateMany).toHaveBeenCalledWith({
       where: { id: "stuck", status: "queued" },
       data: expect.objectContaining({ status: "failed", finishedAt: NOW, lastErrorAt: NOW }),
     });
-    expect(result).toEqual({ scanned: 1, redispatched: 0, agedOutFailed: 1 });
+    expect(result).toEqual({ scanned: 1, redispatched: 0, agedOutFailed: 1, neverDispatched: 0 });
   });
 
   test("does not count an aged-out run that lost the status-guard race", async () => {
@@ -84,7 +108,7 @@ describe("reconcileOrphanedWorkflowRuns", () => {
 
     const result = await reconcile();
 
-    expect(result).toEqual({ scanned: 1, redispatched: 0, agedOutFailed: 0 });
+    expect(result).toEqual({ scanned: 1, redispatched: 0, agedOutFailed: 0, neverDispatched: 0 });
   });
 
   test("isolates a per-run dispatch failure and continues the sweep", async () => {
@@ -95,7 +119,9 @@ describe("reconcileOrphanedWorkflowRuns", () => {
 
     expect(dispatch).toHaveBeenCalledTimes(2);
     expect(error).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ scanned: 2, redispatched: 1, agedOutFailed: 0 });
+    // Only the successfully re-dispatched "good" run is counted + stamped.
+    expect(markDispatched).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ scanned: 2, redispatched: 1, agedOutFailed: 0, neverDispatched: 1 });
   });
 
   test("does nothing when there are no orphans", async () => {
@@ -105,6 +131,7 @@ describe("reconcileOrphanedWorkflowRuns", () => {
 
     expect(dispatch).not.toHaveBeenCalled();
     expect(updateMany).not.toHaveBeenCalled();
-    expect(result).toEqual({ scanned: 0, redispatched: 0, agedOutFailed: 0 });
+    expect(markDispatched).not.toHaveBeenCalled();
+    expect(result).toEqual({ scanned: 0, redispatched: 0, agedOutFailed: 0, neverDispatched: 0 });
   });
 });

--- a/apps/web/modules/workflows/lib/runner/reconcile-orphaned-runs.test.ts
+++ b/apps/web/modules/workflows/lib/runner/reconcile-orphaned-runs.test.ts
@@ -58,6 +58,7 @@ describe("reconcileOrphanedWorkflowRuns", () => {
     expect(markDispatched).toHaveBeenCalledTimes(2);
     expect(markDispatched).toHaveBeenCalledWith(
       "run1",
+      "ws_run1",
       NOW,
       expect.objectContaining({ workflowRunId: "run1" })
     );
@@ -96,7 +97,7 @@ describe("reconcileOrphanedWorkflowRuns", () => {
     expect(dispatch).not.toHaveBeenCalled();
     expect(markDispatched).not.toHaveBeenCalled();
     expect(updateMany).toHaveBeenCalledWith({
-      where: { id: "stuck", status: "queued" },
+      where: { id: "stuck", workspaceId: "ws_stuck", status: "queued" },
       data: expect.objectContaining({ status: "failed", finishedAt: NOW, lastErrorAt: NOW }),
     });
     expect(result).toEqual({ scanned: 1, redispatched: 0, agedOutFailed: 1, neverDispatched: 0 });

--- a/apps/web/modules/workflows/lib/runner/reconcile-orphaned-runs.ts
+++ b/apps/web/modules/workflows/lib/runner/reconcile-orphaned-runs.ts
@@ -101,9 +101,10 @@ export const reconcileOrphanedWorkflowRuns = async ({
 
     try {
       if (orphan.createdAt < maxAgeThreshold) {
-        // Past the ceiling: never re-dispatch forever. Status-guarded so a concurrent claim wins.
+        // Past the ceiling: never re-dispatch forever. Tenant- and status-guarded so a concurrent
+        // claim (queued → running) wins and we never touch a foreign workspace's row.
         const failed = await prisma.workflowRun.updateMany({
-          where: { id: orphan.id, status: "queued" },
+          where: { id: orphan.id, workspaceId: orphan.workspaceId, status: "queued" },
           data: {
             status: "failed",
             error: "Workflow run was never dispatched and exceeded the reconcile age ceiling",
@@ -133,7 +134,7 @@ export const reconcileOrphanedWorkflowRuns = async ({
         // hand-off as a durable DB fact. Already-dispatched-but-still-queued runs (dispatchedAt set) are
         // re-dispatched idempotently above but neither counted nor re-stamped — no churn on the marker.
         neverDispatched += 1;
-        await markWorkflowRunDispatched(orphan.id, now, runLogContext);
+        await markWorkflowRunDispatched(orphan.id, orphan.workspaceId, now, runLogContext);
       }
     } catch (error) {
       // Isolate per run: a single re-dispatch/mark failure must not abort the sweep; the next tick retries.

--- a/apps/web/modules/workflows/lib/runner/reconcile-orphaned-runs.ts
+++ b/apps/web/modules/workflows/lib/runner/reconcile-orphaned-runs.ts
@@ -1,6 +1,7 @@
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
 import { type DispatchWorkflowRun } from "./dispatch";
+import { markWorkflowRunDispatched } from "./mark-dispatched";
 import {
   WORKFLOW_RUN_ORPHAN_MAX_AGE_MS,
   WORKFLOW_RUN_ORPHAN_MIN_AGE_MS,
@@ -19,6 +20,13 @@ export interface ReconcileOrphanedWorkflowRunsResult {
   scanned: number;
   redispatched: number;
   agedOutFailed: number;
+  /**
+   * Of the re-dispatched runs, how many had never been handed off (`dispatchedAt IS NULL`) — genuine
+   * producer-side orphans. The remainder were already dispatched but still `queued` (executor lag or a
+   * lost job), re-dispatched idempotently. Lets operators tell a producer-dispatch problem from an
+   * executor-throughput one.
+   */
+  neverDispatched: number;
 }
 
 /**
@@ -49,6 +57,14 @@ export interface ReconcileOrphanedWorkflowRunsResult {
  * - **Safe under concurrency:** every write is status-guarded (`status: "queued"`) so a run claimed
  *   `queued → running` between the scan and the write is never clobbered; and re-dispatch idempotency
  *   means overlapping sweeps cannot double-dispatch.
+ * - **Dispatch marker (ENG-1658):** the scan still re-dispatches *every* eligible `queued` run (so a
+ *   Redis-loss recovery re-creates all lost jobs via the idempotent port — the `dispatchedAt IS NULL`
+ *   fact is deliberately *not* used to filter the scan, which would strand dispatched-but-lost runs).
+ *   Instead `dispatchedAt` distinguishes outcomes: a run with `dispatchedAt IS NULL` is a genuine
+ *   never-handed-off producer orphan (counted as `neverDispatched`, and stamped on this first
+ *   re-dispatch); one with `dispatchedAt` set was already handed off (executor lag or a lost job) and is
+ *   re-dispatched idempotently but neither counted nor re-stamped. Gives operators a producer-dispatch
+ *   vs executor-throughput signal from a DB fact.
  * - **Isolated:** one run's failure is logged and skipped so it never aborts the sweep.
  */
 export const reconcileOrphanedWorkflowRuns = async ({
@@ -68,11 +84,12 @@ export const reconcileOrphanedWorkflowRuns = async ({
     },
     orderBy: { createdAt: "asc" },
     take: WORKFLOW_RUN_RECONCILE_BATCH_SIZE,
-    select: { id: true, workflowId: true, workspaceId: true, createdAt: true },
+    select: { id: true, workflowId: true, workspaceId: true, createdAt: true, dispatchedAt: true },
   });
 
   let redispatched = 0;
   let agedOutFailed = 0;
+  let neverDispatched = 0;
 
   for (const orphan of orphans) {
     const runLogContext = {
@@ -110,11 +127,19 @@ export const reconcileOrphanedWorkflowRuns = async ({
         workspaceId: orphan.workspaceId,
       });
       redispatched += 1;
+
+      if (orphan.dispatchedAt === null) {
+        // Genuine producer orphan (dispatch never landed): count it, and record this first successful
+        // hand-off as a durable DB fact. Already-dispatched-but-still-queued runs (dispatchedAt set) are
+        // re-dispatched idempotently above but neither counted nor re-stamped — no churn on the marker.
+        neverDispatched += 1;
+        await markWorkflowRunDispatched(orphan.id, now, runLogContext);
+      }
     } catch (error) {
       // Isolate per run: a single re-dispatch/mark failure must not abort the sweep; the next tick retries.
       logger.error({ ...runLogContext, err: error }, "Failed to reconcile orphaned workflow run");
     }
   }
 
-  return { scanned: orphans.length, redispatched, agedOutFailed };
+  return { scanned: orphans.length, redispatched, agedOutFailed, neverDispatched };
 };

--- a/packages/database/migration/20260717000000_add_workflow_run_dispatched_at/migration.sql
+++ b/packages/database/migration/20260717000000_add_workflow_run_dispatched_at/migration.sql
@@ -1,0 +1,6 @@
+-- Add a durable `dispatchedAt` marker to WorkflowRun: stamped by the producer/reconciler right after a
+-- successful hand-off to the task backend. Lets recovery distinguish a genuine never-dispatched producer
+-- orphan (`dispatchedAt IS NULL`) from a dispatched-but-still-queued run as a DB fact, rather than
+-- inferring it from queue-level jobId dedup. Nullable; existing rows backfill to NULL (treated as
+-- "dispatch status unknown" — recovery still re-dispatches them idempotently).
+ALTER TABLE "WorkflowRun" ADD COLUMN "dispatchedAt" TIMESTAMP(3);

--- a/packages/database/schema/workflows.prisma
+++ b/packages/database/schema/workflows.prisma
@@ -85,6 +85,7 @@ model WorkflowRun {
   /// [WorkflowRunData]
   data              Json              @default("{}")
   error             String?
+  dispatchedAt      DateTime?
   startedAt         DateTime?
   finishedAt        DateTime?
   logs              WorkflowRunLog[]


### PR DESCRIPTION
## What does this PR do?

Closes [ENG-1658](https://linear.app/formbricks/issue/ENG-1658). Based on `epic/workflows-v1`.

Adds a durable `dispatchedAt` marker to `WorkflowRun` so the runner's recovery reasoning rests on a **DB fact** rather than only on BullMQ's `jobId`-dedup semantics + a timing window. It's stamped right after a successful hand-off to the task backend, by the producer and the reconciler — never inside the backend-specific dispatch port, so it stays backend-neutral.

**Design note — additive, deliberately not `scan WHERE dispatchedAt IS NULL`.** The ticket floated keying the reconciler's scan off `dispatchedAt IS NULL`. I didn't do that, because `dispatchedAt` lives in Postgres and survives a Redis wipe: today's reconciler re-dispatches *every* still-queued run past the grace window and leans on `jobId` dedup to make that a no-op-or-recovery, which is exactly what recovers all lost jobs after a Redis data loss. Filtering the scan to `dispatchedAt IS NULL` would **skip** already-dispatched-but-lost runs and strand them at the 24h ceiling — a recovery regression. So instead:

- The scan and the 24h ceiling are **unchanged** — re-dispatch-everything, Redis-loss recovery preserved.
- `dispatchedAt` distinguishes *outcomes*: a re-dispatched run with `dispatchedAt IS NULL` is a genuine never-handed-off producer orphan (counted as `neverDispatched`, and stamped on this first re-dispatch); one already stamped was dispatched before (executor lag or a lost job), re-dispatched idempotently but neither counted nor re-stamped (no marker churn).
- The new `neverDispatched` count gives operators a **producer-dispatch vs executor-throughput** signal from a DB fact, surfaced in the existing `Workflow run reconciliation acted` log.

### Changes
- **Schema:** `WorkflowRun.dispatchedAt DateTime?` + migration `20260717000000_add_workflow_run_dispatched_at` (nullable column; existing rows backfill to `NULL` = "dispatch status unknown", still re-dispatched idempotently). No new index — it's a residual/observability field, not the scan key.
- **`mark-dispatched.ts` (new):** small backend-neutral helper that stamps `dispatchedAt`, best-effort (a failed write is logged, never thrown, and self-heals on the next reconcile tick).
- **Producer** (`enqueue-response-completed-runs.ts`): stamp after a successful `dispatch()`.
- **Reconciler** (`reconcile-orphaned-runs.ts`): select `dispatchedAt`, stamp genuine orphans on re-dispatch, add the `neverDispatched` result counter.

## How should this be tested?

```bash
cd apps/web && pnpm exec vitest run modules/workflows/lib/runner    # 76 pass
```

- `mark-dispatched.test.ts` — stamps by id; swallows + logs a write failure (best-effort).
- `reconcile-orphaned-runs.test.ts` — genuine orphans (`dispatchedAt IS NULL`) counted + stamped; an already-dispatched-but-queued run is re-dispatched (recovery preserved) but not counted or re-stamped; scan selects `dispatchedAt`; ceiling/guard-race/isolation paths carry the new counter.
- `enqueue-response-completed-runs.test.ts` — producer stamps after a successful dispatch, and leaves the run unmarked when dispatch fails (so the reconciler recovers it).

Verified locally: 76 runner tests pass, new/changed files 100% line+branch coverage, `@formbricks/web` typecheck 0 errors, ESLint clean.

## Migrations

Adds one migration: `packages/database/migration/20260717000000_add_workflow_run_dispatched_at/migration.sql` — `ALTER TABLE "WorkflowRun" ADD COLUMN "dispatchedAt" TIMESTAMP(3);` (nullable, no backfill needed).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits (the additive-vs-scan rationale, the best-effort marker, the never-dispatched distinction)
- [x] Ran the affected tests + typecheck + lint
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs` (none added)
- [x] Branched off the current base (`epic/workflows-v1`)
- [x] My changes don't cause any responsiveness issues (backend job, no UI)
- [ ] First PR at Formbricks? — no

### Appreciated

- [ ] If a UI change was made: screenshots — N/A, backend
- [ ] Updated the Formbricks Docs — N/A (internal runner observability)
