### PR TITLE
docs(unify-feedback): add Enrichment page and promote MCP to a top-level nav tab

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -86,11 +86,6 @@
                   "platform/features/user-management/two-factor-auth"
                 ]
               },
-              {
-                "group": "MCP",
-                "icon": "robot",
-                "pages": ["platform/mcp/overview", "platform/mcp/setup"]
-              },
               "platform/features/styling-theme",
               "platform/features/email-customization"
             ]
@@ -235,6 +230,7 @@
               "unify-feedback/feedback-datasets",
               "unify-feedback/feedback-sources",
               "unify-feedback/feedback-records",
+              "unify-feedback/enrichment",
               "unify-feedback/dashboards-charts",
               "unify-feedback/topics-subtopics"
             ]
@@ -429,6 +425,15 @@
           }
         ],
         "tab": "Development"
+      },
+      {
+        "groups": [
+          {
+            "group": "MCP",
+            "pages": ["platform/mcp/overview", "platform/mcp/setup"]
+          }
+        ],
+        "tab": "MCP"
       },
       {
         "groups": [

--- a/docs/unify-feedback/enrichment.mdx
+++ b/docs/unify-feedback/enrichment.mdx
@@ -14,13 +14,13 @@ These fields turn free text, which is normally hard to count, into structured si
 
 ## How enrichment works
 
-Enrichment is **automatic and per-record**. You do not configure or trigger it manually:
+Enrichment is **automatic and per-record**. Individual records are never triggered or configured by hand; the only setting is the translation target language, which is configured once at the service level (see [Language consolidation](#language-consolidation)):
 
 1. A Feedback Record is ingested with a text answer in `value_text`.
 2. Formbricks enriches the record **asynchronously**. The enrichment fields are absent until processing finishes, so a record may show as **Not enriched** for a short time after it arrives.
 3. Once complete, the sentiment, emotion, and translation fields appear on the record and in charts.
 
-Only records with open text are enriched. Records that only carry a rating, NPS score, or categorical choice have nothing to analyze.
+Only records with open text receive AI enrichment. Records that only carry a rating, NPS score, or categorical choice have no text to analyze. Categorical answers are still consolidated across languages through their **Value ID**, which is not AI enrichment. See [Consolidating the same option across languages](#consolidating-the-same-option-across-languages).
 
 <Note>
   Enrichment fields are read-only. Editing a record's `value_text` clears its

--- a/docs/unify-feedback/enrichment.mdx
+++ b/docs/unify-feedback/enrichment.mdx
@@ -1,0 +1,115 @@
+---
+title: "Enrichment"
+description: "AI enrichment that adds sentiment, emotions, and a consolidated language to open-text Feedback Records."
+icon: "sparkles"
+---
+
+Enrichment automatically adds AI-generated context to your open-text feedback. When a Feedback Record has a text answer (`value_text`), Formbricks analyzes it and attaches three kinds of enrichment:
+
+- **Sentiment**: how positive or negative the feedback is.
+- **Emotions**: which emotions the text expresses.
+- **Language consolidation**: a translated copy of the text in one common language, so feedback written in different languages can be compared and analyzed together.
+
+These fields turn free text, which is normally hard to count, into structured signals you can filter, chart, and trend over time.
+
+## How enrichment works
+
+Enrichment is **automatic and per-record**. You do not configure or trigger it manually:
+
+1. A Feedback Record is ingested with a text answer in `value_text`.
+2. Formbricks enriches the record **asynchronously**. The enrichment fields are absent until processing finishes, so a record may show as **Not enriched** for a short time after it arrives.
+3. Once complete, the sentiment, emotion, and translation fields appear on the record and in charts.
+
+Only records with open text are enriched. Records that only carry a rating, NPS score, or categorical choice have nothing to analyze.
+
+<Note>
+  Enrichment fields are read-only. Editing a record's `value_text` clears its
+  enrichment and re-queues it for processing. Editing a record's `language`
+  re-runs only the translation.
+</Note>
+
+## Sentiment enrichment
+
+Sentiment classifies each text answer on a polarity scale and assigns a signed score.
+
+**Sentiment label** is one of:
+
+| Label | Meaning |
+| --- | --- |
+| **Very positive** | Strongly positive feedback |
+| **Positive** | Positive feedback |
+| **Neutral** | Neither positive nor negative |
+| **Negative** | Negative feedback |
+| **Very negative** | Strongly negative feedback |
+| **Mixed** | Contains both positive and negative signals |
+
+**Sentiment score** is a number from **-1.0** (very negative) to **1.0** (very positive). `Mixed` records score near 0.
+
+Where you see it:
+
+- **Record detail drawer**, under the **AI enrichment** section, e.g. `Positive (0.82)`.
+- **Topics & Subtopics**, as a colored sentiment badge on each record card.
+- **Charts**, where you can group by **Sentiment** or chart the average **Sentiment Score**. Records that haven't been enriched yet fall into a **Not enriched** bucket.
+
+## Emotion enrichment
+
+Emotion enrichment detects which emotions a text answer expresses. It is **multi-label**: a single record can carry several emotions at once (or none, before it's enriched).
+
+The six recognized emotions are:
+
+- **Joy**
+- **Anger**
+- **Sadness**
+- **Fear**
+- **Surprise**
+- **Disgust**
+
+Where you see it:
+
+- **Record detail drawer**, listed in the **AI enrichment** section.
+- **Topics & Subtopics**, as one colored badge per detected emotion on each record card.
+- **Charts**, where you can chart the count of each emotion.
+
+<Note>
+  Because emotions are a multi-label set, filter charts on a single emotion
+  using the **contains** operator rather than an exact-match equals.
+</Note>
+
+## Language consolidation
+
+Feedback often arrives in many languages, which makes it hard to read and analyze together. Language consolidation solves this in two ways.
+
+### Translation into a common language
+
+Every open-text answer is translated into your organization's configured target language and stored alongside the original:
+
+- The **translated text** is shown throughout Unify Feedback in place of the original, with a **Translated to {language}** chip. The original text is always available in the tooltip and in the record detail drawer.
+- In **Topics & Subtopics**, a **Comment language** toggle lets you switch between the original and the translated text.
+
+This means an analyst working in English can read, cluster, and chart feedback that was originally submitted in German, French, Spanish, and more, all consolidated into one comparable language.
+
+<Note>
+  The target language is set at the service level for your organization. On
+  Formbricks Cloud it is managed for you; self-hosted instances configure it in
+  the Hub service. See [Formbricks Hub](/unify-feedback/formbricks-hub).
+</Note>
+
+### Consolidating the same option across languages
+
+For multiple-choice answers, Formbricks also carries a stable **Value ID**, the option's identifier from the source system (for example, a survey choice id). This lets charts group the **same option** together even when its label was captured in different languages or later edited, instead of splitting it into a separate category per localized label.
+
+When charting choice questions, group by **Value (Option)** rather than the raw text value to keep categories consolidated across languages.
+
+## Using enrichment in charts
+
+All enrichment fields are available in [Dashboards & Charts](/unify-feedback/dashboards-charts) as dimensions and measures. Records that haven't finished enriching are grouped under a **Not enriched** value, so you can see enrichment coverage at a glance.
+
+## Requirements
+
+- A Feedback Dataset with records that contain open text.
+- Enrichment runs on the Formbricks Hub. No local AI provider configuration is required to read enrichment fields.
+
+<Note>
+  Unify Feedback is an enterprise feature. Enable it on Formbricks Cloud with a
+  paid plan, or self-host with a license.
+</Note>

--- a/docs/unify-feedback/overview.mdx
+++ b/docs/unify-feedback/overview.mdx
@@ -16,7 +16,7 @@ Most companies collect feedback in many places: surveys, support tickets, app st
 2. **Connect Sources.** Pull data from Formbricks surveys, upload CSVs, or push records via the API.
 3. **Explore Records.** Browse, filter, edit, and tag individual Feedback Records.
 4. **Enrich.** Open-text feedback is automatically enriched with sentiment, emotions, and a consolidated language.
-5. **Discover Topics.** Use vector based Topics & Subtopics (Preview) to cluster open-text feedback.
+5. **Discover Topics.** Use vector-based Topics & Subtopics (Preview) to cluster open-text feedback.
 6. **Visualize.** Build Charts and group them on Dashboards to share insights with your team.
 
 <CardGroup cols={2}>

--- a/docs/unify-feedback/overview.mdx
+++ b/docs/unify-feedback/overview.mdx
@@ -15,8 +15,9 @@ Most companies collect feedback in many places: surveys, support tickets, app st
 1. **Create a Feedback Dataset.** A dataset is a tenant-scoped bucket for related feedback (for example, "Product Feedback" or "Support 2026").
 2. **Connect Sources.** Pull data from Formbricks surveys, upload CSVs, or push records via the API.
 3. **Explore Records.** Browse, filter, edit, and tag individual Feedback Records.
-4. **Discover Topics.** Use vector based Topics & Subtopics (Preview) to cluster open-text feedback.
-5. **Visualize.** Build Charts and group them on Dashboards to share insights with your team.
+4. **Enrich.** Open-text feedback is automatically enriched with sentiment, emotions, and a consolidated language.
+5. **Discover Topics.** Use vector based Topics & Subtopics (Preview) to cluster open-text feedback.
+6. **Visualize.** Build Charts and group them on Dashboards to share insights with your team.
 
 <CardGroup cols={2}>
   <Card title="Feedback Datasets" icon="folder-tree" href="/unify-feedback/feedback-datasets">
@@ -27,6 +28,9 @@ Most companies collect feedback in many places: surveys, support tickets, app st
   </Card>
   <Card title="Feedback Sources" icon="plug" href="/unify-feedback/feedback-sources">
     Connectors that bring data into a dataset.
+  </Card>
+  <Card title="Enrichment" icon="sparkles" href="/unify-feedback/enrichment">
+    Sentiment, emotions, and language consolidation on open text.
   </Card>
   <Card title="Dashboards & Charts" icon="chart-line" href="/unify-feedback/dashboards-charts">
     Visualize and share feedback insights.


### PR DESCRIPTION
## What & why

Two documentation gaps in the Unify Feedback and Platform docs.

1. **Unify Feedback enrichment was undocumented.** Sentiment, emotions, and language consolidation are computed on open-text Feedback Records, surfaced in the record drawer, Topics & Subtopics, and Charts, but there was no page explaining them. This adds a new **Enrichment** page under Unify Feedback covering all three, and links it from the overview.
2. **MCP navigation.** MCP was buried as a group under the Platform tab. This promotes it to its own top-level nav tab, positioned after Development, and removes the duplicate group from Platform.

New page contents:
- **Sentiment enrichment**: polarity label (very negative → very positive, plus mixed) and a signed score from -1.0 to 1.0.
- **Emotion enrichment**: multi-label from a fixed set of six (joy, anger, sadness, fear, surprise, disgust); filter with `contains`.
- **Language consolidation**: translation of open text into the org's target language (with the "Translated to …" chip and Original/translated toggle), plus `value_id` option consolidation across localized labels.
- Notes that enrichment is automatic, per-record, asynchronous, read-only, and gated by the Unify Feedback (enterprise) entitlement.

Facts were sourced from the code: the Hub SDK feedback-record field definitions and enums, `apps/web/modules/ee/analysis/lib/schema-definition.ts`, the Unify Feedback record drawer and taxonomy components, and the `en-US.json` strings.

## Linear ticket

No ticket. Documentation follow-up for the 5.2 Unify Feedback enrichment and MCP work.

## How this was tested

- Docs-only change (MDX + Mintlify nav config). No application code touched.
- Validated `docs/docs.json` parses as JSON after the nav edits.
- Verified all documented enum values, field names, emotion set, and UI strings against the source (Hub SDK types, `schema-definition.ts`, `en-US.json`).
- Confirmed the new page renders no em dashes and follows the docs style (frontmatter, sentence-case headings, Mintlify `<Note>` blocks).

No UI in the product changed, so no screenshots apply.

## QA / Test Plan

**How to test**

- [ ] Build/serve the Mintlify docs site and open the **Unify Feedback** tab → a new **Enrichment** page appears in the sidebar between "Feedback Records" and "Dashboards & Charts".
- [ ] Open **Unify Feedback → Enrichment** → sections for "Sentiment enrichment", "Emotion enrichment", and "Language consolidation" render, with the sentiment label table and the six emotions listed.
- [ ] On **Unify Feedback → overview**, the "Enrichment" card links to `/unify-feedback/enrichment` and the numbered "How it works" list includes the new Enrich step.
- [ ] In the top navigation bar, **MCP** appears as its own tab immediately after **Development**, and no longer appears as a group under **Platform**.
- [ ] Open **MCP** tab → the "Overview" and "Setup" pages load at their existing `platform/mcp/*` URLs.

**Preconditions / test data**

- A local or preview build of the docs site (`docs/`). No accounts, seed data, or entitlement needed to view docs.

**Risks & regressions**

- MCP page URLs are unchanged (`platform/mcp/overview`, `platform/mcp/setup`); only their nav placement moved. Re-check any hardcoded links to the MCP pages still resolve.
- Nav config edit: confirm no other tab or group was accidentally reordered or dropped.

**Migrations / env / cutover**

- none
