### PR TITLE
fix(auth): stop truncating the localhost warning on the OAuth consent screen [ENG-2120]

### DIFF
--- a/apps/web/app/(app)/account/authorize/page.tsx
+++ b/apps/web/app/(app)/account/authorize/page.tsx
@@ -135,8 +135,12 @@ const Page = async ({ searchParams }: Readonly<{ searchParams: Promise<TSearchPa
           )}
         </dl>
 
+        {/* Default size, not `small`: the small variant truncates title and description to a single
+            line, which cut this warning off mid-sentence ("…Only continue if you started this c…").
+            It is the one thing on the page telling the user how to judge the redirect target, so it
+            has to be readable in full. */}
         {isLocalhostHost(redirectHost) && (
-          <Alert variant="warning" size="small" className="mt-6" role="status">
+          <Alert variant="warning" className="mt-6" role="status">
             <AlertTitle>{t("auth.oauth.localhost_redirect_warning")}</AlertTitle>
             <AlertDescription>{t("auth.oauth.localhost_redirect_warning_description")}</AlertDescription>
           </Alert>

--- a/apps/web/app/(app)/account/authorize/page.tsx
+++ b/apps/web/app/(app)/account/authorize/page.tsx
@@ -135,10 +135,6 @@ const Page = async ({ searchParams }: Readonly<{ searchParams: Promise<TSearchPa
           )}
         </dl>
 
-        {/* Default size, not `small`: the small variant truncates title and description to a single
-            line, which cut this warning off mid-sentence ("…Only continue if you started this c…").
-            It is the one thing on the page telling the user how to judge the redirect target, so it
-            has to be readable in full. */}
         {isLocalhostHost(redirectHost) && (
           <Alert variant="warning" className="mt-6" role="status">
             <AlertTitle>{t("auth.oauth.localhost_redirect_warning")}</AlertTitle>


### PR DESCRIPTION
## What & why

The localhost-redirect warning on the OAuth consent screen was unreadable. `Alert`'s `size="small"` variant applies `truncate` to both title and description, so the warning rendered as a single clipped line:

> ⚠ Local redir…   This client redirects to localhost. Only continue if you started this c…

It is the one element on that page telling the user how to judge the redirect target — the check that stops them handing a token to a client they didn't start. Switched to the default two-row alert, which wraps. `size="small"` is untouched for its other callers.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2120/verify-run-the-unexecuted-recall-value-escaping-qa-for-follow-up-and

## How this was tested

Drove a real OAuth authorization request (dynamic client registration → `/api/auth/oauth2/authorize` with a `localhost` redirect URI) against a local dev server and measured the rendered warning rather than eyeballing it — truncation is invisible to text assertions.

- Before: `{"scrollWidth":530,"clientWidth":390,"clamped":true}` — 530px of text in a 390px box.
- After: not clamped; both lines render in full ✅

Prettier + eslint clean on the changed file. No unit test: per repo guidelines `.tsx` is covered by E2E, and the assertion that matters here is a layout measurement.

Before/after screenshots attached in a comment.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Connect an MCP client whose redirect URI is on `localhost` (any OAuth client registered with a `http://localhost:<port>/…` redirect) and start the authorization flow → the consent screen shows the amber "Local redirect URI" warning with its full text on two lines, nothing cut off with an ellipsis.
- [ ] Narrow the browser window to a phone width → the warning still wraps rather than clipping.
- [ ] Start a flow with a non-localhost `https://` redirect URI → no warning appears at all (unchanged).
- [ ] Check other small alerts in the app (e.g. survey editor warnings) still render on one compact line — the shared `size="small"` variant was not modified.

**Preconditions / test data**

- A registered OAuth client with a localhost redirect URI, and a logged-in user to reach the consent screen.

**Risks & regressions**

- Only this call site changed, so the risk is cosmetic: the alert is now taller and pushes the Allow/Deny buttons down slightly.
- `Alert size="small"` still truncates everywhere else. Other long-text small alerts may have the same problem; not audited here.

**Migrations / env / cutover**

- none

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/6357b54c-f9a8-4c37-a2fa-7befd7a07ece" />

