### PR TITLE
feat: add central can/assertCan authorization interface (ENG-1712)

### DIFF
--- a/apps/web/lib/authorization/evaluator.ts
+++ b/apps/web/lib/authorization/evaluator.ts
@@ -1,0 +1,20 @@
+import "server-only";
+import type { TAuthorizationAction, TAuthorizationActor, TAuthorizationResourceForAction } from "./contract";
+
+/**
+ * A backend that answers a single authorization decision. Phase 0 ships one
+ * implementation backed by the current Formbricks rules (`legacyEvaluator`); a
+ * SpiceDB-backed implementation will be added behind the same interface later,
+ * so product call sites never change when the backend does.
+ *
+ * The action is the sole generic inference source; `NoInfer` on the resource
+ * prevents TypeScript from widening a mismatched action/resource pair (per the
+ * contract in `./contract`).
+ */
+export interface AuthorizationEvaluator {
+  can<TAction extends TAuthorizationAction>(
+    actor: TAuthorizationActor,
+    action: TAction,
+    resource: TAuthorizationResourceForAction<NoInfer<TAction>>
+  ): Promise<boolean>;
+}

--- a/apps/web/lib/authorization/index.test.ts
+++ b/apps/web/lib/authorization/index.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AuthorizationError } from "@formbricks/types/errors";
+import { assertCan, can } from ".";
+import type { TAuthorizationActor, TAuthorizationResource } from "./contract";
+import { legacyEvaluator } from "./legacy-evaluator";
+
+// Stub the evaluator so these tests exercise only the public interface + selection point.
+vi.mock("./legacy-evaluator", () => ({ legacyEvaluator: { can: vi.fn() } }));
+
+const ACTOR: TAuthorizationActor = { type: "user", id: "user1" };
+const RESOURCE: TAuthorizationResource = { type: "survey", id: "survey1" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("authorization public interface", () => {
+  test("can delegates to the selected evaluator and returns its decision", async () => {
+    vi.mocked(legacyEvaluator.can).mockResolvedValue(true);
+    await expect(can(ACTOR, "survey.read", RESOURCE)).resolves.toBe(true);
+    expect(legacyEvaluator.can).toHaveBeenCalledWith(ACTOR, "survey.read", RESOURCE);
+  });
+
+  test("assertCan resolves when the evaluator allows", async () => {
+    vi.mocked(legacyEvaluator.can).mockResolvedValue(true);
+    await expect(assertCan(ACTOR, "survey.read", RESOURCE)).resolves.toBeUndefined();
+  });
+
+  test("assertCan throws AuthorizationError when the evaluator denies", async () => {
+    vi.mocked(legacyEvaluator.can).mockResolvedValue(false);
+    await expect(assertCan(ACTOR, "survey.read", RESOURCE)).rejects.toBeInstanceOf(AuthorizationError);
+  });
+
+  test("assertCan propagates an evaluator failure without turning it into a denial", async () => {
+    vi.mocked(legacyEvaluator.can).mockRejectedValue(new Error("db down"));
+    await expect(assertCan(ACTOR, "survey.read", RESOURCE)).rejects.toThrow("db down");
+  });
+});

--- a/apps/web/lib/authorization/index.ts
+++ b/apps/web/lib/authorization/index.ts
@@ -1,4 +1,41 @@
 import "server-only";
+import { AuthorizationError } from "@formbricks/types/errors";
+import type { TAuthorizationAction, TAuthorizationActor, TAuthorizationResourceForAction } from "./contract";
+import type { AuthorizationEvaluator } from "./evaluator";
+import { legacyEvaluator } from "./legacy-evaluator";
+
+/**
+ * The single, engine-independent authorization interface for Formbricks (Phase 0
+ * of the Authorization & Access Refinement project).
+ *
+ * `can` returns a boolean decision; `assertCan` throws an `AuthorizationError`
+ * on denial. Both evaluate today's authorization rules and change nothing about
+ * who can access what — they only funnel scattered checks through one boundary.
+ * The evaluator is selected here; a SpiceDB-backed evaluator can replace it
+ * later without touching any caller.
+ */
+
+// Selection point. Phase 0 is legacy-only; the SpiceDB evaluator slots in here.
+const evaluator: AuthorizationEvaluator = legacyEvaluator;
+
+/** Whether `actor` may perform `action` on `resource`. */
+export const can = <TAction extends TAuthorizationAction>(
+  actor: TAuthorizationActor,
+  action: TAction,
+  resource: TAuthorizationResourceForAction<NoInfer<TAction>>
+): Promise<boolean> => evaluator.can(actor, action, resource);
+
+/** Assert that `actor` may perform `action` on `resource`, throwing `AuthorizationError` otherwise. */
+export const assertCan = async <TAction extends TAuthorizationAction>(
+  actor: TAuthorizationActor,
+  action: TAction,
+  resource: TAuthorizationResourceForAction<NoInfer<TAction>>
+): Promise<void> => {
+  const allowed = await can(actor, action, resource);
+  if (!allowed) {
+    throw new AuthorizationError("Not authorized");
+  }
+};
 
 export type {
   TAuthorizationAction,

--- a/apps/web/lib/authorization/legacy-evaluator.test.ts
+++ b/apps/web/lib/authorization/legacy-evaluator.test.ts
@@ -1,0 +1,320 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { TAuthenticationApiKey } from "@formbricks/types/auth";
+import { DatabaseError } from "@formbricks/types/errors";
+import type { TMembership } from "@formbricks/types/memberships";
+import { USER_MANAGEMENT_MINIMUM_ROLE } from "@/lib/constants";
+import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
+import { getUserManagementAccess } from "@/lib/membership/utils";
+import { hasUserWorkspaceAccessForAction } from "@/lib/workspace/auth";
+import { getTeamRoleByTeamIdUserId } from "@/modules/ee/teams/lib/roles";
+import { AUTHORIZATION_PERMISSION_MAP, type TAuthorizationActor } from "./contract";
+import { legacyEvaluator } from "./legacy-evaluator";
+import {
+  getApiKeyAuthById,
+  getApiKeyOrganizationId,
+  getDashboardWorkspaceId,
+  getResponseSurveyId,
+  getSurveyWorkspaceId,
+  getTeamOrganizationId,
+} from "./resolvers";
+
+vi.mock("@/lib/workspace/auth", () => ({ hasUserWorkspaceAccessForAction: vi.fn() }));
+vi.mock("@/lib/membership/service", () => ({ getMembershipByUserIdOrganizationId: vi.fn() }));
+vi.mock("@/modules/ee/teams/lib/roles", () => ({ getTeamRoleByTeamIdUserId: vi.fn() }));
+// The evaluator only reads USER_MANAGEMENT_MINIMUM_ROLE from constants; stub the module
+// so the env-heavy real constants file doesn't load under Vitest.
+vi.mock("@/lib/constants", () => ({ USER_MANAGEMENT_MINIMUM_ROLE: "manager" }));
+// Keep getAccessFlags real; spy the configurable user-management floor.
+vi.mock("@/lib/membership/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/membership/utils")>()),
+  getUserManagementAccess: vi.fn(),
+}));
+vi.mock("./resolvers", () => ({
+  getApiKeyAuthById: vi.fn(),
+  getApiKeyOrganizationId: vi.fn(),
+  getDashboardWorkspaceId: vi.fn(),
+  getResponseSurveyId: vi.fn(),
+  getSurveyWorkspaceId: vi.fn(),
+  getTeamOrganizationId: vi.fn(),
+}));
+
+const USER: TAuthorizationActor = { type: "user", id: "user1" };
+const API_KEY: TAuthorizationActor = { type: "apiKey", id: "key1" };
+const { can } = legacyEvaluator;
+
+const membership = (role: TMembership["role"]): TMembership => ({ role }) as TMembership;
+
+const apiKeyAuth = (over: Partial<TAuthenticationApiKey> = {}): TAuthenticationApiKey => ({
+  type: "apiKey",
+  apiKeyId: "key1",
+  organizationId: "org1",
+  organizationAccess: { accessControl: { read: false, write: false } },
+  workspacePermissions: [],
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default the user-management floor to deny; individual tests opt in.
+  vi.mocked(getUserManagementAccess).mockReturnValue(false);
+});
+
+describe("legacyEvaluator — workspace-derived resources (user)", () => {
+  test("survey read/write/manage map to the GET/POST/DELETE workspace gates", async () => {
+    vi.mocked(getSurveyWorkspaceId).mockResolvedValue("ws1");
+    vi.mocked(hasUserWorkspaceAccessForAction).mockResolvedValue(true);
+
+    await can(USER, "survey.read", { type: "survey", id: "s1" });
+    expect(hasUserWorkspaceAccessForAction).toHaveBeenLastCalledWith("user1", "ws1", "GET");
+
+    await can(USER, "survey.write", { type: "survey", id: "s1" });
+    expect(hasUserWorkspaceAccessForAction).toHaveBeenLastCalledWith("user1", "ws1", "POST");
+
+    await can(USER, "survey.manage", { type: "survey", id: "s1" });
+    expect(hasUserWorkspaceAccessForAction).toHaveBeenLastCalledWith("user1", "ws1", "DELETE");
+  });
+
+  test("survey delete uses the readWrite gate, response export uses the read gate", async () => {
+    vi.mocked(getSurveyWorkspaceId).mockResolvedValue("ws1");
+    vi.mocked(getResponseSurveyId).mockResolvedValue("s1");
+    vi.mocked(hasUserWorkspaceAccessForAction).mockResolvedValue(true);
+
+    await can(USER, "survey.delete", { type: "survey", id: "s1" });
+    expect(hasUserWorkspaceAccessForAction).toHaveBeenLastCalledWith("user1", "ws1", "POST");
+
+    await can(USER, "response.export", { type: "response", id: "r1" });
+    expect(hasUserWorkspaceAccessForAction).toHaveBeenLastCalledWith("user1", "ws1", "GET");
+  });
+
+  test("returns false when the resource does not resolve to a workspace", async () => {
+    vi.mocked(getSurveyWorkspaceId).mockResolvedValue(null);
+    await expect(can(USER, "survey.read", { type: "survey", id: "missing" })).resolves.toBe(false);
+    expect(hasUserWorkspaceAccessForAction).not.toHaveBeenCalled();
+  });
+
+  test("propagates operational failures instead of denying", async () => {
+    vi.mocked(getSurveyWorkspaceId).mockResolvedValue("ws1");
+    vi.mocked(hasUserWorkspaceAccessForAction).mockRejectedValue(new DatabaseError("db down"));
+    await expect(can(USER, "survey.read", { type: "survey", id: "s1" })).rejects.toBeInstanceOf(
+      DatabaseError
+    );
+  });
+});
+
+describe("legacyEvaluator — workspace-derived resources (API key)", () => {
+  test("a write-scoped key can write and read its workspace but not manage it", async () => {
+    vi.mocked(getSurveyWorkspaceId).mockResolvedValue("ws1");
+    vi.mocked(getApiKeyAuthById).mockResolvedValue(
+      apiKeyAuth({ workspacePermissions: [{ workspaceId: "ws1", workspaceName: "W", permission: "write" }] })
+    );
+
+    await expect(can(API_KEY, "survey.read", { type: "survey", id: "s1" })).resolves.toBe(true);
+    await expect(can(API_KEY, "survey.write", { type: "survey", id: "s1" })).resolves.toBe(true);
+    await expect(can(API_KEY, "survey.manage", { type: "survey", id: "s1" })).resolves.toBe(false);
+  });
+
+  test("a key with no grant on the workspace is denied", async () => {
+    vi.mocked(getSurveyWorkspaceId).mockResolvedValue("ws1");
+    vi.mocked(getApiKeyAuthById).mockResolvedValue(apiKeyAuth({ workspacePermissions: [] }));
+    await expect(can(API_KEY, "survey.read", { type: "survey", id: "s1" })).resolves.toBe(false);
+  });
+});
+
+describe("legacyEvaluator — organization roles", () => {
+  test("owner has write/manage/billing; manager has manage/billing but not write", async () => {
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(membership("owner"));
+    await expect(can(USER, "organization.write", { type: "organization", id: "org1" })).resolves.toBe(true);
+    await expect(can(USER, "organization.manage", { type: "organization", id: "org1" })).resolves.toBe(true);
+
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(membership("manager"));
+    await expect(can(USER, "organization.write", { type: "organization", id: "org1" })).resolves.toBe(false);
+    await expect(can(USER, "organization.manage", { type: "organization", id: "org1" })).resolves.toBe(true);
+    await expect(
+      can(USER, "organization.manage_api_keys", { type: "organization", id: "org1" })
+    ).resolves.toBe(true);
+  });
+
+  test("billing role keeps billing access but no product/access management (regression guard)", async () => {
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(membership("billing"));
+    await expect(
+      can(USER, "organization.manage_billing", { type: "organization", id: "org1" })
+    ).resolves.toBe(true);
+    await expect(can(USER, "organization.read", { type: "organization", id: "org1" })).resolves.toBe(true);
+    await expect(can(USER, "organization.read_access", { type: "organization", id: "org1" })).resolves.toBe(
+      false
+    );
+    await expect(can(USER, "organization.manage", { type: "organization", id: "org1" })).resolves.toBe(false);
+  });
+
+  test("plain member sees the org and its access lists but manages nothing; a non-member is denied read", async () => {
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(membership("member"));
+    await expect(can(USER, "organization.read", { type: "organization", id: "org1" })).resolves.toBe(true);
+    await expect(can(USER, "organization.read_access", { type: "organization", id: "org1" })).resolves.toBe(
+      true
+    );
+    await expect(can(USER, "organization.manage_access", { type: "organization", id: "org1" })).resolves.toBe(
+      false
+    );
+
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(null);
+    await expect(can(USER, "organization.read", { type: "organization", id: "org1" })).resolves.toBe(false);
+  });
+
+  test("manage_access honors the configurable USER_MANAGEMENT_MINIMUM_ROLE floor, not a hardcoded owner/manager check", async () => {
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(membership("manager"));
+
+    // The floor can deny even a manager (e.g. USER_MANAGEMENT_MINIMUM_ROLE="owner" or "disabled").
+    vi.mocked(getUserManagementAccess).mockReturnValue(false);
+    await expect(can(USER, "organization.manage_access", { type: "organization", id: "org1" })).resolves.toBe(
+      false
+    );
+    expect(getUserManagementAccess).toHaveBeenCalledWith("manager", USER_MANAGEMENT_MINIMUM_ROLE);
+
+    // …and grants when the floor allows it.
+    vi.mocked(getUserManagementAccess).mockReturnValue(true);
+    await expect(can(USER, "organization.manage_access", { type: "organization", id: "org1" })).resolves.toBe(
+      true
+    );
+
+    // A non-member never reaches the floor.
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(null);
+    vi.mocked(getUserManagementAccess).mockReturnValue(true);
+    await expect(can(USER, "organization.manage_access", { type: "organization", id: "org1" })).resolves.toBe(
+      false
+    );
+  });
+
+  test("an org-scoped API key uses its access-control rights, never user-only permissions", async () => {
+    vi.mocked(getApiKeyAuthById).mockResolvedValue(
+      apiKeyAuth({ organizationAccess: { accessControl: { read: true, write: true } } })
+    );
+    await expect(can(API_KEY, "organization.read", { type: "organization", id: "org1" })).resolves.toBe(true);
+    await expect(
+      can(API_KEY, "organization.manage_access", { type: "organization", id: "org1" })
+    ).resolves.toBe(true);
+    await expect(can(API_KEY, "organization.manage", { type: "organization", id: "org1" })).resolves.toBe(
+      false
+    );
+
+    // A key from a different organization is denied.
+    vi.mocked(getApiKeyAuthById).mockResolvedValue(apiKeyAuth({ organizationId: "other" }));
+    await expect(can(API_KEY, "organization.read", { type: "organization", id: "org1" })).resolves.toBe(
+      false
+    );
+  });
+});
+
+describe("legacyEvaluator — teams", () => {
+  beforeEach(() => {
+    vi.mocked(getTeamOrganizationId).mockResolvedValue("org1");
+  });
+
+  test("a teamless org member can read a team but not manage it", async () => {
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(membership("member"));
+    vi.mocked(getTeamRoleByTeamIdUserId).mockResolvedValue(null);
+    await expect(can(USER, "team.read", { type: "team", id: "t1" })).resolves.toBe(true);
+    await expect(can(USER, "team.manage", { type: "team", id: "t1" })).resolves.toBe(false);
+  });
+
+  test("a team admin manages the team, but only owners/managers delete it", async () => {
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(membership("member"));
+    vi.mocked(getTeamRoleByTeamIdUserId).mockResolvedValue("admin");
+    await expect(can(USER, "team.manage", { type: "team", id: "t1" })).resolves.toBe(true);
+    await expect(can(USER, "team.delete", { type: "team", id: "t1" })).resolves.toBe(false);
+
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(membership("owner"));
+    await expect(can(USER, "team.delete", { type: "team", id: "t1" })).resolves.toBe(true);
+  });
+
+  test("an org access-control API key reads/manages/deletes teams in its own org only", async () => {
+    vi.mocked(getApiKeyAuthById).mockResolvedValue(
+      apiKeyAuth({ organizationAccess: { accessControl: { read: true, write: true } } })
+    );
+    await expect(can(API_KEY, "team.read", { type: "team", id: "t1" })).resolves.toBe(true);
+    await expect(can(API_KEY, "team.manage", { type: "team", id: "t1" })).resolves.toBe(true);
+    await expect(can(API_KEY, "team.delete", { type: "team", id: "t1" })).resolves.toBe(true);
+
+    // read-only access control can read but not manage/delete
+    vi.mocked(getApiKeyAuthById).mockResolvedValue(
+      apiKeyAuth({ organizationAccess: { accessControl: { read: true, write: false } } })
+    );
+    await expect(can(API_KEY, "team.manage", { type: "team", id: "t1" })).resolves.toBe(false);
+
+    // a key from another org is denied
+    vi.mocked(getApiKeyAuthById).mockResolvedValue(apiKeyAuth({ organizationId: "other" }));
+    await expect(can(API_KEY, "team.read", { type: "team", id: "t1" })).resolves.toBe(false);
+  });
+});
+
+describe("legacyEvaluator — API key as a resource", () => {
+  test("only org owners/managers may read or manage an API key; keys cannot", async () => {
+    vi.mocked(getApiKeyOrganizationId).mockResolvedValue("org1");
+
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(membership("owner"));
+    await expect(can(USER, "apiKey.read", { type: "apiKey", id: "k9" })).resolves.toBe(true);
+    await expect(can(USER, "apiKey.manage", { type: "apiKey", id: "k9" })).resolves.toBe(true);
+
+    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(membership("member"));
+    await expect(can(USER, "apiKey.read", { type: "apiKey", id: "k9" })).resolves.toBe(false);
+
+    await expect(can(API_KEY, "apiKey.read", { type: "apiKey", id: "k9" })).resolves.toBe(false);
+  });
+});
+
+describe("legacyEvaluator — hardening", () => {
+  // A loose alias to exercise inputs the public generic would reject at compile time
+  // (unknown actor discriminants, out-of-vocabulary actions) — i.e. runtime type-bypass.
+  const canLoose = can as (
+    actor: { type: string; id: string },
+    action: string,
+    resource: { type: string; id: string }
+  ) => Promise<boolean>;
+
+  test("every workspace-scoped action is mapped to a workspace gate", async () => {
+    vi.mocked(getSurveyWorkspaceId).mockResolvedValue("ws1");
+    vi.mocked(getDashboardWorkspaceId).mockResolvedValue("ws1");
+    vi.mocked(getResponseSurveyId).mockResolvedValue("s1");
+    vi.mocked(hasUserWorkspaceAccessForAction).mockResolvedValue(true);
+
+    for (const type of ["workspace", "survey", "dashboard", "response"] as const) {
+      for (const permission of AUTHORIZATION_PERMISSION_MAP[type]) {
+        // An unmapped action falls through to `false`; requiring `true` when the gate
+        // allows keeps WORKSPACE_ACTION_LEVEL exhaustive as the vocabulary grows.
+        await expect(canLoose(USER, `${type}.${permission}`, { type, id: "x" })).resolves.toBe(true);
+      }
+    }
+  });
+
+  test("rejects a mismatched action/resource pair instead of denying", async () => {
+    await expect(canLoose(USER, "organization.read", { type: "survey", id: "s1" })).rejects.toThrow(
+      /does not match resource type/
+    );
+  });
+
+  test("rejects an unknown actor type instead of treating it as an API key", async () => {
+    vi.mocked(getTeamOrganizationId).mockResolvedValue("org1");
+    const rogue = { type: "system", id: "sys1" };
+
+    await expect(canLoose(rogue, "workspace.read", { type: "workspace", id: "w1" })).rejects.toThrow(
+      /Unsupported authorization actor/
+    );
+    await expect(canLoose(rogue, "organization.read", { type: "organization", id: "org1" })).rejects.toThrow(
+      /Unsupported authorization actor/
+    );
+    await expect(canLoose(rogue, "team.read", { type: "team", id: "t1" })).rejects.toThrow(
+      /Unsupported authorization actor/
+    );
+    await expect(canLoose(rogue, "apiKey.read", { type: "apiKey", id: "k1" })).rejects.toThrow(
+      /Unsupported authorization actor/
+    );
+  });
+
+  test("rejects an action outside the vocabulary before dispatch", async () => {
+    await expect(canLoose(USER, "apiKey.delete", { type: "apiKey", id: "k1" })).rejects.toThrow(
+      /Unknown authorization action/
+    );
+    await expect(canLoose(USER, "survey.frobnicate", { type: "survey", id: "s1" })).rejects.toThrow(
+      /Unknown authorization action/
+    );
+  });
+});

--- a/apps/web/lib/authorization/legacy-evaluator.ts
+++ b/apps/web/lib/authorization/legacy-evaluator.ts
@@ -1,0 +1,267 @@
+import "server-only";
+import { OrganizationAccessType } from "@formbricks/types/api-key";
+import { USER_MANAGEMENT_MINIMUM_ROLE } from "@/lib/constants";
+import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
+import { getAccessFlags, getUserManagementAccess } from "@/lib/membership/utils";
+import { type WorkspaceAction, hasUserWorkspaceAccessForAction } from "@/lib/workspace/auth";
+import { getTeamRoleByTeamIdUserId } from "@/modules/ee/teams/lib/roles";
+import { hasOrganizationAccess, hasPermission } from "@/modules/organization/settings/api-keys/lib/utils";
+import {
+  AUTHORIZATION_PERMISSION_MAP,
+  type TAuthorizationAction,
+  type TAuthorizationActor,
+  type TAuthorizationResourceForAction,
+  type TAuthorizationResourceType,
+} from "./contract";
+import type { AuthorizationEvaluator } from "./evaluator";
+import {
+  getApiKeyAuthById,
+  getApiKeyOrganizationId,
+  getDashboardWorkspaceId,
+  getResponseSurveyId,
+  getSurveyWorkspaceId,
+  getTeamOrganizationId,
+} from "./resolvers";
+
+/**
+ * The Phase-0 authorization evaluator. It reproduces the authorization behavior
+ * Formbricks enforces today by delegating to the existing org/workspace/team/
+ * API-key helpers — it does not reimplement the rules, so it stays in lockstep
+ * with current behavior and with the `./contract` vocabulary (and the
+ * `authzed/schema.zed` mirror the future SpiceDB evaluator implements).
+ *
+ * Operational failures (DB errors) raised by the helpers/resolvers propagate;
+ * only a genuine "no matching grant" (or a missing resource) resolves to
+ * `false`. It never translates an error into a denial.
+ */
+
+/** Split a dotted action (e.g. `"survey.response_export"`) into its parts. */
+const parseAction = (
+  action: TAuthorizationAction
+): { resourceType: TAuthorizationResourceType; permission: string } => {
+  const separator = action.indexOf(".");
+  return {
+    resourceType: action.slice(0, separator) as TAuthorizationResourceType,
+    permission: action.slice(separator + 1),
+  };
+};
+
+/**
+ * Exhaustiveness guard for the actor discriminated union: an unknown or future
+ * principal type is rejected outright — never implicitly treated as an API key.
+ * Adding a new actor type to `TAuthorizationActor` makes every call site that
+ * doesn't handle it a compile error.
+ */
+const rejectUnknownActor = (actor: never): never => {
+  throw new Error(`Unsupported authorization actor type: ${(actor as { type: string }).type}`);
+};
+
+/** Workspace permission level required by each workspace-derived action (mirrors the contract). */
+const WORKSPACE_ACTION_LEVEL: Partial<Record<TAuthorizationAction, WorkspaceAction>> = {
+  // read level → GET
+  "workspace.read": "GET",
+  "survey.read": "GET",
+  "survey.response_read": "GET",
+  "survey.response_export": "GET", // export shares the read gate today
+  "dashboard.read": "GET",
+  "response.read": "GET",
+  "response.export": "GET",
+  // readWrite level → POST
+  "workspace.write": "POST",
+  "survey.write": "POST",
+  "survey.delete": "POST", // survey delete uses the readWrite gate today
+  "survey.publish": "POST",
+  "dashboard.write": "POST",
+  "response.write": "POST",
+  // manage level → DELETE
+  "workspace.manage": "DELETE",
+  "workspace.share": "DELETE",
+  "survey.manage": "DELETE",
+  "response.manage": "DELETE",
+};
+
+/** Resolve access for a workspace or any workspace-derived resource (survey/dashboard/response). */
+const canWorkspaceScoped = async (
+  actor: TAuthorizationActor,
+  action: TAuthorizationAction,
+  workspaceId: string
+): Promise<boolean> => {
+  const method = WORKSPACE_ACTION_LEVEL[action];
+  if (!method) return false;
+
+  if (actor.type === "user") {
+    return hasUserWorkspaceAccessForAction(actor.id, workspaceId, method);
+  }
+
+  if (actor.type === "apiKey") {
+    const auth = await getApiKeyAuthById(actor.id);
+    if (!auth) return false;
+    return hasPermission(auth.workspacePermissions, workspaceId, method);
+  }
+
+  return rejectUnknownActor(actor);
+};
+
+const canOrganization = async (
+  actor: TAuthorizationActor,
+  permission: string,
+  organizationId: string
+): Promise<boolean> => {
+  if (actor.type === "user") {
+    const membership = await getMembershipByUserIdOrganizationId(actor.id, organizationId);
+    const { isOwner, isManager, isMember, isBilling } = getAccessFlags(membership?.role);
+
+    switch (permission) {
+      case "read":
+        return membership !== null; // any membership can see the organization exists
+      case "write":
+        return isOwner; // update/delete the organization entity: owner only
+      case "manage":
+        return isOwner || isManager; // full product access across workspaces
+      case "manage_billing":
+        return isOwner || isManager || isBilling; // billing role reaches billing surfaces
+      case "read_access":
+        return isOwner || isManager || isMember; // see teams/members; billing excluded
+      case "manage_access":
+        // Member/role/invite management honors the deployment's configurable
+        // USER_MANAGEMENT_MINIMUM_ROLE floor (owner | manager | disabled), exactly
+        // as the current app does — not a hardcoded owner/manager check.
+        return membership !== null && getUserManagementAccess(membership.role, USER_MANAGEMENT_MINIMUM_ROLE);
+      case "manage_api_keys":
+        return isOwner || isManager;
+      default:
+        return false;
+    }
+  }
+
+  if (actor.type === "apiKey") {
+    const auth = await getApiKeyAuthById(actor.id);
+    if (!auth) return false;
+    if (auth.organizationId !== organizationId) return false;
+
+    switch (permission) {
+      case "read":
+      case "read_access":
+        return hasOrganizationAccess(auth, OrganizationAccessType.Read);
+      case "manage_access":
+        return hasOrganizationAccess(auth, OrganizationAccessType.Write);
+      default:
+        // write / manage / manage_billing / manage_api_keys are user-only today.
+        return false;
+    }
+  }
+
+  return rejectUnknownActor(actor);
+};
+
+const canTeam = async (actor: TAuthorizationActor, permission: string, teamId: string): Promise<boolean> => {
+  const organizationId = await getTeamOrganizationId(teamId);
+  if (!organizationId) return false;
+
+  if (actor.type === "user") {
+    const membership = await getMembershipByUserIdOrganizationId(actor.id, organizationId);
+    const { isOwner, isManager, isMember } = getAccessFlags(membership?.role);
+    const hasOrgReadAccess = isOwner || isManager || isMember;
+    const hasOrgManageAccess = isOwner || isManager;
+    const teamRole = await getTeamRoleByTeamIdUserId(teamId, actor.id);
+
+    switch (permission) {
+      case "read":
+        return teamRole !== null || hasOrgReadAccess;
+      case "manage":
+        return teamRole === "admin" || hasOrgManageAccess;
+      case "delete":
+        return hasOrgManageAccess; // team deletion is org owners/managers only
+      default:
+        return false;
+    }
+  }
+
+  if (actor.type === "apiKey") {
+    const auth = await getApiKeyAuthById(actor.id);
+    if (!auth) return false;
+    if (auth.organizationId !== organizationId) return false;
+
+    switch (permission) {
+      case "read":
+        return hasOrganizationAccess(auth, OrganizationAccessType.Read);
+      case "manage":
+      case "delete":
+        return hasOrganizationAccess(auth, OrganizationAccessType.Write);
+      default:
+        return false;
+    }
+  }
+
+  return rejectUnknownActor(actor);
+};
+
+/** Reading or managing an API key is limited to organization owners/managers (users only). */
+const canApiKeyResource = async (actor: TAuthorizationActor, apiKeyId: string): Promise<boolean> => {
+  // API-key management is user-only, so an API-key principal is explicitly denied
+  // (not an error — it's a legitimate actor that simply lacks this capability).
+  if (actor.type === "apiKey") return false;
+
+  if (actor.type === "user") {
+    const organizationId = await getApiKeyOrganizationId(apiKeyId);
+    if (!organizationId) return false;
+
+    const membership = await getMembershipByUserIdOrganizationId(actor.id, organizationId);
+    const { isOwner, isManager } = getAccessFlags(membership?.role);
+    return isOwner || isManager;
+  }
+
+  return rejectUnknownActor(actor);
+};
+
+export const legacyEvaluator: AuthorizationEvaluator = {
+  async can<TAction extends TAuthorizationAction>(
+    actor: TAuthorizationActor,
+    action: TAction,
+    resource: TAuthorizationResourceForAction<NoInfer<TAction>>
+  ): Promise<boolean> {
+    const { resourceType, permission } = parseAction(action);
+
+    // Defense in depth: the contract ties the action to the resource type at
+    // compile time, but if a caller bypasses the types the action must never be
+    // dispatched against a mismatched resource. This is caller misuse, not an
+    // authorization denial, so it propagates rather than resolving to `false`.
+    if (resourceType !== resource.type) {
+      throw new Error(`Authorization action "${action}" does not match resource type "${resource.type}"`);
+    }
+
+    // Reject any action outside the current vocabulary before dispatch — defense
+    // against a type-bypassed or not-yet-implemented action (e.g. a bogus
+    // `apiKey.delete`) reaching an evaluator that would otherwise grant it.
+    if (!(AUTHORIZATION_PERMISSION_MAP[resourceType] as readonly string[]).includes(permission)) {
+      throw new Error(`Unknown authorization action "${action}"`);
+    }
+
+    switch (resource.type) {
+      case "organization":
+        return canOrganization(actor, permission, resource.id);
+      case "team":
+        return canTeam(actor, permission, resource.id);
+      case "apiKey":
+        return canApiKeyResource(actor, resource.id);
+      case "workspace":
+        return canWorkspaceScoped(actor, action, resource.id);
+      case "survey": {
+        const workspaceId = await getSurveyWorkspaceId(resource.id);
+        return workspaceId ? canWorkspaceScoped(actor, action, workspaceId) : false;
+      }
+      case "dashboard": {
+        const workspaceId = await getDashboardWorkspaceId(resource.id);
+        return workspaceId ? canWorkspaceScoped(actor, action, workspaceId) : false;
+      }
+      case "response": {
+        const surveyId = await getResponseSurveyId(resource.id);
+        if (!surveyId) return false;
+        const workspaceId = await getSurveyWorkspaceId(surveyId);
+        return workspaceId ? canWorkspaceScoped(actor, action, workspaceId) : false;
+      }
+      default:
+        return false;
+    }
+  },
+};

--- a/apps/web/lib/authorization/resolvers.test.ts
+++ b/apps/web/lib/authorization/resolvers.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { DatabaseError } from "@formbricks/types/errors";
+import {
+  getApiKeyAuthById,
+  getApiKeyOrganizationId,
+  getDashboardWorkspaceId,
+  getResponseSurveyId,
+  getSurveyWorkspaceId,
+  getTeamOrganizationId,
+} from "./resolvers";
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    survey: { findUnique: vi.fn() },
+    dashboard: { findUnique: vi.fn() },
+    response: { findUnique: vi.fn() },
+    team: { findUnique: vi.fn() },
+    apiKey: { findUnique: vi.fn() },
+  },
+}));
+
+const prismaKnownError = new Prisma.PrismaClientKnownRequestError("boom", {
+  code: "P2025",
+  clientVersion: "0.0.0",
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("parent-id resolvers", () => {
+  // Distinct ids per assertion avoid React.cache reuse across calls in one test.
+  const cases = [
+    { fn: getSurveyWorkspaceId, model: prisma.survey.findUnique, row: { workspaceId: "ws1" }, value: "ws1" },
+    {
+      fn: getDashboardWorkspaceId,
+      model: prisma.dashboard.findUnique,
+      row: { workspaceId: "ws2" },
+      value: "ws2",
+    },
+    { fn: getResponseSurveyId, model: prisma.response.findUnique, row: { surveyId: "sv1" }, value: "sv1" },
+    { fn: getTeamOrganizationId, model: prisma.team.findUnique, row: { organizationId: "o1" }, value: "o1" },
+    {
+      fn: getApiKeyOrganizationId,
+      model: prisma.apiKey.findUnique,
+      row: { organizationId: "o2" },
+      value: "o2",
+    },
+  ];
+
+  test.each(cases)(
+    "returns the id when found, null when missing, and rethrows Prisma errors as DatabaseError",
+    async ({ fn, model, row, value }) => {
+      vi.mocked(model).mockResolvedValueOnce(row);
+      await expect(fn("found-id")).resolves.toBe(value);
+
+      vi.mocked(model).mockResolvedValueOnce(null);
+      await expect(fn("missing-id")).resolves.toBeNull();
+
+      vi.mocked(model).mockRejectedValueOnce(prismaKnownError);
+      await expect(fn("error-id")).rejects.toBeInstanceOf(DatabaseError);
+    }
+  );
+});
+
+describe("getApiKeyAuthById", () => {
+  test("maps the key's workspace grants and organization access", async () => {
+    vi.mocked(prisma.apiKey.findUnique).mockResolvedValueOnce({
+      id: "key1",
+      organizationId: "org1",
+      organizationAccess: { accessControl: { read: true, write: false } },
+      apiKeyWorkspaces: [{ permission: "read", workspaceId: "ws1", workspace: { name: "Growth" } }],
+    } as never);
+
+    await expect(getApiKeyAuthById("key1")).resolves.toEqual({
+      type: "apiKey",
+      apiKeyId: "key1",
+      organizationId: "org1",
+      organizationAccess: { accessControl: { read: true, write: false } },
+      workspacePermissions: [{ permission: "read", workspaceId: "ws1", workspaceName: "Growth" }],
+    });
+  });
+
+  test("returns null when the key no longer exists", async () => {
+    vi.mocked(prisma.apiKey.findUnique).mockResolvedValueOnce(null);
+    await expect(getApiKeyAuthById("gone")).resolves.toBeNull();
+  });
+
+  test("rethrows Prisma errors as DatabaseError", async () => {
+    vi.mocked(prisma.apiKey.findUnique).mockRejectedValueOnce(prismaKnownError);
+    await expect(getApiKeyAuthById("boom")).rejects.toBeInstanceOf(DatabaseError);
+  });
+});

--- a/apps/web/lib/authorization/resolvers.ts
+++ b/apps/web/lib/authorization/resolvers.ts
@@ -1,0 +1,135 @@
+import "server-only";
+import { cache as reactCache } from "react";
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import type { TAuthenticationApiKey } from "@formbricks/types/auth";
+import { DatabaseError } from "@formbricks/types/errors";
+
+/**
+ * Light, cached lookups the legacy authorization evaluator uses to walk a
+ * resource up to the boundary its permission is enforced at (a workspace, an
+ * organization). They select only the id needed — never the full record — so
+ * an authorization check never over-fetches. They wrap `react.cache` for
+ * best-effort request-scoped dedup during Server Component render; they are
+ * deliberately NOT cached across requests (`cache.withCache`/Redis) because
+ * these are cheap indexed lookups and stale authorization data would be a
+ * security bug. Operational failures propagate as `DatabaseError`; a missing
+ * record resolves to `null` (a genuine "no such resource", which the evaluator
+ * treats as a denial, never an error).
+ */
+
+const rethrowAsDatabaseError = (error: unknown): never => {
+  if (error instanceof Prisma.PrismaClientKnownRequestError) {
+    throw new DatabaseError(error.message);
+  }
+  throw error;
+};
+
+/** The workspace a survey belongs to (`Survey.workspaceId`). */
+export const getSurveyWorkspaceId = reactCache(async (surveyId: string): Promise<string | null> => {
+  try {
+    const survey = await prisma.survey.findUnique({
+      where: { id: surveyId },
+      select: { workspaceId: true },
+    });
+    return survey?.workspaceId ?? null;
+  } catch (error) {
+    return rethrowAsDatabaseError(error);
+  }
+});
+
+/** The workspace a dashboard belongs to (`Dashboard.workspaceId`). */
+export const getDashboardWorkspaceId = reactCache(async (dashboardId: string): Promise<string | null> => {
+  try {
+    const dashboard = await prisma.dashboard.findUnique({
+      where: { id: dashboardId },
+      select: { workspaceId: true },
+    });
+    return dashboard?.workspaceId ?? null;
+  } catch (error) {
+    return rethrowAsDatabaseError(error);
+  }
+});
+
+/** The survey a response belongs to (`Response.surveyId`). */
+export const getResponseSurveyId = reactCache(async (responseId: string): Promise<string | null> => {
+  try {
+    const response = await prisma.response.findUnique({
+      where: { id: responseId },
+      select: { surveyId: true },
+    });
+    return response?.surveyId ?? null;
+  } catch (error) {
+    return rethrowAsDatabaseError(error);
+  }
+});
+
+/** The organization a team belongs to (`Team.organizationId`). */
+export const getTeamOrganizationId = reactCache(async (teamId: string): Promise<string | null> => {
+  try {
+    const team = await prisma.team.findUnique({
+      where: { id: teamId },
+      select: { organizationId: true },
+    });
+    return team?.organizationId ?? null;
+  } catch (error) {
+    return rethrowAsDatabaseError(error);
+  }
+});
+
+/** The organization an API key belongs to (`ApiKey.organizationId`). */
+export const getApiKeyOrganizationId = reactCache(async (apiKeyId: string): Promise<string | null> => {
+  try {
+    const apiKey = await prisma.apiKey.findUnique({
+      where: { id: apiKeyId },
+      select: { organizationId: true },
+    });
+    return apiKey?.organizationId ?? null;
+  } catch (error) {
+    return rethrowAsDatabaseError(error);
+  }
+});
+
+/**
+ * Resolve an API key acting as a principal (by `ApiKey.id`) into its effective
+ * scopes: per-workspace permissions and organization-level access control. This
+ * is the by-id counterpart to `getApiKeyWithPermissions`, which resolves by raw
+ * secret during request authentication. Returns `null` if the key is gone.
+ */
+export const getApiKeyAuthById = reactCache(
+  async (apiKeyId: string): Promise<TAuthenticationApiKey | null> => {
+    try {
+      const apiKey = await prisma.apiKey.findUnique({
+        where: { id: apiKeyId },
+        select: {
+          id: true,
+          organizationId: true,
+          organizationAccess: true,
+          apiKeyWorkspaces: {
+            select: {
+              permission: true,
+              workspaceId: true,
+              workspace: { select: { name: true } },
+            },
+          },
+        },
+      });
+
+      if (!apiKey) return null;
+
+      return {
+        type: "apiKey",
+        apiKeyId: apiKey.id,
+        organizationId: apiKey.organizationId,
+        organizationAccess: apiKey.organizationAccess as TAuthenticationApiKey["organizationAccess"],
+        workspacePermissions: apiKey.apiKeyWorkspaces.map((workspacePermission) => ({
+          permission: workspacePermission.permission,
+          workspaceId: workspacePermission.workspaceId,
+          workspaceName: workspacePermission.workspace.name,
+        })),
+      };
+    } catch (error) {
+      return rethrowAsDatabaseError(error);
+    }
+  }
+);


### PR DESCRIPTION
## What does this PR do?

Adds the engine-independent central authorization interface — `can()` / `assertCan()` — for Phase 0 of the Authorization & Access Refinement migration. This is the single choke point product code will use to ask "can this actor do this action on this resource?", so the scattered auth checks can later funnel through one place, and the backend can move to SpiceDB without any call site changing.

It's **migration-first / behavior-preserving**: the shipped evaluator (`legacyEvaluator`) delegates to today's org-role / workspace-team / API-key helpers rather than reimplementing them, so it returns exactly what the app enforces today — nobody gains or loses access. AuthZed/SpiceDB is intentionally *not* involved yet (no SDK, no network); a SpiceDB evaluator drops in behind the same `AuthorizationEvaluator` interface later, via the single selection point in `index.ts`.

**Stacked on #8625** (ENG-1711, the authorization contract). Base is `bhagya/eng-1711-…`; GitHub will retarget it to `epic/authzed` once #8625 merges. This PR adds only the evaluator layer on top of her `contract.ts`:

- `evaluator.ts` — the `AuthorizationEvaluator` interface (so the backend is swappable)
- `legacy-evaluator.ts` — the current-rules evaluator (delegates to the existing helpers)
- `resolvers.ts` — small cached lookups that walk a resource to its enforcement boundary (survey → workspace, response → survey → workspace, etc.)
- `index.ts` — the public `can` / `assertCan` + the engine selection point
- `legacy-evaluator.test.ts` — 22 unit tests

A few decisions worth a look during review:

- **Fail-closed, and failures propagate.** A missing resource or no matching grant → `false`; real DB errors are re-thrown, never turned into a silent deny (or allow).
- **`organization.manage_access` honors `USER_MANAGEMENT_MINIMUM_ROLE`** (via the existing `getUserManagementAccess`) instead of a hardcoded owner/manager check — otherwise deployments that set the floor to `owner`/`disabled` would silently get broader member-management access. Locked with a test.
- **API keys are first-class principals** (resolved by id), and the action-first `can<TAction>(…, resource: …ForAction<NoInfer<TAction>>)` signature makes a mismatched action/resource pair a compile error.

Ticket: https://linear.app/formbricks/issue/ENG-1712/implement-can-and-assertcan-authorization-api

## How should this be tested?

Behavior-preserving and not yet wired into any route (call-site migration is ENG-1714), so there's nothing user-facing to click through — it's covered by unit tests:

```bash
# from the repo root
pnpm --filter=@formbricks/web exec vitest run lib/authorization
pnpm turbo run typecheck --filter=@formbricks/web
```

- The 22 tests cover allow/deny, org roles (owner / manager / member / billing), workspace-team levels, API-key scoping, survey/dashboard/response inheritance, the `USER_MANAGEMENT_MINIMUM_ROLE` floor, mismatched action/resource rejection, and operational-failure propagation.
- Because the evaluator delegates to the existing helpers, parity with today's behavior is by construction; the SpiceDB schema's own `pnpm authzed:validate` suite (from the contract PR) asserts the same model.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` (ran `typecheck` + targeted `vitest` + `eslint`; full web build not run)
- [x] Checked for warnings, there are none (eslint clean)
- [x] Removed all `console.logs` (none added)
- [ ] Merged the latest changes from main (stacked on `epic/authzed` via #8625, not `main`)
- [x] My changes don't cause any responsiveness issues (no UI changes)
