### PR TITLE
fix(docker): remove npm from runtime image

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -74,6 +74,19 @@ jobs:
             cubejs_api_url=http://localhost:4000
             cubejs_api_secret=build-time-placeholder
 
+      - name: Verify Runtime Image Excludes npm
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          docker run --rm --entrypoint sh "formbricks-test:$GITHUB_SHA" -c '
+            set -eu
+            test ! -d /usr/local/lib/node_modules/npm
+            ! command -v npm >/dev/null 2>&1
+            ! command -v npx >/dev/null 2>&1
+            node --version
+          '
+
       - name: Reject Invalid Environment Before Database Setup
         shell: bash
         env:

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -80,10 +80,11 @@ RUN --mount=type=secret,id=database_url \
 #
 FROM base AS runner
 
-# Upgrade Alpine system packages to pick up security patches, update npm to the patched 11.x line, then create user
-# Note: npm is updated in the runtime image so any bundled transitive packages scanned from the base image are patched
+# Upgrade Alpine system packages, remove build-only npm tooling from the runtime image, then create user.
+# The application and startup migrations run directly with Node.js; npm and npx are only needed in the installer.
 RUN apk update && apk upgrade --no-cache \
-    && npm install --ignore-scripts -g npm@11.17.0 \
+    && rm -rf /usr/local/lib/node_modules/npm \
+    && rm -f /usr/local/bin/npm /usr/local/bin/npx \
     && addgroup -S nextjs \
     && adduser -S -u 1001 -G nextjs nextjs
 


### PR DESCRIPTION
## What & why

AWS Inspector reports 11 findings in the current production and staging images from dependencies
bundled with npm in the final Node.js image (`tar`, `undici`, and `brace-expansion`: 6 high,
3 medium, and 2 low). Formbricks installs dependencies in the installer stage and starts both
migrations and the application directly with Node.js, so npm and npx are not required at runtime.

This removes npm and npx from the final runner image after applying Alpine upgrades. It also adds
a Docker validation step that fails if either command or npm's package directory is present, while
confirming Node.js remains available.

## Linear ticket

Fixes: ENG-2050

## How this was tested

- Full production image build for `linux/arm64` ✅
- Runtime image assertion ✅ npm package directory, `npm`, and `npx` are absent; Node.js v24.18.0,
  the startup script, and the standalone server remain available
- Container startup validation ✅ the default command runs and rejects an intentionally invalid
  environment before database setup
- Trivy v0.68.1 image scan with a freshly downloaded vulnerability database ✅ zero findings
- `pnpm --config.verify-deps-before-run=false lint` ✅ passed with existing warnings only
- Workflow YAML parse and `git diff --check` ✅

## QA / Test Plan

**How to test**

- [ ] Deploy the candidate image to staging and request `GET /health` → the endpoint returns HTTP
  200 after startup and migrations complete.
- [ ] Sign in to the staging app and open an existing environment → the app loads and normal
  authenticated navigation works.
- [ ] Restart the staging workload → the new container becomes ready without a migration or
  application startup regression.

**Preconditions / test data**

- A staging deployment using the candidate multi-architecture ECR image and the normal staging
  database, Redis, and application secrets.
- A valid staging user with access to an existing organization and environment.

**Risks & regressions**

- Operational scripts that unexpectedly invoke npm or npx inside the production container would
  no longer work. The application and migration startup paths invoke Node.js directly, and CI now
  enforces that runtime contract.

**Migrations / env / cutover**

- No database migrations or environment variable changes.
- Roll out through staging before production, then allow AWS Inspector continuous scanning to
  evaluate both architecture-specific ECR image manifests.
