### PR TITLE
fix: correct Helm release image validation (5.2 backport)

### DIFF
--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -83,8 +83,9 @@ jobs:
 
           expected_image="ghcr.io/formbricks/formbricks:${VERSION}"
           image_count="$(grep -c "image: ${expected_image}$" <<< "$rendered" || true)"
-          if [[ "$image_count" -ne 2 ]]; then
-            echo "Expected web Deployment and migration Job to render ${expected_image}; found ${image_count} matches"
+          if [[ "$image_count" -ne 3 ]]; then
+            printf 'Expected %s in web Deployment and both migration containers; found %s matches\n' \
+              "$expected_image" "$image_count"
             grep "image: ghcr.io/formbricks/formbricks:" <<< "$rendered" || true
             exit 1
           fi


### PR DESCRIPTION
## What does this PR do?

Backport of #8589 to `release/5.2`.

The `Validate default Formbricks image tag` step in the Helm release workflow asserted exactly 2 rendered `ghcr.io/formbricks/formbricks:<version>` image lines. The `wait-for-database` initContainer added to the migration Job (9220b022e) renders a third line with the same (correct) tag, so every release run fails — this blocked the `5.2.0-rc.6` release ([failed run](https://github.com/formbricks/formbricks/actions/runs/29740754713/job/88351314336)).

Updates the expected count to 3 (web Deployment + migration Job initContainer + migration container).

## How should this be tested?

- Re-run the `Build, release & deploy Formbricks images` workflow for a 5.2 tag — the validate step should pass.
- Locally: `helm template qa charts/formbricks --set formbricks.webappUrl=https://qa.example.com --show-only templates/deployment.yaml --show-only templates/migration-job.yaml | grep -c 'image: ghcr.io/formbricks/formbricks:'` → 3.