### PR TITLE
feat(surveys): default link surveys to the cardless card arrangement

### DIFF
--- a/apps/web/lib/styling/constants.ts
+++ b/apps/web/lib/styling/constants.ts
@@ -108,7 +108,8 @@ export const STYLE_DEFAULTS: TWorkspaceStyling = {
   highlightBorderColor: { light: _colors["highlightBorderColor.light"] },
   isDarkModeEnabled: false,
   roundness: 8,
-  cardArrangement: { linkSurveys: "simple", appSurveys: "simple" },
+  // Link surveys default to the cardless layout; "cardless" is link-only, so app surveys keep "simple".
+  cardArrangement: { linkSurveys: "cardless", appSurveys: "simple" },
   linkSurveyCardWidth: "default",
 
   // Headlines & Descriptions


### PR DESCRIPTION
## What & why

New link surveys should open in the **cardless** layout instead of stacked cards.

`STYLE_DEFAULTS` (`apps/web/lib/styling/constants.ts`) is the documented single source of truth for styling defaults — it seeds the styling editor's preselected card arrangement, the workspace theme-styling form, the live previews, the email-template renderer, and the "Restore defaults" action. This flips `cardArrangement.linkSurveys` from `"simple"` to `"cardless"`. App surveys stay `"simple"`, since the cardless layout is link-only (`ZAppSurveyCardArrangementOptions` doesn't include it) and the arrangement tabs only offer Cardless for link surveys.

**Scope:** this changes the *canonical default* only. It does **not** retroactively rewrite workspaces/surveys that already have a saved `cardArrangement`, and it deliberately does **not** touch the separate hardcoded render-time fallback (`?? "straight"`) used when a workspace has never saved any styling.

## Linear ticket

No ticket — small default-value change requested directly. Happy to link one if there is one.

## How this was tested

- `pnpm vitest run apps/web/lib/styling/constants.test.ts` ✅ (2 passed) — styling-defaults suite still green.
- Grepped the whole repo (app + packages + Playwright) for fixtures/tests/specs asserting the old `linkSurveys: "simple"` default — none found other than the constant itself, so no test/fixture updates were needed.
- Confirmed the value is type-safe: `"cardless"` is a member of `ZLinkSurveyCardArrangementOptions`, and `STYLE_DEFAULTS` is typed `TWorkspaceStyling`.
- Traced the data flow so the default actually reaches the UI: `STYLE_DEFAULTS` → theme-styling form and survey-editor styling form (both `{ ...STYLE_DEFAULTS, ...cleanWorkspace, ...cleanSurvey }`), previews, and the reset handlers.
- ⚠️ I did not stand up the full app + DB locally, so I have **not** captured live before/after screenshots. The visual delta is between two layouts the product already ships (the "simple" stacked-card link layout vs. the "cardless" layout). Happy to attach editor/preview screenshots if you'd like them before merge.

## QA / Test Plan

**How to test**

- [ ] In a workspace whose theme styling has **not** been customized, create/open a **link** survey → **Styling** tab → expand **Card Styling** → the "Card Arrangement for Link surveys" control shows **Cardless** selected by default (previously *Simple*), and the preview renders without a card border/background.
- [ ] Workspace → **Configuration → Look & Feel** (theme styling), preview type = Link → default arrangement/preview is **Cardless**. Click **Restore to default** → arrangement resets to **Cardless**.
- [ ] In the link survey editor, switch the arrangement to Simple / Straight / Casual → it still applies and persists on save (the new default doesn't lock the choice).
- [ ] Open an **app** survey editor → Card Arrangement still defaults to **Simple** and does **not** offer a Cardless option.

**Preconditions / test data**

- A workspace whose `styling` is still the DB default (`{"allowStyleOverwrite":true}`) or otherwise has no saved `cardArrangement` — a workspace that already saved a card arrangement will keep showing its saved value, not the new default. Works on Cloud and self-host; no plan/entitlement needed.

**Risks & regressions**

- Existing workspaces/surveys with a previously-saved `cardArrangement` are unaffected (no retroactive change).
- Known, out-of-scope by design: an untouched workspace that has never saved any styling still renders **published** link surveys via the hardcoded render-time fallback (`"straight"`), not this new default — so the editor preview (cardless) can differ from a published survey (straight) until theme styling is saved once. This pre-existing preview↔live mismatch is intentionally not addressed here.
- Re-check: app-survey arrangement unchanged; "Restore defaults" in both theme settings and the survey editor; and that saving theme styling on a fresh workspace persists `linkSurveys: "cardless"`.

**Migrations / env / cutover**

- none
