### PR TITLE
fix(web): match protocol in isExternalImageSrc against remotePatterns (#ENG-2003)

### DIFF
--- a/apps/web/lib/image-hosts.test.ts
+++ b/apps/web/lib/image-hosts.test.ts
@@ -40,4 +40,19 @@ describe("isExternalImageSrc", () => {
   test("does not include the deployment domain in the optimizable host allowlist", () => {
     expect(OPTIMIZABLE_IMAGE_HOSTS).not.toContain("app.formbricks.com");
   });
+
+  test("treats an allowlisted public host over plain http as external (protocol mismatches remotePatterns' https)", () => {
+    expect(isExternalImageSrc("http://images.unsplash.com/photo-1.jpg")).toBe(true);
+    expect(isExternalImageSrc("http://avatars.githubusercontent.com/u/1")).toBe(true);
+  });
+
+  test("treats an allowlisted loopback host over https as external (protocol mismatches remotePatterns' http)", () => {
+    expect(isExternalImageSrc("https://localhost:3000/x.png")).toBe(true);
+    expect(isExternalImageSrc("https://127.0.0.1:3000/x.png")).toBe(true);
+  });
+
+  test("treats an allowlisted loopback host over http as optimizable", () => {
+    expect(isExternalImageSrc("http://localhost:3000/x.png")).toBe(false);
+    expect(isExternalImageSrc("http://127.0.0.1:3000/x.png")).toBe(false);
+  });
 });

--- a/apps/web/lib/image-hosts.ts
+++ b/apps/web/lib/image-hosts.ts
@@ -1,11 +1,19 @@
 import { type StaticImageData } from "next/image";
-import { OPTIMIZABLE_IMAGE_HOSTS } from "./optimizable-image-hosts.mjs";
+import { LOOPBACK_HOSTS, OPTIMIZABLE_IMAGE_HOSTS } from "./optimizable-image-hosts.mjs";
 
 // Re-exported from the plain `.mjs` source of truth (also imported by next.config.mjs) so
 // remotePatterns and the runtime check below share one list. See ./optimizable-image-hosts.mjs.
 export { OPTIMIZABLE_IMAGE_HOSTS };
 
 const OPTIMIZABLE_IMAGE_HOSTS_SET: ReadonlySet<string> = new Set(OPTIMIZABLE_IMAGE_HOSTS);
+const LOOPBACK_HOSTS_SET: ReadonlySet<string> = new Set(LOOPBACK_HOSTS);
+
+// Must mirror the protocol `next.config.mjs` pins per host in `images.remotePatterns`: `http` for
+// loopback hosts, `https` for every other allowlisted (public) host. Next.js matches `remotePatterns`
+// protocol strictly, so a src whose protocol disagrees would be rejected by the optimizer even though
+// its hostname is allowlisted.
+const optimizableProtocolFor = (hostname: string): string =>
+  LOOPBACK_HOSTS_SET.has(hostname) ? "http:" : "https:";
 
 /**
  * Whether an `<Image>` src must be rendered with `unoptimized` because the Next.js image optimizer
@@ -14,11 +22,14 @@ const OPTIMIZABLE_IMAGE_HOSTS_SET: ReadonlySet<string> = new Set(OPTIMIZABLE_IMA
  * Returns `false` (i.e. optimize) for:
  * - relative paths (`/storage/...`, `/images/...`) — local images, optimized via `localPatterns`;
  * - `data:` URIs, `StaticImageData` imports, or empty/nullish values;
- * - absolute URLs whose host is in {@link OPTIMIZABLE_IMAGE_HOSTS}.
+ * - absolute URLs whose host is in {@link OPTIMIZABLE_IMAGE_HOSTS} AND whose protocol matches what
+ *   `next.config.mjs` generates for that host in `remotePatterns` (`http` for loopback, `https`
+ *   otherwise).
  *
  * Returns `true` (i.e. bypass the optimizer, serve directly) for any other absolute `http(s)` URL —
- * i.e. arbitrary user-provided external images. This keeps the optimizer from acting as an open
- * proxy for hosts we don't control, without breaking rendering of those images.
+ * i.e. arbitrary user-provided external images, or an allowlisted host requested over the "wrong"
+ * protocol (which the optimizer would reject with a 400 anyway). This keeps the optimizer from acting
+ * as an open proxy for hosts we don't control, without breaking rendering of those images.
  *
  * The decision depends only on the src string, so it is identical on the server and client (no
  * hydration mismatch).
@@ -27,7 +38,10 @@ export const isExternalImageSrc = (src: string | StaticImageData | null | undefi
   if (!src || typeof src !== "string") return false;
   if (!/^https?:\/\//i.test(src)) return false; // relative path or data: URI → local/optimizable
   try {
-    return !OPTIMIZABLE_IMAGE_HOSTS_SET.has(new URL(src).hostname);
+    const url = new URL(src);
+    const isOptimizableHost = OPTIMIZABLE_IMAGE_HOSTS_SET.has(url.hostname);
+    const hasOptimizableProtocol = url.protocol === optimizableProtocolFor(url.hostname);
+    return !(isOptimizableHost && hasOptimizableProtocol);
   } catch {
     return false;
   }

--- a/apps/web/lib/optimizable-image-hosts.mjs
+++ b/apps/web/lib/optimizable-image-hosts.mjs
@@ -15,6 +15,12 @@
  * It therefore contains only *universal* provider hosts that real features rely on and that are
  * identical on every deployment.
  */
+// Loopback hosts are only ever reachable over plain HTTP (local development); every other
+// allowlisted host is a public provider only ever reachable over HTTPS. Exported so both
+// `next.config.mjs` (remotePatterns protocol) and `lib/image-hosts.ts` (runtime protocol check)
+// agree on which hosts are loopback instead of each keeping their own copy.
+export const LOOPBACK_HOSTS = ["localhost", "127.0.0.1"];
+
 export const OPTIMIZABLE_IMAGE_HOSTS = [
   // OAuth profile avatars
   "avatars.githubusercontent.com",
@@ -23,6 +29,5 @@ export const OPTIMIZABLE_IMAGE_HOSTS = [
   // survey editor's Unsplash background picker
   "images.unsplash.com",
   // local development
-  "localhost",
-  "127.0.0.1",
+  ...LOOPBACK_HOSTS,
 ];

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -5,13 +5,12 @@ import { fileURLToPath } from "node:url";
 // Single source of truth for image-optimizer hosts (ENG-1678); shared with the runtime
 // `isExternalImageSrc` check in lib/image-hosts.ts so remotePatterns and the per-<Image>
 // `unoptimized` decision can never drift apart.
-import { OPTIMIZABLE_IMAGE_HOSTS } from "./lib/optimizable-image-hosts.mjs";
+import { LOOPBACK_HOSTS, OPTIMIZABLE_IMAGE_HOSTS } from "./lib/optimizable-image-hosts.mjs";
 
 const jiti = createJiti(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 jiti("./lib/env");
 
-const LOOPBACK_HOSTS = ["localhost", "127.0.0.1"];
 const LOOPBACK_WILDCARD_ORIGINS = LOOPBACK_HOSTS.map((host) => `http://${host}:*`);
 
 const getLoopbackOriginVariants = (value) => {


### PR DESCRIPTION
## What does this PR do?

`isExternalImageSrc` (`apps/web/lib/image-hosts.ts`) decided whether an `<Image>` src should be rendered `unoptimized` by checking **hostname only**. But `apps/web/next.config.mjs` generates `images.remotePatterns` with a **pinned protocol** per host (`https` for public allowlisted hosts, `http` for loopback hosts), and Next.js matches `remotePatterns` protocol strictly.

This meant a hostname could be allowlisted but requested over the "wrong" protocol, e.g.:
- `http://images.unsplash.com/...` (a public host allowlisted for `https`)
- `https://localhost:3000/...` (a loopback host allowlisted for `http`)

In both cases `isExternalImageSrc` said "optimize" but the Next.js image optimizer would reject the request with a `400`, producing a broken image instead of the intended graceful `unoptimized` fallback.

### Fix

- Moved `LOOPBACK_HOSTS` into `apps/web/lib/optimizable-image-hosts.mjs` (the existing single source of truth also imported by `next.config.mjs`), so the loopback list can't drift between `next.config.mjs` and `lib/image-hosts.ts` again.
- `isExternalImageSrc` now requires the src's **hostname AND protocol** to match what `remotePatterns` generates for that host before treating it as optimizable. Any other combination (arbitrary external URL, or an allowlisted host over the wrong protocol) is rendered `unoptimized`, same as before for genuinely external hosts.

Fixes ENG-2003 (found by CodeRabbit while reviewing #8615; follow-up on the allowlist introduced in #8501 / ENG-1678).

## How should this be tested?

- Added unit tests in `apps/web/lib/image-hosts.test.ts` covering the exact mismatch cases from the ticket:
  - `http://images.unsplash.com/...` → external (protocol mismatches `remotePatterns`' `https`)
  - `https://localhost:3000/...` / `https://127.0.0.1:3000/...` → external (protocol mismatches `remotePatterns`' `http`)
  - `http://localhost:3000/...` / `http://127.0.0.1:3000/...` → still optimizable (unchanged loopback behavior)
- `pnpm test` — all 6408 tests pass (520 test files)
- `pnpm lint` — 0 errors (14 pre-existing warnings unrelated to this change)
- `pnpm build` — succeeds

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none (new to this change)
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch
- [x] My changes don't cause any responsiveness issues (no UI change)

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR (n/a — no UI change)
- [ ] Updated the Formbricks Docs if changes were necessary (n/a — internal fix, no doc-facing behavior)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01BsLYiWibncb2njbezojUdf

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsLYiWibncb2njbezojUdf)_