### PR TITLE
fix(charts): pin rating/CSAT Y-axis on ungrouped measure charts [ENG-2226]

### DIFF
--- a/apps/web/modules/ee/analysis/charts/components/cartesian-chart.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/cartesian-chart.tsx
@@ -3,7 +3,7 @@
 import { type ElementType, type ReactNode } from "react";
 import { CartesianGrid, XAxis, YAxis } from "recharts";
 import { formatXAxisTick } from "@/modules/ee/analysis/charts/lib/chart-utils";
-import { computeYAxis } from "@/modules/ee/analysis/charts/lib/y-axis-scale";
+import { type YAxisScale, computeYAxis } from "@/modules/ee/analysis/charts/lib/y-axis-scale";
 import type { TChartDataRow } from "@/modules/ee/analysis/types/analysis";
 import type { ChartConfig } from "@/modules/ui/components/chart";
 import { ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip } from "@/modules/ui/components/chart";
@@ -31,6 +31,10 @@ export interface CartesianChartProps {
    * measure charts keep their category axis but hide the header, since each tooltip row already
    * carries the measure label and a header would just repeat it. */
   tooltipHideLabel?: boolean;
+  /** Precomputed Y-axis scale, used in place of deriving one from `data`/`dataKeys`. Measure-pivot
+   * charts render values under a synthetic key (PIVOTED_VALUE_KEY) that carries no measure id, so
+   * they resolve the fixed-scale axis from the original measure columns and pass it here (ENG-2226). */
+  yAxisScale?: YAxisScale;
 }
 
 export function CartesianChart({
@@ -47,8 +51,9 @@ export function CartesianChart({
   xAxisTickFormatter,
   hasCategoryAxis = true,
   tooltipHideLabel,
+  yAxisScale,
 }: Readonly<CartesianChartProps>) {
-  const yScale = computeYAxis(data, dataKeys, zeroBaseline);
+  const yScale = yAxisScale ?? computeYAxis(data, dataKeys, zeroBaseline);
 
   return (
     <div className="h-full min-h-64 w-full">

--- a/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
@@ -21,6 +21,7 @@ import {
   prepareMeasureSliceData,
   preparePieData,
 } from "@/modules/ee/analysis/charts/lib/chart-utils";
+import { computeYAxis } from "@/modules/ee/analysis/charts/lib/y-axis-scale";
 import {
   FEEDBACK_MEASURE_IDS,
   formatCubeColumnHeader,
@@ -156,6 +157,12 @@ const BarChartView = ({
     const measureData = pivotMeasuresToCategories(sortedData, axisKeys, (key) =>
       formatCubeColumnHeader(key, t)
     );
+    // Pivoting collapses every measure onto PIVOTED_VALUE_KEY ("value"), which carries no measure
+    // id, so an axis derived from the pivoted rows can't look up fixed-scale candidates and falls
+    // back to data-driven "nice" bounds. Resolve the scale from the original measure columns so
+    // rating/CSAT/CES/NPS averages still pin to the question scale, e.g. 3.3 on a 1-5 rating tops
+    // the axis at 5, not 4 (ENG-2226).
+    const yAxisScale = computeYAxis(sortedData, dataKeys, true);
     // Ticks use the short value label ("Very positive") — the full measure label is too
     // wide, so recharts would thin the ticks and bars would lose their name. The tooltip
     // keeps the full label via tooltipLabel.
@@ -167,6 +174,7 @@ const BarChartView = ({
         data={measureData}
         xAxisKey={PIVOTED_MEASURE_KEY}
         dataKeys={[PIVOTED_VALUE_KEY]}
+        yAxisScale={yAxisScale}
         chartConfig={chartConfig}
         tooltipCursor={false}
         zeroBaseline

--- a/apps/web/modules/ee/analysis/charts/lib/y-axis-scale.test.ts
+++ b/apps/web/modules/ee/analysis/charts/lib/y-axis-scale.test.ts
@@ -58,6 +58,17 @@ describe("computeYAxis", () => {
       const data = [{ [RATING_AVG]: 3.2, [CSAT_AVG]: null }];
       expect(computeYAxis(data, [RATING_AVG, CSAT_AVG], true)?.domain).toEqual([0, 5]);
     });
+
+    // Regression for ENG-2226: ungrouped measure charts pivot every measure onto a synthetic
+    // "value" key that resolves no candidates, so pinning must key off the real measure id. The
+    // renderer therefore derives the axis from the original measure columns, not the pivoted key.
+    test("pinning keys off the real measure id, not a synthetic pivot key", () => {
+      const PIVOTED_VALUE_KEY = "value";
+      // Same 1-5 rating average of 3.3: keyed by the measure id it pins to 5; keyed by the
+      // synthetic pivot key it can't look up candidates and falls back to a data-driven 4.
+      expect(computeYAxis([{ [RATING_AVG]: 3.3 }], [RATING_AVG], true)?.domain).toEqual([0, 5]);
+      expect(computeYAxis([{ [PIVOTED_VALUE_KEY]: 3.3 }], [PIVOTED_VALUE_KEY], true)?.domain).toEqual([0, 4]);
+    });
   });
 
   describe("falls back to data-driven nice scaling", () => {


### PR DESCRIPTION
## What & why

`Rating: Average` / `CSAT: Average` (and CES/NPS) charts **without a grouping dimension** rendered a data-driven Y-axis instead of the question's fixed scale — a 3.3 average on a 1–5 rating topped the axis at **4** instead of **5**, so the bar drew to ~82% of plot height instead of 66% and users misread how good a rating is. Regression against #8540, introduced by the measure-pivot in #8542.

Root cause: on the no-category-axis path, `chart-renderer.tsx` pivots every measure onto the synthetic `PIVOTED_VALUE_KEY` (`"value"`) and passed that as the data key. `computeYAxis` → `getMeasureAxisMaxCandidates("value")` matches no measure, returns `undefined`, so the fixed-scale pinning was silently skipped and the axis fell back to "nice" bounds. Adding any grouping dimension took the non-pivot path and pinned correctly — hence the ungrouped-only symptom.

Fix: on the pivot path, derive the scale from the **original measure columns** (real measure ids) via `computeYAxis(sortedData, dataKeys, true)` and pass it to `CartesianChart` through a new optional `yAxisScale` prop, which takes precedence over the internal derivation. The pivoted values are identical numbers, so the pinned scale matches the rendered bars. Non-pivot bar/line/area paths are unchanged.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2226/fixcharts-ratingcsat-y-axis-no-longer-pins-to-the-question-scale-on

## How this was tested

- `pnpm vitest run modules/ee/analysis/charts/lib/y-axis-scale.test.ts` → **20 passed** ✅ (added a regression case asserting pinning keys off the real measure id: `ratingAverage` 3.3 → `[0,5]`, synthetic `"value"` 3.3 → `[0,4]`).
- ESLint `--fix` clean on the three touched files; `tsc --noEmit` no new errors.
- ⚠️ Not exercised in a live chart preview (needs the app + Cube + seeded aggregates). Manual QA below; the logic is locked by the unit test.

### Before / after

Same rating average (3.3 on a 1–5 question), ungrouped:

<!-- DRAG IMAGE HERE: yaxis-before-after.png -->

| | Y-axis | Bar fills |
| --- | --- | --- |
| **Before** (axis from pivot key `"value"`) | tops at **4** | ~83% of the plot |
| **After** (axis from the real measure id) | tops at **5** | ~66% of the plot |

> ℹ️ The image above is from a faithful port of the `computeYAxis` algorithm (bug path vs fix path), not the live chart — a live-app screenshot needs Cube + seeded aggregates. The numbers match the ticket's reproduction table.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Charts → **Create chart** → **Bar Chart** → Measure **Rating: Average** → **Filter data** = `Question` equals a 1–5 rating question (avg ~3.3) → leave **Group data** off → Y-axis tops at **5** with ticks 0,1,2,3,4,5 (was 0–4).
- [ ] Measure **CSAT: Average**, no filter/grouping → Y-axis tops at **5**, ticks 0–5.
- [ ] Same Rating chart → enable **Group data** = `Language` → axis still 0–5 (unchanged, non-pivot path).
- [ ] A **count** measure (e.g. Responses), ungrouped → axis still data-driven "nice" bounds (no regression).

**Preconditions / test data**

- Link/multi-language survey with a 1–5 rating question and CSAT responses; averages in the mid-scale range (e.g. rating 3.3, CSAT 3.9). Cloud or self-host; no flag/entitlement.

**Risks & regressions**

- Scope is the ungrouped measure-pivot bar path only. Re-check: ungrouped multi-measure (emotion/sentiment counts) and single-measure count charts still scale sensibly; grouped charts unchanged.

**Migrations / env / cutover**

- none

