### PR TITLE
feat(workflows): meter workflow runs like responses [ENG-1936]

### DIFF
--- a/apps/web/lib/organization/service.test.ts
+++ b/apps/web/lib/organization/service.test.ts
@@ -201,6 +201,7 @@ describe("Organization Service", () => {
                 workspaces: IS_FORMBRICKS_CLOUD ? 1 : 3,
                 monthly: {
                   responses: IS_FORMBRICKS_CLOUD ? 250 : 1500,
+                  workflowRuns: null,
                 },
               },
               stripeCustomerId: null,

--- a/apps/web/lib/organization/service.ts
+++ b/apps/web/lib/organization/service.ts
@@ -46,6 +46,8 @@ const getDefaultOrganizationBilling = (): TOrganizationBilling => ({
     workspaces: IS_FORMBRICKS_CLOUD ? 1 : 3,
     monthly: {
       responses: IS_FORMBRICKS_CLOUD ? 250 : 1500,
+      // No included workflow runs by default (ENG-1936); the Scale entitlement grants the volume.
+      workflowRuns: null,
     },
   },
   stripeCustomerId: null,

--- a/apps/web/modules/ee/billing/lib/metering.test.ts
+++ b/apps/web/modules/ee/billing/lib/metering.test.ts
@@ -118,4 +118,68 @@ describe("metering", () => {
       "Failed to record Stripe meter event for response_created"
     );
   });
+
+  describe("recordWorkflowRunCreatedMeterEvent", () => {
+    test("records a workflow_run_created meter event with timestamp", async () => {
+      const { recordWorkflowRunCreatedMeterEvent } = await import("./metering");
+
+      await recordWorkflowRunCreatedMeterEvent({
+        stripeCustomerId: "cus_1",
+        workflowRunId: "wr_1",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+      });
+
+      expect(mocks.meterEventsCreate).toHaveBeenCalledWith({
+        event_name: "workflow_run_created",
+        identifier: "workflow_run_created:wr_1",
+        timestamp: Math.floor(new Date("2026-01-01T00:00:00Z").getTime() / 1000),
+        payload: { stripe_customer_id: "cus_1", value: "1" },
+      });
+    });
+
+    test("omits timestamp when createdAt is null", async () => {
+      const { recordWorkflowRunCreatedMeterEvent } = await import("./metering");
+
+      await recordWorkflowRunCreatedMeterEvent({
+        stripeCustomerId: "cus_1",
+        workflowRunId: "wr_2",
+        createdAt: null,
+      });
+
+      expect(mocks.meterEventsCreate).toHaveBeenCalledWith({
+        event_name: "workflow_run_created",
+        identifier: "workflow_run_created:wr_2",
+        payload: { stripe_customer_id: "cus_1", value: "1" },
+      });
+    });
+
+    test("skips when stripeCustomerId is null", async () => {
+      const { recordWorkflowRunCreatedMeterEvent } = await import("./metering");
+
+      await recordWorkflowRunCreatedMeterEvent({ stripeCustomerId: null, workflowRunId: "wr_3" });
+
+      expect(mocks.meterEventsCreate).not.toHaveBeenCalled();
+    });
+
+    test("skips when not cloud", async () => {
+      mocks.isCloud = false;
+      const { recordWorkflowRunCreatedMeterEvent } = await import("./metering");
+
+      await recordWorkflowRunCreatedMeterEvent({ stripeCustomerId: "cus_1", workflowRunId: "wr_4" });
+
+      expect(mocks.meterEventsCreate).not.toHaveBeenCalled();
+    });
+
+    test("logs warning on error", async () => {
+      mocks.meterEventsCreate.mockRejectedValue(new Error("stripe error"));
+      const { recordWorkflowRunCreatedMeterEvent } = await import("./metering");
+
+      await recordWorkflowRunCreatedMeterEvent({ stripeCustomerId: "cus_1", workflowRunId: "wr_5" });
+
+      expect(mocks.loggerWarn).toHaveBeenCalledWith(
+        { error: expect.any(Error), stripeCustomerId: "cus_1", workflowRunId: "wr_5" },
+        "Failed to record Stripe meter event for workflow_run_created"
+      );
+    });
+  });
 });

--- a/apps/web/modules/ee/billing/lib/metering.ts
+++ b/apps/web/modules/ee/billing/lib/metering.ts
@@ -35,3 +35,41 @@ export const recordResponseCreatedMeterEvent = async (input: {
     }
   }
 };
+
+// Metered like responses (ENG-1936): one meter event per created workflow run. Stripe aggregates
+// events against the workflow-runs meter per customer per billing period and bills the overage
+// beyond the plan's included volume — there is no hard cap here, matching response metering. Dry
+// runs are never metered (the caller excludes them). Cloud-only, fire-and-forget: a failed meter
+// event is logged but never blocks run creation.
+export const recordWorkflowRunCreatedMeterEvent = async (input: {
+  stripeCustomerId: string | null | undefined;
+  workflowRunId: string;
+  createdAt?: Date | string | null;
+}): Promise<void> => {
+  if (IS_FORMBRICKS_CLOUD && stripeClient && input.stripeCustomerId) {
+    try {
+      let createdAtSeconds: number | undefined;
+
+      if (input.createdAt instanceof Date || typeof input.createdAt === "string") {
+        createdAtSeconds = Math.floor(new Date(input.createdAt).getTime() / 1000);
+      }
+
+      await stripeClient.billing.meterEvents.create({
+        event_name: "workflow_run_created",
+        identifier: `workflow_run_created:${input.workflowRunId}`,
+        ...(typeof createdAtSeconds === "number" && Number.isFinite(createdAtSeconds)
+          ? { timestamp: createdAtSeconds }
+          : {}),
+        payload: {
+          stripe_customer_id: input.stripeCustomerId,
+          value: "1",
+        },
+      });
+    } catch (error) {
+      logger.warn(
+        { error, stripeCustomerId: input.stripeCustomerId, workflowRunId: input.workflowRunId },
+        "Failed to record Stripe meter event for workflow_run_created"
+      );
+    }
+  }
+};

--- a/apps/web/modules/ee/billing/lib/organization-billing.test.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.test.ts
@@ -790,6 +790,67 @@ describe("organization-billing", () => {
     expect(mocks.cacheDel).toHaveBeenCalledWith(["billing-cache-key"]);
   });
 
+  test("syncOrganizationBillingFromStripe clears a stale workflowRuns limit when the entitlement is absent (downgrade is not sticky)", async () => {
+    // Previous limits carry the Scale-era included volume; the new subscription has no
+    // workflow-runs entitlement (absence is the normal state on plans without workflows).
+    mocks.prismaOrganizationBillingFindUnique.mockResolvedValue({
+      stripeCustomerId: "cus_1",
+      limits: {
+        workspaces: 3,
+        monthly: {
+          responses: 1500,
+          workflowRuns: 1000,
+        },
+      },
+      usageCycleAnchor: new Date(),
+      stripe: { lastSyncedEventId: null },
+    });
+    mocks.subscriptionsList.mockResolvedValue({
+      data: [
+        {
+          id: "sub_1",
+          status: "active",
+          billing_cycle_anchor: 1739923200,
+          items: {
+            data: [
+              {
+                price: {
+                  metadata: {},
+                  product: { id: "prod_pro", metadata: { formbricks_plan: "pro" } },
+                  recurring: { usage_type: "licensed", interval: "year" },
+                },
+              },
+            ],
+          },
+        },
+      ],
+    });
+    mocks.entitlementsList.mockResolvedValue({
+      data: [
+        { id: "ent_0", lookup_key: "workspace-limit-5" },
+        { id: "ent_00", lookup_key: "responses-included-2000" },
+      ],
+      has_more: false,
+    });
+
+    const result = await syncOrganizationBillingFromStripe("org_1", { id: "evt_new", created: 1739923300 });
+
+    expect(mocks.prismaOrganizationBillingUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          limits: {
+            workspaces: 5,
+            monthly: {
+              responses: 2000,
+              workflowRuns: null,
+            },
+          },
+        }),
+      })
+    );
+    expect(result?.limits?.monthly?.workflowRuns).toBeNull();
+  });
+
   test("createPaidPlanCheckoutSession rejects mixed-interval yearly checkout", async () => {
     await expect(
       createPaidPlanCheckoutSession({

--- a/apps/web/modules/ee/billing/lib/organization-billing.test.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.test.ts
@@ -742,6 +742,7 @@ describe("organization-billing", () => {
       data: [
         { id: "ent_0", lookup_key: "workspace-limit-5" },
         { id: "ent_00", lookup_key: "responses-included-2000" },
+        { id: "ent_000", lookup_key: "workflow-runs-included-1000" },
         { id: "ent_1", lookup_key: "custom-links-in-surveys" },
         { id: "ent_2", lookup_key: "custom-links-in-surveys" },
         { id: "ent_3", lookup_key: null },
@@ -759,12 +760,18 @@ describe("organization-billing", () => {
           workspaces: 5,
           monthly: {
             responses: 2000,
+            workflowRuns: 1000,
           },
         },
         stripe: expect.objectContaining({
           plan: "pro",
           subscriptionId: "sub_1",
-          features: ["workspace-limit-5", "responses-included-2000", "custom-links-in-surveys"],
+          features: [
+            "workspace-limit-5",
+            "responses-included-2000",
+            "workflow-runs-included-1000",
+            "custom-links-in-surveys",
+          ],
           lastSyncedEventId: "evt_new",
           lastStripeEventCreatedAt: expect.any(String),
           lastSyncedAt: expect.any(String),
@@ -776,8 +783,10 @@ describe("organization-billing", () => {
     expect(result?.stripe?.features).toEqual([
       "workspace-limit-5",
       "responses-included-2000",
+      "workflow-runs-included-1000",
       "custom-links-in-surveys",
     ]);
+    expect(result?.limits?.monthly?.workflowRuns).toBe(1000);
     expect(mocks.cacheDel).toHaveBeenCalledWith(["billing-cache-key"]);
   });
 
@@ -1634,6 +1643,7 @@ describe("organization-billing", () => {
           workspaces: 5,
           monthly: {
             responses: null,
+            workflowRuns: null,
           },
         },
         stripe: expect.objectContaining({
@@ -1722,6 +1732,7 @@ describe("organization-billing", () => {
           workspaces: 3,
           monthly: {
             responses: 1500,
+            workflowRuns: null,
           },
         },
         stripe: expect.objectContaining({

--- a/apps/web/modules/ee/billing/lib/organization-billing.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.ts
@@ -52,6 +52,9 @@ export const getDefaultOrganizationBilling = (): TOrganizationBilling => ({
     workspaces: IS_FORMBRICKS_CLOUD ? 1 : 3,
     monthly: {
       responses: IS_FORMBRICKS_CLOUD ? 250 : 1500,
+      // No included workflow runs by default — the Scale entitlement grants the volume, and
+      // self-hosted gates workflows by the boolean license feature rather than metering.
+      workflowRuns: null,
     },
   },
   stripeCustomerId: null,
@@ -1221,6 +1224,10 @@ const resolveEntitlementDrivenLimits = (
 ) => {
   const workspaceLimitFromEntitlements = parseEntitlementLimit(featureLookupKeys, "workspace-limit-");
   const responsesIncludedFromEntitlements = parseEntitlementLimit(featureLookupKeys, "responses-included-");
+  const workflowRunsIncludedFromEntitlements = parseEntitlementLimit(
+    featureLookupKeys,
+    "workflow-runs-included-"
+  );
 
   const workspacesLimit =
     workspaceLimitFromEntitlements === undefined
@@ -1246,10 +1253,18 @@ const resolveEntitlementDrivenLimits = (
     );
   }
 
+  // Absent workflow-runs entitlement preserves the previous value (or null). No warning: unlike
+  // responses, workflow metering is opt-in per plan, so most subscriptions legitimately have none.
+  const workflowRunsIncludedLimit =
+    workflowRunsIncludedFromEntitlements === undefined
+      ? (previousLimits?.monthly?.workflowRuns ?? null)
+      : workflowRunsIncludedFromEntitlements;
+
   return {
     workspaces: workspacesLimit,
     monthly: {
       responses: responsesIncludedLimit,
+      workflowRuns: workflowRunsIncludedLimit,
     },
   };
 };

--- a/apps/web/modules/ee/billing/lib/organization-billing.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.ts
@@ -1253,12 +1253,12 @@ const resolveEntitlementDrivenLimits = (
     );
   }
 
-  // Absent workflow-runs entitlement preserves the previous value (or null). No warning: unlike
-  // responses, workflow metering is opt-in per plan, so most subscriptions legitimately have none.
-  const workflowRunsIncludedLimit =
-    workflowRunsIncludedFromEntitlements === undefined
-      ? (previousLimits?.monthly?.workflowRuns ?? null)
-      : workflowRunsIncludedFromEntitlements;
+  // Absent workflow-runs entitlement resolves to null, NOT the previous value: unlike workspaces/
+  // responses (present on every plan, so absence signals a bad read worth preserving against), this
+  // entitlement only exists on plans with workflows — absence is the normal state, and preserving
+  // would keep a stale included volume forever after a downgrade. A transient bad read self-heals
+  // on the next sync; `unlimited` still parses to null upstream.
+  const workflowRunsIncludedLimit = workflowRunsIncludedFromEntitlements ?? null;
 
   return {
     workspaces: workspacesLimit,

--- a/apps/web/modules/ee/billing/lib/stripe-billing-catalog.test.ts
+++ b/apps/web/modules/ee/billing/lib/stripe-billing-catalog.test.ts
@@ -198,6 +198,53 @@ describe("stripe-billing-catalog", () => {
   );
 
   test(
+    "excludes a metered price tagged with a non-responses kind (e.g. workflow_runs) so it does not collide with responses",
+    async () => {
+      // A second metered price on Scale, tagged workflow_runs (ENG-1936). Without the getPriceKind
+      // guard it would fall through usage_type=metered -> "responses" and produce two matches for
+      // scale/responses/monthly, breaking the billing page.
+      const workflowRunsPrice = {
+        id: "price_scale_workflow_runs",
+        active: true,
+        currency: "usd",
+        unit_amount: 0,
+        tiers: RESPONSE_PRICE_TIERS,
+        tiers_mode: "graduated",
+        metadata: {
+          formbricks_plan: "scale",
+          formbricks_price_kind: "workflow_runs",
+          formbricks_interval: "monthly",
+        },
+        recurring: { usage_type: "metered", interval: "month" },
+        product: { id: "prod_scale", active: true, metadata: { formbricks_plan: "scale" } },
+      };
+
+      mocks.pricesList.mockResolvedValue({
+        data: [
+          createPrice({ id: "price_hobby_monthly", plan: "hobby", kind: "base", interval: "monthly" }),
+          createPrice({ id: "price_pro_monthly", plan: "pro", kind: "base", interval: "monthly" }),
+          createPrice({ id: "price_pro_yearly", plan: "pro", kind: "base", interval: "yearly" }),
+          createPrice({ id: "price_pro_responses", plan: "pro", kind: "responses", interval: "monthly" }),
+          createPrice({ id: "price_scale_monthly", plan: "scale", kind: "base", interval: "monthly" }),
+          createPrice({ id: "price_scale_yearly", plan: "scale", kind: "base", interval: "yearly" }),
+          createPrice({ id: "price_scale_responses", plan: "scale", kind: "responses", interval: "monthly" }),
+          workflowRunsPrice,
+        ],
+        has_more: false,
+      });
+
+      const { getCatalogItemsForPlan } = await import("./stripe-billing-catalog");
+
+      // Resolves without throwing "found 2", and the workflow_runs price is not part of the catalog.
+      await expect(getCatalogItemsForPlan("scale", "monthly")).resolves.toEqual([
+        { price: "price_scale_monthly", quantity: 1 },
+        { price: "price_scale_responses" },
+      ]);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  test(
     "fails fast when the catalog is incomplete",
     async () => {
       mocks.pricesList.mockResolvedValue({

--- a/apps/web/modules/ee/billing/lib/stripe-billing-catalog.ts
+++ b/apps/web/modules/ee/billing/lib/stripe-billing-catalog.ts
@@ -118,6 +118,14 @@ const getPriceKind = (price: Stripe.Price): TStripePriceKind | null => {
     return metadataKind;
   }
 
+  // A metered price explicitly tagged with a different kind (e.g. "workflow_runs") is a separate
+  // metered product, not part of the base/responses plan catalog. Exclude it here so the usage_type
+  // fallback below can't misclassify it as "responses" and collide with the real responses price on
+  // the same plan/interval (ENG-1936). Full catalog wiring for such kinds is added separately.
+  if (metadataKind) {
+    return null;
+  }
+
   if (price.recurring?.usage_type === "licensed") {
     return "base";
   }

--- a/apps/web/modules/ee/license-check/lib/utils.test.ts
+++ b/apps/web/modules/ee/license-check/lib/utils.test.ts
@@ -85,6 +85,7 @@ const defaultEntitlementsContext: TOrganizationEntitlementsContext = {
   limits: {
     workspaces: 3,
     monthlyResponses: null,
+    monthlyWorkflowRuns: null,
   },
   licenseStatus: "active",
   licenseFeatures: defaultFeatures,

--- a/apps/web/modules/ee/workflows/lib/runner/enqueue-response-completed-runs.test.ts
+++ b/apps/web/modules/ee/workflows/lib/runner/enqueue-response-completed-runs.test.ts
@@ -10,6 +10,9 @@ const { findMany, create, findUnique } = vi.hoisted(() => ({
 const { warn, error, info } = vi.hoisted(() => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() }));
 const { markDispatched } = vi.hoisted(() => ({ markDispatched: vi.fn() }));
 const { getIsWorkflowsEnabled } = vi.hoisted(() => ({ getIsWorkflowsEnabled: vi.fn() }));
+const { recordWorkflowRunCreatedMeterEvent } = vi.hoisted(() => ({
+  recordWorkflowRunCreatedMeterEvent: vi.fn(),
+}));
 
 vi.mock("@formbricks/database", () => ({
   prisma: { workflow: { findMany }, workflowRun: { create, findUnique } },
@@ -17,6 +20,7 @@ vi.mock("@formbricks/database", () => ({
 vi.mock("@formbricks/logger", () => ({ logger: { warn, error, info } }));
 vi.mock("./mark-dispatched", () => ({ markWorkflowRunDispatched: markDispatched }));
 vi.mock("@/modules/ee/license-check/lib/utils", () => ({ getIsWorkflowsEnabled }));
+vi.mock("@/modules/ee/billing/lib/metering", () => ({ recordWorkflowRunCreatedMeterEvent }));
 
 const workspaceId = "cm9zr4mps000008l8btfy1vtz";
 const organizationId = "cm9zr4org000008l8btfy1org";
@@ -59,6 +63,8 @@ beforeEach(() => {
   dispatch.mockResolvedValue(undefined);
   // Entitled by default; the entitlement-skip tests flip this off explicitly.
   getIsWorkflowsEnabled.mockResolvedValue(true);
+  // The real helper never rejects (it owns its errors); the enqueue awaits the collected promises.
+  recordWorkflowRunCreatedMeterEvent.mockResolvedValue(undefined);
 });
 
 describe("enqueueResponseCompletedWorkflowRuns", () => {
@@ -168,6 +174,47 @@ describe("enqueueResponseCompletedWorkflowRuns", () => {
 
     expect(dispatch).toHaveBeenCalledWith({ workflowRunId: "existing_run", workflowId: "wf_1", workspaceId });
     expect(error).not.toHaveBeenCalled();
+  });
+
+  test("meters a newly created run exactly once, with the run id and its persisted createdAt", async () => {
+    const runCreatedAt = new Date("2026-06-12T09:30:02.000Z");
+    findMany.mockResolvedValue([enabledWorkflow("wf_1", "ver_1")]);
+    create.mockResolvedValue({ id: "run_1", createdAt: runCreatedAt });
+
+    await enqueueResponseCompletedWorkflowRuns({
+      response,
+      workspaceId,
+      organizationId,
+      stripeCustomerId: "cus_123",
+      dispatch,
+    });
+
+    // Timestamped from the run's own createdAt (not response.updatedAt) so usage lands in the
+    // correct billing period.
+    expect(recordWorkflowRunCreatedMeterEvent).toHaveBeenCalledTimes(1);
+    expect(recordWorkflowRunCreatedMeterEvent).toHaveBeenCalledWith({
+      stripeCustomerId: "cus_123",
+      workflowRunId: "run_1",
+      createdAt: runCreatedAt,
+    });
+  });
+
+  test("does not meter a unique-constraint replay that re-found the existing run", async () => {
+    findMany.mockResolvedValue([enabledWorkflow("wf_1", "ver_1")]);
+    create.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+        code: "P2002",
+        clientVersion: "test",
+      })
+    );
+    findUnique.mockResolvedValue({ id: "existing_run", createdAt: new Date("2026-06-11T08:00:00.000Z") });
+
+    await run();
+
+    // The replayed run still dispatches, but is never re-metered: Stripe dedups a meter identifier
+    // for only ~24h, so re-emitting on a later replay would double-bill the same run (ENG-1936).
+    expect(dispatch).toHaveBeenCalledWith({ workflowRunId: "existing_run", workflowId: "wf_1", workspaceId });
+    expect(recordWorkflowRunCreatedMeterEvent).not.toHaveBeenCalled();
   });
 
   test("on a unique violation with no findable existing run, surfaces an error and does not dispatch", async () => {

--- a/apps/web/modules/ee/workflows/lib/runner/enqueue-response-completed-runs.ts
+++ b/apps/web/modules/ee/workflows/lib/runner/enqueue-response-completed-runs.ts
@@ -4,6 +4,7 @@ import { PrismaErrorType } from "@formbricks/database/types/error";
 import { logger } from "@formbricks/logger";
 import { type TWorkflowTriggerRunPayload, ZWorkflowTriggerRunPayload } from "@formbricks/workflows";
 import { isDatabasePoolExhaustionError } from "@/lib/jobs/pool-exhaustion";
+import { recordWorkflowRunCreatedMeterEvent } from "@/modules/ee/billing/lib/metering";
 import { getIsWorkflowsEnabled } from "@/modules/ee/license-check/lib/utils";
 import { type DispatchWorkflowRun } from "./dispatch";
 import { markWorkflowRunDispatched } from "./mark-dispatched";
@@ -28,6 +29,9 @@ interface EnqueueResponseCompletedWorkflowRunsInput {
   response: RunnerResponse;
   workspaceId: string;
   organizationId: string;
+  // Passed through for workflow-run metering (ENG-1936). Null/absent off Formbricks Cloud or when the
+  // org has no Stripe customer — the meter helper no-ops in those cases.
+  stripeCustomerId?: string | null;
   dispatch: DispatchWorkflowRun;
   logContext?: Record<string, unknown>;
 }
@@ -160,6 +164,7 @@ const createAndDispatchWorkflowRun = async ({
   match,
   response,
   workspaceId,
+  stripeCustomerId,
   triggerPayload,
   dispatch,
   logContext,
@@ -167,6 +172,7 @@ const createAndDispatchWorkflowRun = async ({
   match: WorkflowMatch;
   response: RunnerResponse;
   workspaceId: string;
+  stripeCustomerId?: string | null;
   triggerPayload: TWorkflowTriggerRunPayload;
   dispatch: DispatchWorkflowRun;
   logContext?: Record<string, unknown>;
@@ -175,6 +181,18 @@ const createAndDispatchWorkflowRun = async ({
   if (!workflowRunId) {
     return;
   }
+
+  // Meter the run as soon as it is persisted — a persisted run is billable regardless of whether
+  // dispatch later succeeds, matching how responses meter at creation (ENG-1936). These runs are
+  // always real (isDryRun: false); dry runs are metered nowhere. Cloud-only and fire-and-forget:
+  // the helper swallows its own errors, so metering never blocks or fails run creation. Keyed on the
+  // stable workflowRunId, so a pipeline retry that re-finds the same run re-emits an identical
+  // (deduped) meter event.
+  await recordWorkflowRunCreatedMeterEvent({
+    stripeCustomerId,
+    workflowRunId,
+    createdAt: response.updatedAt,
+  });
 
   try {
     await dispatch({ workflowRunId, workflowId: match.workflowId, workspaceId });
@@ -224,6 +242,7 @@ export const enqueueResponseCompletedWorkflowRuns = async ({
   response,
   workspaceId,
   organizationId,
+  stripeCustomerId,
   dispatch,
   logContext,
 }: EnqueueResponseCompletedWorkflowRunsInput): Promise<void> => {
@@ -271,6 +290,7 @@ export const enqueueResponseCompletedWorkflowRuns = async ({
       match,
       response,
       workspaceId,
+      stripeCustomerId,
       triggerPayload,
       dispatch,
       logContext,

--- a/apps/web/modules/ee/workflows/lib/runner/enqueue-response-completed-runs.ts
+++ b/apps/web/modules/ee/workflows/lib/runner/enqueue-response-completed-runs.ts
@@ -105,7 +105,7 @@ const persistQueuedRun = async ({
   workspaceId: string;
   triggerPayload: TWorkflowTriggerRunPayload;
   logContext?: Record<string, unknown>;
-}): Promise<string | null> => {
+}): Promise<{ id: string; createdAt: Date; isNew: boolean } | null> => {
   try {
     const run = await prisma.workflowRun.create({
       data: {
@@ -121,16 +121,19 @@ const persistQueuedRun = async ({
         idempotencyKey: response.id,
         triggerPayload,
       },
-      select: { id: true },
+      select: { id: true, createdAt: true },
     });
-    return run.id;
+    return { id: run.id, createdAt: run.createdAt, isNew: true };
   } catch (error) {
     if (isUniqueConstraintError(error)) {
       const existing = await prisma.workflowRun.findUnique({
         where: { workflowId_idempotencyKey: { workflowId: match.workflowId, idempotencyKey: response.id } },
-        select: { id: true },
+        select: { id: true, createdAt: true },
       });
-      if (existing) return existing.id;
+      // isNew: false — a replayed enqueue re-found an already-persisted run. It must NOT be metered
+      // again: Stripe only dedups a meter identifier for ~24h, so a retry beyond that window would
+      // double-bill the same run (ENG-1936).
+      if (existing) return { id: existing.id, createdAt: existing.createdAt, isNew: false };
       // The unique violation says a run exists, but we can't find it by its idempotency key — a
       // contradictory state with no run id to dispatch. Surface it rather than silently drop it.
       logger.error(
@@ -177,26 +180,30 @@ const createAndDispatchWorkflowRun = async ({
   dispatch: DispatchWorkflowRun;
   logContext?: Record<string, unknown>;
 }): Promise<void> => {
-  const workflowRunId = await persistQueuedRun({ match, response, workspaceId, triggerPayload, logContext });
-  if (!workflowRunId) {
+  const persisted = await persistQueuedRun({ match, response, workspaceId, triggerPayload, logContext });
+  if (!persisted) {
     return;
   }
+  const { id: workflowRunId, createdAt, isNew } = persisted;
 
-  // Meter the run as soon as it is persisted — a persisted run is billable regardless of whether
-  // dispatch later succeeds, matching how responses meter at creation (ENG-1936). These runs are
-  // always real (isDryRun: false); dry runs are metered nowhere. Cloud-only and fire-and-forget:
-  // the helper swallows its own errors, so metering never blocks or fails run creation. Keyed on the
-  // stable workflowRunId, so a pipeline retry that re-finds the same run re-emits an identical
-  // (deduped) meter event.
+  // Meter the run once, only when it is newly created (isNew) — a persisted run is billable
+  // regardless of whether dispatch later succeeds, matching how responses meter at creation
+  // (ENG-1936). A replayed enqueue that re-found an existing run is skipped so it can't double-bill
+  // past Stripe's ~24h identifier-dedup window. These runs are always real (isDryRun: false); dry
+  // runs are metered nowhere. Timestamped from the run's own createdAt so usage lands in the correct
+  // billing period (response.updatedAt could be stale/older than Stripe's 35-day accept window).
   //
-  // Deliberately NOT awaited: awaiting would add a Stripe round-trip to — and, on a Stripe hang, stall
-  // (the client has no explicit timeout) — the serialized per-match dispatch loop below. The helper
-  // owns its errors, so voiding cannot surface an unhandled rejection.
-  void recordWorkflowRunCreatedMeterEvent({
-    stripeCustomerId,
-    workflowRunId,
-    createdAt: response.updatedAt,
-  });
+  // Cloud-only and fire-and-forget: the helper swallows its own errors, so metering never blocks or
+  // fails run creation. Deliberately NOT awaited — awaiting would add a Stripe round-trip to (and, on
+  // a Stripe hang, stall) the serialized per-match dispatch loop below. The helper owns its errors,
+  // so voiding cannot surface an unhandled rejection.
+  if (isNew) {
+    void recordWorkflowRunCreatedMeterEvent({
+      stripeCustomerId,
+      workflowRunId,
+      createdAt,
+    });
+  }
 
   try {
     await dispatch({ workflowRunId, workflowId: match.workflowId, workspaceId });

--- a/apps/web/modules/ee/workflows/lib/runner/enqueue-response-completed-runs.ts
+++ b/apps/web/modules/ee/workflows/lib/runner/enqueue-response-completed-runs.ts
@@ -188,7 +188,11 @@ const createAndDispatchWorkflowRun = async ({
   // the helper swallows its own errors, so metering never blocks or fails run creation. Keyed on the
   // stable workflowRunId, so a pipeline retry that re-finds the same run re-emits an identical
   // (deduped) meter event.
-  await recordWorkflowRunCreatedMeterEvent({
+  //
+  // Deliberately NOT awaited: awaiting would add a Stripe round-trip to — and, on a Stripe hang, stall
+  // (the client has no explicit timeout) — the serialized per-match dispatch loop below. The helper
+  // owns its errors, so voiding cannot surface an unhandled rejection.
+  void recordWorkflowRunCreatedMeterEvent({
     stripeCustomerId,
     workflowRunId,
     createdAt: response.updatedAt,

--- a/apps/web/modules/ee/workflows/lib/runner/enqueue-response-completed-runs.ts
+++ b/apps/web/modules/ee/workflows/lib/runner/enqueue-response-completed-runs.ts
@@ -170,6 +170,7 @@ const createAndDispatchWorkflowRun = async ({
   stripeCustomerId,
   triggerPayload,
   dispatch,
+  meterEvents,
   logContext,
 }: {
   match: WorkflowMatch;
@@ -178,6 +179,7 @@ const createAndDispatchWorkflowRun = async ({
   stripeCustomerId?: string | null;
   triggerPayload: TWorkflowTriggerRunPayload;
   dispatch: DispatchWorkflowRun;
+  meterEvents: Promise<void>[];
   logContext?: Record<string, unknown>;
 }): Promise<void> => {
   const persisted = await persistQueuedRun({ match, response, workspaceId, triggerPayload, logContext });
@@ -193,16 +195,19 @@ const createAndDispatchWorkflowRun = async ({
   // runs are metered nowhere. Timestamped from the run's own createdAt so usage lands in the correct
   // billing period (response.updatedAt could be stale/older than Stripe's 35-day accept window).
   //
-  // Cloud-only and fire-and-forget: the helper swallows its own errors, so metering never blocks or
-  // fails run creation. Deliberately NOT awaited — awaiting would add a Stripe round-trip to (and, on
-  // a Stripe hang, stall) the serialized per-match dispatch loop below. The helper owns its errors,
-  // so voiding cannot surface an unhandled rejection.
+  // Cloud-only; the helper swallows its own errors, so metering never blocks or fails run creation.
+  // The Stripe call starts here but is awaited by the caller only after the dispatch loop: it never
+  // adds a round-trip to (or, on a Stripe hang, stalls) the serialized per-match dispatch below, yet
+  // it is not dropped mid-flight if the worker exits right after the job completes — isNew is
+  // consumed on creation, so a dropped event would leave the run permanently unbilled.
   if (isNew) {
-    void recordWorkflowRunCreatedMeterEvent({
-      stripeCustomerId,
-      workflowRunId,
-      createdAt,
-    });
+    meterEvents.push(
+      recordWorkflowRunCreatedMeterEvent({
+        stripeCustomerId,
+        workflowRunId,
+        createdAt,
+      })
+    );
   }
 
   try {
@@ -296,6 +301,7 @@ export const enqueueResponseCompletedWorkflowRuns = async ({
     triggeredAt: response.updatedAt.toISOString(),
   });
 
+  const meterEvents: Promise<void>[] = [];
   for (const match of matches) {
     await createAndDispatchWorkflowRun({
       match,
@@ -304,7 +310,13 @@ export const enqueueResponseCompletedWorkflowRuns = async ({
       stripeCustomerId,
       triggerPayload,
       dispatch,
+      meterEvents,
       logContext,
     });
   }
+
+  // Meter events ran concurrently with the dispatch loop; settle them before returning so the job
+  // holds the worker alive until every billed run is actually reported (parity with the awaited
+  // response meter event). The helper owns its errors, so this only waits — it can never throw.
+  await Promise.all(meterEvents);
 };

--- a/apps/web/modules/entitlements/lib/checks.test.ts
+++ b/apps/web/modules/entitlements/lib/checks.test.ts
@@ -27,7 +27,7 @@ const baseContext: TOrganizationEntitlementsContext = {
   organizationId: "org1",
   source: "cloud_stripe",
   features: ["rbac", "spam-protection"],
-  limits: { workspaces: 3, monthlyResponses: 500 },
+  limits: { workspaces: 3, monthlyResponses: 500, monthlyWorkflowRuns: null },
   licenseStatus: "no-license",
   licenseFeatures: null,
   stripeCustomerId: "cus_1",
@@ -192,6 +192,7 @@ describe("getOrganizationEntitlementLimits", () => {
     expect(await getOrganizationEntitlementLimits("org1")).toEqual({
       workspaces: 3,
       monthlyResponses: 500,
+      monthlyWorkflowRuns: null,
     });
   });
 });

--- a/apps/web/modules/entitlements/lib/cloud-provider.test.ts
+++ b/apps/web/modules/entitlements/lib/cloud-provider.test.ts
@@ -13,7 +13,7 @@ vi.mock("@formbricks/logger", () => ({
 vi.mock("@/modules/ee/billing/lib/organization-billing", () => ({
   getOrganizationBillingWithReadThroughSync: vi.fn(),
   getDefaultOrganizationBilling: () => ({
-    limits: { workspaces: 1, monthly: { responses: 250 } },
+    limits: { workspaces: 1, monthly: { responses: 250, workflowRuns: null } },
     stripeCustomerId: null,
     usageCycleAnchor: null,
   }),
@@ -32,6 +32,7 @@ const createBillingFixture = (overrides: Partial<TOrganizationBilling> = {}): TO
     workspaces: null,
     monthly: {
       responses: null,
+      workflowRuns: null,
     },
   },
   usageCycleAnchor: null,
@@ -67,7 +68,7 @@ describe("getCloudOrganizationEntitlementsContext", () => {
     mockGetBilling.mockResolvedValue(
       createBillingFixture({
         stripeCustomerId: "cus_1",
-        limits: { workspaces: 5, monthly: { responses: 1000 } },
+        limits: { workspaces: 5, monthly: { responses: 1000, workflowRuns: null } },
         usageCycleAnchor,
         stripe: { features: ["rbac", "spam-protection"], plan: "pro" },
       })
@@ -133,7 +134,7 @@ describe("getCloudOrganizationEntitlementsContext", () => {
     mockGetBilling.mockResolvedValue(
       createBillingFixture({
         stripeCustomerId: "cus_1",
-        limits: { workspaces: 5, monthly: { responses: 1000 } },
+        limits: { workspaces: 5, monthly: { responses: 1000, workflowRuns: null } },
         stripe: { features: ["follow-ups"], subscriptionStatus: "trialing" },
       })
     );

--- a/apps/web/modules/entitlements/lib/cloud-provider.test.ts
+++ b/apps/web/modules/entitlements/lib/cloud-provider.test.ts
@@ -53,7 +53,7 @@ describe("getCloudOrganizationEntitlementsContext", () => {
       organizationId: "org1",
       source: "cloud_stripe",
       features: [],
-      limits: { workspaces: 1, monthlyResponses: 250 },
+      limits: { workspaces: 1, monthlyResponses: 250, monthlyWorkflowRuns: null },
       licenseStatus: "no-license",
       licenseFeatures: null,
       stripeCustomerId: null,
@@ -80,7 +80,7 @@ describe("getCloudOrganizationEntitlementsContext", () => {
       organizationId: "org1",
       source: "cloud_stripe",
       features: ["rbac", "spam-protection"],
-      limits: { workspaces: 5, monthlyResponses: 1000 },
+      limits: { workspaces: 5, monthlyResponses: 1000, monthlyWorkflowRuns: null },
       licenseStatus: "no-license",
       licenseFeatures: null,
       stripeCustomerId: "cus_1",
@@ -96,7 +96,7 @@ describe("getCloudOrganizationEntitlementsContext", () => {
     const result = await getCloudOrganizationEntitlementsContext("org1");
 
     expect(result.features).toEqual([]);
-    expect(result.limits).toEqual({ workspaces: null, monthlyResponses: null });
+    expect(result.limits).toEqual({ workspaces: null, monthlyResponses: null, monthlyWorkflowRuns: null });
     expect(result.stripeCustomerId).toBeNull();
     expect(result.subscriptionStatus).toBeNull();
     expect(result.usageCycleAnchor).toBeNull();

--- a/apps/web/modules/entitlements/lib/cloud-provider.ts
+++ b/apps/web/modules/entitlements/lib/cloud-provider.ts
@@ -32,6 +32,7 @@ export const getCloudOrganizationEntitlementsContext = async (
       limits: {
         workspaces: defaultBilling.limits?.workspaces ?? null,
         monthlyResponses: defaultBilling.limits?.monthly?.responses ?? null,
+        monthlyWorkflowRuns: defaultBilling.limits?.monthly?.workflowRuns ?? null,
       },
       licenseStatus: license.status,
       licenseFeatures: license.features,
@@ -48,6 +49,7 @@ export const getCloudOrganizationEntitlementsContext = async (
     limits: {
       workspaces: billing.limits?.workspaces ?? null,
       monthlyResponses: billing.limits?.monthly?.responses ?? null,
+      monthlyWorkflowRuns: billing.limits?.monthly?.workflowRuns ?? null,
     },
     licenseStatus: license.status,
     licenseFeatures: license.features,

--- a/apps/web/modules/entitlements/lib/self-hosted-provider.test.ts
+++ b/apps/web/modules/entitlements/lib/self-hosted-provider.test.ts
@@ -39,7 +39,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
       organizationId: "org1",
       source: "self_hosted_license",
       features: [],
-      limits: { workspaces: 3, monthlyResponses: null },
+      limits: { workspaces: 3, monthlyResponses: null, monthlyWorkflowRuns: null },
       licenseStatus: "no-license",
       licenseFeatures: null,
       stripeCustomerId: null,

--- a/apps/web/modules/entitlements/lib/self-hosted-provider.ts
+++ b/apps/web/modules/entitlements/lib/self-hosted-provider.ts
@@ -63,6 +63,8 @@ export const getSelfHostedOrganizationEntitlementsContext = async (
       workspaces: license.active ? (license.features?.workspaces ?? 3) : 3,
       // Self-hosted response limits are not license-server-managed today.
       monthlyResponses: null,
+      // Self-hosted workflows are gated by the boolean license feature, not metered (ENG-1936).
+      monthlyWorkflowRuns: null,
     },
     licenseStatus: license.status,
     licenseFeatures: license.features,

--- a/apps/web/modules/entitlements/lib/types.ts
+++ b/apps/web/modules/entitlements/lib/types.ts
@@ -26,6 +26,9 @@ export const isEntitlementFeature = (feature: string): feature is TEntitlementFe
 export type TEntitlementLimits = {
   workspaces: number | null;
   monthlyResponses: number | null;
+  // Included monthly workflow runs (ENG-1936). null = not metered / unlimited (e.g. self-hosted,
+  // where workflows are gated by the boolean license feature rather than metered).
+  monthlyWorkflowRuns: number | null;
 };
 
 export type TOrganizationEntitlementsContext = {

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
@@ -607,12 +607,14 @@ const runResponseFinishedSideEffects = async ({
   data,
   logContext,
   organizationId,
+  stripeCustomerId,
   survey,
   workspaceId,
 }: {
   data: TResponsePipelineJobData;
   logContext: ReturnType<typeof getPipelineLogContext>;
   organizationId: string;
+  stripeCustomerId: string | null | undefined;
   survey: TPipelineSurvey;
   workspaceId: string;
 }) => {
@@ -684,6 +686,7 @@ const runResponseFinishedSideEffects = async ({
       response: data.response,
       workspaceId,
       organizationId,
+      stripeCustomerId,
       dispatch: dispatchWorkflowRunViaJobs,
       logContext,
     });
@@ -797,6 +800,7 @@ export const processResponsePipelineJob: JobHandler<TResponsePipelineJobData> = 
         data,
         logContext,
         organizationId: organization.id,
+        stripeCustomerId: organization.billing?.stripeCustomerId,
         survey,
         workspaceId: data.workspaceId,
       });

--- a/packages/types/organizations.ts
+++ b/packages/types/organizations.ts
@@ -49,13 +49,15 @@ export const ZOrganizationStripeBilling = z.object({
 });
 export type TOrganizationStripeBilling = z.infer<typeof ZOrganizationStripeBilling>;
 
-// responses / workflowRuns can be null to support the unlimited plan. workflowRuns defaults to null
-// so older billing rows written before workflows became metered (ENG-1936) still parse.
+// responses / workflowRuns can be null to support the unlimited plan. workflowRuns is optional (not
+// yet present on billing rows written before workflows became metered, ENG-1936); consumers treat an
+// absent value as "not metered" (null). Kept optional rather than defaulted so the field stays
+// absent from the inferred type unless explicitly set, avoiding churn across every limits literal.
 export const ZOrganizationBillingPlanLimits = z.object({
   workspaces: z.number().nullable(),
   monthly: z.object({
     responses: z.number().nullable(),
-    workflowRuns: z.number().nullable().default(null),
+    workflowRuns: z.number().nullable().optional(),
   }),
 });
 

--- a/packages/types/organizations.ts
+++ b/packages/types/organizations.ts
@@ -49,11 +49,13 @@ export const ZOrganizationStripeBilling = z.object({
 });
 export type TOrganizationStripeBilling = z.infer<typeof ZOrganizationStripeBilling>;
 
-// responses can be null to support the unlimited plan
+// responses / workflowRuns can be null to support the unlimited plan. workflowRuns defaults to null
+// so older billing rows written before workflows became metered (ENG-1936) still parse.
 export const ZOrganizationBillingPlanLimits = z.object({
   workspaces: z.number().nullable(),
   monthly: z.object({
     responses: z.number().nullable(),
+    workflowRuns: z.number().nullable().default(null),
   }),
 });
 
@@ -65,6 +67,7 @@ export const ZOrganizationBilling = z.object({
     workspaces: 3,
     monthly: {
       responses: 1500,
+      workflowRuns: null,
     },
   }),
   usageCycleAnchor: z.date().nullable(),


### PR DESCRIPTION
## What does this PR do?

Part of **[ENG-1936](https://linear.app/formbricks/issue/ENG-1936)** — Workflows is priced **metered like Responses** (Scale plan, 1000 runs/mo included, per-run price ~30% above responses), not a simple on/off flag.

This PR adds the **app-side metering plumbing** for workflow runs, mirroring the responses pattern end-to-end. The boolean entitlement (`getIsWorkflowsEnabled`) stays as the *availability* gate (Scale plan / EE license); this adds *usage billing* on top.

### Decisions (confirmed)
- **Meter on run creation** (when the `WorkflowRun` row is persisted), excluding dry runs — exact parity with response metering.
- **No hard cap** — Stripe bills overage beyond the included volume; the limit is display-only (parity with responses, which has no enforcement).
- **Self-hosted = flag-only** — not metered, gated solely by the boolean `workflows` license feature (ee repo PR #129). Metering is Cloud/Stripe-only.

### Changes (all mirror the responses template)
- `metering.ts` — `recordWorkflowRunCreatedMeterEvent`: posts a `workflow_run_created` Stripe meter event (`identifier: workflow_run_created:<runId>`, `value: "1"`). Cloud-only, never throws (failures are logged, run creation is never blocked), deduped on the stable run id.
- `enqueue-response-completed-runs.ts` — emits the meter event when a run is persisted (before dispatch; persisted = billable), **new runs only** — a unique-constraint replay re-dispatches without re-metering — timestamped from the run's persisted `createdAt`. Meter promises are collected and settled after the dispatch loop (review): no extra round-trip inside the serialized dispatch, but the job doesn't finish until every billed run is reported, so a worker exit can't drop an in-flight event. `stripeCustomerId` threaded in from the pipeline.
- `process-response-pipeline-job.ts` — passes `organization.billing.stripeCustomerId` into the workflow runner.
- `organizations.ts` — `limits.monthly.workflowRuns` (nullable, defaults null so existing billing rows still parse).
- `organization-billing.ts` — resolves `workflowRuns` from the `workflow-runs-included-<n>` Stripe entitlement (`unlimited` → null). An absent entitlement resolves to **null, not the previous value** (review): the key only exists on plans with workflows, so preserving would keep a stale included volume forever after a downgrade.
- entitlements `types.ts` / `cloud-provider.ts` / `self-hosted-provider.ts` — surface `monthlyWorkflowRuns` on the context.

### Tests
`pnpm --filter=@formbricks/web test metering organization-billing cloud-provider self-hosted-provider enqueue-response-completed-runs` → **102 passing**. Covers the new meter event (all branches), the meter call site in the enqueue spec (new run metered exactly once with the run id + persisted `createdAt`; unique-constraint replay never metered), the `workflow-runs-included-` entitlement → `limits.monthly.workflowRuns` including the non-sticky downgrade, and the updated context shape.

## Out of scope (remaining ENG-1936 work)
Metering only bills once the Stripe side exists:
1. **Stripe setup** — create the `workflow_run_created` meter + a metered price on the Scale product (metadata mirroring responses: `formbricks_price_kind: "workflow_runs"`), and a `workflow-runs-included-1000` entitlement feature on Scale.
2. **Catalog provisioning** — extend `stripe-billing-catalog.ts` (`getPriceKind` / `getCatalogItemsForPlan`) to attach the metered workflow-runs line item to the subscription (currently binary base/responses).
3. **Billing UI** — present workflows as metered in `plan-comparison.tsx` (`comparison_row_workflows`, ~L199) and `pricing-table.tsx` (~L591) instead of a boolean checkmark, with overage copy.

## QA / Test Plan

**How to test**

- [ ] Unit suite: `pnpm --filter=@formbricks/web test metering organization-billing cloud-provider self-hosted-provider enqueue-response-completed-runs` → 102 passing.
- [ ] Cloud org on Scale (once the Stripe meter/entitlement from "Out of scope" exists, test mode): submit and finish a response on a survey targeted by an enabled workflow → Stripe Dashboard → the customer's `workflow_run_created` meter shows one event with identifier `workflow_run_created:<runId>` timestamped at the run's creation.
- [ ] Retry/replay the same response through the response pipeline → the existing run is re-dispatched but **no** second meter event appears (replays are never re-metered).
- [ ] Trigger a dry run of a workflow → no meter event.
- [ ] Self-hosted (`IS_FORMBRICKS_CLOUD` unset/false) or an org without a Stripe customer → runs are created and dispatched normally, zero meter events, no errors logged.
- [ ] Simulate a Stripe failure during metering (e.g. invalid key in dev) → log warning `Failed to record Stripe meter event for workflow_run_created`; run creation and dispatch unaffected.
- [ ] Downgrade an org off Scale (workflow-runs entitlement removed in Stripe) → after the next billing sync (Stripe webhook), `organizationBilling.limits.monthly.workflowRuns` is `null`, not the stale `1000`.

**Preconditions / test data**

- Formbricks Cloud env (`IS_FORMBRICKS_CLOUD=true`) with a Stripe test-mode customer on the org; the Stripe-side meter, metered price, and `workflow-runs-included-1000` entitlement are follow-up work — until they land, only the unit suite and the "no meter event" paths are verifiable end-to-end.
- An enabled workflow whose published version has a `response.completed` trigger targeting the test survey.

**Risks & regressions**

- Response pipeline job: the workflow enqueue now settles meter promises before returning — re-check that response side-effects (webhooks, follow-ups, notifications) and job latency are unchanged; meter calls overlap the dispatch loop and the helper never throws.
- Billing sync: only `workflowRuns` switched to null-on-absent; `workspaces`/`responses` must still preserve the previous value on a missing entitlement (guards against bad reads).
- Double billing: the unique-constraint replay path must never meter (pinned by unit test — Stripe's identifier dedup only covers ~24h).

**Migrations / env / cutover**

- none (no DB migrations, no env changes; Stripe meter/price/entitlement setup tracked in "Out of scope")

## How to test
- Unit suite above.
- Manual (Cloud, once Stripe setup lands): complete a response that triggers a workflow → a `workflow_run_created` meter event appears on the customer in Stripe; usage accrues against the workflow-runs meter; billing charges overage beyond 1000/mo. Dry runs emit nothing. Self-hosted: no meter events.

Draft — opening for review of the metering approach + the remaining Stripe/UI plan before wiring the catalog.
