### PR TITLE
fix(survey): keep lists and non-URL attributes in follow-up email bodies [ENG-2120]

### DIFF
--- a/apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx
+++ b/apps/web/modules/survey/follow-ups/components/follow-up-modal.tsx
@@ -2,7 +2,6 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { createId } from "@paralleldrive/cuid2";
-import DOMpurify from "isomorphic-dompurify";
 import {
   ArrowDownIcon,
   EyeOffIcon,
@@ -32,6 +31,7 @@ import {
   type EmailSendToOption,
   buildEmailSendToOptions,
 } from "@/modules/survey/follow-ups/lib/email-send-to-options";
+import { sanitizeFollowUpBody } from "@/modules/survey/follow-ups/lib/sanitize-follow-up-body";
 import { getElementIconMap } from "@/modules/survey/lib/elements";
 import { AdvancedOptionToggle } from "@/modules/ui/components/advanced-option-toggle";
 import { Alert, AlertTitle } from "@/modules/ui/components/alert";
@@ -179,12 +179,7 @@ export const FollowUpModal = ({
         (followUp) => followUp.id === defaultValues.surveyFollowUpId
       );
 
-      const sanitizedBody = DOMpurify.sanitize(data.body, {
-        ALLOWED_TAGS: ["p", "span", "b", "strong", "i", "em", "a", "br"],
-        ALLOWED_ATTR: ["href", "rel", "dir", "class"],
-        ALLOWED_URI_REGEXP: /^https?:\/\//, // Only allow safe URLs starting with http or https
-        ADD_ATTR: ["target"], // Optional: Allow 'target' attribute for links (e.g., _blank)
-      });
+      const sanitizedBody = sanitizeFollowUpBody(data.body);
 
       const updatedFollowUp = {
         id: defaultValues.surveyFollowUpId,
@@ -228,12 +223,7 @@ export const FollowUpModal = ({
       return;
     }
 
-    const sanitizedBody = DOMpurify.sanitize(data.body, {
-      ALLOWED_TAGS: ["p", "span", "b", "strong", "i", "em", "a", "br"],
-      ALLOWED_ATTR: ["href", "rel", "dir", "class"],
-      ALLOWED_URI_REGEXP: /^https?:\/\//, // Only allow safe URLs starting with http or https
-      ADD_ATTR: ["target"], // Optional: Allow 'target' attribute for links (e.g., _blank)
-    });
+    const sanitizedBody = sanitizeFollowUpBody(data.body);
 
     const newFollowUp = {
       id: createId(),

--- a/apps/web/modules/survey/follow-ups/lib/sanitize-follow-up-body.test.ts
+++ b/apps/web/modules/survey/follow-ups/lib/sanitize-follow-up-body.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest";
+import { sanitizeFollowUpBody } from "./sanitize-follow-up-body";
+
+/** What the Body editor's list buttons serialize (Lexical numbers `<li>` explicitly). */
+const EDITOR_ORDERED_LIST =
+  '<ol class="fb-editor-list-ol"><li value="1"><span>First step</span></li><li value="2"><span>Second step</span></li></ol>';
+
+describe("sanitizeFollowUpBody", () => {
+  test("keeps an ordered list authored with the editor's list button", () => {
+    const sanitized = sanitizeFollowUpBody(EDITOR_ORDERED_LIST);
+
+    // Regression: `ul`/`ol`/`li` used to be absent from the allowlist, and DOMPurify keeps the contents
+    // of a tag it removes — so the list arrived as bare spans and the email ran the items together on
+    // one unnumbered line.
+    expect(sanitized).toMatch(/<ol\b/);
+    expect(sanitized).toMatch(/<li\b[^>]*>.*First step.*<\/li>/);
+    expect(sanitized).toMatch(/<li\b[^>]*>.*Second step.*<\/li>/);
+  });
+
+  test("keeps the numbering of a list that does not start at 1", () => {
+    const sanitized = sanitizeFollowUpBody('<ol start="3"><li value="3">Third</li></ol>');
+
+    expect(sanitized).toContain('start="3"');
+    expect(sanitized).toContain('value="3"');
+  });
+
+  test("keeps an unordered list", () => {
+    expect(sanitizeFollowUpBody("<ul><li>Only item</li></ul>")).toMatch(/<ul\b[\s\S]*<li\b/);
+  });
+
+  test("keeps rel and dir, which the URI check was also stripping", () => {
+    // Same root cause as `start`: a custom ALLOWED_URI_REGEXP is applied to every attribute DOMPurify
+    // doesn't already treat as URI-safe, so non-URL attributes were dropped for failing a URL test.
+    const sanitized = sanitizeFollowUpBody(
+      '<p dir="rtl">מימין לשמאל <a href="https://example.com" rel="noopener">link</a></p>'
+    );
+
+    expect(sanitized).toContain('dir="rtl"');
+    expect(sanitized).toContain('rel="noopener"');
+  });
+
+  test("keeps the author's inline formatting and http(s) links", () => {
+    const sanitized = sanitizeFollowUpBody(
+      '<p><strong>Bold</strong> <em>italic</em> <a href="https://example.com">link</a></p>'
+    );
+
+    expect(sanitized).toContain("<strong>Bold</strong>");
+    expect(sanitized).toContain("<em>italic</em>");
+    expect(sanitized).toContain('href="https://example.com"');
+  });
+
+  test("still strips script tags and non-http(s) schemes", () => {
+    const sanitized = sanitizeFollowUpBody(
+      '<p>hi</p><script>alert(1)</script><a href="javascript:alert(1)">x</a>'
+    );
+
+    expect(sanitized).not.toContain("<script");
+    expect(sanitized).not.toContain("javascript:");
+    expect(sanitized).toContain("<p>hi</p>");
+  });
+
+  test("still strips tags outside the allowlist, including the list-adjacent ones", () => {
+    const sanitized = sanitizeFollowUpBody(
+      "<div><h1>Heading</h1><table><tr><td>cell</td></tr></table></div>"
+    );
+
+    expect(sanitized).not.toMatch(/<(div|h1|table|tr|td)\b/);
+    // KEEP_CONTENT: the text survives even though its tags do not.
+    expect(sanitized).toContain("Heading");
+  });
+});

--- a/apps/web/modules/survey/follow-ups/lib/sanitize-follow-up-body.test.ts
+++ b/apps/web/modules/survey/follow-ups/lib/sanitize-follow-up-body.test.ts
@@ -15,6 +15,8 @@ describe("sanitizeFollowUpBody", () => {
     expect(sanitized).toMatch(/<ol\b/);
     expect(sanitized).toMatch(/<li\b[^>]*>.*First step.*<\/li>/);
     expect(sanitized).toMatch(/<li\b[^>]*>.*Second step.*<\/li>/);
+    // The editor's list classes carry the email's list styling, so `class` has to survive too.
+    expect(sanitized).toContain('class="fb-editor-list-ol"');
   });
 
   test("keeps the numbering of a list that does not start at 1", () => {

--- a/apps/web/modules/survey/follow-ups/lib/sanitize-follow-up-body.ts
+++ b/apps/web/modules/survey/follow-ups/lib/sanitize-follow-up-body.ts
@@ -1,0 +1,29 @@
+import DOMpurify from "isomorphic-dompurify";
+
+/**
+ * Save-time allowlist for a follow-up email body, applied before the body is persisted on the survey.
+ *
+ * Kept in step with `sanitizeBody` in `@/modules/email/lib/survey-response-email`, which sanitizes the
+ * same HTML again at send time. The two are independent allowlists over one value, so the narrower one
+ * wins: anything dropped here never reaches the email stage, however permissive that stage is.
+ *
+ * `ul`/`ol`/`li` are on the list because the Body editor offers list buttons. Without them DOMPurify
+ * removes the list tags but keeps their contents (`KEEP_CONTENT` defaults to true), so an authored list
+ * was persisted as bare `<span>`s and the email rendered its items run together on one line, unnumbered.
+ * `start`/`value` keep the numbering of an `<ol>` that doesn't begin at 1 — Lexical writes those
+ * explicitly.
+ */
+const FOLLOW_UP_BODY_SANITIZE_CONFIG = {
+  ALLOWED_TAGS: ["p", "span", "b", "strong", "i", "em", "a", "br", "ul", "ol", "li"],
+  ALLOWED_ATTR: ["href", "rel", "dir", "class", "start", "value"],
+  ALLOWED_URI_REGEXP: /^https?:\/\//, // Only allow safe URLs starting with http or https
+  ADD_ATTR: ["target"], // Optional: Allow 'target' attribute for links (e.g., _blank)
+  // `ALLOWED_URI_REGEXP` is applied to every attribute DOMPurify does not already consider URI-safe,
+  // so a custom one silently drops non-URL attributes too: `rel`, `dir` and `start` were being stripped
+  // because their values aren't http(s) URLs. Declaring them URI-safe exempts them from that check
+  // while leaving `href` — the only URL-bearing attribute here — fully checked.
+  ADD_URI_SAFE_ATTR: ["rel", "dir", "start"],
+} as const;
+
+export const sanitizeFollowUpBody = (body: string): string =>
+  DOMpurify.sanitize(body, FOLLOW_UP_BODY_SANITIZE_CONFIG);

--- a/apps/web/modules/survey/follow-ups/lib/sanitize-follow-up-body.ts
+++ b/apps/web/modules/survey/follow-ups/lib/sanitize-follow-up-body.ts
@@ -23,7 +23,9 @@ const FOLLOW_UP_BODY_SANITIZE_CONFIG = {
   // because their values aren't http(s) URLs. Declaring them URI-safe exempts them from that check
   // while leaving `href` — the only URL-bearing attribute here — fully checked.
   ADD_URI_SAFE_ATTR: ["rel", "dir", "start"],
-} as const;
+  // Deliberately not `as const`: DOMPurify's `Config` takes mutable `string[]`, so readonly tuples
+  // don't satisfy it. (`isomorphic-dompurify` doesn't re-export `Config` to annotate against.)
+};
 
 export const sanitizeFollowUpBody = (body: string): string =>
   DOMpurify.sanitize(body, FOLLOW_UP_BODY_SANITIZE_CONFIG);


### PR DESCRIPTION
## What & why

A list authored in a survey Follow-Up email body never reached the recipient as a list. The Body editor offers bullet/numbered buttons, but the save-time DOMPurify allowlist had no `ul`/`ol`/`li` — and DOMPurify keeps the *contents* of a tag it removes, so the list was persisted as bare `<span>`s and the email ran the items together on one unnumbered line. The send-time sanitizer in `survey-response-email.ts` already allows lists; it simply never saw one, because the body was flattened before it got there.

Same config, second bug: a custom `ALLOWED_URI_REGEXP` is applied by DOMPurify to every attribute it doesn't already treat as URI-safe, so `rel`, `dir` and `start` were silently dropped for failing a URL test — `dir` being the one that matters, since it carries RTL body direction. `ADD_URI_SAFE_ATTR` exempts those three while `href`, the only URL-bearing attribute here, stays fully checked.

The allowlist moves to `lib/sanitize-follow-up-body.ts` so it's unit-testable and the modal's two call sites (create + edit) can't drift apart.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2120/verify-run-the-unexecuted-recall-value-escaping-qa-for-follow-up-and

## How this was tested

- New `sanitize-follow-up-body.test.ts` (7 cases): lists survive, `start`/`value` numbering survives, `rel`/`dir` survive, inline formatting and http(s) links survive, and `<script>`/`javascript:`/out-of-allowlist tags are still stripped. `pnpm exec vitest run modules/survey/follow-ups` → 4 files, 26 tests ✅. Prettier + eslint clean on the touched files.
- End-to-end through real delivery (local Mailhog + Redis): built a follow-up whose body has a recalled date and a numbered list, submitted an anonymous response, and read the delivered message. **Before:** `<span>First step</span><span>Second step</span>`. **After:** `<ol class="fb-editor-list-ol"><li value="1" class="fb-editor-listitem"><span>First step</span></li><li value="2" …>` ✅ — and the persisted `SurveyFollowUp.action.properties.body` keeps the list too.
- The same run confirms the recalled date still localizes (`Montag, 15. Juni 2026` for a `de-DE` respondent), so the send-time sanitizer path is unchanged.

<!-- No UI screenshot: nothing changes in the editor. The observable change is the delivered email,
whose before/after HTML is quoted above. -->

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Survey editor → Follow-ups → New follow-up. In Body, click the numbered-list button, type two items, save the follow-up and publish the survey. Submit a response → the received email shows a properly numbered list on separate lines (previously one run-together line).
- [ ] Repeat with the bulleted-list button → bullets render as a list.
- [ ] Edit an existing follow-up that has a list, save again → the list is still a list (the create and edit paths share one allowlist).
- [ ] Put a link in the body → still clickable in the email; `rel`/`target` intact.
- [ ] Write the body in a right-to-left language → the email keeps the right-to-left direction (`dir` is no longer stripped).
- [ ] Negative: a body pasted with a `<script>` tag, a `javascript:` link, or a heading/table → those are still removed from the delivered email.

**Preconditions / test data**

- SMTP configured so mail is actually delivered, and Redis running for the response-pipeline job that sends follow-ups.
- Self-hosted needs no license for follow-ups; on Cloud the follow-ups entitlement must be active.

**Risks & regressions**

- The allowlist widened: re-check that a follow-up body still can't smuggle markup — the negative cases above cover `<script>`, non-http(s) schemes, and out-of-allowlist tags.
- Bodies saved before this change are already flattened in the database; they stay flattened until re-edited. Not repaired here.
- `ADD_URI_SAFE_ATTR` only exempts `rel`/`dir`/`start` from the URL check. `href` must still reject `javascript:` — covered by a test.

**Migrations / env / cutover**

- none
