### PR TITLE
docs: document accepted risk for pnpm audit oauth-provider finding

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -138,7 +138,8 @@ overrides:
   # typeorm>sqlite3. `pnpm audit` marks these findings `dev: false`. By contributor, the 1.x line is
   # dominated by the eslint plugin graph (typescript-eslint, @vitest/eslint-plugin, eslint-config-next,
   # eslint-plugin-storybook) and the 2.x line by vite-plugin-dts>@vue/language-core across six workspace
-  # packages, plus both prettier plugins. @redocly/cli is the only root on both lines, mostly on 2.x.
+  # packages, plus both prettier plugins. Two roots sit on both lines: @redocly/cli (mostly 2.x) and
+  # @boxyhq/saml-jackson (mostly 1.x, via the node-gyp chain above).
   # What makes it tolerable is the input, not the dependency type: every one of these call sites expands
   # glob patterns supplied by library code or developer config (gaxios' cache cleanup, typeorm's entity
   # discovery, build and lint globs), never by request data.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -117,11 +117,15 @@ overrides:
   # linkify-it, protobufjs@7, undici@7 and uuid@11 all resolve to the patched version on their own now.
   # js-cookie, shell-quote and form-data@4 were retired by bumping react-use to 17.6.1 (js-cookie ^3),
   # concurrently to 9.2.4 (shell-quote 1.9.0) and @redocly/cli to 1.34.17 (form-data 4.0.6) instead.
-  # GHSA-mh99-v99m-4gvg (brace-expansion <=5.0.7) is still reported by `pnpm audit` as high: the range
-  # also matches 1.1.16 / 2.1.2, each the latest release in its line with no patch coming. Those paths
-  # are devDependency-only (eslint, prettier plugins and @redocly/cli, all via minimatch) and never run
-  # against untrusted input, so the residual risk is accepted until their consumers move to
-  # brace-expansion@5 — a pin cannot close it.
+  # GHSA-mh99-v99m-4gvg is still reported by `pnpm audit` as high, but it is now FIXABLE — re-verified
+  # 2026-08-03. The advisory was re-split upstream into per-major ranges, and both lines we resolve have
+  # since shipped a patch: `<1.1.17` (we resolve 1.1.16; 1.1.17 published 2026-07-29) and
+  # `>=2.0.0 <2.1.3` (we resolve 2.1.2; 2.1.3 published 2026-07-28). The earlier note here — "no patch
+  # coming", "a pin cannot close it" — stopped being true on those dates: re-pinning brace-expansion@1
+  # and @2 closes both. That is a dependency change needing its own lockfile and test run, so it is
+  # deferred to a follow-up PR rather than folded into an audit-comment sweep. Until then the residual
+  # risk stays acceptable for the same reason as before: these paths are devDependency-only (eslint,
+  # prettier plugins and @redocly/cli, all via minimatch) and never run against untrusted input.
   # === Accepted risk, no override possible yet (pnpm audit will keep flagging this) ===
   # ENG-1703 / GHSA-p2fr-6hmx-4528 (Dependabot alerts #612 and #613, both dismissed as tolerable risk;
   # the ticket is closed Done with the same conclusion as here). Re-verified 2026-08-03.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -113,39 +113,49 @@ overrides:
   # load-bearing: @prisma/dev pins 1.2.0.
   valibot: 1.4.2
   # === Removed once upstream caught up (kept as a record of what no longer needs a pin) ===
-  # ajv@6, @babel/core, body-parser, brace-expansion@1/@2/@5, dompurify, engine.io@6, fast-uri@3, hono,
-  # linkify-it, protobufjs@7, undici@7 and uuid@11 all resolve to the patched version on their own now.
+  # ajv@6, @babel/core, body-parser, dompurify, engine.io@6, fast-uri@3, hono, linkify-it, protobufjs@7,
+  # undici@7 and uuid@11 all resolve to the patched version on their own now.
   # js-cookie, shell-quote and form-data@4 were retired by bumping react-use to 17.6.1 (js-cookie ^3),
   # concurrently to 9.2.4 (shell-quote 1.9.0) and @redocly/cli to 1.34.17 (form-data 4.0.6) instead.
-  # GHSA-mh99-v99m-4gvg is still reported by `pnpm audit` as high, but it is now FIXABLE — re-verified
-  # 2026-08-03. The advisory was re-split upstream into per-major ranges, and both lines we resolve have
-  # since shipped a patch: `<1.1.17` (we resolve 1.1.16; 1.1.17 published 2026-07-29) and
-  # `>=2.0.0 <2.1.3` (we resolve 2.1.2; 2.1.3 published 2026-07-28). The earlier note here — "no patch
-  # coming", "a pin cannot close it" — stopped being true on those dates: re-pinning brace-expansion@1
-  # and @2 closes both. That is a dependency change needing its own lockfile and test run, so it is
-  # deferred to a follow-up PR rather than folded into an audit-comment sweep. Until then the residual
-  # risk stays acceptable — but NOT for the "devDependency-only" reason this note used to give, which was
-  # wrong. Both lines reach brace-expansion via minimatch, and both are rooted in production chains, not
-  # only dev ones: the 2.x line through `googleapis` and `@boxyhq/saml-jackson` (both apps/web
-  # `dependencies`, via gaxios>rimraf>glob and typeorm>glob) and `@ai-sdk/google-vertex` (a packages/ai
-  # `dependency`); the 1.x line through node-gyp under that same saml-jackson's typeorm>sqlite3.
-  # `pnpm audit` marks both findings `dev: false`. By contributor, the 1.x line is dominated by the
-  # eslint plugin graph (typescript-eslint, @vitest/eslint-plugin, eslint-config-next, the storybook
-  # eslint plugins) and the 2.x line by vite-plugin-dts>@vue/language-core across several workspace
-  # packages, with @redocly/cli and the prettier plugins mostly on the 2.x side.
+  # === Fixable, deferred to its own PR (ENG-2234) — brace-expansion ===
+  # NOT in the list above: every brace-expansion line we resolve (1.1.16, 2.1.2, 5.0.8) is still
+  # vulnerable, and all three are closable by re-pinning. Re-verified 2026-08-05. Two advisories now:
+  # - GHSA-mh99-v99m-4gvg (unbounded expansion length → OOM), re-split upstream into per-major ranges:
+  #   `<1.1.17` and `>=2.0.0 <2.1.3`. The 5.x line is clear of this one.
+  # - GHSA-rgw5-rvv9-x895 (unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation) covers
+  #   all three: `<1.1.18`, `>=2.0.0 <2.1.4` and `>=4.0.0 <5.0.9`.
+  # Pinning the current maintenance releases — 1.1.18 / 2.1.4 / 5.0.9, all published 2026-07-30 and all
+  # past the `minimumReleaseAge` cooldown below — closes both advisories on all three lines. That is a
+  # dependency change needing its own lockfile and test run, so it is deferred to ENG-2234 rather than
+  # folded into an audit-comment sweep; the note here goes away with that PR. (An earlier version of this
+  # note claimed no patch was coming and that a pin could not close it. Both stopped being true on
+  # 2026-07-28.)
+  # Until then the residual risk stays acceptable — but NOT for the "devDependency-only" reason this note
+  # used to give, which was wrong. Every line reaches brace-expansion via minimatch, and they are rooted
+  # in production chains, not only dev ones: the 2.x line through `googleapis` and `@boxyhq/saml-jackson`
+  # (both apps/web `dependencies`, via gaxios>rimraf>glob and typeorm>glob) and `@ai-sdk/google-vertex`
+  # (a packages/ai `dependency`); the 1.x line through node-gyp under that same saml-jackson's
+  # typeorm>sqlite3. `pnpm audit` marks these findings `dev: false`. By contributor, the 1.x line is
+  # dominated by the eslint plugin graph (typescript-eslint, @vitest/eslint-plugin, eslint-config-next,
+  # eslint-plugin-storybook) and the 2.x line by vite-plugin-dts>@vue/language-core across six workspace
+  # packages, plus both prettier plugins. @redocly/cli is the only root on both lines, mostly on 2.x.
   # What makes it tolerable is the input, not the dependency type: every one of these call sites expands
   # glob patterns supplied by library code or developer config (gaxios' cache cleanup, typeorm's entity
   # discovery, build and lint globs), never by request data.
   # === Accepted risk, no override possible yet (pnpm audit will keep flagging this) ===
   # ENG-1703 / GHSA-p2fr-6hmx-4528 (Dependabot alerts #612 and #613, both dismissed as tolerable risk;
-  # the ticket is closed Done with the same conclusion as here). Re-verified 2026-08-03.
+  # the ticket is closed Done with the same conclusion as here). Re-verified 2026-08-05.
   # @better-auth/oauth-provider 1.6.23 (used for the MCP OAuth flow, ENG-1055) fails to bind
   # access-token audiences to their authorization grant (RFC 8707 resource-indicator confusion) — a
   # client can complete a normal authorization flow and then request a JWT scoped to a resource server
-  # the authorization never covered. No pin can close it: the whole 1.6.x line is in range (latest is
-  # 1.6.25) and the patch ships only from 1.7.0-beta.4, a line that is still unreleased (currently at
-  # 1.7.0-rc.2).
-  # Why this deployment isn't exposed today — and what that rests on:
+  # the authorization never covered. No pin can close it: the whole 1.6.x stable line is in range, and the
+  # patch ships only from 1.7.0-beta.4 — a line still in pre-release. (Deliberately version-agnostic: the
+  # `latest` and `rc` tags move about weekly, so naming them here just guarantees this note rots. The
+  # rc-specific claims below are pinned to 1.7.0-rc.4, the release actually inspected.)
+  # Why this deployment isn't exposed to the escalation — and what that rests on. Note the advisory is
+  # explicit that a single-audience deployment still does not bind the resource to the authorization
+  # grant, so the spec-compliance gap remains regardless of the below; this is "not exploitable here",
+  # not "compliant":
   # - apps/web/modules/auth/lib/mcp-oauth-provider-options.ts sets a single-entry validAudiences (the
   #   MCP resource URL), so there is no second audience for a client to escalate into. This is the
   #   load-bearing mitigation, and it holds only while that array stays single-entry.
@@ -163,11 +173,11 @@ overrides:
   # to us (migration 20260702093000_add_better_auth_oauth_provider already created `oauthClient`, not
   # `oauthApplication`, with an `oauthAccessToken.token` column, not `.accessToken`, plus the `sessionId`
   # that session-bound token validity needs — and we have no SCIM), and customAccessTokenClaims.resource
-  # does not apply either (ours only returns email/name). But there is still real DDL to write:
-  # 1.7.0-rc.2 replaces `validAudiences` with a resources model and declares three tables we do not have
-  # — `oauthResource`, `oauthClientResource` and `oauthClientAssertion`. The bigger blocker is that
-  # @better-auth/oauth-provider@1.7.0-rc.2 declares `better-auth` and `@better-auth/core` as
-  # `^1.7.0-rc.2` peers, making this a coupled auth-core upgrade touching login/2FA/SSO/sessions rather
+  # does not apply either (ours only returns email/name). But there is still real DDL to write: as
+  # inspected at 1.7.0-rc.4, the line replaces `validAudiences` with a resources model and declares three
+  # tables we do not have — `oauthResource`, `oauthClientResource` and `oauthClientAssertion`. The bigger
+  # blocker is that the same release declares `better-auth` and `@better-auth/core` as matching
+  # `^1.7.0-rc.x` peers, making this a coupled auth-core upgrade touching login/2FA/SSO/sessions rather
   # than a plugin-only bump. That needs its own reviewed PR once Better Auth ships 1.7.0 stable, not an
   # audit sweep or an unattended dependency-only bump.
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -125,14 +125,17 @@ overrides:
   # and @2 closes both. That is a dependency change needing its own lockfile and test run, so it is
   # deferred to a follow-up PR rather than folded into an audit-comment sweep. Until then the residual
   # risk stays acceptable — but NOT for the "devDependency-only" reason this note used to give, which was
-  # wrong. Both lines reach brace-expansion via minimatch, and the 2.x line does so through production
-  # chains as well: `googleapis` and `@boxyhq/saml-jackson` (both apps/web `dependencies`, via
-  # gaxios>rimraf>glob and typeorm>glob) and `@ai-sdk/google-vertex` (a packages/ai `dependency`). Only
-  # the 1.x line is dev-tooling-only (eslint, prettier plugins, @redocly/cli, and node-gyp under
-  # typeorm's sqlite3); the bulk of the 2.x line is vite-plugin-dts>@vue/language-core across several
-  # workspace packages. What makes it tolerable is the input, not the dependency type: every one of these
-  # call sites expands glob patterns supplied by library code or developer config (gaxios' cache cleanup,
-  # typeorm's entity discovery, build and lint globs), never by request data.
+  # wrong. Both lines reach brace-expansion via minimatch, and both are rooted in production chains, not
+  # only dev ones: the 2.x line through `googleapis` and `@boxyhq/saml-jackson` (both apps/web
+  # `dependencies`, via gaxios>rimraf>glob and typeorm>glob) and `@ai-sdk/google-vertex` (a packages/ai
+  # `dependency`); the 1.x line through node-gyp under that same saml-jackson's typeorm>sqlite3.
+  # `pnpm audit` marks both findings `dev: false`. By contributor, the 1.x line is dominated by the
+  # eslint plugin graph (typescript-eslint, @vitest/eslint-plugin, eslint-config-next, the storybook
+  # eslint plugins) and the 2.x line by vite-plugin-dts>@vue/language-core across several workspace
+  # packages, with @redocly/cli and the prettier plugins mostly on the 2.x side.
+  # What makes it tolerable is the input, not the dependency type: every one of these call sites expands
+  # glob patterns supplied by library code or developer config (gaxios' cache cleanup, typeorm's entity
+  # discovery, build and lint globs), never by request data.
   # === Accepted risk, no override possible yet (pnpm audit will keep flagging this) ===
   # ENG-1703 / GHSA-p2fr-6hmx-4528 (Dependabot alerts #612 and #613, both dismissed as tolerable risk;
   # the ticket is closed Done with the same conclusion as here). Re-verified 2026-08-03.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -122,6 +122,40 @@ overrides:
   # are devDependency-only (eslint, prettier plugins and @redocly/cli, all via minimatch) and never run
   # against untrusted input, so the residual risk is accepted until their consumers move to
   # brace-expansion@5 — a pin cannot close it.
+  # === Accepted risk, no override possible yet (pnpm audit will keep flagging this) ===
+  # ENG-1703 / GHSA-p2fr-6hmx-4528 (Dependabot alerts #612 and #613, both dismissed as tolerable risk;
+  # the ticket is closed Done with the same conclusion as here). Re-verified 2026-08-03.
+  # @better-auth/oauth-provider 1.6.23 (used for the MCP OAuth flow, ENG-1055) fails to bind
+  # access-token audiences to their authorization grant (RFC 8707 resource-indicator confusion) — a
+  # client can complete a normal authorization flow and then request a JWT scoped to a resource server
+  # the authorization never covered. No pin can close it: the whole 1.6.x line is in range (latest is
+  # 1.6.25) and the patch ships only from 1.7.0-beta.4, a line that is still unreleased (currently at
+  # 1.7.0-rc.2).
+  # Why this deployment isn't exposed today — and what that rests on:
+  # - apps/web/modules/auth/lib/mcp-oauth-provider-options.ts sets a single-entry validAudiences (the
+  #   MCP resource URL), so there is no second audience for a client to escalate into. This is the
+  #   load-bearing mitigation, and it holds only while that array stays single-entry.
+  # - apps/web/modules/mcp/auth.ts additionally pins `audience: getMcpResourceUrl()` on the resource
+  #   server's own verifyAccessToken call. That hardens the MCP endpoint but is NOT a substitute for the
+  #   above: the option flows straight into jose's jwtVerify, whose `aud` check is a membership test, so
+  #   a token whose `aud` array also lists other audiences still passes. The advisory's workaround also
+  #   requires rejecting multi-audience tokens, which verifyOptions.audience cannot express — that would
+  #   need an explicit assert on the returned payload. And if a second audience were ever added, the
+  #   party at risk is that other resource server, which our own pin does nothing for.
+  # - Test coverage is uneven: apps/web/modules/mcp/auth.test.ts asserts the audience/issuer pin, so
+  #   that leg is guarded. Single-entry validAudiences is asserted nowhere — that is the assert worth
+  #   adding before anyone touches this config.
+  # Upgrade cost, for whoever picks up 1.7.0: the renames the 1.7 upgrade guide warns about do not apply
+  # to us (migration 20260702093000_add_better_auth_oauth_provider already created `oauthClient`, not
+  # `oauthApplication`, with an `oauthAccessToken.token` column, not `.accessToken`, plus the `sessionId`
+  # that session-bound token validity needs — and we have no SCIM), and customAccessTokenClaims.resource
+  # does not apply either (ours only returns email/name). But there is still real DDL to write:
+  # 1.7.0-rc.2 replaces `validAudiences` with a resources model and declares three tables we do not have
+  # — `oauthResource`, `oauthClientResource` and `oauthClientAssertion`. The bigger blocker is that
+  # @better-auth/oauth-provider@1.7.0-rc.2 declares `better-auth` and `@better-auth/core` as
+  # `^1.7.0-rc.2` peers, making this a coupled auth-core upgrade touching login/2FA/SSO/sessions rather
+  # than a plugin-only bump. That needs its own reviewed PR once Better Auth ships 1.7.0 stable, not an
+  # audit sweep or an unattended dependency-only bump.
 
 autoInstallPeers: true
 linkWorkspacePackages: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -124,8 +124,15 @@ overrides:
   # coming", "a pin cannot close it" — stopped being true on those dates: re-pinning brace-expansion@1
   # and @2 closes both. That is a dependency change needing its own lockfile and test run, so it is
   # deferred to a follow-up PR rather than folded into an audit-comment sweep. Until then the residual
-  # risk stays acceptable for the same reason as before: these paths are devDependency-only (eslint,
-  # prettier plugins and @redocly/cli, all via minimatch) and never run against untrusted input.
+  # risk stays acceptable — but NOT for the "devDependency-only" reason this note used to give, which was
+  # wrong. Both lines reach brace-expansion via minimatch, and the 2.x line does so through production
+  # chains as well: `googleapis` and `@boxyhq/saml-jackson` (both apps/web `dependencies`, via
+  # gaxios>rimraf>glob and typeorm>glob) and `@ai-sdk/google-vertex` (a packages/ai `dependency`). Only
+  # the 1.x line is dev-tooling-only (eslint, prettier plugins, @redocly/cli, and node-gyp under
+  # typeorm's sqlite3); the bulk of the 2.x line is vite-plugin-dts>@vue/language-core across several
+  # workspace packages. What makes it tolerable is the input, not the dependency type: every one of these
+  # call sites expands glob patterns supplied by library code or developer config (gaxios' cache cleanup,
+  # typeorm's entity discovery, build and lint globs), never by request data.
   # === Accepted risk, no override possible yet (pnpm audit will keep flagging this) ===
   # ENG-1703 / GHSA-p2fr-6hmx-4528 (Dependabot alerts #612 and #613, both dismissed as tolerable risk;
   # the ticket is closed Done with the same conclusion as here). Re-verified 2026-08-03.


### PR DESCRIPTION
## What & why

`pnpm audit` reports a moderate finding for `@better-auth/oauth-provider` 1.6.23 ([GHSA-p2fr-6hmx-4528](https://github.com/advisories/GHSA-p2fr-6hmx-4528)), the plugin backing our MCP OAuth flow (ENG-1055). The advisory is that access-token audiences aren't bound to their authorization grant (RFC 8707 resource-indicator confusion): a client can complete a normal authorization flow and then request a JWT scoped to a resource server its authorization never covered.

It can't be closed with a pin like the other entries in `pnpm-workspace.yaml`. The whole 1.6.x stable line is in range and the patch ships only from `1.7.0-beta.4` — a line still in pre-release. Adopting it isn't a plugin bump either: the pre-release declares `better-auth` and `@better-auth/core` as matching `^1.7.0-rc.x` peers, making it a coupled auth-core upgrade touching login/2FA/SSO/sessions, plus new DDL for its resources model.

So this PR does the only thing available: it records the accepted risk in the file the next auditor actually opens, inside `overrides:`, under an explicit `# === Accepted risk, no override possible yet ===` header. The note states what the mitigation actually rests on (single-entry `validAudiences` — the resource-server `audience` pin hardens the MCP endpoint but is *not* a substitute, because it resolves to jose's membership-style `aud` check), that the RFC 8707 binding gap remains even for a single-audience deployment so the note can't be read as "compliant", which of the two legs is covered by a test and which isn't, and a realistic scope for the eventual 1.7.0 upgrade.

Four follow-up commits correct the neighbouring brace-expansion paragraph, which review found wrong on four independent points — each one a stale or mis-transcribed fact rather than a behavioural defect:

1. `GHSA-mh99-v99m-4gvg` was re-split upstream into per-major ranges and the lines we resolve have shipped patches, so the note's "no patch coming" and "a pin cannot close it" were false.
2. It called the affected paths "devDependency-only". They aren't — the chains are production-rooted via `googleapis` and `@boxyhq/saml-jackson` (`apps/web` `dependencies`) and `@ai-sdk/google-vertex` (a `packages/ai` `dependency`), and `pnpm audit` marks them `dev: false`. The conclusion is unchanged but now rests on the input (glob patterns from library code and developer config, never request data) rather than on the dependency type.
3. The per-line contributor lists were attributed to the wrong lines — `vite-plugin-dts>@vue/language-core`, `@redocly/cli` and both prettier plugins are 2.x, not 1.x, and 1.x is the eslint plugin graph.
4. A **second advisory**, [`GHSA-rgw5-rvv9-x895`](https://github.com/advisories/GHSA-rgw5-rvv9-x895), now covers all three lines we resolve **including 5.0.8**. So `brace-expansion` is dropped from the "resolve to the patched version on their own now" enumeration entirely, and that paragraph moved out from under `# === Removed once upstream caught up ===` — a note whose thesis is "re-pinning closes this" doesn't belong under "what no longer needs a pin".

The oauth-provider note is also deliberately version-agnostic now. Naming the `latest` and `rc` tags is what made it rot within two days of its own re-verification stamp; the rc-specific claims are pinned to the release actually inspected.

**Comment-only change.** No dependency versions, no lockfile entries, no runtime behavior.

## Linear ticket

[ENG-1703](https://linear.app/formbricks/issue/ENG-1703/dependabot-613-better-authoauth-provider-better-authoauth-provider-may) — filed from Dependabot alerts for this GHSA (#612 and #613, both dismissed as tolerable risk) and closed `Done` on 2026-07-16 with the same "accept as documented risk" conclusion (verified via Linear). This PR surfaces that reasoning in the file rather than leaving it only in a closed ticket; `pnpm audit` is a separate channel from the Dependabot alerts, which is why the finding still shows up locally.

Follow-ups this PR points at, both filed during review: [ENG-2234](https://linear.app/formbricks/issue/ENG-2234/re-pin-brace-expansion12-to-close-ghsa-mh99-v99m-4gvg) (re-pin brace-expansion; that PR also deletes the paragraph this one corrects) and ENG-2182 (the vite + sanitize-html audit findings).

## How this was tested

Re-verified on 2026-08-05 against `main` at `4aabd0b`, since the branch sat for a week and the facts have a short half-life:

- `pnpm audit` ✅ — `@better-auth/oauth-provider` 1.6.23 still reported, first patched `1.7.0-beta.4`. No pins are touched by this PR, so it cannot change any count. Deliberately not quoting totals here: they moved twice during review (vite dropped out via #8724, then main's lockfile drift added `postcss`, `socket.io-parser`, `undici`, `fast-uri`, `ip-address` and `hono` findings). See "Risks & regressions".
- npm registry checked directly ✅ — no stable 1.7.0 exists; the `latest` and `rc` tags both moved during review, which is exactly why the note no longer names them.
- `1.7.0-rc.4` tarball inspected ✅ — peers are `better-auth: ^1.7.0-rc.4` and `@better-auth/core: ^1.7.0-rc.4`; `validAudiences` is gone; `oauthResource`, `oauthClientResource` and `oauthClientAssertion` are declared, and none of the three exist in `packages/database/schema/main.prisma` or migration `20260702093000_add_better_auth_oauth_provider`.
- Every code claim re-checked against the current tree ✅ — single-entry `validAudiences` (`mcp-oauth-provider-options.ts:20`), the `audience`/`issuer` pin (`modules/mcp/auth.ts:319-322`), `customAccessTokenClaims` returning only email/name, no SCIM anywhere, and the migration having created `oauthClient` with `oauthAccessToken.token` and `sessionId`.
- jose's audience semantics verified from source ✅ — `verifyOptions` flows into `jwtVerify` (`@better-auth/core/dist/oauth2/verify.mjs:64`) and `checkAudiencePresence` is a membership test, so a multi-audience `aud` passes. This is why the resource-server pin is described as hardening rather than as a substitute.
- The single-audience caveat checked against the advisory text ✅ — it states the binding gap remains "even where cross-audience escalation does not apply", which is what the note now says.
- Test-coverage claim ✅ — `apps/web/modules/mcp/auth.test.ts:315-321` asserts the `audience`/`issuer` pin; nothing in `apps/web` asserts `validAudiences`, so that's the assert worth adding.
- brace-expansion re-derived from the audit paths, the manifests and the registry ✅ — both advisories and every range confirmed; 1.1.18 / 2.1.4 / 5.0.9 all published 2026-07-30 and all past the 3-day `minimumReleaseAge` cooldown. Contributor roots counted from the second hop of every path: 1.1.16 is the eslint plugin graph (`typescript-eslint` 33, `@vitest/eslint-plugin` 30, `eslint-config-next` 13, `eslint-plugin-storybook` 9) plus `@boxyhq/saml-jackson` 5 and `@redocly/cli` 1; 2.1.2 is `vite-plugin-dts` 6, `@redocly/cli` 3, the two prettier plugins 2 each, and the three prod chains. `pnpm audit` caps `paths` at 100 per finding and 1.1.16 hits exactly 100, so the 1.x counts are a floor — hence "dominated by" in the note rather than an enumeration.
- YAML parses and no added line exceeds the 110-char print width.
- `pnpm test` / `pnpm lint` / `pnpm build`: delegated to CI on this head — a comment-only YAML change can't affect them and the lockfile is byte-identical. Green on every earlier head, including E2E, Docker Build, Better Auth integration tests and the Sonar gate.

Rebased onto current `main` twice during review, so every placement and attribution call was made against the current file.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Nothing to exercise in the running app or API — this PR only adds and edits YAML comments. Verification is by reading the diff.
- [ ] Read the accepted-risk block and check it against [GHSA-p2fr-6hmx-4528](https://github.com/advisories/GHSA-p2fr-6hmx-4528) and ENG-1703: the advisory range, the two mitigations and which one is load-bearing, the "not exploitable here, not compliant" caveat, the covered/uncovered test legs, and the 1.7.0 upgrade scope.
- [ ] Read the brace-expansion block and check it against [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) and [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895): both advisories are named, all three lines are described as still vulnerable and closable by re-pinning, and the deferral points at ENG-2234.
- [ ] Confirm `brace-expansion` no longer appears in the "Removed once upstream caught up" enumeration, and that the deferral paragraph sits under its own header rather than under that one.

**Preconditions / test data**

- None — no runtime behavior, no env vars, no plan or entitlement dependency, identical on Cloud and self-host.

**Risks & regressions**

- None from this change: comments only, no code, dependency or lockfile change.
- Deliberately **not** fixed here, all real dependency changes wanting their own reviewed PR and test cycle:
  - `brace-expansion` 1.1.16 / 2.1.2 / 5.0.8 — [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) and [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895), both high. This PR corrects the *note*; the pin refresh to 1.1.18 / 2.1.4 / 5.0.9 that closes both is **ENG-2234**, which also deletes the paragraph.
  - `sanitize-html` 2.17.4 — [GHSA-vccv-cmxp-4j9h](https://github.com/advisories/GHSA-vccv-cmxp-4j9h), patched in 2.17.5. Tracked in **ENG-2182**. (`vite` was the other half of that ticket and is already fixed on main via #8724.)
  - Newly surfaced by main's lockfile drift during this review, none of them tracked yet: `postcss` 8.5.18, `socket.io-parser` 4.2.6, `undici` 6.27.0 / 7.28.0 (five advisories between them), `fast-uri` 3.1.4, `ip-address` 10.2.0 (three advisories) and `hono` 4.12.27. Worth a triage sweep of their own — flagging rather than folding in.

**Migrations / env / cutover**

- none
