### PR TITLE
feat(auth): block mailbox.org and yeah.net email domains

### DIFF
--- a/apps/web/modules/auth/lib/personal-email-domains.ts
+++ b/apps/web/modules/auth/lib/personal-email-domains.ts
@@ -34,6 +34,7 @@ export const PERSONAL_EMAIL_DOMAINS: readonly string[] = [
   "proton.me",
   "protonmail.com",
   "pm.me",
+  "mailbox.org",
   // Other mainstream / international
   "gmx.com",
   "gmx.net",
@@ -44,4 +45,5 @@ export const PERSONAL_EMAIL_DOMAINS: readonly string[] = [
   "qq.com",
   "163.com",
   "126.com",
+  "yeah.net",
 ];

--- a/apps/web/modules/auth/lib/personal-email-domains.ts
+++ b/apps/web/modules/auth/lib/personal-email-domains.ts
@@ -25,16 +25,21 @@ export const PERSONAL_EMAIL_DOMAINS: readonly string[] = [
   "yahoo.com",
   "yahoo.co.uk",
   "ymail.com",
+  "rocketmail.com",
   "aol.com",
   // Apple
   "icloud.com",
   "me.com",
   "mac.com",
-  // Privacy-focused
+  // Privacy-focused / relay
   "proton.me",
   "protonmail.com",
   "pm.me",
+  "passmail.com",
   "mailbox.org",
+  "posteo.de",
+  "mozmail.com",
+  "duck.com",
   // Other mainstream / international
   "gmx.com",
   "gmx.net",
@@ -43,7 +48,13 @@ export const PERSONAL_EMAIL_DOMAINS: readonly string[] = [
   "zoho.com",
   "mail.com",
   "qq.com",
+  "foxmail.com",
   "163.com",
   "126.com",
   "yeah.net",
+  "emailn.de",
+  "sfr.fr",
+  "ukr.net",
+  // Common typo of gmail.com
+  "gmaill.com",
 ];

--- a/apps/web/modules/auth/lib/personal-email-domains.ts
+++ b/apps/web/modules/auth/lib/personal-email-domains.ts
@@ -19,6 +19,7 @@ export const PERSONAL_EMAIL_DOMAINS: readonly string[] = [
   // Microsoft
   "outlook.com",
   "hotmail.com",
+  "hotmail.fr",
   "live.com",
   "msn.com",
   // Yahoo / AOL


### PR DESCRIPTION
## Problem

We maintain a curated list of personal / free email providers that are blocked at signup ([`personal-email-domains.ts`](apps/web/modules/auth/lib/personal-email-domains.ts)). Two more providers need to be added to it.

## Solution

Add two domains to `PERSONAL_EMAIL_DOMAINS`:

- `mailbox.org` — placed in the **Privacy-focused** group (alongside Proton).
- `yeah.net` — placed with the **NetEase family** (alongside `163.com` / `126.com` / `qq.com`).

The list is grouped by provider (not alphabetical), so both were inserted by category to match the existing convention.

## Notes

- 🚧 **Draft** — keeping this open so we can add more domains before merging.
- No new tests needed: the existing suite in [`signup-email-domain.test.ts`](apps/web/modules/auth/lib/signup-email-domain.test.ts) asserts behavior via `isBlockedEmailDomain` and doesn't snapshot the array; disposable/burner domains continue to be handled by the `disposable-email-domains` package.
- Matching is exact on the domain after the last `@` (subdomains are intentionally not blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)