### PR TITLE
feat: link follow-ups to workflows (ENG-1896)

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -3067,6 +3067,7 @@ checksums:
     workspace/surveys/edit/follow_ups_modal_trigger_type_response: 8b0e49e76ba09241f512201871bef0f2
     workspace/surveys/edit/follow_ups_modal_updated_successfull_toast: 61204fada3231f4f1fe3866e87e1130a
     workspace/surveys/edit/follow_ups_new: 224c779d252b3e75086e4ed456ba2548
+    workspace/surveys/edit/follow_ups_workflows_alert_title: eeeab44d06dae5afe46c6b990154a1c6
     workspace/surveys/edit/formbricks_sdk_is_not_connected: 35165b0cac182a98408007a378cc677e
     workspace/surveys/edit/four_points: b289628a6b8a6cd0f7d17a14ca6cd7bf
     workspace/surveys/edit/heading: 79e9dfa461f38a239d34b9833ca103f1

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "Teilnehmer schließt Umfrage ab",
         "follow_ups_modal_updated_successfull_toast": "Follow-up aktualisiert und wird gespeichert, sobald du die Umfrage speicherst.",
         "follow_ups_new": "Neues Follow-up",
+        "follow_ups_workflows_alert_title": "Brauchst du mehr Flexibilität? Automatisiere Follow-ups und vieles mehr mit Workflows.",
         "formbricks_sdk_is_not_connected": "Formbricks SDK ist nicht verbunden",
         "four_points": "4 Punkte",
         "heading": "Überschrift",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "Respondent completes survey",
         "follow_ups_modal_updated_successfull_toast": "Follow-up updated and will be saved once you save the survey.",
         "follow_ups_new": "New follow-up",
+        "follow_ups_workflows_alert_title": "Need more flexibility? Automate follow-ups and much more with Workflows.",
         "formbricks_sdk_is_not_connected": "Formbricks SDK is not connected",
         "four_points": "4 points",
         "heading": "Heading",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "El encuestado completa la encuesta",
         "follow_ups_modal_updated_successfull_toast": "Seguimiento actualizado y se guardará cuando guardes la encuesta.",
         "follow_ups_new": "Nuevo seguimiento",
+        "follow_ups_workflows_alert_title": "¿Necesitas más flexibilidad? Automatiza seguimientos y mucho más con Workflows.",
         "formbricks_sdk_is_not_connected": "El SDK de Formbricks no está conectado",
         "four_points": "4 puntos",
         "heading": "Encabezado",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "Le répondant complète l'enquête",
         "follow_ups_modal_updated_successfull_toast": "\"Suivi mis à jour et sera enregistré une fois que vous sauvegarderez le sondage.\"",
         "follow_ups_new": "Nouveau suivi",
+        "follow_ups_workflows_alert_title": "Besoin de plus de flexibilité ? Automatise les relances et bien plus encore avec Workflows.",
         "formbricks_sdk_is_not_connected": "Le SDK Formbricks n'est pas connecté",
         "four_points": "4 points",
         "heading": "En-tête",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "A válaszadó kitölti a kérdőívet",
         "follow_ups_modal_updated_successfull_toast": "Az utókövetés frissítve, és akkor lesz elmentve, ha elmenti a kérdőívet.",
         "follow_ups_new": "Új utókövetés",
+        "follow_ups_workflows_alert_title": "Nagyobb rugalmasságra van szüksége? Automatizálja az utókövetéseket és még sok mást a Workflows segítségével.",
         "formbricks_sdk_is_not_connected": "A Formbricks SDK nincs csatlakoztatva",
         "four_points": "4 pont",
         "heading": "Címsor",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "回答者がフォームを完了したとき",
         "follow_ups_modal_updated_successfull_toast": "フォローアップ が 更新され、 アンケートを 保存すると保存されます。",
         "follow_ups_new": "新しいフォローアップ",
+        "follow_ups_workflows_alert_title": "より柔軟性が必要ですか？ワークフローでフォローアップなどを自動化しましょう。",
         "formbricks_sdk_is_not_connected": "Formbricks SDKが接続されていません",
         "four_points": "4点",
         "heading": "見出し",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "Respondent vult enquête in",
         "follow_ups_modal_updated_successfull_toast": "Follow-up bijgewerkt en wordt opgeslagen zodra u de enquête opslaat.",
         "follow_ups_new": "Nieuw vervolg",
+        "follow_ups_workflows_alert_title": "Meer flexibiliteit nodig? Automatiseer follow-ups en nog veel meer met Workflows.",
         "formbricks_sdk_is_not_connected": "Formbricks SDK is niet verbonden",
         "four_points": "4 punten",
         "heading": "Rubriek",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "Respondente completa a pesquisa",
         "follow_ups_modal_updated_successfull_toast": "Acompanhamento atualizado e será salvo assim que você salvar a pesquisa.",
         "follow_ups_new": "Novo acompanhamento",
+        "follow_ups_workflows_alert_title": "Precisa de mais flexibilidade? Automatize follow-ups e muito mais com Workflows.",
         "formbricks_sdk_is_not_connected": "O SDK do Formbricks não está conectado",
         "four_points": "4 pontos",
         "heading": "Título",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "Respondente conclui inquérito",
         "follow_ups_modal_updated_successfull_toast": "Seguimento atualizado e será guardado assim que guardar o questionário.",
         "follow_ups_new": "Novo acompanhamento",
+        "follow_ups_workflows_alert_title": "Precisas de mais flexibilidade? Automatiza seguimentos e muito mais com Workflows.",
         "formbricks_sdk_is_not_connected": "O SDK do Formbricks não está conectado",
         "four_points": "4 pontos",
         "heading": "Cabeçalho",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "Respondent finalizează sondajul",
         "follow_ups_modal_updated_successfull_toast": "Urmărirea a fost actualizată și va fi salvată odată ce salvați sondajul.",
         "follow_ups_new": "Follow-up nou",
+        "follow_ups_workflows_alert_title": "Ai nevoie de mai multă flexibilitate? Automatizează urmăririle și multe altele cu Workflows.",
         "formbricks_sdk_is_not_connected": "SDK Formbricks nu este conectat",
         "four_points": "4 puncte",
         "heading": "Titlu",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "Респондент завершает опрос",
         "follow_ups_modal_updated_successfull_toast": "Фоллоу-ап обновлён и будет сохранён после сохранения опроса.",
         "follow_ups_new": "Новый фоллоу-ап",
+        "follow_ups_workflows_alert_title": "Нужно больше гибкости? Автоматизируйте напоминания и многое другое с помощью Workflows.",
         "formbricks_sdk_is_not_connected": "Formbricks SDK не подключён",
         "four_points": "4 балла",
         "heading": "Заголовок",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "Respondenten slutför enkäten",
         "follow_ups_modal_updated_successfull_toast": "Uppföljning uppdaterad och sparas när du sparar enkäten.",
         "follow_ups_new": "Ny uppföljning",
+        "follow_ups_workflows_alert_title": "Behöver du mer flexibilitet? Automatisera uppföljningar och mycket mer med Workflows.",
         "formbricks_sdk_is_not_connected": "Formbricks SDK är inte anslutet",
         "four_points": "4 poäng",
         "heading": "Rubrik",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "Katılımcı anketi tamamlıyor",
         "follow_ups_modal_updated_successfull_toast": "Takip güncellendi ve anketi kaydettiğinde kaydedilecek.",
         "follow_ups_new": "Yeni takip",
+        "follow_ups_workflows_alert_title": "Daha fazla esnekliğe mi ihtiyacın var? Takip işlemlerini ve daha fazlasını İş Akışları ile otomatikleştir.",
         "formbricks_sdk_is_not_connected": "Formbricks SDK bağlı değil",
         "four_points": "4 puan",
         "heading": "Başlık",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "受访者 完成 调查",
         "follow_ups_modal_updated_successfull_toast": "后续 操作 已 更新， 并且 在 你 保存 调查 后 将 被 保存。",
         "follow_ups_new": "新的跟进",
+        "follow_ups_workflows_alert_title": "需要更多灵活性？使用工作流自动化后续跟进及更多操作。",
         "formbricks_sdk_is_not_connected": "Formbricks SDK 未连接",
         "four_points": "4 分",
         "heading": "标题",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -3184,6 +3184,7 @@
         "follow_ups_modal_trigger_type_response": "回應者完成問卷",
         "follow_ups_modal_updated_successfull_toast": "後續動作已更新，待你儲存問卷後一併保存。",
         "follow_ups_new": "新增後續追蹤",
+        "follow_ups_workflows_alert_title": "需要更多彈性嗎?使用工作流程自動化後續追蹤及更多功能。",
         "formbricks_sdk_is_not_connected": "Formbricks SDK 未連線",
         "four_points": "4 分",
         "heading": "標題",

--- a/apps/web/modules/survey/follow-ups/components/follow-ups-view.tsx
+++ b/apps/web/modules/survey/follow-ups/components/follow-ups-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { MailIcon } from "lucide-react";
+import Link from "next/link";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TSurveyFollowUp } from "@formbricks/types/surveys/follow-up";
@@ -10,6 +11,7 @@ import { useWorkspace } from "@/app/(app)/workspaces/[workspaceId]/context/works
 import { TFollowUpEmailToUser } from "@/modules/survey/editor/types/survey-follow-up";
 import { FollowUpItem } from "@/modules/survey/follow-ups/components/follow-up-item";
 import { FollowUpModal } from "@/modules/survey/follow-ups/components/follow-up-modal";
+import { Alert, AlertButton, AlertTitle } from "@/modules/ui/components/alert";
 import { Button } from "@/modules/ui/components/button";
 import { UpgradePrompt } from "@/modules/ui/components/upgrade-prompt";
 
@@ -102,23 +104,37 @@ export const FollowUpsView = ({
         )}
       </div>
 
-      <div className="flex flex-col gap-y-2">
-        {surveyFollowUps.map((followUp) => {
-          return (
-            <FollowUpItem
-              key={followUp.id}
-              followUp={followUp}
-              localSurvey={localSurvey}
-              setLocalSurvey={setLocalSurvey}
-              selectedLanguageCode={selectedLanguageCode}
-              mailFrom={mailFrom}
-              userEmail={userEmail}
-              teamMemberDetails={teamMemberDetails}
-              locale={locale}
-            />
-          );
-        })}
-      </div>
+      {surveyFollowUps.length > 0 && (
+        <div className="flex flex-col gap-y-2">
+          {surveyFollowUps.map((followUp) => {
+            return (
+              <FollowUpItem
+                key={followUp.id}
+                followUp={followUp}
+                localSurvey={localSurvey}
+                setLocalSurvey={setLocalSurvey}
+                selectedLanguageCode={selectedLanguageCode}
+                mailFrom={mailFrom}
+                userEmail={userEmail}
+                teamMemberDetails={teamMemberDetails}
+                locale={locale}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      <Alert variant="info" size="small">
+        <AlertTitle>{t("workspace.surveys.edit.follow_ups_workflows_alert_title")}</AlertTitle>
+        <AlertButton asChild>
+          <Link
+            href="https://formbricks.com/docs/workflows/overview"
+            target="_blank"
+            rel="noopener noreferrer">
+            {t("common.learn_more")}
+          </Link>
+        </AlertButton>
+      </Alert>
 
       <FollowUpModal
         localSurvey={localSurvey}


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

Fixes [ENG-1896](https://linear.app/formbricks/issue/ENG-1896/link-follow-ups-to-workflows)

Adds a single-line blue (info) alert to the survey editor's **Follow-ups** tab, below the white card area, pointing users to the Workflows feature. The "Learn more" link opens the Workflows docs (`https://formbricks.com/docs/workflows/overview`) in a new tab — per the ticket, the docs page is the link target for the time being.

Details:

- Uses the shared `Alert` primitive (`variant="info" size="small"`) with `AlertTitle` + `AlertButton asChild` + `next/link`, matching the existing pattern used elsewhere (e.g. app-connection setup page).
- The alert renders in both the empty state (below the dashed empty-state card) and when follow-ups exist (below the follow-up item cards). The non-entitled `UpgradePrompt` branch is untouched.
- The follow-up cards list container is now rendered only when follow-ups exist; previously the empty flex container consumed a `space-y-4` slot, which would have left the alert 32px below the card in the empty state instead of a consistent 16px.
- New i18n key `workspace.surveys.edit.follow_ups_workflows_alert_title` added to `en-US.json`; the link label reuses `common.learn_more`. All other locale files and `i18n.lock` were generated via `pnpm i18n` (Lingo.dev).

Note: this PR targets `epic/workflows-v1` (branched from it), not `main`.

## How should this be tested?

- In a workspace where follow-ups are allowed, open a survey in the editor and go to the **Follow-ups** tab.
- With no follow-ups: the blue single-line alert ("Need more flexibility? Automate follow-ups and much more with Workflows.") shows directly below the white "Send automatic follow-ups" card.
- Add one or more follow-ups: the alert shows below the follow-up cards.
- Click **Learn more**: the Workflows docs page opens in a new tab.
- In an org without the follow-ups entitlement: the upgrade prompt renders as before, without the alert.

Verification run locally:

- `pnpm --filter @formbricks/web typecheck` — pass
- `npx eslint modules/survey/follow-ups/components/follow-ups-view.tsx` (apps/web, no `--fix`) — pass
- `npx prettier --check` on touched view + `en-US.json` — pass
- `pnpm i18n` and `pnpm i18n:validate` — pass
- `vitest run modules/survey/follow-ups` — 3 files, 19 tests passed

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "How to test" section in this PR
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [ ] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [ ] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary
