### PR TITLE
fix(hub): bind feedback records gateway API key access to target organization [ENG-1980]

### DIFF
--- a/apps/web/modules/envoy-auth/service.test.ts
+++ b/apps/web/modules/envoy-auth/service.test.ts
@@ -127,8 +127,8 @@ describe("authorizeEnvoyRequest", () => {
       type: "apiKey",
       apiKeyId: "key_1",
       organizationId: "org_1",
-      organizationAccess: { accessControl: { read: true, write: true } },
-      workspacePermissions: [],
+      organizationAccess: { accessControl: { read: false, write: false } },
+      workspacePermissions: [{ workspaceId: "workspace_1", workspaceName: "Linked", permission: "manage" }],
     });
 
     const response = await authorizeEnvoyRequest(
@@ -241,8 +241,8 @@ describe("authorizeEnvoyRequest", () => {
       type: "apiKey",
       apiKeyId: "key_1",
       organizationId: "org_1",
-      organizationAccess: { accessControl: { read: true, write: false } },
-      workspacePermissions: [],
+      organizationAccess: { accessControl: { read: false, write: false } },
+      workspacePermissions: [{ workspaceId: "workspace_1", workspaceName: "Linked", permission: "read" }],
     });
 
     const response = await authorizeEnvoyRequest(
@@ -453,7 +453,7 @@ describe("authorizeEnvoyRequest", () => {
     expect(response.status).toBe(403);
   });
 
-  test("allows API key with org-level read access for a read op even without workspace match", async () => {
+  test("denies an API key with only org-level access and no workspace match (org access does not grant feedback data)", async () => {
     mockGetFeedbackDirectoryAuthContext.mockResolvedValue({
       organizationId: "org_1",
       workspaceIds: [],
@@ -476,7 +476,7 @@ describe("authorizeEnvoyRequest", () => {
       })
     );
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(403);
   });
 
   test("returns 403 when unify feedback entitlement is disabled", async () => {

--- a/apps/web/modules/envoy-auth/service.test.ts
+++ b/apps/web/modules/envoy-auth/service.test.ts
@@ -391,6 +391,46 @@ describe("authorizeEnvoyRequest", () => {
     expect(response.status).toBe(200);
   });
 
+  test("denies a cross-org API key even with a matching workspace permission (ENG-1980)", async () => {
+    // The directory belongs to org_2; the key belongs to org_1 but carries a workspace permission
+    // whose workspaceId collides with one linked to the org_2 directory. Access must be denied by the
+    // key-belongs-to-directory-org check — this is the exact cross-tenant path ENG-1980 closed.
+    // Wiring-level guard: if authorizeFeedbackRecordsGatewayRequest ever passed the key's own
+    // organizationId (instead of the directory's) into the org check, that check turns into a
+    // tautology and this returns 200; the direct unit test on the pure function can't catch it.
+    mockGetFeedbackDirectoryAuthContext.mockResolvedValue({
+      organizationId: "org_2",
+      workspaceIds: ["workspace_1"],
+      isArchived: false,
+    });
+    mockGetIsFeedbackDirectoriesEnabled.mockResolvedValue(true);
+    mockGetApiKeyFromHeaders.mockReturnValue("fbk_test");
+    mockAuthenticateApiKeyFromHeaders.mockResolvedValue({
+      type: "apiKey",
+      apiKeyId: "key_1",
+      organizationId: "org_1",
+      organizationAccess: { accessControl: { read: false, write: false } },
+      workspacePermissions: [
+        {
+          workspaceId: "workspace_1",
+          workspaceName: "Workspace 1",
+          permission: "manage",
+        },
+      ],
+    });
+
+    const response = await authorizeEnvoyRequest(
+      createRequest(`http://localhost/api/envoy-auth/v1/feedback-records?tenant_id=${feedbackDirectoryId}`, {
+        headers: {
+          "x-api-key": "fbk_test",
+        },
+      })
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockGetIsFeedbackDirectoriesEnabled).toHaveBeenCalledWith("org_2");
+  });
+
   test("returns 403 when API key has read-only workspace permission for a write op", async () => {
     mockGetApiKeyFromHeaders.mockReturnValue("fbk_test");
     mockAuthenticateApiKeyFromHeaders.mockResolvedValue({

--- a/apps/web/modules/hub/feedback-records-gateway-authz.test.ts
+++ b/apps/web/modules/hub/feedback-records-gateway-authz.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { TAuthenticationApiKey } from "@formbricks/types/auth";
+import type { TAuthenticationApiKey } from "@formbricks/types/auth";
 import { hasApiKeyImplicitFeedbackDirectoryAccess } from "./feedback-records-gateway-authz";
 
 const DIRECTORY_ORG_ID = "org_directory";
@@ -82,10 +82,11 @@ describe("hasApiKeyImplicitFeedbackDirectoryAccess", () => {
     });
   });
 
-  describe("workspace-permission path (org-scoped by construction)", () => {
-    test("grants when a workspace permission matches a directory workspace with sufficient weight", () => {
+  describe("workspace-permission path (same-organization keys only)", () => {
+    test("grants a same-organization key (no org-level access) via a matching workspace permission", () => {
+      // Fall-through: org-level accessControl is all-false, so access comes solely from the
+      // per-workspace permission.
       const workspaceKey = makeApiKeyAuth({
-        organizationId: "org_attacker",
         workspacePermissions: [
           { workspaceId: DIRECTORY_WORKSPACE_ID, workspaceName: "Shared", permission: "write" },
         ],
@@ -99,6 +100,27 @@ describe("hasApiKeyImplicitFeedbackDirectoryAccess", () => {
           "write"
         )
       ).toBe(true);
+    });
+
+    test("denies a foreign-organization key even with a matching workspace permission (defense-in-depth, ENG-1980)", () => {
+      // Upstream (authenticateApiKeyFromHeaders) filters workspacePermissions to the key's own org,
+      // so this shape shouldn't occur in production — but the authz function must deny it on its own
+      // rather than rely on that invariant holding.
+      const foreignKey = makeApiKeyAuth({
+        organizationId: "org_attacker",
+        workspacePermissions: [
+          { workspaceId: DIRECTORY_WORKSPACE_ID, workspaceName: "Shared", permission: "manage" },
+        ],
+      });
+
+      expect(
+        hasApiKeyImplicitFeedbackDirectoryAccess(
+          foreignKey,
+          DIRECTORY_ORG_ID,
+          [DIRECTORY_WORKSPACE_ID],
+          "write"
+        )
+      ).toBe(false);
     });
 
     test("denies when the read-only workspace permission is below the required write weight", () => {

--- a/apps/web/modules/hub/feedback-records-gateway-authz.test.ts
+++ b/apps/web/modules/hub/feedback-records-gateway-authz.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "vitest";
+import { TAuthenticationApiKey } from "@formbricks/types/auth";
+import { hasApiKeyImplicitFeedbackDirectoryAccess } from "./feedback-records-gateway-authz";
+
+const DIRECTORY_ORG_ID = "org_directory";
+const DIRECTORY_WORKSPACE_ID = "wsdirectory0000000000000";
+
+const makeApiKeyAuth = (overrides: Partial<TAuthenticationApiKey> = {}): TAuthenticationApiKey => ({
+  type: "apiKey",
+  apiKeyId: "key_1",
+  organizationId: DIRECTORY_ORG_ID,
+  organizationAccess: { accessControl: { read: false, write: false } },
+  workspacePermissions: [],
+  ...overrides,
+});
+
+describe("hasApiKeyImplicitFeedbackDirectoryAccess", () => {
+  describe("organization-level access control is bound to the API key's own organization (ENG-1980)", () => {
+    test("denies a foreign-organization key that has org-level write, for read and write", () => {
+      const foreignKey = makeApiKeyAuth({
+        organizationId: "org_attacker",
+        organizationAccess: { accessControl: { read: true, write: true } },
+      });
+
+      expect(
+        hasApiKeyImplicitFeedbackDirectoryAccess(
+          foreignKey,
+          DIRECTORY_ORG_ID,
+          [DIRECTORY_WORKSPACE_ID],
+          "read"
+        )
+      ).toBe(false);
+      expect(
+        hasApiKeyImplicitFeedbackDirectoryAccess(
+          foreignKey,
+          DIRECTORY_ORG_ID,
+          [DIRECTORY_WORKSPACE_ID],
+          "write"
+        )
+      ).toBe(false);
+    });
+
+    test("grants a same-organization key with org-level write, for read and write", () => {
+      const ownerKey = makeApiKeyAuth({
+        organizationAccess: { accessControl: { read: false, write: true } },
+      });
+
+      expect(
+        hasApiKeyImplicitFeedbackDirectoryAccess(ownerKey, DIRECTORY_ORG_ID, [DIRECTORY_WORKSPACE_ID], "read")
+      ).toBe(true);
+      expect(
+        hasApiKeyImplicitFeedbackDirectoryAccess(
+          ownerKey,
+          DIRECTORY_ORG_ID,
+          [DIRECTORY_WORKSPACE_ID],
+          "write"
+        )
+      ).toBe(true);
+    });
+
+    test("grants a same-organization key with org-level read only for read", () => {
+      const readerKey = makeApiKeyAuth({
+        organizationAccess: { accessControl: { read: true, write: false } },
+      });
+
+      expect(
+        hasApiKeyImplicitFeedbackDirectoryAccess(
+          readerKey,
+          DIRECTORY_ORG_ID,
+          [DIRECTORY_WORKSPACE_ID],
+          "read"
+        )
+      ).toBe(true);
+      expect(
+        hasApiKeyImplicitFeedbackDirectoryAccess(
+          readerKey,
+          DIRECTORY_ORG_ID,
+          [DIRECTORY_WORKSPACE_ID],
+          "write"
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe("workspace-permission path (org-scoped by construction)", () => {
+    test("grants when a workspace permission matches a directory workspace with sufficient weight", () => {
+      const workspaceKey = makeApiKeyAuth({
+        organizationId: "org_attacker",
+        workspacePermissions: [
+          { workspaceId: DIRECTORY_WORKSPACE_ID, workspaceName: "Shared", permission: "write" },
+        ],
+      });
+
+      expect(
+        hasApiKeyImplicitFeedbackDirectoryAccess(
+          workspaceKey,
+          DIRECTORY_ORG_ID,
+          [DIRECTORY_WORKSPACE_ID],
+          "write"
+        )
+      ).toBe(true);
+    });
+
+    test("denies when the read-only workspace permission is below the required write weight", () => {
+      const workspaceKey = makeApiKeyAuth({
+        workspacePermissions: [
+          { workspaceId: DIRECTORY_WORKSPACE_ID, workspaceName: "Shared", permission: "read" },
+        ],
+      });
+
+      expect(
+        hasApiKeyImplicitFeedbackDirectoryAccess(
+          workspaceKey,
+          DIRECTORY_ORG_ID,
+          [DIRECTORY_WORKSPACE_ID],
+          "write"
+        )
+      ).toBe(false);
+    });
+
+    test("denies when no workspace permission matches a directory workspace", () => {
+      const workspaceKey = makeApiKeyAuth({
+        workspacePermissions: [
+          { workspaceId: "wsother00000000000000000", workspaceName: "Other", permission: "manage" },
+        ],
+      });
+
+      expect(
+        hasApiKeyImplicitFeedbackDirectoryAccess(
+          workspaceKey,
+          DIRECTORY_ORG_ID,
+          [DIRECTORY_WORKSPACE_ID],
+          "read"
+        )
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/web/modules/hub/feedback-records-gateway-authz.test.ts
+++ b/apps/web/modules/hub/feedback-records-gateway-authz.test.ts
@@ -15,39 +15,18 @@ const makeApiKeyAuth = (overrides: Partial<TAuthenticationApiKey> = {}): TAuthen
 });
 
 describe("hasApiKeyImplicitFeedbackDirectoryAccess", () => {
-  describe("organization-level access control is bound to the API key's own organization (ENG-1980)", () => {
-    test("denies a foreign-organization key that has org-level write, for read and write", () => {
-      const foreignKey = makeApiKeyAuth({
-        organizationId: "org_attacker",
+  describe("organization-level access control does not grant feedback-record access", () => {
+    // organizationAccess.accessControl governs org management (members/teams), NOT workspace data.
+    // Feedback records are workspace-scoped, so they must never be reachable via org-level access —
+    // only via a matching workspace permission.
+    test("denies a same-organization key with org-level write and no matching workspace permission", () => {
+      const ownerKey = makeApiKeyAuth({
         organizationAccess: { accessControl: { read: true, write: true } },
       });
 
       expect(
-        hasApiKeyImplicitFeedbackDirectoryAccess(
-          foreignKey,
-          DIRECTORY_ORG_ID,
-          [DIRECTORY_WORKSPACE_ID],
-          "read"
-        )
-      ).toBe(false);
-      expect(
-        hasApiKeyImplicitFeedbackDirectoryAccess(
-          foreignKey,
-          DIRECTORY_ORG_ID,
-          [DIRECTORY_WORKSPACE_ID],
-          "write"
-        )
-      ).toBe(false);
-    });
-
-    test("grants a same-organization key with org-level write, for read and write", () => {
-      const ownerKey = makeApiKeyAuth({
-        organizationAccess: { accessControl: { read: false, write: true } },
-      });
-
-      expect(
         hasApiKeyImplicitFeedbackDirectoryAccess(ownerKey, DIRECTORY_ORG_ID, [DIRECTORY_WORKSPACE_ID], "read")
-      ).toBe(true);
+      ).toBe(false);
       expect(
         hasApiKeyImplicitFeedbackDirectoryAccess(
           ownerKey,
@@ -55,25 +34,29 @@ describe("hasApiKeyImplicitFeedbackDirectoryAccess", () => {
           [DIRECTORY_WORKSPACE_ID],
           "write"
         )
-      ).toBe(true);
+      ).toBe(false);
     });
 
-    test("grants a same-organization key with org-level read only for read", () => {
-      const readerKey = makeApiKeyAuth({
-        organizationAccess: { accessControl: { read: true, write: false } },
+    test("denies a foreign-organization key regardless of org-level or workspace access (ENG-1980)", () => {
+      const foreignKey = makeApiKeyAuth({
+        organizationId: "org_attacker",
+        organizationAccess: { accessControl: { read: true, write: true } },
+        workspacePermissions: [
+          { workspaceId: DIRECTORY_WORKSPACE_ID, workspaceName: "Shared", permission: "manage" },
+        ],
       });
 
       expect(
         hasApiKeyImplicitFeedbackDirectoryAccess(
-          readerKey,
+          foreignKey,
           DIRECTORY_ORG_ID,
           [DIRECTORY_WORKSPACE_ID],
           "read"
         )
-      ).toBe(true);
+      ).toBe(false);
       expect(
         hasApiKeyImplicitFeedbackDirectoryAccess(
-          readerKey,
+          foreignKey,
           DIRECTORY_ORG_ID,
           [DIRECTORY_WORKSPACE_ID],
           "write"
@@ -100,27 +83,6 @@ describe("hasApiKeyImplicitFeedbackDirectoryAccess", () => {
           "write"
         )
       ).toBe(true);
-    });
-
-    test("denies a foreign-organization key even with a matching workspace permission (defense-in-depth, ENG-1980)", () => {
-      // Upstream (authenticateApiKeyFromHeaders) filters workspacePermissions to the key's own org,
-      // so this shape shouldn't occur in production — but the authz function must deny it on its own
-      // rather than rely on that invariant holding.
-      const foreignKey = makeApiKeyAuth({
-        organizationId: "org_attacker",
-        workspacePermissions: [
-          { workspaceId: DIRECTORY_WORKSPACE_ID, workspaceName: "Shared", permission: "manage" },
-        ],
-      });
-
-      expect(
-        hasApiKeyImplicitFeedbackDirectoryAccess(
-          foreignKey,
-          DIRECTORY_ORG_ID,
-          [DIRECTORY_WORKSPACE_ID],
-          "write"
-        )
-      ).toBe(false);
     });
 
     test("denies when the read-only workspace permission is below the required write weight", () => {

--- a/apps/web/modules/hub/feedback-records-gateway-authz.ts
+++ b/apps/web/modules/hub/feedback-records-gateway-authz.ts
@@ -21,15 +21,19 @@ const gatewayPermissionToApiKeyPermissionWeight: Record<TFeedbackRecordsGatewayP
 /**
  * Whether an API key may access a feedback directory's records.
  *
- * Both access paths — organization-level access control (`organizationAccess.accessControl`) and
- * the per-workspace permissions — require the key to belong to the directory's organization. A key
- * with access in organization A must never satisfy the check for a directory in organization B
- * (cross-tenant access, ENG-1980), so the organization match is enforced up front for both paths.
+ * Feedback records are workspace-scoped DATA, so access is granted solely by the key's per-workspace
+ * permissions (`workspacePermissions`) — never by `organizationAccess.accessControl`. That org-level
+ * flag governs organization MANAGEMENT (members, teams, roles), not workspace data: the API-key UI
+ * describes it as "Members and teams only — not workspace data", and every other consumer
+ * (`hasOrganizationAccess`, the org users/teams endpoints) uses it only for org-admin operations.
+ * Granting record access from it would let a members-management key read/write feedback data and
+ * would make the workspace-permission check below redundant, so it is deliberately not consulted.
  *
- * The workspace-permission path is already org-scoped upstream (a key's `workspacePermissions` only
- * contain workspaces in its own organization — see `authenticateApiKeyFromHeaders`), so a legitimate
- * workspace match already implies the same organization. Re-checking it here is defense-in-depth: it
- * keeps this decision correct on its own even if that upstream invariant ever regresses.
+ * Access additionally requires the key to belong to the directory's organization. The
+ * workspace-permission match already implies the same organization (a key's `workspacePermissions`
+ * only contain workspaces in its own org — see `authenticateApiKeyFromHeaders`), so the up-front
+ * organization check is defense-in-depth: it keeps this decision correct on its own, and prevents
+ * cross-tenant access (ENG-1980) even if that upstream invariant ever regresses.
  */
 export const hasApiKeyImplicitFeedbackDirectoryAccess = (
   authentication: TAuthenticationApiKey,
@@ -37,17 +41,9 @@ export const hasApiKeyImplicitFeedbackDirectoryAccess = (
   workspaceIds: string[],
   requiredPermission: TFeedbackRecordsGatewayPermission
 ): boolean => {
-  // The key must belong to the directory's organization for either path to grant access.
+  // The key must belong to the directory's organization.
   if (authentication.organizationId !== directoryOrganizationId) {
     return false;
-  }
-
-  const orgAccessControl = authentication.organizationAccess?.accessControl;
-  if (orgAccessControl?.write) {
-    return true;
-  }
-  if (orgAccessControl?.read && requiredPermission === "read") {
-    return true;
   }
 
   const matchingWeights = authentication.workspacePermissions

--- a/apps/web/modules/hub/feedback-records-gateway-authz.ts
+++ b/apps/web/modules/hub/feedback-records-gateway-authz.ts
@@ -1,0 +1,57 @@
+import type { ApiKeyPermission } from "@formbricks/database/prisma";
+import type { TAuthenticationApiKey } from "@formbricks/types/auth";
+
+// Pure authorization logic for the feedback records gateway. Kept free of server-only, Prisma, and
+// env imports so it can be unit-tested in isolation (the gateway module itself pulls in the full
+// request/DB/env stack).
+
+export type TFeedbackRecordsGatewayPermission = "read" | "write";
+
+const apiKeyPermissionWeight: Record<ApiKeyPermission, number> = {
+  read: 1,
+  write: 2,
+  manage: 3,
+};
+
+const gatewayPermissionToApiKeyPermissionWeight: Record<TFeedbackRecordsGatewayPermission, number> = {
+  read: apiKeyPermissionWeight.read,
+  write: apiKeyPermissionWeight.write,
+};
+
+/**
+ * Whether an API key may access a feedback directory's records.
+ *
+ * Organization-level access control (`organizationAccess.accessControl`) only grants access to
+ * directories in the API key's OWN organization. Without the org match, a key with org-level
+ * read/write in organization A would satisfy the check for a directory in organization B — a
+ * cross-tenant access path (ENG-1980). The workspace-permission path is already org-scoped by
+ * construction: a key's `workspacePermissions` only contain workspaces in its own organization, so
+ * the target directory's `workspaceIds` can never match a key from another organization.
+ */
+export const hasApiKeyImplicitFeedbackDirectoryAccess = (
+  authentication: TAuthenticationApiKey,
+  directoryOrganizationId: string,
+  workspaceIds: string[],
+  requiredPermission: TFeedbackRecordsGatewayPermission
+): boolean => {
+  if (authentication.organizationId === directoryOrganizationId) {
+    const orgAccessControl = authentication.organizationAccess?.accessControl;
+    if (orgAccessControl?.write) {
+      return true;
+    }
+    if (orgAccessControl?.read && requiredPermission === "read") {
+      return true;
+    }
+  }
+
+  const matchingWeights = authentication.workspacePermissions
+    .filter((permission) => workspaceIds.includes(permission.workspaceId))
+    .map((permission) => apiKeyPermissionWeight[permission.permission]);
+
+  if (matchingWeights.length === 0) {
+    return false;
+  }
+
+  const maxWeight = Math.max(...matchingWeights);
+  return maxWeight >= gatewayPermissionToApiKeyPermissionWeight[requiredPermission];
+};

--- a/apps/web/modules/hub/feedback-records-gateway-authz.ts
+++ b/apps/web/modules/hub/feedback-records-gateway-authz.ts
@@ -21,12 +21,15 @@ const gatewayPermissionToApiKeyPermissionWeight: Record<TFeedbackRecordsGatewayP
 /**
  * Whether an API key may access a feedback directory's records.
  *
- * Organization-level access control (`organizationAccess.accessControl`) only grants access to
- * directories in the API key's OWN organization. Without the org match, a key with org-level
- * read/write in organization A would satisfy the check for a directory in organization B — a
- * cross-tenant access path (ENG-1980). The workspace-permission path is already org-scoped by
- * construction: a key's `workspacePermissions` only contain workspaces in its own organization, so
- * the target directory's `workspaceIds` can never match a key from another organization.
+ * Both access paths — organization-level access control (`organizationAccess.accessControl`) and
+ * the per-workspace permissions — require the key to belong to the directory's organization. A key
+ * with access in organization A must never satisfy the check for a directory in organization B
+ * (cross-tenant access, ENG-1980), so the organization match is enforced up front for both paths.
+ *
+ * The workspace-permission path is already org-scoped upstream (a key's `workspacePermissions` only
+ * contain workspaces in its own organization — see `authenticateApiKeyFromHeaders`), so a legitimate
+ * workspace match already implies the same organization. Re-checking it here is defense-in-depth: it
+ * keeps this decision correct on its own even if that upstream invariant ever regresses.
  */
 export const hasApiKeyImplicitFeedbackDirectoryAccess = (
   authentication: TAuthenticationApiKey,
@@ -34,14 +37,17 @@ export const hasApiKeyImplicitFeedbackDirectoryAccess = (
   workspaceIds: string[],
   requiredPermission: TFeedbackRecordsGatewayPermission
 ): boolean => {
-  if (authentication.organizationId === directoryOrganizationId) {
-    const orgAccessControl = authentication.organizationAccess?.accessControl;
-    if (orgAccessControl?.write) {
-      return true;
-    }
-    if (orgAccessControl?.read && requiredPermission === "read") {
-      return true;
-    }
+  // The key must belong to the directory's organization for either path to grant access.
+  if (authentication.organizationId !== directoryOrganizationId) {
+    return false;
+  }
+
+  const orgAccessControl = authentication.organizationAccess?.accessControl;
+  if (orgAccessControl?.write) {
+    return true;
+  }
+  if (orgAccessControl?.read && requiredPermission === "read") {
+    return true;
   }
 
   const matchingWeights = authentication.workspacePermissions

--- a/apps/web/modules/hub/feedback-records-gateway.ts
+++ b/apps/web/modules/hub/feedback-records-gateway.ts
@@ -1,9 +1,7 @@
 import "server-only";
 import { NextRequest } from "next/server";
 import { z } from "zod";
-import { ApiKeyPermission } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
-import { TAuthenticationApiKey } from "@formbricks/types/auth";
 import { ZId } from "@formbricks/types/common";
 import { AuthorizationError } from "@formbricks/types/errors";
 import { RequestBodyTooLargeError, readRequestBodyWithLimit } from "@/app/lib/api/request-body";
@@ -18,13 +16,16 @@ import {
   allowGatewayRequest,
   buildGatewayStatusResponse,
 } from "@/modules/gateway-auth/lib/request";
+import {
+  type TFeedbackRecordsGatewayPermission,
+  hasApiKeyImplicitFeedbackDirectoryAccess,
+} from "@/modules/hub/feedback-records-gateway-authz";
 import { getFeedbackRecordTenant } from "@/modules/hub/service";
 
 const FEEDBACK_RECORDS_V3_PREFIX = "/api/v3/feedbackRecords";
 const FEEDBACK_RECORDS_SDK_PREFIX = "/v1/feedback-records";
 const ZFeedbackRecordId = z.uuid();
 
-type TFeedbackRecordsGatewayPermission = "read" | "write";
 type TFeedbackRecordsGatewayOperation =
   | "list"
   | "create"
@@ -40,17 +41,6 @@ type TParsedGatewayRoute = {
   requiredPermission: TFeedbackRecordsGatewayPermission;
   recordId?: string;
   tenantSource: "query" | "body" | "recordLookup";
-};
-
-const apiKeyPermissionWeight: Record<ApiKeyPermission, number> = {
-  read: 1,
-  write: 2,
-  manage: 3,
-};
-
-const gatewayPermissionToApiKeyPermissionWeight: Record<TFeedbackRecordsGatewayPermission, number> = {
-  read: apiKeyPermissionWeight.read,
-  write: apiKeyPermissionWeight.write,
 };
 
 const stripFeedbackRecordsPrefix = (pathname: string, prefix: string): string | null => {
@@ -184,31 +174,6 @@ const getFeedbackRecordsGatewayJwtFromHeaders = (headers: Headers): string | nul
   return getBearerTokenFromHeaders(headers);
 };
 
-const hasApiKeyImplicitFeedbackDirectoryAccess = (
-  authentication: TAuthenticationApiKey,
-  workspaceIds: string[],
-  requiredPermission: TFeedbackRecordsGatewayPermission
-): boolean => {
-  const orgAccessControl = authentication.organizationAccess?.accessControl;
-  if (orgAccessControl?.write) {
-    return true;
-  }
-  if (orgAccessControl?.read && requiredPermission === "read") {
-    return true;
-  }
-
-  const matchingWeights = authentication.workspacePermissions
-    .filter((permission) => workspaceIds.includes(permission.workspaceId))
-    .map((permission) => apiKeyPermissionWeight[permission.permission]);
-
-  if (matchingWeights.length === 0) {
-    return false;
-  }
-
-  const maxWeight = Math.max(...matchingWeights);
-  return maxWeight >= gatewayPermissionToApiKeyPermissionWeight[requiredPermission];
-};
-
 const resolveTenantId = async (
   request: NextRequest,
   route: TParsedGatewayRoute,
@@ -298,6 +263,7 @@ const authorizeFeedbackRecordsGatewayRequest = async (
   if (principal.type === "apiKey") {
     return hasApiKeyImplicitFeedbackDirectoryAccess(
       principal.authentication,
+      feedbackDirectory.organizationId,
       feedbackDirectory.workspaceIds,
       requiredPermission
     )

--- a/apps/web/modules/traefik-auth/service.test.ts
+++ b/apps/web/modules/traefik-auth/service.test.ts
@@ -136,8 +136,8 @@ describe("authorizeTraefikRequest", () => {
       type: "apiKey",
       apiKeyId: "key_1",
       organizationId: "org_1",
-      organizationAccess: { accessControl: { read: true, write: true } },
-      workspacePermissions: [],
+      organizationAccess: { accessControl: { read: false, write: false } },
+      workspacePermissions: [{ workspaceId: "workspace_1", workspaceName: "Linked", permission: "manage" }],
     });
 
     const response = await authorizeTraefikRequest(
@@ -163,8 +163,8 @@ describe("authorizeTraefikRequest", () => {
       type: "apiKey",
       apiKeyId: "key_1",
       organizationId: "org_1",
-      organizationAccess: { accessControl: { read: true, write: true } },
-      workspacePermissions: [],
+      organizationAccess: { accessControl: { read: false, write: false } },
+      workspacePermissions: [{ workspaceId: "workspace_1", workspaceName: "Linked", permission: "manage" }],
     });
 
     const response = await authorizeTraefikRequest(


### PR DESCRIPTION
## What & why

The feedback records gateway (`apps/web/modules/hub/feedback-records-gateway.ts`) authorized API-key requests against the target feedback directory, but the org-level shortcut in `hasApiKeyImplicitFeedbackDirectoryAccess` returned `true` whenever the key had org-level access control (`organizationAccess.accessControl.read`/`write`) — **without checking that the key's organization matched the directory's organization**.

So an API key with org-level read/write in organization **A** could read or write feedback records for a directory in organization **B** if the directory (tenant) id was known — a cross-tenant access path.

**Fix — API-key feedback-record access now comes solely from the key's per-workspace permissions (`workspacePermissions`); the org-level `organizationAccess.accessControl` flag is no longer consulted at all.** That flag governs organization **management** (members, teams, roles), not workspace data — the API-key UI describes it as *"Members and teams only — not workspace data"* (`apps/web/locales/en-US.json`), and every other consumer (`hasOrganizationAccess`, `/api/v2/me`, the org users/teams endpoints) uses it only for org-admin operations. Granting record access from it would let a members-management key read/write feedback data. This also lines the gateway up with the v3 API-key model, which is already workspace-permissions-only (`apps/web/app/api/v3/lib/auth.ts`).

As defense-in-depth, access additionally requires `authentication.organizationId === directory.organizationId`. A matching workspace permission already implies the same organization (a key's `workspacePermissions` only ever contain workspaces in its own org — see `authenticateApiKeyFromHeaders`, ENG-1749), so the two layers are independent: the org-id check keeps the decision correct on its own and blocks cross-tenant access even if that upstream invariant ever regresses. Unknown permission values fail closed (`Math.max()` of an empty set → `-Infinity` → denied).

To make this security-critical decision unit-testable, the pure logic (`hasApiKeyImplicitFeedbackDirectoryAccess` + its permission-weight tables) is extracted into `feedback-records-gateway-authz.ts`, free of `server-only`/Prisma/env imports. The gateway imports it back; the session (user) authorization branch is unchanged.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1980/bind-feedback-records-gateway-api-key-access-to-target-organization

Related: ENG-1972 (source report).

## How this was tested

- `pnpm vitest run modules/hub/feedback-records-gateway-authz.test.ts` ✅ (org-level access never grants; foreign-org denied; workspace-permission grants for read/write/manage; insufficient weight and no-match denied)
- `pnpm typecheck` ✅ touched files (`feedback-records-gateway*.ts`) are error-free
- `eslint --no-fix` + `prettier --check` on all touched files ✅ clean

Tests added: org-level write with no matching workspace permission → **denied** (read and write); foreign-org key with a matching workspace `manage` permission → **denied** (ENG-1980); workspace `write` → write allowed; workspace `read` → read allowed; workspace `manage` → write allowed; workspace `read` → write denied (insufficient weight); no matching workspace → denied.

## QA / Test Plan

**How to test**

- [ ] As org A, create an API key with a **workspace permission** on a workspace assigned to a feedback directory in org A. Call the gateway for that directory (e.g. `GET /api/v3/feedbackRecords?tenant_id=<orgA_directory_id>`, and a `POST`/`PATCH`/`DELETE`) → **allowed** per the permission level (`write`/`manage` for mutations, `read` for reads).
- [ ] Same key, a directory in **org B** (known directory id) → **403 Forbidden**; no records returned or mutated (ENG-1980 cross-tenant path).
- [ ] Org-level access-control key (read and/or write) with **no** workspace permission on the target directory's workspace → **403** for both read and write. Org-level access no longer grants feedback-record access.
- [ ] Workspace `read`-only permission on a write op (`POST`/`PATCH`/`DELETE`) → **403**; on a read op (`GET`) → **allowed**.
- [ ] Regression: user (session) principal access is unchanged — owners/managers and workspace-team members of the directory's org still authorized as before.

**Preconditions / test data**

- Two organizations (A, B), each with at least one feedback directory that has **≥1 assigned workspace**; feedback directories license/entitlement enabled.
- An org-A API key scoped to a workspace shared with the target directory, and an org-A API key with org-level access control but no matching workspace permission.
- A known org-B feedback directory id for the cross-tenant attempt.

**Risks & regressions**

- **Behavioral tightening (intended):** same-org API keys that relied on **org-level** access control to reach feedback records now get **403** — access requires a matching workspace permission. This is a deliberate correction; any integration built against the old org-level behavior must be granted the appropriate workspace permission.
- **Accepted side effect:** a feedback directory with **zero assigned workspaces** is unreachable by every API key (read and write), since access derives solely from workspace permissions. `workspaceIds` is optional on directory create/update, so this state is reachable from the UI. Blast radius is small — the composite FK on `FeedbackSource` means such a directory can't have sources and therefore no ingested records — but `POST /api/v3/feedbackRecords` into a not-yet-assigned directory returns 403. Session users still reach it via the org owner/manager branch. Accepted for this fix; assigning ≥1 workspace resolves it.
- No change to gateway routing, tenant resolution, JWT verification, or the user/session authorization branch.

**Migrations / env / cutover**

- none
