### PR TITLE
feat: project API key scopes to SpiceDB

### DIFF
--- a/apps/web/lib/authzed/api-key.test.ts
+++ b/apps/web/lib/authzed/api-key.test.ts
@@ -1,0 +1,467 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { logger } from "@formbricks/logger";
+import { reconcileApiKeyRelationships } from "./api-key";
+import { getAuthzedClient } from "./client";
+import { isAuthzedEnabled } from "./config";
+import { AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES } from "./constants";
+import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
+
+const clientMocks = {
+  deleteRelationships: vi.fn(),
+  writeRelationships: vi.fn(),
+};
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    apiKey: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("./client", () => ({
+  getAuthzedClient: vi.fn(),
+}));
+
+vi.mock("./config", () => ({
+  isAuthzedEnabled: vi.fn(),
+}));
+
+const API_KEY_ID = "api-key-private-id";
+const ORGANIZATION_ID = "organization-private-id";
+const WORKSPACE_ID = "workspace-private-id";
+
+const createSnapshot = ({
+  apiKeyId = API_KEY_ID,
+  organizationAccess = {
+    accessControl: {
+      read: false,
+      write: false,
+    },
+  },
+  permission = "read",
+  workspaceId = WORKSPACE_ID,
+}: Readonly<{
+  apiKeyId?: string;
+  organizationAccess?: unknown;
+  permission?: "manage" | "read" | "write" | null;
+  workspaceId?: string;
+}> = {}) => ({
+  apiKeyWorkspaces:
+    permission === null
+      ? []
+      : [
+          {
+            permission,
+            workspaceId,
+          },
+        ],
+  id: apiKeyId,
+  organizationAccess,
+  organizationId: ORGANIZATION_ID,
+});
+
+const setStableSnapshot = (
+  options: Parameters<typeof createSnapshot>[0] = {}
+): ReturnType<typeof createSnapshot> => {
+  const snapshot = createSnapshot(options);
+  vi.mocked(prisma.apiKey.findMany).mockResolvedValue([snapshot] as never);
+  return snapshot;
+};
+
+describe("API key relationship projection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isAuthzedEnabled).mockReturnValue(true);
+    vi.mocked(getAuthzedClient).mockReturnValue(
+      clientMocks as unknown as ReturnType<typeof getAuthzedClient>
+    );
+    clientMocks.deleteRelationships.mockResolvedValue(undefined);
+    clientMocks.writeRelationships.mockResolvedValue(undefined);
+    setStableSnapshot();
+  });
+
+  test("reads only authorization-bearing API key fields", async () => {
+    await reconcileApiKeyRelationships({ apiKeyIds: [API_KEY_ID] });
+
+    expect(prisma.apiKey.findMany).toHaveBeenCalledWith({
+      where: {
+        id: {
+          in: [API_KEY_ID],
+        },
+      },
+      select: {
+        apiKeyWorkspaces: {
+          select: {
+            permission: true,
+            workspaceId: true,
+          },
+          orderBy: {
+            workspaceId: "asc",
+          },
+        },
+        id: true,
+        organizationAccess: true,
+        organizationId: true,
+      },
+      orderBy: {
+        id: "asc",
+      },
+    });
+
+    const serializedQuery = JSON.stringify(vi.mocked(prisma.apiKey.findMany).mock.calls[0]);
+    expect(serializedQuery).not.toContain("hashedKey");
+    expect(serializedQuery).not.toContain("lookupHash");
+    expect(serializedQuery).not.toContain("lastUsedAt");
+    expect(serializedQuery).not.toContain("createdBy");
+  });
+
+  test("projects the API key organization parent", async () => {
+    await reconcileApiKeyRelationships({ apiKeyIds: [API_KEY_ID] });
+
+    expect(clientMocks.writeRelationships.mock.calls.flatMap(([batch]) => batch)).toContainEqual({
+      operation: "touch",
+      relationship: {
+        relation: "organization",
+        resource: { objectId: API_KEY_ID, objectType: "api_key" },
+        subject: { objectId: ORGANIZATION_ID, objectType: "organization" },
+      },
+    });
+  });
+
+  test.each([
+    [false, false, []],
+    [true, false, ["api_key_reader"]],
+    [false, true, ["api_key_writer"]],
+    [true, true, ["api_key_reader", "api_key_writer"]],
+  ] as const)(
+    "projects organization access read=%s write=%s independently",
+    async (read, write, touchedRelations) => {
+      setStableSnapshot({
+        organizationAccess: {
+          accessControl: {
+            read,
+            write,
+          },
+        },
+      });
+
+      await reconcileApiKeyRelationships({ apiKeyIds: [API_KEY_ID] });
+
+      const organizationUpdates = clientMocks.writeRelationships.mock.calls
+        .flatMap(([batch]) => batch)
+        .filter(({ relationship }) => relationship.resource.objectType === "organization");
+      expect(organizationUpdates).toHaveLength(2);
+      expect(
+        organizationUpdates
+          .filter(({ operation }) => operation === "touch")
+          .map(({ relationship }) => relationship.relation)
+      ).toEqual(touchedRelations);
+      expect(organizationUpdates.filter(({ operation }) => operation === "delete")).toHaveLength(
+        2 - touchedRelations.length
+      );
+    }
+  );
+
+  test.each([
+    undefined,
+    null,
+    [],
+    {},
+    { accessControl: null },
+    { accessControl: { read: "true", write: 1 } },
+  ])("treats malformed organization access as no access", async (organizationAccess) => {
+    setStableSnapshot({ organizationAccess });
+
+    await reconcileApiKeyRelationships({ apiKeyIds: [API_KEY_ID] });
+
+    const organizationUpdates = clientMocks.writeRelationships.mock.calls
+      .flatMap(([batch]) => batch)
+      .filter(({ relationship }) => relationship.resource.objectType === "organization");
+    expect(organizationUpdates).toHaveLength(2);
+    expect(organizationUpdates.every(({ operation }) => operation === "delete")).toBe(true);
+  });
+
+  test.each([
+    ["read", "reader"],
+    ["write", "writer"],
+    ["manage", "manager"],
+  ] as const)(
+    "projects a %s workspace scope and deletes its alternate grants",
+    async (permission, relation) => {
+      setStableSnapshot({ permission });
+
+      await reconcileApiKeyRelationships({ apiKeyIds: [API_KEY_ID] });
+
+      const workspaceUpdates = clientMocks.writeRelationships.mock.calls
+        .flatMap(([batch]) => batch)
+        .filter(({ relationship }) => relationship.resource.objectType === "workspace");
+      expect(workspaceUpdates).toHaveLength(3);
+      expect(workspaceUpdates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            operation: "touch",
+            relationship: expect.objectContaining({
+              relation,
+              subject: { objectId: API_KEY_ID, objectType: "api_key" },
+            }),
+          }),
+        ])
+      );
+      expect(workspaceUpdates.filter(({ operation }) => operation === "delete")).toHaveLength(2);
+    }
+  );
+
+  test("projects multiple workspace scopes independently", async () => {
+    vi.mocked(prisma.apiKey.findMany).mockResolvedValue([
+      {
+        ...createSnapshot({ permission: null }),
+        apiKeyWorkspaces: [
+          { permission: "read", workspaceId: "workspace-a" },
+          { permission: "manage", workspaceId: "workspace-b" },
+        ],
+      },
+    ] as never);
+
+    await reconcileApiKeyRelationships({ apiKeyIds: [API_KEY_ID] });
+
+    const touchedWorkspaceRelations = clientMocks.writeRelationships.mock.calls
+      .flatMap(([batch]) => batch)
+      .filter(
+        ({ operation, relationship }) =>
+          operation === "touch" && relationship.resource.objectType === "workspace"
+      )
+      .map(({ relationship }) => relationship.relation);
+    expect(touchedWorkspaceRelations).toEqual(["reader", "manager"]);
+  });
+
+  test("deletes a workspace scope observed before a concurrent source removal", async () => {
+    const withScope = createSnapshot({ permission: "manage" });
+    const withoutScope = createSnapshot({ permission: null });
+    vi.mocked(prisma.apiKey.findMany)
+      .mockResolvedValueOnce([withScope] as never)
+      .mockResolvedValueOnce([withoutScope] as never)
+      .mockResolvedValueOnce([withoutScope] as never)
+      .mockResolvedValueOnce([withoutScope] as never);
+
+    await expect(reconcileApiKeyRelationships({ apiKeyIds: [API_KEY_ID] })).resolves.toEqual({
+      passes: 2,
+      status: "projected",
+    });
+
+    const secondPassUpdates = clientMocks.writeRelationships.mock.calls[1][0];
+    const workspaceUpdates = secondPassUpdates.filter(
+      ({ relationship }) => relationship.resource.objectType === "workspace"
+    );
+    expect(workspaceUpdates).toHaveLength(3);
+    expect(workspaceUpdates.every(({ operation }) => operation === "delete")).toBe(true);
+  });
+
+  test("reconciles a complete snapshot again when organization access changes concurrently", async () => {
+    const reader = createSnapshot({
+      organizationAccess: { accessControl: { read: true, write: false } },
+    });
+    const writer = createSnapshot({
+      organizationAccess: { accessControl: { read: false, write: true } },
+    });
+    vi.mocked(prisma.apiKey.findMany)
+      .mockResolvedValueOnce([reader] as never)
+      .mockResolvedValueOnce([writer] as never)
+      .mockResolvedValueOnce([writer] as never)
+      .mockResolvedValueOnce([writer] as never);
+
+    await expect(reconcileApiKeyRelationships({ apiKeyIds: [API_KEY_ID] })).resolves.toEqual({
+      passes: 2,
+      status: "projected",
+    });
+
+    expect(clientMocks.writeRelationships).toHaveBeenCalledTimes(2);
+  });
+
+  test("converges when a missing API key is recreated during reconciliation", async () => {
+    const recreatedApiKey = createSnapshot({
+      organizationAccess: { accessControl: { read: true, write: false } },
+      permission: "write",
+    });
+    vi.mocked(prisma.apiKey.findMany)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([recreatedApiKey] as never)
+      .mockResolvedValueOnce([recreatedApiKey] as never)
+      .mockResolvedValueOnce([recreatedApiKey] as never);
+
+    await expect(reconcileApiKeyRelationships({ apiKeyIds: [API_KEY_ID] })).resolves.toEqual({
+      passes: 2,
+      status: "projected",
+    });
+
+    expect(clientMocks.deleteRelationships).toHaveBeenCalledTimes(3);
+    expect(clientMocks.writeRelationships).toHaveBeenCalledTimes(1);
+    expect(clientMocks.writeRelationships.mock.calls[0][0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation: "touch",
+          relationship: expect.objectContaining({ relation: "api_key_reader" }),
+        }),
+        expect.objectContaining({
+          operation: "touch",
+          relationship: expect.objectContaining({ relation: "writer" }),
+        }),
+      ])
+    );
+  });
+
+  test("returns a stable failure after three changing snapshots", async () => {
+    const reader = createSnapshot({
+      organizationAccess: { accessControl: { read: true, write: false } },
+    });
+    const writer = createSnapshot({
+      organizationAccess: { accessControl: { read: false, write: true } },
+    });
+    vi.mocked(prisma.apiKey.findMany)
+      .mockResolvedValueOnce([reader] as never)
+      .mockResolvedValueOnce([writer] as never)
+      .mockResolvedValueOnce([reader] as never)
+      .mockResolvedValueOnce([writer] as never)
+      .mockResolvedValueOnce([reader] as never)
+      .mockResolvedValueOnce([writer] as never);
+
+    await expect(reconcileApiKeyRelationships({ apiKeyIds: [API_KEY_ID] })).resolves.toEqual({
+      attempts: 3,
+      code: "authzed_projection_unstable",
+      retryable: false,
+      status: "failed",
+    });
+  });
+
+  test("deduplicates and deterministically orders API key targets", async () => {
+    const secondApiKeyId = "another-api-key";
+    vi.mocked(prisma.apiKey.findMany).mockResolvedValue([
+      createSnapshot({ apiKeyId: secondApiKeyId }),
+      createSnapshot(),
+    ] as never);
+
+    await reconcileApiKeyRelationships({
+      apiKeyIds: [API_KEY_ID, secondApiKeyId, API_KEY_ID],
+    });
+
+    expect(prisma.apiKey.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: {
+            in: [secondApiKeyId, API_KEY_ID],
+          },
+        },
+      })
+    );
+  });
+
+  test("packs at most 1,000 updates without splitting an organization access pair", async () => {
+    const apiKeys = Array.from({ length: 334 }, (_, index) =>
+      createSnapshot({ apiKeyId: `api-key-${index}`, permission: null })
+    );
+    vi.mocked(prisma.apiKey.findMany).mockResolvedValue(apiKeys as never);
+
+    await reconcileApiKeyRelationships({ apiKeyIds: apiKeys.map(({ id }) => id) });
+
+    expect(clientMocks.writeRelationships).toHaveBeenCalledTimes(2);
+    expect(clientMocks.writeRelationships.mock.calls[0][0]).toHaveLength(1_000);
+    expect(clientMocks.writeRelationships.mock.calls[1][0]).toHaveLength(2);
+    expect(
+      clientMocks.writeRelationships.mock.calls[1][0].every(
+        ({ relationship }) => relationship.resource.objectType === "organization"
+      )
+    ).toBe(true);
+  });
+
+  test("cleans every resource and subject relationship for a missing API key", async () => {
+    vi.mocked(prisma.apiKey.findMany).mockResolvedValue([]);
+
+    await reconcileApiKeyRelationships({ apiKeyIds: [API_KEY_ID] });
+
+    expect(clientMocks.deleteRelationships).toHaveBeenNthCalledWith(1, {
+      resourceId: API_KEY_ID,
+      resourceType: "api_key",
+    });
+    expect(clientMocks.deleteRelationships).toHaveBeenNthCalledWith(2, {
+      resourceType: "organization",
+      subject: { objectId: API_KEY_ID, objectType: "api_key" },
+    });
+    expect(clientMocks.deleteRelationships).toHaveBeenNthCalledWith(3, {
+      resourceType: "workspace",
+      subject: { objectId: API_KEY_ID, objectType: "api_key" },
+    });
+  });
+
+  test("bounds parallel relationship deletion for large API key cascades", async () => {
+    const missingApiKeyIds = Array.from({ length: 12 }, (_, index) => `missing-api-key-${index}`);
+    let activeDeletes = 0;
+    let maxActiveDeletes = 0;
+    vi.mocked(prisma.apiKey.findMany).mockResolvedValue([]);
+    clientMocks.deleteRelationships.mockImplementation(async () => {
+      activeDeletes++;
+      maxActiveDeletes = Math.max(maxActiveDeletes, activeDeletes);
+      await Promise.resolve();
+      activeDeletes--;
+    });
+
+    await reconcileApiKeyRelationships({ apiKeyIds: missingApiKeyIds });
+
+    expect(clientMocks.deleteRelationships).toHaveBeenCalledTimes(missingApiKeyIds.length * 3);
+    expect(maxActiveDeletes).toBe(AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES);
+  });
+
+  test("returns disabled before reading PostgreSQL or constructing a client", async () => {
+    vi.mocked(isAuthzedEnabled).mockReturnValue(false);
+
+    await expect(reconcileApiKeyRelationships({ apiKeyIds: [API_KEY_ID] })).resolves.toEqual({
+      status: "disabled",
+    });
+
+    expect(prisma.apiKey.findMany).not.toHaveBeenCalled();
+    expect(getAuthzedClient).not.toHaveBeenCalled();
+  });
+
+  test("treats an empty target set as a zero-pass no-op without constructing a client", async () => {
+    await expect(reconcileApiKeyRelationships({})).resolves.toEqual({
+      passes: 0,
+      status: "projected",
+    });
+
+    expect(prisma.apiKey.findMany).not.toHaveBeenCalled();
+    expect(getAuthzedClient).not.toHaveBeenCalled();
+  });
+
+  test("contains operational failures with sanitized logs and results", async () => {
+    clientMocks.writeRelationships.mockRejectedValue(
+      new AuthzedError({
+        attempts: 3,
+        cause: new Error("raw-sdk-message-with-private-api-key"),
+        code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+        operation: "write_relationships",
+        retryable: true,
+      })
+    );
+
+    await expect(reconcileApiKeyRelationships({ apiKeyIds: [API_KEY_ID] })).resolves.toEqual({
+      attempts: 3,
+      code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+      retryable: true,
+      status: "failed",
+    });
+
+    const serializedLog = JSON.stringify(vi.mocked(logger.warn).mock.calls[0]);
+    expect(serializedLog).not.toContain(API_KEY_ID);
+    expect(serializedLog).not.toContain(ORGANIZATION_ID);
+    expect(serializedLog).not.toContain(WORKSPACE_ID);
+    expect(serializedLog).not.toContain("private-api-key");
+    expect(serializedLog).not.toContain("raw-sdk-message");
+  });
+});

--- a/apps/web/lib/authzed/api-key.ts
+++ b/apps/web/lib/authzed/api-key.ts
@@ -217,6 +217,9 @@ export const reconcileApiKeyRelationships = async (
       return 0;
     }
 
+    // Workspace scopes are immutable today, so current snapshots contain every workspace that needs
+    // reconciliation. If scope removal is added, callers must also target pre-change workspace IDs
+    // so stale subject-side grants are deleted.
     const observedWorkspaceIds = new Map(apiKeyIds.map((apiKeyId) => [apiKeyId, new Set<string>()]));
 
     for (let pass = 1; pass <= AUTHZED_MAX_RECONCILIATION_PASSES; pass++) {

--- a/apps/web/lib/authzed/api-key.ts
+++ b/apps/web/lib/authzed/api-key.ts
@@ -1,0 +1,234 @@
+import "server-only";
+import { prisma } from "@formbricks/database";
+import { ApiKeyPermission } from "@formbricks/database/prisma";
+import { type TAuthzedRelationshipFilter, type TAuthzedRelationshipUpdate, getAuthzedClient } from "./client";
+import {
+  AUTHZED_MAX_RECONCILIATION_PASSES,
+  AuthzedProjectionUnstableError,
+  type TAuthzedProjectionResult,
+  runBestEffortProjection,
+} from "./projection";
+import { deleteRelationshipsInBoundedBatches, packRelationshipUpdateGroups } from "./relationship-batches";
+
+const ORGANIZATION_ACCESS_RELATIONS = {
+  read: "api_key_reader",
+  write: "api_key_writer",
+} as const;
+
+const WORKSPACE_RELATIONS = {
+  [ApiKeyPermission.manage]: "manager",
+  [ApiKeyPermission.read]: "reader",
+  [ApiKeyPermission.write]: "writer",
+} as const satisfies Record<ApiKeyPermission, string>;
+
+const WORKSPACE_RELATION_NAMES = Object.values(WORKSPACE_RELATIONS);
+
+export type TApiKeyProjectionTargets = Readonly<{
+  apiKeyIds?: ReadonlyArray<string>;
+}>;
+
+type TOrganizationAccessSnapshot = Readonly<{
+  read: boolean;
+  write: boolean;
+}>;
+
+type TApiKeyWorkspaceSnapshot = Readonly<{
+  permission: ApiKeyPermission;
+  workspaceId: string;
+}>;
+
+type TApiKeySnapshot = ReadonlyArray<
+  Readonly<{
+    apiKeyWorkspaces: ReadonlyArray<TApiKeyWorkspaceSnapshot>;
+    id: string;
+    organizationAccess: TOrganizationAccessSnapshot;
+    organizationId: string;
+  }>
+>;
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const normalizeOrganizationAccess = (value: unknown): TOrganizationAccessSnapshot => {
+  if (!isRecord(value) || !isRecord(value.accessControl)) {
+    return { read: false, write: false };
+  }
+
+  return {
+    read: value.accessControl.read === true,
+    write: value.accessControl.write === true,
+  };
+};
+
+const normalizeTargets = (targets: TApiKeyProjectionTargets): ReadonlyArray<string> =>
+  [...new Set(targets.apiKeyIds ?? [])].sort((left, right) => left.localeCompare(right));
+
+const readSnapshot = async (apiKeyIds: ReadonlyArray<string>): Promise<TApiKeySnapshot> => {
+  const apiKeys = await prisma.apiKey.findMany({
+    where: {
+      id: {
+        in: [...apiKeyIds],
+      },
+    },
+    select: {
+      apiKeyWorkspaces: {
+        select: {
+          permission: true,
+          workspaceId: true,
+        },
+        orderBy: {
+          workspaceId: "asc",
+        },
+      },
+      id: true,
+      organizationAccess: true,
+      organizationId: true,
+    },
+    orderBy: {
+      id: "asc",
+    },
+  });
+
+  return apiKeys.map((apiKey) => ({
+    apiKeyWorkspaces: apiKey.apiKeyWorkspaces,
+    id: apiKey.id,
+    organizationAccess: normalizeOrganizationAccess(apiKey.organizationAccess),
+    organizationId: apiKey.organizationId,
+  }));
+};
+
+const snapshotsMatch = (left: TApiKeySnapshot, right: TApiKeySnapshot): boolean =>
+  JSON.stringify(left) === JSON.stringify(right);
+
+const createParentUpdate = (apiKeyId: string, organizationId: string): TAuthzedRelationshipUpdate => ({
+  operation: "touch",
+  relationship: {
+    relation: "organization",
+    resource: { objectId: apiKeyId, objectType: "api_key" },
+    subject: { objectId: organizationId, objectType: "organization" },
+  },
+});
+
+const createOrganizationAccessUpdates = (
+  apiKeyId: string,
+  organizationId: string,
+  organizationAccess: TOrganizationAccessSnapshot
+): ReadonlyArray<TAuthzedRelationshipUpdate> =>
+  (Object.keys(ORGANIZATION_ACCESS_RELATIONS) as ReadonlyArray<keyof TOrganizationAccessSnapshot>).map(
+    (permission) => ({
+      operation: organizationAccess[permission] ? "touch" : "delete",
+      relationship: {
+        relation: ORGANIZATION_ACCESS_RELATIONS[permission],
+        resource: { objectId: organizationId, objectType: "organization" },
+        subject: { objectId: apiKeyId, objectType: "api_key" },
+      },
+    })
+  );
+
+const createWorkspaceUpdates = (
+  apiKeyId: string,
+  workspaceId: string,
+  permission: ApiKeyPermission | null
+): ReadonlyArray<TAuthzedRelationshipUpdate> =>
+  WORKSPACE_RELATION_NAMES.map((relation) => ({
+    operation: permission !== null && relation === WORKSPACE_RELATIONS[permission] ? "touch" : "delete",
+    relationship: {
+      relation,
+      resource: { objectId: workspaceId, objectType: "workspace" },
+      subject: { objectId: apiKeyId, objectType: "api_key" },
+    },
+  }));
+
+const addObservedWorkspaceTargets = (
+  observedWorkspaceIds: Map<string, Set<string>>,
+  snapshot: TApiKeySnapshot
+): void => {
+  for (const apiKey of snapshot) {
+    const workspaceIds = observedWorkspaceIds.get(apiKey.id);
+    if (!workspaceIds) {
+      continue;
+    }
+
+    for (const grant of apiKey.apiKeyWorkspaces) {
+      workspaceIds.add(grant.workspaceId);
+    }
+  }
+};
+
+const writeSnapshot = async (
+  apiKeyIds: ReadonlyArray<string>,
+  snapshot: TApiKeySnapshot,
+  observedWorkspaceIds: ReadonlyMap<string, ReadonlySet<string>>
+): Promise<void> => {
+  const client = getAuthzedClient();
+  const apiKeysById = new Map(snapshot.map((apiKey) => [apiKey.id, apiKey]));
+  const updateGroups: TAuthzedRelationshipUpdate[][] = [];
+
+  for (const apiKey of snapshot) {
+    updateGroups.push([createParentUpdate(apiKey.id, apiKey.organizationId)]);
+    updateGroups.push([
+      ...createOrganizationAccessUpdates(apiKey.id, apiKey.organizationId, apiKey.organizationAccess),
+    ]);
+
+    const currentGrants = new Map(
+      apiKey.apiKeyWorkspaces.map((grant) => [grant.workspaceId, grant.permission])
+    );
+    const workspaceIds = [...(observedWorkspaceIds.get(apiKey.id) ?? [])].sort((left, right) =>
+      left.localeCompare(right)
+    );
+
+    for (const workspaceId of workspaceIds) {
+      updateGroups.push([
+        ...createWorkspaceUpdates(apiKey.id, workspaceId, currentGrants.get(workspaceId) ?? null),
+      ]);
+    }
+  }
+
+  for (const batch of packRelationshipUpdateGroups(updateGroups)) {
+    await client.writeRelationships(batch);
+  }
+
+  const deletionFilters: TAuthzedRelationshipFilter[] = [];
+  for (const apiKeyId of apiKeyIds) {
+    if (apiKeysById.has(apiKeyId)) {
+      continue;
+    }
+
+    deletionFilters.push({ resourceId: apiKeyId, resourceType: "api_key" });
+    deletionFilters.push({
+      resourceType: "organization",
+      subject: { objectId: apiKeyId, objectType: "api_key" },
+    });
+    deletionFilters.push({
+      resourceType: "workspace",
+      subject: { objectId: apiKeyId, objectType: "api_key" },
+    });
+  }
+
+  await deleteRelationshipsInBoundedBatches(client, deletionFilters);
+};
+
+export const reconcileApiKeyRelationships = async (
+  targets: TApiKeyProjectionTargets
+): Promise<TAuthzedProjectionResult> =>
+  runBestEffortProjection("reconcile_api_key_relationships", "api_key", async () => {
+    const apiKeyIds = normalizeTargets(targets);
+    if (apiKeyIds.length === 0) {
+      return 0;
+    }
+
+    const observedWorkspaceIds = new Map(apiKeyIds.map((apiKeyId) => [apiKeyId, new Set<string>()]));
+
+    for (let pass = 1; pass <= AUTHZED_MAX_RECONCILIATION_PASSES; pass++) {
+      const sourceSnapshot = await readSnapshot(apiKeyIds);
+      addObservedWorkspaceTargets(observedWorkspaceIds, sourceSnapshot);
+      await writeSnapshot(apiKeyIds, sourceSnapshot, observedWorkspaceIds);
+
+      const verifiedSnapshot = await readSnapshot(apiKeyIds);
+      if (snapshotsMatch(sourceSnapshot, verifiedSnapshot)) {
+        return pass;
+      }
+    }
+
+    throw new AuthzedProjectionUnstableError();
+  });

--- a/apps/web/lib/authzed/api-key.ts
+++ b/apps/web/lib/authzed/api-key.ts
@@ -13,7 +13,7 @@ import { deleteRelationshipsInBoundedBatches, packRelationshipUpdateGroups } fro
 const ORGANIZATION_ACCESS_RELATIONS = {
   read: "api_key_reader",
   write: "api_key_writer",
-} as const;
+} as const satisfies Record<keyof TOrganizationAccessSnapshot, string>;
 
 const WORKSPACE_RELATIONS = {
   [ApiKeyPermission.manage]: "manager",

--- a/apps/web/lib/authzed/relationship-batches.ts
+++ b/apps/web/lib/authzed/relationship-batches.ts
@@ -1,0 +1,41 @@
+import "server-only";
+import type { TAuthzedClient, TAuthzedRelationshipFilter, TAuthzedRelationshipUpdate } from "./client";
+import { AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES, AUTHZED_MAX_RELATIONSHIP_UPDATES } from "./constants";
+
+export const packRelationshipUpdateGroups = (
+  groups: ReadonlyArray<ReadonlyArray<TAuthzedRelationshipUpdate>>
+): ReadonlyArray<ReadonlyArray<TAuthzedRelationshipUpdate>> => {
+  const batches: TAuthzedRelationshipUpdate[][] = [];
+  let batch: TAuthzedRelationshipUpdate[] = [];
+
+  for (const group of groups) {
+    if (group.length > AUTHZED_MAX_RELATIONSHIP_UPDATES) {
+      throw new Error("AuthZed relationship update group exceeds the maximum batch size");
+    }
+
+    if (batch.length > 0 && batch.length + group.length > AUTHZED_MAX_RELATIONSHIP_UPDATES) {
+      batches.push(batch);
+      batch = [];
+    }
+    batch.push(...group);
+  }
+
+  if (batch.length > 0) {
+    batches.push(batch);
+  }
+
+  return batches;
+};
+
+export const deleteRelationshipsInBoundedBatches = async (
+  client: TAuthzedClient,
+  filters: ReadonlyArray<TAuthzedRelationshipFilter>
+): Promise<void> => {
+  for (let start = 0; start < filters.length; start += AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES) {
+    await Promise.all(
+      filters
+        .slice(start, start + AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES)
+        .map((filter) => client.deleteRelationships(filter))
+    );
+  }
+};

--- a/apps/web/lib/authzed/team-workspace.ts
+++ b/apps/web/lib/authzed/team-workspace.ts
@@ -7,13 +7,13 @@ import {
   type TAuthzedRelationshipUpdate,
   getAuthzedClient,
 } from "./client";
-import { AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES, AUTHZED_MAX_RELATIONSHIP_UPDATES } from "./constants";
 import {
   AUTHZED_MAX_RECONCILIATION_PASSES,
   AuthzedProjectionUnstableError,
   type TAuthzedProjectionResult,
   runBestEffortProjection,
 } from "./projection";
+import { deleteRelationshipsInBoundedBatches, packRelationshipUpdateGroups } from "./relationship-batches";
 
 const TEAM_RELATIONS = {
   [TeamUserRole.admin]: "admin",
@@ -192,40 +192,6 @@ const createWorkspaceTeamUpdates = (
     },
   }));
 
-const packUpdateGroups = (
-  groups: ReadonlyArray<ReadonlyArray<TAuthzedRelationshipUpdate>>
-): ReadonlyArray<ReadonlyArray<TAuthzedRelationshipUpdate>> => {
-  const batches: TAuthzedRelationshipUpdate[][] = [];
-  let batch: TAuthzedRelationshipUpdate[] = [];
-
-  for (const group of groups) {
-    if (batch.length > 0 && batch.length + group.length > AUTHZED_MAX_RELATIONSHIP_UPDATES) {
-      batches.push(batch);
-      batch = [];
-    }
-    batch.push(...group);
-  }
-
-  if (batch.length > 0) {
-    batches.push(batch);
-  }
-
-  return batches;
-};
-
-const deleteRelationshipsInBoundedBatches = async (
-  client: TAuthzedClient,
-  filters: ReadonlyArray<TAuthzedRelationshipFilter>
-): Promise<void> => {
-  for (let start = 0; start < filters.length; start += AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES) {
-    await Promise.all(
-      filters
-        .slice(start, start + AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES)
-        .map((filter) => client.deleteRelationships(filter))
-    );
-  }
-};
-
 const writeSnapshot = async (
   client: TAuthzedClient,
   targets: TNormalizedTargets,
@@ -256,7 +222,7 @@ const writeSnapshot = async (
     updateGroups.push([...createWorkspaceTeamUpdates(target, grant?.permission ?? null)]);
   }
 
-  for (const batch of packUpdateGroups(updateGroups)) {
+  for (const batch of packRelationshipUpdateGroups(updateGroups)) {
     await client.writeRelationships(batch);
   }
 

--- a/apps/web/lib/organization/service.test.ts
+++ b/apps/web/lib/organization/service.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError } from "@formbricks/types/errors";
+import { reconcileApiKeyRelationships } from "@/lib/authzed/api-key";
 import { deleteOrganizationRelationships } from "@/lib/authzed/organization-membership";
 import { reconcileTeamWorkspaceRelationships } from "@/lib/authzed/team-workspace";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
@@ -45,6 +46,9 @@ vi.mock("@/lib/user/service", () => ({
 
 vi.mock("@/lib/authzed/organization-membership", () => ({
   deleteOrganizationRelationships: vi.fn(),
+}));
+vi.mock("@/lib/authzed/api-key", () => ({
+  reconcileApiKeyRelationships: vi.fn(),
 }));
 vi.mock("@/lib/authzed/team-workspace", () => ({
   reconcileTeamWorkspaceRelationships: vi.fn(),
@@ -367,6 +371,7 @@ describe("Organization Service", () => {
         memberships: [],
         workspaces: [],
         teams: [],
+        apiKeys: [{ id: "api-key-1" }],
         feedbackDirectories: [],
       } as any);
 
@@ -376,6 +381,9 @@ describe("Organization Service", () => {
       expect(reconcileTeamWorkspaceRelationships).toHaveBeenCalledWith({
         teamIds: [],
         workspaceIds: [],
+      });
+      expect(reconcileApiKeyRelationships).toHaveBeenCalledWith({
+        apiKeyIds: ["api-key-1"],
       });
       if (IS_FORMBRICKS_CLOUD) {
         expect(cleanupStripeCustomer).toHaveBeenCalledWith("cus_123");
@@ -391,6 +399,7 @@ describe("Organization Service", () => {
         memberships: [],
         workspaces: [{ id: "workspace-1" }],
         teams: [{ id: "team-1" }],
+        apiKeys: [{ id: "api-key-1" }, { id: "api-key-2" }],
         feedbackDirectories: [{ id: "frd_1" }, { id: "frd_2" }],
       } as any);
 
@@ -402,6 +411,9 @@ describe("Organization Service", () => {
       expect(reconcileTeamWorkspaceRelationships).toHaveBeenCalledWith({
         teamIds: ["team-1"],
         workspaceIds: ["workspace-1"],
+      });
+      expect(reconcileApiKeyRelationships).toHaveBeenCalledWith({
+        apiKeyIds: ["api-key-1", "api-key-2"],
       });
     });
   });

--- a/apps/web/lib/organization/service.ts
+++ b/apps/web/lib/organization/service.ts
@@ -14,6 +14,7 @@ import {
   ZOrganizationCreateInput,
 } from "@formbricks/types/organizations";
 import { TUserNotificationSettings } from "@formbricks/types/user";
+import { reconcileApiKeyRelationships } from "@/lib/authzed/api-key";
 import { deleteOrganizationRelationships } from "@/lib/authzed/organization-membership";
 import { runPostCommitProjection } from "@/lib/authzed/projection-boundary";
 import { reconcileTeamWorkspaceRelationships } from "@/lib/authzed/team-workspace";
@@ -301,6 +302,11 @@ export const deleteOrganization = async (organizationId: string) => {
             id: true,
           },
         },
+        apiKeys: {
+          select: {
+            id: true,
+          },
+        },
         feedbackDirectories: {
           select: {
             id: true,
@@ -316,6 +322,11 @@ export const deleteOrganization = async (organizationId: string) => {
       reconcileTeamWorkspaceRelationships({
         teamIds: deletedOrganization.teams.map(({ id }) => id),
         workspaceIds: deletedOrganization.workspaces.map(({ id }) => id),
+      })
+    );
+    await runPostCommitProjection("organization_delete_api_key_cleanup", () =>
+      reconcileApiKeyRelationships({
+        apiKeyIds: deletedOrganization.apiKeys.map(({ id }) => id),
       })
     );
 

--- a/apps/web/modules/organization/settings/api-keys/lib/api-key.ts
+++ b/apps/web/modules/organization/settings/api-keys/lib/api-key.ts
@@ -7,6 +7,8 @@ import { logger } from "@formbricks/logger";
 import { TOrganizationAccess } from "@formbricks/types/api-key";
 import { ZId } from "@formbricks/types/common";
 import { DatabaseError } from "@formbricks/types/errors";
+import { reconcileApiKeyRelationships } from "@/lib/authzed/api-key";
+import { runPostCommitProjection } from "@/lib/authzed/projection-boundary";
 import { CONTROL_HASH } from "@/lib/constants";
 import { hashSecret, hashSha256, parseApiKeyV2, verifySecret } from "@/lib/crypto";
 import { validateInputs } from "@/lib/utils/validate";
@@ -138,6 +140,10 @@ export const deleteApiKey = async (id: string): Promise<ApiKey | null> => {
       },
     });
 
+    await runPostCommitProjection("api_key_delete_relationship_reconciliation", () =>
+      reconcileApiKeyRelationships({ apiKeyIds: [id] })
+    );
+
     return deletedApiKeyData;
   } catch (error) {
     if (error instanceof Prisma.PrismaClientKnownRequestError) {
@@ -197,6 +203,10 @@ export const createApiKey = async (
         apiKeyWorkspaces: true,
       },
     });
+
+    await runPostCommitProjection("api_key_create_relationship_reconciliation", () =>
+      reconcileApiKeyRelationships({ apiKeyIds: [result.id] })
+    );
 
     // Return the new v2 format: fbk_{secret}
     return { ...result, actualKey: `fbk_${secret}` };

--- a/apps/web/modules/organization/settings/api-keys/lib/api-keys.test.ts
+++ b/apps/web/modules/organization/settings/api-keys/lib/api-keys.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { ApiKey, ApiKeyPermission, Prisma } from "@formbricks/database/prisma";
 import { DatabaseError } from "@formbricks/types/errors";
+import { reconcileApiKeyRelationships } from "@/lib/authzed/api-key";
+import { runPostCommitProjection } from "@/lib/authzed/projection-boundary";
 import { TApiKeyWithEnvironmentPermission } from "../types/api-keys";
 import {
   createApiKey,
@@ -50,6 +52,20 @@ vi.mock("@formbricks/database", () => ({
       update: vi.fn(),
     },
   },
+}));
+
+vi.mock("@/lib/authzed/api-key", () => ({
+  reconcileApiKeyRelationships: vi.fn(),
+}));
+
+vi.mock("@/lib/authzed/projection-boundary", () => ({
+  runPostCommitProjection: vi.fn(async (_operation: string, projection: () => Promise<unknown>) => {
+    try {
+      await projection();
+    } catch {
+      // Post-commit projection failures must never replace a successful source mutation.
+    }
+  }),
 }));
 
 vi.mock("crypto", async () => {
@@ -387,6 +403,20 @@ describe("API Key Management", () => {
           id: mockApiKey.id,
         },
       });
+      expect(runPostCommitProjection).toHaveBeenCalledWith(
+        "api_key_delete_relationship_reconciliation",
+        expect.any(Function)
+      );
+      expect(reconcileApiKeyRelationships).toHaveBeenCalledWith({
+        apiKeyIds: [mockApiKey.id],
+      });
+    });
+
+    test("preserves a successful deletion when projection fails", async () => {
+      vi.mocked(prisma.apiKey.delete).mockResolvedValueOnce(mockApiKey);
+      vi.mocked(reconcileApiKeyRelationships).mockRejectedValueOnce(new Error("projection failed"));
+
+      await expect(deleteApiKey(mockApiKey.id)).resolves.toEqual(mockApiKey);
     });
 
     test("throws DatabaseError on prisma error", async () => {
@@ -397,6 +427,7 @@ describe("API Key Management", () => {
       vi.mocked(prisma.apiKey.delete).mockRejectedValueOnce(errToThrow);
 
       await expect(deleteApiKey(mockApiKey.id)).rejects.toThrow(DatabaseError);
+      expect(reconcileApiKeyRelationships).not.toHaveBeenCalled();
     });
 
     test("throws error if prisma throws an error", async () => {
@@ -404,6 +435,7 @@ describe("API Key Management", () => {
       vi.mocked(prisma.apiKey.delete).mockRejectedValueOnce(errToThrow);
 
       await expect(deleteApiKey(mockApiKey.id)).rejects.toThrow(errToThrow);
+      expect(reconcileApiKeyRelationships).not.toHaveBeenCalled();
     });
   });
 
@@ -449,6 +481,13 @@ describe("API Key Management", () => {
           apiKeyWorkspaces: true,
         },
       });
+      expect(runPostCommitProjection).toHaveBeenCalledWith(
+        "api_key_create_relationship_reconciliation",
+        expect.any(Function)
+      );
+      expect(reconcileApiKeyRelationships).toHaveBeenCalledWith({
+        apiKeyIds: [mockApiKey.id],
+      });
     });
 
     test("creates an API key with environment permissions successfully", async () => {
@@ -461,6 +500,16 @@ describe("API Key Management", () => {
 
       expect(result).toEqual({ ...mockApiKeyWithEnvironments, actualKey: "fbk_testSecret123" });
       expect(prisma.apiKey.create).toHaveBeenCalled();
+    });
+
+    test("preserves the one-time API key when projection fails", async () => {
+      vi.mocked(prisma.apiKey.create).mockResolvedValueOnce(mockApiKey);
+      vi.mocked(reconcileApiKeyRelationships).mockRejectedValueOnce(new Error("projection failed"));
+
+      await expect(createApiKey("org123", "user123", mockApiKeyData)).resolves.toEqual({
+        ...mockApiKey,
+        actualKey: "fbk_testSecret123",
+      });
     });
 
     test("rejects create input with duplicate workspaceId", async () => {
@@ -485,6 +534,7 @@ describe("API Key Management", () => {
       vi.mocked(prisma.apiKey.create).mockRejectedValueOnce(errToThrow);
 
       await expect(createApiKey("org123", "user123", mockApiKeyData)).rejects.toThrow(DatabaseError);
+      expect(reconcileApiKeyRelationships).not.toHaveBeenCalled();
     });
 
     test("throws error if prisma throws an error", async () => {
@@ -493,6 +543,7 @@ describe("API Key Management", () => {
       vi.mocked(prisma.apiKey.create).mockRejectedValueOnce(errToThrow);
 
       await expect(createApiKey("org123", "user123", mockApiKeyData)).rejects.toThrow(errToThrow);
+      expect(reconcileApiKeyRelationships).not.toHaveBeenCalled();
     });
   });
 
@@ -505,6 +556,7 @@ describe("API Key Management", () => {
 
       expect(result).toEqual(updatedApiKey);
       expect(prisma.apiKey.update).toHaveBeenCalled();
+      expect(reconcileApiKeyRelationships).not.toHaveBeenCalled();
     });
 
     test("throws DatabaseError on prisma error", async () => {

--- a/apps/web/scripts/authzed-relationships-smoke.ts
+++ b/apps/web/scripts/authzed-relationships-smoke.ts
@@ -12,14 +12,26 @@ const ALICE_ID = "application-graph-alice";
 const BOB_ID = "application-graph-bob";
 const TEAM_RELATIONS = ["admin", "contributor"] as const;
 const WORKSPACE_TEAM_RELATIONS = ["manager_team", "reader_team", "writer_team"] as const;
+const API_KEY_ORGANIZATION_ID = "application-api-key-organization";
+const PRIMARY_API_KEY_WORKSPACE_ID = "application-api-key-primary";
+const SECONDARY_API_KEY_WORKSPACE_ID = "application-api-key-secondary";
+const READER_API_KEY_ID = "application-api-key-reader";
+const WRITER_API_KEY_ID = "application-api-key-writer";
+const MANAGER_API_KEY_ID = "application-api-key-manager";
+const API_KEY_ORGANIZATION_RELATIONS = ["api_key_reader", "api_key_writer"] as const;
+const API_KEY_WORKSPACE_RELATIONS = ["manager", "reader", "writer"] as const;
 
 type TSmokeCommand =
   | "delete"
+  | "delete-api-key"
   | "delete-manager-team"
   | "delete-workspace"
+  | "downgrade-api-key-manager"
   | "downgrade-manager-grant"
   | "remove-alice-memberships"
+  | "remove-api-key-scope"
   | "remove-reader-grant"
+  | "seed-api-key"
   | "seed-team-workspace"
   | "set-billing"
   | "set-owner";
@@ -30,11 +42,15 @@ const writeResult = (result: object): void => {
 
 const isSmokeCommand = (value: string | undefined): value is TSmokeCommand =>
   value === "delete" ||
+  value === "delete-api-key" ||
   value === "delete-manager-team" ||
   value === "delete-workspace" ||
+  value === "downgrade-api-key-manager" ||
   value === "downgrade-manager-grant" ||
   value === "remove-alice-memberships" ||
+  value === "remove-api-key-scope" ||
   value === "remove-reader-grant" ||
+  value === "seed-api-key" ||
   value === "seed-team-workspace" ||
   value === "set-billing" ||
   value === "set-owner";
@@ -63,6 +79,33 @@ const createWorkspaceGrantUpdates = (
       relation,
       resource: { objectId: GRAPH_WORKSPACE_ID, objectType: "workspace" },
       subject: { objectId: teamId, objectType: "team", relation: "member" },
+    },
+  }));
+
+const createApiKeyOrganizationAccessUpdates = (
+  apiKeyId: string,
+  selectedRelation?: (typeof API_KEY_ORGANIZATION_RELATIONS)[number]
+): ReadonlyArray<TAuthzedRelationshipUpdate> =>
+  API_KEY_ORGANIZATION_RELATIONS.map((relation) => ({
+    operation: relation === selectedRelation ? "touch" : "delete",
+    relationship: {
+      relation,
+      resource: { objectId: API_KEY_ORGANIZATION_ID, objectType: "organization" },
+      subject: { objectId: apiKeyId, objectType: "api_key" },
+    },
+  }));
+
+const createApiKeyWorkspaceUpdates = (
+  apiKeyId: string,
+  workspaceId: string,
+  selectedRelation?: (typeof API_KEY_WORKSPACE_RELATIONS)[number]
+): ReadonlyArray<TAuthzedRelationshipUpdate> =>
+  API_KEY_WORKSPACE_RELATIONS.map((relation) => ({
+    operation: relation === selectedRelation ? "touch" : "delete",
+    relationship: {
+      relation,
+      resource: { objectId: workspaceId, objectType: "workspace" },
+      subject: { objectId: apiKeyId, objectType: "api_key" },
     },
   }));
 
@@ -133,6 +176,57 @@ const deleteManagerTeamProjection = async (client: TAuthzedClient): Promise<void
   });
 };
 
+const seedApiKeyProjection = async (client: TAuthzedClient): Promise<void> => {
+  await client.writeRelationships([
+    ...[READER_API_KEY_ID, WRITER_API_KEY_ID, MANAGER_API_KEY_ID].map((apiKeyId) => ({
+      operation: "touch" as const,
+      relationship: {
+        relation: "organization",
+        resource: { objectId: apiKeyId, objectType: "api_key" },
+        subject: { objectId: API_KEY_ORGANIZATION_ID, objectType: "organization" },
+      },
+    })),
+    {
+      operation: "touch",
+      relationship: {
+        relation: "organization",
+        resource: { objectId: PRIMARY_API_KEY_WORKSPACE_ID, objectType: "workspace" },
+        subject: { objectId: API_KEY_ORGANIZATION_ID, objectType: "organization" },
+      },
+    },
+    {
+      operation: "touch",
+      relationship: {
+        relation: "organization",
+        resource: { objectId: SECONDARY_API_KEY_WORKSPACE_ID, objectType: "workspace" },
+        subject: { objectId: API_KEY_ORGANIZATION_ID, objectType: "organization" },
+      },
+    },
+    ...createApiKeyOrganizationAccessUpdates(READER_API_KEY_ID, "api_key_reader"),
+    ...createApiKeyOrganizationAccessUpdates(WRITER_API_KEY_ID, "api_key_writer"),
+    ...createApiKeyOrganizationAccessUpdates(MANAGER_API_KEY_ID),
+    ...createApiKeyWorkspaceUpdates(READER_API_KEY_ID, PRIMARY_API_KEY_WORKSPACE_ID, "reader"),
+    ...createApiKeyWorkspaceUpdates(WRITER_API_KEY_ID, PRIMARY_API_KEY_WORKSPACE_ID, "writer"),
+    ...createApiKeyWorkspaceUpdates(MANAGER_API_KEY_ID, PRIMARY_API_KEY_WORKSPACE_ID, "manager"),
+    ...createApiKeyWorkspaceUpdates(MANAGER_API_KEY_ID, SECONDARY_API_KEY_WORKSPACE_ID, "reader"),
+  ]);
+};
+
+const deleteWriterApiKeyProjection = async (client: TAuthzedClient): Promise<void> => {
+  await client.deleteRelationships({
+    resourceId: WRITER_API_KEY_ID,
+    resourceType: "api_key",
+  });
+  await client.deleteRelationships({
+    resourceType: "organization",
+    subject: { objectId: WRITER_API_KEY_ID, objectType: "api_key" },
+  });
+  await client.deleteRelationships({
+    resourceType: "workspace",
+    subject: { objectId: WRITER_API_KEY_ID, objectType: "api_key" },
+  });
+};
+
 const executeSmokeCommand = async (client: TAuthzedClient, command: TSmokeCommand): Promise<void> => {
   switch (command) {
     case "delete":
@@ -142,6 +236,22 @@ const executeSmokeCommand = async (client: TAuthzedClient, command: TSmokeComman
       return;
     case "seed-team-workspace":
       await seedTeamWorkspaceProjection(client);
+      return;
+    case "seed-api-key":
+      await seedApiKeyProjection(client);
+      return;
+    case "downgrade-api-key-manager":
+      await client.writeRelationships(
+        createApiKeyWorkspaceUpdates(MANAGER_API_KEY_ID, PRIMARY_API_KEY_WORKSPACE_ID, "writer")
+      );
+      return;
+    case "remove-api-key-scope":
+      await client.writeRelationships(
+        createApiKeyWorkspaceUpdates(MANAGER_API_KEY_ID, SECONDARY_API_KEY_WORKSPACE_ID)
+      );
+      return;
+    case "delete-api-key":
+      await deleteWriterApiKeyProjection(client);
       return;
     case "downgrade-manager-grant":
       await client.writeRelationships(createWorkspaceGrantUpdates(MANAGER_TEAM_ID, "reader_team"));

--- a/apps/web/scripts/authzed-relationships-smoke.ts
+++ b/apps/web/scripts/authzed-relationships-smoke.ts
@@ -18,6 +18,7 @@ const SECONDARY_API_KEY_WORKSPACE_ID = "application-api-key-secondary";
 const READER_API_KEY_ID = "application-api-key-reader";
 const WRITER_API_KEY_ID = "application-api-key-writer";
 const MANAGER_API_KEY_ID = "application-api-key-manager";
+const COMBINED_ACCESS_API_KEY_ID = "application-api-key-combined-access";
 const API_KEY_ORGANIZATION_RELATIONS = ["api_key_reader", "api_key_writer"] as const;
 const API_KEY_WORKSPACE_RELATIONS = ["manager", "reader", "writer"] as const;
 
@@ -84,10 +85,10 @@ const createWorkspaceGrantUpdates = (
 
 const createApiKeyOrganizationAccessUpdates = (
   apiKeyId: string,
-  selectedRelation?: (typeof API_KEY_ORGANIZATION_RELATIONS)[number]
+  selectedRelations: ReadonlyArray<(typeof API_KEY_ORGANIZATION_RELATIONS)[number]> = []
 ): ReadonlyArray<TAuthzedRelationshipUpdate> =>
   API_KEY_ORGANIZATION_RELATIONS.map((relation) => ({
-    operation: relation === selectedRelation ? "touch" : "delete",
+    operation: selectedRelations.includes(relation) ? "touch" : "delete",
     relationship: {
       relation,
       resource: { objectId: API_KEY_ORGANIZATION_ID, objectType: "organization" },
@@ -178,14 +179,16 @@ const deleteManagerTeamProjection = async (client: TAuthzedClient): Promise<void
 
 const seedApiKeyProjection = async (client: TAuthzedClient): Promise<void> => {
   await client.writeRelationships([
-    ...[READER_API_KEY_ID, WRITER_API_KEY_ID, MANAGER_API_KEY_ID].map((apiKeyId) => ({
-      operation: "touch" as const,
-      relationship: {
-        relation: "organization",
-        resource: { objectId: apiKeyId, objectType: "api_key" },
-        subject: { objectId: API_KEY_ORGANIZATION_ID, objectType: "organization" },
-      },
-    })),
+    ...[READER_API_KEY_ID, WRITER_API_KEY_ID, MANAGER_API_KEY_ID, COMBINED_ACCESS_API_KEY_ID].map(
+      (apiKeyId) => ({
+        operation: "touch" as const,
+        relationship: {
+          relation: "organization",
+          resource: { objectId: apiKeyId, objectType: "api_key" },
+          subject: { objectId: API_KEY_ORGANIZATION_ID, objectType: "organization" },
+        },
+      })
+    ),
     {
       operation: "touch",
       relationship: {
@@ -202,9 +205,13 @@ const seedApiKeyProjection = async (client: TAuthzedClient): Promise<void> => {
         subject: { objectId: API_KEY_ORGANIZATION_ID, objectType: "organization" },
       },
     },
-    ...createApiKeyOrganizationAccessUpdates(READER_API_KEY_ID, "api_key_reader"),
-    ...createApiKeyOrganizationAccessUpdates(WRITER_API_KEY_ID, "api_key_writer"),
+    ...createApiKeyOrganizationAccessUpdates(READER_API_KEY_ID, ["api_key_reader"]),
+    ...createApiKeyOrganizationAccessUpdates(WRITER_API_KEY_ID, ["api_key_writer"]),
     ...createApiKeyOrganizationAccessUpdates(MANAGER_API_KEY_ID),
+    ...createApiKeyOrganizationAccessUpdates(COMBINED_ACCESS_API_KEY_ID, [
+      "api_key_reader",
+      "api_key_writer",
+    ]),
     ...createApiKeyWorkspaceUpdates(READER_API_KEY_ID, PRIMARY_API_KEY_WORKSPACE_ID, "reader"),
     ...createApiKeyWorkspaceUpdates(WRITER_API_KEY_ID, PRIMARY_API_KEY_WORKSPACE_ID, "writer"),
     ...createApiKeyWorkspaceUpdates(MANAGER_API_KEY_ID, PRIMARY_API_KEY_WORKSPACE_ID, "manager"),

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -138,8 +138,8 @@ The organization-membership projection boundary covers:
   cascades.
 
 User deletion removes both organization-role and team-role relationships for
-the deleted user. API-key relationship projection remains owned by a later
-ticket.
+the deleted user. API-key projection is described separately below because API
+keys are independent authorization subjects rather than user-owned role edges.
 
 The application facade accepts only Formbricks-owned relationship types. It
 supports idempotent `touch`/`delete` batches of at most 1,000 updates and safely
@@ -195,6 +195,49 @@ assignment, organization-role promotions, membership removal, API v2 nested
 organization-user team changes, and user/organization cascades. Existing
 records are not backfilled here: ENG-1718 remains mandatory before AuthZed
 shadow evaluation or enforcement.
+
+## API-key scope projection
+
+PostgreSQL remains authoritative for API-key ownership and access. After API
+key creation commits, Formbricks reconciles:
+
+- `ApiKey.organizationId` to `api_key#organization@organization`;
+- `organizationAccess.accessControl.read` to
+  `organization#api_key_reader@api_key`;
+- `organizationAccess.accessControl.write` to
+  `organization#api_key_writer@api_key`;
+- `ApiKeyWorkspace.permission` (`read`, `write`, or `manage`) to exactly one
+  `workspace#reader`, `workspace#writer`, or `workspace#manager` relationship
+  whose subject is the API key.
+
+The organization-access flags are independent. Missing, malformed, or
+non-boolean JSON values are treated as `false`, matching the current evaluator.
+Each workspace scope touches its selected relation and deletes the other two,
+so repeating a write is idempotent and a lower permission removes any stale
+higher grant.
+
+API-key scopes are selected during creation and are not editable today. Label
+and `lastUsedAt` updates do not affect authorization and therefore do not
+project. There is no separate revoked state in the current data model: deleting
+an API key is revocation.
+
+Deletion cleanup removes every relationship on the API-key resource and every
+organization or workspace relationship where the API key is the subject.
+Organization deletion captures API-key IDs before PostgreSQL cascades and then
+performs the same idempotent cleanup. Workspace deletion is already covered by
+the workspace projector, which deletes every relationship on the missing
+workspace resource.
+
+The projector reads only IDs, organization access, and workspace permissions;
+it never reads or logs plaintext keys, hashes, lookup hashes, creator metadata,
+or usage timestamps. Reconciliation uses the same post-commit, best-effort,
+three-pass convergence and bounded batching contract as organization, team,
+and workspace projection.
+
+Existing API keys are not backfilled by mutation hooks. ENG-1718 must perform
+authoritative backfill and repair before API-key shadow evaluation or
+enforcement is enabled. Routing API-key principals through the central
+interface remains ENG-1731, and SpiceDB comparison/cutover remains ENG-1738.
 
 ## Resource parent resolution during the current-model migration
 

--- a/docker/authzed-smoke.sh
+++ b/docker/authzed-smoke.sh
@@ -272,6 +272,14 @@ jq --exit-status '.status == "projected"' <<<"${api_key_seed}" >/dev/null
     api_key:application-api-key-writer --consistency-full
 )" == *"true"* ]]
 [[ "$(
+  zed permission check organization:application-api-key-organization read_access \
+    api_key:application-api-key-combined-access --consistency-full
+)" == *"true"* ]]
+[[ "$(
+  zed permission check organization:application-api-key-organization manage_access \
+    api_key:application-api-key-combined-access --consistency-full
+)" == *"true"* ]]
+[[ "$(
   zed permission check workspace:application-api-key-primary read \
     api_key:application-api-key-reader --consistency-full
 )" == *"true"* ]]
@@ -478,6 +486,10 @@ jq --exit-status '.status == "projected"' <<<"${restored_projection}" >/dev/null
 [[ "$(
   zed permission check organization:application-api-key-organization manage_access \
     api_key:application-api-key-writer --consistency-full
+)" == *"true"* ]]
+[[ "$(
+  zed permission check organization:application-api-key-organization manage_access \
+    api_key:application-api-key-combined-access --consistency-full
 )" == *"true"* ]]
 [[ "$(
   zed permission check workspace:application-api-key-primary manage \

--- a/docker/authzed-smoke.sh
+++ b/docker/authzed-smoke.sh
@@ -257,6 +257,82 @@ jq --exit-status '.status == "projected"' <<<"${idempotent_deleted_projection}" 
     user:application-relationship-smoke --consistency-full
 )" == *"false"* ]]
 
+api_key_seed="$(authzed_relationships "${AUTHZED_TOKEN}" seed-api-key)"
+jq --exit-status '.status == "projected"' <<<"${api_key_seed}" >/dev/null
+[[ "$(
+  zed permission check organization:application-api-key-organization read_access \
+    api_key:application-api-key-reader --consistency-full
+)" == *"true"* ]]
+[[ "$(
+  zed permission check organization:application-api-key-organization manage_access \
+    api_key:application-api-key-reader --consistency-full
+)" == *"false"* ]]
+[[ "$(
+  zed permission check organization:application-api-key-organization manage_access \
+    api_key:application-api-key-writer --consistency-full
+)" == *"true"* ]]
+[[ "$(
+  zed permission check workspace:application-api-key-primary read \
+    api_key:application-api-key-reader --consistency-full
+)" == *"true"* ]]
+[[ "$(
+  zed permission check workspace:application-api-key-primary write \
+    api_key:application-api-key-reader --consistency-full
+)" == *"false"* ]]
+[[ "$(
+  zed permission check workspace:application-api-key-primary write \
+    api_key:application-api-key-writer --consistency-full
+)" == *"true"* ]]
+[[ "$(
+  zed permission check workspace:application-api-key-primary manage \
+    api_key:application-api-key-writer --consistency-full
+)" == *"false"* ]]
+[[ "$(
+  zed permission check workspace:application-api-key-primary manage \
+    api_key:application-api-key-manager --consistency-full
+)" == *"true"* ]]
+[[ "$(
+  zed permission check workspace:application-api-key-secondary read \
+    api_key:application-api-key-manager --consistency-full
+)" == *"true"* ]]
+
+downgraded_api_key="$(
+  authzed_relationships "${AUTHZED_TOKEN}" downgrade-api-key-manager
+)"
+jq --exit-status '.status == "projected"' <<<"${downgraded_api_key}" >/dev/null
+[[ "$(
+  zed permission check workspace:application-api-key-primary manage \
+    api_key:application-api-key-manager --consistency-full
+)" == *"false"* ]]
+[[ "$(
+  zed permission check workspace:application-api-key-primary write \
+    api_key:application-api-key-manager --consistency-full
+)" == *"true"* ]]
+
+removed_api_key_scope="$(
+  authzed_relationships "${AUTHZED_TOKEN}" remove-api-key-scope
+)"
+jq --exit-status '.status == "projected"' <<<"${removed_api_key_scope}" >/dev/null
+[[ "$(
+  zed permission check workspace:application-api-key-secondary read \
+    api_key:application-api-key-manager --consistency-full
+)" == *"false"* ]]
+
+deleted_api_key="$(authzed_relationships "${AUTHZED_TOKEN}" delete-api-key)"
+idempotent_deleted_api_key="$(
+  authzed_relationships "${AUTHZED_TOKEN}" delete-api-key
+)"
+jq --exit-status '.status == "projected"' <<<"${deleted_api_key}" >/dev/null
+jq --exit-status '.status == "projected"' <<<"${idempotent_deleted_api_key}" >/dev/null
+[[ "$(
+  zed permission check organization:application-api-key-organization read_access \
+    api_key:application-api-key-writer --consistency-full
+)" == *"false"* ]]
+[[ "$(
+  zed permission check workspace:application-api-key-primary read \
+    api_key:application-api-key-writer --consistency-full
+)" == *"false"* ]]
+
 team_workspace_seed="$(authzed_relationships "${AUTHZED_TOKEN}" seed-team-workspace)"
 jq --exit-status '.status == "projected"' <<<"${team_workspace_seed}" >/dev/null
 [[ "$(
@@ -342,6 +418,8 @@ persisted_team_workspace_seed="$(
   authzed_relationships "${AUTHZED_TOKEN}" seed-team-workspace
 )"
 jq --exit-status '.status == "projected"' <<<"${persisted_team_workspace_seed}" >/dev/null
+persisted_api_key_seed="$(authzed_relationships "${AUTHZED_TOKEN}" seed-api-key)"
+jq --exit-status '.status == "projected"' <<<"${persisted_api_key_seed}" >/dev/null
 
 zed relationship create organization:smoke owner user:alice
 zed relationship create workspace:smoke organization organization:smoke
@@ -397,12 +475,24 @@ jq --exit-status '.status == "projected"' <<<"${restored_projection}" >/dev/null
   zed permission check workspace:application-graph-smoke read \
     user:application-graph-bob --consistency-full
 )" == *"true"* ]]
+[[ "$(
+  zed permission check organization:application-api-key-organization manage_access \
+    api_key:application-api-key-writer --consistency-full
+)" == *"true"* ]]
+[[ "$(
+  zed permission check workspace:application-api-key-primary manage \
+    api_key:application-api-key-manager --consistency-full
+)" == *"true"* ]]
+[[ "$(
+  zed permission check workspace:application-api-key-secondary read \
+    api_key:application-api-key-manager --consistency-full
+)" == *"true"* ]]
 
 persisted_schema_check="$(authzed_schema "${AUTHZED_TOKEN}" check)"
 jq --exit-status '.status == "matched" and .differenceCount == 0' <<<"${persisted_schema_check}" >/dev/null
 
 service_logs="$(compose logs --no-color postgres authzed-db-bootstrap spicedb-migrate spicedb)"
-application_outputs="${empty_schema_health}${wrong_token_health}${empty_schema_check}${initial_apply}${matched_schema_check}${unchanged_apply}${drift_schema_write}${drifted_schema_check}${restored_apply}${refused_relationship_driver}${owner_projection}${billing_projection}${idempotent_billing_projection}${deleted_projection}${idempotent_deleted_projection}${team_workspace_seed}${downgraded_manager_grant}${removed_reader_grant}${removed_alice_memberships}${team_workspace_reseed}${deleted_manager_team}${idempotent_deleted_manager_team}${team_workspace_reseed_for_delete}${deleted_graph_workspace}${idempotent_deleted_graph_workspace}${persisted_team_workspace_seed}${unavailable_health}${unavailable_projection}${restored_health}${restored_projection}${persisted_schema_check}"
+application_outputs="${empty_schema_health}${wrong_token_health}${empty_schema_check}${initial_apply}${matched_schema_check}${unchanged_apply}${drift_schema_write}${drifted_schema_check}${restored_apply}${refused_relationship_driver}${owner_projection}${billing_projection}${idempotent_billing_projection}${deleted_projection}${idempotent_deleted_projection}${api_key_seed}${downgraded_api_key}${removed_api_key_scope}${deleted_api_key}${idempotent_deleted_api_key}${team_workspace_seed}${downgraded_manager_grant}${removed_reader_grant}${removed_alice_memberships}${team_workspace_reseed}${deleted_manager_team}${idempotent_deleted_manager_team}${team_workspace_reseed_for_delete}${deleted_graph_workspace}${idempotent_deleted_graph_workspace}${persisted_team_workspace_seed}${persisted_api_key_seed}${unavailable_health}${unavailable_projection}${restored_health}${restored_projection}${persisted_schema_check}"
 if [[ "${service_logs}${application_outputs}" == *"${AUTHZED_TOKEN}"* || \
   "${service_logs}${application_outputs}" == *"${WRONG_AUTHZED_TOKEN}"* || \
   "${service_logs}${application_outputs}" == *"${AUTHZED_DATABASE_PASSWORD}"* || \
@@ -411,4 +501,4 @@ if [[ "${service_logs}${application_outputs}" == *"${AUTHZED_TOKEN}"* || \
   exit 1
 fi
 
-printf '%s\n' "AuthZed smoke test passed: schema lifecycle, organization/team/workspace projection, multi-team permission union, grant and membership revocation, idempotent cascade cleanup, health, authentication failure, bounded outage handling, migrations, and persistence were verified."
+printf '%s\n' "AuthZed smoke test passed: schema lifecycle, organization/team/workspace/API-key projection, permission ladders, grant and membership revocation, idempotent cascade cleanup, health, authentication failure, bounded outage handling, migrations, and persistence were verified."


### PR DESCRIPTION
## What does this PR do?

Implements [ENG-1717](https://linear.app/formbricks/issue/ENG-1717/project-existing-api-key-workspace-scopes-into-spicedb) on top of the relationship-projection foundation merged in #8670.

This PR:

- adds a server-only API-key projector for organization ownership, organization access-control read/write flags, and existing workspace `read`/`write`/`manage` grants;
- reconciles complete PostgreSQL snapshots for up to three passes and deletes stale alternate permission relations atomically;
- cleans deleted API keys on both the resource and subject sides, including organization-delete cascades;
- extracts the existing 1,000-operation grouping and bounded deletion behavior into a shared internal projection utility;
- invokes projection after API-key creation/deletion and organization deletion without changing successful source mutations when AuthZed is unavailable;
- extends the isolated Docker smoke test to cover API-key permission ladders, multiple workspace scopes, downgrade/removal, deletion, outage recovery, and persistence;
- covers the independent `accessControl.read=true` plus `accessControl.write=true` state and compile-time completeness of the organization-access relation map;
- records the current immutable-workspace-scope invariant so future scope editing must reconcile pre-change workspace IDs and remove stale grants;
- documents the current API-key projection and repair contract.

PostgreSQL and the legacy evaluator remain authoritative. The canonical SpiceDB schema is unchanged.

Out of scope:

- API-key authorization through the central evaluator (ENG-1731);
- historical backfill and global repair (ENG-1718);
- SpiceDB shadow comparison or enforcement (ENG-1738);
- editable/new API-key scopes, UI changes, database migrations, or environment changes.

There are no visual changes.

## How should this be tested?

Automated validation completed locally with Node 22.22.0:

```bash
CUBEJS_API_URL=https://cube.formbricks.local \
HUB_API_URL=https://hub.formbricks.local \
HUB_API_KEY=test-hub-key \
pnpm --filter @formbricks/web exec vitest run \
  lib/authzed \
  modules/organization/settings/api-keys \
  lib/organization/service.test.ts \
  modules/workspaces/settings/lib/workspace.test.ts
```

Result: 17 test files and 228 tests passed.

```bash
pnpm --filter @formbricks/web typecheck
pnpm authzed:validate
pnpm authzed:smoke
pnpm build --filter=@formbricks/web... --force
```

Results:

- web typecheck passed;
- schema validation loaded 27 relationships and passed 131 assertions plus 2 expected-relations checks;
- the isolated Docker smoke test passed API-key organization access (including simultaneous read/write flags), all workspace grant levels, multiple scopes, downgrade/removal, idempotent deletion, outage recovery, migrations, and persistence;
- a forced production build passed with AuthZed disabled;
- a production build passed with AuthZed enabled and `127.0.0.1:1` as an unreachable endpoint, confirming no build-time RPC.

Review the projector tests for the four organization-access combinations, all three workspace permissions, malformed JSON, batching, bounded deletion, concurrent source changes, recreation, disabled behavior, and secret-safe failures.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings introduced by this change; there are none
- [x] Removed all `console.logs`
- [x] Started from and rechecked the latest `epic/authzed` target branch
- [x] My changes don't cause any responsiveness issues
- [x] Not my first PR at Formbricks

### Appreciated

- [x] No UI change was made, so screenshots are not applicable
- [x] Updated the AuthZed authorization documentation
