### PR TITLE
fix(workflows): strip tags in linear time and bound the email body

### DIFF
--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -4719,7 +4719,10 @@ components:
       additionalProperties: false
     WorkflowSendEmailActionConfig:
       type: object
-      description: Send-email action with 1:1 field parity to survey Follow-ups (`ZSurveyFollowUpAction`).
+      description: |-
+        Send-email action with 1:1 field parity to survey Follow-ups (`ZSurveyFollowUpAction`).
+
+        `to`, `subject` and `body` accept an empty string on create and update, so an author can save an unfinished draft. Completeness is enforced when the workflow has to run: enabling it returns **422** `workflow_not_executable` naming each blank field, and the dry run reports them as problems.
       required:
         - to
         - from
@@ -4730,7 +4733,6 @@ components:
       properties:
         to:
           type: string
-          minLength: 1
           description: |
             Recipient: either a literal email address (e.g. a teammate) or the element id of a
             survey question / hidden field whose answer contains the respondent's email address
@@ -4751,13 +4753,11 @@ components:
             format: email
         subject:
           type: string
-          minLength: 1
           maxLength: 998
           description: |
             Email subject. Used verbatim (recall tokens are not expanded in the subject), the same as Follow-ups. Capped at RFC 5322's maximum line length.
         body:
           type: string
-          minLength: 1
           maxLength: 100000
           description: |
             Email body as HTML with recall tokens (`#recall:[elementId]/fallback:x#`). Recall tokens

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -4752,11 +4752,13 @@ components:
         subject:
           type: string
           minLength: 1
+          maxLength: 998
           description: |
-            Email subject. Used verbatim (recall tokens are not expanded in the subject), the same as Follow-ups.
+            Email subject. Used verbatim (recall tokens are not expanded in the subject), the same as Follow-ups. Capped at RFC 5322's maximum line length.
         body:
           type: string
           minLength: 1
+          maxLength: 100000
           description: |
             Email body as HTML with recall tokens (`#recall:[elementId]/fallback:x#`). Recall tokens
             are expanded against the response, the result is sanitized to a narrow HTML allowlist,

--- a/docs/api-v3-reference/src/components/schemas/WorkflowSendEmailActionConfig.yml
+++ b/docs/api-v3-reference/src/components/schemas/WorkflowSendEmailActionConfig.yml
@@ -2,6 +2,12 @@ type: object
 description: >-
   Send-email action with 1:1 field parity to survey Follow-ups
   (`ZSurveyFollowUpAction`).
+
+
+  `to`, `subject` and `body` accept an empty string on create and update, so an
+  author can save an unfinished draft. Completeness is enforced when the workflow
+  has to run: enabling it returns **422** `workflow_not_executable` naming each
+  blank field, and the dry run reports them as problems.
 required:
   - to
   - from
@@ -12,7 +18,6 @@ required:
 properties:
   to:
     type: string
-    minLength: 1
     description: >
       Recipient: either a literal email address (e.g. a teammate) or the element
       id of a
@@ -47,7 +52,6 @@ properties:
       format: email
   subject:
     type: string
-    minLength: 1
     maxLength: 998
     description: >
       Email subject. Used verbatim (recall tokens are not expanded in the
@@ -55,7 +59,6 @@ properties:
       length.
   body:
     type: string
-    minLength: 1
     maxLength: 100000
     description: >
       Email body as HTML with recall tokens (`#recall:[elementId]/fallback:x#`).

--- a/docs/api-v3-reference/src/components/schemas/WorkflowSendEmailActionConfig.yml
+++ b/docs/api-v3-reference/src/components/schemas/WorkflowSendEmailActionConfig.yml
@@ -48,12 +48,15 @@ properties:
   subject:
     type: string
     minLength: 1
+    maxLength: 998
     description: >
       Email subject. Used verbatim (recall tokens are not expanded in the
-      subject), the same as Follow-ups.
+      subject), the same as Follow-ups. Capped at RFC 5322's maximum line
+      length.
   body:
     type: string
     minLength: 1
+    maxLength: 100000
     description: >
       Email body as HTML with recall tokens (`#recall:[elementId]/fallback:x#`).
       Recall tokens

--- a/packages/workflows/src/types/actions/send-email.ts
+++ b/packages/workflows/src/types/actions/send-email.ts
@@ -16,7 +16,19 @@ import { WORKFLOW_ACTIONS } from "./enum";
  *  - `subject`: used verbatim (recall is not applied to the subject).
  *  - `from`: vestigial seed value, NOT the actual sender. Emails always send from the deployment
  *    `MAIL_FROM` (parity with Follow-ups); `from` is only used to derive the stable Message-ID domain.
+ *
+ * One deliberate divergence from that parity: `subject` and `body` are length-bounded here and
+ * unbounded in Follow-ups. Nothing else caps them — the persisted schema is permissive so authors can
+ * save work in progress — so without these the only ceiling is the 16MB proxy body cap, and every
+ * consumer that walks the body (the blankness predicate, recall expansion, sanitization) inherits it.
+ * The limits sit far above any body a person would write; Follow-ups is left alone because tightening
+ * it would have to reckon with already-stored surveys.
  */
+// Gmail clips a message past ~102KB, so a body larger than this cannot render intact anyway.
+const MAX_BODY_LENGTH = 100_000;
+// RFC 5322's maximum line length, and ~13x what a client will actually display.
+const MAX_SUBJECT_LENGTH = 998;
+
 export const ZWorkflowSendEmailActionConfig = z.object({
   to: z
     .string()
@@ -25,8 +37,8 @@ export const ZWorkflowSendEmailActionConfig = z.object({
     ),
   from: z.email(),
   replyTo: z.array(z.email()),
-  subject: z.string(),
-  body: z.string(),
+  subject: z.string().max(MAX_SUBJECT_LENGTH),
+  body: z.string().max(MAX_BODY_LENGTH),
   attachResponseData: z.boolean(),
   includeVariables: z.boolean().optional(),
   includeHiddenFields: z.boolean().optional(),

--- a/packages/workflows/src/types/content.test.ts
+++ b/packages/workflows/src/types/content.test.ts
@@ -34,6 +34,22 @@ describe("isBlankWorkflowRichText", () => {
     expect(isBlankWorkflowRichText("<p>a > b</p>")).toBe(false);
   });
 
+  test("treats an unclosed tag-shaped bracket in visible text as filled", () => {
+    // `<b` is visible text the user typed, and the `</p>` after it is a real tag. A tag body that
+    // allowed `<` would match `<b c</p>` as one tag and strip the sentence down to "a".
+    expect(isBlankWorkflowRichText("<p><b</p>")).toBe(false);
+    expect(isBlankWorkflowRichText("<p>a <b c</p>")).toBe(false);
+  });
+
+  test("strips tags in linear time", () => {
+    // Guards the `[^<>]*` tag body against regressing to `[^>]*`, which rescans to end-of-string
+    // from every `<` and turns this input into ~28s of blocked event loop. The budget is four orders
+    // of magnitude above the ~1ms this takes, so it fails only on a genuine complexity regression.
+    const start = performance.now();
+    expect(isBlankWorkflowRichText("<A".repeat(100_000))).toBe(false);
+    expect(performance.now() - start).toBeLessThan(1000);
+  });
+
   test("treats a recall-token-only body as filled", () => {
     // RecallNode.exportDOM writes the token as the element's text content, so a body that is
     // nothing but a recall reference must not be mistaken for an empty one.

--- a/packages/workflows/src/types/content.ts
+++ b/packages/workflows/src/types/content.ts
@@ -2,7 +2,16 @@
 // visible text that merely contains an angle bracket. The gate matters because the editor's
 // serializer un-escapes `&lt;`/`&gt;` back into literal brackets before storing — without it a body
 // of "<3" strips down to nothing and reads as blank.
-const HTML_TAG_PATTERN = /<\/?[a-zA-Z][^>]*>/g;
+//
+// The body of the tag excludes `<` as well as `>`, which matters for two reasons:
+//   1. It keeps matching linear. With `[^>]*`, an unterminated `<A` repeated n times makes the
+//      engine rescan to end-of-string from every `<`, i.e. O(n²) — 200KB of `<A<A…` took ~28s in a
+//      single pass, blocking the whole event loop, and the executable schema runs this on a stored
+//      body an API client controls (CodeQL js/polynomial-redos). Excluding `<` lets a failed match
+//      stop at the next `<` instead, which is linear.
+//   2. A tag genuinely cannot contain `<` — the HTML spec makes it a parse error — so this also
+//      stops a stray `<b` in visible text from consuming the real `</p>` that follows it.
+const HTML_TAG_PATTERN = /<\/?[a-zA-Z][^<>]*>/g;
 
 // Entities the editor emits for whitespace. They carry no visible content but survive tag removal.
 const HTML_WHITESPACE_ENTITY_PATTERN = /&nbsp;|&#160;|&#xa0;/gi;
@@ -20,10 +29,13 @@ const HTML_WHITESPACE_ENTITY_PATTERN = /&nbsp;|&#160;|&#xa0;/gi;
  * of a recall token is correctly treated as filled.
  *
  * Known limit: because the stored value is not guaranteed well-formed HTML (see the un-escaping
- * above), a body whose ONLY visible text is an unclosed bracket immediately followed by a letter
- * (`<b`) still reads as blank. Resolving that needs the editor to persist an unambiguous
- * representation rather than lossy HTML; until then this errs toward "blank", which nags the author
- * for more content instead of sending an empty email.
+ * above), tag detection is a regex rather than a parse, so a `<` inside an attribute value
+ * (`<p title="a<b"></p>`) ends the tag early and leaves the rest of the markup looking like visible
+ * text — an empty body then reads as filled. The editor cannot produce that: it emits only fixed
+ * `class`/`dir`/`style` attributes plus a link `href`, and a link carries text of its own. An API
+ * client can, since `body` is a free string, and the cost is one author sending themselves an empty
+ * email. Resolving it properly needs the editor to persist an unambiguous representation rather than
+ * lossy HTML.
  */
 export const isBlankWorkflowRichText = (value: string): boolean =>
   value.replaceAll(HTML_TAG_PATTERN, "").replaceAll(HTML_WHITESPACE_ENTITY_PATTERN, " ").trim().length === 0;

--- a/packages/workflows/src/types/index.test.ts
+++ b/packages/workflows/src/types/index.test.ts
@@ -180,6 +180,25 @@ describe("@formbricks/workflows", () => {
     expect(() => ZWorkflowExecutableDefinition.parse(definition)).toThrow(/missing body/);
   });
 
+  test.each([
+    { field: "subject", limit: 998 },
+    { field: "body", limit: 100_000 },
+  ] as const)("bounds the length of a send_email $field, drafts included", ({ field, limit }) => {
+    // The bound belongs to the persisted schema, not just the executable one: a draft is what an
+    // oversized body would be stored as, and every later consumer walks it.
+    const atLimit = createDefinition();
+    const withinNode = atLimit.nodes[0];
+    if (withinNode.type !== "action") throw new Error("expected send_email node");
+    withinNode.config = { ...withinNode.config, [field]: "a".repeat(limit) };
+    expect(ZWorkflowDefinition.parse(atLimit).nodes).toHaveLength(1);
+
+    const overLimit = createDefinition();
+    const overNode = overLimit.nodes[0];
+    if (overNode.type !== "action") throw new Error("expected send_email node");
+    overNode.config = { ...overNode.config, [field]: "a".repeat(limit + 1) };
+    expect(() => ZWorkflowDefinition.parse(overLimit)).toThrow();
+  });
+
   test("allows persisting a draft definition whose send_email node is incomplete", () => {
     const definition = createDefinition();
     const emailNode = definition.nodes[0];


### PR DESCRIPTION
## What & why

CodeQL fails the epic PR (#8281) with two high-severity alerts on the same line of
`packages/workflows/src/types/content.ts`. This fixes the real one and documents why the other is a
false positive.

**Alert 529 — `js/polynomial-redos` (real).** The tag-stripping regex was `/<\/?[a-zA-Z][^>]*>/g`.
Because the tag body allowed `<`, an input like `<A<A<A…` with no `>` made the engine rescan to
end-of-string from every `<` position — quadratic. Measured on the actual pattern:

| body | before | after |
| --- | --- | --- |
| 200 KB | 28.5 s (measured) | 1 ms |
| 1 MB | ~12 min (n² fit) | 4 ms |
| 16 MB | ~51 h (n² fit) | 52 ms |

Node is single-threaded, so this stalls the whole process for every tenant, not just the caller.
`body` was a bare `z.string()` with no cap, so the only ceiling was `proxyClientMaxBodySize: "16mb"`.
It is reachable server-side: `enable` and `test` parse the definition **from the database**, so you
PATCH a draft (the persisted schema is deliberately permissive) and then call enable.

Excluding `<` from the tag body makes a failed match stop at the next `<`. That also matches what a
tag can actually contain — `<` in a tag is a parse error per spec — so a stray `<b` in visible text no
longer consumes the `</p>` after it. That was the "known limit" the old doc comment recorded, so the
comment now records the remaining one instead: a `<` inside an *attribute value* ends the tag early,
which the Lexical editor cannot produce (it emits only fixed `class`/`dir`/`style` plus a link `href`,
and a link carries its own text) but an API client can.

**Also, from review:** the spec declared `minLength: 1` on `to`, `subject` and `body`, but the Zod
schema has never constrained them — a draft saves with all three blank. A validator generated from the
spec would have rejected a valid draft create/update. Removed all three minimums and stated the real
rule once at the schema level: blank is accepted on write, completeness is enforced on enable
(`422 workflow_not_executable`) and on the dry run.

Also bounds `subject` and `body` so nothing unbounded reaches the predicate, recall expansion, or
sanitization. This is a deliberate divergence from the documented Follow-ups field parity; Follow-ups
is left alone because tightening it would have to reckon with already-stored surveys.

**Alert 528 — `js/incomplete-multi-character-sanitization` (false positive, no code change).**
`isBlankWorkflowRichText` is a predicate: it returns a boolean and the tag-stripped string never
leaves the function — all five call sites consume only the boolean or the field list. Real body
sanitization happens in `apps/web/modules/email/lib/survey-response-email.ts` via `sanitizeHtml` with
a narrow allowlist (`allowedSchemes: ["http","https"]`), which is what the workflow runner calls at
`process-workflow-run-job.ts:199`. This needs **dismissing in the Security tab with that
justification** — it is not fixed by this PR, and note the regex change does not clear it: for
`<scr<script>ipt>` the stripped intermediate goes from `"ipt>"` to `"<script>"`. Still unexploitable,
same reason.

## Linear ticket

No ticket — this closes out the two CodeQL scanning threads raised in review on #8281.

## How this was tested

- `pnpm exec vitest run` in `packages/workflows` — 233 passed / 13 files ✅ (was 231; +2 new)
- `pnpm exec vitest run modules/ee/workflows` in `apps/web` — 403 passed / 37 files ✅
  (needs `pnpm build --filter=@formbricks/workflows` first; a stale `dist` fails these on the epic
  branch too, unrelated to this change)
- `pnpm turbo typecheck --filter=@formbricks/workflows` ✅
- `pnpm exec eslint` on the four changed TS files — clean ✅; `pnpm exec prettier --check` ✅
- `pnpm api:v3:bundle` + `pnpm api:v3:check` — spec back in sync ✅; `pnpm api:v3:lint` valid ✅
- Tests added: `<b`/`<p>a <b c</p>` now read as filled; a linear-time guard on 100k `<A` reps
  (1000ms budget vs ~1ms actual, so it only trips on a genuine complexity regression); at-limit and
  over-limit cases for both new bounds, asserted against the *persisted* schema since a draft is what
  an oversized body would be stored as.
- Benchmarked the before/after table above directly against both regexes; the 1MB/16MB "before"
  figures are extrapolated from the measured n² fit rather than waited out.

No UI change — this is a validator and a predicate.

## Breaking changes

None. `maxLength` on `subject`/`body` tightens the v3 request contract, but the whole workflows v3
surface is unreleased — it ships with this epic and is license-gated — so no existing integration can
be affected.

## QA / Test Plan

**How to test**

- [ ] Workflow editor → Send email step → put only `<b` in the body (nothing else) → the step no
      longer shows the "needs contents" issue and the workflow can be enabled. Before this change the
      warning stayed and enable was blocked.
- [ ] Same step → delete every character of the body → the "needs contents" issue still appears and
      enable is still blocked (`422 workflow_not_executable`). This must not regress.
- [ ] Body with `5 < 6`, `<3`, or `a > b` as its only text → still treated as filled.
- [ ] `PATCH /api/v3/workflows/{workflowId}` with a `body` of exactly 100,000 characters → `200`.
      With 100,001 → `400` validation error naming `body`.
- [ ] Same route with a `subject` of exactly 998 characters → `200`. With 999 → `400` naming
      `subject`.
- [ ] `PATCH /api/v3/workflows/{workflowId}` with `subject: ""` and `body: ""` → `200`, the draft
      saves. Then `POST /api/v3/workflows/{workflowId}/enable` → `422 workflow_not_executable` naming
      the blank fields. This is the contract the spec now documents.
- [ ] Enable a workflow and let it send once → the received email renders as before (bold, links,
      lists, recall values all intact).

**Preconditions / test data**

- Workspace on a plan with the `workflows` entitlement, and a survey with at least one ending card to
  bind the trigger to.
- A workflow with a `send_email` action, plus API-key credentials for the `PATCH` steps.

**Risks & regressions**

- The blankness rule is shared by the executable schema, the canvas issue flag, and the inspector's
  per-field errors, so re-check that all three agree: canvas badge, inline field error, and the
  enable/test response should never disagree about a missing body.
- Re-check bodies that are only a recall token — they must still count as filled.
- The new length caps sit on the persisted schema, so they apply to draft saves too, not just enable.

**Migrations / env / cutover**

- none

