### PR TITLE
fix(logger): resolve OTEL transport from runtime root

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -299,7 +299,9 @@ RUN chmod -R 755 \
       ./node_modules/@opentelemetry/exporter-logs-otlp-proto \
     && OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 node -e "\
       const pino = require('pino'); \
-      const target = process.cwd() + '/node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js'; \
+      process.chdir('/home/nextjs/apps/web'); \
+      const runtimeRoot = process.cwd().replace(/[\/\\\\]apps[\/\\\\]web$/, ''); \
+      const target = runtimeRoot + '/node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js'; \
       process.on('uncaughtException', (error) => { console.error(error); process.exit(1); }); \
       process.on('unhandledRejection', (error) => { console.error(error); process.exit(1); }); \
       const logger = pino({ \

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -165,22 +165,25 @@ describe("Logger", () => {
     expect(logger).toBeDefined();
   });
 
-  test("production OTEL logs use the absolute pino-opentelemetry transport target when enabled", async () => {
+  test("production OTEL logs use the runtime-root pino-opentelemetry transport target when enabled", async () => {
     process.env.NODE_ENV = "production";
     process.env.NEXT_RUNTIME = "nodejs";
     process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://signoz-otel-collector.signoz:4318";
     process.env.OTEL_LOGS_ENABLED = "1";
     process.env.OTEL_SERVICE_NAME = "formbricks-web";
     process.env.npm_package_version = "5.1.2";
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue("/home/nextjs/apps/web");
 
     const { logger } = await import("./logger");
     const loggerConfig = vi.mocked(Pino).mock.calls.at(-1)?.[0] as Pino.LoggerOptions;
+    cwdSpy.mockRestore();
 
     expect(loggerConfig.transport).toEqual(
       expect.objectContaining({
         targets: expect.arrayContaining([
           expect.objectContaining({
-            target: `${process.cwd()}/node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js`,
+            target:
+              "/home/nextjs/node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js",
             options: expect.objectContaining({
               loggerName: "formbricks-web",
               serviceVersion: "5.1.2",

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -4,6 +4,9 @@ import { type TLogLevel, ZLogLevel } from "../types/logger";
 const IS_PRODUCTION = !process.env.NODE_ENV || process.env.NODE_ENV === "production";
 const IS_BUILD = process.env.NEXT_PHASE === "phase-production-build";
 const PROCESS_GLOBAL_KEY = "process";
+const NEXT_STANDALONE_APP_DIR_PATTERN = /[/\\]apps[/\\]web$/;
+const OTEL_TRANSPORT_PACKAGE_PATH =
+  "node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js";
 
 interface TransportStream {
   on?: (event: "error", listener: (error: unknown) => void) => void;
@@ -11,8 +14,10 @@ interface TransportStream {
 
 const getNodeProcess = (): typeof process => globalThis[PROCESS_GLOBAL_KEY];
 
-const getOtelTransportTarget = (): string =>
-  `${getNodeProcess().cwd()}/node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js`;
+const getOtelTransportTarget = (): string => {
+  const runtimeRoot = getNodeProcess().cwd().replace(NEXT_STANDALONE_APP_DIR_PATTERN, "");
+  return `${runtimeRoot}/${OTEL_TRANSPORT_PACKAGE_PATH}`;
+};
 
 const getLogLevel = (): TLogLevel => {
   let logLevel: TLogLevel = "info";


### PR DESCRIPTION
## Summary
- resolve the Pino OTEL transport from the standalone runtime root when the app process cwd is apps/web
- update the Docker image smoke check to simulate the real Next.js runtime cwd before loading the transport
- cover the standalone cwd case in the logger unit test

## Staging evidence
- Endpoint-only OTEL was enabled in staging with OTEL_LOGS_ENABLED=0 and remained healthy
- Enabling OTEL_LOGS_ENABLED=1 exposed the remaining runtime error: Pino looked for /home/nextjs/apps/web/node_modules/pino-opentelemetry-transport/... while the package exists at /home/nextjs/node_modules/...
- Logs were disabled again; staging returned to Synced/Healthy with public /health = 200

## Validation
- pnpm --filter @formbricks/logger test
- pnpm --filter @formbricks/logger typecheck
- pnpm --filter @formbricks/logger lint
- git diff --check
- local Pino OTEL transport smoke command from an apps/web cwd