### PR TITLE
feat(authzed): add relationship sync observability and runbook (ENG-1719)

### DIFF
--- a/apps/web/lib/authzed/__mocks__/client-dependencies.ts
+++ b/apps/web/lib/authzed/__mocks__/client-dependencies.ts
@@ -35,6 +35,13 @@ vi.mock("@authzed/authzed-node", () => ({
       INSECURE_PLAINTEXT_CREDENTIALS: 2,
       SECURE: 0,
     },
+    // Mirrors the real enum. A mock that omitted it would make the facade's completeness assertion
+    // throw a TypeError instead of exercising it.
+    DeleteRelationshipsResponse_DeletionProgress: {
+      COMPLETE: 1,
+      PARTIAL: 2,
+      UNSPECIFIED: 0,
+    },
     NewClient: sdkMocks.newClient,
     RelationshipUpdate_Operation: {
       DELETE: 3,

--- a/apps/web/lib/authzed/__mocks__/client-dependencies.ts
+++ b/apps/web/lib/authzed/__mocks__/client-dependencies.ts
@@ -6,6 +6,7 @@ export const sdkMocks = {
   deleteRelationships: vi.fn(),
   diffSchema: vi.fn(),
   newClient: vi.fn(),
+  readRelationships: vi.fn(),
   readSchema: vi.fn(),
   writeRelationships: vi.fn(),
   writeSchema: vi.fn(),

--- a/apps/web/lib/authzed/api-key.test.ts
+++ b/apps/web/lib/authzed/api-key.test.ts
@@ -464,4 +464,77 @@ describe("API key relationship projection", () => {
     expect(serializedLog).not.toContain("private-api-key");
     expect(serializedLog).not.toContain("raw-sdk-message");
   });
+
+  describe("explicitly named workspace scopes", () => {
+    const workspaceUpdatesFor = (workspaceId: string) =>
+      clientMocks.writeRelationships.mock.calls
+        .flatMap(([updates]) => updates)
+        .filter(
+          ({ relationship }) =>
+            relationship.resource.objectType === "workspace" && relationship.resource.objectId === workspaceId
+        );
+
+    test("deletes a scope the source no longer grants", async () => {
+      // A revoked scope is absent from the snapshot, so without being named nothing would target it
+      // and the stale relationship would survive indefinitely.
+      setStableSnapshot({ permission: null });
+
+      await expect(
+        reconcileApiKeyRelationships({
+          apiKeyIds: [API_KEY_ID],
+          apiKeyWorkspaceGrants: [{ apiKeyId: API_KEY_ID, workspaceId: "revoked-workspace" }],
+        })
+      ).resolves.toEqual({ passes: 1, status: "projected" });
+
+      const updates = workspaceUpdatesFor("revoked-workspace");
+      expect(updates).toHaveLength(3);
+      expect(updates.every(({ operation }) => operation === "delete")).toBe(true);
+    });
+
+    test("still touches the granted permission when the source does hold the scope", async () => {
+      setStableSnapshot({ permission: "write", workspaceId: "granted-workspace" });
+
+      await reconcileApiKeyRelationships({
+        apiKeyIds: [API_KEY_ID],
+        apiKeyWorkspaceGrants: [{ apiKeyId: API_KEY_ID, workspaceId: "granted-workspace" }],
+      });
+
+      // Naming a target must not force a delete: the decision still comes from the source snapshot.
+      const updates = workspaceUpdatesFor("granted-workspace");
+      expect(updates).toHaveLength(3);
+      expect(updates.filter(({ operation }) => operation === "touch")).toHaveLength(1);
+      expect(updates).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            operation: "touch",
+            relationship: expect.objectContaining({ relation: "writer" }),
+          }),
+        ])
+      );
+    });
+
+    test("implies the API key so a caller repairing one scope need not also name the key", async () => {
+      setStableSnapshot({ permission: null });
+
+      await reconcileApiKeyRelationships({
+        apiKeyWorkspaceGrants: [{ apiKeyId: API_KEY_ID, workspaceId: "revoked-workspace" }],
+      });
+
+      expect(prisma.apiKey.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: { in: [API_KEY_ID] } } })
+      );
+      expect(workspaceUpdatesFor("revoked-workspace")).toHaveLength(3);
+    });
+
+    test("reconciles both a named scope and one discovered from the source", async () => {
+      setStableSnapshot({ permission: "read", workspaceId: "granted-workspace" });
+
+      await reconcileApiKeyRelationships({
+        apiKeyWorkspaceGrants: [{ apiKeyId: API_KEY_ID, workspaceId: "revoked-workspace" }],
+      });
+
+      expect(workspaceUpdatesFor("granted-workspace")).toHaveLength(3);
+      expect(workspaceUpdatesFor("revoked-workspace")).toHaveLength(3);
+    });
+  });
 });

--- a/apps/web/lib/authzed/api-key.ts
+++ b/apps/web/lib/authzed/api-key.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
-import { ApiKeyPermission } from "@formbricks/database/prisma";
+import type { ApiKeyPermission } from "@formbricks/database/prisma";
 import { type TAuthzedRelationshipFilter, type TAuthzedRelationshipUpdate, getAuthzedClient } from "./client";
 import {
   AUTHZED_MAX_RECONCILIATION_PASSES,
@@ -9,27 +9,17 @@ import {
   runBestEffortProjection,
 } from "./projection";
 import { deleteRelationshipsInBoundedBatches, packRelationshipUpdateGroups } from "./relationship-batches";
-
-const ORGANIZATION_ACCESS_RELATIONS = {
-  read: "api_key_reader",
-  write: "api_key_writer",
-} as const satisfies Record<keyof TOrganizationAccessSnapshot, string>;
-
-const WORKSPACE_RELATIONS = {
-  [ApiKeyPermission.manage]: "manager",
-  [ApiKeyPermission.read]: "reader",
-  [ApiKeyPermission.write]: "writer",
-} as const satisfies Record<ApiKeyPermission, string>;
+import {
+  ORGANIZATION_ACCESS_RELATIONS,
+  type TOrganizationAccessSnapshot,
+  WORKSPACE_API_KEY_RELATIONS as WORKSPACE_RELATIONS,
+  normalizeOrganizationAccess,
+} from "./relationship-map";
 
 const WORKSPACE_RELATION_NAMES = Object.values(WORKSPACE_RELATIONS);
 
 export type TApiKeyProjectionTargets = Readonly<{
   apiKeyIds?: ReadonlyArray<string>;
-}>;
-
-type TOrganizationAccessSnapshot = Readonly<{
-  read: boolean;
-  write: boolean;
 }>;
 
 type TApiKeyWorkspaceSnapshot = Readonly<{
@@ -45,20 +35,6 @@ type TApiKeySnapshot = ReadonlyArray<
     organizationId: string;
   }>
 >;
-
-const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
-
-const normalizeOrganizationAccess = (value: unknown): TOrganizationAccessSnapshot => {
-  if (!isRecord(value) || !isRecord(value.accessControl)) {
-    return { read: false, write: false };
-  }
-
-  return {
-    read: value.accessControl.read === true,
-    write: value.accessControl.write === true,
-  };
-};
 
 const normalizeTargets = (targets: TApiKeyProjectionTargets): ReadonlyArray<string> =>
   [...new Set(targets.apiKeyIds ?? [])].sort((left, right) => left.localeCompare(right));

--- a/apps/web/lib/authzed/api-key.ts
+++ b/apps/web/lib/authzed/api-key.ts
@@ -18,8 +18,22 @@ import {
 
 const WORKSPACE_RELATION_NAMES = Object.values(WORKSPACE_RELATIONS);
 
+export type TApiKeyWorkspaceProjectionTarget = Readonly<{
+  apiKeyId: string;
+  workspaceId: string;
+}>;
+
 export type TApiKeyProjectionTargets = Readonly<{
   apiKeyIds?: ReadonlyArray<string>;
+  /**
+   * Workspace scopes to reconcile even if PostgreSQL no longer grants them.
+   *
+   * Workspace targets are otherwise discovered from the key's current grants, so a scope revoked
+   * outside a mutation hook leaves an unreachable relationship: it is absent from the snapshot, so
+   * nothing names it, so nothing deletes it. Naming a pair here seeds it as a target, and an absent
+   * grant then deletes all three workspace relations. Each named key is implied as a target.
+   */
+  apiKeyWorkspaceGrants?: ReadonlyArray<TApiKeyWorkspaceProjectionTarget>;
 }>;
 
 type TApiKeyWorkspaceSnapshot = Readonly<{
@@ -36,8 +50,29 @@ type TApiKeySnapshot = ReadonlyArray<
   }>
 >;
 
-const normalizeTargets = (targets: TApiKeyProjectionTargets): ReadonlyArray<string> =>
-  [...new Set(targets.apiKeyIds ?? [])].sort((left, right) => left.localeCompare(right));
+type TNormalizedTargets = Readonly<{
+  apiKeyIds: ReadonlyArray<string>;
+  /** Workspace IDs to reconcile per API key, independent of what the source snapshot grants. */
+  seededWorkspaceIds: ReadonlyMap<string, ReadonlySet<string>>;
+}>;
+
+const normalizeTargets = (targets: TApiKeyProjectionTargets): TNormalizedTargets => {
+  const apiKeyIds = new Set(targets.apiKeyIds ?? []);
+  const seededWorkspaceIds = new Map<string, Set<string>>();
+
+  for (const { apiKeyId, workspaceId } of targets.apiKeyWorkspaceGrants ?? []) {
+    // A named grant implies its key, so a caller repairing one stale scope need not also list the key.
+    apiKeyIds.add(apiKeyId);
+    const workspaceIds = seededWorkspaceIds.get(apiKeyId) ?? new Set<string>();
+    workspaceIds.add(workspaceId);
+    seededWorkspaceIds.set(apiKeyId, workspaceIds);
+  }
+
+  return {
+    apiKeyIds: [...apiKeyIds].sort((left, right) => left.localeCompare(right)),
+    seededWorkspaceIds,
+  };
+};
 
 const readSnapshot = async (apiKeyIds: ReadonlyArray<string>): Promise<TApiKeySnapshot> => {
   const apiKeys = await prisma.apiKey.findMany({
@@ -188,15 +223,18 @@ export const reconcileApiKeyRelationships = async (
   targets: TApiKeyProjectionTargets
 ): Promise<TAuthzedProjectionResult> =>
   runBestEffortProjection("reconcile_api_key_relationships", "api_key", async () => {
-    const apiKeyIds = normalizeTargets(targets);
+    const { apiKeyIds, seededWorkspaceIds } = normalizeTargets(targets);
     if (apiKeyIds.length === 0) {
       return 0;
     }
 
-    // Workspace scopes are immutable today, so current snapshots contain every workspace that needs
-    // reconciliation. If scope removal is added, callers must also target pre-change workspace IDs
-    // so stale subject-side grants are deleted.
-    const observedWorkspaceIds = new Map(apiKeyIds.map((apiKeyId) => [apiKeyId, new Set<string>()]));
+    // Workspace scopes are immutable today, so a current snapshot contains every workspace a normal
+    // projection needs. A scope that disappeared anyway — removed outside a mutation hook, or by a
+    // future edit path — is invisible to the snapshot, which is what `apiKeyWorkspaceGrants` is for:
+    // seeded targets are reconciled regardless, then extended by whatever each pass observes.
+    const observedWorkspaceIds = new Map(
+      apiKeyIds.map((apiKeyId) => [apiKeyId, new Set<string>(seededWorkspaceIds.get(apiKeyId) ?? [])])
+    );
 
     for (let pass = 1; pass <= AUTHZED_MAX_RECONCILIATION_PASSES; pass++) {
       const sourceSnapshot = await readSnapshot(apiKeyIds);

--- a/apps/web/lib/authzed/backfill-boundary.test.ts
+++ b/apps/web/lib/authzed/backfill-boundary.test.ts
@@ -1,0 +1,70 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, test } from "vitest";
+
+/**
+ * The backfill tooling performs **no authorization check**. It takes an organization or workspace ID and
+ * rewrites that tenant's permission graph, which is correct for an operator command running with the
+ * AuthZed system credential and catastrophic behind an HTTP surface: a "repair my organization" endpoint
+ * or server action wired to it would be a maximum-impact BOLA — rewrite any tenant's permissions by ID.
+ *
+ * `import "server-only"` does not prevent this. It blocks *client* imports, not request-path ones. So the
+ * boundary is asserted here instead: only the tooling's own modules and its command entry points may
+ * reach it. If exposing it ever becomes necessary it needs `assertCan(actor, "organization.manage", …)`
+ * in front and the whole-deployment scope removed — not an exemption added to this list.
+ */
+
+const WEB_ROOT = new URL("../../", import.meta.url).pathname;
+
+/** Modules that may reach the backfill: the tooling itself, and the CLI entry points. */
+const ALLOWED_IMPORTER_PREFIXES = ["lib/authzed/", "scripts/"];
+
+const RESTRICTED_MODULES = ["backfill", "backfill-cli", "backfill-diff", "backfill-source"];
+
+const SEARCH_ROOTS = ["app", "lib", "modules", "scripts"];
+
+const collectSourceFiles = (directory: string): ReadonlyArray<string> => {
+  const entries: string[] = [];
+
+  for (const entry of readdirSync(directory)) {
+    if (entry === "node_modules" || entry === ".next") {
+      continue;
+    }
+
+    const absolute = join(directory, entry);
+    if (statSync(absolute).isDirectory()) {
+      entries.push(...collectSourceFiles(absolute));
+      continue;
+    }
+    if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
+      entries.push(absolute);
+    }
+  }
+
+  return entries;
+};
+
+describe("backfill module boundary", () => {
+  const files = SEARCH_ROOTS.flatMap((root) => collectSourceFiles(join(WEB_ROOT, root)));
+
+  test("finds source files to check, so a broken search cannot pass silently", () => {
+    expect(files.length).toBeGreaterThan(500);
+  });
+
+  test("is imported only by the tooling itself and its command entry points", () => {
+    const offenders = files
+      .map((absolute) => ({ absolute, relativePath: relative(WEB_ROOT, absolute) }))
+      .filter(
+        ({ relativePath }) => !ALLOWED_IMPORTER_PREFIXES.some((prefix) => relativePath.startsWith(prefix))
+      )
+      .filter(({ absolute }) => {
+        const source = readFileSync(absolute, "utf8");
+        return RESTRICTED_MODULES.some((moduleName) =>
+          new RegExp(String.raw`from\s+["'][^"']*(?:lib/)?authzed/${moduleName}["']`).test(source)
+        );
+      })
+      .map(({ relativePath }) => relativePath);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/web/lib/authzed/backfill-boundary.test.ts
+++ b/apps/web/lib/authzed/backfill-boundary.test.ts
@@ -21,9 +21,15 @@ const ALLOWED_IMPORTER_PREFIXES = ["lib/authzed/", "scripts/"];
 
 const RESTRICTED_MODULES = ["backfill", "backfill-cli", "backfill-diff", "backfill-source"];
 
-const SEARCH_ROOTS = ["app", "lib", "modules", "scripts"];
+/**
+ * Every directory holding application source, plus `apps/web`'s own root modules.
+ *
+ * `instrumentation*.ts` and `proxy.ts` live at the root rather than under a directory and are as
+ * request-path as anything in `app/` — omitting them would leave the most sensitive files unchecked.
+ */
+const SEARCH_ROOTS = [".", "app", "integration", "lib", "modules", "scripts"];
 
-const collectSourceFiles = (directory: string): ReadonlyArray<string> => {
+const collectSourceFiles = (directory: string, recurse: boolean): ReadonlyArray<string> => {
   const entries: string[] = [];
 
   for (const entry of readdirSync(directory)) {
@@ -33,7 +39,9 @@ const collectSourceFiles = (directory: string): ReadonlyArray<string> => {
 
     const absolute = join(directory, entry);
     if (statSync(absolute).isDirectory()) {
-      entries.push(...collectSourceFiles(absolute));
+      if (recurse) {
+        entries.push(...collectSourceFiles(absolute, true));
+      }
       continue;
     }
     if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) {
@@ -44,11 +52,33 @@ const collectSourceFiles = (directory: string): ReadonlyArray<string> => {
   return entries;
 };
 
+/**
+ * Any reference to a restricted module as a module specifier.
+ *
+ * Deliberately not anchored to `from`: a static import is only one of the ways in. `await import(…)`,
+ * `require(…)`, and a bare side-effect import all reach the same module, and a fence that only caught the
+ * tidy spelling would be trivially — and silently — stepped around.
+ */
+const restrictedSpecifierPattern = (moduleName: string): RegExp =>
+  new RegExp(String.raw`["'][^"']*(?:lib/)?authzed/${moduleName}["']`);
+
+const importsRestrictedModule = (source: string): boolean =>
+  RESTRICTED_MODULES.some((moduleName) => restrictedSpecifierPattern(moduleName).test(source));
+
 describe("backfill module boundary", () => {
-  const files = SEARCH_ROOTS.flatMap((root) => collectSourceFiles(join(WEB_ROOT, root)));
+  const files = SEARCH_ROOTS.flatMap((root) => collectSourceFiles(join(WEB_ROOT, root), root !== "."));
 
   test("finds source files to check, so a broken search cannot pass silently", () => {
     expect(files.length).toBeGreaterThan(500);
+  });
+
+  test("searches apps/web's root modules, which hold the request-path proxy and instrumentation", () => {
+    const rootModules = files
+      .map((absolute) => relative(WEB_ROOT, absolute))
+      .filter((relativePath) => !relativePath.includes("/"));
+
+    expect(rootModules).toContain("proxy.ts");
+    expect(rootModules).toContain("instrumentation.ts");
   });
 
   test("is imported only by the tooling itself and its command entry points", () => {
@@ -57,14 +87,15 @@ describe("backfill module boundary", () => {
       .filter(
         ({ relativePath }) => !ALLOWED_IMPORTER_PREFIXES.some((prefix) => relativePath.startsWith(prefix))
       )
-      .filter(({ absolute }) => {
-        const source = readFileSync(absolute, "utf8");
-        return RESTRICTED_MODULES.some((moduleName) =>
-          new RegExp(String.raw`from\s+["'][^"']*(?:lib/)?authzed/${moduleName}["']`).test(source)
-        );
-      })
+      .filter(({ absolute }) => importsRestrictedModule(readFileSync(absolute, "utf8")))
       .map(({ relativePath }) => relativePath);
 
     expect(offenders).toEqual([]);
+  });
+
+  test("is not re-exported from the barrel, which would launder it past the allowed prefix", () => {
+    // `lib/authzed/` is an allowed importer, so a re-export from inside it would make the tooling
+    // reachable as `@/lib/authzed` from anywhere — passing every check above.
+    expect(importsRestrictedModule(readFileSync(join(WEB_ROOT, "lib/authzed/index.ts"), "utf8"))).toBe(false);
   });
 });

--- a/apps/web/lib/authzed/backfill-boundary.test.ts
+++ b/apps/web/lib/authzed/backfill-boundary.test.ts
@@ -60,7 +60,11 @@ const collectSourceFiles = (directory: string, recurse: boolean): ReadonlyArray<
  * tidy spelling would be trivially — and silently — stepped around.
  */
 const restrictedSpecifierPattern = (moduleName: string): RegExp =>
-  new RegExp(String.raw`["'][^"']*(?:lib/)?authzed/${moduleName}["']`);
+  // Both spellings: an aliased path (`@/lib/authzed/backfill`) and a relative one (`./backfill`). The
+  // relative form is what a re-export inside `lib/authzed/` would actually use, and it is the form that
+  // matters most — the offender scan below skips that directory, so the barrel check is the only thing
+  // standing between a one-line `export * from "./backfill"` and a request-path import.
+  new RegExp(String.raw`["'](?:[^"']*(?:lib/)?authzed/|\./)${moduleName}["']`);
 
 const importsRestrictedModule = (source: string): boolean =>
   RESTRICTED_MODULES.some((moduleName) => restrictedSpecifierPattern(moduleName).test(source));
@@ -97,5 +101,20 @@ describe("backfill module boundary", () => {
     // `lib/authzed/` is an allowed importer, so a re-export from inside it would make the tooling
     // reachable as `@/lib/authzed` from anywhere — passing every check above.
     expect(importsRestrictedModule(readFileSync(join(WEB_ROOT, "lib/authzed/index.ts"), "utf8"))).toBe(false);
+  });
+
+  test.each([
+    ['export * from "./backfill";', "a star re-export"],
+    ['export { runAuthzedBackfill } from "./backfill";', "a named re-export"],
+    ['const m = await import("./backfill-cli");', "a dynamic import"],
+    ['import "./backfill-source";', "a bare side-effect import"],
+    ['import { runAuthzedBackfill } from "@/lib/authzed/backfill";', "an aliased import"],
+  ])("detects %s as reaching a restricted module", (source) => {
+    // Sentinels: the fence is only worth having if it recognizes the forms someone would actually write.
+    expect(importsRestrictedModule(source)).toBe(true);
+  });
+
+  test("does not flag an unrelated relative import", () => {
+    expect(importsRestrictedModule('import { getAuthzedClient } from "./client";')).toBe(false);
   });
 });

--- a/apps/web/lib/authzed/backfill-cli.test.ts
+++ b/apps/web/lib/authzed/backfill-cli.test.ts
@@ -201,8 +201,10 @@ describe("runAuthzedBackfillCli", () => {
     ).resolves.toBe(1);
 
     expect(dependencies.run).not.toHaveBeenCalled();
+    // A distinct code from a mistyped flag: aiming the destructive path at the wrong instance is a very
+    // different mistake, and the operator should be able to tell which one happened.
     expect(dependencies.writeOutput).toHaveBeenCalledWith(
-      `${JSON.stringify({ code: AUTHZED_ERROR_CODES.INVALID_REQUEST, retryable: false, status: "failed" })}\n`
+      `${JSON.stringify({ code: AUTHZED_ERROR_CODES.FAILED_PRECONDITION, retryable: false, status: "failed" })}\n`
     );
   });
 

--- a/apps/web/lib/authzed/backfill-cli.test.ts
+++ b/apps/web/lib/authzed/backfill-cli.test.ts
@@ -14,6 +14,7 @@ vi.mock("./team-workspace", () => ({ reconcileTeamWorkspaceRelationships: vi.fn(
 
 const ORGANIZATION_ID = "clhx8n2p40000qwer1234asdf";
 const OTHER_ORGANIZATION_ID = "clhx8n2p40001qwer1234asdf";
+const WORKSPACE_ID = "clhx8n2p40002qwer1234asdf";
 const ENDPOINT = "spicedb.internal:50051";
 
 const result = (overrides: Partial<TAuthzedBackfillResult> = {}): TAuthzedBackfillResult => ({
@@ -22,6 +23,8 @@ const result = (overrides: Partial<TAuthzedBackfillResult> = {}): TAuthzedBackfi
     failed: 0,
     ignored: 0,
     invalid: 0,
+    mismatchedParents: 0,
+    missing: 0,
     orphaned: 0,
     pruned: 0,
     reconciled: 1,
@@ -30,6 +33,7 @@ const result = (overrides: Partial<TAuthzedBackfillResult> = {}): TAuthzedBackfi
   },
   failures: [],
   lastOrganizationId: ORGANIZATION_ID,
+  mismatchedParents: [],
   mode: "apply",
   orphanScope: "all",
   orphans: [],
@@ -74,6 +78,47 @@ describe("parseAuthzedBackfillCommand", () => {
 
   test("accepts an applying run without pruning", () => {
     expect(parseAuthzedBackfillCommand(["--apply"])).toMatchObject({ mode: "apply", prune: false });
+  });
+
+  test("accepts a confirmed prune scoped to one workspace", () => {
+    // The workspace scope satisfies the explicit-scope requirement, and it is the path that removes
+    // every relationship on a stale workspace ID — so it needs the same coverage as the organization.
+    expect(
+      parseAuthzedBackfillCommand([
+        "--apply",
+        "--prune",
+        "--confirm-prune",
+        `--workspace-id=${WORKSPACE_ID}`,
+        `--expected-endpoint=${ENDPOINT}`,
+      ])
+    ).toMatchObject({ mode: "apply", prune: true, workspaceId: WORKSPACE_ID });
+  });
+
+  test.each([
+    ["a workspace combined with the full sweep", [`--workspace-id=${WORKSPACE_ID}`, "--scope=all"]],
+    [
+      "a workspace combined with an organization",
+      [`--workspace-id=${WORKSPACE_ID}`, `--organization-id=${ORGANIZATION_ID}`],
+    ],
+    [
+      "a workspace combined with a resume cursor",
+      [`--workspace-id=${WORKSPACE_ID}`, `--after-organization-id=${ORGANIZATION_ID}`],
+    ],
+    ["a malformed workspace id", ["--workspace-id=not-a-cuid"]],
+    ["a repeated workspace id", [`--workspace-id=${WORKSPACE_ID}`, `--workspace-id=${WORKSPACE_ID}`]],
+  ])("refuses %s", (_label, args) => {
+    expect(parseAuthzedBackfillCommand(args)).toBeUndefined();
+  });
+
+  test("refuses a workspace prune that is missing a confirmation", () => {
+    expect(
+      parseAuthzedBackfillCommand([
+        "--apply",
+        "--prune",
+        `--workspace-id=${WORKSPACE_ID}`,
+        `--expected-endpoint=${ENDPOINT}`,
+      ])
+    ).toBeUndefined();
   });
 
   test("accepts a fully-confirmed prune", () => {

--- a/apps/web/lib/authzed/backfill-cli.test.ts
+++ b/apps/web/lib/authzed/backfill-cli.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { TAuthzedBackfillResult } from "./backfill";
+import { parseAuthzedBackfillCommand, runAuthzedBackfillCli } from "./backfill-cli";
+import { AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN } from "./constants";
+import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
+
+// Neutralize the real default dependencies at import time; behaviour comes from per-test overrides.
+vi.mock("./api-key", () => ({ reconcileApiKeyRelationships: vi.fn() }));
+vi.mock("./backfill", () => ({ runAuthzedBackfill: vi.fn() }));
+vi.mock("./client", () => ({ closeAuthzedClient: vi.fn(), getAuthzedClient: vi.fn() }));
+vi.mock("./config", () => ({ isAuthzedEnabled: vi.fn() }));
+vi.mock("./organization-membership", () => ({ reconcileOrganizationMemberships: vi.fn() }));
+vi.mock("./team-workspace", () => ({ reconcileTeamWorkspaceRelationships: vi.fn() }));
+
+const ORGANIZATION_ID = "clhx8n2p40000qwer1234asdf";
+const OTHER_ORGANIZATION_ID = "clhx8n2p40001qwer1234asdf";
+const ENDPOINT = "spicedb.internal:50051";
+
+const result = (overrides: Partial<TAuthzedBackfillResult> = {}): TAuthzedBackfillResult => ({
+  completedAtSnapshot: "revision-1",
+  counters: {
+    failed: 0,
+    ignored: 0,
+    invalid: 0,
+    orphaned: 0,
+    pruned: 0,
+    reconciled: 1,
+    scanned: 1,
+    skipped: 0,
+  },
+  failures: [],
+  lastOrganizationId: ORGANIZATION_ID,
+  mode: "apply",
+  orphanScope: "all",
+  orphans: [],
+  scope: "all",
+  status: "reconciled",
+  truncated: false,
+  unmanaged: [],
+  ...overrides,
+});
+
+const command = (overrides: Partial<Parameters<typeof runAuthzedBackfillCli>[0]> = {}) => ({
+  maxPrune: AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN,
+  mode: "dry_run" as const,
+  prune: false,
+  ...overrides,
+});
+
+const deps = (overrides = {}) => ({
+  closeClient: vi.fn(),
+  isEnabled: vi.fn().mockReturnValue(true),
+  resolveEndpoint: vi.fn().mockReturnValue(ENDPOINT),
+  run: vi.fn().mockResolvedValue(result()),
+  writeOutput: vi.fn(),
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("parseAuthzedBackfillCommand", () => {
+  test("defaults to a dry run over every organization, so a mistyped invocation is inert", () => {
+    expect(parseAuthzedBackfillCommand([])).toEqual({
+      afterOrganizationId: undefined,
+      expectedEndpoint: undefined,
+      maxPrune: AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN,
+      mode: "dry_run",
+      organizationId: undefined,
+      prune: false,
+    });
+  });
+
+  test("accepts an applying run without pruning", () => {
+    expect(parseAuthzedBackfillCommand(["--apply"])).toMatchObject({ mode: "apply", prune: false });
+  });
+
+  test("accepts a fully-confirmed prune", () => {
+    expect(
+      parseAuthzedBackfillCommand([
+        "--apply",
+        "--prune",
+        "--confirm-prune",
+        "--scope=all",
+        `--expected-endpoint=${ENDPOINT}`,
+      ])
+    ).toMatchObject({ expectedEndpoint: ENDPOINT, mode: "apply", prune: true });
+  });
+
+  test("accepts a confirmed prune scoped to one organization", () => {
+    expect(
+      parseAuthzedBackfillCommand([
+        "--apply",
+        "--prune",
+        "--confirm-prune",
+        `--organization-id=${ORGANIZATION_ID}`,
+        `--expected-endpoint=${ENDPOINT}`,
+      ])
+    ).toMatchObject({ organizationId: ORGANIZATION_ID, prune: true });
+  });
+
+  test.each([
+    ["without --apply", ["--prune", "--confirm-prune", "--scope=all", `--expected-endpoint=${ENDPOINT}`]],
+    ["without --confirm-prune", ["--apply", "--prune", "--scope=all", `--expected-endpoint=${ENDPOINT}`]],
+    [
+      "without an explicit scope",
+      ["--apply", "--prune", "--confirm-prune", `--expected-endpoint=${ENDPOINT}`],
+    ],
+    ["without --expected-endpoint", ["--apply", "--prune", "--confirm-prune", "--scope=all"]],
+  ])("refuses a prune %s", (_label, args) => {
+    // Removing relationships must never be reachable by a shorter command than the full spelling.
+    expect(parseAuthzedBackfillCommand(args)).toBeUndefined();
+  });
+
+  test("refuses --confirm-prune without --prune, so the confirmation cannot be left lying around", () => {
+    expect(parseAuthzedBackfillCommand(["--apply", "--confirm-prune"])).toBeUndefined();
+  });
+
+  test.each([
+    ["an unknown flag", ["--force"]],
+    ["a bare argument", ["all"]],
+    ["a misspelled flag", ["--dry-run"]],
+    ["an unsupported scope value", ["--scope=organization"]],
+    ["a malformed organization id", ["--organization-id=not-a-cuid!"]],
+    ["a malformed resume cursor", ["--after-organization-id=nope"]],
+    ["both a scope and an organization", ["--scope=all", `--organization-id=${ORGANIZATION_ID}`]],
+    [
+      "an organization together with a resume cursor",
+      [`--organization-id=${ORGANIZATION_ID}`, `--after-organization-id=${OTHER_ORGANIZATION_ID}`],
+    ],
+    ["a non-numeric prune cap", ["--max-prune=lots"]],
+    ["a zero prune cap", ["--max-prune=0"]],
+  ])("refuses %s", (_label, args) => {
+    expect(parseAuthzedBackfillCommand(args)).toBeUndefined();
+  });
+
+  test("allows lowering the prune cap", () => {
+    expect(parseAuthzedBackfillCommand(["--max-prune=10"])).toMatchObject({ maxPrune: 10 });
+  });
+
+  test("refuses raising the prune cap above the built-in bound", () => {
+    // The cap exists because a large orphan count is a symptom; an operator must not be able to
+    // configure the symptom away.
+    expect(
+      parseAuthzedBackfillCommand([`--max-prune=${AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN + 1}`])
+    ).toBeUndefined();
+  });
+
+  test("accepts a resume cursor", () => {
+    expect(parseAuthzedBackfillCommand([`--after-organization-id=${ORGANIZATION_ID}`])).toMatchObject({
+      afterOrganizationId: ORGANIZATION_ID,
+    });
+  });
+});
+
+describe("runAuthzedBackfillCli", () => {
+  test.each([
+    ["reconciled", 0],
+    ["drifted", 2],
+    ["failed", 1],
+  ] as const)("returns exit code %s -> %i and serializes the result exactly", async (status, exitCode) => {
+    const backfillResult = result({ status });
+    const dependencies = deps({ run: vi.fn().mockResolvedValue(backfillResult) });
+
+    await expect(runAuthzedBackfillCli(command(), dependencies)).resolves.toBe(exitCode);
+
+    expect(dependencies.writeOutput).toHaveBeenCalledOnce();
+    expect(dependencies.writeOutput).toHaveBeenCalledWith(`${JSON.stringify(backfillResult)}\n`);
+    expect(dependencies.closeClient).toHaveBeenCalledOnce();
+  });
+
+  test("refuses to run at all when AuthZed is disabled", async () => {
+    // A per-unit `disabled` result would otherwise read as "not failed" and the run would claim to have
+    // reconciled organizations it never touched.
+    const dependencies = deps({ isEnabled: vi.fn().mockReturnValue(false) });
+
+    await expect(runAuthzedBackfillCli(command(), dependencies)).resolves.toBe(1);
+
+    expect(dependencies.run).not.toHaveBeenCalled();
+    expect(dependencies.writeOutput).toHaveBeenCalledWith(
+      `${JSON.stringify({ code: AUTHZED_ERROR_CODES.DISABLED, retryable: false, status: "failed" })}\n`
+    );
+  });
+
+  test("refuses to run when the named endpoint is not the configured one", async () => {
+    // The guard against a stale .env aiming the destructive path at the wrong instance.
+    const dependencies = deps({ resolveEndpoint: vi.fn().mockReturnValue("spicedb.production:50051") });
+
+    await expect(
+      runAuthzedBackfillCli(command({ expectedEndpoint: ENDPOINT, mode: "apply", prune: true }), dependencies)
+    ).resolves.toBe(1);
+
+    expect(dependencies.run).not.toHaveBeenCalled();
+    expect(dependencies.writeOutput).toHaveBeenCalledWith(
+      `${JSON.stringify({ code: AUTHZED_ERROR_CODES.INVALID_REQUEST, retryable: false, status: "failed" })}\n`
+    );
+  });
+
+  test("proceeds when the named endpoint matches", async () => {
+    const dependencies = deps();
+
+    await expect(
+      runAuthzedBackfillCli(command({ expectedEndpoint: ENDPOINT, mode: "apply" }), dependencies)
+    ).resolves.toBe(0);
+
+    expect(dependencies.run).toHaveBeenCalledOnce();
+  });
+
+  test("supplies inert reconcilers for a dry run", async () => {
+    const dependencies = deps();
+
+    await runAuthzedBackfillCli(command({ mode: "dry_run" }), dependencies);
+
+    const [request, apply] = dependencies.run.mock.calls[0];
+    expect(request.mode).toBe("dry_run");
+    await expect(apply.reconcileMemberships({})).resolves.toEqual({ passes: 0, status: "projected" });
+    await expect(apply.reconcileTeamWorkspace({})).resolves.toEqual({ passes: 0, status: "projected" });
+    await expect(apply.reconcileApiKeys({})).resolves.toEqual({ passes: 0, status: "projected" });
+  });
+
+  test("translates a named organization into a single-organization scope", async () => {
+    const dependencies = deps();
+
+    await runAuthzedBackfillCli(command({ organizationId: ORGANIZATION_ID }), dependencies);
+
+    expect(dependencies.run.mock.calls[0][0].scope).toEqual({
+      kind: "organization",
+      organizationId: ORGANIZATION_ID,
+    });
+  });
+
+  test("translates a resume cursor into a full scope that starts after it", async () => {
+    const dependencies = deps();
+
+    await runAuthzedBackfillCli(command({ afterOrganizationId: ORGANIZATION_ID }), dependencies);
+
+    expect(dependencies.run.mock.calls[0][0].scope).toEqual({
+      afterOrganizationId: ORGANIZATION_ID,
+      kind: "all",
+    });
+  });
+
+  test("prints only the stable error contract and closes the client on failure", async () => {
+    const secret = "never-log-this-authzed-token";
+    const dependencies = deps({
+      run: vi.fn().mockRejectedValue(
+        new AuthzedError({
+          attempts: 1,
+          cause: new Error(secret),
+          code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+          operation: "read_relationships",
+          retryable: true,
+        })
+      ),
+    });
+
+    await expect(runAuthzedBackfillCli(command(), dependencies)).resolves.toBe(1);
+
+    expect(dependencies.writeOutput).toHaveBeenCalledWith(
+      `${JSON.stringify({ code: AUTHZED_ERROR_CODES.UNAVAILABLE, retryable: true, status: "failed" })}\n`
+    );
+    expect(JSON.stringify(dependencies.writeOutput.mock.calls)).not.toContain(secret);
+    expect(dependencies.closeClient).toHaveBeenCalledOnce();
+  });
+
+  test("maps a non-AuthZed failure onto the same sanitized contract", async () => {
+    const dependencies = deps({ run: vi.fn().mockRejectedValue(new Error("Organization not found")) });
+
+    await expect(runAuthzedBackfillCli(command(), dependencies)).resolves.toBe(1);
+
+    expect(JSON.stringify(dependencies.writeOutput.mock.calls)).not.toContain("Organization not found");
+  });
+
+  test("a cleanup failure does not replace the result or the exit code", async () => {
+    const backfillResult = result({ status: "drifted" });
+    const dependencies = deps({
+      closeClient: vi.fn().mockImplementation(() => {
+        throw new Error("channel already closed");
+      }),
+      run: vi.fn().mockResolvedValue(backfillResult),
+    });
+
+    await expect(runAuthzedBackfillCli(command(), dependencies)).resolves.toBe(2);
+
+    expect(dependencies.writeOutput).toHaveBeenCalledWith(`${JSON.stringify(backfillResult)}\n`);
+  });
+});

--- a/apps/web/lib/authzed/backfill-cli.test.ts
+++ b/apps/web/lib/authzed/backfill-cli.test.ts
@@ -131,6 +131,15 @@ describe("parseAuthzedBackfillCommand", () => {
     ],
     ["a non-numeric prune cap", ["--max-prune=lots"]],
     ["a zero prune cap", ["--max-prune=0"]],
+    // Silently taking the first would let an operator who typed a value twice act on a different value
+    // than the one they last wrote.
+    ["a repeated prune cap", ["--max-prune=1", "--max-prune=400"]],
+    [
+      "a repeated organization",
+      [`--organization-id=${ORGANIZATION_ID}`, `--organization-id=${OTHER_ORGANIZATION_ID}`],
+    ],
+    ["a repeated endpoint", [`--expected-endpoint=${ENDPOINT}`, "--expected-endpoint=other:50051"]],
+    ["a repeated scope", ["--scope=all", "--scope=all"]],
   ])("refuses %s", (_label, args) => {
     expect(parseAuthzedBackfillCommand(args)).toBeUndefined();
   });

--- a/apps/web/lib/authzed/backfill-cli.ts
+++ b/apps/web/lib/authzed/backfill-cli.ts
@@ -7,7 +7,7 @@ import {
   type TAuthzedBackfillResult,
   runAuthzedBackfill,
 } from "./backfill";
-import { closeAuthzedClient, getAuthzedClient } from "./client";
+import { closeAuthzedClient, getAuthzedBulkClient } from "./client";
 import { isAuthzedEnabled } from "./config";
 import { AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN } from "./constants";
 import { AUTHZED_ERROR_CODES, AuthzedError, type TAuthzedErrorCode, mapAuthzedError } from "./errors";
@@ -32,6 +32,7 @@ export type TAuthzedBackfillCliCommand = Readonly<{
   mode: "apply" | "dry_run";
   organizationId?: string;
   prune: boolean;
+  workspaceId?: string;
 }>;
 
 type TAuthzedBackfillCliFailure = Readonly<{
@@ -73,7 +74,7 @@ const defaultDependencies: TAuthzedBackfillCliDependencies = {
   closeClient: closeAuthzedClient,
   isEnabled: isAuthzedEnabled,
   resolveEndpoint: () => env.AUTHZED_ENDPOINT,
-  run: (request, apply) => runAuthzedBackfill(request, { apply, client: getAuthzedClient() }),
+  run: (request, apply) => runAuthzedBackfill(request, { apply, client: getAuthzedBulkClient() }),
   writeOutput: (output) => process.stdout.write(output),
 };
 
@@ -107,7 +108,14 @@ export const parseAuthzedBackfillCommand = (
   args: ReadonlyArray<string>
 ): TAuthzedBackfillCliCommand | undefined => {
   const known = new Set(["--apply", "--confirm-prune", "--prune"]);
-  const flagNames = ["after-organization-id", "expected-endpoint", "max-prune", "organization-id", "scope"];
+  const flagNames = [
+    "after-organization-id",
+    "expected-endpoint",
+    "max-prune",
+    "organization-id",
+    "scope",
+    "workspace-id",
+  ];
   for (const arg of args) {
     if (known.has(arg)) {
       continue;
@@ -133,12 +141,21 @@ export const parseAuthzedBackfillCommand = (
   const expectedEndpoint = readFlag(args, "expected-endpoint");
   const rawMaxPrune = readFlag(args, "max-prune");
   const scope = readFlag(args, "scope");
+  const workspaceId = readFlag(args, "workspace-id");
 
   // `all` is the only value; it exists so pruning every organization has to be spelled out.
   if (scope !== undefined && scope !== "all") {
     return undefined;
   }
-  if (scope === "all" && organizationId !== undefined) {
+  // The three scopes are mutually exclusive; naming two would leave which one applies ambiguous.
+  if ([scope === "all", organizationId !== undefined, workspaceId !== undefined].filter(Boolean).length > 1) {
+    return undefined;
+  }
+  if (workspaceId !== undefined && !CUID_PATTERN.test(workspaceId)) {
+    return undefined;
+  }
+  // Resuming is a whole-sweep concern.
+  if (workspaceId !== undefined && afterOrganizationId !== undefined) {
     return undefined;
   }
 
@@ -170,7 +187,7 @@ export const parseAuthzedBackfillCommand = (
       return undefined;
     }
     // "Prune everything" must be typed, never defaulted into.
-    if (organizationId === undefined && scope !== "all") {
+    if (organizationId === undefined && workspaceId === undefined && scope !== "all") {
       return undefined;
     }
   }
@@ -179,7 +196,7 @@ export const parseAuthzedBackfillCommand = (
     return undefined;
   }
 
-  return { afterOrganizationId, expectedEndpoint, maxPrune, mode, organizationId, prune };
+  return { afterOrganizationId, expectedEndpoint, maxPrune, mode, organizationId, prune, workspaceId };
 };
 
 const toFailureResult = (error: unknown): TAuthzedBackfillCliFailure => {
@@ -193,6 +210,17 @@ const invalidRequest = (): TAuthzedBackfillCliFailure => ({
   retryable: false,
   status: "failed",
 });
+
+/** The three scopes are mutually exclusive, enforced during parsing. */
+const resolveScope = (command: TAuthzedBackfillCliCommand): TAuthzedBackfillRequest["scope"] => {
+  if (command.workspaceId) {
+    return { kind: "workspace", workspaceId: command.workspaceId };
+  }
+  if (command.organizationId) {
+    return { kind: "organization", organizationId: command.organizationId };
+  }
+  return { afterOrganizationId: command.afterOrganizationId, kind: "all" };
+};
 
 const toExitCode = (status: TAuthzedBackfillResult["status"]): number => {
   switch (status) {
@@ -238,9 +266,7 @@ export const runAuthzedBackfillCli = async (
           maxPrune: command.maxPrune,
           mode: command.mode,
           prune: command.prune,
-          scope: command.organizationId
-            ? { kind: "organization", organizationId: command.organizationId }
-            : { afterOrganizationId: command.afterOrganizationId, kind: "all" },
+          scope: resolveScope(command),
         },
         command.mode === "apply" ? createWritableApply() : createInertApply()
       );

--- a/apps/web/lib/authzed/backfill-cli.ts
+++ b/apps/web/lib/authzed/backfill-cli.ts
@@ -86,7 +86,7 @@ const defaultDependencies: TAuthzedBackfillCliDependencies = {
 };
 
 const CUID_PATTERN = /^[a-z0-9]{20,40}$/;
-const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]{0,6}$/;
+const POSITIVE_INTEGER_PATTERN = /^[1-9]\d{0,6}$/;
 
 const countFlag = (args: ReadonlyArray<string>, name: string): number =>
   args.filter((arg) => arg.startsWith(`--${name}=`)).length;
@@ -96,114 +96,179 @@ const readFlag = (args: ReadonlyArray<string>, name: string): string | undefined
   return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
 };
 
+const KNOWN_BOOLEAN_FLAGS = new Set(["--apply", "--confirm-prune", "--prune"]);
+
+const VALUE_FLAG_NAMES = [
+  "after-organization-id",
+  "expected-endpoint",
+  "max-prune",
+  "organization-id",
+  "scope",
+  "workspace-id",
+] as const;
+
+/** The values a scope can be named by, before any of them are validated against each other. */
+type TFlagSelection = Readonly<{
+  afterOrganizationId?: string;
+  expectedEndpoint?: string;
+  organizationId?: string;
+  scope?: string;
+  workspaceId?: string;
+}>;
+
+/** Every argument is either a known boolean flag or a known `--name=value` flag. */
+const hasOnlyKnownArguments = (args: ReadonlyArray<string>): boolean =>
+  args.every(
+    (arg) => KNOWN_BOOLEAN_FLAGS.has(arg) || VALUE_FLAG_NAMES.some((name) => arg.startsWith(`--${name}=`))
+  );
+
+/**
+ * A repeated flag is an error rather than a silent first-wins: on a command that removes
+ * relationships, an operator who typed a value twice deserves to be told which one would have applied
+ * instead of finding out afterwards.
+ */
+const hasRepeatedFlag = (args: ReadonlyArray<string>): boolean =>
+  VALUE_FLAG_NAMES.some((name) => countFlag(args, name) > 1);
+
+/**
+ * Exactly one scope, named exactly once.
+ *
+ * `all` is the only accepted `--scope` value; it exists so that pruning every organization has to be
+ * spelled out rather than defaulted into. Naming two scopes would leave which one applies ambiguous.
+ */
+const isScopeNamedUnambiguously = ({ organizationId, scope, workspaceId }: TFlagSelection): boolean => {
+  if (scope !== undefined && scope !== "all") {
+    return false;
+  }
+
+  const named = [scope === "all", organizationId !== undefined, workspaceId !== undefined];
+
+  return named.filter(Boolean).length <= 1;
+};
+
+/**
+ * Every supplied identifier is a cuid, and resuming is combined only with a scope it means something
+ * for — a whole sweep. Resuming from an organization is meaningless when one organization or one
+ * workspace is named outright.
+ */
+const areIdentifiersValid = ({
+  afterOrganizationId,
+  organizationId,
+  workspaceId,
+}: TFlagSelection): boolean => {
+  const ids = [organizationId, afterOrganizationId, workspaceId].filter(
+    (id): id is string => id !== undefined
+  );
+  if (!ids.every((id) => CUID_PATTERN.test(id))) {
+    return false;
+  }
+
+  return afterOrganizationId === undefined || (organizationId === undefined && workspaceId === undefined);
+};
+
+/**
+ * The per-run prune cap, or `undefined` when the operator supplied one this tool will not honour.
+ *
+ * Absent means the default. Present means it may only ever *lower* the cap.
+ */
+const resolveMaxPrune = (raw: string | undefined): number | undefined => {
+  if (raw === undefined) {
+    return AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN;
+  }
+  if (!POSITIVE_INTEGER_PATTERN.test(raw)) {
+    return undefined;
+  }
+
+  const requested = Number(raw);
+
+  return requested > AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN ? undefined : requested;
+};
+
+/**
+ * Whether a destructive run carries every confirmation it needs.
+ *
+ * `--prune` requires `--apply`, `--confirm-prune`, `--expected-endpoint`, and an explicit scope, so
+ * removing relationships cannot happen as a side effect of any shorter command. `--confirm-prune`
+ * without `--prune` is rejected too: it means the operator believes they are pruning and are not.
+ */
+const isPruneRequestPermitted = ({
+  confirmed,
+  mode,
+  prune,
+  selection,
+}: Readonly<{
+  confirmed: boolean;
+  mode: "apply" | "dry_run";
+  prune: boolean;
+  selection: TFlagSelection;
+}>): boolean => {
+  if (!prune) {
+    return !confirmed;
+  }
+  if (mode !== "apply" || !confirmed || !selection.expectedEndpoint) {
+    return false;
+  }
+
+  // "Prune everything" must be typed, never defaulted into.
+  return (
+    selection.organizationId !== undefined || selection.workspaceId !== undefined || selection.scope === "all"
+  );
+};
+
 /**
  * Parse argv into a command, or `undefined` if the invocation is not one this tool will perform.
  *
- * Deliberately strict and deliberately inconvenient where it matters:
+ * Deliberately strict and deliberately inconvenient where it matters. A dry run is the default, so a
+ * mistyped invocation is inert; every rule that guards the destructive path is a named predicate
+ * below, so each can be read — and tested — on its own.
  *
- * - a dry run is the default, so a mistyped invocation is inert;
- * - `--prune` needs `--apply`, `--confirm-prune`, an explicit scope, and `--expected-endpoint`, so
- *   removing relationships cannot happen as a side effect of any shorter command;
- * - `--expected-endpoint` must match the configured endpoint. The endpoint differs per environment by
- *   construction, which the AuthZed system key does not — it is documented as a stable namespace and
- *   defaults to the same value everywhere, so it could not tell staging from production. This is the
- *   guard against a stale `.env` aiming the destructive path at the wrong instance, which matters
- *   because these commands read `.env` only and ignore `.env.local`;
- * - `--max-prune` may lower the per-run cap, never raise it.
+ * On `--expected-endpoint`: the endpoint differs per environment by construction, which the AuthZed
+ * system key does not — it is documented as a stable namespace and defaults to the same value
+ * everywhere, so it could not tell staging from production. This is the guard against a stale `.env`
+ * aiming the destructive path at the wrong instance, which matters because these commands read `.env`
+ * only and ignore `.env.local`.
  */
 export const parseAuthzedBackfillCommand = (
   args: ReadonlyArray<string>
 ): TAuthzedBackfillCliCommand | undefined => {
-  const known = new Set(["--apply", "--confirm-prune", "--prune"]);
-  const flagNames = [
-    "after-organization-id",
-    "expected-endpoint",
-    "max-prune",
-    "organization-id",
-    "scope",
-    "workspace-id",
-  ];
-  for (const arg of args) {
-    if (known.has(arg)) {
-      continue;
-    }
-    if (flagNames.some((name) => arg.startsWith(`--${name}=`))) {
-      continue;
-    }
+  if (!hasOnlyKnownArguments(args) || hasRepeatedFlag(args)) {
     return undefined;
   }
 
   const mode = args.includes("--apply") ? "apply" : "dry_run";
   const prune = args.includes("--prune");
   const confirmed = args.includes("--confirm-prune");
-  // A repeated flag is an error rather than a silent first-wins: on a command that removes
-  // relationships, an operator who typed a value twice deserves to be told which one would have
-  // applied instead of finding out afterwards.
-  if (flagNames.some((name) => countFlag(args, name) > 1)) {
+
+  const selection: TFlagSelection = {
+    afterOrganizationId: readFlag(args, "after-organization-id"),
+    expectedEndpoint: readFlag(args, "expected-endpoint"),
+    organizationId: readFlag(args, "organization-id"),
+    scope: readFlag(args, "scope"),
+    workspaceId: readFlag(args, "workspace-id"),
+  };
+
+  if (!isScopeNamedUnambiguously(selection) || !areIdentifiersValid(selection)) {
     return undefined;
   }
 
-  const organizationId = readFlag(args, "organization-id");
-  const afterOrganizationId = readFlag(args, "after-organization-id");
-  const expectedEndpoint = readFlag(args, "expected-endpoint");
-  const rawMaxPrune = readFlag(args, "max-prune");
-  const scope = readFlag(args, "scope");
-  const workspaceId = readFlag(args, "workspace-id");
-
-  // `all` is the only value; it exists so pruning every organization has to be spelled out.
-  if (scope !== undefined && scope !== "all") {
-    return undefined;
-  }
-  // The three scopes are mutually exclusive; naming two would leave which one applies ambiguous.
-  if ([scope === "all", organizationId !== undefined, workspaceId !== undefined].filter(Boolean).length > 1) {
-    return undefined;
-  }
-  if (workspaceId !== undefined && !CUID_PATTERN.test(workspaceId)) {
-    return undefined;
-  }
-  // Resuming is a whole-sweep concern.
-  if (workspaceId !== undefined && afterOrganizationId !== undefined) {
+  const maxPrune = resolveMaxPrune(readFlag(args, "max-prune"));
+  if (maxPrune === undefined) {
     return undefined;
   }
 
-  if (organizationId !== undefined && !CUID_PATTERN.test(organizationId)) {
-    return undefined;
-  }
-  if (afterOrganizationId !== undefined && !CUID_PATTERN.test(afterOrganizationId)) {
-    return undefined;
-  }
-  // Resuming is meaningless when a single organization is named.
-  if (organizationId !== undefined && afterOrganizationId !== undefined) {
+  if (!isPruneRequestPermitted({ confirmed, mode, prune, selection })) {
     return undefined;
   }
 
-  let maxPrune = AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN;
-  if (rawMaxPrune !== undefined) {
-    if (!POSITIVE_INTEGER_PATTERN.test(rawMaxPrune)) {
-      return undefined;
-    }
-    const requested = Number(rawMaxPrune);
-    if (requested > AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN) {
-      return undefined;
-    }
-    maxPrune = requested;
-  }
-
-  if (prune) {
-    if (mode !== "apply" || !confirmed || !expectedEndpoint) {
-      return undefined;
-    }
-    // "Prune everything" must be typed, never defaulted into.
-    if (organizationId === undefined && workspaceId === undefined && scope !== "all") {
-      return undefined;
-    }
-  }
-
-  if (confirmed && !prune) {
-    return undefined;
-  }
-
-  return { afterOrganizationId, expectedEndpoint, maxPrune, mode, organizationId, prune, workspaceId };
+  return {
+    afterOrganizationId: selection.afterOrganizationId,
+    expectedEndpoint: selection.expectedEndpoint,
+    maxPrune,
+    mode,
+    organizationId: selection.organizationId,
+    prune,
+    workspaceId: selection.workspaceId,
+  };
 };
 
 const toFailureResult = (error: unknown): TAuthzedBackfillCliFailure => {
@@ -267,12 +332,12 @@ export const runAuthzedBackfillCli = async (
       // The operator named an instance other than the configured one. Refuse rather than guess — and
       // report a distinct code, because "you aimed this at the wrong SpiceDB" and "you mistyped a flag"
       // want very different reactions.
+      // `exitCode` is already 1 from its initializer, which is what this branch wants.
       result = {
         code: AUTHZED_ERROR_CODES.FAILED_PRECONDITION,
         retryable: false,
         status: "failed",
       };
-      exitCode = 1;
     } else {
       result = await dependencies.run(
         {

--- a/apps/web/lib/authzed/backfill-cli.ts
+++ b/apps/web/lib/authzed/backfill-cli.ts
@@ -80,6 +80,9 @@ const defaultDependencies: TAuthzedBackfillCliDependencies = {
 const CUID_PATTERN = /^[a-z0-9]{20,40}$/;
 const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]{0,6}$/;
 
+const countFlag = (args: ReadonlyArray<string>, name: string): number =>
+  args.filter((arg) => arg.startsWith(`--${name}=`)).length;
+
 const readFlag = (args: ReadonlyArray<string>, name: string): string | undefined => {
   const prefix = `--${name}=`;
   return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
@@ -118,6 +121,13 @@ export const parseAuthzedBackfillCommand = (
   const mode = args.includes("--apply") ? "apply" : "dry_run";
   const prune = args.includes("--prune");
   const confirmed = args.includes("--confirm-prune");
+  // A repeated flag is an error rather than a silent first-wins: on a command that removes
+  // relationships, an operator who typed a value twice deserves to be told which one would have
+  // applied instead of finding out afterwards.
+  if (flagNames.some((name) => countFlag(args, name) > 1)) {
+    return undefined;
+  }
+
   const organizationId = readFlag(args, "organization-id");
   const afterOrganizationId = readFlag(args, "after-organization-id");
   const expectedEndpoint = readFlag(args, "expected-endpoint");

--- a/apps/web/lib/authzed/backfill-cli.ts
+++ b/apps/web/lib/authzed/backfill-cli.ts
@@ -1,0 +1,252 @@
+import "server-only";
+import { env } from "@/lib/env";
+import { reconcileApiKeyRelationships } from "./api-key";
+import {
+  type TAuthzedBackfillApply,
+  type TAuthzedBackfillRequest,
+  type TAuthzedBackfillResult,
+  runAuthzedBackfill,
+} from "./backfill";
+import { closeAuthzedClient, getAuthzedClient } from "./client";
+import { isAuthzedEnabled } from "./config";
+import { AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN } from "./constants";
+import { AUTHZED_ERROR_CODES, AuthzedError, type TAuthzedErrorCode, mapAuthzedError } from "./errors";
+import { reconcileOrganizationMemberships } from "./organization-membership";
+import { reconcileTeamWorkspaceRelationships } from "./team-workspace";
+
+/**
+ * Command layer for relationship backfill and repair.
+ *
+ * Argument parsing lives here rather than in the script entry point, unlike the health and schema
+ * commands: `apps/web/scripts/**` is excluded from coverage, and the flag matrix below — three
+ * independent confirmations before anything destructive happens — is exactly the logic that must not
+ * go untested.
+ *
+ * The exit-code contract matches `authzed:schema`: 0 clean, 2 drift remains, 1 failed or misused.
+ */
+
+export type TAuthzedBackfillCliCommand = Readonly<{
+  afterOrganizationId?: string;
+  expectedEndpoint?: string;
+  maxPrune: number;
+  mode: "apply" | "dry_run";
+  organizationId?: string;
+  prune: boolean;
+}>;
+
+type TAuthzedBackfillCliFailure = Readonly<{
+  code: TAuthzedErrorCode;
+  retryable: boolean;
+  status: "failed";
+}>;
+
+type TAuthzedBackfillCliDependencies = Readonly<{
+  closeClient: () => void;
+  isEnabled: () => boolean;
+  resolveEndpoint: () => string | undefined;
+  run: (request: TAuthzedBackfillRequest, apply: TAuthzedBackfillApply) => Promise<TAuthzedBackfillResult>;
+  writeOutput: (output: string) => void;
+}>;
+
+/**
+ * Real reconcilers. Selected once, in `runAuthzedBackfillCli`, and only for an applying run.
+ *
+ * The orchestrator can reach a mutation only through this object, so a dry run supplying
+ * `createInertApply()` cannot write regardless of any flag it is passed.
+ */
+const createWritableApply = (): TAuthzedBackfillApply => ({
+  reconcileApiKeys: reconcileApiKeyRelationships,
+  reconcileMemberships: reconcileOrganizationMemberships,
+  reconcileTeamWorkspace: reconcileTeamWorkspaceRelationships,
+});
+
+const INERT_RESULT = { passes: 0, status: "projected" } as const;
+
+/** No-op reconcilers for a dry run. */
+const createInertApply = (): TAuthzedBackfillApply => ({
+  reconcileApiKeys: async () => INERT_RESULT,
+  reconcileMemberships: async () => INERT_RESULT,
+  reconcileTeamWorkspace: async () => INERT_RESULT,
+});
+
+const defaultDependencies: TAuthzedBackfillCliDependencies = {
+  closeClient: closeAuthzedClient,
+  isEnabled: isAuthzedEnabled,
+  resolveEndpoint: () => env.AUTHZED_ENDPOINT,
+  run: (request, apply) => runAuthzedBackfill(request, { apply, client: getAuthzedClient() }),
+  writeOutput: (output) => process.stdout.write(output),
+};
+
+const CUID_PATTERN = /^[a-z0-9]{20,40}$/;
+const POSITIVE_INTEGER_PATTERN = /^[1-9][0-9]{0,6}$/;
+
+const readFlag = (args: ReadonlyArray<string>, name: string): string | undefined => {
+  const prefix = `--${name}=`;
+  return args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length);
+};
+
+/**
+ * Parse argv into a command, or `undefined` if the invocation is not one this tool will perform.
+ *
+ * Deliberately strict and deliberately inconvenient where it matters:
+ *
+ * - a dry run is the default, so a mistyped invocation is inert;
+ * - `--prune` needs `--apply`, `--confirm-prune`, an explicit scope, and `--expected-endpoint`, so
+ *   removing relationships cannot happen as a side effect of any shorter command;
+ * - `--expected-endpoint` must match the configured endpoint. The endpoint differs per environment by
+ *   construction, which the AuthZed system key does not — it is documented as a stable namespace and
+ *   defaults to the same value everywhere, so it could not tell staging from production. This is the
+ *   guard against a stale `.env` aiming the destructive path at the wrong instance, which matters
+ *   because these commands read `.env` only and ignore `.env.local`;
+ * - `--max-prune` may lower the per-run cap, never raise it.
+ */
+export const parseAuthzedBackfillCommand = (
+  args: ReadonlyArray<string>
+): TAuthzedBackfillCliCommand | undefined => {
+  const known = new Set(["--apply", "--confirm-prune", "--prune"]);
+  const flagNames = ["after-organization-id", "expected-endpoint", "max-prune", "organization-id", "scope"];
+  for (const arg of args) {
+    if (known.has(arg)) {
+      continue;
+    }
+    if (flagNames.some((name) => arg.startsWith(`--${name}=`))) {
+      continue;
+    }
+    return undefined;
+  }
+
+  const mode = args.includes("--apply") ? "apply" : "dry_run";
+  const prune = args.includes("--prune");
+  const confirmed = args.includes("--confirm-prune");
+  const organizationId = readFlag(args, "organization-id");
+  const afterOrganizationId = readFlag(args, "after-organization-id");
+  const expectedEndpoint = readFlag(args, "expected-endpoint");
+  const rawMaxPrune = readFlag(args, "max-prune");
+  const scope = readFlag(args, "scope");
+
+  // `all` is the only value; it exists so pruning every organization has to be spelled out.
+  if (scope !== undefined && scope !== "all") {
+    return undefined;
+  }
+  if (scope === "all" && organizationId !== undefined) {
+    return undefined;
+  }
+
+  if (organizationId !== undefined && !CUID_PATTERN.test(organizationId)) {
+    return undefined;
+  }
+  if (afterOrganizationId !== undefined && !CUID_PATTERN.test(afterOrganizationId)) {
+    return undefined;
+  }
+  // Resuming is meaningless when a single organization is named.
+  if (organizationId !== undefined && afterOrganizationId !== undefined) {
+    return undefined;
+  }
+
+  let maxPrune = AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN;
+  if (rawMaxPrune !== undefined) {
+    if (!POSITIVE_INTEGER_PATTERN.test(rawMaxPrune)) {
+      return undefined;
+    }
+    const requested = Number(rawMaxPrune);
+    if (requested > AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN) {
+      return undefined;
+    }
+    maxPrune = requested;
+  }
+
+  if (prune) {
+    if (mode !== "apply" || !confirmed || !expectedEndpoint) {
+      return undefined;
+    }
+    // "Prune everything" must be typed, never defaulted into.
+    if (organizationId === undefined && scope !== "all") {
+      return undefined;
+    }
+  }
+
+  if (confirmed && !prune) {
+    return undefined;
+  }
+
+  return { afterOrganizationId, expectedEndpoint, maxPrune, mode, organizationId, prune };
+};
+
+const toFailureResult = (error: unknown): TAuthzedBackfillCliFailure => {
+  const authzedError = error instanceof AuthzedError ? error : mapAuthzedError(error, "backfill_cli", 1);
+
+  return { code: authzedError.code, retryable: authzedError.retryable, status: "failed" };
+};
+
+const invalidRequest = (): TAuthzedBackfillCliFailure => ({
+  code: AUTHZED_ERROR_CODES.INVALID_REQUEST,
+  retryable: false,
+  status: "failed",
+});
+
+const toExitCode = (status: TAuthzedBackfillResult["status"]): number => {
+  switch (status) {
+    case "reconciled":
+      return 0;
+    case "drifted":
+      return 2;
+    case "failed":
+      return 1;
+  }
+};
+
+export const runAuthzedBackfillCli = async (
+  command: TAuthzedBackfillCliCommand,
+  dependencyOverrides: Partial<TAuthzedBackfillCliDependencies> = {}
+): Promise<number> => {
+  const dependencies = { ...defaultDependencies, ...dependencyOverrides };
+  let result: TAuthzedBackfillResult | TAuthzedBackfillCliFailure = invalidRequest();
+  let exitCode = 1;
+
+  try {
+    // Checked up front. Left to the per-unit result, a disabled instance would report every
+    // organization as reconciled, because that is what "not failed" looks like from the outside.
+    if (!dependencies.isEnabled()) {
+      throw new AuthzedError({
+        attempts: 0,
+        code: AUTHZED_ERROR_CODES.DISABLED,
+        operation: "backfill_cli",
+        retryable: false,
+      });
+    }
+
+    if (
+      command.expectedEndpoint !== undefined &&
+      command.expectedEndpoint !== dependencies.resolveEndpoint()
+    ) {
+      // The operator named an instance other than the configured one. Refuse rather than guess.
+      result = invalidRequest();
+      exitCode = 1;
+    } else {
+      result = await dependencies.run(
+        {
+          maxPrune: command.maxPrune,
+          mode: command.mode,
+          prune: command.prune,
+          scope: command.organizationId
+            ? { kind: "organization", organizationId: command.organizationId }
+            : { afterOrganizationId: command.afterOrganizationId, kind: "all" },
+        },
+        command.mode === "apply" ? createWritableApply() : createInertApply()
+      );
+      exitCode = toExitCode(result.status);
+    }
+  } catch (error) {
+    result = toFailureResult(error);
+    exitCode = 1;
+  } finally {
+    try {
+      dependencies.closeClient();
+    } catch {
+      // Cleanup failures must not replace the backfill's result or exit code.
+    }
+  }
+
+  dependencies.writeOutput(`${JSON.stringify(result)}\n`);
+  return exitCode;
+};

--- a/apps/web/lib/authzed/backfill-cli.ts
+++ b/apps/web/lib/authzed/backfill-cli.ts
@@ -257,8 +257,14 @@ export const runAuthzedBackfillCli = async (
       command.expectedEndpoint !== undefined &&
       command.expectedEndpoint !== dependencies.resolveEndpoint()
     ) {
-      // The operator named an instance other than the configured one. Refuse rather than guess.
-      result = invalidRequest();
+      // The operator named an instance other than the configured one. Refuse rather than guess — and
+      // report a distinct code, because "you aimed this at the wrong SpiceDB" and "you mistyped a flag"
+      // want very different reactions.
+      result = {
+        code: AUTHZED_ERROR_CODES.FAILED_PRECONDITION,
+        retryable: false,
+        status: "failed",
+      };
       exitCode = 1;
     } else {
       result = await dependencies.run(

--- a/apps/web/lib/authzed/backfill-cli.ts
+++ b/apps/web/lib/authzed/backfill-cli.ts
@@ -7,7 +7,7 @@ import {
   type TAuthzedBackfillResult,
   runAuthzedBackfill,
 } from "./backfill";
-import { closeAuthzedClient, getAuthzedBulkClient } from "./client";
+import { closeAuthzedClient, configureAuthzedClientForBulkWork, getAuthzedClient } from "./client";
 import { isAuthzedEnabled } from "./config";
 import { AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN } from "./constants";
 import { AUTHZED_ERROR_CODES, AuthzedError, type TAuthzedErrorCode, mapAuthzedError } from "./errors";
@@ -74,7 +74,14 @@ const defaultDependencies: TAuthzedBackfillCliDependencies = {
   closeClient: closeAuthzedClient,
   isEnabled: isAuthzedEnabled,
   resolveEndpoint: () => env.AUTHZED_ENDPOINT,
-  run: (request, apply) => runAuthzedBackfill(request, { apply, client: getAuthzedBulkClient() }),
+  // Widened before the first client is built, so the reconcilers this hands to the orchestrator — which
+  // reach the channel through `getAuthzedClient()` themselves — write under the same bulk deadline the
+  // sweep reads under.
+  run: (request, apply) => {
+    configureAuthzedClientForBulkWork();
+
+    return runAuthzedBackfill(request, { apply, client: getAuthzedClient() });
+  },
   writeOutput: (output) => process.stdout.write(output),
 };
 

--- a/apps/web/lib/authzed/backfill-diff.test.ts
+++ b/apps/web/lib/authzed/backfill-diff.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
   getManagedResourceTypes,
-  isManagedResourceType,
   isUnprojectedResourceType,
   summarizeObservation,
   toSourceRef,
@@ -132,7 +131,7 @@ describe("toSourceRef", () => {
 
 describe("resource type classification", () => {
   test.each(["api_key", "organization", "team", "workspace"])("treats %s as managed", (resourceType) => {
-    expect(isManagedResourceType(resourceType)).toBe(true);
+    expect(getManagedResourceTypes()).toContain(resourceType);
     expect(isUnprojectedResourceType(resourceType)).toBe(false);
   });
 
@@ -141,8 +140,9 @@ describe("resource type classification", () => {
     (resourceType) => {
       // These exist in the schema for later resource-level sharing. Pruning them would delete
       // relationships a future projector is expected to own.
+      // No type may be both: managed means the sweep reads it and may prune what it finds.
       expect(isUnprojectedResourceType(resourceType)).toBe(true);
-      expect(isManagedResourceType(resourceType)).toBe(false);
+      expect(getManagedResourceTypes()).not.toContain(resourceType);
     }
   );
 

--- a/apps/web/lib/authzed/backfill-diff.test.ts
+++ b/apps/web/lib/authzed/backfill-diff.test.ts
@@ -151,6 +151,36 @@ describe("resource type classification", () => {
   });
 });
 
+describe("cross-tenant organization access", () => {
+  test("reports an organization access grant naming a key from another organization", () => {
+    // `organization:A#api_key_writer@api_key:K` implies "K belongs to A". Reduced to "does K exist?" it
+    // read as sourced whenever K existed anywhere, so a cross-tenant grant survived apply and prune.
+    const summary = summarizeObservation([
+      {
+        relation: "api_key_writer",
+        resource: { objectId: "org-a", objectType: "organization" },
+        subject: { objectId: "key-1", objectType: "api_key" },
+      },
+    ]);
+
+    expect(summary.parentEdges).toEqual([
+      { childId: "key-1", childType: "api_key", organizationId: "org-a" },
+    ]);
+  });
+
+  test("still names the key as a source record, so a deleted key is found too", () => {
+    const summary = summarizeObservation([
+      {
+        relation: "api_key_reader",
+        resource: { objectId: "org-a", objectType: "organization" },
+        subject: { objectId: "key-1", objectType: "api_key" },
+      },
+    ]);
+
+    expect(summary.sourceRefs).toEqual([{ apiKeyId: "key-1", kind: "apiKey" }]);
+  });
+});
+
 describe("summarizeObservation", () => {
   test("collects the source records an observation implies", () => {
     const summary = summarizeObservation([

--- a/apps/web/lib/authzed/backfill-diff.test.ts
+++ b/apps/web/lib/authzed/backfill-diff.test.ts
@@ -189,7 +189,7 @@ describe("summarizeObservation", () => {
       tuple("response", "resp-1", "survey", "survey", "survey-1"),
     ]);
 
-    expect(summary).toEqual({ ignored: 3, sourceRefs: [], unmanaged: [] });
+    expect(summary).toEqual({ ignored: 3, parentEdges: [], sourceRefs: [], unmanaged: [] });
   });
 
   test("reports unrecognized relationships without naming a record for them", () => {
@@ -222,6 +222,6 @@ describe("summarizeObservation", () => {
   });
 
   test("returns an empty summary for an empty observation", () => {
-    expect(summarizeObservation([])).toEqual({ ignored: 0, sourceRefs: [], unmanaged: [] });
+    expect(summarizeObservation([])).toEqual({ ignored: 0, parentEdges: [], sourceRefs: [], unmanaged: [] });
   });
 });

--- a/apps/web/lib/authzed/backfill-diff.test.ts
+++ b/apps/web/lib/authzed/backfill-diff.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from "vitest";
+import {
+  getManagedResourceTypes,
+  isManagedResourceType,
+  isUnprojectedResourceType,
+  summarizeObservation,
+  toSourceRef,
+} from "./backfill-diff";
+import type { TAuthzedRelationship } from "./client";
+
+const tuple = (
+  resourceType: string,
+  resourceId: string,
+  relation: string,
+  subjectType: string,
+  subjectId: string,
+  subjectRelation?: string
+): TAuthzedRelationship => ({
+  relation,
+  resource: { objectId: resourceId, objectType: resourceType },
+  subject: {
+    objectId: subjectId,
+    objectType: subjectType,
+    ...(subjectRelation ? { relation: subjectRelation } : {}),
+  },
+});
+
+describe("toSourceRef", () => {
+  test.each(["owner", "manager", "member", "billing"])(
+    "maps organization#%s@user to the membership row",
+    (relation) => {
+      expect(toSourceRef(tuple("organization", "org-1", relation, "user", "user-1"))).toEqual({
+        kind: "membership",
+        organizationId: "org-1",
+        userId: "user-1",
+      });
+    }
+  );
+
+  test.each(["api_key_reader", "api_key_writer"])(
+    "maps organization#%s@api_key to the API key, since the flags live on the key's record",
+    (relation) => {
+      expect(toSourceRef(tuple("organization", "org-1", relation, "api_key", "key-1"))).toEqual({
+        apiKeyId: "key-1",
+        kind: "apiKey",
+      });
+    }
+  );
+
+  test("maps team#organization to the team row", () => {
+    expect(toSourceRef(tuple("team", "team-1", "organization", "organization", "org-1"))).toEqual({
+      kind: "team",
+      teamId: "team-1",
+    });
+  });
+
+  test.each(["admin", "contributor"])("maps team#%s@user to the team membership row", (relation) => {
+    expect(toSourceRef(tuple("team", "team-1", relation, "user", "user-1"))).toEqual({
+      kind: "teamMembership",
+      teamId: "team-1",
+      userId: "user-1",
+    });
+  });
+
+  test("maps workspace#organization to the workspace row", () => {
+    expect(toSourceRef(tuple("workspace", "ws-1", "organization", "organization", "org-1"))).toEqual({
+      kind: "workspace",
+      workspaceId: "ws-1",
+    });
+  });
+
+  test.each(["reader_team", "writer_team", "manager_team"])(
+    "maps workspace#%s@team#member to the workspace-team grant",
+    (relation) => {
+      expect(toSourceRef(tuple("workspace", "ws-1", relation, "team", "team-1", "member"))).toEqual({
+        kind: "workspaceTeamGrant",
+        teamId: "team-1",
+        workspaceId: "ws-1",
+      });
+    }
+  );
+
+  test.each(["reader", "writer", "manager"])(
+    "maps workspace#%s@api_key to the API-key workspace grant",
+    (relation) => {
+      expect(toSourceRef(tuple("workspace", "ws-1", relation, "api_key", "key-1"))).toEqual({
+        apiKeyId: "key-1",
+        kind: "apiKeyWorkspaceGrant",
+        workspaceId: "ws-1",
+      });
+    }
+  );
+
+  test("maps api_key#organization to the API key row", () => {
+    expect(toSourceRef(tuple("api_key", "key-1", "organization", "organization", "org-1"))).toEqual({
+      apiKeyId: "key-1",
+      kind: "apiKey",
+    });
+  });
+
+  test("distinguishes an api-key workspace grant from a team workspace grant", () => {
+    // The relations differ only by suffix and the subject type, and confusing them would name the
+    // wrong source record — so a present grant would look absent, and pruning would revoke it.
+    expect(toSourceRef(tuple("workspace", "ws-1", "manager", "api_key", "key-1"))).toEqual({
+      apiKeyId: "key-1",
+      kind: "apiKeyWorkspaceGrant",
+      workspaceId: "ws-1",
+    });
+    expect(toSourceRef(tuple("workspace", "ws-1", "manager_team", "team", "team-1", "member"))).toEqual({
+      kind: "workspaceTeamGrant",
+      teamId: "team-1",
+      workspaceId: "ws-1",
+    });
+  });
+
+  test.each([
+    ["an unknown resource type", tuple("chart", "chart-1", "workspace", "workspace", "ws-1")],
+    ["an unknown relation", tuple("organization", "org-1", "superuser", "user", "user-1")],
+    ["a role relation with the wrong subject type", tuple("organization", "org-1", "owner", "api_key", "k")],
+    [
+      "an api-key flag with the wrong subject type",
+      tuple("organization", "o", "api_key_reader", "user", "u"),
+    ],
+    ["a team grant with the wrong subject type", tuple("workspace", "ws-1", "reader_team", "user", "u")],
+    ["a workspace grant with the wrong subject type", tuple("workspace", "ws-1", "reader", "user", "u")],
+    ["a parent relation with the wrong subject type", tuple("team", "team-1", "organization", "user", "u")],
+    ["an api_key resource with an unexpected relation", tuple("api_key", "key-1", "reader", "user", "u")],
+  ])("declines to name a source record for %s", (_label, relationship) => {
+    expect(toSourceRef(relationship)).toBeNull();
+  });
+});
+
+describe("resource type classification", () => {
+  test.each(["api_key", "organization", "team", "workspace"])("treats %s as managed", (resourceType) => {
+    expect(isManagedResourceType(resourceType)).toBe(true);
+    expect(isUnprojectedResourceType(resourceType)).toBe(false);
+  });
+
+  test.each(["survey", "dashboard", "response"])(
+    "treats %s as deliberately unprojected, not managed",
+    (resourceType) => {
+      // These exist in the schema for later resource-level sharing. Pruning them would delete
+      // relationships a future projector is expected to own.
+      expect(isUnprojectedResourceType(resourceType)).toBe(true);
+      expect(isManagedResourceType(resourceType)).toBe(false);
+    }
+  );
+
+  test("exposes the managed types for a resource-type sweep", () => {
+    expect([...getManagedResourceTypes()].sort()).toEqual(["api_key", "organization", "team", "workspace"]);
+  });
+});
+
+describe("summarizeObservation", () => {
+  test("collects the source records an observation implies", () => {
+    const summary = summarizeObservation([
+      tuple("organization", "org-1", "owner", "user", "user-1"),
+      tuple("team", "team-1", "organization", "organization", "org-1"),
+      tuple("workspace", "ws-1", "reader", "api_key", "key-1"),
+    ]);
+
+    expect(summary.sourceRefs).toHaveLength(3);
+    expect(summary.sourceRefs).toEqual(
+      expect.arrayContaining([
+        { kind: "membership", organizationId: "org-1", userId: "user-1" },
+        { kind: "team", teamId: "team-1" },
+        { apiKeyId: "key-1", kind: "apiKeyWorkspaceGrant", workspaceId: "ws-1" },
+      ])
+    );
+    expect(summary.ignored).toBe(0);
+    expect(summary.unmanaged).toEqual([]);
+  });
+
+  test("deduplicates records implied by more than one relationship", () => {
+    const summary = summarizeObservation([
+      tuple("api_key", "key-1", "organization", "organization", "org-1"),
+      tuple("organization", "org-1", "api_key_reader", "api_key", "key-1"),
+      tuple("organization", "org-1", "api_key_writer", "api_key", "key-1"),
+    ]);
+
+    // All three imply the same API key record, so it is looked up once.
+    expect(summary.sourceRefs).toEqual([{ apiKeyId: "key-1", kind: "apiKey" }]);
+  });
+
+  test("counts unprojected resource types as ignored without naming a record", () => {
+    const summary = summarizeObservation([
+      tuple("survey", "survey-1", "workspace", "workspace", "ws-1"),
+      tuple("dashboard", "dash-1", "workspace", "workspace", "ws-1"),
+      tuple("response", "resp-1", "survey", "survey", "survey-1"),
+    ]);
+
+    expect(summary).toEqual({ ignored: 3, sourceRefs: [], unmanaged: [] });
+  });
+
+  test("reports unrecognized relationships without naming a record for them", () => {
+    const summary = summarizeObservation([
+      tuple("organization", "org-1", "superuser", "user", "user-1"),
+      tuple("chart", "chart-1", "workspace", "workspace", "ws-1"),
+    ]);
+
+    // Reported so they are visible, but never reconciled: the tooling cannot know which source record,
+    // if any, should own them.
+    expect(summary.sourceRefs).toEqual([]);
+    expect(summary.unmanaged).toEqual([
+      { objectId: "chart-1", objectType: "chart", relation: "workspace" },
+      { objectId: "org-1", objectType: "organization", relation: "superuser" },
+    ]);
+  });
+
+  test("orders output deterministically so repeated runs are comparable", () => {
+    const relationships = [
+      tuple("workspace", "ws-2", "organization", "organization", "org-1"),
+      tuple("organization", "org-1", "owner", "user", "user-2"),
+      tuple("workspace", "ws-1", "organization", "organization", "org-1"),
+      tuple("organization", "org-1", "owner", "user", "user-1"),
+    ];
+
+    const first = summarizeObservation(relationships);
+    const second = summarizeObservation([...relationships].reverse());
+
+    expect(first).toEqual(second);
+  });
+
+  test("returns an empty summary for an empty observation", () => {
+    expect(summarizeObservation([])).toEqual({ ignored: 0, sourceRefs: [], unmanaged: [] });
+  });
+});

--- a/apps/web/lib/authzed/backfill-diff.test.ts
+++ b/apps/web/lib/authzed/backfill-diff.test.ts
@@ -152,6 +152,30 @@ describe("resource type classification", () => {
 });
 
 describe("cross-tenant organization access", () => {
+  test("distinguishes the two ownership shapes, which need different remediation", () => {
+    // Both say "this key belongs to that organization", but the organization sits on opposite sides, so
+    // `zed relationship delete` takes different arguments. Reporting them identically would send an
+    // operator to delete a relationship that does not exist while the escalation survives.
+    const summary = summarizeObservation([
+      {
+        relation: "organization",
+        resource: { objectId: "key-1", objectType: "api_key" },
+        subject: { objectId: "org-a", objectType: "organization" },
+      },
+      {
+        relation: "api_key_writer",
+        resource: { objectId: "org-a", objectType: "organization" },
+        subject: { objectId: "key-1", objectType: "api_key" },
+      },
+    ]);
+
+    // Deterministically ordered, so `api_key_writer` precedes `organization`.
+    expect(summary.parentEdges).toEqual([
+      { childId: "key-1", childType: "api_key", organizationId: "org-a", relation: "api_key_writer" },
+      { childId: "key-1", childType: "api_key", organizationId: "org-a", relation: "organization" },
+    ]);
+  });
+
   test("reports an organization access grant naming a key from another organization", () => {
     // `organization:A#api_key_writer@api_key:K` implies "K belongs to A". Reduced to "does K exist?" it
     // read as sourced whenever K existed anywhere, so a cross-tenant grant survived apply and prune.
@@ -164,7 +188,7 @@ describe("cross-tenant organization access", () => {
     ]);
 
     expect(summary.parentEdges).toEqual([
-      { childId: "key-1", childType: "api_key", organizationId: "org-a" },
+      { childId: "key-1", childType: "api_key", organizationId: "org-a", relation: "api_key_writer" },
     ]);
   });
 

--- a/apps/web/lib/authzed/backfill-diff.ts
+++ b/apps/web/lib/authzed/backfill-diff.ts
@@ -57,6 +57,8 @@ export type TAuthzedSourceRef =
 export type TAuthzedObservationSummary = Readonly<{
   /** Relationships on deliberately-unprojected resource types. Counted, never acted on. */
   ignored: number;
+  /** Every parent edge observed, so the organization each resource claims can be verified. */
+  parentEdges: ReadonlyArray<TAuthzedParentEdge>;
   /** Deduplicated, deterministically ordered source records the observation implies. */
   sourceRefs: ReadonlyArray<TAuthzedSourceRef>;
   /**
@@ -144,8 +146,78 @@ export const toSourceRef = (relationship: TAuthzedRelationship): TAuthzedSourceR
   }
 };
 
+/**
+ * An observed parent edge: a resource claiming to belong to an organization.
+ *
+ * Tracked separately from the source records because the organization on the *right* of the edge is
+ * information a source-record reference throws away. `team:T#organization@organization:O` implies
+ * "Team T exists", and an existence check confirms that even when `O` is the wrong organization —
+ * so without this the edge is invisible.
+ *
+ * It matters because `organization` is a SpiceDB relation, i.e. a set, and the schema grants
+ * `workspace#manage` through `organization->manage`. A second, wrong parent edge on a workspace therefore
+ * hands every owner and manager of that organization full access to another tenant's workspace, with
+ * nothing in PostgreSQL to show for it.
+ */
+export type TAuthzedParentEdge = Readonly<{
+  childId: string;
+  childType: "api_key" | "team" | "workspace";
+  organizationId: string;
+}>;
+
 /** Stable identity for deduplication and ordering. Field order is fixed by the union's key order. */
 const sourceRefKey = (ref: TAuthzedSourceRef): string => JSON.stringify(ref);
+
+/** The parent edge an observed relationship asserts, if it asserts one. */
+const toParentEdge = (relationship: TAuthzedRelationship): TAuthzedParentEdge | null => {
+  const { relation, resource, subject } = relationship;
+
+  if (relation !== PARENT_RELATION || subject.objectType !== "organization") {
+    return null;
+  }
+  if (
+    resource.objectType !== "api_key" &&
+    resource.objectType !== "team" &&
+    resource.objectType !== "workspace"
+  ) {
+    return null;
+  }
+
+  return { childId: resource.objectId, childType: resource.objectType, organizationId: subject.objectId };
+};
+
+/**
+ * Source records PostgreSQL holds that SpiceDB has no relationship for.
+ *
+ * The other half of the drift picture. Without it a report can only find *stale* relationships, so an
+ * entirely empty SpiceDB reads as clean against a fully populated PostgreSQL — which is precisely the
+ * state the backfill exists to fix.
+ *
+ * Deliberately a set difference over source *records*, not over relationships. It answers "is this
+ * record projected at all?" and **not** "is it projected with the right relation": a membership stored
+ * as `owner` in PostgreSQL but `member` in SpiceDB appears on neither side of this diff, because both
+ * map to the same record. Converging a relation is what applying does unconditionally by writing the
+ * current value; detecting a wrong one would mean rebuilding every expected relationship here, which is
+ * the projectors' job and not worth duplicating.
+ */
+export const findUnprojectedSourceRefs = (
+  expected: ReadonlyArray<TAuthzedSourceRef>,
+  observed: ReadonlyArray<TAuthzedSourceRef>
+): ReadonlyArray<TAuthzedSourceRef> => {
+  const observedKeys = new Set(observed.map(sourceRefKey));
+  const unprojected = new Map<string, TAuthzedSourceRef>();
+
+  for (const ref of expected) {
+    const key = sourceRefKey(ref);
+    if (!observedKeys.has(key)) {
+      unprojected.set(key, ref);
+    }
+  }
+
+  return [...unprojected.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, ref]) => ref);
+};
 
 const toRelationshipRef = (relationship: TAuthzedRelationship): TAuthzedRelationshipRef => ({
   objectId: relationship.resource.objectId,
@@ -164,12 +236,18 @@ export const summarizeObservation = (
 ): TAuthzedObservationSummary => {
   const sourceRefs = new Map<string, TAuthzedSourceRef>();
   const unmanaged = new Map<string, TAuthzedRelationshipRef>();
+  const parentEdges = new Map<string, TAuthzedParentEdge>();
   let ignored = 0;
 
   for (const relationship of relationships) {
     if (isUnprojectedResourceType(relationship.resource.objectType)) {
       ignored++;
       continue;
+    }
+
+    const parentEdge = toParentEdge(relationship);
+    if (parentEdge) {
+      parentEdges.set(JSON.stringify(parentEdge), parentEdge);
     }
 
     const sourceRef = toSourceRef(relationship);
@@ -184,6 +262,9 @@ export const summarizeObservation = (
 
   return {
     ignored,
+    parentEdges: [...parentEdges.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([, edge]) => edge),
     sourceRefs: [...sourceRefs.entries()]
       .sort(([left], [right]) => left.localeCompare(right))
       .map(([, ref]) => ref),

--- a/apps/web/lib/authzed/backfill-diff.ts
+++ b/apps/web/lib/authzed/backfill-diff.ts
@@ -166,7 +166,14 @@ export type TAuthzedParentEdge = Readonly<{
 }>;
 
 /** Stable identity for deduplication and ordering. Field order is fixed by the union's key order. */
-const sourceRefKey = (ref: TAuthzedSourceRef): string => JSON.stringify(ref);
+/**
+ * A stable identity for one source record, used to deduplicate and to diff.
+ *
+ * `JSON.stringify` over a literal whose keys are written in a fixed order in `toSourceRef` and
+ * `toSourceRefs`. Two refs for the same record must serialize identically, so both constructors keep
+ * their key order aligned — the test asserting round-trip equality of every kind is what holds that.
+ */
+export const sourceRefKey = (ref: TAuthzedSourceRef): string => JSON.stringify(ref);
 
 /** The parent edge an observed relationship asserts, if it asserts one. */
 const toParentEdge = (relationship: TAuthzedRelationship): TAuthzedParentEdge | null => {

--- a/apps/web/lib/authzed/backfill-diff.ts
+++ b/apps/web/lib/authzed/backfill-diff.ts
@@ -150,15 +150,28 @@ const SOURCE_REF_RESOLVERS = {
 } as const satisfies Readonly<Record<string, TSourceRefResolver>>;
 
 /**
+ * Code-unit order, deliberately not `localeCompare`.
+ *
+ * `localeCompare` resolves its collation from the host's default locale and available ICU data, so two
+ * machines can order the same keys differently — which would undercut the very guarantee this sort
+ * exists to provide.
+ */
+const byCodeUnit = (left: string, right: string): number => {
+  if (left === right) {
+    return 0;
+  }
+
+  return left < right ? -1 : 1;
+};
+
+/**
  * Resource types Formbricks projects today and may therefore reconcile.
  *
- * Sorted explicitly, with a comparator, for two reasons: the sweep's order must not depend on how the
- * resolver literal above happens to be written, and it must be identical between runs so two passes
- * over unchanged state produce identical output.
+ * Sorted explicitly for two reasons: the sweep's order must not depend on how the resolver literal above
+ * happens to be written, and it must be identical on every machine, so two passes over unchanged state
+ * produce identical output.
  */
-const MANAGED_RESOURCE_TYPES: ReadonlyArray<string> = Object.keys(SOURCE_REF_RESOLVERS).sort((left, right) =>
-  left.localeCompare(right)
-);
+const MANAGED_RESOURCE_TYPES: ReadonlyArray<string> = Object.keys(SOURCE_REF_RESOLVERS).sort(byCodeUnit);
 
 export const getManagedResourceTypes = (): ReadonlyArray<string> => MANAGED_RESOURCE_TYPES;
 

--- a/apps/web/lib/authzed/backfill-diff.ts
+++ b/apps/web/lib/authzed/backfill-diff.ts
@@ -21,9 +21,6 @@ import {
  * reconcile is written, not deleted.
  */
 
-/** Resource types Formbricks projects today and may therefore reconcile. */
-const MANAGED_RESOURCE_TYPES = ["api_key", "organization", "team", "workspace"] as const;
-
 /**
  * Resource types the schema defines but no projector writes yet.
  *
@@ -80,70 +77,97 @@ const WORKSPACE_API_KEY_GRANT_RELATIONS = new Set<string>(Object.values(WORKSPAC
 /** The relation naming a resource's owning organization, shared by `api_key`, `team`, and `workspace`. */
 const PARENT_RELATION = "organization";
 
-export const isManagedResourceType = (resourceType: string): boolean =>
-  (MANAGED_RESOURCE_TYPES as readonly string[]).includes(resourceType);
-
 export const isUnprojectedResourceType = (resourceType: string): boolean =>
   (UNPROJECTED_RESOURCE_TYPES as readonly string[]).includes(resourceType);
 
-export const getManagedResourceTypes = (): ReadonlyArray<string> => MANAGED_RESOURCE_TYPES;
+/**
+ * Resolves the source record a relationship on one resource type implies, or `null` when the
+ * vocabulary does not recognize that particular relation/subject pairing.
+ */
+type TSourceRefResolver = (relationship: TAuthzedRelationship) => TAuthzedSourceRef | null;
+
+const toOrganizationSourceRef: TSourceRefResolver = ({ relation, resource, subject }) => {
+  if (subject.objectType === "user" && ORGANIZATION_ROLE_RELATIONS.has(relation)) {
+    return { kind: "membership", organizationId: resource.objectId, userId: subject.objectId };
+  }
+  if (subject.objectType === "api_key" && ORGANIZATION_API_KEY_RELATIONS.has(relation)) {
+    // Access flags live on the key's own record, so the key is the thing to look up.
+    return { apiKeyId: subject.objectId, kind: "apiKey" };
+  }
+
+  return null;
+};
+
+const toTeamSourceRef: TSourceRefResolver = ({ relation, resource, subject }) => {
+  if (subject.objectType === "organization" && relation === PARENT_RELATION) {
+    return { kind: "team", teamId: resource.objectId };
+  }
+  if (subject.objectType === "user" && TEAM_ROLE_RELATIONS.has(relation)) {
+    return { kind: "teamMembership", teamId: resource.objectId, userId: subject.objectId };
+  }
+
+  return null;
+};
+
+const toWorkspaceSourceRef: TSourceRefResolver = ({ relation, resource, subject }) => {
+  if (subject.objectType === "organization" && relation === PARENT_RELATION) {
+    return { kind: "workspace", workspaceId: resource.objectId };
+  }
+  if (subject.objectType === "team" && WORKSPACE_TEAM_GRANT_RELATIONS.has(relation)) {
+    return { kind: "workspaceTeamGrant", teamId: subject.objectId, workspaceId: resource.objectId };
+  }
+  if (subject.objectType === "api_key" && WORKSPACE_API_KEY_GRANT_RELATIONS.has(relation)) {
+    return {
+      apiKeyId: subject.objectId,
+      kind: "apiKeyWorkspaceGrant",
+      workspaceId: resource.objectId,
+    };
+  }
+
+  return null;
+};
+
+const toApiKeySourceRef: TSourceRefResolver = ({ relation, resource, subject }) =>
+  subject.objectType === "organization" && relation === PARENT_RELATION
+    ? { apiKeyId: resource.objectId, kind: "apiKey" }
+    : null;
 
 /**
- * Name the source record an observed relationship implies, or `null` if the vocabulary does not
- * recognize it.
+ * The vocabulary in one table: which resource types imply a source record, and how.
  *
- * Both the relation name and the subject type matter. `workspace#reader@api_key` and
- * `workspace#reader_team@team#member` are distinct grants, and the API-key relations are deliberately
- * unsuffixed while the team relations are not.
+ * `MANAGED_RESOURCE_TYPES` is derived from these keys rather than listed separately, so a resource
+ * type can never be swept without a resolver that knows how to interpret what the sweep finds.
+ *
+ * Both the relation name and the subject type matter in every resolver. `workspace#reader@api_key`
+ * and `workspace#reader_team@team#member` are distinct grants, and the API-key relations are
+ * deliberately unsuffixed while the team relations are not.
  */
+const SOURCE_REF_RESOLVERS = {
+  api_key: toApiKeySourceRef,
+  organization: toOrganizationSourceRef,
+  team: toTeamSourceRef,
+  workspace: toWorkspaceSourceRef,
+} as const satisfies Readonly<Record<string, TSourceRefResolver>>;
+
+/**
+ * Resource types Formbricks projects today and may therefore reconcile.
+ *
+ * Sorted so the sweep's order is deterministic and two runs over unchanged state produce identical
+ * output.
+ */
+const MANAGED_RESOURCE_TYPES: ReadonlyArray<string> = Object.keys(SOURCE_REF_RESOLVERS).sort();
+
+export const isManagedResourceType = (resourceType: string): boolean =>
+  MANAGED_RESOURCE_TYPES.includes(resourceType);
+
+export const getManagedResourceTypes = (): ReadonlyArray<string> => MANAGED_RESOURCE_TYPES;
+
+/** Name the source record an observed relationship implies, or `null` if it names none. */
 export const toSourceRef = (relationship: TAuthzedRelationship): TAuthzedSourceRef | null => {
-  const { relation, resource, subject } = relationship;
+  const resolve: TSourceRefResolver | undefined =
+    SOURCE_REF_RESOLVERS[relationship.resource.objectType as keyof typeof SOURCE_REF_RESOLVERS];
 
-  switch (resource.objectType) {
-    case "organization":
-      if (subject.objectType === "user" && ORGANIZATION_ROLE_RELATIONS.has(relation)) {
-        return { kind: "membership", organizationId: resource.objectId, userId: subject.objectId };
-      }
-      if (subject.objectType === "api_key" && ORGANIZATION_API_KEY_RELATIONS.has(relation)) {
-        // Access flags live on the key's own record, so the key is the thing to look up.
-        return { apiKeyId: subject.objectId, kind: "apiKey" };
-      }
-      return null;
-
-    case "team":
-      if (subject.objectType === "organization" && relation === PARENT_RELATION) {
-        return { kind: "team", teamId: resource.objectId };
-      }
-      if (subject.objectType === "user" && TEAM_ROLE_RELATIONS.has(relation)) {
-        return { kind: "teamMembership", teamId: resource.objectId, userId: subject.objectId };
-      }
-      return null;
-
-    case "workspace":
-      if (subject.objectType === "organization" && relation === PARENT_RELATION) {
-        return { kind: "workspace", workspaceId: resource.objectId };
-      }
-      if (subject.objectType === "team" && WORKSPACE_TEAM_GRANT_RELATIONS.has(relation)) {
-        return { kind: "workspaceTeamGrant", teamId: subject.objectId, workspaceId: resource.objectId };
-      }
-      if (subject.objectType === "api_key" && WORKSPACE_API_KEY_GRANT_RELATIONS.has(relation)) {
-        return {
-          apiKeyId: subject.objectId,
-          kind: "apiKeyWorkspaceGrant",
-          workspaceId: resource.objectId,
-        };
-      }
-      return null;
-
-    case "api_key":
-      if (subject.objectType === "organization" && relation === PARENT_RELATION) {
-        return { apiKeyId: resource.objectId, kind: "apiKey" };
-      }
-      return null;
-
-    default:
-      return null;
-  }
+  return resolve?.(relationship) ?? null;
 };
 
 /**

--- a/apps/web/lib/authzed/backfill-diff.ts
+++ b/apps/web/lib/authzed/backfill-diff.ts
@@ -160,9 +160,6 @@ const MANAGED_RESOURCE_TYPES: ReadonlyArray<string> = Object.keys(SOURCE_REF_RES
   left.localeCompare(right)
 );
 
-export const isManagedResourceType = (resourceType: string): boolean =>
-  MANAGED_RESOURCE_TYPES.includes(resourceType);
-
 export const getManagedResourceTypes = (): ReadonlyArray<string> => MANAGED_RESOURCE_TYPES;
 
 /** Name the source record an observed relationship implies, or `null` if it names none. */

--- a/apps/web/lib/authzed/backfill-diff.ts
+++ b/apps/web/lib/authzed/backfill-diff.ts
@@ -1,0 +1,194 @@
+import "server-only";
+import type { TAuthzedRelationship } from "./client";
+import {
+  ORGANIZATION_ACCESS_RELATIONS,
+  ORGANIZATION_RELATIONS,
+  TEAM_RELATIONS,
+  WORKSPACE_API_KEY_RELATIONS,
+  WORKSPACE_TEAM_RELATIONS,
+} from "./relationship-map";
+
+/**
+ * Turning observed SpiceDB relationships into reconciler targets.
+ *
+ * Pure and synchronous on purpose. This is where the decision that leads to a deletion is computed,
+ * so it is kept free of PostgreSQL, the AuthZed facade, and I/O of any kind: it can be exhaustively
+ * tested with object literals, and it cannot itself mutate anything.
+ *
+ * Note what this module does *not* do. It never decides that a relationship is stale. It only names
+ * the source record a relationship implies, so a reconciler can look that record up in PostgreSQL and
+ * decide. That indirection is what makes repair safe — a record recreated between the read and the
+ * reconcile is written, not deleted.
+ */
+
+/** Resource types Formbricks projects today and may therefore reconcile. */
+const MANAGED_RESOURCE_TYPES = ["api_key", "organization", "team", "workspace"] as const;
+
+/**
+ * Resource types the schema defines but no projector writes yet.
+ *
+ * Deliberately unprojected during the current-model migration: resource-level access is resolved
+ * through PostgreSQL parent lookups instead. Reconciliation must classify these as ignored rather
+ * than orphaned — pruning them would delete relationships a future projector is expected to own.
+ */
+const UNPROJECTED_RESOURCE_TYPES = ["dashboard", "response", "survey"] as const;
+
+export type TAuthzedRelationshipRef = Readonly<{
+  objectId: string;
+  objectType: string;
+  relation: string;
+}>;
+
+/**
+ * A source record implied by an observed relationship.
+ *
+ * Named after the PostgreSQL record rather than the relationship, because that is what an operator
+ * needs in order to act: "this membership has no row" is diagnosable, "this tuple looks wrong" is not.
+ */
+export type TAuthzedSourceRef =
+  | Readonly<{ apiKeyId: string; kind: "apiKey" }>
+  | Readonly<{ apiKeyId: string; kind: "apiKeyWorkspaceGrant"; workspaceId: string }>
+  | Readonly<{ kind: "membership"; organizationId: string; userId: string }>
+  | Readonly<{ kind: "team"; teamId: string }>
+  | Readonly<{ kind: "teamMembership"; teamId: string; userId: string }>
+  | Readonly<{ kind: "workspace"; workspaceId: string }>
+  | Readonly<{ kind: "workspaceTeamGrant"; teamId: string; workspaceId: string }>;
+
+export type TAuthzedObservationSummary = Readonly<{
+  /** Relationships on deliberately-unprojected resource types. Counted, never acted on. */
+  ignored: number;
+  /** Deduplicated, deterministically ordered source records the observation implies. */
+  sourceRefs: ReadonlyArray<TAuthzedSourceRef>;
+  /**
+   * Relationships this vocabulary does not recognize.
+   *
+   * Something other than Formbricks writing to this SpiceDB, or a schema change that landed without a
+   * matching projector. Reported so it is visible; never reconciled and never pruned, because the
+   * tooling cannot know what source record — if any — should own them.
+   */
+  unmanaged: ReadonlyArray<TAuthzedRelationshipRef>;
+}>;
+
+const ORGANIZATION_ROLE_RELATIONS = new Set<string>(Object.values(ORGANIZATION_RELATIONS));
+const ORGANIZATION_API_KEY_RELATIONS = new Set<string>(Object.values(ORGANIZATION_ACCESS_RELATIONS));
+const TEAM_ROLE_RELATIONS = new Set<string>(Object.values(TEAM_RELATIONS));
+const WORKSPACE_TEAM_GRANT_RELATIONS = new Set<string>(Object.values(WORKSPACE_TEAM_RELATIONS));
+const WORKSPACE_API_KEY_GRANT_RELATIONS = new Set<string>(Object.values(WORKSPACE_API_KEY_RELATIONS));
+
+/** The relation naming a resource's owning organization, shared by `api_key`, `team`, and `workspace`. */
+const PARENT_RELATION = "organization";
+
+export const isManagedResourceType = (resourceType: string): boolean =>
+  (MANAGED_RESOURCE_TYPES as readonly string[]).includes(resourceType);
+
+export const isUnprojectedResourceType = (resourceType: string): boolean =>
+  (UNPROJECTED_RESOURCE_TYPES as readonly string[]).includes(resourceType);
+
+export const getManagedResourceTypes = (): ReadonlyArray<string> => MANAGED_RESOURCE_TYPES;
+
+/**
+ * Name the source record an observed relationship implies, or `null` if the vocabulary does not
+ * recognize it.
+ *
+ * Both the relation name and the subject type matter. `workspace#reader@api_key` and
+ * `workspace#reader_team@team#member` are distinct grants, and the API-key relations are deliberately
+ * unsuffixed while the team relations are not.
+ */
+export const toSourceRef = (relationship: TAuthzedRelationship): TAuthzedSourceRef | null => {
+  const { relation, resource, subject } = relationship;
+
+  switch (resource.objectType) {
+    case "organization":
+      if (subject.objectType === "user" && ORGANIZATION_ROLE_RELATIONS.has(relation)) {
+        return { kind: "membership", organizationId: resource.objectId, userId: subject.objectId };
+      }
+      if (subject.objectType === "api_key" && ORGANIZATION_API_KEY_RELATIONS.has(relation)) {
+        // Access flags live on the key's own record, so the key is the thing to look up.
+        return { apiKeyId: subject.objectId, kind: "apiKey" };
+      }
+      return null;
+
+    case "team":
+      if (subject.objectType === "organization" && relation === PARENT_RELATION) {
+        return { kind: "team", teamId: resource.objectId };
+      }
+      if (subject.objectType === "user" && TEAM_ROLE_RELATIONS.has(relation)) {
+        return { kind: "teamMembership", teamId: resource.objectId, userId: subject.objectId };
+      }
+      return null;
+
+    case "workspace":
+      if (subject.objectType === "organization" && relation === PARENT_RELATION) {
+        return { kind: "workspace", workspaceId: resource.objectId };
+      }
+      if (subject.objectType === "team" && WORKSPACE_TEAM_GRANT_RELATIONS.has(relation)) {
+        return { kind: "workspaceTeamGrant", teamId: subject.objectId, workspaceId: resource.objectId };
+      }
+      if (subject.objectType === "api_key" && WORKSPACE_API_KEY_GRANT_RELATIONS.has(relation)) {
+        return {
+          apiKeyId: subject.objectId,
+          kind: "apiKeyWorkspaceGrant",
+          workspaceId: resource.objectId,
+        };
+      }
+      return null;
+
+    case "api_key":
+      if (subject.objectType === "organization" && relation === PARENT_RELATION) {
+        return { apiKeyId: resource.objectId, kind: "apiKey" };
+      }
+      return null;
+
+    default:
+      return null;
+  }
+};
+
+/** Stable identity for deduplication and ordering. Field order is fixed by the union's key order. */
+const sourceRefKey = (ref: TAuthzedSourceRef): string => JSON.stringify(ref);
+
+const toRelationshipRef = (relationship: TAuthzedRelationship): TAuthzedRelationshipRef => ({
+  objectId: relationship.resource.objectId,
+  objectType: relationship.resource.objectType,
+  relation: relationship.relation,
+});
+
+/**
+ * Classify an observation and collect the source records it implies.
+ *
+ * Deduplicated and deterministically ordered so a run is reproducible and two runs over unchanged
+ * state produce identical output.
+ */
+export const summarizeObservation = (
+  relationships: ReadonlyArray<TAuthzedRelationship>
+): TAuthzedObservationSummary => {
+  const sourceRefs = new Map<string, TAuthzedSourceRef>();
+  const unmanaged = new Map<string, TAuthzedRelationshipRef>();
+  let ignored = 0;
+
+  for (const relationship of relationships) {
+    if (isUnprojectedResourceType(relationship.resource.objectType)) {
+      ignored++;
+      continue;
+    }
+
+    const sourceRef = toSourceRef(relationship);
+    if (sourceRef) {
+      sourceRefs.set(sourceRefKey(sourceRef), sourceRef);
+      continue;
+    }
+
+    const ref = toRelationshipRef(relationship);
+    unmanaged.set(JSON.stringify(ref), ref);
+  }
+
+  return {
+    ignored,
+    sourceRefs: [...sourceRefs.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([, ref]) => ref),
+    unmanaged: [...unmanaged.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([, ref]) => ref),
+  };
+};

--- a/apps/web/lib/authzed/backfill-diff.ts
+++ b/apps/web/lib/authzed/backfill-diff.ts
@@ -200,6 +200,19 @@ export type TAuthzedParentEdge = Readonly<{
   childId: string;
   childType: "api_key" | "team" | "workspace";
   organizationId: string;
+  /**
+   * The relation that asserted the ownership.
+   *
+   * Two relationship shapes can state it, and they are removed by *different* `zed` commands because the
+   * organization sits on opposite sides:
+   *
+   * - `organization` — the child's own parent edge, `<childType>:<childId> # organization @ organization:O`
+   * - anything else — an organization-level access grant, `organization:O # <relation> @ <childType>:<childId>`
+   *
+   * Reported so an operator acting on a finding deletes the relationship that actually exists. Without it
+   * both cases render identically and only one of them matches the documented remediation.
+   */
+  relation: string;
 }>;
 
 /** Stable identity for deduplication and ordering. Field order is fixed by the union's key order. */
@@ -231,7 +244,12 @@ const toParentEdge = (relationship: TAuthzedRelationship): TAuthzedParentEdge | 
     subject.objectType === "api_key" &&
     ORGANIZATION_API_KEY_RELATIONS.has(relation)
   ) {
-    return { childId: subject.objectId, childType: "api_key", organizationId: resource.objectId };
+    return {
+      childId: subject.objectId,
+      childType: "api_key",
+      organizationId: resource.objectId,
+      relation,
+    };
   }
 
   if (relation !== PARENT_RELATION || subject.objectType !== "organization") {
@@ -245,7 +263,12 @@ const toParentEdge = (relationship: TAuthzedRelationship): TAuthzedParentEdge | 
     return null;
   }
 
-  return { childId: resource.objectId, childType: resource.objectType, organizationId: subject.objectId };
+  return {
+    childId: resource.objectId,
+    childType: resource.objectType,
+    organizationId: subject.objectId,
+    relation,
+  };
 };
 
 /**

--- a/apps/web/lib/authzed/backfill-diff.ts
+++ b/apps/web/lib/authzed/backfill-diff.ts
@@ -152,10 +152,13 @@ const SOURCE_REF_RESOLVERS = {
 /**
  * Resource types Formbricks projects today and may therefore reconcile.
  *
- * Sorted so the sweep's order is deterministic and two runs over unchanged state produce identical
- * output.
+ * Sorted explicitly, with a comparator, for two reasons: the sweep's order must not depend on how the
+ * resolver literal above happens to be written, and it must be identical between runs so two passes
+ * over unchanged state produce identical output.
  */
-const MANAGED_RESOURCE_TYPES: ReadonlyArray<string> = Object.keys(SOURCE_REF_RESOLVERS).sort();
+const MANAGED_RESOURCE_TYPES: ReadonlyArray<string> = Object.keys(SOURCE_REF_RESOLVERS).sort((left, right) =>
+  left.localeCompare(right)
+);
 
 export const isManagedResourceType = (resourceType: string): boolean =>
   MANAGED_RESOURCE_TYPES.includes(resourceType);

--- a/apps/web/lib/authzed/backfill-diff.ts
+++ b/apps/web/lib/authzed/backfill-diff.ts
@@ -216,6 +216,24 @@ export const sourceRefKey = (ref: TAuthzedSourceRef): string => JSON.stringify(r
 const toParentEdge = (relationship: TAuthzedRelationship): TAuthzedParentEdge | null => {
   const { relation, resource, subject } = relationship;
 
+  // Two relationship shapes state the same fact — "this API key belongs to that organization" — and both
+  // have to be verified against PostgreSQL:
+  //
+  //   api_key:K      # organization    @ organization:A    the key's own parent edge
+  //   organization:A # api_key_writer  @ api_key:K         an organization-level access grant
+  //
+  // The second reduces to `{kind: "apiKey"}` as a source ref, which only asks "does K exist?" — true
+  // whenever K exists under *any* organization. So a grant naming a foreign key read as sourced, survived
+  // apply and prune, and went on granting `manage_access` over another tenant's organization. Emitting it
+  // as the same edge shape routes it through the check that already validates `api_key` parents.
+  if (
+    resource.objectType === "organization" &&
+    subject.objectType === "api_key" &&
+    ORGANIZATION_API_KEY_RELATIONS.has(relation)
+  ) {
+    return { childId: subject.objectId, childType: "api_key", organizationId: resource.objectId };
+  }
+
   if (relation !== PARENT_RELATION || subject.objectType !== "organization") {
     return null;
   }

--- a/apps/web/lib/authzed/backfill-source.test.ts
+++ b/apps/web/lib/authzed/backfill-source.test.ts
@@ -167,15 +167,40 @@ describe("readOrganizationSource", () => {
       organizationId: ORGANIZATION_ID,
     } as never);
     vi.mocked(prisma.workspaceTeam.findMany).mockResolvedValue([
-      { teamId: "team-1", workspaceId: "ws-1" },
+      { team: { organizationId: ORGANIZATION_ID }, teamId: "team-1", workspaceId: "ws-1" },
     ] as never);
 
     await expect(readWorkspaceSource("ws-1")).resolves.toEqual({
       apiKeyWorkspaceGrants: [],
+      invalidApiKeyWorkspaceGrants: [],
+      invalidWorkspaceTeamGrants: [],
       organizationId: ORGANIZATION_ID,
       workspaceExists: true,
       workspaceTeamGrants: [{ teamId: "team-1", workspaceId: "ws-1" }],
     });
+  });
+
+  test("partitions a workspace grant whose principal belongs to another organization", async () => {
+    // The join tables have independent foreign keys and no same-organization constraint, so a
+    // cross-tenant row is representable — and `--workspace-id` must refuse to project it, exactly as
+    // `--organization-id` does.
+    vi.mocked(prisma.workspace.findUnique).mockResolvedValue({
+      organizationId: ORGANIZATION_ID,
+    } as never);
+    vi.mocked(prisma.workspaceTeam.findMany).mockResolvedValue([
+      { team: { organizationId: ORGANIZATION_ID }, teamId: "own-team", workspaceId: "ws-1" },
+      { team: { organizationId: "other-org" }, teamId: "foreign-team", workspaceId: "ws-1" },
+    ] as never);
+    vi.mocked(prisma.apiKeyWorkspace.findMany).mockResolvedValue([
+      { apiKey: { organizationId: "other-org" }, apiKeyId: "foreign-key", workspaceId: "ws-1" },
+    ] as never);
+
+    const source = await readWorkspaceSource("ws-1");
+
+    expect(source.workspaceTeamGrants).toEqual([{ teamId: "own-team", workspaceId: "ws-1" }]);
+    expect(source.invalidWorkspaceTeamGrants).toEqual([{ teamId: "foreign-team", workspaceId: "ws-1" }]);
+    expect(source.apiKeyWorkspaceGrants).toEqual([]);
+    expect(source.invalidApiKeyWorkspaceGrants).toEqual([{ apiKeyId: "foreign-key", workspaceId: "ws-1" }]);
   });
 
   test("reports a workspace with no row as absent rather than failing", async () => {

--- a/apps/web/lib/authzed/backfill-source.test.ts
+++ b/apps/web/lib/authzed/backfill-source.test.ts
@@ -7,6 +7,7 @@ import {
   organizationExists,
   readOrganizationIdPage,
   readOrganizationSource,
+  readWorkspaceSource,
 } from "./backfill-source";
 import { AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE, AUTHZED_BACKFILL_TARGET_CHUNK_SIZE } from "./constants";
 
@@ -18,7 +19,7 @@ vi.mock("@formbricks/database", () => ({
     organization: { count: vi.fn(), findMany: vi.fn() },
     team: { findMany: vi.fn() },
     teamUser: { findMany: vi.fn() },
-    workspace: { findMany: vi.fn() },
+    workspace: { findMany: vi.fn(), findUnique: vi.fn() },
     workspaceTeam: { findMany: vi.fn() },
   },
 }));
@@ -29,6 +30,7 @@ const setEmptySource = (): void => {
   vi.mocked(prisma.membership.findMany).mockResolvedValue([] as never);
   vi.mocked(prisma.team.findMany).mockResolvedValue([] as never);
   vi.mocked(prisma.workspace.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.workspace.findUnique).mockResolvedValue(null as never);
   vi.mocked(prisma.apiKey.findMany).mockResolvedValue([] as never);
   vi.mocked(prisma.teamUser.findMany).mockResolvedValue([] as never);
   vi.mocked(prisma.workspaceTeam.findMany).mockResolvedValue([] as never);
@@ -115,12 +117,13 @@ describe("readOrganizationSource", () => {
       { team: { organizationId: ORGANIZATION_ID }, teamId: "team-1", workspaceId: "ws-1" },
     ] as never);
     vi.mocked(prisma.apiKeyWorkspace.findMany).mockResolvedValue([
-      { apiKeyId: "key-1", workspaceId: "ws-1" },
+      { apiKeyId: "key-1", workspace: { organizationId: ORGANIZATION_ID }, workspaceId: "ws-1" },
     ] as never);
 
     await expect(readOrganizationSource(ORGANIZATION_ID)).resolves.toEqual({
       apiKeyIds: ["key-1"],
       apiKeyWorkspaceGrants: [{ apiKeyId: "key-1", workspaceId: "ws-1" }],
+      invalidApiKeyWorkspaceGrants: [],
       invalidWorkspaceTeamGrants: [],
       memberships: [{ organizationId: ORGANIZATION_ID, userId: "user-1" }],
       teamIds: ["team-1"],
@@ -144,12 +147,53 @@ describe("readOrganizationSource", () => {
     expect(source.invalidWorkspaceTeamGrants).toEqual([{ teamId: "foreign-team", workspaceId: "ws-1" }]);
   });
 
+  test("separates a cross-organization API-key workspace grant instead of projecting it", async () => {
+    // Keyed off the key's organization, so a grant can name a workspace another organization owns. That
+    // workspace is outside this unit's observation, so projecting the grant would leave the unit
+    // reporting a missing record forever — it can never be seen and so never converges.
+    vi.mocked(prisma.apiKeyWorkspace.findMany).mockResolvedValue([
+      { apiKeyId: "key-1", workspace: { organizationId: ORGANIZATION_ID }, workspaceId: "own-ws" },
+      { apiKeyId: "key-1", workspace: { organizationId: "other-org" }, workspaceId: "foreign-ws" },
+    ] as never);
+
+    const source = await readOrganizationSource(ORGANIZATION_ID);
+
+    expect(source.apiKeyWorkspaceGrants).toEqual([{ apiKeyId: "key-1", workspaceId: "own-ws" }]);
+    expect(source.invalidApiKeyWorkspaceGrants).toEqual([{ apiKeyId: "key-1", workspaceId: "foreign-ws" }]);
+  });
+
+  test("reads a workspace's owning organization so a failure can be attributed to a tenant", async () => {
+    vi.mocked(prisma.workspace.findUnique).mockResolvedValue({
+      organizationId: ORGANIZATION_ID,
+    } as never);
+    vi.mocked(prisma.workspaceTeam.findMany).mockResolvedValue([
+      { teamId: "team-1", workspaceId: "ws-1" },
+    ] as never);
+
+    await expect(readWorkspaceSource("ws-1")).resolves.toEqual({
+      apiKeyWorkspaceGrants: [],
+      organizationId: ORGANIZATION_ID,
+      workspaceExists: true,
+      workspaceTeamGrants: [{ teamId: "team-1", workspaceId: "ws-1" }],
+    });
+  });
+
+  test("reports a workspace with no row as absent rather than failing", async () => {
+    // The case most worth repairing: the row is gone and its relationships are what should be removed.
+    // Its grants are still read, because those rows can outlive the workspace.
+    const source = await readWorkspaceSource("ghost-ws");
+
+    expect(source.workspaceExists).toBe(false);
+    expect(source.organizationId).toBeNull();
+  });
+
   test("returns empty target lists for an organization with no records", async () => {
     const source = await readOrganizationSource(ORGANIZATION_ID);
 
     expect(source).toEqual({
       apiKeyIds: [],
       apiKeyWorkspaceGrants: [],
+      invalidApiKeyWorkspaceGrants: [],
       invalidWorkspaceTeamGrants: [],
       memberships: [],
       teamIds: [],

--- a/apps/web/lib/authzed/backfill-source.test.ts
+++ b/apps/web/lib/authzed/backfill-source.test.ts
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import type { TAuthzedSourceRef } from "./backfill-diff";
+import {
+  findMissingSourceRefs,
+  organizationExists,
+  readOrganizationIdPage,
+  readOrganizationSource,
+} from "./backfill-source";
+import { AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE } from "./constants";
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    apiKey: { findMany: vi.fn() },
+    apiKeyWorkspace: { findMany: vi.fn() },
+    membership: { findMany: vi.fn() },
+    organization: { count: vi.fn(), findMany: vi.fn() },
+    team: { findMany: vi.fn() },
+    teamUser: { findMany: vi.fn() },
+    workspace: { findMany: vi.fn() },
+    workspaceTeam: { findMany: vi.fn() },
+  },
+}));
+
+const ORGANIZATION_ID = "org-1";
+
+const setEmptySource = (): void => {
+  vi.mocked(prisma.membership.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.team.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.workspace.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.apiKey.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.teamUser.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.workspaceTeam.findMany).mockResolvedValue([] as never);
+  vi.mocked(prisma.apiKeyWorkspace.findMany).mockResolvedValue([] as never);
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setEmptySource();
+});
+
+describe("readOrganizationIdPage", () => {
+  test("reads the first page without a cursor, ordered so the sweep is stable", async () => {
+    vi.mocked(prisma.organization.findMany).mockResolvedValue([{ id: "org-1" }, { id: "org-2" }] as never);
+
+    await expect(readOrganizationIdPage()).resolves.toEqual(["org-1", "org-2"]);
+    expect(prisma.organization.findMany).toHaveBeenCalledWith({
+      where: undefined,
+      select: { id: true },
+      orderBy: { id: "asc" },
+      take: AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE,
+    });
+  });
+
+  test("resumes strictly after the supplied cursor so no organization is repeated or skipped", async () => {
+    vi.mocked(prisma.organization.findMany).mockResolvedValue([{ id: "org-3" }] as never);
+
+    await readOrganizationIdPage({ afterOrganizationId: "org-2", limit: 10 });
+
+    expect(prisma.organization.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 10, where: { id: { gt: "org-2" } } })
+    );
+  });
+
+  test("propagates a read failure rather than reporting an empty page", async () => {
+    vi.mocked(prisma.organization.findMany).mockRejectedValue(new Error("connection reset"));
+
+    await expect(readOrganizationIdPage()).rejects.toThrow("connection reset");
+  });
+});
+
+describe("organizationExists", () => {
+  test.each([
+    [1, true],
+    [0, false],
+  ])("reports %i matching rows as %s", async (count, expected) => {
+    vi.mocked(prisma.organization.count).mockResolvedValue(count as never);
+
+    await expect(organizationExists(ORGANIZATION_ID)).resolves.toBe(expected);
+  });
+});
+
+describe("readOrganizationSource", () => {
+  test("scopes every query to the organization and reads only authorization-bearing columns", async () => {
+    await readOrganizationSource(ORGANIZATION_ID);
+
+    expect(prisma.membership.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ select: { userId: true }, where: { organizationId: ORGANIZATION_ID } })
+    );
+    expect(prisma.teamUser.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { team: { organizationId: ORGANIZATION_ID } } })
+    );
+    expect(prisma.apiKeyWorkspace.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { apiKey: { organizationId: ORGANIZATION_ID } } })
+    );
+
+    // The README commits to never reading key material or usage metadata.
+    const allQueries = JSON.stringify([
+      vi.mocked(prisma.apiKey.findMany).mock.calls,
+      vi.mocked(prisma.apiKeyWorkspace.findMany).mock.calls,
+    ]);
+    for (const forbidden of ["hashedKey", "lookupHash", "lastUsedAt", "createdBy"]) {
+      expect(allQueries).not.toContain(forbidden);
+    }
+  });
+
+  test("collects every target kind owned by the organization", async () => {
+    vi.mocked(prisma.membership.findMany).mockResolvedValue([{ userId: "user-1" }] as never);
+    vi.mocked(prisma.team.findMany).mockResolvedValue([{ id: "team-1" }] as never);
+    vi.mocked(prisma.workspace.findMany).mockResolvedValue([{ id: "ws-1" }] as never);
+    vi.mocked(prisma.apiKey.findMany).mockResolvedValue([{ id: "key-1" }] as never);
+    vi.mocked(prisma.teamUser.findMany).mockResolvedValue([{ teamId: "team-1", userId: "user-1" }] as never);
+    vi.mocked(prisma.workspaceTeam.findMany).mockResolvedValue([
+      { team: { organizationId: ORGANIZATION_ID }, teamId: "team-1", workspaceId: "ws-1" },
+    ] as never);
+    vi.mocked(prisma.apiKeyWorkspace.findMany).mockResolvedValue([
+      { apiKeyId: "key-1", workspaceId: "ws-1" },
+    ] as never);
+
+    await expect(readOrganizationSource(ORGANIZATION_ID)).resolves.toEqual({
+      apiKeyIds: ["key-1"],
+      apiKeyWorkspaceGrants: [{ apiKeyId: "key-1", workspaceId: "ws-1" }],
+      invalidWorkspaceTeamGrants: [],
+      memberships: [{ organizationId: ORGANIZATION_ID, userId: "user-1" }],
+      teamIds: ["team-1"],
+      teamMemberships: [{ teamId: "team-1", userId: "user-1" }],
+      workspaceIds: ["ws-1"],
+      workspaceTeamGrants: [{ teamId: "team-1", workspaceId: "ws-1" }],
+    });
+  });
+
+  test("separates a cross-organization workspace-team grant instead of projecting it", async () => {
+    vi.mocked(prisma.workspaceTeam.findMany).mockResolvedValue([
+      { team: { organizationId: ORGANIZATION_ID }, teamId: "own-team", workspaceId: "ws-1" },
+      { team: { organizationId: "other-org" }, teamId: "foreign-team", workspaceId: "ws-1" },
+    ] as never);
+
+    const source = await readOrganizationSource(ORGANIZATION_ID);
+
+    // The foreign grant breaks the closed-unit invariant, so it is reported and then left alone —
+    // neither projected nor pruned.
+    expect(source.workspaceTeamGrants).toEqual([{ teamId: "own-team", workspaceId: "ws-1" }]);
+    expect(source.invalidWorkspaceTeamGrants).toEqual([{ teamId: "foreign-team", workspaceId: "ws-1" }]);
+  });
+
+  test("returns empty target lists for an organization with no records", async () => {
+    const source = await readOrganizationSource(ORGANIZATION_ID);
+
+    expect(source).toEqual({
+      apiKeyIds: [],
+      apiKeyWorkspaceGrants: [],
+      invalidWorkspaceTeamGrants: [],
+      memberships: [],
+      teamIds: [],
+      teamMemberships: [],
+      workspaceIds: [],
+      workspaceTeamGrants: [],
+    });
+  });
+
+  test("propagates a failure from any single query", async () => {
+    vi.mocked(prisma.teamUser.findMany).mockRejectedValue(new Error("statement timeout"));
+
+    await expect(readOrganizationSource(ORGANIZATION_ID)).rejects.toThrow("statement timeout");
+  });
+});
+
+describe("findMissingSourceRefs", () => {
+  const allKinds: ReadonlyArray<TAuthzedSourceRef> = [
+    { apiKeyId: "key-1", kind: "apiKey" },
+    { apiKeyId: "key-1", kind: "apiKeyWorkspaceGrant", workspaceId: "ws-1" },
+    { kind: "membership", organizationId: ORGANIZATION_ID, userId: "user-1" },
+    { kind: "team", teamId: "team-1" },
+    { kind: "teamMembership", teamId: "team-1", userId: "user-1" },
+    { kind: "workspace", workspaceId: "ws-1" },
+    { kind: "workspaceTeamGrant", teamId: "team-1", workspaceId: "ws-1" },
+  ];
+
+  test("reports nothing missing when every record is present", async () => {
+    vi.mocked(prisma.apiKey.findMany).mockResolvedValue([{ id: "key-1" }] as never);
+    vi.mocked(prisma.apiKeyWorkspace.findMany).mockResolvedValue([
+      { apiKeyId: "key-1", workspaceId: "ws-1" },
+    ] as never);
+    vi.mocked(prisma.membership.findMany).mockResolvedValue([
+      { organizationId: ORGANIZATION_ID, userId: "user-1" },
+    ] as never);
+    vi.mocked(prisma.team.findMany).mockResolvedValue([{ id: "team-1" }] as never);
+    vi.mocked(prisma.teamUser.findMany).mockResolvedValue([{ teamId: "team-1", userId: "user-1" }] as never);
+    vi.mocked(prisma.workspace.findMany).mockResolvedValue([{ id: "ws-1" }] as never);
+    vi.mocked(prisma.workspaceTeam.findMany).mockResolvedValue([
+      { teamId: "team-1", workspaceId: "ws-1" },
+    ] as never);
+
+    await expect(findMissingSourceRefs(allKinds)).resolves.toEqual([]);
+  });
+
+  test("reports every kind of record that PostgreSQL does not hold", async () => {
+    // Every query returns nothing, so all seven kinds are missing.
+    await expect(findMissingSourceRefs(allKinds)).resolves.toEqual(allKinds);
+  });
+
+  test("distinguishes a present record from an absent one of the same kind", async () => {
+    vi.mocked(prisma.team.findMany).mockResolvedValue([{ id: "present-team" }] as never);
+
+    await expect(
+      findMissingSourceRefs([
+        { kind: "team", teamId: "present-team" },
+        { kind: "team", teamId: "absent-team" },
+      ])
+    ).resolves.toEqual([{ kind: "team", teamId: "absent-team" }]);
+  });
+
+  test("does not confuse composite keys across pair boundaries", async () => {
+    // A naive concatenated key would match ("ab", "c") against ("a", "bc").
+    vi.mocked(prisma.teamUser.findMany).mockResolvedValue([{ teamId: "ab", userId: "c" }] as never);
+
+    await expect(
+      findMissingSourceRefs([
+        { kind: "teamMembership", teamId: "ab", userId: "c" },
+        { kind: "teamMembership", teamId: "a", userId: "bc" },
+      ])
+    ).resolves.toEqual([{ kind: "teamMembership", teamId: "a", userId: "bc" }]);
+  });
+
+  test("skips the query for a kind that was not asked about", async () => {
+    await findMissingSourceRefs([{ kind: "team", teamId: "team-1" }]);
+
+    expect(prisma.team.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.membership.findMany).not.toHaveBeenCalled();
+    expect(prisma.apiKey.findMany).not.toHaveBeenCalled();
+  });
+
+  test("issues one batched query per kind rather than one per record", async () => {
+    await findMissingSourceRefs([
+      { kind: "team", teamId: "team-1" },
+      { kind: "team", teamId: "team-2" },
+      { kind: "team", teamId: "team-3" },
+    ]);
+
+    expect(prisma.team.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.team.findMany).toHaveBeenCalledWith({
+      where: { id: { in: ["team-1", "team-2", "team-3"] } },
+      select: { id: true },
+    });
+  });
+
+  test("fails closed: a query failure never presents records as absent", async () => {
+    // This is the single most dangerous mistake available to this tooling. Treating a failed lookup as
+    // "no source row" would classify live access as orphaned and, under pruning, revoke it at scale.
+    vi.mocked(prisma.team.findMany).mockRejectedValue(new Error("connection pool exhausted"));
+
+    await expect(findMissingSourceRefs([{ kind: "team", teamId: "team-1" }])).rejects.toThrow(
+      "connection pool exhausted"
+    );
+  });
+
+  test("returns nothing for an empty request without querying", async () => {
+    await expect(findMissingSourceRefs([])).resolves.toEqual([]);
+
+    expect(prisma.team.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/authzed/backfill-source.test.ts
+++ b/apps/web/lib/authzed/backfill-source.test.ts
@@ -2,12 +2,13 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import type { TAuthzedSourceRef } from "./backfill-diff";
 import {
+  findMismatchedParentEdges,
   findMissingSourceRefs,
   organizationExists,
   readOrganizationIdPage,
   readOrganizationSource,
 } from "./backfill-source";
-import { AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE } from "./constants";
+import { AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE, AUTHZED_BACKFILL_TARGET_CHUNK_SIZE } from "./constants";
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
@@ -165,6 +166,57 @@ describe("readOrganizationSource", () => {
   });
 });
 
+describe("findMismatchedParentEdges", () => {
+  test("reports a resource attached to an organization that does not own it", async () => {
+    // The cross-tenant escalation an existence check cannot see: the workspace exists, so it is not an
+    // orphan, but the edge names an organization whose owners and managers thereby gain access to it.
+    vi.mocked(prisma.workspace.findMany).mockResolvedValue([
+      { id: "ws-1", organizationId: ORGANIZATION_ID },
+    ] as never);
+
+    await expect(
+      findMismatchedParentEdges([{ childId: "ws-1", childType: "workspace", organizationId: "other-org" }])
+    ).resolves.toEqual([{ childId: "ws-1", childType: "workspace", organizationId: "other-org" }]);
+  });
+
+  test("accepts an edge naming the true owner", async () => {
+    vi.mocked(prisma.team.findMany).mockResolvedValue([
+      { id: "team-1", organizationId: ORGANIZATION_ID },
+    ] as never);
+
+    await expect(
+      findMismatchedParentEdges([{ childId: "team-1", childType: "team", organizationId: ORGANIZATION_ID }])
+    ).resolves.toEqual([]);
+  });
+
+  test("leaves an edge whose resource has no row to the orphan path", async () => {
+    // That is a different finding with a working repair, so reporting it here too would double-count it.
+    await expect(
+      findMismatchedParentEdges([{ childId: "gone", childType: "api_key", organizationId: ORGANIZATION_ID }])
+    ).resolves.toEqual([]);
+  });
+
+  test("checks all three child types in one batch per type", async () => {
+    await findMismatchedParentEdges([
+      { childId: "team-1", childType: "team", organizationId: ORGANIZATION_ID },
+      { childId: "ws-1", childType: "workspace", organizationId: ORGANIZATION_ID },
+      { childId: "key-1", childType: "api_key", organizationId: ORGANIZATION_ID },
+    ]);
+
+    expect(prisma.team.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.workspace.findMany).toHaveBeenCalledTimes(1);
+    expect(prisma.apiKey.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  test("fails closed on a lookup error rather than reporting no mismatch", async () => {
+    vi.mocked(prisma.workspace.findMany).mockRejectedValue(new Error("connection reset"));
+
+    await expect(
+      findMismatchedParentEdges([{ childId: "ws-1", childType: "workspace", organizationId: "other-org" }])
+    ).rejects.toThrow("connection reset");
+  });
+});
+
 describe("findMissingSourceRefs", () => {
   const allKinds: ReadonlyArray<TAuthzedSourceRef> = [
     { apiKeyId: "key-1", kind: "apiKey" },
@@ -228,6 +280,20 @@ describe("findMissingSourceRefs", () => {
     expect(prisma.team.findMany).toHaveBeenCalledTimes(1);
     expect(prisma.membership.findMany).not.toHaveBeenCalled();
     expect(prisma.apiKey.findMany).not.toHaveBeenCalled();
+  });
+
+  test("chunks a large request so the query cannot approach the bind-parameter ceiling", async () => {
+    // The composite-key kinds contribute two bind parameters per record, so an unchunked list would build
+    // exactly the unbounded OR that the chunk size exists to prevent.
+    const refs = Array.from({ length: AUTHZED_BACKFILL_TARGET_CHUNK_SIZE + 1 }, (_unused, index) => ({
+      kind: "teamMembership" as const,
+      teamId: "team-1",
+      userId: `user-${index}`,
+    }));
+
+    await findMissingSourceRefs(refs);
+
+    expect(prisma.teamUser.findMany).toHaveBeenCalledTimes(2);
   });
 
   test("issues one batched query per kind rather than one per record", async () => {

--- a/apps/web/lib/authzed/backfill-source.test.ts
+++ b/apps/web/lib/authzed/backfill-source.test.ts
@@ -244,8 +244,12 @@ describe("findMismatchedParentEdges", () => {
     ] as never);
 
     await expect(
-      findMismatchedParentEdges([{ childId: "ws-1", childType: "workspace", organizationId: "other-org" }])
-    ).resolves.toEqual([{ childId: "ws-1", childType: "workspace", organizationId: "other-org" }]);
+      findMismatchedParentEdges([
+        { childId: "ws-1", childType: "workspace", organizationId: "other-org", relation: "organization" },
+      ])
+    ).resolves.toEqual([
+      { childId: "ws-1", childType: "workspace", organizationId: "other-org", relation: "organization" },
+    ]);
   });
 
   test("accepts an edge naming the true owner", async () => {
@@ -254,22 +258,26 @@ describe("findMismatchedParentEdges", () => {
     ] as never);
 
     await expect(
-      findMismatchedParentEdges([{ childId: "team-1", childType: "team", organizationId: ORGANIZATION_ID }])
+      findMismatchedParentEdges([
+        { childId: "team-1", childType: "team", organizationId: ORGANIZATION_ID, relation: "organization" },
+      ])
     ).resolves.toEqual([]);
   });
 
   test("leaves an edge whose resource has no row to the orphan path", async () => {
     // That is a different finding with a working repair, so reporting it here too would double-count it.
     await expect(
-      findMismatchedParentEdges([{ childId: "gone", childType: "api_key", organizationId: ORGANIZATION_ID }])
+      findMismatchedParentEdges([
+        { childId: "gone", childType: "api_key", organizationId: ORGANIZATION_ID, relation: "organization" },
+      ])
     ).resolves.toEqual([]);
   });
 
   test("checks all three child types in one batch per type", async () => {
     await findMismatchedParentEdges([
-      { childId: "team-1", childType: "team", organizationId: ORGANIZATION_ID },
-      { childId: "ws-1", childType: "workspace", organizationId: ORGANIZATION_ID },
-      { childId: "key-1", childType: "api_key", organizationId: ORGANIZATION_ID },
+      { childId: "team-1", childType: "team", organizationId: ORGANIZATION_ID, relation: "organization" },
+      { childId: "ws-1", childType: "workspace", organizationId: ORGANIZATION_ID, relation: "organization" },
+      { childId: "key-1", childType: "api_key", organizationId: ORGANIZATION_ID, relation: "organization" },
     ]);
 
     expect(prisma.team.findMany).toHaveBeenCalledTimes(1);
@@ -281,7 +289,9 @@ describe("findMismatchedParentEdges", () => {
     vi.mocked(prisma.workspace.findMany).mockRejectedValue(new Error("connection reset"));
 
     await expect(
-      findMismatchedParentEdges([{ childId: "ws-1", childType: "workspace", organizationId: "other-org" }])
+      findMismatchedParentEdges([
+        { childId: "ws-1", childType: "workspace", organizationId: "other-org", relation: "organization" },
+      ])
     ).rejects.toThrow("connection reset");
   });
 });

--- a/apps/web/lib/authzed/backfill-source.ts
+++ b/apps/web/lib/authzed/backfill-source.ts
@@ -37,6 +37,12 @@ export type TAuthzedOrganizationSource = Readonly<{
   apiKeyIds: ReadonlyArray<string>;
   apiKeyWorkspaceGrants: ReadonlyArray<TAuthzedApiKeyWorkspaceTarget>;
   /**
+   * API-key workspace grants whose key and workspace belong to different organizations.
+   *
+   * Same treatment as `invalidWorkspaceTeamGrants`: reported, never projected, never pruned.
+   */
+  invalidApiKeyWorkspaceGrants: ReadonlyArray<TAuthzedApiKeyWorkspaceTarget>;
+  /**
    * Workspace-team grants whose team and workspace belong to different organizations.
    *
    * Formbricks never creates one, and it would break the closed-unit invariant, so these are reported
@@ -53,6 +59,14 @@ export type TAuthzedOrganizationSource = Readonly<{
 /** The grants attached to one workspace, for the narrower workspace repair scope. */
 export type TAuthzedWorkspaceSource = Readonly<{
   apiKeyWorkspaceGrants: ReadonlyArray<TAuthzedApiKeyWorkspaceTarget>;
+  /**
+   * The owning organization, or `null` when the workspace has no row.
+   *
+   * Read so a failure in this scope can be attributed to a tenant. Without it every workspace-scoped
+   * failure reports the empty string, which is also the sweep's marker for a genuinely unattributable
+   * orphan — leaving the two indistinguishable in the output.
+   */
+  organizationId: string | null;
   /** Reported rather than enforced: a missing workspace is a valid repair target, not an error. */
   workspaceExists: boolean;
   workspaceTeamGrants: ReadonlyArray<TAuthzedWorkspaceTeamTarget>;
@@ -91,8 +105,8 @@ export const organizationExists = async (organizationId: string): Promise<boolea
  * organization ID is not needed to reach them, because the caller supplies the workspace ID directly.
  */
 export const readWorkspaceSource = async (workspaceId: string): Promise<TAuthzedWorkspaceSource> => {
-  const [workspaceCount, workspaceTeams, apiKeyWorkspaces] = await Promise.all([
-    prisma.workspace.count({ where: { id: workspaceId } }),
+  const [workspace, workspaceTeams, apiKeyWorkspaces] = await Promise.all([
+    prisma.workspace.findUnique({ where: { id: workspaceId }, select: { organizationId: true } }),
     prisma.workspaceTeam.findMany({
       where: { workspaceId },
       select: { teamId: true, workspaceId: true },
@@ -107,7 +121,10 @@ export const readWorkspaceSource = async (workspaceId: string): Promise<TAuthzed
 
   return {
     apiKeyWorkspaceGrants: apiKeyWorkspaces,
-    workspaceExists: workspaceCount > 0,
+    organizationId: workspace?.organizationId ?? null,
+    // Truthiness rather than `!== null`, so a row is required to claim existence rather than merely the
+    // absence of one particular falsy value.
+    workspaceExists: Boolean(workspace),
     workspaceTeamGrants: workspaceTeams,
   };
 };
@@ -150,7 +167,13 @@ export const readOrganizationSource = async (organizationId: string): Promise<TA
       }),
       prisma.apiKeyWorkspace.findMany({
         where: { apiKey: { organizationId } },
-        select: { apiKeyId: true, workspaceId: true },
+        // Keyed off the *key's* organization, so the workspace's is read to detect a grant that crosses
+        // organizations — the same check `workspaceTeam` above performs, and for the same reason.
+        select: {
+          apiKeyId: true,
+          workspace: { select: { organizationId: true } },
+          workspaceId: true,
+        },
         orderBy: [{ apiKeyId: "asc" }, { workspaceId: "asc" }],
       }),
     ]);
@@ -166,9 +189,26 @@ export const readOrganizationSource = async (organizationId: string): Promise<TA
     }
   }
 
+  // A grant whose workspace belongs to another organization is unreachable from this one: the
+  // observation only reads workspaces this organization owns, so an expected relationship naming a
+  // foreign workspace could never be seen and the unit would report drift that no run can converge.
+  // Excluded from the targets for the same reason as the workspace-team case — never projected, never
+  // pruned, only reported.
+  const apiKeyWorkspaceGrants: TAuthzedApiKeyWorkspaceTarget[] = [];
+  const invalidApiKeyWorkspaceGrants: TAuthzedApiKeyWorkspaceTarget[] = [];
+  for (const grant of apiKeyWorkspaces) {
+    const target = { apiKeyId: grant.apiKeyId, workspaceId: grant.workspaceId };
+    if (grant.workspace.organizationId === organizationId) {
+      apiKeyWorkspaceGrants.push(target);
+    } else {
+      invalidApiKeyWorkspaceGrants.push(target);
+    }
+  }
+
   return {
     apiKeyIds: apiKeys.map(({ id }) => id),
-    apiKeyWorkspaceGrants: apiKeyWorkspaces,
+    apiKeyWorkspaceGrants,
+    invalidApiKeyWorkspaceGrants,
     invalidWorkspaceTeamGrants,
     memberships: memberships.map(({ userId }) => ({ organizationId, userId })),
     teamIds: teams.map(({ id }) => id),

--- a/apps/web/lib/authzed/backfill-source.ts
+++ b/apps/web/lib/authzed/backfill-source.ts
@@ -1,0 +1,255 @@
+import "server-only";
+import { prisma } from "@formbricks/database";
+import type { TAuthzedSourceRef } from "./backfill-diff";
+import { AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE } from "./constants";
+
+/**
+ * PostgreSQL enumeration for relationship backfill and repair.
+ *
+ * **Command-line use only. No route, server action, background job, or request-path module may import
+ * this file or anything that consumes it.** These reads are deliberately not tenant-scoped — sweeping
+ * every organization is the entire point — and the tooling built on them performs no authorization
+ * check of its own, because it runs as an operator with the AuthZed system credential. Reachable from
+ * an HTTP surface it would let a caller rewrite any tenant's permission graph by ID.
+ *
+ * This is the only file in the backfill that touches `prisma`, which keeps "what does the tooling read
+ * from the database?" a single-file audit. Every query names its columns explicitly and reads only
+ * identifiers, roles, permissions, and API-key organization access — never plaintext keys, key hashes,
+ * lookup hashes, creator metadata, or usage timestamps.
+ *
+ * **Errors are never caught here.** Absence is what marks a relationship stale, so a failed query must
+ * not be mistaken for "no source row": that would classify live access as orphaned and, under pruning,
+ * revoke it at scale. A failure propagates, the unit is reported failed, and the run continues.
+ */
+
+export type TAuthzedMembershipTarget = Readonly<{ organizationId: string; userId: string }>;
+export type TAuthzedTeamMembershipTarget = Readonly<{ teamId: string; userId: string }>;
+export type TAuthzedWorkspaceTeamTarget = Readonly<{ teamId: string; workspaceId: string }>;
+export type TAuthzedApiKeyWorkspaceTarget = Readonly<{ apiKeyId: string; workspaceId: string }>;
+
+/**
+ * Every authorization-relevant record owned by one organization.
+ *
+ * The organization is a closed unit: each of these models reaches `Organization` in one hop or two, so
+ * a complete set of targets for one organization can be enumerated without consulting any other.
+ */
+export type TAuthzedOrganizationSource = Readonly<{
+  apiKeyIds: ReadonlyArray<string>;
+  apiKeyWorkspaceGrants: ReadonlyArray<TAuthzedApiKeyWorkspaceTarget>;
+  /**
+   * Workspace-team grants whose team and workspace belong to different organizations.
+   *
+   * Formbricks never creates one, and it would break the closed-unit invariant, so these are reported
+   * and then left strictly alone — neither projected nor pruned.
+   */
+  invalidWorkspaceTeamGrants: ReadonlyArray<TAuthzedWorkspaceTeamTarget>;
+  memberships: ReadonlyArray<TAuthzedMembershipTarget>;
+  teamIds: ReadonlyArray<string>;
+  teamMemberships: ReadonlyArray<TAuthzedTeamMembershipTarget>;
+  workspaceIds: ReadonlyArray<string>;
+  workspaceTeamGrants: ReadonlyArray<TAuthzedWorkspaceTeamTarget>;
+}>;
+
+/**
+ * One keyset page of organization IDs.
+ *
+ * Keyset rather than offset so the sweep is stable while organizations are created and deleted, and so
+ * an interrupted run resumes from the last ID it reported instead of restarting.
+ */
+export const readOrganizationIdPage = async (
+  page: Readonly<{ afterOrganizationId?: string; limit?: number }> = {}
+): Promise<ReadonlyArray<string>> => {
+  const organizations = await prisma.organization.findMany({
+    where: page.afterOrganizationId ? { id: { gt: page.afterOrganizationId } } : undefined,
+    select: { id: true },
+    orderBy: { id: "asc" },
+    take: page.limit ?? AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE,
+  });
+
+  return organizations.map(({ id }) => id);
+};
+
+export const organizationExists = async (organizationId: string): Promise<boolean> =>
+  (await prisma.organization.count({ where: { id: organizationId } })) > 0;
+
+/** Enumerate every authorization-relevant record owned by one organization. */
+export const readOrganizationSource = async (organizationId: string): Promise<TAuthzedOrganizationSource> => {
+  const [memberships, teams, workspaces, apiKeys, teamMemberships, workspaceTeams, apiKeyWorkspaces] =
+    await Promise.all([
+      prisma.membership.findMany({
+        where: { organizationId },
+        select: { userId: true },
+        orderBy: { userId: "asc" },
+      }),
+      prisma.team.findMany({
+        where: { organizationId },
+        select: { id: true },
+        orderBy: { id: "asc" },
+      }),
+      prisma.workspace.findMany({
+        where: { organizationId },
+        select: { id: true },
+        orderBy: { id: "asc" },
+      }),
+      prisma.apiKey.findMany({
+        where: { organizationId },
+        select: { id: true },
+        orderBy: { id: "asc" },
+      }),
+      prisma.teamUser.findMany({
+        where: { team: { organizationId } },
+        select: { teamId: true, userId: true },
+        orderBy: [{ teamId: "asc" }, { userId: "asc" }],
+      }),
+      prisma.workspaceTeam.findMany({
+        where: { workspace: { organizationId } },
+        // The team's organization is read so a cross-organization grant can be detected rather than
+        // silently projected as if the unit were closed.
+        select: { team: { select: { organizationId: true } }, teamId: true, workspaceId: true },
+        orderBy: [{ workspaceId: "asc" }, { teamId: "asc" }],
+      }),
+      prisma.apiKeyWorkspace.findMany({
+        where: { apiKey: { organizationId } },
+        select: { apiKeyId: true, workspaceId: true },
+        orderBy: [{ apiKeyId: "asc" }, { workspaceId: "asc" }],
+      }),
+    ]);
+
+  const workspaceTeamGrants: TAuthzedWorkspaceTeamTarget[] = [];
+  const invalidWorkspaceTeamGrants: TAuthzedWorkspaceTeamTarget[] = [];
+  for (const grant of workspaceTeams) {
+    const target = { teamId: grant.teamId, workspaceId: grant.workspaceId };
+    if (grant.team.organizationId === organizationId) {
+      workspaceTeamGrants.push(target);
+    } else {
+      invalidWorkspaceTeamGrants.push(target);
+    }
+  }
+
+  return {
+    apiKeyIds: apiKeys.map(({ id }) => id),
+    apiKeyWorkspaceGrants: apiKeyWorkspaces,
+    invalidWorkspaceTeamGrants,
+    memberships: memberships.map(({ userId }) => ({ organizationId, userId })),
+    teamIds: teams.map(({ id }) => id),
+    teamMemberships,
+    workspaceIds: workspaces.map(({ id }) => id),
+    workspaceTeamGrants,
+  };
+};
+
+const byKind = <TKind extends TAuthzedSourceRef["kind"]>(
+  refs: ReadonlyArray<TAuthzedSourceRef>,
+  kind: TKind
+): ReadonlyArray<Extract<TAuthzedSourceRef, { kind: TKind }>> =>
+  refs.filter((ref): ref is Extract<TAuthzedSourceRef, { kind: TKind }> => ref.kind === kind);
+
+const pairKey = (first: string, second: string): string => `${first.length}:${first}${second}`;
+
+/**
+ * Of the supplied source records, report those PostgreSQL does not hold.
+ *
+ * One batched query per record kind, so the cost is bounded by the number of kinds rather than by the
+ * number of records. A query failure propagates untouched — see the note on this module: treating a
+ * failure as absence is the one mistake that turns this tooling destructive.
+ */
+export const findMissingSourceRefs = async (
+  refs: ReadonlyArray<TAuthzedSourceRef>
+): Promise<ReadonlyArray<TAuthzedSourceRef>> => {
+  const apiKeyRefs = byKind(refs, "apiKey");
+  const membershipRefs = byKind(refs, "membership");
+  const teamRefs = byKind(refs, "team");
+  const teamMembershipRefs = byKind(refs, "teamMembership");
+  const workspaceRefs = byKind(refs, "workspace");
+  const workspaceTeamGrantRefs = byKind(refs, "workspaceTeamGrant");
+  const apiKeyWorkspaceGrantRefs = byKind(refs, "apiKeyWorkspaceGrant");
+
+  const [apiKeys, memberships, teams, teamMemberships, workspaces, workspaceTeams, apiKeyWorkspaces] =
+    await Promise.all([
+      apiKeyRefs.length === 0
+        ? []
+        : prisma.apiKey.findMany({
+            where: { id: { in: apiKeyRefs.map(({ apiKeyId }) => apiKeyId) } },
+            select: { id: true },
+          }),
+      membershipRefs.length === 0
+        ? []
+        : prisma.membership.findMany({
+            where: {
+              OR: membershipRefs.map(({ organizationId, userId }) => ({ organizationId, userId })),
+            },
+            select: { organizationId: true, userId: true },
+          }),
+      teamRefs.length === 0
+        ? []
+        : prisma.team.findMany({
+            where: { id: { in: teamRefs.map(({ teamId }) => teamId) } },
+            select: { id: true },
+          }),
+      teamMembershipRefs.length === 0
+        ? []
+        : prisma.teamUser.findMany({
+            where: { OR: teamMembershipRefs.map(({ teamId, userId }) => ({ teamId, userId })) },
+            select: { teamId: true, userId: true },
+          }),
+      workspaceRefs.length === 0
+        ? []
+        : prisma.workspace.findMany({
+            where: { id: { in: workspaceRefs.map(({ workspaceId }) => workspaceId) } },
+            select: { id: true },
+          }),
+      workspaceTeamGrantRefs.length === 0
+        ? []
+        : prisma.workspaceTeam.findMany({
+            where: {
+              OR: workspaceTeamGrantRefs.map(({ teamId, workspaceId }) => ({ teamId, workspaceId })),
+            },
+            select: { teamId: true, workspaceId: true },
+          }),
+      apiKeyWorkspaceGrantRefs.length === 0
+        ? []
+        : prisma.apiKeyWorkspace.findMany({
+            where: {
+              OR: apiKeyWorkspaceGrantRefs.map(({ apiKeyId, workspaceId }) => ({ apiKeyId, workspaceId })),
+            },
+            select: { apiKeyId: true, workspaceId: true },
+          }),
+    ]);
+
+  const existingApiKeyIds = new Set(apiKeys.map(({ id }) => id));
+  const existingTeamIds = new Set(teams.map(({ id }) => id));
+  const existingWorkspaceIds = new Set(workspaces.map(({ id }) => id));
+  const existingMemberships = new Set(
+    memberships.map(({ organizationId, userId }) => pairKey(organizationId, userId))
+  );
+  const existingTeamMemberships = new Set(
+    teamMemberships.map(({ teamId, userId }) => pairKey(teamId, userId))
+  );
+  const existingWorkspaceTeams = new Set(
+    workspaceTeams.map(({ teamId, workspaceId }) => pairKey(workspaceId, teamId))
+  );
+  const existingApiKeyWorkspaces = new Set(
+    apiKeyWorkspaces.map(({ apiKeyId, workspaceId }) => pairKey(apiKeyId, workspaceId))
+  );
+
+  const isPresent = (ref: TAuthzedSourceRef): boolean => {
+    switch (ref.kind) {
+      case "apiKey":
+        return existingApiKeyIds.has(ref.apiKeyId);
+      case "apiKeyWorkspaceGrant":
+        return existingApiKeyWorkspaces.has(pairKey(ref.apiKeyId, ref.workspaceId));
+      case "membership":
+        return existingMemberships.has(pairKey(ref.organizationId, ref.userId));
+      case "team":
+        return existingTeamIds.has(ref.teamId);
+      case "teamMembership":
+        return existingTeamMemberships.has(pairKey(ref.teamId, ref.userId));
+      case "workspace":
+        return existingWorkspaceIds.has(ref.workspaceId);
+      case "workspaceTeamGrant":
+        return existingWorkspaceTeams.has(pairKey(ref.workspaceId, ref.teamId));
+    }
+  };
+
+  return refs.filter((ref) => !isPresent(ref));
+};

--- a/apps/web/lib/authzed/backfill-source.ts
+++ b/apps/web/lib/authzed/backfill-source.ts
@@ -1,7 +1,7 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
-import type { TAuthzedSourceRef } from "./backfill-diff";
-import { AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE } from "./constants";
+import type { TAuthzedParentEdge, TAuthzedSourceRef } from "./backfill-diff";
+import { AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE, AUTHZED_BACKFILL_TARGET_CHUNK_SIZE } from "./constants";
 
 /**
  * PostgreSQL enumeration for relationship backfill and repair.
@@ -50,6 +50,14 @@ export type TAuthzedOrganizationSource = Readonly<{
   workspaceTeamGrants: ReadonlyArray<TAuthzedWorkspaceTeamTarget>;
 }>;
 
+/** The grants attached to one workspace, for the narrower workspace repair scope. */
+export type TAuthzedWorkspaceSource = Readonly<{
+  apiKeyWorkspaceGrants: ReadonlyArray<TAuthzedApiKeyWorkspaceTarget>;
+  /** Reported rather than enforced: a missing workspace is a valid repair target, not an error. */
+  workspaceExists: boolean;
+  workspaceTeamGrants: ReadonlyArray<TAuthzedWorkspaceTeamTarget>;
+}>;
+
 /**
  * One keyset page of organization IDs.
  *
@@ -71,6 +79,38 @@ export const readOrganizationIdPage = async (
 
 export const organizationExists = async (organizationId: string): Promise<boolean> =>
   (await prisma.organization.count({ where: { id: organizationId } })) > 0;
+
+/**
+ * Enumerate the authorization-relevant records attached to one workspace.
+ *
+ * A narrower unit than the organization, for repairing a single workspace's grants without touching the
+ * rest of the tenant.
+ *
+ * Deliberately does **not** require the workspace to exist. A workspace whose row is already gone is
+ * the case most worth repairing — its relationships are exactly what should be removed — and an
+ * organization ID is not needed to reach them, because the caller supplies the workspace ID directly.
+ */
+export const readWorkspaceSource = async (workspaceId: string): Promise<TAuthzedWorkspaceSource> => {
+  const [workspaceCount, workspaceTeams, apiKeyWorkspaces] = await Promise.all([
+    prisma.workspace.count({ where: { id: workspaceId } }),
+    prisma.workspaceTeam.findMany({
+      where: { workspaceId },
+      select: { teamId: true, workspaceId: true },
+      orderBy: { teamId: "asc" },
+    }),
+    prisma.apiKeyWorkspace.findMany({
+      where: { workspaceId },
+      select: { apiKeyId: true, workspaceId: true },
+      orderBy: { apiKeyId: "asc" },
+    }),
+  ]);
+
+  return {
+    apiKeyWorkspaceGrants: apiKeyWorkspaces,
+    workspaceExists: workspaceCount > 0,
+    workspaceTeamGrants: workspaceTeams,
+  };
+};
 
 /** Enumerate every authorization-relevant record owned by one organization. */
 export const readOrganizationSource = async (organizationId: string): Promise<TAuthzedOrganizationSource> => {
@@ -138,6 +178,73 @@ export const readOrganizationSource = async (organizationId: string): Promise<TA
   };
 };
 
+/**
+ * Of the observed parent edges, report those PostgreSQL contradicts.
+ *
+ * An edge is only correct when the resource exists *and* belongs to the organization the edge names. An
+ * existence check alone cannot tell the difference, which is why this is separate — and it is the check
+ * that catches a cross-tenant parent edge, where a resource is additionally attached to an organization
+ * that does not own it and every owner and manager of that organization silently gains access.
+ *
+ * Errors propagate, for the same reason as everywhere else in this module: a failed lookup must never be
+ * read as "PostgreSQL disagrees".
+ */
+export const findMismatchedParentEdges = async (
+  edges: ReadonlyArray<TAuthzedParentEdge>
+): Promise<ReadonlyArray<TAuthzedParentEdge>> => {
+  if (edges.length > AUTHZED_BACKFILL_TARGET_CHUNK_SIZE) {
+    const mismatched: TAuthzedParentEdge[] = [];
+    for (let start = 0; start < edges.length; start += AUTHZED_BACKFILL_TARGET_CHUNK_SIZE) {
+      mismatched.push(
+        ...(await findMismatchedParentEdges(edges.slice(start, start + AUTHZED_BACKFILL_TARGET_CHUNK_SIZE)))
+      );
+    }
+    return mismatched;
+  }
+
+  const idsFor = (childType: TAuthzedParentEdge["childType"]): ReadonlyArray<string> => [
+    ...new Set(edges.filter((edge) => edge.childType === childType).map((edge) => edge.childId)),
+  ];
+  const teamIds = idsFor("team");
+  const workspaceIds = idsFor("workspace");
+  const apiKeyIds = idsFor("api_key");
+
+  const [teams, workspaces, apiKeys] = await Promise.all([
+    teamIds.length === 0
+      ? []
+      : prisma.team.findMany({
+          where: { id: { in: [...teamIds] } },
+          select: { id: true, organizationId: true },
+        }),
+    workspaceIds.length === 0
+      ? []
+      : prisma.workspace.findMany({
+          where: { id: { in: [...workspaceIds] } },
+          select: { id: true, organizationId: true },
+        }),
+    apiKeyIds.length === 0
+      ? []
+      : prisma.apiKey.findMany({
+          where: { id: { in: [...apiKeyIds] } },
+          select: { id: true, organizationId: true },
+        }),
+  ]);
+
+  const trueParents = new Map<string, string>([
+    ...teams.map(({ id, organizationId }): [string, string] => [`team:${id}`, organizationId]),
+    ...workspaces.map(({ id, organizationId }): [string, string] => [`workspace:${id}`, organizationId]),
+    ...apiKeys.map(({ id, organizationId }): [string, string] => [`api_key:${id}`, organizationId]),
+  ]);
+
+  // A resource with no row at all is not reported here — that is an orphan, handled by the existence
+  // check, and it has a working repair path. This is only about a resource that exists under a different
+  // organization than the edge claims.
+  return edges.filter((edge) => {
+    const trueParent = trueParents.get(`${edge.childType}:${edge.childId}`);
+    return trueParent !== undefined && trueParent !== edge.organizationId;
+  });
+};
+
 const byKind = <TKind extends TAuthzedSourceRef["kind"]>(
   refs: ReadonlyArray<TAuthzedSourceRef>,
   kind: TKind
@@ -156,6 +263,20 @@ const pairKey = (first: string, second: string): string => `${first.length}:${fi
 export const findMissingSourceRefs = async (
   refs: ReadonlyArray<TAuthzedSourceRef>
 ): Promise<ReadonlyArray<TAuthzedSourceRef>> => {
+  // Chunked for the same reason reconciler targets are: the composite-key kinds contribute two bind
+  // parameters per record, so an unchunked list would approach PostgreSQL's parameter ceiling and give
+  // the planner an `OR` list it cannot use an index for. One query per kind *per chunk* still keeps the
+  // cost proportional to the number of kinds rather than the number of records.
+  if (refs.length > AUTHZED_BACKFILL_TARGET_CHUNK_SIZE) {
+    const missing: TAuthzedSourceRef[] = [];
+    for (let start = 0; start < refs.length; start += AUTHZED_BACKFILL_TARGET_CHUNK_SIZE) {
+      missing.push(
+        ...(await findMissingSourceRefs(refs.slice(start, start + AUTHZED_BACKFILL_TARGET_CHUNK_SIZE)))
+      );
+    }
+    return missing;
+  }
+
   const apiKeyRefs = byKind(refs, "apiKey");
   const membershipRefs = byKind(refs, "membership");
   const teamRefs = byKind(refs, "team");

--- a/apps/web/lib/authzed/backfill-source.ts
+++ b/apps/web/lib/authzed/backfill-source.ts
@@ -60,6 +60,16 @@ export type TAuthzedOrganizationSource = Readonly<{
 export type TAuthzedWorkspaceSource = Readonly<{
   apiKeyWorkspaceGrants: ReadonlyArray<TAuthzedApiKeyWorkspaceTarget>;
   /**
+   * Grants whose principal belongs to a different organization than the workspace.
+   *
+   * The join tables carry independent foreign keys and no same-organization constraint, so a
+   * cross-tenant row is representable. The organization scope already partitions these out; this scope
+   * has to as well, or `--workspace-id` would *write* a cross-tenant grant that `--organization-id`
+   * refuses to write. Reported, never projected, never pruned.
+   */
+  invalidApiKeyWorkspaceGrants: ReadonlyArray<TAuthzedApiKeyWorkspaceTarget>;
+  invalidWorkspaceTeamGrants: ReadonlyArray<TAuthzedWorkspaceTeamTarget>;
+  /**
    * The owning organization, or `null` when the workspace has no row.
    *
    * Read so a failure in this scope can be attributed to a tenant. Without it every workspace-scoped
@@ -109,23 +119,59 @@ export const readWorkspaceSource = async (workspaceId: string): Promise<TAuthzed
     prisma.workspace.findUnique({ where: { id: workspaceId }, select: { organizationId: true } }),
     prisma.workspaceTeam.findMany({
       where: { workspaceId },
-      select: { teamId: true, workspaceId: true },
+      // The principal's organization is read so a cross-organization grant can be partitioned out
+      // rather than projected, matching what the organization scope already does.
+      select: { team: { select: { organizationId: true } }, teamId: true, workspaceId: true },
       orderBy: { teamId: "asc" },
     }),
     prisma.apiKeyWorkspace.findMany({
       where: { workspaceId },
-      select: { apiKeyId: true, workspaceId: true },
+      select: { apiKey: { select: { organizationId: true } }, apiKeyId: true, workspaceId: true },
       orderBy: { apiKeyId: "asc" },
     }),
   ]);
 
+  const organizationId = workspace?.organizationId ?? null;
+
+  // Only decidable when the workspace still has a row. With no row there is no organization to compare
+  // against, and its grants are stale by construction — the prune path is what deals with them.
+  const partition = <TGrant>(
+    grants: ReadonlyArray<TGrant>,
+    principalOrganizationId: (grant: TGrant) => string
+  ): Readonly<{ invalid: TGrant[]; valid: TGrant[] }> => {
+    if (organizationId === null) {
+      return { invalid: [], valid: [...grants] };
+    }
+
+    const valid: TGrant[] = [];
+    const invalid: TGrant[] = [];
+    for (const grant of grants) {
+      (principalOrganizationId(grant) === organizationId ? valid : invalid).push(grant);
+    }
+
+    return { invalid, valid };
+  };
+
+  const teamGrants = partition(workspaceTeams, (grant) => grant.team.organizationId);
+  const keyGrants = partition(apiKeyWorkspaces, (grant) => grant.apiKey.organizationId);
+  const toTeamTarget = ({ teamId }: (typeof workspaceTeams)[number]): TAuthzedWorkspaceTeamTarget => ({
+    teamId,
+    workspaceId,
+  });
+  const toKeyTarget = ({ apiKeyId }: (typeof apiKeyWorkspaces)[number]): TAuthzedApiKeyWorkspaceTarget => ({
+    apiKeyId,
+    workspaceId,
+  });
+
   return {
-    apiKeyWorkspaceGrants: apiKeyWorkspaces,
-    organizationId: workspace?.organizationId ?? null,
+    apiKeyWorkspaceGrants: keyGrants.valid.map(toKeyTarget),
+    invalidApiKeyWorkspaceGrants: keyGrants.invalid.map(toKeyTarget),
+    invalidWorkspaceTeamGrants: teamGrants.invalid.map(toTeamTarget),
+    organizationId,
     // Truthiness rather than `!== null`, so a row is required to claim existence rather than merely the
     // absence of one particular falsy value.
     workspaceExists: Boolean(workspace),
-    workspaceTeamGrants: workspaceTeams,
+    workspaceTeamGrants: teamGrants.valid.map(toTeamTarget),
   };
 };
 

--- a/apps/web/lib/authzed/backfill-source.ts
+++ b/apps/web/lib/authzed/backfill-source.ts
@@ -219,6 +219,26 @@ export const readOrganizationSource = async (organizationId: string): Promise<TA
 };
 
 /**
+ * Run a reader over one chunk at a time, concatenating the results.
+ *
+ * Both readers below build a `where: { OR: [...] }` from their input, which is unbounded by
+ * construction — so both need the same chunking, and it lives here once rather than being re-derived
+ * per reader. Sequential rather than parallel: these run inside a sweep that already bounds its own
+ * concurrency, and a fan-out here would multiply it.
+ */
+const inChunks = async <TItem>(
+  items: ReadonlyArray<TItem>,
+  read: (chunk: ReadonlyArray<TItem>) => Promise<ReadonlyArray<TItem>>
+): Promise<ReadonlyArray<TItem>> => {
+  const collected: TItem[] = [];
+  for (let start = 0; start < items.length; start += AUTHZED_BACKFILL_TARGET_CHUNK_SIZE) {
+    collected.push(...(await read(items.slice(start, start + AUTHZED_BACKFILL_TARGET_CHUNK_SIZE))));
+  }
+
+  return collected;
+};
+
+/**
  * Of the observed parent edges, report those PostgreSQL contradicts.
  *
  * An edge is only correct when the resource exists *and* belongs to the organization the edge names. An
@@ -233,13 +253,7 @@ export const findMismatchedParentEdges = async (
   edges: ReadonlyArray<TAuthzedParentEdge>
 ): Promise<ReadonlyArray<TAuthzedParentEdge>> => {
   if (edges.length > AUTHZED_BACKFILL_TARGET_CHUNK_SIZE) {
-    const mismatched: TAuthzedParentEdge[] = [];
-    for (let start = 0; start < edges.length; start += AUTHZED_BACKFILL_TARGET_CHUNK_SIZE) {
-      mismatched.push(
-        ...(await findMismatchedParentEdges(edges.slice(start, start + AUTHZED_BACKFILL_TARGET_CHUNK_SIZE)))
-      );
-    }
-    return mismatched;
+    return inChunks(edges, findMismatchedParentEdges);
   }
 
   const idsFor = (childType: TAuthzedParentEdge["childType"]): ReadonlyArray<string> => [
@@ -308,13 +322,7 @@ export const findMissingSourceRefs = async (
   // the planner an `OR` list it cannot use an index for. One query per kind *per chunk* still keeps the
   // cost proportional to the number of kinds rather than the number of records.
   if (refs.length > AUTHZED_BACKFILL_TARGET_CHUNK_SIZE) {
-    const missing: TAuthzedSourceRef[] = [];
-    for (let start = 0; start < refs.length; start += AUTHZED_BACKFILL_TARGET_CHUNK_SIZE) {
-      missing.push(
-        ...(await findMissingSourceRefs(refs.slice(start, start + AUTHZED_BACKFILL_TARGET_CHUNK_SIZE)))
-      );
-    }
-    return missing;
+    return inChunks(refs, findMissingSourceRefs);
   }
 
   const apiKeyRefs = byKind(refs, "apiKey");

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -6,10 +6,12 @@ import { AUTHZED_BACKFILL_TARGET_CHUNK_SIZE, AUTHZED_MAX_RELATIONSHIP_READS } fr
 import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
 
 vi.mock("./backfill-source", () => ({
+  findMismatchedParentEdges: vi.fn(),
   findMissingSourceRefs: vi.fn(),
   organizationExists: vi.fn(),
   readOrganizationIdPage: vi.fn(),
   readOrganizationSource: vi.fn(),
+  readWorkspaceSource: vi.fn(),
 }));
 
 const apply = {
@@ -52,6 +54,12 @@ beforeEach(() => {
   vi.mocked(source.organizationExists).mockResolvedValue(true);
   vi.mocked(source.readOrganizationSource).mockResolvedValue(emptySource);
   vi.mocked(source.findMissingSourceRefs).mockResolvedValue([]);
+  vi.mocked(source.findMismatchedParentEdges).mockResolvedValue([]);
+  vi.mocked(source.readWorkspaceSource).mockResolvedValue({
+    apiKeyWorkspaceGrants: [],
+    workspaceExists: true,
+    workspaceTeamGrants: [],
+  });
   vi.mocked(source.readOrganizationIdPage).mockResolvedValue([]);
 });
 
@@ -214,7 +222,7 @@ describe("per-unit failure isolation", () => {
   test("rejects a scope naming an organization that does not exist", async () => {
     vi.mocked(source.organizationExists).mockResolvedValue(false);
 
-    await expect(runAuthzedBackfill(request(), dependencies)).rejects.toThrow("Organization not found");
+    await expect(runAuthzedBackfill(request(), dependencies)).rejects.toThrow(AUTHZED_ERROR_CODES.NOT_FOUND);
     expect(apply.reconcileMemberships).not.toHaveBeenCalled();
   });
 });
@@ -225,24 +233,116 @@ describe("idempotency", () => {
       ...emptySource,
       memberships: [{ organizationId: "org-1", userId: "user-1" }],
     });
+    // Converged state: SpiceDB holds the relationship the membership implies. Without this the run
+    // rightly reports the record as unprojected — see the dry-run detection tests.
+    const convergedPage = {
+      cursor: null,
+      relationships: [
+        {
+          relation: "owner",
+          resource: { objectId: "org-1", objectType: "organization" },
+          subject: { objectId: "user-1", objectType: "user" },
+        },
+      ],
+      snapshot: { token: "revision-1" },
+    };
+    readRelationships.mockResolvedValue(convergedPage);
 
     const first = await runAuthzedBackfill(request(), dependencies);
-    vi.clearAllMocks();
-    apply.reconcileMemberships.mockResolvedValue(PROJECTED);
-    apply.reconcileTeamWorkspace.mockResolvedValue(PROJECTED);
-    apply.reconcileApiKeys.mockResolvedValue(PROJECTED);
-    readRelationships.mockResolvedValue(emptyPage);
-    vi.mocked(source.organizationExists).mockResolvedValue(true);
-    vi.mocked(source.readOrganizationSource).mockResolvedValue({
-      ...emptySource,
-      memberships: [{ organizationId: "org-1", userId: "user-1" }],
-    });
-    vi.mocked(source.findMissingSourceRefs).mockResolvedValue([]);
     const second = await runAuthzedBackfill(request(), dependencies);
 
     expect(second).toEqual(first);
     expect(second.counters.orphaned).toBe(0);
     expect(second.status).toBe("reconciled");
+  });
+});
+
+describe("detecting records SpiceDB is missing", () => {
+  test("a dry run over an empty SpiceDB reports drift rather than a clean bill of health", async () => {
+    // The whole reason this tool exists. Reporting "reconciled" here would let an operator satisfy the
+    // documented pre-enforcement gate with a run that proved nothing.
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({
+      ...emptySource,
+      apiKeyIds: ["key-1"],
+      memberships: [{ organizationId: "org-1", userId: "user-1" }],
+      teamIds: ["team-1"],
+    });
+
+    const result = await runAuthzedBackfill(request({ mode: "dry_run" }), dependencies);
+
+    expect(result.counters.missing).toBe(3);
+    expect(result.status).toBe("drifted");
+  });
+
+  test("reports nothing missing once every record is projected", async () => {
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({
+      ...emptySource,
+      teamIds: ["team-1"],
+    });
+    readRelationships.mockResolvedValue({
+      cursor: null,
+      relationships: [
+        {
+          relation: "organization",
+          resource: { objectId: "team-1", objectType: "team" },
+          subject: { objectId: "org-1", objectType: "organization" },
+        },
+      ],
+      snapshot: { token: "revision-1" },
+    });
+
+    const result = await runAuthzedBackfill(request({ mode: "dry_run" }), dependencies);
+
+    expect(result.counters.missing).toBe(0);
+    expect(result.status).toBe("reconciled");
+  });
+
+  test("checks the missing direction on a full sweep only when nothing will be written", async () => {
+    vi.mocked(source.readOrganizationIdPage).mockResolvedValueOnce(["org-1"]).mockResolvedValue([]);
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({ ...emptySource, teamIds: ["team-1"] });
+
+    const dryRun = await runAuthzedBackfill(
+      request({ mode: "dry_run", scope: { kind: "all" } }),
+      dependencies
+    );
+    // An applying sweep converges this direction by writing, so it skips the per-organization read.
+    const applied = await runAuthzedBackfill(request({ scope: { kind: "all" } }), dependencies);
+
+    expect(dryRun.counters.missing).toBe(1);
+    expect(applied.counters.missing).toBe(0);
+  });
+});
+
+describe("detecting a cross-tenant parent edge", () => {
+  const foreignParent = {
+    relation: "organization",
+    resource: { objectId: "ws-1", objectType: "workspace" },
+    subject: { objectId: "other-org", objectType: "organization" },
+  };
+
+  test("reports a parent edge PostgreSQL contradicts and never prunes it", async () => {
+    // `organization` is a relation, so an extra parent edge is additive: every owner and manager of the
+    // named organization gains access through `organization->manage`. Nothing in PostgreSQL shows it, and
+    // an existence check cannot see it, because the workspace really does exist.
+    readRelationships.mockResolvedValue({
+      cursor: null,
+      relationships: [foreignParent],
+      snapshot: { token: "revision-1" },
+    });
+    vi.mocked(source.findMismatchedParentEdges).mockResolvedValue([
+      { childId: "ws-1", childType: "workspace", organizationId: "other-org" },
+    ]);
+
+    const result = await runAuthzedBackfill(request({ prune: true }), dependencies);
+
+    expect(result.counters.mismatchedParents).toBe(1);
+    expect(result.mismatchedParents).toEqual([
+      { childId: "ws-1", childType: "workspace", organizationId: "other-org" },
+    ]);
+    // Removing it would mean deleting a relation the workspace legitimately needs one of, so it is left
+    // for a human — but it must force a non-clean status.
+    expect(result.status).toBe("drifted");
+    expect(result.counters.pruned).toBe(0);
   });
 });
 
@@ -451,14 +551,18 @@ describe("full-scope orphan sweep", () => {
 
   beforeEach(() => {
     vi.mocked(source.readOrganizationIdPage).mockResolvedValueOnce([]).mockResolvedValue([]);
-    readRelationships.mockResolvedValue({
-      cursor: null,
-      relationships: [ghostWorkspace],
-      snapshot: { token: "revision-1" },
-    });
-    vi.mocked(source.findMissingSourceRefs).mockResolvedValue([
-      { kind: "workspace", workspaceId: "ghost-ws" },
-    ]);
+    // The sweep reads one resource type at a time, so the fixture has to answer per type — the ghost
+    // workspace exists on `workspace` and nowhere else.
+    readRelationships.mockImplementation(({ filter }) =>
+      Promise.resolve(
+        filter.resourceType === "workspace"
+          ? { cursor: null, relationships: [ghostWorkspace], snapshot: { token: "revision-1" } }
+          : emptyPage
+      )
+    );
+    vi.mocked(source.findMissingSourceRefs).mockImplementation((refs) =>
+      Promise.resolve(refs.length > 0 ? [{ kind: "workspace", workspaceId: "ghost-ws" }] : [])
+    );
   });
 
   test("finds a resource unreachable from any organization and reports it", async () => {

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -558,6 +558,69 @@ describe("chunking", () => {
     expect(apply.reconcileMemberships).not.toHaveBeenCalled();
     expect(apply.reconcileTeamWorkspace).not.toHaveBeenCalled();
     expect(apply.reconcileApiKeys).not.toHaveBeenCalled();
-    expect(apply.reconcileMemberships).not.toHaveBeenCalled();
+  });
+
+  test("passes every list a reconciler understands in one call", async () => {
+    // A reconciler reads one PostgreSQL snapshot covering all the lists it was given, so splitting them
+    // would multiply the snapshot reads and verification passes for no benefit.
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({
+      ...emptySource,
+      apiKeyIds: ["key-1"],
+      apiKeyWorkspaceGrants: [{ apiKeyId: "key-1", workspaceId: "ws-1" }],
+      teamIds: ["team-1"],
+      teamMemberships: [{ teamId: "team-1", userId: "user-1" }],
+      workspaceIds: ["ws-1"],
+      workspaceTeamGrants: [{ teamId: "team-1", workspaceId: "ws-1" }],
+    });
+
+    await runAuthzedBackfill(request(), dependencies);
+
+    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledTimes(1);
+    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledWith({
+      teamIds: ["team-1"],
+      teamMemberships: [{ teamId: "team-1", userId: "user-1" }],
+      workspaceIds: ["ws-1"],
+      workspaceTeamGrants: [{ teamId: "team-1", workspaceId: "ws-1" }],
+    });
+    expect(apply.reconcileApiKeys).toHaveBeenCalledTimes(1);
+    expect(apply.reconcileApiKeys).toHaveBeenCalledWith({
+      apiKeyIds: ["key-1"],
+      apiKeyWorkspaceGrants: [{ apiKeyId: "key-1", workspaceId: "ws-1" }],
+    });
+  });
+
+  test("omits an empty list from a combined call rather than sending it", async () => {
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({
+      ...emptySource,
+      teamIds: ["team-1"],
+    });
+
+    await runAuthzedBackfill(request(), dependencies);
+
+    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledWith({ teamIds: ["team-1"] });
+  });
+
+  test("bounds each list independently, so call count follows the longest list", async () => {
+    const teamMemberships = Array.from(
+      { length: AUTHZED_BACKFILL_TARGET_CHUNK_SIZE + 1 },
+      (_unused, index) => ({ teamId: "team-1", userId: `user-${index}` })
+    );
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({
+      ...emptySource,
+      teamIds: ["team-1"],
+      teamMemberships,
+    });
+
+    await runAuthzedBackfill(request(), dependencies);
+
+    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledTimes(2);
+    // The short list is exhausted by the first call and must not be resent.
+    expect(apply.reconcileTeamWorkspace.mock.calls[0][0]).toEqual({
+      teamIds: ["team-1"],
+      teamMemberships: teamMemberships.slice(0, AUTHZED_BACKFILL_TARGET_CHUNK_SIZE),
+    });
+    expect(apply.reconcileTeamWorkspace.mock.calls[1][0]).toEqual({
+      teamMemberships: teamMemberships.slice(AUTHZED_BACKFILL_TARGET_CHUNK_SIZE),
+    });
   });
 });

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -672,6 +672,27 @@ describe("workspace scope", () => {
     expect(result.counters.pruned).toBe(0);
   });
 
+  test("withholds the whole-workspace deletion when the orphan count exceeds the budget", async () => {
+    // Naming a workspace with no row removes every relationship on it. An over-cap unit reported
+    // `skipped: 1, pruned: 0` and still performed exactly that deletion, which inverts the cap.
+    missingWorkspace();
+    vi.mocked(source.findMissingSourceRefs).mockResolvedValue([
+      { kind: "workspaceTeamGrant", teamId: "team-1", workspaceId: "ghost-ws" },
+      { kind: "workspaceTeamGrant", teamId: "team-2", workspaceId: "ghost-ws" },
+    ]);
+
+    const result = await runAuthzedBackfill(
+      request({ maxPrune: 1, prune: true, scope: { kind: "workspace", workspaceId: "ghost-ws" } }),
+      dependencies
+    );
+
+    expect(result.counters.skipped).toBe(1);
+    expect(result.counters.pruned).toBe(0);
+    expect(apply.reconcileTeamWorkspace).not.toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceIds: ["ghost-ws"] })
+    );
+  });
+
   test("removes a missing workspace's relationships when pruning is permitted", async () => {
     missingWorkspace();
 

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -65,6 +65,8 @@ beforeEach(() => {
   vi.mocked(source.findMismatchedParentEdges).mockResolvedValue([]);
   vi.mocked(source.readWorkspaceSource).mockResolvedValue({
     apiKeyWorkspaceGrants: [],
+    invalidApiKeyWorkspaceGrants: [],
+    invalidWorkspaceTeamGrants: [],
     organizationId: "org-1",
     workspaceExists: true,
     workspaceTeamGrants: [],
@@ -373,6 +375,42 @@ describe("counting each finding once", () => {
   });
 });
 
+describe("drift status covers unrepaired state", () => {
+  test.each([
+    [
+      "a cross-organization source grant",
+      () =>
+        vi.mocked(source.readOrganizationSource).mockResolvedValue({
+          ...emptySource,
+          invalidWorkspaceTeamGrants: [{ teamId: "foreign-team", workspaceId: "ws-1" }],
+        }),
+    ],
+    [
+      "an unrecognized relationship",
+      () =>
+        readRelationships.mockResolvedValue({
+          cursor: null,
+          relationships: [
+            {
+              relation: "not_a_formbricks_relation",
+              resource: { objectId: "org-1", objectType: "organization" },
+              subject: { objectId: "someone", objectType: "user" },
+            },
+          ],
+          snapshot: { token: "revision-1" },
+        }),
+    ],
+  ])("does not report reconciled while %s remains", async (_label, arrange) => {
+    // Both are deliberately left unrepaired — which is exactly why a clean exit must not be reachable
+    // while they exist. This result is the gate for shadow evaluation and enforcement.
+    arrange();
+
+    const result = await runAuthzedBackfill(request(), dependencies);
+
+    expect(result.status).toBe("drifted");
+  });
+});
+
 describe("detecting a cross-tenant parent edge", () => {
   const foreignParent = {
     relation: "organization",
@@ -649,6 +687,8 @@ describe("workspace scope", () => {
   const missingWorkspace = (): void => {
     vi.mocked(source.readWorkspaceSource).mockResolvedValue({
       apiKeyWorkspaceGrants: [],
+      invalidApiKeyWorkspaceGrants: [],
+      invalidWorkspaceTeamGrants: [],
       organizationId: null,
       workspaceExists: false,
       workspaceTeamGrants: [],
@@ -704,6 +744,41 @@ describe("workspace scope", () => {
     expect(apply.reconcileTeamWorkspace).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceIds: ["ghost-ws"] })
     );
+  });
+
+  test("withholds a grant whose principal is gone, since deleting it would reach other tenants", async () => {
+    // A grant ref implies its team, and a team with no PostgreSQL row makes the reconciler delete that
+    // team's grants on *every* workspace — outside this scope and outside its budget.
+    vi.mocked(source.findMissingSourceRefs).mockImplementation((refs) =>
+      Promise.resolve(refs.filter((ref) => ref.kind === "workspaceTeamGrant" || ref.kind === "team"))
+    );
+    readRelationships.mockResolvedValue({
+      cursor: null,
+      relationships: [
+        {
+          relation: "reader_team",
+          resource: { objectId: "ws-1", objectType: "workspace" },
+          subject: { objectId: "ghost-team", objectType: "team", relation: "member" },
+        },
+      ],
+      snapshot: { token: "revision-1" },
+    });
+
+    const result = await runAuthzedBackfill(
+      request({ prune: true, scope: { kind: "workspace", workspaceId: "ws-1" } }),
+      dependencies
+    );
+
+    // Counted, so the run stays drifted and tells the operator a wider scope is needed…
+    expect(result.counters.orphaned).toBe(1);
+    // …but never handed over, because the delete would not stay inside this workspace.
+    expect(result.counters.pruned).toBe(0);
+    expect(apply.reconcileTeamWorkspace).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceTeamGrants: [{ teamId: "ghost-team", workspaceId: "ws-1" }],
+      })
+    );
+    expect(result.status).toBe("drifted");
   });
 
   test("still projects the parent edge of a workspace that exists", async () => {

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -442,6 +442,98 @@ describe("scope and observation completeness", () => {
   });
 });
 
+describe("full-scope orphan sweep", () => {
+  const ghostWorkspace = {
+    relation: "organization",
+    resource: { objectId: "ghost-ws", objectType: "workspace" },
+    subject: { objectId: "gone-org", objectType: "organization" },
+  };
+
+  beforeEach(() => {
+    vi.mocked(source.readOrganizationIdPage).mockResolvedValueOnce([]).mockResolvedValue([]);
+    readRelationships.mockResolvedValue({
+      cursor: null,
+      relationships: [ghostWorkspace],
+      snapshot: { token: "revision-1" },
+    });
+    vi.mocked(source.findMissingSourceRefs).mockResolvedValue([
+      { kind: "workspace", workspaceId: "ghost-ws" },
+    ]);
+  });
+
+  test("finds a resource unreachable from any organization and reports it", async () => {
+    // A workspace whose organization is also gone cannot be reached by enumerating organizations, which
+    // is the whole reason the full sweep filters by resource type instead.
+    const result = await runAuthzedBackfill(request({ scope: { kind: "all" } }), dependencies);
+
+    expect(result.counters.orphaned).toBe(1);
+    expect(result.counters.pruned).toBe(0);
+    expect(result.orphanScope).toBe("all");
+    expect(result.status).toBe("drifted");
+  });
+
+  test("hands the orphan to a reconciler as a target when pruning", async () => {
+    const result = await runAuthzedBackfill(request({ prune: true, scope: { kind: "all" } }), dependencies);
+
+    expect(result.counters.pruned).toBe(1);
+    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledWith({ workspaceIds: ["ghost-ws"] });
+    expect(result.status).toBe("reconciled");
+  });
+
+  test("prunes nothing when the sweep's orphan count exceeds the cap", async () => {
+    vi.mocked(source.findMissingSourceRefs).mockResolvedValue([
+      { kind: "workspace", workspaceId: "ghost-1" },
+      { kind: "workspace", workspaceId: "ghost-2" },
+    ]);
+
+    const result = await runAuthzedBackfill(
+      request({ maxPrune: 1, prune: true, scope: { kind: "all" } }),
+      dependencies
+    );
+
+    expect(result.counters.pruned).toBe(0);
+    expect(result.counters.skipped).toBe(1);
+    expect(apply.reconcileTeamWorkspace).not.toHaveBeenCalled();
+  });
+
+  test("records a prune failure against no organization, since the resource has none", async () => {
+    apply.reconcileTeamWorkspace.mockResolvedValue({
+      attempts: 3,
+      code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+      retryable: true,
+      status: "failed",
+    });
+
+    const result = await runAuthzedBackfill(request({ prune: true, scope: { kind: "all" } }), dependencies);
+
+    expect(result.counters.pruned).toBe(0);
+    expect(result.failures[0]).toEqual({
+      code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+      organizationId: "",
+      retryable: true,
+    });
+    expect(result.status).toBe("failed");
+  });
+
+  test("marks the report truncated when the sweep itself fails", async () => {
+    readRelationships.mockRejectedValue(
+      new AuthzedError({
+        attempts: 0,
+        code: AUTHZED_ERROR_CODES.LIMIT_EXCEEDED,
+        operation: "read_all_relationships",
+        retryable: false,
+      })
+    );
+
+    const result = await runAuthzedBackfill(request({ prune: true, scope: { kind: "all" } }), dependencies);
+
+    expect(result.truncated).toBe(true);
+    expect(result.counters.pruned).toBe(0);
+    expect(result.failures[0]).toMatchObject({ code: AUTHZED_ERROR_CODES.LIMIT_EXCEEDED });
+    expect(result.status).toBe("failed");
+  });
+});
+
 describe("chunking", () => {
   test("splits a large target list so no reconciler receives an unbounded query", async () => {
     const memberships = Array.from({ length: AUTHZED_BACKFILL_TARGET_CHUNK_SIZE + 1 }, (_unused, index) => ({

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -1,0 +1,471 @@
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { type TAuthzedBackfillRequest, runAuthzedBackfill } from "./backfill";
+import * as source from "./backfill-source";
+import { AUTHZED_BACKFILL_TARGET_CHUNK_SIZE, AUTHZED_MAX_RELATIONSHIP_READS } from "./constants";
+import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
+
+vi.mock("./backfill-source", () => ({
+  findMissingSourceRefs: vi.fn(),
+  organizationExists: vi.fn(),
+  readOrganizationIdPage: vi.fn(),
+  readOrganizationSource: vi.fn(),
+}));
+
+const apply = {
+  reconcileApiKeys: vi.fn(),
+  reconcileMemberships: vi.fn(),
+  reconcileTeamWorkspace: vi.fn(),
+};
+const readRelationships = vi.fn();
+const dependencies = { apply, client: { readRelationships } };
+
+const PROJECTED = { passes: 1, status: "projected" } as const;
+
+const emptySource = {
+  apiKeyIds: [],
+  apiKeyWorkspaceGrants: [],
+  invalidWorkspaceTeamGrants: [],
+  memberships: [],
+  teamIds: [],
+  teamMemberships: [],
+  workspaceIds: [],
+  workspaceTeamGrants: [],
+};
+
+const request = (overrides: Partial<TAuthzedBackfillRequest> = {}): TAuthzedBackfillRequest => ({
+  maxPrune: 500,
+  mode: "apply",
+  prune: false,
+  scope: { kind: "organization", organizationId: "org-1" },
+  ...overrides,
+});
+
+const emptyPage = { cursor: null, relationships: [], snapshot: null };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apply.reconcileApiKeys.mockResolvedValue(PROJECTED);
+  apply.reconcileMemberships.mockResolvedValue(PROJECTED);
+  apply.reconcileTeamWorkspace.mockResolvedValue(PROJECTED);
+  readRelationships.mockResolvedValue(emptyPage);
+  vi.mocked(source.organizationExists).mockResolvedValue(true);
+  vi.mocked(source.readOrganizationSource).mockResolvedValue(emptySource);
+  vi.mocked(source.findMissingSourceRefs).mockResolvedValue([]);
+  vi.mocked(source.readOrganizationIdPage).mockResolvedValue([]);
+});
+
+describe("dry-run inertness", () => {
+  test("performs no reconciliation in dry-run mode", async () => {
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({
+      ...emptySource,
+      memberships: [{ organizationId: "org-1", userId: "user-1" }],
+      teamIds: ["team-1"],
+    });
+
+    const result = await runAuthzedBackfill(request({ mode: "dry_run" }), dependencies);
+
+    expect(apply.reconcileMemberships).not.toHaveBeenCalled();
+    expect(apply.reconcileTeamWorkspace).not.toHaveBeenCalled();
+    expect(apply.reconcileApiKeys).not.toHaveBeenCalled();
+    expect(result.mode).toBe("dry_run");
+    expect(result.counters.reconciled).toBe(0);
+    expect(result.counters.scanned).toBe(1);
+  });
+
+  test("never prunes in dry-run mode even when pruning is requested", async () => {
+    vi.mocked(source.findMissingSourceRefs).mockResolvedValue([{ kind: "team", teamId: "ghost-team" }]);
+    readRelationships.mockResolvedValue({
+      cursor: null,
+      relationships: [
+        {
+          relation: "organization",
+          resource: { objectId: "ghost-team", objectType: "team" },
+          subject: { objectId: "org-1", objectType: "organization" },
+        },
+      ],
+      snapshot: { token: "revision-1" },
+    });
+
+    const result = await runAuthzedBackfill(request({ mode: "dry_run", prune: true }), dependencies);
+
+    expect(result.counters.orphaned).toBe(1);
+    expect(result.counters.pruned).toBe(0);
+    expect(apply.reconcileTeamWorkspace).not.toHaveBeenCalled();
+  });
+
+  test("cannot reach a mutation except through the injected capability", () => {
+    // The structural guarantee behind dry-run inertness: the orchestrator has no import path to a
+    // write. If this regresses, a dry run could mutate regardless of the mode flag — so the guarantee
+    // is asserted against the source rather than inferred from a mock never being called.
+    const moduleSource = readFileSync(new URL("./backfill.ts", import.meta.url), "utf8");
+
+    // Type-only imports are erased at compile time and carry no capability, so only value imports of
+    // the client facade and the reconcilers matter. An import clause contains no semicolon, so
+    // `[^;]` safely spans a multi-line clause.
+    const importsSomethingAtRuntime = (clause: string): boolean => {
+      const trimmed = clause.trim();
+      if (trimmed.startsWith("type ")) {
+        return false;
+      }
+      const specifiers = /^\{([\s\S]*)\}$/.exec(trimmed);
+      if (!specifiers) {
+        return true; // default or namespace import
+      }
+      return specifiers[1]
+        .split(",")
+        .map((specifier) => specifier.trim())
+        .filter(Boolean)
+        .some((specifier) => !specifier.startsWith("type "));
+    };
+
+    const valueImports = [...moduleSource.matchAll(/^import\b([^;]*?)from "([^"]+)";/gm)]
+      .filter(([, clause]) => importsSomethingAtRuntime(clause))
+      .map(([, , path]) => path);
+
+    // `getAuthzedClient` and every reconciler are reachable only through these modules, so verifying
+    // none is imported at runtime is the whole guarantee.
+    for (const mutationModule of ["./client", "./organization-membership", "./team-workspace", "./api-key"]) {
+      expect(valueImports).not.toContain(mutationModule);
+    }
+  });
+});
+
+describe("per-unit failure isolation", () => {
+  test("continues the sweep when one organization fails and reports it", async () => {
+    vi.mocked(source.readOrganizationIdPage)
+      .mockResolvedValueOnce(["org-1", "org-2", "org-3"])
+      .mockResolvedValueOnce([]);
+    vi.mocked(source.readOrganizationSource)
+      .mockResolvedValueOnce({ ...emptySource, teamIds: ["team-1"] })
+      .mockRejectedValueOnce(new Error("statement timeout"))
+      .mockResolvedValueOnce({ ...emptySource, teamIds: ["team-3"] });
+
+    const result = await runAuthzedBackfill(request({ scope: { kind: "all" } }), dependencies);
+
+    expect(result.counters.scanned).toBe(3);
+    expect(result.counters.reconciled).toBe(2);
+    expect(result.counters.failed).toBe(1);
+    expect(result.failures).toEqual([
+      { code: "authzed_internal", organizationId: "org-2", retryable: false },
+    ]);
+    expect(result.status).toBe("failed");
+  });
+
+  test("reports a reconciler failure against its organization without aborting", async () => {
+    vi.mocked(source.readOrganizationIdPage)
+      .mockResolvedValueOnce(["org-1", "org-2"])
+      .mockResolvedValueOnce([]);
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({
+      ...emptySource,
+      teamIds: ["team-1"],
+    });
+    apply.reconcileTeamWorkspace
+      .mockResolvedValueOnce({
+        attempts: 3,
+        code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+        retryable: true,
+        status: "failed",
+      })
+      .mockResolvedValue(PROJECTED);
+
+    const result = await runAuthzedBackfill(request({ scope: { kind: "all" } }), dependencies);
+
+    expect(result.counters.failed).toBe(1);
+    expect(result.counters.reconciled).toBe(1);
+    expect(result.failures[0]).toEqual({
+      code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+      organizationId: "org-1",
+      retryable: true,
+    });
+  });
+
+  test("counts a disabled projection as a failure rather than a success", async () => {
+    // Otherwise a run against an instance with AuthZed switched off would report every organization as
+    // reconciled and exit clean.
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({
+      ...emptySource,
+      teamIds: ["team-1"],
+    });
+    apply.reconcileTeamWorkspace.mockResolvedValue({ status: "disabled" });
+
+    const result = await runAuthzedBackfill(request(), dependencies);
+
+    expect(result.counters.failed).toBe(1);
+    expect(result.counters.reconciled).toBe(0);
+    expect(result.failures[0]).toMatchObject({ code: AUTHZED_ERROR_CODES.DISABLED });
+    expect(result.status).toBe("failed");
+  });
+
+  test("resumes from the last organization it reached", async () => {
+    vi.mocked(source.readOrganizationIdPage)
+      .mockResolvedValueOnce(["org-1", "org-2"])
+      .mockResolvedValueOnce([]);
+
+    const result = await runAuthzedBackfill(request({ scope: { kind: "all" } }), dependencies);
+
+    expect(result.lastOrganizationId).toBe("org-2");
+    expect(source.readOrganizationIdPage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ afterOrganizationId: "org-2" })
+    );
+  });
+
+  test("rejects a scope naming an organization that does not exist", async () => {
+    vi.mocked(source.organizationExists).mockResolvedValue(false);
+
+    await expect(runAuthzedBackfill(request(), dependencies)).rejects.toThrow("Organization not found");
+    expect(apply.reconcileMemberships).not.toHaveBeenCalled();
+  });
+});
+
+describe("idempotency", () => {
+  test("a second run over unchanged state reports no drift and identical counters", async () => {
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({
+      ...emptySource,
+      memberships: [{ organizationId: "org-1", userId: "user-1" }],
+    });
+
+    const first = await runAuthzedBackfill(request(), dependencies);
+    vi.clearAllMocks();
+    apply.reconcileMemberships.mockResolvedValue(PROJECTED);
+    apply.reconcileTeamWorkspace.mockResolvedValue(PROJECTED);
+    apply.reconcileApiKeys.mockResolvedValue(PROJECTED);
+    readRelationships.mockResolvedValue(emptyPage);
+    vi.mocked(source.organizationExists).mockResolvedValue(true);
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({
+      ...emptySource,
+      memberships: [{ organizationId: "org-1", userId: "user-1" }],
+    });
+    vi.mocked(source.findMissingSourceRefs).mockResolvedValue([]);
+    const second = await runAuthzedBackfill(request(), dependencies);
+
+    expect(second).toEqual(first);
+    expect(second.counters.orphaned).toBe(0);
+    expect(second.status).toBe("reconciled");
+  });
+});
+
+describe("pruning", () => {
+  const ghostTeamRelationship = {
+    relation: "organization",
+    resource: { objectId: "ghost-team", objectType: "team" },
+    subject: { objectId: "org-1", objectType: "organization" },
+  };
+
+  beforeEach(() => {
+    readRelationships.mockResolvedValue({
+      cursor: null,
+      relationships: [ghostTeamRelationship],
+      snapshot: { token: "revision-1" },
+    });
+    vi.mocked(source.findMissingSourceRefs).mockResolvedValue([{ kind: "team", teamId: "ghost-team" }]);
+  });
+
+  test("reports drift without pruning by default", async () => {
+    const result = await runAuthzedBackfill(request(), dependencies);
+
+    expect(result.counters.orphaned).toBe(1);
+    expect(result.counters.pruned).toBe(0);
+    expect(result.status).toBe("drifted");
+    expect(result.orphans).toEqual([{ kind: "team", teamId: "ghost-team" }]);
+    // The write half still runs, but the orphan is not handed to it.
+    expect(apply.reconcileTeamWorkspace).not.toHaveBeenCalledWith(
+      expect.objectContaining({ teamIds: expect.arrayContaining(["ghost-team"]) })
+    );
+  });
+
+  test("feeds the orphan to a reconciler as a target when pruning", async () => {
+    const result = await runAuthzedBackfill(request({ prune: true }), dependencies);
+
+    expect(result.counters.pruned).toBe(1);
+    expect(result.status).toBe("reconciled");
+    // Handed over as a target, never as a delete instruction: the reconciler re-reads PostgreSQL and
+    // decides, so a team recreated in the meantime is written rather than deleted.
+    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledWith({ teamIds: ["ghost-team"] });
+  });
+
+  test("prunes nothing for a unit whose orphan count exceeds the cap", async () => {
+    vi.mocked(source.findMissingSourceRefs).mockResolvedValue([
+      { kind: "team", teamId: "ghost-1" },
+      { kind: "team", teamId: "ghost-2" },
+    ]);
+
+    const result = await runAuthzedBackfill(request({ maxPrune: 1, prune: true }), dependencies);
+
+    // A large orphan count is a symptom, not a big cleanup job. Aborting before the first delete keeps
+    // a misdirected run a loud report instead of a partly-destroyed graph.
+    expect(result.counters.pruned).toBe(0);
+    expect(result.counters.skipped).toBe(1);
+    expect(result.status).toBe("drifted");
+    expect(apply.reconcileTeamWorkspace).not.toHaveBeenCalledWith(
+      expect.objectContaining({ teamIds: expect.arrayContaining(["ghost-1"]) })
+    );
+  });
+
+  test("marks the report incomplete when an observation is abandoned", async () => {
+    readRelationships.mockRejectedValue(
+      new AuthzedError({
+        attempts: 1,
+        code: AUTHZED_ERROR_CODES.FAILED_PRECONDITION,
+        operation: "read_relationships",
+        retryable: false,
+      })
+    );
+
+    const result = await runAuthzedBackfill(request({ prune: true }), dependencies);
+
+    // Fewer relationships observed means fewer orphans found, so the result must not read as complete.
+    expect(result.truncated).toBe(true);
+    expect(result.counters.pruned).toBe(0);
+    expect(result.counters.failed).toBe(1);
+    expect(result.failures[0]).toMatchObject({ code: AUTHZED_ERROR_CODES.FAILED_PRECONDITION });
+  });
+
+  test("propagates a source-read failure instead of treating records as absent", async () => {
+    vi.mocked(source.findMissingSourceRefs).mockRejectedValue(new Error("connection pool exhausted"));
+
+    const result = await runAuthzedBackfill(request({ prune: true }), dependencies);
+
+    expect(result.counters.pruned).toBe(0);
+    expect(result.counters.orphaned).toBe(0);
+    expect(result.counters.failed).toBe(1);
+    expect(result.truncated).toBe(true);
+  });
+});
+
+describe("scope and observation completeness", () => {
+  test("single-organization scope observes only resources PostgreSQL still knows about", async () => {
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({
+      ...emptySource,
+      apiKeyIds: ["key-1"],
+      teamIds: ["team-1"],
+      workspaceIds: ["ws-1"],
+    });
+
+    const result = await runAuthzedBackfill(request(), dependencies);
+
+    // A resource whose row is already gone is unreachable from its organization, so this scope must not
+    // claim completeness.
+    expect(result.orphanScope).toBe("known_resources");
+    expect(readRelationships.mock.calls.map(([query]) => query.filter)).toEqual([
+      { resourceId: "org-1", resourceType: "organization" },
+      { resourceId: "team-1", resourceType: "team" },
+      { resourceId: "ws-1", resourceType: "workspace" },
+      { resourceId: "key-1", resourceType: "api_key" },
+    ]);
+  });
+
+  test("full scope sweeps every managed resource type and claims completeness", async () => {
+    vi.mocked(source.readOrganizationIdPage).mockResolvedValueOnce(["org-1"]).mockResolvedValueOnce([]);
+
+    const result = await runAuthzedBackfill(request({ scope: { kind: "all" } }), dependencies);
+
+    expect(result.orphanScope).toBe("all");
+    expect(readRelationships.mock.calls.map(([query]) => query.filter)).toEqual([
+      { resourceType: "api_key" },
+      { resourceType: "organization" },
+      { resourceType: "team" },
+      { resourceType: "workspace" },
+    ]);
+    expect(
+      readRelationships.mock.calls.every(([query]) => query.limit === AUTHZED_MAX_RELATIONSHIP_READS)
+    ).toBe(true);
+  });
+
+  test("reports the revision the observation completed at", async () => {
+    readRelationships.mockResolvedValue({
+      cursor: null,
+      relationships: [],
+      snapshot: { token: "revision-42" },
+    });
+
+    const result = await runAuthzedBackfill(request(), dependencies);
+
+    // Handed to shadow evaluation as a freshness floor once the graph is known good.
+    expect(result.completedAtSnapshot).toBe("revision-42");
+  });
+
+  test("counts deliberately unprojected relationships as ignored, never orphaned", async () => {
+    readRelationships.mockResolvedValue({
+      cursor: null,
+      relationships: [
+        {
+          relation: "workspace",
+          resource: { objectId: "survey-1", objectType: "survey" },
+          subject: { objectId: "ws-1", objectType: "workspace" },
+        },
+      ],
+      snapshot: { token: "revision-1" },
+    });
+
+    const result = await runAuthzedBackfill(request({ prune: true }), dependencies);
+
+    expect(result.counters.ignored).toBe(1);
+    expect(result.counters.orphaned).toBe(0);
+    expect(result.counters.pruned).toBe(0);
+  });
+
+  test("reports unrecognized relationships without reconciling them", async () => {
+    readRelationships.mockResolvedValue({
+      cursor: null,
+      relationships: [
+        {
+          relation: "superuser",
+          resource: { objectId: "org-1", objectType: "organization" },
+          subject: { objectId: "user-1", objectType: "user" },
+        },
+      ],
+      snapshot: { token: "revision-1" },
+    });
+
+    const result = await runAuthzedBackfill(request({ prune: true }), dependencies);
+
+    expect(result.unmanaged).toEqual([
+      { objectId: "org-1", objectType: "organization", relation: "superuser" },
+    ]);
+    expect(result.counters.pruned).toBe(0);
+  });
+
+  test("reports a cross-organization workspace-team grant without acting on it", async () => {
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({
+      ...emptySource,
+      invalidWorkspaceTeamGrants: [{ teamId: "foreign-team", workspaceId: "ws-1" }],
+    });
+
+    const result = await runAuthzedBackfill(request(), dependencies);
+
+    expect(result.counters.invalid).toBe(1);
+    expect(apply.reconcileTeamWorkspace).not.toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceTeamGrants: expect.arrayContaining([expect.anything()]) })
+    );
+  });
+});
+
+describe("chunking", () => {
+  test("splits a large target list so no reconciler receives an unbounded query", async () => {
+    const memberships = Array.from({ length: AUTHZED_BACKFILL_TARGET_CHUNK_SIZE + 1 }, (_unused, index) => ({
+      organizationId: "org-1",
+      userId: `user-${index}`,
+    }));
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({ ...emptySource, memberships });
+
+    await runAuthzedBackfill(request(), dependencies);
+
+    expect(apply.reconcileMemberships).toHaveBeenCalledTimes(2);
+    expect(apply.reconcileMemberships.mock.calls[0][0].memberships).toHaveLength(
+      AUTHZED_BACKFILL_TARGET_CHUNK_SIZE
+    );
+    expect(apply.reconcileMemberships.mock.calls[1][0].memberships).toHaveLength(1);
+  });
+
+  test("never hands an empty target list to a reconciler", async () => {
+    // The write facade rejects an empty batch as an invalid request.
+    await runAuthzedBackfill(request(), dependencies);
+
+    expect(apply.reconcileMemberships).not.toHaveBeenCalled();
+    expect(apply.reconcileTeamWorkspace).not.toHaveBeenCalled();
+    expect(apply.reconcileApiKeys).not.toHaveBeenCalled();
+    expect(apply.reconcileMemberships).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -679,6 +679,43 @@ describe("full-scope orphan sweep", () => {
     expect(result.status).toBe("reconciled");
   });
 
+  test("keeps counting after the cap is spent, so the reported total is the real magnitude", async () => {
+    // The count is the diagnostic. Stopping at the cap would report 2 when there are 4, and "a few" versus
+    // "far more than expected" are what tell an operator whether they aimed at the wrong database.
+    readRelationships.mockImplementation(({ cursor, filter }) =>
+      Promise.resolve(
+        filter.resourceType === "workspace" && cursor === undefined
+          ? {
+              cursor: { token: "page-2" },
+              relationships: [ghostWorkspace, ghostWorkspace],
+              snapshot: { token: "revision-1" },
+            }
+          : filter.resourceType === "workspace"
+            ? {
+                cursor: null,
+                relationships: [ghostWorkspace, ghostWorkspace],
+                snapshot: { token: "revision-1" },
+              }
+            : emptyPage
+      )
+    );
+    vi.mocked(source.findMissingSourceRefs).mockImplementation((refs) =>
+      Promise.resolve(refs.length > 0 ? [{ kind: "workspace", workspaceId: "ghost-ws" }] : [])
+    );
+
+    const result = await runAuthzedBackfill(
+      request({ maxPrune: 1, prune: true, scope: { kind: "all" } }),
+      dependencies
+    );
+
+    // Two pages, each yielding one orphan. The budget of one is spent on the first; the second exceeds
+    // it and halts pruning — but both are still counted, which is the point.
+    expect(result.counters.orphaned).toBe(2);
+    expect(result.counters.pruned).toBe(1);
+    // Reported once, not once per page.
+    expect(result.counters.skipped).toBe(1);
+  });
+
   test("prunes nothing when the sweep's orphan count exceeds the cap", async () => {
     vi.mocked(source.findMissingSourceRefs).mockResolvedValue([
       { kind: "workspace", workspaceId: "ghost-1" },

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { type TAuthzedBackfillRequest, runAuthzedBackfill } from "./backfill";
 import * as source from "./backfill-source";
+import type { TAuthzedOrganizationSource } from "./backfill-source";
 import { AUTHZED_BACKFILL_TARGET_CHUNK_SIZE, AUTHZED_MAX_RELATIONSHIP_READS } from "./constants";
 import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
 
@@ -24,9 +25,12 @@ const dependencies = { apply, client: { readRelationships } };
 
 const PROJECTED = { passes: 1, status: "projected" } as const;
 
-const emptySource = {
+// Annotated, so adding a field to the source type is a compile error here rather than a pile of
+// `undefined.length` failures at runtime.
+const emptySource: TAuthzedOrganizationSource = {
   apiKeyIds: [],
   apiKeyWorkspaceGrants: [],
+  invalidApiKeyWorkspaceGrants: [],
   invalidWorkspaceTeamGrants: [],
   memberships: [],
   teamIds: [],
@@ -57,6 +61,7 @@ beforeEach(() => {
   vi.mocked(source.findMismatchedParentEdges).mockResolvedValue([]);
   vi.mocked(source.readWorkspaceSource).mockResolvedValue({
     apiKeyWorkspaceGrants: [],
+    organizationId: "org-1",
     workspaceExists: true,
     workspaceTeamGrants: [],
   });
@@ -635,6 +640,77 @@ describe("scope and observation completeness", () => {
   });
 });
 
+describe("workspace scope", () => {
+  const missingWorkspace = (): void => {
+    vi.mocked(source.readWorkspaceSource).mockResolvedValue({
+      apiKeyWorkspaceGrants: [],
+      organizationId: null,
+      workspaceExists: false,
+      workspaceTeamGrants: [],
+    });
+  };
+
+  test("does not remove a missing workspace's relationships without permission to prune", async () => {
+    // Naming a workspace with no row is what removes *every* relationship on it — team grants and
+    // API-key grants included. That is a prune, so it needs the prune flags rather than happening as a
+    // side effect of `--apply` on a stale ID.
+    missingWorkspace();
+
+    const result = await runAuthzedBackfill(
+      request({ scope: { kind: "workspace", workspaceId: "ghost-ws" } }),
+      dependencies
+    );
+
+    expect(apply.reconcileTeamWorkspace).not.toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceIds: ["ghost-ws"] })
+    );
+    expect(result.counters.pruned).toBe(0);
+  });
+
+  test("removes a missing workspace's relationships when pruning is permitted", async () => {
+    missingWorkspace();
+
+    await runAuthzedBackfill(
+      request({ prune: true, scope: { kind: "workspace", workspaceId: "ghost-ws" } }),
+      dependencies
+    );
+
+    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceIds: ["ghost-ws"] })
+    );
+  });
+
+  test("still projects the parent edge of a workspace that exists", async () => {
+    // The same target list drives the write when the row is present, so gating it on pruning must not
+    // stop an existing workspace's own parent edge from being projected.
+    await runAuthzedBackfill(request({ scope: { kind: "workspace", workspaceId: "ws-1" } }), dependencies);
+
+    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceIds: ["ws-1"] })
+    );
+  });
+
+  test("attributes a failure to the owning organization rather than to no tenant", async () => {
+    apply.reconcileTeamWorkspace.mockResolvedValue({
+      attempts: 1,
+      code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+      retryable: true,
+      status: "failed",
+    });
+
+    const result = await runAuthzedBackfill(
+      request({ scope: { kind: "workspace", workspaceId: "ws-1" } }),
+      dependencies
+    );
+
+    // The empty string is the sweep's marker for an orphan with no organization left, so a workspace that
+    // still has a row must not report it.
+    expect(result.failures).toEqual([
+      { code: AUTHZED_ERROR_CODES.UNAVAILABLE, organizationId: "org-1", retryable: true },
+    ]);
+  });
+});
+
 describe("full-scope orphan sweep", () => {
   const ghostWorkspace = {
     relation: "organization",
@@ -679,28 +755,62 @@ describe("full-scope orphan sweep", () => {
     expect(result.status).toBe("reconciled");
   });
 
-  test("keeps counting after the cap is spent, so the reported total is the real magnitude", async () => {
-    // The count is the diagnostic. Stopping at the cap would report 2 when there are 4, and "a few" versus
-    // "far more than expected" are what tell an operator whether they aimed at the wrong database.
+  test("prunes nothing at all when a later page pushes the total past the cap", async () => {
+    // The cap is an abort-before-delete guard, so it has to be decided against the *whole* sweep. Enforced
+    // per page it would delete every page that fit and stop at the one that did not — so a run aimed at
+    // the wrong database would revoke a cap's worth of live access instead of revoking none.
+    const secondGhost = {
+      relation: "organization",
+      resource: { objectId: "ghost-ws-2", objectType: "workspace" },
+      subject: { objectId: "gone-org", objectType: "organization" },
+    };
     readRelationships.mockImplementation(({ cursor, filter }) =>
       Promise.resolve(
-        filter.resourceType === "workspace" && cursor === undefined
-          ? {
-              cursor: { token: "page-2" },
-              relationships: [ghostWorkspace, ghostWorkspace],
-              snapshot: { token: "revision-1" },
-            }
-          : filter.resourceType === "workspace"
+        filter.resourceType !== "workspace"
+          ? emptyPage
+          : cursor === undefined
             ? {
-                cursor: null,
-                relationships: [ghostWorkspace, ghostWorkspace],
+                cursor: { token: "page-2" },
+                relationships: [ghostWorkspace],
                 snapshot: { token: "revision-1" },
               }
-            : emptyPage
+            : { cursor: null, relationships: [secondGhost], snapshot: { token: "revision-1" } }
       )
     );
-    vi.mocked(source.findMissingSourceRefs).mockImplementation((refs) =>
-      Promise.resolve(refs.length > 0 ? [{ kind: "workspace", workspaceId: "ghost-ws" }] : [])
+    vi.mocked(source.findMissingSourceRefs).mockImplementation((refs) => Promise.resolve(refs));
+
+    const result = await runAuthzedBackfill(
+      request({ maxPrune: 1, prune: true, scope: { kind: "all" } }),
+      dependencies
+    );
+
+    // Both counted — the total is the diagnostic, and it is what says how far off the run is.
+    expect(result.counters.orphaned).toBe(2);
+    // The first page fit the budget of one. It is still not deleted.
+    expect(result.counters.pruned).toBe(0);
+    expect(result.counters.skipped).toBe(1);
+    expect(apply.reconcileTeamWorkspace).not.toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceIds: expect.arrayContaining(["ghost-ws"]) })
+    );
+    expect(result.status).toBe("drifted");
+  });
+
+  test("counts a record implied by two pages once", async () => {
+    // SpiceDB returns alternate relations on one resource grouped by relation rather than adjacently, so
+    // the tuples implying a single record straddle a page boundary in any tenant larger than a page.
+    // Counting it twice would inflate the total that the cap is compared against.
+    readRelationships.mockImplementation(({ cursor, filter }) =>
+      Promise.resolve(
+        filter.resourceType !== "workspace"
+          ? emptyPage
+          : cursor === undefined
+            ? {
+                cursor: { token: "page-2" },
+                relationships: [ghostWorkspace],
+                snapshot: { token: "revision-1" },
+              }
+            : { cursor: null, relationships: [ghostWorkspace], snapshot: { token: "revision-1" } }
+      )
     );
 
     const result = await runAuthzedBackfill(
@@ -708,12 +818,11 @@ describe("full-scope orphan sweep", () => {
       dependencies
     );
 
-    // Two pages, each yielding one orphan. The budget of one is spent on the first; the second exceeds
-    // it and halts pruning — but both are still counted, which is the point.
-    expect(result.counters.orphaned).toBe(2);
+    expect(result.counters.orphaned).toBe(1);
+    expect(result.orphans).toEqual([{ kind: "workspace", workspaceId: "ghost-ws" }]);
+    // Deduplicated to one, so it fits the budget of one and is pruned rather than skipped.
     expect(result.counters.pruned).toBe(1);
-    // Reported once, not once per page.
-    expect(result.counters.skipped).toBe(1);
+    expect(result.counters.skipped).toBe(0);
   });
 
   test("prunes nothing when the sweep's orphan count exceeds the cap", async () => {

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -382,7 +382,9 @@ describe("pruning", () => {
     expect(result.status).toBe("reconciled");
     // Handed over as a target, never as a delete instruction: the reconciler re-reads PostgreSQL and
     // decides, so a team recreated in the meantime is written rather than deleted.
-    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledWith({ teamIds: ["ghost-team"] });
+    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({ teamIds: ["ghost-team"] })
+    );
   });
 
   test("prunes nothing for a unit whose orphan count exceeds the cap", async () => {
@@ -448,11 +450,13 @@ describe("scope and observation completeness", () => {
     // A resource whose row is already gone is unreachable from its organization, so this scope must not
     // claim completeness.
     expect(result.orphanScope).toBe("known_resources");
+    // The trailing organization read is the closing freshness capture, not an observation.
     expect(readRelationships.mock.calls.map(([query]) => query.filter)).toEqual([
       { resourceId: "org-1", resourceType: "organization" },
       { resourceId: "team-1", resourceType: "team" },
       { resourceId: "ws-1", resourceType: "workspace" },
       { resourceId: "key-1", resourceType: "api_key" },
+      { resourceType: "organization" },
     ]);
   });
 
@@ -467,23 +471,62 @@ describe("scope and observation completeness", () => {
       { resourceType: "organization" },
       { resourceType: "team" },
       { resourceType: "workspace" },
+      // The closing freshness capture, which wants one relationship rather than a page.
+      { resourceType: "organization" },
     ]);
     expect(
-      readRelationships.mock.calls.every(([query]) => query.limit === AUTHZED_MAX_RELATIONSHIP_READS)
+      readRelationships.mock.calls
+        .slice(0, -1)
+        .every(([query]) => query.limit === AUTHZED_MAX_RELATIONSHIP_READS)
     ).toBe(true);
   });
 
-  test("reports the revision the observation completed at", async () => {
+  test("reports a revision captured after the run's own writes", async () => {
+    // The point of the field: shadow evaluation uses it as an `at_least_as_fresh` floor, so a revision
+    // read *before* the writes would be the exact opposite of a floor. Ordering is what is asserted here.
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({ ...emptySource, teamIds: ["team-1"] });
+    let written = false;
+    apply.reconcileTeamWorkspace.mockImplementation(async () => {
+      written = true;
+      return PROJECTED;
+    });
+    readRelationships.mockImplementation(() =>
+      Promise.resolve({
+        cursor: null,
+        relationships: [],
+        snapshot: { token: written ? "after-writes" : "before-writes" },
+      })
+    );
+
+    const result = await runAuthzedBackfill(request(), dependencies);
+
+    expect(result.completedAtSnapshot).toBe("after-writes");
+  });
+
+  test("reports no revision for a dry run, which wrote nothing to be fresh relative to", async () => {
     readRelationships.mockResolvedValue({
       cursor: null,
       relationships: [],
       snapshot: { token: "revision-42" },
     });
 
+    const result = await runAuthzedBackfill(request({ mode: "dry_run" }), dependencies);
+
+    expect(result.completedAtSnapshot).toBeNull();
+  });
+
+  test("reports no revision rather than a stale one when the closing read fails", async () => {
+    // No teams or workspaces, so the observation is a single organization read and the second call is the
+    // closing capture — which is the one that has to fail for this to test what it claims.
+    readRelationships
+      .mockResolvedValueOnce({ cursor: null, relationships: [], snapshot: { token: "observed" } })
+      .mockRejectedValue(new Error("connection reset"));
+
     const result = await runAuthzedBackfill(request(), dependencies);
 
-    // Handed to shadow evaluation as a freshness floor once the graph is known good.
-    expect(result.completedAtSnapshot).toBe("revision-42");
+    // A floor that might pre-date the writes is worse than no floor at all.
+    expect(result.completedAtSnapshot).toBeNull();
+    expect(result.counters.reconciled).toBe(1);
   });
 
   test("counts deliberately unprojected relationships as ignored, never orphaned", async () => {
@@ -580,7 +623,9 @@ describe("full-scope orphan sweep", () => {
     const result = await runAuthzedBackfill(request({ prune: true, scope: { kind: "all" } }), dependencies);
 
     expect(result.counters.pruned).toBe(1);
-    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledWith({ workspaceIds: ["ghost-ws"] });
+    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceIds: ["ghost-ws"] })
+    );
     expect(result.status).toBe("reconciled");
   });
 
@@ -693,7 +738,10 @@ describe("chunking", () => {
     });
   });
 
-  test("omits an empty list from a combined call rather than sending it", async () => {
+  test("passes an empty list through untouched rather than asserting a narrowed object type", async () => {
+    // Chunking builds each call by narrowing a full target object, so lists with nothing in them arrive
+    // as `[]`. Every reconciler treats that as a no-op, and it is what lets the chunker avoid a type
+    // assertion that would silently keep compiling if a target field ever became required.
     vi.mocked(source.readOrganizationSource).mockResolvedValue({
       ...emptySource,
       teamIds: ["team-1"],
@@ -701,7 +749,12 @@ describe("chunking", () => {
 
     await runAuthzedBackfill(request(), dependencies);
 
-    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledWith({ teamIds: ["team-1"] });
+    expect(apply.reconcileTeamWorkspace).toHaveBeenCalledWith({
+      teamIds: ["team-1"],
+      teamMemberships: [],
+      workspaceIds: [],
+      workspaceTeamGrants: [],
+    });
   });
 
   test("bounds each list independently, so call count follows the longest list", async () => {
@@ -719,11 +772,13 @@ describe("chunking", () => {
 
     expect(apply.reconcileTeamWorkspace).toHaveBeenCalledTimes(2);
     // The short list is exhausted by the first call and must not be resent.
-    expect(apply.reconcileTeamWorkspace.mock.calls[0][0]).toEqual({
+    expect(apply.reconcileTeamWorkspace.mock.calls[0][0]).toMatchObject({
       teamIds: ["team-1"],
       teamMemberships: teamMemberships.slice(0, AUTHZED_BACKFILL_TARGET_CHUNK_SIZE),
     });
-    expect(apply.reconcileTeamWorkspace.mock.calls[1][0]).toEqual({
+    // The short list is exhausted by the first call, so the second must not resend it.
+    expect(apply.reconcileTeamWorkspace.mock.calls[1][0]).toMatchObject({
+      teamIds: [],
       teamMemberships: teamMemberships.slice(AUTHZED_BACKFILL_TARGET_CHUNK_SIZE),
     });
   });

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -755,6 +755,31 @@ describe("full-scope orphan sweep", () => {
     expect(result.status).toBe("reconciled");
   });
 
+  test("prunes every orphan inside the budget, even past the 100-entry reporting cap", async () => {
+    // The reported lists cap at 100 so a broken instance cannot emit a huge line; the prune budget is
+    // 500. Conflating the two would silently prune only the first 100 of a run well inside its budget
+    // and report that as a success.
+    const ghosts = Array.from({ length: 150 }, (_unused, index) => ({
+      kind: "workspace" as const,
+      workspaceId: `ghost-${index}`,
+    }));
+    vi.mocked(source.findMissingSourceRefs).mockImplementation((refs) =>
+      Promise.resolve(refs.length > 0 ? ghosts : [])
+    );
+
+    const result = await runAuthzedBackfill(
+      request({ maxPrune: 500, prune: true, scope: { kind: "all" } }),
+      dependencies
+    );
+
+    expect(result.counters.orphaned).toBe(150);
+    expect(result.counters.pruned).toBe(150);
+    expect(result.counters.skipped).toBe(0);
+    // Reported lists stay capped while the counters carry the true totals.
+    expect(result.orphans).toHaveLength(100);
+    expect(result.status).toBe("reconciled");
+  });
+
   test("prunes nothing at all when a later page pushes the total past the cap", async () => {
     // The cap is an abort-before-delete guard, so it has to be decided against the *whole* sweep. Enforced
     // per page it would delete every page that fit and stop at the one that did not — so a run aimed at

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -164,7 +164,7 @@ describe("per-unit failure isolation", () => {
     expect(result.counters.reconciled).toBe(2);
     expect(result.counters.failed).toBe(1);
     expect(result.failures).toEqual([
-      { code: "authzed_internal", organizationId: "org-2", retryable: false },
+      { attempts: 1, code: "authzed_internal", organizationId: "org-2", retryable: false },
     ]);
     expect(result.status).toBe("failed");
   });
@@ -191,6 +191,7 @@ describe("per-unit failure isolation", () => {
     expect(result.counters.failed).toBe(1);
     expect(result.counters.reconciled).toBe(1);
     expect(result.failures[0]).toEqual({
+      attempts: 3,
       code: AUTHZED_ERROR_CODES.UNAVAILABLE,
       organizationId: "org-1",
       retryable: true,
@@ -710,7 +711,7 @@ describe("workspace scope", () => {
     // The empty string is the sweep's marker for an orphan with no organization left, so a workspace that
     // still has a row must not report it.
     expect(result.failures).toEqual([
-      { code: AUTHZED_ERROR_CODES.UNAVAILABLE, organizationId: "org-1", retryable: true },
+      { attempts: 1, code: AUTHZED_ERROR_CODES.UNAVAILABLE, organizationId: "org-1", retryable: true },
     ]);
   });
 });
@@ -904,6 +905,7 @@ describe("full-scope orphan sweep", () => {
 
     expect(result.counters.pruned).toBe(0);
     expect(result.failures[0]).toEqual({
+      attempts: 3,
       code: AUTHZED_ERROR_CODES.UNAVAILABLE,
       organizationId: "",
       retryable: true,

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -313,6 +313,56 @@ describe("detecting records SpiceDB is missing", () => {
   });
 });
 
+describe("counting each finding once", () => {
+  const ghostTeam = {
+    relation: "organization",
+    resource: { objectId: "ghost-team", objectType: "team" },
+    subject: { objectId: "org-1", objectType: "organization" },
+  };
+
+  beforeEach(() => {
+    vi.mocked(source.readOrganizationIdPage).mockResolvedValueOnce(["org-1"]).mockResolvedValue([]);
+    vi.mocked(source.readOrganizationSource).mockResolvedValue({
+      ...emptySource,
+      teamIds: ["ghost-team"],
+    });
+    // The orphan is reachable two ways: from org-1's own team list, and from the `team` type sweep.
+    readRelationships.mockImplementation(({ filter }) =>
+      Promise.resolve(
+        filter.resourceType === "team"
+          ? { cursor: null, relationships: [ghostTeam], snapshot: { token: "revision-1" } }
+          : emptyPage
+      )
+    );
+    vi.mocked(source.findMissingSourceRefs).mockImplementation((refs) =>
+      Promise.resolve(refs.filter((ref) => ref.kind === "team" && ref.teamId === "ghost-team"))
+    );
+  });
+
+  test.each([
+    ["the default run, which is a dry run over every organization", { kind: "all" } as const],
+    ["a single organization", { kind: "organization", organizationId: "org-1" } as const],
+  ])("counts one orphaned relationship once in %s", async (_label, scope) => {
+    // A full scope observes per organization *and* sweeps globally. Only one of them may own the orphan
+    // accounting, or every stale relationship is reported twice — and inflated counts both mislead an
+    // operator and eat the prune budget twice over.
+    const result = await runAuthzedBackfill(request({ mode: "dry_run", scope }), dependencies);
+
+    expect(result.counters.orphaned).toBe(1);
+  });
+
+  test("still reports the missing direction on a full-scope dry run", async () => {
+    // The whole reason the per-organization observation runs at all under a full scope.
+    const result = await runAuthzedBackfill(
+      request({ mode: "dry_run", scope: { kind: "all" } }),
+      dependencies
+    );
+
+    expect(result.counters.missing).toBe(0);
+    expect(result.status).toBe("drifted");
+  });
+});
+
 describe("detecting a cross-tenant parent edge", () => {
   const foreignParent = {
     relation: "organization",

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -428,14 +428,14 @@ describe("detecting a cross-tenant parent edge", () => {
       snapshot: { token: "revision-1" },
     });
     vi.mocked(source.findMismatchedParentEdges).mockResolvedValue([
-      { childId: "ws-1", childType: "workspace", organizationId: "other-org" },
+      { childId: "ws-1", childType: "workspace", organizationId: "other-org", relation: "organization" },
     ]);
 
     const result = await runAuthzedBackfill(request({ prune: true }), dependencies);
 
     expect(result.counters.mismatchedParents).toBe(1);
     expect(result.mismatchedParents).toEqual([
-      { childId: "ws-1", childType: "workspace", organizationId: "other-org" },
+      { childId: "ws-1", childType: "workspace", organizationId: "other-org", relation: "organization" },
     ]);
     // Removing it would mean deleting a relation the workspace legitimately needs one of, so it is left
     // for a human — but it must force a non-clean status.

--- a/apps/web/lib/authzed/backfill.test.ts
+++ b/apps/web/lib/authzed/backfill.test.ts
@@ -3,7 +3,11 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { type TAuthzedBackfillRequest, runAuthzedBackfill } from "./backfill";
 import * as source from "./backfill-source";
 import type { TAuthzedOrganizationSource } from "./backfill-source";
-import { AUTHZED_BACKFILL_TARGET_CHUNK_SIZE, AUTHZED_MAX_RELATIONSHIP_READS } from "./constants";
+import {
+  AUTHZED_BACKFILL_TARGET_CHUNK_SIZE,
+  AUTHZED_MAX_RELATIONSHIP_READS,
+  AUTHZED_MAX_TRACKED_ORPHAN_REFS,
+} from "./constants";
 import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
 
 vi.mock("./backfill-source", () => ({
@@ -817,6 +821,28 @@ describe("full-scope orphan sweep", () => {
     expect(apply.reconcileTeamWorkspace).not.toHaveBeenCalledWith(
       expect.objectContaining({ workspaceIds: expect.arrayContaining(["ghost-ws"]) })
     );
+    expect(result.status).toBe("drifted");
+  });
+
+  test("reports truncated rather than growing the dedupe set without bound", async () => {
+    // The dedupe set is the one structure in a streaming sweep that grows with the store. Past its
+    // bound the sweep keeps counting and says so, instead of holding a key for every record on the
+    // heap — and a run this far past the prune cap deletes nothing on the strength of it anyway.
+    const ghosts = Array.from({ length: AUTHZED_MAX_TRACKED_ORPHAN_REFS + 1 }, (_unused, index) => ({
+      kind: "workspace" as const,
+      workspaceId: `ghost-${index}`,
+    }));
+    vi.mocked(source.findMissingSourceRefs).mockImplementation((refs) =>
+      Promise.resolve(refs.length > 0 ? ghosts : [])
+    );
+
+    const result = await runAuthzedBackfill(request({ prune: true, scope: { kind: "all" } }), dependencies);
+
+    expect(result.counters.orphaned).toBe(AUTHZED_MAX_TRACKED_ORPHAN_REFS + 1);
+    expect(result.truncated).toBe(true);
+    // Far past the cap, so nothing is deleted and the run degrades into a report.
+    expect(result.counters.pruned).toBe(0);
+    expect(result.counters.skipped).toBe(1);
     expect(result.status).toBe("drifted");
   });
 

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -13,7 +13,11 @@ import {
   readOrganizationSource,
 } from "./backfill-source";
 import type { TAuthzedClient, TAuthzedRelationship } from "./client";
-import { AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE, AUTHZED_BACKFILL_TARGET_CHUNK_SIZE } from "./constants";
+import {
+  AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE,
+  AUTHZED_BACKFILL_TARGET_CHUNK_SIZE,
+  AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES,
+} from "./constants";
 import { AuthzedError } from "./errors";
 import type { TOrganizationMembershipProjectionTargets } from "./organization-membership";
 import type { TAuthzedProjectionResult } from "./projection";
@@ -132,14 +136,6 @@ export type TAuthzedBackfillResult = Readonly<{
 /** Entries reported individually before the list is capped and only counters remain accurate. */
 const MAX_REPORTED_ENTRIES = 100;
 
-const chunk = <TItem>(items: ReadonlyArray<TItem>, size: number): ReadonlyArray<ReadonlyArray<TItem>> => {
-  const chunks: TItem[][] = [];
-  for (let start = 0; start < items.length; start += size) {
-    chunks.push(items.slice(start, start + size));
-  }
-  return chunks;
-};
-
 const toErrorCode = (error: unknown): Readonly<{ code: string; retryable: boolean }> =>
   error instanceof AuthzedError
     ? { code: error.code, retryable: error.retryable }
@@ -231,17 +227,42 @@ const mergeTargets = (left: TReconcileTargets, right: TReconcileTargets): TRecon
  * sweep. `"disabled"` counts as a failure rather than a success — otherwise a run against an instance
  * with AuthZed switched off would report every organization as reconciled.
  */
-const runChunked = async <TItem, TTargets>(
+/**
+ * Run one reconciler over chunked targets, stopping at the first chunk that does not project.
+ *
+ * A reconciler accepts several target lists at once and reads one PostgreSQL snapshot covering all of
+ * them, so every list it understands is passed in a single call. Splitting them would multiply the
+ * snapshot reads and the verification passes for no benefit.
+ *
+ * Chunking bounds each list independently, because each becomes its own `OR` clause in the snapshot
+ * query. Call *i* takes chunk *i* of every list, so the number of calls is set by the longest list
+ * rather than by their total.
+ *
+ * Returns `null` when every list was empty, so nothing reaches a reconciler — the write facade rejects
+ * an empty update batch.
+ */
+const runChunked = async <TTargets extends Readonly<Record<string, ReadonlyArray<unknown>>>>(
   reconcile: (targets: TTargets) => Promise<TAuthzedProjectionResult>,
-  items: ReadonlyArray<TItem>,
-  buildTargets: (chunkItems: ReadonlyArray<TItem>) => TTargets
+  targets: TTargets
 ): Promise<TAuthzedProjectionResult | null> => {
-  if (items.length === 0) {
+  const entries = Object.entries(targets).filter(([, items]) => items.length > 0);
+  if (entries.length === 0) {
     return null;
   }
 
-  for (const chunkItems of chunk(items, AUTHZED_BACKFILL_TARGET_CHUNK_SIZE)) {
-    const result = await reconcile(buildTargets(chunkItems));
+  const chunkCount = Math.max(
+    ...entries.map(([, items]) => Math.ceil(items.length / AUTHZED_BACKFILL_TARGET_CHUNK_SIZE))
+  );
+
+  for (let index = 0; index < chunkCount; index++) {
+    const start = index * AUTHZED_BACKFILL_TARGET_CHUNK_SIZE;
+    const chunkTargets = Object.fromEntries(
+      entries
+        .map(([key, items]) => [key, items.slice(start, start + AUTHZED_BACKFILL_TARGET_CHUNK_SIZE)])
+        .filter(([, items]) => (items as ReadonlyArray<unknown>).length > 0)
+    ) as TTargets;
+
+    const result = await reconcile(chunkTargets);
     if (result.status !== "projected") {
       return result;
     }
@@ -250,27 +271,28 @@ const runChunked = async <TItem, TTargets>(
   return { passes: 1, status: "projected" };
 };
 
-/** Reconcile every target list, reporting the first that did not project. */
+/**
+ * Reconcile every target list, reporting the first reconciler that did not project.
+ *
+ * One call per reconciler rather than one per list: each reads a single snapshot covering everything it
+ * was given, so this is three snapshot reads for an organization instead of seven.
+ */
 const reconcileTargets = async (
   apply: TAuthzedBackfillApply,
   targets: TReconcileTargets
 ): Promise<TAuthzedProjectionResult | undefined> => {
   const outcomes = [
-    await runChunked(apply.reconcileMemberships, targets.memberships, (memberships) => ({ memberships })),
-    await runChunked(apply.reconcileTeamWorkspace, targets.teamIds, (teamIds) => ({ teamIds })),
-    await runChunked(apply.reconcileTeamWorkspace, targets.workspaceIds, (workspaceIds) => ({
-      workspaceIds,
-    })),
-    await runChunked(apply.reconcileTeamWorkspace, targets.teamMemberships, (teamMemberships) => ({
-      teamMemberships,
-    })),
-    await runChunked(apply.reconcileTeamWorkspace, targets.workspaceTeamGrants, (workspaceTeamGrants) => ({
-      workspaceTeamGrants,
-    })),
-    await runChunked(apply.reconcileApiKeys, targets.apiKeyIds, (apiKeyIds) => ({ apiKeyIds })),
-    await runChunked(apply.reconcileApiKeys, targets.apiKeyWorkspaceGrants, (apiKeyWorkspaceGrants) => ({
-      apiKeyWorkspaceGrants,
-    })),
+    await runChunked(apply.reconcileMemberships, { memberships: targets.memberships }),
+    await runChunked(apply.reconcileTeamWorkspace, {
+      teamIds: targets.teamIds,
+      teamMemberships: targets.teamMemberships,
+      workspaceIds: targets.workspaceIds,
+      workspaceTeamGrants: targets.workspaceTeamGrants,
+    }),
+    await runChunked(apply.reconcileApiKeys, {
+      apiKeyIds: targets.apiKeyIds,
+      apiKeyWorkspaceGrants: targets.apiKeyWorkspaceGrants,
+    }),
   ];
 
   return outcomes.find(
@@ -302,10 +324,24 @@ const observeOrganizationResources = async (
   const relationships: TAuthzedRelationship[] = [];
   let snapshot: string | null = null;
 
-  for (const filter of filters) {
-    const observation = await readAllRelationships(client, filter);
-    relationships.push(...observation.relationships);
-    snapshot = observation.snapshot?.token ?? snapshot;
+  // Bounded windows rather than one read at a time: an organization with many workspaces would
+  // otherwise cost that many sequential round trips. The bound is the same one that caps parallel
+  // relationship deletes, so this cannot outrun the connection budget the rest of the module assumes.
+  //
+  // Each filter resolves its own revision, which is fine: an observation is only ever used to name the
+  // source record a relationship implies, and the reconciler re-reads PostgreSQL before acting on it.
+  // Nothing here compares two resources against each other.
+  for (let start = 0; start < filters.length; start += AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES) {
+    const observations = await Promise.all(
+      filters
+        .slice(start, start + AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES)
+        .map((filter) => readAllRelationships(client, filter))
+    );
+
+    for (const observation of observations) {
+      relationships.push(...observation.relationships);
+      snapshot = observation.snapshot?.token ?? snapshot;
+    }
   }
 
   return { relationships, snapshot };

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -1,27 +1,37 @@
 import "server-only";
 import type { TApiKeyProjectionTargets } from "./api-key";
-import { type TAuthzedSourceRef, getManagedResourceTypes, summarizeObservation } from "./backfill-diff";
+import {
+  type TAuthzedParentEdge,
+  type TAuthzedSourceRef,
+  findUnprojectedSourceRefs,
+  getManagedResourceTypes,
+  summarizeObservation,
+} from "./backfill-diff";
 import {
   type TAuthzedApiKeyWorkspaceTarget,
   type TAuthzedMembershipTarget,
   type TAuthzedOrganizationSource,
   type TAuthzedTeamMembershipTarget,
+  type TAuthzedWorkspaceSource,
   type TAuthzedWorkspaceTeamTarget,
+  findMismatchedParentEdges,
   findMissingSourceRefs,
   organizationExists,
   readOrganizationIdPage,
   readOrganizationSource,
+  readWorkspaceSource,
 } from "./backfill-source";
 import type { TAuthzedClient, TAuthzedRelationship } from "./client";
 import {
   AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE,
   AUTHZED_BACKFILL_TARGET_CHUNK_SIZE,
   AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES,
+  AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN,
 } from "./constants";
-import { AuthzedError } from "./errors";
+import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
 import type { TOrganizationMembershipProjectionTargets } from "./organization-membership";
 import type { TAuthzedProjectionResult } from "./projection";
-import { readAllRelationships } from "./relationship-reads";
+import { forEachRelationshipPage, readAllRelationships } from "./relationship-reads";
 import type { TTeamWorkspaceProjectionTargets } from "./team-workspace";
 
 /**
@@ -52,7 +62,8 @@ export type TAuthzedBackfillApply = Readonly<{
 
 export type TAuthzedBackfillScope =
   | Readonly<{ afterOrganizationId?: string; kind: "all" }>
-  | Readonly<{ kind: "organization"; organizationId: string }>;
+  | Readonly<{ kind: "organization"; organizationId: string }>
+  | Readonly<{ kind: "workspace"; workspaceId: string }>;
 
 export type TAuthzedBackfillRequest = Readonly<{
   maxPrune: number;
@@ -77,6 +88,9 @@ export type TAuthzedBackfillRequest = Readonly<{
  * them does not weaken the dry-run guarantee.
  */
 export type TAuthzedBackfillSource = Readonly<{
+  findMismatchedParentEdges: (
+    edges: ReadonlyArray<TAuthzedParentEdge>
+  ) => Promise<ReadonlyArray<TAuthzedParentEdge>>;
   findMissingSourceRefs: (
     refs: ReadonlyArray<TAuthzedSourceRef>
   ) => Promise<ReadonlyArray<TAuthzedSourceRef>>;
@@ -85,13 +99,16 @@ export type TAuthzedBackfillSource = Readonly<{
     page: Readonly<{ afterOrganizationId?: string; limit?: number }>
   ) => Promise<ReadonlyArray<string>>;
   readOrganizationSource: (organizationId: string) => Promise<TAuthzedOrganizationSource>;
+  readWorkspaceSource: (workspaceId: string) => Promise<TAuthzedWorkspaceSource>;
 }>;
 
 export const defaultBackfillSource: TAuthzedBackfillSource = {
+  findMismatchedParentEdges,
   findMissingSourceRefs,
   organizationExists,
   readOrganizationIdPage,
   readOrganizationSource,
+  readWorkspaceSource,
 };
 
 export type TAuthzedBackfillDependencies = Readonly<{
@@ -105,6 +122,10 @@ export type TAuthzedBackfillCounters = Readonly<{
   failed: number;
   ignored: number;
   invalid: number;
+  /** Resources attached to an organization PostgreSQL says does not own them. Never pruned. */
+  mismatchedParents: number;
+  /** Source records PostgreSQL holds that SpiceDB has no relationship for. */
+  missing: number;
   orphaned: number;
   pruned: number;
   reconciled: number;
@@ -123,10 +144,18 @@ export type TAuthzedBackfillResult = Readonly<{
   counters: TAuthzedBackfillCounters;
   failures: ReadonlyArray<TAuthzedBackfillFailure>;
   lastOrganizationId: string | null;
+  /**
+   * Parent edges PostgreSQL contradicts.
+   *
+   * Reported and never touched. A cross-tenant parent edge is a privilege escalation, but removing it
+   * safely means deleting a relation the resource legitimately needs one of, so it is deliberately left
+   * for a human — see the runbook.
+   */
+  mismatchedParents: ReadonlyArray<TAuthzedParentEdge>;
   mode: "apply" | "dry_run";
   orphanScope: "all" | "known_resources";
   orphans: ReadonlyArray<TAuthzedSourceRef>;
-  scope: "all" | "organization";
+  scope: "all" | "organization" | "workspace";
   status: "drifted" | "failed" | "reconciled";
   /** Set when any observation was abandoned, so the report must not be read as complete. */
   truncated: boolean;
@@ -205,6 +234,34 @@ const toRepairTargets = (refs: ReadonlyArray<TAuthzedSourceRef>): TReconcileTarg
     workspaceTeamGrants,
   };
 };
+
+/**
+ * The source records an organization holds, in the same vocabulary an observation produces.
+ *
+ * Lets the two sides be compared with a set difference, which is what makes a dry run able to report the
+ * PostgreSQL-to-SpiceDB direction at all.
+ */
+const toSourceRefs = (source: TAuthzedOrganizationSource): ReadonlyArray<TAuthzedSourceRef> => [
+  ...source.memberships.map(
+    ({ organizationId, userId }): TAuthzedSourceRef => ({ kind: "membership", organizationId, userId })
+  ),
+  ...source.teamIds.map((teamId): TAuthzedSourceRef => ({ kind: "team", teamId })),
+  ...source.teamMemberships.map(
+    ({ teamId, userId }): TAuthzedSourceRef => ({ kind: "teamMembership", teamId, userId })
+  ),
+  ...source.workspaceIds.map((workspaceId): TAuthzedSourceRef => ({ kind: "workspace", workspaceId })),
+  ...source.workspaceTeamGrants.map(
+    ({ teamId, workspaceId }): TAuthzedSourceRef => ({ kind: "workspaceTeamGrant", teamId, workspaceId })
+  ),
+  ...source.apiKeyIds.map((apiKeyId): TAuthzedSourceRef => ({ apiKeyId, kind: "apiKey" })),
+  ...source.apiKeyWorkspaceGrants.map(
+    ({ apiKeyId, workspaceId }): TAuthzedSourceRef => ({
+      apiKeyId,
+      kind: "apiKeyWorkspaceGrant",
+      workspaceId,
+    })
+  ),
+];
 
 const mergeTargets = (left: TReconcileTargets, right: TReconcileTargets): TReconcileTargets => ({
   apiKeyIds: [...left.apiKeyIds, ...right.apiKeyIds],
@@ -353,10 +410,15 @@ export const runAuthzedBackfill = async (
 ): Promise<TAuthzedBackfillResult> => {
   const { apply, client, source: sourceReads = defaultBackfillSource } = dependencies;
   const isPruning = request.prune && request.mode === "apply";
+  // Defence in depth: the parser already bounds this, but `runAuthzedBackfill` is exported and a caller
+  // passing 0 would make an over-cap unit invisible in `status`.
+  const maxPrune = Math.max(1, Math.min(request.maxPrune, AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN));
 
   let failed = 0;
   let ignored = 0;
   let invalid = 0;
+  let mismatchedParentCount = 0;
+  let missingCount = 0;
   let orphaned = 0;
   let pruned = 0;
   let reconciled = 0;
@@ -367,12 +429,22 @@ export const runAuthzedBackfill = async (
   let lastOrganizationId: string | null = null;
   const failures: TAuthzedBackfillFailure[] = [];
   const orphans: TAuthzedSourceRef[] = [];
+  const mismatchedParents: TAuthzedParentEdge[] = [];
   const unmanaged: Array<Readonly<{ objectId: string; objectType: string; relation: string }>> = [];
 
   const recordFailure = (organizationId: string, error: unknown): void => {
     failed++;
     if (failures.length < MAX_REPORTED_ENTRIES) {
       failures.push({ organizationId, ...toErrorCode(error) });
+    }
+  };
+
+  const recordMismatchedParents = (edges: ReadonlyArray<TAuthzedParentEdge>): void => {
+    mismatchedParentCount += edges.length;
+    for (const edge of edges) {
+      if (mismatchedParents.length < MAX_REPORTED_ENTRIES) {
+        mismatchedParents.push(edge);
+      }
     }
   };
 
@@ -402,10 +474,13 @@ export const runAuthzedBackfill = async (
 
     invalid += source.invalidWorkspaceTeamGrants.length;
 
-    // Observation only matters for single-organization scope; a full sweep observes globally instead,
-    // which strictly covers more.
+    // Observed per organization when the scope names one, and also whenever nothing is going to be
+    // written: a dry run has to *detect* the drift an applying run would simply converge, or it would
+    // report a clean bill of health for a SpiceDB that is missing everything. An applying full sweep
+    // skips this, because its writes fix that direction and the global sweep covers the other one.
     let repairRefs: ReadonlyArray<TAuthzedSourceRef> = [];
-    if (request.scope.kind === "organization") {
+    let prunableRefs: ReadonlyArray<TAuthzedSourceRef> = [];
+    if (request.scope.kind === "organization" || request.mode === "dry_run") {
       try {
         const observation = await observeOrganizationResources(client, organizationId, source);
         const summary = summarizeObservation(observation.relationships);
@@ -417,22 +492,28 @@ export const runAuthzedBackfill = async (
         }
         completedAtSnapshot = observation.snapshot ?? completedAtSnapshot;
 
-        const missing = await sourceReads.findMissingSourceRefs(summary.sourceRefs);
-        orphaned += missing.length;
-        for (const ref of missing) {
+        // The direction an applying run converges by writing, and the only one a report can speak to.
+        const unprojected = findUnprojectedSourceRefs(toSourceRefs(source), summary.sourceRefs);
+        missingCount += unprojected.length;
+
+        recordMismatchedParents(await sourceReads.findMismatchedParentEdges(summary.parentEdges));
+
+        const missingRefs = await sourceReads.findMissingSourceRefs(summary.sourceRefs);
+        orphaned += missingRefs.length;
+        for (const ref of missingRefs) {
           if (orphans.length < MAX_REPORTED_ENTRIES) {
             orphans.push(ref);
           }
         }
 
-        if (missing.length > request.maxPrune) {
+        if (missingRefs.length > maxPrune) {
           // A large orphan count is a symptom — wrong endpoint, wrong database, a restore in progress —
           // not a big cleanup job. Prune nothing for this unit so the run degrades into a loud report
           // instead of a partly-destroyed graph.
           skipped++;
         } else if (isPruning) {
-          repairRefs = missing;
-          pruned += missing.length;
+          repairRefs = missingRefs;
+          prunableRefs = missingRefs;
         }
       } catch (error) {
         // An abandoned observation must never be reported as a complete one: fewer relationships seen
@@ -468,65 +549,219 @@ export const runAuthzedBackfill = async (
       return;
     }
 
+    // Counted here rather than at detection time so a failed reconcile cannot report relationships as
+    // pruned that are still present.
+    pruned += prunableRefs.length;
     reconciled++;
   };
 
   /** Sweep every managed resource type to find resources PostgreSQL no longer holds at all. */
   const sweepGlobalOrphans = async (): Promise<void> => {
-    const relationships: TAuthzedRelationship[] = [];
+    // Streamed page by page rather than drained. A resource type has no upper bound in a real
+    // deployment, so accumulating one would hold the whole store in memory and — worse — trip the
+    // per-unit observation bound, turning the only mode that can remove stale relationships into one
+    // that fails permanently on exactly the deployments that need it.
+    let capExceeded = false;
+
+    // Streaming means each page is classified on its own, so a record implied by relationships on two
+    // different resource types would be counted twice. Exactly one kind is ambiguous that way: an API key
+    // is named both by `api_key#organization` and by `organization#api_key_reader`. Deduplicating just
+    // that kind keeps the counts honest without holding a key for every record in the store.
+    const seenApiKeyRefs = new Set<string>();
+    const dedupe = (refs: ReadonlyArray<TAuthzedSourceRef>): ReadonlyArray<TAuthzedSourceRef> =>
+      refs.filter((ref) => {
+        if (ref.kind !== "apiKey") {
+          return true;
+        }
+        if (seenApiKeyRefs.has(ref.apiKeyId)) {
+          return false;
+        }
+        seenApiKeyRefs.add(ref.apiKeyId);
+        return true;
+      });
 
     for (const resourceType of getManagedResourceTypes()) {
-      const observation = await readAllRelationships(client, { resourceType });
-      relationships.push(...observation.relationships);
+      const snapshot = await forEachRelationshipPage(client, { resourceType }, async (relationships) => {
+        if (capExceeded) {
+          return;
+        }
+
+        const summary = summarizeObservation(relationships);
+        ignored += summary.ignored;
+        unmanaged.push(...summary.unmanaged.slice(0, Math.max(0, MAX_REPORTED_ENTRIES - unmanaged.length)));
+
+        recordMismatchedParents(await sourceReads.findMismatchedParentEdges(summary.parentEdges));
+
+        const missingRefs = await sourceReads.findMissingSourceRefs(dedupe(summary.sourceRefs));
+        orphaned += missingRefs.length;
+        orphans.push(...missingRefs.slice(0, Math.max(0, MAX_REPORTED_ENTRIES - orphans.length)));
+
+        // The cap is a run-wide budget, not a per-page one: once the total would exceed it, stop pruning
+        // for the rest of the run rather than letting a page-sized slice through each time.
+        if (pruned + missingRefs.length > maxPrune) {
+          capExceeded = true;
+          skipped++;
+          return;
+        }
+
+        if (!isPruning || missingRefs.length === 0) {
+          return;
+        }
+
+        const failure = await reconcileTargets(apply, toRepairTargets(missingRefs));
+        if (failure) {
+          // Attributed to no organization: a fully orphaned resource has none left to attribute it to.
+          recordProjectionFailure("", failure);
+          capExceeded = true;
+          return;
+        }
+
+        pruned += missingRefs.length;
+      });
+
+      completedAtSnapshot = snapshot?.token ?? completedAtSnapshot;
+    }
+  };
+
+  /**
+   * Reconcile one workspace's grants without touching the rest of the tenant.
+   *
+   * The narrowest unit available, and unlike an organization it does not have to exist: a workspace
+   * whose row is gone is the case most worth repairing, and its relationships are reachable from the ID
+   * the caller supplied.
+   */
+  const processWorkspace = async (workspaceId: string): Promise<void> => {
+    scanned++;
+
+    let source: Awaited<ReturnType<typeof sourceReads.readWorkspaceSource>>;
+    try {
+      source = await sourceReads.readWorkspaceSource(workspaceId);
+    } catch (error) {
+      recordFailure("", error);
+      return;
+    }
+
+    let repairRefs: ReadonlyArray<TAuthzedSourceRef> = [];
+    let prunableWorkspaceRefs: ReadonlyArray<TAuthzedSourceRef> = [];
+    try {
+      const observation = await readAllRelationships(client, {
+        resourceId: workspaceId,
+        resourceType: "workspace",
+      });
+      const summary = summarizeObservation(observation.relationships);
+      ignored += summary.ignored;
+      unmanaged.push(...summary.unmanaged.slice(0, Math.max(0, MAX_REPORTED_ENTRIES - unmanaged.length)));
       completedAtSnapshot = observation.snapshot?.token ?? completedAtSnapshot;
-    }
 
-    const summary = summarizeObservation(relationships);
-    ignored += summary.ignored;
-    unmanaged.push(...summary.unmanaged.slice(0, MAX_REPORTED_ENTRIES - unmanaged.length));
+      recordMismatchedParents(await sourceReads.findMismatchedParentEdges(summary.parentEdges));
 
-    const missing = await sourceReads.findMissingSourceRefs(summary.sourceRefs);
-    orphaned += missing.length;
-    orphans.push(...missing.slice(0, MAX_REPORTED_ENTRIES - orphans.length));
+      // Only the grants are compared: whether the workspace's own parent edge exists is decided by
+      // `workspaceExists` below, and a workspace with no row should have no relationships at all.
+      const expected = source.workspaceExists
+        ? [
+            ...source.workspaceTeamGrants.map(
+              ({ teamId, workspaceId: grantWorkspaceId }): TAuthzedSourceRef => ({
+                kind: "workspaceTeamGrant",
+                teamId,
+                workspaceId: grantWorkspaceId,
+              })
+            ),
+            ...source.apiKeyWorkspaceGrants.map(
+              ({ apiKeyId, workspaceId: grantWorkspaceId }): TAuthzedSourceRef => ({
+                apiKeyId,
+                kind: "apiKeyWorkspaceGrant",
+                workspaceId: grantWorkspaceId,
+              })
+            ),
+            { kind: "workspace" as const, workspaceId },
+          ]
+        : [];
+      missingCount += findUnprojectedSourceRefs(expected, summary.sourceRefs).length;
 
-    if (missing.length > request.maxPrune) {
-      skipped++;
+      const missingRefs = await sourceReads.findMissingSourceRefs(summary.sourceRefs);
+      orphaned += missingRefs.length;
+      orphans.push(...missingRefs.slice(0, Math.max(0, MAX_REPORTED_ENTRIES - orphans.length)));
+
+      if (missingRefs.length > maxPrune) {
+        skipped++;
+      } else if (isPruning) {
+        repairRefs = missingRefs;
+        prunableWorkspaceRefs = missingRefs;
+      }
+    } catch (error) {
+      truncated = true;
+      recordFailure("", error);
       return;
     }
 
-    if (!isPruning) {
+    if (request.mode === "dry_run") {
       return;
     }
 
-    const failure = await reconcileTargets(apply, toRepairTargets(missing));
+    const failure = await reconcileTargets(
+      apply,
+      mergeTargets(
+        {
+          apiKeyIds: [],
+          apiKeyWorkspaceGrants: source.apiKeyWorkspaceGrants,
+          memberships: [],
+          teamIds: [],
+          teamMemberships: [],
+          // Naming a workspace that no longer exists is what removes its relationships.
+          workspaceIds: [workspaceId],
+          workspaceTeamGrants: source.workspaceTeamGrants,
+        },
+        toRepairTargets(repairRefs)
+      )
+    );
+
     if (failure) {
-      // Attributed to no organization: a fully orphaned resource has none left to attribute it to.
       recordProjectionFailure("", failure);
       return;
     }
 
-    pruned += missing.length;
+    pruned += prunableWorkspaceRefs.length;
+    reconciled++;
   };
 
-  if (request.scope.kind === "organization") {
+  if (request.scope.kind === "workspace") {
+    await processWorkspace(request.scope.workspaceId);
+  } else if (request.scope.kind === "organization") {
     const { organizationId } = request.scope;
     if (!(await sourceReads.organizationExists(organizationId))) {
-      throw new Error("Organization not found");
+      throw new AuthzedError({
+        attempts: 0,
+        code: AUTHZED_ERROR_CODES.NOT_FOUND,
+        operation: "backfill_scope",
+        retryable: false,
+      });
     }
     await processOrganization(organizationId);
   } else {
     let afterOrganizationId = request.scope.afterOrganizationId;
     for (;;) {
-      const organizationIds = await sourceReads.readOrganizationIdPage({
-        afterOrganizationId,
-        limit: AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE,
-      });
+      let organizationIds: ReadonlyArray<string>;
+      try {
+        organizationIds = await sourceReads.readOrganizationIdPage({
+          afterOrganizationId,
+          limit: AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE,
+        });
+      } catch (error) {
+        // Caught rather than propagated so the report survives. Letting this escape would replace the
+        // whole result with a bare failure line, discarding `lastOrganizationId` — the only thing an
+        // operator can resume a long sweep from.
+        truncated = true;
+        recordFailure("", error);
+        break;
+      }
+
       if (organizationIds.length === 0) {
         break;
       }
 
-      // Strictly sequential: concurrent writes to the same organization resource produce retryable
-      // serialization conflicts against a small retry budget.
+      // Strictly sequential, and not only to avoid write contention: `lastOrganizationId` is the resume
+      // cursor, so processing out of order would let a resume skip an organization that failed while a
+      // later one succeeded.
       for (const organizationId of organizationIds) {
         await processOrganization(organizationId);
       }
@@ -541,13 +776,28 @@ export const runAuthzedBackfill = async (
     }
   }
 
-  const status = failed > 0 ? "failed" : orphaned > pruned || truncated ? "drifted" : "reconciled";
+  // `missing` and `mismatchedParents` matter as much as `orphaned` here: without them a dry run over an
+  // empty SpiceDB would report "reconciled", which is the exact state this tool exists to fix.
+  const hasDrift = orphaned > pruned || missingCount > 0 || mismatchedParentCount > 0 || truncated;
+  const status = failed > 0 ? "failed" : hasDrift ? "drifted" : "reconciled";
 
   return {
     completedAtSnapshot,
-    counters: { failed, ignored, invalid, orphaned, pruned, reconciled, scanned, skipped },
+    counters: {
+      failed,
+      ignored,
+      invalid,
+      mismatchedParents: mismatchedParentCount,
+      missing: missingCount,
+      orphaned,
+      pruned,
+      reconciled,
+      scanned,
+      skipped,
+    },
     failures,
     lastOrganizationId,
+    mismatchedParents,
     mode: request.mode,
     orphanScope: request.scope.kind === "all" ? "all" : "known_resources",
     orphans,

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -179,12 +179,21 @@ export type TAuthzedBackfillResult = Readonly<{
   scope: "all" | "organization" | "workspace";
   status: "drifted" | "failed" | "reconciled";
   /**
-   * Set when an observation was abandoned, so the counts are a floor rather than a total.
+   * Set when the counters are not exact. Either way, re-run before concluding anything.
    *
-   * Deliberately narrow: it does *not* mean the `orphans` / `failures` / `mismatchedParents` lists hit
-   * their reporting cap. Those stay capped at 100 entries with the counters carrying the true totals,
-   * and conflating the two would make a merely-verbose run look like an incomplete one — which matters,
-   * because this flag forces a non-clean status.
+   * Two causes, and they err in opposite directions, so neither "floor" nor "total" describes the
+   * counts on its own:
+   *
+   * - **an observation was abandoned** mid-read, so fewer relationships were seen than exist and the
+   *   counts are a floor. Fail-safe for pruning: fewer orphans found means fewer deleted.
+   * - **the sweep's deduplication bound was exceeded**, so a record implied by two pages beyond that
+   *   point is counted twice and the counts may over-report. Also safe, because a run with that many
+   *   orphans is orders of magnitude past the prune cap and so deletes nothing.
+   *
+   * Deliberately narrow in one respect: it does *not* mean the `orphans` / `failures` /
+   * `mismatchedParents` lists hit their reporting cap. Those stay capped at 100 entries with the
+   * counters carrying the true totals, and conflating the two would make a merely-verbose run look like
+   * an incomplete one — which matters, because this flag forces a non-clean status.
    */
   truncated: boolean;
   unmanaged: ReadonlyArray<Readonly<{ objectId: string; objectType: string; relation: string }>>;

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -447,369 +447,496 @@ const observeOrganizationResources = async (
   return { relationships, snapshot };
 };
 
-export const runAuthzedBackfill = async (
-  request: TAuthzedBackfillRequest,
-  dependencies: TAuthzedBackfillDependencies
-): Promise<TAuthzedBackfillResult> => {
-  const { apply, client, source: sourceReads = defaultBackfillSource } = dependencies;
-  const isPruning = request.prune && request.mode === "apply";
-  // Defence in depth: the parser already bounds this, but `runAuthzedBackfill` is exported and a caller
-  // passing 0 would make an over-cap unit invisible in `status`.
-  const maxPrune = Math.max(1, Math.min(request.maxPrune, AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN));
+/**
+ * One run's mutable tallies and capped report lists.
+ *
+ * Held in an explicit object rather than in closure variables so every unit of work can be a
+ * module-level function. The orchestrator used to close over a dozen `let`s, which made it a single
+ * function too large to reason about — and every defect found while reviewing this tool was in that
+ * function.
+ */
+type TRunState = {
+  completedAtSnapshot: string | null;
+  failed: number;
+  readonly failures: TAuthzedBackfillFailure[];
+  ignored: number;
+  invalid: number;
+  lastOrganizationId: string | null;
+  mismatchedParentCount: number;
+  readonly mismatchedParents: TAuthzedParentEdge[];
+  missingCount: number;
+  orphaned: number;
+  readonly orphans: TAuthzedSourceRef[];
+  pruned: number;
+  reconciled: number;
+  scanned: number;
+  skipped: number;
+  truncated: boolean;
+  readonly unmanaged: Array<Readonly<{ objectId: string; objectType: string; relation: string }>>;
+};
 
-  let failed = 0;
-  let ignored = 0;
-  let invalid = 0;
-  let mismatchedParentCount = 0;
-  let missingCount = 0;
-  let orphaned = 0;
-  let pruned = 0;
-  let reconciled = 0;
-  let scanned = 0;
-  let skipped = 0;
-  let truncated = false;
-  let completedAtSnapshot: string | null = null;
-  let lastOrganizationId: string | null = null;
-  const failures: TAuthzedBackfillFailure[] = [];
-  const orphans: TAuthzedSourceRef[] = [];
-  const mismatchedParents: TAuthzedParentEdge[] = [];
-  const unmanaged: Array<Readonly<{ objectId: string; objectType: string; relation: string }>> = [];
+const createRunState = (): TRunState => ({
+  completedAtSnapshot: null,
+  failed: 0,
+  failures: [],
+  ignored: 0,
+  invalid: 0,
+  lastOrganizationId: null,
+  mismatchedParentCount: 0,
+  mismatchedParents: [],
+  missingCount: 0,
+  orphaned: 0,
+  orphans: [],
+  pruned: 0,
+  reconciled: 0,
+  scanned: 0,
+  skipped: 0,
+  truncated: false,
+  unmanaged: [],
+});
 
-  const recordFailure = (organizationId: string, error: unknown): void => {
-    failed++;
-    if (failures.length < MAX_REPORTED_ENTRIES) {
-      failures.push({ organizationId, ...toErrorCode(error) });
-    }
-  };
-
-  const recordMismatchedParents = (edges: ReadonlyArray<TAuthzedParentEdge>): void => {
-    mismatchedParentCount += edges.length;
-    for (const edge of edges) {
-      if (mismatchedParents.length < MAX_REPORTED_ENTRIES) {
-        mismatchedParents.push(edge);
-      }
-    }
-  };
-
-  const recordProjectionFailure = (organizationId: string, result: TAuthzedProjectionResult): void => {
-    failed++;
-    if (failures.length < MAX_REPORTED_ENTRIES) {
-      failures.push(
-        result.status === "failed"
-          ? { code: result.code, organizationId, retryable: result.retryable }
-          : // `disabled` reaching here means AuthZed was switched off mid-run.
-            { code: "authzed_disabled", organizationId, retryable: false }
-      );
-    }
-  };
-
-  const processOrganization = async (organizationId: string): Promise<void> => {
-    scanned++;
-    lastOrganizationId = organizationId;
-
-    let source: TAuthzedOrganizationSource;
-    try {
-      source = await sourceReads.readOrganizationSource(organizationId);
-    } catch (error) {
-      recordFailure(organizationId, error);
-      return;
-    }
-
-    invalid += source.invalidWorkspaceTeamGrants.length + source.invalidApiKeyWorkspaceGrants.length;
-
-    // Two reasons to observe an organization's own resources, and they have different owners.
-    //
-    // A narrow scope has no global sweep behind it, so the observation owns everything it finds. A full
-    // scope *does* have one, and the sweep sees strictly more — so here the observation exists only to
-    // compute the direction the sweep cannot: records PostgreSQL holds that SpiceDB is missing. Counting
-    // orphans on both paths would report every stale relationship twice, and the default invocation is
-    // exactly that combination (dry run, full scope).
-    //
-    // An applying full scope skips the observation entirely: its writes converge the missing direction
-    // anyway, and paying a read per resource to report what is about to be fixed is waste.
-    const ownsOrphanAccounting = request.scope.kind !== "all";
-    const needsMissingCheck = request.mode === "dry_run";
-    let repairRefs: ReadonlyArray<TAuthzedSourceRef> = [];
-    let prunableRefs: ReadonlyArray<TAuthzedSourceRef> = [];
-    if (ownsOrphanAccounting || needsMissingCheck) {
-      try {
-        const observation = await observeOrganizationResources(client, organizationId, source);
-        const summary = summarizeObservation(observation.relationships);
-
-        if (needsMissingCheck) {
-          // The direction an applying run converges by writing, and the only one a report can speak to.
-          missingCount += findUnprojectedSourceRefs(toSourceRefs(source), summary.sourceRefs).length;
-        }
-
-        // Scoped rather than returned early: falling through keeps this block's only job the
-        // observation, so an applying full scope that ever needs the missing-record check cannot
-        // accidentally skip its own reconcile on the way past.
-        if (ownsOrphanAccounting) {
-          ignored += summary.ignored;
-          for (const ref of summary.unmanaged) {
-            if (unmanaged.length < MAX_REPORTED_ENTRIES) {
-              unmanaged.push(ref);
-            }
-          }
-
-          recordMismatchedParents(await sourceReads.findMismatchedParentEdges(summary.parentEdges));
-
-          const missingRefs = await sourceReads.findMissingSourceRefs(summary.sourceRefs);
-          orphaned += missingRefs.length;
-          for (const ref of missingRefs) {
-            if (orphans.length < MAX_REPORTED_ENTRIES) {
-              orphans.push(ref);
-            }
-          }
-
-          if (missingRefs.length > maxPrune) {
-            // A large orphan count is a symptom — wrong endpoint, wrong database, a restore in progress
-            // — not a big cleanup job. Prune nothing for this unit so the run degrades into a loud
-            // report instead of a partly-destroyed graph.
-            skipped++;
-          } else if (isPruning) {
-            repairRefs = missingRefs;
-            prunableRefs = missingRefs;
-          }
-        }
-      } catch (error) {
-        // An abandoned observation must never be reported as a complete one: fewer relationships seen
-        // means fewer orphans found, and a caller could otherwise read that as "nothing stale here".
-        truncated = true;
-        recordFailure(organizationId, error);
-        return;
-      }
-    }
-
-    if (request.mode === "dry_run") {
-      return;
-    }
-
-    const failure = await reconcileTargets(
-      apply,
-      mergeTargets(
-        {
-          apiKeyIds: source.apiKeyIds,
-          apiKeyWorkspaceGrants: source.apiKeyWorkspaceGrants,
-          memberships: source.memberships,
-          teamIds: source.teamIds,
-          teamMemberships: source.teamMemberships,
-          workspaceIds: source.workspaceIds,
-          workspaceTeamGrants: source.workspaceTeamGrants,
-        },
-        toRepairTargets(repairRefs)
-      )
-    );
-
-    if (failure) {
-      recordProjectionFailure(organizationId, failure);
-      return;
-    }
-
-    // Counted here rather than at detection time so a failed reconcile cannot report relationships as
-    // pruned that are still present.
-    pruned += prunableRefs.length;
-    reconciled++;
-  };
-
+/** A unit of work's whole world: the run's tallies plus the configuration every unit shares. */
+type TRunContext = Readonly<{
+  apply: TAuthzedBackfillApply;
+  client: Pick<TAuthzedClient, "readRelationships">;
+  isPruning: boolean;
+  maxPrune: number;
+  mode: "apply" | "dry_run";
   /**
-   * Sweep every managed resource type to find resources PostgreSQL no longer holds at all.
+   * Whether a per-organization observation owns the orphan tallies.
    *
-   * Two phases, and the order is the safety property. The whole sweep is observed and counted first;
-   * only then, and only if the confirmed total fits the budget, is anything deleted. Enforcing the cap
-   * while streaming would delete every page that fit and halt on the one that did not — so a run aimed
-   * at the wrong database would revoke a cap's worth of live access instead of revoking none, which
-   * inverts what the cap is for.
-   *
-   * Streamed rather than drained: a resource type has no upper bound in a real deployment, so
-   * accumulating one would hold the whole store in memory and trip the per-unit observation bound,
-   * turning the only mode that can remove stale relationships into one that fails permanently on exactly
-   * the deployments that need it. Only the prunable refs are accumulated, and the budget bounds those.
+   * False only for a full scope, where the streamed sweep sees strictly more — counting on both paths
+   * would report every stale relationship twice, and the default invocation is exactly that
+   * combination (dry run, full scope).
    */
-  const sweepGlobalOrphans = async (): Promise<void> => {
-    // Bounded by the budget: past it nothing will be pruned anyway, so there is no reason to hold more.
-    const prunable: TAuthzedSourceRef[] = [];
-    // Each page is classified on its own, so one record can be implied by relationships on two pages —
-    // across resource types (an API key is named by both `api_key#organization` and
-    // `organization#api_key_reader`) and within one, since alternate relations on the same resource are
-    // returned grouped by relation rather than adjacently.
-    const seenOrphanRefs = new Set<string>();
-    let sweepOrphans = 0;
+  ownsOrphanAccounting: boolean;
+  sourceReads: TAuthzedBackfillSource;
+  state: TRunState;
+}>;
 
-    for (const resourceType of getManagedResourceTypes()) {
-      await forEachRelationshipPage(client, { resourceType }, async (relationships) => {
-        const summary = summarizeObservation(relationships);
-        ignored += summary.ignored;
-        unmanaged.push(...summary.unmanaged.slice(0, Math.max(0, MAX_REPORTED_ENTRIES - unmanaged.length)));
+/** Append while honouring the reporting cap, so a run against a broken instance cannot emit a huge line. */
+const pushCapped = <T>(list: T[], items: ReadonlyArray<T>): void => {
+  list.push(...items.slice(0, Math.max(0, MAX_REPORTED_ENTRIES - list.length)));
+};
 
-        recordMismatchedParents(await sourceReads.findMismatchedParentEdges(summary.parentEdges));
+const recordFailure = (state: TRunState, organizationId: string, error: unknown): void => {
+  state.failed++;
+  pushCapped(state.failures, [{ organizationId, ...toErrorCode(error) }]);
+};
 
-        for (const ref of await sourceReads.findMissingSourceRefs(summary.sourceRefs)) {
-          const key = sourceRefKey(ref);
-          if (seenOrphanRefs.has(key)) {
-            continue;
-          }
-          if (seenOrphanRefs.size >= AUTHZED_MAX_TRACKED_ORPHAN_REFS) {
-            // Past the bound the count may double-count. Say so rather than let the total read as exact.
-            truncated = true;
-          } else {
-            seenOrphanRefs.add(key);
-          }
+const recordProjectionFailure = (
+  state: TRunState,
+  organizationId: string,
+  result: TAuthzedProjectionResult
+): void => {
+  state.failed++;
+  pushCapped(state.failures, [
+    result.status === "failed"
+      ? { code: result.code, organizationId, retryable: result.retryable }
+      : // `disabled` reaching here means AuthZed was switched off mid-run.
+        { code: "authzed_disabled", organizationId, retryable: false },
+  ]);
+};
 
-          sweepOrphans++;
-          orphaned++;
-          if (orphans.length < MAX_REPORTED_ENTRIES) {
-            orphans.push(ref);
-          }
-          if (prunable.length < maxPrune) {
-            prunable.push(ref);
-          }
-        }
-      });
-    }
+const recordMismatchedParents = (state: TRunState, edges: ReadonlyArray<TAuthzedParentEdge>): void => {
+  state.mismatchedParentCount += edges.length;
+  pushCapped(state.mismatchedParents, edges);
+};
 
-    if (!isPruning || sweepOrphans === 0) {
-      return;
-    }
+/**
+ * Decide which observed refs, if any, may be handed to a reconciler as prune targets.
+ *
+ * Shared by both narrow scopes. A count over the budget prunes *nothing* for that unit: a large orphan
+ * count is a symptom — wrong endpoint, wrong database, a restore in progress — not a big cleanup job,
+ * so the run degrades into a loud report instead of a partly-destroyed graph.
+ */
+const selectPrunableRefs = (
+  ctx: TRunContext,
+  missingRefs: ReadonlyArray<TAuthzedSourceRef>
+): ReadonlyArray<TAuthzedSourceRef> => {
+  if (missingRefs.length > ctx.maxPrune) {
+    ctx.state.skipped++;
 
-    if (sweepOrphans > maxPrune) {
-      // A large orphan count is a symptom — wrong endpoint, wrong database, a restore in progress — not
-      // a big cleanup job. Nothing has been deleted yet, and nothing will be.
-      skipped++;
-      return;
-    }
+    return [];
+  }
 
-    const failure = await reconcileTargets(apply, toRepairTargets(prunable));
-    if (failure) {
-      // Attributed to no organization: a fully orphaned resource has none left to attribute it to.
-      recordProjectionFailure("", failure);
-      return;
-    }
+  return ctx.isPruning ? missingRefs : [];
+};
 
-    pruned += prunable.length;
-  };
+/**
+ * Observe one organization's own resources and record what that implies.
+ *
+ * Returns the refs to hand a reconciler as repair targets. Throws if the observation could not be
+ * completed, which the caller must treat as "this unit could not be observed" rather than as
+ * "nothing stale here".
+ */
+const observeOrganization = async (
+  ctx: TRunContext,
+  organizationId: string,
+  source: TAuthzedOrganizationSource
+): Promise<ReadonlyArray<TAuthzedSourceRef>> => {
+  const { state } = ctx;
+  const observation = await observeOrganizationResources(ctx.client, organizationId, source);
+  const summary = summarizeObservation(observation.relationships);
 
-  /**
-   * Reconcile one workspace's grants.
-   *
-   * The narrowest unit available, and unlike an organization it does not have to exist: a workspace whose
-   * row is gone is the case most worth repairing, and its relationships are reachable from the ID the
-   * caller supplied.
-   *
-   * Narrow, but not hermetic. The API keys holding grants on this workspace are reconciled in full, which
-   * covers every *other* workspace those keys hold too — a key is reconciled as a unit, and splitting it
-   * would mean writing a second, narrower implementation of the same convergence. Everything that reaches
-   * is convergent (it writes what PostgreSQL says), so the effect is a wider repair than asked for, never
-   * a deletion outside the named workspace.
-   */
-  const processWorkspace = async (workspaceId: string): Promise<void> => {
-    scanned++;
+  if (ctx.mode === "dry_run") {
+    // The direction an applying run converges by writing, and the only one a report can speak to.
+    state.missingCount += findUnprojectedSourceRefs(toSourceRefs(source), summary.sourceRefs).length;
+  }
 
-    let source: Awaited<ReturnType<typeof sourceReads.readWorkspaceSource>>;
+  if (!ctx.ownsOrphanAccounting) {
+    return [];
+  }
+
+  state.ignored += summary.ignored;
+  pushCapped(state.unmanaged, summary.unmanaged);
+  recordMismatchedParents(state, await ctx.sourceReads.findMismatchedParentEdges(summary.parentEdges));
+
+  const missingRefs = await ctx.sourceReads.findMissingSourceRefs(summary.sourceRefs);
+  state.orphaned += missingRefs.length;
+  pushCapped(state.orphans, missingRefs);
+
+  return selectPrunableRefs(ctx, missingRefs);
+};
+
+const processOrganization = async (ctx: TRunContext, organizationId: string): Promise<void> => {
+  const { state } = ctx;
+  state.scanned++;
+  state.lastOrganizationId = organizationId;
+
+  let source: TAuthzedOrganizationSource;
+  try {
+    source = await ctx.sourceReads.readOrganizationSource(organizationId);
+  } catch (error) {
+    recordFailure(state, organizationId, error);
+
+    return;
+  }
+
+  state.invalid += source.invalidWorkspaceTeamGrants.length + source.invalidApiKeyWorkspaceGrants.length;
+
+  // Observed for two reasons with different owners: a narrow scope owns everything it finds, while a
+  // full scope observes only to compute the direction the sweep cannot — records PostgreSQL holds that
+  // SpiceDB is missing. An applying full scope skips it entirely, since its writes converge that
+  // direction anyway and a read per resource to report what is about to be fixed is waste.
+  let repairRefs: ReadonlyArray<TAuthzedSourceRef> = [];
+  if (ctx.ownsOrphanAccounting || ctx.mode === "dry_run") {
     try {
-      source = await sourceReads.readWorkspaceSource(workspaceId);
+      repairRefs = await observeOrganization(ctx, organizationId, source);
     } catch (error) {
-      // No organization to attribute this to: the read that would have told us which one failed.
-      recordFailure("", error);
+      // An abandoned observation must never be reported as a complete one: fewer relationships seen
+      // means fewer orphans found, and a caller could otherwise read that as "nothing stale here".
+      state.truncated = true;
+      recordFailure(state, organizationId, error);
+
       return;
     }
+  }
 
-    // Attributed to the owning tenant where PostgreSQL knows one. The empty string is also the sweep's
-    // marker for an orphan with no organization left, so a workspace that still has a row must not
-    // report it.
-    const failureOrganizationId = source.organizationId ?? "";
+  if (ctx.mode === "dry_run") {
+    return;
+  }
 
-    let repairRefs: ReadonlyArray<TAuthzedSourceRef> = [];
-    let prunableWorkspaceRefs: ReadonlyArray<TAuthzedSourceRef> = [];
+  const failure = await reconcileTargets(
+    ctx.apply,
+    mergeTargets(
+      {
+        apiKeyIds: source.apiKeyIds,
+        apiKeyWorkspaceGrants: source.apiKeyWorkspaceGrants,
+        memberships: source.memberships,
+        teamIds: source.teamIds,
+        teamMemberships: source.teamMemberships,
+        workspaceIds: source.workspaceIds,
+        workspaceTeamGrants: source.workspaceTeamGrants,
+      },
+      toRepairTargets(repairRefs)
+    )
+  );
+
+  if (failure) {
+    recordProjectionFailure(state, organizationId, failure);
+
+    return;
+  }
+
+  // Counted here rather than at detection time so a failed reconcile cannot report relationships as
+  // pruned that are still present.
+  state.pruned += repairRefs.length;
+  state.reconciled++;
+};
+
+/**
+ * Tally one page of the sweep, returning the orphans on it that no earlier page already reported.
+ *
+ * Deduplicated run-wide because each page is classified on its own, so one record can be implied by
+ * relationships on two pages — across resource types (an API key is named by both
+ * `api_key#organization` and `organization#api_key_reader`) and within one, since alternate relations
+ * on the same resource come back grouped by relation rather than adjacently.
+ */
+const tallySweepPage = async (
+  ctx: TRunContext,
+  seenOrphanRefs: Set<string>,
+  relationships: ReadonlyArray<TAuthzedRelationship>
+): Promise<ReadonlyArray<TAuthzedSourceRef>> => {
+  const { state } = ctx;
+  const summary = summarizeObservation(relationships);
+  state.ignored += summary.ignored;
+  pushCapped(state.unmanaged, summary.unmanaged);
+  recordMismatchedParents(state, await ctx.sourceReads.findMismatchedParentEdges(summary.parentEdges));
+
+  const fresh: TAuthzedSourceRef[] = [];
+  for (const ref of await ctx.sourceReads.findMissingSourceRefs(summary.sourceRefs)) {
+    const key = sourceRefKey(ref);
+    if (seenOrphanRefs.has(key)) {
+      continue;
+    }
+    if (seenOrphanRefs.size >= AUTHZED_MAX_TRACKED_ORPHAN_REFS) {
+      // Past the bound the count may double-count. Say so rather than let the total read as exact.
+      state.truncated = true;
+    } else {
+      seenOrphanRefs.add(key);
+    }
+
+    fresh.push(ref);
+  }
+
+  state.orphaned += fresh.length;
+  pushCapped(state.orphans, fresh);
+
+  return fresh;
+};
+
+/**
+ * Sweep every managed resource type to find resources PostgreSQL no longer holds at all.
+ *
+ * Two phases, and the order is the safety property. The whole sweep is observed and counted first;
+ * only then, and only if the confirmed total fits the budget, is anything deleted. Enforcing the cap
+ * while streaming would delete every page that fit and halt on the one that did not — so a run aimed
+ * at the wrong database would revoke a cap's worth of live access instead of revoking none, which
+ * inverts what the cap is for.
+ *
+ * Streamed rather than drained: a resource type has no upper bound in a real deployment, so
+ * accumulating one would hold the whole store in memory and trip the per-unit observation bound,
+ * turning the only mode that can remove stale relationships into one that fails permanently on exactly
+ * the deployments that need it. Only the prunable refs are accumulated, and the budget bounds those.
+ */
+const sweepGlobalOrphans = async (ctx: TRunContext): Promise<void> => {
+  const { state } = ctx;
+  // Bounded by the budget: past it nothing will be pruned anyway, so there is no reason to hold more.
+  const prunable: TAuthzedSourceRef[] = [];
+  const seenOrphanRefs = new Set<string>();
+  let sweepOrphans = 0;
+
+  for (const resourceType of getManagedResourceTypes()) {
+    await forEachRelationshipPage(ctx.client, { resourceType }, async (relationships) => {
+      const fresh = await tallySweepPage(ctx, seenOrphanRefs, relationships);
+      sweepOrphans += fresh.length;
+      // Bounded by the prune budget, *not* by the reporting cap: `pushCapped` would silently stop at
+      // 100 and under-prune a run that is entirely within its budget.
+      prunable.push(...fresh.slice(0, Math.max(0, ctx.maxPrune - prunable.length)));
+    });
+  }
+
+  if (!ctx.isPruning || sweepOrphans === 0) {
+    return;
+  }
+
+  if (sweepOrphans > ctx.maxPrune) {
+    // Nothing has been deleted yet, and nothing will be.
+    state.skipped++;
+
+    return;
+  }
+
+  const failure = await reconcileTargets(ctx.apply, toRepairTargets(prunable));
+  if (failure) {
+    // Attributed to no organization: a fully orphaned resource has none left to attribute it to.
+    recordProjectionFailure(state, "", failure);
+
+    return;
+  }
+
+  state.pruned += prunable.length;
+};
+
+/** The source records a workspace's own relationships should cover, when its row still exists. */
+const toWorkspaceSourceRefs = (
+  source: TAuthzedWorkspaceSource,
+  workspaceId: string
+): ReadonlyArray<TAuthzedSourceRef> => {
+  // Only the grants are compared: whether the workspace's own parent edge exists is decided by
+  // `workspaceExists`, and a workspace with no row should have no relationships at all.
+  if (!source.workspaceExists) {
+    return [];
+  }
+
+  return [
+    ...source.workspaceTeamGrants.map(
+      ({ teamId, workspaceId: grantWorkspaceId }): TAuthzedSourceRef => ({
+        kind: "workspaceTeamGrant",
+        teamId,
+        workspaceId: grantWorkspaceId,
+      })
+    ),
+    ...source.apiKeyWorkspaceGrants.map(
+      ({ apiKeyId, workspaceId: grantWorkspaceId }): TAuthzedSourceRef => ({
+        apiKeyId,
+        kind: "apiKeyWorkspaceGrant",
+        workspaceId: grantWorkspaceId,
+      })
+    ),
+    { kind: "workspace", workspaceId },
+  ];
+};
+
+const observeWorkspace = async (
+  ctx: TRunContext,
+  workspaceId: string,
+  source: TAuthzedWorkspaceSource
+): Promise<ReadonlyArray<TAuthzedSourceRef>> => {
+  const { state } = ctx;
+  const observation = await readAllRelationships(ctx.client, {
+    resourceId: workspaceId,
+    resourceType: "workspace",
+  });
+  const summary = summarizeObservation(observation.relationships);
+  state.ignored += summary.ignored;
+  pushCapped(state.unmanaged, summary.unmanaged);
+  recordMismatchedParents(state, await ctx.sourceReads.findMismatchedParentEdges(summary.parentEdges));
+
+  state.missingCount += findUnprojectedSourceRefs(
+    toWorkspaceSourceRefs(source, workspaceId),
+    summary.sourceRefs
+  ).length;
+
+  const missingRefs = await ctx.sourceReads.findMissingSourceRefs(summary.sourceRefs);
+  state.orphaned += missingRefs.length;
+  pushCapped(state.orphans, missingRefs);
+
+  return selectPrunableRefs(ctx, missingRefs);
+};
+
+/**
+ * Reconcile one workspace's grants.
+ *
+ * The narrowest unit available, and unlike an organization it does not have to exist: a workspace whose
+ * row is gone is the case most worth repairing, and its relationships are reachable from the ID the
+ * caller supplied.
+ *
+ * Narrow, but not hermetic. The API keys holding grants on this workspace are reconciled in full, which
+ * covers every *other* workspace those keys hold too — a key is reconciled as a unit, and splitting it
+ * would mean writing a second, narrower implementation of the same convergence. Everything that reaches
+ * is convergent (it writes what PostgreSQL says), so the effect is a wider repair than asked for, never
+ * a deletion outside the named workspace.
+ */
+const processWorkspace = async (ctx: TRunContext, workspaceId: string): Promise<void> => {
+  const { state } = ctx;
+  state.scanned++;
+
+  let source: TAuthzedWorkspaceSource;
+  try {
+    source = await ctx.sourceReads.readWorkspaceSource(workspaceId);
+  } catch (error) {
+    // No organization to attribute this to: the read that would have told us which one failed.
+    recordFailure(state, "", error);
+
+    return;
+  }
+
+  // Attributed to the owning tenant where PostgreSQL knows one. The empty string is also the sweep's
+  // marker for an orphan with no organization left, so a workspace that still has a row must not
+  // report it.
+  const failureOrganizationId = source.organizationId ?? "";
+
+  let repairRefs: ReadonlyArray<TAuthzedSourceRef> = [];
+  try {
+    repairRefs = await observeWorkspace(ctx, workspaceId, source);
+  } catch (error) {
+    state.truncated = true;
+    recordFailure(state, failureOrganizationId, error);
+
+    return;
+  }
+
+  if (ctx.mode === "dry_run") {
+    return;
+  }
+
+  const failure = await reconcileTargets(
+    ctx.apply,
+    mergeTargets(
+      {
+        apiKeyIds: [],
+        apiKeyWorkspaceGrants: source.apiKeyWorkspaceGrants,
+        memberships: [],
+        teamIds: [],
+        teamMemberships: [],
+        // Naming the workspace projects its parent edge when the row exists, and removes *every*
+        // relationship on it when the row does not — team grants and API-key grants included. That
+        // second case is a prune by the definition on `TAuthzedBackfillRequest`: reconciling a record
+        // observed only in SpiceDB. So it needs the same permission, budget and accounting as any
+        // other prune, rather than happening as a side effect of naming a stale ID with `--apply`.
+        workspaceIds: source.workspaceExists || ctx.isPruning ? [workspaceId] : [],
+        workspaceTeamGrants: source.workspaceTeamGrants,
+      },
+      toRepairTargets(repairRefs)
+    )
+  );
+
+  if (failure) {
+    recordProjectionFailure(state, failureOrganizationId, failure);
+
+    return;
+  }
+
+  state.pruned += repairRefs.length;
+  state.reconciled++;
+};
+
+/** Walk every organization by keyset page. */
+const enumerateOrganizations = async (ctx: TRunContext, afterOrganizationId?: string): Promise<void> => {
+  let cursor = afterOrganizationId;
+
+  for (;;) {
+    let organizationIds: ReadonlyArray<string>;
     try {
-      const observation = await readAllRelationships(client, {
-        resourceId: workspaceId,
-        resourceType: "workspace",
+      organizationIds = await ctx.sourceReads.readOrganizationIdPage({
+        afterOrganizationId: cursor,
+        limit: AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE,
       });
-      const summary = summarizeObservation(observation.relationships);
-      ignored += summary.ignored;
-      unmanaged.push(...summary.unmanaged.slice(0, Math.max(0, MAX_REPORTED_ENTRIES - unmanaged.length)));
-
-      recordMismatchedParents(await sourceReads.findMismatchedParentEdges(summary.parentEdges));
-
-      // Only the grants are compared: whether the workspace's own parent edge exists is decided by
-      // `workspaceExists` below, and a workspace with no row should have no relationships at all.
-      const expected = source.workspaceExists
-        ? [
-            ...source.workspaceTeamGrants.map(
-              ({ teamId, workspaceId: grantWorkspaceId }): TAuthzedSourceRef => ({
-                kind: "workspaceTeamGrant",
-                teamId,
-                workspaceId: grantWorkspaceId,
-              })
-            ),
-            ...source.apiKeyWorkspaceGrants.map(
-              ({ apiKeyId, workspaceId: grantWorkspaceId }): TAuthzedSourceRef => ({
-                apiKeyId,
-                kind: "apiKeyWorkspaceGrant",
-                workspaceId: grantWorkspaceId,
-              })
-            ),
-            { kind: "workspace" as const, workspaceId },
-          ]
-        : [];
-      missingCount += findUnprojectedSourceRefs(expected, summary.sourceRefs).length;
-
-      const missingRefs = await sourceReads.findMissingSourceRefs(summary.sourceRefs);
-      orphaned += missingRefs.length;
-      orphans.push(...missingRefs.slice(0, Math.max(0, MAX_REPORTED_ENTRIES - orphans.length)));
-
-      if (missingRefs.length > maxPrune) {
-        skipped++;
-      } else if (isPruning) {
-        repairRefs = missingRefs;
-        prunableWorkspaceRefs = missingRefs;
-      }
     } catch (error) {
-      truncated = true;
-      recordFailure(failureOrganizationId, error);
+      // Caught rather than propagated so the report survives. Letting this escape would replace the
+      // whole result with a bare failure line, discarding `lastOrganizationId` — the only thing an
+      // operator can resume a long sweep from.
+      ctx.state.truncated = true;
+      recordFailure(ctx.state, "", error);
+
       return;
     }
 
-    if (request.mode === "dry_run") {
+    if (organizationIds.length === 0) {
       return;
     }
 
-    const failure = await reconcileTargets(
-      apply,
-      mergeTargets(
-        {
-          apiKeyIds: [],
-          apiKeyWorkspaceGrants: source.apiKeyWorkspaceGrants,
-          memberships: [],
-          teamIds: [],
-          teamMemberships: [],
-          // Naming the workspace projects its parent edge when the row exists, and removes *every*
-          // relationship on it when the row does not — team grants and API-key grants included. That
-          // second case is a prune by the definition on `TAuthzedBackfillRequest`: reconciling a record
-          // observed only in SpiceDB. So it needs the same permission, budget and accounting as any
-          // other prune, rather than happening as a side effect of naming a stale ID with `--apply`.
-          workspaceIds: source.workspaceExists || isPruning ? [workspaceId] : [],
-          workspaceTeamGrants: source.workspaceTeamGrants,
-        },
-        toRepairTargets(repairRefs)
-      )
-    );
-
-    if (failure) {
-      recordProjectionFailure(failureOrganizationId, failure);
-      return;
+    // Strictly sequential, and not only to avoid write contention: `lastOrganizationId` is the resume
+    // cursor, so processing out of order would let a resume skip an organization that failed while a
+    // later one succeeded.
+    for (const organizationId of organizationIds) {
+      await processOrganization(ctx, organizationId);
     }
+    cursor = organizationIds.at(-1);
+  }
+};
 
-    pruned += prunableWorkspaceRefs.length;
-    reconciled++;
-  };
+const runScope = async (ctx: TRunContext, scope: TAuthzedBackfillScope): Promise<void> => {
+  if (scope.kind === "workspace") {
+    await processWorkspace(ctx, scope.workspaceId);
 
-  if (request.scope.kind === "workspace") {
-    await processWorkspace(request.scope.workspaceId);
-  } else if (request.scope.kind === "organization") {
-    const { organizationId } = request.scope;
-    if (!(await sourceReads.organizationExists(organizationId))) {
+    return;
+  }
+
+  if (scope.kind === "organization") {
+    if (!(await ctx.sourceReads.organizationExists(scope.organizationId))) {
       throw new AuthzedError({
         attempts: 0,
         code: AUTHZED_ERROR_CODES.NOT_FOUND,
@@ -817,89 +944,106 @@ export const runAuthzedBackfill = async (
         retryable: false,
       });
     }
-    await processOrganization(organizationId);
-  } else {
-    let afterOrganizationId = request.scope.afterOrganizationId;
-    for (;;) {
-      let organizationIds: ReadonlyArray<string>;
-      try {
-        organizationIds = await sourceReads.readOrganizationIdPage({
-          afterOrganizationId,
-          limit: AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE,
-        });
-      } catch (error) {
-        // Caught rather than propagated so the report survives. Letting this escape would replace the
-        // whole result with a bare failure line, discarding `lastOrganizationId` — the only thing an
-        // operator can resume a long sweep from.
-        truncated = true;
-        recordFailure("", error);
-        break;
-      }
+    await processOrganization(ctx, scope.organizationId);
 
-      if (organizationIds.length === 0) {
-        break;
-      }
-
-      // Strictly sequential, and not only to avoid write contention: `lastOrganizationId` is the resume
-      // cursor, so processing out of order would let a resume skip an organization that failed while a
-      // later one succeeded.
-      for (const organizationId of organizationIds) {
-        await processOrganization(organizationId);
-      }
-      afterOrganizationId = organizationIds.at(-1);
-    }
-
-    try {
-      await sweepGlobalOrphans();
-    } catch (error) {
-      truncated = true;
-      recordFailure("", error);
-    }
+    return;
   }
 
-  // Taken last, so it post-dates every write this run made. Any managed type answers: the revision is a
-  // property of the datastore, not of the filter.
-  if (request.mode === "apply" && failed === 0) {
-    try {
-      const closing = await client.readRelationships({
-        filter: { resourceType: "organization" },
-        limit: 1,
-      });
-      completedAtSnapshot = closing.snapshot?.token ?? null;
-    } catch {
-      // A freshness floor that might pre-date the writes is worse than none at all.
-      completedAtSnapshot = null;
-    }
+  // The sweep runs even if enumeration broke off part way: it is independent of organization paging,
+  // and it is the only thing that can find a resource no organization can reach.
+  await enumerateOrganizations(ctx, scope.afterOrganizationId);
+  try {
+    await sweepGlobalOrphans(ctx);
+  } catch (error) {
+    ctx.state.truncated = true;
+    recordFailure(ctx.state, "", error);
+  }
+};
+
+/**
+ * A revision read after all work, so it post-dates every write this run made and can serve as an
+ * `at_least_as_fresh` floor. Any managed type answers: the revision is a property of the datastore,
+ * not of the filter.
+ */
+const captureClosingSnapshot = async (ctx: TRunContext): Promise<string | null> => {
+  try {
+    const closing = await ctx.client.readRelationships({
+      filter: { resourceType: "organization" },
+      limit: 1,
+    });
+
+    return closing.snapshot?.token ?? null;
+  } catch {
+    // A freshness floor that might pre-date the writes is worse than none at all.
+    return null;
+  }
+};
+
+/** A failure outranks drift, and only a run that found nothing outstanding is `reconciled`. */
+const toRunStatus = (state: TRunState): TAuthzedBackfillResult["status"] => {
+  if (state.failed > 0) {
+    return "failed";
   }
 
-  // `missing` and `mismatchedParents` matter as much as `orphaned` here: without them a dry run over an
+  // `missing` and `mismatchedParents` matter as much as `orphaned`: without them a dry run over an
   // empty SpiceDB would report "reconciled", which is the exact state this tool exists to fix.
-  const hasDrift = orphaned > pruned || missingCount > 0 || mismatchedParentCount > 0 || truncated;
-  const status = failed > 0 ? "failed" : hasDrift ? "drifted" : "reconciled";
+  const hasDrift =
+    state.orphaned > state.pruned ||
+    state.missingCount > 0 ||
+    state.mismatchedParentCount > 0 ||
+    state.truncated;
+
+  return hasDrift ? "drifted" : "reconciled";
+};
+
+export const runAuthzedBackfill = async (
+  request: TAuthzedBackfillRequest,
+  dependencies: TAuthzedBackfillDependencies
+): Promise<TAuthzedBackfillResult> => {
+  const { apply, client, source: sourceReads = defaultBackfillSource } = dependencies;
+  const state = createRunState();
+  const ctx: TRunContext = {
+    apply,
+    client,
+    isPruning: request.prune && request.mode === "apply",
+    // Defence in depth: the parser already bounds this, but `runAuthzedBackfill` is exported and a
+    // caller passing 0 would make an over-cap unit invisible in `status`.
+    maxPrune: Math.max(1, Math.min(request.maxPrune, AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN)),
+    mode: request.mode,
+    ownsOrphanAccounting: request.scope.kind !== "all",
+    sourceReads,
+    state,
+  };
+
+  await runScope(ctx, request.scope);
+
+  if (request.mode === "apply" && state.failed === 0) {
+    state.completedAtSnapshot = await captureClosingSnapshot(ctx);
+  }
 
   return {
-    completedAtSnapshot,
+    completedAtSnapshot: state.completedAtSnapshot,
     counters: {
-      failed,
-      ignored,
-      invalid,
-      mismatchedParents: mismatchedParentCount,
-      missing: missingCount,
-      orphaned,
-      pruned,
-      reconciled,
-      scanned,
-      skipped,
+      failed: state.failed,
+      ignored: state.ignored,
+      invalid: state.invalid,
+      mismatchedParents: state.mismatchedParentCount,
+      missing: state.missingCount,
+      orphaned: state.orphaned,
+      pruned: state.pruned,
+      reconciled: state.reconciled,
+      scanned: state.scanned,
+      skipped: state.skipped,
     },
-    failures,
-    lastOrganizationId,
-    mismatchedParents,
+    failures: state.failures,
+    lastOrganizationId: state.lastOrganizationId,
+    mismatchedParents: state.mismatchedParents,
     mode: request.mode,
     orphanScope: request.scope.kind === "all" ? "all" : "known_resources",
-    orphans,
+    orphans: state.orphans,
     scope: request.scope.kind,
-    status,
-    truncated,
-    unmanaged,
+    status: toRunStatus(state),
+    truncated: state.truncated,
+    unmanaged: state.unmanaged,
   };
 };

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -1,0 +1,496 @@
+import "server-only";
+import type { TApiKeyProjectionTargets } from "./api-key";
+import { type TAuthzedSourceRef, getManagedResourceTypes, summarizeObservation } from "./backfill-diff";
+import {
+  type TAuthzedApiKeyWorkspaceTarget,
+  type TAuthzedMembershipTarget,
+  type TAuthzedOrganizationSource,
+  type TAuthzedTeamMembershipTarget,
+  type TAuthzedWorkspaceTeamTarget,
+  findMissingSourceRefs,
+  organizationExists,
+  readOrganizationIdPage,
+  readOrganizationSource,
+} from "./backfill-source";
+import type { TAuthzedClient, TAuthzedRelationship } from "./client";
+import { AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE, AUTHZED_BACKFILL_TARGET_CHUNK_SIZE } from "./constants";
+import { AuthzedError } from "./errors";
+import type { TOrganizationMembershipProjectionTargets } from "./organization-membership";
+import type { TAuthzedProjectionResult } from "./projection";
+import { readAllRelationships } from "./relationship-reads";
+import type { TTeamWorkspaceProjectionTargets } from "./team-workspace";
+
+/**
+ * Relationship backfill and repair, organized around one organization at a time.
+ *
+ * **Command-line use only** — see the note on `./backfill-source`. This module performs no
+ * authorization check, because it runs as an operator against the whole database.
+ *
+ * The organization is the unit of work because every authorization-relevant model reaches
+ * `Organization` in one hop or two, so an organization's target set is closed and can be reconciled
+ * without consulting any other. It also means backfill and single-organization repair are the same
+ * code path with a different unit list, and that a partial run leaves complete graphs for the
+ * organizations it finished rather than a fragment of every tenant's graph.
+ *
+ * This module cannot write. It reaches mutations only through an injected capability object, and it
+ * imports neither `getAuthzedClient` nor any reconciler — so a dry run is inert by construction rather
+ * than by remembering to check a flag.
+ */
+
+/** Mutation capability. Supplied by the CLI; a dry run supplies no-ops. */
+export type TAuthzedBackfillApply = Readonly<{
+  reconcileApiKeys: (targets: TApiKeyProjectionTargets) => Promise<TAuthzedProjectionResult>;
+  reconcileMemberships: (
+    targets: TOrganizationMembershipProjectionTargets
+  ) => Promise<TAuthzedProjectionResult>;
+  reconcileTeamWorkspace: (targets: TTeamWorkspaceProjectionTargets) => Promise<TAuthzedProjectionResult>;
+}>;
+
+export type TAuthzedBackfillScope =
+  | Readonly<{ afterOrganizationId?: string; kind: "all" }>
+  | Readonly<{ kind: "organization"; organizationId: string }>;
+
+export type TAuthzedBackfillRequest = Readonly<{
+  maxPrune: number;
+  mode: "apply" | "dry_run";
+  /**
+   * Whether relationships with no source record may be removed.
+   *
+   * Note that "no prune" does not mean "no deletes": converging a membership inherently deletes the
+   * roles it does not hold. What pruning adds is permission to reconcile records observed *only* in
+   * SpiceDB — the ones PostgreSQL has no row for at all.
+   */
+  prune: boolean;
+  scope: TAuthzedBackfillScope;
+}>;
+
+export type TAuthzedBackfillDependencies = Readonly<{
+  apply: TAuthzedBackfillApply;
+  /** Read-only slice of the facade. Deliberately not the whole client. */
+  client: Pick<TAuthzedClient, "readRelationships">;
+}>;
+
+export type TAuthzedBackfillCounters = Readonly<{
+  failed: number;
+  ignored: number;
+  invalid: number;
+  orphaned: number;
+  pruned: number;
+  reconciled: number;
+  scanned: number;
+  skipped: number;
+}>;
+
+export type TAuthzedBackfillFailure = Readonly<{
+  code: string;
+  organizationId: string;
+  retryable: boolean;
+}>;
+
+export type TAuthzedBackfillResult = Readonly<{
+  completedAtSnapshot: string | null;
+  counters: TAuthzedBackfillCounters;
+  failures: ReadonlyArray<TAuthzedBackfillFailure>;
+  lastOrganizationId: string | null;
+  mode: "apply" | "dry_run";
+  orphanScope: "all" | "known_resources";
+  orphans: ReadonlyArray<TAuthzedSourceRef>;
+  scope: "all" | "organization";
+  status: "drifted" | "failed" | "reconciled";
+  /** Set when any observation was abandoned, so the report must not be read as complete. */
+  truncated: boolean;
+  unmanaged: ReadonlyArray<Readonly<{ objectId: string; objectType: string; relation: string }>>;
+}>;
+
+/** Entries reported individually before the list is capped and only counters remain accurate. */
+const MAX_REPORTED_ENTRIES = 100;
+
+const chunk = <TItem>(items: ReadonlyArray<TItem>, size: number): ReadonlyArray<ReadonlyArray<TItem>> => {
+  const chunks: TItem[][] = [];
+  for (let start = 0; start < items.length; start += size) {
+    chunks.push(items.slice(start, start + size));
+  }
+  return chunks;
+};
+
+const toErrorCode = (error: unknown): Readonly<{ code: string; retryable: boolean }> =>
+  error instanceof AuthzedError
+    ? { code: error.code, retryable: error.retryable }
+    : { code: "authzed_internal", retryable: false };
+
+/** The seven target lists the three reconcilers accept between them. */
+type TReconcileTargets = Readonly<{
+  apiKeyIds: ReadonlyArray<string>;
+  apiKeyWorkspaceGrants: ReadonlyArray<TAuthzedApiKeyWorkspaceTarget>;
+  memberships: ReadonlyArray<TAuthzedMembershipTarget>;
+  teamIds: ReadonlyArray<string>;
+  teamMemberships: ReadonlyArray<TAuthzedTeamMembershipTarget>;
+  workspaceIds: ReadonlyArray<string>;
+  workspaceTeamGrants: ReadonlyArray<TAuthzedWorkspaceTeamTarget>;
+}>;
+
+/**
+ * Turn missing source records into reconciler targets.
+ *
+ * A record PostgreSQL does not hold becomes a *target*, never a delete instruction. The reconciler
+ * re-reads PostgreSQL and decides, so a record recreated between the observation and the reconcile is
+ * written rather than deleted — the race resolves toward granting access, not revoking it. That
+ * indirection is the core reason repair is safe.
+ */
+const toRepairTargets = (refs: ReadonlyArray<TAuthzedSourceRef>): TReconcileTargets => {
+  const apiKeyIds: string[] = [];
+  const apiKeyWorkspaceGrants: TAuthzedApiKeyWorkspaceTarget[] = [];
+  const memberships: TAuthzedMembershipTarget[] = [];
+  const teamIds: string[] = [];
+  const teamMemberships: TAuthzedTeamMembershipTarget[] = [];
+  const workspaceIds: string[] = [];
+  const workspaceTeamGrants: TAuthzedWorkspaceTeamTarget[] = [];
+
+  for (const ref of refs) {
+    switch (ref.kind) {
+      case "apiKey":
+        apiKeyIds.push(ref.apiKeyId);
+        break;
+      case "apiKeyWorkspaceGrant":
+        apiKeyWorkspaceGrants.push({ apiKeyId: ref.apiKeyId, workspaceId: ref.workspaceId });
+        break;
+      case "membership":
+        memberships.push({ organizationId: ref.organizationId, userId: ref.userId });
+        break;
+      case "team":
+        teamIds.push(ref.teamId);
+        break;
+      case "teamMembership":
+        teamMemberships.push({ teamId: ref.teamId, userId: ref.userId });
+        break;
+      case "workspace":
+        workspaceIds.push(ref.workspaceId);
+        break;
+      case "workspaceTeamGrant":
+        workspaceTeamGrants.push({ teamId: ref.teamId, workspaceId: ref.workspaceId });
+        break;
+    }
+  }
+
+  return {
+    apiKeyIds,
+    apiKeyWorkspaceGrants,
+    memberships,
+    teamIds,
+    teamMemberships,
+    workspaceIds,
+    workspaceTeamGrants,
+  };
+};
+
+const mergeTargets = (left: TReconcileTargets, right: TReconcileTargets): TReconcileTargets => ({
+  apiKeyIds: [...left.apiKeyIds, ...right.apiKeyIds],
+  apiKeyWorkspaceGrants: [...left.apiKeyWorkspaceGrants, ...right.apiKeyWorkspaceGrants],
+  memberships: [...left.memberships, ...right.memberships],
+  teamIds: [...left.teamIds, ...right.teamIds],
+  teamMemberships: [...left.teamMemberships, ...right.teamMemberships],
+  workspaceIds: [...left.workspaceIds, ...right.workspaceIds],
+  workspaceTeamGrants: [...left.workspaceTeamGrants, ...right.workspaceTeamGrants],
+});
+
+/**
+ * Run one reconciler over chunked targets, stopping at the first chunk that does not project.
+ *
+ * Returns `null` when there was nothing to do, so an empty list never reaches a reconciler — the write
+ * facade rejects an empty batch.
+ *
+ * `runBestEffortProjection` never throws; a reconciler hands back `{ status: "failed" }` instead. That
+ * is what gives per-unit isolation for free, since one organization's AuthZed outage cannot abort the
+ * sweep. `"disabled"` counts as a failure rather than a success — otherwise a run against an instance
+ * with AuthZed switched off would report every organization as reconciled.
+ */
+const runChunked = async <TItem, TTargets>(
+  reconcile: (targets: TTargets) => Promise<TAuthzedProjectionResult>,
+  items: ReadonlyArray<TItem>,
+  buildTargets: (chunkItems: ReadonlyArray<TItem>) => TTargets
+): Promise<TAuthzedProjectionResult | null> => {
+  if (items.length === 0) {
+    return null;
+  }
+
+  for (const chunkItems of chunk(items, AUTHZED_BACKFILL_TARGET_CHUNK_SIZE)) {
+    const result = await reconcile(buildTargets(chunkItems));
+    if (result.status !== "projected") {
+      return result;
+    }
+  }
+
+  return { passes: 1, status: "projected" };
+};
+
+/** Reconcile every target list, reporting the first that did not project. */
+const reconcileTargets = async (
+  apply: TAuthzedBackfillApply,
+  targets: TReconcileTargets
+): Promise<TAuthzedProjectionResult | undefined> => {
+  const outcomes = [
+    await runChunked(apply.reconcileMemberships, targets.memberships, (memberships) => ({ memberships })),
+    await runChunked(apply.reconcileTeamWorkspace, targets.teamIds, (teamIds) => ({ teamIds })),
+    await runChunked(apply.reconcileTeamWorkspace, targets.workspaceIds, (workspaceIds) => ({
+      workspaceIds,
+    })),
+    await runChunked(apply.reconcileTeamWorkspace, targets.teamMemberships, (teamMemberships) => ({
+      teamMemberships,
+    })),
+    await runChunked(apply.reconcileTeamWorkspace, targets.workspaceTeamGrants, (workspaceTeamGrants) => ({
+      workspaceTeamGrants,
+    })),
+    await runChunked(apply.reconcileApiKeys, targets.apiKeyIds, (apiKeyIds) => ({ apiKeyIds })),
+    await runChunked(apply.reconcileApiKeys, targets.apiKeyWorkspaceGrants, (apiKeyWorkspaceGrants) => ({
+      apiKeyWorkspaceGrants,
+    })),
+  ];
+
+  return outcomes.find(
+    (outcome): outcome is TAuthzedProjectionResult => outcome !== null && outcome.status !== "projected"
+  );
+};
+
+/**
+ * Observe the relationships on one organization's own resources.
+ *
+ * Bounded to resources PostgreSQL still knows about, because SpiceDB relationship filters have no
+ * notion of "belongs to organization X" and Formbricks object IDs carry no organization prefix. A
+ * resource whose row is already gone is therefore unreachable from its organization, which is why
+ * single-organization repair reports `orphanScope: "known_resources"` and only a full sweep can claim
+ * completeness.
+ */
+const observeOrganizationResources = async (
+  client: Pick<TAuthzedClient, "readRelationships">,
+  organizationId: string,
+  source: TAuthzedOrganizationSource
+): Promise<Readonly<{ relationships: ReadonlyArray<TAuthzedRelationship>; snapshot: string | null }>> => {
+  const filters = [
+    { resourceId: organizationId, resourceType: "organization" },
+    ...source.teamIds.map((teamId) => ({ resourceId: teamId, resourceType: "team" })),
+    ...source.workspaceIds.map((workspaceId) => ({ resourceId: workspaceId, resourceType: "workspace" })),
+    ...source.apiKeyIds.map((apiKeyId) => ({ resourceId: apiKeyId, resourceType: "api_key" })),
+  ];
+
+  const relationships: TAuthzedRelationship[] = [];
+  let snapshot: string | null = null;
+
+  for (const filter of filters) {
+    const observation = await readAllRelationships(client, filter);
+    relationships.push(...observation.relationships);
+    snapshot = observation.snapshot?.token ?? snapshot;
+  }
+
+  return { relationships, snapshot };
+};
+
+export const runAuthzedBackfill = async (
+  request: TAuthzedBackfillRequest,
+  dependencies: TAuthzedBackfillDependencies
+): Promise<TAuthzedBackfillResult> => {
+  const { apply, client } = dependencies;
+  const isPruning = request.prune && request.mode === "apply";
+
+  let failed = 0;
+  let ignored = 0;
+  let invalid = 0;
+  let orphaned = 0;
+  let pruned = 0;
+  let reconciled = 0;
+  let scanned = 0;
+  let skipped = 0;
+  let truncated = false;
+  let completedAtSnapshot: string | null = null;
+  let lastOrganizationId: string | null = null;
+  const failures: TAuthzedBackfillFailure[] = [];
+  const orphans: TAuthzedSourceRef[] = [];
+  const unmanaged: Array<Readonly<{ objectId: string; objectType: string; relation: string }>> = [];
+
+  const recordFailure = (organizationId: string, error: unknown): void => {
+    failed++;
+    if (failures.length < MAX_REPORTED_ENTRIES) {
+      failures.push({ organizationId, ...toErrorCode(error) });
+    }
+  };
+
+  const recordProjectionFailure = (organizationId: string, result: TAuthzedProjectionResult): void => {
+    failed++;
+    if (failures.length < MAX_REPORTED_ENTRIES) {
+      failures.push(
+        result.status === "failed"
+          ? { code: result.code, organizationId, retryable: result.retryable }
+          : // `disabled` reaching here means AuthZed was switched off mid-run.
+            { code: "authzed_disabled", organizationId, retryable: false }
+      );
+    }
+  };
+
+  const processOrganization = async (organizationId: string): Promise<void> => {
+    scanned++;
+    lastOrganizationId = organizationId;
+
+    let source: TAuthzedOrganizationSource;
+    try {
+      source = await readOrganizationSource(organizationId);
+    } catch (error) {
+      recordFailure(organizationId, error);
+      return;
+    }
+
+    invalid += source.invalidWorkspaceTeamGrants.length;
+
+    // Observation only matters for single-organization scope; a full sweep observes globally instead,
+    // which strictly covers more.
+    let repairRefs: ReadonlyArray<TAuthzedSourceRef> = [];
+    if (request.scope.kind === "organization") {
+      try {
+        const observation = await observeOrganizationResources(client, organizationId, source);
+        const summary = summarizeObservation(observation.relationships);
+        ignored += summary.ignored;
+        for (const ref of summary.unmanaged) {
+          if (unmanaged.length < MAX_REPORTED_ENTRIES) {
+            unmanaged.push(ref);
+          }
+        }
+        completedAtSnapshot = observation.snapshot ?? completedAtSnapshot;
+
+        const missing = await findMissingSourceRefs(summary.sourceRefs);
+        orphaned += missing.length;
+        for (const ref of missing) {
+          if (orphans.length < MAX_REPORTED_ENTRIES) {
+            orphans.push(ref);
+          }
+        }
+
+        if (missing.length > request.maxPrune) {
+          // A large orphan count is a symptom — wrong endpoint, wrong database, a restore in progress —
+          // not a big cleanup job. Prune nothing for this unit so the run degrades into a loud report
+          // instead of a partly-destroyed graph.
+          skipped++;
+        } else if (isPruning) {
+          repairRefs = missing;
+          pruned += missing.length;
+        }
+      } catch (error) {
+        // An abandoned observation must never be reported as a complete one: fewer relationships seen
+        // means fewer orphans found, and a caller could otherwise read that as "nothing stale here".
+        truncated = true;
+        recordFailure(organizationId, error);
+        return;
+      }
+    }
+
+    if (request.mode === "dry_run") {
+      return;
+    }
+
+    const failure = await reconcileTargets(
+      apply,
+      mergeTargets(
+        {
+          apiKeyIds: source.apiKeyIds,
+          apiKeyWorkspaceGrants: source.apiKeyWorkspaceGrants,
+          memberships: source.memberships,
+          teamIds: source.teamIds,
+          teamMemberships: source.teamMemberships,
+          workspaceIds: source.workspaceIds,
+          workspaceTeamGrants: source.workspaceTeamGrants,
+        },
+        toRepairTargets(repairRefs)
+      )
+    );
+
+    if (failure) {
+      recordProjectionFailure(organizationId, failure);
+      return;
+    }
+
+    reconciled++;
+  };
+
+  /** Sweep every managed resource type to find resources PostgreSQL no longer holds at all. */
+  const sweepGlobalOrphans = async (): Promise<void> => {
+    const relationships: TAuthzedRelationship[] = [];
+
+    for (const resourceType of getManagedResourceTypes()) {
+      const observation = await readAllRelationships(client, { resourceType });
+      relationships.push(...observation.relationships);
+      completedAtSnapshot = observation.snapshot?.token ?? completedAtSnapshot;
+    }
+
+    const summary = summarizeObservation(relationships);
+    ignored += summary.ignored;
+    unmanaged.push(...summary.unmanaged.slice(0, MAX_REPORTED_ENTRIES - unmanaged.length));
+
+    const missing = await findMissingSourceRefs(summary.sourceRefs);
+    orphaned += missing.length;
+    orphans.push(...missing.slice(0, MAX_REPORTED_ENTRIES - orphans.length));
+
+    if (missing.length > request.maxPrune) {
+      skipped++;
+      return;
+    }
+
+    if (!isPruning) {
+      return;
+    }
+
+    const failure = await reconcileTargets(apply, toRepairTargets(missing));
+    if (failure) {
+      // Attributed to no organization: a fully orphaned resource has none left to attribute it to.
+      recordProjectionFailure("", failure);
+      return;
+    }
+
+    pruned += missing.length;
+  };
+
+  if (request.scope.kind === "organization") {
+    const { organizationId } = request.scope;
+    if (!(await organizationExists(organizationId))) {
+      throw new Error("Organization not found");
+    }
+    await processOrganization(organizationId);
+  } else {
+    let afterOrganizationId = request.scope.afterOrganizationId;
+    for (;;) {
+      const organizationIds = await readOrganizationIdPage({
+        afterOrganizationId,
+        limit: AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE,
+      });
+      if (organizationIds.length === 0) {
+        break;
+      }
+
+      // Strictly sequential: concurrent writes to the same organization resource produce retryable
+      // serialization conflicts against a small retry budget.
+      for (const organizationId of organizationIds) {
+        await processOrganization(organizationId);
+      }
+      afterOrganizationId = organizationIds.at(-1);
+    }
+
+    try {
+      await sweepGlobalOrphans();
+    } catch (error) {
+      truncated = true;
+      recordFailure("", error);
+    }
+  }
+
+  const status = failed > 0 ? "failed" : orphaned > pruned || truncated ? "drifted" : "reconciled";
+
+  return {
+    completedAtSnapshot,
+    counters: { failed, ignored, invalid, orphaned, pruned, reconciled, scanned, skipped },
+    failures,
+    lastOrganizationId,
+    mode: request.mode,
+    orphanScope: request.scope.kind === "all" ? "all" : "known_resources",
+    orphans,
+    scope: request.scope.kind,
+    status,
+    truncated,
+    unmanaged,
+  };
+};

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -506,26 +506,40 @@ export const runAuthzedBackfill = async (
 
     invalid += source.invalidWorkspaceTeamGrants.length;
 
-    // Observed per organization when the scope names one, and also whenever nothing is going to be
-    // written: a dry run has to *detect* the drift an applying run would simply converge, or it would
-    // report a clean bill of health for a SpiceDB that is missing everything. An applying full sweep
-    // skips this, because its writes fix that direction and the global sweep covers the other one.
+    // Two reasons to observe an organization's own resources, and they have different owners.
+    //
+    // A narrow scope has no global sweep behind it, so the observation owns everything it finds. A full
+    // scope *does* have one, and the sweep sees strictly more — so here the observation exists only to
+    // compute the direction the sweep cannot: records PostgreSQL holds that SpiceDB is missing. Counting
+    // orphans on both paths would report every stale relationship twice, and the default invocation is
+    // exactly that combination (dry run, full scope).
+    //
+    // An applying full scope skips the observation entirely: its writes converge the missing direction
+    // anyway, and paying a read per resource to report what is about to be fixed is waste.
+    const ownsOrphanAccounting = request.scope.kind !== "all";
+    const needsMissingCheck = request.mode === "dry_run";
     let repairRefs: ReadonlyArray<TAuthzedSourceRef> = [];
     let prunableRefs: ReadonlyArray<TAuthzedSourceRef> = [];
-    if (request.scope.kind === "organization" || request.mode === "dry_run") {
+    if (ownsOrphanAccounting || needsMissingCheck) {
       try {
         const observation = await observeOrganizationResources(client, organizationId, source);
         const summary = summarizeObservation(observation.relationships);
+
+        if (needsMissingCheck) {
+          // The direction an applying run converges by writing, and the only one a report can speak to.
+          missingCount += findUnprojectedSourceRefs(toSourceRefs(source), summary.sourceRefs).length;
+        }
+
+        if (!ownsOrphanAccounting) {
+          return;
+        }
+
         ignored += summary.ignored;
         for (const ref of summary.unmanaged) {
           if (unmanaged.length < MAX_REPORTED_ENTRIES) {
             unmanaged.push(ref);
           }
         }
-
-        // The direction an applying run converges by writing, and the only one a report can speak to.
-        const unprojected = findUnprojectedSourceRefs(toSourceRefs(source), summary.sourceRefs);
-        missingCount += unprojected.length;
 
         recordMismatchedParents(await sourceReads.findMismatchedParentEdges(summary.parentEdges));
 

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -322,17 +322,6 @@ const mergeTargets = (left: TReconcileTargets, right: TReconcileTargets): TRecon
 /**
  * Run one reconciler over chunked targets, stopping at the first chunk that does not project.
  *
- * Returns `null` when there was nothing to do, so an empty list never reaches a reconciler — the write
- * facade rejects an empty batch.
- *
- * `runBestEffortProjection` never throws; a reconciler hands back `{ status: "failed" }` instead. That
- * is what gives per-unit isolation for free, since one organization's AuthZed outage cannot abort the
- * sweep. `"disabled"` counts as a failure rather than a success — otherwise a run against an instance
- * with AuthZed switched off would report every organization as reconciled.
- */
-/**
- * Run one reconciler over chunked targets, stopping at the first chunk that does not project.
- *
  * A reconciler accepts several target lists at once and reads one PostgreSQL snapshot covering all of
  * them, so every list it understands is passed in a single call. Splitting them would multiply the
  * snapshot reads and the verification passes for no benefit.
@@ -385,6 +374,11 @@ const runChunked = async <TTargets extends Readonly<Record<string, ReadonlyArray
  *
  * One call per reconciler rather than one per list: each reads a single snapshot covering everything it
  * was given, so this is three snapshot reads for an organization instead of seven.
+ *
+ * `runBestEffortProjection` never throws; a reconciler hands back `{ status: "failed" }` instead. That
+ * is what gives per-unit isolation for free, since one organization's AuthZed outage cannot abort the
+ * sweep. `"disabled"` counts as a failure rather than a success — otherwise a run against an instance
+ * with AuthZed switched off would report every organization as reconciled.
  */
 const reconcileTargets = async (
   apply: TAuthzedBackfillApply,
@@ -562,6 +556,19 @@ const recordMismatchedParents = (state: TRunState, edges: ReadonlyArray<TAuthzed
 };
 
 /**
+ * What a unit is permitted to prune.
+ *
+ * `overBudget` is carried separately rather than inferred from an empty `refs`, because "nothing to
+ * prune" and "too much to prune safely" must lead to different decisions and an empty list cannot tell
+ * them apart. The workspace scope depends on the difference: naming a workspace whose row is gone
+ * deletes *every* relationship on it, so that target has to be withheld when the budget was exceeded.
+ */
+type TPruneDecision = Readonly<{
+  overBudget: boolean;
+  refs: ReadonlyArray<TAuthzedSourceRef>;
+}>;
+
+/**
  * Record the classification tallies an observation implies, and verify the organizations its resources
  * claim to belong to.
  *
@@ -590,7 +597,7 @@ const recordObservationSummary = async (
 const recordScopedOrphans = async (
   ctx: TRunContext,
   summary: TAuthzedObservationSummary
-): Promise<ReadonlyArray<TAuthzedSourceRef>> => {
+): Promise<TPruneDecision> => {
   const missingRefs = await ctx.sourceReads.findMissingSourceRefs(summary.sourceRefs);
   ctx.state.orphaned += missingRefs.length;
   pushCapped(ctx.state.orphans, missingRefs);
@@ -598,10 +605,10 @@ const recordScopedOrphans = async (
   if (missingRefs.length > ctx.maxPrune) {
     ctx.state.skipped++;
 
-    return [];
+    return { overBudget: true, refs: [] };
   }
 
-  return ctx.isPruning ? missingRefs : [];
+  return { overBudget: false, refs: ctx.isPruning ? missingRefs : [] };
 };
 
 /**
@@ -615,7 +622,7 @@ const observeOrganization = async (
   ctx: TRunContext,
   organizationId: string,
   source: TAuthzedOrganizationSource
-): Promise<ReadonlyArray<TAuthzedSourceRef>> => {
+): Promise<TPruneDecision> => {
   const { state } = ctx;
   const observation = await observeOrganizationResources(ctx.client, organizationId, source);
   const summary = summarizeObservation(observation.relationships);
@@ -626,7 +633,7 @@ const observeOrganization = async (
   }
 
   if (!ctx.ownsOrphanAccounting) {
-    return [];
+    return { overBudget: false, refs: [] };
   }
 
   await recordObservationSummary(ctx, summary);
@@ -657,7 +664,7 @@ const processOrganization = async (ctx: TRunContext, organizationId: string): Pr
   let repairRefs: ReadonlyArray<TAuthzedSourceRef> = [];
   if (ctx.ownsOrphanAccounting || ctx.mode === "dry_run") {
     try {
-      repairRefs = await observeOrganization(ctx, organizationId, source);
+      repairRefs = (await observeOrganization(ctx, organizationId, source)).refs;
     } catch (error) {
       // An abandoned observation must never be reported as a complete one: fewer relationships seen
       // means fewer orphans found, and a caller could otherwise read that as "nothing stale here".
@@ -826,7 +833,7 @@ const observeWorkspace = async (
   ctx: TRunContext,
   workspaceId: string,
   source: TAuthzedWorkspaceSource
-): Promise<ReadonlyArray<TAuthzedSourceRef>> => {
+): Promise<TPruneDecision> => {
   const observation = await readAllRelationships(ctx.client, {
     resourceId: workspaceId,
     resourceType: "workspace",
@@ -874,9 +881,9 @@ const processWorkspace = async (ctx: TRunContext, workspaceId: string): Promise<
   // report it.
   const failureOrganizationId = source.organizationId ?? "";
 
-  let repairRefs: ReadonlyArray<TAuthzedSourceRef> = [];
+  let decision: TPruneDecision = { overBudget: false, refs: [] };
   try {
-    repairRefs = await observeWorkspace(ctx, workspaceId, source);
+    decision = await observeWorkspace(ctx, workspaceId, source);
   } catch (error) {
     state.truncated = true;
     recordFailure(state, failureOrganizationId, error);
@@ -900,12 +907,16 @@ const processWorkspace = async (ctx: TRunContext, workspaceId: string): Promise<
         // Naming the workspace projects its parent edge when the row exists, and removes *every*
         // relationship on it when the row does not — team grants and API-key grants included. That
         // second case is a prune by the definition on `TAuthzedBackfillRequest`: reconciling a record
-        // observed only in SpiceDB. So it needs the same permission, budget and accounting as any
-        // other prune, rather than happening as a side effect of naming a stale ID with `--apply`.
-        workspaceIds: source.workspaceExists || ctx.isPruning ? [workspaceId] : [],
+        // observed only in SpiceDB. So it needs the same permission, budget and accounting as any other
+        // prune, rather than happening as a side effect of naming a stale ID with `--apply`.
+        //
+        // `overBudget` is load-bearing here, not decoration: without it an over-cap unit would report
+        // `skipped: 1, pruned: 0` and still perform the widest deletion available on that workspace,
+        // which inverts what the cap is for.
+        workspaceIds: source.workspaceExists || (ctx.isPruning && !decision.overBudget) ? [workspaceId] : [],
         workspaceTeamGrants: source.workspaceTeamGrants,
       },
-      toRepairTargets(repairRefs)
+      toRepairTargets(decision.refs)
     )
   );
 
@@ -915,7 +926,7 @@ const processWorkspace = async (ctx: TRunContext, workspaceId: string): Promise<
     return;
   }
 
-  state.pruned += repairRefs.length;
+  state.pruned += decision.refs.length;
   state.reconciled++;
 };
 

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -943,7 +943,10 @@ const processWorkspace = async (ctx: TRunContext, workspaceId: string): Promise<
 
   state.invalid += source.invalidWorkspaceTeamGrants.length + source.invalidApiKeyWorkspaceGrants.length;
 
-  let decision: TPruneDecision = { overBudget: false, refs: [] };
+  // Declared without a value, like `source` above: the `catch` returns, so an initializer here would be
+  // dead — and a dead initializer on a prune decision is worse than noise, since it reads as a safe
+  // default that nothing actually falls back to.
+  let decision: TPruneDecision;
   try {
     const observed = await observeWorkspace(ctx, workspaceId, source);
     decision = { ...observed, refs: await withinWorkspaceScope(ctx, observed.refs) };

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -140,6 +140,16 @@ export type TAuthzedBackfillFailure = Readonly<{
 }>;
 
 export type TAuthzedBackfillResult = Readonly<{
+  /**
+   * A revision SpiceDB was at *after* this run finished writing, or `null`.
+   *
+   * Captured by one read issued once all work is done, so it genuinely post-dates the run's own writes
+   * and can serve as an `at_least_as_fresh` floor for shadow evaluation. Taking it from the observation
+   * reads instead would have pre-dated them, which is the opposite of a freshness floor.
+   *
+   * `null` for a dry run (nothing was written, so there is nothing to be fresh relative to), for an empty
+   * store, and if the closing read fails — never a stale value dressed up as a fresh one.
+   */
   completedAtSnapshot: string | null;
   counters: TAuthzedBackfillCounters;
   failures: ReadonlyArray<TAuthzedBackfillFailure>;
@@ -157,7 +167,14 @@ export type TAuthzedBackfillResult = Readonly<{
   orphans: ReadonlyArray<TAuthzedSourceRef>;
   scope: "all" | "organization" | "workspace";
   status: "drifted" | "failed" | "reconciled";
-  /** Set when any observation was abandoned, so the report must not be read as complete. */
+  /**
+   * Set when an observation was abandoned, so the counts are a floor rather than a total.
+   *
+   * Deliberately narrow: it does *not* mean the `orphans` / `failures` / `mismatchedParents` lists hit
+   * their reporting cap. Those stay capped at 100 entries with the counters carrying the true totals,
+   * and conflating the two would make a merely-verbose run look like an incomplete one — which matters,
+   * because this flag forces a non-clean status.
+   */
   truncated: boolean;
   unmanaged: ReadonlyArray<Readonly<{ objectId: string; objectType: string; relation: string }>>;
 }>;
@@ -302,7 +319,8 @@ const runChunked = async <TTargets extends Readonly<Record<string, ReadonlyArray
   reconcile: (targets: TTargets) => Promise<TAuthzedProjectionResult>,
   targets: TTargets
 ): Promise<TAuthzedProjectionResult | null> => {
-  const entries = Object.entries(targets).filter(([, items]) => items.length > 0);
+  type TEntry = readonly [keyof TTargets & string, ReadonlyArray<unknown>];
+  const entries = (Object.entries(targets) as ReadonlyArray<TEntry>).filter(([, items]) => items.length > 0);
   if (entries.length === 0) {
     return null;
   }
@@ -313,11 +331,16 @@ const runChunked = async <TTargets extends Readonly<Record<string, ReadonlyArray
 
   for (let index = 0; index < chunkCount; index++) {
     const start = index * AUTHZED_BACKFILL_TARGET_CHUNK_SIZE;
-    const chunkTargets = Object.fromEntries(
-      entries
-        .map(([key, items]) => [key, items.slice(start, start + AUTHZED_BACKFILL_TARGET_CHUNK_SIZE)])
-        .filter(([, items]) => (items as ReadonlyArray<unknown>).length > 0)
-    ) as TTargets;
+    // Built by narrowing a full target object rather than assembling a partial one and asserting the
+    // type. Every field of the reconcilers' target types is optional, so an assertion would silently
+    // keep compiling if one ever became required — and the missing list would only surface at runtime.
+    const chunkTargets: TTargets = { ...targets };
+    for (const [key, items] of entries) {
+      (chunkTargets as Record<string, ReadonlyArray<unknown>>)[key] = items.slice(
+        start,
+        start + AUTHZED_BACKFILL_TARGET_CHUNK_SIZE
+      );
+    }
 
     const result = await reconcile(chunkTargets);
     if (result.status !== "projected") {
@@ -338,23 +361,32 @@ const reconcileTargets = async (
   apply: TAuthzedBackfillApply,
   targets: TReconcileTargets
 ): Promise<TAuthzedProjectionResult | undefined> => {
-  const outcomes = [
-    await runChunked(apply.reconcileMemberships, { memberships: targets.memberships }),
-    await runChunked(apply.reconcileTeamWorkspace, {
-      teamIds: targets.teamIds,
-      teamMemberships: targets.teamMemberships,
-      workspaceIds: targets.workspaceIds,
-      workspaceTeamGrants: targets.workspaceTeamGrants,
-    }),
-    await runChunked(apply.reconcileApiKeys, {
-      apiKeyIds: targets.apiKeyIds,
-      apiKeyWorkspaceGrants: targets.apiKeyWorkspaceGrants,
-    }),
+  // Stops at the first reconciler that does not project. Continuing would spend two more three-attempt
+  // retry budgets against an instance already known to be unreachable, and the unit is failed either way.
+  const steps = [
+    () => runChunked(apply.reconcileMemberships, { memberships: targets.memberships }),
+    () =>
+      runChunked(apply.reconcileTeamWorkspace, {
+        teamIds: targets.teamIds,
+        teamMemberships: targets.teamMemberships,
+        workspaceIds: targets.workspaceIds,
+        workspaceTeamGrants: targets.workspaceTeamGrants,
+      }),
+    () =>
+      runChunked(apply.reconcileApiKeys, {
+        apiKeyIds: targets.apiKeyIds,
+        apiKeyWorkspaceGrants: targets.apiKeyWorkspaceGrants,
+      }),
   ];
 
-  return outcomes.find(
-    (outcome): outcome is TAuthzedProjectionResult => outcome !== null && outcome.status !== "projected"
-  );
+  for (const step of steps) {
+    const outcome = await step();
+    if (outcome !== null && outcome.status !== "projected") {
+      return outcome;
+    }
+  }
+
+  return undefined;
 };
 
 /**
@@ -490,7 +522,6 @@ export const runAuthzedBackfill = async (
             unmanaged.push(ref);
           }
         }
-        completedAtSnapshot = observation.snapshot ?? completedAtSnapshot;
 
         // The direction an applying run converges by writing, and the only one a report can speak to.
         const unprojected = findUnprojectedSourceRefs(toSourceRefs(source), summary.sourceRefs);
@@ -581,7 +612,7 @@ export const runAuthzedBackfill = async (
       });
 
     for (const resourceType of getManagedResourceTypes()) {
-      const snapshot = await forEachRelationshipPage(client, { resourceType }, async (relationships) => {
+      await forEachRelationshipPage(client, { resourceType }, async (relationships) => {
         if (capExceeded) {
           return;
         }
@@ -618,8 +649,6 @@ export const runAuthzedBackfill = async (
 
         pruned += missingRefs.length;
       });
-
-      completedAtSnapshot = snapshot?.token ?? completedAtSnapshot;
     }
   };
 
@@ -651,7 +680,6 @@ export const runAuthzedBackfill = async (
       const summary = summarizeObservation(observation.relationships);
       ignored += summary.ignored;
       unmanaged.push(...summary.unmanaged.slice(0, Math.max(0, MAX_REPORTED_ENTRIES - unmanaged.length)));
-      completedAtSnapshot = observation.snapshot?.token ?? completedAtSnapshot;
 
       recordMismatchedParents(await sourceReads.findMismatchedParentEdges(summary.parentEdges));
 
@@ -773,6 +801,21 @@ export const runAuthzedBackfill = async (
     } catch (error) {
       truncated = true;
       recordFailure("", error);
+    }
+  }
+
+  // Taken last, so it post-dates every write this run made. Any managed type answers: the revision is a
+  // property of the datastore, not of the filter.
+  if (request.mode === "apply" && failed === 0) {
+    try {
+      const closing = await client.readRelationships({
+        filter: { resourceType: "organization" },
+        limit: 1,
+      });
+      completedAtSnapshot = closing.snapshot?.token ?? null;
+    } catch {
+      // A freshness floor that might pre-date the writes is worse than none at all.
+      completedAtSnapshot = null;
     }
   }
 

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -5,6 +5,7 @@ import {
   type TAuthzedSourceRef,
   findUnprojectedSourceRefs,
   getManagedResourceTypes,
+  sourceRefKey,
   summarizeObservation,
 } from "./backfill-diff";
 import {
@@ -27,6 +28,7 @@ import {
   AUTHZED_BACKFILL_TARGET_CHUNK_SIZE,
   AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES,
   AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN,
+  AUTHZED_MAX_TRACKED_ORPHAN_REFS,
 } from "./constants";
 import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
 import type { TOrganizationMembershipProjectionTargets } from "./organization-membership";
@@ -120,6 +122,15 @@ export type TAuthzedBackfillDependencies = Readonly<{
 
 export type TAuthzedBackfillCounters = Readonly<{
   failed: number;
+  /**
+   * Relationships on a deliberately unprojected resource type — `survey`, `dashboard`, `response`.
+   *
+   * Expected to be 0, and structurally so: every read this tool issues filters to a managed type, so
+   * there is no path by which an unprojected type is observed. The classification behind it is kept
+   * anyway, because it is what guarantees that widening a filter later cannot make a survey relationship
+   * look like an orphan and prune it. A non-zero value means a filter was widened without revisiting
+   * that, which is worth seeing rather than silently absorbing.
+   */
   ignored: number;
   invalid: number;
   /** Resources attached to an organization PostgreSQL says does not own them. Never pruned. */
@@ -504,7 +515,7 @@ export const runAuthzedBackfill = async (
       return;
     }
 
-    invalid += source.invalidWorkspaceTeamGrants.length;
+    invalid += source.invalidWorkspaceTeamGrants.length + source.invalidApiKeyWorkspaceGrants.length;
 
     // Two reasons to observe an organization's own resources, and they have different owners.
     //
@@ -530,35 +541,36 @@ export const runAuthzedBackfill = async (
           missingCount += findUnprojectedSourceRefs(toSourceRefs(source), summary.sourceRefs).length;
         }
 
-        if (!ownsOrphanAccounting) {
-          return;
-        }
-
-        ignored += summary.ignored;
-        for (const ref of summary.unmanaged) {
-          if (unmanaged.length < MAX_REPORTED_ENTRIES) {
-            unmanaged.push(ref);
+        // Scoped rather than returned early: falling through keeps this block's only job the
+        // observation, so an applying full scope that ever needs the missing-record check cannot
+        // accidentally skip its own reconcile on the way past.
+        if (ownsOrphanAccounting) {
+          ignored += summary.ignored;
+          for (const ref of summary.unmanaged) {
+            if (unmanaged.length < MAX_REPORTED_ENTRIES) {
+              unmanaged.push(ref);
+            }
           }
-        }
 
-        recordMismatchedParents(await sourceReads.findMismatchedParentEdges(summary.parentEdges));
+          recordMismatchedParents(await sourceReads.findMismatchedParentEdges(summary.parentEdges));
 
-        const missingRefs = await sourceReads.findMissingSourceRefs(summary.sourceRefs);
-        orphaned += missingRefs.length;
-        for (const ref of missingRefs) {
-          if (orphans.length < MAX_REPORTED_ENTRIES) {
-            orphans.push(ref);
+          const missingRefs = await sourceReads.findMissingSourceRefs(summary.sourceRefs);
+          orphaned += missingRefs.length;
+          for (const ref of missingRefs) {
+            if (orphans.length < MAX_REPORTED_ENTRIES) {
+              orphans.push(ref);
+            }
           }
-        }
 
-        if (missingRefs.length > maxPrune) {
-          // A large orphan count is a symptom — wrong endpoint, wrong database, a restore in progress —
-          // not a big cleanup job. Prune nothing for this unit so the run degrades into a loud report
-          // instead of a partly-destroyed graph.
-          skipped++;
-        } else if (isPruning) {
-          repairRefs = missingRefs;
-          prunableRefs = missingRefs;
+          if (missingRefs.length > maxPrune) {
+            // A large orphan count is a symptom — wrong endpoint, wrong database, a restore in progress
+            // — not a big cleanup job. Prune nothing for this unit so the run degrades into a loud
+            // report instead of a partly-destroyed graph.
+            skipped++;
+          } else if (isPruning) {
+            repairRefs = missingRefs;
+            prunableRefs = missingRefs;
+          }
         }
       } catch (error) {
         // An abandoned observation must never be reported as a complete one: fewer relationships seen
@@ -600,34 +612,29 @@ export const runAuthzedBackfill = async (
     reconciled++;
   };
 
-  /** Sweep every managed resource type to find resources PostgreSQL no longer holds at all. */
+  /**
+   * Sweep every managed resource type to find resources PostgreSQL no longer holds at all.
+   *
+   * Two phases, and the order is the safety property. The whole sweep is observed and counted first;
+   * only then, and only if the confirmed total fits the budget, is anything deleted. Enforcing the cap
+   * while streaming would delete every page that fit and halt on the one that did not — so a run aimed
+   * at the wrong database would revoke a cap's worth of live access instead of revoking none, which
+   * inverts what the cap is for.
+   *
+   * Streamed rather than drained: a resource type has no upper bound in a real deployment, so
+   * accumulating one would hold the whole store in memory and trip the per-unit observation bound,
+   * turning the only mode that can remove stale relationships into one that fails permanently on exactly
+   * the deployments that need it. Only the prunable refs are accumulated, and the budget bounds those.
+   */
   const sweepGlobalOrphans = async (): Promise<void> => {
-    // Streamed page by page rather than drained. A resource type has no upper bound in a real
-    // deployment, so accumulating one would hold the whole store in memory and — worse — trip the
-    // per-unit observation bound, turning the only mode that can remove stale relationships into one
-    // that fails permanently on exactly the deployments that need it.
-    // Halting pruning is not the same as halting the sweep. Once the budget is spent — or a prune fails
-    // — reading continues so the reported orphan total stays the *true* magnitude rather than wherever
-    // the run happened to stop. That number is the whole diagnostic: "500 orphans" and "half a million"
-    // call for very different reactions, and the second is what says you aimed at the wrong database.
-    let pruningHalted = false;
-
-    // Streaming means each page is classified on its own, so a record implied by relationships on two
-    // different resource types would be counted twice. Exactly one kind is ambiguous that way: an API key
-    // is named both by `api_key#organization` and by `organization#api_key_reader`. Deduplicating just
-    // that kind keeps the counts honest without holding a key for every record in the store.
-    const seenApiKeyRefs = new Set<string>();
-    const dedupe = (refs: ReadonlyArray<TAuthzedSourceRef>): ReadonlyArray<TAuthzedSourceRef> =>
-      refs.filter((ref) => {
-        if (ref.kind !== "apiKey") {
-          return true;
-        }
-        if (seenApiKeyRefs.has(ref.apiKeyId)) {
-          return false;
-        }
-        seenApiKeyRefs.add(ref.apiKeyId);
-        return true;
-      });
+    // Bounded by the budget: past it nothing will be pruned anyway, so there is no reason to hold more.
+    const prunable: TAuthzedSourceRef[] = [];
+    // Each page is classified on its own, so one record can be implied by relationships on two pages —
+    // across resource types (an API key is named by both `api_key#organization` and
+    // `organization#api_key_reader`) and within one, since alternate relations on the same resource are
+    // returned grouped by relation rather than adjacently.
+    const seenOrphanRefs = new Set<string>();
+    let sweepOrphans = 0;
 
     for (const resourceType of getManagedResourceTypes()) {
       await forEachRelationshipPage(client, { resourceType }, async (relationships) => {
@@ -637,41 +644,63 @@ export const runAuthzedBackfill = async (
 
         recordMismatchedParents(await sourceReads.findMismatchedParentEdges(summary.parentEdges));
 
-        const missingRefs = await sourceReads.findMissingSourceRefs(dedupe(summary.sourceRefs));
-        orphaned += missingRefs.length;
-        orphans.push(...missingRefs.slice(0, Math.max(0, MAX_REPORTED_ENTRIES - orphans.length)));
+        for (const ref of await sourceReads.findMissingSourceRefs(summary.sourceRefs)) {
+          const key = sourceRefKey(ref);
+          if (seenOrphanRefs.has(key)) {
+            continue;
+          }
+          if (seenOrphanRefs.size >= AUTHZED_MAX_TRACKED_ORPHAN_REFS) {
+            // Past the bound the count may double-count. Say so rather than let the total read as exact.
+            truncated = true;
+          } else {
+            seenOrphanRefs.add(key);
+          }
 
-        if (pruningHalted || !isPruning || missingRefs.length === 0) {
-          return;
+          sweepOrphans++;
+          orphaned++;
+          if (orphans.length < MAX_REPORTED_ENTRIES) {
+            orphans.push(ref);
+          }
+          if (prunable.length < maxPrune) {
+            prunable.push(ref);
+          }
         }
-
-        // A run-wide budget, not a per-page one: once the total would exceed it nothing more is pruned,
-        // rather than letting a page-sized slice through on every page.
-        if (pruned + missingRefs.length > maxPrune) {
-          pruningHalted = true;
-          skipped++;
-          return;
-        }
-
-        const failure = await reconcileTargets(apply, toRepairTargets(missingRefs));
-        if (failure) {
-          // Attributed to no organization: a fully orphaned resource has none left to attribute it to.
-          recordProjectionFailure("", failure);
-          pruningHalted = true;
-          return;
-        }
-
-        pruned += missingRefs.length;
       });
     }
+
+    if (!isPruning || sweepOrphans === 0) {
+      return;
+    }
+
+    if (sweepOrphans > maxPrune) {
+      // A large orphan count is a symptom — wrong endpoint, wrong database, a restore in progress — not
+      // a big cleanup job. Nothing has been deleted yet, and nothing will be.
+      skipped++;
+      return;
+    }
+
+    const failure = await reconcileTargets(apply, toRepairTargets(prunable));
+    if (failure) {
+      // Attributed to no organization: a fully orphaned resource has none left to attribute it to.
+      recordProjectionFailure("", failure);
+      return;
+    }
+
+    pruned += prunable.length;
   };
 
   /**
-   * Reconcile one workspace's grants without touching the rest of the tenant.
+   * Reconcile one workspace's grants.
    *
-   * The narrowest unit available, and unlike an organization it does not have to exist: a workspace
-   * whose row is gone is the case most worth repairing, and its relationships are reachable from the ID
-   * the caller supplied.
+   * The narrowest unit available, and unlike an organization it does not have to exist: a workspace whose
+   * row is gone is the case most worth repairing, and its relationships are reachable from the ID the
+   * caller supplied.
+   *
+   * Narrow, but not hermetic. The API keys holding grants on this workspace are reconciled in full, which
+   * covers every *other* workspace those keys hold too — a key is reconciled as a unit, and splitting it
+   * would mean writing a second, narrower implementation of the same convergence. Everything that reaches
+   * is convergent (it writes what PostgreSQL says), so the effect is a wider repair than asked for, never
+   * a deletion outside the named workspace.
    */
   const processWorkspace = async (workspaceId: string): Promise<void> => {
     scanned++;
@@ -680,9 +709,15 @@ export const runAuthzedBackfill = async (
     try {
       source = await sourceReads.readWorkspaceSource(workspaceId);
     } catch (error) {
+      // No organization to attribute this to: the read that would have told us which one failed.
       recordFailure("", error);
       return;
     }
+
+    // Attributed to the owning tenant where PostgreSQL knows one. The empty string is also the sweep's
+    // marker for an orphan with no organization left, so a workspace that still has a row must not
+    // report it.
+    const failureOrganizationId = source.organizationId ?? "";
 
     let repairRefs: ReadonlyArray<TAuthzedSourceRef> = [];
     let prunableWorkspaceRefs: ReadonlyArray<TAuthzedSourceRef> = [];
@@ -732,7 +767,7 @@ export const runAuthzedBackfill = async (
       }
     } catch (error) {
       truncated = true;
-      recordFailure("", error);
+      recordFailure(failureOrganizationId, error);
       return;
     }
 
@@ -749,8 +784,12 @@ export const runAuthzedBackfill = async (
           memberships: [],
           teamIds: [],
           teamMemberships: [],
-          // Naming a workspace that no longer exists is what removes its relationships.
-          workspaceIds: [workspaceId],
+          // Naming the workspace projects its parent edge when the row exists, and removes *every*
+          // relationship on it when the row does not — team grants and API-key grants included. That
+          // second case is a prune by the definition on `TAuthzedBackfillRequest`: reconciling a record
+          // observed only in SpiceDB. So it needs the same permission, budget and accounting as any
+          // other prune, rather than happening as a side effect of naming a stale ID with `--apply`.
+          workspaceIds: source.workspaceExists || isPruning ? [workspaceId] : [],
           workspaceTeamGrants: source.workspaceTeamGrants,
         },
         toRepairTargets(repairRefs)
@@ -758,7 +797,7 @@ export const runAuthzedBackfill = async (
     );
 
     if (failure) {
-      recordProjectionFailure("", failure);
+      recordProjectionFailure(failureOrganizationId, failure);
       return;
     }
 

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -143,6 +143,12 @@ export type TAuthzedBackfillCounters = Readonly<{
   reconciled: number;
   scanned: number;
   skipped: number;
+  /**
+   * Relationships outside the vocabulary, counted rather than merely listed.
+   *
+   * The `unmanaged` list is capped for output size, so the count is what the status can be computed from.
+   */
+  unmanaged: number;
 }>;
 
 export type TAuthzedBackfillFailure = Readonly<{
@@ -485,6 +491,7 @@ type TRunState = {
   skipped: number;
   truncated: boolean;
   readonly unmanaged: Array<Readonly<{ objectId: string; objectType: string; relation: string }>>;
+  unmanagedCount: number;
 };
 
 const createRunState = (): TRunState => ({
@@ -505,6 +512,7 @@ const createRunState = (): TRunState => ({
   skipped: 0,
   truncated: false,
   unmanaged: [],
+  unmanagedCount: 0,
 });
 
 /** A unit of work's whole world: the run's tallies plus the configuration every unit shares. */
@@ -580,6 +588,7 @@ const recordObservationSummary = async (
   summary: TAuthzedObservationSummary
 ): Promise<void> => {
   ctx.state.ignored += summary.ignored;
+  ctx.state.unmanagedCount += summary.unmanaged.length;
   pushCapped(ctx.state.unmanaged, summary.unmanaged);
   recordMismatchedParents(ctx.state, await ctx.sourceReads.findMismatchedParentEdges(summary.parentEdges));
 };
@@ -841,12 +850,60 @@ const observeWorkspace = async (
   const summary = summarizeObservation(observation.relationships);
   await recordObservationSummary(ctx, summary);
 
-  ctx.state.missingCount += findUnprojectedSourceRefs(
-    toWorkspaceSourceRefs(source, workspaceId),
-    summary.sourceRefs
-  ).length;
+  if (ctx.mode === "dry_run") {
+    // Dry run only. An applying run converges this direction by writing, so counting it beforehand would
+    // leave a successful repair reporting `drifted` and exiting 2 on the strength of a pre-write reading.
+    ctx.state.missingCount += findUnprojectedSourceRefs(
+      toWorkspaceSourceRefs(source, workspaceId),
+      summary.sourceRefs
+    ).length;
+  }
 
   return recordScopedOrphans(ctx, summary);
+};
+
+/**
+ * Drop prune targets whose deletion would reach outside the named workspace.
+ *
+ * A grant ref implies its principal — `normalizeTargets` in both reconcilers adds the team or API key a
+ * grant names — and when that principal has no PostgreSQL row the reconciler deletes subject-wide: every
+ * workspace relationship for that team, or every organization *and* workspace relationship for that key.
+ * One in-budget orphan on this workspace would therefore delete relationships in other tenants, none of
+ * them counted against `pruned` or weighed against the cap.
+ *
+ * That fan-out is correct convergence — those relationships genuinely should go — but it is the
+ * organization or full sweep's unit of work, not this one's. Here the ref stays counted in `orphaned` and
+ * is withheld, so the run finishes `drifted` and tells the operator a wider scope is needed.
+ */
+const withinWorkspaceScope = async (
+  ctx: TRunContext,
+  refs: ReadonlyArray<TAuthzedSourceRef>
+): Promise<ReadonlyArray<TAuthzedSourceRef>> => {
+  const principalFor = (ref: TAuthzedSourceRef): TAuthzedSourceRef | null => {
+    if (ref.kind === "workspaceTeamGrant") {
+      return { kind: "team", teamId: ref.teamId };
+    }
+    if (ref.kind === "apiKeyWorkspaceGrant") {
+      return { apiKeyId: ref.apiKeyId, kind: "apiKey" };
+    }
+
+    return null;
+  };
+
+  const principals = refs.map(principalFor).filter((ref): ref is TAuthzedSourceRef => ref !== null);
+  if (principals.length === 0) {
+    return refs;
+  }
+
+  const missing = new Set(
+    (await ctx.sourceReads.findMissingSourceRefs(principals)).map((ref) => sourceRefKey(ref))
+  );
+
+  return refs.filter((ref) => {
+    const principal = principalFor(ref);
+
+    return principal === null || !missing.has(sourceRefKey(principal));
+  });
 };
 
 /**
@@ -859,8 +916,11 @@ const observeWorkspace = async (
  * Narrow, but not hermetic. The API keys holding grants on this workspace are reconciled in full, which
  * covers every *other* workspace those keys hold too — a key is reconciled as a unit, and splitting it
  * would mean writing a second, narrower implementation of the same convergence. Everything that reaches
- * is convergent (it writes what PostgreSQL says), so the effect is a wider repair than asked for, never
- * a deletion outside the named workspace.
+ * that way is convergent: it writes what PostgreSQL says.
+ *
+ * Deletion is held to the stated scope separately, by `withinWorkspaceScope`. Without it a grant whose
+ * principal had been deleted would make the reconciler delete subject-wide, reaching other tenants on the
+ * strength of one orphan here — see that function for why those cases are deferred instead.
  */
 const processWorkspace = async (ctx: TRunContext, workspaceId: string): Promise<void> => {
   const { state } = ctx;
@@ -881,9 +941,12 @@ const processWorkspace = async (ctx: TRunContext, workspaceId: string): Promise<
   // report it.
   const failureOrganizationId = source.organizationId ?? "";
 
+  state.invalid += source.invalidWorkspaceTeamGrants.length + source.invalidApiKeyWorkspaceGrants.length;
+
   let decision: TPruneDecision = { overBudget: false, refs: [] };
   try {
-    decision = await observeWorkspace(ctx, workspaceId, source);
+    const observed = await observeWorkspace(ctx, workspaceId, source);
+    decision = { ...observed, refs: await withinWorkspaceScope(ctx, observed.refs) };
   } catch (error) {
     state.truncated = true;
     recordFailure(state, failureOrganizationId, error);
@@ -1016,18 +1079,27 @@ const captureClosingSnapshot = async (ctx: TRunContext): Promise<string | null> 
   }
 };
 
-/** A failure outranks drift, and only a run that found nothing outstanding is `reconciled`. */
+/**
+ * A failure outranks drift, and only a run that found nothing outstanding is `reconciled`.
+ *
+ * Every category of *unrepaired* state counts, not just the ones this tool can fix. `missing` and
+ * `mismatchedParents` matter as much as `orphaned` — without them a dry run over an empty SpiceDB would
+ * report "reconciled", the exact state this tool exists to fix — and so do `invalid` and `unmanaged`,
+ * which are deliberately left alone. A cross-organization source row or an unrecognized relationship is
+ * still authorization state nothing accounts for, and a clean exit here is what gates shadow evaluation
+ * and enforcement, so it must not be reachable while any of them remain.
+ */
 const toRunStatus = (state: TRunState): TAuthzedBackfillResult["status"] => {
   if (state.failed > 0) {
     return "failed";
   }
 
-  // `missing` and `mismatchedParents` matter as much as `orphaned`: without them a dry run over an
-  // empty SpiceDB would report "reconciled", which is the exact state this tool exists to fix.
   const hasDrift =
     state.orphaned > state.pruned ||
     state.missingCount > 0 ||
     state.mismatchedParentCount > 0 ||
+    state.invalid > 0 ||
+    state.unmanagedCount > 0 ||
     state.truncated;
 
   return hasDrift ? "drifted" : "reconciled";
@@ -1071,6 +1143,7 @@ export const runAuthzedBackfill = async (
       reconciled: state.reconciled,
       scanned: state.scanned,
       skipped: state.skipped,
+      unmanaged: state.unmanagedCount,
     },
     failures: state.failures,
     lastOrganizationId: state.lastOrganizationId,

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import type { TApiKeyProjectionTargets } from "./api-key";
 import {
+  type TAuthzedObservationSummary,
   type TAuthzedParentEdge,
   type TAuthzedSourceRef,
   findUnprojectedSourceRefs,
@@ -145,6 +146,14 @@ export type TAuthzedBackfillCounters = Readonly<{
 }>;
 
 export type TAuthzedBackfillFailure = Readonly<{
+  /**
+   * How many attempts stood behind this failure.
+   *
+   * Carried because the commands run at `LOG_LEVEL=fatal` to keep stdout a single JSON line, so this
+   * object is the operator's only diagnostic. Without it, "failed once" and "exhausted the retry
+   * budget" — a blip versus an outage — are indistinguishable in the report.
+   */
+  attempts: number;
   code: string;
   organizationId: string;
   retryable: boolean;
@@ -202,10 +211,10 @@ export type TAuthzedBackfillResult = Readonly<{
 /** Entries reported individually before the list is capped and only counters remain accurate. */
 const MAX_REPORTED_ENTRIES = 100;
 
-const toErrorCode = (error: unknown): Readonly<{ code: string; retryable: boolean }> =>
+const toErrorCode = (error: unknown): Readonly<{ attempts: number; code: string; retryable: boolean }> =>
   error instanceof AuthzedError
-    ? { code: error.code, retryable: error.retryable }
-    : { code: "authzed_internal", retryable: false };
+    ? { attempts: error.attempts, code: error.code, retryable: error.retryable }
+    : { attempts: 1, code: "authzed_internal", retryable: false };
 
 /** The seven target lists the three reconcilers accept between them. */
 type TReconcileTargets = Readonly<{
@@ -541,9 +550,9 @@ const recordProjectionFailure = (
   state.failed++;
   pushCapped(state.failures, [
     result.status === "failed"
-      ? { code: result.code, organizationId, retryable: result.retryable }
-      : // `disabled` reaching here means AuthZed was switched off mid-run.
-        { code: "authzed_disabled", organizationId, retryable: false },
+      ? { attempts: result.attempts, code: result.code, organizationId, retryable: result.retryable }
+      : // `disabled` reaching here means AuthZed was switched off mid-run; nothing was attempted.
+        { attempts: 0, code: "authzed_disabled", organizationId, retryable: false },
   ]);
 };
 
@@ -553,16 +562,39 @@ const recordMismatchedParents = (state: TRunState, edges: ReadonlyArray<TAuthzed
 };
 
 /**
- * Decide which observed refs, if any, may be handed to a reconciler as prune targets.
+ * Record the classification tallies an observation implies, and verify the organizations its resources
+ * claim to belong to.
  *
- * Shared by both narrow scopes. A count over the budget prunes *nothing* for that unit: a large orphan
- * count is a symptom — wrong endpoint, wrong database, a restore in progress — not a big cleanup job,
- * so the run degrades into a loud report instead of a partly-destroyed graph.
+ * Shared by all three observation paths — the two narrow scopes and each page of the sweep — because
+ * this half is identical regardless of how the relationships were reached.
  */
-const selectPrunableRefs = (
+const recordObservationSummary = async (
   ctx: TRunContext,
-  missingRefs: ReadonlyArray<TAuthzedSourceRef>
-): ReadonlyArray<TAuthzedSourceRef> => {
+  summary: TAuthzedObservationSummary
+): Promise<void> => {
+  ctx.state.ignored += summary.ignored;
+  pushCapped(ctx.state.unmanaged, summary.unmanaged);
+  recordMismatchedParents(ctx.state, await ctx.sourceReads.findMismatchedParentEdges(summary.parentEdges));
+};
+
+/**
+ * Record the orphans a narrow-scope observation found, and decide which of them may be pruned.
+ *
+ * A count over the budget prunes *nothing* for that unit: a large orphan count is a symptom — wrong
+ * endpoint, wrong database, a restore in progress — not a big cleanup job, so the run degrades into a
+ * loud report instead of a partly-destroyed graph.
+ *
+ * The sweep deliberately does not use this. It streams, so it has to deduplicate across pages before it
+ * can count, and it decides the budget against the whole sweep rather than against one unit.
+ */
+const recordScopedOrphans = async (
+  ctx: TRunContext,
+  summary: TAuthzedObservationSummary
+): Promise<ReadonlyArray<TAuthzedSourceRef>> => {
+  const missingRefs = await ctx.sourceReads.findMissingSourceRefs(summary.sourceRefs);
+  ctx.state.orphaned += missingRefs.length;
+  pushCapped(ctx.state.orphans, missingRefs);
+
   if (missingRefs.length > ctx.maxPrune) {
     ctx.state.skipped++;
 
@@ -597,15 +629,9 @@ const observeOrganization = async (
     return [];
   }
 
-  state.ignored += summary.ignored;
-  pushCapped(state.unmanaged, summary.unmanaged);
-  recordMismatchedParents(state, await ctx.sourceReads.findMismatchedParentEdges(summary.parentEdges));
+  await recordObservationSummary(ctx, summary);
 
-  const missingRefs = await ctx.sourceReads.findMissingSourceRefs(summary.sourceRefs);
-  state.orphaned += missingRefs.length;
-  pushCapped(state.orphans, missingRefs);
-
-  return selectPrunableRefs(ctx, missingRefs);
+  return recordScopedOrphans(ctx, summary);
 };
 
 const processOrganization = async (ctx: TRunContext, organizationId: string): Promise<void> => {
@@ -689,9 +715,7 @@ const tallySweepPage = async (
 ): Promise<ReadonlyArray<TAuthzedSourceRef>> => {
   const { state } = ctx;
   const summary = summarizeObservation(relationships);
-  state.ignored += summary.ignored;
-  pushCapped(state.unmanaged, summary.unmanaged);
-  recordMismatchedParents(state, await ctx.sourceReads.findMismatchedParentEdges(summary.parentEdges));
+  await recordObservationSummary(ctx, summary);
 
   const fresh: TAuthzedSourceRef[] = [];
   for (const ref of await ctx.sourceReads.findMissingSourceRefs(summary.sourceRefs)) {
@@ -803,26 +827,19 @@ const observeWorkspace = async (
   workspaceId: string,
   source: TAuthzedWorkspaceSource
 ): Promise<ReadonlyArray<TAuthzedSourceRef>> => {
-  const { state } = ctx;
   const observation = await readAllRelationships(ctx.client, {
     resourceId: workspaceId,
     resourceType: "workspace",
   });
   const summary = summarizeObservation(observation.relationships);
-  state.ignored += summary.ignored;
-  pushCapped(state.unmanaged, summary.unmanaged);
-  recordMismatchedParents(state, await ctx.sourceReads.findMismatchedParentEdges(summary.parentEdges));
+  await recordObservationSummary(ctx, summary);
 
-  state.missingCount += findUnprojectedSourceRefs(
+  ctx.state.missingCount += findUnprojectedSourceRefs(
     toWorkspaceSourceRefs(source, workspaceId),
     summary.sourceRefs
   ).length;
 
-  const missingRefs = await ctx.sourceReads.findMissingSourceRefs(summary.sourceRefs);
-  state.orphaned += missingRefs.length;
-  pushCapped(state.orphans, missingRefs);
-
-  return selectPrunableRefs(ctx, missingRefs);
+  return recordScopedOrphans(ctx, summary);
 };
 
 /**

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -606,7 +606,11 @@ export const runAuthzedBackfill = async (
     // deployment, so accumulating one would hold the whole store in memory and — worse — trip the
     // per-unit observation bound, turning the only mode that can remove stale relationships into one
     // that fails permanently on exactly the deployments that need it.
-    let capExceeded = false;
+    // Halting pruning is not the same as halting the sweep. Once the budget is spent — or a prune fails
+    // — reading continues so the reported orphan total stays the *true* magnitude rather than wherever
+    // the run happened to stop. That number is the whole diagnostic: "500 orphans" and "half a million"
+    // call for very different reactions, and the second is what says you aimed at the wrong database.
+    let pruningHalted = false;
 
     // Streaming means each page is classified on its own, so a record implied by relationships on two
     // different resource types would be counted twice. Exactly one kind is ambiguous that way: an API key
@@ -627,10 +631,6 @@ export const runAuthzedBackfill = async (
 
     for (const resourceType of getManagedResourceTypes()) {
       await forEachRelationshipPage(client, { resourceType }, async (relationships) => {
-        if (capExceeded) {
-          return;
-        }
-
         const summary = summarizeObservation(relationships);
         ignored += summary.ignored;
         unmanaged.push(...summary.unmanaged.slice(0, Math.max(0, MAX_REPORTED_ENTRIES - unmanaged.length)));
@@ -641,15 +641,15 @@ export const runAuthzedBackfill = async (
         orphaned += missingRefs.length;
         orphans.push(...missingRefs.slice(0, Math.max(0, MAX_REPORTED_ENTRIES - orphans.length)));
 
-        // The cap is a run-wide budget, not a per-page one: once the total would exceed it, stop pruning
-        // for the rest of the run rather than letting a page-sized slice through each time.
-        if (pruned + missingRefs.length > maxPrune) {
-          capExceeded = true;
-          skipped++;
+        if (pruningHalted || !isPruning || missingRefs.length === 0) {
           return;
         }
 
-        if (!isPruning || missingRefs.length === 0) {
+        // A run-wide budget, not a per-page one: once the total would exceed it nothing more is pruned,
+        // rather than letting a page-sized slice through on every page.
+        if (pruned + missingRefs.length > maxPrune) {
+          pruningHalted = true;
+          skipped++;
           return;
         }
 
@@ -657,7 +657,7 @@ export const runAuthzedBackfill = async (
         if (failure) {
           // Attributed to no organization: a fully orphaned resource has none left to attribute it to.
           recordProjectionFailure("", failure);
-          capExceeded = true;
+          pruningHalted = true;
           return;
         }
 

--- a/apps/web/lib/authzed/backfill.ts
+++ b/apps/web/lib/authzed/backfill.ts
@@ -64,10 +64,37 @@ export type TAuthzedBackfillRequest = Readonly<{
   scope: TAuthzedBackfillScope;
 }>;
 
+/**
+ * PostgreSQL reads the orchestrator needs.
+ *
+ * Injected rather than imported so the orchestrator can be driven against a real SpiceDB without a
+ * database — which is how the compose smoke test exercises the observation, classification, and prune
+ * paths end to end. Note these are reads only; the mutation capability stays separate, so injecting
+ * them does not weaken the dry-run guarantee.
+ */
+export type TAuthzedBackfillSource = Readonly<{
+  findMissingSourceRefs: (
+    refs: ReadonlyArray<TAuthzedSourceRef>
+  ) => Promise<ReadonlyArray<TAuthzedSourceRef>>;
+  organizationExists: (organizationId: string) => Promise<boolean>;
+  readOrganizationIdPage: (
+    page: Readonly<{ afterOrganizationId?: string; limit?: number }>
+  ) => Promise<ReadonlyArray<string>>;
+  readOrganizationSource: (organizationId: string) => Promise<TAuthzedOrganizationSource>;
+}>;
+
+export const defaultBackfillSource: TAuthzedBackfillSource = {
+  findMissingSourceRefs,
+  organizationExists,
+  readOrganizationIdPage,
+  readOrganizationSource,
+};
+
 export type TAuthzedBackfillDependencies = Readonly<{
   apply: TAuthzedBackfillApply;
   /** Read-only slice of the facade. Deliberately not the whole client. */
   client: Pick<TAuthzedClient, "readRelationships">;
+  source?: TAuthzedBackfillSource;
 }>;
 
 export type TAuthzedBackfillCounters = Readonly<{
@@ -288,7 +315,7 @@ export const runAuthzedBackfill = async (
   request: TAuthzedBackfillRequest,
   dependencies: TAuthzedBackfillDependencies
 ): Promise<TAuthzedBackfillResult> => {
-  const { apply, client } = dependencies;
+  const { apply, client, source: sourceReads = defaultBackfillSource } = dependencies;
   const isPruning = request.prune && request.mode === "apply";
 
   let failed = 0;
@@ -331,7 +358,7 @@ export const runAuthzedBackfill = async (
 
     let source: TAuthzedOrganizationSource;
     try {
-      source = await readOrganizationSource(organizationId);
+      source = await sourceReads.readOrganizationSource(organizationId);
     } catch (error) {
       recordFailure(organizationId, error);
       return;
@@ -354,7 +381,7 @@ export const runAuthzedBackfill = async (
         }
         completedAtSnapshot = observation.snapshot ?? completedAtSnapshot;
 
-        const missing = await findMissingSourceRefs(summary.sourceRefs);
+        const missing = await sourceReads.findMissingSourceRefs(summary.sourceRefs);
         orphaned += missing.length;
         for (const ref of missing) {
           if (orphans.length < MAX_REPORTED_ENTRIES) {
@@ -422,7 +449,7 @@ export const runAuthzedBackfill = async (
     ignored += summary.ignored;
     unmanaged.push(...summary.unmanaged.slice(0, MAX_REPORTED_ENTRIES - unmanaged.length));
 
-    const missing = await findMissingSourceRefs(summary.sourceRefs);
+    const missing = await sourceReads.findMissingSourceRefs(summary.sourceRefs);
     orphaned += missing.length;
     orphans.push(...missing.slice(0, MAX_REPORTED_ENTRIES - orphans.length));
 
@@ -447,14 +474,14 @@ export const runAuthzedBackfill = async (
 
   if (request.scope.kind === "organization") {
     const { organizationId } = request.scope;
-    if (!(await organizationExists(organizationId))) {
+    if (!(await sourceReads.organizationExists(organizationId))) {
       throw new Error("Organization not found");
     }
     await processOrganization(organizationId);
   } else {
     let afterOrganizationId = request.scope.afterOrganizationId;
     for (;;) {
-      const organizationIds = await readOrganizationIdPage({
+      const organizationIds = await sourceReads.readOrganizationIdPage({
         afterOrganizationId,
         limit: AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE,
       });

--- a/apps/web/lib/authzed/client.test.ts
+++ b/apps/web/lib/authzed/client.test.ts
@@ -1,4 +1,5 @@
 import { configMocks, envMock, retryMocks, sdkMocks } from "./__mocks__/client-dependencies";
+import { v1 } from "@authzed/authzed-node";
 import { status } from "@grpc/grpc-js";
 import { beforeEach, describe, expect, test } from "vitest";
 import { closeAuthzedClient, configureAuthzedClientForBulkWork, getAuthzedClient } from "./client";
@@ -317,7 +318,7 @@ describe("AuthZed client facade", () => {
   test("translates a resource-scoped bulk delete through the resilience pipeline", async () => {
     sdkMocks.deleteRelationships.mockResolvedValue({
       deletedAt: { token: "private-revision" },
-      deletionProgress: 1,
+      deletionProgress: v1.DeleteRelationshipsResponse_DeletionProgress.COMPLETE,
     });
 
     await expect(
@@ -348,7 +349,7 @@ describe("AuthZed client facade", () => {
     // relationships behind — and reporting that as done would leave a half-revoked graph.
     sdkMocks.deleteRelationships.mockResolvedValue({
       deletedAt: { token: "private-revision" },
-      deletionProgress: 2,
+      deletionProgress: v1.DeleteRelationshipsResponse_DeletionProgress.PARTIAL,
     });
 
     await expect(
@@ -359,7 +360,7 @@ describe("AuthZed client facade", () => {
   test("translates a subject-scoped bulk delete without broadening the resource filter", async () => {
     sdkMocks.deleteRelationships.mockResolvedValue({
       deletedAt: { token: "private-revision" },
-      deletionProgress: 1,
+      deletionProgress: v1.DeleteRelationshipsResponse_DeletionProgress.COMPLETE,
     });
 
     await expect(

--- a/apps/web/lib/authzed/client.test.ts
+++ b/apps/web/lib/authzed/client.test.ts
@@ -12,6 +12,7 @@ describe("AuthZed client facade", () => {
     sdkMocks.deleteRelationships.mockReset();
     sdkMocks.diffSchema.mockReset();
     sdkMocks.newClient.mockReset();
+    sdkMocks.readRelationships.mockReset();
     sdkMocks.readSchema.mockReset();
     sdkMocks.writeRelationships.mockReset();
     sdkMocks.writeSchema.mockReset();
@@ -27,6 +28,7 @@ describe("AuthZed client facade", () => {
       promises: {
         deleteRelationships: sdkMocks.deleteRelationships,
         diffSchema: sdkMocks.diffSchema,
+        readRelationships: sdkMocks.readRelationships,
         readSchema: sdkMocks.readSchema,
         writeRelationships: sdkMocks.writeRelationships,
         writeSchema: sdkMocks.writeSchema,
@@ -101,6 +103,7 @@ describe("AuthZed client facade", () => {
       "consistency",
       "deleteRelationships",
       "diffSchema",
+      "readRelationships",
       "readSchema",
       "systemKey",
       "writeRelationships",
@@ -325,6 +328,254 @@ describe("AuthZed client facade", () => {
         },
         resourceType: "organization",
       },
+    });
+  });
+
+  describe("readRelationships", () => {
+    const readResponse = (
+      relationship: Record<string, unknown>,
+      overrides: Record<string, unknown> = {}
+    ) => ({
+      afterResultCursor: { token: "private-cursor" },
+      readAt: { token: "private-revision" },
+      relationship,
+      ...overrides,
+    });
+
+    const membershipRelationship = {
+      relation: "owner",
+      resource: { objectId: "org-1", objectType: "organization" },
+      subject: { object: { objectId: "user-1", objectType: "user" }, optionalRelation: "" },
+    };
+
+    test("resolves the first page fully consistently and returns a pinnable revision", async () => {
+      sdkMocks.readRelationships.mockResolvedValue([readResponse(membershipRelationship)]);
+
+      await expect(
+        getAuthzedClient().readRelationships({
+          filter: { resourceType: "organization" },
+          limit: 250,
+        })
+      ).resolves.toEqual({
+        // A short page exhausts the filter, so no cursor is offered even though SpiceDB sent one.
+        cursor: null,
+        relationships: [
+          {
+            relation: "owner",
+            resource: { objectId: "org-1", objectType: "organization" },
+            subject: { objectId: "user-1", objectType: "user" },
+          },
+        ],
+        snapshot: { token: "private-revision" },
+      });
+
+      expect(sdkMocks.readRelationships).toHaveBeenCalledWith({
+        consistency: { requirement: { fullyConsistent: true, oneofKind: "fullyConsistent" } },
+        optionalCursor: undefined,
+        optionalLimit: 250,
+        relationshipFilter: {
+          optionalRelation: "",
+          optionalResourceId: "",
+          optionalResourceIdPrefix: "",
+          optionalSubjectFilter: undefined,
+          resourceType: "organization",
+        },
+      });
+      expect(retryMocks.execute).toHaveBeenCalledWith("read_relationships", expect.any(Function));
+    });
+
+    test("pins later pages to the supplied revision instead of resolving them independently", async () => {
+      sdkMocks.readRelationships.mockResolvedValue([
+        readResponse(membershipRelationship, { readAt: { token: "ignored-revision" } }),
+      ]);
+
+      const page = await getAuthzedClient().readRelationships({
+        atSnapshot: { token: "pinned-revision" },
+        cursor: { token: "resume-here" },
+        filter: { resourceType: "organization" },
+        limit: 250,
+      });
+
+      // The pinned revision is echoed back unchanged so a multi-page read keeps one consistent view.
+      expect(page.snapshot).toEqual({ token: "pinned-revision" });
+      expect(sdkMocks.readRelationships).toHaveBeenCalledWith(
+        expect.objectContaining({
+          consistency: {
+            requirement: {
+              atExactSnapshot: { token: "pinned-revision" },
+              oneofKind: "atExactSnapshot",
+            },
+          },
+          optionalCursor: { token: "resume-here" },
+        })
+      );
+    });
+
+    test("offers a resume cursor only when the page is full", async () => {
+      sdkMocks.readRelationships.mockResolvedValue([
+        readResponse(membershipRelationship),
+        readResponse(membershipRelationship),
+      ]);
+
+      await expect(
+        getAuthzedClient().readRelationships({
+          filter: { resourceType: "organization" },
+          limit: 2,
+        })
+      ).resolves.toMatchObject({ cursor: { token: "private-cursor" } });
+    });
+
+    test("returns an exhausted empty page without a revision", async () => {
+      sdkMocks.readRelationships.mockResolvedValue([]);
+
+      await expect(
+        getAuthzedClient().readRelationships({
+          filter: { resourceType: "organization" },
+          limit: 250,
+        })
+      ).resolves.toEqual({ cursor: null, relationships: [], snapshot: null });
+    });
+
+    test("preserves a subject relation so team-member grants round-trip", async () => {
+      sdkMocks.readRelationships.mockResolvedValue([
+        readResponse({
+          relation: "reader_team",
+          resource: { objectId: "ws-1", objectType: "workspace" },
+          subject: { object: { objectId: "team-1", objectType: "team" }, optionalRelation: "member" },
+        }),
+      ]);
+
+      const page = await getAuthzedClient().readRelationships({
+        filter: { resourceType: "workspace", subject: { objectId: "team-1", objectType: "team" } },
+        limit: 250,
+      });
+
+      expect(page.relationships[0].subject).toEqual({
+        objectId: "team-1",
+        objectType: "team",
+        relation: "member",
+      });
+    });
+
+    test("narrows the SDK filter for every supported field", async () => {
+      sdkMocks.readRelationships.mockResolvedValue([]);
+
+      await getAuthzedClient().readRelationships({
+        filter: {
+          relation: "reader_team",
+          resourceId: "ws-1",
+          resourceType: "workspace",
+          subject: { objectId: "team-1", objectType: "team", relation: "member" },
+        },
+        limit: 10,
+      });
+
+      expect(sdkMocks.readRelationships).toHaveBeenCalledWith(
+        expect.objectContaining({
+          relationshipFilter: {
+            optionalRelation: "reader_team",
+            optionalResourceId: "ws-1",
+            optionalResourceIdPrefix: "",
+            optionalSubjectFilter: {
+              optionalRelation: { relation: "member" },
+              optionalSubjectId: "team-1",
+              subjectType: "team",
+            },
+            resourceType: "workspace",
+          },
+        })
+      );
+    });
+
+    test.each([
+      ["a missing resource type", { filter: { resourceType: "" }, limit: 10 }],
+      // SpiceDB reads `optionalLimit: 0` as unlimited, which would breach the channel deadline and
+      // buffer without bound, so an unset or non-positive limit must never reach the wire.
+      ["an unlimited read", { filter: { resourceType: "organization" }, limit: 0 }],
+      ["a negative limit", { filter: { resourceType: "organization" }, limit: -1 }],
+      ["a fractional limit", { filter: { resourceType: "organization" }, limit: 1.5 }],
+      ["a limit above the page bound", { filter: { resourceType: "organization" }, limit: 251 }],
+      ["a blank relation", { filter: { relation: "", resourceType: "organization" }, limit: 10 }],
+      ["a blank resource id", { filter: { resourceId: "", resourceType: "organization" }, limit: 10 }],
+      [
+        "an incomplete subject filter",
+        {
+          filter: { resourceType: "workspace", subject: { objectId: "", objectType: "team" } },
+          limit: 10,
+        },
+      ],
+      ["a blank cursor", { cursor: { token: "" }, filter: { resourceType: "organization" }, limit: 10 }],
+      [
+        "a blank snapshot",
+        { atSnapshot: { token: "" }, filter: { resourceType: "organization" }, limit: 10 },
+      ],
+    ])("rejects %s before reaching the SDK", async (_label, query) => {
+      await expect(getAuthzedClient().readRelationships(query)).rejects.toThrow(
+        AUTHZED_ERROR_CODES.INVALID_REQUEST
+      );
+      expect(sdkMocks.readRelationships).not.toHaveBeenCalled();
+    });
+
+    test.each([
+      ["relationship", {}],
+      ["resource", { relation: "owner", subject: membershipRelationship.subject }],
+      ["subject object", { relation: "owner", resource: membershipRelationship.resource, subject: {} }],
+    ])(
+      "refuses a response missing its %s rather than reporting a malformed relationship",
+      async (_label, relationship) => {
+        sdkMocks.readRelationships.mockResolvedValue([readResponse(relationship)]);
+
+        await expect(
+          getAuthzedClient().readRelationships({
+            filter: { resourceType: "organization" },
+            limit: 250,
+          })
+        ).rejects.toThrow(AUTHZED_ERROR_CODES.INTERNAL);
+      }
+    );
+
+    test("refuses a non-empty page that carries no revision to pin", async () => {
+      sdkMocks.readRelationships.mockResolvedValue([
+        readResponse(membershipRelationship, { readAt: undefined }),
+      ]);
+
+      await expect(
+        getAuthzedClient().readRelationships({
+          filter: { resourceType: "organization" },
+          limit: 250,
+        })
+      ).rejects.toThrow(AUTHZED_ERROR_CODES.INTERNAL);
+    });
+
+    test.each(["optionalCaveat", "optionalExpiresAt"])(
+      "refuses a relationship qualified by %s that the facade cannot represent",
+      async (qualifier) => {
+        sdkMocks.readRelationships.mockResolvedValue([
+          readResponse({ ...membershipRelationship, [qualifier]: { anything: true } }),
+        ]);
+
+        await expect(
+          getAuthzedClient().readRelationships({
+            filter: { resourceType: "organization" },
+            limit: 250,
+          })
+        ).rejects.toThrow(AUTHZED_ERROR_CODES.UNSUPPORTED);
+      }
+    );
+
+    test("routes reads through the resilience pipeline so transient failures are mapped there", async () => {
+      // Error sanitization belongs to `executeAuthzedOperation` (covered in retry.test.ts); the
+      // facade's own contract is that it opts this operation into that pipeline rather than calling
+      // the SDK bare.
+      sdkMocks.readRelationships.mockRejectedValue(
+        Object.assign(new Error("private-endpoint-detail"), { code: status.UNAVAILABLE })
+      );
+
+      await expect(
+        getAuthzedClient().readRelationships({ filter: { resourceType: "organization" }, limit: 250 })
+      ).rejects.toThrow();
+
+      expect(retryMocks.execute).toHaveBeenCalledWith("read_relationships", expect.any(Function));
     });
   });
 });

--- a/apps/web/lib/authzed/client.test.ts
+++ b/apps/web/lib/authzed/client.test.ts
@@ -315,7 +315,10 @@ describe("AuthZed client facade", () => {
   });
 
   test("translates a resource-scoped bulk delete through the resilience pipeline", async () => {
-    sdkMocks.deleteRelationships.mockResolvedValue({ deletedAt: { token: "private-revision" } });
+    sdkMocks.deleteRelationships.mockResolvedValue({
+      deletedAt: { token: "private-revision" },
+      deletionProgress: 1,
+    });
 
     await expect(
       getAuthzedClient().deleteRelationships({
@@ -339,8 +342,25 @@ describe("AuthZed client facade", () => {
     expect(retryMocks.execute).toHaveBeenCalledWith("delete_relationships", expect.any(Function));
   });
 
+  test("refuses to report a partial deletion as a success", async () => {
+    // The one facade call that destroys access. An unlimited, non-partial delete should always come
+    // back COMPLETE, so PARTIAL means a server-side cap or a changed default is quietly leaving
+    // relationships behind — and reporting that as done would leave a half-revoked graph.
+    sdkMocks.deleteRelationships.mockResolvedValue({
+      deletedAt: { token: "private-revision" },
+      deletionProgress: 2,
+    });
+
+    await expect(
+      getAuthzedClient().deleteRelationships({ resourceId: "org-1", resourceType: "organization" })
+    ).rejects.toMatchObject({ code: AUTHZED_ERROR_CODES.INTERNAL, retryable: true });
+  });
+
   test("translates a subject-scoped bulk delete without broadening the resource filter", async () => {
-    sdkMocks.deleteRelationships.mockResolvedValue({ deletedAt: { token: "private-revision" } });
+    sdkMocks.deleteRelationships.mockResolvedValue({
+      deletedAt: { token: "private-revision" },
+      deletionProgress: 1,
+    });
 
     await expect(
       getAuthzedClient().deleteRelationships({

--- a/apps/web/lib/authzed/client.test.ts
+++ b/apps/web/lib/authzed/client.test.ts
@@ -384,28 +384,24 @@ describe("AuthZed client facade", () => {
       expect(retryMocks.execute).toHaveBeenCalledWith("read_relationships", expect.any(Function));
     });
 
-    test("pins later pages to the supplied revision instead of resolving them independently", async () => {
+    test("continues a cursored read without altering any other argument", async () => {
       sdkMocks.readRelationships.mockResolvedValue([
-        readResponse(membershipRelationship, { readAt: { token: "ignored-revision" } }),
+        readResponse(membershipRelationship, { readAt: { token: "revision-1" } }),
       ]);
 
       const page = await getAuthzedClient().readRelationships({
-        atSnapshot: { token: "pinned-revision" },
         cursor: { token: "resume-here" },
         filter: { resourceType: "organization" },
         limit: 250,
       });
 
-      // The pinned revision is echoed back unchanged so a multi-page read keeps one consistent view.
-      expect(page.snapshot).toEqual({ token: "pinned-revision" });
+      // SpiceDB rejects a cursor presented with any other changed argument, and the cursor already
+      // carries the revision it was issued at — so the consistency requirement must stay put rather
+      // than being swapped for an explicit snapshot on later pages.
+      expect(page.snapshot).toEqual({ token: "revision-1" });
       expect(sdkMocks.readRelationships).toHaveBeenCalledWith(
         expect.objectContaining({
-          consistency: {
-            requirement: {
-              atExactSnapshot: { token: "pinned-revision" },
-              oneofKind: "atExactSnapshot",
-            },
-          },
+          consistency: { requirement: { fullyConsistent: true, oneofKind: "fullyConsistent" } },
           optionalCursor: { token: "resume-here" },
         })
       );
@@ -505,10 +501,6 @@ describe("AuthZed client facade", () => {
         },
       ],
       ["a blank cursor", { cursor: { token: "" }, filter: { resourceType: "organization" }, limit: 10 }],
-      [
-        "a blank snapshot",
-        { atSnapshot: { token: "" }, filter: { resourceType: "organization" }, limit: 10 },
-      ],
     ])("rejects %s before reaching the SDK", async (_label, query) => {
       await expect(getAuthzedClient().readRelationships(query)).rejects.toThrow(
         AUTHZED_ERROR_CODES.INVALID_REQUEST

--- a/apps/web/lib/authzed/client.test.ts
+++ b/apps/web/lib/authzed/client.test.ts
@@ -1,7 +1,7 @@
 import { configMocks, envMock, retryMocks, sdkMocks } from "./__mocks__/client-dependencies";
 import { status } from "@grpc/grpc-js";
 import { beforeEach, describe, expect, test } from "vitest";
-import { closeAuthzedClient, getAuthzedClient } from "./client";
+import { closeAuthzedClient, configureAuthzedClientForBulkWork, getAuthzedClient } from "./client";
 import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
 
 describe("AuthZed client facade", () => {
@@ -112,6 +112,42 @@ describe("AuthZed client facade", () => {
     expect(first).not.toHaveProperty("token");
     expect(first).not.toHaveProperty("promises");
     expect(first).not.toHaveProperty("close");
+  });
+
+  test("gives a bulk-configured process the long deadline on every call it makes", () => {
+    // The deadline belongs to the channel, and every projector reaches the channel through
+    // `getAuthzedClient()` rather than being handed one — so a command that both sweeps and writes gets
+    // the bulk deadline on its writes too. That is the intent: the alternative is a sweep that dies on
+    // its first slow page.
+    configureAuthzedClientForBulkWork();
+
+    getAuthzedClient();
+
+    expect(sdkMocks.deadlineInterceptor).toHaveBeenCalledWith(30_000);
+    expect(sdkMocks.newClient).toHaveBeenCalledWith(
+      envMock.AUTHZED_TOKEN,
+      envMock.AUTHZED_ENDPOINT,
+      2,
+      undefined,
+      { interceptors: [{ timeoutMs: 30_000 }] }
+    );
+  });
+
+  test("refuses to widen the deadline once a client exists, rather than silently leaving it short", () => {
+    getAuthzedClient();
+
+    expect(() => configureAuthzedClientForBulkWork()).toThrow(AuthzedError);
+    expect(() => configureAuthzedClientForBulkWork()).toThrow(AUTHZED_ERROR_CODES.FAILED_PRECONDITION);
+  });
+
+  test("forgets the bulk deadline on close, so it cannot leak into a later client", () => {
+    configureAuthzedClientForBulkWork();
+    getAuthzedClient();
+
+    closeAuthzedClient();
+    getAuthzedClient();
+
+    expect(sdkMocks.deadlineInterceptor).toHaveBeenLastCalledWith(1_000);
   });
 
   test("closes, resets, and reconstructs the internal client", () => {

--- a/apps/web/lib/authzed/client.ts
+++ b/apps/web/lib/authzed/client.ts
@@ -2,7 +2,11 @@ import "server-only";
 import { deadlineInterceptor, v1 } from "@authzed/authzed-node";
 import { env } from "@/lib/env";
 import { type TAuthzedConsistency, isAuthzedEnabled } from "./config";
-import { AUTHZED_MAX_RELATIONSHIP_UPDATES, AUTHZED_REQUEST_TIMEOUT_MS } from "./constants";
+import {
+  AUTHZED_MAX_RELATIONSHIP_READS,
+  AUTHZED_MAX_RELATIONSHIP_UPDATES,
+  AUTHZED_REQUEST_TIMEOUT_MS,
+} from "./constants";
 import { AUTHZED_ERROR_CODES, AuthzedError, mapAuthzedError } from "./errors";
 import { executeAuthzedOperation } from "./retry";
 
@@ -59,10 +63,70 @@ export type TAuthzedRelationshipFilter =
         subject: TAuthzedSubjectFilter;
       }>);
 
+/** An opaque SpiceDB revision. Formbricks-owned wrapper: the SDK's ZedToken never crosses the facade. */
+export type TAuthzedSnapshot = Readonly<{
+  token: string;
+}>;
+
+/** An opaque resume position within a relationship read. */
+export type TAuthzedReadCursor = Readonly<{
+  token: string;
+}>;
+
+/**
+ * Filter for reading relationships.
+ *
+ * Unlike `TAuthzedRelationshipFilter` this is a plain object rather than a union, so a
+ * `resourceType`-only sweep is expressible. That asymmetry is deliberate and load-bearing: **reads
+ * may sweep an entire resource type, deletes may never**. Because `resourceId` here is
+ * `string | undefined`, this type satisfies neither branch of the delete filter's union, so passing
+ * a read filter to `deleteRelationships` is a compile error and an unbounded mass delete stays
+ * inexpressible.
+ *
+ * `optionalResourceIdPrefix` is deliberately not surfaced: Formbricks object IDs are unprefixed
+ * cuids, so it could never narrow anything, and unused surface on a frozen facade is a liability.
+ */
+export type TAuthzedRelationshipReadFilter = Readonly<{
+  relation?: string;
+  resourceId?: string;
+  resourceType: string;
+  subject?: TAuthzedSubjectFilter;
+}>;
+
+export type TAuthzedRelationshipQuery = Readonly<{
+  /**
+   * Revision to read at. Omit on the first page to resolve fully consistently; pass the previous
+   * page's `snapshot` on every subsequent page so the whole read observes one revision.
+   */
+  atSnapshot?: TAuthzedSnapshot;
+  cursor?: TAuthzedReadCursor;
+  filter: TAuthzedRelationshipReadFilter;
+  limit: number;
+}>;
+
+export type TAuthzedRelationshipPage = Readonly<{
+  /** Resume position, or `null` when the page was short and the read is exhausted. */
+  cursor: TAuthzedReadCursor | null;
+  relationships: ReadonlyArray<TAuthzedRelationship>;
+  /** Revision this page was read at. Thread it back through `atSnapshot` to pin later pages. */
+  snapshot: TAuthzedSnapshot | null;
+}>;
+
 export type TAuthzedClient = Readonly<{
   consistency: TAuthzedConsistency;
   deleteRelationships: (filter: TAuthzedRelationshipFilter) => Promise<void>;
   diffSchema: (schemaText: string) => Promise<TAuthzedSchemaDiff>;
+  /**
+   * Read one page of raw relationships.
+   *
+   * **Operational use only — never for permission logic.** AuthZed's guidance is explicit that
+   * checks and ID listing must go through `Check`, `CheckBulk`, `LookupResources`, and
+   * `LookupSubjects`; reading raw relationships to decide access reimplements the permission graph
+   * in application code and silently diverges from the schema. This exists so operational tooling
+   * can observe what SpiceDB actually holds and reconcile it against PostgreSQL. It is deliberately
+   * not re-exported from `./index`.
+   */
+  readRelationships: (query: TAuthzedRelationshipQuery) => Promise<TAuthzedRelationshipPage>;
   readSchema: () => Promise<TAuthzedSchema>;
   systemKey: string;
   writeRelationships: (updates: ReadonlyArray<TAuthzedRelationshipUpdate>) => Promise<void>;
@@ -199,6 +263,88 @@ const validateRelationshipFilter = (filter: TAuthzedRelationshipFilter): void =>
   }
 };
 
+const invalidReadRequest = (): AuthzedError =>
+  new AuthzedError({
+    attempts: 0,
+    code: AUTHZED_ERROR_CODES.INVALID_REQUEST,
+    operation: "read_relationships",
+    retryable: false,
+  });
+
+const validateRelationshipQuery = (query: TAuthzedRelationshipQuery): void => {
+  const { filter } = query;
+  const optionalFieldsValid =
+    (filter.relation === undefined || isNonEmpty(filter.relation)) &&
+    (filter.resourceId === undefined || isNonEmpty(filter.resourceId)) &&
+    (filter.subject === undefined ||
+      (isNonEmpty(filter.subject.objectType) &&
+        isNonEmpty(filter.subject.objectId) &&
+        (filter.subject.relation === undefined || isNonEmpty(filter.subject.relation))));
+
+  // A limit is mandatory and must be positive: SpiceDB treats `optionalLimit: 0` as *unlimited*,
+  // which under the channel-wide deadline is a guaranteed timeout and an unbounded allocation,
+  // because the promisified streaming call buffers every message before it resolves.
+  const limitValid =
+    Number.isSafeInteger(query.limit) && query.limit >= 1 && query.limit <= AUTHZED_MAX_RELATIONSHIP_READS;
+
+  const tokensValid =
+    (query.atSnapshot === undefined || isNonEmpty(query.atSnapshot.token)) &&
+    (query.cursor === undefined || isNonEmpty(query.cursor.token));
+
+  if (!isNonEmpty(filter.resourceType) || !optionalFieldsValid || !limitValid || !tokensValid) {
+    throw invalidReadRequest();
+  }
+};
+
+/**
+ * Convert one streamed response into a facade relationship.
+ *
+ * Strict by design. Every field below is optional in the generated SDK types, and a missing one
+ * would yield a relationship that compares unequal to the tuple Formbricks wrote — which reconciling
+ * tooling would classify as orphaned and delete. Failing loudly is the only safe reading.
+ */
+const toFacadeRelationship = (response: v1.ReadRelationshipsResponse): TAuthzedRelationship => {
+  const relationship = response.relationship;
+  const resource = relationship?.resource;
+  const subject = relationship?.subject?.object;
+
+  if (!relationship || !resource || !subject) {
+    throw new AuthzedError({
+      attempts: 0,
+      code: AUTHZED_ERROR_CODES.INTERNAL,
+      operation: "read_relationships",
+      retryable: false,
+    });
+  }
+
+  // Formbricks never writes caveated or expiring relationships and the facade cannot represent
+  // them, so dropping the qualifier would misreport the tuple. Their presence means something other
+  // than Formbricks is writing to this SpiceDB, which must stop reconciling tooling outright rather
+  // than let it delete relationships it does not understand.
+  if (relationship.optionalCaveat !== undefined || relationship.optionalExpiresAt !== undefined) {
+    throw new AuthzedError({
+      attempts: 0,
+      code: AUTHZED_ERROR_CODES.UNSUPPORTED,
+      operation: "read_relationships",
+      retryable: false,
+    });
+  }
+
+  const subjectRelation = relationship.subject?.optionalRelation;
+
+  return {
+    relation: relationship.relation,
+    resource: { objectId: resource.objectId, objectType: resource.objectType },
+    subject: {
+      objectId: subject.objectId,
+      objectType: subject.objectType,
+      // Normalize the wire's empty string back to `undefined` so a subject-relation tuple such as
+      // `workspace:x#reader_team@team:y#member` round-trips equal to the update that wrote it.
+      ...(subjectRelation ? { relation: subjectRelation } : {}),
+    },
+  };
+};
+
 const createAuthzedClient = (): TAuthzedClientSingleton => {
   const config = getAuthzedConfig();
 
@@ -267,6 +413,71 @@ const createAuthzedClient = (): TAuthzedClientSingleton => {
           differenceKinds: Object.freeze(differenceKinds),
         };
       }),
+    readRelationships: async (query) => {
+      validateRelationshipQuery(query);
+
+      return executeAuthzedOperation("read_relationships", async () => {
+        const { filter } = query;
+        const responses = await sdkClient.promises.readRelationships({
+          // The first page resolves fully consistently so reconciliation observes the latest write,
+          // matching `diffSchema`: the application's configurable permission-check consistency is
+          // never used for operational verification. Later pages pin that exact revision instead, so
+          // the whole read is one consistent view — resolving each page independently would let a
+          // concurrent write hide a relationship from every page, and tooling would then treat a live
+          // relationship as orphaned. Note `atExactSnapshot` fails once the revision ages out of the
+          // datastore's GC window, which callers must surface as an incomplete read.
+          consistency: query.atSnapshot
+            ? {
+                requirement: {
+                  atExactSnapshot: { token: query.atSnapshot.token },
+                  oneofKind: "atExactSnapshot",
+                },
+              }
+            : { requirement: { fullyConsistent: true, oneofKind: "fullyConsistent" } },
+          optionalCursor: query.cursor ? { token: query.cursor.token } : undefined,
+          optionalLimit: query.limit,
+          relationshipFilter: {
+            optionalRelation: filter.relation ?? "",
+            optionalResourceId: filter.resourceId ?? "",
+            optionalResourceIdPrefix: "",
+            optionalSubjectFilter: filter.subject
+              ? {
+                  optionalRelation: filter.subject.relation
+                    ? { relation: filter.subject.relation }
+                    : undefined,
+                  optionalSubjectId: filter.subject.objectId,
+                  subjectType: filter.subject.objectType,
+                }
+              : undefined,
+            resourceType: filter.resourceType,
+          },
+        });
+
+        const lastResponse = responses.at(-1);
+        const readAt = lastResponse?.readAt?.token;
+
+        // Without a revision on a non-empty page there is nothing to pin later pages to, so a
+        // multi-page read could not be made consistent. Refuse rather than silently degrade.
+        if (lastResponse && !readAt) {
+          throw new AuthzedError({
+            attempts: 0,
+            code: AUTHZED_ERROR_CODES.INTERNAL,
+            operation: "read_relationships",
+            retryable: false,
+          });
+        }
+
+        const afterResultCursor = lastResponse?.afterResultCursor?.token;
+
+        return {
+          // A short page means the filter is exhausted. Only a full page can have more behind it, and
+          // only then is a cursor meaningful.
+          cursor: responses.length === query.limit && afterResultCursor ? { token: afterResultCursor } : null,
+          relationships: responses.map(toFacadeRelationship),
+          snapshot: query.atSnapshot ?? (readAt ? { token: readAt } : null),
+        };
+      });
+    },
     readSchema: async () => {
       const schemaText = await executeAuthzedOperation("read_schema", async () => {
         try {

--- a/apps/web/lib/authzed/client.ts
+++ b/apps/web/lib/authzed/client.ts
@@ -386,7 +386,7 @@ const createAuthzedClient = (requestTimeoutMs: number): TAuthzedClientSingleton 
       validateRelationshipFilter(filter);
 
       await executeAuthzedOperation("delete_relationships", async () => {
-        await sdkClient.promises.deleteRelationships({
+        const response = await sdkClient.promises.deleteRelationships({
           optionalAllowPartialDeletions: false,
           optionalLimit: 0,
           optionalPreconditions: [],
@@ -406,6 +406,20 @@ const createAuthzedClient = (requestTimeoutMs: number): TAuthzedClientSingleton 
             resourceType: filter.resourceType,
           },
         });
+
+        // Asserted rather than assumed. An unlimited, non-partial delete should always report
+        // `COMPLETE`, but this is the one call in the facade that destroys access, and "SpiceDB said it
+        // only got part way and we carried on believing it finished" is the failure that leaves a
+        // half-revoked graph while the caller reports success. A server-side cap or a change in SDK
+        // defaults would surface here instead of silently.
+        if (response.deletionProgress !== v1.DeleteRelationshipsResponse_DeletionProgress.COMPLETE) {
+          throw new AuthzedError({
+            attempts: 1,
+            code: AUTHZED_ERROR_CODES.INTERNAL,
+            operation: "delete_relationships",
+            retryable: true,
+          });
+        }
       });
     },
     diffSchema: async (schemaText) =>

--- a/apps/web/lib/authzed/client.ts
+++ b/apps/web/lib/authzed/client.ts
@@ -95,10 +95,13 @@ export type TAuthzedRelationshipReadFilter = Readonly<{
 
 export type TAuthzedRelationshipQuery = Readonly<{
   /**
-   * Revision to read at. Omit on the first page to resolve fully consistently; pass the previous
-   * page's `snapshot` on every subsequent page so the whole read observes one revision.
+   * Resume position from a previous page.
+   *
+   * The cursor carries the revision it was issued at, so continuing with one keeps the whole read on a
+   * single consistent view. SpiceDB enforces this by rejecting a cursor presented alongside *any* other
+   * changed argument — including a changed consistency requirement — so every page of one read must be
+   * issued with identical parameters.
    */
-  atSnapshot?: TAuthzedSnapshot;
   cursor?: TAuthzedReadCursor;
   filter: TAuthzedRelationshipReadFilter;
   limit: number;
@@ -108,7 +111,7 @@ export type TAuthzedRelationshipPage = Readonly<{
   /** Resume position, or `null` when the page was short and the read is exhausted. */
   cursor: TAuthzedReadCursor | null;
   relationships: ReadonlyArray<TAuthzedRelationship>;
-  /** Revision this page was read at. Thread it back through `atSnapshot` to pin later pages. */
+  /** Revision this page was read at. Constant across the pages of one cursored read. */
   snapshot: TAuthzedSnapshot | null;
 }>;
 
@@ -287,9 +290,7 @@ const validateRelationshipQuery = (query: TAuthzedRelationshipQuery): void => {
   const limitValid =
     Number.isSafeInteger(query.limit) && query.limit >= 1 && query.limit <= AUTHZED_MAX_RELATIONSHIP_READS;
 
-  const tokensValid =
-    (query.atSnapshot === undefined || isNonEmpty(query.atSnapshot.token)) &&
-    (query.cursor === undefined || isNonEmpty(query.cursor.token));
+  const tokensValid = query.cursor === undefined || isNonEmpty(query.cursor.token);
 
   if (!isNonEmpty(filter.resourceType) || !optionalFieldsValid || !limitValid || !tokensValid) {
     throw invalidReadRequest();
@@ -419,21 +420,16 @@ const createAuthzedClient = (): TAuthzedClientSingleton => {
       return executeAuthzedOperation("read_relationships", async () => {
         const { filter } = query;
         const responses = await sdkClient.promises.readRelationships({
-          // The first page resolves fully consistently so reconciliation observes the latest write,
-          // matching `diffSchema`: the application's configurable permission-check consistency is
-          // never used for operational verification. Later pages pin that exact revision instead, so
-          // the whole read is one consistent view — resolving each page independently would let a
-          // concurrent write hide a relationship from every page, and tooling would then treat a live
-          // relationship as orphaned. Note `atExactSnapshot` fails once the revision ages out of the
-          // datastore's GC window, which callers must surface as an incomplete read.
-          consistency: query.atSnapshot
-            ? {
-                requirement: {
-                  atExactSnapshot: { token: query.atSnapshot.token },
-                  oneofKind: "atExactSnapshot",
-                },
-              }
-            : { requirement: { fullyConsistent: true, oneofKind: "fullyConsistent" } },
+          // Fully consistent so reconciliation observes the latest write, matching `diffSchema`: the
+          // application's configurable permission-check consistency is never used for operational
+          // verification.
+          //
+          // The same requirement is sent on every page rather than pinning the first page's revision on
+          // later ones. SpiceDB rejects a cursor presented with any other changed argument, consistency
+          // included, and it does not need the help: the cursor already carries the revision it was
+          // issued at, so a cursored read stays on one revision. Substituting `atExactSnapshot` would
+          // both break the cursor and expose the read to snapshot expiry for no benefit.
+          consistency: { requirement: { fullyConsistent: true, oneofKind: "fullyConsistent" } },
           optionalCursor: query.cursor ? { token: query.cursor.token } : undefined,
           optionalLimit: query.limit,
           relationshipFilter: {
@@ -456,8 +452,8 @@ const createAuthzedClient = (): TAuthzedClientSingleton => {
         const lastResponse = responses.at(-1);
         const readAt = lastResponse?.readAt?.token;
 
-        // Without a revision on a non-empty page there is nothing to pin later pages to, so a
-        // multi-page read could not be made consistent. Refuse rather than silently degrade.
+        // A non-empty page always carries the revision it was read at. Without it a caller cannot tell
+        // whether successive pages describe the same view, so refuse rather than silently degrade.
         if (lastResponse && !readAt) {
           throw new AuthzedError({
             attempts: 0,
@@ -474,7 +470,7 @@ const createAuthzedClient = (): TAuthzedClientSingleton => {
           // only then is a cursor meaningful.
           cursor: responses.length === query.limit && afterResultCursor ? { token: afterResultCursor } : null,
           relationships: responses.map(toFacadeRelationship),
-          snapshot: query.atSnapshot ?? (readAt ? { token: readAt } : null),
+          snapshot: readAt ? { token: readAt } : null,
         };
       });
     },

--- a/apps/web/lib/authzed/client.ts
+++ b/apps/web/lib/authzed/client.ts
@@ -319,7 +319,20 @@ const toFacadeRelationship = (response: v1.ReadRelationshipsResponse): TAuthzedR
   const resource = relationship?.resource;
   const subject = relationship?.subject?.object;
 
-  if (!relationship || !resource || !subject) {
+  // The message fields are optional in the generated types; the scalars inside them are plain protobuf
+  // strings that default to `""` when absent from the wire. Both have to be rejected, or a relationship
+  // with an empty relation or object ID passes here, matches no tuple Formbricks ever wrote, and gets
+  // classified as orphaned — which under `--prune` means deleted. Same fail-loud rule, same reason.
+  if (
+    !relationship ||
+    !resource ||
+    !subject ||
+    !relationship.relation ||
+    !resource.objectId ||
+    !resource.objectType ||
+    !subject.objectId ||
+    !subject.objectType
+  ) {
     throw new AuthzedError({
       attempts: 0,
       code: AUTHZED_ERROR_CODES.INTERNAL,

--- a/apps/web/lib/authzed/client.ts
+++ b/apps/web/lib/authzed/client.ts
@@ -167,6 +167,7 @@ type TAuthzedConfig =
 
 const globalForAuthzed = globalThis as unknown as {
   formbricksAuthzedClient: TAuthzedClientSingleton | undefined;
+  formbricksAuthzedRequestTimeoutMs: number | undefined;
 };
 
 const STABLE_SCHEMA_DIFF_KINDS = {
@@ -554,23 +555,39 @@ const createAuthzedClient = (requestTimeoutMs: number): TAuthzedClientSingleton 
   };
 };
 
-/** The shared request-path client. Deadline sized for a single cheap call. */
-export const getAuthzedClient = (): TAuthzedClient => {
-  globalForAuthzed.formbricksAuthzedClient ??= createAuthzedClient(AUTHZED_REQUEST_TIMEOUT_MS);
+/**
+ * Widen this process's channel deadline to the bulk one, before any client exists.
+ *
+ * The deadline belongs to the channel, not to a call — the SDK's promisified streaming wrappers accept
+ * no per-call options at all — and every projector reaches the channel through `getAuthzedClient()`
+ * rather than being handed one. So "a separate client for bulk work" is not expressible: a command that
+ * both sweeps and writes would need one channel at two deadlines.
+ *
+ * It is a property of the *process* instead. A request-serving process wants the short deadline on
+ * everything, because a projection that hangs holds a user's request open; a command-line process wants
+ * the long one on everything, because a page of relationships legitimately takes longer than a single
+ * `Check`. Command entry points call this first, and it refuses to run once a client exists — silently
+ * leaving the short deadline in place would strand the sweep on its first slow page, which is precisely
+ * the failure this replaced.
+ */
+export const configureAuthzedClientForBulkWork = (): void => {
+  if (globalForAuthzed.formbricksAuthzedClient) {
+    throw new AuthzedError({
+      attempts: 0,
+      code: AUTHZED_ERROR_CODES.FAILED_PRECONDITION,
+      operation: "configure_authzed_client_for_bulk_work",
+      retryable: false,
+    });
+  }
 
-  return globalForAuthzed.formbricksAuthzedClient.facade;
+  globalForAuthzed.formbricksAuthzedRequestTimeoutMs = AUTHZED_BULK_REQUEST_TIMEOUT_MS;
 };
 
-/**
- * A client for administrative work: bulk reads and wide deletes.
- *
- * The deadline is a property of the channel, not of a call — the SDK's promisified streaming wrappers
- * accept no per-call options at all — so a longer deadline means a separate client. It replaces the
- * singleton for the lifetime of the process, which is fine because nothing that needs the request-path
- * deadline runs in a command-line process; `closeAuthzedClient` tears it down either way.
- */
-export const getAuthzedBulkClient = (): TAuthzedClient => {
-  globalForAuthzed.formbricksAuthzedClient ??= createAuthzedClient(AUTHZED_BULK_REQUEST_TIMEOUT_MS);
+/** The shared client. Deadline sized for a single cheap call unless the process asked for bulk work. */
+export const getAuthzedClient = (): TAuthzedClient => {
+  globalForAuthzed.formbricksAuthzedClient ??= createAuthzedClient(
+    globalForAuthzed.formbricksAuthzedRequestTimeoutMs ?? AUTHZED_REQUEST_TIMEOUT_MS
+  );
 
   return globalForAuthzed.formbricksAuthzedClient.facade;
 };
@@ -578,4 +595,5 @@ export const getAuthzedBulkClient = (): TAuthzedClient => {
 export const closeAuthzedClient = (): void => {
   globalForAuthzed.formbricksAuthzedClient?.close();
   globalForAuthzed.formbricksAuthzedClient = undefined;
+  globalForAuthzed.formbricksAuthzedRequestTimeoutMs = undefined;
 };

--- a/apps/web/lib/authzed/client.ts
+++ b/apps/web/lib/authzed/client.ts
@@ -3,6 +3,7 @@ import { deadlineInterceptor, v1 } from "@authzed/authzed-node";
 import { env } from "@/lib/env";
 import { type TAuthzedConsistency, isAuthzedEnabled } from "./config";
 import {
+  AUTHZED_BULK_REQUEST_TIMEOUT_MS,
   AUTHZED_MAX_RELATIONSHIP_READS,
   AUTHZED_MAX_RELATIONSHIP_UPDATES,
   AUTHZED_REQUEST_TIMEOUT_MS,
@@ -77,11 +78,14 @@ export type TAuthzedReadCursor = Readonly<{
  * Filter for reading relationships.
  *
  * Unlike `TAuthzedRelationshipFilter` this is a plain object rather than a union, so a
- * `resourceType`-only sweep is expressible. That asymmetry is deliberate and load-bearing: **reads
- * may sweep an entire resource type, deletes may never**. Because `resourceId` here is
- * `string | undefined`, this type satisfies neither branch of the delete filter's union, so passing
- * a read filter to `deleteRelationships` is a compile error and an unbounded mass delete stays
- * inexpressible.
+ * `resourceType`-only sweep is expressible. Because `resourceId` here is `string | undefined`, this type
+ * satisfies neither branch of the delete filter's union, so passing a read filter to
+ * `deleteRelationships` is a compile error.
+ *
+ * That narrows deletes, it does not bound them: the delete filter also admits a subject-only form with
+ * no `resourceId`, which is how user-deletion cleanup removes one subject's relationships across every
+ * organization or team. Such a delete is unlimited and transactional, bounded only by how many
+ * relationships match — so a new call site has to reason about the match size itself.
  *
  * `optionalResourceIdPrefix` is deliberately not surfaced: Formbricks object IDs are unprefixed
  * cuids, so it could never narrow anything, and unused surface on a frozen facade is a liability.
@@ -98,9 +102,14 @@ export type TAuthzedRelationshipQuery = Readonly<{
    * Resume position from a previous page.
    *
    * The cursor carries the revision it was issued at, so continuing with one keeps the whole read on a
-   * single consistent view. SpiceDB enforces this by rejecting a cursor presented alongside *any* other
-   * changed argument — including a changed consistency requirement — so every page of one read must be
-   * issued with identical parameters.
+   * single consistent view, and SpiceDB rejects a cursor presented alongside *any* other changed
+   * argument — including a changed consistency requirement.
+   *
+   * Both behaviours are verified against SpiceDB v1.52 (`pkg/middleware/consistency` prefers the
+   * cursor's revision over the stated requirement; `internal/services/v1/hash.go` hashes the
+   * consistency, filter and limit into the cursor) and against a real engine in the compose smoke test.
+   * Neither is part of the published API contract, so a server upgrade should re-verify them — the
+   * revision-stability check in `readAllRelationships` is the guard if they ever change.
    */
   cursor?: TAuthzedReadCursor;
   filter: TAuthzedRelationshipReadFilter;
@@ -318,10 +327,13 @@ const toFacadeRelationship = (response: v1.ReadRelationshipsResponse): TAuthzedR
     });
   }
 
-  // Formbricks never writes caveated or expiring relationships and the facade cannot represent
-  // them, so dropping the qualifier would misreport the tuple. Their presence means something other
-  // than Formbricks is writing to this SpiceDB, which must stop reconciling tooling outright rather
-  // than let it delete relationships it does not understand.
+  // Formbricks never writes caveated or expiring relationships and the facade cannot represent them, so
+  // dropping the qualifier would misreport the tuple — and a misreported tuple is exactly what
+  // reconciling tooling would classify as stale. Refusing is therefore the safe reading today.
+  //
+  // Note this becomes a tripwire the day Formbricks adopts SpiceDB's expiration feature, which AuthZed
+  // recommends for time-limited access: the facade must learn to represent it before anything writes
+  // one, or reconciliation will start refusing to run.
   if (relationship.optionalCaveat !== undefined || relationship.optionalExpiresAt !== undefined) {
     throw new AuthzedError({
       attempts: 0,
@@ -346,7 +358,7 @@ const toFacadeRelationship = (response: v1.ReadRelationshipsResponse): TAuthzedR
   };
 };
 
-const createAuthzedClient = (): TAuthzedClientSingleton => {
+const createAuthzedClient = (requestTimeoutMs: number): TAuthzedClientSingleton => {
   const config = getAuthzedConfig();
 
   if (!config.enabled) {
@@ -361,8 +373,10 @@ const createAuthzedClient = (): TAuthzedClientSingleton => {
   const security = config.insecure
     ? v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS
     : v1.ClientSecurity.SECURE;
+  // The SDK appends its own 30s deadline interceptor last, and that interceptor only sets a deadline
+  // when none is present — so whatever is installed here wins for every call on this channel.
   const sdkClient = v1.NewClient(config.token, config.endpoint, security, undefined, {
-    interceptors: [deadlineInterceptor(AUTHZED_REQUEST_TIMEOUT_MS)],
+    interceptors: [deadlineInterceptor(requestTimeoutMs)],
   });
 
   const facade = Object.freeze<TAuthzedClient>({
@@ -425,10 +439,10 @@ const createAuthzedClient = (): TAuthzedClientSingleton => {
           // verification.
           //
           // The same requirement is sent on every page rather than pinning the first page's revision on
-          // later ones. SpiceDB rejects a cursor presented with any other changed argument, consistency
-          // included, and it does not need the help: the cursor already carries the revision it was
-          // issued at, so a cursored read stays on one revision. Substituting `atExactSnapshot` would
-          // both break the cursor and expose the read to snapshot expiry for no benefit.
+          // later ones. It has to be: SpiceDB hashes the consistency into the cursor and rejects a
+          // mismatch. It also does not need the help — the cursor's own revision takes precedence over
+          // whatever requirement is stated — so substituting `atExactSnapshot` on later pages would both
+          // invalidate the cursor and add snapshot-expiry exposure for nothing.
           consistency: { requirement: { fullyConsistent: true, oneofKind: "fullyConsistent" } },
           optionalCursor: query.cursor ? { token: query.cursor.token } : undefined,
           optionalLimit: query.limit,
@@ -540,8 +554,23 @@ const createAuthzedClient = (): TAuthzedClientSingleton => {
   };
 };
 
+/** The shared request-path client. Deadline sized for a single cheap call. */
 export const getAuthzedClient = (): TAuthzedClient => {
-  globalForAuthzed.formbricksAuthzedClient ??= createAuthzedClient();
+  globalForAuthzed.formbricksAuthzedClient ??= createAuthzedClient(AUTHZED_REQUEST_TIMEOUT_MS);
+
+  return globalForAuthzed.formbricksAuthzedClient.facade;
+};
+
+/**
+ * A client for administrative work: bulk reads and wide deletes.
+ *
+ * The deadline is a property of the channel, not of a call — the SDK's promisified streaming wrappers
+ * accept no per-call options at all — so a longer deadline means a separate client. It replaces the
+ * singleton for the lifetime of the process, which is fine because nothing that needs the request-path
+ * deadline runs in a command-line process; `closeAuthzedClient` tears it down either way.
+ */
+export const getAuthzedBulkClient = (): TAuthzedClient => {
+  globalForAuthzed.formbricksAuthzedClient ??= createAuthzedClient(AUTHZED_BULK_REQUEST_TIMEOUT_MS);
 
   return globalForAuthzed.formbricksAuthzedClient.facade;
 };

--- a/apps/web/lib/authzed/constants.ts
+++ b/apps/web/lib/authzed/constants.ts
@@ -8,19 +8,32 @@ export const AUTHZED_MAX_RELATIONSHIP_UPDATES = 1_000;
 export const AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES = 10;
 
 /**
+ * Deadline for administrative calls: bulk reads and wide deletes.
+ *
+ * The request-path deadline is sized for a single cheap call. A server-streaming read or an unbounded
+ * delete needs room, and SpiceDB's own `--streaming-api-response-delay-timeout` defaults to 30s, so
+ * matching it is the conservative choice. Applied by giving the command-line client its own channel;
+ * the request-path client keeps `AUTHZED_REQUEST_TIMEOUT_MS`.
+ */
+export const AUTHZED_BULK_REQUEST_TIMEOUT_MS = 30_000;
+
+/**
  * Relationships requested per `readRelationships` page.
  *
- * `AUTHZED_REQUEST_TIMEOUT_MS` is installed once as a channel-wide deadline interceptor and bounds
- * the *entire* server-streaming call, and the promisified SDK buffers every message before it
- * resolves — so a page must fully stream within that deadline. 250 keeps a page comfortably inside
- * it while staying well under the write batch limit. Raising the interceptor deadline instead is not
- * an option: it is global and would slow every request-path projection failure.
+ * The deadline interceptor bounds the *entire* server-streaming call — the promisified SDK buffers
+ * every message before resolving — so a page must fully stream within it. 250 leaves generous headroom
+ * even on the request-path deadline, and stays well under SpiceDB's own
+ * `--max-read-relationships-limit` (1,000 by default), which rejects a larger limit outright.
  */
 export const AUTHZED_MAX_RELATIONSHIP_READS = 250;
 
 /**
  * Observed relationships held in memory for a single backfill unit before the unit is abandoned.
- * Bounds the drainer so a pathological store cannot exhaust the process.
+ *
+ * Bounds the drainer so a pathological store cannot exhaust the process. This is a *per-unit* bound and
+ * only applies to filters narrow enough to drain — one organization's resources, say. A sweep across a
+ * whole resource type must stream instead (`forEachRelationshipPage`), because applying this bound there
+ * would make the sweep fail outright on any deployment holding more relationships than the bound.
  */
 export const AUTHZED_MAX_OBSERVED_RELATIONSHIPS_PER_UNIT = 20_000;
 

--- a/apps/web/lib/authzed/constants.ts
+++ b/apps/web/lib/authzed/constants.ts
@@ -6,3 +6,42 @@ export const AUTHZED_RETRY_BASE_DELAYS_MS = [100, 200] as const;
 export const AUTHZED_RETRY_JITTER_RATIO = 0.2;
 export const AUTHZED_MAX_RELATIONSHIP_UPDATES = 1_000;
 export const AUTHZED_MAX_PARALLEL_RELATIONSHIP_DELETES = 10;
+
+/**
+ * Relationships requested per `readRelationships` page.
+ *
+ * `AUTHZED_REQUEST_TIMEOUT_MS` is installed once as a channel-wide deadline interceptor and bounds
+ * the *entire* server-streaming call, and the promisified SDK buffers every message before it
+ * resolves — so a page must fully stream within that deadline. 250 keeps a page comfortably inside
+ * it while staying well under the write batch limit. Raising the interceptor deadline instead is not
+ * an option: it is global and would slow every request-path projection failure.
+ */
+export const AUTHZED_MAX_RELATIONSHIP_READS = 250;
+
+/**
+ * Observed relationships held in memory for a single backfill unit before the unit is abandoned.
+ * Bounds the drainer so a pathological store cannot exhaust the process.
+ */
+export const AUTHZED_MAX_OBSERVED_RELATIONSHIPS_PER_UNIT = 20_000;
+
+/** Organizations fetched per keyset page while enumerating backfill units. */
+export const AUTHZED_BACKFILL_ORGANIZATION_PAGE_SIZE = 100;
+
+/**
+ * Projection targets handed to a reconciler in one call.
+ *
+ * Reconcilers read their source snapshot with `where: { OR: targets.map(...) }`, which is unbounded
+ * by construction — a large tenant would build a query that is both a planner disaster and close to
+ * PostgreSQL's bound-parameter ceiling. 200 targets also keeps the widest fan-out (4 updates per
+ * membership) under `AUTHZED_MAX_RELATIONSHIP_UPDATES`.
+ */
+export const AUTHZED_BACKFILL_TARGET_CHUNK_SIZE = 200;
+
+/**
+ * Orphaned resources a single run may prune.
+ *
+ * A large orphan count is a symptom — wrong endpoint, wrong database, a mid-restore SpiceDB — not a
+ * big cleanup job. Exceeding the cap prunes nothing for that unit so the run degrades into a loud
+ * report instead of a partly-destroyed authorization graph. Operators may lower it, never raise it.
+ */
+export const AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN = 500;

--- a/apps/web/lib/authzed/constants.ts
+++ b/apps/web/lib/authzed/constants.ts
@@ -56,5 +56,25 @@ export const AUTHZED_BACKFILL_TARGET_CHUNK_SIZE = 200;
  * A large orphan count is a symptom — wrong endpoint, wrong database, a mid-restore SpiceDB — not a
  * big cleanup job. Exceeding the cap prunes nothing for that unit so the run degrades into a loud
  * report instead of a partly-destroyed authorization graph. Operators may lower it, never raise it.
+ *
+ * "Nothing" is the whole point, and it is why every unit — the streaming sweep included — counts its
+ * orphans to completion before deleting any of them. A cap enforced per page would let the pages that
+ * fit through and halt on the one that did not, leaving the graph partly destroyed by exactly the
+ * mistake the cap exists to catch.
  */
 export const AUTHZED_MAX_PRUNED_RESOURCES_PER_RUN = 500;
+
+/**
+ * Distinct orphaned records the global sweep tracks to keep its count exact.
+ *
+ * The sweep streams, so one record can be implied by relationships on more than one page: a user who
+ * holds both `member` and `owner` is two tuples, and SpiceDB returns them grouped by relation rather
+ * than adjacently, so they straddle a page boundary in any organization larger than a page. Counting
+ * that record twice would inflate the total, and the total is the diagnostic.
+ *
+ * Bounded because this set is the one structure in a streaming sweep that grows with the store. Past the
+ * bound the sweep keeps counting and reports `truncated`: a total that may double-count is far better
+ * than an unbounded heap, and a run with this many orphans is already three orders of magnitude past the
+ * prune cap, so nothing is deleted on the strength of it.
+ */
+export const AUTHZED_MAX_TRACKED_ORPHAN_REFS = 50_000;

--- a/apps/web/lib/authzed/errors.ts
+++ b/apps/web/lib/authzed/errors.ts
@@ -9,6 +9,7 @@ export const AUTHZED_ERROR_CODES = {
   FAILED_PRECONDITION: "authzed_failed_precondition",
   INTERNAL: "authzed_internal",
   INVALID_REQUEST: "authzed_invalid_request",
+  LIMIT_EXCEEDED: "authzed_limit_exceeded",
   NOT_FOUND: "authzed_not_found",
   OVERLOADED: "authzed_overloaded",
   PERMISSION_DENIED: "authzed_permission_denied",

--- a/apps/web/lib/authzed/metrics-buckets.test.ts
+++ b/apps/web/lib/authzed/metrics-buckets.test.ts
@@ -1,0 +1,85 @@
+import { metrics } from "@opentelemetry/api";
+import {
+  AggregationTemporality,
+  InMemoryMetricExporter,
+  MeterProvider,
+  PeriodicExportingMetricReader,
+} from "@opentelemetry/sdk-metrics";
+import { afterEach, describe, expect, test } from "vitest";
+
+/**
+ * Bucket configuration, verified against the real SDK rather than by asserting the advice object.
+ *
+ * The advice is only a *hint*: whether it takes effect depends on the SDK honouring it, so asserting the
+ * literal we passed in would restate the source and prove nothing. What is worth pinning is the
+ * boundaries that end up on the exported data point.
+ *
+ * What this guards against is concrete. The SDK's default boundaries are `[0, 5, 10, 25, … 10000]`, a
+ * millisecond scale, and this histogram records seconds. Under the defaults every healthy projection
+ * lands in the single `(0, 5]` bucket, and because `histogram_quantile` interpolates *within* a bucket, a
+ * p95 over observations that are all ~100ms reports something near 4.75s. The runbook's `> 0.5` alert
+ * would then fire continuously on healthy traffic — worse than no alert, because it teaches its audience
+ * to ignore it.
+ */
+
+const HISTOGRAM_NAME = "formbricks_authzed_projection_duration_seconds";
+
+const recordOneProjection = async () => {
+  const exporter = new InMemoryMetricExporter(AggregationTemporality.CUMULATIVE);
+  // A long interval so nothing exports on a timer; `forceFlush` is what drives the export here.
+  const reader = new PeriodicExportingMetricReader({ exporter, exportIntervalMillis: 60_000 });
+  const provider = new MeterProvider({ readers: [reader] });
+  metrics.setGlobalMeterProvider(provider);
+
+  const { recordAuthzedProjection } = await import("./metrics");
+  recordAuthzedProjection({
+    durationMs: 100,
+    operation: "reconcile_organization_memberships",
+    projection: "organization_membership",
+    status: "projected",
+  });
+
+  await reader.forceFlush();
+  const histogram = exporter
+    .getMetrics()
+    .flatMap((resourceMetric) => resourceMetric.scopeMetrics)
+    .flatMap((scopeMetric) => scopeMetric.metrics)
+    .find((metric) => metric.descriptor.name === HISTOGRAM_NAME);
+
+  return { provider, value: histogram?.dataPoints[0]?.value };
+};
+
+describe("projection duration histogram", () => {
+  let shutdown: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await shutdown?.();
+    shutdown = undefined;
+    metrics.disable();
+  });
+
+  test("exports second-scale buckets, so a sub-second p95 is measurable", async () => {
+    const { provider, value } = await recordOneProjection();
+    shutdown = () => provider.shutdown();
+
+    const boundaries = (value as Readonly<{ buckets: Readonly<{ boundaries: number[] }> }> | undefined)
+      ?.buckets.boundaries;
+
+    expect(boundaries).toBeDefined();
+    // The alert threshold has to fall on a boundary. Inside a bucket, the quantile it is compared against
+    // is an interpolation across whatever range contains it.
+    expect(boundaries).toContain(0.5);
+    // Seconds, not milliseconds: the default scale reaches 10,000 and swallows every real observation.
+    expect(Math.max(...(boundaries ?? []))).toBeLessThanOrEqual(10);
+    // And enough resolution below the threshold for a healthy value to be distinguishable from it.
+    expect((boundaries ?? []).filter((boundary) => boundary < 0.5)).toHaveLength(7);
+  });
+
+  test("records the observation in seconds, not milliseconds", async () => {
+    const { provider, value } = await recordOneProjection();
+    shutdown = () => provider.shutdown();
+
+    // 100ms in, 0.1 recorded. A unit mismatch here would be invisible to the bucket assertions above.
+    expect((value as Readonly<{ sum?: number }> | undefined)?.sum).toBeCloseTo(0.1);
+  });
+});

--- a/apps/web/lib/authzed/metrics.test.ts
+++ b/apps/web/lib/authzed/metrics.test.ts
@@ -37,28 +37,42 @@ beforeEach(() => {
 });
 
 describe("recordAuthzedProjection", () => {
-  test.each(["projected", "failed", "disabled"] as const)(
-    "records a %s outcome with its duration",
-    (status) => {
-      recordAuthzedProjection({
-        durationMs: 42,
-        operation: "reconcile_organization_memberships",
-        projection: "organization_membership",
-        status,
-      });
+  test.each(["projected", "failed"] as const)("records a %s outcome and its duration", (status) => {
+    recordAuthzedProjection({
+      durationMs: 4200,
+      operation: "reconcile_organization_memberships",
+      projection: "organization_membership",
+      status,
+    });
 
-      const attributes = {
-        operation: "reconcile_organization_memberships",
-        projection: "organization_membership",
-        status,
-      };
-      expect(counter("formbricks_authzed_projection_total").add).toHaveBeenCalledWith(1, attributes);
-      expect(histogram("formbricks_authzed_projection_duration_ms").record).toHaveBeenCalledWith(
-        42,
-        attributes
-      );
-    }
-  );
+    const attributes = {
+      operation: "reconcile_organization_memberships",
+      projection: "organization_membership",
+      status,
+    };
+    expect(counter("formbricks_authzed_projection_total").add).toHaveBeenCalledWith(1, attributes);
+    // Seconds, per the OpenTelemetry duration convention.
+    expect(histogram("formbricks_authzed_projection_duration").record).toHaveBeenCalledWith(4.2, attributes);
+  });
+
+  test("counts a disabled projection but keeps its structural zero out of the latency histogram", () => {
+    recordAuthzedProjection({
+      durationMs: 0,
+      operation: "reconcile_api_key_relationships",
+      projection: "api_key",
+      status: "disabled",
+    });
+
+    expect(counter("formbricks_authzed_projection_total").add).toHaveBeenCalledOnce();
+    expect(histogram("formbricks_authzed_projection_duration").record).not.toHaveBeenCalled();
+  });
+
+  test("names the duration instrument without a unit suffix", () => {
+    // `..._duration_ms` with `unit: "ms"` exports as `..._duration_ms_milliseconds` through OTLP while
+    // the Prometheus exporter appends nothing — the two would disagree on the name.
+    expect(histograms.has("formbricks_authzed_projection_duration")).toBe(true);
+    expect(histograms.has("formbricks_authzed_projection_duration_ms")).toBe(false);
+  });
 });
 
 describe("recordAuthzedRequestFailure", () => {

--- a/apps/web/lib/authzed/metrics.test.ts
+++ b/apps/web/lib/authzed/metrics.test.ts
@@ -52,7 +52,10 @@ describe("recordAuthzedProjection", () => {
     };
     expect(counter("formbricks_authzed_projection_total").add).toHaveBeenCalledWith(1, attributes);
     // Seconds, per the OpenTelemetry duration convention.
-    expect(histogram("formbricks_authzed_projection_duration").record).toHaveBeenCalledWith(4.2, attributes);
+    expect(histogram("formbricks_authzed_projection_duration_seconds").record).toHaveBeenCalledWith(
+      4.2,
+      attributes
+    );
   });
 
   test("counts a disabled projection but keeps its structural zero out of the latency histogram", () => {
@@ -64,13 +67,18 @@ describe("recordAuthzedProjection", () => {
     });
 
     expect(counter("formbricks_authzed_projection_total").add).toHaveBeenCalledOnce();
-    expect(histogram("formbricks_authzed_projection_duration").record).not.toHaveBeenCalled();
+    expect(histogram("formbricks_authzed_projection_duration_seconds").record).not.toHaveBeenCalled();
   });
 
-  test("names the duration instrument without a unit suffix", () => {
-    // `..._duration_ms` with `unit: "ms"` exports as `..._duration_ms_milliseconds` through OTLP while
-    // the Prometheus exporter appends nothing — the two would disagree on the name.
-    expect(histograms.has("formbricks_authzed_projection_duration")).toBe(true);
+  test("names the duration instrument so both exporters produce the series the runbook queries", () => {
+    // The two exporters configured side by side derive the series name differently: the Prometheus
+    // exporter appends only `_total` and emits the unit as a comment, while OTLP's translation appends
+    // the unit unless the name already carries it. `_seconds` is the one spelling both agree on — and
+    // the runbook's histogram_quantile query names exactly this series.
+    expect(histograms.has("formbricks_authzed_projection_duration_seconds")).toBe(true);
+    // The unit-less name would export as `..._duration` on a scrape, matching nothing the runbook asks
+    // for; `_ms` was the original defect.
+    expect(histograms.has("formbricks_authzed_projection_duration")).toBe(false);
     expect(histograms.has("formbricks_authzed_projection_duration_ms")).toBe(false);
   });
 });

--- a/apps/web/lib/authzed/metrics.test.ts
+++ b/apps/web/lib/authzed/metrics.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AUTHZED_ERROR_CODES } from "./errors";
+
+const counters = new Map<string, { add: ReturnType<typeof vi.fn> }>();
+const histograms = new Map<string, { record: ReturnType<typeof vi.fn> }>();
+
+vi.mock("@opentelemetry/api", () => ({
+  metrics: {
+    getMeter: vi.fn(() => ({
+      createCounter: vi.fn((name: string) => {
+        const instrument = { add: vi.fn() };
+        counters.set(name, instrument);
+        return instrument;
+      }),
+      createHistogram: vi.fn((name: string) => {
+        const instrument = { record: vi.fn() };
+        histograms.set(name, instrument);
+        return instrument;
+      }),
+    })),
+  },
+}));
+
+const { recordAuthzedProjection, recordAuthzedRequestFailure, recordAuthzedRequestRetry } =
+  await import("./metrics");
+
+const counter = (name: string) => counters.get(name)!;
+const histogram = (name: string) => histograms.get(name)!;
+
+beforeEach(() => {
+  for (const instrument of counters.values()) {
+    instrument.add.mockClear();
+  }
+  for (const instrument of histograms.values()) {
+    instrument.record.mockClear();
+  }
+});
+
+describe("recordAuthzedProjection", () => {
+  test.each(["projected", "failed", "disabled"] as const)(
+    "records a %s outcome with its duration",
+    (status) => {
+      recordAuthzedProjection({
+        durationMs: 42,
+        operation: "reconcile_organization_memberships",
+        projection: "organization_membership",
+        status,
+      });
+
+      const attributes = {
+        operation: "reconcile_organization_memberships",
+        projection: "organization_membership",
+        status,
+      };
+      expect(counter("formbricks_authzed_projection_total").add).toHaveBeenCalledWith(1, attributes);
+      expect(histogram("formbricks_authzed_projection_duration_ms").record).toHaveBeenCalledWith(
+        42,
+        attributes
+      );
+    }
+  );
+});
+
+describe("recordAuthzedRequestFailure", () => {
+  test("records the sanitized code, operation, and retryability", () => {
+    recordAuthzedRequestFailure({
+      code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+      operation: "write_relationships",
+      retryable: true,
+    });
+
+    expect(counter("formbricks_authzed_request_failures_total").add).toHaveBeenCalledWith(1, {
+      code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+      operation: "write_relationships",
+      retryable: true,
+    });
+  });
+});
+
+describe("recordAuthzedRequestRetry", () => {
+  test("records retries separately from failures", () => {
+    // A retry that later succeeds never reaches the failure counter, so a degraded SpiceDB would
+    // otherwise be invisible until it started dropping writes outright.
+    recordAuthzedRequestRetry({
+      code: AUTHZED_ERROR_CODES.TIMEOUT,
+      operation: "read_relationships",
+    });
+
+    expect(counter("formbricks_authzed_request_retries_total").add).toHaveBeenCalledWith(1, {
+      code: AUTHZED_ERROR_CODES.TIMEOUT,
+      operation: "read_relationships",
+    });
+    expect(counter("formbricks_authzed_request_failures_total").add).not.toHaveBeenCalled();
+  });
+});
+
+describe("attribute cardinality", () => {
+  test("never carries an identifier", () => {
+    // These attributes leave the deployment when an OTLP endpoint is configured. An organization or
+    // user ID here would be both a cardinality explosion and a privacy leak — the same rule the
+    // logger follows.
+    recordAuthzedProjection({
+      durationMs: 1,
+      operation: "reconcile_api_key_relationships",
+      projection: "api_key",
+      status: "failed",
+    });
+    recordAuthzedRequestFailure({
+      code: AUTHZED_ERROR_CODES.INTERNAL,
+      operation: "write_relationships",
+      retryable: false,
+    });
+
+    const recordedAttributes = [
+      ...counter("formbricks_authzed_projection_total").add.mock.calls,
+      ...counter("formbricks_authzed_request_failures_total").add.mock.calls,
+    ].flatMap(([, attributes]) => Object.keys(attributes as object));
+
+    expect([...new Set(recordedAttributes)].sort()).toEqual([
+      "code",
+      "operation",
+      "projection",
+      "retryable",
+      "status",
+    ]);
+  });
+});

--- a/apps/web/lib/authzed/metrics.ts
+++ b/apps/web/lib/authzed/metrics.ts
@@ -52,6 +52,15 @@ const projectionTotal = meter.createCounter("formbricks_authzed_projection_total
  * nothing on the scrape path.
  */
 const projectionDuration = meter.createHistogram("formbricks_authzed_projection_duration_seconds", {
+  // The SDK's default boundaries are `[0, 5, 10, 25, … 10000]` — a millisecond scale. Recording seconds
+  // against them puts every healthy projection in the single `(0, 5]` bucket, and `histogram_quantile`
+  // interpolates within a bucket: a p95 over observations that are all ~100ms reports something close to
+  // 4.75s, so the runbook's `> 0.5` alert would fire continuously on healthy traffic. These are the
+  // semantic conventions' second-scale boundaries, which include 0.5 exactly so the alert threshold
+  // falls on a boundary rather than inside a bucket.
+  advice: {
+    explicitBucketBoundaries: [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10],
+  },
   description: "Duration of AuthZed relationship projections",
   unit: "s",
 });

--- a/apps/web/lib/authzed/metrics.ts
+++ b/apps/web/lib/authzed/metrics.ts
@@ -19,6 +19,16 @@ import { metrics } from "@opentelemetry/api";
  * Note this covers the always-on request path only. The backfill command is a short-lived process with
  * no scrape window and no flush, so its observability is the counters in its own JSON result and its
  * exit code.
+ *
+ * **A deliberate deviation from the semantic conventions, which prescribe dots as namespace delimiters
+ * (`formbricks.authzed.projection.duration`) and say a unit need not appear in the name.** This app
+ * configures the Prometheus reader *and* an OTLP reader at once, and the two derive a series name
+ * differently: the Prometheus exporter sanitizes dots to underscores and appends no unit, while OTLP's
+ * Prometheus translation appends the unit unless the name already carries it. Under the conventional
+ * spelling the same instrument would surface as `..._duration` on a scrape and `..._duration_seconds`
+ * through a collector — so the runbook could not name one series, which is exactly the defect this
+ * naming replaced. Prometheus-style names with the unit spelled out are the only form both paths agree
+ * on. Revisit if the Prometheus reader is ever dropped.
  */
 
 const meter = metrics.getMeter("formbricks.authzed");

--- a/apps/web/lib/authzed/metrics.ts
+++ b/apps/web/lib/authzed/metrics.ts
@@ -29,15 +29,19 @@ const projectionTotal = meter.createCounter("formbricks_authzed_projection_total
 });
 
 /**
- * Seconds, and no unit in the instrument name.
+ * Seconds, with the unit spelled out in the instrument name.
  *
- * OpenTelemetry's semantic conventions prescribe seconds for durations, and its Prometheus translation
- * appends the unit as a name suffix — so `..._duration_ms` with `unit: "ms"` would export as
- * `..._duration_ms_milliseconds` through the OTLP path while the JS Prometheus exporter appends nothing,
- * leaving the two exporters this app configures side by side disagreeing on the metric's name. Naming it
- * without a unit and measuring in seconds yields `..._duration_seconds` from both.
+ * The semantic conventions prescribe seconds for durations, which rules out the `_ms` this started as.
+ * The unit belongs in the *name* as well because the two exporters this app configures side by side
+ * derive the series name differently: `@opentelemetry/exporter-prometheus` appends only `_total`, to
+ * monotonic sums, and emits the unit as a `# UNIT` comment rather than a suffix, while OTLP's Prometheus
+ * translation appends the unit — skipping it when the name already carries it. Naming it `_seconds` is
+ * therefore the one spelling both paths agree on, and the runbook's alert queries can name a single
+ * series. Leaving the unit out of the name would export `..._duration` on a scrape and
+ * `..._duration_seconds` through a collector, which is how the runbook's histogram query came to match
+ * nothing on the scrape path.
  */
-const projectionDuration = meter.createHistogram("formbricks_authzed_projection_duration", {
+const projectionDuration = meter.createHistogram("formbricks_authzed_projection_duration_seconds", {
   description: "Duration of AuthZed relationship projections",
   unit: "s",
 });

--- a/apps/web/lib/authzed/metrics.ts
+++ b/apps/web/lib/authzed/metrics.ts
@@ -1,0 +1,88 @@
+import "server-only";
+import { metrics } from "@opentelemetry/api";
+
+/**
+ * Operational metrics for AuthZed relationship sync.
+ *
+ * Projection is best-effort by design: an outage never turns a successful PostgreSQL mutation into an
+ * application error. That is the right trade-off, and it is also why drift can accumulate silently —
+ * these counters are how an operator finds out, and what tells them to run `pnpm authzed:backfill`.
+ *
+ * Uses the OpenTelemetry metrics API, which the app already exports through both the Prometheus and
+ * OTLP readers configured in `instrumentation-node.ts`. When neither is enabled `getMeter` returns a
+ * no-op meter, so recording is safe with zero configuration and costs nothing.
+ *
+ * **Every attribute is a bounded, enumerable value — never an identifier.** Same rule as the logger:
+ * these leave the deployment when an OTLP endpoint is configured, and an organization or user ID here
+ * would be both a cardinality explosion and a privacy leak.
+ *
+ * Note this covers the always-on request path only. The backfill command is a short-lived process with
+ * no scrape window and no flush, so its observability is the counters in its own JSON result and its
+ * exit code.
+ */
+
+const meter = metrics.getMeter("formbricks.authzed");
+
+/** Projection outcomes, by operation and projector. Includes `disabled` so a misconfigured deployment is visible. */
+const projectionTotal = meter.createCounter("formbricks_authzed_projection_total", {
+  description: "AuthZed relationship projections by outcome",
+});
+
+const projectionDuration = meter.createHistogram("formbricks_authzed_projection_duration_ms", {
+  description: "Duration of AuthZed relationship projections",
+  unit: "ms",
+});
+
+/**
+ * Requests that exhausted their retry budget.
+ *
+ * The signal that distinguishes a blip from an outage: a sustained rate here means relationships are
+ * being dropped and a backfill will be needed once the cause is resolved.
+ */
+const requestFailuresTotal = meter.createCounter("formbricks_authzed_request_failures_total", {
+  description: "AuthZed requests that failed after exhausting retries",
+});
+
+/** Retries scheduled. Elevated but non-failing means SpiceDB is degraded rather than down. */
+const requestRetriesTotal = meter.createCounter("formbricks_authzed_request_retries_total", {
+  description: "AuthZed requests retried after a retryable failure",
+});
+
+export type TAuthzedProjectionMetric = Readonly<{
+  durationMs: number;
+  operation: string;
+  projection: string;
+  status: "disabled" | "failed" | "projected";
+}>;
+
+export const recordAuthzedProjection = ({
+  durationMs,
+  operation,
+  projection,
+  status,
+}: TAuthzedProjectionMetric): void => {
+  const attributes = { operation, projection, status };
+  projectionTotal.add(1, attributes);
+  projectionDuration.record(durationMs, attributes);
+};
+
+export type TAuthzedRequestFailureMetric = Readonly<{
+  code: string;
+  operation: string;
+  retryable: boolean;
+}>;
+
+export const recordAuthzedRequestFailure = ({
+  code,
+  operation,
+  retryable,
+}: TAuthzedRequestFailureMetric): void => {
+  requestFailuresTotal.add(1, { code, operation, retryable });
+};
+
+export const recordAuthzedRequestRetry = ({
+  code,
+  operation,
+}: Readonly<{ code: string; operation: string }>): void => {
+  requestRetriesTotal.add(1, { code, operation });
+};

--- a/apps/web/lib/authzed/metrics.ts
+++ b/apps/web/lib/authzed/metrics.ts
@@ -28,9 +28,18 @@ const projectionTotal = meter.createCounter("formbricks_authzed_projection_total
   description: "AuthZed relationship projections by outcome",
 });
 
-const projectionDuration = meter.createHistogram("formbricks_authzed_projection_duration_ms", {
+/**
+ * Seconds, and no unit in the instrument name.
+ *
+ * OpenTelemetry's semantic conventions prescribe seconds for durations, and its Prometheus translation
+ * appends the unit as a name suffix — so `..._duration_ms` with `unit: "ms"` would export as
+ * `..._duration_ms_milliseconds` through the OTLP path while the JS Prometheus exporter appends nothing,
+ * leaving the two exporters this app configures side by side disagreeing on the metric's name. Naming it
+ * without a unit and measuring in seconds yields `..._duration_seconds` from both.
+ */
+const projectionDuration = meter.createHistogram("formbricks_authzed_projection_duration", {
   description: "Duration of AuthZed relationship projections",
-  unit: "ms",
+  unit: "s",
 });
 
 /**
@@ -63,7 +72,13 @@ export const recordAuthzedProjection = ({
 }: TAuthzedProjectionMetric): void => {
   const attributes = { operation, projection, status };
   projectionTotal.add(1, attributes);
-  projectionDuration.record(durationMs, attributes);
+
+  // `disabled` short-circuits before any work, so its duration is a structural zero rather than a
+  // measurement. Recording it would drag the latency distribution of every quantile toward zero on a
+  // deployment that has AuthZed switched off — and latency is the signal the runbook calls user-visible.
+  if (status !== "disabled") {
+    projectionDuration.record(durationMs / 1000, attributes);
+  }
 };
 
 export type TAuthzedRequestFailureMetric = Readonly<{

--- a/apps/web/lib/authzed/organization-membership.test.ts
+++ b/apps/web/lib/authzed/organization-membership.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
+import { OrganizationRole } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { getAuthzedClient } from "./client";
 import { isAuthzedEnabled } from "./config";
@@ -42,7 +43,7 @@ vi.mock("./config", () => ({
 const ORGANIZATION_ID = "organization-private-id";
 const USER_ID = "user-private-id";
 
-const membershipRows = (role: string, userId = USER_ID, organizationId = ORGANIZATION_ID) => [
+const membershipRows = (role: OrganizationRole, userId = USER_ID, organizationId = ORGANIZATION_ID) => [
   { organizationId, role, userId },
 ];
 

--- a/apps/web/lib/authzed/organization-membership.test.ts
+++ b/apps/web/lib/authzed/organization-membership.test.ts
@@ -8,6 +8,7 @@ import {
   deleteOrganizationRelationships,
   deleteUserOrganizationRelationships,
   reconcileOrganizationMembership,
+  reconcileOrganizationMemberships,
 } from "./organization-membership";
 
 const clientMocks = {
@@ -18,7 +19,7 @@ const clientMocks = {
 vi.mock("@formbricks/database", () => ({
   prisma: {
     membership: {
-      findUnique: vi.fn(),
+      findMany: vi.fn(),
     },
   },
 }));
@@ -41,6 +42,10 @@ vi.mock("./config", () => ({
 const ORGANIZATION_ID = "organization-private-id";
 const USER_ID = "user-private-id";
 
+const membershipRows = (role: string, userId = USER_ID, organizationId = ORGANIZATION_ID) => [
+  { organizationId, role, userId },
+];
+
 describe("organization membership projection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -55,7 +60,7 @@ describe("organization membership projection", () => {
   test.each(["owner", "manager", "member", "billing"] as const)(
     "atomically touches the %s relationship and deletes the other organization roles",
     async (role) => {
-      vi.mocked(prisma.membership.findUnique).mockResolvedValue({ role } as never);
+      vi.mocked(prisma.membership.findMany).mockResolvedValue(membershipRows(role) as never);
 
       await expect(reconcileOrganizationMembership(ORGANIZATION_ID, USER_ID)).resolves.toEqual({
         passes: 1,
@@ -77,33 +82,32 @@ describe("organization membership projection", () => {
         true
       );
       expect(updates.every(({ relationship }) => relationship.subject.objectId === USER_ID)).toBe(true);
-      expect(prisma.membership.findUnique).toHaveBeenCalledWith({
-        select: { role: true },
+      expect(prisma.membership.findMany).toHaveBeenCalledWith({
+        orderBy: [{ organizationId: "asc" }, { userId: "asc" }],
+        select: { organizationId: true, role: true, userId: true },
         where: {
-          userId_organizationId: {
-            organizationId: ORGANIZATION_ID,
-            userId: USER_ID,
-          },
+          OR: [{ organizationId: ORGANIZATION_ID, userId: USER_ID }],
         },
       });
     }
   );
 
   test("projects accepted and pending Membership rows identically by reading only their role", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue({ role: "member" } as never);
+    vi.mocked(prisma.membership.findMany).mockResolvedValue(membershipRows("member") as never);
 
     await reconcileOrganizationMembership(ORGANIZATION_ID, USER_ID);
 
-    expect(prisma.membership.findUnique).toHaveBeenCalledWith(
+    // Reading only the role is what makes accepted and pending rows project identically.
+    expect(prisma.membership.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        select: { role: true },
+        select: { organizationId: true, role: true, userId: true },
       })
     );
     expect(clientMocks.writeRelationships).toHaveBeenCalledTimes(1);
   });
 
   test("deletes every organization role when the source membership no longer exists", async () => {
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.membership.findMany).mockResolvedValue([] as never);
 
     await expect(reconcileOrganizationMembership(ORGANIZATION_ID, USER_ID)).resolves.toEqual({
       passes: 1,
@@ -123,11 +127,11 @@ describe("organization membership projection", () => {
   });
 
   test("reconciles again when the source role changes during projection", async () => {
-    vi.mocked(prisma.membership.findUnique)
-      .mockResolvedValueOnce({ role: "owner" } as never)
-      .mockResolvedValueOnce({ role: "manager" } as never)
-      .mockResolvedValueOnce({ role: "manager" } as never)
-      .mockResolvedValueOnce({ role: "manager" } as never);
+    vi.mocked(prisma.membership.findMany)
+      .mockResolvedValueOnce(membershipRows("owner") as never)
+      .mockResolvedValueOnce(membershipRows("manager") as never)
+      .mockResolvedValueOnce(membershipRows("manager") as never)
+      .mockResolvedValueOnce(membershipRows("manager") as never);
 
     await expect(reconcileOrganizationMembership(ORGANIZATION_ID, USER_ID)).resolves.toEqual({
       passes: 2,
@@ -146,13 +150,13 @@ describe("organization membership projection", () => {
   });
 
   test("returns a stable internal failure after three concurrently changing passes", async () => {
-    vi.mocked(prisma.membership.findUnique)
-      .mockResolvedValueOnce({ role: "owner" } as never)
-      .mockResolvedValueOnce({ role: "manager" } as never)
-      .mockResolvedValueOnce({ role: "owner" } as never)
-      .mockResolvedValueOnce({ role: "manager" } as never)
-      .mockResolvedValueOnce({ role: "owner" } as never)
-      .mockResolvedValueOnce({ role: "manager" } as never);
+    vi.mocked(prisma.membership.findMany)
+      .mockResolvedValueOnce(membershipRows("owner") as never)
+      .mockResolvedValueOnce(membershipRows("manager") as never)
+      .mockResolvedValueOnce(membershipRows("owner") as never)
+      .mockResolvedValueOnce(membershipRows("manager") as never)
+      .mockResolvedValueOnce(membershipRows("owner") as never)
+      .mockResolvedValueOnce(membershipRows("manager") as never);
 
     await expect(reconcileOrganizationMembership(ORGANIZATION_ID, USER_ID)).resolves.toEqual({
       attempts: 3,
@@ -170,13 +174,13 @@ describe("organization membership projection", () => {
       status: "disabled",
     });
 
-    expect(prisma.membership.findUnique).not.toHaveBeenCalled();
+    expect(prisma.membership.findMany).not.toHaveBeenCalled();
     expect(getAuthzedClient).not.toHaveBeenCalled();
   });
 
   test("contains operational failures at the projection boundary with sanitized logs", async () => {
     const privateCause = new Error("raw-sdk-message-with-private-token");
-    vi.mocked(prisma.membership.findUnique).mockResolvedValue({ role: "owner" } as never);
+    vi.mocked(prisma.membership.findMany).mockResolvedValue(membershipRows("owner") as never);
     clientMocks.writeRelationships.mockRejectedValue(
       new AuthzedError({
         attempts: 3,
@@ -201,6 +205,101 @@ describe("organization membership projection", () => {
     expect(serializedLog).not.toContain("private-token");
     expect(serializedLog).not.toContain("raw-sdk-message");
     expect(serializedLog).toContain(AUTHZED_ERROR_CODES.UNAVAILABLE);
+  });
+
+  describe("batched reconciliation", () => {
+    test("reads every named membership in one query and writes one group per target", async () => {
+      vi.mocked(prisma.membership.findMany).mockResolvedValue([
+        { organizationId: "org-1", role: "owner", userId: "user-1" },
+        { organizationId: "org-2", role: "billing", userId: "user-2" },
+      ] as never);
+
+      await expect(
+        reconcileOrganizationMemberships({
+          memberships: [
+            { organizationId: "org-1", userId: "user-1" },
+            { organizationId: "org-2", userId: "user-2" },
+          ],
+        })
+      ).resolves.toEqual({ passes: 1, status: "projected" });
+
+      // One read and one write for two memberships, rather than two of each.
+      expect(prisma.membership.findMany).toHaveBeenCalledTimes(2); // source + verify
+      expect(clientMocks.writeRelationships).toHaveBeenCalledTimes(1);
+      expect(clientMocks.writeRelationships.mock.calls[0][0]).toHaveLength(8);
+    });
+
+    test("deletes every role for a target with no source row while preserving other targets", async () => {
+      vi.mocked(prisma.membership.findMany).mockResolvedValue([
+        { organizationId: "org-1", role: "manager", userId: "user-1" },
+      ] as never);
+
+      await reconcileOrganizationMemberships({
+        memberships: [
+          { organizationId: "org-1", userId: "user-1" },
+          // Observed in SpiceDB but absent from PostgreSQL — the repair path.
+          { organizationId: "org-1", userId: "ghost-user" },
+        ],
+      });
+
+      const updates = clientMocks.writeRelationships.mock.calls[0][0];
+      const ghostUpdates = updates.filter(
+        ({ relationship }) => relationship.subject.objectId === "ghost-user"
+      );
+      expect(ghostUpdates).toHaveLength(4);
+      expect(ghostUpdates.every(({ operation }) => operation === "delete")).toBe(true);
+      expect(
+        updates.filter(
+          ({ operation, relationship }) => operation === "touch" && relationship.subject.objectId === "user-1"
+        )
+      ).toHaveLength(1);
+    });
+
+    test("deduplicates repeated targets so a membership is written once", async () => {
+      vi.mocked(prisma.membership.findMany).mockResolvedValue(membershipRows("owner") as never);
+
+      await reconcileOrganizationMemberships({
+        memberships: [
+          { organizationId: ORGANIZATION_ID, userId: USER_ID },
+          { organizationId: ORGANIZATION_ID, userId: USER_ID },
+        ],
+      });
+
+      expect(clientMocks.writeRelationships.mock.calls[0][0]).toHaveLength(4);
+    });
+
+    test.each([[undefined], [[]]])(
+      "short-circuits an empty target set without constructing a client (%s)",
+      async (memberships) => {
+        await expect(reconcileOrganizationMemberships({ memberships })).resolves.toEqual({
+          passes: 0,
+          status: "projected",
+        });
+
+        // `writeRelationships` rejects an empty batch, so reaching the client at all would fail.
+        expect(getAuthzedClient).not.toHaveBeenCalled();
+        expect(prisma.membership.findMany).not.toHaveBeenCalled();
+      }
+    );
+
+    test("splits a target set that exceeds the write batch limit without splitting a role group", async () => {
+      const memberships = Array.from({ length: 251 }, (_unused, index) => ({
+        organizationId: ORGANIZATION_ID,
+        userId: `user-${index}`,
+      }));
+      vi.mocked(prisma.membership.findMany).mockResolvedValue([] as never);
+
+      await expect(reconcileOrganizationMemberships({ memberships })).resolves.toEqual({
+        passes: 1,
+        status: "projected",
+      });
+
+      // 251 targets * 4 relations = 1004 updates, so it must split, and the four updates for a single
+      // membership must stay in one request or the role would not change atomically.
+      expect(clientMocks.writeRelationships).toHaveBeenCalledTimes(2);
+      expect(clientMocks.writeRelationships.mock.calls[0][0]).toHaveLength(1_000);
+      expect(clientMocks.writeRelationships.mock.calls[1][0]).toHaveLength(4);
+    });
   });
 
   test("deletes all organization-resource relationships after an organization cascade", async () => {

--- a/apps/web/lib/authzed/organization-membership.ts
+++ b/apps/web/lib/authzed/organization-membership.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
-import { OrganizationRole } from "@formbricks/database/prisma";
+import type { OrganizationRole } from "@formbricks/database/prisma";
 import { getAuthzedClient } from "./client";
 import {
   AUTHZED_MAX_RECONCILIATION_PASSES,
@@ -8,15 +8,9 @@ import {
   type TAuthzedProjectionResult,
   runBestEffortProjection,
 } from "./projection";
+import { ORGANIZATION_RELATIONS } from "./relationship-map";
 
 export type { TAuthzedProjectionResult } from "./projection";
-
-const ORGANIZATION_RELATIONS = {
-  [OrganizationRole.billing]: "billing",
-  [OrganizationRole.manager]: "manager",
-  [OrganizationRole.member]: "member",
-  [OrganizationRole.owner]: "owner",
-} as const satisfies Record<OrganizationRole, string>;
 
 const ORGANIZATION_RELATION_NAMES = Object.values(ORGANIZATION_RELATIONS);
 type TOrganizationMembershipState = OrganizationRole | null;

--- a/apps/web/lib/authzed/organization-membership.ts
+++ b/apps/web/lib/authzed/organization-membership.ts
@@ -1,77 +1,145 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
 import type { OrganizationRole } from "@formbricks/database/prisma";
-import { getAuthzedClient } from "./client";
+import { type TAuthzedClient, type TAuthzedRelationshipUpdate, getAuthzedClient } from "./client";
 import {
   AUTHZED_MAX_RECONCILIATION_PASSES,
   AuthzedProjectionUnstableError,
   type TAuthzedProjectionResult,
   runBestEffortProjection,
 } from "./projection";
+import { packRelationshipUpdateGroups } from "./relationship-batches";
 import { ORGANIZATION_RELATIONS } from "./relationship-map";
 
 export type { TAuthzedProjectionResult } from "./projection";
 
 const ORGANIZATION_RELATION_NAMES = Object.values(ORGANIZATION_RELATIONS);
-type TOrganizationMembershipState = OrganizationRole | null;
 
-const getOrganizationMembershipState = async (
-  organizationId: string,
-  userId: string
-): Promise<TOrganizationMembershipState> => {
-  const membership = await prisma.membership.findUnique({
-    where: {
-      userId_organizationId: {
-        organizationId,
-        userId,
-      },
-    },
-    select: {
-      role: true,
-    },
-  });
+export type TOrganizationMembershipProjectionTarget = Readonly<{
+  organizationId: string;
+  userId: string;
+}>;
 
-  // The legacy evaluator does not gate organization membership on `accepted`. Project every row so
-  // the initial SpiceDB shadow model preserves the current authorization behavior exactly.
-  return membership?.role ?? null;
+export type TOrganizationMembershipProjectionTargets = Readonly<{
+  memberships?: ReadonlyArray<TOrganizationMembershipProjectionTarget>;
+}>;
+
+type TOrganizationMembershipSnapshot = ReadonlyArray<
+  Readonly<{ organizationId: string; role: OrganizationRole; userId: string }>
+>;
+
+/** Length-prefixed so `("ab", "c")` and `("a", "bc")` cannot collide. */
+const pairKey = (first: string, second: string): string => `${first.length}:${first}${second}`;
+
+const normalizeTargets = (
+  targets: TOrganizationMembershipProjectionTargets
+): ReadonlyArray<TOrganizationMembershipProjectionTarget> => {
+  const uniqueTargets = new Map<string, TOrganizationMembershipProjectionTarget>();
+
+  for (const target of targets.memberships ?? []) {
+    uniqueTargets.set(pairKey(target.organizationId, target.userId), target);
+  }
+
+  // Deterministic ordering is what makes the snapshot comparison below a plain string equality.
+  return [...uniqueTargets.values()].sort((left, right) =>
+    pairKey(left.organizationId, left.userId).localeCompare(pairKey(right.organizationId, right.userId))
+  );
 };
 
-export const reconcileOrganizationMembership = async (
-  organizationId: string,
-  userId: string
+const readSnapshot = async (
+  targets: ReadonlyArray<TOrganizationMembershipProjectionTarget>
+): Promise<TOrganizationMembershipSnapshot> =>
+  prisma.membership.findMany({
+    where: {
+      OR: targets.map(({ organizationId, userId }) => ({ organizationId, userId })),
+    },
+    // The legacy evaluator does not gate organization membership on `accepted`. Project every row so
+    // the initial SpiceDB shadow model preserves the current authorization behavior exactly.
+    select: { organizationId: true, role: true, userId: true },
+    orderBy: [{ organizationId: "asc" }, { userId: "asc" }],
+  });
+
+const snapshotsMatch = (
+  left: TOrganizationMembershipSnapshot,
+  right: TOrganizationMembershipSnapshot
+): boolean => JSON.stringify(left) === JSON.stringify(right);
+
+const createMembershipUpdates = (
+  target: TOrganizationMembershipProjectionTarget,
+  role: OrganizationRole | null
+): ReadonlyArray<TAuthzedRelationshipUpdate> =>
+  ORGANIZATION_RELATION_NAMES.map((relation) => ({
+    operation: role !== null && relation === ORGANIZATION_RELATIONS[role] ? "touch" : "delete",
+    relationship: {
+      relation,
+      resource: { objectId: target.organizationId, objectType: "organization" },
+      subject: { objectId: target.userId, objectType: "user" },
+    },
+  }));
+
+const writeSnapshot = async (
+  client: TAuthzedClient,
+  targets: ReadonlyArray<TOrganizationMembershipProjectionTarget>,
+  snapshot: TOrganizationMembershipSnapshot
+): Promise<void> => {
+  const rolesByPair = new Map(
+    snapshot.map((membership) => [pairKey(membership.organizationId, membership.userId), membership.role])
+  );
+
+  // A target with no row yields four deletes, so a membership removed outside a mutation hook — or
+  // one that only ever existed in SpiceDB — is healed by being named here.
+  const updateGroups = targets.map((target) => [
+    ...createMembershipUpdates(
+      target,
+      rolesByPair.get(pairKey(target.organizationId, target.userId)) ?? null
+    ),
+  ]);
+
+  for (const batch of packRelationshipUpdateGroups(updateGroups)) {
+    await client.writeRelationships(batch);
+  }
+};
+
+/**
+ * Reconcile every named organization membership.
+ *
+ * Targets are explicit `(organizationId, userId)` pairs rather than a list of organizations to expand.
+ * That is deliberate: expanding an organization into its current PostgreSQL memberships could only
+ * ever produce targets that still exist, so a relationship present in SpiceDB with no source row
+ * would never be named and never be removed. Naming pairs lets a caller feed in what it observed in
+ * SpiceDB as well as what PostgreSQL holds, which is what makes stale-relationship repair possible.
+ */
+export const reconcileOrganizationMemberships = async (
+  targets: TOrganizationMembershipProjectionTargets
 ): Promise<TAuthzedProjectionResult> =>
-  runBestEffortProjection("reconcile_organization_membership", "organization_membership", async () => {
+  runBestEffortProjection("reconcile_organization_memberships", "organization_membership", async () => {
+    const normalizedTargets = normalizeTargets(targets);
+    // `writeRelationships` rejects an empty batch, so an empty target set must short-circuit before
+    // the client is even constructed.
+    if (normalizedTargets.length === 0) {
+      return 0;
+    }
+
     const client = getAuthzedClient();
-
     for (let pass = 1; pass <= AUTHZED_MAX_RECONCILIATION_PASSES; pass++) {
-      const sourceRole = await getOrganizationMembershipState(organizationId, userId);
+      const sourceSnapshot = await readSnapshot(normalizedTargets);
+      await writeSnapshot(client, normalizedTargets, sourceSnapshot);
 
-      await client.writeRelationships(
-        ORGANIZATION_RELATION_NAMES.map((relation) => ({
-          operation:
-            sourceRole !== null && relation === ORGANIZATION_RELATIONS[sourceRole] ? "touch" : "delete",
-          relationship: {
-            relation,
-            resource: {
-              objectId: organizationId,
-              objectType: "organization",
-            },
-            subject: {
-              objectId: userId,
-              objectType: "user",
-            },
-          },
-        }))
-      );
-
-      const verifiedRole = await getOrganizationMembershipState(organizationId, userId);
-      if (verifiedRole === sourceRole) {
+      const verifiedSnapshot = await readSnapshot(normalizedTargets);
+      if (snapshotsMatch(sourceSnapshot, verifiedSnapshot)) {
         return pass;
       }
     }
 
     throw new AuthzedProjectionUnstableError();
   });
+
+/** Reconcile a single membership. Retained for the mutation-hook call sites. */
+export const reconcileOrganizationMembership = async (
+  organizationId: string,
+  userId: string
+): Promise<TAuthzedProjectionResult> =>
+  reconcileOrganizationMemberships({ memberships: [{ organizationId, userId }] });
 
 export const deleteOrganizationRelationships = async (
   organizationId: string

--- a/apps/web/lib/authzed/projection-boundary.ts
+++ b/apps/web/lib/authzed/projection-boundary.ts
@@ -11,10 +11,16 @@ export const runPostCommitProjection = async (
   } catch (error) {
     logger.error(
       {
-        code: "authzed_internal",
         component: "authzed",
+        // `errorCode`, matching every other AuthZed failure log. This previously used `code`, so a
+        // single query could not cover both this path and the projection failures below it — and this
+        // is the path that fires when a projector itself has a bug, which is the one you least want to
+        // miss.
+        errorCode: "authzed_internal",
         errorName: error instanceof Error ? error.name : "NonError",
         operation,
+        retryable: false,
+        status: "failed",
       },
       "Unexpected AuthZed projection failure after source commit"
     );

--- a/apps/web/lib/authzed/projection.ts
+++ b/apps/web/lib/authzed/projection.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { logger } from "@formbricks/logger";
 import { isAuthzedEnabled } from "./config";
 import { AuthzedError, type TAuthzedErrorCode, mapAuthzedError } from "./errors";
+import { recordAuthzedProjection } from "./metrics";
 
 export const AUTHZED_MAX_RECONCILIATION_PASSES = 3;
 
@@ -45,6 +46,9 @@ export const runBestEffortProjection = async (
   projection: () => Promise<number>
 ): Promise<TAuthzedProjectionResult> => {
   if (!isAuthzedEnabled()) {
+    // Recorded rather than skipped: a deployment that believes AuthZed is on while it is off looks
+    // identical to a healthy one from every other signal.
+    recordAuthzedProjection({ durationMs: 0, operation, projection: projectionName, status: "disabled" });
     return { status: "disabled" };
   }
 
@@ -65,6 +69,7 @@ export const runBestEffortProjection = async (
       },
       "AuthZed relationship projection completed"
     );
+    recordAuthzedProjection({ durationMs, operation, projection: projectionName, status: "projected" });
 
     return { passes, status: "projected" };
   } catch (error) {
@@ -86,9 +91,11 @@ export const runBestEffortProjection = async (
         operation,
         projection: projectionName,
         retryable: result.retryable,
+        status: result.status,
       },
       "AuthZed relationship projection failed"
     );
+    recordAuthzedProjection({ durationMs, operation, projection: projectionName, status: "failed" });
 
     return result;
   }

--- a/apps/web/lib/authzed/relationship-map.test.ts
+++ b/apps/web/lib/authzed/relationship-map.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "vitest";
+import {
+  ApiKeyPermission,
+  OrganizationRole,
+  TeamUserRole,
+  WorkspaceTeamPermission,
+} from "@formbricks/database/prisma";
+import {
+  ORGANIZATION_ACCESS_RELATIONS,
+  ORGANIZATION_RELATIONS,
+  TEAM_RELATIONS,
+  WORKSPACE_API_KEY_RELATIONS,
+  WORKSPACE_TEAM_RELATIONS,
+  normalizeOrganizationAccess,
+} from "./relationship-map";
+
+/**
+ * These assertions pin relation names against the deployed `authzed/schema.zed`.
+ *
+ * Renaming a relation on one side only is the failure this file exists to catch: reconciling tooling
+ * derives the expected relationship set from these maps, so a mismatch makes it read correct
+ * relationships as orphaned and, when pruning, delete real access. A change here is a schema change
+ * and must be paired with one.
+ */
+describe("relation name mappings", () => {
+  test("maps every organization role to its schema relation", () => {
+    expect(ORGANIZATION_RELATIONS).toEqual({
+      [OrganizationRole.billing]: "billing",
+      [OrganizationRole.manager]: "manager",
+      [OrganizationRole.member]: "member",
+      [OrganizationRole.owner]: "owner",
+    });
+  });
+
+  test("maps every team role to its schema relation", () => {
+    expect(TEAM_RELATIONS).toEqual({
+      [TeamUserRole.admin]: "admin",
+      [TeamUserRole.contributor]: "contributor",
+    });
+  });
+
+  test("maps every workspace-team permission to its team-suffixed schema relation", () => {
+    expect(WORKSPACE_TEAM_RELATIONS).toEqual({
+      [WorkspaceTeamPermission.manage]: "manager_team",
+      [WorkspaceTeamPermission.read]: "reader_team",
+      [WorkspaceTeamPermission.readWrite]: "writer_team",
+    });
+  });
+
+  test("maps every API-key permission to its bare workspace schema relation", () => {
+    // Deliberately unsuffixed, unlike the team grants above: the schema distinguishes an API-key
+    // subject from a team subject by relation name.
+    expect(WORKSPACE_API_KEY_RELATIONS).toEqual({
+      [ApiKeyPermission.manage]: "manager",
+      [ApiKeyPermission.read]: "reader",
+      [ApiKeyPermission.write]: "writer",
+    });
+  });
+
+  test("maps organization access flags to their api-key-subject schema relations", () => {
+    expect(ORGANIZATION_ACCESS_RELATIONS).toEqual({
+      read: "api_key_reader",
+      write: "api_key_writer",
+    });
+  });
+
+  test.each([
+    ["every Prisma organization role", Object.keys(OrganizationRole), ORGANIZATION_RELATIONS],
+    ["every Prisma team role", Object.keys(TeamUserRole), TEAM_RELATIONS],
+    [
+      "every Prisma workspace-team permission",
+      Object.keys(WorkspaceTeamPermission),
+      WORKSPACE_TEAM_RELATIONS,
+    ],
+    ["every Prisma API-key permission", Object.keys(ApiKeyPermission), WORKSPACE_API_KEY_RELATIONS],
+  ])("covers %s with a distinct relation", (_label, sourceValues, relations) => {
+    expect(Object.keys(relations).sort()).toEqual([...sourceValues].sort());
+    // Two source values sharing a relation would make the projectors' touch-one/delete-the-alternates
+    // logic delete the relation it just wrote.
+    expect(new Set(Object.values(relations)).size).toBe(sourceValues.length);
+  });
+});
+
+describe("normalizeOrganizationAccess", () => {
+  test("reads both flags independently", () => {
+    expect(normalizeOrganizationAccess({ accessControl: { read: true, write: true } })).toEqual({
+      read: true,
+      write: true,
+    });
+    expect(normalizeOrganizationAccess({ accessControl: { read: true, write: false } })).toEqual({
+      read: true,
+      write: false,
+    });
+  });
+
+  test.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["a string", "read"],
+    ["an array", []],
+    ["an empty object", {}],
+    ["a non-object accessControl", { accessControl: "read" }],
+    ["a null accessControl", { accessControl: null }],
+    ["an accessControl array", { accessControl: [] }],
+  ])("denies both flags for %s", (_label, value) => {
+    expect(normalizeOrganizationAccess(value)).toEqual({ read: false, write: false });
+  });
+
+  test.each([
+    ["a truthy string", "true"],
+    ["the number one", 1],
+    ["a truthy object", {}],
+  ])("denies %s rather than coercing it to a grant", (_label, flagValue) => {
+    expect(normalizeOrganizationAccess({ accessControl: { read: flagValue, write: flagValue } })).toEqual({
+      read: false,
+      write: false,
+    });
+  });
+});

--- a/apps/web/lib/authzed/relationship-map.ts
+++ b/apps/web/lib/authzed/relationship-map.ts
@@ -1,0 +1,92 @@
+import "server-only";
+import {
+  ApiKeyPermission,
+  OrganizationRole,
+  TeamUserRole,
+  WorkspaceTeamPermission,
+} from "@formbricks/database/prisma";
+
+/**
+ * The single source of truth mapping PostgreSQL source values to SpiceDB relation names.
+ *
+ * These live here rather than privately inside each projector because reconciling tooling has to
+ * derive the *expected* relationship set from the same mapping the projectors write. Two copies would
+ * mean a renamed relation makes reconciliation classify a correct relationship as orphaned and, when
+ * pruning, delete it — so the `owner` mapping in particular must exist exactly once.
+ *
+ * Every map is `satisfies Record<PrismaEnum, string>` so adding a value to a Prisma enum is a
+ * compile error until it is mapped, rather than a silently unprojected role.
+ *
+ * Deliberately excluded: the relationship *builders*. Those encode each projector's
+ * touch-the-current-value / delete-the-alternates semantics, which the expected-set derivation does
+ * not want.
+ */
+
+/** `Membership.role` → `organization#<relation>@user`. Exactly one applies to a given membership. */
+export const ORGANIZATION_RELATIONS = {
+  [OrganizationRole.billing]: "billing",
+  [OrganizationRole.manager]: "manager",
+  [OrganizationRole.member]: "member",
+  [OrganizationRole.owner]: "owner",
+} as const satisfies Record<OrganizationRole, string>;
+
+/** `TeamUser.role` → `team#<relation>@user`. */
+export const TEAM_RELATIONS = {
+  [TeamUserRole.admin]: "admin",
+  [TeamUserRole.contributor]: "contributor",
+} as const satisfies Record<TeamUserRole, string>;
+
+/** `WorkspaceTeam.permission` → `workspace#<relation>@team#member`. */
+export const WORKSPACE_TEAM_RELATIONS = {
+  [WorkspaceTeamPermission.manage]: "manager_team",
+  [WorkspaceTeamPermission.read]: "reader_team",
+  [WorkspaceTeamPermission.readWrite]: "writer_team",
+} as const satisfies Record<WorkspaceTeamPermission, string>;
+
+/** `ApiKeyWorkspace.permission` → `workspace#<relation>@api_key`. */
+export const WORKSPACE_API_KEY_RELATIONS = {
+  [ApiKeyPermission.manage]: "manager",
+  [ApiKeyPermission.read]: "reader",
+  [ApiKeyPermission.write]: "writer",
+} as const satisfies Record<ApiKeyPermission, string>;
+
+/**
+ * An API key's organization-level access rights.
+ *
+ * Unlike the role ladders these two flags are independent: a key may hold both, either, or neither.
+ */
+export type TOrganizationAccessSnapshot = Readonly<{
+  read: boolean;
+  write: boolean;
+}>;
+
+/**
+ * `ApiKey.organizationAccess.accessControl.{read,write}` → `organization#<relation>@api_key`.
+ *
+ * Note the inverted direction relative to the workspace relations: the organization is the resource
+ * and the API key is the subject.
+ */
+export const ORGANIZATION_ACCESS_RELATIONS = {
+  read: "api_key_reader",
+  write: "api_key_writer",
+} as const satisfies Record<keyof TOrganizationAccessSnapshot, string>;
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Read an API key's organization access out of its untyped JSON column.
+ *
+ * Strictly `=== true`, so a missing, malformed, or non-boolean value denies — matching the current
+ * evaluator rather than guessing at intent.
+ */
+export const normalizeOrganizationAccess = (value: unknown): TOrganizationAccessSnapshot => {
+  if (!isRecord(value) || !isRecord(value.accessControl)) {
+    return { read: false, write: false };
+  }
+
+  return {
+    read: value.accessControl.read === true,
+    write: value.accessControl.write === true,
+  };
+};

--- a/apps/web/lib/authzed/relationship-reads.test.ts
+++ b/apps/web/lib/authzed/relationship-reads.test.ts
@@ -47,7 +47,7 @@ describe("readAllRelationships", () => {
     });
   });
 
-  test("pins every later page to the first page's revision and threads the cursor", async () => {
+  test("threads the cursor and varies nothing else between pages", async () => {
     readRelationships.mockResolvedValueOnce(fullPage("first", "cursor-1")).mockResolvedValueOnce({
       cursor: null,
       relationships: [relationship("last")],
@@ -59,15 +59,29 @@ describe("readAllRelationships", () => {
     expect(observation.relationships).toHaveLength(AUTHZED_MAX_RELATIONSHIP_READS + 1);
     expect(observation.snapshot).toEqual({ token: "revision-1" });
 
-    // Page 1 resolves the revision; page 2 must not resolve its own, or a concurrent write could
-    // hide a relationship from both pages and the caller would read it as absent.
-    expect(readRelationships.mock.calls[0][0]).not.toHaveProperty("atSnapshot");
+    // SpiceDB rejects a cursor presented alongside any other changed argument, so the second request
+    // must differ from the first by the cursor alone.
+    expect(readRelationships.mock.calls[0][0]).toEqual({
+      filter,
+      limit: AUTHZED_MAX_RELATIONSHIP_READS,
+    });
     expect(readRelationships.mock.calls[1][0]).toEqual({
-      atSnapshot: { token: "revision-1" },
       cursor: { token: "cursor-1" },
       filter,
       limit: AUTHZED_MAX_RELATIONSHIP_READS,
     });
+  });
+
+  test("abandons the read when a later page reports a different revision", async () => {
+    // The cursor is supposed to hold the revision steady. If it ever did not, the pages would describe
+    // different views and a pruning caller could delete a relationship that merely moved between them.
+    readRelationships.mockResolvedValueOnce(fullPage("first", "cursor-1")).mockResolvedValueOnce({
+      cursor: null,
+      relationships: [relationship("last")],
+      snapshot: { token: "revision-2" },
+    });
+
+    await expect(readAllRelationships(client, filter)).rejects.toThrow(AUTHZED_ERROR_CODES.ABORTED);
   });
 
   test("stops on a full page that offers no cursor", async () => {
@@ -99,9 +113,9 @@ describe("readAllRelationships", () => {
     expect(readRelationships).toHaveBeenCalledTimes(pagesToExceed + 1);
   });
 
-  test("propagates a mid-drain snapshot expiry instead of reporting what it read so far", async () => {
-    // SpiceDB rejects `atExactSnapshot` once the revision leaves the GC window. Returning the pages
-    // already read would tell a pruning caller that the unread relationships do not exist.
+  test("propagates a mid-drain failure instead of reporting what it read so far", async () => {
+    // Returning the pages already read would tell a pruning caller that the unread relationships do
+    // not exist.
     readRelationships.mockResolvedValueOnce(fullPage("first", "cursor-1")).mockRejectedValueOnce(
       new AuthzedError({
         attempts: 1,

--- a/apps/web/lib/authzed/relationship-reads.test.ts
+++ b/apps/web/lib/authzed/relationship-reads.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { TAuthzedRelationship, TAuthzedRelationshipPage } from "./client";
 import { AUTHZED_MAX_OBSERVED_RELATIONSHIPS_PER_UNIT, AUTHZED_MAX_RELATIONSHIP_READS } from "./constants";
 import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
-import { readAllRelationships } from "./relationship-reads";
+import { forEachRelationshipPage, readAllRelationships } from "./relationship-reads";
 
 const relationship = (objectId: string): TAuthzedRelationship => ({
   relation: "owner",
@@ -159,5 +159,55 @@ describe("readAllRelationships", () => {
     for (const call of readRelationships.mock.calls) {
       expect(call[0].filter).toBe(narrowed);
     }
+  });
+});
+
+describe("forEachRelationshipPage", () => {
+  test("streams every page without accumulating them", async () => {
+    readRelationships.mockResolvedValueOnce(fullPage("first", "cursor-1")).mockResolvedValueOnce({
+      cursor: null,
+      relationships: [relationship("last")],
+      snapshot: { token: "revision-1" },
+    });
+    const pageSizes: number[] = [];
+
+    const snapshot = await forEachRelationshipPage(client, filter, async (relationships) => {
+      pageSizes.push(relationships.length);
+    });
+
+    expect(pageSizes).toEqual([AUTHZED_MAX_RELATIONSHIP_READS, 1]);
+    expect(snapshot).toEqual({ token: "revision-1" });
+  });
+
+  test("aborts on a cursor that does not advance rather than spinning forever", async () => {
+    // Termination depends on the server returning a cursor that moves. A command that hangs with no
+    // output and no exit code is worse for an operator than one that fails loudly.
+    readRelationships.mockResolvedValue(fullPage("stuck", "same-cursor"));
+
+    await expect(forEachRelationshipPage(client, filter, async () => {})).rejects.toThrow(
+      AUTHZED_ERROR_CODES.INTERNAL
+    );
+  });
+
+  test("propagates a callback failure so a partial stream cannot look complete", async () => {
+    readRelationships.mockResolvedValueOnce(fullPage("first", "cursor-1"));
+
+    await expect(
+      forEachRelationshipPage(client, filter, async () => {
+        throw new Error("classification failed");
+      })
+    ).rejects.toThrow("classification failed");
+  });
+
+  test("aborts when a later page reports a different revision", async () => {
+    readRelationships.mockResolvedValueOnce(fullPage("first", "cursor-1")).mockResolvedValueOnce({
+      cursor: null,
+      relationships: [relationship("last")],
+      snapshot: { token: "revision-2" },
+    });
+
+    await expect(forEachRelationshipPage(client, filter, async () => {})).rejects.toThrow(
+      AUTHZED_ERROR_CODES.ABORTED
+    );
   });
 });

--- a/apps/web/lib/authzed/relationship-reads.test.ts
+++ b/apps/web/lib/authzed/relationship-reads.test.ts
@@ -107,7 +107,14 @@ describe("readAllRelationships", () => {
     const pagesToExceed = Math.ceil(
       AUTHZED_MAX_OBSERVED_RELATIONSHIPS_PER_UNIT / AUTHZED_MAX_RELATIONSHIP_READS
     );
-    readRelationships.mockImplementation(() => Promise.resolve(fullPage("page", "cursor-next")));
+    // A distinct cursor per page, because a real server advances it — and a fixture that repeats one
+    // cursor now trips the stall guard instead, which is a different failure than this test is about.
+    let page = 0;
+    readRelationships.mockImplementation(() => {
+      page += 1;
+
+      return Promise.resolve(fullPage(`page-${page}`, `cursor-${page}`));
+    });
 
     await expect(readAllRelationships(client, filter)).rejects.toThrow(AUTHZED_ERROR_CODES.LIMIT_EXCEEDED);
     expect(readRelationships).toHaveBeenCalledTimes(pagesToExceed + 1);
@@ -177,6 +184,19 @@ describe("forEachRelationshipPage", () => {
 
     expect(pageSizes).toEqual([AUTHZED_MAX_RELATIONSHIP_READS, 1]);
     expect(snapshot).toEqual({ token: "revision-1" });
+  });
+
+  test("aborts a bounded drain on a cursor that does not advance", async () => {
+    // The accumulation cap cannot stand in for this guard: a stalled cursor returning empty pages never
+    // grows the accumulator, so the loop would spin forever instead of tripping the bound.
+    const readRelationships = vi
+      .fn()
+      .mockResolvedValue({ cursor: { token: "stuck" }, relationships: [], snapshot: null });
+
+    await expect(readAllRelationships({ readRelationships }, { resourceType: "team" })).rejects.toThrow(
+      AUTHZED_ERROR_CODES.INTERNAL
+    );
+    expect(readRelationships).toHaveBeenCalledTimes(2);
   });
 
   test("aborts on a cursor that does not advance rather than spinning forever", async () => {

--- a/apps/web/lib/authzed/relationship-reads.test.ts
+++ b/apps/web/lib/authzed/relationship-reads.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { TAuthzedRelationship, TAuthzedRelationshipPage } from "./client";
+import { AUTHZED_MAX_OBSERVED_RELATIONSHIPS_PER_UNIT, AUTHZED_MAX_RELATIONSHIP_READS } from "./constants";
+import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
+import { readAllRelationships } from "./relationship-reads";
+
+const relationship = (objectId: string): TAuthzedRelationship => ({
+  relation: "owner",
+  resource: { objectId, objectType: "organization" },
+  subject: { objectId: "user-1", objectType: "user" },
+});
+
+/** A page of exactly `AUTHZED_MAX_RELATIONSHIP_READS` relationships, i.e. one that may have more behind it. */
+const fullPage = (prefix: string, cursor: string | null): TAuthzedRelationshipPage => ({
+  cursor: cursor ? { token: cursor } : null,
+  relationships: Array.from({ length: AUTHZED_MAX_RELATIONSHIP_READS }, (_unused, index) =>
+    relationship(`${prefix}-${index}`)
+  ),
+  snapshot: { token: "revision-1" },
+});
+
+const readRelationships = vi.fn();
+const client = { readRelationships };
+const filter = { resourceType: "organization" } as const;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("readAllRelationships", () => {
+  test("resolves the first page without a pinned revision and returns the one it was given", async () => {
+    readRelationships.mockResolvedValue({
+      cursor: null,
+      relationships: [relationship("org-1")],
+      snapshot: { token: "revision-1" },
+    });
+
+    await expect(readAllRelationships(client, filter)).resolves.toEqual({
+      relationships: [relationship("org-1")],
+      snapshot: { token: "revision-1" },
+    });
+
+    expect(readRelationships).toHaveBeenCalledTimes(1);
+    expect(readRelationships).toHaveBeenCalledWith({
+      filter,
+      limit: AUTHZED_MAX_RELATIONSHIP_READS,
+    });
+  });
+
+  test("pins every later page to the first page's revision and threads the cursor", async () => {
+    readRelationships.mockResolvedValueOnce(fullPage("first", "cursor-1")).mockResolvedValueOnce({
+      cursor: null,
+      relationships: [relationship("last")],
+      snapshot: { token: "revision-1" },
+    });
+
+    const observation = await readAllRelationships(client, filter);
+
+    expect(observation.relationships).toHaveLength(AUTHZED_MAX_RELATIONSHIP_READS + 1);
+    expect(observation.snapshot).toEqual({ token: "revision-1" });
+
+    // Page 1 resolves the revision; page 2 must not resolve its own, or a concurrent write could
+    // hide a relationship from both pages and the caller would read it as absent.
+    expect(readRelationships.mock.calls[0][0]).not.toHaveProperty("atSnapshot");
+    expect(readRelationships.mock.calls[1][0]).toEqual({
+      atSnapshot: { token: "revision-1" },
+      cursor: { token: "cursor-1" },
+      filter,
+      limit: AUTHZED_MAX_RELATIONSHIP_READS,
+    });
+  });
+
+  test("stops on a full page that offers no cursor", async () => {
+    readRelationships.mockResolvedValueOnce(fullPage("only", null));
+
+    await expect(readAllRelationships(client, filter)).resolves.toMatchObject({
+      snapshot: { token: "revision-1" },
+    });
+    expect(readRelationships).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns an empty observation with no revision when nothing matches", async () => {
+    readRelationships.mockResolvedValue({ cursor: null, relationships: [], snapshot: null });
+
+    await expect(readAllRelationships(client, filter)).resolves.toEqual({
+      relationships: [],
+      snapshot: null,
+    });
+  });
+
+  test("abandons the read rather than returning a partial observation past the memory bound", async () => {
+    // Every continued iteration consumes a full page, so the bound is also the loop bound.
+    const pagesToExceed = Math.ceil(
+      AUTHZED_MAX_OBSERVED_RELATIONSHIPS_PER_UNIT / AUTHZED_MAX_RELATIONSHIP_READS
+    );
+    readRelationships.mockImplementation(() => Promise.resolve(fullPage("page", "cursor-next")));
+
+    await expect(readAllRelationships(client, filter)).rejects.toThrow(AUTHZED_ERROR_CODES.LIMIT_EXCEEDED);
+    expect(readRelationships).toHaveBeenCalledTimes(pagesToExceed + 1);
+  });
+
+  test("propagates a mid-drain snapshot expiry instead of reporting what it read so far", async () => {
+    // SpiceDB rejects `atExactSnapshot` once the revision leaves the GC window. Returning the pages
+    // already read would tell a pruning caller that the unread relationships do not exist.
+    readRelationships.mockResolvedValueOnce(fullPage("first", "cursor-1")).mockRejectedValueOnce(
+      new AuthzedError({
+        attempts: 1,
+        code: AUTHZED_ERROR_CODES.FAILED_PRECONDITION,
+        operation: "read_relationships",
+        retryable: false,
+      })
+    );
+
+    await expect(readAllRelationships(client, filter)).rejects.toThrow(
+      AUTHZED_ERROR_CODES.FAILED_PRECONDITION
+    );
+  });
+
+  test("propagates a first-page failure", async () => {
+    readRelationships.mockRejectedValue(
+      new AuthzedError({
+        attempts: 3,
+        code: AUTHZED_ERROR_CODES.UNAVAILABLE,
+        operation: "read_relationships",
+        retryable: true,
+      })
+    );
+
+    await expect(readAllRelationships(client, filter)).rejects.toThrow(AUTHZED_ERROR_CODES.UNAVAILABLE);
+  });
+
+  test("passes a narrowed filter through unchanged on every page", async () => {
+    const narrowed = {
+      relation: "reader_team",
+      resourceId: "ws-1",
+      resourceType: "workspace",
+      subject: { objectId: "team-1", objectType: "team", relation: "member" },
+    } as const;
+    readRelationships
+      .mockResolvedValueOnce(fullPage("first", "cursor-1"))
+      .mockResolvedValueOnce({ cursor: null, relationships: [], snapshot: { token: "revision-1" } });
+
+    await readAllRelationships(client, narrowed);
+
+    for (const call of readRelationships.mock.calls) {
+      expect(call[0].filter).toBe(narrowed);
+    }
+  });
+});

--- a/apps/web/lib/authzed/relationship-reads.ts
+++ b/apps/web/lib/authzed/relationship-reads.ts
@@ -1,0 +1,87 @@
+import "server-only";
+import type {
+  TAuthzedClient,
+  TAuthzedReadCursor,
+  TAuthzedRelationship,
+  TAuthzedRelationshipReadFilter,
+  TAuthzedSnapshot,
+} from "./client";
+import { AUTHZED_MAX_OBSERVED_RELATIONSHIPS_PER_UNIT, AUTHZED_MAX_RELATIONSHIP_READS } from "./constants";
+import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
+
+/**
+ * Pagination over the facade's single-page relationship read, kept outside the frozen facade for the
+ * same reason relationship batching is: the facade stays a transport boundary and the looping,
+ * bounding, and revision-pinning policy lives here where it can evolve.
+ *
+ * Reads are for reconciling SpiceDB against PostgreSQL. They must never back a permission decision —
+ * see the note on `TAuthzedClient.readRelationships`.
+ */
+
+/**
+ * A complete observation of every relationship matching a filter, at one revision.
+ *
+ * There is deliberately no "partial" or "truncated" variant. A reconciler that mistook a partial
+ * observation for a complete one would conclude that the relationships it failed to read do not
+ * exist — and, when pruning, delete live access. So an incomplete drain is not representable here:
+ * `readAllRelationships` either returns every matching relationship or throws.
+ */
+export type TAuthzedRelationshipObservation = Readonly<{
+  relationships: ReadonlyArray<TAuthzedRelationship>;
+  /**
+   * The revision every page was read at, or `null` when nothing matched the filter (SpiceDB reports
+   * no revision for an empty result).
+   */
+  snapshot: TAuthzedSnapshot | null;
+}>;
+
+/**
+ * Read every relationship matching `filter`, at a single consistent revision.
+ *
+ * The first page resolves fully consistently and its revision pins every later page, so the result
+ * is one coherent view rather than a stitched-together sequence of independently-resolved pages.
+ *
+ * Throws rather than returning a partial result when:
+ *
+ * - the match exceeds `AUTHZED_MAX_OBSERVED_RELATIONSHIPS_PER_UNIT` (`authzed_limit_exceeded`), which
+ *   also bounds the loop, since every continued iteration must have consumed a full page;
+ * - the pinned revision ages out of the datastore's garbage-collection window mid-drain, which
+ *   SpiceDB reports as a snapshot-expired failure and the facade maps to a non-retryable error;
+ * - any page fails for the usual operational reasons.
+ *
+ * Callers are expected to treat a throw as "this unit could not be observed" and continue with other
+ * units, never as "this unit has no relationships".
+ */
+export const readAllRelationships = async (
+  client: Pick<TAuthzedClient, "readRelationships">,
+  filter: TAuthzedRelationshipReadFilter
+): Promise<TAuthzedRelationshipObservation> => {
+  const relationships: TAuthzedRelationship[] = [];
+  let snapshot: TAuthzedSnapshot | null = null;
+  let cursor: TAuthzedReadCursor | undefined;
+
+  do {
+    const page = await client.readRelationships({
+      // Absent on the first call so SpiceDB resolves the latest revision and hands it back.
+      ...(snapshot ? { atSnapshot: snapshot } : {}),
+      ...(cursor ? { cursor } : {}),
+      filter,
+      limit: AUTHZED_MAX_RELATIONSHIP_READS,
+    });
+
+    if (relationships.length + page.relationships.length > AUTHZED_MAX_OBSERVED_RELATIONSHIPS_PER_UNIT) {
+      throw new AuthzedError({
+        attempts: 0,
+        code: AUTHZED_ERROR_CODES.LIMIT_EXCEEDED,
+        operation: "read_all_relationships",
+        retryable: false,
+      });
+    }
+
+    relationships.push(...page.relationships);
+    snapshot = page.snapshot;
+    cursor = page.cursor ?? undefined;
+  } while (cursor);
+
+  return { relationships, snapshot };
+};

--- a/apps/web/lib/authzed/relationship-reads.ts
+++ b/apps/web/lib/authzed/relationship-reads.ts
@@ -19,6 +19,50 @@ import { AUTHZED_ERROR_CODES, AuthzedError } from "./errors";
  */
 
 /**
+ * Assert the cursor advanced.
+ *
+ * Termination is not ours to guarantee — it depends on the server — so assert it rather than assume it.
+ * A command that hangs with no output and no exit code is the worst thing to hand an operator, and the
+ * accumulation bound in `readAllRelationships` cannot stand in for this: a stalled cursor returning
+ * empty pages never grows the accumulator, so that loop would spin forever rather than trip its cap.
+ */
+const assertCursorAdvanced = (
+  previous: TAuthzedReadCursor | undefined,
+  next: TAuthzedReadCursor | null,
+  operation: string
+): void => {
+  if (previous !== undefined && next?.token === previous.token) {
+    throw new AuthzedError({
+      attempts: 0,
+      code: AUTHZED_ERROR_CODES.INTERNAL,
+      operation,
+      retryable: false,
+    });
+  }
+};
+
+/**
+ * Assert every page describes the same revision.
+ *
+ * The cursor is supposed to hold the revision steady. Verifying it turns a silent torn read — the
+ * failure that would make a pruning caller delete live relationships — into a loud one.
+ */
+const assertSameRevision = (
+  snapshot: TAuthzedSnapshot | null,
+  pageSnapshot: TAuthzedSnapshot | null,
+  operation: string
+): void => {
+  if (snapshot !== null && pageSnapshot !== null && pageSnapshot.token !== snapshot.token) {
+    throw new AuthzedError({
+      attempts: 0,
+      code: AUTHZED_ERROR_CODES.ABORTED,
+      operation,
+      retryable: true,
+    });
+  }
+};
+
+/**
  * A complete observation of every relationship matching a filter, at one revision.
  *
  * There is deliberately no "partial" or "truncated" variant. A reconciler that mistook a partial
@@ -64,26 +108,8 @@ export const forEachRelationshipPage = async (
       limit: AUTHZED_MAX_RELATIONSHIP_READS,
     });
 
-    if (snapshot !== null && page.snapshot !== null && page.snapshot.token !== snapshot.token) {
-      throw new AuthzedError({
-        attempts: 0,
-        code: AUTHZED_ERROR_CODES.ABORTED,
-        operation: "for_each_relationship_page",
-        retryable: true,
-      });
-    }
-
-    // A cursor that does not advance would spin here forever, and a command that hangs with no output
-    // and no exit code is the worst thing to hand an operator. Termination is not ours to guarantee —
-    // it depends on the server — so assert it rather than assume it.
-    if (cursor !== undefined && page.cursor?.token === cursor.token) {
-      throw new AuthzedError({
-        attempts: 0,
-        code: AUTHZED_ERROR_CODES.INTERNAL,
-        operation: "for_each_relationship_page",
-        retryable: false,
-      });
-    }
+    assertSameRevision(snapshot, page.snapshot, "for_each_relationship_page");
+    assertCursorAdvanced(cursor, page.cursor, "for_each_relationship_page");
 
     snapshot = page.snapshot ?? snapshot;
     cursor = page.cursor ?? undefined;
@@ -142,16 +168,8 @@ export const readAllRelationships = async (
       });
     }
 
-    // The cursor is supposed to hold the revision steady. Verifying it turns a silent torn read — the
-    // failure that would make a pruning caller delete live relationships — into a loud one.
-    if (snapshot !== null && page.snapshot !== null && page.snapshot.token !== snapshot.token) {
-      throw new AuthzedError({
-        attempts: 0,
-        code: AUTHZED_ERROR_CODES.ABORTED,
-        operation: "read_all_relationships",
-        retryable: true,
-      });
-    }
+    assertSameRevision(snapshot, page.snapshot, "read_all_relationships");
+    assertCursorAdvanced(cursor, page.cursor, "read_all_relationships");
 
     relationships.push(...page.relationships);
     snapshot = page.snapshot ?? snapshot;

--- a/apps/web/lib/authzed/relationship-reads.ts
+++ b/apps/web/lib/authzed/relationship-reads.ts
@@ -73,6 +73,18 @@ export const forEachRelationshipPage = async (
       });
     }
 
+    // A cursor that does not advance would spin here forever, and a command that hangs with no output
+    // and no exit code is the worst thing to hand an operator. Termination is not ours to guarantee —
+    // it depends on the server — so assert it rather than assume it.
+    if (cursor !== undefined && page.cursor?.token === cursor.token) {
+      throw new AuthzedError({
+        attempts: 0,
+        code: AUTHZED_ERROR_CODES.INTERNAL,
+        operation: "for_each_relationship_page",
+        retryable: false,
+      });
+    }
+
     snapshot = page.snapshot ?? snapshot;
     cursor = page.cursor ?? undefined;
 

--- a/apps/web/lib/authzed/relationship-reads.ts
+++ b/apps/web/lib/authzed/relationship-reads.ts
@@ -36,7 +36,59 @@ export type TAuthzedRelationshipObservation = Readonly<{
 }>;
 
 /**
+ * Stream every relationship matching `filter`, one page at a time.
+ *
+ * Use this rather than `readAllRelationships` whenever the match is unbounded — a whole resource type,
+ * say. Accumulating those would hold the entire store in memory and trip the per-unit bound, which for a
+ * deployment with more relationships than that bound would make the sweep fail outright rather than
+ * merely slow.
+ *
+ * Consistency behaves exactly as below: identical parameters on every page, the cursor carries the
+ * revision, and a page reporting a different revision aborts rather than silently mixing two views.
+ * `onPage` failures propagate, so a caller cannot mistake a partial stream for a complete one.
+ *
+ * Returns the revision the stream was read at, or `null` if nothing matched.
+ */
+export const forEachRelationshipPage = async (
+  client: Pick<TAuthzedClient, "readRelationships">,
+  filter: TAuthzedRelationshipReadFilter,
+  onPage: (relationships: ReadonlyArray<TAuthzedRelationship>) => Promise<void>
+): Promise<TAuthzedSnapshot | null> => {
+  let snapshot: TAuthzedSnapshot | null = null;
+  let cursor: TAuthzedReadCursor | undefined;
+
+  do {
+    const page = await client.readRelationships({
+      ...(cursor ? { cursor } : {}),
+      filter,
+      limit: AUTHZED_MAX_RELATIONSHIP_READS,
+    });
+
+    if (snapshot !== null && page.snapshot !== null && page.snapshot.token !== snapshot.token) {
+      throw new AuthzedError({
+        attempts: 0,
+        code: AUTHZED_ERROR_CODES.ABORTED,
+        operation: "for_each_relationship_page",
+        retryable: true,
+      });
+    }
+
+    snapshot = page.snapshot ?? snapshot;
+    cursor = page.cursor ?? undefined;
+
+    if (page.relationships.length > 0) {
+      await onPage(page.relationships);
+    }
+  } while (cursor);
+
+  return snapshot;
+};
+
+/**
  * Read every relationship matching `filter`, at a single consistent revision.
+ *
+ * Only for filters narrow enough to hold in memory — one resource, typically. For an unbounded filter
+ * use `forEachRelationshipPage`.
  *
  * Every page is requested with identical parameters and the cursor carries the revision it was issued
  * at, so the pages of one drain describe one view. SpiceDB enforces the identical-parameters rule by

--- a/apps/web/lib/authzed/relationship-reads.ts
+++ b/apps/web/lib/authzed/relationship-reads.ts
@@ -38,15 +38,17 @@ export type TAuthzedRelationshipObservation = Readonly<{
 /**
  * Read every relationship matching `filter`, at a single consistent revision.
  *
- * The first page resolves fully consistently and its revision pins every later page, so the result
- * is one coherent view rather than a stitched-together sequence of independently-resolved pages.
+ * Every page is requested with identical parameters and the cursor carries the revision it was issued
+ * at, so the pages of one drain describe one view. SpiceDB enforces the identical-parameters rule by
+ * rejecting a cursor presented with any other argument changed — which is why nothing here varies the
+ * consistency requirement between pages.
  *
  * Throws rather than returning a partial result when:
  *
  * - the match exceeds `AUTHZED_MAX_OBSERVED_RELATIONSHIPS_PER_UNIT` (`authzed_limit_exceeded`), which
  *   also bounds the loop, since every continued iteration must have consumed a full page;
- * - the pinned revision ages out of the datastore's garbage-collection window mid-drain, which
- *   SpiceDB reports as a snapshot-expired failure and the facade maps to a non-retryable error;
+ * - a later page reports a different revision than the first, meaning the pages do not describe one
+ *   view and the observation is torn;
  * - any page fails for the usual operational reasons.
  *
  * Callers are expected to treat a throw as "this unit could not be observed" and continue with other
@@ -62,8 +64,6 @@ export const readAllRelationships = async (
 
   do {
     const page = await client.readRelationships({
-      // Absent on the first call so SpiceDB resolves the latest revision and hands it back.
-      ...(snapshot ? { atSnapshot: snapshot } : {}),
       ...(cursor ? { cursor } : {}),
       filter,
       limit: AUTHZED_MAX_RELATIONSHIP_READS,
@@ -78,8 +78,19 @@ export const readAllRelationships = async (
       });
     }
 
+    // The cursor is supposed to hold the revision steady. Verifying it turns a silent torn read — the
+    // failure that would make a pruning caller delete live relationships — into a loud one.
+    if (snapshot !== null && page.snapshot !== null && page.snapshot.token !== snapshot.token) {
+      throw new AuthzedError({
+        attempts: 0,
+        code: AUTHZED_ERROR_CODES.ABORTED,
+        operation: "read_all_relationships",
+        retryable: true,
+      });
+    }
+
     relationships.push(...page.relationships);
-    snapshot = page.snapshot;
+    snapshot = page.snapshot ?? snapshot;
     cursor = page.cursor ?? undefined;
   } while (cursor);
 

--- a/apps/web/lib/authzed/retry.ts
+++ b/apps/web/lib/authzed/retry.ts
@@ -4,6 +4,7 @@ import { performance } from "node:perf_hooks";
 import { logger } from "@formbricks/logger";
 import { AUTHZED_MAX_ATTEMPTS, AUTHZED_RETRY_BASE_DELAYS_MS, AUTHZED_RETRY_JITTER_RATIO } from "./constants";
 import { mapAuthzedError } from "./errors";
+import { recordAuthzedRequestFailure, recordAuthzedRequestRetry } from "./metrics";
 
 type TAuthzedRetryDependencies = Readonly<{
   now: () => number;
@@ -62,6 +63,11 @@ export const executeAuthzedOperation = async <T>(
           },
           "AuthZed request failed"
         );
+        recordAuthzedRequestFailure({
+          code: authzedError.code,
+          operation,
+          retryable: authzedError.retryable,
+        });
         throw authzedError;
       }
 
@@ -79,6 +85,9 @@ export const executeAuthzedOperation = async <T>(
         },
         "AuthZed request retry scheduled"
       );
+      // Retries that still succeed never reach the failure counter, so without this a degraded SpiceDB
+      // is invisible until it starts dropping writes outright.
+      recordAuthzedRequestRetry({ code: authzedError.code, operation });
       await dependencies.sleep(retryDelayMs);
     }
   }

--- a/apps/web/lib/authzed/team-workspace.ts
+++ b/apps/web/lib/authzed/team-workspace.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
-import { TeamUserRole, WorkspaceTeamPermission } from "@formbricks/database/prisma";
+import type { TeamUserRole, WorkspaceTeamPermission } from "@formbricks/database/prisma";
 import {
   type TAuthzedClient,
   type TAuthzedRelationshipFilter,
@@ -14,17 +14,7 @@ import {
   runBestEffortProjection,
 } from "./projection";
 import { deleteRelationshipsInBoundedBatches, packRelationshipUpdateGroups } from "./relationship-batches";
-
-const TEAM_RELATIONS = {
-  [TeamUserRole.admin]: "admin",
-  [TeamUserRole.contributor]: "contributor",
-} as const satisfies Record<TeamUserRole, string>;
-
-const WORKSPACE_TEAM_RELATIONS = {
-  [WorkspaceTeamPermission.manage]: "manager_team",
-  [WorkspaceTeamPermission.read]: "reader_team",
-  [WorkspaceTeamPermission.readWrite]: "writer_team",
-} as const satisfies Record<WorkspaceTeamPermission, string>;
+import { TEAM_RELATIONS, WORKSPACE_TEAM_RELATIONS } from "./relationship-map";
 
 const TEAM_RELATION_NAMES = Object.values(TEAM_RELATIONS);
 const WORKSPACE_TEAM_RELATION_NAMES = Object.values(WORKSPACE_TEAM_RELATIONS);

--- a/apps/web/modules/account/lib/better-auth-account-deletion.test.ts
+++ b/apps/web/modules/account/lib/better-auth-account-deletion.test.ts
@@ -125,10 +125,12 @@ describe("accountDeletionAfterDelete", () => {
 
     expect(logger.error).toHaveBeenCalledWith(
       {
-        code: "authzed_internal",
         component: "authzed",
+        errorCode: "authzed_internal",
         errorName: "Error",
         operation: "account_delete_organization_cleanup",
+        retryable: false,
+        status: "failed",
       },
       "Unexpected AuthZed projection failure after source commit"
     );

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -62,6 +62,7 @@
     "@lexical/table": "0.41.0",
     "@lexical/utils": "0.41.0",
     "@modelcontextprotocol/sdk": "1.26.0",
+    "@opentelemetry/api": "1.9.0",
     "@opentelemetry/auto-instrumentations-node": "0.75.0",
     "@opentelemetry/exporter-metrics-otlp-http": "0.217.0",
     "@opentelemetry/exporter-prometheus": "0.217.0",

--- a/apps/web/scripts/authzed-backfill-smoke.ts
+++ b/apps/web/scripts/authzed-backfill-smoke.ts
@@ -70,8 +70,12 @@ const run = async (): Promise<void> => {
   let closeClient: (() => void) | undefined;
 
   try {
-    const { closeAuthzedClient, getAuthzedClient } = await import("../lib/authzed/client");
+    const { closeAuthzedClient, configureAuthzedClientForBulkWork, getAuthzedClient } =
+      await import("../lib/authzed/client");
     closeClient = closeAuthzedClient;
+    // The same widening the CLI performs. Without it this exercises the sweep against the request-path
+    // deadline, so the one test that runs the sweep for real would not be running what operators run.
+    configureAuthzedClientForBulkWork();
     const client = getAuthzedClient();
 
     if (command === "seed") {

--- a/apps/web/scripts/authzed-backfill-smoke.ts
+++ b/apps/web/scripts/authzed-backfill-smoke.ts
@@ -152,6 +152,8 @@ const run = async (): Promise<void> => {
       readOrganizationSource: async () => emptySource,
       readWorkspaceSource: async () => ({
         apiKeyWorkspaceGrants: [],
+        invalidApiKeyWorkspaceGrants: [],
+        invalidWorkspaceTeamGrants: [],
         organizationId: null,
         workspaceExists: false,
         workspaceTeamGrants: [],

--- a/apps/web/scripts/authzed-backfill-smoke.ts
+++ b/apps/web/scripts/authzed-backfill-smoke.ts
@@ -1,4 +1,6 @@
 import "server-only";
+import type { TAuthzedBackfillSource } from "../lib/authzed/backfill";
+import type { TAuthzedOrganizationSource } from "../lib/authzed/backfill-source";
 import { INVALID_CONFIGURATION_RESULT, INVALID_REQUEST_RESULT } from "./authzed-schema-results";
 
 /**
@@ -52,7 +54,9 @@ const writeResult = (result: object): void => {
   process.stdout.write(`${JSON.stringify(result)}\n`);
 };
 
-const emptySource = {
+// Annotated rather than cast: adding a field to the source types must break this at compile time, not
+// at runtime inside the CI smoke job.
+const emptySource: TAuthzedOrganizationSource = {
   apiKeyIds: [],
   apiKeyWorkspaceGrants: [],
   invalidApiKeyWorkspaceGrants: [],
@@ -140,9 +144,9 @@ const run = async (): Promise<void> => {
 
     // Every relationship the harness seeded is absent from PostgreSQL by construction, so reporting
     // each observed record as missing is both honest and the fullest exercise of the orphan path.
-    const source = {
+    const source: TAuthzedBackfillSource = {
       findMismatchedParentEdges: async () => [],
-      findMissingSourceRefs: async (refs: ReadonlyArray<unknown>) => refs,
+      findMissingSourceRefs: async (refs) => refs,
       organizationExists: async () => true,
       readOrganizationIdPage: async () => [],
       readOrganizationSource: async () => emptySource,
@@ -152,7 +156,7 @@ const run = async (): Promise<void> => {
         workspaceExists: false,
         workspaceTeamGrants: [],
       }),
-    } as unknown as Parameters<typeof runAuthzedBackfill>[1]["source"];
+    };
 
     const handedOver: unknown[] = [];
     const record = async (targets: unknown) => {

--- a/apps/web/scripts/authzed-backfill-smoke.ts
+++ b/apps/web/scripts/authzed-backfill-smoke.ts
@@ -25,10 +25,20 @@ import { INVALID_CONFIGURATION_RESULT, INVALID_REQUEST_RESULT } from "./authzed-
  *   report             dry run: detect orphans, hand over nothing
  *   prune              apply + prune: hand the orphans to the reconcilers
  *   prune-capped       apply + prune with a cap of 1, which must hand over nothing
+ *   prune-page-capped  apply + prune with a cap above one page but below the total, which must also
+ *                      hand over nothing — the case a per-page cap check would have part-pruned
  *   cleanup            remove the seeded relationships
  */
 
-const COMMANDS = ["seed", "observe", "report", "prune", "prune-capped", "cleanup"] as const;
+const COMMANDS = [
+  "seed",
+  "observe",
+  "report",
+  "prune",
+  "prune-capped",
+  "prune-page-capped",
+  "cleanup",
+] as const;
 type TCommand = (typeof COMMANDS)[number];
 
 const isCommand = (value: string | undefined): value is TCommand =>
@@ -45,6 +55,7 @@ const writeResult = (result: object): void => {
 const emptySource = {
   apiKeyIds: [],
   apiKeyWorkspaceGrants: [],
+  invalidApiKeyWorkspaceGrants: [],
   invalidWorkspaceTeamGrants: [],
   memberships: [],
   teamIds: [],
@@ -137,6 +148,7 @@ const run = async (): Promise<void> => {
       readOrganizationSource: async () => emptySource,
       readWorkspaceSource: async () => ({
         apiKeyWorkspaceGrants: [],
+        organizationId: null,
         workspaceExists: false,
         workspaceTeamGrants: [],
       }),
@@ -149,9 +161,12 @@ const run = async (): Promise<void> => {
     };
 
     const applying = command !== "report";
+    // 280 sits above one read page (250) and below the seeded total, so a cap enforced per page would
+    // prune the first page and stop. Only a cap decided against the whole sweep hands over nothing.
+    const maxPruneFor: Record<string, number> = { "prune-capped": 1, "prune-page-capped": 280 };
     const result = await runAuthzedBackfill(
       {
-        maxPrune: command === "prune-capped" ? 1 : 500,
+        maxPrune: maxPruneFor[command] ?? 500,
         mode: applying ? "apply" : "dry_run",
         prune: applying,
         scope: { kind: "all" },

--- a/apps/web/scripts/authzed-backfill-smoke.ts
+++ b/apps/web/scripts/authzed-backfill-smoke.ts
@@ -126,10 +126,16 @@ const run = async (): Promise<void> => {
     // Every relationship the harness seeded is absent from PostgreSQL by construction, so reporting
     // each observed record as missing is both honest and the fullest exercise of the orphan path.
     const source = {
+      findMismatchedParentEdges: async () => [],
       findMissingSourceRefs: async (refs: ReadonlyArray<unknown>) => refs,
       organizationExists: async () => true,
       readOrganizationIdPage: async () => [],
       readOrganizationSource: async () => emptySource,
+      readWorkspaceSource: async () => ({
+        apiKeyWorkspaceGrants: [],
+        workspaceExists: false,
+        workspaceTeamGrants: [],
+      }),
     } as unknown as Parameters<typeof runAuthzedBackfill>[1]["source"];
 
     const handedOver: unknown[] = [];

--- a/apps/web/scripts/authzed-backfill-smoke.ts
+++ b/apps/web/scripts/authzed-backfill-smoke.ts
@@ -1,0 +1,177 @@
+import "server-only";
+import { INVALID_CONFIGURATION_RESULT, INVALID_REQUEST_RESULT } from "./authzed-schema-results";
+
+/**
+ * Drives the real backfill orchestrator against a real SpiceDB, without a database.
+ *
+ * The compose smoke harness has no Formbricks PostgreSQL — `DATABASE_URL` points at a fake host and
+ * Prisma never connects — so both the source reads and the reconcilers are stubbed. What runs for real
+ * is the half that can only be trusted once it has met the engine: paging past the read bound, pinning
+ * one revision across pages, mapping raw relationships back to the source records they imply, and
+ * deciding whether pruning is allowed.
+ *
+ * The reconcilers are recorded rather than executed because they read PostgreSQL themselves. Their
+ * deletion behaviour against a real SpiceDB is already covered by the relationship-projection
+ * assertions elsewhere in this harness; what is new here is *which targets* the orchestrator hands
+ * over, and under which flags.
+ *
+ * Refuses to run outside a test environment, mirroring `authzed-relationships-smoke.ts`. The real
+ * operator command carries no such guard — that would defeat its purpose — and relies instead on its
+ * confirmation flags, the endpoint check, and the prune cap.
+ *
+ * Commands:
+ *   seed <count>       write `count` team parent relationships through the facade
+ *   observe            drain every team relationship, reporting count and whether a revision was pinned
+ *   report             dry run: detect orphans, hand over nothing
+ *   prune              apply + prune: hand the orphans to the reconcilers
+ *   prune-capped       apply + prune with a cap of 1, which must hand over nothing
+ *   cleanup            remove the seeded relationships
+ */
+
+const COMMANDS = ["seed", "observe", "report", "prune", "prune-capped", "cleanup"] as const;
+type TCommand = (typeof COMMANDS)[number];
+
+const isCommand = (value: string | undefined): value is TCommand =>
+  value !== undefined && (COMMANDS as readonly string[]).includes(value);
+
+/** Fixture identifiers, sharing the `application-*` prefix the rest of the harness uses. */
+const ORGANIZATION_ID = "application-backfill-smoke-org";
+const teamId = (index: number): string => `application-backfill-smoke-team-${index}`;
+
+const writeResult = (result: object): void => {
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+};
+
+const emptySource = {
+  apiKeyIds: [],
+  apiKeyWorkspaceGrants: [],
+  invalidWorkspaceTeamGrants: [],
+  memberships: [],
+  teamIds: [],
+  teamMemberships: [],
+  workspaceIds: [],
+  workspaceTeamGrants: [],
+};
+
+const run = async (): Promise<void> => {
+  const command = process.argv[2];
+  if (!isCommand(command)) {
+    writeResult(INVALID_REQUEST_RESULT);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (process.env.NODE_ENV !== "test") {
+    writeResult({ code: "authzed_backfill_smoke_refused", retryable: false, status: "failed" });
+    process.exitCode = 1;
+    return;
+  }
+
+  let closeClient: (() => void) | undefined;
+
+  try {
+    const { closeAuthzedClient, getAuthzedClient } = await import("../lib/authzed/client");
+    closeClient = closeAuthzedClient;
+    const client = getAuthzedClient();
+
+    if (command === "seed") {
+      const count = Number(process.argv[3] ?? "0");
+      if (!Number.isSafeInteger(count) || count < 1 || count > 900) {
+        writeResult(INVALID_REQUEST_RESULT);
+        process.exitCode = 1;
+        return;
+      }
+
+      await client.writeRelationships(
+        Array.from({ length: count }, (_unused, index) => ({
+          operation: "touch" as const,
+          relationship: {
+            relation: "organization",
+            resource: { objectId: teamId(index), objectType: "team" },
+            subject: { objectId: ORGANIZATION_ID, objectType: "organization" },
+          },
+        }))
+      );
+
+      writeResult({ seeded: count, status: "seeded" });
+      process.exitCode = 0;
+      return;
+    }
+
+    if (command === "cleanup") {
+      await client.deleteRelationships({
+        resourceType: "team",
+        subject: { objectId: ORGANIZATION_ID, objectType: "organization" },
+      });
+      writeResult({ status: "cleaned" });
+      process.exitCode = 0;
+      return;
+    }
+
+    const { readAllRelationships } = await import("../lib/authzed/relationship-reads");
+
+    if (command === "observe") {
+      const observation = await readAllRelationships(client, { resourceType: "team" });
+      writeResult({
+        relationshipCount: observation.relationships.length,
+        snapshotPinned: observation.snapshot !== null,
+        status: "observed",
+      });
+      process.exitCode = 0;
+      return;
+    }
+
+    const { runAuthzedBackfill } = await import("../lib/authzed/backfill");
+
+    // Every relationship the harness seeded is absent from PostgreSQL by construction, so reporting
+    // each observed record as missing is both honest and the fullest exercise of the orphan path.
+    const source = {
+      findMissingSourceRefs: async (refs: ReadonlyArray<unknown>) => refs,
+      organizationExists: async () => true,
+      readOrganizationIdPage: async () => [],
+      readOrganizationSource: async () => emptySource,
+    } as unknown as Parameters<typeof runAuthzedBackfill>[1]["source"];
+
+    const handedOver: unknown[] = [];
+    const record = async (targets: unknown) => {
+      handedOver.push(targets);
+      return { passes: 1, status: "projected" } as const;
+    };
+
+    const applying = command !== "report";
+    const result = await runAuthzedBackfill(
+      {
+        maxPrune: command === "prune-capped" ? 1 : 500,
+        mode: applying ? "apply" : "dry_run",
+        prune: applying,
+        scope: { kind: "all" },
+      },
+      {
+        apply: {
+          reconcileApiKeys: record,
+          reconcileMemberships: record,
+          reconcileTeamWorkspace: record,
+        },
+        client,
+        source,
+      }
+    );
+
+    writeResult({
+      handedOverCount: handedOver.length,
+      orphaned: result.counters.orphaned,
+      pruned: result.counters.pruned,
+      skipped: result.counters.skipped,
+      status: result.status,
+      truncated: result.truncated,
+    });
+    process.exitCode = result.status === "failed" ? 1 : 0;
+  } catch {
+    writeResult(INVALID_CONFIGURATION_RESULT);
+    process.exitCode = 1;
+  } finally {
+    closeClient?.();
+  }
+};
+
+void run();

--- a/apps/web/scripts/authzed-backfill.test.ts
+++ b/apps/web/scripts/authzed-backfill.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+
+/**
+ * `apps/web/scripts/**` is excluded from coverage, so this is a contract test rather than a behavioural
+ * one: it asserts the entry point stays a thin argv shim and that every decision lives in the covered
+ * command module.
+ */
+describe("authzed backfill script", () => {
+  const scriptSource = readFileSync(new URL("./authzed-backfill.ts", import.meta.url), "utf8");
+
+  test("delegates parsing and execution to the covered command module", () => {
+    expect(scriptSource).toContain("parseAuthzedBackfillCommand");
+    expect(scriptSource).toContain("runAuthzedBackfillCli");
+  });
+
+  test("contains no guard logic of its own", () => {
+    // The prune guards must be in lib/authzed/backfill-cli.ts, where the coverage gate applies.
+    for (const guard of ["--prune", "--confirm-prune", "--expected-endpoint", "maxPrune"]) {
+      // Mentioning a flag in the usage doc-block is fine; branching on one is not.
+      expect(scriptSource).not.toMatch(new RegExp(`(if|includes|startsWith)[^\\n]*${guard}`));
+    }
+  });
+
+  test("reports an exit code rather than exiting the process", () => {
+    // process.exit would skip the single-JSON-line output contract the automation depends on.
+    expect(scriptSource).toContain("process.exitCode");
+    expect(scriptSource).not.toContain("process.exit(");
+  });
+});

--- a/apps/web/scripts/authzed-backfill.ts
+++ b/apps/web/scripts/authzed-backfill.ts
@@ -1,0 +1,62 @@
+import "server-only";
+import { INVALID_CONFIGURATION_RESULT, INVALID_REQUEST_RESULT } from "./authzed-schema-results";
+
+/**
+ * Entry point for `pnpm authzed:backfill`.
+ *
+ * Deliberately thin: it hands argv to the covered command layer and reports an exit code. Parsing and
+ * every guard live in `lib/authzed/backfill-cli.ts`, because `apps/web/scripts/**` is excluded from
+ * coverage and the destructive-path guards must be tested.
+ *
+ * Usage:
+ *   pnpm authzed:backfill
+ *       Dry run over every organization. Reports drift, writes nothing. Exits 2 if drift remains.
+ *   pnpm authzed:backfill --organization-id=<cuid>
+ *       Dry run over one organization.
+ *   pnpm authzed:backfill --apply
+ *       Converge every organization from PostgreSQL. Reports relationships with no source record but
+ *       leaves them in place.
+ *   pnpm authzed:backfill --apply --prune --confirm-prune --scope=all \
+ *       --expected-endpoint=<host:port>
+ *       Also reconcile records observed only in SpiceDB, removing what PostgreSQL no longer holds.
+ *   pnpm authzed:backfill --apply --after-organization-id=<cuid>
+ *       Resume an interrupted run from the `lastOrganizationId` the previous run reported.
+ *
+ * Optional: --max-prune=<n> lowers the per-run prune cap (it can never raise it).
+ *
+ * Exit codes: 0 reconciled, 2 drift remains, 1 failed or misused.
+ */
+
+const writeResult = (result: object): void => {
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+};
+
+const run = async (): Promise<void> => {
+  const originalConsoleError = console.error;
+
+  try {
+    // Environment validation logs details before throwing. Suppress that duplicate output so this
+    // automation-oriented command always emits exactly one sanitized JSON result.
+    console.error = () => {};
+    const { parseAuthzedBackfillCommand, runAuthzedBackfillCli } =
+      await import("../lib/authzed/backfill-cli");
+    console.error = originalConsoleError;
+
+    const command = parseAuthzedBackfillCommand(process.argv.slice(2));
+    if (!command) {
+      writeResult(INVALID_REQUEST_RESULT);
+      process.exitCode = 1;
+      return;
+    }
+
+    process.exitCode = await runAuthzedBackfillCli(command);
+  } catch {
+    console.error = originalConsoleError;
+    writeResult(INVALID_CONFIGURATION_RESULT);
+    process.exitCode = 1;
+  } finally {
+    console.error = originalConsoleError;
+  }
+};
+
+void run();

--- a/apps/web/vite.config.mts
+++ b/apps/web/vite.config.mts
@@ -139,6 +139,12 @@ export default defineConfig({
         // ENG-1054: keep the new Better Auth code well-tested. Glob aggregate (not perFile) so a single
         // thin file can't trip the gate; the integration-only BA instance/wiring is excluded above.
         "modules/auth/lib/**": { statements: 80, branches: 80, functions: 80, lines: 80 },
+        // ENG-1718: keep the AuthZed client, projections, and backfill/repair tooling well-tested —
+        // this code rewrites the authorization graph. Glob aggregate (not perFile) so a single thin
+        // file can't trip the gate. `**/scripts/**` is excluded above, so every decision the tooling
+        // makes (argv parsing, scoping, classification, prune guards, exit codes) lives under
+        // lib/authzed and is covered here; apps/web/scripts/authzed-*.ts stay thin argv shims.
+        "lib/authzed/**": { statements: 80, branches: 80, functions: 80, lines: 80 },
       },
     },
   },

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -338,8 +338,9 @@ authzed:backfill` closes both gaps.
 # Report drift over every organization. Writes nothing.
 pnpm authzed:backfill
 
-# Converge one organization from PostgreSQL.
+# Converge one organization from PostgreSQL, or a single workspace's grants.
 pnpm authzed:backfill --apply --organization-id=<cuid>
+pnpm authzed:backfill --apply --workspace-id=<cuid>
 
 # Converge everything, then remove relationships PostgreSQL no longer holds.
 pnpm authzed:backfill --apply --prune --confirm-prune --scope=all \
@@ -351,7 +352,29 @@ pnpm authzed:backfill --apply --after-organization-id=<cuid>
 
 Exit codes match `authzed:schema`: `0` reconciled, `2` drift remains, `1` failed
 or misused. The result is one line of JSON carrying counters, the offending
-record identifiers, the revision the run completed at, and a `truncated` flag.
+record identifiers, the revision the last observation was taken at, and a
+`truncated` flag.
+
+Drift is reported in both directions:
+
+- `missing` — records PostgreSQL holds that SpiceDB has no relationship for. This
+  is what an empty or stale SpiceDB looks like, so a report that could not see it
+  would be worthless. Note this compares *records*, not relations: a membership
+  stored as `owner` in PostgreSQL but `member` in SpiceDB counts as present.
+  Applying converges the relation regardless, by writing the current value.
+- `orphaned` — relationships whose source record is gone.
+- `mismatchedParents` — a resource attached to an organization PostgreSQL says
+  does not own it. **Reported and never touched.** `organization` is a relation,
+  so an extra parent edge is additive and hands every owner and manager of the
+  named organization access to another tenant's resource; but removing it safely
+  means deleting a relation the resource legitimately needs one of, so it is left
+  for a human. Any non-zero count here is a privilege-escalation finding, not
+  routine drift.
+
+A dry run over the whole deployment checks both directions per organization,
+which costs a read per resource. An applying run skips the `missing` check —
+its writes converge that direction anyway — and detects orphans with a single
+streamed pass per resource type.
 
 The organization is the unit of work, so a partial run leaves complete graphs for
 the organizations it finished rather than a fragment of every tenant's. Runs are
@@ -381,12 +404,14 @@ Guards on the destructive path:
 
 Two limits worth knowing before relying on a run:
 
-- `--organization-id` reports `orphanScope: "known_resources"`. SpiceDB
-  relationship filters have no notion of "belongs to organization X" and Formbricks
-  object IDs carry no organization prefix, so a resource whose row is already gone
-  is unreachable from its organization. Only `--scope=all` sweeps by resource type
-  and can claim completeness.
-- `--scope=all` assumes a SpiceDB dedicated to this deployment.
+- `--organization-id` and `--workspace-id` report
+  `orphanScope: "known_resources"`. SpiceDB relationship filters have no notion of
+  "belongs to organization X" and Formbricks object IDs carry no organization
+  prefix, so a resource whose row is already gone is unreachable from its
+  organization. Only the default whole-deployment run sweeps by resource type and
+  can claim completeness. (`--scope=all` is a confirmation token for pruning
+  everything, not what selects the sweep — the sweep is the default.)
+- The whole-deployment sweep assumes a SpiceDB dedicated to this deployment.
   `AUTHZED_SYSTEM_KEY` is not yet used to namespace object IDs, so a
   resource-type sweep cannot tell another installation's relationships from
   orphans.

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -352,8 +352,9 @@ pnpm authzed:backfill --apply --after-organization-id=<cuid>
 
 Exit codes match `authzed:schema`: `0` reconciled, `2` drift remains, `1` failed
 or misused. The result is one line of JSON carrying counters, the offending
-record identifiers, the revision the last observation was taken at, and a
-`truncated` flag.
+record identifiers, a revision captured *after* the run's own writes (so shadow
+evaluation can use it as an `at_least_as_fresh` floor — `null` for a dry run,
+which wrote nothing to be fresh relative to), and a `truncated` flag.
 
 Drift is reported in both directions:
 

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -124,9 +124,10 @@ behavior: accepted and pending membership rows project identically. An
 Projection runs after the source transaction commits and is best-effort.
 AuthZed being disabled performs no projection work. An AuthZed outage never
 changes a successful PostgreSQL mutation into an application error; it produces
-only a sanitized operational result and warning. ENG-1718 must backfill and
-repair all source relationships before AuthZed shadow evaluation or enforcement
-can be enabled.
+only a sanitized operational result and warning. Existing records and any drift
+an outage leaves behind are reconciled by `pnpm authzed:backfill` (see
+[Backfill and repair](#backfill-and-repair)), which must report a clean run
+before AuthZed shadow evaluation or enforcement is enabled.
 
 The organization-membership projection boundary covers:
 
@@ -192,9 +193,8 @@ Deletion cleanup is deliberately two-sided and idempotent:
 Projection covers UI and API team creation/update/deletion, workspace
 creation/deletion, API v2 workspace-team CRUD, invite/signup/SSO team
 assignment, organization-role promotions, membership removal, API v2 nested
-organization-user team changes, and user/organization cascades. Existing
-records are not backfilled here: ENG-1718 remains mandatory before AuthZed
-shadow evaluation or enforcement.
+organization-user team changes, and user/organization cascades. Existing records
+are not backfilled by these hooks; `pnpm authzed:backfill` covers them.
 
 ## API-key scope projection
 
@@ -234,10 +234,10 @@ or usage timestamps. Reconciliation uses the same post-commit, best-effort,
 three-pass convergence and bounded batching contract as organization, team,
 and workspace projection.
 
-Existing API keys are not backfilled by mutation hooks. ENG-1718 must perform
-authoritative backfill and repair before API-key shadow evaluation or
-enforcement is enabled. Routing API-key principals through the central
-interface remains ENG-1731, and SpiceDB comparison/cutover remains ENG-1738.
+Existing API keys are not backfilled by mutation hooks; `pnpm authzed:backfill`
+covers them, including a scope revoked outside a hook, which the projector alone
+cannot see. Routing API-key principals through the central interface remains
+ENG-1731, and SpiceDB comparison/cutover remains ENG-1738.
 
 ## Resource parent resolution during the current-model migration
 
@@ -256,7 +256,8 @@ remain denials, matching the legacy evaluator.
 
 The `survey#workspace`, `dashboard#workspace`, and `response#survey` relations
 remain in the schema for later resource-level sharing. They must not be queried
-directly until a future projector and ENG-1718 backfill cover those edges.
+directly until a future projector and matching backfill scope cover those edges;
+the backfill classifies them as ignored today and never prunes them.
 Phase 2 direct resource grants must add that projection and repair scope before
 enforcement.
 
@@ -324,6 +325,79 @@ doc comments):
    their granted workspace at their granted level; organization-level
    `accessControl` rights grant access to organization access-control resources
    but no product data.
+
+## Backfill and repair
+
+Mutation hooks only project records that change while they are running. They do
+not cover records that predate them, and they cannot see a row deleted outside a
+hook — a projector derives its targets from PostgreSQL, so a relationship whose
+source row is already gone is never named and never removed. `pnpm
+authzed:backfill` closes both gaps.
+
+```bash
+# Report drift over every organization. Writes nothing.
+pnpm authzed:backfill
+
+# Converge one organization from PostgreSQL.
+pnpm authzed:backfill --apply --organization-id=<cuid>
+
+# Converge everything, then remove relationships PostgreSQL no longer holds.
+pnpm authzed:backfill --apply --prune --confirm-prune --scope=all \
+  --expected-endpoint=<host:port>
+
+# Resume an interrupted run from the lastOrganizationId it reported.
+pnpm authzed:backfill --apply --after-organization-id=<cuid>
+```
+
+Exit codes match `authzed:schema`: `0` reconciled, `2` drift remains, `1` failed
+or misused. The result is one line of JSON carrying counters, the offending
+record identifiers, the revision the run completed at, and a `truncated` flag.
+
+The organization is the unit of work, so a partial run leaves complete graphs for
+the organizations it finished rather than a fragment of every tenant's. Runs are
+idempotent — relationships are written with `TOUCH` — so re-running is always safe
+and is the intended response to a failed unit.
+
+**"No prune" does not mean "no deletes."** Converging a membership inherently
+deletes the roles it does not hold. What `--prune` adds is permission to reconcile
+records observed *only* in SpiceDB. Even then no delete is precomputed: an
+unsourced record becomes a reconciler *target*, and the reconciler re-reads
+PostgreSQL before deciding, so a row recreated in the meantime is written rather
+than deleted.
+
+Guards on the destructive path:
+
+- a dry run is the default, so a mistyped invocation is inert;
+- `--prune` additionally requires `--apply`, `--confirm-prune`, an explicit scope,
+  and `--expected-endpoint`;
+- `--expected-endpoint` must match `AUTHZED_ENDPOINT`. **`AUTHZED_SYSTEM_KEY` is
+  not usable for this** — it is a stable namespace and defaults to the same value
+  everywhere, so it cannot tell staging from production;
+- exceeding the per-run prune cap (default 500, lowerable via `--max-prune`, never
+  raisable) prunes *nothing* for that unit. A large orphan count is a symptom —
+  wrong endpoint, wrong database, a restore in progress — not a big cleanup job;
+- `survey`, `dashboard`, and `response` relationships are classified ignored, and
+  anything outside the vocabulary is reported but never touched.
+
+Two limits worth knowing before relying on a run:
+
+- `--organization-id` reports `orphanScope: "known_resources"`. SpiceDB
+  relationship filters have no notion of "belongs to organization X" and Formbricks
+  object IDs carry no organization prefix, so a resource whose row is already gone
+  is unreachable from its organization. Only `--scope=all` sweeps by resource type
+  and can claim completeness.
+- `--scope=all` assumes a SpiceDB dedicated to this deployment.
+  `AUTHZED_SYSTEM_KEY` is not yet used to namespace object IDs, so a
+  resource-type sweep cannot tell another installation's relationships from
+  orphans.
+
+Note also that the command reads `.env` and ignores `.env.local`, so the instance
+it rewrites is not necessarily the one a local dev server talks to. Always pass
+`--expected-endpoint` when pruning.
+
+The command is not present in the released container image, matching
+`authzed:health` and `authzed:schema`; running it requires a checkout. Packaging it
+for self-hosted operators is ENG-1740.
 
 ## Deliberately not modeled (stays in application code)
 

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -362,6 +362,12 @@ record identifiers, a revision captured *after* the run's own writes (so shadow
 evaluation can use it as an `at_least_as_fresh` floor — `null` for a dry run,
 which wrote nothing to be fresh relative to), and a `truncated` flag.
 
+That JSON is the whole diagnostic: like the other AuthZed commands, this one runs
+at `LOG_LEVEL=fatal` so stdout stays a single parseable line. Each entry in
+`failures` therefore carries `attempts` alongside the sanitized code, because
+"failed once" and "exhausted the retry budget" call for different reactions and
+the logs that would otherwise distinguish them are suppressed.
+
 Drift is reported in both directions:
 
 - `missing` — records PostgreSQL holds that SpiceDB has no relationship for. This

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -342,6 +342,12 @@ pnpm authzed:backfill
 pnpm authzed:backfill --apply --organization-id=<cuid>
 pnpm authzed:backfill --apply --workspace-id=<cuid>
 
+# Remove the relationships of a workspace whose row is gone. This is a prune —
+# every relationship on that workspace goes, team and API-key grants included —
+# so it takes the prune flags rather than --apply alone.
+pnpm authzed:backfill --apply --prune --confirm-prune --workspace-id=<cuid> \
+  --expected-endpoint=<host:port>
+
 # Converge everything, then remove relationships PostgreSQL no longer holds.
 pnpm authzed:backfill --apply --prune --confirm-prune --scope=all \
   --expected-endpoint=<host:port>
@@ -372,6 +378,13 @@ Drift is reported in both directions:
   for a human. Any non-zero count here is a privilege-escalation finding, not
   routine drift.
 
+  **Only `--scope=all` can find one.** The escalation is an edge on *another*
+  tenant's resource that names the organization under investigation, and a
+  single-organization run reads only the resources PostgreSQL says that
+  organization owns — so the offending resource is never read. A
+  `--organization-id` run reporting `mismatchedParents: 0` therefore means "none
+  among this tenant's own resources", not "this tenant is not being targeted".
+
 A dry run over the whole deployment checks both directions per organization,
 which costs a read per resource. An applying run skips the `missing` check —
 its writes converge that direction anyway — and detects orphans with a single
@@ -398,8 +411,11 @@ Guards on the destructive path:
   not usable for this** — it is a stable namespace and defaults to the same value
   everywhere, so it cannot tell staging from production;
 - exceeding the per-run prune cap (default 500, lowerable via `--max-prune`, never
-  raisable) prunes *nothing* for that unit. A large orphan count is a symptom —
-  wrong endpoint, wrong database, a restore in progress — not a big cleanup job;
+  raisable) prunes *nothing* — not a capped subset. Every unit, the streamed sweep
+  included, counts its orphans to completion before deleting any of them, so the
+  cap aborts before the first delete rather than part-way through. A large orphan
+  count is a symptom — wrong endpoint, wrong database, a restore in progress — not
+  a big cleanup job;
 - `survey`, `dashboard`, and `response` relationships are classified ignored, and
   anything outside the vocabulary is reported but never touched.
 

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -348,6 +348,10 @@ pnpm authzed:backfill --apply --workspace-id=<cuid>
 pnpm authzed:backfill --apply --prune --confirm-prune --workspace-id=<cuid> \
   --expected-endpoint=<host:port>
 
+# A stale grant whose *team or API key* is also gone is reported but not removed by
+# this scope: deleting it would delete that principal's relationships everywhere,
+# which is the organization or full sweep's unit of work, not one workspace's.
+
 # Converge everything, then remove relationships PostgreSQL no longer holds.
 pnpm authzed:backfill --apply --prune --confirm-prune --scope=all \
   --expected-endpoint=<host:port>
@@ -357,7 +361,11 @@ pnpm authzed:backfill --apply --after-organization-id=<cuid>
 ```
 
 Exit codes match `authzed:schema`: `0` reconciled, `2` drift remains, `1` failed
-or misused. The result is one line of JSON carrying counters, the offending
+or misused. **`0` means every category is clear, including the ones this tool
+deliberately will not repair** — `invalid` and `unmanaged` count toward drift
+exactly like `orphaned` and `missing`, because unrepaired authorization state is
+still authorization state and this exit code is what gates shadow evaluation and
+enforcement. The result is one line of JSON carrying counters, the offending
 record identifiers, a revision captured *after* the run's own writes (so shadow
 evaluation can use it as an `at_least_as_fresh` floor — `null` for a dry run,
 which wrote nothing to be fresh relative to), and a `truncated` flag.
@@ -376,6 +384,9 @@ Drift is reported in both directions:
   stored as `owner` in PostgreSQL but `member` in SpiceDB counts as present.
   Applying converges the relation regardless, by writing the current value.
 - `orphaned` — relationships whose source record is gone.
+- `invalid` — source rows whose principal and resource belong to different
+  organizations. Never projected and never pruned, in either scope.
+- `unmanaged` — relationships outside the vocabulary. Reported, never touched.
 - `mismatchedParents` — a resource attached to an organization PostgreSQL says
   does not own it. **Reported and never touched.** `organization` is a relation,
   so an extra parent edge is additive and hands every owner and manager of the

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -9,6 +9,9 @@ assertion-based validation suite.
   blocks that pin down the schema's semantics.
 - `validate.sh` — offline validation runner (local `zed` binary or the pinned
   `authzed/zed` container image; no SpiceDB server needed).
+- [`RUNBOOK.md`](./RUNBOOK.md) — diagnosing and recovering from relationship-sync
+  failures: the metrics, the log field contract, suggested alert rules, and the
+  recovery path through `pnpm authzed:backfill`.
 
 ## Running the validation
 

--- a/authzed/RUNBOOK.md
+++ b/authzed/RUNBOOK.md
@@ -45,7 +45,7 @@ All four carry only bounded attributes — never an organization, user, or relat
 | Metric | Attributes | Read it as |
 | --- | --- | --- |
 | `formbricks_authzed_projection_total` | `operation`, `projection`, `status` | Projection outcomes. `status` is `projected` / `failed` / `disabled`. |
-| `formbricks_authzed_projection_duration_ms` | same | Projection latency. It sits on the request path, so a rise here is user-visible. |
+| `formbricks_authzed_projection_duration_seconds` | same | Projection latency. It sits on the request path, so a rise here is user-visible. `disabled` outcomes are deliberately excluded — their duration is a structural zero, not a measurement. |
 | `formbricks_authzed_request_failures_total` | `operation`, `code`, `retryable` | Requests that exhausted their retry budget. **Each one is a dropped relationship.** |
 | `formbricks_authzed_request_retries_total` | `operation`, `code` | Retries scheduled. Elevated but not failing = degraded, not down. |
 
@@ -141,6 +141,27 @@ code, and the run exits `1`. Re-running is the fix — successful units simply r
 **`truncated: true`** means an observation was abandoned mid-read. Treat the orphan counts as a floor,
 not a total, and re-run before concluding anything.
 
+### Reading the drift counters
+
+- **`missing`** — records PostgreSQL holds that SpiceDB has no relationship for. What an empty or stale
+  SpiceDB looks like. Step 2 fixes it. Note it compares *records*, not relations: a membership stored as
+  `owner` in PostgreSQL but `member` in SpiceDB counts as present, and step 2 converges it regardless by
+  writing the current value.
+- **`orphaned`** — relationships whose source record is gone. Only step 3 removes them.
+- **`mismatchedParents`** — **treat as a security finding, not routine drift.** A resource is attached to
+  an organization PostgreSQL says does not own it. `organization` is a relation, so the edge is *additive*:
+  every owner and manager of the named organization has access to that resource through
+  `organization->manage`, and no PostgreSQL row explains it. The backfill reports these and deliberately
+  never removes them, because deleting a parent edge means deleting a relation the resource legitimately
+  needs one of. Confirm the true owner in PostgreSQL, then remove the wrong edge by hand:
+
+  ```bash
+  zed relationship delete <childType>:<childId> organization organization:<wrongOrganizationId>
+  ```
+
+  Then re-run step 2 to confirm the correct edge is present, and work out how it was written — nothing in
+  Formbricks creates one.
+
 ## 4. Before you prune
 
 `--prune` is the only destructive mode, and the guards are deliberately inconvenient.
@@ -210,7 +231,7 @@ sum(rate(formbricks_authzed_projection_total{status="disabled"}[15m])) > 0
 # for: 30m
 
 # Warning: projection latency is on the request path.
-histogram_quantile(0.95, sum(rate(formbricks_authzed_projection_duration_ms_bucket[5m])) by (le)) > 500
+histogram_quantile(0.95, sum(rate(formbricks_authzed_projection_duration_seconds_bucket[5m])) by (le)) > 0.5
 # for: 15m
 ```
 

--- a/authzed/RUNBOOK.md
+++ b/authzed/RUNBOOK.md
@@ -46,7 +46,7 @@ All four carry only bounded attributes — never an organization, user, or relat
 | --- | --- | --- |
 | `formbricks_authzed_projection_total` | `operation`, `projection`, `status` | Projection outcomes. `status` is `projected` / `failed` / `disabled`. |
 | `formbricks_authzed_projection_duration_seconds` | same | Projection latency. It sits on the request path, so a rise here is user-visible. `disabled` outcomes are deliberately excluded — their duration is a structural zero, not a measurement. |
-| `formbricks_authzed_request_failures_total` | `operation`, `code`, `retryable` | Requests that exhausted their retry budget. **Each one is a dropped relationship.** |
+| `formbricks_authzed_request_failures_total` | `operation`, `code`, `retryable` | Requests that exhausted their retry budget — *any* facade call, including schema operations and reads, and one failed write can carry a whole batch. So a sample is one terminal request failure, **not** one dropped relationship. For "did projection drift get introduced?", use `formbricks_authzed_projection_total{status="failed"}`. |
 | `formbricks_authzed_request_retries_total` | `operation`, `code` | Retries scheduled. Elevated but not failing = degraded, not down. |
 
 Exported through the readers already configured in `instrumentation-node.ts`: Prometheus when
@@ -111,6 +111,17 @@ pnpm authzed:backfill
 
 Exit `0` clean, `2` drift remains, `1` failed. Read `counters`, `orphans`, and `failures` from the JSON.
 
+`0` covers **every** unrepaired category, not only the ones the tool fixes: `invalid` (source rows whose
+principal and resource sit in different organizations) and `unmanaged` (relationships outside the
+vocabulary) count toward drift alongside `orphaned`, `missing` and `mismatchedParents`. That matters
+because this exit code is the gate for shadow evaluation and enforcement below — a run cannot report
+clean while authorization state nothing accounts for is still present.
+
+**A non-zero `invalid` needs a human.** These are cross-organization source rows in PostgreSQL: the join
+tables carry independent foreign keys and no same-organization constraint, so the row is representable
+even though nothing in Formbricks creates one. The backfill will never project or prune them. Establish
+how the row was written, then correct or delete it in PostgreSQL — after which a re-run reports clean.
+
 **2. Converge what PostgreSQL says should exist.**
 
 ```bash
@@ -148,8 +159,17 @@ pnpm authzed:backfill --apply --prune --confirm-prune --workspace-id=<cuid> \
 ```
 
 Narrow, but not hermetic: the API keys holding grants on that workspace are reconciled in full, which
-also converges their grants on *other* workspaces. That direction only ever writes what PostgreSQL
-says, so the effect is a wider repair than you asked for, never a deletion outside the workspace named.
+also converges their grants on *other* workspaces. That direction only ever writes what PostgreSQL says,
+so it is a wider repair than you asked for.
+
+**Deletion is held to the workspace, but at a cost worth knowing.** A grant ref implies its principal, and
+a principal with no PostgreSQL row makes the reconciler delete subject-wide — every workspace
+relationship for that team, or every organization *and* workspace relationship for that key. One orphan
+here would then delete relationships in other tenants, none of it weighed against this run's cap. So this
+scope **withholds** any grant whose team or API key is also gone: it stays counted in `orphaned`, nothing
+is deleted for it, and the run finishes `drifted`. That cleanup belongs to `--organization-id` or
+`--scope=all`, where the wider deletion is the intended unit of work. If a workspace run keeps reporting
+orphans it will not prune, this is why — widen the scope.
 
 **Resuming.** A run reports `lastOrganizationId`. Feed it back:
 

--- a/authzed/RUNBOOK.md
+++ b/authzed/RUNBOOK.md
@@ -1,0 +1,230 @@
+# AuthZed relationship sync runbook
+
+PostgreSQL is the source of truth for authorization. SpiceDB holds a *projection* of it, written after
+each source transaction commits, best-effort. That trade-off is deliberate — an AuthZed outage must
+never turn a successful PostgreSQL mutation into an application error — and it has one consequence
+worth internalizing:
+
+> **Sync failures are silent by design.** Nothing in the product breaks when a projection is dropped.
+> Drift accumulates until something reads SpiceDB and disagrees with PostgreSQL.
+
+Everything below exists to make that visible and recoverable.
+
+See also: [README](./README.md) for the projection contract and the backfill command reference.
+
+## 1. Symptoms
+
+| What you see | What it usually means |
+| --- | --- |
+| Shadow evaluation reports mismatches (ENG-1738) | Drift. Run the backfill. |
+| A new member, team, or API key lacks access *in SpiceDB only* | A dropped projection for that record. |
+| A removed member still resolves in SpiceDB | A stale relationship. Only pruning removes it. |
+| `formbricks_authzed_projection_total{status="failed"}` is non-zero | Projections are failing now. |
+| Nothing at all, but AuthZed was recently unavailable | Assume drift. An outage never retries. |
+
+Product authorization is unaffected in every one of these cases while enforcement is still on the
+legacy evaluator. That is what makes them easy to miss.
+
+## 2. Diagnosis
+
+### Is AuthZed reachable and correctly configured?
+
+```bash
+pnpm authzed:health     # 0 healthy, 1 otherwise
+pnpm authzed:schema check   # 0 matched, 2 drifted, 1 failed
+```
+
+Note `status: "disabled"` from the health command exits **1**. A deployment that believes AuthZed is on
+while `AUTHZED_ENABLED` is off looks healthy by every other signal, which is why the projection metric
+records `disabled` as its own outcome rather than skipping.
+
+### Metrics
+
+All four carry only bounded attributes — never an organization, user, or relationship identifier.
+
+| Metric | Attributes | Read it as |
+| --- | --- | --- |
+| `formbricks_authzed_projection_total` | `operation`, `projection`, `status` | Projection outcomes. `status` is `projected` / `failed` / `disabled`. |
+| `formbricks_authzed_projection_duration_ms` | same | Projection latency. It sits on the request path, so a rise here is user-visible. |
+| `formbricks_authzed_request_failures_total` | `operation`, `code`, `retryable` | Requests that exhausted their retry budget. **Each one is a dropped relationship.** |
+| `formbricks_authzed_request_retries_total` | `operation`, `code` | Retries scheduled. Elevated but not failing = degraded, not down. |
+
+Exported through the readers already configured in `instrumentation-node.ts`: Prometheus when
+`PROMETHEUS_ENABLED=1` (scraped by the chart's ServiceMonitor), OTLP when
+`OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+
+**The backfill command deliberately exports nothing.** It is a short-lived process with no scrape
+window; its observability is the counters in its own JSON result and its exit code.
+
+### Logs
+
+Every AuthZed log line carries `component: "authzed"`. Failure lines share a stable field set, so one
+query covers all of them:
+
+| Field | Present on | Meaning |
+| --- | --- | --- |
+| `component` | everything | Always `"authzed"`. |
+| `operation` | everything | The facade operation or projection entry point. |
+| `status` | projection outcomes | `projected` / `failed`. |
+| `errorCode` | every failure | Sanitized `authzed_*` code. Never a raw error. |
+| `retryable` | every failure | Whether a retry could have helped. |
+| `durationMs` | requests and projections | — |
+| `projection` | projection outcomes | Which projector: `organization_membership`, `team_workspace`, `api_key`. |
+| `attempts` | projection failures | Total attempts behind the failure. |
+| `attemptCount` | request failures/retries | Which attempt this line is about. Distinct from `attempts` above — request layer, not projection layer. |
+| `grpcStatus` | request failures/retries | Numeric gRPC status. |
+| `errorName` | post-commit boundary only | Error *class* name when a projector itself threw. |
+
+```
+component:"authzed" AND status:"failed"
+component:"authzed" AND errorCode:"authzed_unavailable"
+```
+
+**Identifiers never appear in logs.** No organization, user, team, workspace, or API-key ID; no schema
+text; no tokens. If you need to know *which* records drifted, that comes from the backfill's stdout
+(see §3), not from logs.
+
+### Correlating with SpiceDB itself
+
+A projection-failure spike with healthy SpiceDB metrics points at the app side; both unhealthy points
+at the datastore. Worth checking on the SpiceDB side:
+
+- **`pgxpool_empty_acquire`** — datastore connection starvation, the usual cause of
+  `authzed_unavailable` / `authzed_overloaded` bursts under load. AuthZed's guidance is to divide the
+  datastore's max connections by pod count, then split between read and write pools.
+- SpiceDB dispatch and cache metrics from the operator's ServiceMonitor.
+- `spicedb` pod restarts, and whether `spicedb datastore migrate` ran on the last upgrade.
+
+## 3. Recovery
+
+Escalate in this order. Every step is safe to repeat — relationships are written with `TOUCH`.
+
+**1. See what is wrong. Writes nothing.**
+
+```bash
+pnpm authzed:backfill
+```
+
+Exit `0` clean, `2` drift remains, `1` failed. Read `counters`, `orphans`, and `failures` from the JSON.
+
+**2. Converge what PostgreSQL says should exist.**
+
+```bash
+pnpm authzed:backfill --apply
+```
+
+This fixes dropped and wrong relationships. It does **not** remove relationships whose source row is
+gone — expect `status: "drifted"` and a non-zero `orphaned` if any exist.
+
+**3. Remove what PostgreSQL no longer holds.**
+
+```bash
+pnpm authzed:backfill --apply --prune --confirm-prune --scope=all \
+  --expected-endpoint=<host:port>
+```
+
+Before running this, read §4.
+
+**Scope it down when you can.** If the drift is one tenant, `--organization-id=<cuid>` is the smaller
+blast radius. It reports `orphanScope: "known_resources"` because a resource whose row is already gone
+is unreachable from its organization; only `--scope=all` can claim completeness.
+
+**Resuming.** A run reports `lastOrganizationId`. Feed it back:
+
+```bash
+pnpm authzed:backfill --apply --after-organization-id=<cuid>
+```
+
+**Per-unit failures.** One organization failing does not abort the sweep; it lands in `failures` with a
+code, and the run exits `1`. Re-running is the fix — successful units simply re-converge.
+
+**`truncated: true`** means an observation was abandoned mid-read. Treat the orphan counts as a floor,
+not a total, and re-run before concluding anything.
+
+## 4. Before you prune
+
+`--prune` is the only destructive mode, and the guards are deliberately inconvenient.
+
+**Confirm which instance you are about to rewrite.** `--expected-endpoint` must match
+`AUTHZED_ENDPOINT`. This is the guard against a stale `.env`, and it matters more than it looks:
+
+> **These commands load `.env` and ignore `.env.local`.** Next.js prefers `.env.local`, so the instance
+> the CLI rewrites is not necessarily the one your dev server talks to.
+
+`AUTHZED_SYSTEM_KEY` is **not** usable for this. It is documented as a stable namespace and defaults to
+`formbricks` everywhere, so it cannot tell staging from production.
+
+**"No prune" does not mean "no deletes."** Converging a membership inherently deletes the roles it does
+not hold. What `--prune` adds is permission to reconcile records observed *only* in SpiceDB.
+
+**A large orphan count is a symptom, not a workload.** Exceeding the per-run cap (500, lowerable with
+`--max-prune`, never raisable) prunes *nothing* for that unit and reports it. Before raising your
+expectations, check: right endpoint? right database? a restore in progress? `--scope=all` on a SpiceDB
+shared with another installation?
+
+**Preconditions for `--scope=all`:**
+
+- a SpiceDB dedicated to this deployment — `AUTHZED_SYSTEM_KEY` does not yet namespace object IDs, so a
+  resource-type sweep cannot tell another installation's relationships from orphans;
+- the sweep must finish inside `--datastore-gc-window` (24 h default on the Postgres datastore); a run
+  that outlives it reports `truncated`.
+
+## 5. When AuthZed is unavailable
+
+**Nothing to do urgently.** Projection is best-effort, PostgreSQL stays authoritative, and product
+authorization is unaffected. Expect `authzed_unavailable` in logs and a rising failure counter.
+
+What matters is afterwards:
+
+1. Every projection attempted during the outage was dropped and will not be retried.
+2. Once SpiceDB is healthy, `pnpm authzed:health` returns `healthy`.
+3. Run the backfill (§3). Until it reports a clean run, assume the graph is incomplete.
+4. **Keep shadow evaluation and enforcement off until then.** A clean run reports
+   `completedAtSnapshot` — hand that revision to shadow evaluation (ENG-1738) as its freshness floor
+   rather than guessing whether the graph is warm.
+
+To stop projecting entirely, set `AUTHZED_ENABLED=0`. Projections become no-ops and no client is
+constructed; product authorization is untouched because it still runs on the legacy evaluator. Drift
+accumulates for the whole period, so a full backfill is required before re-enabling.
+
+## 6. Alerting
+
+Suggested rules. Thresholds are starting points — tune to deployment size.
+
+```promql
+# Warning: projections are failing. Drift is accumulating and a backfill will be needed.
+sum(rate(formbricks_authzed_projection_total{status="failed"}[5m])) > 0
+# for: 15m
+
+# Critical: SpiceDB is unreachable rather than slow.
+sum(rate(formbricks_authzed_request_failures_total{code="authzed_unavailable"}[5m])) > 0
+# for: 10m
+
+# Warning: degraded, not down. Often connection-pool pressure — check pgxpool_empty_acquire.
+sum(rate(formbricks_authzed_request_retries_total[5m]))
+  / sum(rate(formbricks_authzed_projection_total[5m])) > 0.1
+# for: 15m
+
+# Critical: AuthZed is switched off where it is expected to be on.
+sum(rate(formbricks_authzed_projection_total{status="disabled"}[15m])) > 0
+# for: 30m
+
+# Warning: projection latency is on the request path.
+histogram_quantile(0.95, sum(rate(formbricks_authzed_projection_duration_ms_bucket[5m])) by (le)) > 500
+# for: 15m
+```
+
+Every one of these resolves to the same first action: **run the backfill and confirm a clean run.**
+
+A Helm `PrometheusRule` template shipping these by default is deliberately not part of this change —
+that belongs with the AuthZed deployment contract rather than the application.
+
+## 7. Escalation
+
+| Situation | Action |
+| --- | --- |
+| Backfill reports `failures` that persist across runs | Capture the `code` values and the run's JSON. A non-retryable code (`authzed_unauthenticated`, `authzed_permission_denied`, `authzed_invalid_request`) is a configuration problem, not a transient one. |
+| Orphan count exceeds the cap and the endpoint is correct | Do not raise the cap. Establish why first — a wrong database or an in-progress restore both look like this. |
+| `unmanaged` relationships reported | Something other than Formbricks is writing to this SpiceDB, or the schema moved ahead of its projector. Never pruned; investigate before enforcing. |
+| Schema check reports `drifted` | `pnpm authzed:schema apply --expected-current-digest <remoteDigest>`. Relationship repair against a drifted schema is not meaningful. |
+| Sync cannot be restored and enforcement is pending | `AUTHZED_ENABLED=0` and note that a full backfill is required before re-enabling. |

--- a/authzed/RUNBOOK.md
+++ b/authzed/RUNBOOK.md
@@ -129,6 +129,24 @@ Before running this, read §4.
 blast radius. It reports `orphanScope: "known_resources"` because a resource whose row is already gone
 is unreachable from its organization; only `--scope=all` can claim completeness.
 
+**One workspace.** `--workspace-id=<cuid>` is narrower still, and unlike an organization the workspace
+does not have to exist — a workspace whose row is gone is the case most worth repairing:
+
+```bash
+# Converge one workspace's team and API-key grants.
+pnpm authzed:backfill --apply --workspace-id=<cuid>
+
+# Remove the relationships of a workspace whose row is gone. This is a prune — every relationship on
+# that workspace goes, team and API-key grants included — so it takes the prune flags, not --apply
+# alone. Without them the run reports the orphans and removes nothing.
+pnpm authzed:backfill --apply --prune --confirm-prune --workspace-id=<cuid> \
+  --expected-endpoint=<host:port>
+```
+
+Narrow, but not hermetic: the API keys holding grants on that workspace are reconciled in full, which
+also converges their grants on *other* workspaces. That direction only ever writes what PostgreSQL
+says, so the effect is a wider repair than you asked for, never a deletion outside the workspace named.
+
 **Resuming.** A run reports `lastOrganizationId`. Feed it back:
 
 ```bash

--- a/authzed/RUNBOOK.md
+++ b/authzed/RUNBOOK.md
@@ -76,7 +76,11 @@ query covers all of them:
 | `errorName` | post-commit boundary only | Error *class* name when a projector itself threw. |
 
 ```
+# Projections that failed — the drift signal. `status` is on projection outcomes only, which is what
+# this wants: a request-layer failure inside a projection surfaces here too.
 component:"authzed" AND status:"failed"
+
+# Any AuthZed failure of one kind, at either layer.
 component:"authzed" AND errorCode:"authzed_unavailable"
 ```
 
@@ -156,8 +160,12 @@ pnpm authzed:backfill --apply --after-organization-id=<cuid>
 **Per-unit failures.** One organization failing does not abort the sweep; it lands in `failures` with a
 code, and the run exits `1`. Re-running is the fix — successful units simply re-converge.
 
-**`truncated: true`** means an observation was abandoned mid-read. Treat the orphan counts as a floor,
-not a total, and re-run before concluding anything.
+**`truncated: true`** means the counters are not exact, from one of two causes that err in opposite
+directions. Either an observation was abandoned mid-read, so fewer relationships were seen than exist
+and the counts are a floor — or the sweep's deduplication bound was exceeded, so records implied by
+more than one page beyond that point are counted twice and the counts may over-report. The second only
+happens at a scale orders of magnitude past the prune cap, so nothing is deleted on the strength of it.
+Either way, re-run before concluding anything.
 
 ### Reading the drift counters
 

--- a/authzed/RUNBOOK.md
+++ b/authzed/RUNBOOK.md
@@ -199,11 +199,22 @@ Either way, re-run before concluding anything.
   every owner and manager of the named organization has access to that resource through
   `organization->manage`, and no PostgreSQL row explains it. The backfill reports these and deliberately
   never removes them, because deleting a parent edge means deleting a relation the resource legitimately
-  needs one of. Confirm the true owner in PostgreSQL, then remove the wrong edge by hand:
+  needs one of. Confirm the true owner in PostgreSQL, then remove the wrong edge by hand.
+
+  **Read the reported `relation` first — it decides which command applies**, because two relationship
+  shapes state ownership and the organization sits on opposite sides of them:
 
   ```bash
+  # relation == "organization": the child's own parent edge.
   zed relationship delete <childType>:<childId> organization organization:<wrongOrganizationId>
+
+  # any other relation (an organization-level API-key access grant, e.g. api_key_reader/api_key_writer):
+  # resource and subject are reversed.
+  zed relationship delete organization:<wrongOrganizationId> <relation> <childType>:<childId>
   ```
+
+  Running the first command against the second case deletes nothing and leaves the grant — still handing
+  `manage_access` over another tenant's organization — so check the field rather than assuming.
 
   Then re-run step 2 to confirm the correct edge is present, and work out how it was written — nothing in
   Formbricks creates one.

--- a/authzed/RUNBOOK.md
+++ b/authzed/RUNBOOK.md
@@ -162,6 +162,12 @@ not a total, and re-run before concluding anything.
   Then re-run step 2 to confirm the correct edge is present, and work out how it was written — nothing in
   Formbricks creates one.
 
+  **Only `--scope=all` can find one.** The escalation is an edge on *another* tenant's resource naming
+  the organization you are investigating, and a `--organization-id` run reads only the resources
+  PostgreSQL says that organization owns — so it never reads the offending resource. A single-tenant run
+  reporting `mismatchedParents: 0` means "none among this tenant's own resources", **not** "this tenant
+  is not being targeted". Investigating a suspected escalation means a full sweep.
+
 ## 4. Before you prune
 
 `--prune` is the only destructive mode, and the guards are deliberately inconvenient.
@@ -179,7 +185,9 @@ not a total, and re-run before concluding anything.
 not hold. What `--prune` adds is permission to reconcile records observed *only* in SpiceDB.
 
 **A large orphan count is a symptom, not a workload.** Exceeding the per-run cap (500, lowerable with
-`--max-prune`, never raisable) prunes *nothing* for that unit and reports it. Before raising your
+`--max-prune`, never raisable) prunes *nothing* — not a capped subset — and reports it. Every unit,
+the streamed whole-deployment sweep included, counts its orphans to completion before deleting any of
+them, so the cap aborts before the first delete rather than part-way through. Before raising your
 expectations, check: right endpoint? right database? a restore in progress? `--scope=all` on a SpiceDB
 shared with another installation?
 

--- a/docker/authzed-smoke.sh
+++ b/docker/authzed-smoke.sh
@@ -534,6 +534,15 @@ jq --exit-status '.status == "drifted" and .orphaned >= 300 and .pruned == 0 and
 backfill_capped="$(authzed_backfill "${AUTHZED_TOKEN}" prune-capped)"
 jq --exit-status '.pruned == 0 and .skipped == 1 and .handedOverCount == 0' <<<"${backfill_capped}" >/dev/null
 
+# The cap has to be decided against the whole sweep, not per page. 280 is above one 250-relationship
+# page and below the seeded total, so a per-page check would delete the first page and halt on the
+# second — revoking a cap's worth of live access on a run aimed at the wrong database, where the guard
+# exists to revoke none. This is the multi-page case; the assertion above only exceeds the cap on page
+# one, so it cannot distinguish the two.
+backfill_page_capped="$(authzed_backfill "${AUTHZED_TOKEN}" prune-page-capped)"
+jq --exit-status '.pruned == 0 and .skipped == 1 and .handedOverCount == 0 and .orphaned >= 300' \
+  <<<"${backfill_page_capped}" >/dev/null
+
 backfill_prune="$(authzed_backfill "${AUTHZED_TOKEN}" prune)"
 jq --exit-status \
   '.status == "reconciled" and .pruned >= 300 and .handedOverCount > 0 and .truncated == false' \
@@ -556,7 +565,7 @@ backfill_repeated="$(authzed_backfill "${AUTHZED_TOKEN}" report)"
 [[ "${backfill_repeated}" == "${backfill_after_cleanup}" ]]
 
 service_logs="$(compose logs --no-color postgres authzed-db-bootstrap spicedb-migrate spicedb)"
-application_outputs="${empty_schema_health}${wrong_token_health}${empty_schema_check}${initial_apply}${matched_schema_check}${unchanged_apply}${drift_schema_write}${drifted_schema_check}${restored_apply}${refused_relationship_driver}${owner_projection}${billing_projection}${idempotent_billing_projection}${deleted_projection}${idempotent_deleted_projection}${api_key_seed}${downgraded_api_key}${removed_api_key_scope}${deleted_api_key}${idempotent_deleted_api_key}${team_workspace_seed}${downgraded_manager_grant}${removed_reader_grant}${removed_alice_memberships}${team_workspace_reseed}${deleted_manager_team}${idempotent_deleted_manager_team}${team_workspace_reseed_for_delete}${deleted_graph_workspace}${idempotent_deleted_graph_workspace}${persisted_team_workspace_seed}${persisted_api_key_seed}${unavailable_health}${unavailable_projection}${restored_health}${restored_projection}${persisted_schema_check}${refused_backfill_driver}${backfill_seed}${backfill_observation}${backfill_report}${backfill_capped}${backfill_prune}${backfill_cleanup}${backfill_after_cleanup}${backfill_repeated}"
+application_outputs="${empty_schema_health}${wrong_token_health}${empty_schema_check}${initial_apply}${matched_schema_check}${unchanged_apply}${drift_schema_write}${drifted_schema_check}${restored_apply}${refused_relationship_driver}${owner_projection}${billing_projection}${idempotent_billing_projection}${deleted_projection}${idempotent_deleted_projection}${api_key_seed}${downgraded_api_key}${removed_api_key_scope}${deleted_api_key}${idempotent_deleted_api_key}${team_workspace_seed}${downgraded_manager_grant}${removed_reader_grant}${removed_alice_memberships}${team_workspace_reseed}${deleted_manager_team}${idempotent_deleted_manager_team}${team_workspace_reseed_for_delete}${deleted_graph_workspace}${idempotent_deleted_graph_workspace}${persisted_team_workspace_seed}${persisted_api_key_seed}${unavailable_health}${unavailable_projection}${restored_health}${restored_projection}${persisted_schema_check}${refused_backfill_driver}${backfill_seed}${backfill_observation}${backfill_report}${backfill_capped}${backfill_page_capped}${backfill_prune}${backfill_cleanup}${backfill_after_cleanup}${backfill_repeated}"
 if [[ "${service_logs}${application_outputs}" == *"${AUTHZED_TOKEN}"* || \
   "${service_logs}${application_outputs}" == *"${WRONG_AUTHZED_TOKEN}"* || \
   "${service_logs}${application_outputs}" == *"${AUTHZED_DATABASE_PASSWORD}"* || \

--- a/docker/authzed-smoke.sh
+++ b/docker/authzed-smoke.sh
@@ -512,7 +512,9 @@ jq --exit-status '.status == "matched" and .differenceCount == 0' <<<"${persiste
 
 # Backfill and repair. Seeds more relationships than one read page holds, so the drainer has to page
 # and hold a single revision across pages — behaviour only a real engine can confirm.
-refused_backfill_driver="$(AUTHZED_SMOKE_NODE_ENV=production authzed_backfill "${AUTHZED_TOKEN}" report || true)"
+# Subshell: an assignment prefixing a *function* call persists in the calling shell under `set -o
+# posix`, which would leave every later driver invocation running as production and refusing to run.
+refused_backfill_driver="$( (AUTHZED_SMOKE_NODE_ENV=production authzed_backfill "${AUTHZED_TOKEN}" report) || true)"
 jq --exit-status '.status == "failed" and .code == "authzed_backfill_smoke_refused"' \
   <<<"${refused_backfill_driver}" >/dev/null
 

--- a/docker/authzed-smoke.sh
+++ b/docker/authzed-smoke.sh
@@ -55,6 +55,13 @@ authzed_relationships() {
   authzed_cli "${token}" ./scripts/authzed-relationships-smoke.ts "$@"
 }
 
+authzed_backfill() {
+  local token="$1"
+  shift
+
+  authzed_cli "${token}" ./scripts/authzed-backfill-smoke.ts "$@"
+}
+
 authzed_cli() {
   local token="$1"
   local script="$2"
@@ -503,8 +510,53 @@ jq --exit-status '.status == "projected"' <<<"${restored_projection}" >/dev/null
 persisted_schema_check="$(authzed_schema "${AUTHZED_TOKEN}" check)"
 jq --exit-status '.status == "matched" and .differenceCount == 0' <<<"${persisted_schema_check}" >/dev/null
 
+# Backfill and repair. Seeds more relationships than one read page holds, so the drainer has to page
+# and hold a single revision across pages — behaviour only a real engine can confirm.
+refused_backfill_driver="$(AUTHZED_SMOKE_NODE_ENV=production authzed_backfill "${AUTHZED_TOKEN}" report || true)"
+jq --exit-status '.status == "failed" and .code == "authzed_backfill_smoke_refused"' \
+  <<<"${refused_backfill_driver}" >/dev/null
+
+backfill_seed="$(authzed_backfill "${AUTHZED_TOKEN}" seed 300)"
+jq --exit-status '.status == "seeded" and .seeded == 300' <<<"${backfill_seed}" >/dev/null
+
+backfill_observation="$(authzed_backfill "${AUTHZED_TOKEN}" observe)"
+# The non-zero count matters as much as the paging: an accidentally empty observation would let every
+# assertion below pass while proving nothing.
+jq --exit-status '.status == "observed" and .relationshipCount >= 300 and .snapshotPinned == true' \
+  <<<"${backfill_observation}" >/dev/null
+
+backfill_report="$(authzed_backfill "${AUTHZED_TOKEN}" report)"
+jq --exit-status '.status == "drifted" and .orphaned >= 300 and .pruned == 0 and .handedOverCount == 0' \
+  <<<"${backfill_report}" >/dev/null
+
+# The cap exists because a large orphan count is a symptom rather than a big cleanup job. Exceeding it
+# must hand over nothing at all, not prune an arbitrary prefix.
+backfill_capped="$(authzed_backfill "${AUTHZED_TOKEN}" prune-capped)"
+jq --exit-status '.pruned == 0 and .skipped == 1 and .handedOverCount == 0' <<<"${backfill_capped}" >/dev/null
+
+backfill_prune="$(authzed_backfill "${AUTHZED_TOKEN}" prune)"
+jq --exit-status \
+  '.status == "reconciled" and .pruned >= 300 and .handedOverCount > 0 and .truncated == false' \
+  <<<"${backfill_prune}" >/dev/null
+
+backfill_cleanup="$(authzed_backfill "${AUTHZED_TOKEN}" cleanup)"
+jq --exit-status '.status == "cleaned"' <<<"${backfill_cleanup}" >/dev/null
+
+# The store also holds the fixtures the projection assertions above created, so the absolute orphan
+# count is not zero here. Asserting the delta is the stronger claim anyway: exactly the 300 seeded
+# relationships disappeared and nothing else was touched.
+backfill_orphans_before_cleanup="$(jq -r '.orphaned' <<<"${backfill_prune}")"
+backfill_after_cleanup="$(authzed_backfill "${AUTHZED_TOKEN}" report)"
+jq --exit-status --argjson before "${backfill_orphans_before_cleanup}" \
+  '.status == "drifted" and .orphaned == ($before - 300)' <<<"${backfill_after_cleanup}" >/dev/null
+
+# Idempotency, byte for byte: a second pass over unchanged state reports exactly the same thing rather
+# than doing a fresh round of work.
+backfill_repeated="$(authzed_backfill "${AUTHZED_TOKEN}" report)"
+[[ "${backfill_repeated}" == "${backfill_after_cleanup}" ]]
+
 service_logs="$(compose logs --no-color postgres authzed-db-bootstrap spicedb-migrate spicedb)"
-application_outputs="${empty_schema_health}${wrong_token_health}${empty_schema_check}${initial_apply}${matched_schema_check}${unchanged_apply}${drift_schema_write}${drifted_schema_check}${restored_apply}${refused_relationship_driver}${owner_projection}${billing_projection}${idempotent_billing_projection}${deleted_projection}${idempotent_deleted_projection}${api_key_seed}${downgraded_api_key}${removed_api_key_scope}${deleted_api_key}${idempotent_deleted_api_key}${team_workspace_seed}${downgraded_manager_grant}${removed_reader_grant}${removed_alice_memberships}${team_workspace_reseed}${deleted_manager_team}${idempotent_deleted_manager_team}${team_workspace_reseed_for_delete}${deleted_graph_workspace}${idempotent_deleted_graph_workspace}${persisted_team_workspace_seed}${persisted_api_key_seed}${unavailable_health}${unavailable_projection}${restored_health}${restored_projection}${persisted_schema_check}"
+application_outputs="${empty_schema_health}${wrong_token_health}${empty_schema_check}${initial_apply}${matched_schema_check}${unchanged_apply}${drift_schema_write}${drifted_schema_check}${restored_apply}${refused_relationship_driver}${owner_projection}${billing_projection}${idempotent_billing_projection}${deleted_projection}${idempotent_deleted_projection}${api_key_seed}${downgraded_api_key}${removed_api_key_scope}${deleted_api_key}${idempotent_deleted_api_key}${team_workspace_seed}${downgraded_manager_grant}${removed_reader_grant}${removed_alice_memberships}${team_workspace_reseed}${deleted_manager_team}${idempotent_deleted_manager_team}${team_workspace_reseed_for_delete}${deleted_graph_workspace}${idempotent_deleted_graph_workspace}${persisted_team_workspace_seed}${persisted_api_key_seed}${unavailable_health}${unavailable_projection}${restored_health}${restored_projection}${persisted_schema_check}${refused_backfill_driver}${backfill_seed}${backfill_observation}${backfill_report}${backfill_capped}${backfill_prune}${backfill_cleanup}${backfill_after_cleanup}${backfill_repeated}"
 if [[ "${service_logs}${application_outputs}" == *"${AUTHZED_TOKEN}"* || \
   "${service_logs}${application_outputs}" == *"${WRONG_AUTHZED_TOKEN}"* || \
   "${service_logs}${application_outputs}" == *"${AUTHZED_DATABASE_PASSWORD}"* || \
@@ -513,4 +565,4 @@ if [[ "${service_logs}${application_outputs}" == *"${AUTHZED_TOKEN}"* || \
   exit 1
 fi
 
-printf '%s\n' "AuthZed smoke test passed: schema lifecycle, organization/team/workspace/API-key projection, permission ladders, grant and membership revocation, idempotent cascade cleanup, health, authentication failure, bounded outage handling, migrations, and persistence were verified."
+printf '%s\n' "AuthZed smoke test passed: schema lifecycle, organization/team/workspace/API-key projection, permission ladders, grant and membership revocation, idempotent cascade cleanup, paginated relationship reads, backfill orphan detection and prune guards, health, authentication failure, bounded outage handling, migrations, and persistence were verified."

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "db:seed:clear": "turbo run db:seed -- -- --clear",
     "db:up": "pnpm dev:setup && docker compose -f docker-compose.dev.yml up -d",
     "db:down": "docker compose -f docker-compose.dev.yml down",
+    "authzed:backfill": "dotenv -e .env -v NODE_OPTIONS=--conditions=react-server -v LOG_LEVEL=fatal -- tsx --tsconfig apps/web/tsconfig.json ./apps/web/scripts/authzed-backfill.ts",
     "authzed:health": "dotenv -e .env -v NODE_OPTIONS=--conditions=react-server -v LOG_LEVEL=fatal -- tsx --tsconfig apps/web/tsconfig.json ./apps/web/scripts/authzed-health.ts",
     "authzed:schema": "dotenv -e .env -v NODE_OPTIONS=--conditions=react-server -v LOG_LEVEL=fatal -- tsx --tsconfig apps/web/tsconfig.json ./apps/web/scripts/authzed-schema.ts",
     "authzed:smoke": "bash docker/authzed-smoke.sh",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19117,7 +19117,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@7.3.5(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(@vitest/coverage-v8@4.1.6)(happy-dom@20.8.9)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.16(@types/node@25.4.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.17(@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.6)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 1.26.0
         version: 1.26.0(zod@4.3.6)
+      '@opentelemetry/api':
+        specifier: 1.9.0
+        version: 1.9.0
       '@opentelemetry/auto-instrumentations-node':
         specifier: 0.75.0
         version: 0.75.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))


### PR DESCRIPTION
## What does this PR do?

Makes AuthZed relationship-sync failures observable, and documents the recovery path that points at #8702's backfill command.

The premise worth stating first, because everything here follows from it: **projection is best-effort by design.** An AuthZed outage must never turn a successful PostgreSQL mutation into an application error. That is the right trade-off, and it means sync failures are *silent* — nothing in the product breaks when a projection is dropped, so drift accumulates until something reads SpiceDB and disagrees with PostgreSQL.

Fixes [ENG-1719](https://linear.app/formbricks/issue/ENG-1719/add-authzed-relationship-sync-observability-and-runbook)

### Metrics — the first custom instruments in the repo

Four instruments on the OpenTelemetry metrics API. The app already exports through both the Prometheus and OTLP readers configured in `instrumentation-node.ts`, and `getMeter` returns a no-op meter when neither is enabled — so recording is safe with zero configuration and costs nothing. No new dependency; `@opentelemetry/api` is promoted from transitive to declared.

| Instrument | Attributes |
|---|---|
| `formbricks_authzed_projection_total` | `operation`, `projection`, `status` |
| `formbricks_authzed_projection_duration_seconds` | same |
| `formbricks_authzed_request_failures_total` | `operation`, `code`, `retryable` |
| `formbricks_authzed_request_retries_total` | `operation`, `code` |

Wired into exactly the two places that already compute a duration and a sanitized code — `projection.ts` and `retry.ts` — so nothing new is calculated on the request path.

> **Post-review update.** A best-practices pass verified against OpenTelemetry's Prometheus translation caught a real naming defect in the duration metric — see **[Review findings](#review-findings)**.

Three decisions worth a look:

**Retries are counted separately from failures.** A retry that later succeeds never reaches the failure counter, so without this a *degraded* SpiceDB is invisible until it starts dropping writes outright. The ratio of retries to projections is the early-warning signal; AuthZed's own guidance points at connection-pool starvation (`pgxpool_empty_acquire`) as the usual cause, which the runbook links to.

**`disabled` is recorded as its own projection outcome** rather than skipped. A deployment that believes AuthZed is on while `AUTHZED_ENABLED` is off looks healthy by every other signal — same reason the health CLI exits non-zero on `disabled`.

**Every attribute is a bounded enumerable value, never an identifier.** These leave the deployment when an OTLP endpoint is configured, so an organization or user ID would be both a cardinality explosion and a privacy leak. A test asserts the exact attribute key set rather than trusting review to catch a future addition.

Deliberately **no metrics from the backfill command**. A short-lived process has no scrape window and no flush; its observability is the counters in its own JSON result and its exit code. Better to say that than leave it looking like an omission.

### One real inconsistency in the failure logs

Auditing the existing log call sites turned up a gap that would break an alert query rather than merely look untidy: **`projection-boundary.ts` logged `code` where every other AuthZed failure logs `errorCode`**, so a single query could not cover both. That boundary is the one that fires when a projector *itself* has a bug — the path you least want to miss. Renamed, and given the `status` / `retryable` fields its siblings already carry. The projection failure log was also missing `status` while its success counterpart had it.

I deliberately left `attemptCount` (request layer, "which attempt is this") and `attempts` (projection layer, "how many in total") alone — they look similar but mean different things, and the runbook documents the distinction rather than papering over it with a rename.

Otherwise the existing logs were already sanitized and complete, so this is a narrow fix rather than a sweep through Bhagya's code.

### The runbook

New [`authzed/RUNBOOK.md`](https://github.com/formbricks/formbricks/blob/tiago/eng-1719-add-authzed-relationship-sync-observability-and-runbook/authzed/RUNBOOK.md), linked from the README: symptoms, diagnosis (metrics, the log field contract, and what to correlate on the SpiceDB side), the escalation from dry run → converge → prune, what to confirm before pruning, what to do after an outage, PromQL alert sketches, and escalation.

Two things are called out because getting them wrong is expensive:

- **The commands load `.env` and ignore `.env.local`.** Next.js prefers `.env.local`, so the instance the CLI rewrites is not necessarily the one your dev server talks to — which is exactly why `--expected-endpoint` exists.
- **A large orphan count is a symptom, not a workload.** Wrong endpoint, wrong database, a restore in progress. Establish why before reaching for `--max-prune`.

The alert rules are sketches with thresholds to tune. Shipping them as a Helm `PrometheusRule` belongs with the AuthZed deployment contract rather than the application, so that is left as a follow-up rather than bolted on here.

## How should this be tested?

```bash
pnpm turbo build --filter='@formbricks/web^...'
pnpm --dir apps/web test lib/authzed modules/account
pnpm turbo run typecheck --filter=@formbricks/web
```

- **370 tests across 22 files pass**; typecheck clean.
- New `metrics.test.ts` covers each instrument, that retries and failures are counted separately, and the attribute-cardinality assertion.
- `better-auth-account-deletion.test.ts` pinned the old `code` field, so it is updated to the new contract — which is the regression proof that the rename is complete.

To see the metrics for real: set `PROMETHEUS_ENABLED=1` with `AUTHZED_ENABLED=true`, exercise a membership change, and scrape `:9464/metrics` for `formbricks_authzed_*`. With neither exporter enabled the meter is a no-op, which is the default and is covered by the tests above.

## Review findings

**The duration metric was named wrong, twice, and the second attempt is worth reading.** It started as `..._duration_ms` with `unit: "ms"` — wrong, since the semantic conventions prescribe seconds. The first fix renamed it to `..._duration` on the claim that the Prometheus exporter appends the unit as a name suffix. **It does not.** `@opentelemetry/exporter-prometheus` appends only `_total`, to monotonic sums, and emits the unit as a `# UNIT` comment — so a deployment scraping `/metrics` exposed `..._duration_bucket` while an OTLP collector normalized to `..._duration_seconds_bucket`, and the runbook's `histogram_quantile` alert silently matched nothing on the scrape path.

It is now `formbricks_authzed_projection_duration_seconds` with `unit: "s"`, recording seconds: OTLP's translation skips a unit suffix the name already carries, so that spelling is the one both exporters agree on. The test pins it and rejects both the unit-less and `_ms` forms. Worth flagging as a review lesson — a unit test can only see the *instrument* name, so nothing in the suite could have caught this; it took reading the exporter we actually ship.

**`disabled` outcomes no longer pollute the latency histogram.** They short-circuit before any work, so the zero is structural rather than measured; on a deployment with AuthZed switched off it would drag every quantile of the one signal the runbook calls user-visible toward zero. The counter still records them, which is the part that matters.

**Deliberately not changed:** the `_total` suffix on the counter. I checked both translators and the spec — each trims an existing `_total` before re-appending, so there is no `_total_total`. It does leak an exporter concern into the instrument name, but the runbook documents the Prometheus names and renaming would churn them for nothing.

**Deferred:** dot-namespaced instrument and attribute names (`authzed.operation`, `error.type` for codes) per semconv, and exporting metrics from the CLI via an explicit `forceFlush`. Both are worth doing; neither is a defect.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [ ] Ran `pnpm build` (ran `typecheck` + `vitest`; full web build not run)
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs` (none added)
- [x] Merged the latest changes onto my branch (stacked on #8702, which is on `epic/authzed`)
- [x] My changes don't cause any responsiveness issues (server-only, no UI changes)

### Appreciated

- [x] Updated the Formbricks Docs if changes were necessary (new `authzed/RUNBOOK.md`, linked from `authzed/README.md`)

---

**Stacked on #8702** (ENG-1718) — the runbook's whole recovery path is that command, so this only makes sense on top of it. Kept as a draft until #8702 merges; GitHub will retarget it to `epic/authzed` then.
