### PR TITLE
feat(embedded-data): add EmbeddedData and SurveyEmbeddedData tables

### DIFF
--- a/apps/web/integration/embedded-data-tenancy.integration.test.ts
+++ b/apps/web/integration/embedded-data-tenancy.integration.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import { resetDb } from "@/integration/reset-db";
+
+/**
+ * Embedded Data tenancy, against real Postgres (ENG-1833).
+ *
+ * `EmbeddedData` and `SurveyEmbeddedData` are scoped to a workspace by composite foreign keys that
+ * carry `workspaceId` — `(surveyId, workspaceId)` and `(embeddedDataId, workspaceId)`, both pointing
+ * at `@@unique([id, workspaceId])`. Nothing else stops a survey linking another workspace's field,
+ * so that guarantee lives entirely in DDL: `ZSurveyEmbeddedData` checks that `workspaceId` is
+ * present, never that the two foreign keys agree on it, and the unit suite mocks the database.
+ *
+ * Weakening either relation back to a single column therefore leaves `prisma validate` and the whole
+ * unit suite green. These tests are what notices — and ENG-1835, 1836, 1837 and 1978 all still have
+ * to alter these tables.
+ */
+
+/** Two workspaces under one organization, each with a survey. */
+const seedTwoWorkspaces = async (): Promise<{
+  workspaceA: string;
+  workspaceB: string;
+  surveyA: string;
+  surveyB: string;
+}> => {
+  const organization = await prisma.organization.create({ data: { name: "Tenancy Org" } });
+  const [workspaceA, workspaceB] = await Promise.all([
+    prisma.workspace.create({ data: { name: "Workspace A", organizationId: organization.id } }),
+    prisma.workspace.create({ data: { name: "Workspace B", organizationId: organization.id } }),
+  ]);
+  const [surveyA, surveyB] = await Promise.all([
+    prisma.survey.create({ data: { name: "Survey A", workspaceId: workspaceA.id } }),
+    prisma.survey.create({ data: { name: "Survey B", workspaceId: workspaceB.id } }),
+  ]);
+  return { workspaceA: workspaceA.id, workspaceB: workspaceB.id, surveyA: surveyA.id, surveyB: surveyB.id };
+};
+
+/**
+ * Runs `operation` and returns the foreign-key constraint it violated.
+ *
+ * Asserting the constraint by name is the point: a plain "it threw" would still pass if a later
+ * migration recreated the key single-column, because the row would then fail some other way (or not
+ * at all). Prisma reports the name under `meta.constraint` for P2003.
+ */
+const violatedConstraint = async (operation: () => Promise<unknown>): Promise<string> => {
+  try {
+    await operation();
+  } catch (error) {
+    const meta = (error as { code?: string; meta?: { constraint?: unknown } }).meta;
+    return String(meta?.constraint ?? error);
+  }
+  throw new Error("Expected the write to be rejected, but it succeeded");
+};
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("Embedded Data is scoped to a workspace by the database (real Postgres)", () => {
+  test("a shared field with no owning survey is accepted", async () => {
+    const { workspaceA } = await seedTwoWorkspaces();
+
+    const field = await prisma.embeddedData.create({
+      data: { name: "Plan tier", key: "plan_tier", source: "ingested", workspaceId: workspaceA },
+    });
+
+    expect(field.surveyId).toBeNull();
+  });
+
+  test("a local field owned by a survey in the same workspace is accepted", async () => {
+    const { workspaceA, surveyA } = await seedTwoWorkspaces();
+
+    const field = await prisma.embeddedData.create({
+      data: {
+        name: "Score",
+        source: "computed",
+        dataType: "number",
+        workspaceId: workspaceA,
+        surveyId: surveyA,
+      },
+    });
+
+    expect(field.surveyId).toBe(surveyA);
+  });
+
+  test("a local field cannot be owned by a survey in another workspace", async () => {
+    const { workspaceA, surveyB } = await seedTwoWorkspaces();
+
+    const constraint = await violatedConstraint(() =>
+      prisma.embeddedData.create({
+        data: {
+          name: "Score",
+          source: "computed",
+          dataType: "number",
+          workspaceId: workspaceA,
+          surveyId: surveyB,
+        },
+      })
+    );
+
+    expect(constraint).toContain("EmbeddedData_surveyId_workspaceId_fkey");
+  });
+
+  test("a survey cannot link a field defined in another workspace", async () => {
+    const { workspaceA, workspaceB, surveyB } = await seedTwoWorkspaces();
+    const fieldInA = await prisma.embeddedData.create({
+      data: { name: "Plan tier", key: "plan_tier", source: "ingested", workspaceId: workspaceA },
+    });
+
+    const constraint = await violatedConstraint(() =>
+      prisma.surveyEmbeddedData.create({
+        data: {
+          workspaceId: workspaceB,
+          surveyId: surveyB,
+          embeddedDataId: fieldInA.id,
+          storageKey: "plan_tier",
+        },
+      })
+    );
+
+    expect(constraint).toContain("SurveyEmbeddedData_embeddedDataId_workspaceId_fkey");
+  });
+
+  test("a link cannot name a survey from a workspace other than its own", async () => {
+    const { workspaceA, surveyB } = await seedTwoWorkspaces();
+    const fieldInA = await prisma.embeddedData.create({
+      data: { name: "Plan tier", key: "plan_tier", source: "ingested", workspaceId: workspaceA },
+    });
+
+    const constraint = await violatedConstraint(() =>
+      prisma.surveyEmbeddedData.create({
+        data: {
+          workspaceId: workspaceA,
+          surveyId: surveyB,
+          embeddedDataId: fieldInA.id,
+          storageKey: "plan_tier",
+        },
+      })
+    );
+
+    expect(constraint).toContain("SurveyEmbeddedData_surveyId_workspaceId_fkey");
+  });
+
+  test("deleting a survey removes its local field and its links, but not the shared library", async () => {
+    const { workspaceA, surveyA } = await seedTwoWorkspaces();
+    const [shared, local] = await Promise.all([
+      prisma.embeddedData.create({
+        data: { name: "Plan tier", key: "plan_tier", source: "ingested", workspaceId: workspaceA },
+      }),
+      prisma.embeddedData.create({
+        data: {
+          name: "Score",
+          source: "computed",
+          dataType: "number",
+          workspaceId: workspaceA,
+          surveyId: surveyA,
+        },
+      }),
+    ]);
+    await prisma.surveyEmbeddedData.create({
+      data: {
+        workspaceId: workspaceA,
+        surveyId: surveyA,
+        embeddedDataId: shared.id,
+        storageKey: "plan_tier",
+      },
+    });
+
+    await prisma.survey.delete({ where: { id: surveyA } });
+
+    expect(await prisma.embeddedData.findUnique({ where: { id: local.id } })).toBeNull();
+    expect(await prisma.surveyEmbeddedData.count()).toBe(0);
+    expect(await prisma.embeddedData.findUnique({ where: { id: shared.id } })).not.toBeNull();
+  });
+});

--- a/packages/database/json-types.ts
+++ b/packages/database/json-types.ts
@@ -2,6 +2,7 @@
 import { type TActionClassNoCodeConfig } from "@formbricks/types/action-classes";
 import type { TChartConfig, TChartQuery, TWidgetLayout } from "@formbricks/types/analysis";
 import type { TOrganizationAccess } from "@formbricks/types/api-key";
+import { type TEmbeddedDataDefaultValue } from "@formbricks/types/embedded-data";
 import { type TIntegrationConfig } from "@formbricks/types/integration";
 import {
   type TOrganizationBilling,
@@ -83,6 +84,7 @@ declare global {
     export type OrganizationAccess = TOrganizationAccess;
     export type SurveyMetadata = TSurveyMetadata;
     export type SurveyQuotaLogic = TSurveyQuotaLogic;
+    export type EmbeddedDataDefaultValue = TEmbeddedDataDefaultValue;
     export type ChartQuery = TChartQuery;
     export type ChartConfig = TChartConfig;
     export type WidgetLayout = TWidgetLayout;

--- a/packages/database/migration/20260729115216_add_embedded_data_tables/migration.sql
+++ b/packages/database/migration/20260729115216_add_embedded_data_tables/migration.sql
@@ -1,0 +1,82 @@
+-- ENG-1833: Embedded Data — workspace-level field definitions + per-survey links.
+--
+-- Additive only. Nothing reads or writes these tables yet: surveys keep using
+-- Survey.hiddenFields / Survey.variables until ENG-1837 repoints readers, and no response
+-- data is touched at any point.
+--
+-- EmbeddedData holds one field definition. A field is either local (bespoke to a single
+-- survey, which is how existing variables and hidden fields get migrated in ENG-1835) or
+-- shared (part of the workspace library). SurveyEmbeddedData links a survey to a field and
+-- records the storage key its value lives under inside that survey.
+
+-- CreateEnum
+CREATE TYPE "EmbeddedDataSource" AS ENUM ('computed', 'ingested', 'reserved');
+
+-- CreateEnum
+CREATE TYPE "EmbeddedDataType" AS ENUM ('string', 'number', 'boolean', 'date');
+
+-- CreateTable
+CREATE TABLE "EmbeddedData" (
+    "id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "key" TEXT,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "source" "EmbeddedDataSource" NOT NULL,
+    "dataType" "EmbeddedDataType" NOT NULL DEFAULT 'string',
+    "defaultValue" JSONB,
+    "locked" BOOLEAN NOT NULL DEFAULT false,
+    "isLocal" BOOLEAN NOT NULL DEFAULT true,
+    "surveyId" TEXT,
+    "workspaceId" TEXT NOT NULL,
+
+    CONSTRAINT "EmbeddedData_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SurveyEmbeddedData" (
+    "id" TEXT NOT NULL,
+    "surveyId" TEXT NOT NULL,
+    "embeddedDataId" TEXT NOT NULL,
+    "storageKey" TEXT NOT NULL,
+
+    CONSTRAINT "SurveyEmbeddedData_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "EmbeddedData_workspaceId_idx" ON "EmbeddedData"("workspaceId");
+
+-- CreateIndex
+CREATE INDEX "EmbeddedData_surveyId_idx" ON "EmbeddedData"("surveyId");
+
+-- CreateIndex
+-- Only shared fields carry a key. Postgres treats NULLs as distinct, so any number of local
+-- fields can coexist in a workspace while the shared library itself stays de-duplicated.
+CREATE UNIQUE INDEX "EmbeddedData_workspaceId_key_key" ON "EmbeddedData"("workspaceId", "key");
+
+-- CreateIndex
+CREATE INDEX "SurveyEmbeddedData_surveyId_idx" ON "SurveyEmbeddedData"("surveyId");
+
+-- CreateIndex
+CREATE INDEX "SurveyEmbeddedData_embeddedDataId_idx" ON "SurveyEmbeddedData"("embeddedDataId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SurveyEmbeddedData_surveyId_embeddedDataId_key" ON "SurveyEmbeddedData"("surveyId", "embeddedDataId");
+
+-- CreateIndex
+-- No two fields inside one survey may share a storage key, which stops a newly linked field
+-- from colliding with an existing one and overwriting its response values.
+CREATE UNIQUE INDEX "SurveyEmbeddedData_surveyId_storageKey_key" ON "SurveyEmbeddedData"("surveyId", "storageKey");
+
+-- AddForeignKey
+ALTER TABLE "EmbeddedData" ADD CONSTRAINT "EmbeddedData_surveyId_fkey" FOREIGN KEY ("surveyId") REFERENCES "Survey"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "EmbeddedData" ADD CONSTRAINT "EmbeddedData_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SurveyEmbeddedData" ADD CONSTRAINT "SurveyEmbeddedData_surveyId_fkey" FOREIGN KEY ("surveyId") REFERENCES "Survey"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SurveyEmbeddedData" ADD CONSTRAINT "SurveyEmbeddedData_embeddedDataId_fkey" FOREIGN KEY ("embeddedDataId") REFERENCES "EmbeddedData"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/migration/20260806000000_add_embedded_data_tables/migration.sql
+++ b/packages/database/migration/20260806000000_add_embedded_data_tables/migration.sql
@@ -1,14 +1,3 @@
--- ENG-1833: Embedded Data — workspace-level field definitions + per-survey links.
---
--- Additive only. Nothing reads or writes these tables yet: surveys keep using
--- Survey.hiddenFields / Survey.variables until ENG-1837 repoints readers, and no response
--- data is touched at any point.
---
--- EmbeddedData holds one field definition. A field is either local (bespoke to a single
--- survey, which is how existing variables and hidden fields get migrated in ENG-1835) or
--- shared (part of the workspace library). SurveyEmbeddedData links a survey to a field and
--- records the storage key its value lives under inside that survey.
-
 -- CreateEnum
 CREATE TYPE "EmbeddedDataSource" AS ENUM ('computed', 'ingested', 'reserved');
 
@@ -27,7 +16,6 @@ CREATE TABLE "EmbeddedData" (
     "dataType" "EmbeddedDataType" NOT NULL DEFAULT 'string',
     "defaultValue" JSONB,
     "locked" BOOLEAN NOT NULL DEFAULT false,
-    "isLocal" BOOLEAN NOT NULL DEFAULT true,
     "surveyId" TEXT,
     "workspaceId" TEXT NOT NULL,
 
@@ -37,6 +25,7 @@ CREATE TABLE "EmbeddedData" (
 -- CreateTable
 CREATE TABLE "SurveyEmbeddedData" (
     "id" TEXT NOT NULL,
+    "workspaceId" TEXT NOT NULL,
     "surveyId" TEXT NOT NULL,
     "embeddedDataId" TEXT NOT NULL,
     "storageKey" TEXT NOT NULL,
@@ -45,18 +34,13 @@ CREATE TABLE "SurveyEmbeddedData" (
 );
 
 -- CreateIndex
-CREATE INDEX "EmbeddedData_workspaceId_idx" ON "EmbeddedData"("workspaceId");
-
--- CreateIndex
 CREATE INDEX "EmbeddedData_surveyId_idx" ON "EmbeddedData"("surveyId");
 
 -- CreateIndex
--- Only shared fields carry a key. Postgres treats NULLs as distinct, so any number of local
--- fields can coexist in a workspace while the shared library itself stays de-duplicated.
 CREATE UNIQUE INDEX "EmbeddedData_workspaceId_key_key" ON "EmbeddedData"("workspaceId", "key");
 
 -- CreateIndex
-CREATE INDEX "SurveyEmbeddedData_surveyId_idx" ON "SurveyEmbeddedData"("surveyId");
+CREATE UNIQUE INDEX "EmbeddedData_id_workspaceId_key" ON "EmbeddedData"("id", "workspaceId");
 
 -- CreateIndex
 CREATE INDEX "SurveyEmbeddedData_embeddedDataId_idx" ON "SurveyEmbeddedData"("embeddedDataId");
@@ -65,18 +49,16 @@ CREATE INDEX "SurveyEmbeddedData_embeddedDataId_idx" ON "SurveyEmbeddedData"("em
 CREATE UNIQUE INDEX "SurveyEmbeddedData_surveyId_embeddedDataId_key" ON "SurveyEmbeddedData"("surveyId", "embeddedDataId");
 
 -- CreateIndex
--- No two fields inside one survey may share a storage key, which stops a newly linked field
--- from colliding with an existing one and overwriting its response values.
 CREATE UNIQUE INDEX "SurveyEmbeddedData_surveyId_storageKey_key" ON "SurveyEmbeddedData"("surveyId", "storageKey");
 
 -- AddForeignKey
-ALTER TABLE "EmbeddedData" ADD CONSTRAINT "EmbeddedData_surveyId_fkey" FOREIGN KEY ("surveyId") REFERENCES "Survey"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "EmbeddedData" ADD CONSTRAINT "EmbeddedData_surveyId_workspaceId_fkey" FOREIGN KEY ("surveyId", "workspaceId") REFERENCES "Survey"("id", "workspaceId") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "EmbeddedData" ADD CONSTRAINT "EmbeddedData_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "Workspace"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "SurveyEmbeddedData" ADD CONSTRAINT "SurveyEmbeddedData_surveyId_fkey" FOREIGN KEY ("surveyId") REFERENCES "Survey"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "SurveyEmbeddedData" ADD CONSTRAINT "SurveyEmbeddedData_surveyId_workspaceId_fkey" FOREIGN KEY ("surveyId", "workspaceId") REFERENCES "Survey"("id", "workspaceId") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- AddForeignKey
-ALTER TABLE "SurveyEmbeddedData" ADD CONSTRAINT "SurveyEmbeddedData_embeddedDataId_fkey" FOREIGN KEY ("embeddedDataId") REFERENCES "EmbeddedData"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "SurveyEmbeddedData" ADD CONSTRAINT "SurveyEmbeddedData_embeddedDataId_workspaceId_fkey" FOREIGN KEY ("embeddedDataId", "workspaceId") REFERENCES "EmbeddedData"("id", "workspaceId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/schema/main.prisma
+++ b/packages/database/schema/main.prisma
@@ -405,6 +405,8 @@ model Survey {
   pin                             String?
   displayPercentage               Decimal?
   languages                       SurveyLanguage[]
+  embeddedData                    EmbeddedData[]
+  embeddedDataLinks               SurveyEmbeddedData[]
   showLanguageSwitch              Boolean?
   followUps                       SurveyFollowUp[]
   /// [SurveyRecaptcha]
@@ -617,6 +619,7 @@ model Workspace {
   clickOutsideClose           Boolean                      @default(true)
   overlay                     SurveyOverlay                @default(none)
   languages                   Language[]
+  embeddedData                EmbeddedData[]
   /// [Logo]
   logo                        Json?
   workspaceTeams              WorkspaceTeam[]
@@ -1141,6 +1144,88 @@ model SurveyLanguage {
 
   @@id([languageId, surveyId])
   @@index([surveyId])
+}
+
+/// Where an Embedded Data field's value comes from.
+/// `computed` is set by survey logic, `ingested` arrives from a URL param or the SDK, and
+/// `reserved` is auto-captured system metadata. Reserved fields are never stored as rows —
+/// they are a static catalog in code — but the value exists so every layer shares one type.
+enum EmbeddedDataSource {
+  computed
+  ingested
+  reserved
+}
+
+/// The declared type of an Embedded Data field's value.
+enum EmbeddedDataType {
+  string
+  number
+  boolean
+  date
+}
+
+/// Defines one Embedded Data field: the extra context stored on a response that isn't an
+/// answer to a question (brand, plan, page type, a computed score, ...).
+///
+/// A field is either **local** — bespoke to a single survey, which is how existing variables
+/// and hidden fields are migrated — or **shared**, meaning it is part of the workspace library
+/// and can be linked by many surveys. Those states move together:
+/// `isLocal = true` <=> `surveyId` is set <=> `key` is null.
+///
+/// @property key - Library name, unique per workspace and immutable. Null for local fields
+/// @property name - Human-readable display label
+/// @property source - Where the value comes from (computed | ingested)
+/// @property dataType - Declared value type, used for coercion at ingest
+/// @property defaultValue - Initial value (computed) or fallback when nothing arrives (ingested)
+/// @property locked - Ingested only: ignore external writes and use the default instead
+/// @property isLocal - True when the field belongs to one survey rather than the shared library
+/// @property survey - The owning survey for a local field; cascades so nothing is orphaned
+model EmbeddedData {
+  id          String   @id @default(cuid())
+  createdAt   DateTime @default(now()) @map(name: "created_at")
+  updatedAt   DateTime @updatedAt @map(name: "updated_at")
+  key         String?
+  name        String
+  description String?
+
+  source       EmbeddedDataSource
+  dataType     EmbeddedDataType   @default(string)
+  /// [EmbeddedDataDefaultValue]
+  defaultValue Json?
+  locked       Boolean            @default(false)
+  isLocal      Boolean            @default(true)
+
+  survey      Survey?              @relation(fields: [surveyId], references: [id], onDelete: Cascade)
+  surveyId    String?
+  workspace   Workspace            @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  workspaceId String
+  surveyLinks SurveyEmbeddedData[]
+
+  // Only shared fields carry a key, and Postgres treats NULLs as distinct, so any number of
+  // local fields can coexist in a workspace while the library itself stays de-duplicated.
+  @@unique([workspaceId, key])
+  @@index([workspaceId])
+  @@index([surveyId])
+}
+
+/// Links a survey to an Embedded Data field and records the key that field's value is stored
+/// under inside that survey.
+///
+/// @property storageKey - The key the value lives under: a cuid for computed fields, the field
+/// name for ingested ones. Migrated fields keep their original key, which is what lets existing
+/// recall tokens, logic conditions and stored responses keep resolving untouched.
+model SurveyEmbeddedData {
+  id             String       @id @default(cuid())
+  survey         Survey       @relation(fields: [surveyId], references: [id], onDelete: Cascade)
+  surveyId       String
+  embeddedData   EmbeddedData @relation(fields: [embeddedDataId], references: [id], onDelete: Cascade)
+  embeddedDataId String
+  storageKey     String
+
+  @@unique([surveyId, embeddedDataId])
+  @@unique([surveyId, storageKey])
+  @@index([surveyId])
+  @@index([embeddedDataId])
 }
 
 /// Represents a team within an organization.

--- a/packages/database/schema/main.prisma
+++ b/packages/database/schema/main.prisma
@@ -1167,18 +1167,20 @@ enum EmbeddedDataType {
 /// Defines one Embedded Data field: the extra context stored on a response that isn't an
 /// answer to a question (brand, plan, page type, a computed score, ...).
 ///
-/// A field is either **local** — bespoke to a single survey, which is how existing variables
-/// and hidden fields are migrated — or **shared**, meaning it is part of the workspace library
-/// and can be linked by many surveys. Those states move together:
-/// `isLocal = true` <=> `surveyId` is set <=> `key` is null.
+/// A field is either **local** — used by a single survey, which is how existing variables and
+/// hidden fields are migrated — or **shared**, meaning it is part of the workspace library and can
+/// be linked by many surveys. There is no stored flag for that: `surveyId` is the owner and `key`
+/// is the library name, so a local field has `surveyId` set and `key` null, and a shared field the
+/// other way round. Deriving it rather than storing a boolean removes a column that could drift
+/// out of step with the two fields it stands for.
 ///
 /// @property key - Library name, unique per workspace and immutable. Null for local fields
 /// @property name - Human-readable display label
-/// @property source - Where the value comes from (computed | ingested)
+/// @property source - Where the value comes from (computed | ingested). `reserved` is part of the
+/// shared enum but never stored as a row: those fields are a static catalog in code
 /// @property dataType - Declared value type, used for coercion at ingest
 /// @property defaultValue - Initial value (computed) or fallback when nothing arrives (ingested)
 /// @property locked - Ingested only: ignore external writes and use the default instead
-/// @property isLocal - True when the field belongs to one survey rather than the shared library
 /// @property survey - The owning survey for a local field; cascades so nothing is orphaned
 model EmbeddedData {
   id          String   @id @default(cuid())
@@ -1193,9 +1195,12 @@ model EmbeddedData {
   /// [EmbeddedDataDefaultValue]
   defaultValue Json?
   locked       Boolean            @default(false)
-  isLocal      Boolean            @default(true)
 
-  survey      Survey?              @relation(fields: [surveyId], references: [id], onDelete: Cascade)
+  // Composite for the same reason SurveyEmbeddedData's are: on its own, `surveyId` would let a
+  // local field name a survey from a different workspace. `surveyId` is nullable and Postgres
+  // skips a multi-column foreign key when any of its columns is NULL, so shared fields (no owning
+  // survey) are unaffected.
+  survey      Survey?              @relation(fields: [surveyId, workspaceId], references: [id, workspaceId], onDelete: Cascade)
   surveyId    String?
   workspace   Workspace            @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
   workspaceId String
@@ -1204,27 +1209,35 @@ model EmbeddedData {
   // Only shared fields carry a key, and Postgres treats NULLs as distinct, so any number of
   // local fields can coexist in a workspace while the library itself stays de-duplicated.
   @@unique([workspaceId, key])
-  @@index([workspaceId])
+  // Target for SurveyEmbeddedData's composite foreign key, which is what stops a survey linking
+  // a field definition from another workspace.
+  @@unique([id, workspaceId])
   @@index([surveyId])
 }
 
 /// Links a survey to an Embedded Data field and records the key that field's value is stored
 /// under inside that survey.
 ///
+/// `workspaceId` is part of both foreign keys on purpose: `surveyId` and `embeddedDataId` alone are
+/// independent, so nothing would stop a survey in one workspace linking a field defined in another.
+/// Referencing `(id, workspaceId)` on both sides makes a cross-workspace pair unrepresentable, and
+/// puts the workspace scope every query needs on the row instead of behind a join through Survey.
+///
 /// @property storageKey - The key the value lives under: a cuid for computed fields, the field
 /// name for ingested ones. Migrated fields keep their original key, which is what lets existing
 /// recall tokens, logic conditions and stored responses keep resolving untouched.
 model SurveyEmbeddedData {
-  id             String       @id @default(cuid())
-  survey         Survey       @relation(fields: [surveyId], references: [id], onDelete: Cascade)
+  id             String @id @default(cuid())
+  workspaceId    String
   surveyId       String
-  embeddedData   EmbeddedData @relation(fields: [embeddedDataId], references: [id], onDelete: Cascade)
   embeddedDataId String
   storageKey     String
 
+  survey       Survey       @relation(fields: [surveyId, workspaceId], references: [id, workspaceId], onDelete: Cascade)
+  embeddedData EmbeddedData @relation(fields: [embeddedDataId, workspaceId], references: [id, workspaceId], onDelete: Cascade)
+
   @@unique([surveyId, embeddedDataId])
   @@unique([surveyId, storageKey])
-  @@index([surveyId])
   @@index([embeddedDataId])
 }
 

--- a/packages/types/embedded-data.test.ts
+++ b/packages/types/embedded-data.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "vitest";
+import { ZEmbeddedData, ZSurveyEmbeddedData } from "./embedded-data";
+
+const localField = {
+  id: "clx000000000000000000001",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  key: null,
+  name: "score",
+  description: null,
+  source: "computed" as const,
+  dataType: "number" as const,
+  defaultValue: 0,
+  locked: false,
+  isLocal: true,
+  surveyId: "clx000000000000000000002",
+  workspaceId: "clx000000000000000000003",
+};
+
+const sharedField = {
+  ...localField,
+  key: "weighted_score",
+  isLocal: false,
+  surveyId: null,
+};
+
+/** Collects the `path[0]` of every issue so tests can assert which field was rejected. */
+const failedPaths = (input: unknown): string[] => {
+  const result = ZEmbeddedData.safeParse(input);
+  if (result.success) return [];
+  return result.error.issues.map((issue) => String(issue.path[0]));
+};
+
+describe("ZEmbeddedData", () => {
+  test("accepts a local field and a shared field", () => {
+    expect(ZEmbeddedData.safeParse(localField).success).toBe(true);
+    expect(ZEmbeddedData.safeParse(sharedField).success).toBe(true);
+  });
+
+  describe("local / shared invariant", () => {
+    test("rejects a local field without a survey", () => {
+      expect(failedPaths({ ...localField, surveyId: null })).toContain("surveyId");
+    });
+
+    test("rejects a local field that also has a library key", () => {
+      expect(failedPaths({ ...localField, key: "score" })).toContain("key");
+    });
+
+    test("rejects a shared field without a library key", () => {
+      expect(failedPaths({ ...sharedField, key: null })).toContain("key");
+    });
+
+    test("rejects a shared field that belongs to a survey", () => {
+      expect(failedPaths({ ...sharedField, surveyId: "clx000000000000000000002" })).toContain("surveyId");
+    });
+  });
+
+  describe("key naming rule", () => {
+    test.each([
+      ["Brand", "uppercase"],
+      ["page-type", "hyphen"],
+      ["1st_page", "leading digit"],
+      ["page type", "space"],
+    ])("rejects %s (%s)", (key) => {
+      expect(failedPaths({ ...sharedField, key })).toContain("key");
+    });
+
+    test("accepts lowercase letters, digits and underscores", () => {
+      expect(ZEmbeddedData.safeParse({ ...sharedField, key: "page_type_2" }).success).toBe(true);
+    });
+  });
+
+  describe("source guards", () => {
+    test("rejects locked on a computed field", () => {
+      expect(failedPaths({ ...localField, locked: true })).toContain("locked");
+    });
+
+    test("accepts locked on an ingested field", () => {
+      const ingested = {
+        ...localField,
+        source: "ingested" as const,
+        dataType: "string" as const,
+        defaultValue: "web",
+        locked: true,
+      };
+      expect(ZEmbeddedData.safeParse(ingested).success).toBe(true);
+    });
+
+    test("rejects a default value on a reserved field", () => {
+      const reserved = {
+        ...localField,
+        source: "reserved" as const,
+        dataType: "string" as const,
+        defaultValue: "DE",
+      };
+      expect(failedPaths(reserved)).toContain("defaultValue");
+    });
+
+    test.each(["boolean", "date"] as const)("rejects a computed field typed as %s", (dataType) => {
+      // The logic engine only calculates strings and numbers.
+      expect(failedPaths({ ...localField, dataType, defaultValue: null })).toContain("dataType");
+    });
+
+    test.each(["string", "number"] as const)("accepts a computed field typed as %s", (dataType) => {
+      const value = dataType === "number" ? 0 : "";
+      expect(ZEmbeddedData.safeParse({ ...localField, dataType, defaultValue: value }).success).toBe(true);
+    });
+  });
+});
+
+describe("ZSurveyEmbeddedData", () => {
+  const link = {
+    id: "clx000000000000000000004",
+    surveyId: "clx000000000000000000002",
+    embeddedDataId: "clx000000000000000000001",
+    storageKey: "plan",
+  };
+
+  test("accepts a link", () => {
+    expect(ZSurveyEmbeddedData.safeParse(link).success).toBe(true);
+  });
+
+  test.each([
+    ["clx000000000000000000005", "a computed field's cuid"],
+    ["Brand-Name", "a legacy hidden field name with caps and a hyphen"],
+  ])("accepts %s as a storage key (%s)", (storageKey) => {
+    // storageKey is deliberately not safe-identifier validated: migrated fields keep the
+    // address their existing recall tokens and stored responses already use.
+    expect(ZSurveyEmbeddedData.safeParse({ ...link, storageKey }).success).toBe(true);
+  });
+
+  test("rejects an empty storage key", () => {
+    expect(ZSurveyEmbeddedData.safeParse({ ...link, storageKey: "" }).success).toBe(false);
+  });
+});

--- a/packages/types/embedded-data.test.ts
+++ b/packages/types/embedded-data.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { ZEmbeddedData, ZSurveyEmbeddedData } from "./embedded-data";
+import { ZEmbeddedData, ZSurveyEmbeddedData, isLocalEmbeddedData } from "./embedded-data";
+import { RESERVED_DECLARED_FIELD_NAMES } from "./surveys/validation";
 
 const localField = {
   id: "clx000000000000000000001",
@@ -12,7 +13,6 @@ const localField = {
   dataType: "number" as const,
   defaultValue: 0,
   locked: false,
-  isLocal: true,
   surveyId: "clx000000000000000000002",
   workspaceId: "clx000000000000000000003",
 };
@@ -20,7 +20,6 @@ const localField = {
 const sharedField = {
   ...localField,
   key: "weighted_score",
-  isLocal: false,
   surveyId: null,
 };
 
@@ -37,21 +36,18 @@ describe("ZEmbeddedData", () => {
     expect(ZEmbeddedData.safeParse(sharedField).success).toBe(true);
   });
 
-  describe("local / shared invariant", () => {
-    test("rejects a local field without a survey", () => {
-      expect(failedPaths({ ...localField, surveyId: null })).toContain("surveyId");
-    });
-
-    test("rejects a local field that also has a library key", () => {
+  describe("local / shared derivation", () => {
+    test("rejects a field that is both owned by a survey and in the library", () => {
       expect(failedPaths({ ...localField, key: "score" })).toContain("key");
     });
 
-    test("rejects a shared field without a library key", () => {
-      expect(failedPaths({ ...sharedField, key: null })).toContain("key");
+    test("rejects a field that is neither owned by a survey nor in the library", () => {
+      expect(failedPaths({ ...localField, key: null, surveyId: null })).toContain("key");
     });
 
-    test("rejects a shared field that belongs to a survey", () => {
-      expect(failedPaths({ ...sharedField, surveyId: "clx000000000000000000002" })).toContain("surveyId");
+    test("isLocalEmbeddedData derives from surveyId", () => {
+      expect(isLocalEmbeddedData(localField)).toBe(true);
+      expect(isLocalEmbeddedData(sharedField)).toBe(false);
     });
   });
 
@@ -68,9 +64,41 @@ describe("ZEmbeddedData", () => {
     test("accepts lowercase letters, digits and underscores", () => {
       expect(ZEmbeddedData.safeParse({ ...sharedField, key: "page_type_2" }).success).toBe(true);
     });
+
+    test("rejects every reserved name, in any casing", () => {
+      // A shared ingested field keyed `verify` or `lang` could never be filled, because ingestion
+      // refuses to capture a reserved param. Blocked here so it can't be created in the first place.
+      for (const reserved of RESERVED_DECLARED_FIELD_NAMES) {
+        for (const candidate of [reserved, reserved.toUpperCase()]) {
+          expect(failedPaths({ ...sharedField, key: candidate })).toContain("key");
+        }
+      }
+    });
+
+    test("accepts a name that merely contains a reserved word", () => {
+      expect(ZEmbeddedData.safeParse({ ...sharedField, key: "language_pref" }).success).toBe(true);
+    });
   });
 
   describe("source guards", () => {
+    test("rejects a reserved field as a stored row", () => {
+      // Reserved fields are a code catalog (ENG-1839), never rows — in either shape.
+      const asLocal = {
+        ...localField,
+        source: "reserved" as const,
+        dataType: "string" as const,
+        defaultValue: null,
+      };
+      const asShared = {
+        ...sharedField,
+        source: "reserved" as const,
+        dataType: "string" as const,
+        defaultValue: null,
+      };
+      expect(failedPaths(asLocal)).toContain("source");
+      expect(failedPaths(asShared)).toContain("source");
+    });
+
     test("rejects locked on a computed field", () => {
       expect(failedPaths({ ...localField, locked: true })).toContain("locked");
     });
@@ -86,16 +114,6 @@ describe("ZEmbeddedData", () => {
       expect(ZEmbeddedData.safeParse(ingested).success).toBe(true);
     });
 
-    test("rejects a default value on a reserved field", () => {
-      const reserved = {
-        ...localField,
-        source: "reserved" as const,
-        dataType: "string" as const,
-        defaultValue: "DE",
-      };
-      expect(failedPaths(reserved)).toContain("defaultValue");
-    });
-
     test.each(["boolean", "date"] as const)("rejects a computed field typed as %s", (dataType) => {
       // The logic engine only calculates strings and numbers.
       expect(failedPaths({ ...localField, dataType, defaultValue: null })).toContain("dataType");
@@ -106,11 +124,43 @@ describe("ZEmbeddedData", () => {
       expect(ZEmbeddedData.safeParse({ ...localField, dataType, defaultValue: value }).success).toBe(true);
     });
   });
+
+  describe("defaultValue must match dataType", () => {
+    /** Ingested so every dataType is allowed; the computed restriction is covered above. */
+    const ingested = { ...localField, source: "ingested" as const };
+
+    test.each([
+      ["number", "abc"],
+      ["boolean", 0],
+      ["string", true],
+      ["date", "banana"],
+      ["date", 20260806],
+    ] as const)("rejects dataType %s with default %p", (dataType, defaultValue) => {
+      expect(failedPaths({ ...ingested, dataType, defaultValue })).toContain("defaultValue");
+    });
+
+    test.each([
+      ["number", 42],
+      ["boolean", true],
+      ["string", "web"],
+      ["date", "2026-08-06"],
+      ["date", "2026-08-06T10:30:00Z"],
+    ] as const)("accepts dataType %s with default %p", (dataType, defaultValue) => {
+      expect(ZEmbeddedData.safeParse({ ...ingested, dataType, defaultValue }).success).toBe(true);
+    });
+
+    test("accepts a null default for every dataType", () => {
+      for (const dataType of ["string", "number", "boolean", "date"] as const) {
+        expect(ZEmbeddedData.safeParse({ ...ingested, dataType, defaultValue: null }).success).toBe(true);
+      }
+    });
+  });
 });
 
 describe("ZSurveyEmbeddedData", () => {
   const link = {
     id: "clx000000000000000000004",
+    workspaceId: "clx000000000000000000003",
     surveyId: "clx000000000000000000002",
     embeddedDataId: "clx000000000000000000001",
     storageKey: "plan",
@@ -120,16 +170,26 @@ describe("ZSurveyEmbeddedData", () => {
     expect(ZSurveyEmbeddedData.safeParse(link).success).toBe(true);
   });
 
+  test("requires a workspaceId, since it is part of both foreign keys", () => {
+    const { workspaceId: _omitted, ...withoutWorkspace } = link;
+    expect(ZSurveyEmbeddedData.safeParse(withoutWorkspace).success).toBe(false);
+  });
+
   test.each([
     ["clx000000000000000000005", "a computed field's cuid"],
     ["Brand-Name", "a legacy hidden field name with caps and a hyphen"],
+    ["verify", "a reserved name a stored survey may already hold"],
+    ["x".repeat(300), "a name longer than any create-time cap"],
   ])("accepts %s as a storage key (%s)", (storageKey) => {
-    // storageKey is deliberately not safe-identifier validated: migrated fields keep the
-    // address their existing recall tokens and stored responses already use.
+    // Migrated fields keep the address their existing recall tokens and stored responses use, so
+    // this schema stays lenient: any restriction here would fail the ENG-1835 backfill.
     expect(ZSurveyEmbeddedData.safeParse({ ...link, storageKey }).success).toBe(true);
   });
 
-  test("rejects an empty storage key", () => {
-    expect(ZSurveyEmbeddedData.safeParse({ ...link, storageKey: "" }).success).toBe(false);
+  test.each([
+    ["", "empty"],
+    ["   ", "whitespace only"],
+  ])("rejects a %s storage key", (storageKey) => {
+    expect(ZSurveyEmbeddedData.safeParse({ ...link, storageKey }).success).toBe(false);
   });
 });

--- a/packages/types/embedded-data.test.ts
+++ b/packages/types/embedded-data.test.ts
@@ -51,6 +51,23 @@ describe("ZEmbeddedData", () => {
     });
   });
 
+  describe("name", () => {
+    test.each([
+      ["", "empty"],
+      ["   ", "whitespace only"],
+      ["\t", "a single tab"],
+    ])("rejects a %s name", (name) => {
+      // `name` is the label the library and the editor render, so blank means an unreadable row.
+      expect(failedPaths({ ...localField, name })).toContain("name");
+    });
+
+    test("accepts a name with surrounding whitespace without trimming it", () => {
+      const result = ZEmbeddedData.safeParse({ ...localField, name: " Score " });
+      expect(result.success).toBe(true);
+      expect(result.data?.name).toBe(" Score ");
+    });
+  });
+
   describe("key naming rule", () => {
     test.each([
       ["Brand", "uppercase"],
@@ -182,14 +199,20 @@ describe("ZSurveyEmbeddedData", () => {
     ["x".repeat(300), "a name longer than any create-time cap"],
   ])("accepts %s as a storage key (%s)", (storageKey) => {
     // Migrated fields keep the address their existing recall tokens and stored responses use, so
-    // this schema stays lenient: any restriction here would fail the ENG-1835 backfill.
+    // anything the ENG-1835 backfill can move has to parse here.
     expect(ZSurveyEmbeddedData.safeParse({ ...link, storageKey }).success).toBe(true);
   });
 
   test.each([
     ["", "empty"],
     ["   ", "whitespace only"],
-  ])("rejects a %s storage key", (storageKey) => {
+    [" plan ", "padded — would never match ?plan= and counts as distinct from plan"],
+    ["page type", "contains a space"],
+    ["a;DROP TABLE", "outside the legacy charset"],
+    ["../../etc/passwd", "outside the legacy charset"],
+  ])("rejects %s as a storage key (%s)", (storageKey) => {
+    // The ceiling is `isLegacyIdCharset`, which the survey load path already enforces on hidden
+    // field ids — so no survey that still loads can hold a name this rejects.
     expect(ZSurveyEmbeddedData.safeParse({ ...link, storageKey }).success).toBe(false);
   });
 });

--- a/packages/types/embedded-data.ts
+++ b/packages/types/embedded-data.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { isSafeIdentifier } from "./safe-identifier";
+import { isLegacyIdCharset, isSafeIdentifier } from "./safe-identifier";
 import { RESERVED_DECLARED_FIELD_NAMES } from "./surveys/validation";
 
 /** Longest allowed field key / display name. */
@@ -67,7 +67,13 @@ export const ZEmbeddedData = z
       // `lang`, and ingestion would then refuse to fill it — a field that can never hold a value.
       .refine((key) => !RESERVED_DECLARED_FIELD_NAMES.has(key.toLowerCase()), "Key is reserved")
       .nullable(),
-    name: z.string().min(1).max(EMBEDDED_DATA_NAME_MAX_LENGTH),
+    // Blank rather than empty: `name` is the label the library and the editor render, and a
+    // whitespace-only one draws a row with nothing to read or click. Checked, not trimmed, so the
+    // stored value is never silently rewritten.
+    name: z
+      .string()
+      .refine((value) => value.trim().length > 0, "Name must not be blank")
+      .max(EMBEDDED_DATA_NAME_MAX_LENGTH),
     description: z.string().nullable(),
     source: ZEmbeddedDataSource,
     dataType: ZEmbeddedDataType.prefault("string"),
@@ -164,19 +170,32 @@ export const isLocalEmbeddedData = (field: Pick<TEmbeddedData, "surveyId">): boo
  * `workspaceId` is part of both foreign keys in the schema, so a survey cannot link a field defined
  * in another workspace.
  *
- * `storageKey` is deliberately **not** validated as a safe identifier, has no length cap, and does
- * not exclude reserved names: migrated fields keep their original address, which for a computed
- * field is a cuid and for an ingested field can be a legacy name with uppercase letters or hyphens.
- * Any restriction here that `ZSurveyHiddenFields.fieldIds` doesn't also impose would fail the
- * ENG-1835 backfill on a name a survey is currently using. The strict rule belongs on the create
- * path — see `RESERVED_DECLARED_FIELD_NAMES` and the third enforcement point on ENG-1839.
+ * `storageKey` holds exactly the restrictions `ZSurveyHiddenFields.fieldIds` already imposes on
+ * stored surveys, and no more. Migrated fields keep their original address — a cuid for a computed
+ * field, and for an ingested field a legacy name that may carry uppercase letters or hyphens — so
+ * anything stricter would fail the ENG-1835 backfill on a name a survey is using today.
+ *
+ * What that leaves in: `isLegacyIdCharset`, because the load path enforces it, so no survey that
+ * still loads can hold a name outside it. That rules out the case with a concrete failure — for an
+ * ingested field `storageKey` is the URL param name, so a padded `" plan "` never matches `?plan=`
+ * while `@@unique([surveyId, storageKey])` counts it as distinct from `"plan"`, giving one survey
+ * two fields where one can never hold a value.
+ *
+ * What that leaves out: `isSafeIdentifier`, any length cap, and the reserved names. Reserved is the
+ * subtle one — `RESERVED_DECLARED_FIELD_NAMES` is `FORBIDDEN_IDS` plus the link-survey system
+ * params, so a survey stored before those params were reserved can still hold a hidden field named
+ * `lang` and still load. Rejecting it here would strand that survey mid-backfill. The strict rule
+ * belongs on the create path instead — see the enforcement points on ENG-1839.
  */
 export const ZSurveyEmbeddedData = z.object({
   id: z.cuid2(),
   workspaceId: z.cuid2(),
   surveyId: z.cuid2(),
   embeddedDataId: z.cuid2(),
-  storageKey: z.string().refine((key) => key.trim().length > 0, "Storage key must not be blank"),
+  storageKey: z
+    .string()
+    .refine((key) => key.trim().length > 0, "Storage key must not be blank")
+    .refine(isLegacyIdCharset, "Storage key must contain only letters, digits, hyphens and underscores"),
 });
 
 export type TSurveyEmbeddedData = z.infer<typeof ZSurveyEmbeddedData>;

--- a/packages/types/embedded-data.ts
+++ b/packages/types/embedded-data.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { isSafeIdentifier } from "./safe-identifier";
+import { RESERVED_DECLARED_FIELD_NAMES } from "./surveys/validation";
 
-/** Longest allowed field key / name / storage key. */
+/** Longest allowed field key / display name. */
 export const EMBEDDED_DATA_NAME_MAX_LENGTH = 255;
 
 /**
@@ -9,8 +10,10 @@ export const EMBEDDED_DATA_NAME_MAX_LENGTH = 255;
  *
  * - `computed` — set inside the survey by logic (what used to be a "variable")
  * - `ingested` — arrives from outside via URL param or SDK (what used to be a "hidden field")
- * - `reserved` — auto-captured system metadata. Read-only, and never stored as a row:
- *   reserved fields are a static catalog in code (ENG-1839), globally available to every survey.
+ * - `reserved` — auto-captured system metadata. Read-only, globally available to every survey, and
+ *   **never stored as a row**: reserved fields are a static catalog in code (ENG-1839). The value
+ *   lives in this enum so the resolver and the catalog share one vocabulary; `ZEmbeddedData`
+ *   rejects it, because that schema describes a stored row.
  */
 export const ZEmbeddedDataSource = z.enum(["computed", "ingested", "reserved"]);
 
@@ -22,31 +25,47 @@ export type TEmbeddedDataType = z.infer<typeof ZEmbeddedDataType>;
 
 /**
  * A field's fallback value.
- * For `computed` fields this is the initial value; for `ingested` fields it is used
- * when nothing arrives from the URL or the SDK.
+ * For `computed` fields this is the initial value; for `ingested` fields it is used when nothing
+ * arrives from the URL or the SDK. The runtime type has to agree with the field's `dataType` —
+ * `ZEmbeddedData` enforces that, since `dataType` is what ingest coerces against.
  */
 export const ZEmbeddedDataDefaultValue = z.union([z.string(), z.number(), z.boolean()]).nullable();
 
 export type TEmbeddedDataDefaultValue = z.infer<typeof ZEmbeddedDataDefaultValue>;
 
+/** A `date` default is stored as a string, so pin it to ISO 8601 — either a date or a datetime. */
+const ZIsoDateOrDateTime = z.union([z.iso.date(), z.iso.datetime()]);
+
+/** Runtime type each non-date `dataType` expects its default value to have. */
+const DEFAULT_VALUE_TYPE_BY_DATA_TYPE = {
+  string: "string",
+  number: "number",
+  boolean: "boolean",
+} as const;
+
 /**
  * One Embedded Data field definition, owned by a workspace.
  *
- * A field is either **local** (bespoke to a single survey) or **shared** (part of the
- * workspace library). Those two states move together with `surveyId` and `key`:
- * `isLocal === true` ⟺ `surveyId !== null` ⟺ `key === null`.
+ * A field is either **local** (used by a single survey) or **shared** (part of the workspace
+ * library). That isn't stored as a flag: `surveyId` is the owner and `key` is the library name, so a
+ * local field has `surveyId` set and `key` null, and a shared field the other way round. Use
+ * {@link isLocalEmbeddedData} rather than re-deriving it at each call site.
  */
 export const ZEmbeddedData = z
   .object({
     id: z.cuid2(),
     createdAt: z.date(),
     updatedAt: z.date(),
-    // Library name — workspace-unique and immutable. Null for local fields, which
-    // aren't listed in the shared library and therefore have no library name.
+    // Library name — workspace-unique and immutable. Null for local fields, which aren't listed in
+    // the shared library and therefore have no library name.
     key: z
       .string()
       .max(EMBEDDED_DATA_NAME_MAX_LENGTH)
       .refine(isSafeIdentifier, "Key must start with a lowercase letter and contain only a-z, 0-9 and _")
+      // A library key is always newly authored (local fields carry `key: null`), so it goes through
+      // the strict create-time rule. Without this a shared ingested field could be keyed `verify` or
+      // `lang`, and ingestion would then refuse to fill it — a field that can never hold a value.
+      .refine((key) => !RESERVED_DECLARED_FIELD_NAMES.has(key.toLowerCase()), "Key is reserved")
       .nullable(),
     name: z.string().min(1).max(EMBEDDED_DATA_NAME_MAX_LENGTH),
     description: z.string().nullable(),
@@ -54,43 +73,35 @@ export const ZEmbeddedData = z
     dataType: ZEmbeddedDataType.prefault("string"),
     defaultValue: ZEmbeddedDataDefaultValue,
     locked: z.boolean().prefault(false),
-    isLocal: z.boolean().prefault(true),
     surveyId: z.cuid2().nullable(),
     workspaceId: z.cuid2(),
   })
   .superRefine((field, ctx) => {
-    // A local field belongs to exactly one survey and has no library key;
-    // a shared field has a library key and belongs to no single survey.
-    if (field.isLocal) {
-      if (field.surveyId === null) {
-        ctx.addIssue({
-          code: "custom",
-          message: "A local field must belong to a survey",
-          path: ["surveyId"],
-        });
-      }
-      if (field.key !== null) {
-        ctx.addIssue({
-          code: "custom",
-          message: "A local field must not have a library key",
-          path: ["key"],
-        });
-      }
-    } else {
-      if (field.surveyId !== null) {
-        ctx.addIssue({
-          code: "custom",
-          message: "A shared field must not belong to a single survey",
-          path: ["surveyId"],
-        });
-      }
-      if (field.key === null) {
-        ctx.addIssue({
-          code: "custom",
-          message: "A shared field must have a library key",
-          path: ["key"],
-        });
-      }
+    // Reserved fields are a code catalog, never rows. Rejecting the value here keeps the row schema
+    // honest about what can be persisted, and gives ENG-1839 an unambiguous starting point.
+    if (field.source === "reserved") {
+      ctx.addIssue({
+        code: "custom",
+        message: "Reserved fields are a code catalog and are never stored as rows",
+        path: ["source"],
+      });
+    }
+
+    // A local field belongs to exactly one survey and has no library key; a shared field has a
+    // library key and belongs to no single survey. Exactly one of the two is always set.
+    if (field.surveyId !== null && field.key !== null) {
+      ctx.addIssue({
+        code: "custom",
+        message: "A field owned by a survey is local and must not have a library key",
+        path: ["key"],
+      });
+    }
+    if (field.surveyId === null && field.key === null) {
+      ctx.addIssue({
+        code: "custom",
+        message: "A field must either belong to a survey or have a library key",
+        path: ["key"],
+      });
     }
 
     // Locking blocks writes from outside, which only ingested fields receive.
@@ -102,15 +113,6 @@ export const ZEmbeddedData = z
       });
     }
 
-    // Reserved fields are read-only, so a default would never be used.
-    if (field.source === "reserved" && field.defaultValue !== null) {
-      ctx.addIssue({
-        code: "custom",
-        message: "Reserved fields are read-only and cannot have a default value",
-        path: ["defaultValue"],
-      });
-    }
-
     // The logic engine can only calculate strings and numbers.
     if (field.source === "computed" && field.dataType !== "string" && field.dataType !== "number") {
       ctx.addIssue({
@@ -119,23 +121,62 @@ export const ZEmbeddedData = z
         path: ["dataType"],
       });
     }
+
+    // `dataType` is what ingest coerces against, so a default that disagrees with it would surface
+    // far from here — as a wrong value in the resolver, or a coercion failure at ingest.
+    if (field.defaultValue !== null) {
+      if (field.dataType === "date") {
+        const isIsoString =
+          typeof field.defaultValue === "string" && ZIsoDateOrDateTime.safeParse(field.defaultValue).success;
+        if (!isIsoString) {
+          ctx.addIssue({
+            code: "custom",
+            message: "A date field's default value must be an ISO 8601 date or datetime string",
+            path: ["defaultValue"],
+          });
+        }
+      } else {
+        const expectedType = DEFAULT_VALUE_TYPE_BY_DATA_TYPE[field.dataType];
+        if (typeof field.defaultValue !== expectedType) {
+          ctx.addIssue({
+            code: "custom",
+            message: `A ${field.dataType} field's default value must be a ${expectedType}`,
+            path: ["defaultValue"],
+          });
+        }
+      }
+    }
   });
 
 export type TEmbeddedData = z.infer<typeof ZEmbeddedData>;
 
 /**
- * Links a survey to an Embedded Data field, and records the key that field's value is
- * stored under inside that survey.
+ * True when the field is used by a single survey rather than being part of the workspace library.
+ * Derived from `surveyId` so there is no stored flag to drift out of step.
+ */
+export const isLocalEmbeddedData = (field: Pick<TEmbeddedData, "surveyId">): boolean =>
+  field.surveyId !== null;
+
+/**
+ * Links a survey to an Embedded Data field, and records the key that field's value is stored under
+ * inside that survey.
  *
- * `storageKey` is deliberately **not** validated as a safe identifier: migrated fields keep
- * their original address, which for a computed field is a cuid and for an ingested field can
- * be a legacy name containing uppercase letters or hyphens.
+ * `workspaceId` is part of both foreign keys in the schema, so a survey cannot link a field defined
+ * in another workspace.
+ *
+ * `storageKey` is deliberately **not** validated as a safe identifier, has no length cap, and does
+ * not exclude reserved names: migrated fields keep their original address, which for a computed
+ * field is a cuid and for an ingested field can be a legacy name with uppercase letters or hyphens.
+ * Any restriction here that `ZSurveyHiddenFields.fieldIds` doesn't also impose would fail the
+ * ENG-1835 backfill on a name a survey is currently using. The strict rule belongs on the create
+ * path — see `RESERVED_DECLARED_FIELD_NAMES` and the third enforcement point on ENG-1839.
  */
 export const ZSurveyEmbeddedData = z.object({
   id: z.cuid2(),
+  workspaceId: z.cuid2(),
   surveyId: z.cuid2(),
   embeddedDataId: z.cuid2(),
-  storageKey: z.string().min(1).max(EMBEDDED_DATA_NAME_MAX_LENGTH),
+  storageKey: z.string().refine((key) => key.trim().length > 0, "Storage key must not be blank"),
 });
 
 export type TSurveyEmbeddedData = z.infer<typeof ZSurveyEmbeddedData>;

--- a/packages/types/embedded-data.ts
+++ b/packages/types/embedded-data.ts
@@ -1,0 +1,141 @@
+import { z } from "zod";
+import { isSafeIdentifier } from "./safe-identifier";
+
+/** Longest allowed field key / name / storage key. */
+export const EMBEDDED_DATA_NAME_MAX_LENGTH = 255;
+
+/**
+ * Where an Embedded Data field's value comes from.
+ *
+ * - `computed` — set inside the survey by logic (what used to be a "variable")
+ * - `ingested` — arrives from outside via URL param or SDK (what used to be a "hidden field")
+ * - `reserved` — auto-captured system metadata. Read-only, and never stored as a row:
+ *   reserved fields are a static catalog in code (ENG-1839), globally available to every survey.
+ */
+export const ZEmbeddedDataSource = z.enum(["computed", "ingested", "reserved"]);
+
+export type TEmbeddedDataSource = z.infer<typeof ZEmbeddedDataSource>;
+
+export const ZEmbeddedDataType = z.enum(["string", "number", "boolean", "date"]);
+
+export type TEmbeddedDataType = z.infer<typeof ZEmbeddedDataType>;
+
+/**
+ * A field's fallback value.
+ * For `computed` fields this is the initial value; for `ingested` fields it is used
+ * when nothing arrives from the URL or the SDK.
+ */
+export const ZEmbeddedDataDefaultValue = z.union([z.string(), z.number(), z.boolean()]).nullable();
+
+export type TEmbeddedDataDefaultValue = z.infer<typeof ZEmbeddedDataDefaultValue>;
+
+/**
+ * One Embedded Data field definition, owned by a workspace.
+ *
+ * A field is either **local** (bespoke to a single survey) or **shared** (part of the
+ * workspace library). Those two states move together with `surveyId` and `key`:
+ * `isLocal === true` ⟺ `surveyId !== null` ⟺ `key === null`.
+ */
+export const ZEmbeddedData = z
+  .object({
+    id: z.cuid2(),
+    createdAt: z.date(),
+    updatedAt: z.date(),
+    // Library name — workspace-unique and immutable. Null for local fields, which
+    // aren't listed in the shared library and therefore have no library name.
+    key: z
+      .string()
+      .max(EMBEDDED_DATA_NAME_MAX_LENGTH)
+      .refine(isSafeIdentifier, "Key must start with a lowercase letter and contain only a-z, 0-9 and _")
+      .nullable(),
+    name: z.string().min(1).max(EMBEDDED_DATA_NAME_MAX_LENGTH),
+    description: z.string().nullable(),
+    source: ZEmbeddedDataSource,
+    dataType: ZEmbeddedDataType.prefault("string"),
+    defaultValue: ZEmbeddedDataDefaultValue,
+    locked: z.boolean().prefault(false),
+    isLocal: z.boolean().prefault(true),
+    surveyId: z.cuid2().nullable(),
+    workspaceId: z.cuid2(),
+  })
+  .superRefine((field, ctx) => {
+    // A local field belongs to exactly one survey and has no library key;
+    // a shared field has a library key and belongs to no single survey.
+    if (field.isLocal) {
+      if (field.surveyId === null) {
+        ctx.addIssue({
+          code: "custom",
+          message: "A local field must belong to a survey",
+          path: ["surveyId"],
+        });
+      }
+      if (field.key !== null) {
+        ctx.addIssue({
+          code: "custom",
+          message: "A local field must not have a library key",
+          path: ["key"],
+        });
+      }
+    } else {
+      if (field.surveyId !== null) {
+        ctx.addIssue({
+          code: "custom",
+          message: "A shared field must not belong to a single survey",
+          path: ["surveyId"],
+        });
+      }
+      if (field.key === null) {
+        ctx.addIssue({
+          code: "custom",
+          message: "A shared field must have a library key",
+          path: ["key"],
+        });
+      }
+    }
+
+    // Locking blocks writes from outside, which only ingested fields receive.
+    if (field.locked && field.source !== "ingested") {
+      ctx.addIssue({
+        code: "custom",
+        message: "Only ingested fields can be locked",
+        path: ["locked"],
+      });
+    }
+
+    // Reserved fields are read-only, so a default would never be used.
+    if (field.source === "reserved" && field.defaultValue !== null) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Reserved fields are read-only and cannot have a default value",
+        path: ["defaultValue"],
+      });
+    }
+
+    // The logic engine can only calculate strings and numbers.
+    if (field.source === "computed" && field.dataType !== "string" && field.dataType !== "number") {
+      ctx.addIssue({
+        code: "custom",
+        message: "Computed fields support only string or number",
+        path: ["dataType"],
+      });
+    }
+  });
+
+export type TEmbeddedData = z.infer<typeof ZEmbeddedData>;
+
+/**
+ * Links a survey to an Embedded Data field, and records the key that field's value is
+ * stored under inside that survey.
+ *
+ * `storageKey` is deliberately **not** validated as a safe identifier: migrated fields keep
+ * their original address, which for a computed field is a cuid and for an ingested field can
+ * be a legacy name containing uppercase letters or hyphens.
+ */
+export const ZSurveyEmbeddedData = z.object({
+  id: z.cuid2(),
+  surveyId: z.cuid2(),
+  embeddedDataId: z.cuid2(),
+  storageKey: z.string().min(1).max(EMBEDDED_DATA_NAME_MAX_LENGTH),
+});
+
+export type TSurveyEmbeddedData = z.infer<typeof ZSurveyEmbeddedData>;


### PR DESCRIPTION
## What & why

Embedded Data lives inside each survey today as JSON — `survey.variables` (keyed by cuid) and `survey.hiddenFields.fieldIds` (keyed by name) — so the same field has to be re-created by hand in every survey that needs it. This adds the storage that lets a field be defined once at workspace level and reused, which is the foundation the rest of Milestone 1 builds on.

Two new tables:

- **`EmbeddedData`** — one field definition, owned by a workspace. A field is either **local** (used by a single survey — how existing variables and hidden fields get migrated in ENG-1835) or **shared** (part of the workspace library). There is no stored flag for that: `surveyId` is the owner and `key` is the library name, so a local field has `surveyId` set and `key` null, and a shared field the other way round. `isLocalEmbeddedData()` derives it in one place.
- **`SurveyEmbeddedData`** — links a survey to a field and records the **`storageKey`** its value lives under inside that survey. This is the piece that makes the migration safe: a migrated field keeps the exact address its recall tokens, logic conditions and stored responses already use, so nothing has to be rewritten.

`source` (`computed` | `ingested` | `reserved`) replaces the old variable-vs-hidden-field split. `reserved` exists in the enum so every layer shares one type, but reserved fields are never stored as rows — they are a code catalog (ENG-1839), and `ZEmbeddedData` rejects the value for that reason.

Schema, types and validation only. **Nothing reads or writes these tables yet** — surveys keep using `hiddenFields` / `variables` until ENG-1837 repoints readers — and **no response data is touched**.

**Tenancy is enforced by the database, not by callers.** Every foreign key that could cross a workspace boundary carries `workspaceId`:

- `SurveyEmbeddedData` → `Survey(id, workspaceId)` and → `EmbeddedData(id, workspaceId)`
- `EmbeddedData` → `Survey(id, workspaceId)` for its owning survey

On their own, `surveyId` and `embeddedDataId` are independent, so nothing would stop a survey linking a field defined in another workspace, or a local field naming a survey from one. Referencing `(id, workspaceId)` makes a cross-workspace pair unrepresentable, and puts the workspace scope every query needs on the row instead of behind a join. `EmbeddedData.surveyId` is nullable and Postgres skips a multi-column foreign key when any of its columns is NULL, so shared fields are unaffected. `@@unique([id, workspaceId])` is the existing pattern here — the schema already uses it in three other places.

One thing worth a reviewer's eye: **`storageKey` carries exactly the rules `ZSurveyHiddenFields.fieldIds` already imposes on stored surveys, and no more.** A migrated field keeps its original address — a cuid for a computed field, a legacy name that may hold uppercase letters or hyphens for an ingested one — so anything stricter would fail the ENG-1835 backfill on a name a survey is using today.

- **In:** non-blank and `isLegacyIdCharset`. The survey load path already enforces that charset, so no survey that still loads can hold a name this rejects, and it rules out the case with a concrete failure: for an ingested field `storageKey` *is* the URL param name, so a padded `" plan "` never matches `?plan=` while `@@unique([surveyId, storageKey])` counts it as distinct from `"plan"` — one survey, two fields, one of which can never hold a value.
- **Out:** `isSafeIdentifier`, any length cap, and the reserved names. Reserved is the subtle one — `RESERVED_DECLARED_FIELD_NAMES` is `FORBIDDEN_IDS` **plus** the link-survey system params, so a survey stored before those params were reserved can still hold a hidden field named `lang` and still load. Rejecting it here would strand that survey mid-backfill.

The strict create-time rule stays on the create path (`isSafeIdentifier` from #8721, plus the reserved-name check). `key` — always newly authored — does go through it.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1833/schema-add-embeddeddata-surveyembeddeddata-tables

Part of Milestone 1 of the [Embedded Data](https://linear.app/formbricks/project/embedded-data-3d184a43d2f9) project. Targets the `epic/embedded-data-v1` branch — all of v1 (M1–M4) ships as one release. Rebased on #8721, so `isSafeIdentifier` now comes from the shared `@formbricks/types/safe-identifier` rather than a copy added here.

## How this was tested

**Unit — `pnpm test` in `packages/types`: 89 passed**, of which **45** are new in `embedded-data.test.ts`: local/shared derivation, the `key` naming rule, every reserved name in both casings, reserved-as-a-row rejection, the blank-`name` guard, the `locked` and computed-`dataType` guards, the full `defaultValue` × `dataType` matrix, and both sides of the `storageKey` rule.

**Integration — `pnpm test:integration` in `apps/web`: 83 passed across 22 files**, 6 of them new in `integration/embedded-data-tenancy.integration.test.ts`. The tenancy guarantee is pure DDL — `ZSurveyEmbeddedData` checks that `workspaceId` is present, never that the two foreign keys agree on it, and the unit suite mocks the database — so nothing but a real Postgres can see it. That harness already runs on `packages/**` changes and in the merge queue.

| Case | Result |
| --- | --- |
| Shared field with no owning survey | accepted |
| Local field owned by a survey in the same workspace | accepted |
| Local field owned by a survey in **another** workspace | rejected by `EmbeddedData_surveyId_workspaceId_fkey` |
| Survey links a field defined in another workspace | rejected by `SurveyEmbeddedData_embeddedDataId_workspaceId_fkey` |
| Link names a survey outside its own workspace | rejected by `SurveyEmbeddedData_surveyId_workspaceId_fkey` |
| Delete the owning survey | local field and its links cascade away, shared library field untouched |

Each rejection is asserted **by constraint name**, not just "it threw" — a later migration that recreates one of these single-column has to fail loudly. Checked that it does: weakening `SurveyEmbeddedData`'s second relation to a single column on the test database makes the cross-workspace link succeed and the suite fail with `Expected the write to be rejected, but it succeeded`. `prisma validate` and all 89 unit tests stay green through that same change, which is why these tests exist.

**Other checks**

- `pnpm typecheck` — clean in `packages/types` and `packages/database`
- `pnpm lint` — 0 errors (the 4 warnings in `packages/types` are pre-existing, in `surveys/*.ts`)
- `npx prisma validate` — schema valid; `prisma migrate diff` against the applied database is empty, so the migration and the models agree
- **Migration applied through the repo's runner** — both tables and enums created, migration recorded, 8 indexes and 4 cascading foreign keys match the models. Re-ran the runner: reports "already applied", nothing re-runs

## QA / Test Plan

**How to test**

There is nothing user-visible in this PR — it adds tables that no code reads or writes yet. The useful check is that nothing regressed around the fields it will eventually replace:

- [ ] Open a survey with variables and hidden fields in the editor → both cards load and list their fields exactly as before
- [ ] Add, rename and remove a hidden field and a variable, save → all succeed, no new errors
- [ ] Use a variable and a hidden field in recall (`@`) and in a logic condition, then submit a response → the values resolve as before
- [ ] Export that survey's responses → variable and hidden-field columns appear with the same headers and values as before
- [ ] Duplicate the survey → duplicate opens with the same fields
- [ ] Delete a survey that has variables and hidden fields → deletes cleanly, no foreign-key error in the logs

**Preconditions / test data**

- Any workspace with an existing survey that has at least one variable and one hidden field, plus a few responses collected before this change.

**Risks & regressions**

- Low: additive tables only, no reads/writes, no changes to survey or response payloads.
- The only shared-code touch is one file in `packages/types` plus one added `PrismaJson` type, so the area to re-check is that the app still builds and existing survey/response flows behave unchanged.
- The new file under `apps/web/integration/` is test-only and ships no runtime code. It is the first non-Better-Auth spec in that harness; it reuses `resetDb()` unchanged, and both new tables are FK-cascade-reachable from `Organization`, so the harness's isolation invariant still holds.

**Migrations / env / cutover**

- One new schema migration: `20260806000000_add_embedded_data_tables` — creates two tables and two enums. Additive and non-breaking; no data is written or backfilled (that is ENG-1835).
- No env changes.
