### PR TITLE
fix(logger): resolve OTEL transport from runtime root (backport #8744 to release/5.2)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -289,7 +289,9 @@ RUN chmod -R 755 \
       ./node_modules/@opentelemetry/exporter-logs-otlp-proto \
     && OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318 node -e "\
       const pino = require('pino'); \
-      const target = process.cwd() + '/node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js'; \
+      process.chdir('/home/nextjs/apps/web'); \
+      const runtimeRoot = process.cwd().replace(/[\/\\\\]apps[\/\\\\]web$/, ''); \
+      const target = runtimeRoot + '/node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js'; \
       process.on('uncaughtException', (error) => { console.error(error); process.exit(1); }); \
       process.on('unhandledRejection', (error) => { console.error(error); process.exit(1); }); \
       const logger = pino({ \

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -165,22 +165,25 @@ describe("Logger", () => {
     expect(logger).toBeDefined();
   });
 
-  test("production OTEL logs use the absolute pino-opentelemetry transport target when enabled", async () => {
+  test("production OTEL logs use the runtime-root pino-opentelemetry transport target when enabled", async () => {
     process.env.NODE_ENV = "production";
     process.env.NEXT_RUNTIME = "nodejs";
     process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://signoz-otel-collector.signoz:4318";
     process.env.OTEL_LOGS_ENABLED = "1";
     process.env.OTEL_SERVICE_NAME = "formbricks-web";
     process.env.npm_package_version = "5.1.2";
+    const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue("/home/nextjs/apps/web");
 
     const { logger } = await import("./logger");
     const loggerConfig = vi.mocked(Pino).mock.calls.at(-1)?.[0] as Pino.LoggerOptions;
+    cwdSpy.mockRestore();
 
     expect(loggerConfig.transport).toEqual(
       expect.objectContaining({
         targets: expect.arrayContaining([
           expect.objectContaining({
-            target: `${process.cwd()}/node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js`,
+            target:
+              "/home/nextjs/node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js",
             options: expect.objectContaining({
               loggerName: "formbricks-web",
               serviceVersion: "5.1.2",

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -4,6 +4,9 @@ import { type TLogLevel, ZLogLevel } from "../types/logger";
 const IS_PRODUCTION = !process.env.NODE_ENV || process.env.NODE_ENV === "production";
 const IS_BUILD = process.env.NEXT_PHASE === "phase-production-build";
 const PROCESS_GLOBAL_KEY = "process";
+const NEXT_STANDALONE_APP_DIR_PATTERN = /[/\\]apps[/\\]web$/;
+const OTEL_TRANSPORT_PACKAGE_PATH =
+  "node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js";
 
 interface TransportStream {
   on?: (event: "error", listener: (error: unknown) => void) => void;
@@ -11,8 +14,10 @@ interface TransportStream {
 
 const getNodeProcess = (): typeof process => globalThis[PROCESS_GLOBAL_KEY];
 
-const getOtelTransportTarget = (): string =>
-  `${getNodeProcess().cwd()}/node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js`;
+const getOtelTransportTarget = (): string => {
+  const runtimeRoot = getNodeProcess().cwd().replace(NEXT_STANDALONE_APP_DIR_PATTERN, "");
+  return `${runtimeRoot}/${OTEL_TRANSPORT_PACKAGE_PATH}`;
+};
 
 const getLogLevel = (): TLogLevel => {
   let logLevel: TLogLevel = "info";


### PR DESCRIPTION
## What does this PR do?

Backport of #8744 to `release/5.2` — clean cherry-pick of `b2d20287`, the diff is byte-identical to the upstream PR.

When `OTEL_LOGS_ENABLED=1`, Pino resolved the OTEL transport target from `process.cwd()`. In the Docker image the Next.js standalone server runs with cwd `/home/nextjs/apps/web`, but the transport package is copied to the runtime root `/home/nextjs/node_modules`, so the worker thread died with `Cannot find module '/home/nextjs/apps/web/node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js'` and no logs ever reached SigNoz.

- `packages/logger/src/logger.ts` — strip a trailing `apps/web` off the cwd to get the runtime root, and build the transport target from there.
- `apps/web/Dockerfile` — the build-time smoke check ran at cwd `/home/nextjs`, so it accidentally resolved the transport correctly and never caught this. It now `chdir`s to `/home/nextjs/apps/web` first, simulating the real runtime cwd.
- `packages/logger/src/logger.test.ts` — covers the standalone cwd case.

Sibling backport to `release/5.3`: #8747.

Upstream #8744 is still open at the time of writing; if it changes during review this branch needs to be re-synced before merge.

Fixes: no Linear ticket — carried over from #8744, which tracks the staging OTEL logging failure.

## How should this be tested?

CI covers the unit tests, the web build and the Docker build. Locally, against this branch:

- **Package gates** — all green:
  - `pnpm --filter @formbricks/logger test` (14 passed)
  - `pnpm --filter @formbricks/logger typecheck`
  - `pnpm --filter @formbricks/logger lint`
  - `pnpm --filter @formbricks/logger build`
- **Functional smoke test of the transport resolution.** Reproduced the standalone layout from the image — transport package at `<root>/node_modules`, nothing at `<root>/apps/web/node_modules` — and pointed `OTEL_EXPORTER_OTLP_ENDPOINT` at a local OTLP/HTTP collector stand-in, then asserted on what it received:

  | case | cwd | result |
  |---|---|---|
  | pre-fix target (`cwd() + /node_modules/…`) | `<root>/apps/web` | `Cannot find module …/apps/web/node_modules/pino-opentelemetry-transport/…`, **0** deliveries — reproduces the staging failure |
  | this branch, real built `@formbricks/logger` | `<root>/apps/web` | **1** `POST /v1/logs` carrying `formbricks-web` + the log record |
  | this branch, real built `@formbricks/logger` | `<root>` | **1** `POST /v1/logs` — non-standalone cwd still resolves, no regression |

  Note the pre-fix process still exits 0: the transport error only goes to stderr, which is why the pod looked healthy while logs silently went nowhere.
- **Dockerfile smoke command.** Extracted the `node -e "…"` block verbatim from `apps/web/Dockerfile`, retargeted `/home/nextjs` at the fake root, and ran it through `/bin/sh` from cwd `<root>` (mirroring `WORKDIR /home/nextjs`): exit 0, and the collector received the `formbricks-build-smoke` record. This confirms the shell-escaped regex `/[\/\\\\]apps[\/\\\\]web$/` survives Docker's `RUN` quoting and evaluates as `/[\/\\]apps[\/\\]web$/`.
- Verified `/home/nextjs/apps/web` already exists when the smoke check runs — created by the standalone copy at `apps/web/Dockerfile:92` and the static copy at `:107`, both well before the check — so the new `process.chdir` cannot fail the build.
- Verified no other place on `release/5.2` builds a cwd-relative transport path (only `next.config.mjs` / `vite.config.ts` package references remain).

## Checklist

### Required

- [x] Filled out the "How to test" section in this PR
- [x] Read [How we Code at Formbricks](https://formbricks.com/docs/contributing/how-we-code)
- [x] Self-reviewed my own code
- [x] Commented on my code in hard-to-understand bits
- [x] Ran `pnpm build` — `@formbricks/logger` locally; the full web build is covered by CI
- [x] Checked for warnings, there are none
- [x] Removed all `console.logs`
- [x] Merged the latest changes from main onto my branch with `git pull origin main` — n/a for a backport; branched off the current `origin/release/5.2` tip
- [x] My changes don't cause any responsiveness issues
- [ ] First PR at Formbricks? [Please sign the CLA!](https://cla-assistant.io/formbricks/formbricks) Without it we wont be able to merge it 🙏

### Appreciated

- [ ] If a UI change was made: Added a screen recording or screenshots to this PR — n/a, no UI change
- [ ] Updated the Formbricks Docs if changes were necessary — n/a, no user-facing behaviour change
