### PR TITLE
fix(workflows): remove phantom horizontal scrollbar from collapsed inspector

### DIFF
--- a/apps/web/modules/ee/workflows/components/inspector/workflow-inspector-panel.tsx
+++ b/apps/web/modules/ee/workflows/components/inspector/workflow-inspector-panel.tsx
@@ -27,9 +27,16 @@ export const WorkflowInspectorPanel = ({ isEditingNode }: Readonly<WorkflowInspe
         "shrink-0 overflow-hidden pb-8 transition-[width,opacity] duration-150 ease-in-out",
         isVisible ? "w-[360px] opacity-100" : "w-0 opacity-0"
       )}>
-      <div className="flex w-[360px] flex-col gap-3 self-start">
-        <WorkflowNodeConfigPanel isEditable={isEditingNode} />
-      </div>
+      {/* Only mount the fixed-width content while the panel is open. Left mounted when collapsed,
+          this 360px block lays out off-screen to the right and — even inside the `w-0`
+          `overflow-hidden` column — inflates the document's scroll width, producing a phantom
+          horizontal scrollbar (most visible after collapsing the main nav). The content is already
+          hidden (opacity-0) while collapsed, so gating the mount changes nothing visible. */}
+      {isVisible && (
+        <div className="flex w-[360px] flex-col gap-3 self-start">
+          <WorkflowNodeConfigPanel isEditable={isEditingNode} />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## What & why

The workflow editor showed a phantom horizontal scrollbar (most noticeable after collapsing the main navigation, which widens the editor and re-lays it out).

Root cause: the inspector column animates its width between `0` and `360px`, but its **inner content was a fixed `w-[360px]` block that stayed mounted while the panel was collapsed**. Even though the outer column is `w-0 overflow-hidden`, that off-screen fixed-width block still lays out to the right of the viewport and inflates the document's scroll width — so the browser renders a horizontal scrollbar.

Fix: only mount the fixed-width content while the panel is visible. It's already hidden (`opacity-0`) when collapsed, so nothing visible changes.

`apps/web/modules/ee/workflows/components/inspector/workflow-inspector-panel.tsx` — one component, gate the inner block on `isVisible`.

## Linear ticket

No ticket — found during QA of the workflows editor. Targets `epic/workflows-v1` (the feature integration branch), not `main`.

## How this was tested

Reproduced and verified in the running app (workflow editor, a node selected so the inspector mounts, then main nav collapsed):

- Measured `document.documentElement.scrollWidth − clientWidth`:
  - **Before:** `40px` (phantom horizontal overflow).
  - Isolation: hiding the inspector column → `0`; hiding the react-flow canvas → still `40` (so the canvas is not the cause).
  - Removing/zeroing the inner `w-[360px]` block (what this fix does) → **`0`**.
- `eslint` on the changed file → clean.

No visible rendering change (collapsed content was already `opacity-0`); the only effect is the scroll width no longer overflowing.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Open a workflow in the editor, select a node so the inspector panel opens on the right.
- [ ] Collapse the inspector (its collapse control) and/or collapse the main left navigation → no horizontal scrollbar appears at the bottom of the editor; the page does not scroll sideways.
- [ ] Re-select a node / expand the inspector → panel still opens at 360px with its config content intact.
- [ ] Toggle the main nav collapse/expand repeatedly with a node selected → no horizontal scrollbar at any point.

**Preconditions / test data**

- A workspace on a plan with workflows enabled (Pro trial is fine) and at least one workflow with a node to select.

**Risks & regressions**

- Inspector content now unmounts when collapsed and remounts when reopened. Confirm no unsaved-state loss on collapse/reopen (edits autosave to the workflow store, so state is driven by atoms, not local component state).

**Migrations / env / cutover**

- none
