### PR TITLE
fix(mcp): surface the missing OAuth scope and fix recall search [ENG-2120]

### DIFF
--- a/apps/web/app/api/mcp/route.test.ts
+++ b/apps/web/app/api/mcp/route.test.ts
@@ -171,7 +171,7 @@ describe("POST /api/mcp", () => {
     expect(response.status).toBe(401);
     expect(response.headers.get("Content-Type")).toBe("application/problem+json");
     expect(response.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
+      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp", scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
     );
     expect(applyIPRateLimit).toHaveBeenCalled();
   });
@@ -445,7 +445,7 @@ describe("POST /api/mcp", () => {
     expect(authenticateApiKeyFromHeaders).not.toHaveBeenCalled();
     expect(applyIPRateLimit).toHaveBeenCalled();
     expect(response.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
+      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp", scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
     );
   });
 

--- a/apps/web/app/api/mcp/route.test.ts
+++ b/apps/web/app/api/mcp/route.test.ts
@@ -485,7 +485,7 @@ describe("POST /api/mcp", () => {
     expect(message.result.structuredContent.error).toMatchObject({
       status: 403,
       code: "forbidden",
-      detail: "OAuth token does not include the required MCP scope",
+      detail: expect.stringContaining("OAuth token does not include the required MCP scope:"),
       requestId: "req_read_only",
     });
   });
@@ -528,7 +528,9 @@ describe("POST /api/mcp", () => {
     expect(message.result.structuredContent.error).toMatchObject({
       status: 403,
       code: "forbidden",
-      detail: "OAuth token does not include the required MCP scope",
+      // The refusal names the scope the client must obtain, since a JSON-RPC tool result carries no
+      // WWW-Authenticate header for it to read.
+      detail: "OAuth token does not include the required MCP scope: workflows:write",
       requestId: "req_wf_read_only",
     });
     // The scope gate must fire BEFORE any mutation side effect: no audit log is built or queued for a

--- a/apps/web/app/api/mcp/route.test.ts
+++ b/apps/web/app/api/mcp/route.test.ts
@@ -485,7 +485,9 @@ describe("POST /api/mcp", () => {
     expect(message.result.structuredContent.error).toMatchObject({
       status: 403,
       code: "forbidden",
-      detail: expect.stringContaining("OAuth token does not include the required MCP scope:"),
+      // Names the scope this specific call needed, not just that some scope was missing — that is
+      // the only thing the client can act on.
+      detail: "OAuth token does not include the required MCP scope: surveys:write",
       requestId: "req_read_only",
     });
   });

--- a/apps/web/modules/mcp/auth.test.ts
+++ b/apps/web/modules/mcp/auth.test.ts
@@ -346,8 +346,10 @@ describe("authenticateMcpRequest", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.response.status).toBe(401);
-      expect(result.response.headers.get("WWW-Authenticate")).toContain(
-        'resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/mcp"'
+      // Auth-params are comma-separated (RFC 9110 `#auth-param`), so a strict client parser can read
+      // `resource_metadata` out of the challenge instead of choking on the whole tail.
+      expect(result.response.headers.get("WWW-Authenticate")).toBe(
+        'Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/mcp", scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
       );
       expect(await result.response.json()).toMatchObject({
         detail: "Invalid OAuth access token",
@@ -439,8 +441,10 @@ describe("authenticateMcpRequest", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.response.status).toBe(401);
-      expect(result.response.headers.get("WWW-Authenticate")).toContain(
-        'resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/mcp"'
+      // Auth-params are comma-separated (RFC 9110 `#auth-param`), so a strict client parser can read
+      // `resource_metadata` out of the challenge instead of choking on the whole tail.
+      expect(result.response.headers.get("WWW-Authenticate")).toBe(
+        'Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/mcp", scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
       );
       expect(await result.response.json()).toMatchObject({
         detail: "Invalid OAuth access token",

--- a/apps/web/modules/mcp/auth.ts
+++ b/apps/web/modules/mcp/auth.ts
@@ -212,9 +212,12 @@ export function withMcpResponseHeaders(response: Response, requestId: string): R
 
 function withOAuthChallenge(response: Response, scope = MCP_CHALLENGE_SCOPE): Response {
   const headers = new Headers(response.headers);
+  // Comma-separated auth-params, per the `#auth-param` list grammar in RFC 9110 §11.6.1 (as used by
+  // RFC 6750 and RFC 9728). Space-separated, a strict parser reads the whole tail as one malformed
+  // param and misses `resource_metadata` — the pointer MCP clients follow to discover this server.
   headers.set(
     "WWW-Authenticate",
-    `Bearer resource_metadata="${getMcpProtectedResourceMetadataUrl()}" scope="${scope}"`
+    `Bearer resource_metadata="${getMcpProtectedResourceMetadataUrl()}", scope="${scope}"`
   );
 
   return new Response(response.body, {

--- a/apps/web/modules/mcp/auth.ts
+++ b/apps/web/modules/mcp/auth.ts
@@ -418,9 +418,20 @@ export function hasAnyMcpScope(authInfo: AuthInfo | undefined, allowedScopes: re
   return allowedScopes.some((scope) => scopes.includes(scope));
 }
 
+/**
+ * The scopes are named in `detail`, not only in the `WWW-Authenticate` challenge, because the tool path
+ * cannot carry a header: `guardMcpScopes` hands this Response to `responseToMcpToolResult`, which
+ * serializes the JSON body into a JSON-RPC result and drops every header. Without them in the body a
+ * client that is refused a tool call learns only "some scope is missing" and cannot re-authorize for the
+ * right one. The challenge is still set for the transport-level 403, where the header does reach clients.
+ */
 export function createMcpInsufficientScopeResponse(requestId: string, scopes: string[]): Response {
   return withInsufficientScopeChallenge(
-    problemForbidden(requestId, "OAuth token does not include the required MCP scope", "/api/mcp"),
+    problemForbidden(
+      requestId,
+      `OAuth token does not include the required MCP scope: ${scopes.join(" ")}`,
+      "/api/mcp"
+    ),
     scopes
   );
 }

--- a/apps/web/modules/mcp/tools/guard-scopes.test.ts
+++ b/apps/web/modules/mcp/tools/guard-scopes.test.ts
@@ -76,7 +76,9 @@ describe("registerScopedTool", () => {
     expect((result.structuredContent as ScopeErrorContent).error).toMatchObject({
       status: 403,
       code: "forbidden",
-      detail: "OAuth token does not include the required MCP scope",
+      // The missing scope must be in the body: this result reaches the client as a JSON-RPC payload
+      // with no headers, so the WWW-Authenticate challenge cannot tell it what to re-authorize for.
+      detail: "OAuth token does not include the required MCP scope: surveys:write",
       requestId: "req_denied",
     });
   });
@@ -92,5 +94,9 @@ describe("registerScopedTool", () => {
 
     expect(handler).not.toHaveBeenCalled();
     expect(result.isError).toBe(true);
+    // Every required scope is listed, not just the first one that failed.
+    expect((result.structuredContent as ScopeErrorContent).error.detail).toContain(
+      "surveys:read surveys:write"
+    );
   });
 });

--- a/apps/web/modules/mcp/tools/surveys.test.ts
+++ b/apps/web/modules/mcp/tools/surveys.test.ts
@@ -498,7 +498,7 @@ describe("registerSurveyTools", () => {
     expect(result.structuredContent.error).toMatchObject({
       status: 403,
       code: "forbidden",
-      detail: "OAuth token does not include the required MCP scope",
+      detail: "OAuth token does not include the required MCP scope: surveys:write",
       requestId: "req_tool",
     });
   });
@@ -543,7 +543,7 @@ describe("registerSurveyTools", () => {
     expect(result.structuredContent.error).toMatchObject({
       status: 403,
       code: "forbidden",
-      detail: "OAuth token does not include the required MCP scope",
+      detail: "OAuth token does not include the required MCP scope: surveys:read",
       requestId: "req_tool",
     });
   });

--- a/apps/web/modules/mcp/tools/workflows.test.ts
+++ b/apps/web/modules/mcp/tools/workflows.test.ts
@@ -465,10 +465,12 @@ describe("MCP scope enforcement (ENG-1967)", () => {
     vi.mocked(queueV3AuditLog).mockResolvedValue(undefined);
   });
 
+  // Shared by the read and write cases below, which require different scopes; the detail names the
+  // missing one, so match its prefix here and assert the exact scope in guard-scopes.test.ts.
   const INSUFFICIENT_SCOPE = {
     status: 403,
     code: "forbidden",
-    detail: "OAuth token does not include the required MCP scope",
+    detail: expect.stringContaining("OAuth token does not include the required MCP scope:"),
   };
 
   // Every mutating tool + a representative valid input for it.

--- a/apps/web/modules/mcp/tools/workflows.test.ts
+++ b/apps/web/modules/mcp/tools/workflows.test.ts
@@ -465,13 +465,13 @@ describe("MCP scope enforcement (ENG-1967)", () => {
     vi.mocked(queueV3AuditLog).mockResolvedValue(undefined);
   });
 
-  // Shared by the read and write cases below, which require different scopes; the detail names the
-  // missing one, so match its prefix here and assert the exact scope in guard-scopes.test.ts.
-  const INSUFFICIENT_SCOPE = {
+  // The detail names the scope the denied call needed, so each case asserts its own — a regression that
+  // dropped or mislabelled the scope would slip past a generic prefix match.
+  const insufficientScope = (scope: string) => ({
     status: 403,
     code: "forbidden",
-    detail: expect.stringContaining("OAuth token does not include the required MCP scope:"),
-  };
+    detail: `OAuth token does not include the required MCP scope: ${scope}`,
+  });
 
   // Every mutating tool + a representative valid input for it.
   const writeTools: { name: string; handlerKey: keyof typeof workflowsHandlers; input: unknown }[] = [
@@ -500,7 +500,10 @@ describe("MCP scope enforcement (ENG-1967)", () => {
       expect(workflowsHandlers[handlerKey]).not.toHaveBeenCalled();
       expect(queueV3AuditLog).not.toHaveBeenCalled();
       expect(result.isError).toBe(true);
-      expect(result.structuredContent.error).toMatchObject({ ...INSUFFICIENT_SCOPE, requestId: "req_tool" });
+      expect(result.structuredContent.error).toMatchObject({
+        ...insufficientScope("workflows:write"),
+        requestId: "req_tool",
+      });
     }
   );
 
@@ -525,7 +528,10 @@ describe("MCP scope enforcement (ENG-1967)", () => {
 
     expect(workflowsHandlers.list).not.toHaveBeenCalled();
     expect(result.isError).toBe(true);
-    expect(result.structuredContent.error).toMatchObject({ ...INSUFFICIENT_SCOPE, requestId: "req_tool" });
+    expect(result.structuredContent.error).toMatchObject({
+      ...insufficientScope("workflows:read"),
+      requestId: "req_tool",
+    });
   });
 
   test("read tools succeed for a read-only token", async () => {

--- a/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
+++ b/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
@@ -19,6 +19,7 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TSurveyElement, TSurveyElementId, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey, TSurveyHiddenFields, TSurveyRecallItem } from "@formbricks/types/surveys/types";
+import { getTextContent } from "@formbricks/types/surveys/validation";
 import { getTextContentWithRecallTruncated } from "@/lib/utils/recall";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 import {
@@ -137,13 +138,15 @@ export const RecallItemSelect = ({
   }, [elementId, elements, recallItemIds, selectedLanguageCode]);
 
   const filteredRecallItems: TSurveyRecallItem[] = useMemo(() => {
+    const query = searchValue.trim().toLowerCase();
+    if (!query) return [...surveyElementRecallItems, ...hiddenFieldRecallItems, ...variableRecallItems];
+
+    // Match the label's text content, not the label itself: an element's label is its raw headline HTML
+    // (`<p class="fb-editor-paragraph">…`), so comparing against it made every query for question text
+    // miss. `includes` rather than `startsWith` so a query also matches mid-headline words, and so it
+    // still matches items whose displayed label is elided by the truncation below.
     return [...surveyElementRecallItems, ...hiddenFieldRecallItems, ...variableRecallItems].filter(
-      (recallItems) => {
-        if (searchValue.trim() === "") return true;
-        else {
-          return recallItems.label.toLowerCase().startsWith(searchValue.toLowerCase());
-        }
-      }
+      (recallItem) => getTextContent(recallItem.label).toLowerCase().includes(query)
     );
   }, [surveyElementRecallItems, hiddenFieldRecallItems, variableRecallItems, searchValue]);
 


### PR DESCRIPTION
## What & why

Three bugs found running the ENG-2120 QA, one commit each.

**1. A refused MCP tool call never says which scope is missing.** `guardMcpScopes` builds a `WWW-Authenticate: … scope="workflows:write"` challenge, then `responseToMcpToolResult` serializes only the JSON body and drops every header. A client denied `enable_workflow` on a `workflows:read` token learns only that *some* scope is missing, so it can't re-authorize for the right one. Now named in the problem `detail`, which does travel. Enforcement itself was already correct.

**2. The 401 challenge's auth-params were space-separated.** Auth-params are a comma-separated list (RFC 9110 `#auth-param`, per RFC 6750/9728). Space-separated, a strict parser reads the tail as one malformed param and misses `resource_metadata` — the pointer MCP clients follow to discover this server, so discovery can fail before consent. The 403 builder in the same file already used commas.

**3. Search in the recall dropdown matched nothing.** The filter compared the query to `recallItem.label`, which for an element is raw headline HTML (`<p class="fb-editor-paragraph">…`), so any question text gave "No recall items found". Affects the workflow `send_email` body editor and every other recall dropdown. Now compares the label's text content, `includes` so mid-headline words match.

Out of scope, filed separately: ordered lists stripped from survey Follow-Up bodies at save time (Follow-Ups only; the workflow email path keeps them), and the truncated localhost-redirect warning on the OAuth consent screen.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2120/verify-run-the-unexecuted-recall-value-escaping-qa-for-follow-up-and

## How this was tested

- `pnpm exec vitest run modules/mcp app/api/mcp modules/survey` → 70 files, 952 tests ✅. Scope-denial assertions updated in `guard-scopes.test.ts` (now pins the exact scope), `surveys.test.ts`, `workflows.test.ts`, `route.test.ts`; challenge assertions in `auth.test.ts`/`route.test.ts`. `pnpm exec eslint` on the touched modules → clean.
- Live OAuth flow on a local dev server (dynamic client registration → consent → PKCE token exchange). With a `workflows:read`-only token: `list_workspaces` 200, `list_surveys` refused, `enable_workflow` refused with `"…required MCP scope: workflows:write"` ✅.
- `curl -i -X POST localhost:3000/api/mcp` → `www-authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource/api/mcp", scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"` ✅.
- Recall search: `Preferred` and `date` both surface the "Preferred date" question; nonsense still shows the empty state ✅. Screenshot attached in a comment.

## Breaking changes

None

<!-- The MCP problem `detail` gains a `": <scopes>"` suffix. Not a contract change: `status`, `title`
and `code` are unchanged, and `detail` is human-readable prose per RFC 9457. -->

## QA / Test Plan

**How to test**

- [ ] Connect an MCP client to `/api/mcp`, grant only `workflows:read`, then call a workflow write tool (e.g. enable a workflow) → refused, error text ends with `does not include the required MCP scope: workflows:write`.
- [ ] Same read-only grant: list workspaces → succeeds; list surveys → refused, naming `surveys:read`.
- [ ] Unauthenticated `POST /api/mcp` → `401`, and `WWW-Authenticate` has a comma between `resource_metadata="…"` and `scope="…"`, listing all six resource scopes.
- [ ] Point a real MCP client at the server with no token → it discovers the server from the challenge and reaches the consent screen.
- [ ] Survey editor with two or more questions → Follow-ups → New follow-up → in Body press `@`, type part of a question's text → that question is listed; a mid-headline word → still listed; nonsense → "No recall items found".
- [ ] Same `@` search in a workflow's Send email step body → behaves identically.

**Preconditions / test data**

- An MCP client supporting remote HTTP servers with OAuth, and an HTTPS `WEBAPP_URL` (clients reject plaintext redirect/issuer URLs).
- Workflows Enterprise-licensed for the workflow tools and the Send email step.

**Risks & regressions**

- The insufficient-scope `detail` string changed; anything asserting it verbatim needs updating (all in-repo assertions are updated here).
- Recall search is a shared dropdown — also re-check `@` search in question headlines and endings, not just the two email editors.
- Only the 401 path changed; the 403 insufficient-scope challenge header is untouched.

**Migrations / env / cutover**

- none
