### PR TITLE
fix(workflows): keep list formatting in email bodies (ENG-2034)

### DIFF
--- a/apps/web/modules/email/lib/survey-response-email.test.ts
+++ b/apps/web/modules/email/lib/survey-response-email.test.ts
@@ -105,6 +105,16 @@ describe("buildSurveyResponseEmailHtml", () => {
     mockResolveStorageUrl.mockImplementation((url: string) => `https://cdn.example.com/${url}`);
   });
 
+  const sanitizedBodyOf = (html: string): Promise<string> => {
+    mockParseRecallInfo.mockReturnValue(html);
+    return buildSurveyResponseEmailHtml({
+      body: "irrelevant",
+      survey,
+      response,
+      attachResponseData: false,
+    }).then(() => mockRenderFollowUpEmail.mock.calls[0][0].body as string);
+  };
+
   test("sanitizes the recall-parsed body before rendering (drops disallowed markup)", async () => {
     mockParseRecallInfo.mockReturnValue('<p>Hi Jane</p><script>alert("x")</script><img src=x>');
 
@@ -124,6 +134,67 @@ describe("buildSurveyResponseEmailHtml", () => {
     expect(rendered.body).toBe("<p>Hi Jane</p>");
     expect(rendered.body).not.toContain("<script>");
     expect(rendered.body).not.toContain("<img");
+  });
+
+  // Lists used to be stripped while their items were kept, so "1. Banana / 2. Mango" arrived as
+  // "BananaMango" on a single line.
+  test("keeps ordered list structure and numbering", async () => {
+    const body = await sanitizedBodyOf(
+      '<p class="fb-editor-paragraph">What I eat in a day</p>' +
+        '<ol class="fb-editor-list-ol" start="2">' +
+        '<li value="2" class="fb-editor-listitem"><span>Banana</span></li>' +
+        '<li value="3" class="fb-editor-listitem"><span>Mango</span></li>' +
+        "</ol>"
+    );
+
+    expect(body).toBe(
+      '<p class="fb-editor-paragraph">What I eat in a day</p>' +
+        '<ol class="fb-editor-list-ol" start="2">' +
+        '<li value="2" class="fb-editor-listitem"><span>Banana</span></li>' +
+        '<li value="3" class="fb-editor-listitem"><span>Mango</span></li>' +
+        "</ol>"
+    );
+  });
+
+  test("keeps unordered and nested list structure", async () => {
+    const body = await sanitizedBodyOf("<ul><li>Fruit<ul><li>Banana</li></ul></li><li>Bread</li></ul>");
+
+    expect(body).toBe("<ul><li>Fruit<ul><li>Banana</li></ul></li><li>Bread</li></ul>");
+  });
+
+  test("keeps inline formatting and links inside list items", async () => {
+    const body = await sanitizedBodyOf(
+      "<ul><li><b><strong>bold</strong></b> <i><em>italic</em></i><br />" +
+        '<a href="https://formbricks.com">link</a></li></ul>'
+    );
+
+    expect(body).toBe(
+      "<ul><li><b><strong>bold</strong></b> <i><em>italic</em></i><br />" +
+        '<a href="https://formbricks.com">link</a></li></ul>'
+    );
+  });
+
+  test("keeps http(s) links but drops other schemes, inline styles and event handlers", async () => {
+    const body = await sanitizedBodyOf(
+      '<p style="color:red" onclick="steal()">' +
+        '<a href="https://formbricks.com" target="_blank" rel="noopener">ok</a>' +
+        '<a href="javascript:alert(1)">bad</a>' +
+        "</p>"
+    );
+
+    expect(body).toBe(
+      '<p><a href="https://formbricks.com" target="_blank" rel="noopener">ok</a><a>bad</a></p>'
+    );
+  });
+
+  test("still discards embedded, scripted and layout markup", async () => {
+    const body = await sanitizedBodyOf(
+      "<script>alert(1)</script><style>p{}</style><iframe src=x></iframe>" +
+        '<img src="x" onerror="alert(1)" /><table><tr><td>cell</td></tr></table>'
+    );
+
+    expect(body).not.toMatch(/<(script|style|iframe|img|table|tr|td)\b/);
+    expect(body).not.toContain("onerror");
   });
 
   test("omits response data / variables / hidden fields when attachResponseData is off", async () => {

--- a/apps/web/modules/email/lib/survey-response-email.ts
+++ b/apps/web/modules/email/lib/survey-response-email.ts
@@ -21,12 +21,19 @@ import { resolveStorageUrl } from "@/modules/storage/utils";
  * Sanitize a recall-templated body the same way the survey Follow-Ups email does. Recall tags are
  * expanded against the response first, then only a narrow HTML allowlist survives — so
  * respondent-controlled recall values cannot inject markup or non-http(s) schemes.
+ *
+ * `ul`/`ol`/`li` are on the list because `sanitize-html` drops a disallowed tag but keeps its text:
+ * without them the Body editor's list buttons produced items run together on one line, unnumbered.
  */
 const sanitizeBody = (body: string, response: TResponse): string =>
   sanitizeHtml(parseRecallInfo(body, response.data, response.variables), {
-    allowedTags: ["p", "span", "b", "strong", "i", "em", "a", "br"],
+    allowedTags: ["p", "span", "b", "strong", "i", "em", "a", "br", "ul", "ol", "li"],
     allowedAttributes: {
       a: ["href", "rel", "target"],
+      // Lexical numbers list items explicitly; keep both so an `<ol>` that starts at something other
+      // than 1 keeps its numbering instead of restarting.
+      ol: ["start"],
+      li: ["value"],
       "*": ["dir", "class"],
     },
     allowedSchemes: ["http", "https"],


### PR DESCRIPTION
## What does this PR do?

A list added in the **Body** editor of the Workflows **Send email** action was lost in the received email: the ticket's `1. Banana / 2. Mango / 3. Apple` arrived as `BananaMangoApple` — no numbers, no bullets, no line breaks.

**Root cause.** Both the workflow `send_email` action and survey **Follow-Ups** render through the shared `sanitizeBody` in `apps/web/modules/email/lib/survey-response-email.ts`, whose allowlist had no list tags:

```ts
allowedTags: ["p", "span", "b", "strong", "i", "em", "a", "br"],
```

`sanitize-html` discards a disallowed tag but **keeps its text content**, so `<ol>`/`<li>` vanished while the items collapsed into one unseparated run. The Body toolbar offers ordered + unordered list buttons, so the editor let authors create markup the email could not render.

**Fix.** Add `ul`, `ol`, `li` to the allowlist, plus `ol[start]` and `li[value]` to `allowedAttributes` — Lexical numbers list items explicitly, and without `start` an `<ol>` continued from a number other than 1 restarts at 1.

That's the whole change: 3 substantive lines.

```diff
-    allowedTags: ["p", "span", "b", "strong", "i", "em", "a", "br"],
+    allowedTags: ["p", "span", "b", "strong", "i", "em", "a", "br", "ul", "ol", "li"],
     allowedAttributes: {
       a: ["href", "rel", "target"],
+      ol: ["start"],
+      li: ["value"],
       "*": ["dir", "class"],
     },
```

Actual sanitizer output for the ticket's repro:

```
BEFORE
<p …>This is what I eat in a day</p><span>Banana</span><span>Mango</span><span>Apple</span>

AFTER
<p …>This is what I eat in a day</p><ol class="fb-editor-list-ol"><li value="1" …><span>Banana</span></li><li value="2" …><span>Mango</span></li><li value="3" …><span>Apple</span></li></ol>
```

Per the ticket's note, the sanitize path is shared, so this fixes **both** the workflow Send email action and survey Follow-Ups in one place (`survey-response-email.ts` is the repo's only `sanitizeHtml` call).

**Security posture is unchanged.** `ul`/`ol`/`li` are inert layout tags with no scripting or resource-loading capability, and `start`/`value` are numeric list attributes scoped to those tags. Still discarded: `script`, `style`, `iframe`, `img`, `table`/`tr`/`td`, inline `style` attributes, `on*` event handlers, and non-`http(s)` schemes on `a`. Recall values are still expanded *before* sanitizing, so respondent-controlled text remains bounded by the same allowlist.

No new user-facing strings, no schema/migration/env changes.

### Deliberately not in this PR

The ticket also asked to confirm the toolbar's wider formatting set is covered. It isn't, and I left it that way to keep this fix scoped to the reported bug:

- **Underline** is a visible toolbar button in both Body editors, but `u` is not allowlisted, so underlining is silently dropped the same way lists were. Same bug class, no report yet — happy to fold in or file separately, your call.
- **Headings, quote, inline code, strike, highlight** are reachable only by typing markdown (`# `, `> `, `` ` ``, `~~`, `==`); the heading dropdown is hidden at both call sites via `excludedToolbarItems={["blockType"]}`. Those shortcuts are only live because the `Editor`'s `disableLists` transformer filter is index-based and stale against `@lexical/markdown` 0.41 — a separate bug I'd rather fix at the source than accommodate in the sanitizer.

Closes ENG-2034
https://linear.app/formbricks/issue/ENG-2034

## How should this be tested?

Automated (`apps/web/modules/email/lib/survey-response-email.test.ts`):

- ordered list keeps `ol`, `li`, `start` and `value` (the ticket's regression)
- unordered **and nested** list structure survives
- bold / italic / `<br>` / links still survive *inside* list items
- `https://` links survive; `javascript:` href, inline `style` and `onclick` are stripped
- `script`, `style`, `iframe`, `img`, `table`/`tr`/`td` are still discarded

Also verified the markup survives the real email render (not just the sanitizer): rendering `renderFollowUpEmail` with a list body emits the `<ol><li value="1">…</li></ol>` intact inside the branded template — `dangerouslySetInnerHTML` content is untouched by react-email's Tailwind pass.

Commands run:

```bash
pnpm --filter @formbricks/web exec vitest run modules/email modules/survey/follow-ups modules/ee/workflows/lib/runner
```

→ `Test Files 14 passed (14) · Tests 138 passed (138)`, `tsc --noEmit` and `eslint` clean on the changed files.

Manual:

1. Survey → **Workflows** → add a **Send email** action, set To/Subject.
2. In **Body**, type a line of text, then use the **numbered list** button for three items; add a bulleted list too.
3. Save, enable the workflow, submit a response.
4. The received email shows `1. / 2. / 3.` and bullets on separate lines.
5. Repeat via survey **Follow-Ups** (same shared path) to confirm parity.

## QA / Test Plan

- **Workflows → Send email, ordered list**: Body with `Text` + numbered list of 3 items → received email renders `1.`/`2.`/`3.` on separate lines. Previously the items ran together with no numbers.
- **Workflows → Send email, unordered + nested list**: bulleted list, one item nested → bullets render on separate lines with the nested item indented.
- **Workflows → Send email, formatting inside a list**: bold/italic text and a link inside a list item → all render, inside the list item.
- **Survey Follow-Ups, same three cases**: identical rendering, since both features share one sanitizer.
- **Recall in a list**: put a recall tag inside a list item → the recalled value renders inside the list item, and answer text containing markup is still escaped/stripped.
- **Existing bodies unchanged**: a plain-text / bold / italic / link body sent before this change renders identically.
- **Sanitizing still holds**: paste an image or table into Body and send → neither appears in the received email; no broken/embedded content.
- **Known gap (not a regression)**: underline in Body still does not survive to the email — pre-existing, see "Deliberately not in this PR".

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` — ran scoped `vitest` + `tsc --noEmit` + `eslint` instead; no build-affecting change (two files, no new deps)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from `epic/workflows-v1` onto my branch
- [x] My changes don't cause any responsiveness issues

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR — no UI change; the before/after sanitizer output is inlined above
- [ ] Updated the Formbricks Docs if changes were necessary — not necessary
