### PR TITLE
fix: enforce workspace-level access in getWorkspaceAuth [ENG-1769]

### DIFF
--- a/apps/web/modules/workspaces/lib/utils.test.ts
+++ b/apps/web/modules/workspaces/lib/utils.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AuthenticationError, AuthorizationError, ResourceNotFoundError } from "@formbricks/types/errors";
+import type { TMembership, TOrganizationRole } from "@formbricks/types/memberships";
+import type { TOrganization } from "@formbricks/types/organizations";
+import type { TWorkspace } from "@formbricks/types/workspace";
+import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
+import { getOrganization } from "@/lib/organization/service";
+import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { getWorkspace } from "@/lib/workspace/service";
+import { getSession } from "@/modules/auth/lib/session";
+import { getWorkspacePermissionByUserId } from "@/modules/ee/teams/lib/roles";
+import { getWorkspaceAuth } from "./utils";
+
+vi.mock("@/lib/membership/service", () => ({
+  getMembershipByUserIdOrganizationId: vi.fn(),
+}));
+vi.mock("@/lib/organization/service", () => ({
+  getOrganization: vi.fn(),
+  getMonthlyOrganizationResponseCount: vi.fn(),
+}));
+vi.mock("@/lib/workspace/service", () => ({
+  getWorkspace: vi.fn(),
+}));
+vi.mock("@/lib/workspace/auth", () => ({
+  hasUserWorkspaceAccess: vi.fn(),
+}));
+vi.mock("@/modules/ee/teams/lib/roles", () => ({
+  getWorkspacePermissionByUserId: vi.fn(),
+}));
+vi.mock("@/lingodotdev/server", () => ({
+  getTranslate: vi.fn(() => Promise.resolve((k: string) => k)),
+}));
+vi.mock("@/modules/auth/lib/session", () => ({
+  getSession: vi.fn(),
+}));
+// getAccessFlags and getTeamPermissionFlags are intentionally NOT mocked: the
+// real (pure) implementations exercise the true role → isReadOnly logic.
+vi.mock("react", () => ({ cache: (fn: (...args: unknown[]) => unknown) => fn }));
+
+const WORKSPACE_ID = "workspace-1";
+const ORG_ID = "org-1";
+const USER_ID = "user-1";
+
+const mockSession = { user: { id: USER_ID }, expires: new Date().toISOString() };
+const mockWorkspace = { id: WORKSPACE_ID, organizationId: ORG_ID } as unknown as TWorkspace;
+const mockOrganization = { id: ORG_ID } as unknown as TOrganization;
+
+const membershipWithRole = (role: TOrganizationRole): TMembership => ({
+  role,
+  organizationId: ORG_ID,
+  userId: USER_ID,
+  accepted: true,
+});
+
+describe("getWorkspaceAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Happy-path defaults: an org member with read-only workspace access.
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace);
+    vi.mocked(getSession).mockResolvedValue(mockSession);
+    vi.mocked(getOrganization).mockResolvedValue(mockOrganization);
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(membershipWithRole("member"));
+    vi.mocked(hasUserWorkspaceAccess).mockResolvedValue(true);
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("read");
+  });
+
+  test("throws ResourceNotFoundError when the workspace is missing", async () => {
+    vi.mocked(getWorkspace).mockResolvedValue(null);
+    await expect(getWorkspaceAuth(WORKSPACE_ID)).rejects.toThrow(ResourceNotFoundError);
+  });
+
+  test("throws AuthenticationError when there is no session", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    await expect(getWorkspaceAuth(WORKSPACE_ID)).rejects.toThrow(AuthenticationError);
+  });
+
+  test("throws ResourceNotFoundError when the organization is missing", async () => {
+    vi.mocked(getOrganization).mockResolvedValue(null);
+    await expect(getWorkspaceAuth(WORKSPACE_ID)).rejects.toThrow(ResourceNotFoundError);
+  });
+
+  test("throws AuthorizationError when the user has no org membership", async () => {
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(null);
+    await expect(getWorkspaceAuth(WORKSPACE_ID)).rejects.toThrow(AuthorizationError);
+  });
+
+  // The core fix: an org member with no WorkspaceTeam grant for this workspace
+  // must be rejected instead of being admitted (and mislabeled as a writer).
+  test("throws AuthorizationError when the user has no workspace access", async () => {
+    vi.mocked(hasUserWorkspaceAccess).mockResolvedValue(false);
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue(null);
+    await expect(getWorkspaceAuth(WORKSPACE_ID)).rejects.toThrow(AuthorizationError);
+    expect(hasUserWorkspaceAccess).toHaveBeenCalledWith(USER_ID, WORKSPACE_ID);
+  });
+
+  test("marks a member with a read grant as read-only", async () => {
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("read");
+    const auth = await getWorkspaceAuth(WORKSPACE_ID);
+    expect(auth.isMember).toBe(true);
+    expect(auth.hasReadAccess).toBe(true);
+    expect(auth.isReadOnly).toBe(true);
+  });
+
+  test("does not mark a member with a readWrite grant as read-only", async () => {
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("readWrite");
+    const auth = await getWorkspaceAuth(WORKSPACE_ID);
+    expect(auth.hasReadWriteAccess).toBe(true);
+    expect(auth.isReadOnly).toBe(false);
+  });
+
+  test("does not mark a member with a manage grant as read-only", async () => {
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("manage");
+    const auth = await getWorkspaceAuth(WORKSPACE_ID);
+    expect(auth.hasManageAccess).toBe(true);
+    expect(auth.isReadOnly).toBe(false);
+  });
+
+  // Fail-safe: even if a member reaches the flags with no resolved permission,
+  // isReadOnly must be true (most restricted), never false (writer).
+  test("treats a member with no resolved permission as read-only (fail safe)", async () => {
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue(null);
+    const auth = await getWorkspaceAuth(WORKSPACE_ID);
+    expect(auth.isMember).toBe(true);
+    expect(auth.hasReadAccess).toBe(false);
+    expect(auth.hasReadWriteAccess).toBe(false);
+    expect(auth.hasManageAccess).toBe(false);
+    expect(auth.isReadOnly).toBe(true);
+  });
+
+  test("does not mark an owner as read-only", async () => {
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(membershipWithRole("owner"));
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue(null);
+    const auth = await getWorkspaceAuth(WORKSPACE_ID);
+    expect(auth.isOwner).toBe(true);
+    expect(auth.isReadOnly).toBe(false);
+  });
+
+  test("returns the resolved workspace, organization, and session on success", async () => {
+    const auth = await getWorkspaceAuth(WORKSPACE_ID);
+    expect(auth.workspace).toBe(mockWorkspace);
+    expect(auth.organization).toBe(mockOrganization);
+    expect(auth.session).toBe(mockSession);
+    expect(auth.workspacePermission).toBe("read");
+  });
+});

--- a/apps/web/modules/workspaces/lib/utils.ts
+++ b/apps/web/modules/workspaces/lib/utils.ts
@@ -26,9 +26,13 @@ import { getTeamPermissionFlags } from "@/modules/ee/teams/utils/teams";
 import { TWorkspaceAuth, TWorkspaceLayoutData } from "@/modules/workspaces/types/workspace-auth";
 
 /**
- * Workspace-scoped equivalent of getEnvironmentAuth.
- * Accepts a workspaceId, resolves the production environment automatically,
- * and performs the same authorization checks as getEnvironmentAuth.
+ * Resolves a workspace and returns the caller's authorization context for it.
+ *
+ * This helper is self-contained: it enforces workspace-level access itself
+ * (org membership *and* a WorkspaceTeam grant / owner|manager|billing role) and
+ * throws when the caller has none, rather than relying on the route layout to
+ * gate. That makes it safe to reuse from any page or route without silently
+ * admitting org members who have no access to this specific workspace.
  */
 export const getWorkspaceAuth = reactCache(async (workspaceId: string): Promise<TWorkspaceAuth> => {
   const t = await getTranslate();
@@ -56,11 +60,26 @@ export const getWorkspaceAuth = reactCache(async (workspaceId: string): Promise<
 
   const { isMember, isOwner, isManager, isBilling } = getAccessFlags(currentUserMembership.role);
 
-  const workspacePermission = await getWorkspacePermissionByUserId(session.user.id, workspace.id);
+  // Enforce workspace access here instead of delegating to the route layout, so
+  // getWorkspaceAuth is safe to reuse anywhere. An org member with no WorkspaceTeam
+  // grant for this workspace has no access and must be rejected — not silently
+  // treated as a writer. Runs alongside the permission lookup to avoid extra latency.
+  const [hasWorkspaceAccess, workspacePermission] = await Promise.all([
+    hasUserWorkspaceAccess(session.user.id, workspace.id),
+    getWorkspacePermissionByUserId(session.user.id, workspace.id),
+  ]);
+
+  if (!hasWorkspaceAccess) {
+    throw new AuthorizationError(t("common.not_authorized"));
+  }
 
   const { hasReadAccess, hasReadWriteAccess, hasManageAccess } = getTeamPermissionFlags(workspacePermission);
 
-  const isReadOnly = isMember && hasReadAccess;
+  // Fail safe: a member is read-only unless they hold an explicit write or manage
+  // grant. Deriving from the *absence* of write access (rather than the presence of
+  // an exact "read" grant) means a member with no resolved permission is treated as
+  // the most restricted, never mislabeled as a writer.
+  const isReadOnly = isMember && !hasReadWriteAccess && !hasManageAccess;
 
   return {
     workspace,


### PR DESCRIPTION
## What does this PR do?

`getWorkspaceAuth` (the workspace-scoped auth helper behind ~35 pages/routes) only asserted org membership and left the real workspace-access gate to the `[workspaceId]` route layout. That made it a footgun to reuse: any page/route calling it outside that layout would admit an org member with no `WorkspaceTeam` grant and show them write UI. On top of that, `isReadOnly = isMember && hasReadAccess` failed open — a team-less member (no resolved permission) came back as `isReadOnly = false`, i.e. mislabeled as a writer.

This isn't a live exploit today (every current caller sits under the layout that already blocks team-less members), but it's a latent gap flagged by the internal security audit (I-34c) — and it's already being worked around, since `getWorkflowsRouteAuth` re-derives the missing check by hand.

Changes:

- Make `getWorkspaceAuth` self-contained: it now calls `hasUserWorkspaceAccess` itself and throws `AuthorizationError` when the caller has no access to the workspace (the same check its siblings `getWorkspaceLayoutData` / `workspaceIdLayoutChecks` already use). Runs in parallel with the existing permission lookup, so no added latency.
- Make `isReadOnly` fail safe: derive it from the *absence* of write/manage access (`isMember && !hasReadWriteAccess && !hasManageAccess`), so a member with no resolved permission is the most restricted, never a writer.
- Fix a stale doc comment (it referenced a `getEnvironmentAuth` that no longer exists) and add unit coverage (there was none for this file).

Notes:

- No behavior change for anyone who can currently reach these pages (owner/manager/billing, or a member with a grant) — only team-less members are newly rejected, and they were already blocked upstream by the layout.
- Billing-role access is intentionally unchanged here; that's tracked separately as I-30 ([ENG-1763](https://linear.app/formbricks/issue/ENG-1763)).
- Targets `main`; it flows into `epic/workflows-v1` via the regular main merge (the function is identical on both today).

Linear: https://linear.app/formbricks/issue/ENG-1769

## How should this be tested?

Unit tests (from `apps/web`):

- `pnpm vitest run modules/workspaces/lib/utils.test.ts` — covers the new access gate (team-less member → `AuthorizationError`, and asserts the check is called with the right `userId`/`workspaceId`) plus the full `isReadOnly` matrix (read → read-only; readWrite/manage → not; no resolved permission → read-only; owner → not).
- `pnpm vitest run modules/workspaces modules/workflows/lib/auth.test.ts redirect-billing-role` — the existing suites that consume/mock `getWorkspaceAuth` still pass.

Behavioral check (optional): as an org member with no team grant on a given workspace, hitting a page backed by `getWorkspaceAuth` should return "Not authorized" instead of rendering write UI. Owner/manager/billing and members with a grant are unaffected.

`pnpm lint` and the changed-file typecheck are clean. (Skipped a full `pnpm build` for a two-file auth change.)

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
