### PR TITLE
fix(i18n): heal empty default-language keys that reject valid choice responses [ENG-2001]

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -3279,6 +3279,7 @@ checksums:
     workspace/surveys/edit/then: 5e941fb7dd51a18651fcfb865edd5ba6
     workspace/surveys/edit/this_action_will_remove_all_the_translations_from_this_survey: 3340c89696f10bdc01b9a1047ff0b987
     workspace/surveys/edit/this_will_remove_the_language_and_all_its_translations: 6a71ae70abbd61f13f15323d825a47f6
+    workspace/surveys/edit/this_will_remove_the_language_from_this_survey: 65cfdf7f8ce806cc4f1a5a34466de080
     workspace/surveys/edit/three_points: d7f299aec752d7d690ef0ab6373327ae
     workspace/surveys/edit/translated: 5b9d805410310b726f12bacb06da44e3
     workspace/surveys/edit/trigger_survey_when_one_of_the_actions_is_fired: 8570291668ec9879d204f10e861112db

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -3398,6 +3398,7 @@
         "then": "Dann",
         "this_action_will_remove_all_the_translations_from_this_survey": "Diese Aktion entfernt alle Übersetzungen aus dieser Umfrage.",
         "this_will_remove_the_language_and_all_its_translations": "Dies entfernt diese Sprache und alle zugehörigen Übersetzungen aus dieser Umfrage. Diese Aktion kann nicht rückgängig gemacht werden.",
+        "this_will_remove_the_language_from_this_survey": "Dadurch wird diese Sprache aus dieser Umfrage entfernt. Diese Aktion kann nicht rückgängig gemacht werden.",
         "three_points": "3 Punkte",
         "translated": "Übersetzt",
         "trigger_survey_when_one_of_the_actions_is_fired": "Umfrage auslösen, wenn eine der Aktionen ausgeführt wird...",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -3398,6 +3398,7 @@
         "then": "Then",
         "this_action_will_remove_all_the_translations_from_this_survey": "This action will remove all the translations from this survey.",
         "this_will_remove_the_language_and_all_its_translations": "This will remove this language and all its translations from this survey. This action cannot be undone.",
+        "this_will_remove_the_language_from_this_survey": "This will remove this language from this survey. This action cannot be undone.",
         "three_points": "3 points",
         "translated": "Translated",
         "trigger_survey_when_one_of_the_actions_is_fired": "Trigger survey when one of the actions is fired…",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -3398,6 +3398,7 @@
         "then": "Entonces",
         "this_action_will_remove_all_the_translations_from_this_survey": "Esta acción eliminará todas las traducciones de esta encuesta.",
         "this_will_remove_the_language_and_all_its_translations": "Esto eliminará este idioma y todas sus traducciones de esta encuesta. Esta acción no se puede deshacer.",
+        "this_will_remove_the_language_from_this_survey": "Esto eliminará este idioma de esta encuesta. Esta acción no se puede deshacer.",
         "three_points": "3 puntos",
         "translated": "Traducido",
         "trigger_survey_when_one_of_the_actions_is_fired": "Activar encuesta cuando se dispare una de las acciones...",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -3398,6 +3398,7 @@
         "then": "Alors",
         "this_action_will_remove_all_the_translations_from_this_survey": "Cette action supprimera toutes les traductions de cette enquête.",
         "this_will_remove_the_language_and_all_its_translations": "Cela supprimera cette langue et toutes ses traductions de ce questionnaire. Cette action est irréversible.",
+        "this_will_remove_the_language_from_this_survey": "Cela supprimera cette langue de ce sondage. Cette action est irréversible.",
         "three_points": "3 points",
         "translated": "Traduit",
         "trigger_survey_when_one_of_the_actions_is_fired": "Déclencher l'enquête lorsqu'une des actions est déclenchée...",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -3398,6 +3398,7 @@
         "then": "Azután",
         "this_action_will_remove_all_the_translations_from_this_survey": "Ez a művelet eltávolítja az összes fordítást ebből a kérdőívből.",
         "this_will_remove_the_language_and_all_its_translations": "Ez el fogja távolítani ezt a nyelvet és annak összes fordítását ebből a kérdőívből. Ezt a műveletet nem lehet visszavonni.",
+        "this_will_remove_the_language_from_this_survey": "Ezzel eltávolítja ezt a nyelvet ebből a felmérésből. Ez a művelet nem vonható vissza.",
         "three_points": "3 pont",
         "translated": "Lefordítva",
         "trigger_survey_when_one_of_the_actions_is_fired": "A kérdőív aktiválása, ha a műveletek egyikét elindítják…",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -3398,6 +3398,7 @@
         "then": "その後",
         "this_action_will_remove_all_the_translations_from_this_survey": "このアクションは、このフォームからすべての翻訳を削除します。",
         "this_will_remove_the_language_and_all_its_translations": "この言語とすべての翻訳がこのアンケートから削除されます。この操作は元に戻せません。",
+        "this_will_remove_the_language_from_this_survey": "この言語がこのアンケートから削除されます。この操作は元に戻せません。",
         "three_points": "3点",
         "translated": "翻訳済み",
         "trigger_survey_when_one_of_the_actions_is_fired": "以下のアクションのいずれかが発火したときにフォームをトリガーします...",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -3398,6 +3398,7 @@
         "then": "Dan",
         "this_action_will_remove_all_the_translations_from_this_survey": "Met deze actie worden alle vertalingen uit deze enquête verwijderd.",
         "this_will_remove_the_language_and_all_its_translations": "Dit verwijdert deze taal en alle vertalingen uit deze enquête. Deze actie kan niet ongedaan worden gemaakt.",
+        "this_will_remove_the_language_from_this_survey": "Hiermee verwijder je deze taal uit deze enquête. Deze actie kan niet ongedaan worden gemaakt.",
         "three_points": "3 punten",
         "translated": "Vertaald",
         "trigger_survey_when_one_of_the_actions_is_fired": "Enquête activeren wanneer een van de acties wordt afgevuurd...",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -3398,6 +3398,7 @@
         "then": "Então",
         "this_action_will_remove_all_the_translations_from_this_survey": "Essa ação vai remover todas as traduções dessa pesquisa.",
         "this_will_remove_the_language_and_all_its_translations": "Isso removerá este idioma e todas as suas traduções desta pesquisa. Esta ação não pode ser desfeita.",
+        "this_will_remove_the_language_from_this_survey": "Isso vai remover este idioma desta pesquisa. Esta ação não pode ser desfeita.",
         "three_points": "3 pontos",
         "translated": "Traduzido",
         "trigger_survey_when_one_of_the_actions_is_fired": "Disparar pesquisa quando uma das ações for executada...",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -3398,6 +3398,7 @@
         "then": "Então",
         "this_action_will_remove_all_the_translations_from_this_survey": "Esta ação irá remover todas as traduções deste inquérito.",
         "this_will_remove_the_language_and_all_its_translations": "Isto irá remover este idioma e todas as suas traduções deste inquérito. Esta ação não pode ser revertida.",
+        "this_will_remove_the_language_from_this_survey": "Isto irá remover este idioma deste questionário. Esta ação não pode ser revertida.",
         "three_points": "3 pontos",
         "translated": "Traduzido",
         "trigger_survey_when_one_of_the_actions_is_fired": "Desencadear inquérito quando uma das ações for disparada...",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -3398,6 +3398,7 @@
         "then": "Apoi",
         "this_action_will_remove_all_the_translations_from_this_survey": "Această acțiune va elimina toate traducerile din acest sondaj.",
         "this_will_remove_the_language_and_all_its_translations": "Aceasta va elimina această limbă și toate traducerile ei din acest chestionar. Această acțiune nu poate fi anulată.",
+        "this_will_remove_the_language_from_this_survey": "Aceasta va elimina această limbă din acest sondaj. Această acțiune nu poate fi anulată.",
         "three_points": "3 puncte",
         "translated": "Tradus",
         "trigger_survey_when_one_of_the_actions_is_fired": "Declanșați sondajul atunci când una dintre acțiuni este realizată...",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -3398,6 +3398,7 @@
         "then": "Затем",
         "this_action_will_remove_all_the_translations_from_this_survey": "Это действие удалит все переводы из этого опроса.",
         "this_will_remove_the_language_and_all_its_translations": "Это удалит данный язык и все его переводы из этого опроса. Это действие нельзя отменить.",
+        "this_will_remove_the_language_from_this_survey": "Это удалит данный язык из этого опроса. Это действие нельзя отменить.",
         "three_points": "3 балла",
         "translated": "Переведено",
         "trigger_survey_when_one_of_the_actions_is_fired": "Запустить опрос при выполнении одного из действий...",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -3398,6 +3398,7 @@
         "then": "Sedan",
         "this_action_will_remove_all_the_translations_from_this_survey": "Denna åtgärd kommer att ta bort alla översättningar från denna enkät.",
         "this_will_remove_the_language_and_all_its_translations": "Detta tar bort språket och alla dess översättningar från denna enkät. Denna åtgärd kan inte ångras.",
+        "this_will_remove_the_language_from_this_survey": "Detta tar bort språket från den här undersökningen. Åtgärden kan inte ångras.",
         "three_points": "3 poäng",
         "translated": "Översatt",
         "trigger_survey_when_one_of_the_actions_is_fired": "Utlös enkät när en av åtgärderna aktiveras...",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -3398,6 +3398,7 @@
         "then": "Ardından",
         "this_action_will_remove_all_the_translations_from_this_survey": "Bu işlem bu anketteki tüm çevirileri kaldıracak.",
         "this_will_remove_the_language_and_all_its_translations": "Bu işlem bu dili ve tüm çevirilerini anketten kaldıracak. Bu işlem geri alınamaz.",
+        "this_will_remove_the_language_from_this_survey": "Bu dil bu anketten kaldırılacak. Bu işlem geri alınamaz.",
         "three_points": "3 puan",
         "translated": "Çevrildi",
         "trigger_survey_when_one_of_the_actions_is_fired": "İşlemlerden biri gerçekleştiğinde anketi tetikle…",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -3398,6 +3398,7 @@
         "then": "然后",
         "this_action_will_remove_all_the_translations_from_this_survey": "此操作将删除该调查中的所有翻译。",
         "this_will_remove_the_language_and_all_its_translations": "这将从此调查问卷中删除该语言及其所有翻译。此操作无法撤销。",
+        "this_will_remove_the_language_from_this_survey": "这将从此调查中删除该语言。此操作无法撤销。",
         "three_points": "3 分",
         "translated": "已翻译",
         "trigger_survey_when_one_of_the_actions_is_fired": "当 其中 一个 动作 被 触发 时 启动 调查…",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -3398,6 +3398,7 @@
         "then": "然後",
         "this_action_will_remove_all_the_translations_from_this_survey": "此操作將從此問卷中移除所有翻譯。",
         "this_will_remove_the_language_and_all_its_translations": "這將會從此問卷中移除該語言及其所有翻譯。此操作無法復原。",
+        "this_will_remove_the_language_from_this_survey": "這將從此調查中移除該語言。此操作無法復原。",
         "three_points": "3 分",
         "translated": "已翻譯",
         "trigger_survey_when_one_of_the_actions_is_fired": "當觸發其中一個操作時，觸發問卷...",

--- a/apps/web/modules/survey/multi-language-surveys/components/language-view.tsx
+++ b/apps/web/modules/survey/multi-language-surveys/components/language-view.tsx
@@ -88,6 +88,18 @@ export const LanguageView = ({
 
   const enabledLanguages = getEnabledLanguages(localSurvey.languages);
 
+  // Every non-default language to show in the table: the union of workspace languages and languages
+  // already stored on the survey. Including survey-only languages (e.g. one later removed from the
+  // workspace) guarantees a language present in the survey object always stays visible here, so it
+  // can be managed or removed instead of silently lingering in the data (ENG-2001).
+  const nonDefaultLanguageCodes = useMemo(() => {
+    const codes = new Set<string>();
+    workspaceLanguages.forEach((l) => codes.add(l.code));
+    localSurvey.languages.forEach((sl) => codes.add(sl.language.code));
+    if (defaultLanguage) codes.delete(defaultLanguage.code);
+    return [...codes];
+  }, [workspaceLanguages, localSurvey.languages, defaultLanguage]);
+
   // Check AI availability once on mount
   useEffect(() => {
     let isCurrent = true;
@@ -186,8 +198,14 @@ export const LanguageView = ({
       newLanguages.push({ enabled: true, default: true, language });
     }
 
+    // The default language is always keyed as "default" throughout the survey object. Strip any
+    // stale/empty code key for the promoted language so it can never end up as the default while
+    // its own code key sits empty next to a populated "default" — the state that makes the response
+    // API reject valid choice answers (ENG-2001).
+    const cleanedSurvey = removeLanguageKeysFromSurvey(localSurvey, language.code);
+
     setConfirmationModalInfo((prev) => ({ ...prev, open: false }));
-    setLocalSurvey({ ...localSurvey, languages: newLanguages });
+    setLocalSurvey({ ...cleanedSurvey, languages: newLanguages });
   };
 
   const handleToggleLanguage = (code: string) => {
@@ -231,13 +249,19 @@ export const LanguageView = ({
 
   const handleRemoveTranslations = (code: string) => {
     const label = getLanguageLabel(code, locale) ?? code;
+    const progress = computeTranslationProgress(translatableStrings, code);
+    const hasTranslations = progress.translated > 0;
     setConfirmationModalInfo({
       open: true,
       title: `${t("workspace.surveys.edit.remove_translations")}: ${label}`,
-      body: t("workspace.surveys.edit.this_will_remove_the_language_and_all_its_translations"),
+      body: hasTranslations
+        ? t("workspace.surveys.edit.this_will_remove_the_language_and_all_its_translations")
+        : t("workspace.surveys.edit.this_will_remove_the_language_from_this_survey"),
       buttonText: t("workspace.surveys.edit.remove_translations"),
       buttonVariant: "destructive",
       onConfirm: () => {
+        // Fully strip the language's keys from the survey object (not just blank the strings) so a
+        // removed language can never linger and later corrupt the default (ENG-2001).
         const cleanedSurvey = removeLanguageKeysFromSurvey(localSurvey, code);
         const updatedLanguages = localSurvey.languages.filter((l) => l.language.code !== code);
         setLocalSurvey({ ...cleanedSurvey, languages: updatedLanguages });
@@ -254,7 +278,16 @@ export const LanguageView = ({
       buttonText: t("workspace.surveys.edit.remove_translations"),
       buttonVariant: "destructive",
       onConfirm: () => {
-        updateSurveyTranslations(localSurvey, []);
+        // Actually strip every non-default language's keys from the survey object. Using
+        // updateSurveyTranslations([]) here only re-seeds keys and leaves stale empty code keys
+        // behind, which can later be promoted into a broken default (ENG-2001).
+        let cleanedSurvey = localSurvey;
+        for (const lang of localSurvey.languages) {
+          if (!lang.default) {
+            cleanedSurvey = removeLanguageKeysFromSurvey(cleanedSurvey, lang.language.code);
+          }
+        }
+        setLocalSurvey({ ...cleanedSurvey, languages: [] });
         setIsMultiLanguageActivated(false);
         setConfirmationModalInfo((prev) => ({ ...prev, open: false }));
       },
@@ -385,84 +418,79 @@ export const LanguageView = ({
                     </td>
                   </tr>
 
-                  {/* Non-default language rows — all workspace languages except default */}
-                  {workspaceLanguages
-                    .filter((pl) => pl.code !== defaultLanguage.code)
-                    .map((pl) => {
-                      const surveyLang = localSurvey.languages.find((sl) => sl.language.code === pl.code);
-                      const inSurvey = !!surveyLang;
-                      const enabled = surveyLang?.enabled ?? false;
-                      const progress = inSurvey
-                        ? computeTranslationProgress(translatableStrings, pl.code)
-                        : null;
+                  {/* Non-default rows — every workspace language plus any language already stored on
+                      the survey (union), so a survey language is always visible and removable. */}
+                  {nonDefaultLanguageCodes.map((code) => {
+                    const surveyLang = localSurvey.languages.find((sl) => sl.language.code === code);
+                    const inSurvey = !!surveyLang;
+                    const enabled = surveyLang?.enabled ?? false;
+                    const progress = inSurvey ? computeTranslationProgress(translatableStrings, code) : null;
 
-                      return (
-                        <tr
-                          key={pl.code}
-                          className={cn(
-                            "border-t border-slate-200",
-                            inSurvey && "cursor-pointer hover:bg-slate-50"
-                          )}
-                          onClick={() => {
-                            if (inSurvey) {
-                              openTranslationModal(pl.code);
-                            }
-                          }}>
-                          <td className="px-4 py-3 font-medium text-slate-800">
-                            {getLanguageLabel(pl.code, locale)}
-                          </td>
-                          <td className="px-4 py-3 text-slate-600">{pl.code}</td>
-                          <td className="px-4 py-3">
-                            {inSurvey && progress && (
-                              <div className="flex items-center gap-2">
-                                <div className="h-2 w-24 overflow-hidden rounded-full bg-slate-200">
-                                  <div
-                                    className={cn(
-                                      "h-full rounded-full transition-all",
-                                      getProgressColor(progress.percentage)
-                                    )}
-                                    style={{ width: `${progress.percentage}%` }}
-                                  />
-                                </div>
-                                <span
+                    return (
+                      <tr
+                        key={code}
+                        className={cn(
+                          "border-t border-slate-200",
+                          inSurvey && "cursor-pointer hover:bg-slate-50"
+                        )}
+                        onClick={() => {
+                          if (inSurvey) {
+                            openTranslationModal(code);
+                          }
+                        }}>
+                        <td className="px-4 py-3 font-medium text-slate-800">
+                          {getLanguageLabel(code, locale)}
+                        </td>
+                        <td className="px-4 py-3 text-slate-600">{code}</td>
+                        <td className="px-4 py-3">
+                          {inSurvey && progress && (
+                            <div className="flex items-center gap-2">
+                              <div className="h-2 w-24 overflow-hidden rounded-full bg-slate-200">
+                                <div
                                   className={cn(
-                                    "text-xs font-medium",
-                                    getProgressTextColor(progress.percentage)
-                                  )}>
-                                  {progress.translated}/{progress.total}
-                                </span>
-                              </div>
-                            )}
-                          </td>
-                          <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
-                            <Switch checked={enabled} onCheckedChange={() => handleToggleLanguage(pl.code)} />
-                          </td>
-                          <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
-                            {inSurvey && (
-                              <DropdownMenu>
-                                <DropdownMenuTrigger asChild>
-                                  <button type="button" className="rounded-sm p-1 hover:bg-slate-100">
-                                    <EllipsisVerticalIcon className="size-4 text-slate-500" />
-                                  </button>
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent align="end">
-                                  <DropdownMenuItem onClick={() => openTranslationModal(pl.code)}>
-                                    {t("workspace.surveys.edit.manage_translations")}
-                                  </DropdownMenuItem>
-                                  {progress && progress.translated > 0 && (
-                                    <DropdownMenuItem
-                                      className="text-red-600 focus:text-red-600"
-                                      onClick={() => handleRemoveTranslations(pl.code)}>
-                                      {t("workspace.surveys.edit.remove_translations")}
-                                    </DropdownMenuItem>
+                                    "h-full rounded-full transition-all",
+                                    getProgressColor(progress.percentage)
                                   )}
-                                </DropdownMenuContent>
-                              </DropdownMenu>
-                            )}
-                          </td>
-                        </tr>
-                      );
-                    })}
+                                  style={{ width: `${progress.percentage}%` }}
+                                />
+                              </div>
+                              <span
+                                className={cn(
+                                  "text-xs font-medium",
+                                  getProgressTextColor(progress.percentage)
+                                )}>
+                                {progress.translated}/{progress.total}
+                              </span>
+                            </div>
+                          )}
+                        </td>
+                        <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                          <Switch checked={enabled} onCheckedChange={() => handleToggleLanguage(code)} />
+                        </td>
+                        <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                          {inSurvey && (
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <button type="button" className="rounded-sm p-1 hover:bg-slate-100">
+                                  <EllipsisVerticalIcon className="size-4 text-slate-500" />
+                                </button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end">
+                                <DropdownMenuItem onClick={() => openTranslationModal(code)}>
+                                  {t("workspace.surveys.edit.manage_translations")}
+                                </DropdownMenuItem>
+                                <DropdownMenuItem
+                                  className="text-red-600 focus:text-red-600"
+                                  onClick={() => handleRemoveTranslations(code)}>
+                                  {t("workspace.surveys.edit.remove_translations")}
+                                </DropdownMenuItem>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/packages/surveys/src/lib/i18n.test.ts
+++ b/packages/surveys/src/lib/i18n.test.ts
@@ -31,5 +31,29 @@ describe("i18n", () => {
       };
       expect(getLocalizedValue(i18nString, "fr")).toBe("French text");
     });
+
+    test("should fall back to default when the requested language key is an empty string", () => {
+      const i18nString: TI18nString = {
+        default: "Default text",
+        "en-GB": "",
+      };
+      expect(getLocalizedValue(i18nString, "en-GB")).toBe("Default text");
+    });
+
+    test("should fall back to default when the requested language key is whitespace-only", () => {
+      const i18nString: TI18nString = {
+        default: "Default text",
+        "en-GB": "   ",
+      };
+      expect(getLocalizedValue(i18nString, "en-GB")).toBe("Default text");
+    });
+
+    test("should still return the localized value when it is a non-empty string", () => {
+      const i18nString: TI18nString = {
+        default: "Default text",
+        "en-GB": "British text",
+      };
+      expect(getLocalizedValue(i18nString, "en-GB")).toBe("British text");
+    });
   });
 });

--- a/packages/surveys/src/lib/i18n.ts
+++ b/packages/surveys/src/lib/i18n.ts
@@ -24,8 +24,14 @@ export const getLocalizedValue = (
   let result = "";
 
   if (isI18nObject(value)) {
-    if (typeof value[languageId] === "string") {
-      result = value[languageId];
+    // An empty (or whitespace-only) localized value means the string was never translated for this
+    // language, so fall back to `default`. This is standard i18n behavior and, critically, keeps
+    // choice-membership validation correct: a survey whose default language is keyed by its real
+    // code (e.g. "en-GB": "") with content still under `default` must resolve to the default label
+    // rather than an empty string, otherwise valid responses are rejected (see ENG-2001).
+    const localized = value[languageId];
+    if (typeof localized === "string" && localized.trim() !== "") {
+      result = localized;
     } else {
       result = value.default;
     }

--- a/packages/surveys/src/lib/validation/evaluator.test.ts
+++ b/packages/surveys/src/lib/validation/evaluator.test.ts
@@ -21,12 +21,16 @@ const mockT = vi.fn((key: string) => {
 vi.mock("@/lib/i18n", () => {
   const mockTFn = vi.fn((key: string) => key) as unknown as TFunction;
   return {
+    // Mirror the real getLocalizedValue (ENG-2001): an empty or whitespace-only localized value
+    // falls back to `default`, so validation resolves the default label rather than an empty string.
     getLocalizedValue: (
       localizedString: Record<string, string> | undefined,
       languageCode: string
     ): string => {
       if (!localizedString) return "";
-      return localizedString[languageCode] || localizedString.default || "";
+      const localized = localizedString[languageCode];
+      if (typeof localized === "string" && localized.trim() !== "") return localized;
+      return localizedString.default || "";
     },
     getTranslations: () => mockTFn,
   };
@@ -252,6 +256,43 @@ describe("validateElementResponse", () => {
       } as unknown as TSurveyElement;
 
       const result = validateElementResponse(element, ["Option 1", "injected"], "en");
+      expect(result.valid).toBe(false);
+      expect(result.errors[0].ruleId).toBe("invalidOption");
+    });
+
+    test("should accept a choice by its default label when the response language code's label is empty (ENG-2001)", () => {
+      // Reproduces the broken-survey state: the default language is keyed by its real code
+      // ("en-GB") but that key is empty, while the actual label text lives under "default".
+      // The submitted value is the default label; membership must still resolve via the fallback.
+      const element = {
+        id: "single1",
+        type: TSurveyElementTypeEnum.MultipleChoiceSingle,
+        headline: { default: "Pick", "en-GB": "" },
+        required: true,
+        choices: [
+          { id: "c1", label: { default: "AdJUST", "en-GB": "" } },
+          { id: "c2", label: { default: "Keep", "en-GB": "" } },
+        ],
+      } as unknown as TSurveyElement;
+
+      // Response recorded under the default language's real code (see getDefaultLanguageCode).
+      expect(validateElementResponse(element, "AdJUST", "en-GB").valid).toBe(true);
+      expect(validateElementResponse(element, "c2", "en-GB").valid).toBe(true); // still matches by id
+    });
+
+    test("should still reject a genuinely invalid value when labels are empty for the language (ENG-2001)", () => {
+      const element = {
+        id: "single1",
+        type: TSurveyElementTypeEnum.MultipleChoiceSingle,
+        headline: { default: "Pick", "en-GB": "" },
+        required: true,
+        choices: [
+          { id: "c1", label: { default: "AdJUST", "en-GB": "" } },
+          { id: "c2", label: { default: "Keep", "en-GB": "" } },
+        ],
+      } as unknown as TSurveyElement;
+
+      const result = validateElementResponse(element, "INJECTED", "en-GB");
       expect(result.valid).toBe(false);
       expect(result.errors[0].ruleId).toBe("invalidOption");
     });

--- a/packages/surveys/src/lib/validation/evaluator.test.ts
+++ b/packages/surveys/src/lib/validation/evaluator.test.ts
@@ -17,21 +17,13 @@ const mockT = vi.fn((key: string) => {
   return key;
 }) as unknown as TFunction;
 
-// Mock getLocalizedValue and getTranslations
-vi.mock("@/lib/i18n", () => {
+// Mock only getTranslations; keep the real getLocalizedValue so these tests exercise the actual
+// localization fallback the evaluator relies on (a hand-rolled mirror masked ENG-2001).
+vi.mock("@/lib/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/i18n")>();
   const mockTFn = vi.fn((key: string) => key) as unknown as TFunction;
   return {
-    // Mirror the real getLocalizedValue (ENG-2001): an empty or whitespace-only localized value
-    // falls back to `default`, so validation resolves the default label rather than an empty string.
-    getLocalizedValue: (
-      localizedString: Record<string, string> | undefined,
-      languageCode: string
-    ): string => {
-      if (!localizedString) return "";
-      const localized = localizedString[languageCode];
-      if (typeof localized === "string" && localized.trim() !== "") return localized;
-      return localizedString.default || "";
-    },
+    ...actual,
     getTranslations: () => mockTFn,
   };
 });


### PR DESCRIPTION
## What does this PR do?

Closes **[ENG-2001](https://linear.app/formbricks/issue/ENG-2001)** (High). A multi-language survey could end up with its **default language keyed by its real code (e.g. `"en-GB": ""`) while the actual content stayed under the `default` key**. The response API then rejected valid answers to choice questions **without an "Other" option** with `"Please enter a valid format"`, because choice-membership validation read the empty `en-GB` key instead of falling back to `default`.

## Root cause

`getLocalizedValue` (`packages/surveys/src/lib/i18n.ts`) returned `""` for an empty language key instead of falling back to `default` (`"" ` is a string, so the fallback branch was never reached). `validateChoiceMembership` (`evaluator.ts`) uses this to build the set of known labels, so with an empty key it only knew the choice **ids** — the submitted default label matched nothing and was rejected. Choice questions with "Other" short-circuit before the membership check, which is why they appeared unaffected.

The broken state is reachable in the editor because "change default" left stale empty code keys behind (`updateSurveyTranslations([])` only re-seeds keys, never strips them), which could then be promoted into the default.

## The fix

**Fix A — data integrity (heals existing broken surveys).** `getLocalizedValue` treats an empty/whitespace-only localized value as untranslated and falls back to `default`. This is standard i18n behavior and, since `evaluator.ts` imports the same function, it fixes both blank rendering and the wrongful response rejection. The editor-side `getLocalizedValue` in `apps/web/lib/i18n/utils.ts` is intentionally **left unchanged** (it must return `""` so translation inputs render empty).

**Prevention in the language editor** (`multi-language-surveys/components/language-view.tsx`):
- Setting a language as default now **strips that language's own code keys**, enforcing the invariant that the default is always keyed `default` — it can never sit empty next to a populated `default`.
- "Change default" now **actually strips every secondary language's keys** (mirrors the multi-language deactivation path) instead of leaving stale empty keys.
- **"Remove translations" is always available** in the row menu — including for a language with 0 translations (previously the menu only offered "Manage translations"). It fully removes the language's keys from the survey object, not just blanks the strings.
- The languages table renders the **union of workspace and survey languages**, so a language present in the survey object (e.g. after being removed from the workspace) always stays visible and removable rather than lingering invisibly in the data.

## How to test

```
pnpm --filter=@formbricks/surveys exec vitest run src/lib/i18n.test.ts src/lib/validation/evaluator.test.ts
```

- `getLocalizedValue` falls back to `default` for empty/whitespace keys; still returns non-empty localized values.
- `validateChoiceMembership` accepts a choice by its default label when the response language code's label is empty (regression), and still rejects genuinely invalid values.

Manual:
1. Reproduce the broken survey (default language with empty code key, content under `default`, choice question without "Other"). Submitting a valid choice answer no longer returns "Please enter a valid format".
2. In the editor, a language with 0 translations shows a "Remove translations" option that clears it from the survey object.
3. A language present on the survey but not in the workspace still appears in the table and can be removed.

## Notes

- New i18n string `workspace.surveys.edit.this_will_remove_the_language_from_this_survey` added to `en-US.json` and generated via `pnpm i18n`.
- No `.tsx` unit tests per repo convention; editor behavior is covered by Playwright/manual QA.
- Draft: opening for review of the approach (Fix A + editor invariants) before finalizing.
