### PR TITLE
feat: add canonical AuthZed schema deployment

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Build web workspace dependencies
         run: pnpm build --filter=@formbricks/web^...
 
+      - name: Test AuthZed client and schema lifecycle
+        run: pnpm --dir apps/web test lib/authzed
+
       - name: Validate Compose contracts
         run: bash docker/authzed-compose-contract.sh
 

--- a/apps/web/lib/authzed/__mocks__/client-dependencies.ts
+++ b/apps/web/lib/authzed/__mocks__/client-dependencies.ts
@@ -3,8 +3,10 @@ import { vi } from "vitest";
 export const sdkMocks = {
   close: vi.fn(),
   deadlineInterceptor: vi.fn((timeoutMs: number) => ({ timeoutMs })),
+  diffSchema: vi.fn(),
   newClient: vi.fn(),
   readSchema: vi.fn(),
+  writeSchema: vi.fn(),
 };
 
 export const configMocks = {

--- a/apps/web/lib/authzed/client.test.ts
+++ b/apps/web/lib/authzed/client.test.ts
@@ -9,8 +9,10 @@ describe("AuthZed client facade", () => {
     closeAuthzedClient();
     sdkMocks.close.mockReset();
     sdkMocks.deadlineInterceptor.mockClear();
+    sdkMocks.diffSchema.mockReset();
     sdkMocks.newClient.mockReset();
     sdkMocks.readSchema.mockReset();
+    sdkMocks.writeSchema.mockReset();
     configMocks.isAuthzedEnabled.mockReset();
     retryMocks.execute.mockClear();
     envMock.AUTHZED_CONSISTENCY = undefined;
@@ -20,7 +22,11 @@ describe("AuthZed client facade", () => {
     envMock.AUTHZED_TOKEN = "private-token";
     sdkMocks.newClient.mockReturnValue({
       close: sdkMocks.close,
-      promises: { readSchema: sdkMocks.readSchema },
+      promises: {
+        diffSchema: sdkMocks.diffSchema,
+        readSchema: sdkMocks.readSchema,
+        writeSchema: sdkMocks.writeSchema,
+      },
     });
     configMocks.isAuthzedEnabled.mockReturnValue(true);
   });
@@ -87,7 +93,13 @@ describe("AuthZed client facade", () => {
 
     expect(first).toBe(second);
     expect(sdkMocks.newClient).toHaveBeenCalledTimes(1);
-    expect(Object.keys(first).sort()).toEqual(["consistency", "readSchema", "systemKey"]);
+    expect(Object.keys(first).sort()).toEqual([
+      "consistency",
+      "diffSchema",
+      "readSchema",
+      "systemKey",
+      "writeSchema",
+    ]);
     expect(first).not.toHaveProperty("token");
     expect(first).not.toHaveProperty("promises");
     expect(first).not.toHaveProperty("close");
@@ -122,5 +134,47 @@ describe("AuthZed client facade", () => {
 
     await expect(getAuthzedClient().readSchema()).resolves.toEqual({ schemaText: "" });
     expect(retryMocks.execute).toHaveBeenCalledWith("read_schema", expect.any(Function));
+  });
+
+  test("returns only aggregate schema differences without SDK details", async () => {
+    sdkMocks.diffSchema.mockResolvedValue({
+      diffs: [
+        { diff: { definitionAdded: { name: "private_definition" }, oneofKind: "definitionAdded" } },
+        { diff: { definitionAdded: { name: "another_private_definition" }, oneofKind: "definitionAdded" } },
+        {
+          diff: {
+            oneofKind: "permissionExprChanged",
+            permissionExprChanged: { name: "private_permission" },
+          },
+        },
+        { diff: { oneofKind: undefined } },
+      ],
+      readAt: { token: "private-revision" },
+    });
+
+    await expect(getAuthzedClient().diffSchema("definition user {}")).resolves.toEqual({
+      differenceCount: 4,
+      differenceKinds: {
+        definition_added: 2,
+        permission_expr_changed: 1,
+        unknown: 1,
+      },
+    });
+    expect(sdkMocks.diffSchema).toHaveBeenCalledWith({
+      comparisonSchema: "definition user {}",
+      consistency: {
+        requirement: { fullyConsistent: true, oneofKind: "fullyConsistent" },
+      },
+    });
+    expect(retryMocks.execute).toHaveBeenCalledWith("diff_schema", expect.any(Function));
+  });
+
+  test("writes the supplied schema through an explicitly retried schema operation", async () => {
+    sdkMocks.writeSchema.mockResolvedValue({ writtenAt: { token: "private-revision" } });
+
+    await expect(getAuthzedClient().writeSchema("definition user {}")).resolves.toBeUndefined();
+
+    expect(sdkMocks.writeSchema).toHaveBeenCalledWith({ schema: "definition user {}" });
+    expect(retryMocks.execute).toHaveBeenCalledWith("write_schema", expect.any(Function));
   });
 });

--- a/apps/web/lib/authzed/client.ts
+++ b/apps/web/lib/authzed/client.ts
@@ -10,10 +10,17 @@ export type TAuthzedSchema = Readonly<{
   schemaText: string;
 }>;
 
+export type TAuthzedSchemaDiff = Readonly<{
+  differenceCount: number;
+  differenceKinds: Readonly<Record<string, number>>;
+}>;
+
 export type TAuthzedClient = Readonly<{
   consistency: TAuthzedConsistency;
+  diffSchema: (schemaText: string) => Promise<TAuthzedSchemaDiff>;
   readSchema: () => Promise<TAuthzedSchema>;
   systemKey: string;
+  writeSchema: (schemaText: string) => Promise<void>;
 }>;
 
 type TAuthzedClientSingleton = Readonly<{
@@ -38,6 +45,36 @@ type TAuthzedConfig =
 
 const globalForAuthzed = globalThis as unknown as {
   formbricksAuthzedClient: TAuthzedClientSingleton | undefined;
+};
+
+const STABLE_SCHEMA_DIFF_KINDS = {
+  caveatAdded: "caveat_added",
+  caveatDocCommentChanged: "caveat_doc_comment_changed",
+  caveatExprChanged: "caveat_expr_changed",
+  caveatParameterAdded: "caveat_parameter_added",
+  caveatParameterRemoved: "caveat_parameter_removed",
+  caveatParameterTypeChanged: "caveat_parameter_type_changed",
+  caveatRemoved: "caveat_removed",
+  definitionAdded: "definition_added",
+  definitionDocCommentChanged: "definition_doc_comment_changed",
+  definitionRemoved: "definition_removed",
+  permissionAdded: "permission_added",
+  permissionDocCommentChanged: "permission_doc_comment_changed",
+  permissionExprChanged: "permission_expr_changed",
+  permissionRemoved: "permission_removed",
+  relationAdded: "relation_added",
+  relationDocCommentChanged: "relation_doc_comment_changed",
+  relationRemoved: "relation_removed",
+  relationSubjectTypeAdded: "relation_subject_type_added",
+  relationSubjectTypeRemoved: "relation_subject_type_removed",
+} as const;
+
+const toStableDiffKind = (kind: string | undefined): string => {
+  if (!kind || !Object.hasOwn(STABLE_SCHEMA_DIFF_KINDS, kind)) {
+    return "unknown";
+  }
+
+  return STABLE_SCHEMA_DIFF_KINDS[kind as keyof typeof STABLE_SCHEMA_DIFF_KINDS];
 };
 
 const getAuthzedConfig = (): TAuthzedConfig => {
@@ -85,6 +122,27 @@ const createAuthzedClient = (): TAuthzedClientSingleton => {
 
   const facade = Object.freeze<TAuthzedClient>({
     consistency: config.consistency,
+    diffSchema: async (schemaText) =>
+      executeAuthzedOperation("diff_schema", async () => {
+        const response = await sdkClient.promises.diffSchema({
+          comparisonSchema: schemaText,
+          // Operational schema checks must observe the latest write. The application's configurable
+          // permission-check consistency is intentionally not used for deployment verification.
+          consistency: {
+            requirement: { fullyConsistent: true, oneofKind: "fullyConsistent" },
+          },
+        });
+        const differenceKinds = response.diffs.reduce<Record<string, number>>((counts, difference) => {
+          const kind = toStableDiffKind(difference.diff.oneofKind);
+          counts[kind] = (counts[kind] ?? 0) + 1;
+          return counts;
+        }, {});
+
+        return {
+          differenceCount: response.diffs.length,
+          differenceKinds: Object.freeze(differenceKinds),
+        };
+      }),
     readSchema: async () => {
       const schemaText = await executeAuthzedOperation("read_schema", async () => {
         try {
@@ -103,6 +161,13 @@ const createAuthzedClient = (): TAuthzedClientSingleton => {
       return { schemaText };
     },
     systemKey: config.systemKey,
+    // Repeating WriteSchema with the exact same schema is idempotent. Keep this explicit so future
+    // relationship writes cannot inherit retries accidentally.
+    writeSchema: async (schemaText) => {
+      await executeAuthzedOperation("write_schema", async () => {
+        await sdkClient.promises.writeSchema({ schema: schemaText });
+      });
+    },
   });
 
   return {

--- a/apps/web/lib/authzed/errors.ts
+++ b/apps/web/lib/authzed/errors.ts
@@ -12,6 +12,8 @@ export const AUTHZED_ERROR_CODES = {
   NOT_FOUND: "authzed_not_found",
   OVERLOADED: "authzed_overloaded",
   PERMISSION_DENIED: "authzed_permission_denied",
+  SCHEMA_CHANGED: "authzed_schema_changed",
+  SCHEMA_VERIFICATION_FAILED: "authzed_schema_verification_failed",
   TIMEOUT: "authzed_timeout",
   UNAUTHENTICATED: "authzed_unauthenticated",
   UNAVAILABLE: "authzed_unavailable",

--- a/apps/web/lib/authzed/index.ts
+++ b/apps/web/lib/authzed/index.ts
@@ -1,6 +1,17 @@
 import "server-only";
 
-export { getAuthzedClient, type TAuthzedClient, type TAuthzedSchema } from "./client";
+export {
+  getAuthzedClient,
+  type TAuthzedClient,
+  type TAuthzedSchema,
+  type TAuthzedSchemaDiff,
+} from "./client";
 export { isAuthzedEnabled, type TAuthzedConsistency } from "./config";
 export { AuthzedError, type TAuthzedErrorCode } from "./errors";
 export { checkAuthzedHealth, type TAuthzedHealthResult } from "./health";
+export {
+  applyCanonicalAuthzedSchema,
+  checkCanonicalAuthzedSchema,
+  type TAuthzedSchemaApplyResult,
+  type TAuthzedSchemaCheckResult,
+} from "./schema";

--- a/apps/web/lib/authzed/schema-cli.test.ts
+++ b/apps/web/lib/authzed/schema-cli.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test, vi } from "vitest";
+import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
+import { runAuthzedSchemaCli } from "./schema-cli";
+
+vi.mock("./client", () => ({ closeAuthzedClient: vi.fn() }));
+vi.mock("./schema", () => ({
+  applyCanonicalAuthzedSchema: vi.fn(),
+  checkCanonicalAuthzedSchema: vi.fn(),
+}));
+
+const matchedResult = {
+  differenceCount: 0,
+  differenceKinds: {},
+  remoteDigest: "sha256:remote",
+  remoteState: "present",
+  sourceDigest: "sha256:source",
+  status: "matched",
+} as const;
+
+const driftedResult = {
+  differenceCount: 1,
+  differenceKinds: { definition_added: 1 },
+  remoteDigest: "sha256:remote",
+  remoteState: "present",
+  sourceDigest: "sha256:source",
+  status: "drifted",
+} as const;
+
+describe("runAuthzedSchemaCli", () => {
+  test.each([
+    [matchedResult, 0],
+    [driftedResult, 2],
+  ] as const)("serializes a check result and returns exit code %i", async (result, exitCode) => {
+    const closeClient = vi.fn();
+    const writeOutput = vi.fn();
+
+    await expect(
+      runAuthzedSchemaCli(
+        { action: "check" },
+        {
+          checkSchema: vi.fn().mockResolvedValue(result),
+          closeClient,
+          writeOutput,
+        }
+      )
+    ).resolves.toBe(exitCode);
+
+    expect(writeOutput).toHaveBeenCalledOnce();
+    expect(writeOutput).toHaveBeenCalledWith(`${JSON.stringify(result)}\n`);
+    expect(closeClient).toHaveBeenCalledOnce();
+  });
+
+  test.each(["applied", "unchanged"] as const)("returns success for an %s apply", async (status) => {
+    const result = {
+      differenceCount: 0,
+      remoteDigest: "sha256:remote",
+      remoteState: "present",
+      sourceDigest: "sha256:source",
+      status,
+    } as const;
+    const applySchema = vi.fn().mockResolvedValue(result);
+    const closeClient = vi.fn();
+    const writeOutput = vi.fn();
+
+    await expect(
+      runAuthzedSchemaCli(
+        { action: "apply", expectedCurrentDigest: "sha256:previous" },
+        { applySchema, closeClient, writeOutput }
+      )
+    ).resolves.toBe(0);
+
+    expect(applySchema).toHaveBeenCalledWith("sha256:previous");
+    expect(writeOutput).toHaveBeenCalledWith(`${JSON.stringify(result)}\n`);
+    expect(closeClient).toHaveBeenCalledOnce();
+  });
+
+  test("prints only the stable error contract and closes the client on failure", async () => {
+    const secret = "never-log-this-authzed-token";
+    const closeClient = vi.fn();
+    const writeOutput = vi.fn();
+
+    await expect(
+      runAuthzedSchemaCli(
+        { action: "apply" },
+        {
+          applySchema: vi.fn().mockRejectedValue(
+            new AuthzedError({
+              attempts: 1,
+              cause: new Error(secret),
+              code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+              operation: "write_schema",
+              retryable: true,
+            })
+          ),
+          closeClient,
+          writeOutput,
+        }
+      )
+    ).resolves.toBe(1);
+
+    expect(writeOutput).toHaveBeenCalledWith(
+      `${JSON.stringify({
+        code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+        retryable: true,
+        status: "failed",
+      })}\n`
+    );
+    expect(JSON.stringify(writeOutput.mock.calls)).not.toContain(secret);
+    expect(closeClient).toHaveBeenCalledOnce();
+  });
+
+  test("sanitizes unexpected errors", async () => {
+    const secret = "never-log-this-schema";
+    const writeOutput = vi.fn();
+
+    await expect(
+      runAuthzedSchemaCli(
+        { action: "check" },
+        {
+          checkSchema: vi.fn().mockRejectedValue(new Error(secret)),
+          closeClient: vi.fn(),
+          writeOutput,
+        }
+      )
+    ).resolves.toBe(1);
+
+    expect(writeOutput).toHaveBeenCalledWith(
+      `${JSON.stringify({
+        code: AUTHZED_ERROR_CODES.INTERNAL,
+        retryable: false,
+        status: "failed",
+      })}\n`
+    );
+    expect(JSON.stringify(writeOutput.mock.calls)).not.toContain(secret);
+  });
+});

--- a/apps/web/lib/authzed/schema-cli.test.ts
+++ b/apps/web/lib/authzed/schema-cli.test.ts
@@ -133,4 +133,23 @@ describe("runAuthzedSchemaCli", () => {
     );
     expect(JSON.stringify(writeOutput.mock.calls)).not.toContain(secret);
   });
+
+  test("preserves the schema result when closing the client fails", async () => {
+    const writeOutput = vi.fn();
+
+    await expect(
+      runAuthzedSchemaCli(
+        { action: "check" },
+        {
+          checkSchema: vi.fn().mockResolvedValue(driftedResult),
+          closeClient: vi.fn(() => {
+            throw new Error("close failed");
+          }),
+          writeOutput,
+        }
+      )
+    ).resolves.toBe(2);
+
+    expect(writeOutput).toHaveBeenCalledWith(`${JSON.stringify(driftedResult)}\n`);
+  });
 });

--- a/apps/web/lib/authzed/schema-cli.ts
+++ b/apps/web/lib/authzed/schema-cli.ts
@@ -1,0 +1,70 @@
+import "server-only";
+import { closeAuthzedClient } from "./client";
+import { AuthzedError, type TAuthzedErrorCode, mapAuthzedError } from "./errors";
+import {
+  type TAuthzedSchemaApplyResult,
+  type TAuthzedSchemaCheckResult,
+  applyCanonicalAuthzedSchema,
+  checkCanonicalAuthzedSchema,
+} from "./schema";
+
+export type TAuthzedSchemaCliCommand =
+  | Readonly<{ action: "check" }>
+  | Readonly<{ action: "apply"; expectedCurrentDigest?: string }>;
+
+type TAuthzedSchemaCliFailure = Readonly<{
+  code: TAuthzedErrorCode;
+  retryable: boolean;
+  status: "failed";
+}>;
+
+type TAuthzedSchemaCliDependencies = Readonly<{
+  applySchema: (expectedCurrentDigest?: string) => Promise<TAuthzedSchemaApplyResult>;
+  checkSchema: () => Promise<TAuthzedSchemaCheckResult>;
+  closeClient: () => void;
+  writeOutput: (output: string) => void;
+}>;
+
+const defaultDependencies: TAuthzedSchemaCliDependencies = {
+  applySchema: applyCanonicalAuthzedSchema,
+  checkSchema: checkCanonicalAuthzedSchema,
+  closeClient: closeAuthzedClient,
+  writeOutput: (output) => process.stdout.write(output),
+};
+
+const toFailureResult = (error: unknown): TAuthzedSchemaCliFailure => {
+  const authzedError = error instanceof AuthzedError ? error : mapAuthzedError(error, "schema_cli", 1);
+
+  return {
+    code: authzedError.code,
+    retryable: authzedError.retryable,
+    status: "failed",
+  };
+};
+
+export const runAuthzedSchemaCli = async (
+  command: TAuthzedSchemaCliCommand,
+  dependencyOverrides: Partial<TAuthzedSchemaCliDependencies> = {}
+): Promise<number> => {
+  const dependencies = { ...defaultDependencies, ...dependencyOverrides };
+  let result: TAuthzedSchemaApplyResult | TAuthzedSchemaCheckResult | TAuthzedSchemaCliFailure;
+  let exitCode: number;
+
+  try {
+    if (command.action === "apply") {
+      result = await dependencies.applySchema(command.expectedCurrentDigest);
+      exitCode = 0;
+    } else {
+      result = await dependencies.checkSchema();
+      exitCode = result.status === "matched" ? 0 : 2;
+    }
+  } catch (error) {
+    result = toFailureResult(error);
+    exitCode = 1;
+  } finally {
+    dependencies.closeClient();
+  }
+
+  dependencies.writeOutput(`${JSON.stringify(result)}\n`);
+  return exitCode;
+};

--- a/apps/web/lib/authzed/schema-cli.ts
+++ b/apps/web/lib/authzed/schema-cli.ts
@@ -62,7 +62,11 @@ export const runAuthzedSchemaCli = async (
     result = toFailureResult(error);
     exitCode = 1;
   } finally {
-    dependencies.closeClient();
+    try {
+      dependencies.closeClient();
+    } catch {
+      // Cleanup failures must not replace the schema operation's result or exit code.
+    }
   }
 
   dependencies.writeOutput(`${JSON.stringify(result)}\n`);

--- a/apps/web/lib/authzed/schema.test.ts
+++ b/apps/web/lib/authzed/schema.test.ts
@@ -1,0 +1,186 @@
+import { createHash } from "node:crypto";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
+import { applyCanonicalAuthzedSchema, checkCanonicalAuthzedSchema } from "./schema";
+
+vi.mock("./client", () => ({ getAuthzedClient: vi.fn() }));
+
+const canonicalSchema = "definition user {}\n";
+const remoteSchema = "definition document {}\n";
+const digest = (schemaText: string): string =>
+  `sha256:${createHash("sha256").update(schemaText).digest("hex")}`;
+
+const createDependencies = () => ({
+  diffSchema: vi.fn(),
+  readCanonicalSchema: vi.fn().mockResolvedValue(canonicalSchema),
+  readSchema: vi.fn(),
+  writeSchema: vi.fn(),
+});
+
+describe("canonical AuthZed schema lifecycle", () => {
+  let dependencies: ReturnType<typeof createDependencies>;
+
+  beforeEach(() => {
+    dependencies = createDependencies();
+  });
+
+  const overrides = () => ({
+    getClient: () => ({
+      diffSchema: dependencies.diffSchema,
+      readSchema: dependencies.readSchema,
+      writeSchema: dependencies.writeSchema,
+    }),
+    readCanonicalSchema: dependencies.readCanonicalSchema,
+  });
+
+  test("reports an empty SpiceDB installation as drift without diffing", async () => {
+    dependencies.readSchema.mockResolvedValue({ schemaText: "" });
+
+    await expect(checkCanonicalAuthzedSchema(overrides())).resolves.toEqual({
+      differenceCount: 1,
+      differenceKinds: { schema_missing: 1 },
+      remoteDigest: null,
+      remoteState: "empty",
+      sourceDigest: digest(canonicalSchema),
+      status: "drifted",
+    });
+    expect(dependencies.diffSchema).not.toHaveBeenCalled();
+  });
+
+  test("uses semantic differences instead of raw text equality", async () => {
+    dependencies.readSchema.mockResolvedValue({ schemaText: `${canonicalSchema}\n` });
+    dependencies.diffSchema.mockResolvedValue({ differenceCount: 0, differenceKinds: {} });
+
+    await expect(checkCanonicalAuthzedSchema(overrides())).resolves.toEqual({
+      differenceCount: 0,
+      differenceKinds: {},
+      remoteDigest: digest(`${canonicalSchema}\n`),
+      remoteState: "present",
+      sourceDigest: digest(canonicalSchema),
+      status: "matched",
+    });
+    expect(dependencies.diffSchema).toHaveBeenCalledWith(canonicalSchema);
+  });
+
+  test("reports only aggregate semantic drift and content digests", async () => {
+    dependencies.readSchema.mockResolvedValue({ schemaText: remoteSchema });
+    dependencies.diffSchema.mockResolvedValue({
+      differenceCount: 2,
+      differenceKinds: { definition_added: 1, definition_removed: 1 },
+    });
+
+    await expect(checkCanonicalAuthzedSchema(overrides())).resolves.toEqual({
+      differenceCount: 2,
+      differenceKinds: { definition_added: 1, definition_removed: 1 },
+      remoteDigest: digest(remoteSchema),
+      remoteState: "present",
+      sourceDigest: digest(canonicalSchema),
+      status: "drifted",
+    });
+  });
+
+  test("rejects an empty or unreadable canonical source with a stable sanitized error", async () => {
+    const secretPath = "/private/never-log-this-token";
+    dependencies.readCanonicalSchema.mockRejectedValue(new Error(secretPath));
+
+    const result = await checkCanonicalAuthzedSchema(overrides()).catch((error: unknown) => error);
+
+    expect(result).toBeInstanceOf(AuthzedError);
+    expect(result).toMatchObject({
+      code: AUTHZED_ERROR_CODES.INTERNAL,
+      message: AUTHZED_ERROR_CODES.INTERNAL,
+      operation: "load_canonical_schema",
+      retryable: false,
+    });
+    expect((result as Error).message).not.toContain(secretPath);
+
+    dependencies.readCanonicalSchema.mockResolvedValue(" \n");
+    await expect(checkCanonicalAuthzedSchema(overrides())).rejects.toMatchObject({
+      code: AUTHZED_ERROR_CODES.INTERNAL,
+    });
+  });
+
+  test("applies to an empty installation and verifies semantic convergence", async () => {
+    dependencies.readSchema
+      .mockResolvedValueOnce({ schemaText: "" })
+      .mockResolvedValueOnce({ schemaText: canonicalSchema });
+    dependencies.diffSchema.mockResolvedValue({ differenceCount: 0, differenceKinds: {} });
+
+    await expect(applyCanonicalAuthzedSchema(undefined, overrides())).resolves.toEqual({
+      differenceCount: 0,
+      remoteDigest: digest(canonicalSchema),
+      remoteState: "present",
+      sourceDigest: digest(canonicalSchema),
+      status: "applied",
+    });
+    expect(dependencies.writeSchema).toHaveBeenCalledOnce();
+    expect(dependencies.writeSchema).toHaveBeenCalledWith(canonicalSchema);
+  });
+
+  test("returns unchanged without writing when the remote schema already matches", async () => {
+    dependencies.readSchema.mockResolvedValue({ schemaText: canonicalSchema });
+    dependencies.diffSchema.mockResolvedValue({ differenceCount: 0, differenceKinds: {} });
+
+    await expect(applyCanonicalAuthzedSchema(undefined, overrides())).resolves.toEqual({
+      differenceCount: 0,
+      remoteDigest: digest(canonicalSchema),
+      remoteState: "present",
+      sourceDigest: digest(canonicalSchema),
+      status: "unchanged",
+    });
+    expect(dependencies.writeSchema).not.toHaveBeenCalled();
+  });
+
+  test("requires the reviewed current digest before replacing non-empty drift", async () => {
+    dependencies.readSchema.mockResolvedValue({ schemaText: remoteSchema });
+    dependencies.diffSchema.mockResolvedValue({
+      differenceCount: 1,
+      differenceKinds: { definition_removed: 1 },
+    });
+
+    await expect(applyCanonicalAuthzedSchema(undefined, overrides())).rejects.toMatchObject({
+      attempts: 0,
+      code: AUTHZED_ERROR_CODES.SCHEMA_CHANGED,
+      operation: "write_schema_precondition",
+      retryable: false,
+    });
+    await expect(applyCanonicalAuthzedSchema("sha256:incorrect", overrides())).rejects.toMatchObject({
+      code: AUTHZED_ERROR_CODES.SCHEMA_CHANGED,
+    });
+    expect(dependencies.writeSchema).not.toHaveBeenCalled();
+  });
+
+  test("replaces reviewed drift and verifies the resulting schema", async () => {
+    dependencies.readSchema
+      .mockResolvedValueOnce({ schemaText: remoteSchema })
+      .mockResolvedValueOnce({ schemaText: canonicalSchema });
+    dependencies.diffSchema
+      .mockResolvedValueOnce({
+        differenceCount: 1,
+        differenceKinds: { definition_removed: 1 },
+      })
+      .mockResolvedValueOnce({ differenceCount: 0, differenceKinds: {} });
+
+    await expect(applyCanonicalAuthzedSchema(digest(remoteSchema), overrides())).resolves.toMatchObject({
+      differenceCount: 0,
+      status: "applied",
+    });
+    expect(dependencies.writeSchema).toHaveBeenCalledWith(canonicalSchema);
+  });
+
+  test("fails closed when read-back verification still detects drift", async () => {
+    dependencies.readSchema
+      .mockResolvedValueOnce({ schemaText: "" })
+      .mockResolvedValueOnce({ schemaText: remoteSchema });
+    dependencies.diffSchema.mockResolvedValue({
+      differenceCount: 1,
+      differenceKinds: { definition_removed: 1 },
+    });
+
+    await expect(applyCanonicalAuthzedSchema(undefined, overrides())).rejects.toMatchObject({
+      code: AUTHZED_ERROR_CODES.SCHEMA_VERIFICATION_FAILED,
+      operation: "verify_written_schema",
+      retryable: false,
+    });
+  });
+});

--- a/apps/web/lib/authzed/schema.ts
+++ b/apps/web/lib/authzed/schema.ts
@@ -1,0 +1,181 @@
+import "server-only";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { type TAuthzedClient, getAuthzedClient } from "./client";
+import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
+
+type TAuthzedSchemaDigest = `sha256:${string}`;
+
+type TAuthzedSchemaState = Readonly<{
+  remoteDigest: TAuthzedSchemaDigest | null;
+  remoteState: "empty" | "present";
+  sourceDigest: TAuthzedSchemaDigest;
+}>;
+
+export type TAuthzedSchemaCheckResult =
+  | (TAuthzedSchemaState &
+      Readonly<{
+        differenceCount: 0;
+        differenceKinds: Readonly<Record<string, never>>;
+        remoteDigest: TAuthzedSchemaDigest;
+        remoteState: "present";
+        status: "matched";
+      }>)
+  | (TAuthzedSchemaState &
+      Readonly<{
+        differenceCount: number;
+        differenceKinds: Readonly<Record<string, number>>;
+        status: "drifted";
+      }>);
+
+export type TAuthzedSchemaApplyResult = TAuthzedSchemaState &
+  Readonly<{
+    differenceCount: 0;
+    status: "applied" | "unchanged";
+  }>;
+
+type TAuthzedSchemaDependencies = Readonly<{
+  getClient: () => Pick<TAuthzedClient, "diffSchema" | "readSchema" | "writeSchema">;
+  readCanonicalSchema: () => Promise<string>;
+}>;
+
+const canonicalSchemaUrl = new URL("../../../../authzed/schema.zed", import.meta.url);
+
+const readCanonicalSchema = async (): Promise<string> => readFile(canonicalSchemaUrl, "utf8");
+
+const defaultDependencies: TAuthzedSchemaDependencies = {
+  getClient: getAuthzedClient,
+  readCanonicalSchema,
+};
+
+const createSchemaDigest = (schemaText: string): TAuthzedSchemaDigest =>
+  `sha256:${createHash("sha256").update(schemaText).digest("hex")}`;
+
+const loadCanonicalSchema = async (
+  dependencies: TAuthzedSchemaDependencies
+): Promise<Readonly<{ digest: TAuthzedSchemaDigest; schemaText: string }>> => {
+  try {
+    const schemaText = await dependencies.readCanonicalSchema();
+
+    if (schemaText.trim().length === 0) {
+      throw new Error("Canonical schema is empty");
+    }
+
+    return {
+      digest: createSchemaDigest(schemaText),
+      schemaText,
+    };
+  } catch (error) {
+    throw new AuthzedError({
+      attempts: 1,
+      cause: error,
+      code: AUTHZED_ERROR_CODES.INTERNAL,
+      operation: "load_canonical_schema",
+      retryable: false,
+    });
+  }
+};
+
+const compareSchema = async (
+  dependencies: TAuthzedSchemaDependencies,
+  canonicalSchema: Readonly<{ digest: TAuthzedSchemaDigest; schemaText: string }>
+): Promise<TAuthzedSchemaCheckResult> => {
+  const client = dependencies.getClient();
+  const { schemaText: remoteSchemaText } = await client.readSchema();
+
+  if (remoteSchemaText.length === 0) {
+    return {
+      differenceCount: 1,
+      differenceKinds: { schema_missing: 1 },
+      remoteDigest: null,
+      remoteState: "empty",
+      sourceDigest: canonicalSchema.digest,
+      status: "drifted",
+    };
+  }
+
+  const remoteDigest = createSchemaDigest(remoteSchemaText);
+  const differences = await client.diffSchema(canonicalSchema.schemaText);
+
+  if (differences.differenceCount === 0) {
+    return {
+      differenceCount: 0,
+      differenceKinds: {},
+      remoteDigest,
+      remoteState: "present",
+      sourceDigest: canonicalSchema.digest,
+      status: "matched",
+    };
+  }
+
+  return {
+    ...differences,
+    remoteDigest,
+    remoteState: "present",
+    sourceDigest: canonicalSchema.digest,
+    status: "drifted",
+  };
+};
+
+export const checkCanonicalAuthzedSchema = async (
+  dependencyOverrides: Partial<TAuthzedSchemaDependencies> = {}
+): Promise<TAuthzedSchemaCheckResult> => {
+  const dependencies = { ...defaultDependencies, ...dependencyOverrides };
+  const canonicalSchema = await loadCanonicalSchema(dependencies);
+
+  return compareSchema(dependencies, canonicalSchema);
+};
+
+export const applyCanonicalAuthzedSchema = async (
+  expectedCurrentDigest?: string,
+  dependencyOverrides: Partial<TAuthzedSchemaDependencies> = {}
+): Promise<TAuthzedSchemaApplyResult> => {
+  const dependencies = { ...defaultDependencies, ...dependencyOverrides };
+  const canonicalSchema = await loadCanonicalSchema(dependencies);
+  const currentState = await compareSchema(dependencies, canonicalSchema);
+
+  if (currentState.status === "matched") {
+    return {
+      differenceCount: 0,
+      remoteDigest: currentState.remoteDigest,
+      remoteState: currentState.remoteState,
+      sourceDigest: currentState.sourceDigest,
+      status: "unchanged",
+    };
+  }
+
+  const preconditionSatisfied =
+    currentState.remoteState === "empty"
+      ? expectedCurrentDigest === undefined
+      : expectedCurrentDigest === currentState.remoteDigest;
+
+  if (!preconditionSatisfied) {
+    throw new AuthzedError({
+      attempts: 0,
+      code: AUTHZED_ERROR_CODES.SCHEMA_CHANGED,
+      operation: "write_schema_precondition",
+      retryable: false,
+    });
+  }
+
+  await dependencies.getClient().writeSchema(canonicalSchema.schemaText);
+
+  const verifiedState = await compareSchema(dependencies, canonicalSchema);
+
+  if (verifiedState.status !== "matched") {
+    throw new AuthzedError({
+      attempts: 1,
+      code: AUTHZED_ERROR_CODES.SCHEMA_VERIFICATION_FAILED,
+      operation: "verify_written_schema",
+      retryable: false,
+    });
+  }
+
+  return {
+    differenceCount: 0,
+    remoteDigest: verifiedState.remoteDigest,
+    remoteState: verifiedState.remoteState,
+    sourceDigest: verifiedState.sourceDigest,
+    status: "applied",
+  };
+};

--- a/apps/web/scripts/authzed-schema-results.ts
+++ b/apps/web/scripts/authzed-schema-results.ts
@@ -1,0 +1,11 @@
+export const INVALID_REQUEST_RESULT = {
+  code: "authzed_invalid_request",
+  retryable: false,
+  status: "failed",
+} as const;
+
+export const INVALID_CONFIGURATION_RESULT = {
+  code: "authzed_internal",
+  retryable: false,
+  status: "failed",
+} as const;

--- a/apps/web/scripts/authzed-schema.test.ts
+++ b/apps/web/scripts/authzed-schema.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+import { AUTHZED_ERROR_CODES } from "../lib/authzed/errors";
+import { INVALID_CONFIGURATION_RESULT, INVALID_REQUEST_RESULT } from "./authzed-schema-results";
+
+describe("authzed schema script results", () => {
+  test("keeps the argument error code aligned with the AuthZed error contract", () => {
+    expect(INVALID_REQUEST_RESULT.code).toBe(AUTHZED_ERROR_CODES.INVALID_REQUEST);
+  });
+
+  test("keeps the configuration error code aligned with the AuthZed error contract", () => {
+    expect(INVALID_CONFIGURATION_RESULT.code).toBe(AUTHZED_ERROR_CODES.INTERNAL);
+  });
+});

--- a/apps/web/scripts/authzed-schema.ts
+++ b/apps/web/scripts/authzed-schema.ts
@@ -1,0 +1,75 @@
+import "server-only";
+
+const INVALID_REQUEST_RESULT = {
+  code: "authzed_invalid_request",
+  retryable: false,
+  status: "failed",
+} as const;
+
+const INVALID_CONFIGURATION_RESULT = {
+  code: "authzed_internal",
+  retryable: false,
+  status: "failed",
+} as const;
+
+type TSchemaCommand =
+  | Readonly<{ action: "check" }>
+  | Readonly<{ action: "apply"; expectedCurrentDigest?: string }>;
+
+const parseCommand = (args: string[]): TSchemaCommand | undefined => {
+  if (args.length === 1 && args[0] === "check") {
+    return { action: "check" };
+  }
+
+  if (args[0] !== "apply") {
+    return undefined;
+  }
+
+  if (args.length === 1) {
+    return { action: "apply" };
+  }
+
+  if (
+    args.length === 3 &&
+    args[1] === "--expected-current-digest" &&
+    /^sha256:[a-f0-9]{64}$/.test(args[2] ?? "")
+  ) {
+    return { action: "apply", expectedCurrentDigest: args[2] };
+  }
+
+  return undefined;
+};
+
+const writeResult = (result: object): void => {
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+};
+
+const run = async (): Promise<void> => {
+  const command = parseCommand(process.argv.slice(2));
+
+  if (!command) {
+    writeResult(INVALID_REQUEST_RESULT);
+    process.exitCode = 1;
+    return;
+  }
+
+  const originalConsoleError = console.error;
+
+  try {
+    // Environment validation logs details before throwing. Suppress that duplicate output here so this
+    // automation-oriented command always emits exactly one sanitized JSON result.
+    console.error = () => {};
+    const { runAuthzedSchemaCli } = await import("../lib/authzed/schema-cli");
+    console.error = originalConsoleError;
+
+    process.exitCode = await runAuthzedSchemaCli(command);
+  } catch {
+    console.error = originalConsoleError;
+    writeResult(INVALID_CONFIGURATION_RESULT);
+    process.exitCode = 1;
+  } finally {
+    console.error = originalConsoleError;
+  }
+};
+
+void run();

--- a/apps/web/scripts/authzed-schema.ts
+++ b/apps/web/scripts/authzed-schema.ts
@@ -1,16 +1,5 @@
 import "server-only";
-
-const INVALID_REQUEST_RESULT = {
-  code: "authzed_invalid_request",
-  retryable: false,
-  status: "failed",
-} as const;
-
-const INVALID_CONFIGURATION_RESULT = {
-  code: "authzed_internal",
-  retryable: false,
-  status: "failed",
-} as const;
+import { INVALID_CONFIGURATION_RESULT, INVALID_REQUEST_RESULT } from "./authzed-schema-results";
 
 type TSchemaCommand =
   | Readonly<{ action: "check" }>

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -55,6 +55,8 @@ pnpm authzed:schema apply \
 ```
 
 This guards against applying over a schema the operator did not inspect.
+The digest precondition is not atomic because SpiceDB schema writes do not support compare-and-swap, so ensure
+there is no concurrent schema writer between `check` and `apply`.
 `apply` exits `0` only after reading the schema back and confirming that its
 semantic diff is empty. Applying an already matching schema returns
 `status: "unchanged"` without issuing another write. Invalid configuration,

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -21,6 +21,66 @@ The validation job is a dependency of the required `PR Check Summary`, so a
 failing assertion blocks the change: it means the schema no longer matches the
 documented semantics.
 
+## Checking and applying the schema
+
+Schema deployment is an explicit operational action. Formbricks never writes a
+schema during application startup, database migration, health checks,
+readiness, or Helm reconciliation.
+
+Configure the normal server-only AuthZed variables, then check the connected
+SpiceDB instance without changing it:
+
+```bash
+pnpm authzed:schema check
+```
+
+The command compares the checked-in schema with SpiceDB semantically by using
+the AuthZed schema-diff API. It does not compare raw formatted text. A matching
+schema exits `0`; drift exits `2`. Both cases print exactly one sanitized JSON
+object containing source and remote SHA-256 digests and aggregate difference
+counts. Schema contents and changed object names are never printed.
+
+An empty SpiceDB installation can be initialized explicitly:
+
+```bash
+pnpm authzed:schema apply
+```
+
+Replacing a non-empty schema requires the exact remote digest returned by the
+immediately preceding check:
+
+```bash
+pnpm authzed:schema apply \
+  --expected-current-digest sha256:<digest-from-check>
+```
+
+This guards against applying over a schema the operator did not inspect.
+`apply` exits `0` only after reading the schema back and confirming that its
+semantic diff is empty. Applying an already matching schema returns
+`status: "unchanged"` without issuing another write. Invalid configuration,
+transport failures, digest mismatches, unsafe SpiceDB schema changes, and
+read-back failures exit `1` with a stable `authzed_*` code.
+
+The command loads the repository `.env`. For an external TLS endpoint use a
+bare `host:port` with `AUTHZED_INSECURE=false`; internal Docker or Kubernetes
+plaintext endpoints use `AUTHZED_INSECURE=true`. Restart long-running
+Formbricks processes after changing AuthZed environment values.
+
+### Backups and rollback
+
+Before replacing any non-empty schema:
+
+1. Export the current schema with the pinned `zed` CLI.
+2. Export relationships that depend on definitions or relations being removed.
+3. Store both files with mode `0600`.
+4. Run `check` and retain its remote digest.
+5. Apply only the reviewed canonical schema.
+
+Rollback is safe only while no relationships depend on definitions introduced
+by the new schema. Once relationships exist, do not force a downgrade. Use an
+expand, backfill, and contract migration so every intermediate schema accepts
+the stored relationships.
+
 ## Guiding principle: mirror the current system
 
 The schema is a **technical migration of the current Formbricks authorization

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -152,6 +152,19 @@ endpoint; plaintext transport sends the preshared token without TLS protection. 
 the Formbricks app. Authorization checks must fail closed once product enforcement is enabled; general
 Formbricks readiness remains independent from transient SpiceDB availability.
 
+The chart deliberately does not install or update the Formbricks authorization schema. After SpiceDB is ready,
+run the release-matched repository command from an operator workstation or controlled deployment runner:
+
+```bash
+pnpm authzed:schema check
+pnpm authzed:schema apply
+```
+
+The initial apply to an empty instance needs no digest. A non-empty instance must first be checked and then
+applied with `--expected-current-digest sha256:<digest-from-check>`. This separation keeps schema changes out of
+Helm hooks, app startup, migrations, liveness, and readiness. Back up the current schema and affected
+relationships before replacement; see the repository `authzed/README.md` for exit codes and rollback rules.
+
 ## Cube
 
 Cube is part of the baseline Formbricks v5 stack and is deployed by this chart by default

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -157,7 +157,13 @@ run the release-matched repository command from an operator workstation or contr
 
 ```bash
 pnpm authzed:schema check
+
+# Empty instances only
 pnpm authzed:schema apply
+
+# Non-empty instances: use the remoteDigest returned by the immediately preceding check
+pnpm authzed:schema apply \
+  --expected-current-digest sha256:<digest-from-check>
 ```
 
 The initial apply to an empty instance needs no digest. A non-empty instance must first be checked and then

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -75,7 +75,7 @@ services:
     profiles: ["authzed-tools"]
     entrypoint: ["zed"]
     volumes:
-      - ./docker/authzed-smoke-schema.zed:/schema.zed:ro
+      - ./authzed/schema.zed:/schema.zed:ro
 
   authzed-ui:
     image: ${GRPCUI_IMAGE_REF:-fullstorydev/grpcui:v1.5.2}

--- a/docker/README.md
+++ b/docker/README.md
@@ -72,7 +72,13 @@ Installations from source can check or explicitly apply the canonical Formbricks
 
 ```bash
 pnpm authzed:schema check
+
+# Empty instances only
 pnpm authzed:schema apply
+
+# Non-empty instances: use the remoteDigest returned by the immediately preceding check
+pnpm authzed:schema apply \
+  --expected-current-digest sha256:<digest-from-check>
 ```
 
 The first apply to an empty SpiceDB needs no additional argument. Replacing a non-empty schema requires

--- a/docker/README.md
+++ b/docker/README.md
@@ -68,6 +68,19 @@ token, schema, raw SDK error, or stack trace. It is intentionally not exposed th
 and SpiceDB availability does not affect the normal Formbricks `/health` result. Restart Formbricks after
 changing AuthZed configuration.
 
+Installations from source can check or explicitly apply the canonical Formbricks schema with:
+
+```bash
+pnpm authzed:schema check
+pnpm authzed:schema apply
+```
+
+The first apply to an empty SpiceDB needs no additional argument. Replacing a non-empty schema requires
+`--expected-current-digest sha256:<digest-from-check>`. The command verifies the write by reading and comparing
+the schema again. It is never invoked by `docker compose up`, Formbricks startup, or `/health`. See
+[`authzed/README.md`](../authzed/README.md) for the JSON contract, exit codes, backup requirements, and rollback
+rules.
+
 `AUTHZED_ENABLED` and `AUTHZED_INSECURE` accept `true`, `false`, `1`, and `0`. Unset means disabled and secure
 TLS, respectively. `AUTHZED_ENDPOINT` is a bare `host:port` (including bracketed IPv6) with no scheme or path;
 `AUTHZED_CONSISTENCY` accepts `minimize_latency` (the default) or `fully_consistent`.

--- a/docker/authzed-smoke-schema.zed
+++ b/docker/authzed-smoke-schema.zed
@@ -1,6 +1,0 @@
-definition user {}
-
-definition document {
-  relation reader: user
-  permission view = reader
-}

--- a/docker/authzed-smoke.sh
+++ b/docker/authzed-smoke.sh
@@ -10,7 +10,8 @@ readonly AUTHZED_TOKEN="00000000000000000000000000000000000000000000000000000000
 readonly AUTHZED_DATABASE_PASSWORD="0000000000000000000000000000000000000000000000000000000000000002"
 readonly WRONG_AUTHZED_TOKEN="0000000000000000000000000000000000000000000000000000000000000003"
 readonly SCHEMA_LOG_SENTINEL="Canonical Formbricks authorization schema."
-readonly SMOKE_TEMP_DIR="$(mktemp -d)"
+SMOKE_TEMP_DIR="$(mktemp -d)" || exit 1
+readonly SMOKE_TEMP_DIR
 readonly DRIFT_SCHEMA_FILE="${SMOKE_TEMP_DIR}/schema-with-drift.zed"
 
 compose() {
@@ -183,12 +184,14 @@ zed() {
 
 cp "${REPO_ROOT}/authzed/schema.zed" "${DRIFT_SCHEMA_FILE}"
 printf '\n/** Disposable smoke-test drift. */\ndefinition smoke_test_drift {}\n' >>"${DRIFT_SCHEMA_FILE}"
-compose run --rm --no-deps --volume "${DRIFT_SCHEMA_FILE}:/drift-schema.zed:ro" authzed-cli \
-  schema write /drift-schema.zed \
-  --endpoint spicedb:50051 \
-  --token "${AUTHZED_TOKEN}" \
-  --insecure \
-  --skip-version-check
+drift_schema_write="$(
+  compose run --rm --no-deps --volume "${DRIFT_SCHEMA_FILE}:/drift-schema.zed:ro" authzed-cli \
+    schema write /drift-schema.zed \
+    --endpoint spicedb:50051 \
+    --token "${AUTHZED_TOKEN}" \
+    --insecure \
+    --skip-version-check 2>&1
+)"
 
 if drifted_schema_check="$(authzed_schema "${AUTHZED_TOKEN}" check 2>&1)"; then
   printf '%s\n' "Schema check unexpectedly matched a deliberately drifted schema." >&2
@@ -243,7 +246,7 @@ persisted_schema_check="$(authzed_schema "${AUTHZED_TOKEN}" check)"
 jq --exit-status '.status == "matched" and .differenceCount == 0' <<<"${persisted_schema_check}" >/dev/null
 
 service_logs="$(compose logs --no-color postgres authzed-db-bootstrap spicedb-migrate spicedb)"
-application_outputs="${empty_schema_health}${wrong_token_health}${empty_schema_check}${initial_apply}${matched_schema_check}${unchanged_apply}${drifted_schema_check}${restored_apply}${unavailable_health}${restored_health}${persisted_schema_check}"
+application_outputs="${empty_schema_health}${wrong_token_health}${empty_schema_check}${initial_apply}${matched_schema_check}${unchanged_apply}${drift_schema_write}${drifted_schema_check}${restored_apply}${unavailable_health}${restored_health}${persisted_schema_check}"
 if [[ "${service_logs}${application_outputs}" == *"${AUTHZED_TOKEN}"* || \
   "${service_logs}${application_outputs}" == *"${WRONG_AUTHZED_TOKEN}"* || \
   "${service_logs}${application_outputs}" == *"${AUTHZED_DATABASE_PASSWORD}"* || \

--- a/docker/authzed-smoke.sh
+++ b/docker/authzed-smoke.sh
@@ -9,6 +9,9 @@ readonly PROJECT_NAME="formbricks-authzed-smoke-${$}"
 readonly AUTHZED_TOKEN="0000000000000000000000000000000000000000000000000000000000000001"
 readonly AUTHZED_DATABASE_PASSWORD="0000000000000000000000000000000000000000000000000000000000000002"
 readonly WRONG_AUTHZED_TOKEN="0000000000000000000000000000000000000000000000000000000000000003"
+readonly SCHEMA_LOG_SENTINEL="Canonical Formbricks authorization schema."
+readonly SMOKE_TEMP_DIR="$(mktemp -d)"
+readonly DRIFT_SCHEMA_FILE="${SMOKE_TEMP_DIR}/schema-with-drift.zed"
 
 compose() {
   docker compose --project-name "${PROJECT_NAME}" --file "${COMPOSE_FILE}" "$@"
@@ -34,6 +37,21 @@ refresh_spicedb_port() {
 authzed_health() {
   local token="$1"
 
+  authzed_cli "${token}" ./scripts/authzed-health.ts
+}
+
+authzed_schema() {
+  local token="$1"
+  shift
+
+  authzed_cli "${token}" ./scripts/authzed-schema.ts "$@"
+}
+
+authzed_cli() {
+  local token="$1"
+  local script="$2"
+  shift 2
+
   env \
     AUTHZED_CONSISTENCY=minimize_latency \
     AUTHZED_ENABLED=true \
@@ -50,7 +68,7 @@ authzed_health() {
     LOG_LEVEL=fatal \
     NODE_ENV=test \
     NODE_OPTIONS=--conditions=react-server \
-    pnpm --dir "${REPO_ROOT}/apps/web" exec tsx ./scripts/authzed-health.ts
+    pnpm --dir "${REPO_ROOT}/apps/web" exec tsx "${script}" "$@"
 }
 
 assert_health_result() {
@@ -94,6 +112,7 @@ cleanup() {
   fi
 
   compose down --volumes --remove-orphans >/dev/null 2>&1 || true
+  rm -rf "${SMOKE_TEMP_DIR}"
   exit "${exit_code}"
 }
 
@@ -130,6 +149,30 @@ fi
 assert_health_result "${wrong_token_health}" "unhealthy" "authzed_permission_denied"
 jq --exit-status '.retryable == false' <<<"${wrong_token_health}" >/dev/null
 
+if empty_schema_check="$(authzed_schema "${AUTHZED_TOKEN}" check 2>&1)"; then
+  printf '%s\n' "Schema check unexpectedly matched before schema installation." >&2
+  exit 1
+else
+  empty_schema_check_exit_code=$?
+fi
+[[ "${empty_schema_check_exit_code}" -eq 2 ]]
+jq --exit-status \
+  '.status == "drifted" and .remoteState == "empty" and .remoteDigest == null and .differenceCount > 0' \
+  <<<"${empty_schema_check}" >/dev/null
+
+initial_apply="$(authzed_schema "${AUTHZED_TOKEN}" apply)"
+jq --exit-status \
+  '.status == "applied" and .remoteState == "present" and .differenceCount == 0 and (.sourceDigest | startswith("sha256:"))' \
+  <<<"${initial_apply}" >/dev/null
+
+matched_schema_check="$(authzed_schema "${AUTHZED_TOKEN}" check)"
+jq --exit-status \
+  '.status == "matched" and .differenceCount == 0 and (.remoteDigest | startswith("sha256:"))' \
+  <<<"${matched_schema_check}" >/dev/null
+
+unchanged_apply="$(authzed_schema "${AUTHZED_TOKEN}" apply)"
+jq --exit-status '.status == "unchanged" and .differenceCount == 0' <<<"${unchanged_apply}" >/dev/null
+
 zed() {
   compose run --rm --no-deps authzed-cli "$@" \
     --endpoint spicedb:50051 \
@@ -138,12 +181,38 @@ zed() {
     --skip-version-check
 }
 
-zed schema write /schema.zed
+cp "${REPO_ROOT}/authzed/schema.zed" "${DRIFT_SCHEMA_FILE}"
+printf '\n/** Disposable smoke-test drift. */\ndefinition smoke_test_drift {}\n' >>"${DRIFT_SCHEMA_FILE}"
+compose run --rm --no-deps --volume "${DRIFT_SCHEMA_FILE}:/drift-schema.zed:ro" authzed-cli \
+  schema write /drift-schema.zed \
+  --endpoint spicedb:50051 \
+  --token "${AUTHZED_TOKEN}" \
+  --insecure \
+  --skip-version-check
 
-zed relationship create document:smoke reader user:alice
+if drifted_schema_check="$(authzed_schema "${AUTHZED_TOKEN}" check 2>&1)"; then
+  printf '%s\n' "Schema check unexpectedly matched a deliberately drifted schema." >&2
+  exit 1
+else
+  drifted_schema_check_exit_code=$?
+fi
+[[ "${drifted_schema_check_exit_code}" -eq 2 ]]
+jq --exit-status \
+  '.status == "drifted" and .remoteState == "present" and .differenceCount > 0 and (.remoteDigest | startswith("sha256:"))' \
+  <<<"${drifted_schema_check}" >/dev/null
+drifted_schema_digest="$(jq --raw-output '.remoteDigest' <<<"${drifted_schema_check}")"
 
-alice_result="$(zed permission check document:smoke view user:alice --consistency-full)"
-bob_result="$(zed permission check document:smoke view user:bob --consistency-full)"
+restored_apply="$(
+  authzed_schema "${AUTHZED_TOKEN}" apply --expected-current-digest "${drifted_schema_digest}"
+)"
+jq --exit-status '.status == "applied" and .differenceCount == 0' <<<"${restored_apply}" >/dev/null
+
+zed relationship create organization:smoke owner user:alice
+zed relationship create workspace:smoke organization organization:smoke
+zed relationship create survey:smoke workspace workspace:smoke
+
+alice_result="$(zed permission check survey:smoke read user:alice --consistency-full)"
+bob_result="$(zed permission check survey:smoke read user:bob --consistency-full)"
 
 [[ "${alice_result}" == *"true"* ]]
 [[ "${bob_result}" == *"false"* ]]
@@ -167,16 +236,20 @@ if ! restored_health="$(authzed_health "${AUTHZED_TOKEN}" 2>&1)"; then
 fi
 assert_health_result "${restored_health}" "healthy"
 
-[[ "$(zed permission check document:smoke view user:alice --consistency-full)" == *"true"* ]]
-[[ "$(zed permission check document:smoke view user:bob --consistency-full)" == *"false"* ]]
+[[ "$(zed permission check survey:smoke read user:alice --consistency-full)" == *"true"* ]]
+[[ "$(zed permission check survey:smoke read user:bob --consistency-full)" == *"false"* ]]
+
+persisted_schema_check="$(authzed_schema "${AUTHZED_TOKEN}" check)"
+jq --exit-status '.status == "matched" and .differenceCount == 0' <<<"${persisted_schema_check}" >/dev/null
 
 service_logs="$(compose logs --no-color postgres authzed-db-bootstrap spicedb-migrate spicedb)"
-application_outputs="${empty_schema_health}${wrong_token_health}${unavailable_health}${restored_health}"
+application_outputs="${empty_schema_health}${wrong_token_health}${empty_schema_check}${initial_apply}${matched_schema_check}${unchanged_apply}${drifted_schema_check}${restored_apply}${unavailable_health}${restored_health}${persisted_schema_check}"
 if [[ "${service_logs}${application_outputs}" == *"${AUTHZED_TOKEN}"* || \
   "${service_logs}${application_outputs}" == *"${WRONG_AUTHZED_TOKEN}"* || \
-  "${service_logs}${application_outputs}" == *"${AUTHZED_DATABASE_PASSWORD}"* ]]; then
-  printf '%s\n' "AuthZed service logs exposed a configured secret." >&2
+  "${service_logs}${application_outputs}" == *"${AUTHZED_DATABASE_PASSWORD}"* || \
+  "${service_logs}${application_outputs}" == *"${SCHEMA_LOG_SENTINEL}"* ]]; then
+  printf '%s\n' "AuthZed logs exposed a configured secret or schema content." >&2
   exit 1
 fi
 
-printf '%s\n' "AuthZed smoke test passed: application health, authentication failure, bounded outage handling, idempotent migrations, and persistence were verified."
+printf '%s\n' "AuthZed smoke test passed: schema check/apply/drift recovery, application health, authentication failure, bounded outage handling, idempotent migrations, and persistence were verified."

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "db:up": "pnpm dev:setup && docker compose -f docker-compose.dev.yml up -d",
     "db:down": "docker compose -f docker-compose.dev.yml down",
     "authzed:health": "dotenv -e .env -v NODE_OPTIONS=--conditions=react-server -v LOG_LEVEL=fatal -- tsx --tsconfig apps/web/tsconfig.json ./apps/web/scripts/authzed-health.ts",
+    "authzed:schema": "dotenv -e .env -v NODE_OPTIONS=--conditions=react-server -v LOG_LEVEL=fatal -- tsx --tsconfig apps/web/tsconfig.json ./apps/web/scripts/authzed-schema.ts",
     "authzed:smoke": "bash docker/authzed-smoke.sh",
     "authzed:validate": "bash authzed/validate.sh",
     "go": "pnpm db:up && turbo run go --concurrency 20",


### PR DESCRIPTION
## Problem

[ENG-1933](https://linear.app/formbricks/issue/ENG-1933/deploy-and-verify-canonical-spicedb-schema-across-environments) needs an explicit and verifiable way to deploy the checked-in canonical SpiceDB schema. Schema writes must not happen during Formbricks startup, health checks, database migrations, or Helm reconciliation.

Depends on the AuthZed client foundation and canonical schema already merged into `epic/authzed` through ENG-1708 and ENG-1710.

## Solution

- extend the server-only Formbricks AuthZed facade with aggregate `DiffSchema` and explicit `WriteSchema` operations
- compare schema semantics at full consistency and report only digests plus aggregate difference kinds
- add `pnpm authzed:schema check` and guarded `apply` commands
- require the reviewed current digest before replacing any non-empty remote schema
- read back and semantically verify every successful write
- keep schema contents, object identifiers, tokens, metadata, and raw SDK errors out of CLI output and logs
- document Docker and Helm invocation, backup, rollback, and expand/backfill/contract requirements
- extend isolated Docker validation for empty install, idempotency, deliberate drift, recovery, permissions, outage handling, and persistence

## Operational contract

- `check`: read-only; exit `0` when matched and `2` on drift
- `apply`: exit `0` only after verified convergence; an already matching schema returns `unchanged`
- failures: exit `1` with a stable `authzed_*` code
- no HTTP endpoint or browser page
- no startup, readiness, liveness, migration, or Helm hook integration

## Validation

- `pnpm --dir apps/web test lib/authzed` — 80 tests passed
- `pnpm --filter @formbricks/web typecheck` — passed on Node 22
- `pnpm authzed:validate` — 27 relationships, 131 assertions, 2 expected relations
- `bash docker/authzed-compose-contract.sh` — passed
- `pnpm authzed:smoke` — passed, including full-consistency drift detection and persistence after SpiceDB recreation
- focused ESLint, Prettier, shell syntax, and diff checks — passed

## Deliberate exclusions

Relationship projection/backfill, permission enforcement, startup schema writes, public health routes, and new authorization capabilities remain out of scope.

## Sandbox deployment — 2026-07-23

Deployed commit `58ed567a7` to `core-eks/authzed-sandbox` through the public TLS endpoint and verified it directly against each replica.

- backed up the pre-existing two-definition POC schema and its one disposable relationship to local mode-0600 files
- pre-apply semantic check exited `2` with 9 aggregate differences; no schema contents or identifiers were emitted
- deleted exactly the backed-up POC relationship, then verified zero `document` relationships remained
- applied using the reviewed pre-apply digest as the concurrency guard; post-write diff was zero
- public TLS check: `matched`, zero differences
- both existing replicas checked directly over port-forwarded plaintext gRPC: `matched`, zero differences
- recycled one of two replicas and checked the replacement directly: `matched`, zero differences; 2/2 replicas ready
- Formbricks `/health` and `/api/v2/health`: HTTP 200
- retained command-output and SpiceDB-log scans found neither the token nor canonical schema text

The deployed canonical source digest is `sha256:84517c430f065fc2d122545fd650fd1c5314cab0d28cc2cfafd8e0d9c1d4e406`. The private rollback backup remains outside the repository.