### PR TITLE
fix: bump tar to 7.5.19 to patch decompression DoS (ENG-1947)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ overrides:
   esbuild: 0.28.1
   undici@7: 7.28.0
   form-data@4: 4.0.6
-  tar: 7.5.16
+  tar: 7.5.19
   js-yaml@4: 4.2.0
 
 importers:
@@ -11515,8 +11515,8 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.19:
+    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
 
   tarn@3.0.2:
@@ -19938,7 +19938,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 7.5.16
+      tar: 7.5.19
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -22842,7 +22842,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.8.0
-      tar: 7.5.16
+      tar: 7.5.19
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -24521,7 +24521,7 @@ snapshots:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
-      tar: 7.5.16
+      tar: 7.5.19
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
@@ -24839,7 +24839,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar@7.5.16:
+  tar@7.5.19:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,7 +71,10 @@ overrides:
   # ENG-1513 / GHSA-fjxv-7rqg-78g4: form-data <4.0.4 uses an unsafe random function for the
   # multipart boundary. @redocly/respect-core pins 4.0.0; patched in 4.0.4+.
   form-data@4: 4.0.6
-  tar: 7.5.16
+  # ENG-1947 / GHSA-23hp-3jrh-7fpw (CVE-2026-59873): node-tar <=7.5.18 has no hard
+  # upper bound on total decompressed bytes / entry count, so a small gzip bomb can
+  # exhaust disk and CPU (DoS). Patched in 7.5.19.
+  tar: 7.5.19
   # ENG-1527-batch / GHSA-mh29-5h37-fv8m + GHSA-h67p-54hq-rp68: js-yaml <4.1.2 quadratic-complexity
   # DoS via merge keys / repeated aliases (dev-only, via @redocly/cli). No 4.1.2 published; 4.2.0 is the
   # lowest patched and stays <5. Scoped to the 4.x line so any 3.x consumer is untouched.


### PR DESCRIPTION
## Problem

Dependabot alert [#631](https://github.com/formbricks/formbricks/security/dependabot/631) — **critical**.

`node-tar` (`tar`) `<=7.5.18` enforces no hard upper bound on total decompressed bytes, entry count, or decompression ratio during extraction. `maxReadSize` only caps internal read chunk size (16MB default), not cumulative bytes written to disk. A small, highly-compressible "gzip bomb" can therefore expand to gigabytes and exhaust disk + CPU — an unauthenticated **Denial of Service**.

- **Advisory:** GHSA-23hp-3jrh-7fpw
- **CVE:** CVE-2026-59873
- **Affected:** `<= 7.5.18`
- **Patched:** `7.5.19`

## Solution

`tar` is a transitive-only dependency (no direct dep in the workspace). Raised the existing security override in `pnpm-workspace.yaml` from `7.5.16` to the patched `7.5.19` and regenerated the lockfile.

Note: pnpm 11.7 no longer reads `pnpm.overrides` from `package.json` — overrides live in `pnpm-workspace.yaml`.

## Changes

- `pnpm-workspace.yaml` — `tar: 7.5.16` → `7.5.19` (+ advisory comment)
- `pnpm-lock.yaml` — regenerated; `tar@7.5.19` at both lockfile entries

Closes ENG-1947.