### PR TITLE
fix(helm): bound Hub worker API wait (backport #8727 to release/5.3)

### DIFF
--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -69,6 +69,11 @@ Cube is part of the baseline Formbricks v5 stack and is deployed by this chart b
 ## Hub worker and self-hosted embeddings
 
 The chart deploys Hub API and, by default, a `hub-worker` deployment. Hub API is insert-only for River jobs; webhook dispatch and embedding jobs are processed by `hub-worker`.
+When `hub.worker.waitForApi.enabled` is enabled (the default), the worker waits for Hub API health
+before it starts. Each health request and the delay between failed checks are bounded to five
+seconds; `hub.worker.waitForApi.maxAttempts` limits the failed checks before the init container
+exits. Setting `hub.worker.waitForApi.enabled=false` omits the health gate, so the worker starts
+without waiting for Hub API health.
 
 When the Formbricks migration job is enabled, Hub waits for the `formbricks-migration` Job to complete before its own goose/river init migrations run. This keeps fresh shared-database installs from creating Hub tables before Prisma has initialized the Formbricks schema.
 If the Job has already been cleaned up, Hub only continues after all expected Prisma and data migration success markers are present in the database.
@@ -405,7 +410,7 @@ JSON that can call Vertex AI.
 | hub.worker.resources.requests.cpu                                  | string | `"100m"`                                                                    |                                                           |
 | hub.worker.resources.requests.memory                               | string | `"256Mi"`                                                                   |                                                           |
 | hub.worker.waitForApi.enabled                                      | bool   | `true`                                                                      |                                                           |
-| hub.worker.waitForApi.maxAttempts                                  | int    | `120`                                                                       | 120 attempts at 5s intervals = 10 minutes.                |
+| hub.worker.waitForApi.maxAttempts                                  | int    | `120`                                                                       | Health requests and retry delays are bounded to 5s each.  |
 | ingress.annotations                                                | object | `{}`                                                                        |                                                           |
 | ingress.enabled                                                    | bool   | `false`                                                                     |                                                           |
 | ingress.hosts[0].host                                              | string | `"k8s.formbricks.com"`                                                      |                                                           |

--- a/charts/formbricks/templates/hub-worker-deployment.yaml
+++ b/charts/formbricks/templates/hub-worker-deployment.yaml
@@ -61,13 +61,13 @@ spec:
             - |
               attempts=0
               max_attempts={{ .Values.hub.worker.waitForApi.maxAttempts | default 120 }}
-              until wget --no-verbose --tries=1 --spider http://{{ include "formbricks.hubname" . }}:8080/health; do
+              until timeout 5 wget --no-verbose --tries=1 --timeout=5 --spider http://{{ include "formbricks.hubname" . }}:8080/health; do
                 attempts=$((attempts+1))
                 if [ "$attempts" -ge "$max_attempts" ]; then
-                  echo "Hub API health check timed out after $((max_attempts * 5)) seconds"
+                  echo "Hub API did not become healthy after $max_attempts attempt(s)"
                   exit 1
                 fi
-                echo "Waiting for Hub API migrations and health check..."
+                echo "Waiting for Hub API migrations and health check (attempt $attempts/$max_attempts)..."
                 sleep 5
               done
       {{- end }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -1030,7 +1030,8 @@ hub:
     waitForApi:
       # Avoid starting workers before the API service is healthy during installs/upgrades.
       enabled: true
-      # 120 attempts * 5 seconds = 10 minutes.
+      # Maximum failed checks before the init container exits. Each health request and the delay
+      # between failed checks are bounded to 5 seconds.
       maxAttempts: 120
 
     resources:


### PR DESCRIPTION
Backport of #8727 to `release/5.3`. Minimal, single-fix backport per the backport policy.

Ref ENG-2181

## What

A hub-worker init container could hang indefinitely: its first Hub API health request could connect before the endpoint was ready but never return, and since the request had no hard total deadline, the retry counter and max-attempt guard never kicked in — the deploy stalls.

The fix wraps each health `wget` in the pinned image's `timeout` utility (hard 5s process deadline) plus Wget's own `--timeout=5`, so every attempt is bounded and the `maxAttempts` guard actually bounds the wait. Also adds attempt-aware log lines.

## Files

- `charts/formbricks/templates/hub-worker-deployment.yaml` — the fix (bounded wget).
- `charts/formbricks/values.yaml` — `hub.worker.waitForApi` default(s).
- `charts/formbricks/README.md` — documents the values.

**Dropped per policy:** the source PR also added `.github/workflows/helm-chart-validation.yml` (a new CI workflow) — out of scope for a minimal backport, and that path already exists on `release/5.3`, so it's left untouched here.

## QA / Test Plan

- [ ] `helm lint charts/formbricks` passes.
- [ ] Render the hub-worker deployment (`helm template`) and confirm the init container's wait loop uses `timeout 5 wget … --timeout=5` and respects `hub.worker.waitForApi.maxAttempts`.
- [ ] On a cluster where the Hub API is slow/unready, the init container fails after `maxAttempts` instead of hanging indefinitely, and logs the attempt count.

### Validation

Chart-only change confined to a shell block scalar in `hub-worker-deployment.yaml`; the repo's `pnpm lint` covers JS/TS, not Helm, and `helm` isn't available in this environment, so chart lint runs in CI (helm-chart-validation).
