### PR TITLE
refactor: route authorization checks through central interface

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/actions.test.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/actions.test.ts
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthorizationError, OperationNotAllowedError } from "@formbricks/types/errors";
-import { updateOrganizationAISettingsAction } from "./actions";
+import {
+  deleteOrganizationAction,
+  updateOrganizationAISettingsAction,
+  updateOrganizationNameAction,
+} from "./actions";
 import { ZOrganizationAISettingsInput } from "./schemas";
 
 const mocks = vi.hoisted(() => ({
   isInstanceAIConfigured: vi.fn(),
-  checkAuthorizationUpdated: vi.fn(),
+  assertCan: vi.fn(),
   deleteOrganization: vi.fn(),
   getOrganization: vi.fn(),
   getIsMultiOrgEnabled: vi.fn(),
@@ -21,8 +25,8 @@ vi.mock("@/lib/utils/action-client", () => ({
   },
 }));
 
-vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
-  checkAuthorizationUpdated: mocks.checkAuthorizationUpdated,
+vi.mock("@/lib/authorization", () => ({
+  assertCan: mocks.assertCan,
 }));
 
 vi.mock("@/lib/organization/service", () => ({
@@ -53,7 +57,7 @@ describe("organization AI settings actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mocks.checkAuthorizationUpdated.mockResolvedValue(undefined);
+    mocks.assertCan.mockResolvedValue(undefined);
     mocks.getOrganization.mockResolvedValue({
       id: organizationId,
       isAISmartToolsEnabled: false,
@@ -79,7 +83,7 @@ describe("organization AI settings actions", () => {
     });
   });
 
-  test("passes owner and manager roles to the authorization check and updates organization settings", async () => {
+  test("requires organization.manage and updates organization settings", async () => {
     const ctx = {
       user: { id: "user_1", locale: "en-US" },
       auditLoggingCtx: {},
@@ -93,17 +97,9 @@ describe("organization AI settings actions", () => {
 
     const result = await updateOrganizationAISettingsAction({ ctx, parsedInput } as any);
 
-    expect(mocks.checkAuthorizationUpdated).toHaveBeenCalledWith({
-      userId: "user_1",
-      organizationId,
-      access: [
-        {
-          type: "organization",
-          schema: ZOrganizationAISettingsInput,
-          data: parsedInput.data,
-          roles: ["owner", "manager"],
-        },
-      ],
+    expect(mocks.assertCan).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "organization.manage", {
+      type: "organization",
+      id: organizationId,
     });
     expect(mocks.getOrganization).toHaveBeenCalledWith(organizationId);
     expect(mocks.updateOrganization).toHaveBeenCalledWith(organizationId, parsedInput.data);
@@ -125,7 +121,7 @@ describe("organization AI settings actions", () => {
   });
 
   test("propagates authorization failures so members cannot update AI settings", async () => {
-    mocks.checkAuthorizationUpdated.mockRejectedValueOnce(new AuthorizationError("Not authorized"));
+    mocks.assertCan.mockRejectedValueOnce(new AuthorizationError("Not authorized"));
 
     await expect(
       updateOrganizationAISettingsAction({
@@ -143,6 +139,44 @@ describe("organization AI settings actions", () => {
     ).rejects.toThrow(AuthorizationError);
 
     expect(mocks.updateOrganization).not.toHaveBeenCalled();
+  });
+
+  test("requires organization.write for organization name updates", async () => {
+    const ctx = {
+      user: { id: "user_owner", locale: "en-US" },
+      auditLoggingCtx: {},
+    };
+
+    await updateOrganizationNameAction({
+      ctx,
+      parsedInput: {
+        organizationId,
+        data: { name: "Renamed organization" },
+      },
+    } as never);
+
+    expect(mocks.assertCan).toHaveBeenCalledWith({ type: "user", id: "user_owner" }, "organization.write", {
+      type: "organization",
+      id: organizationId,
+    });
+  });
+
+  test("requires organization.write for organization deletion", async () => {
+    const ctx = {
+      user: { id: "user_owner", locale: "en-US" },
+      auditLoggingCtx: {},
+    };
+
+    await deleteOrganizationAction({
+      ctx,
+      parsedInput: { organizationId },
+    } as never);
+
+    expect(mocks.assertCan).toHaveBeenCalledWith({ type: "user", id: "user_owner" }, "organization.write", {
+      type: "organization",
+      id: organizationId,
+    });
+    expect(mocks.deleteOrganization).toHaveBeenCalledWith(organizationId);
   });
 
   test("rejects enabling AI when the instance AI provider is not configured", async () => {

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/actions.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/general/actions.ts
@@ -3,12 +3,11 @@
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
-import type { TOrganizationRole } from "@formbricks/types/memberships";
 import { ZOrganizationUpdateInput } from "@formbricks/types/organizations";
 import { isInstanceAIConfigured } from "@/lib/ai/service";
+import { type TAuthorizationAction, assertCan } from "@/lib/authorization";
 import { deleteOrganization, getOrganization, updateOrganization } from "@/lib/organization/service";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { AuthenticatedActionClientCtx } from "@/lib/utils/action-client/types/context";
 import { getTranslate } from "@/lingodotdev/server";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
@@ -18,21 +17,15 @@ import { ZOrganizationAISettingsInput, ZUpdateOrganizationAISettingsAction } fro
 async function updateOrganizationAction<T extends z.ZodRawShape>({
   ctx,
   organizationId,
-  schema,
   data,
-  roles,
+  action,
 }: {
   ctx: AuthenticatedActionClientCtx;
   organizationId: string;
-  schema: z.ZodObject<T>;
   data: z.infer<z.ZodObject<T>>;
-  roles: TOrganizationRole[];
+  action: Extract<TAuthorizationAction, "organization.write" | "organization.manage">;
 }) {
-  await checkAuthorizationUpdated({
-    userId: ctx.user.id,
-    organizationId,
-    access: [{ type: "organization", schema, data, roles }],
-  });
+  await assertCan({ type: "user", id: ctx.user.id }, action, { type: "organization", id: organizationId });
   ctx.auditLoggingCtx.organizationId = organizationId;
   const oldObject = await getOrganization(organizationId);
   const result = await updateOrganization(organizationId, data);
@@ -62,9 +55,8 @@ export const updateOrganizationNameAction = authenticatedActionClient
         updateOrganizationAction({
           ctx,
           organizationId: parsedInput.organizationId,
-          schema: ZOrganizationUpdateInput.pick({ name: true }),
           data: parsedInput.data,
-          roles: ["owner"],
+          action: "organization.write",
         })
     )
   );
@@ -144,9 +136,8 @@ export const updateOrganizationAISettingsAction = authenticatedActionClient
         return updateOrganizationAction({
           ctx,
           organizationId: parsedInput.organizationId,
-          schema: ZOrganizationAISettingsInput,
           data: parsedInput.data,
-          roles: ["owner", "manager"],
+          action: "organization.manage",
         });
       }
     )
@@ -166,15 +157,9 @@ export const deleteOrganizationAction = authenticatedActionClient
         throw new OperationNotAllowedError(t("workspace.settings.general.organization_deletion_disabled"));
       }
 
-      await checkAuthorizationUpdated({
-        userId: ctx.user.id,
-        organizationId: parsedInput.organizationId,
-        access: [
-          {
-            type: "organization",
-            roles: ["owner"],
-          },
-        ],
+      await assertCan({ type: "user", id: ctx.user.id }, "organization.write", {
+        type: "organization",
+        id: parsedInput.organizationId,
       });
       ctx.auditLoggingCtx.organizationId = parsedInput.organizationId;
       const oldObject = await getOrganization(parsedInput.organizationId);

--- a/apps/web/app/api/v3/lib/auth.test.ts
+++ b/apps/web/app/api/v3/lib/auth.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ApiKeyPermission } from "@formbricks/database/prisma";
 import { AuthorizationError } from "@formbricks/types/errors";
-import { assertCan } from "@/lib/authorization";
+import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { getWorkspace } from "@/lib/workspace/service";
 import { requireSessionWorkspaceAccess, requireV3WorkspaceAccess } from "./auth";
@@ -23,8 +23,8 @@ vi.mock("@/lib/workspace/service", () => ({
   getWorkspace: vi.fn(),
 }));
 
-vi.mock("@/lib/authorization", () => ({
-  assertCan: vi.fn(),
+vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
+  checkAuthorizationUpdated: vi.fn(),
 }));
 
 const requestId = "req-123";
@@ -40,7 +40,7 @@ describe("requireSessionWorkspaceAccess", () => {
     expect(body.status).toBe(401);
     expect(body.code).toBe("not_authenticated");
     expect(getWorkspace).not.toHaveBeenCalled();
-    expect(assertCan).not.toHaveBeenCalled();
+    expect(checkAuthorizationUpdated).not.toHaveBeenCalled();
   });
 
   test("returns 401 when authentication is API key (no user)", async () => {
@@ -73,13 +73,13 @@ describe("requireSessionWorkspaceAccess", () => {
     expect(body.requestId).toBe(requestId);
     expect(body.code).toBe("forbidden");
     expect(getWorkspace).toHaveBeenCalledWith("ws_nonexistent");
-    expect(assertCan).not.toHaveBeenCalled();
+    expect(checkAuthorizationUpdated).not.toHaveBeenCalled();
   });
 
   test("returns 403 when user has no access to workspace", async () => {
     vi.mocked(getWorkspace).mockResolvedValueOnce({ id: "proj_abc" } as any);
     vi.mocked(getOrganizationIdFromWorkspaceId).mockResolvedValueOnce("org_1");
-    vi.mocked(assertCan).mockRejectedValueOnce(new AuthorizationError("Not authorized"));
+    vi.mocked(checkAuthorizationUpdated).mockRejectedValueOnce(new AuthorizationError("Not authorized"));
     const result = await requireSessionWorkspaceAccess(
       { user: { id: "user_1" }, expires: "" } as any,
       "proj_abc",
@@ -91,16 +91,20 @@ describe("requireSessionWorkspaceAccess", () => {
     const body = await (result as Response).json();
     expect(body.requestId).toBe(requestId);
     expect(body.code).toBe("forbidden");
-    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "workspace.read", {
-      type: "workspace",
-      id: "proj_abc",
+    expect(checkAuthorizationUpdated).toHaveBeenCalledWith({
+      userId: "user_1",
+      organizationId: "org_1",
+      access: [
+        { type: "organization", roles: ["owner", "manager"] },
+        { type: "workspaceTeam", workspaceId: "proj_abc", minPermission: "read" },
+      ],
     });
   });
 
   test("returns workspace context when session is valid and user has access", async () => {
     vi.mocked(getWorkspace).mockResolvedValueOnce({ id: "proj_abc" } as any);
     vi.mocked(getOrganizationIdFromWorkspaceId).mockResolvedValueOnce("org_1");
-    vi.mocked(assertCan).mockResolvedValueOnce(undefined);
+    vi.mocked(checkAuthorizationUpdated).mockResolvedValueOnce(undefined as any);
     const result = await requireSessionWorkspaceAccess(
       { user: { id: "user_1" }, expires: "" } as any,
       "proj_abc",
@@ -112,9 +116,13 @@ describe("requireSessionWorkspaceAccess", () => {
       workspaceId: "proj_abc",
       organizationId: "org_1",
     });
-    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "workspace.write", {
-      type: "workspace",
-      id: "proj_abc",
+    expect(checkAuthorizationUpdated).toHaveBeenCalledWith({
+      userId: "user_1",
+      organizationId: "org_1",
+      access: [
+        { type: "organization", roles: ["owner", "manager"] },
+        { type: "workspaceTeam", workspaceId: "proj_abc", minPermission: "readWrite" },
+      ],
     });
   });
 });
@@ -148,7 +156,7 @@ describe("requireV3WorkspaceAccess", () => {
   test("delegates to session flow when user is present", async () => {
     vi.mocked(getWorkspace).mockResolvedValueOnce({ id: "proj_s" } as any);
     vi.mocked(getOrganizationIdFromWorkspaceId).mockResolvedValueOnce("org_s");
-    vi.mocked(assertCan).mockResolvedValueOnce(undefined);
+    vi.mocked(checkAuthorizationUpdated).mockResolvedValueOnce(undefined as any);
     const r = await requireV3WorkspaceAccess(
       { user: { id: "user_1" }, expires: "" } as any,
       "proj_s",

--- a/apps/web/app/api/v3/lib/auth.test.ts
+++ b/apps/web/app/api/v3/lib/auth.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ApiKeyPermission } from "@formbricks/database/prisma";
 import { AuthorizationError } from "@formbricks/types/errors";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
+import { assertCan } from "@/lib/authorization";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { getWorkspace } from "@/lib/workspace/service";
 import { requireSessionWorkspaceAccess, requireV3WorkspaceAccess } from "./auth";
@@ -23,8 +23,8 @@ vi.mock("@/lib/workspace/service", () => ({
   getWorkspace: vi.fn(),
 }));
 
-vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
-  checkAuthorizationUpdated: vi.fn(),
+vi.mock("@/lib/authorization", () => ({
+  assertCan: vi.fn(),
 }));
 
 const requestId = "req-123";
@@ -40,7 +40,7 @@ describe("requireSessionWorkspaceAccess", () => {
     expect(body.status).toBe(401);
     expect(body.code).toBe("not_authenticated");
     expect(getWorkspace).not.toHaveBeenCalled();
-    expect(checkAuthorizationUpdated).not.toHaveBeenCalled();
+    expect(assertCan).not.toHaveBeenCalled();
   });
 
   test("returns 401 when authentication is API key (no user)", async () => {
@@ -73,13 +73,13 @@ describe("requireSessionWorkspaceAccess", () => {
     expect(body.requestId).toBe(requestId);
     expect(body.code).toBe("forbidden");
     expect(getWorkspace).toHaveBeenCalledWith("ws_nonexistent");
-    expect(checkAuthorizationUpdated).not.toHaveBeenCalled();
+    expect(assertCan).not.toHaveBeenCalled();
   });
 
   test("returns 403 when user has no access to workspace", async () => {
     vi.mocked(getWorkspace).mockResolvedValueOnce({ id: "proj_abc" } as any);
     vi.mocked(getOrganizationIdFromWorkspaceId).mockResolvedValueOnce("org_1");
-    vi.mocked(checkAuthorizationUpdated).mockRejectedValueOnce(new AuthorizationError("Not authorized"));
+    vi.mocked(assertCan).mockRejectedValueOnce(new AuthorizationError("Not authorized"));
     const result = await requireSessionWorkspaceAccess(
       { user: { id: "user_1" }, expires: "" } as any,
       "proj_abc",
@@ -91,20 +91,16 @@ describe("requireSessionWorkspaceAccess", () => {
     const body = await (result as Response).json();
     expect(body.requestId).toBe(requestId);
     expect(body.code).toBe("forbidden");
-    expect(checkAuthorizationUpdated).toHaveBeenCalledWith({
-      userId: "user_1",
-      organizationId: "org_1",
-      access: [
-        { type: "organization", roles: ["owner", "manager"] },
-        { type: "workspaceTeam", workspaceId: "proj_abc", minPermission: "read" },
-      ],
+    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "workspace.read", {
+      type: "workspace",
+      id: "proj_abc",
     });
   });
 
   test("returns workspace context when session is valid and user has access", async () => {
     vi.mocked(getWorkspace).mockResolvedValueOnce({ id: "proj_abc" } as any);
     vi.mocked(getOrganizationIdFromWorkspaceId).mockResolvedValueOnce("org_1");
-    vi.mocked(checkAuthorizationUpdated).mockResolvedValueOnce(undefined as any);
+    vi.mocked(assertCan).mockResolvedValueOnce(undefined);
     const result = await requireSessionWorkspaceAccess(
       { user: { id: "user_1" }, expires: "" } as any,
       "proj_abc",
@@ -116,13 +112,9 @@ describe("requireSessionWorkspaceAccess", () => {
       workspaceId: "proj_abc",
       organizationId: "org_1",
     });
-    expect(checkAuthorizationUpdated).toHaveBeenCalledWith({
-      userId: "user_1",
-      organizationId: "org_1",
-      access: [
-        { type: "organization", roles: ["owner", "manager"] },
-        { type: "workspaceTeam", workspaceId: "proj_abc", minPermission: "readWrite" },
-      ],
+    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "workspace.write", {
+      type: "workspace",
+      id: "proj_abc",
     });
   });
 });
@@ -156,7 +148,7 @@ describe("requireV3WorkspaceAccess", () => {
   test("delegates to session flow when user is present", async () => {
     vi.mocked(getWorkspace).mockResolvedValueOnce({ id: "proj_s" } as any);
     vi.mocked(getOrganizationIdFromWorkspaceId).mockResolvedValueOnce("org_s");
-    vi.mocked(checkAuthorizationUpdated).mockResolvedValueOnce(undefined as any);
+    vi.mocked(assertCan).mockResolvedValueOnce(undefined);
     const r = await requireV3WorkspaceAccess(
       { user: { id: "user_1" }, expires: "" } as any,
       "proj_s",

--- a/apps/web/app/api/v3/lib/auth.ts
+++ b/apps/web/app/api/v3/lib/auth.ts
@@ -5,7 +5,8 @@ import { ApiKeyPermission } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import type { TAuthenticationApiKey } from "@formbricks/types/auth";
 import { AuthorizationError, ResourceNotFoundError } from "@formbricks/types/errors";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
+import { assertCan } from "@/lib/authorization";
+import { getWorkspaceActionForPermission } from "@/lib/authorization/compatibility";
 import type { TTeamPermission } from "@/modules/ee/teams/workspace-teams/types/team";
 import { problemForbidden, problemUnauthorized } from "./response";
 import type { TV3Authentication } from "./types";
@@ -55,14 +56,9 @@ export async function requireSessionWorkspaceAccess(
     // Resolve workspaceId → workspaceId, organizationId (single place to change when Workspace exists).
     const context = await resolveV3WorkspaceContext(workspaceId);
 
-    // Org + workspace-team access; we use internal IDs from context.
-    await checkAuthorizationUpdated({
-      userId,
-      organizationId: context.organizationId,
-      access: [
-        { type: "organization", roles: ["owner", "manager"] },
-        { type: "workspaceTeam", workspaceId: context.workspaceId, minPermission },
-      ],
+    await assertCan({ type: "user", id: userId }, getWorkspaceActionForPermission(minPermission), {
+      type: "workspace",
+      id: context.workspaceId,
     });
 
     return context;

--- a/apps/web/app/api/v3/lib/auth.ts
+++ b/apps/web/app/api/v3/lib/auth.ts
@@ -5,8 +5,7 @@ import { ApiKeyPermission } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import type { TAuthenticationApiKey } from "@formbricks/types/auth";
 import { AuthorizationError, ResourceNotFoundError } from "@formbricks/types/errors";
-import { assertCan } from "@/lib/authorization";
-import { getWorkspaceActionForPermission } from "@/lib/authorization/compatibility";
+import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import type { TTeamPermission } from "@/modules/ee/teams/workspace-teams/types/team";
 import { problemForbidden, problemUnauthorized } from "./response";
 import type { TV3Authentication } from "./types";
@@ -56,9 +55,13 @@ export async function requireSessionWorkspaceAccess(
     // Resolve workspaceId → workspaceId, organizationId (single place to change when Workspace exists).
     const context = await resolveV3WorkspaceContext(workspaceId);
 
-    await assertCan({ type: "user", id: userId }, getWorkspaceActionForPermission(minPermission), {
-      type: "workspace",
-      id: context.workspaceId,
+    await checkAuthorizationUpdated({
+      userId,
+      organizationId: context.organizationId,
+      access: [
+        { type: "organization", roles: ["owner", "manager"] },
+        { type: "workspaceTeam", workspaceId: context.workspaceId, minPermission },
+      ],
     });
 
     return context;

--- a/apps/web/lib/auth.test.ts
+++ b/apps/web/lib/auth.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { prisma } from "@formbricks/database";
 import { AuthenticationError } from "@formbricks/types/errors";
+import { can } from "@/lib/authorization";
 import {
   hasOrganizationAccess,
   hasOrganizationAuthority,
@@ -13,13 +13,8 @@ import {
 
 const PASSWORD_TEST_TIMEOUT_MS = 30_000;
 
-// Mock prisma
-vi.mock("@formbricks/database", () => ({
-  prisma: {
-    membership: {
-      findUnique: vi.fn(),
-    },
-  },
+vi.mock("@/lib/authorization", () => ({
+  can: vi.fn(),
 }));
 
 describe("Password Management", () => {
@@ -66,79 +61,61 @@ describe("Organization Access", () => {
   });
 
   test("hasOrganizationAccess should return true when user has membership", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue({
-      userId: mockUserId,
-      organizationId: mockOrgId,
-      role: "member",
-      accepted: true,
-    });
+    vi.mocked(can).mockResolvedValue(true);
 
     const hasAccess = await hasOrganizationAccess(mockUserId, mockOrgId);
     expect(hasAccess).toBe(true);
+    expect(can).toHaveBeenCalledWith({ type: "user", id: mockUserId }, "organization.read", {
+      type: "organization",
+      id: mockOrgId,
+    });
   });
 
   test("hasOrganizationAccess should return false when user has no membership", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue(null);
+    vi.mocked(can).mockResolvedValue(false);
 
     const hasAccess = await hasOrganizationAccess(mockUserId, mockOrgId);
     expect(hasAccess).toBe(false);
   });
 
   test("isManagerOrOwner should return true for manager role", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue({
-      userId: mockUserId,
-      organizationId: mockOrgId,
-      role: "manager",
-      accepted: true,
-    });
+    vi.mocked(can).mockResolvedValue(true);
 
     const isManager = await isManagerOrOwner(mockUserId, mockOrgId);
     expect(isManager).toBe(true);
+    expect(can).toHaveBeenCalledWith({ type: "user", id: mockUserId }, "organization.manage", {
+      type: "organization",
+      id: mockOrgId,
+    });
   });
 
   test("isManagerOrOwner should return true for owner role", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue({
-      userId: mockUserId,
-      organizationId: mockOrgId,
-      role: "owner",
-      accepted: true,
-    });
+    vi.mocked(can).mockResolvedValue(true);
 
     const isOwner = await isManagerOrOwner(mockUserId, mockOrgId);
     expect(isOwner).toBe(true);
   });
 
   test("isManagerOrOwner should return false for member role", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue({
-      userId: mockUserId,
-      organizationId: mockOrgId,
-      role: "member",
-      accepted: true,
-    });
+    vi.mocked(can).mockResolvedValue(false);
 
     const isManagerOrOwnerRole = await isManagerOrOwner(mockUserId, mockOrgId);
     expect(isManagerOrOwnerRole).toBe(false);
   });
 
   test("isOwner should return true only for owner role", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue({
-      userId: mockUserId,
-      organizationId: mockOrgId,
-      role: "owner",
-      accepted: true,
-    });
+    vi.mocked(can).mockResolvedValue(true);
 
     const isOwnerRole = await isOwner(mockUserId, mockOrgId);
     expect(isOwnerRole).toBe(true);
+    expect(can).toHaveBeenCalledWith({ type: "user", id: mockUserId }, "organization.write", {
+      type: "organization",
+      id: mockOrgId,
+    });
   });
 
   test("isOwner should return false for non-owner roles", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue({
-      userId: mockUserId,
-      organizationId: mockOrgId,
-      role: "manager",
-      accepted: true,
-    });
+    vi.mocked(can).mockResolvedValue(false);
 
     const isOwnerRole = await isOwner(mockUserId, mockOrgId);
     expect(isOwnerRole).toBe(false);
@@ -154,59 +131,39 @@ describe("Organization Authority", () => {
   });
 
   test("hasOrganizationAuthority should return true for manager", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue({
-      userId: mockUserId,
-      organizationId: mockOrgId,
-      role: "manager",
-      accepted: true,
-    });
+    vi.mocked(can).mockResolvedValue(true);
 
     const hasAuthority = await hasOrganizationAuthority(mockUserId, mockOrgId);
     expect(hasAuthority).toBe(true);
   });
 
   test("hasOrganizationAuthority should throw for non-member", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue(null);
+    vi.mocked(can).mockResolvedValue(false);
 
     await expect(hasOrganizationAuthority(mockUserId, mockOrgId)).rejects.toThrow(AuthenticationError);
   });
 
   test("hasOrganizationAuthority should throw for member role", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue({
-      userId: mockUserId,
-      organizationId: mockOrgId,
-      role: "member",
-      accepted: true,
-    });
+    vi.mocked(can).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
 
     await expect(hasOrganizationAuthority(mockUserId, mockOrgId)).rejects.toThrow(AuthenticationError);
   });
 
   test("hasOrganizationOwnership should return true for owner", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue({
-      userId: mockUserId,
-      organizationId: mockOrgId,
-      role: "owner",
-      accepted: true,
-    });
+    vi.mocked(can).mockResolvedValue(true);
 
     const hasOwnership = await hasOrganizationOwnership(mockUserId, mockOrgId);
     expect(hasOwnership).toBe(true);
   });
 
   test("hasOrganizationOwnership should throw for non-member", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue(null);
+    vi.mocked(can).mockResolvedValue(false);
 
     await expect(hasOrganizationOwnership(mockUserId, mockOrgId)).rejects.toThrow(AuthenticationError);
   });
 
   test("hasOrganizationOwnership should throw for non-owner roles", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue({
-      userId: mockUserId,
-      organizationId: mockOrgId,
-      role: "manager",
-      accepted: true,
-    });
+    vi.mocked(can).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
 
     await expect(hasOrganizationOwnership(mockUserId, mockOrgId)).rejects.toThrow(AuthenticationError);
   });

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -1,6 +1,7 @@
+import "server-only";
 import { compare, hash } from "bcryptjs";
-import { prisma } from "@formbricks/database";
 import { AuthenticationError } from "@formbricks/types/errors";
+import { can } from "@/lib/authorization";
 
 export const hashPassword = async (password: string) => {
   const hashedPassword = await hash(password, 12);
@@ -12,52 +13,14 @@ export const verifyPassword = async (password: string, hashedPassword: string) =
   return isValid;
 };
 
-export const hasOrganizationAccess = async (userId: string, organizationId: string): Promise<boolean> => {
-  const membership = await prisma.membership.findUnique({
-    where: {
-      userId_organizationId: {
-        userId,
-        organizationId,
-      },
-    },
-  });
+export const hasOrganizationAccess = (userId: string, organizationId: string): Promise<boolean> =>
+  can({ type: "user", id: userId }, "organization.read", { type: "organization", id: organizationId });
 
-  return !!membership;
-};
+export const isManagerOrOwner = (userId: string, organizationId: string): Promise<boolean> =>
+  can({ type: "user", id: userId }, "organization.manage", { type: "organization", id: organizationId });
 
-export const isManagerOrOwner = async (userId: string, organizationId: string) => {
-  const membership = await prisma.membership.findUnique({
-    where: {
-      userId_organizationId: {
-        userId,
-        organizationId,
-      },
-    },
-  });
-
-  if (membership && (membership.role === "owner" || membership.role === "manager")) {
-    return true;
-  }
-
-  return false;
-};
-
-export const isOwner = async (userId: string, organizationId: string) => {
-  const membership = await prisma.membership.findUnique({
-    where: {
-      userId_organizationId: {
-        userId,
-        organizationId,
-      },
-    },
-  });
-
-  if (membership && membership.role === "owner") {
-    return true;
-  }
-
-  return false;
-};
+export const isOwner = (userId: string, organizationId: string): Promise<boolean> =>
+  can({ type: "user", id: userId }, "organization.write", { type: "organization", id: organizationId });
 
 export const hasOrganizationAuthority = async (userId: string, organizationId: string) => {
   const hasAccess = await hasOrganizationAccess(userId, organizationId);

--- a/apps/web/lib/authorization/README.md
+++ b/apps/web/lib/authorization/README.md
@@ -85,6 +85,38 @@ evaluator must continue honoring `USER_MANAGEMENT_MINIMUM_ROLE`:
 This deployment setting is evaluator input. It is not encoded into the static
 actor/action/resource types.
 
+## Migration inventory
+
+The central interface still selects the legacy evaluator. Migration means
+callers use semantic actor/action/resource decisions; it does not enable an
+AuthZed network dependency.
+
+### Migrated by ENG-1714
+
+- Canonical organization, workspace-team, and team-admin patterns accepted by
+  the action-client compatibility adapter.
+- Organization membership and role helper decisions.
+- Action-aware workspace access and shared analysis/V3 session workspace
+  authorization.
+- Organization settings, workspace settings, team operations, and
+  user-managed API-key settings migrated to explicit actions.
+
+### Assigned to ENG-1731
+
+- API-key principals in V1, V2, V3, MCP, and storage authorization paths.
+- `ApiKeyWorkspace` permissions and organization access-control flags.
+- Organization-only API-key opt-in and API-key revocation behavior.
+
+### Assigned to ENG-1737
+
+- The broad, non-action-aware `hasUserWorkspaceAccess` navigation helper.
+- Layout and UI-derived access flags.
+- Unrecognized action-client compatibility shapes and remaining
+  feature-specific role checks.
+
+New authorization-sensitive code must use `can` or `assertCan`; it must not add
+callers to the compatibility fallback or broad workspace helper.
+
 ## Explicit exclusions
 
 The current contract has no system/service principal, survey-level sharing,

--- a/apps/web/lib/authorization/compatibility.ts
+++ b/apps/web/lib/authorization/compatibility.ts
@@ -1,0 +1,17 @@
+import "server-only";
+import type { TTeamPermission } from "@/modules/ee/teams/workspace-teams/types/team";
+import type { TAuthorizationAction } from "./contract";
+
+type TWorkspaceAction = Extract<TAuthorizationAction, `workspace.${string}`>;
+
+/**
+ * Maps the current WorkspaceTeam permission ladder to the central vocabulary.
+ *
+ * This is intentionally not exported from the public authorization barrel;
+ * it exists only while legacy signatures are migrated.
+ */
+export const getWorkspaceActionForPermission = (minPermission?: TTeamPermission): TWorkspaceAction => {
+  if (minPermission === "manage") return "workspace.manage";
+  if (minPermission === "readWrite") return "workspace.write";
+  return "workspace.read";
+};

--- a/apps/web/lib/authorization/legacy-evaluator.test.ts
+++ b/apps/web/lib/authorization/legacy-evaluator.test.ts
@@ -5,10 +5,10 @@ import type { TMembership } from "@formbricks/types/memberships";
 import { USER_MANAGEMENT_MINIMUM_ROLE } from "@/lib/constants";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getUserManagementAccess } from "@/lib/membership/utils";
-import { hasUserWorkspaceAccessForAction } from "@/lib/workspace/auth";
 import { getTeamRoleByTeamIdUserId } from "@/modules/ee/teams/lib/roles";
 import { AUTHORIZATION_PERMISSION_MAP, type TAuthorizationActor } from "./contract";
 import { legacyEvaluator } from "./legacy-evaluator";
+import { hasUserWorkspaceAccessForActionLegacy } from "./legacy-workspace-access";
 import {
   getApiKeyAuthById,
   getApiKeyOrganizationId,
@@ -18,7 +18,7 @@ import {
   getTeamOrganizationId,
 } from "./resolvers";
 
-vi.mock("@/lib/workspace/auth", () => ({ hasUserWorkspaceAccessForAction: vi.fn() }));
+vi.mock("./legacy-workspace-access", () => ({ hasUserWorkspaceAccessForActionLegacy: vi.fn() }));
 vi.mock("@/lib/membership/service", () => ({ getMembershipByUserIdOrganizationId: vi.fn() }));
 vi.mock("@/modules/ee/teams/lib/roles", () => ({ getTeamRoleByTeamIdUserId: vi.fn() }));
 // The evaluator only reads USER_MANAGEMENT_MINIMUM_ROLE from constants; stub the module
@@ -62,39 +62,39 @@ beforeEach(() => {
 describe("legacyEvaluator — workspace-derived resources (user)", () => {
   test("survey read/write/manage map to the GET/POST/DELETE workspace gates", async () => {
     vi.mocked(getSurveyWorkspaceId).mockResolvedValue("ws1");
-    vi.mocked(hasUserWorkspaceAccessForAction).mockResolvedValue(true);
+    vi.mocked(hasUserWorkspaceAccessForActionLegacy).mockResolvedValue(true);
 
     await can(USER, "survey.read", { type: "survey", id: "s1" });
-    expect(hasUserWorkspaceAccessForAction).toHaveBeenLastCalledWith("user1", "ws1", "GET");
+    expect(hasUserWorkspaceAccessForActionLegacy).toHaveBeenLastCalledWith("user1", "ws1", "GET");
 
     await can(USER, "survey.write", { type: "survey", id: "s1" });
-    expect(hasUserWorkspaceAccessForAction).toHaveBeenLastCalledWith("user1", "ws1", "POST");
+    expect(hasUserWorkspaceAccessForActionLegacy).toHaveBeenLastCalledWith("user1", "ws1", "POST");
 
     await can(USER, "survey.manage", { type: "survey", id: "s1" });
-    expect(hasUserWorkspaceAccessForAction).toHaveBeenLastCalledWith("user1", "ws1", "DELETE");
+    expect(hasUserWorkspaceAccessForActionLegacy).toHaveBeenLastCalledWith("user1", "ws1", "DELETE");
   });
 
   test("survey delete uses the readWrite gate, response export uses the read gate", async () => {
     vi.mocked(getSurveyWorkspaceId).mockResolvedValue("ws1");
     vi.mocked(getResponseSurveyId).mockResolvedValue("s1");
-    vi.mocked(hasUserWorkspaceAccessForAction).mockResolvedValue(true);
+    vi.mocked(hasUserWorkspaceAccessForActionLegacy).mockResolvedValue(true);
 
     await can(USER, "survey.delete", { type: "survey", id: "s1" });
-    expect(hasUserWorkspaceAccessForAction).toHaveBeenLastCalledWith("user1", "ws1", "POST");
+    expect(hasUserWorkspaceAccessForActionLegacy).toHaveBeenLastCalledWith("user1", "ws1", "POST");
 
     await can(USER, "response.export", { type: "response", id: "r1" });
-    expect(hasUserWorkspaceAccessForAction).toHaveBeenLastCalledWith("user1", "ws1", "GET");
+    expect(hasUserWorkspaceAccessForActionLegacy).toHaveBeenLastCalledWith("user1", "ws1", "GET");
   });
 
   test("returns false when the resource does not resolve to a workspace", async () => {
     vi.mocked(getSurveyWorkspaceId).mockResolvedValue(null);
     await expect(can(USER, "survey.read", { type: "survey", id: "missing" })).resolves.toBe(false);
-    expect(hasUserWorkspaceAccessForAction).not.toHaveBeenCalled();
+    expect(hasUserWorkspaceAccessForActionLegacy).not.toHaveBeenCalled();
   });
 
   test("propagates operational failures instead of denying", async () => {
     vi.mocked(getSurveyWorkspaceId).mockResolvedValue("ws1");
-    vi.mocked(hasUserWorkspaceAccessForAction).mockRejectedValue(new DatabaseError("db down"));
+    vi.mocked(hasUserWorkspaceAccessForActionLegacy).mockRejectedValue(new DatabaseError("db down"));
     await expect(can(USER, "survey.read", { type: "survey", id: "s1" })).rejects.toBeInstanceOf(
       DatabaseError
     );
@@ -274,7 +274,7 @@ describe("legacyEvaluator — hardening", () => {
     vi.mocked(getSurveyWorkspaceId).mockResolvedValue("ws1");
     vi.mocked(getDashboardWorkspaceId).mockResolvedValue("ws1");
     vi.mocked(getResponseSurveyId).mockResolvedValue("s1");
-    vi.mocked(hasUserWorkspaceAccessForAction).mockResolvedValue(true);
+    vi.mocked(hasUserWorkspaceAccessForActionLegacy).mockResolvedValue(true);
 
     for (const type of ["workspace", "survey", "dashboard", "response"] as const) {
       for (const permission of AUTHORIZATION_PERMISSION_MAP[type]) {

--- a/apps/web/lib/authorization/legacy-evaluator.ts
+++ b/apps/web/lib/authorization/legacy-evaluator.ts
@@ -3,7 +3,6 @@ import { OrganizationAccessType } from "@formbricks/types/api-key";
 import { USER_MANAGEMENT_MINIMUM_ROLE } from "@/lib/constants";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getAccessFlags, getUserManagementAccess } from "@/lib/membership/utils";
-import { type WorkspaceAction, hasUserWorkspaceAccessForAction } from "@/lib/workspace/auth";
 import { getTeamRoleByTeamIdUserId } from "@/modules/ee/teams/lib/roles";
 import { hasOrganizationAccess, hasPermission } from "@/modules/organization/settings/api-keys/lib/utils";
 import {
@@ -14,6 +13,7 @@ import {
   type TAuthorizationResourceType,
 } from "./contract";
 import type { AuthorizationEvaluator } from "./evaluator";
+import { type LegacyWorkspaceAction, hasUserWorkspaceAccessForActionLegacy } from "./legacy-workspace-access";
 import {
   getApiKeyAuthById,
   getApiKeyOrganizationId,
@@ -57,7 +57,7 @@ const rejectUnknownActor = (actor: never): never => {
 };
 
 /** Workspace permission level required by each workspace-derived action (mirrors the contract). */
-const WORKSPACE_ACTION_LEVEL: Partial<Record<TAuthorizationAction, WorkspaceAction>> = {
+const WORKSPACE_ACTION_LEVEL: Partial<Record<TAuthorizationAction, LegacyWorkspaceAction>> = {
   // read level → GET
   "workspace.read": "GET",
   "survey.read": "GET",
@@ -90,7 +90,7 @@ const canWorkspaceScoped = async (
   if (!method) return false;
 
   if (actor.type === "user") {
-    return hasUserWorkspaceAccessForAction(actor.id, workspaceId, method);
+    return hasUserWorkspaceAccessForActionLegacy(actor.id, workspaceId, method);
   }
 
   if (actor.type === "apiKey") {

--- a/apps/web/lib/authorization/legacy-workspace-access.test.ts
+++ b/apps/web/lib/authorization/legacy-workspace-access.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { Prisma } from "@formbricks/database/prisma";
+import { DatabaseError } from "@formbricks/types/errors";
 import { hasUserWorkspaceAccessForActionLegacy } from "./legacy-workspace-access";
 
 const mocks = vi.hoisted(() => ({
@@ -98,5 +100,21 @@ describe("hasUserWorkspaceAccessForActionLegacy", () => {
     mocks.workspaceTeamFindMany.mockResolvedValue([{ permission: "read" }, { permission: "readWrite" }]);
 
     expect(await hasUserWorkspaceAccessForActionLegacy(userId, workspaceId, "DELETE")).toBe(false);
+  });
+
+  test("wraps known Prisma errors as DatabaseError without losing the database message", async () => {
+    const prismaError = new Prisma.PrismaClientKnownRequestError("Database unavailable", {
+      code: "P2024",
+      clientVersion: "0.0.0",
+    });
+    mocks.membershipFindFirst.mockRejectedValue(prismaError);
+
+    const caughtError = await hasUserWorkspaceAccessForActionLegacy(userId, workspaceId, "GET").catch(
+      (error: unknown) => error
+    );
+
+    expect(caughtError).toBeInstanceOf(DatabaseError);
+    expect(caughtError).toMatchObject({ message: prismaError.message });
+    expect(mocks.workspaceTeamFindMany).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/authorization/legacy-workspace-access.test.ts
+++ b/apps/web/lib/authorization/legacy-workspace-access.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { hasUserWorkspaceAccessForActionLegacy } from "./legacy-workspace-access";
+
+const mocks = vi.hoisted(() => ({
+  membershipFindFirst: vi.fn(),
+  workspaceTeamFindMany: vi.fn(),
+}));
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    membership: {
+      findFirst: mocks.membershipFindFirst,
+    },
+    workspaceTeam: {
+      findMany: mocks.workspaceTeamFindMany,
+    },
+  },
+}));
+
+vi.mock("@/lib/utils/validate", () => ({
+  validateInputs: vi.fn(),
+}));
+
+describe("hasUserWorkspaceAccessForActionLegacy", () => {
+  const userId = "00000000-0000-0000-0000-000000000001";
+  const workspaceId = "00000000-0000-0000-0000-000000000002";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.workspaceTeamFindMany.mockResolvedValue([]);
+  });
+
+  test("returns false when the user has no organization membership for the workspace", async () => {
+    mocks.membershipFindFirst.mockResolvedValue(null);
+
+    expect(await hasUserWorkspaceAccessForActionLegacy(userId, workspaceId, "GET")).toBe(false);
+    expect(mocks.workspaceTeamFindMany).not.toHaveBeenCalled();
+  });
+
+  test.each(["GET", "POST", "PUT", "PATCH", "DELETE"] as const)(
+    "returns false for billing role on %s",
+    async (action) => {
+      mocks.membershipFindFirst.mockResolvedValue({ role: "billing" });
+
+      expect(await hasUserWorkspaceAccessForActionLegacy(userId, workspaceId, action)).toBe(false);
+      expect(mocks.workspaceTeamFindMany).not.toHaveBeenCalled();
+    }
+  );
+
+  test.each(["owner", "manager"] as const)(
+    "returns true for %s role on any action without consulting team permissions",
+    async (role) => {
+      mocks.membershipFindFirst.mockResolvedValue({ role });
+
+      expect(await hasUserWorkspaceAccessForActionLegacy(userId, workspaceId, "DELETE")).toBe(true);
+      expect(mocks.workspaceTeamFindMany).not.toHaveBeenCalled();
+    }
+  );
+
+  test("returns false for member role when no team grants workspace access", async () => {
+    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
+
+    expect(await hasUserWorkspaceAccessForActionLegacy(userId, workspaceId, "GET")).toBe(false);
+  });
+
+  test.each([
+    { permission: "read", allowed: ["GET"], denied: ["POST", "DELETE"] },
+    { permission: "readWrite", allowed: ["GET", "POST", "PUT", "PATCH"], denied: ["DELETE"] },
+    { permission: "manage", allowed: ["GET", "POST", "PUT", "PATCH", "DELETE"], denied: [] },
+  ] as const)(
+    "enforces the $permission workspace permission ladder",
+    async ({ permission, allowed, denied }) => {
+      mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
+      mocks.workspaceTeamFindMany.mockResolvedValue([{ permission }]);
+
+      for (const action of allowed) {
+        expect(await hasUserWorkspaceAccessForActionLegacy(userId, workspaceId, action)).toBe(true);
+      }
+      for (const action of denied) {
+        expect(await hasUserWorkspaceAccessForActionLegacy(userId, workspaceId, action)).toBe(false);
+      }
+    }
+  );
+
+  test("uses the highest permission across multiple teams", async () => {
+    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
+    mocks.workspaceTeamFindMany.mockResolvedValue([
+      { permission: "read" },
+      { permission: "manage" },
+      { permission: "readWrite" },
+    ]);
+
+    expect(await hasUserWorkspaceAccessForActionLegacy(userId, workspaceId, "DELETE")).toBe(true);
+  });
+
+  test("denies when none of the team grants satisfy the requested action", async () => {
+    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
+    mocks.workspaceTeamFindMany.mockResolvedValue([{ permission: "read" }, { permission: "readWrite" }]);
+
+    expect(await hasUserWorkspaceAccessForActionLegacy(userId, workspaceId, "DELETE")).toBe(false);
+  });
+});

--- a/apps/web/lib/authorization/legacy-workspace-access.ts
+++ b/apps/web/lib/authorization/legacy-workspace-access.ts
@@ -1,0 +1,88 @@
+import "server-only";
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { ZId } from "@formbricks/types/common";
+import { DatabaseError } from "@formbricks/types/errors";
+import { validateInputs } from "@/lib/utils/validate";
+
+export type LegacyWorkspaceAction = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+type WorkspacePermissionLevel = "read" | "readWrite" | "manage";
+
+const ACTION_REQUIRED_PERMISSION: Record<LegacyWorkspaceAction, WorkspacePermissionLevel> = {
+  GET: "read",
+  POST: "readWrite",
+  PUT: "readWrite",
+  PATCH: "readWrite",
+  DELETE: "manage",
+};
+
+const PERMISSION_RANK: Record<WorkspacePermissionLevel, number> = {
+  read: 0,
+  readWrite: 1,
+  manage: 2,
+};
+
+const teamPermissionSatisfies = (
+  teamPermission: WorkspacePermissionLevel,
+  required: WorkspacePermissionLevel
+): boolean => PERMISSION_RANK[teamPermission] >= PERMISSION_RANK[required];
+
+/**
+ * Database-backed implementation of the current workspace permission ladder.
+ *
+ * This is intentionally internal to the legacy evaluator. Public callers must
+ * use the central authorization interface (directly or through the temporary
+ * compatibility wrapper in `@/lib/workspace/auth`).
+ */
+export const hasUserWorkspaceAccessForActionLegacy = async (
+  userId: string,
+  workspaceId: string,
+  action: LegacyWorkspaceAction
+): Promise<boolean> => {
+  validateInputs([userId, ZId], [workspaceId, ZId]);
+
+  try {
+    const orgMembership = await prisma.membership.findFirst({
+      where: {
+        userId,
+        organization: {
+          workspaces: {
+            some: { id: workspaceId },
+          },
+        },
+      },
+    });
+
+    if (!orgMembership) return false;
+    if (orgMembership.role === "billing") return false;
+    if (orgMembership.role === "owner" || orgMembership.role === "manager") return true;
+
+    const workspaceTeams = await prisma.workspaceTeam.findMany({
+      where: {
+        workspaceId,
+        team: {
+          teamUsers: {
+            some: { userId },
+          },
+        },
+      },
+      select: { permission: true },
+    });
+
+    if (workspaceTeams.length === 0) return false;
+
+    const highestPermission = workspaceTeams.reduce<WorkspacePermissionLevel>(
+      (max, workspaceTeam) =>
+        PERMISSION_RANK[workspaceTeam.permission] > PERMISSION_RANK[max] ? workspaceTeam.permission : max,
+      workspaceTeams[0].permission
+    );
+
+    return teamPermissionSatisfies(highestPermission, ACTION_REQUIRED_PERMISSION[action]);
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      throw new DatabaseError(error.message);
+    }
+    throw error;
+  }
+};

--- a/apps/web/lib/organization/auth.test.ts
+++ b/apps/web/lib/organization/auth.test.ts
@@ -1,126 +1,94 @@
-import { describe, expect, test, vi } from "vitest";
-import { TMembership } from "@formbricks/types/memberships";
-import { TOrganization } from "@formbricks/types/organizations";
-import { getMembershipByUserIdOrganizationId } from "../membership/service";
-import { getAccessFlags } from "../membership/utils";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { can } from "../authorization";
+import { validateInputs } from "../utils/validate";
 import { canUserAccessOrganization, verifyUserRoleAccess } from "./auth";
-import { getOrganizationsByUserId } from "./service";
 
-vi.mock("./service", () => ({
-  getOrganizationsByUserId: vi.fn(),
+vi.mock("../authorization", () => ({
+  can: vi.fn(),
 }));
 
-vi.mock("../membership/service", () => ({
-  getMembershipByUserIdOrganizationId: vi.fn(),
+vi.mock("../utils/validate", () => ({
+  validateInputs: vi.fn(),
 }));
 
-vi.mock("../membership/utils", () => ({
-  getAccessFlags: vi.fn(),
-}));
+describe("organization authorization helpers", () => {
+  const userId = "user1";
+  const organizationId = "org1";
 
-describe("auth", () => {
-  describe("canUserAccessOrganization", () => {
-    test("returns true when user has access to organization", async () => {
-      const mockOrganizations: TOrganization[] = [
-        {
-          id: "org1",
-          createdAt: new Date(),
-          updatedAt: new Date(),
-          name: "Org 1",
-          billing: {
-            stripeCustomerId: null,
-            limits: {
-              workspaces: 3,
-              monthly: {
-                responses: 1500,
-              },
-            },
-            usageCycleAnchor: new Date(),
-          },
-          isAISmartToolsEnabled: false,
-        },
-      ];
-      vi.mocked(getOrganizationsByUserId).mockResolvedValue(mockOrganizations);
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-      const result = await canUserAccessOrganization("user1", "org1");
-      expect(result).toBe(true);
+  test("canUserAccessOrganization delegates to organization.read", async () => {
+    vi.mocked(can).mockResolvedValue(true);
+
+    await expect(canUserAccessOrganization(userId, organizationId)).resolves.toBe(true);
+
+    expect(validateInputs).toHaveBeenCalledWith(
+      [userId, expect.anything()],
+      [organizationId, expect.anything()]
+    );
+    expect(can).toHaveBeenCalledWith({ type: "user", id: userId }, "organization.read", {
+      type: "organization",
+      id: organizationId,
     });
   });
 
-  describe("verifyUserRoleAccess", () => {
-    test("returns all access for owner role", async () => {
-      const mockMembership: TMembership = {
-        organizationId: "org1",
-        userId: "user1",
-        accepted: true,
-        role: "owner",
-      };
-      vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(mockMembership);
-      vi.mocked(getAccessFlags).mockReturnValue({
-        isOwner: true,
-        isManager: false,
-        isBilling: false,
-        isMember: false,
-      });
-
-      const result = await verifyUserRoleAccess("org1", "user1");
-      expect(result).toEqual({
+  test.each([
+    {
+      name: "owner",
+      owner: true,
+      manager: true,
+      expected: {
         hasCreateOrUpdateAccess: true,
         hasDeleteAccess: true,
         hasCreateOrUpdateMembersAccess: true,
         hasDeleteMembersAccess: true,
         hasBillingAccess: true,
-      });
-    });
-
-    test("returns limited access for manager role", async () => {
-      const mockMembership: TMembership = {
-        organizationId: "org1",
-        userId: "user1",
-        accepted: true,
-        role: "manager",
-      };
-      vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(mockMembership);
-      vi.mocked(getAccessFlags).mockReturnValue({
-        isOwner: false,
-        isManager: true,
-        isBilling: false,
-        isMember: false,
-      });
-
-      const result = await verifyUserRoleAccess("org1", "user1");
-      expect(result).toEqual({
+      },
+    },
+    {
+      name: "manager",
+      owner: false,
+      manager: true,
+      expected: {
         hasCreateOrUpdateAccess: false,
         hasDeleteAccess: false,
         hasCreateOrUpdateMembersAccess: true,
         hasDeleteMembersAccess: true,
         hasBillingAccess: true,
-      });
-    });
-
-    test("returns no access for member role", async () => {
-      const mockMembership: TMembership = {
-        organizationId: "org1",
-        userId: "user1",
-        accepted: true,
-        role: "member",
-      };
-      vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(mockMembership);
-      vi.mocked(getAccessFlags).mockReturnValue({
-        isOwner: false,
-        isManager: false,
-        isBilling: false,
-        isMember: true,
-      });
-
-      const result = await verifyUserRoleAccess("org1", "user1");
-      expect(result).toEqual({
+      },
+    },
+    {
+      name: "member",
+      owner: false,
+      manager: false,
+      expected: {
         hasCreateOrUpdateAccess: false,
         hasDeleteAccess: false,
         hasCreateOrUpdateMembersAccess: false,
         hasDeleteMembersAccess: false,
         hasBillingAccess: false,
-      });
+      },
+    },
+  ])("preserves the $name role access bundle", async ({ owner, manager, expected }) => {
+    vi.mocked(can).mockResolvedValueOnce(owner).mockResolvedValueOnce(manager);
+
+    await expect(verifyUserRoleAccess(organizationId, userId)).resolves.toEqual(expected);
+
+    expect(can).toHaveBeenNthCalledWith(1, { type: "user", id: userId }, "organization.write", {
+      type: "organization",
+      id: organizationId,
     });
+    expect(can).toHaveBeenNthCalledWith(2, { type: "user", id: userId }, "organization.manage", {
+      type: "organization",
+      id: organizationId,
+    });
+  });
+
+  test("propagates evaluator failures", async () => {
+    vi.mocked(can).mockRejectedValue(new Error("database unavailable"));
+
+    await expect(verifyUserRoleAccess(organizationId, userId)).rejects.toThrow("database unavailable");
   });
 });

--- a/apps/web/lib/organization/auth.ts
+++ b/apps/web/lib/organization/auth.ts
@@ -1,19 +1,12 @@
 import "server-only";
 import { ZId } from "@formbricks/types/common";
-import { getMembershipByUserIdOrganizationId } from "../membership/service";
-import { getAccessFlags } from "../membership/utils";
+import { can } from "../authorization";
 import { validateInputs } from "../utils/validate";
-import { getOrganizationsByUserId } from "./service";
 
 export const canUserAccessOrganization = async (userId: string, organizationId: string): Promise<boolean> => {
   validateInputs([userId, ZId], [organizationId, ZId]);
 
-  try {
-    const userOrganizations = await getOrganizationsByUserId(userId);
-    return userOrganizations.some((organization) => organization.id === organizationId);
-  } catch (error) {
-    throw error;
-  }
+  return can({ type: "user", id: userId }, "organization.read", { type: "organization", id: organizationId });
 };
 
 export const verifyUserRoleAccess = async (
@@ -26,30 +19,18 @@ export const verifyUserRoleAccess = async (
   hasDeleteMembersAccess: boolean;
   hasBillingAccess: boolean;
 }> => {
-  const accessObject = {
-    hasCreateOrUpdateAccess: true,
-    hasDeleteAccess: true,
-    hasCreateOrUpdateMembersAccess: true,
-    hasDeleteMembersAccess: true,
-    hasBillingAccess: true,
+  const actor = { type: "user", id: userId } as const;
+  const organization = { type: "organization", id: organizationId } as const;
+  const [hasOwnerAccess, hasManagerAccess] = await Promise.all([
+    can(actor, "organization.write", organization),
+    can(actor, "organization.manage", organization),
+  ]);
+
+  return {
+    hasCreateOrUpdateAccess: hasOwnerAccess,
+    hasDeleteAccess: hasOwnerAccess,
+    hasCreateOrUpdateMembersAccess: hasManagerAccess,
+    hasDeleteMembersAccess: hasManagerAccess,
+    hasBillingAccess: hasManagerAccess,
   };
-
-  const currentUserMembership = await getMembershipByUserIdOrganizationId(userId, organizationId);
-  const { isOwner, isManager } = getAccessFlags(currentUserMembership?.role);
-
-  if (!isOwner) {
-    accessObject.hasCreateOrUpdateAccess = false;
-    accessObject.hasDeleteAccess = false;
-    accessObject.hasCreateOrUpdateMembersAccess = false;
-    accessObject.hasDeleteMembersAccess = false;
-    accessObject.hasBillingAccess = false;
-  }
-
-  if (isManager) {
-    accessObject.hasCreateOrUpdateMembersAccess = true;
-    accessObject.hasDeleteMembersAccess = true;
-    accessObject.hasBillingAccess = true;
-  }
-
-  return accessObject;
 };

--- a/apps/web/lib/utils/action-client/action-client-middleware.test.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.test.ts
@@ -249,6 +249,30 @@ describe("action-client-middleware", () => {
       ).rejects.toThrow(new AuthorizationError("Not authorized"));
     });
 
+    test("preserves legacy WorkspaceTeam access when the central workspace decision denies", async () => {
+      vi.mocked(can).mockImplementation(async (_actor, action) => action === "organization.read");
+      vi.mocked(getMembershipRole).mockResolvedValue("billing");
+      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("manage");
+
+      await expect(
+        checkAuthorizationUpdated({
+          userId,
+          organizationId,
+          access: [
+            { type: "organization", roles: ["owner", "manager"] },
+            { type: "workspaceTeam", workspaceId, minPermission: "manage" },
+          ],
+        })
+      ).resolves.toBe(true);
+
+      expect(can).toHaveBeenCalledWith({ type: "user", id: userId }, "workspace.manage", {
+        type: "workspace",
+        id: workspaceId,
+      });
+      expect(getMembershipRole).toHaveBeenCalledWith(userId, organizationId);
+      expect(getWorkspacePermissionByUserId).toHaveBeenCalledWith(userId, workspaceId);
+    });
+
     test("propagates central evaluator failures", async () => {
       const failure = new Error("database unavailable");
       vi.mocked(can).mockRejectedValue(failure);

--- a/apps/web/lib/utils/action-client/action-client-middleware.test.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.test.ts
@@ -1,11 +1,16 @@
 import { cleanup } from "@testing-library/react";
 import { returnValidationErrors } from "next-safe-action";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ZodIssue, z } from "zod";
 import { AuthorizationError } from "@formbricks/types/errors";
+import { can } from "@/lib/authorization";
 import { getMembershipRole } from "@/lib/membership/hooks/actions";
 import { getTeamRoleByTeamIdUserId, getWorkspacePermissionByUserId } from "@/modules/ee/teams/lib/roles";
 import { checkAuthorizationUpdated, formatErrors } from "./action-client-middleware";
+
+vi.mock("@/lib/authorization", () => ({
+  can: vi.fn(),
+}));
 
 vi.mock("@/lib/membership/hooks/actions", () => ({
   getMembershipRole: vi.fn(),
@@ -26,15 +31,16 @@ describe("action-client-middleware", () => {
   const workspaceId = "workspace-1";
   const teamId = "team-1";
 
+  beforeEach(() => {
+    vi.mocked(can).mockResolvedValue(false);
+  });
+
   afterEach(() => {
     cleanup();
     vi.resetAllMocks();
   });
 
   describe("formatErrors", () => {
-    // We need to access the private function for testing
-    // Using any to access the function directly
-
     test("formats simple path ZodIssue", () => {
       const issues = [
         {
@@ -44,37 +50,19 @@ describe("action-client-middleware", () => {
         },
       ] as ZodIssue[];
 
-      const result = formatErrors(issues);
-      expect(result).toEqual({
+      expect(formatErrors(issues)).toEqual({
         name: {
           _errors: ["Name is required"],
         },
       });
     });
 
-    test("formats nested path ZodIssue", () => {
+    test("formats nested and multiple ZodIssues", () => {
       const issues = [
         {
           code: "custom",
           path: ["user", "address", "street"],
           message: "Street is required",
-        },
-      ] as ZodIssue[];
-
-      const result = formatErrors(issues);
-      expect(result).toEqual({
-        "user.address.street": {
-          _errors: ["Street is required"],
-        },
-      });
-    });
-
-    test("formats multiple ZodIssues", () => {
-      const issues = [
-        {
-          code: "custom",
-          path: ["name"],
-          message: "Name is required",
         },
         {
           code: "custom",
@@ -83,10 +71,9 @@ describe("action-client-middleware", () => {
         },
       ] as ZodIssue[];
 
-      const result = formatErrors(issues);
-      expect(result).toEqual({
-        name: {
-          _errors: ["Name is required"],
+      expect(formatErrors(issues)).toEqual({
+        "user.address.street": {
+          _errors: ["Street is required"],
         },
         email: {
           _errors: ["Invalid email"],
@@ -95,292 +82,253 @@ describe("action-client-middleware", () => {
     });
   });
 
-  describe("checkAuthorizationUpdated", () => {
-    test("returns validation errors when schema validation fails", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("owner");
+  describe("central compatibility shapes", () => {
+    test.each([
+      [["owner", "manager", "member", "billing"], "organization.read"],
+      [["owner", "manager", "member"], "organization.read_access"],
+      [["owner", "manager", "billing"], "organization.manage_billing"],
+      [["owner", "manager"], "organization.manage"],
+      [["owner"], "organization.write"],
+    ] as const)("maps organization roles %j to %s", async (roles, expectedAction) => {
+      vi.mocked(can).mockResolvedValue(true);
 
-      const mockSchema = z.object({
-        name: z.string(),
+      await expect(
+        checkAuthorizationUpdated({
+          userId,
+          organizationId,
+          access: [{ type: "organization", roles: [...roles] }],
+        })
+      ).resolves.toBe(true);
+
+      expect(can).toHaveBeenCalledWith({ type: "user", id: userId }, "organization.read", {
+        type: "organization",
+        id: organizationId,
+      });
+      expect(can).toHaveBeenCalledWith({ type: "user", id: userId }, expectedAction, {
+        type: "organization",
+        id: organizationId,
+      });
+      expect(getMembershipRole).not.toHaveBeenCalled();
+    });
+
+    test.each([
+      [undefined, "workspace.read"],
+      ["read", "workspace.read"],
+      ["readWrite", "workspace.write"],
+      ["manage", "workspace.manage"],
+    ] as const)("maps workspace permission %s to %s", async (minPermission, expectedAction) => {
+      vi.mocked(can).mockImplementation(async (_actor, action) =>
+        ["organization.read", expectedAction].includes(action)
+      );
+
+      await expect(
+        checkAuthorizationUpdated({
+          userId,
+          organizationId,
+          access: [
+            { type: "organization", roles: ["owner", "manager"] },
+            { type: "workspaceTeam", workspaceId, minPermission },
+          ],
+        })
+      ).resolves.toBe(true);
+
+      expect(can).toHaveBeenCalledWith({ type: "user", id: userId }, expectedAction, {
+        type: "workspace",
+        id: workspaceId,
+      });
+      expect(getWorkspacePermissionByUserId).not.toHaveBeenCalled();
+    });
+
+    test("maps an admin team alternative to team.manage", async () => {
+      vi.mocked(can).mockImplementation(async (_actor, action) =>
+        ["organization.read", "team.manage"].includes(action)
+      );
+
+      await expect(
+        checkAuthorizationUpdated({
+          userId,
+          organizationId,
+          access: [
+            { type: "organization", roles: ["owner", "manager"] },
+            { type: "team", teamId, minPermission: "admin" },
+          ],
+        })
+      ).resolves.toBe(true);
+
+      expect(can).toHaveBeenCalledWith({ type: "user", id: userId }, "team.manage", {
+        type: "team",
+        id: teamId,
+      });
+      expect(getTeamRoleByTeamIdUserId).not.toHaveBeenCalled();
+    });
+
+    test("preserves ordered OR evaluation across multiple workspace alternatives", async () => {
+      const otherWorkspaceId = "workspace-2";
+      vi.mocked(can).mockImplementation(async (_actor, action, resource) => {
+        if (action === "organization.read") return true;
+        return resource.id === otherWorkspaceId;
       });
 
-      const mockData = { name: 123 }; // Type error to trigger validation failure
+      await expect(
+        checkAuthorizationUpdated({
+          userId,
+          organizationId,
+          access: [
+            { type: "organization", roles: ["owner", "manager"] },
+            { type: "workspaceTeam", workspaceId, minPermission: "readWrite" },
+            { type: "workspaceTeam", workspaceId: otherWorkspaceId, minPermission: "readWrite" },
+          ],
+        })
+      ).resolves.toBe(true);
 
+      expect(can).toHaveBeenNthCalledWith(3, { type: "user", id: userId }, "workspace.write", {
+        type: "workspace",
+        id: workspaceId,
+      });
+      expect(can).toHaveBeenNthCalledWith(4, { type: "user", id: userId }, "workspace.write", {
+        type: "workspace",
+        id: otherWorkspaceId,
+      });
+    });
+
+    test("rejects a non-member before evaluating access alternatives", async () => {
+      vi.mocked(can).mockResolvedValue(false);
+
+      await expect(
+        checkAuthorizationUpdated({
+          userId,
+          organizationId,
+          access: [{ type: "organization", roles: ["owner"] }],
+        })
+      ).rejects.toThrow(new AuthorizationError("Not authorized"));
+
+      expect(can).toHaveBeenCalledTimes(1);
+    });
+
+    test("returns validation errors after membership and before the permission decision", async () => {
+      const schema = z.object({ name: z.string() });
+      vi.mocked(can).mockResolvedValue(true);
       vi.mocked(returnValidationErrors).mockReturnValue("validation-error" as unknown as never);
-
-      const access = [
-        {
-          type: "organization" as const,
-          schema: mockSchema,
-          data: mockData as any,
-          roles: ["owner" as const],
-        },
-      ];
 
       const result = await checkAuthorizationUpdated({
         userId,
         organizationId,
-        access,
+        access: [
+          {
+            type: "organization",
+            schema,
+            data: { name: 123 } as never,
+            roles: ["owner"],
+          },
+        ],
       });
 
-      expect(returnValidationErrors).toHaveBeenCalledWith(expect.any(Object), expect.any(Object));
       expect(result).toBe("validation-error");
-    });
-
-    test("returns true when organization access matches role", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("owner");
-
-      const access = [
-        {
-          type: "organization" as const,
-          roles: ["owner" as const],
-        },
-      ];
-
-      const result = await checkAuthorizationUpdated({ userId, organizationId, access });
-
-      expect(result).toBe(true);
-    });
-
-    test("continues checking other access items when organization role doesn't match", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("member");
-
-      const access = [
-        {
-          type: "organization" as const,
-          roles: ["owner" as const],
-        },
-        {
-          type: "workspaceTeam" as const,
-          workspaceId,
-          minPermission: "read" as const,
-        },
-      ];
-
-      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("readWrite");
-
-      const result = await checkAuthorizationUpdated({ userId, organizationId, access });
-
-      expect(result).toBe(true);
-      expect(getWorkspacePermissionByUserId).toHaveBeenCalledWith(userId, workspaceId);
-    });
-
-    test("returns true when workspaceTeam access matches permission", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("member");
-
-      const access = [
-        {
-          type: "workspaceTeam" as const,
-          workspaceId,
-          minPermission: "read" as const,
-        },
-      ];
-
-      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("readWrite");
-
-      const result = await checkAuthorizationUpdated({ userId, organizationId, access });
-
-      expect(result).toBe(true);
-      expect(getWorkspacePermissionByUserId).toHaveBeenCalledWith(userId, workspaceId);
-    });
-
-    test("continues checking other access items when workspaceTeam permission is insufficient", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("member");
-
-      const access = [
-        {
-          type: "workspaceTeam" as const,
-          workspaceId,
-          minPermission: "manage" as const,
-        },
-        {
-          type: "team" as const,
-          teamId,
-          minPermission: "contributor" as const,
-        },
-      ];
-
-      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("read");
-      vi.mocked(getTeamRoleByTeamIdUserId).mockResolvedValue("admin");
-
-      const result = await checkAuthorizationUpdated({ userId, organizationId, access });
-
-      expect(result).toBe(true);
-      expect(getWorkspacePermissionByUserId).toHaveBeenCalledWith(userId, workspaceId);
-      expect(getTeamRoleByTeamIdUserId).toHaveBeenCalledWith(teamId, userId);
-    });
-
-    test("returns true when team access matches role", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("member");
-
-      const access = [
-        {
-          type: "team" as const,
-          teamId,
-          minPermission: "contributor" as const,
-        },
-      ];
-
-      vi.mocked(getTeamRoleByTeamIdUserId).mockResolvedValue("admin");
-
-      const result = await checkAuthorizationUpdated({ userId, organizationId, access });
-
-      expect(result).toBe(true);
-      expect(getTeamRoleByTeamIdUserId).toHaveBeenCalledWith(teamId, userId);
-    });
-
-    test("continues checking other access items when team role is insufficient", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("member");
-
-      const access = [
-        {
-          type: "team" as const,
-          teamId,
-          minPermission: "admin" as const,
-        },
-        {
-          type: "organization" as const,
-          roles: ["member" as const],
-        },
-      ];
-
-      vi.mocked(getTeamRoleByTeamIdUserId).mockResolvedValue("contributor");
-
-      const result = await checkAuthorizationUpdated({ userId, organizationId, access });
-
-      expect(result).toBe(true);
-      expect(getTeamRoleByTeamIdUserId).toHaveBeenCalledWith(teamId, userId);
-    });
-
-    test("throws AuthorizationError when no access matches", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("member");
-
-      const access = [
-        {
-          type: "organization" as const,
-          roles: ["owner" as const],
-        },
-        {
-          type: "workspaceTeam" as const,
-          workspaceId,
-          minPermission: "manage" as const,
-        },
-        {
-          type: "team" as const,
-          teamId,
-          minPermission: "admin" as const,
-        },
-      ];
-
-      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("read");
-      vi.mocked(getTeamRoleByTeamIdUserId).mockResolvedValue("contributor");
-
-      await expect(checkAuthorizationUpdated({ userId, organizationId, access })).rejects.toThrow(
-        AuthorizationError
-      );
-      await expect(checkAuthorizationUpdated({ userId, organizationId, access })).rejects.toThrow(
-        "Not authorized"
-      );
-    });
-
-    test("continues to check when workspacePermission is null", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("member");
-
-      const access = [
-        {
-          type: "workspaceTeam" as const,
-          workspaceId,
-          minPermission: "read" as const,
-        },
-        {
-          type: "organization" as const,
-          roles: ["member" as const],
-        },
-      ];
-
-      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue(null);
-
-      const result = await checkAuthorizationUpdated({ userId, organizationId, access });
-
-      expect(result).toBe(true);
-    });
-
-    test("continues to check when teamRole is null", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("member");
-
-      const access = [
-        {
-          type: "team" as const,
-          teamId,
-          minPermission: "contributor" as const,
-        },
-        {
-          type: "organization" as const,
-          roles: ["member" as const],
-        },
-      ];
-
-      vi.mocked(getTeamRoleByTeamIdUserId).mockResolvedValue(null);
-
-      const result = await checkAuthorizationUpdated({ userId, organizationId, access });
-
-      expect(result).toBe(true);
-    });
-
-    test("returns true when schema validation passes", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("owner");
-
-      const mockSchema = z.object({
-        name: z.string(),
+      expect(returnValidationErrors).toHaveBeenCalledWith(expect.any(Object), {
+        name: { _errors: ["Invalid input: expected string, received number"] },
       });
-
-      const mockData = { name: "test" };
-
-      const access = [
-        {
-          type: "organization" as const,
-          schema: mockSchema,
-          data: mockData,
-          roles: ["owner" as const],
-        },
-      ];
-
-      const result = await checkAuthorizationUpdated({ userId, organizationId, access });
-
-      expect(result).toBe(true);
+      expect(can).toHaveBeenCalledTimes(1);
     });
 
-    test("handles workspaceTeam access without minPermission specified", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("member");
+    test("throws the standard denial after every alternative denies", async () => {
+      vi.mocked(can).mockImplementation(async (_actor, action) => action === "organization.read");
 
-      const access = [
-        {
-          type: "workspaceTeam" as const,
-          workspaceId,
-        },
-      ];
-
-      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("read");
-
-      const result = await checkAuthorizationUpdated({ userId, organizationId, access });
-
-      expect(result).toBe(true);
+      await expect(
+        checkAuthorizationUpdated({
+          userId,
+          organizationId,
+          access: [
+            { type: "organization", roles: ["owner", "manager"] },
+            { type: "workspaceTeam", workspaceId, minPermission: "manage" },
+            { type: "team", teamId, minPermission: "admin" },
+          ],
+        })
+      ).rejects.toThrow(new AuthorizationError("Not authorized"));
     });
 
-    test("handles team access without minPermission specified", async () => {
+    test("propagates central evaluator failures", async () => {
+      const failure = new Error("database unavailable");
+      vi.mocked(can).mockRejectedValue(failure);
+
+      await expect(
+        checkAuthorizationUpdated({
+          userId,
+          organizationId,
+          access: [{ type: "organization", roles: ["owner"] }],
+        })
+      ).rejects.toBe(failure);
+    });
+  });
+
+  describe("legacy fallback", () => {
+    test("preserves arbitrary organization role sets", async () => {
       vi.mocked(getMembershipRole).mockResolvedValue("member");
 
-      const access = [
-        {
-          type: "team" as const,
-          teamId,
-        },
-      ];
+      await expect(
+        checkAuthorizationUpdated({
+          userId,
+          organizationId,
+          access: [{ type: "organization", roles: ["member"] }],
+        })
+      ).resolves.toBe(true);
 
-      vi.mocked(getTeamRoleByTeamIdUserId).mockResolvedValue("contributor");
+      expect(can).not.toHaveBeenCalled();
+    });
 
-      const result = await checkAuthorizationUpdated({ userId, organizationId, access });
+    test("preserves standalone workspace access", async () => {
+      vi.mocked(getMembershipRole).mockResolvedValue("member");
+      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("readWrite");
 
-      expect(result).toBe(true);
+      await expect(
+        checkAuthorizationUpdated({
+          userId,
+          organizationId,
+          access: [{ type: "workspaceTeam", workspaceId, minPermission: "read" }],
+        })
+      ).resolves.toBe(true);
+
+      expect(getWorkspacePermissionByUserId).toHaveBeenCalledWith(userId, workspaceId);
+      expect(can).not.toHaveBeenCalled();
+    });
+
+    test("preserves contributor team checks", async () => {
+      vi.mocked(getMembershipRole).mockResolvedValue("member");
+      vi.mocked(getTeamRoleByTeamIdUserId).mockResolvedValue("admin");
+
+      await expect(
+        checkAuthorizationUpdated({
+          userId,
+          organizationId,
+          access: [
+            { type: "organization", roles: ["owner", "manager"] },
+            { type: "team", teamId, minPermission: "contributor" },
+          ],
+        })
+      ).resolves.toBe(true);
+
+      expect(getTeamRoleByTeamIdUserId).toHaveBeenCalledWith(teamId, userId);
+      expect(can).not.toHaveBeenCalled();
+    });
+
+    test("preserves fallback schema validation", async () => {
+      const schema = z.object({ name: z.string() });
+      vi.mocked(getMembershipRole).mockResolvedValue("member");
+      vi.mocked(returnValidationErrors).mockReturnValue("validation-error" as unknown as never);
+
+      await expect(
+        checkAuthorizationUpdated({
+          userId,
+          organizationId,
+          access: [
+            {
+              type: "organization",
+              schema,
+              data: { name: 123 } as never,
+              roles: ["member"],
+            },
+          ],
+        })
+      ).resolves.toBe("validation-error");
     });
   });
 });

--- a/apps/web/lib/utils/action-client/action-client-middleware.test.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.test.ts
@@ -90,7 +90,9 @@ describe("action-client-middleware", () => {
       [["owner", "manager"], "organization.manage"],
       [["owner"], "organization.write"],
     ] as const)("maps organization roles %j to %s", async (roles, expectedAction) => {
-      vi.mocked(can).mockResolvedValue(true);
+      vi.mocked(can)
+        .mockResolvedValueOnce(true)
+        .mockImplementation(async (_actor, action) => action === expectedAction);
 
       await expect(
         checkAuthorizationUpdated({
@@ -108,6 +110,7 @@ describe("action-client-middleware", () => {
         type: "organization",
         id: organizationId,
       });
+      expect(can).toHaveBeenCalledTimes(expectedAction === "organization.read" ? 1 : 2);
       expect(getMembershipRole).not.toHaveBeenCalled();
     });
 
@@ -329,6 +332,8 @@ describe("action-client-middleware", () => {
           ],
         })
       ).resolves.toBe("validation-error");
+
+      expect(can).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/lib/utils/action-client/action-client-middleware.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.ts
@@ -224,5 +224,8 @@ export const checkAuthorizationUpdated = async <T extends z.ZodRawShape>({
     if (accessResult) return accessResult;
   }
 
-  throw new AuthorizationError("Not authorized");
+  // Some legacy OR signatures grant a WorkspaceTeam permission independently
+  // of the organization role. Keep that edge-case behavior until the
+  // compatibility adapter is removed under ENG-1737.
+  return checkLegacyAuthorization({ userId, organizationId, access });
 };

--- a/apps/web/lib/utils/action-client/action-client-middleware.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.ts
@@ -171,13 +171,15 @@ const checkLegacyAuthorization = async <T extends z.ZodRawShape>({
 const checkCentralAccessItem = async <T extends z.ZodRawShape>(
   accessItem: TAccess<T>,
   actor: TUserActor,
-  organization: TOrganizationResource
+  organization: TOrganizationResource,
+  isOrganizationMember: boolean
 ) => {
   if (accessItem.type === "organization") {
     const validationError = getOrganizationValidationError(accessItem);
     if (validationError) return validationError;
 
     const action = getOrganizationAction(accessItem.roles);
+    if (action === "organization.read") return isOrganizationMember;
     return action ? can(actor, action, organization) : false;
   }
 
@@ -218,7 +220,7 @@ export const checkAuthorizationUpdated = async <T extends z.ZodRawShape>({
   }
 
   for (const accessItem of access) {
-    const accessResult = await checkCentralAccessItem(accessItem, actor, organization);
+    const accessResult = await checkCentralAccessItem(accessItem, actor, organization, isOrganizationMember);
     if (accessResult) return accessResult;
   }
 

--- a/apps/web/lib/utils/action-client/action-client-middleware.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.ts
@@ -3,7 +3,12 @@ import { returnValidationErrors } from "next-safe-action";
 import { ZodIssue, z } from "zod";
 import { AuthorizationError } from "@formbricks/types/errors";
 import { type TOrganizationRole } from "@formbricks/types/memberships";
-import { type TAuthorizationAction, can } from "@/lib/authorization";
+import {
+  type TAuthorizationAction,
+  type TAuthorizationActor,
+  type TAuthorizationResource,
+  can,
+} from "@/lib/authorization";
 import { getWorkspaceActionForPermission } from "@/lib/authorization/compatibility";
 import { getMembershipRole } from "@/lib/membership/hooks/actions";
 import { getTeamRoleByTeamIdUserId, getWorkspacePermissionByUserId } from "@/modules/ee/teams/lib/roles";
@@ -52,6 +57,8 @@ const teamRoleWeight = {
 
 type TOrganizationAction = Extract<TAuthorizationAction, `organization.${string}`>;
 type TTeamAction = Extract<TAuthorizationAction, `team.${string}`>;
+type TUserActor = Extract<TAuthorizationActor, { type: "user" }>;
+type TOrganizationResource = Extract<TAuthorizationResource, { type: "organization" }>;
 
 const ORGANIZATION_ACTION_BY_ROLE_SET: Readonly<Record<string, TOrganizationAction>> = {
   "billing,manager,member,owner": "organization.read",
@@ -62,7 +69,7 @@ const ORGANIZATION_ACTION_BY_ROLE_SET: Readonly<Record<string, TOrganizationActi
 };
 
 const getOrganizationAction = (roles: TOrganizationRole[]): TOrganizationAction | null => {
-  const roleSet = [...new Set(roles)].sort().join(",");
+  const roleSet = [...new Set(roles)].sort((roleA, roleB) => roleA.localeCompare(roleB)).join(",");
   return ORGANIZATION_ACTION_BY_ROLE_SET[roleSet] ?? null;
 };
 
@@ -161,6 +168,28 @@ const checkLegacyAuthorization = async <T extends z.ZodRawShape>({
   throw new AuthorizationError("Not authorized");
 };
 
+const checkCentralAccessItem = async <T extends z.ZodRawShape>(
+  accessItem: TAccess<T>,
+  actor: TUserActor,
+  organization: TOrganizationResource
+) => {
+  if (accessItem.type === "organization") {
+    const validationError = getOrganizationValidationError(accessItem);
+    if (validationError) return validationError;
+
+    const action = getOrganizationAction(accessItem.roles);
+    return action ? can(actor, action, organization) : false;
+  }
+
+  if (accessItem.type === "workspaceTeam") {
+    const action = getWorkspaceActionForPermission(accessItem.minPermission);
+    return can(actor, action, { type: "workspace", id: accessItem.workspaceId });
+  }
+
+  const action = getTeamAction(accessItem.minPermission);
+  return action ? can(actor, action, { type: "team", id: accessItem.teamId }) : false;
+};
+
 /**
  * Compatibility adapter for the pre-ENG-1712 action-client authorization signature.
  *
@@ -189,23 +218,8 @@ export const checkAuthorizationUpdated = async <T extends z.ZodRawShape>({
   }
 
   for (const accessItem of access) {
-    if (accessItem.type === "organization") {
-      const validationError = getOrganizationValidationError(accessItem);
-      if (validationError) return validationError;
-
-      const action = getOrganizationAction(accessItem.roles);
-      if (action && (await can(actor, action, organization))) return true;
-    }
-
-    if (accessItem.type === "workspaceTeam") {
-      const action = getWorkspaceActionForPermission(accessItem.minPermission);
-      if (await can(actor, action, { type: "workspace", id: accessItem.workspaceId })) return true;
-    }
-
-    if (accessItem.type === "team") {
-      const action = getTeamAction(accessItem.minPermission);
-      if (action && (await can(actor, action, { type: "team", id: accessItem.teamId }))) return true;
-    }
+    const accessResult = await checkCentralAccessItem(accessItem, actor, organization);
+    if (accessResult) return accessResult;
   }
 
   throw new AuthorizationError("Not authorized");

--- a/apps/web/lib/utils/action-client/action-client-middleware.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.ts
@@ -1,7 +1,10 @@
+import "server-only";
 import { returnValidationErrors } from "next-safe-action";
 import { ZodIssue, z } from "zod";
 import { AuthorizationError } from "@formbricks/types/errors";
 import { type TOrganizationRole } from "@formbricks/types/memberships";
+import { type TAuthorizationAction, can } from "@/lib/authorization";
+import { getWorkspaceActionForPermission } from "@/lib/authorization/compatibility";
 import { getMembershipRole } from "@/lib/membership/hooks/actions";
 import { getTeamRoleByTeamIdUserId, getWorkspacePermissionByUserId } from "@/modules/ee/teams/lib/roles";
 import { type TTeamRole } from "@/modules/ee/teams/team-list/types/team";
@@ -47,23 +50,49 @@ const teamRoleWeight = {
   admin: 2,
 };
 
+type TOrganizationAction = Extract<TAuthorizationAction, `organization.${string}`>;
+type TTeamAction = Extract<TAuthorizationAction, `team.${string}`>;
+
+const ORGANIZATION_ACTION_BY_ROLE_SET: Readonly<Record<string, TOrganizationAction>> = {
+  "billing,manager,member,owner": "organization.read",
+  "manager,member,owner": "organization.read_access",
+  "billing,manager,owner": "organization.manage_billing",
+  "manager,owner": "organization.manage",
+  owner: "organization.write",
+};
+
+const getOrganizationAction = (roles: TOrganizationRole[]): TOrganizationAction | null => {
+  const roleSet = [...new Set(roles)].sort().join(",");
+  return ORGANIZATION_ACTION_BY_ROLE_SET[roleSet] ?? null;
+};
+
+const getTeamAction = (minPermission?: TTeamRole): TTeamAction | null =>
+  minPermission === "admin" ? "team.manage" : null;
+
+const getOrganizationValidationError = <T extends z.ZodRawShape>(accessItem: TAccess<T>) => {
+  if (accessItem.type !== "organization" || !accessItem.schema) return null;
+
+  const resultSchema = accessItem.schema.strict();
+  const parsedResult = resultSchema.safeParse(accessItem.data);
+  if (parsedResult.success) return null;
+
+  // @ts-expect-error -- match dynamic next-safe-action types
+  return returnValidationErrors(resultSchema, formatErrors(parsedResult.error.issues));
+};
+
 const checkOrganizationAccess = <T extends z.ZodRawShape>(
   accessItem: TAccess<T>,
   role: TOrganizationRole
 ) => {
   if (accessItem.type !== "organization") return false;
-  if (accessItem.schema) {
-    const resultSchema = accessItem.schema.strict();
-    const parsedResult = resultSchema.safeParse(accessItem.data);
-    if (!parsedResult.success) {
-      // @ts-expect-error -- match dynamic next-safe-action types
-      return returnValidationErrors(resultSchema, formatErrors(parsedResult.error.issues));
-    }
-  }
+
+  const validationError = getOrganizationValidationError(accessItem);
+  if (validationError) return validationError;
+
   return accessItem.roles.includes(role);
 };
 
-const checkWorkspaceTeamAccess = async (accessItem: any, userId: string) => {
+const checkWorkspaceTeamAccess = async <T extends z.ZodRawShape>(accessItem: TAccess<T>, userId: string) => {
   if (accessItem.type !== "workspaceTeam") return false;
   const workspacePermission = await getWorkspacePermissionByUserId(userId, accessItem.workspaceId);
   if (!workspacePermission) return false;
@@ -77,7 +106,7 @@ const checkWorkspaceTeamAccess = async (accessItem: any, userId: string) => {
   return true;
 };
 
-const checkTeamAccess = async (accessItem: any, userId: string) => {
+const checkTeamAccess = async <T extends z.ZodRawShape>(accessItem: TAccess<T>, userId: string) => {
   if (accessItem.type !== "team") return false;
   const teamRole = await getTeamRoleByTeamIdUserId(accessItem.teamId, userId);
   if (!teamRole) return false;
@@ -91,7 +120,18 @@ const checkTeamAccess = async (accessItem: any, userId: string) => {
   return true;
 };
 
-export const checkAuthorizationUpdated = async <T extends z.ZodRawShape>({
+const isCentralCompatibilityShape = <T extends z.ZodRawShape>(access: TAccess<T>[]): boolean => {
+  const includesOrganizationAccess = access.some((accessItem) => accessItem.type === "organization");
+  if (!includesOrganizationAccess) return false;
+
+  return access.every((accessItem) => {
+    if (accessItem.type === "organization") return getOrganizationAction(accessItem.roles) !== null;
+    if (accessItem.type === "workspaceTeam") return true;
+    return getTeamAction(accessItem.minPermission) !== null;
+  });
+};
+
+const checkLegacyAuthorization = async <T extends z.ZodRawShape>({
   userId,
   organizationId,
   access,
@@ -106,7 +146,7 @@ export const checkAuthorizationUpdated = async <T extends z.ZodRawShape>({
     if (accessItem.type === "organization") {
       const orgResult = checkOrganizationAccess(accessItem, role);
       if (orgResult === true) return true;
-      if (orgResult) return orgResult; // validation error
+      if (orgResult) return orgResult;
     }
 
     if (accessItem.type === "workspaceTeam" && (await checkWorkspaceTeamAccess(accessItem, userId))) {
@@ -115,6 +155,56 @@ export const checkAuthorizationUpdated = async <T extends z.ZodRawShape>({
 
     if (accessItem.type === "team" && (await checkTeamAccess(accessItem, userId))) {
       return true;
+    }
+  }
+
+  throw new AuthorizationError("Not authorized");
+};
+
+/**
+ * Compatibility adapter for the pre-ENG-1712 action-client authorization signature.
+ *
+ * @deprecated New code must call `can` or `assertCan` with a semantic action and
+ * resource. Unrecognized legacy shapes remain supported only until ENG-1737.
+ */
+export const checkAuthorizationUpdated = async <T extends z.ZodRawShape>({
+  userId,
+  organizationId,
+  access,
+}: {
+  userId: string;
+  organizationId: string;
+  access: TAccess<T>[];
+}) => {
+  if (!isCentralCompatibilityShape(access)) {
+    return checkLegacyAuthorization({ userId, organizationId, access });
+  }
+
+  const actor = { type: "user", id: userId } as const;
+  const organization = { type: "organization", id: organizationId } as const;
+  const isOrganizationMember = await can(actor, "organization.read", organization);
+
+  if (!isOrganizationMember) {
+    throw new AuthorizationError("Not authorized");
+  }
+
+  for (const accessItem of access) {
+    if (accessItem.type === "organization") {
+      const validationError = getOrganizationValidationError(accessItem);
+      if (validationError) return validationError;
+
+      const action = getOrganizationAction(accessItem.roles);
+      if (action && (await can(actor, action, organization))) return true;
+    }
+
+    if (accessItem.type === "workspaceTeam") {
+      const action = getWorkspaceActionForPermission(accessItem.minPermission);
+      if (await can(actor, action, { type: "workspace", id: accessItem.workspaceId })) return true;
+    }
+
+    if (accessItem.type === "team") {
+      const action = getTeamAction(accessItem.minPermission);
+      if (action && (await can(actor, action, { type: "team", id: accessItem.teamId }))) return true;
     }
   }
 

--- a/apps/web/lib/workspace/auth.test.ts
+++ b/apps/web/lib/workspace/auth.test.ts
@@ -1,19 +1,21 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { hasUserWorkspaceAccessForAction } from "./auth";
+import { can } from "@/lib/authorization";
+import { validateInputs } from "../utils/validate";
+import { hasUserWorkspaceAccess, hasUserWorkspaceAccessForAction } from "./auth";
 
 const mocks = vi.hoisted(() => ({
   membershipFindFirst: vi.fn(),
-  workspaceTeamFindMany: vi.fn(),
+  teamUserFindFirst: vi.fn(),
+}));
+
+vi.mock("@/lib/authorization", () => ({
+  can: vi.fn(),
 }));
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
-    membership: {
-      findFirst: mocks.membershipFindFirst,
-    },
-    workspaceTeam: {
-      findMany: mocks.workspaceTeamFindMany,
-    },
+    membership: { findFirst: mocks.membershipFindFirst },
+    teamUser: { findFirst: mocks.teamUserFindFirst },
   },
 }));
 
@@ -27,89 +29,64 @@ describe("hasUserWorkspaceAccessForAction", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.workspaceTeamFindMany.mockResolvedValue([]);
+    vi.mocked(can).mockResolvedValue(true);
   });
 
-  test("returns false when the user has no organization membership for the workspace", async () => {
-    mocks.membershipFindFirst.mockResolvedValue(null);
+  test.each([
+    ["GET", "workspace.read"],
+    ["POST", "workspace.write"],
+    ["PUT", "workspace.write"],
+    ["PATCH", "workspace.write"],
+    ["DELETE", "workspace.manage"],
+  ] as const)("maps %s to %s", async (method, action) => {
+    await expect(hasUserWorkspaceAccessForAction(userId, workspaceId, method)).resolves.toBe(true);
 
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(false);
-    expect(mocks.workspaceTeamFindMany).not.toHaveBeenCalled();
+    expect(validateInputs).toHaveBeenCalledWith(
+      [userId, expect.anything()],
+      [workspaceId, expect.anything()]
+    );
+    expect(can).toHaveBeenCalledWith({ type: "user", id: userId }, action, {
+      type: "workspace",
+      id: workspaceId,
+    });
   });
 
-  test.each(["GET", "POST", "PUT", "PATCH", "DELETE"] as const)(
-    "returns false for billing role on %s",
-    async (action) => {
-      mocks.membershipFindFirst.mockResolvedValue({ role: "billing" });
+  test("returns the central authorization denial", async () => {
+    vi.mocked(can).mockResolvedValue(false);
 
-      expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, action)).toBe(false);
-      expect(mocks.workspaceTeamFindMany).not.toHaveBeenCalled();
-    }
-  );
+    await expect(hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).resolves.toBe(false);
+  });
 
-  test.each(["owner", "manager"] as const)(
-    "returns true for %s role on any action without consulting team permissions",
-    async (role) => {
-      mocks.membershipFindFirst.mockResolvedValue({ role });
+  test("propagates central evaluator failures", async () => {
+    vi.mocked(can).mockRejectedValue(new Error("database unavailable"));
 
-      expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(true);
-      expect(mocks.workspaceTeamFindMany).not.toHaveBeenCalled();
-    }
-  );
+    await expect(hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).rejects.toThrow(
+      "database unavailable"
+    );
+  });
+});
 
-  test("returns false for member role when no team grants workspace access", async () => {
+describe("hasUserWorkspaceAccess navigation compatibility", () => {
+  const userId = "00000000-0000-0000-0000-000000000001";
+  const workspaceId = "00000000-0000-0000-0000-000000000002";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("preserves billing-role navigation access", async () => {
+    mocks.membershipFindFirst.mockResolvedValue({ role: "billing" });
+
+    await expect(hasUserWorkspaceAccess(userId, workspaceId)).resolves.toBe(true);
+
+    expect(can).not.toHaveBeenCalled();
+    expect(mocks.teamUserFindFirst).not.toHaveBeenCalled();
+  });
+
+  test("preserves member navigation access through any workspace team", async () => {
     mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
-    mocks.workspaceTeamFindMany.mockResolvedValue([]);
+    mocks.teamUserFindFirst.mockResolvedValue({ userId });
 
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(false);
-  });
-
-  test("member with read team permission can GET but cannot POST or DELETE", async () => {
-    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
-    mocks.workspaceTeamFindMany.mockResolvedValue([{ permission: "read" }]);
-
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(true);
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "POST")).toBe(false);
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(false);
-  });
-
-  test("member with readWrite team permission can GET/POST/PUT/PATCH but cannot DELETE", async () => {
-    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
-    mocks.workspaceTeamFindMany.mockResolvedValue([{ permission: "readWrite" }]);
-
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(true);
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "POST")).toBe(true);
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "PUT")).toBe(true);
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "PATCH")).toBe(true);
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(false);
-  });
-
-  test("member with manage team permission can perform any action", async () => {
-    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
-    mocks.workspaceTeamFindMany.mockResolvedValue([{ permission: "manage" }]);
-
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(true);
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "POST")).toBe(true);
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(true);
-  });
-
-  test("member in multiple teams uses the highest permission across them", async () => {
-    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
-    mocks.workspaceTeamFindMany.mockResolvedValue([
-      { permission: "read" },
-      { permission: "manage" },
-      { permission: "readWrite" },
-    ]);
-
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(true);
-  });
-
-  test("member in multiple teams none of which grant sufficient permission is denied", async () => {
-    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
-    mocks.workspaceTeamFindMany.mockResolvedValue([{ permission: "read" }, { permission: "readWrite" }]);
-
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "GET")).toBe(true);
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "POST")).toBe(true);
-    expect(await hasUserWorkspaceAccessForAction(userId, workspaceId, "DELETE")).toBe(false);
+    await expect(hasUserWorkspaceAccess(userId, workspaceId)).resolves.toBe(true);
   });
 });

--- a/apps/web/lib/workspace/auth.ts
+++ b/apps/web/lib/workspace/auth.ts
@@ -1,43 +1,27 @@
+import "server-only";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { ZId } from "@formbricks/types/common";
 import { DatabaseError } from "@formbricks/types/errors";
+import { can } from "@/lib/authorization";
+import type { LegacyWorkspaceAction } from "@/lib/authorization/legacy-workspace-access";
 import { validateInputs } from "../utils/validate";
 
-export type WorkspaceAction = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+export type WorkspaceAction = LegacyWorkspaceAction;
 
-type WorkspacePermissionLevel = "read" | "readWrite" | "manage";
-
-const ACTION_REQUIRED_PERMISSION: Record<WorkspaceAction, WorkspacePermissionLevel> = {
-  GET: "read",
-  POST: "readWrite",
-  PUT: "readWrite",
-  PATCH: "readWrite",
-  DELETE: "manage",
-};
-
-const PERMISSION_RANK: Record<WorkspacePermissionLevel, number> = {
-  read: 0,
-  readWrite: 1,
-  manage: 2,
-};
-
-const teamPermissionSatisfies = (
-  teamPermission: WorkspacePermissionLevel,
-  required: WorkspacePermissionLevel
-): boolean => PERMISSION_RANK[teamPermission] >= PERMISSION_RANK[required];
+const ACTION_PERMISSION = {
+  GET: "workspace.read",
+  POST: "workspace.write",
+  PUT: "workspace.write",
+  PATCH: "workspace.write",
+  DELETE: "workspace.manage",
+} as const satisfies Record<WorkspaceAction, "workspace.read" | "workspace.write" | "workspace.manage">;
 
 /**
- * Action-aware workspace access check for session-authenticated users.
+ * Compatibility wrapper for action-aware workspace access.
  *
- * - Billing role: never authorized — billing users are excluded from product data surfaces.
- * - Owner / manager: always authorized.
- * - Member: authorized only when a WorkspaceTeam grants a permission level that
- *   meets or exceeds the action's required level (read for GET, readWrite for
- *   POST/PUT/PATCH, manage for DELETE).
- *
- * The broader {@link hasUserWorkspaceAccess} helper does not gate by action and
- * should not be used for routes that mutate or expose workspace data.
+ * @deprecated New authorization-sensitive code must call `can` or `assertCan`
+ * with the semantic workspace action directly.
  */
 export const hasUserWorkspaceAccessForAction = async (
   userId: string,
@@ -46,54 +30,16 @@ export const hasUserWorkspaceAccessForAction = async (
 ): Promise<boolean> => {
   validateInputs([userId, ZId], [workspaceId, ZId]);
 
-  try {
-    const orgMembership = await prisma.membership.findFirst({
-      where: {
-        userId,
-        organization: {
-          workspaces: {
-            some: { id: workspaceId },
-          },
-        },
-      },
-    });
-
-    if (!orgMembership) return false;
-    if (orgMembership.role === "billing") return false;
-    if (orgMembership.role === "owner" || orgMembership.role === "manager") return true;
-
-    const workspaceTeams = await prisma.workspaceTeam.findMany({
-      where: {
-        workspaceId,
-        team: {
-          teamUsers: {
-            some: { userId },
-          },
-        },
-      },
-      select: { permission: true },
-    });
-
-    if (workspaceTeams.length === 0) return false;
-
-    // A user can belong to multiple teams that each grant access to the same
-    // workspace at different permission levels (the WorkspaceTeam unique key
-    // is [workspaceId, teamId], not [workspaceId, userId]). Pick the highest
-    // level so a `read` team membership doesn't shadow a `manage` one.
-    const highestPermission = workspaceTeams.reduce<WorkspacePermissionLevel>(
-      (max, wt) => (PERMISSION_RANK[wt.permission] > PERMISSION_RANK[max] ? wt.permission : max),
-      workspaceTeams[0].permission
-    );
-
-    return teamPermissionSatisfies(highestPermission, ACTION_REQUIRED_PERMISSION[action]);
-  } catch (error) {
-    if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      throw new DatabaseError(error.message);
-    }
-    throw error;
-  }
+  return can({ type: "user", id: userId }, ACTION_PERMISSION[action], { type: "workspace", id: workspaceId });
 };
 
+/**
+ * Navigation/layout compatibility check.
+ *
+ * @deprecated This helper is not action-aware and intentionally includes the
+ * billing role. Do not use it for new data-access or mutation authorization;
+ * migrate remaining callers under ENG-1737.
+ */
 export const hasUserWorkspaceAccess = async (userId: string, workspaceId: string) => {
   validateInputs([userId, ZId], [workspaceId, ZId]);
 

--- a/apps/web/modules/ee/analysis/lib/access.test.ts
+++ b/apps/web/modules/ee/analysis/lib/access.test.ts
@@ -5,7 +5,7 @@ import { checkFeedbackDirectoryAccess, checkWorkspaceAccess } from "./access";
 vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
-  assertCan: vi.fn(),
+  checkAuthorizationUpdated: vi.fn(),
   getFeedbackDirectoryAuthContext: vi.fn(),
   getOrganizationIdFromWorkspaceId: vi.fn(),
   loggerError: vi.fn(),
@@ -19,8 +19,8 @@ vi.mock("@formbricks/logger", () => ({
   },
 }));
 
-vi.mock("@/lib/authorization", () => ({
-  assertCan: mocks.assertCan,
+vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
+  checkAuthorizationUpdated: mocks.checkAuthorizationUpdated,
 }));
 
 vi.mock("@/lib/utils/helper", () => ({
@@ -52,7 +52,7 @@ beforeEach(() => {
 describe("checkWorkspaceAccess", () => {
   test("returns organizationId and workspaceId on successful access check", async () => {
     mocks.getOrganizationIdFromWorkspaceId.mockResolvedValue(workspaceAccessInput.organizationId);
-    mocks.assertCan.mockResolvedValue(undefined);
+    mocks.checkAuthorizationUpdated.mockResolvedValue(undefined);
 
     const result = await checkWorkspaceAccess(
       workspaceAccessInput.userId,
@@ -65,35 +65,27 @@ describe("checkWorkspaceAccess", () => {
       workspaceId: workspaceAccessInput.workspaceId,
     });
     expect(mocks.getOrganizationIdFromWorkspaceId).toHaveBeenCalledWith(workspaceAccessInput.workspaceId);
-    expect(mocks.assertCan).toHaveBeenCalledWith(
-      { type: "user", id: workspaceAccessInput.userId },
-      "workspace.write",
-      { type: "workspace", id: workspaceAccessInput.workspaceId }
-    );
+    expect(mocks.checkAuthorizationUpdated).toHaveBeenCalledWith({
+      userId: workspaceAccessInput.userId,
+      organizationId: workspaceAccessInput.organizationId,
+      access: [
+        { type: "organization", roles: ["owner", "manager"] },
+        {
+          type: "workspaceTeam",
+          minPermission: "readWrite",
+          workspaceId: workspaceAccessInput.workspaceId,
+        },
+      ],
+    });
   });
 
-  test("propagates authorization errors from the central interface", async () => {
+  test("propagates authorization errors from checkAuthorizationUpdated", async () => {
     mocks.getOrganizationIdFromWorkspaceId.mockResolvedValue(workspaceAccessInput.organizationId);
-    mocks.assertCan.mockRejectedValue(new Error("Unauthorized"));
+    mocks.checkAuthorizationUpdated.mockRejectedValue(new Error("Unauthorized"));
 
     await expect(
       checkWorkspaceAccess(workspaceAccessInput.userId, workspaceAccessInput.workspaceId, "manage")
     ).rejects.toThrow("Unauthorized");
-  });
-
-  test.each([
-    ["read", "workspace.read"],
-    ["readWrite", "workspace.write"],
-    ["manage", "workspace.manage"],
-  ] as const)("maps %s permission to %s", async (permission, action) => {
-    mocks.getOrganizationIdFromWorkspaceId.mockResolvedValue(workspaceAccessInput.organizationId);
-
-    await checkWorkspaceAccess(workspaceAccessInput.userId, workspaceAccessInput.workspaceId, permission);
-
-    expect(mocks.assertCan).toHaveBeenCalledWith({ type: "user", id: workspaceAccessInput.userId }, action, {
-      type: "workspace",
-      id: workspaceAccessInput.workspaceId,
-    });
   });
 });
 

--- a/apps/web/modules/ee/analysis/lib/access.test.ts
+++ b/apps/web/modules/ee/analysis/lib/access.test.ts
@@ -5,7 +5,7 @@ import { checkFeedbackDirectoryAccess, checkWorkspaceAccess } from "./access";
 vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
-  checkAuthorizationUpdated: vi.fn(),
+  assertCan: vi.fn(),
   getFeedbackDirectoryAuthContext: vi.fn(),
   getOrganizationIdFromWorkspaceId: vi.fn(),
   loggerError: vi.fn(),
@@ -19,8 +19,8 @@ vi.mock("@formbricks/logger", () => ({
   },
 }));
 
-vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
-  checkAuthorizationUpdated: mocks.checkAuthorizationUpdated,
+vi.mock("@/lib/authorization", () => ({
+  assertCan: mocks.assertCan,
 }));
 
 vi.mock("@/lib/utils/helper", () => ({
@@ -52,7 +52,7 @@ beforeEach(() => {
 describe("checkWorkspaceAccess", () => {
   test("returns organizationId and workspaceId on successful access check", async () => {
     mocks.getOrganizationIdFromWorkspaceId.mockResolvedValue(workspaceAccessInput.organizationId);
-    mocks.checkAuthorizationUpdated.mockResolvedValue(undefined);
+    mocks.assertCan.mockResolvedValue(undefined);
 
     const result = await checkWorkspaceAccess(
       workspaceAccessInput.userId,
@@ -65,23 +65,35 @@ describe("checkWorkspaceAccess", () => {
       workspaceId: workspaceAccessInput.workspaceId,
     });
     expect(mocks.getOrganizationIdFromWorkspaceId).toHaveBeenCalledWith(workspaceAccessInput.workspaceId);
-    expect(mocks.checkAuthorizationUpdated).toHaveBeenCalledWith({
-      userId: workspaceAccessInput.userId,
-      organizationId: workspaceAccessInput.organizationId,
-      access: [
-        { type: "organization", roles: ["owner", "manager"] },
-        { type: "workspaceTeam", minPermission: "readWrite", workspaceId: workspaceAccessInput.workspaceId },
-      ],
-    });
+    expect(mocks.assertCan).toHaveBeenCalledWith(
+      { type: "user", id: workspaceAccessInput.userId },
+      "workspace.write",
+      { type: "workspace", id: workspaceAccessInput.workspaceId }
+    );
   });
 
-  test("propagates authorization errors from checkAuthorizationUpdated", async () => {
+  test("propagates authorization errors from the central interface", async () => {
     mocks.getOrganizationIdFromWorkspaceId.mockResolvedValue(workspaceAccessInput.organizationId);
-    mocks.checkAuthorizationUpdated.mockRejectedValue(new Error("Unauthorized"));
+    mocks.assertCan.mockRejectedValue(new Error("Unauthorized"));
 
     await expect(
       checkWorkspaceAccess(workspaceAccessInput.userId, workspaceAccessInput.workspaceId, "manage")
     ).rejects.toThrow("Unauthorized");
+  });
+
+  test.each([
+    ["read", "workspace.read"],
+    ["readWrite", "workspace.write"],
+    ["manage", "workspace.manage"],
+  ] as const)("maps %s permission to %s", async (permission, action) => {
+    mocks.getOrganizationIdFromWorkspaceId.mockResolvedValue(workspaceAccessInput.organizationId);
+
+    await checkWorkspaceAccess(workspaceAccessInput.userId, workspaceAccessInput.workspaceId, permission);
+
+    expect(mocks.assertCan).toHaveBeenCalledWith({ type: "user", id: workspaceAccessInput.userId }, action, {
+      type: "workspace",
+      id: workspaceAccessInput.workspaceId,
+    });
   });
 });
 

--- a/apps/web/modules/ee/analysis/lib/access.ts
+++ b/apps/web/modules/ee/analysis/lib/access.ts
@@ -1,8 +1,7 @@
 import "server-only";
 import { logger } from "@formbricks/logger";
 import { AuthorizationError } from "@formbricks/types/errors";
-import { assertCan } from "@/lib/authorization";
-import { getWorkspaceActionForPermission } from "@/lib/authorization/compatibility";
+import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { getFeedbackDirectoryAuthContext } from "@/modules/ee/feedback-directory/lib/feedback-directory";
 import type { TTeamPermission } from "@/modules/ee/teams/workspace-teams/types/team";
@@ -14,9 +13,13 @@ export const checkWorkspaceAccess = async (
 ) => {
   const organizationId = await getOrganizationIdFromWorkspaceId(workspaceId);
 
-  await assertCan({ type: "user", id: userId }, getWorkspaceActionForPermission(minPermission), {
-    type: "workspace",
-    id: workspaceId,
+  await checkAuthorizationUpdated({
+    userId,
+    organizationId,
+    access: [
+      { type: "organization", roles: ["owner", "manager"] },
+      { type: "workspaceTeam", minPermission, workspaceId },
+    ],
   });
 
   return { organizationId, workspaceId };

--- a/apps/web/modules/ee/analysis/lib/access.ts
+++ b/apps/web/modules/ee/analysis/lib/access.ts
@@ -1,7 +1,8 @@
 import "server-only";
 import { logger } from "@formbricks/logger";
 import { AuthorizationError } from "@formbricks/types/errors";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
+import { assertCan } from "@/lib/authorization";
+import { getWorkspaceActionForPermission } from "@/lib/authorization/compatibility";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { getFeedbackDirectoryAuthContext } from "@/modules/ee/feedback-directory/lib/feedback-directory";
 import type { TTeamPermission } from "@/modules/ee/teams/workspace-teams/types/team";
@@ -13,13 +14,9 @@ export const checkWorkspaceAccess = async (
 ) => {
   const organizationId = await getOrganizationIdFromWorkspaceId(workspaceId);
 
-  await checkAuthorizationUpdated({
-    userId,
-    organizationId,
-    access: [
-      { type: "organization", roles: ["owner", "manager"] },
-      { type: "workspaceTeam", minPermission, workspaceId },
-    ],
+  await assertCan({ type: "user", id: userId }, getWorkspaceActionForPermission(minPermission), {
+    type: "workspace",
+    id: workspaceId,
   });
 
   return { organizationId, workspaceId };

--- a/apps/web/modules/ee/teams/team-list/actions.test.ts
+++ b/apps/web/modules/ee/teams/team-list/actions.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { assertCan } from "@/lib/authorization";
+import { createTeamAction, deleteTeamAction, getTeamDetailsAction, updateTeamDetailsAction } from "./actions";
+
+const mocks = vi.hoisted(() => ({
+  checkRoleManagementPermission: vi.fn(),
+  createTeam: vi.fn(),
+  deleteTeam: vi.fn(),
+  getOrganizationIdFromTeamId: vi.fn(),
+  getTeamDetails: vi.fn(),
+  updateTeamDetails: vi.fn(),
+}));
+
+vi.mock("@/lib/authorization", () => ({
+  assertCan: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/action-client", () => ({
+  authenticatedActionClient: {
+    inputSchema: vi.fn(() => ({
+      action: vi.fn((fn) => fn),
+    })),
+  },
+}));
+
+vi.mock("@/lib/utils/helper", () => ({
+  getOrganizationIdFromTeamId: mocks.getOrganizationIdFromTeamId,
+}));
+
+vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
+  withAuditLogging: vi.fn((_eventName, _objectType, fn) => fn),
+}));
+
+vi.mock("@/modules/ee/role-management/actions", () => ({
+  checkRoleManagementPermission: mocks.checkRoleManagementPermission,
+}));
+
+vi.mock("@/modules/ee/teams/lib/roles", () => ({
+  getTeamRoleByTeamIdUserId: vi.fn(),
+}));
+
+vi.mock("@/modules/ee/teams/team-list/lib/team", () => ({
+  createTeam: mocks.createTeam,
+  deleteTeam: mocks.deleteTeam,
+  getTeamDetails: mocks.getTeamDetails,
+  updateTeamDetails: mocks.updateTeamDetails,
+}));
+
+describe("team-list authorization", () => {
+  const organizationId = "org-1";
+  const teamId = "team-1";
+  const ctx = { user: { id: "user-1" }, auditLoggingCtx: {} };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getOrganizationIdFromTeamId.mockResolvedValue(organizationId);
+    mocks.createTeam.mockResolvedValue(teamId);
+    mocks.getTeamDetails.mockResolvedValue({ id: teamId, name: "Team" });
+  });
+
+  test("requires organization.manage to create a team", async () => {
+    await createTeamAction({
+      ctx,
+      parsedInput: { organizationId, name: "Team" },
+    } as never);
+
+    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user-1" }, "organization.manage", {
+      type: "organization",
+      id: organizationId,
+    });
+    expect(mocks.checkRoleManagementPermission).toHaveBeenCalledWith(organizationId);
+  });
+
+  test.each([
+    ["read details", getTeamDetailsAction, { teamId }],
+    ["update", updateTeamDetailsAction, { teamId, data: { name: "Updated" } }],
+  ] as const)("requires team.manage to %s", async (_name, action, parsedInput) => {
+    await action({ ctx, parsedInput } as never);
+
+    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user-1" }, "team.manage", {
+      type: "team",
+      id: teamId,
+    });
+  });
+
+  test("requires team.delete to delete a team", async () => {
+    await deleteTeamAction({ ctx, parsedInput: { teamId } } as never);
+
+    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user-1" }, "team.delete", {
+      type: "team",
+      id: teamId,
+    });
+  });
+
+  test("preserves entitlement checks after authorization", async () => {
+    const callOrder: string[] = [];
+    vi.mocked(assertCan).mockImplementation(async () => {
+      callOrder.push("authorize");
+    });
+    mocks.checkRoleManagementPermission.mockImplementation(async () => {
+      callOrder.push("entitlement");
+    });
+
+    await createTeamAction({
+      ctx,
+      parsedInput: { organizationId, name: "Team" },
+    } as never);
+
+    expect(callOrder).toEqual(["authorize", "entitlement"]);
+  });
+});

--- a/apps/web/modules/ee/teams/team-list/actions.ts
+++ b/apps/web/modules/ee/teams/team-list/actions.ts
@@ -2,8 +2,8 @@
 
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
+import { assertCan } from "@/lib/authorization";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromTeamId } from "@/lib/utils/helper";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import { checkRoleManagementPermission } from "@/modules/ee/role-management/actions";
@@ -23,15 +23,9 @@ const ZCreateTeamAction = z.object({
 
 export const createTeamAction = authenticatedActionClient.inputSchema(ZCreateTeamAction).action(
   withAuditLogging("created", "team", async ({ ctx, parsedInput }) => {
-    await checkAuthorizationUpdated({
-      userId: ctx.user.id,
-      organizationId: parsedInput.organizationId,
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-      ],
+    await assertCan({ type: "user", id: ctx.user.id }, "organization.manage", {
+      type: "organization",
+      id: parsedInput.organizationId,
     });
     await checkRoleManagementPermission(parsedInput.organizationId);
 
@@ -54,20 +48,9 @@ export const getTeamDetailsAction = authenticatedActionClient
   .action(async ({ parsedInput, ctx }) => {
     const organizationId = await getOrganizationIdFromTeamId(parsedInput.teamId);
 
-    await checkAuthorizationUpdated({
-      userId: ctx.user.id,
-      organizationId: organizationId,
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-        {
-          teamId: parsedInput.teamId,
-          type: "team",
-          minPermission: "admin",
-        },
-      ],
+    await assertCan({ type: "user", id: ctx.user.id }, "team.manage", {
+      type: "team",
+      id: parsedInput.teamId,
     });
 
     await checkRoleManagementPermission(organizationId);
@@ -83,15 +66,9 @@ export const deleteTeamAction = authenticatedActionClient.inputSchema(ZDeleteTea
   withAuditLogging("deleted", "team", async ({ ctx, parsedInput }) => {
     const organizationId = await getOrganizationIdFromTeamId(parsedInput.teamId);
 
-    await checkAuthorizationUpdated({
-      userId: ctx.user.id,
-      organizationId,
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-      ],
+    await assertCan({ type: "user", id: ctx.user.id }, "team.delete", {
+      type: "team",
+      id: parsedInput.teamId,
     });
 
     await checkRoleManagementPermission(organizationId);
@@ -112,20 +89,9 @@ export const updateTeamDetailsAction = authenticatedActionClient.inputSchema(ZUp
   withAuditLogging("updated", "team", async ({ ctx, parsedInput }) => {
     const organizationId = await getOrganizationIdFromTeamId(parsedInput.teamId);
 
-    await checkAuthorizationUpdated({
-      userId: ctx.user.id,
-      organizationId,
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-        {
-          type: "team",
-          teamId: parsedInput.teamId,
-          minPermission: "admin",
-        },
-      ],
+    await assertCan({ type: "user", id: ctx.user.id }, "team.manage", {
+      type: "team",
+      id: parsedInput.teamId,
     });
 
     await checkRoleManagementPermission(organizationId);

--- a/apps/web/modules/organization/settings/api-keys/actions.test.ts
+++ b/apps/web/modules/organization/settings/api-keys/actions.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { assertCan } from "@/lib/authorization";
+import { createApiKeyAction, deleteApiKeyAction, updateApiKeyAction } from "./actions";
+
+const mocks = vi.hoisted(() => ({
+  capturePostHogEvent: vi.fn(),
+  createApiKey: vi.fn(),
+  deleteApiKey: vi.fn(),
+  getOrganizationIdFromApiKeyId: vi.fn(),
+  updateApiKey: vi.fn(),
+}));
+
+vi.mock("@/lib/authorization", () => ({
+  assertCan: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/action-client", () => ({
+  authenticatedActionClient: {
+    inputSchema: vi.fn(() => ({
+      action: vi.fn((fn) => fn),
+    })),
+  },
+}));
+
+vi.mock("@/lib/posthog", () => ({
+  capturePostHogEvent: mocks.capturePostHogEvent,
+}));
+
+vi.mock("@/lib/utils/helper", () => ({
+  getOrganizationIdFromApiKeyId: mocks.getOrganizationIdFromApiKeyId,
+}));
+
+vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
+  withAuditLogging: vi.fn((_eventName, _objectType, fn) => fn),
+}));
+
+vi.mock("@/modules/organization/settings/api-keys/lib/api-key", () => ({
+  createApiKey: mocks.createApiKey,
+  deleteApiKey: mocks.deleteApiKey,
+  updateApiKey: mocks.updateApiKey,
+}));
+
+describe("API-key settings authorization", () => {
+  const organizationId = "org-1";
+  const apiKeyId = "key-1";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getOrganizationIdFromApiKeyId.mockResolvedValue(organizationId);
+    mocks.createApiKey.mockResolvedValue({ id: apiKeyId });
+    mocks.deleteApiKey.mockResolvedValue({ id: apiKeyId });
+    mocks.updateApiKey.mockResolvedValue({ id: apiKeyId });
+  });
+
+  test("requires organization.manage_api_keys to create a key", async () => {
+    await createApiKeyAction({
+      ctx: { user: { id: "user-1" }, auditLoggingCtx: {} },
+      parsedInput: {
+        organizationId,
+        apiKeyData: { label: "Automation" },
+      },
+    } as never);
+
+    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user-1" }, "organization.manage_api_keys", {
+      type: "organization",
+      id: organizationId,
+    });
+    expect(mocks.createApiKey).toHaveBeenCalled();
+  });
+
+  test.each([
+    ["delete", deleteApiKeyAction, { id: apiKeyId }],
+    ["update", updateApiKeyAction, { apiKeyId, apiKeyData: { label: "Updated" } }],
+  ] as const)("requires apiKey.manage to %s a key", async (_name, action, parsedInput) => {
+    await action({
+      ctx: { user: { id: "user-1" }, auditLoggingCtx: {} },
+      parsedInput,
+    } as never);
+
+    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user-1" }, "apiKey.manage", {
+      type: "apiKey",
+      id: apiKeyId,
+    });
+  });
+
+  test("does not mutate a key when authorization fails", async () => {
+    vi.mocked(assertCan).mockRejectedValue(new Error("not authorized"));
+
+    await expect(
+      deleteApiKeyAction({
+        ctx: { user: { id: "user-1" }, auditLoggingCtx: {} },
+        parsedInput: { id: apiKeyId },
+      } as never)
+    ).rejects.toThrow("not authorized");
+
+    expect(mocks.deleteApiKey).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/modules/organization/settings/api-keys/actions.ts
+++ b/apps/web/modules/organization/settings/api-keys/actions.ts
@@ -2,9 +2,9 @@
 
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
+import { assertCan } from "@/lib/authorization";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromApiKeyId } from "@/lib/utils/helper";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import {
@@ -21,15 +21,9 @@ const ZDeleteApiKeyAction = z.object({
 export const deleteApiKeyAction = authenticatedActionClient.inputSchema(ZDeleteApiKeyAction).action(
   withAuditLogging("deleted", "apiKey", async ({ ctx, parsedInput }) => {
     const organizationId = await getOrganizationIdFromApiKeyId(parsedInput.id);
-    await checkAuthorizationUpdated({
-      userId: ctx.user.id,
-      organizationId,
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-      ],
+    await assertCan({ type: "user", id: ctx.user.id }, "apiKey.manage", {
+      type: "apiKey",
+      id: parsedInput.id,
     });
 
     ctx.auditLoggingCtx.organizationId = organizationId;
@@ -48,15 +42,9 @@ const ZCreateApiKeyAction = z.object({
 
 export const createApiKeyAction = authenticatedActionClient.inputSchema(ZCreateApiKeyAction).action(
   withAuditLogging("created", "apiKey", async ({ ctx, parsedInput }) => {
-    await checkAuthorizationUpdated({
-      userId: ctx.user.id,
-      organizationId: parsedInput.organizationId,
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-      ],
+    await assertCan({ type: "user", id: ctx.user.id }, "organization.manage_api_keys", {
+      type: "organization",
+      id: parsedInput.organizationId,
     });
 
     ctx.auditLoggingCtx.organizationId = parsedInput.organizationId;
@@ -82,15 +70,9 @@ const ZUpdateApiKeyAction = z.object({
 export const updateApiKeyAction = authenticatedActionClient.inputSchema(ZUpdateApiKeyAction).action(
   withAuditLogging("updated", "apiKey", async ({ ctx, parsedInput }) => {
     const organizationId = await getOrganizationIdFromApiKeyId(parsedInput.apiKeyId);
-    await checkAuthorizationUpdated({
-      userId: ctx.user.id,
-      organizationId,
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-      ],
+    await assertCan({ type: "user", id: ctx.user.id }, "apiKey.manage", {
+      type: "apiKey",
+      id: parsedInput.apiKeyId,
     });
 
     ctx.auditLoggingCtx.organizationId = organizationId;

--- a/apps/web/modules/workspaces/settings/actions.test.ts
+++ b/apps/web/modules/workspaces/settings/actions.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AuthorizationError } from "@formbricks/types/errors";
 import { assertCan } from "@/lib/authorization";
 import { getTeamsByOrganizationIdAction, updateWorkspaceAction } from "./actions";
 
@@ -81,6 +82,21 @@ describe("workspace settings authorization", () => {
     expect(mocks.updateWorkspace).toHaveBeenCalledWith(workspaceId, { name: "New name" });
   });
 
+  test("does not update the workspace when authorization fails", async () => {
+    const authorizationError = new AuthorizationError("Not authorized");
+    vi.mocked(assertCan).mockRejectedValueOnce(authorizationError);
+
+    await expect(
+      updateWorkspaceAction({
+        ctx,
+        parsedInput: { workspaceId, data: { name: "New name" } },
+      } as never)
+    ).rejects.toBe(authorizationError);
+
+    expect(mocks.getWorkspace).not.toHaveBeenCalled();
+    expect(mocks.updateWorkspace).not.toHaveBeenCalled();
+  });
+
   test("requires organization.manage to list teams for workspace settings", async () => {
     await getTeamsByOrganizationIdAction({
       ctx,
@@ -91,5 +107,19 @@ describe("workspace settings authorization", () => {
       type: "organization",
       id: organizationId,
     });
+  });
+
+  test("does not list teams when authorization fails", async () => {
+    const authorizationError = new AuthorizationError("Not authorized");
+    vi.mocked(assertCan).mockRejectedValueOnce(authorizationError);
+
+    await expect(
+      getTeamsByOrganizationIdAction({
+        ctx,
+        parsedInput: { organizationId },
+      } as never)
+    ).rejects.toBe(authorizationError);
+
+    expect(mocks.getTeamsByOrganizationId).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/modules/workspaces/settings/actions.test.ts
+++ b/apps/web/modules/workspaces/settings/actions.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthorizationError } from "@formbricks/types/errors";
 import { assertCan } from "@/lib/authorization";
+import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getTeamsByOrganizationIdAction, updateWorkspaceAction } from "./actions";
 
 const mocks = vi.hoisted(() => ({
@@ -14,6 +15,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@/lib/authorization", () => ({
   assertCan: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
+  checkAuthorizationUpdated: vi.fn(),
 }));
 
 vi.mock("@/lib/utils/action-client", () => ({
@@ -69,22 +74,35 @@ describe("workspace settings authorization", () => {
     mocks.getTeamsByOrganizationId.mockResolvedValue([]);
   });
 
-  test("requires workspace.manage to update workspace settings", async () => {
+  test("preserves the organization-or-workspace-team authorization signature for workspace updates", async () => {
     await updateWorkspaceAction({
       ctx,
       parsedInput: { workspaceId, data: { name: "New name" } },
     } as never);
 
-    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user-1" }, "workspace.manage", {
-      type: "workspace",
-      id: workspaceId,
+    expect(checkAuthorizationUpdated).toHaveBeenCalledWith({
+      userId: "user-1",
+      organizationId,
+      access: [
+        {
+          schema: expect.any(Object),
+          data: { name: "New name" },
+          type: "organization",
+          roles: ["owner", "manager"],
+        },
+        {
+          type: "workspaceTeam",
+          workspaceId,
+          minPermission: "manage",
+        },
+      ],
     });
     expect(mocks.updateWorkspace).toHaveBeenCalledWith(workspaceId, { name: "New name" });
   });
 
   test("does not update the workspace when authorization fails", async () => {
     const authorizationError = new AuthorizationError("Not authorized");
-    vi.mocked(assertCan).mockRejectedValueOnce(authorizationError);
+    vi.mocked(checkAuthorizationUpdated).mockRejectedValueOnce(authorizationError);
 
     await expect(
       updateWorkspaceAction({

--- a/apps/web/modules/workspaces/settings/actions.test.ts
+++ b/apps/web/modules/workspaces/settings/actions.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { assertCan } from "@/lib/authorization";
+import { getTeamsByOrganizationIdAction, updateWorkspaceAction } from "./actions";
+
+const mocks = vi.hoisted(() => ({
+  getOrganization: vi.fn(),
+  getOrganizationIdFromWorkspaceId: vi.fn(),
+  getRemoveBrandingPermission: vi.fn(),
+  getTeamsByOrganizationId: vi.fn(),
+  getWorkspace: vi.fn(),
+  updateWorkspace: vi.fn(),
+}));
+
+vi.mock("@/lib/authorization", () => ({
+  assertCan: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/action-client", () => ({
+  authenticatedActionClient: {
+    inputSchema: vi.fn(() => ({
+      action: vi.fn((fn) => fn),
+    })),
+  },
+}));
+
+vi.mock("@/lib/organization/service", () => ({
+  getOrganization: mocks.getOrganization,
+}));
+
+vi.mock("@/lib/posthog", () => ({
+  capturePostHogEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/utils/helper", () => ({
+  getOrganizationIdFromWorkspaceId: mocks.getOrganizationIdFromWorkspaceId,
+}));
+
+vi.mock("@/lib/workspace/service", () => ({
+  getWorkspace: mocks.getWorkspace,
+}));
+
+vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
+  withAuditLogging: vi.fn((_eventName, _objectType, fn) => fn),
+}));
+
+vi.mock("@/modules/ee/license-check/lib/utils", () => ({
+  getRemoveBrandingPermission: mocks.getRemoveBrandingPermission,
+}));
+
+vi.mock("@/modules/ee/teams/team-list/lib/team", () => ({
+  getTeamsByOrganizationId: mocks.getTeamsByOrganizationId,
+}));
+
+vi.mock("@/modules/workspaces/settings/lib/workspace", () => ({
+  updateWorkspace: mocks.updateWorkspace,
+}));
+
+describe("workspace settings authorization", () => {
+  const organizationId = "org-1";
+  const workspaceId = "workspace-1";
+  const ctx = { user: { id: "user-1" }, auditLoggingCtx: {} };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getOrganizationIdFromWorkspaceId.mockResolvedValue(organizationId);
+    mocks.getWorkspace.mockResolvedValue({ id: workspaceId, name: "Old name" });
+    mocks.updateWorkspace.mockResolvedValue({ id: workspaceId, name: "New name" });
+    mocks.getTeamsByOrganizationId.mockResolvedValue([]);
+  });
+
+  test("requires workspace.manage to update workspace settings", async () => {
+    await updateWorkspaceAction({
+      ctx,
+      parsedInput: { workspaceId, data: { name: "New name" } },
+    } as never);
+
+    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user-1" }, "workspace.manage", {
+      type: "workspace",
+      id: workspaceId,
+    });
+    expect(mocks.updateWorkspace).toHaveBeenCalledWith(workspaceId, { name: "New name" });
+  });
+
+  test("requires organization.manage to list teams for workspace settings", async () => {
+    await getTeamsByOrganizationIdAction({
+      ctx,
+      parsedInput: { organizationId },
+    } as never);
+
+    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user-1" }, "organization.manage", {
+      type: "organization",
+      id: organizationId,
+    });
+  });
+});

--- a/apps/web/modules/workspaces/settings/actions.ts
+++ b/apps/web/modules/workspaces/settings/actions.ts
@@ -8,6 +8,7 @@ import { assertCan } from "@/lib/authorization";
 import { getOrganization } from "@/lib/organization/service";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
+import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { getWorkspace } from "@/lib/workspace/service";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
@@ -24,9 +25,22 @@ export const updateWorkspaceAction = authenticatedActionClient.inputSchema(ZUpda
   withAuditLogging("updated", "workspace", async ({ ctx, parsedInput }) => {
     const organizationId = await getOrganizationIdFromWorkspaceId(parsedInput.workspaceId);
 
-    await assertCan({ type: "user", id: ctx.user.id }, "workspace.manage", {
-      type: "workspace",
-      id: parsedInput.workspaceId,
+    await checkAuthorizationUpdated({
+      userId: ctx.user.id,
+      organizationId,
+      access: [
+        {
+          schema: ZWorkspaceUpdateInput,
+          data: parsedInput.data,
+          type: "organization",
+          roles: ["owner", "manager"],
+        },
+        {
+          type: "workspaceTeam",
+          workspaceId: parsedInput.workspaceId,
+          minPermission: "manage",
+        },
+      ],
     });
 
     if (

--- a/apps/web/modules/workspaces/settings/actions.ts
+++ b/apps/web/modules/workspaces/settings/actions.ts
@@ -4,10 +4,10 @@ import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { ZWorkspaceUpdateInput } from "@formbricks/types/workspace";
+import { assertCan } from "@/lib/authorization";
 import { getOrganization } from "@/lib/organization/service";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { getWorkspace } from "@/lib/workspace/service";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
@@ -24,22 +24,9 @@ export const updateWorkspaceAction = authenticatedActionClient.inputSchema(ZUpda
   withAuditLogging("updated", "workspace", async ({ ctx, parsedInput }) => {
     const organizationId = await getOrganizationIdFromWorkspaceId(parsedInput.workspaceId);
 
-    await checkAuthorizationUpdated({
-      userId: ctx.user.id,
-      organizationId,
-      access: [
-        {
-          schema: ZWorkspaceUpdateInput,
-          data: parsedInput.data,
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-        {
-          type: "workspaceTeam",
-          workspaceId: parsedInput.workspaceId,
-          minPermission: "manage",
-        },
-      ],
+    await assertCan({ type: "user", id: ctx.user.id }, "workspace.manage", {
+      type: "workspace",
+      id: parsedInput.workspaceId,
     });
 
     if (
@@ -113,15 +100,9 @@ const ZGetTeamsByOrganizationIdAction = z.object({
 export const getTeamsByOrganizationIdAction = authenticatedActionClient
   .inputSchema(ZGetTeamsByOrganizationIdAction)
   .action(async ({ ctx, parsedInput }) => {
-    await checkAuthorizationUpdated({
-      userId: ctx.user.id,
-      organizationId: parsedInput.organizationId,
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-      ],
+    await assertCan({ type: "user", id: ctx.user.id }, "organization.manage", {
+      type: "organization",
+      id: parsedInput.organizationId,
     });
     const teams = await getTeamsByOrganizationId(parsedInput.organizationId);
     return teams;


### PR DESCRIPTION
## What does this PR do?

Fixes [ENG-1714](https://linear.app/formbricks/issue/ENG-1714/route-existing-authorization-checks-through-the-central) on top of the merged ENG-1712 central authorization interface.

This PR routes the first shared authorization paths through Formbricks-owned `can()` / `assertCan()` decisions while keeping the legacy evaluator authoritative:

- translates canonical action-client organization, workspace-team, and team-admin signatures into semantic actions;
- preserves a legacy fallback for ambiguous or unusual compatibility signatures, including central-denied OR cases where legacy workspace-team grants are broader;
- splits the database-backed workspace permission ladder from its public compatibility wrapper to prevent evaluator recursion;
- migrates organization helpers, shared analysis and V3 session workspace access, organization/workspace settings, team actions, and user-managed API-key settings;
- documents the remaining API-key-principal work for ENG-1731 and long-tail migration for ENG-1737.

Authorization behavior is unchanged. There are no AuthZed network calls, schema changes, relationship writes, database migrations, environment changes, public endpoints, or new permissions. API-key principals remain out of scope.

## How should this be tested?

Precondition: run with AuthZed disabled and credentials absent; the central interface continues to select the legacy evaluator.

Automated validation completed:

- `pnpm --filter=@formbricks/web exec vitest run lib/authorization lib/utils/action-client/action-client-middleware.test.ts lib/workspace/auth.test.ts lib/organization/auth.test.ts lib/auth.test.ts modules/ee/analysis/lib/access.test.ts app/api/v3/lib/auth.test.ts 'app/(app)/workspaces/[workspaceId]/settings/organization/general/actions.test.ts' modules/ee/teams/team-list/actions.test.ts modules/organization/settings/api-keys/actions.test.ts modules/workspaces/settings/actions.test.ts` — 16 files, 145 tests passed, including the billing-role + WorkspaceTeam parity regression.
- `pnpm --filter @formbricks/web typecheck` — passed.
- `pnpm authzed:validate` with checksum-verified `zed` v1.1.1 — 27 relationships, 131 assertions, and 2 expected relations passed.
- `pnpm build --filter=@formbricks/web... --force` — 12/12 tasks passed.
- ESLint on every changed TypeScript file — passed with no findings.
- SonarCloud follow-up passed after extracting central access-item evaluation and adding an explicit role comparator.

Manual QA matrix:

1. Verify owner, manager, member, and billing organization decisions remain unchanged.
2. Verify workspace read, readWrite, and manage permission ladders, including a billing-role user with an explicit WorkspaceTeam grant, and team-admin decisions.
3. Verify authorization denials stop workspace/team/API-key mutations and preserve existing error responses.
4. Verify legacy fallback schema validation and operational evaluator failures propagate unchanged.

Risk is limited to authorization routing. Rollback is a normal PR revert. There are no data, environment, deployment, or migration steps. No UI behavior changed, so screenshots are not applicable.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read How we Code at Formbricks
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked application build output for warnings; no change-related warnings remain
- [x] Removed all `console.logs`
- [x] Based the branch on the latest `epic/authzed`
- [x] My changes don't cause any responsiveness issues
- [x] Not a first-time Formbricks contributor

### Appreciated

- [x] No UI change; screenshots are not applicable
- [x] Updated the internal authorization migration documentation