### PR TITLE
fix(billing): stop reverse trial laundering into active paid plan (backport #8602 to release/5.2)

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -2373,6 +2373,7 @@ checksums:
     workspace/settings/billing/payment_error_contact_support: 3145080022ff17d06e41afe78363a6cc
     workspace/settings/billing/payment_error_failed_invoice: 5344b45e2acaf0287b69b043d37a964d
     workspace/settings/billing/payment_error_requires_action: 934ac70b26f53819314add46305b6d87
+    workspace/settings/billing/payment_method_required: 34c8095c7fe1f9c64aadf2206abf9c80
     workspace/settings/billing/pending_change_removed: c80cc7f1f83f28db186e897fb18282a3
     workspace/settings/billing/pending_plan_badge: 1283929a2810dcf6110765f387dc118e
     workspace/settings/billing/pending_plan_change_description: 6923bada769d33cadcad557521362c1f

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "Bitte kontaktiere <supportLink>hola@formbricks.com</supportLink> für Unterstützung.",
         "payment_error_failed_invoice": "Die Zahlung konnte nicht abgeschlossen werden.",
         "payment_error_requires_action": "Die Zahlung erfordert eine zusätzliche Authentifizierung.",
+        "payment_method_required": "Füge eine Zahlungsmethode hinzu, um zu einem kostenpflichtigen Tarif zu wechseln.",
         "pending_change_removed": "Geplante Planänderung entfernt.",
         "pending_plan_badge": "Geplant",
         "pending_plan_change_description": "Dein Plan wechselt am {date} zu {plan}.",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "Please contact <supportLink>hola@formbricks.com</supportLink> for support.",
         "payment_error_failed_invoice": "Payment could not be completed.",
         "payment_error_requires_action": "Payment requires additional authentication.",
+        "payment_method_required": "Add a payment method to switch to a paid plan.",
         "pending_change_removed": "Scheduled plan change removed.",
         "pending_plan_badge": "Scheduled",
         "pending_plan_change_description": "Your plan will switch to {plan} on {date}.",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "Por favor, contacta con <supportLink>hola@formbricks.com</supportLink> para recibir asistencia.",
         "payment_error_failed_invoice": "No se pudo completar el pago.",
         "payment_error_requires_action": "El pago requiere autenticación adicional.",
+        "payment_method_required": "Añade un método de pago para cambiar a un plan de pago.",
         "pending_change_removed": "Cambio de plan programado eliminado.",
         "pending_plan_badge": "Programado",
         "pending_plan_change_description": "Tu plan cambiará a {plan} el {date}.",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "Merci de contacter <supportLink>hola@formbricks.com</supportLink> pour obtenir de l'aide.",
         "payment_error_failed_invoice": "Le paiement n'a pas pu être effectué.",
         "payment_error_requires_action": "Le paiement nécessite une authentification supplémentaire.",
+        "payment_method_required": "Ajoute un moyen de paiement pour passer à un forfait payant.",
         "pending_change_removed": "Changement de formule programmé supprimé.",
         "pending_plan_badge": "Programmé",
         "pending_plan_change_description": "Votre forfait passera à {plan} le {date}.",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "Kérem, vegye fel a kapcsolatot a következő címmel támogatásért: <supportLink>hola@formbricks.com</supportLink>.",
         "payment_error_failed_invoice": "A fizetés nem volt teljesíthető.",
         "payment_error_requires_action": "A fizetés további hitelesítést igényel.",
+        "payment_method_required": "Adjon hozzá egy fizetési módot a fizetős csomagra való váltáshoz.",
         "pending_change_removed": "Az ütemezett csomagváltoztatás eltávolítva.",
         "pending_plan_badge": "Ütemezett",
         "pending_plan_change_description": "A csomagja {plan} csomagra fog váltani ekkor: {date}.",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "サポートについては<supportLink>hola@formbricks.com</supportLink>までお問い合わせください。",
         "payment_error_failed_invoice": "支払いを完了できませんでした。",
         "payment_error_requires_action": "支払いには追加の認証が必要です。",
+        "payment_method_required": "有料プランに切り替えるには、お支払い方法を追加してください。",
         "pending_change_removed": "予定されていたプラン変更を取り消しました。",
         "pending_plan_badge": "変更予定",
         "pending_plan_change_description": "プランは {date} に {plan} に切り替わります。",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "Neem contact op met <supportLink>hola@formbricks.com</supportLink> voor ondersteuning.",
         "payment_error_failed_invoice": "De betaling kon niet worden voltooid.",
         "payment_error_requires_action": "De betaling vereist aanvullende verificatie.",
+        "payment_method_required": "Voeg een betaalmethode toe om over te schakelen naar een betaald abonnement.",
         "pending_change_removed": "Geplande abonnementswijziging verwijderd.",
         "pending_plan_badge": "Gepland",
         "pending_plan_change_description": "Je abonnement wordt op {date} omgezet naar {plan}.",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "Entre em contato com <supportLink>hola@formbricks.com</supportLink> para obter suporte.",
         "payment_error_failed_invoice": "Não foi possível concluir o pagamento.",
         "payment_error_requires_action": "O pagamento requer autenticação adicional.",
+        "payment_method_required": "Adicione um método de pagamento para mudar para um plano pago.",
         "pending_change_removed": "Mudança de plano agendada removida.",
         "pending_plan_badge": "Agendado",
         "pending_plan_change_description": "Seu plano mudará para {plan} em {date}.",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "Por favor, contacta <supportLink>hola@formbricks.com</supportLink> para obter suporte.",
         "payment_error_failed_invoice": "O pagamento não pôde ser concluído.",
         "payment_error_requires_action": "O pagamento requer autenticação adicional.",
+        "payment_method_required": "Adiciona um método de pagamento para mudares para um plano pago.",
         "pending_change_removed": "Alteração de plano agendada removida.",
         "pending_plan_badge": "Agendado",
         "pending_plan_change_description": "O teu plano mudará para {plan} em {date}.",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "Te rugăm să contactezi <supportLink>hola@formbricks.com</supportLink> pentru asistență.",
         "payment_error_failed_invoice": "Plata nu a putut fi finalizată.",
         "payment_error_requires_action": "Plata necesită autentificare suplimentară.",
+        "payment_method_required": "Adaugă o metodă de plată pentru a trece la un plan plătit.",
         "pending_change_removed": "Schimbarea de plan programată a fost anulată.",
         "pending_plan_badge": "Programat",
         "pending_plan_change_description": "Abonamentul tău va trece la {plan} pe {date}.",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "Пожалуйста, свяжитесь с нами <supportLink>hola@formbricks.com</supportLink> для получения помощи.",
         "payment_error_failed_invoice": "Не удалось завершить платёж.",
         "payment_error_requires_action": "Платёж требует дополнительной аутентификации.",
+        "payment_method_required": "Добавь способ оплаты, чтобы перейти на платный тариф.",
         "pending_change_removed": "Запланированное изменение тарифа отменено.",
         "pending_plan_badge": "Запланирован",
         "pending_plan_change_description": "Твой тариф сменится на {plan} на {date}.",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "Vänligen kontakta <supportLink>hola@formbricks.com</supportLink> för support.",
         "payment_error_failed_invoice": "Betalningen kunde inte genomföras.",
         "payment_error_requires_action": "Betalningen kräver ytterligare autentisering.",
+        "payment_method_required": "Lägg till en betalningsmetod för att byta till en betald plan.",
         "pending_change_removed": "Schemalagd abonnemangsändring har tagits bort.",
         "pending_plan_badge": "Schemalagd",
         "pending_plan_change_description": "Din plan kommer att byta till {plan} den {date}.",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "Destek için lütfen <supportLink>hola@formbricks.com</supportLink> ile iletişime geç.",
         "payment_error_failed_invoice": "Ödeme tamamlanamadı.",
         "payment_error_requires_action": "Ödeme için ek doğrulama gerekiyor.",
+        "payment_method_required": "Ücretli bir plana geçmek için bir ödeme yöntemi ekle.",
         "pending_change_removed": "Planlanmış plan değişikliği kaldırıldı.",
         "pending_plan_badge": "Planlandı",
         "pending_plan_change_description": "Planınız {date} tarihinde {plan} olarak değişecek.",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "请联系 <supportLink>hola@formbricks.com</supportLink> 获取支持。",
         "payment_error_failed_invoice": "支付无法完成。",
         "payment_error_requires_action": "支付需要额外验证。",
+        "payment_method_required": "添加付款方式以切换到付费套餐。",
         "pending_change_removed": "已取消预定的方案变更。",
         "pending_plan_badge": "已预定",
         "pending_plan_change_description": "你的套餐将在 {date} 切换为 {plan}。",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -2470,6 +2470,7 @@
         "payment_error_contact_support": "如需協助，請聯絡 <supportLink>hola@formbricks.com</supportLink>。",
         "payment_error_failed_invoice": "付款無法完成。",
         "payment_error_requires_action": "付款需要額外的身份驗證。",
+        "payment_method_required": "新增付款方式以切換至付費方案。",
         "pending_change_removed": "已取消預定的方案變更。",
         "pending_plan_badge": "已排程",
         "pending_plan_change_description": "您的方案將於 {date} 切換至 {plan}。",

--- a/apps/web/modules/ee/billing/actions.ts
+++ b/apps/web/modules/ee/billing/actions.ts
@@ -388,6 +388,13 @@ export const changeBillingPlanAction = authenticatedActionClient.inputSchema(ZCh
       throw new ResourceNotFoundError("OrganizationBilling", organizationId);
     }
 
+    // Mirror the client rule server-side: a paid plan change requires a collected payment method.
+    // The client routes no-card paid changes through the add-card checkout; this rejects any direct
+    // call that bypasses it (e.g. a trialing no-card org trying to launder into active paid Pro).
+    if (parsedInput.targetPlan !== "hobby" && organization.billing.stripe?.hasPaymentMethod !== true) {
+      throw new OperationNotAllowedError("payment_method_required");
+    }
+
     const result = await switchOrganizationToCloudPlan({
       organizationId,
       customerId: organization.billing.stripeCustomerId,

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -161,6 +161,10 @@ const getActionErrorMessage = (serverError: string, t: (key: string) => string) 
     return t("workspace.settings.billing.yearly_checkout_unavailable");
   }
 
+  if (serverError === "payment_method_required") {
+    return t("workspace.settings.billing.payment_method_required");
+  }
+
   return t("common.something_went_wrong_please_try_again");
 };
 

--- a/apps/web/modules/ee/billing/lib/organization-billing.test.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.test.ts
@@ -372,6 +372,13 @@ describe("organization-billing", () => {
     }));
     mocks.subscriptionSchedulesRelease.mockResolvedValue({});
     mocks.subscriptionsUpdate.mockResolvedValue({});
+    // Default: no card at the customer level either. The payment-method check falls back to the
+    // customer default when the subscription has none, so it must always resolve to a customer.
+    mocks.customersRetrieve.mockResolvedValue({
+      id: "cus_1",
+      deleted: false,
+      invoice_settings: { default_payment_method: null },
+    });
   });
 
   test("ensureStripeCustomerForOrganization returns null when org does not exist", async () => {

--- a/apps/web/modules/ee/billing/lib/organization-billing.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.ts
@@ -907,6 +907,75 @@ const scheduleSubscriptionPlanChange = async (
   return pendingChange;
 };
 
+/**
+ * Whether a payment method has been collected for the subscription. Checks the subscription
+ * default first, then falls back to the customer-level default so a card saved on the customer
+ * (but not yet attached to the subscription) still counts — this avoids falsely blocking a
+ * legitimately card-backed org on a paid switch.
+ */
+const hasCollectedPaymentMethod = async (
+  subscription: NonNullable<Awaited<ReturnType<typeof resolveCurrentSubscription>>>,
+  customerId: string
+): Promise<boolean> => {
+  if (subscription.default_payment_method != null) {
+    return true;
+  }
+
+  if (!stripeClient) {
+    return false;
+  }
+
+  const customer = await stripeClient.customers.retrieve(customerId);
+  if (customer.deleted) {
+    return false;
+  }
+
+  return customer.invoice_settings?.default_payment_method != null;
+};
+
+/**
+ * Cancels a no-card trial at period end so the org lands on Hobby without ever being converted
+ * into a billable schedule. Releases any stray schedule first (a schedule would otherwise rebuild
+ * the trial into a billable Pro phase), then sets cancel_at_period_end so Stripe cancels the
+ * trialing subscription instead of charging it — no schedule, no card required.
+ */
+const cancelTrialToHobbyAtPeriodEnd = async (
+  organizationId: string,
+  subscription: NonNullable<Awaited<ReturnType<typeof resolveCurrentSubscription>>>
+): Promise<TOrganizationStripePendingChange> => {
+  if (!stripeClient) {
+    throw new Error("Stripe is not configured");
+  }
+
+  if (subscription.schedule) {
+    const scheduleId =
+      typeof subscription.schedule === "string" ? subscription.schedule : subscription.schedule.id;
+    await stripeClient.subscriptionSchedules.release(scheduleId, {
+      preserve_cancel_date: false,
+    });
+  }
+
+  await stripeClient.subscriptions.update(subscription.id, {
+    cancel_at_period_end: true,
+  });
+
+  const effectiveAt =
+    resolvePendingChangeEffectiveAt(subscription) ??
+    (subscription.trial_end ? new Date(subscription.trial_end * 1000).toISOString() : null) ??
+    new Date().toISOString();
+
+  const pendingChange: TOrganizationStripePendingChange = {
+    type: "plan_change",
+    targetPlan: "hobby",
+    targetInterval: "monthly",
+    effectiveAt,
+  };
+
+  await updatePendingPlanChangeSnapshot(organizationId, pendingChange);
+
+  return pendingChange;
+};
+
 export const switchOrganizationToCloudPlan = async (input: {
   organizationId: string;
   customerId: string;
@@ -931,6 +1000,23 @@ export const switchOrganizationToCloudPlan = async (input: {
 
   if (isSameSelection) {
     return { mode: "immediate", pendingChange: null, clientSecret: null, requiresAction: false };
+  }
+
+  // A trialing subscription with no payment method must never be converted into a billable
+  // subscription. The scheduled path rebuilds phases without the trial guard, ending the trial and
+  // turning phase 1 into a billable Pro phase; undoing that pending change would then leave the org
+  // on active paid Pro with no card. So special-case it: a downgrade cancels the trial (landing on
+  // Hobby, no card), and any paid switch is rejected and routed through the add-card checkout.
+  if (
+    subscription.status === "trialing" &&
+    !(await hasCollectedPaymentMethod(subscription, input.customerId))
+  ) {
+    if (input.targetPlan === "hobby") {
+      const pendingChange = await cancelTrialToHobbyAtPeriodEnd(input.organizationId, subscription);
+      return { mode: "scheduled", pendingChange, clientSecret: null, requiresAction: false };
+    }
+
+    throw new OperationNotAllowedError("payment_method_required");
   }
 
   if (isImmediateUpgrade) {
@@ -1397,6 +1483,10 @@ export const syncOrganizationBillingFromStripe = async (
   const subscriptionStatus = resolveSubscriptionStatus(subscription);
   const usageCycleAnchor = resolveUsageCycleAnchor(subscription);
   const pendingChange = await resolvePendingPlanChange(subscription);
+  // Match the guard in switchOrganizationToCloudPlan / changeBillingPlanAction: a card saved on the
+  // customer (but not yet attached to the subscription) still counts, so the cached flag must not
+  // falsely block a legitimately card-backed org on a paid switch.
+  const hasPaymentMethod = subscription ? await hasCollectedPaymentMethod(subscription, customerId) : false;
 
   const transition = resolveSubscriptionLifecycleTransition(
     existingStripeSnapshot,
@@ -1423,7 +1513,7 @@ export const syncOrganizationBillingFromStripe = async (
       interval: billingInterval,
       subscriptionStatus,
       subscriptionId: subscription?.id ?? null,
-      hasPaymentMethod: subscription?.default_payment_method != null,
+      hasPaymentMethod,
       features: featureLookupKeys,
       pendingChange,
       // Clear the payment-failure banner only when this sync reflects a real settlement:


### PR DESCRIPTION
Backport of #8602 into `release/5.2`.

Minimal, single-fix backport per policy — critical billing/data-integrity fix.

## What & why
Original: `fix(billing): stop reverse trial laundering into active paid plan [ENG-1968]` (#8602). A trialing subscription with no payment method could be laundered into an active paid Pro plan via the scheduled-change path (schedule rebuild dropped the trial guard; undoing the pending change then left the org on paid Pro with no card). The fix special-cases no-card trials in `switchOrganizationToCloudPlan`: a downgrade cancels the trial to Hobby at period end (no schedule, no card), and any paid switch is rejected and routed through add-card checkout. `syncOrganizationBillingFromStripe` uses the same `hasCollectedPaymentMethod` guard (subscription default, falling back to the customer default).

## Cherry-pick
- `git cherry-pick -x 2f8d1682acbdb714778616951ab7135159940b07` (squash commit, clean — no conflicts).

## Files changed (code)
- `modules/ee/billing/lib/organization-billing.ts` (+92) — `hasCollectedPaymentMethod`, `cancelTrialToHobbyAtPeriodEnd`, no-card-trial guard in `switchOrganizationToCloudPlan`, guard reuse in sync.
- `modules/ee/billing/actions.ts` (+7), `modules/ee/billing/components/pricing-table.tsx` (+4) — surface the `payment_method_required` path.
- `locales/en-US.json` + 14 machine-generated locales + `i18n.lock` — one new billing string.

## Dropped per policy (no net-new tests)
- Dropped the **304 net-new test cases** the original PR added to `organization-billing.test.ts`.
- **Kept** the one edit to the existing `beforeEach` (a default `customersRetrieve` mock) — required so the pre-existing suite still passes against the new payment-method check. Test file delta here is +7 (mock only), not +305.

## Validation
- `pnpm eslint` on the four touched source files — PASS (no `--fix`).
- `pnpm vitest run modules/ee/billing/lib/organization-billing.test.ts` — PASS, 53/53 (existing cases, new code path exercised via the retained mock).

## QA / Test Plan

**How to test**
- [ ] Org on a **trialing** subscription with **no card** attached → attempt to switch to a paid plan (e.g. Pro): the switch is rejected and you're routed to add-card checkout (`payment_method_required`), not converted to active paid Pro.
- [ ] Same no-card trial → **downgrade to Hobby**: the trial is cancelled at period end and the org lands on Hobby (no billable schedule created, no card required).
- [ ] Org with a card saved at the **customer** level (not on the subscription) → paid switch still allowed (fallback check passes).
- [ ] Stripe webhook sync (`syncOrganizationBillingFromStripe`) on the above states produces the correct snapshot and does not flip a no-card trial into active paid.

**Preconditions / test data**
- Stripe test mode; a trialing subscription without a default payment method; a second customer with a customer-level default payment method.

**Risks & regressions**
- Scope limited to `modules/ee/billing`. Re-check normal paid upgrade/downgrade for card-backed orgs is unaffected (covered by the retained existing unit tests).

**Migrations / env / cutover**
- none
