### PR TITLE
docs: remove embedded YouTube videos from docs

### DIFF
--- a/docs/surveys/general-features/multi-language-surveys.mdx
+++ b/docs/surveys/general-features/multi-language-surveys.mdx
@@ -10,16 +10,6 @@ How to deliver a specific language depends on the survey type (app or link surve
 
 - Link survey: Add a `lang` parameter in the survey URL. [Read this guide for Link Surveys](#link-surveys-configuration)
 
-<iframe
-  width="560"
-  height="315"
-  src="https://www.youtube-nocookie.com/embed/Vol5zjYIoos?si=bdP2y3uk8-xR0uSD&controls=0"
-  title="Formbricks Multi-language Surveys"
-  frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
-/>
-
 ---
 
 ## Creating a Multi-language Survey

--- a/docs/surveys/link-surveys/source-tracking.mdx
+++ b/docs/surveys/link-surveys/source-tracking.mdx
@@ -6,10 +6,6 @@ icon: "display-chart-up"
 
 Understand the source a survey respondent comes from when responding to your survey – all while keeping data privacy standards high!
 
-Check out this video to learn more about source tracking in link surveys:
-
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/CytWhuyEMVI?si=nxRrdMmlsQ5P6wwp&amp;controls=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
 ## Purpose
 
 Source tracking for link surveys is essential when you:


### PR DESCRIPTION
## What & why

Two docs pages embedded YouTube videos via `<iframe>`. This removes those embeds so the docs no longer link out to YouTube:

- **Source Tracking** (`docs/surveys/link-surveys/source-tracking.mdx`) — removed the embedded video and its "Check out this video to learn more…" lead-in line.
- **Multi-language Surveys** (`docs/surveys/general-features/multi-language-surveys.mdx`) — removed the embedded video (the `---` divider and surrounding copy are kept).

Content-only change; no other text referenced the removed videos.

Note: the "Add Image / Video" page still documents that the product supports YouTube/Vimeo/Loom URLs for video questions — that's a product feature, not an embedded video, so it's intentionally left untouched.

## Linear ticket

No ticket — housekeeping to remove embedded YouTube videos from the docs.

## How this was tested

- Docs-only content removal (Mintlify MDX); no application code or tests are affected, so no automated suite applies.
- Reviewed the full diff: only the two `<iframe>` blocks (and the one lead-in sentence) were removed; surrounding headings, dividers, and copy are intact.
- `grep -rniE "youtube|youtu\.be" docs` confirms no embedded YouTube iframes remain — the only remaining hits are the intentional feature-doc mentions on the "Add Image / Video" page.

## QA / Test Plan

**How to test**

- [ ] Open the docs site → **Surveys → Link Surveys → Source Tracking**. Expected: no embedded video, and no "Check out this video…" line; the page reads from the intro straight into the **Purpose** section.
- [ ] Open **Surveys → General Features → Multi-language Surveys**. Expected: no embedded video between the intro bullets and the **Creating a Multi-language Survey** section; the horizontal divider is still present.
- [ ] Open **Surveys → General Features → Add Image / Video**. Expected: unchanged — still states "We support YouTube, Vimeo, and Loom URLs" and the YouTube Privacy Mode note (verifies feature docs were not removed).

**Preconditions / test data**

- Access to the published or preview docs site. No accounts, seed data, or feature flags required.

**Risks & regressions**

- Minimal — content-only removal on two pages. Nothing elsewhere links to the removed videos. Re-check that both pages render without a dangling divider or empty gap.

**Migrations / env / cutover**

- none
