### PR TITLE
fix: count only finished responses for survey response limit

### DIFF
--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -3332,7 +3332,7 @@
         "respect_global_waiting_time": "Use Cooldown Period",
         "respect_global_waiting_time_description": "This survey follows the Cooldown Period set in the workspace’s configuration. It only shows if no other survey has appeared during that period.",
         "response_limit_can_t_be_set_to_0": "Response limit cannot be set to 0",
-        "response_limit_needs_to_exceed_number_of_received_responses": "Response limit needs to exceed the number of completed responses ({responseCount}).",
+        "response_limit_needs_to_exceed_number_of_received_responses": "Response limit needs to exceed number of received responses ({responseCount}).",
         "response_limits_redirections_and_more": "Response limits, redirections and more.",
         "response_options": "Response Options",
         "reverse_order_occasionally": "Reverse order occasionally",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -3332,7 +3332,7 @@
         "respect_global_waiting_time": "Use Cooldown Period",
         "respect_global_waiting_time_description": "This survey follows the Cooldown Period set in the workspace’s configuration. It only shows if no other survey has appeared during that period.",
         "response_limit_can_t_be_set_to_0": "Response limit cannot be set to 0",
-        "response_limit_needs_to_exceed_number_of_received_responses": "Response limit needs to exceed number of received responses ({responseCount}).",
+        "response_limit_needs_to_exceed_number_of_received_responses": "Response limit needs to exceed the number of completed responses ({responseCount}).",
         "response_limits_redirections_and_more": "Response limits, redirections and more.",
         "response_options": "Response Options",
         "reverse_order_occasionally": "Reverse order occasionally",

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
@@ -9,6 +9,7 @@ const {
   mockCreatePinnedDispatcher,
   mockDispatcherDestroy,
   mockGetIntegrations,
+  mockGetFinishedResponseCountBySurveyId,
   mockGetResponseCountBySurveyId,
   mockHandleIntegrations,
   mockLoggerError,
@@ -34,6 +35,7 @@ const {
     mockCreatePinnedDispatcher: vi.fn(() => ({ destroy: dispatcherDestroy })),
     mockDispatcherDestroy: dispatcherDestroy,
     mockGetIntegrations: vi.fn(),
+    mockGetFinishedResponseCountBySurveyId: vi.fn(),
     mockGetResponseCountBySurveyId: vi.fn(),
     mockHandleIntegrations: vi.fn(),
     mockLoggerError: vi.fn(),
@@ -103,6 +105,10 @@ vi.mock("@/lib/integration/service", () => ({
 
 vi.mock("@/lib/response/service", () => ({
   getResponseCountBySurveyId: mockGetResponseCountBySurveyId,
+}));
+
+vi.mock("@/modules/survey/lib/response", () => ({
+  getFinishedResponseCountBySurveyId: mockGetFinishedResponseCountBySurveyId,
 }));
 
 vi.mock("./posthog", () => ({
@@ -210,7 +216,8 @@ describe("processResponsePipelineJob", () => {
     mockGetIntegrations.mockResolvedValue([]);
     mockPrismaWebhookFindMany.mockResolvedValue([]);
     mockPrismaUserFindMany.mockResolvedValue([]);
-    mockGetResponseCountBySurveyId.mockResolvedValue(1);
+    mockGetResponseCountBySurveyId.mockResolvedValue(7);
+    mockGetFinishedResponseCountBySurveyId.mockResolvedValue(1);
     mockHandleIntegrations.mockResolvedValue(undefined);
     mockValidateAndResolveWebhookUrl.mockResolvedValue({ ip: "93.184.216.34", family: 4 });
     mockDispatcherDestroy.mockResolvedValue(undefined);
@@ -393,7 +400,9 @@ describe("processResponsePipelineJob", () => {
       "workspace_123",
       expect.objectContaining({ id: "survey_123" }),
       baseData.response,
-      1
+      // The notification email deliberately reports the *total* response count, not the
+      // completed-only count the response limit uses.
+      7
     );
     expect(mockPrismaSurveyUpdate).toHaveBeenCalledWith({
       data: {
@@ -417,10 +426,9 @@ describe("processResponsePipelineJob", () => {
   });
 
   test("only counts finished responses towards the auto-complete response limit", async () => {
-    // Total responses (starts) exceed the limit, but finished responses do not.
-    mockGetResponseCountBySurveyId.mockImplementation((_surveyId, filterCriteria) =>
-      Promise.resolve(filterCriteria?.finished ? 3 : 500)
-    );
+    // Total responses (starts) far exceed the limit, but finished responses do not.
+    mockGetResponseCountBySurveyId.mockResolvedValue(500);
+    mockGetFinishedResponseCountBySurveyId.mockResolvedValue(3);
     mockPrismaSurveyFindUnique.mockResolvedValue({
       ...survey,
       autoComplete: 5,
@@ -437,9 +445,92 @@ describe("processResponsePipelineJob", () => {
     ).resolves.toBeUndefined();
 
     // The auto-complete decision must be based on finished responses only.
-    expect(mockGetResponseCountBySurveyId).toHaveBeenCalledWith("survey_123", { finished: true });
+    expect(mockGetFinishedResponseCountBySurveyId).toHaveBeenCalledWith("survey_123");
     // 3 finished responses < limit of 5 → the survey must stay open.
     expect(mockPrismaSurveyUpdate).not.toHaveBeenCalled();
+  });
+
+  test("auto-completes the survey once finished responses reach the limit", async () => {
+    mockGetFinishedResponseCountBySurveyId.mockResolvedValue(5);
+    mockPrismaSurveyFindUnique.mockResolvedValue({
+      ...survey,
+      autoComplete: 5,
+    });
+
+    await expect(
+      processResponsePipelineJob(
+        {
+          ...baseData,
+          event: "responseFinished",
+        },
+        baseContext
+      )
+    ).resolves.toBeUndefined();
+
+    expect(mockPrismaSurveyUpdate).toHaveBeenCalledWith({
+      data: {
+        status: "completed",
+      },
+      where: {
+        id: "survey_123",
+      },
+    });
+  });
+
+  test("does not count finished responses when no response limit is set", async () => {
+    // The default survey fixture has autoComplete: null.
+    await expect(
+      processResponsePipelineJob(
+        {
+          ...baseData,
+          event: "responseFinished",
+        },
+        baseContext
+      )
+    ).resolves.toBeUndefined();
+
+    expect(mockGetFinishedResponseCountBySurveyId).not.toHaveBeenCalled();
+    expect(mockPrismaSurveyUpdate).not.toHaveBeenCalled();
+  });
+
+  test("does not re-close a survey that is already completed", async () => {
+    mockGetFinishedResponseCountBySurveyId.mockResolvedValue(50);
+    mockPrismaSurveyFindUnique.mockResolvedValue({
+      ...survey,
+      autoComplete: 5,
+      status: "completed",
+    });
+
+    await expect(
+      processResponsePipelineJob(
+        {
+          ...baseData,
+          event: "responseFinished",
+        },
+        baseContext
+      )
+    ).resolves.toBeUndefined();
+
+    expect(mockGetFinishedResponseCountBySurveyId).not.toHaveBeenCalled();
+    expect(mockPrismaSurveyUpdate).not.toHaveBeenCalled();
+    expect(mockQueueAuditEventWithoutRequest).not.toHaveBeenCalled();
+  });
+
+  test("does not count total responses when nobody subscribes to notifications", async () => {
+    // No user has response notifications enabled, so nothing consumes the total count.
+    await expect(
+      processResponsePipelineJob(
+        {
+          ...baseData,
+          event: "responseFinished",
+        },
+        baseContext
+      )
+    ).resolves.toBeUndefined();
+
+    expect(mockPrismaUserFindMany).toHaveBeenCalled();
+    expect(mockGetResponseCountBySurveyId).not.toHaveBeenCalled();
+    expect(mockSendResponseFinishedEmail).not.toHaveBeenCalled();
   });
 
   test("skips auto-complete when the finished response count cannot be loaded", async () => {
@@ -448,12 +539,7 @@ describe("processResponsePipelineJob", () => {
       ...survey,
       autoComplete: 1,
     });
-    mockGetResponseCountBySurveyId.mockImplementation((_surveyId, filterCriteria) => {
-      if (filterCriteria?.finished) {
-        return Promise.reject(countError);
-      }
-      return Promise.resolve(1);
-    });
+    mockGetFinishedResponseCountBySurveyId.mockRejectedValue(countError);
 
     await expect(
       processResponsePipelineJob(
@@ -692,6 +778,13 @@ describe("processResponsePipelineJob", () => {
         url: "https://example.com/webhook",
       },
     ]);
+    // The total count is only looked up when a notification recipient consumes it.
+    mockPrismaUserFindMany.mockResolvedValue([
+      {
+        email: "owner@example.com",
+        locale: "en",
+      },
+    ]);
     mockGetResponseCountBySurveyId.mockRejectedValue(responseCountError);
 
     await expect(
@@ -713,6 +806,7 @@ describe("processResponsePipelineJob", () => {
       }),
       "Response pipeline response count lookup failed"
     );
+    expect(mockSendResponseFinishedEmail).not.toHaveBeenCalled();
   });
 
   test("logs telemetry failures without failing the responseCreated job", async () => {

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.test.ts
@@ -416,6 +416,65 @@ describe("processResponsePipelineJob", () => {
     expect(mockSendTelemetryEvents).not.toHaveBeenCalled();
   });
 
+  test("only counts finished responses towards the auto-complete response limit", async () => {
+    // Total responses (starts) exceed the limit, but finished responses do not.
+    mockGetResponseCountBySurveyId.mockImplementation((_surveyId, filterCriteria) =>
+      Promise.resolve(filterCriteria?.finished ? 3 : 500)
+    );
+    mockPrismaSurveyFindUnique.mockResolvedValue({
+      ...survey,
+      autoComplete: 5,
+    });
+
+    await expect(
+      processResponsePipelineJob(
+        {
+          ...baseData,
+          event: "responseFinished",
+        },
+        baseContext
+      )
+    ).resolves.toBeUndefined();
+
+    // The auto-complete decision must be based on finished responses only.
+    expect(mockGetResponseCountBySurveyId).toHaveBeenCalledWith("survey_123", { finished: true });
+    // 3 finished responses < limit of 5 → the survey must stay open.
+    expect(mockPrismaSurveyUpdate).not.toHaveBeenCalled();
+  });
+
+  test("skips auto-complete when the finished response count cannot be loaded", async () => {
+    const countError = new Error("count offline");
+    mockPrismaSurveyFindUnique.mockResolvedValue({
+      ...survey,
+      autoComplete: 1,
+    });
+    mockGetResponseCountBySurveyId.mockImplementation((_surveyId, filterCriteria) => {
+      if (filterCriteria?.finished) {
+        return Promise.reject(countError);
+      }
+      return Promise.resolve(1);
+    });
+
+    await expect(
+      processResponsePipelineJob(
+        {
+          ...baseData,
+          event: "responseFinished",
+        },
+        baseContext
+      )
+    ).resolves.toBeUndefined();
+
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        autoCompleteThreshold: 1,
+        err: countError,
+      }),
+      "Response pipeline survey auto-complete skipped because the finished response count could not be loaded"
+    );
+    expect(mockPrismaSurveyUpdate).not.toHaveBeenCalled();
+  });
+
   test("logs responseFinished side-effect failures without failing the job", async () => {
     mockPrismaUserFindMany.mockResolvedValue([
       {

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
@@ -20,6 +20,7 @@ import { captureSurveyResponsePostHogEvent } from "@/modules/response-pipeline/l
 import { resolveStorageUrlsInObject } from "@/modules/storage/utils";
 import { sendFollowUpsForResponse } from "@/modules/survey/follow-ups/lib/follow-ups";
 import { FollowUpSendError } from "@/modules/survey/follow-ups/types/follow-up";
+import { getFinishedResponseCountBySurveyId } from "@/modules/survey/lib/response";
 import { handleIntegrations } from "./handle-integrations";
 import { sendTelemetryEvents } from "./telemetry";
 
@@ -322,47 +323,54 @@ const deliverWebhooks = async ({
   );
 };
 
-const loadResponseFinishedContext = async ({
-  data,
+const loadIntegrationsSafely = async ({
   logContext,
   workspaceId,
 }: {
-  data: TResponsePipelineJobData;
   logContext: ReturnType<typeof getPipelineLogContext>;
   workspaceId: string;
-}): Promise<{
-  integrations: Awaited<ReturnType<typeof getIntegrations>>;
-  responseCount: number | null;
-}> => {
-  const [integrationsResult, responseCountResult] = await Promise.allSettled([
-    getIntegrations(workspaceId),
-    getResponseCountBySurveyId(data.surveyId),
-  ]);
-
-  if (integrationsResult.status === "rejected") {
+}): Promise<Awaited<ReturnType<typeof getIntegrations>>> => {
+  try {
+    return await getIntegrations(workspaceId);
+  } catch (error) {
     logger.error(
       {
         ...logContext,
-        err: integrationsResult.reason,
+        err: error,
       },
       "Response pipeline integration lookup failed"
     );
-  }
 
-  if (responseCountResult.status === "rejected") {
+    return [];
+  }
+};
+
+/**
+ * Response counts are optional side inputs: a failed lookup must never fail the job, so it
+ * resolves to `null` and the consumer skips its own work instead.
+ */
+const loadResponseCountSafely = async ({
+  count,
+  failureMessage,
+  logContext,
+}: {
+  count: () => Promise<number>;
+  failureMessage: string;
+  logContext: Record<string, unknown>;
+}): Promise<number | null> => {
+  try {
+    return await count();
+  } catch (error) {
     logger.error(
       {
         ...logContext,
-        err: responseCountResult.reason,
+        err: error,
       },
-      "Response pipeline response count lookup failed"
+      failureMessage
     );
-  }
 
-  return {
-    integrations: integrationsResult.status === "fulfilled" ? integrationsResult.value : [],
-    responseCount: responseCountResult.status === "fulfilled" ? responseCountResult.value : null,
-  };
+    return null;
+  }
 };
 
 const getUsersWithNotifications = async ({
@@ -535,39 +543,37 @@ const sendNotificationEmailsSafely = async ({
   );
 };
 
+/**
+ * The completed-response count that closes this survey, or `null` when the response limit
+ * cannot apply — no limit configured, or the survey is already closed.
+ *
+ * The limit is defined in terms of *completed* responses, so only finished responses count
+ * towards it. Counting every response would close the survey once the number of starts
+ * (partial + finished) hit the limit.
+ */
+const getAutoCompleteThreshold = (survey: TPipelineSurvey): number | null =>
+  survey.autoComplete && survey.status !== "completed" ? survey.autoComplete : null;
+
 const handleSurveyAutoCompleteSafely = async ({
+  finishedResponseCount,
   logContext,
   organizationId,
   survey,
 }: {
+  finishedResponseCount: number | null;
   logContext: ReturnType<typeof getPipelineLogContext>;
   organizationId: string;
   survey: TPipelineSurvey;
 }): Promise<void> => {
-  if (!survey.autoComplete) {
+  const autoCompleteThreshold = getAutoCompleteThreshold(survey);
+
+  // `finishedResponseCount` is only looked up when a threshold applies, so a `null` here means
+  // the lookup failed — already logged by loadResponseCountSafely.
+  if (autoCompleteThreshold === null || finishedResponseCount === null) {
     return;
   }
 
-  // The response limit is defined in terms of completed responses, so only finished
-  // responses may count towards the auto-complete threshold. Counting all responses would
-  // close the survey once the number of starts (partial + finished) hits the limit.
-  let finishedResponseCount: number;
-  try {
-    finishedResponseCount = await getResponseCountBySurveyId(survey.id, { finished: true });
-  } catch (error) {
-    logger.error(
-      {
-        ...logContext,
-        autoCompleteThreshold: survey.autoComplete,
-        err: error,
-      },
-      "Response pipeline survey auto-complete skipped because the finished response count could not be loaded"
-    );
-
-    return;
-  }
-
-  if (finishedResponseCount < survey.autoComplete) {
+  if (finishedResponseCount < autoCompleteThreshold) {
     return;
   }
 
@@ -635,9 +641,8 @@ const runResponseFinishedSideEffects = async ({
   survey: TPipelineSurvey;
   workspaceId: string;
 }) => {
-  const [{ integrations, responseCount }, usersWithNotifications] = await Promise.all([
-    loadResponseFinishedContext({
-      data,
+  const [integrations, usersWithNotifications] = await Promise.all([
+    loadIntegrationsSafely({
       logContext,
       workspaceId,
     }),
@@ -647,6 +652,30 @@ const runResponseFinishedSideEffects = async ({
       workspaceId,
     }),
   ]);
+
+  // Neither count is consumed until the notification/auto-complete steps at the end, so start
+  // them here to overlap with the integration and follow-up work below. Each is skipped
+  // entirely when nothing would consume it, keeping this off the hot path for the common case.
+  const autoCompleteThreshold = getAutoCompleteThreshold(survey);
+
+  const responseCountPromise =
+    usersWithNotifications.length > 0
+      ? loadResponseCountSafely({
+          count: () => getResponseCountBySurveyId(data.surveyId),
+          failureMessage: "Response pipeline response count lookup failed",
+          logContext,
+        })
+      : Promise.resolve(null);
+
+  const finishedResponseCountPromise =
+    autoCompleteThreshold !== null
+      ? loadResponseCountSafely({
+          count: () => getFinishedResponseCountBySurveyId(survey.id),
+          failureMessage:
+            "Response pipeline survey auto-complete skipped because the finished response count could not be loaded",
+          logContext: { ...logContext, autoCompleteThreshold },
+        })
+      : Promise.resolve(null);
 
   if (integrations.length > 0) {
     try {
@@ -683,13 +712,14 @@ const runResponseFinishedSideEffects = async ({
   await sendNotificationEmailsSafely({
     data,
     logContext,
-    responseCount,
+    responseCount: await responseCountPromise,
     survey,
     usersWithNotifications,
     workspaceId,
   });
 
   await handleSurveyAutoCompleteSafely({
+    finishedResponseCount: await finishedResponseCountPromise,
     logContext,
     organizationId,
     survey,

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
@@ -538,29 +538,36 @@ const sendNotificationEmailsSafely = async ({
 const handleSurveyAutoCompleteSafely = async ({
   logContext,
   organizationId,
-  responseCount,
   survey,
 }: {
   logContext: ReturnType<typeof getPipelineLogContext>;
   organizationId: string;
-  responseCount: number | null;
   survey: TPipelineSurvey;
 }): Promise<void> => {
-  if (responseCount === null) {
-    if (survey.autoComplete) {
-      logger.error(
-        {
-          ...logContext,
-          autoCompleteThreshold: survey.autoComplete,
-        },
-        "Response pipeline survey auto-complete skipped because the response count could not be loaded"
-      );
-    }
+  if (!survey.autoComplete) {
+    return;
+  }
+
+  // The response limit is defined in terms of completed responses, so only finished
+  // responses may count towards the auto-complete threshold. Counting all responses would
+  // close the survey once the number of starts (partial + finished) hits the limit.
+  let finishedResponseCount: number;
+  try {
+    finishedResponseCount = await getResponseCountBySurveyId(survey.id, { finished: true });
+  } catch (error) {
+    logger.error(
+      {
+        ...logContext,
+        autoCompleteThreshold: survey.autoComplete,
+        err: error,
+      },
+      "Response pipeline survey auto-complete skipped because the finished response count could not be loaded"
+    );
 
     return;
   }
 
-  if (!survey.autoComplete || responseCount < survey.autoComplete) {
+  if (finishedResponseCount < survey.autoComplete) {
     return;
   }
 
@@ -685,7 +692,6 @@ const runResponseFinishedSideEffects = async ({
   await handleSurveyAutoCompleteSafely({
     logContext,
     organizationId,
-    responseCount,
     survey,
   });
 };

--- a/apps/web/modules/survey/editor/components/response-options-card.tsx
+++ b/apps/web/modules/survey/editor/components/response-options-card.tsx
@@ -26,7 +26,7 @@ import { Slider } from "@/modules/ui/components/slider";
 interface ResponseOptionsCardProps {
   localSurvey: TSurvey;
   setLocalSurvey: (survey: TSurvey | ((prev: TSurvey) => TSurvey)) => void;
-  responseCount: number;
+  finishedResponseCount: number;
   isSpamProtectionAllowed: boolean;
   surveySchedulingConfig: TSurveySchedulingConfig;
   locale: TUserLocale;
@@ -35,7 +35,7 @@ interface ResponseOptionsCardProps {
 export const ResponseOptionsCard = ({
   localSurvey,
   setLocalSurvey,
-  responseCount,
+  finishedResponseCount,
   isSpamProtectionAllowed,
   surveySchedulingConfig,
   locale,
@@ -245,7 +245,7 @@ export const ResponseOptionsCard = ({
       const updatedSurvey = { ...localSurvey, autoComplete: null };
       setLocalSurvey(updatedSurvey);
     } else {
-      const updatedSurvey = { ...localSurvey, autoComplete: Math.max(25, responseCount + 5) };
+      const updatedSurvey = { ...localSurvey, autoComplete: Math.max(25, finishedResponseCount + 5) };
       setLocalSurvey(updatedSurvey);
     }
   };
@@ -266,10 +266,10 @@ export const ResponseOptionsCard = ({
       return;
     }
 
-    if (Number.parseInt(e.target.value) <= responseCount) {
+    if (Number.parseInt(e.target.value) <= finishedResponseCount) {
       toast.error(
         t("workspace.surveys.edit.response_limit_needs_to_exceed_number_of_received_responses", {
-          responseCount,
+          responseCount: finishedResponseCount,
         }),
         {
           id: "response-limit-error",
@@ -423,7 +423,7 @@ export const ResponseOptionsCard = ({
                       <Input
                         autoFocus
                         type="number"
-                        min={responseCount ? (responseCount + 1).toString() : "1"}
+                        min={finishedResponseCount ? (finishedResponseCount + 1).toString() : "1"}
                         id="autoCompleteResponses"
                         value={localSurvey.autoComplete?.toString()}
                         onChange={handleInputResponse}

--- a/apps/web/modules/survey/editor/components/settings-view.tsx
+++ b/apps/web/modules/survey/editor/components/settings-view.tsx
@@ -23,6 +23,7 @@ interface SettingsViewProps {
   contactAttributeKeys: TContactAttributeKey[];
   segments: TSegment[];
   responseCount: number;
+  finishedResponseCount: number;
   membershipRole?: OrganizationRole;
   isUserTargetingAllowed?: boolean;
   isSpamProtectionAllowed: boolean;
@@ -43,6 +44,7 @@ export const SettingsView = ({
   contactAttributeKeys,
   segments,
   responseCount,
+  finishedResponseCount,
   membershipRole,
   isUserTargetingAllowed = false,
   isSpamProtectionAllowed,
@@ -109,7 +111,7 @@ export const SettingsView = ({
       <ResponseOptionsCard
         localSurvey={localSurvey}
         setLocalSurvey={setLocalSurvey}
-        responseCount={responseCount}
+        finishedResponseCount={finishedResponseCount}
         isSpamProtectionAllowed={isSpamProtectionAllowed}
         surveySchedulingConfig={surveySchedulingConfig}
         locale={locale}

--- a/apps/web/modules/survey/editor/components/survey-editor.tsx
+++ b/apps/web/modules/survey/editor/components/survey-editor.tsx
@@ -32,6 +32,7 @@ interface SurveyEditorProps {
   contactAttributeKeys: TContactAttributeKey[];
   segments: TSegment[];
   responseCount: number;
+  finishedResponseCount: number;
   membershipRole?: OrganizationRole;
   colors: string[];
   isUserTargetingAllowed?: boolean;
@@ -63,6 +64,7 @@ export const SurveyEditor = ({
   contactAttributeKeys,
   segments,
   responseCount,
+  finishedResponseCount,
   membershipRole,
   colors,
   isUserTargetingAllowed = false,
@@ -184,6 +186,7 @@ export const SurveyEditor = ({
         setInvalidElements={setInvalidElements}
         workspace={localWorkspace}
         responseCount={responseCount}
+        finishedResponseCount={finishedResponseCount}
         selectedLanguageCode={selectedLanguageCode}
         setSelectedLanguageCode={setSelectedLanguageCode}
         isCxMode={isCxMode}
@@ -259,6 +262,7 @@ export const SurveyEditor = ({
               contactAttributeKeys={contactAttributeKeys}
               segments={segments}
               responseCount={responseCount}
+              finishedResponseCount={finishedResponseCount}
               membershipRole={membershipRole}
               isUserTargetingAllowed={isUserTargetingAllowed}
               isSpamProtectionAllowed={isSpamProtectionAllowed}

--- a/apps/web/modules/survey/editor/components/survey-menu-bar.tsx
+++ b/apps/web/modules/survey/editor/components/survey-menu-bar.tsx
@@ -39,6 +39,7 @@ interface SurveyMenuBarProps {
   setInvalidElements: React.Dispatch<React.SetStateAction<string[] | null>>;
   workspace: Workspace;
   responseCount: number;
+  finishedResponseCount: number;
   selectedLanguageCode: string;
   setSelectedLanguageCode: (selectedLanguage: string) => void;
   isCxMode: boolean;
@@ -56,6 +57,7 @@ export const SurveyMenuBar = ({
   setInvalidElements,
   workspace,
   responseCount,
+  finishedResponseCount,
   selectedLanguageCode,
   isCxMode,
   locale,
@@ -408,7 +410,7 @@ export const SurveyMenuBar = ({
     }
 
     try {
-      const isSurveyValidResult = isSurveyValid(localSurvey, selectedLanguageCode, t, responseCount);
+      const isSurveyValidResult = isSurveyValid(localSurvey, selectedLanguageCode, t, finishedResponseCount);
       if (!isSurveyValidResult) {
         setIsSurveySaving(false);
         return false;
@@ -492,7 +494,7 @@ export const SurveyMenuBar = ({
     }
 
     try {
-      const isSurveyValidResult = isSurveyValid(localSurvey, selectedLanguageCode, t, responseCount);
+      const isSurveyValidResult = isSurveyValid(localSurvey, selectedLanguageCode, t, finishedResponseCount);
       if (!isSurveyValidResult) {
         isSurveyPublishingRef.current = false;
         setIsSurveyPublishing(false);
@@ -550,7 +552,7 @@ export const SurveyMenuBar = ({
     }
 
     try {
-      const isSurveyValidResult = isSurveyValid(localSurvey, selectedLanguageCode, t, responseCount);
+      const isSurveyValidResult = isSurveyValid(localSurvey, selectedLanguageCode, t, finishedResponseCount);
       if (!isSurveyValidResult) {
         isSurveyPublishingRef.current = false;
         setIsSurveyPublishing(false);

--- a/apps/web/modules/survey/editor/lib/validation.ts
+++ b/apps/web/modules/survey/editor/lib/validation.ts
@@ -262,7 +262,11 @@ export const isSurveyValid = (
   survey: TSurvey,
   selectedLanguageCode: string,
   t: TFunction,
-  responseCount?: number
+  /**
+   * Completed responses only — `survey.autoComplete` is a limit on completions, so partial
+   * starts must not count towards it.
+   */
+  finishedResponseCount?: number
 ) => {
   const questionWithEmptyFallback = checkForEmptyFallBackValue(survey, selectedLanguageCode);
   if (questionWithEmptyFallback) {
@@ -284,16 +288,16 @@ export const isSurveyValid = (
   }
 
   // Response limit validation
-  if (survey.autoComplete !== null && responseCount !== undefined) {
+  if (survey.autoComplete !== null && finishedResponseCount !== undefined) {
     if (survey.autoComplete === 0) {
       toast.error(t("workspace.surveys.edit.response_limit_can_t_be_set_to_0"));
       return false;
     }
 
-    if (survey.autoComplete <= responseCount) {
+    if (survey.autoComplete <= finishedResponseCount) {
       toast.error(
         t("workspace.surveys.edit.response_limit_needs_to_exceed_number_of_received_responses", {
-          responseCount,
+          responseCount: finishedResponseCount,
         }),
         {
           id: "response-limit-error",

--- a/apps/web/modules/survey/editor/page.tsx
+++ b/apps/web/modules/survey/editor/page.tsx
@@ -24,7 +24,10 @@ import { getWorkspaceLanguages } from "@/modules/survey/editor/lib/workspace";
 import { getSurveyFollowUpsPermission } from "@/modules/survey/follow-ups/lib/utils";
 import { getActionClasses } from "@/modules/survey/lib/action-class";
 import { getExternalUrlsPermission } from "@/modules/survey/lib/permission";
-import { getResponseCountBySurveyId } from "@/modules/survey/lib/response";
+import {
+  getFinishedResponseCountBySurveyId,
+  getResponseCountBySurveyId,
+} from "@/modules/survey/lib/response";
 import { getOrganizationBilling, getSurvey } from "@/modules/survey/lib/survey";
 import { getWorkspaceWithTeamIds } from "@/modules/survey/lib/workspace";
 import { SURVEY_SCHEDULING_CONFIG } from "@/modules/survey/scheduling/lib/constants";
@@ -53,15 +56,23 @@ export const SurveyEditorPage = async (props: {
 
   const t = await getTranslate();
 
-  const [survey, workspaceWithTeamIds, actionClasses, contactAttributeKeys, responseCount, segments] =
-    await Promise.all([
-      getSurvey(params.surveyId),
-      getWorkspaceWithTeamIds(params.workspaceId),
-      getActionClasses(workspace.id),
-      getContactAttributeKeys(workspace.id),
-      getResponseCountBySurveyId(params.surveyId),
-      getSegments(workspace.id),
-    ]);
+  const [
+    survey,
+    workspaceWithTeamIds,
+    actionClasses,
+    contactAttributeKeys,
+    responseCount,
+    finishedResponseCount,
+    segments,
+  ] = await Promise.all([
+    getSurvey(params.surveyId),
+    getWorkspaceWithTeamIds(params.workspaceId),
+    getActionClasses(workspace.id),
+    getContactAttributeKeys(workspace.id),
+    getResponseCountBySurveyId(params.surveyId),
+    getFinishedResponseCountBySurveyId(params.surveyId),
+    getSegments(workspace.id),
+  ]);
 
   if (!workspaceWithTeamIds) {
     throw new ResourceNotFoundError(t("common.workspace"), null);
@@ -119,6 +130,7 @@ export const SurveyEditorPage = async (props: {
       actionClasses={actionClasses}
       contactAttributeKeys={contactAttributeKeys}
       responseCount={responseCount}
+      finishedResponseCount={finishedResponseCount}
       membershipRole={currentUserMembership.role}
       workspacePermission={workspacePermission}
       colors={SURVEY_BG_COLORS}

--- a/apps/web/modules/survey/lib/response.test.ts
+++ b/apps/web/modules/survey/lib/response.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError } from "@formbricks/types/errors";
-import { getResponseCountBySurveyId } from "./response";
+import { getFinishedResponseCountBySurveyId, getResponseCountBySurveyId } from "./response";
 
 vi.mock("react", async () => {
   const actual = await vi.importActual("react");
@@ -60,5 +60,39 @@ describe("getResponseCountBySurveyId", () => {
     expect(prisma.response.count).toHaveBeenCalledWith({
       where: { surveyId },
     });
+  });
+});
+
+describe("getFinishedResponseCountBySurveyId", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("should count only finished responses, excluding partial starts", async () => {
+    vi.mocked(prisma.response.count).mockResolvedValue(3);
+
+    const result = await getFinishedResponseCountBySurveyId(surveyId);
+
+    expect(result).toBe(3);
+    expect(prisma.response.count).toHaveBeenCalledWith({
+      where: { surveyId, finished: true },
+    });
+  });
+
+  test("should throw DatabaseError if PrismaClientKnownRequestError occurs", async () => {
+    const prismaError = new Prisma.PrismaClientKnownRequestError("Test Prisma Error", {
+      code: "P2002",
+      clientVersion: "2.0.0",
+    });
+    vi.mocked(prisma.response.count).mockRejectedValue(prismaError);
+
+    await expect(getFinishedResponseCountBySurveyId(surveyId)).rejects.toThrow(DatabaseError);
+  });
+
+  test("should throw generic error if an unknown error occurs", async () => {
+    const genericError = new Error("Test Generic Error");
+    vi.mocked(prisma.response.count).mockRejectedValue(genericError);
+
+    await expect(getFinishedResponseCountBySurveyId(surveyId)).rejects.toThrow(genericError);
   });
 });

--- a/apps/web/modules/survey/lib/response.ts
+++ b/apps/web/modules/survey/lib/response.ts
@@ -3,14 +3,9 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError } from "@formbricks/types/errors";
 
-export const getResponseCountBySurveyId = reactCache(async (surveyId: string): Promise<number> => {
+const countResponses = async (where: Prisma.ResponseWhereInput): Promise<number> => {
   try {
-    const responseCount = await prisma.response.count({
-      where: {
-        surveyId,
-      },
-    });
-    return responseCount;
+    return await prisma.response.count({ where });
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       throw new DatabaseError(error.message);
@@ -18,4 +13,18 @@ export const getResponseCountBySurveyId = reactCache(async (surveyId: string): P
 
     throw error;
   }
-});
+};
+
+/** Counts every response row for the survey, including partial starts. */
+export const getResponseCountBySurveyId = reactCache(
+  async (surveyId: string): Promise<number> => countResponses({ surveyId })
+);
+
+/**
+ * Counts completed responses only. The response limit ("Close survey on response limit") is
+ * defined in terms of completed responses, so partial starts must never count towards it —
+ * anything comparing against `survey.autoComplete` has to use this count.
+ */
+export const getFinishedResponseCountBySurveyId = reactCache(
+  async (surveyId: string): Promise<number> => countResponses({ surveyId, finished: true })
+);


### PR DESCRIPTION
## What & why

A customer reported that a survey limited to 500 responses closed at **500 starts**, not 500 completed responses.

The "Close survey on response limit" setting is described in the UI as *"Automatically mark the survey as complete after N **completed** responses."* But the auto-complete check in the response pipeline compared the limit against `getResponseCountBySurveyId(surveyId)`, which counts **every** response row for the survey — including partial starts (`finished: false`). So the survey closed once *starts* (partial + finished) reached the limit, contradicting the label.

This fix makes the auto-complete threshold count **finished responses only**. The count now runs lazily — only when a limit is actually set — and the notification email's total-response count is deliberately left unchanged.

This is a long-standing bug (present in the pre-BullMQ pipeline too), not a recent regression.

### Follow-up fixes from review

Review turned up that the pipeline was only half the feature. Three further fixes:

**The survey editor validated the limit against total responses too.** `isSurveyValid` aborted the save when `survey.autoComplete <= responseCount`, where `responseCount` was the unfiltered count. Once the pipeline correctly keeps a survey open past its limit in starts, that state becomes normal — and the editor then refused **every** save and publish with *"response limit needs to exceed number of received responses (N)"* until the limit was raised above the start count. Fixed by adding `getFinishedResponseCountBySurveyId` and using it everywhere that compares against `survey.autoComplete`: the save/publish validation and the limit input's `min`, its default, and its on-blur warning.

The total count deliberately stays where *"has this survey been answered at all"* is the real question — the caution banner about editing a live survey, and the block-editing alert — since a partial start is still data recorded against the old structure.

**Already-closed surveys are left alone.** Auto-complete now skips a survey whose status is already `completed`. Previously every response arriving after closure re-issued the same survey update and queued another audit event.

**Response counts are no longer loaded when nothing consumes them.** The total count ran on every finished response even though its only remaining consumer is the notification email, so on the common path (nobody subscribed to response notifications) it was pure waste — and two queries rather than one, since the response service loads the full survey to build its where-clause and `cache()` does not dedupe that in a worker. Both counts are now conditional and run concurrently with the integration and follow-up work instead of blocking on it, so the auto-complete count costs no extra round trip either.

## Linear ticket

No Linear ticket — customer-reported bug filed directly. Not closing a GitHub issue.

## How this was tested

- `vitest run modules/response-pipeline modules/survey/lib/response.test.ts modules/survey/editor/lib/validation.test.ts` → **178 passed** ✅ (the pipeline suite went 24 → 28).
- Wider sweep over `modules/survey`, `modules/response-pipeline` and `lib/response` → **1097 passed** ✅, no collateral breakage.
- Regression tests added:
  - Auto-complete ignores starts: total 500 / finished 3 against a limit of 5 → survey stays open, and the completed-only count is the one queried.
  - Auto-complete fires once finished responses reach the limit.
  - No limit set → the completed-response count is never queried.
  - Survey already `completed` → no further count, no survey update, no audit event.
  - No notification subscribers → the total count is never queried and no email is sent.
  - Either count failing is logged and skipped without failing the job.
  - `getFinishedResponseCountBySurveyId` filters on `finished: true` and maps Prisma errors to `DatabaseError`.
- Each new behaviour was **negative-controlled**: reverting the status guard, the finished-vs-total counting, and the lazy total count each fails exactly its own test and nothing else.
- The total and completed counts now use **distinct values in test fixtures**, so a test can no longer pass while confusing the two; the notification email is asserted against the total specifically.
- `eslint` on all changed files → clean ✅ (2 pre-existing `react-hooks/exhaustive-deps` warnings in `survey-editor.tsx`, untouched by this diff).
- `prettier --check` on all changed files → clean ✅.
- `tsc --noEmit` for `apps/web` → no errors in any changed file ✅.

No UI change, so no screenshots.

## Changelog

This is a user-visible behaviour change, so it needs a changelog line — a survey with a response limit now stays open longer and collects more responses before closing, which on paid plans consumes more of the monthly response allowance.

Drafted into the Linear 5.3 release notes: https://linear.app/formbricks/pipeline/formbricks/release/53-67c924b9ec85/release-notes/53-128c0c9c0996

## QA / Test Plan

**How to test**

- [ ] Create and publish a **link survey**. In the survey editor → **Settings → Response Options**, enable **"Close survey on response limit"** and set the limit to a small number, e.g. **2**.
- [ ] **Only partial starts stay open:** Open the survey link and answer the first question but **do not** submit/finish. Repeat so there are ~3 partial starts. → Survey status stays **In progress** and the link keeps accepting responses (it must **not** close).
- [ ] **The editor still saves in that state:** with those ~3 partial starts and the limit still **2**, change anything in the editor (e.g. a question headline) and hit **Save**. → It saves. Before this fix it failed with *"Response limit needs to exceed number of received responses (3)"*.
- [ ] **Completions close it:** Now fully complete the survey **2 times** (reach the end / submit). → Shortly after the 2nd *completed* response, the survey auto-closes: status becomes **Completed** and opening the link shows the "survey completed / no longer accepting responses" screen. (Closing is processed by an async worker, so allow a few seconds.)
- [ ] **Edge — mixed:** With the limit still 2, on a fresh survey submit **1** complete response and leave several partials. → Survey stays open (only completions count toward the limit).
- [ ] **Edge — limit input:** With ~3 partial starts and 0 completions, open the response-limit field. → It accepts a limit of **1** or **2** (the minimum tracks *completed* responses, not starts).
- [ ] **Notification email unchanged:** with response notifications enabled for your user, complete a response. → The "View N more responses" email still reports the **total** response count (partials included).

**Preconditions / test data**

- A survey with the response-limit option enabled and a small `autoComplete` limit. Works on both Cloud and self-host. No special plan/entitlement or feature flag required.

**Risks & regressions**

- **Surveys that already closed early are not reopened** — the pipeline only ever sets status *to* `completed`, so anyone already affected has a survey stuck in "Completed" that must be reopened by hand. Deliberately out of scope here: reopening them automatically would be a new feature, not part of this fix.
- **Surveys with a limit now run longer than before**, since they close at N completions rather than N starts. For a survey with a low completion rate that is materially more responses (and, on Cloud, more billable volume) before it closes. Probably worth a changelog note so the higher count does not read as a regression.
- The response-finished **notification email** intentionally still uses the total response count; verify that email still renders a sensible number.
- Re-check that surveys with a limit still close (at the completed-response count) and that closing still writes the audit-log event.
- The editor's "this survey already has responses" caution still triggers on *any* response including partials — that is deliberate and unchanged.

**Migrations / env / cutover**

- none
- No locale changes. Note that `response_limit_needs_to_exceed_number_of_received_responses` now reports a *completed*-response count while its wording still says "received responses" — rewording it needs a `pnpm i18n` regeneration pass, so it is left as a cosmetic follow-up rather than holding this fix.
