### PR TITLE
fix(auth): block billing-role members from workspace product data [ENG-1763]

### DIFF
--- a/apps/web/modules/workspaces/lib/utils.test.ts
+++ b/apps/web/modules/workspaces/lib/utils.test.ts
@@ -1,0 +1,87 @@
+import { redirect } from "next/navigation";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { TMembership, TOrganizationRole } from "@formbricks/types/memberships";
+import { getBillingFallbackPath } from "@/lib/membership/navigation";
+import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
+import { getOrganization } from "@/lib/organization/service";
+import { getWorkspace } from "@/lib/workspace/service";
+import { getSession } from "@/modules/auth/lib/session";
+import { getWorkspacePermissionByUserId } from "@/modules/ee/teams/lib/roles";
+import { getWorkspaceAuth } from "./utils";
+
+const mocks = vi.hoisted(() => ({ isFormbricksCloud: false }));
+
+// Real getAccessFlags is used on purpose so the tests exercise the actual role -> isBilling mapping
+// that the redirect branch keys off of. Everything else getWorkspaceAuth touches is stubbed.
+vi.mock("react", () => ({ cache: (fn: (...args: unknown[]) => unknown) => fn }));
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  IS_FORMBRICKS_CLOUD: mocks.isFormbricksCloud,
+}));
+vi.mock("@/lib/workspace/service", () => ({ getWorkspace: vi.fn() }));
+vi.mock("@/lib/organization/service", () => ({ getOrganization: vi.fn() }));
+vi.mock("@/lib/membership/service", () => ({ getMembershipByUserIdOrganizationId: vi.fn() }));
+vi.mock("@/lib/membership/navigation", () => ({ getBillingFallbackPath: vi.fn() }));
+vi.mock("@/lingodotdev/server", () => ({ getTranslate: vi.fn(() => Promise.resolve((k: string) => k)) }));
+vi.mock("@/modules/auth/lib/session", () => ({ getSession: vi.fn() }));
+vi.mock("@/modules/ee/teams/lib/roles", () => ({ getWorkspacePermissionByUserId: vi.fn() }));
+vi.mock("@/modules/ee/teams/utils/teams", () => ({
+  getTeamPermissionFlags: vi.fn(() => ({
+    hasReadAccess: false,
+    hasReadWriteAccess: false,
+    hasManageAccess: false,
+  })),
+}));
+
+const workspaceId = "workspace-1";
+const organizationId = "organization-1";
+const billingFallbackPath = `/organizations/${organizationId}/settings/enterprise`;
+
+const primeAuth = (role: TOrganizationRole) => {
+  vi.mocked(getWorkspace).mockResolvedValue({ id: workspaceId, organizationId } as Awaited<
+    ReturnType<typeof getWorkspace>
+  >);
+  vi.mocked(getSession).mockResolvedValue({
+    user: { id: "user-1" },
+    expires: new Date(0).toISOString(),
+  } as Awaited<ReturnType<typeof getSession>>);
+  vi.mocked(getOrganization).mockResolvedValue({ id: organizationId } as Awaited<
+    ReturnType<typeof getOrganization>
+  >);
+  vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue({
+    role,
+    organizationId,
+    userId: "user-1",
+    accepted: true,
+  } as TMembership);
+  vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue(null);
+  vi.mocked(getBillingFallbackPath).mockReturnValue(billingFallbackPath);
+};
+
+describe("getWorkspaceAuth billing gate (ENG-1763)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("redirects a billing-role member to the billing fallback path", async () => {
+    primeAuth("billing");
+
+    await getWorkspaceAuth(workspaceId);
+
+    expect(getBillingFallbackPath).toHaveBeenCalledWith(organizationId, mocks.isFormbricksCloud);
+    expect(redirect).toHaveBeenCalledWith(billingFallbackPath);
+  });
+
+  test.each<TOrganizationRole>(["owner", "manager", "member"])(
+    "does not redirect a %s member",
+    async (role) => {
+      primeAuth(role);
+
+      const result = await getWorkspaceAuth(workspaceId);
+
+      expect(redirect).not.toHaveBeenCalled();
+      expect(getBillingFallbackPath).not.toHaveBeenCalled();
+      expect(result.isBilling).toBe(false);
+    }
+  );
+});

--- a/apps/web/modules/workspaces/lib/utils.ts
+++ b/apps/web/modules/workspaces/lib/utils.ts
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import { cache as reactCache } from "react";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
@@ -10,6 +11,7 @@ import {
   ResourceNotFoundError,
 } from "@formbricks/types/errors";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { getBillingFallbackPath } from "@/lib/membership/navigation";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getAccessFlags } from "@/lib/membership/utils";
 import { getMonthlyOrganizationResponseCount, getOrganization } from "@/lib/organization/service";
@@ -55,6 +57,15 @@ export const getWorkspaceAuth = reactCache(async (workspaceId: string): Promise<
   }
 
   const { isMember, isOwner, isManager, isBilling } = getAccessFlags(currentUserMembership.role);
+
+  // Billing-role members are scoped to billing/enterprise screens only. They must never reach
+  // workspace product data (contacts PII, survey summaries/responses, dashboards). This is the
+  // single choke point every product page flows through, so gating here closes all of them at
+  // once and keeps this helper aligned with hasUserWorkspaceAccessForAction, which already denies
+  // billing. Individual pages that also guard billing inline remain correct (defense in depth).
+  if (isBilling) {
+    redirect(getBillingFallbackPath(organization.id, IS_FORMBRICKS_CLOUD));
+  }
 
   const workspacePermission = await getWorkspacePermissionByUserId(session.user.id, workspace.id);
 

--- a/apps/web/playwright/billing-role-access.spec.ts
+++ b/apps/web/playwright/billing-role-access.spec.ts
@@ -1,0 +1,63 @@
+import { expect } from "@playwright/test";
+import { prisma } from "@formbricks/database";
+import type { UsersFixture } from "./fixtures/users";
+import { test } from "./lib/fixtures";
+
+// ENG-1763 regression: a billing-role member must not reach workspace product data (contacts PII,
+// survey summaries/responses, dashboards) by direct navigation. getWorkspaceAuth is the single choke
+// point every product page flows through, so it bounces billing users to their org billing/enterprise
+// home instead. The owner test guards against a naive "redirect everyone" fix regressing product
+// access for legitimate roles.
+
+// Creates an organization (owned by `owner`) with a workspace holding product data, plus a second
+// user who is a billing-role member of that same organization.
+const setupOrgWithBillingMember = async (users: UsersFixture) => {
+  const owner = await users.create();
+  if (!owner.organizationId || !owner.workspaceId) {
+    throw new Error("Owner org/workspace not seeded for test");
+  }
+
+  const billingUser = await users.create({ withoutWorkspace: true });
+  await prisma.membership.create({
+    data: {
+      userId: billingUser.id,
+      organizationId: owner.organizationId,
+      role: "billing",
+      accepted: true,
+    },
+  });
+
+  return {
+    owner,
+    billingUser,
+    workspaceId: owner.workspaceId,
+    contactsUrl: `/workspaces/${owner.workspaceId}/contacts`,
+    dashboardsUrl: `/workspaces/${owner.workspaceId}/dashboards`,
+  };
+};
+
+test.describe("Billing-role workspace access (ENG-1763)", () => {
+  const billingHomeUrl = /\/organizations\/[^/]+\/settings\/(billing|enterprise)/;
+
+  test("redirects a billing member off product pages to the billing home", async ({ page, users }) => {
+    const { billingUser, contactsUrl, dashboardsUrl } = await setupOrgWithBillingMember(users);
+
+    await billingUser.login();
+
+    for (const url of [contactsUrl, dashboardsUrl]) {
+      await page.goto(url, { waitUntil: "domcontentloaded" });
+      await expect(page).toHaveURL(billingHomeUrl);
+    }
+  });
+
+  test("keeps product-page access for a non-billing owner", async ({ page, users }) => {
+    const { owner, workspaceId, contactsUrl } = await setupOrgWithBillingMember(users);
+
+    await owner.login();
+    await page.goto(contactsUrl, { waitUntil: "domcontentloaded" });
+
+    // Owner stays on the product route (the page may render an upgrade prompt when the enterprise
+    // feature is unlicensed, but crucially it is not bounced to the billing home).
+    await expect(page).toHaveURL(new RegExp(`/workspaces/${workspaceId}/contacts`));
+  });
+});

--- a/apps/web/playwright/billing-role-access.spec.ts
+++ b/apps/web/playwright/billing-role-access.spec.ts
@@ -27,12 +27,25 @@ const setupOrgWithBillingMember = async (users: UsersFixture) => {
     },
   });
 
+  // users.create seeds a survey in the workspace; it backs the survey summary/responses URLs below.
+  const survey = await prisma.survey.findFirstOrThrow({
+    where: { workspaceId: owner.workspaceId },
+    select: { id: true },
+  });
+
+  const workspaceBase = `/workspaces/${owner.workspaceId}`;
   return {
     owner,
     billingUser,
     workspaceId: owner.workspaceId,
-    contactsUrl: `/workspaces/${owner.workspaceId}/contacts`,
-    dashboardsUrl: `/workspaces/${owner.workspaceId}/dashboards`,
+    contactsUrl: `${workspaceBase}/contacts`,
+    // Every workspace product surface flows through getWorkspaceAuth, so all of them must redirect.
+    productUrls: [
+      `${workspaceBase}/contacts`,
+      `${workspaceBase}/dashboards`,
+      `${workspaceBase}/surveys/${survey.id}/summary`,
+      `${workspaceBase}/surveys/${survey.id}/responses`,
+    ],
   };
 };
 
@@ -40,13 +53,13 @@ test.describe("Billing-role workspace access (ENG-1763)", () => {
   const billingHomeUrl = /\/organizations\/[^/]+\/settings\/(billing|enterprise)/;
 
   test("redirects a billing member off product pages to the billing home", async ({ page, users }) => {
-    const { billingUser, contactsUrl, dashboardsUrl } = await setupOrgWithBillingMember(users);
+    const { billingUser, productUrls } = await setupOrgWithBillingMember(users);
 
     await billingUser.login();
 
-    for (const url of [contactsUrl, dashboardsUrl]) {
+    for (const url of productUrls) {
       await page.goto(url, { waitUntil: "domcontentloaded" });
-      await expect(page).toHaveURL(billingHomeUrl);
+      await expect(page, `billing member should be redirected off ${url}`).toHaveURL(billingHomeUrl);
     }
   });
 


### PR DESCRIPTION
## What does this PR do?

Closes **ENG-1763** (I-30, security — High).

**Problem.** The two workspace-access helpers disagree on the `billing` role: `hasUserWorkspaceAccess` returns `true`, while `hasUserWorkspaceAccessForAction` returns `false`. The workspace layout gates on the permissive one, and product pages (contacts, survey summary/responses, dashboards, unify) authorize via `getWorkspaceAuth`, which only checks that a membership exists — it never re-checks `isBilling`. As a result a finance user invited as `billing` (intended: billing/enterprise screens only) could direct-navigate to `/workspaces/{id}/contacts`, a dashboard, or a survey summary and read customer emails/attributes and feedback aggregates. Because `isReadOnly = isMember && hasReadAccess` is `false` for billing, they were also treated as non-read-only, so write CTAs rendered too.

**Fix.** Add the billing guard at the single choke point every workspace product page already flows through — `getWorkspaceAuth`. A billing-role member is now redirected to their org billing/enterprise home (`getBillingFallbackPath`), exactly as the settings pages and the workspace root page already do. This closes every exposed product surface at once (contacts, dashboards, charts, unify, survey summary/responses) and realigns `getWorkspaceAuth` with `hasUserWorkspaceAccessForAction`, which already denies billing. Existing inline billing guards on individual pages remain correct as defense in depth.

Chosen over the alternative (tightening `hasUserWorkspaceAccess` itself) because that helper also gates the workspace *layout*, so denying billing there would turn a clean redirect into an `AuthorizationError` error page.

### Out of scope (noted for follow-up)
The integration API routes (`notion`/`airtable`/`slack`/`google-sheet`) also use the permissive `hasUserWorkspaceAccess` and would let a billing user hit integration setup. That's a privilege issue rather than the PII/product-data leak this ticket covers — likely a separate follow-up.

## How should this be tested?

Automated: `apps/web/playwright/billing-role-access.spec.ts` (new) — both tests pass locally.

1. **Billing member is redirected** — a billing-role member of an org navigates directly to `/workspaces/{id}/contacts` and `/workspaces/{id}/dashboards`; asserts they land on `/organizations/{id}/settings/{billing|enterprise}` and never on the product route.
2. **Owner keeps access** (control) — an owner navigates to `/contacts` and stays there, so the fix doesn't blanket-redirect legitimate roles.

Manual:
- Invite a user as `billing`, then as that user open `/workspaces/{id}/contacts`, a dashboard, and a survey summary → each should redirect to the billing/enterprise home.
- Repeat as an `owner`/`manager`/`member` → product pages load as before.

```
pnpm --filter=@formbricks/web exec playwright test billing-role-access
```

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
