### PR TITLE
fix(surveys): stop the focus trap recursing into a stack overflow (ENG-2090)

### DIFF
--- a/packages/surveys/src/lib/use-focus-trap.test.tsx
+++ b/packages/surveys/src/lib/use-focus-trap.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/preact";
 import { type ComponentChildren } from "preact";
+import { useEffect, useRef } from "preact/hooks";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { useFocusTrap } from "./use-focus-trap";
 
@@ -42,6 +43,64 @@ const FocusTrapUnmountFixture = ({
     ) : null}
   </>
 );
+
+// Mimics a host page that runs its own focus manager (another focus trap, a modal from the embedding
+// app) and pushes focus back out every time it lands inside the survey.
+const CompetingFocusManagerFixture = ({
+  onCompetingRedirect,
+  reactAsynchronously = false,
+}: {
+  onCompetingRedirect: () => void;
+  reactAsynchronously?: boolean;
+}) => {
+  const focusTrapRef = useFocusTrap<HTMLDivElement>({ enabled: true });
+  const outsideButtonRef = useRef<HTMLButtonElement>(null);
+  const onCompetingRedirectRef = useRef(onCompetingRedirect);
+
+  useEffect(() => {
+    onCompetingRedirectRef.current = onCompetingRedirect;
+  }, [onCompetingRedirect]);
+
+  useEffect(() => {
+    const takeFocusOut = () => {
+      const outsideButton = outsideButtonRef.current;
+      if (!outsideButton) return;
+
+      onCompetingRedirectRef.current();
+      outsideButton.focus();
+    };
+
+    const handleFocusIn = (event: FocusEvent) => {
+      const container = focusTrapRef.current;
+      const target = event.target as HTMLElement | null;
+
+      if (!container || !target) return;
+      if (!container.contains(target)) return;
+
+      if (reactAsynchronously) {
+        setTimeout(takeFocusOut, 0);
+        return;
+      }
+
+      takeFocusOut();
+    };
+
+    document.addEventListener("focusin", handleFocusIn);
+    return () => {
+      document.removeEventListener("focusin", handleFocusIn);
+    };
+  }, [focusTrapRef, reactAsynchronously]);
+
+  return (
+    <>
+      <button>Host page button</button>
+      <button ref={outsideButtonRef}>Competing manager target</button>
+      <div ref={focusTrapRef} tabIndex={-1}>
+        <button>Survey action</button>
+      </div>
+    </>
+  );
+};
 
 describe("useFocusTrap", () => {
   afterEach(() => {
@@ -249,6 +308,65 @@ describe("useFocusTrap", () => {
     await waitFor(() => {
       expect(document.activeElement).toBe(screen.getByRole("button", { name: "Enabled action" }));
     });
+  });
+
+  test("gives up instead of recursing when the page fights it for focus", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const onCompetingRedirect = vi.fn();
+
+    render(<CompetingFocusManagerFixture onCompetingRedirect={onCompetingRedirect} />);
+
+    const trappedButton = screen.getByRole("button", { name: "Survey action" });
+    const hostPageButton = screen.getByRole("button", { name: "Host page button" });
+    const trapContainer = trappedButton.parentElement as HTMLElement;
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(trappedButton);
+    });
+
+    // Every round the trap pulls focus back in and the competing manager takes it straight out again.
+    // Before the guards this recursed until "Maximum call stack size exceeded".
+    for (let round = 0; round < 5; round++) {
+      hostPageButton.focus();
+      await Promise.resolve();
+    }
+
+    expect(onCompetingRedirect.mock.calls.length).toBeLessThan(20);
+    expect(warnSpy).toHaveBeenCalled();
+    expect(trapContainer.contains(document.activeElement)).toBe(false);
+
+    warnSpy.mockRestore();
+  });
+
+  test("stops the focus tug-of-war when the page fights back asynchronously", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const onCompetingRedirect = vi.fn();
+
+    render(<CompetingFocusManagerFixture onCompetingRedirect={onCompetingRedirect} reactAsynchronously />);
+
+    const trappedButton = screen.getByRole("button", { name: "Survey action" });
+    const hostPageButton = screen.getByRole("button", { name: "Host page button" });
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(trappedButton);
+    });
+
+    // An async competing manager cannot overflow the stack, but it can keep the two sides swapping
+    // focus forever. The trap has to run out of redirect budget and back off.
+    hostPageButton.focus();
+
+    await waitFor(() => {
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    const redirectsOnBackoff = onCompetingRedirect.mock.calls.length;
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+
+    expect(onCompetingRedirect.mock.calls.length).toBe(redirectsOnBackoff);
+
+    warnSpy.mockRestore();
   });
 
   test("does not move focus when inactive", async () => {

--- a/packages/surveys/src/lib/use-focus-trap.ts
+++ b/packages/surveys/src/lib/use-focus-trap.ts
@@ -7,6 +7,16 @@ type UseFocusTrapOptions = {
   onEscapeKeyDown?: () => void;
 };
 
+// A host page can run its own focus manager (another focus trap, a modal from the embedding app, a
+// second embedded survey bundle). When it pulls focus out every time this trap pulls it back in, the
+// two ping-pong focus synchronously and blow the call stack. Two guards stop that: the trap ignores
+// focus events caused by its own redirects, and it gives up after a few redirects the page undoes.
+const REDIRECT_WINDOW_MS = 250;
+const MAX_REDIRECTS_PER_WINDOW = 10;
+const MAX_FAILED_REDIRECTS = 3;
+
+const getTimestamp = () => (typeof performance === "undefined" ? Date.now() : performance.now());
+
 // focus trap behavior adapted from Radix UI FocusScope (MIT) for this Preact runtime.
 const focusScopesStack = (() => {
   let stack: FocusScope[] = [];
@@ -170,6 +180,57 @@ export const useFocusTrap = <TElement extends HTMLElement>({
       focus(lastFocusedElement ?? firstFocusableElement ?? container, { select: true });
     };
 
+    let isRedirectingFocus = false;
+    let hasYieldedToPage = false;
+    let redirectWindowStart = getTimestamp();
+    let redirectsInWindow = 0;
+    let failedRedirects = 0;
+
+    const yieldToPage = () => {
+      hasYieldedToPage = true;
+      console.warn("Formbricks: focus trap turned off, another focus handler on the page keeps taking focus");
+    };
+
+    const hasRedirectBudget = () => {
+      const timestamp = getTimestamp();
+      if (timestamp - redirectWindowStart > REDIRECT_WINDOW_MS) {
+        redirectWindowStart = timestamp;
+        redirectsInWindow = 0;
+      }
+
+      redirectsInWindow += 1;
+      return redirectsInWindow <= MAX_REDIRECTS_PER_WINDOW;
+    };
+
+    // Pull focus back into the survey. Never re-entrant, so a competing focus manager that reacts to
+    // our own focus move cannot recurse through the handlers below.
+    const redirectFocusIntoContainer = () => {
+      if (isRedirectingFocus || hasYieldedToPage) return;
+
+      if (!hasRedirectBudget()) {
+        yieldToPage();
+        return;
+      }
+
+      isRedirectingFocus = true;
+      try {
+        focusLastElementInsideContainer();
+      } finally {
+        isRedirectingFocus = false;
+      }
+
+      if (container.contains(document.activeElement)) {
+        failedRedirects = 0;
+        return;
+      }
+
+      // Something moved focus straight back out. Stop fighting for it after a few tries.
+      failedRedirects += 1;
+      if (failedRedirects >= MAX_FAILED_REDIRECTS) {
+        yieldToPage();
+      }
+    };
+
     const handleFocusIn = (event: FocusEvent) => {
       if (focusScope.paused) return;
 
@@ -179,7 +240,7 @@ export const useFocusTrap = <TElement extends HTMLElement>({
         return;
       }
 
-      focusLastElementInsideContainer();
+      redirectFocusIntoContainer();
     };
 
     const handleFocusOut = (event: FocusEvent) => {
@@ -187,14 +248,14 @@ export const useFocusTrap = <TElement extends HTMLElement>({
 
       const relatedTarget = event.relatedTarget as HTMLElement | null;
       if (relatedTarget && !container.contains(relatedTarget)) {
-        focusLastElementInsideContainer();
+        redirectFocusIntoContainer();
         return;
       }
 
       if (relatedTarget === null) {
         setTimeout(() => {
           if (!isUnmounting && !container.contains(document.activeElement)) {
-            focusLastElementInsideContainer();
+            redirectFocusIntoContainer();
           }
         }, 0);
       }
@@ -202,7 +263,7 @@ export const useFocusTrap = <TElement extends HTMLElement>({
 
     const handleMutations = () => {
       if (!container.contains(document.activeElement)) {
-        focusLastElementInsideContainer();
+        redirectFocusIntoContainer();
       }
     };
 


### PR DESCRIPTION
## What & why

A user on `qualworld.wallstreetenglish.com` hit a recurring `RangeError: Maximum call stack size exceeded` from `surveys.umd.cjs` whenever a survey was shown, and the tab stopped responding.

`useFocusTrap` pulled focus back into the survey container on every `focusin`/`focusout` that landed outside it, with no re-entrancy guard and no upper bound. That is safe on its own — a single trap's own re-focus always lands inside, so it settles. It is not safe when the host page runs its own focus manager whose container excludes the survey: each side undoes the other, and because browsers dispatch focus events **synchronously**, the two handlers nest inside one another until the stack overflows.

The site embeds the SDK, so `js-core` `<script src>`-loads `/js/surveys.umd.cjs` (`packages/js-core/src/lib/survey/widget.ts:326`) and renders the survey as a modal, which is the normal supported path and legitimately arms the trap. Their own site bundle is a Vite build (`index-<hash>.js`) that runs a focus lock. Nothing about the customer's setup is wrong — the trap simply had no defence against a second focus manager.

I pinned the frames to the exact lines rather than guessing, using the drift-immune intra-module byte deltas between the three reported offsets (`105876`, `107541`, `107724`) measured against an unguarded build:

| Reported frame | Source | `Δ` from previous frame |
| --- | --- | --- |
| `_o` | `use-focus-trap.ts:37` — `element.focus({ preventScroll: true })` | — |
| `u` | `use-focus-trap.ts:180` — `focusLastElementInsideContainer` | 1665 (measured 1666) |
| `p` | `use-focus-trap.ts:250` — `handleFocusOut`, the `relatedTarget` branch | 183 (measured 183, exact) |

`handleFocusIn` gives 107 for that last delta, so it is excluded. `handleFocusOut` being the entry point also matches event ordering: when the host yanks focus away, `focusout` fires on the *losing* element before `focusin` fires on the gaining one, so our `focusout` handler is the one that reacts first.

### The fix

Every re-focus now routes through a single guarded helper, `redirectFocusIntoContainer`:

- **Re-entrancy guard.** A flag is set for the duration of our own `focus()` call. Because the browser dispatches focus events synchronously, the competing manager's counter-move happens *inside* that call, so our handler sees the flag and returns. The cycle stops one level deep instead of nesting. This is what fixes the crash.
- **Bounded budget.** The flag alone cannot stop a manager that reacts on a `setTimeout`/`requestAnimationFrame` — that variant does not overflow the stack but spins focus forever. So the trap gives up after 3 redirects that do not stick, or 10 within 250ms, logging one `console.warn`.

Four call sites changed from `focusLastElementInsideContainer()` to `redirectFocusIntoContainer()`: `handleFocusIn`, both `handleFocusOut` branches, and `handleMutations`. Nothing else moved. Tab cycling, initial autofocus, Escape and the focus restore on close all take the same paths as before, and `handleFocusIn` still records the last focused element before any guard so the trap does not forget where the user was.

Guarding our own side means this holds regardless of who the other focus manager turns out to be — host app code, a browser extension, or a second focus scope. After the guard trips, focus trapping degrades gracefully (the host's manager wins) rather than the tab dying.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2090/maximum-call-stack-size-exceeded-when-survey-is-shown

## How this was tested

**Reproduced the exact failure first**, so the regression tests are known to be meaningful rather than passing vacuously. Against the unmodified hook, the new sync test throws the reported error from the reported place:

```
RangeError: Maximum call stack size exceeded
 ❯ Object.acceptNode               use-focus-trap.ts:88
 ❯ getTabbableCandidates           use-focus-trap.ts:97
 ❯ getTabbableEdges                use-focus-trap.ts:105
 ❯ focusLastElementInsideContainer use-focus-trap.ts:164
```

and the new async test times out (the fight never ends). Both pass with the guard.

**Automated**

- `packages/surveys` — `26 files, 665 tests` ✅ (13 in `use-focus-trap.test.tsx`, 2 of them new)
- `packages/survey-ui` — `4 files, 73 tests` ✅
- `apps/web/playwright/survey-keyboard.spec.ts` — `4 passed` ✅
- `apps/web/playwright/survey-accessibility.spec.ts` — `9 passed` ✅ (axe WCAG AA across desktop/mobile/tablet/forced-colors/reduced-motion/dark/RTL-Arabic)
- `apps/web/playwright/survey.spec.ts` — `3 passed` ✅
- `tsc --noEmit`, `eslint`, `prettier --check` clean on both packages

**Tests added** — two in `use-focus-trap.test.tsx`, driven by a fixture that plays the hostile host page (a document `focusin` listener that pushes focus back out whenever it lands in the trap):

1. competing manager reacting **synchronously** → no runaway, trap warns and yields, focus settles
2. competing manager reacting **on a timer** → trap runs out of budget and backs off, redirect count stops climbing

**Manual, in a real browser (Playwright against a local stack)** — built a throwaway probe that renders this same survey in *modal* mode (so the trap is live) by intercepting the props the link-survey page passes to `renderSurvey`, then opened a dropdown-variant question inside it. Used it to check the fix causes no behaviour change on that path: menu stays open and no page errors on `main`, and identically on this branch. The probe was deleted; it is described here because it is what ruled out an earlier candidate fix (`modal={false}` on the survey dropdowns) that turned out to make dropdowns close instantly inside modal surveys.

No UI change, so no screenshots — the only visible difference is one `console.warn` on pages that fight the trap.

## QA / Test Plan

**How to test**

- [ ] **Regression, normal app-survey focus behaviour.** Create a survey → Settings → *How to send* → **App survey**; *When to send* → add a **Page View** action; Publish. Install the JS snippet from the app's setup instructions on any test page and load it. When the survey modal appears: the first control is focused automatically → pressing `Tab` and `Shift+Tab` cycles **only** through controls inside the survey card and never reaches page content behind it → `Escape` closes the survey → clicking the dark overlay closes it. Expected: all unchanged from before this PR.
- [ ] **Regression, link survey.** Open any published link survey at `/s/<surveyId>`. Answer through to the end using only the keyboard. Expected: unchanged — link surveys render inline and never had the trap active, so this is a no-change check.
- [ ] **Regression, dropdown questions.** In a survey with a single-select and a multi-select question each set to the **dropdown** display type, open both dropdowns. Expected: menu opens, the search box is focused, arrow keys move through options, `Enter`/`Space` selects, `Escape` closes.
- [ ] **The fix itself (needs a host page that also traps focus).** Put the app-survey snippet on a page that also runs its own modal/focus-lock component (any dialog library that re-focuses into itself, e.g. Radix `FocusScope`, `react-focus-lock`, `focus-trap`), and have that component active while the survey is displayed. Move focus between the survey and the page. Expected **before** this change: the tab freezes and the console shows `RangeError: Maximum call stack size exceeded`. Expected **after**: no error, the page stays responsive, and the console shows exactly one `Formbricks: focus trap turned off, another focus handler on the page keeps taking focus`. Focus then follows the host page's manager — that is intended, the survey stops fighting for it.
- [ ] **Edge case, repeated focus changes.** With no competing focus manager, click rapidly between the survey and page content behind the overlay ~10 times. Expected: focus is pulled back into the survey every time and **no** warning appears — the trap must not give up during ordinary use. *(Thresholds are 3 non-sticking redirects, or 10 within 250 ms — please verify the second one cannot be tripped by fast clicking.)*

**Preconditions / test data**

- A published **app** survey with a Page View trigger, plus the JS snippet on a test page. The crash path additionally needs that page to run its own focus-trapping component.
- A published **link** survey, and one survey containing dropdown-display single-select and multi-select questions.
- Applies to Cloud and self-host equally. No feature flag, no plan/entitlement gating.
- Reproducing the original crash needs a build from before this PR.

**Risks & regressions**

- Focus behaviour in **modal (app/website) surveys** is the blast radius: initial autofocus, `Tab`/`Shift+Tab` cycling, `Escape`, click-outside, and focus restoring to the previously focused element after the survey closes.
- Link surveys render inline and never activate the trap, so they are unaffected — worth a spot check regardless since the file is shared.
- **By design, focus trapping now switches itself off** on pages with a competing focus manager (after 3 non-sticking redirects) and logs a warning. On such pages the survey keeps working but focus is governed by the host page. This is the intended trade against crashing.
- Watch for any report of the warning appearing during ordinary single-trap use — that would mean a threshold is too tight.

**Migrations / env / cutover**

- No DB migration, no env changes.
- **Cutover: the CDN cache must be purged for `/js/surveys.umd.cjs` as part of this release.** `apps/web/next.config.mjs` serves `/js/(.*)` with `s-maxage=2592000`, so without a purge affected sites keep loading the old bundle — and keep crashing — for up to 30 days after deploy. Sites embedding the SDK need no change on their side; they pick up the fixed bundle from our origin.
