### PR TITLE
feat: project organization memberships to SpiceDB

### DIFF
--- a/apps/web/lib/authzed/__mocks__/client-dependencies.ts
+++ b/apps/web/lib/authzed/__mocks__/client-dependencies.ts
@@ -3,9 +3,11 @@ import { vi } from "vitest";
 export const sdkMocks = {
   close: vi.fn(),
   deadlineInterceptor: vi.fn((timeoutMs: number) => ({ timeoutMs })),
+  deleteRelationships: vi.fn(),
   diffSchema: vi.fn(),
   newClient: vi.fn(),
   readSchema: vi.fn(),
+  writeRelationships: vi.fn(),
   writeSchema: vi.fn(),
 };
 
@@ -33,6 +35,10 @@ vi.mock("@authzed/authzed-node", () => ({
       SECURE: 0,
     },
     NewClient: sdkMocks.newClient,
+    RelationshipUpdate_Operation: {
+      DELETE: 3,
+      TOUCH: 2,
+    },
   },
 }));
 

--- a/apps/web/lib/authzed/client.test.ts
+++ b/apps/web/lib/authzed/client.test.ts
@@ -9,9 +9,11 @@ describe("AuthZed client facade", () => {
     closeAuthzedClient();
     sdkMocks.close.mockReset();
     sdkMocks.deadlineInterceptor.mockClear();
+    sdkMocks.deleteRelationships.mockReset();
     sdkMocks.diffSchema.mockReset();
     sdkMocks.newClient.mockReset();
     sdkMocks.readSchema.mockReset();
+    sdkMocks.writeRelationships.mockReset();
     sdkMocks.writeSchema.mockReset();
     configMocks.isAuthzedEnabled.mockReset();
     retryMocks.execute.mockClear();
@@ -23,8 +25,10 @@ describe("AuthZed client facade", () => {
     sdkMocks.newClient.mockReturnValue({
       close: sdkMocks.close,
       promises: {
+        deleteRelationships: sdkMocks.deleteRelationships,
         diffSchema: sdkMocks.diffSchema,
         readSchema: sdkMocks.readSchema,
+        writeRelationships: sdkMocks.writeRelationships,
         writeSchema: sdkMocks.writeSchema,
       },
     });
@@ -95,9 +99,11 @@ describe("AuthZed client facade", () => {
     expect(sdkMocks.newClient).toHaveBeenCalledTimes(1);
     expect(Object.keys(first).sort()).toEqual([
       "consistency",
+      "deleteRelationships",
       "diffSchema",
       "readSchema",
       "systemKey",
+      "writeRelationships",
       "writeSchema",
     ]);
     expect(first).not.toHaveProperty("token");
@@ -176,5 +182,149 @@ describe("AuthZed client facade", () => {
 
     expect(sdkMocks.writeSchema).toHaveBeenCalledWith({ schema: "definition user {}" });
     expect(retryMocks.execute).toHaveBeenCalledWith("write_schema", expect.any(Function));
+  });
+
+  test("translates Formbricks relationship updates without exposing SDK responses", async () => {
+    sdkMocks.writeRelationships.mockResolvedValue({ writtenAt: { token: "private-revision" } });
+
+    await expect(
+      getAuthzedClient().writeRelationships([
+        {
+          operation: "touch",
+          relationship: {
+            relation: "owner",
+            resource: { objectId: "org-1", objectType: "organization" },
+            subject: { objectId: "user-1", objectType: "user" },
+          },
+        },
+        {
+          operation: "delete",
+          relationship: {
+            relation: "manager",
+            resource: { objectId: "org-1", objectType: "organization" },
+            subject: { objectId: "user-1", objectType: "user", relation: "member" },
+          },
+        },
+      ])
+    ).resolves.toBeUndefined();
+
+    expect(sdkMocks.writeRelationships).toHaveBeenCalledWith({
+      optionalPreconditions: [],
+      updates: [
+        {
+          operation: 2,
+          relationship: {
+            optionalCaveat: undefined,
+            optionalExpiresAt: undefined,
+            relation: "owner",
+            resource: { objectId: "org-1", objectType: "organization" },
+            subject: {
+              object: { objectId: "user-1", objectType: "user" },
+              optionalRelation: "",
+            },
+          },
+        },
+        {
+          operation: 3,
+          relationship: {
+            optionalCaveat: undefined,
+            optionalExpiresAt: undefined,
+            relation: "manager",
+            resource: { objectId: "org-1", objectType: "organization" },
+            subject: {
+              object: { objectId: "user-1", objectType: "user" },
+              optionalRelation: "member",
+            },
+          },
+        },
+      ],
+    });
+    expect(retryMocks.execute).toHaveBeenCalledWith("write_relationships", expect.any(Function));
+  });
+
+  test.each([0, 1_001])(
+    "rejects a relationship batch with %i updates before an SDK request",
+    async (batchSize) => {
+      const updates = Array.from({ length: batchSize }, () => ({
+        operation: "touch" as const,
+        relationship: {
+          relation: "owner",
+          resource: { objectId: "org-1", objectType: "organization" },
+          subject: { objectId: "user-1", objectType: "user" },
+        },
+      }));
+
+      await expect(getAuthzedClient().writeRelationships(updates)).rejects.toMatchObject({
+        attempts: 0,
+        code: AUTHZED_ERROR_CODES.INVALID_REQUEST,
+      });
+      expect(sdkMocks.writeRelationships).not.toHaveBeenCalled();
+    }
+  );
+
+  test("requires a narrowed relationship delete filter", async () => {
+    await expect(
+      getAuthzedClient().deleteRelationships({
+        resourceId: "",
+        resourceType: "organization",
+      })
+    ).rejects.toMatchObject({
+      attempts: 0,
+      code: AUTHZED_ERROR_CODES.INVALID_REQUEST,
+    });
+    expect(sdkMocks.deleteRelationships).not.toHaveBeenCalled();
+  });
+
+  test("translates a resource-scoped bulk delete through the resilience pipeline", async () => {
+    sdkMocks.deleteRelationships.mockResolvedValue({ deletedAt: { token: "private-revision" } });
+
+    await expect(
+      getAuthzedClient().deleteRelationships({
+        resourceId: "org-1",
+        resourceType: "organization",
+      })
+    ).resolves.toBeUndefined();
+
+    expect(sdkMocks.deleteRelationships).toHaveBeenCalledWith({
+      optionalAllowPartialDeletions: false,
+      optionalLimit: 0,
+      optionalPreconditions: [],
+      relationshipFilter: {
+        optionalRelation: "",
+        optionalResourceId: "org-1",
+        optionalResourceIdPrefix: "",
+        optionalSubjectFilter: undefined,
+        resourceType: "organization",
+      },
+    });
+    expect(retryMocks.execute).toHaveBeenCalledWith("delete_relationships", expect.any(Function));
+  });
+
+  test("translates a subject-scoped bulk delete without broadening the resource filter", async () => {
+    sdkMocks.deleteRelationships.mockResolvedValue({ deletedAt: { token: "private-revision" } });
+
+    await expect(
+      getAuthzedClient().deleteRelationships({
+        resourceType: "organization",
+        subject: { objectId: "user-1", objectType: "user" },
+      })
+    ).resolves.toBeUndefined();
+
+    expect(sdkMocks.deleteRelationships).toHaveBeenCalledWith({
+      optionalAllowPartialDeletions: false,
+      optionalLimit: 0,
+      optionalPreconditions: [],
+      relationshipFilter: {
+        optionalRelation: "",
+        optionalResourceId: "",
+        optionalResourceIdPrefix: "",
+        optionalSubjectFilter: {
+          optionalRelation: undefined,
+          optionalSubjectId: "user-1",
+          subjectType: "user",
+        },
+        resourceType: "organization",
+      },
+    });
   });
 });

--- a/apps/web/lib/authzed/client.ts
+++ b/apps/web/lib/authzed/client.ts
@@ -15,11 +15,57 @@ export type TAuthzedSchemaDiff = Readonly<{
   differenceKinds: Readonly<Record<string, number>>;
 }>;
 
+export type TAuthzedObjectReference = Readonly<{
+  objectId: string;
+  objectType: string;
+}>;
+
+export type TAuthzedSubjectReference = TAuthzedObjectReference &
+  Readonly<{
+    relation?: string;
+  }>;
+
+export type TAuthzedRelationship = Readonly<{
+  relation: string;
+  resource: TAuthzedObjectReference;
+  subject: TAuthzedSubjectReference;
+}>;
+
+export type TAuthzedRelationshipUpdate = Readonly<{
+  operation: "delete" | "touch";
+  relationship: TAuthzedRelationship;
+}>;
+
+type TAuthzedSubjectFilter = Readonly<{
+  objectId: string;
+  objectType: string;
+  relation?: string;
+}>;
+
+type TAuthzedRelationshipFilterBase = Readonly<{
+  relation?: string;
+  resourceType: string;
+}>;
+
+export type TAuthzedRelationshipFilter =
+  | (TAuthzedRelationshipFilterBase &
+      Readonly<{
+        resourceId: string;
+        subject?: TAuthzedSubjectFilter;
+      }>)
+  | (TAuthzedRelationshipFilterBase &
+      Readonly<{
+        resourceId?: never;
+        subject: TAuthzedSubjectFilter;
+      }>);
+
 export type TAuthzedClient = Readonly<{
   consistency: TAuthzedConsistency;
+  deleteRelationships: (filter: TAuthzedRelationshipFilter) => Promise<void>;
   diffSchema: (schemaText: string) => Promise<TAuthzedSchemaDiff>;
   readSchema: () => Promise<TAuthzedSchema>;
   systemKey: string;
+  writeRelationships: (updates: ReadonlyArray<TAuthzedRelationshipUpdate>) => Promise<void>;
   writeSchema: (schemaText: string) => Promise<void>;
 }>;
 
@@ -46,6 +92,8 @@ type TAuthzedConfig =
 const globalForAuthzed = globalThis as unknown as {
   formbricksAuthzedClient: TAuthzedClientSingleton | undefined;
 };
+
+const AUTHZED_MAX_RELATIONSHIP_UPDATES = 1_000;
 
 const STABLE_SCHEMA_DIFF_KINDS = {
   caveatAdded: "caveat_added",
@@ -101,6 +149,58 @@ const getAuthzedConfig = (): TAuthzedConfig => {
   };
 };
 
+const isNonEmpty = (value: string): boolean => value.length > 0;
+
+const validateRelationshipUpdates = (updates: ReadonlyArray<TAuthzedRelationshipUpdate>): void => {
+  if (updates.length === 0 || updates.length > AUTHZED_MAX_RELATIONSHIP_UPDATES) {
+    throw new AuthzedError({
+      attempts: 0,
+      code: AUTHZED_ERROR_CODES.INVALID_REQUEST,
+      operation: "write_relationships",
+      retryable: false,
+    });
+  }
+
+  const valid = updates.every(
+    ({ relationship }) =>
+      isNonEmpty(relationship.resource.objectType) &&
+      isNonEmpty(relationship.resource.objectId) &&
+      isNonEmpty(relationship.relation) &&
+      isNonEmpty(relationship.subject.objectType) &&
+      isNonEmpty(relationship.subject.objectId) &&
+      (relationship.subject.relation === undefined || isNonEmpty(relationship.subject.relation))
+  );
+
+  if (!valid) {
+    throw new AuthzedError({
+      attempts: 0,
+      code: AUTHZED_ERROR_CODES.INVALID_REQUEST,
+      operation: "write_relationships",
+      retryable: false,
+    });
+  }
+};
+
+const validateRelationshipFilter = (filter: TAuthzedRelationshipFilter): void => {
+  const hasResourceId = filter.resourceId !== undefined && isNonEmpty(filter.resourceId);
+  const hasSubjectId = filter.subject !== undefined && isNonEmpty(filter.subject.objectId);
+  const valid =
+    isNonEmpty(filter.resourceType) &&
+    (filter.relation === undefined || isNonEmpty(filter.relation)) &&
+    (filter.subject === undefined ||
+      (isNonEmpty(filter.subject.objectType) &&
+        (filter.subject.relation === undefined || isNonEmpty(filter.subject.relation))));
+
+  if (!valid || (!hasResourceId && !hasSubjectId)) {
+    throw new AuthzedError({
+      attempts: 0,
+      code: AUTHZED_ERROR_CODES.INVALID_REQUEST,
+      operation: "delete_relationships",
+      retryable: false,
+    });
+  }
+};
+
 const createAuthzedClient = (): TAuthzedClientSingleton => {
   const config = getAuthzedConfig();
 
@@ -122,6 +222,32 @@ const createAuthzedClient = (): TAuthzedClientSingleton => {
 
   const facade = Object.freeze<TAuthzedClient>({
     consistency: config.consistency,
+    deleteRelationships: async (filter) => {
+      validateRelationshipFilter(filter);
+
+      await executeAuthzedOperation("delete_relationships", async () => {
+        await sdkClient.promises.deleteRelationships({
+          optionalAllowPartialDeletions: false,
+          optionalLimit: 0,
+          optionalPreconditions: [],
+          relationshipFilter: {
+            optionalRelation: filter.relation ?? "",
+            optionalResourceId: filter.resourceId ?? "",
+            optionalResourceIdPrefix: "",
+            optionalSubjectFilter: filter.subject
+              ? {
+                  optionalRelation: filter.subject.relation
+                    ? { relation: filter.subject.relation }
+                    : undefined,
+                  optionalSubjectId: filter.subject.objectId,
+                  subjectType: filter.subject.objectType,
+                }
+              : undefined,
+            resourceType: filter.resourceType,
+          },
+        });
+      });
+    },
     diffSchema: async (schemaText) =>
       executeAuthzedOperation("diff_schema", async () => {
         const response = await sdkClient.promises.diffSchema({
@@ -161,6 +287,39 @@ const createAuthzedClient = (): TAuthzedClientSingleton => {
       return { schemaText };
     },
     systemKey: config.systemKey,
+    // TOUCH and DELETE relationship updates are idempotent. Keep retries opt-in at this facade
+    // operation so future non-idempotent mutations cannot inherit them accidentally.
+    writeRelationships: async (updates) => {
+      validateRelationshipUpdates(updates);
+
+      await executeAuthzedOperation("write_relationships", async () => {
+        await sdkClient.promises.writeRelationships({
+          optionalPreconditions: [],
+          updates: updates.map(({ operation, relationship }) => ({
+            operation:
+              operation === "touch"
+                ? v1.RelationshipUpdate_Operation.TOUCH
+                : v1.RelationshipUpdate_Operation.DELETE,
+            relationship: {
+              optionalCaveat: undefined,
+              optionalExpiresAt: undefined,
+              relation: relationship.relation,
+              resource: {
+                objectId: relationship.resource.objectId,
+                objectType: relationship.resource.objectType,
+              },
+              subject: {
+                object: {
+                  objectId: relationship.subject.objectId,
+                  objectType: relationship.subject.objectType,
+                },
+                optionalRelation: relationship.subject.relation ?? "",
+              },
+            },
+          })),
+        });
+      });
+    },
     // Repeating WriteSchema with the exact same schema is idempotent. Keep this explicit so future
     // relationship writes cannot inherit retries accidentally.
     writeSchema: async (schemaText) => {

--- a/apps/web/lib/authzed/index.ts
+++ b/apps/web/lib/authzed/index.ts
@@ -3,8 +3,13 @@ import "server-only";
 export {
   getAuthzedClient,
   type TAuthzedClient,
+  type TAuthzedObjectReference,
+  type TAuthzedRelationship,
+  type TAuthzedRelationshipFilter,
+  type TAuthzedRelationshipUpdate,
   type TAuthzedSchema,
   type TAuthzedSchemaDiff,
+  type TAuthzedSubjectReference,
 } from "./client";
 export { isAuthzedEnabled, type TAuthzedConsistency } from "./config";
 export { AuthzedError, type TAuthzedErrorCode } from "./errors";

--- a/apps/web/lib/authzed/organization-membership.test.ts
+++ b/apps/web/lib/authzed/organization-membership.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { logger } from "@formbricks/logger";
+import { getAuthzedClient } from "./client";
+import { isAuthzedEnabled } from "./config";
+import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
+import {
+  deleteOrganizationRelationships,
+  deleteUserOrganizationRelationships,
+  reconcileOrganizationMembership,
+} from "./organization-membership";
+
+const clientMocks = {
+  deleteRelationships: vi.fn(),
+  writeRelationships: vi.fn(),
+};
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    membership: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("./client", () => ({
+  getAuthzedClient: vi.fn(),
+}));
+
+vi.mock("./config", () => ({
+  isAuthzedEnabled: vi.fn(),
+}));
+
+const ORGANIZATION_ID = "organization-private-id";
+const USER_ID = "user-private-id";
+
+describe("organization membership projection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isAuthzedEnabled).mockReturnValue(true);
+    vi.mocked(getAuthzedClient).mockReturnValue(
+      clientMocks as unknown as ReturnType<typeof getAuthzedClient>
+    );
+    clientMocks.deleteRelationships.mockResolvedValue(undefined);
+    clientMocks.writeRelationships.mockResolvedValue(undefined);
+  });
+
+  test.each(["owner", "manager", "member", "billing"] as const)(
+    "atomically touches the %s relationship and deletes the other organization roles",
+    async (role) => {
+      vi.mocked(prisma.membership.findUnique).mockResolvedValue({ role } as never);
+
+      await expect(reconcileOrganizationMembership(ORGANIZATION_ID, USER_ID)).resolves.toEqual({
+        passes: 1,
+        status: "projected",
+      });
+
+      const updates = clientMocks.writeRelationships.mock.calls[0][0];
+      expect(updates).toHaveLength(4);
+      expect(updates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            operation: "touch",
+            relationship: expect.objectContaining({ relation: role }),
+          }),
+        ])
+      );
+      expect(updates.filter((update) => update.operation === "delete")).toHaveLength(3);
+      expect(updates.every(({ relationship }) => relationship.resource.objectId === ORGANIZATION_ID)).toBe(
+        true
+      );
+      expect(updates.every(({ relationship }) => relationship.subject.objectId === USER_ID)).toBe(true);
+      expect(prisma.membership.findUnique).toHaveBeenCalledWith({
+        select: { role: true },
+        where: {
+          userId_organizationId: {
+            organizationId: ORGANIZATION_ID,
+            userId: USER_ID,
+          },
+        },
+      });
+    }
+  );
+
+  test("projects accepted and pending Membership rows identically by reading only their role", async () => {
+    vi.mocked(prisma.membership.findUnique).mockResolvedValue({ role: "member" } as never);
+
+    await reconcileOrganizationMembership(ORGANIZATION_ID, USER_ID);
+
+    expect(prisma.membership.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: { role: true },
+      })
+    );
+    expect(clientMocks.writeRelationships).toHaveBeenCalledTimes(1);
+  });
+
+  test("deletes every organization role when the source membership no longer exists", async () => {
+    vi.mocked(prisma.membership.findUnique).mockResolvedValue(null);
+
+    await expect(reconcileOrganizationMembership(ORGANIZATION_ID, USER_ID)).resolves.toEqual({
+      passes: 1,
+      status: "projected",
+    });
+
+    expect(clientMocks.writeRelationships.mock.calls[0][0]).toEqual(
+      expect.arrayContaining(
+        ["owner", "manager", "member", "billing"].map((relation) =>
+          expect.objectContaining({
+            operation: "delete",
+            relationship: expect.objectContaining({ relation }),
+          })
+        )
+      )
+    );
+  });
+
+  test("reconciles again when the source role changes during projection", async () => {
+    vi.mocked(prisma.membership.findUnique)
+      .mockResolvedValueOnce({ role: "owner" } as never)
+      .mockResolvedValueOnce({ role: "manager" } as never)
+      .mockResolvedValueOnce({ role: "manager" } as never)
+      .mockResolvedValueOnce({ role: "manager" } as never);
+
+    await expect(reconcileOrganizationMembership(ORGANIZATION_ID, USER_ID)).resolves.toEqual({
+      passes: 2,
+      status: "projected",
+    });
+
+    expect(clientMocks.writeRelationships).toHaveBeenCalledTimes(2);
+    expect(clientMocks.writeRelationships.mock.calls[1][0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: "touch",
+          relationship: expect.objectContaining({ relation: "manager" }),
+        }),
+      ])
+    );
+  });
+
+  test("returns a stable internal failure after three concurrently changing passes", async () => {
+    vi.mocked(prisma.membership.findUnique)
+      .mockResolvedValueOnce({ role: "owner" } as never)
+      .mockResolvedValueOnce({ role: "manager" } as never)
+      .mockResolvedValueOnce({ role: "owner" } as never)
+      .mockResolvedValueOnce({ role: "manager" } as never)
+      .mockResolvedValueOnce({ role: "owner" } as never)
+      .mockResolvedValueOnce({ role: "manager" } as never);
+
+    await expect(reconcileOrganizationMembership(ORGANIZATION_ID, USER_ID)).resolves.toEqual({
+      attempts: 3,
+      code: "authzed_projection_unstable",
+      retryable: false,
+      status: "failed",
+    });
+    expect(clientMocks.writeRelationships).toHaveBeenCalledTimes(3);
+  });
+
+  test("does not read the database or construct a client when AuthZed is disabled", async () => {
+    vi.mocked(isAuthzedEnabled).mockReturnValue(false);
+
+    await expect(reconcileOrganizationMembership(ORGANIZATION_ID, USER_ID)).resolves.toEqual({
+      status: "disabled",
+    });
+
+    expect(prisma.membership.findUnique).not.toHaveBeenCalled();
+    expect(getAuthzedClient).not.toHaveBeenCalled();
+  });
+
+  test("contains operational failures at the projection boundary with sanitized logs", async () => {
+    const privateCause = new Error("raw-sdk-message-with-private-token");
+    vi.mocked(prisma.membership.findUnique).mockResolvedValue({ role: "owner" } as never);
+    clientMocks.writeRelationships.mockRejectedValue(
+      new AuthzedError({
+        attempts: 3,
+        cause: privateCause,
+        code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+        operation: "write_relationships",
+        retryable: true,
+      })
+    );
+
+    await expect(reconcileOrganizationMembership(ORGANIZATION_ID, USER_ID)).resolves.toEqual({
+      attempts: 3,
+      code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+      retryable: true,
+      status: "failed",
+    });
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    const serializedLog = JSON.stringify(vi.mocked(logger.warn).mock.calls[0]);
+    expect(serializedLog).not.toContain(ORGANIZATION_ID);
+    expect(serializedLog).not.toContain(USER_ID);
+    expect(serializedLog).not.toContain("private-token");
+    expect(serializedLog).not.toContain("raw-sdk-message");
+    expect(serializedLog).toContain(AUTHZED_ERROR_CODES.UNAVAILABLE);
+  });
+
+  test("deletes all organization-resource relationships after an organization cascade", async () => {
+    await expect(deleteOrganizationRelationships(ORGANIZATION_ID)).resolves.toEqual({
+      passes: 1,
+      status: "projected",
+    });
+
+    expect(clientMocks.deleteRelationships).toHaveBeenCalledWith({
+      resourceId: ORGANIZATION_ID,
+      resourceType: "organization",
+    });
+  });
+
+  test("deletes only organization relationships for a deleted user subject", async () => {
+    await expect(deleteUserOrganizationRelationships(USER_ID)).resolves.toEqual({
+      passes: 1,
+      status: "projected",
+    });
+
+    expect(clientMocks.deleteRelationships).toHaveBeenCalledWith({
+      resourceType: "organization",
+      subject: {
+        objectId: USER_ID,
+        objectType: "user",
+      },
+    });
+  });
+});

--- a/apps/web/lib/authzed/organization-membership.ts
+++ b/apps/web/lib/authzed/organization-membership.ts
@@ -1,0 +1,206 @@
+import "server-only";
+import { prisma } from "@formbricks/database";
+import { OrganizationRole } from "@formbricks/database/prisma";
+import { logger } from "@formbricks/logger";
+import { getAuthzedClient } from "./client";
+import { isAuthzedEnabled } from "./config";
+import { AuthzedError, type TAuthzedErrorCode, mapAuthzedError } from "./errors";
+
+const ORGANIZATION_RELATIONS = {
+  [OrganizationRole.billing]: "billing",
+  [OrganizationRole.manager]: "manager",
+  [OrganizationRole.member]: "member",
+  [OrganizationRole.owner]: "owner",
+} as const satisfies Record<OrganizationRole, string>;
+
+const ORGANIZATION_RELATION_NAMES = Object.values(ORGANIZATION_RELATIONS);
+const MAX_RECONCILIATION_PASSES = 3;
+
+type TOrganizationProjectionOperation =
+  | "delete_organization_relationships"
+  | "delete_user_organization_relationships"
+  | "reconcile_organization_membership";
+
+type TAuthzedProjectionErrorCode = TAuthzedErrorCode | "authzed_projection_unstable";
+
+class AuthzedProjectionUnstableError extends Error {
+  readonly attempts = MAX_RECONCILIATION_PASSES;
+  readonly code = "authzed_projection_unstable";
+  readonly retryable = false;
+}
+
+export type TAuthzedProjectionResult =
+  | Readonly<{ status: "disabled" }>
+  | Readonly<{ passes: number; status: "projected" }>
+  | Readonly<{
+      attempts: number;
+      code: TAuthzedProjectionErrorCode;
+      retryable: boolean;
+      status: "failed";
+    }>;
+
+type TOrganizationMembershipState = OrganizationRole | null;
+
+const getOrganizationMembershipState = async (
+  organizationId: string,
+  userId: string
+): Promise<TOrganizationMembershipState> => {
+  const membership = await prisma.membership.findUnique({
+    where: {
+      userId_organizationId: {
+        organizationId,
+        userId,
+      },
+    },
+    select: {
+      role: true,
+    },
+  });
+
+  // The legacy evaluator does not gate organization membership on `accepted`. Project every row so
+  // the initial SpiceDB shadow model preserves the current authorization behavior exactly.
+  return membership?.role ?? null;
+};
+
+const getProjectionError = (
+  error: unknown,
+  operation: TOrganizationProjectionOperation
+): Readonly<{
+  attempts: number;
+  code: TAuthzedProjectionErrorCode;
+  retryable: boolean;
+}> => {
+  if (error instanceof AuthzedProjectionUnstableError) {
+    return error;
+  }
+
+  const attempts = error instanceof AuthzedError ? error.attempts : 1;
+  return mapAuthzedError(error, operation, attempts);
+};
+
+const logProjectionFailure = (
+  operation: TOrganizationProjectionOperation,
+  error: Readonly<{
+    attempts: number;
+    code: TAuthzedProjectionErrorCode;
+    retryable: boolean;
+  }>,
+  durationMs: number
+): void => {
+  logger.warn(
+    {
+      attempts: error.attempts,
+      component: "authzed",
+      durationMs,
+      errorCode: error.code,
+      operation,
+      projection: "organization_membership",
+      retryable: error.retryable,
+    },
+    "AuthZed relationship projection failed"
+  );
+};
+
+const runBestEffortProjection = async (
+  operation: TOrganizationProjectionOperation,
+  projection: () => Promise<number>
+): Promise<TAuthzedProjectionResult> => {
+  if (!isAuthzedEnabled()) {
+    return { status: "disabled" };
+  }
+
+  const startedAt = performance.now();
+
+  try {
+    const passes = await projection();
+    const durationMs = Math.max(0, Math.round(performance.now() - startedAt));
+
+    logger.debug(
+      {
+        component: "authzed",
+        durationMs,
+        operation,
+        passes,
+        projection: "organization_membership",
+        status: "projected",
+      },
+      "AuthZed relationship projection completed"
+    );
+
+    return { passes, status: "projected" };
+  } catch (error) {
+    const mappedError = getProjectionError(error, operation);
+    const durationMs = Math.max(0, Math.round(performance.now() - startedAt));
+    const result = {
+      attempts: mappedError.attempts,
+      code: mappedError.code,
+      retryable: mappedError.retryable,
+      status: "failed" as const,
+    };
+
+    logProjectionFailure(operation, result, durationMs);
+    return result;
+  }
+};
+
+export const reconcileOrganizationMembership = async (
+  organizationId: string,
+  userId: string
+): Promise<TAuthzedProjectionResult> =>
+  runBestEffortProjection("reconcile_organization_membership", async () => {
+    const client = getAuthzedClient();
+
+    for (let pass = 1; pass <= MAX_RECONCILIATION_PASSES; pass++) {
+      const sourceRole = await getOrganizationMembershipState(organizationId, userId);
+
+      await client.writeRelationships(
+        ORGANIZATION_RELATION_NAMES.map((relation) => ({
+          operation:
+            sourceRole !== null && relation === ORGANIZATION_RELATIONS[sourceRole] ? "touch" : "delete",
+          relationship: {
+            relation,
+            resource: {
+              objectId: organizationId,
+              objectType: "organization",
+            },
+            subject: {
+              objectId: userId,
+              objectType: "user",
+            },
+          },
+        }))
+      );
+
+      const verifiedRole = await getOrganizationMembershipState(organizationId, userId);
+      if (verifiedRole === sourceRole) {
+        return pass;
+      }
+    }
+
+    throw new AuthzedProjectionUnstableError();
+  });
+
+export const deleteOrganizationRelationships = async (
+  organizationId: string
+): Promise<TAuthzedProjectionResult> =>
+  runBestEffortProjection("delete_organization_relationships", async () => {
+    await getAuthzedClient().deleteRelationships({
+      resourceId: organizationId,
+      resourceType: "organization",
+    });
+    return 1;
+  });
+
+export const deleteUserOrganizationRelationships = async (
+  userId: string
+): Promise<TAuthzedProjectionResult> =>
+  runBestEffortProjection("delete_user_organization_relationships", async () => {
+    await getAuthzedClient().deleteRelationships({
+      resourceType: "organization",
+      subject: {
+        objectId: userId,
+        objectType: "user",
+      },
+    });
+    return 1;
+  });

--- a/apps/web/lib/membership/service.test.ts
+++ b/apps/web/lib/membership/service.test.ts
@@ -3,6 +3,7 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError, UnknownError } from "@formbricks/types/errors";
 import { TMembership } from "@formbricks/types/memberships";
+import { reconcileOrganizationMembership } from "../authzed/organization-membership";
 import { createMembership, getMembershipByUserIdOrganizationId } from "./service";
 
 vi.mock("@formbricks/database", () => ({
@@ -13,6 +14,10 @@ vi.mock("@formbricks/database", () => ({
       update: vi.fn(),
     },
   },
+}));
+
+vi.mock("../authzed/organization-membership", () => ({
+  reconcileOrganizationMembership: vi.fn(),
 }));
 
 describe("Membership Service", () => {
@@ -127,6 +132,7 @@ describe("Membership Service", () => {
           role: mockMembershipData.role,
         },
       });
+      expect(reconcileOrganizationMembership).toHaveBeenCalledWith(mockOrgId, mockUserId);
     });
 
     test("returns existing membership if role matches", async () => {
@@ -143,6 +149,7 @@ describe("Membership Service", () => {
       expect(result).toEqual(existingMembership);
       expect(prisma.membership.create).not.toHaveBeenCalled();
       expect(prisma.membership.update).not.toHaveBeenCalled();
+      expect(reconcileOrganizationMembership).toHaveBeenCalledWith(mockOrgId, mockUserId);
     });
 
     test("updates existing membership if role differs", async () => {
@@ -175,6 +182,33 @@ describe("Membership Service", () => {
           role: "owner",
         },
       });
+      expect(reconcileOrganizationMembership).toHaveBeenCalledWith(mockOrgId, mockUserId);
+    });
+
+    test("defers projection when the membership participates in an outer transaction", async () => {
+      const createdMembership = {
+        organizationId: mockOrgId,
+        userId: mockUserId,
+        accepted: true,
+        role: "member",
+      } as TMembership;
+      const transaction = {
+        membership: {
+          create: vi.fn().mockResolvedValue(createdMembership),
+          findUnique: vi.fn().mockResolvedValue(null),
+          update: vi.fn(),
+        },
+      } as any;
+
+      await expect(
+        createMembership(mockOrgId, mockUserId, mockMembershipData, {
+          projection: "deferred",
+          transaction,
+        })
+      ).resolves.toEqual(createdMembership);
+
+      expect(transaction.membership.create).toHaveBeenCalled();
+      expect(reconcileOrganizationMembership).not.toHaveBeenCalled();
     });
 
     test("throws DatabaseError on Prisma error", async () => {

--- a/apps/web/lib/membership/service.ts
+++ b/apps/web/lib/membership/service.ts
@@ -6,9 +6,15 @@ import { logger } from "@formbricks/logger";
 import { ZString } from "@formbricks/types/common";
 import { DatabaseError, UnknownError } from "@formbricks/types/errors";
 import { TMembership, ZMembership } from "@formbricks/types/memberships";
+import { reconcileOrganizationMembership } from "../authzed/organization-membership";
 import { validateInputs } from "../utils/validate";
 
 type TMembershipDbClient = PrismaClient | Prisma.TransactionClient;
+
+type TDeferredMembershipProjection = Readonly<{
+  projection: "deferred";
+  transaction: Prisma.TransactionClient;
+}>;
 
 const getDbClient = (tx?: Prisma.TransactionClient): TMembershipDbClient => tx ?? prisma;
 
@@ -62,12 +68,14 @@ export const createMembership = async (
   organizationId: string,
   userId: string,
   data: Partial<TMembership>,
-  tx?: Prisma.TransactionClient
+  options?: TDeferredMembershipProjection
 ): Promise<TMembership> => {
   validateInputs([organizationId, ZString], [userId, ZString], [data, ZMembership.partial()]);
 
+  let membership: TMembership;
+
   try {
-    const prismaClient = getDbClient(tx);
+    const prismaClient = getDbClient(options?.transaction);
     const existingMembership = await prismaClient.membership.findUnique({
       where: {
         userId_organizationId: {
@@ -78,11 +86,8 @@ export const createMembership = async (
     });
 
     if (existingMembership && existingMembership.role === data.role) {
-      return existingMembership;
-    }
-
-    let membership: TMembership;
-    if (!existingMembership) {
+      membership = existingMembership;
+    } else if (!existingMembership) {
       membership = await prismaClient.membership.create({
         data: {
           userId,
@@ -105,8 +110,6 @@ export const createMembership = async (
         },
       });
     }
-
-    return membership;
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       throw new DatabaseError(error.message);
@@ -114,4 +117,12 @@ export const createMembership = async (
 
     throw error;
   }
+
+  // Transactional callers must project only after their outer transaction commits. Non-transactional
+  // callers reconcile even on an idempotent retry so a repeated source mutation can heal SpiceDB.
+  if (!options) {
+    await reconcileOrganizationMembership(organizationId, userId);
+  }
+
+  return membership;
 };

--- a/apps/web/lib/organization/service.test.ts
+++ b/apps/web/lib/organization/service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError } from "@formbricks/types/errors";
+import { deleteOrganizationRelationships } from "@/lib/authzed/organization-membership";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { updateUser } from "@/lib/user/service";
 import {
@@ -39,6 +40,10 @@ vi.mock("@formbricks/database", () => ({
 
 vi.mock("@/lib/user/service", () => ({
   updateUser: vi.fn(),
+}));
+
+vi.mock("@/lib/authzed/organization-membership", () => ({
+  deleteOrganizationRelationships: vi.fn(),
 }));
 
 vi.mock("@/modules/ee/billing/lib/organization-billing", () => ({
@@ -362,6 +367,7 @@ describe("Organization Service", () => {
 
       await deleteOrganization("org1");
 
+      expect(deleteOrganizationRelationships).toHaveBeenCalledWith("org1");
       if (IS_FORMBRICKS_CLOUD) {
         expect(cleanupStripeCustomer).toHaveBeenCalledWith("cus_123");
       }

--- a/apps/web/lib/organization/service.ts
+++ b/apps/web/lib/organization/service.ts
@@ -14,6 +14,7 @@ import {
   ZOrganizationCreateInput,
 } from "@formbricks/types/organizations";
 import { TUserNotificationSettings } from "@formbricks/types/user";
+import { deleteOrganizationRelationships } from "@/lib/authzed/organization-membership";
 import { IS_FORMBRICKS_CLOUD, ITEMS_PER_PAGE } from "@/lib/constants";
 import { updateUser } from "@/lib/user/service";
 import { getBillingUsageCycleWindow } from "@/lib/utils/billing";
@@ -300,6 +301,8 @@ export const deleteOrganization = async (organizationId: string) => {
         },
       },
     });
+
+    await deleteOrganizationRelationships(organizationId);
 
     const stripeCustomerId = deletedOrganization.billing?.stripeCustomerId;
     if (IS_FORMBRICKS_CLOUD && stripeCustomerId) {

--- a/apps/web/lib/user/service.test.ts
+++ b/apps/web/lib/user/service.test.ts
@@ -5,6 +5,7 @@ import { PrismaErrorType } from "@formbricks/database/types/error";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TOrganization } from "@formbricks/types/organizations";
 import { TUserLocale, TUserUpdateInput } from "@formbricks/types/user";
+import { deleteUserOrganizationRelationships } from "@/lib/authzed/organization-membership";
 import { deleteOrganization, getOrganizationsWhereUserIsSingleOwner } from "@/lib/organization/service";
 import { publicUserSelect } from "./public-user";
 import { deleteUser, getUser, getUserByEmail, getUsersWithOrganization, updateUser } from "./service";
@@ -27,6 +28,10 @@ vi.mock("@formbricks/database", () => ({
 vi.mock("@/lib/organization/service", () => ({
   getOrganizationsWhereUserIsSingleOwner: vi.fn(),
   deleteOrganization: vi.fn(),
+}));
+
+vi.mock("@/lib/authzed/organization-membership", () => ({
+  deleteUserOrganizationRelationships: vi.fn(),
 }));
 
 describe("User Service", () => {
@@ -212,6 +217,7 @@ describe("User Service", () => {
         where: { id: "user1" },
         select: publicUserSelect,
       });
+      expect(deleteUserOrganizationRelationships).toHaveBeenCalledWith("user1");
     });
 
     // Regression for ENG-1057: Invite.creatorId has no onDelete rule, so any

--- a/apps/web/lib/user/service.ts
+++ b/apps/web/lib/user/service.ts
@@ -7,6 +7,7 @@ import { PrismaErrorType } from "@formbricks/database/types/error";
 import { ZId } from "@formbricks/types/common";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TUser, TUserLocale, TUserUpdateInput, ZUserUpdateInput } from "@formbricks/types/user";
+import { deleteUserOrganizationRelationships } from "@/lib/authzed/organization-membership";
 import { deleteOrganization, getOrganizationsWhereUserIsSingleOwner } from "@/lib/organization/service";
 import { deleteBrevoCustomerByEmail } from "@/modules/auth/lib/brevo";
 import { validateInputs } from "../utils/validate";
@@ -117,6 +118,7 @@ export const deleteUser = async (id: string): Promise<TUser> => {
     await prisma.invite.deleteMany({ where: { creatorId: id } });
 
     const deletedUser = await deleteUserById(id);
+    await deleteUserOrganizationRelationships(id);
     await deleteBrevoCustomerByEmail({ email: deletedUser.email });
 
     return deletedUser;

--- a/apps/web/modules/account/lib/better-auth-account-deletion.test.ts
+++ b/apps/web/modules/account/lib/better-auth-account-deletion.test.ts
@@ -2,6 +2,7 @@ import { APIError } from "better-auth/api";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
+import { deleteUserOrganizationRelationships } from "@/lib/authzed/organization-membership";
 import { deleteOrganization, getOrganizationsWhereUserIsSingleOwner } from "@/lib/organization/service";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { deleteBrevoCustomerByEmail } from "@/modules/auth/lib/brevo";
@@ -16,6 +17,9 @@ import {
 
 vi.mock("@formbricks/database", () => ({ prisma: { invite: { deleteMany: vi.fn() } } }));
 vi.mock("@formbricks/logger", () => ({ logger: { error: vi.fn() } }));
+vi.mock("@/lib/authzed/organization-membership", () => ({
+  deleteUserOrganizationRelationships: vi.fn(),
+}));
 vi.mock("@/lib/organization/service", () => ({
   deleteOrganization: vi.fn(),
   getOrganizationsWhereUserIsSingleOwner: vi.fn(),
@@ -88,6 +92,7 @@ describe("accountDeletionAfterDelete", () => {
   test("deletes the Brevo customer and queues a success audit event with the deleted user", async () => {
     await accountDeletionAfterDelete(user);
 
+    expect(deleteUserOrganizationRelationships).toHaveBeenCalledWith("user-1");
     expect(deleteBrevoCustomerByEmail).toHaveBeenCalledWith({ email: "ada@example.com" });
     expect(queueAccountDeletionAuditEvent).toHaveBeenCalledWith({
       oldUser: user,

--- a/apps/web/modules/account/lib/better-auth-account-deletion.test.ts
+++ b/apps/web/modules/account/lib/better-auth-account-deletion.test.ts
@@ -112,6 +112,28 @@ describe("accountDeletionAfterDelete", () => {
       expect.objectContaining({ status: "success", targetUserId: "user-1" })
     );
   });
+
+  test("continues post-delete cleanup when the AuthZed cleanup unexpectedly rejects", async () => {
+    vi.mocked(deleteUserOrganizationRelationships).mockRejectedValue(new Error("sensitive raw error"));
+
+    await expect(accountDeletionAfterDelete(user)).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      {
+        code: "authzed_internal",
+        component: "authzed",
+        operation: "delete_user_organization_relationships",
+      },
+      "Unexpected AuthZed cleanup failure after account deletion"
+    );
+    expect(deleteBrevoCustomerByEmail).toHaveBeenCalledWith({ email: "ada@example.com" });
+    expect(queueAccountDeletionAuditEvent).toHaveBeenCalledWith({
+      oldUser: user,
+      status: "success",
+      targetUserId: "user-1",
+    });
+    expect(capturePostHogEvent).toHaveBeenCalledWith("user-1", "delete_account");
+  });
 });
 
 describe("accountDeletionConfig", () => {

--- a/apps/web/modules/account/lib/better-auth-account-deletion.ts
+++ b/apps/web/modules/account/lib/better-auth-account-deletion.ts
@@ -69,7 +69,18 @@ export const accountDeletionBeforeDelete: NonNullable<DeleteUserConfig["beforeDe
  * completed delete would be misleading.
  */
 export const accountDeletionAfterDelete: NonNullable<DeleteUserConfig["afterDelete"]> = async (user) => {
-  await deleteUserOrganizationRelationships(user.id);
+  try {
+    await deleteUserOrganizationRelationships(user.id);
+  } catch {
+    logger.error(
+      {
+        code: "authzed_internal",
+        component: "authzed",
+        operation: "delete_user_organization_relationships",
+      },
+      "Unexpected AuthZed cleanup failure after account deletion"
+    );
+  }
 
   try {
     await deleteBrevoCustomerByEmail({ email: user.email });

--- a/apps/web/modules/account/lib/better-auth-account-deletion.ts
+++ b/apps/web/modules/account/lib/better-auth-account-deletion.ts
@@ -3,6 +3,7 @@ import type { BetterAuthOptions } from "better-auth";
 import { APIError } from "better-auth/api";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
+import { deleteUserOrganizationRelationships } from "@/lib/authzed/organization-membership";
 import { deleteOrganization, getOrganizationsWhereUserIsSingleOwner } from "@/lib/organization/service";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { ACCOUNT_DELETION_SOLE_OWNER_BLOCK_MESSAGE } from "@/modules/account/constants";
@@ -68,6 +69,8 @@ export const accountDeletionBeforeDelete: NonNullable<DeleteUserConfig["beforeDe
  * completed delete would be misleading.
  */
 export const accountDeletionAfterDelete: NonNullable<DeleteUserConfig["afterDelete"]> = async (user) => {
+  await deleteUserOrganizationRelationships(user.id);
+
   try {
     await deleteBrevoCustomerByEmail({ email: user.email });
   } catch (error) {

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/tests/users.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { PrismaErrorType } from "@formbricks/database/types/error";
+import { reconcileOrganizationMembership } from "@/lib/authzed/organization-membership";
 import { TGetUsersFilter } from "@/modules/api/v2/organizations/[organizationId]/users/types/users";
 import { createUser, getUsers, updateUser } from "../users";
 
@@ -40,6 +41,10 @@ vi.mock("@formbricks/database", () => ({
     },
     $transaction: vi.fn(),
   },
+}));
+
+vi.mock("@/lib/authzed/organization-membership", () => ({
+  reconcileOrganizationMembership: vi.fn(),
 }));
 
 describe("Users Lib", () => {
@@ -89,6 +94,7 @@ describe("Users Lib", () => {
         "org456"
       );
       expect(prisma.user.create).toHaveBeenCalled();
+      expect(reconcileOrganizationMembership).toHaveBeenCalledWith("org456", mockUser.id);
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.data.id).toBe(mockUser.id);
@@ -157,6 +163,7 @@ describe("Users Lib", () => {
       (prisma.$transaction as any).mockResolvedValueOnce([{ ...mockUser, name: "Updated User" }]);
       const result = await updateUser({ email: mockUser.email, name: "Updated User" }, "org456");
       expect(prisma.user.findFirst).toHaveBeenCalled();
+      expect(reconcileOrganizationMembership).toHaveBeenCalledWith("org456", mockUser.id);
       expect(result.ok).toBe(true);
       if (result.ok) {
         expect(result.data.name).toBe("Updated User");

--- a/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
+++ b/apps/web/modules/api/v2/organizations/[organizationId]/users/lib/users.ts
@@ -3,6 +3,7 @@ import { OrganizationRole, Prisma, TeamUserRole } from "@formbricks/database/pri
 import { PrismaErrorType } from "@formbricks/database/types/error";
 import { TUser } from "@formbricks/database/zod/users";
 import { Result, err, ok } from "@formbricks/types/error-handlers";
+import { reconcileOrganizationMembership } from "@/lib/authzed/organization-membership";
 import { getUsersQuery } from "@/modules/api/v2/organizations/[organizationId]/users/lib/utils";
 import {
   TGetUsersFilter,
@@ -128,6 +129,8 @@ export const createUser = async (
         },
       },
     });
+
+    await reconcileOrganizationMembership(organizationId, user.id);
 
     const returnedUser = {
       id: user.id,
@@ -299,6 +302,8 @@ export const updateUser = async (
 
     // Retrieve the updated user result. Since the update was the last operation, it is the last item.
     const updatedUser = results[results.length - 1];
+
+    await reconcileOrganizationMembership(organizationId, updatedUser.id);
 
     const returnedUser = {
       id: updatedUser.id,

--- a/apps/web/modules/ee/role-management/lib/membership.test.ts
+++ b/apps/web/modules/ee/role-management/lib/membership.test.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@formbricks/database/prisma";
 import { PrismaErrorType } from "@formbricks/database/types/error";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { TOrganizationRole } from "@formbricks/types/memberships";
+import { reconcileOrganizationMembership } from "@/lib/authzed/organization-membership";
 import { updateMembership } from "./membership";
 
 vi.mock("@formbricks/database", () => ({
@@ -17,6 +18,10 @@ vi.mock("@formbricks/database", () => ({
       updateMany: vi.fn(),
     },
   },
+}));
+
+vi.mock("@/lib/authzed/organization-membership", () => ({
+  reconcileOrganizationMembership: vi.fn(),
 }));
 
 describe("updateMembership", () => {
@@ -54,6 +59,7 @@ describe("updateMembership", () => {
       },
       data: { role: "owner" },
     });
+    expect(reconcileOrganizationMembership).toHaveBeenCalledWith("org1", "user1");
   });
 
   test("should throw ResourceNotFoundError when membership doesn't exist", async () => {

--- a/apps/web/modules/ee/role-management/lib/membership.ts
+++ b/apps/web/modules/ee/role-management/lib/membership.ts
@@ -5,6 +5,7 @@ import { PrismaErrorType } from "@formbricks/database/types/error";
 import { ZString } from "@formbricks/types/common";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { TMembership, TMembershipUpdateInput, ZMembershipUpdateInput } from "@formbricks/types/memberships";
+import { reconcileOrganizationMembership } from "@/lib/authzed/organization-membership";
 import { validateInputs } from "@/lib/utils/validate";
 
 export const updateMembership = async (
@@ -24,6 +25,8 @@ export const updateMembership = async (
       },
       data,
     });
+
+    await reconcileOrganizationMembership(organizationId, userId);
 
     await prisma.teamUser.findMany({
       where: {

--- a/apps/web/modules/ee/sso/lib/sso-handlers.ts
+++ b/apps/web/modules/ee/sso/lib/sso-handlers.ts
@@ -3,6 +3,7 @@ import type { IdentityProvider, Organization } from "@formbricks/database/prisma
 import { logger } from "@formbricks/logger";
 import type { Account } from "@formbricks/types/auth";
 import type { TUser, TUserNotificationSettings } from "@formbricks/types/user";
+import { reconcileOrganizationMembership } from "@/lib/authzed/organization-membership";
 import { DEFAULT_TEAM_ID, SKIP_INVITE_FOR_SSO } from "@/lib/constants";
 import { getIsFreshInstance } from "@/lib/instance/service";
 import { verifyInviteToken } from "@/lib/jwt";
@@ -405,7 +406,12 @@ const provisionNewSsoUser = async ({
         { newUserId: createdUser.id, organizationId: organization.id, role: "member" },
         "Assigning user to organization"
       );
-      await createMembership(organization.id, createdUser.id, { role: "member", accepted: true }, tx);
+      await createMembership(
+        organization.id,
+        createdUser.id,
+        { role: "member", accepted: true },
+        { projection: "deferred", transaction: tx }
+      );
 
       if (SKIP_INVITE_FOR_SSO && DEFAULT_TEAM_ID) {
         contextLogger.debug(
@@ -436,6 +442,10 @@ const provisionNewSsoUser = async ({
 
     return createdUser;
   });
+
+  if (organization) {
+    await reconcileOrganizationMembership(organization.id, userProfile.id);
+  }
 
   contextLogger.debug(
     { newUserId: userProfile.id, identityProvider: provider },

--- a/apps/web/modules/ee/sso/lib/sso-provisioning.test.ts
+++ b/apps/web/modules/ee/sso/lib/sso-provisioning.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
 import { SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE } from "@formbricks/types/errors";
+import { reconcileOrganizationMembership } from "@/lib/authzed/organization-membership";
 import { getIsFreshInstance } from "@/lib/instance/service";
 import { createMembership } from "@/lib/membership/service";
 import { capturePostHogEvent, identifyPostHogPerson } from "@/lib/posthog";
@@ -21,6 +22,9 @@ vi.mock("@formbricks/database", () => ({
   },
 }));
 vi.mock("@formbricks/logger", () => ({ logger: { error: vi.fn(), warn: vi.fn(), debug: vi.fn() } }));
+vi.mock("@/lib/authzed/organization-membership", () => ({
+  reconcileOrganizationMembership: vi.fn(),
+}));
 vi.mock("@/lib/instance/service", () => ({ getIsFreshInstance: vi.fn() }));
 vi.mock("@/lib/membership/service", () => ({ createMembership: vi.fn() }));
 vi.mock("@/lib/posthog", () => ({ capturePostHogEvent: vi.fn(), identifyPostHogPerson: vi.fn() }));
@@ -284,8 +288,9 @@ describe("provisionSsoUserMemberships", () => {
       "org-1",
       "u1",
       { role: "member", accepted: true },
-      expect.anything()
+      expect.objectContaining({ projection: "deferred", transaction: expect.anything() })
     );
+    expect(reconcileOrganizationMembership).toHaveBeenCalledWith("org-1", "u1");
     expect(createDefaultTeamMembership).not.toHaveBeenCalled();
     expect(updateUser).toHaveBeenCalledWith(
       "u1",
@@ -324,6 +329,7 @@ describe("provisionSsoUserMemberships", () => {
     vi.mocked(createMembership).mockRejectedValue(new Error("db down"));
     await expect(provisionSsoUserMemberships(baseArgs)).resolves.toBeUndefined();
     expect(createMembership).toHaveBeenCalledTimes(2); // initial + one retry
+    expect(reconcileOrganizationMembership).not.toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalledTimes(1);
     expect(createBrevoCustomer).toHaveBeenCalled();
     expect(capturePostHogEvent).toHaveBeenCalled();
@@ -335,6 +341,7 @@ describe("provisionSsoUserMemberships", () => {
       .mockResolvedValue(undefined as never);
     await provisionSsoUserMemberships(baseArgs);
     expect(createMembership).toHaveBeenCalledTimes(2);
+    expect(reconcileOrganizationMembership).toHaveBeenCalledWith("org-1", "u1");
     expect(logger.error).not.toHaveBeenCalled();
   });
 

--- a/apps/web/modules/ee/sso/lib/sso-provisioning.ts
+++ b/apps/web/modules/ee/sso/lib/sso-provisioning.ts
@@ -4,6 +4,7 @@ import type { IdentityProvider } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE } from "@formbricks/types/errors";
 import type { TUserNotificationSettings } from "@formbricks/types/user";
+import { reconcileOrganizationMembership } from "@/lib/authzed/organization-membership";
 import { DEFAULT_TEAM_ID, SKIP_INVITE_FOR_SSO, WEBAPP_URL } from "@/lib/constants";
 import { getIsFreshInstance } from "@/lib/instance/service";
 import { createMembership } from "@/lib/membership/service";
@@ -170,7 +171,12 @@ export const provisionSsoUserMemberships = async ({
     for (let attempt = 1; attempt <= MAX_ATTEMPTS && !assigned; attempt++) {
       try {
         await prisma.$transaction(async (tx) => {
-          await createMembership(organizationId, userId, { role: "member", accepted: true }, tx);
+          await createMembership(
+            organizationId,
+            userId,
+            { role: "member", accepted: true },
+            { projection: "deferred", transaction: tx }
+          );
           if (assignToDefaultTeam) {
             await createDefaultTeamMembership(userId, tx);
           }
@@ -193,6 +199,7 @@ export const provisionSsoUserMemberships = async ({
             tx
           );
         });
+        await reconcileOrganizationMembership(organizationId, userId);
         assigned = true;
       } catch (error) {
         // The user + account are already committed by Better Auth; never throw here (it would not

--- a/apps/web/modules/ee/sso/lib/tests/sso-handlers.test.ts
+++ b/apps/web/modules/ee/sso/lib/tests/sso-handlers.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Organization } from "@formbricks/database/prisma";
+import { reconcileOrganizationMembership } from "@/lib/authzed/organization-membership";
 import { getIsFreshInstance } from "@/lib/instance/service";
 import { verifyInviteToken } from "@/lib/jwt";
 import { createMembership } from "@/lib/membership/service";
@@ -94,6 +95,10 @@ vi.mock("@/modules/ee/sso/lib/team", () => ({
 
 vi.mock("@/lib/membership/service", () => ({
   createMembership: vi.fn(),
+}));
+
+vi.mock("@/lib/authzed/organization-membership", () => ({
+  reconcileOrganizationMembership: vi.fn(),
 }));
 
 vi.mock("@/lib/utils/locale", () => ({
@@ -786,8 +791,9 @@ describe("handleSsoCallback", () => {
       mockOrganization.id,
       mockUser.id,
       { role: "member", accepted: true },
-      expect.anything()
+      expect.objectContaining({ projection: "deferred", transaction: expect.anything() })
     );
+    expect(reconcileOrganizationMembership).toHaveBeenCalledWith(mockOrganization.id, mockUser.id);
   });
 
   test("assigns invited SSO users into the resolved organization and syncs notification settings", async () => {
@@ -821,8 +827,9 @@ describe("handleSsoCallback", () => {
       mockOrganization.id,
       mockUser.id,
       { role: "member", accepted: true },
-      expect.anything()
+      expect.objectContaining({ projection: "deferred", transaction: expect.anything() })
     );
+    expect(reconcileOrganizationMembership).toHaveBeenCalledWith(mockOrganization.id, mockUser.id);
     expect(updateUser).toHaveBeenCalledWith(
       mockUser.id,
       {

--- a/apps/web/modules/organization/settings/teams/lib/membership.test.ts
+++ b/apps/web/modules/organization/settings/teams/lib/membership.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError, UnknownError } from "@formbricks/types/errors";
+import { reconcileOrganizationMembership } from "@/lib/authzed/organization-membership";
 import {
   deleteMembership,
   getMembersByOrganizationId,
@@ -28,6 +29,9 @@ vi.mock("@/lib/constants", () => ({ ITEMS_PER_PAGE: 2 }));
 vi.mock("@/lib/utils/validate", () => ({ validateInputs: vi.fn() }));
 vi.mock("react", () => ({ cache: (fn: Function) => fn }));
 vi.mock("@formbricks/logger", () => ({ logger: { error: vi.fn() } }));
+vi.mock("@/lib/authzed/organization-membership", () => ({
+  reconcileOrganizationMembership: vi.fn(),
+}));
 
 const organizationId = "org-1";
 const userId = "user-1";
@@ -106,6 +110,7 @@ describe("deleteMembership", () => {
     vi.mocked(prisma.$transaction).mockResolvedValue([{}, {}]);
     const result = await deleteMembership(userId, organizationId);
     expect(result[0].teamId).toBe(teamId);
+    expect(reconcileOrganizationMembership).toHaveBeenCalledWith(organizationId, userId);
   });
   test("throws DatabaseError on prisma error", async () => {
     const prismaError = new Prisma.PrismaClientKnownRequestError("db", {

--- a/apps/web/modules/organization/settings/teams/lib/membership.ts
+++ b/apps/web/modules/organization/settings/teams/lib/membership.ts
@@ -6,6 +6,7 @@ import { logger } from "@formbricks/logger";
 import { ZOptionalNumber, ZString } from "@formbricks/types/common";
 import { DatabaseError, UnknownError } from "@formbricks/types/errors";
 import { TMember, TMembership } from "@formbricks/types/memberships";
+import { reconcileOrganizationMembership } from "@/lib/authzed/organization-membership";
 import { ITEMS_PER_PAGE } from "@/lib/constants";
 import { validateInputs } from "@/lib/utils/validate";
 import { TOrganizationMember } from "@/modules/ee/teams/team-list/types/team";
@@ -117,6 +118,8 @@ export const deleteMembership = async (
         },
       }),
     ]);
+
+    await reconcileOrganizationMembership(organizationId, userId);
 
     return deletedTeamMemberships;
   } catch (error) {

--- a/apps/web/scripts/authzed-relationships-smoke.ts
+++ b/apps/web/scripts/authzed-relationships-smoke.ts
@@ -1,0 +1,96 @@
+import "server-only";
+
+const ORGANIZATION_ID = "application-relationship-smoke";
+const USER_ID = "application-relationship-smoke";
+const ORGANIZATION_RELATIONS = ["billing", "manager", "member", "owner"] as const;
+
+type TSmokeCommand = "delete" | "set-billing" | "set-owner";
+
+const writeResult = (result: object): void => {
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+};
+
+const isSmokeCommand = (value: string | undefined): value is TSmokeCommand =>
+  value === "delete" || value === "set-billing" || value === "set-owner";
+
+const run = async (): Promise<void> => {
+  const startedAt = performance.now();
+  const latencyMs = (): number => Math.max(0, Math.round(performance.now() - startedAt));
+
+  if (process.env.NODE_ENV !== "test") {
+    writeResult({
+      code: "authzed_smoke_refused",
+      latencyMs: latencyMs(),
+      retryable: false,
+      status: "failed",
+    });
+    process.exitCode = 1;
+    return;
+  }
+
+  const command = process.argv[2];
+  if (!isSmokeCommand(command)) {
+    writeResult({
+      code: "authzed_invalid_request",
+      latencyMs: latencyMs(),
+      retryable: false,
+      status: "failed",
+    });
+    process.exitCode = 1;
+    return;
+  }
+
+  let closeClient: (() => void) | undefined;
+
+  try {
+    const { closeAuthzedClient, getAuthzedClient } = await import("../lib/authzed/client");
+    closeClient = closeAuthzedClient;
+
+    const selectedRelation =
+      command === "set-owner" ? "owner" : command === "set-billing" ? "billing" : undefined;
+
+    await getAuthzedClient().writeRelationships(
+      ORGANIZATION_RELATIONS.map((relation) => ({
+        operation: selectedRelation === relation ? "touch" : "delete",
+        relationship: {
+          relation,
+          resource: {
+            objectId: ORGANIZATION_ID,
+            objectType: "organization",
+          },
+          subject: {
+            objectId: USER_ID,
+            objectType: "user",
+          },
+        },
+      }))
+    );
+
+    writeResult({ latencyMs: latencyMs(), status: "projected" });
+    process.exitCode = 0;
+  } catch (error) {
+    const { AuthzedError } = await import("../lib/authzed/errors");
+
+    if (error instanceof AuthzedError) {
+      writeResult({
+        attempts: error.attempts,
+        code: error.code,
+        latencyMs: latencyMs(),
+        retryable: error.retryable,
+        status: "failed",
+      });
+    } else {
+      writeResult({
+        code: "authzed_internal",
+        latencyMs: latencyMs(),
+        retryable: false,
+        status: "failed",
+      });
+    }
+    process.exitCode = 1;
+  } finally {
+    closeClient?.();
+  }
+};
+
+void run();

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -100,6 +100,53 @@ Any schema change must keep `pnpm authzed:validate` green and extend the
 assertions to document the new semantics. Intentional semantic changes require
 updating the assertions in the same PR, with review.
 
+## Organization membership projection
+
+PostgreSQL remains the source of truth for membership lifecycle and roles.
+After a `Membership` source mutation commits, Formbricks reconciles the
+corresponding SpiceDB `organization` relationship:
+
+- `Membership.role` maps exhaustively to exactly one of `owner`, `manager`,
+  `member`, or `billing`.
+- A present membership atomically touches its current role and deletes the
+  other three roles.
+- A deleted membership deletes all four possible role relationships.
+- Repeating the same create, update, or delete is safe and can heal a missed
+  projection.
+- If the source role changes concurrently, reconciliation reads PostgreSQL
+  again and converges for up to three passes.
+
+The current legacy evaluator authorizes every `Membership` row without checking
+`Membership.accepted`. The initial projection deliberately preserves that
+behavior: accepted and pending membership rows project identically. An
+`Invite` alone is not projected.
+
+Projection runs after the source transaction commits and is best-effort.
+AuthZed being disabled performs no projection work. An AuthZed outage never
+changes a successful PostgreSQL mutation into an application error; it produces
+only a sanitized operational result and warning. ENG-1718 must backfill and
+repair all source relationships before AuthZed shadow evaluation or enforcement
+can be enabled.
+
+The organization-membership projection boundary covers:
+
+- the shared `createMembership` service, including idempotent retries;
+- SSO provisioning after its outer transaction commits;
+- organization role updates and explicit membership deletion;
+- API v2 organization-user nested membership creation and role updates;
+- organization deletion and both legacy and Better Auth user-deletion
+  cascades.
+
+User deletion is intentionally scoped to relationships whose resource type is
+`organization`. Team, workspace, and API-key relationship projection is owned
+by later tickets.
+
+The application facade accepts only Formbricks-owned relationship types. It
+supports idempotent `touch`/`delete` batches of at most 1,000 updates and safely
+narrowed bulk deletions. The SDK client, credentials, SDK request/response
+types, and raw errors never cross the facade. Relationship identifiers are
+write-only inputs and never appear in projection results or logs.
+
 ## Mapping from the current system
 
 | Application concept                                                  | Schema element                                                                           |

--- a/docker/authzed-smoke.sh
+++ b/docker/authzed-smoke.sh
@@ -48,6 +48,13 @@ authzed_schema() {
   authzed_cli "${token}" ./scripts/authzed-schema.ts "$@"
 }
 
+authzed_relationships() {
+  local token="$1"
+  shift
+
+  authzed_cli "${token}" ./scripts/authzed-relationships-smoke.ts "$@"
+}
+
 authzed_cli() {
   local token="$1"
   local script="$2"
@@ -67,7 +74,7 @@ authzed_cli() {
     HUB_API_KEY=authzed-smoke-hub-key \
     HUB_API_URL=https://hub.formbricks.local \
     LOG_LEVEL=fatal \
-    NODE_ENV=test \
+    NODE_ENV="${AUTHZED_SMOKE_NODE_ENV:-test}" \
     NODE_OPTIONS=--conditions=react-server \
     pnpm --dir "${REPO_ROOT}/apps/web" exec tsx "${script}" "$@"
 }
@@ -210,6 +217,46 @@ restored_apply="$(
 )"
 jq --exit-status '.status == "applied" and .differenceCount == 0' <<<"${restored_apply}" >/dev/null
 
+if refused_relationship_driver="$(
+  AUTHZED_SMOKE_NODE_ENV=production authzed_relationships "${AUTHZED_TOKEN}" set-owner 2>&1
+)"; then
+  printf '%s\n' "The application relationship smoke driver unexpectedly ran outside test mode." >&2
+  exit 1
+fi
+jq --exit-status \
+  '.status == "failed" and .code == "authzed_smoke_refused" and .retryable == false' \
+  <<<"${refused_relationship_driver}" >/dev/null
+
+owner_projection="$(authzed_relationships "${AUTHZED_TOKEN}" set-owner)"
+jq --exit-status '.status == "projected"' <<<"${owner_projection}" >/dev/null
+[[ "$(
+  zed permission check organization:application-relationship-smoke write \
+    user:application-relationship-smoke --consistency-full
+)" == *"true"* ]]
+
+billing_projection="$(authzed_relationships "${AUTHZED_TOKEN}" set-billing)"
+jq --exit-status '.status == "projected"' <<<"${billing_projection}" >/dev/null
+[[ "$(
+  zed permission check organization:application-relationship-smoke manage_billing \
+    user:application-relationship-smoke --consistency-full
+)" == *"true"* ]]
+[[ "$(
+  zed permission check organization:application-relationship-smoke write \
+    user:application-relationship-smoke --consistency-full
+)" == *"false"* ]]
+
+idempotent_billing_projection="$(authzed_relationships "${AUTHZED_TOKEN}" set-billing)"
+jq --exit-status '.status == "projected"' <<<"${idempotent_billing_projection}" >/dev/null
+
+deleted_projection="$(authzed_relationships "${AUTHZED_TOKEN}" delete)"
+idempotent_deleted_projection="$(authzed_relationships "${AUTHZED_TOKEN}" delete)"
+jq --exit-status '.status == "projected"' <<<"${deleted_projection}" >/dev/null
+jq --exit-status '.status == "projected"' <<<"${idempotent_deleted_projection}" >/dev/null
+[[ "$(
+  zed permission check organization:application-relationship-smoke read \
+    user:application-relationship-smoke --consistency-full
+)" == *"false"* ]]
+
 zed relationship create organization:smoke owner user:alice
 zed relationship create workspace:smoke organization organization:smoke
 zed relationship create survey:smoke workspace workspace:smoke
@@ -229,6 +276,14 @@ fi
 assert_health_result "${unavailable_health}" "unhealthy" "authzed_unavailable"
 jq --exit-status '.latencyMs <= 4000' <<<"${unavailable_health}" >/dev/null
 
+if unavailable_projection="$(authzed_relationships "${AUTHZED_TOKEN}" set-owner 2>&1)"; then
+  printf '%s\n' "Application relationship projection unexpectedly succeeded while SpiceDB was stopped." >&2
+  exit 1
+fi
+jq --exit-status \
+  '.status == "failed" and .code == "authzed_unavailable" and .attempts == 3 and .retryable == true and .latencyMs <= 4000' \
+  <<<"${unavailable_projection}" >/dev/null
+
 compose up --detach --force-recreate spicedb
 wait_for_spicedb
 refresh_spicedb_port
@@ -239,6 +294,13 @@ if ! restored_health="$(authzed_health "${AUTHZED_TOKEN}" 2>&1)"; then
 fi
 assert_health_result "${restored_health}" "healthy"
 
+restored_projection="$(authzed_relationships "${AUTHZED_TOKEN}" set-owner)"
+jq --exit-status '.status == "projected"' <<<"${restored_projection}" >/dev/null
+[[ "$(
+  zed permission check organization:application-relationship-smoke write \
+    user:application-relationship-smoke --consistency-full
+)" == *"true"* ]]
+
 [[ "$(zed permission check survey:smoke read user:alice --consistency-full)" == *"true"* ]]
 [[ "$(zed permission check survey:smoke read user:bob --consistency-full)" == *"false"* ]]
 
@@ -246,7 +308,7 @@ persisted_schema_check="$(authzed_schema "${AUTHZED_TOKEN}" check)"
 jq --exit-status '.status == "matched" and .differenceCount == 0' <<<"${persisted_schema_check}" >/dev/null
 
 service_logs="$(compose logs --no-color postgres authzed-db-bootstrap spicedb-migrate spicedb)"
-application_outputs="${empty_schema_health}${wrong_token_health}${empty_schema_check}${initial_apply}${matched_schema_check}${unchanged_apply}${drift_schema_write}${drifted_schema_check}${restored_apply}${unavailable_health}${restored_health}${persisted_schema_check}"
+application_outputs="${empty_schema_health}${wrong_token_health}${empty_schema_check}${initial_apply}${matched_schema_check}${unchanged_apply}${drift_schema_write}${drifted_schema_check}${restored_apply}${refused_relationship_driver}${owner_projection}${billing_projection}${idempotent_billing_projection}${deleted_projection}${idempotent_deleted_projection}${unavailable_health}${unavailable_projection}${restored_health}${restored_projection}${persisted_schema_check}"
 if [[ "${service_logs}${application_outputs}" == *"${AUTHZED_TOKEN}"* || \
   "${service_logs}${application_outputs}" == *"${WRONG_AUTHZED_TOKEN}"* || \
   "${service_logs}${application_outputs}" == *"${AUTHZED_DATABASE_PASSWORD}"* || \
@@ -255,4 +317,4 @@ if [[ "${service_logs}${application_outputs}" == *"${AUTHZED_TOKEN}"* || \
   exit 1
 fi
 
-printf '%s\n' "AuthZed smoke test passed: schema check/apply/drift recovery, application health, authentication failure, bounded outage handling, idempotent migrations, and persistence were verified."
+printf '%s\n' "AuthZed smoke test passed: schema lifecycle, application relationship projection, role transition, idempotent deletion, health, authentication failure, bounded outage handling, migrations, and persistence were verified."


### PR DESCRIPTION
## What does this PR do?

Implements [ENG-1715](https://linear.app/formbricks/issue/ENG-1715/project-organization-memberships-and-roles-into-spicedb) on top of the merged central authorization interface from #8653.

PostgreSQL remains the source of truth and the legacy evaluator remains authoritative. This PR adds post-commit, best-effort projection of the current organization membership model into SpiceDB:

- Extends the server-only Formbricks AuthZed facade with SDK-independent, idempotent relationship `touch`/`delete` batches and safely narrowed bulk deletion.
- Reconciles each `Membership` to exactly one `organization` role relation (`owner`, `manager`, `member`, or `billing`) and deletes stale roles atomically.
- Preserves current behavior by projecting accepted and pending membership rows identically; invites alone are not projected.
- Re-reads PostgreSQL after each write and retries reconciliation for up to three passes when a role changes concurrently.
- Projects only after source commits across shared membership creation, SSO transactions, role updates, explicit deletion, API v2 nested writes, organization deletion, and both user-deletion paths.
- Contains AuthZed failures at the projection boundary so an outage never misreports a committed PostgreSQL mutation as failed. Logs and results are sanitized and contain no identifiers, tokens, SDK objects, requests, responses, or raw errors.
- Defensively isolates Better Auth post-delete cleanup from an unexpected AuthZed cleanup rejection, ensuring Brevo cleanup, audit emission, and analytics still execute after the user deletion has committed.
- Extends the isolated Docker smoke test with the application relationship client, owner-to-billing transition, idempotent repeat/delete, bounded outage failure, recovery, persistence, test-only guard, and secret scanning.
- Documents the source-of-truth, accepted-membership parity, mutation inventory, and ENG-1718 repair dependency.

This deliberately does **not** add schema changes, backfill/repair, team/workspace/API-key projection, shadow evaluation, enforcement, public endpoints, database migrations, or ZedToken persistence. ENG-1718 must repair/backfill source relationships before shadow mode or enforcement can be enabled.

## How should this be tested?

- `pnpm --filter @formbricks/web exec vitest run lib/authzed lib/membership/service.test.ts modules/ee/role-management/lib/membership.test.ts modules/organization/settings/teams/lib/membership.test.ts modules/api/v2/organizations/'[organizationId]'/users/lib/tests/users.test.ts modules/ee/sso/lib/sso-provisioning.test.ts modules/ee/sso/lib/tests/sso-handlers.test.ts lib/organization/service.test.ts lib/user/service.test.ts modules/account/lib/better-auth-account-deletion.test.ts`
  - 18 files and 230 tests passed.
- `pnpm --filter @formbricks/web exec vitest run modules/account/lib/better-auth-account-deletion.test.ts`
  - 13 tests passed, including unexpected AuthZed cleanup rejection isolation.
- `pnpm --filter @formbricks/web typecheck`
  - Passed.
- `pnpm authzed:validate`
  - 27 relationships, 131 assertions, and 2 expected relations passed.
- `pnpm build --filter=@formbricks/web... --force`
  - Passed with AuthZed disabled and credentials absent.
- `pnpm --filter @formbricks/web build`
  - Passed with AuthZed enabled, syntactically valid credentials, and an unreachable endpoint; no startup RPC was attempted.
- `pnpm authzed:smoke`
  - Passed schema lifecycle, relationship projection, role transition, idempotent deletion, authentication failure, bounded outage handling, recovery, migrations, persistence, and secret scanning.
- Focused ESLint, Prettier, `bash -n`, and `git diff --check`
  - Passed.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [ ] Checked for warnings, there are none — local commands emitted only the expected engine warning because the workstation uses unsupported Node 25; CI uses the repository-supported Node 22 runtime
- [x] Removed all `console.logs`
- [x] Created the branch from the latest `epic/authzed` target (`eb0987ac6`); merging `main` is not applicable to this stacked epic branch
- [x] My changes don't cause any responsiveness issues (server-only, no UI changes)
- [x] CLA is already signed

### Appreciated

- [x] No UI change; screenshots or a recording are not applicable
- [x] Updated the AuthZed architecture documentation in `authzed/README.md`