### PR TITLE
fix: bump tar to 7.5.19 to patch decompression DoS (backport #8604 to release/5.2)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ overrides:
   esbuild: 0.28.1
   undici@7: 7.28.0
   form-data@4: 4.0.6
-  tar: 7.5.16
+  tar: 7.5.19
   js-yaml@4: 4.2.0
 
 importers:
@@ -11512,8 +11512,8 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.19:
+    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
 
   tarn@3.0.2:
@@ -19935,7 +19935,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 7.5.16
+      tar: 7.5.19
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -22839,7 +22839,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.8.0
-      tar: 7.5.16
+      tar: 7.5.19
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -24518,7 +24518,7 @@ snapshots:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
-      tar: 7.5.16
+      tar: 7.5.19
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
@@ -24836,7 +24836,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar@7.5.16:
+  tar@7.5.19:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,7 +71,10 @@ overrides:
   # ENG-1513 / GHSA-fjxv-7rqg-78g4: form-data <4.0.4 uses an unsafe random function for the
   # multipart boundary. @redocly/respect-core pins 4.0.0; patched in 4.0.4+.
   form-data@4: 4.0.6
-  tar: 7.5.16
+  # ENG-1947 / GHSA-23hp-3jrh-7fpw (CVE-2026-59873): node-tar <=7.5.18 has no hard
+  # upper bound on total decompressed bytes / entry count, so a small gzip bomb can
+  # exhaust disk and CPU (DoS). Patched in 7.5.19.
+  tar: 7.5.19
   # ENG-1527-batch / GHSA-mh29-5h37-fv8m + GHSA-h67p-54hq-rp68: js-yaml <4.1.2 quadratic-complexity
   # DoS via merge keys / repeated aliases (dev-only, via @redocly/cli). No 4.1.2 published; 4.2.0 is the
   # lowest patched and stays <5. Scoped to the 4.x line so any 3.x consumer is untouched.


### PR DESCRIPTION
Backport of #8604 to `release/5.2`.

Minimal, single-fix backport per policy — security dependency bump only, no code/refactors.

## What & why

**ENG-1947 / GHSA-23hp-3jrh-7fpw (CVE-2026-59873):** node-tar `<=7.5.18` has no hard upper bound on total decompressed bytes / entry count, so a small gzip bomb can exhaust disk and CPU (DoS). Patched in `7.5.19`.

Bumps the `tar` pnpm override `7.5.16 -> 7.5.19` (release/5.2 was pinned at 7.5.16). This was the sole **critical** finding in a `pnpm audit` of `release/5.2`.

## Files changed
- `pnpm-workspace.yaml` — `tar` override 7.5.16 -> 7.5.19 (+ advisory comment)
- `pnpm-lock.yaml` — regenerated resolutions

No net-new tests carried (none in the source PR).

## QA / Test Plan
- Dependency-only change; no runtime code touched.
- `pnpm install --frozen-lockfile --ignore-scripts` → **lockfile up to date**, resolution skipped, **supply-chain policies pass** (2396 entries).
- Post-bump lockfile resolves `tar@7.5.19` across all paths (verified via `pnpm-lock.yaml` diff).

Cherry-picked commit: `bab631f1c26ef0ee90419e487eb171b0f8599920`.
