### PR TITLE
fix(scheduling): drop NEXT_PUBLIC_ prefix from survey scheduling env vars (ENG-1665)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,11 +44,12 @@ LOG_LEVEL=info
 # Number of concurrent jobs each BullMQ worker can process.
 # BULLMQ_WORKER_CONCURRENCY=1
 
-# Survey publish/close scheduling is configured with public build-time env vars because the editor UI
-# also needs to render the selected execution time and timezone.
-# NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE=Europe/Berlin
-# NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR=0
-# NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE=0
+# Survey publish/close scheduling execution time. These are server-side runtime env vars, so
+# self-hosted Docker deployments can change them without rebuilding the image. The editor UI
+# receives the configured values from the server to render the selected execution time and timezone.
+# SURVEY_SCHEDULING_TIME_ZONE=Europe/Berlin
+# SURVEY_SCHEDULING_LOCAL_HOUR=0
+# SURVEY_SCHEDULING_LOCAL_MINUTE=0
 
 ##############
 #  DATABASE  #

--- a/apps/web/lib/env.test.ts
+++ b/apps/web/lib/env.test.ts
@@ -301,35 +301,35 @@ describe("env", () => {
 
   test("uses the default survey scheduling configuration when env vars are not set", async () => {
     setTestEnv({
-      NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR: undefined,
-      NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE: undefined,
-      NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE: undefined,
+      SURVEY_SCHEDULING_LOCAL_HOUR: undefined,
+      SURVEY_SCHEDULING_LOCAL_MINUTE: undefined,
+      SURVEY_SCHEDULING_TIME_ZONE: undefined,
     });
 
     const { env } = await import("./env");
 
-    expect(env.NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE).toBe("Europe/Berlin");
-    expect(env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR).toBe(0);
-    expect(env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE).toBe(0);
+    expect(env.SURVEY_SCHEDULING_TIME_ZONE).toBe("Europe/Berlin");
+    expect(env.SURVEY_SCHEDULING_LOCAL_HOUR).toBe(0);
+    expect(env.SURVEY_SCHEDULING_LOCAL_MINUTE).toBe(0);
   });
 
   test("uses the configured survey scheduling configuration", async () => {
     setTestEnv({
-      NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR: "18",
-      NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE: "45",
-      NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE: "America/New_York",
+      SURVEY_SCHEDULING_LOCAL_HOUR: "18",
+      SURVEY_SCHEDULING_LOCAL_MINUTE: "45",
+      SURVEY_SCHEDULING_TIME_ZONE: "America/New_York",
     });
 
     const { env } = await import("./env");
 
-    expect(env.NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE).toBe("America/New_York");
-    expect(env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR).toBe(18);
-    expect(env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE).toBe(45);
+    expect(env.SURVEY_SCHEDULING_TIME_ZONE).toBe("America/New_York");
+    expect(env.SURVEY_SCHEDULING_LOCAL_HOUR).toBe(18);
+    expect(env.SURVEY_SCHEDULING_LOCAL_MINUTE).toBe(45);
   });
 
   test("fails to load when the survey scheduling timezone is invalid", async () => {
     setTestEnv({
-      NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE: "Mars/OlympusMons",
+      SURVEY_SCHEDULING_TIME_ZONE: "Mars/OlympusMons",
     });
 
     await expect(import("./env")).rejects.toThrow("Invalid environment variables");
@@ -337,7 +337,7 @@ describe("env", () => {
 
   test("fails to load when the survey scheduling hour is out of range", async () => {
     setTestEnv({
-      NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR: "24",
+      SURVEY_SCHEDULING_LOCAL_HOUR: "24",
     });
 
     await expect(import("./env")).rejects.toThrow("Invalid environment variables");
@@ -345,7 +345,7 @@ describe("env", () => {
 
   test("fails to load when the survey scheduling minute is out of range", async () => {
     setTestEnv({
-      NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE: "60",
+      SURVEY_SCHEDULING_LOCAL_MINUTE: "60",
     });
 
     await expect(import("./env")).rejects.toThrow("Invalid environment variables");

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -192,7 +192,7 @@ const isValidIanaTimeZone = (value: string): boolean => {
 };
 
 const ZSurveySchedulingTimeZone = z.string().trim().min(1).refine(isValidIanaTimeZone, {
-  message: "NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE must be a valid IANA time zone",
+  message: "SURVEY_SCHEDULING_TIME_ZONE must be a valid IANA time zone",
 });
 
 const ZSurveySchedulingLocalHour = z.coerce.number().int().min(0).max(23);
@@ -374,12 +374,11 @@ const parsedEnv = createEnv({
       .transform((val) => Number.parseInt(val, 10))
       .optional(),
     SENTRY_ENVIRONMENT: z.string().optional(),
+    SURVEY_SCHEDULING_TIME_ZONE: ZSurveySchedulingTimeZone.optional().default("Europe/Berlin"),
+    SURVEY_SCHEDULING_LOCAL_HOUR: ZSurveySchedulingLocalHour.optional().default(0),
+    SURVEY_SCHEDULING_LOCAL_MINUTE: ZSurveySchedulingLocalMinute.optional().default(0),
   },
-  client: {
-    NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE: ZSurveySchedulingTimeZone.optional().default("Europe/Berlin"),
-    NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR: ZSurveySchedulingLocalHour.optional().default(0),
-    NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE: ZSurveySchedulingLocalMinute.optional().default(0),
-  },
+  client: {},
 
   /*
    * Due to how Next.js bundles environment variables on Edge and Client,
@@ -464,9 +463,9 @@ const parsedEnv = createEnv({
     MAIL_FROM_NAME: process.env.MAIL_FROM_NAME,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
-    NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR: process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR,
-    NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE: process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE,
-    NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE: process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE,
+    SURVEY_SCHEDULING_LOCAL_HOUR: process.env.SURVEY_SCHEDULING_LOCAL_HOUR,
+    SURVEY_SCHEDULING_LOCAL_MINUTE: process.env.SURVEY_SCHEDULING_LOCAL_MINUTE,
+    SURVEY_SCHEDULING_TIME_ZONE: process.env.SURVEY_SCHEDULING_TIME_ZONE,
     SENTRY_DSN: process.env.SENTRY_DSN,
     NOTION_OAUTH_CLIENT_ID: process.env.NOTION_OAUTH_CLIENT_ID,
     NOTION_OAUTH_CLIENT_SECRET: process.env.NOTION_OAUTH_CLIENT_SECRET,

--- a/apps/web/modules/survey/editor/components/response-options-card.tsx
+++ b/apps/web/modules/survey/editor/components/response-options-card.tsx
@@ -39,7 +39,7 @@ export const ResponseOptionsCard = ({
   isSpamProtectionAllowed,
   surveySchedulingConfig,
   locale,
-}: ResponseOptionsCardProps) => {
+}: Readonly<ResponseOptionsCardProps>) => {
   const { t } = useTranslation();
   const { toCalendarDate, getMinimumSurveySchedulingCalendarDate } = useMemo(
     () => createSurveySchedulingDateUtils(surveySchedulingConfig),

--- a/apps/web/modules/survey/editor/components/response-options-card.tsx
+++ b/apps/web/modules/survey/editor/components/response-options-card.tsx
@@ -2,19 +2,18 @@
 
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { CheckIcon } from "lucide-react";
-import { KeyboardEventHandler, useEffect, useState } from "react";
+import { KeyboardEventHandler, useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { Trans, useTranslation } from "react-i18next";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
 import { cn } from "@/lib/cn";
 import {
-  SURVEY_SCHEDULING_TIME_LABEL,
-  SURVEY_SCHEDULING_TIME_ZONE_LABEL,
-} from "@/modules/survey/scheduling/lib/constants";
+  type TSurveySchedulingConfig,
+  getSurveySchedulingTimeLabel,
+} from "@/modules/survey/scheduling/lib/config";
 import {
-  getMinimumSurveySchedulingCalendarDate,
-  toCalendarDate,
+  createSurveySchedulingDateUtils,
   toDateOnlySelection,
 } from "@/modules/survey/scheduling/lib/date-utils";
 import { AdvancedOptionToggle } from "@/modules/ui/components/advanced-option-toggle";
@@ -29,6 +28,7 @@ interface ResponseOptionsCardProps {
   setLocalSurvey: (survey: TSurvey | ((prev: TSurvey) => TSurvey)) => void;
   responseCount: number;
   isSpamProtectionAllowed: boolean;
+  surveySchedulingConfig: TSurveySchedulingConfig;
   locale: TUserLocale;
 }
 
@@ -37,9 +37,16 @@ export const ResponseOptionsCard = ({
   setLocalSurvey,
   responseCount,
   isSpamProtectionAllowed,
+  surveySchedulingConfig,
   locale,
 }: ResponseOptionsCardProps) => {
   const { t } = useTranslation();
+  const { toCalendarDate, getMinimumSurveySchedulingCalendarDate } = useMemo(
+    () => createSurveySchedulingDateUtils(surveySchedulingConfig),
+    [surveySchedulingConfig]
+  );
+  const surveySchedulingTimeLabel = getSurveySchedulingTimeLabel(surveySchedulingConfig);
+  const surveySchedulingTimeZoneLabel = surveySchedulingConfig.timeZone;
   const [open, setOpen] = useState(localSurvey.type === "link");
   const autoComplete = localSurvey.autoComplete !== null;
   const [surveyClosedMessageToggle, setSurveyClosedMessageToggle] = useState(false);
@@ -193,7 +200,7 @@ export const ResponseOptionsCard = ({
         closeOn: null,
       };
     });
-  }, [closeOn, publishOn, setLocalSurvey]);
+  }, [closeOn, publishOn, setLocalSurvey, toCalendarDate]);
 
   const togglePublishOnDate = () => {
     if (isPublishOnDateEnabled) {
@@ -331,8 +338,8 @@ export const ResponseOptionsCard = ({
             onToggle={togglePublishOnDate}
             title={t("workspace.surveys.edit.publish_survey_on_date")}
             description={t("workspace.surveys.edit.survey_will_be_published_at_midnight_cet", {
-              time: SURVEY_SCHEDULING_TIME_LABEL,
-              timeZone: SURVEY_SCHEDULING_TIME_ZONE_LABEL,
+              time: surveySchedulingTimeLabel,
+              timeZone: surveySchedulingTimeZoneLabel,
             })}
             childBorder={true}>
             <div className="p-4">
@@ -371,8 +378,8 @@ export const ResponseOptionsCard = ({
             onToggle={toggleCloseOnDate}
             title={t("workspace.surveys.edit.close_survey_on_date")}
             description={t("workspace.surveys.edit.survey_will_be_closed_at_midnight_cet", {
-              time: SURVEY_SCHEDULING_TIME_LABEL,
-              timeZone: SURVEY_SCHEDULING_TIME_ZONE_LABEL,
+              time: surveySchedulingTimeLabel,
+              timeZone: surveySchedulingTimeZoneLabel,
             })}
             childBorder={true}>
             <div className="p-4">

--- a/apps/web/modules/survey/editor/components/settings-view.tsx
+++ b/apps/web/modules/survey/editor/components/settings-view.tsx
@@ -14,6 +14,7 @@ import { ResponseOptionsCard } from "@/modules/survey/editor/components/response
 import { SurveyPlacementCard } from "@/modules/survey/editor/components/survey-placement-card";
 import { TargetingLockedCard } from "@/modules/survey/editor/components/targeting-locked-card";
 import { WhenToSendCard } from "@/modules/survey/editor/components/when-to-send-card";
+import { type TSurveySchedulingConfig } from "@/modules/survey/scheduling/lib/config";
 
 interface SettingsViewProps {
   localSurvey: TSurvey;
@@ -29,6 +30,7 @@ interface SettingsViewProps {
   isFormbricksCloud: boolean;
   isQuotasAllowed: boolean;
   quotas: TSurveyQuota[];
+  surveySchedulingConfig: TSurveySchedulingConfig;
   locale: TUserLocale;
   appSetupCompleted: boolean;
   enterpriseLicenseRequestFormUrl: string;
@@ -48,6 +50,7 @@ export const SettingsView = ({
   workspacePermission,
   isFormbricksCloud,
   quotas,
+  surveySchedulingConfig,
   locale,
   appSetupCompleted,
   enterpriseLicenseRequestFormUrl,
@@ -108,6 +111,7 @@ export const SettingsView = ({
         setLocalSurvey={setLocalSurvey}
         responseCount={responseCount}
         isSpamProtectionAllowed={isSpamProtectionAllowed}
+        surveySchedulingConfig={surveySchedulingConfig}
         locale={locale}
       />
 

--- a/apps/web/modules/survey/editor/components/survey-editor.tsx
+++ b/apps/web/modules/survey/editor/components/survey-editor.tsx
@@ -21,6 +21,7 @@ import { SurveyMenuBar } from "@/modules/survey/editor/components/survey-menu-ba
 import { TFollowUpEmailToUser } from "@/modules/survey/editor/types/survey-follow-up";
 import { FollowUpsView } from "@/modules/survey/follow-ups/components/follow-ups-view";
 import { LanguageView } from "@/modules/survey/multi-language-surveys/components/language-view";
+import { type TSurveySchedulingConfig } from "@/modules/survey/scheduling/lib/config";
 import { PreviewSurvey } from "@/modules/ui/components/preview-survey";
 import { getWorkspaceLanguagesAction, refetchWorkspaceAction } from "../actions";
 
@@ -39,6 +40,7 @@ interface SurveyEditorProps {
   isUnsplashConfigured: boolean;
   isQuotasAllowed: boolean;
   isCxMode: boolean;
+  surveySchedulingConfig: TSurveySchedulingConfig;
   locale: TUserLocale;
   workspacePermission: TTeamPermission | null;
   mailFrom: string;
@@ -69,6 +71,7 @@ export const SurveyEditor = ({
   isUnsplashConfigured,
   isQuotasAllowed,
   isCxMode = false,
+  surveySchedulingConfig,
   locale,
   workspacePermission,
   mailFrom,
@@ -266,6 +269,7 @@ export const SurveyEditor = ({
               isFormbricksCloud={isFormbricksCloud}
               isQuotasAllowed={isQuotasAllowed}
               quotas={quotas}
+              surveySchedulingConfig={surveySchedulingConfig}
               locale={locale}
               appSetupCompleted={localWorkspace.appSetupCompleted}
               enterpriseLicenseRequestFormUrl={enterpriseLicenseRequestFormUrl}

--- a/apps/web/modules/survey/editor/page.tsx
+++ b/apps/web/modules/survey/editor/page.tsx
@@ -27,6 +27,7 @@ import { getExternalUrlsPermission } from "@/modules/survey/lib/permission";
 import { getResponseCountBySurveyId } from "@/modules/survey/lib/response";
 import { getOrganizationBilling, getSurvey } from "@/modules/survey/lib/survey";
 import { getWorkspaceWithTeamIds } from "@/modules/survey/lib/workspace";
+import { SURVEY_SCHEDULING_CONFIG } from "@/modules/survey/scheduling/lib/constants";
 import { ErrorComponent } from "@/modules/ui/components/error-component";
 import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
 import { SurveyEditor } from "./components/survey-editor";
@@ -128,6 +129,7 @@ export const SurveyEditorPage = async (props: {
       isFormbricksCloud={IS_FORMBRICKS_CLOUD}
       isUnsplashConfigured={!!UNSPLASH_ACCESS_KEY}
       isCxMode={isCxMode}
+      surveySchedulingConfig={SURVEY_SCHEDULING_CONFIG}
       locale={locale ?? DEFAULT_LOCALE}
       mailFrom={MAIL_FROM ?? "hola@formbricks.com"}
       isSurveyFollowUpsAllowed={isSurveyFollowUpsAllowed}

--- a/apps/web/modules/survey/scheduling/lib/config.ts
+++ b/apps/web/modules/survey/scheduling/lib/config.ts
@@ -1,0 +1,10 @@
+export interface TSurveySchedulingConfig {
+  timeZone: string;
+  localHour: number;
+  localMinute: number;
+}
+
+const padSchedulingTimePart = (value: number): string => value.toString().padStart(2, "0");
+
+export const getSurveySchedulingTimeLabel = (config: TSurveySchedulingConfig): string =>
+  `${padSchedulingTimePart(config.localHour)}:${padSchedulingTimePart(config.localMinute)}`;

--- a/apps/web/modules/survey/scheduling/lib/constants.test.ts
+++ b/apps/web/modules/survey/scheduling/lib/constants.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const ORIGINAL_ENV = process.env;
+
+const setSchedulingEnv = (overrides: Record<string, string | undefined> = {}) => {
+  process.env = {
+    ...ORIGINAL_ENV,
+    SURVEY_SCHEDULING_TIME_ZONE: undefined,
+    SURVEY_SCHEDULING_LOCAL_HOUR: undefined,
+    SURVEY_SCHEDULING_LOCAL_MINUTE: undefined,
+    ...overrides,
+  };
+};
+
+describe("survey scheduling constants", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  test("defaults to Europe/Berlin at midnight when env vars are unset", async () => {
+    setSchedulingEnv();
+
+    const constants = await import("./constants");
+
+    expect(constants.SURVEY_SCHEDULING_CONFIG).toEqual({
+      timeZone: "Europe/Berlin",
+      localHour: 0,
+      localMinute: 0,
+    });
+    expect(constants.SURVEY_SCHEDULING_TIME_LABEL).toBe("00:00");
+    expect(constants.SURVEY_SCHEDULING_DAILY_CRON_PATTERN).toBe("0 0 * * *");
+  });
+
+  test("reads a valid runtime configuration from server-side env vars", async () => {
+    setSchedulingEnv({
+      SURVEY_SCHEDULING_TIME_ZONE: "America/New_York",
+      SURVEY_SCHEDULING_LOCAL_HOUR: "18",
+      SURVEY_SCHEDULING_LOCAL_MINUTE: "45",
+    });
+
+    const constants = await import("./constants");
+
+    expect(constants.SURVEY_SCHEDULING_CONFIG).toEqual({
+      timeZone: "America/New_York",
+      localHour: 18,
+      localMinute: 45,
+    });
+    expect(constants.SURVEY_SCHEDULING_TIME_LABEL).toBe("18:45");
+    expect(constants.SURVEY_SCHEDULING_DAILY_CRON_PATTERN).toBe("45 18 * * *");
+  });
+});

--- a/apps/web/modules/survey/scheduling/lib/constants.ts
+++ b/apps/web/modules/survey/scheduling/lib/constants.ts
@@ -1,40 +1,15 @@
+import { env } from "@/lib/env";
 import { type TSurveySchedulingConfig, getSurveySchedulingTimeLabel } from "./config";
 
-const parseSchedulingTimePart = (
-  value: string | undefined,
-  fallback: number,
-  { min, max }: { min: number; max: number }
-): number => {
-  if (!value) {
-    return fallback;
-  }
-
-  const parsedValue = Number.parseInt(value, 10);
-
-  if (!Number.isInteger(parsedValue) || parsedValue < min || parsedValue > max) {
-    return fallback;
-  }
-
-  return parsedValue;
-};
-
 // Read at runtime from server-only env vars (no NEXT_PUBLIC_ prefix) so self-hosted Docker
-// deployments can configure the scheduling execution time without rebuilding the image. The
-// editor UI receives these values as props instead of importing this module on the client.
-export const SURVEY_SCHEDULING_TIME_ZONE = process.env.SURVEY_SCHEDULING_TIME_ZONE ?? "Europe/Berlin";
-export const SURVEY_SCHEDULING_LOCAL_HOUR = parseSchedulingTimePart(
-  process.env.SURVEY_SCHEDULING_LOCAL_HOUR,
-  0,
-  {
-    min: 0,
-    max: 23,
-  }
-);
-export const SURVEY_SCHEDULING_LOCAL_MINUTE = parseSchedulingTimePart(
-  process.env.SURVEY_SCHEDULING_LOCAL_MINUTE,
-  0,
-  { min: 0, max: 59 }
-);
+// deployments can configure the scheduling execution time without rebuilding the image. Values
+// are validated and normalized in apps/web/lib/env.ts (single source of truth): the time zone is
+// checked against Intl.DateTimeFormat and hour/minute are coerced to their valid ranges, so a bad
+// override is rejected there instead of silently reaching Intl.DateTimeFormat here. The editor UI
+// receives these values as props instead of importing this module on the client.
+export const SURVEY_SCHEDULING_TIME_ZONE = env.SURVEY_SCHEDULING_TIME_ZONE;
+export const SURVEY_SCHEDULING_LOCAL_HOUR = env.SURVEY_SCHEDULING_LOCAL_HOUR;
+export const SURVEY_SCHEDULING_LOCAL_MINUTE = env.SURVEY_SCHEDULING_LOCAL_MINUTE;
 
 export const SURVEY_SCHEDULING_CONFIG: TSurveySchedulingConfig = {
   timeZone: SURVEY_SCHEDULING_TIME_ZONE,

--- a/apps/web/modules/survey/scheduling/lib/constants.ts
+++ b/apps/web/modules/survey/scheduling/lib/constants.ts
@@ -1,4 +1,4 @@
-const padSchedulingTimePart = (value: number): string => value.toString().padStart(2, "0");
+import { type TSurveySchedulingConfig, getSurveySchedulingTimeLabel } from "./config";
 
 const parseSchedulingTimePart = (
   value: string | undefined,
@@ -18,20 +18,31 @@ const parseSchedulingTimePart = (
   return parsedValue;
 };
 
-// Use static NEXT_PUBLIC_* lookups so these values can be safely inlined into client bundles.
-export const SURVEY_SCHEDULING_TIME_ZONE =
-  process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE ?? "Europe/Berlin";
+// Read at runtime from server-only env vars (no NEXT_PUBLIC_ prefix) so self-hosted Docker
+// deployments can configure the scheduling execution time without rebuilding the image. The
+// editor UI receives these values as props instead of importing this module on the client.
+export const SURVEY_SCHEDULING_TIME_ZONE = process.env.SURVEY_SCHEDULING_TIME_ZONE ?? "Europe/Berlin";
 export const SURVEY_SCHEDULING_LOCAL_HOUR = parseSchedulingTimePart(
-  process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR,
+  process.env.SURVEY_SCHEDULING_LOCAL_HOUR,
   0,
-  { min: 0, max: 23 }
+  {
+    min: 0,
+    max: 23,
+  }
 );
 export const SURVEY_SCHEDULING_LOCAL_MINUTE = parseSchedulingTimePart(
-  process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE,
+  process.env.SURVEY_SCHEDULING_LOCAL_MINUTE,
   0,
   { min: 0, max: 59 }
 );
-export const SURVEY_SCHEDULING_TIME_LABEL = `${padSchedulingTimePart(SURVEY_SCHEDULING_LOCAL_HOUR)}:${padSchedulingTimePart(SURVEY_SCHEDULING_LOCAL_MINUTE)}`;
+
+export const SURVEY_SCHEDULING_CONFIG: TSurveySchedulingConfig = {
+  timeZone: SURVEY_SCHEDULING_TIME_ZONE,
+  localHour: SURVEY_SCHEDULING_LOCAL_HOUR,
+  localMinute: SURVEY_SCHEDULING_LOCAL_MINUTE,
+};
+
+export const SURVEY_SCHEDULING_TIME_LABEL = getSurveySchedulingTimeLabel(SURVEY_SCHEDULING_CONFIG);
 export const SURVEY_SCHEDULING_TIME_ZONE_LABEL = SURVEY_SCHEDULING_TIME_ZONE;
 export const SURVEY_SCHEDULING_DAILY_CRON_PATTERN = `${SURVEY_SCHEDULING_LOCAL_MINUTE} ${SURVEY_SCHEDULING_LOCAL_HOUR} * * *`;
 export const SURVEY_SCHEDULING_GLOBAL_SCOPE = "global";

--- a/apps/web/modules/survey/scheduling/lib/date-utils.test.ts
+++ b/apps/web/modules/survey/scheduling/lib/date-utils.test.ts
@@ -4,12 +4,19 @@ import {
   SURVEY_SCHEDULING_LOCAL_MINUTE,
   SURVEY_SCHEDULING_TIME_ZONE,
 } from "./constants";
-import {
+import { createSurveySchedulingDateUtils, toDateOnlySelection } from "./date-utils";
+
+const defaultConfig = {
+  timeZone: "Europe/Berlin",
+  localHour: 0,
+  localMinute: 0,
+};
+
+const {
+  toCalendarDate,
   getMinimumSurveySchedulingCalendarDate,
   normalizeDateOnlySelectionToSurveySchedulingDateTime,
-  toCalendarDate,
-  toDateOnlySelection,
-} from "./date-utils";
+} = createSurveySchedulingDateUtils(defaultConfig);
 
 describe("survey scheduling date utils", () => {
   test("stores selected dates as noon UTC date-only values", () => {
@@ -66,6 +73,19 @@ describe("survey scheduling date utils", () => {
     expect(minSelectableDate.getMonth()).toBe(3);
     expect(minSelectableDate.getDate()).toBe(17);
     expect(minSelectableDate.getHours()).toBe(12);
+  });
+
+  test("honors a runtime-configured timezone, hour, and minute", () => {
+    const { normalizeDateOnlySelectionToSurveySchedulingDateTime: normalize } =
+      createSurveySchedulingDateUtils({
+        timeZone: "America/New_York",
+        localHour: 18,
+        localMinute: 45,
+      });
+    const storedDate = new Date("2026-01-17T12:00:00.000Z");
+
+    // 2026-01-17 18:45 in America/New_York (EST, UTC-5) is 23:45 UTC.
+    expect(normalize(storedDate)?.toISOString()).toBe("2026-01-17T23:45:00.000Z");
   });
 
   test("documents the default scheduling configuration", () => {

--- a/apps/web/modules/survey/scheduling/lib/date-utils.ts
+++ b/apps/web/modules/survey/scheduling/lib/date-utils.ts
@@ -1,8 +1,4 @@
-import {
-  SURVEY_SCHEDULING_LOCAL_HOUR,
-  SURVEY_SCHEDULING_LOCAL_MINUTE,
-  SURVEY_SCHEDULING_TIME_ZONE,
-} from "./constants";
+import type { TSurveySchedulingConfig } from "./config";
 
 const DATE_ONLY_SELECTION_UTC_HOUR = 12;
 const LOCAL_CALENDAR_NOON_HOUR = 12;
@@ -15,103 +11,6 @@ interface TimeZoneDateParts {
   year: number;
 }
 
-const timeZoneFormatter = new Intl.DateTimeFormat("en-CA", {
-  day: "2-digit",
-  hour: "2-digit",
-  hourCycle: "h23",
-  minute: "2-digit",
-  month: "2-digit",
-  second: "2-digit",
-  timeZone: SURVEY_SCHEDULING_TIME_ZONE,
-  year: "numeric",
-});
-
-const timeZoneOffsetFormatter = new Intl.DateTimeFormat("en-US", {
-  hour: "2-digit",
-  hourCycle: "h23",
-  minute: "2-digit",
-  timeZone: SURVEY_SCHEDULING_TIME_ZONE,
-  timeZoneName: "shortOffset",
-});
-
-const getTimeZoneDateParts = (date: Date): TimeZoneDateParts => {
-  const parts = timeZoneFormatter.formatToParts(date);
-  const getPartValue = (type: Intl.DateTimeFormatPartTypes): number => {
-    const value = parts.find((part) => part.type === type)?.value;
-
-    if (!value) {
-      throw new Error(`Missing ${type} in survey scheduling date formatter output`);
-    }
-
-    return Number.parseInt(value, 10);
-  };
-
-  return {
-    day: getPartValue("day"),
-    hour: getPartValue("hour"),
-    minute: getPartValue("minute"),
-    month: getPartValue("month"),
-    year: getPartValue("year"),
-  };
-};
-
-const getTimeZoneOffsetMs = (date: Date): number => {
-  const offsetValue = timeZoneOffsetFormatter
-    .formatToParts(date)
-    .find((part) => part.type === "timeZoneName")?.value;
-
-  if (!offsetValue || offsetValue === "GMT") {
-    return 0;
-  }
-
-  const match = /^GMT(?<sign>[+-])(?<hours>\d{1,2})(?::(?<minutes>\d{2}))?$/.exec(offsetValue);
-
-  if (!match?.groups) {
-    throw new Error(`Unsupported survey scheduling timezone offset: ${offsetValue}`);
-  }
-
-  const sign = match.groups.sign === "+" ? 1 : -1;
-  const hours = Number.parseInt(match.groups.hours, 10);
-  const minutes = Number.parseInt(match.groups.minutes ?? "0", 10);
-
-  return sign * ((hours * 60 + minutes) * 60 * 1000);
-};
-
-const matchesSurveySchedulingLocalTime = (date: Date, year: number, month: number, day: number): boolean => {
-  const parts = getTimeZoneDateParts(date);
-
-  return (
-    parts.year === year &&
-    parts.month === month + 1 &&
-    parts.day === day &&
-    parts.hour === SURVEY_SCHEDULING_LOCAL_HOUR &&
-    parts.minute === SURVEY_SCHEDULING_LOCAL_MINUTE
-  );
-};
-
-const createSurveySchedulingDateTime = (year: number, month: number, day: number): Date => {
-  const utcGuessMs = Date.UTC(
-    year,
-    month,
-    day,
-    SURVEY_SCHEDULING_LOCAL_HOUR,
-    SURVEY_SCHEDULING_LOCAL_MINUTE,
-    0,
-    0
-  );
-  let candidate = new Date(utcGuessMs);
-
-  for (let attempt = 0; attempt < 3; attempt++) {
-    candidate = new Date(utcGuessMs - getTimeZoneOffsetMs(candidate));
-
-    if (matchesSurveySchedulingLocalTime(candidate, year, month, day)) {
-      return candidate;
-    }
-  }
-
-  return candidate;
-};
-
 const createLocalCalendarDate = ({
   day,
   month,
@@ -119,42 +18,153 @@ const createLocalCalendarDate = ({
 }: Pick<TimeZoneDateParts, "day" | "month" | "year">): Date =>
   new Date(year, month - 1, day, LOCAL_CALENDAR_NOON_HOUR, 0, 0, 0);
 
+// Config-independent helpers. `toDateOnlySelection` stores the picked day as noon UTC and
+// `isDateDue` compares absolute instants, so neither depends on the scheduling time zone.
 export const toDateOnlySelection = (date: Date): Date =>
   new Date(
     Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), DATE_ONLY_SELECTION_UTC_HOUR, 0, 0, 0)
   );
 
-export const toCalendarDate = (date: Date): Date => {
-  return createLocalCalendarDate(getTimeZoneDateParts(date));
-};
-
-export const getMinimumSurveySchedulingCalendarDate = (now: Date = new Date()): Date => {
-  const currentSchedulingDateParts = getTimeZoneDateParts(now);
-  const minimumSchedulingDate = createLocalCalendarDate(currentSchedulingDateParts);
-  const currentSchedulingRunAt = createSurveySchedulingDateTime(
-    currentSchedulingDateParts.year,
-    currentSchedulingDateParts.month - 1,
-    currentSchedulingDateParts.day
-  );
-
-  if (now.getTime() < currentSchedulingRunAt.getTime()) {
-    return minimumSchedulingDate;
-  }
-
-  const nextSchedulingDate = new Date(minimumSchedulingDate);
-  nextSchedulingDate.setDate(nextSchedulingDate.getDate() + 1);
-  return nextSchedulingDate;
-};
-
-export const normalizeDateOnlySelectionToSurveySchedulingDateTime = (date: Date | null): Date | null => {
-  if (!date) {
-    return null;
-  }
-
-  const { day, month, year } = getTimeZoneDateParts(date);
-
-  return createSurveySchedulingDateTime(year, month - 1, day);
-};
-
 export const isDateDue = (date: Date | null, now: Date = new Date()): boolean =>
   date !== null && date.getTime() <= now.getTime();
+
+/**
+ * Builds the timezone-aware scheduling date helpers for a given configuration. The config is
+ * sourced from server-only env vars and passed in explicitly so the same logic can run on the
+ * server (reconciliation) and on the client (survey editor) with runtime-configured values.
+ */
+export const createSurveySchedulingDateUtils = (config: TSurveySchedulingConfig) => {
+  const timeZoneFormatter = new Intl.DateTimeFormat("en-CA", {
+    day: "2-digit",
+    hour: "2-digit",
+    hourCycle: "h23",
+    minute: "2-digit",
+    month: "2-digit",
+    second: "2-digit",
+    timeZone: config.timeZone,
+    year: "numeric",
+  });
+
+  const timeZoneOffsetFormatter = new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    hourCycle: "h23",
+    minute: "2-digit",
+    timeZone: config.timeZone,
+    timeZoneName: "shortOffset",
+  });
+
+  const getTimeZoneDateParts = (date: Date): TimeZoneDateParts => {
+    const parts = timeZoneFormatter.formatToParts(date);
+    const getPartValue = (type: Intl.DateTimeFormatPartTypes): number => {
+      const value = parts.find((part) => part.type === type)?.value;
+
+      if (!value) {
+        throw new Error(`Missing ${type} in survey scheduling date formatter output`);
+      }
+
+      return Number.parseInt(value, 10);
+    };
+
+    return {
+      day: getPartValue("day"),
+      hour: getPartValue("hour"),
+      minute: getPartValue("minute"),
+      month: getPartValue("month"),
+      year: getPartValue("year"),
+    };
+  };
+
+  const getTimeZoneOffsetMs = (date: Date): number => {
+    const offsetValue = timeZoneOffsetFormatter
+      .formatToParts(date)
+      .find((part) => part.type === "timeZoneName")?.value;
+
+    if (!offsetValue || offsetValue === "GMT") {
+      return 0;
+    }
+
+    const match = /^GMT(?<sign>[+-])(?<hours>\d{1,2})(?::(?<minutes>\d{2}))?$/.exec(offsetValue);
+
+    if (!match?.groups) {
+      throw new Error(`Unsupported survey scheduling timezone offset: ${offsetValue}`);
+    }
+
+    const sign = match.groups.sign === "+" ? 1 : -1;
+    const hours = Number.parseInt(match.groups.hours, 10);
+    const minutes = Number.parseInt(match.groups.minutes ?? "0", 10);
+
+    return sign * ((hours * 60 + minutes) * 60 * 1000);
+  };
+
+  const matchesSurveySchedulingLocalTime = (
+    date: Date,
+    year: number,
+    month: number,
+    day: number
+  ): boolean => {
+    const parts = getTimeZoneDateParts(date);
+
+    return (
+      parts.year === year &&
+      parts.month === month + 1 &&
+      parts.day === day &&
+      parts.hour === config.localHour &&
+      parts.minute === config.localMinute
+    );
+  };
+
+  const createSurveySchedulingDateTime = (year: number, month: number, day: number): Date => {
+    const utcGuessMs = Date.UTC(year, month, day, config.localHour, config.localMinute, 0, 0);
+    let candidate = new Date(utcGuessMs);
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      candidate = new Date(utcGuessMs - getTimeZoneOffsetMs(candidate));
+
+      if (matchesSurveySchedulingLocalTime(candidate, year, month, day)) {
+        return candidate;
+      }
+    }
+
+    return candidate;
+  };
+
+  const toCalendarDate = (date: Date): Date => {
+    return createLocalCalendarDate(getTimeZoneDateParts(date));
+  };
+
+  const getMinimumSurveySchedulingCalendarDate = (now: Date = new Date()): Date => {
+    const currentSchedulingDateParts = getTimeZoneDateParts(now);
+    const minimumSchedulingDate = createLocalCalendarDate(currentSchedulingDateParts);
+    const currentSchedulingRunAt = createSurveySchedulingDateTime(
+      currentSchedulingDateParts.year,
+      currentSchedulingDateParts.month - 1,
+      currentSchedulingDateParts.day
+    );
+
+    if (now.getTime() < currentSchedulingRunAt.getTime()) {
+      return minimumSchedulingDate;
+    }
+
+    const nextSchedulingDate = new Date(minimumSchedulingDate);
+    nextSchedulingDate.setDate(nextSchedulingDate.getDate() + 1);
+    return nextSchedulingDate;
+  };
+
+  const normalizeDateOnlySelectionToSurveySchedulingDateTime = (date: Date | null): Date | null => {
+    if (!date) {
+      return null;
+    }
+
+    const { day, month, year } = getTimeZoneDateParts(date);
+
+    return createSurveySchedulingDateTime(year, month - 1, day);
+  };
+
+  return {
+    toCalendarDate,
+    getMinimumSurveySchedulingCalendarDate,
+    normalizeDateOnlySelectionToSurveySchedulingDateTime,
+  };
+};
+
+export type SurveySchedulingDateUtils = ReturnType<typeof createSurveySchedulingDateUtils>;

--- a/apps/web/modules/survey/scheduling/lib/survey-scheduling.ts
+++ b/apps/web/modules/survey/scheduling/lib/survey-scheduling.ts
@@ -6,8 +6,11 @@ import { ValidationError } from "@formbricks/types/errors";
 import type { TSurvey } from "@formbricks/types/surveys/types";
 import { queueAuditEventWithoutRequest } from "@/modules/ee/audit-logs/lib/handler";
 import { type TAuditStatus } from "@/modules/ee/audit-logs/types/audit-log";
-import { SURVEY_SCHEDULING_RECONCILIATION_BATCH_SIZE } from "./constants";
-import { isDateDue, normalizeDateOnlySelectionToSurveySchedulingDateTime } from "./date-utils";
+import { SURVEY_SCHEDULING_CONFIG, SURVEY_SCHEDULING_RECONCILIATION_BATCH_SIZE } from "./constants";
+import { createSurveySchedulingDateUtils, isDateDue } from "./date-utils";
+
+const { normalizeDateOnlySelectionToSurveySchedulingDateTime } =
+  createSurveySchedulingDateUtils(SURVEY_SCHEDULING_CONFIG);
 
 type TSurveySchedulingTransition = "publish" | "close";
 

--- a/turbo.json
+++ b/turbo.json
@@ -218,10 +218,7 @@
         "WEBAPP_URL",
         "NEXTAUTH_URL",
         "S3_ENDPOINT_URL",
-        "POSTHOG_KEY",
-        "NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE",
-        "NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR",
-        "NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE"
+        "POSTHOG_KEY"
       ],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**", "!.next/dev/**"],
       "passThroughEnv": [
@@ -348,6 +345,9 @@
         "STRIPE_PUBLISHABLE_KEY",
         "SURVEYS_PACKAGE_MODE",
         "SURVEYS_PACKAGE_BUILD",
+        "SURVEY_SCHEDULING_TIME_ZONE",
+        "SURVEY_SCHEDULING_LOCAL_HOUR",
+        "SURVEY_SCHEDULING_LOCAL_MINUTE",
         "PUBLIC_URL",
         "TURNSTILE_SECRET_KEY",
         "TURNSTILE_SITE_KEY",


### PR DESCRIPTION
## Problem

The env vars controlling the survey publish/close scheduling execution time were prefixed with `NEXT_PUBLIC_`:

- `NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE`
- `NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR`
- `NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE`

Next.js inlines `NEXT_PUBLIC_*` vars into the bundle **at build time**. This means self-hosting users running our prebuilt Docker image cannot configure these values at runtime — they are baked into the image. (Reported by @mattinannt on Slack.)

Closes ENG-1665.

## Solution

Move the three vars to **server-only** env vars (no `NEXT_PUBLIC_` prefix), read from `process.env` at runtime:

- `SURVEY_SCHEDULING_TIME_ZONE`
- `SURVEY_SCHEDULING_LOCAL_HOUR`
- `SURVEY_SCHEDULING_LOCAL_MINUTE`

The scheduling feature is functionally server-side (the daily reconciliation cron in `instrumentation-jobs.ts` and normalization in `survey-scheduling.ts`), so those paths now pick up runtime config for free.

The survey editor is a client tree and also needs these values — for the schedule label ("Survey will be published at `HH:MM` in the `<tz>` timezone") and for calendar date math. Since server-only env vars are `undefined` in the browser bundle, the resolved config is now **threaded from the server** down to the client:

- `page.tsx` (server) reads `SURVEY_SCHEDULING_CONFIG` and passes it as a `surveySchedulingConfig` prop
- `SurveyEditor` → `SettingsView` → `ResponseOptionsCard` forward the prop (same pattern as the existing `locale` prop)
- `date-utils.ts` is refactored from module-level constants into `createSurveySchedulingDateUtils(config)`, so the exact same timezone/hour/minute logic runs on both the server (reconciliation) and the client (editor) with runtime-configured values
- Client-safe helpers (`TSurveySchedulingConfig`, `getSurveySchedulingTimeLabel`) live in a new `config.ts` that does not touch `process.env`

This keeps the editor label and calendar boundaries correct for any runtime override, instead of falling back to the build-time default.

## Changes

- `apps/web/lib/env.ts` — move the three vars from the `client` block to the `server` block; drop the prefix; update `runtimeEnv` and the validation message
- `apps/web/modules/survey/scheduling/lib/constants.ts` — read non-prefixed vars from `process.env`; export `SURVEY_SCHEDULING_CONFIG`
- `apps/web/modules/survey/scheduling/lib/config.ts` — **new** client-safe config type + label helper
- `apps/web/modules/survey/scheduling/lib/date-utils.ts` — `createSurveySchedulingDateUtils(config)` factory; `toDateOnlySelection`/`isDateDue` stay pure
- `apps/web/modules/survey/scheduling/lib/survey-scheduling.ts` — instantiate the utils with `SURVEY_SCHEDULING_CONFIG`
- `apps/web/modules/survey/editor/{page,components/survey-editor,components/settings-view,components/response-options-card}` — thread `surveySchedulingConfig` prop
- `turbo.json` — move the vars out of `build.env` (no longer build inputs) into `passThroughEnv`
- `.env.example` — document them as server-side runtime vars

## Testing

- Updated `env.test.ts` and `date-utils.test.ts`; added a test asserting a runtime-configured timezone/hour/minute is honored
- `pnpm vitest run lib/env.test.ts modules/survey/scheduling` → **48 passed**
- `eslint` and `prettier` clean on all changed files
- Type-checked the touched files (no new errors)

## Notes for reviewers

- No breaking change for Formbricks Cloud (defaults unchanged: `Europe/Berlin`, `00:00`).
- **Self-hosters who set the old `NEXT_PUBLIC_*` vars must rename them** to the non-prefixed names. Called out in `.env.example`.
