### PR TITLE
fix(taxonomy): map Hub 404 to 404 instead of a blanket 502 (ENG-1886)

### DIFF
--- a/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.test.ts
+++ b/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.test.ts
@@ -5,14 +5,17 @@ import {
   getActiveTaxonomyTree,
   getTaxonomyRun,
   listTaxonomyFields,
+  listTaxonomyNodeRecordCounts,
   listTaxonomyNodeRecords,
   listTaxonomyRuns,
   removeTaxonomyNode,
   renameTaxonomyNode,
 } from "@/modules/hub/service";
 import type { FeedbackRecordData, TaxonomyNode, TaxonomyRun } from "@/modules/hub/types";
+import { NO_CONFIG_ERROR } from "@/modules/hub/utils";
 import { getSessionUserId, requireUnifyDirectoryAccess } from "./access";
 import {
+  getV3TaxonomyNodeRecordCounts,
   getV3TaxonomyNodeRecords,
   getV3TaxonomyRun,
   getV3TaxonomyState,
@@ -36,6 +39,7 @@ vi.mock("@/modules/hub/service", () => ({
   getTaxonomyRun: vi.fn(),
   createTaxonomyRun: vi.fn(),
   listTaxonomyNodeRecords: vi.fn(),
+  listTaxonomyNodeRecordCounts: vi.fn(),
   renameTaxonomyNode: vi.fn(),
   removeTaxonomyNode: vi.fn(),
 }));
@@ -80,6 +84,23 @@ const node: TaxonomyNode = {
   updated_at: "2026-07-01T00:00:00.000Z",
 };
 
+/**
+ * Hub failures, shaped the way the SDK actually produces them: it has no `message` field to read off an
+ * RFC 9457 body, so it stringifies the whole body — internal problem URLs included — into `message`.
+ * Nothing built from these may reach the response, which is what the `toContain` guards below check.
+ */
+const HUB_INTERNAL_MARKER = "hub.formbricks.com/problems";
+const hubNotFound = {
+  status: 404,
+  message: `404 {"type":"https://${HUB_INTERNAL_MARKER}/not-found","title":"Not Found"}`,
+  detail: "",
+};
+const hubServerError = {
+  status: 500,
+  message: `500 {"type":"https://${HUB_INTERNAL_MARKER}/internal","title":"Internal Server Error"}`,
+  detail: "",
+};
+
 const record: FeedbackRecordData = {
   id: "rec-1",
   collected_at: "2026-07-01T00:00:00.000Z",
@@ -109,19 +130,15 @@ describe("listV3TaxonomyFields", () => {
     expect(await response.json()).toEqual({ data: { fields: [field], unavailable: false } });
   });
 
-  test("returns 200 with unavailable=true on a Hub error (no false gate)", async () => {
-    vi.mocked(listTaxonomyFields).mockResolvedValue({
-      data: null,
-      error: { status: 503, message: "Embeddings not configured", detail: "" },
-    });
+  test("returns 200 with a bare unavailable=true on a Hub error (no false gate, no Hub text)", async () => {
+    vi.mocked(listTaxonomyFields).mockResolvedValue({ data: null, error: hubServerError });
 
     const response = await listV3TaxonomyFields(base);
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body.data.unavailable).toBe(true);
-    expect(body.data.unavailableMessage).toBe("Embeddings not configured");
-    expect(body.data.fields).toEqual([]);
+    expect(body.data).toEqual({ fields: [], unavailable: true });
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
   });
 
   test("returns the auth Response and skips the Hub call when access is denied", async () => {
@@ -171,21 +188,27 @@ describe("getV3TaxonomyState", () => {
     expect(body.data.unavailable).toBe(false);
   });
 
-  test("returns unavailable=true when the runs call errors", async () => {
-    vi.mocked(getActiveTaxonomyTree).mockResolvedValue({
-      data: null,
-      error: { status: 500, message: "x", detail: "" },
-    });
-    vi.mocked(listTaxonomyRuns).mockResolvedValue({
-      data: null,
-      error: { status: 500, message: "boom", detail: "" },
-    });
+  test("returns a bare unavailable=true when the runs call errors, without the Hub's own text", async () => {
+    vi.mocked(getActiveTaxonomyTree).mockResolvedValue({ data: null, error: hubServerError });
+    vi.mocked(listTaxonomyRuns).mockResolvedValue({ data: null, error: hubServerError });
 
     const response = await getV3TaxonomyState(stateParams);
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body.data.unavailable).toBe(true);
+    expect(body.data).toEqual({ activeTree: null, runs: [], unavailable: true });
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
+  });
+
+  test("flags a tree outage without the Hub's own text when only the tree call errors", async () => {
+    vi.mocked(getActiveTaxonomyTree).mockResolvedValue({ data: null, error: hubServerError });
+    vi.mocked(listTaxonomyRuns).mockResolvedValue({ data: { data: [run] }, error: null });
+
+    const response = await getV3TaxonomyState(stateParams);
+    const body = await response.json();
+
+    expect(body.data).toEqual({ activeTree: null, runs: [run], unavailable: true });
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
   });
 });
 
@@ -199,15 +222,95 @@ describe("getV3TaxonomyRun", () => {
     expect(await response.json()).toEqual({ data: run });
   });
 
-  test("returns 502 on a Hub error", async () => {
+  test("returns 404, not 502, when the Hub does not have the run", async () => {
+    vi.mocked(getTaxonomyRun).mockResolvedValue({ data: null, error: hubNotFound });
+
+    const response = await getV3TaxonomyRun({ ...base, runId: run.id });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.code).toBe("not_found");
+    expect(body.detail).toBe("Taxonomy run not found");
+    expect(body.details).toEqual({ resource_type: "Taxonomy run", resource_id: run.id });
+    // Only the id the caller already sent — no run payload, and none of the Hub's own error text.
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
+    expect(JSON.stringify(body)).not.toContain(run.tenant_id);
+  });
+
+  test("returns 502 with a sanitized detail on a Hub 5xx", async () => {
+    vi.mocked(getTaxonomyRun).mockResolvedValue({ data: null, error: hubServerError });
+
+    const response = await getV3TaxonomyRun({ ...base, runId: run.id });
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.detail).toBe("Failed to load taxonomy run");
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
+  });
+
+  test("returns 502 on a connection failure, which has no status", async () => {
     vi.mocked(getTaxonomyRun).mockResolvedValue({
       data: null,
-      error: { status: 500, message: "boom", detail: "" },
+      error: { status: 0, message: "Connection error.", detail: "Connection error." },
     });
 
     const response = await getV3TaxonomyRun({ ...base, runId: run.id });
 
     expect(response.status).toBe(502);
+  });
+
+  test("returns 503 when the Hub integration is not configured", async () => {
+    vi.mocked(getTaxonomyRun).mockResolvedValue({ data: null, error: { ...NO_CONFIG_ERROR } });
+
+    const response = await getV3TaxonomyRun({ ...base, runId: run.id });
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.code).toBe("service_unavailable");
+    // The sentinel names the env var; the response must not.
+    expect(body.detail).not.toContain("HUB_API_KEY");
+  });
+
+  test("returns 502 when the Hub reports success but no payload", async () => {
+    vi.mocked(getTaxonomyRun).mockResolvedValue({ data: null, error: null });
+
+    const response = await getV3TaxonomyRun({ ...base, runId: run.id });
+
+    expect(response.status).toBe(502);
+  });
+});
+
+describe("getV3TaxonomyNodeRecordCounts", () => {
+  test("returns the per-node counts on success", async () => {
+    const counts = [{ node_id: node.id, record_count: 12 }];
+    vi.mocked(listTaxonomyNodeRecordCounts).mockResolvedValue({ data: { counts }, error: null });
+
+    const response = await getV3TaxonomyNodeRecordCounts({ ...base, runId: run.id });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ data: { counts } });
+  });
+
+  test("returns 404, not 502, when the Hub does not have the run", async () => {
+    vi.mocked(listTaxonomyNodeRecordCounts).mockResolvedValue({ data: null, error: hubNotFound });
+
+    const response = await getV3TaxonomyNodeRecordCounts({ ...base, runId: run.id });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.details).toEqual({ resource_type: "Taxonomy run", resource_id: run.id });
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
+  });
+
+  test("returns 502 with a sanitized detail on a Hub 5xx", async () => {
+    vi.mocked(listTaxonomyNodeRecordCounts).mockResolvedValue({ data: null, error: hubServerError });
+
+    const response = await getV3TaxonomyNodeRecordCounts({ ...base, runId: run.id });
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.detail).toBe("Failed to load record counts");
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
   });
 });
 
@@ -226,15 +329,28 @@ describe("getV3TaxonomyNodeRecords", () => {
     expect(body.meta).toEqual({ limit: 100 });
   });
 
-  test("returns 502 on a Hub error", async () => {
-    vi.mocked(listTaxonomyNodeRecords).mockResolvedValue({
-      data: null,
-      error: { status: 500, message: "boom", detail: "" },
-    });
+  test("returns 404, not 502, when the Hub does not have the node", async () => {
+    vi.mocked(listTaxonomyNodeRecords).mockResolvedValue({ data: null, error: hubNotFound });
 
     const response = await getV3TaxonomyNodeRecords({ ...base, nodeId: node.id, limit: 100 });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.details).toEqual({ resource_type: "Taxonomy node", resource_id: node.id });
+    // No record sample leaks onto the not-found path.
+    expect(body).not.toHaveProperty("data");
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
+  });
+
+  test("returns 502 with a sanitized detail on a Hub 5xx", async () => {
+    vi.mocked(listTaxonomyNodeRecords).mockResolvedValue({ data: null, error: hubServerError });
+
+    const response = await getV3TaxonomyNodeRecords({ ...base, nodeId: node.id, limit: 100 });
+    const body = await response.json();
 
     expect(response.status).toBe(502);
+    expect(body.detail).toBe("Failed to load feedback records");
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
   });
 });
 
@@ -287,6 +403,28 @@ describe("triggerV3TaxonomyRun", () => {
     expect(response.status).toBe(401);
     expect(createTaxonomyRun).not.toHaveBeenCalled();
   });
+
+  test("keeps a Hub 404 as a 502 — there is no resource to report missing on a create", async () => {
+    vi.mocked(createTaxonomyRun).mockResolvedValue({ data: null, error: hubNotFound });
+
+    const response = await triggerV3TaxonomyRun(runParams);
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.detail).toBe("Failed to start taxonomy generation");
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
+  });
+
+  test("returns 502 with a sanitized detail on a Hub 5xx", async () => {
+    vi.mocked(createTaxonomyRun).mockResolvedValue({ data: null, error: hubServerError });
+
+    const response = await triggerV3TaxonomyRun(runParams);
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.detail).toBe("Failed to start taxonomy generation");
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
+  });
 });
 
 describe("renameV3TaxonomyNode", () => {
@@ -300,15 +438,26 @@ describe("renameV3TaxonomyNode", () => {
     expect(await response.json()).toEqual({ data: renamed });
   });
 
-  test("returns 502 on a Hub error", async () => {
-    vi.mocked(renameTaxonomyNode).mockResolvedValue({
-      data: null,
-      error: { status: 500, message: "boom", detail: "" },
-    });
+  test("returns 404, not 502, when the node was already removed", async () => {
+    vi.mocked(renameTaxonomyNode).mockResolvedValue({ data: null, error: hubNotFound });
 
     const response = await renameV3TaxonomyNode({ ...base, nodeId: node.id, label: "Copilot" });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.details).toEqual({ resource_type: "Taxonomy node", resource_id: node.id });
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
+  });
+
+  test("returns 502 with a sanitized detail on a Hub 5xx", async () => {
+    vi.mocked(renameTaxonomyNode).mockResolvedValue({ data: null, error: hubServerError });
+
+    const response = await renameV3TaxonomyNode({ ...base, nodeId: node.id, label: "Copilot" });
+    const body = await response.json();
 
     expect(response.status).toBe(502);
+    expect(body.detail).toBe("Failed to rename taxonomy node");
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
   });
 });
 
@@ -321,14 +470,25 @@ describe("removeV3TaxonomyNode", () => {
     expect(response.status).toBe(204);
   });
 
-  test("returns 502 on a Hub error", async () => {
-    vi.mocked(removeTaxonomyNode).mockResolvedValue({
-      data: null,
-      error: { status: 500, message: "boom", detail: "" },
-    });
+  test("returns 404, not 502, when the node was already removed", async () => {
+    vi.mocked(removeTaxonomyNode).mockResolvedValue({ data: null, error: hubNotFound });
 
     const response = await removeV3TaxonomyNode({ ...base, nodeId: node.id });
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.details).toEqual({ resource_type: "Taxonomy node", resource_id: node.id });
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
+  });
+
+  test("returns 502 with a sanitized detail on a Hub 5xx", async () => {
+    vi.mocked(removeTaxonomyNode).mockResolvedValue({ data: null, error: hubServerError });
+
+    const response = await removeV3TaxonomyNode({ ...base, nodeId: node.id });
+    const body = await response.json();
 
     expect(response.status).toBe(502);
+    expect(body.detail).toBe("Failed to remove taxonomy node");
+    expect(JSON.stringify(body)).not.toContain(HUB_INTERNAL_MARKER);
   });
 });

--- a/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.ts
+++ b/apps/web/app/api/v3/unify-feedback/taxonomy/lib/operations.ts
@@ -2,6 +2,8 @@ import "server-only";
 import {
   noContentResponse,
   problemBadGateway,
+  problemNotFound,
+  problemServiceUnavailable,
   problemUnauthorized,
   successListResponse,
   successResponse,
@@ -19,6 +21,7 @@ import {
   renameTaxonomyNode,
 } from "@/modules/hub/service";
 import type { TaxonomyScopeInput, TaxonomyScopeType } from "@/modules/hub/types";
+import { type HubError, isHubNotConfigured } from "@/modules/hub/utils";
 import { getSessionUserId, requireUnifyDirectoryAccess } from "./access";
 
 type TBaseParams = {
@@ -53,10 +56,61 @@ function buildTaxonomyScope(
   };
 }
 
+type THubFailureOptions = {
+  requestId: string;
+  instance: string;
+  /** The 502 detail. Static text only — never the Hub's own message (see below). */
+  fallbackDetail: string;
+  /**
+   * When set, a Hub 404 maps to a 404 for this resource. Omit it on creates, where "not found" says
+   * nothing useful about the request.
+   */
+  notFound?: { resourceType: string; resourceId: string };
+};
+
+/**
+ * Turns a failed Hub call into the right problem response.
+ *
+ * Not every Hub failure is a fault: a 404 is the benign "gone, or never existed" — a stale run id, a
+ * node someone else just removed — and returning that as a 502 both misreads to the caller as a server
+ * crash and counts a normal outcome towards the 5xx rate. NO_CONFIG means the integration is switched
+ * off on this deployment, which is a 503. Everything else — 5xx, timeout, connection, or a null payload
+ * with no error at all — is a genuine upstream failure and stays a 502.
+ *
+ * The 404 is not an existence oracle: every caller checks directory access first and scopes the Hub
+ * call by `tenant_id`, so it only ever means "not in *your* directory".
+ *
+ * The Hub's own error text is never relayed. The SDK folds the entire RFC 9457 problem body into
+ * `message`, so echoing it puts internal Hub URLs and problem codes into a customer-facing response.
+ * The full error is already logged in `@/modules/hub/service`; correlate on `requestId`.
+ */
+function hubFailureResponse(error: HubError | null, options: THubFailureOptions): Response {
+  const { requestId, instance, fallbackDetail, notFound } = options;
+
+  if (error) {
+    if (error.status === 404 && notFound) {
+      return problemNotFound(requestId, notFound.resourceType, notFound.resourceId, instance);
+    }
+    if (isHubNotConfigured(error)) {
+      return problemServiceUnavailable(
+        requestId,
+        "The Hub integration is not configured on this deployment.",
+        instance
+      );
+    }
+  }
+
+  return problemBadGateway(requestId, fallbackDetail, instance);
+}
+
 /**
  * `fields` and `state` return 200 with an `unavailable` flag on Hub error / NO_CONFIG (mirroring the
  * legacy actions) so a transient Hub blip never trips a false "not enough feedback"/"embedding" gate.
- * The other endpoints return 502 so React Query surfaces an error state and the UI can retry.
+ * The other endpoints return a problem response (see `hubFailureResponse`) so React Query surfaces an
+ * error state and the UI can retry.
+ *
+ * The flag carries no message on purpose: the UI renders a localized alert off the boolean, so any
+ * string sent from here would either go unused or ship untranslated.
  */
 
 export async function listV3TaxonomyFields(params: TBaseParams): Promise<Response> {
@@ -74,14 +128,7 @@ export async function listV3TaxonomyFields(params: TBaseParams): Promise<Respons
 
   const result = await listTaxonomyFields(directoryId);
   if (result.error) {
-    return successResponse(
-      {
-        fields: [],
-        unavailable: true,
-        unavailableMessage: result.error.message || "Taxonomy fields are unavailable",
-      },
-      { requestId }
-    );
+    return successResponse({ fields: [], unavailable: true }, { requestId });
   }
 
   return successResponse({ fields: result.data?.data ?? [], unavailable: false }, { requestId });
@@ -125,15 +172,7 @@ export async function getV3TaxonomyState(
   ]);
 
   if (runs.error) {
-    return successResponse(
-      {
-        activeTree: null,
-        runs: [],
-        unavailable: true,
-        unavailableMessage: runs.error.message || "Taxonomy runs are unavailable",
-      },
-      { requestId }
-    );
+    return successResponse({ activeTree: null, runs: [], unavailable: true }, { requestId });
   }
 
   // A 404 from the active-tree endpoint means "no active taxonomy yet", not an outage.
@@ -143,9 +182,6 @@ export async function getV3TaxonomyState(
       activeTree: activeTree.error?.status === 404 ? null : (activeTree.data ?? null),
       runs: runs.data?.data ?? [],
       unavailable: treeUnavailable,
-      unavailableMessage: treeUnavailable
-        ? activeTree.error?.message || "Active taxonomy is unavailable"
-        : undefined,
     },
     { requestId }
   );
@@ -166,7 +202,12 @@ export async function getV3TaxonomyRun(params: TBaseParams & { runId: string }):
 
   const result = await getTaxonomyRun(runId, directoryId);
   if (result.error || !result.data) {
-    return problemBadGateway(requestId, result.error?.message || "Failed to load taxonomy run", instance);
+    return hubFailureResponse(result.error, {
+      requestId,
+      instance,
+      fallbackDetail: "Failed to load taxonomy run",
+      notFound: { resourceType: "Taxonomy run", resourceId: runId },
+    });
   }
 
   return successResponse(result.data, { requestId });
@@ -189,7 +230,12 @@ export async function getV3TaxonomyNodeRecordCounts(
 
   const result = await listTaxonomyNodeRecordCounts(runId, directoryId);
   if (result.error || !result.data) {
-    return problemBadGateway(requestId, result.error?.message || "Failed to load record counts", instance);
+    return hubFailureResponse(result.error, {
+      requestId,
+      instance,
+      fallbackDetail: "Failed to load record counts",
+      notFound: { resourceType: "Taxonomy run", resourceId: runId },
+    });
   }
 
   return successResponse({ counts: result.data.counts }, { requestId });
@@ -237,11 +283,12 @@ export async function triggerV3TaxonomyRun(
     actor_id: actorId,
   });
   if (result.error || !result.data) {
-    return problemBadGateway(
+    // No `notFound` mapping: this creates a run, so a 404 says nothing useful about the request.
+    return hubFailureResponse(result.error, {
       requestId,
-      result.error?.message || "Failed to start taxonomy generation",
-      instance
-    );
+      instance,
+      fallbackDetail: "Failed to start taxonomy generation",
+    });
   }
 
   return successResponse({ run: result.data.run, inProgress: result.data.in_progress }, { requestId });
@@ -264,7 +311,12 @@ export async function getV3TaxonomyNodeRecords(
 
   const result = await listTaxonomyNodeRecords(nodeId, { tenant_id: directoryId, limit });
   if (result.error || !result.data) {
-    return problemBadGateway(requestId, result.error?.message || "Failed to load feedback records", instance);
+    return hubFailureResponse(result.error, {
+      requestId,
+      instance,
+      fallbackDetail: "Failed to load feedback records",
+      notFound: { resourceType: "Taxonomy node", resourceId: nodeId },
+    });
   }
 
   return successListResponse(result.data.data, { limit: result.data.limit }, { requestId });
@@ -294,7 +346,12 @@ export async function renameV3TaxonomyNode(
     label,
   });
   if (result.error || !result.data) {
-    return problemBadGateway(requestId, result.error?.message || "Failed to rename taxonomy node", instance);
+    return hubFailureResponse(result.error, {
+      requestId,
+      instance,
+      fallbackDetail: "Failed to rename taxonomy node",
+      notFound: { resourceType: "Taxonomy node", resourceId: nodeId },
+    });
   }
 
   return successResponse(result.data, { requestId });
@@ -318,7 +375,12 @@ export async function removeV3TaxonomyNode(params: TBaseParams & { nodeId: strin
 
   const result = await removeTaxonomyNode(nodeId, { tenant_id: directoryId, actor_id: actorId });
   if (result.error || !result.data) {
-    return problemBadGateway(requestId, result.error?.message || "Failed to remove taxonomy node", instance);
+    return hubFailureResponse(result.error, {
+      requestId,
+      instance,
+      fallbackDetail: "Failed to remove taxonomy node",
+      notFound: { resourceType: "Taxonomy node", resourceId: nodeId },
+    });
   }
 
   return noContentResponse({ requestId });

--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/lib/api-client.ts
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/lib/api-client.ts
@@ -20,14 +20,12 @@ const MUTATION_TIMEOUT_MS = 15_000;
 export type TTaxonomyFieldsResponse = {
   fields: TaxonomyFieldOption[];
   unavailable: boolean;
-  unavailableMessage?: string;
 };
 
 export type TTaxonomyStateResponse = {
   activeTree: TaxonomyTreeResponse | null;
   runs: TaxonomyRun[];
   unavailable: boolean;
-  unavailableMessage?: string;
 };
 
 export type TTriggerRunResponse = {

--- a/apps/web/modules/hub/service.ts
+++ b/apps/web/modules/hub/service.ts
@@ -423,7 +423,14 @@ export const getTaxonomyRun = async (runId: string, tenantId: string): Promise<H
     const data = await client.taxonomy.runs.retrieve(runId, { tenant_id: tenantId });
     return { data, error: null };
   } catch (err) {
-    logger.warn({ err, runId, tenantId }, "Hub: getTaxonomyRun failed");
+    // A run is polled every few seconds while it generates, so a 404 (the run was deleted, or the id is
+    // stale) would otherwise write a warning with a stack trace on every tick. It is a benign outcome —
+    // the v3 route returns a 404 of its own — so log it at debug, same as the missing tree below.
+    if (getErrorStatus(err) === 404) {
+      logger.debug({ runId, tenantId }, "Hub: taxonomy run not found");
+    } else {
+      logger.warn({ err, runId, tenantId }, "Hub: getTaxonomyRun failed");
+    }
     return createHubResultFromError(err);
   }
 };

--- a/apps/web/modules/hub/utils.test.ts
+++ b/apps/web/modules/hub/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { createHubResultFromError, getErrorProblem } from "./utils";
+import { NO_CONFIG_ERROR, createHubResultFromError, getErrorProblem, isHubNotConfigured } from "./utils";
 
 /**
  * The Hub SDK exposes the parsed problem body as `error` on its API errors. These cover the duck-typed
@@ -63,5 +63,24 @@ describe("createHubResultFromError", () => {
         problemDetail: "cursor is not valid",
       },
     });
+  });
+});
+
+describe("isHubNotConfigured", () => {
+  test("is true only for the NO_CONFIG sentinel", () => {
+    expect(isHubNotConfigured({ ...NO_CONFIG_ERROR })).toBe(true);
+  });
+
+  test("is false for a connection failure, which also has no status", () => {
+    // The SDK reports a dead socket / timeout without a status, so `getErrorStatus` returns 0 for it
+    // too. That is an upstream fault (502), not "the integration is switched off" (503).
+    const connectionFailure = createHubResultFromError(new Error("Connection error.")).error;
+
+    expect(connectionFailure?.status).toBe(0);
+    expect(isHubNotConfigured(connectionFailure!)).toBe(false);
+  });
+
+  test("is false for a Hub error with a status", () => {
+    expect(isHubNotConfigured({ status: 503, message: "Service Unavailable", detail: "" })).toBe(false);
   });
 });

--- a/apps/web/modules/hub/utils.ts
+++ b/apps/web/modules/hub/utils.ts
@@ -28,6 +28,16 @@ export const NO_CONFIG_ERROR = {
   detail: "HUB_API_KEY is not set; Hub integration is disabled.",
 } as const;
 
+/**
+ * "Hub is switched off on this deployment" — as opposed to a Hub that is configured but unreachable.
+ *
+ * `status: 0` alone cannot tell them apart: the SDK reports a connection failure or timeout without a
+ * status too, so `getErrorStatus` returns 0 for both. Match on the sentinel's message so a dead socket
+ * still reads as an upstream fault (502) while a missing config reads as "not enabled here" (503).
+ */
+export const isHubNotConfigured = (error: HubError): boolean =>
+  error.status === NO_CONFIG_ERROR.status && error.message === NO_CONFIG_ERROR.message;
+
 export const getErrorMessage = (err: unknown): string => {
   if (err instanceof Error) return err.message;
   if (typeof err === "string") return err;


### PR DESCRIPTION
## What & why

Every taxonomy v3 route collapsed **all** Hub failures into `problemBadGateway`, regardless of what the Hub actually said. So a benign **404** — a stale run id, a node someone else already removed — surfaced as **"502 Bad Gateway"**: reads like a server fault, and counts a perfectly normal outcome towards the 5xx rate.

The 502 also echoed `result.error.message`. The Hub SDK has no `message` field to read off an RFC 9457 problem body, so it stringifies the whole body into `message` — meaning internal Hub problem URLs and codes were landing in a customer-facing response:

```
502 Bad Gateway
detail: 404 {"type":"https://hub.formbricks.com/problems/not-found","title":"Not Found"}
```

`HubError.status` was already available; the taxonomy ops just weren't reading it. A new `hubFailureResponse` helper now routes on it:

| Hub returned | Before | After |
| --- | --- | --- |
| `404` | 502 | **404** (`Taxonomy run not found` / `Taxonomy node not found`) |
| NO_CONFIG | 502 | **503** (`problemServiceUnavailable`) |
| 5xx / timeout / connection / null payload | 502 | 502, with a **static** detail |

Notes on the edges:

- **No IDOR oracle.** Directory access is verified before the Hub call and every call is scoped by `tenant_id`, so a 404 only ever means "not in *your* directory".
- **Creates keep 502.** `POST /runs` gets no 404 mapping — "not found" says nothing useful about a create.
- **`isHubNotConfigured` matches the sentinel, not `status === 0`.** The SDK also reports connection failures and timeouts without a status, so matching on 0 alone would turn a dead socket into a 503. Those stay 502.
- **502 details are static.** The full Hub error is already logged server-side in `@/modules/hub/service`; correlate on `requestId`.

Two things found while in here:

- **`unavailableMessage` removed** from the `fields` / `state` responses. It carried the same raw Hub JSON, this time inside a **200** body. It is rendered nowhere — the UI switched to a localized alert in ENG-1917 and this field was left behind — and being outside `t()` it would ship untranslated English if anyone ever did render it. The `unavailable` boolean it sits next to is still live (drives the alert, the Generate gating, and `gate.ts`).
- **`getTaxonomyRun` logs a 404 at `debug`**, not `warn`. A run is polled every 5s while it generates, so a deleted run wrote a warning with a full stack trace on every tick. Matches what `getActiveTaxonomyTree` already does. The other four ops are user-click driven, so they keep `warn`.

Depends on nothing; no Hub change. Follow-up: the Hub currently returns 200-empty (not 404) on `nodes/{id}/records` for a tenant mismatch, so that one 404 mapping is unreachable until [ENG-1887](https://linear.app/formbricks/issue/ENG-1887) lands — after which this side needs no further change.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1886/triage-map-hub-404-404-instead-of-blanket-502-in-taxonomy-v3-routes

## How this was tested

- `pnpm vitest run app/api/v3/unify-feedback/taxonomy/ modules/hub/ modules/ee/unify-feedback/` → **347 passed (28 files)** ✅
- `pnpm eslint` on all six changed files → clean ✅
- `tsc --noEmit` → no new errors from this diff. One pre-existing error remains at `modules/ee/unify-feedback/topics-subtopics/lib/api-client.test.ts:196` (`triggerTaxonomyRun` call missing `scopeType`); verified it reproduces on a clean `main` via `git stash`, so it is not from this change.
- Tests added/updated in `operations.test.ts`: per call site, Hub `{status: 404}` → 404 with the right `resource_type`/`resource_id`; Hub 5xx → 502 with the static detail; NO_CONFIG → 503; connection failure (status 0, no sentinel) → 502; `{data: null, error: null}` → 502; create keeps 502 on a Hub 404. Every case also asserts the response body contains no `hub.formbricks.com/problems` marker.
- Tests added in `modules/hub/utils.test.ts` for `isHubNotConfigured`, including the connection-failure case that must **not** be treated as "not configured".

No UI change — the UI already rendered localized strings for all of these states and never showed the raw detail, so there is nothing visual to capture.

## Breaking changes

None

<!-- These are session-authenticated internal routes consumed only by our own Topics & Subtopics UI.
They are not in the public OpenAPI spec and have no external consumers, so the new 404/503 statuses
and the dropped `unavailableMessage` field cannot break an integration or a self-hosted setup. -->

## QA / Test Plan

**How to test**

- [ ] Open **Workspace → Unify → Topics & Subtopics**, pick a feedback directory with an existing taxonomy. The tree, per-node record counts and the record drilldown all load as before — this change is invisible on the happy path.
- [ ] Generate a taxonomy and watch it run to completion. The spinner, the "Generating…" state and the hand-off to the finished tree all behave as before.
- [ ] Rename a topic and remove a topic. Both still succeed, and the success/error toasts are unchanged.
- [ ] **Stale run (the main case).** With a run polling, delete that run from the Hub (or point at a run id that no longer exists) and re-open the page. In DevTools → Network, `GET /api/v3/unify-feedback/taxonomy/runs/{runId}` now returns **404** with body `detail: "Taxonomy run not found"` and `code: "not_found"` — previously **502** `bad_gateway`. On screen the behaviour is unchanged: the soft "something went wrong / retry" warning.
- [ ] **Hub off.** Unset `HUB_API_KEY` and restart. Any taxonomy call that used to 502 now returns **503** with `code: "service_unavailable"`. Confirm the body does **not** contain the string `HUB_API_KEY`. The Topics & Subtopics page shows the localized "service unavailable" alert with a Retry button, and the Generate button is disabled.
- [ ] **Hub unreachable (must stay 502).** Point `HUB_API_URL` at a dead port and restart. Calls return **502** `bad_gateway` — *not* 503. This is the case that must not be confused with "not configured".
- [ ] **No internal detail leaks.** In any of the failure cases above, inspect the raw JSON response body. It must not contain `hub.formbricks.com` or a `https://.../problems/...` URL. The `detail` should be one of the fixed strings: "Failed to load taxonomy run", "Failed to load record counts", "Failed to load feedback records", "Failed to start taxonomy generation", "Failed to rename taxonomy node", "Failed to remove taxonomy node".
- [ ] **Fields/state shape.** With the Hub unreachable, inspect `GET /api/v3/unify-feedback/taxonomy/fields` and `/state`. Both still return **200** with `unavailable: true` (they must not become 4xx/5xx — that would trip a false "not enough feedback" gate). The `unavailableMessage` field is now absent; the on-screen alert text is unchanged because it comes from the app's own translations.

**Preconditions / test data**

- A workspace on a plan with Unify / feedback directories enabled, and at least one feedback directory holding enough open-text records to generate a taxonomy.
- A user with `readWrite` on the workspace (needed for generate / rename / remove).
- Ability to restart the app with `HUB_API_KEY` / `HUB_API_URL` changed — the 503 and 502 cases can't be produced from the UI alone.
- A running Hub for the happy path.

**Risks & regressions**

- The blast radius is the six taxonomy v3 endpoints (`fields`, `state`, `runs`, `runs/{id}`, `runs/{id}/record-counts`, `nodes/{id}`, `nodes/{id}/records`). Nothing else calls `hubFailureResponse`.
- Watch the run-poll loop specifically: a run that 404s must still surface the soft warning and must not hard-error the page or stop the page rendering the rest of the taxonomy.
- `isHubNotConfigured` is the one genuinely subtle bit — re-check that a **timeout / dead socket** is still a 502 and has not been reclassified as 503.
- `unavailableMessage` was removed from the response and from the client type. Re-check that the fields/state unavailable alert still renders with its Retry button and that Generate is still disabled while unavailable.
- Log-level change on `getTaxonomyRun`: a genuine Hub 5xx on a run poll must still write a `warn` with the error; only 404s dropped to `debug`.

**Migrations / env / cutover**

- none
