### PR TITLE
fix(web): exit non-zero when typegen env validation fails

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm run build",
     "start": "next start",
     "typecheck": "pnpm typegen && tsc --noEmit --project tsconfig.typecheck.json",
-    "typegen": "dotenv -e ../../.env -- next typegen",
+    "typegen": "dotenv -e ../../.env -- tsx scripts/typegen.ts",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "dotenv -e ../../.env -- vitest run",

--- a/apps/web/scripts/typegen.test.ts
+++ b/apps/web/scripts/typegen.test.ts
@@ -4,27 +4,32 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const scriptPath = path.join(scriptDir, "typegen.ts");
 const appDir = path.resolve(scriptDir, "..");
 
 // Regression guard for the failure exit-code path: `next typegen` used to swallow
 // environment-validation failures and still exit 0, so CI could not detect that
-// type generation ran against an invalid environment. The wrapper must now surface
-// that failure as a non-zero exit while still listing the offending variables.
+// type generation ran against an invalid environment. The `typegen` script must
+// now surface that failure as a non-zero exit while still listing the offending
+// variables.
+//
+// This drives the real package entrypoint (`pnpm typegen`) rather than the wrapper
+// module directly, so a regression in the script command itself — e.g. re-adding a
+// hardcoded `cross-env DATABASE_URL=...` that would mask a caller-supplied invalid
+// value — is also caught.
 //
 // The success path (valid env -> exit 0, "Types generated successfully") is
-// exercised by the `typegen` / `typecheck` CI step, which runs the wrapper for
+// exercised by the `typegen` / `typecheck` CI step, which runs the entrypoint for
 // real; duplicating it here would mean running a full `next typegen` inside a unit
 // test.
-describe("typegen wrapper", () => {
+describe("typegen entrypoint", () => {
   test("exits non-zero and lists invalid variables when env validation fails", () => {
-    const result = spawnSync(process.execPath, ["--import", "tsx", scriptPath], {
+    const result = spawnSync("pnpm", ["typegen"], {
       cwd: appDir,
       encoding: "utf8",
-      timeout: 60_000,
-      // Override DATABASE_URL with an invalid value; it takes precedence over any
-      // value loaded from `.env`, so validation fails deterministically regardless
-      // of the machine's env files.
+      timeout: 120_000,
+      // Override DATABASE_URL with an invalid value. dotenv does not overwrite an
+      // already-set variable, so this takes precedence over `.env` and validation
+      // fails deterministically regardless of the machine's env files.
       env: { ...process.env, DATABASE_URL: "not-a-valid-url" },
     });
 

--- a/apps/web/scripts/typegen.test.ts
+++ b/apps/web/scripts/typegen.test.ts
@@ -31,6 +31,10 @@ describe("typegen wrapper", () => {
     expect(result.status).not.toBe(0);
     const output = `${result.stdout}${result.stderr}`;
     expect(output).toContain("Invalid environment variables");
+    // Assert the specific overridden variable is reported, not just that *some*
+    // validation failed — otherwise an unrelated missing var could mask a
+    // DATABASE_URL validation/reporting regression.
+    expect(output).toContain("DATABASE_URL");
     expect(output).not.toContain("Types generated successfully");
   });
 });

--- a/apps/web/scripts/typegen.test.ts
+++ b/apps/web/scripts/typegen.test.ts
@@ -1,0 +1,36 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const scriptPath = path.join(scriptDir, "typegen.ts");
+const appDir = path.resolve(scriptDir, "..");
+
+// Regression guard for the failure exit-code path: `next typegen` used to swallow
+// environment-validation failures and still exit 0, so CI could not detect that
+// type generation ran against an invalid environment. The wrapper must now surface
+// that failure as a non-zero exit while still listing the offending variables.
+//
+// The success path (valid env -> exit 0, "Types generated successfully") is
+// exercised by the `typegen` / `typecheck` CI step, which runs the wrapper for
+// real; duplicating it here would mean running a full `next typegen` inside a unit
+// test.
+describe("typegen wrapper", () => {
+  test("exits non-zero and lists invalid variables when env validation fails", () => {
+    const result = spawnSync(process.execPath, ["--import", "tsx", scriptPath], {
+      cwd: appDir,
+      encoding: "utf8",
+      timeout: 60_000,
+      // Override DATABASE_URL with an invalid value; it takes precedence over any
+      // value loaded from `.env`, so validation fails deterministically regardless
+      // of the machine's env files.
+      env: { ...process.env, DATABASE_URL: "not-a-valid-url" },
+    });
+
+    expect(result.status).not.toBe(0);
+    const output = `${result.stdout}${result.stderr}`;
+    expect(output).toContain("Invalid environment variables");
+    expect(output).not.toContain("Types generated successfully");
+  });
+});

--- a/apps/web/scripts/typegen.ts
+++ b/apps/web/scripts/typegen.ts
@@ -1,0 +1,42 @@
+import { loadEnvConfig } from "@next/env";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Wrapper around `next typegen` that fails loudly on an invalid environment.
+ *
+ * `next typegen` loads `next.config.mjs`, which imports `lib/env`. When required
+ * variables are missing or invalid, `@t3-oss/env-nextjs` throws and the offending
+ * variables are logged — but `next typegen` swallows that failure (it surfaces
+ * only as an unhandled promise rejection) and still exits `0`. CI and scripts can
+ * therefore not tell that type generation ran against an invalid environment.
+ *
+ * Importing `lib/env` here first runs the same validation up front, so a failure
+ * becomes a hard non-zero exit before `next typegen` is ever spawned.
+ */
+async function main(): Promise<void> {
+  // Load `.env` files exactly as `next typegen` does before it evaluates
+  // `next.config.mjs`, so the preflight validation below sees the same
+  // environment Next would. Existing `process.env` values (e.g. the ones the
+  // package script injects via cross-env) take precedence over `.env`.
+  loadEnvConfig(process.cwd());
+
+  try {
+    await import("../lib/env");
+  } catch {
+    // `throwEnvValidationError` already printed the formatted list of invalid
+    // variables; just propagate the failure as a non-zero exit code.
+    process.exit(1);
+  }
+
+  const nextBin = require.resolve("next/dist/bin/next");
+  const result = spawnSync(process.execPath, [nextBin, "typegen"], { stdio: "inherit" });
+
+  // `spawnSync` returns a null status when the process was killed by a signal;
+  // treat that as a failure too rather than reporting success.
+  process.exit(result.status ?? 1);
+}
+
+void main();

--- a/apps/web/scripts/typegen.ts
+++ b/apps/web/scripts/typegen.ts
@@ -27,8 +27,10 @@ async function main(): Promise<void> {
     await import("../lib/env");
   } catch {
     // `throwEnvValidationError` already printed the formatted list of invalid
-    // variables; just propagate the failure as a non-zero exit code.
-    process.exit(1);
+    // variables. Set the exit code and return rather than calling `process.exit`
+    // so that buffered diagnostics are flushed before the process terminates.
+    process.exitCode = 1;
+    return;
   }
 
   const nextBin = require.resolve("next/dist/bin/next");

--- a/apps/web/scripts/typegen.ts
+++ b/apps/web/scripts/typegen.ts
@@ -19,8 +19,9 @@ const require = createRequire(import.meta.url);
 async function main(): Promise<void> {
   // Load `.env` files exactly as `next typegen` does before it evaluates
   // `next.config.mjs`, so the preflight validation below sees the same
-  // environment Next would. Existing `process.env` values (e.g. the ones the
-  // package script injects via cross-env) take precedence over `.env`.
+  // environment Next would. Existing `process.env` values (e.g. a caller-supplied
+  // or dotenv-loaded variable) take precedence over `.env`, so an invalid value
+  // passed on the command line is not masked here.
   loadEnvConfig(process.cwd());
 
   try {


### PR DESCRIPTION
## What does this PR do?

Fixes ENG-2183: `pnpm --filter=@formbricks/web typegen` now exits non-zero when environment validation fails.

`next typegen` loads `next.config.mjs`, which imports `lib/env`. When required variables are missing or invalid, `@t3-oss/env-nextjs` throws — but that failure surfaces only as an *unhandled promise rejection* during config load: the offending variables are printed, yet the process still exits `0`. CI and scripts therefore can't detect that type generation ran against an invalid environment.

This wraps typegen in `apps/web/scripts/typegen.ts`:

1. Loads the same `.env` files Next does, via `@next/env`'s `loadEnvConfig` (so the preflight sees exactly the environment Next would).
2. Imports `lib/env`, running the identical `@t3-oss/env-nextjs` validation up front.
3. On failure → prints the offending variables and exits `1` **before** `next typegen` is ever spawned.
4. On success → spawns `next typegen`, generates types, exits `0`, and propagates its exit code.

The package `typegen` script now runs `tsx scripts/typegen.ts` instead of `next typegen` directly (same injected env vars, unchanged otherwise).

Fixes ENG-2183.

## How should this be tested?

```sh
# Failure path — invalid var, exits non-zero, lists the variable, no success message
DATABASE_URL=not-a-valid-url pnpm --filter=@formbricks/web typegen; echo "exit: $?"

# Success path — valid root .env, generates types, exits 0
pnpm --filter=@formbricks/web typegen; echo "exit: $?"
```

Automated: `apps/web/scripts/typegen.test.ts` spawns the wrapper with an invalid `DATABASE_URL` and asserts a non-zero exit + "Invalid environment variables" in output, with no success message.

## QA / Test Plan

- [ ] `pnpm --filter=@formbricks/web typegen` exits non-zero when a required env var is missing/invalid.
- [ ] The validation output still lists the missing/invalid variables.
- [ ] No "Types generated successfully" message after a validation failure.
- [ ] A valid root `.env` generates types and exits `0` (existing behavior unchanged).
- [ ] `pnpm --filter=@formbricks/web typecheck` (which runs typegen) still passes.

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build`
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
