### PR TITLE
docs: reorg docs & tweaks

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,15 +58,6 @@
             "pages": [
               "platform/features/ai-features",
               {
-                "group": "Workflows",
-                "icon": "https://d3gk2c5xim1je2.cloudfront.net/lucide/v1.16.0/workflow.svg",
-                "pages": [
-                  "platform/features/workflows/overview",
-                  "platform/features/workflows/build",
-                  "platform/features/workflows/manage-and-monitor"
-                ]
-              },
-              {
                 "group": "Integrations",
                 "icon": "bridge",
                 "pages": [
@@ -228,7 +219,7 @@
             ]
           }
         ],
-        "tab": "Surveys"
+        "tab": "Surveys (Ask)"
       },
       {
         "groups": [
@@ -267,7 +258,20 @@
             "pages": ["unify-feedback/formbricks-hub"]
           }
         ],
-        "tab": "Unify Feedback"
+        "tab": "Unify Feedback (Analyze)"
+      },
+      {
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": ["workflows/overview"]
+          },
+          {
+            "group": "Workflow Features",
+            "pages": ["workflows/build", "workflows/manage-and-monitor"]
+          }
+        ],
+        "tab": "Workflows (Act)"
       },
       {
         "groups": [
@@ -342,7 +346,8 @@
                   "self-hosting/advanced/enterprise-features/audit-logging",
                   "self-hosting/advanced/enterprise-features/unify-feedback",
                   "self-hosting/advanced/enterprise-features/dashboards",
-                  "self-hosting/advanced/enterprise-features/ai-features"
+                  "self-hosting/advanced/enterprise-features/ai-features",
+                  "self-hosting/advanced/enterprise-features/workflows"
                 ]
               },
               "self-hosting/advanced/rate-limiting"

--- a/docs/platform/features/integrations/overview.mdx
+++ b/docs/platform/features/integrations/overview.mdx
@@ -6,6 +6,10 @@ description: "Configure third-party integrations with Formbricks Cloud."
 At Formbricks, we understand the importance of integrating with third-party applications. We have step-by-step guides to configure our third-party integrations with Formbricks Cloud.&#x20;
 
 <Note>
+  For automations that stay inside Formbricks — without a third-party tool — use [Workflows](/workflows/overview) to trigger actions like sending an email when a response is completed.
+</Note>
+
+<Note>
   If you are on a self-hosted instance, you will need to configure these integrations manually. Please follow the guides [here](/self-hosting/configuration/integrations) to configure integrations on your self-hosted instance.
 </Note>
 

--- a/docs/platform/introduction.mdx
+++ b/docs/platform/introduction.mdx
@@ -8,6 +8,8 @@ icon: "presentation-screen"
 
 Formbricks is a versatile open-source platform for collecting and analyzing feedback from customers, users, and employees through targeted surveys. Whether you need simple forms or complex experience management solutions, Formbricks scales with your needs.
 
+Formbricks is an end-to-end experience management (XM) suite: **Ask** with surveys, **Analyze** with Unify Feedback and dashboards, and **Act** with Workflows.
+
 This guide covers everything you need to set up, use, and develop with Formbricks. You'll find step-by-step instructions, feature explanations, and best practices. It also includes advanced docs on extending Formbricks using its self-hosted option, APIs, and SDKs.
 
 

--- a/docs/platform/what-is-formbricks.mdx
+++ b/docs/platform/what-is-formbricks.mdx
@@ -16,6 +16,22 @@ With Formbricks, you can replace many existing survey tools:
 
 The survey platform is **mostly free, even for commercial use**. Over time, all survey features will stay part of the free Community Edition.
 
+## An end-to-end XM Suite
+
+Formbricks covers the full experience-management loop — from collecting feedback to acting on it — in one platform:
+
+<CardGroup cols={3}>
+  <Card title="Ask" icon="square-poll-vertical" href="/surveys/overview">
+    Collect feedback with link, website, and in-app surveys built in a powerful, fully customizable builder.
+  </Card>
+  <Card title="Analyze" icon="chart-line" href="/unify-feedback/overview">
+    Unify feedback from every source into one store, then visualize it with charts and shareable dashboards.
+  </Card>
+  <Card title="Act" icon="diagram-project" href="/workflows/overview">
+    Turn responses into action with Workflows that trigger emails and other automations — no code required.
+  </Card>
+</CardGroup>
+
 ### Formbricks – The Experience Management (XM) Suite
 
 To support the development of our open-source platform, we’ve created a premium offering: the **Formbricks XM Suite**.

--- a/docs/self-hosting/advanced/enterprise-features/workflows.mdx
+++ b/docs/self-hosting/advanced/enterprise-features/workflows.mdx
@@ -1,0 +1,10 @@
+---
+title: "Workflows"
+description: "Automate response-driven tasks with triggers, filters, and actions."
+icon: "https://d3gk2c5xim1je2.cloudfront.net/lucide/v1.16.0/workflow.svg"
+sidebarTitle: "Workflows"
+---
+
+Workflows automate tasks in response to events in Formbricks. You choose a trigger, narrow down which events qualify with optional filters, and run an action such as sending an email.
+
+Read the full guide: [Workflows overview](/workflows/overview).

--- a/docs/self-hosting/advanced/license.mdx
+++ b/docs/self-hosting/advanced/license.mdx
@@ -87,6 +87,7 @@ The Enterprise Edition allows us to fund the development of Formbricks sustainab
 | Teams & access roles                           | ❌                | ✅                 |
 | Contact management & segments                  | ❌                | ✅                 |
 | Quota Management                               | ❌                | ✅                 |
+| Workflows                                      | ❌                | ✅                 |
 | Unify Feedback Inbox                           | ❌                | ✅                 |
 | Feedback Directories                            | ❌                | ✅                 |
 | Insights Dashboards                            | ❌                | ✅                 |

--- a/docs/self-hosting/configuration/job-runner.mdx
+++ b/docs/self-hosting/configuration/job-runner.mdx
@@ -5,7 +5,7 @@ icon: "gears"
 ---
 
 Formbricks uses a shared BullMQ Job Runner for asynchronous work such as response processing, survey
-scheduling, and [Workflows](/platform/features/workflows/overview). Formbricks starts the worker inside the web
+scheduling, and [Workflows](/workflows/overview). Formbricks starts the worker inside the web
 application by default, so a standard self-hosted deployment does not need a separate worker container.
 
 <Note>

--- a/docs/surveys/general-features/email-followups.mdx
+++ b/docs/surveys/general-features/email-followups.mdx
@@ -4,6 +4,12 @@ description: "Automatically send customized emails to respondents based on their
 icon: "envelope"
 ---
 
+<Warning>
+  Email Follow-ups are being deprecated in favor of [Workflows](/workflows/overview). Workflows
+  offer the same response- and ending-based email automation plus additional triggers and actions. We recommend
+  building new email automations as Workflows.
+</Warning>
+
 <Note>
   Email followups is a paid feature. It is only available for users on paid plans or if you have [Enterprise Edition](/self-hosting/advanced/license).
 </Note>

--- a/docs/unify-feedback/overview.mdx
+++ b/docs/unify-feedback/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Unify Feedback"
-description: "Bring feedback from every source into one place and turn it into insights."
+description: "Bring feedback from any source to Formbricks and turn it into insights."
 icon: "layer-group"
 ---
 

--- a/docs/workflows/build.mdx
+++ b/docs/workflows/build.mdx
@@ -54,7 +54,6 @@ Under **Ending cards**, choose one of these scopes:
 - **All endings** runs the workflow for every completed response, including ending cards added later.
 - **Specific endings** runs it only when the respondent reaches one of the selected ending cards.
 
-If the survey has no ending cards, the workflow applies to every completed response.
 
 ## Configure the Send email action
 

--- a/docs/workflows/manage-and-monitor.mdx
+++ b/docs/workflows/manage-and-monitor.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Manage and monitor Workflows"
+title: "Manage and monitor workflows"
+sidebarTitle: "Manage and monitor"
 description: "Manage workflow statuses, duplicate or delete workflows, and inspect runs and step logs."
 icon: "magnifying-glass-chart"
 ---

--- a/docs/workflows/overview.mdx
+++ b/docs/workflows/overview.mdx
@@ -1,11 +1,14 @@
 ---
-title: "Workflows overview"
+title: "Workflows"
+sidebarTitle: "Overview"
 description: "Automate response-driven tasks in Formbricks with triggers, filters, actions, and observable runs."
 icon: "https://d3gk2c5xim1je2.cloudfront.net/lucide/v1.16.0/workflow.svg"
 ---
 
 Workflows automate tasks in response to events in Formbricks. You define the event that starts the workflow,
 narrow down which events qualify, and choose the action Formbricks should perform.
+
+<Note>Workflows are part of the Formbricks [Enterprise Edition](/self-hosting/advanced/license).</Note>
 
 ## How Workflows work
 
@@ -34,6 +37,29 @@ For example, a workflow using the currently available trigger and action can fol
 
 `Response completed trigger` → `optional ending card filter` → `Send email action`
 
+## Available triggers, conditions, and actions
+
+The builder lists the options available in your Formbricks version. The tables below show what you can use
+today.
+
+### Triggers
+
+| Trigger                | Description                                                                    |
+| ---------------------- | ------------------------------------------------------------------------------ |
+| **Response completed** | Starts the workflow when a survey linked to it records a completed response.   |
+
+### Conditions
+
+| Condition             | Description                                                                             |
+| --------------------- | --------------------------------------------------------------------------------------- |
+| **Ending card filter** | Runs the workflow for all ending cards or only the selected ones of the survey. |
+
+### Actions
+
+| Action           | Description                                                              |
+| ---------------- | ------------------------------------------------------------------------ |
+| **Send email**   | Sends a personalized email using data from the triggering response.      |
+
 ## Current capabilities
 
 You can currently use Workflows to:
@@ -52,14 +78,14 @@ You can currently use Workflows to:
 ## Get started
 
 <CardGroup cols={2}>
-  <Card title="Build a workflow" icon="rocket" href="/platform/features/workflows/build">
+  <Card title="Build a workflow" icon="rocket" href="/workflows/build">
     Choose a trigger and action, configure them, optionally validate the workflow, and enable it.
   </Card>
 
   <Card
     title="Manage and monitor"
     icon="magnifying-glass-chart"
-    href="/platform/features/workflows/manage-and-monitor"
+    href="/workflows/manage-and-monitor"
   >
     Manage the workflow lifecycle and investigate runs and step logs.
   </Card>


### PR DESCRIPTION
## Summary

Docs: establish Workflows as a first-class "Act" section and position Formbricks as an end-to-end XM Suite (Ask / Analyze / Act).

## Navigation (docs.json)

- Added a new "Workflows (Act)" tab before Self Hosting, with an Overview group and a Workflow Features group.
- Moved the three workflow pages from `platform/features/workflows/` to a top-level `workflows/` directory (via `git mv`, history preserved) to match the Surveys and Unify Feedback structure.
- Removed the old Workflows group from the Platform tab.

## Content

- `workflows/overview`: added an Enterprise Edition note and an "Available triggers, conditions, and actions" section with three tables.
- Added `self-hosting/advanced/enterprise-features/workflows.mdx` (thin page linking to the overview) and registered it in the Self Hosting → Enterprise Features menu.
- `license`: added Workflows (Enterprise-only) to the free-features comparison table.
- `email-followups`: added a deprecation warning pointing to Workflows.
- `integrations/overview`: added a note pointing to native Workflows.
- `what-is-formbricks`: added an "end-to-end XM Suite" section with Ask / Analyze / Act cards.
- `introduction`: added a one-line Ask / Analyze / Act positioning sentence.

## Links

- Rewrote all internal links from `/platform/features/workflows/*` to `/workflows/*` across six files. No backwards-compatibility redirects (feature not yet released). Verified no stale references remain and `docs.json` is valid JSON.

Fixes ENG-1895