### PR TITLE
docs(self-hosting): add v5.3 migration guide

### DIFF
--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -24,7 +24,9 @@ hops:
 
 - `TRUSTED_PROXY_HOP_COUNT` — optional, **defaults to `1`**. Set it to the number of trusted proxies /
   load balancers in front of Formbricks (e.g. an ingress plus a CDN = `2`). An explicit `0` trusts no
-  proxy and uses the socket peer address.
+  proxy at all: the runtime exposes no socket peer address, so the client IP then resolves to a fixed
+  "untrusted" placeholder that rate limiting and response audit logging record in place of a real address.
+  Leave it at `1` (or your real hop count) unless you deliberately want to stop capturing client IPs.
 
 <Warning>
   Setting `TRUSTED_PROXY_HOP_COUNT` **higher** than your real hop count lets a client spoof its IP by
@@ -74,17 +76,22 @@ moves to `0.8.1` — pull the new image.
 
 1. Back up your database.
 2. Set `TRUSTED_PROXY_HOP_COUNT` to the number of proxies in front of your instance (default `1`).
-3. Pull the v5.3 images and restart (`docker compose pull && docker compose down && docker compose up -d`,
-   or `helm upgrade` with the new chart / tag). Migrations apply automatically on startup.
-4. Redeploy / refresh **Cube** so it picks up the updated `FeedbackRecords.js` schema.
-5. Smoke test: sign in (including 2FA), create and schedule a survey, and open the Feedback Records
+3. Update your deployment assets to v5.3 **before** pulling images. `docker compose pull` reads your local
+   Compose file, so fetch the v5.3 `docker-compose.yml` first (it pins the new Hub image and ships the
+   updated `FeedbackRecords.js` Cube schema) — otherwise you re-pull the old images. Helm users use the
+   v5.3 chart.
+4. Pull and restart (`docker compose pull && docker compose down && docker compose up -d`, or
+   `helm upgrade` with the new chart / tag). Migrations apply automatically on startup.
+5. Redeploy / refresh **Cube** so it picks up the updated `FeedbackRecords.js` schema.
+6. Smoke test: sign in (including 2FA), create and schedule a survey, and open the Feedback Records
    dashboards / charts to confirm analytics render correctly.
 
 ### Rollback
 
 The v5.3 migrations are additive and are not read by v5.2, so rolling back the application images / Helm
 values to v5.2 is safe without touching the database. Restore a database backup only if you specifically
-need to undo the schema additions.
+need to undo the schema additions — and note that doing so discards any data written after the backup was
+taken, so perform it within a maintenance window.
 
 ## v5.2
 

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -8,9 +8,9 @@ icon: "arrow-right"
 
 Formbricks v5.3 is a **drop-in upgrade for most self-hosted instances**. There are no breaking API,
 webhook, or authentication changes, and every database migration is additive and runs automatically on
-startup. The only externally visible changes are configuration cleanup (the in-product support chat moved
-from Chatwoot to Plain) and a few new optional variables. The two things worth doing before you deploy are
-setting `TRUSTED_PROXY_HOP_COUNT` for your proxy setup and refreshing the Cube analytics schema.
+startup. The only self-hosting-relevant changes are a few new optional variables. The two things worth
+doing before you deploy are setting `TRUSTED_PROXY_HOP_COUNT` for your proxy setup and refreshing the Cube
+analytics schema.
 
 <Info>
   All new environment variables are optional and defaulted — none of them block startup. You can upgrade
@@ -40,11 +40,8 @@ hops:
   no higher. The default of `1` is correct for a single reverse proxy / ingress.
 </Warning>
 
-### Removed and Renamed Configuration
+### Renamed Configuration
 
-- **Chatwoot removed.** The in-product support chat moved from Chatwoot to Plain (see below). All
-  `CHATWOOT_*` variables (`CHATWOOT_BASE_URL`, `CHATWOOT_WEBSITE_TOKEN`, `CHATWOOT_CONFIGURED`,
-  `CHATWOOT_SCRIPT_ID`, …) are now no-ops. Remove them from your environment.
 - **Scheduling variables renamed.** `NEXT_PUBLIC_SURVEY_SCHEDULING_*` → `SURVEY_SCHEDULING_*` (the
   `NEXT_PUBLIC_` prefix was dropped). This only affects you if you ran a v5.3 release candidate that used
   the old names; a clean v5.2 → v5.3 upgrade never set them.
@@ -52,15 +49,6 @@ hops:
 ### Optional New Configuration
 
 None of the following is required to run v5.3. Add them only if you want the associated feature.
-
-#### In-Product Support Chat (Plain)
-
-Formbricks now uses [Plain](https://plain.com) for the in-app support chat (replacing Chatwoot). Leave
-these unset to disable the support chat entirely.
-
-- `PLAIN_APP_ID` — the Plain application id that enables the chat widget.
-- `PLAIN_CHAT_HMAC_SECRET` — secret used to sign the customer identity (identity verification).
-- `PLAIN_ACTIVE_CUSTOMER_LABEL_TYPE_ID` — optional label applied to active customers.
 
 #### Survey Scheduling
 
@@ -93,21 +81,18 @@ moves to `0.8.1` — pull the new image.
 ### Upgrade Steps
 
 1. Back up your database.
-2. Remove any `CHATWOOT_*` variables from your environment; optionally add the `PLAIN_*` variables if you
-   want the support chat.
-3. Set `TRUSTED_PROXY_HOP_COUNT` to the number of proxies in front of your instance (default `1`).
-4. Pull the v5.3 images and restart (`docker compose pull && docker compose down && docker compose up -d`,
+2. Set `TRUSTED_PROXY_HOP_COUNT` to the number of proxies in front of your instance (default `1`).
+3. Pull the v5.3 images and restart (`docker compose pull && docker compose down && docker compose up -d`,
    or `helm upgrade` with the new chart / tag). Migrations apply automatically on startup.
-5. Redeploy / refresh **Cube** so it picks up the updated `FeedbackRecords.js` schema.
-6. Smoke test: sign in (including 2FA), create and schedule a survey, and open the Feedback Records
+4. Redeploy / refresh **Cube** so it picks up the updated `FeedbackRecords.js` schema.
+5. Smoke test: sign in (including 2FA), create and schedule a survey, and open the Feedback Records
    dashboards / charts to confirm analytics render correctly.
 
 ### Rollback
 
 The v5.3 migrations are additive and are not read by v5.2, so rolling back the application images / Helm
-values to v5.2 is safe without touching the database. Re-add any `CHATWOOT_*` variables you removed if you
-want the old support chat back, and restore a database backup only if you specifically need to undo the
-schema additions.
+values to v5.2 is safe without touching the database. Restore a database backup only if you specifically
+need to undo the schema additions.
 
 ## v5.2
 

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -4,6 +4,111 @@ description: "Formbricks Self-hosted version migration"
 icon: "arrow-right"
 ---
 
+## v5.3
+
+Formbricks v5.3 is a **drop-in upgrade for most self-hosted instances**. There are no breaking API,
+webhook, or authentication changes, and every database migration is additive and runs automatically on
+startup. The only externally visible changes are configuration cleanup (the in-product support chat moved
+from Chatwoot to Plain) and a few new optional variables. The two things worth doing before you deploy are
+setting `TRUSTED_PROXY_HOP_COUNT` for your proxy setup and refreshing the Cube analytics schema.
+
+<Info>
+  All new environment variables are optional and defaulted — none of them block startup. You can upgrade
+  to v5.3 without changing any environment variables and everything will run.
+</Info>
+
+### Database Migrations
+
+v5.3 adds several migrations (new `Workflow` tables and enum, a nullable `Survey.archivedAt`, and
+two-factor lockout fields). They are all additive — no `NOT NULL` columns without defaults, no dropped
+columns, no `DELETE`/`TRUNCATE` — so there is **no manual migration step and no risk of data loss**. They
+apply with the standard automatic Prisma migrations on startup (or your migration job). Just back up your
+database first, as always.
+
+### Client IP Resolution Behind a Proxy (recommended)
+
+v5.3 resolves the client IP from the `X-Forwarded-For` chain using a configurable number of trusted proxy
+hops:
+
+- `TRUSTED_PROXY_HOP_COUNT` — optional, **defaults to `1`**. Set it to the number of trusted proxies /
+  load balancers in front of Formbricks (e.g. an ingress plus a CDN = `2`). An explicit `0` trusts no
+  proxy and uses the socket peer address.
+
+<Warning>
+  Setting `TRUSTED_PROXY_HOP_COUNT` **higher** than your real hop count lets a client spoof its IP by
+  sending a forged `X-Forwarded-For` header. Set it to the exact number of proxies in front of the app —
+  no higher. The default of `1` is correct for a single reverse proxy / ingress.
+</Warning>
+
+### Removed and Renamed Configuration
+
+- **Chatwoot removed.** The in-product support chat moved from Chatwoot to Plain (see below). All
+  `CHATWOOT_*` variables (`CHATWOOT_BASE_URL`, `CHATWOOT_WEBSITE_TOKEN`, `CHATWOOT_CONFIGURED`,
+  `CHATWOOT_SCRIPT_ID`, …) are now no-ops. Remove them from your environment.
+- **Scheduling variables renamed.** `NEXT_PUBLIC_SURVEY_SCHEDULING_*` → `SURVEY_SCHEDULING_*` (the
+  `NEXT_PUBLIC_` prefix was dropped). This only affects you if you ran a v5.3 release candidate that used
+  the old names; a clean v5.2 → v5.3 upgrade never set them.
+
+### Optional New Configuration
+
+None of the following is required to run v5.3. Add them only if you want the associated feature.
+
+#### In-Product Support Chat (Plain)
+
+Formbricks now uses [Plain](https://plain.com) for the in-app support chat (replacing Chatwoot). Leave
+these unset to disable the support chat entirely.
+
+- `PLAIN_APP_ID` — the Plain application id that enables the chat widget.
+- `PLAIN_CHAT_HMAC_SECRET` — secret used to sign the customer identity (identity verification).
+- `PLAIN_ACTIVE_CUSTOMER_LABEL_TYPE_ID` — optional label applied to active customers.
+
+#### Survey Scheduling
+
+The new survey-scheduling feature runs on a fixed daily local time. All three are optional and defaulted:
+
+- `SURVEY_SCHEDULING_TIME_ZONE` — a valid IANA time zone. Default `Europe/Berlin`.
+- `SURVEY_SCHEDULING_LOCAL_HOUR` — default `0`.
+- `SURVEY_SCHEDULING_LOCAL_MINUTE` — default `0`.
+
+#### Password Breach Check
+
+- `PASSWORD_HIBP_CHECK_DISABLED` — set to `"1"` to disable the "Have I Been Pwned" breached-password
+  check on sign-up / password change (`"0"` or unset keeps it on).
+
+### Analytics (Cube) — refresh the schema
+
+The Cube schema for Feedback Records changed in v5.3 (`FeedbackRecords.js`, updated in both `docker/` and
+`charts/`). **Redeploy Cube with the updated schema (or refresh its schema) after upgrading**, otherwise
+Feedback Records analytics and dashboards can drift from the underlying data. The bundled Hub image also
+moves to `0.8.1` — pull the new image.
+
+<Note>
+  Docker Compose users get the updated `FeedbackRecords.js` and Hub image by pulling the v5.3
+  `docker-compose.yml`. Helm users get them from the v5.3 chart, which also pins
+  `TRUSTED_PROXY_HOP_COUNT: "1"`, sets `CUBEJS_EXTERNAL_DEFAULT: "false"` (no Cube Store unless you use
+  external pre-aggregations), and adds a `waitForDatabase` step so the migration job waits for Postgres.
+  If you run Argo CD, confirm the migration-job sync-wave (`-1`) runs after the bundled Postgres (`-2`).
+</Note>
+
+### Upgrade Steps
+
+1. Back up your database.
+2. Remove any `CHATWOOT_*` variables from your environment; optionally add the `PLAIN_*` variables if you
+   want the support chat.
+3. Set `TRUSTED_PROXY_HOP_COUNT` to the number of proxies in front of your instance (default `1`).
+4. Pull the v5.3 images and restart (`docker compose pull && docker compose down && docker compose up -d`,
+   or `helm upgrade` with the new chart / tag). Migrations apply automatically on startup.
+5. Redeploy / refresh **Cube** so it picks up the updated `FeedbackRecords.js` schema.
+6. Smoke test: sign in (including 2FA), create and schedule a survey, and open the Feedback Records
+   dashboards / charts to confirm analytics render correctly.
+
+### Rollback
+
+The v5.3 migrations are additive and are not read by v5.2, so rolling back the application images / Helm
+values to v5.2 is safe without touching the database. Re-add any `CHATWOOT_*` variables you removed if you
+want the old support chat back, and restore a database backup only if you specifically need to undo the
+schema additions.
+
 ## v5.2
 
 Formbricks v5.2 migrates authentication from NextAuth to **Better Auth**. For most self-hosted

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -8,9 +8,8 @@ icon: "arrow-right"
 
 Formbricks v5.3 is a **drop-in upgrade for most self-hosted instances**. There are no breaking API,
 webhook, or authentication changes, and every database migration is additive and runs automatically on
-startup. The only self-hosting-relevant changes are a few new optional variables. The two things worth
-doing before you deploy are setting `TRUSTED_PROXY_HOP_COUNT` for your proxy setup and refreshing the Cube
-analytics schema.
+startup. The only self-hosting-relevant changes are a few new optional variables. The main thing worth
+setting before you deploy is `TRUSTED_PROXY_HOP_COUNT` for your proxy setup; everything else is optional.
 
 <Info>
   All new environment variables are optional and defaulted — none of them block startup. You can upgrade
@@ -55,35 +54,29 @@ The new survey-scheduling feature runs on a fixed daily local time. All three ar
 #### Password Breach Check
 
 - `PASSWORD_HIBP_CHECK_DISABLED` — set to `"1"` to disable the "Have I Been Pwned" breached-password
-  check on sign-up / password change (`"0"` or unset keeps it on).
+  check on sign-up and password reset (`"0"` or unset keeps it on).
 
-### Analytics (Cube) — refresh the schema
+### Analytics (Cube)
 
-The Cube schema for Feedback Records changed in v5.3 (`FeedbackRecords.js`, updated in both `docker/` and
-`charts/`). **Redeploy Cube with the updated schema (or refresh its schema) after upgrading**, otherwise
-Feedback Records analytics and dashboards can drift from the underlying data. The bundled Hub image also
-moves to `0.8.1` — pull the new image.
+Two Cube-related deltas in v5.3. Neither changes the Cube schema, so there is **no schema refresh to run**:
 
-<Note>
-  Docker Compose users get the updated `FeedbackRecords.js` and Hub image by pulling the v5.3
-  `docker-compose.yml`. Helm users get them from the v5.3 chart, which also pins
-  `TRUSTED_PROXY_HOP_COUNT: "1"`, sets `CUBEJS_EXTERNAL_DEFAULT: "false"` (no Cube Store unless you use
-  external pre-aggregations), and adds a `waitForDatabase` step so the migration job waits for Postgres.
-  If you run Argo CD, confirm the migration-job sync-wave (`-1`) runs after the bundled Postgres (`-2`).
-</Note>
+- **`CUBEJS_EXTERNAL_DEFAULT` now defaults to `false`** (in both `docker/docker-compose.yml` and the Helm
+  chart). Cube Store is used only when you explicitly opt into external pre-aggregations — a safe default
+  for most self-hosters. Set it back to `true` only if you run external pre-aggregations.
+- **The Hub image moves to `0.8.1`.** The Helm chart pins `0.8.1`. Docker Compose instead resolves the Hub
+  image through `${HUB_IMAGE_REF:-:latest}`, so a plain `docker compose pull` fetches whatever `:latest`
+  currently is — set `HUB_IMAGE_REF=:0.8.1` in `docker/.env` before pulling for a deterministic upgrade.
 
 ### Upgrade Steps
 
 1. Back up your database.
 2. Set `TRUSTED_PROXY_HOP_COUNT` to the number of proxies in front of your instance (default `1`).
-3. Update your deployment assets to v5.3 **before** pulling images. `docker compose pull` reads your local
-   Compose file, so fetch the v5.3 `docker-compose.yml` first (it pins the new Hub image and ships the
-   updated `FeedbackRecords.js` Cube schema) — otherwise you re-pull the old images. Helm users use the
-   v5.3 chart.
+3. Update your deployment assets to v5.3 **before** pulling images — `docker compose pull` reads your local
+   Compose file, so fetch the v5.3 `docker-compose.yml` first (Helm users use the v5.3 chart). For a
+   deterministic Hub image on Compose, set `HUB_IMAGE_REF=:0.8.1` in `docker/.env`.
 4. Pull and restart (`docker compose pull && docker compose down && docker compose up -d`, or
    `helm upgrade` with the new chart / tag). Migrations apply automatically on startup.
-5. Redeploy / refresh **Cube** so it picks up the updated `FeedbackRecords.js` schema.
-6. Smoke test: sign in (including 2FA), create and schedule a survey, and open the Feedback Records
+5. Smoke test: sign in (including 2FA), create and schedule a survey, and open the Feedback Records
    dashboards / charts to confirm analytics render correctly.
 
 ### Rollback

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -17,14 +17,6 @@ analytics schema.
   to v5.3 without changing any environment variables and everything will run.
 </Info>
 
-### Database Migrations
-
-v5.3 adds several migrations (new `Workflow` tables and enum, a nullable `Survey.archivedAt`, and
-two-factor lockout fields). They are all additive — no `NOT NULL` columns without defaults, no dropped
-columns, no `DELETE`/`TRUNCATE` — so there is **no manual migration step and no risk of data loss**. They
-apply with the standard automatic Prisma migrations on startup (or your migration job). Just back up your
-database first, as always.
-
 ### Client IP Resolution Behind a Proxy (recommended)
 
 v5.3 resolves the client IP from the `X-Forwarded-For` chain using a configurable number of trusted proxy


### PR DESCRIPTION
## Problem

The self-hosting migration guide (`docs/self-hosting/advanced/migration.mdx`) has no v5.3 section. Self-hosters upgrading 5.2 → 5.3 need to know what changed from a deployment perspective: new/removed env vars, migrations, and infra (Cube schema, Hub image, proxy IP handling).

## Solution

Add a `## v5.3` section (newest-first, above `## v5.2`) mirroring the v5.2 guide, covering:

- **Drop-in upgrade** — no breaking API/webhook/auth changes; all migrations additive and automatic (new `Workflow` tables/enum, `Survey.archivedAt`, 2FA lockout fields) — no manual step, no data loss.
- **`TRUSTED_PROXY_HOP_COUNT`** (default `1`) — client-IP resolution behind proxies, with the IP-spoofing warning for setting it too high.
- **Renamed config** — `NEXT_PUBLIC_SURVEY_SCHEDULING_*` → `SURVEY_SCHEDULING_*` (only relevant if a 5.3 RC ran).
- **Optional new config** — survey scheduling (`SURVEY_SCHEDULING_TIME_ZONE`/`_LOCAL_HOUR`/`_LOCAL_MINUTE`), `PASSWORD_HIBP_CHECK_DISABLED`.
- **Analytics (Cube)** — `FeedbackRecords.js` schema changed → redeploy/refresh Cube after upgrade; Hub image → `0.8.1`. Helm notes: `CUBEJS_EXTERNAL_DEFAULT: "false"`, pinned `TRUSTED_PROXY_HOP_COUNT`, `waitForDatabase`, Argo CD sync-wave ordering.
- **Upgrade steps + rollback** (additive migrations → v5.2 rollback is safe without touching the DB).

Based on PR #8593 (the v5.2 guide) and the diff findings in ENG-2146.

## Verification

Facts confirmed against `main`:
- `apps/web/lib/env.ts` — all 8 new vars present with the documented defaults (`TRUSTED_PROXY_HOP_COUNT` → 1; `SURVEY_SCHEDULING_TIME_ZONE` → `Europe/Berlin`, hour/minute → 0; `PASSWORD_HIBP_CHECK_DISABLED` enum `1`/`0`; `PLAIN_*`).
- `packages/database/migrations/` — 5.3 migrations are additive (workflow tables, `add_survey_archived_at`, `add_two_factor_lockout_fields`, …).
- `charts/formbricks/values.yaml` — Hub image `0.8.1`.

## Notes

- Docs-only; no `en-US.json` strings changed, so `pnpm i18n` not needed.
- Cloud-only config (the Plain/Chatwoot in-product support chat) is intentionally omitted — it does not apply to self-hosted instances.
- Closes ENG-2146 (documents the 5.3 deployment-readiness scan for self-hosters).

## QA / Test Plan

- [ ] Render `docs/self-hosting/advanced/migration.mdx` in Mintlify; the v5.3 section appears above v5.2 with valid `Info`/`Warning`/`Note` callouts.
- [ ] Env-var names, defaults, and removals match `apps/web/lib/env.ts`.
