### PR TITLE
fix(auth): resolve login-path deadlock and stop over-capturing auth failures

### DIFF
--- a/apps/web/modules/auth/lib/better-auth-observability.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.test.ts
@@ -1,11 +1,14 @@
+import * as Sentry from "@sentry/nextjs";
 import { APIError } from "better-auth/api";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
+import { logger } from "@formbricks/logger";
 import { queueAuditEventBackground } from "@/modules/ee/audit-logs/lib/handler";
 import { UNKNOWN_DATA } from "@/modules/ee/audit-logs/types/audit-log";
 import {
   auditFailedAuthAfter,
   auditPasswordReset,
+  betterAuthLogger,
   getSignInAuthMethod,
   signInAuditDatabaseHook,
 } from "./better-auth-observability";
@@ -18,6 +21,23 @@ vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
 
 vi.mock("@formbricks/database", () => ({
   prisma: { user: { findUnique: vi.fn() } },
+}));
+
+vi.mock("@sentry/nextjs", () => ({
+  captureException: vi.fn(),
+}));
+
+// Stable context-logger so the betterAuthLogger tests can assert the local log level.
+const contextLoggerMock = { error: vi.fn(), warn: vi.fn(), info: vi.fn() };
+vi.mock("@formbricks/logger", () => ({
+  logger: { withContext: vi.fn(() => contextLoggerMock) },
+}));
+
+// betterAuthLogger only captures to Sentry when SENTRY_DSN && IS_PRODUCTION; force both on for the file.
+vi.mock("@/lib/constants", async (importActual) => ({
+  ...(await importActual<typeof import("@/lib/constants")>()),
+  IS_PRODUCTION: true,
+  SENTRY_DSN: "https://examplePublicKey@o0.ingest.sentry.io/0",
 }));
 
 vi.mock("./sign-in-tracking", () => ({
@@ -250,5 +270,71 @@ describe("auditPasswordReset (onPasswordReset audit)", () => {
     vi.mocked(queueAuditEventBackground).mockRejectedValueOnce(new Error("redis down"));
 
     await expect(auditPasswordReset("user-1")).resolves.toBeUndefined();
+  });
+});
+
+describe("betterAuthLogger (Sentry capture gating, ENG-2037)", () => {
+  // Optional on the BetterAuthOptions["logger"] type, but always defined here.
+  const log = betterAuthLogger.log!;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Better Auth logs handled OAuth rejections as a bare string code (redirectOnError) — the top Sentry
+  // noise source (FORMBRICKS-16Q). These must NOT be captured, only logged locally.
+  test.each(["account_not_linked", "unable_to_create_user", "unable_to_get_user_info", "email_not_found"])(
+    "does not capture the handled OAuth rejection code %s",
+    (code) => {
+      log("error", code);
+
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      // The rejection is still visible in the application log.
+      expect(contextLoggerMock.error).toHaveBeenCalledWith(code);
+    }
+  );
+
+  test("does not capture a client-facing APIError (handled 4xx, e.g. FAILED_TO_CREATE_USER)", () => {
+    const apiError = new APIError("UNPROCESSABLE_ENTITY", {
+      message: "Failed to create user",
+      code: "FAILED_TO_CREATE_USER",
+    });
+
+    // BA logs this as ("Failed to create user", apiError) on the credential path.
+    log("error", "Failed to create user", apiError);
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(contextLoggerMock.error).toHaveBeenCalledWith("Failed to create user");
+  });
+
+  test("captures a genuine internal fault passed as a trailing arg (DB/adapter error)", () => {
+    const dbError = new Error("Better auth was unable to query your database");
+
+    log("error", "Better auth was unable to query your database.\nError: ", dbError);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(dbError);
+  });
+
+  test("captures the deadlock DriverAdapterError so the ENG-2038 signal stays visible", () => {
+    // A non-APIError Error must still reach Sentry — this is the signal we watch post-deploy.
+    const deadlock = new Error("deadlock detected");
+
+    log("error", deadlock);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(deadlock);
+  });
+
+  test("warn-level logs are never captured", () => {
+    log("warn", "account isn't linked");
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(contextLoggerMock.warn).toHaveBeenCalledWith("account isn't linked");
+  });
+
+  test("info/debug-level logs go to info and are never captured", () => {
+    log("info", "some info");
+
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(contextLoggerMock.info).toHaveBeenCalledWith("some info");
   });
 });

--- a/apps/web/modules/auth/lib/better-auth-observability.ts
+++ b/apps/web/modules/auth/lib/better-auth-observability.ts
@@ -102,9 +102,23 @@ export const signInAuditDatabaseHook: NonNullable<
 };
 
 /**
- * Route Better Auth's logger to @formbricks/logger and capture errors to Sentry in production —
- * replaces auth.ts's placeholder logger (and the route's Sentry.captureException on auth failures).
- * Normal auth failures (wrong password) log at `warn`, so only genuine internal errors reach Sentry.
+ * Route Better Auth's logger to @formbricks/logger and capture GENUINE internal faults to Sentry in
+ * production — replaces auth.ts's placeholder logger (and the route's Sentry.captureException on auth
+ * failures).
+ *
+ * Sentry gating (ENG-2037): Better Auth logs many EXPECTED, handled rejections at `error` level, so
+ * "capture everything at error" floods Sentry with non-actionable noise. Two shapes dominate:
+ *   1. OAuth callback rejections logged as a bare string code (`logger.error("account_not_linked")`,
+ *      `"unable_to_create_user"`, `"unable_to_get_user_info"`, … via `redirectOnError`) — no Error
+ *      object; these are client-facing redirects, e.g. our blocked-domain / SSO provisioning gate
+ *      returning `false`. These were the top volume in Sentry (FORMBRICKS-16Q).
+ *   2. Credential-path rejections thrown as a Better Auth `APIError` (`FAILED_TO_CREATE_USER`,
+ *      `USER_ALREADY_EXISTS_USE_ANOTHER_EMAIL`, invalid-input codes) — a 4xx-equivalent response, not a
+ *      server fault.
+ * Neither is an actionable error, so we capture ONLY a real `Error` that is NOT an `APIError` (the
+ * genuinely-exceptional class: DB/adapter faults, misconfig, unexpected throws — including the
+ * `deadlock detected` DriverAdapterError we watch for ENG-2038). Everything still reaches the local
+ * logger, so handled rejections remain visible in logs — they just don't page via Sentry.
  */
 export const betterAuthLogger: NonNullable<BetterAuthOptions["logger"]> = {
   level: "warn",
@@ -116,7 +130,11 @@ export const betterAuthLogger: NonNullable<BetterAuthOptions["logger"]> = {
       if (SENTRY_DSN && IS_PRODUCTION) {
         // BA usually passes the Error as a trailing arg, but a couple of sites pass it as `message`.
         const cause = [...args, message].find((arg): arg is Error => arg instanceof Error);
-        Sentry.captureException(cause ?? new Error(`[better-auth] ${String(message)}`));
+        // Skip handled rejections: a bare string code (no Error) or a client-facing APIError. Capture
+        // only genuine internal faults so Sentry stays actionable (see the reason-split above).
+        if (cause && !isAPIError(cause)) {
+          Sentry.captureException(cause);
+        }
       }
     } else if (level === "warn") {
       contextLogger.warn(message);

--- a/apps/web/modules/auth/lib/user.test.ts
+++ b/apps/web/modules/auth/lib/user.test.ts
@@ -226,6 +226,43 @@ describe("User Management", () => {
 
       await expect(updateUserLastLoginAt(mockUser.email)).rejects.toThrow("boom");
     });
+
+    test("retries on a deadlock (P2034) and succeeds on the next attempt (ENG-2038)", async () => {
+      const previousLastLoginAt = new Date("2025-04-16T10:00:00.000Z");
+      const deadlock = new Prisma.PrismaClientKnownRequestError("deadlock", {
+        code: "P2034",
+        clientVersion: "0.0.1",
+      });
+      vi.mocked(prisma.$transaction)
+        .mockRejectedValueOnce(deadlock)
+        .mockImplementationOnce(async (callback) =>
+          callback({
+            $queryRaw: vi.fn().mockResolvedValue([{ id: mockUser.id, lastLoginAt: previousLastLoginAt }]),
+            user: { update: vi.fn().mockResolvedValue({ ...mockPrismaUser, lastLoginAt: new Date() }) },
+          } as any)
+        );
+
+      const result = await updateUserLastLoginAt(mockUser.email);
+
+      expect(result).toEqual(previousLastLoginAt);
+      expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+    });
+
+    test("gives up after the max attempts when a deadlock persists", async () => {
+      // A driver-adapter deadlock surfaces as a plain Error with this message (the ENG-2038 shape).
+      vi.mocked(prisma.$transaction).mockRejectedValue(new Error("deadlock detected"));
+
+      await expect(updateUserLastLoginAt(mockUser.email)).rejects.toThrow("deadlock detected");
+      expect(prisma.$transaction).toHaveBeenCalledTimes(3);
+    });
+
+    test("does not retry a non-deadlock error", async () => {
+      vi.mocked(prisma.$transaction).mockRejectedValue(new Error("boom"));
+
+      await expect(updateUserLastLoginAt(mockUser.email)).rejects.toThrow("boom");
+      // Non-deadlock errors propagate on the first attempt — no retry.
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("getUserByEmail", () => {

--- a/apps/web/modules/auth/lib/user.test.ts
+++ b/apps/web/modules/auth/lib/user.test.ts
@@ -178,6 +178,26 @@ describe("User Management", () => {
       expect(result).toEqual(previousLastLoginAt);
     });
 
+    test("locks the row with FOR NO KEY UPDATE (not FOR UPDATE) to avoid the sign-in FK deadlock (ENG-2038)", async () => {
+      const queryRaw = vi.fn().mockResolvedValue([{ id: mockUser.id, lastLoginAt: null }]);
+      vi.mocked(prisma.$transaction).mockImplementationOnce(async (callback) =>
+        callback({
+          $queryRaw: queryRaw,
+          user: {
+            update: vi.fn().mockResolvedValue({ ...mockPrismaUser, lastLoginAt: new Date() }),
+          },
+        } as any)
+      );
+
+      await updateUserLastLoginAt(mockUser.email);
+
+      // $queryRaw is a tagged template: the first call arg is the array of string literals.
+      const sql = (queryRaw.mock.calls[0][0] as string[]).join(" ").replace(/\s+/g, " ");
+      expect(sql).toContain("FOR NO KEY UPDATE");
+      // FOR UPDATE conflicts with the FK FOR KEY SHARE lock — a revert must fail this test.
+      expect(sql).not.toContain("FOR UPDATE");
+    });
+
     test("throws ResourceNotFoundError when user doesn't exist", async () => {
       vi.mocked(prisma.$transaction).mockImplementationOnce(async (callback) =>
         callback({

--- a/apps/web/modules/auth/lib/user.test.ts
+++ b/apps/web/modules/auth/lib/user.test.ts
@@ -178,7 +178,7 @@ describe("User Management", () => {
       expect(result).toEqual(previousLastLoginAt);
     });
 
-    test("locks the row with FOR NO KEY UPDATE (not FOR UPDATE) to avoid the sign-in FK deadlock (ENG-2038)", async () => {
+    test("locks with FOR NO KEY UPDATE, not FOR UPDATE (sign-in FK deadlock, ENG-2038)", async () => {
       const queryRaw = vi.fn().mockResolvedValue([{ id: mockUser.id, lastLoginAt: null }]);
       vi.mocked(prisma.$transaction).mockImplementationOnce(async (callback) =>
         callback({

--- a/apps/web/modules/auth/lib/user.ts
+++ b/apps/web/modules/auth/lib/user.ts
@@ -12,6 +12,37 @@ type TUserDbClient = PrismaClient | Prisma.TransactionClient;
 
 const getDbClient = (tx?: Prisma.TransactionClient): TUserDbClient => tx ?? prisma;
 
+// A Postgres deadlock aborts ONE transaction in the cycle (SQLSTATE 40P01) and is safe to retry.
+// Prisma reports it as P2034 on interactive transactions; the pg driver adapter can also surface it as
+// a DriverAdapterError whose message carries "deadlock detected" (the shape seen in Sentry for ENG-2038).
+const isDeadlockError = (error: unknown): boolean => {
+  if (isPrismaKnownRequestError(error) && error.code === "P2034") {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : "";
+  return /deadlock detected/i.test(message) || message.includes("40P01");
+};
+
+const DEADLOCK_MAX_ATTEMPTS = 3;
+
+/**
+ * Retry a DB operation a bounded number of times when it fails with a deadlock, with a short linear
+ * backoff so retried transactions don't re-collide in lockstep. Non-deadlock errors propagate on the
+ * first attempt. Defense-in-depth for the login write path (ENG-2038); the caller must be idempotent.
+ */
+const retryOnDeadlock = async <T>(operation: () => Promise<T>): Promise<T> => {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (attempt >= DEADLOCK_MAX_ATTEMPTS || !isDeadlockError(error)) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, attempt * 25));
+    }
+  }
+};
+
 export const updateUser = async (id: string, data: TUserUpdateInput, tx?: Prisma.TransactionClient) => {
   validateInputs([id, ZId], [data, ZUserUpdateInput.partial()]);
 
@@ -42,35 +73,39 @@ export const updateUserLastLoginAt = async (email: string) => {
   validateInputs([email, ZUserEmail]);
 
   try {
-    return await prisma.$transaction(async (tx) => {
-      // FOR NO KEY UPDATE (not FOR UPDATE): this serializes concurrent same-user updates of
-      // lastLoginAt, but — unlike FOR UPDATE — does NOT conflict with the FOR KEY SHARE lock that a
-      // concurrent Session→User FK insert takes on this row during sign-in. FOR UPDATE here was
-      // stronger than the subsequent UPDATE needs and created a deadlock cycle on the login path
-      // (ENG-2038). The row is only read to return the previous lastLoginAt for a login analytics flag.
-      const lockedUsers = await tx.$queryRaw<Array<{ id: string; lastLoginAt: Date | null }>>`
+    // Retry on a transient deadlock (40P01): the last-login bump is idempotent, so a bounded retry
+    // clears rare cross-transaction contention on the hot login path instead of surfacing a 500.
+    return await retryOnDeadlock(() =>
+      prisma.$transaction(async (tx) => {
+        // FOR NO KEY UPDATE (not FOR UPDATE): this serializes concurrent same-user updates of
+        // lastLoginAt, but — unlike FOR UPDATE — does NOT conflict with the FOR KEY SHARE lock that a
+        // concurrent Session→User FK insert takes on this row during sign-in. FOR UPDATE here was
+        // stronger than the subsequent UPDATE needs and created a deadlock cycle on the login path
+        // (ENG-2038). The row is only read to return the previous lastLoginAt for a login analytics flag.
+        const lockedUsers = await tx.$queryRaw<Array<{ id: string; lastLoginAt: Date | null }>>`
         SELECT "id", "lastLoginAt"
         FROM "User"
         WHERE "email" = ${email}
         FOR NO KEY UPDATE
       `;
-      const lockedUser = lockedUsers[0];
+        const lockedUser = lockedUsers[0];
 
-      if (!lockedUser) {
-        throw new ResourceNotFoundError("email", email);
-      }
+        if (!lockedUser) {
+          throw new ResourceNotFoundError("email", email);
+        }
 
-      await tx.user.update({
-        where: {
-          id: lockedUser.id,
-        },
-        data: {
-          lastLoginAt: new Date(),
-        },
-      });
+        await tx.user.update({
+          where: {
+            id: lockedUser.id,
+          },
+          data: {
+            lastLoginAt: new Date(),
+          },
+        });
 
-      return lockedUser.lastLoginAt;
-    });
+        return lockedUser.lastLoginAt;
+      })
+    );
   } catch (error) {
     if (error instanceof ResourceNotFoundError) {
       throw error;

--- a/apps/web/modules/auth/lib/user.ts
+++ b/apps/web/modules/auth/lib/user.ts
@@ -43,11 +43,16 @@ export const updateUserLastLoginAt = async (email: string) => {
 
   try {
     return await prisma.$transaction(async (tx) => {
+      // FOR NO KEY UPDATE (not FOR UPDATE): this serializes concurrent same-user updates of
+      // lastLoginAt, but — unlike FOR UPDATE — does NOT conflict with the FOR KEY SHARE lock that a
+      // concurrent Session→User FK insert takes on this row during sign-in. FOR UPDATE here was
+      // stronger than the subsequent UPDATE needs and created a deadlock cycle on the login path
+      // (ENG-2038). The row is only read to return the previous lastLoginAt for a login analytics flag.
       const lockedUsers = await tx.$queryRaw<Array<{ id: string; lastLoginAt: Date | null }>>`
         SELECT "id", "lastLoginAt"
         FROM "User"
         WHERE "email" = ${email}
-        FOR UPDATE
+        FOR NO KEY UPDATE
       `;
       const lockedUser = lockedUsers[0];
 

--- a/apps/web/modules/auth/lib/utils.test.ts
+++ b/apps/web/modules/auth/lib/utils.test.ts
@@ -827,35 +827,22 @@ describe("Auth Utils", () => {
     });
   });
 
-  describe("Sentry Integration", () => {
-    test("should capture authentication failures to Sentry", () => {
+  describe("Sentry Integration (ENG-2037)", () => {
+    test("does NOT capture expected auth failures to Sentry, but still audits them", () => {
       logAuthEvent("authenticationAttempted", "failure", "user_123", "user@example.com", {
         failureReason: "invalid_password",
         provider: "credentials",
         authMethod: "password_validation",
-        tags: { security_event: "password_failure" },
       });
 
-      expect(Sentry.captureException).toHaveBeenCalledWith(
-        expect.any(Error),
-        expect.objectContaining({
-          tags: expect.objectContaining({
-            component: "authentication",
-            action: "authenticationAttempted",
-            status: "failure",
-            security_event: "password_failure",
-          }),
-          extra: expect.objectContaining({
-            userId: "user_123",
-            provider: "credentials",
-            authMethod: "password_validation",
-            failureReason: "invalid_password",
-          }),
-        })
+      // Expected auth failures are noise in Sentry — the audit log is the security record.
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+      expect(queueAuditEventBackground).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "authenticationAttempted", status: "failure" })
       );
     });
 
-    test("should not capture successful authentication to Sentry", () => {
+    test("does not capture successful authentication to Sentry", () => {
       vi.clearAllMocks();
 
       logAuthEvent("passwordVerified", "success", "user_123", "user@example.com", {

--- a/apps/web/modules/auth/lib/utils.ts
+++ b/apps/web/modules/auth/lib/utils.ts
@@ -1,9 +1,7 @@
-import * as Sentry from "@sentry/nextjs";
 import { createHash, randomUUID } from "crypto";
 import { createCacheKey } from "@formbricks/cache";
 import { logger } from "@formbricks/logger";
 import { cache } from "@/lib/cache";
-import { IS_PRODUCTION, SENTRY_DSN } from "@/lib/constants";
 import { hashSecret, verifySecret } from "@/lib/crypto";
 import { queueAuditEventBackground } from "@/modules/ee/audit-logs/lib/handler";
 import { TAuditAction, TAuditStatus, UNKNOWN_DATA } from "@/modules/ee/audit-logs/types/audit-log";
@@ -44,26 +42,10 @@ export const logAuthEvent = (
 ) => {
   const auditActorId = userId === UNKNOWN_DATA && email ? createAuditIdentifier(email, "email") : userId;
 
-  // Log failures to Sentry for monitoring and alerting
-  if (status === "failure" && SENTRY_DSN && IS_PRODUCTION) {
-    const error = new Error(`Authentication ${action} failed`);
-    Sentry.captureException(error, {
-      tags: {
-        component: "authentication",
-        action,
-        status,
-        ...(additionalData.tags ?? {}),
-      },
-      extra: {
-        userId: auditActorId,
-        provider: additionalData.provider,
-        authMethod: additionalData.authMethod,
-        failureReason: additionalData.failureReason,
-        ...additionalData,
-      },
-    });
-  }
-
+  // Auth failures are NOT sent to Sentry: they're expected (wrong password / unknown user), so
+  // capturing every attempt was noise, not signal. The security trail is the audit log below
+  // (throttled by shouldLogAuthFailure + rate-limiting); genuine *internal* auth errors are still
+  // captured via the Better Auth logger's error level (ENG-2037).
   queueAuditEventBackground({
     action,
     targetType: "user",

--- a/apps/web/modules/ee/billing/lib/organization-billing.test.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.test.ts
@@ -19,6 +19,7 @@ vi.mock("server-only", () => ({}));
 const mocks = vi.hoisted(() => ({
   isCloud: true,
   getBillingCacheKey: vi.fn(),
+  getBillingSyncLockKey: vi.fn(),
   getCustomCacheKey: vi.fn(),
   prismaOrganizationFindUnique: vi.fn(),
   prismaOrganizationBillingFindUnique: vi.fn(),
@@ -28,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   cacheWithCache: vi.fn(),
   cacheWithCacheNullable: vi.fn(),
   cacheDel: vi.fn(),
+  cacheTryLock: vi.fn(),
   loggerWarn: vi.fn(),
   getCloudPlanFromProduct: vi.fn(),
   customersCreate: vi.fn(),
@@ -70,6 +72,7 @@ vi.mock("@formbricks/cache", () => ({
   createCacheKey: {
     organization: {
       billing: mocks.getBillingCacheKey,
+      billingSyncLock: mocks.getBillingSyncLockKey,
     },
     custom: mocks.getCustomCacheKey,
   },
@@ -97,6 +100,7 @@ vi.mock("@/lib/cache", () => ({
     withCache: mocks.cacheWithCache,
     withCacheNullable: mocks.cacheWithCacheNullable,
     del: mocks.cacheDel,
+    tryLock: mocks.cacheTryLock,
   },
 }));
 
@@ -167,12 +171,17 @@ describe("organization-billing", () => {
     vi.clearAllMocks();
     mocks.isCloud = true;
     mocks.getBillingCacheKey.mockReturnValue("billing-cache-key");
+    mocks.getBillingSyncLockKey.mockImplementation(
+      (organizationId: string) => `org:${organizationId}:billing-sync-lock`
+    );
     mocks.getCustomCacheKey.mockImplementation(
       (namespace: string, identifier: string, subresource?: string) =>
         [namespace, identifier, subresource].filter(Boolean).join(":")
     );
     mocks.cacheWithCache.mockImplementation(async (fn: () => Promise<unknown>) => await fn());
     mocks.cacheWithCacheNullable.mockImplementation(async (fn: () => Promise<unknown>) => await fn());
+    // Default: the read-through single-flight lock is acquired, so stale-sync tests exercise the sync.
+    mocks.cacheTryLock.mockResolvedValue({ ok: true, data: true });
     mocks.getCloudPlanFromProduct.mockReturnValue("pro");
     mocks.subscriptionsList.mockResolvedValue({ data: [] });
     mocks.customersList.mockResolvedValue({ data: [] });
@@ -2407,6 +2416,41 @@ describe("organization-billing", () => {
       { error: expect.any(Error), organizationId: "org_1" },
       "Failed to refresh billing snapshot from Stripe"
     );
+  });
+
+  test("getOrganizationBillingWithReadThroughSync serves cached and skips sync when another process holds the lock", async () => {
+    const cachedBilling = {
+      stripeCustomerId: "cus_1",
+      stripe: { lastSyncedAt: new Date(Date.now() - 6 * 60 * 1000).toISOString() },
+    };
+    mocks.cacheWithCacheNullable.mockResolvedValue(cachedBilling);
+    // Lock NOT acquired (another request/process is already syncing this org).
+    mocks.cacheTryLock.mockResolvedValue({ ok: true, data: false });
+
+    const result = await getOrganizationBillingWithReadThroughSync("org_1");
+
+    expect(result).toEqual(cachedBilling);
+    // Single-flight: no Stripe sync + no OrganizationBilling write happen in the loser.
+    expect(mocks.subscriptionsList).not.toHaveBeenCalled();
+    expect(mocks.prismaOrganizationBillingUpdate).not.toHaveBeenCalled();
+    // Lock is scoped to this org so it can't gate a different tenant's sync.
+    expect(mocks.cacheTryLock).toHaveBeenCalledWith("org:org_1:billing-sync-lock", "1", expect.any(Number));
+  });
+
+  test("getOrganizationBillingWithReadThroughSync serves cached and skips sync when the lock backend is unavailable", async () => {
+    const cachedBilling = {
+      stripeCustomerId: "cus_1",
+      stripe: { lastSyncedAt: new Date(Date.now() - 6 * 60 * 1000).toISOString() },
+    };
+    mocks.cacheWithCacheNullable.mockResolvedValue(cachedBilling);
+    // Redis unavailable → tryLock returns an error Result; treat as "not acquired", serve cached.
+    mocks.cacheTryLock.mockResolvedValue({ ok: false, error: { code: "RedisConnectionError" } });
+
+    const result = await getOrganizationBillingWithReadThroughSync("org_1");
+
+    expect(result).toEqual(cachedBilling);
+    expect(mocks.subscriptionsList).not.toHaveBeenCalled();
+    expect(mocks.prismaOrganizationBillingUpdate).not.toHaveBeenCalled();
   });
 
   test("getOrganizationBillingWithReadThroughSync bypasses Redis cache in self-hosted mode", async () => {

--- a/apps/web/modules/ee/billing/lib/organization-billing.test.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.test.ts
@@ -2434,7 +2434,7 @@ describe("organization-billing", () => {
     expect(mocks.subscriptionsList).not.toHaveBeenCalled();
     expect(mocks.prismaOrganizationBillingUpdate).not.toHaveBeenCalled();
     // Lock is scoped to this org so it can't gate a different tenant's sync.
-    expect(mocks.cacheTryLock).toHaveBeenCalledWith("org:org_1:billing-sync-lock", "1", expect.any(Number));
+    expect(mocks.cacheTryLock).toHaveBeenCalledWith("org:org_1:billing-sync-lock", "1", 30_000);
   });
 
   test("getOrganizationBillingWithReadThroughSync serves cached and skips sync when the lock backend is unavailable", async () => {
@@ -2451,6 +2451,34 @@ describe("organization-billing", () => {
     expect(result).toEqual(cachedBilling);
     expect(mocks.subscriptionsList).not.toHaveBeenCalled();
     expect(mocks.prismaOrganizationBillingUpdate).not.toHaveBeenCalled();
+  });
+
+  test("getOrganizationBillingWithReadThroughSync stops waiting at the deadline and serves cached (never overruns the lease)", async () => {
+    vi.useFakeTimers();
+    try {
+      const cachedBilling = {
+        stripeCustomerId: "cus_1",
+        // Fixed old timestamp so staleness doesn't depend on the fake clock.
+        stripe: { lastSyncedAt: new Date("2020-01-01T00:00:00.000Z").toISOString() },
+      };
+      mocks.cacheWithCacheNullable.mockResolvedValue(cachedBilling);
+      // Sync hangs on its first DB read → it would run past the 20s deadline (which is < the 30s lease).
+      mocks.prismaOrganizationBillingFindUnique.mockReturnValue(new Promise(() => {}));
+
+      const resultPromise = getOrganizationBillingWithReadThroughSync("org_1");
+      await vi.advanceTimersByTimeAsync(20_000 + 1);
+      const result = await resultPromise;
+
+      expect(result).toEqual(cachedBilling);
+      // Deadline fired before any write, so the request returns without blocking or writing.
+      expect(mocks.prismaOrganizationBillingUpdate).not.toHaveBeenCalled();
+      expect(mocks.loggerWarn).toHaveBeenCalledWith(
+        { error: expect.any(Error), organizationId: "org_1" },
+        "Failed to refresh billing snapshot from Stripe"
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   test("getOrganizationBillingWithReadThroughSync bypasses Redis cache in self-hosted mode", async () => {

--- a/apps/web/modules/ee/billing/lib/organization-billing.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.ts
@@ -32,6 +32,21 @@ const BILLING_SYNC_STALE_MS = 5 * 60 * 1000;
 // round-trips + the write, short enough that a crashed holder can't block refreshes for long. The
 // lock is released by expiry (no explicit unlock), matching the license-fetch pattern.
 const BILLING_SYNC_LOCK_TTL_MS = 30 * 1000;
+// Hard deadline for the read-through sync, strictly below the lock TTL. This runs on a hot render
+// path, so if Stripe is slow we stop waiting and serve the cached snapshot instead of blocking the
+// request. Because the OrganizationBilling write is idempotent (Stripe is the source of truth;
+// last-write-wins on a single row), a sync that finishes after the deadline — or after the lease
+// expires — can't corrupt data or deadlock, so a lease heartbeat isn't needed.
+const BILLING_SYNC_DEADLINE_MS = 20 * 1000;
+
+/** A promise that rejects after `ms`, with a canceller so the timer never outlives the race. */
+const rejectAfter = (ms: number, message: string): { promise: Promise<never>; cancel: () => void } => {
+  let timer: ReturnType<typeof setTimeout>;
+  const promise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return { promise, cancel: () => clearTimeout(timer) };
+};
 const ACTIVE_SUBSCRIPTION_STATUSES = new Set<string>(["trialing", "active", "past_due", "unpaid", "paused"]);
 
 const ORGANIZATION_BILLING_SELECT = {
@@ -1678,8 +1693,16 @@ export const getOrganizationBillingWithReadThroughSync = async (
   }
 
   try {
-    const syncedBilling = await syncOrganizationBillingFromStripe(organizationId);
-    return syncedBilling ?? cachedBilling;
+    const syncPromise = syncOrganizationBillingFromStripe(organizationId);
+    // Guard against an unhandled rejection if the sync settles after the deadline already won the race.
+    syncPromise.catch(() => undefined);
+    const deadline = rejectAfter(BILLING_SYNC_DEADLINE_MS, "billing sync exceeded deadline");
+    try {
+      const syncedBilling = await Promise.race([syncPromise, deadline.promise]);
+      return syncedBilling ?? cachedBilling;
+    } finally {
+      deadline.cancel();
+    }
   } catch (error) {
     logger.warn({ error, organizationId }, "Failed to refresh billing snapshot from Stripe");
     return cachedBilling;

--- a/apps/web/modules/ee/billing/lib/organization-billing.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.ts
@@ -28,6 +28,10 @@ import { stripeClient } from "./stripe-client";
 import { CLOUD_PLAN_LEVEL, type TCloudStripePlan, getCloudPlanFromProduct } from "./stripe-plan";
 
 const BILLING_SYNC_STALE_MS = 5 * 60 * 1000;
+// Single-flight lock TTL for the stale read-through Stripe sync: long enough to cover a few Stripe
+// round-trips + the write, short enough that a crashed holder can't block refreshes for long. The
+// lock is released by expiry (no explicit unlock), matching the license-fetch pattern.
+const BILLING_SYNC_LOCK_TTL_MS = 30 * 1000;
 const ACTIVE_SUBSCRIPTION_STATUSES = new Set<string>(["trialing", "active", "past_due", "unpaid", "paused"]);
 
 const ORGANIZATION_BILLING_SELECT = {
@@ -1656,6 +1660,20 @@ export const getOrganizationBillingWithReadThroughSync = async (
   }
 
   if (!isSnapshotStale(cachedBilling)) {
+    return cachedBilling;
+  }
+
+  // Single-flight the stale refresh: withCache does NOT dedupe concurrent callers, so without this a
+  // burst of requests for the same org (e.g. the post-login workspace layout render) would each run
+  // the Stripe sync + OrganizationBilling write — a thundering herd and a deadlock surface (ENG-2038).
+  // Only the lock winner refreshes; everyone else (incl. the Redis-unavailable case) serves the
+  // already-cached snapshot, which is at most one stale cycle old — acceptable for billing display.
+  const lockResult = await cache.tryLock(
+    createCacheKey.organization.billingSyncLock(organizationId),
+    "1",
+    BILLING_SYNC_LOCK_TTL_MS
+  );
+  if (!(lockResult.ok && lockResult.data === true)) {
     return cachedBilling;
   }
 

--- a/packages/cache/src/cache-keys.test.ts
+++ b/packages/cache/src/cache-keys.test.ts
@@ -38,6 +38,11 @@ describe("@formbricks/cache cacheKeys", () => {
         expect(key).toBe("fb:org:org-123:billing");
       });
 
+      test("should create organization billing-sync-lock key scoped to the org", () => {
+        const key = createCacheKey.organization.billingSyncLock("org-123");
+        expect(key).toBe("fb:org:org-123:billing-sync-lock");
+      });
+
       test("should handle complex organization IDs", () => {
         const key = createCacheKey.organization.billing("org-enterprise-team_123");
         expect(key).toBe("fb:org:org-enterprise-team_123:billing");

--- a/packages/cache/src/cache-keys.ts
+++ b/packages/cache/src/cache-keys.ts
@@ -26,6 +26,9 @@ export const createCacheKey = {
   // Organization-related keys
   organization: {
     billing: (organizationId: string): CacheKey => makeCacheKey("org", organizationId, "billing"),
+    // Single-flight lock so only one process refreshes an org's stale billing snapshot at a time.
+    billingSyncLock: (organizationId: string): CacheKey =>
+      makeCacheKey("org", organizationId, "billing-sync-lock"),
   },
 
   // License and enterprise features


### PR DESCRIPTION
## What & why

Two related Better Auth login/session-path fixes surfaced from Sentry, combined into one PR (both small, same area).

**ENG-2038 — Postgres deadlock on the login write path.** `updateUserLastLoginAt` (runs on every sign-in via `session.create.after`) took `SELECT … FOR UPDATE` on the `User` row. `FOR UPDATE` conflicts with the `FOR KEY SHARE` lock that a concurrent `Session`→`User` FK insert takes on that same row — and it's stronger than the subsequent `UPDATE` even needs. Under concurrent same-org sign-in + billing activity this produces a deadlock. Two changes shrink the deadlock surface:
- `user.ts` — `FOR UPDATE` → **`FOR NO KEY UPDATE`**: still serializes concurrent `lastLoginAt` writes, but is compatible with the FK share lock, so it can't deadlock against session inserts. (The lock only exists to read the previous `lastLoginAt` for one analytics flag.)
- `organization-billing.ts` — the read-through billing sync (`getOrganizationBillingWithReadThroughSync`, which runs on the post-login workspace layout render) did an inline Stripe sync + `OrganizationBilling` write whenever the 5-min snapshot was stale. `withCache` does **not** dedupe concurrent callers, so a burst of same-org requests each ran the sync — a thundering herd and the main write-contention surface. Now guarded by a per-org **single-flight** (`cache.tryLock`, mirroring the license-fetch pattern): only the lock winner refreshes; everyone else (and the Redis-down case) serves the already-cached snapshot.
- `user.ts` — **deadlock-safe retry** (defense-in-depth, per the ENG-2038 AC): the last-login transaction is wrapped in a bounded retry (3 attempts, short backoff) that fires only on a deadlock (Prisma `P2034` or a driver-adapter `deadlock detected`) and propagates everything else immediately. A deadlock aborts one transaction in the cycle and is safe to retry; the bump is idempotent.

**ENG-2037 — auth logger over-captures expected failures.** Better Auth surfaces *expected, handled* auth rejections at `error` level, and our observability layer sent them all to Sentry. Two capture sites, both fixed:

- `better-auth-observability.ts` — `betterAuthLogger` (the primary root cause, FORMBRICKS-16Q, ~226 events/wk). Better Auth logs handled OAuth-callback rejections as a **bare string code** (`logger.error("account_not_linked")`, `"unable_to_create_user"`, `"unable_to_get_user_info"` via `redirectOnError` — e.g. our blocked-domain / SSO-provisioning gate returning `false`) and credential rejections as a client-facing **`APIError`** (`FAILED_TO_CREATE_USER`, `USER_ALREADY_EXISTS_…`, invalid-input codes). The old logger's `cause ?? new Error(\`[better-auth] ${message}\`)` fallback *manufactured* a Sentry exception from those string codes — the top auth noise source. Now it captures **only a genuine `Error` that is not an `APIError`** (DB/adapter faults, misconfig, unexpected throws — including the `deadlock detected` `DriverAdapterError` we watch for ENG-2038). Handled rejections still reach the local (Pino) logger — they just no longer page via Sentry.
- `utils.ts` — `logAuthEvent` (the related wrong-password theme, FORMBRICKS-16E/DM). It sent every `status:"failure"` to Sentry; its only live feeder is `logAuthAttempt`, which fires on expected credential rejections (`invalid_email_or_password`). Removed the capture: these are recorded in the audit log (throttled by `shouldLogAuthFailure` + rate-limiting) — the real security signal.

Reason-split (code-level; prod Sentry wasn't reachable while preparing this): the error-level `betterAuthLogger` feeders are the handled OAuth string codes + credential `APIError`s (expected) vs the DB/adapter `logger.error(msg, err)` sites (genuine). The discriminator "real `Error` && not `APIError`" is Better Auth's own handled-vs-internal boundary (it branches on `isAPIError` at `callback.mjs:154` and `sign-up.mjs:230`), so new handled rejections are covered structurally without enumerating codes. Residual: a handled rejection that surfaces as a raw non-`APIError` `Error` (e.g. the SSO gate returning `false` triggers a null-deref `TypeError` inside Better Auth's `createOAuthUser`) would still be captured; if Sentry shows those persist post-deploy, the fix is to make that reject path throw a clean `APIError` rather than widen the logger filter (follow-up).

Honest caveat: the Sentry deadlock event drops the Postgres DETAIL line, so the exact contending statements are unrecoverable. These fixes remove two well-understood anti-patterns on the implicated path; confirm resolution by watching the `deadlock detected` signal post-deploy. Login is not broken today — the failing writes are swallowed — so severity is Low.

## Before / after

Backend-only change (no UI), so before/after is behavioral:

| Path | Before | After |
|---|---|---|
| **Sign-in lastLoginAt write** | `SELECT … FROM "User" WHERE email=… FOR UPDATE` — conflicts with the `FOR KEY SHARE` lock a concurrent `Session` FK insert takes → deadlock-prone | `… FOR NO KEY UPDATE` — compatible with the FK share lock; still serializes `lastLoginAt` writes, no deadlock |
| **Post-login billing read-through (Cloud)** | stale snapshot → **every** concurrent same-org request runs the Stripe sync + `OrganizationBilling` write (thundering herd) | per-org `cache.tryLock` single-flight → **one** request refreshes; the rest (and Redis-down) serve the cached snapshot |
| **Handled Better Auth rejection** (blocked-domain / SSO-gate → `account_not_linked` / `unable_to_create_user`; credential `APIError`s) | every error-level BA log → `Sentry.captureException` (string codes synthesized into exceptions — the top auth noise) | not captured; still logged locally. Only a genuine non-`APIError` `Error` (DB/adapter/deadlock) reaches Sentry |
| **Failed login (wrong password / unknown user)** | `Sentry.captureException` on every attempt in prod (noise) | not sent to Sentry; recorded in the audit log (rate-limited) — genuine internal errors still captured |

Empirical confirmation of the lock change — same held `FOR KEY SHARE`, opposite outcomes:

```text
Before:  SELECT … FOR UPDATE          → ERROR: canceling statement due to lock timeout   (conflict → deadlock-prone)
After:   SELECT … FOR NO KEY UPDATE   → clseedmanager0000000000 / COMMIT                 (no conflict)
```

## Linear ticket

- https://linear.app/formbricks/issue/ENG-2038
- https://linear.app/formbricks/issue/ENG-2037

## How this was tested

- `pnpm --filter=@formbricks/web test` on the touched suites — `user.test.ts`, `utils.test.ts`, `organization-billing.test.ts`, `better-auth-observability.test.ts` (35) — ✅; `@formbricks/cache` `cache-keys.test.ts` (30) ✅. Added: a regression test asserting the lock clause is `FOR NO KEY UPDATE`; deadlock-retry tests (retry-then-succeed, exhaustion, non-deadlock not retried); single-flight tests for lock-acquired / not-acquired / Redis-error + a deadline test; the audit-not-Sentry assertion; the per-org lock-key test; and `betterAuthLogger` capture-gating tests (handled OAuth string codes + `APIError` not captured; genuine `Error` incl. the deadlock signal captured; warn/info never captured).
- `pnpm lint` + `tsc` clean on all touched files; gitleaks + Semgrep (110 rules) clean on the diff.
- **Postgres lock proof:** with a `FOR KEY SHARE` held on a `User` row, `SELECT … FOR UPDATE` times out (conflict) while `SELECT … FOR NO KEY UPDATE` succeeds — confirming the fix's mechanism.
- **Real-infra smoke:** the exact `updateUserLastLoginAt` query runs cleanly against the dev DB; the built `@formbricks/cache` returns `fb:org:{id}:billing-sync-lock`.

## Design note — billing single-flight is deliberately not exactly-once

The billing read-through sync is guarded by a per-org `cache.tryLock` (30s lease) plus a **20s hard deadline** (`< lease`) so a slow Stripe call can't block the render. The deadline bounds the *wait*, not the background sync — so in the rare case a sync runs past the lease, its idempotent `OrganizationBilling` write could overlap a replacement lock-holder. That's an accepted tradeoff, not a bug:

- **Purpose is herd reduction, not exactly-once.** Without the gate, a burst of same-org renders each ran the Stripe sync + write (N concurrent). Worst case now degrades to **≤2** (needs Stripe > both 20s and 30s), never the full herd.
- **The overlap is safe.** The write is a single-row `FOR NO KEY UPDATE` upsert of Stripe-sourced data (last-write-wins), and it does **not** reintroduce the ENG-2038 deadlock (that was a `User`↔`Session` FK-lock cycle on a different table/lock-mode; two `OrganizationBilling` writers just serialize).
- **Matches precedent.** Same `tryLock`+TTL shape as `license.ts` (no renewal). A true lease heartbeat (new Redis primitive) or a cancellable sync (`AbortSignal` through the shared sync + Stripe calls) would be disproportionate for a rare, benign, self-limiting case. Revisit if the >30s-Stripe overlap ever shows up in Sentry. (CodeRabbit raised this; discussion in-thread.)

## QA / Test Plan

**How to test**

- [ ] Sign in with valid credentials → you're logged in and land on the workspace; no error. (Exercises the `lastLoginAt` write on the sign-in path.)
- [ ] On Formbricks Cloud, open the workspace after login → the page and billing/usage display render normally (exercises the billing read-through single-flight).
- [ ] Sign in with a wrong password → rejected with the normal "invalid credentials" error (unchanged user-facing behavior; it simply no longer creates a Sentry error).
- [ ] Trigger a handled Better Auth rejection — e.g. an SSO sign-in for a user whose account isn't linked (`account_not_linked`), or a sign-up from a blocked email domain → the user still gets the normal rejection/redirect (unchanged UX), but no Sentry exception is produced. A genuine internal fault (DB down during sign-in) should still surface in Sentry.
- [ ] Reload the workspace repeatedly / open it in several tabs at once for the same org → still renders correctly; billing values are consistent (may be up to ~5 min stale, by design).

**Preconditions / test data**

- A seeded user with a known password. For the billing step: a **Formbricks Cloud** org with a Stripe customer (self-hosted skips the read-through sync entirely). Redis available (single-flight degrades safely to cached if not).

**Risks & regressions**

- Under concurrent same-org load a stale billing snapshot may be served for up to one 5-min cycle longer than before (single-flight losers serve cached) — acceptable for billing display; re-check the billing/usage panel shows correct values after a refresh.
- `lastLoginAt` / `is_first_login_today` analytics is best-effort; verify sign-in still succeeds.
- Post-deploy: confirm the `deadlock detected` and expected-auth-failure signals drop in Sentry.

**Preconditions / feature flags:** Cloud vs self-host as above; no new flags.

**Migrations / env / cutover**

- none
