### PR TITLE
ci: fall back to db:migrate:dev when db:migrate:ci is absent

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -156,7 +156,15 @@ jobs:
           # @formbricks/database is already built by the "Build App" step above,
           # so run the migration runner directly instead of db:migrate:dev
           # (which would rebuild + re-generate the package unnecessarily).
-          pnpm --filter=@formbricks/database db:migrate:ci
+          # db:migrate:ci was added in #8627; PR branches cut before it lack the
+          # script (this workflow runs from the base ref against the PR-head code),
+          # so fall back to db:migrate:dev, which every older branch already has.
+          if node -e "process.exit(require('./packages/database/package.json').scripts['db:migrate:ci'] ? 0 : 1)"; then
+            pnpm --filter=@formbricks/database db:migrate:ci
+          else
+            echo "::warning::db:migrate:ci absent on this ref (predates #8627); falling back to db:migrate:dev"
+            pnpm --filter=@formbricks/database db:migrate:dev
+          fi
 
       - name: Run Rate Limiter Load Tests
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -132,7 +132,16 @@ jobs:
         # @formbricks/database is already built by the "Build workspace package
         # dependencies" step above, so run the migration runner directly instead
         # of db:migrate:dev (which would rebuild + re-generate the package).
-        run: pnpm --filter=@formbricks/database db:migrate:ci
+        # db:migrate:ci was added in #8627; PR branches cut before it lack the
+        # script (this workflow runs from the base ref against the PR-head code),
+        # so fall back to db:migrate:dev, which every older branch already has.
+        run: |
+          if node -e "process.exit(require('./packages/database/package.json').scripts['db:migrate:ci'] ? 0 : 1)"; then
+            pnpm --filter=@formbricks/database db:migrate:ci
+          else
+            echo "::warning::db:migrate:ci absent on this ref (predates #8627); falling back to db:migrate:dev"
+            pnpm --filter=@formbricks/database db:migrate:dev
+          fi
         shell: bash
 
       # Shared with apps/web/integration/global-setup.ts (the local harness applies the same file) so


### PR DESCRIPTION
## What & why

The E2E and Better Auth integration workflows started calling `pnpm --filter=@formbricks/database db:migrate:ci` for the migration step in #8627. That script was **added** in the same PR (previously the step ran `db:migrate:dev`).

For `pull_request` runs, the workflow *definition* comes from the base ref (main, which calls `db:migrate:ci`) while `./.github/actions/dangerous-git-checkout` restores the **PR-head** code. So any PR branch cut before #8627 has no `db:migrate:ci` in its `packages/database/package.json`, and the step hard-fails:

```
[ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT] None of the selected packages has a "db:migrate:ci" script
```

This is currently failing **every open PR that hasn't merged main since #8627** (E2E + Better Auth checks), independent of the PR's own changes.

## Solution

Make the migration step resilient in both `e2e.yml` and `integration-tests.yml`: run `db:migrate:ci` when the checked-out ref has it (the fast path, unchanged for up-to-date branches), otherwise fall back to `db:migrate:dev` — the exact command CI used before #8627, which every older branch already ships.

```bash
if node -e "process.exit(require('./packages/database/package.json').scripts['db:migrate:ci'] ? 0 : 1)"; then
  pnpm --filter=@formbricks/database db:migrate:ci
else
  pnpm --filter=@formbricks/database db:migrate:dev
fi
```

Fixes the failure fleet-wide the moment it lands on main, since PR CI runs the base-ref workflow definition.

## Linear ticket

No ticket — CI infra fix. Recurring failure observed across open PRs (e.g. #8588).

## How this was tested

- `python3 -c "import yaml; yaml.safe_load(...)"` on both workflow files ✅ — parse cleanly.
- `node -e "...scripts['db:migrate:ci']..."` against current `packages/database/package.json` ✅ — detects the script (fast path preserved on up-to-date branches).
- Fallback command `db:migrate:dev` is the pre-#8627 CI command, already proven on older branches.

## QA / Test Plan

**How to test**

- [ ] On this PR (branched from current main): E2E + Better Auth migration step runs `db:migrate:ci` (fast path) and passes.
- [ ] On any open PR branched before #8627 (e.g. #8588) after this merges: the migration step logs the `db:migrate:ci absent … falling back to db:migrate:dev` warning and the migration succeeds.

**Preconditions / test data**

- None. CI-only change.

**Risks & regressions**

- Up-to-date branches keep the exact `db:migrate:ci` behavior (guarded by the presence check). Only branches missing the script change behavior, and only to the command they used previously.

**Migrations / env / cutover**

- none