### PR TITLE
fix(charts): pin rating/CSAT Y-axis on ungrouped measure charts (backport #8749 to release/5.3)

### DIFF
--- a/apps/web/modules/ee/analysis/charts/components/cartesian-chart.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/cartesian-chart.tsx
@@ -3,7 +3,7 @@
 import { type ElementType, type ReactNode } from "react";
 import { CartesianGrid, XAxis, YAxis } from "recharts";
 import { formatXAxisTick } from "@/modules/ee/analysis/charts/lib/chart-utils";
-import { computeYAxis } from "@/modules/ee/analysis/charts/lib/y-axis-scale";
+import { type YAxisScale, computeYAxis } from "@/modules/ee/analysis/charts/lib/y-axis-scale";
 import type { TChartDataRow } from "@/modules/ee/analysis/types/analysis";
 import type { ChartConfig } from "@/modules/ui/components/chart";
 import { ChartContainer, ChartLegend, ChartLegendContent, ChartTooltip } from "@/modules/ui/components/chart";
@@ -31,6 +31,10 @@ export interface CartesianChartProps {
    * measure charts keep their category axis but hide the header, since each tooltip row already
    * carries the measure label and a header would just repeat it. */
   tooltipHideLabel?: boolean;
+  /** Precomputed Y-axis scale, used in place of deriving one from `data`/`dataKeys`. Measure-pivot
+   * charts render values under a synthetic key (PIVOTED_VALUE_KEY) that carries no measure id, so
+   * they resolve the fixed-scale axis from the original measure columns and pass it here (ENG-2226). */
+  yAxisScale?: YAxisScale;
 }
 
 export function CartesianChart({
@@ -47,8 +51,9 @@ export function CartesianChart({
   xAxisTickFormatter,
   hasCategoryAxis = true,
   tooltipHideLabel,
+  yAxisScale,
 }: Readonly<CartesianChartProps>) {
-  const yScale = computeYAxis(data, dataKeys, zeroBaseline);
+  const yScale = yAxisScale ?? computeYAxis(data, dataKeys, zeroBaseline);
 
   return (
     <div className="h-full min-h-64 w-full">

--- a/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx
@@ -21,6 +21,7 @@ import {
   prepareMeasureSliceData,
   preparePieData,
 } from "@/modules/ee/analysis/charts/lib/chart-utils";
+import { computeYAxis } from "@/modules/ee/analysis/charts/lib/y-axis-scale";
 import {
   FEEDBACK_MEASURE_IDS,
   formatCubeColumnHeader,
@@ -156,6 +157,12 @@ const BarChartView = ({
     const measureData = pivotMeasuresToCategories(sortedData, axisKeys, (key) =>
       formatCubeColumnHeader(key, t)
     );
+    // Pivoting collapses every measure onto PIVOTED_VALUE_KEY ("value"), which carries no measure
+    // id, so an axis derived from the pivoted rows can't look up fixed-scale candidates and falls
+    // back to data-driven "nice" bounds. Resolve the scale from the original measure columns so
+    // rating/CSAT/CES/NPS averages still pin to the question scale, e.g. 3.3 on a 1-5 rating tops
+    // the axis at 5, not 4 (ENG-2226).
+    const yAxisScale = computeYAxis(sortedData, dataKeys, true);
     // Ticks use the short value label ("Very positive") — the full measure label is too
     // wide, so recharts would thin the ticks and bars would lose their name. The tooltip
     // keeps the full label via tooltipLabel.
@@ -167,6 +174,7 @@ const BarChartView = ({
         data={measureData}
         xAxisKey={PIVOTED_MEASURE_KEY}
         dataKeys={[PIVOTED_VALUE_KEY]}
+        yAxisScale={yAxisScale}
         chartConfig={chartConfig}
         tooltipCursor={false}
         zeroBaseline


### PR DESCRIPTION
## What & why

Backport of #8749 into `release/5.3`. Ref ENG-2226.

Ungrouped `Rating: Average` / `CSAT: Average` (and CES/NPS) charts rendered a data-driven Y-axis instead of pinning to the question scale — a 3.3 average on a 1–5 rating topped the axis at **4** instead of **5**, so the bar drew to ~83% of plot height instead of ~66% and users misread how good a rating is. Regression against #8540, introduced by the measure-pivot in #8542.

Root cause: on the no-category-axis path the renderer pivots every measure onto the synthetic `PIVOTED_VALUE_KEY` (`"value"`) and passed that as the axis data key. `getMeasureAxisMaxCandidates("value")` matches no measure → pinning silently skipped. Fix derives the scale from the original measure columns (real measure ids) and passes it to `CartesianChart` via a new optional `yAxisScale` prop. This is the fix ENG-2226 flagged as a low-risk Milestone-2 backport.

Minimal single-fix backport per policy.

## Files changed

- `apps/web/modules/ee/analysis/charts/components/chart-renderer.tsx` (+8) — pivot path computes the scale from real measure ids and passes `yAxisScale`.
- `apps/web/modules/ee/analysis/charts/components/cartesian-chart.tsx` (+7/-2) — new optional `yAxisScale` prop, used in place of the internal derivation.

**Dropped from the backport:** the net-new unit test case added by #8749 in `y-axis-scale.test.ts` (per backport policy — no new tests; existing tests unchanged so the suite still passes).

## QA / Test Plan

**How to test**

- [ ] Charts → **Create chart** → **Bar Chart** → measure **Rating: Average** → **Filter data** = `Question` equals a 1–5 rating question (avg ~3.3) → leave **Group data** off → Y-axis tops at **5**, ticks 0–5 (was 0–4).
- [ ] Measure **CSAT: Average**, no filter/grouping → Y-axis tops at **5**, ticks 0–5.
- [ ] Same Rating chart → enable **Group data** = `Language` → axis still 0–5 (unchanged, non-pivot path).
- [ ] A **count** measure (e.g. Responses), ungrouped → axis stays data-driven "nice" bounds (no regression).

**Preconditions / test data**

- Link/multi-language survey with a 1–5 rating question and CSAT responses, mid-scale averages (rating ~3.3, CSAT ~3.9). Cloud or self-host; no flag/entitlement.

**Risks & regressions**

- Scope is the ungrouped measure-pivot bar path only. Re-check: ungrouped multi-measure (emotion/sentiment counts) and single-measure count charts still scale sensibly; grouped charts unchanged.

**Migrations / env / cutover**

- none

## Validation

- `pnpm exec eslint` on both touched files → clean ✅
- `pnpm vitest run modules/ee/analysis/charts/lib/y-axis-scale.test.ts` → **19 passed** ✅ (existing suite, new case intentionally not carried over).
- Cherry-pick of `1da8af6` applied clean; test file reset to the release/5.3 baseline.
