### PR TITLE
fix(i18n): stop the translation scanner CLI running on import

### DIFF
--- a/packages/i18n-utils/src/scan-translations.ts
+++ b/packages/i18n-utils/src/scan-translations.ts
@@ -709,5 +709,17 @@ async function main(): Promise<void> {
   }
 }
 
-// Run the script
-void main();
+// Run the script only when this file IS the process entrypoint (`tsx src/scan-translations.ts`, i.e.
+// `pnpm scan-translations` / `pnpm i18n` / the translation-check workflow).
+//
+// This module doubles as a library: scan-translations.test.ts imports the pure helpers above. Calling
+// main() unconditionally meant that importing it started a full repo-wide scan (~1900 files under
+// apps/web) in the background, which then raced the importing test suite for the event loop and ended
+// in a process.exit() that could tear the vitest worker down mid-run. Locally the tests finish before
+// the scan gets far, so it looked fine; under CI load it surfaced as an unrelated-looking 5s test
+// timeout in the SonarQube job.
+const isProcessEntrypoint = process.argv[1] !== undefined && path.resolve(process.argv[1]) === __filename;
+
+if (isProcessEntrypoint) {
+  void main();
+}


### PR DESCRIPTION
## What & why

`packages/i18n-utils/src/scan-translations.ts` is both a CLI and a library — `scan-translations.test.ts`
imports its pure helpers (`stripComments`, `flattenKeys`, `parseLockfile`, `validateLockfile`, …) — but
the file ended with an unguarded top-level call:

```ts
// Run the script
void main();
```

So *importing* the module ran the entire validation script: a repo-wide scan of ~1900 files under
`apps/web`, plus `packages/email` and `packages/surveys`, ending in `process.exit()`.

**This is what made the SonarQube check flaky.** The background scan raced the importing test suite for
the event loop, and `main()`'s `process.exit()` could tear the vitest worker down mid-run. It surfaced
as a misleading failure — `Test timed out in 5000ms` on `validateLockfile identifies missing, outOfSync,
and extra keys` — a test that is itself trivial (two small file writes into a temp dir) and never goes
near `apps/web`. Locally the tests finish before the scan gets far, so it looked green; under CI load
(slower machine, v8 coverage instrumentation, 18 packages building in parallel) it did not.

Seen on 2026-07-31 in [this run](https://github.com/formbricks/formbricks/actions/runs/30616682441/job/91111382915),
where the test overshot the 5s default by 180ms.

The fix guards the call on the module actually being the process entrypoint. Every real caller —
`pnpm i18n`, `pnpm scan-translations`, `pnpm i18n:validate`, and the `translation-check` workflow — runs
it as `tsx src/scan-translations.ts`, so all of them are unaffected; importing now has no side effects.

I deliberately did **not** just raise `testTimeout`. The timeout was a symptom: the test was never slow
on its own merits, and bumping it would have left a repo-wide scan running underneath every
`i18n-utils` test run, with `process.exit()` still able to kill the worker. It also removes the
repo-size coupling, so the margin stops shrinking as `apps/web` grows.

## Linear ticket

No ticket — flaky-CI fix, found while syncing `main` into `epic/workflows-v1` (#8706), where this check
failed on an unrelated diff.

## How this was tested

Direct before/after evidence, by importing the module in a subprocess that then waits 4 seconds:

| | before the guard | after |
| --- | --- | --- |
| scan output | `Found 1811 files to scan in apps/web`, `26` in packages/email, `89` in packages/surveys | none |
| process survives the 4s timer | **no** — `process.exit()` killed it first | yes |

That second row is the actual failure mechanism, not just wasted work.

- `pnpm --filter @formbricks/i18n-utils test:coverage` — **80/80 passed**, duration **706ms → ~290ms**
  (no scan competing), and `files to scan` no longer appears in the test output at all
- `pnpm --filter @formbricks/i18n-utils scan-translations` — still scans all three trees and validates,
  identical behaviour to before
- `pnpm --filter @formbricks/i18n-utils typecheck` — clean
- `pnpm exec eslint . --quiet` in the package — clean

No new test: asserting "importing this module has no side effects" requires spawning a subprocess, which
is exactly the slow/flaky shape AGENTS.md warns against. The guard is a three-line invariant with the
reasoning recorded next to it, and the suite's own runtime is the practical signal — if the guard is
removed, `i18n-utils` tests slow down and start flaking again.

No UI change — no screenshots.

## QA / Test Plan

**How to test**

This is developer-tooling only; there is no product surface. Verification is CLI-level.

- [ ] Run `pnpm i18n:validate` → it scans `apps/web`, `packages/email` and `packages/surveys`, prints
      the per-tree file counts and the validation summary, and exits 0 when translations are valid.
- [ ] Introduce a deliberate problem — add a key to `apps/web/locales/en-US.json` without updating
      `apps/web/i18n.lock` — then run `pnpm i18n:validate` → it still reports the lockfile issue and
      exits non-zero. (Revert afterwards.)
- [ ] Run `pnpm i18n` → generation followed by the scan, both behaving as before.
- [ ] Open any PR touching a translation key → the **Validate Translation Keys** workflow still runs
      the scanner and still fails on an out-of-sync lockfile.

**Preconditions / test data**

- None beyond a normal `pnpm install`. No services, database or entitlements involved.

**Risks & regressions**

- The one risk is the guard being too strict and silently turning the CLI into a no-op — which would
  make `Validate Translation Keys` pass vacuously instead of catching real problems. The second and
  fourth checks above are what confirm it still fails when it should; a green run alone is not
  sufficient evidence.
- No runtime/product code is touched, so there is no user-facing blast radius.

**Migrations / env / cutover**

- none
