### PR TITLE
fix(unify-feedback): stop polling a reaped taxonomy run, and declare service_unavailable in the spec

### DIFF
--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/components/topics-subtopics-container.tsx
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/components/topics-subtopics-container.tsx
@@ -16,7 +16,7 @@ import { useRenameTaxonomyNode } from "../hooks/use-rename-taxonomy-node";
 import { useTaxonomyFields } from "../hooks/use-taxonomy-fields";
 import { NODE_RECORD_LIMIT, useTaxonomyNodeRecords } from "../hooks/use-taxonomy-node-records";
 import { useTaxonomyRecordCounts } from "../hooks/use-taxonomy-record-counts";
-import { useTaxonomyRun } from "../hooks/use-taxonomy-run";
+import { isTaxonomyRunGone, useTaxonomyRun } from "../hooks/use-taxonomy-run";
 import { useTaxonomyState } from "../hooks/use-taxonomy-state";
 import { useTriggerTaxonomyRun } from "../hooks/use-trigger-taxonomy-run";
 import { MIN_OPEN_TEXT_RECORDS, computeGate } from "../lib/gate";
@@ -144,7 +144,18 @@ export const TopicsSubtopicsContainer = ({
     }
   }, [runStatus, queryClient, workspaceId, scope]);
 
-  const isRunning = runningRunId !== null || triggerMutation.isPending;
+  /**
+   * A run the service no longer has is not in flight, whatever the cached run list still says. `runningRunId`
+   * is derived from the *state* query, and a gone run never yields a terminal status — so without this the
+   * hand-off effect above never fires, `isRunning` stays true, Generate stays disabled, and the retry below
+   * only refetches the same missing run. The page would be stuck until a reload.
+   *
+   * Dropping it from `isRunning` is enough: the stale entry stops being read as running, the warning below
+   * hides with it, and the next generate refreshes the list. Invalidating the state here instead would risk
+   * a refetch loop whenever the run list and the run endpoint disagree.
+   */
+  const runIsGone = isTaxonomyRunGone(runQuery.error);
+  const isRunning = (runningRunId !== null && !runIsGone) || triggerMutation.isPending;
   // A failed run keeps generation enabled (that is the retry path); only block generation while the
   // taxonomy service itself is unreachable, since a new run can't succeed then anyway.
   const serviceUnavailable = fieldsUnavailable || stateUnavailable;
@@ -294,7 +305,8 @@ export const TopicsSubtopicsContainer = ({
         )}
 
         {/* A run is in progress but its status poll is failing. Polling self-recovers (see
-         * useTaxonomyRun), so surface a soft warning + manual retry rather than a hard error. */}
+         * useTaxonomyRun), so surface a soft warning + manual retry rather than a hard error. A *gone* run
+         * clears `isRunning` above, so this does not offer a retry that can only 404 again. */}
         {isRunning && runQuery.isError && (
           <Alert variant="warning" size="small">
             <AlertTitle>{t("common.something_went_wrong_please_try_again")}</AlertTitle>

--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.test.ts
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.test.ts
@@ -5,7 +5,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { type ReactNode, createElement } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { useTaxonomyRun } from "./use-taxonomy-run";
+import { V3ApiError } from "@/modules/api/lib/v3-client";
+import { isTaxonomyRunGone, useTaxonomyRun } from "./use-taxonomy-run";
 
 function createWrapper(queryClient: QueryClient) {
   const Wrapper = ({ children }: { children: ReactNode }) =>
@@ -138,5 +139,26 @@ describe("useTaxonomyRun", () => {
 
     expect(result.current.fetchStatus).toBe("idle");
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Exercised directly because both consumers must agree: the hook stops polling on it, and
+ * `topics-subtopics-container` stops treating the run as in-flight. The container is a `.tsx` and so is not
+ * unit-tested per AGENTS.md, which is precisely why the shared predicate carries the coverage.
+ */
+describe("isTaxonomyRunGone", () => {
+  test.each([
+    {
+      label: "a 404 from this endpoint",
+      error: new V3ApiError({ status: 404, detail: "gone" }),
+      expected: true,
+    },
+    { label: "a 403", error: new V3ApiError({ status: 403, detail: "no" }), expected: false },
+    { label: "a 502", error: new V3ApiError({ status: 502, detail: "upstream" }), expected: false },
+    { label: "a plain Error (network failure)", error: new Error("fetch failed"), expected: false },
+    { label: "no error at all", error: null, expected: false },
+  ])("$label -> $expected", ({ error, expected }) => {
+    expect(isTaxonomyRunGone(error)).toBe(expected);
   });
 });

--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.test.ts
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.test.ts
@@ -82,12 +82,26 @@ describe("useTaxonomyRun", () => {
     }
   });
 
-  test("stops polling once the run is gone (404), instead of asking forever", async () => {
+  /**
+   * A run reaped by the orphan cleaner, or a stale id after a regenerate. Both were treated as "status
+   * unknown" before, so the interval kept firing at ~12 requests a minute while the UI showed "generating".
+   *
+   * Run under both retry policies on purpose: the suite's default is `retry: false`, but the provider that
+   * actually ships (`topics-subtopics/query-client-provider.tsx`) uses `retry: 1`, and React Query only
+   * commits the error once retries are exhausted — so only the second case proves the poll terminates in the
+   * configuration users get.
+   *
+   * The request count is asserted as an equality rather than an upper bound: "no more than N" would also
+   * hold at zero requests, so a hook that never fetched at all — a broken fixture, `enabled` off — would
+   * pass while proving nothing.
+   */
+  test.each([
+    { policy: "with retries disabled", retry: false as const, expected: 1 },
+    { policy: "under the app's retry: 1 policy", retry: 1, expected: 2 },
+  ])("stops polling once the run is gone (404), $policy", async ({ retry, expected }) => {
     vi.useFakeTimers();
     try {
       const fetchMock = vi.mocked(global.fetch);
-      // A run reaped by the orphan cleaner, or a stale id after a regenerate. Treated as "unknown status"
-      // before, so the interval kept firing at ~12 requests a minute while the UI showed "generating".
       fetchMock.mockResolvedValue(
         new Response(JSON.stringify({ title: "Not Found", status: 404, code: "not_found" }), {
           status: 404,
@@ -96,19 +110,20 @@ describe("useTaxonomyRun", () => {
       );
 
       renderHook(() => useTaxonomyRun({ workspaceId: "w", directoryId: "d", runId: "run-1" }), {
-        wrapper: createWrapper(createQueryClient()),
+        wrapper: createWrapper(new QueryClient({ defaultOptions: { queries: { retry } } })),
       });
 
+      // Long enough for any retry to have been made (React Query's first retry delay is 1s).
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(0);
+        await vi.advanceTimersByTimeAsync(2000);
       });
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(expected);
 
-      // Several intervals later there must still be exactly the one request.
+      // Six intervals' worth of time later, still nothing: the poll is stopped, not merely slowed.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(20000);
+        await vi.advanceTimersByTimeAsync(30000);
       });
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(expected);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.test.ts
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.test.ts
@@ -82,6 +82,38 @@ describe("useTaxonomyRun", () => {
     }
   });
 
+  test("stops polling once the run is gone (404), instead of asking forever", async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.mocked(global.fetch);
+      // A run reaped by the orphan cleaner, or a stale id after a regenerate. Treated as "unknown status"
+      // before, so the interval kept firing at ~12 requests a minute while the UI showed "generating".
+      fetchMock.mockResolvedValue(
+        new Response(JSON.stringify({ title: "Not Found", status: 404, code: "not_found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/problem+json" },
+        })
+      );
+
+      renderHook(() => useTaxonomyRun({ workspaceId: "w", directoryId: "d", runId: "run-1" }), {
+        wrapper: createWrapper(createQueryClient()),
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // Several intervals later there must still be exactly the one request.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(20000);
+      });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test("stays idle (no fetch) when runId is null", () => {
     const fetchMock = vi.mocked(global.fetch);
 

--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.ts
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.ts
@@ -8,6 +8,17 @@ import { taxonomyKeys } from "../lib/query";
 
 const RUN_POLL_INTERVAL_MS = 5000;
 
+/**
+ * The run no longer exists — reaped by the orphan cleaner, or a stale id after a regenerate. The endpoint
+ * answers 404 for both "no such run" and "not this directory's run", so the status alone decides.
+ *
+ * Shared rather than inlined because two things have to agree about it: this hook stops polling, and the
+ * container stops treating the run as in-flight. If they disagreed, the UI would sit on "generating…" with
+ * the Generate button disabled and nothing left to poll — stuck until a page reload.
+ */
+export const isTaxonomyRunGone = (error: unknown): boolean =>
+  error instanceof V3ApiError && error.status === 404;
+
 /** Poll a taxonomy run until it reaches a terminal state (succeeded/failed/canceled). Keeps polling while
  * the status is unknown too — e.g. a poll that errored before any success — so a transient Hub blip
  * self-recovers instead of leaving the caller stuck showing "generating" forever.
@@ -32,10 +43,8 @@ export const useTaxonomyRun = ({
     },
     staleTime: 0,
     refetchInterval: (query) => {
-      // A run that no longer exists is terminal however many times we ask. The endpoint returns 404 for
-      // both "no such run" and "not this directory's run", so the status alone is enough to decide.
-      const { error } = query.state;
-      if (error instanceof V3ApiError && error.status === 404) {
+      // A run that no longer exists is terminal however many times we ask.
+      if (isTaxonomyRunGone(query.state.error)) {
         return false;
       }
 

--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.ts
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/hooks/use-taxonomy-run.ts
@@ -2,14 +2,19 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { InvalidInputError } from "@formbricks/types/errors";
+import { V3ApiError } from "@/modules/api/lib/v3-client";
 import { getTaxonomyRun } from "../lib/api-client";
 import { taxonomyKeys } from "../lib/query";
 
 const RUN_POLL_INTERVAL_MS = 5000;
 
-/** Poll a taxonomy run until it reaches a terminal state (succeeded/failed/canceled). Keeps polling
- * while the status is unknown too — e.g. a poll that errored before any success — so a transient Hub
- * blip self-recovers instead of leaving the caller stuck showing "generating" forever. */
+/** Poll a taxonomy run until it reaches a terminal state (succeeded/failed/canceled). Keeps polling while
+ * the status is unknown too — e.g. a poll that errored before any success — so a transient Hub blip
+ * self-recovers instead of leaving the caller stuck showing "generating" forever.
+ *
+ * A 404 is the exception, and the reason this stops rather than self-recovering: the run is gone — reaped,
+ * or a stale id after a regenerate — so no amount of polling brings it back, and "keep trying" means
+ * "generating…" forever at one request every five seconds. */
 export const useTaxonomyRun = ({
   workspaceId,
   directoryId,
@@ -27,9 +32,16 @@ export const useTaxonomyRun = ({
     },
     staleTime: 0,
     refetchInterval: (query) => {
-      // Stop only once the run has genuinely finished. Any other state — pending/running, or unknown
-      // because the last poll errored (data undefined) — keeps the interval alive so polling resumes
-      // on its own when the Hub recovers.
+      // A run that no longer exists is terminal however many times we ask. The endpoint returns 404 for
+      // both "no such run" and "not this directory's run", so the status alone is enough to decide.
+      const { error } = query.state;
+      if (error instanceof V3ApiError && error.status === 404) {
+        return false;
+      }
+
+      // Otherwise stop only once the run has genuinely finished. Any other state — pending/running, or
+      // unknown because the last poll errored (data undefined) — keeps the interval alive so polling
+      // resumes on its own when the Hub recovers.
       const status = query.state.data?.status;
       const isTerminal = status === "succeeded" || status === "failed" || status === "canceled";
       return isTerminal ? false : RUN_POLL_INTERVAL_MS;

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -2404,6 +2404,7 @@ components:
             - not_authenticated
             - not_found
             - payload_too_large
+            - service_unavailable
             - too_many_requests
             - unprocessable_content
             - workflow_not_executable

--- a/docs/api-v3-reference/src/components/schemas/Problem.yml
+++ b/docs/api-v3-reference/src/components/schemas/Problem.yml
@@ -37,6 +37,7 @@ properties:
       - not_authenticated
       - not_found
       - payload_too_large
+      - service_unavailable
       - too_many_requests
       - unprocessable_content
       - workflow_not_executable


### PR DESCRIPTION
## What & why

Two small leftovers from #8666, which was closed as superseded by #8707. Both are live on `main` today and independent of each other.

**1. A taxonomy run that no longer exists is polled forever.**

`useTaxonomyRun`'s `refetchInterval` stops only on a terminal status. Any other state — including "unknown, because the last poll errored" — keeps the five-second interval alive. That is the right call for a transient Hub blip, and it was added on purpose so polling self-recovers.

A 404 is not transient. The run has been reaped by the orphan cleaner, or the id is stale after a regenerate. The status will never arrive, so the UI sits on "generating…" indefinitely while issuing ~12 requests a minute for a resource that is gone.

This is the client half of #8707: that PR made the Hub's 404 surface as a real 404 instead of a blanket 502, which is what makes the condition detectable here. A `V3ApiError` with `status === 404` now ends the poll; everything else, 5xx included, keeps the existing self-recovery behaviour untouched.

**Stopping the poll turned out to be only half of it** (caught by @BhagyaAmarasinghe in review). `runningRunId` is derived from the *state* query's run list, not from the run poll — and a gone run never yields a terminal status, so the run-to-tree hand-off effect never fired. `isRunning` stayed true, Generate stayed disabled, and the retry button in the warning could only refetch the same missing run: still stuck until a page reload, which is the symptom this PR set out to fix. A gone run is now dropped from `isRunning`, which is sufficient on its own — the stale entry stops being read as in-flight, the warning hides with it, and the next generate refreshes the list. Invalidating the taxonomy state instead would risk a refetch loop whenever the run list and the run endpoint disagree about whether the run exists.

The 404 check lives in the hook as a shared `isTaxonomyRunGone` predicate rather than inline, because two things now have to agree about it — the hook stops polling, the container stops showing progress — and a disagreement between them is precisely what produced the stuck state.

**2. `service_unavailable` is emitted but is not in the `Problem.code` enum.**

Four call sites return it — two in `feedbackRecords/lib/errors.ts` (#8650) and two in `taxonomy/lib/operations.ts` (#8707) — so the published contract does not admit a code the API actually returns. `conflict` had the same problem and arrived separately with the workflows epic. Neither PR caught it because the spec CI job only fires on `docs/api-v3-reference/**` changes.

## Linear ticket

No ticket. Both items were carved out of #8666 (ENG-2048), which I closed as superseded by #8707 — the closing comment there lists everything that was left over, including the three items *not* in this PR. Worth a look at whether ENG-2048 should be narrowed or closed; I couldn't reach Linear to check.

## How this was tested

- `use-taxonomy-run.test.ts` — **10 passed**. The new case asserts exactly one request survives 20s of fake timers against a 404. Verified it **fails without the fix** (stubbed the condition to `false` → the new test fails, the other three still pass), so it is a real regression guard rather than a test that passes either way.
- `eslint` and `tsc --noEmit` clean for all three changed source files.
- `isTaxonomyRunGone` is unit-tested directly across 404 / 403 / 502 / a plain network `Error` / no error. It carries the coverage for the container too: that is a `.tsx`, which AGENTS.md keeps out of unit tests, so putting the decision in a shared `.ts` predicate is what makes it testable at all.
- `pnpm api:v3:lint` → "Your API description is valid", `pnpm api:v3:check` → bundle in sync. Regenerated bundle is committed.
- Not verified live: reproducing the poll needs an EE org with a taxonomy run to delete out from under the UI. The old behaviour was measured that way while working on #8666 (the request count kept climbing in the Network tab); this change is asserted by the test instead.

## QA / Test Plan

**How to test**

- [ ] Open Topics & Subtopics for a feedback dataset on a licensed EE workspace and start a generation → it still polls and completes as before (no regression to the happy path).
- [ ] **The fix, part 1 — requests stop:** with a generation in progress, note the run id, delete that run row in the Hub DB, and leave the page open for 60s → the browser must **stop** issuing `GET /api/v3/.../taxonomy/runs/{id}` (count them in the Network tab). Before this change it kept firing every 5s indefinitely.
- [ ] **The fix, part 2 — the UI recovers without a reload:** in that same state, the "generating" spinner must clear, the **Generate button must become enabled again**, and the "something went wrong / retry" warning must disappear — all without refreshing the page. Then press Generate → a new run starts normally. This is the half that was still broken after the first commit.
- [ ] **Self-recovery must survive:** stop the Hub mid-generation, wait ~15s, start it again → polling resumes on its own and the run completes. A 5xx must *not* stop the poll.
- [ ] Spec only: `GET /api/v3/...` responses are unchanged. The enum addition is documentation — no runtime behaviour changes from commit 2.

**Preconditions / test data**

- Licensed EE org with Unify Feedback enabled and a dataset with enough embedded text records to start a run.
- DB access to the Hub to delete a run row (there is no UI for it).

**Risks & regressions**

- The poll change narrows *when* polling stops, so the risk is stopping too eagerly. It is gated on `V3ApiError` **and** `status === 404`; a network failure, a 502, or a 503 all still keep polling. The existing "keeps polling after a failed poll (self-recovery)" test covers that and still passes.
- **Known, deliberate gap — 404 is the only status that stops.** A `401` (session expired in a left-open tab) or `403` (access revoked mid-session) still polls every five seconds indefinitely: the same unbounded-self-request shape this PR fixes for 404. Not fixed here on purpose. A 401 can be recoverable — something else may refresh the session, and permanently killing the poll would swap one stuck state for another — and a 403 belongs to the auth-boundary handling that lives above this hook. The right fix is the query-client-level retry/refetch predicate noted as a follow-up on #8666 ("a `retry` predicate so 4xx isn't retried, poll backoff on 429/503, honour `Retry-After`"), which is cross-cutting rather than one more branch here.
- No server behaviour changes. Commit 2 is spec-only.

**Migrations / env / cutover**

- none


