### PR TITLE
fix(workflows): commit the editor title rename on Enter (ENG-1969)

### DIFF
--- a/apps/web/modules/ee/workflows/components/workflow-page-title.tsx
+++ b/apps/web/modules/ee/workflows/components/workflow-page-title.tsx
@@ -66,7 +66,10 @@ export const WorkflowPageTitle = ({ workflowId, isReadOnly }: Readonly<WorkflowP
   // settled, and the draft is flushed right away rather than waiting out the autosave debounce,
   // which turns the header's "Changes saved" pill into the confirmation.
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    if (event.key !== "Enter") return;
+    // An IME (Japanese/Chinese/Korean) uses Enter to accept the highlighted candidate, so
+    // committing there would blur mid-composition and persist a half-typed name. The synthetic
+    // event doesn't carry isComposing; the native one does.
+    if (event.key !== "Enter" || event.nativeEvent.isComposing) return;
     event.preventDefault();
     // The PATCH contract requires a name, so an empty field keeps focus for an in-place fix;
     // save() is still called either way because it owns both the error and the success feedback.

--- a/apps/web/modules/ee/workflows/components/workflow-page-title.tsx
+++ b/apps/web/modules/ee/workflows/components/workflow-page-title.tsx
@@ -3,10 +3,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAtomValue, useSetAtom } from "jotai";
 import { usePathname, useRouter, useSearchParams, useSelectedLayoutSegment } from "next/navigation";
-import { useEffect, useRef } from "react";
+import { type KeyboardEvent, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { cn } from "@/lib/cn";
 import { WorkflowStatusPill } from "@/modules/ee/workflows/components/workflow-status-pill";
+import { useWorkflowBuilder } from "@/modules/ee/workflows/hooks/use-workflow-builder";
 import { getWorkflow } from "@/modules/ee/workflows/lib/api-client";
 import { workflowKeys } from "@/modules/ee/workflows/lib/query";
 import { setWorkflowNameAtom, workflowAtom, workflowNameAtom } from "@/modules/ee/workflows/state/editor";
@@ -21,8 +22,9 @@ interface WorkflowPageTitleProps {
 // once the atom carries a name, so the builder page never double-fetches.
 //
 // On the edit tab the title doubles as the name editor: it binds to the draft atom and is
-// persisted by the page-level autosave. A workflow arriving from the dialog-less
-// create flow (?new=1) gets the title focused and selected so the user names it immediately.
+// persisted by the page-level autosave, with Enter committing it immediately. A workflow arriving
+// from the dialog-less create flow (?new=1) gets the title focused and selected so the user names
+// it immediately.
 export const WorkflowPageTitle = ({ workflowId, isReadOnly }: Readonly<WorkflowPageTitleProps>) => {
   const { t } = useTranslation();
   const segment = useSelectedLayoutSegment();
@@ -35,6 +37,8 @@ export const WorkflowPageTitle = ({ workflowId, isReadOnly }: Readonly<WorkflowP
   const inputRef = useRef<HTMLInputElement>(null);
   const hasAutoFocusedRef = useRef(false);
   const isNew = searchParams.get("new") === "1";
+  // Actions and atom state only — the builder page owns the load and the debounced autosave.
+  const { save } = useWorkflowBuilder({ workflowId, isReadOnly, loadOnMount: false });
 
   const { data } = useQuery({
     queryKey: workflowKeys.detail(workflowId),
@@ -58,6 +62,18 @@ export const WorkflowPageTitle = ({ workflowId, isReadOnly }: Readonly<WorkflowP
     router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
   }, [isNew, isEditable, searchParams, router, pathname]);
 
+  // Enter commits the rename instead of doing nothing: the field blurs so the title reads as
+  // settled, and the draft is flushed right away rather than waiting out the autosave debounce,
+  // which turns the header's "Changes saved" pill into the confirmation.
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Enter") return;
+    event.preventDefault();
+    // The PATCH contract requires a name, so an empty field keeps focus for an in-place fix;
+    // save() is still called either way because it owns both the error and the success feedback.
+    if (workflowName.trim()) inputRef.current?.blur();
+    void save();
+  };
+
   const resolved = workflow ?? data;
   if (!resolved) return null;
 
@@ -69,6 +85,7 @@ export const WorkflowPageTitle = ({ workflowId, isReadOnly }: Readonly<WorkflowP
           ref={inputRef}
           value={workflowName}
           onChange={(event) => setWorkflowName(event.target.value)}
+          onKeyDown={handleKeyDown}
           aria-label={t("common.workflow_name")}
           placeholder={t("common.workflow_name")}
           // Approximates content sizing where field-sizing is unsupported (Firefox/Safari).

--- a/apps/web/modules/ee/workflows/hooks/use-workflow-builder.test.ts
+++ b/apps/web/modules/ee/workflows/hooks/use-workflow-builder.test.ts
@@ -149,6 +149,34 @@ describe("save", () => {
     expect(updateWorkflow).not.toHaveBeenCalled();
   });
 
+  test("reports a missing name even while another save is in flight", async () => {
+    getWorkflow.mockResolvedValue(apiWorkflow);
+    // Never settles, so the first save stays in flight and the overlap guard stays armed.
+    updateWorkflow.mockReturnValue(new Promise(() => undefined));
+
+    const { result, store } = renderBuilder({ workflowId: "wf-api", isReadOnly: false });
+    await waitFor(() => expect(result.current.workflow?.id).toBe("wf-api"));
+
+    await act(async () => {
+      void result.current.save();
+    });
+    await waitFor(() => expect(result.current.isSaving).toBe(true));
+    expect(updateWorkflow).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      store.set(setWorkflowNameAtom, "   ");
+    });
+    await act(async () => {
+      await expect(result.current.save()).resolves.toBe(false);
+    });
+
+    // The overlap guard must not swallow the validation message: the title field commits with
+    // Enter, so a silent refusal here reads as "Enter did nothing" all over again.
+    expect(toastError).toHaveBeenCalledWith("workspace.workflows.name_required");
+    // Still no second PATCH — the guard's actual job is intact.
+    expect(updateWorkflow).toHaveBeenCalledTimes(1);
+  });
+
   test("PATCHes via API", async () => {
     getWorkflow.mockResolvedValue(apiWorkflow);
     updateWorkflow.mockResolvedValue(apiWorkflow);

--- a/apps/web/modules/ee/workflows/hooks/use-workflow-builder.ts
+++ b/apps/web/modules/ee/workflows/hooks/use-workflow-builder.ts
@@ -134,20 +134,23 @@ export const useWorkflowBuilder = ({
   // Resolves true only when the draft was actually persisted.
   const save = useCallback(
     async ({ silent = false }: { silent?: boolean } = {}): Promise<boolean> => {
-      // Don't overlap with an in-flight save or lifecycle transition; a save landing during an
-      // enable/disable can clobber the transitioned status (and vice versa).
-      if (store.get(isWorkflowSavingAtom) || store.get(isWorkflowTransitioningAtom)) return false;
-
       const state = store.get(workflowEditorAtom);
       const currentWorkflow = state.workflow;
       const currentDefinition = state.definition;
       if (!currentWorkflow || !currentDefinition) return false;
 
+      // Validated ahead of the overlap guard below so an explicit save always explains a missing
+      // name. Behind it, clearing the name while a save or transition was in flight returned
+      // silently — and a title rename committed with Enter would look like it did nothing.
       const trimmedName = state.workflowName.trim();
       if (!trimmedName) {
         if (!silent) toast.error(t("workspace.workflows.name_required"));
         return false;
       }
+
+      // Don't overlap with an in-flight save or lifecycle transition; a save landing during an
+      // enable/disable can clobber the transitioned status (and vice versa).
+      if (store.get(isWorkflowSavingAtom) || store.get(isWorkflowTransitioningAtom)) return false;
 
       const trimmedDescription = state.workflowDescription.trim() || null;
       const payload: TPatchWorkflowInput = { name: trimmedName, description: trimmedDescription };


### PR DESCRIPTION
## What & why

In the workflow editor the page title doubles as the name field — an always-visible inline `<input>` while the workflow is editable. The input carried only an `onChange` handler and had no wrapping `<form>`, so **pressing Enter did nothing**: the field kept focus and gave no confirmation, which reads as "the rename was dropped". The name was in fact persisted by the page-level debounced autosave (~2 s), so there was never data loss — only misleading feedback.

`WorkflowPageTitle` now handles Enter: it blurs the field so the title reads as settled, and flushes the draft immediately instead of waiting out the autosave debounce, which makes the header's existing "Changes saved" pill the confirmation. The save goes through the same `useWorkflowBuilder({ loadOnMount: false })` instance the header CTA already uses, so it reuses the existing save path (concurrency guards, dirty tracking, error toasts) rather than adding a second one.

An empty name is the one case that does not blur: the PATCH contract requires a name, so focus stays on the field for an in-place fix while `save()` surfaces the reason.

Two follow-up commits address review findings:

- **IME composition guard** (`657e255a4`) — with an IME active (Japanese/Chinese/Korean), Enter accepts the highlighted candidate. Unguarded, that keystroke committed the rename: `preventDefault()` interfered with the IME's own confirm, and the blur ended the composition and persisted a half-typed name. Guarded on the native event's `isComposing`, since React's synthetic keyboard event doesn't carry it.
- **Name validated before the save overlap guard** (`eb6565445`) — `save()` bailed on its in-flight-save/transition guard before it read the name, so clearing the title during that window returned `false` with no feedback, reproducing this very bug in a narrow window. The name check now runs first, so an explicit save always explains a missing name while the guard still blocks the duplicate PATCH.

Not included: the ticket's secondary "nice-to-have" pencil-icon / tooltip affordance. The premise has partly aged out — the field already has a hover border, a focus ring, and an `aria-label` — and the ticket assigns that discoverability work to the §12 sweep in ENG-1910, so it is better done there with the rest of the pass.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1969/workflows-editor-enter-in-the-workflow-name-field-does-nothing-no

## How this was tested

- `pnpm exec turbo typecheck --filter=@formbricks/web --concurrency=1 --force` → ✅ 10/10 tasks. (An early run failed on unrelated files; the cause was an unbuilt `@formbricks/jobs` in the worktree, fixed by `turbo build --filter=@formbricks/web^...` — not this change.)
- `pnpm exec vitest run modules/ee/workflows` → ✅ 33 files, 327 tests passed.
- **Test added** for the second review fix: `reports a missing name even while another save is in flight` in `use-workflow-builder.test.ts` holds a save open with a never-settling `updateWorkflow`, clears the name, then asserts both the `name_required` toast and that `updateWorkflow` was still called only once. Confirmed it fails on the previous guard ordering (`expected "vi.fn()" to be called with arguments: [ 'workspace.workflows.name_required' ]`) and passes after the reorder.
- `pnpm exec eslint` on the three touched files → ✅ clean. `pnpm exec prettier --check` → ✅ clean.
- No test for the Enter handler or the IME guard: both live in a `.tsx` component, and `AGENTS.md` routes component behavior to Playwright rather than unit tests. No new i18n keys — `workspace.workflows.save_success`, `workspace.workflows.name_required`, and `workspace.workflows.changes_saved` all already exist.
- SonarCloud reports 0 issues and 0 security hotspots on this PR.

**Browser verification not run — needs a reviewer or QA pass on staging.** Two local blockers: workflows are entitlement-gated and this machine's license reports `workflows: false`, and `WEBAPP_URL`/`NEXTAUTH_URL` are pinned to `localhost:3000`, which was occupied by another dev server, so auth redirects could not be exercised on an alternate port. No before/after screenshots for that reason — the QA steps below cover it, and the behavior is a keyboard interaction that a recording conveys better than a still.

## QA / Test Plan

**How to test**

- [ ] Open a **draft** workflow's editor at `/workspaces/{workspaceId}/workflows/{workflowId}` → the title renders as an editable field (hover shows a border).
- [ ] Click the title, type a new name, press **Enter** → the field loses focus (focus ring disappears), a "Workflow saved." toast appears, and the "Changes saved" pill in the header flashes green. Reload → the new name persisted.
- [ ] Clear the title completely and press **Enter** → focus **stays** in the field and a "Please enter a name." toast appears. Nothing is saved.
- [ ] Type a new name and click elsewhere instead of pressing Enter → the name still autosaves within ~2 s and the pill flashes ("Changes saved"). Enter is an accelerator, not the only path.
- [ ] Press **Enter** in the title without changing anything → the field blurs and a save round-trip runs; no error.
- [ ] Repeat the happy path in **Firefox** specifically — the ticket was reported there, and the field uses a `[field-sizing:content]` fallback on that browser.
- [ ] **IME check:** switch the OS input source to Japanese (or Chinese/Korean), click the title, type romaji to open the candidate list, and press **Enter** to accept a candidate → the candidate is committed into the field and the field **keeps focus**; the rename is *not* submitted and the title does not blur. Press Enter a second time (no longer composing) → now it commits, blurs, and saves.
- [ ] Open an **enabled** workflow → the title is still editable (metadata edits are allowed while enabled); Enter commits the rename and the workflow stays enabled.
- [ ] Open an **archived** workflow → the title renders as plain text, not an input; there is nothing to type into.
- [ ] As a **read-only** member, open any workflow → the title renders as plain text; the header shows the "Read-only" pill instead of the autosave pill.
- [ ] Open the workflow's **Runs** tab → the title renders as plain text (not editable) and shows the correct name.
- [ ] Create a workflow via the create flow so the editor opens with `?new=1` → the title is focused and pre-selected; typing a name and pressing Enter commits it in one gesture.

**Preconditions / test data**

- An organization whose plan/license includes the `workflows` entitlement (the editor 403s and shows the upgrade prompt otherwise).
- At least one draft workflow, plus one enabled and one archived workflow to cover the status gates.
- A second account with read-only membership on the workspace for the permissions step.
- For the IME step: an OS input source for Japanese, Chinese, or Korean.

**Risks & regressions**

- Nearby behavior to re-check: the debounced autosave and the "Changes saved" pill (Enter now triggers the same save path, so watch for double saves or a stuck "saving" state), and the `?new=1` autofocus-and-select behavior.
- The name-validation reorder in `use-workflow-builder.ts` affects **every** `save()` caller, not just the title: the header CTA's Save, the autosave, and the pre-transition flush in `enable`/`disable`/`archive`/`unarchive`. Behavior only changes for a non-silent save with an empty name during an overlap — previously silent, now toasts. Silent (autosave) callers are unaffected. Re-check that enabling a workflow still flushes pending edits first.
- Enter now moves focus to the document body. Keyboard-only users continuing with Tab will resume from the start of the document rather than after the title — flagged deliberately, since the ticket asks for the field to blur on commit.
- If Enter is pressed at the exact moment the 2 s autosave fires, the in-flight save wins and Enter's own toast is skipped; the blur and the pill still confirm the commit. Not expected to be observable in normal use.

**Migrations / env / cutover**

- none
