### PR TITLE
fix(billing): stop reverse trial laundering into active paid plan [ENG-1968]

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -2374,6 +2374,7 @@ checksums:
     workspace/settings/billing/payment_error_contact_support: 3145080022ff17d06e41afe78363a6cc
     workspace/settings/billing/payment_error_failed_invoice: 5344b45e2acaf0287b69b043d37a964d
     workspace/settings/billing/payment_error_requires_action: 934ac70b26f53819314add46305b6d87
+    workspace/settings/billing/payment_method_required: 34c8095c7fe1f9c64aadf2206abf9c80
     workspace/settings/billing/pending_change_removed: c80cc7f1f83f28db186e897fb18282a3
     workspace/settings/billing/pending_plan_badge: 1283929a2810dcf6110765f387dc118e
     workspace/settings/billing/pending_plan_change_description: 6923bada769d33cadcad557521362c1f

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "Bitte kontaktiere <supportLink>hola@formbricks.com</supportLink> für Unterstützung.",
         "payment_error_failed_invoice": "Die Zahlung konnte nicht abgeschlossen werden.",
         "payment_error_requires_action": "Die Zahlung erfordert eine zusätzliche Authentifizierung.",
+        "payment_method_required": "Füge eine Zahlungsmethode hinzu, um zu einem kostenpflichtigen Tarif zu wechseln.",
         "pending_change_removed": "Geplante Planänderung entfernt.",
         "pending_plan_badge": "Geplant",
         "pending_plan_change_description": "Dein Plan wechselt am {date} zu {plan}.",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "Please contact <supportLink>hola@formbricks.com</supportLink> for support.",
         "payment_error_failed_invoice": "Payment could not be completed.",
         "payment_error_requires_action": "Payment requires additional authentication.",
+        "payment_method_required": "Add a payment method to switch to a paid plan.",
         "pending_change_removed": "Scheduled plan change removed.",
         "pending_plan_badge": "Scheduled",
         "pending_plan_change_description": "Your plan will switch to {plan} on {date}.",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "Por favor, contacta con <supportLink>hola@formbricks.com</supportLink> para recibir asistencia.",
         "payment_error_failed_invoice": "No se pudo completar el pago.",
         "payment_error_requires_action": "El pago requiere autenticación adicional.",
+        "payment_method_required": "Añade un método de pago para cambiar a un plan de pago.",
         "pending_change_removed": "Cambio de plan programado eliminado.",
         "pending_plan_badge": "Programado",
         "pending_plan_change_description": "Tu plan cambiará a {plan} el {date}.",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "Merci de contacter <supportLink>hola@formbricks.com</supportLink> pour obtenir de l'aide.",
         "payment_error_failed_invoice": "Le paiement n'a pas pu être effectué.",
         "payment_error_requires_action": "Le paiement nécessite une authentification supplémentaire.",
+        "payment_method_required": "Ajoute un moyen de paiement pour passer à un forfait payant.",
         "pending_change_removed": "Changement de formule programmé supprimé.",
         "pending_plan_badge": "Programmé",
         "pending_plan_change_description": "Votre forfait passera à {plan} le {date}.",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "Kérem, vegye fel a kapcsolatot a következő címmel támogatásért: <supportLink>hola@formbricks.com</supportLink>.",
         "payment_error_failed_invoice": "A fizetés nem volt teljesíthető.",
         "payment_error_requires_action": "A fizetés további hitelesítést igényel.",
+        "payment_method_required": "Adjon hozzá egy fizetési módot a fizetős csomagra való váltáshoz.",
         "pending_change_removed": "Az ütemezett csomagváltoztatás eltávolítva.",
         "pending_plan_badge": "Ütemezett",
         "pending_plan_change_description": "A csomagja {plan} csomagra fog váltani ekkor: {date}.",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "サポートについては<supportLink>hola@formbricks.com</supportLink>までお問い合わせください。",
         "payment_error_failed_invoice": "支払いを完了できませんでした。",
         "payment_error_requires_action": "支払いには追加の認証が必要です。",
+        "payment_method_required": "有料プランに切り替えるには、お支払い方法を追加してください。",
         "pending_change_removed": "予定されていたプラン変更を取り消しました。",
         "pending_plan_badge": "変更予定",
         "pending_plan_change_description": "プランは {date} に {plan} に切り替わります。",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "Neem contact op met <supportLink>hola@formbricks.com</supportLink> voor ondersteuning.",
         "payment_error_failed_invoice": "De betaling kon niet worden voltooid.",
         "payment_error_requires_action": "De betaling vereist aanvullende verificatie.",
+        "payment_method_required": "Voeg een betaalmethode toe om over te schakelen naar een betaald abonnement.",
         "pending_change_removed": "Geplande abonnementswijziging verwijderd.",
         "pending_plan_badge": "Gepland",
         "pending_plan_change_description": "Je abonnement wordt op {date} omgezet naar {plan}.",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "Entre em contato com <supportLink>hola@formbricks.com</supportLink> para obter suporte.",
         "payment_error_failed_invoice": "Não foi possível concluir o pagamento.",
         "payment_error_requires_action": "O pagamento requer autenticação adicional.",
+        "payment_method_required": "Adicione um método de pagamento para mudar para um plano pago.",
         "pending_change_removed": "Mudança de plano agendada removida.",
         "pending_plan_badge": "Agendado",
         "pending_plan_change_description": "Seu plano mudará para {plan} em {date}.",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "Por favor, contacta <supportLink>hola@formbricks.com</supportLink> para obter suporte.",
         "payment_error_failed_invoice": "O pagamento não pôde ser concluído.",
         "payment_error_requires_action": "O pagamento requer autenticação adicional.",
+        "payment_method_required": "Adiciona um método de pagamento para mudares para um plano pago.",
         "pending_change_removed": "Alteração de plano agendada removida.",
         "pending_plan_badge": "Agendado",
         "pending_plan_change_description": "O teu plano mudará para {plan} em {date}.",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "Te rugăm să contactezi <supportLink>hola@formbricks.com</supportLink> pentru asistență.",
         "payment_error_failed_invoice": "Plata nu a putut fi finalizată.",
         "payment_error_requires_action": "Plata necesită autentificare suplimentară.",
+        "payment_method_required": "Adaugă o metodă de plată pentru a trece la un plan plătit.",
         "pending_change_removed": "Schimbarea de plan programată a fost anulată.",
         "pending_plan_badge": "Programat",
         "pending_plan_change_description": "Abonamentul tău va trece la {plan} pe {date}.",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "Пожалуйста, свяжитесь с нами <supportLink>hola@formbricks.com</supportLink> для получения помощи.",
         "payment_error_failed_invoice": "Не удалось завершить платёж.",
         "payment_error_requires_action": "Платёж требует дополнительной аутентификации.",
+        "payment_method_required": "Добавь способ оплаты, чтобы перейти на платный тариф.",
         "pending_change_removed": "Запланированное изменение тарифа отменено.",
         "pending_plan_badge": "Запланирован",
         "pending_plan_change_description": "Твой тариф сменится на {plan} на {date}.",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "Vänligen kontakta <supportLink>hola@formbricks.com</supportLink> för support.",
         "payment_error_failed_invoice": "Betalningen kunde inte genomföras.",
         "payment_error_requires_action": "Betalningen kräver ytterligare autentisering.",
+        "payment_method_required": "Lägg till en betalningsmetod för att byta till en betald plan.",
         "pending_change_removed": "Schemalagd abonnemangsändring har tagits bort.",
         "pending_plan_badge": "Schemalagd",
         "pending_plan_change_description": "Din plan kommer att byta till {plan} den {date}.",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "Destek için lütfen <supportLink>hola@formbricks.com</supportLink> ile iletişime geç.",
         "payment_error_failed_invoice": "Ödeme tamamlanamadı.",
         "payment_error_requires_action": "Ödeme için ek doğrulama gerekiyor.",
+        "payment_method_required": "Ücretli bir plana geçmek için bir ödeme yöntemi ekle.",
         "pending_change_removed": "Planlanmış plan değişikliği kaldırıldı.",
         "pending_plan_badge": "Planlandı",
         "pending_plan_change_description": "Planınız {date} tarihinde {plan} olarak değişecek.",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "请联系 <supportLink>hola@formbricks.com</supportLink> 获取支持。",
         "payment_error_failed_invoice": "支付无法完成。",
         "payment_error_requires_action": "支付需要额外验证。",
+        "payment_method_required": "添加付款方式以切换到付费套餐。",
         "pending_change_removed": "已取消预定的方案变更。",
         "pending_plan_badge": "已预定",
         "pending_plan_change_description": "你的套餐将在 {date} 切换为 {plan}。",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -2471,6 +2471,7 @@
         "payment_error_contact_support": "如需協助，請聯絡 <supportLink>hola@formbricks.com</supportLink>。",
         "payment_error_failed_invoice": "付款無法完成。",
         "payment_error_requires_action": "付款需要額外的身份驗證。",
+        "payment_method_required": "新增付款方式以切換至付費方案。",
         "pending_change_removed": "已取消預定的方案變更。",
         "pending_plan_badge": "已排程",
         "pending_plan_change_description": "您的方案將於 {date} 切換至 {plan}。",

--- a/apps/web/modules/ee/billing/actions.ts
+++ b/apps/web/modules/ee/billing/actions.ts
@@ -388,6 +388,13 @@ export const changeBillingPlanAction = authenticatedActionClient.inputSchema(ZCh
       throw new ResourceNotFoundError("OrganizationBilling", organizationId);
     }
 
+    // Mirror the client rule server-side: a paid plan change requires a collected payment method.
+    // The client routes no-card paid changes through the add-card checkout; this rejects any direct
+    // call that bypasses it (e.g. a trialing no-card org trying to launder into active paid Pro).
+    if (parsedInput.targetPlan !== "hobby" && organization.billing.stripe?.hasPaymentMethod !== true) {
+      throw new OperationNotAllowedError("payment_method_required");
+    }
+
     const result = await switchOrganizationToCloudPlan({
       organizationId,
       customerId: organization.billing.stripeCustomerId,

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -161,6 +161,10 @@ const getActionErrorMessage = (serverError: string, t: (key: string) => string) 
     return t("workspace.settings.billing.yearly_checkout_unavailable");
   }
 
+  if (serverError === "payment_method_required") {
+    return t("workspace.settings.billing.payment_method_required");
+  }
+
   return t("common.something_went_wrong_please_try_again");
 };
 

--- a/apps/web/modules/ee/billing/lib/organization-billing.test.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.test.ts
@@ -921,6 +921,161 @@ describe("organization-billing", () => {
     expect(mocks.cacheDel).toHaveBeenCalledWith(["billing-cache-key"]);
   });
 
+  test("switchOrganizationToCloudPlan cancels a no-card trial at period end on downgrade instead of building a billable schedule", async () => {
+    mocks.subscriptionsList.mockResolvedValue({
+      data: [
+        {
+          id: "sub_trial",
+          status: "trialing",
+          billing_cycle_anchor: 1739923200,
+          cancel_at_period_end: false,
+          default_payment_method: null,
+          trial_end: 1742515200,
+          schedule: null,
+          items: {
+            data: [
+              {
+                id: "si_pro_base",
+                current_period_end: 1742515200,
+                price: {
+                  id: "price_pro_monthly",
+                  metadata: {
+                    formbricks_plan: "pro",
+                    formbricks_price_kind: "base",
+                    formbricks_interval: "monthly",
+                  },
+                  product: { id: "prod_pro", metadata: { formbricks_plan: "pro" }, active: true },
+                  recurring: { usage_type: "licensed", interval: "month" },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    // No card on the subscription and none on the customer either.
+    mocks.customersRetrieve.mockResolvedValue({
+      id: "cus_1",
+      deleted: false,
+      invoice_settings: { default_payment_method: null },
+    });
+    mocks.prismaOrganizationBillingFindUnique.mockResolvedValue({
+      stripeCustomerId: "cus_1",
+      limits: { workspaces: 3, monthly: { responses: 1500 } },
+      usageCycleAnchor: new Date(),
+      stripe: {
+        subscriptionId: "sub_trial",
+        plan: "pro",
+        interval: "monthly",
+        subscriptionStatus: "trialing",
+        hasPaymentMethod: false,
+      },
+    });
+
+    const result = await switchOrganizationToCloudPlan({
+      organizationId: "org_1",
+      customerId: "cus_1",
+      targetPlan: "hobby",
+      targetInterval: "monthly",
+    });
+
+    expect(result).toEqual({
+      mode: "scheduled",
+      pendingChange: {
+        type: "plan_change",
+        targetPlan: "hobby",
+        targetInterval: "monthly",
+        effectiveAt: new Date(1742515200 * 1000).toISOString(),
+      },
+      clientSecret: null,
+      requiresAction: false,
+    });
+    // The trial is cancelled at period end — never rebuilt into a billable schedule.
+    expect(mocks.subscriptionsUpdate).toHaveBeenCalledWith("sub_trial", {
+      cancel_at_period_end: true,
+    });
+    expect(mocks.subscriptionSchedulesCreate).not.toHaveBeenCalled();
+    expect(mocks.subscriptionSchedulesUpdate).not.toHaveBeenCalled();
+    expect(mocks.prismaOrganizationBillingUpdate).toHaveBeenCalledWith({
+      where: { organizationId: "org_1" },
+      data: {
+        stripe: expect.objectContaining({
+          pendingChange: {
+            type: "plan_change",
+            targetPlan: "hobby",
+            targetInterval: "monthly",
+            effectiveAt: new Date(1742515200 * 1000).toISOString(),
+          },
+        }),
+      },
+    });
+  });
+
+  test("switchOrganizationToCloudPlan rejects a paid switch from a no-card trial", async () => {
+    mocks.subscriptionsList.mockResolvedValue({
+      data: [
+        {
+          id: "sub_trial",
+          status: "trialing",
+          billing_cycle_anchor: 1739923200,
+          cancel_at_period_end: false,
+          default_payment_method: null,
+          trial_end: 1742515200,
+          schedule: null,
+          items: {
+            data: [
+              {
+                id: "si_pro_base",
+                current_period_end: 1742515200,
+                price: {
+                  id: "price_pro_monthly",
+                  metadata: {
+                    formbricks_plan: "pro",
+                    formbricks_price_kind: "base",
+                    formbricks_interval: "monthly",
+                  },
+                  product: { id: "prod_pro", metadata: { formbricks_plan: "pro" }, active: true },
+                  recurring: { usage_type: "licensed", interval: "month" },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    mocks.customersRetrieve.mockResolvedValue({
+      id: "cus_1",
+      deleted: false,
+      invoice_settings: { default_payment_method: null },
+    });
+    mocks.prismaOrganizationBillingFindUnique.mockResolvedValue({
+      stripeCustomerId: "cus_1",
+      limits: { workspaces: 3, monthly: { responses: 1500 } },
+      usageCycleAnchor: new Date(),
+      stripe: {
+        subscriptionId: "sub_trial",
+        plan: "pro",
+        interval: "monthly",
+        subscriptionStatus: "trialing",
+        hasPaymentMethod: false,
+      },
+    });
+
+    await expect(
+      switchOrganizationToCloudPlan({
+        organizationId: "org_1",
+        customerId: "cus_1",
+        targetPlan: "scale",
+        targetInterval: "monthly",
+      })
+    ).rejects.toThrow("payment_method_required");
+
+    // No billable conversion is attempted.
+    expect(mocks.subscriptionsUpdate).not.toHaveBeenCalled();
+    expect(mocks.subscriptionSchedulesCreate).not.toHaveBeenCalled();
+    expect(mocks.subscriptionSchedulesUpdate).not.toHaveBeenCalled();
+  });
+
   test("switchOrganizationToCloudPlan uses pending_if_incomplete for immediate upgrades so the plan is granted only once paid", async () => {
     mocks.subscriptionsList.mockResolvedValue({
       data: [

--- a/apps/web/modules/ee/billing/lib/organization-billing.test.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.test.ts
@@ -372,6 +372,13 @@ describe("organization-billing", () => {
     }));
     mocks.subscriptionSchedulesRelease.mockResolvedValue({});
     mocks.subscriptionsUpdate.mockResolvedValue({});
+    // Default: no card at the customer level either. The payment-method check falls back to the
+    // customer default when the subscription has none, so it must always resolve to a customer.
+    mocks.customersRetrieve.mockResolvedValue({
+      id: "cus_1",
+      deleted: false,
+      invoice_settings: { default_payment_method: null },
+    });
   });
 
   test("ensureStripeCustomerForOrganization returns null when org does not exist", async () => {
@@ -1074,6 +1081,149 @@ describe("organization-billing", () => {
     expect(mocks.subscriptionsUpdate).not.toHaveBeenCalled();
     expect(mocks.subscriptionSchedulesCreate).not.toHaveBeenCalled();
     expect(mocks.subscriptionSchedulesUpdate).not.toHaveBeenCalled();
+  });
+
+  test("switchOrganizationToCloudPlan releases a stray schedule before cancelling a no-card trial on downgrade", async () => {
+    mocks.subscriptionsList.mockResolvedValue({
+      data: [
+        {
+          id: "sub_trial",
+          status: "trialing",
+          billing_cycle_anchor: 1739923200,
+          cancel_at_period_end: false,
+          default_payment_method: null,
+          trial_end: 1742515200,
+          schedule: "sched_trial",
+          items: {
+            data: [
+              {
+                id: "si_pro_base",
+                current_period_end: 1742515200,
+                price: {
+                  id: "price_pro_monthly",
+                  metadata: {
+                    formbricks_plan: "pro",
+                    formbricks_price_kind: "base",
+                    formbricks_interval: "monthly",
+                  },
+                  product: { id: "prod_pro", metadata: { formbricks_plan: "pro" }, active: true },
+                  recurring: { usage_type: "licensed", interval: "month" },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    mocks.customersRetrieve.mockResolvedValue({
+      id: "cus_1",
+      deleted: false,
+      invoice_settings: { default_payment_method: null },
+    });
+    mocks.prismaOrganizationBillingFindUnique.mockResolvedValue({
+      stripeCustomerId: "cus_1",
+      limits: { workspaces: 3, monthly: { responses: 1500 } },
+      usageCycleAnchor: new Date(),
+      stripe: {
+        subscriptionId: "sub_trial",
+        plan: "pro",
+        interval: "monthly",
+        subscriptionStatus: "trialing",
+        hasPaymentMethod: false,
+      },
+    });
+
+    const result = await switchOrganizationToCloudPlan({
+      organizationId: "org_1",
+      customerId: "cus_1",
+      targetPlan: "hobby",
+      targetInterval: "monthly",
+    });
+
+    expect(result.mode).toBe("scheduled");
+    // The stray schedule (which would otherwise rebuild the trial into a billable Pro phase) is
+    // released first, then the trial is cancelled at period end — never converted to a schedule.
+    expect(mocks.subscriptionSchedulesRelease).toHaveBeenCalledWith("sched_trial", {
+      preserve_cancel_date: false,
+    });
+    expect(mocks.subscriptionsUpdate).toHaveBeenCalledWith("sub_trial", {
+      cancel_at_period_end: true,
+    });
+    expect(mocks.subscriptionSchedulesCreate).not.toHaveBeenCalled();
+    expect(mocks.subscriptionSchedulesUpdate).not.toHaveBeenCalled();
+  });
+
+  test("switchOrganizationToCloudPlan allows a paid switch from a trial when the card is only on the customer", async () => {
+    mocks.subscriptionsList.mockResolvedValue({
+      data: [
+        {
+          id: "sub_trial",
+          status: "trialing",
+          billing_cycle_anchor: 1739923200,
+          cancel_at_period_end: false,
+          // No card on the subscription itself...
+          default_payment_method: null,
+          trial_end: 1742515200,
+          schedule: null,
+          items: {
+            data: [
+              {
+                id: "si_pro_base",
+                current_period_end: 1742515200,
+                price: {
+                  id: "price_pro_monthly",
+                  metadata: {
+                    formbricks_plan: "pro",
+                    formbricks_price_kind: "base",
+                    formbricks_interval: "monthly",
+                  },
+                  product: { id: "prod_pro", metadata: { formbricks_plan: "pro" }, active: true },
+                  recurring: { usage_type: "licensed", interval: "month" },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    // ...but a card is saved at the customer level, so the paid switch must be allowed through.
+    mocks.customersRetrieve.mockResolvedValue({
+      id: "cus_1",
+      deleted: false,
+      invoice_settings: { default_payment_method: "pm_customer" },
+    });
+    mocks.prismaOrganizationBillingFindUnique.mockResolvedValue({
+      stripeCustomerId: "cus_1",
+      limits: { workspaces: 3, monthly: { responses: 1500 } },
+      usageCycleAnchor: new Date(),
+      stripe: {
+        subscriptionId: "sub_trial",
+        plan: "pro",
+        interval: "monthly",
+        subscriptionStatus: "trialing",
+        hasPaymentMethod: false,
+      },
+    });
+
+    const result = await switchOrganizationToCloudPlan({
+      organizationId: "org_1",
+      customerId: "cus_1",
+      targetPlan: "scale",
+      targetInterval: "monthly",
+    });
+
+    // Proceeds through the normal paid path instead of being rejected or cancelled.
+    expect(result.mode).toBe("immediate");
+    expect(mocks.subscriptionsUpdate).toHaveBeenCalledWith(
+      "sub_trial",
+      expect.objectContaining({
+        payment_behavior: "pending_if_incomplete",
+        proration_behavior: "always_invoice",
+      })
+    );
+    expect(mocks.subscriptionsUpdate).not.toHaveBeenCalledWith("sub_trial", {
+      cancel_at_period_end: true,
+    });
   });
 
   test("switchOrganizationToCloudPlan uses pending_if_incomplete for immediate upgrades so the plan is granted only once paid", async () => {

--- a/apps/web/modules/ee/billing/lib/organization-billing.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.ts
@@ -907,6 +907,75 @@ const scheduleSubscriptionPlanChange = async (
   return pendingChange;
 };
 
+/**
+ * Whether a payment method has been collected for the subscription. Checks the subscription
+ * default first, then falls back to the customer-level default so a card saved on the customer
+ * (but not yet attached to the subscription) still counts — this avoids falsely blocking a
+ * legitimately card-backed org on a paid switch.
+ */
+const hasCollectedPaymentMethod = async (
+  subscription: NonNullable<Awaited<ReturnType<typeof resolveCurrentSubscription>>>,
+  customerId: string
+): Promise<boolean> => {
+  if (subscription.default_payment_method != null) {
+    return true;
+  }
+
+  if (!stripeClient) {
+    return false;
+  }
+
+  const customer = await stripeClient.customers.retrieve(customerId);
+  if (customer.deleted) {
+    return false;
+  }
+
+  return customer.invoice_settings?.default_payment_method != null;
+};
+
+/**
+ * Cancels a no-card trial at period end so the org lands on Hobby without ever being converted
+ * into a billable schedule. Releases any stray schedule first (a schedule would otherwise rebuild
+ * the trial into a billable Pro phase), then sets cancel_at_period_end so Stripe cancels the
+ * trialing subscription instead of charging it — no schedule, no card required.
+ */
+const cancelTrialToHobbyAtPeriodEnd = async (
+  organizationId: string,
+  subscription: NonNullable<Awaited<ReturnType<typeof resolveCurrentSubscription>>>
+): Promise<TOrganizationStripePendingChange> => {
+  if (!stripeClient) {
+    throw new Error("Stripe is not configured");
+  }
+
+  if (subscription.schedule) {
+    const scheduleId =
+      typeof subscription.schedule === "string" ? subscription.schedule : subscription.schedule.id;
+    await stripeClient.subscriptionSchedules.release(scheduleId, {
+      preserve_cancel_date: false,
+    });
+  }
+
+  await stripeClient.subscriptions.update(subscription.id, {
+    cancel_at_period_end: true,
+  });
+
+  const effectiveAt =
+    resolvePendingChangeEffectiveAt(subscription) ??
+    (subscription.trial_end ? new Date(subscription.trial_end * 1000).toISOString() : null) ??
+    new Date().toISOString();
+
+  const pendingChange: TOrganizationStripePendingChange = {
+    type: "plan_change",
+    targetPlan: "hobby",
+    targetInterval: "monthly",
+    effectiveAt,
+  };
+
+  await updatePendingPlanChangeSnapshot(organizationId, pendingChange);
+
+  return pendingChange;
+};
+
 export const switchOrganizationToCloudPlan = async (input: {
   organizationId: string;
   customerId: string;
@@ -931,6 +1000,23 @@ export const switchOrganizationToCloudPlan = async (input: {
 
   if (isSameSelection) {
     return { mode: "immediate", pendingChange: null, clientSecret: null, requiresAction: false };
+  }
+
+  // A trialing subscription with no payment method must never be converted into a billable
+  // subscription. The scheduled path rebuilds phases without the trial guard, ending the trial and
+  // turning phase 1 into a billable Pro phase; undoing that pending change would then leave the org
+  // on active paid Pro with no card. So special-case it: a downgrade cancels the trial (landing on
+  // Hobby, no card), and any paid switch is rejected and routed through the add-card checkout.
+  if (
+    subscription.status === "trialing" &&
+    !(await hasCollectedPaymentMethod(subscription, input.customerId))
+  ) {
+    if (input.targetPlan === "hobby") {
+      const pendingChange = await cancelTrialToHobbyAtPeriodEnd(input.organizationId, subscription);
+      return { mode: "scheduled", pendingChange, clientSecret: null, requiresAction: false };
+    }
+
+    throw new OperationNotAllowedError("payment_method_required");
   }
 
   if (isImmediateUpgrade) {

--- a/apps/web/modules/ee/billing/lib/organization-billing.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.ts
@@ -1483,6 +1483,10 @@ export const syncOrganizationBillingFromStripe = async (
   const subscriptionStatus = resolveSubscriptionStatus(subscription);
   const usageCycleAnchor = resolveUsageCycleAnchor(subscription);
   const pendingChange = await resolvePendingPlanChange(subscription);
+  // Match the guard in switchOrganizationToCloudPlan / changeBillingPlanAction: a card saved on the
+  // customer (but not yet attached to the subscription) still counts, so the cached flag must not
+  // falsely block a legitimately card-backed org on a paid switch.
+  const hasPaymentMethod = subscription ? await hasCollectedPaymentMethod(subscription, customerId) : false;
 
   const transition = resolveSubscriptionLifecycleTransition(
     existingStripeSnapshot,
@@ -1509,7 +1513,7 @@ export const syncOrganizationBillingFromStripe = async (
       interval: billingInterval,
       subscriptionStatus,
       subscriptionId: subscription?.id ?? null,
-      hasPaymentMethod: subscription?.default_payment_method != null,
+      hasPaymentMethod,
       features: featureLookupKeys,
       pendingChange,
       // Clear the payment-failure banner only when this sync reflects a real settlement:


### PR DESCRIPTION
## What does this PR do?

Closes **[ENG-1968](https://linear.app/formbricks/issue/ENG-1968/reverse-trial-can-be-laundered-into-an-active-paid-pro-subscription)** (High severity, Cloud billing — revenue/entitlement bypass).

### The issue

A new org owner could obtain ~30 days of active **Pro/Scale with no payment method**, entirely through the billing UI, by abusing the interaction between the reverse trial and schedule-based plan changes:

1. Start the reverse Pro trial as a new org owner (no card).
2. Billing → **Downgrade to Hobby**.
3. Switch back to **Pro** to undo the pending change.
4. Result: the org is on **active Pro, no payment method**, never prompted for a card — and keeps paid entitlements until Stripe dunning cancels the unpaid subscription.

**Root cause.** Downgrading a `trialing` subscription took the *scheduled* path, which rebuilt the schedule phases **without `trial_end` / `trial_settings`**. That ended the trial and turned phase 1 into a billable Pro phase, dropping the `trial_settings.end_behavior.missing_payment_method: "cancel"` guard. Undoing the pending change released the schedule, leaving a plain **active Pro, no trial, no card** subscription. Since `active` and `past_due` both count as active subscription states, the app granted Pro the whole time.

**Contributing gap.** `changeBillingPlanAction` / `switchOrganizationToCloudPlan` did no server-side payment-method check — the "no card → route to checkout" rule lived only in the client (`pricing-table.tsx`), so a direct call bypassed it.

### The fix

Special-case `trialing` subscriptions in `switchOrganizationToCloudPlan` so a no-card trial is **never converted into a billable schedule**:

- **Downgrade-to-Hobby from a trial** → `cancelTrialToHobbyAtPeriodEnd`: releases any stray schedule (which would otherwise rebuild the trial into a billable Pro phase), then sets `cancel_at_period_end` so Stripe cancels the trialing subscription instead of charging it. Org lands on Hobby, no schedule, no card required.
- **Any paid switch from a no-card trial** → rejected with `OperationNotAllowedError("payment_method_required")` and routed through the add-card checkout.

Defense in depth:

- Same **server-side `hasPaymentMethod` guard added to `changeBillingPlanAction`**, mirroring the client rule so a direct action call can't bypass it.
- New `hasCollectedPaymentMethod` helper checks the subscription default first, then falls back to the **customer-level default payment method** — this also addresses the ticket's noted follow-up (previously `hasPaymentMethod` ignored the customer-level default, risking false negatives on the from-scratch checkout path).

### Out of scope (follow-up)

Data remediation: audit existing `OrganizationBilling` rows where plan is `pro`/`scale`, `hasPaymentMethod = false`, and `subscriptionStatus` is `active`/`past_due`, and remediate already-affected orgs. Tracked separately per the ticket.

## How should this be tested?

Automated regression tests added in `apps/web/modules/ee/billing/lib/organization-billing.test.ts`:

1. **Downgrade a no-card trial → Hobby** cancels at period end (`cancel_at_period_end: true`) and never builds a billable schedule (`subscriptionSchedules.create/update` not called).
2. **Paid switch from a no-card trial** (`scale`) rejects with `payment_method_required` and attempts no billable conversion.

```
pnpm --filter=@formbricks/web test organization-billing
```

Manual (Cloud):
- Start reverse Pro trial (no card) → downgrade to Hobby → switch back to Pro. Should now require adding a card (routed to checkout), never landing on active paid Pro without a payment method.
- Downgrade to Hobby from a trial still works with no card and lands on Hobby.

## Checklist

- [x] Server-side guard mirrors client rule (defense in depth)
- [x] Regression tests added for trialing→schedule path
- [x] i18n string added to `en-US.json` and generated via `pnpm i18n`
- [x] Self-reviewed my own code
