### PR TITLE
fix: proxy feedback records in local development

### DIFF
--- a/apps/web/app/api/v3/feedbackRecords/[[...path]]/route.ts
+++ b/apps/web/app/api/v3/feedbackRecords/[[...path]]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { proxyFeedbackRecordsRequest } from "@/modules/hub/feedback-records-proxy";
+
+const handler = async (request: NextRequest): Promise<Response> => {
+  return await proxyFeedbackRecordsRequest(request);
+};
+
+export const GET = handler;
+export const POST = handler;
+export const PUT = handler;
+export const PATCH = handler;
+export const DELETE = handler;
+export const HEAD = handler;
+export const OPTIONS = handler;

--- a/apps/web/app/v1/feedback-records/[[...path]]/route.ts
+++ b/apps/web/app/v1/feedback-records/[[...path]]/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest } from "next/server";
+import { proxyFeedbackRecordsRequest } from "@/modules/hub/feedback-records-proxy";
+
+const handler = async (request: NextRequest): Promise<Response> => {
+  return await proxyFeedbackRecordsRequest(request);
+};
+
+export const GET = handler;
+export const POST = handler;
+export const PUT = handler;
+export const PATCH = handler;
+export const DELETE = handler;
+export const HEAD = handler;
+export const OPTIONS = handler;

--- a/apps/web/modules/hub/feedback-records-gateway.ts
+++ b/apps/web/modules/hub/feedback-records-gateway.ts
@@ -18,10 +18,9 @@ import {
   allowGatewayRequest,
   buildGatewayStatusResponse,
 } from "@/modules/gateway-auth/lib/request";
+import { normalizeFeedbackRecordsPath } from "@/modules/hub/feedback-records-routing";
 import { getFeedbackRecordTenant } from "@/modules/hub/service";
 
-const FEEDBACK_RECORDS_V3_PREFIX = "/api/v3/feedbackRecords";
-const FEEDBACK_RECORDS_SDK_PREFIX = "/v1/feedback-records";
 const ZFeedbackRecordId = z.uuid();
 
 type TFeedbackRecordsGatewayPermission = "read" | "write";
@@ -51,32 +50,6 @@ const apiKeyPermissionWeight: Record<ApiKeyPermission, number> = {
 const gatewayPermissionToApiKeyPermissionWeight: Record<TFeedbackRecordsGatewayPermission, number> = {
   read: apiKeyPermissionWeight.read,
   write: apiKeyPermissionWeight.write,
-};
-
-const stripFeedbackRecordsPrefix = (pathname: string, prefix: string): string | null => {
-  if (pathname === prefix) {
-    return "/";
-  }
-
-  if (!pathname.startsWith(`${prefix}/`)) {
-    return null;
-  }
-
-  return pathname.slice(prefix.length) || "/";
-};
-
-const normalizeFeedbackRecordsPath = (pathname: string): string | null => {
-  const v3Path = stripFeedbackRecordsPrefix(pathname, FEEDBACK_RECORDS_V3_PREFIX);
-  if (v3Path) {
-    return v3Path;
-  }
-
-  const sdkPath = stripFeedbackRecordsPrefix(pathname, FEEDBACK_RECORDS_SDK_PREFIX);
-  if (sdkPath) {
-    return sdkPath;
-  }
-
-  return null;
 };
 
 const parseFeedbackRecordsGatewayRoute = (method: string, pathname: string): TParsedGatewayRoute | null => {

--- a/apps/web/modules/hub/feedback-records-proxy.test.ts
+++ b/apps/web/modules/hub/feedback-records-proxy.test.ts
@@ -115,10 +115,11 @@ describe("proxyFeedbackRecordsRequest", () => {
       new NextRequest("http://localhost:3000/v1/feedback-records?tenant_id=dir_1", {
         headers: {
           authorization: "Bearer client-token",
-          connection: "keep-alive",
+          connection: "keep-alive, X-Client-Context",
           cookie: "session=secret",
           host: "localhost:3000",
           "x-api-key": "fbk_client-key",
+          "x-client-context": "sensitive-client-context",
         },
       })
     );
@@ -129,6 +130,7 @@ describe("proxyFeedbackRecordsRequest", () => {
     expect(hubRequest.headers.has("x-api-key")).toBe(false);
     expect(hubRequest.headers.has("connection")).toBe(false);
     expect(hubRequest.headers.has("host")).toBe(false);
+    expect(hubRequest.headers.has("x-client-context")).toBe(false);
   });
 
   test("passes the Hub response through unchanged", async () => {

--- a/apps/web/modules/hub/feedback-records-proxy.test.ts
+++ b/apps/web/modules/hub/feedback-records-proxy.test.ts
@@ -1,0 +1,235 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { proxyFeedbackRecordsRequest } from "@/modules/hub/feedback-records-proxy";
+
+const { mockAuthorizeGatewayRequest, mockLoggerError, runtime } = vi.hoisted(() => ({
+  mockAuthorizeGatewayRequest: vi.fn(),
+  mockLoggerError: vi.fn(),
+  runtime: {
+    isProduction: false,
+  },
+}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: {
+    error: mockLoggerError,
+  },
+}));
+
+vi.mock("@/lib/constants", () => ({
+  HUB_API_KEY: "hub-api-key",
+  HUB_API_URL: "https://hub.test",
+  get IS_PRODUCTION() {
+    return runtime.isProduction;
+  },
+}));
+
+vi.mock("@/modules/gateway-auth/lib/request", () => ({
+  authorizeGatewayRequest: mockAuthorizeGatewayRequest,
+}));
+
+vi.mock("@/modules/hub/feedback-records-gateway", () => ({
+  feedbackRecordsGatewayAuthorizer: {
+    authorize: vi.fn(),
+    matches: vi.fn(),
+  },
+}));
+
+describe("proxyFeedbackRecordsRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    runtime.isProduction = false;
+    mockAuthorizeGatewayRequest.mockResolvedValue(new Response(null, { status: 200 }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test.each([
+    [
+      "http://localhost:3000/api/v3/feedbackRecords?tenant_id=dir_1&limit=25",
+      "https://hub.test/v1/feedback-records?tenant_id=dir_1&limit=25",
+    ],
+    [
+      "http://localhost:3000/api/v3/feedbackRecords/record_1/similar?limit=3",
+      "https://hub.test/v1/feedback-records/record_1/similar?limit=3",
+    ],
+    [
+      "http://localhost:3000/v1/feedback-records?tenant_id=dir_1&limit=25",
+      "https://hub.test/v1/feedback-records?tenant_id=dir_1&limit=25",
+    ],
+    [
+      "http://localhost:3000/v1/feedback-records/record_1?include=fields",
+      "https://hub.test/v1/feedback-records/record_1?include=fields",
+    ],
+  ])("proxies %s to %s", async (requestUrl, expectedHubUrl) => {
+    const fetchMock = vi.fn().mockResolvedValue(Response.json({ data: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await proxyFeedbackRecordsRequest(new NextRequest(requestUrl));
+
+    const hubRequest = fetchMock.mock.calls[0][0] as Request;
+    expect(hubRequest.url).toBe(expectedHubUrl);
+    expect(fetchMock).toHaveBeenCalledWith(hubRequest, { cache: "no-store" });
+  });
+
+  test("authorizes a cloned request before forwarding the original body", async () => {
+    const body = JSON.stringify({ tenant_id: "dir_1", text: "Feedback" });
+    mockAuthorizeGatewayRequest.mockImplementationOnce(async ({ request }: { request: NextRequest }) => {
+      expect(await request.text()).toBe(body);
+      return new Response(null, { status: 200 });
+    });
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 201 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await proxyFeedbackRecordsRequest(
+      new NextRequest("http://localhost:3000/api/v3/feedbackRecords", {
+        method: "POST",
+        body,
+        headers: {
+          "content-type": "application/json",
+          "x-request-id": "request_1",
+        },
+      })
+    );
+
+    const authorizationInput = mockAuthorizeGatewayRequest.mock.calls[0][0];
+    expect(authorizationInput.originalRequest).toEqual({
+      method: "POST",
+      url: new URL("http://localhost:3000/api/v3/feedbackRecords"),
+    });
+    expect(authorizationInput.requestId).toBe("request_1");
+
+    const hubRequest = fetchMock.mock.calls[0][0] as Request;
+    expect(hubRequest.method).toBe("POST");
+    expect(hubRequest.headers.get("content-type")).toBe("application/json");
+    expect(await hubRequest.text()).toBe(body);
+  });
+
+  test("replaces client credentials with the internal Hub credential", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await proxyFeedbackRecordsRequest(
+      new NextRequest("http://localhost:3000/v1/feedback-records?tenant_id=dir_1", {
+        headers: {
+          authorization: "Bearer client-token",
+          connection: "keep-alive",
+          cookie: "session=secret",
+          host: "localhost:3000",
+          "x-api-key": "fbk_client-key",
+        },
+      })
+    );
+
+    const hubRequest = fetchMock.mock.calls[0][0] as Request;
+    expect(hubRequest.headers.get("authorization")).toBe("Bearer hub-api-key");
+    expect(hubRequest.headers.has("cookie")).toBe(false);
+    expect(hubRequest.headers.has("x-api-key")).toBe(false);
+    expect(hubRequest.headers.has("connection")).toBe(false);
+    expect(hubRequest.headers.has("host")).toBe(false);
+  });
+
+  test("passes the Hub response through unchanged", async () => {
+    const hubResponse = new Response("created", {
+      status: 201,
+      headers: {
+        "content-type": "application/json",
+        "x-hub-request-id": "hub_request_1",
+      },
+    });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(hubResponse));
+
+    const response = await proxyFeedbackRecordsRequest(
+      new NextRequest("http://localhost:3000/api/v3/feedbackRecords?tenant_id=dir_1")
+    );
+
+    expect(response).toBe(hubResponse);
+    expect(response.status).toBe(201);
+    expect(response.headers.get("x-hub-request-id")).toBe("hub_request_1");
+    expect(await response.text()).toBe("created");
+  });
+
+  test("returns the authorization response without calling Hub", async () => {
+    const authorizationResponse = new Response("Forbidden", { status: 403 });
+    mockAuthorizeGatewayRequest.mockResolvedValueOnce(authorizationResponse);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await proxyFeedbackRecordsRequest(
+      new NextRequest("http://localhost:3000/v1/feedback-records?tenant_id=dir_1")
+    );
+
+    expect(response).toBe(authorizationResponse);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("returns the authorizer response for an unsupported operation", async () => {
+    mockAuthorizeGatewayRequest.mockResolvedValueOnce(
+      new Response("Unsupported FeedbackRecords route", { status: 400 })
+    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await proxyFeedbackRecordsRequest(
+      new NextRequest("http://localhost:3000/api/v3/feedbackRecords?tenant_id=dir_1", {
+        method: "PUT",
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.text()).toBe("Unsupported FeedbackRecords route");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("rejects requests outside the FeedbackRecords route prefixes", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await proxyFeedbackRecordsRequest(
+      new NextRequest("http://localhost:3000/api/v3/feedbackRecordsFoo")
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockAuthorizeGatewayRequest).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("returns a sanitized bad gateway response when Hub is unavailable", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED secret-url")));
+
+    const response = await proxyFeedbackRecordsRequest(
+      new NextRequest("http://localhost:3000/api/v3/feedbackRecords?tenant_id=dir_1", {
+        headers: {
+          "x-request-id": "request_1",
+        },
+      })
+    );
+
+    expect(response.status).toBe(502);
+    expect(await response.text()).toBe("Bad Gateway");
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      {
+        requestId: "request_1",
+        method: "GET",
+        pathname: "/api/v3/feedbackRecords",
+      },
+      "Feedback records local proxy request failed"
+    );
+  });
+
+  test("is unavailable in production", async () => {
+    runtime.isProduction = true;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await proxyFeedbackRecordsRequest(
+      new NextRequest("http://localhost:3000/api/v3/feedbackRecords?tenant_id=dir_1")
+    );
+
+    expect(response.status).toBe(404);
+    expect(mockAuthorizeGatewayRequest).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/modules/hub/feedback-records-proxy.ts
+++ b/apps/web/modules/hub/feedback-records-proxy.ts
@@ -1,0 +1,96 @@
+import "server-only";
+import { NextRequest } from "next/server";
+import { logger } from "@formbricks/logger";
+import { HUB_API_KEY, HUB_API_URL, IS_PRODUCTION } from "@/lib/constants";
+import { authorizeGatewayRequest } from "@/modules/gateway-auth/lib/request";
+import { feedbackRecordsGatewayAuthorizer } from "@/modules/hub/feedback-records-gateway";
+import { getFeedbackRecordsHubPathname } from "@/modules/hub/feedback-records-routing";
+
+const FORWARDED_CREDENTIAL_HEADERS = ["authorization", "cookie", "x-api-key"] as const;
+const HOP_BY_HOP_REQUEST_HEADERS = [
+  "connection",
+  "content-length",
+  "host",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+] as const;
+
+const buildHubRequestUrl = (requestUrl: URL): URL | null => {
+  const hubPathname = getFeedbackRecordsHubPathname(requestUrl.pathname);
+  if (!hubPathname) {
+    return null;
+  }
+
+  const hubUrl = new URL(HUB_API_URL);
+  hubUrl.pathname = hubPathname;
+  hubUrl.search = requestUrl.search;
+  hubUrl.hash = "";
+
+  return hubUrl;
+};
+
+const buildHubRequest = (request: NextRequest, hubUrl: URL): Request => {
+  const hubRequest = new Request(hubUrl, request);
+
+  for (const header of FORWARDED_CREDENTIAL_HEADERS) {
+    hubRequest.headers.delete(header);
+  }
+  for (const header of HOP_BY_HOP_REQUEST_HEADERS) {
+    hubRequest.headers.delete(header);
+  }
+
+  hubRequest.headers.set("authorization", `Bearer ${HUB_API_KEY}`);
+
+  return hubRequest;
+};
+
+const buildAllowResponse = (): Response => new Response(null, { status: 200 });
+
+export const proxyFeedbackRecordsRequest = async (request: NextRequest): Promise<Response> => {
+  if (IS_PRODUCTION) {
+    return new Response(null, { status: 404 });
+  }
+
+  const originalUrl = new URL(request.url);
+  const requestId = request.headers.get("x-request-id") ?? "unknown";
+  const hubUrl = buildHubRequestUrl(originalUrl);
+  if (!hubUrl) {
+    return new Response("Unsupported FeedbackRecords proxy route", { status: 400 });
+  }
+
+  const authorizationResponse = await authorizeGatewayRequest({
+    request: new NextRequest(request.clone()),
+    originalRequest: {
+      method: request.method.toUpperCase(),
+      url: originalUrl,
+    },
+    authorizers: [feedbackRecordsGatewayAuthorizer],
+    requestId,
+    buildAllowResponse,
+    unsupportedRouteMessage: "Unsupported FeedbackRecords proxy route",
+  });
+
+  if (!authorizationResponse.ok) {
+    return authorizationResponse;
+  }
+
+  try {
+    return await fetch(buildHubRequest(request, hubUrl), { cache: "no-store" });
+  } catch {
+    logger.error(
+      {
+        requestId,
+        method: request.method,
+        pathname: originalUrl.pathname,
+      },
+      "Feedback records local proxy request failed"
+    );
+
+    return new Response("Bad Gateway", { status: 502 });
+  }
+};

--- a/apps/web/modules/hub/feedback-records-proxy.ts
+++ b/apps/web/modules/hub/feedback-records-proxy.ts
@@ -19,6 +19,7 @@ const HOP_BY_HOP_REQUEST_HEADERS = [
   "transfer-encoding",
   "upgrade",
 ] as const;
+const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
 const buildHubRequestUrl = (requestUrl: URL): URL | null => {
   const hubPathname = getFeedbackRecordsHubPathname(requestUrl.pathname);
@@ -36,11 +37,17 @@ const buildHubRequestUrl = (requestUrl: URL): URL | null => {
 
 const buildHubRequest = (request: NextRequest, hubUrl: URL): Request => {
   const hubRequest = new Request(hubUrl, request);
+  const connectionHeaders = (request.headers.get("connection") ?? "")
+    .split(",")
+    .map((header) => header.trim().toLowerCase())
+    .filter((header) => HEADER_NAME_PATTERN.test(header));
+  const headersToRemove = new Set([
+    ...FORWARDED_CREDENTIAL_HEADERS,
+    ...HOP_BY_HOP_REQUEST_HEADERS,
+    ...connectionHeaders,
+  ]);
 
-  for (const header of FORWARDED_CREDENTIAL_HEADERS) {
-    hubRequest.headers.delete(header);
-  }
-  for (const header of HOP_BY_HOP_REQUEST_HEADERS) {
+  for (const header of headersToRemove) {
     hubRequest.headers.delete(header);
   }
 

--- a/apps/web/modules/hub/feedback-records-routing.test.ts
+++ b/apps/web/modules/hub/feedback-records-routing.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import {
+  getFeedbackRecordsHubPathname,
+  normalizeFeedbackRecordsPath,
+} from "@/modules/hub/feedback-records-routing";
+
+describe("feedback records routing", () => {
+  test.each([
+    ["/api/v3/feedbackRecords", "/"],
+    ["/api/v3/feedbackRecords/", "/"],
+    ["/api/v3/feedbackRecords/record_1", "/record_1"],
+    ["/v1/feedback-records", "/"],
+    ["/v1/feedback-records/search/semantic", "/search/semantic"],
+  ])("normalizes %s", (pathname, expected) => {
+    expect(normalizeFeedbackRecordsPath(pathname)).toBe(expected);
+  });
+
+  test.each([
+    ["/api/v3/feedbackRecords", "/v1/feedback-records"],
+    ["/api/v3/feedbackRecords/", "/v1/feedback-records/"],
+    ["/api/v3/feedbackRecords/record_1/similar", "/v1/feedback-records/record_1/similar"],
+    ["/v1/feedback-records", "/v1/feedback-records"],
+    ["/v1/feedback-records/record_1", "/v1/feedback-records/record_1"],
+  ])("maps %s to the Hub pathname", (pathname, expected) => {
+    expect(getFeedbackRecordsHubPathname(pathname)).toBe(expected);
+  });
+
+  test.each([
+    "/api/v3/feedbackRecordsFoo",
+    "/v1/feedback-records-other",
+    "/api/v3/other",
+    "/feedback-records",
+  ])("does not match %s", (pathname) => {
+    expect(normalizeFeedbackRecordsPath(pathname)).toBeNull();
+    expect(getFeedbackRecordsHubPathname(pathname)).toBeNull();
+  });
+});

--- a/apps/web/modules/hub/feedback-records-routing.ts
+++ b/apps/web/modules/hub/feedback-records-routing.ts
@@ -1,0 +1,36 @@
+export const FEEDBACK_RECORDS_V3_PREFIX = "/api/v3/feedbackRecords";
+export const FEEDBACK_RECORDS_SDK_PREFIX = "/v1/feedback-records";
+
+const stripFeedbackRecordsPrefix = (pathname: string, prefix: string): string | null => {
+  if (pathname === prefix) {
+    return "/";
+  }
+
+  if (!pathname.startsWith(`${prefix}/`)) {
+    return null;
+  }
+
+  return pathname.slice(prefix.length) || "/";
+};
+
+export const normalizeFeedbackRecordsPath = (pathname: string): string | null => {
+  const v3Path = stripFeedbackRecordsPrefix(pathname, FEEDBACK_RECORDS_V3_PREFIX);
+  if (v3Path) {
+    return v3Path;
+  }
+
+  const sdkPath = stripFeedbackRecordsPrefix(pathname, FEEDBACK_RECORDS_SDK_PREFIX);
+  if (sdkPath) {
+    return sdkPath;
+  }
+
+  return null;
+};
+
+export const getFeedbackRecordsHubPathname = (pathname: string): string | null => {
+  if (stripFeedbackRecordsPrefix(pathname, FEEDBACK_RECORDS_V3_PREFIX) !== null) {
+    return `${FEEDBACK_RECORDS_SDK_PREFIX}${pathname.slice(FEEDBACK_RECORDS_V3_PREFIX.length)}`;
+  }
+
+  return stripFeedbackRecordsPrefix(pathname, FEEDBACK_RECORDS_SDK_PREFIX) !== null ? pathname : null;
+};

--- a/docker/README.md
+++ b/docker/README.md
@@ -152,3 +152,9 @@ The one-click Traefik installer exposes Hub-backed FeedbackRecords on the Formbr
 `/api/v3/feedbackRecords` and `/v1/feedback-records`. Traefik uses Formbricks gateway auth, rewrites the v3
 path to Hub's `/v1/feedback-records`, injects `Authorization: Bearer ${HUB_API_KEY}` for Hub, and strips client
 API key/cookie headers before the Hub hop.
+
+The local development server exposes the same routes at `http://localhost:3000`. With `HUB_API_URL` and
+`HUB_API_KEY` configured as shown in `.env.example`, the Next.js app applies the same Formbricks gateway
+authorization, rewrites `/api/v3/feedbackRecords` to Hub's `/v1/feedback-records`, replaces client credentials
+with the Hub API key, and proxies the request to the Hub service running on port **8080**. This app-level proxy
+is development-only; production deployments continue to use Traefik or Envoy for FeedbackRecords routing.


### PR DESCRIPTION
Fixes: ENG-1773
## What & why

Local Next.js development bypasses the Traefik/Envoy gateways that normally expose Hub FeedbackRecords, so `/api/v3/feedbackRecords` and `/v1/feedback-records` were unavailable on `localhost:3000`.

This adds development/test-only optional catch-all Route Handlers that reuse the existing FeedbackRecords gateway authorizer, clone body-bearing requests before authorization, translate the v3 path, replace client credentials with the internal Hub credential, strip fixed and `Connection`-nominated hop-by-hop headers, and proxy requests without caching. Production app handlers return 404, leaving deployed Traefik/Envoy routing unchanged. Shared path normalization keeps the proxy and gateway authorizer aligned.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1773/make-apiv3feedbackrecords-work-in-local-development-setup

## How this was tested

- Focused Vitest suites for the proxy, path routing, shared gateway request auth, Traefik auth, and Envoy auth: 5 files / 55 tests passed, including a regression test for a custom `Connection: X-Client-Context` token ✅
- Targeted ESLint for all changed TypeScript files passed ✅
- `pnpm --filter @formbricks/web typecheck` passed ✅
- `pnpm --filter @formbricks/web build` passed; the route manifest contains both optional catch-all proxy routes and the existing `/api/v3/feedbackRecords/token` route ✅
- Manual local Next.js checks: both new routes returned `401 Unauthorized` without credentials, and `/api/v3/feedbackRecords/token` continued to reach its existing handler and returned `401` while signed out ✅
- A full authenticated Hub round trip was not run because the local Docker daemon/Hub dependencies were unavailable.

## QA / Test Plan

**How to test**

- [ ] Start the local stack with the existing `.env.example` Hub defaults (`HUB_API_URL=http://localhost:8080`, `HUB_API_KEY=dev-api-key`) and request `GET /api/v3/feedbackRecords?tenant_id=<feedback-directory-id>` with a read-capable Formbricks API key → `200` with Hub records.
- [ ] Request the equivalent `GET /v1/feedback-records?tenant_id=<feedback-directory-id>` → `200` with the same records.
- [ ] Send a valid write request with a write-capable key, including `POST /api/v3/feedbackRecords` with `tenant_id` in the JSON body → the request reaches Hub and preserves the body/content type.
- [ ] Request a nested record operation with query parameters through either prefix → the record path and query string reach Hub unchanged, except for the expected v3-to-v1 prefix rewrite.
- [ ] Repeat without credentials → `401 Unauthorized`; repeat with insufficient permissions → `403 Forbidden` and Hub is not called.
- [ ] Sign in and call `POST /api/v3/feedbackRecords/token` → the existing token handler returns a gateway token, not a proxied Hub response.
- [ ] Run a production build/deployment behind the supported external gateway → FeedbackRecords continues through Traefik/Envoy; the app-level fallback itself is unavailable in production.

**Preconditions / test data**

- Local Formbricks and Hub services running, with the existing Hub URL/key variables configured.
- A feedback directory containing at least one record.
- Formbricks API keys with read-only and write permissions, plus a signed-in user for the token-route check.

**Risks & regressions**

- Re-check body-bearing authorization to ensure reading tenant data does not consume the body sent to Hub.
- Re-check client `Authorization`, `X-API-Key`, `Cookie`, fixed hop-by-hop, and `Connection`-nominated headers are never forwarded to Hub.
- Re-check the static token route wins over the optional catch-all and deployed production routing remains gateway-owned.

**Migrations / env / cutover**

- No migrations or new environment variables. Local use requires the existing `HUB_API_URL` and `HUB_API_KEY` values.