### PR TITLE
chore: merge main into epic/workflows-v1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,11 +44,12 @@ LOG_LEVEL=info
 # Number of concurrent jobs each BullMQ worker can process.
 # BULLMQ_WORKER_CONCURRENCY=1
 
-# Survey publish/close scheduling is configured with public build-time env vars because the editor UI
-# also needs to render the selected execution time and timezone.
-# NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE=Europe/Berlin
-# NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR=0
-# NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE=0
+# Survey publish/close scheduling execution time. These are server-side runtime env vars, so
+# self-hosted Docker deployments can change them without rebuilding the image. The editor UI
+# receives the configured values from the server to render the selected execution time and timezone.
+# SURVEY_SCHEDULING_TIME_ZONE=Europe/Berlin
+# SURVEY_SCHEDULING_LOCAL_HOUR=0
+# SURVEY_SCHEDULING_LOCAL_MINUTE=0
 
 ##############
 #  DATABASE  #

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/actions.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/actions.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { OperationNotAllowedError } from "@formbricks/types/errors";
+
+const mocks = vi.hoisted(() => ({
+  checkAuthorizationUpdated: vi.fn(),
+  getOrganizationIdFromWorkspaceId: vi.fn(),
+  getSpreadsheetNameById: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/action-client", () => ({
+  authenticatedActionClient: {
+    inputSchema: vi.fn(() => ({ action: vi.fn((fn) => fn) })),
+  },
+}));
+
+vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
+  checkAuthorizationUpdated: mocks.checkAuthorizationUpdated,
+}));
+
+vi.mock("@/lib/utils/helper", () => ({
+  getOrganizationIdFromWorkspaceId: mocks.getOrganizationIdFromWorkspaceId,
+}));
+
+vi.mock("@/lib/googleSheet/service", () => ({
+  getSpreadsheetNameById: mocks.getSpreadsheetNameById,
+  validateGoogleSheetsConnection: vi.fn(),
+}));
+
+vi.mock("@/lib/integration/service", () => ({ getIntegrationByType: vi.fn() }));
+
+const { getSpreadsheetNameByIdAction } = await import("./actions");
+
+const call = (googleSheetIntegration: unknown, workspaceId: string) =>
+  (getSpreadsheetNameByIdAction as unknown as (args: unknown) => Promise<unknown>)({
+    ctx: { user: { id: "user1" } },
+    parsedInput: { googleSheetIntegration, workspaceId, spreadsheetId: "sheet1" },
+  });
+
+describe("getSpreadsheetNameByIdAction — ENG-1921 cross-workspace integration hijack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.checkAuthorizationUpdated.mockResolvedValue(undefined);
+    mocks.getOrganizationIdFromWorkspaceId.mockResolvedValue("org1");
+    mocks.getSpreadsheetNameById.mockResolvedValue("My Sheet");
+  });
+
+  test("rejects an integration whose workspaceId differs from the authorized workspace", async () => {
+    await expect(call({ workspaceId: "victim-ws", config: { data: [] } }, "attacker-ws")).rejects.toThrow(
+      OperationNotAllowedError
+    );
+    expect(mocks.getSpreadsheetNameById).not.toHaveBeenCalled();
+  });
+
+  test("allows an integration for the authorized workspace", async () => {
+    const result = await call({ workspaceId: "attacker-ws", config: { data: [] } }, "attacker-ws");
+    expect(mocks.getSpreadsheetNameById).toHaveBeenCalled();
+    expect(result).toBe("My Sheet");
+  });
+});

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/actions.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/actions.ts
@@ -2,6 +2,7 @@
 
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
+import { OperationNotAllowedError } from "@formbricks/types/errors";
 import {
   TIntegrationGoogleSheets,
   ZIntegrationGoogleSheets,
@@ -68,6 +69,14 @@ export const getSpreadsheetNameByIdAction = authenticatedActionClient
         },
       ],
     });
+
+    // ENG-1921: googleSheetIntegration is fully client-supplied and carries its own workspaceId,
+    // which is used downstream to upsert the integration (incl. OAuth tokens) on the token-refresh
+    // path. Reject it unless it targets the authorized workspace, otherwise a caller could
+    // create/overwrite another tenant's integration.
+    if (parsedInput.googleSheetIntegration.workspaceId !== parsedInput.workspaceId) {
+      throw new OperationNotAllowedError("Integration does not belong to the specified workspace");
+    }
 
     const integrationData = structuredClone(parsedInput.googleSheetIntegration);
     integrationData.config.data.forEach((data) => {

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/PictureChoiceSummary.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/components/PictureChoiceSummary.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { type TI18nString } from "@formbricks/types/i18n";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey, TSurveyElementSummaryPictureSelection } from "@formbricks/types/surveys/types";
+import { isExternalImageSrc } from "@/lib/image-hosts";
 import { getChoiceIdByValue } from "@/lib/response/utils";
 import { IdBadge } from "@/modules/ui/components/id-badge";
 import { ProgressBar } from "@/modules/ui/components/progress-bar";
@@ -68,6 +69,7 @@ export const PictureChoiceSummary = ({ elementSummary, survey, setFilter }: Pict
                       layout="fill"
                       objectFit="cover"
                       className="rounded-md"
+                      unoptimized={isExternalImageSrc(result.imageUrl)}
                     />
                   </div>
                   <div className="self-end">{choiceId && <IdBadge id={choiceId} />}</div>

--- a/apps/web/app/api/v1/auth.test.ts
+++ b/apps/web/app/api/v1/auth.test.ts
@@ -30,7 +30,7 @@ describe("getApiKeyWithPermissions", () => {
         {
           workspaceId: "workspace-1",
           permission: "manage" as const,
-          workspace: { id: "workspace-1", name: "Workspace 1" },
+          workspace: { id: "workspace-1", name: "Workspace 1", organizationId: "org-id" },
         },
       ],
     };
@@ -112,7 +112,7 @@ describe("authenticateRequest", () => {
         {
           workspaceId: "workspace-1",
           permission: "manage" as const,
-          workspace: { id: "workspace-1", name: "Workspace 1" },
+          workspace: { id: "workspace-1", name: "Workspace 1", organizationId: "org-id" },
         },
       ],
     };

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.test.ts
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   validateClientFileUploads: vi.fn(),
   validateOtherOptionLengthForMultipleChoice: vi.fn(),
   validateResponseData: vi.fn(),
+  verifyLinkSurveyPinToken: vi.fn(),
 }));
 
 vi.mock("@formbricks/logger", () => ({
@@ -63,6 +64,10 @@ vi.mock("./response", () => ({
 
 vi.mock("./validated-response-update-input", () => ({
   getValidatedResponseUpdateInput: mocks.getValidatedResponseUpdateInput,
+}));
+
+vi.mock("@/modules/survey/link/lib/pin-token", () => ({
+  verifyLinkSurveyPinToken: mocks.verifyLinkSurveyPinToken,
 }));
 
 const workspaceId = "workspace_a";
@@ -139,6 +144,7 @@ describe("putResponseHandler", () => {
     mocks.validateClientFileUploads.mockReturnValue(true);
     mocks.validateOtherOptionLengthForMultipleChoice.mockReturnValue(null);
     mocks.validateResponseData.mockReturnValue(null);
+    mocks.verifyLinkSurveyPinToken.mockReturnValue(true);
   });
 
   test("returns a bad request response when the response id is missing", async () => {
@@ -333,6 +339,53 @@ describe("putResponseHandler", () => {
       details: { surveyId },
     });
     expect(mocks.updateResponseWithQuotaEvaluation).not.toHaveBeenCalled();
+  });
+
+  test("rejects updates to a PIN-protected survey without a valid PIN token", async () => {
+    mocks.getSurvey.mockResolvedValue({
+      ...getBaseSurvey(),
+      pin: "1234",
+    });
+    mocks.getValidatedResponseUpdateInput.mockResolvedValue({
+      responseUpdateInput: { ...getBaseResponseUpdateInput(), pinAuthToken: "invalid" },
+    });
+    mocks.verifyLinkSurveyPinToken.mockReturnValue(false);
+
+    const result = await putResponseHandler(createHandlerParams());
+
+    expect(result.response.status).toBe(403);
+    await expect(result.response.json()).resolves.toEqual({
+      code: "forbidden",
+      message: "Survey is protected by a PIN",
+      details: { surveyId },
+    });
+    expect(mocks.verifyLinkSurveyPinToken).toHaveBeenCalledWith("invalid", surveyId);
+    expect(mocks.updateResponseWithQuotaEvaluation).not.toHaveBeenCalled();
+  });
+
+  test("allows updates to a PIN-protected survey with a valid PIN token", async () => {
+    mocks.getSurvey.mockResolvedValue({
+      ...getBaseSurvey(),
+      pin: "1234",
+    });
+    mocks.getValidatedResponseUpdateInput.mockResolvedValue({
+      responseUpdateInput: { ...getBaseResponseUpdateInput(), pinAuthToken: "valid-token" },
+    });
+    mocks.verifyLinkSurveyPinToken.mockReturnValue(true);
+
+    const result = await putResponseHandler(createHandlerParams());
+
+    expect(result.response.status).toBe(200);
+    expect(mocks.verifyLinkSurveyPinToken).toHaveBeenCalledWith("valid-token", surveyId);
+    expect(mocks.updateResponseWithQuotaEvaluation).toHaveBeenCalled();
+  });
+
+  test("does not require a PIN token when the survey has no PIN", async () => {
+    const result = await putResponseHandler(createHandlerParams());
+
+    expect(result.response.status).toBe(200);
+    expect(mocks.verifyLinkSurveyPinToken).not.toHaveBeenCalled();
+    expect(mocks.updateResponseWithQuotaEvaluation).toHaveBeenCalled();
   });
 
   test("rejects invalid file upload updates", async () => {

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.ts
@@ -18,6 +18,7 @@ import { formatValidationErrorsForV1Api, validateResponseData } from "@/modules/
 import { validateOtherOptionLengthForMultipleChoice } from "@/modules/api/v2/lib/element";
 import { createQuotaFullObject } from "@/modules/ee/quotas/lib/helpers";
 import { validateClientFileUploads } from "@/modules/storage/utils";
+import { verifyLinkSurveyPinToken } from "@/modules/survey/link/lib/pin-token";
 import { updateResponseWithQuotaEvaluation } from "./response";
 import { getValidatedResponseUpdateInput } from "./validated-response-update-input";
 
@@ -275,6 +276,17 @@ export const putResponseHandler = async ({
   if (survey.workspaceId !== workspaceId) {
     return {
       response: responses.notFoundResponse("Response", responseId, true),
+    };
+  }
+
+  // Mirror the POST endpoint: PIN-protected link surveys require a server-verifiable PIN token.
+  // Without this, an unfinished response of a PIN survey could be updated/finalized without the PIN
+  // (CWE-602, ENG-1579).
+  if (survey.pin && !verifyLinkSurveyPinToken(responseUpdateInput.pinAuthToken, survey.id)) {
+    return {
+      response: responses.forbiddenResponse("Survey is protected by a PIN", true, {
+        surveyId: survey.id,
+      }),
     };
   }
 

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/route.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/route.ts
@@ -19,6 +19,7 @@ import { formatValidationErrorsForV1Api, validateResponseData } from "@/modules/
 import { getIsContactsEnabled } from "@/modules/ee/license-check/lib/utils";
 import { createQuotaFullObject } from "@/modules/ee/quotas/lib/helpers";
 import { validateClientFileUploads } from "@/modules/storage/utils";
+import { verifyLinkSurveyPinToken } from "@/modules/survey/link/lib/pin-token";
 import { createResponseWithQuotaEvaluation } from "./lib/response";
 
 export const OPTIONS = async (): Promise<Response> => {
@@ -143,6 +144,12 @@ export const POST = withV1ApiWrapper({
         response: responses.forbiddenResponse("Survey is not accepting submissions", true, {
           surveyId: survey.id,
         }),
+      };
+    }
+
+    if (survey.pin && !verifyLinkSurveyPinToken(responseInputData.pinAuthToken, survey.id)) {
+      return {
+        response: responses.forbiddenResponse("Survey is protected by a PIN", true, { surveyId: survey.id }),
       };
     }
 

--- a/apps/web/app/api/v1/management/me/route.ts
+++ b/apps/web/app/api/v1/management/me/route.ts
@@ -18,6 +18,7 @@ const apiKeySelect = {
       workspace: {
         select: {
           id: true,
+          organizationId: true,
           legacyEnvironmentId: true,
           createdAt: true,
           updatedAt: true,
@@ -40,6 +41,7 @@ type ApiKeyData = {
     permission: string;
     workspace: {
       id: string;
+      organizationId: string;
       legacyEnvironmentId: string | null;
       createdAt: Date;
       updatedAt: Date;
@@ -52,11 +54,20 @@ type ApiKeyData = {
 const validateApiKey = async (apiKey: string): Promise<ApiKeyData | null> => {
   const v2Parsed = parseApiKeyV2(apiKey);
 
-  if (v2Parsed) {
-    return validateV2ApiKey(v2Parsed);
+  const apiKeyData = v2Parsed ? await validateV2ApiKey(v2Parsed) : await validateLegacyApiKey(apiKey);
+  if (!apiKeyData) {
+    return null;
   }
 
-  return validateLegacyApiKey(apiKey);
+  // ENG-1749: drop workspace permissions outside the key's organization (defense-in-depth,
+  // mirroring authenticateApiKeyFromHeaders) so a pre-fix cross-org row can't leak workspace
+  // metadata through this legacy route.
+  return {
+    ...apiKeyData,
+    apiKeyWorkspaces: apiKeyData.apiKeyWorkspaces.filter(
+      (workspacePermission) => workspacePermission.workspace.organizationId === apiKeyData.organizationId
+    ),
+  };
 };
 
 const validateV2ApiKey = async (v2Parsed: { secret: string }): Promise<ApiKeyData | null> => {

--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/utils.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/utils.ts
@@ -9,6 +9,7 @@ import { symmetricDecrypt } from "@/lib/crypto";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { validateSurveySingleUseLinkParams } from "@/lib/utils/single-use-surveys";
 import { getIsSpamProtectionEnabled } from "@/modules/ee/license-check/lib/utils";
+import { verifyLinkSurveyPinToken } from "@/modules/survey/link/lib/pin-token";
 
 export const RECAPTCHA_VERIFICATION_ERROR_CODE = "recaptcha_verification_failed";
 
@@ -31,6 +32,10 @@ export const checkSurveyValidity = async (
     return responses.forbiddenResponse("Survey is not accepting submissions", true, {
       surveyId: survey.id,
     });
+  }
+
+  if (survey.pin && !verifyLinkSurveyPinToken(responseInput.pinAuthToken, survey.id)) {
+    return responses.forbiddenResponse("Survey is protected by a PIN", true, { surveyId: survey.id });
   }
 
   if (survey.type === "link" && survey.singleUse?.enabled) {

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -94,6 +94,7 @@ export const MAIL_FROM = env.MAIL_FROM;
 export const MAIL_FROM_NAME = env.MAIL_FROM_NAME;
 
 export const NEXTAUTH_SECRET = env.NEXTAUTH_SECRET;
+export const BETTER_AUTH_SECRET = env.BETTER_AUTH_SECRET;
 export const ITEMS_PER_PAGE = 30;
 export const SURVEYS_PER_PAGE = 12;
 export const RESPONSES_PER_PAGE = 25;

--- a/apps/web/lib/env.test.ts
+++ b/apps/web/lib/env.test.ts
@@ -301,35 +301,35 @@ describe("env", () => {
 
   test("uses the default survey scheduling configuration when env vars are not set", async () => {
     setTestEnv({
-      NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR: undefined,
-      NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE: undefined,
-      NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE: undefined,
+      SURVEY_SCHEDULING_LOCAL_HOUR: undefined,
+      SURVEY_SCHEDULING_LOCAL_MINUTE: undefined,
+      SURVEY_SCHEDULING_TIME_ZONE: undefined,
     });
 
     const { env } = await import("./env");
 
-    expect(env.NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE).toBe("Europe/Berlin");
-    expect(env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR).toBe(0);
-    expect(env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE).toBe(0);
+    expect(env.SURVEY_SCHEDULING_TIME_ZONE).toBe("Europe/Berlin");
+    expect(env.SURVEY_SCHEDULING_LOCAL_HOUR).toBe(0);
+    expect(env.SURVEY_SCHEDULING_LOCAL_MINUTE).toBe(0);
   });
 
   test("uses the configured survey scheduling configuration", async () => {
     setTestEnv({
-      NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR: "18",
-      NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE: "45",
-      NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE: "America/New_York",
+      SURVEY_SCHEDULING_LOCAL_HOUR: "18",
+      SURVEY_SCHEDULING_LOCAL_MINUTE: "45",
+      SURVEY_SCHEDULING_TIME_ZONE: "America/New_York",
     });
 
     const { env } = await import("./env");
 
-    expect(env.NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE).toBe("America/New_York");
-    expect(env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR).toBe(18);
-    expect(env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE).toBe(45);
+    expect(env.SURVEY_SCHEDULING_TIME_ZONE).toBe("America/New_York");
+    expect(env.SURVEY_SCHEDULING_LOCAL_HOUR).toBe(18);
+    expect(env.SURVEY_SCHEDULING_LOCAL_MINUTE).toBe(45);
   });
 
   test("fails to load when the survey scheduling timezone is invalid", async () => {
     setTestEnv({
-      NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE: "Mars/OlympusMons",
+      SURVEY_SCHEDULING_TIME_ZONE: "Mars/OlympusMons",
     });
 
     await expect(import("./env")).rejects.toThrow("Invalid environment variables");
@@ -337,7 +337,7 @@ describe("env", () => {
 
   test("fails to load when the survey scheduling hour is out of range", async () => {
     setTestEnv({
-      NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR: "24",
+      SURVEY_SCHEDULING_LOCAL_HOUR: "24",
     });
 
     await expect(import("./env")).rejects.toThrow("Invalid environment variables");
@@ -345,7 +345,7 @@ describe("env", () => {
 
   test("fails to load when the survey scheduling minute is out of range", async () => {
     setTestEnv({
-      NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE: "60",
+      SURVEY_SCHEDULING_LOCAL_MINUTE: "60",
     });
 
     await expect(import("./env")).rejects.toThrow("Invalid environment variables");

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -192,7 +192,7 @@ const isValidIanaTimeZone = (value: string): boolean => {
 };
 
 const ZSurveySchedulingTimeZone = z.string().trim().min(1).refine(isValidIanaTimeZone, {
-  message: "NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE must be a valid IANA time zone",
+  message: "SURVEY_SCHEDULING_TIME_ZONE must be a valid IANA time zone",
 });
 
 const ZSurveySchedulingLocalHour = z.coerce.number().int().min(0).max(23);
@@ -374,12 +374,11 @@ const parsedEnv = createEnv({
       .transform((val) => Number.parseInt(val, 10))
       .optional(),
     SENTRY_ENVIRONMENT: z.string().optional(),
+    SURVEY_SCHEDULING_TIME_ZONE: ZSurveySchedulingTimeZone.optional().default("Europe/Berlin"),
+    SURVEY_SCHEDULING_LOCAL_HOUR: ZSurveySchedulingLocalHour.optional().default(0),
+    SURVEY_SCHEDULING_LOCAL_MINUTE: ZSurveySchedulingLocalMinute.optional().default(0),
   },
-  client: {
-    NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE: ZSurveySchedulingTimeZone.optional().default("Europe/Berlin"),
-    NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR: ZSurveySchedulingLocalHour.optional().default(0),
-    NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE: ZSurveySchedulingLocalMinute.optional().default(0),
-  },
+  client: {},
 
   /*
    * Due to how Next.js bundles environment variables on Edge and Client,
@@ -464,9 +463,9 @@ const parsedEnv = createEnv({
     MAIL_FROM_NAME: process.env.MAIL_FROM_NAME,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
-    NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR: process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR,
-    NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE: process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE,
-    NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE: process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE,
+    SURVEY_SCHEDULING_LOCAL_HOUR: process.env.SURVEY_SCHEDULING_LOCAL_HOUR,
+    SURVEY_SCHEDULING_LOCAL_MINUTE: process.env.SURVEY_SCHEDULING_LOCAL_MINUTE,
+    SURVEY_SCHEDULING_TIME_ZONE: process.env.SURVEY_SCHEDULING_TIME_ZONE,
     SENTRY_DSN: process.env.SENTRY_DSN,
     NOTION_OAUTH_CLIENT_ID: process.env.NOTION_OAUTH_CLIENT_ID,
     NOTION_OAUTH_CLIENT_SECRET: process.env.NOTION_OAUTH_CLIENT_SECRET,

--- a/apps/web/lib/image-hosts.test.ts
+++ b/apps/web/lib/image-hosts.test.ts
@@ -1,0 +1,43 @@
+import { type StaticImageData } from "next/image";
+import { describe, expect, test } from "vitest";
+import { OPTIMIZABLE_IMAGE_HOSTS, isExternalImageSrc } from "./image-hosts";
+
+describe("isExternalImageSrc", () => {
+  test("treats relative first-party paths as optimizable (not external)", () => {
+    expect(isExternalImageSrc("/storage/ws/public/logo.png")).toBe(false);
+    expect(isExternalImageSrc("/images/hero.png")).toBe(false);
+  });
+
+  test("treats data URIs as optimizable (not external)", () => {
+    expect(isExternalImageSrc("data:image/png;base64,iVBORw0KGgo=")).toBe(false);
+  });
+
+  test("treats nullish / non-string (StaticImageData) srcs as not external", () => {
+    expect(isExternalImageSrc(undefined)).toBe(false);
+    expect(isExternalImageSrc(null)).toBe(false);
+    expect(isExternalImageSrc("")).toBe(false);
+    expect(isExternalImageSrc({ src: "/x.png", height: 1, width: 1 } as StaticImageData)).toBe(false);
+  });
+
+  test("treats absolute URLs on allowlisted provider hosts as optimizable", () => {
+    expect(isExternalImageSrc("https://images.unsplash.com/photo-1.jpg")).toBe(false);
+    expect(isExternalImageSrc("https://avatars.githubusercontent.com/u/1")).toBe(false);
+  });
+
+  test("treats arbitrary external URLs as external (must bypass the optimizer)", () => {
+    expect(isExternalImageSrc("https://evil.example.com/x.png")).toBe(true);
+    expect(isExternalImageSrc("http://random-host.test/logo.svg")).toBe(true);
+    // Cloud-specific infra is not in the universal allowlist — treated as external.
+    expect(isExternalImageSrc("https://formbricks-cdn.s3.eu-central-1.amazonaws.com/x.png")).toBe(true);
+  });
+
+  test("treats an absolute URL to the deployment's own domain as external (relative is the supported first-party form)", () => {
+    // The running domain is intentionally not in the allowlist; first-party images must be relative.
+    expect(isExternalImageSrc("https://app.formbricks.com/storage/ws/public/logo.png")).toBe(true);
+    expect(isExternalImageSrc("https://survey.company.com/storage/ws/public/logo.png")).toBe(true);
+  });
+
+  test("does not include the deployment domain in the optimizable host allowlist", () => {
+    expect(OPTIMIZABLE_IMAGE_HOSTS).not.toContain("app.formbricks.com");
+  });
+});

--- a/apps/web/lib/image-hosts.ts
+++ b/apps/web/lib/image-hosts.ts
@@ -1,0 +1,34 @@
+import { type StaticImageData } from "next/image";
+import { OPTIMIZABLE_IMAGE_HOSTS } from "./optimizable-image-hosts.mjs";
+
+// Re-exported from the plain `.mjs` source of truth (also imported by next.config.mjs) so
+// remotePatterns and the runtime check below share one list. See ./optimizable-image-hosts.mjs.
+export { OPTIMIZABLE_IMAGE_HOSTS };
+
+const OPTIMIZABLE_IMAGE_HOSTS_SET: ReadonlySet<string> = new Set(OPTIMIZABLE_IMAGE_HOSTS);
+
+/**
+ * Whether an `<Image>` src must be rendered with `unoptimized` because the Next.js image optimizer
+ * would not (and should not) serve it.
+ *
+ * Returns `false` (i.e. optimize) for:
+ * - relative paths (`/storage/...`, `/images/...`) — local images, optimized via `localPatterns`;
+ * - `data:` URIs, `StaticImageData` imports, or empty/nullish values;
+ * - absolute URLs whose host is in {@link OPTIMIZABLE_IMAGE_HOSTS}.
+ *
+ * Returns `true` (i.e. bypass the optimizer, serve directly) for any other absolute `http(s)` URL —
+ * i.e. arbitrary user-provided external images. This keeps the optimizer from acting as an open
+ * proxy for hosts we don't control, without breaking rendering of those images.
+ *
+ * The decision depends only on the src string, so it is identical on the server and client (no
+ * hydration mismatch).
+ */
+export const isExternalImageSrc = (src: string | StaticImageData | null | undefined): boolean => {
+  if (!src || typeof src !== "string") return false;
+  if (!/^https?:\/\//i.test(src)) return false; // relative path or data: URI → local/optimizable
+  try {
+    return !OPTIMIZABLE_IMAGE_HOSTS_SET.has(new URL(src).hostname);
+  } catch {
+    return false;
+  }
+};

--- a/apps/web/lib/optimizable-image-hosts.mjs
+++ b/apps/web/lib/optimizable-image-hosts.mjs
@@ -1,0 +1,28 @@
+/**
+ * Hosts whose images are safe to run through the Next.js image optimizer (ENG-1678).
+ *
+ * Plain `.mjs` so `next.config.mjs` can statically import it at config-eval time (no jiti/TS needed)
+ * while `lib/image-hosts.ts` re-exports it for the runtime `isExternalImageSrc` check — one source of
+ * truth, so `images.remotePatterns` and the per-`<Image>` `unoptimized` decision can never drift.
+ *
+ * Two hard constraints shape this list:
+ * - `next.config` (and therefore `remotePatterns`) is frozen into the build. The same Docker image
+ *   serves multiple domains (app.formbricks.com, ksa.formbricks.com, and every self-hoster), so the
+ *   deployment's own domain can NOT be baked in here and is intentionally absent.
+ * - First-party uploads are served from same-origin `/storage/...` (relative) paths, which Next
+ *   treats as local images (default: optimize all) and never checks against `remotePatterns`.
+ *
+ * It therefore contains only *universal* provider hosts that real features rely on and that are
+ * identical on every deployment.
+ */
+export const OPTIMIZABLE_IMAGE_HOSTS = [
+  // OAuth profile avatars
+  "avatars.githubusercontent.com",
+  "avatars.slack-edge.com",
+  "lh3.googleusercontent.com",
+  // survey editor's Unsplash background picker
+  "images.unsplash.com",
+  // local development
+  "localhost",
+  "127.0.0.1",
+];

--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -320,6 +320,21 @@ describe("Tests for updateSurvey", () => {
       expect(updatedSurvey).toEqual(mockTransformedSurveyOutput);
     });
 
+    test("does not persist workspaceId or id from the payload on update — pinned to the existing survey (ENG-1749)", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce(mockSurveyOutput);
+      prisma.survey.update.mockResolvedValueOnce(mockSurveyOutput);
+
+      await updateSurvey(updateSurveyInput);
+
+      const updateArg = vi.mocked(prisma.survey.update).mock.calls.at(-1)?.[0];
+      // workspaceId/id are the survey's tenant anchors: they must come from the existing record,
+      // never the client payload, so an authorized editor cannot re-point their survey to another
+      // workspace/organization on update.
+      expect(updateArg?.data).not.toHaveProperty("workspaceId");
+      expect(updateArg?.data).not.toHaveProperty("id");
+      expect(updateArg?.where).toEqual({ id: updateSurveyInput.id });
+    });
+
     // Note: Language handling tests (for languages.length > 0 fix) are covered in
     // apps/web/modules/survey/editor/lib/survey.test.ts where we have better control
     // over the test mocks. The key fix ensures languages.length > 0 (not > 1) is used.
@@ -357,6 +372,145 @@ describe("Tests for updateSurvey", () => {
       prisma.survey.findUnique.mockResolvedValueOnce(mockSurveyOutput);
       prisma.survey.update.mockRejectedValue(new Error(mockErrorMessage));
       await expect(updateSurvey(updateSurveyInput)).rejects.toThrow(Error);
+    });
+
+    // ENG-1749 sibling: the update path must not update/delete a segment from another workspace
+    // even when the caller is authorized for the survey being updated.
+    test("rejects a segment that belongs to another workspace", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce(mockSurveyOutput);
+      prisma.segment.findUnique.mockResolvedValueOnce({
+        id: "clseg123456789012345678901",
+        title: "Segment",
+        description: null,
+        isPrivate: true,
+        filters: [],
+        workspaceId: "clotherworkspace1234567890",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      await expect(
+        updateSurvey({
+          ...updateSurveyInput,
+          segment: {
+            id: "clseg123456789012345678901",
+            title: "Segment",
+            description: null,
+            isPrivate: true,
+            filters: [],
+            workspaceId: updateSurveyInput.workspaceId,
+            surveys: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          },
+        })
+      ).rejects.toThrow(ResourceNotFoundError);
+
+      expect(prisma.segment.delete).not.toHaveBeenCalled();
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
+
+    // ENG-1749 sibling: the update path (incl. drafts, skipValidation=true) must not link a language
+    // from another workspace. The guard resolves the language's workspace from the DB, so a request
+    // that LIES about language.workspaceId (claiming this survey's workspace) is still rejected.
+    test("rejects a language whose real (DB) workspace differs, even when the input claims otherwise", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce(mockSurveyOutput);
+      prisma.language.findMany.mockResolvedValueOnce([
+        { id: "cllangforeign00000000001", workspaceId: "clforeignws0000000000001" },
+      ] as any);
+
+      await expect(
+        updateSurveyInternal(
+          {
+            ...updateSurveyInput,
+            languages: [
+              {
+                language: {
+                  id: "cllangforeign00000000001",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  code: "de",
+                  alias: null,
+                  workspaceId: updateSurveyInput.workspaceId, // the lie: claims the survey's own workspace
+                },
+                default: true,
+                enabled: true,
+              },
+            ],
+          },
+          true
+        )
+      ).rejects.toThrow(ResourceNotFoundError);
+
+      expect(prisma.language.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ["cllangforeign00000000001"] } },
+        select: { id: true, workspaceId: true },
+      });
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
+
+    test("rejects a language id that does not exist (absent from the DB result)", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce(mockSurveyOutput);
+      prisma.language.findMany.mockResolvedValueOnce([] as any);
+
+      await expect(
+        updateSurveyInternal(
+          {
+            ...updateSurveyInput,
+            languages: [
+              {
+                language: {
+                  id: "cllangmissing0000000001",
+                  createdAt: new Date(),
+                  updatedAt: new Date(),
+                  code: "de",
+                  alias: null,
+                  workspaceId: updateSurveyInput.workspaceId,
+                },
+                default: true,
+                enabled: true,
+              },
+            ],
+          },
+          true
+        )
+      ).rejects.toThrow(ResourceNotFoundError);
+      expect(prisma.survey.update).not.toHaveBeenCalled();
+    });
+
+    // ENG-1749/ENG-1920: the app-survey segment block connects segment.surveys by id; a survey from
+    // another workspace must not be connectable (would re-point that survey's targeting).
+    test("rejects connecting a survey from another workspace to the segment (app survey update)", async () => {
+      prisma.survey.findUnique.mockResolvedValueOnce(mockSurveyOutput); // getSurvey → current survey (own workspace)
+      prisma.segment.findUnique.mockResolvedValueOnce({
+        workspaceId: updateSurveyInput.workspaceId,
+      } as any); // segment.id belongs to the survey's workspace (passes the segment guard)
+      prisma.survey.findMany.mockResolvedValueOnce([
+        { id: "clvictimsurvey0000000001", workspaceId: "clforeignws0000000000001" },
+      ] as any); // the connected survey is in ANOTHER workspace
+
+      await expect(
+        updateSurveyInternal(
+          {
+            ...updateSurveyInput,
+            type: "app",
+            segment: {
+              id: "clownsegment000000000001",
+              title: "seg",
+              description: null,
+              isPrivate: false,
+              filters: [],
+              workspaceId: updateSurveyInput.workspaceId,
+              surveys: ["clvictimsurvey0000000001"],
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            },
+          } as any,
+          true
+        )
+      ).rejects.toThrow(InvalidInputError);
+
+      expect(prisma.segment.update).not.toHaveBeenCalled();
     });
   });
 });
@@ -784,6 +938,9 @@ describe("Tests for createSurvey", () => {
 
     test("creates survey languages from validated language inputs", async () => {
       vi.mocked(getOrganizationByWorkspaceId).mockResolvedValueOnce(mockOrganizationOutput);
+      prisma.language.findMany.mockResolvedValueOnce([
+        { id: "cllang12345678901234567890", workspaceId: mockWorkspaceId },
+      ] as any);
       prisma.survey.create.mockResolvedValueOnce({
         ...mockSurveyOutput,
       });
@@ -938,6 +1095,11 @@ describe("Tests for createSurvey", () => {
     });
 
     test("rejects survey languages from a different workspace", async () => {
+      // The DB says this language belongs to another workspace, regardless of what the input claims.
+      prisma.language.findMany.mockResolvedValueOnce([
+        { id: "cllang12345678901234567890", workspaceId: "clotherworkspace0000000000" },
+      ] as any);
+
       await expect(
         createSurvey(mockWorkspaceId, {
           ...mockCreateSurveyInput,
@@ -949,7 +1111,7 @@ describe("Tests for createSurvey", () => {
                 id: "cllang12345678901234567890",
                 code: "en-US",
                 alias: null,
-                workspaceId: "clotherworkspace0000000000",
+                workspaceId: mockWorkspaceId,
                 createdAt: new Date(),
                 updatedAt: new Date(),
               },

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -12,6 +12,7 @@ import {
   getOrganizationByWorkspaceId,
   subscribeOrganizationMembersToSurveyResponses,
 } from "@/lib/organization/service";
+import { getSurveyWorkspaceIdMap } from "@/modules/ee/contacts/segments/lib/segments";
 import { handleTriggerUpdates } from "@/modules/survey/lib/trigger-updates";
 import {
   isSurveySchedulingDue,
@@ -284,14 +285,38 @@ export const updateSurveyInternal = async (
     const surveyId = updatedSurvey.id;
     let data: any = {};
 
-    const actionClasses = await getActionClasses(updatedSurvey.workspaceId);
     const currentSurvey = await getSurvey(surveyId);
 
     if (!currentSurvey) {
       throw new ResourceNotFoundError("Survey", surveyId);
     }
 
-    const { triggers, segment, questions, languages, type, followUps, ...surveyData } = updatedSurvey;
+    // ENG-1749: workspaceId and id are the survey's tenant anchors. Always resolve the workspace from
+    // the existing survey (never the client payload), and strip workspaceId/id from the update below,
+    // so an authorized editor cannot re-point their own survey into another workspace/organization.
+    const actionClasses = await getActionClasses(currentSurvey.workspaceId);
+
+    const {
+      triggers,
+      segment,
+      questions,
+      languages,
+      type,
+      followUps,
+      workspaceId: _workspaceId,
+      id: _id,
+      ...surveyData
+    } = updatedSurvey;
+
+    // ENG-1749 sibling: the segment block below updates/deletes by segment.id directly. Ensure the
+    // segment belongs to this survey's workspace so a caller cannot mutate or delete another
+    // tenant's segment by supplying its id. Mirrors the create path guard.
+    await assertSurveySegmentBelongsToWorkspace(currentSurvey.workspaceId, segment);
+
+    // ENG-1749 sibling: the languages block below links languages by language.id. Ensure every
+    // referenced language belongs to this survey's workspace so a caller cannot attach another
+    // tenant's language. Mirrors the create path guard (covers drafts too — runs before validation).
+    await assertSurveyLanguagesBelongToWorkspace(currentSurvey.workspaceId, languages);
 
     if (!skipValidation) {
       checkForInvalidImagesInQuestions(questions);
@@ -373,21 +398,33 @@ export const updateSurveyInternal = async (
           throw new InvalidInputError("Invalid user segment filters");
         }
 
-        try {
-          // update the segment:
-          let updatedInput: Prisma.SegmentUpdateInput = {
-            ...segment,
-            surveys: undefined,
-          };
-
-          if (segment.surveys) {
-            updatedInput = {
-              ...segment,
-              surveys: {
-                connect: segment.surveys.map((surveyId) => ({ id: surveyId })),
-              },
-            };
+        // ENG-1749/ENG-1920: the connected survey ids are client-supplied; ensure each belongs to
+        // this survey's workspace before re-pointing it to the segment (a foreign id would hijack
+        // another tenant's survey targeting). Done outside the try below, which masks errors as a
+        // generic Error and would otherwise hide this rejection.
+        if (segment.surveys && segment.surveys.length > 0) {
+          const workspaceBySurveyId = await getSurveyWorkspaceIdMap(segment.surveys);
+          if (
+            !segment.surveys.every(
+              (surveyId) => workspaceBySurveyId.get(surveyId) === currentSurvey.workspaceId
+            )
+          ) {
+            throw new InvalidInputError("Survey and segment are not in the same workspace");
           }
+        }
+
+        try {
+          // Update only the segment's own mutable fields — never mass-assign workspaceId/id/
+          // timestamps from the client-supplied segment object (ENG-1749).
+          const updatedInput: Prisma.SegmentUpdateInput = {
+            title: segment.title,
+            description: segment.description,
+            isPrivate: segment.isPrivate,
+            filters: segment.filters,
+            ...(segment.surveys
+              ? { surveys: { connect: segment.surveys.map((surveyId) => ({ id: surveyId })) } }
+              : {}),
+          };
 
           await prisma.segment.update({
             where: { id: segment.id },
@@ -436,7 +473,7 @@ export const updateSurveyInternal = async (
       }
     } else if (type === "app") {
       if (!currentSurvey.segment) {
-        const workspaceId = updatedSurvey.workspaceId;
+        const workspaceId = currentSurvey.workspaceId;
         await prisma.survey.update({
           where: {
             id: surveyId,
@@ -630,20 +667,35 @@ const validateSurveyCreateDataMedia = (
   return data;
 };
 
-const assertSurveyLanguagesBelongToWorkspace = (
+const assertSurveyLanguagesBelongToWorkspace = async (
   workspaceId: string,
-  languages: TSurveyCreateInput["languages"]
-): void => {
-  for (const surveyLanguage of languages ?? []) {
-    if (surveyLanguage.language.workspaceId !== workspaceId) {
-      throw new ResourceNotFoundError("Language", surveyLanguage.language.id);
+  languages: Array<{ language: { id: string } }> | null | undefined
+): Promise<void> => {
+  const languageIds = [...new Set((languages ?? []).map((surveyLanguage) => surveyLanguage.language.id))];
+  if (languageIds.length === 0) {
+    return;
+  }
+
+  // ENG-1749: resolve each language's real owning workspace from the DB rather than trusting the
+  // caller-supplied language.workspaceId — the survey payload is client-controlled, so an attacker
+  // could otherwise claim a foreign language belongs to this workspace. A single batched query
+  // avoids a per-language fan-out; an unknown id is absent from the map and thus rejected.
+  const dbLanguages = await prisma.language.findMany({
+    where: { id: { in: languageIds } },
+    select: { id: true, workspaceId: true },
+  });
+  const workspaceByLanguageId = new Map(dbLanguages.map((language) => [language.id, language.workspaceId]));
+
+  for (const languageId of languageIds) {
+    if (workspaceByLanguageId.get(languageId) !== workspaceId) {
+      throw new ResourceNotFoundError("Language", languageId);
     }
   }
 };
 
 const assertSurveySegmentBelongsToWorkspace = async (
   workspaceId: string,
-  segment: TSurveyCreateInput["segment"]
+  segment: { id?: string | null } | null | undefined
 ): Promise<void> => {
   if (!segment?.id) {
     return;
@@ -671,7 +723,7 @@ export const createSurvey = async (
 
   try {
     const { createdBy, languages, segment, followUps, styling, ...restSurveyBody } = parsedSurveyBody;
-    assertSurveyLanguagesBelongToWorkspace(parsedWorkspaceId, languages);
+    await assertSurveyLanguagesBelongToWorkspace(parsedWorkspaceId, languages);
     await assertSurveySegmentBelongsToWorkspace(parsedWorkspaceId, segment);
 
     // An app survey can never be shown without a trigger, so block creating one directly in a

--- a/apps/web/lib/utils/resolve-client-id.test.ts
+++ b/apps/web/lib/utils/resolve-client-id.test.ts
@@ -29,7 +29,7 @@ describe("resolveClientApiIds", () => {
     });
     expect(prisma.workspace.findFirst).toHaveBeenCalledWith({
       where: { OR: [{ id: "ws-456" }, { legacyEnvironmentId: "ws-456" }] },
-      select: { id: true },
+      select: { id: true, organizationId: true },
     });
   });
 
@@ -42,7 +42,7 @@ describe("resolveClientApiIds", () => {
     expect(prisma.workspace.findFirst).toHaveBeenCalledTimes(1);
     expect(prisma.workspace.findFirst).toHaveBeenCalledWith({
       where: { OR: [{ id: "env-old-123" }, { legacyEnvironmentId: "env-old-123" }] },
-      select: { id: true },
+      select: { id: true, organizationId: true },
     });
   });
 

--- a/apps/web/lib/utils/resolve-client-id.ts
+++ b/apps/web/lib/utils/resolve-client-id.ts
@@ -9,12 +9,14 @@ export type TResolvedClientIds = {
 /**
  * Finds a workspace by its primary id or by legacyEnvironmentId in a single query.
  * Both columns have unique indexes so the query planner will use index scans.
- * Returns the workspace id if found, null otherwise.
+ * Returns the workspace id and its owning organizationId if found, null otherwise.
  */
-export const findWorkspaceByIdOrLegacyEnvId = async (id: string): Promise<{ id: string } | null> => {
+export const findWorkspaceByIdOrLegacyEnvId = async (
+  id: string
+): Promise<{ id: string; organizationId: string } | null> => {
   return await prisma.workspace.findFirst({
     where: { OR: [{ id }, { legacyEnvironmentId: id }] },
-    select: { id: true },
+    select: { id: true, organizationId: true },
   });
 };
 

--- a/apps/web/modules/api/lib/api-key-auth.test.ts
+++ b/apps/web/modules/api/lib/api-key-auth.test.ts
@@ -1,5 +1,15 @@
-import { describe, expect, test } from "vitest";
-import { getApiKeyFromHeaders, getBearerTokenFromHeaders } from "./api-key-auth";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  authenticateApiKeyFromHeaders,
+  getApiKeyFromHeaders,
+  getBearerTokenFromHeaders,
+} from "./api-key-auth";
+
+const mocks = vi.hoisted(() => ({ getApiKeyWithPermissions: vi.fn() }));
+
+vi.mock("@/modules/organization/settings/api-keys/lib/api-key", () => ({
+  getApiKeyWithPermissions: mocks.getApiKeyWithPermissions,
+}));
 
 describe("api-key-auth helpers", () => {
   test("prefers x-api-key over bearer authorization", () => {
@@ -36,5 +46,53 @@ describe("api-key-auth helpers", () => {
 
     expect(getApiKeyFromHeaders(headers)).toBeNull();
     expect(getBearerTokenFromHeaders(headers)).toBe("opaque_service_token");
+  });
+});
+
+describe("authenticateApiKeyFromHeaders — ENG-1749 cross-org permission filter", () => {
+  const headers = new Headers({ "x-api-key": "fbk_secret" });
+
+  const apiKeyData = (workspaces: unknown[]) => ({
+    id: "key1",
+    organizationId: "org-self",
+    organizationAccess: { accessControl: { read: false, write: false } },
+    apiKeyWorkspaces: workspaces,
+  });
+
+  const ws = (id: string, organizationId: string) => ({
+    permission: "manage",
+    workspaceId: id,
+    workspace: { id, name: id, organizationId },
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("drops workspace permissions whose workspace is in another organization", async () => {
+    mocks.getApiKeyWithPermissions.mockResolvedValue(
+      apiKeyData([ws("ws-own", "org-self"), ws("ws-victim", "org-other")])
+    );
+
+    const auth = await authenticateApiKeyFromHeaders(headers);
+
+    expect(auth?.workspacePermissions).toEqual([
+      { permission: "manage", workspaceId: "ws-own", workspaceName: "ws-own" },
+    ]);
+  });
+
+  test("returns null when only cross-org permissions remain", async () => {
+    mocks.getApiKeyWithPermissions.mockResolvedValue(apiKeyData([ws("ws-victim", "org-other")]));
+
+    expect(await authenticateApiKeyFromHeaders(headers)).toBeNull();
+  });
+
+  test("keeps a cross-org-only key for org-scoped routes but with no workspace permissions", async () => {
+    mocks.getApiKeyWithPermissions.mockResolvedValue(apiKeyData([ws("ws-victim", "org-other")]));
+
+    const auth = await authenticateApiKeyFromHeaders(headers, { allowOrganizationOnlyApiKey: true });
+
+    expect(auth).not.toBeNull();
+    expect(auth?.workspacePermissions).toEqual([]);
   });
 });

--- a/apps/web/modules/api/lib/api-key-auth.ts
+++ b/apps/web/modules/api/lib/api-key-auth.ts
@@ -52,19 +52,32 @@ export const authenticateApiKeyFromHeaders = async (
     return null;
   }
 
+  // ENG-1749 defense-in-depth: only honor workspace permissions whose workspace belongs to the
+  // key's own organization. API keys are org-scoped, so a permission on a foreign workspace is
+  // always illegitimate (it can only exist from a pre-fix bug/exploit). Filtering here — the single
+  // point where the permission list is built — protects every consumer, including the read/list
+  // routes that authorize off this list directly rather than through resolveBodyIdsV2.
+  const workspacePermissions = (apiKeyData.apiKeyWorkspaces ?? [])
+    .filter(
+      (workspacePermission) => workspacePermission.workspace.organizationId === apiKeyData.organizationId
+    )
+    .map((workspacePermission) => ({
+      permission: workspacePermission.permission,
+      workspaceId: workspacePermission.workspaceId,
+      workspaceName: workspacePermission.workspace.name,
+    }));
+
   // Reject org-only API keys for routes that require workspace-scoped permissions
   // (those routes opt in via allowOrganizationOnlyApiKey when an org-only key is acceptable).
-  if (!options.allowOrganizationOnlyApiKey && (apiKeyData.apiKeyWorkspaces?.length ?? 0) === 0) {
+  // Uses the filtered list so a key left with only cross-org (now-dropped) permissions is treated
+  // as having no workspace access.
+  if (!options.allowOrganizationOnlyApiKey && workspacePermissions.length === 0) {
     return null;
   }
 
   return {
     type: "apiKey",
-    workspacePermissions: (apiKeyData.apiKeyWorkspaces ?? []).map((workspacePermission) => ({
-      permission: workspacePermission.permission,
-      workspaceId: workspacePermission.workspaceId,
-      workspaceName: workspacePermission.workspace.name,
-    })),
+    workspacePermissions,
     apiKeyId: apiKeyData.id,
     organizationId: apiKeyData.organizationId,
     organizationAccess: apiKeyData.organizationAccess,

--- a/apps/web/modules/api/v2/auth/tests/authenticate-request.test.ts
+++ b/apps/web/modules/api/v2/auth/tests/authenticate-request.test.ts
@@ -40,6 +40,7 @@ describe("authenticateRequest", () => {
           workspace: {
             id: "workspace-id-1",
             name: "Workspace 1",
+            organizationId: "org-id",
           },
         },
         {
@@ -49,6 +50,7 @@ describe("authenticateRequest", () => {
           workspace: {
             id: "workspace-id-2",
             name: "Workspace 2",
+            organizationId: "org-id",
           },
         },
       ],

--- a/apps/web/modules/api/v2/management/contact-attribute-keys/route.ts
+++ b/apps/web/modules/api/v2/management/contact-attribute-keys/route.ts
@@ -43,7 +43,7 @@ export const POST = async (request: NextRequest) =>
       body: ZContactAttributeKeyCreateInput,
     },
     bodyTransform: async (body, auth) => {
-      const resolved = await resolveBodyIdsV2(body, auth.workspacePermissions, "POST");
+      const resolved = await resolveBodyIdsV2(body, auth, "POST");
       if (!resolved.ok) throw resolved.error;
       return { ...body, ...resolved.data };
     },

--- a/apps/web/modules/api/v2/management/lib/workspace-resolver.test.ts
+++ b/apps/web/modules/api/v2/management/lib/workspace-resolver.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ApiKeyPermission } from "@formbricks/database/prisma";
+import { findWorkspaceByIdOrLegacyEnvId } from "@/lib/utils/resolve-client-id";
+import { resolveBodyIdsV2 } from "./workspace-resolver";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/utils/resolve-client-id", () => ({
+  findWorkspaceByIdOrLegacyEnvId: vi.fn(),
+}));
+
+const auth = (organizationId: string, workspaceId: string, permission: ApiKeyPermission) => ({
+  organizationId,
+  workspacePermissions: [{ workspaceId, permission }],
+});
+
+describe("resolveBodyIdsV2", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns bad_request when no workspaceId/environmentId is provided", async () => {
+    const result = await resolveBodyIdsV2({}, auth("org1", "ws1", ApiKeyPermission.manage), "POST");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.type).toBe("bad_request");
+    expect(findWorkspaceByIdOrLegacyEnvId).not.toHaveBeenCalled();
+  });
+
+  test("returns not_found when the workspace does not exist", async () => {
+    vi.mocked(findWorkspaceByIdOrLegacyEnvId).mockResolvedValueOnce(null);
+
+    const result = await resolveBodyIdsV2(
+      { workspaceId: "ws-missing" },
+      auth("org1", "ws-missing", ApiKeyPermission.manage),
+      "POST"
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.type).toBe("not_found");
+  });
+
+  // ENG-1749 defense-in-depth: a permission row for a workspace in another organization must not
+  // grant access, even though hasPermission alone would match on workspaceId.
+  test("returns forbidden when the workspace belongs to a different organization", async () => {
+    vi.mocked(findWorkspaceByIdOrLegacyEnvId).mockResolvedValueOnce({
+      id: "victim-ws",
+      organizationId: "victim-org",
+    });
+
+    const result = await resolveBodyIdsV2(
+      { workspaceId: "victim-ws" },
+      // Attacker's key carries a (illegitimate) manage permission on the victim workspace.
+      auth("attacker-org", "victim-ws", ApiKeyPermission.manage),
+      "POST"
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.type).toBe("forbidden");
+  });
+
+  test("returns forbidden when the key lacks permission for an in-org workspace", async () => {
+    vi.mocked(findWorkspaceByIdOrLegacyEnvId).mockResolvedValueOnce({
+      id: "ws1",
+      organizationId: "org1",
+    });
+
+    const result = await resolveBodyIdsV2(
+      { workspaceId: "ws1" },
+      auth("org1", "ws1", ApiKeyPermission.read), // read cannot POST (needs write)
+      "POST"
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.type).toBe("forbidden");
+  });
+
+  test("resolves the workspaceId for a same-org workspace the key can access", async () => {
+    vi.mocked(findWorkspaceByIdOrLegacyEnvId).mockResolvedValueOnce({
+      id: "ws1",
+      organizationId: "org1",
+    });
+
+    const result = await resolveBodyIdsV2(
+      { workspaceId: "ws1" },
+      auth("org1", "ws1", ApiKeyPermission.manage),
+      "POST"
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual({ workspaceId: "ws1" });
+  });
+});

--- a/apps/web/modules/api/v2/management/lib/workspace-resolver.ts
+++ b/apps/web/modules/api/v2/management/lib/workspace-resolver.ts
@@ -1,4 +1,4 @@
-import { TAPIKeyWorkspacePermission } from "@formbricks/types/auth";
+import { TAuthenticationApiKey } from "@formbricks/types/auth";
 import { Result, err, ok } from "@formbricks/types/error-handlers";
 import { findWorkspaceByIdOrLegacyEnvId } from "@/lib/utils/resolve-client-id";
 import { ApiErrorResponseV2 } from "@/modules/api/v2/types/api-error";
@@ -17,7 +17,7 @@ type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
  */
 export const resolveBodyIdsV2 = async (
   body: { workspaceId?: string; environmentId?: string },
-  permissions: TAPIKeyWorkspacePermission[],
+  authentication: Pick<TAuthenticationApiKey, "organizationId" | "workspacePermissions">,
   method: HttpMethod
 ): Promise<Result<{ workspaceId: string }, ApiErrorResponseV2>> => {
   const rawId = body.workspaceId ?? body.environmentId;
@@ -31,7 +31,14 @@ export const resolveBodyIdsV2 = async (
       });
     }
 
-    if (!hasPermission(permissions, workspace.id, method)) {
+    // ENG-1749 defense-in-depth: even if the API key somehow carries a permission row for this
+    // workspace, refuse it unless the workspace belongs to the key's own organization. This is a
+    // second, independent tenant boundary behind the create-time check in createApiKey.
+    if (workspace.organizationId !== authentication.organizationId) {
+      return err({ type: "forbidden" });
+    }
+
+    if (!hasPermission(authentication.workspacePermissions, workspace.id, method)) {
       return err({ type: "forbidden" });
     }
 

--- a/apps/web/modules/api/v2/management/webhooks/route.ts
+++ b/apps/web/modules/api/v2/management/webhooks/route.ts
@@ -44,7 +44,7 @@ export const POST = async (request: NextRequest) =>
       body: ZWebhookCreateInput,
     },
     bodyTransform: async (body, auth) => {
-      const resolved = await resolveBodyIdsV2(body, auth.workspacePermissions, "POST");
+      const resolved = await resolveBodyIdsV2(body, auth, "POST");
       if (!resolved.ok) throw resolved.error;
       return { ...body, ...resolved.data };
     },

--- a/apps/web/modules/ee/contacts/api/v2/management/contacts/bulk/route.ts
+++ b/apps/web/modules/ee/contacts/api/v2/management/contacts/bulk/route.ts
@@ -14,7 +14,7 @@ export const PUT = async (request: Request) =>
       body: ZContactBulkUploadRequest,
     },
     bodyTransform: async (body, auth) => {
-      const resolved = await resolveBodyIdsV2(body, auth.workspacePermissions, "PUT");
+      const resolved = await resolveBodyIdsV2(body, auth, "PUT");
       if (!resolved.ok) throw resolved.error;
       return { ...body, ...resolved.data };
     },

--- a/apps/web/modules/ee/contacts/api/v2/management/contacts/route.ts
+++ b/apps/web/modules/ee/contacts/api/v2/management/contacts/route.ts
@@ -15,7 +15,7 @@ export const POST = async (request: NextRequest) =>
       body: ZContactCreateRequest,
     },
     bodyTransform: async (body, auth) => {
-      const resolved = await resolveBodyIdsV2(body, auth.workspacePermissions, "POST");
+      const resolved = await resolveBodyIdsV2(body, auth, "POST");
       if (!resolved.ok) throw resolved.error;
       return { ...body, ...resolved.data };
     },

--- a/apps/web/modules/ee/contacts/segments/actions.test.ts
+++ b/apps/web/modules/ee/contacts/segments/actions.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { InvalidInputError } from "@formbricks/types/errors";
+
+const mocks = vi.hoisted(() => ({
+  checkAuthorizationUpdated: vi.fn(),
+  getOrganizationIdFromSegmentId: vi.fn(),
+  getWorkspaceIdFromSegmentId: vi.fn(),
+  getWorkspaceIdFromSurveyId: vi.fn(),
+  getSurveyWorkspaceIdMap: vi.fn(),
+  getIsContactsEnabled: vi.fn(),
+  getOrganization: vi.fn(),
+  updateSegment: vi.fn(),
+  getSegment: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/action-client", () => ({
+  authenticatedActionClient: {
+    inputSchema: vi.fn(() => ({ action: vi.fn((fn) => fn) })),
+  },
+}));
+
+vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
+  withAuditLogging: vi.fn((_eventName, _objectType, fn) => fn),
+}));
+
+vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
+  checkAuthorizationUpdated: mocks.checkAuthorizationUpdated,
+}));
+
+vi.mock("@/lib/utils/helper", () => ({
+  getOrganizationIdFromContactAttributeKeyId: vi.fn(),
+  getOrganizationIdFromSegmentId: mocks.getOrganizationIdFromSegmentId,
+  getOrganizationIdFromSurveyId: vi.fn(),
+  getOrganizationIdFromWorkspaceId: vi.fn(),
+  getWorkspaceIdFromContactAttributeKeyId: vi.fn(),
+  getWorkspaceIdFromSegmentId: mocks.getWorkspaceIdFromSegmentId,
+  getWorkspaceIdFromSurveyId: mocks.getWorkspaceIdFromSurveyId,
+}));
+
+vi.mock("@/modules/ee/license-check/lib/utils", () => ({
+  getIsContactsEnabled: mocks.getIsContactsEnabled,
+}));
+
+vi.mock("@/modules/ee/contacts/segments/lib/segments", () => ({
+  cloneSegment: vi.fn(),
+  createSegment: vi.fn(),
+  deleteSegment: vi.fn(),
+  getSegment: mocks.getSegment,
+  getSurveyWorkspaceIdMap: mocks.getSurveyWorkspaceIdMap,
+  resetSegmentInSurvey: vi.fn(),
+  updateSegment: mocks.updateSegment,
+}));
+
+vi.mock("@/lib/survey/service", () => ({ loadNewSegmentInSurvey: vi.fn() }));
+vi.mock("@/lib/organization/service", () => ({ getOrganization: mocks.getOrganization }));
+vi.mock("@/lib/posthog", () => ({ capturePostHogEvent: vi.fn() }));
+vi.mock("@/modules/ee/contacts/lib/contact-attributes", () => ({ getDistinctAttributeValues: vi.fn() }));
+vi.mock("@/modules/ee/contacts/segments/lib/helper", () => ({ checkForRecursiveSegmentFilter: vi.fn() }));
+
+// Import after mocks so the action client / audit wrappers are the passthrough versions.
+const { updateSegmentAction } = await import("./actions");
+
+const callUpdate = (data: Record<string, unknown>) =>
+  (updateSegmentAction as unknown as (args: unknown) => Promise<unknown>)({
+    ctx: { user: { id: "user1" }, auditLoggingCtx: {} },
+    parsedInput: { segmentId: "seg1", data },
+  });
+
+describe("updateSegmentAction — ENG-1920 cross-workspace survey re-point", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.checkAuthorizationUpdated.mockResolvedValue(undefined);
+    mocks.getOrganizationIdFromSegmentId.mockResolvedValue("org1");
+    mocks.getWorkspaceIdFromSegmentId.mockResolvedValue("ws-segment");
+    mocks.getIsContactsEnabled.mockResolvedValue(true);
+    mocks.getOrganization.mockResolvedValue({ id: "org1" });
+  });
+
+  test("rejects a survey that belongs to another workspace", async () => {
+    mocks.getSurveyWorkspaceIdMap.mockResolvedValue(new Map([["victim-survey", "ws-other"]]));
+
+    await expect(callUpdate({ surveys: ["victim-survey"] })).rejects.toThrow(InvalidInputError);
+    expect(mocks.updateSegment).not.toHaveBeenCalled();
+  });
+
+  test("rejects a survey id that does not resolve to any workspace (uniform rejection, no oracle)", async () => {
+    mocks.getSurveyWorkspaceIdMap.mockResolvedValue(new Map());
+
+    await expect(callUpdate({ surveys: ["nonexistent-survey"] })).rejects.toThrow(InvalidInputError);
+    expect(mocks.updateSegment).not.toHaveBeenCalled();
+  });
+
+  test("allows surveys in the segment's own workspace", async () => {
+    mocks.getSurveyWorkspaceIdMap.mockResolvedValue(new Map([["own-survey", "ws-segment"]]));
+    mocks.getSegment.mockResolvedValue({ id: "seg1" });
+    mocks.updateSegment.mockResolvedValue({ id: "seg1", surveys: [] });
+
+    await callUpdate({ surveys: ["own-survey"] });
+
+    expect(mocks.updateSegment).toHaveBeenCalledWith("seg1", { surveys: ["own-survey"] });
+    expect(mocks.getSurveyWorkspaceIdMap).toHaveBeenCalledWith(["own-survey"]);
+  });
+});

--- a/apps/web/modules/ee/contacts/segments/actions.ts
+++ b/apps/web/modules/ee/contacts/segments/actions.ts
@@ -26,6 +26,7 @@ import {
   createSegment,
   deleteSegment,
   getSegment,
+  getSurveyWorkspaceIdMap,
   resetSegmentInSurvey,
   updateSegment,
 } from "@/modules/ee/contacts/segments/lib/segments";
@@ -116,6 +117,7 @@ const ZUpdateSegmentAction = z.object({
 export const updateSegmentAction = authenticatedActionClient.inputSchema(ZUpdateSegmentAction).action(
   withAuditLogging("updated", "segment", async ({ ctx, parsedInput }) => {
     const organizationId = await getOrganizationIdFromSegmentId(parsedInput.segmentId);
+    const segmentWorkspaceId = await getWorkspaceIdFromSegmentId(parsedInput.segmentId);
     await checkAuthorizationUpdated({
       userId: ctx.user.id,
       organizationId,
@@ -127,12 +129,26 @@ export const updateSegmentAction = authenticatedActionClient.inputSchema(ZUpdate
         {
           type: "workspaceTeam",
           minPermission: "readWrite",
-          workspaceId: await getWorkspaceIdFromSegmentId(parsedInput.segmentId),
+          workspaceId: segmentWorkspaceId,
         },
       ],
     });
 
     await checkAdvancedTargetingPermission(organizationId);
+
+    // ENG-1920: the surveys are connected to the segment by id alone, so ensure every survey
+    // belongs to the segment's workspace — otherwise a caller could re-point another tenant's
+    // survey to their segment. A single batched lookup avoids fanning out a query per survey id
+    // over the caller-controlled array; an unknown id is absent from the map and thus rejected.
+    if (parsedInput.data.surveys && parsedInput.data.surveys.length > 0) {
+      const surveyWorkspaceIdMap = await getSurveyWorkspaceIdMap(parsedInput.data.surveys);
+      const allInSegmentWorkspace = parsedInput.data.surveys.every(
+        (surveyId) => surveyWorkspaceIdMap.get(surveyId) === segmentWorkspaceId
+      );
+      if (!allInSegmentWorkspace) {
+        throw new InvalidInputError("Survey and segment are not in the same workspace");
+      }
+    }
 
     const { filters } = parsedInput.data;
     if (filters) {

--- a/apps/web/modules/ee/contacts/segments/lib/segments.test.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/segments.test.ts
@@ -22,6 +22,7 @@ import {
   getSegment,
   getSegments,
   getSegmentsByAttributeKey,
+  getSurveyWorkspaceIdMap,
   resetSegmentInSurvey,
   selectSegment,
   transformPrismaSegment,
@@ -42,6 +43,7 @@ vi.mock("@formbricks/database", () => ({
     },
     survey: {
       update: vi.fn(),
+      findMany: vi.fn(),
     },
     $transaction: vi.fn((callback) => callback(prisma)), // Mock transaction to execute the callback
   },
@@ -164,6 +166,36 @@ describe("Segment Service Tests", () => {
     test("should throw DatabaseError on Prisma error", async () => {
       vi.mocked(prisma.segment.findMany).mockRejectedValue(new Error("DB error"));
       await expect(getSegments("workspace-id-mock")).rejects.toThrow(Error);
+    });
+  });
+
+  describe("getSurveyWorkspaceIdMap", () => {
+    test("builds an id→workspaceId map, selecting only id and workspaceId", async () => {
+      vi.mocked(prisma.survey.findMany).mockResolvedValue([
+        { id: "survey1", workspaceId: "ws-a" },
+        { id: "survey2", workspaceId: "ws-b" },
+      ] as any);
+
+      const result = await getSurveyWorkspaceIdMap(["survey1", "survey2"]);
+
+      expect(result).toEqual(
+        new Map([
+          ["survey1", "ws-a"],
+          ["survey2", "ws-b"],
+        ])
+      );
+      expect(prisma.survey.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ["survey1", "survey2"] } },
+        select: { id: true, workspaceId: true },
+      });
+    });
+
+    test("returns an empty map when no surveys match", async () => {
+      vi.mocked(prisma.survey.findMany).mockResolvedValue([] as any);
+
+      const result = await getSurveyWorkspaceIdMap(["missing"]);
+
+      expect(result.size).toBe(0);
     });
   });
 

--- a/apps/web/modules/ee/contacts/segments/lib/segments.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/segments.ts
@@ -348,6 +348,26 @@ export const resetSegmentInSurvey = async (surveyId: string): Promise<TSegment> 
   }
 };
 
+// Batched lookup of the owning workspace for a set of surveys, used to keep segment↔survey links
+// within one workspace (ENG-1920). A single query avoids fanning out one lookup per survey id over
+// a caller-controlled, unbounded array. Missing ids are simply absent from the map.
+export const getSurveyWorkspaceIdMap = reactCache(
+  async (surveyIds: string[]): Promise<Map<string, string>> => {
+    try {
+      const surveys = await prisma.survey.findMany({
+        where: { id: { in: surveyIds } },
+        select: { id: true, workspaceId: true },
+      });
+      return new Map(surveys.map((survey) => [survey.id, survey.workspaceId]));
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw new DatabaseError(error.message);
+      }
+      throw error;
+    }
+  }
+);
+
 export const updateSegment = async (segmentId: string, data: TSegmentUpdateInput): Promise<TSegment> => {
   validateInputs([segmentId, ZId], [data, ZSegmentUpdateInput]);
 

--- a/apps/web/modules/ee/quotas/lib/quotas.test.ts
+++ b/apps/web/modules/ee/quotas/lib/quotas.test.ts
@@ -193,10 +193,23 @@ describe("Quota Service", () => {
       const result = await updateQuota(updateInput, mockQuotaId);
 
       expect(result).toEqual(updatedQuota);
+      // surveyId is immutable on update (ENG-1749) and is stripped from the persisted data.
+      const { surveyId: _omittedSurveyId, ...expectedData } = updateInput;
       expect(prisma.surveyQuota.update).toHaveBeenCalledWith({
         where: { id: mockQuotaId },
-        data: updateInput,
+        data: expectedData,
       });
+    });
+
+    // ENG-1749 sibling: updateQuota must not re-point a quota to a different (potentially
+    // cross-tenant) survey. Even when a foreign surveyId is supplied, it must not be persisted.
+    test("never persists a caller-supplied surveyId", async () => {
+      vi.mocked(prisma.surveyQuota.update).mockResolvedValue(mockQuota);
+
+      await updateQuota({ ...updateInput, surveyId: "clvictimsurvey0000000000001" }, mockQuotaId);
+
+      const arg = vi.mocked(prisma.surveyQuota.update).mock.calls[0][0];
+      expect(arg.data).not.toHaveProperty("surveyId");
     });
 
     test("should throw DatabaseError when quota not found", async () => {

--- a/apps/web/modules/ee/quotas/lib/quotas.ts
+++ b/apps/web/modules/ee/quotas/lib/quotas.ts
@@ -72,9 +72,13 @@ export const createQuota = async (quota: TSurveyQuotaInput): Promise<TSurveyQuot
 
 export const updateQuota = async (quota: TSurveyQuotaInput, id: string): Promise<TSurveyQuota> => {
   try {
+    // ENG-1749: surveyId is the quota's tenant anchor, set at creation and immutable thereafter.
+    // Persisting a caller-supplied surveyId here would let an authorized quota owner re-point their
+    // quota onto another tenant's survey, so it is stripped from the update payload.
+    const { surveyId: _surveyId, ...quotaData } = quota;
     const updatedQuota = await prisma.surveyQuota.update({
       where: { id },
-      data: quota,
+      data: quotaData,
     });
 
     return updatedQuota;

--- a/apps/web/modules/ee/whitelabel/email-customization/components/email-customization-settings.tsx
+++ b/apps/web/modules/ee/whitelabel/email-customization/components/email-customization-settings.tsx
@@ -11,6 +11,7 @@ import { TAllowedFileExtension } from "@formbricks/types/storage";
 import { TUser } from "@formbricks/types/user";
 import { SettingsCard } from "@/app/(app)/workspaces/[workspaceId]/settings/components/SettingsCard";
 import { cn } from "@/lib/cn";
+import { isExternalImageSrc } from "@/lib/image-hosts";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import {
   removeOrganizationEmailLogoUrlAction,
@@ -219,6 +220,7 @@ export const EmailCustomizationSettings = ({
                         className="max-h-24 max-w-full object-contain"
                         width={192}
                         height={192}
+                        unoptimized={isExternalImageSrc(logoUrl)}
                       />
                     </div>
 
@@ -287,6 +289,7 @@ export const EmailCustomizationSettings = ({
                 className="mx-auto max-h-[100px] max-w-full object-contain"
                 width={192}
                 height={192}
+                unoptimized={isExternalImageSrc(logoUrl || fbLogoUrl)}
               />
               <P className="font-bold">
                 {t("workspace.settings.general.email_customization_preview_email_heading", {

--- a/apps/web/modules/ee/whitelabel/favicon-customization/components/favicon-customization-settings.tsx
+++ b/apps/web/modules/ee/whitelabel/favicon-customization/components/favicon-customization-settings.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { TOrganization } from "@formbricks/types/organizations";
 import { TAllowedFileExtension } from "@formbricks/types/storage";
 import { SettingsCard } from "@/app/(app)/workspaces/[workspaceId]/settings/components/SettingsCard";
+import { isExternalImageSrc } from "@/lib/image-hosts";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import {
   removeOrganizationFaviconUrlAction,
@@ -172,6 +173,7 @@ export const FaviconCustomizationSettings = ({
               width={64}
               height={64}
               className="-mb-2 size-16 rounded-lg border object-contain p-1"
+              unoptimized={isExternalImageSrc(faviconUrl)}
             />
           ) : (
             <FileInput

--- a/apps/web/modules/organization/settings/api-keys/lib/api-key.ts
+++ b/apps/web/modules/organization/settings/api-keys/lib/api-key.ts
@@ -6,10 +6,11 @@ import { ApiKey, ApiKeyPermission, Prisma } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { TOrganizationAccess } from "@formbricks/types/api-key";
 import { ZId } from "@formbricks/types/common";
-import { DatabaseError } from "@formbricks/types/errors";
+import { DatabaseError, OperationNotAllowedError } from "@formbricks/types/errors";
 import { CONTROL_HASH } from "@/lib/constants";
 import { hashSecret, hashSha256, parseApiKeyV2, verifySecret } from "@/lib/crypto";
 import { validateInputs } from "@/lib/utils/validate";
+import { getWorkspacesByOrganizationId } from "@/modules/organization/settings/api-keys/lib/workspaces";
 import {
   TApiKeyCreateInput,
   TApiKeyUpdateInput,
@@ -61,6 +62,10 @@ export const getApiKeyWithPermissions = reactCache(
               select: {
                 id: true,
                 name: true,
+                // ENG-1749: needed so the auth layer can drop any workspace permission whose
+                // workspace is outside the key's organization (defense-in-depth for the read path,
+                // which authorizes off the permission list rather than resolveBodyIdsV2).
+                organizationId: true,
               },
             },
           },
@@ -161,6 +166,24 @@ export const createApiKey = async (
 ): Promise<TApiKeyWithEnvironmentPermission & { actualKey: string }> => {
   validateInputs([organizationId, ZId], [apiKeyData, ZApiKeyCreateInput]);
   try {
+    // ENG-1749: an API key is created at the organization level but carries per-workspace
+    // permissions. Reject any workspace that does not belong to the authorized organization,
+    // otherwise a caller could mint a key scoped to another tenant's workspace (cross-tenant
+    // BOLA). Validate before generating/hashing the secret so illegitimate input does no work.
+    const { workspacePermissions, organizationAccess, ...apiKeyDataWithoutPermissions } = apiKeyData;
+    if (workspacePermissions && workspacePermissions.length > 0) {
+      const orgWorkspaceIds = new Set(
+        (await getWorkspacesByOrganizationId(organizationId)).map((workspace) => workspace.id)
+      );
+      for (const { workspaceId } of workspacePermissions) {
+        if (!orgWorkspaceIds.has(workspaceId)) {
+          throw new OperationNotAllowedError(
+            `Workspace ${workspaceId} does not belong to organization ${organizationId}`
+          );
+        }
+      }
+    }
+
     // Generate a secure random secret (32 bytes base64url)
     const secret = randomBytes(32).toString("base64url");
 
@@ -170,8 +193,6 @@ export const createApiKey = async (
 
     // 2. bcrypt hash
     const hashedKey = await hashSecret(secret, 12);
-
-    const { workspacePermissions, organizationAccess, ...apiKeyDataWithoutPermissions } = apiKeyData;
 
     // Create the API key
     const result = await prisma.apiKey.create({

--- a/apps/web/modules/organization/settings/api-keys/lib/api-keys.test.ts
+++ b/apps/web/modules/organization/settings/api-keys/lib/api-keys.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { ApiKey, ApiKeyPermission, Prisma } from "@formbricks/database/prisma";
-import { DatabaseError } from "@formbricks/types/errors";
+import { DatabaseError, OperationNotAllowedError } from "@formbricks/types/errors";
 import { TApiKeyWithEnvironmentPermission } from "../types/api-keys";
 import {
   createApiKey,
@@ -10,6 +10,7 @@ import {
   getApiKeysWithEnvironmentPermissions,
   updateApiKey,
 } from "./api-key";
+import { getWorkspacesByOrganizationId } from "./workspaces";
 
 const mockApiKey: ApiKey = {
   id: "apikey123",
@@ -50,6 +51,10 @@ vi.mock("@formbricks/database", () => ({
       update: vi.fn(),
     },
   },
+}));
+
+vi.mock("./workspaces", () => ({
+  getWorkspacesByOrganizationId: vi.fn(),
 }));
 
 vi.mock("crypto", async () => {
@@ -344,7 +349,7 @@ describe("API Key Management", () => {
           apiKeyWorkspaces: {
             include: {
               workspace: {
-                select: { id: true, name: true },
+                select: { id: true, name: true, organizationId: true },
               },
             },
           },
@@ -366,7 +371,7 @@ describe("API Key Management", () => {
           apiKeyWorkspaces: {
             include: {
               workspace: {
-                select: { id: true, name: true },
+                select: { id: true, name: true, organizationId: true },
               },
             },
           },
@@ -452,6 +457,9 @@ describe("API Key Management", () => {
     });
 
     test("creates an API key with environment permissions successfully", async () => {
+      vi.mocked(getWorkspacesByOrganizationId).mockResolvedValueOnce([
+        { id: "workspace123", name: "Workspace 123" },
+      ]);
       vi.mocked(prisma.apiKey.create).mockResolvedValueOnce(mockApiKeyWithEnvironments);
 
       const result = await createApiKey("org123", "user123", {
@@ -461,6 +469,23 @@ describe("API Key Management", () => {
 
       expect(result).toEqual({ ...mockApiKeyWithEnvironments, actualKey: "fbk_testSecret123" });
       expect(prisma.apiKey.create).toHaveBeenCalled();
+    });
+
+    test("rejects a workspace permission for a workspace outside the organization (ENG-1749)", async () => {
+      // The organization owns only "own-workspace"; the caller attempts to scope the key to a
+      // victim organization's workspace. This must be refused before any key is persisted.
+      vi.mocked(getWorkspacesByOrganizationId).mockResolvedValueOnce([
+        { id: "own-workspace", name: "Own Workspace" },
+      ]);
+
+      await expect(
+        createApiKey("org123", "user123", {
+          ...mockApiKeyData,
+          workspacePermissions: [{ workspaceId: "victim-workspace", permission: ApiKeyPermission.manage }],
+        })
+      ).rejects.toThrow(OperationNotAllowedError);
+      expect(getWorkspacesByOrganizationId).toHaveBeenCalledWith("org123");
+      expect(prisma.apiKey.create).not.toHaveBeenCalled();
     });
 
     test("rejects create input with duplicate workspaceId", async () => {

--- a/apps/web/modules/organization/settings/api-keys/types/api-keys.ts
+++ b/apps/web/modules/organization/settings/api-keys/types/api-keys.ts
@@ -59,7 +59,7 @@ const ZApiKeyWorkspaceWithWorkspace = z.object({
   apiKeyId: z.string(),
   workspaceId: z.string(),
   permission: ZApiKeyPermission,
-  workspace: ZWorkspace.pick({ id: true, name: true }),
+  workspace: ZWorkspace.pick({ id: true, name: true, organizationId: true }),
 });
 
 const ZApiKey = z.object({

--- a/apps/web/modules/survey/editor/components/logo-settings-card.tsx
+++ b/apps/web/modules/survey/editor/components/logo-settings-card.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { TSurveyStyling } from "@formbricks/types/surveys/types";
 import { TWorkspaceStyling } from "@formbricks/types/workspace";
 import { cn } from "@/lib/cn";
+import { isExternalImageSrc } from "@/lib/image-hosts";
 import { handleFileUpload } from "@/modules/storage/file-upload";
 import { showFileUploadErrorToast } from "@/modules/storage/file-upload-error";
 import { AdvancedOptionToggle } from "@/modules/ui/components/advanced-option-toggle";
@@ -189,6 +190,7 @@ export const LogoSettingsCard = ({
                       height={56}
                       style={{ backgroundColor: logoBgColor || undefined }}
                       className="h-20 w-auto max-w-64 rounded-lg border object-contain p-1"
+                      unoptimized={isExternalImageSrc(logoUrl)}
                     />
                   </div>
 

--- a/apps/web/modules/survey/editor/components/option-ids.tsx
+++ b/apps/web/modules/survey/editor/components/option-ids.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurveyVariable } from "@formbricks/types/surveys/types";
 import { getLocalizedValue } from "@/lib/i18n/utils";
+import { isExternalImageSrc } from "@/lib/image-hosts";
 import { IdBadge } from "@/modules/ui/components/id-badge";
 import { Label } from "@/modules/ui/components/label";
 
@@ -54,6 +55,7 @@ export const OptionIds = (props: OptionIdsProps) => {
                       style={{ objectFit: "cover" }}
                       quality={75}
                       className="rounded-lg transition-opacity duration-200"
+                      unoptimized={isExternalImageSrc(imageUrl)}
                     />
                   </div>
                   <IdBadge id={choice.id} />

--- a/apps/web/modules/survey/editor/components/response-options-card.tsx
+++ b/apps/web/modules/survey/editor/components/response-options-card.tsx
@@ -2,19 +2,18 @@
 
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { CheckIcon } from "lucide-react";
-import { KeyboardEventHandler, useEffect, useState } from "react";
+import { KeyboardEventHandler, useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import { Trans, useTranslation } from "react-i18next";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
 import { cn } from "@/lib/cn";
 import {
-  SURVEY_SCHEDULING_TIME_LABEL,
-  SURVEY_SCHEDULING_TIME_ZONE_LABEL,
-} from "@/modules/survey/scheduling/lib/constants";
+  type TSurveySchedulingConfig,
+  getSurveySchedulingTimeLabel,
+} from "@/modules/survey/scheduling/lib/config";
 import {
-  getMinimumSurveySchedulingCalendarDate,
-  toCalendarDate,
+  createSurveySchedulingDateUtils,
   toDateOnlySelection,
 } from "@/modules/survey/scheduling/lib/date-utils";
 import { AdvancedOptionToggle } from "@/modules/ui/components/advanced-option-toggle";
@@ -29,6 +28,7 @@ interface ResponseOptionsCardProps {
   setLocalSurvey: (survey: TSurvey | ((prev: TSurvey) => TSurvey)) => void;
   responseCount: number;
   isSpamProtectionAllowed: boolean;
+  surveySchedulingConfig: TSurveySchedulingConfig;
   locale: TUserLocale;
 }
 
@@ -37,9 +37,16 @@ export const ResponseOptionsCard = ({
   setLocalSurvey,
   responseCount,
   isSpamProtectionAllowed,
+  surveySchedulingConfig,
   locale,
-}: ResponseOptionsCardProps) => {
+}: Readonly<ResponseOptionsCardProps>) => {
   const { t } = useTranslation();
+  const { toCalendarDate, getMinimumSurveySchedulingCalendarDate } = useMemo(
+    () => createSurveySchedulingDateUtils(surveySchedulingConfig),
+    [surveySchedulingConfig]
+  );
+  const surveySchedulingTimeLabel = getSurveySchedulingTimeLabel(surveySchedulingConfig);
+  const surveySchedulingTimeZoneLabel = surveySchedulingConfig.timeZone;
   const [open, setOpen] = useState(localSurvey.type === "link");
   const autoComplete = localSurvey.autoComplete !== null;
   const [surveyClosedMessageToggle, setSurveyClosedMessageToggle] = useState(false);
@@ -193,7 +200,7 @@ export const ResponseOptionsCard = ({
         closeOn: null,
       };
     });
-  }, [closeOn, publishOn, setLocalSurvey]);
+  }, [closeOn, publishOn, setLocalSurvey, toCalendarDate]);
 
   const togglePublishOnDate = () => {
     if (isPublishOnDateEnabled) {
@@ -331,8 +338,8 @@ export const ResponseOptionsCard = ({
             onToggle={togglePublishOnDate}
             title={t("workspace.surveys.edit.publish_survey_on_date")}
             description={t("workspace.surveys.edit.survey_will_be_published_at_midnight_cet", {
-              time: SURVEY_SCHEDULING_TIME_LABEL,
-              timeZone: SURVEY_SCHEDULING_TIME_ZONE_LABEL,
+              time: surveySchedulingTimeLabel,
+              timeZone: surveySchedulingTimeZoneLabel,
             })}
             childBorder={true}>
             <div className="p-4">
@@ -371,8 +378,8 @@ export const ResponseOptionsCard = ({
             onToggle={toggleCloseOnDate}
             title={t("workspace.surveys.edit.close_survey_on_date")}
             description={t("workspace.surveys.edit.survey_will_be_closed_at_midnight_cet", {
-              time: SURVEY_SCHEDULING_TIME_LABEL,
-              timeZone: SURVEY_SCHEDULING_TIME_ZONE_LABEL,
+              time: surveySchedulingTimeLabel,
+              timeZone: surveySchedulingTimeZoneLabel,
             })}
             childBorder={true}>
             <div className="p-4">

--- a/apps/web/modules/survey/editor/components/settings-view.tsx
+++ b/apps/web/modules/survey/editor/components/settings-view.tsx
@@ -14,6 +14,7 @@ import { ResponseOptionsCard } from "@/modules/survey/editor/components/response
 import { SurveyPlacementCard } from "@/modules/survey/editor/components/survey-placement-card";
 import { TargetingLockedCard } from "@/modules/survey/editor/components/targeting-locked-card";
 import { WhenToSendCard } from "@/modules/survey/editor/components/when-to-send-card";
+import { type TSurveySchedulingConfig } from "@/modules/survey/scheduling/lib/config";
 
 interface SettingsViewProps {
   localSurvey: TSurvey;
@@ -29,6 +30,7 @@ interface SettingsViewProps {
   isFormbricksCloud: boolean;
   isQuotasAllowed: boolean;
   quotas: TSurveyQuota[];
+  surveySchedulingConfig: TSurveySchedulingConfig;
   locale: TUserLocale;
   appSetupCompleted: boolean;
   enterpriseLicenseRequestFormUrl: string;
@@ -48,6 +50,7 @@ export const SettingsView = ({
   workspacePermission,
   isFormbricksCloud,
   quotas,
+  surveySchedulingConfig,
   locale,
   appSetupCompleted,
   enterpriseLicenseRequestFormUrl,
@@ -108,6 +111,7 @@ export const SettingsView = ({
         setLocalSurvey={setLocalSurvey}
         responseCount={responseCount}
         isSpamProtectionAllowed={isSpamProtectionAllowed}
+        surveySchedulingConfig={surveySchedulingConfig}
         locale={locale}
       />
 

--- a/apps/web/modules/survey/editor/components/survey-editor.tsx
+++ b/apps/web/modules/survey/editor/components/survey-editor.tsx
@@ -21,6 +21,7 @@ import { SurveyMenuBar } from "@/modules/survey/editor/components/survey-menu-ba
 import { TFollowUpEmailToUser } from "@/modules/survey/editor/types/survey-follow-up";
 import { FollowUpsView } from "@/modules/survey/follow-ups/components/follow-ups-view";
 import { LanguageView } from "@/modules/survey/multi-language-surveys/components/language-view";
+import { type TSurveySchedulingConfig } from "@/modules/survey/scheduling/lib/config";
 import { PreviewSurvey } from "@/modules/ui/components/preview-survey";
 import { getWorkspaceLanguagesAction, refetchWorkspaceAction } from "../actions";
 
@@ -39,6 +40,7 @@ interface SurveyEditorProps {
   isUnsplashConfigured: boolean;
   isQuotasAllowed: boolean;
   isCxMode: boolean;
+  surveySchedulingConfig: TSurveySchedulingConfig;
   locale: TUserLocale;
   workspacePermission: TTeamPermission | null;
   mailFrom: string;
@@ -69,6 +71,7 @@ export const SurveyEditor = ({
   isUnsplashConfigured,
   isQuotasAllowed,
   isCxMode = false,
+  surveySchedulingConfig,
   locale,
   workspacePermission,
   mailFrom,
@@ -266,6 +269,7 @@ export const SurveyEditor = ({
               isFormbricksCloud={isFormbricksCloud}
               isQuotasAllowed={isQuotasAllowed}
               quotas={quotas}
+              surveySchedulingConfig={surveySchedulingConfig}
               locale={locale}
               appSetupCompleted={localWorkspace.appSetupCompleted}
               enterpriseLicenseRequestFormUrl={enterpriseLicenseRequestFormUrl}

--- a/apps/web/modules/survey/editor/components/unsplash-images.tsx
+++ b/apps/web/modules/survey/editor/components/unsplash-images.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { TSurveyBackgroundBgType } from "@formbricks/types/surveys/types";
+import { isExternalImageSrc } from "@/lib/image-hosts";
 import { debounce } from "@/lib/utils/debounce";
 import { Button } from "@/modules/ui/components/button";
 import { Input } from "@/modules/ui/components/input";
@@ -213,6 +214,7 @@ export const ImageFromUnsplashSurveyBg = ({ handleBgChange }: ImageFromUnsplashS
                 alt={image.alt_description}
                 onClick={() => handleImageSelected(image.urls.regularWithAttribution, image.urls.download)}
                 className="h-full cursor-pointer rounded-lg object-cover"
+                unoptimized={isExternalImageSrc(image.urls.regularWithAttribution)}
               />
               {image.authorName && (
                 <span className="absolute right-1 bottom-1 hidden rounded-sm bg-black/75 px-2 py-1 text-xs text-white group-hover:block">

--- a/apps/web/modules/survey/editor/page.tsx
+++ b/apps/web/modules/survey/editor/page.tsx
@@ -27,6 +27,7 @@ import { getExternalUrlsPermission } from "@/modules/survey/lib/permission";
 import { getResponseCountBySurveyId } from "@/modules/survey/lib/response";
 import { getOrganizationBilling, getSurvey } from "@/modules/survey/lib/survey";
 import { getWorkspaceWithTeamIds } from "@/modules/survey/lib/workspace";
+import { SURVEY_SCHEDULING_CONFIG } from "@/modules/survey/scheduling/lib/constants";
 import { ErrorComponent } from "@/modules/ui/components/error-component";
 import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
 import { SurveyEditor } from "./components/survey-editor";
@@ -128,6 +129,7 @@ export const SurveyEditorPage = async (props: {
       isFormbricksCloud={IS_FORMBRICKS_CLOUD}
       isUnsplashConfigured={!!UNSPLASH_ACCESS_KEY}
       isCxMode={isCxMode}
+      surveySchedulingConfig={SURVEY_SCHEDULING_CONFIG}
       locale={locale ?? DEFAULT_LOCALE}
       mailFrom={MAIL_FROM ?? "hola@formbricks.com"}
       isSurveyFollowUpsAllowed={isSurveyFollowUpsAllowed}

--- a/apps/web/modules/survey/link/actions.ts
+++ b/apps/web/modules/survey/link/actions.ts
@@ -10,6 +10,7 @@ import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { getOrganizationLogoUrl } from "@/modules/ee/whitelabel/email-customization/lib/organization";
 import { sendLinkSurveyToVerifiedEmail } from "@/modules/email";
 import { getSurveyWithMetadata, isSurveyResponsePresent } from "@/modules/survey/link/lib/data";
+import { createLinkSurveyPinToken } from "@/modules/survey/link/lib/pin-token";
 
 export const sendLinkSurveyEmailAction = actionClient
   .inputSchema(ZLinkSurveyEmailData)
@@ -53,7 +54,7 @@ export const validateSurveyPinAction = actionClient
       throw new InvalidInputError("INVALID_PIN");
     }
 
-    return { survey };
+    return { survey, pinAuthToken: createLinkSurveyPinToken(survey.id) };
   });
 
 const ZIsSurveyResponsePresentAction = z.object({

--- a/apps/web/modules/survey/link/components/pin-screen.tsx
+++ b/apps/web/modules/survey/link/components/pin-screen.tsx
@@ -62,6 +62,7 @@ export const PinScreen = (props: PinScreenProps) => {
   const { t } = useTranslation();
   const [error, setError] = useState("");
   const [survey, setSurvey] = useState<TSurvey>();
+  const [pinAuthToken, setPinAuthToken] = useState<string | undefined>();
   const isCardless = styling.cardArrangement?.linkSurveys === "cardless";
   const linkSurveyCardMaxWidth = getLinkSurveyCardMaxWidth(styling.linkSurveyCardWidth);
 
@@ -91,6 +92,7 @@ export const PinScreen = (props: PinScreenProps) => {
         const response = await validateSurveyPinAction({ surveyId, pin: localPinEntry });
         if (response?.data?.survey) {
           setSurvey(response.data.survey);
+          setPinAuthToken(response.data.pinAuthToken ?? undefined);
         } else {
           const errorMessage = getFormattedErrorMessage(response);
           setError(errorMessage);
@@ -149,6 +151,7 @@ export const PinScreen = (props: PinScreenProps) => {
       PRIVACY_URL={PRIVACY_URL}
       TERMS_URL={TERMS_URL}
       IS_FORMBRICKS_CLOUD={IS_FORMBRICKS_CLOUD}
+      pinAuthToken={pinAuthToken}
     />
   );
 };

--- a/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
+++ b/apps/web/modules/survey/link/components/survey-client-wrapper.tsx
@@ -37,6 +37,7 @@ interface SurveyClientWrapperProps {
   PRIVACY_URL?: string;
   TERMS_URL?: string;
   IS_FORMBRICKS_CLOUD: boolean;
+  pinAuthToken?: string;
 }
 
 let setBlockId = (_: string) => {};
@@ -62,6 +63,7 @@ export const SurveyClientWrapper = ({
   PRIVACY_URL,
   TERMS_URL,
   IS_FORMBRICKS_CLOUD,
+  pinAuthToken,
 }: SurveyClientWrapperProps) => {
   const searchParams = useSearchParams();
   const { i18n } = useTranslation();
@@ -244,6 +246,7 @@ export const SurveyClientWrapper = ({
           }}
           singleUseId={singleUseId}
           singleUseResponseId={singleUseResponseId}
+          pinAuthToken={pinAuthToken}
           getSetIsResponseSendingFinished={(_f: (value: boolean) => void) => {}}
           contactId={contactId}
           userId={userId}

--- a/apps/web/modules/survey/link/lib/pin-token.test.ts
+++ b/apps/web/modules/survey/link/lib/pin-token.test.ts
@@ -1,0 +1,102 @@
+import jwt from "jsonwebtoken";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: { warn: vi.fn() },
+}));
+
+const TEST_SECRET = "test-secret-at-least-32-chars-long!!";
+
+vi.mock("@/lib/constants", () => ({
+  BETTER_AUTH_SECRET: undefined,
+  NEXTAUTH_SECRET: TEST_SECRET,
+}));
+
+// Import after mocks are set up
+const { createLinkSurveyPinToken, verifyLinkSurveyPinToken } = await import("./pin-token");
+
+const SURVEY_ID = "clxsurvey0000abcdef123456";
+
+describe("createLinkSurveyPinToken", () => {
+  test("returns a signed JWT string", () => {
+    const token = createLinkSurveyPinToken(SURVEY_ID);
+    expect(typeof token).toBe("string");
+    expect(token.split(".")).toHaveLength(3);
+  });
+});
+
+describe("verifyLinkSurveyPinToken", () => {
+  test("valid token for correct surveyId returns true", () => {
+    const token = createLinkSurveyPinToken(SURVEY_ID);
+    expect(verifyLinkSurveyPinToken(token, SURVEY_ID)).toBe(true);
+  });
+
+  test("valid token with wrong surveyId returns false", () => {
+    const token = createLinkSurveyPinToken(SURVEY_ID);
+    expect(verifyLinkSurveyPinToken(token, "clxsurveyXXXXabcdef000000")).toBe(false);
+  });
+
+  test("tampered token returns false", () => {
+    const token = createLinkSurveyPinToken(SURVEY_ID);
+    const parts = token.split(".");
+    // Flip a character in the signature
+    const tampered = `${parts[0]}.${parts[1]}.${parts[2].slice(0, -1)}X`;
+    expect(verifyLinkSurveyPinToken(tampered, SURVEY_ID)).toBe(false);
+  });
+
+  test("null token returns false", () => {
+    expect(verifyLinkSurveyPinToken(null, SURVEY_ID)).toBe(false);
+  });
+
+  test("undefined token returns false", () => {
+    expect(verifyLinkSurveyPinToken(undefined, SURVEY_ID)).toBe(false);
+  });
+
+  test("token signed with a different purpose returns false", () => {
+    const wrongPurposeToken = jwt.sign({ surveyId: SURVEY_ID, purpose: "some_other_purpose" }, TEST_SECRET, {
+      algorithm: "HS256",
+    });
+    expect(verifyLinkSurveyPinToken(wrongPurposeToken, SURVEY_ID)).toBe(false);
+  });
+
+  test("expired token returns false", () => {
+    const expiredToken = jwt.sign({ surveyId: SURVEY_ID, purpose: "link_survey_pin" }, TEST_SECRET, {
+      algorithm: "HS256",
+      expiresIn: -1,
+    });
+    expect(verifyLinkSurveyPinToken(expiredToken, SURVEY_ID)).toBe(false);
+  });
+});
+
+describe("secret resolution", () => {
+  test("prefers BETTER_AUTH_SECRET over NEXTAUTH_SECRET", async () => {
+    vi.resetModules();
+    const betterAuthSecret = "better-auth-secret-at-least-32-chars!!";
+    vi.doMock("@/lib/constants", () => ({
+      BETTER_AUTH_SECRET: betterAuthSecret,
+      NEXTAUTH_SECRET: TEST_SECRET,
+    }));
+    const mod = await import("./pin-token");
+
+    const token = mod.createLinkSurveyPinToken(SURVEY_ID);
+    // Verifies against BETTER_AUTH_SECRET, not the NextAuth fallback.
+    expect(() => jwt.verify(token, betterAuthSecret)).not.toThrow();
+    expect(() => jwt.verify(token, TEST_SECRET)).toThrow();
+    expect(mod.verifyLinkSurveyPinToken(token, SURVEY_ID)).toBe(true);
+  });
+
+  test("falls back to NEXTAUTH_SECRET when BETTER_AUTH_SECRET is unset", async () => {
+    vi.resetModules();
+    vi.doMock("@/lib/constants", () => ({
+      BETTER_AUTH_SECRET: undefined,
+      NEXTAUTH_SECRET: TEST_SECRET,
+    }));
+    const mod = await import("./pin-token");
+
+    const token = mod.createLinkSurveyPinToken(SURVEY_ID);
+    expect(() => jwt.verify(token, TEST_SECRET)).not.toThrow();
+    expect(mod.verifyLinkSurveyPinToken(token, SURVEY_ID)).toBe(true);
+  });
+});

--- a/apps/web/modules/survey/link/lib/pin-token.ts
+++ b/apps/web/modules/survey/link/lib/pin-token.ts
@@ -1,0 +1,46 @@
+import "server-only";
+import jwt from "jsonwebtoken";
+import { logger } from "@formbricks/logger";
+import { BETTER_AUTH_SECRET, NEXTAUTH_SECRET } from "@/lib/constants";
+
+const PIN_TOKEN_PURPOSE = "link_survey_pin";
+const PIN_TOKEN_TTL_SECONDS = 60 * 60; // 1 hour
+
+// Mirror the auth session secret resolution (auth.ts / session-cookie.ts): prefer
+// BETTER_AUTH_SECRET, fall back to NEXTAUTH_SECRET. A better-auth-only deployment sets only
+// BETTER_AUTH_SECRET, so keying PIN tokens off NEXTAUTH_SECRET alone would throw and break PIN
+// enforcement even though auth itself works.
+//
+// Resolved lazily inside the functions rather than at module scope: reading the constants at
+// import time makes every unrelated test that mocks "@/lib/constants" (and transitively imports
+// this module) fail Vitest's strict missing-export check. Deferring the access keeps import
+// side-effect-free, matching the pre-existing pattern.
+const resolvePinTokenSecret = (): string | undefined => BETTER_AUTH_SECRET ?? NEXTAUTH_SECRET;
+
+export const createLinkSurveyPinToken = (surveyId: string): string => {
+  const secret = resolvePinTokenSecret();
+  if (!secret) {
+    throw new Error("No auth secret set (BETTER_AUTH_SECRET or NEXTAUTH_SECRET)");
+  }
+  return jwt.sign({ surveyId, purpose: PIN_TOKEN_PURPOSE }, secret, {
+    algorithm: "HS256",
+    expiresIn: PIN_TOKEN_TTL_SECONDS,
+  });
+};
+
+export const verifyLinkSurveyPinToken = (token: string | null | undefined, surveyId: string): boolean => {
+  const secret = resolvePinTokenSecret();
+  if (!token || !secret) {
+    return false;
+  }
+  try {
+    const payload = jwt.verify(token, secret, { algorithms: ["HS256"] }) as jwt.JwtPayload & {
+      surveyId?: string;
+      purpose?: string;
+    };
+    return payload.purpose === PIN_TOKEN_PURPOSE && payload.surveyId === surveyId;
+  } catch (error) {
+    logger.warn({ error, surveyId }, "Invalid link survey PIN token");
+    return false;
+  }
+};

--- a/apps/web/modules/survey/scheduling/lib/config.ts
+++ b/apps/web/modules/survey/scheduling/lib/config.ts
@@ -1,0 +1,10 @@
+export interface TSurveySchedulingConfig {
+  timeZone: string;
+  localHour: number;
+  localMinute: number;
+}
+
+const padSchedulingTimePart = (value: number): string => value.toString().padStart(2, "0");
+
+export const getSurveySchedulingTimeLabel = (config: TSurveySchedulingConfig): string =>
+  `${padSchedulingTimePart(config.localHour)}:${padSchedulingTimePart(config.localMinute)}`;

--- a/apps/web/modules/survey/scheduling/lib/constants.test.ts
+++ b/apps/web/modules/survey/scheduling/lib/constants.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const ORIGINAL_ENV = process.env;
+
+const setSchedulingEnv = (overrides: Record<string, string | undefined> = {}) => {
+  process.env = {
+    ...ORIGINAL_ENV,
+    SURVEY_SCHEDULING_TIME_ZONE: undefined,
+    SURVEY_SCHEDULING_LOCAL_HOUR: undefined,
+    SURVEY_SCHEDULING_LOCAL_MINUTE: undefined,
+    ...overrides,
+  };
+};
+
+describe("survey scheduling constants", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  test("defaults to Europe/Berlin at midnight when env vars are unset", async () => {
+    setSchedulingEnv();
+
+    const constants = await import("./constants");
+
+    expect(constants.SURVEY_SCHEDULING_CONFIG).toEqual({
+      timeZone: "Europe/Berlin",
+      localHour: 0,
+      localMinute: 0,
+    });
+    expect(constants.SURVEY_SCHEDULING_TIME_LABEL).toBe("00:00");
+    expect(constants.SURVEY_SCHEDULING_DAILY_CRON_PATTERN).toBe("0 0 * * *");
+  });
+
+  test("reads a valid runtime configuration from server-side env vars", async () => {
+    setSchedulingEnv({
+      SURVEY_SCHEDULING_TIME_ZONE: "America/New_York",
+      SURVEY_SCHEDULING_LOCAL_HOUR: "18",
+      SURVEY_SCHEDULING_LOCAL_MINUTE: "45",
+    });
+
+    const constants = await import("./constants");
+
+    expect(constants.SURVEY_SCHEDULING_CONFIG).toEqual({
+      timeZone: "America/New_York",
+      localHour: 18,
+      localMinute: 45,
+    });
+    expect(constants.SURVEY_SCHEDULING_TIME_LABEL).toBe("18:45");
+    expect(constants.SURVEY_SCHEDULING_DAILY_CRON_PATTERN).toBe("45 18 * * *");
+  });
+});

--- a/apps/web/modules/survey/scheduling/lib/constants.ts
+++ b/apps/web/modules/survey/scheduling/lib/constants.ts
@@ -1,37 +1,23 @@
-const padSchedulingTimePart = (value: number): string => value.toString().padStart(2, "0");
+import { env } from "@/lib/env";
+import { type TSurveySchedulingConfig, getSurveySchedulingTimeLabel } from "./config";
 
-const parseSchedulingTimePart = (
-  value: string | undefined,
-  fallback: number,
-  { min, max }: { min: number; max: number }
-): number => {
-  if (!value) {
-    return fallback;
-  }
+// Read at runtime from server-only env vars (no NEXT_PUBLIC_ prefix) so self-hosted Docker
+// deployments can configure the scheduling execution time without rebuilding the image. Values
+// are validated and normalized in apps/web/lib/env.ts (single source of truth): the time zone is
+// checked against Intl.DateTimeFormat and hour/minute are coerced to their valid ranges, so a bad
+// override is rejected there instead of silently reaching Intl.DateTimeFormat here. The editor UI
+// receives these values as props instead of importing this module on the client.
+export const SURVEY_SCHEDULING_TIME_ZONE = env.SURVEY_SCHEDULING_TIME_ZONE;
+export const SURVEY_SCHEDULING_LOCAL_HOUR = env.SURVEY_SCHEDULING_LOCAL_HOUR;
+export const SURVEY_SCHEDULING_LOCAL_MINUTE = env.SURVEY_SCHEDULING_LOCAL_MINUTE;
 
-  const parsedValue = Number.parseInt(value, 10);
-
-  if (!Number.isInteger(parsedValue) || parsedValue < min || parsedValue > max) {
-    return fallback;
-  }
-
-  return parsedValue;
+export const SURVEY_SCHEDULING_CONFIG: TSurveySchedulingConfig = {
+  timeZone: SURVEY_SCHEDULING_TIME_ZONE,
+  localHour: SURVEY_SCHEDULING_LOCAL_HOUR,
+  localMinute: SURVEY_SCHEDULING_LOCAL_MINUTE,
 };
 
-// Use static NEXT_PUBLIC_* lookups so these values can be safely inlined into client bundles.
-export const SURVEY_SCHEDULING_TIME_ZONE =
-  process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE ?? "Europe/Berlin";
-export const SURVEY_SCHEDULING_LOCAL_HOUR = parseSchedulingTimePart(
-  process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR,
-  0,
-  { min: 0, max: 23 }
-);
-export const SURVEY_SCHEDULING_LOCAL_MINUTE = parseSchedulingTimePart(
-  process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE,
-  0,
-  { min: 0, max: 59 }
-);
-export const SURVEY_SCHEDULING_TIME_LABEL = `${padSchedulingTimePart(SURVEY_SCHEDULING_LOCAL_HOUR)}:${padSchedulingTimePart(SURVEY_SCHEDULING_LOCAL_MINUTE)}`;
+export const SURVEY_SCHEDULING_TIME_LABEL = getSurveySchedulingTimeLabel(SURVEY_SCHEDULING_CONFIG);
 export const SURVEY_SCHEDULING_TIME_ZONE_LABEL = SURVEY_SCHEDULING_TIME_ZONE;
 export const SURVEY_SCHEDULING_DAILY_CRON_PATTERN = `${SURVEY_SCHEDULING_LOCAL_MINUTE} ${SURVEY_SCHEDULING_LOCAL_HOUR} * * *`;
 export const SURVEY_SCHEDULING_GLOBAL_SCOPE = "global";

--- a/apps/web/modules/survey/scheduling/lib/date-utils.test.ts
+++ b/apps/web/modules/survey/scheduling/lib/date-utils.test.ts
@@ -4,12 +4,19 @@ import {
   SURVEY_SCHEDULING_LOCAL_MINUTE,
   SURVEY_SCHEDULING_TIME_ZONE,
 } from "./constants";
-import {
+import { createSurveySchedulingDateUtils, toDateOnlySelection } from "./date-utils";
+
+const defaultConfig = {
+  timeZone: "Europe/Berlin",
+  localHour: 0,
+  localMinute: 0,
+};
+
+const {
+  toCalendarDate,
   getMinimumSurveySchedulingCalendarDate,
   normalizeDateOnlySelectionToSurveySchedulingDateTime,
-  toCalendarDate,
-  toDateOnlySelection,
-} from "./date-utils";
+} = createSurveySchedulingDateUtils(defaultConfig);
 
 describe("survey scheduling date utils", () => {
   test("stores selected dates as noon UTC date-only values", () => {
@@ -66,6 +73,19 @@ describe("survey scheduling date utils", () => {
     expect(minSelectableDate.getMonth()).toBe(3);
     expect(minSelectableDate.getDate()).toBe(17);
     expect(minSelectableDate.getHours()).toBe(12);
+  });
+
+  test("honors a runtime-configured timezone, hour, and minute", () => {
+    const { normalizeDateOnlySelectionToSurveySchedulingDateTime: normalize } =
+      createSurveySchedulingDateUtils({
+        timeZone: "America/New_York",
+        localHour: 18,
+        localMinute: 45,
+      });
+    const storedDate = new Date("2026-01-17T12:00:00.000Z");
+
+    // 2026-01-17 18:45 in America/New_York (EST, UTC-5) is 23:45 UTC.
+    expect(normalize(storedDate)?.toISOString()).toBe("2026-01-17T23:45:00.000Z");
   });
 
   test("documents the default scheduling configuration", () => {

--- a/apps/web/modules/survey/scheduling/lib/date-utils.ts
+++ b/apps/web/modules/survey/scheduling/lib/date-utils.ts
@@ -1,8 +1,4 @@
-import {
-  SURVEY_SCHEDULING_LOCAL_HOUR,
-  SURVEY_SCHEDULING_LOCAL_MINUTE,
-  SURVEY_SCHEDULING_TIME_ZONE,
-} from "./constants";
+import type { TSurveySchedulingConfig } from "./config";
 
 const DATE_ONLY_SELECTION_UTC_HOUR = 12;
 const LOCAL_CALENDAR_NOON_HOUR = 12;
@@ -15,103 +11,6 @@ interface TimeZoneDateParts {
   year: number;
 }
 
-const timeZoneFormatter = new Intl.DateTimeFormat("en-CA", {
-  day: "2-digit",
-  hour: "2-digit",
-  hourCycle: "h23",
-  minute: "2-digit",
-  month: "2-digit",
-  second: "2-digit",
-  timeZone: SURVEY_SCHEDULING_TIME_ZONE,
-  year: "numeric",
-});
-
-const timeZoneOffsetFormatter = new Intl.DateTimeFormat("en-US", {
-  hour: "2-digit",
-  hourCycle: "h23",
-  minute: "2-digit",
-  timeZone: SURVEY_SCHEDULING_TIME_ZONE,
-  timeZoneName: "shortOffset",
-});
-
-const getTimeZoneDateParts = (date: Date): TimeZoneDateParts => {
-  const parts = timeZoneFormatter.formatToParts(date);
-  const getPartValue = (type: Intl.DateTimeFormatPartTypes): number => {
-    const value = parts.find((part) => part.type === type)?.value;
-
-    if (!value) {
-      throw new Error(`Missing ${type} in survey scheduling date formatter output`);
-    }
-
-    return Number.parseInt(value, 10);
-  };
-
-  return {
-    day: getPartValue("day"),
-    hour: getPartValue("hour"),
-    minute: getPartValue("minute"),
-    month: getPartValue("month"),
-    year: getPartValue("year"),
-  };
-};
-
-const getTimeZoneOffsetMs = (date: Date): number => {
-  const offsetValue = timeZoneOffsetFormatter
-    .formatToParts(date)
-    .find((part) => part.type === "timeZoneName")?.value;
-
-  if (!offsetValue || offsetValue === "GMT") {
-    return 0;
-  }
-
-  const match = /^GMT(?<sign>[+-])(?<hours>\d{1,2})(?::(?<minutes>\d{2}))?$/.exec(offsetValue);
-
-  if (!match?.groups) {
-    throw new Error(`Unsupported survey scheduling timezone offset: ${offsetValue}`);
-  }
-
-  const sign = match.groups.sign === "+" ? 1 : -1;
-  const hours = Number.parseInt(match.groups.hours, 10);
-  const minutes = Number.parseInt(match.groups.minutes ?? "0", 10);
-
-  return sign * ((hours * 60 + minutes) * 60 * 1000);
-};
-
-const matchesSurveySchedulingLocalTime = (date: Date, year: number, month: number, day: number): boolean => {
-  const parts = getTimeZoneDateParts(date);
-
-  return (
-    parts.year === year &&
-    parts.month === month + 1 &&
-    parts.day === day &&
-    parts.hour === SURVEY_SCHEDULING_LOCAL_HOUR &&
-    parts.minute === SURVEY_SCHEDULING_LOCAL_MINUTE
-  );
-};
-
-const createSurveySchedulingDateTime = (year: number, month: number, day: number): Date => {
-  const utcGuessMs = Date.UTC(
-    year,
-    month,
-    day,
-    SURVEY_SCHEDULING_LOCAL_HOUR,
-    SURVEY_SCHEDULING_LOCAL_MINUTE,
-    0,
-    0
-  );
-  let candidate = new Date(utcGuessMs);
-
-  for (let attempt = 0; attempt < 3; attempt++) {
-    candidate = new Date(utcGuessMs - getTimeZoneOffsetMs(candidate));
-
-    if (matchesSurveySchedulingLocalTime(candidate, year, month, day)) {
-      return candidate;
-    }
-  }
-
-  return candidate;
-};
-
 const createLocalCalendarDate = ({
   day,
   month,
@@ -119,42 +18,153 @@ const createLocalCalendarDate = ({
 }: Pick<TimeZoneDateParts, "day" | "month" | "year">): Date =>
   new Date(year, month - 1, day, LOCAL_CALENDAR_NOON_HOUR, 0, 0, 0);
 
+// Config-independent helpers. `toDateOnlySelection` stores the picked day as noon UTC and
+// `isDateDue` compares absolute instants, so neither depends on the scheduling time zone.
 export const toDateOnlySelection = (date: Date): Date =>
   new Date(
     Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), DATE_ONLY_SELECTION_UTC_HOUR, 0, 0, 0)
   );
 
-export const toCalendarDate = (date: Date): Date => {
-  return createLocalCalendarDate(getTimeZoneDateParts(date));
-};
-
-export const getMinimumSurveySchedulingCalendarDate = (now: Date = new Date()): Date => {
-  const currentSchedulingDateParts = getTimeZoneDateParts(now);
-  const minimumSchedulingDate = createLocalCalendarDate(currentSchedulingDateParts);
-  const currentSchedulingRunAt = createSurveySchedulingDateTime(
-    currentSchedulingDateParts.year,
-    currentSchedulingDateParts.month - 1,
-    currentSchedulingDateParts.day
-  );
-
-  if (now.getTime() < currentSchedulingRunAt.getTime()) {
-    return minimumSchedulingDate;
-  }
-
-  const nextSchedulingDate = new Date(minimumSchedulingDate);
-  nextSchedulingDate.setDate(nextSchedulingDate.getDate() + 1);
-  return nextSchedulingDate;
-};
-
-export const normalizeDateOnlySelectionToSurveySchedulingDateTime = (date: Date | null): Date | null => {
-  if (!date) {
-    return null;
-  }
-
-  const { day, month, year } = getTimeZoneDateParts(date);
-
-  return createSurveySchedulingDateTime(year, month - 1, day);
-};
-
 export const isDateDue = (date: Date | null, now: Date = new Date()): boolean =>
   date !== null && date.getTime() <= now.getTime();
+
+/**
+ * Builds the timezone-aware scheduling date helpers for a given configuration. The config is
+ * sourced from server-only env vars and passed in explicitly so the same logic can run on the
+ * server (reconciliation) and on the client (survey editor) with runtime-configured values.
+ */
+export const createSurveySchedulingDateUtils = (config: TSurveySchedulingConfig) => {
+  const timeZoneFormatter = new Intl.DateTimeFormat("en-CA", {
+    day: "2-digit",
+    hour: "2-digit",
+    hourCycle: "h23",
+    minute: "2-digit",
+    month: "2-digit",
+    second: "2-digit",
+    timeZone: config.timeZone,
+    year: "numeric",
+  });
+
+  const timeZoneOffsetFormatter = new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    hourCycle: "h23",
+    minute: "2-digit",
+    timeZone: config.timeZone,
+    timeZoneName: "shortOffset",
+  });
+
+  const getTimeZoneDateParts = (date: Date): TimeZoneDateParts => {
+    const parts = timeZoneFormatter.formatToParts(date);
+    const getPartValue = (type: Intl.DateTimeFormatPartTypes): number => {
+      const value = parts.find((part) => part.type === type)?.value;
+
+      if (!value) {
+        throw new Error(`Missing ${type} in survey scheduling date formatter output`);
+      }
+
+      return Number.parseInt(value, 10);
+    };
+
+    return {
+      day: getPartValue("day"),
+      hour: getPartValue("hour"),
+      minute: getPartValue("minute"),
+      month: getPartValue("month"),
+      year: getPartValue("year"),
+    };
+  };
+
+  const getTimeZoneOffsetMs = (date: Date): number => {
+    const offsetValue = timeZoneOffsetFormatter
+      .formatToParts(date)
+      .find((part) => part.type === "timeZoneName")?.value;
+
+    if (!offsetValue || offsetValue === "GMT") {
+      return 0;
+    }
+
+    const match = /^GMT(?<sign>[+-])(?<hours>\d{1,2})(?::(?<minutes>\d{2}))?$/.exec(offsetValue);
+
+    if (!match?.groups) {
+      throw new Error(`Unsupported survey scheduling timezone offset: ${offsetValue}`);
+    }
+
+    const sign = match.groups.sign === "+" ? 1 : -1;
+    const hours = Number.parseInt(match.groups.hours, 10);
+    const minutes = Number.parseInt(match.groups.minutes ?? "0", 10);
+
+    return sign * ((hours * 60 + minutes) * 60 * 1000);
+  };
+
+  const matchesSurveySchedulingLocalTime = (
+    date: Date,
+    year: number,
+    month: number,
+    day: number
+  ): boolean => {
+    const parts = getTimeZoneDateParts(date);
+
+    return (
+      parts.year === year &&
+      parts.month === month + 1 &&
+      parts.day === day &&
+      parts.hour === config.localHour &&
+      parts.minute === config.localMinute
+    );
+  };
+
+  const createSurveySchedulingDateTime = (year: number, month: number, day: number): Date => {
+    const utcGuessMs = Date.UTC(year, month, day, config.localHour, config.localMinute, 0, 0);
+    let candidate = new Date(utcGuessMs);
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      candidate = new Date(utcGuessMs - getTimeZoneOffsetMs(candidate));
+
+      if (matchesSurveySchedulingLocalTime(candidate, year, month, day)) {
+        return candidate;
+      }
+    }
+
+    return candidate;
+  };
+
+  const toCalendarDate = (date: Date): Date => {
+    return createLocalCalendarDate(getTimeZoneDateParts(date));
+  };
+
+  const getMinimumSurveySchedulingCalendarDate = (now: Date = new Date()): Date => {
+    const currentSchedulingDateParts = getTimeZoneDateParts(now);
+    const minimumSchedulingDate = createLocalCalendarDate(currentSchedulingDateParts);
+    const currentSchedulingRunAt = createSurveySchedulingDateTime(
+      currentSchedulingDateParts.year,
+      currentSchedulingDateParts.month - 1,
+      currentSchedulingDateParts.day
+    );
+
+    if (now.getTime() < currentSchedulingRunAt.getTime()) {
+      return minimumSchedulingDate;
+    }
+
+    const nextSchedulingDate = new Date(minimumSchedulingDate);
+    nextSchedulingDate.setDate(nextSchedulingDate.getDate() + 1);
+    return nextSchedulingDate;
+  };
+
+  const normalizeDateOnlySelectionToSurveySchedulingDateTime = (date: Date | null): Date | null => {
+    if (!date) {
+      return null;
+    }
+
+    const { day, month, year } = getTimeZoneDateParts(date);
+
+    return createSurveySchedulingDateTime(year, month - 1, day);
+  };
+
+  return {
+    toCalendarDate,
+    getMinimumSurveySchedulingCalendarDate,
+    normalizeDateOnlySelectionToSurveySchedulingDateTime,
+  };
+};
+
+export type SurveySchedulingDateUtils = ReturnType<typeof createSurveySchedulingDateUtils>;

--- a/apps/web/modules/survey/scheduling/lib/survey-scheduling.ts
+++ b/apps/web/modules/survey/scheduling/lib/survey-scheduling.ts
@@ -6,8 +6,11 @@ import { ValidationError } from "@formbricks/types/errors";
 import type { TSurvey } from "@formbricks/types/surveys/types";
 import { queueAuditEventWithoutRequest } from "@/modules/ee/audit-logs/lib/handler";
 import { type TAuditStatus } from "@/modules/ee/audit-logs/types/audit-log";
-import { SURVEY_SCHEDULING_RECONCILIATION_BATCH_SIZE } from "./constants";
-import { isDateDue, normalizeDateOnlySelectionToSurveySchedulingDateTime } from "./date-utils";
+import { SURVEY_SCHEDULING_CONFIG, SURVEY_SCHEDULING_RECONCILIATION_BATCH_SIZE } from "./constants";
+import { createSurveySchedulingDateUtils, isDateDue } from "./date-utils";
+
+const { normalizeDateOnlySelectionToSurveySchedulingDateTime } =
+  createSurveySchedulingDateUtils(SURVEY_SCHEDULING_CONFIG);
 
 type TSurveySchedulingTransition = "publish" | "close";
 

--- a/apps/web/modules/ui/components/client-logo/index.tsx
+++ b/apps/web/modules/ui/components/client-logo/index.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from "react-i18next";
 import { Workspace } from "@formbricks/database/prisma-browser";
 import { TLogo } from "@formbricks/types/styling";
 import { cn } from "@/lib/cn";
+import { isExternalImageSrc } from "@/lib/image-hosts";
 
 interface ClientLogoProps {
   workspaceLogo: Workspace["logo"] | null;
@@ -73,6 +74,7 @@ export const ClientLogo = ({
           width={256}
           height={64}
           alt={t("workspace.surveys.edit.company_logo")}
+          unoptimized={isExternalImageSrc(logoToUse?.url)}
         />
       ) : disableLinks ? (
         <span className="rounded-md border border-dashed border-slate-400 bg-slate-200 px-6 py-3 text-xs whitespace-nowrap text-slate-900 opacity-50 backdrop-blur-xs">

--- a/apps/web/modules/ui/components/connect-integration/index.tsx
+++ b/apps/web/modules/ui/components/connect-integration/index.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { Trans, useTranslation } from "react-i18next";
 import { TIntegrationType } from "@formbricks/types/integration";
+import { isExternalImageSrc } from "@/lib/image-hosts";
 import { Button } from "@/modules/ui/components/button";
 import { FormbricksLogo } from "@/modules/ui/components/formbricks-logo";
 import { getIntegrationDetails } from "./lib/utils";
@@ -54,7 +55,12 @@ export const ConnectIntegration = ({
             <FormbricksLogo />
           </div>
           <div className="flex size-32 items-center justify-center rounded-full bg-white p-4 shadow-md">
-            <Image className="w-1/2" src={integrationLogoSrc} alt="logo" />
+            <Image
+              className="w-1/2"
+              src={integrationLogoSrc}
+              alt="logo"
+              unoptimized={isExternalImageSrc(integrationLogoSrc)}
+            />
           </div>
         </div>
         <p className="my-8">{integrationDetails?.text}</p>

--- a/apps/web/modules/ui/components/file-input/index.tsx
+++ b/apps/web/modules/ui/components/file-input/index.tsx
@@ -7,6 +7,7 @@ import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { TAllowedFileExtension } from "@formbricks/types/storage";
 import { cn } from "@/lib/cn";
+import { isExternalImageSrc } from "@/lib/image-hosts";
 import { handleFileUpload } from "@/modules/storage/file-upload";
 import { showFileUploadErrorToast } from "@/modules/storage/file-upload-error";
 import { LoadingSpinner } from "@/modules/ui/components/loading-spinner";
@@ -261,11 +262,12 @@ export const FileInput = ({
                               style={{ objectFit: "cover" }}
                               quality={100}
                               className={!file.uploaded ? "opacity-50" : ""}
+                              unoptimized={isExternalImageSrc(file.url)}
                             />
                             {file.uploaded ? (
                               <button
                                 type="button"
-                                className="absolute right-2 top-2 flex cursor-pointer items-center justify-center rounded-md bg-slate-100 p-1 hover:bg-slate-200 hover:bg-white/90"
+                                className="absolute top-2 right-2 flex cursor-pointer items-center justify-center rounded-md bg-slate-100 p-1 hover:bg-slate-200 hover:bg-white/90"
                                 onClick={(e) => {
                                   e.preventDefault();
                                   handleRemove(idx);
@@ -287,7 +289,7 @@ export const FileInput = ({
                             {file.uploaded ? (
                               <button
                                 type="button"
-                                className="absolute right-2 top-2 flex cursor-pointer items-center justify-center rounded-md bg-slate-100 p-1 hover:bg-slate-200 hover:bg-white/90"
+                                className="absolute top-2 right-2 flex cursor-pointer items-center justify-center rounded-md bg-slate-100 p-1 hover:bg-slate-200 hover:bg-white/90"
                                 onClick={(e) => {
                                   e.preventDefault();
                                   handleRemove(idx);
@@ -328,11 +330,12 @@ export const FileInput = ({
                           style={{ objectFit: imageFit }}
                           quality={100}
                           className={!selectedFiles[0].uploaded ? "opacity-50" : ""}
+                          unoptimized={isExternalImageSrc(selectedFiles[0].url)}
                         />
                         {selectedFiles[0].uploaded ? (
                           <button
                             type="button"
-                            className="absolute right-2 top-2 flex cursor-pointer items-center justify-center rounded-md bg-slate-100 p-1 hover:bg-slate-200 hover:bg-white/90"
+                            className="absolute top-2 right-2 flex cursor-pointer items-center justify-center rounded-md bg-slate-100 p-1 hover:bg-slate-200 hover:bg-white/90"
                             onClick={(e) => {
                               e.preventDefault();
                               handleRemove(0);
@@ -352,7 +355,7 @@ export const FileInput = ({
                         {selectedFiles[0].uploaded ? (
                           <button
                             type="button"
-                            className="absolute right-2 top-2 flex cursor-pointer items-center justify-center rounded-md bg-slate-100 p-1 hover:bg-slate-200 hover:bg-white/90"
+                            className="absolute top-2 right-2 flex cursor-pointer items-center justify-center rounded-md bg-slate-100 p-1 hover:bg-slate-200 hover:bg-white/90"
                             onClick={(e) => {
                               e.preventDefault();
                               handleRemove(0);

--- a/apps/web/modules/ui/components/input-combo-box/index.tsx
+++ b/apps/web/modules/ui/components/input-combo-box/index.tsx
@@ -13,6 +13,7 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
+import { isExternalImageSrc } from "@/lib/image-hosts";
 import {
   Command,
   CommandEmpty,
@@ -107,7 +108,14 @@ function ComboboxOptionLabel({
       )}
       {option.icon && <option.icon className={iconClassName} />}
       {option.imgSrc && (
-        <Image src={option.imgSrc} alt={option.label} width={24} height={24} className="shrink-0" />
+        <Image
+          src={option.imgSrc}
+          alt={option.label}
+          width={24}
+          height={24}
+          className="shrink-0"
+          unoptimized={isExternalImageSrc(option.imgSrc)}
+        />
       )}
       {hasOptionDetails(option) ? (
         <span className="flex min-w-0 flex-col">
@@ -239,7 +247,15 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
             {i > 0 && <span>, </span>}
             <div className="flex min-w-0 items-center gap-2 overflow-hidden">
               {opt.icon && <opt.icon className={cn("shrink-0", iconClassName)} />}
-              {opt.imgSrc && <Image src={opt.imgSrc} alt={opt.label} width={24} height={24} />}
+              {opt.imgSrc && (
+                <Image
+                  src={opt.imgSrc}
+                  alt={opt.label}
+                  width={24}
+                  height={24}
+                  unoptimized={isExternalImageSrc(opt.imgSrc)}
+                />
+              )}
               <span className="truncate" title={opt.label}>
                 {opt.label}
               </span>
@@ -254,7 +270,15 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
     return (
       <div className="flex min-w-0 items-center gap-2 overflow-hidden">
         {opt.icon && <opt.icon className={cn("shrink-0", iconClassName)} />}
-        {opt.imgSrc && <Image src={opt.imgSrc} alt={opt.label} width={24} height={24} />}
+        {opt.imgSrc && (
+          <Image
+            src={opt.imgSrc}
+            alt={opt.label}
+            width={24}
+            height={24}
+            unoptimized={isExternalImageSrc(opt.imgSrc)}
+          />
+        )}
         <span className="truncate" title={opt.label}>
           {opt.label}
         </span>
@@ -420,6 +444,7 @@ export const InputCombobox: React.FC<InputComboboxProps> = ({
                                     width={24}
                                     height={24}
                                     className="shrink-0"
+                                    unoptimized={isExternalImageSrc(opt.imgSrc)}
                                   />
                                 )}
                                 <span className="flex-1 truncate text-slate-900">{opt.label}</span>

--- a/apps/web/modules/ui/components/media-background/index.tsx
+++ b/apps/web/modules/ui/components/media-background/index.tsx
@@ -8,6 +8,7 @@ import { SurveyType } from "@formbricks/database/prisma-browser";
 import { TSurveyStyling } from "@formbricks/types/surveys/types";
 import { TWorkspaceStyling } from "@formbricks/types/workspace";
 import { cn } from "@/lib/cn";
+import { isExternalImageSrc } from "@/lib/image-hosts";
 
 interface MediaBackgroundProps {
   children: React.ReactNode;
@@ -112,10 +113,10 @@ export const MediaBackground: React.FC<MediaBackgroundProps> = ({
               <Image
                 src={background?.bg}
                 alt="Background image"
-                layout="fill"
-                objectFit="cover"
-                style={{ filter: `${filterStyle}` }}
-                onLoadingComplete={() => setBackgroundLoaded(true)}
+                fill
+                style={{ objectFit: "cover", filter: `${filterStyle}` }}
+                unoptimized={isExternalImageSrc(background?.bg)}
+                onLoad={() => setBackgroundLoaded(true)}
               />
               {authorDetailsForUnsplash.authorName && (
                 <div className="absolute right-6 bottom-4 z-10 ml-auto hidden w-max text-xs text-slate-400 md:block">
@@ -147,10 +148,10 @@ export const MediaBackground: React.FC<MediaBackgroundProps> = ({
             <Image
               src={background?.bg}
               alt="Background image"
-              layout="fill"
-              objectFit="cover"
-              style={{ filter: `${filterStyle}` }}
-              onLoadingComplete={() => setBackgroundLoaded(true)}
+              fill
+              style={{ objectFit: "cover", filter: `${filterStyle}` }}
+              unoptimized={isExternalImageSrc(background?.bg)}
+              onLoad={() => setBackgroundLoaded(true)}
             />
           </div>
         );

--- a/apps/web/modules/ui/components/picture-selection-response/index.tsx
+++ b/apps/web/modules/ui/components/picture-selection-response/index.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import { cn } from "@/lib/cn";
+import { isExternalImageSrc } from "@/lib/image-hosts";
 import { IdBadge } from "@/modules/ui/components/id-badge";
 
 interface PictureSelectionResponseProps {
@@ -40,6 +41,7 @@ export const PictureSelectionResponse = ({
                   fill
                   style={{ objectFit: "cover" }}
                   className="rounded-lg"
+                  unoptimized={isExternalImageSrc(choiceImageMapping[id])}
                 />
               </div>
               {showId && <IdBadge id={id} />}

--- a/apps/web/modules/workspaces/lib/utils.test.ts
+++ b/apps/web/modules/workspaces/lib/utils.test.ts
@@ -1,0 +1,87 @@
+import { redirect } from "next/navigation";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { TMembership, TOrganizationRole } from "@formbricks/types/memberships";
+import { getBillingFallbackPath } from "@/lib/membership/navigation";
+import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
+import { getOrganization } from "@/lib/organization/service";
+import { getWorkspace } from "@/lib/workspace/service";
+import { getSession } from "@/modules/auth/lib/session";
+import { getWorkspacePermissionByUserId } from "@/modules/ee/teams/lib/roles";
+import { getWorkspaceAuth } from "./utils";
+
+const mocks = vi.hoisted(() => ({ isFormbricksCloud: false }));
+
+// Real getAccessFlags is used on purpose so the tests exercise the actual role -> isBilling mapping
+// that the redirect branch keys off of. Everything else getWorkspaceAuth touches is stubbed.
+vi.mock("react", () => ({ cache: (fn: (...args: unknown[]) => unknown) => fn }));
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  IS_FORMBRICKS_CLOUD: mocks.isFormbricksCloud,
+}));
+vi.mock("@/lib/workspace/service", () => ({ getWorkspace: vi.fn() }));
+vi.mock("@/lib/organization/service", () => ({ getOrganization: vi.fn() }));
+vi.mock("@/lib/membership/service", () => ({ getMembershipByUserIdOrganizationId: vi.fn() }));
+vi.mock("@/lib/membership/navigation", () => ({ getBillingFallbackPath: vi.fn() }));
+vi.mock("@/lingodotdev/server", () => ({ getTranslate: vi.fn(() => Promise.resolve((k: string) => k)) }));
+vi.mock("@/modules/auth/lib/session", () => ({ getSession: vi.fn() }));
+vi.mock("@/modules/ee/teams/lib/roles", () => ({ getWorkspacePermissionByUserId: vi.fn() }));
+vi.mock("@/modules/ee/teams/utils/teams", () => ({
+  getTeamPermissionFlags: vi.fn(() => ({
+    hasReadAccess: false,
+    hasReadWriteAccess: false,
+    hasManageAccess: false,
+  })),
+}));
+
+const workspaceId = "workspace-1";
+const organizationId = "organization-1";
+const billingFallbackPath = `/organizations/${organizationId}/settings/enterprise`;
+
+const primeAuth = (role: TOrganizationRole) => {
+  vi.mocked(getWorkspace).mockResolvedValue({ id: workspaceId, organizationId } as Awaited<
+    ReturnType<typeof getWorkspace>
+  >);
+  vi.mocked(getSession).mockResolvedValue({
+    user: { id: "user-1" },
+    expires: new Date(0).toISOString(),
+  } as Awaited<ReturnType<typeof getSession>>);
+  vi.mocked(getOrganization).mockResolvedValue({ id: organizationId } as Awaited<
+    ReturnType<typeof getOrganization>
+  >);
+  vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue({
+    role,
+    organizationId,
+    userId: "user-1",
+    accepted: true,
+  } as TMembership);
+  vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue(null);
+  vi.mocked(getBillingFallbackPath).mockReturnValue(billingFallbackPath);
+};
+
+describe("getWorkspaceAuth billing gate (ENG-1763)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("redirects a billing-role member to the billing fallback path", async () => {
+    primeAuth("billing");
+
+    await getWorkspaceAuth(workspaceId);
+
+    expect(getBillingFallbackPath).toHaveBeenCalledWith(organizationId, mocks.isFormbricksCloud);
+    expect(redirect).toHaveBeenCalledWith(billingFallbackPath);
+  });
+
+  test.each<TOrganizationRole>(["owner", "manager", "member"])(
+    "does not redirect a %s member",
+    async (role) => {
+      primeAuth(role);
+
+      const result = await getWorkspaceAuth(workspaceId);
+
+      expect(redirect).not.toHaveBeenCalled();
+      expect(getBillingFallbackPath).not.toHaveBeenCalled();
+      expect(result.isBilling).toBe(false);
+    }
+  );
+});

--- a/apps/web/modules/workspaces/lib/utils.test.ts
+++ b/apps/web/modules/workspaces/lib/utils.test.ts
@@ -1,9 +1,11 @@
 import { redirect } from "next/navigation";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AuthenticationError, AuthorizationError, ResourceNotFoundError } from "@formbricks/types/errors";
 import type { TMembership, TOrganizationRole } from "@formbricks/types/memberships";
 import { getBillingFallbackPath } from "@/lib/membership/navigation";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getOrganization } from "@/lib/organization/service";
+import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
 import { getWorkspace } from "@/lib/workspace/service";
 import { getSession } from "@/modules/auth/lib/session";
 import { getWorkspacePermissionByUserId } from "@/modules/ee/teams/lib/roles";
@@ -11,30 +13,30 @@ import { getWorkspaceAuth } from "./utils";
 
 const mocks = vi.hoisted(() => ({ isFormbricksCloud: false }));
 
-// Real getAccessFlags is used on purpose so the tests exercise the actual role -> isBilling mapping
-// that the redirect branch keys off of. Everything else getWorkspaceAuth touches is stubbed.
+// Real getAccessFlags and getTeamPermissionFlags are used on purpose so the tests exercise the
+// actual role -> isBilling mapping (the redirect branch) and the permission -> isReadOnly mapping.
+// Everything else getWorkspaceAuth touches is stubbed. next/navigation is globally mocked in
+// vitestSetup.ts, so `redirect` is a no-op spy here.
 vi.mock("react", () => ({ cache: (fn: (...args: unknown[]) => unknown) => fn }));
 vi.mock("@/lib/constants", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/constants")>()),
   IS_FORMBRICKS_CLOUD: mocks.isFormbricksCloud,
 }));
 vi.mock("@/lib/workspace/service", () => ({ getWorkspace: vi.fn() }));
-vi.mock("@/lib/organization/service", () => ({ getOrganization: vi.fn() }));
+vi.mock("@/lib/workspace/auth", () => ({ hasUserWorkspaceAccess: vi.fn() }));
+vi.mock("@/lib/organization/service", () => ({
+  getOrganization: vi.fn(),
+  getMonthlyOrganizationResponseCount: vi.fn(),
+}));
 vi.mock("@/lib/membership/service", () => ({ getMembershipByUserIdOrganizationId: vi.fn() }));
 vi.mock("@/lib/membership/navigation", () => ({ getBillingFallbackPath: vi.fn() }));
 vi.mock("@/lingodotdev/server", () => ({ getTranslate: vi.fn(() => Promise.resolve((k: string) => k)) }));
 vi.mock("@/modules/auth/lib/session", () => ({ getSession: vi.fn() }));
 vi.mock("@/modules/ee/teams/lib/roles", () => ({ getWorkspacePermissionByUserId: vi.fn() }));
-vi.mock("@/modules/ee/teams/utils/teams", () => ({
-  getTeamPermissionFlags: vi.fn(() => ({
-    hasReadAccess: false,
-    hasReadWriteAccess: false,
-    hasManageAccess: false,
-  })),
-}));
 
 const workspaceId = "workspace-1";
 const organizationId = "organization-1";
+const userId = "user-1";
 const billingFallbackPath = `/organizations/${organizationId}/settings/enterprise`;
 
 const primeAuth = (role: TOrganizationRole) => {
@@ -42,7 +44,7 @@ const primeAuth = (role: TOrganizationRole) => {
     ReturnType<typeof getWorkspace>
   >);
   vi.mocked(getSession).mockResolvedValue({
-    user: { id: "user-1" },
+    user: { id: userId },
     expires: new Date(0).toISOString(),
   } as Awaited<ReturnType<typeof getSession>>);
   vi.mocked(getOrganization).mockResolvedValue({ id: organizationId } as Awaited<
@@ -51,9 +53,10 @@ const primeAuth = (role: TOrganizationRole) => {
   vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue({
     role,
     organizationId,
-    userId: "user-1",
+    userId,
     accepted: true,
   } as TMembership);
+  vi.mocked(hasUserWorkspaceAccess).mockResolvedValue(true);
   vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue(null);
   vi.mocked(getBillingFallbackPath).mockReturnValue(billingFallbackPath);
 };
@@ -84,4 +87,92 @@ describe("getWorkspaceAuth billing gate (ENG-1763)", () => {
       expect(result.isBilling).toBe(false);
     }
   );
+});
+
+describe("getWorkspaceAuth workspace-access gate + isReadOnly (ENG-1769)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Happy-path default: an org member with read-only workspace access.
+    primeAuth("member");
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("read");
+  });
+
+  test("throws ResourceNotFoundError when the workspace is missing", async () => {
+    vi.mocked(getWorkspace).mockResolvedValue(null);
+    await expect(getWorkspaceAuth(workspaceId)).rejects.toThrow(ResourceNotFoundError);
+  });
+
+  test("throws AuthenticationError when there is no session", async () => {
+    vi.mocked(getSession).mockResolvedValue(null);
+    await expect(getWorkspaceAuth(workspaceId)).rejects.toThrow(AuthenticationError);
+  });
+
+  test("throws ResourceNotFoundError when the organization is missing", async () => {
+    vi.mocked(getOrganization).mockResolvedValue(null);
+    await expect(getWorkspaceAuth(workspaceId)).rejects.toThrow(ResourceNotFoundError);
+  });
+
+  test("throws AuthorizationError when the user has no org membership", async () => {
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(null);
+    await expect(getWorkspaceAuth(workspaceId)).rejects.toThrow(AuthorizationError);
+  });
+
+  // The core fix: an org member with no WorkspaceTeam grant for this workspace
+  // must be rejected instead of being admitted (and mislabeled as a writer).
+  test("throws AuthorizationError when the user has no workspace access", async () => {
+    vi.mocked(hasUserWorkspaceAccess).mockResolvedValue(false);
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue(null);
+    await expect(getWorkspaceAuth(workspaceId)).rejects.toThrow(AuthorizationError);
+    expect(hasUserWorkspaceAccess).toHaveBeenCalledWith(userId, workspaceId);
+  });
+
+  test("marks a member with a read grant as read-only", async () => {
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("read");
+    const auth = await getWorkspaceAuth(workspaceId);
+    expect(auth.isMember).toBe(true);
+    expect(auth.hasReadAccess).toBe(true);
+    expect(auth.isReadOnly).toBe(true);
+  });
+
+  test("does not mark a member with a readWrite grant as read-only", async () => {
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("readWrite");
+    const auth = await getWorkspaceAuth(workspaceId);
+    expect(auth.hasReadWriteAccess).toBe(true);
+    expect(auth.isReadOnly).toBe(false);
+  });
+
+  test("does not mark a member with a manage grant as read-only", async () => {
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("manage");
+    const auth = await getWorkspaceAuth(workspaceId);
+    expect(auth.hasManageAccess).toBe(true);
+    expect(auth.isReadOnly).toBe(false);
+  });
+
+  // Fail-safe: even if a member reaches the flags with no resolved permission,
+  // isReadOnly must be true (most restricted), never false (writer).
+  test("treats a member with no resolved permission as read-only (fail safe)", async () => {
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue(null);
+    const auth = await getWorkspaceAuth(workspaceId);
+    expect(auth.isMember).toBe(true);
+    expect(auth.hasReadAccess).toBe(false);
+    expect(auth.hasReadWriteAccess).toBe(false);
+    expect(auth.hasManageAccess).toBe(false);
+    expect(auth.isReadOnly).toBe(true);
+  });
+
+  test("does not mark an owner as read-only", async () => {
+    primeAuth("owner");
+    vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue(null);
+    const auth = await getWorkspaceAuth(workspaceId);
+    expect(auth.isOwner).toBe(true);
+    expect(auth.isReadOnly).toBe(false);
+  });
+
+  test("returns the resolved workspace, organization, and session on success", async () => {
+    const auth = await getWorkspaceAuth(workspaceId);
+    expect(auth.workspace).toMatchObject({ id: workspaceId, organizationId });
+    expect(auth.organization).toMatchObject({ id: organizationId });
+    expect(auth.session.user.id).toBe(userId);
+    expect(auth.workspacePermission).toBe("read");
+  });
 });

--- a/apps/web/modules/workspaces/lib/utils.ts
+++ b/apps/web/modules/workspaces/lib/utils.ts
@@ -28,9 +28,13 @@ import { getTeamPermissionFlags } from "@/modules/ee/teams/utils/teams";
 import { TWorkspaceAuth, TWorkspaceLayoutData } from "@/modules/workspaces/types/workspace-auth";
 
 /**
- * Workspace-scoped equivalent of getEnvironmentAuth.
- * Accepts a workspaceId, resolves the production environment automatically,
- * and performs the same authorization checks as getEnvironmentAuth.
+ * Resolves a workspace and returns the caller's authorization context for it.
+ *
+ * This helper is self-contained: it enforces workspace-level access itself rather
+ * than relying on the route layout to gate, so it is safe to reuse from any page or
+ * route. Billing-role members are redirected to billing/enterprise screens; any org
+ * member without a WorkspaceTeam grant (and who is not an owner/manager) is rejected
+ * with an AuthorizationError instead of being silently admitted as a writer.
  */
 export const getWorkspaceAuth = reactCache(async (workspaceId: string): Promise<TWorkspaceAuth> => {
   const t = await getTranslate();
@@ -67,11 +71,26 @@ export const getWorkspaceAuth = reactCache(async (workspaceId: string): Promise<
     redirect(getBillingFallbackPath(organization.id, IS_FORMBRICKS_CLOUD));
   }
 
-  const workspacePermission = await getWorkspacePermissionByUserId(session.user.id, workspace.id);
+  // Enforce workspace access here instead of delegating to the route layout, so
+  // getWorkspaceAuth is safe to reuse anywhere. An org member with no WorkspaceTeam
+  // grant for this workspace has no access and must be rejected — not silently
+  // treated as a writer. Runs alongside the permission lookup to avoid extra latency.
+  const [hasWorkspaceAccess, workspacePermission] = await Promise.all([
+    hasUserWorkspaceAccess(session.user.id, workspace.id),
+    getWorkspacePermissionByUserId(session.user.id, workspace.id),
+  ]);
+
+  if (!hasWorkspaceAccess) {
+    throw new AuthorizationError(t("common.not_authorized"));
+  }
 
   const { hasReadAccess, hasReadWriteAccess, hasManageAccess } = getTeamPermissionFlags(workspacePermission);
 
-  const isReadOnly = isMember && hasReadAccess;
+  // Fail safe: a member is read-only unless they hold an explicit write or manage
+  // grant. Deriving from the *absence* of write access (rather than the presence of
+  // an exact "read" grant) means a member with no resolved permission is treated as
+  // the most restricted, never mislabeled as a writer.
+  const isReadOnly = isMember && !hasReadWriteAccess && !hasManageAccess;
 
   return {
     workspace,

--- a/apps/web/modules/workspaces/lib/utils.ts
+++ b/apps/web/modules/workspaces/lib/utils.ts
@@ -1,3 +1,4 @@
+import { redirect } from "next/navigation";
 import { cache as reactCache } from "react";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
@@ -10,6 +11,7 @@ import {
   ResourceNotFoundError,
 } from "@formbricks/types/errors";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
+import { getBillingFallbackPath } from "@/lib/membership/navigation";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getAccessFlags } from "@/lib/membership/utils";
 import { getMonthlyOrganizationResponseCount, getOrganization } from "@/lib/organization/service";
@@ -55,6 +57,15 @@ export const getWorkspaceAuth = reactCache(async (workspaceId: string): Promise<
   }
 
   const { isMember, isOwner, isManager, isBilling } = getAccessFlags(currentUserMembership.role);
+
+  // Billing-role members are scoped to billing/enterprise screens only. They must never reach
+  // workspace product data (contacts PII, survey summaries/responses, dashboards). This is the
+  // single choke point every product page flows through, so gating here closes all of them at
+  // once and keeps this helper aligned with hasUserWorkspaceAccessForAction, which already denies
+  // billing. Individual pages that also guard billing inline remain correct (defense in depth).
+  if (isBilling) {
+    redirect(getBillingFallbackPath(organization.id, IS_FORMBRICKS_CLOUD));
+  }
 
   const workspacePermission = await getWorkspacePermissionByUserId(session.user.id, workspace.id);
 

--- a/apps/web/modules/workspaces/settings/lib/workspace.test.ts
+++ b/apps/web/modules/workspaces/settings/lib/workspace.test.ts
@@ -4,12 +4,13 @@ import { Prisma } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { StorageErrorCode } from "@formbricks/storage";
 import { DatabaseError, InvalidInputError, ValidationError } from "@formbricks/types/errors";
+import { TWorkspace } from "@formbricks/types/workspace";
 import { deleteFilesByWorkspaceId } from "@/modules/storage/service";
 import { createWorkspace, deleteWorkspace, updateWorkspace } from "./workspace";
 
 vi.mock("server-only", () => ({}));
 
-const baseWorkspace = {
+const baseWorkspace: TWorkspace = {
   id: "p1",
   createdAt: new Date(),
   updatedAt: new Date(),
@@ -77,7 +78,7 @@ describe("workspace lib", () => {
 
   describe("updateWorkspace", () => {
     test("updates workspace and revalidates cache", async () => {
-      vi.mocked(prisma.workspace.update).mockResolvedValueOnce(baseWorkspace as any);
+      vi.mocked(prisma.workspace.update).mockResolvedValueOnce(baseWorkspace);
       const result = await updateWorkspace("p1", {
         name: "Workspace 1",
       });
@@ -101,6 +102,14 @@ describe("workspace lib", () => {
       vi.mocked(prisma.workspace.update).mockResolvedValueOnce({ ...baseWorkspace, id: 123 } as any);
       const result = await updateWorkspace("p1", { name: "Workspace 1" });
       expect(result).toEqual({ ...baseWorkspace, id: 123 });
+    });
+
+    // ENG-1919: a workspace must not be moved to another organization via update.
+    test("never persists a caller-supplied organizationId", async () => {
+      vi.mocked(prisma.workspace.update).mockResolvedValueOnce(baseWorkspace);
+      await updateWorkspace("p1", { name: "Workspace 1", organizationId: "attacker-target-org" });
+      const arg = vi.mocked(prisma.workspace.update).mock.calls[0][0];
+      expect(arg.data).not.toHaveProperty("organizationId");
     });
   });
 

--- a/apps/web/modules/workspaces/settings/lib/workspace.ts
+++ b/apps/web/modules/workspaces/settings/lib/workspace.ts
@@ -77,7 +77,10 @@ export const updateWorkspace = async (
   inputWorkspace: TWorkspaceUpdateInput
 ): Promise<TWorkspace> => {
   validateInputs([workspaceId, ZId], [inputWorkspace, ZWorkspaceUpdateInput]);
-  const { ...data } = inputWorkspace;
+  // ENG-1919: organizationId is the workspace's tenant anchor, set at creation and immutable on
+  // update. Persisting a caller-supplied organizationId here would let an authorized workspace
+  // owner move their workspace (and all its data) into another organization, so it is stripped.
+  const { organizationId: _organizationId, ...data } = inputWorkspace;
   let updatedWorkspace;
   try {
     updatedWorkspace = await prisma.workspace.update({

--- a/apps/web/modules/workspaces/settings/look/components/edit-logo.tsx
+++ b/apps/web/modules/workspaces/settings/look/components/edit-logo.tsx
@@ -6,6 +6,7 @@ import { ChangeEvent, useRef, useState } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { TWorkspace } from "@formbricks/types/workspace";
+import { isExternalImageSrc } from "@/lib/image-hosts";
 import { getFormattedErrorMessage } from "@/lib/utils/helper";
 import { handleFileUpload } from "@/modules/storage/file-upload";
 import { showFileUploadErrorToast } from "@/modules/storage/file-upload-error";
@@ -145,6 +146,7 @@ export const EditLogo = ({ workspace, workspaceId, isReadOnly, isStorageConfigur
             height={56}
             style={{ backgroundColor: logoBgColor || undefined }}
             className="-mb-6 h-20 w-auto max-w-64 rounded-lg border object-contain p-1"
+            unoptimized={isExternalImageSrc(logoUrl)}
           />
         ) : (
           <FileInput

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -2,6 +2,10 @@ import { withSentryConfig } from "@sentry/nextjs";
 import createJiti from "jiti";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
+// Single source of truth for image-optimizer hosts (ENG-1678); shared with the runtime
+// `isExternalImageSrc` check in lib/image-hosts.ts so remotePatterns and the per-<Image>
+// `unoptimized` decision can never drift apart.
+import { OPTIMIZABLE_IMAGE_HOSTS } from "./lib/optimizable-image-hosts.mjs";
 
 const jiti = createJiti(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -97,40 +101,15 @@ const nextConfig = {
     formats: ["image/webp"], // WebP is faster to process and smaller than JPEG/PNG
     minimumCacheTTL: 60, // Cache optimized images for at least 60 seconds
     dangerouslyAllowSVG: true, // Allow SVG images
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "avatars.githubusercontent.com",
-      },
-      {
-        protocol: "https",
-        hostname: "avatars.slack-edge.com",
-      },
-      {
-        protocol: "https",
-        hostname: "lh3.googleusercontent.com",
-      },
-      {
-        protocol: "http",
-        hostname: "localhost",
-      },
-      {
-        protocol: "http",
-        hostname: "127.0.0.1",
-      },
-      {
-        protocol: "https",
-        hostname: "app.formbricks.com",
-      },
-      {
-        protocol: "https",
-        hostname: "formbricks-cdn.s3.eu-central-1.amazonaws.com",
-      },
-      {
-        protocol: "https",
-        hostname: "images.unsplash.com",
-      },
-    ],
+    // Only universal provider/CDN hosts are optimized (ENG-1678). Same-origin `/storage/...` uploads
+    // are relative paths (local images, always optimized) and need no entry; the deployment's own
+    // domain is intentionally NOT listed since the same build serves every domain. Arbitrary
+    // user-provided external URLs are rendered `unoptimized` (see lib/image-hosts.ts) instead of
+    // being allowlisted, so the optimizer never acts as an open proxy.
+    remotePatterns: OPTIMIZABLE_IMAGE_HOSTS.map((hostname) => ({
+      protocol: LOOPBACK_HOSTS.includes(hostname) ? "http" : "https",
+      hostname,
+    })),
   },
   async redirects() {
     return [
@@ -490,12 +469,6 @@ if (process.env.WEBAPP_URL) {
     bodySizeLimit: "2mb",
   };
 }
-
-// Allow all origins for next/image
-nextConfig.images.remotePatterns.push({
-  protocol: "https",
-  hostname: "**",
-});
 
 const sentryOptions = {
   // For all available options, see:

--- a/apps/web/playwright/billing-role-access.spec.ts
+++ b/apps/web/playwright/billing-role-access.spec.ts
@@ -1,0 +1,76 @@
+import { expect } from "@playwright/test";
+import { prisma } from "@formbricks/database";
+import type { UsersFixture } from "./fixtures/users";
+import { test } from "./lib/fixtures";
+
+// ENG-1763 regression: a billing-role member must not reach workspace product data (contacts PII,
+// survey summaries/responses, dashboards) by direct navigation. getWorkspaceAuth is the single choke
+// point every product page flows through, so it bounces billing users to their org billing/enterprise
+// home instead. The owner test guards against a naive "redirect everyone" fix regressing product
+// access for legitimate roles.
+
+// Creates an organization (owned by `owner`) with a workspace holding product data, plus a second
+// user who is a billing-role member of that same organization.
+const setupOrgWithBillingMember = async (users: UsersFixture) => {
+  const owner = await users.create();
+  if (!owner.organizationId || !owner.workspaceId) {
+    throw new Error("Owner org/workspace not seeded for test");
+  }
+
+  const billingUser = await users.create({ withoutWorkspace: true });
+  await prisma.membership.create({
+    data: {
+      userId: billingUser.id,
+      organizationId: owner.organizationId,
+      role: "billing",
+      accepted: true,
+    },
+  });
+
+  // users.create seeds a survey in the workspace; it backs the survey summary/responses URLs below.
+  const survey = await prisma.survey.findFirstOrThrow({
+    where: { workspaceId: owner.workspaceId },
+    select: { id: true },
+  });
+
+  const workspaceBase = `/workspaces/${owner.workspaceId}`;
+  return {
+    owner,
+    billingUser,
+    workspaceId: owner.workspaceId,
+    contactsUrl: `${workspaceBase}/contacts`,
+    // Every workspace product surface flows through getWorkspaceAuth, so all of them must redirect.
+    productUrls: [
+      `${workspaceBase}/contacts`,
+      `${workspaceBase}/dashboards`,
+      `${workspaceBase}/surveys/${survey.id}/summary`,
+      `${workspaceBase}/surveys/${survey.id}/responses`,
+    ],
+  };
+};
+
+test.describe("Billing-role workspace access (ENG-1763)", () => {
+  const billingHomeUrl = /\/organizations\/[^/]+\/settings\/(billing|enterprise)/;
+
+  test("redirects a billing member off product pages to the billing home", async ({ page, users }) => {
+    const { billingUser, productUrls } = await setupOrgWithBillingMember(users);
+
+    await billingUser.login();
+
+    for (const url of productUrls) {
+      await page.goto(url, { waitUntil: "domcontentloaded" });
+      await expect(page, `billing member should be redirected off ${url}`).toHaveURL(billingHomeUrl);
+    }
+  });
+
+  test("keeps product-page access for a non-billing owner", async ({ page, users }) => {
+    const { owner, workspaceId, contactsUrl } = await setupOrgWithBillingMember(users);
+
+    await owner.login();
+    await page.goto(contactsUrl, { waitUntil: "domcontentloaded" });
+
+    // Owner stays on the product route (the page may render an upgrade prompt when the enterprise
+    // feature is unlicensed, but crucially it is not bounced to the billing home).
+    await expect(page).toHaveURL(new RegExp(`/workspaces/${workspaceId}/contacts`));
+  });
+});

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -4,6 +4,131 @@ description: "Formbricks Self-hosted version migration"
 icon: "arrow-right"
 ---
 
+## v5.2
+
+Formbricks v5.2 migrates authentication from NextAuth to **Better Auth**. For most self-hosted
+instances this is a drop-in upgrade, but **if you use SSO (Azure AD / Entra ID, generic OIDC, or SAML)
+you must re-register the OAuth callback URL at your identity provider before the first v5.2 restart**,
+or SSO sign-in will fail with a redirect-URI mismatch.
+
+<Warning>
+  All users are signed out once when you upgrade to v5.2. Better Auth takes over session handling and
+  there is no dual-read from the old NextAuth sessions, so the cutover is a one-time forced re-login.
+  Passwords are preserved — existing credential hashes are migrated automatically, so no password reset
+  is needed.
+</Warning>
+
+### SSO Callback URL Change (action required for SSO users)
+
+Better Auth serves the OAuth2/OIDC callback at a new path:
+
+- old (NextAuth): `/api/auth/callback/{provider}`
+- new (Better Auth): `/api/auth/oauth2/callback/{providerId}`
+
+Update the redirect / callback URIs at your identity provider to the new path. Replace `https://your-domain.com`
+with your instance URL:
+
+| Provider | Where to update | New callback URL |
+| --- | --- | --- |
+| Azure AD / Entra ID | Azure portal -> App registration -> Authentication -> Redirect URIs | `https://your-domain.com/api/auth/oauth2/callback/azuread` |
+| Generic OIDC | At your OIDC provider | `https://your-domain.com/api/auth/oauth2/callback/openid` |
+| SAML (BoxyHQ / Jackson) | The Jackson connection's `redirect_uri` | `https://your-domain.com/api/auth/oauth2/callback/saml` |
+
+<Note>
+  **Google and GitHub sign-in do not change.** They use Better Auth's built-in social providers, whose
+  callback path (`/api/auth/callback/{provider}`) is unchanged — nothing to do there.
+
+  For SAML, only the Jackson connection's `redirect_uri` changes. The IdP-side ACS endpoint
+  (`/api/auth/saml/callback`) is unchanged, so you do **not** need to reconfigure your IdP's SAML app.
+
+  Leave the old `/api/auth/callback/*` redirect URIs registered through the transition. Keeping them in
+  place is harmless and makes a rollback to v5.1 clean.
+</Note>
+
+### Authentication Environment Variables
+
+Better Auth introduces two optional variables. **Neither is required** for a standard upgrade — both fall
+back to your existing NextAuth configuration:
+
+- `BETTER_AUTH_SECRET` — cookie/session signing secret. Falls back to `NEXTAUTH_SECRET` when unset. If you
+  set it explicitly it must be at least 32 characters. Keeping the `NEXTAUTH_SECRET` fallback is
+  recommended so the value the forward-auth proxy already verifies with stays consistent.
+- `BETTER_AUTH_URL` — the auth base URL. Falls back to `NEXTAUTH_URL` (and then `WEBAPP_URL`) when unset.
+
+<Info>
+  If your instance already sets `NEXTAUTH_SECRET` and `NEXTAUTH_URL` (all v5.1 instances do), you can
+  upgrade without adding any new auth variables.
+</Info>
+
+**Removed:** `DISABLE_ACCOUNT_DELETION_SSO_CONFIRMATION` no longer exists. Remove it from your environment
+if you set it; it now has no effect.
+
+### Optional New Configuration
+
+None of the following is required to run v5.2. Add them only if you want the associated feature.
+
+#### Hub Enrichment (sentiment, emotion, translation)
+
+Hub `>= 0.8.0` can classify sentiment and emotion and translate feedback. These are **off** unless you set
+a provider and model, and they run in both the Hub API and the hub-worker, so set the variables on **both**
+services. Bump your Hub image to `>= 0.8.0` (via `HUB_IMAGE_REF`) to pick up these features.
+
+- `SENTIMENT_PROVIDER`, `SENTIMENT_MODEL`, `SENTIMENT_PROVIDER_API_KEY`
+- `EMOTIONS_PROVIDER`, `EMOTIONS_MODEL`, `EMOTIONS_PROVIDER_API_KEY`
+- `TRANSLATION_PROVIDER`, `TRANSLATION_MODEL`, `TRANSLATION_PROVIDER_API_KEY`, `TRANSLATION_DEFAULT_LANGUAGE`
+
+Supported providers: `openai`, `google` (AI Studio, needs `*_PROVIDER_API_KEY`), and `google-gemini`
+(Vertex, needs `*_GOOGLE_CLOUD_PROJECT` / `*_LOCATION` plus Application Default Credentials).
+
+<Warning>
+  A provider set **without** its required credentials crash-loops both Hub containers on startup — it does
+  not degrade gracefully. Set the credentials, or leave the provider unset.
+</Warning>
+
+#### AI Taxonomy (beta)
+
+An optional standalone taxonomy service, enabled in Docker Compose with `COMPOSE_PROFILES=taxonomy`. It
+shares an internal token with Hub:
+
+- `TAXONOMY_SERVICE_URL` (the internal URL to the taxonomy service)
+- `HUB_INTERNAL_API_TOKEN`, `TAXONOMY_SERVICE_TOKEN` (strong random secrets)
+- `TAXONOMY_LLM_PROVIDER` / `TAXONOMY_LLM_MODEL` / `TAXONOMY_LLM_BASE_URL` / `TAXONOMY_LLM_API_KEY`
+  (`openai-compatible` by default; `bedrock` and `vertex-gemini` also supported)
+- `TAXONOMY_IMAGE_REF` to pin a released image (e.g. `:v0.1.0`)
+
+Use `COMPOSE_PROFILES=qwen,taxonomy` to back it with the bundled Qwen/vLLM service.
+
+#### Bundled Qwen / vLLM Runtime
+
+Docker Compose can now run a bundled OpenAI-compatible LLM for self-hosted AI features with
+`COMPOSE_PROFILES=qwen`. Tunable via `QWEN_VLLM_IMAGE`, `QWEN_MODEL_ID`, `QWEN_SERVED_MODEL_NAME`,
+`QWEN_MAX_MODEL_LEN`, `QWEN_MAX_NUM_SEQS`, `QWEN_GPU_MEMORY_UTILIZATION`, `QWEN_VLLM_HOST`, and
+`QWEN_VLLM_PORT`.
+
+#### OpenTelemetry Log Export
+
+- `OTEL_LOGS_ENABLED=1` — export Pino application logs via OTLP (off by default; also needs
+  `OTEL_EXPORTER_OTLP_ENDPOINT`).
+
+### Upgrade Steps
+
+v5.2 requires no manual database migration step beyond the standard automatic Prisma migrations on startup
+(the credential-account backfill runs automatically). The Helm chart is unchanged from v5.1.
+
+1. **If you use SSO**, add the new `/api/auth/oauth2/callback/{providerId}` redirect URIs at your IdP (see
+   the table above), keeping the old ones in place.
+2. Back up your database.
+3. Pull the v5.2 images and restart (`docker compose pull && docker compose down && docker compose up -d`,
+   or `helm upgrade` with the new tag).
+4. After startup, sign in again (the one-time forced re-login) and verify each configured SSO provider
+   completes sign-in.
+
+### Rollback
+
+Because the old `/api/auth/callback/*` redirect URIs are left in place, rolling back to v5.1 is clean:
+revert your image tags / Helm values, and the previous NextAuth callback path works again. Restore the
+database backup only if you need to undo schema changes.
+
 ## v5
 
 Formbricks v5 changes the self-hosted runtime contract. If you are upgrading an existing Formbricks 4.x

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -108,6 +108,7 @@ export function Survey({
   action,
   singleUseId,
   singleUseResponseId,
+  pinAuthToken,
   isWebEnvironment = true,
   getRecaptchaToken,
   isSpamProtectionEnabled,
@@ -132,13 +133,23 @@ export function Survey({
   const surveyState = useMemo(() => {
     if (appUrl && workspaceId) {
       if (mode === "inline") {
-        return new SurveyState(survey.id, singleUseId, singleUseResponseId, userId, contactId);
+        return new SurveyState(survey.id, singleUseId, singleUseResponseId, userId, contactId, pinAuthToken);
       }
 
-      return new SurveyState(survey.id, null, null, userId, contactId);
+      return new SurveyState(survey.id, null, null, userId, contactId, pinAuthToken);
     }
     return null;
-  }, [appUrl, workspaceId, mode, survey.id, userId, singleUseId, singleUseResponseId, contactId]);
+  }, [
+    appUrl,
+    workspaceId,
+    mode,
+    survey.id,
+    userId,
+    singleUseId,
+    singleUseResponseId,
+    contactId,
+    pinAuthToken,
+  ]);
 
   // Update the responseQueue to use the stored responseId
 

--- a/packages/surveys/src/lib/api-client.ts
+++ b/packages/surveys/src/lib/api-client.ts
@@ -97,6 +97,7 @@ export class ApiClient {
     ttc,
     variables,
     language,
+    pinAuthToken,
   }: TResponseUpdateInput & { responseId: string }): Promise<
     Result<TResponseUpdateResponse, ApiErrorResponse>
   > {
@@ -107,6 +108,7 @@ export class ApiClient {
       ttc,
       variables,
       language,
+      pinAuthToken,
     });
   }
 

--- a/packages/surveys/src/lib/response-queue.ts
+++ b/packages/surveys/src/lib/response-queue.ts
@@ -648,6 +648,7 @@ export class ResponseQueue {
         response = await this.api.updateResponse({
           ...responseUpdate,
           responseId: this.surveyState.responseId,
+          pinAuthToken: this.surveyState.pinAuthToken || null,
         });
 
         if (!response.ok) {
@@ -662,6 +663,7 @@ export class ResponseQueue {
           userId: this.surveyState.userId || null,
           singleUseId: this.surveyState.singleUseId || null,
           displayId: this.surveyState.displayId,
+          pinAuthToken: this.surveyState.pinAuthToken || null,
           recaptchaToken: this.responseRecaptchaToken ?? undefined,
         });
 

--- a/packages/surveys/src/lib/response.queue.test.ts
+++ b/packages/surveys/src/lib/response.queue.test.ts
@@ -39,6 +39,7 @@ const getSurveyState: () => SurveyState = () => ({
   contactId: "contact1",
   surveyId: "survey1",
   singleUseId: "single1",
+  pinAuthToken: null,
   shouldCreateResponseFromState: false,
   responseAcc: { finished: false, data: {}, ttc: {}, variables: {} },
   updateResponseId: vi.fn(),

--- a/packages/surveys/src/lib/survey-state.ts
+++ b/packages/surveys/src/lib/survey-state.ts
@@ -9,19 +9,22 @@ export class SurveyState {
   shouldCreateResponseFromState = false;
   responseAcc: TResponseUpdate = { finished: false, data: {}, ttc: {}, variables: {} };
   singleUseId: string | null;
+  pinAuthToken: string | null;
 
   constructor(
     surveyId: string,
     singleUseId?: string | null,
     responseId?: string | null,
     userId?: string | null,
-    contactId?: string | null
+    contactId?: string | null,
+    pinAuthToken?: string | null
   ) {
     this.surveyId = surveyId;
     this.userId = userId ?? null;
     this.singleUseId = singleUseId ?? null;
     this.responseId = responseId ?? null;
     this.contactId = contactId ?? null;
+    this.pinAuthToken = pinAuthToken ?? null;
   }
 
   /**
@@ -41,7 +44,8 @@ export class SurveyState {
       this.singleUseId ?? undefined,
       this.responseId ?? undefined,
       this.userId ?? undefined,
-      this.contactId ?? undefined
+      this.contactId ?? undefined,
+      this.pinAuthToken ?? undefined
     );
     copyInstance.responseId = this.responseId;
     copyInstance.responseAcc = this.responseAcc;

--- a/packages/types/formbricks-surveys.ts
+++ b/packages/types/formbricks-surveys.ts
@@ -67,6 +67,7 @@ export interface SurveyContainerProps extends Omit<SurveyBaseProps, "onFileUploa
   action?: string;
   singleUseId?: string;
   singleUseResponseId?: string;
+  pinAuthToken?: string;
   isWebEnvironment?: boolean;
   isSpamProtectionEnabled?: boolean;
   recaptchaSiteKey?: string;

--- a/packages/types/responses.ts
+++ b/packages/types/responses.ts
@@ -364,6 +364,7 @@ export const ZResponseInput = z.object({
   userId: z.string().nullish(),
   displayId: z.string().nullish(),
   singleUseId: z.string().nullable().optional(),
+  pinAuthToken: z.string().nullish(),
   finished: z.boolean(),
   endingId: z.string().nullish(),
   language: z.string().optional(),
@@ -397,6 +398,7 @@ export const ZResponseUpdateInput = z.object({
   variables: ZResponseVariables.optional(),
   ttc: ZResponseTtcInput.optional(),
   language: z.string().optional(),
+  pinAuthToken: z.string().nullish(),
 });
 
 export type TResponseUpdateInput = z.infer<typeof ZResponseUpdateInput>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,7 +32,7 @@ overrides:
   esbuild: 0.28.1
   undici@7: 7.28.0
   form-data@4: 4.0.6
-  tar: 7.5.16
+  tar: 7.5.19
   js-yaml@4: 4.2.0
 
 importers:
@@ -11515,8 +11515,8 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar@7.5.16:
-    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
+  tar@7.5.19:
+    resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
 
   tarn@3.0.2:
@@ -19938,7 +19938,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 7.5.16
+      tar: 7.5.19
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -22842,7 +22842,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.8.0
-      tar: 7.5.16
+      tar: 7.5.19
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -24521,7 +24521,7 @@ snapshots:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
-      tar: 7.5.16
+      tar: 7.5.19
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
@@ -24839,7 +24839,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar@7.5.16:
+  tar@7.5.19:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -71,7 +71,10 @@ overrides:
   # ENG-1513 / GHSA-fjxv-7rqg-78g4: form-data <4.0.4 uses an unsafe random function for the
   # multipart boundary. @redocly/respect-core pins 4.0.0; patched in 4.0.4+.
   form-data@4: 4.0.6
-  tar: 7.5.16
+  # ENG-1947 / GHSA-23hp-3jrh-7fpw (CVE-2026-59873): node-tar <=7.5.18 has no hard
+  # upper bound on total decompressed bytes / entry count, so a small gzip bomb can
+  # exhaust disk and CPU (DoS). Patched in 7.5.19.
+  tar: 7.5.19
   # ENG-1527-batch / GHSA-mh29-5h37-fv8m + GHSA-h67p-54hq-rp68: js-yaml <4.1.2 quadratic-complexity
   # DoS via merge keys / repeated aliases (dev-only, via @redocly/cli). No 4.1.2 published; 4.2.0 is the
   # lowest patched and stays <5. Scoped to the 4.x line so any 3.x consumer is untouched.

--- a/turbo.json
+++ b/turbo.json
@@ -218,10 +218,7 @@
         "WEBAPP_URL",
         "NEXTAUTH_URL",
         "S3_ENDPOINT_URL",
-        "POSTHOG_KEY",
-        "NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE",
-        "NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_HOUR",
-        "NEXT_PUBLIC_SURVEY_SCHEDULING_LOCAL_MINUTE"
+        "POSTHOG_KEY"
       ],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**", "!.next/dev/**"],
       "passThroughEnv": [
@@ -348,6 +345,9 @@
         "STRIPE_PUBLISHABLE_KEY",
         "SURVEYS_PACKAGE_MODE",
         "SURVEYS_PACKAGE_BUILD",
+        "SURVEY_SCHEDULING_TIME_ZONE",
+        "SURVEY_SCHEDULING_LOCAL_HOUR",
+        "SURVEY_SCHEDULING_LOCAL_MINUTE",
         "PUBLIC_URL",
         "TURNSTILE_SECRET_KEY",
         "TURNSTILE_SITE_KEY",


### PR DESCRIPTION
## What does this PR do?

Merges the latest `main` into `epic/workflows-v1` to keep the epic branch up to date. Brings in 8 commits from main, including:

- fix(web): unoptimize external next/image srcs instead of a host wildcard (#8501)
- fix(surveys): enforce link-survey PIN on the client response API [ENG-1579] (#8506)
- fix: enforce workspace-level access in getWorkspaceAuth [ENG-1769] (#8591)
- fix(scheduling): drop NEXT_PUBLIC_ prefix from survey scheduling env vars (ENG-1665) (#8601)
- fix: bump tar to 7.5.19 to patch decompression DoS (ENG-1947) (#8604)
- docs(self-hosting): add v5.2 migration guide (#8593)
- fix(auth): block billing-role members from workspace product data [ENG-1763] (#8592)
- fix: enforce organization/workspace scoping across API keys, surveys, quotas, and integrations (ENG-1749) (#8596)

There were no merge conflicts — git auto-merged everything, including the three files touched by both branches (`apps/web/next.config.mjs`, `pnpm-lock.yaml`, `turbo.json`), which were manually reviewed for correctness.

## How should this be tested?

- `pnpm install` — lockfile resolves cleanly (only the tar 7.5.19 security bump)
- `pnpm typecheck` in `apps/web` — passes
- Ran the Vitest suites for all files touched by the merge (survey service, workspace utils, api-key auth, image hosts, pin token, env, segments actions, scheduling, workspace resolver): 160 tests passed

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits (n/a — merge commit only)
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs` (n/a)
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues