### PR TITLE
fix(api-v3): stop the taxonomy routes leaking raw Hub error text, and map upstream status

### DIFF
--- a/apps/web/app/api/v3/feedbackRecords/lib/access.ts
+++ b/apps/web/app/api/v3/feedbackRecords/lib/access.ts
@@ -6,7 +6,7 @@ import type { TV3Authentication } from "@/app/api/v3/lib/types";
 import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
 import { retrieveFeedbackRecord } from "@/modules/hub/service";
 import type { FeedbackRecordData } from "@/modules/hub/types";
-import { hubErrorToProblemResponse } from "./errors";
+import { hubErrorToProblemResponse } from "@/app/api/v3/lib/hub-errors";
 
 /**
  * Tenant isolation for the feedback-records surface. Two guards live here, and every operation goes

--- a/apps/web/app/api/v3/feedbackRecords/lib/errors.ts
+++ b/apps/web/app/api/v3/feedbackRecords/lib/errors.ts
@@ -1,37 +1,16 @@
 import "server-only";
-import type { z } from "zod";
-import type { logger } from "@formbricks/logger";
-import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
-import {
-  type InvalidParam,
-  problemBadGateway,
-  problemBadRequest,
-  problemConflict,
-  problemForbidden,
-  problemInternalError,
-  problemPayloadTooLarge,
-  problemServiceUnavailable,
-  problemTooManyRequests,
-  problemUnprocessableContent,
-} from "@/app/api/v3/lib/response";
-import type { HubError } from "@/modules/hub/utils";
 
 /**
- * Error mapping for the feedback-records surface: Hub failures and unexpected throws → controlled v3
- * problem responses. Split out of `operations.ts` so the operations read as a dispatcher and the mapping
- * rules — the part with the disclosure risk — can be tested on their own.
+ * Wording specific to the feedback-records surface. The Hub-error *mapping* is shared and lives in
+ * `@/app/api/v3/lib/hub-errors`; these are the two messages only this surface can produce, passed into it.
  */
-
-// Bounds on what a Hub 4xx may contribute to our response body (see `hubErrorToProblemResponse`).
-const MAX_RELAYED_INVALID_PARAMS = 20;
-const MAX_RELAYED_DETAIL_LENGTH = 512;
 
 /**
  * Semantic search and similarity need embeddings, which are optional in the Hub. Our own static message,
  * not the upstream body: it names the setting to change, on both processes that need it.
  *
  * Passed explicitly by the two search operations rather than being the 503 default, because those are the
- * only ones for which it is true — see `GENERIC_SERVICE_UNAVAILABLE_DETAIL`.
+ * only ones for which it is true; every other operation gets the generic default from `hub-errors`.
  */
 export const EMBEDDINGS_UNAVAILABLE_DETAIL =
   "Semantic search is not available: the feedback service has no embedding model configured. A self-hosting administrator can enable it by setting EMBEDDING_PROVIDER and EMBEDDING_MODEL on both the Hub API and the Hub worker.";
@@ -44,150 +23,3 @@ export const EMBEDDINGS_UNAVAILABLE_DETAIL =
  */
 export const EMBEDDING_PENDING_DETAIL =
   "This feedback record has no embedding, so similar records cannot be found. If it was just created, embeddings are generated in the background — retry in a moment. If it has no text, or its text was cleared by an update, it has no embedding at all and retrying will not help.";
-
-/**
- * What a 503 says when the caller has not named a cause. Deliberately vague: the Hub answers 503 for
- * several unrelated unconfigured subsystems, so naming one would be wrong for the rest — a plain Hub outage
- * on a list or a create must not tell an operator to configure embeddings, which has nothing to do with it.
- */
-const GENERIC_SERVICE_UNAVAILABLE_DETAIL =
-  "This feature depends on a part of the feedback service that is not configured on this deployment.";
-
-/**
- * Hub statuses whose detail describes the *caller's own* request, and may therefore be echoed: a rejected
- * field value, a duplicate submission, an oversized record.
- *
- * Deliberately not "any 4xx". A Hub 401/403 means *our* Hub credentials were refused and a 404 can reveal
- * upstream addressing — neither is the caller's business, and both would be describing our infrastructure
- * rather than their request.
- */
-const RELAYABLE_HUB_STATUSES = new Set([400, 409, 413, 422]);
-
-/**
- * Translate the Hub's internal vocabulary into this API's, for any upstream text we relay.
- *
- * The Hub's tenant *is* our dataset — `serializeV3FeedbackRecord` already renames the field on the way out —
- * so a relayed message naming `tenant_id` contradicts the rest of the surface and points a caller at a
- * parameter that does not exist here. Reproduced with a duplicate create, whose Hub 409 reads "a feedback
- * record with this tenant_id, submission_id, and field_id already exists".
- *
- * Word-bounded so it renames the term and nothing else. Applied to every relayed string — detail and
- * `invalid_params` alike — because the Hub names fields in both.
- */
-function toApiVocabulary(text: string): string {
-  return text.replace(/\btenant_id\b/g, "dataset_id");
-}
-
-/**
- * The one place that decides what a Hub failure may say to a caller.
- *
- * The Hub owns content rules we deliberately don't duplicate (NULL bytes, its own length limits), so for
- * the relayable statuses its message is relayed — bounded, and in this API's vocabulary — because without it
- * an agent cannot correct its own request. Everything else is replaced by a fixed string. Used both for
- * whole-request problem responses and for the per-record failures of a batch write, so neither can drift
- * into leaking more than the other.
- */
-export function relayableHubDetail(error: HubError | null, fallback: string): string {
-  if (!error?.problemDetail || !RELAYABLE_HUB_STATUSES.has(error.status)) {
-    return fallback;
-  }
-  // Rewritten before slicing, not after: `dataset_id` is a character longer than `tenant_id`, so a
-  // slice-then-rewrite could push the result past the cap it is supposed to enforce.
-  return toApiVocabulary(error.problemDetail).slice(0, MAX_RELAYED_DETAIL_LENGTH);
-}
-
-/**
- * Map a Hub service error to a controlled v3 problem response.
- *
- * A Hub 400/422 describes the *caller's own* input, so its field-level detail is relayed: the Hub owns
- * the content rules we deliberately don't duplicate here (NULL bytes, its own length limits), and
- * without them an agent can't correct its request. Everything else —
- * unconfigured/unreachable Hub, our own Hub credentials being rejected, upstream 5xx — collapses to a
- * generic 502 and is only ever logged, never echoed.
- */
-export function hubErrorToProblemResponse(
-  error: HubError | null,
-  requestId: string,
-  instance: string,
-  options?: {
-    /**
-     * What a Hub 503 means for this operation. Worth passing from any caller that can actually receive one;
-     * the rest get a message that names no subsystem.
-     */
-    serviceUnavailableDetail?: string;
-  }
-): Response {
-  const status = error?.status ?? 0;
-  if (status === 429) {
-    return problemTooManyRequests(requestId, "The feedback service is rate limiting requests.");
-  }
-
-  // A duplicate (submission_id, field_id) or an in-progress tenant purge — the caller's request, not an
-  // outage, and retryable in the purge case. Reported as 409 so an agent doesn't retry-loop on a 502.
-  if (status === 409) {
-    return problemConflict(
-      requestId,
-      relayableHubDetail(error, "The feedback service reported a conflict."),
-      instance
-    );
-  }
-
-  // The Hub's body cap is lower than ours, so this is reachable with a large (but locally valid) payload.
-  if (status === 413) {
-    return problemPayloadTooLarge(
-      requestId,
-      relayableHubDetail(error, "The feedback record is too large."),
-      instance
-    );
-  }
-
-  // A deployment-level "not enabled", not an outage — so it must not collapse into the generic 502 below,
-  // which would read as "retry later" for something no retry can fix. What is unconfigured depends on the
-  // operation, so the wording comes from the caller.
-  if (status === 503) {
-    return problemServiceUnavailable(
-      requestId,
-      options?.serviceUnavailableDetail ?? GENERIC_SERVICE_UNAVAILABLE_DETAIL,
-      instance
-    );
-  }
-
-  if (status === 400 || status === 422) {
-    // Only name/reason cross over: the Hub's `code` vocabulary is its own, not the v3 InvalidParamCode set.
-    // Bounded on both axes — the Hub is a remote service, so we don't let it size our response body.
-    const invalidParams: InvalidParam[] | undefined = error?.invalidParams
-      ?.slice(0, MAX_RELAYED_INVALID_PARAMS)
-      .map(({ name, reason }) => ({
-        name: toApiVocabulary(name).slice(0, MAX_RELAYED_DETAIL_LENGTH),
-        reason: toApiVocabulary(reason).slice(0, MAX_RELAYED_DETAIL_LENGTH),
-      }));
-    const detail = relayableHubDetail(error, "The feedback service rejected the request.");
-
-    return status === 400
-      ? problemBadRequest(requestId, detail, { instance, invalid_params: invalidParams })
-      : problemUnprocessableContent(requestId, detail, { instance, invalid_params: invalidParams });
-  }
-
-  return problemBadGateway(requestId, "The feedback service is unavailable.", instance);
-}
-
-export function handleUnexpectedError(
-  err: unknown,
-  log: ReturnType<typeof logger.withContext>,
-  requestId: string,
-  instance: string
-): Response {
-  if (err instanceof ResourceNotFoundError) {
-    log.warn({ statusCode: 403, errorCode: err.name }, "Resource not found");
-    return problemForbidden(requestId, "You are not authorized to access this resource", instance);
-  }
-  if (err instanceof DatabaseError) {
-    log.error({ error: err, statusCode: 500 }, "Database error");
-    return problemInternalError(requestId, "An unexpected error occurred.", instance);
-  }
-  log.error({ error: err, statusCode: 500 }, "Unexpected error");
-  return problemInternalError(requestId, "An unexpected error occurred.", instance);
-}
-
-export const toInvalidParams = (error: z.ZodError): InvalidParam[] =>
-  error.issues.map((issue) => ({ name: issue.path.join("."), reason: issue.message }));

--- a/apps/web/app/api/v3/feedbackRecords/lib/operations.ts
+++ b/apps/web/app/api/v3/feedbackRecords/lib/operations.ts
@@ -4,6 +4,12 @@ import type { z } from "zod";
 import { logger } from "@formbricks/logger";
 import { requireUnifyFeedbackWorkspaceAccess } from "@/app/api/v3/lib/feedback-access";
 import {
+  handleUnexpectedError,
+  hubErrorToProblemResponse,
+  relayableHubDetail,
+  toInvalidParams,
+} from "@/app/api/v3/lib/hub-errors";
+import {
   noContentResponse,
   problemConflict,
   problemUnprocessableContent,
@@ -37,14 +43,7 @@ import {
   requireOwnedFeedbackRecord,
   resolveWorkspaceFeedbackTenant,
 } from "./access";
-import {
-  EMBEDDINGS_UNAVAILABLE_DETAIL,
-  EMBEDDING_PENDING_DETAIL,
-  handleUnexpectedError,
-  hubErrorToProblemResponse,
-  relayableHubDetail,
-  toInvalidParams,
-} from "./errors";
+import { EMBEDDINGS_UNAVAILABLE_DETAIL, EMBEDDING_PENDING_DETAIL } from "./errors";
 import {
   SIMILARITY_LIMIT_DEFAULT,
   SIMILARITY_MIN_SCORE_DEFAULT,

--- a/apps/web/app/api/v3/lib/hub-errors.test.ts
+++ b/apps/web/app/api/v3/lib/hub-errors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
-import { EMBEDDINGS_UNAVAILABLE_DETAIL, handleUnexpectedError, hubErrorToProblemResponse } from "./errors";
+import { handleUnexpectedError, hubErrorToProblemResponse } from "./hub-errors";
 
 vi.mock("server-only", () => ({}));
 
@@ -9,9 +9,9 @@ const instance = "/api/mcp";
 const log = { warn: vi.fn(), error: vi.fn(), info: vi.fn() } as any;
 
 /**
- * The status matrix is exercised end-to-end in `operations.test.ts`; what is pinned here is the part that
- * only this module owns — the *bounds* on what a remote service may contribute to our response body, and
- * the unexpected-throw mapping, which no operation test reaches.
+ * The status matrix is exercised end-to-end by the surfaces that use this mapper; what is pinned here is the
+ * part only this module owns — the *bounds* on what a remote service may contribute to our response body, the
+ * vocabulary rewrite, and the unexpected-throw mapping, which no operation test reaches.
  */
 describe("hubErrorToProblemResponse", () => {
   const hubError = (status: number, extra: Record<string, unknown> = {}) => ({
@@ -149,10 +149,10 @@ describe("hubErrorToProblemResponse", () => {
 
   test("uses the caller's wording for a 503 when it knows what is unconfigured", async () => {
     const body = await hubErrorToProblemResponse(hubError(503), requestId, instance, {
-      serviceUnavailableDetail: EMBEDDINGS_UNAVAILABLE_DETAIL,
+      serviceUnavailableDetail: "Feature X needs Y configured.",
     }).json();
 
-    expect(body.detail).toContain("EMBEDDING_PROVIDER");
+    expect(body.detail).toBe("Feature X needs Y configured.");
   });
 
   /**

--- a/apps/web/app/api/v3/lib/hub-errors.ts
+++ b/apps/web/app/api/v3/lib/hub-errors.ts
@@ -52,8 +52,9 @@ const RELAYABLE_HUB_STATUSES = new Set([400, 409, 413, 422]);
  *
  * The Hub's tenant *is* a Formbricks feedback dataset — "dataset" is what the product calls it, and
  * `serializeV3FeedbackRecord` already renames the field on the way out — so a relayed message naming
- * `tenant_id` contradicts the surface it appears on and points a caller at a parameter that does not exist. Reproduced with a duplicate create, whose Hub 409 reads "a feedback
- * record with this tenant_id, submission_id, and field_id already exists".
+ * `tenant_id` contradicts the surface it appears on and points a caller at a parameter that does not exist.
+ * Reproduced with a duplicate create, whose Hub 409 reads "a feedback record with this tenant_id,
+ * submission_id, and field_id already exists".
  *
  * Word-bounded so it renames the term and nothing else. Applied to every relayed string — detail and
  * `invalid_params` alike — because the Hub names fields in both.

--- a/apps/web/app/api/v3/lib/hub-errors.ts
+++ b/apps/web/app/api/v3/lib/hub-errors.ts
@@ -1,0 +1,177 @@
+import "server-only";
+import type { z } from "zod";
+import type { logger } from "@formbricks/logger";
+import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
+import {
+  type InvalidParam,
+  problemBadGateway,
+  problemBadRequest,
+  problemConflict,
+  problemForbidden,
+  problemInternalError,
+  problemPayloadTooLarge,
+  problemServiceUnavailable,
+  problemTooManyRequests,
+  problemUnprocessableContent,
+} from "@/app/api/v3/lib/response";
+import type { HubError } from "@/modules/hub/utils";
+
+/**
+ * Mapping from Formbricks Hub failures — and unexpected throws — to controlled v3 problem responses.
+ *
+ * Lives in `app/api/v3/lib` rather than under a single resource because more than one v3 surface talks to the
+ * Hub, and a resource module must not import from a sibling resource. Feature-specific wording stays with the
+ * feature (see the `serviceUnavailableDetail` option); what is here is the part with the disclosure risk, so
+ * it is one implementation with one set of tests rather than a rule each surface re-derives.
+ */
+
+// Bounds on what a Hub 4xx may contribute to our response body (see `hubErrorToProblemResponse`).
+const MAX_RELAYED_INVALID_PARAMS = 20;
+const MAX_RELAYED_DETAIL_LENGTH = 512;
+
+/**
+ * What a 503 says when the caller has not named a cause. Deliberately vague: the Hub answers 503 for
+ * several unrelated unconfigured subsystems, so naming one would be wrong for the rest — a plain Hub outage
+ * on a list or a create must not tell an operator to configure embeddings, which has nothing to do with it.
+ */
+const GENERIC_SERVICE_UNAVAILABLE_DETAIL =
+  "This feature depends on a part of the feedback service that is not configured on this deployment.";
+
+/**
+ * Hub statuses whose detail describes the *caller's own* request, and may therefore be echoed: a rejected
+ * field value, a duplicate submission, an oversized record.
+ *
+ * Deliberately not "any 4xx". A Hub 401/403 means *our* Hub credentials were refused and a 404 can reveal
+ * upstream addressing — neither is the caller's business, and both would be describing our infrastructure
+ * rather than their request.
+ */
+const RELAYABLE_HUB_STATUSES = new Set([400, 409, 413, 422]);
+
+/**
+ * Translate the Hub's internal vocabulary into this API's, for any upstream text we relay.
+ *
+ * The Hub's tenant *is* a Formbricks feedback dataset — "dataset" is what the product calls it, and
+ * `serializeV3FeedbackRecord` already renames the field on the way out — so a relayed message naming
+ * `tenant_id` contradicts the surface it appears on and points a caller at a parameter that does not exist. Reproduced with a duplicate create, whose Hub 409 reads "a feedback
+ * record with this tenant_id, submission_id, and field_id already exists".
+ *
+ * Word-bounded so it renames the term and nothing else. Applied to every relayed string — detail and
+ * `invalid_params` alike — because the Hub names fields in both.
+ */
+function toApiVocabulary(text: string): string {
+  return text.replace(/\btenant_id\b/g, "dataset_id");
+}
+
+/**
+ * The one place that decides what a Hub failure may say to a caller.
+ *
+ * The Hub owns content rules we deliberately don't duplicate (NULL bytes, its own length limits), so for
+ * the relayable statuses its message is relayed — bounded, and in this API's vocabulary — because without it
+ * an agent cannot correct its own request. Everything else is replaced by a fixed string. Used both for
+ * whole-request problem responses and for the per-record failures of a batch write, so neither can drift
+ * into leaking more than the other.
+ */
+export function relayableHubDetail(error: HubError | null, fallback: string): string {
+  if (!error?.problemDetail || !RELAYABLE_HUB_STATUSES.has(error.status)) {
+    return fallback;
+  }
+  // Rewritten before slicing, not after: `dataset_id` is a character longer than `tenant_id`, so a
+  // slice-then-rewrite could push the result past the cap it is supposed to enforce.
+  return toApiVocabulary(error.problemDetail).slice(0, MAX_RELAYED_DETAIL_LENGTH);
+}
+
+/**
+ * Map a Hub service error to a controlled v3 problem response.
+ *
+ * A Hub 400/422 describes the *caller's own* input, so its field-level detail is relayed: the Hub owns
+ * the content rules we deliberately don't duplicate here (NULL bytes, its own length limits), and
+ * without them an agent can't correct its request. Everything else —
+ * unconfigured/unreachable Hub, our own Hub credentials being rejected, upstream 5xx — collapses to a
+ * generic 502 and is only ever logged, never echoed.
+ */
+export function hubErrorToProblemResponse(
+  error: HubError | null,
+  requestId: string,
+  instance: string,
+  options?: {
+    /**
+     * What a Hub 503 means for this operation. Worth passing from any caller that can actually receive one;
+     * the rest get a message that names no subsystem.
+     */
+    serviceUnavailableDetail?: string;
+  }
+): Response {
+  const status = error?.status ?? 0;
+  if (status === 429) {
+    return problemTooManyRequests(requestId, "The feedback service is rate limiting requests.");
+  }
+
+  // A duplicate (submission_id, field_id) or an in-progress tenant purge — the caller's request, not an
+  // outage, and retryable in the purge case. Reported as 409 so an agent doesn't retry-loop on a 502.
+  if (status === 409) {
+    return problemConflict(
+      requestId,
+      relayableHubDetail(error, "The feedback service reported a conflict."),
+      instance
+    );
+  }
+
+  // The Hub's body cap is lower than ours, so this is reachable with a large (but locally valid) payload.
+  if (status === 413) {
+    return problemPayloadTooLarge(
+      requestId,
+      relayableHubDetail(error, "The feedback record is too large."),
+      instance
+    );
+  }
+
+  // A deployment-level "not enabled", not an outage — so it must not collapse into the generic 502 below,
+  // which would read as "retry later" for something no retry can fix. What is unconfigured depends on the
+  // operation, so the wording comes from the caller.
+  if (status === 503) {
+    return problemServiceUnavailable(
+      requestId,
+      options?.serviceUnavailableDetail ?? GENERIC_SERVICE_UNAVAILABLE_DETAIL,
+      instance
+    );
+  }
+
+  if (status === 400 || status === 422) {
+    // Only name/reason cross over: the Hub's `code` vocabulary is its own, not the v3 InvalidParamCode set.
+    // Bounded on both axes — the Hub is a remote service, so we don't let it size our response body.
+    const invalidParams: InvalidParam[] | undefined = error?.invalidParams
+      ?.slice(0, MAX_RELAYED_INVALID_PARAMS)
+      .map(({ name, reason }) => ({
+        name: toApiVocabulary(name).slice(0, MAX_RELAYED_DETAIL_LENGTH),
+        reason: toApiVocabulary(reason).slice(0, MAX_RELAYED_DETAIL_LENGTH),
+      }));
+    const detail = relayableHubDetail(error, "The feedback service rejected the request.");
+
+    return status === 400
+      ? problemBadRequest(requestId, detail, { instance, invalid_params: invalidParams })
+      : problemUnprocessableContent(requestId, detail, { instance, invalid_params: invalidParams });
+  }
+
+  return problemBadGateway(requestId, "The feedback service is unavailable.", instance);
+}
+
+export function handleUnexpectedError(
+  err: unknown,
+  log: ReturnType<typeof logger.withContext>,
+  requestId: string,
+  instance: string
+): Response {
+  if (err instanceof ResourceNotFoundError) {
+    log.warn({ statusCode: 403, errorCode: err.name }, "Resource not found");
+    return problemForbidden(requestId, "You are not authorized to access this resource", instance);
+  }
+  if (err instanceof DatabaseError) {
+    log.error({ error: err, statusCode: 500 }, "Database error");
+    return problemInternalError(requestId, "An unexpected error occurred.", instance);
+  }
+  log.error({ error: err, statusCode: 500 }, "Unexpected error");
+  return problemInternalError(requestId, "An unexpected error occurred.", instance);
+}
+
+export const toInvalidParams = (error: z.ZodError): InvalidParam[] =>
+  error.issues.map((issue) => ({ name: issue.path.join("."), reason: issue.message }));

--- a/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.test.ts
+++ b/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.test.ts
@@ -5,14 +5,17 @@ import {
   getActiveTaxonomyTree,
   getTaxonomyRun,
   listTaxonomyFields,
+  listTaxonomyNodeRecordCounts,
   listTaxonomyNodeRecords,
   listTaxonomyRuns,
   removeTaxonomyNode,
   renameTaxonomyNode,
 } from "@/modules/hub/service";
 import type { FeedbackRecordData, TaxonomyNode, TaxonomyRun } from "@/modules/hub/types";
+import { NO_CONFIG_ERROR } from "@/modules/hub/utils";
 import { getSessionUserId, requireUnifyDirectoryAccess } from "./access";
 import {
+  getV3TaxonomyNodeRecordCounts,
   getV3TaxonomyNodeRecords,
   getV3TaxonomyRun,
   getV3TaxonomyState,
@@ -23,6 +26,12 @@ import {
 } from "./operations";
 
 vi.mock("server-only", () => ({}));
+
+const logWarn = vi.fn();
+const logError = vi.fn();
+vi.mock("@formbricks/logger", () => ({
+  logger: { withContext: vi.fn(() => ({ warn: logWarn, error: logError })) },
+}));
 
 vi.mock("./access", () => ({
   requireUnifyDirectoryAccess: vi.fn(),
@@ -36,6 +45,7 @@ vi.mock("@/modules/hub/service", () => ({
   getTaxonomyRun: vi.fn(),
   createTaxonomyRun: vi.fn(),
   listTaxonomyNodeRecords: vi.fn(),
+  listTaxonomyNodeRecordCounts: vi.fn(),
   renameTaxonomyNode: vi.fn(),
   removeTaxonomyNode: vi.fn(),
 }));
@@ -109,10 +119,10 @@ describe("listV3TaxonomyFields", () => {
     expect(await response.json()).toEqual({ data: { fields: [field], unavailable: false } });
   });
 
-  test("returns 200 with unavailable=true on a Hub error (no false gate)", async () => {
+  test("returns 200 with unavailable=true on a Hub error (no false gate), without echoing Hub text", async () => {
     vi.mocked(listTaxonomyFields).mockResolvedValue({
       data: null,
-      error: { status: 503, message: "Embeddings not configured", detail: "" },
+      error: { status: 503, message: "HUB_API_KEY is not set; Hub integration is disabled.", detail: "" },
     });
 
     const response = await listV3TaxonomyFields(base);
@@ -120,7 +130,8 @@ describe("listV3TaxonomyFields", () => {
 
     expect(response.status).toBe(200);
     expect(body.data.unavailable).toBe(true);
-    expect(body.data.unavailableMessage).toBe("Embeddings not configured");
+    expect(body.data.unavailableMessage).toBe("Taxonomy fields are unavailable");
+    expect(JSON.stringify(body)).not.toContain("HUB_API_KEY");
     expect(body.data.fields).toEqual([]);
   });
 
@@ -199,15 +210,19 @@ describe("getV3TaxonomyRun", () => {
     expect(await response.json()).toEqual({ data: run });
   });
 
-  test("returns 502 on a Hub error", async () => {
+  test("maps a Hub 404 to 404 with no resource id, so the client can stop polling", async () => {
     vi.mocked(getTaxonomyRun).mockResolvedValue({
       data: null,
-      error: { status: 500, message: "boom", detail: "" },
+      error: { status: 404, message: "run not found", detail: "", code: "not_found" },
     });
 
     const response = await getV3TaxonomyRun({ ...base, runId: run.id });
+    const body = await response.json();
 
-    expect(response.status).toBe(502);
+    expect(response.status).toBe(404);
+    expect(body.code).toBe("not_found");
+    expect(body.details).toEqual({ resource_type: "Taxonomy run", resource_id: null });
+    expect(JSON.stringify(body)).not.toContain(run.id);
   });
 });
 
@@ -226,15 +241,18 @@ describe("getV3TaxonomyNodeRecords", () => {
     expect(body.meta).toEqual({ limit: 100 });
   });
 
-  test("returns 502 on a Hub error", async () => {
+  test("returns a fixed-detail 502 on a Hub 500, without the upstream message", async () => {
     vi.mocked(listTaxonomyNodeRecords).mockResolvedValue({
       data: null,
-      error: { status: 500, message: "boom", detail: "" },
+      error: { status: 500, message: "pq: relation \"taxonomy_nodes\" does not exist", detail: "" },
     });
 
     const response = await getV3TaxonomyNodeRecords({ ...base, nodeId: node.id, limit: 100 });
+    const body = await response.json();
 
     expect(response.status).toBe(502);
+    expect(body.detail).toBe("The feedback service is unavailable.");
+    expect(JSON.stringify(body)).not.toContain("taxonomy_nodes");
   });
 });
 
@@ -300,15 +318,18 @@ describe("renameV3TaxonomyNode", () => {
     expect(await response.json()).toEqual({ data: renamed });
   });
 
-  test("returns 502 on a Hub error", async () => {
+  test("returns a fixed-detail 502 on a Hub 500, without the upstream message", async () => {
     vi.mocked(renameTaxonomyNode).mockResolvedValue({
       data: null,
-      error: { status: 500, message: "boom", detail: "" },
+      error: { status: 500, message: "pq: relation \"taxonomy_nodes\" does not exist", detail: "" },
     });
 
     const response = await renameV3TaxonomyNode({ ...base, nodeId: node.id, label: "Copilot" });
+    const body = await response.json();
 
     expect(response.status).toBe(502);
+    expect(body.detail).toBe("The feedback service is unavailable.");
+    expect(JSON.stringify(body)).not.toContain("taxonomy_nodes");
   });
 });
 
@@ -321,14 +342,271 @@ describe("removeV3TaxonomyNode", () => {
     expect(response.status).toBe(204);
   });
 
-  test("returns 502 on a Hub error", async () => {
+  test("returns a fixed-detail 502 on a Hub 500, without the upstream message", async () => {
     vi.mocked(removeTaxonomyNode).mockResolvedValue({
       data: null,
-      error: { status: 500, message: "boom", detail: "" },
+      error: { status: 500, message: "pq: relation \"taxonomy_nodes\" does not exist", detail: "" },
     });
 
     const response = await removeV3TaxonomyNode({ ...base, nodeId: node.id });
+    const body = await response.json();
 
     expect(response.status).toBe(502);
+    expect(body.detail).toBe("The feedback service is unavailable.");
+    expect(JSON.stringify(body)).not.toContain("taxonomy_nodes");
+  });
+});
+
+describe("getV3TaxonomyNodeRecordCounts", () => {
+  const counts = [
+    { node_id: node.id, record_count: 42 },
+    { node_id: "node-2", record_count: 7 },
+  ];
+
+  test("returns the per-node counts on success", async () => {
+    vi.mocked(listTaxonomyNodeRecordCounts).mockResolvedValue({ data: { counts }, error: null });
+
+    const response = await getV3TaxonomyNodeRecordCounts({ ...base, runId: run.id });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ data: { counts } });
+    expect(listTaxonomyNodeRecordCounts).toHaveBeenCalledWith(run.id, directoryId);
+  });
+
+  test("returns the auth Response and skips the Hub call when access is denied", async () => {
+    const denied = new Response("forbidden", { status: 403 });
+    vi.mocked(requireUnifyDirectoryAccess).mockResolvedValue(denied);
+
+    const response = await getV3TaxonomyNodeRecordCounts({ ...base, runId: run.id });
+
+    expect(response).toBe(denied);
+    expect(listTaxonomyNodeRecordCounts).not.toHaveBeenCalled();
+  });
+
+  /**
+   * One table over every Hub status these endpoints can actually produce. The Hub has no 429/413/422 path
+   * for taxonomy, so those shared-mapper branches stay untested here on purpose. `detail` is asserted
+   * because it is the field this change alters — status alone would pass against the old code too.
+   */
+  test.each([
+    { hub: 0, status: 502, code: "bad_gateway", detail: "The feedback service is unavailable." },
+    { hub: 400, status: 400, code: "bad_request", detail: "at least 750 embedded records required; found 12" },
+    { hub: 401, status: 502, code: "bad_gateway", detail: "The feedback service is unavailable." },
+    { hub: 404, status: 404, code: "not_found", detail: "Taxonomy run not found" },
+    { hub: 409, status: 409, code: "conflict", detail: "at least 750 embedded records required; found 12" },
+    { hub: 500, status: 502, code: "bad_gateway", detail: "The feedback service is unavailable." },
+    { hub: 503, status: 503, code: "service_unavailable", detail: undefined },
+  ])("maps Hub $hub to $status", async ({ hub, status, code, detail }) => {
+    vi.mocked(listTaxonomyNodeRecordCounts).mockResolvedValue({
+      data: null,
+      error: {
+        status: hub,
+        message: "GET http://hub.internal:8080/v1/taxonomy/runs failed: upstream boom",
+        detail: "",
+        // Only relayed for the statuses the shared mapper allows; the fixture is the same for all of them
+        // so a status that must not relay is caught by the expected `detail` below.
+        problemDetail: "at least 750 embedded records required; found 12",
+      },
+    });
+
+    const response = await getV3TaxonomyNodeRecordCounts({ ...base, runId: run.id });
+    const body = await response.json();
+
+    expect(response.status).toBe(status);
+    expect(body.code).toBe(code);
+    if (detail !== undefined) {
+      expect(body.detail).toBe(detail);
+    }
+    // Whatever the mapping, the SDK's own error string never reaches the caller.
+    expect(JSON.stringify(body)).not.toContain("hub.internal");
+    expect(JSON.stringify(body)).not.toContain("upstream boom");
+  });
+
+  test("a 503 names the taxonomy subsystems, not embeddings", async () => {
+    vi.mocked(listTaxonomyNodeRecordCounts).mockResolvedValue({
+      data: null,
+      error: { status: 503, message: "embeddings not configured", detail: "" },
+    });
+
+    const response = await getV3TaxonomyNodeRecordCounts({ ...base, runId: run.id });
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    // A taxonomy 503 has four upstream causes and only one is embeddings — and that one is unreachable
+    // through the UI, since /fields gates the button first. Pointing this at feedbackRecords'
+    // embeddings-specific copy would therefore be wrong in exactly the case a user can hit.
+    expect(body.detail).not.toBe("Embeddings are not configured for this deployment.");
+    expect(body.detail).toContain("taxonomy");
+    expect(body.detail).toContain("retry");
+  });
+});
+
+describe("Hub error disclosure", () => {
+  const leaky = {
+    status: 500,
+    message:
+      'HUB_API_KEY is not set; GET http://hub.internal:8080/v1/taxonomy/runs/x?tenant_id=y -> 500 (request_id: hub_req_9f3) at /app/internal/service/taxonomy_service.go:196',
+    detail: "pq: relation \"taxonomy_nodes\" does not exist",
+    problemDetail: "internal: /app/internal/service/taxonomy_service.go:196",
+  };
+  const markers = [
+    "HUB_API_KEY",
+    "hub.internal",
+    "hub_req_9f3",
+    "taxonomy_service.go",
+    "taxonomy_nodes",
+    "/app/internal",
+  ];
+
+  /**
+   * The invariant this whole change exists for: no upstream text on the wire, whichever endpoint failed.
+   * Planted markers rather than a reading of the code, so a future call site that forgets the mapper fails
+   * here instead of shipping.
+   */
+  test.each([
+    {
+      name: "listV3TaxonomyFields",
+      arrange: () => vi.mocked(listTaxonomyFields).mockResolvedValue({ data: null, error: leaky }),
+      act: () => listV3TaxonomyFields(base),
+    },
+    {
+      name: "getV3TaxonomyState",
+      arrange: () => {
+        vi.mocked(listTaxonomyRuns).mockResolvedValue({ data: null, error: leaky });
+        vi.mocked(getActiveTaxonomyTree).mockResolvedValue({ data: null, error: leaky });
+      },
+      act: () => getV3TaxonomyState({ ...base, scopeType: "directory" as const }),
+    },
+    {
+      name: "getV3TaxonomyRun",
+      arrange: () => vi.mocked(getTaxonomyRun).mockResolvedValue({ data: null, error: leaky }),
+      act: () => getV3TaxonomyRun({ ...base, runId: run.id }),
+    },
+    {
+      name: "getV3TaxonomyNodeRecordCounts",
+      arrange: () =>
+        vi.mocked(listTaxonomyNodeRecordCounts).mockResolvedValue({ data: null, error: leaky }),
+      act: () => getV3TaxonomyNodeRecordCounts({ ...base, runId: run.id }),
+    },
+    {
+      name: "triggerV3TaxonomyRun",
+      arrange: () => vi.mocked(createTaxonomyRun).mockResolvedValue({ data: null, error: leaky }),
+      act: () =>
+        triggerV3TaxonomyRun({
+          ...base,
+          scopeType: "field" as const,
+          sourceType: "survey",
+          sourceId: "s1",
+          fieldId: "q1",
+        }),
+    },
+    {
+      name: "getV3TaxonomyNodeRecords",
+      arrange: () => vi.mocked(listTaxonomyNodeRecords).mockResolvedValue({ data: null, error: leaky }),
+      act: () => getV3TaxonomyNodeRecords({ ...base, nodeId: node.id, limit: 100 }),
+    },
+    {
+      name: "renameV3TaxonomyNode",
+      arrange: () => vi.mocked(renameTaxonomyNode).mockResolvedValue({ data: null, error: leaky }),
+      act: () => renameV3TaxonomyNode({ ...base, nodeId: node.id, label: "Copilot" }),
+    },
+    {
+      name: "removeV3TaxonomyNode",
+      arrange: () => vi.mocked(removeTaxonomyNode).mockResolvedValue({ data: null, error: leaky }),
+      act: () => removeV3TaxonomyNode({ ...base, nodeId: node.id }),
+    },
+  ])("$name returns no upstream internals", async ({ arrange, act }) => {
+    arrange();
+
+    const serialised = await (await act()).text();
+
+    for (const marker of markers) {
+      expect(serialised).not.toContain(marker);
+    }
+  });
+});
+
+describe("triggerV3TaxonomyRun error branch", () => {
+  const runParams = {
+    ...base,
+    scopeType: "directory" as const,
+  };
+
+  test("relays a Hub 400's actionable detail so the user learns why the run was refused", async () => {
+    vi.mocked(createTaxonomyRun).mockResolvedValue({
+      data: null,
+      error: {
+        status: 400,
+        message: "bad request",
+        detail: "",
+        code: "bad_request",
+        problemDetail: "at least 750 embedded records required; found 12",
+      },
+    });
+
+    const response = await triggerV3TaxonomyRun(runParams);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.detail).toBe("at least 750 embedded records required; found 12");
+  });
+
+  test("maps the Hub's 'no config' error (status 0) to a fixed 502", async () => {
+    vi.mocked(createTaxonomyRun).mockResolvedValue({
+      data: null,
+      error: { ...NO_CONFIG_ERROR },
+    });
+
+    const response = await triggerV3TaxonomyRun(runParams);
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.detail).toBe("The feedback service is unavailable.");
+    expect(JSON.stringify(body)).not.toContain("HUB_API_KEY");
+  });
+});
+
+describe("Hub failure logging", () => {
+  /**
+   * The other half of the disclosure rule: the upstream diagnostic still has to exist, just server-side.
+   * Removing it from the response without logging it would make these failures undebuggable.
+   */
+  test("logs a 5xx at error level, with the Hub error under the serialised `err` key", async () => {
+    const error = { status: 500, message: "upstream boom", detail: "" };
+    vi.mocked(getTaxonomyRun).mockResolvedValue({ data: null, error });
+
+    await getV3TaxonomyRun({ ...base, runId: run.id });
+
+    expect(logError).toHaveBeenCalledWith(
+      { hubStatus: 500, hubCode: undefined, err: error },
+      "Hub getRun failed"
+    );
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
+  test("logs a 4xx at warn level and without a stack, since it is not our fault", async () => {
+    vi.mocked(createTaxonomyRun).mockResolvedValue({
+      data: null,
+      error: { status: 400, message: "too few records", detail: "", code: "bad_request" },
+    });
+
+    await triggerV3TaxonomyRun({ ...base, scopeType: "directory" as const });
+
+    expect(logWarn).toHaveBeenCalledWith({ hubStatus: 400, hubCode: "bad_request" }, "Hub rejected startRun");
+    expect(logError).not.toHaveBeenCalled();
+  });
+
+  test("logs the 200-with-unavailable paths too, where the response says nothing at all", async () => {
+    vi.mocked(listTaxonomyFields).mockResolvedValue({
+      data: null,
+      error: { status: 0, message: "HUB_API_KEY is not set; Hub integration is disabled.", detail: "" },
+    });
+
+    await listV3TaxonomyFields(base);
+
+    expect(logError).toHaveBeenCalledWith(
+      expect.objectContaining({ hubStatus: 0 }),
+      "Hub listFields failed"
+    );
   });
 });

--- a/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.test.ts
+++ b/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.test.ts
@@ -596,6 +596,21 @@ describe("Hub failure logging", () => {
     expect(logError).not.toHaveBeenCalled();
   });
 
+  test("logs a Hub 401 loudly — it is our credentials, not the caller's request", async () => {
+    const error = { status: 401, message: "invalid api key", detail: "" };
+    vi.mocked(getTaxonomyRun).mockResolvedValue({ data: null, error });
+
+    const response = await getV3TaxonomyRun({ ...base, runId: run.id });
+
+    // The caller gets an opaque 502, so the log is the only place this is explainable.
+    expect(response.status).toBe(502);
+    expect(logError).toHaveBeenCalledWith(
+      { hubStatus: 401, hubCode: undefined, err: error },
+      "Hub getRun failed"
+    );
+    expect(logWarn).not.toHaveBeenCalled();
+  });
+
   test("logs the 200-with-unavailable paths too, where the response says nothing at all", async () => {
     vi.mocked(listTaxonomyFields).mockResolvedValue({
       data: null,

--- a/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.test.ts
+++ b/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.test.ts
@@ -50,6 +50,12 @@ vi.mock("@/modules/hub/service", () => ({
   removeTaxonomyNode: vi.fn(),
 }));
 
+/**
+ * A Hub 4xx `detail` the shared mapper is allowed to echo back. This is the Hub's real wording: on a
+ * validation failure it keeps `detail` fixed and puts the actionable message in `invalid_params`.
+ */
+const RELAYABLE_HUB_DETAIL = "One or more request parameters are invalid";
+
 const workspaceId = "clxx1234567890123456789012";
 const directoryId = "clfd1234567890123456789012";
 const context: V3WorkspaceContext = { workspaceId, organizationId: "org_1" };
@@ -390,10 +396,10 @@ describe("getV3TaxonomyNodeRecordCounts", () => {
    */
   test.each([
     { hub: 0, status: 502, code: "bad_gateway", detail: "The feedback service is unavailable." },
-    { hub: 400, status: 400, code: "bad_request", detail: "at least 750 embedded records required; found 12" },
+    { hub: 400, status: 400, code: "bad_request", detail: RELAYABLE_HUB_DETAIL },
     { hub: 401, status: 502, code: "bad_gateway", detail: "The feedback service is unavailable." },
     { hub: 404, status: 404, code: "not_found", detail: "Taxonomy run not found" },
-    { hub: 409, status: 409, code: "conflict", detail: "at least 750 embedded records required; found 12" },
+    { hub: 409, status: 409, code: "conflict", detail: RELAYABLE_HUB_DETAIL },
     { hub: 500, status: 502, code: "bad_gateway", detail: "The feedback service is unavailable." },
     { hub: 503, status: 503, code: "service_unavailable", detail: undefined },
   ])("maps Hub $hub to $status", async ({ hub, status, code, detail }) => {
@@ -403,9 +409,9 @@ describe("getV3TaxonomyNodeRecordCounts", () => {
         status: hub,
         message: "GET http://hub.internal:8080/v1/taxonomy/runs failed: upstream boom",
         detail: "",
-        // Only relayed for the statuses the shared mapper allows; the fixture is the same for all of them
-        // so a status that must not relay is caught by the expected `detail` below.
-        problemDetail: "at least 750 embedded records required; found 12",
+        // Same fixture on every row, so a status that must *not* relay is caught by the expected
+        // `detail` below rather than by the fixture simply being absent.
+        problemDetail: RELAYABLE_HUB_DETAIL,
       },
     });
 
@@ -532,15 +538,24 @@ describe("triggerV3TaxonomyRun error branch", () => {
     scopeType: "directory" as const,
   };
 
-  test("relays a Hub 400's actionable detail so the user learns why the run was refused", async () => {
+  /**
+   * The Hub's real 400 body, taken from a live response: `detail` is a fixed "one or more parameters are
+   * invalid" string and the *actionable* message sits in `invalid_params[0].reason`. Relaying `detail`
+   * alone would therefore drop the only text that tells a user why the run was refused.
+   */
+  test("keeps a Hub 400's actionable reason, which lives in invalid_params and not in detail", async () => {
+    const reason = "at least 750 embedded text feedback records are required; found 12";
+    // `TaxonomyScope.tenant_id` in the Hub's wording — the shared mapper rewrites the internal term to the
+    // product's own ("dataset") for every surface, so this asserts the rewritten name.
     vi.mocked(createTaxonomyRun).mockResolvedValue({
       data: null,
       error: {
         status: 400,
         message: "bad request",
         detail: "",
-        code: "bad_request",
-        problemDetail: "at least 750 embedded records required; found 12",
+        code: "validation",
+        problemDetail: RELAYABLE_HUB_DETAIL,
+        invalidParams: [{ name: "TaxonomyScope.tenant_id", reason }],
       },
     });
 
@@ -548,7 +563,10 @@ describe("triggerV3TaxonomyRun error branch", () => {
     const body = await response.json();
 
     expect(response.status).toBe(400);
-    expect(body.detail).toBe("at least 750 embedded records required; found 12");
+    expect(body.detail).toBe(RELAYABLE_HUB_DETAIL);
+    expect(body.invalid_params).toEqual([{ name: "TaxonomyScope.dataset_id", reason }]);
+    // The Hub's own `code` vocabulary ("validation") does not cross over into ours.
+    expect(body.code).toBe("bad_request");
   });
 
   test("maps the Hub's 'no config' error (status 0) to a fixed 502", async () => {

--- a/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.ts
+++ b/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.ts
@@ -111,8 +111,15 @@ function taxonomyHubErrorResponse(
 }
 
 /**
- * Log a Hub failure server-side — the diagnostic the response deliberately no longer carries. Ids and
- * statuses only: never the request body, the node label, or record content.
+ * A Hub status that describes the caller's own request rather than a fault on our side. Note that 401/403
+ * are excluded on purpose: from the caller's perspective those are *our* credentials failing, they surface
+ * as a generic 502, and logging them quietly would leave that outage with no explanation anywhere.
+ */
+const CALLER_FAULT_HUB_STATUSES = new Set([400, 404, 409, 413, 422]);
+
+/**
+ * Log a Hub failure server-side — the diagnostic the response deliberately no longer carries. Context is
+ * ids and statuses only: never the request body, the node label, or record content.
  */
 function logHubFailure(params: TBaseParams, error: HubError | null, operation: string): void {
   const { requestId, workspaceId, directoryId } = params;
@@ -120,8 +127,9 @@ function logHubFailure(params: TBaseParams, error: HubError | null, operation: s
   const hubStatus = error?.status ?? 0;
   const context = { hubStatus, hubCode: error?.code };
 
-  // A 4xx is the caller's or the tenant's situation, not a fault of ours — warn, and skip the stack.
-  if (hubStatus >= 400 && hubStatus < 500) {
+  // Nothing is broken and the caller already got the detail in the response, so no stack and no upstream
+  // text — the one place a Hub 4xx can echo caller input back at us.
+  if (CALLER_FAULT_HUB_STATUSES.has(hubStatus)) {
     log.warn(context, `Hub rejected ${operation}`);
     return;
   }

--- a/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.ts
+++ b/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.ts
@@ -4,7 +4,6 @@ import { hubErrorToProblemResponse } from "@/app/api/v3/lib/hub-errors";
 import {
   noContentResponse,
   problemNotFound,
-  problemServiceUnavailable,
   problemUnauthorized,
   successListResponse,
   successResponse,
@@ -97,14 +96,13 @@ function taxonomyHubErrorResponse(
   instance: string,
   resource: string
 ): Response {
-  if (error?.status === 503) {
-    return problemServiceUnavailable(requestId, TAXONOMY_UNAVAILABLE_DETAIL, instance);
-  }
   // No resource id in the body: the client only needs "this is gone, stop asking". A Hub 404 covers both
   // "no such run" and "not this tenant's run", so it is not an existence oracle either way.
   if (error?.status === 404) {
     return problemNotFound(requestId, resource, null, instance);
   }
+  // 404 is the only status this surface handles itself; the 503 wording is passed through to the shared
+  // mapper rather than special-cased here, which would be the same response written twice.
   return hubErrorToProblemResponse(error, requestId, instance, {
     serviceUnavailableDetail: TAXONOMY_UNAVAILABLE_DETAIL,
   });

--- a/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.ts
+++ b/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.ts
@@ -1,7 +1,10 @@
 import "server-only";
+import { logger } from "@formbricks/logger";
+import { hubErrorToProblemResponse } from "@/app/api/v3/lib/hub-errors";
 import {
   noContentResponse,
-  problemBadGateway,
+  problemNotFound,
+  problemServiceUnavailable,
   problemUnauthorized,
   successListResponse,
   successResponse,
@@ -19,6 +22,7 @@ import {
   renameTaxonomyNode,
 } from "@/modules/hub/service";
 import type { TaxonomyScopeInput, TaxonomyScopeType } from "@/modules/hub/types";
+import type { HubError } from "@/modules/hub/utils";
 import { getSessionUserId, requireUnifyDirectoryAccess } from "./access";
 
 type TBaseParams = {
@@ -56,8 +60,74 @@ function buildTaxonomyScope(
 /**
  * `fields` and `state` return 200 with an `unavailable` flag on Hub error / NO_CONFIG (mirroring the
  * legacy actions) so a transient Hub blip never trips a false "not enough feedback"/"embedding" gate.
- * The other endpoints return 502 so React Query surfaces an error state and the UI can retry.
+ * Their `unavailableMessage` is a fixed string: the upstream text is logged, never returned (see below).
+ *
+ * The other endpoints map the Hub's status through `taxonomyHubErrorResponse` — a Hub 400/409 surfaces as
+ * itself with its (bounded) detail, a 404 as a 404 so the client can stop polling, a 503 as a 503, and
+ * anything else as a generic 502.
  */
+
+/**
+ * What a Hub 503 means here. Deliberately *not* the feedback-records wording: the Hub returns 503 for
+ * taxonomy when either embeddings **or** the taxonomy compute service is unconfigured
+ * (`taxonomy_handler.go` / `taxonomy_service.go`), and the embeddings case is unreachable through the UI
+ * anyway — unset embeddings make `/fields` report `unavailable`, which disables the Generate button. So a
+ * message naming only embeddings would be wrong in exactly the case a user can reach. Retry-honest,
+ * because the compute service can also reject a run transiently.
+ */
+const TAXONOMY_UNAVAILABLE_DETAIL =
+  "Taxonomy generation is unavailable: the feedback service has no embedding model or no taxonomy compute service configured. If this is transient, retry in a few minutes; otherwise a self-hosting administrator can check EMBEDDING_MODEL and the taxonomy service on the Hub.";
+
+/** Fixed, caller-safe replacements for the three 200-with-`unavailable` paths. */
+const FIELDS_UNAVAILABLE_MESSAGE = "Taxonomy fields are unavailable";
+const RUNS_UNAVAILABLE_MESSAGE = "Taxonomy runs are unavailable";
+const ACTIVE_TREE_UNAVAILABLE_MESSAGE = "Active taxonomy is unavailable";
+
+/**
+ * Taxonomy's Hub-error policy. Two statuses mean something specific here; the rest go through the shared
+ * mapping, which is also what bounds how much of an upstream 4xx detail may be echoed.
+ *
+ * The Hub can only return 0 (network / no config), 400, 401, 404, 409, 500 and 503 on these endpoints — it
+ * has no 429, 413 or 422 path for taxonomy, so those branches of the shared mapper are unreachable from
+ * here and are deliberately untested on this surface.
+ */
+function taxonomyHubErrorResponse(
+  error: HubError | null,
+  requestId: string,
+  instance: string,
+  resource: string
+): Response {
+  if (error?.status === 503) {
+    return problemServiceUnavailable(requestId, TAXONOMY_UNAVAILABLE_DETAIL, instance);
+  }
+  // No resource id in the body: the client only needs "this is gone, stop asking". A Hub 404 covers both
+  // "no such run" and "not this tenant's run", so it is not an existence oracle either way.
+  if (error?.status === 404) {
+    return problemNotFound(requestId, resource, null, instance);
+  }
+  return hubErrorToProblemResponse(error, requestId, instance, {
+    serviceUnavailableDetail: TAXONOMY_UNAVAILABLE_DETAIL,
+  });
+}
+
+/**
+ * Log a Hub failure server-side — the diagnostic the response deliberately no longer carries. Ids and
+ * statuses only: never the request body, the node label, or record content.
+ */
+function logHubFailure(params: TBaseParams, error: HubError | null, operation: string): void {
+  const { requestId, workspaceId, directoryId } = params;
+  const log = logger.withContext({ requestId, workspaceId, directoryId });
+  const hubStatus = error?.status ?? 0;
+  const context = { hubStatus, hubCode: error?.code };
+
+  // A 4xx is the caller's or the tenant's situation, not a fault of ours — warn, and skip the stack.
+  if (hubStatus >= 400 && hubStatus < 500) {
+    log.warn(context, `Hub rejected ${operation}`);
+    return;
+  }
+  // `err` and not `error`: pino's stdSerializers.err is registered for that key only.
+  log.error({ ...context, err: error }, `Hub ${operation} failed`);
+}
 
 export async function listV3TaxonomyFields(params: TBaseParams): Promise<Response> {
   const { authentication, workspaceId, directoryId, requestId, instance } = params;
@@ -74,12 +144,9 @@ export async function listV3TaxonomyFields(params: TBaseParams): Promise<Respons
 
   const result = await listTaxonomyFields(directoryId);
   if (result.error) {
+    logHubFailure(params, result.error, "listFields");
     return successResponse(
-      {
-        fields: [],
-        unavailable: true,
-        unavailableMessage: result.error.message || "Taxonomy fields are unavailable",
-      },
+      { fields: [], unavailable: true, unavailableMessage: FIELDS_UNAVAILABLE_MESSAGE },
       { requestId }
     );
   }
@@ -125,27 +192,24 @@ export async function getV3TaxonomyState(
   ]);
 
   if (runs.error) {
+    logHubFailure(params, runs.error, "listRuns");
     return successResponse(
-      {
-        activeTree: null,
-        runs: [],
-        unavailable: true,
-        unavailableMessage: runs.error.message || "Taxonomy runs are unavailable",
-      },
+      { activeTree: null, runs: [], unavailable: true, unavailableMessage: RUNS_UNAVAILABLE_MESSAGE },
       { requestId }
     );
   }
 
   // A 404 from the active-tree endpoint means "no active taxonomy yet", not an outage.
   const treeUnavailable = Boolean(activeTree.error && activeTree.error.status !== 404);
+  if (treeUnavailable) {
+    logHubFailure(params, activeTree.error, "getActiveTree");
+  }
   return successResponse(
     {
       activeTree: activeTree.error?.status === 404 ? null : (activeTree.data ?? null),
       runs: runs.data?.data ?? [],
       unavailable: treeUnavailable,
-      unavailableMessage: treeUnavailable
-        ? activeTree.error?.message || "Active taxonomy is unavailable"
-        : undefined,
+      unavailableMessage: treeUnavailable ? ACTIVE_TREE_UNAVAILABLE_MESSAGE : undefined,
     },
     { requestId }
   );
@@ -166,7 +230,8 @@ export async function getV3TaxonomyRun(params: TBaseParams & { runId: string }):
 
   const result = await getTaxonomyRun(runId, directoryId);
   if (result.error || !result.data) {
-    return problemBadGateway(requestId, result.error?.message || "Failed to load taxonomy run", instance);
+    logHubFailure(params, result.error, "getRun");
+    return taxonomyHubErrorResponse(result.error, requestId, instance, "Taxonomy run");
   }
 
   return successResponse(result.data, { requestId });
@@ -189,7 +254,8 @@ export async function getV3TaxonomyNodeRecordCounts(
 
   const result = await listTaxonomyNodeRecordCounts(runId, directoryId);
   if (result.error || !result.data) {
-    return problemBadGateway(requestId, result.error?.message || "Failed to load record counts", instance);
+    logHubFailure(params, result.error, "getRecordCounts");
+    return taxonomyHubErrorResponse(result.error, requestId, instance, "Taxonomy run");
   }
 
   return successResponse({ counts: result.data.counts }, { requestId });
@@ -237,11 +303,10 @@ export async function triggerV3TaxonomyRun(
     actor_id: actorId,
   });
   if (result.error || !result.data) {
-    return problemBadGateway(
-      requestId,
-      result.error?.message || "Failed to start taxonomy generation",
-      instance
-    );
+    logHubFailure(params, result.error, "startRun");
+    // The most common failure here is a Hub 400 ("at least N embedded text records are required; found
+    // M") — squarely the caller's own situation, so the shared mapper relays that detail (bounded).
+    return taxonomyHubErrorResponse(result.error, requestId, instance, "Taxonomy run");
   }
 
   return successResponse({ run: result.data.run, inProgress: result.data.in_progress }, { requestId });
@@ -264,7 +329,8 @@ export async function getV3TaxonomyNodeRecords(
 
   const result = await listTaxonomyNodeRecords(nodeId, { tenant_id: directoryId, limit });
   if (result.error || !result.data) {
-    return problemBadGateway(requestId, result.error?.message || "Failed to load feedback records", instance);
+    logHubFailure(params, result.error, "getNodeRecords");
+    return taxonomyHubErrorResponse(result.error, requestId, instance, "Taxonomy node");
   }
 
   return successListResponse(result.data.data, { limit: result.data.limit }, { requestId });
@@ -294,7 +360,8 @@ export async function renameV3TaxonomyNode(
     label,
   });
   if (result.error || !result.data) {
-    return problemBadGateway(requestId, result.error?.message || "Failed to rename taxonomy node", instance);
+    logHubFailure(params, result.error, "renameNode");
+    return taxonomyHubErrorResponse(result.error, requestId, instance, "Taxonomy node");
   }
 
   return successResponse(result.data, { requestId });
@@ -318,7 +385,8 @@ export async function removeV3TaxonomyNode(params: TBaseParams & { nodeId: strin
 
   const result = await removeTaxonomyNode(nodeId, { tenant_id: directoryId, actor_id: actorId });
   if (result.error || !result.data) {
-    return problemBadGateway(requestId, result.error?.message || "Failed to remove taxonomy node", instance);
+    logHubFailure(params, result.error, "removeNode");
+    return taxonomyHubErrorResponse(result.error, requestId, instance, "Taxonomy node");
   }
 
   return noContentResponse({ requestId });

--- a/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.ts
+++ b/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.ts
@@ -312,8 +312,9 @@ export async function triggerV3TaxonomyRun(
   });
   if (result.error || !result.data) {
     logHubFailure(params, result.error, "startRun");
-    // The most common failure here is a Hub 400 ("at least N embedded text records are required; found
-    // M") — squarely the caller's own situation, so the shared mapper relays that detail (bounded).
+    // The most common failure here is a Hub 400: "at least N embedded text feedback records are required;
+    // found M" — squarely the caller's own situation. Note the Hub puts that in `invalid_params[0].reason`
+    // and keeps a fixed string in `detail`, so it is the relayed params, not the detail, that carry it.
     return taxonomyHubErrorResponse(result.error, requestId, instance, "Taxonomy run");
   }
 

--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.test.ts
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.test.ts
@@ -82,6 +82,38 @@ describe("useTaxonomyRun", () => {
     }
   });
 
+  test("stops polling once the run is gone (404), instead of asking forever", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.mocked(global.fetch);
+      // A run reaped by the orphan cleaner, or a stale id after a regenerate. Before this behaviour the
+      // status stayed unknown, so the interval kept firing at ~12 req/min while the UI showed "generating".
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ title: "Not Found", status: 404, code: "not_found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/problem+json" },
+        })
+      );
+
+      renderHook(() => useTaxonomyRun({ workspaceId: "w", directoryId: "d", runId: "run-1" }), {
+        wrapper: createWrapper(createQueryClient()),
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // Several intervals later there must still be exactly the one request.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20000);
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("stays idle (no fetch) when runId is null", () => {
     const fetchMock = vi.mocked(global.fetch);
 

--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.ts
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.ts
@@ -2,14 +2,19 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { InvalidInputError } from "@formbricks/types/errors";
+import { V3ApiError } from "@/modules/api/lib/v3-client";
 import { getTaxonomyRun } from "../lib/api-client";
 import { taxonomyKeys } from "../lib/query";
 
 const RUN_POLL_INTERVAL_MS = 5000;
 
-/** Poll a taxonomy run until it reaches a terminal state (succeeded/failed/canceled). Keeps polling
- * while the status is unknown too — e.g. a poll that errored before any success — so a transient Hub
- * blip self-recovers instead of leaving the caller stuck showing "generating" forever. */
+/** Poll a taxonomy run until it reaches a terminal state (succeeded/failed/canceled). Keeps polling while
+ * the status is unknown too — e.g. a poll that errored before any success — so a transient Hub blip
+ * self-recovers instead of leaving the caller stuck showing "generating" forever.
+ *
+ * A 404 is the exception: the run is gone (reaped, or a stale id after a regenerate) and no amount of
+ * polling will bring it back, so keeping the interval alive would mean "generating…" forever at one request
+ * every five seconds. That case stops. */
 export const useTaxonomyRun = ({
   workspaceId,
   directoryId,
@@ -27,9 +32,17 @@ export const useTaxonomyRun = ({
     },
     staleTime: 0,
     refetchInterval: (query) => {
-      // Stop only once the run has genuinely finished. Any other state — pending/running, or unknown
-      // because the last poll errored (data undefined) — keeps the interval alive so polling resumes
-      // on its own when the Hub recovers.
+      // A run that no longer exists is terminal, however many times we ask. Every 404 on this endpoint
+      // means "gone" — the Hub returns it for both "no such run" and "not this directory's run" — so the
+      // status alone is enough to decide.
+      const { error } = query.state;
+      if (error instanceof V3ApiError && error.status === 404) {
+        return false;
+      }
+
+      // Otherwise stop only once the run has genuinely finished. Any other state — pending/running, or
+      // unknown because the last poll errored (data undefined) — keeps the interval alive so polling
+      // resumes on its own when the Hub recovers.
       const status = query.state.data?.status;
       const isTerminal = status === "succeeded" || status === "failed" || status === "canceled";
       return isTerminal ? false : RUN_POLL_INTERVAL_MS;

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -1630,11 +1630,13 @@ components:
             - ai_smart_tools_disabled
             - bad_gateway
             - bad_request
+            - conflict
             - forbidden
             - internal_server_error
             - not_authenticated
             - not_found
             - payload_too_large
+            - service_unavailable
             - too_many_requests
             - unprocessable_content
         requestId:

--- a/docs/api-v3-reference/src/components/schemas/Problem.yml
+++ b/docs/api-v3-reference/src/components/schemas/Problem.yml
@@ -30,11 +30,13 @@ properties:
       - ai_smart_tools_disabled
       - bad_gateway
       - bad_request
+      - conflict
       - forbidden
       - internal_server_error
       - not_authenticated
       - not_found
       - payload_too_large
+      - service_unavailable
       - too_many_requests
       - unprocessable_content
   requestId:


### PR DESCRIPTION
> [!NOTE]
> Was stacked on #8650, which has now merged. Rebased onto `main` — the diff is these 7 commits and 11 files only. Still a draft pending a look-over.

## What & why

`app/api/v3/unify-feedback/taxonomy/lib/operations.ts` was putting raw upstream Hub error text into its own HTTP responses in nine places. `HubError.message` is the SDK error string, and for the Hub SDK that is the *whole* upstream problem body. Captured from the local Hub:

```
GET /api/v3/.../taxonomy/runs/<gone>  →  502
detail: "404 {\"type\":\"https://hub.formbricks.com/problems/not-found\",\"title\":\"Not Found\",
  \"status\":404,\"detail\":\"taxonomy run not found\",
  \"instance\":\"/v1/taxonomy/runs/00000000-0000-0000-0000-000000000000\",\"code\":\"not_found\",
  \"request_id\":\"019fa935-82ab-7cb6-9a34-80e364ddb9d3\",\"details\":{...}}"
```

So: the Hub's internal endpoint path and its own `request_id`, in a browser-visible response. `NO_CONFIG_ERROR` rode the same path, putting the literal `HUB_API_KEY is not set; Hub integration is disabled.` on the wire. That contradicts the rule the v3 layer documents for itself (`response.ts`'s `problemNotFound` JSDoc, and the OpenAPI Security section on not leaking existence).

Two things turned up alongside it:

- **The file logged nothing at all** — the diagnostic went to the client instead of to us.
- **Every Hub failure collapsed to 502**, discarding `error.status`. That hid a live bug: a run reaped by the orphan cleaner returns Hub 404 → surfaced as 502 → `useTaxonomyRun` never treats it as terminal, so the UI showed "generating…" indefinitely while polling every five seconds.

Found during the #8650 security review, checking whether that PR's relay rules were repeated correctly elsewhere.

### What changed

**Status mapping** for the set the Hub can actually emit here (`0/400/401/404/409/500/503`):

| Hub | → | detail |
| --- | --- | --- |
| 400 | 400 | fixed string + the Hub's `invalid_params` relayed (bounded) |
| 409 | 409 | Hub's detail, relayed (bounded 512) — retryable tenant-purge conflict |
| 404 | 404 | static, `resource_type` and **no** `resource_id` — the terminal signal the client needs |
| 503 | 503 | taxonomy's own wording (below) |
| 0 / 401 / 500 / other | 502 | fixed `"The feedback service is unavailable."` |

A **503 deliberately does not reuse the feedback-records "embeddings are not configured" copy.** The Hub returns 503 for taxonomy when embeddings **or** the compute service is unconfigured, and the embeddings case can't be reached through the UI at all — unset embeddings make `/fields` report `unavailable`, which disables the Generate button first. Confirmed live: this deployment has `EMBEDDING_MODEL` set and no starter, and its taxonomy 503 is `"Taxonomy service is not available."` — precisely the case the embeddings wording would have described wrongly. `hubErrorToProblemResponse`'s 503 detail is therefore a caller-supplied option whose default names no subsystem — that part landed on the base branch, where the same problem was raised in review for `feedbackRecords`, so this PR just uses it.

**The three `200 + unavailable: true` responses keep their shape** — the Generate gate depends on it — but carry a fixed message instead of `result.error.message`.

**Logging, where there was none.** `warn` for the statuses that really describe the caller's own request, `error` with the serialised `err` key for everything else. Context is ids and statuses only — never request bodies, node labels, or record content. A Hub **401** is in the error bucket on purpose: that's our `HUB_API_KEY` failing, it surfaces to the caller as an opaque 502, and logging it quietly would leave that outage explainable from nowhere.

**Client:** a `V3ApiError` with status 404 now ends the run poll. Everything else, 5xx included, keeps the existing self-recovery behaviour.

**Spec:** `conflict` and `service_unavailable` were emitted by response helpers but missing from the `Problem.code` enum. The spec CI job only fires on `docs/api-v3-reference/**`, so nothing caught the drift.

Out of scope: **part 2 of the ticket** (consolidating the duplicated `handleUnexpectedError` blocks). ENG-2048 is updated to say part 1 only.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2048

## How this was tested

**Automated** — `892 passed (61 files)` across `app/api/v3`, `modules/ee/unify-feedback`, `modules/mcp`, `modules/hub`. eslint clean on every changed file; `tsc --noEmit` clean for them. `api:v3:lint` valid and `api:v3:check` in sync.

Tests added:
- A status table over the whole reachable set, asserting status, `code` **and `detail`**. Every prior fixture used `status: 500`, so the old status-only assertions would have passed unchanged and given zero regression signal.
- A **disclosure guard**: `HUB_API_KEY`, an internal host, a fake upstream `request_id` and a Go source path are planted in the Hub error, and asserted absent from every response of all eight operations.
- A **503 regression guard** — a taxonomy 503 must not carry the embeddings copy — so nobody re-points this at the shared branch later.
- Logging assertions, including the 401-is-loud case.
- First tests for `getV3TaxonomyNodeRecordCounts`, which had none (`listTaxonomyNodeRecordCounts` wasn't even in the `vi.mock` factory) despite owning one of the nine sites.
- The 404-stops-the-poll test, verified to fail without the fix.

Coverage on changed code: taxonomy `operations.ts` 91.3% stmts / 98.9% lines, `hub-errors.ts` 87.9% / 90.6%.

**Against the live Hub** (`localhost:8080`), driving the real SDK → `HubError` → mapper chain with no mocks:
- A real Hub 404 → the `HubError.message` quoted at the top; mapped body carries none of it.
- A real Hub 503 (`"Taxonomy service is not available."`) → mapped to 503 with taxonomy's wording.
- A real Hub 400 → `detail` is a fixed `"One or more request parameters are invalid"` with the actionable message in `invalid_params[0].reason` and its own `code: "validation"`. That corrected a test fixture that had assumed the message lived in `detail`: relaying detail alone would have dropped the only text explaining a refused run, so the params relay is now asserted.

**Security** — gitleaks and semgrep (`p/typescript`, `p/secrets`) clean on the diff. No Prisma queries added and `requireUnifyDirectoryAccess` still runs before every Hub call, so tenant scoping is untouched; no response gains a field.

### Note on the rebase

#8650's review raised the same 503 problem for `feedbackRecords`. Rather than leave `main` briefly wrong and
fix it one PR later, that fix went into #8650 itself (now on `main`) and this branch rebased onto it, so
commit 1 here is a pure module relocation. One knock-on: the shared mapper's `tenant_id` → `dataset_id` rewrite (also added on
the base) now applies to the taxonomy routes too. That is correct at the product level — "dataset" is what the
UI calls a feedback directory, in 45 user-facing strings — though it does highlight that the taxonomy routes
spell their own query parameter `directoryId`. That inconsistency between v3 surfaces predates this PR and is
left alone here.

## QA / Test Plan

**How to test**

- [ ] Open Topics & Subtopics for a feedback directory on a licensed EE workspace → the page loads as before. Regenerating and renaming/removing nodes all behave unchanged on the happy path.
- [ ] With the Hub's taxonomy compute service unconfigured, press Generate → the request fails with **503** and a message naming *both* the embedding model and the taxonomy service, and suggesting a retry. It must **not** say only "embeddings".
- [ ] On a directory with too few embedded records (needs a fully configured Hub), press Generate → **400**, and the response still tells you *"at least N embedded text feedback records are required; found M"* (now in `invalid_params`). If that has gone generic, the relay is broken.
- [ ] **The poll fix:** start a generation, note the run id, delete that run row in the Hub DB, and leave the page open for 60s → the browser must **stop** issuing `/api/v3/.../taxonomy/runs/{id}` (count them in the Network tab). Before this change it kept polling every 5s forever.
- [ ] Stop the Hub entirely and load the page → **200** with the empty/unavailable state (not an error page), and the response body contains no `HUB_API_KEY`, host/port, or stack trace.
- [ ] Inspect every error body from the steps above for Hub internals — host/port, `HUB_API_URL`, `HUB_API_KEY`, `request_id` from the Hub, Go source paths, `/v1/...` paths. There should be none, including in `unavailableMessage`.
- [ ] Check the server logs for the failing cases: the upstream diagnostic must now be *there* instead. A bad `HUB_API_KEY` should log at **error** level with the Hub error attached.

**Preconditions / test data**

- Licensed EE org with Unify Feedback enabled, and a feedback directory with text records.
- The 400 case needs a Hub with both `EMBEDDING_MODEL` and the taxonomy compute service configured, plus a directory below the embedded-record minimum. The 503 case needs the compute service *un*configured.
- The record threshold is the Hub's `minimumEmbeddingCount` — **please confirm the live value** rather than trusting the 750 used in test fixtures.

**Risks & regressions**

- Status codes on these routes are now wire-visible where they were uniformly 502. Nothing in the Unify UI reads `V3ApiError.status` and retry is a flat `retry: 1` with no status predicate, so apart from the 404 fix this is hardening — but it is a behaviour change for any direct API consumer.
- The `200 + unavailable` shape is load-bearing for the Generate gate; it is unchanged, only its message is fixed text. Re-check that the gate still enables and disables correctly.
- No E2E coverage exists on this surface (`apps/web/playwright/` has no Unify specs), so the route-level tests are the safety net.

**Migrations / env / cutover**

- none

## Follow-ups (not in this PR)

- **ENG-2048 part 2** — the `handleUnexpectedError` duplication (six variants in `surveys/lib/operations.ts` with drifting log messages, plus `list-resource.ts`, two in `lib/auth.ts`, and the api-wrapper catch).
- `surveys/generate/route.ts:112` returns `problemNotFound` **with** the `organizationId` in the body, against `response.ts`'s own JSDoc.
- `list-resource.ts:83` forwards an `InvalidInputError` message into `problemBadRequest` and `invalid_params[0].reason`.
- `api-client.test.ts:192` simulates `409 "already running"`, but the Hub returns **200 + `in_progress: true`** for that; 409 is `tenant_write_conflict`. It also has a pre-existing type error. Left alone to keep this diff scoped.
- Client hardening: a `retry` predicate so 4xx isn't retried, poll backoff on 429/503, and honouring `Retry-After` — nothing in `apps/web` does today.

