### PR TITLE
feat(license): add Workflows to the enterprise licensed features list

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/components/EnterpriseLicenseFeaturesTable.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/components/EnterpriseLicenseFeaturesTable.tsx
@@ -91,6 +91,11 @@ const getFeatureDefinitions = (t: TFunction): TFeatureDefinition[] => {
       labelKey: t("workspace.settings.general.ai_smart_tools_enabled"),
       docsUrl: "https://formbricks.com/docs/self-hosting/configuration/ai",
     },
+    {
+      key: "workflows",
+      labelKey: t("workspace.settings.enterprise.workflows"),
+      docsUrl: "https://formbricks.com/docs/workflows/overview",
+    },
   ];
 };
 

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -2560,6 +2560,7 @@ checksums:
     workspace/settings/enterprise/unlock_the_full_power_of_formbricks_free_for_30_days: a96f8df102a5d1f0367f3f82ac1f344b
     workspace/settings/enterprise/white_glove_onboarding: 79d5f04ad3decd659e63f5cf61628ea0
     workspace/settings/enterprise/whitelabel_email_follow_ups: 4d62c861b60c5dceb6ad72cd5d1186d7
+    workspace/settings/enterprise/workflows: b0c9c8615a9ba7d9cb73e767290a7f72
     workspace/settings/feedback_directories/archive: fa813ab3074103e5daad07462af25789
     workspace/settings/feedback_directories/archive_directory: c2b39feb0962b93f883a4bac6ffadd1e
     workspace/settings/feedback_directories/archive_not_allowed: 929b16f54260e321b0ebf5d458499d60

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "Vereinheitlichter Feedback-Posteingang",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "Entfalte das volle Potenzial von Formbricks.",
         "white_glove_onboarding": "Premium-Onboarding",
-        "whitelabel_email_follow_ups": "White-Label E-Mail-Nachfassaktionen"
+        "whitelabel_email_follow_ups": "White-Label E-Mail-Nachfassaktionen",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "Archivieren",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "Unify Feedback Inbox",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "Unlock the full power of Formbricks.",
         "white_glove_onboarding": "White-glove onboarding",
-        "whitelabel_email_follow_ups": "Whitelabel email follow-ups"
+        "whitelabel_email_follow_ups": "Whitelabel email follow-ups",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "Archive",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "Bandeja de Entrada de Comentarios Unificada",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "Desbloquea todo el potencial de Formbricks.",
         "white_glove_onboarding": "Incorporación personalizada",
-        "whitelabel_email_follow_ups": "Seguimientos por correo de marca blanca"
+        "whitelabel_email_follow_ups": "Seguimientos por correo de marca blanca",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "Archivar",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "Boîte de réception de feedback unifiée",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "Débloquez tout le potentiel de Formbricks.",
         "white_glove_onboarding": "Accompagnement personnalisé à l'intégration",
-        "whitelabel_email_follow_ups": "Suivis par e-mail en marque blanche"
+        "whitelabel_email_follow_ups": "Suivis par e-mail en marque blanche",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "Archiver",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "Egyesített visszajelzési postaláda",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "Használja ki a Formbricks teljes erejét.",
         "white_glove_onboarding": "Prémium bevezetés",
-        "whitelabel_email_follow_ups": "Whitelabel e-mail követések"
+        "whitelabel_email_follow_ups": "Whitelabel e-mail követések",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "Archiválás",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "フィードバック受信箱の統合",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "Formbricksの全機能を解放しましょう。",
         "white_glove_onboarding": "専任サポート付きオンボーディング",
-        "whitelabel_email_follow_ups": "ホワイトラベルメールフォローアップ"
+        "whitelabel_email_follow_ups": "ホワイトラベルメールフォローアップ",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "アーカイブ",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "Uniforme Feedback Inbox",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "Ontgrendel de volledige kracht van Formbricks.",
         "white_glove_onboarding": "White-glove onboarding",
-        "whitelabel_email_follow_ups": "Whitelabel e-mail follow-ups"
+        "whitelabel_email_follow_ups": "Whitelabel e-mail follow-ups",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "Archiveren",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "Caixa de Entrada de Feedback Unificada",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "Desbloqueie todo o poder do Formbricks.",
         "white_glove_onboarding": "Onboarding personalizado",
-        "whitelabel_email_follow_ups": "Follow-ups de e-mail em marca branca"
+        "whitelabel_email_follow_ups": "Follow-ups de e-mail em marca branca",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "Arquivar",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "Caixa de Entrada de Feedback Unificada",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "Liberta todo o poder do Formbricks.",
         "white_glove_onboarding": "Onboarding personalizado",
-        "whitelabel_email_follow_ups": "Follow-ups por e-mail sem marca"
+        "whitelabel_email_follow_ups": "Follow-ups por e-mail sem marca",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "Arquivar",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "Inbox unificat pentru feedback",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "Deblochează întregul potențial al Formbricks.",
         "white_glove_onboarding": "Onboarding personalizat",
-        "whitelabel_email_follow_ups": "Follow-up-uri email whitelabel"
+        "whitelabel_email_follow_ups": "Follow-up-uri email whitelabel",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "Arhivează",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "Единый почтовый ящик обратной связи",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "Раскройте весь потенциал Formbricks.",
         "white_glove_onboarding": "VIP-онбординг",
-        "whitelabel_email_follow_ups": "Whitelabel email-рассылки"
+        "whitelabel_email_follow_ups": "Whitelabel email-рассылки",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "Архивировать",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "Enhetlig feedbackinkorg",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "Lås upp Formbricks fulla potential.",
         "white_glove_onboarding": "Personlig onboarding",
-        "whitelabel_email_follow_ups": "White label-uppföljningar via e-post"
+        "whitelabel_email_follow_ups": "White label-uppföljningar via e-post",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "Arkivera",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "Birleşik Geri Bildirim Kutusu",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "Formbricks'in tüm gücünü ortaya çıkarın.",
         "white_glove_onboarding": "Kapsamlı başlangıç desteği",
-        "whitelabel_email_follow_ups": "Beyaz etiketli e-posta takipleri"
+        "whitelabel_email_follow_ups": "Beyaz etiketli e-posta takipleri",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "Arşivle",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "统一反馈收件箱",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "解锁 Formbricks 的全部功能。",
         "white_glove_onboarding": "专属引导服务",
-        "whitelabel_email_follow_ups": "白标电子邮件跟进"
+        "whitelabel_email_follow_ups": "白标电子邮件跟进",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "归档",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -2660,7 +2660,8 @@
         "unify_feedback_inbox": "統一回饋收件匣",
         "unlock_the_full_power_of_formbricks_free_for_30_days": "解鎖 Formbricks 的完整功能。",
         "white_glove_onboarding": "專屬引導服務",
-        "whitelabel_email_follow_ups": "白標電子郵件追蹤"
+        "whitelabel_email_follow_ups": "白標電子郵件追蹤",
+        "workflows": "Workflows"
       },
       "feedback_directories": {
         "archive": "封存",

--- a/apps/web/modules/ee/license-check/lib/license.test.ts
+++ b/apps/web/modules/ee/license-check/lib/license.test.ts
@@ -153,6 +153,7 @@ describe("License Core Logic", () => {
       quotas: true,
       feedbackDirectories: false,
       dashboards: false,
+      workflows: false,
     };
     const mockFetchedLicenseDetails: TEnterpriseLicenseDetails = {
       status: "active",
@@ -292,6 +293,7 @@ describe("License Core Logic", () => {
             quotas: false,
             feedbackDirectories: false,
             dashboards: false,
+            workflows: false,
           },
           lastChecked: expect.any(Date),
         },
@@ -315,6 +317,7 @@ describe("License Core Logic", () => {
           quotas: false,
           feedbackDirectories: false,
           dashboards: false,
+          workflows: false,
         },
         lastChecked: expect.any(Date),
         isPendingDowngrade: false,
@@ -347,6 +350,7 @@ describe("License Core Logic", () => {
         quotas: false,
         feedbackDirectories: false,
         dashboards: false,
+        workflows: false,
       };
       expect(mockCache.set).toHaveBeenCalledWith(
         expect.stringContaining("fb:license:"),
@@ -538,6 +542,7 @@ describe("License Core Logic", () => {
           quotas: true,
           feedbackDirectories: false,
           dashboards: false,
+          workflows: false,
         },
       };
 
@@ -604,6 +609,7 @@ describe("License Core Logic", () => {
           quotas: true,
           feedbackDirectories: false,
           dashboards: false,
+          workflows: false,
         },
       };
 
@@ -661,6 +667,7 @@ describe("License Core Logic", () => {
           quotas: true,
           feedbackDirectories: false,
           dashboards: false,
+          workflows: false,
         },
       };
 
@@ -864,6 +871,7 @@ describe("License Core Logic", () => {
                   quotas: false,
                   feedbackDirectories: false,
                   dashboards: false,
+                  workflows: false,
                 },
               },
             },
@@ -1044,6 +1052,7 @@ describe("License Core Logic", () => {
           quotas: true,
           feedbackDirectories: false,
           dashboards: false,
+          workflows: false,
         },
       };
 
@@ -1172,6 +1181,7 @@ describe("License Core Logic", () => {
         quotas: true,
         feedbackDirectories: false,
         dashboards: false,
+        workflows: false,
       },
     };
 

--- a/apps/web/modules/ee/license-check/lib/license.ts
+++ b/apps/web/modules/ee/license-check/lib/license.ts
@@ -90,6 +90,7 @@ const LicenseFeaturesSchema = z.object({
   quotas: z.boolean(),
   feedbackDirectories: z.boolean().default(false),
   dashboards: z.boolean().default(false),
+  workflows: z.boolean().default(false),
 });
 
 const LicenseDetailsSchema = z.object({
@@ -159,6 +160,7 @@ const DEFAULT_FEATURES: TEnterpriseLicenseFeatures = {
   quotas: false,
   feedbackDirectories: false,
   dashboards: false,
+  workflows: false,
 };
 
 // Helper functions

--- a/apps/web/modules/ee/license-check/lib/utils.test.ts
+++ b/apps/web/modules/ee/license-check/lib/utils.test.ts
@@ -65,6 +65,7 @@ const defaultFeatures: TEnterpriseLicenseFeatures = {
   quotas: false,
   feedbackDirectories: false,
   dashboards: false,
+  workflows: false,
 };
 
 const defaultLicense = {

--- a/apps/web/modules/ee/license-check/types/enterprise-license.ts
+++ b/apps/web/modules/ee/license-check/types/enterprise-license.ts
@@ -20,6 +20,7 @@ const ZEnterpriseLicenseFeatures = z.object({
   quotas: z.boolean(),
   feedbackDirectories: z.boolean().default(false),
   dashboards: z.boolean().default(false),
+  workflows: z.boolean().default(false),
 });
 
 export type TEnterpriseLicenseFeatures = z.infer<typeof ZEnterpriseLicenseFeatures>;


### PR DESCRIPTION
## What & why

The self-hosted **Organization → Settings → Enterprise → Licensed Features** table is data-driven from the enterprise license feature schema (`TEnterpriseLicenseFeatures`). It listed every enterprise feature except Workflows.

This adds **Workflows** as a licensed feature so the table shows its access state based on the enterprise license server's response, exactly like every other row:

- New `workflows` boolean (default `false`) in both license feature Zod schemas (`ZEnterpriseLicenseFeatures` in `types/enterprise-license.ts`, `LicenseFeaturesSchema` in `lib/license.ts`) and in `DEFAULT_FEATURES`. Using `.default(false)` keeps older license-server responses that don't yet send the flag parsing safely (row renders as "Disabled").
- New row in `EnterpriseLicenseFeaturesTable`, with the docs link pointing to `/docs/workflows/overview`.
- New `workspace.settings.enterprise.workflows` en-US translation key.

Scope is intentionally minimal and **self-hosted only** — the Enterprise settings page `notFound()`s on Cloud. No Stripe entitlement/billing wiring and no `getIsWorkflows…` permission helper are added, because no product code gates a Workflows feature yet and that would be dead code. The access badge reuses the table's existing **Enabled / Disabled** wording for consistency with every other row; it flips purely on the license server's `workflows` value.

![Licensed Features table with the new Workflows row](https://raw.githubusercontent.com/formbricks/formbricks/assets/pr-workflows-licensed-feature/workflows-licensed-feature.png)

*Faithful render of the table component. The **NEW** badge and row highlight are annotations for this PR, not part of the UI. The live page requires a self-hosted instance with an active enterprise license (it 404s on Cloud).*

## Linear ticket

No ticket — direct request to surface Workflows in the licensed features list.

## How this was tested

- `pnpm scan-translations` ✅ — "All translation validations passed": 0 missing / unused / incomplete keys across all 15 web locales, and `i18n.lock` valid.
- Unit tests (run with the self-hosted `.env`):
  - `modules/ee/license-check/lib/license.test.ts` ✅ **33 passed**
  - `modules/ee/license-check/lib/utils.test.ts` ✅ **37 passed**
- `eslint` on changed source files ✅, `prettier --check` on changed files ✅.

> Non-English locale files carry `"workflows": "Workflows"` as a placeholder to satisfy the translation gate. Per the repo's en-US-only workflow, Lingo.dev replaces these with real translations on its next run.

## QA / Test Plan

**How to test**

- [ ] On a **self-hosted** instance with an **active enterprise license**, sign in as an owner/admin and open **Organization → Settings → Enterprise** (`/organizations/{organizationId}/settings/enterprise`) → the **Licensed Features** table now includes a **Workflows** row.
- [ ] Workflows **Access** badge shows **Enabled** when the license server returns `workflows: true`, and **Disabled** when it returns `false` or omits the flag → expected: badge reflects the license response.
- [ ] Click the Workflows **Read docs** link → opens `https://formbricks.com/docs/workflows/overview` in a new tab.
- [ ] Edge — **Formbricks Cloud**: the Enterprise settings page still returns **404** (unchanged).
- [ ] Edge — instance with **no license**: page shows the upgrade prompt; the Licensed Features table is not rendered (unchanged).

**Preconditions / test data**

- Self-hosted Formbricks with `ENTERPRISE_LICENSE_KEY` set and the license server reachable.
- Owner or admin account (the page 404s for members).

**Risks & regressions**

- Low; additive change to a data-driven table. Re-check that the Licensed Features table renders all existing rows plus Workflows, and that license parsing still succeeds for responses that omit `workflows` (covered by `default(false)`).

**Migrations / env / cutover**

- none
