### PR TITLE
fix(workflows): add Reply To helper text, align email labels (ENG-2033)

### DIFF
--- a/apps/web/modules/ee/workflows/components/inspector/workflow-email-action-form.tsx
+++ b/apps/web/modules/ee/workflows/components/inspector/workflow-email-action-form.tsx
@@ -228,6 +228,9 @@ export const WorkflowEmailActionForm = ({
       {/* Reply To */}
       <div className="flex flex-col gap-2">
         <Label htmlFor="workflow-email-reply-to">{t("workspace.workflows.email_reply_to_label")}</Label>
+        <p className="text-xs text-slate-500">
+          {t("workspace.surveys.edit.follow_ups_modal_action_replyTo_description")}
+        </p>
         <FollowUpActionMultiEmailInput
           disabled={!isEditable}
           emails={node.config.replyTo}


### PR DESCRIPTION
## Problem

In the Workflows **Send email** action, the **Reply To** field had no helper description, unlike **To** and **From** — its meaning was unclear.

## Solution

Add the helper description under **Reply To**, reusing the existing follow-ups copy (`follow_ups_modal_action_replyTo_description`: _"If the recipient hits reply, the following email address will receive it"_).

Single-line, copy-only change — no logic, no new strings, no label changes.

<img width="395" height="772" alt="Screenshot 2026-07-27 at 12 32 22 PM" src="https://github.com/user-attachments/assets/995fd747-cec2-4daf-94b9-a81d4589b609" />


Closes ENG-2033
https://linear.app/formbricks/issue/ENG-2033