### PR TITLE
docs: fix Linear auto-linking guidance in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,8 +9,23 @@ keep it short enough to grasp without opening files. -->
 
 ## Linear ticket
 
-<!-- Paste the full Linear ticket URL (e.g. https://linear.app/formbricks/issue/ENG-1234/…) so it
-auto-links. No ticket? Say why. Closing a GitHub issue? Add "Fixes #123". -->
+<!-- A bare ticket URL does NOT link the PR. Linear only links when a magic word comes BEFORE the
+issue ID or URL, so replace the line below with one of:
+
+    Fixes ENG-1234
+    Fixes https://linear.app/formbricks/issue/ENG-1234/some-slug
+
+Closing magic words (`fix`/`fixes`/`closes`/`resolves`/`completes`/`implements`) move the ticket to
+its merge status when this PR merges — use these for the normal case. Use a non-closing word
+(`ref`/`refs`/`part of`/`related to`) when the PR only partially addresses the ticket and it should
+stay open. Several tickets: `Fixes ENG-1234, ENG-5678`.
+
+Putting the issue ID in the branch name or the PR title links the PR too (copy the branch name from
+Linear with Cmd/Ctrl+Shift+.), so magic words here are what to rely on when the branch name has no ID.
+
+No ticket? Delete the line and say why. Closing a GitHub issue as well? Add "Fixes #123". -->
+
+Fixes ENG-
 
 ## How this was tested
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,13 +15,19 @@ issue ID or URL, so replace the line below with one of:
     Fixes ENG-1234
     Fixes https://linear.app/formbricks/issue/ENG-1234/some-slug
 
-Closing magic words (`fix`/`fixes`/`closes`/`resolves`/`completes`/`implements`) move the ticket to
-its merge status when this PR merges — use these for the normal case. Use a non-closing word
-(`ref`/`refs`/`part of`/`related to`) when the PR only partially addresses the ticket and it should
-stay open. Several tickets: `Fixes ENG-1234, ENG-5678`.
+Closing magic words move the ticket to its on-merge status when this PR merges — use one of these for
+the normal case: `close`, `fix`, `resolve`, `complete`, `implement`, in any tense (`fixes`, `fixed`,
+`fixing`, …).
+
+Non-closing magic words still link the PR and still let your team's other automations run (e.g.
+moving the ticket to In Progress when the PR opens); they only skip the on-merge transition. Use one
+when this PR is a partial step: `ref`, `refs`, `references`, `part of`, `related to`, `relates to`,
+`contributes to`, `toward`, `towards`. Several tickets: `Fixes ENG-1234, ENG-5678`.
 
 Putting the issue ID in the branch name or the PR title links the PR too (copy the branch name from
 Linear with Cmd/Ctrl+Shift+.), so magic words here are what to rely on when the branch name has no ID.
+
+Full keyword list and linking rules: https://linear.app/docs/github
 
 No ticket? Delete the line and say why. Closing a GitHub issue as well? Add "Fixes #123". -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,27 +9,11 @@ keep it short enough to grasp without opening files. -->
 
 ## Linear ticket
 
-<!-- A bare ticket URL does NOT link the PR. Linear only links when a magic word comes BEFORE the
-issue ID or URL, so replace the line below with one of:
-
-    Fixes ENG-1234
-    Fixes https://linear.app/formbricks/issue/ENG-1234/some-slug
-
-Closing magic words move the ticket to its on-merge status when this PR merges — use one of these for
-the normal case: `close`, `fix`, `resolve`, `complete`, `implement`, in any tense (`fixes`, `fixed`,
-`fixing`, …).
-
-Non-closing magic words still link the PR and still let your team's other automations run (e.g.
-moving the ticket to In Progress when the PR opens); they only skip the on-merge transition. Use one
-when this PR is a partial step: `ref`, `refs`, `references`, `part of`, `related to`, `relates to`,
-`contributes to`, `toward`, `towards`. Several tickets: `Fixes ENG-1234, ENG-5678`.
-
-Putting the issue ID in the branch name or the PR title links the PR too (copy the branch name from
-Linear with Cmd/Ctrl+Shift+.), so magic words here are what to rely on when the branch name has no ID.
-
-Full keyword list and linking rules: https://linear.app/docs/github
-
-No ticket? Delete the line and say why. Closing a GitHub issue as well? Add "Fixes #123". -->
+<!-- Complete the line below: `Fixes ENG-1234`. A bare URL does NOT link the PR — the magic word has
+to come first. Use `Ref ENG-1234` instead if this PR only partly addresses the ticket, so merging
+doesn't close it. A full ticket URL works in place of the ID.
+No ticket? Delete the line and say why. Closing a GitHub issue? Add "Fixes #123".
+More: https://linear.app/docs/github -->
 
 Fixes ENG-
 


### PR DESCRIPTION
## What & why

The `## Linear ticket` section told contributors to paste the full ticket URL "so it auto-links". That doesn't work: per [Linear's docs](https://linear.app/docs/github#linking-linear-issues-to-github-prs), Linear only links a PR when a **magic word comes before** the issue ID or URL. A bare URL links nothing, so PRs that followed the template exactly were left unlinked — #8725 is a live example (CodeRabbit's "Linked Issues check" reported *"skipped because no linked issues were found"* even though the ticket URL was in the body).

The replacement keeps to what an author has to do, not how Linear works internally:

- `Fixes ENG-1234` is the instruction, with `Fixes ENG-` prefilled in the body so the working form is the default rather than something to remember.
- States the actual rule — a bare URL doesn't link, the magic word has to come first — since that's the trap.
- `Ref ENG-1234` as the escape hatch when the PR only partly addresses a ticket and shouldn't close it on merge.
- A link to Linear's docs for anything beyond that (full keyword list, `skip`/`ignore`, branch-name linking).

Net effect is 5 lines of guidance where there were 2, and they work. Only this section changed.

## Linear ticket

No ticket — this came out of noticing the broken linking on #8725 while working ENG-1686. Happy to file one retroactively if that's preferred.

## How this was tested

- Verified the rule against https://linear.app/docs/github#linking-linear-issues-to-github-prs: linking requires a magic word before the ID or URL; `fix`/`fixes`/`closes`/… transition the ticket on merge, `ref`/`part of`/… link without the on-merge transition.
- The end-to-end proof is this PR's sibling: #8725 pasted a bare ticket URL exactly as the old template instructed and Linear did not link it.
- Markdown-only change to a GitHub template; no code, no tests to run. Note that `npx prettier --check` already fails on this file on `main` (it wants to reflow the untouched `## QA / Test Plan` bullets), and `.github/**/*.md` is covered by neither lint-staged nor any CI lint job — so I deliberately did **not** run `prettier --write`, to keep the diff to the one section and avoid mangling the QA structure.
- Real verification is the next PR opened after this merges: it should show a linked Linear issue. Worth a glance on the first one.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Open a new PR in this repo → the description is prefilled from the template and the `## Linear ticket` section shows `Fixes ENG-` with the short guidance comment above it.
- [ ] Complete it to a real ticket (e.g. `Fixes ENG-1234`) and open the PR → within a few seconds the Linear issue shows the PR under its links.
- [ ] Open the corresponding Linear issue → the GitHub PR appears attached; on merge the issue moves to the team's on-merge status.
- [ ] Partial-work variant: use `Ref ENG-1234` instead → the PR links to the issue, but merging does **not** move it to the on-merge status.
- [ ] Regression check on the old behaviour: a PR whose body contains only a bare `https://linear.app/formbricks/issue/ENG-1234/…` with no magic word → no link is created. This is the bug being fixed.

**Preconditions / test data**

- The Linear ↔ GitHub integration must be connected for the workspace (it already is).
- A real, open Linear ticket to point at. Use a throwaway/test ticket for the merge step so a real one isn't transitioned.
- The branch used for the test PR should **not** contain an issue ID, otherwise the branch name links the PR on its own and the description's magic word isn't what's under test.

**Risks & regressions**

- Template-only change, so the blast radius is PR descriptions. Worst case is wording that confuses contributors rather than anything breaking.
- The prefilled `Fixes ENG-` could get left incomplete in a PR body; it's plainly visible in the description and Linear simply won't match it, so it fails loudly rather than silently.
- Closing magic words now transition tickets on merge where previously nothing was linked at all — expected, but reviewers may notice Linear tickets moving automatically for the first time.

**Migrations / env / cutover**

- none
