### PR TITLE
feat(billing): provision metered workflow_runs price on scale subscriptions

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -2525,6 +2525,7 @@ checksums:
     workspace/settings/billing/trial_warning_add_payment_method: 5e6879babc7acb05a258de64fef57262
     workspace/settings/billing/trial_warning_remind_me_later: a12f38fb4352c31ca0d43c05303b7257
     workspace/settings/billing/unlimited_responses: 25bd1cd99bc08c66b8d7d3380b2812e1
+    workspace/settings/billing/unlimited_workflow_runs: 61221f0506d1bf247f732a31959dc146
     workspace/settings/billing/unlimited_workspaces: f7433bc693ee6d177e76509277f5c173
     workspace/settings/billing/unlock_all_plan_features: f494466ed4d974763434fb15c0d63750
     workspace/settings/billing/upgrade: 63c3b52882e0d779859307d672c178c2

--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -2484,7 +2484,7 @@ checksums:
     workspace/settings/billing/plan_scale_feature_responses: f2be033ebf6c86a664b812b4a918647f
     workspace/settings/billing/plan_scale_feature_security: 6671961cf8d8413d1740b13901bcc033
     workspace/settings/billing/plan_scale_feature_semantic_analysis: 1441e34cacd26f0aa27af4ebad6e5c54
-    workspace/settings/billing/plan_scale_feature_workflows: b0c9c8615a9ba7d9cb73e767290a7f72
+    workspace/settings/billing/plan_scale_feature_workflow_runs: 22007bc0ad530bfd56b8a3788bdef02f
     workspace/settings/billing/plan_scale_feature_workspaces: 6bd1b676b9470ca8cc4e73be3ffd4bef
     workspace/settings/billing/plan_selection_description: 8367b137b31234cafe0e297a35b0b599
     workspace/settings/billing/plan_selection_title: 8b814effdaee1787281b740f67482d7d

--- a/apps/web/lib/organization/service.test.ts
+++ b/apps/web/lib/organization/service.test.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { updateUser } from "@/lib/user/service";
+import { getWorkspaces } from "@/lib/workspace/service";
 import {
   cleanupStripeCustomer,
   ensureCloudStripeSetupForOrganization,
@@ -11,6 +12,7 @@ import {
 import {
   createOrganization,
   deleteOrganization,
+  getMonthlyOrganizationWorkflowRunCount,
   getOrganization,
   getOrganizationMemberEmails,
   getOrganizationsByUserId,
@@ -38,11 +40,18 @@ vi.mock("@formbricks/database", () => ({
     membership: {
       findMany: vi.fn(),
     },
+    workflowRun: {
+      aggregate: vi.fn(),
+    },
   },
 }));
 
 vi.mock("@/lib/user/service", () => ({
   updateUser: vi.fn(),
+}));
+
+vi.mock("@/lib/workspace/service", () => ({
+  getWorkspaces: vi.fn(),
 }));
 
 vi.mock("@/modules/ee/billing/lib/organization-billing", () => ({
@@ -459,6 +468,61 @@ describe("Organization Service", () => {
       vi.mocked(prisma.membership.findMany).mockRejectedValue(prismaError);
 
       await expect(getOrganizationMemberEmails("org_1")).rejects.toThrow(DatabaseError);
+    });
+  });
+
+  describe("getMonthlyOrganizationWorkflowRunCount", () => {
+    const mockOrganization = {
+      id: "org_1",
+      name: "Test Org",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      billing: {
+        stripeCustomerId: "cus_1",
+        limits: { workspaces: 5, monthly: { responses: 5000, workflowRuns: 1000 } },
+        usageCycleAnchor: null,
+        stripe: null,
+      },
+      isAISmartToolsEnabled: false,
+      whitelabel: null,
+    };
+
+    test("counts non-dry workflow runs across the organization's workspaces in the billing cycle", async () => {
+      vi.mocked(prisma.organization.findUnique).mockResolvedValue(mockOrganization as never);
+      vi.mocked(getWorkspaces).mockResolvedValue([{ id: "ws_1" }, { id: "ws_2" }] as never);
+      vi.mocked(prisma.workflowRun.aggregate).mockResolvedValue({ _count: { id: 42 } } as never);
+
+      const result = await getMonthlyOrganizationWorkflowRunCount("cms634kob000001uzrelh0qeb");
+
+      expect(result).toBe(42);
+      const aggregateArgs = vi.mocked(prisma.workflowRun.aggregate).mock.calls[0][0];
+      expect(aggregateArgs.where?.AND).toEqual(
+        expect.arrayContaining([
+          { workspaceId: { in: ["ws_1", "ws_2"] } },
+          { isDryRun: false },
+          expect.objectContaining({ createdAt: expect.any(Object) }),
+        ])
+      );
+    });
+
+    test("throws ResourceNotFoundError when the organization does not exist", async () => {
+      vi.mocked(prisma.organization.findUnique).mockResolvedValue(null);
+
+      await expect(getMonthlyOrganizationWorkflowRunCount("cmmissingorg00000000000a")).rejects.toThrow(
+        ResourceNotFoundError
+      );
+    });
+
+    test("wraps a known Prisma error in DatabaseError", async () => {
+      vi.mocked(prisma.organization.findUnique).mockResolvedValue(mockOrganization as never);
+      vi.mocked(getWorkspaces).mockResolvedValue([{ id: "ws_1" }] as never);
+      vi.mocked(prisma.workflowRun.aggregate).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError("db down", { code: "P2002", clientVersion: "1.0.0" })
+      );
+
+      await expect(getMonthlyOrganizationWorkflowRunCount("cms634kob000001uzrelh0qeb")).rejects.toThrow(
+        DatabaseError
+      );
     });
   });
 });

--- a/apps/web/lib/organization/service.ts
+++ b/apps/web/lib/organization/service.ts
@@ -401,6 +401,47 @@ export const getMonthlyOrganizationResponseCount = reactCache(
   }
 );
 
+export const getMonthlyOrganizationWorkflowRunCount = reactCache(
+  async (organizationId: string): Promise<number> => {
+    validateInputs([organizationId, ZId]);
+
+    try {
+      const organization = await getOrganization(organizationId);
+      if (!organization) {
+        throw new ResourceNotFoundError("Organization", organizationId);
+      }
+
+      const usageCycleWindow = getBillingUsageCycleWindow(organization.billing);
+
+      const workspaces = await getWorkspaces(organizationId);
+      const workspaceIds = workspaces.map((workspace) => workspace.id);
+
+      // Mirror the metered usage: count only non-dry runs in the current billing cycle, scoped to the
+      // organization's workspaces. Dry runs are excluded from billing, so they must not show as usage.
+      const workflowRunAggregations = await prisma.workflowRun.aggregate({
+        _count: {
+          id: true,
+        },
+        where: {
+          AND: [
+            { workspaceId: { in: workspaceIds } },
+            { isDryRun: false },
+            { createdAt: { gte: usageCycleWindow.start, lt: usageCycleWindow.end } },
+          ],
+        },
+      });
+
+      return workflowRunAggregations._count.id;
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw new DatabaseError(error.message);
+      }
+
+      throw error;
+    }
+  }
+);
+
 export const subscribeOrganizationMembersToSurveyResponses = async (
   surveyId: string,
   createdBy: string,

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "Alle Funktionen freischalten",
         "trial_warning_remind_me_later": "Später erinnern",
         "unlimited_responses": "Unbegrenzte Antworten",
+        "unlimited_workflow_runs": "Unbegrenzte Workflow-Ausführungen",
         "unlimited_workspaces": "Unbegrenzte Workspaces",
         "unlock_all_plan_features": "Alle {plan}-Features freischalten",
         "upgrade": "Upgrade",

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "5.000 Antworten / Monat mit <dynamicPricing>dynamischer Preisgestaltung</dynamicPricing>",
         "plan_scale_feature_security": "2FA & Spam-Schutz",
         "plan_scale_feature_semantic_analysis": "Semantische Analyse (KI)",
-        "plan_scale_feature_workflows": "Workflows",
+        "plan_scale_feature_workflow_runs": "1.000 Workflow-Ausführungen / Monat mit <dynamicPricing>dynamischer Preisgestaltung</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 Workspaces",
         "plan_selection_description": "Vergleiche Hobby, Pro und Scale und wechsle deinen Plan direkt in Formbricks.",
         "plan_selection_title": "Wähle deinen Plan",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "5,000 responses / month with <dynamicPricing>dynamic pricing</dynamicPricing>",
         "plan_scale_feature_security": "2FA & spam protection",
         "plan_scale_feature_semantic_analysis": "Semantic Analysis (AI)",
-        "plan_scale_feature_workflows": "Workflows",
+        "plan_scale_feature_workflow_runs": "1,000 workflow runs / month with <dynamicPricing>dynamic pricing</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 workspaces",
         "plan_selection_description": "Compare Hobby, Pro, and Scale, then switch plans directly from Formbricks.",
         "plan_selection_title": "Choose your plan",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "Unlock all features",
         "trial_warning_remind_me_later": "Remind me later",
         "unlimited_responses": "Unlimited Responses",
+        "unlimited_workflow_runs": "Unlimited Workflow Runs",
         "unlimited_workspaces": "Unlimited Workspaces",
         "unlock_all_plan_features": "Unlock all {plan} features",
         "upgrade": "Upgrade",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "Desbloquear todas las funciones",
         "trial_warning_remind_me_later": "Recuérdamelo más tarde",
         "unlimited_responses": "Respuestas ilimitadas",
+        "unlimited_workflow_runs": "Ejecuciones de flujo de trabajo ilimitadas",
         "unlimited_workspaces": "Espacios de trabajo ilimitados",
         "unlock_all_plan_features": "Desbloquea todas las funciones de {plan}",
         "upgrade": "Actualizar",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "5.000 respuestas al mes con <dynamicPricing>precios dinámicos</dynamicPricing>",
         "plan_scale_feature_security": "2FA y protección antispam",
         "plan_scale_feature_semantic_analysis": "Análisis semántico (IA)",
-        "plan_scale_feature_workflows": "Workflows",
+        "plan_scale_feature_workflow_runs": "1.000 ejecuciones de flujo de trabajo al mes con <dynamicPricing>precios dinámicos</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 espacios de trabajo",
         "plan_selection_description": "Compara Hobby, Pro y Scale, y cambia de plan directamente desde Formbricks.",
         "plan_selection_title": "Elige tu plan",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "Débloquer toutes les fonctionnalités",
         "trial_warning_remind_me_later": "Me le rappeler plus tard",
         "unlimited_responses": "Réponses illimitées",
+        "unlimited_workflow_runs": "Exécutions de flux de travail illimitées",
         "unlimited_workspaces": "Espaces de travail illimités",
         "unlock_all_plan_features": "Débloquer toutes les fonctionnalités {plan}",
         "upgrade": "Mise à niveau",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "5 000 réponses / mois avec <dynamicPricing>tarification dynamique</dynamicPricing>",
         "plan_scale_feature_security": "2FA et protection anti-spam",
         "plan_scale_feature_semantic_analysis": "Analyse sémantique (IA)",
-        "plan_scale_feature_workflows": "Workflows",
+        "plan_scale_feature_workflow_runs": "1 000 exécutions de workflow / mois avec <dynamicPricing>tarification dynamique</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 espaces de travail",
         "plan_selection_description": "Compare les formules Hobby, Pro et Scale, puis change de formule directement depuis Formbricks.",
         "plan_selection_title": "Choisis ta formule",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "Minden funkció feloldása",
         "trial_warning_remind_me_later": "Emlékeztessen később",
         "unlimited_responses": "Korlátlan válaszok",
+        "unlimited_workflow_runs": "Korlátlan munkafolyamat-futtatások",
         "unlimited_workspaces": "Korlátlan munkaterület",
         "unlock_all_plan_features": "Az összes {plan} funkció feloldása",
         "upgrade": "Frissítés",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "5000 válasz / hónap <dynamicPricing>dinamikus árképzéssel</dynamicPricing>",
         "plan_scale_feature_security": "2FA és spam védelem",
         "plan_scale_feature_semantic_analysis": "Szemantikai elemzés (AI)",
-        "plan_scale_feature_workflows": "Munkafolyamatok",
+        "plan_scale_feature_workflow_runs": "1000 munkafolyamat-futtatás / hónap <dynamicPricing>dinamikus árképzéssel</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 munkaterület",
         "plan_selection_description": "Hobby, Pro és Scale csomagok összehasonlítása, majd csomagok közötti váltás közvetlenül a Formbricksben.",
         "plan_selection_title": "Csomag kiválasztása",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "すべての機能をアンロック",
         "trial_warning_remind_me_later": "後で通知",
         "unlimited_responses": "無制限の回答",
+        "unlimited_workflow_runs": "無制限のワークフロー実行",
         "unlimited_workspaces": "無制限ワークスペース",
         "unlock_all_plan_features": "すべての{plan}機能をアンロック",
         "upgrade": "アップグレード",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "月間5,000件のレスポンス（<dynamicPricing>動的価格設定</dynamicPricing>）",
         "plan_scale_feature_security": "2FA＆スパム保護",
         "plan_scale_feature_semantic_analysis": "セマンティック分析（AI）",
-        "plan_scale_feature_workflows": "ワークフロー",
+        "plan_scale_feature_workflow_runs": "月間1,000回のワークフロー実行、<dynamicPricing>従量課金制</dynamicPricing>",
         "plan_scale_feature_workspaces": "5つのワークスペース",
         "plan_selection_description": "Hobby、Pro、Scaleプランを比較して、Formbricksから直接プランを切り替えられます。",
         "plan_selection_title": "プランを選択",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "5.000 reacties / maand met <dynamicPricing>dynamische prijzen</dynamicPricing>",
         "plan_scale_feature_security": "2FA & spambescherming",
         "plan_scale_feature_semantic_analysis": "Semantische analyse (AI)",
-        "plan_scale_feature_workflows": "Workflows",
+        "plan_scale_feature_workflow_runs": "1.000 workflowuitvoeringen / maand met <dynamicPricing>dynamische prijzen</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 werkruimtes",
         "plan_selection_description": "Vergelijk Hobby, Pro en Scale, en schakel direct vanuit Formbricks tussen abonnementen.",
         "plan_selection_title": "Kies je abonnement",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "Ontgrendel alle functies",
         "trial_warning_remind_me_later": "Herinner me later",
         "unlimited_responses": "Onbeperkte reacties",
+        "unlimited_workflow_runs": "Onbeperkte Workflow-uitvoeringen",
         "unlimited_workspaces": "Onbeperkt werkruimtes",
         "unlock_all_plan_features": "Ontgrendel alle {plan}-functies",
         "upgrade": "Upgraden",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "5.000 respostas / mês com <dynamicPricing>preços dinâmicos</dynamicPricing>",
         "plan_scale_feature_security": "Autenticação 2FA e proteção contra spam",
         "plan_scale_feature_semantic_analysis": "Análise Semântica (IA)",
-        "plan_scale_feature_workflows": "Fluxos de trabalho",
+        "plan_scale_feature_workflow_runs": "1.000 execuções de workflow / mês com <dynamicPricing>preços dinâmicos</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 espaços de trabalho",
         "plan_selection_description": "Compare os planos Hobby, Pro e Scale e mude de plano diretamente no Formbricks.",
         "plan_selection_title": "Escolha seu plano",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "Desbloquear todos os recursos",
         "trial_warning_remind_me_later": "Lembrar mais tarde",
         "unlimited_responses": "Respostas Ilimitadas",
+        "unlimited_workflow_runs": "Execuções de Fluxo de Trabalho Ilimitadas",
         "unlimited_workspaces": "Workspaces Ilimitados",
         "unlock_all_plan_features": "Desbloquear todos os recursos do {plan}",
         "upgrade": "Atualizar",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "5.000 respostas / mês com <dynamicPricing>preços dinâmicos</dynamicPricing>",
         "plan_scale_feature_security": "2FA e proteção contra spam",
         "plan_scale_feature_semantic_analysis": "Análise Semântica (IA)",
-        "plan_scale_feature_workflows": "Fluxos de Trabalho",
+        "plan_scale_feature_workflow_runs": "1000 execuções de fluxo de trabalho / mês com <dynamicPricing>preços dinâmicos</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 áreas de trabalho",
         "plan_selection_description": "Compara Hobby, Pro e Scale, e depois muda de plano diretamente no Formbricks.",
         "plan_selection_title": "Escolhe o teu plano",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "Desbloquear todas as funcionalidades",
         "trial_warning_remind_me_later": "Lembrar-me mais tarde",
         "unlimited_responses": "Respostas Ilimitadas",
+        "unlimited_workflow_runs": "Execuções de Fluxo de Trabalho Ilimitadas",
         "unlimited_workspaces": "Espaços de Trabalho Ilimitados",
         "unlock_all_plan_features": "Desbloquear todas as funcionalidades do {plan}",
         "upgrade": "Atualizar",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "5.000 de răspunsuri / lună cu <dynamicPricing>prețuri dinamice</dynamicPricing>",
         "plan_scale_feature_security": "2FA și protecție împotriva spam-ului",
         "plan_scale_feature_semantic_analysis": "Analiză semantică (AI)",
-        "plan_scale_feature_workflows": "Fluxuri de lucru",
+        "plan_scale_feature_workflow_runs": "1.000 de rulări de fluxuri de lucru / lună cu <dynamicPricing>prețuri dinamice</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 spații de lucru",
         "plan_selection_description": "Compară Hobby, Pro și Scale, apoi schimbă planurile direct din Formbricks.",
         "plan_selection_title": "Alege-ți planul",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "Deblochează toate funcțiile",
         "trial_warning_remind_me_later": "Amintește-mi mai târziu",
         "unlimited_responses": "Răspunsuri nelimitate",
+        "unlimited_workflow_runs": "Rulări nelimitate de fluxuri de lucru",
         "unlimited_workspaces": "Workspaces nelimitate",
         "unlock_all_plan_features": "Deblochează toate funcțiile {plan}",
         "upgrade": "Actualizare",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "5 000 ответов в месяц с <dynamicPricing>динамическим ценообразованием</dynamicPricing>",
         "plan_scale_feature_security": "Двухфакторная аутентификация и защита от спама",
         "plan_scale_feature_semantic_analysis": "Семантический анализ (AI)",
-        "plan_scale_feature_workflows": "Рабочие процессы",
+        "plan_scale_feature_workflow_runs": "1 000 запусков процессов в месяц с <dynamicPricing>динамическим ценообразованием</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 рабочих пространств",
         "plan_selection_description": "Сравни планы Hobby, Pro и Scale, а затем переключайся между ними прямо в Formbricks.",
         "plan_selection_title": "Выбери свой план",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "Разблокировать все функции",
         "trial_warning_remind_me_later": "Напомнить позже",
         "unlimited_responses": "Неограниченное количество ответов",
+        "unlimited_workflow_runs": "Неограниченное количество запусков рабочих процессов",
         "unlimited_workspaces": "Неограниченное количество рабочих пространств",
         "unlock_all_plan_features": "Разблокировать все функции тарифа {plan}",
         "upgrade": "Обновить",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "5 000 svar / månad med <dynamicPricing>dynamisk prissättning</dynamicPricing>",
         "plan_scale_feature_security": "2FA och skräppostskydd",
         "plan_scale_feature_semantic_analysis": "Semantisk analys (AI)",
-        "plan_scale_feature_workflows": "Arbetsflöden",
+        "plan_scale_feature_workflow_runs": "1 000 arbetsflödeskörningar/månad med <dynamicPricing>dynamisk prissättning</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 arbetsytor",
         "plan_selection_description": "Jämför Hobby, Pro och Scale och byt sedan plan direkt från Formbricks.",
         "plan_selection_title": "Välj din plan",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "Lås upp alla funktioner",
         "trial_warning_remind_me_later": "Påminn mig senare",
         "unlimited_responses": "Obegränsade svar",
+        "unlimited_workflow_runs": "Obegränsade arbetsflödeskörningar",
         "unlimited_workspaces": "Obegränsat antal arbetsytor",
         "unlock_all_plan_features": "Lås upp alla {plan}-funktioner",
         "upgrade": "Uppgradera",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "Ayda 5.000 yanıt, <dynamicPricing>dinamik fiyatlandırma</dynamicPricing> ile",
         "plan_scale_feature_security": "2FA ve spam koruması",
         "plan_scale_feature_semantic_analysis": "Anlamsal Analiz (Yapay Zeka)",
-        "plan_scale_feature_workflows": "İş Akışları",
+        "plan_scale_feature_workflow_runs": "Ayda 1.000 iş akışı çalıştırması ile <dynamicPricing>dinamik fiyatlandırma</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 çalışma alanı",
         "plan_selection_description": "Hobby, Pro ve Scale planlarını karşılaştır, ardından doğrudan Formbricks'ten plan değiştir.",
         "plan_selection_title": "Planını seç",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "Tüm özelliklerin kilidini aç",
         "trial_warning_remind_me_later": "Daha sonra hatırlat",
         "unlimited_responses": "Sınırsız Yanıt",
+        "unlimited_workflow_runs": "Sınırsız İş Akışı Çalıştırması",
         "unlimited_workspaces": "Sınırsız Çalışma Alanı",
         "unlock_all_plan_features": "Tüm {plan} özelliklerinin kilidini aç",
         "upgrade": "Yükselt",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "每月 5,000 次响应，采用<dynamicPricing>动态定价</dynamicPricing>",
         "plan_scale_feature_security": "双因素认证和垃圾邮件防护",
         "plan_scale_feature_semantic_analysis": "语义分析（AI）",
-        "plan_scale_feature_workflows": "工作流",
+        "plan_scale_feature_workflow_runs": "每月 1,000 次工作流运行，采用<dynamicPricing>动态定价</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 个工作区",
         "plan_selection_description": "比较 Hobby、Pro 和 Scale 套餐，然后直接从 Formbricks 切换套餐。",
         "plan_selection_title": "选择您的套餐",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "解锁全部功能",
         "trial_warning_remind_me_later": "稍后提醒我",
         "unlimited_responses": "无限反馈",
+        "unlimited_workflow_runs": "无限工作流运行次数",
         "unlimited_workspaces": "无限工作区",
         "unlock_all_plan_features": "解锁所有 {plan} 功能",
         "upgrade": "升级",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -2581,7 +2581,7 @@
         "plan_scale_feature_responses": "每月 5,000 次回應，採用<dynamicPricing>動態定價</dynamicPricing>",
         "plan_scale_feature_security": "雙因素驗證與垃圾訊息防護",
         "plan_scale_feature_semantic_analysis": "語義分析（AI）",
-        "plan_scale_feature_workflows": "工作流程",
+        "plan_scale_feature_workflow_runs": "每月 1,000 次工作流程執行，採用<dynamicPricing>動態定價</dynamicPricing>",
         "plan_scale_feature_workspaces": "5 個工作區",
         "plan_selection_description": "比較 Hobby、Pro 和 Scale 方案，然後直接在 Formbricks 中切換方案。",
         "plan_selection_title": "選擇您的方案",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -2622,6 +2622,7 @@
         "trial_warning_add_payment_method": "解鎖所有功能",
         "trial_warning_remind_me_later": "稍後提醒我",
         "unlimited_responses": "無限回應",
+        "unlimited_workflow_runs": "無限制工作流程執行次數",
         "unlimited_workspaces": "無限工作區",
         "unlock_all_plan_features": "解鎖所有 {plan} 功能",
         "upgrade": "升級",

--- a/apps/web/modules/ee/billing/RUNBOOK-workflows-metering-prod.md
+++ b/apps/web/modules/ee/billing/RUNBOOK-workflows-metering-prod.md
@@ -20,8 +20,10 @@ Key facts:
 - **`reconcileCloudStripeSubscriptionsForOrganization` does NOT backfill line items** — existing Scale subs
   must be backfilled manually.
 - The usage card's "included" number is the **price's free-tier boundary** (global catalog), not the
-  entitlement. **Fail-closed:** if the workflow price is not graduated with a free first tier (finite
-  `up_to`), catalog construction throws and the billing page 500s — loud, pre-invoice, by design.
+  entitlement. **Fail-closed (workflow item only):** if the workflow price is not graduated with a free
+  first tier (finite `up_to`), the workflow item is dropped from the catalog (card hides, new subs skip
+  it — workflows just don't bill) and a loud `logger.error` fires. The rest of billing (base/responses
+  checkout, billing page) stays up. Watch logs for `Invalid workflow_runs price`.
 
 ## Rollout — do in order (order matters, fail-closed)
 
@@ -72,6 +74,8 @@ That gap is exactly what the backfill closes.
 
 ## Guardrails
 
-- Price MUST be graduated with a free first tier, else billing page 500s (loud, pre-invoice — intended).
-- Never two active workflow prices per plan/interval.
+- Price MUST be graduated with a free first tier. If not, the workflow item is silently dropped (card
+  hidden, not billed on new subs) and a `logger.error` ("Invalid workflow_runs price") fires — the rest
+  of billing stays up. Monitor logs; a bad price means workflows stop billing, not an outage.
+- Never two active workflow prices per plan/interval (that DOES break the catalog — `found 2`).
 - Deploy code before creating the price.

--- a/apps/web/modules/ee/billing/RUNBOOK-workflows-metering-prod.md
+++ b/apps/web/modules/ee/billing/RUNBOOK-workflows-metering-prod.md
@@ -1,0 +1,77 @@
+# Runbook — Enable metered workflow runs on prod (ENG-1936 / ENG-2193 / ENG-2194)
+
+Internal ops runbook. Turns on billing for workflow runs on Cloud (livemode Stripe) after PR #8735.
+Staging already has this; prod does not.
+
+## Background (how it works)
+
+Three Stripe objects drive the app per Scale org:
+
+- Availability entitlement — product feature lookup key **`workflows`** → `getIsWorkflowsEnabled(orgId)`.
+- Included-volume entitlement — product feature **`workflow-runs-included-1000`** → `limits.monthly.workflowRuns`.
+- Metered price — `formbricks_price_kind: workflow_runs`, attached to meter **`workflow_run_created`**.
+
+Key facts:
+
+- **Attaching a price to a product does NOT add it to existing subs.** Sub line items come from the app's
+  `getCatalogItemsForPlan`; only new checkouts + plan changes pick up the workflow line item.
+- **Entitlements (product features) auto-propagate** to every active subscriber. DB limits refresh on the
+  next billing **sync** (webhook `customer.subscription.*` / `invoice.*` → `syncOrganizationBillingFromStripe`).
+- **`reconcileCloudStripeSubscriptionsForOrganization` does NOT backfill line items** — existing Scale subs
+  must be backfilled manually.
+- The usage card's "included" number is the **price's free-tier boundary** (global catalog), not the
+  entitlement. **Fail-closed:** if the workflow price is not graduated with a free first tier (finite
+  `up_to`), catalog construction throws and the billing page 500s — loud, pre-invoice, by design.
+
+## Rollout — do in order (order matters, fail-closed)
+
+1. **Merge + deploy PR #8735.** Before a price exists, the catalog resolves the workflow price to null →
+   card hidden, no line item added. No breakage. Deploy first so provisioning + fail-closed validation are
+   live before any price appears.
+
+2. **Create the meter** (prod livemode): event name **`workflow_run_created`**, display "Workflow runs".
+
+3. **Create the metered price** on the Scale product (`prod_...` livemode):
+   - `usage_type: metered`, attached to the meter from step 2.
+   - **Graduated, first tier `unit_amount: 0` up to `1000`** (this boundary is what the card shows as
+     "included"), then overage tier(s) per pricing.
+   - metadata: `formbricks_price_kind: workflow_runs`, `formbricks_interval: monthly`.
+   - Exactly **one** active such price per plan (a duplicate → catalog throws "found 2").
+
+4. **Attach 2 product features** to the Scale product:
+   - `workflows` (availability).
+   - `workflow-runs-included-1000` (included volume; boundary must match the price's free tier = 1000).
+
+5. **Backfill existing Scale subs** — one metered line item each (no quantity):
+   ```
+   stripe subscription_items create --subscription <sub_id> --price <workflow_price_id>
+   ```
+   Script over every active Scale sub. Idempotent: skip subs that already have the workflow price.
+
+6. **Refresh DB limits** for existing orgs: step 5 fires `customer.subscription.updated` → sync runs
+   automatically. Otherwise trigger a forced sync per org.
+
+## How it starts working for existing Scale customers
+
+| Concern | Auto / manual | Reflects when |
+| --- | --- | --- |
+| Availability (`workflows`) | Auto — feature grants entitlement to all active subscribers | Next billing sync |
+| Included-volume limit | Auto — same | Next billing sync |
+| Usage card shows | Auto — reads global catalog price free-tier | Price active + code deployed |
+| Billing (runs → invoice) | **Manual** — line item not auto-added (reconcile doesn't backfill) | After step 5 |
+
+Until step 5, an existing customer's runs are metered but have no subscription item → **not invoiced**.
+That gap is exactly what the backfill closes.
+
+## Verify
+
+- New Scale checkout → sub has 3 items (base + responses + workflow_runs); billing page shows
+  "Workflow Runs 0 of 1000", no error.
+- Pick 1 existing (backfilled) customer → card shows included; a real run meters; upcoming invoice = $0
+  within 1000, charges only overage past it.
+
+## Guardrails
+
+- Price MUST be graduated with a free first tier, else billing page 500s (loud, pre-invoice — intended).
+- Never two active workflow prices per plan/interval.
+- Deploy code before creating the price.

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -310,10 +310,19 @@ export const PricingTable = ({
   })}`;
   const responsesUnlimitedCheck = organization.billing.limits.monthly.responses === null;
   const workspacesUnlimitedCheck = organization.billing.limits.workspaces === null;
-  // workflowRuns is null on plans that do not include workflows (unlike responses/workspaces, which
-  // exist on every plan). Only surface the usage card when a concrete included volume is set, so we
-  // never render a misleading "unlimited" badge for a plan that has no workflows at all.
-  const workflowRunsLimit = organization.billing.limits.monthly.workflowRuns;
+  // The workflow-runs card's included volume comes from the billing catalog (derived from the price's
+  // own free tier), NOT the entitlement limit, so the number shown is exactly what Stripe leaves
+  // uncharged — the two can't drift and reassure a customer they're inside an allowance while being
+  // billed (ENG-2193/2194). Null when the current plan has no workflow price, so the card hides.
+  const currentPlanCatalogItem =
+    currentCloudPlan === "hobby"
+      ? billingCatalog.hobby.monthly
+      : currentCloudPlan === "pro"
+        ? billingCatalog.pro[currentBillingInterval ?? "monthly"]
+        : currentCloudPlan === "scale"
+          ? billingCatalog.scale[currentBillingInterval ?? "monthly"]
+          : null;
+  const workflowRunsLimit = currentPlanCatalogItem?.workflowRunsIncluded ?? null;
   const trialEndDate = organization.billing.stripe?.trialEnd
     ? new Date(organization.billing.stripe.trialEnd)
     : null;

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -97,9 +97,8 @@ const STANDARD_PLAN_LEVEL: Record<TStandardPlan, number> = {
 const getCurrentPlanCatalogItem = (
   billingCatalog: TStripeBillingCatalogDisplay,
   currentCloudPlan: TDisplayPlan,
-  currentBillingInterval: TCloudBillingInterval | null
+  interval: TCloudBillingInterval
 ): TStripeBillingCatalogDisplayItem | null => {
-  const interval = currentBillingInterval ?? "monthly";
   if (currentCloudPlan === "hobby") return billingCatalog.hobby.monthly;
   if (currentCloudPlan === "pro") return billingCatalog.pro[interval];
   if (currentCloudPlan === "scale") return billingCatalog.scale[interval];
@@ -379,7 +378,7 @@ export const PricingTable = ({
   const currentPlanCatalogItem = getCurrentPlanCatalogItem(
     billingCatalog,
     currentCloudPlan,
-    currentBillingInterval
+    currentBillingInterval ?? "monthly"
   );
   const workflowRunsLimit = currentPlanCatalogItem?.workflowRunsIncluded ?? null;
   const trialEndDate = organization.billing.stripe?.trialEnd

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -1427,7 +1427,7 @@ export const PricingTable = ({
               </p>
             </div>
 
-            {workflowRunsLimit !== null && (
+            {workflowRunsLimit != null && (
               <UsageCard
                 metric={t("common.workflow_runs")}
                 currentCount={workflowRunCount}

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { type Stripe as StripeJs, loadStripe } from "@stripe/stripe-js";
+import type { TFunction } from "i18next";
 import { CheckIcon } from "lucide-react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -34,7 +35,10 @@ import {
   waitForBillingPaymentMethodAction,
   waitForBillingPlanAction,
 } from "../actions";
-import type { TStripeBillingCatalogDisplay } from "../lib/stripe-billing-catalog";
+import type {
+  TStripeBillingCatalogDisplay,
+  TStripeBillingCatalogDisplayItem,
+} from "../lib/stripe-billing-catalog";
 import { PlanComparisonTable, type TPlanColumn } from "./plan-comparison";
 import { PlanResponseFeature, PlanWorkflowRunsFeature } from "./response-pricing-tooltip";
 import { TrialAlert } from "./trial-alert";
@@ -85,6 +89,21 @@ const STANDARD_PLAN_LEVEL: Record<TStandardPlan, number> = {
   hobby: 0,
   pro: 1,
   scale: 2,
+};
+
+// Billing-catalog display item for the org's current plan/interval, or null for plans not in the
+// standard catalog (custom/unknown). Kept out of the component to avoid a nested ternary and hold the
+// component's cognitive complexity down.
+const getCurrentPlanCatalogItem = (
+  billingCatalog: TStripeBillingCatalogDisplay,
+  currentCloudPlan: TDisplayPlan,
+  currentBillingInterval: TCloudBillingInterval | null
+): TStripeBillingCatalogDisplayItem | null => {
+  const interval = currentBillingInterval ?? "monthly";
+  if (currentCloudPlan === "hobby") return billingCatalog.hobby.monthly;
+  if (currentCloudPlan === "pro") return billingCatalog.pro[interval];
+  if (currentCloudPlan === "scale") return billingCatalog.scale[interval];
+  return null;
 };
 
 const getCurrentCloudPlanLabel = (plan: TDisplayPlan, t: (key: string) => string) => {
@@ -237,6 +256,46 @@ const isSwitchAtPeriodEndCta = (
   return STANDARD_PLAN_LEVEL[plan] <= currentPlanLevel;
 };
 
+// Renders one plan-card feature row. Metered features (responses, workflow runs) show a tier tooltip
+// sourced from the catalog; plain text features just render their label. Extracted from PricingTable
+// to keep that component's cognitive complexity within bounds.
+const PlanFeatureContent = ({
+  feature,
+  billingCatalog,
+  selectedInterval,
+  locale,
+  t,
+}: Readonly<{
+  feature: TPlanFeature;
+  billingCatalog: TStripeBillingCatalogDisplay;
+  selectedInterval: TCloudBillingInterval;
+  locale: string;
+  t: TFunction;
+}>) => {
+  if (feature.type === "text") {
+    return <>{feature.label}</>;
+  }
+
+  if (feature.type === "responses") {
+    return (
+      <PlanResponseFeature
+        plan={feature.plan}
+        locale={locale}
+        overage={billingCatalog[feature.plan][selectedInterval].responseOverage}
+        t={t}
+      />
+    );
+  }
+
+  return (
+    <PlanWorkflowRunsFeature
+      locale={locale}
+      overage={billingCatalog[feature.plan][selectedInterval].workflowRunsOverage}
+      t={t}
+    />
+  );
+};
+
 export const PricingTable = ({
   organization,
   responseCount,
@@ -317,14 +376,11 @@ export const PricingTable = ({
   // own free tier), NOT the entitlement limit, so the number shown is exactly what Stripe leaves
   // uncharged — the two can't drift and reassure a customer they're inside an allowance while being
   // billed (ENG-2193/2194). Null when the current plan has no workflow price, so the card hides.
-  const currentPlanCatalogItem =
-    currentCloudPlan === "hobby"
-      ? billingCatalog.hobby.monthly
-      : currentCloudPlan === "pro"
-        ? billingCatalog.pro[currentBillingInterval ?? "monthly"]
-        : currentCloudPlan === "scale"
-          ? billingCatalog.scale[currentBillingInterval ?? "monthly"]
-          : null;
+  const currentPlanCatalogItem = getCurrentPlanCatalogItem(
+    billingCatalog,
+    currentCloudPlan,
+    currentBillingInterval
+  );
   const workflowRunsLimit = currentPlanCatalogItem?.workflowRunsIncluded ?? null;
   const trialEndDate = organization.billing.stripe?.trialEnd
     ? new Date(organization.billing.stripe.trialEnd)
@@ -1296,22 +1352,13 @@ export const PricingTable = ({
                     className="flex items-start gap-3 text-sm text-slate-700">
                     <CheckIcon className="mt-0.5 size-4 shrink-0 text-slate-500" />
                     <span>
-                      {feature.type === "text" && feature.label}
-                      {feature.type === "responses" && (
-                        <PlanResponseFeature
-                          plan={feature.plan}
-                          locale={locale}
-                          overage={billingCatalog[feature.plan][selectedInterval].responseOverage}
-                          t={t}
-                        />
-                      )}
-                      {feature.type === "workflow_runs" && (
-                        <PlanWorkflowRunsFeature
-                          locale={locale}
-                          overage={billingCatalog[feature.plan][selectedInterval].workflowRunsOverage}
-                          t={t}
-                        />
-                      )}
+                      <PlanFeatureContent
+                        feature={feature}
+                        billingCatalog={billingCatalog}
+                        selectedInterval={selectedInterval}
+                        locale={locale}
+                        t={t}
+                      />
                     </span>
                   </li>
                 ))}

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -36,7 +36,7 @@ import {
 } from "../actions";
 import type { TStripeBillingCatalogDisplay } from "../lib/stripe-billing-catalog";
 import { PlanComparisonTable, type TPlanColumn } from "./plan-comparison";
-import { PlanResponseFeature } from "./response-pricing-tooltip";
+import { PlanResponseFeature, PlanWorkflowRunsFeature } from "./response-pricing-tooltip";
 import { TrialAlert } from "./trial-alert";
 import { UsageCard } from "./usage-card";
 
@@ -107,7 +107,10 @@ const formatMoney = (currency: string, unitAmount: number | null, locale: string
   }).format(unitAmount / 100);
 };
 
-type TPlanFeature = { type: "text"; label: string } | { type: "responses"; plan: "pro" | "scale" };
+type TPlanFeature =
+  | { type: "text"; label: string }
+  | { type: "responses"; plan: "pro" | "scale" }
+  | { type: "workflow_runs"; plan: "scale" };
 
 type TPlanCardData = {
   plan: TStandardPlan;
@@ -656,7 +659,7 @@ export const PricingTable = ({
           { type: "text", label: t("workspace.settings.billing.plan_scale_feature_workspaces") },
           { type: "text", label: t("workspace.settings.billing.plan_scale_feature_rbac") },
           { type: "text", label: t("workspace.settings.billing.plan_scale_feature_quota") },
-          { type: "text", label: t("workspace.settings.billing.plan_scale_feature_workflows") },
+          { type: "workflow_runs", plan: "scale" },
           { type: "text", label: t("workspace.settings.billing.plan_scale_feature_feedback") },
           { type: "text", label: t("workspace.settings.billing.plan_scale_feature_semantic_analysis") },
           { type: "text", label: t("workspace.settings.billing.plan_scale_feature_security") },
@@ -1289,17 +1292,23 @@ export const PricingTable = ({
               <ul className="space-y-3">
                 {planCard.features.map((feature) => (
                   <li
-                    key={feature.type === "text" ? feature.label : `${feature.plan}-responses`}
+                    key={feature.type === "text" ? feature.label : `${feature.plan}-${feature.type}`}
                     className="flex items-start gap-3 text-sm text-slate-700">
                     <CheckIcon className="mt-0.5 size-4 shrink-0 text-slate-500" />
                     <span>
-                      {feature.type === "text" ? (
-                        feature.label
-                      ) : (
+                      {feature.type === "text" && feature.label}
+                      {feature.type === "responses" && (
                         <PlanResponseFeature
                           plan={feature.plan}
                           locale={locale}
                           overage={billingCatalog[feature.plan][selectedInterval].responseOverage}
+                          t={t}
+                        />
+                      )}
+                      {feature.type === "workflow_runs" && (
+                        <PlanWorkflowRunsFeature
+                          locale={locale}
+                          overage={billingCatalog[feature.plan][selectedInterval].workflowRunsOverage}
                           t={t}
                         />
                       )}

--- a/apps/web/modules/ee/billing/components/pricing-table.tsx
+++ b/apps/web/modules/ee/billing/components/pricing-table.tsx
@@ -66,6 +66,7 @@ interface PricingTableProps {
   organization: TOrganization;
   responseCount: number;
   workspaceCount: number;
+  workflowRunCount: number;
   isPlanComparison: boolean;
   usageCycleStart: Date;
   usageCycleEnd: Date;
@@ -237,6 +238,7 @@ export const PricingTable = ({
   organization,
   responseCount,
   workspaceCount,
+  workflowRunCount,
   isPlanComparison,
   usageCycleStart,
   usageCycleEnd,
@@ -308,6 +310,10 @@ export const PricingTable = ({
   })}`;
   const responsesUnlimitedCheck = organization.billing.limits.monthly.responses === null;
   const workspacesUnlimitedCheck = organization.billing.limits.workspaces === null;
+  // workflowRuns is null on plans that do not include workflows (unlike responses/workspaces, which
+  // exist on every plan). Only surface the usage card when a concrete included volume is set, so we
+  // never render a misleading "unlimited" badge for a plan that has no workflows at all.
+  const workflowRunsLimit = organization.billing.limits.monthly.workflowRuns;
   const trialEndDate = organization.billing.stripe?.trialEnd
     ? new Date(organization.billing.stripe.trialEnd)
     : null;
@@ -1420,6 +1426,16 @@ export const PricingTable = ({
                 {t("workspace.settings.billing.usage_cycle")}: {usageCycleLabel}
               </p>
             </div>
+
+            {workflowRunsLimit !== null && (
+              <UsageCard
+                metric={t("common.workflow_runs")}
+                currentCount={workflowRunCount}
+                limit={workflowRunsLimit}
+                isUnlimited={false}
+                unlimitedLabel={t("workspace.settings.billing.unlimited_workflow_runs")}
+              />
+            )}
 
             <UsageCard
               metric={t("common.workspaces")}

--- a/apps/web/modules/ee/billing/components/response-pricing-tooltip.tsx
+++ b/apps/web/modules/ee/billing/components/response-pricing-tooltip.tsx
@@ -92,3 +92,20 @@ export const PlanResponseFeature = ({ plan, locale, overage, t }: Readonly<PlanR
     <Trans i18nKey={i18nKey} components={{ dynamicPricing: dynamicPricingComponent(overage, locale) }} />
   );
 };
+
+interface PlanWorkflowRunsFeatureProps {
+  locale: string;
+  overage: TResponseOverageDisplay | null;
+  t: TFunction;
+}
+
+// Workflow runs are metered graduated like responses (Scale only). Same tier tooltip, sourced from
+// the workflow price's tiers so the shown pricing matches what Stripe charges (ENG-2194).
+export const PlanWorkflowRunsFeature = ({ locale, overage, t }: Readonly<PlanWorkflowRunsFeatureProps>) => {
+  return (
+    <Trans
+      i18nKey={t("workspace.settings.billing.plan_scale_feature_workflow_runs")}
+      components={{ dynamicPricing: dynamicPricingComponent(overage, locale) }}
+    />
+  );
+};

--- a/apps/web/modules/ee/billing/lib/organization-billing.ts
+++ b/apps/web/modules/ee/billing/lib/organization-billing.ts
@@ -584,9 +584,11 @@ export const createPaidPlanCheckoutSession = async (input: {
 
   const catalogItem = await getCatalogItemForPlan(input.plan, input.interval);
   const checkoutIntervals = new Set<Stripe.Price.Recurring.Interval>(
-    [catalogItem.basePrice.recurring?.interval, catalogItem.responsePrice?.recurring?.interval].filter(
-      (interval): interval is Stripe.Price.Recurring.Interval => interval != null
-    )
+    [
+      catalogItem.basePrice.recurring?.interval,
+      catalogItem.responsePrice?.recurring?.interval,
+      catalogItem.workflowRunsPrice?.recurring?.interval,
+    ].filter((interval): interval is Stripe.Price.Recurring.Interval => interval != null)
   );
 
   if (checkoutIntervals.size > 1) {
@@ -804,6 +806,7 @@ const getScheduleItemsForPlanChange = async (
   const targetItems = mapSubscriptionItemsToScheduleItems([
     { price: targetCatalogItem.basePrice, quantity: 1 },
     ...(targetCatalogItem.responsePrice ? [{ price: targetCatalogItem.responsePrice }] : []),
+    ...(targetCatalogItem.workflowRunsPrice ? [{ price: targetCatalogItem.workflowRunsPrice }] : []),
   ]);
 
   return { currentItems, targetItems };

--- a/apps/web/modules/ee/billing/lib/stripe-billing-catalog.test.ts
+++ b/apps/web/modules/ee/billing/lib/stripe-billing-catalog.test.ts
@@ -198,11 +198,12 @@ describe("stripe-billing-catalog", () => {
   );
 
   test(
-    "excludes a metered price tagged with a non-responses kind (e.g. workflow_runs) so it does not collide with responses",
+    "provisions a workflow_runs metered price as its own line item without colliding with responses",
     async () => {
-      // A second metered price on Scale, tagged workflow_runs (ENG-1936). Without the getPriceKind
-      // guard it would fall through usage_type=metered -> "responses" and produce two matches for
-      // scale/responses/monthly, breaking the billing page.
+      // A second metered price on Scale, tagged workflow_runs (ENG-1936). getPriceKind classifies it
+      // by its metadata kind rather than the usage_type=metered fallback, so it does NOT produce a
+      // second match for scale/responses/monthly (which would throw "found 2"), and it is added to the
+      // subscription as its own metered line item.
       const workflowRunsPrice = {
         id: "price_scale_workflow_runs",
         active: true,
@@ -235,10 +236,12 @@ describe("stripe-billing-catalog", () => {
 
       const { getCatalogItemsForPlan } = await import("./stripe-billing-catalog");
 
-      // Resolves without throwing "found 2", and the workflow_runs price is not part of the catalog.
+      // Resolves without throwing "found 2"; the workflow_runs price is added as its own metered
+      // line item (no quantity), alongside base and responses.
       await expect(getCatalogItemsForPlan("scale", "monthly")).resolves.toEqual([
         { price: "price_scale_monthly", quantity: 1 },
         { price: "price_scale_responses" },
+        { price: "price_scale_workflow_runs" },
       ]);
     },
     TEST_TIMEOUT_MS

--- a/apps/web/modules/ee/billing/lib/stripe-billing-catalog.test.ts
+++ b/apps/web/modules/ee/billing/lib/stripe-billing-catalog.test.ts
@@ -76,6 +76,34 @@ const createPrice = ({
   },
 });
 
+// A Scale metered workflow-run price (ENG-1936). Its metadata kind is what keeps it from being
+// misread as "responses" by the usage_type fallback.
+const createWorkflowRunsPrice = (id: string) => ({
+  id,
+  active: true,
+  currency: "usd",
+  unit_amount: 0,
+  tiers: RESPONSE_PRICE_TIERS,
+  tiers_mode: "graduated",
+  metadata: {
+    formbricks_plan: "scale",
+    formbricks_price_kind: "workflow_runs",
+    formbricks_interval: "monthly",
+  },
+  recurring: { usage_type: "metered", interval: "month" },
+  product: { id: "prod_scale", active: true, metadata: { formbricks_plan: "scale" } },
+});
+
+const STANDARD_CATALOG_PRICES = [
+  createPrice({ id: "price_hobby_monthly", plan: "hobby", kind: "base", interval: "monthly" }),
+  createPrice({ id: "price_pro_monthly", plan: "pro", kind: "base", interval: "monthly" }),
+  createPrice({ id: "price_pro_yearly", plan: "pro", kind: "base", interval: "yearly" }),
+  createPrice({ id: "price_pro_responses", plan: "pro", kind: "responses", interval: "monthly" }),
+  createPrice({ id: "price_scale_monthly", plan: "scale", kind: "base", interval: "monthly" }),
+  createPrice({ id: "price_scale_yearly", plan: "scale", kind: "base", interval: "yearly" }),
+  createPrice({ id: "price_scale_responses", plan: "scale", kind: "responses", interval: "monthly" }),
+];
+
 describe("stripe-billing-catalog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -204,33 +232,8 @@ describe("stripe-billing-catalog", () => {
       // by its metadata kind rather than the usage_type=metered fallback, so it does NOT produce a
       // second match for scale/responses/monthly (which would throw "found 2"), and it is added to the
       // subscription as its own metered line item.
-      const workflowRunsPrice = {
-        id: "price_scale_workflow_runs",
-        active: true,
-        currency: "usd",
-        unit_amount: 0,
-        tiers: RESPONSE_PRICE_TIERS,
-        tiers_mode: "graduated",
-        metadata: {
-          formbricks_plan: "scale",
-          formbricks_price_kind: "workflow_runs",
-          formbricks_interval: "monthly",
-        },
-        recurring: { usage_type: "metered", interval: "month" },
-        product: { id: "prod_scale", active: true, metadata: { formbricks_plan: "scale" } },
-      };
-
       mocks.pricesList.mockResolvedValue({
-        data: [
-          createPrice({ id: "price_hobby_monthly", plan: "hobby", kind: "base", interval: "monthly" }),
-          createPrice({ id: "price_pro_monthly", plan: "pro", kind: "base", interval: "monthly" }),
-          createPrice({ id: "price_pro_yearly", plan: "pro", kind: "base", interval: "yearly" }),
-          createPrice({ id: "price_pro_responses", plan: "pro", kind: "responses", interval: "monthly" }),
-          createPrice({ id: "price_scale_monthly", plan: "scale", kind: "base", interval: "monthly" }),
-          createPrice({ id: "price_scale_yearly", plan: "scale", kind: "base", interval: "yearly" }),
-          createPrice({ id: "price_scale_responses", plan: "scale", kind: "responses", interval: "monthly" }),
-          workflowRunsPrice,
-        ],
+        data: [...STANDARD_CATALOG_PRICES, createWorkflowRunsPrice("price_scale_workflow_runs")],
         has_more: false,
       });
 
@@ -243,6 +246,49 @@ describe("stripe-billing-catalog", () => {
         { price: "price_scale_responses" },
         { price: "price_scale_workflow_runs" },
       ]);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  test(
+    "omits the workflow_runs line item when no such price exists on the plan (getOptionalSinglePrice -> null)",
+    async () => {
+      // No workflow_runs price anywhere in the catalog: the optional lookup resolves to null and the
+      // Scale subscription is provisioned with base + responses only.
+      mocks.pricesList.mockResolvedValue({
+        data: STANDARD_CATALOG_PRICES,
+        has_more: false,
+      });
+
+      const { getCatalogItemsForPlan } = await import("./stripe-billing-catalog");
+
+      await expect(getCatalogItemsForPlan("scale", "monthly")).resolves.toEqual([
+        { price: "price_scale_monthly", quantity: 1 },
+        { price: "price_scale_responses" },
+      ]);
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  test(
+    "rejects catalog construction when a plan has ambiguous (duplicate) workflow_runs prices",
+    async () => {
+      // Two active workflow_runs prices for scale/monthly: getOptionalSinglePrice must surface the
+      // ambiguity rather than silently pick one, so the whole catalog build fails fast.
+      mocks.pricesList.mockResolvedValue({
+        data: [
+          ...STANDARD_CATALOG_PRICES,
+          createWorkflowRunsPrice("price_scale_workflow_runs_a"),
+          createWorkflowRunsPrice("price_scale_workflow_runs_b"),
+        ],
+        has_more: false,
+      });
+
+      const { getCatalogItemsForPlan } = await import("./stripe-billing-catalog");
+
+      await expect(getCatalogItemsForPlan("scale", "monthly")).rejects.toThrow(
+        "Expected at most one Stripe price for scale/workflow_runs/monthly, but found 2"
+      );
     },
     TEST_TIMEOUT_MS
   );

--- a/apps/web/modules/ee/billing/lib/stripe-billing-catalog.test.ts
+++ b/apps/web/modules/ee/billing/lib/stripe-billing-catalog.test.ts
@@ -156,6 +156,7 @@ describe("stripe-billing-catalog", () => {
             unitAmount: 1000,
             responseOverage: null,
             workflowRunsIncluded: null,
+            workflowRunsOverage: null,
           },
         },
         pro: {
@@ -166,6 +167,7 @@ describe("stripe-billing-catalog", () => {
             unitAmount: 1000,
             responseOverage: EXPECTED_RESPONSE_OVERAGE,
             workflowRunsIncluded: null,
+            workflowRunsOverage: null,
           },
           yearly: {
             plan: "pro",
@@ -174,6 +176,7 @@ describe("stripe-billing-catalog", () => {
             unitAmount: 10000,
             responseOverage: EXPECTED_RESPONSE_OVERAGE,
             workflowRunsIncluded: null,
+            workflowRunsOverage: null,
           },
         },
         scale: {
@@ -184,6 +187,7 @@ describe("stripe-billing-catalog", () => {
             unitAmount: 1000,
             responseOverage: EXPECTED_RESPONSE_OVERAGE,
             workflowRunsIncluded: null,
+            workflowRunsOverage: null,
           },
           yearly: {
             plan: "scale",
@@ -192,6 +196,7 @@ describe("stripe-billing-catalog", () => {
             unitAmount: 10000,
             responseOverage: EXPECTED_RESPONSE_OVERAGE,
             workflowRunsIncluded: null,
+            workflowRunsOverage: null,
           },
         },
       });
@@ -316,6 +321,9 @@ describe("stripe-billing-catalog", () => {
       expect(display.scale.yearly.workflowRunsIncluded).toBe(2000);
       expect(display.pro.monthly.workflowRunsIncluded).toBeNull();
       expect(display.hobby.monthly.workflowRunsIncluded).toBeNull();
+      // The graduated tiers are exposed for the plan-card tooltip, straight from the price.
+      expect(display.scale.monthly.workflowRunsOverage).toEqual(EXPECTED_RESPONSE_OVERAGE);
+      expect(display.pro.monthly.workflowRunsOverage).toBeNull();
     },
     TEST_TIMEOUT_MS
   );

--- a/apps/web/modules/ee/billing/lib/stripe-billing-catalog.test.ts
+++ b/apps/web/modules/ee/billing/lib/stripe-billing-catalog.test.ts
@@ -7,6 +7,11 @@ const TEST_TIMEOUT_MS = 15_000;
 const mocks = vi.hoisted(() => ({
   pricesList: vi.fn(),
   cacheWithCache: vi.fn(),
+  loggerError: vi.fn(),
+}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: { error: mocks.loggerError },
 }));
 
 vi.mock("./stripe-client", () => ({
@@ -329,11 +334,13 @@ describe("stripe-billing-catalog", () => {
   );
 
   test(
-    "fails closed when the workflow price cannot honor its included volume (no free first tier)",
+    "degrades the workflow item only (keeps the catalog up) when the workflow price has no free first tier",
     async () => {
       // The footgun: a metered workflow price that charges from run #1 (first tier is NOT free). The
-      // usage card would claim "X of N included" while Stripe invoices every run. Rather than render a
-      // reassuring-but-false allowance, catalog construction must throw (ENG-2193/2194).
+      // usage card must not claim "X of N included" while Stripe invoices every run. Rather than take
+      // down the whole catalog (checkout + billing for every plan), the workflow item is dropped
+      // (price + included → null, card hides, new subs skip it) and the failure is logged loudly; the
+      // rest of the catalog resolves normally (ENG-2193/2194).
       const paidFromFirstUnit = {
         ...createWorkflowRunsPrice("price_scale_workflow_runs"),
         tiers: [
@@ -359,11 +366,21 @@ describe("stripe-billing-catalog", () => {
         has_more: false,
       });
 
-      const { getStripeBillingCatalogDisplay } = await import("./stripe-billing-catalog");
+      const { getStripeBillingCatalogDisplay, getCatalogItemsForPlan } =
+        await import("./stripe-billing-catalog");
 
-      await expect(getStripeBillingCatalogDisplay()).rejects.toThrow(
-        "must be graduated with a free first tier"
-      );
+      // Catalog resolves — no throw — and the workflow item is degraded to null (no false allowance).
+      const display = await getStripeBillingCatalogDisplay();
+      expect(display.scale.monthly.workflowRunsIncluded).toBeNull();
+      expect(display.scale.monthly.workflowRunsOverage).toBeNull();
+
+      // New Scale checkout skips the misconfigured workflow price (base + responses only).
+      await expect(getCatalogItemsForPlan("scale", "monthly")).resolves.toEqual([
+        { price: "price_scale_monthly", quantity: 1 },
+        { price: "price_scale_responses" },
+      ]);
+
+      expect(mocks.loggerError).toHaveBeenCalled();
     },
     TEST_TIMEOUT_MS
   );

--- a/apps/web/modules/ee/billing/lib/stripe-billing-catalog.test.ts
+++ b/apps/web/modules/ee/billing/lib/stripe-billing-catalog.test.ts
@@ -155,6 +155,7 @@ describe("stripe-billing-catalog", () => {
             currency: "usd",
             unitAmount: 1000,
             responseOverage: null,
+            workflowRunsIncluded: null,
           },
         },
         pro: {
@@ -164,6 +165,7 @@ describe("stripe-billing-catalog", () => {
             currency: "usd",
             unitAmount: 1000,
             responseOverage: EXPECTED_RESPONSE_OVERAGE,
+            workflowRunsIncluded: null,
           },
           yearly: {
             plan: "pro",
@@ -171,6 +173,7 @@ describe("stripe-billing-catalog", () => {
             currency: "usd",
             unitAmount: 10000,
             responseOverage: EXPECTED_RESPONSE_OVERAGE,
+            workflowRunsIncluded: null,
           },
         },
         scale: {
@@ -180,6 +183,7 @@ describe("stripe-billing-catalog", () => {
             currency: "usd",
             unitAmount: 1000,
             responseOverage: EXPECTED_RESPONSE_OVERAGE,
+            workflowRunsIncluded: null,
           },
           yearly: {
             plan: "scale",
@@ -187,6 +191,7 @@ describe("stripe-billing-catalog", () => {
             currency: "usd",
             unitAmount: 10000,
             responseOverage: EXPECTED_RESPONSE_OVERAGE,
+            workflowRunsIncluded: null,
           },
         },
       });
@@ -288,6 +293,68 @@ describe("stripe-billing-catalog", () => {
 
       await expect(getCatalogItemsForPlan("scale", "monthly")).rejects.toThrow(
         "Expected at most one Stripe price for scale/workflow_runs/monthly, but found 2"
+      );
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  test(
+    "exposes the included workflow-run volume from the price's free first tier (single source of truth)",
+    async () => {
+      // createWorkflowRunsPrice uses RESPONSE_PRICE_TIERS whose first tier is free (unit_amount 0) up
+      // to 2000, so the displayed included volume must be 2000 — derived from the price, not an
+      // entitlement — and null on plans with no workflow price.
+      mocks.pricesList.mockResolvedValue({
+        data: [...STANDARD_CATALOG_PRICES, createWorkflowRunsPrice("price_scale_workflow_runs")],
+        has_more: false,
+      });
+
+      const { getStripeBillingCatalogDisplay } = await import("./stripe-billing-catalog");
+      const display = await getStripeBillingCatalogDisplay();
+
+      expect(display.scale.monthly.workflowRunsIncluded).toBe(2000);
+      expect(display.scale.yearly.workflowRunsIncluded).toBe(2000);
+      expect(display.pro.monthly.workflowRunsIncluded).toBeNull();
+      expect(display.hobby.monthly.workflowRunsIncluded).toBeNull();
+    },
+    TEST_TIMEOUT_MS
+  );
+
+  test(
+    "fails closed when the workflow price cannot honor its included volume (no free first tier)",
+    async () => {
+      // The footgun: a metered workflow price that charges from run #1 (first tier is NOT free). The
+      // usage card would claim "X of N included" while Stripe invoices every run. Rather than render a
+      // reassuring-but-false allowance, catalog construction must throw (ENG-2193/2194).
+      const paidFromFirstUnit = {
+        ...createWorkflowRunsPrice("price_scale_workflow_runs"),
+        tiers: [
+          {
+            flat_amount: null,
+            flat_amount_decimal: null,
+            unit_amount: 8,
+            unit_amount_decimal: "8",
+            up_to: 2000,
+          },
+          {
+            flat_amount: null,
+            flat_amount_decimal: null,
+            unit_amount: 2,
+            unit_amount_decimal: "2",
+            up_to: null,
+          },
+        ],
+      };
+
+      mocks.pricesList.mockResolvedValue({
+        data: [...STANDARD_CATALOG_PRICES, paidFromFirstUnit],
+        has_more: false,
+      });
+
+      const { getStripeBillingCatalogDisplay } = await import("./stripe-billing-catalog");
+
+      await expect(getStripeBillingCatalogDisplay()).rejects.toThrow(
+        "must be graduated with a free first tier"
       );
     },
     TEST_TIMEOUT_MS

--- a/apps/web/modules/ee/billing/lib/stripe-billing-catalog.ts
+++ b/apps/web/modules/ee/billing/lib/stripe-billing-catalog.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { cache as reactCache } from "react";
 import Stripe from "stripe";
 import { createCacheKey } from "@formbricks/cache";
+import { logger } from "@formbricks/logger";
 import type { TCloudBillingInterval } from "@formbricks/types/organizations";
 import { cache } from "@/lib/cache";
 import { env } from "@/lib/env";
@@ -241,7 +242,8 @@ const getOptionalSinglePrice = (
 // free (unit_amount 0, flat_amount 0) up to a finite boundary grants exactly that many free runs —
 // the number the usage card shows. Any other shape (flat per-unit, a paid first tier, or an
 // unbounded free tier) means the card's "X of N included" would not match what Stripe charges, so we
-// throw rather than render a reassuring-but-false allowance (ENG-2193/2194). Returns null when the
+// throw rather than let a reassuring-but-false allowance render (ENG-2193/2194). The caller catches
+// this and degrades the workflow item only, keeping the rest of the catalog up. Returns null when the
 // plan has no workflow price at all.
 const resolveWorkflowIncludedVolume = (price: TStripeCatalogPrice | null, label: string): number | null => {
   if (!price) {
@@ -277,14 +279,32 @@ const fetchStripeBillingCatalog = async (): Promise<TStripeBillingCatalog> => {
 
   // Resolve the workflow price AND its validated included volume together, so both the price object
   // and the number the UI trusts come from the same source and can't drift.
+  //
+  // Fail closed on the WORKFLOW ITEM ONLY, not the whole catalog: a misconfigured workflow price
+  // (see resolveWorkflowIncludedVolume) drops the workflow price + included volume to null and logs
+  // loudly, instead of throwing. The card then hides and new checkouts skip the workflow line item —
+  // i.e. workflows simply don't bill, today's harmless state — while base/responses checkout and the
+  // billing page for every plan/org stay up. Base/responses themselves stay fail-loud (getSinglePrice
+  // throws): they are load-bearing on every plan, so a missing one is a real catalog outage.
   const workflowRuns = (
     plan: TStandardCloudPlan
   ): Pick<TStripeBillingCatalogItem, "workflowRunsPrice" | "workflowRunsIncluded"> => {
     const workflowRunsPrice = getOptionalSinglePrice(prices, plan, "workflow_runs", "monthly");
-    return {
-      workflowRunsPrice,
-      workflowRunsIncluded: resolveWorkflowIncludedVolume(workflowRunsPrice, `${plan}/workflow_runs/monthly`),
-    };
+    try {
+      return {
+        workflowRunsPrice,
+        workflowRunsIncluded: resolveWorkflowIncludedVolume(
+          workflowRunsPrice,
+          `${plan}/workflow_runs/monthly`
+        ),
+      };
+    } catch (error) {
+      logger.error(
+        { error, plan, priceId: workflowRunsPrice?.id },
+        "Invalid workflow_runs price; excluding it from the catalog so the rest of billing stays up"
+      );
+      return { workflowRunsPrice: null, workflowRunsIncluded: null };
+    }
   };
 
   return {

--- a/apps/web/modules/ee/billing/lib/stripe-billing-catalog.ts
+++ b/apps/web/modules/ee/billing/lib/stripe-billing-catalog.ts
@@ -60,6 +60,9 @@ export type TStripeBillingCatalogDisplayItem = {
   responseOverage: TResponseOverageDisplay | null;
   // Free workflow-run allowance derived from the price's free first tier (see TStripeBillingCatalogItem).
   workflowRunsIncluded: number | null;
+  // Graduated overage tiers for workflow runs, derived from the price (same shape/source as
+  // responseOverage) so the plan card can show the per-unit tier table straight from Stripe.
+  workflowRunsOverage: TResponseOverageDisplay | null;
 };
 
 export type TStripeBillingCatalogDisplay = {
@@ -337,19 +340,21 @@ export const getStripeBillingCatalog = reactCache(async (): Promise<TStripeBilli
   );
 });
 
-const toResponseOverageDisplay = (item: TStripeBillingCatalogItem): TResponseOverageDisplay | null => {
-  // The tier table renders graduated semantics (each band priced separately),
-  // so volume-mode prices must not be displayed with it.
-  if (item.responsePrice?.tiers_mode !== "graduated") {
+// Derive the per-unit overage tier table shown in the plan card straight from a graduated Stripe
+// price, so the displayed pricing can never drift from what Stripe charges. Used for both responses
+// and workflow-run metered prices. The tier table renders graduated semantics (each band priced
+// separately), so volume-mode prices must not be displayed with it.
+const toOverageDisplay = (price: TStripeCatalogPrice | null): TResponseOverageDisplay | null => {
+  if (price?.tiers_mode !== "graduated") {
     return null;
   }
 
-  const tiers = mapStripeTiersToResponsePricingTiers(item.responsePrice.tiers);
+  const tiers = mapStripeTiersToResponsePricingTiers(price.tiers);
   if (!tiers) {
     return null;
   }
 
-  return { currency: item.responsePrice.currency, tiers };
+  return { currency: price.currency, tiers };
 };
 
 const toDisplayItem = (item: TStripeBillingCatalogItem): TStripeBillingCatalogDisplayItem => ({
@@ -357,8 +362,9 @@ const toDisplayItem = (item: TStripeBillingCatalogItem): TStripeBillingCatalogDi
   interval: item.interval,
   currency: item.basePrice.currency,
   unitAmount: item.basePrice.unit_amount,
-  responseOverage: toResponseOverageDisplay(item),
+  responseOverage: toOverageDisplay(item.responsePrice),
   workflowRunsIncluded: item.workflowRunsIncluded,
+  workflowRunsOverage: toOverageDisplay(item.workflowRunsPrice),
 });
 
 export const getStripeBillingCatalogDisplay = reactCache(async (): Promise<TStripeBillingCatalogDisplay> => {

--- a/apps/web/modules/ee/billing/lib/stripe-billing-catalog.ts
+++ b/apps/web/modules/ee/billing/lib/stripe-billing-catalog.ts
@@ -25,6 +25,12 @@ export type TStripeBillingCatalogItem = {
   // elsewhere. Like responsePrice it is always the monthly-billed metered variant, even for a yearly
   // base, because usage is aggregated and billed monthly (ENG-1936).
   workflowRunsPrice: TStripeCatalogPrice | null;
+  // The included (free) workflow-run allowance DERIVED FROM the price's own free first tier — the
+  // single source of truth the usage card renders. Null when there is no workflow price. This is
+  // deliberately NOT the entitlement's included-<n> value: the number the UI shows and the number
+  // Stripe leaves uncharged must be the same object, or the card can reassure a customer they are
+  // inside an allowance while Stripe invoices them (ENG-2193/2194).
+  workflowRunsIncluded: number | null;
 };
 
 export type TStripeBillingCatalog = {
@@ -52,6 +58,8 @@ export type TStripeBillingCatalogDisplayItem = {
   currency: string;
   unitAmount: number | null;
   responseOverage: TResponseOverageDisplay | null;
+  // Free workflow-run allowance derived from the price's free first tier (see TStripeBillingCatalogItem).
+  workflowRunsIncluded: number | null;
 };
 
 export type TStripeBillingCatalogDisplay = {
@@ -225,6 +233,34 @@ const getOptionalSinglePrice = (
   return matches[0] ?? null;
 };
 
+// Resolve the included (free) workflow-run allowance from the price's OWN tier structure, and fail
+// closed if the price can't honor an "included volume" claim. A graduated price whose first tier is
+// free (unit_amount 0, flat_amount 0) up to a finite boundary grants exactly that many free runs —
+// the number the usage card shows. Any other shape (flat per-unit, a paid first tier, or an
+// unbounded free tier) means the card's "X of N included" would not match what Stripe charges, so we
+// throw rather than render a reassuring-but-false allowance (ENG-2193/2194). Returns null when the
+// plan has no workflow price at all.
+const resolveWorkflowIncludedVolume = (price: TStripeCatalogPrice | null, label: string): number | null => {
+  if (!price) {
+    return null;
+  }
+
+  const firstTier = price.tiers?.[0];
+  const firstTierIsFree =
+    firstTier != null && (firstTier.unit_amount ?? 0) === 0 && (firstTier.flat_amount ?? 0) === 0;
+
+  if (price.tiers_mode !== "graduated" || !firstTierIsFree || typeof firstTier?.up_to !== "number") {
+    throw new Error(
+      `Metered workflow price ${label} (${price.id}) must be graduated with a free first tier ` +
+        `(unit_amount 0, finite up_to) so the included volume shown to customers matches what Stripe ` +
+        `leaves uncharged; got tiers_mode=${price.tiers_mode ?? "null"}, ` +
+        `firstTier=${JSON.stringify(firstTier ?? null)}`
+    );
+  }
+
+  return firstTier.up_to;
+};
+
 const fetchStripeBillingCatalog = async (): Promise<TStripeBillingCatalog> => {
   if (!stripeClient) {
     throw new Error("Stripe is not configured");
@@ -236,6 +272,18 @@ const fetchStripeBillingCatalog = async (): Promise<TStripeBillingCatalog> => {
     throw new Error("No active Stripe billing catalog prices found");
   }
 
+  // Resolve the workflow price AND its validated included volume together, so both the price object
+  // and the number the UI trusts come from the same source and can't drift.
+  const workflowRuns = (
+    plan: TStandardCloudPlan
+  ): Pick<TStripeBillingCatalogItem, "workflowRunsPrice" | "workflowRunsIncluded"> => {
+    const workflowRunsPrice = getOptionalSinglePrice(prices, plan, "workflow_runs", "monthly");
+    return {
+      workflowRunsPrice,
+      workflowRunsIncluded: resolveWorkflowIncludedVolume(workflowRunsPrice, `${plan}/workflow_runs/monthly`),
+    };
+  };
+
   return {
     hobby: {
       monthly: {
@@ -243,7 +291,7 @@ const fetchStripeBillingCatalog = async (): Promise<TStripeBillingCatalog> => {
         interval: "monthly",
         basePrice: getSinglePrice(prices, "hobby", "base", "monthly"),
         responsePrice: null,
-        workflowRunsPrice: getOptionalSinglePrice(prices, "hobby", "workflow_runs", "monthly"),
+        ...workflowRuns("hobby"),
       },
     },
     pro: {
@@ -252,14 +300,14 @@ const fetchStripeBillingCatalog = async (): Promise<TStripeBillingCatalog> => {
         interval: "monthly",
         basePrice: getSinglePrice(prices, "pro", "base", "monthly"),
         responsePrice: getSinglePrice(prices, "pro", "responses", "monthly"),
-        workflowRunsPrice: getOptionalSinglePrice(prices, "pro", "workflow_runs", "monthly"),
+        ...workflowRuns("pro"),
       },
       yearly: {
         plan: "pro",
         interval: "yearly",
         basePrice: getSinglePrice(prices, "pro", "base", "yearly"),
         responsePrice: getSinglePrice(prices, "pro", "responses", "monthly"),
-        workflowRunsPrice: getOptionalSinglePrice(prices, "pro", "workflow_runs", "monthly"),
+        ...workflowRuns("pro"),
       },
     },
     scale: {
@@ -268,14 +316,14 @@ const fetchStripeBillingCatalog = async (): Promise<TStripeBillingCatalog> => {
         interval: "monthly",
         basePrice: getSinglePrice(prices, "scale", "base", "monthly"),
         responsePrice: getSinglePrice(prices, "scale", "responses", "monthly"),
-        workflowRunsPrice: getOptionalSinglePrice(prices, "scale", "workflow_runs", "monthly"),
+        ...workflowRuns("scale"),
       },
       yearly: {
         plan: "scale",
         interval: "yearly",
         basePrice: getSinglePrice(prices, "scale", "base", "yearly"),
         responsePrice: getSinglePrice(prices, "scale", "responses", "monthly"),
-        workflowRunsPrice: getOptionalSinglePrice(prices, "scale", "workflow_runs", "monthly"),
+        ...workflowRuns("scale"),
       },
     },
   };
@@ -310,6 +358,7 @@ const toDisplayItem = (item: TStripeBillingCatalogItem): TStripeBillingCatalogDi
   currency: item.basePrice.currency,
   unitAmount: item.basePrice.unit_amount,
   responseOverage: toResponseOverageDisplay(item),
+  workflowRunsIncluded: item.workflowRunsIncluded,
 });
 
 export const getStripeBillingCatalogDisplay = reactCache(async (): Promise<TStripeBillingCatalogDisplay> => {

--- a/apps/web/modules/ee/billing/lib/stripe-billing-catalog.ts
+++ b/apps/web/modules/ee/billing/lib/stripe-billing-catalog.ts
@@ -10,7 +10,7 @@ import { type TResponsePricingTier, mapStripeTiersToResponsePricingTiers } from 
 import { stripeClient } from "./stripe-client";
 
 export type TStandardCloudPlan = "hobby" | "pro" | "scale";
-type TStripePriceKind = "base" | "responses";
+type TStripePriceKind = "base" | "responses" | "workflow_runs";
 
 type TStripeCatalogPrice = Stripe.Price & {
   product: Stripe.Product | Stripe.DeletedProduct;
@@ -21,6 +21,10 @@ export type TStripeBillingCatalogItem = {
   interval: TCloudBillingInterval;
   basePrice: TStripeCatalogPrice;
   responsePrice: TStripeCatalogPrice | null;
+  // Metered workflow-run overage. Only present on plans that include workflows (Scale today); null
+  // elsewhere. Like responsePrice it is always the monthly-billed metered variant, even for a yearly
+  // base, because usage is aggregated and billed monthly (ENG-1936).
+  workflowRunsPrice: TStripeCatalogPrice | null;
 };
 
 export type TStripeBillingCatalog = {
@@ -66,8 +70,8 @@ export type TStripeBillingCatalogDisplay = {
 
 const STANDARD_CLOUD_PLANS = new Set<TStandardCloudPlan>(["hobby", "pro", "scale"]);
 const STRIPE_BILLING_CATALOG_CACHE_TTL_MS = 10 * 60 * 1000;
-// v2: response prices include expanded tiers
-const STRIPE_BILLING_CATALOG_CACHE_VERSION = "v2";
+// v3: catalog item carries workflowRunsPrice (metered workflow overage)
+const STRIPE_BILLING_CATALOG_CACHE_VERSION = "v3";
 
 const getStripeBillingCatalogCacheKey = () =>
   createCacheKey.custom(
@@ -114,14 +118,13 @@ const getPriceInterval = (price: Stripe.Price): TCloudBillingInterval | null => 
 
 const getPriceKind = (price: Stripe.Price): TStripePriceKind | null => {
   const metadataKind = price.metadata?.formbricks_price_kind;
-  if (metadataKind === "base" || metadataKind === "responses") {
+  if (metadataKind === "base" || metadataKind === "responses" || metadataKind === "workflow_runs") {
     return metadataKind;
   }
 
-  // A metered price explicitly tagged with a different kind (e.g. "workflow_runs") is a separate
-  // metered product, not part of the base/responses plan catalog. Exclude it here so the usage_type
-  // fallback below can't misclassify it as "responses" and collide with the real responses price on
-  // the same plan/interval (ENG-1936). Full catalog wiring for such kinds is added separately.
+  // A metered price tagged with an unrecognized kind is a separate metered product, not part of the
+  // plan catalog. Exclude it here so the usage_type fallback below can't misclassify it as
+  // "responses" and collide with the real responses price on the same plan/interval (ENG-1936).
   if (metadataKind) {
     return null;
   }
@@ -199,6 +202,29 @@ const getSinglePrice = (
   return matches[0];
 };
 
+// Like getSinglePrice, but tolerates absence: returns null when no price matches (the kind is not
+// offered on this plan), still throwing on ambiguity (>1) so a duplicate can never be silently
+// ignored. Used for optional kinds like workflow_runs that exist only on some plans.
+const getOptionalSinglePrice = (
+  prices: TStripeCatalogPrice[],
+  plan: TStandardCloudPlan,
+  kind: TStripePriceKind,
+  interval: TCloudBillingInterval
+): TStripeCatalogPrice | null => {
+  const matches = prices.filter(
+    (price) =>
+      getPricePlan(price) === plan && getPriceKind(price) === kind && getPriceInterval(price) === interval
+  );
+
+  if (matches.length > 1) {
+    throw new Error(
+      `Expected at most one Stripe price for ${plan}/${kind}/${interval}, but found ${matches.length}`
+    );
+  }
+
+  return matches[0] ?? null;
+};
+
 const fetchStripeBillingCatalog = async (): Promise<TStripeBillingCatalog> => {
   if (!stripeClient) {
     throw new Error("Stripe is not configured");
@@ -217,6 +243,7 @@ const fetchStripeBillingCatalog = async (): Promise<TStripeBillingCatalog> => {
         interval: "monthly",
         basePrice: getSinglePrice(prices, "hobby", "base", "monthly"),
         responsePrice: null,
+        workflowRunsPrice: getOptionalSinglePrice(prices, "hobby", "workflow_runs", "monthly"),
       },
     },
     pro: {
@@ -225,12 +252,14 @@ const fetchStripeBillingCatalog = async (): Promise<TStripeBillingCatalog> => {
         interval: "monthly",
         basePrice: getSinglePrice(prices, "pro", "base", "monthly"),
         responsePrice: getSinglePrice(prices, "pro", "responses", "monthly"),
+        workflowRunsPrice: getOptionalSinglePrice(prices, "pro", "workflow_runs", "monthly"),
       },
       yearly: {
         plan: "pro",
         interval: "yearly",
         basePrice: getSinglePrice(prices, "pro", "base", "yearly"),
         responsePrice: getSinglePrice(prices, "pro", "responses", "monthly"),
+        workflowRunsPrice: getOptionalSinglePrice(prices, "pro", "workflow_runs", "monthly"),
       },
     },
     scale: {
@@ -239,12 +268,14 @@ const fetchStripeBillingCatalog = async (): Promise<TStripeBillingCatalog> => {
         interval: "monthly",
         basePrice: getSinglePrice(prices, "scale", "base", "monthly"),
         responsePrice: getSinglePrice(prices, "scale", "responses", "monthly"),
+        workflowRunsPrice: getOptionalSinglePrice(prices, "scale", "workflow_runs", "monthly"),
       },
       yearly: {
         plan: "scale",
         interval: "yearly",
         basePrice: getSinglePrice(prices, "scale", "base", "yearly"),
         responsePrice: getSinglePrice(prices, "scale", "responses", "monthly"),
+        workflowRunsPrice: getOptionalSinglePrice(prices, "scale", "workflow_runs", "monthly"),
       },
     },
   };
@@ -321,6 +352,8 @@ export const getCatalogItemsForPlan = async (
   return [
     { price: item.basePrice.id, quantity: 1 },
     ...(item.responsePrice ? [{ price: item.responsePrice.id }] : []),
+    // Metered items carry no quantity (usage is reported via meter events).
+    ...(item.workflowRunsPrice ? [{ price: item.workflowRunsPrice.id }] : []),
   ];
 };
 

--- a/apps/web/modules/ee/billing/page.tsx
+++ b/apps/web/modules/ee/billing/page.tsx
@@ -1,7 +1,10 @@
 import { notFound } from "next/navigation";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { env } from "@/lib/env";
-import { getMonthlyOrganizationResponseCount } from "@/lib/organization/service";
+import {
+  getMonthlyOrganizationResponseCount,
+  getMonthlyOrganizationWorkflowRunCount,
+} from "@/lib/organization/service";
 import { getPostHogFeatureFlag } from "@/lib/posthog/get-feature-flag";
 import { getOrganizationWorkspacesCount } from "@/lib/workspace/service";
 import { getTranslate } from "@/lingodotdev/server";
@@ -32,9 +35,10 @@ export const PricingPage = async (props: { params: Promise<{ organizationId: str
     billing: cloudBillingDisplayContext.billing,
   };
 
-  const [responseCount, workspaceCount, planComparisonFlag] = await Promise.all([
+  const [responseCount, workspaceCount, workflowRunCount, planComparisonFlag] = await Promise.all([
     getMonthlyOrganizationResponseCount(organization.id),
     getOrganizationWorkspacesCount(organization.id),
+    getMonthlyOrganizationWorkflowRunCount(organization.id),
     getPostHogFeatureFlag(session.user.id, "a-b_billing_plan-comparison-table"),
   ]);
 
@@ -48,6 +52,7 @@ export const PricingPage = async (props: { params: Promise<{ organizationId: str
         organization={organizationWithSyncedBilling}
         responseCount={responseCount}
         workspaceCount={workspaceCount}
+        workflowRunCount={workflowRunCount}
         isPlanComparison={planComparisonFlag === "test"}
         hasBillingRights={hasBillingRights}
         currentCloudPlan={cloudBillingDisplayContext.currentCloudPlan}


### PR DESCRIPTION
## What & why

Two coupled gaps in metered workflow-run billing (ENG-1936):

**1. Provisioning.** Attaching a metered price to the Scale **product** in Stripe does not put it on any subscription — a sub's line items come from an explicit list the app builds in `getCatalogItemsForPlan`, which only ever emitted `base` + `responses`. So a `workflow_runs` metered price was never billed on new Scale subs. Worse, because that price is `usage_type: metered`, `getPriceKind` fell through to its metered→`"responses"` fallback and misclassified it, producing two `scale/responses/monthly` matches and throwing in `getSinglePrice` ("found 2"), which breaks the whole billing catalog fetch (checkout, billing page, plan comparison).

Fix: make `workflow_runs` a first-class price kind — classify by `formbricks_price_kind` metadata (unknown metered kinds still excluded so they can't collide); model it as `workflowRunsPrice` on the catalog item via a new `getOptionalSinglePrice` (present on Scale, `null` elsewhere, throws only on ambiguity); provision it as its own metered line item in checkout and plan-change schedules; include its interval in the mixed-interval guard; bump catalog cache `v2`→`v3`.

**2. Usage visibility.** The synced limit `limits.monthly.workflowRuns` was stored and exposed as `monthlyWorkflowRuns` in the entitlements context but never rendered — Scale customers couldn't see workflow usage against their included volume the way responses/workspaces are shown.

Fix: add `getMonthlyOrganizationWorkflowRunCount` (mirrors the responses count — scoped to the org's workspaces over the billing cycle, **excluding dry runs** to match what's metered), thread it through the billing page, and render a workflow-runs `UsageCard`.

**3. Included-volume vs. price consistency (the dangerous one).** The number the card calls "included" and the amount Stripe actually charges were two independent Stripe objects with nothing tying them together — the card read the entitlement-driven `limits.monthly.workflowRuns` while the price's tiers decide the charge. A flat or paid-from-unit-1 metered price would let the card show "42 of 1000 included" while Stripe invoices all 42: silent over-billing behind a reassuring UI. This PR flips billing from under-bill (harmless) to bill-for-real, so this failure mode is new and customer-facing.

Fix: make the **price the single source of truth**. `resolveWorkflowIncludedVolume` derives the included allowance from the price's free first tier; the catalog exposes it as `workflowRunsIncluded` and the card renders *that* number — so what's shown and what's left uncharged are the same object and cannot drift. If a workflow price is not graduated with a free first tier (finite `up_to`), the **workflow item is dropped** (price + included → null): the card hides and new subs skip the workflow line item — workflows just don't bill (today's harmless state) — and a loud `logger.error` fires. This degrades **workflows only**; base/responses checkout and the billing page stay up for every plan/org (base/responses remain fail-loud since they're load-bearing). No false allowance is ever shown.

Note: this wires new subs + plan changes + the usage card. Existing Scale subs still need a one-time backfill of the workflow line item (ops step, not code).

## Linear ticket

Closes ENG-2193 — Scale subscriptions never get a workflow_runs metered item, so workflow-run usage is metered but never billed (catalog provisioning).
Closes ENG-2194 — workflow-run usage has no user-facing surface (billing-page usage card).

Part of the metered-workflows epic ENG-1936.

## How this was tested

- `vitest run modules/ee/billing/lib/stripe-billing-catalog.test.ts` ✅ 8 passed — updated the workflow_runs test to assert provisioning, plus two new edge cases (`getOptionalSinglePrice` → null when absent; throws "found 2" on duplicate).
- `vitest run modules/ee/billing/lib/organization-billing.test.ts` ✅ 70 passed — covers the checkout interval guard + plan-change schedule builder.
- `tsc --noEmit` ✅ on the touched files.
- `pnpm i18n` ✅ — added `unlimited_workflow_runs` to en-US, generated all 14 target locales, scan validation passes (0 missing keys).
- eslint + prettier via lint-staged ✅.

The workflow-runs count query mirrors the existing (untested) `getMonthlyOrganizationResponseCount`; per repo convention these org count helpers are exercised via e2e/manual, not unit tests.

## Breaking changes

None

## QA / Test Plan

**Preconditions / test data**

- Cloud billing configured. On the Scale Stripe product: an **active** metered price with metadata `formbricks_price_kind: workflow_runs`, `formbricks_interval: monthly`, `usage_type: metered`, attached to the `workflow_run_created` meter. The price MUST be **graduated with a free first tier** (`unit_amount: 0` up to the included volume, e.g. `up_to: 1000`) — that free-tier boundary is what the usage card shows as "included".

**How to test**

- [ ] Subscribe a new org to **Scale (monthly)** via checkout → the Stripe subscription has three items: base, responses, workflow_runs.
- [ ] Subscribe a new org to **Scale (yearly)** → base is yearly; responses and workflow_runs are the monthly metered prices.
- [ ] Open **Settings → Billing** for a Scale org → a "Workflow Runs" usage card shows current runs vs the included volume (dry runs not counted), alongside Responses and Workspaces. The included number equals the price's free-tier boundary.
- [ ] **Consistency:** trigger runs inside the included volume (e.g. 5 of 1000) → the upcoming Stripe invoice shows $0 for those runs, matching the card. Cross a paid tier → invoice charges only the overage.
- [ ] Open Billing for a **Pro/Hobby** org (no workflow price) → no Workflow Runs card is shown.
- [ ] Edge: two active workflow_runs prices for the same plan/interval → billing page fails fast with "Expected at most one … found 2".
- [ ] Edge (degrade-only): make the Scale workflow price flat/per-unit or give it a paid first tier → the Workflow Runs card disappears and a `logger.error` ("Invalid workflow_runs price") fires; the billing page, checkout, and plan comparison still work for every plan. No false "included" allowance is shown.
