### PR TITLE
chore(deps): document pnpm audit findings pending upstream fixes

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -122,6 +122,22 @@ overrides:
   # are devDependency-only (eslint, prettier plugins and @redocly/cli, all via minimatch) and never run
   # against untrusted input, so the residual risk is accepted until their consumers move to
   # brace-expansion@5 — a pin cannot close it.
+  # Re-checked 2026-07-30: minimatch@10.2.6 (published 2026-07-27) now depends on brace-expansion
+  # ^5.0.8, which would close the redocly/vite-plugin-dts paths that resolve through our minimatch@10
+  # pin above — but the release is not yet 3 days old (our minimumReleaseAge cooldown), and it's high
+  # (not Urgent/Critical), so it isn't eligible for the pin yet. Bump the minimatch@10 override to
+  # 10.2.6 once it clears cooldown; the eslint (minimatch@3) and glob (minimatch@5/9) paths still have
+  # no brace-expansion@5-compatible release to move to.
+  #
+  # GHSA-p2fr-6hmx-4528 (@better-auth/oauth-provider, moderate): access tokens can be issued for
+  # unauthorized audiences via unbound resource indicators. This is a live gap, not theoretical — the
+  # MCP OAuth provider config sets `validAudiences` (apps/web/modules/auth/lib/mcp-oauth-provider-options.ts).
+  # The fix first shipped in 1.7.0-beta.4 (2026-06-10) and is still only on the beta/rc channels
+  # (1.7.0-rc.2 as of 2026-07-30); there is no patched 1.6.x or stable 1.7.0 release to pin to. Adopting
+  # it means moving the whole better-auth stack (better-auth, @better-auth/core, @better-auth/oauth-provider)
+  # off latest onto a release candidate for a security-critical auth path, which is a materially bigger
+  # and riskier change than a version pin. Per policy we only bypass the cooldown for Urgent/Critical;
+  # this is Moderate, so it stays tracked here — bump to the 1.7.0 stable release once it ships.
 
 autoInstallPeers: true
 linkWorkspacePackages: true


### PR DESCRIPTION
## What & why

Ran `pnpm audit` as part of a scheduled dependency-vulnerability sweep. It surfaced two advisories:

- **GHSA-mh99-v99m-4gvg** — `brace-expansion` (**high**): DoS via unbounded expansion length.
- **GHSA-p2fr-6hmx-4528** — `@better-auth/oauth-provider` (**moderate**): access tokens can be issued for unauthorized audiences via unbound resource indicators. This one is a live gap, not theoretical — the MCP OAuth provider config sets `validAudiences` (`apps/web/modules/auth/lib/mcp-oauth-provider-options.ts`).

Neither is Urgent/Critical, so per our release-age cooldown policy (`minimumReleaseAge: 4320` in `pnpm-workspace.yaml`) they don't get a cooldown exception, and investigation showed neither has a safe, cooldown-eligible fix to pin right now:

- `brace-expansion`: `minimatch@10.2.6` (published 2026-07-27) now depends on a patched `brace-expansion@^5.0.8`, but it's under 3 days old, so it isn't eligible for our `minimatch@10` override yet. The eslint (`minimatch@3`) and glob (`minimatch@5`/`9`) dependency chains still have no `brace-expansion@5`-compatible release to move to at all, so this can't be fully closed by a pin regardless of cooldown.
- `@better-auth/oauth-provider`: the fix only shipped on the `better-auth` 1.7.0 beta/rc channel (first in `1.7.0-beta.4`, 2026-06-10); there is still no patched 1.6.x or stable 1.7.0 release. Pinning to a release candidate would mean moving the whole auth stack (`better-auth`, `@better-auth/core`, `@better-auth/oauth-provider`) off `latest` onto a prerelease for a security-critical path — a materially bigger and riskier change than a version pin, so it's being tracked instead of forced.

This PR adds a dated tracking note for both in `pnpm-workspace.yaml`, next to the existing accepted-risk documentation for other audit findings, so the next dependency sweep knows what's still open and why, and what needs to happen to close each one (cooldown clearing for the first, a stable 1.7.0 release for the second). No dependency versions changed.

## Linear ticket

No ticket — this is a routine scheduled `pnpm audit` sweep, not tied to a planned piece of work.

## How this was tested

- `pnpm i` ✅
- `pnpm test` ✅ (531 test files, 6667 tests passed)
- `pnpm lint` ✅ (0 errors; pre-existing warnings only, unrelated to this change)
- `pnpm build` ✅ (full monorepo build succeeded)
- `pnpm audit` re-run after the change — same 2 findings reported, confirming this is a documentation-only change with no functional/dependency impact.

## QA / Test Plan

**How to test**

- [ ] Run `pnpm audit` on `main` → confirm it reports the same 1 high (`brace-expansion`) + 1 moderate (`@better-auth/oauth-provider`) findings as before this PR (no regression, no new findings introduced).
- [ ] Run `pnpm i`, `pnpm build`, and boot the app → confirm no change in behavior (this PR only edits a comment block in `pnpm-workspace.yaml`).

**Preconditions / test data**

- None.

**Risks & regressions**

- None expected — the only change is a comment addition in `pnpm-workspace.yaml`; no `overrides`, dependency versions, or code paths changed.

**Migrations / env / cutover**

- none


---
_Generated by [Claude Code](https://claude.ai/code/session_01MHbCVXxztSFRcn7mSHFUwb)_