### PR TITLE
chore: remove runtime react deps from root package.json (#1693)

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,6 @@
     "i18n:validate": "pnpm scan-translations",
     "dev:setup": "bash scripts/setup-dev-env.sh"
   },
-  "dependencies": {
-    "react": "19.2.6",
-    "react-dom": "19.2.6"
-  },
   "devDependencies": {
     "@axe-core/playwright": "4.11.3",
     "@azure/playwright": "1.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,13 +31,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      react:
-        specifier: 19.2.6
-        version: 19.2.6
-      react-dom:
-        specifier: 19.2.6
-        version: 19.2.6(react@19.2.6)
     devDependencies:
       '@axe-core/playwright':
         specifier: 4.11.3


### PR DESCRIPTION
&lt;!-- PR title must follow Conventional Commits: https://www.conventionalcommits.org/en/v1.0.0/#summary --&gt;

## What & why

The root `package.json` listed `react` and `react-dom` under `dependencies`, even though a workspace root should only carry tooling. They were there purely to force hoisted resolution under the non-strict node-linker. `apps/web`, `packages/email`, and `packages/survey-ui` already declare their own `react`/`react-dom`, so the root copy was redundant and misleading (it reads as if the root itself ships runtime React code).

This removes the `dependencies` block from the root `package.json` and updates `pnpm-lock.yaml` accordingly.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1693/remove-runtime-dependencies-from-the-root-packagejson

## How this was tested

- `pnpm install` — resolves cleanly (186 packages removed, 49 added due to dedupe shift; no errors).
- `pnpm build` ✅ — all 12 build tasks pass, including `@formbricks/web`, `@formbricks/email`, and `@formbricks/survey-ui` (the packages that depend on React).
- `pnpm lint` ✅ — 0 errors (41 pre-existing warnings, unrelated to this change).
- `pnpm test` ✅ — 532 test files / 6684 tests passed.

No UI-facing change — this is a dependency-graph cleanup only.

## QA / Test Plan

**How to test**

- [ ] Run `pnpm install && pnpm build` from a clean clone → build succeeds with no missing-React errors in `apps/web`, `packages/email`, or `packages/survey-ui`.

**Preconditions / test data**

- None.

**Risks & regressions**

- Low risk: `react`/`react-dom` remain declared directly in every package that actually imports them. If pnpm's hoisting behavior changed such that some other package relied on the root's copy without declaring it itself, that package's build would fail — the full `pnpm build` run above did not surface this.

**Migrations / env / cutover**

- none


---
_Generated by [Claude Code](https://claude.ai/code/session_014ZmRDsC7aC54sbPTZSkcPf)_