### PR TITLE
chore: remove dead nextBundleAnalysis config from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,11 +79,5 @@
   "engines": {
     "node": ">=20.19.0 <21 || >=22.12.0 <23 || >=24.0.0 <25"
   },
-  "packageManager": "pnpm@11.7.0",
-  "nextBundleAnalysis": {
-    "budget": 358400,
-    "budgetPercentIncreaseRed": 20,
-    "minimumChangeThreshold": 0,
-    "showDetails": true
-  }
+  "packageManager": "pnpm@11.7.0"
 }


### PR DESCRIPTION
## What & why

The root `package.json` carried a `nextBundleAnalysis` budget block that no workflow, `next.config`, or bundle-analyzer tooling anywhere in the repo actually reads — a leftover from tooling that was never wired up. The other half of the ticket (a root ESLint override that existed mainly to patch a single package) was already resolved by the prior ESLint 9 flat-config migration (#8505), so there was nothing left to fold in there. This PR removes the now-fully-dead config block.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1698/remove-or-wire-up-dead-root-config

## How this was tested

- `pnpm install` ✅
- `pnpm lint` ✅ (0 errors; only pre-existing, unrelated warnings)
- `pnpm test` ✅ (526 files / 6522 tests passed)
- `pnpm build` ✅
- Repo-wide search confirmed `nextBundleAnalysis` / bundle-analysis is not referenced by any GitHub Actions workflow, `next.config`, or application code — only in `package.json` itself.

## QA / Test Plan

This is a repo-tooling-only change with no user-facing behavior, UI, or API surface.

**How to test**

- [ ] N/A — no user-facing change. Verified via `pnpm build` / `pnpm lint` / `pnpm test` above.

**Preconditions / test data**

- none

**Risks & regressions**

- none — the removed block was inert; no CI job, script, or config ever read it.

**Migrations / env / cutover**

- none


---
_Generated by [Claude Code](https://claude.ai/code/session_01482W3UnJp3H7b9fsk8EZf6)_