### PR TITLE
fix(mcp): enforce workflows:write scope on MCP workflow write tools

### DIFF
--- a/apps/web/app/.well-known/oauth-protected-resource/route.test.ts
+++ b/apps/web/app/.well-known/oauth-protected-resource/route.test.ts
@@ -43,7 +43,13 @@ describe("OAuth protected resource metadata", () => {
       // offline_access must stay advertised: MCP clients register (DCR) with exactly these
       // scopes, and the oauth-provider plugin validates /authorize against the client's
       // registered scopes — dropping it re-breaks refresh-token issuance for all MCP clients.
-      scopes_supported: ["surveys:read", "surveys:write", "offline_access"],
+      scopes_supported: [
+        "surveys:read",
+        "surveys:write",
+        "workflows:read",
+        "workflows:write",
+        "offline_access",
+      ],
       bearer_methods_supported: ["header"],
     });
   });

--- a/apps/web/app/api/mcp/route.test.ts
+++ b/apps/web/app/api/mcp/route.test.ts
@@ -43,7 +43,7 @@ vi.mock("@formbricks/database", () => ({
 }));
 
 vi.mock("@/modules/auth/lib/oauth-urls", () => ({
-  MCP_RESOURCE_SCOPES: ["surveys:read", "surveys:write"],
+  MCP_RESOURCE_SCOPES: ["surveys:read", "surveys:write", "workflows:read", "workflows:write"],
   getAuthIssuerUrl: () => "http://localhost/api/auth",
   getMcpOrigin: () => "http://localhost",
   getMcpProtectedResourceMetadataUrl: () => "http://localhost/.well-known/oauth-protected-resource/api/mcp",
@@ -161,7 +161,7 @@ describe("POST /api/mcp", () => {
     expect(response.status).toBe(401);
     expect(response.headers.get("Content-Type")).toBe("application/problem+json");
     expect(response.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read surveys:write"'
+      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read surveys:write workflows:read workflows:write"'
     );
     expect(applyIPRateLimit).toHaveBeenCalled();
   });
@@ -425,7 +425,7 @@ describe("POST /api/mcp", () => {
     expect(authenticateApiKeyFromHeaders).not.toHaveBeenCalled();
     expect(applyIPRateLimit).toHaveBeenCalled();
     expect(response.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read surveys:write"'
+      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read surveys:write workflows:read workflows:write"'
     );
   });
 
@@ -467,6 +467,49 @@ describe("POST /api/mcp", () => {
       code: "forbidden",
       detail: "OAuth token does not include the required MCP scope",
       requestId: "req_read_only",
+    });
+  });
+
+  test("blocks workflow write tools for tokens without workflows:write", async () => {
+    // A write-capable user whose OAuth token was only granted read scopes (surveys:read + workflows:read)
+    // must not be able to reach a workflow mutation — the ENG-1967 token-scope boundary.
+    verifyAccessTokenMock.mockResolvedValueOnce({
+      sub: "user_1",
+      email: "person@example.com",
+      scope: "openid profile email surveys:read workflows:read",
+      exp: Math.floor(Date.now() / 1000) + 900,
+      azp: "client_wf_read_only",
+    });
+
+    const response = await POST(
+      createMcpRequest(
+        {
+          jsonrpc: "2.0",
+          id: 10,
+          method: "tools/call",
+          params: {
+            name: "delete_workflow",
+            arguments: {
+              workflowId: "wf1234567890123456789012ab",
+            },
+          },
+        },
+        {
+          authorization: "Bearer eyJhbGciOiJFZERTQSJ9.wfreadonly.signature",
+          "x-api-key": "",
+          "x-request-id": "req_wf_read_only",
+        }
+      )
+    );
+
+    expect(response.status).toBe(200);
+    const message = await readMcpResponse(response);
+    expect(message.result.isError).toBe(true);
+    expect(message.result.structuredContent.error).toMatchObject({
+      status: 403,
+      code: "forbidden",
+      detail: "OAuth token does not include the required MCP scope",
+      requestId: "req_wf_read_only",
     });
   });
 

--- a/apps/web/app/api/mcp/route.test.ts
+++ b/apps/web/app/api/mcp/route.test.ts
@@ -1,6 +1,7 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ApiKeyPermission } from "@formbricks/database/prisma";
+import { buildV3AuditLog, queueV3AuditLog } from "@/app/api/v3/lib/audit";
 import {
   createdResponse,
   problemBadRequest,
@@ -511,6 +512,10 @@ describe("POST /api/mcp", () => {
       detail: "OAuth token does not include the required MCP scope",
       requestId: "req_wf_read_only",
     });
+    // The scope gate must fire BEFORE any mutation side effect: no audit log is built or queued for a
+    // request that never reaches the workflow handler.
+    expect(buildV3AuditLog).not.toHaveBeenCalled();
+    expect(queueV3AuditLog).not.toHaveBeenCalled();
   });
 
   test("calls create_survey through the MCP route", async () => {

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -82,6 +82,8 @@ checksums:
     auth/oauth/scopes/profile: ea073dc28851ee1a00365047be103d50
     auth/oauth/scopes/surveys_read: 8280264457fe7c3b759c82422052aed2
     auth/oauth/scopes/surveys_write: fb128cebe62dfd5685d086d706c432c2
+    auth/oauth/scopes/workflows_read: b3b216cd6e77b26500068bdf7afad004
+    auth/oauth/scopes/workflows_write: c9ce0488b4188718bf4c235855ca5c5a
     auth/oauth/unknown_client: 561bc5afdb90606fbc1ed97f20698ead
     auth/password_compromised: d4ab0f66aaed039f956c2515328ed1c9
     auth/saml_connection_error: 03c69c534e7eaafcb2c22b7daf9f3efc

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -96,7 +96,9 @@
         "openid": "Identify you with OpenID Connect",
         "profile": "View your profile",
         "surveys_read": "Read surveys",
-        "surveys_write": "Create, update, and delete surveys"
+        "surveys_write": "Create, update, and delete surveys",
+        "workflows_read": "Read workflows",
+        "workflows_write": "Create, update, and delete workflows"
       },
       "unknown_client": "Unknown client"
     },

--- a/apps/web/modules/auth/lib/mcp-oauth-dcr.test.ts
+++ b/apps/web/modules/auth/lib/mcp-oauth-dcr.test.ts
@@ -137,7 +137,13 @@ describe("MCP OAuth Dynamic Client Registration → authorize (real-client shape
 
     expect(response.status).toBe(200);
     expect(body.scope?.split(" ")).toEqual(
-      expect.arrayContaining(["surveys:read", "surveys:write", "offline_access"])
+      expect.arrayContaining([
+        "surveys:read",
+        "surveys:write",
+        "workflows:read",
+        "workflows:write",
+        "offline_access",
+      ])
     );
   });
 

--- a/apps/web/modules/auth/lib/mcp-oauth-provider-options.ts
+++ b/apps/web/modules/auth/lib/mcp-oauth-provider-options.ts
@@ -20,26 +20,19 @@ export const getMcpOauthProviderOptions = (): TOauthProviderOptions => ({
   validAudiences: [getMcpResourceUrl()],
   allowDynamicClientRegistration: true,
   allowUnauthenticatedClientRegistration: true,
-  // Register MCP clients with read + write by default so the consent screen offers write and the
-  // write tools are reachable (clients derive their DCR/authorize scopes from what we advertise, and
-  // the plugin validates authorize against the client's registered scopes). Granting the write scope
-  // is safe: actual write access is still enforced downstream by the user's workspace permissions.
-  clientRegistrationDefaultScopes: [
-    "openid",
-    "profile",
-    "email",
-    "offline_access",
-    "surveys:read",
-    "surveys:write",
-    "workflows:read",
-    "workflows:write",
-  ],
+  // Register MCP clients with the full advertised scope set by default so the consent screen offers
+  // write and the write tools are reachable (clients derive their DCR/authorize scopes from what we
+  // advertise, and the plugin validates authorize against the client's registered scopes). Granting
+  // write is safe: actual write access is still enforced downstream by the user's workspace
+  // permissions. Spread the single source of truth so the defaults can't drift from MCP_OAUTH_SCOPES.
+  clientRegistrationDefaultScopes: [...MCP_OAUTH_SCOPES],
   accessTokenExpiresIn: 15 * 60,
   refreshTokenExpiresIn: 30 * 24 * 60 * 60,
-  scopeExpirations: {
-    "surveys:write": "15m",
-    "workflows:write": "15m",
-  },
+  // Every write scope gets the 15-minute step-up expiry, derived from the scope list so a new
+  // `<resource>:write` scope inherits it automatically (no separate hand-edit to keep in sync).
+  scopeExpirations: Object.fromEntries(
+    MCP_OAUTH_SCOPES.filter((scope) => scope.endsWith(":write")).map((scope) => [scope, "15m"])
+  ),
   // Store opaque access-token and refresh-token lookup values as hashes. JWT access tokens are
   // stateless and bounded by the short 15-minute lifetime above.
   storeTokens: "hashed",

--- a/apps/web/modules/auth/lib/mcp-oauth-provider-options.ts
+++ b/apps/web/modules/auth/lib/mcp-oauth-provider-options.ts
@@ -31,11 +31,14 @@ export const getMcpOauthProviderOptions = (): TOauthProviderOptions => ({
     "offline_access",
     "surveys:read",
     "surveys:write",
+    "workflows:read",
+    "workflows:write",
   ],
   accessTokenExpiresIn: 15 * 60,
   refreshTokenExpiresIn: 30 * 24 * 60 * 60,
   scopeExpirations: {
     "surveys:write": "15m",
+    "workflows:write": "15m",
   },
   // Store opaque access-token and refresh-token lookup values as hashes. JWT access tokens are
   // stateless and bounded by the short 15-minute lifetime above.

--- a/apps/web/modules/auth/lib/oauth-client-metadata.test.ts
+++ b/apps/web/modules/auth/lib/oauth-client-metadata.test.ts
@@ -32,6 +32,8 @@ describe("OAuth client metadata helpers", () => {
     expect(getOAuthScopeLabel("offline_access", t)).toBe("translated:auth.oauth.scopes.offline_access");
     expect(getOAuthScopeLabel("surveys:read", t)).toBe("translated:auth.oauth.scopes.surveys_read");
     expect(getOAuthScopeLabel("surveys:write", t)).toBe("translated:auth.oauth.scopes.surveys_write");
+    expect(getOAuthScopeLabel("workflows:read", t)).toBe("translated:auth.oauth.scopes.workflows_read");
+    expect(getOAuthScopeLabel("workflows:write", t)).toBe("translated:auth.oauth.scopes.workflows_write");
   });
 
   test("keeps unknown OAuth scopes readable", () => {

--- a/apps/web/modules/auth/lib/oauth-client-metadata.ts
+++ b/apps/web/modules/auth/lib/oauth-client-metadata.ts
@@ -44,6 +44,10 @@ export const getOAuthScopeLabel = (scope: string, t: (key: string) => string): s
       return t("auth.oauth.scopes.surveys_read");
     case "surveys:write":
       return t("auth.oauth.scopes.surveys_write");
+    case "workflows:read":
+      return t("auth.oauth.scopes.workflows_read");
+    case "workflows:write":
+      return t("auth.oauth.scopes.workflows_write");
     default:
       return scope;
   }

--- a/apps/web/modules/auth/lib/oauth-urls.ts
+++ b/apps/web/modules/auth/lib/oauth-urls.ts
@@ -47,9 +47,16 @@ export const MCP_OAUTH_SCOPES = [
   "offline_access",
   "surveys:read",
   "surveys:write",
+  "workflows:read",
+  "workflows:write",
 ] as const;
 
-export const MCP_RESOURCE_SCOPES = ["surveys:read", "surveys:write"] as const;
+export const MCP_RESOURCE_SCOPES = [
+  "surveys:read",
+  "surveys:write",
+  "workflows:read",
+  "workflows:write",
+] as const;
 
 // Scopes advertised in the RFC 9728 protected-resource metadata. MCP clients derive their
 // Dynamic Client Registration + authorize scopes from this list (NOT from the AS metadata),

--- a/apps/web/modules/mcp/auth.test.ts
+++ b/apps/web/modules/mcp/auth.test.ts
@@ -46,8 +46,17 @@ vi.mock("@/modules/core/rate-limit/helpers", () => ({
 }));
 
 vi.mock("@/modules/auth/lib/oauth-urls", () => ({
-  MCP_OAUTH_SCOPES: ["openid", "profile", "email", "offline_access", "surveys:read", "surveys:write"],
-  MCP_RESOURCE_SCOPES: ["surveys:read", "surveys:write"],
+  MCP_OAUTH_SCOPES: [
+    "openid",
+    "profile",
+    "email",
+    "offline_access",
+    "surveys:read",
+    "surveys:write",
+    "workflows:read",
+    "workflows:write",
+  ],
+  MCP_RESOURCE_SCOPES: ["surveys:read", "surveys:write", "workflows:read", "workflows:write"],
   getAuthIssuerUrl: vi.fn(() => "https://app.example.com/api/auth"),
   getMcpOrigin: vi.fn(() => "https://app.example.com"),
   getMcpProtectedResourceMetadataUrl: vi.fn(
@@ -107,7 +116,9 @@ describe("authenticateMcpRequest", () => {
       expect(result.response.status).toBe(401);
       // The challenge must advertise read + write so clients request write at consent and can reach
       // the write tools (advertising only read is why write was unreachable — ENG-1055 QA).
-      expect(result.response.headers.get("WWW-Authenticate")).toContain('scope="surveys:read surveys:write"');
+      expect(result.response.headers.get("WWW-Authenticate")).toContain(
+        'scope="surveys:read surveys:write workflows:read workflows:write"'
+      );
       expect(await result.response.json()).toMatchObject({
         code: "not_authenticated",
         detail: "API key or OAuth access token required",

--- a/apps/web/modules/mcp/tools/guard-scopes.test.ts
+++ b/apps/web/modules/mcp/tools/guard-scopes.test.ts
@@ -3,6 +3,11 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { describe, expect, test, vi } from "vitest";
 import { registerScopedTool } from "./guard-scopes";
 
+// The insufficient-scope shape the guard puts on structuredContent — narrowed from `unknown`.
+type ScopeErrorContent = {
+  error: { status: number; code: string; detail: string; requestId: string };
+};
+
 // A minimal stand-in for McpServer that captures what registerScopedTool registers.
 function createToolServer() {
   const tools = new Map<
@@ -68,7 +73,7 @@ describe("registerScopedTool", () => {
 
     expect(handler).not.toHaveBeenCalled();
     expect(result.isError).toBe(true);
-    expect((result.structuredContent as any).error).toMatchObject({
+    expect((result.structuredContent as ScopeErrorContent).error).toMatchObject({
       status: 403,
       code: "forbidden",
       detail: "OAuth token does not include the required MCP scope",

--- a/apps/web/modules/mcp/tools/guard-scopes.test.ts
+++ b/apps/web/modules/mcp/tools/guard-scopes.test.ts
@@ -1,0 +1,91 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, test, vi } from "vitest";
+import { registerScopedTool } from "./guard-scopes";
+
+// A minimal stand-in for McpServer that captures what registerScopedTool registers.
+function createToolServer() {
+  const tools = new Map<
+    string,
+    { config: Record<string, unknown>; handler: (input: unknown, extra: unknown) => Promise<CallToolResult> }
+  >();
+  const server = {
+    registerTool: vi.fn((name: string, config: Record<string, unknown>, handler: any) => {
+      tools.set(name, { config, handler });
+    }),
+  };
+  return { server, tools };
+}
+
+function authInfoWithScopes(scopes: string[], requestId = "req_guard"): AuthInfo {
+  return {
+    token: "tok",
+    clientId: "client",
+    scopes,
+    extra: { requestId },
+  } as unknown as AuthInfo;
+}
+
+const CONFIG = {
+  title: "Do thing",
+  description: "A guarded tool",
+  annotations: { readOnlyHint: false },
+};
+
+describe("registerScopedTool", () => {
+  test("registers the tool under its name with the config untouched", () => {
+    const { server, tools } = createToolServer();
+
+    registerScopedTool(server as any, "do_thing", CONFIG, ["surveys:write"], vi.fn() as any);
+
+    expect(server.registerTool).toHaveBeenCalledTimes(1);
+    expect(server.registerTool.mock.calls[0][0]).toBe("do_thing");
+    expect(tools.get("do_thing")?.config).toBe(CONFIG);
+  });
+
+  test("runs the handler and returns its result when the token holds every required scope", async () => {
+    const { server, tools } = createToolServer();
+    const handlerResult = { structuredContent: { ok: true } } as unknown as CallToolResult;
+    const handler = vi.fn().mockResolvedValue(handlerResult);
+    registerScopedTool(server as any, "do_thing", CONFIG, ["surveys:read", "surveys:write"], handler as any);
+
+    const input = { a: 1 };
+    const extra = { authInfo: authInfoWithScopes(["surveys:read", "surveys:write"]) };
+    const result = await tools.get("do_thing")!.handler(input, extra);
+
+    expect(handler).toHaveBeenCalledWith(input, extra);
+    expect(result).toBe(handlerResult);
+  });
+
+  test("blocks the handler with a 403 insufficient-scope result when a required scope is missing", async () => {
+    const { server, tools } = createToolServer();
+    const handler = vi.fn();
+    registerScopedTool(server as any, "do_thing", CONFIG, ["surveys:write"], handler as any);
+
+    const result = await tools
+      .get("do_thing")!
+      .handler({}, { authInfo: authInfoWithScopes(["surveys:read"], "req_denied") });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect((result.structuredContent as any).error).toMatchObject({
+      status: 403,
+      code: "forbidden",
+      detail: "OAuth token does not include the required MCP scope",
+      requestId: "req_denied",
+    });
+  });
+
+  test("denies when the token holds only some of several required scopes", async () => {
+    const { server, tools } = createToolServer();
+    const handler = vi.fn();
+    registerScopedTool(server as any, "do_thing", CONFIG, ["surveys:read", "surveys:write"], handler as any);
+
+    const result = await tools
+      .get("do_thing")!
+      .handler({}, { authInfo: authInfoWithScopes(["surveys:read"]) });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+  });
+});

--- a/apps/web/modules/mcp/tools/guard-scopes.ts
+++ b/apps/web/modules/mcp/tools/guard-scopes.ts
@@ -1,6 +1,8 @@
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { createMcpInsufficientScopeResponse, hasMcpScopes } from "../auth";
+import type { McpServer, ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult, ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import type { ZodRawShape } from "zod";
+import { createMcpInsufficientScopeResponse, getMcpRequestId, hasMcpScopes } from "../auth";
 import { responseToMcpToolResult } from "../errors";
 
 /**
@@ -20,4 +22,40 @@ export async function guardMcpScopes(
     createMcpInsufficientScopeResponse(requestId, requiredScopes),
     requestId
   );
+}
+
+type ScopedToolConfig<InputArgs extends ZodRawShape> = {
+  title?: string;
+  description?: string;
+  inputSchema?: InputArgs;
+  annotations?: ToolAnnotations;
+};
+
+/**
+ * Register an MCP tool with a MANDATORY OAuth scope gate. `requiredScopes` is a required argument, so a
+ * tool cannot be registered without declaring the scope it needs — the gate always runs (returning a
+ * 403 insufficient-scope result) BEFORE the handler, so no tool can reach a v3 operation unguarded.
+ *
+ * This is the single registration path for every MCP tool: read tools pass `["<resource>:read"]`,
+ * mutating tools pass `["<resource>:write"]`. Enforcing scope structurally (vs. a per-tool
+ * `guardMcpScopes` call that's easy to forget) is what prevents the ENG-1967 class of gap from
+ * recurring as new tools are added.
+ */
+export function registerScopedTool<InputArgs extends ZodRawShape>(
+  server: McpServer,
+  name: string,
+  config: ScopedToolConfig<InputArgs>,
+  requiredScopes: string[],
+  handler: ToolCallback<InputArgs>
+): void {
+  const guardedHandler = (async (input: unknown, extra: { authInfo?: AuthInfo }) => {
+    const requestId = getMcpRequestId(extra.authInfo);
+    const scopeError = await guardMcpScopes(extra.authInfo, requiredScopes, requestId);
+    if (scopeError) {
+      return scopeError;
+    }
+    return (handler as (input: unknown, extra: unknown) => Promise<CallToolResult>)(input, extra);
+  }) as ToolCallback<InputArgs>;
+
+  server.registerTool(name, config, guardedHandler);
 }

--- a/apps/web/modules/mcp/tools/guard-scopes.ts
+++ b/apps/web/modules/mcp/tools/guard-scopes.ts
@@ -9,7 +9,7 @@ import { responseToMcpToolResult } from "../errors";
  * Shared MCP scope gate: returns `null` when the caller holds all `requiredScopes`, otherwise an
  * insufficient-scope tool result. Used by every tool before it touches a v3 operation.
  */
-export async function guardMcpScopes(
+async function guardMcpScopes(
   authInfo: AuthInfo | undefined,
   requiredScopes: string[],
   requestId: string

--- a/apps/web/modules/mcp/tools/guard-scopes.ts
+++ b/apps/web/modules/mcp/tools/guard-scopes.ts
@@ -45,7 +45,8 @@ export function registerScopedTool<InputArgs extends ZodRawShape>(
   server: McpServer,
   name: string,
   config: ScopedToolConfig<InputArgs>,
-  requiredScopes: string[],
+  // Non-empty tuple: a tool cannot be registered with `[]`, which would gate on nothing.
+  requiredScopes: [string, ...string[]],
   handler: ToolCallback<InputArgs>
 ): void {
   const guardedHandler = (async (input: unknown, extra: { authInfo?: AuthInfo }) => {

--- a/apps/web/modules/mcp/tools/guard-scopes.ts
+++ b/apps/web/modules/mcp/tools/guard-scopes.ts
@@ -55,6 +55,11 @@ export function registerScopedTool<InputArgs extends ZodRawShape>(
     if (scopeError) {
       return scopeError;
     }
+    // Cast needed only because ToolCallback<InputArgs> is an overloaded/conditional signature that
+    // TS can't call with the erased `unknown` params here. It's safe: the SDK validates `input`
+    // against this tool's inputSchema (InputArgs) BEFORE invoking guardedHandler, and we forward the
+    // exact same `input`/`extra` through unchanged — so the runtime value already conforms to the
+    // handler's declared type; nothing is reshaped.
     return (handler as (input: unknown, extra: unknown) => Promise<CallToolResult>)(input, extra);
   }) as ToolCallback<InputArgs>;
 

--- a/apps/web/modules/mcp/tools/run-mcp-mutation.ts
+++ b/apps/web/modules/mcp/tools/run-mcp-mutation.ts
@@ -19,7 +19,11 @@ type McpMutationExtra = { authInfo?: AuthInfo };
  */
 export async function runMcpMutation(
   extra: McpMutationExtra,
-  opts: {
+  {
+    action,
+    resource,
+    logContext = {},
+  }: {
     action: Parameters<typeof buildV3AuditLog>[1];
     resource: Parameters<typeof buildV3AuditLog>[2];
     logContext?: Record<string, unknown>;
@@ -32,8 +36,8 @@ export async function runMcpMutation(
 ): Promise<CallToolResult> {
   const requestId = getMcpRequestId(extra.authInfo);
   const authentication = getMcpAuthentication(extra.authInfo);
-  const log = logger.withContext({ requestId, ...(opts.logContext ?? {}) });
-  const auditLog = buildV3AuditLog(authentication, opts.action, opts.resource, MCP_API_ROUTE);
+  const log = logger.withContext({ requestId, ...logContext });
+  const auditLog = buildV3AuditLog(authentication, action, resource, MCP_API_ROUTE);
 
   try {
     const response = await run({ authentication, requestId, auditLog });

--- a/apps/web/modules/mcp/tools/run-mcp-mutation.ts
+++ b/apps/web/modules/mcp/tools/run-mcp-mutation.ts
@@ -1,0 +1,59 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { logger } from "@formbricks/logger";
+import { buildV3AuditLog, queueV3AuditLog } from "@/app/api/v3/lib/audit";
+import { MCP_API_ROUTE } from "@/modules/mcp/constants";
+import { getMcpAuthentication, getMcpRequestId } from "../auth";
+import { responseToMcpToolResult } from "../errors";
+
+type McpMutationExtra = { authInfo?: AuthInfo };
+
+/**
+ * Shared audit lifecycle for every MCP mutation tool, matching what the v3 route wrapper provides:
+ * derive the authentication + request id, build the audit log, run the operation, mark
+ * success/failure, and ALWAYS queue the audit log (even on throw) before propagating.
+ *
+ * The per-resource runners (survey/workflow) only supply the audit `resource`, optional logger
+ * context, and a `run` callback that performs the actual v3 operation with the injected
+ * authentication/requestId/auditLog — so the try/catch/status/queue logic lives in exactly one place.
+ */
+export async function runMcpMutation(
+  extra: McpMutationExtra,
+  opts: {
+    action: Parameters<typeof buildV3AuditLog>[1];
+    resource: Parameters<typeof buildV3AuditLog>[2];
+    logContext?: Record<string, unknown>;
+  },
+  run: (args: {
+    authentication: ReturnType<typeof getMcpAuthentication>;
+    requestId: string;
+    auditLog: ReturnType<typeof buildV3AuditLog>;
+  }) => Promise<Response>
+): Promise<CallToolResult> {
+  const requestId = getMcpRequestId(extra.authInfo);
+  const authentication = getMcpAuthentication(extra.authInfo);
+  const log = logger.withContext({ requestId, ...(opts.logContext ?? {}) });
+  const auditLog = buildV3AuditLog(authentication, opts.action, opts.resource, MCP_API_ROUTE);
+
+  try {
+    const response = await run({ authentication, requestId, auditLog });
+
+    if (auditLog) {
+      if (response.ok) {
+        auditLog.status = "success";
+      } else {
+        auditLog.eventId = requestId;
+      }
+    }
+
+    await queueV3AuditLog(auditLog, requestId, log);
+    return await responseToMcpToolResult(response, requestId);
+  } catch (error) {
+    if (auditLog) {
+      auditLog.eventId = requestId;
+      await queueV3AuditLog(auditLog, requestId, log);
+    }
+
+    throw error;
+  }
+}

--- a/apps/web/modules/mcp/tools/surveys.ts
+++ b/apps/web/modules/mcp/tools/surveys.ts
@@ -12,7 +12,7 @@ import {
 import { MCP_API_ROUTE } from "@/modules/mcp/constants";
 import { getMcpAuthentication, getMcpRequestId } from "../auth";
 import { responseToMcpToolResult } from "../errors";
-import { guardMcpScopes } from "./guard-scopes";
+import { registerScopedTool } from "./guard-scopes";
 import {
   type TMcpCreateSurveyInput,
   type TMcpDeleteSurveyInput,
@@ -62,7 +62,8 @@ export function buildListSurveysSearchParams(input: TMcpListSurveysInput): URLSe
 }
 
 export function registerSurveyTools(server: McpServer): void {
-  server.registerTool(
+  registerScopedTool(
+    server,
     "list_surveys",
     {
       title: "List surveys",
@@ -75,13 +76,9 @@ export function registerSurveyTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["surveys:read"],
     async (input: TMcpListSurveysInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
-      const scopeError = await guardMcpScopes(extra.authInfo, ["surveys:read"], requestId);
-      if (scopeError) {
-        return scopeError;
-      }
-
       const response = await listV3Surveys({
         searchParams: buildListSurveysSearchParams(input),
         authentication: getMcpAuthentication(extra.authInfo),
@@ -93,7 +90,8 @@ export function registerSurveyTools(server: McpServer): void {
     }
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "get_survey",
     {
       title: "Get survey",
@@ -106,13 +104,9 @@ export function registerSurveyTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["surveys:read"],
     async (input: TMcpGetSurveyInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
-      const scopeError = await guardMcpScopes(extra.authInfo, ["surveys:read"], requestId);
-      if (scopeError) {
-        return scopeError;
-      }
-
       const response = await getV3Survey({
         surveyId: input.surveyId,
         lang: input.lang,
@@ -125,7 +119,8 @@ export function registerSurveyTools(server: McpServer): void {
     }
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "create_survey",
     {
       title: "Create survey",
@@ -138,13 +133,9 @@ export function registerSurveyTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["surveys:write"],
     async (input: TMcpCreateSurveyInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
-      const scopeError = await guardMcpScopes(extra.authInfo, ["surveys:write"], requestId);
-      if (scopeError) {
-        return scopeError;
-      }
-
       const authentication = getMcpAuthentication(extra.authInfo);
       const log = logger.withContext({ requestId, workspaceId: input.workspaceId });
       const auditLog = buildV3AuditLog(authentication, "created", "survey", MCP_API_ROUTE);
@@ -179,7 +170,8 @@ export function registerSurveyTools(server: McpServer): void {
     }
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "validate_survey",
     {
       title: "Validate survey",
@@ -192,16 +184,12 @@ export function registerSurveyTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["surveys:read"],
     async (input: TMcpValidateSurveyInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
       // validate_survey never persists changes (readOnlyHint) — a dry-run validation of a create or
       // patch payload only needs read access. The actual write permission is enforced by the v3 layer
       // when create_survey / patch_survey run.
-      const scopeError = await guardMcpScopes(extra.authInfo, ["surveys:read"], requestId);
-      if (scopeError) {
-        return scopeError;
-      }
-
       const response = await validateV3SurveyFromRawInput({
         body: input,
         authentication: getMcpAuthentication(extra.authInfo),
@@ -213,7 +201,8 @@ export function registerSurveyTools(server: McpServer): void {
     }
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "patch_survey",
     {
       title: "Patch survey",
@@ -229,13 +218,9 @@ export function registerSurveyTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["surveys:write"],
     async (input: TMcpPatchSurveyInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
-      const scopeError = await guardMcpScopes(extra.authInfo, ["surveys:write"], requestId);
-      if (scopeError) {
-        return scopeError;
-      }
-
       const authentication = getMcpAuthentication(extra.authInfo);
       const log = logger.withContext({ requestId, surveyId: input.surveyId });
       const auditLog = buildV3AuditLog(authentication, "updated", "survey", MCP_API_ROUTE);
@@ -271,7 +256,8 @@ export function registerSurveyTools(server: McpServer): void {
     }
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "delete_survey",
     {
       title: "Delete survey",
@@ -284,13 +270,9 @@ export function registerSurveyTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["surveys:write"],
     async (input: TMcpDeleteSurveyInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
-      const scopeError = await guardMcpScopes(extra.authInfo, ["surveys:write"], requestId);
-      if (scopeError) {
-        return scopeError;
-      }
-
       const authentication = getMcpAuthentication(extra.authInfo);
       const log = logger.withContext({ requestId, surveyId: input.surveyId });
       const auditLog = buildV3AuditLog(authentication, "deleted", "survey", MCP_API_ROUTE);

--- a/apps/web/modules/mcp/tools/surveys.ts
+++ b/apps/web/modules/mcp/tools/surveys.ts
@@ -1,7 +1,4 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { logger } from "@formbricks/logger";
-import { buildV3AuditLog, queueV3AuditLog } from "@/app/api/v3/lib/audit";
 import {
   createV3SurveyResponseFromRawInput,
   deleteV3Survey,
@@ -14,6 +11,7 @@ import { MCP_API_ROUTE } from "@/modules/mcp/constants";
 import { getMcpAuthentication, getMcpRequestId } from "../auth";
 import { responseToMcpToolResult } from "../errors";
 import { registerScopedTool } from "./guard-scopes";
+import { runMcpMutation } from "./run-mcp-mutation";
 import {
   type TMcpCreateSurveyInput,
   type TMcpDeleteSurveyInput,
@@ -60,49 +58,6 @@ export function buildListSurveysSearchParams(input: TMcpListSurveysInput): URLSe
   });
 
   return searchParams;
-}
-
-/**
- * Run a survey mutation with the same audit lifecycle the v3 route wrapper provides: build the audit
- * log, run the operation, mark success/failure, and always queue it. Mirrors runWorkflowMutation so
- * every MCP mutation tool shares a single audit path instead of copy-pasting the try/catch per tool.
- */
-async function runSurveyMutation(
-  extra: { authInfo?: NonNullable<Parameters<typeof getMcpAuthentication>[0]> },
-  action: Parameters<typeof buildV3AuditLog>[1],
-  logContext: Record<string, unknown>,
-  run: (args: {
-    authentication: ReturnType<typeof getMcpAuthentication>;
-    requestId: string;
-    auditLog: ReturnType<typeof buildV3AuditLog>;
-  }) => Promise<Response>
-): Promise<CallToolResult> {
-  const requestId = getMcpRequestId(extra.authInfo);
-  const authentication = getMcpAuthentication(extra.authInfo);
-  const log = logger.withContext({ requestId, ...logContext });
-  const auditLog = buildV3AuditLog(authentication, action, "survey", MCP_API_ROUTE);
-
-  try {
-    const response = await run({ authentication, requestId, auditLog });
-
-    if (auditLog) {
-      if (response.ok) {
-        auditLog.status = "success";
-      } else {
-        auditLog.eventId = requestId;
-      }
-    }
-
-    await queueV3AuditLog(auditLog, requestId, log);
-    return await responseToMcpToolResult(response, requestId);
-  } catch (error) {
-    if (auditLog) {
-      auditLog.eventId = requestId;
-      await queueV3AuditLog(auditLog, requestId, log);
-    }
-
-    throw error;
-  }
 }
 
 export function registerSurveyTools(server: McpServer): void {
@@ -179,10 +134,9 @@ export function registerSurveyTools(server: McpServer): void {
     },
     ["surveys:write"],
     async (input: TMcpCreateSurveyInput, extra) =>
-      runSurveyMutation(
+      runMcpMutation(
         extra,
-        "created",
-        { workspaceId: input.workspaceId },
+        { action: "created", resource: "survey", logContext: { workspaceId: input.workspaceId } },
         ({ authentication, requestId, auditLog }) =>
           createV3SurveyResponseFromRawInput({
             body: input,
@@ -244,10 +198,9 @@ export function registerSurveyTools(server: McpServer): void {
     },
     ["surveys:write"],
     async (input: TMcpPatchSurveyInput, extra) =>
-      runSurveyMutation(
+      runMcpMutation(
         extra,
-        "updated",
-        { surveyId: input.surveyId },
+        { action: "updated", resource: "survey", logContext: { surveyId: input.surveyId } },
         ({ authentication, requestId, auditLog }) =>
           patchV3SurveyResponse({
             surveyId: input.surveyId,
@@ -276,10 +229,9 @@ export function registerSurveyTools(server: McpServer): void {
     },
     ["surveys:write"],
     async (input: TMcpDeleteSurveyInput, extra) =>
-      runSurveyMutation(
+      runMcpMutation(
         extra,
-        "deleted",
-        { surveyId: input.surveyId },
+        { action: "deleted", resource: "survey", logContext: { surveyId: input.surveyId } },
         ({ authentication, requestId, auditLog }) =>
           deleteV3Survey({
             surveyId: input.surveyId,

--- a/apps/web/modules/mcp/tools/surveys.ts
+++ b/apps/web/modules/mcp/tools/surveys.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "@formbricks/logger";
 import { buildV3AuditLog, queueV3AuditLog } from "@/app/api/v3/lib/audit";
 import {
@@ -59,6 +60,49 @@ export function buildListSurveysSearchParams(input: TMcpListSurveysInput): URLSe
   });
 
   return searchParams;
+}
+
+/**
+ * Run a survey mutation with the same audit lifecycle the v3 route wrapper provides: build the audit
+ * log, run the operation, mark success/failure, and always queue it. Mirrors runWorkflowMutation so
+ * every MCP mutation tool shares a single audit path instead of copy-pasting the try/catch per tool.
+ */
+async function runSurveyMutation(
+  extra: { authInfo?: NonNullable<Parameters<typeof getMcpAuthentication>[0]> },
+  action: Parameters<typeof buildV3AuditLog>[1],
+  logContext: Record<string, unknown>,
+  run: (args: {
+    authentication: ReturnType<typeof getMcpAuthentication>;
+    requestId: string;
+    auditLog: ReturnType<typeof buildV3AuditLog>;
+  }) => Promise<Response>
+): Promise<CallToolResult> {
+  const requestId = getMcpRequestId(extra.authInfo);
+  const authentication = getMcpAuthentication(extra.authInfo);
+  const log = logger.withContext({ requestId, ...logContext });
+  const auditLog = buildV3AuditLog(authentication, action, "survey", MCP_API_ROUTE);
+
+  try {
+    const response = await run({ authentication, requestId, auditLog });
+
+    if (auditLog) {
+      if (response.ok) {
+        auditLog.status = "success";
+      } else {
+        auditLog.eventId = requestId;
+      }
+    }
+
+    await queueV3AuditLog(auditLog, requestId, log);
+    return await responseToMcpToolResult(response, requestId);
+  } catch (error) {
+    if (auditLog) {
+      auditLog.eventId = requestId;
+      await queueV3AuditLog(auditLog, requestId, log);
+    }
+
+    throw error;
+  }
 }
 
 export function registerSurveyTools(server: McpServer): void {
@@ -134,40 +178,20 @@ export function registerSurveyTools(server: McpServer): void {
       },
     },
     ["surveys:write"],
-    async (input: TMcpCreateSurveyInput, extra) => {
-      const requestId = getMcpRequestId(extra.authInfo);
-      const authentication = getMcpAuthentication(extra.authInfo);
-      const log = logger.withContext({ requestId, workspaceId: input.workspaceId });
-      const auditLog = buildV3AuditLog(authentication, "created", "survey", MCP_API_ROUTE);
-
-      try {
-        const response = await createV3SurveyResponseFromRawInput({
-          body: input,
-          authentication,
-          requestId,
-          instance: MCP_API_ROUTE,
-          auditLog,
-        });
-
-        if (auditLog) {
-          if (response.ok) {
-            auditLog.status = "success";
-          } else {
-            auditLog.eventId = requestId;
-          }
-        }
-
-        await queueV3AuditLog(auditLog, requestId, log);
-        return await responseToMcpToolResult(response, requestId);
-      } catch (error) {
-        if (auditLog) {
-          auditLog.eventId = requestId;
-          await queueV3AuditLog(auditLog, requestId, log);
-        }
-
-        throw error;
-      }
-    }
+    async (input: TMcpCreateSurveyInput, extra) =>
+      runSurveyMutation(
+        extra,
+        "created",
+        { workspaceId: input.workspaceId },
+        ({ authentication, requestId, auditLog }) =>
+          createV3SurveyResponseFromRawInput({
+            body: input,
+            authentication,
+            requestId,
+            instance: MCP_API_ROUTE,
+            auditLog,
+          })
+      )
   );
 
   registerScopedTool(
@@ -219,41 +243,21 @@ export function registerSurveyTools(server: McpServer): void {
       },
     },
     ["surveys:write"],
-    async (input: TMcpPatchSurveyInput, extra) => {
-      const requestId = getMcpRequestId(extra.authInfo);
-      const authentication = getMcpAuthentication(extra.authInfo);
-      const log = logger.withContext({ requestId, surveyId: input.surveyId });
-      const auditLog = buildV3AuditLog(authentication, "updated", "survey", MCP_API_ROUTE);
-
-      try {
-        const response = await patchV3SurveyResponse({
-          surveyId: input.surveyId,
-          body: input.data,
-          authentication,
-          requestId,
-          instance: MCP_API_ROUTE,
-          auditLog,
-        });
-
-        if (auditLog) {
-          if (response.ok) {
-            auditLog.status = "success";
-          } else {
-            auditLog.eventId = requestId;
-          }
-        }
-
-        await queueV3AuditLog(auditLog, requestId, log);
-        return await responseToMcpToolResult(response, requestId);
-      } catch (error) {
-        if (auditLog) {
-          auditLog.eventId = requestId;
-          await queueV3AuditLog(auditLog, requestId, log);
-        }
-
-        throw error;
-      }
-    }
+    async (input: TMcpPatchSurveyInput, extra) =>
+      runSurveyMutation(
+        extra,
+        "updated",
+        { surveyId: input.surveyId },
+        ({ authentication, requestId, auditLog }) =>
+          patchV3SurveyResponse({
+            surveyId: input.surveyId,
+            body: input.data,
+            authentication,
+            requestId,
+            instance: MCP_API_ROUTE,
+            auditLog,
+          })
+      )
   );
 
   registerScopedTool(
@@ -271,39 +275,19 @@ export function registerSurveyTools(server: McpServer): void {
       },
     },
     ["surveys:write"],
-    async (input: TMcpDeleteSurveyInput, extra) => {
-      const requestId = getMcpRequestId(extra.authInfo);
-      const authentication = getMcpAuthentication(extra.authInfo);
-      const log = logger.withContext({ requestId, surveyId: input.surveyId });
-      const auditLog = buildV3AuditLog(authentication, "deleted", "survey", MCP_API_ROUTE);
-
-      try {
-        const response = await deleteV3Survey({
-          surveyId: input.surveyId,
-          authentication,
-          requestId,
-          instance: MCP_API_ROUTE,
-          auditLog,
-        });
-
-        if (auditLog) {
-          if (response.ok) {
-            auditLog.status = "success";
-          } else {
-            auditLog.eventId = requestId;
-          }
-        }
-
-        await queueV3AuditLog(auditLog, requestId, log);
-        return await responseToMcpToolResult(response, requestId);
-      } catch (error) {
-        if (auditLog) {
-          auditLog.eventId = requestId;
-          await queueV3AuditLog(auditLog, requestId, log);
-        }
-
-        throw error;
-      }
-    }
+    async (input: TMcpDeleteSurveyInput, extra) =>
+      runSurveyMutation(
+        extra,
+        "deleted",
+        { surveyId: input.surveyId },
+        ({ authentication, requestId, auditLog }) =>
+          deleteV3Survey({
+            surveyId: input.surveyId,
+            authentication,
+            requestId,
+            instance: MCP_API_ROUTE,
+            auditLog,
+          })
+      )
   );
 }

--- a/apps/web/modules/mcp/tools/workflows.test.ts
+++ b/apps/web/modules/mcp/tools/workflows.test.ts
@@ -353,6 +353,37 @@ describe("registerWorkflowTools", () => {
     expect(queueV3AuditLog).toHaveBeenCalledWith(auditLog, "req_tool", expect.any(Object));
   });
 
+  test("a thrown mutation still queues the audit log and re-propagates the error", async () => {
+    const { tools } = createToolServer();
+    const auditLog: any = { status: "failure" };
+    vi.mocked(buildV3AuditLog).mockReturnValue(auditLog);
+    const boom = new Error("workflow operation exploded");
+    vi.mocked(workflowsHandlers.create).mockRejectedValue(boom);
+    const body = { workspaceId: WORKSPACE_ID, name: "WF", definition: { nodes: [], edges: [] } };
+
+    // The shared runner must not swallow errors: it flags the audit eventId, queues it, then rethrows.
+    await expect(tools.get("create_workflow")!.handler(body, { authInfo })).rejects.toThrow(boom);
+    expect(auditLog).toMatchObject({ eventId: "req_tool" });
+    expect(queueV3AuditLog).toHaveBeenCalledWith(auditLog, "req_tool", expect.any(Object));
+  });
+
+  test("a null audit log is tolerated (still queues, no crash)", async () => {
+    const { tools } = createToolServer();
+    // buildV3AuditLog can return null (auditing disabled); the runner must not dereference it.
+    vi.mocked(buildV3AuditLog).mockReturnValue(null as any);
+    vi.mocked(workflowsHandlers.enable).mockResolvedValue(
+      successResponse({ id: WORKFLOW_ID, status: "enabled" }, { requestId: "req_tool" })
+    );
+
+    const result = await tools.get("enable_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
+
+    expect(queueV3AuditLog).toHaveBeenCalledWith(null, "req_tool", expect.any(Object));
+    expect(result.structuredContent).toEqual({
+      data: { id: WORKFLOW_ID, status: "enabled" },
+      requestId: "req_tool",
+    });
+  });
+
   test("patch_workflow sends a body request with params and queues an updated audit log", async () => {
     const { tools } = createToolServer();
     const auditLog: any = { status: "failure" };

--- a/apps/web/modules/mcp/tools/workflows.test.ts
+++ b/apps/web/modules/mcp/tools/workflows.test.ts
@@ -53,16 +53,28 @@ const apiKeyAuth = {
   organizationId: "org_1",
   organizationAccess: { accessControl: { read: true, write: true } },
   workspacePermissions: [
-    { workspaceId: WORKSPACE_ID, workspaceName: "Workspace", permission: ApiKeyPermission.read },
+    { workspaceId: WORKSPACE_ID, workspaceName: "Workspace", permission: ApiKeyPermission.write },
   ],
 };
 
+// Full-scope token used by the behavior tests below.
 const authInfo = {
   token: "key_1",
   clientId: "key_1",
-  scopes: ["workflows:read"],
+  scopes: ["workflows:read", "workflows:write"],
   extra: { formbricksAuthentication: apiKeyAuth, requestId: "req_tool" },
 };
+
+// A write-capable user's OAuth token that was only granted read scope — the ENG-1967 case: workspace
+// permissions would allow the write, but the token scope must not.
+const readOnlyAuthInfo = {
+  ...authInfo,
+  token: "oauth:user_1:client_1",
+  clientId: "client_1",
+  scopes: ["workflows:read"],
+  extra: { ...authInfo.extra, authMethod: "oauth" },
+};
+const noScopeAuthInfo = { ...readOnlyAuthInfo, scopes: [] as string[] };
 
 function createToolServer() {
   const tools = new Map<
@@ -412,5 +424,87 @@ describe("registerWorkflowTools", () => {
       params: { workflowId: WORKFLOW_ID },
     });
     expect(auditLog.status).toBe("success");
+  });
+});
+
+describe("MCP scope enforcement (ENG-1967)", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(buildWorkflowApiContext).mockReturnValue({ __ctx: true } as any);
+    vi.mocked(queueV3AuditLog).mockResolvedValue(undefined);
+  });
+
+  const INSUFFICIENT_SCOPE = {
+    status: 403,
+    code: "forbidden",
+    detail: "OAuth token does not include the required MCP scope",
+  };
+
+  // Every mutating tool + a representative valid input for it.
+  const writeTools: { name: string; handlerKey: keyof typeof workflowsHandlers; input: unknown }[] = [
+    {
+      name: "create_workflow",
+      handlerKey: "create",
+      input: { workspaceId: WORKSPACE_ID, name: "WF", definition: { nodes: [], edges: [] } },
+    },
+    { name: "patch_workflow", handlerKey: "patch", input: { workflowId: WORKFLOW_ID, data: { name: "x" } } },
+    { name: "duplicate_workflow", handlerKey: "duplicate", input: { workflowId: WORKFLOW_ID } },
+    { name: "delete_workflow", handlerKey: "delete", input: { workflowId: WORKFLOW_ID } },
+    { name: "enable_workflow", handlerKey: "enable", input: { workflowId: WORKFLOW_ID } },
+    { name: "disable_workflow", handlerKey: "disable", input: { workflowId: WORKFLOW_ID } },
+    { name: "archive_workflow", handlerKey: "archive", input: { workflowId: WORKFLOW_ID } },
+    { name: "unarchive_workflow", handlerKey: "unarchive", input: { workflowId: WORKFLOW_ID } },
+  ];
+
+  test.each(writeTools)(
+    "$name is denied for a read-scoped token before the mutation runs",
+    async ({ name, handlerKey, input }) => {
+      const { tools } = createToolServer();
+
+      const result = await tools.get(name)!.handler(input, { authInfo: readOnlyAuthInfo });
+
+      // The mutation never runs, and no audit log is queued for a request that was blocked at the gate.
+      expect(workflowsHandlers[handlerKey]).not.toHaveBeenCalled();
+      expect(queueV3AuditLog).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(result.structuredContent.error).toMatchObject({ ...INSUFFICIENT_SCOPE, requestId: "req_tool" });
+    }
+  );
+
+  test("write tools succeed once the token carries workflows:write", async () => {
+    const { tools } = createToolServer();
+    vi.mocked(buildV3AuditLog).mockReturnValue({ status: "failure" } as any);
+    vi.mocked(workflowsHandlers.enable).mockResolvedValue(
+      successResponse({ id: WORKFLOW_ID, status: "enabled" }, { requestId: "req_tool" })
+    );
+
+    await tools.get("enable_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
+
+    expect(workflowsHandlers.enable).toHaveBeenCalledTimes(1);
+  });
+
+  test("read tools require workflows:read", async () => {
+    const { tools } = createToolServer();
+
+    const result = await tools
+      .get("list_workflows")!
+      .handler({ workspaceId: WORKSPACE_ID, limit: 20 }, { authInfo: noScopeAuthInfo });
+
+    expect(workflowsHandlers.list).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent.error).toMatchObject({ ...INSUFFICIENT_SCOPE, requestId: "req_tool" });
+  });
+
+  test("read tools succeed for a read-only token", async () => {
+    const { tools } = createToolServer();
+    vi.mocked(workflowsHandlers.list).mockResolvedValue(
+      successListResponse([{ id: WORKFLOW_ID }], { limit: 20, nextCursor: null }, { requestId: "req_tool" })
+    );
+
+    await tools
+      .get("list_workflows")!
+      .handler({ workspaceId: WORKSPACE_ID, limit: 20 }, { authInfo: readOnlyAuthInfo });
+
+    expect(workflowsHandlers.list).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/modules/mcp/tools/workflows.ts
+++ b/apps/web/modules/mcp/tools/workflows.ts
@@ -6,6 +6,7 @@ import { buildWorkflowApiContext, workflowsHandlers } from "@/app/api/v3/workflo
 import { MCP_API_ROUTE } from "@/modules/mcp/constants";
 import { getMcpAuthentication, getMcpRequestId } from "../auth";
 import { responseToMcpToolResult } from "../errors";
+import { registerScopedTool } from "./guard-scopes";
 import {
   type TMcpCreateWorkflowInput,
   type TMcpDuplicateWorkflowInput,
@@ -148,7 +149,8 @@ async function runWorkflowMutation(
 }
 
 export function registerWorkflowTools(server: McpServer): void {
-  server.registerTool(
+  registerScopedTool(
+    server,
     "list_workflows",
     {
       title: "List workflows",
@@ -161,6 +163,7 @@ export function registerWorkflowTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["workflows:read"],
     async (input: TMcpListWorkflowsInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
       const ctx = buildWorkflowApiContext(getMcpAuthentication(extra.authInfo), requestId, MCP_API_ROUTE);
@@ -173,7 +176,8 @@ export function registerWorkflowTools(server: McpServer): void {
     }
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "get_workflow",
     {
       title: "Get workflow",
@@ -186,6 +190,7 @@ export function registerWorkflowTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["workflows:read"],
     async (input: TMcpGetWorkflowInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
       const ctx = buildWorkflowApiContext(getMcpAuthentication(extra.authInfo), requestId, MCP_API_ROUTE);
@@ -195,7 +200,8 @@ export function registerWorkflowTools(server: McpServer): void {
     }
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "list_workflow_runs",
     {
       title: "List workflow runs",
@@ -209,6 +215,7 @@ export function registerWorkflowTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["workflows:read"],
     async (input: TMcpListWorkflowRunsInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
       const ctx = buildWorkflowApiContext(getMcpAuthentication(extra.authInfo), requestId, MCP_API_ROUTE);
@@ -221,7 +228,8 @@ export function registerWorkflowTools(server: McpServer): void {
     }
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "get_workflow_run",
     {
       title: "Get workflow run",
@@ -235,6 +243,7 @@ export function registerWorkflowTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["workflows:read"],
     async (input: TMcpGetWorkflowRunInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
       const ctx = buildWorkflowApiContext(getMcpAuthentication(extra.authInfo), requestId, MCP_API_ROUTE);
@@ -244,7 +253,8 @@ export function registerWorkflowTools(server: McpServer): void {
     }
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "test_workflow",
     {
       title: "Test workflow (dry-run)",
@@ -262,6 +272,7 @@ export function registerWorkflowTools(server: McpServer): void {
       },
       inputSchema: ZMcpTestWorkflowInput.shape,
     },
+    ["workflows:read"],
     async (input: TMcpTestWorkflowInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
       const ctx = buildWorkflowApiContext(getMcpAuthentication(extra.authInfo), requestId, MCP_API_ROUTE);
@@ -274,7 +285,8 @@ export function registerWorkflowTools(server: McpServer): void {
     }
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "create_workflow",
     {
       title: "Create workflow",
@@ -287,13 +299,15 @@ export function registerWorkflowTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["workflows:write"],
     async (input: TMcpCreateWorkflowInput, extra) =>
       runWorkflowMutation(extra, "created", (ctx) =>
         workflowsHandlers.create({ req: buildWorkflowsBodyRequest(input), ctx })
       )
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "patch_workflow",
     {
       title: "Patch workflow",
@@ -309,6 +323,7 @@ export function registerWorkflowTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["workflows:write"],
     async (input: TMcpPatchWorkflowInput, extra) =>
       runWorkflowMutation(extra, "updated", (ctx) =>
         workflowsHandlers.patch({
@@ -319,7 +334,8 @@ export function registerWorkflowTools(server: McpServer): void {
       )
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "duplicate_workflow",
     {
       title: "Duplicate workflow",
@@ -333,6 +349,7 @@ export function registerWorkflowTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["workflows:write"],
     async (input: TMcpDuplicateWorkflowInput, extra) =>
       runWorkflowMutation(extra, "created", (ctx) =>
         workflowsHandlers.duplicate({
@@ -343,7 +360,8 @@ export function registerWorkflowTools(server: McpServer): void {
       )
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "delete_workflow",
     {
       title: "Delete workflow",
@@ -356,13 +374,15 @@ export function registerWorkflowTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["workflows:write"],
     async (input: TMcpWorkflowIdInput, extra) =>
       runWorkflowMutation(extra, "deleted", (ctx) =>
         workflowsHandlers.delete({ ctx, params: { workflowId: input.workflowId } })
       )
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "enable_workflow",
     {
       title: "Enable workflow",
@@ -380,13 +400,15 @@ export function registerWorkflowTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["workflows:write"],
     async (input: TMcpWorkflowIdInput, extra) =>
       runWorkflowMutation(extra, "updated", (ctx) =>
         workflowsHandlers.enable({ ctx, params: { workflowId: input.workflowId } })
       )
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "disable_workflow",
     {
       title: "Disable workflow",
@@ -400,13 +422,15 @@ export function registerWorkflowTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["workflows:write"],
     async (input: TMcpWorkflowIdInput, extra) =>
       runWorkflowMutation(extra, "updated", (ctx) =>
         workflowsHandlers.disable({ ctx, params: { workflowId: input.workflowId } })
       )
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "archive_workflow",
     {
       title: "Archive workflow",
@@ -420,13 +444,15 @@ export function registerWorkflowTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["workflows:write"],
     async (input: TMcpWorkflowIdInput, extra) =>
       runWorkflowMutation(extra, "updated", (ctx) =>
         workflowsHandlers.archive({ ctx, params: { workflowId: input.workflowId } })
       )
   );
 
-  server.registerTool(
+  registerScopedTool(
+    server,
     "unarchive_workflow",
     {
       title: "Unarchive workflow",
@@ -439,6 +465,7 @@ export function registerWorkflowTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["workflows:write"],
     async (input: TMcpWorkflowIdInput, extra) =>
       runWorkflowMutation(extra, "updated", (ctx) =>
         workflowsHandlers.unarchive({ ctx, params: { workflowId: input.workflowId } })

--- a/apps/web/modules/mcp/tools/workflows.ts
+++ b/apps/web/modules/mcp/tools/workflows.ts
@@ -1,12 +1,12 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { logger } from "@formbricks/logger";
-import { buildV3AuditLog, queueV3AuditLog } from "@/app/api/v3/lib/audit";
+import { buildV3AuditLog } from "@/app/api/v3/lib/audit";
 import { buildWorkflowApiContext, workflowsHandlers } from "@/app/api/v3/workflows/lib/context";
 import { MCP_API_ROUTE } from "@/modules/mcp/constants";
 import { getMcpAuthentication, getMcpRequestId } from "../auth";
 import { responseToMcpToolResult } from "../errors";
 import { registerScopedTool } from "./guard-scopes";
+import { runMcpMutation } from "./run-mcp-mutation";
 import {
   type TMcpCreateWorkflowInput,
   type TMcpDuplicateWorkflowInput,
@@ -119,33 +119,11 @@ async function runWorkflowMutation(
   action: Parameters<typeof buildV3AuditLog>[1],
   run: (ctx: WorkflowApiContext) => Promise<Response>
 ): Promise<CallToolResult> {
-  const requestId = getMcpRequestId(extra.authInfo);
-  const authentication = getMcpAuthentication(extra.authInfo);
-  const log = logger.withContext({ requestId });
-  const auditLog = buildV3AuditLog(authentication, action, "workflow", MCP_API_ROUTE);
-
-  try {
-    const ctx = buildWorkflowApiContext(authentication, requestId, MCP_API_ROUTE, auditLog ?? undefined);
-    const response = await run(ctx);
-
-    if (auditLog) {
-      if (response.ok) {
-        auditLog.status = "success";
-      } else {
-        auditLog.eventId = requestId;
-      }
-    }
-
-    await queueV3AuditLog(auditLog, requestId, log);
-    return await responseToMcpToolResult(response, requestId);
-  } catch (error) {
-    if (auditLog) {
-      auditLog.eventId = requestId;
-      await queueV3AuditLog(auditLog, requestId, log);
-    }
-
-    throw error;
-  }
+  // The shared runner owns the audit lifecycle; workflows only differ in building their API context
+  // (which threads the same auditLog through) before delegating to the caller's operation.
+  return runMcpMutation(extra, { action, resource: "workflow" }, ({ authentication, requestId, auditLog }) =>
+    run(buildWorkflowApiContext(authentication, requestId, MCP_API_ROUTE, auditLog ?? undefined))
+  );
 }
 
 export function registerWorkflowTools(server: McpServer): void {

--- a/apps/web/modules/mcp/tools/workspaces.ts
+++ b/apps/web/modules/mcp/tools/workspaces.ts
@@ -3,11 +3,13 @@ import { listV3Workspaces } from "@/app/api/v3/workspaces/lib/operations";
 import { MCP_API_ROUTE } from "@/modules/mcp/constants";
 import { getMcpAuthentication, getMcpRequestId } from "../auth";
 import { responseToMcpToolResult } from "../errors";
-import { guardMcpScopes } from "./guard-scopes";
+import { registerScopedTool } from "./guard-scopes";
 import { type TMcpListWorkspacesInput, ZMcpListWorkspacesInput } from "./schemas";
 
 export function registerWorkspaceTools(server: McpServer): void {
-  server.registerTool(
+  // Listing workspaces is the read-prerequisite for the survey read tools, so it reuses surveys:read.
+  registerScopedTool(
+    server,
     "list_workspaces",
     {
       title: "List workspaces",
@@ -21,14 +23,9 @@ export function registerWorkspaceTools(server: McpServer): void {
         openWorldHint: true,
       },
     },
+    ["surveys:read"],
     async (_input: TMcpListWorkspacesInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
-      // Listing workspaces is the read-prerequisite for the survey read tools, so it reuses surveys:read.
-      const scopeError = await guardMcpScopes(extra.authInfo, ["surveys:read"], requestId);
-      if (scopeError) {
-        return scopeError;
-      }
-
       const response = await listV3Workspaces({
         authentication: getMcpAuthentication(extra.authInfo),
         requestId,

--- a/apps/web/modules/mcp/tools/workspaces.ts
+++ b/apps/web/modules/mcp/tools/workspaces.ts
@@ -7,7 +7,12 @@ import { registerScopedTool } from "./guard-scopes";
 import { type TMcpListWorkspacesInput, ZMcpListWorkspacesInput } from "./schemas";
 
 export function registerWorkspaceTools(server: McpServer): void {
-  // Listing workspaces is the read-prerequisite for the survey read tools, so it reuses surveys:read.
+  // list_workspaces is the workspaceId-discovery prerequisite for BOTH the survey and workflow tools.
+  // It gates on surveys:read because that is the mandatory MCP baseline read scope: auth.ts rejects any
+  // token that lacks it, and every issued token carries it (API keys always include surveys:read +
+  // workflows:read; DCR clients default to the full advertised set). So workflows:* is always granted
+  // alongside surveys:read — a workflows-only token is intentionally unsupported (see the handbook).
+  // Supporting one would require relaxing the auth.ts baseline to "any resource read scope" (follow-up).
   registerScopedTool(
     server,
     "list_workspaces",

--- a/docs/development/technical-handbook/mcp-server.mdx
+++ b/docs/development/technical-handbook/mcp-server.mdx
@@ -76,23 +76,33 @@ Discovery endpoints:
 
 Supported scopes:
 
-| Scope             | Use                                                                       |
-| ----------------- | ------------------------------------------------------------------------- |
-| `surveys:read`    | `list_surveys`, `get_survey`, and read-only validation paths              |
-| `surveys:write`   | `create_survey`, `patch_survey`, `delete_survey`, and write validations   |
-| `openid`          | OpenID Connect subject interoperability                                   |
-| `profile`         | User profile claims                                                       |
-| `email`           | User email claim                                                          |
-| `offline_access`  | Refresh tokens for MCP clients                                            |
+| Scope              | Use                                                                       |
+| ------------------ | ------------------------------------------------------------------------- |
+| `surveys:read`     | `list_surveys`, `get_survey`, and read-only validation paths              |
+| `surveys:write`    | `create_survey`, `patch_survey`, `delete_survey`, and write validations   |
+| `workflows:read`   | `list_workflows`, `get_workflow`, `list_workflow_runs`, `get_workflow_run`, `test_workflow` |
+| `workflows:write`  | `create_workflow`, `patch_workflow`, `duplicate_workflow`, `delete_workflow`, and the enable/disable/archive/unarchive mutations |
+| `openid`           | OpenID Connect subject interoperability                                   |
+| `profile`          | User profile claims                                                       |
+| `email`            | User email claim                                                          |
+| `offline_access`   | Refresh tokens for MCP clients                                            |
+
+**The rule:** every MCP tool is registered through `registerScopedTool`, which takes the required
+scope(s) as a mandatory argument and runs the gate before the handler. Read tools declare
+`<resource>:read`; every mutating tool declares `<resource>:write`. A tool cannot be registered
+without declaring a scope, so a new tool inherits enforcement by construction — the gate returns a
+`403 insufficient_scope` before the handler touches a v3 operation.
 
 The authorization server supports all of the above, but the MCP protected-resource metadata
-(`/.well-known/oauth-protected-resource/api/mcp`) advertises only `surveys:read`, `surveys:write`,
-and `offline_access` — the scopes an MCP client needs. Clients derive their Dynamic Client
-Registration scopes from that list, so `offline_access` must be advertised there for clients to be
-issued refresh tokens (`openid`/`profile`/`email` are OIDC scopes the MCP resource does not require).
+(`/.well-known/oauth-protected-resource/api/mcp`) advertises only the resource scopes an MCP client
+needs — `surveys:read`, `surveys:write`, `workflows:read`, `workflows:write`, and `offline_access`.
+Clients derive their Dynamic Client Registration scopes from that list, so `offline_access` must be
+advertised there for clients to be issued refresh tokens (`openid`/`profile`/`email` are OIDC scopes
+the MCP resource does not require).
 
-OAuth scopes only gate MCP tool categories. Actual workspace access is still evaluated at tool
-execution through the existing v3 authorization checks for the signed-in Formbricks user.
+OAuth scopes gate MCP tool categories at the token layer. Actual workspace access is still evaluated
+at tool execution through the existing v3 authorization checks for the signed-in Formbricks user, so
+a token scope and a workspace role are independent gates — a call must satisfy both.
 
 ### API-key fallback
 
@@ -135,9 +145,10 @@ API key permissions are enforced through the same workspace access checks as the
 | `archive_workflow`    | `write` or `manage` |
 | `unarchive_workflow`  | `write` or `manage` |
 
-Advertised MCP scopes: `surveys:read` + `workflows:read` always; `surveys:write` + `workflows:write`
-when the key has `write` or `manage` on any workspace. Scopes are advisory — the per-workspace access
-check above is the real enforcement.
+Synthesized MCP scopes for an API key: `surveys:read` + `workflows:read` always; `surveys:write` +
+`workflows:write` when the key has `write` or `manage` on any workspace. The scope gate and the
+per-workspace access check above are independent — a `:write` tool requires **both** the `:write`
+scope on the token and write/manage on the target workspace.
 
 <Warning>
   Store fallback MCP API keys as environment variables or client secrets. Do not commit API keys into MCP client
@@ -179,14 +190,14 @@ curl -sS -X POST http://localhost:3000/api/auth/oauth2/register \
     "token_endpoint_auth_method": "none",
     "grant_types": ["authorization_code", "refresh_token"],
     "response_types": ["code"],
-    "scope": "openid profile email offline_access surveys:read surveys:write"
+    "scope": "openid profile email offline_access surveys:read surveys:write workflows:read workflows:write"
   }'
 ```
 
 <Note>
   This passes `scope` explicitly, so it does **not** reproduce a real client's behavior — real MCP
   clients register with the scopes from the protected-resource metadata's `scopes_supported`
-  (`surveys:read surveys:write offline_access`). Because the authorization server validates the
+  (`surveys:read surveys:write workflows:read workflows:write offline_access`). Because the authorization server validates the
   `/authorize` request against the client's **registered** scopes, a client that registers with a
   narrower set than it later requests (e.g. it registers surveys-only but requests `offline_access`)
   is rejected with `invalid_scope`. To smoke-test the real path, omit `scope` and let the client
@@ -228,14 +239,14 @@ Authenticate and request the scopes the agent needs:
 
 ```bash
 codex mcp login formbricks-local \
-  --scopes openid,profile,email,offline_access,surveys:read,surveys:write
+  --scopes openid,profile,email,offline_access,surveys:read,surveys:write,workflows:read,workflows:write
 ```
 
-For read-only usage, omit `surveys:write`:
+For read-only usage, omit the `:write` scopes:
 
 ```bash
 codex mcp login formbricks-local \
-  --scopes openid,profile,email,offline_access,surveys:read
+  --scopes openid,profile,email,offline_access,surveys:read,workflows:read
 ```
 
 Codex opens the browser to Formbricks, completes Dynamic Client Registration, and stores the OAuth
@@ -299,10 +310,11 @@ claude mcp add --transport http formbricks-local http://localhost:3000/api/mcp
 
 Run `/mcp` and authenticate `formbricks-local`. Claude Code discovers the MCP protected-resource
 metadata, registers a public client whose scopes are taken from that metadata's `scopes_supported`
-(`surveys:read surveys:write offline_access`), and launches the browser-based OAuth flow — there is
-no scope-entry step. You approve the requested scopes on the Formbricks consent screen. Workspace
-role determines whether `surveys:write` tools actually succeed at execution time (see
-[Authentication](#authentication)), regardless of the granted scope.
+(`surveys:read surveys:write workflows:read workflows:write offline_access`), and launches the
+browser-based OAuth flow — there is no scope-entry step. You approve the requested scopes on the
+Formbricks consent screen. A `:write` tool requires both the matching `:write` scope on the token and
+write/manage permission on the target workspace at execution time (see
+[Authentication](#authentication)).
 
 Verify it:
 

--- a/docs/development/technical-handbook/mcp-server.mdx
+++ b/docs/development/technical-handbook/mcp-server.mdx
@@ -93,6 +93,13 @@ scope(s) as a mandatory argument and runs the gate before the handler. Read tool
 without declaring a scope, so a new tool inherits enforcement by construction — the gate returns a
 `403 insufficient_scope` before the handler touches a v3 operation.
 
+**`surveys:read` is the mandatory baseline read scope.** Authentication rejects any MCP token that
+lacks it, and `list_workspaces` — the workspaceId-discovery prerequisite for *all* resource tools,
+including the workflow tools — gates on it. `workflows:*` is additive, always granted alongside
+`surveys:read` (API keys include both; DCR clients default to the full advertised set). A
+**workflows-only token is therefore not currently supported**; enabling one would mean relaxing the
+baseline to "any resource read scope".
+
 The authorization server supports all of the above, but the MCP protected-resource metadata
 (`/.well-known/oauth-protected-resource/api/mcp`) advertises only the resource scopes an MCP client
 needs — `surveys:read`, `surveys:write`, `workflows:read`, `workflows:write`, and `offline_access`.

--- a/docs/platform/mcp/overview.mdx
+++ b/docs/platform/mcp/overview.mdx
@@ -36,16 +36,20 @@ The whole flow uses Authorization Code + PKCE, the standard the [MCP authorizati
 
 ## What the agent can do
 
-The MCP server exposes six survey tools, grouped into two scopes you approve on the consent screen:
+The MCP server exposes survey and workflow tools, grouped into scopes you approve on the consent
+screen. Read tools require the matching `:read` scope; tools that create, update, or delete require
+the `:write` scope:
 
 | Scope | Tools | What it allows |
 | --- | --- | --- |
 | `surveys:read` | `list_surveys`, `get_survey`, `validate_survey` | Read surveys and validate survey documents |
 | `surveys:write` | `create_survey`, `patch_survey`, `delete_survey` | Create, update, and delete surveys |
+| `workflows:read` | `list_workflows`, `get_workflow`, `list_workflow_runs`, `get_workflow_run`, `test_workflow` | Read workflows and their runs |
+| `workflows:write` | `create_workflow`, `patch_workflow`, `duplicate_workflow`, `delete_workflow`, `enable_workflow`, `disable_workflow`, `archive_workflow`, `unarchive_workflow` | Create, update, and delete workflows |
 
 <Warning>
   Scopes are only a coarse gate. **Access is always bounded by your Formbricks workspace role**: even
-  if a client holds `surveys:write`, a call only succeeds if you have write/manage permission on the
+  if a client holds a `:write` scope, a call only succeeds if you have write/manage permission on the
   target workspace. An agent can never do more than you can.
 </Warning>
 

--- a/docs/platform/mcp/overview.mdx
+++ b/docs/platform/mcp/overview.mdx
@@ -44,8 +44,10 @@ the `:write` scope:
 | --- | --- | --- |
 | `surveys:read` | `list_surveys`, `get_survey`, `validate_survey` | Read surveys and validate survey documents |
 | `surveys:write` | `create_survey`, `patch_survey`, `delete_survey` | Create, update, and delete surveys |
-| `workflows:read` | `list_workflows`, `get_workflow`, `list_workflow_runs`, `get_workflow_run`, `test_workflow` | Read workflows and their runs |
+| `workflows:read` | `list_workflows`, `get_workflow`, `list_workflow_runs`, `get_workflow_run`, `test_workflow`¹ | Read workflows and their runs |
 | `workflows:write` | `create_workflow`, `patch_workflow`, `duplicate_workflow`, `delete_workflow`, `enable_workflow`, `disable_workflow`, `archive_workflow`, `unarchive_workflow` | Create, update, and delete workflows |
+
+¹ `test_workflow` is a dry-run (no changes are saved), so it only needs the `workflows:read` scope — but because it evaluates the live workflow definition, it requires **write or manage** permission on the workspace. A read-only member will get a 403 even though the scope matches.
 
 <Warning>
   Scopes are only a coarse gate. **Access is always bounded by your Formbricks workspace role**: even

--- a/docs/platform/mcp/setup.mdx
+++ b/docs/platform/mcp/setup.mdx
@@ -94,7 +94,7 @@ Use this for **claude.ai** and **Claude Desktop**, where Formbricks is added as 
     Codex opens the browser to Formbricks, registers itself, and you **approve** on the consent
     screen. For read-only access, restrict the scopes:
     ```bash
-    codex mcp login formbricks --scopes surveys:read,offline_access
+    codex mcp login formbricks --scopes surveys:read,workflows:read,offline_access
     ```
   </Step>
   <Step title="Verify">
@@ -141,7 +141,8 @@ periodically for safety.
   </Accordion>
   <Accordion title="invalid_scope during sign-in">
     The client requested a scope it isn't registered for. Reconnect from scratch so it re-registers
-    with the scopes the server advertises (`surveys:read`, `surveys:write`, `offline_access`).
+    with the scopes the server advertises (`surveys:read`, `surveys:write`, `workflows:read`,
+    `workflows:write`, `offline_access`).
   </Accordion>
   <Accordion title="Stuck in a consent loop / keeps asking you to sign in">
     Usually a cookie or stale-session issue. Make sure you're signed in to Formbricks in the same
@@ -151,8 +152,10 @@ periodically for safety.
     incorrect base URL (see below) also causes repeated redirects.
   </Accordion>
   <Accordion title="A tool call fails even though you're connected">
-    Scopes don't override your workspace role. Creating, editing, or deleting surveys requires
-    `write` or `manage` permission on that workspace — ask a workspace owner/manager to grant it.
+    Scopes don't override your workspace role. Creating, editing, or deleting surveys or workflows
+    requires `write` or `manage` permission on that workspace — ask a workspace owner/manager to grant
+    it. A `:write` tool also 403s if your token was only granted the matching `:read` scope; reconnect
+    and approve write access.
   </Accordion>
   <Accordion title="Self-hosted: the browser can't complete sign-in / redirects fail">
     OAuth discovery and redirects are built from your configured base URL. Serve Formbricks from a

--- a/docs/platform/mcp/setup.mdx
+++ b/docs/platform/mcp/setup.mdx
@@ -154,8 +154,9 @@ periodically for safety.
   <Accordion title="A tool call fails even though you're connected">
     Scopes don't override your workspace role. Creating, editing, or deleting surveys or workflows
     requires `write` or `manage` permission on that workspace — ask a workspace owner/manager to grant
-    it. A `:write` tool also 403s if your token was only granted the matching `:read` scope; reconnect
-    and approve write access.
+    it. `test_workflow` also needs `write`/`manage` even though it's a read-scoped dry-run, because it
+    evaluates the live workflow definition. A `:write` tool likewise 403s if your token was only granted
+    the matching `:read` scope; reconnect and approve write access.
   </Accordion>
   <Accordion title="Self-hosted: the browser can't complete sign-in / redirects fail">
     OAuth discovery and redirects are built from your configured base URL. Serve Formbricks from a


### PR DESCRIPTION
## What does this PR do?

Security fix from the workflows-epic QA ([ENG-1967](https://linear.app/formbricks/issue/ENG-1967)). **Stacked on `epic/workflows-v1`** (the workflow MCP tools don't exist on `main`), so please review/merge against that base.

The MCP workflow write tools mutated with no MCP-layer OAuth scope check — `workflows.ts` never called `guardMcpScopes`, so all 8 mutations (`create`/`patch`/`duplicate`/`delete`/`enable`/`disable`/`archive`/`unarchive`) leaned only on the downstream v3 workspace-permission check. A read-scoped OAuth token held by a write-capable user could therefore still write via MCP — the token exceeded its granted scope. This is the **token-scope** boundary (defense-in-depth), not user-privilege escalation: workspace authz still blocks a read-only *user*. Survey write tools already did this correctly (`surveys:write`); this brings workflow tools to parity and makes the guarantee structural.

What changed:

- **`workflows:read` / `workflows:write` are now first-class OAuth scopes** alongside `surveys:*` — advertised in the challenge, the protected-resource metadata (PRM), the DCR default scopes, and the consent screen, with the same 15m step-up expiry on `:write`. Without this, a token could never actually carry a workflow scope. `surveys:*` is unchanged. (Migration note: OAuth tokens issued before this change lack `workflows:*`, so QA clients must re-authorize to pick up the new DCR defaults — acceptable on an unreleased epic.)
- **`registerScopedTool`** — a single registration path where the required scope is a *mandatory* argument and the gate runs before the handler. A tool literally can't be registered without declaring a scope, so a new tool inherits enforcement by construction (this is how the gap happened — a per-tool `guardMcpScopes` call is easy to forget). All survey, workflow, and workspace tools are migrated onto it; the survey/workspace migration is refactor-only (no behavior change) but closes the "forgot the guard" class for good.
- Read tools require `<resource>:read`, mutating tools `<resource>:write`; a token missing the scope gets `403 insufficient_scope` before any mutation or audit log runs.
- Docs updated (overview, setup, technical handbook) to list the workflow scopes and state the rule.

The v3 workspace-authorization layer is untouched — this only adds the token-scope gate in front of it, so a `:write` call now has to satisfy both.

## How should this be tested?

Automated (all green locally):

```bash
pnpm --filter=@formbricks/web exec vitest run \
  modules/mcp/tools/workflows.test.ts \
  modules/mcp/tools/surveys.test.ts \
  modules/mcp/tools/workspaces.test.ts \
  modules/mcp/tools/guard-scopes.test.ts \
  modules/mcp/auth.test.ts \
  modules/auth/lib/oauth-client-metadata.test.ts \
  modules/auth/lib/mcp-oauth-dcr.test.ts \
  app/.well-known/oauth-protected-resource/route.test.ts \
  app/api/mcp/route.test.ts
```

Coverage on the new code: `guard-scopes.ts` 100%, `workflows.ts` ~93% (the uncovered lines are pre-existing audit-log branches, not the scope gate). New/updated cases assert the allowed **and** denied paths for read-only vs write-scoped tokens, at both the tool layer and the JSON-RPC route layer.

Manual (MCP, API-key path, like the ENG-1776 smoke test):

1. Connect with an API key that has only `read` on the workspace → its token carries `workflows:read` but not `workflows:write`. `create_workflow` / `delete_workflow` return `403` (`OAuth token does not include the required MCP scope`); `list_workflows` succeeds.
2. Connect with a `write`/`manage` key → workflow write tools succeed.
3. `GET /.well-known/oauth-protected-resource/api/mcp` and `tools/list` advertise `workflows:read` + `workflows:write`.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` (ran targeted typecheck + lint + the affected Vitest suites instead)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main` (stacked on `epic/workflows-v1`, rebased on its latest head)
- [x] My changes don't cause any responsiveness issues (backend + docs only, no UI)

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR (no UI change)
- [x] Updated the Formbricks Docs if changes were necessary
