### PR TITLE
fix(surveys): make Cal.com scheduler header legible and honor style override (backport #8729 to release/5.3)

### DIFF
--- a/packages/surveys/src/components/general/cal-embed.tsx
+++ b/packages/surveys/src/components/general/cal-embed.tsx
@@ -1,5 +1,5 @@
 import snippet from "@calcom/embed-snippet";
-import { useEffect, useMemo } from "preact/hooks";
+import { useEffect, useMemo, useRef } from "preact/hooks";
 import { useTranslation } from "react-i18next";
 import { type TSurveyCalElement } from "@formbricks/types/surveys/elements";
 import { cn } from "@/lib/utils";
@@ -9,22 +9,79 @@ interface CalEmbedProps {
   onSuccessfulBooking: () => void;
 }
 
-export function CalEmbed({ element, onSuccessfulBooking }: CalEmbedProps) {
+// Resolve a survey CSS custom property (e.g. `--fb-heading-color`) to a concrete
+// color string, or `undefined` when the property isn't set on the scope.
+//
+// `getComputedStyle(probe).color` always returns *some* color — for an undefined
+// var it falls back to the inherited `color`, which would silently override Cal's
+// default theme. So we first confirm the custom property is actually declared,
+// and only then resolve its (possibly `var(--slate-900)`-style) token to an rgb()
+// via a throwaway probe. Cal.com's embed lives in a cross-origin iframe and can't
+// read the parent's vars, so we forward the resolved colors into its own
+// `cal-text-*` vars below.
+function resolveSurveyColor(scope: HTMLElement, varName: string): string | undefined {
+  if (!getComputedStyle(scope).getPropertyValue(varName).trim()) return undefined;
+  const probe = document.createElement("span");
+  probe.style.color = `var(${varName})`;
+  probe.style.display = "none";
+  scope.appendChild(probe);
+  const color = getComputedStyle(probe).color;
+  probe.remove();
+  return color || undefined;
+}
+
+export function CalEmbed({ element, onSuccessfulBooking }: Readonly<CalEmbedProps>) {
   const { t } = useTranslation();
   const iframeTitle = t("common.scheduling_calendar");
-  // Per-element id so multiple Cal questions on one page don't all inject into the
-  // first container (and so the iframe-title lookup below targets the right one).
+  // Per-element id + Cal namespace so multiple Cal questions on one page don't
+  // share a container, UI config, or the bookingSuccessful listener — a booking
+  // in one scheduler must not fire another scheduler's callback.
   const containerId = `cal-embed-${element.id}`;
+  const namespace = `cal-embed-${element.id}`;
 
-  const cal = useMemo(() => {
-    const calInline = snippet("https://cal.com/embed.js");
+  // Keep the latest booking callback in a ref so the Cal listener registered in
+  // the effect below stays stable and doesn't churn (register/unregister) every
+  // time `onSuccessfulBooking` changes identity.
+  const onSuccessfulBookingRef = useRef(onSuccessfulBooking);
+  onSuccessfulBookingRef.current = onSuccessfulBooking;
+
+  const cal = useMemo(() => snippet("https://cal.com/embed.js"), []);
+
+  useEffect(() => {
+    // Initialize a namespaced Cal instance; `cal.ns[namespace]` is created
+    // synchronously by the snippet so all further commands stay scoped to it.
+    cal("init", namespace, {
+      calOrigin: element.calHost ? `https://${element.calHost}` : "https://cal.com",
+    });
+    const ns = cal.ns[namespace];
+
+    const embedContainer = document.getElementById(containerId);
+
+    // Forward the survey's resolved text colors into Cal's own text vars so the
+    // scheduler header (host, title, description, duration/link/timezone) stays
+    // legible and honors the survey style override instead of Cal's washed-out
+    // grey defaults. Unresolved vars fall back to Cal's default theme.
+    const headingColor = embedContainer
+      ? resolveSurveyColor(embedContainer, "--fb-heading-color")
+      : undefined;
+    const subheadingColor = embedContainer
+      ? resolveSurveyColor(embedContainer, "--fb-subheading-color")
+      : undefined;
+    const infoColor = embedContainer ? resolveSurveyColor(embedContainer, "--fb-info-text-color") : undefined;
+
+    const calTextVars = {
+      ...(headingColor ? { "cal-text-emphasis": headingColor } : {}),
+      ...(subheadingColor ? { "cal-text": subheadingColor, "cal-text-subtle": subheadingColor } : {}),
+      ...(infoColor ? { "cal-text-muted": infoColor } : {}),
+    };
 
     const calCssVars = {
       "cal-border-subtle": "transparent",
       "cal-border-booker": "transparent",
+      ...calTextVars,
     };
 
-    calInline("ui", {
+    ns("ui", {
       theme: "light",
       cssVarsPerTheme: {
         light: {
@@ -38,46 +95,40 @@ export function CalEmbed({ element, onSuccessfulBooking }: CalEmbedProps) {
       },
     });
 
-    calInline("on", {
-      action: "bookingSuccessful",
-      callback: () => {
-        onSuccessfulBooking();
-      },
-    });
+    const handleBooking = (): void => {
+      onSuccessfulBookingRef.current();
+    };
+    ns("on", { action: "bookingSuccessful", callback: handleBooking });
 
-    return calInline;
-  }, [onSuccessfulBooking]);
-
-  useEffect(() => {
-    // remove any existing cal-inline elements
-    document.querySelectorAll("cal-inline").forEach((el) => {
-      el.remove();
-    });
-    cal("init", { calOrigin: element.calHost ? `https://${element.calHost}` : "https://cal.com" });
-    cal("inline", {
+    ns("inline", {
       elementOrSelector: `#${containerId}`,
       calLink: element.calUserName,
     });
 
     // The snippet injects the iframe asynchronously without a title, so screen
     // readers announce it as just "iframe". Title it as soon as it appears.
-    const embedContainer = document.getElementById(containerId);
-    if (!embedContainer) return;
-    const titleIframe = (): boolean => {
-      const iframe = embedContainer.querySelector("iframe");
-      if (iframe && !iframe.title) iframe.title = iframeTitle;
-      return Boolean(iframe);
-    };
-    if (!titleIframe()) {
-      const observer = new MutationObserver(() => {
-        if (titleIframe()) observer.disconnect();
-      });
-      observer.observe(embedContainer, { childList: true, subtree: true });
-      return () => {
-        observer.disconnect();
+    let observer: MutationObserver | undefined;
+    if (embedContainer) {
+      const titleIframe = (): boolean => {
+        const iframe = embedContainer.querySelector("iframe");
+        if (iframe && !iframe.title) iframe.title = iframeTitle;
+        return Boolean(iframe);
       };
+      if (!titleIframe()) {
+        observer = new MutationObserver(() => {
+          if (titleIframe()) observer?.disconnect();
+        });
+        observer.observe(embedContainer, { childList: true, subtree: true });
+      }
     }
-  }, [cal, element.calHost, element.calUserName, iframeTitle, containerId]);
+
+    return () => {
+      ns("off", { action: "bookingSuccessful", callback: handleBooking });
+      observer?.disconnect();
+      // Remove only this scheduler's injected embed, not every cal-inline on the page.
+      embedContainer?.querySelector("cal-inline")?.remove();
+    };
+  }, [cal, namespace, containerId, element.calHost, element.calUserName, iframeTitle]);
 
   return (
     <div className="relative mt-4 overflow-auto">


### PR DESCRIPTION
Backport of #8729 to `release/5.3`. Minimal, single-fix backport per the backport policy.

Ref ENG-2172

## What

A Cal.com scheduler question rendered its entire header block (host name, question title, description, and the duration / "Link meeting" / timezone rows) in Cal's default washed-out grey — well below WCAG AA contrast against the survey card — and the survey's style override never reached it, so authors couldn't fix it either.

The fix forwards the survey's resolved text colors into Cal's own `cal-text-*` CSS vars (Cal lives in a cross-origin iframe and can't read the parent's vars), so the header stays legible and honors the configured text color. Colors are resolved via a throwaway probe element, and the resolver returns `undefined` for unset vars so Cal's default theme is preserved. The embed is also scoped per-element (namespace) and the booking listener is registered/cleaned up in an effect.

## Files

- `packages/surveys/src/components/general/cal-embed.tsx` — the fix.

Nothing dropped — the PR added no test files (survey `.tsx` components are covered by Playwright E2E, not unit tests).

## QA / Test Plan

- [ ] Add a Cal.com scheduling question to a survey and apply a custom text-color style.
- [ ] Open the survey in the player (link survey): the scheduler header (host, title, description, duration/link/timezone) is legible and matches the configured text color.
- [ ] The calendar grid still renders normally; multiple Cal questions on one survey each render correctly and a booking in one doesn't fire another's callback.

### Validation

`pnpm --filter @formbricks/surveys exec tsc --noEmit` passes. The `@formbricks/surveys` bundle is rebuilt by CI (dist / public/js are gitignored). The identical source passed lint + E2E on the source PR (#8729).
