### PR TITLE
docs: document built-in survey interface languages

### DIFF
--- a/docs/surveys/general-features/multi-language-surveys.mdx
+++ b/docs/surveys/general-features/multi-language-surveys.mdx
@@ -76,22 +76,24 @@ Beyond the content you translate yourself, every survey ships with a set of buil
 - Offline, retry, and "sending responses" notices
 - Attribution and helper labels like "Powered by" and "Required"
 
-These built-in strings are currently provided in **19 languages**:
+These built-in strings are currently provided in **23 languages**:
 
 | Language | Code | Language | Code |
 | --- | --- | --- | --- |
 | English (base) | `en-US` | Italian | `it-IT` |
 | Arabic | `ar-EG` | Japanese | `ja-JP` |
 | Chinese (Simplified) | `zh-Hans-CN` | Portuguese (Brazil) | `pt-BR` |
-| Danish | `da-DK` | Romanian | `ro-RO` |
-| Dutch | `nl-NL` | Russian | `ru-RU` |
-| Estonian | `et-EE` | Spanish | `es-ES` |
-| French | `fr-FR` | Swedish | `sv-SE` |
-| German | `de-DE` | Turkish | `tr-TR` |
+| Chinese (Traditional) | `zh-Hant-TW` | Romanian | `ro-RO` |
+| Danish | `da-DK` | Russian | `ru-RU` |
+| Dutch | `nl-NL` | Spanish | `es-ES` |
+| Estonian | `et-EE` | Swedish | `sv-SE` |
+| French | `fr-FR` | Turkish | `tr-TR` |
+| German | `de-DE` | Urdu | `ur-PK` |
 | Hindi | `hi-IN` | Uzbek | `uz-UZ` |
-| Hungarian | `hu-HU` | | |
+| Hungarian | `hu-HU` | Vietnamese | `vi-VN` |
+| Indonesian | `id-ID` | | |
 
-Formbricks matches the survey's active language to the closest available bundle — for example, `de-AT` and `de` both use the German bundle, and `pt-PT` uses `pt-BR`. If a language has no matching bundle, your translated survey content is still shown as usual, but these built-in interface strings fall back to English.
+Formbricks matches the survey's active language to the closest available bundle — for example, `de-AT` and `de` both use the German bundle, and `pt-PT` uses `pt-BR`. Writing script is preserved when matching, so `zh-Hant` and `zh-TW` resolve to the Traditional Chinese bundle rather than the Simplified one. If a language has no matching bundle, your translated survey content is still shown as usual, but these built-in interface strings fall back to English.
 
 <Note>
   Don't see your language? These interface translations live in the open-source `@formbricks/surveys` package. You can add a new one by contributing a locale file on [GitHub](https://github.com/formbricks/formbricks).

--- a/docs/surveys/general-features/multi-language-surveys.mdx
+++ b/docs/surveys/general-features/multi-language-surveys.mdx
@@ -64,6 +64,41 @@ How to deliver a specific language depends on the survey type (app or link surve
   </Step>
 </Steps>
 
+---
+
+## Built-in Interface Translations
+
+Beyond the content you translate yourself, every survey ships with a set of built-in interface strings that Formbricks localizes automatically — so respondents see them in their own language without any extra work from you. These include:
+
+- Default navigation and action buttons (**Back**, **Next**, **Finish**)
+- Form validation messages (e.g. "Please fill out this field", "Please enter a valid email address")
+- File-upload prompts and states
+- Offline, retry, and "sending responses" notices
+- Attribution and helper labels like "Powered by" and "Required"
+
+These built-in strings are currently provided in **19 languages**:
+
+| Language | Code | Language | Code |
+| --- | --- | --- | --- |
+| English (base) | `en-US` | Italian | `it-IT` |
+| Arabic | `ar-EG` | Japanese | `ja-JP` |
+| Chinese (Simplified) | `zh-Hans-CN` | Portuguese (Brazil) | `pt-BR` |
+| Danish | `da-DK` | Romanian | `ro-RO` |
+| Dutch | `nl-NL` | Russian | `ru-RU` |
+| Estonian | `et-EE` | Spanish | `es-ES` |
+| French | `fr-FR` | Swedish | `sv-SE` |
+| German | `de-DE` | Turkish | `tr-TR` |
+| Hindi | `hi-IN` | Uzbek | `uz-UZ` |
+| Hungarian | `hu-HU` | | |
+
+Formbricks matches the survey's active language to the closest available bundle — for example, `de-AT` and `de` both use the German bundle, and `pt-PT` uses `pt-BR`. If a language has no matching bundle, your translated survey content is still shown as usual, but these built-in interface strings fall back to English.
+
+<Note>
+  Don't see your language? These interface translations live in the open-source `@formbricks/surveys` package. You can add a new one by contributing a locale file on [GitHub](https://github.com/formbricks/formbricks).
+</Note>
+
+---
+
 ## App Surveys Configuration
 
 <Steps>


### PR DESCRIPTION
## What & why

The Multi-language Surveys guide only explained how a creator translates their own survey **content** (questions, options, labels). It never documented that the `@formbricks/surveys` runtime also ships **hard-coded interface strings** — navigation/action buttons, validation messages, file-upload/offline/retry text, and attribution labels — and localizes them automatically.

This adds a **"Built-in Interface Translations"** section to `docs/surveys/general-features/multi-language-surveys.mdx` that:

- Lists the **23 languages** these built-in strings are provided in (sourced from `packages/surveys/locales/` and `packages/surveys/src/lib/i18n.config.ts`), including the recent additions Indonesian (`id-ID`), Urdu (`ur-PK`), Vietnamese (`vi-VN`), and Chinese (Traditional) (`zh-Hant-TW`).
- Explains the closest-bundle matching (`de-AT`/`de` → `de-DE`, `pt-PT` → `pt-BR`) and that writing script is preserved (`zh-Hant`/`zh-TW` → `zh-Hant-TW`, not the Simplified bundle), with **English fallback** when no bundle matches — while the creator's translated content still renders.
- Points contributors to the open-source package for adding a new locale.

Docs-only change; no product code touched.

## Linear ticket

No ticket — small, self-contained docs improvement prompted by a question about which languages the surveys package bundles UI strings for.

## How this was tested

- Docs-only MDX edit; no code paths changed, so no automated tests apply.
- Rebased onto `main` and re-verified the language list against the source of truth: every code in the table matches 1:1 the files in `packages/surveys/locales/` and the `supportedLngs`/`resources` entries in `packages/surveys/src/lib/i18n.config.ts` (23 each, no extras or omissions on either side).
- Confirmed the fallback description against `resolveFallbackBundles()` in `i18n.config.ts` and its unit tests in `i18n.config.test.ts`, which assert `zh-Hant`/`zh-TW`/`zh-HK` → `zh-Hant-TW` and never fall back to `zh-Hans-CN`.

## QA / Test Plan

**How to test**

- [ ] Open the docs site and navigate to **Surveys → General Features → Multi-language Surveys** → the new **"Built-in Interface Translations"** section renders between "Creating a Multi-language Survey" and "App Surveys Configuration".
- [ ] The languages table renders with 23 languages and their codes — including Indonesian, Urdu, Vietnamese, and Chinese (Traditional) — and the `<Note>` callout displays with a working GitHub link.

**Preconditions / test data**

- None — public docs page, no auth or seed data required.

**Risks & regressions**

- None functional. Docs-only; worst case is a formatting/typo issue on the page. Re-check the table renders correctly in Mintlify.

**Migrations / env / cutover**

- none
