### PR TITLE
fix: enforce organization/workspace scoping across API keys, surveys, quotas, and integrations (ENG-1749)

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/actions.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/actions.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { OperationNotAllowedError } from "@formbricks/types/errors";
+
+const mocks = vi.hoisted(() => ({
+  checkAuthorizationUpdated: vi.fn(),
+  getOrganizationIdFromWorkspaceId: vi.fn(),
+  getSpreadsheetNameById: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/action-client", () => ({
+  authenticatedActionClient: {
+    inputSchema: vi.fn(() => ({ action: vi.fn((fn) => fn) })),
+  },
+}));
+
+vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
+  checkAuthorizationUpdated: mocks.checkAuthorizationUpdated,
+}));
+
+vi.mock("@/lib/utils/helper", () => ({
+  getOrganizationIdFromWorkspaceId: mocks.getOrganizationIdFromWorkspaceId,
+}));
+
+vi.mock("@/lib/googleSheet/service", () => ({
+  getSpreadsheetNameById: mocks.getSpreadsheetNameById,
+  validateGoogleSheetsConnection: vi.fn(),
+}));
+
+vi.mock("@/lib/integration/service", () => ({ getIntegrationByType: vi.fn() }));
+
+const { getSpreadsheetNameByIdAction } = await import("./actions");
+
+const call = (googleSheetIntegration: unknown, workspaceId: string) =>
+  (getSpreadsheetNameByIdAction as unknown as (args: unknown) => Promise<unknown>)({
+    ctx: { user: { id: "user1" } },
+    parsedInput: { googleSheetIntegration, workspaceId, spreadsheetId: "sheet1" },
+  });
+
+describe("getSpreadsheetNameByIdAction — ENG-1921 cross-workspace integration hijack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.checkAuthorizationUpdated.mockResolvedValue(undefined);
+    mocks.getOrganizationIdFromWorkspaceId.mockResolvedValue("org1");
+    mocks.getSpreadsheetNameById.mockResolvedValue("My Sheet");
+  });
+
+  test("rejects an integration whose workspaceId differs from the authorized workspace", async () => {
+    await expect(call({ workspaceId: "victim-ws", config: { data: [] } }, "attacker-ws")).rejects.toThrow(
+      OperationNotAllowedError
+    );
+    expect(mocks.getSpreadsheetNameById).not.toHaveBeenCalled();
+  });
+
+  test("allows an integration for the authorized workspace", async () => {
+    const result = await call({ workspaceId: "attacker-ws", config: { data: [] } }, "attacker-ws");
+    expect(mocks.getSpreadsheetNameById).toHaveBeenCalled();
+    expect(result).toBe("My Sheet");
+  });
+});

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/actions.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/actions.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
+import { OperationNotAllowedError } from "@formbricks/types/errors";
 import {
   TIntegrationGoogleSheets,
   ZIntegrationGoogleSheets,
@@ -68,6 +69,14 @@ export const getSpreadsheetNameByIdAction = authenticatedActionClient
         },
       ],
     });
+
+    // ENG-1921: googleSheetIntegration is fully client-supplied and carries its own workspaceId,
+    // which is used downstream to upsert the integration (incl. OAuth tokens) on the token-refresh
+    // path. Reject it unless it targets the authorized workspace, otherwise a caller could
+    // create/overwrite another tenant's integration.
+    if (parsedInput.googleSheetIntegration.workspaceId !== parsedInput.workspaceId) {
+      throw new OperationNotAllowedError("Integration does not belong to the specified workspace");
+    }
 
     const integrationData = structuredClone(parsedInput.googleSheetIntegration);
     integrationData.config.data.forEach((data) => {

--- a/apps/web/app/api/v1/auth.test.ts
+++ b/apps/web/app/api/v1/auth.test.ts
@@ -30,7 +30,7 @@ describe("getApiKeyWithPermissions", () => {
         {
           workspaceId: "workspace-1",
           permission: "manage" as const,
-          workspace: { id: "workspace-1", name: "Workspace 1" },
+          workspace: { id: "workspace-1", name: "Workspace 1", organizationId: "org-id" },
         },
       ],
     };
@@ -112,7 +112,7 @@ describe("authenticateRequest", () => {
         {
           workspaceId: "workspace-1",
           permission: "manage" as const,
-          workspace: { id: "workspace-1", name: "Workspace 1" },
+          workspace: { id: "workspace-1", name: "Workspace 1", organizationId: "org-id" },
         },
       ],
     };

--- a/apps/web/app/api/v1/management/me/route.ts
+++ b/apps/web/app/api/v1/management/me/route.ts
@@ -18,6 +18,7 @@ const apiKeySelect = {
       workspace: {
         select: {
           id: true,
+          organizationId: true,
           legacyEnvironmentId: true,
           createdAt: true,
           updatedAt: true,
@@ -40,6 +41,7 @@ type ApiKeyData = {
     permission: string;
     workspace: {
       id: string;
+      organizationId: string;
       legacyEnvironmentId: string | null;
       createdAt: Date;
       updatedAt: Date;
@@ -52,11 +54,20 @@ type ApiKeyData = {
 const validateApiKey = async (apiKey: string): Promise<ApiKeyData | null> => {
   const v2Parsed = parseApiKeyV2(apiKey);
 
-  if (v2Parsed) {
-    return validateV2ApiKey(v2Parsed);
+  const apiKeyData = v2Parsed ? await validateV2ApiKey(v2Parsed) : await validateLegacyApiKey(apiKey);
+  if (!apiKeyData) {
+    return null;
   }
 
-  return validateLegacyApiKey(apiKey);
+  // ENG-1749: drop workspace permissions outside the key's organization (defense-in-depth,
+  // mirroring authenticateApiKeyFromHeaders) so a pre-fix cross-org row can't leak workspace
+  // metadata through this legacy route.
+  return {
+    ...apiKeyData,
+    apiKeyWorkspaces: apiKeyData.apiKeyWorkspaces.filter(
+      (workspacePermission) => workspacePermission.workspace.organizationId === apiKeyData.organizationId
+    ),
+  };
 };
 
 const validateV2ApiKey = async (v2Parsed: { secret: string }): Promise<ApiKeyData | null> => {

--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -395,10 +395,14 @@ describe("Tests for updateSurvey", () => {
       expect(prisma.survey.update).not.toHaveBeenCalled();
     });
 
-    // ENG-1749 sibling: the update path (incl. drafts, skipValidation=true) must not link a
-    // language from another workspace even when the caller is authorized for the survey.
-    test("rejects a language that belongs to another workspace", async () => {
+    // ENG-1749 sibling: the update path (incl. drafts, skipValidation=true) must not link a language
+    // from another workspace. The guard resolves the language's workspace from the DB, so a request
+    // that LIES about language.workspaceId (claiming this survey's workspace) is still rejected.
+    test("rejects a language whose real (DB) workspace differs, even when the input claims otherwise", async () => {
       prisma.survey.findUnique.mockResolvedValueOnce(mockSurveyOutput);
+      prisma.language.findMany.mockResolvedValueOnce([
+        { id: "cllangforeign00000000001", workspaceId: "clforeignws0000000000001" },
+      ] as any);
 
       await expect(
         updateSurveyInternal(
@@ -412,7 +416,7 @@ describe("Tests for updateSurvey", () => {
                   updatedAt: new Date(),
                   code: "de",
                   alias: null,
-                  workspaceId: "clforeignws0000000000001",
+                  workspaceId: updateSurveyInput.workspaceId, // the lie: claims the survey's own workspace
                 },
                 default: true,
                 enabled: true,
@@ -423,7 +427,75 @@ describe("Tests for updateSurvey", () => {
         )
       ).rejects.toThrow(ResourceNotFoundError);
 
+      expect(prisma.language.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ["cllangforeign00000000001"] } },
+        select: { id: true, workspaceId: true },
+      });
       expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
+
+    test("rejects a language id that does not exist (absent from the DB result)", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce(mockSurveyOutput);
+      prisma.language.findMany.mockResolvedValueOnce([] as any);
+
+      await expect(
+        updateSurveyInternal(
+          {
+            ...updateSurveyInput,
+            languages: [
+              {
+                language: {
+                  id: "cllangmissing0000000001",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  code: "de",
+                  alias: null,
+                  workspaceId: updateSurveyInput.workspaceId,
+                },
+                default: true,
+                enabled: true,
+              },
+            ],
+          },
+          true
+        )
+      ).rejects.toThrow(ResourceNotFoundError);
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
+
+    // ENG-1749/ENG-1920: the app-survey segment block connects segment.surveys by id; a survey from
+    // another workspace must not be connectable (would re-point that survey's targeting).
+    test("rejects connecting a survey from another workspace to the segment (app survey update)", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce(mockSurveyOutput); // getSurvey → current survey (own workspace)
+      prisma.segment.findUnique.mockResolvedValueOnce({
+        workspaceId: updateSurveyInput.workspaceId,
+      } as any); // segment.id belongs to the survey's workspace (passes the segment guard)
+      prisma.survey.findMany.mockResolvedValueOnce([
+        { id: "clvictimsurvey0000000001", workspaceId: "clforeignws0000000000001" },
+      ] as any); // the connected survey is in ANOTHER workspace
+
+      await expect(
+        updateSurveyInternal(
+          {
+            ...updateSurveyInput,
+            type: "app",
+            segment: {
+              id: "clownsegment000000000001",
+              title: "seg",
+              description: null,
+              isPrivate: false,
+              filters: [],
+              workspaceId: updateSurveyInput.workspaceId,
+              surveys: ["clvictimsurvey0000000001"],
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          } as any,
+          true
+        )
+      ).rejects.toThrow(InvalidInputError);
+
+      expect(prisma.segment.update).not.toHaveBeenCalled();
     });
   });
 });
@@ -851,6 +923,9 @@ describe("Tests for createSurvey", () => {
 
     test("creates survey languages from validated language inputs", async () => {
       vi.mocked(getOrganizationByWorkspaceId).mockResolvedValueOnce(mockOrganizationOutput);
+      prisma.language.findMany.mockResolvedValueOnce([
+        { id: "cllang12345678901234567890", workspaceId: mockWorkspaceId },
+      ] as any);
       prisma.survey.create.mockResolvedValueOnce({
         ...mockSurveyOutput,
       });
@@ -1005,6 +1080,11 @@ describe("Tests for createSurvey", () => {
     });
 
     test("rejects survey languages from a different workspace", async () => {
+      // The DB says this language belongs to another workspace, regardless of what the input claims.
+      prisma.language.findMany.mockResolvedValueOnce([
+        { id: "cllang12345678901234567890", workspaceId: "clotherworkspace0000000000" },
+      ] as any);
+
       await expect(
         createSurvey(mockWorkspaceId, {
           ...mockCreateSurveyInput,
@@ -1016,7 +1096,7 @@ describe("Tests for createSurvey", () => {
                 id: "cllang12345678901234567890",
                 code: "en-US",
                 alias: null,
-                workspaceId: "clotherworkspace0000000000",
+                workspaceId: mockWorkspaceId,
                 createdAt: new Date(),
                 updatedAt: new Date(),
               },

--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -394,6 +394,37 @@ describe("Tests for updateSurvey", () => {
       expect(prisma.segment.delete).not.toHaveBeenCalled();
       expect(prisma.survey.update).not.toHaveBeenCalled();
     });
+
+    // ENG-1749 sibling: the update path (incl. drafts, skipValidation=true) must not link a
+    // language from another workspace even when the caller is authorized for the survey.
+    test("rejects a language that belongs to another workspace", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce(mockSurveyOutput);
+
+      await expect(
+        updateSurveyInternal(
+          {
+            ...updateSurveyInput,
+            languages: [
+              {
+                language: {
+                  id: "cllangforeign00000000001",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  code: "de",
+                  alias: null,
+                  workspaceId: "clforeignws0000000000001",
+                },
+                default: true,
+                enabled: true,
+              },
+            ],
+          },
+          true
+        )
+      ).rejects.toThrow(ResourceNotFoundError);
+
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -320,6 +320,21 @@ describe("Tests for updateSurvey", () => {
       expect(updatedSurvey).toEqual(mockTransformedSurveyOutput);
     });
 
+    test("does not persist workspaceId or id from the payload on update — pinned to the existing survey (ENG-1749)", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce(mockSurveyOutput);
+      prisma.survey.update.mockResolvedValueOnce(mockSurveyOutput);
+
+      await updateSurvey(updateSurveyInput);
+
+      const updateArg = vi.mocked(prisma.survey.update).mock.calls.at(-1)?.[0];
+      // workspaceId/id are the survey's tenant anchors: they must come from the existing record,
+      // never the client payload, so an authorized editor cannot re-point their survey to another
+      // workspace/organization on update.
+      expect(updateArg?.data).not.toHaveProperty("workspaceId");
+      expect(updateArg?.data).not.toHaveProperty("id");
+      expect(updateArg?.where).toEqual({ id: updateSurveyInput.id });
+    });
+
     // Note: Language handling tests (for languages.length > 0 fix) are covered in
     // apps/web/modules/survey/editor/lib/survey.test.ts where we have better control
     // over the test mocks. The key fix ensures languages.length > 0 (not > 1) is used.

--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -358,6 +358,42 @@ describe("Tests for updateSurvey", () => {
       prisma.survey.update.mockRejectedValue(new Error(mockErrorMessage));
       await expect(updateSurvey(updateSurveyInput)).rejects.toThrow(Error);
     });
+
+    // ENG-1749 sibling: the update path must not update/delete a segment from another workspace
+    // even when the caller is authorized for the survey being updated.
+    test("rejects a segment that belongs to another workspace", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce(mockSurveyOutput);
+      prisma.segment.findUnique.mockResolvedValueOnce({
+        id: "clseg123456789012345678901",
+        title: "Segment",
+        description: null,
+        isPrivate: true,
+        filters: [],
+        workspaceId: "clotherworkspace1234567890",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await expect(
+        updateSurvey({
+          ...updateSurveyInput,
+          segment: {
+            id: "clseg123456789012345678901",
+            title: "Segment",
+            description: null,
+            isPrivate: true,
+            filters: [],
+            workspaceId: updateSurveyInput.workspaceId,
+            surveys: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        })
+      ).rejects.toThrow(ResourceNotFoundError);
+
+      expect(prisma.segment.delete).not.toHaveBeenCalled();
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -12,6 +12,7 @@ import {
   getOrganizationByWorkspaceId,
   subscribeOrganizationMembersToSurveyResponses,
 } from "@/lib/organization/service";
+import { getSurveyWorkspaceIdMap } from "@/modules/ee/contacts/segments/lib/segments";
 import { handleTriggerUpdates } from "@/modules/survey/lib/trigger-updates";
 import {
   isSurveySchedulingDue,
@@ -388,11 +389,7 @@ export const updateSurveyInternal = async (
         // another tenant's survey targeting). Done outside the try below, which masks errors as a
         // generic Error and would otherwise hide this rejection.
         if (segment.surveys && segment.surveys.length > 0) {
-          const connectedSurveys = await prisma.survey.findMany({
-            where: { id: { in: segment.surveys } },
-            select: { id: true, workspaceId: true },
-          });
-          const workspaceBySurveyId = new Map(connectedSurveys.map((s) => [s.id, s.workspaceId]));
+          const workspaceBySurveyId = await getSurveyWorkspaceIdMap(segment.surveys);
           if (
             !segment.surveys.every(
               (surveyId) => workspaceBySurveyId.get(surveyId) === currentSurvey.workspaceId

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -293,6 +293,11 @@ export const updateSurveyInternal = async (
 
     const { triggers, segment, questions, languages, type, followUps, ...surveyData } = updatedSurvey;
 
+    // ENG-1749 sibling: the segment block below updates/deletes by segment.id directly. Ensure the
+    // segment belongs to this survey's workspace so a caller cannot mutate or delete another
+    // tenant's segment by supplying its id. Mirrors the create path guard.
+    await assertSurveySegmentBelongsToWorkspace(currentSurvey.workspaceId, segment);
+
     if (!skipValidation) {
       checkForInvalidImagesInQuestions(questions);
 
@@ -643,7 +648,7 @@ const assertSurveyLanguagesBelongToWorkspace = (
 
 const assertSurveySegmentBelongsToWorkspace = async (
   workspaceId: string,
-  segment: TSurveyCreateInput["segment"]
+  segment: { id?: string | null } | null | undefined
 ): Promise<void> => {
   if (!segment?.id) {
     return;

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -301,7 +301,7 @@ export const updateSurveyInternal = async (
     // ENG-1749 sibling: the languages block below links languages by language.id. Ensure every
     // referenced language belongs to this survey's workspace so a caller cannot attach another
     // tenant's language. Mirrors the create path guard (covers drafts too — runs before validation).
-    assertSurveyLanguagesBelongToWorkspace(currentSurvey.workspaceId, languages);
+    await assertSurveyLanguagesBelongToWorkspace(currentSurvey.workspaceId, languages);
 
     if (!skipValidation) {
       checkForInvalidImagesInQuestions(questions);
@@ -383,21 +383,37 @@ export const updateSurveyInternal = async (
           throw new InvalidInputError("Invalid user segment filters");
         }
 
-        try {
-          // update the segment:
-          let updatedInput: Prisma.SegmentUpdateInput = {
-            ...segment,
-            surveys: undefined,
-          };
-
-          if (segment.surveys) {
-            updatedInput = {
-              ...segment,
-              surveys: {
-                connect: segment.surveys.map((surveyId) => ({ id: surveyId })),
-              },
-            };
+        // ENG-1749/ENG-1920: the connected survey ids are client-supplied; ensure each belongs to
+        // this survey's workspace before re-pointing it to the segment (a foreign id would hijack
+        // another tenant's survey targeting). Done outside the try below, which masks errors as a
+        // generic Error and would otherwise hide this rejection.
+        if (segment.surveys && segment.surveys.length > 0) {
+          const connectedSurveys = await prisma.survey.findMany({
+            where: { id: { in: segment.surveys } },
+            select: { id: true, workspaceId: true },
+          });
+          const workspaceBySurveyId = new Map(connectedSurveys.map((s) => [s.id, s.workspaceId]));
+          if (
+            !segment.surveys.every(
+              (surveyId) => workspaceBySurveyId.get(surveyId) === currentSurvey.workspaceId
+            )
+          ) {
+            throw new InvalidInputError("Survey and segment are not in the same workspace");
           }
+        }
+
+        try {
+          // Update only the segment's own mutable fields — never mass-assign workspaceId/id/
+          // timestamps from the client-supplied segment object (ENG-1749).
+          const updatedInput: Prisma.SegmentUpdateInput = {
+            title: segment.title,
+            description: segment.description,
+            isPrivate: segment.isPrivate,
+            filters: segment.filters,
+            ...(segment.surveys
+              ? { surveys: { connect: segment.surveys.map((surveyId) => ({ id: surveyId })) } }
+              : {}),
+          };
 
           await prisma.segment.update({
             where: { id: segment.id },
@@ -640,13 +656,28 @@ const validateSurveyCreateDataMedia = (
   return data;
 };
 
-const assertSurveyLanguagesBelongToWorkspace = (
+const assertSurveyLanguagesBelongToWorkspace = async (
   workspaceId: string,
-  languages: Array<{ language: { id: string; workspaceId: string } }> | null | undefined
-): void => {
-  for (const surveyLanguage of languages ?? []) {
-    if (surveyLanguage.language.workspaceId !== workspaceId) {
-      throw new ResourceNotFoundError("Language", surveyLanguage.language.id);
+  languages: Array<{ language: { id: string } }> | null | undefined
+): Promise<void> => {
+  const languageIds = [...new Set((languages ?? []).map((surveyLanguage) => surveyLanguage.language.id))];
+  if (languageIds.length === 0) {
+    return;
+  }
+
+  // ENG-1749: resolve each language's real owning workspace from the DB rather than trusting the
+  // caller-supplied language.workspaceId — the survey payload is client-controlled, so an attacker
+  // could otherwise claim a foreign language belongs to this workspace. A single batched query
+  // avoids a per-language fan-out; an unknown id is absent from the map and thus rejected.
+  const dbLanguages = await prisma.language.findMany({
+    where: { id: { in: languageIds } },
+    select: { id: true, workspaceId: true },
+  });
+  const workspaceByLanguageId = new Map(dbLanguages.map((language) => [language.id, language.workspaceId]));
+
+  for (const languageId of languageIds) {
+    if (workspaceByLanguageId.get(languageId) !== workspaceId) {
+      throw new ResourceNotFoundError("Language", languageId);
     }
   }
 };
@@ -681,7 +712,7 @@ export const createSurvey = async (
 
   try {
     const { createdBy, languages, segment, followUps, styling, ...restSurveyBody } = parsedSurveyBody;
-    assertSurveyLanguagesBelongToWorkspace(parsedWorkspaceId, languages);
+    await assertSurveyLanguagesBelongToWorkspace(parsedWorkspaceId, languages);
     await assertSurveySegmentBelongsToWorkspace(parsedWorkspaceId, segment);
 
     // An app survey can never be shown without a trigger, so block creating one directly in a

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -285,14 +285,28 @@ export const updateSurveyInternal = async (
     const surveyId = updatedSurvey.id;
     let data: any = {};
 
-    const actionClasses = await getActionClasses(updatedSurvey.workspaceId);
     const currentSurvey = await getSurvey(surveyId);
 
     if (!currentSurvey) {
       throw new ResourceNotFoundError("Survey", surveyId);
     }
 
-    const { triggers, segment, questions, languages, type, followUps, ...surveyData } = updatedSurvey;
+    // ENG-1749: workspaceId and id are the survey's tenant anchors. Always resolve the workspace from
+    // the existing survey (never the client payload), and strip workspaceId/id from the update below,
+    // so an authorized editor cannot re-point their own survey into another workspace/organization.
+    const actionClasses = await getActionClasses(currentSurvey.workspaceId);
+
+    const {
+      triggers,
+      segment,
+      questions,
+      languages,
+      type,
+      followUps,
+      workspaceId: _workspaceId,
+      id: _id,
+      ...surveyData
+    } = updatedSurvey;
 
     // ENG-1749 sibling: the segment block below updates/deletes by segment.id directly. Ensure the
     // segment belongs to this survey's workspace so a caller cannot mutate or delete another
@@ -459,7 +473,7 @@ export const updateSurveyInternal = async (
       }
     } else if (type === "app") {
       if (!currentSurvey.segment) {
-        const workspaceId = updatedSurvey.workspaceId;
+        const workspaceId = currentSurvey.workspaceId;
         await prisma.survey.update({
           where: {
             id: surveyId,

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -298,6 +298,11 @@ export const updateSurveyInternal = async (
     // tenant's segment by supplying its id. Mirrors the create path guard.
     await assertSurveySegmentBelongsToWorkspace(currentSurvey.workspaceId, segment);
 
+    // ENG-1749 sibling: the languages block below links languages by language.id. Ensure every
+    // referenced language belongs to this survey's workspace so a caller cannot attach another
+    // tenant's language. Mirrors the create path guard (covers drafts too — runs before validation).
+    assertSurveyLanguagesBelongToWorkspace(currentSurvey.workspaceId, languages);
+
     if (!skipValidation) {
       checkForInvalidImagesInQuestions(questions);
 
@@ -637,7 +642,7 @@ const validateSurveyCreateDataMedia = (
 
 const assertSurveyLanguagesBelongToWorkspace = (
   workspaceId: string,
-  languages: TSurveyCreateInput["languages"]
+  languages: Array<{ language: { id: string; workspaceId: string } }> | null | undefined
 ): void => {
   for (const surveyLanguage of languages ?? []) {
     if (surveyLanguage.language.workspaceId !== workspaceId) {

--- a/apps/web/lib/utils/resolve-client-id.test.ts
+++ b/apps/web/lib/utils/resolve-client-id.test.ts
@@ -29,7 +29,7 @@ describe("resolveClientApiIds", () => {
     });
     expect(prisma.workspace.findFirst).toHaveBeenCalledWith({
       where: { OR: [{ id: "ws-456" }, { legacyEnvironmentId: "ws-456" }] },
-      select: { id: true },
+      select: { id: true, organizationId: true },
     });
   });
 
@@ -42,7 +42,7 @@ describe("resolveClientApiIds", () => {
     expect(prisma.workspace.findFirst).toHaveBeenCalledTimes(1);
     expect(prisma.workspace.findFirst).toHaveBeenCalledWith({
       where: { OR: [{ id: "env-old-123" }, { legacyEnvironmentId: "env-old-123" }] },
-      select: { id: true },
+      select: { id: true, organizationId: true },
     });
   });
 

--- a/apps/web/lib/utils/resolve-client-id.ts
+++ b/apps/web/lib/utils/resolve-client-id.ts
@@ -9,12 +9,14 @@ export type TResolvedClientIds = {
 /**
  * Finds a workspace by its primary id or by legacyEnvironmentId in a single query.
  * Both columns have unique indexes so the query planner will use index scans.
- * Returns the workspace id if found, null otherwise.
+ * Returns the workspace id and its owning organizationId if found, null otherwise.
  */
-export const findWorkspaceByIdOrLegacyEnvId = async (id: string): Promise<{ id: string } | null> => {
+export const findWorkspaceByIdOrLegacyEnvId = async (
+  id: string
+): Promise<{ id: string; organizationId: string } | null> => {
   return await prisma.workspace.findFirst({
     where: { OR: [{ id }, { legacyEnvironmentId: id }] },
-    select: { id: true },
+    select: { id: true, organizationId: true },
   });
 };
 

--- a/apps/web/modules/api/lib/api-key-auth.test.ts
+++ b/apps/web/modules/api/lib/api-key-auth.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, test } from "vitest";
-import { getApiKeyFromHeaders, getBearerTokenFromHeaders } from "./api-key-auth";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  authenticateApiKeyFromHeaders,
+  getApiKeyFromHeaders,
+  getBearerTokenFromHeaders,
+} from "./api-key-auth";
+
+const mocks = vi.hoisted(() => ({ getApiKeyWithPermissions: vi.fn() }));
+
+vi.mock("@/modules/organization/settings/api-keys/lib/api-key", () => ({
+  getApiKeyWithPermissions: mocks.getApiKeyWithPermissions,
+}));
 
 describe("api-key-auth helpers", () => {
   test("prefers x-api-key over bearer authorization", () => {
@@ -36,5 +46,53 @@ describe("api-key-auth helpers", () => {
 
     expect(getApiKeyFromHeaders(headers)).toBeNull();
     expect(getBearerTokenFromHeaders(headers)).toBe("opaque_service_token");
+  });
+});
+
+describe("authenticateApiKeyFromHeaders — ENG-1749 cross-org permission filter", () => {
+  const headers = new Headers({ "x-api-key": "fbk_secret" });
+
+  const apiKeyData = (workspaces: unknown[]) => ({
+    id: "key1",
+    organizationId: "org-self",
+    organizationAccess: { accessControl: { read: false, write: false } },
+    apiKeyWorkspaces: workspaces,
+  });
+
+  const ws = (id: string, organizationId: string) => ({
+    permission: "manage",
+    workspaceId: id,
+    workspace: { id, name: id, organizationId },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("drops workspace permissions whose workspace is in another organization", async () => {
+    mocks.getApiKeyWithPermissions.mockResolvedValue(
+      apiKeyData([ws("ws-own", "org-self"), ws("ws-victim", "org-other")])
+    );
+
+    const auth = await authenticateApiKeyFromHeaders(headers);
+
+    expect(auth?.workspacePermissions).toEqual([
+      { permission: "manage", workspaceId: "ws-own", workspaceName: "ws-own" },
+    ]);
+  });
+
+  test("returns null when only cross-org permissions remain", async () => {
+    mocks.getApiKeyWithPermissions.mockResolvedValue(apiKeyData([ws("ws-victim", "org-other")]));
+
+    expect(await authenticateApiKeyFromHeaders(headers)).toBeNull();
+  });
+
+  test("keeps a cross-org-only key for org-scoped routes but with no workspace permissions", async () => {
+    mocks.getApiKeyWithPermissions.mockResolvedValue(apiKeyData([ws("ws-victim", "org-other")]));
+
+    const auth = await authenticateApiKeyFromHeaders(headers, { allowOrganizationOnlyApiKey: true });
+
+    expect(auth).not.toBeNull();
+    expect(auth?.workspacePermissions).toEqual([]);
   });
 });

--- a/apps/web/modules/api/lib/api-key-auth.ts
+++ b/apps/web/modules/api/lib/api-key-auth.ts
@@ -52,19 +52,32 @@ export const authenticateApiKeyFromHeaders = async (
     return null;
   }
 
+  // ENG-1749 defense-in-depth: only honor workspace permissions whose workspace belongs to the
+  // key's own organization. API keys are org-scoped, so a permission on a foreign workspace is
+  // always illegitimate (it can only exist from a pre-fix bug/exploit). Filtering here — the single
+  // point where the permission list is built — protects every consumer, including the read/list
+  // routes that authorize off this list directly rather than through resolveBodyIdsV2.
+  const workspacePermissions = (apiKeyData.apiKeyWorkspaces ?? [])
+    .filter(
+      (workspacePermission) => workspacePermission.workspace.organizationId === apiKeyData.organizationId
+    )
+    .map((workspacePermission) => ({
+      permission: workspacePermission.permission,
+      workspaceId: workspacePermission.workspaceId,
+      workspaceName: workspacePermission.workspace.name,
+    }));
+
   // Reject org-only API keys for routes that require workspace-scoped permissions
   // (those routes opt in via allowOrganizationOnlyApiKey when an org-only key is acceptable).
-  if (!options.allowOrganizationOnlyApiKey && (apiKeyData.apiKeyWorkspaces?.length ?? 0) === 0) {
+  // Uses the filtered list so a key left with only cross-org (now-dropped) permissions is treated
+  // as having no workspace access.
+  if (!options.allowOrganizationOnlyApiKey && workspacePermissions.length === 0) {
     return null;
   }
 
   return {
     type: "apiKey",
-    workspacePermissions: (apiKeyData.apiKeyWorkspaces ?? []).map((workspacePermission) => ({
-      permission: workspacePermission.permission,
-      workspaceId: workspacePermission.workspaceId,
-      workspaceName: workspacePermission.workspace.name,
-    })),
+    workspacePermissions,
     apiKeyId: apiKeyData.id,
     organizationId: apiKeyData.organizationId,
     organizationAccess: apiKeyData.organizationAccess,

--- a/apps/web/modules/api/v2/auth/tests/authenticate-request.test.ts
+++ b/apps/web/modules/api/v2/auth/tests/authenticate-request.test.ts
@@ -40,6 +40,7 @@ describe("authenticateRequest", () => {
           workspace: {
             id: "workspace-id-1",
             name: "Workspace 1",
+            organizationId: "org-id",
           },
         },
         {
@@ -49,6 +50,7 @@ describe("authenticateRequest", () => {
           workspace: {
             id: "workspace-id-2",
             name: "Workspace 2",
+            organizationId: "org-id",
           },
         },
       ],

--- a/apps/web/modules/api/v2/management/contact-attribute-keys/route.ts
+++ b/apps/web/modules/api/v2/management/contact-attribute-keys/route.ts
@@ -43,7 +43,7 @@ export const POST = async (request: NextRequest) =>
       body: ZContactAttributeKeyCreateInput,
     },
     bodyTransform: async (body, auth) => {
-      const resolved = await resolveBodyIdsV2(body, auth.workspacePermissions, "POST");
+      const resolved = await resolveBodyIdsV2(body, auth, "POST");
       if (!resolved.ok) throw resolved.error;
       return { ...body, ...resolved.data };
     },

--- a/apps/web/modules/api/v2/management/lib/workspace-resolver.test.ts
+++ b/apps/web/modules/api/v2/management/lib/workspace-resolver.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ApiKeyPermission } from "@formbricks/database/prisma";
+import { findWorkspaceByIdOrLegacyEnvId } from "@/lib/utils/resolve-client-id";
+import { resolveBodyIdsV2 } from "./workspace-resolver";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/utils/resolve-client-id", () => ({
+  findWorkspaceByIdOrLegacyEnvId: vi.fn(),
+}));
+
+const auth = (organizationId: string, workspaceId: string, permission: ApiKeyPermission) => ({
+  organizationId,
+  workspacePermissions: [{ workspaceId, permission }],
+});
+
+describe("resolveBodyIdsV2", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns bad_request when no workspaceId/environmentId is provided", async () => {
+    const result = await resolveBodyIdsV2({}, auth("org1", "ws1", ApiKeyPermission.manage), "POST");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.type).toBe("bad_request");
+    expect(findWorkspaceByIdOrLegacyEnvId).not.toHaveBeenCalled();
+  });
+
+  test("returns not_found when the workspace does not exist", async () => {
+    vi.mocked(findWorkspaceByIdOrLegacyEnvId).mockResolvedValueOnce(null);
+
+    const result = await resolveBodyIdsV2(
+      { workspaceId: "ws-missing" },
+      auth("org1", "ws-missing", ApiKeyPermission.manage),
+      "POST"
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.type).toBe("not_found");
+  });
+
+  // ENG-1749 defense-in-depth: a permission row for a workspace in another organization must not
+  // grant access, even though hasPermission alone would match on workspaceId.
+  test("returns forbidden when the workspace belongs to a different organization", async () => {
+    vi.mocked(findWorkspaceByIdOrLegacyEnvId).mockResolvedValueOnce({
+      id: "victim-ws",
+      organizationId: "victim-org",
+    });
+
+    const result = await resolveBodyIdsV2(
+      { workspaceId: "victim-ws" },
+      // Attacker's key carries a (illegitimate) manage permission on the victim workspace.
+      auth("attacker-org", "victim-ws", ApiKeyPermission.manage),
+      "POST"
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.type).toBe("forbidden");
+  });
+
+  test("returns forbidden when the key lacks permission for an in-org workspace", async () => {
+    vi.mocked(findWorkspaceByIdOrLegacyEnvId).mockResolvedValueOnce({
+      id: "ws1",
+      organizationId: "org1",
+    });
+
+    const result = await resolveBodyIdsV2(
+      { workspaceId: "ws1" },
+      auth("org1", "ws1", ApiKeyPermission.read), // read cannot POST (needs write)
+      "POST"
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.type).toBe("forbidden");
+  });
+
+  test("resolves the workspaceId for a same-org workspace the key can access", async () => {
+    vi.mocked(findWorkspaceByIdOrLegacyEnvId).mockResolvedValueOnce({
+      id: "ws1",
+      organizationId: "org1",
+    });
+
+    const result = await resolveBodyIdsV2(
+      { workspaceId: "ws1" },
+      auth("org1", "ws1", ApiKeyPermission.manage),
+      "POST"
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual({ workspaceId: "ws1" });
+  });
+});

--- a/apps/web/modules/api/v2/management/lib/workspace-resolver.ts
+++ b/apps/web/modules/api/v2/management/lib/workspace-resolver.ts
@@ -1,4 +1,4 @@
-import { TAPIKeyWorkspacePermission } from "@formbricks/types/auth";
+import { TAuthenticationApiKey } from "@formbricks/types/auth";
 import { Result, err, ok } from "@formbricks/types/error-handlers";
 import { findWorkspaceByIdOrLegacyEnvId } from "@/lib/utils/resolve-client-id";
 import { ApiErrorResponseV2 } from "@/modules/api/v2/types/api-error";
@@ -17,7 +17,7 @@ type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
  */
 export const resolveBodyIdsV2 = async (
   body: { workspaceId?: string; environmentId?: string },
-  permissions: TAPIKeyWorkspacePermission[],
+  authentication: Pick<TAuthenticationApiKey, "organizationId" | "workspacePermissions">,
   method: HttpMethod
 ): Promise<Result<{ workspaceId: string }, ApiErrorResponseV2>> => {
   const rawId = body.workspaceId ?? body.environmentId;
@@ -31,7 +31,14 @@ export const resolveBodyIdsV2 = async (
       });
     }
 
-    if (!hasPermission(permissions, workspace.id, method)) {
+    // ENG-1749 defense-in-depth: even if the API key somehow carries a permission row for this
+    // workspace, refuse it unless the workspace belongs to the key's own organization. This is a
+    // second, independent tenant boundary behind the create-time check in createApiKey.
+    if (workspace.organizationId !== authentication.organizationId) {
+      return err({ type: "forbidden" });
+    }
+
+    if (!hasPermission(authentication.workspacePermissions, workspace.id, method)) {
       return err({ type: "forbidden" });
     }
 

--- a/apps/web/modules/api/v2/management/webhooks/route.ts
+++ b/apps/web/modules/api/v2/management/webhooks/route.ts
@@ -44,7 +44,7 @@ export const POST = async (request: NextRequest) =>
       body: ZWebhookCreateInput,
     },
     bodyTransform: async (body, auth) => {
-      const resolved = await resolveBodyIdsV2(body, auth.workspacePermissions, "POST");
+      const resolved = await resolveBodyIdsV2(body, auth, "POST");
       if (!resolved.ok) throw resolved.error;
       return { ...body, ...resolved.data };
     },

--- a/apps/web/modules/ee/contacts/api/v2/management/contacts/bulk/route.ts
+++ b/apps/web/modules/ee/contacts/api/v2/management/contacts/bulk/route.ts
@@ -14,7 +14,7 @@ export const PUT = async (request: Request) =>
       body: ZContactBulkUploadRequest,
     },
     bodyTransform: async (body, auth) => {
-      const resolved = await resolveBodyIdsV2(body, auth.workspacePermissions, "PUT");
+      const resolved = await resolveBodyIdsV2(body, auth, "PUT");
       if (!resolved.ok) throw resolved.error;
       return { ...body, ...resolved.data };
     },

--- a/apps/web/modules/ee/contacts/api/v2/management/contacts/route.ts
+++ b/apps/web/modules/ee/contacts/api/v2/management/contacts/route.ts
@@ -15,7 +15,7 @@ export const POST = async (request: NextRequest) =>
       body: ZContactCreateRequest,
     },
     bodyTransform: async (body, auth) => {
-      const resolved = await resolveBodyIdsV2(body, auth.workspacePermissions, "POST");
+      const resolved = await resolveBodyIdsV2(body, auth, "POST");
       if (!resolved.ok) throw resolved.error;
       return { ...body, ...resolved.data };
     },

--- a/apps/web/modules/ee/contacts/segments/actions.test.ts
+++ b/apps/web/modules/ee/contacts/segments/actions.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { InvalidInputError } from "@formbricks/types/errors";
+
+const mocks = vi.hoisted(() => ({
+  checkAuthorizationUpdated: vi.fn(),
+  getOrganizationIdFromSegmentId: vi.fn(),
+  getWorkspaceIdFromSegmentId: vi.fn(),
+  getWorkspaceIdFromSurveyId: vi.fn(),
+  getSurveyWorkspaceIdMap: vi.fn(),
+  getIsContactsEnabled: vi.fn(),
+  getOrganization: vi.fn(),
+  updateSegment: vi.fn(),
+  getSegment: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/action-client", () => ({
+  authenticatedActionClient: {
+    inputSchema: vi.fn(() => ({ action: vi.fn((fn) => fn) })),
+  },
+}));
+
+vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
+  withAuditLogging: vi.fn((_eventName, _objectType, fn) => fn),
+}));
+
+vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
+  checkAuthorizationUpdated: mocks.checkAuthorizationUpdated,
+}));
+
+vi.mock("@/lib/utils/helper", () => ({
+  getOrganizationIdFromContactAttributeKeyId: vi.fn(),
+  getOrganizationIdFromSegmentId: mocks.getOrganizationIdFromSegmentId,
+  getOrganizationIdFromSurveyId: vi.fn(),
+  getOrganizationIdFromWorkspaceId: vi.fn(),
+  getWorkspaceIdFromContactAttributeKeyId: vi.fn(),
+  getWorkspaceIdFromSegmentId: mocks.getWorkspaceIdFromSegmentId,
+  getWorkspaceIdFromSurveyId: mocks.getWorkspaceIdFromSurveyId,
+}));
+
+vi.mock("@/modules/ee/license-check/lib/utils", () => ({
+  getIsContactsEnabled: mocks.getIsContactsEnabled,
+}));
+
+vi.mock("@/modules/ee/contacts/segments/lib/segments", () => ({
+  cloneSegment: vi.fn(),
+  createSegment: vi.fn(),
+  deleteSegment: vi.fn(),
+  getSegment: mocks.getSegment,
+  getSurveyWorkspaceIdMap: mocks.getSurveyWorkspaceIdMap,
+  resetSegmentInSurvey: vi.fn(),
+  updateSegment: mocks.updateSegment,
+}));
+
+vi.mock("@/lib/survey/service", () => ({ loadNewSegmentInSurvey: vi.fn() }));
+vi.mock("@/lib/organization/service", () => ({ getOrganization: mocks.getOrganization }));
+vi.mock("@/lib/posthog", () => ({ capturePostHogEvent: vi.fn() }));
+vi.mock("@/modules/ee/contacts/lib/contact-attributes", () => ({ getDistinctAttributeValues: vi.fn() }));
+vi.mock("@/modules/ee/contacts/segments/lib/helper", () => ({ checkForRecursiveSegmentFilter: vi.fn() }));
+
+// Import after mocks so the action client / audit wrappers are the passthrough versions.
+const { updateSegmentAction } = await import("./actions");
+
+const callUpdate = (data: Record<string, unknown>) =>
+  (updateSegmentAction as unknown as (args: unknown) => Promise<unknown>)({
+    ctx: { user: { id: "user1" }, auditLoggingCtx: {} },
+    parsedInput: { segmentId: "seg1", data },
+  });
+
+describe("updateSegmentAction — ENG-1920 cross-workspace survey re-point", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.checkAuthorizationUpdated.mockResolvedValue(undefined);
+    mocks.getOrganizationIdFromSegmentId.mockResolvedValue("org1");
+    mocks.getWorkspaceIdFromSegmentId.mockResolvedValue("ws-segment");
+    mocks.getIsContactsEnabled.mockResolvedValue(true);
+    mocks.getOrganization.mockResolvedValue({ id: "org1" });
+  });
+
+  test("rejects a survey that belongs to another workspace", async () => {
+    mocks.getSurveyWorkspaceIdMap.mockResolvedValue(new Map([["victim-survey", "ws-other"]]));
+
+    await expect(callUpdate({ surveys: ["victim-survey"] })).rejects.toThrow(InvalidInputError);
+    expect(mocks.updateSegment).not.toHaveBeenCalled();
+  });
+
+  test("rejects a survey id that does not resolve to any workspace (uniform rejection, no oracle)", async () => {
+    mocks.getSurveyWorkspaceIdMap.mockResolvedValue(new Map());
+
+    await expect(callUpdate({ surveys: ["nonexistent-survey"] })).rejects.toThrow(InvalidInputError);
+    expect(mocks.updateSegment).not.toHaveBeenCalled();
+  });
+
+  test("allows surveys in the segment's own workspace", async () => {
+    mocks.getSurveyWorkspaceIdMap.mockResolvedValue(new Map([["own-survey", "ws-segment"]]));
+    mocks.getSegment.mockResolvedValue({ id: "seg1" });
+    mocks.updateSegment.mockResolvedValue({ id: "seg1", surveys: [] });
+
+    await callUpdate({ surveys: ["own-survey"] });
+
+    expect(mocks.updateSegment).toHaveBeenCalledWith("seg1", { surveys: ["own-survey"] });
+    expect(mocks.getSurveyWorkspaceIdMap).toHaveBeenCalledWith(["own-survey"]);
+  });
+});

--- a/apps/web/modules/ee/contacts/segments/actions.ts
+++ b/apps/web/modules/ee/contacts/segments/actions.ts
@@ -26,6 +26,7 @@ import {
   createSegment,
   deleteSegment,
   getSegment,
+  getSurveyWorkspaceIdMap,
   resetSegmentInSurvey,
   updateSegment,
 } from "@/modules/ee/contacts/segments/lib/segments";
@@ -116,6 +117,7 @@ const ZUpdateSegmentAction = z.object({
 export const updateSegmentAction = authenticatedActionClient.inputSchema(ZUpdateSegmentAction).action(
   withAuditLogging("updated", "segment", async ({ ctx, parsedInput }) => {
     const organizationId = await getOrganizationIdFromSegmentId(parsedInput.segmentId);
+    const segmentWorkspaceId = await getWorkspaceIdFromSegmentId(parsedInput.segmentId);
     await checkAuthorizationUpdated({
       userId: ctx.user.id,
       organizationId,
@@ -127,12 +129,26 @@ export const updateSegmentAction = authenticatedActionClient.inputSchema(ZUpdate
         {
           type: "workspaceTeam",
           minPermission: "readWrite",
-          workspaceId: await getWorkspaceIdFromSegmentId(parsedInput.segmentId),
+          workspaceId: segmentWorkspaceId,
         },
       ],
     });
 
     await checkAdvancedTargetingPermission(organizationId);
+
+    // ENG-1920: the surveys are connected to the segment by id alone, so ensure every survey
+    // belongs to the segment's workspace — otherwise a caller could re-point another tenant's
+    // survey to their segment. A single batched lookup avoids fanning out a query per survey id
+    // over the caller-controlled array; an unknown id is absent from the map and thus rejected.
+    if (parsedInput.data.surveys && parsedInput.data.surveys.length > 0) {
+      const surveyWorkspaceIdMap = await getSurveyWorkspaceIdMap(parsedInput.data.surveys);
+      const allInSegmentWorkspace = parsedInput.data.surveys.every(
+        (surveyId) => surveyWorkspaceIdMap.get(surveyId) === segmentWorkspaceId
+      );
+      if (!allInSegmentWorkspace) {
+        throw new InvalidInputError("Survey and segment are not in the same workspace");
+      }
+    }
 
     const { filters } = parsedInput.data;
     if (filters) {

--- a/apps/web/modules/ee/contacts/segments/lib/segments.test.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/segments.test.ts
@@ -22,6 +22,7 @@ import {
   getSegment,
   getSegments,
   getSegmentsByAttributeKey,
+  getSurveyWorkspaceIdMap,
   resetSegmentInSurvey,
   selectSegment,
   transformPrismaSegment,
@@ -42,6 +43,7 @@ vi.mock("@formbricks/database", () => ({
     },
     survey: {
       update: vi.fn(),
+      findMany: vi.fn(),
     },
     $transaction: vi.fn((callback) => callback(prisma)), // Mock transaction to execute the callback
   },
@@ -164,6 +166,36 @@ describe("Segment Service Tests", () => {
     test("should throw DatabaseError on Prisma error", async () => {
       vi.mocked(prisma.segment.findMany).mockRejectedValue(new Error("DB error"));
       await expect(getSegments("workspace-id-mock")).rejects.toThrow(Error);
+    });
+  });
+
+  describe("getSurveyWorkspaceIdMap", () => {
+    test("builds an id→workspaceId map, selecting only id and workspaceId", async () => {
+      vi.mocked(prisma.survey.findMany).mockResolvedValue([
+        { id: "survey1", workspaceId: "ws-a" },
+        { id: "survey2", workspaceId: "ws-b" },
+      ] as any);
+
+      const result = await getSurveyWorkspaceIdMap(["survey1", "survey2"]);
+
+      expect(result).toEqual(
+        new Map([
+          ["survey1", "ws-a"],
+          ["survey2", "ws-b"],
+        ])
+      );
+      expect(prisma.survey.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ["survey1", "survey2"] } },
+        select: { id: true, workspaceId: true },
+      });
+    });
+
+    test("returns an empty map when no surveys match", async () => {
+      vi.mocked(prisma.survey.findMany).mockResolvedValue([] as any);
+
+      const result = await getSurveyWorkspaceIdMap(["missing"]);
+
+      expect(result.size).toBe(0);
     });
   });
 

--- a/apps/web/modules/ee/contacts/segments/lib/segments.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/segments.ts
@@ -348,6 +348,26 @@ export const resetSegmentInSurvey = async (surveyId: string): Promise<TSegment> 
   }
 };
 
+// Batched lookup of the owning workspace for a set of surveys, used to keep segment↔survey links
+// within one workspace (ENG-1920). A single query avoids fanning out one lookup per survey id over
+// a caller-controlled, unbounded array. Missing ids are simply absent from the map.
+export const getSurveyWorkspaceIdMap = reactCache(
+  async (surveyIds: string[]): Promise<Map<string, string>> => {
+    try {
+      const surveys = await prisma.survey.findMany({
+        where: { id: { in: surveyIds } },
+        select: { id: true, workspaceId: true },
+      });
+      return new Map(surveys.map((survey) => [survey.id, survey.workspaceId]));
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw new DatabaseError(error.message);
+      }
+      throw error;
+    }
+  }
+);
+
 export const updateSegment = async (segmentId: string, data: TSegmentUpdateInput): Promise<TSegment> => {
   validateInputs([segmentId, ZId], [data, ZSegmentUpdateInput]);
 

--- a/apps/web/modules/ee/quotas/lib/quotas.test.ts
+++ b/apps/web/modules/ee/quotas/lib/quotas.test.ts
@@ -193,10 +193,23 @@ describe("Quota Service", () => {
       const result = await updateQuota(updateInput, mockQuotaId);
 
       expect(result).toEqual(updatedQuota);
+      // surveyId is immutable on update (ENG-1749) and is stripped from the persisted data.
+      const { surveyId: _omittedSurveyId, ...expectedData } = updateInput;
       expect(prisma.surveyQuota.update).toHaveBeenCalledWith({
         where: { id: mockQuotaId },
-        data: updateInput,
+        data: expectedData,
       });
+    });
+
+    // ENG-1749 sibling: updateQuota must not re-point a quota to a different (potentially
+    // cross-tenant) survey. Even when a foreign surveyId is supplied, it must not be persisted.
+    test("never persists a caller-supplied surveyId", async () => {
+      vi.mocked(prisma.surveyQuota.update).mockResolvedValue(mockQuota);
+
+      await updateQuota({ ...updateInput, surveyId: "clvictimsurvey0000000000001" }, mockQuotaId);
+
+      const arg = vi.mocked(prisma.surveyQuota.update).mock.calls[0][0];
+      expect(arg.data).not.toHaveProperty("surveyId");
     });
 
     test("should throw DatabaseError when quota not found", async () => {

--- a/apps/web/modules/ee/quotas/lib/quotas.ts
+++ b/apps/web/modules/ee/quotas/lib/quotas.ts
@@ -72,9 +72,13 @@ export const createQuota = async (quota: TSurveyQuotaInput): Promise<TSurveyQuot
 
 export const updateQuota = async (quota: TSurveyQuotaInput, id: string): Promise<TSurveyQuota> => {
   try {
+    // ENG-1749: surveyId is the quota's tenant anchor, set at creation and immutable thereafter.
+    // Persisting a caller-supplied surveyId here would let an authorized quota owner re-point their
+    // quota onto another tenant's survey, so it is stripped from the update payload.
+    const { surveyId: _surveyId, ...quotaData } = quota;
     const updatedQuota = await prisma.surveyQuota.update({
       where: { id },
-      data: quota,
+      data: quotaData,
     });
 
     return updatedQuota;

--- a/apps/web/modules/organization/settings/api-keys/lib/api-key.ts
+++ b/apps/web/modules/organization/settings/api-keys/lib/api-key.ts
@@ -6,10 +6,11 @@ import { ApiKey, ApiKeyPermission, Prisma } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { TOrganizationAccess } from "@formbricks/types/api-key";
 import { ZId } from "@formbricks/types/common";
-import { DatabaseError } from "@formbricks/types/errors";
+import { DatabaseError, OperationNotAllowedError } from "@formbricks/types/errors";
 import { CONTROL_HASH } from "@/lib/constants";
 import { hashSecret, hashSha256, parseApiKeyV2, verifySecret } from "@/lib/crypto";
 import { validateInputs } from "@/lib/utils/validate";
+import { getWorkspacesByOrganizationId } from "@/modules/organization/settings/api-keys/lib/workspaces";
 import {
   TApiKeyCreateInput,
   TApiKeyUpdateInput,
@@ -161,6 +162,24 @@ export const createApiKey = async (
 ): Promise<TApiKeyWithEnvironmentPermission & { actualKey: string }> => {
   validateInputs([organizationId, ZId], [apiKeyData, ZApiKeyCreateInput]);
   try {
+    // ENG-1749: an API key is created at the organization level but carries per-workspace
+    // permissions. Reject any workspace that does not belong to the authorized organization,
+    // otherwise a caller could mint a key scoped to another tenant's workspace (cross-tenant
+    // BOLA). Validate before generating/hashing the secret so illegitimate input does no work.
+    const { workspacePermissions, organizationAccess, ...apiKeyDataWithoutPermissions } = apiKeyData;
+    if (workspacePermissions && workspacePermissions.length > 0) {
+      const orgWorkspaceIds = new Set(
+        (await getWorkspacesByOrganizationId(organizationId)).map((workspace) => workspace.id)
+      );
+      for (const { workspaceId } of workspacePermissions) {
+        if (!orgWorkspaceIds.has(workspaceId)) {
+          throw new OperationNotAllowedError(
+            `Workspace ${workspaceId} does not belong to organization ${organizationId}`
+          );
+        }
+      }
+    }
+
     // Generate a secure random secret (32 bytes base64url)
     const secret = randomBytes(32).toString("base64url");
 
@@ -170,8 +189,6 @@ export const createApiKey = async (
 
     // 2. bcrypt hash
     const hashedKey = await hashSecret(secret, 12);
-
-    const { workspacePermissions, organizationAccess, ...apiKeyDataWithoutPermissions } = apiKeyData;
 
     // Create the API key
     const result = await prisma.apiKey.create({

--- a/apps/web/modules/organization/settings/api-keys/lib/api-key.ts
+++ b/apps/web/modules/organization/settings/api-keys/lib/api-key.ts
@@ -62,6 +62,10 @@ export const getApiKeyWithPermissions = reactCache(
               select: {
                 id: true,
                 name: true,
+                // ENG-1749: needed so the auth layer can drop any workspace permission whose
+                // workspace is outside the key's organization (defense-in-depth for the read path,
+                // which authorizes off the permission list rather than resolveBodyIdsV2).
+                organizationId: true,
               },
             },
           },

--- a/apps/web/modules/organization/settings/api-keys/lib/api-keys.test.ts
+++ b/apps/web/modules/organization/settings/api-keys/lib/api-keys.test.ts
@@ -349,7 +349,7 @@ describe("API Key Management", () => {
           apiKeyWorkspaces: {
             include: {
               workspace: {
-                select: { id: true, name: true },
+                select: { id: true, name: true, organizationId: true },
               },
             },
           },
@@ -371,7 +371,7 @@ describe("API Key Management", () => {
           apiKeyWorkspaces: {
             include: {
               workspace: {
-                select: { id: true, name: true },
+                select: { id: true, name: true, organizationId: true },
               },
             },
           },

--- a/apps/web/modules/organization/settings/api-keys/lib/api-keys.test.ts
+++ b/apps/web/modules/organization/settings/api-keys/lib/api-keys.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { ApiKey, ApiKeyPermission, Prisma } from "@formbricks/database/prisma";
-import { DatabaseError } from "@formbricks/types/errors";
+import { DatabaseError, OperationNotAllowedError } from "@formbricks/types/errors";
 import { TApiKeyWithEnvironmentPermission } from "../types/api-keys";
 import {
   createApiKey,
@@ -10,6 +10,7 @@ import {
   getApiKeysWithEnvironmentPermissions,
   updateApiKey,
 } from "./api-key";
+import { getWorkspacesByOrganizationId } from "./workspaces";
 
 const mockApiKey: ApiKey = {
   id: "apikey123",
@@ -50,6 +51,10 @@ vi.mock("@formbricks/database", () => ({
       update: vi.fn(),
     },
   },
+}));
+
+vi.mock("./workspaces", () => ({
+  getWorkspacesByOrganizationId: vi.fn(),
 }));
 
 vi.mock("crypto", async () => {
@@ -452,6 +457,9 @@ describe("API Key Management", () => {
     });
 
     test("creates an API key with environment permissions successfully", async () => {
+      vi.mocked(getWorkspacesByOrganizationId).mockResolvedValueOnce([
+        { id: "workspace123", name: "Workspace 123" },
+      ]);
       vi.mocked(prisma.apiKey.create).mockResolvedValueOnce(mockApiKeyWithEnvironments);
 
       const result = await createApiKey("org123", "user123", {
@@ -461,6 +469,23 @@ describe("API Key Management", () => {
 
       expect(result).toEqual({ ...mockApiKeyWithEnvironments, actualKey: "fbk_testSecret123" });
       expect(prisma.apiKey.create).toHaveBeenCalled();
+    });
+
+    test("rejects a workspace permission for a workspace outside the organization (ENG-1749)", async () => {
+      // The organization owns only "own-workspace"; the caller attempts to scope the key to a
+      // victim organization's workspace. This must be refused before any key is persisted.
+      vi.mocked(getWorkspacesByOrganizationId).mockResolvedValueOnce([
+        { id: "own-workspace", name: "Own Workspace" },
+      ]);
+
+      await expect(
+        createApiKey("org123", "user123", {
+          ...mockApiKeyData,
+          workspacePermissions: [{ workspaceId: "victim-workspace", permission: ApiKeyPermission.manage }],
+        })
+      ).rejects.toThrow(OperationNotAllowedError);
+      expect(getWorkspacesByOrganizationId).toHaveBeenCalledWith("org123");
+      expect(prisma.apiKey.create).not.toHaveBeenCalled();
     });
 
     test("rejects create input with duplicate workspaceId", async () => {

--- a/apps/web/modules/organization/settings/api-keys/types/api-keys.ts
+++ b/apps/web/modules/organization/settings/api-keys/types/api-keys.ts
@@ -59,7 +59,7 @@ const ZApiKeyWorkspaceWithWorkspace = z.object({
   apiKeyId: z.string(),
   workspaceId: z.string(),
   permission: ZApiKeyPermission,
-  workspace: ZWorkspace.pick({ id: true, name: true }),
+  workspace: ZWorkspace.pick({ id: true, name: true, organizationId: true }),
 });
 
 const ZApiKey = z.object({

--- a/apps/web/modules/workspaces/settings/lib/workspace.test.ts
+++ b/apps/web/modules/workspaces/settings/lib/workspace.test.ts
@@ -102,6 +102,14 @@ describe("workspace lib", () => {
       const result = await updateWorkspace("p1", { name: "Workspace 1" });
       expect(result).toEqual({ ...baseWorkspace, id: 123 });
     });
+
+    // ENG-1919: a workspace must not be moved to another organization via update.
+    test("never persists a caller-supplied organizationId", async () => {
+      vi.mocked(prisma.workspace.update).mockResolvedValueOnce(baseWorkspace as any);
+      await updateWorkspace("p1", { name: "Workspace 1", organizationId: "attacker-target-org" });
+      const arg = vi.mocked(prisma.workspace.update).mock.calls[0][0];
+      expect(arg.data).not.toHaveProperty("organizationId");
+    });
   });
 
   describe("createWorkspace", () => {

--- a/apps/web/modules/workspaces/settings/lib/workspace.test.ts
+++ b/apps/web/modules/workspaces/settings/lib/workspace.test.ts
@@ -4,12 +4,13 @@ import { Prisma } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { StorageErrorCode } from "@formbricks/storage";
 import { DatabaseError, InvalidInputError, ValidationError } from "@formbricks/types/errors";
+import { TWorkspace } from "@formbricks/types/workspace";
 import { deleteFilesByWorkspaceId } from "@/modules/storage/service";
 import { createWorkspace, deleteWorkspace, updateWorkspace } from "./workspace";
 
 vi.mock("server-only", () => ({}));
 
-const baseWorkspace = {
+const baseWorkspace: TWorkspace = {
   id: "p1",
   createdAt: new Date(),
   updatedAt: new Date(),
@@ -77,7 +78,7 @@ describe("workspace lib", () => {
 
   describe("updateWorkspace", () => {
     test("updates workspace and revalidates cache", async () => {
-      vi.mocked(prisma.workspace.update).mockResolvedValueOnce(baseWorkspace as any);
+      vi.mocked(prisma.workspace.update).mockResolvedValueOnce(baseWorkspace);
       const result = await updateWorkspace("p1", {
         name: "Workspace 1",
       });
@@ -105,7 +106,7 @@ describe("workspace lib", () => {
 
     // ENG-1919: a workspace must not be moved to another organization via update.
     test("never persists a caller-supplied organizationId", async () => {
-      vi.mocked(prisma.workspace.update).mockResolvedValueOnce(baseWorkspace as any);
+      vi.mocked(prisma.workspace.update).mockResolvedValueOnce(baseWorkspace);
       await updateWorkspace("p1", { name: "Workspace 1", organizationId: "attacker-target-org" });
       const arg = vi.mocked(prisma.workspace.update).mock.calls[0][0];
       expect(arg.data).not.toHaveProperty("organizationId");

--- a/apps/web/modules/workspaces/settings/lib/workspace.ts
+++ b/apps/web/modules/workspaces/settings/lib/workspace.ts
@@ -77,7 +77,10 @@ export const updateWorkspace = async (
   inputWorkspace: TWorkspaceUpdateInput
 ): Promise<TWorkspace> => {
   validateInputs([workspaceId, ZId], [inputWorkspace, ZWorkspaceUpdateInput]);
-  const { ...data } = inputWorkspace;
+  // ENG-1919: organizationId is the workspace's tenant anchor, set at creation and immutable on
+  // update. Persisting a caller-supplied organizationId here would let an authorized workspace
+  // owner move their workspace (and all its data) into another organization, so it is stripped.
+  const { organizationId: _organizationId, ...data } = inputWorkspace;
   let updatedWorkspace;
   try {
     updatedWorkspace = await prisma.workspace.update({


### PR DESCRIPTION
## What & why

Tightens tenant scoping across several server-side management and API paths so each operation is
constrained to the caller's own organization / workspace. It closes cases where a nested identifier
in a request (a workspace / segment / survey / language id, a relation to `connect`, or a spread
object) could reference or affect a resource belonging to another tenant. Security hardening — context
in ENG-1749.

## Changes

- **API keys** — reject workspace permissions outside the key's organization at creation; drop any
  cross-organization permission when authenticating (protects the read/list routes) and when resolving
  workspace ids on the write routes; same organization filter applied on `/api/v1/management/me`.
- **Surveys (update path)** — scope the referenced segment and languages to the survey's workspace
  (owner resolved from the DB, not the request), validate that connected surveys belong to that
  workspace, and allow-list mutable segment fields instead of spreading the input object.
- **Quotas** — `surveyId` is treated as immutable on update.
- **Workspaces** — `organizationId` is treated as immutable on update.
- **Segments / integrations** — validate segment↔survey workspace membership; scope the google-sheets
  integration action to the authorized workspace.

## Testing

- Touched unit suites pass; `typecheck` and `lint` are clean. Each guard has a colocated test
  (mutation-checked — the test fails if the guard is removed).
- Full CI runs on this PR.

Backports to `release/5.1` and `release/5.2` accompany this (for 5.1.5 / 5.2.1 patch releases).
