### PR TITLE
fix(support): skip Plain active-customer lookup on self-hosted [ENG-1984]

### DIFF
--- a/apps/web/app/plain/lib/customer.test.ts
+++ b/apps/web/app/plain/lib/customer.test.ts
@@ -2,6 +2,16 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { getOrganizationsByUserId } from "@/lib/organization/service";
 import { getIsActiveCustomer } from "./customer";
 
+// A getter lets each test flip the deployment flag at runtime — the helper reads it through a live
+// import binding at call time. Cloud is the default since that is where the label is used.
+const constantsOverrides = vi.hoisted(() => ({ IS_FORMBRICKS_CLOUD: true }));
+
+vi.mock("@/lib/constants", () => ({
+  get IS_FORMBRICKS_CLOUD() {
+    return constantsOverrides.IS_FORMBRICKS_CLOUD;
+  },
+}));
+
 vi.mock("@/lib/organization/service", () => ({
   getOrganizationsByUserId: vi.fn(),
 }));
@@ -19,6 +29,7 @@ const mockOrgs = (orgs: unknown[]) =>
 describe("getIsActiveCustomer", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    constantsOverrides.IS_FORMBRICKS_CLOUD = true;
   });
 
   test("returns true for a paid plan with an active subscription", async () => {
@@ -59,5 +70,12 @@ describe("getIsActiveCustomer", () => {
   test("returns false when the user has no organizations", async () => {
     mockOrgs([]);
     await expect(getIsActiveCustomer("user-1")).resolves.toBe(false);
+  });
+
+  test("returns false on self-hosted instances without querying organizations", async () => {
+    constantsOverrides.IS_FORMBRICKS_CLOUD = false;
+    mockOrgs([orgWith("scale", "active")]);
+    await expect(getIsActiveCustomer("user-1")).resolves.toBe(false);
+    expect(getOrganizationsByUserId).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/plain/lib/customer.ts
+++ b/apps/web/app/plain/lib/customer.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { TCloudBillingPlan } from "@formbricks/types/organizations";
+import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getOrganizationsByUserId } from "@/lib/organization/service";
 
 const PAID_BILLING_PLANS = new Set<TCloudBillingPlan>(["pro", "scale"]);
@@ -8,8 +9,15 @@ const PAID_BILLING_PLANS = new Set<TCloudBillingPlan>(["pro", "scale"]);
  * Whether the user belongs to at least one organization on a paid, active plan.
  * Resolved server-side so the active-customer label can be attached to Plain
  * threads at init time, before the user opens their first thread.
+ *
+ * Stripe billing plans only exist on Formbricks Cloud, so self-hosted instances
+ * short-circuit to false instead of querying the user's organizations.
  */
 export const getIsActiveCustomer = async (userId: string): Promise<boolean> => {
+  if (!IS_FORMBRICKS_CLOUD) {
+    return false;
+  }
+
   const organizations = await getOrganizationsByUserId(userId);
   return organizations.some((organization) => {
     const stripe = organization.billing.stripe;


### PR DESCRIPTION
## What & why

Follow-up to Matty's review comment on #8654 ([discussion_r3666800831](https://github.com/formbricks/formbricks/pull/8654#discussion_r3666800831)): the Plain active-customer label is a Formbricks Cloud concern only.

`getIsActiveCustomer()` resolves the paying-customer label from the `Organization.billing.stripe` snapshot. Self-hosted instances never populate that snapshot, so on every `(app)` layout render the helper queried all of the user's organizations only to always return `false`. It now returns early when `IS_FORMBRICKS_CLOUD` is not set, so self-hosting does no billing lookup at all.

Stacked on `dhruwang/eng-1984-move-in-product-chat-to-new-support-platform` (#8654) — the diff is two files.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1984/move-in-product-chat-to-new-support-platform

## How this was tested

- `pnpm vitest run app/plain/lib/customer.test.ts app/plain/lib/identity.test.ts app/plain/lib/utils.test.ts` ✅ — 3 files, 16 tests passing (`customer` is now 9, up from 8).
- Test added: `returns false on self-hosted instances without querying organizations` — asserts both the `false` result and that `getOrganizationsByUserId` is never called. The existing 8 cases run with `IS_FORMBRICKS_CLOUD = true` via a hoisted getter override, matching the pattern already used in `modules/auth/lib/signup-email-domain.test.ts`.
- `eslint` and `prettier --check` on both touched files — clean. `tsc --project tsconfig.typecheck.json` — no errors under `app/plain`.

No UI change: this only removes a query whose result was already `false` on self-hosted.

## QA / Test Plan

**How to test**

- [ ] Self-hosted (`IS_FORMBRICKS_CLOUD` unset), with `PLAIN_APP_ID` and `PLAIN_ACTIVE_CUSTOMER_LABEL_TYPE_ID` set → log in, open the Plain widget, send a message → thread is created in Plain **without** the active-customer label, and the app pages load normally.
- [ ] Cloud (`IS_FORMBRICKS_CLOUD=1`), user in a `pro`/`scale` org with an active or trialing subscription → new thread **still carries** the active-customer label (unchanged behavior).
- [ ] Cloud, user only in `hobby`/`custom`/free orgs → new thread carries **no** label (unchanged behavior).

**Preconditions / test data**

- A Plain Chat app (`PLAIN_APP_ID`, `PLAIN_ACTIVE_CUSTOMER_LABEL_TYPE_ID`). For the Cloud cases: an org on `pro` or `scale` with an active/trialing Stripe subscription. Needs one run with `IS_FORMBRICKS_CLOUD=1` and one without.

**Risks & regressions**

- Only affects the label attached at `Plain.init` time. Cloud labelling logic is untouched; the widget, identity verification, and launcher hiding are unaffected.
- If an instance runs paid plans without `IS_FORMBRICKS_CLOUD=1`, its users would stop getting the label — that combination is not a supported setup.

**Migrations / env / cutover**

- none


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xpei6HqA635ePokJjMPUTR)_