### PR TITLE
docs(helm): document taxonomy observability

### DIFF
--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -259,6 +259,36 @@ taxonomy:
 The `taxonomy-vertex-secret` secret must contain `TAXONOMY_GOOGLE_CLOUD_CREDENTIALS_JSON` with service-account
 JSON that can call Vertex AI.
 
+### Taxonomy metrics and structured logs
+
+Hub and the taxonomy service can export OpenTelemetry metrics over OTLP/HTTP. Configure the standard `OTEL_*`
+environment variables through the existing `hub.env` and `taxonomy.env` maps; no chart-specific collector values
+are required. For an in-cluster collector listening on port 4318:
+
+```yaml
+hub:
+  env:
+    LOG_FORMAT: json
+    OTEL_METRICS_EXPORTER: otlp
+    OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+    OTEL_EXPORTER_OTLP_ENDPOINT: http://signoz-otel-collector.signoz.svc.cluster.local:4318
+    OTEL_SERVICE_NAME: formbricks-hub
+    OTEL_RESOURCE_ATTRIBUTES: deployment.environment=production,service.namespace=formbricks
+
+taxonomy:
+  env:
+    LOG_FORMAT: json
+    OTEL_METRICS_EXPORTER: otlp
+    OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+    OTEL_EXPORTER_OTLP_ENDPOINT: http://signoz-otel-collector.signoz.svc.cluster.local:4318
+    OTEL_SERVICE_NAME: formbricks-taxonomy
+    OTEL_RESOURCE_ATTRIBUTES: deployment.environment=production,service.namespace=formbricks
+```
+
+Metrics use only bounded lifecycle, phase, provider, outcome, and reason attributes. Run, request, tenant, source,
+and field identifiers are emitted only in correlated JSON logs. Prompt text, feedback, model output, embeddings,
+credentials, authorization tokens, provider response bodies, and collector URLs are never telemetry fields.
+
 ## Values
 
 | Key                                                                | Type   | Default                                                                     | Description                                               |

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -259,11 +259,13 @@ taxonomy:
 The `taxonomy-vertex-secret` secret must contain `TAXONOMY_GOOGLE_CLOUD_CREDENTIALS_JSON` with service-account
 JSON that can call Vertex AI.
 
-### Taxonomy metrics and structured logs
+### Hub and Taxonomy metrics and structured logs
 
 Hub and the taxonomy service can export OpenTelemetry metrics over OTLP/HTTP. Configure the standard `OTEL_*`
 environment variables through the existing `hub.env` and `taxonomy.env` maps; no chart-specific collector values
-are required. For an in-cluster collector listening on port 4318:
+are required. The example below uses a SigNoz collector in the `signoz` namespace and labels both services as
+`production`. Replace the collector DNS name and `deployment.environment` with values matching each cluster and
+environment:
 
 ```yaml
 hub:


### PR DESCRIPTION
## Summary

- document supported Hub and Taxonomy `OTEL_*` metrics configuration
- reuse the existing `hub.env` and `taxonomy.env` chart surfaces
- document OTLP/HTTP port 4318, environment resource attributes, JSON logging, and the safe telemetry boundary
- add no redundant chart values

## Verification

Rendered the chart with all three ENG-1200 GitOps configurations:

- staging
- AWS production
- KSA production

## Related work and rollout

- [formbricks/hub#119](https://github.com/formbricks/hub/pull/119)
- [formbricks/taxonomy#14](https://github.com/formbricks/taxonomy/pull/14)

This is PR 3 of 5 for [ENG-1200](https://linear.app/formbricks/issue/ENG-1200/add-observability-for-taxonomy-run-duration-failures-and-record-counts).