### PR TITLE
fix(web): exit non-zero when typegen env validation fails (backport #8730 to release/5.3)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
     "build:dev": "pnpm run build",
     "start": "next start",
     "typecheck": "pnpm typegen && tsc --noEmit --project tsconfig.typecheck.json",
-    "typegen": "dotenv -e ../../.env -- next typegen",
+    "typegen": "dotenv -e ../../.env -- tsx scripts/typegen.ts",
     "lint": "eslint . --fix",
     "test": "dotenv -e ../../.env -- vitest run",
     "test:coverage": "dotenv -e ../../.env -- vitest run --coverage",

--- a/apps/web/scripts/typegen.ts
+++ b/apps/web/scripts/typegen.ts
@@ -1,0 +1,45 @@
+import { loadEnvConfig } from "@next/env";
+import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Wrapper around `next typegen` that fails loudly on an invalid environment.
+ *
+ * `next typegen` loads `next.config.mjs`, which imports `lib/env`. When required
+ * variables are missing or invalid, `@t3-oss/env-nextjs` throws and the offending
+ * variables are logged — but `next typegen` swallows that failure (it surfaces
+ * only as an unhandled promise rejection) and still exits `0`. CI and scripts can
+ * therefore not tell that type generation ran against an invalid environment.
+ *
+ * Importing `lib/env` here first runs the same validation up front, so a failure
+ * becomes a hard non-zero exit before `next typegen` is ever spawned.
+ */
+async function main(): Promise<void> {
+  // Load `.env` files exactly as `next typegen` does before it evaluates
+  // `next.config.mjs`, so the preflight validation below sees the same
+  // environment Next would. Existing `process.env` values (e.g. a caller-supplied
+  // or dotenv-loaded variable) take precedence over `.env`, so an invalid value
+  // passed on the command line is not masked here.
+  loadEnvConfig(process.cwd());
+
+  try {
+    await import("../lib/env");
+  } catch {
+    // `throwEnvValidationError` already printed the formatted list of invalid
+    // variables. Set the exit code and return rather than calling `process.exit`
+    // so that buffered diagnostics are flushed before the process terminates.
+    process.exitCode = 1;
+    return;
+  }
+
+  const nextBin = require.resolve("next/dist/bin/next");
+  const result = spawnSync(process.execPath, [nextBin, "typegen"], { stdio: "inherit" });
+
+  // `spawnSync` returns a null status when the process was killed by a signal;
+  // treat that as a failure too rather than reporting success.
+  process.exit(result.status ?? 1);
+}
+
+void main();


### PR DESCRIPTION
Backport of #8730 to `release/5.3`. Minimal, single-fix backport per the backport policy.

Ref ENG-2183

## What

`next typegen` swallowed environment-validation failures and still exited `0`, so CI/scripts couldn't detect that type generation ran against an invalid environment. This wraps typegen in `scripts/typegen.ts`, which loads `.env` via `@next/env` and validates `lib/env` up front — a validation failure now exits non-zero before `next typegen` runs; a valid env still generates types and exits `0`.

Cherry-picked `3377de9` (`fix(web): exit non-zero when typegen env validation fails`).

## Files

- `apps/web/scripts/typegen.ts` (new) — the wrapper.
- `apps/web/package.json` — `typegen` script → `dotenv -e ../../.env -- tsx scripts/typegen.ts`.

**Dropped per policy:** the net-new `apps/web/scripts/typegen.test.ts` (no net-new tests in a backport). The `lint`/`lint:fix` split from `main` was also not carried — release/5.3 keeps its existing `"lint": "eslint . --fix"`.

## QA / Test Plan

- [ ] `DATABASE_URL=not-a-valid-url pnpm --filter=@formbricks/web typegen` exits non-zero and lists the invalid variable (no "Types generated successfully").
- [ ] A valid `.env` → `pnpm --filter=@formbricks/web typegen` generates types and exits `0`.
- [ ] `pnpm --filter=@formbricks/web typecheck` (runs typegen) still passes.

### Validation

Fail path verified on this branch: `DATABASE_URL=not-a-valid-url tsx scripts/typegen.ts` → exit `1`, printed "Invalid environment variables". `tsx` and `next` (`@next/env`) are present on release/5.3.

