### PR TITLE
fix(security): close the high-severity auth, authz and exposure gaps [2/4 high]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -361,6 +361,16 @@ ENTERPRISE_LICENSE_KEY=
 # Ignore Rate Limiting across the Formbricks app
 # RATE_LIMITING_DISABLED=1
 
+# Number of reverse proxies in front of Formbricks whose X-Forwarded-For entries can be trusted.
+# X-Forwarded-For is appended to by each proxy, so its leftmost entry is whatever the client sent;
+# only the rightmost N entries were added by infrastructure you control. Defaults to 1, which is
+# correct for a single nginx/Traefik/Envoy in front of the app. Set it to 2 if Cloudflare (or another
+# CDN) also fronts that proxy, and so on. Setting it higher than your real topology lets callers spoof
+# their address again by prepending entries; setting it to 0 believes no forwarding header at all,
+# which means IP-based rate limiting and the IP recorded on responses and audit logs cannot identify
+# individual clients. cf-connecting-ip is never trusted — Cloudflare also populates X-Forwarded-For.
+# TRUSTED_PROXY_HOP_COUNT=1
+
 # Disable telemetry reporting (usage stats sent to Formbricks). Ignored when an EE license is active.
 # TELEMETRY_DISABLED=1
 

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/actions.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/actions.ts
@@ -3,7 +3,12 @@
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { ZIntegrationInput } from "@formbricks/types/integration";
-import { createOrUpdateIntegration, deleteIntegration } from "@/lib/integration/service";
+import { withStoredIntegrationKey } from "@/lib/integration/redact-credentials";
+import {
+  createOrUpdateIntegration,
+  deleteIntegration,
+  getIntegrationByType,
+} from "@/lib/integration/service";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
@@ -42,7 +47,22 @@ export const createOrUpdateIntegrationAction = authenticatedActionClient
       });
 
       ctx.auditLoggingCtx.organizationId = organizationId;
-      const result = await createOrUpdateIntegration(parsedInput.workspaceId, parsedInput.integrationData);
+
+      // `config.key` holds the provider's OAuth credentials, which the settings pages now redact before
+      // handing the integration to a client component (lib/integration/redact-credentials.ts). The
+      // mapping UI echoes the whole integration object back here on every add, edit *and* delete, so
+      // trusting the `key` it sends would write those blanks straight over the stored tokens and
+      // silently disconnect the integration — while the UI still rendered it as connected, because the
+      // wrappers only test `config.key` for presence. The stored value is the sole source of truth on
+      // this path; credentials are written only by the OAuth callbacks, which call
+      // createOrUpdateIntegration directly rather than through this action.
+      const storedIntegration = await getIntegrationByType(
+        parsedInput.workspaceId,
+        parsedInput.integrationData.type
+      );
+      const integrationData = withStoredIntegrationKey(parsedInput.integrationData, storedIntegration);
+
+      const result = await createOrUpdateIntegration(parsedInput.workspaceId, integrationData);
       ctx.auditLoggingCtx.integrationId = result.id;
       ctx.auditLoggingCtx.newObject = result;
 

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/airtable/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/airtable/page.tsx
@@ -6,6 +6,7 @@ import { AirtableWrapper } from "@/app/(app)/workspaces/[workspaceId]/settings/w
 import { getSurveys } from "@/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/lib/surveys";
 import { getAirtableTables } from "@/lib/airtable/service";
 import { AIRTABLE_CLIENT_ID, DEFAULT_LOCALE, WEBAPP_URL } from "@/lib/constants";
+import { redactIntegrationCredentials } from "@/lib/integration/redact-credentials";
 import { getIntegrations } from "@/lib/integration/service";
 import { getUserLocale } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
@@ -52,7 +53,7 @@ const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
       <div className="h-[75vh] w-full">
         <AirtableWrapper
           isEnabled={isEnabled}
-          airtableIntegration={airtableIntegration}
+          airtableIntegration={redactIntegrationCredentials(airtableIntegration)}
           airtableArray={airtableArray}
           workspaceId={workspace.id}
           surveys={surveys}

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/google-sheets/page.tsx
@@ -9,6 +9,7 @@ import {
   GOOGLE_SHEETS_REDIRECT_URL,
   WEBAPP_URL,
 } from "@/lib/constants";
+import { redactIntegrationCredentials } from "@/lib/integration/redact-credentials";
 import { getIntegrations } from "@/lib/integration/service";
 import { getUserLocale } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
@@ -46,7 +47,7 @@ const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
           isEnabled={isEnabled}
           workspaceId={workspace.id}
           surveys={surveys}
-          googleSheetIntegration={googleSheetIntegration}
+          googleSheetIntegration={redactIntegrationCredentials(googleSheetIntegration)}
           webAppUrl={WEBAPP_URL}
           locale={locale ?? DEFAULT_LOCALE}
         />

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/page.tsx
@@ -10,6 +10,7 @@ import {
   NOTION_REDIRECT_URI,
   WEBAPP_URL,
 } from "@/lib/constants";
+import { redactIntegrationCredentials } from "@/lib/integration/redact-credentials";
 import { getIntegrationByType } from "@/lib/integration/service";
 import { getNotionDatabases } from "@/lib/notion/service";
 import { getUserLocale } from "@/lib/user/service";
@@ -56,7 +57,7 @@ const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
         enabled={enabled}
         surveys={surveys}
         workspaceId={workspace.id}
-        notionIntegration={notionIntegration as TIntegrationNotion}
+        notionIntegration={redactIntegrationCredentials(notionIntegration as TIntegrationNotion)}
         webAppUrl={WEBAPP_URL}
         databasesArray={databasesArray}
         locale={locale ?? DEFAULT_LOCALE}

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/slack/page.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/slack/page.tsx
@@ -3,6 +3,7 @@ import { TIntegrationSlack } from "@formbricks/types/integration/slack";
 import { getSurveys } from "@/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/lib/surveys";
 import { SlackWrapper } from "@/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/slack/components/SlackWrapper";
 import { DEFAULT_LOCALE, SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, WEBAPP_URL } from "@/lib/constants";
+import { redactIntegrationCredentials } from "@/lib/integration/redact-credentials";
 import { getIntegrationByType } from "@/lib/integration/service";
 import { getUserLocale } from "@/lib/user/service";
 import { getTranslate } from "@/lingodotdev/server";
@@ -38,7 +39,7 @@ const Page = async (props: { params: Promise<{ workspaceId: string }> }) => {
           isEnabled={isEnabled}
           workspaceId={workspace.id}
           surveys={surveys}
-          slackIntegration={slackIntegration as TIntegrationSlack}
+          slackIntegration={redactIntegrationCredentials(slackIntegration as TIntegrationSlack)}
           webAppUrl={WEBAPP_URL}
           locale={locale ?? DEFAULT_LOCALE}
         />

--- a/apps/web/app/api/google-sheet/callback/route.ts
+++ b/apps/web/app/api/google-sheet/callback/route.ts
@@ -16,7 +16,7 @@ import {
 } from "@/lib/oauth/integration-state";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { canUserWriteWorkspaceIntegrations } from "@/lib/workspace/auth";
 import { getSession } from "@/modules/auth/lib/session";
 
 const getGoogleSheetsRedirectUrl = (workspaceId: string) =>
@@ -97,7 +97,7 @@ export const GET = async (req: Request) => {
   }
 
   const workspaceId = oauthState.workspaceId;
-  const canUserAccessWorkspace = await hasUserWorkspaceAccess(session.user.id, workspaceId);
+  const canUserAccessWorkspace = await canUserWriteWorkspaceIntegrations(session.user.id, workspaceId);
   if (!canUserAccessWorkspace) {
     return responses.unauthorizedResponse();
   }

--- a/apps/web/app/api/google-sheet/route.ts
+++ b/apps/web/app/api/google-sheet/route.ts
@@ -8,7 +8,7 @@ import {
   GOOGLE_SHEETS_REDIRECT_URL,
 } from "@/lib/constants";
 import { createIntegrationOAuthState } from "@/lib/oauth/integration-state";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { canUserWriteWorkspaceIntegrations } from "@/lib/workspace/auth";
 import { getSession } from "@/modules/auth/lib/session";
 
 const scopes = [
@@ -28,7 +28,7 @@ export const GET = async (req: NextRequest) => {
     return responses.notAuthenticatedResponse();
   }
 
-  const canUserAccessWorkspace = await hasUserWorkspaceAccess(session?.user.id, workspaceId);
+  const canUserAccessWorkspace = await canUserWriteWorkspaceIntegrations(session?.user.id, workspaceId);
   if (!canUserAccessWorkspace) {
     return responses.unauthorizedResponse();
   }

--- a/apps/web/app/api/v1/integrations/airtable/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/airtable/callback/route.ts
@@ -12,7 +12,7 @@ import {
 } from "@/lib/oauth/integration-state";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { canUserWriteWorkspaceIntegrations } from "@/lib/workspace/auth";
 
 const getEmail = async (token: string) => {
   const req_ = await fetch("https://api.airtable.com/v0/meta/whoami", {
@@ -144,7 +144,10 @@ export const GET = withV1ApiWrapper({
       };
     }
 
-    const canUserAccessWorkspace = await hasUserWorkspaceAccess(authentication.user.id, workspaceId);
+    const canUserAccessWorkspace = await canUserWriteWorkspaceIntegrations(
+      authentication.user.id,
+      workspaceId
+    );
     if (!canUserAccessWorkspace) {
       return {
         response: responses.unauthorizedResponse(),

--- a/apps/web/app/api/v1/integrations/airtable/route.ts
+++ b/apps/web/app/api/v1/integrations/airtable/route.ts
@@ -2,7 +2,7 @@ import { responses } from "@/app/lib/api/response";
 import { withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
 import { AIRTABLE_CLIENT_ID, WEBAPP_URL } from "@/lib/constants";
 import { createIntegrationOAuthState, generatePkcePair } from "@/lib/oauth/integration-state";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { canUserWriteWorkspaceIntegrations } from "@/lib/workspace/auth";
 
 const scope = `data.records:read data.records:write schema.bases:read schema.bases:write user.email:read`;
 
@@ -20,7 +20,10 @@ export const GET = withV1ApiWrapper({
       };
     }
 
-    const canUserAccessWorkspace = await hasUserWorkspaceAccess(authentication.user.id, workspaceId);
+    const canUserAccessWorkspace = await canUserWriteWorkspaceIntegrations(
+      authentication.user.id,
+      workspaceId
+    );
     if (!canUserAccessWorkspace) {
       return {
         response: responses.unauthorizedResponse(),

--- a/apps/web/app/api/v1/integrations/airtable/tables/route.ts
+++ b/apps/web/app/api/v1/integrations/airtable/tables/route.ts
@@ -3,7 +3,7 @@ import { responses } from "@/app/lib/api/response";
 import { withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
 import { getAirtableToken, getTables } from "@/lib/airtable/service";
 import { getIntegrationByType } from "@/lib/integration/service";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { canUserReadWorkspaceIntegrations } from "@/lib/workspace/auth";
 
 export const GET = withV1ApiWrapper({
   handler: async ({ req, authentication }) => {
@@ -28,7 +28,10 @@ export const GET = withV1ApiWrapper({
       };
     }
 
-    const canUserAccessWorkspace = await hasUserWorkspaceAccess(authentication.user.id, workspaceId);
+    const canUserAccessWorkspace = await canUserReadWorkspaceIntegrations(
+      authentication.user.id,
+      workspaceId
+    );
     if (!canUserAccessWorkspace) {
       return {
         response: responses.unauthorizedResponse(),

--- a/apps/web/app/api/v1/integrations/notion/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/notion/callback/route.ts
@@ -18,7 +18,7 @@ import {
 } from "@/lib/oauth/integration-state";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { canUserWriteWorkspaceIntegrations } from "@/lib/workspace/auth";
 
 export const GET = withV1ApiWrapper({
   handler: async ({ req, authentication }) => {
@@ -56,7 +56,10 @@ export const GET = withV1ApiWrapper({
       };
     }
 
-    const canUserAccessWorkspace = await hasUserWorkspaceAccess(authentication.user.id, workspaceId);
+    const canUserAccessWorkspace = await canUserWriteWorkspaceIntegrations(
+      authentication.user.id,
+      workspaceId
+    );
     if (!canUserAccessWorkspace) {
       return {
         response: responses.unauthorizedResponse(),

--- a/apps/web/app/api/v1/integrations/notion/route.ts
+++ b/apps/web/app/api/v1/integrations/notion/route.ts
@@ -7,7 +7,7 @@ import {
   NOTION_REDIRECT_URI,
 } from "@/lib/constants";
 import { createIntegrationOAuthState } from "@/lib/oauth/integration-state";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { canUserWriteWorkspaceIntegrations } from "@/lib/workspace/auth";
 
 export const GET = withV1ApiWrapper({
   handler: async ({ req, authentication }) => {
@@ -23,7 +23,10 @@ export const GET = withV1ApiWrapper({
       };
     }
 
-    const canUserAccessWorkspace = await hasUserWorkspaceAccess(authentication.user.id, workspaceId);
+    const canUserAccessWorkspace = await canUserWriteWorkspaceIntegrations(
+      authentication.user.id,
+      workspaceId
+    );
     if (!canUserAccessWorkspace) {
       return {
         response: responses.unauthorizedResponse(),

--- a/apps/web/app/api/v1/integrations/slack/callback/route.ts
+++ b/apps/web/app/api/v1/integrations/slack/callback/route.ts
@@ -15,7 +15,7 @@ import {
 } from "@/lib/oauth/integration-state";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { canUserWriteWorkspaceIntegrations } from "@/lib/workspace/auth";
 
 export const GET = withV1ApiWrapper({
   handler: async ({ req, authentication }) => {
@@ -53,7 +53,10 @@ export const GET = withV1ApiWrapper({
       };
     }
 
-    const canUserAccessWorkspace = await hasUserWorkspaceAccess(authentication.user.id, workspaceId);
+    const canUserAccessWorkspace = await canUserWriteWorkspaceIntegrations(
+      authentication.user.id,
+      workspaceId
+    );
     if (!canUserAccessWorkspace) {
       return {
         response: responses.unauthorizedResponse(),

--- a/apps/web/app/api/v1/integrations/slack/route.ts
+++ b/apps/web/app/api/v1/integrations/slack/route.ts
@@ -2,7 +2,7 @@ import { responses } from "@/app/lib/api/response";
 import { withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
 import { SLACK_AUTH_URL, SLACK_CLIENT_ID, SLACK_CLIENT_SECRET } from "@/lib/constants";
 import { createIntegrationOAuthState } from "@/lib/oauth/integration-state";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { canUserWriteWorkspaceIntegrations } from "@/lib/workspace/auth";
 
 export const GET = withV1ApiWrapper({
   handler: async ({ req, authentication }) => {
@@ -19,7 +19,10 @@ export const GET = withV1ApiWrapper({
       };
     }
 
-    const canUserAccessWorkspace = await hasUserWorkspaceAccess(authentication.user.id, workspaceId);
+    const canUserAccessWorkspace = await canUserWriteWorkspaceIntegrations(
+      authentication.user.id,
+      workspaceId
+    );
     if (!canUserAccessWorkspace) {
       return {
         response: responses.unauthorizedResponse(),

--- a/apps/web/lib/constants.ts
+++ b/apps/web/lib/constants.ts
@@ -166,6 +166,16 @@ export const ENTERPRISE_LICENSE_REQUEST_FORM_URL =
 
 export const REDIS_URL = env.REDIS_URL;
 export const RATE_LIMITING_DISABLED = env.RATE_LIMITING_DISABLED === "1";
+/**
+ * Number of reverse proxies in front of the app whose `X-Forwarded-For` entries may be believed.
+ *
+ * Defaults to 1 because that matches every supported topology — the Helm chart's Traefik/Envoy ingress,
+ * docker-compose behind a proxy, and Formbricks Cloud — and because Next 16 gives route handlers no
+ * socket peer address to fall back on, so a default of 0 would leave IP-based rate limiting unable to
+ * tell clients apart until an operator set this. Deployments with a longer proxy chain must raise it;
+ * setting it higher than the real chain lets a caller spoof the address by prepending entries.
+ */
+export const TRUSTED_PROXY_HOP_COUNT = env.TRUSTED_PROXY_HOP_COUNT ?? 1;
 export const TELEMETRY_DISABLED = env.TELEMETRY_DISABLED === "1";
 
 // Opt-out for the Have-I-Been-Pwned breach check (ENG-1587). Set to "1" on air-gapped /

--- a/apps/web/lib/env.ts
+++ b/apps/web/lib/env.ts
@@ -315,6 +315,18 @@ const parsedEnv = createEnv({
       .optional()
       .or(z.string().refine((str) => str === "")),
     RATE_LIMITING_DISABLED: z.enum(["1", "0"]).optional(),
+    // Number of reverse proxies in front of the app whose X-Forwarded-For entries can be believed.
+    // Unset falls back to 1 (see TRUSTED_PROXY_HOP_COUNT in lib/constants.ts); an explicit 0 trusts no
+    // forwarding header at all. See resolveClientIp in lib/utils/client-ip.ts.
+    // Preprocessed because `z.coerce.number()` turns "" into 0, and 0 is a *valid* value here (the
+    // explicit "trust nothing" opt-out) rather than something `.min()` would reject. A deployment that
+    // renders the variable empty when unset — the common docker-compose / Helm shape — would otherwise
+    // silently opt out of trusting any forwarding header, collapsing every request into one rate-limit
+    // bucket. The neighbouring numeric vars only fail loudly on "" because their minimums exceed 0.
+    TRUSTED_PROXY_HOP_COUNT: z.preprocess(
+      (value) => (value === "" ? undefined : value),
+      z.coerce.number().int().min(0).max(10).optional()
+    ),
     TELEMETRY_DISABLED: z.enum(["1", "0"]).optional(),
     S3_ACCESS_KEY: z.string().optional(),
     S3_BUCKET_NAME: z.string().optional(),
@@ -480,6 +492,7 @@ const parsedEnv = createEnv({
     PASSWORD_RESET_TOKEN_LIFETIME_MINUTES: process.env.PASSWORD_RESET_TOKEN_LIFETIME_MINUTES,
     PRIVACY_URL: process.env.PRIVACY_URL,
     RATE_LIMITING_DISABLED: process.env.RATE_LIMITING_DISABLED,
+    TRUSTED_PROXY_HOP_COUNT: process.env.TRUSTED_PROXY_HOP_COUNT,
     TELEMETRY_DISABLED: process.env.TELEMETRY_DISABLED,
     S3_ACCESS_KEY: process.env.S3_ACCESS_KEY,
     S3_BUCKET_NAME: process.env.S3_BUCKET_NAME,

--- a/apps/web/lib/integration/redact-credentials.test.ts
+++ b/apps/web/lib/integration/redact-credentials.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "vitest";
+import { redactIntegrationCredentials, withStoredIntegrationKey } from "./redact-credentials";
+
+describe("redactIntegrationCredentials", () => {
+  // Regression: these objects are passed to "use client" wrappers, so anything left in them ends up in
+  // the RSC payload in the page source.
+  test("blanks the OAuth tokens on a Google Sheets integration", () => {
+    const integration = {
+      id: "int_1",
+      type: "googleSheets",
+      config: {
+        email: "owner@example.com",
+        data: [{ spreadsheetId: "sheet_1" }],
+        key: {
+          scope: "https://www.googleapis.com/auth/spreadsheets",
+          token_type: "Bearer",
+          expiry_date: 123,
+          access_token: "ya29.super-secret",
+          refresh_token: "1//long-lived-secret",
+        },
+      },
+    };
+
+    const redacted = redactIntegrationCredentials(integration);
+
+    expect(redacted?.config.key.access_token).toBe("");
+    expect(redacted?.config.key.refresh_token).toBe("");
+    // Non-secret fields the UI needs are preserved.
+    expect(redacted?.config.key.scope).toBe("https://www.googleapis.com/auth/spreadsheets");
+    expect(redacted?.config.email).toBe("owner@example.com");
+    expect(redacted?.config.data).toEqual([{ spreadsheetId: "sheet_1" }]);
+  });
+
+  test("preserves the display fields Notion and Slack read from the key", () => {
+    const notion = redactIntegrationCredentials({
+      config: { key: { access_token: "secret", bot_id: "bot_1", workspace_name: "Acme" }, data: [] },
+    });
+    expect(notion?.config.key).toEqual({ access_token: "", bot_id: "bot_1", workspace_name: "Acme" });
+
+    const slack = redactIntegrationCredentials({
+      config: { key: { access_token: "xoxb-secret", team: { id: "T1", name: "Acme" } }, data: [] },
+    });
+    expect(slack?.config.key).toEqual({ access_token: "", team: { id: "T1", name: "Acme" } });
+  });
+
+  // The point of matching on the field name is that a credential a provider adds later is redacted
+  // without anyone having to remember to extend a list.
+  test("blanks credential-shaped fields it has never seen before", () => {
+    const redacted = redactIntegrationCredentials({
+      config: {
+        key: {
+          id_token: "eyJ-secret",
+          client_secret: "cs-secret",
+          service_account_private_key: "-----BEGIN PRIVATE KEY-----",
+          api_key: "ak-secret",
+          token: "bare-secret",
+        },
+        data: [],
+      },
+    });
+
+    expect(redacted?.config.key).toEqual({
+      id_token: "",
+      client_secret: "",
+      service_account_private_key: "",
+      api_key: "",
+      token: "",
+    });
+  });
+
+  // `token_type` names the scheme, and Slack/Google Sheets type it as a Zod literal — blanking it would
+  // make the redacted object stop satisfying the integration type it is passed as.
+  test.each([
+    ["token_type", "Bearer"],
+    ["workspace_id", "ws_1"],
+    ["bot_user_id", "U1"],
+    ["app_id", "A1"],
+    ["expiry_date", "2026-01-01"],
+  ])("leaves the non-secret field %s alone", (field, value) => {
+    const redacted = redactIntegrationCredentials({
+      config: { key: { [field]: value, access_token: "secret" }, data: [] },
+    });
+
+    expect(redacted?.config.key[field]).toBe(value);
+    expect(redacted?.config.key.access_token).toBe("");
+  });
+
+  test("does not mutate the input", () => {
+    const key = { access_token: "secret", refresh_token: "secret2" };
+    const integration = { config: { key } };
+
+    redactIntegrationCredentials(integration);
+
+    expect(key.access_token).toBe("secret");
+    expect(key.refresh_token).toBe("secret2");
+  });
+
+  test.each([
+    ["undefined integration", undefined],
+    ["no config", {}],
+    ["null config", { config: null }],
+    ["no key", { config: { data: [] } }],
+  ])("passes through %s unchanged", (_label, input) => {
+    expect(redactIntegrationCredentials(input as never)).toEqual(input);
+  });
+});
+
+describe("withStoredIntegrationKey", () => {
+  const stored = {
+    config: { key: { access_token: "real-access", refresh_token: "real-refresh" }, data: [] },
+  };
+
+  // Regression for the round-trip that redaction created: the settings pages blank config.key on the
+  // way out, and the mapping UI echoes the whole integration back on add / edit / delete. Honouring the
+  // echoed key wrote empty strings over the stored tokens and disconnected the integration, while the
+  // UI still showed it connected because the wrappers only test config.key for presence.
+  test("keeps the stored credentials when the client echoes blanked ones", () => {
+    const incoming = {
+      type: "notion",
+      config: { key: { access_token: "", refresh_token: "" }, data: [{ surveyId: "s1" }] },
+    };
+
+    const result = withStoredIntegrationKey(incoming as never, stored as never);
+
+    expect(result.config.key).toEqual(stored.config.key);
+    // the non-secret payload the client legitimately owns still wins
+    expect(result.config.data).toEqual([{ surveyId: "s1" }]);
+  });
+
+  test("keeps the stored credentials even when the client sends a different key", () => {
+    const incoming = { type: "notion", config: { key: { access_token: "attacker" }, data: [] } };
+
+    expect(withStoredIntegrationKey(incoming as never, stored as never).config.key).toEqual(
+      stored.config.key
+    );
+  });
+
+  test.each([
+    ["no stored integration", null],
+    ["stored integration without a key", { config: { data: [] } }],
+  ])("passes the input through when there is %s", (_label, storedValue) => {
+    const incoming = { type: "notion", config: { key: { access_token: "fresh" }, data: [] } };
+
+    expect(withStoredIntegrationKey(incoming as never, storedValue as never)).toEqual(incoming);
+  });
+});

--- a/apps/web/lib/integration/redact-credentials.ts
+++ b/apps/web/lib/integration/redact-credentials.ts
@@ -1,0 +1,88 @@
+/**
+ * Strips OAuth credentials out of an integration before it is handed to a client component.
+ *
+ * The integration settings pages pass the whole integration — including `config.key`, which holds the
+ * provider's `access_token` and, for Google Sheets and Airtable, a long-lived `refresh_token` — into
+ * `"use client"` wrappers. Anything a client component receives is serialized into the RSC payload and
+ * readable in the page source, so those credentials were exposed to every member who could open the
+ * page, and to anything with access to that HTML (browser extensions, HAR captures, a shared screen).
+ * A refresh token in particular grants access to the connected Google/Airtable account well outside
+ * Formbricks, and long after the member's Formbricks access is revoked.
+ *
+ * The client only needs the non-secret parts: `config.data` (the survey→destination mappings),
+ * `config.email`, and a few display/presence fields inside `key` (`bot_id`, `workspace_name`,
+ * `team.name`). Secret fields are blanked rather than removed so every consumer stays type-valid.
+ */
+const REDACTED = "";
+
+/**
+ * Matched against each field name in `config.key`, so a credential a provider adds later is redacted by
+ * default rather than exposed until someone remembers to extend a list.
+ *
+ * Deliberately matches `token` only as a whole word or `*_token` suffix: Slack and Google Sheets type
+ * `token_type` as a Zod *literal* (`"bot"` / `"Bearer"`), so blanking it would make the redacted object
+ * fail to satisfy the integration type it is passed as. `token_type` names a scheme, not a secret.
+ */
+const SECRET_KEY_FIELD_PATTERN = /(^token$|_token$|secret|password|credential|private_key|api_?key)/i;
+
+/** Always redacted, whatever the pattern says. */
+const SECRET_KEY_FIELDS = ["access_token", "refresh_token"] as const;
+
+const isSecretKeyField = (field: string): boolean =>
+  SECRET_KEY_FIELDS.includes(field as (typeof SECRET_KEY_FIELDS)[number]) ||
+  SECRET_KEY_FIELD_PATTERN.test(field);
+
+type TIntegrationWithConfig = {
+  config?: { key?: Record<string, unknown> | null } | null;
+};
+
+export const redactIntegrationCredentials = <T extends TIntegrationWithConfig>(
+  integration: T | undefined
+): T | undefined => {
+  if (!integration?.config?.key || typeof integration.config.key !== "object") {
+    return integration;
+  }
+
+  const redactedKey: Record<string, unknown> = { ...integration.config.key };
+  for (const field of Object.keys(redactedKey)) {
+    // Only string values are blanked: every credential these providers issue is a string, and an
+    // object- or number-typed field (Slack's `team`, Google's `expiry_date`) would stop matching its
+    // schema if replaced with "".
+    if (isSecretKeyField(field) && typeof redactedKey[field] === "string") {
+      redactedKey[field] = REDACTED;
+    }
+  }
+
+  return {
+    ...integration,
+    config: { ...integration.config, key: redactedKey },
+  };
+};
+
+/**
+ * The inbound counterpart to {@link redactIntegrationCredentials}: replaces a client-supplied
+ * `config.key` with the stored one.
+ *
+ * Because the settings pages redact credentials on the way out, and the mapping UI echoes the whole
+ * integration object back when a link is added, edited or removed, an unguarded save writes the blanked
+ * tokens over the real ones — disconnecting the integration while the UI still shows it as connected,
+ * since the wrappers only test `config.key` for presence. Credentials therefore never come from the
+ * request on that path; they are written only by the OAuth callbacks, which reach
+ * `createOrUpdateIntegration` directly.
+ *
+ * With no stored integration there is nothing to preserve and the input passes through unchanged: that
+ * is the first-connect case, which only the callbacks perform.
+ */
+export const withStoredIntegrationKey = <T extends TIntegrationWithConfig>(
+  incoming: T,
+  stored: TIntegrationWithConfig | null | undefined
+): T => {
+  if (!stored?.config?.key || !incoming.config) {
+    return incoming;
+  }
+
+  return {
+    ...incoming,
+    config: { ...incoming.config, key: stored.config.key },
+  };
+};

--- a/apps/web/lib/jwt.test.ts
+++ b/apps/web/lib/jwt.test.ts
@@ -298,6 +298,20 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
       const token = jwt.sign({ email: "test@example.com" }, TEST_NEXTAUTH_SECRET);
       await testMissingSecretsError(getEmailFromEmailToken, [token]);
     });
+
+    test("should reject a link survey token minted for another flow", () => {
+      const token = createTokenForLinkSurvey("test-survey-id", mockUser.email);
+      expect(() => getEmailFromEmailToken(token)).toThrow("Invalid token");
+    });
+
+    test("should reject an expired email-display token", () => {
+      const token = jwt.sign(
+        { email: `encrypted_${mockUser.email}`, purpose: "email_display" },
+        TEST_NEXTAUTH_SECRET,
+        { expiresIn: "-1s" }
+      );
+      expect(() => getEmailFromEmailToken(token)).toThrow();
+    });
   });
 
   describe("verifyTokenForLinkSurvey", () => {
@@ -306,6 +320,43 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
       const token = createTokenForLinkSurvey(surveyId, mockUser.email);
       const verifiedEmail = verifyTokenForLinkSurvey(token, surveyId);
       expect(verifiedEmail).toBe(mockUser.email);
+    });
+
+    // Regression: every token in this module is signed with NEXTAUTH_SECRET, so a token minted for a
+    // different flow must not pass as a verified email. `createEmailToken` is reachable through an
+    // unauthenticated server action for any registered address, so accepting it here bypassed the
+    // link-survey email gate for arbitrary people.
+    test("should reject an email-display token as a link survey verification token", () => {
+      const token = createEmailToken(mockUser.email);
+      expect(verifyTokenForLinkSurvey(token, "test-survey-id")).toBeNull();
+    });
+
+    test("should reject an invite token as a link survey verification token", () => {
+      const token = createInviteToken("invite-id", mockUser.email);
+      expect(verifyTokenForLinkSurvey(token, "test-survey-id")).toBeNull();
+    });
+
+    test("should reject a token with no surveyId claim signed with the plain secret", () => {
+      const token = jwt.sign({ email: `encrypted_${mockUser.email}` }, TEST_NEXTAUTH_SECRET);
+      expect(verifyTokenForLinkSurvey(token, "test-survey-id")).toBeNull();
+    });
+
+    test("should reject a link survey token whose purpose is for another flow", () => {
+      const token = jwt.sign(
+        { email: `encrypted_${mockUser.email}`, surveyId: "test-survey-id", purpose: "email_display" },
+        TEST_NEXTAUTH_SECRET
+      );
+      expect(verifyTokenForLinkSurvey(token, "test-survey-id")).toBeNull();
+    });
+
+    test("should reject an expired link survey token", () => {
+      const surveyId = "test-survey-id";
+      const token = jwt.sign(
+        { email: `encrypted_${mockUser.email}`, surveyId, purpose: "link_survey_email_verification" },
+        TEST_NEXTAUTH_SECRET,
+        { expiresIn: "-1s" }
+      );
+      expect(verifyTokenForLinkSurvey(token, surveyId)).toBeNull();
     });
 
     test("should return null for invalid token", () => {

--- a/apps/web/lib/jwt.ts
+++ b/apps/web/lib/jwt.ts
@@ -16,6 +16,19 @@ const decryptWithFallback = (encryptedText: string, key: string): string => {
   }
 };
 
+/**
+ * Every token minted here is signed with the same `NEXTAUTH_SECRET`, so the signature alone proves
+ * nothing about *which* flow a token was issued for. Tokens that grant something must therefore carry
+ * an explicit `purpose` claim and the verifier must require it, otherwise a token handed out by one
+ * flow is replayable against another (e.g. an email- or invite-token accepted as proof of email
+ * verification for a link survey).
+ */
+export const LINK_SURVEY_EMAIL_VERIFICATION_PURPOSE = "link_survey_email_verification";
+export const EMAIL_DISPLAY_TOKEN_PURPOSE = "email_display";
+
+const LINK_SURVEY_TOKEN_TTL = "7d";
+const EMAIL_DISPLAY_TOKEN_TTL = "1d";
+
 export const VERIFICATION_TOKEN_PURPOSES = ["email_verification", "sso_recovery"] as const;
 
 export type TVerificationTokenPurpose = (typeof VERIFICATION_TOKEN_PURPOSES)[number];
@@ -110,7 +123,11 @@ export const createTokenForLinkSurvey = (surveyId: string, userEmail: string): s
   }
 
   const encryptedEmail = symmetricEncrypt(userEmail, ENCRYPTION_KEY);
-  return jwt.sign({ email: encryptedEmail, surveyId }, NEXTAUTH_SECRET);
+  return jwt.sign(
+    { email: encryptedEmail, surveyId, purpose: LINK_SURVEY_EMAIL_VERIFICATION_PURPOSE },
+    NEXTAUTH_SECRET,
+    { expiresIn: LINK_SURVEY_TOKEN_TTL }
+  );
 };
 
 export const verifyEmailChangeToken = async (token: string): Promise<{ id: string; email: string }> => {
@@ -205,7 +222,11 @@ export const createEmailToken = (email: string): string => {
   }
 
   const encryptedEmail = symmetricEncrypt(email, ENCRYPTION_KEY);
-  return jwt.sign({ email: encryptedEmail }, NEXTAUTH_SECRET);
+  // Handed out by an unauthenticated action purely so the "check your inbox" screen can echo the
+  // address back. It must therefore be inert everywhere else: scope it with a purpose and a TTL.
+  return jwt.sign({ email: encryptedEmail, purpose: EMAIL_DISPLAY_TOKEN_PURPOSE }, NEXTAUTH_SECRET, {
+    expiresIn: EMAIL_DISPLAY_TOKEN_TTL,
+  });
 };
 
 export const getEmailFromEmailToken = (token: string): string => {
@@ -219,7 +240,15 @@ export const getEmailFromEmailToken = (token: string): string => {
 
   const payload = jwt.verify(token, NEXTAUTH_SECRET, { algorithms: ["HS256"] }) as JwtPayload & {
     email: string;
+    purpose?: string;
   };
+
+  // Tokens minted before the purpose claim existed have none; anything else was issued for a
+  // different flow and must not resolve to an email here.
+  if (payload.purpose !== undefined && payload.purpose !== EMAIL_DISPLAY_TOKEN_PURPOSE) {
+    throw new Error("Invalid token");
+  }
+
   return decryptWithFallback(payload.email, ENCRYPTION_KEY);
 };
 
@@ -243,7 +272,10 @@ export const verifyTokenForLinkSurvey = (token: string, surveyId: string): strin
   }
 
   try {
-    let payload: JwtPayload & { email: string; surveyId?: string };
+    let payload: JwtPayload & { email: string; surveyId?: string; purpose?: string };
+    // Legacy tokens carry no `surveyId` claim; they are bound to one survey by their signing key
+    // (`NEXTAUTH_SECRET + surveyId`) instead, so that path needs no claim check.
+    let isBoundBySigningKey = false;
 
     // Try primary method first (consistent secret)
     try {
@@ -259,14 +291,23 @@ export const verifyTokenForLinkSurvey = (token: string, surveyId: string): strin
         payload = jwt.verify(token, NEXTAUTH_SECRET + surveyId, { algorithms: ["HS256"] }) as JwtPayload & {
           email: string;
         };
+        isBoundBySigningKey = true;
       } catch (legacyError) {
         logger.error(legacyError, "Token verification failed with legacy method");
         throw new Error("Invalid token");
       }
     }
 
-    // Verify the surveyId matches if present in payload (new format)
-    if (payload.surveyId && payload.surveyId !== surveyId) {
+    // A token verified with the plain secret MUST name this survey. Accepting a missing `surveyId`
+    // here let any NEXTAUTH_SECRET-signed token that happens to carry an `email` claim — e.g. the one
+    // `createEmailToken` hands out for an arbitrary address — pass as a verified email for any survey.
+    if (!isBoundBySigningKey && payload.surveyId !== surveyId) {
+      return null;
+    }
+
+    // Reject tokens explicitly minted for a different flow. Tokens issued before the purpose claim
+    // existed have none; they are already survey-bound by the check above.
+    if (payload.purpose !== undefined && payload.purpose !== LINK_SURVEY_EMAIL_VERIFICATION_PURPOSE) {
       return null;
     }
 

--- a/apps/web/lib/utils/client-ip.test.ts
+++ b/apps/web/lib/utils/client-ip.test.ts
@@ -1,6 +1,6 @@
 import * as nextHeaders from "next/headers";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { getClientIpFromHeaders } from "./client-ip";
+import { UNTRUSTED_CLIENT_IP, getClientIpFromHeaders, resolveClientIp } from "./client-ip";
 
 // Mock next/headers
 declare module "next/headers" {
@@ -11,72 +11,193 @@ vi.mock("next/headers", () => ({
   headers: vi.fn(),
 }));
 
+// Mirrors the shipped default of 1: one trusted reverse proxy in front of the app.
+vi.mock("@/lib/constants", () => ({ TRUSTED_PROXY_HOP_COUNT: 1 }));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: { error: vi.fn() },
+}));
+
+const buildHeaders = (headerMap: Record<string, string | undefined>): Headers =>
+  ({
+    get: (key: string) => headerMap[key.toLowerCase()] ?? null,
+  }) as Headers;
+
 const mockHeaders = (headerMap: Record<string, string | undefined>) => {
-  vi.mocked(nextHeaders.headers).mockReturnValue({
-    get: (key: string) => headerMap[key.toLowerCase()] ?? undefined,
-  });
+  vi.mocked(nextHeaders.headers).mockReturnValue(buildHeaders(headerMap));
 };
+
+describe("resolveClientIp", () => {
+  // Regression: X-Forwarded-For is appended to by each proxy, so its leftmost entry is client-supplied.
+  // Reading it let a caller rotate the header to mint a fresh rate-limit bucket per request, bypassing
+  // the login / forgot-password / signup / public-API limits, and to forge captured IPs.
+  describe("with one trusted proxy", () => {
+    test("takes the entry the trusted proxy appended, not the client-supplied one", () => {
+      const headers = buildHeaders({ "x-forwarded-for": "1.1.1.1, 203.0.113.7" });
+      expect(resolveClientIp(headers, 1)).toBe("203.0.113.7");
+    });
+
+    test("ignores a spoofed chain the client prepended", () => {
+      const headers = buildHeaders({
+        "x-forwarded-for": "9.9.9.9, 8.8.8.8, 7.7.7.7, 203.0.113.7",
+      });
+      expect(resolveClientIp(headers, 1)).toBe("203.0.113.7");
+    });
+
+    // A hop count says "one proxy is in front", not "that proxy is Cloudflare". Traefik, Envoy and
+    // nginx all pass cf-connecting-ip through untouched, so believing it ahead of the hop-counted
+    // chain would hand the spoof straight back to the caller.
+    test("ignores cf-connecting-ip in favour of the forwarded chain", () => {
+      const headers = buildHeaders({
+        "cf-connecting-ip": "198.51.100.5",
+        "x-forwarded-for": "1.1.1.1, 203.0.113.7",
+      });
+      expect(resolveClientIp(headers, 1)).toBe("203.0.113.7");
+    });
+
+    test("ignores cf-connecting-ip even when it is the only header present", () => {
+      const headers = buildHeaders({ "cf-connecting-ip": "198.51.100.5" });
+      expect(resolveClientIp(headers, 1)).toBe(UNTRUSTED_CLIENT_IP);
+    });
+
+    test("trims whitespace around the selected entry", () => {
+      const headers = buildHeaders({ "x-forwarded-for": "  1.1.1.1  ,   203.0.113.7  " });
+      expect(resolveClientIp(headers, 1)).toBe("203.0.113.7");
+    });
+
+    // Regression: x-real-ip is only ever reached when no XFF arrived, which means the request did not
+    // come through the proxy this app is configured to trust — so the header is caller-supplied, and
+    // honouring it would hand back the per-request bucket rotation this function exists to stop.
+    test("ignores x-real-ip when there is no forwarded chain", () => {
+      const headers = buildHeaders({ "x-real-ip": "203.0.113.9" });
+      expect(resolveClientIp(headers, 1)).toBe(UNTRUSTED_CLIENT_IP);
+    });
+
+    test("ignores x-real-ip even when a forwarded chain is present", () => {
+      const headers = buildHeaders({
+        "x-forwarded-for": "1.1.1.1, 203.0.113.7",
+        "x-real-ip": "9.9.9.9",
+      });
+      expect(resolveClientIp(headers, 1)).toBe("203.0.113.7");
+    });
+
+    test("reports the client as untrusted when no header identifies it", () => {
+      expect(resolveClientIp(buildHeaders({}), 1)).toBe(UNTRUSTED_CLIENT_IP);
+    });
+  });
+
+  describe("with two trusted proxies", () => {
+    test("takes the second entry from the right", () => {
+      const headers = buildHeaders({ "x-forwarded-for": "1.1.1.1, 203.0.113.7, 10.0.0.1" });
+      expect(resolveClientIp(headers, 2)).toBe("203.0.113.7");
+    });
+
+    test("clamps to the earliest entry when the chain is shorter than configured", () => {
+      const headers = buildHeaders({ "x-forwarded-for": "203.0.113.7" });
+      expect(resolveClientIp(headers, 2)).toBe("203.0.113.7");
+    });
+  });
+
+  describe("with no trusted proxy", () => {
+    test.each([
+      ["x-forwarded-for", { "x-forwarded-for": "1.1.1.1, 203.0.113.7" }],
+      ["cf-connecting-ip", { "cf-connecting-ip": "1.1.1.1" }],
+      ["x-real-ip", { "x-real-ip": "1.1.1.1" }],
+    ])("does not believe %s", (_label, headerMap) => {
+      expect(resolveClientIp(buildHeaders(headerMap), 0)).toBe(UNTRUSTED_CLIENT_IP);
+    });
+
+    test("treats a negative hop count as zero", () => {
+      const headers = buildHeaders({ "x-forwarded-for": "1.1.1.1" });
+      expect(resolveClientIp(headers, -1)).toBe(UNTRUSTED_CLIENT_IP);
+    });
+  });
+});
 
 describe("getClientIpFromHeaders", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  test("returns cf-connecting-ip if present", async () => {
-    mockHeaders({ "cf-connecting-ip": "1.2.3.4" });
-    const ip = await getClientIpFromHeaders();
-    expect(ip).toBe("1.2.3.4");
+  // At the shipped default of 1, the address is the entry the single trusted proxy appended, and the
+  // client-supplied prefix and `cf-connecting-ip` are both ignored.
+  test("takes the trusted proxy's entry at the default hop count of 1", async () => {
+    mockHeaders({ "cf-connecting-ip": "1.2.3.4", "x-forwarded-for": "9.9.9.9, 203.0.113.7" });
+    await expect(getClientIpFromHeaders()).resolves.toBe("203.0.113.7");
   });
 
-  test("returns first x-forwarded-for if cf-connecting-ip is missing", async () => {
-    mockHeaders({ "x-forwarded-for": "5.6.7.8, 9.10.11.12" });
-    const ip = await getClientIpFromHeaders();
-    expect(ip).toBe("5.6.7.8");
-  });
-
-  test("returns x-real-ip if cf-connecting-ip and x-forwarded-for are missing", async () => {
-    mockHeaders({ "x-real-ip": "13.14.15.16" });
-    const ip = await getClientIpFromHeaders();
-    expect(ip).toBe("13.14.15.16");
-  });
-
-  test("returns ::1 if no headers are present", async () => {
+  test("reports the client as untrusted when no header identifies it", async () => {
     mockHeaders({});
-    const ip = await getClientIpFromHeaders();
-    expect(ip).toBe("::1");
+    await expect(getClientIpFromHeaders()).resolves.toBe(UNTRUSTED_CLIENT_IP);
   });
 
-  test("trims whitespace in x-forwarded-for", async () => {
-    mockHeaders({ "x-forwarded-for": "  21.22.23.24  , 25.26.27.28" });
-    const ip = await getClientIpFromHeaders();
-    expect(ip).toBe("21.22.23.24");
-  });
-
-  test("getClientIpFromHeaders should return the value of the cf-connecting-ip header when it is present", async () => {
-    const testIp = "123.123.123.123";
-
-    vi.mocked(nextHeaders.headers).mockReturnValue({
-      get: vi.fn().mockImplementation((headerName: string) => {
-        if (headerName === "cf-connecting-ip") {
-          return testIp;
-        }
-        return null;
-      }),
-    } as any);
-
-    const result = await getClientIpFromHeaders();
-
-    expect(result).toBe(testIp);
-    expect(nextHeaders.headers).toHaveBeenCalled();
-  });
-
-  test("getClientIpFromHeaders should handle errors when headers() throws an exception", async () => {
+  test("handles errors when headers() throws an exception", async () => {
     vi.mocked(nextHeaders.headers).mockImplementation(() => {
       throw new Error("Failed to get headers");
     });
 
-    const result = await getClientIpFromHeaders();
+    await expect(getClientIpFromHeaders()).resolves.toBe(UNTRUSTED_CLIENT_IP);
+  });
+});
 
-    expect(result).toBe("::1");
+describe("misconfiguration warning", () => {
+  // The throttle timestamp is module-level state, so each case re-imports the module to get a fresh
+  // one. The logger has to be imported *after* the reset too, or it would be a different mock instance
+  // than the one the re-imported module captured.
+  const loadFresh = async () => {
+    vi.resetModules();
+    const { logger } = await import("@formbricks/logger");
+    const { resolveClientIp: freshResolveClientIp } = await import("./client-ip");
+    return { logger, freshResolveClientIp };
+  };
+
+  test("warns once per throttle window when forwarding headers arrive but no hop is trusted", async () => {
+    const { logger, freshResolveClientIp } = await loadFresh();
+    const headers = buildHeaders({ "x-forwarded-for": "1.1.1.1, 203.0.113.7" });
+
+    freshResolveClientIp(headers, 0);
+    freshResolveClientIp(headers, 0);
+    freshResolveClientIp(buildHeaders({ "cf-connecting-ip": "1.1.1.1" }), 0);
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logger.error).mock.calls[0][0]).toContain("TRUSTED_PROXY_HOP_COUNT");
+  });
+
+  // The point of the time window over a once-per-process flag: an operator who leaves
+  // TRUSTED_PROXY_HOP_COUNT=0 keeps getting a signal, instead of one line at boot and silence after.
+  test("warns again after the throttle window elapses", async () => {
+    const { logger, freshResolveClientIp } = await loadFresh();
+    const headers = buildHeaders({ "x-forwarded-for": "1.1.1.1, 203.0.113.7" });
+
+    vi.useFakeTimers();
+    try {
+      freshResolveClientIp(headers, 0);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(9 * 60 * 1000);
+      freshResolveClientIp(headers, 0);
+      expect(logger.error).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(2 * 60 * 1000);
+      freshResolveClientIp(headers, 0);
+      expect(logger.error).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("stays quiet when the request carries no forwarding header at all", async () => {
+    const { logger, freshResolveClientIp } = await loadFresh();
+
+    expect(freshResolveClientIp(buildHeaders({}), 0)).toBe(UNTRUSTED_CLIENT_IP);
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  test("stays quiet when a hop is trusted", async () => {
+    const { logger, freshResolveClientIp } = await loadFresh();
+
+    freshResolveClientIp(buildHeaders({ "x-forwarded-for": "1.1.1.1, 203.0.113.7" }), 1);
+
+    expect(logger.error).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/utils/client-ip.ts
+++ b/apps/web/lib/utils/client-ip.ts
@@ -1,5 +1,98 @@
 import { headers } from "next/headers";
 import { logger } from "@formbricks/logger";
+import { TRUSTED_PROXY_HOP_COUNT } from "@/lib/constants";
+
+/**
+ * Returned when no forwarding header may be believed, so the client is genuinely unidentifiable.
+ *
+ * Next 16 exposes no socket peer address to route handlers or server actions (`NextRequest.ip` was
+ * removed and `headers()` carries only HTTP headers), so with no trusted proxy there is nothing else to
+ * fall back to.
+ */
+export const UNTRUSTED_CLIENT_IP = "untrusted-client-ip";
+
+/**
+ * Throttle window for the misconfiguration warning. Time-based rather than once-per-process: a warning
+ * that fires only on the first request goes silent for the life of a long-running deployment, so an
+ * ongoing misconfiguration disappears from monitoring after one line. Raised by CodeRabbit on #8680.
+ */
+const UNTRUSTED_IP_WARNING_INTERVAL_MS = 10 * 60 * 1000;
+
+let lastUntrustedIpWarningAt: number | null = null;
+
+const warnAboutUntrustedIp = (): void => {
+  const now = Date.now();
+  if (
+    lastUntrustedIpWarningAt !== null &&
+    now - lastUntrustedIpWarningAt < UNTRUSTED_IP_WARNING_INTERVAL_MS
+  ) {
+    return;
+  }
+  lastUntrustedIpWarningAt = now;
+  logger.error(
+    "TRUSTED_PROXY_HOP_COUNT is set to 0 but the request carries forwarding headers. IP-based rate " +
+      "limiting and IP capture cannot identify individual clients while no hop is trusted. Unset it to " +
+      "take the default of 1, or set it to the number of reverse proxies actually in front of this app."
+  );
+};
+
+/**
+ * Resolves the client IP from forwarding headers, trusting only as many proxy hops as configured.
+ *
+ * `X-Forwarded-For` is *appended* to by each proxy, so its leftmost entry is whatever the client itself
+ * sent — reading that, as this used to, let a caller supply any value. Because the result keys the
+ * IP-based rate limits (login, forgot-password, signup, the public client API), a caller could rotate
+ * the header to mint a fresh bucket per request and bypass all of them, and could also forge the
+ * `ipAddress` recorded on responses and in audit-log entries.
+ *
+ * With `hopCount` proxies in front, the address the outermost trusted proxy observed is the
+ * `hopCount`-th entry from the right; everything left of it is client-supplied and ignored.
+ * `TRUSTED_PROXY_HOP_COUNT` defaults to 1, matching every supported topology; `0` is an explicit
+ * opt-out that trusts nothing and therefore cannot identify a client at all.
+ *
+ * `cf-connecting-ip` is deliberately *not* consulted. It is only trustworthy when the request provably
+ * came from Cloudflare's edge, and a hop count cannot establish that: `hopCount >= 1` says "one proxy is
+ * in front", which for most deployments is Traefik, Envoy or nginx — none of which strip
+ * `cf-connecting-ip`. Preferring it would therefore hand the spoof straight back to the caller. Nothing
+ * is lost by dropping it: Cloudflare also puts the visitor address into `X-Forwarded-For`, so a
+ * Cloudflare deployment is just `hopCount = 1` (or 2 with a proxy of its own behind it).
+ *
+ * Exported separately from {@link getClientIpFromHeaders} so the parsing is unit-testable without
+ * mocking `next/headers`.
+ */
+export const resolveClientIp = (headersList: Headers, hopCount: number): string => {
+  const xForwardedFor = headersList.get("x-forwarded-for");
+
+  if (hopCount <= 0) {
+    if (xForwardedFor || headersList.get("cf-connecting-ip") || headersList.get("x-real-ip")) {
+      warnAboutUntrustedIp();
+    }
+    return UNTRUSTED_CLIENT_IP;
+  }
+
+  if (xForwardedFor) {
+    const entries = xForwardedFor
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+
+    if (entries.length > 0) {
+      // Clamped rather than falling back to the leftmost entry: a request with fewer hops than
+      // configured arrived through a shorter path than expected, and the earliest entry present is the
+      // closest thing to what a trusted proxy saw.
+      const index = Math.max(0, entries.length - hopCount);
+      return entries[index];
+    }
+  }
+
+  // No `x-real-ip` fallback. It is only reachable when no `X-Forwarded-For` arrived at all, and a proxy
+  // that is genuinely in front appends to XFF — so the absence of XFF means the request did not come
+  // through the trusted hop this app is configured for, and `x-real-ip` is then whatever the caller
+  // chose to send. Reading it would restore exactly the per-request bucket rotation this function
+  // exists to stop. This is the same argument the docstring makes against `cf-connecting-ip`; applying
+  // it to one header and not the other was inconsistent. Raised by @pandeymangg on #8680.
+  return UNTRUSTED_CLIENT_IP;
+};
 
 export async function getClientIpFromHeaders(): Promise<string> {
   let headersList: Headers;
@@ -7,16 +100,8 @@ export async function getClientIpFromHeaders(): Promise<string> {
     headersList = await headers();
   } catch (e) {
     logger.error(e, "Failed to get headers in getClientIpFromHeaders");
-    return "::1";
+    return UNTRUSTED_CLIENT_IP;
   }
 
-  // Try common proxy headers first
-  const cfConnectingIp = headersList.get("cf-connecting-ip");
-  if (cfConnectingIp) return cfConnectingIp;
-
-  const xForwardedFor = headersList.get("x-forwarded-for");
-  if (xForwardedFor) return xForwardedFor.split(",")[0].trim();
-
-  // Fallback (may be undefined or localhost in dev)
-  return headersList.get("x-real-ip") || "::1"; // NOSONAR - We want to fallback when the result is ""
+  return resolveClientIp(headersList, TRUSTED_PROXY_HOP_COUNT);
 }

--- a/apps/web/lib/workspace/auth.ts
+++ b/apps/web/lib/workspace/auth.ts
@@ -94,6 +94,31 @@ export const hasUserWorkspaceAccessForAction = async (
   }
 };
 
+/**
+ * Authorization for the integration OAuth routes (Notion / Airtable / Slack / Google Sheets).
+ *
+ * These are credential *mutations* delivered over GET: completing the flow writes the workspace's
+ * third-party credentials, after which survey responses are forwarded to whichever account was
+ * connected. They must therefore be gated on readWrite, not on mere workspace access —
+ * {@link hasUserWorkspaceAccess} returns true for the `billing` role (which is otherwise excluded from
+ * all product data) and for a `read`-only team member, either of whom could otherwise bind their own
+ * account as the workspace integration and start receiving another team's responses, or overwrite the
+ * credentials an admin configured.
+ */
+export const canUserWriteWorkspaceIntegrations = async (
+  userId: string,
+  workspaceId: string
+): Promise<boolean> => hasUserWorkspaceAccessForAction(userId, workspaceId, "POST");
+
+/**
+ * Read-only counterpart for routes that only surface a connected integration's data. Unlike
+ * {@link hasUserWorkspaceAccess} this still excludes the `billing` role.
+ */
+export const canUserReadWorkspaceIntegrations = async (
+  userId: string,
+  workspaceId: string
+): Promise<boolean> => hasUserWorkspaceAccessForAction(userId, workspaceId, "GET");
+
 export const hasUserWorkspaceAccess = async (userId: string, workspaceId: string) => {
   validateInputs([userId, ZId], [workspaceId, ZId]);
 

--- a/apps/web/modules/auth/actions.ts
+++ b/apps/web/modules/auth/actions.ts
@@ -6,6 +6,8 @@ import { ZUserEmail } from "@formbricks/types/user";
 import { createEmailToken } from "@/lib/jwt";
 import { getUserByEmail } from "@/lib/user/service";
 import { actionClient } from "@/lib/utils/action-client";
+import { applyIPRateLimit } from "@/modules/core/rate-limit/helpers";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 
 const ZCreateEmailTokenAction = z.object({
   email: ZUserEmail,
@@ -14,6 +16,10 @@ const ZCreateEmailTokenAction = z.object({
 export const createEmailTokenAction = actionClient
   .inputSchema(ZCreateEmailTokenAction)
   .action(async ({ parsedInput }) => {
+    // Unauthenticated: it answers "is this email registered?" for any address the caller names, so it
+    // needs the same throttling as the other auth endpoints that expose that signal.
+    await applyIPRateLimit(rateLimitConfigs.auth.emailToken);
+
     const normalizedEmail = parsedInput.email.toLowerCase();
     const user = await getUserByEmail(normalizedEmail);
     if (!user) {

--- a/apps/web/modules/auth/lib/auth.ts
+++ b/apps/web/modules/auth/lib/auth.ts
@@ -10,6 +10,7 @@ import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
 import type { TUserLocale } from "@formbricks/types/user";
 import {
+  EMAIL_AUTH_ENABLED,
   EMAIL_VERIFICATION_DISABLED,
   PASSWORD_RESET_TOKEN_LIFETIME_MINUTES,
   RATE_LIMITING_DISABLED,
@@ -90,7 +91,12 @@ export const auth = betterAuth({
   socialProviders: ssoSocialProviders,
 
   emailAndPassword: {
-    enabled: true,
+    // EMAIL_AUTH_DISABLED=1 has to switch the credential endpoints off here, not just hide the form on
+    // the login/signup pages (its only other use). Hardcoding `true` left
+    // POST /api/auth/sign-in/email live on an instance the operator had configured as SSO-only, so any
+    // account that still carried a password could sign in around the IdP — and around whatever the IdP
+    // enforces, such as MFA, conditional access, or deprovisioning.
+    enabled: EMAIL_AUTH_ENABLED,
     // Matches ZUserPassword (min 8 / max 128); the upper+digit composition rule stays enforced
     // by ZUserPassword at the app layer (deferred policy modernization → design doc §10.6).
     minPasswordLength: 8,

--- a/apps/web/modules/auth/lib/session.test.ts
+++ b/apps/web/modules/auth/lib/session.test.ts
@@ -1,10 +1,17 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 // Mock the Better Auth instance so the test never loads the real auth.ts graph (Redis/prisma/etc.).
-const { getSessionMock } = vi.hoisted(() => ({ getSessionMock: vi.fn() }));
+const { getSessionMock, findUniqueMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  findUniqueMock: vi.fn(),
+}));
 
 vi.mock("@/modules/auth/lib/auth", () => ({
   auth: { api: { getSession: getSessionMock } },
+}));
+
+vi.mock("@formbricks/database", () => ({
+  prisma: { user: { findUnique: findUniqueMock } },
 }));
 
 // `next/headers` and `server-only` are stubbed globally in vitestSetup; the mocked
@@ -17,6 +24,8 @@ describe("getSession — Better Auth DAL (ENG-1054)", () => {
   beforeEach(() => {
     vi.resetModules();
     getSessionMock.mockReset();
+    findUniqueMock.mockReset();
+    findUniqueMock.mockResolvedValue({ isActive: true });
   });
 
   test("returns null when Better Auth has no session", async () => {
@@ -50,5 +59,34 @@ describe("getSession — Better Auth DAL (ENG-1054)", () => {
     });
     const getSession = await importGetSession();
     await expect(getSession()).resolves.toMatchObject({ expires: "2026-07-01T00:00:00.000Z" });
+  });
+
+  // Regression: `rejectInactiveUserOnSessionCreate` only gates session creation, and Better Auth
+  // serves the user from Redis + a 5-minute cookie cache — so without a live read a user deactivated
+  // after signing in kept full access for the life of a rolling 1-day session.
+  test("returns null when the user has been deactivated since signing in", async () => {
+    getSessionMock.mockResolvedValue({
+      session: { expiresAt: new Date("2026-07-01T00:00:00.000Z") },
+      user: { id: "user_abc123", email: "user@example.com", name: "Ada Lovelace" },
+    });
+    findUniqueMock.mockResolvedValue({ isActive: false });
+
+    const getSession = await importGetSession();
+    await expect(getSession()).resolves.toBeNull();
+    expect(findUniqueMock).toHaveBeenCalledWith({
+      where: { id: "user_abc123" },
+      select: { isActive: true },
+    });
+  });
+
+  test("returns null when the session's user row no longer exists", async () => {
+    getSessionMock.mockResolvedValue({
+      session: { expiresAt: new Date("2026-07-01T00:00:00.000Z") },
+      user: { id: "deleted_user", email: "gone@example.com", name: "Gone" },
+    });
+    findUniqueMock.mockResolvedValue(null);
+
+    const getSession = await importGetSession();
+    await expect(getSession()).resolves.toBeNull();
   });
 });

--- a/apps/web/modules/auth/lib/session.ts
+++ b/apps/web/modules/auth/lib/session.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { headers } from "next/headers";
 import { cache } from "react";
+import { prisma } from "@formbricks/database";
 import type { Session } from "@formbricks/types/auth";
 import { auth } from "@/modules/auth/lib/auth";
 
@@ -19,9 +20,32 @@ import { auth } from "@/modules/auth/lib/auth";
  * resolves to `null`: Better Auth deletes the credential session and issues a short-lived
  * two-factor cookie until the code is verified, so no authenticated session exists yet.
  */
+/**
+ * Deactivation must take effect on the *existing* session, not just the next sign-in.
+ *
+ * `rejectInactiveUserOnSessionCreate` only gates session *creation*, and Better Auth serves this
+ * session from Redis secondary storage and a 5-minute signed cookie cache, so neither the session
+ * record nor `result.user` reflects a user who was deactivated after signing in. Without this read a
+ * deactivated user keeps full access — server actions, v3 session routes, storage — for the life of a
+ * rolling 1-day session. `getProxySession` already performs the equivalent check for the middleware.
+ */
+const isUserActive = async (userId: string): Promise<boolean> => {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { isActive: true },
+  });
+
+  // A session whose user row is gone is not a session either.
+  return user?.isActive === true;
+};
+
 export const getSession = cache(async (): Promise<Session | null> => {
   const result = await auth.api.getSession({ headers: await headers() });
   if (!result?.user) {
+    return null;
+  }
+
+  if (!(await isUserActive(result.user.id))) {
     return null;
   }
 

--- a/apps/web/modules/auth/signup/actions.test.ts
+++ b/apps/web/modules/auth/signup/actions.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE } from "@formbricks/types/errors";
+import {
+  INVITE_TOKEN_INVALID_ERROR_CODE,
+  SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE,
+} from "@formbricks/types/errors";
 import { verifyInviteToken } from "@/lib/jwt";
+import { createMembership } from "@/lib/membership/service";
 import { getUserByEmail } from "@/lib/user/service";
 import { auth } from "@/modules/auth/lib/auth";
 import { getInvite, resolveInviteMatch } from "@/modules/auth/signup/lib/invite";
@@ -12,6 +16,7 @@ import { createUserAction } from "./actions";
 vi.mock("@formbricks/logger", () => ({
   logger: {
     error: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
@@ -89,7 +94,9 @@ describe("createUserAction — signup verification email callbackURL", () => {
     notificationSettings: { alert: {} },
   };
 
-  const baseInput = { name: "Ada", email: "Ada@Example.com", password: "Password123!" };
+  // Mirrors what signup-form.tsx actually posts: it always sends the field, as `inviteToken ?? ""`,
+  // so an uninvited sign-up arrives with an empty string rather than undefined.
+  const baseInput = { name: "Ada", email: "Ada@Example.com", password: "Password123!", inviteToken: "" };
 
   const newCtx = () => ({ auditLoggingCtx: { organizationId: "", userId: "" } });
 
@@ -115,6 +122,7 @@ describe("createUserAction — signup verification email callbackURL", () => {
   });
 
   test("does not point the verification callback at /invite for invite signups (ENG-1527)", async () => {
+    vi.mocked(resolveInviteMatch).mockResolvedValue("valid");
     vi.mocked(verifyInviteToken).mockReturnValue({ inviteId: "invite-1", email: "ada@example.com" } as never);
     vi.mocked(getInvite).mockResolvedValue({
       id: "invite-1",
@@ -141,6 +149,50 @@ describe("createUserAction — signup verification email callbackURL", () => {
     });
   });
 
+  // Regression: signup-form.tsx sends `inviteToken: inviteToken ?? ""`, so an uninvited sign-up arrives
+  // with an empty string. Guarding the "unusable invite" check on `!== undefined` rather than
+  // truthiness rejected every public sign-up with INVITE_TOKEN_INVALID_ERROR_CODE.
+  test.each(["", "   ", undefined])(
+    "treats %p as no invite and completes an ordinary sign-up",
+    async (inviteToken) => {
+      vi.mocked(resolveInviteMatch).mockResolvedValue("missing");
+
+      const result = await createUserAction({
+        ctx: newCtx(),
+        parsedInput: { ...baseInput, inviteToken },
+      } as never);
+
+      expect(result).toEqual({ success: true });
+      expect(auth.api.signUpEmail).toHaveBeenCalled();
+      // No invite means no membership grant — the org-creation path handles it instead.
+      expect(createMembership).not.toHaveBeenCalled();
+    }
+  );
+
+  // Regression: an invite binds a role in an organization to one address. Accepting it only on a valid
+  // signature meant a leaked or forwarded invite link could be redeemed with any address.
+  test.each(["email_mismatch", "invalid_or_expired", "verification_error", "missing"] as const)(
+    "refuses to grant membership when the invite resolves as %s",
+    async (inviteMatch) => {
+      vi.mocked(resolveInviteMatch).mockResolvedValue(inviteMatch);
+      vi.mocked(verifyInviteToken).mockReturnValue({
+        inviteId: "invite-1",
+        email: "someone-else@example.com",
+      } as never);
+
+      await expect(
+        createUserAction({
+          ctx: newCtx(),
+          parsedInput: { ...baseInput, inviteToken: "invite-jwt-123" },
+        } as never)
+        // The stable code, not just "some error": the sign-up form maps this to localized copy, so a
+        // regression to a raw message would break the UI while still passing a bare toThrow().
+      ).rejects.toThrow(INVITE_TOKEN_INVALID_ERROR_CODE);
+
+      expect(createMembership).not.toHaveBeenCalled();
+    }
+  );
+
   test("treats a duplicate email as already-existed without post-creation side effects", async () => {
     vi.mocked(auth.api.signUpEmail).mockRejectedValue(new Error("user already exists"));
     vi.mocked(getUserByEmail).mockResolvedValue(createdUser as never);
@@ -161,12 +213,17 @@ describe("createUserAction — personal email domain block (Cloud)", () => {
     locale: "en-US",
     notificationSettings: { alert: {} },
   };
-  const blockedInput = { name: "Spammer", email: "spammer@gmail.com", password: "Password123!" };
+  const blockedInput = {
+    name: "Spammer",
+    email: "spammer@gmail.com",
+    password: "Password123!",
+    inviteToken: "",
+  };
   const newCtx = () => ({ auditLoggingCtx: { organizationId: "", userId: "" } });
 
   beforeEach(() => {
     vi.resetAllMocks();
-    constantsOverrides.IS_FORMBRICKS_CLOUD = true; // this suite runs as Formbricks Cloud
+    constantsOverrides.IS_FORMBRICKS_CLOUD = true;
     constantsOverrides.SIGNUP_DOMAIN_CHECK_ON_INVITES = false;
     vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true } as never);
     vi.mocked(getUserByEmail).mockResolvedValue(createdUser as never);
@@ -211,18 +268,21 @@ describe("createUserAction — personal email domain block (Cloud)", () => {
   test("blocks when the invite email does not match the signup email", async () => {
     vi.mocked(resolveInviteMatch).mockResolvedValue("email_mismatch");
 
+    // A mismatched invite is now rejected outright rather than merely losing its domain exemption, so
+    // no user row is created for it either.
     await expect(
       createUserAction({
         ctx: newCtx(),
         parsedInput: { ...blockedInput, inviteToken: "invite-jwt-123" },
       } as never)
-    ).rejects.toThrow(SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE);
+    ).rejects.toThrow(INVITE_TOKEN_INVALID_ERROR_CODE);
     expect(auth.api.signUpEmail).not.toHaveBeenCalled();
   });
 
   test("blocks a personal-domain invite when the kill-switch is enabled", async () => {
     constantsOverrides.SIGNUP_DOMAIN_CHECK_ON_INVITES = true;
-    // Kill-switch on: the invite exemption isn't consulted at all, so resolveInviteMatch is irrelevant.
+    // The invite itself is usable; the kill-switch is what removes its domain exemption.
+    vi.mocked(resolveInviteMatch).mockResolvedValue("valid");
 
     await expect(
       createUserAction({

--- a/apps/web/modules/auth/signup/actions.ts
+++ b/apps/web/modules/auth/signup/actions.ts
@@ -4,6 +4,7 @@ import { cookies } from "next/headers";
 import { z } from "zod";
 import { logger } from "@formbricks/logger";
 import {
+  INVITE_TOKEN_INVALID_ERROR_CODE,
   InvalidInputError,
   PASSWORD_COMPROMISED_ERROR_CODE,
   SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE,
@@ -131,6 +132,17 @@ async function handleInviteAcceptance(
   inviteToken: string,
   user: TCreatedUser
 ): Promise<void> {
+  // An invite grants a specific address a specific role in a specific organization. Verifying the
+  // signature and loading the row is not enough: without matching the token's email against the account
+  // being created, anyone holding an invite link — they get forwarded, pasted into tickets, and land in
+  // referrer logs — could redeem it with an arbitrary address and take the invited role, which may be
+  // manager or owner. `resolveInviteMatch` also enforces the invite's expiry, which this path skipped.
+  const inviteMatch = await resolveInviteMatch(inviteToken, user.email);
+  if (inviteMatch !== "valid") {
+    logger.warn({ inviteMatch }, "Rejected invite acceptance during sign-up");
+    throw new InvalidInputError(INVITE_TOKEN_INVALID_ERROR_CODE);
+  }
+
   const inviteTokenData = verifyInviteToken(inviteToken);
   const invite = await getInvite(inviteTokenData.inviteId);
 
@@ -263,14 +275,23 @@ export const createUserAction = actionClient.inputSchema(ZCreateUserAction).acti
     await applyIPRateLimit(rateLimitConfigs.auth.signup);
     await verifyTurnstileIfConfigured(parsedInput.turnstileToken);
 
+    // Normalized once, up front, and used for every downstream decision. The sign-up form always sends
+    // this field as `inviteToken ?? ""`, so an ordinary uninvited sign-up arrives with an empty string —
+    // anything blank has to mean "no invite" everywhere, or the checks below disagree with
+    // `handlePostUserCreation` about which path the request is on.
+    const inviteToken = parsedInput.inviteToken?.trim() || undefined;
+    const inviteMatch = await resolveInviteMatch(inviteToken, parsedInput.email);
+
+    // A supplied-but-unusable invite is rejected before the user row is created, so a bad token can't
+    // leave an orphaned account behind (handleInviteAcceptance would otherwise throw after signup).
+    if (inviteToken && inviteMatch !== "valid") {
+      logger.warn({ inviteMatch }, "Rejected sign-up with an unusable invite token");
+      throw new InvalidInputError(INVITE_TOKEN_INVALID_ERROR_CODE);
+    }
+
     // Formbricks Cloud only: reject personal/free/disposable email domains before any user is created.
     // Invited users are exempt unless SIGNUP_DOMAIN_CHECK_ON_INVITES is enabled.
-    if (
-      await isSignupEmailDomainBlocked(
-        parsedInput.email,
-        async () => (await resolveInviteMatch(parsedInput.inviteToken, parsedInput.email)) === "valid"
-      )
-    ) {
+    if (await isSignupEmailDomainBlocked(parsedInput.email, async () => inviteMatch === "valid")) {
       throw new InvalidInputError(SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE);
     }
 
@@ -288,7 +309,7 @@ export const createUserAction = actionClient.inputSchema(ZCreateUserAction).acti
     });
 
     if (!userAlreadyExisted && user) {
-      await handlePostUserCreation(ctx, user, parsedInput.inviteToken);
+      await handlePostUserCreation(ctx, user, inviteToken);
 
       await subscribeUserToMailingList({
         email: user.email,
@@ -310,7 +331,7 @@ export const createUserAction = actionClient.inputSchema(ZCreateUserAction).acti
           ...attributionProperties,
           auth_provider: "credentials",
           email_domain: user.email.split("@")[1],
-          signup_source: parsedInput.inviteToken ? "invite" : "direct",
+          signup_source: inviteToken ? "invite" : "direct",
           invite_organization_id: ctx.auditLoggingCtx.organizationId ?? null,
         },
         ctx.auditLoggingCtx.organizationId

--- a/apps/web/modules/auth/signup/components/signup-form.tsx
+++ b/apps/web/modules/auth/signup/components/signup-form.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import Turnstile, { useTurnstile } from "react-turnstile";
 import { z } from "zod";
 import {
+  INVITE_TOKEN_INVALID_ERROR_CODE,
   PASSWORD_COMPROMISED_ERROR_CODE,
   SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE,
 } from "@formbricks/types/errors";
@@ -158,6 +159,12 @@ export const SignupForm = ({
         } else if (errorMessage === PASSWORD_COMPROMISED_ERROR_CODE) {
           // Breached password: surface under the password field with a clear, actionable message.
           form.setError("password", { type: "manual", message: t("auth.password_compromised") });
+        } else if (errorMessage === INVITE_TOKEN_INVALID_ERROR_CODE) {
+          // Reachable when the invite expires or is revoked between this page rendering and the form
+          // being submitted. Reuses the existing invite copy rather than naming the specific reason,
+          // matching the server, which returns one code for expired / revoked / wrong-address so it
+          // cannot be used to probe which invites exist.
+          toast.error(t("auth.invite.invite_not_found_description"));
         } else {
           toast.error(errorMessage);
         }

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
@@ -64,7 +64,14 @@ describe("rateLimitConfigs", () => {
 
     test("should have all auth configurations", () => {
       const authConfigs = Object.keys(rateLimitConfigs.auth);
-      expect(authConfigs).toEqual(["login", "signup", "forgotPassword", "verifyEmail"]);
+      expect(authConfigs).toEqual(["login", "signup", "forgotPassword", "verifyEmail", "emailToken"]);
+      // The values, not just the key: emailToken throttles an unauthenticated endpoint that also
+      // reveals whether an address is registered, so a loosened quota is a security regression.
+      expect(rateLimitConfigs.auth.emailToken).toEqual({
+        interval: 3600,
+        allowedPerInterval: 10,
+        namespace: "auth:email-token",
+      });
     });
 
     test("should have all API configurations", () => {

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.ts
@@ -5,6 +5,7 @@ export const rateLimitConfigs = {
     signup: { interval: 3600, allowedPerInterval: 30, namespace: "auth:signup" }, // 30 per hour
     forgotPassword: { interval: 3600, allowedPerInterval: 5, namespace: "auth:forgot" }, // 5 per hour
     verifyEmail: { interval: 3600, allowedPerInterval: 10, namespace: "auth:verify" }, // 10 per hour
+    emailToken: { interval: 3600, allowedPerInterval: 10, namespace: "auth:email-token" }, // 10 per hour — unauthenticated, tells the caller whether an email is registered
   },
 
   // API endpoints - higher limits for legitimate usage

--- a/apps/web/modules/ee/teams/team-list/actions.ts
+++ b/apps/web/modules/ee/teams/team-list/actions.ts
@@ -14,6 +14,7 @@ import {
   getTeamDetails,
   updateTeamDetails,
 } from "@/modules/ee/teams/team-list/lib/team";
+import { hasWorkspaceAccessChanges } from "@/modules/ee/teams/team-list/lib/workspace-access";
 import { ZTeamSettingsFormSchema } from "@/modules/ee/teams/team-list/types/team";
 
 const ZCreateTeamAction = z.object({
@@ -132,6 +133,23 @@ export const updateTeamDetailsAction = authenticatedActionClient.inputSchema(ZUp
     ctx.auditLoggingCtx.organizationId = organizationId;
     ctx.auditLoggingCtx.teamId = parsedInput.teamId;
     const oldObject = await getTeamDetails(parsedInput.teamId);
+
+    // A team admin may be a plain org `member`, and this input carries the team's full workspace grant
+    // list — so without this gate they could grant their own team `manage` on every workspace in the
+    // organization. Changing workspace access stays owner/manager-only, matching what the UI offers.
+    if (hasWorkspaceAccessChanges(oldObject?.workspaces ?? [], parsedInput.data.workspaces)) {
+      await checkAuthorizationUpdated({
+        userId: ctx.user.id,
+        organizationId,
+        access: [
+          {
+            type: "organization",
+            roles: ["owner", "manager"],
+          },
+        ],
+      });
+    }
+
     const result = await updateTeamDetails(parsedInput.teamId, parsedInput.data);
     ctx.auditLoggingCtx.oldObject = oldObject;
     ctx.auditLoggingCtx.newObject = await getTeamDetails(parsedInput.teamId);

--- a/apps/web/modules/ee/teams/team-list/lib/workspace-access.test.ts
+++ b/apps/web/modules/ee/teams/team-list/lib/workspace-access.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "vitest";
+import { hasWorkspaceAccessChanges } from "./workspace-access";
+
+describe("hasWorkspaceAccessChanges", () => {
+  test("reports no change when the submitted grants match the stored ones", () => {
+    const current = [
+      { workspaceId: "ws-1", permission: "read" as const },
+      { workspaceId: "ws-2", permission: "manage" as const },
+    ];
+
+    expect(hasWorkspaceAccessChanges(current, current)).toBe(false);
+  });
+
+  test("reports no change when the same grants arrive in a different order", () => {
+    expect(
+      hasWorkspaceAccessChanges(
+        [
+          { workspaceId: "ws-1", permission: "read" as const },
+          { workspaceId: "ws-2", permission: "manage" as const },
+        ],
+        [
+          { workspaceId: "ws-2", permission: "manage" as const },
+          { workspaceId: "ws-1", permission: "read" as const },
+        ]
+      )
+    ).toBe(false);
+  });
+
+  // The escalation this guards: a team admin submitting an extra workspace, or upgrading an existing
+  // grant, to give their own team access org-wide.
+  test("reports a change when a workspace is added", () => {
+    expect(
+      hasWorkspaceAccessChanges(
+        [{ workspaceId: "ws-1", permission: "read" as const }],
+        [
+          { workspaceId: "ws-1", permission: "read" as const },
+          { workspaceId: "ws-victim", permission: "manage" as const },
+        ]
+      )
+    ).toBe(true);
+  });
+
+  test("reports a change when a permission is escalated", () => {
+    expect(
+      hasWorkspaceAccessChanges(
+        [{ workspaceId: "ws-1", permission: "read" as const }],
+        [{ workspaceId: "ws-1", permission: "manage" as const }]
+      )
+    ).toBe(true);
+  });
+
+  test("reports a change when a workspace is removed", () => {
+    expect(
+      hasWorkspaceAccessChanges(
+        [
+          { workspaceId: "ws-1", permission: "read" as const },
+          { workspaceId: "ws-2", permission: "read" as const },
+        ],
+        [{ workspaceId: "ws-1", permission: "read" as const }]
+      )
+    ).toBe(true);
+  });
+
+  test("reports a change when a workspace is swapped for another", () => {
+    expect(
+      hasWorkspaceAccessChanges(
+        [{ workspaceId: "ws-1", permission: "read" as const }],
+        [{ workspaceId: "ws-victim", permission: "read" as const }]
+      )
+    ).toBe(true);
+  });
+
+  // Duplicates must not let a submission pad its length to match the stored count.
+  test("reports a change when a duplicated workspace masks an added one", () => {
+    expect(
+      hasWorkspaceAccessChanges(
+        [
+          { workspaceId: "ws-1", permission: "read" as const },
+          { workspaceId: "ws-2", permission: "read" as const },
+        ],
+        [
+          { workspaceId: "ws-1", permission: "read" as const },
+          { workspaceId: "ws-1", permission: "read" as const },
+          { workspaceId: "ws-victim", permission: "manage" as const },
+        ]
+      )
+    ).toBe(true);
+  });
+
+  // The harder duplicate: the *last* entry matches the stored grant, so a `Map` keyed on workspaceId
+  // collapses to something equal to `current` and the gate would be skipped, while an earlier entry
+  // carries the escalated permission. Raised by CodeRabbit on #8680.
+  test("reports a change when a duplicate hides an escalated permission behind a matching one", () => {
+    expect(
+      hasWorkspaceAccessChanges(
+        [{ workspaceId: "ws-1", permission: "read" as const }],
+        [
+          { workspaceId: "ws-1", permission: "manage" as const },
+          { workspaceId: "ws-1", permission: "read" as const },
+        ]
+      )
+    ).toBe(true);
+  });
+});

--- a/apps/web/modules/ee/teams/team-list/lib/workspace-access.ts
+++ b/apps/web/modules/ee/teams/team-list/lib/workspace-access.ts
@@ -1,0 +1,52 @@
+import { type TTeamPermission } from "@/modules/ee/teams/workspace-teams/types/team";
+
+type TWorkspaceGrant = {
+  workspaceId: string;
+  permission: TTeamPermission;
+};
+
+/**
+ * True when a team-settings submission would add, remove, or re-scope any of the team's workspace
+ * grants.
+ *
+ * `updateTeamDetailsAction` is reachable by an org owner/manager *or* a team admin, and a team admin
+ * may be a plain org `member`. Its input carries the team's whole workspace grant list, so without
+ * this check a team admin could grant their own team `manage` on every workspace in the organization —
+ * i.e. read/write on all surveys, responses, and contacts — while the UI only ever offered them the
+ * members section (workspace selects are disabled for non-owners in `workspace-row.tsx`).
+ *
+ * Comparing the submitted list against the stored one lets the member-management path keep working
+ * (it round-trips the existing grants unchanged) while any actual access change requires owner/manager.
+ */
+export const hasWorkspaceAccessChanges = (
+  current: readonly TWorkspaceGrant[],
+  submitted: readonly TWorkspaceGrant[]
+): boolean => {
+  const currentByWorkspace = new Map(current.map(({ workspaceId, permission }) => [workspaceId, permission]));
+
+  const submittedByWorkspace = new Map(
+    submitted.map(({ workspaceId, permission }) => [workspaceId, permission])
+  );
+
+  // A repeated workspaceId is treated as a change so the owner/manager gate applies. `Map` keeps the
+  // last entry for a duplicate, so `[{ws1, manage}, {ws1, read}]` would otherwise compare equal to a
+  // stored `read` grant and skip the gate. `updateTeamDetails` already rejects duplicates (it counts
+  // the submitted ids against a distinct `in` query, so the lengths disagree), which is why this was
+  // not exploitable — but that makes the outcome depend on a check in a different module. Deciding it
+  // here keeps this function correct on its own terms. Raised by CodeRabbit on #8680.
+  if (submittedByWorkspace.size !== submitted.length) {
+    return true;
+  }
+
+  if (currentByWorkspace.size !== submittedByWorkspace.size) {
+    return true;
+  }
+
+  for (const [workspaceId, permission] of submittedByWorkspace) {
+    if (currentByWorkspace.get(workspaceId) !== permission) {
+      return true;
+    }
+  }
+
+  return false;
+};

--- a/apps/web/modules/survey/link/lib/data.ts
+++ b/apps/web/modules/survey/link/lib/data.ts
@@ -125,7 +125,20 @@ export const getSurveyWithMetadata = reactCache(async (surveyId: string) => {
       throw new ResourceNotFoundError("Survey", surveyId);
     }
 
-    return transformPrismaSurvey<TSurvey>(survey);
+    const transformedSurvey = transformPrismaSurvey<TSurvey>(survey);
+
+    // This survey object is handed to a client component on the *public* link-survey page, so every
+    // field in it ends up in the page payload for anonymous visitors. Follow-up configuration carries
+    // internal recipient addresses, subjects and email bodies, and segment filters carry targeting
+    // rules built from contact attributes — none of which the survey renderer reads. They are selected
+    // above only because `TSurvey` requires the keys, so blank them out before they leave the server.
+    return {
+      ...transformedSurvey,
+      followUps: [],
+      ...(transformedSurvey.segment
+        ? { segment: { ...transformedSurvey.segment, filters: [], description: null } }
+        : {}),
+    };
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
       throw new DatabaseError(error.message);

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -114,7 +114,13 @@ deployment:
   # AI_OPENAI_COMPATIBLE_PROVIDER_NAME: vllm
   # AI_OPENAI_COMPATIBLE_SUPPORTS_STRUCTURED_OUTPUTS: "1"
   # Secret values can use valueFrom.secretKeyRef; omit unused provider variables.
-  env: {}
+  env:
+    # The app sits behind exactly one reverse proxy (Traefik/Envoy) in this chart, so the client address
+    # is the last X-Forwarded-For entry. Pinned here rather than relying on the code default (also 1) so
+    # the assumption is visible next to the ingress it describes. Raise it if you put further proxies —
+    # a CDN, a corporate load balancer — in front of the ingress; setting it higher than the real chain
+    # lets callers spoof their address by prepending entries.
+    TRUSTED_PROXY_HOP_COUNT: "1"
 
   # Tolerations for scheduling pods on tainted nodes
   tolerations: []

--- a/packages/survey-ui/src/components/general/element-media.tsx
+++ b/packages/survey-ui/src/components/general/element-media.tsx
@@ -1,7 +1,13 @@
 import { Download, ExternalLink } from "lucide-react";
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { checkForLoomUrl, checkForVimeoUrl, checkForYoutubeUrl, convertToEmbedUrl } from "@/lib/video";
+import {
+  checkForLoomUrl,
+  checkForVimeoUrl,
+  checkForYoutubeUrl,
+  convertToEmbedUrl,
+  isSafeMediaUrl,
+} from "@/lib/video";
 
 //Function to add extra params to videoUrls in order to reduce video controls
 const getVideoUrlWithParams = (videoUrl: string): string => {
@@ -17,6 +23,10 @@ const getVideoUrlWithParams = (videoUrl: string): string => {
   return videoUrl;
 };
 
+/** Validated media URL, or `undefined` when it must not reach a `src`/`href`. */
+const asSafeMediaUrl = (url: string | undefined): string | undefined =>
+  url && isSafeMediaUrl(url) ? url : undefined;
+
 interface ElementMediaProps {
   imgUrl?: string;
   videoUrl?: string;
@@ -24,10 +34,16 @@ interface ElementMediaProps {
 }
 
 function ElementMedia({ imgUrl, videoUrl, altText = "Image" }: Readonly<ElementMediaProps>): React.ReactNode {
-  const videoUrlWithParams = videoUrl ? getVideoUrlWithParams(videoUrl) : undefined;
+  // Every sink is validated, not just the href. `ZStorageUrl` now rejects unsafe schemes on write, but
+  // this component renders survey JSON straight from the API, and rows written before that validation
+  // can still carry a `javascript:`/`data:` URL. An unsafe value in `<iframe src>` executes; in
+  // `<img src>` it does not, but neither should reach the DOM from stored data.
+  const safeVideoUrl = asSafeMediaUrl(videoUrl ? getVideoUrlWithParams(videoUrl) : undefined);
+  const safeImgUrl = asSafeMediaUrl(imgUrl);
+  const safeHref = asSafeMediaUrl(imgUrl ?? convertToEmbedUrl(videoUrl ?? ""));
   const [isLoading, setIsLoading] = React.useState(true);
 
-  if (!imgUrl && !videoUrl) {
+  if (!safeImgUrl && !safeVideoUrl) {
     return null;
   }
 
@@ -36,10 +52,10 @@ function ElementMedia({ imgUrl, videoUrl, altText = "Image" }: Readonly<ElementM
       {isLoading ? (
         <div className="absolute inset-auto flex h-full w-full animate-pulse items-center justify-center rounded-md bg-slate-200" />
       ) : null}
-      {imgUrl ? (
+      {safeImgUrl ? (
         <img
-          key={imgUrl}
-          src={imgUrl}
+          key={safeImgUrl}
+          src={safeImgUrl}
           alt={altText}
           className={cn("mx-auto max-h-[40dvh] rounded-md object-contain", isLoading ? "opacity-0" : "")}
           onLoad={() => {
@@ -50,11 +66,11 @@ function ElementMedia({ imgUrl, videoUrl, altText = "Image" }: Readonly<ElementM
           }}
         />
       ) : null}
-      {videoUrlWithParams ? (
+      {safeVideoUrl ? (
         <div className="relative">
           <div className="rounded-md bg-black">
             <iframe
-              src={videoUrlWithParams}
+              src={safeVideoUrl}
               title="Question video"
               className={cn("aspect-video w-full rounded-md border-0", isLoading ? "opacity-0" : "")}
               onLoad={() => {
@@ -70,7 +86,7 @@ function ElementMedia({ imgUrl, videoUrl, altText = "Image" }: Readonly<ElementM
         </div>
       ) : null}
       <a
-        href={imgUrl ?? convertToEmbedUrl(videoUrl ?? "")}
+        href={safeHref}
         target="_blank"
         rel="noreferrer"
         aria-label="Open in new tab"

--- a/packages/survey-ui/src/index.ts
+++ b/packages/survey-ui/src/index.ts
@@ -35,6 +35,7 @@ export {
 export { Matrix, type MatrixProps, type MatrixOption } from "@/components/elements/matrix";
 export { DateElement, type DateElementProps } from "@/components/elements/date";
 export { getDateFnsLocale } from "@/lib/locale";
+export { isSafeMediaUrl } from "@/lib/video";
 export {
   PictureSelect,
   type PictureSelectProps,

--- a/packages/survey-ui/src/lib/video.test.ts
+++ b/packages/survey-ui/src/lib/video.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "vitest";
-import { checkForLoomUrl, checkForVimeoUrl, checkForYoutubeUrl, convertToEmbedUrl } from "./video";
+import {
+  checkForLoomUrl,
+  checkForVimeoUrl,
+  checkForYoutubeUrl,
+  convertToEmbedUrl,
+  isSafeMediaUrl,
+} from "./video";
 
 describe("checkForYoutubeUrl", () => {
   test("returns true for valid YouTube URLs with https", () => {
@@ -171,4 +177,30 @@ describe("convertToEmbedUrl", () => {
       expect(convertToEmbedUrl("")).toBeUndefined();
     });
   });
+});
+
+describe("isSafeMediaUrl", () => {
+  // Regression: these values come from an editable survey field and used to be rendered straight into
+  // an anchor `href`, where a `javascript:` URL executes on click.
+  test.each([
+    "javascript:alert(document.domain)",
+    "JavaScript:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "not a url",
+    "",
+    // Protocol-relative: a browser resolves these against the page's scheme and lands on the
+    // attacker's origin, so they are not the "relative storage path" the leading slash suggests.
+    "//attacker.example/file",
+    String.raw`/\attacker.example/file`,
+  ])("rejects %s", (url) => {
+    expect(isSafeMediaUrl(url)).toBe(false);
+  });
+
+  test.each(["https://www.youtube.com/embed/abc", "http://example.com/a.png", "/storage/ws_1/private/a.png"])(
+    "accepts %s",
+    (url) => {
+      expect(isSafeMediaUrl(url)).toBe(true);
+    }
+  );
 });

--- a/packages/survey-ui/src/lib/video.ts
+++ b/packages/survey-ui/src/lib/video.ts
@@ -119,3 +119,23 @@ export const convertToEmbedUrl = (url: string): string | undefined => {
   // If no supported platform found, return undefined
   return undefined;
 };
+
+/**
+ * True when a stored media URL is safe to put in an `href`/`src`.
+ *
+ * `ZStorageUrl` now rejects non-http(s) schemes, but the renderer must not depend on that alone: it is
+ * handed survey JSON from the API, and rows written before that validation landed can still carry a
+ * `javascript:` or `data:` URL, which executes on click from an anchor `href`.
+ */
+export const isSafeMediaUrl = (url: string): boolean => {
+  // One leading slash, not followed by another slash or a backslash: that is a same-origin relative
+  // path. `//host` is protocol-relative and `/\host` is normalized to it by browsers, so both resolve
+  // cross-origin and must not be waved through as "relative".
+  if (/^\/(?![/\\])/.test(url)) return true; // relative storage path
+  try {
+    const { protocol } = new URL(url);
+    return protocol === "https:" || protocol === "http:";
+  } catch {
+    return false;
+  }
+};

--- a/packages/surveys/src/components/general/element-media.tsx
+++ b/packages/surveys/src/components/general/element-media.tsx
@@ -1,5 +1,6 @@
 import { useState } from "preact/hooks";
 import { useTranslation } from "react-i18next";
+import { isSafeMediaUrl } from "@formbricks/survey-ui";
 import { ExpandIcon } from "@/components/icons/expand-icon";
 import { ImageDownIcon } from "@/components/icons/image-down-icon";
 import { cn } from "@/lib/utils";
@@ -19,6 +20,10 @@ const getVideoUrlWithParams = (videoUrl: string): string => {
   return videoUrl;
 };
 
+/** Validated media URL, or `undefined` when it must not reach a `src`/`href`. */
+const asSafeMediaUrl = (url: string | undefined): string | undefined =>
+  url && isSafeMediaUrl(url) ? url : undefined;
+
 interface ElementMediaProps {
   imgUrl?: string;
   videoUrl?: string;
@@ -28,7 +33,13 @@ interface ElementMediaProps {
 
 export function ElementMedia({ imgUrl, videoUrl, altText = "Image", className }: ElementMediaProps) {
   const { t } = useTranslation();
-  const videoUrlWithParams = videoUrl ? getVideoUrlWithParams(videoUrl) : undefined;
+  // Every sink is validated, not just the href. `ZStorageUrl` now rejects unsafe schemes on write, but
+  // this component renders survey JSON straight from the API, and rows written before that validation
+  // can still carry a `javascript:`/`data:` URL. An unsafe value in `<iframe src>` executes; in
+  // `<img src>` it does not, but neither should reach the DOM from stored data.
+  const safeVideoUrl = asSafeMediaUrl(videoUrl ? getVideoUrlWithParams(videoUrl) : undefined);
+  const safeImgUrl = asSafeMediaUrl(imgUrl);
+  const safeHref = asSafeMediaUrl(imgUrl ?? convertToEmbedUrl(videoUrl ?? ""));
   const [isLoading, setIsLoading] = useState(true);
 
   return (
@@ -36,10 +47,10 @@ export function ElementMedia({ imgUrl, videoUrl, altText = "Image", className }:
       {isLoading ? (
         <div className="absolute inset-auto flex h-full w-full animate-pulse items-center justify-center rounded-md bg-slate-200" />
       ) : null}
-      {imgUrl ? (
+      {safeImgUrl ? (
         <img
-          key={imgUrl}
-          src={imgUrl}
+          key={safeImgUrl}
+          src={safeImgUrl}
           alt={altText}
           className={cn("rounded-custom mx-auto max-h-[40dvh] object-contain", isLoading ? "opacity-0" : "")}
           onLoad={() => {
@@ -50,11 +61,11 @@ export function ElementMedia({ imgUrl, videoUrl, altText = "Image", className }:
           }}
         />
       ) : null}
-      {videoUrlWithParams ? (
+      {safeVideoUrl ? (
         <div className="relative">
           <div className="rounded-custom bg-black">
             <iframe
-              src={videoUrlWithParams}
+              src={safeVideoUrl}
               title={t("common.question_video")}
               frameBorder="0"
               className={cn("rounded-custom aspect-video w-full", isLoading ? "opacity-0" : "")}
@@ -71,7 +82,7 @@ export function ElementMedia({ imgUrl, videoUrl, altText = "Image", className }:
         </div>
       ) : null}
       <a
-        href={imgUrl ? imgUrl : convertToEmbedUrl(videoUrl ?? "")}
+        href={safeHref}
         target="_blank"
         rel="noreferrer"
         aria-label={t("common.open_in_new_tab")}

--- a/packages/types/common.ts
+++ b/packages/types/common.ts
@@ -19,15 +19,20 @@ export const ZStorageUrl = z.string().refine(
     }
     // Otherwise validate as URL
     try {
-      // Using void to satisfy ESLint "no-new" rule while still validating the URL
-      void new URL(val);
-      return true;
+      const parsed = new URL(val);
+      // The scheme has to be constrained, not just parseable: these values are survey image/video
+      // URLs, organization logos and favicons, and styling background URLs, and they are rendered
+      // straight into `src`/`href` attributes. `new URL()` happily accepts `javascript:`, `data:` and
+      // `vbscript:`, so accepting any parseable URL turned an editable survey field into stored XSS —
+      // on a link survey that executes on the Formbricks origin, and in an embedded survey on the
+      // customer's own site.
+      return parsed.protocol === "https:" || parsed.protocol === "http:";
     } catch {
       return false;
     }
   },
   {
-    error: "Must be a valid URL or a relative storage path (/storage/...)",
+    error: "Must be a valid http(s) URL or a relative storage path (/storage/...)",
   }
 );
 

--- a/packages/types/errors.ts
+++ b/packages/types/errors.ts
@@ -210,6 +210,12 @@ export const SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE = "email_domain_not_allowed"
  */
 export const PASSWORD_COMPROMISED_ERROR_CODE = "password_compromised";
 
+/**
+ * Stable, locale-independent marker used when a sign-up presents an invite token that is malformed,
+ * expired, or issued to a different email address than the account being created.
+ */
+export const INVITE_TOKEN_INVALID_ERROR_CODE = "invite_token_invalid";
+
 export interface ApiErrorResponse {
   code:
     | "not_found"

--- a/turbo.json
+++ b/turbo.json
@@ -347,6 +347,7 @@
         "TURNSTILE_SITE_KEY",
         "RECAPTCHA_SITE_KEY",
         "RECAPTCHA_SECRET_KEY",
+        "TRUSTED_PROXY_HOP_COUNT",
         "TELEMETRY_DISABLED",
         "TERMS_URL",
         "VERSION",


### PR DESCRIPTION
## What & why

**2 of 4** from the pre-release security review, split out of #8667 by severity. **Severity: High** — 10 findings. Each is reachable by a low-privilege or unauthenticated caller.

> ⚠️ **Stacked on #8679.** Base is `claude/security-critical`, so this PR's diff shows only the high-severity work. Merge #8679 first, then this retargets to `main`.

### Auth and identity

- **Cross-purpose token reuse.** Every token in `lib/jwt.ts` is signed with the same `NEXTAUTH_SECRET`, and `verifyTokenForLinkSurvey` accepted a token carrying **no `surveyId` claim at all**. The unauthenticated `createEmailTokenAction` mints exactly such a token for any registered address, so it could be replayed as `?verify=<token>` to clear *any* link survey's email gate as that person — no account, no inbox access. Tokens are now bound to the survey, carry explicit `purpose` claims and TTLs, and that action is rate-limited (it also answers "is this address registered?"). Confirmed as a failing test against the real mint/verify pair before the fix.
- **Invite acceptance not bound to the invited address or expiry.** The signature was verified; the token's email was never compared to the account being created, and expiry was never checked. Anyone holding a forwarded invite link — they get pasted into tickets and land in referrer logs — could redeem it with an address of their own **at the invited role, up to `owner`**. `resolveInviteMatch` already implemented the check and was wired only to the domain exemption.
- **`EMAIL_AUTH_DISABLED=1` didn't disable credential auth.** It only hid the login form; `emailAndPassword.enabled` was hardcoded `true`, leaving `POST /api/auth/sign-in/email` live on an instance configured as SSO-only. Any account still carrying a password could sign in **around the IdP** — and around whatever the IdP enforces: MFA, conditional access, deprovisioning.
- **Deactivation didn't end existing sessions.** `rejectInactiveUserOnSessionCreate` gates session *creation* only, and the session is served from Redis secondary storage behind a 5-minute signed cookie cache. Someone offboarded through the org-users API kept full access — server actions, v3 session routes, storage — for the life of a rolling 1-day session. `getSession` now reads `isActive`, the check the middleware's `getProxySession` already did.

### Privilege escalation

- **Team admin could grant itself `manage` on every workspace.** `updateTeamDetailsAction` is reachable by a team admin, who may be a plain org `member`, and its input carries the team's whole workspace grant list. `manage` satisfies every downstream `read`/`readWrite`/`manage` check, so the forged grant is honoured by the normal authorization layer. The UI already restricted these controls to owners/managers (`workspace-row.tsx`) — client-side enforcement only. Implemented as "did the grant set change at all", not "is `manage` being added": a level-only check would let a team admin add themselves at `read` and escalate in a second request, and would miss removals.
- **Integration OAuth routes used the wrong authorization helper.** Notion / Airtable / Slack / Google Sheets gated credential *writes* with `hasUserWorkspaceAccess`, which its own docstring says must not be used for mutating routes: it admits the `billing` role and read-only team members. Either could bind **their own** provider account as the workspace integration and start receiving another team's responses — an exfiltration channel granted by the lowest-privilege roles, that looks like a legitimate integration in the UI.

### Exposure

- **OAuth tokens in the RSC payload.** The four integration settings pages passed `config.key` — the provider access token, plus a long-lived **refresh** token for Google Sheets and Airtable — into `"use client"` wrappers, so those credentials were serialized into the page payload and readable in the page source. A refresh token survives password changes and session revocation. Redaction matches credential-shaped field *names* rather than a fixed pair, so a token a provider adds later is blanked by default.
- **Public link-survey page leaked internal config.** The whole survey object went to a client component, so `followUps` — internal recipient addresses, subjects and email bodies — and the target segment's filters were serialized for anonymous visitors. The renderer reads neither.
- **`ZStorageUrl` accepted `javascript:` / `data:` / `vbscript:`.** It guards survey image and video URLs, organization logos and favicons, and styling background URLs, all rendered into `src`/`href` — so an editable survey field became **stored XSS**, executing on the Formbricks origin for a link survey and on the customer's own site for an embedded one. Constrained to http(s) or a relative `/storage/` path, plus `isSafeMediaUrl` at the anchor sink, since the renderer receives survey JSON from the API and rows written before this validation can still carry an unsafe URL. The sink check rejects protocol-relative `//host` and `/\host`, which a browser resolves cross-origin.

### Rate limiting

- **Client IP taken from client-supplied headers.** `getClientIpFromHeaders` believed `cf-connecting-ip`, then the **leftmost** `X-Forwarded-For` entry. XFF is appended to by each proxy, so that entry is whatever the client sent: rotating it minted a fresh bucket per request and defeated every IP limit (login 10/15min, forgot-password 5/hr, sign-up, public client API), and forged the `ipAddress` stored on responses and audit entries. The address now comes from the rightmost `TRUSTED_PROXY_HOP_COUNT` entries. `cf-connecting-ip` is **not consulted at all** — a hop count cannot establish Cloudflare provenance, and Traefik/Envoy/nginx pass that header through untouched, so trusting it would hand the spoof straight back.

## Linear ticket

[ENG-2042](https://linear.app/formbricks/issue/ENG-2042) covers the team-admin escalation (reported by D0HY30N, CVSS 8.8, PoC available — worth taking them up on validating the fix). The others are documented here; see the tracking comment on #8667 for the full mapping.

## How this was tested

- `pnpm test` (`apps/web`) — 531 files / 6614 tests ✅; `packages/surveys` 26/670 ✅; `packages/survey-ui` 4/73 ✅.
- `eslint` and `tsc --noEmit` clean for every touched file. `TRUSTED_PROXY_HOP_COUNT` added to `turbo.json` as `turbo/no-undeclared-env-vars` requires.
- Regression tests: cross-purpose token replay (`lib/jwt.test.ts`), deactivated-user sessions (`session.test.ts`), team workspace-grant escalation (`workspace-access.test.ts` — add/remove/level-change/reorder/duplicate/no-op), credential redaction incl. unknown future token names (`redact-credentials.test.ts`), unsafe and protocol-relative media URLs (`video-upload.test.ts`), trusted-hop IP resolution and the one-shot misconfiguration warning (`client-ip.test.ts`), invite email/expiry binding (`signup/actions.test.ts`).
- `pnpm build --filter=@formbricks/surveys... --force` after the `packages/surveys` change, per AGENTS.md.
- Not run here: Playwright E2E and manual QA — no Docker daemon or database in the authoring environment.

## QA / Test Plan

**How to test**

- [ ] Link survey with "Verify email before submission": a valid emailed link still lets you through and records the address. Then take a token minted by the email-verification action for survey A and replay it as `?verify=` on survey B → rejected.
- [ ] Invite flow: invite `a@example.com`, open the link, try to sign up as `b@example.com` → rejected; signing up as `a@example.com` still joins at the invited role. An expired invite is now rejected too.
- [ ] Set `EMAIL_AUTH_DISABLED=1`: the login form hides the credential fields **and** `POST /api/auth/sign-in/email` no longer authenticates. Unset → both work again.
- [ ] Deactivate a user via `PATCH /api/v2/organizations/<orgId>/users` while they have an active session → their next request is unauthenticated, rather than working for up to a day.
- [ ] Teams: as a **team admin who is a plain org member**, submit a team update with an extra workspace grant → rejected. Renaming the team and changing its membership still work. As an org owner/manager, workspace grants still save.
- [ ] Integrations: as an org `owner`, connect and disconnect Notion / Slack / Airtable / Google Sheets → unchanged. View the settings page source → no `access_token` / `refresh_token`. As a `billing`-role member, hit the OAuth start URL → 401.
- [ ] Survey editor: set an ending-card image URL to `javascript:alert(1)` → rejected by validation. A YouTube/Vimeo/Loom URL still renders.
- [ ] Public link survey page source: no follow-up recipients/subjects/bodies and no segment filter rules present.
- [ ] Client IP: with `TRUSTED_PROXY_HOP_COUNT` unset (default 1), send a forged `X-Forwarded-For` prefix **and** a forged `cf-connecting-ip` → the recorded `ipAddress` and the rate-limit bucket both follow the address the real proxy appended. Login and forgot-password limits still trip for a genuine client.

**Preconditions**

- Two organizations; a team whose workspace permission is exactly `readWrite`; a `billing`-role member; an Enterprise license for teams and SSO paths; both a Cloud and a self-hosted pass (`EMAIL_AUTH_DISABLED` and the proxy setting differ).

**Risks & regressions**

- **`TRUSTED_PROXY_HOP_COUNT` defaults to 1** — one trusted reverse proxy, which matches the Helm chart's Traefik/Envoy ingress, docker-compose behind a proxy, and Cloud. **A longer chain must raise it:** with a CDN in front of that proxy it is 2, and until it is raised the address resolves to the *inner* proxy's, so every client behind the CDN shares one rate-limit bucket. Setting it *higher* than the real chain re-opens the spoof. `0` is an explicit opt-out that identifies no client at all, because Next 16 gives route handlers no socket peer address to fall back on.
- Link-survey verification tokens now expire after 7 days and carry a purpose claim. Already-issued tokens have no `exp` and keep working, but any flow that stored one long-term should be re-checked.
- `ZStorageUrl` is stricter, so a pre-existing row holding a non-http(s) media URL will fail validation on the next save of that survey. Worth an audit query; this PR stops such rows rendering but does not clean them up.
- Integration credentials were readable by anyone who could open the settings page. Worth deciding whether to rotate the affected provider tokens as part of the release.
- Deactivation adds one indexed `user.findUnique` per `getSession`; `getSession` is wrapped in React `cache()`, so once per request.

**Migrations / env / cutover**

- No DB migrations.
- New env var `TRUSTED_PROXY_HOP_COUNT` (integer 0–10, **default 1**): documented in `.env.example`, declared in `turbo.json`, pinned to `"1"` in `charts/formbricks/values.yaml`. No action for a single-proxy deployment.
- New rate-limit bucket `auth.emailToken` (10/hour per IP); no configuration needed.
- New error code `invite_token_invalid`; no locale changes (the client maps it to existing translated copy).

## Merge order

1. #8679 (Critical)
2. **#PENDING_HIGH — this PR** (High)
3. #PENDING_MEDIUM (Medium)
4. #PENDING_LOW (Low)

---
_Generated by [Claude Code](https://claude.ai/code/session_011GyivGy7zu4oFftnKBZNGN)_