### PR TITLE
chore: add breaking changes section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,26 @@ auto-links. No ticket? Say why. Closing a GitHub issue? Add "Fixes #123". -->
 
 <!-- REQUIRED for any UI change: attach before/after screenshots or a recording. No visual proof → sent back. -->
 
+## Breaking changes
+
+<!-- REQUIRED. Does this PR change a public contract in a way that could break existing integrations or
+self-hosted setups? Count as breaking: API/SDK request or response shape (renamed, removed, or retyped
+fields, or changed values like `EN` → `en-US`), removed/renamed endpoints or routes, changed webhook
+payloads, changed defaults, new/removed/renamed env vars or config, and DB migrations that need manual
+action. If YES:
+  1. Add the `breaking-change` label to this PR.
+  2. Fill the table below — one row per change. This text feeds the GitHub release notes and the
+     self-hoster migration guide, so write it for an external integrator, not for the team.
+If there are no breaking changes, leave "None" below. -->
+
+None
+
+<!-- Delete "None" above and use this table when there IS a breaking change:
+| Change | Before | After | Who's affected | Action required |
+| --- | --- | --- | --- | --- |
+| `language` field on responses | `EN`, `DE` | `en-US`, `de-DE` | API v1 consumers | Map the new BCP-47 locale codes in your integration |
+-->
+
 ## QA / Test Plan
 
 <!--

--- a/.github/workflows/pr-label-sync.yml
+++ b/.github/workflows/pr-label-sync.yml
@@ -1,0 +1,96 @@
+name: PR Label Sync
+
+# Keeps PR labels in sync with declared sections in the PR body (see .github/pull_request_template.md).
+# Generic engine: to drive a new label from a new "## <heading>" section, add one entry to RULES
+# below — no other changes needed.
+#
+# Currently configured:
+#   - "Breaking changes" section (a filled table / any content other than "None") -> `breaking-change`
+#     The Release QA audit filters on this label to compile release notes + the migration guide.
+#
+# Uses pull_request_target because adding a label needs a write-scoped token (incl. fork PRs). This is
+# safe here: the job only reads the PR *body* (data) and never checks out or runs PR code.
+# Note: pull_request_target always runs the workflow definition from the base branch, so changes here
+# take effect once merged to main — they do not self-run on their own introducing PR.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-label-sync-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Sync labels from PR body sections
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // A section is "declared" when it holds real content — a filled table or prose —
+            // i.e. it is neither empty nor a bare "None". Reusable default rule predicate.
+            const isDeclared = (content) => !(content === "" || /^none\.?$/i.test(content));
+
+            // Label rules. Add an entry to sync a new label from a new "## <heading>" PR-body section.
+            // `isActive(content)` decides whether the label should be present for the given section text.
+            const RULES = [
+              { heading: "Breaking changes", label: "breaking-change", isActive: isDeclared },
+            ];
+
+            const pr = context.payload.pull_request;
+            // Strip HTML comments so template guidance and example rows never count as content.
+            const body = (pr.body || "").replace(/<!--[\s\S]*?-->/g, "");
+
+            // Content under a "## <heading>" up to the next H2 (or end of body); null when absent.
+            const sectionContent = (heading) => {
+              const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+              const m = body.match(new RegExp(`^##\\s+${escaped}\\s*$`, "im"));
+              if (!m) return null;
+              const after = body.slice(m.index + m[0].length);
+              const nextH2 = after.search(/^##\s/m);
+              return (nextH2 === -1 ? after : after.slice(0, nextH2)).trim();
+            };
+
+            const current = new Set((pr.labels || []).map((l) => l.name));
+
+            for (const rule of RULES) {
+              const content = sectionContent(rule.heading);
+              if (content === null) {
+                core.info(`[${rule.label}] no "## ${rule.heading}" section found; leaving unchanged.`);
+                continue;
+              }
+              const active = rule.isActive(content);
+              const has = current.has(rule.label);
+              if (active && !has) {
+                await github.rest.issues.addLabels({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  labels: [rule.label],
+                });
+                core.info(`[${rule.label}] added.`);
+              } else if (!active && has) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: rule.label,
+                });
+                core.info(`[${rule.label}] removed.`);
+              } else {
+                core.info(`[${rule.label}] already in the correct state.`);
+              }
+            }


### PR DESCRIPTION
## What & why

A customer's integration broke when APIv1 started returning canonical locale codes (`EN` → `en-US`) with no announcement (ENG-2068). Root cause on the process side: nothing in the PR flow captures a public-contract change, so it can't be surfaced in the GitHub release notes or the self-hoster migration guide.

This does two things:

1. **PR template** — adds a **Breaking changes** section to `.github/pull_request_template.md`. Authors (and coding agents) declare whether the PR changes a public contract — API/SDK shape, values, endpoints, webhooks, defaults, env/config, or migrations — and fill a before → after table written for external integrators. Defaults to "None".
2. **Auto-label workflow** — `.github/workflows/pr-label-sync.yml` is a generic label-sync engine: a `RULES` table maps each `## <heading>` PR-body section to a label. It ships the `breaking-change` rule today (label added when the **Breaking changes** section declares a change, removed when it says "None"), so the label is applied automatically from the self-declaration instead of relying on the author to remember. Adding a future label (e.g. `security`) is a one-line `RULES` entry — no new workflow. The Release QA audit (ENG-2086) filters on `breaking-change` to compile release notes + the migration guide.

Pairs with ENG-2086 (release-process / Notion updates) and the `breaking-change` GitHub label.

### Notes for reviewers

- The workflow uses `pull_request_target` because labeling needs a write-scoped token (incl. fork PRs). Safe here: it only reads the PR **body** (data) — no checkout, never runs PR code. Follows repo conventions (harden-runner first, SHA-pinned actions, minimal `permissions`).
- `pull_request_target` always runs the workflow definition from the **base branch**, so this activates once merged to `main` — it does not self-run on this PR. Parsing logic was unit-tested locally against default / filled / mixed / missing-section bodies, plus a second hypothetical rule to confirm the engine is generic.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2087/update-pr-template-for-breaking-change-details

## How this was tested

- Template + workflow only; no app runtime surface.
- YAML validated (`yaml.safe_load`). Parse/decision logic unit-tested in node against multiple PR-body shapes: default "None" → no label; filled table → label; table with a stray "None" line → label; prose section → label; missing section (old PRs) → no-op; label wrongly present on a "None" section → removed; and a second hypothetical rule → independent add. All passed.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Open a new PR against `main` → description pre-filled with a **Breaking changes** section (between "How this was tested" and "QA / Test Plan"), defaulting to "None".
- [ ] Once this is on `main`: open a PR whose body leaves "None" → the `breaking-change` label is NOT applied.
- [ ] Edit that PR's body to fill the Breaking changes table → on save, the `breaking-change` label is auto-added. Revert to "None" → label auto-removed.
- [ ] The `breaking-change` label exists in the repo.

**Preconditions / test data**

- Label auto-sync only takes effect after this PR merges to `main` (pull_request_target runs the base-branch workflow).

**Risks & regressions**

- Workflow reads only the PR body; no code execution. Affects labels on new/edited PRs going forward. No app runtime impact.

**Migrations / env / cutover**

- none
