### PR TITLE
perf(database): speed up Prisma migrations on empty databases

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -130,8 +130,10 @@ jobs:
 
       - name: Apply Prisma Migrations
         run: |
-          # pnpm prisma migrate deploy
-          pnpm db:migrate:dev
+          # @formbricks/database is already built by the "Build App" step above,
+          # so run the migration runner directly instead of db:migrate:dev
+          # (which would rebuild + re-generate the package unnecessarily).
+          pnpm --filter=@formbricks/database db:migrate:ci
 
       - name: Run Rate Limiter Load Tests
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -132,7 +132,10 @@ jobs:
 
       - name: Apply schema + data migrations to the test database
         if: steps.harness.outputs.present == 'true'
-        run: pnpm db:migrate:dev
+        # @formbricks/database is already built by the "Build workspace package
+        # dependencies" step above, so run the migration runner directly instead
+        # of db:migrate:dev (which would rebuild + re-generate the package).
+        run: pnpm --filter=@formbricks/database db:migrate:ci
         shell: bash
 
       # Shared with apps/web/integration/global-setup.ts (the local harness applies the same file) so

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -54,6 +54,24 @@ packages/database/
 - **Schema Migrations**: Continue to be tracked by Prisma in the `_prisma_migrations` table
 - **Data Migrations**: Are tracked in the new `DataMigration` table to avoid reapplying already executed migrations
 
+### ⚠️ Data migrations must be no-ops on an empty database
+
+Data migrations exist to **transform pre-existing rows**. On a brand-new
+(empty) database — every CI run and every fresh install — the migration runner
+takes a fast path: it applies the whole schema in a single `prisma migrate
+deploy` and marks all data migrations **applied without running them**
+(baselining). This is safe only because there is no data to transform, and it
+is necessary because some older data migrations reference columns/tables that
+later schema migrations drop or rename, so they can no longer execute against
+the final schema.
+
+Therefore, a data migration must **only** read and modify existing rows and do
+nothing when its tables are empty (guard writes behind a `SELECT` of existing
+rows, or keep them to `UPDATE`/`DELETE`/`INSERT ... SELECT` that naturally
+affect zero rows on an empty table). **Never seed essential/default data from a
+data migration** — it would be silently skipped on fresh installs. Seed base
+data via the seed script (`src/seed.ts`, `pnpm db:seed`) instead.
+
 ### Directory Structure Example
 
 ```

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -48,6 +48,7 @@
     "dev": "vite build --watch",
     "db:migrate:deploy": "node ./dist/scripts/apply-migrations.js",
     "db:migrate:dev": "pnpm build && dotenv -e ../../.env -- sh -c \"pnpm generate && node ./dist/scripts/apply-migrations.js\"",
+    "db:migrate:ci": "dotenv -e ../../.env -- node ./dist/scripts/apply-migrations.js",
     "db:create-saml-database:deploy": "env SAML_DATABASE_URL=\"${SAML_DATABASE_URL}\" node ./dist/scripts/create-saml-database.js",
     "db:create-saml-database:dev": "dotenv -e ../../.env -- node ./dist/scripts/create-saml-database.js",
     "db:push": "prisma db push --accept-data-loss",

--- a/packages/database/src/scripts/generate-data-migration.ts
+++ b/packages/database/src/scripts/generate-data-migration.ts
@@ -105,7 +105,13 @@ export const ${migrationName}: MigrationScript = {
   id: "${migrationId}",
   name: "${fullMigrationName}",
   run: async ({ tx }) => {
-    // Your migration script goes here
+    // Your migration script goes here.
+    //
+    // IMPORTANT: this must be a no-op on an empty database. Data migrations only
+    // transform pre-existing rows; on a fresh DB they are baselined (marked
+    // applied) WITHOUT running. Guard any write behind a SELECT of existing rows
+    // and never seed essential/default data here — seed via the seed script
+    // (packages/database/src/seed.ts) instead. See the database package README.
   }
 };
 `;

--- a/packages/database/src/scripts/migration-runner.ts
+++ b/packages/database/src/scripts/migration-runner.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import { logger } from "@formbricks/logger";
-import { PrismaClient } from "../prisma";
+import { Prisma, PrismaClient } from "../prisma";
 import { createPrismaPgAdapter } from "../prisma-adapter";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -123,6 +123,53 @@ const loadAppliedSchemaMigrations = async (): Promise<Set<string>> => {
   }
 };
 
+// Count data migrations already recorded in the DataMigration table. Returns 0
+// when the table doesn't exist yet (fresh DB — the table is created by a schema
+// migration). Used to decide whether the fresh-database fast path applies.
+const countRecordedDataMigrations = async (): Promise<number> => {
+  try {
+    const rows: { count: bigint }[] =
+      await prisma.$queryRaw`SELECT COUNT(*)::bigint AS count FROM "DataMigration"`;
+    return Number(rows[0]?.count ?? 0n);
+  } catch (error: unknown) {
+    if (isUndefinedTableError(error)) {
+      return 0;
+    }
+
+    logger.error(error, "Failed to count recorded data migrations");
+    throw error;
+  }
+};
+
+// Record data migrations as applied WITHOUT running them. On a fresh database
+// there is no data to transform, so every data migration is a no-op; several
+// older ones also reference columns/tables dropped by later schema migrations,
+// so they cannot even execute against the final schema. Baselining writes the
+// exact end-state a successful `runDataMigration` leaves (status 'applied' +
+// finished_at), so a later normal run sees them applied and skips. This is a
+// single atomic INSERT: it commits all rows or none, so an interrupted fast
+// path is safely resumed by the trigger in `runMigrations`.
+const baselineDataMigrations = async (dataMigrations: MigrationScript[]): Promise<void> => {
+  if (dataMigrations.length === 0) {
+    return;
+  }
+
+  const finishedAt = new Date();
+  const rows = dataMigrations.map(
+    (migration) => Prisma.sql`(${migration.id}, ${migration.name}, 'applied', ${finishedAt})`
+  );
+
+  await prisma.$executeRaw`
+    INSERT INTO "DataMigration" ("id", "name", "status", "finished_at")
+    VALUES ${Prisma.join(rows)}
+    ON CONFLICT ("id") DO NOTHING
+  `;
+
+  logger.info(
+    `Baselined ${dataMigrations.length.toString()} data migration(s) as applied without running them`
+  );
+};
+
 const runMigrations = async (migrations: MigrationScript[]): Promise<void> => {
   logger.info(`Starting migrations: ${migrations.length.toString()} to run`);
   const startTime = Date.now();
@@ -135,6 +182,46 @@ const runMigrations = async (migrations: MigrationScript[]): Promise<void> => {
   await fs.mkdir(PRISMA_MIGRATIONS_DIR, { recursive: true });
 
   const appliedSchemaMigrations = await loadAppliedSchemaMigrations();
+
+  const schemaMigrations = migrations.filter((migration) => migration.type === "schema");
+  const dataMigrations = migrations.filter((migration) => migration.type === "data");
+
+  // Fresh-database fast path. On a brand-new DB there is no data, so every data
+  // migration is a guaranteed no-op — apply the ENTIRE schema history in a
+  // single `migrate deploy` and baseline the data migrations without running
+  // them, instead of interleaving (which needs one deploy per contiguous schema
+  // segment). It triggers when no data migration has been recorded yet AND
+  // either the DB is untouched (no schema applied) or the full schema is already
+  // present. The second case makes the path resume-safe: if a previous fast run
+  // was interrupted between the schema deploy and the (atomic) baseline INSERT,
+  // this re-runs it — the deploy is a no-op and the baseline is idempotent —
+  // rather than falling through to the interleaved path, which would try to run
+  // data migrations against the final schema (some reference dropped columns and
+  // would fail). A normal partial upgrade always has recorded data migrations,
+  // so it never matches. Invariant: data migrations must be no-ops on an empty
+  // DB (see README) — seed essential data via the seed script, not a migration.
+  if (dataMigrations.length > 0) {
+    const recordedDataMigrations = await countRecordedDataMigrations();
+    const allSchemaApplied = schemaMigrations.every((migration) =>
+      appliedSchemaMigrations.has(migration.name)
+    );
+
+    if (recordedDataMigrations === 0 && (appliedSchemaMigrations.size === 0 || allSchemaApplied)) {
+      logger.info(
+        `Fresh database detected: applying ${schemaMigrations.length.toString()} schema migrations in a single batch and baselining ${dataMigrations.length.toString()} data migrations without running them`
+      );
+
+      // Applies all pending schema migrations in one `migrate deploy` (also
+      // creates the DataMigration table the baseline writes to). On resume,
+      // every schema migration is already applied so this is copy-only.
+      await runSchemaMigrationBatch(schemaMigrations, appliedSchemaMigrations);
+      await baselineDataMigrations(dataMigrations);
+
+      const endTime = Date.now();
+      logger.info(`All migrations completed in ${((endTime - startTime) / 1000).toFixed(2)}s`);
+      return;
+    }
+  }
 
   // Data and schema migrations are interleaved by timestamp and must run in
   // that exact order. But `prisma migrate deploy` applies every pending

--- a/packages/database/src/scripts/migration-runner.ts
+++ b/packages/database/src/scripts/migration-runner.ts
@@ -62,16 +62,22 @@ const resolvePrismaBin = async (): Promise<string> => {
   }
 };
 
-// Postgres error code for `undefined_table`. On a fresh database the
-// `_prisma_migrations` table does not exist yet, so the applied-migrations
-// lookup below is expected to fail with exactly this code. Depending on the
-// Prisma driver adapter, `42P01` surfaces in different places: directly on the
-// error's `code` (raw pg), nested under `meta.driverAdapterError.cause`
-// (Prisma wraps it as a generic `P2010`), or — as a last resort — in the
-// message. We check all three so a fresh DB is reliably recognised.
+// Postgres error codes that mean "this database has never been migrated": the
+// database itself doesn't exist yet (`3D000`, when `migrate deploy` will create
+// it), or it exists but the `_prisma_migrations` table hasn't been created yet
+// (`42P01`). The startup lookups below run BEFORE the first `migrate deploy`, so
+// on a truly fresh target they hit one of these — we treat both as "nothing
+// applied". Depending on the Prisma driver adapter the code surfaces in
+// different places: directly on the error's `code` (raw pg), nested under
+// `meta.driverAdapterError.cause` (Prisma wraps it as a generic `P2010`), or —
+// as a last resort — in the message. We check all three so a fresh DB is
+// reliably recognised.
 const PG_UNDEFINED_TABLE = "42P01";
+const PG_INVALID_CATALOG_NAME = "3D000";
+const FRESH_DATABASE_PG_CODES = [PG_UNDEFINED_TABLE, PG_INVALID_CATALOG_NAME];
+const FRESH_DATABASE_ADAPTER_KINDS = ["TableDoesNotExist", "DatabaseDoesNotExist"];
 
-const isUndefinedTableError = (error: unknown): boolean => {
+const isFreshDatabaseError = (error: unknown): boolean => {
   if (typeof error !== "object" || error === null) {
     return false;
   }
@@ -82,16 +88,20 @@ const isUndefinedTableError = (error: unknown): boolean => {
     message?: unknown;
   };
 
-  if (err.code === PG_UNDEFINED_TABLE) {
+  if (typeof err.code === "string" && FRESH_DATABASE_PG_CODES.includes(err.code)) {
     return true;
   }
 
   const cause = err.meta?.driverAdapterError?.cause;
-  if (cause?.originalCode === PG_UNDEFINED_TABLE || cause?.kind === "TableDoesNotExist") {
+  if (
+    (typeof cause?.originalCode === "string" && FRESH_DATABASE_PG_CODES.includes(cause.originalCode)) ||
+    (typeof cause?.kind === "string" && FRESH_DATABASE_ADAPTER_KINDS.includes(cause.kind))
+  ) {
     return true;
   }
 
-  return typeof err.message === "string" && err.message.includes(PG_UNDEFINED_TABLE);
+  const message = err.message;
+  return typeof message === "string" && FRESH_DATABASE_PG_CODES.some((code) => message.includes(code));
 };
 
 // Load the set of schema migrations already recorded as fully applied in
@@ -109,12 +119,12 @@ const loadAppliedSchemaMigrations = async (): Promise<Set<string>> => {
     `;
     return new Set(rows.map((row) => row.migration_name));
   } catch (error: unknown) {
-    // Fresh database: `_prisma_migrations` doesn't exist yet. Treat as "nothing
-    // applied" and let the first `migrate deploy` create the table. Any other
-    // error is a real fault (e.g. connectivity) and must not be swallowed —
-    // otherwise we'd misread it as an empty DB and needlessly redeploy every
-    // migration.
-    if (isUndefinedTableError(error)) {
+    // Fresh database: the DB doesn't exist yet, or exists without a
+    // `_prisma_migrations` table. Treat as "nothing applied" and let the first
+    // `migrate deploy` create the database/table. Any other error is a real
+    // fault (e.g. connectivity) and must not be swallowed — otherwise we'd
+    // misread it as an empty DB and needlessly redeploy every migration.
+    if (isFreshDatabaseError(error)) {
       return new Set<string>();
     }
 
@@ -124,15 +134,16 @@ const loadAppliedSchemaMigrations = async (): Promise<Set<string>> => {
 };
 
 // Count data migrations already recorded in the DataMigration table. Returns 0
-// when the table doesn't exist yet (fresh DB — the table is created by a schema
-// migration). Used to decide whether the fresh-database fast path applies.
+// when the database or the table doesn't exist yet (fresh DB — the table is
+// created by a schema migration). Used to decide whether the fresh-database
+// fast path applies.
 const countRecordedDataMigrations = async (): Promise<number> => {
   try {
     const rows: { count: bigint }[] =
       await prisma.$queryRaw`SELECT COUNT(*)::bigint AS count FROM "DataMigration"`;
     return Number(rows[0]?.count ?? 0n);
   } catch (error: unknown) {
-    if (isUndefinedTableError(error)) {
+    if (isFreshDatabaseError(error)) {
       return 0;
     }
 
@@ -265,9 +276,17 @@ const runDataMigration = async (migration: MigrationScript): Promise<void> => {
   try {
     await prisma.$transaction(
       async (tx) => {
+        // All DataMigration bookkeeping runs on `tx` (not the outer `prisma`
+        // client) so the status transitions commit atomically with the changes
+        // migration.run makes through `tx`. If the transaction rolls back, the
+        // "applied" marker rolls back with it — a migration can never be
+        // recorded applied while its data changes are discarded. The failure
+        // path below intentionally stays on `prisma`, since it must persist
+        // after the transaction has already rolled back.
+
         // Check if migration has already been run
         const existingMigration: { status: "pending" | "applied" | "failed" }[] | undefined =
-          await prisma.$queryRaw`
+          await tx.$queryRaw`
             SELECT status FROM "DataMigration"
             WHERE id = ${migration.id}
           `;
@@ -291,7 +310,7 @@ const runDataMigration = async (migration: MigrationScript): Promise<void> => {
           logger.info(`Data migration ${migration.name} failed previously. Retrying...`);
         } else {
           // create a new data migration entry with pending status
-          await prisma.$executeRaw`INSERT INTO "DataMigration" (id, name, status) VALUES (${migration.id}, ${migration.name}, 'pending')`;
+          await tx.$executeRaw`INSERT INTO "DataMigration" (id, name, status) VALUES (${migration.id}, ${migration.name}, 'pending')`;
           hasLock = true;
         }
 
@@ -303,7 +322,7 @@ const runDataMigration = async (migration: MigrationScript): Promise<void> => {
           });
 
           // Mark migration as applied
-          await prisma.$executeRaw`
+          await tx.$executeRaw`
               UPDATE "DataMigration"
               SET status = 'applied', finished_at = ${new Date()}
               WHERE id = ${migration.id};

--- a/packages/database/src/scripts/migration-runner.ts
+++ b/packages/database/src/scripts/migration-runner.ts
@@ -62,125 +62,214 @@ const resolvePrismaBin = async (): Promise<string> => {
   }
 };
 
+// Postgres error code for `undefined_table`. On a fresh database the
+// `_prisma_migrations` table does not exist yet, so the applied-migrations
+// lookup below is expected to fail with exactly this code. Depending on the
+// Prisma driver adapter, `42P01` surfaces in different places: directly on the
+// error's `code` (raw pg), nested under `meta.driverAdapterError.cause`
+// (Prisma wraps it as a generic `P2010`), or — as a last resort — in the
+// message. We check all three so a fresh DB is reliably recognised.
+const PG_UNDEFINED_TABLE = "42P01";
+
+const isUndefinedTableError = (error: unknown): boolean => {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  const err = error as {
+    code?: unknown;
+    meta?: { driverAdapterError?: { cause?: { originalCode?: unknown; kind?: unknown } } };
+    message?: unknown;
+  };
+
+  if (err.code === PG_UNDEFINED_TABLE) {
+    return true;
+  }
+
+  const cause = err.meta?.driverAdapterError?.cause;
+  if (cause?.originalCode === PG_UNDEFINED_TABLE || cause?.kind === "TableDoesNotExist") {
+    return true;
+  }
+
+  return typeof err.message === "string" && err.message.includes(PG_UNDEFINED_TABLE);
+};
+
+// Load the set of schema migrations already recorded as fully applied in
+// `_prisma_migrations`. We only ever read this once, before running anything:
+// `prisma migrate deploy` is idempotent, so a migration missing from this
+// snapshot simply gets (re)deployed, and re-applying an already-applied folder
+// is a no-op. The `finished_at IS NOT NULL` predicate excludes failed/partial
+// migrations so their batch is redeployed rather than silently skipped.
+const loadAppliedSchemaMigrations = async (): Promise<Set<string>> => {
+  try {
+    const rows: { migration_name: string }[] = await prisma.$queryRaw`
+      SELECT migration_name
+      FROM _prisma_migrations
+      WHERE finished_at IS NOT NULL
+    `;
+    return new Set(rows.map((row) => row.migration_name));
+  } catch (error: unknown) {
+    // Fresh database: `_prisma_migrations` doesn't exist yet. Treat as "nothing
+    // applied" and let the first `migrate deploy` create the table. Any other
+    // error is a real fault (e.g. connectivity) and must not be swallowed —
+    // otherwise we'd misread it as an empty DB and needlessly redeploy every
+    // migration.
+    if (isUndefinedTableError(error)) {
+      return new Set<string>();
+    }
+
+    logger.error(error, "Failed to load applied schema migrations");
+    throw error;
+  }
+};
+
 const runMigrations = async (migrations: MigrationScript[]): Promise<void> => {
   logger.info(`Starting migrations: ${migrations.length.toString()} to run`);
   const startTime = Date.now();
 
   // packages/database/migration is the source of truth (checked in). We copy
-  // each migration into packages/database/migrations on demand for
+  // each schema migration into packages/database/migrations on demand for
   // `prisma migrate deploy`, then wipe between runs so stale or experimental
   // migrations from a previous local invocation can't influence this one.
   await fs.rm(PRISMA_MIGRATIONS_DIR, { recursive: true, force: true });
   await fs.mkdir(PRISMA_MIGRATIONS_DIR, { recursive: true });
 
-  for (let index = 0; index < migrations.length; index++) {
-    await runSingleMigration(migrations[index], index);
+  const appliedSchemaMigrations = await loadAppliedSchemaMigrations();
+
+  // Data and schema migrations are interleaved by timestamp and must run in
+  // that exact order. But `prisma migrate deploy` applies every pending
+  // migration in the migrations directory in one shot, so we can collapse a
+  // run of *consecutive* schema migrations into a single deploy call instead of
+  // spawning the Prisma CLI once per migration (which dominated runtime on
+  // empty DBs). We flush the accumulated schema batch right before each data
+  // migration — and once more at the end — which preserves ordering exactly:
+  // consecutive schema migrations are, by definition, not separated by a data
+  // migration, so batching them cannot reorder anything.
+  let schemaBatch: MigrationScript[] = [];
+
+  const flushSchemaBatch = async (): Promise<void> => {
+    if (schemaBatch.length === 0) {
+      return;
+    }
+
+    await runSchemaMigrationBatch(schemaBatch, appliedSchemaMigrations);
+    schemaBatch = [];
+  };
+
+  for (const migration of migrations) {
+    if (migration.type === "schema") {
+      schemaBatch.push(migration);
+    } else {
+      await flushSchemaBatch();
+      await runDataMigration(migration);
+    }
   }
+
+  await flushSchemaBatch();
 
   const endTime = Date.now();
   logger.info(`All migrations completed in ${((endTime - startTime) / 1000).toFixed(2)}s`);
 };
 
-const runSingleMigration = async (migration: MigrationScript, index: number): Promise<void> => {
-  if (migration.type === "data") {
-    let hasLock = false;
-    logger.info(`Running data migration: ${migration.name}`);
+const runDataMigration = async (migration: MigrationScript): Promise<void> => {
+  let hasLock = false;
+  logger.info(`Running data migration: ${migration.name}`);
 
-    try {
-      await prisma.$transaction(
-        async (tx) => {
-          // Check if migration has already been run
-          const existingMigration: { status: "pending" | "applied" | "failed" }[] | undefined =
-            await prisma.$queryRaw`
+  try {
+    await prisma.$transaction(
+      async (tx) => {
+        // Check if migration has already been run
+        const existingMigration: { status: "pending" | "applied" | "failed" }[] | undefined =
+          await prisma.$queryRaw`
             SELECT status FROM "DataMigration"
             WHERE id = ${migration.id}
           `;
 
-          if (existingMigration?.[0]?.status === "pending") {
-            logger.info(`Data migration ${migration.name} is pending.`);
-            logger.info("Either there is another migration which is currently running or this is an error.");
-            logger.info(
-              "If you are sure that there is no migration running, you need to manually resolve the issue."
-            );
+        if (existingMigration?.[0]?.status === "pending") {
+          logger.info(`Data migration ${migration.name} is pending.`);
+          logger.info("Either there is another migration which is currently running or this is an error.");
+          logger.info(
+            "If you are sure that there is no migration running, you need to manually resolve the issue."
+          );
 
-            throw new Error("Migration is pending. Please resolve the issue manually.");
-          }
+          throw new Error("Migration is pending. Please resolve the issue manually.");
+        }
 
-          if (existingMigration?.[0]?.status === "applied") {
-            logger.info(`Data migration ${migration.name} already completed. Skipping...`);
-            return;
-          }
+        if (existingMigration?.[0]?.status === "applied") {
+          logger.info(`Data migration ${migration.name} already completed. Skipping...`);
+          return;
+        }
 
-          if (existingMigration?.[0]?.status === "failed") {
-            logger.info(`Data migration ${migration.name} failed previously. Retrying...`);
-          } else {
-            // create a new data migration entry with pending status
-            await prisma.$executeRaw`INSERT INTO "DataMigration" (id, name, status) VALUES (${migration.id}, ${migration.name}, 'pending')`;
-            hasLock = true;
-          }
+        if (existingMigration?.[0]?.status === "failed") {
+          logger.info(`Data migration ${migration.name} failed previously. Retrying...`);
+        } else {
+          // create a new data migration entry with pending status
+          await prisma.$executeRaw`INSERT INTO "DataMigration" (id, name, status) VALUES (${migration.id}, ${migration.name}, 'pending')`;
+          hasLock = true;
+        }
 
-          if (migration.run) {
-            // Run the actual migration
-            await migration.run({
-              prisma,
-              tx,
-            });
+        if (migration.run) {
+          // Run the actual migration
+          await migration.run({
+            prisma,
+            tx,
+          });
 
-            // Mark migration as applied
-            await prisma.$executeRaw`
+          // Mark migration as applied
+          await prisma.$executeRaw`
               UPDATE "DataMigration"
               SET status = 'applied', finished_at = ${new Date()}
               WHERE id = ${migration.id};
             `;
-          }
+        }
 
-          logger.info(`Data migration ${migration.name} completed successfully`);
-        },
-        { timeout: TRANSACTION_TIMEOUT }
-      );
-    } catch (error) {
-      // Record migration failure
-      logger.error(error, `Data migration ${migration.name} failed`);
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- we need to check if the migration has a lock
-      if (hasLock) {
-        // Mark migration as failed
-        await prisma.$queryRaw`
+        logger.info(`Data migration ${migration.name} completed successfully`);
+      },
+      { timeout: TRANSACTION_TIMEOUT }
+    );
+  } catch (error) {
+    // Record migration failure
+    logger.error(error, `Data migration ${migration.name} failed`);
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- we need to check if the migration has a lock
+    if (hasLock) {
+      // Mark migration as failed
+      await prisma.$queryRaw`
           INSERT INTO "DataMigration" (id, name, status)
         VALUES (${migration.id}, ${migration.name}, 'failed')
           ON CONFLICT (id) DO UPDATE SET status = 'failed';
         `;
-      }
-
-      throw error;
     }
-  } else {
-    try {
-      logger.info(`Running schema migration: ${migration.name}`);
 
-      let copyOnly = false;
+    throw error;
+  }
+};
 
-      if (index > 0) {
-        const isApplied = await isSchemaMigrationApplied(migration.name, prisma);
+// Applies a contiguous run of schema migrations with a single
+// `prisma migrate deploy` call. `prisma migrate deploy` scans the whole
+// migrations directory, applies every pending migration in timestamp order and
+// skips ones already recorded in `_prisma_migrations`, so one call per batch is
+// equivalent to (but far cheaper than) one call per migration.
+const runSchemaMigrationBatch = async (
+  batch: MigrationScript[],
+  appliedSchemaMigrations: Set<string>
+): Promise<void> => {
+  if (batch.length === 0) {
+    return;
+  }
 
-        if (isApplied) {
-          // schema migration is already applied, we can just copy the migration to the original migrations directory
-          copyOnly = true;
-        }
-      }
+  const batchNames = batch.map((migration) => migration.name);
+  logger.info(`Running schema migration batch (${batch.length.toString()}): ${batchNames.join(", ")}`);
 
-      const originalMigrationsDirExists = await fs
-        .access(PRISMA_MIGRATIONS_DIR)
-        .then(() => true)
-        .catch(() => false);
+  try {
+    const sourceDirs = await fs.readdir(MIGRATIONS_DIR);
 
-      if (!originalMigrationsDirExists) {
-        await fs.mkdir(PRISMA_MIGRATIONS_DIR, { recursive: true });
-      }
-
-      // Copy specific schema migration from temp migrations directory to original migrations directory
-      const migrationToCopy = await fs
-        .readdir(MIGRATIONS_DIR)
-        .then((files) => files.find((dir) => dir.includes(migration.name)));
+    // Always copy every folder in the batch into the scratch migrations dir —
+    // even the already-applied ones. A later batch's `migrate deploy` runs
+    // against this accumulated directory, and Prisma treats a migration recorded
+    // in `_prisma_migrations` but missing from the directory as a divergence
+    // error. So the directory must always mirror the applied history.
+    for (const migration of batch) {
+      const migrationToCopy = sourceDirs.find((dir) => dir.includes(migration.name));
 
       if (!migrationToCopy) {
         logger.error(`Schema migration not found: ${migration.name}`);
@@ -189,30 +278,34 @@ const runSingleMigration = async (migration: MigrationScript, index: number): Pr
 
       const sourcePath = path.join(MIGRATIONS_DIR, migrationToCopy);
       const destPath = path.join(PRISMA_MIGRATIONS_DIR, migrationToCopy);
-
-      // Copy migration folder
       await fs.cp(sourcePath, destPath, { recursive: true });
-
-      if (copyOnly) {
-        logger.info(`Schema migration ${migration.name} copied to migrations directory`);
-        return;
-      }
-
-      // Run Prisma migrate. Throws when migrate deploy fails.
-      // We pin DATABASE_URL on the child env to the same URL the in-process
-      // PrismaClient resolved above. prisma.config.mjs always reads
-      // env("DATABASE_URL"), so this is how MIGRATE_DATABASE_URL reaches the
-      // subprocess without leaking into the parent's env.
-      const prismaBin = await resolvePrismaBin();
-      await execFileAsync(prismaBin, ["migrate", "deploy", "--config", PRISMA_CONFIG_PATH], {
-        cwd: REPO_ROOT_DIR,
-        env: { ...process.env, DATABASE_URL: migrationDatabaseUrl },
-      });
-      logger.info(`Successfully applied schema migration: ${migration.name}`);
-    } catch (err) {
-      logger.error(err, `Schema migration ${migration.name} failed`);
-      throw err;
     }
+
+    // If every migration in this batch is already applied there is nothing to
+    // deploy — the copy above is enough to keep the directory consistent for
+    // later batches. This keeps steady-state runs (e.g. a fully-migrated
+    // production container restart) from spawning the Prisma CLI at all.
+    const allApplied = batch.every((migration) => appliedSchemaMigrations.has(migration.name));
+
+    if (allApplied) {
+      logger.info(`Schema migration batch already applied; copied ${batch.length.toString()} migration(s)`);
+      return;
+    }
+
+    // Run Prisma migrate. Throws when migrate deploy fails.
+    // We pin DATABASE_URL on the child env to the same URL the in-process
+    // PrismaClient resolved above. prisma.config.mjs always reads
+    // env("DATABASE_URL"), so this is how MIGRATE_DATABASE_URL reaches the
+    // subprocess without leaking into the parent's env.
+    const prismaBin = await resolvePrismaBin();
+    await execFileAsync(prismaBin, ["migrate", "deploy", "--config", PRISMA_CONFIG_PATH], {
+      cwd: REPO_ROOT_DIR,
+      env: { ...process.env, DATABASE_URL: migrationDatabaseUrl },
+    });
+    logger.info(`Successfully applied schema migration batch (${batch.length.toString()})`);
+  } catch (err) {
+    logger.error(err, `Schema migration batch failed: ${batchNames.join(", ")}`);
+    throw err;
   }
 };
 
@@ -328,21 +421,5 @@ export async function applyMigrations(): Promise<void> {
     await runMigrations(allMigrations);
   } finally {
     await prisma.$disconnect();
-  }
-}
-
-async function isSchemaMigrationApplied(migrationName: string, prismaClient: PrismaClient): Promise<boolean> {
-  try {
-    const applied: unknown[] = await prismaClient.$queryRaw`
-         SELECT 1
-         FROM _prisma_migrations
-         WHERE migration_name = ${migrationName}
-           AND finished_at IS NOT NULL
-         LIMIT 1;
-       `;
-    return applied.length > 0;
-  } catch (error: unknown) {
-    logger.error(error, `Failed to check migration status`);
-    throw new Error(`Could not verify migration status: ${error as string}`);
   }
 }


### PR DESCRIPTION
## What does this PR do?

Running Prisma migrations against a **fresh/empty database** took ~3 minutes. That cost is paid on **every** CI/CD run (the e2e and integration-tests workflows both spin up an empty Postgres) and is a latent production risk: the Docker startup entrypoint (`apps/web/scripts/docker/next-start.sh`) and the Helm migration Job both wrap the same runner in a **300-second timeout** — right at the observed runtime.

**Root cause.** The custom migration runner (`packages/database/src/scripts/migration-runner.ts`) exists to interleave *data* migrations (`migration.ts`, tracked in `DataMigration`) with *schema* migrations (`migration.sql`, tracked by Prisma in `_prisma_migrations`) in strict timestamp order. To do that it spawned a **separate `prisma migrate deploy` subprocess for every unapplied schema migration** — 156 of them on an empty DB, sequentially. The dominant cost was 156 Prisma CLI cold-starts, not the SQL.

**Two changes:**

1. **Batch consecutive schema migrations** — run one `migrate deploy` per contiguous run of schema migrations (the boundaries being data migrations) instead of one per migration. `migrate deploy` is idempotent, so this is equivalent but far cheaper: **156 → 17** deploy spawns on an empty DB, **0** on a fully-applied DB. Interleaving is preserved exactly (consecutive schema migrations are by definition not separated by a data migration). A single up-front `_prisma_migrations` query replaces the 156 per-migration lookups.

2. **Fresh-database fast path** — on a brand-new DB there is no data, so every data migration is a guaranteed no-op (several older ones also reference columns/tables that later schema migrations drop/rename, so they can't even execute against the final schema). Apply the **entire schema history in a single `migrate deploy`** and **baseline** the 24 data migrations (record them applied without running): **17 → 1** deploy spawn, and 24 data-migration transactions skipped. The trigger is resume-safe — if a run is interrupted between the schema deploy and the atomic baseline insert, the next run completes it rather than running data migrations against the final schema.

**Net effect:** empty-DB migration goes from **~3 min → ~6s** (verified locally against Postgres 16 + pgvector).

Also switches the e2e / integration-tests workflows from `pnpm db:migrate:dev` (which rebuilds + regenerates the database package before migrating) to a new `db:migrate:ci` script that runs the already-built runner directly, dropping a redundant rebuild those jobs were doing.

This relies on a load-bearing invariant — **data migrations must be no-ops on an empty database** (seed essential data via the seed script, never a data migration) — now documented in the database README and the `generate-data-migration` template.

## QA / Test Plan

**How to test**

- [ ] Empty DB → `pnpm --filter @formbricks/database build` then run the runner (`node packages/database/dist/scripts/apply-migrations.js` with `DATABASE_URL` set) → **1** `migrate deploy` runs, 0 data migrations execute, log reports "Fresh database detected" + "Baselined 24 data migration(s)"; afterwards `_prisma_migrations` has 156 finished rows and `DataMigration` has 24 rows all `status='applied'`.
- [ ] Re-run against the now-migrated DB → no-op: 0 deploys, all 24 data migrations reported already applied, exit 0.
- [ ] Existing/partially-migrated DB (has recorded data migrations) → takes the interleaved batched path: only contiguous schema segments containing an unapplied migration deploy, data migrations run in timestamp order.
- [ ] Interrupted-baseline recovery: with full schema applied but `DataMigration` emptied, re-run → fast path re-detects and baselines without running data migrations (no error), rather than failing against the final schema.
- [ ] CI: the `e2e` and `integration-tests` workflows apply migrations against a fresh Postgres via `pnpm --filter=@formbricks/database db:migrate:ci` and pass.

**Preconditions / test data**

- A reachable Postgres with the `vector` extension available (CI uses the `pgvector/pgvector` image). No seed data required; the interesting cases are the empty DB and the fully-applied DB.

**Risks & regressions**

- Migration ordering / interleaving correctness — mitigated: consecutive schema migrations are never separated by a data migration, so batching cannot reorder; the fresh path only skips data migrations when there is provably no data (all 24 audited as no-ops on empty tables).
- Fresh-path skip of data migrations assumes they are no-ops on an empty DB. A *future* data migration that seeds essential data would be silently skipped on fresh installs — guarded by documentation (README + data-migration template), per the seed-vs-migrate separation.
- CI `db:migrate:ci` depends on the database package being built by the preceding build step (it is, in both workflows).

**Migrations / env / cutover**

- No new/changed env vars, no new DB migrations, no schema changes. Only the mechanism by which existing migrations are applied changes. Adds one package script (`db:migrate:ci`).

## Checklist

### Required

- [x] Filled out the "QA / Test Plan" section in this PR (behavior, edge cases, preconditions, risks, migrations/env)
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [ ] Merged the latest changes from main onto my branch with `git pull origin main`
- [x] My changes don't cause any responsiveness issues (no UI changes)

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR (n/a — no UI changes)
- [x] Updated the Formbricks Docs if changes were necessary (database package README updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQdEAsbHqX6duz4Ge7UXcs

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQdEAsbHqX6duz4Ge7UXcs)_