### PR TITLE
fix(security): harden the low-severity storage, authz and abuse paths [4/4 low]

### DIFF
--- a/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
@@ -97,10 +97,20 @@ describe("rateLimitConfigs", () => {
         "isSurveyResponsePresent",
         "validateSurveyPin",
         "licenseRecheck",
+        "unsplash",
         "inviteMember",
         "bulkInviteMembers",
         "generateExampleResponses",
       ]);
+
+      // Exact values, not just presence: this quota is the only thing bounding one account from
+      // exhausting the instance-wide UNSPLASH_ACCESS_KEY, so a loosened interval, allowance or
+      // namespace is a security regression and should fail here rather than in production.
+      expect(rateLimitConfigs.actions.unsplash).toEqual({
+        interval: 60,
+        allowedPerInterval: 30,
+        namespace: "action:unsplash",
+      });
     });
 
     test("should have all storage configurations", () => {
@@ -171,6 +181,7 @@ describe("rateLimitConfigs", () => {
         { config: rateLimitConfigs.api.clientEnvironment, identifier: "environment-id" },
         { config: rateLimitConfigs.actions.emailUpdate, identifier: "user-profile" },
         { config: rateLimitConfigs.actions.accountDeletion, identifier: "user-account-delete" },
+        { config: rateLimitConfigs.actions.unsplash, identifier: "user-unsplash" },
         { config: rateLimitConfigs.storage.upload, identifier: "storage-upload" },
         { config: rateLimitConfigs.storage.uploadPerWorkspace, identifier: "storage-upload-workspace" },
         { config: rateLimitConfigs.storage.delete, identifier: "storage-delete" },

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.ts
@@ -48,6 +48,7 @@ export const rateLimitConfigs = {
       namespace: "action:validate-survey-pin",
     }, // 10 per minute — prevents brute-force PIN guessing
     licenseRecheck: { interval: 60, allowedPerInterval: 5, namespace: "action:license-recheck" }, // 5 per minute
+    unsplash: { interval: 60, allowedPerInterval: 30, namespace: "action:unsplash" }, // 30 per minute per user — bounds one account exhausting the instance-wide UNSPLASH_ACCESS_KEY quota
     inviteMember: { interval: 3600 * 24, allowedPerInterval: 20, namespace: "action:invite-member" }, // 20 per day  — bounds invite-spam abuse
     bulkInviteMembers: {
       interval: 3600 * 24,

--- a/apps/web/modules/integrations/webhooks/actions.ts
+++ b/apps/web/modules/integrations/webhooks/actions.ts
@@ -141,6 +141,10 @@ export const updateWebhookAction = authenticatedActionClient.inputSchema(ZUpdate
 const ZTestEndpointAction = z.object({
   url: z.string(),
   webhookId: ZId.optional(),
+  // Required so the not-yet-created-webhook path has something to authorize against; without it this
+  // action did no authorization at all and any logged-in user — including a billing-only member with no
+  // product access — could make the server POST a signed test payload to any URL they named.
+  workspaceId: ZId,
   secret: z.string().optional(),
 });
 
@@ -173,6 +177,23 @@ export const testEndpointAction = authenticatedActionClient
 
       secret = webhookResult.data.secret ?? undefined;
     } else {
+      // No webhook yet: authorize against the workspace the webhook is being created in.
+      await checkAuthorizationUpdated({
+        userId: ctx.user.id,
+        organizationId: await getOrganizationIdFromWorkspaceId(parsedInput.workspaceId),
+        access: [
+          {
+            type: "organization",
+            roles: ["owner", "manager"],
+          },
+          {
+            type: "workspaceTeam",
+            minPermission: "readWrite",
+            workspaceId: parsedInput.workspaceId,
+          },
+        ],
+      });
+
       // New webhook, use the provided secret or generate a new one
       secret = parsedInput.secret ?? generateWebhookSecret();
     }

--- a/apps/web/modules/integrations/webhooks/components/add-webhook-modal.tsx
+++ b/apps/web/modules/integrations/webhooks/components/add-webhook-modal.tsx
@@ -75,6 +75,7 @@ export const AddWebhookModal = ({
       const testEndpointActionResult = await testEndpointAction({
         url: testEndpointInput,
         secret: webhookSecret,
+        workspaceId,
       });
 
       if (!testEndpointActionResult?.data) {

--- a/apps/web/modules/integrations/webhooks/components/webhook-settings-tab.tsx
+++ b/apps/web/modules/integrations/webhooks/components/webhook-settings-tab.tsx
@@ -76,6 +76,7 @@ export const WebhookSettingsTab = ({
       const testEndpointActionResult = await testEndpointAction({
         url: testEndpointInput,
         webhookId: webhook.id,
+        workspaceId: webhook.workspaceId,
       });
       if (!testEndpointActionResult?.data?.success) {
         const errorMessage = getFormattedErrorMessage(testEndpointActionResult);

--- a/apps/web/modules/storage/service.test.ts
+++ b/apps/web/modules/storage/service.test.ts
@@ -405,6 +405,29 @@ describe("storage service", () => {
       expect(result).toEqual(mockError);
       expect(deleteFileFromS3).toHaveBeenCalledTimes(1);
     });
+
+    // Regression: the key is `${id}/${accessType}/${fileName}`, so a `..` segment would delete
+    // objects outside the workspace prefix the caller was authorized against.
+    test.each([
+      "../../ws-victim/private/secret.pdf",
+      "sub/../../../ws-victim/private/secret.pdf",
+      "./file.jpg",
+    ])("should reject traversal in the file name: %s", async (fileName) => {
+      const result = await deleteFile("ws-456", "public" as TAccessType, fileName);
+
+      expect(result.ok).toBe(false);
+      expect(deleteFileFromS3).not.toHaveBeenCalled();
+    });
+
+    test("should still allow nested file paths without dot segments", async () => {
+      const mockSuccess = { ok: true, data: undefined } as MockedDeleteFileReturn;
+      vi.mocked(deleteFileFromS3).mockResolvedValue(mockSuccess);
+
+      const result = await deleteFile("ws-456", "public" as TAccessType, "survey-1/q-2/file.jpg");
+
+      expect(result).toEqual(mockSuccess);
+      expect(deleteFileFromS3).toHaveBeenCalledWith("ws-456/public/survey-1/q-2/file.jpg");
+    });
   });
 
   describe("deleteFilesByWorkspaceId", () => {
@@ -449,6 +472,40 @@ describe("storage service", () => {
   });
 
   describe("getFileStreamForDownload", () => {
+    // Regression: `fileName` comes from the `[...filePath]` route param and the key is
+    // `${id}/${accessType}/${fileName}`, so a `..` segment let a caller name an object outside their
+    // own workspace prefix — reachable with no auth at all through the `public/` access type, which
+    // skips authorizePrivateDownload. The `%252e`/`%2e` cases cover the extra decodeURIComponent the
+    // handler applies on top of Next's own param decoding.
+    test.each([
+      "../../ws-victim/private/secret.pdf",
+      "sub/../../../ws-victim/private/secret.pdf",
+      "%2e%2e/%2e%2e/ws-victim/private/secret.pdf",
+      "./secret.pdf",
+    ])("should reject traversal in the file name: %s", async (fileName) => {
+      const result = await getFileStreamForDownload(fileName, "ws-attacker", "public" as TAccessType);
+
+      expect(result.ok).toBe(false);
+      expect(getFileStream).not.toHaveBeenCalled();
+    });
+
+    test("should still allow nested file paths without dot segments", async () => {
+      const mockStreamResult = {
+        ok: true,
+        data: { body: new ReadableStream(), contentType: "image/jpeg", contentLength: 1 },
+      } as MockedFileStreamReturn;
+      vi.mocked(getFileStream).mockResolvedValue(mockStreamResult);
+
+      const result = await getFileStreamForDownload(
+        "survey-1/q-2/file.jpg",
+        "ws-456",
+        "public" as TAccessType
+      );
+
+      expect(result.ok).toBe(true);
+      expect(getFileStream).toHaveBeenCalledWith("ws-456/public/survey-1/q-2/file.jpg");
+    });
+
     test("should return file stream for public file", async () => {
       const mockStream = new ReadableStream();
       const mockStreamResult = {

--- a/apps/web/modules/storage/service.ts
+++ b/apps/web/modules/storage/service.ts
@@ -15,6 +15,21 @@ import { sanitizeFileName } from "./utils";
 
 const SAFE_FILE_PATH_SEGMENT = /^[A-Za-z0-9_-]+$/;
 
+/**
+ * Rejects relative path segments in a caller-supplied storage file name.
+ *
+ * Download/delete keys are built as `${id}/${accessType}/${fileName}`, and `fileName` arrives from the
+ * `[...filePath]` route param, so `..` segments let a caller step out of their own
+ * `workspaceId/accessType/` prefix and name another tenant's object — including a `private/` one via
+ * the unauthenticated `public/` route. Object stores treat keys opaquely and SigV4 signs the
+ * unnormalized path, so this does not resolve on a stock S3/MinIO backend; but whether one tenant can
+ * name another's file must not depend on how the storage backend or any proxy in front of it happens
+ * to treat dot segments. `fileName` legitimately contains `/` (upload nests it under
+ * `filePathSegments`), so only the segments themselves are constrained.
+ */
+const hasTraversalSegment = (fileName: string): boolean =>
+  fileName.split("/").some((segment) => segment === "." || segment === "..");
+
 export const getSignedUrlForUpload = async (
   fileName: string,
   workspaceId: string,
@@ -89,6 +104,13 @@ export const getFileStreamForDownload = async (
 ): Promise<Result<FileStreamResult, StorageError>> => {
   try {
     const fileNameDecoded = decodeURIComponent(fileName);
+
+    // Checked after the decode: the route param is already URL-decoded once, so a `%252e%252e`
+    // traversal only becomes `..` here.
+    if (hasTraversalSegment(fileName) || hasTraversalSegment(fileNameDecoded)) {
+      return err({ code: StorageErrorCode.InvalidInput });
+    }
+
     const primaryKey = `${primaryId}/${accessType}/${fileNameDecoded}`;
 
     const streamResult = await getFileStream(primaryKey);
@@ -116,6 +138,12 @@ export const deleteFile = async (
   fileName: string,
   fallbackId?: string
 ) => {
+  // Same reasoning as the download path: a `..` segment would let an authorized caller delete objects
+  // outside the workspace prefix they were authorized against.
+  if (hasTraversalSegment(fileName)) {
+    return err({ code: StorageErrorCode.InvalidInput });
+  }
+
   const result = await deleteFileFromS3(`${primaryId}/${accessType}/${fileName}`);
 
   if (!result.ok && result.error.code === StorageErrorCode.FileNotFoundError && fallbackId) {

--- a/apps/web/modules/survey/editor/actions.ts
+++ b/apps/web/modules/survey/editor/actions.ts
@@ -13,13 +13,15 @@ import {
   UNSPLASH_ALLOWED_DOMAINS,
 } from "@/lib/constants";
 import { capturePostHogEvent } from "@/lib/posthog";
-import { actionClient, authenticatedActionClient } from "@/lib/utils/action-client";
+import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import {
   getOrganizationIdFromSurveyId,
   getOrganizationIdFromWorkspaceId,
   getWorkspaceIdFromSurveyId,
 } from "@/lib/utils/helper";
+import { applyRateLimit } from "@/modules/core/rate-limit/helpers";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import { createActionClass } from "@/modules/survey/editor/lib/action-class";
 import { checkExternalUrlsPermission } from "@/modules/survey/editor/lib/check-external-urls-permission";
@@ -399,9 +401,16 @@ const ZGetImagesFromUnsplashAction = z.object({
   page: z.number().optional(),
 });
 
-export const getImagesFromUnsplashAction = actionClient
+// Authenticated: these spend the instance's UNSPLASH_ACCESS_KEY quota on the caller's behalf, and
+// plain `actionClient` left them reachable by anyone on the internet. Both are only ever called
+// from the survey editor, which already requires a session.
+export const getImagesFromUnsplashAction = authenticatedActionClient
   .inputSchema(ZGetImagesFromUnsplashAction)
-  .action(async ({ parsedInput }) => {
+  .action(async ({ parsedInput, ctx }) => {
+    // Per-user: neither action carries a workspace or survey id, so a session is the only thing to
+    // scope against, and the quota being spent belongs to the whole instance.
+    await applyRateLimit(rateLimitConfigs.actions.unsplash, ctx.user.id);
+
     if (!UNSPLASH_ACCESS_KEY) {
       throw new Error("Unsplash access key is not set");
     }
@@ -461,9 +470,14 @@ const ZTriggerDownloadUnsplashImageAction = z.object({
   downloadUrl: z.url(),
 });
 
-export const triggerDownloadUnsplashImageAction = actionClient
+// Authenticated: these spend the instance's UNSPLASH_ACCESS_KEY quota on the caller's behalf, and
+// plain `actionClient` left them reachable by anyone on the internet. Both are only ever called
+// from the survey editor, which already requires a session.
+export const triggerDownloadUnsplashImageAction = authenticatedActionClient
   .inputSchema(ZTriggerDownloadUnsplashImageAction)
-  .action(async ({ parsedInput }) => {
+  .action(async ({ parsedInput, ctx }) => {
+    await applyRateLimit(rateLimitConfigs.actions.unsplash, ctx.user.id);
+
     if (!isValidUnsplashUrl(parsedInput.downloadUrl)) {
       throw new Error("Invalid Unsplash URL");
     }


### PR DESCRIPTION
## What & why

**4 of 4** from the pre-release security review, split out of #8667 by severity. **Severity: Low** — 4 findings. None is a live bypass on a stock deployment; each removes a way for the next change to become one, or brings a permission into line with the rest of the API.

> ⚠️ **Stacked on #8681.** Base is `claude/security-medium`, so this PR's diff shows only the low-severity work. #8679 has merged; merge #8680 and #8681 before this one.

- **Relative path segments in storage keys.** Download and delete keys are built as `${id}/${accessType}/${fileName}`, and `fileName` comes from the `[...filePath]` route param, so `..` segments named an object outside the caller's own `workspaceId/accessType/` prefix — including a `private/` one through the unauthenticated `public/` route. This does **not** resolve on a stock S3/MinIO backend, which treats keys as opaque and signs the unnormalized path, so it is hardening rather than an exploit. But whether one tenant can name another's file should not depend on how the storage backend, or a proxy in front of it, happens to treat dot segments. Rejected on read and delete, and checked both before *and* after the decode because the download handler decodes twice (`%252e%252e` only becomes `..` on the second pass).

- **`testEndpointAction` unauthorized when `webhookId` was omitted.** Any logged-in user — including a billing-only member — could make the server POST a signed payload to a URL of their choosing. SSRF was already blocked by the pinned dispatcher (IP-pinned, `redirect: "manual"`); this closes the "who may use it" half.

- **Unsplash actions were unauthenticated** while spending the instance's `UNSPLASH_ACCESS_KEY`. Now behind `authenticatedActionClient` and rate-limited **per user** (30/min) — neither action carries a workspace or survey id to scope against, and the quota belongs to the whole instance, so a session is the only thing to key on.

- **`deleteWorkspaceAction` name-confirmation oracle.** It compared the typed workspace name *before* authorizing, so the mismatch error distinguished "wrong name" from "workspace you may not touch" — a cross-tenant workspace-name oracle.

## Removed from this PR: feedback-record deletion at `manage` level

An earlier revision raised feedback-record deletion from `write`/`readWrite` to `manage` on both the v3 gateway and the UI server action. **That has been dropped in favour of #8675 (ENG-1770)**, after @xernobyl [flagged the conflict](https://github.com/formbricks/formbricks/pull/8682#issuecomment-5116736738) and @mattinannt confirmed the call.

The reason is not merge convenience — #8675 is simply correct where mine was not. My change kept the *workspace* as the dimension and only raised the bar within it. But a feedback record's only tenancy is its feedback directory, and a directory is shared by every workspace assigned to it, so the record carries no workspace of its own. No workspace permission can therefore distinguish workspace A's records from workspace B's: a workspace-`manage` holder in B could still delete records that A's surveys ingested. #8675 removes the workspace path for record mutations entirely, which is the only thing that actually draws that line, and it also covers `update`, both the gateway and the server action, the UI affordances and the taxonomy routes.

Consequences of the removal, recorded so nothing is assumed:

- `apps/web/modules/hub/feedback-records-gateway.ts` and `apps/web/modules/ee/unify-feedback/actions.ts` are now byte-identical to their `claude/security-medium` versions, and `apps/web/modules/hub/feedback-records-gateway.test.ts` is gone from this PR. That also clears the add/add conflict with #8675, which creates the same test file, and means this PR no longer needs porting into the `feedback-records-gateway-authz.ts` module that #8648 extracts.
- This PR previously and incidentally closed the cross-org `delete`/`bulkDelete` paths, because org-level access control only models read/write and so could never satisfy `manage`. That is no longer closed here. It is **#8648's** to close for every operation at once — and note it is not closed by #8675 either, whose `hasApiKeyImplicitFeedbackDirectoryAccess` still returns `true` on `orgAccessControl?.write` before its mutation check. If #8675 lands before #8648, the cross-org delete path is open in the interim. Flagged on #8648 as a reason to keep it first.

## Linear ticket

Documented here rather than filed individually; see the tracking comment on #8667.

## How this was tested

- `npx vitest run modules/storage modules/core/rate-limit modules/integrations/webhooks modules/hub modules/ee/unify-feedback` (`apps/web`) — 32 files / 484 tests ✅ after the removal, including the untouched gateway suites.
- Whole-stack run after rebasing onto the post-#8679 `main`: 402 files / 5040 tests ✅ across every area the four PRs touch.
- `eslint` and `tsc --noEmit` clean for every touched file.
- Regression tests: storage path traversal on read and delete, raw and double-encoded (`storage/service.test.ts`); the rate-limit config surface (`rate-limit-configs.test.ts`).
- Not run here: Playwright E2E and manual QA — no Docker daemon or database in the authoring environment.

## QA / Test Plan

**How to test**

- [ ] Storage: uploading, downloading and deleting a survey file upload all still work. Requesting a download path containing an encoded `..` segment (e.g. `/storage/<workspaceId>/public/..%252f..%252f<otherWorkspaceId>%252fprivate%252ffile.pdf`) → rejected as invalid input rather than reaching the backend.
- [ ] Webhooks: "Test endpoint" still works when creating a webhook and on an existing webhook's settings tab. As a `billing`-role member, calling the action directly → rejected.
- [ ] Unsplash: the survey editor's image search and selection still work; hammering the search past 30 requests/minute as one user returns a rate-limit error. Signed-out callers are rejected.
- [ ] Workspace deletion: the confirm-by-name flow still works for an owner. For a workspace you have no access to, the error does not distinguish a wrong name from missing permission.
- [ ] Regression from the removal above: deleting a feedback record still behaves exactly as it does on `main` today (workspace `readWrite` in the UI, `write` over the gateway). The tightening now arrives via #8675, not this PR.

**Preconditions / test data**

- A `billing`-role member; a survey with a file-upload question and both public and private stored files; `UNSPLASH_ACCESS_KEY` configured; a second workspace the test user cannot access, for the deletion-oracle check.

**Risks & regressions**

- No user-visible permissions change remains in this PR. The feedback-record tightening that previously needed a release note has moved to #8675.
- Unsplash is now authenticated, so any non-editor caller of those actions (there should be none — they are only used by the survey editor) would break.
- The storage path check runs on every download and delete. It rejects only keys containing dot segments, which no legitimate client produces, but it is on a hot read path.

**Migrations / env / cutover**

- No DB migrations.
- New rate-limit bucket `actions.unsplash` (30/minute per user); no configuration needed.

## Merge order

1. ~~#8679 (Critical)~~ — merged as `f1114c1`
2. #8680 (High) — now targets `main`
3. #8681 (Medium)
4. **#8682 — this PR** (Low)
