### PR TITLE
fix: load typegen env from a file instead of inline placeholders

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm run build",
     "start": "next start",
     "typecheck": "pnpm typegen && tsc --noEmit --project tsconfig.typecheck.json",
-    "typegen": "cross-env DATABASE_URL=postgresql://postgres:postgres@localhost:5432/formbricks ENCRYPTION_KEY=example REDIS_URL=redis://localhost:6379 next typegen",
+    "typegen": "dotenv -e ../../.env -- next typegen",
     "lint": "eslint . --fix",
     "test": "dotenv -e ../../.env -- vitest run",
     "test:coverage": "dotenv -e ../../.env -- vitest run --coverage",


### PR DESCRIPTION
## What & why

The web app's `typegen` script embedded literal placeholder secret-shaped values (`DATABASE_URL`, `ENCRYPTION_KEY`, `REDIS_URL`) directly inline via `cross-env`. These are harmless placeholders, but they read like leaked credentials when grepping the repo, and they can silently drift out of sync with `.env.example`.

The `test` script already solves this the right way, by loading env vars from the repo's root `.env` file via `dotenv-cli`. This change makes `typegen` follow the same pattern instead of hardcoding values inline.

`apps/web/package.json`:
```diff
- "typegen": "cross-env DATABASE_URL=postgresql://postgres:postgres@localhost:5432/formbricks ENCRYPTION_KEY=example REDIS_URL=redis://localhost:6379 next typegen",
+ "typegen": "dotenv -e ../../.env -- next typegen",
```

`dotenv-cli` was already a devDependency, so no new dependencies were introduced.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1699/load-typegen-env-from-a-file-instead-of-inline-placeholders

## How this was tested

- `pnpm typegen` (in `apps/web`) ✅ — `✓ Types generated successfully`
- `pnpm i` ✅
- `pnpm test` ✅ — 526 test files / 6522 tests passed
- `pnpm lint` ✅ — 18/18 tasks successful
- `pnpm build` ✅ — 12/12 tasks successful

Note (per @itsjavi's review): none of these are direct evidence for the `typegen` script itself — no CI workflow runs `pnpm typegen`/`pnpm typecheck` directly (the `next typegen` invoked inside `next build` is a separate code path where CI/Docker already supply env vars another way). The `pnpm typegen` run above, executed locally against the repo's `.env`, is the actual verification for this change.

## QA / Test Plan

**How to test**

- [ ] From a clean checkout with a valid root `.env` file, run `pnpm --filter=@formbricks/web typegen` (or `pnpm --filter=@formbricks/web typecheck`, which calls `typegen` first) → command succeeds and prints "Types generated successfully", using `DATABASE_URL`/`ENCRYPTION_KEY`/`REDIS_URL` from `.env` rather than hardcoded values.
- [ ] Edge case: run the same command without a root `.env` file present → `dotenv-cli` does not error on a missing file (it exits 0 and leaves the vars unset), so the command proceeds and then fails inside `apps/web/lib/env.ts`'s validation with "Invalid environment variables", listing all 7 vars required there (`DATABASE_URL`, `ENCRYPTION_KEY`, `CUBEJS_API_SECRET`, `CUBEJS_API_URL`, `HUB_API_URL`, `HUB_API_KEY`, `REDIS_URL`). This precondition isn't new — `main` already can't run `typegen` without a root `.env`, since 4 of those 7 vars were never in the old inline-placeholder list either.

**Preconditions / test data**

- A root `.env` file populated from `.env.example` with valid values for the env-validated vars (same precondition already required by the `test` script).

**Risks & regressions**

- Low risk: this only changes how the `typegen` script sources its env vars, not any application logic. The main thing to re-check is that CI/dev environments that run `pnpm typegen` or `pnpm typecheck` have a `.env` file available at the repo root (they already do, since `pnpm test` depends on the same file).

**Migrations / env / cutover**

- none

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQvX2nss96ji9iqLEc2FpY)_