### PR TITLE
fix(helm): bound Hub worker API wait

### DIFF
--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -64,11 +64,13 @@ jobs:
             --set formbricks.webappUrl=https://qa.example.com \
             --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-worker-default.yaml"
           grep -q 'max_attempts=120' "$render_dir/hub-worker-default.yaml"
-          grep -q 'wget --no-verbose --tries=1 --timeout=5 --spider' "$render_dir/hub-worker-default.yaml"
+          grep -q 'timeout 5 wget --no-verbose --tries=1 --timeout=5 --spider' \
+            "$render_dir/hub-worker-default.yaml"
           grep -q 'Waiting for Hub API migrations and health check (attempt \$attempts/\$max_attempts)' \
             "$render_dir/hub-worker-default.yaml"
           grep -q 'Hub API did not become healthy after \$max_attempts attempt(s)' \
             "$render_dir/hub-worker-default.yaml"
+          grep -q 'sleep 5' "$render_dir/hub-worker-default.yaml"
 
           helm template qa "$chart" \
             --set formbricks.webappUrl=https://qa.example.com \
@@ -96,11 +98,20 @@ jobs:
             --set 'hub.extraVolumeMounts[0].name=qa-hub-credentials' \
             --set 'hub.extraVolumeMounts[0].mountPath=/var/run/qa-credentials' \
             --set 'hub.extraVolumeMounts[0].readOnly=true' \
-            --show-only templates/hub-deployment.yaml \
-            --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-volumes.yaml"
-          test "$(grep -c 'secretName: qa-hub-credentials' "$render_dir/hub-volumes.yaml")" -eq 2
-          test "$(grep -c 'mountPath: /var/run/qa-credentials' "$render_dir/hub-volumes.yaml")" -eq 2
-          test "$(grep -c 'readOnly: true' "$render_dir/hub-volumes.yaml")" -eq 2
+            --show-only templates/hub-deployment.yaml > "$render_dir/hub-api-volumes.yaml"
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set 'hub.extraVolumes[0].name=qa-hub-credentials' \
+            --set 'hub.extraVolumes[0].secret.secretName=qa-hub-credentials' \
+            --set 'hub.extraVolumeMounts[0].name=qa-hub-credentials' \
+            --set 'hub.extraVolumeMounts[0].mountPath=/var/run/qa-credentials' \
+            --set 'hub.extraVolumeMounts[0].readOnly=true' \
+            --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-worker-volumes.yaml"
+          for manifest in "$render_dir/hub-api-volumes.yaml" "$render_dir/hub-worker-volumes.yaml"; do
+            test "$(grep -c 'secretName: qa-hub-credentials' "$manifest")" -eq 1
+            test "$(grep -c 'mountPath: /var/run/qa-credentials' "$manifest")" -eq 1
+            test "$(grep -c 'readOnly: true' "$manifest")" -eq 1
+          done
 
           helm template qa "$chart" \
             --set formbricks.webappUrl=https://qa.example.com \

--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -62,6 +62,48 @@ jobs:
 
           helm template qa "$chart" \
             --set formbricks.webappUrl=https://qa.example.com \
+            --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-worker-default.yaml"
+          grep -q 'max_attempts=120' "$render_dir/hub-worker-default.yaml"
+          grep -q 'wget --no-verbose --tries=1 --timeout=5 --spider' "$render_dir/hub-worker-default.yaml"
+          grep -q 'Waiting for Hub API migrations and health check (attempt \$attempts/\$max_attempts)' \
+            "$render_dir/hub-worker-default.yaml"
+          grep -q 'Hub API did not become healthy after \$max_attempts attempt(s)' \
+            "$render_dir/hub-worker-default.yaml"
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set hub.worker.waitForApi.maxAttempts=3 \
+            --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-worker-override.yaml"
+          grep -q 'max_attempts=3' "$render_dir/hub-worker-override.yaml"
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set hub.worker.waitForApi.enabled=false \
+            --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-worker-disabled.yaml"
+          ! grep -q 'wait-for-hub-api' "$render_dir/hub-worker-disabled.yaml"
+          grep -q '/app/hub-worker' "$render_dir/hub-worker-disabled.yaml"
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --show-only templates/hub-deployment.yaml \
+            --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-default.yaml"
+          ! grep -q 'qa-hub-credentials' "$render_dir/hub-default.yaml"
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set 'hub.extraVolumes[0].name=qa-hub-credentials' \
+            --set 'hub.extraVolumes[0].secret.secretName=qa-hub-credentials' \
+            --set 'hub.extraVolumeMounts[0].name=qa-hub-credentials' \
+            --set 'hub.extraVolumeMounts[0].mountPath=/var/run/qa-credentials' \
+            --set 'hub.extraVolumeMounts[0].readOnly=true' \
+            --show-only templates/hub-deployment.yaml \
+            --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-volumes.yaml"
+          test "$(grep -c 'secretName: qa-hub-credentials' "$render_dir/hub-volumes.yaml")" -eq 2
+          test "$(grep -c 'mountPath: /var/run/qa-credentials' "$render_dir/hub-volumes.yaml")" -eq 2
+          test "$(grep -c 'readOnly: true' "$render_dir/hub-volumes.yaml")" -eq 2
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
             --show-only templates/migration-job.yaml > "$render_dir/default.yaml"
 
           grep -q 'packages/database/dist/scripts/wait-for-database.js' "$render_dir/default.yaml"

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -69,9 +69,11 @@ Cube is part of the baseline Formbricks v5 stack and is deployed by this chart b
 ## Hub worker and self-hosted embeddings
 
 The chart deploys Hub API and, by default, a `hub-worker` deployment. Hub API is insert-only for River jobs; webhook dispatch and embedding jobs are processed by `hub-worker`.
-The worker waits for Hub API health before it starts. Each health request and the delay between
-failed checks are bounded to five seconds; `hub.worker.waitForApi.maxAttempts` limits the failed
-checks before the init container exits.
+When `hub.worker.waitForApi.enabled` is enabled (the default), the worker waits for Hub API health
+before it starts. Each health request and the delay between failed checks are bounded to five
+seconds; `hub.worker.waitForApi.maxAttempts` limits the failed checks before the init container
+exits. Setting `hub.worker.waitForApi.enabled=false` omits the health gate, so the worker starts
+without waiting for Hub API health.
 
 When the Formbricks migration job is enabled, Hub waits for the `formbricks-migration` Job to complete before its own goose/river init migrations run. This keeps fresh shared-database installs from creating Hub tables before Prisma has initialized the Formbricks schema.
 If the Job has already been cleaned up, Hub only continues after all expected Prisma and data migration success markers are present in the database.

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -69,6 +69,9 @@ Cube is part of the baseline Formbricks v5 stack and is deployed by this chart b
 ## Hub worker and self-hosted embeddings
 
 The chart deploys Hub API and, by default, a `hub-worker` deployment. Hub API is insert-only for River jobs; webhook dispatch and embedding jobs are processed by `hub-worker`.
+The worker waits for Hub API health before it starts. Each health request and the delay between
+failed checks are bounded to five seconds; `hub.worker.waitForApi.maxAttempts` limits the failed
+checks before the init container exits.
 
 When the Formbricks migration job is enabled, Hub waits for the `formbricks-migration` Job to complete before its own goose/river init migrations run. This keeps fresh shared-database installs from creating Hub tables before Prisma has initialized the Formbricks schema.
 If the Job has already been cleaned up, Hub only continues after all expected Prisma and data migration success markers are present in the database.
@@ -405,7 +408,7 @@ JSON that can call Vertex AI.
 | hub.worker.resources.requests.cpu                                  | string | `"100m"`                                                                    |                                                           |
 | hub.worker.resources.requests.memory                               | string | `"256Mi"`                                                                   |                                                           |
 | hub.worker.waitForApi.enabled                                      | bool   | `true`                                                                      |                                                           |
-| hub.worker.waitForApi.maxAttempts                                  | int    | `120`                                                                       | 120 attempts at 5s intervals = 10 minutes.                |
+| hub.worker.waitForApi.maxAttempts                                  | int    | `120`                                                                       | Health requests and retry delays are bounded to 5s each.  |
 | ingress.annotations                                                | object | `{}`                                                                        |                                                           |
 | ingress.enabled                                                    | bool   | `false`                                                                     |                                                           |
 | ingress.hosts[0].host                                              | string | `"k8s.formbricks.com"`                                                      |                                                           |

--- a/charts/formbricks/templates/hub-worker-deployment.yaml
+++ b/charts/formbricks/templates/hub-worker-deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - |
               attempts=0
               max_attempts={{ .Values.hub.worker.waitForApi.maxAttempts | default 120 }}
-              until wget --no-verbose --tries=1 --timeout=5 --spider http://{{ include "formbricks.hubname" . }}:8080/health; do
+              until timeout 5 wget --no-verbose --tries=1 --timeout=5 --spider http://{{ include "formbricks.hubname" . }}:8080/health; do
                 attempts=$((attempts+1))
                 if [ "$attempts" -ge "$max_attempts" ]; then
                   echo "Hub API did not become healthy after $max_attempts attempt(s)"

--- a/charts/formbricks/templates/hub-worker-deployment.yaml
+++ b/charts/formbricks/templates/hub-worker-deployment.yaml
@@ -61,13 +61,13 @@ spec:
             - |
               attempts=0
               max_attempts={{ .Values.hub.worker.waitForApi.maxAttempts | default 120 }}
-              until wget --no-verbose --tries=1 --spider http://{{ include "formbricks.hubname" . }}:8080/health; do
+              until wget --no-verbose --tries=1 --timeout=5 --spider http://{{ include "formbricks.hubname" . }}:8080/health; do
                 attempts=$((attempts+1))
                 if [ "$attempts" -ge "$max_attempts" ]; then
-                  echo "Hub API health check timed out after $((max_attempts * 5)) seconds"
+                  echo "Hub API did not become healthy after $max_attempts attempt(s)"
                   exit 1
                 fi
-                echo "Waiting for Hub API migrations and health check..."
+                echo "Waiting for Hub API migrations and health check (attempt $attempts/$max_attempts)..."
                 sleep 5
               done
       {{- end }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -1030,7 +1030,8 @@ hub:
     waitForApi:
       # Avoid starting workers before the API service is healthy during installs/upgrades.
       enabled: true
-      # 120 attempts * 5 seconds = 10 minutes.
+      # Maximum failed checks before the init container exits. Each health request and the delay
+      # between failed checks are bounded to 5 seconds.
       maxAttempts: 120
 
     resources:


### PR DESCRIPTION
## What & why

A hub-worker init container could hang indefinitely when its first Hub API health request connected before the endpoint was ready but never returned. Because the request itself had no hard total deadline, the surrounding retry counter and maximum-attempt guard were ineffective.

This wraps each GNU Wget health request in the pinned image's `timeout` utility for a hard five-second process deadline while retaining Wget's DNS/connect/read timeouts. It also adds attempt-aware logs and replaces the inaccurate elapsed-time failure message. Chart documentation now describes the bounded request and retry behavior, including the disabled wait mode, and Helm validation covers the default, overridden, disabled, and shared-volume rendering paths independently.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2181/helm-hub-worker-can-hang-indefinitely-while-waiting-for-hub-api

## How this was tested

- `helm lint charts/formbricks --set formbricks.webappUrl=https://qa.example.com` ✅
- Executed the complete `helm-chart-validation.yml` render-validation script locally ✅
- Rendered the default wait, `maxAttempts=3`, disabled wait, default-volume, and secret-backed shared-volume variants; the validation now checks `timeout 5`, `sleep 5`, and Hub API/worker volume propagation independently ✅
- Verified the pinned Hub 0.8.1 image provides BusyBox `/usr/bin/timeout` and `/usr/bin/wget --timeout`; a two-second process-timeout probe terminated in two seconds ✅
- Initial Minikube 1.38.1 / Kubernetes 1.35.1 verification: simulated both connection refusal and a socket that accepted but did not return HTTP headers; the same worker pod logged three bounded retries and started automatically when Hub returned HTTP 200 ✅
- Initial Minikube verification: Hub API and worker mounted the credentials file with matching SHA-256, with zero init/main-container restarts ✅
- Attempted to rerun the Kubernetes scenario after the review follow-up, but the recreated local Minikube control plane never started its kubelet/API server; the broken profile was removed. The exact post-review timeout command was instead verified in the pinned runtime image as noted above.
- `git diff --check` ✅

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Deploy the Helm chart while the Hub API endpoint remains unavailable or nonresponsive for more than five seconds → hub-worker stays in its wait init container, logs increasing bounded attempt numbers, and does not remain stuck in one request.
- [ ] Restore Hub API health before `hub.worker.waitForApi.maxAttempts` is exhausted → the existing hub-worker pod completes initialization and becomes Ready without being deleted or recreated.
- [ ] Configure a Secret through `hub.extraVolumes` and `hub.extraVolumeMounts` → Hub API and hub-worker both become Ready and can read the same mounted file.
- [ ] Set `hub.worker.waitForApi.enabled=false` → hub-worker starts without the API-wait init container.

**Preconditions / test data**

- A self-hosted Kubernetes test cluster with the Formbricks Helm chart.
- Ability to delay and restore the Hub API endpoint.
- A test Kubernetes Secret containing a non-sensitive credentials file.

**Risks & regressions**

- Hub worker startup timing and retry exhaustion.
- Compatibility of `timeout` and Wget health-check flags with the chart-pinned Hub image.
- Shared Hub API/worker volume and mount rendering.

**Migrations / env / cutover**

- none
