### PR TITLE
fix(editor): support nested lists via Tab in the rich text editor [ENG-1747]

### DIFF
--- a/apps/web/modules/email/components/preview-email-template.tsx
+++ b/apps/web/modules/email/components/preview-email-template.tsx
@@ -57,6 +57,7 @@ import {
   getSecondaryButtonStyle,
   importantStyle,
   normalizeRichTextSpacing,
+  suppressNestedListMarkers,
 } from "../lib/preview-email-template-styles";
 import { getNPSOptionColor, getRatingNumberOptionColor } from "../lib/utils";
 
@@ -159,9 +160,9 @@ function PreviewElementHeader({
   return (
     <ElementHeader
       className={className}
-      headline={normalizeRichTextSpacing(headline)}
+      headline={suppressNestedListMarkers(normalizeRichTextSpacing(headline))}
       style={getLightModeTextStyle(styleTokens)}
-      subheader={subheader ? normalizeRichTextSpacing(subheader) : undefined}
+      subheader={subheader ? suppressNestedListMarkers(normalizeRichTextSpacing(subheader)) : undefined}
       subheaderStyle={{
         ...getForcedColorStyle(styleTokens.elementDescriptionColor),
         fontSize: styleTokens.elementDescriptionFontSize,

--- a/apps/web/modules/email/lib/preview-email-template-styles.test.ts
+++ b/apps/web/modules/email/lib/preview-email-template-styles.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "vitest";
+import { suppressNestedListMarkers } from "./preview-email-template-styles";
+
+describe("suppressNestedListMarkers", () => {
+  test("adds an inline marker suppression to a nested-list wrapper li", () => {
+    const html = '<ul><li class="fb-editor-nested-listitem"><ul><li>child</li></ul></li></ul>';
+
+    expect(suppressNestedListMarkers(html)).toBe(
+      '<ul><li class="fb-editor-nested-listitem" style="list-style-type:none"><ul><li>child</li></ul></li></ul>'
+    );
+  });
+
+  test("leaves list items without the nested class untouched", () => {
+    const html = '<ul><li class="fb-editor-listitem" value="1">one</li><li>two</li></ul>';
+
+    expect(suppressNestedListMarkers(html)).toBe(html);
+  });
+
+  test("does not match class names that merely contain the nested class as a substring", () => {
+    const html = '<ul><li class="fb-editor-nested-listitem-custom">item</li></ul>';
+
+    expect(suppressNestedListMarkers(html)).toBe(html);
+  });
+
+  test("matches the nested class among multiple classes regardless of attribute order", () => {
+    const html = '<ol><li value="2" class="fb-editor-listitem fb-editor-nested-listitem"><ol></ol></li></ol>';
+
+    expect(suppressNestedListMarkers(html)).toBe(
+      '<ol><li value="2" class="fb-editor-listitem fb-editor-nested-listitem" style="list-style-type:none"><ol></ol></li></ol>'
+    );
+  });
+
+  test("preserves the value attribute on ordered-list items", () => {
+    const html = '<ol><li class="fb-editor-nested-listitem" value="3"><ol></ol></li></ol>';
+
+    expect(suppressNestedListMarkers(html)).toContain('value="3"');
+  });
+
+  test("appends to an existing style attribute instead of replacing it", () => {
+    const html = '<ul><li class="fb-editor-nested-listitem" style="text-align: center"><ul></ul></li></ul>';
+
+    expect(suppressNestedListMarkers(html)).toBe(
+      '<ul><li class="fb-editor-nested-listitem" style="text-align: center;list-style-type:none"><ul></ul></li></ul>'
+    );
+  });
+
+  test("handles single-quoted attributes", () => {
+    const html = "<ul><li class='fb-editor-nested-listitem'><ul></ul></li></ul>";
+
+    expect(suppressNestedListMarkers(html)).toBe(
+      "<ul><li class='fb-editor-nested-listitem' style=\"list-style-type:none\"><ul></ul></li></ul>"
+    );
+  });
+
+  test("is idempotent when applied twice", () => {
+    const html =
+      '<ul><li class="fb-editor-nested-listitem"><ul></ul></li>' +
+      '<li class="fb-editor-nested-listitem" style="text-align: right"><ol></ol></li></ul>';
+
+    const once = suppressNestedListMarkers(html);
+
+    expect(suppressNestedListMarkers(once)).toBe(once);
+  });
+
+  test("leaves html without list items unchanged", () => {
+    const html = "<p>hello <strong>world</strong></p>";
+
+    expect(suppressNestedListMarkers(html)).toBe(html);
+  });
+});

--- a/apps/web/modules/email/lib/preview-email-template-styles.test.ts
+++ b/apps/web/modules/email/lib/preview-email-template-styles.test.ts
@@ -5,13 +5,37 @@ import {
 } from "@/modules/ui/components/editor/lib/example-theme";
 import { suppressNestedListMarkers } from "./preview-email-template-styles";
 
-describe("suppressNestedListMarkers", () => {
-  test("adds an inline marker suppression to a nested-list wrapper li", () => {
-    const html = `<ul><li class="${NESTED_LIST_ITEM_CLASS}"><ul><li>child</li></ul></li></ul>`;
+const marker = `style="${NESTED_LIST_ITEM_MARKER_STYLE}"`;
 
-    expect(suppressNestedListMarkers(html)).toBe(
-      `<ul><li class="${NESTED_LIST_ITEM_CLASS}" style="${NESTED_LIST_ITEM_MARKER_STYLE}"><ul><li>child</li></ul></li></ul>`
-    );
+describe("suppressNestedListMarkers", () => {
+  test.each([
+    [
+      "a nested-list wrapper li",
+      `<ul><li class="${NESTED_LIST_ITEM_CLASS}"><ul><li>child</li></ul></li></ul>`,
+      `<ul><li class="${NESTED_LIST_ITEM_CLASS}" ${marker}><ul><li>child</li></ul></li></ul>`,
+    ],
+    [
+      "the nested class among multiple classes, whatever the attribute order",
+      `<ol><li value="2" class="fb-editor-listitem ${NESTED_LIST_ITEM_CLASS}"><ol></ol></li></ol>`,
+      `<ol><li value="2" class="fb-editor-listitem ${NESTED_LIST_ITEM_CLASS}" ${marker}><ol></ol></li></ol>`,
+    ],
+    [
+      "a wrapper li without dropping its ordered-list value",
+      `<ol><li class="${NESTED_LIST_ITEM_CLASS}" value="3"><ol></ol></li></ol>`,
+      `<ol><li class="${NESTED_LIST_ITEM_CLASS}" value="3" ${marker}><ol></ol></li></ol>`,
+    ],
+    [
+      "a wrapper li by appending to its existing style instead of replacing it",
+      `<ul><li class="${NESTED_LIST_ITEM_CLASS}" style="text-align: center"><ul></ul></li></ul>`,
+      `<ul><li class="${NESTED_LIST_ITEM_CLASS}" style="text-align: center;${NESTED_LIST_ITEM_MARKER_STYLE}"><ul></ul></li></ul>`,
+    ],
+    [
+      "a wrapper li with single-quoted attributes",
+      `<ul><li class='${NESTED_LIST_ITEM_CLASS}'><ul></ul></li></ul>`,
+      `<ul><li class='${NESTED_LIST_ITEM_CLASS}' ${marker}><ul></ul></li></ul>`,
+    ],
+  ])("suppresses the marker on %s", (_case, html, expected) => {
+    expect(suppressNestedListMarkers(html)).toBe(expected);
   });
 
   test.each([
@@ -26,36 +50,6 @@ describe("suppressNestedListMarkers", () => {
     ["html without list items", "<p>hello <strong>world</strong></p>"],
   ])("leaves %s untouched", (_case, html) => {
     expect(suppressNestedListMarkers(html)).toBe(html);
-  });
-
-  test("matches the nested class among multiple classes regardless of attribute order", () => {
-    const html = `<ol><li value="2" class="fb-editor-listitem ${NESTED_LIST_ITEM_CLASS}"><ol></ol></li></ol>`;
-
-    expect(suppressNestedListMarkers(html)).toBe(
-      `<ol><li value="2" class="fb-editor-listitem ${NESTED_LIST_ITEM_CLASS}" style="${NESTED_LIST_ITEM_MARKER_STYLE}"><ol></ol></li></ol>`
-    );
-  });
-
-  test("preserves the value attribute on ordered-list items", () => {
-    const html = `<ol><li class="${NESTED_LIST_ITEM_CLASS}" value="3"><ol></ol></li></ol>`;
-
-    expect(suppressNestedListMarkers(html)).toContain('value="3"');
-  });
-
-  test("appends to an existing style attribute instead of replacing it", () => {
-    const html = `<ul><li class="${NESTED_LIST_ITEM_CLASS}" style="text-align: center"><ul></ul></li></ul>`;
-
-    expect(suppressNestedListMarkers(html)).toBe(
-      `<ul><li class="${NESTED_LIST_ITEM_CLASS}" style="text-align: center;${NESTED_LIST_ITEM_MARKER_STYLE}"><ul></ul></li></ul>`
-    );
-  });
-
-  test("handles single-quoted attributes", () => {
-    const html = `<ul><li class='${NESTED_LIST_ITEM_CLASS}'><ul></ul></li></ul>`;
-
-    expect(suppressNestedListMarkers(html)).toBe(
-      `<ul><li class='${NESTED_LIST_ITEM_CLASS}' style="${NESTED_LIST_ITEM_MARKER_STYLE}"><ul></ul></li></ul>`
-    );
   });
 
   test("is idempotent when applied twice", () => {

--- a/apps/web/modules/email/lib/preview-email-template-styles.test.ts
+++ b/apps/web/modules/email/lib/preview-email-template-styles.test.ts
@@ -1,70 +1,70 @@
 import { describe, expect, test } from "vitest";
+import {
+  NESTED_LIST_ITEM_CLASS,
+  NESTED_LIST_ITEM_MARKER_STYLE,
+} from "@/modules/ui/components/editor/lib/example-theme";
 import { suppressNestedListMarkers } from "./preview-email-template-styles";
 
 describe("suppressNestedListMarkers", () => {
   test("adds an inline marker suppression to a nested-list wrapper li", () => {
-    const html = '<ul><li class="fb-editor-nested-listitem"><ul><li>child</li></ul></li></ul>';
+    const html = `<ul><li class="${NESTED_LIST_ITEM_CLASS}"><ul><li>child</li></ul></li></ul>`;
 
     expect(suppressNestedListMarkers(html)).toBe(
-      '<ul><li class="fb-editor-nested-listitem" style="list-style-type:none"><ul><li>child</li></ul></li></ul>'
+      `<ul><li class="${NESTED_LIST_ITEM_CLASS}" style="${NESTED_LIST_ITEM_MARKER_STYLE}"><ul><li>child</li></ul></li></ul>`
     );
   });
 
-  test("leaves list items without the nested class untouched", () => {
-    const html = '<ul><li class="fb-editor-listitem" value="1">one</li><li>two</li></ul>';
-
-    expect(suppressNestedListMarkers(html)).toBe(html);
-  });
-
-  test("does not match class names that merely contain the nested class as a substring", () => {
-    const html = '<ul><li class="fb-editor-nested-listitem-custom">item</li></ul>';
-
+  test.each([
+    [
+      "list items without the nested class",
+      '<ul><li class="fb-editor-listitem" value="1">one</li><li>two</li></ul>',
+    ],
+    [
+      "class names that merely contain the nested class as a substring",
+      `<ul><li class="${NESTED_LIST_ITEM_CLASS}-custom">item</li></ul>`,
+    ],
+    ["html without list items", "<p>hello <strong>world</strong></p>"],
+  ])("leaves %s untouched", (_case, html) => {
     expect(suppressNestedListMarkers(html)).toBe(html);
   });
 
   test("matches the nested class among multiple classes regardless of attribute order", () => {
-    const html = '<ol><li value="2" class="fb-editor-listitem fb-editor-nested-listitem"><ol></ol></li></ol>';
+    const html = `<ol><li value="2" class="fb-editor-listitem ${NESTED_LIST_ITEM_CLASS}"><ol></ol></li></ol>`;
 
     expect(suppressNestedListMarkers(html)).toBe(
-      '<ol><li value="2" class="fb-editor-listitem fb-editor-nested-listitem" style="list-style-type:none"><ol></ol></li></ol>'
+      `<ol><li value="2" class="fb-editor-listitem ${NESTED_LIST_ITEM_CLASS}" style="${NESTED_LIST_ITEM_MARKER_STYLE}"><ol></ol></li></ol>`
     );
   });
 
   test("preserves the value attribute on ordered-list items", () => {
-    const html = '<ol><li class="fb-editor-nested-listitem" value="3"><ol></ol></li></ol>';
+    const html = `<ol><li class="${NESTED_LIST_ITEM_CLASS}" value="3"><ol></ol></li></ol>`;
 
     expect(suppressNestedListMarkers(html)).toContain('value="3"');
   });
 
   test("appends to an existing style attribute instead of replacing it", () => {
-    const html = '<ul><li class="fb-editor-nested-listitem" style="text-align: center"><ul></ul></li></ul>';
+    const html = `<ul><li class="${NESTED_LIST_ITEM_CLASS}" style="text-align: center"><ul></ul></li></ul>`;
 
     expect(suppressNestedListMarkers(html)).toBe(
-      '<ul><li class="fb-editor-nested-listitem" style="text-align: center;list-style-type:none"><ul></ul></li></ul>'
+      `<ul><li class="${NESTED_LIST_ITEM_CLASS}" style="text-align: center;${NESTED_LIST_ITEM_MARKER_STYLE}"><ul></ul></li></ul>`
     );
   });
 
   test("handles single-quoted attributes", () => {
-    const html = "<ul><li class='fb-editor-nested-listitem'><ul></ul></li></ul>";
+    const html = `<ul><li class='${NESTED_LIST_ITEM_CLASS}'><ul></ul></li></ul>`;
 
     expect(suppressNestedListMarkers(html)).toBe(
-      "<ul><li class='fb-editor-nested-listitem' style=\"list-style-type:none\"><ul></ul></li></ul>"
+      `<ul><li class='${NESTED_LIST_ITEM_CLASS}' style="${NESTED_LIST_ITEM_MARKER_STYLE}"><ul></ul></li></ul>`
     );
   });
 
   test("is idempotent when applied twice", () => {
     const html =
-      '<ul><li class="fb-editor-nested-listitem"><ul></ul></li>' +
-      '<li class="fb-editor-nested-listitem" style="text-align: right"><ol></ol></li></ul>';
+      `<ul><li class="${NESTED_LIST_ITEM_CLASS}"><ul></ul></li>` +
+      `<li class="${NESTED_LIST_ITEM_CLASS}" style="text-align: right"><ol></ol></li></ul>`;
 
     const once = suppressNestedListMarkers(html);
 
     expect(suppressNestedListMarkers(once)).toBe(once);
-  });
-
-  test("leaves html without list items unchanged", () => {
-    const html = "<p>hello <strong>world</strong></p>";
-
-    expect(suppressNestedListMarkers(html)).toBe(html);
   });
 });

--- a/apps/web/modules/email/lib/preview-email-template-styles.ts
+++ b/apps/web/modules/email/lib/preview-email-template-styles.ts
@@ -73,8 +73,12 @@ const EMAIL_PREVIEW_ACCENT_COLORS = {
 } as const;
 
 const RICH_TEXT_PARAGRAPH_TAG_REGEX = /<p\b([^>]*)>/gi;
+const RICH_TEXT_LIST_ITEM_TAG_REGEX = /<li\b([^>]*)>/gi;
 const RICH_TEXT_STYLE_ATTRIBUTE_REGEX = /\sstyle=(["'])(.*?)\1/i;
 const RICH_TEXT_STYLE_ATTRIBUTE_REPLACE_REGEX = /\sstyle=(["'])(.*?)\1/gi;
+const RICH_TEXT_CLASS_ATTRIBUTE_REGEX = /\sclass=(["'])(.*?)\1/i;
+const NESTED_LIST_ITEM_CLASS = "fb-editor-nested-listitem";
+const NESTED_LIST_ITEM_MARKER_STYLE = "list-style-type:none";
 
 export const importantStyle = (value: string): string => `${value} !important`;
 
@@ -93,6 +97,39 @@ export const normalizeRichTextSpacing = (html: string): string =>
     }
 
     return `<p${attributes} style="margin:0">`;
+  });
+
+/**
+ * Lexical wraps a nested list in a structural <li class="fb-editor-nested-listitem"> that must not
+ * show its own bullet/number. Email clients ignore the app stylesheets, so the suppression is
+ * inlined per list item (best effort: legacy Outlook's Word engine ignores list-style-type).
+ */
+export const suppressNestedListMarkers = (html: string): string =>
+  html.replaceAll(RICH_TEXT_LIST_ITEM_TAG_REGEX, (tag: string, attributes: string = "") => {
+    const classMatch = RICH_TEXT_CLASS_ATTRIBUTE_REGEX.exec(attributes);
+    const classNames = classMatch ? classMatch[2].split(/\s+/) : [];
+    if (!classNames.includes(NESTED_LIST_ITEM_CLASS)) {
+      return tag;
+    }
+
+    if (RICH_TEXT_STYLE_ATTRIBUTE_REGEX.test(attributes)) {
+      return `<li${attributes.replaceAll(
+        RICH_TEXT_STYLE_ATTRIBUTE_REPLACE_REGEX,
+        (_styleAttribute, quote: string, styleValue: string) => {
+          const trimmedStyle = styleValue.trim();
+          if (trimmedStyle.includes(NESTED_LIST_ITEM_MARKER_STYLE)) {
+            return ` style=${quote}${styleValue}${quote}`;
+          }
+          const styleWithMarker = trimmedStyle
+            ? `${trimmedStyle};${NESTED_LIST_ITEM_MARKER_STYLE}`
+            : NESTED_LIST_ITEM_MARKER_STYLE;
+
+          return ` style=${quote}${styleWithMarker}${quote}`;
+        }
+      )}>`;
+    }
+
+    return `<li${attributes} style="${NESTED_LIST_ITEM_MARKER_STYLE}">`;
   });
 
 const getPreviewDimension = (value: PreviewStyleValue, fallback: PreviewStyleValue): string => {

--- a/apps/web/modules/email/lib/preview-email-template-styles.ts
+++ b/apps/web/modules/email/lib/preview-email-template-styles.ts
@@ -2,6 +2,10 @@ import type { CSSProperties } from "react";
 import type { TSurveyStyling } from "@formbricks/types/surveys/types";
 import { COLOR_DEFAULTS, STYLE_DEFAULTS } from "@/lib/styling/constants";
 import { isLight, mixColor } from "@/lib/utils/colors";
+import {
+  NESTED_LIST_ITEM_CLASS,
+  NESTED_LIST_ITEM_MARKER_STYLE,
+} from "@/modules/ui/components/editor/lib/example-theme";
 
 export interface PreviewEmailStyleTokens {
   accentBackgroundColor: string;
@@ -77,8 +81,6 @@ const RICH_TEXT_LIST_ITEM_TAG_REGEX = /<li\b([^>]*)>/gi;
 const RICH_TEXT_STYLE_ATTRIBUTE_REGEX = /\sstyle=(["'])(.*?)\1/i;
 const RICH_TEXT_STYLE_ATTRIBUTE_REPLACE_REGEX = /\sstyle=(["'])(.*?)\1/gi;
 const RICH_TEXT_CLASS_ATTRIBUTE_REGEX = /\sclass=(["'])(.*?)\1/i;
-const NESTED_LIST_ITEM_CLASS = "fb-editor-nested-listitem";
-const NESTED_LIST_ITEM_MARKER_STYLE = "list-style-type:none";
 
 export const importantStyle = (value: string): string => `${value} !important`;
 
@@ -100,9 +102,9 @@ export const normalizeRichTextSpacing = (html: string): string =>
   });
 
 /**
- * Lexical wraps a nested list in a structural <li class="fb-editor-nested-listitem"> that must not
- * show its own bullet/number. Email clients ignore the app stylesheets, so the suppression is
- * inlined per list item (best effort: legacy Outlook's Word engine ignores list-style-type).
+ * Lexical wraps a nested list in a structural <li> (NESTED_LIST_ITEM_CLASS) that must not show its
+ * own bullet/number. Email clients ignore the app stylesheets, so the suppression is inlined per
+ * list item (best effort: legacy Outlook's Word engine ignores list-style-type).
  */
 export const suppressNestedListMarkers = (html: string): string =>
   html.replaceAll(RICH_TEXT_LIST_ITEM_TAG_REGEX, (tag: string, attributes: string = "") => {

--- a/apps/web/modules/ui/components/editor/components/editor.tsx
+++ b/apps/web/modules/ui/components/editor/components/editor.tsx
@@ -24,6 +24,7 @@ import "../styles-editor.css";
 import { PlaygroundAutoLinkPlugin as AutoLinkPlugin } from "./auto-link-plugin";
 import { EditorContentChecker } from "./editor-content-checker";
 import { LinkEditor } from "./link-editor";
+import { ListTabIndentationPlugin } from "./list-tab-indentation-plugin";
 import { RecallNode } from "./recall-node";
 import { RecallPlugin } from "./recall-plugin";
 import { ToolbarPlugin } from "./toolbar-plugin";
@@ -138,6 +139,7 @@ export const Editor = (props: TextEditorProps) => {
                 ErrorBoundary={LexicalErrorBoundary}
               />
               <ListPlugin />
+              <ListTabIndentationPlugin />
               {props.isExternalUrlsAllowed && <LinkPlugin />}
               {props.isExternalUrlsAllowed && <AutoLinkPlugin />}
               {props.autoFocus && <AutoFocusPlugin />}

--- a/apps/web/modules/ui/components/editor/components/list-tab-indentation-plugin.tsx
+++ b/apps/web/modules/ui/components/editor/components/list-tab-indentation-plugin.tsx
@@ -1,0 +1,69 @@
+import { $isListItemNode } from "@lexical/list";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { $findMatchingParent, $handleIndentAndOutdent, mergeRegister } from "@lexical/utils";
+import {
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_CRITICAL,
+  COMMAND_PRIORITY_EDITOR,
+  INDENT_CONTENT_COMMAND,
+  KEY_TAB_COMMAND,
+  OUTDENT_CONTENT_COMMAND,
+} from "lexical";
+import { useEffect } from "react";
+
+// Same cap as Lexical's playground (maxIndent 7): items can nest up to indent level 6.
+const MAX_INDENT = 7;
+
+/**
+ * Scoped alternative to Lexical's TabIndentationPlugin: Tab indents and Shift+Tab outdents only
+ * while the selection is inside list items, so Tab keeps moving focus everywhere else and the
+ * editor does not trap keyboard users.
+ */
+export const ListTabIndentationPlugin = () => {
+  const [editor] = useLexicalComposerContext();
+
+  useEffect(() => {
+    return mergeRegister(
+      editor.registerCommand(
+        KEY_TAB_COMMAND,
+        (event) => {
+          const selection = $getSelection();
+          if (!$isRangeSelection(selection)) {
+            return false;
+          }
+          const anchorListItem = $findMatchingParent(selection.anchor.getNode(), $isListItemNode);
+          const focusListItem = $findMatchingParent(selection.focus.getNode(), $isListItemNode);
+          if (!anchorListItem || !focusListItem) {
+            return false;
+          }
+          event.preventDefault();
+          return editor.dispatchCommand(
+            event.shiftKey ? OUTDENT_CONTENT_COMMAND : INDENT_CONTENT_COMMAND,
+            undefined
+          );
+        },
+        COMMAND_PRIORITY_EDITOR
+      ),
+      // Caps indentation before @lexical/rich-text's uncapped INDENT_CONTENT_COMMAND handler runs.
+      editor.registerCommand(
+        INDENT_CONTENT_COMMAND,
+        () => {
+          const selection = $getSelection();
+          if (!$isRangeSelection(selection)) {
+            return false;
+          }
+          return $handleIndentAndOutdent((block) => {
+            const newIndent = block.getIndent() + 1;
+            if (newIndent < MAX_INDENT) {
+              block.setIndent(newIndent);
+            }
+          });
+        },
+        COMMAND_PRIORITY_CRITICAL
+      )
+    );
+  }, [editor]);
+
+  return null;
+};

--- a/apps/web/modules/ui/components/editor/components/toolbar-plugin.tsx
+++ b/apps/web/modules/ui/components/editor/components/toolbar-plugin.tsx
@@ -99,6 +99,7 @@ const ToolbarButton = ({ icon: Icon, active, onClick, tooltipText, disabled }: T
           variant="ghost"
           size="icon"
           type="button"
+          aria-label={tooltipText}
           tabIndex={-1}
           onClick={onClick}
           disabled={disabled}

--- a/apps/web/modules/ui/components/editor/lib/example-theme.test.ts
+++ b/apps/web/modules/ui/components/editor/lib/example-theme.test.ts
@@ -1,5 +1,7 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
-import { exampleTheme } from "./example-theme";
+import { NESTED_LIST_ITEM_CLASS, NESTED_LIST_ITEM_MARKER_STYLE, exampleTheme } from "./example-theme";
 
 describe("exampleTheme", () => {
   test("contains all required theme properties", () => {
@@ -23,7 +25,19 @@ describe("exampleTheme", () => {
     expect(exampleTheme.list).toHaveProperty("ol");
     expect(exampleTheme.list).toHaveProperty("ul");
     expect(exampleTheme.list).toHaveProperty("listitem");
-    expect(exampleTheme.list.nested).toHaveProperty("listitem");
+    expect(exampleTheme.list.nested.listitem).toBe(NESTED_LIST_ITEM_CLASS);
+  });
+
+  // The stylesheet cannot import the constants, and it is what hides the marker on the structural
+  // <li> in the editor, the survey runtime and the studio preview alike. Renaming the theme class
+  // without renaming the selector would silently bring the stray bullet back on every surface.
+  test("the shared stylesheet suppresses the marker for the theme's nested list class", () => {
+    const stylesheet = readFileSync(
+      fileURLToPath(new URL("../styles-editor-frontend.css", import.meta.url)),
+      "utf8"
+    ).replaceAll(/\s+/g, "");
+
+    expect(stylesheet).toContain(`.${NESTED_LIST_ITEM_CLASS}{${NESTED_LIST_ITEM_MARKER_STYLE}`);
   });
 
   test("contains text formatting styles", () => {

--- a/apps/web/modules/ui/components/editor/lib/example-theme.ts
+++ b/apps/web/modules/ui/components/editor/lib/example-theme.ts
@@ -1,3 +1,13 @@
+/**
+ * Lexical wraps a nested list in a structural <li> that carries no text of its own. Its class and
+ * the declaration that hides its marker are declared here once and consumed by
+ * `suppressNestedListMarkers` (email preview) and, by reference, by the two stylesheets that style
+ * the same markup: `styles-editor-frontend.css` and `packages/surveys/src/styles/global.css`.
+ * `example-theme.test.ts` fails if a rename leaves one of those stylesheets behind.
+ */
+export const NESTED_LIST_ITEM_CLASS = "fb-editor-nested-listitem";
+export const NESTED_LIST_ITEM_MARKER_STYLE = "list-style-type:none";
+
 export const exampleTheme = {
   rtl: "fb-editor-rtl",
   ltr: "fb-editor-ltr",
@@ -9,7 +19,7 @@ export const exampleTheme = {
   },
   list: {
     nested: {
-      listitem: "fb-editor-nested-listitem",
+      listitem: NESTED_LIST_ITEM_CLASS,
     },
     ol: "fb-editor-list-ol",
     ul: "fb-editor-list-ul",

--- a/apps/web/modules/ui/components/editor/styles-editor-frontend.css
+++ b/apps/web/modules/ui/components/editor/styles-editor-frontend.css
@@ -55,6 +55,24 @@
   list-style-type: none !important;
 }
 
+/*
+ * Nesting advances by exactly one moderate step per level: the structural wrapper <li> that
+ * Lexical puts around a nested list must not add its own horizontal offset (it also carries
+ * .fb-editor-listitem and its 32px margin), and the nested list itself indents 1.5em.
+ */
+.fb-editor-listitem.fb-editor-nested-listitem {
+  margin-inline: 0 !important;
+  padding-inline-start: 0 !important;
+}
+
+.fb-editor-list-ul .fb-editor-list-ul,
+.fb-editor-list-ul .fb-editor-list-ol,
+.fb-editor-list-ol .fb-editor-list-ul,
+.fb-editor-list-ol .fb-editor-list-ol {
+  margin-block: 0 !important;
+  padding-inline-start: 1.5em !important;
+}
+
 .fb-editor-rtl {
   text-align: right !important;
 }

--- a/apps/web/modules/ui/components/editor/styles-editor-frontend.css
+++ b/apps/web/modules/ui/components/editor/styles-editor-frontend.css
@@ -39,38 +39,45 @@
   margin-bottom: 20px !important;
 }
 
+/*
+ * One list model for every surface: the survey runtime injects this stylesheet as well
+ * (packages/surveys/src/lib/styles.ts), so a list looks the same in the editor, in the preview and
+ * for the respondent. Every level — the first one included — advances by exactly the list's own
+ * 1.5em padding; the items themselves add no horizontal offset.
+ */
+.fb-editor-list-ul,
+.fb-editor-list-ol {
+  list-style-position: outside !important;
+  margin-block: 0 12px !important;
+  padding-inline-start: 1.5em !important;
+}
+
 .fb-editor-list-ul {
-  margin-bottom: 12px !important;
+  list-style-type: disc !important;
 }
 
 .fb-editor-list-ol {
-  margin-bottom: 12px !important;
+  list-style-type: decimal !important;
 }
 
 .fb-editor-listitem {
-  margin: 0px 32px !important;
+  margin: 0 !important;
 }
 
+/*
+ * Lexical wraps a nested list in a structural <li> that carries no text of its own, so it must not
+ * show a marker. Source of truth for the class: lib/example-theme.ts -> list.nested.listitem.
+ */
 .fb-editor-nested-listitem {
   list-style-type: none !important;
 }
 
-/*
- * Nesting advances by exactly one moderate step per level: the structural wrapper <li> that
- * Lexical puts around a nested list must not add its own horizontal offset (it also carries
- * .fb-editor-listitem and its 32px margin), and the nested list itself indents 1.5em.
- */
-.fb-editor-listitem.fb-editor-nested-listitem {
-  margin-inline: 0 !important;
-  padding-inline-start: 0 !important;
-}
-
+/* Only the outermost list keeps the trailing gap; nesting adds no vertical space. */
 .fb-editor-list-ul .fb-editor-list-ul,
 .fb-editor-list-ul .fb-editor-list-ol,
 .fb-editor-list-ol .fb-editor-list-ul,
 .fb-editor-list-ol .fb-editor-list-ol {
   margin-block: 0 !important;
-  padding-inline-start: 1.5em !important;
 }
 
 .fb-editor-rtl {

--- a/apps/web/modules/ui/components/editor/styles-editor.css
+++ b/apps/web/modules/ui/components/editor/styles-editor.css
@@ -3,18 +3,10 @@
   font-size: 14px;
 }
 
-.editor li {
-  padding-left: 1.28571429em;
-  text-indent: -1.28571429em;
-}
-
-.editor ul {
-  list-style: disc inside;
-}
-
-.editor ol {
-  list-style: decimal inside;
-}
+/*
+ * List rendering lives in styles-editor-frontend.css, which the survey runtime injects too, so the
+ * editor and the respondent view stay in sync. Editor-only list rules would re-introduce the drift.
+ */
 
 .editor-container {
   border-radius: 6px;

--- a/apps/web/playwright/survey-editor-rich-text-tabs.spec.ts
+++ b/apps/web/playwright/survey-editor-rich-text-tabs.spec.ts
@@ -1,0 +1,111 @@
+import { type Page, expect } from "@playwright/test";
+import { type Fixtures, test } from "./lib/fixtures";
+import { createSurveyFromScratch } from "./utils/helper";
+
+/**
+ * Tab behavior of the survey editor's rich text editor (ENG-1747).
+ *
+ * Regression: Tab always moved focus out of the Lexical editor, so nested lists
+ * could not be created. The fix (ListTabIndentationPlugin) makes Tab indent and
+ * Shift+Tab outdent only while the caret is inside a list item. Outside list
+ * items Tab must keep its default behavior and move focus out of the editor —
+ * a deliberate a11y requirement (no keyboard trap).
+ *
+ * Both scenarios use the welcome card panel, which renders two rich text
+ * editors: "Note*" (headline) and "Welcome message" (description).
+ */
+
+const openWelcomeCardPanel = async (page: Page): Promise<void> => {
+  await expect(page.locator("#welcome-toggle")).toBeVisible();
+  await page.getByText("Welcome Card").click();
+  await page.locator("#welcome-toggle").check();
+  await expect(page.locator('label:has-text("Welcome message")')).toBeVisible();
+
+  // Enabling the card remounts the live preview's card, which focuses its first
+  // control (the welcome card's "Next" button) once it re-renders. Wait for that
+  // one-time focus steal to complete, otherwise it lands mid-typing and both
+  // drops characters and breaks focus assertions. Stacked off-screen preview
+  // cards render dummy buttons with tabindex="-1"; the real one is tabbable.
+  const previewNext = page
+    .locator("#formbricks-survey-container")
+    .getByRole("button", { name: "Next", exact: true })
+    .and(page.locator('[tabindex="0"]'));
+  await expect(previewNext).toBeFocused({ timeout: 15000 });
+};
+
+/**
+ * Same label -> container walk as fillRichTextEditor (utils/helper.ts); the
+ * container also holds the editor's toolbar, whose icon buttons expose their
+ * translated tooltip text as the accessible name ("Bulleted list" is
+ * workspace.surveys.edit.bulleted_list in en-US.json).
+ */
+const editorField = (page: Page, labelText: string) => {
+  const container = page.locator(`label:has-text("${labelText}")`).locator("..").locator("..");
+  return {
+    input: container.locator(".editor-input").first(),
+    bulletListButton: container.getByRole("button", { name: "Bulleted list", exact: true }),
+  };
+};
+
+const gotoFreshSurveyEditorWelcomeCard = async (page: Page, users: Fixtures["users"]): Promise<void> => {
+  const user = await users.create();
+  await user.login();
+  await page.waitForURL(/\/workspaces\/[^/]+\/surveys/);
+  await createSurveyFromScratch(page);
+  await openWelcomeCardPanel(page);
+};
+
+const clearEditor = async (input: ReturnType<typeof editorField>["input"]): Promise<void> => {
+  await input.click();
+  await input.press("ControlOrMeta+a");
+  await input.press("Backspace");
+};
+
+test.describe("Survey editor rich text editor Tab behavior", () => {
+  test("Tab nests a bullet list item and Shift+Tab flattens it back", async ({ page, users }) => {
+    await gotoFreshSurveyEditorWelcomeCard(page, users);
+    const { input, bulletListButton } = editorField(page, "Welcome message");
+
+    // Turn the cleared editor's block into a bullet list via the toolbar
+    // (the markdown "- " shortcut is not registered in this editor).
+    await clearEditor(input);
+    await bulletListButton.click();
+    await expect(input.locator("ul > li")).toHaveCount(1);
+
+    // Two sibling items; the caret ends up at the end of the second item.
+    await input.pressSequentially("First item", { delay: 50 });
+    await input.press("Enter");
+    await input.pressSequentially("Second item", { delay: 50 });
+    await expect(input.locator("ul > li")).toHaveCount(2);
+    await expect(input.locator("li ul li")).toHaveCount(0);
+
+    // Tab keeps focus in the editor and nests the second item (li > ul > li).
+    await input.press("Tab");
+    await expect(input).toBeFocused();
+    await expect(input.locator("li ul li")).toHaveText("Second item");
+    await expect(input.locator("li.fb-editor-nested-listitem")).toBeVisible();
+
+    // Shift+Tab returns it to a single-level list.
+    await input.press("Shift+Tab");
+    await expect(input).toBeFocused();
+    await expect(input.locator("li ul li")).toHaveCount(0);
+    await expect(input.locator("ul > li")).toHaveText(["First item", "Second item"]);
+  });
+
+  test("Tab in plain text moves focus out of the editor (no keyboard trap)", async ({ page, users }) => {
+    await gotoFreshSurveyEditorWelcomeCard(page, users);
+    const { input } = editorField(page, "Note*");
+
+    // Caret sits in a plain paragraph, not a list item.
+    await clearEditor(input);
+    await input.pressSequentially("Plain text", { delay: 50 });
+    await expect(input.locator("li")).toHaveCount(0);
+    await expect(input).toBeFocused();
+
+    // Tab must not be swallowed by the editor: focus leaves this contenteditable.
+    // (It may legitimately land on the page's next tab stop, e.g. another field.)
+    await input.press("Tab");
+    await expect(input).not.toBeFocused();
+    await expect.poll(() => input.evaluate((el) => el.contains(document.activeElement))).toBe(false);
+  });
+});

--- a/apps/web/playwright/survey-editor-rich-text-tabs.spec.ts
+++ b/apps/web/playwright/survey-editor-rich-text-tabs.spec.ts
@@ -61,6 +61,20 @@ const clearEditor = async (input: ReturnType<typeof editorField>["input"]): Prom
   await input.press("Backspace");
 };
 
+/** Deepest chain of nested lists in the editor: 1 for a flat list, 2 after one Tab, and so on. */
+const listNestingDepth = async (input: ReturnType<typeof editorField>["input"]): Promise<number> =>
+  input.evaluate((editor) => {
+    const depthOf = (item: Element): number => {
+      let depth = 0;
+      for (let node = item.parentElement; node && node !== editor; node = node.parentElement) {
+        if (node.tagName === "UL" || node.tagName === "OL") depth++;
+      }
+      return depth;
+    };
+
+    return Math.max(0, ...Array.from(editor.querySelectorAll("li"), depthOf));
+  });
+
 test.describe("Survey editor rich text editor Tab behavior", () => {
   test("Tab nests a bullet list item and Shift+Tab flattens it back", async ({ page, users }) => {
     await gotoFreshSurveyEditorWelcomeCard(page, users);
@@ -90,6 +104,14 @@ test.describe("Survey editor rich text editor Tab behavior", () => {
     await expect(input).toBeFocused();
     await expect(input.locator("li ul li")).toHaveCount(0);
     await expect(input.locator("ul > li")).toHaveText(["First item", "Second item"]);
+
+    // Each further Tab nests one more level until MAX_INDENT (7 levels). Past the ceiling the
+    // plugin still swallows the key, so focus stays in the editor instead of escaping mid-list.
+    for (let press = 0; press < 10; press++) {
+      await input.press("Tab");
+    }
+    await expect(input).toBeFocused();
+    await expect.poll(() => listNestingDepth(input)).toBe(7);
   });
 
   test("Tab in plain text moves focus out of the editor (no keyboard trap)", async ({ page, users }) => {

--- a/packages/surveys/src/styles/global.css
+++ b/packages/surveys/src/styles/global.css
@@ -102,6 +102,15 @@
 #fbjs [data-variant="description"] li {
   margin: 0.25em 0;
 }
+/*
+ * Lexical wraps a nested list in an extra <li class="fb-editor-nested-listitem"> (theme class kept
+ * in the stored HTML); hide that structural item's marker so nesting shows no stray bullet/number.
+ */
+#fbjs .htmlbody li.fb-editor-nested-listitem,
+#fbjs [data-variant="headline"] li.fb-editor-nested-listitem,
+#fbjs [data-variant="description"] li.fb-editor-nested-listitem {
+  list-style-type: none;
+}
 
 /* without this, it wont override the color */
 #fbjs p.editor-paragraph {

--- a/packages/surveys/src/styles/global.css
+++ b/packages/surveys/src/styles/global.css
@@ -105,11 +105,31 @@
 /*
  * Lexical wraps a nested list in an extra <li class="fb-editor-nested-listitem"> (theme class kept
  * in the stored HTML); hide that structural item's marker so nesting shows no stray bullet/number.
+ * The wrapper must not add horizontal offset either (the editor stylesheet bundled into the runtime
+ * gives every .fb-editor-listitem a 32px !important margin), so each nesting level advances by
+ * exactly the one 1.5em list padding step above.
  */
 #fbjs .htmlbody li.fb-editor-nested-listitem,
 #fbjs [data-variant="headline"] li.fb-editor-nested-listitem,
 #fbjs [data-variant="description"] li.fb-editor-nested-listitem {
   list-style-type: none;
+  margin-inline: 0 !important;
+  padding-inline-start: 0;
+}
+/* Nested lists add no extra vertical gap; the 0.5em block margin stays on top-level lists only. */
+#fbjs .htmlbody ul ul,
+#fbjs .htmlbody ul ol,
+#fbjs .htmlbody ol ul,
+#fbjs .htmlbody ol ol,
+#fbjs [data-variant="headline"] ul ul,
+#fbjs [data-variant="headline"] ul ol,
+#fbjs [data-variant="headline"] ol ul,
+#fbjs [data-variant="headline"] ol ol,
+#fbjs [data-variant="description"] ul ul,
+#fbjs [data-variant="description"] ul ol,
+#fbjs [data-variant="description"] ol ul,
+#fbjs [data-variant="description"] ol ol {
+  margin-block: 0;
 }
 
 /* without this, it wont override the color */

--- a/packages/surveys/src/styles/global.css
+++ b/packages/surveys/src/styles/global.css
@@ -85,7 +85,7 @@
 #fbjs [data-variant="description"] ol {
   list-style-position: outside;
   margin: 0.5em 0;
-  padding-left: 1.5em;
+  padding-inline-start: 1.5em;
 }
 #fbjs .htmlbody ul,
 #fbjs [data-variant="headline"] ul,
@@ -103,34 +103,13 @@
   margin: 0.25em 0;
 }
 /*
- * Lexical wraps a nested list in an extra <li class="fb-editor-nested-listitem"> (theme class kept
- * in the stored HTML); hide that structural item's marker so nesting shows no stray bullet/number.
- * The wrapper must not add horizontal offset either (the editor stylesheet bundled into the runtime
- * gives every .fb-editor-listitem a 32px !important margin), so each nesting level advances by
- * exactly the one 1.5em list padding step above.
+ * The rules above are the fallback for list markup without the editor's theme classes. Rich text
+ * authored in the app carries them, and its geometry (1.5em per level, no item margins, no marker
+ * on the .fb-editor-nested-listitem wrapper Lexical puts around a nested list) comes from the
+ * editor stylesheet that lib/styles.ts injects right after this file — one definition shared with
+ * the editor itself. Source of truth for those class names:
+ * apps/web/modules/ui/components/editor/lib/example-theme.ts
  */
-#fbjs .htmlbody li.fb-editor-nested-listitem,
-#fbjs [data-variant="headline"] li.fb-editor-nested-listitem,
-#fbjs [data-variant="description"] li.fb-editor-nested-listitem {
-  list-style-type: none;
-  margin-inline: 0 !important;
-  padding-inline-start: 0;
-}
-/* Nested lists add no extra vertical gap; the 0.5em block margin stays on top-level lists only. */
-#fbjs .htmlbody ul ul,
-#fbjs .htmlbody ul ol,
-#fbjs .htmlbody ol ul,
-#fbjs .htmlbody ol ol,
-#fbjs [data-variant="headline"] ul ul,
-#fbjs [data-variant="headline"] ul ol,
-#fbjs [data-variant="headline"] ol ul,
-#fbjs [data-variant="headline"] ol ol,
-#fbjs [data-variant="description"] ul ul,
-#fbjs [data-variant="description"] ul ol,
-#fbjs [data-variant="description"] ol ul,
-#fbjs [data-variant="description"] ol ol {
-  margin-block: 0;
-}
 
 /* without this, it wont override the color */
 #fbjs p.editor-paragraph {


### PR DESCRIPTION
<!-- We require pull request titles to follow the Conventional Commits specification ( https://www.conventionalcommits.org/en/v1.0.0/#summary ). Please make sure your title follow these conventions -->

## What does this PR do?

Fixes [ENG-1747](https://linear.app/formbricks/issue/ENG-1747/fix-tabs-in-rich-text-editor)

In the rich text editor (Lexical), pressing Tab moved browser focus to the next form field, so nested lists could not be created. The editor registered `ListPlugin` and the theme/CSS for nested lists already existed, but nothing handled `KEY_TAB_COMMAND`.

**What changes:**

- **New `ListTabIndentationPlugin`** (`apps/web/modules/ui/components/editor/components/list-tab-indentation-plugin.tsx`): Tab indents and Shift+Tab outdents **only while the selection is inside list items** (both endpoints). Everywhere else Tab keeps its default focus-move behavior, so the editor never traps keyboard users (dashboard a11y guideline §7). Indentation is capped at depth 7, mirroring Lexical's stock `TabIndentationPlugin` mechanics. The plugin mounts unconditionally: `disableLists` only strips the markdown `- ` shortcuts, while all product editors still offer the toolbar list buttons.
- **One list model for every surface** (`styles-editor-frontend.css`, which `packages/surveys/src/lib/styles.ts` injects into the runtime, so it already reaches the editor, the studio preview and respondents): the editor and the runtime had drifted apart, each carrying its own list rules on top of a shared `.fb-editor-listitem { margin: 0 32px }`. Measured on the real stylesheets, a level-1 item sat **48px** from the text in the editor and **56px** in the preview, while each nesting level advanced only 1.5em — and the preview added a 0.5em gap above every list that the editor did not have. List geometry now lives in one place: the container owns the indent (`padding-inline-start: 1.5em`), items add no offset, and the structural wrapper `<li>` Lexical puts around a nested list shows no marker. Result: **1.5em per level on both surfaces, first level included** (21px in the editor at 14px, 24px in the runtime at 16px), and no extra line before a list. The editor-only `.editor li/ul/ol` rules that caused the drift were removed, as were the runtime overrides that were compensating for it.
- **RTL**: the runtime's list fallback used a physical `padding-left`, which left a stray 24px on the wrong side for RTL content; it is now `padding-inline-start` (verified: `padding-left: 0px / padding-right: 24px` in RTL, unchanged in LTR).
- **Email preview** (`apps/web/modules/email/lib/preview-email-template-styles.ts` + `preview-email-template.tsx`): email clients don't load the runtime stylesheet, so a unit-tested `suppressNestedListMarkers()` transform inlines `list-style-type:none` on the wrapper `<li>` for the embed-survey email preview and the sent preview email (best-effort on legacy Outlook).
- **Single source for the nested-list contract**: `NESTED_LIST_ITEM_CLASS` and `NESTED_LIST_ITEM_MARKER_STYLE` are exported from `lib/example-theme.ts` (the Lexical theme that emits the class) and imported by the email transform and its tests. The stylesheets can't import TS, so each carries a reference comment **and** `example-theme.test.ts` reads `styles-editor-frontend.css` and fails if a rename leaves the marker-suppression selector behind.
- **Toolbar accessibility** (`toolbar-plugin.tsx`): the icon-only toolbar buttons had no accessible name; they now expose their translated tooltip text as `aria-label` (no new strings).
- **Playwright coverage** (`apps/web/playwright/survey-editor-rich-text-tabs.spec.ts`): asserts Tab nests / Shift+Tab flattens, that further Tabs stop at the `MAX_INDENT` ceiling (7 levels) without escaping the editor, and that Tab in plain text still moves focus out (keyboard-trap guard). This spec caught a real bug during development (an over-eager render gate that disabled the feature in all product editors), so it guards both halves of the behavior.

**Known, deliberately out of scope** (pre-existing, discovered while testing):

- Sent follow-up emails strip `ul`/`ol`/`li` entirely via their `sanitize-html` allowlist, so lists authored in the follow-up editor silently flatten to text — needs a product decision (the marker bug cannot occur there).
- The live survey preview steals focus from the editor pane when a card mounts (separate fix in progress).
- Toolbar buttons remain `tabIndex={-1}` (not keyboard-tabbable), as before.

## QA / Test Plan

**How to test**

- [ ] Open a survey in the editor → Welcome card → "Welcome message" field (or any question description) → click the "Bulleted list" toolbar button → type `First`, press Enter, type `Second`.
- [ ] With the caret on `Second`, press Tab → the item indents under `First` as a nested list, focus stays in the editor, exactly one bullet per item.
- [ ] Press Shift+Tab → the list flattens back to two top-level items.
- [ ] Repeat with "Numbered list": after nesting, visible numbering stays continuous (1, 2 — the structural wrapper shows no ordinal).
- [ ] Place the caret in plain (non-list) text in the same editor and press Tab → focus moves to the next form field (no keyboard trap).
- [ ] Edge: press Tab repeatedly on a nested item → indentation stops at 7 levels; further Tabs are swallowed (focus stays in the editor).
- [ ] Edge: Shift+Tab on a top-level list item → no-op; focus stays in the editor.
- [ ] Indentation: a flat list sits one small step (1.5em) from the surrounding text — noticeably tighter than before — and every nesting level adds exactly one more step of the same size, in the editor and in the preview. Note: nested ordered lists restart numbering at "1." per level (standard Lexical behavior, not a bug).
- [ ] Editor vs preview: put a paragraph directly above a list. The vertical gap and the left indent match between the editor pane and the live preview — no extra blank line in the preview.
- [ ] Runtime: preview the survey (or answer it as a respondent) → the nested list renders with exactly one marker per item — no stray bullet/ordinal at the nesting point — for both bullet and numbered lists.
- [ ] Email: survey summary → share/embed → Email tab → the preview (and "send preview email") shows the nested list without a stray marker. Legacy Outlook (Word engine) is best-effort.
- [ ] Screen reader / a11y spot check: editor toolbar buttons now announce names ("Bold", "Italic", "Bulleted list", …) matching their tooltips.
- [ ] RTL spot check: in RTL content, lists indent from the right at every level, with no leftover padding on the left.

**Preconditions / test data**

- Any survey with a rich text field (welcome card or question description); no flags or plan requirements.
- Local runtime check only: rebuild the surveys bundle first (`pnpm build --filter=@formbricks/surveys... --force`) and hard-refresh — the package is pre-compiled into `apps/web/public/js/`. CI/production build it fresh.

**Risks & regressions**

- Tab handling in the editor is new: re-check that Tab still leaves the editor from plain paragraphs/headings (covered by the new e2e a11y-guard test) and that `disableLists` editors (follow-up modal, translation inputs) behave unchanged when no list is present.
- List indentation changes everywhere rich text is rendered, flat lists included — that is the intent (they were over-indented), but it is a visible change on existing surveys, not only on nested lists.
- Removing the `.editor li/ul/ol` rules means bullets/numbers in the editor now come from `.fb-editor-list-ul/-ol`. Only Lexical-authored lists live inside `.editor` (the toolbar renders no lists), so nothing else depended on them.
- The runtime's generic `#fbjs … ul/ol/li` rules are untouched apart from the RTL padding fix; they remain the fallback for markup without the editor's theme classes.
- Email preview transform is regex-based; it is idempotent, preserves `class`/`value`/existing `style` attributes, and is covered by unit tests.
- All editor toolbar buttons now have `aria-label`s (translated tooltip text) — no visual change expected.

**Migrations / env / cutover**

- none

## Checklist

<!-- We're starting to get more and more contributions. Please help us making this efficient for all of us and go through this checklist. Please tick off what you did  -->

### Required

- [x] Filled out the "QA / Test Plan" section in this PR (behavior, edge cases, preconditions, risks, migrations/env)
- [ ] Read [How we Code at Formbricks](<[https://github.com/formbricks/formbricks/blob/main/CONTRIBUTING.md](https://formbricks.com/docs/contributing/how-we-code)>)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main`
- [ ] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR
- [ ] Updated the Formbricks Docs if changes were necessary

---

### Verification evidence

Latest run (review follow-up commit):

| Command | Scope | Result |
| --- | --- | --- |
| `pnpm exec prettier --check <8 touched files>` | formatting | PASS |
| `pnpm exec eslint <5 touched TS files>` (no `--fix`) | lint | PASS |
| `pnpm exec vitest run modules/email modules/ui/components/editor modules/survey` (in `apps/web`) | unit tests | PASS — 63 files / 839 tests |
| `pnpm exec vitest run` (in `packages/surveys`) | unit tests | PASS — 26 files / 659 tests |
| `pnpm typecheck` (in `apps/web`: `next typegen` + `tsc --noEmit`) | types | PASS |
| `tsc --noEmit` over `playwright/**` + the two touched test files (the repo config excludes both) | types | PASS — 0 errors in touched files (11 pre-existing errors in `survey-accessibility.spec.ts`, untouched here) |
| `pnpm build --filter="./packages/*"` | packages incl. runtime bundle | PASS — built `surveys.umd.cjs` contains `.fb-editor-list-ul,.fb-editor-list-ol{list-style-position:outside!important;margin-block:0 12px!important;padding-inline-start:1.5em!important}` and no longer `margin:0px 32px` |
| Indentation measurement (headless Chromium over the real `preflight.css` + `global.css` + `styles-editor.css` + `styles-editor-frontend.css`, `getBoundingClientRect` per level) | editor + runtime, ol + ul + RTL | see table below |

Measured indent per nesting level (px from the surrounding paragraph):

| Surface | level 1 | level 2 | level 3 | gap above list |
| --- | --- | --- | --- | --- |
| editor — before | 48.5 | +21 | +21 | 0 |
| editor — after | 21 | +21 | +21 | 0 |
| runtime — before | 56 | +24 | +24 | 8px |
| runtime — after | 24 | +24 | +24 | 0 |

`pnpm test:e2e` was not re-runnable in this checkout (no app build), so the updated spec — including the new depth-7 ceiling assertion — was first exercised by CI: **Run E2E Tests passed in 19m09s**, alongside Build, Linters, Unit Tests and SonarQube (0 open issues).
