### PR TITLE
docs(pr): require an agent-maintained QA / Test Plan section on every PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,12 +10,31 @@ Fixes #(issue)
  Loom Video: https://www.loom.com/
 -->
 
-## How should this be tested?
+## QA / Test Plan
 
-<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->
+<!--
+This section is the source of truth for release QA — QA checklists are generated from it. Describe the
+PR's ACTUAL behavior, not the commit titles. Keep steps click-by-click and grounded in real behavior.
+Omit a subsection only when it genuinely does not apply. Flag any inferred specifics (thresholds, rate
+limits, timeouts) for human verification.
+-->
 
-- Test A
-- Test B
+**How to test** <!-- happy path first, then edge cases (boundaries, negative input, permissions) -->
+
+- [ ] Step → expected result (include route, error code, and any env flag/var)
+- [ ] Edge case → expected result
+
+**Preconditions / test data** <!-- accounts, seed data, feature flags, plan/entitlement, Cloud vs self-host -->
+
+-
+
+**Risks & regressions** <!-- what nearby behavior could break; what to re-check -->
+
+-
+
+**Migrations / env / cutover** <!-- new/changed env vars (diff .env.example), DB migrations, cutover steps; write "none" if none -->
+
+- none
 
 ## Checklist
 
@@ -23,7 +42,7 @@ Fixes #(issue)
 
 ### Required
 
-- [ ] Filled out the "How to test" section in this PR
+- [ ] Filled out the "QA / Test Plan" section in this PR (behavior, edge cases, preconditions, risks, migrations/env)
 - [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
 - [ ] Self-reviewed my own code
 - [ ] Commented on my code in hard-to-understand bits

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,25 +133,7 @@ Heuristic:
 
 Commits follow a lightweight Conventional Commit format (`fix:`, `chore:`, `feat:`) and usually append the PR number, e.g. `fix: update OpenAPI schema (#6617)`. Keep commits scoped and lint-clean. Pull requests should outline the problem, summarize the solution, and link to issues or product specs. Attach screenshots or gifs for UI-facing work, list any migrations or env changes, and paste the output of relevant commands (`pnpm test`, `pnpm lint`, `pnpm db:migrate:dev`) so reviewers can verify readiness.
 
-### PR QA / Test Plan (required, agent-maintained)
-
-Every PR body MUST contain a `## QA / Test Plan` section. This section is the source of truth for release QA — QA checklists are generated from it first, falling back to the diff only for gaps — so it must describe the PR's **actual behavior**, not restate commit titles.
-
-Agents open and maintain this section automatically; do not wait for the author to ask:
-
-- **On PR open:** write the section from the change.
-- **On every PR update (new commits, scope changes, review fixes):** re-read your own diff and update the section in the same turn so it never drifts from the code. Treat a stale QA section as a bug.
-
-Fill the `## QA / Test Plan` section that `.github/pull_request_template.md` already scaffolds — keep its subsection headings verbatim so every PR stays consistent (do not invent an alternate layout). The overall intent stays in the template's separate `## What does this PR do?` section; do not duplicate it here. Replace each placeholder, and omit a subsection only when it genuinely does not apply.
-
-The template's subsections and what goes in each:
-
-- **How to test** — click-by-click steps, each as `- [ ] action → expected result`, with concrete routes, error codes, and any env flags/vars to set. Cover happy path first, then **edge cases** (boundaries, negative input, permissions). For UI-facing work include all relevant states/variants; for accessibility work include an "all question types / all states" pass.
-- **Preconditions / test data** — accounts, seed data, feature flags, plan/entitlement, Cloud vs self-host.
-- **Risks & regressions** — what nearby behavior could break; what to re-check.
-- **Migrations / env / cutover** — new or changed env vars (diff `.env.example`), DB migrations, and any cutover steps (secrets, redirect URIs, migration order). State "none" explicitly if there are none.
-
-Keep every item executable and grounded in real behavior. Flag any inferred specifics (thresholds, rate limits, timeouts) for human verification rather than asserting them. If the template's structure changes, this list follows it — the template is canonical.
+Every PR must use `.github/pull_request_template.md` — including its `## QA / Test Plan` section, which is the source of truth for release QA (follow the guidance inline in the template; keep its subsection headings). Agents fill it on PR open and re-update it in the same turn on every PR change (new commits, scope or review fixes) so it never drifts from the diff — treat a stale QA section as a bug.
 
 ## Next.js Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,6 +133,26 @@ Heuristic:
 
 Commits follow a lightweight Conventional Commit format (`fix:`, `chore:`, `feat:`) and usually append the PR number, e.g. `fix: update OpenAPI schema (#6617)`. Keep commits scoped and lint-clean. Pull requests should outline the problem, summarize the solution, and link to issues or product specs. Attach screenshots or gifs for UI-facing work, list any migrations or env changes, and paste the output of relevant commands (`pnpm test`, `pnpm lint`, `pnpm db:migrate:dev`) so reviewers can verify readiness.
 
+### PR QA / Test Plan (required, agent-maintained)
+
+Every PR body MUST contain a `## QA / Test Plan` section. This section is the source of truth for release QA — QA checklists are generated from it first, falling back to the diff only for gaps — so it must describe the PR's **actual behavior**, not restate commit titles.
+
+Agents open and maintain this section automatically; do not wait for the author to ask:
+
+- **On PR open:** write the section from the change.
+- **On every PR update (new commits, scope changes, review fixes):** re-read your own diff and update the section in the same turn so it never drifts from the code. Treat a stale QA section as a bug.
+
+Fill the `## QA / Test Plan` section that `.github/pull_request_template.md` already scaffolds — keep its subsection headings verbatim so every PR stays consistent (do not invent an alternate layout). The overall intent stays in the template's separate `## What does this PR do?` section; do not duplicate it here. Replace each placeholder, and omit a subsection only when it genuinely does not apply.
+
+The template's subsections and what goes in each:
+
+- **How to test** — click-by-click steps, each as `- [ ] action → expected result`, with concrete routes, error codes, and any env flags/vars to set. Cover happy path first, then **edge cases** (boundaries, negative input, permissions). For UI-facing work include all relevant states/variants; for accessibility work include an "all question types / all states" pass.
+- **Preconditions / test data** — accounts, seed data, feature flags, plan/entitlement, Cloud vs self-host.
+- **Risks & regressions** — what nearby behavior could break; what to re-check.
+- **Migrations / env / cutover** — new or changed env vars (diff `.env.example`), DB migrations, and any cutover steps (secrets, redirect URIs, migration order). State "none" explicitly if there are none.
+
+Keep every item executable and grounded in real behavior. Flag any inferred specifics (thresholds, rate limits, timeouts) for human verification rather than asserting them. If the template's structure changes, this list follows it — the template is canonical.
+
 ## Next.js Documentation
 
 Do not rely on training data for Next.js behavior in this repo. For any Next.js-related work (routing, layouts, server/client components, caching, next.config, etc.), use the `nextjs-docs` skill, which indexes the version-pinned local docs in `.next-docs/`.


### PR DESCRIPTION
## What does this PR do?

Adds a **QA / Test Plan** rule to `AGENTS.md` and restructures `.github/pull_request_template.md` around it.

Context: release-QA tickets are generated from the diff today, which produces irrelevant/hallucinated test points. Making each PR carry a well-structured, behavior-grounded test plan gives QA generation a high-signal primary source (read the PR plan first, fall back to the diff only for gaps).

## QA / Test Plan

**How to test**

- [ ] Open a new PR (or edit an existing one) → the body is pre-seeded with a `## QA / Test Plan` section (How to test · Preconditions / test data · Risks & regressions · Migrations / env / cutover) → expected: this replaces the old "How should this be tested? / Test A/B" block
- [ ] Read `AGENTS.md` → "Commit & Pull Request Guidelines" → the new **PR QA / Test Plan (required, agent-maintained)** subsection exists → expected: it points at the template as canonical and mandates create-on-open + update-on-every-update
- [ ] Cross-check the subsection names in `AGENTS.md` against the template → expected: they match exactly (no `What & why` duplication; intent stays in `## What does this PR do?`)

**Preconditions / test data**

- None — docs/process only.

**Risks & regressions**

- Contributors see a different (structured) test section in new PRs. No code paths affected.

**Migrations / env / cutover**

- none

## Checklist

### Required

- [x] Filled out the "QA / Test Plan" section in this PR
- [x] Self-reviewed my own code