### PR TITLE
fix: correct Helm release image validation

### DIFF
--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -83,8 +83,9 @@ jobs:
 
           expected_image="ghcr.io/formbricks/formbricks:${VERSION}"
           image_count="$(grep -c "image: ${expected_image}$" <<< "$rendered" || true)"
-          if [[ "$image_count" -ne 2 ]]; then
-            echo "Expected web Deployment and migration Job to render ${expected_image}; found ${image_count} matches"
+          if [[ "$image_count" -ne 3 ]]; then
+            printf 'Expected %s in web Deployment and both migration containers; found %s matches\n' \
+              "$expected_image" "$image_count"
             grep "image: ghcr.io/formbricks/formbricks:" <<< "$rendered" || true
             exit 1
           fi


### PR DESCRIPTION
## What changed

- Update the Helm release workflow to expect three Formbricks image references: the web deployment, the database readiness init container, and the migration container.
- Clarify the validation failure message so it identifies the expected workloads.

## Why

The `wait-for-database` init container added for Helm migrations introduced a third intentional reference to the Formbricks image. The release workflow still expected only two references, causing the `5.2.0-rc.6` Helm chart publishing job to fail before packaging the chart.

This change keeps the release guard aligned with the chart's default rendered resources and unblocks future Helm chart releases from `main`.

The same commit will need to be backported to `release/5.2` before publishing the next 5.2 release candidate.

## Validation

- `helm template` rendered exactly three references to `ghcr.io/formbricks/formbricks:5.2.0-rc.6`
- `helm lint charts/formbricks --set formbricks.webappUrl=https://qa.example.com`
- `pnpm exec prettier --check .github/workflows/release-helm-chart.yml`
- `git diff --check`