### PR TITLE
fix(security): scope historical response import to the authorized workspace (backport #8679 to release/5.2)

### DIFF
--- a/apps/web/lib/feedback-source/actions.ts
+++ b/apps/web/lib/feedback-source/actions.ts
@@ -7,15 +7,12 @@ import { ZId } from "@formbricks/types/common";
 import { AuthorizationError, InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
 import {
   TFeedbackSourceWithMappings,
-  THubFieldType,
   ZFeedbackSourceCreateInput,
   ZFeedbackSourceFieldMappingCreateInput,
   ZFeedbackSourceUpdateInput,
-  getHubFieldTypeFromElementType,
 } from "@formbricks/types/feedback-source";
 import { getResponseCountBySurveyId } from "@/lib/response/service";
 import { getSurvey } from "@/lib/survey/service";
-import { getElementsFromBlocks } from "@/lib/survey/utils";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { AuthenticatedActionClientCtx } from "@/lib/utils/action-client/types/context";
@@ -29,6 +26,7 @@ import { getContactIdsByUserIds } from "@/modules/ee/unify-feedback/lib/contacts
 import { listFeedbackRecords } from "@/modules/hub/service";
 import type { FeedbackRecordListParams, FeedbackRecordListResponse } from "@/modules/hub/types";
 import { importHistoricalResponses } from "./import";
+import { resolveFormbricksMappingsInput } from "./mappings";
 import {
   TMappingsInput,
   createFeedbackSourceWithMappings,
@@ -77,55 +75,6 @@ export const deleteFeedbackSourceAction = authenticatedActionClient
       return deleteFeedbackSource(parsedInput.feedbackSourceId, parsedInput.workspaceId);
     }
   );
-
-const resolveSurveyMappings = async (
-  surveyId: string,
-  elementIds: string[]
-): Promise<{ surveyId: string; elementId: string; hubFieldType: THubFieldType }[]> => {
-  const survey = await getSurvey(surveyId);
-  if (!survey) {
-    throw new ResourceNotFoundError("Survey", surveyId);
-  }
-
-  const elements = getElementsFromBlocks(survey.blocks);
-  const elementMap = new Map(elements.map((el) => [el.id, el]));
-
-  return elementIds.flatMap((elementId) => {
-    const element = elementMap.get(elementId);
-    if (!element) {
-      logger.warn(
-        { surveyId, elementId },
-        "Skipping unknown elementId when building feedbackSource mappings"
-      );
-      return [];
-    }
-
-    const hubFieldType = getHubFieldTypeFromElementType(element.type);
-    if (!hubFieldType) {
-      logger.warn(
-        { surveyId, elementId, elementType: element.type },
-        "Skipping unmappable element type when building feedbackSource mappings"
-      );
-      return [];
-    }
-
-    return [{ surveyId, elementId, hubFieldType }];
-  });
-};
-
-const resolveFormbricksMappingsInput = async (
-  entries: { surveyId: string; elementIds: string[] }[]
-): Promise<TMappingsInput> => {
-  const allMappings = await Promise.all(
-    entries.map(({ surveyId, elementIds }) => resolveSurveyMappings(surveyId, elementIds))
-  );
-  const flattenedMappings = allMappings.flat();
-  if (flattenedMappings.length === 0) {
-    throw new InvalidInputError("No supported survey questions selected for feedbackSource mapping");
-  }
-
-  return { type: "formbricks_survey", mappings: flattenedMappings };
-};
 
 const ZFormbricksSurveyMapping = z.object({
   surveyId: ZId,
@@ -218,16 +167,7 @@ export const createFeedbackSourceWithMappingsAction = authenticatedActionClient
     const { formbricksMappings, fieldMappings } = parsedInput;
 
     if (formbricksMappings?.length) {
-      await Promise.all(
-        formbricksMappings.map(async ({ surveyId }) => {
-          const orgId = await getOrganizationIdFromSurveyId(surveyId);
-          if (orgId !== organizationId) {
-            throw new AuthorizationError("You are not authorized to access this survey");
-          }
-        })
-      );
-
-      mappingsInput = await resolveFormbricksMappingsInput(formbricksMappings);
+      mappingsInput = await resolveFormbricksMappingsInput(formbricksMappings, parsedInput.workspaceId);
     } else if (fieldMappings?.length) {
       mappingsInput = {
         type: "field",
@@ -280,28 +220,27 @@ export const updateFeedbackSourceWithMappingsAction = authenticatedActionClient
         ],
       });
 
+      // The check above proves the caller may act in `workspaceId`; it does not prove this feedback
+      // source lives there, and the organization it was authorized against came from the source
+      // rather than the workspace. Pin the two together up front so every branch below — and the
+      // mappings resolved against the same workspace — operates on one tenant, and so a mismatch
+      // fails here rather than as a Prisma error from the update.
+      const feedbackSource = await prisma.feedbackSource.findUnique({
+        where: { id: parsedInput.feedbackSourceId, workspaceId: parsedInput.workspaceId },
+        select: { type: true },
+      });
+      if (!feedbackSource) {
+        throw new ResourceNotFoundError("FeedbackSource", parsedInput.feedbackSourceId);
+      }
+
       let mappingsInput: TMappingsInput | undefined;
 
       if (parsedInput.formbricksMappings?.length) {
-        await Promise.all(
-          parsedInput.formbricksMappings.map(async ({ surveyId }) => {
-            const orgId = await getOrganizationIdFromSurveyId(surveyId);
-            if (orgId !== organizationId) {
-              throw new AuthorizationError("You are not authorized to access this survey");
-            }
-          })
+        mappingsInput = await resolveFormbricksMappingsInput(
+          parsedInput.formbricksMappings,
+          parsedInput.workspaceId
         );
-
-        mappingsInput = await resolveFormbricksMappingsInput(parsedInput.formbricksMappings);
       } else if (parsedInput.fieldMappings && parsedInput.fieldMappings.length > 0) {
-        const feedbackSource = await prisma.feedbackSource.findUnique({
-          where: { id: parsedInput.feedbackSourceId, workspaceId: parsedInput.workspaceId },
-          select: { type: true },
-        });
-        if (!feedbackSource) {
-          throw new ResourceNotFoundError("FeedbackSource", parsedInput.feedbackSourceId);
-        }
-
         mappingsInput = {
           type: "field",
           mappings:
@@ -399,6 +338,16 @@ export const importHistoricalResponsesAction = authenticatedActionClient
 
       const survey = await getSurvey(parsedInput.surveyId);
       if (!survey) {
+        throw new ResourceNotFoundError("Survey", parsedInput.surveyId);
+      }
+
+      // The authorization above covers the feedback source's workspace, not this survey — and the
+      // import reads every response of `surveyId` and copies them into the source's feedback
+      // directory. Without this check any caller with readWrite on one workspace could name a survey
+      // from another organization and exfiltrate its responses into their own directory. Survey ids
+      // are public (they appear in `/s/<surveyId>` links), so the id is not a secret. The picker only
+      // ever offers surveys from this workspace (`getSurveysForUnifyAction` → `getSurveys(workspaceId)`).
+      if (survey.workspaceId !== parsedInput.workspaceId) {
         throw new ResourceNotFoundError("Survey", parsedInput.surveyId);
       }
 

--- a/apps/web/lib/feedback-source/mappings.test.ts
+++ b/apps/web/lib/feedback-source/mappings.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { TSurvey } from "@formbricks/types/surveys/types";
+import { resolveFormbricksMappingsInput } from "./mappings";
+
+vi.mock("@/lib/survey/service", () => ({
+  getSurvey: vi.fn(),
+}));
+
+// Deliberately unmocked: @/lib/survey/utils — getElementsFromBlocks is a plain flatMap over the
+// blocks, so the real one keeps the fixtures honest about the shape it reads.
+
+const { getSurvey } = vi.mocked(await import("@/lib/survey/service"));
+
+const WORKSPACE_ID = "clxxxxxxxxxxxxxxxx001";
+const OTHER_WORKSPACE_ID = "clxxxxxxxxxxxxxxxx002";
+const SURVEY_ID = "clxxxxxxxxxxxxxxxx003";
+const OTHER_SURVEY_ID = "clxxxxxxxxxxxxxxxx004";
+
+const buildSurvey = (id: string, workspaceId: string): TSurvey =>
+  ({
+    id,
+    workspaceId,
+    blocks: [
+      {
+        elements: [
+          { id: "el-text", type: "openText" },
+          { id: "el-nps", type: "nps" },
+        ],
+      },
+      {
+        elements: [
+          { id: "el-rating", type: "rating" },
+          // No Hub field type exists for file uploads.
+          { id: "el-file", type: "fileUpload" },
+        ],
+      },
+    ],
+  }) as unknown as TSurvey;
+
+describe("resolveFormbricksMappingsInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("resolves elements across surveys and blocks in the workspace", async () => {
+    getSurvey.mockImplementation(async (surveyId: string) => buildSurvey(surveyId, WORKSPACE_ID));
+
+    const result = await resolveFormbricksMappingsInput(
+      [
+        { surveyId: SURVEY_ID, elementIds: ["el-text", "el-rating"] },
+        { surveyId: OTHER_SURVEY_ID, elementIds: ["el-nps"] },
+      ],
+      WORKSPACE_ID
+    );
+
+    expect(result).toEqual({
+      type: "formbricks_survey",
+      mappings: [
+        { surveyId: SURVEY_ID, elementId: "el-text", hubFieldType: "text" },
+        { surveyId: SURVEY_ID, elementId: "el-rating", hubFieldType: "rating" },
+        { surveyId: OTHER_SURVEY_ID, elementId: "el-nps", hubFieldType: "nps" },
+      ],
+    });
+  });
+
+  // Tenancy guard: the caller is authorized on `workspaceId`, but `surveyId` is caller-supplied and
+  // survey ids are not secret (they appear in every /s/<surveyId> link). Not-found rather than
+  // unauthorized, so the response cannot confirm that a foreign survey id exists.
+  test("rejects a survey from another workspace", async () => {
+    getSurvey.mockResolvedValue(buildSurvey(SURVEY_ID, OTHER_WORKSPACE_ID));
+
+    await expect(
+      resolveFormbricksMappingsInput([{ surveyId: SURVEY_ID, elementIds: ["el-text"] }], WORKSPACE_ID)
+    ).rejects.toThrow(ResourceNotFoundError);
+  });
+
+  test("rejects the whole input when only one of several surveys is foreign", async () => {
+    getSurvey.mockImplementation(async (surveyId: string) =>
+      buildSurvey(surveyId, surveyId === OTHER_SURVEY_ID ? OTHER_WORKSPACE_ID : WORKSPACE_ID)
+    );
+
+    await expect(
+      resolveFormbricksMappingsInput(
+        [
+          { surveyId: SURVEY_ID, elementIds: ["el-text"] },
+          { surveyId: OTHER_SURVEY_ID, elementIds: ["el-text"] },
+        ],
+        WORKSPACE_ID
+      )
+    ).rejects.toThrow(ResourceNotFoundError);
+  });
+
+  test("rejects a survey that does not exist", async () => {
+    getSurvey.mockResolvedValue(null);
+
+    await expect(
+      resolveFormbricksMappingsInput([{ surveyId: SURVEY_ID, elementIds: ["el-text"] }], WORKSPACE_ID)
+    ).rejects.toThrow(ResourceNotFoundError);
+  });
+
+  test("skips unknown element ids and element types with no Hub field", async () => {
+    getSurvey.mockResolvedValue(buildSurvey(SURVEY_ID, WORKSPACE_ID));
+
+    const result = await resolveFormbricksMappingsInput(
+      [{ surveyId: SURVEY_ID, elementIds: ["el-text", "el-gone", "el-file"] }],
+      WORKSPACE_ID
+    );
+
+    expect(result.mappings).toEqual([{ surveyId: SURVEY_ID, elementId: "el-text", hubFieldType: "text" }]);
+  });
+
+  test("throws InvalidInputError when nothing is mappable", async () => {
+    getSurvey.mockResolvedValue(buildSurvey(SURVEY_ID, WORKSPACE_ID));
+
+    await expect(
+      resolveFormbricksMappingsInput([{ surveyId: SURVEY_ID, elementIds: ["el-file"] }], WORKSPACE_ID)
+    ).rejects.toThrow(InvalidInputError);
+  });
+});

--- a/apps/web/lib/feedback-source/mappings.ts
+++ b/apps/web/lib/feedback-source/mappings.ts
@@ -1,0 +1,69 @@
+import "server-only";
+import { logger } from "@formbricks/logger";
+import { InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { THubFieldType, getHubFieldTypeFromElementType } from "@formbricks/types/feedback-source";
+import { getSurvey } from "@/lib/survey/service";
+import { getElementsFromBlocks } from "@/lib/survey/utils";
+import type { TMappingsInput } from "./service";
+
+const resolveSurveyMappings = async (
+  surveyId: string,
+  elementIds: string[],
+  workspaceId: string
+): Promise<{ surveyId: string; elementId: string; hubFieldType: THubFieldType }[]> => {
+  const survey = await getSurvey(surveyId);
+  // Mapping rows are written with the feedback source's workspaceId, and the composite FK
+  // (surveyId, workspaceId) → Survey(id, workspaceId) already makes a survey from another workspace
+  // impossible to persist. Reject it here so the caller gets a clean not-found instead of a raw
+  // Prisma FK error, and so the app-level check matches the workspace the caller was authorized on
+  // rather than the whole organization. Not-found rather than unauthorized: the response must not
+  // confirm that a foreign survey id exists.
+  if (survey?.workspaceId !== workspaceId) {
+    throw new ResourceNotFoundError("Survey", surveyId);
+  }
+
+  const elements = getElementsFromBlocks(survey.blocks);
+  const elementMap = new Map(elements.map((el) => [el.id, el]));
+
+  return elementIds.flatMap((elementId) => {
+    const element = elementMap.get(elementId);
+    if (!element) {
+      logger.warn(
+        { surveyId, elementId },
+        "Skipping unknown elementId when building feedbackSource mappings"
+      );
+      return [];
+    }
+
+    const hubFieldType = getHubFieldTypeFromElementType(element.type);
+    if (!hubFieldType) {
+      logger.warn(
+        { surveyId, elementId, elementType: element.type },
+        "Skipping unmappable element type when building feedbackSource mappings"
+      );
+      return [];
+    }
+
+    return [{ surveyId, elementId, hubFieldType }];
+  });
+};
+
+/**
+ * Builds the Formbricks-survey mapping input for a feedback source, and is the single place that
+ * binds the mapped surveys to the workspace the caller was authorized on. Every survey must live in
+ * `workspaceId`; unknown elements and element types with no Hub field are skipped with a warning.
+ */
+export const resolveFormbricksMappingsInput = async (
+  entries: { surveyId: string; elementIds: string[] }[],
+  workspaceId: string
+): Promise<TMappingsInput> => {
+  const allMappings = await Promise.all(
+    entries.map(({ surveyId, elementIds }) => resolveSurveyMappings(surveyId, elementIds, workspaceId))
+  );
+  const flattenedMappings = allMappings.flat();
+  if (flattenedMappings.length === 0) {
+    throw new InvalidInputError("No supported survey questions selected for feedbackSource mapping");
+  }
+
+  return { type: "formbricks_survey", mappings: flattenedMappings };
+};


### PR DESCRIPTION
## What & why

Backport of #8679 to `release/5.2` for the 5.2 patch release. **Severity: Critical** — cross-tenant disclosure of respondent PII, reachable by any authenticated user holding `readWrite` on a single workspace.

`importHistoricalResponsesAction` authorized the caller against the organization that owns the **feedback source**, then loaded an arbitrary caller-supplied `surveyId` with no ownership check and copied every one of that survey's responses into the caller's own feedback directory, where they are readable:

```ts
const organizationId = await getOrganizationIdFromFeedbackSourceId(parsedInput.feedbackSourceId);
await checkAuthorizationUpdated({ /* … authorizes the caller's OWN org/workspace … */ });
const survey = await getSurvey(parsedInput.surveyId);   // never checked against that org
return importHistoricalResponses(feedbackSource, survey);
```

So anyone with `readWrite` on one workspace could name a survey belonging to another organization and exfiltrate its responses. Survey ids are not secret — they appear in every `/s/<surveyId>` link. Enterprise-licensed (Unify Feedback), so it affects Cloud and enterprise self-hosted — the multi-tenant deployments where the isolation matters.

The survey must now belong to the workspace the caller was authorized against, which is also the only thing the picker ever offers (`getSurveysForUnifyAction` → `getSurveys(workspaceId)`). Bound to the **workspace** rather than the organization because the caller may hold only `workspaceTeam` `readWrite`, so an org-level check would still permit importing across workspaces inside one organization. Raised as `ResourceNotFoundError` rather than `AuthorizationError` so the endpoint does not become a cross-tenant survey-existence oracle.

This also carries the same-file hardening from #8679: the mapping resolution moves into `mappings.ts` so create and update share one workspace-scoped guard where the survey is loaded, and the update handler pins the feedback source to the request workspace for **every** branch (previously only the CSV branch checked, so a plain name/status update had no source check at all). Neither of those was exploitable — the composite FK `(surveyId, workspaceId) → Survey(id, workspaceId)` already made a foreign survey impossible to persist — but both were looser than the database, and porting them keeps this file identical to `main` so the next backport touching it doesn't conflict.

### This is the same change, not an adaptation

`apps/web/lib/feedback-source/actions.ts` on `release/5.2` was **byte-identical** to the pre-fix version on `main` (both blob `975a09e4`), so the vulnerability is present in exactly the same form and the fix applies exactly. The two files here are taken verbatim from the merged head of #8679.

### Deviation from #8679: no test file

#8679 adds `apps/web/lib/feedback-source/mappings.test.ts` (6 tests over the tenancy guard). That file is **omitted here**, per the backport policy of dropping newly-added test files — see 6fb3671 ("test: drop newly-added test files from backport (per backport policy; test updates retained)") on this branch.

Flagging it rather than deciding silently: the consequence is that the guard has no automated coverage on `release/5.2`, and this is a Critical security fix. The source is byte-identical to `main`, where the test does run, so the risk is low — but if the policy is not meant to apply to security backports, say so and I'll add the file. It applies cleanly with no other changes.

## Linear ticket

[ENG-1915](https://linear.app/formbricks/issue/ENG-1915). Reported privately by Kaivalya Ahir (github.com/default-cybe); worth coordinating advisory credit.

## How this was tested

- `npx vitest run lib/feedback-source` (`apps/web`) — 8 files / 172 tests ✅ (the existing suites; no new test file, see above)
- `tsc --noEmit --project tsconfig.typecheck.json` — 28 errors, **all** pre-existing `Cannot find module '@/images/…'` / `.svg` asset declarations from not running `typegen` first; **zero** in `feedback-source` or `mappings`
- `eslint lib/feedback-source/actions.ts lib/feedback-source/mappings.ts` — clean (exit 0), and `prettier --check` clean
- Verified every import the new `mappings.ts` needs already exists on `release/5.2`: `getHubFieldTypeFromElementType`, `getElementsFromBlocks`, `getSurvey`, `TMappingsInput`
- **Not run here:** Playwright E2E, `pnpm build`, and manual QA — no Docker daemon or database in this environment. CI covers E2E and build; the manual checks are below.

## QA / Test Plan

**How to test**

- [ ] With two organizations, each holding a feedback source and a survey with responses: as a user with `readWrite` in org A, trigger the historical-response import with A's `feedbackSourceId`/`workspaceId` and **B's** `surveyId` → rejected as not-found, and no records appear in A's feedback directory.
- [ ] Same call naming a survey from a *different workspace of org A* → also rejected (this is the workspace-level part, stricter than an org check).
- [ ] Happy path: importing historical responses for a survey in the authorized workspace still works and imports the expected number of records.
- [ ] The survey picker in the feedback-source UI still lists only the current workspace's surveys.
- [ ] Create a Formbricks feedback source from the picker and confirm the mappings save; edit it and change the selected questions → still saves.
- [ ] Rename a feedback source and toggle its status → still saves (this path now revalidates that the source belongs to the workspace).
- [ ] Create and edit a CSV feedback source with field mappings → unchanged behaviour.

**Preconditions / test data**

- Two organizations with separate workspaces, surveys and responses; an Enterprise license for Unify Feedback / feedback directories.
- A user whose access to the importing workspace comes from a `workspaceTeam` `readWrite` permission rather than org owner/manager, to exercise the workspace-level (not org-level) guard.

**Risks & regressions**

- The import behaves differently only for a request naming a survey outside the authorized workspace, which the UI never produces.
- Create and update now reject a cross-workspace mapped survey with `ResourceNotFoundError` where they previously raised `AuthorizationError` (cross-org) or a `DatabaseError` from the foreign-key violation (same org, other workspace). Both were already failures; only the error type changes. Nothing in the UI switches on those — `getTranslatedFeedbackSourceError` matches only `FEEDBACK_SOURCE_*` codes.
- No schema, API-shape or permission-level change, and no behaviour change for callers already staying inside one workspace.

**Migrations / env / cutover**

- none

## Note on ordering

At the time of opening, #8679 is approved and green but still sitting in the merge queue — it had not yet landed on `main` (`main` was at `874960c`). This backport does not depend on that: it applies the same two files to `release/5.2`, whose copy was byte-identical. If #8679 changes before it merges, this PR needs re-syncing.


---
_Generated by [Claude Code](https://claude.ai/code/session_011GyivGy7zu4oFftnKBZNGN)_