### PR TITLE
fix: enforce tenant scoping on workspace teamIds and response contact/display links (ENG-1922, ENG-1923)

### DIFF
--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
@@ -148,10 +148,12 @@ const notFound = (field: string): ApiErrorResponseV2 => ({
   details: [{ field, issue: "not found" }],
 });
 
+/** Either the request-scoped transaction client or the shared one — both satisfy these reads. */
+type ResponseDbClient = Prisma.TransactionClient | typeof prisma;
+
 /** The response's own tenant anchor, loaded once and shared by the FK checks below. */
 type ResponseTenantAnchor = {
   surveyId: string;
-  contactId: string | null;
   survey: { workspaceId: string };
 };
 
@@ -159,7 +161,7 @@ type ResponseTenantAnchor = {
 const validateContactScope = async (
   contactId: string,
   workspaceId: string,
-  prismaClient: Prisma.TransactionClient | typeof prisma
+  prismaClient: ResponseDbClient
 ): Promise<ApiErrorResponseV2 | null> => {
   const contact = await prismaClient.contact.findUnique({
     where: { id: contactId, workspaceId },
@@ -171,15 +173,22 @@ const validateContactScope = async (
 
 /**
  * Rejects a display that belongs to another workspace or survey, or that is already claimed by a
- * different response or contact. A ValidationError from the lookup means the id was malformed, which
- * is reported as not-found for the same reason as above.
+ * different response. A ValidationError from the lookup means the id was malformed, which is reported
+ * as not-found for the same reason as above.
+ *
+ * Deliberately does NOT require the display's contact to match the response's: the display is already
+ * pinned to this response's workspace and survey, and a caller-supplied contactId is separately
+ * scoped to the same workspace by validateContactScope, so a contact rule adds no tenant isolation
+ * here. It would instead reject legitimate same-tenant edits — clearing contactId while keeping the
+ * response's own display, or moving the response to another contact in the same workspace — and,
+ * because the errors are deliberately uniform, report them as an undiagnosable 404 on displayId.
+ * (assertDisplayOwnership enforces it on the create path, where a fresh display has no prior owner.)
  */
 const validateDisplayScope = async (
   displayId: string,
   responseId: string,
   anchor: ResponseTenantAnchor,
-  effectiveContactId: string | null,
-  prismaClient: Prisma.TransactionClient | typeof prisma
+  prismaClient: ResponseDbClient
 ): Promise<ApiErrorResponseV2 | null> => {
   let display: Awaited<ReturnType<typeof getDisplayForResponseValidation>>;
   try {
@@ -195,8 +204,7 @@ const validateDisplayScope = async (
     display !== null &&
     display.workspaceId === anchor.survey.workspaceId &&
     display.surveyId === anchor.surveyId &&
-    (display.responseId === null || display.responseId === responseId) &&
-    (display.contactId === null || display.contactId === effectiveContactId);
+    (display.responseId === null || display.responseId === responseId);
 
   return isUsable ? null : notFound("displayId");
 };
@@ -215,7 +223,7 @@ const validateDisplayScope = async (
 const validateResponseLinkScope = async (
   responseId: string,
   responseInput: z.infer<typeof ZResponseUpdateSchema>,
-  prismaClient: Prisma.TransactionClient | typeof prisma
+  prismaClient: ResponseDbClient
 ): Promise<ApiErrorResponseV2 | null> => {
   if (!responseInput.contactId && !responseInput.displayId) {
     return null;
@@ -223,7 +231,7 @@ const validateResponseLinkScope = async (
 
   const anchor = await prismaClient.response.findUnique({
     where: { id: responseId },
-    select: { surveyId: true, contactId: true, survey: { select: { workspaceId: true } } },
+    select: { surveyId: true, survey: { select: { workspaceId: true } } },
   });
   if (!anchor) {
     return notFound("response");
@@ -244,11 +252,7 @@ const validateResponseLinkScope = async (
     return null;
   }
 
-  // An explicit contactId in this same update wins over the stored one, including an explicit null.
-  const effectiveContactId =
-    responseInput.contactId !== undefined ? responseInput.contactId : anchor.contactId;
-
-  return validateDisplayScope(responseInput.displayId, responseId, anchor, effectiveContactId, prismaClient);
+  return validateDisplayScope(responseInput.displayId, responseId, anchor, prismaClient);
 };
 
 export const updateResponse = async (

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
@@ -4,7 +4,9 @@ import { prisma } from "@formbricks/database";
 import { Prisma, Response } from "@formbricks/database/prisma";
 import { PrismaErrorType } from "@formbricks/database/types/error";
 import { Result, err, ok } from "@formbricks/types/error-handlers";
+import { ValidationError } from "@formbricks/types/errors";
 import { TResponse } from "@formbricks/types/responses";
+import { getDisplayForResponseValidation } from "@/lib/display/service";
 import { normalizeResponseLanguage } from "@/lib/response/utils";
 import { deleteDisplay } from "@/modules/api/v2/management/responses/[responseId]/lib/display";
 import { getSurveyQuestions } from "@/modules/api/v2/management/responses/[responseId]/lib/survey";
@@ -146,6 +148,54 @@ export const updateResponse = async (
 ): Promise<Result<Response, ApiErrorResponseV2>> => {
   try {
     const prismaClient = tx ?? prisma;
+
+    // ENG-1923: contactId and displayId are caller-supplied FKs mass-assigned into the update
+    // below. Verify each belongs to this response's own workspace/survey before persisting — a
+    // caller authorized on this response must not be able to re-point it at another tenant's
+    // contact or display (cross-tenant BOLA). surveyId is not updatable (omitted from the schema),
+    // so the response's workspace anchor is stable. Foreign and nonexistent ids fail identically
+    // (404, generic) — no cross-tenant existence oracle.
+    const existingResponse = await prismaClient.response.findUnique({
+      where: { id: responseId },
+      select: { surveyId: true, contactId: true, survey: { select: { workspaceId: true } } },
+    });
+    if (!existingResponse) {
+      return err({ type: "not_found", details: [{ field: "response", issue: "not found" }] });
+    }
+    const workspaceId = existingResponse.survey.workspaceId;
+
+    if (responseInput.contactId) {
+      const contact = await prismaClient.contact.findUnique({
+        where: { id: responseInput.contactId, workspaceId },
+        select: { id: true },
+      });
+      if (!contact) {
+        return err({ type: "not_found", details: [{ field: "contactId", issue: "not found" }] });
+      }
+    }
+
+    if (responseInput.displayId) {
+      const effectiveContactId =
+        responseInput.contactId !== undefined ? responseInput.contactId : existingResponse.contactId;
+      try {
+        const display = await getDisplayForResponseValidation(responseInput.displayId, prismaClient);
+        const displayValid =
+          display !== null &&
+          display.workspaceId === workspaceId &&
+          display.surveyId === existingResponse.surveyId &&
+          (display.responseId === null || display.responseId === responseId) &&
+          (display.contactId === null || display.contactId === effectiveContactId);
+        if (!displayValid) {
+          return err({ type: "not_found", details: [{ field: "displayId", issue: "not found" }] });
+        }
+      } catch (error) {
+        if (error instanceof ValidationError) {
+          return err({ type: "not_found", details: [{ field: "displayId", issue: "not found" }] });
+        }
+        throw error;
+      }
+    }
+
     const updatedResponse = await prismaClient.response.update({
       where: {
         id: responseId,

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/response.ts
@@ -141,6 +141,116 @@ export const deleteResponse = async (responseId: string): Promise<Result<Respons
   }
 };
 
+// A rejected foreign key and a nonexistent one must be indistinguishable, so every failure below
+// is the same generic 404 — anything more specific would be a cross-tenant existence oracle.
+const notFound = (field: string): ApiErrorResponseV2 => ({
+  type: "not_found",
+  details: [{ field, issue: "not found" }],
+});
+
+/** The response's own tenant anchor, loaded once and shared by the FK checks below. */
+type ResponseTenantAnchor = {
+  surveyId: string;
+  contactId: string | null;
+  survey: { workspaceId: string };
+};
+
+/** Rejects a contact that is not in the response's own workspace. */
+const validateContactScope = async (
+  contactId: string,
+  workspaceId: string,
+  prismaClient: Prisma.TransactionClient | typeof prisma
+): Promise<ApiErrorResponseV2 | null> => {
+  const contact = await prismaClient.contact.findUnique({
+    where: { id: contactId, workspaceId },
+    select: { id: true },
+  });
+
+  return contact ? null : notFound("contactId");
+};
+
+/**
+ * Rejects a display that belongs to another workspace or survey, or that is already claimed by a
+ * different response or contact. A ValidationError from the lookup means the id was malformed, which
+ * is reported as not-found for the same reason as above.
+ */
+const validateDisplayScope = async (
+  displayId: string,
+  responseId: string,
+  anchor: ResponseTenantAnchor,
+  effectiveContactId: string | null,
+  prismaClient: Prisma.TransactionClient | typeof prisma
+): Promise<ApiErrorResponseV2 | null> => {
+  let display: Awaited<ReturnType<typeof getDisplayForResponseValidation>>;
+  try {
+    display = await getDisplayForResponseValidation(displayId, prismaClient);
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      return notFound("displayId");
+    }
+    throw error;
+  }
+
+  const isUsable =
+    display !== null &&
+    display.workspaceId === anchor.survey.workspaceId &&
+    display.surveyId === anchor.surveyId &&
+    (display.responseId === null || display.responseId === responseId) &&
+    (display.contactId === null || display.contactId === effectiveContactId);
+
+  return isUsable ? null : notFound("displayId");
+};
+
+/**
+ * ENG-1923: contactId and displayId are caller-supplied FKs mass-assigned into the update in
+ * updateResponse. When either is present, verify it belongs to this response's own workspace/survey
+ * before persisting — a caller authorized on this response must not be able to re-point it at
+ * another tenant's contact or display (cross-tenant BOLA). surveyId is not updatable (omitted from
+ * the schema), so the response's workspace anchor is stable.
+ *
+ * Returns null when there is nothing to reject. When neither FK is supplied the tenant lookup is
+ * skipped entirely; a missing response is still surfaced as a 404 by the update's
+ * PrismaClientKnownRequestError handler.
+ */
+const validateResponseLinkScope = async (
+  responseId: string,
+  responseInput: z.infer<typeof ZResponseUpdateSchema>,
+  prismaClient: Prisma.TransactionClient | typeof prisma
+): Promise<ApiErrorResponseV2 | null> => {
+  if (!responseInput.contactId && !responseInput.displayId) {
+    return null;
+  }
+
+  const anchor = await prismaClient.response.findUnique({
+    where: { id: responseId },
+    select: { surveyId: true, contactId: true, survey: { select: { workspaceId: true } } },
+  });
+  if (!anchor) {
+    return notFound("response");
+  }
+
+  if (responseInput.contactId) {
+    const contactError = await validateContactScope(
+      responseInput.contactId,
+      anchor.survey.workspaceId,
+      prismaClient
+    );
+    if (contactError) {
+      return contactError;
+    }
+  }
+
+  if (!responseInput.displayId) {
+    return null;
+  }
+
+  // An explicit contactId in this same update wins over the stored one, including an explicit null.
+  const effectiveContactId =
+    responseInput.contactId !== undefined ? responseInput.contactId : anchor.contactId;
+
+  return validateDisplayScope(responseInput.displayId, responseId, anchor, effectiveContactId, prismaClient);
+};
+
 export const updateResponse = async (
   responseId: string,
   responseInput: z.infer<typeof ZResponseUpdateSchema>,
@@ -149,51 +259,9 @@ export const updateResponse = async (
   try {
     const prismaClient = tx ?? prisma;
 
-    // ENG-1923: contactId and displayId are caller-supplied FKs mass-assigned into the update
-    // below. Verify each belongs to this response's own workspace/survey before persisting — a
-    // caller authorized on this response must not be able to re-point it at another tenant's
-    // contact or display (cross-tenant BOLA). surveyId is not updatable (omitted from the schema),
-    // so the response's workspace anchor is stable. Foreign and nonexistent ids fail identically
-    // (404, generic) — no cross-tenant existence oracle.
-    const existingResponse = await prismaClient.response.findUnique({
-      where: { id: responseId },
-      select: { surveyId: true, contactId: true, survey: { select: { workspaceId: true } } },
-    });
-    if (!existingResponse) {
-      return err({ type: "not_found", details: [{ field: "response", issue: "not found" }] });
-    }
-    const workspaceId = existingResponse.survey.workspaceId;
-
-    if (responseInput.contactId) {
-      const contact = await prismaClient.contact.findUnique({
-        where: { id: responseInput.contactId, workspaceId },
-        select: { id: true },
-      });
-      if (!contact) {
-        return err({ type: "not_found", details: [{ field: "contactId", issue: "not found" }] });
-      }
-    }
-
-    if (responseInput.displayId) {
-      const effectiveContactId =
-        responseInput.contactId !== undefined ? responseInput.contactId : existingResponse.contactId;
-      try {
-        const display = await getDisplayForResponseValidation(responseInput.displayId, prismaClient);
-        const displayValid =
-          display !== null &&
-          display.workspaceId === workspaceId &&
-          display.surveyId === existingResponse.surveyId &&
-          (display.responseId === null || display.responseId === responseId) &&
-          (display.contactId === null || display.contactId === effectiveContactId);
-        if (!displayValid) {
-          return err({ type: "not_found", details: [{ field: "displayId", issue: "not found" }] });
-        }
-      } catch (error) {
-        if (error instanceof ValidationError) {
-          return err({ type: "not_found", details: [{ field: "displayId", issue: "not found" }] });
-        }
-        throw error;
-      }
+    const linkScopeError = await validateResponseLinkScope(responseId, responseInput, prismaClient);
+    if (linkScopeError) {
+      return err(linkScopeError);
     }
 
     const updatedResponse = await prismaClient.response.update({

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
@@ -532,6 +532,26 @@ describe("Response Lib", () => {
       expect(prisma.response.update).not.toHaveBeenCalled();
     });
 
+    // ENG-1923: the tenant guard must not reject legitimate same-tenant edits. contactId and
+    // displayId are required-nullable in ZResponseUpdateSchema, so every PUT carries both — clearing
+    // the contact while keeping the response's own display is an ordinary update, even though that
+    // display still records the previous contact. Tenant isolation comes from workspace + survey +
+    // self-link; a display↔contact match rule would 404 this case, reported against the wrong field.
+    test("allows clearing contactId while keeping the response's own displayId (ENG-1923)", async () => {
+      vi.mocked(getDisplayForResponseValidation).mockResolvedValue({
+        ...validDisplay,
+        contactId: responseInput.contactId, // display still points at the contact being unlinked
+      });
+      vi.mocked(prisma.response.update).mockResolvedValue(response);
+
+      const result = await updateResponse(responseId, { ...responseInput, contactId: null });
+
+      expect(result.ok).toBe(true);
+      // No contact lookup is needed when the caller is clearing the link.
+      expect(prisma.contact.findUnique).not.toHaveBeenCalled();
+      expect(prisma.response.update).toHaveBeenCalledTimes(1);
+    });
+
     test("rejects a displayId already linked to a different response (ENG-1923)", async () => {
       vi.mocked(getDisplayForResponseValidation).mockResolvedValue({
         ...validDisplay,

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
@@ -505,6 +505,12 @@ describe("Response Lib", () => {
           details: [{ field: "contactId", issue: "not found" }],
         });
       }
+      // The lookup itself must be workspace-scoped: asserting only the rejection would still pass
+      // if the `workspaceId` filter were dropped, since the mock returns null either way.
+      expect(prisma.contact.findUnique).toHaveBeenCalledWith({
+        where: { id: responseInput.contactId, workspaceId: responseWorkspaceId },
+        select: { id: true },
+      });
       expect(prisma.response.update).not.toHaveBeenCalled();
     });
 
@@ -540,6 +546,28 @@ describe("Response Lib", () => {
           type: "not_found",
           details: [{ field: "displayId", issue: "not found" }],
         });
+      }
+      expect(prisma.response.update).not.toHaveBeenCalled();
+    });
+
+    // ENG-1923: the anti-enumeration property itself. A display that exists but belongs to another
+    // tenant and one that does not exist at all must be reported identically, or the endpoint
+    // becomes a cross-tenant existence oracle. Asserting each rejection separately would not catch
+    // a later change that made one of them more specific.
+    test("reports a foreign and a nonexistent displayId identically (ENG-1923)", async () => {
+      vi.mocked(getDisplayForResponseValidation).mockResolvedValue({
+        ...validDisplay,
+        workspaceId: "another-workspace",
+      });
+      const foreign = await updateResponse(responseId, responseInput);
+
+      vi.mocked(getDisplayForResponseValidation).mockResolvedValue(null);
+      const missing = await updateResponse(responseId, responseInput);
+
+      expect(foreign.ok).toBe(false);
+      expect(missing.ok).toBe(false);
+      if (!foreign.ok && !missing.ok) {
+        expect(missing.error).toEqual(foreign.error);
       }
       expect(prisma.response.update).not.toHaveBeenCalled();
     });

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
@@ -462,6 +462,23 @@ describe("Response Lib", () => {
       }
     });
 
+    // ENG-1923 perf: when the update sets no contact/display link (both null) there is no FK to
+    // validate, so the tenant lookup is skipped entirely — a missing response is still surfaced as
+    // a 404 by the update's Prisma handler. Guards against reintroducing an unconditional
+    // round-trip when neither link is being (re)assigned.
+    test("skips the tenant lookup when neither contactId nor displayId is set", async () => {
+      const inputWithoutLinks = { ...responseInput, contactId: null, displayId: null };
+      vi.mocked(prisma.response.update).mockResolvedValue(response);
+
+      const result = await updateResponse(responseId, inputWithoutLinks);
+
+      expect(result.ok).toBe(true);
+      expect(prisma.response.findUnique).not.toHaveBeenCalled();
+      expect(prisma.contact.findUnique).not.toHaveBeenCalled();
+      expect(getDisplayForResponseValidation).not.toHaveBeenCalled();
+      expect(prisma.response.update).toHaveBeenCalledTimes(1);
+    });
+
     test("return an error when prisma.response.update throws", async () => {
       vi.mocked(prisma.response.update).mockRejectedValue(new Error("Update failed"));
       const result = await updateResponse(responseId, responseInput);

--- a/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
+++ b/apps/web/modules/api/v2/management/responses/[responseId]/lib/tests/response.test.ts
@@ -5,6 +5,7 @@ import { Prisma } from "@formbricks/database/prisma";
 import { PrismaErrorType } from "@formbricks/database/types/error";
 import { ok, okVoid } from "@formbricks/types/error-handlers";
 import { TSurveyQuota } from "@formbricks/types/quota";
+import { getDisplayForResponseValidation } from "@/lib/display/service";
 import { evaluateResponseQuotas } from "@/modules/ee/quotas/lib/evaluation-service";
 import { deleteDisplay } from "../display";
 import {
@@ -34,6 +35,20 @@ const mockQuota: TSurveyQuota = {
   countPartialSubmissions: false,
 };
 
+// ENG-1923 fixtures: the response's own tenant + a display that legitimately belongs to it.
+const responseWorkspaceId = "ws_mock_workspace_id";
+const existingResponseRow = {
+  surveyId: responseInput.surveyId,
+  contactId: responseInput.contactId,
+  survey: { workspaceId: responseWorkspaceId },
+};
+const validDisplay = {
+  surveyId: responseInput.surveyId,
+  workspaceId: responseWorkspaceId,
+  responseId, // linked to this response (self) → allowed on update
+  contactId: responseInput.contactId,
+};
+
 vi.mock("../display", () => ({
   deleteDisplay: vi.fn(),
 }));
@@ -50,12 +65,19 @@ vi.mock("@/modules/ee/quotas/lib/evaluation-service", () => ({
   evaluateResponseQuotas: vi.fn(),
 }));
 
+vi.mock("@/lib/display/service", () => ({
+  getDisplayForResponseValidation: vi.fn(),
+}));
+
 vi.mock("@formbricks/database", () => ({
   prisma: {
     response: {
       findUnique: vi.fn(),
       delete: vi.fn(),
       update: vi.fn(),
+    },
+    contact: {
+      findUnique: vi.fn(),
     },
     display: {
       delete: vi.fn(),
@@ -379,6 +401,15 @@ describe("Response Lib", () => {
   });
 
   describe("updateResponse", () => {
+    // ENG-1923: updateResponse now validates the caller-supplied contactId/displayId against the
+    // response's own tenant before writing. Default these lookups to the happy path; reject tests
+    // override them.
+    beforeEach(() => {
+      vi.mocked(prisma.response.findUnique).mockResolvedValue(existingResponseRow as any);
+      vi.mocked(prisma.contact.findUnique).mockResolvedValue({ id: responseInput.contactId } as any);
+      vi.mocked(getDisplayForResponseValidation).mockResolvedValue(validDisplay);
+    });
+
     test("update the response and revalidate caches including singleUseId", async () => {
       vi.mocked(prisma.response.update).mockResolvedValue(response);
 
@@ -442,12 +473,84 @@ describe("Response Lib", () => {
         });
       }
     });
+
+    // ENG-1923: a caller authorized on this response must not re-point it at another tenant's
+    // contact or display. Foreign and nonexistent ids fail identically as a 404 — no oracle.
+    test("rejects a contactId that does not belong to the response's workspace (ENG-1923)", async () => {
+      vi.mocked(prisma.contact.findUnique).mockResolvedValue(null);
+
+      const result = await updateResponse(responseId, responseInput);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toEqual({
+          type: "not_found",
+          details: [{ field: "contactId", issue: "not found" }],
+        });
+      }
+      expect(prisma.response.update).not.toHaveBeenCalled();
+    });
+
+    test("rejects a displayId from another workspace (ENG-1923)", async () => {
+      vi.mocked(getDisplayForResponseValidation).mockResolvedValue({
+        ...validDisplay,
+        workspaceId: "another-workspace",
+      });
+
+      const result = await updateResponse(responseId, responseInput);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toEqual({
+          type: "not_found",
+          details: [{ field: "displayId", issue: "not found" }],
+        });
+      }
+      expect(prisma.response.update).not.toHaveBeenCalled();
+    });
+
+    test("rejects a displayId already linked to a different response (ENG-1923)", async () => {
+      vi.mocked(getDisplayForResponseValidation).mockResolvedValue({
+        ...validDisplay,
+        responseId: "some-other-response",
+      });
+
+      const result = await updateResponse(responseId, responseInput);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toEqual({
+          type: "not_found",
+          details: [{ field: "displayId", issue: "not found" }],
+        });
+      }
+      expect(prisma.response.update).not.toHaveBeenCalled();
+    });
+
+    test("returns not_found when the response does not exist (ENG-1923)", async () => {
+      vi.mocked(prisma.response.findUnique).mockResolvedValue(null);
+
+      const result = await updateResponse(responseId, responseInput);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toEqual({
+          type: "not_found",
+          details: [{ field: "response", issue: "not found" }],
+        });
+      }
+      expect(prisma.response.update).not.toHaveBeenCalled();
+    });
   });
 
   describe("updateResponseWithQuotaEvaluation", () => {
     type MockTx = {
       response: {
+        findUnique: ReturnType<typeof vi.fn>;
         update: ReturnType<typeof vi.fn>;
+      };
+      contact: {
+        findUnique: ReturnType<typeof vi.fn>;
       };
     };
     let mockTx: MockTx;
@@ -457,9 +560,15 @@ describe("Response Lib", () => {
 
       mockTx = {
         response: {
+          // ENG-1923: updateResponse loads the response's tenant + validates links before writing.
+          findUnique: vi.fn().mockResolvedValue(existingResponseRow),
           update: vi.fn(),
         },
+        contact: {
+          findUnique: vi.fn().mockResolvedValue({ id: responseInput.contactId }),
+        },
       };
+      vi.mocked(getDisplayForResponseValidation).mockResolvedValue(validDisplay);
 
       prisma.$transaction = vi.fn(async (cb: any) => cb(mockTx));
     });

--- a/apps/web/modules/workspaces/settings/lib/workspace.test.ts
+++ b/apps/web/modules/workspaces/settings/lib/workspace.test.ts
@@ -31,6 +31,7 @@ const baseWorkspace: TWorkspace = {
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
+    $transaction: vi.fn(),
     workspace: {
       update: vi.fn(),
       create: vi.fn(),
@@ -84,6 +85,9 @@ vi.mock("@/modules/storage/service", () => ({
 describe("workspace lib", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // createWorkspace runs its ownership check and both writes in one transaction. Hand the callback
+    // the same prisma mock so assertions stay on `prisma.*` and a rollback surfaces as a throw.
+    vi.mocked(prisma.$transaction).mockImplementation(async (callback: any) => callback(prisma));
   });
 
   describe("updateWorkspace", () => {
@@ -172,6 +176,22 @@ describe("workspace lib", () => {
       // ...and the workspace and the join rows must never be written.
       expect(prisma.workspace.create).not.toHaveBeenCalled();
       expect(prisma.workspaceTeam.createMany).not.toHaveBeenCalled();
+      // The rejection is logged for security observability, naming only tenant ids (no PII).
+      expect(logger.warn).toHaveBeenCalledWith(
+        { organizationId: "org1", foreignTeamIds: ["foreign-team"] },
+        expect.stringContaining("Rejected cross-organization team assignment")
+      );
+    });
+
+    // ENG-1922: the rejection log must not fire when every team is in the caller's organization.
+    test("does not log a cross-organization warning on the happy path", async () => {
+      vi.mocked(prisma.team.findMany).mockResolvedValueOnce(mockOrgTeams("t1"));
+      vi.mocked(prisma.workspace.create).mockResolvedValueOnce({ ...baseWorkspace, id: "p3" } as any);
+      vi.mocked(prisma.workspaceTeam.createMany).mockResolvedValueOnce({} as any);
+
+      await createWorkspace("org1", { name: "Workspace 1", teamIds: ["t1"] });
+
+      expect(logger.warn).not.toHaveBeenCalled();
     });
 
     // ENG-1922: a mix of own-org and foreign teamIds must be rejected wholesale (count mismatch),

--- a/apps/web/modules/workspaces/settings/lib/workspace.test.ts
+++ b/apps/web/modules/workspaces/settings/lib/workspace.test.ts
@@ -53,6 +53,12 @@ vi.mock("@formbricks/database", () => ({
   },
 }));
 
+// ENG-1922: createWorkspace's org-scope guard queries team.findMany({ select: { id: true } }).
+// Model exactly that projection for the mock — a single localized assertion instead of scattered
+// `any` casts, so the fixture can't silently drift from the query's shape.
+const mockOrgTeams = (...ids: string[]) =>
+  ids.map((id) => ({ id })) as unknown as Awaited<ReturnType<typeof prisma.team.findMany>>;
+
 const expectNoFrdSideEffects = () => {
   expect(prisma.feedbackDirectory.upsert).not.toHaveBeenCalled();
   expect(prisma.feedbackDirectory.findFirst).not.toHaveBeenCalled();
@@ -134,7 +140,7 @@ describe("workspace lib", () => {
   describe("createWorkspace", () => {
     test("creates workspace with team links and no FRD side-effects", async () => {
       const createdWorkspace = { ...baseWorkspace, id: "p2" };
-      vi.mocked(prisma.team.findMany).mockResolvedValueOnce([{ id: "t1" }] as any);
+      vi.mocked(prisma.team.findMany).mockResolvedValueOnce(mockOrgTeams("t1"));
       vi.mocked(prisma.workspace.create).mockResolvedValueOnce(createdWorkspace as any);
       vi.mocked(prisma.workspaceTeam.createMany).mockResolvedValueOnce({} as any);
 
@@ -153,7 +159,7 @@ describe("workspace lib", () => {
     // ENG-1922: a caller must not link a team from another organization to their workspace.
     test("rejects teamIds that belong to another organization", async () => {
       // Foreign team: the org-scoped lookup returns nothing.
-      vi.mocked(prisma.team.findMany).mockResolvedValueOnce([]);
+      vi.mocked(prisma.team.findMany).mockResolvedValueOnce(mockOrgTeams());
 
       await expect(
         createWorkspace("org1", { name: "Workspace 1", teamIds: ["foreign-team"] })
@@ -172,7 +178,7 @@ describe("workspace lib", () => {
     // not partially linked.
     test("rejects when only some teamIds belong to the organization", async () => {
       // Only t1 is in the org; the org-scoped lookup omits the foreign id.
-      vi.mocked(prisma.team.findMany).mockResolvedValueOnce([{ id: "t1" }] as any);
+      vi.mocked(prisma.team.findMany).mockResolvedValueOnce(mockOrgTeams("t1"));
 
       await expect(
         createWorkspace("org1", { name: "Workspace 1", teamIds: ["t1", "foreign-team"] })

--- a/apps/web/modules/workspaces/settings/lib/workspace.test.ts
+++ b/apps/web/modules/workspaces/settings/lib/workspace.test.ts
@@ -39,6 +39,9 @@ vi.mock("@formbricks/database", () => ({
     workspaceTeam: {
       createMany: vi.fn(),
     },
+    team: {
+      findMany: vi.fn(),
+    },
     feedbackDirectory: {
       upsert: vi.fn(),
       findFirst: vi.fn(),
@@ -60,6 +63,7 @@ const expectNoFrdSideEffects = () => {
 vi.mock("@formbricks/logger", () => ({
   logger: {
     error: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
@@ -130,15 +134,66 @@ describe("workspace lib", () => {
   describe("createWorkspace", () => {
     test("creates workspace with team links and no FRD side-effects", async () => {
       const createdWorkspace = { ...baseWorkspace, id: "p2" };
+      vi.mocked(prisma.team.findMany).mockResolvedValueOnce([{ id: "t1" }] as any);
       vi.mocked(prisma.workspace.create).mockResolvedValueOnce(createdWorkspace as any);
       vi.mocked(prisma.workspaceTeam.createMany).mockResolvedValueOnce({} as any);
 
       const result = await createWorkspace("org1", { name: "Workspace 1", teamIds: ["t1"] });
 
       expect(result).toEqual(createdWorkspace);
+      // ENG-1922: teamIds must be validated against the target org before linking.
+      expect(prisma.team.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: { in: ["t1"] }, organizationId: "org1" } })
+      );
       expect(prisma.workspace.create).toHaveBeenCalled();
       expect(prisma.workspaceTeam.createMany).toHaveBeenCalled();
       expectNoFrdSideEffects();
+    });
+
+    // ENG-1922: a caller must not link a team from another organization to their workspace.
+    test("rejects teamIds that belong to another organization", async () => {
+      // Foreign team: the org-scoped lookup returns nothing.
+      vi.mocked(prisma.team.findMany).mockResolvedValueOnce([]);
+
+      await expect(
+        createWorkspace("org1", { name: "Workspace 1", teamIds: ["foreign-team"] })
+      ).rejects.toThrow(ValidationError);
+
+      // The membership check must run org-scoped...
+      expect(prisma.team.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: { in: ["foreign-team"] }, organizationId: "org1" } })
+      );
+      // ...and the workspace and the join rows must never be written.
+      expect(prisma.workspace.create).not.toHaveBeenCalled();
+      expect(prisma.workspaceTeam.createMany).not.toHaveBeenCalled();
+    });
+
+    // ENG-1922: a mix of own-org and foreign teamIds must be rejected wholesale (count mismatch),
+    // not partially linked.
+    test("rejects when only some teamIds belong to the organization", async () => {
+      // Only t1 is in the org; the org-scoped lookup omits the foreign id.
+      vi.mocked(prisma.team.findMany).mockResolvedValueOnce([{ id: "t1" }] as any);
+
+      await expect(
+        createWorkspace("org1", { name: "Workspace 1", teamIds: ["t1", "foreign-team"] })
+      ).rejects.toThrow(ValidationError);
+
+      expect(prisma.team.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: { in: ["t1", "foreign-team"] }, organizationId: "org1" } })
+      );
+      expect(prisma.workspace.create).not.toHaveBeenCalled();
+      expect(prisma.workspaceTeam.createMany).not.toHaveBeenCalled();
+    });
+
+    test("rejects duplicate teamIds", async () => {
+      await expect(createWorkspace("org1", { name: "Workspace 1", teamIds: ["t1", "t1"] })).rejects.toThrow(
+        ValidationError
+      );
+
+      // Rejected before any lookup or write.
+      expect(prisma.team.findMany).not.toHaveBeenCalled();
+      expect(prisma.workspace.create).not.toHaveBeenCalled();
+      expect(prisma.workspaceTeam.createMany).not.toHaveBeenCalled();
     });
 
     test("seeds English as the default survey language when creating a workspace", async () => {

--- a/apps/web/modules/workspaces/settings/lib/workspace.ts
+++ b/apps/web/modules/workspaces/settings/lib/workspace.ts
@@ -111,65 +111,73 @@ export const createWorkspace = async (
   }
 
   const { teamIds, ...data } = workspaceInput;
+  // Captured out here so the guard above still narrows it: inside the transaction callback below,
+  // TypeScript widens workspaceInput.name back to `string | undefined`.
+  const name = workspaceInput.name;
 
   try {
-    // ENG-1922: teamIds are caller-supplied. Validate that every team belongs to this
-    // organization before linking it — otherwise a caller could attach another org's team
-    // to their workspace (a cross-tenant WorkspaceTeam write). The FK only enforces that the
-    // team exists, not that it belongs here, so this must be checked at the app layer. A
-    // foreign-but-real id and a nonexistent id fail identically, so this is not an
-    // existence oracle for other orgs' teams.
-    if (teamIds && teamIds.length > 0) {
-      const uniqueTeamIds = new Set(teamIds);
-      if (uniqueTeamIds.size !== teamIds.length) {
-        throw new ValidationError("teamIds must be unique");
+    // The ownership check and both writes share one transaction: it keeps the check and the link
+    // atomic (a team cannot leave the organization in between), and stops a failed createMany from
+    // leaving an orphan workspace with no team links.
+    return await prisma.$transaction(async (tx) => {
+      // ENG-1922: teamIds are caller-supplied. Validate that every team belongs to this
+      // organization before linking it — otherwise a caller could attach another org's team
+      // to their workspace (a cross-tenant WorkspaceTeam write). The FK only enforces that the
+      // team exists, not that it belongs here, so this must be checked at the app layer. A
+      // foreign-but-real id and a nonexistent id fail identically, so this is not an
+      // existence oracle for other orgs' teams.
+      if (teamIds && teamIds.length > 0) {
+        const uniqueTeamIds = new Set(teamIds);
+        if (uniqueTeamIds.size !== teamIds.length) {
+          throw new ValidationError("teamIds must be unique");
+        }
+        const teams = await tx.team.findMany({
+          where: { id: { in: teamIds }, organizationId },
+          select: { id: true },
+        });
+        if (teams.length !== uniqueTeamIds.size) {
+          const foundTeamIds = new Set(teams.map((team) => team.id));
+          const foreignTeamIds = [...uniqueTeamIds].filter((teamId) => !foundTeamIds.has(teamId));
+          // ENG-1922: log the rejected cross-organization attempt for security observability.
+          // Only tenant identifiers (org id + the caller-supplied team ids) are logged — no PII.
+          logger.warn(
+            { organizationId, foreignTeamIds },
+            "Rejected cross-organization team assignment on workspace creation (ENG-1922)"
+          );
+          throw new ValidationError("teamIds must belong to the organization");
+        }
       }
-      const teams = await prisma.team.findMany({
-        where: { id: { in: teamIds }, organizationId },
-        select: { id: true },
-      });
-      if (teams.length !== uniqueTeamIds.size) {
-        const foundTeamIds = new Set(teams.map((team) => team.id));
-        const foreignTeamIds = [...uniqueTeamIds].filter((teamId) => !foundTeamIds.has(teamId));
-        // ENG-1922: log the rejected cross-organization attempt for security observability.
-        // Only tenant identifiers (org id + the caller-supplied team ids) are logged — no PII.
-        logger.warn(
-          { organizationId, foreignTeamIds },
-          "Rejected cross-organization team assignment on workspace creation (ENG-1922)"
-        );
-        throw new ValidationError("teamIds must belong to the organization");
-      }
-    }
 
-    const workspace = await prisma.workspace.create({
-      data: {
-        config: {
-          channel: null,
-          industry: null,
+      const workspace = await tx.workspace.create({
+        data: {
+          config: {
+            channel: null,
+            industry: null,
+          },
+          ...data,
+          name,
+          organizationId,
+          contactAttributeKeys: {
+            create: DEFAULT_CONTACT_ATTRIBUTE_KEYS,
+          },
+          languages: {
+            create: [DEFAULT_WORKSPACE_LANGUAGE],
+          },
         },
-        ...data,
-        name: workspaceInput.name,
-        organizationId,
-        contactAttributeKeys: {
-          create: DEFAULT_CONTACT_ATTRIBUTE_KEYS,
-        },
-        languages: {
-          create: [DEFAULT_WORKSPACE_LANGUAGE],
-        },
-      },
-      select: selectWorkspace,
+        select: selectWorkspace,
+      });
+
+      if (teamIds) {
+        await tx.workspaceTeam.createMany({
+          data: teamIds.map((teamId) => ({
+            workspaceId: workspace.id,
+            teamId,
+          })),
+        });
+      }
+
+      return workspace;
     });
-
-    if (teamIds) {
-      await prisma.workspaceTeam.createMany({
-        data: teamIds.map((teamId) => ({
-          workspaceId: workspace.id,
-          teamId,
-        })),
-      });
-    }
-
-    return workspace;
   } catch (error) {
     if (isUniqueConstraintError(error)) {
       throw new InvalidInputError("A workspace with this name already exists in your organization");

--- a/apps/web/modules/workspaces/settings/lib/workspace.ts
+++ b/apps/web/modules/workspaces/settings/lib/workspace.ts
@@ -113,6 +113,34 @@ export const createWorkspace = async (
   const { teamIds, ...data } = workspaceInput;
 
   try {
+    // ENG-1922: teamIds are caller-supplied. Validate that every team belongs to this
+    // organization before linking it — otherwise a caller could attach another org's team
+    // to their workspace (a cross-tenant WorkspaceTeam write). The FK only enforces that the
+    // team exists, not that it belongs here, so this must be checked at the app layer. A
+    // foreign-but-real id and a nonexistent id fail identically, so this is not an
+    // existence oracle for other orgs' teams.
+    if (teamIds && teamIds.length > 0) {
+      const uniqueTeamIds = new Set(teamIds);
+      if (uniqueTeamIds.size !== teamIds.length) {
+        throw new ValidationError("teamIds must be unique");
+      }
+      const teams = await prisma.team.findMany({
+        where: { id: { in: teamIds }, organizationId },
+        select: { id: true },
+      });
+      if (teams.length !== uniqueTeamIds.size) {
+        const foundTeamIds = new Set(teams.map((team) => team.id));
+        const foreignTeamIds = [...uniqueTeamIds].filter((teamId) => !foundTeamIds.has(teamId));
+        // ENG-1922: log the rejected cross-organization attempt for security observability.
+        // Only tenant identifiers (org id + the caller-supplied team ids) are logged — no PII.
+        logger.warn(
+          { organizationId, foreignTeamIds },
+          "Rejected cross-organization team assignment on workspace creation (ENG-1922)"
+        );
+        throw new ValidationError("teamIds must belong to the organization");
+      }
+    }
+
     const workspace = await prisma.workspace.create({
       data: {
         config: {


### PR DESCRIPTION
## What & why

Two related cross-tenant BOLAs (same "trust a nested id" class as ENG-1749). In both, a caller authorized on one object supplies a nested id belonging to another tenant, and the server links it without an ownership check.

- **ENG-1922 — `createWorkspace` teamIds.** `createWorkspaceAction` let a caller attach arbitrary `teamIds` to a new workspace, gated only by the access-control license — it never verified the teams belong to the caller's organization, so another org's team could be linked. Fixed at the `createWorkspace` lib sink: reject any `teamId` not in the target organization (and duplicate ids) before writing the `WorkspaceTeam` rows. Mirrors the existing `inviteUser` org-scope guard. The check and both writes now share one `$transaction`, so the check and the link are atomic and a failed `createMany` can't leave an orphan workspace. The duplicate-id check also fixes an unrelated bug in passing: `teamIds: ["t1","t1"]` used to create the workspace, fail `createMany` on the composite PK, and be mislabelled *"A workspace with this name already exists"*.
- **ENG-1923 — v2 response *update* `contactId` / `displayId`.** `updateResponse` mass-assigned a client-supplied `contactId` and `displayId` into `prisma.response.update` (`data: { ...responseInput }`) with no ownership check, so a caller authorized on a response could re-point it at another tenant's contact or display. Fixed at the `updateResponse` lib sink: load the response's own `survey → workspaceId` and reject a `contactId` not in that workspace, or a `displayId` not in the same survey / already linked to another response (the response's own current display is still allowed, so idempotent PUTs work). The checks live in small `validate*Scope` helpers.
  - Worth stating what the *previous* behaviour was, since it is worse than "unvalidated": a **foreign** id wrote successfully (the BOLA), while a **nonexistent** id hit a `P2003` that this function's catch didn't map — returning a **500 echoing the raw Prisma message**. Both are now a clean `404`.
  - The guard deliberately does **not** require the display's contact to match the response's. The display is already pinned to this response's workspace and survey, and a supplied `contactId` is separately scoped to the same workspace, so a contact rule adds no isolation — it would only reject legitimate same-tenant edits (see Risks). `assertDisplayOwnership` keeps that rule on the create path, where a fresh display has no prior owner.
  - Cost: the tenant lookup is skipped only when the update carries neither link. Because both fields are **required-nullable** in `ZResponseUpdateSchema`, that means a PUT sending both as `null`; a PUT that replays a stored response's contact/display pays two extra indexed point lookups. Threading the route's already-resolved `workspaceId`/`surveyId` down would make it free, but `getResponse` reads outside the transaction, so passing the values in is the safe version — left as a follow-up rather than trading atomicity for a query.

> **Scope split with #8681 (coordinated on that PR):** #8681 (now merged) owns the **create-response** `displayId` scoping; **#8669 owns the update path plus the contact side** (`contactId` + `displayId`, including the already-linked case). Neither PR alone makes "the responses API covered" — they are complementary, and the create-path guard was deliberately kept in exactly one place (#8681) to avoid two implementations drifting apart.

Both follow modern-REST + OWASP practice for multi-tenant isolation: validate every client-supplied foreign key server-side, **reject rather than silently strip**, and return a **uniform `404`** for foreign-vs-nonexistent so the endpoint is not a cross-tenant existence oracle (RFC 9110 §15.5.4; OWASP API1:2023 BOLA). No schema or API-shape changes; validation stays in the existing v2 `Result` convention.

## Linear ticket

- https://linear.app/formbricks/issue/ENG-1922/medium-cross-tenant-bola-createworkspaceaction-attaches-arbitrary
- https://linear.app/formbricks/issue/ENG-1923/medium-cross-tenant-bola-v2-responses-api-links-contactiddisplayid

## How this was tested

- `pnpm test` (vitest) on the touched suites ✅ — `workspaces/settings/lib/workspace.test.ts` + the v2 responses `[responseId]` module: **69 tests passing (7 files)**. Re-verified against `main` after the full 4/4 security stack (#8679–#8682) and the workflows epic landed: no overlap with any of my four files, and the dry-run merge is clean. Both sinks are still unguarded on `main`, so this PR is still required.
- New lib tests cover each guard (foreign / duplicate / self-link + happy paths), the no-link update path (asserts the tenant lookup is skipped), the **workspace scoping of the contact lookup itself**, and the **404 indistinguishability** of a foreign vs nonexistent `displayId` (anti-enumeration).
- **Mutation-verified** (each mutation fails only its own assertion): unscoping the contact lookup (dropping `workspaceId`) fails exactly the scoping assertion (1 failed / 28 passed); reinstating the display↔contact rule fails exactly the same-tenant regression test (1 failed / 29 passed); disabling each guard fails only its own reject test.
- **Smoke-tested against a real Postgres** (not mocks), since every unit test here mocks Prisma:
  - All four guard query shapes execute successfully against the live schema — including `contact.findUnique({ where: { id, workspaceId } })`, which relies on Prisma's extended-where-unique (confirmed valid on Prisma 7.8.0). A malformed guard query would have passed every mocked test and failed only in production.
  - Behavioural A/B on seeded data (two orgs): the victim's team/contact **is** found when scoped to its own tenant and **is not** found when scoped to the attacker's, and a foreign vs nonexistent contact are both `null` (identical 404). Re-run after the review round with real `survey`/`display`/`response` rows, confirming the relaxed display rule accepts a response's own display while its `contactId` is being cleared. **9/9 passed**; seeding ran in a transaction that always rolls back, verified to leave no rows.
- **Security scans clean**: `gitleaks` on the PR commit range — no leaks; `semgrep` (`p/typescript`, `p/owasp-top-ten`) on both changed source files — no findings.
- **Sibling sweep**: the other response-update sink (`apps/web/lib/response/service.ts`) is safe by construction — it writes an explicit field allowlist and its input type doesn't accept `contactId`/`displayId`. The v2 management spread was the outlier.
- `tsc --noEmit` clean on both changed source files. (It caught a real break in the review round: moving `createWorkspace` into a transaction lost the `name` narrowing inside the callback — fixed by capturing it before the closure. The two remaining errors in `workspace.test.ts` are pre-existing `baseWorkspace` typings on lines this PR doesn't touch, identical on `main`.) Lint is validated by the CI **Run Linters** job (the shared ESLint config isn't resolvable from the local worktree).
- No UI change (server-side API/lib only), so no screenshots.

## QA / Test Plan

**How to test**

- [ ] (ENG-1922) As an org **owner/manager**, create a workspace supplying a `teamId` from a **different** organization → the creation **fails with the error "teamIds must belong to the organization"** and the workspace is **not** created (verify it's absent from the workspace switcher). Note this is a *server action*, not a REST endpoint: the network tab shows a `200` POST whose payload carries `serverError` with that message — there is no HTTP `400`. Using your own org's team → succeeds.
- [ ] (ENG-1922) Supply duplicate `teamIds` → same failure shape, message "teamIds must be unique".
- [ ] (ENG-1923) `PUT /api/v2/management/responses/{id}` (management API key) with a `contactId` from another workspace → **`404`**, not persisted. With a `displayId` from another workspace/survey, or one already linked to a **different** response → **`404`**. Re-sending the response's own current `contactId`/`displayId` → succeeds.
- [ ] (ENG-1923) A **foreign** id and a **nonexistent** id return the *same* `404` — no signal that the id exists in another tenant.
- [ ] (ENG-1923, must still SUCCEED) On a response that has both a contact and a display, PUT `contactId: null` while keeping its own `displayId` → **`200`**, contact cleared, display retained. Then PUT a **different `contactId` from the same workspace**, keeping the same `displayId` → **`200`**. Neither may 404: the display still records the old contact, and that is fine.

**Preconditions / test data**

- Two organizations, **A** (attacker) and **B** (victim), and a management **API key** in A.
- In B: a team, a workspace, and a survey with a response + a display + a contact. The **teams** feature must be license-enabled for the workspace-team path (ENG-1922).

**Risks & regressions**

- Legitimate **same-tenant** links must still work: own team on workspace create; own contact/display on response update; idempotent re-send of a response's own `displayId`/`contactId`. Covered by happy-path tests.
- **Explicitly preserved** (was briefly broken by an earlier revision of this PR, caught in review): a PUT that **clears `contactId` while keeping the response's own `displayId`**, and one that moves the response to a **different contact in the same workspace**, must still succeed — even though the display still records the previous contact. Both are ordinary same-tenant edits. There is now a regression test for the first, mutation-checked so the rule can't come back unnoticed.
- No behaviour change for any request that doesn't carry a `contactId`/`displayId`, and none of the accepted-input surface changed (no schema edits).
- Scope is confined to these two sinks. The **create-response** path is owned by #8681 (see the scope-split note above); read/list responses, the client (widget) response APIs, and the team-side / API-v2 workspace-teams paths (already tenant-checked) are untouched.

**Migrations / env / cutover**

- none



