### PR TITLE
docs(helm): enable trace correlation in the observability example

### DIFF
--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -259,12 +259,12 @@ taxonomy:
 The `taxonomy-vertex-secret` secret must contain `TAXONOMY_GOOGLE_CLOUD_CREDENTIALS_JSON` with service-account
 JSON that can call Vertex AI.
 
-### Hub and Taxonomy metrics and structured logs
+## Hub and Taxonomy metrics and structured logs
 
-Hub and the taxonomy service can export OpenTelemetry metrics over OTLP/HTTP. Configure the standard `OTEL_*`
-environment variables through the existing `hub.env` and `taxonomy.env` maps; no chart-specific collector values
-are required. The example below uses a SigNoz collector in the `signoz` namespace and labels both services as
-`production`. Replace the collector DNS name and `deployment.environment` with values matching each cluster and
+Hub and the taxonomy service can export OpenTelemetry metrics and traces over OTLP/HTTP. Configure the standard
+`OTEL_*` environment variables through the existing `hub.env` and `taxonomy.env` maps; no chart-specific collector
+values are required. The example below uses a SigNoz collector in the `signoz` namespace and labels both services
+as `production`. Replace the collector DNS name and `deployment.environment` with values matching each cluster and
 environment:
 
 ```yaml
@@ -272,6 +272,7 @@ hub:
   env:
     LOG_FORMAT: json
     OTEL_METRICS_EXPORTER: otlp
+    OTEL_TRACES_EXPORTER: otlp
     OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     OTEL_EXPORTER_OTLP_ENDPOINT: http://signoz-otel-collector.signoz.svc.cluster.local:4318
     OTEL_SERVICE_NAME: formbricks-hub
@@ -281,15 +282,22 @@ taxonomy:
   env:
     LOG_FORMAT: json
     OTEL_METRICS_EXPORTER: otlp
+    OTEL_TRACES_EXPORTER: otlp
     OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     OTEL_EXPORTER_OTLP_ENDPOINT: http://signoz-otel-collector.signoz.svc.cluster.local:4318
     OTEL_SERVICE_NAME: formbricks-taxonomy
     OTEL_RESOURCE_ATTRIBUTES: deployment.environment=production,service.namespace=formbricks
 ```
 
-Metrics use only bounded lifecycle, phase, provider, outcome, and reason attributes. Run, request, tenant, source,
-and field identifiers are emitted only in correlated JSON logs. Prompt text, feedback, model output, embeddings,
-credentials, authorization tokens, provider response bodies, and collector URLs are never telemetry fields.
+`OTEL_TRACES_EXPORTER` is what makes the logs *correlated*: Hub only stamps `trace_id` and `span_id` onto log
+records when tracing is enabled. With metrics alone, JSON logs carry `request_id` and nothing else, and Hub logs
+`tracing not enabled (OTEL_TRACES_EXPORTER empty or unset)` at startup. `LOG_FORMAT: json` needs a Hub image built
+after 0.8.2; earlier images ignore it and keep the text format.
+
+Metric attributes are restricted to a fixed, low-cardinality set — for Hub's taxonomy metrics that is
+`scope_type`, `status`, `failure_code`, and `reason`. Run, request, tenant, source, and field identifiers are
+emitted only in correlated JSON logs. Prompt text, feedback, model output, embeddings, credentials, authorization
+tokens, provider response bodies, and collector URLs are never telemetry fields.
 
 ## Values
 

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -301,10 +301,10 @@ the Hub API and the Hub worker Deployments, so setting it there would report two
 keeps them apart. If you do want custom names, override per component in `hub.worker.env` rather than widening
 `hub.env`. The taxonomy service has no such built-in default and would report `unknown_service` without it.
 
-Both blocks need images newer than the ones this chart currently pins. Hub reads `LOG_FORMAT` only in builds after
-0.8.2, and the taxonomy service gained its OpenTelemetry and JSON-logging support after `v0.1.0`. Older images
-ignore these variables entirely rather than failing, so a rollout ahead of the image bump is silent — expect text
-logs and no taxonomy metrics until both images are updated.
+Both blocks need recent images. Hub reads `LOG_FORMAT` from 0.8.3 onward, and the taxonomy service's
+OpenTelemetry and JSON-logging support is newer than `v0.1.0`. Older images ignore these variables entirely
+rather than failing, so applying them ahead of the image bump is silent — expect text logs and no taxonomy
+metrics until each image is new enough.
 
 Hub's metric attributes are restricted to a fixed, low-cardinality set — for its taxonomy metrics that is
 `scope_type`, `status`, `failure_code`, and `reason`. Run, request, tenant, source, and field identifiers are

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -275,7 +275,6 @@ hub:
     OTEL_TRACES_EXPORTER: otlp
     OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     OTEL_EXPORTER_OTLP_ENDPOINT: http://signoz-otel-collector.signoz.svc.cluster.local:4318
-    OTEL_SERVICE_NAME: formbricks-hub
     OTEL_RESOURCE_ATTRIBUTES: deployment.environment=production,service.namespace=formbricks
 
 taxonomy:
@@ -294,6 +293,13 @@ and Hub warns `tracing not enabled (OTEL_TRACES_EXPORTER empty or unset)` at sta
 metrics but does not emit traces, so the variable is deliberately absent from `taxonomy.env`; it correlates its
 logs through `request_id` and `run_id`, both of which Hub also logs, so a run can still be followed across the two
 services.
+
+`OTEL_SERVICE_NAME` is set for the taxonomy service but deliberately not for Hub. `hub.env` is applied to both
+the Hub API and the Hub worker Deployments, so setting it there would report two different processes under one
+`service.name` and make them indistinguishable at the collector. Hub already names each binary itself —
+`hub-api` and `hub-worker` — and only falls back to that when the variable is unset, so leaving it out is what
+keeps them apart. If you do want custom names, override per component in `hub.worker.env` rather than widening
+`hub.env`. The taxonomy service has no such built-in default and would report `unknown_service` without it.
 
 Both blocks need images newer than the ones this chart currently pins. Hub reads `LOG_FORMAT` only in builds after
 0.8.2, and the taxonomy service gained its OpenTelemetry and JSON-logging support after `v0.1.0`. Older images

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -300,7 +300,7 @@ Both blocks need images newer than the ones this chart currently pins. Hub reads
 ignore these variables entirely rather than failing, so a rollout ahead of the image bump is silent — expect text
 logs and no taxonomy metrics until both images are updated.
 
-Metric attributes are restricted to a fixed, low-cardinality set — for Hub's taxonomy metrics that is
+Hub's metric attributes are restricted to a fixed, low-cardinality set — for its taxonomy metrics that is
 `scope_type`, `status`, `failure_code`, and `reason`. Run, request, tenant, source, and field identifiers are
 emitted only in correlated JSON logs. Prompt text, feedback, model output, embeddings, credentials, authorization
 tokens, provider response bodies, and collector URLs are never telemetry fields.

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -261,11 +261,11 @@ JSON that can call Vertex AI.
 
 ## Hub and Taxonomy metrics and structured logs
 
-Hub and the taxonomy service can export OpenTelemetry metrics and traces over OTLP/HTTP. Configure the standard
-`OTEL_*` environment variables through the existing `hub.env` and `taxonomy.env` maps; no chart-specific collector
-values are required. The example below uses a SigNoz collector in the `signoz` namespace and labels both services
-as `production`. Replace the collector DNS name and `deployment.environment` with values matching each cluster and
-environment:
+Hub and the taxonomy service can export OpenTelemetry metrics over OTLP/HTTP, and Hub can additionally export
+traces. Configure the standard `OTEL_*` environment variables through the existing `hub.env` and `taxonomy.env`
+maps; no chart-specific collector values are required. The example below uses a SigNoz collector in the `signoz`
+namespace and labels both services as `production`. Replace the collector DNS name and `deployment.environment`
+with values matching each cluster and environment:
 
 ```yaml
 hub:
@@ -282,17 +282,23 @@ taxonomy:
   env:
     LOG_FORMAT: json
     OTEL_METRICS_EXPORTER: otlp
-    OTEL_TRACES_EXPORTER: otlp
     OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
     OTEL_EXPORTER_OTLP_ENDPOINT: http://signoz-otel-collector.signoz.svc.cluster.local:4318
     OTEL_SERVICE_NAME: formbricks-taxonomy
     OTEL_RESOURCE_ATTRIBUTES: deployment.environment=production,service.namespace=formbricks
 ```
 
-`OTEL_TRACES_EXPORTER` is what makes the logs *correlated*: Hub only stamps `trace_id` and `span_id` onto log
-records when tracing is enabled. With metrics alone, JSON logs carry `request_id` and nothing else, and Hub logs
-`tracing not enabled (OTEL_TRACES_EXPORTER empty or unset)` at startup. `LOG_FORMAT: json` needs a Hub image built
-after 0.8.2; earlier images ignore it and keep the text format.
+`OTEL_TRACES_EXPORTER` is set for Hub only, and it is what puts `trace_id` and `span_id` in Hub's logs — Hub
+stamps them onto a log record only when tracing is enabled. Without it, Hub's JSON logs carry `request_id` alone
+and Hub warns `tracing not enabled (OTEL_TRACES_EXPORTER empty or unset)` at startup. The taxonomy service exports
+metrics but does not emit traces, so the variable is deliberately absent from `taxonomy.env`; it correlates its
+logs through `request_id` and `run_id`, both of which Hub also logs, so a run can still be followed across the two
+services.
+
+Both blocks need images newer than the ones this chart currently pins. Hub reads `LOG_FORMAT` only in builds after
+0.8.2, and the taxonomy service gained its OpenTelemetry and JSON-logging support after `v0.1.0`. Older images
+ignore these variables entirely rather than failing, so a rollout ahead of the image bump is silent — expect text
+logs and no taxonomy metrics until both images are updated.
 
 Metric attributes are restricted to a fixed, low-cardinality set — for Hub's taxonomy metrics that is
 `scope_type`, `status`, `failure_code`, and `reason`. Run, request, tenant, source, and field identifiers are


### PR DESCRIPTION
## What & why

Follow-up to #8737, which documented the Hub/taxonomy OpenTelemetry setup in the chart README. Five corrections to that section:

**The example never enabled tracing for Hub.** It set `OTEL_METRICS_EXPORTER` but not `OTEL_TRACES_EXPORTER`. Hub reads the two independently, and its `TraceContextHandler` only attaches `trace_id`/`span_id` when a valid span context exists — so an operator following the section verbatim got JSON logs carrying `request_id` and nothing else, plus `tracing not enabled (OTEL_TRACES_EXPORTER empty or unset)` at every startup. The section calls these "correlated JSON logs", and cross-service correlation is exactly what `trace_id` provides, so Hub's block now enables both signals and the prose explains why.

**Tracing is Hub-only, and the docs now say so.** The taxonomy service has no tracer at all — no `TracerProvider`, no span exporter, no `OTEL_TRACES_EXPORTER` read anywhere, and metrics-only OTel dependencies. Setting the variable under `taxonomy.env` would document a no-op, so it is deliberately absent there, with a note that the service correlates through `request_id` and `run_id` instead — both of which Hub logs too, so a run is still followable across the two services.

**The section was nested under `## AI Taxonomy Beta`.** Hub's OTLP wiring is not taxonomy-specific — the same env vars cover its webhook, embedding, translation, sentiment and enrichment metrics — and an operator wiring up Hub metrics is unlikely to look inside a taxonomy beta section. Promoted to `##`, alongside the other top-level sections.

**The metric-attribute list didn't match what Hub emits, and its scope was too broad.** It named `phase` and `provider`, which are fields inside the failure-diagnostics JSON blob rather than metric attributes. Hub's taxonomy metrics carry `scope_type`, `status`, `failure_code` and `reason`, so the sentence now names those. The surrounding "restricted to a fixed, low-cardinality set" claim was also unqualified in a section covering both services; it is now scoped to Hub, because the taxonomy service's pending telemetry work adds a config-derived `model` attribute that is not enum-bounded. Since this is the cardinality/privacy claim people cite, it should not overreach.

**The example collapsed hub-api and hub-worker under one `service.name`.** `hub.env` is applied to *both* Hub Deployments, so `OTEL_SERVICE_NAME: formbricks-hub` rendered onto each of them and reported two distinct processes under a single service name — indistinguishable at the collector, and no per-process dashboard or alert is possible. Hub already names each binary (`hub-api`, `hub-worker`) and only falls back to that when the variable is unset, so the variable is now omitted from `hub.env` and the prose explains why, pointing at `hub.worker.env` for anyone who genuinely wants custom names. The taxonomy block keeps its explicit name: that service has no built-in default and would report `unknown_service` without it.

Also added an image-version caveat covering both blocks: `LOG_FORMAT` needs Hub 0.8.3 or newer (it landed in formbricks/hub#119, released in 0.8.3), and the taxonomy service's OTel and JSON-logging support postdates the pinned `v0.1.0`. Older images ignore these variables silently rather than failing, which is worth stating explicitly.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1200/add-observability-for-taxonomy-run-duration-failures-and-record-counts

## How this was tested

Docs-only, so verification was against each service's source rather than a deployment:

- `helm lint charts/formbricks` ✅ (only the pre-existing `formbricks.webappUrl is required` warning, unrelated to this change)
- Hub: confirmed `OTEL_TRACES_EXPORTER` is read separately from `OTEL_METRICS_EXPORTER` (`internal/config/config.go`), that `otlp` is the value its exporter switch accepts (`internal/observability/provider.go`), and that the "tracing not enabled" warning fires when unset (`cmd/api/app.go`).
- Taxonomy: grepped the service for any tracer/span/`OTEL_TRACES_EXPORTER` usage — none exists; `pyproject.toml` pulls only `opentelemetry-api`, `-sdk` and `-exporter-otlp-proto-http`, and `TaxonomyTelemetry.from_env` builds a `MeterProvider` only. Confirmed it does read `OTEL_METRICS_EXPORTER` and `LOG_FORMAT`, and that its log correlation uses `request_id`/`run_id`.
- Attribute set checked against Hub's `internal/observability/taxonomy.go` and the test there asserting `run_id`/`request_id`/`tenant_id`/`source_id`/`field_id` never appear as metric attributes.
- Versions: confirmed `LOG_FORMAT` is present in the 0.8.3 tree (`internal/config/config.go`) and absent from 0.8.2, and that the 0.8.3 tag contains the hub#119 commit. The taxonomy OTel work is still an open PR, so nothing newer than `v0.1.0` carries its half yet.
- Re-read the rendered section for heading order; it now sits at `##` between `## AI Taxonomy Beta` and `## Values`.
- **Rendered the chart with the documented block as actual values** (`helm template -f`), then asserted per Deployment what each container receives. This is what caught the `service.name` collapse. Final state: `formbricks-hub` and `formbricks-hub-worker` receive no `OTEL_SERVICE_NAME` (each resolves its own binary default) and `OTEL_TRACES_EXPORTER=otlp`; `formbricks-taxonomy` receives `OTEL_SERVICE_NAME=formbricks-taxonomy` and no `OTEL_TRACES_EXPORTER`. That matches the prose exactly.
- Confirmed Hub's per-binary names at both call sites (`NewMeterProvider(cfg, "hub-api")` / `"hub-worker"`, same for the tracer) and that `newResource` returns early when `OTEL_SERVICE_NAME` is set, which is what makes an operator-supplied value override them.

No UI change, so no screenshots.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Self-hosted Helm install with the `hub.env` block from this section applied, on Hub 0.8.3 or newer → Hub pod logs are single-line JSON, and each request-scoped line carries `request_id`, `trace_id` and `span_id`.
- [ ] At the collector, confirm the Hub API and Hub worker arrive as two separate services (`hub-api` and `hub-worker`), not merged under one name.
- [ ] Same install with `OTEL_TRACES_EXPORTER` removed from `hub.env` → Hub logs `tracing not enabled (OTEL_TRACES_EXPORTER empty or unset)` on startup, and log lines carry `request_id` but no `trace_id`/`span_id`. This is the behavior the docs previously produced.
- [ ] Apply the `taxonomy.env` block on a taxonomy image newer than `v0.1.0` → taxonomy metrics arrive at the collector under service name `formbricks-taxonomy`; taxonomy log lines carry `request_id`/`run_id` and no `trace_id`.
- [ ] Trigger a taxonomy run and follow it across both services using the `request_id` from the originating Hub request → the run is traceable end-to-end via that field alone.
- [ ] Apply either block on an older image (hub 0.8.1 or earlier, taxonomy `v0.1.0`) → pods start normally, logs stay in text format, no metrics appear. Confirms the "ignored, not fatal" claim.

**Preconditions / test data**

- Self-hosted Kubernetes install of the chart; Cloud is unaffected (this is chart documentation only).
- A reachable OTLP/HTTP collector. The example targets SigNoz at `signoz-otel-collector.signoz.svc.cluster.local:4318`; substitute your own and adjust `deployment.environment`.
- The taxonomy checks need `taxonomy.enabled: true`, which is off by default.

**Risks & regressions**

- Documentation-only: no chart templates, values, or defaults changed, so no deployed behavior changes from merging this.
- The risk is the reverse: an operator who already followed #8737 has tracing disabled while believing it is on, and has hub-api and hub-worker merged under one `service.name`. Both shipped in that PR, so worth a release note rather than assuming the doc fix reaches them.
- The Hub version statement is now concrete (0.8.3). The taxonomy one is still perishable — it says "newer than `v0.1.0`" because no taxonomy release carries the OTel work yet; replace it with a version once formbricks/taxonomy#14 ships.
- The chart still pins hub 0.8.1, so this guidance does not take effect until the digest bump lands. That is a separate PR.

**Migrations / env / cutover**

- No migrations. No changes to `.env.example` or `values.yaml` — the documented variables are passed through the existing `hub.env` / `taxonomy.env` maps, which already exist.
- Cutover note for whoever picks up the chart bump: this section's guidance only takes effect once the pinned Hub and taxonomy images are updated.
