### PR TITLE
feat(helm): backport Hub volume extension points to release/5.2

### DIFF
--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -97,6 +97,40 @@ The TEI service is internal-only (`ClusterIP`) and not exposed through ingress. 
 
 When TEI auth is enabled, configure the shared key through `hub.embeddings.auth.apiKey` or `hub.embeddings.auth.existingSecret`; the chart manages both TEI `API_KEY` and Hub `EMBEDDING_PROVIDER_API_KEY` from that source.
 
+Configure Hub enrichment providers through `hub.env`. API-key providers can keep their secrets in
+`hub.existingSecret`. Providers that need credential files, custom CA bundles, or other pod-level
+configuration can use the provider-neutral `hub.extraVolumes` and `hub.extraVolumeMounts`
+settings, which apply to both Hub API and hub-worker.
+
+For example, a Vertex AI deployment can mount an existing Google credential JSON Secret and point
+Application Default Credentials at it:
+
+```yaml
+hub:
+  extraVolumes:
+    - name: google-cloud-credentials
+      secret:
+        secretName: formbricks-app-secrets
+        items:
+          - key: GOOGLE_APPLICATION_CREDENTIALS_JSON
+            path: credentials.json
+
+  extraVolumeMounts:
+    - name: google-cloud-credentials
+      mountPath: /var/run/secrets/formbricks/google
+      readOnly: true
+
+  env:
+    GOOGLE_APPLICATION_CREDENTIALS: /var/run/secrets/formbricks/google/credentials.json
+    SENTIMENT_PROVIDER: google-gemini
+    SENTIMENT_MODEL: gemini-2.5-flash
+    SENTIMENT_GOOGLE_CLOUD_PROJECT: your-google-cloud-project
+    SENTIMENT_GOOGLE_CLOUD_LOCATION: global
+```
+
+The chart renders these additions unchanged into both Hub processes. Keep credential values out of
+values files and reference existing Kubernetes Secrets instead.
+
 Autoscaling is opt-in for Hub API, Hub worker, and the embeddings runtime. If you scale the embeddings runtime above one replica while persistence is enabled, the cache PVC must support `ReadWriteMany`; otherwise set `hub.embeddings.persistence.enabled=false` or provide a compatible `existingClaim`.
 
 ## Web AI with self-hosted Qwen/vLLM
@@ -338,10 +372,12 @@ JSON that can call Vertex AI.
 | hub.embeddings.service.type                                        | string | `"ClusterIP"`                                                               |                                                           |
 | hub.env                                                            | object | `{}`                                                                        |                                                           |
 | hub.existingSecret                                                 | string | `""`                                                                        |                                                           |
-| hub.image.digest                                                   | string | `"sha256:b22c5f8d1e2dd79224574f526a6714a3cc5372d18f4c047eaa9d18fe6ab75591"` | When set, takes precedence over tag (immutable pin).      |
+| hub.extraVolumeMounts                                              | list   | `[]`                                                                        | Additional volume mounts for Hub API and worker.          |
+| hub.extraVolumes                                                   | list   | `[]`                                                                        | Additional pod volumes for Hub API and worker.            |
+| hub.image.digest                                                   | string | `"sha256:5d7e7c6138ff77984db54b7c91693d8f56017cefa74bc69390fc7191403208c5"` | When set, takes precedence over tag (immutable pin).      |
 | hub.image.pullPolicy                                               | string | `"IfNotPresent"`                                                            |                                                           |
 | hub.image.repository                                               | string | `"ghcr.io/formbricks/hub"`                                                  |                                                           |
-| hub.image.tag                                                      | string | `"0.6.0"`                                                                   | Fallback when digest is empty.                            |
+| hub.image.tag                                                      | string | `"0.8.1"`                                                                   | Fallback when digest is empty.                            |
 | hub.migration.activeDeadlineSeconds                                | int    | `900`                                                                       |                                                           |
 | hub.migration.backoffLimit                                         | int    | `3`                                                                         |                                                           |
 | hub.migration.ttlSecondsAfterFinished                              | int    | `300`                                                                       |                                                           |

--- a/charts/formbricks/templates/hub-deployment.yaml
+++ b/charts/formbricks/templates/hub-deployment.yaml
@@ -388,6 +388,10 @@ spec:
             {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
             {{- end }}
             {{- end }}
+          {{- with .Values.hub.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.hub.resources }}
           resources:
             {{- toYaml .Values.hub.resources | nindent 12 }}
@@ -416,3 +420,7 @@ spec:
               port: 8080
             failureThreshold: 30
             periodSeconds: 10
+      {{- with .Values.hub.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/formbricks/templates/hub-worker-deployment.yaml
+++ b/charts/formbricks/templates/hub-worker-deployment.yaml
@@ -99,8 +99,16 @@ spec:
             {{- end }}
             {{- end }}
           {{- end }}
+          {{- with .Values.hub.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.hub.worker.resources }}
           resources:
             {{- toYaml .Values.hub.worker.resources | nindent 12 }}
           {{- end }}
+      {{- with .Values.hub.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -939,10 +939,10 @@ hub:
     # Pinned by digest for immutable, reproducible deployments. When digest is set it takes
     # precedence over tag, and deployment, init container, and migration job all resolve to the
     # same immutable image. Update on each Hub release.
-    # Current digest corresponds to ghcr.io/formbricks/hub:0.8.0.
-    digest: "sha256:619d6bc4572fced76720810c1ba1665943f0a91e1c0e20fadf2f27c35b0ada14"
+    # Current digest corresponds to ghcr.io/formbricks/hub:0.8.1.
+    digest: "sha256:5d7e7c6138ff77984db54b7c91693d8f56017cefa74bc69390fc7191403208c5"
     # Tag is a fallback for dev/non-prod when digest is cleared; keep aligned with the digest above.
-    tag: "0.8.0"
+    tag: "0.8.1"
     pullPolicy: IfNotPresent
 
   # Optional override for the secret Hub reads from.
@@ -952,6 +952,12 @@ hub:
   # When secret.enabled=true, the custom Hub secret must already exist at render time so Helm can copy HUB_API_KEY
   # into the generated app secret and Envoy credential.
   existingSecret: ""
+
+  # Provider-neutral pod extensions applied to both Hub API and hub-worker.
+  # Use these for credential files, custom CA bundles, or other provider-specific runtime
+  # requirements without placing secret values in Helm values.
+  extraVolumes: []
+  extraVolumeMounts: []
 
   # Optional env vars (non-secret). Use existingSecret for secret values such as DATABASE_URL and HUB_API_KEY.
   # Applied to both the Hub API and hub-worker (the worker merges hub.env), so providers set here also


### PR DESCRIPTION
## What changed

Backports `f7bf6fba80ce58a01438308bb7d632970c3cadc8` / #8504 onto `release/5.2`.

- adds provider-neutral `hub.extraVolumes` and `hub.extraVolumeMounts`
- applies the additions to both Hub API and hub-worker
- documents file-based provider credentials
- keeps the source change's corrected Hub 0.8.1 default

## Why

The 5.2 release line branched immediately before the Hub volume-extension commit, so the `5.2.1` chart does not contain the secret-mount support used by Formbricks Cloud production. Backporting it gives the release branch a compatible Helm revision that can be promoted together with the 5.2.1 application image.

## Validation

- `git diff --check origin/release/5.2...HEAD`
- `helm lint charts/formbricks`
- rendered the chart with EU production values and confirmed `google-cloud-credentials` is mounted into both `formbricks-hub` and `formbricks-hub-worker`
- rendered the chart successfully with KSA production values
