### PR TITLE
fix: stop echoing raw error.message in v1 API 500 responses

### DIFF
--- a/apps/web/app/api/v1/auth.test.ts
+++ b/apps/web/app/api/v1/auth.test.ts
@@ -299,11 +299,12 @@ describe("handleErrorResponse", () => {
     expect(body.message).toBe("Action with name foo already exists");
   });
 
-  test("returns 400 badRequest for DatabaseError", async () => {
+  test("returns a generic 500 for DatabaseError without leaking the message", async () => {
     const response = handleErrorResponse(new DatabaseError("db boom"));
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(500);
     const body = await response.json();
-    expect(body.message).toBe("db boom");
+    expect(body.message).toBe("Something went wrong. Please try again.");
+    expect(JSON.stringify(body)).not.toContain("db boom");
   });
 
   test("returns 400 badRequest for InvalidInputError", async () => {
@@ -327,10 +328,10 @@ describe("handleErrorResponse", () => {
     });
   });
 
-  test("returns 500 internalServerError for unknown errors", async () => {
+  test("returns a generic 500 for unknown errors", async () => {
     const response = handleErrorResponse(new Error("something else"));
     expect(response.status).toBe(500);
     const body = await response.json();
-    expect(body.message).toBe("Some error occurred");
+    expect(body.message).toBe("Something went wrong. Please try again.");
   });
 });

--- a/apps/web/app/api/v1/auth.test.ts
+++ b/apps/web/app/api/v1/auth.test.ts
@@ -278,29 +278,33 @@ describe("authenticateRequest", () => {
 
 describe("handleErrorResponse", () => {
   test("returns 401 notAuthenticated for 'NotAuthenticated' message", async () => {
-    const response = handleErrorResponse(new Error("NotAuthenticated"));
+    const { response } = handleErrorResponse(new Error("NotAuthenticated"));
     expect(response.status).toBe(401);
     const body = await response.json();
     expect(body.code).toBe("not_authenticated");
   });
 
   test("returns 401 unauthorized for 'Unauthorized' message", async () => {
-    const response = handleErrorResponse(new Error("Unauthorized"));
+    const { response } = handleErrorResponse(new Error("Unauthorized"));
     expect(response.status).toBe(401);
     const body = await response.json();
     expect(body.code).toBe("unauthorized");
   });
 
   test("returns 409 conflict for UniqueConstraintError", async () => {
-    const response = handleErrorResponse(new UniqueConstraintError("Action with name foo already exists"));
+    const { response } = handleErrorResponse(new UniqueConstraintError("Action with name foo already exists"));
     expect(response.status).toBe(409);
     const body = await response.json();
     expect(body.code).toBe("conflict");
     expect(body.message).toBe("Action with name foo already exists");
   });
 
-  test("returns a generic 500 for DatabaseError without leaking the message", async () => {
-    const response = handleErrorResponse(new DatabaseError("db boom"));
+  test("returns a generic 500 for DatabaseError, threads the real error, and doesn't leak the message", async () => {
+    const error = new DatabaseError("db boom");
+    const { response, error: reportedError } = handleErrorResponse(error);
+    // The real error must reach the wrapper's reportApiError (not a synthetic one), so 5xx errors
+    // from routes still on handleErrorResponse keep their Sentry signal.
+    expect(reportedError).toBe(error);
     expect(response.status).toBe(500);
     const body = await response.json();
     expect(body.message).toBe("Something went wrong. Please try again.");
@@ -308,14 +312,14 @@ describe("handleErrorResponse", () => {
   });
 
   test("returns 400 badRequest for InvalidInputError", async () => {
-    const response = handleErrorResponse(new InvalidInputError("bad input"));
+    const { response } = handleErrorResponse(new InvalidInputError("bad input"));
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.message).toBe("bad input");
   });
 
   test("returns 404 notFound for ResourceNotFoundError", async () => {
-    const response = handleErrorResponse(new ResourceNotFoundError("Survey", "id-1"));
+    const { response } = handleErrorResponse(new ResourceNotFoundError("Survey", "id-1"));
     expect(response.status).toBe(404);
     const body = await response.json();
     expect(body).toEqual({
@@ -329,7 +333,7 @@ describe("handleErrorResponse", () => {
   });
 
   test("returns a generic 500 for unknown errors", async () => {
-    const response = handleErrorResponse(new Error("something else"));
+    const { response } = handleErrorResponse(new Error("something else"));
     expect(response.status).toBe(500);
     const body = await response.json();
     expect(body.message).toBe("Something went wrong. Please try again.");

--- a/apps/web/app/api/v1/auth.ts
+++ b/apps/web/app/api/v1/auth.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { TAuthenticationApiKey } from "@formbricks/types/auth";
-import { handleApiError } from "@/app/lib/api/handle-api-error";
+import { type ApiErrorResult, handleApiError } from "@/app/lib/api/handle-api-error";
 import { responses } from "@/app/lib/api/response";
 import {
   type AuthenticateApiKeyOptions,
@@ -14,15 +14,17 @@ export const authenticateRequest = async (
   return await authenticateApiKeyFromHeaders(request.headers, options);
 };
 
-export const handleErrorResponse = (error: any): Response => {
-  switch (error.message) {
+export const handleErrorResponse = (error: unknown): ApiErrorResult => {
+  const message = error instanceof Error ? error.message : undefined;
+  switch (message) {
     case "NotAuthenticated":
-      return responses.notAuthenticatedResponse();
+      return { response: responses.notAuthenticatedResponse() };
     case "Unauthorized":
-      return responses.unauthorizedResponse();
+      return { response: responses.unauthorizedResponse() };
     default:
-      // Delegate to the shared boundary: expected 4xx errors keep their status/message; a
-      // DatabaseError or anything unexpected becomes a generic 500 (never echo internals).
-      return handleApiError(error).response;
+      // Delegate to the shared boundary and return its full { response, error } result — not just
+      // `.response` — so the wrapper's reportApiError receives the real 5xx error (e.g. a
+      // DatabaseError) instead of a synthetic one. Expected 4xx errors keep their status/message.
+      return handleApiError(error);
   }
 };

--- a/apps/web/app/api/v1/auth.ts
+++ b/apps/web/app/api/v1/auth.ts
@@ -1,11 +1,6 @@
 import { NextRequest } from "next/server";
 import { TAuthenticationApiKey } from "@formbricks/types/auth";
-import {
-  DatabaseError,
-  InvalidInputError,
-  ResourceNotFoundError,
-  UniqueConstraintError,
-} from "@formbricks/types/errors";
+import { handleApiError } from "@/app/lib/api/handle-api-error";
 import { responses } from "@/app/lib/api/response";
 import {
   type AuthenticateApiKeyOptions,
@@ -26,15 +21,8 @@ export const handleErrorResponse = (error: any): Response => {
     case "Unauthorized":
       return responses.unauthorizedResponse();
     default:
-      if (error instanceof UniqueConstraintError) {
-        return responses.conflictResponse(error.message);
-      }
-      if (error instanceof ResourceNotFoundError) {
-        return responses.notFoundResponse(error.resourceType, error.resourceId);
-      }
-      if (error instanceof DatabaseError || error instanceof InvalidInputError) {
-        return responses.badRequestResponse(error.message);
-      }
-      return responses.internalServerErrorResponse("Some error occurred");
+      // Delegate to the shared boundary: expected 4xx errors keep their status/message; a
+      // DatabaseError or anything unexpected becomes a generic 500 (never echo internals).
+      return handleApiError(error).response;
   }
 };

--- a/apps/web/app/api/v1/client/[workspaceId]/displays/[displayId]/response/route.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/displays/[displayId]/response/route.ts
@@ -1,5 +1,5 @@
-import { logger } from "@formbricks/logger";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
+import { handleApiError } from "@/app/lib/api/handle-api-error";
 import { responses } from "@/app/lib/api/response";
 import { THandlerParams, withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
 import { resolveClientApiIds } from "@/lib/utils/resolve-client-id";
@@ -11,7 +11,6 @@ export const OPTIONS = async (): Promise<Response> => {
 
 export const GET = withV1ApiWrapper({
   handler: async ({
-    req,
     props,
   }: THandlerParams<{ params: Promise<{ workspaceId: string; displayId: string }> }>) => {
     const params = await props.params;
@@ -36,14 +35,7 @@ export const GET = withV1ApiWrapper({
           response: responses.notFoundResponse("Display", params.displayId, true),
         };
       }
-
-      logger.error(
-        { error, url: req.url, workspaceId, displayId: params.displayId },
-        "Error in GET /api/v1/client/[workspaceId]/displays/[displayId]/response"
-      );
-      return {
-        response: responses.internalServerErrorResponse("Something went wrong. Please try again."),
-      };
+      return handleApiError(error, { cors: true });
     }
   },
 });

--- a/apps/web/app/api/v1/client/[workspaceId]/displays/route.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/displays/route.ts
@@ -1,6 +1,6 @@
-import { logger } from "@formbricks/logger";
 import { ZDisplayCreateInput } from "@formbricks/types/displays";
 import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { handleApiError } from "@/app/lib/api/handle-api-error";
 import { RequestBodyTooLargeError, parseJsonBodyWithLimit } from "@/app/lib/api/request-body";
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
@@ -89,20 +89,17 @@ export const POST = withV1ApiWrapper({
     } catch (error) {
       if (error instanceof ResourceNotFoundError) {
         return {
-          response: responses.notFoundResponse("Survey", inputValidation.data.surveyId),
+          response: responses.notFoundResponse("Survey", inputValidation.data.surveyId, true),
         };
-      } else if (error instanceof InvalidInputError) {
+      }
+      if (error instanceof InvalidInputError) {
         return {
           response: responses.forbiddenResponse(error.message, true, {
             surveyId: inputValidation.data.surveyId,
           }),
         };
-      } else {
-        logger.error({ error, url: req.url }, "Error in POST /api/v1/client/[workspaceId]/displays");
-        return {
-          response: responses.internalServerErrorResponse("Something went wrong. Please try again."),
-        };
       }
+      return handleApiError(error, { cors: true });
     }
   },
 });

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.test.ts
@@ -13,7 +13,6 @@ const mocks = vi.hoisted(() => ({
   getResponse: vi.fn(),
   getSurvey: vi.fn(),
   getValidatedResponseUpdateInput: vi.fn(),
-  loggerError: vi.fn(),
   resolveClientApiIds: vi.fn(),
   sendToPipeline: vi.fn(),
   updateResponseWithQuotaEvaluation: vi.fn(),
@@ -21,12 +20,6 @@ const mocks = vi.hoisted(() => ({
   validateOtherOptionLengthForMultipleChoice: vi.fn(),
   validateResponseData: vi.fn(),
   verifyLinkSurveyPinToken: vi.fn(),
-}));
-
-vi.mock("@formbricks/logger", () => ({
-  logger: {
-    error: mocks.loggerError,
-  },
 }));
 
 vi.mock("@/app/lib/pipelines", () => ({

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.test.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.test.ts
@@ -220,26 +220,20 @@ describe("putResponseHandler", () => {
     });
   });
 
-  test("maps database lookup errors to a reported internal server error", async () => {
+  test("maps database lookup errors to an internal server error without leaking the message", async () => {
     const error = new DatabaseError("Lookup failed");
     mocks.getResponse.mockRejectedValue(error);
 
     const result = await putResponseHandler(createHandlerParams());
 
+    // The real error is threaded back so the wrapper logs/reports it; the client sees a generic message.
     expect(result.error).toBe(error);
     expect(result.response.status).toBe(500);
     await expect(result.response.json()).resolves.toEqual({
       code: "internal_server_error",
-      message: "Lookup failed",
+      message: "Something went wrong. Please try again.",
       details: {},
     });
-    expect(mocks.loggerError).toHaveBeenCalledWith(
-      {
-        error,
-        url: createRequest().url,
-      },
-      "Error in PUT /api/v1/client/[workspaceId]/responses/[responseId]"
-    );
   });
 
   test("maps unknown lookup failures to a generic internal server error", async () => {
@@ -252,7 +246,7 @@ describe("putResponseHandler", () => {
     expect(result.response.status).toBe(500);
     await expect(result.response.json()).resolves.toEqual({
       code: "internal_server_error",
-      message: "Unknown error occurred",
+      message: "Something went wrong. Please try again.",
       details: {},
     });
   });
@@ -470,7 +464,7 @@ describe("putResponseHandler", () => {
     });
   });
 
-  test("returns a reported internal server error for database update failures", async () => {
+  test("returns an internal server error for database update failures without leaking the message", async () => {
     const error = new DatabaseError("Update failed");
     mocks.updateResponseWithQuotaEvaluation.mockRejectedValue(error);
 
@@ -480,16 +474,9 @@ describe("putResponseHandler", () => {
     expect(result.response.status).toBe(500);
     await expect(result.response.json()).resolves.toEqual({
       code: "internal_server_error",
-      message: "Update failed",
+      message: "Something went wrong. Please try again.",
       details: {},
     });
-    expect(mocks.loggerError).toHaveBeenCalledWith(
-      {
-        error,
-        url: createRequest().url,
-      },
-      "Error in PUT /api/v1/client/[workspaceId]/responses/[responseId]"
-    );
   });
 
   test("returns a generic internal server error for unexpected update failures", async () => {
@@ -502,16 +489,9 @@ describe("putResponseHandler", () => {
     expect(result.response.status).toBe(500);
     await expect(result.response.json()).resolves.toEqual({
       code: "internal_server_error",
-      message: "Something went wrong",
+      message: "Something went wrong. Please try again.",
       details: {},
     });
-    expect(mocks.loggerError).toHaveBeenCalledWith(
-      {
-        error,
-        url: createRequest().url,
-      },
-      "Error in PUT /api/v1/client/[workspaceId]/responses/[responseId]"
-    );
   });
 
   test("returns a success payload and emits a responseUpdated pipeline event", async () => {

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.ts
@@ -2,7 +2,7 @@ import { RESPONSE_ALREADY_FINISHED_ERROR_CODE, ResourceNotFoundError } from "@fo
 import { TResponse, TResponseUpdateInput } from "@formbricks/types/responses";
 import { TSurveyElement } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
-import { handleApiError } from "@/app/lib/api/handle-api-error";
+import { type ApiErrorResult, handleApiError } from "@/app/lib/api/handle-api-error";
 import { responses } from "@/app/lib/api/response";
 import { THandlerParams } from "@/app/lib/api/with-api-logging";
 import { sendToPipeline } from "@/app/lib/pipelines";
@@ -17,10 +17,7 @@ import { verifyLinkSurveyPinToken } from "@/modules/survey/link/lib/pin-token";
 import { updateResponseWithQuotaEvaluation } from "./response";
 import { getValidatedResponseUpdateInput } from "./validated-response-update-input";
 
-type TRouteResult = {
-  response: Response;
-  error?: unknown;
-};
+type TRouteResult = ApiErrorResult;
 
 type TExistingResponseResult = { existingResponse: TResponse } | TRouteResult;
 type TSurveyResult = { survey: TSurvey } | TRouteResult;

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.ts
@@ -1,13 +1,8 @@
-import { logger } from "@formbricks/logger";
-import {
-  DatabaseError,
-  InvalidInputError,
-  RESPONSE_ALREADY_FINISHED_ERROR_CODE,
-  ResourceNotFoundError,
-} from "@formbricks/types/errors";
+import { RESPONSE_ALREADY_FINISHED_ERROR_CODE, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TResponse, TResponseUpdateInput } from "@formbricks/types/responses";
 import { TSurveyElement } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
+import { handleApiError } from "@/app/lib/api/handle-api-error";
 import { responses } from "@/app/lib/api/response";
 import { THandlerParams } from "@/app/lib/api/with-api-logging";
 import { sendToPipeline } from "@/app/lib/pipelines";
@@ -40,30 +35,13 @@ export type TPutRouteParams = {
   }>;
 };
 
-const handleDatabaseError = (
-  error: Error,
-  url: string,
-  endpoint: string,
-  responseId: string
-): TRouteResult => {
+const handleDatabaseError = (error: unknown, responseId: string): TRouteResult => {
+  // A missing resource keeps its route-specific "Response" framing; everything else (DatabaseError,
+  // unexpected) is generic-ized here and reported server-side by the wrapper via handleApiError.
   if (error instanceof ResourceNotFoundError) {
     return { response: responses.notFoundResponse("Response", responseId, true) };
   }
-  if (error instanceof InvalidInputError) {
-    return { response: responses.badRequestResponse(error.message, undefined, true) };
-  }
-  if (error instanceof DatabaseError) {
-    logger.error({ error, url }, `Error in ${endpoint}`);
-    return {
-      response: responses.internalServerErrorResponse(error.message, true),
-      error,
-    };
-  }
-
-  return {
-    response: responses.internalServerErrorResponse("Unknown error occurred", true),
-    error,
-  };
+  return handleApiError(error, { cors: true });
 };
 
 const validateResponse = (
@@ -94,7 +72,7 @@ const validateResponse = (
   }
 };
 
-const getExistingResponse = async (req: Request, responseId: string): Promise<TExistingResponseResult> => {
+const getExistingResponse = async (responseId: string): Promise<TExistingResponseResult> => {
   try {
     const existingResponse = await getResponse(responseId);
 
@@ -102,31 +80,17 @@ const getExistingResponse = async (req: Request, responseId: string): Promise<TE
       ? { existingResponse }
       : { response: responses.notFoundResponse("Response", responseId, true) };
   } catch (error) {
-    return handleDatabaseError(
-      error instanceof Error ? error : new Error(String(error)),
-      req.url,
-      "PUT /api/v1/client/[workspaceId]/responses/[responseId]",
-      responseId
-    );
+    return handleDatabaseError(error, responseId);
   }
 };
 
-const getSurveyForResponse = async (
-  req: Request,
-  responseId: string,
-  surveyId: string
-): Promise<TSurveyResult> => {
+const getSurveyForResponse = async (responseId: string, surveyId: string): Promise<TSurveyResult> => {
   try {
     const survey = await getSurvey(surveyId);
 
     return survey ? { survey } : { response: responses.notFoundResponse("Survey", surveyId, true) };
   } catch (error) {
-    return handleDatabaseError(
-      error instanceof Error ? error : new Error(String(error)),
-      req.url,
-      "PUT /api/v1/client/[workspaceId]/responses/[responseId]",
-      responseId
-    );
+    return handleDatabaseError(error, responseId);
   }
 };
 
@@ -192,7 +156,6 @@ const validateUpdateRequest = (
 };
 
 const getUpdatedResponse = async (
-  req: Request,
   responseId: string,
   responseUpdateInput: TResponseUpdateInput
 ): Promise<TUpdatedResponseResult> => {
@@ -201,36 +164,9 @@ const getUpdatedResponse = async (
     return { updatedResponse };
   } catch (error) {
     if (error instanceof ResourceNotFoundError) {
-      return {
-        response: responses.notFoundResponse("Response", responseId, true),
-      };
+      return { response: responses.notFoundResponse("Response", responseId, true) };
     }
-    if (error instanceof InvalidInputError) {
-      return {
-        response: responses.badRequestResponse(error.message),
-      };
-    }
-    if (error instanceof DatabaseError) {
-      logger.error(
-        { error, url: req.url },
-        "Error in PUT /api/v1/client/[workspaceId]/responses/[responseId]"
-      );
-      return {
-        response: responses.internalServerErrorResponse(error.message),
-        error,
-      };
-    }
-
-    const unexpectedError = error instanceof Error ? error : new Error(String(error));
-
-    logger.error(
-      { error: unexpectedError, url: req.url },
-      "Error in PUT /api/v1/client/[workspaceId]/responses/[responseId]"
-    );
-    return {
-      response: responses.internalServerErrorResponse("Something went wrong"),
-      error: unexpectedError,
-    };
+    return handleApiError(error, { cors: true });
   }
 };
 
@@ -261,13 +197,13 @@ export const putResponseHandler = async ({
   }
   const { responseUpdateInput } = validatedUpdateInput;
 
-  const existingResponseResult = await getExistingResponse(req, responseId);
+  const existingResponseResult = await getExistingResponse(responseId);
   if ("response" in existingResponseResult) {
     return existingResponseResult;
   }
   const { existingResponse } = existingResponseResult;
 
-  const surveyResult = await getSurveyForResponse(req, responseId, existingResponse.surveyId);
+  const surveyResult = await getSurveyForResponse(responseId, existingResponse.surveyId);
   if ("response" in surveyResult) {
     return surveyResult;
   }
@@ -295,7 +231,7 @@ export const putResponseHandler = async ({
     return validationResult;
   }
 
-  const updatedResponseResult = await getUpdatedResponse(req, responseId, responseUpdateInput);
+  const updatedResponseResult = await getUpdatedResponse(responseId, responseUpdateInput);
   if ("response" in updatedResponseResult) {
     return updatedResponseResult;
   }

--- a/apps/web/app/api/v1/client/[workspaceId]/responses/route.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/responses/route.ts
@@ -1,11 +1,10 @@
 import { headers } from "next/headers";
 import { UAParser } from "ua-parser-js";
-import { logger } from "@formbricks/logger";
-import { InvalidInputError, UniqueConstraintError } from "@formbricks/types/errors";
 import { TResponseWithQuotaFull } from "@formbricks/types/quota";
 import { TResponseInput, ZResponseInput } from "@formbricks/types/responses";
 import { TSurvey } from "@formbricks/types/surveys/types";
 import { validateSingleUseResponseInput } from "@/app/api/client/[workspaceId]/responses/lib/single-use";
+import { handleApiError } from "@/app/lib/api/handle-api-error";
 import { RequestBodyTooLargeError, parseJsonBodyWithLimit } from "@/app/lib/api/request-body";
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
@@ -206,22 +205,7 @@ export const POST = withV1ApiWrapper({
         meta,
       });
     } catch (error) {
-      if (error instanceof InvalidInputError) {
-        return {
-          response: responses.badRequestResponse(error.message),
-        };
-      } else if (error instanceof UniqueConstraintError) {
-        return {
-          response: responses.conflictResponse(error.message, undefined, true),
-        };
-      } else {
-        logger.error({ error, url: req.url }, "Error creating response");
-        return {
-          response: responses.internalServerErrorResponse(
-            error instanceof Error ? error.message : "Unknown error occurred"
-          ),
-        };
-      }
+      return handleApiError(error, { cors: true });
     }
 
     const { quotaFull, ...responseData } = response;

--- a/apps/web/app/api/v1/management/action-classes/[actionClassId]/route.ts
+++ b/apps/web/app/api/v1/management/action-classes/[actionClassId]/route.ts
@@ -51,9 +51,7 @@ export const GET = withV1ApiWrapper({
         response: responses.notFoundResponse("Action Class", params.actionClassId),
       };
     } catch (error) {
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
 });
@@ -138,9 +136,7 @@ export const PUT = withV1ApiWrapper({
         response: responses.internalServerErrorResponse("Some error occurred while updating action"),
       };
     } catch (error) {
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
   action: "updated",
@@ -180,9 +176,7 @@ export const DELETE = withV1ApiWrapper({
         response: responses.successResponse(deletedActionClass),
       };
     } catch (error) {
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
   action: "deleted",

--- a/apps/web/app/api/v1/management/action-classes/route.ts
+++ b/apps/web/app/api/v1/management/action-classes/route.ts
@@ -1,7 +1,7 @@
 import { logger } from "@formbricks/logger";
 import { TActionClass, ZActionClassInput } from "@formbricks/types/action-classes";
-import { DatabaseError, UniqueConstraintError } from "@formbricks/types/errors";
 import { resolveBodyIds } from "@/app/api/v1/management/lib/workspace-resolver";
+import { handleApiError } from "@/app/lib/api/handle-api-error";
 import { RequestBodyTooLargeError, parseJsonBodyWithLimit } from "@/app/lib/api/request-body";
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
@@ -27,12 +27,7 @@ export const GET = withV1ApiWrapper({
         response: responses.successResponse(actionClasses),
       };
     } catch (error) {
-      if (error instanceof DatabaseError) {
-        return {
-          response: responses.badRequestResponse(error.message),
-        };
-      }
-      throw error;
+      return handleApiError(error);
     }
   },
 });
@@ -91,17 +86,7 @@ export const POST = withV1ApiWrapper({
         response: responses.successResponse(actionClass),
       };
     } catch (error) {
-      if (error instanceof UniqueConstraintError) {
-        return {
-          response: responses.conflictResponse(error.message),
-        };
-      }
-      if (error instanceof DatabaseError) {
-        return {
-          response: responses.badRequestResponse(error.message),
-        };
-      }
-      throw error;
+      return handleApiError(error);
     }
   },
   action: "created",

--- a/apps/web/app/api/v1/management/responses/[responseId]/route.ts
+++ b/apps/web/app/api/v1/management/responses/[responseId]/route.ts
@@ -62,9 +62,7 @@ export const GET = withV1ApiWrapper({
         }),
       };
     } catch (error) {
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
 });
@@ -95,9 +93,7 @@ export const DELETE = withV1ApiWrapper({
         response: responses.successResponse(deletedResponse),
       };
     } catch (error) {
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
   action: "deleted",
@@ -201,9 +197,7 @@ export const PUT = withV1ApiWrapper({
         response: responses.successResponse({ ...updated, data: resolveStorageUrlsInObject(updated.data) }),
       };
     } catch (error) {
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
   action: "updated",

--- a/apps/web/app/api/v1/management/responses/route.ts
+++ b/apps/web/app/api/v1/management/responses/route.ts
@@ -160,35 +160,31 @@ export const POST = withV1ApiWrapper({
         responseInput.updatedAt = responseInput.createdAt;
       }
 
-      try {
-        const response = await createResponseWithQuotaEvaluation(responseInput);
-        if (auditLog) {
-          auditLog.targetId = response.id;
-          auditLog.newObject = response;
-        }
+      const response = await createResponseWithQuotaEvaluation(responseInput);
+      if (auditLog) {
+        auditLog.targetId = response.id;
+        auditLog.newObject = response;
+      }
 
+      await sendToPipeline({
+        event: "responseCreated",
+        workspaceId: surveyResult.survey.workspaceId,
+        surveyId: response.surveyId,
+        response: response,
+      });
+
+      if (response.finished) {
         await sendToPipeline({
-          event: "responseCreated",
+          event: "responseFinished",
           workspaceId: surveyResult.survey.workspaceId,
           surveyId: response.surveyId,
           response: response,
         });
-
-        if (response.finished) {
-          await sendToPipeline({
-            event: "responseFinished",
-            workspaceId: surveyResult.survey.workspaceId,
-            surveyId: response.surveyId,
-            response: response,
-          });
-        }
-
-        return {
-          response: responses.successResponse(response, true),
-        };
-      } catch (error) {
-        return handleApiError(error);
       }
+
+      return {
+        response: responses.successResponse(response, true),
+      };
     } catch (error) {
       return handleApiError(error);
     }

--- a/apps/web/app/api/v1/management/responses/route.ts
+++ b/apps/web/app/api/v1/management/responses/route.ts
@@ -1,7 +1,7 @@
 import { logger } from "@formbricks/logger";
-import { DatabaseError, InvalidInputError } from "@formbricks/types/errors";
 import { TResponse, TResponseInput, ZResponseInput } from "@formbricks/types/responses";
 import { resolveBodyIds } from "@/app/api/v1/management/lib/workspace-resolver";
+import { handleApiError } from "@/app/lib/api/handle-api-error";
 import { RequestBodyTooLargeError, parseJsonBodyWithLimit } from "@/app/lib/api/request-body";
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
@@ -54,12 +54,7 @@ export const GET = withV1ApiWrapper({
         ),
       };
     } catch (error) {
-      if (error instanceof DatabaseError) {
-        return {
-          response: responses.badRequestResponse(error.message),
-        };
-      }
-      throw error;
+      return handleApiError(error);
     }
   },
 });
@@ -192,27 +187,10 @@ export const POST = withV1ApiWrapper({
           response: responses.successResponse(response, true),
         };
       } catch (error) {
-        logger.error({ error, url: req.url }, "Error in POST /api/v1/management/responses");
-
-        if (error instanceof InvalidInputError) {
-          return {
-            response: responses.badRequestResponse(error.message),
-          };
-        }
-
-        return {
-          response: responses.internalServerErrorResponse(
-            error instanceof Error ? error.message : "Unknown error occurred"
-          ),
-        };
+        return handleApiError(error);
       }
     } catch (error) {
-      if (error instanceof DatabaseError) {
-        return {
-          response: responses.badRequestResponse("An unexpected error occurred while creating the response"),
-        };
-      }
-      throw error;
+      return handleApiError(error);
     }
   },
   action: "created",

--- a/apps/web/app/api/v1/management/surveys/[surveyId]/route.ts
+++ b/apps/web/app/api/v1/management/surveys/[surveyId]/route.ts
@@ -75,9 +75,7 @@ export const GET = withV1ApiWrapper({
         };
       }
 
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
 });
@@ -112,9 +110,7 @@ export const DELETE = withV1ApiWrapper({
         response: responses.successResponse(deletedSurvey),
       };
     } catch (error) {
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
   action: "deleted",
@@ -227,14 +223,10 @@ export const PUT = withV1ApiWrapper({
           ),
         };
       } catch (error) {
-        return {
-          response: handleErrorResponse(error),
-        };
+        return handleErrorResponse(error);
       }
     } catch (error) {
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
   action: "updated",

--- a/apps/web/app/api/v1/management/surveys/[surveyId]/singleUseIds/route.ts
+++ b/apps/web/app/api/v1/management/surveys/[surveyId]/singleUseIds/route.ts
@@ -77,9 +77,7 @@ export const GET = withV1ApiWrapper({
         response: responses.successResponse(surveyLinks),
       };
     } catch (error) {
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
 });

--- a/apps/web/app/api/v1/management/surveys/route.ts
+++ b/apps/web/app/api/v1/management/surveys/route.ts
@@ -1,5 +1,4 @@
 import { logger } from "@formbricks/logger";
-import { DatabaseError, InvalidInputError } from "@formbricks/types/errors";
 import { ZSurveyCreateInputWithWorkspaceId } from "@formbricks/types/surveys/types";
 import { resolveBodyIds } from "@/app/api/v1/management/lib/workspace-resolver";
 import { checkFeaturePermissions } from "@/app/api/v1/management/surveys/lib/utils";
@@ -8,6 +7,7 @@ import {
   addLegacyProjectOverwritesToList,
   normaliseProjectOverwritesToWorkspace,
 } from "@/app/lib/api/api-backwards-compat";
+import { handleApiError } from "@/app/lib/api/handle-api-error";
 import { RequestBodyTooLargeError, parseJsonBodyWithLimit } from "@/app/lib/api/request-body";
 import { responses } from "@/app/lib/api/response";
 import {
@@ -51,12 +51,7 @@ export const GET = withV1ApiWrapper({
         ),
       };
     } catch (error) {
-      if (error instanceof DatabaseError) {
-        return {
-          response: responses.badRequestResponse(error.message),
-        };
-      }
-      throw error;
+      return handleApiError(error);
     }
   },
 });
@@ -157,19 +152,9 @@ export const POST = withV1ApiWrapper({
       };
     } catch (error) {
       // Invalid survey media (e.g. an unsupported/unparseable choice imageUrl) surfaces as an
-      // InvalidInputError — it's bad user input, so return a 400 with the message instead of
-      // letting it fall through to an unhandled 500 (which would page Sentry).
-      if (error instanceof InvalidInputError) {
-        return {
-          response: responses.badRequestResponse(error.message),
-        };
-      }
-      if (error instanceof DatabaseError) {
-        return {
-          response: responses.internalServerErrorResponse(error.message),
-        };
-      }
-      throw error;
+      // InvalidInputError, which handleApiError returns as a 400 with its message instead of a 500
+      // that would page Sentry. DatabaseError and unexpected errors become a generic, reported 500.
+      return handleApiError(error);
     }
   },
   action: "created",

--- a/apps/web/app/api/v1/webhooks/route.ts
+++ b/apps/web/app/api/v1/webhooks/route.ts
@@ -1,7 +1,7 @@
-import { DatabaseError, InvalidInputError } from "@formbricks/types/errors";
 import { resolveBodyIds } from "@/app/api/v1/management/lib/workspace-resolver";
 import { createWebhook, getWebhooks } from "@/app/api/v1/webhooks/lib/webhook";
 import { ZWebhookInput } from "@/app/api/v1/webhooks/types/webhooks";
+import { handleApiError } from "@/app/lib/api/handle-api-error";
 import { RequestBodyTooLargeError, parseJsonBodyWithLimit } from "@/app/lib/api/request-body";
 import { responses } from "@/app/lib/api/response";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
@@ -23,12 +23,7 @@ export const GET = withV1ApiWrapper({
         response: responses.successResponse(webhooks),
       };
     } catch (error) {
-      if (error instanceof DatabaseError) {
-        return {
-          response: responses.internalServerErrorResponse(error.message),
-        };
-      }
-      throw error;
+      return handleApiError(error);
     }
   },
 });
@@ -93,17 +88,7 @@ export const POST = withV1ApiWrapper({
         response: responses.successResponse(webhook),
       };
     } catch (error) {
-      if (error instanceof InvalidInputError) {
-        return {
-          response: responses.badRequestResponse(error.message),
-        };
-      }
-      if (error instanceof DatabaseError) {
-        return {
-          response: responses.internalServerErrorResponse(error.message),
-        };
-      }
-      throw error;
+      return handleApiError(error);
     }
   },
   action: "created",

--- a/apps/web/app/lib/api/handle-api-error.test.ts
+++ b/apps/web/app/lib/api/handle-api-error.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "vitest";
+import {
+  AuthenticationError,
+  AuthorizationError,
+  DatabaseError,
+  InvalidInputError,
+  OperationNotAllowedError,
+  QueryExecutionError,
+  ResourceNotFoundError,
+  UniqueConstraintError,
+  UnknownError,
+  ValidationError,
+} from "@formbricks/types/errors";
+import { GENERIC_API_ERROR_MESSAGE, handleApiError } from "./handle-api-error";
+
+const CORS_HEADER = "Access-Control-Allow-Origin";
+
+describe("handleApiError", () => {
+  describe("unexpected / server errors never leak the underlying message", () => {
+    const SECRET = "column workspace.secret_column violates constraint fk_secret";
+
+    test.each([
+      ["DatabaseError", new DatabaseError(SECRET)],
+      ["QueryExecutionError", new QueryExecutionError(SECRET)], // expected-name but statusCode 500
+      ["UnknownError", new UnknownError(SECRET)],
+      ["plain Error", new Error(SECRET)],
+    ])("%s -> generic 500 with the real error threaded back", async (_label, error) => {
+      const result = handleApiError(error);
+
+      expect(result.response.status).toBe(500);
+      // The real error is threaded so the wrapper's reportApiError logs/Sentry-reports it.
+      expect(result.error).toBe(error);
+
+      const body = await result.response.json();
+      expect(body.code).toBe("internal_server_error");
+      expect(body.message).toBe(GENERIC_API_ERROR_MESSAGE);
+      // The raw internal detail must never reach the client.
+      expect(JSON.stringify(body)).not.toContain(SECRET);
+    });
+
+    test("non-Error values still map to a generic 500 and are threaded back", async () => {
+      const result = handleApiError("boom");
+
+      expect(result.response.status).toBe(500);
+      expect(result.error).toBe("boom");
+
+      const body = await result.response.json();
+      expect(body.message).toBe(GENERIC_API_ERROR_MESSAGE);
+    });
+  });
+
+  describe("expected client (4xx) errors surface their domain message at the right status", () => {
+    test("InvalidInputError -> 400", async () => {
+      const result = handleApiError(new InvalidInputError("field 'email' is invalid"));
+
+      expect(result.response.status).toBe(400);
+      // Expected 4xx errors are not server errors, so nothing is threaded back for reporting.
+      expect(result.error).toBeUndefined();
+
+      const body = await result.response.json();
+      expect(body.code).toBe("bad_request");
+      expect(body.message).toBe("field 'email' is invalid");
+    });
+
+    test("ValidationError -> 400", async () => {
+      const result = handleApiError(new ValidationError("bad shape"));
+      expect(result.response.status).toBe(400);
+      expect((await result.response.json()).message).toBe("bad shape");
+    });
+
+    test("UniqueConstraintError -> 409", async () => {
+      const result = handleApiError(new UniqueConstraintError("already exists"));
+
+      expect(result.response.status).toBe(409);
+      expect(result.error).toBeUndefined();
+
+      const body = await result.response.json();
+      expect(body.code).toBe("conflict");
+      expect(body.message).toBe("already exists");
+    });
+
+    test("ResourceNotFoundError -> 404 with resource details", async () => {
+      const result = handleApiError(new ResourceNotFoundError("Survey", "abc123"));
+
+      expect(result.response.status).toBe(404);
+
+      const body = await result.response.json();
+      expect(body.code).toBe("not_found");
+      expect(body.message).toBe("Survey not found");
+      expect(body.details).toEqual({ resource_id: "abc123", resource_type: "Survey" });
+    });
+
+    test.each([
+      ["AuthorizationError", new AuthorizationError("no access")],
+      ["OperationNotAllowedError", new OperationNotAllowedError("no access")],
+    ])("%s -> 403", async (_label, error) => {
+      const result = handleApiError(error);
+
+      expect(result.response.status).toBe(403);
+
+      const body = await result.response.json();
+      expect(body.code).toBe("forbidden");
+      expect(body.message).toBe("no access");
+    });
+
+    test("AuthenticationError -> 401", async () => {
+      const result = handleApiError(new AuthenticationError("nope"));
+
+      expect(result.response.status).toBe(401);
+      expect((await result.response.json()).code).toBe("not_authenticated");
+    });
+  });
+
+  describe("cors option", () => {
+    test("omits CORS headers by default", () => {
+      const result = handleApiError(new DatabaseError("x"));
+      expect(result.response.headers.get(CORS_HEADER)).toBeNull();
+    });
+
+    test("adds CORS headers on the 500 path when cors is true", () => {
+      const result = handleApiError(new DatabaseError("x"), { cors: true });
+      expect(result.response.headers.get(CORS_HEADER)).toBe("*");
+    });
+
+    test("adds CORS headers on the 4xx path when cors is true", () => {
+      const result = handleApiError(new InvalidInputError("x"), { cors: true });
+      expect(result.response.headers.get(CORS_HEADER)).toBe("*");
+    });
+  });
+});

--- a/apps/web/app/lib/api/handle-api-error.test.ts
+++ b/apps/web/app/lib/api/handle-api-error.test.ts
@@ -7,6 +7,7 @@ import {
   OperationNotAllowedError,
   QueryExecutionError,
   ResourceNotFoundError,
+  TooManyRequestsError,
   UniqueConstraintError,
   UnknownError,
   ValidationError,
@@ -108,6 +109,17 @@ describe("handleApiError", () => {
 
       expect(result.response.status).toBe(401);
       expect((await result.response.json()).code).toBe("not_authenticated");
+    });
+
+    test("TooManyRequestsError -> 429, message surfaced, not threaded for reporting", async () => {
+      const result = handleApiError(new TooManyRequestsError("Rate limit exceeded"));
+
+      expect(result.response.status).toBe(429);
+      // Expected error → must NOT be threaded (no false Sentry report on the 4xx path).
+      expect(result.error).toBeUndefined();
+      const body = await result.response.json();
+      expect(body.code).toBe("too_many_requests");
+      expect(body.message).toBe("Rate limit exceeded");
     });
   });
 

--- a/apps/web/app/lib/api/handle-api-error.ts
+++ b/apps/web/app/lib/api/handle-api-error.ts
@@ -44,6 +44,11 @@ export const handleApiError = (
   { cors = false }: HandleApiErrorOptions = {}
 ): ApiErrorResult => {
   if (error instanceof Error && isExpectedError(error)) {
+    // ResourceNotFoundError is the only expected 404 and needs its resource fields, so handle it
+    // explicitly before the status switch.
+    if (error instanceof ResourceNotFoundError) {
+      return { response: responses.notFoundResponse(error.resourceType, error.resourceId, cors) };
+    }
     // `isExpectedError` also matches business errors that are technically 5xx (e.g.
     // QueryExecutionError), so gate on the status: only 4xx messages are safe to surface.
     const statusCode = (error as { statusCode?: number }).statusCode ?? 500;
@@ -55,13 +60,6 @@ export const handleApiError = (
           return { response: responses.notAuthenticatedResponse(cors) };
         case 403:
           return { response: responses.forbiddenResponse(error.message, cors) };
-        case 404:
-          return {
-            response:
-              error instanceof ResourceNotFoundError
-                ? responses.notFoundResponse(error.resourceType, error.resourceId, cors)
-                : responses.notFoundResponse("Resource", null, cors),
-          };
         case 409:
           return { response: responses.conflictResponse(error.message, undefined, cors) };
         case 429:

--- a/apps/web/app/lib/api/handle-api-error.ts
+++ b/apps/web/app/lib/api/handle-api-error.ts
@@ -31,9 +31,10 @@ interface HandleApiErrorOptions {
  *   `error` back so the wrapper's `reportApiError` logs it (and reports it to Sentry on 5xx). This
  *   guarantees no raw `error.message` is ever echoed on the unexpected/5xx path.
  *
- * Rate-limit (429) and payload-too-large (413) errors are handled at their own boundaries (the
- * wrapper's rate limiter and `parseJsonBodyWithLimit` respectively) and never reach here, so they
- * are not mapped explicitly.
+ * A `TooManyRequestsError` (429) is mapped defensively: it is normally handled by the wrapper's
+ * rate limiter before a handler runs, but mapping it keeps this shared boundary from turning a
+ * stray 429 into a mis-statused, falsely Sentry-reported 500. `RequestBodyTooLargeError` (413) has
+ * no `statusCode` and is always caught at the `parseJsonBodyWithLimit` boundary, so it isn't mapped.
  *
  * @param error - The caught error (unknown).
  * @param options.cors - Whether the response should include CORS headers (public/client routes).
@@ -63,6 +64,8 @@ export const handleApiError = (
           };
         case 409:
           return { response: responses.conflictResponse(error.message, undefined, cors) };
+        case 429:
+          return { response: responses.tooManyRequestsResponse(error.message, cors) };
       }
     }
   }

--- a/apps/web/app/lib/api/handle-api-error.ts
+++ b/apps/web/app/lib/api/handle-api-error.ts
@@ -8,6 +8,13 @@ import { responses } from "@/app/lib/api/response";
  */
 export const GENERIC_API_ERROR_MESSAGE = "Something went wrong. Please try again.";
 
+/** The `{ response, error? }` result shape v1 route handlers return to `withV1ApiWrapper`. */
+export interface ApiErrorResult {
+  response: Response;
+  /** The real caught error, threaded back so the wrapper's `reportApiError` logs/reports it (5xx path). */
+  error?: unknown;
+}
+
 interface HandleApiErrorOptions {
   /** Pass `true` for public/client routes so the error response carries CORS headers. */
   cors?: boolean;
@@ -34,7 +41,7 @@ interface HandleApiErrorOptions {
 export const handleApiError = (
   error: unknown,
   { cors = false }: HandleApiErrorOptions = {}
-): { response: Response; error?: unknown } => {
+): ApiErrorResult => {
   if (error instanceof Error && isExpectedError(error)) {
     // `isExpectedError` also matches business errors that are technically 5xx (e.g.
     // QueryExecutionError), so gate on the status: only 4xx messages are safe to surface.

--- a/apps/web/app/lib/api/handle-api-error.ts
+++ b/apps/web/app/lib/api/handle-api-error.ts
@@ -1,0 +1,69 @@
+import { ResourceNotFoundError, isExpectedError } from "@formbricks/types/errors";
+import { responses } from "@/app/lib/api/response";
+
+/**
+ * Fixed, client-facing message returned for any unexpected or server-side (5xx) error.
+ * Intentionally generic so we never leak internal details (e.g. a `DatabaseError` wrapping a raw
+ * Prisma message with schema/column/constraint info). Matches the string used by the v2 routes.
+ */
+export const GENERIC_API_ERROR_MESSAGE = "Something went wrong. Please try again.";
+
+interface HandleApiErrorOptions {
+  /** Pass `true` for public/client routes so the error response carries CORS headers. */
+  cors?: boolean;
+}
+
+/**
+ * Shared error boundary for v1 API handlers. Maps a caught error to the
+ * `{ response, error? }` result shape expected by `withV1ApiWrapper`.
+ *
+ * - Expected business errors with a **4xx** status surface their (domain-authored, safe) message
+ *   at the correct status.
+ * - Everything else — `DatabaseError`, `QueryExecutionError`, `UnknownError`, any other 5xx, or a
+ *   non-domain `Error` — returns the fixed {@link GENERIC_API_ERROR_MESSAGE} and threads the real
+ *   `error` back so the wrapper's `reportApiError` logs it (and reports it to Sentry on 5xx). This
+ *   guarantees no raw `error.message` is ever echoed on the unexpected/5xx path.
+ *
+ * Rate-limit (429) and payload-too-large (413) errors are handled at their own boundaries (the
+ * wrapper's rate limiter and `parseJsonBodyWithLimit` respectively) and never reach here, so they
+ * are not mapped explicitly.
+ *
+ * @param error - The caught error (unknown).
+ * @param options.cors - Whether the response should include CORS headers (public/client routes).
+ */
+export const handleApiError = (
+  error: unknown,
+  { cors = false }: HandleApiErrorOptions = {}
+): { response: Response; error?: unknown } => {
+  if (error instanceof Error && isExpectedError(error)) {
+    // `isExpectedError` also matches business errors that are technically 5xx (e.g.
+    // QueryExecutionError), so gate on the status: only 4xx messages are safe to surface.
+    const statusCode = (error as { statusCode?: number }).statusCode ?? 500;
+    if (statusCode < 500) {
+      switch (statusCode) {
+        case 400:
+          return { response: responses.badRequestResponse(error.message, undefined, cors) };
+        case 401:
+          return { response: responses.notAuthenticatedResponse(cors) };
+        case 403:
+          return { response: responses.forbiddenResponse(error.message, cors) };
+        case 404:
+          return {
+            response:
+              error instanceof ResourceNotFoundError
+                ? responses.notFoundResponse(error.resourceType, error.resourceId, cors)
+                : responses.notFoundResponse("Resource", null, cors),
+          };
+        case 409:
+          return { response: responses.conflictResponse(error.message, undefined, cors) };
+      }
+    }
+  }
+
+  // Unexpected / 5xx: generic message to the client, real error threaded back for server-side
+  // reporting via the wrapper's reportApiError.
+  return {
+    response: responses.internalServerErrorResponse(GENERIC_API_ERROR_MESSAGE, cors),
+    error,
+  };
+};

--- a/apps/web/modules/ee/contacts/api/v1/management/contact-attribute-keys/[contactAttributeKeyId]/route.ts
+++ b/apps/web/modules/ee/contacts/api/v1/management/contact-attribute-keys/[contactAttributeKeyId]/route.ts
@@ -63,9 +63,7 @@ export const GET = withV1ApiWrapper({
           response: responses.forbiddenResponse(error.message),
         };
       }
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
 });
@@ -109,9 +107,7 @@ export const DELETE = withV1ApiWrapper({
         response: responses.successResponse(deletedContactAttributeKey),
       };
     } catch (error) {
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
   action: "deleted",
@@ -191,9 +187,7 @@ export const PUT = withV1ApiWrapper({
         ),
       };
     } catch (error) {
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
   action: "updated",

--- a/apps/web/modules/ee/contacts/api/v1/management/contacts/[contactId]/route.ts
+++ b/apps/web/modules/ee/contacts/api/v1/management/contacts/[contactId]/route.ts
@@ -58,9 +58,7 @@ export const GET = withV1ApiWrapper({
         response: responses.successResponse(result.contact),
       };
     } catch (error) {
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
 });
@@ -109,9 +107,7 @@ export const DELETE = withV1ApiWrapper({
         response: responses.successResponse({ success: "Contact deleted successfully" }),
       };
     } catch (error) {
-      return {
-        response: handleErrorResponse(error),
-      };
+      return handleErrorResponse(error);
     }
   },
   action: "deleted",


### PR DESCRIPTION
## What does this PR do?

Several v1 API handlers passed a raw `error.message` straight into their 500 response on the unexpected-error path:

```ts
responses.internalServerErrorResponse(error instanceof Error ? error.message : "Unknown error occurred")
```

When the thrown error was a `DatabaseError` (which wraps the underlying Prisma message — schema/column/constraint detail, sometimes query fragments) or any other unexpected `Error`, those internals were returned to the client. Some of the affected endpoints (e.g. `POST /api/v1/client/[workspaceId]/responses`) are public/unauthenticated, so this was a real information-disclosure hazard (OWASP: never return internals in an API response). Pre-existing debt, surfaced during the ENG-1660 Prisma-error review.

The fix is a single shared error boundary that v1 handlers route through:

- **`handleApiError(error, { cors })`** (`apps/web/app/lib/api/handle-api-error.ts`) maps a caught error to the `{ response, error }` shape `withV1ApiWrapper` already expects. Expected business errors with a **4xx** status keep their (domain-authored, safe) message; everything **5xx**/unknown returns a fixed generic message — `"Something went wrong. Please try again."` — while the *real* error is threaded back so the wrapper's `reportApiError` still logs it (and reports to Sentry on 5xx). The gate is `isExpectedError(error) && statusCode < 500`, so a `QueryExecutionError` (an "expected" name but a 500) is genericized too.
- This mirrors what the **v2** responses route already does — v1 was the straggler.
- `auth.ts`'s shared `handleErrorResponse` now delegates its default branch to the same boundary, which closes the leak for every route that uses it (`surveys/[surveyId]`, `action-classes/[actionClassId]`, `responses/[responseId]`, `singleUseIds`) in one place.

While consolidating I found one more leak the ticket's line-grep missed — a **multi-line** `internalServerErrorResponse(error.message)` in `management/responses` — now closed. A multi-line sweep confirms no `internalServerErrorResponse(…error.message…)` remains anywhere in `apps/web`.

Intentional 4xx validation/domain messages (e.g. `InvalidInputError → 400` with its message) are preserved on purpose — this is not a blanket genericize.

Linear: https://linear.app/formbricks/issue/ENG-1808

## Before / After

Public response-submission endpoint hitting an unexpected DB error (illustrative):

**Before** — raw Prisma internals returned to an unauthenticated client:

```http
POST /api/v1/client/{workspaceId}/responses  →  500
```
```json
{
  "code": "internal_server_error",
  "message": "Invalid `prisma.response.create()` invocation: Foreign key constraint failed on the field: `Response_surveyId_fkey (index)`",
  "details": {}
}
```

**After** — generic message to the client; the real error is logged + sent to Sentry server-side:

```http
POST /api/v1/client/{workspaceId}/responses  →  500
```
```json
{
  "code": "internal_server_error",
  "message": "Something went wrong. Please try again.",
  "details": {}
}
```

Expected client errors are unchanged — the domain message is still surfaced (no over-genericizing):

```http
POST /api/v1/webhooks   (invalid body)  →  400
```
```json
{
  "code": "bad_request",
  "message": "Fields are missing or incorrectly formatted",
  "details": { "...": "..." }
}
```

## QA / Test Plan

**How to test**

- [ ] Unit: `pnpm --filter=@formbricks/web test "app/lib/api/handle-api-error.test.ts"` → passes; asserts every 5xx/`DatabaseError`/unknown case returns the generic message (never the input message) and threads the real error, and that expected 4xx errors keep their status + message.
- [ ] Unit: `pnpm --filter=@formbricks/web test "app/api/v1/client/[workspaceId]/responses/[responseId]/lib/put-response-handler.test.ts"` → the DB-error cases now assert the generic body, not the raw message.
- [ ] Happy path: normal v1 requests still work unchanged — e.g. `GET /api/v1/webhooks` with a valid API key (200), `POST /api/v1/client/{workspaceId}/responses` with a valid payload (201).
- [ ] Leak check: force an unexpected server/DB error on a v1 endpoint (e.g. temporarily break a query) → the response body is exactly `{"code":"internal_server_error","message":"Something went wrong. Please try again.","details":{}}`, and the real error shows up in the server log / Sentry (5xx) — not in the HTTP body.
- [ ] Edge: an expected validation error (malformed webhook / survey / response input) still returns its **4xx** with the domain message.
- [ ] Regression sweep: `grep -rnE "internalServerErrorResponse\([^)]*error\.message" apps/web/app/api/v1` returns nothing.

**Preconditions / test data**

- A management API key (for `/api/v1/management/*` and `/api/v1/webhooks`) and a published link survey + workspace (for `/api/v1/client/*`). Works on Cloud or self-host; no feature flags.

**Risks & regressions**

- **Status change:** `GET /api/v1/management/surveys`, `GET /api/v1/management/responses`, and `GET /api/v1/management/action-classes` now return a generic **500** on a DB failure instead of a **400** carrying the raw message (a DB failure is a server error, so 500 is the correct status). Same for the `management/responses` create outer catch.
- **Headers:** a few client-route error responses now carry CORS headers they inconsistently lacked (additive).
- **Observability:** DB errors on webhooks / management-surveys / management-responses are now reported to Sentry on 5xx — they previously returned without threading the error, so nothing was reported. Expect more signal there, not less.
- No change to success responses or to intended 4xx messages.

**Migrations / env / cutover**

- none

## Checklist

### Required

- [x] Filled out the "QA / Test Plan" section in this PR (behavior, edge cases, preconditions, risks, migrations/env)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs` (none added)
- [x] Merged the latest changes from main onto my branch (branch cut from current `main`)
- [x] My changes don't cause any responsiveness issues (no UI changes)

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR (no UI changes)
- [ ] Updated the Formbricks Docs if changes were necessary (no doc-facing changes)
