### PR TITLE
fix(mcp,api): OAuth challenge parity, audit logging, Prisma 7 constraint fields and dry-run scopes (backport #8718 + #8743 to release/5.3)

### DIFF
--- a/apps/web/app/.well-known/oauth-protected-resource/route.test.ts
+++ b/apps/web/app/.well-known/oauth-protected-resource/route.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/modules/auth/lib/oauth-urls", async (importOriginal) => ({
   getMcpResourceUrl: () => "https://app.example.com/api/mcp",
 }));
 
-const { MCP_OAUTH_SCOPES } = await import("@/modules/auth/lib/oauth-urls");
+const { MCP_OAUTH_SCOPES, MCP_CHALLENGE_SCOPE } = await import("@/modules/auth/lib/oauth-urls");
 
 const createRequest = () =>
   new NextRequest("https://app.example.com/.well-known/oauth-protected-resource/api/mcp");
@@ -71,6 +71,27 @@ describe("OAuth protected resource metadata", () => {
     for (const scope of scopesSupported) {
       expect(MCP_OAUTH_SCOPES).toContain(scope);
     }
+  });
+
+  test("the 401 WWW-Authenticate challenge scope matches scopes_supported exactly", async () => {
+    // The regression guard for ENG-2175. A client that hits the MCP 401 before fetching this
+    // document uses the challenge string as its DCR `scope`; the oauth-provider then validates
+    // /authorize against the client's REGISTERED scopes. If the challenge is narrower than what
+    // this document advertises, the client registers narrow, authorizes wide, and its first
+    // connect fails with `invalid_scope` — succeeding only on retry, once the metadata is cached.
+    // The provider validates authorize as a subset of the registered scopes, so the challenge must
+    // COVER this list; a wider challenge would also pass. Asserting equality is the stricter check,
+    // and it holds because both derive from MCP_PROTECTED_RESOURCE_SCOPES — so a drift in either
+    // direction is a deliberate change, not an accident.
+    const response = await GET(createRequest(), {
+      params: Promise.resolve({ resource: ["api", "mcp"] }),
+    });
+    const { scopes_supported: scopesSupported } = (await response.json()) as {
+      scopes_supported: string[];
+    };
+
+    expect(MCP_CHALLENGE_SCOPE.split(" ")).toEqual(scopesSupported);
+    expect(MCP_CHALLENGE_SCOPE).toContain("offline_access");
   });
 
   test("returns 404 for unrelated protected resource metadata paths", async () => {

--- a/apps/web/app/api/client/[workspaceId]/responses/lib/response-error.integration.test.ts
+++ b/apps/web/app/api/client/[workspaceId]/responses/lib/response-error.integration.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import { DatabaseError, InvalidInputError, UniqueConstraintError } from "@formbricks/types/errors";
+import { resetDb } from "@/integration/reset-db";
+import { handleClientResponseCreateError } from "./response-error";
+
+/**
+ * ENG-2174, against the REAL Prisma 7 + @prisma/adapter-pg stack.
+ *
+ * The adapter builds the P2002 column list by regex-scraping the Postgres error DETAIL
+ * (`Key ("surveyId", "singleUseId")=(…)`) and never unquotes it, so every camelCase column arrives
+ * wrapped in double quotes. The exact-equality checks in `response-error.ts` therefore never matched
+ * and a routine duplicate submission fell through to `DatabaseError` — a 500, plus a Sentry report,
+ * instead of the documented 409.
+ *
+ * The unit tests could not have caught this: they build the meta by hand, and every fixture in the
+ * repo passed unquoted names. Only a genuine violation produces the quoting, so this drives one.
+ */
+beforeEach(async () => {
+  await resetDb();
+});
+
+const createSurvey = async () => {
+  const organization = await prisma.organization.create({ data: { name: "ENG-2174 Org" } });
+  const workspace = await prisma.workspace.create({
+    data: { name: "ENG-2174 Workspace", organizationId: organization.id },
+  });
+  return prisma.survey.create({ data: { name: "ENG-2174 Survey", workspaceId: workspace.id } });
+};
+
+describe("handleClientResponseCreateError vs real Prisma 7 + adapter-pg (ENG-2174)", () => {
+  test("maps a duplicate (surveyId, singleUseId) to a 409, not a 500", async () => {
+    const survey = await createSurvey();
+    const singleUseId = "eng2174-single-use";
+    await prisma.response.create({ data: { surveyId: survey.id, singleUseId, data: {} } });
+
+    const error = await prisma.response
+      .create({ data: { surveyId: survey.id, singleUseId, data: {} } })
+      .catch((e) => e);
+
+    expect(error?.code).toBe("P2002");
+    // The premise of the bug: the adapter reports the columns quoted.
+    const rawFields = (
+      error?.meta as { driverAdapterError?: { cause?: { constraint?: { fields?: string[] } } } }
+    )?.driverAdapterError?.cause?.constraint?.fields;
+    expect(rawFields).toContain('"singleUseId"');
+
+    expect(() => handleClientResponseCreateError(error)).toThrow(UniqueConstraintError);
+    expect(() => handleClientResponseCreateError(error)).toThrow(
+      "Response already submitted for this single-use link"
+    );
+    // Guards the actual regression: before the fix this fell through to DatabaseError (500).
+    expect(() => handleClientResponseCreateError(error)).not.toThrow(DatabaseError);
+  });
+
+  test("maps a duplicate displayId to a 400, not a 500", async () => {
+    const survey = await createSurvey();
+    const display = await prisma.display.create({ data: { surveyId: survey.id } });
+    await prisma.response.create({ data: { surveyId: survey.id, displayId: display.id, data: {} } });
+
+    const error = await prisma.response
+      .create({ data: { surveyId: survey.id, displayId: display.id, data: {} } })
+      .catch((e) => e);
+
+    expect(error?.code).toBe("P2002");
+    const rawFields = (
+      error?.meta as { driverAdapterError?: { cause?: { constraint?: { fields?: string[] } } } }
+    )?.driverAdapterError?.cause?.constraint?.fields;
+    expect(rawFields).toContain('"displayId"');
+
+    expect(() => handleClientResponseCreateError(error, display.id)).toThrow(InvalidInputError);
+    expect(() => handleClientResponseCreateError(error, display.id)).not.toThrow(DatabaseError);
+  });
+});

--- a/apps/web/app/api/mcp/route.test.ts
+++ b/apps/web/app/api/mcp/route.test.ts
@@ -43,22 +43,22 @@ vi.mock("@formbricks/database", () => ({
   },
 }));
 
-vi.mock("@/modules/auth/lib/oauth-urls", () => ({
-  // Must mirror the real MCP_RESOURCE_SCOPES: the route's minimum-scope gate and its WWW-Authenticate
-  // challenge are both derived from this list, so a short mock would test a world production doesn't have.
-  MCP_RESOURCE_SCOPES: [
-    "surveys:read",
-    "surveys:write",
-    "workflows:read",
-    "workflows:write",
-    "feedbackRecords:read",
-    "feedbackRecords:write",
-  ],
+// Only the env-dependent URL getters are mocked. The scope constants are the real ones: the route's
+// minimum-scope gate and its WWW-Authenticate challenge are both derived from them, so literals here
+// would test a world production doesn't have and mask scope drift (ENG-2175).
+vi.mock("@/modules/auth/lib/oauth-urls", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/modules/auth/lib/oauth-urls")>()),
   getAuthIssuerUrl: () => "http://localhost/api/auth",
   getMcpOrigin: () => "http://localhost",
   getMcpProtectedResourceMetadataUrl: () => "http://localhost/.well-known/oauth-protected-resource/api/mcp",
   getMcpResourceUrl: () => "http://localhost/api/mcp",
 }));
+
+const { MCP_CHALLENGE_SCOPE } = await import("@/modules/auth/lib/oauth-urls");
+// The auth-params are comma-separated per RFC 9110 §11.6.1 (#8718): asserting the whole string is what
+// keeps the separator from regressing, since a strict client parser needs it to read `resource_metadata`.
+// The scope list interpolates the real constant, so this stays honest as the advertised scopes change.
+const EXPECTED_CHALLENGE = `Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp", scope="${MCP_CHALLENGE_SCOPE}"`;
 
 vi.mock("@/modules/api/lib/api-key-auth", () => ({
   authenticateApiKeyFromHeaders: vi.fn(),
@@ -170,9 +170,7 @@ describe("POST /api/mcp", () => {
 
     expect(response.status).toBe(401);
     expect(response.headers.get("Content-Type")).toBe("application/problem+json");
-    expect(response.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp", scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
-    );
+    expect(response.headers.get("WWW-Authenticate")).toBe(EXPECTED_CHALLENGE);
     expect(applyIPRateLimit).toHaveBeenCalled();
   });
 
@@ -444,9 +442,7 @@ describe("POST /api/mcp", () => {
     expect(response.status).toBe(401);
     expect(authenticateApiKeyFromHeaders).not.toHaveBeenCalled();
     expect(applyIPRateLimit).toHaveBeenCalled();
-    expect(response.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp", scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
-    );
+    expect(response.headers.get("WWW-Authenticate")).toBe(EXPECTED_CHALLENGE);
   });
 
   test("blocks write tools for read-only OAuth tokens", async () => {

--- a/apps/web/app/api/mcp/route.test.ts
+++ b/apps/web/app/api/mcp/route.test.ts
@@ -171,7 +171,7 @@ describe("POST /api/mcp", () => {
     expect(response.status).toBe(401);
     expect(response.headers.get("Content-Type")).toBe("application/problem+json");
     expect(response.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
+      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp", scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
     );
     expect(applyIPRateLimit).toHaveBeenCalled();
   });
@@ -445,7 +445,7 @@ describe("POST /api/mcp", () => {
     expect(authenticateApiKeyFromHeaders).not.toHaveBeenCalled();
     expect(applyIPRateLimit).toHaveBeenCalled();
     expect(response.headers.get("WWW-Authenticate")).toBe(
-      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp" scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
+      'Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp", scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
     );
   });
 
@@ -485,7 +485,9 @@ describe("POST /api/mcp", () => {
     expect(message.result.structuredContent.error).toMatchObject({
       status: 403,
       code: "forbidden",
-      detail: "OAuth token does not include the required MCP scope",
+      // Names the scope this specific call needed, not just that some scope was missing — that is
+      // the only thing the client can act on.
+      detail: "OAuth token does not include the required MCP scope: surveys:write",
       requestId: "req_read_only",
     });
   });
@@ -528,7 +530,9 @@ describe("POST /api/mcp", () => {
     expect(message.result.structuredContent.error).toMatchObject({
       status: 403,
       code: "forbidden",
-      detail: "OAuth token does not include the required MCP scope",
+      // The refusal names the scope the client must obtain, since a JSON-RPC tool result carries no
+      // WWW-Authenticate header for it to read.
+      detail: "OAuth token does not include the required MCP scope: workflows:write",
       requestId: "req_wf_read_only",
     });
     // The scope gate must fire BEFORE any mutation side effect: no audit log is built or queued for a

--- a/apps/web/app/api/v3/surveys/lib/operations.test.ts
+++ b/apps/web/app/api/v3/surveys/lib/operations.test.ts
@@ -320,6 +320,16 @@ describe("createV3SurveyResponse", () => {
 
     expect(response.status).toBe(201);
     expect(response.headers.get("Location")).toBe("/api/v3/surveys/survey_1");
+    // Negative control for the level, not just the check: validateV3Survey was moved across this
+    // same seam from "readWrite" to "read" because it writes nothing. Create does write, so it must
+    // stay at "readWrite" — without this, the same move here would pass the suite.
+    expect(vi.mocked(requireV3WorkspaceAccess)).toHaveBeenCalledWith(
+      authentication,
+      workspaceId,
+      "readWrite",
+      requestId,
+      instance
+    );
     expect(vi.mocked(createV3Survey)).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceId,
@@ -913,10 +923,12 @@ describe("validateV3Survey", () => {
     } as any);
 
     expect(response.status).toBe(200);
+    // "read", not "readWrite": validation writes nothing, and the MCP validate_survey tool is
+    // registered surveys:read. Raising this back to readWrite re-breaks that tool (ENG-2179).
     expect(vi.mocked(requireV3WorkspaceAccess)).toHaveBeenCalledWith(
       authentication,
       workspaceId,
-      "readWrite",
+      "read",
       requestId,
       instance
     );
@@ -953,10 +965,11 @@ describe("validateV3Survey", () => {
     } as any);
 
     expect(response.status).toBe(200);
+    // See the create-branch note above: the patch dry run is gated at "read" too.
     expect(vi.mocked(getAuthorizedV3Survey)).toHaveBeenCalledWith({
       surveyId: validSurveyId,
       authentication,
-      access: "readWrite",
+      access: "read",
       requestId,
       instance,
     });

--- a/apps/web/app/api/v3/surveys/lib/operations.ts
+++ b/apps/web/app/api/v3/surveys/lib/operations.ts
@@ -690,6 +690,16 @@ export async function patchV3SurveyResponse({
   }
 }
 
+/**
+ * Dry-run validation of a create or patch payload. Neither branch writes: the create branch is a
+ * pure function of the input, and the patch branch merges the payload into the loaded survey in
+ * memory. Both are therefore gated at `read`, not `readWrite`.
+ *
+ * That level is load-bearing for the MCP `validate_survey` tool, which is registered `surveys:read`
+ * (and annotated `readOnlyHint`). Requiring write here made a read-scoped agent 403 on a tool that
+ * mutates nothing (ENG-2179). If this is ever raised back to `readWrite`, that tool's declared scope
+ * has to move with it.
+ */
 export async function validateV3Survey({
   body,
   authentication,
@@ -710,7 +720,7 @@ export async function validateV3Survey({
         const authResult = await requireV3WorkspaceAccess(
           authentication,
           workspaceResult.data.workspaceId,
-          "readWrite",
+          "read",
           requestId,
           instance
         );
@@ -732,7 +742,7 @@ export async function validateV3Survey({
     const { survey, response } = await getAuthorizedV3Survey({
       surveyId: validationBody.surveyId,
       authentication,
-      access: "readWrite",
+      access: "read",
       requestId,
       instance,
     });

--- a/apps/web/lib/utils/prisma-constraint.integration.test.ts
+++ b/apps/web/lib/utils/prisma-constraint.integration.test.ts
@@ -48,4 +48,25 @@ describe("getUniqueConstraintFields vs real Prisma 7 + adapter-pg (ENG-1801)", (
     // The adapter reports the DB column name (`token_hash`), not the Prisma field name (`tokenHash`).
     expect(getUniqueConstraintFields(error)).toEqual(["token_hash"]);
   });
+
+  test("unquotes camelCase columns, which Postgres quotes in the error DETAIL (ENG-2174)", async () => {
+    const organization = await prisma.organization.create({ data: { name: "ENG-2174 quoting" } });
+    await prisma.workspace.create({ data: { name: "Duplicate", organizationId: organization.id } });
+
+    const error = await prisma.workspace
+      .create({ data: { name: "Duplicate", organizationId: organization.id } })
+      .catch((e) => e);
+
+    expect(error?.code).toBe("P2002");
+    // The premise: Postgres quotes any identifier that is not all-lowercase, and the adapter
+    // regex-scrapes the DETAIL without unquoting — so the raw meta carries the quotes.
+    const rawFields = (
+      error?.meta as { driverAdapterError?: { cause?: { constraint?: { fields?: string[] } } } }
+    )?.driverAdapterError?.cause?.constraint?.fields;
+    expect(rawFields).toContain('"organizationId"');
+
+    // ...and the helper hands back usable Prisma field names. Note `name` is lowercase and therefore
+    // never quoted, which is why callers that only read fields[0] kept working by luck.
+    expect(getUniqueConstraintFields(error)).toEqual(["organizationId", "name"]);
+  });
 });

--- a/apps/web/lib/utils/prisma-constraint.test.ts
+++ b/apps/web/lib/utils/prisma-constraint.test.ts
@@ -54,4 +54,48 @@ describe("getUniqueConstraintFields", () => {
   test("filters out non-string entries defensively", () => {
     expect(getUniqueConstraintFields(legacyP2002(["email", null as unknown as string]))).toEqual(["email"]);
   });
+
+  // The adapter regex-scrapes the Postgres DETAIL, which quotes every identifier that isn't
+  // all-lowercase. Before this was handled, `includes("singleUseId")` never matched `'"singleUseId"'`
+  // and duplicate single-use responses fell through to a 500 instead of a 409 (ENG-2174).
+  describe("quoted identifiers (Postgres quote_identifier)", () => {
+    test("unquotes a fully quoted composite key", () => {
+      expect(getUniqueConstraintFields(adapterP2002(['"surveyId"', '"singleUseId"']))).toEqual([
+        "surveyId",
+        "singleUseId",
+      ]);
+    });
+
+    test("unquotes a single quoted column", () => {
+      expect(getUniqueConstraintFields(adapterP2002(['"displayId"']))).toEqual(["displayId"]);
+    });
+
+    test("handles a mixed list, leaving the bare lowercase column untouched", () => {
+      // ActionClass_name_workspaceId_key — callers that read fields[0] must be unaffected.
+      const fields = getUniqueConstraintFields(adapterP2002(["name", '"workspaceId"']));
+      expect(fields).toEqual(["name", "workspaceId"]);
+      expect(fields[0]).toBe("name");
+    });
+
+    test("leaves @map()ed snake_case columns unchanged (Postgres never quotes them)", () => {
+      expect(getUniqueConstraintFields(adapterP2002(["token_hash"]))).toEqual(["token_hash"]);
+    });
+
+    test("normalises the legacy shape too, so both shapes stay interchangeable", () => {
+      expect(getUniqueConstraintFields(legacyP2002(['"email"']))).toEqual(["email"]);
+      expect(getUniqueConstraintFields(legacyP2002(["email"]))).toEqual(["email"]);
+    });
+
+    test("only strips a matched outer pair", () => {
+      // A lone quote is not a pair; an inner quote is part of the identifier.
+      expect(getUniqueConstraintFields(adapterP2002(['"']))).toEqual(['"']);
+      expect(getUniqueConstraintFields(adapterP2002(['""']))).toEqual([""]);
+      expect(getUniqueConstraintFields(adapterP2002(['"a"b"']))).toEqual(['a"b']);
+    });
+
+    test("is idempotent — an already-bare name survives a second pass", () => {
+      const once = getUniqueConstraintFields(adapterP2002(['"surveyId"']));
+      expect(getUniqueConstraintFields(adapterP2002(once))).toEqual(once);
+    });
+  });
 });

--- a/apps/web/lib/utils/prisma-constraint.ts
+++ b/apps/web/lib/utils/prisma-constraint.ts
@@ -15,6 +15,26 @@ export const isUniqueConstraintError = (error: unknown): error is PrismaClientKn
   error instanceof Prisma.PrismaClientKnownRequestError && error.code === UNIQUE_CONSTRAINT_VIOLATION;
 
 /**
+ * Strips one symmetric pair of double quotes from a column name.
+ *
+ * `@prisma/adapter-pg` derives the column list by regex-scraping the Postgres error DETAIL
+ * (`Key ("surveyId", "singleUseId")=(…)`) and never unquotes it. Postgres quotes any identifier
+ * `quote_identifier()` does not consider safe to leave bare — not all-lowercase, starting with a
+ * digit, containing anything outside `[a-z0-9_]`, or colliding with a keyword — so `singleUseId`
+ * arrives as `"singleUseId"` while `token_hash` arrives bare. (`quote_all_identifiers = on` quotes
+ * everything, which this also handles.)
+ *
+ * Only a matched outer pair is removed, so already-bare names pass through byte-identical. Applied
+ * to the legacy `meta.target` shape too: that engine does not quote, but running both branches
+ * through the same normaliser keeps the two interchangeable for callers and tests.
+ */
+const unquoteIdentifier = (field: string): string =>
+  field.length >= 2 && field.startsWith('"') && field.endsWith('"') ? field.slice(1, -1) : field;
+
+const toColumnNames = (fields: unknown[]): string[] =>
+  fields.filter((field): field is string => typeof field === "string").map(unquoteIdentifier);
+
+/**
  * Returns the column names involved in a P2002 unique-constraint violation.
  *
  * Prisma's `error.meta` shape is explicitly NOT public API (prisma#28953) and differs by engine:
@@ -28,7 +48,8 @@ export const isUniqueConstraintError = (error: unknown): error is PrismaClientKn
  *
  * Security: only the structured column names are returned. Never surface `originalMessage`, the
  * constraint name, or any other raw `driverAdapterError.cause` string to a response or log — the
- * underlying Postgres unique-violation detail can contain the offending value (PII).
+ * underlying Postgres unique-violation detail can contain the offending value (PII). Stripping the
+ * quotes below is deliberately the *only* string processing done here, for the same reason.
  */
 export const getUniqueConstraintFields = (error: PrismaClientKnownRequestError): string[] => {
   const meta = error.meta as
@@ -41,13 +62,13 @@ export const getUniqueConstraintFields = (error: PrismaClientKnownRequestError):
   // Legacy / library-engine shape.
   const legacyTarget = meta?.target;
   if (Array.isArray(legacyTarget)) {
-    return legacyTarget.filter((field): field is string => typeof field === "string");
+    return toColumnNames(legacyTarget);
   }
 
   // Prisma 7 driver-adapter shape.
   const adapterFields = meta?.driverAdapterError?.cause?.constraint?.fields;
   if (Array.isArray(adapterFields)) {
-    return adapterFields.filter((field): field is string => typeof field === "string");
+    return toColumnNames(adapterFields);
   }
 
   return [];

--- a/apps/web/modules/auth/lib/oauth-urls.ts
+++ b/apps/web/modules/auth/lib/oauth-urls.ts
@@ -71,3 +71,18 @@ export const MCP_PROTECTED_RESOURCE_SCOPES = [
   ...MCP_RESOURCE_SCOPES,
   "offline_access",
 ] as const satisfies readonly (typeof MCP_OAUTH_SCOPES)[number][];
+
+/**
+ * The `scope` advertised in the 401 `WWW-Authenticate` challenge from the MCP endpoint.
+ *
+ * A client that hits the 401 *before* fetching the protected-resource metadata uses this string as
+ * its Dynamic Client Registration `scope`, then authorizes with the scopes the metadata advertises.
+ * The oauth-provider validates an authorize request as a *subset* of the client's registered scopes,
+ * so the invariant is that this list must **cover** the metadata list. A narrower challenge means the
+ * client registers narrow, authorizes wide, and is rejected with `invalid_scope` — failing its first
+ * connect and succeeding only on retry, once the metadata is cached (ENG-2175).
+ *
+ * Derived from the same array so the two are identical, which satisfies the invariant by construction
+ * and leaves nothing to drift.
+ */
+export const MCP_CHALLENGE_SCOPE = MCP_PROTECTED_RESOURCE_SCOPES.join(" ");

--- a/apps/web/modules/ee/audit-logs/lib/handler.test.ts
+++ b/apps/web/modules/ee/audit-logs/lib/handler.test.ts
@@ -89,7 +89,9 @@ const baseEventParams = {
   status: "success" as TAuditStatus,
   oldObject: { foo: "bar" },
   newObject: { foo: "baz" },
-  apiUrl: "/api/test",
+  // Absolute: the schema validates apiUrl with z.url(). This file mocks the service out, so a bare
+  // path would pass here while being dropped in production (see service.test.ts).
+  apiUrl: "http://localhost:3000/api/test",
 };
 
 const fullUser = {

--- a/apps/web/modules/ee/audit-logs/lib/service.test.ts
+++ b/apps/web/modules/ee/audit-logs/lib/service.test.ts
@@ -61,6 +61,43 @@ describe("logAuditEvent", () => {
     await logAuditEvent(validEvent);
     expect(logger.error).toHaveBeenCalled();
   });
+
+  // `apiUrl` is validated with z.url(), and a validation failure is swallowed into a logger.error
+  // rather than surfaced — so a producer passing a malformed value silently drops the whole audit
+  // event. That is exactly how every MCP mutation went unaudited (ENG-2173).
+  describe("apiUrl", () => {
+    beforeEach(() => {
+      getIsAuditLogsEnabled.mockResolvedValue(true);
+    });
+
+    test("drops the event when apiUrl is a bare path", async () => {
+      await logAuditEvent({ ...validEvent, apiUrl: "/api/mcp" } as any);
+      expect(logger.audit).not.toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    test("logs the event when apiUrl is absolute", async () => {
+      const event = { ...validEvent, apiUrl: "http://localhost:3000/api/mcp" };
+      await logAuditEvent(event);
+      expect(logger.audit).toHaveBeenCalledWith(event);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    test("logs the event when apiUrl is omitted (optional, unlike a malformed one)", async () => {
+      await logAuditEvent(validEvent);
+      expect(logger.audit).toHaveBeenCalledWith(validEvent);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    // Ties the MCP producer to this schema: the exact value the MCP tools pass must be one this
+    // validator accepts, which is the invariant that broke.
+    test("accepts the apiUrl the MCP tools actually pass", async () => {
+      const { getMcpResourceUrl } = await import("@/modules/auth/lib/oauth-urls");
+      await logAuditEvent({ ...validEvent, apiUrl: getMcpResourceUrl() });
+      expect(logger.audit).toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe("logAuditEvent export", () => {

--- a/apps/web/modules/mcp/auth.test.ts
+++ b/apps/web/modules/mcp/auth.test.ts
@@ -45,27 +45,11 @@ vi.mock("@/modules/core/rate-limit/helpers", () => ({
   applyRateLimit: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("@/modules/auth/lib/oauth-urls", () => ({
-  MCP_OAUTH_SCOPES: [
-    "openid",
-    "profile",
-    "email",
-    "offline_access",
-    "surveys:read",
-    "surveys:write",
-    "workflows:read",
-    "workflows:write",
-    "feedbackRecords:read",
-    "feedbackRecords:write",
-  ],
-  MCP_RESOURCE_SCOPES: [
-    "surveys:read",
-    "surveys:write",
-    "workflows:read",
-    "workflows:write",
-    "feedbackRecords:read",
-    "feedbackRecords:write",
-  ],
+// Only the env-dependent URL getters are stubbed; the scope constants come from the real module.
+// Re-declaring them here would assert the mock against itself and mask scope drift — which is how
+// the challenge list silently diverged from the protected-resource metadata (ENG-2175).
+vi.mock("@/modules/auth/lib/oauth-urls", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/modules/auth/lib/oauth-urls")>()),
   getAuthIssuerUrl: vi.fn(() => "https://app.example.com/api/auth"),
   getMcpOrigin: vi.fn(() => "https://app.example.com"),
   getMcpProtectedResourceMetadataUrl: vi.fn(
@@ -82,6 +66,16 @@ vi.mock("@formbricks/logger", () => ({
     })),
   },
 }));
+
+// Imported dynamically so it resolves against the partially-mocked module above rather than being
+// hoisted past it.
+const { MCP_CHALLENGE_SCOPE } = await import("@/modules/auth/lib/oauth-urls");
+
+// Two comma-separated quoted auth-params, per the `#auth-param` list grammar in RFC 9110 §11.6.1 (#8718).
+// Cases that care about the challenge's *shape* assert this rather than the whole string, so they do not
+// have to be rewritten every time the advertised scope list changes; the exact value is pinned once, from
+// the real constant, in app/api/mcp/route.test.ts.
+const CHALLENGE_GRAMMAR = /^Bearer resource_metadata="[^"]+", scope="[^"]+"$/;
 
 const apiKeyAuth = {
   type: "apiKey" as const,
@@ -124,10 +118,11 @@ describe("authenticateMcpRequest", () => {
     if (!result.ok) {
       expect(result.response.status).toBe(401);
       // The challenge must advertise every resource scope so clients request them at consent and can
-      // reach the write tools (advertising only read is why write was unreachable — ENG-1055 QA).
-      expect(result.response.headers.get("WWW-Authenticate")).toContain(
-        'scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
-      );
+      // reach the write tools (advertising only read is why write was unreachable — ENG-1055 QA),
+      // plus offline_access so a client that registers from this string can still be granted a
+      // refresh token (ENG-2175). Asserted against the real constant, not a literal.
+      expect(result.response.headers.get("WWW-Authenticate")).toContain(`scope="${MCP_CHALLENGE_SCOPE}"`);
+      expect(MCP_CHALLENGE_SCOPE).toContain("offline_access");
       expect(await result.response.json()).toMatchObject({
         code: "not_authenticated",
         detail: "API key or OAuth access token required",
@@ -347,9 +342,13 @@ describe("authenticateMcpRequest", () => {
     if (!result.ok) {
       expect(result.response.status).toBe(401);
       // Auth-params are comma-separated (RFC 9110 `#auth-param`), so a strict client parser can read
-      // `resource_metadata` out of the challenge instead of choking on the whole tail.
-      expect(result.response.headers.get("WWW-Authenticate")).toBe(
-        'Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/mcp", scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
+      // `resource_metadata` out of the challenge instead of choking on the whole tail. What this case is
+      // really about is the metadata URL being built from the configured origin, so assert that plus the
+      // grammar — not the scope list, which is pinned from the real constant elsewhere.
+      const challenge = result.response.headers.get("WWW-Authenticate");
+      expect(challenge).toMatch(CHALLENGE_GRAMMAR);
+      expect(challenge).toContain(
+        'resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/mcp"'
       );
       expect(await result.response.json()).toMatchObject({
         detail: "Invalid OAuth access token",
@@ -380,11 +379,37 @@ describe("authenticateMcpRequest", () => {
     if (!result.ok) {
       expect(result.response.status).toBe(403);
       expect(result.response.headers.get("WWW-Authenticate")).toContain('error="insufficient_scope"');
+      // Deliberately the RESOURCE scopes, not the challenge scope: RFC 6750 `scope` names what the
+      // resource requires, and offline_access is not one of those. If this ever needs offline_access
+      // added, the baseline auth gate has been widened and MCP is accepting a token that grants no
+      // resource access.
       expect(result.response.headers.get("WWW-Authenticate")).toContain(
         'scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
       );
     }
     expect(applyRateLimit).not.toHaveBeenCalled();
+  });
+
+  // The inverse of the challenge fix: offline_access is advertised so clients can obtain a refresh
+  // token, but it grants no resource access, so it must never satisfy the baseline gate on its own.
+  test("rejects an OAuth bearer token scoped only to offline_access", async () => {
+    verifyAccessTokenMock.mockResolvedValue({
+      sub: "user_1",
+      client_id: "client_2",
+      scope: "openid profile email offline_access",
+    });
+
+    const result = await authenticateMcpRequest(
+      createRequest("http://localhost/api/mcp", {
+        authorization: "Bearer oauth_access_token",
+      })
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(403);
+      expect(result.response.headers.get("WWW-Authenticate")).toContain('error="insufficient_scope"');
+    }
   });
 
   // Any single resource scope is enough to authenticate: a feedbackRecords-only grant is a legitimate
@@ -442,9 +467,13 @@ describe("authenticateMcpRequest", () => {
     if (!result.ok) {
       expect(result.response.status).toBe(401);
       // Auth-params are comma-separated (RFC 9110 `#auth-param`), so a strict client parser can read
-      // `resource_metadata` out of the challenge instead of choking on the whole tail.
-      expect(result.response.headers.get("WWW-Authenticate")).toBe(
-        'Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/mcp", scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
+      // `resource_metadata` out of the challenge instead of choking on the whole tail. What this case is
+      // really about is the metadata URL being built from the configured origin, so assert that plus the
+      // grammar — not the scope list, which is pinned from the real constant elsewhere.
+      const challenge = result.response.headers.get("WWW-Authenticate");
+      expect(challenge).toMatch(CHALLENGE_GRAMMAR);
+      expect(challenge).toContain(
+        'resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/mcp"'
       );
       expect(await result.response.json()).toMatchObject({
         detail: "Invalid OAuth access token",

--- a/apps/web/modules/mcp/auth.test.ts
+++ b/apps/web/modules/mcp/auth.test.ts
@@ -346,8 +346,10 @@ describe("authenticateMcpRequest", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.response.status).toBe(401);
-      expect(result.response.headers.get("WWW-Authenticate")).toContain(
-        'resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/mcp"'
+      // Auth-params are comma-separated (RFC 9110 `#auth-param`), so a strict client parser can read
+      // `resource_metadata` out of the challenge instead of choking on the whole tail.
+      expect(result.response.headers.get("WWW-Authenticate")).toBe(
+        'Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/mcp", scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
       );
       expect(await result.response.json()).toMatchObject({
         detail: "Invalid OAuth access token",
@@ -439,8 +441,10 @@ describe("authenticateMcpRequest", () => {
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.response.status).toBe(401);
-      expect(result.response.headers.get("WWW-Authenticate")).toContain(
-        'resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/mcp"'
+      // Auth-params are comma-separated (RFC 9110 `#auth-param`), so a strict client parser can read
+      // `resource_metadata` out of the challenge instead of choking on the whole tail.
+      expect(result.response.headers.get("WWW-Authenticate")).toBe(
+        'Bearer resource_metadata="https://app.example.com/.well-known/oauth-protected-resource/api/mcp", scope="surveys:read surveys:write workflows:read workflows:write feedbackRecords:read feedbackRecords:write"'
       );
       expect(await result.response.json()).toMatchObject({
         detail: "Invalid OAuth access token",

--- a/apps/web/modules/mcp/auth.ts
+++ b/apps/web/modules/mcp/auth.ts
@@ -19,6 +19,7 @@ import { parseApiKeyV2 } from "@/lib/crypto";
 import { authenticateApiKeyFromHeaders, getBearerTokenFromHeaders } from "@/modules/api/lib/api-key-auth";
 import { auth } from "@/modules/auth/lib/auth";
 import {
+  MCP_CHALLENGE_SCOPE,
   MCP_RESOURCE_SCOPES,
   getAuthIssuerUrl,
   getMcpOrigin,
@@ -37,16 +38,6 @@ const QUERY_CREDENTIAL_PARAMS = new Set([
   "authorization",
 ]);
 
-// Minimum grant required to authenticate against the MCP server at all: at least ONE resource scope.
-// Any single one is enough — a token granted only `feedbackRecords:read` is a legitimate MCP client and
-// must not be rejected here for lacking `surveys:read`. Which tools it can actually call is enforced
-// per-tool by guardMcpScopes at call time.
-const MCP_MINIMUM_SCOPES = MCP_RESOURCE_SCOPES;
-// Scopes advertised in the 401 WWW-Authenticate challenge. Clients build their DCR + authorize
-// requests from this, so it must list every resource scope (read + write) or clients only ever
-// request read and can never reach the write tools. Actual write access is still gated downstream
-// by the user's workspace permissions in the v3 layer.
-const MCP_CHALLENGE_SCOPE = MCP_RESOURCE_SCOPES.join(" ");
 const oauthResourceClient = oauthProviderResourceClient(auth);
 
 export type TMcpAuthInfo = AuthInfo & {
@@ -373,14 +364,24 @@ async function authenticateMcpOAuthBearer(
     };
   }
 
-  if (!hasAnyMcpScope(authInfo, MCP_MINIMUM_SCOPES)) {
+  // Minimum grant required to authenticate against the MCP server at all: at least ONE *resource*
+  // scope. Any single one is enough — a token granted only `feedbackRecords:read` is a legitimate
+  // MCP client and must not be rejected here for lacking `surveys:read`. Which tools it can actually
+  // call is enforced per-tool by guardMcpScopes at call time.
+  //
+  // Deliberately NOT MCP_CHALLENGE_SCOPE / MCP_PROTECTED_RESOURCE_SCOPES: those include
+  // `offline_access`, and an any-of gate over that list would let a token holding *only*
+  // `offline_access` — which grants no resource access at all — authenticate to the MCP server.
+  // Same reason the insufficient_scope challenge below advertises only the resource scopes: RFC 6750
+  // `scope` names the scopes *required* for the resource, and `offline_access` is not one of them.
+  if (!hasAnyMcpScope(authInfo, MCP_RESOURCE_SCOPES)) {
     log.warn({ statusCode: 403, clientId: authInfo.clientId }, "MCP OAuth token missing every MCP scope");
     return {
       ok: false,
       requestId,
       response: withInsufficientScopeChallenge(
         problemForbidden(requestId, "OAuth token does not include the required MCP scope", instance),
-        [...MCP_MINIMUM_SCOPES]
+        [...MCP_RESOURCE_SCOPES]
       ),
     };
   }

--- a/apps/web/modules/mcp/auth.ts
+++ b/apps/web/modules/mcp/auth.ts
@@ -212,9 +212,12 @@ export function withMcpResponseHeaders(response: Response, requestId: string): R
 
 function withOAuthChallenge(response: Response, scope = MCP_CHALLENGE_SCOPE): Response {
   const headers = new Headers(response.headers);
+  // Comma-separated auth-params, per the `#auth-param` list grammar in RFC 9110 §11.6.1 (as used by
+  // RFC 6750 and RFC 9728). Space-separated, a strict parser reads the whole tail as one malformed
+  // param and misses `resource_metadata` — the pointer MCP clients follow to discover this server.
   headers.set(
     "WWW-Authenticate",
-    `Bearer resource_metadata="${getMcpProtectedResourceMetadataUrl()}" scope="${scope}"`
+    `Bearer resource_metadata="${getMcpProtectedResourceMetadataUrl()}", scope="${scope}"`
   );
 
   return new Response(response.body, {
@@ -418,9 +421,20 @@ export function hasAnyMcpScope(authInfo: AuthInfo | undefined, allowedScopes: re
   return allowedScopes.some((scope) => scopes.includes(scope));
 }
 
+/**
+ * The scopes are named in `detail`, not only in the `WWW-Authenticate` challenge, because the tool path
+ * cannot carry a header: `guardMcpScopes` hands this Response to `responseToMcpToolResult`, which
+ * serializes the JSON body into a JSON-RPC result and drops every header. Without them in the body a
+ * client that is refused a tool call learns only "some scope is missing" and cannot re-authorize for the
+ * right one. The challenge is still set for the transport-level 403, where the header does reach clients.
+ */
 export function createMcpInsufficientScopeResponse(requestId: string, scopes: string[]): Response {
   return withInsufficientScopeChallenge(
-    problemForbidden(requestId, "OAuth token does not include the required MCP scope", "/api/mcp"),
+    problemForbidden(
+      requestId,
+      `OAuth token does not include the required MCP scope: ${scopes.join(" ")}`,
+      "/api/mcp"
+    ),
     scopes
   );
 }

--- a/apps/web/modules/mcp/constants.ts
+++ b/apps/web/modules/mcp/constants.ts
@@ -1,4 +1,9 @@
+/**
+ * The MCP endpoint path. Correct for the RFC 9457 problem-document `instance` member, which is a
+ * URI *reference* — relative is expected there.
+ */
 export const MCP_API_ROUTE = "/api/mcp" as const;
+
 // Names the whole XM Suite surface, not just surveys — the server also exposes workspace discovery and
 // feedback records. Client config keys are user-chosen, so this is a display name only.
 export const MCP_SERVER_NAME = "formbricks-xm-suite" as const;

--- a/apps/web/modules/mcp/tools/feedback-records.test.ts
+++ b/apps/web/modules/mcp/tools/feedback-records.test.ts
@@ -20,7 +20,14 @@ import {
   successListResponse,
   successResponse,
 } from "@/app/api/v3/lib/response";
+import { UNKNOWN_DATA } from "@/modules/ee/audit-logs/types/audit-log";
 import { registerFeedbackRecordTools } from "./feedback-records";
+
+// Asserted as a shape, not by calling getMcpResourceUrl() here: comparing production's value with
+// itself would still pass if it regressed to the bare path "/api/mcp" — the ENG-2173 bug. The
+// invariant that matters is that the audit apiUrl is absolute, because the audit schema validates it
+// with z.url() and drops the whole event otherwise.
+const ABSOLUTE_MCP_AUDIT_URL = expect.stringMatching(/^https?:\/\/[^/]+\/api\/mcp$/);
 
 vi.mock("@/app/api/v3/feedbackRecords/lib/operations", () => ({
   countV3FeedbackRecords: vi.fn(),
@@ -237,7 +244,12 @@ describe("create_feedback_record", () => {
 
     await tools.get("create_feedback_record")!.handler(body, { authInfo });
 
-    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "created", "feedbackRecord", "/api/mcp");
+    expect(buildV3AuditLog).toHaveBeenCalledWith(
+      apiKeyAuth,
+      "created",
+      "feedbackRecord",
+      ABSOLUTE_MCP_AUDIT_URL
+    );
     expect(createV3FeedbackRecord).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceId, body, authentication: apiKeyAuth })
     );
@@ -299,7 +311,12 @@ describe("delete_feedback_record", () => {
 
     const result = await tools.get("delete_feedback_record")!.handler(input, { authInfo });
 
-    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "deleted", "feedbackRecord", "/api/mcp");
+    expect(buildV3AuditLog).toHaveBeenCalledWith(
+      apiKeyAuth,
+      "deleted",
+      "feedbackRecord",
+      ABSOLUTE_MCP_AUDIT_URL
+    );
     expect(deleteV3FeedbackRecord).toHaveBeenCalledWith(
       expect.objectContaining({
         workspaceId,
@@ -445,6 +462,11 @@ describe("count_feedback_records", () => {
 });
 
 describe("create_feedback_records", () => {
+  // buildAuditLogBaseObject seeds `targetId` with the UNKNOWN_DATA placeholder and the batch path
+  // branches on it, so the mock has to carry it. Omitting it (as these tests used to) makes a plain
+  // truthiness check pass here while matching every entry in production — which is how the batch path
+  // came to emit success events for records the Hub had rejected.
+  const makeAuditLog = () => ({ status: "failure", targetId: UNKNOWN_DATA }) as any;
   const records = [
     { source_type: "call_notes", field_id: "note", field_type: "text", value_text: "one" },
     { source_type: "call_notes", field_id: "note", field_type: "text", value_text: "two" },
@@ -465,7 +487,7 @@ describe("create_feedback_records", () => {
   test("queues one success audit event per created record", async () => {
     const built: any[] = [];
     vi.mocked(buildV3AuditLog).mockImplementation(() => {
-      const auditLog = { status: "failure" } as any;
+      const auditLog = makeAuditLog();
       built.push(auditLog);
       return auditLog;
     });
@@ -482,12 +504,16 @@ describe("create_feedback_records", () => {
     expect(queueV3AuditLog).toHaveBeenCalledTimes(1);
     expect(built[0].status).toBe("success");
     expect(built[1].status).toBe("failure");
+    // The rejected record keeps the placeholder, so it must never be reported as a creation: an
+    // audit trail that invents records is worse than one with gaps.
+    expect(built[1].targetId).toBe(UNKNOWN_DATA);
+    expect(vi.mocked(queueV3AuditLog).mock.calls[0][0]).toBe(built[0]);
   });
 
   test("still queues a failure event when the batch operation throws, and rethrows", async () => {
     const built: any[] = [];
     vi.mocked(buildV3AuditLog).mockImplementation(() => {
-      const auditLog = { status: "failure" } as any;
+      const auditLog = makeAuditLog();
       built.push(auditLog);
       return auditLog;
     });
@@ -503,7 +529,7 @@ describe("create_feedback_records", () => {
   test("queues a single failure event when nothing was created", async () => {
     const built: any[] = [];
     vi.mocked(buildV3AuditLog).mockImplementation(() => {
-      const auditLog = { status: "failure" } as any;
+      const auditLog = makeAuditLog();
       built.push(auditLog);
       return auditLog;
     });
@@ -533,7 +559,12 @@ describe("update_feedback_record", () => {
 
     await tools.get("update_feedback_record")!.handler(input, { authInfo });
 
-    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "feedbackRecord", "/api/mcp");
+    expect(buildV3AuditLog).toHaveBeenCalledWith(
+      apiKeyAuth,
+      "updated",
+      "feedbackRecord",
+      ABSOLUTE_MCP_AUDIT_URL
+    );
     expect(updateV3FeedbackRecord).toHaveBeenCalledWith(
       expect.objectContaining({ workspaceId, feedbackRecordId: recordId, body: input, auditLog })
     );

--- a/apps/web/modules/mcp/tools/feedback-records.ts
+++ b/apps/web/modules/mcp/tools/feedback-records.ts
@@ -16,10 +16,13 @@ import {
 } from "@/app/api/v3/feedbackRecords/lib/operations";
 import { buildV3AuditLog, queueV3AuditLog } from "@/app/api/v3/lib/audit";
 import type { TV3AuditLog, TV3Authentication } from "@/app/api/v3/lib/types";
+import { getMcpResourceUrl } from "@/modules/auth/lib/oauth-urls";
+import { UNKNOWN_DATA } from "@/modules/ee/audit-logs/types/audit-log";
 import { MCP_API_ROUTE } from "@/modules/mcp/constants";
 import { getMcpAuthentication, getMcpRequestId } from "../auth";
 import { responseToMcpToolResult } from "../errors";
 import { guardMcpScopes } from "./guard-scopes";
+import { runMcpMutation } from "./run-mcp-mutation";
 import {
   type TMcpCountFeedbackRecordsInput,
   type TMcpCreateFeedbackRecordInput,
@@ -86,31 +89,14 @@ function writeHandler<TInput extends { workspaceId: string }>(
       return scopeError;
     }
 
-    const authentication = getMcpAuthentication(extra.authInfo);
-    const log = logger.withContext({ requestId, workspaceId: input.workspaceId });
-    const auditLog = buildV3AuditLog(authentication, action, "feedbackRecord", MCP_API_ROUTE);
-
-    try {
-      const response = await run(input, authentication, requestId, auditLog);
-
-      if (auditLog) {
-        if (response.ok) {
-          auditLog.status = "success";
-        } else {
-          auditLog.eventId = requestId;
-        }
-      }
-
-      await queueV3AuditLog(auditLog, requestId, log);
-      return await responseToMcpToolResult(response, requestId);
-    } catch (error) {
-      if (auditLog) {
-        auditLog.eventId = requestId;
-        await queueV3AuditLog(auditLog, requestId, log);
-      }
-
-      throw error;
-    }
+    // The scope gate above is the only part that differs from the survey/workflow tools, which get
+    // theirs from registerScopedTool; the audit lifecycle itself is shared.
+    return await runMcpMutation(
+      extra,
+      { action, resource: "feedbackRecord", logContext: { workspaceId: input.workspaceId } },
+      ({ authentication, requestId: mutationRequestId, auditLog }) =>
+        run(input, authentication, mutationRequestId, auditLog)
+    );
   };
 }
 
@@ -261,13 +247,19 @@ export function registerFeedbackRecordTools(server: McpServer): void {
       // attribute a creation to the wrong record. `buildV3AuditLog` returns undefined for every record or
       // none (it only depends on whether auditing is enabled), so the holes are all-or-nothing.
       const auditLogs = input.records.map(() =>
-        buildV3AuditLog(authentication, "created", "feedbackRecord", MCP_API_ROUTE)
+        buildV3AuditLog(authentication, "created", "feedbackRecord", getMcpResourceUrl())
       );
 
       const queueOutcome = async () => {
-        const stamped = auditLogs.filter((auditLog) => auditLog?.targetId);
+        // `targetId` must be compared against the placeholder, not just tested for truthiness:
+        // buildAuditLogBaseObject seeds it with UNKNOWN_DATA ("unknown"), so a truthy check matches
+        // every entry — including records the Hub rejected — and would emit a success event
+        // asserting a creation that never happened, with targetId "unknown" and no newObject.
+        // Only createV3FeedbackRecords overwrites it, and only for records it actually created.
+        const stamped = auditLogs.filter(
+          (auditLog): auditLog is TV3AuditLog => !!auditLog && auditLog.targetId !== UNKNOWN_DATA
+        );
         for (const auditLog of stamped) {
-          if (!auditLog) continue;
           auditLog.status = "success";
           await queueV3AuditLog(auditLog, requestId, log);
         }

--- a/apps/web/modules/mcp/tools/guard-scopes.test.ts
+++ b/apps/web/modules/mcp/tools/guard-scopes.test.ts
@@ -76,7 +76,9 @@ describe("registerScopedTool", () => {
     expect((result.structuredContent as ScopeErrorContent).error).toMatchObject({
       status: 403,
       code: "forbidden",
-      detail: "OAuth token does not include the required MCP scope",
+      // The missing scope must be in the body: this result reaches the client as a JSON-RPC payload
+      // with no headers, so the WWW-Authenticate challenge cannot tell it what to re-authorize for.
+      detail: "OAuth token does not include the required MCP scope: surveys:write",
       requestId: "req_denied",
     });
   });
@@ -92,5 +94,9 @@ describe("registerScopedTool", () => {
 
     expect(handler).not.toHaveBeenCalled();
     expect(result.isError).toBe(true);
+    // Every required scope is listed, not just the first one that failed.
+    expect((result.structuredContent as ScopeErrorContent).error.detail).toContain(
+      "surveys:read surveys:write"
+    );
   });
 });

--- a/apps/web/modules/mcp/tools/run-mcp-mutation.ts
+++ b/apps/web/modules/mcp/tools/run-mcp-mutation.ts
@@ -2,7 +2,7 @@ import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "@formbricks/logger";
 import { buildV3AuditLog, queueV3AuditLog } from "@/app/api/v3/lib/audit";
-import { MCP_API_ROUTE } from "@/modules/mcp/constants";
+import { getMcpResourceUrl } from "@/modules/auth/lib/oauth-urls";
 import { getMcpAuthentication, getMcpRequestId } from "../auth";
 import { responseToMcpToolResult } from "../errors";
 
@@ -37,7 +37,12 @@ export async function runMcpMutation(
   const requestId = getMcpRequestId(extra.authInfo);
   const authentication = getMcpAuthentication(extra.authInfo);
   const log = logger.withContext({ requestId, ...logContext });
-  const auditLog = buildV3AuditLog(authentication, action, resource, MCP_API_ROUTE);
+  // getMcpResourceUrl(), NOT MCP_API_ROUTE: the audit schema validates apiUrl with z.url(), and
+  // logAuditEvent catches the failure and downgrades it to a logger.error — so a bare path silently
+  // drops the whole event, which is why no MCP mutation was ever audited (ENG-2173). This is the same
+  // absolute URL the OAuth protected-resource metadata advertises, so the two agree by construction
+  // and it stays correct on a sub-path deployment (WEBAPP_URL=https://host/formbricks).
+  const auditLog = buildV3AuditLog(authentication, action, resource, getMcpResourceUrl());
 
   try {
     const response = await run({ authentication, requestId, auditLog });

--- a/apps/web/modules/mcp/tools/surveys.test.ts
+++ b/apps/web/modules/mcp/tools/surveys.test.ts
@@ -498,7 +498,7 @@ describe("registerSurveyTools", () => {
     expect(result.structuredContent.error).toMatchObject({
       status: 403,
       code: "forbidden",
-      detail: "OAuth token does not include the required MCP scope",
+      detail: "OAuth token does not include the required MCP scope: surveys:write",
       requestId: "req_tool",
     });
   });
@@ -543,7 +543,7 @@ describe("registerSurveyTools", () => {
     expect(result.structuredContent.error).toMatchObject({
       status: 403,
       code: "forbidden",
-      detail: "OAuth token does not include the required MCP scope",
+      detail: "OAuth token does not include the required MCP scope: surveys:read",
       requestId: "req_tool",
     });
   });

--- a/apps/web/modules/mcp/tools/surveys.test.ts
+++ b/apps/web/modules/mcp/tools/surveys.test.ts
@@ -19,6 +19,12 @@ import {
 } from "@/app/api/v3/surveys/lib/operations";
 import { buildListSurveysSearchParams, registerSurveyTools } from "./surveys";
 
+// Asserted as a shape, not by calling getMcpResourceUrl() here: comparing production's value with
+// itself would still pass if it regressed to the bare path "/api/mcp" — the ENG-2173 bug. The
+// invariant that matters is that the audit apiUrl is absolute, because the audit schema validates it
+// with z.url() and drops the whole event otherwise.
+const ABSOLUTE_MCP_AUDIT_URL = expect.stringMatching(/^https?:\/\/[^/]+\/api\/mcp$/);
+
 vi.mock("@/app/api/v3/surveys/lib/operations", () => ({
   createV3SurveyResponseFromRawInput: vi.fn(),
   deleteV3Survey: vi.fn(),
@@ -347,7 +353,7 @@ describe("registerSurveyTools", () => {
 
     const result = await tools.get("create_survey")!.handler(createBody, { authInfo });
 
-    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "created", "survey", "/api/mcp");
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "created", "survey", ABSOLUTE_MCP_AUDIT_URL);
     expect(createV3SurveyResponseFromRawInput).toHaveBeenCalledWith({
       body: createBody,
       authentication: apiKeyAuth,
@@ -408,7 +414,7 @@ describe("registerSurveyTools", () => {
 
     const result = await tools.get("patch_survey")!.handler(patchInput, { authInfo });
 
-    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "survey", "/api/mcp");
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "survey", ABSOLUTE_MCP_AUDIT_URL);
     expect(patchV3SurveyResponse).toHaveBeenCalledWith({
       surveyId: "clxx1234567890123456789012",
       body: {
@@ -503,6 +509,9 @@ describe("registerSurveyTools", () => {
     });
   });
 
+  // Covers the MCP scope gate only — validateV3SurveyFromRawInput is mocked here, so this passed
+  // even while the real v3 operation demanded readWrite and 403'd every read-scoped caller
+  // (ENG-2179). The v3 gate itself is asserted in app/api/v3/surveys/lib/operations.test.ts.
   test("validate_survey allows patch validations for read-only OAuth scopes", async () => {
     const { tools } = createToolServer();
     vi.mocked(validateV3SurveyFromRawInput).mockResolvedValue(

--- a/apps/web/modules/mcp/tools/surveys.ts
+++ b/apps/web/modules/mcp/tools/surveys.ts
@@ -166,8 +166,8 @@ export function registerSurveyTools(server: McpServer): void {
     async (input: TMcpValidateSurveyInput, extra) => {
       const requestId = getMcpRequestId(extra.authInfo);
       // validate_survey never persists changes (readOnlyHint) — a dry-run validation of a create or
-      // patch payload only needs read access. The actual write permission is enforced by the v3 layer
-      // when create_survey / patch_survey run.
+      // patch payload only needs read access, and validateV3Survey gates at "read" to match. The
+      // actual write permission is enforced when create_survey / patch_survey run.
       const response = await validateV3SurveyFromRawInput({
         body: input,
         authentication: getMcpAuthentication(extra.authInfo),

--- a/apps/web/modules/mcp/tools/workflows.test.ts
+++ b/apps/web/modules/mcp/tools/workflows.test.ts
@@ -15,6 +15,12 @@ import {
   registerWorkflowTools,
 } from "./workflows";
 
+// Asserted as a shape, not by calling getMcpResourceUrl() here: comparing production's value with
+// itself would still pass if it regressed to the bare path "/api/mcp" — the ENG-2173 bug. The
+// invariant that matters is that the audit apiUrl is absolute, because the audit schema validates it
+// with z.url() and drops the whole event otherwise.
+const ABSOLUTE_MCP_AUDIT_URL = expect.stringMatching(/^https?:\/\/[^/]+\/api\/mcp$/);
+
 vi.mock("@/app/api/v3/workflows/lib/context", () => ({
   buildWorkflowApiContext: vi.fn(() => ({ __ctx: true })),
   workflowsHandlers: {
@@ -294,7 +300,7 @@ describe("registerWorkflowTools", () => {
 
     const result = await tools.get("create_workflow")!.handler(body, { authInfo });
 
-    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "created", "workflow", "/api/mcp");
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "created", "workflow", ABSOLUTE_MCP_AUDIT_URL);
     expect(buildWorkflowApiContext).toHaveBeenCalledWith(apiKeyAuth, "req_tool", "/api/mcp", auditLog);
     const callArg = vi.mocked(workflowsHandlers.create).mock.calls[0][0];
     expect(callArg.ctx).toEqual({ __ctx: true });
@@ -314,7 +320,7 @@ describe("registerWorkflowTools", () => {
 
     await tools.get("enable_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
 
-    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "workflow", "/api/mcp");
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "workflow", ABSOLUTE_MCP_AUDIT_URL);
     expect(workflowsHandlers.enable).toHaveBeenCalledWith({
       ctx: { __ctx: true },
       params: { workflowId: WORKFLOW_ID },
@@ -331,7 +337,7 @@ describe("registerWorkflowTools", () => {
 
     const result = await tools.get("delete_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
 
-    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "deleted", "workflow", "/api/mcp");
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "deleted", "workflow", ABSOLUTE_MCP_AUDIT_URL);
     expect(auditLog.status).toBe("success");
     expect(result.structuredContent).toEqual({ requestId: "req_tool" });
   });
@@ -396,7 +402,7 @@ describe("registerWorkflowTools", () => {
       .get("patch_workflow")!
       .handler({ workflowId: WORKFLOW_ID, data: { name: "Renamed" } }, { authInfo });
 
-    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "workflow", "/api/mcp");
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "workflow", ABSOLUTE_MCP_AUDIT_URL);
     const callArg = vi.mocked(workflowsHandlers.patch).mock.calls[0][0];
     expect(callArg.params).toEqual({ workflowId: WORKFLOW_ID });
     expect(JSON.parse(await callArg.req.text())).toEqual({ name: "Renamed" });
@@ -414,7 +420,7 @@ describe("registerWorkflowTools", () => {
 
     await tools.get("duplicate_workflow")!.handler({ workflowId: WORKFLOW_ID, name: "Copy" }, { authInfo });
 
-    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "created", "workflow", "/api/mcp");
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "created", "workflow", ABSOLUTE_MCP_AUDIT_URL);
     const callArg = vi.mocked(workflowsHandlers.duplicate).mock.calls[0][0];
     expect(callArg.params).toEqual({ workflowId: WORKFLOW_ID });
     expect(JSON.parse(await callArg.req.text())).toEqual({ name: "Copy" });
@@ -431,7 +437,7 @@ describe("registerWorkflowTools", () => {
 
     await tools.get("archive_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
 
-    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "workflow", "/api/mcp");
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "workflow", ABSOLUTE_MCP_AUDIT_URL);
     expect(workflowsHandlers.archive).toHaveBeenCalledWith({
       ctx: { __ctx: true },
       params: { workflowId: WORKFLOW_ID },
@@ -449,7 +455,7 @@ describe("registerWorkflowTools", () => {
 
     await tools.get("unarchive_workflow")!.handler({ workflowId: WORKFLOW_ID }, { authInfo });
 
-    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "workflow", "/api/mcp");
+    expect(buildV3AuditLog).toHaveBeenCalledWith(apiKeyAuth, "updated", "workflow", ABSOLUTE_MCP_AUDIT_URL);
     expect(workflowsHandlers.unarchive).toHaveBeenCalledWith({
       ctx: { __ctx: true },
       params: { workflowId: WORKFLOW_ID },

--- a/apps/web/modules/mcp/tools/workflows.test.ts
+++ b/apps/web/modules/mcp/tools/workflows.test.ts
@@ -465,11 +465,13 @@ describe("MCP scope enforcement (ENG-1967)", () => {
     vi.mocked(queueV3AuditLog).mockResolvedValue(undefined);
   });
 
-  const INSUFFICIENT_SCOPE = {
+  // The detail names the scope the denied call needed, so each case asserts its own — a regression that
+  // dropped or mislabelled the scope would slip past a generic prefix match.
+  const insufficientScope = (scope: string) => ({
     status: 403,
     code: "forbidden",
-    detail: "OAuth token does not include the required MCP scope",
-  };
+    detail: `OAuth token does not include the required MCP scope: ${scope}`,
+  });
 
   // Every mutating tool + a representative valid input for it.
   const writeTools: { name: string; handlerKey: keyof typeof workflowsHandlers; input: unknown }[] = [
@@ -498,7 +500,10 @@ describe("MCP scope enforcement (ENG-1967)", () => {
       expect(workflowsHandlers[handlerKey]).not.toHaveBeenCalled();
       expect(queueV3AuditLog).not.toHaveBeenCalled();
       expect(result.isError).toBe(true);
-      expect(result.structuredContent.error).toMatchObject({ ...INSUFFICIENT_SCOPE, requestId: "req_tool" });
+      expect(result.structuredContent.error).toMatchObject({
+        ...insufficientScope("workflows:write"),
+        requestId: "req_tool",
+      });
     }
   );
 
@@ -523,7 +528,10 @@ describe("MCP scope enforcement (ENG-1967)", () => {
 
     expect(workflowsHandlers.list).not.toHaveBeenCalled();
     expect(result.isError).toBe(true);
-    expect(result.structuredContent.error).toMatchObject({ ...INSUFFICIENT_SCOPE, requestId: "req_tool" });
+    expect(result.structuredContent.error).toMatchObject({
+      ...insufficientScope("workflows:read"),
+      requestId: "req_tool",
+    });
   });
 
   test("read tools succeed for a read-only token", async () => {

--- a/apps/web/modules/mcp/tools/workflows.ts
+++ b/apps/web/modules/mcp/tools/workflows.ts
@@ -242,7 +242,9 @@ export function registerWorkflowTools(server: McpServer): void {
         "No run is persisted and no side effects occur; the response reports { ok, problems }.",
       ].join(" "),
       annotations: {
-        // Dry-run: validates + mock-executes with all side effects suppressed, so no world mutation.
+        // Dry-run: validates the definition and resolves its trigger references. Nothing is
+        // executed and no run is created, so the handler gates at "read" to match the
+        // workflows:read scope declared below.
         readOnlyHint: true,
         destructiveHint: false,
         idempotentHint: true,

--- a/apps/web/modules/mcp/tools/workspaces.ts
+++ b/apps/web/modules/mcp/tools/workspaces.ts
@@ -9,7 +9,7 @@ import { type TMcpListWorkspacesInput, ZMcpListWorkspacesInput } from "./schemas
 export function registerWorkspaceTools(server: McpServer): void {
   // list_workspaces is the workspaceId-discovery prerequisite for the survey, workflow AND
   // feedback-record tools, so it gates on ANY resource read scope rather than a single one. auth.ts's
-  // baseline is now "at least one resource scope" (MCP_MINIMUM_SCOPES), so a workflows-only or
+  // baseline is now "at least one resource scope" (MCP_RESOURCE_SCOPES), so a workflows-only or
   // feedbackRecords-only token is a legitimate client and must still be able to discover its
   // workspaceId. The result is derived from the caller's own memberships/key grants, so admitting any
   // read scope exposes nothing extra.

--- a/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
+++ b/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
@@ -19,6 +19,7 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { TSurveyElement, TSurveyElementId, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey, TSurveyHiddenFields, TSurveyRecallItem } from "@formbricks/types/surveys/types";
+import { getTextContent } from "@formbricks/types/surveys/validation";
 import { getTextContentWithRecallTruncated } from "@/lib/utils/recall";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 import {
@@ -137,13 +138,15 @@ export const RecallItemSelect = ({
   }, [elementId, elements, recallItemIds, selectedLanguageCode]);
 
   const filteredRecallItems: TSurveyRecallItem[] = useMemo(() => {
+    const query = searchValue.trim().toLowerCase();
+    if (!query) return [...surveyElementRecallItems, ...hiddenFieldRecallItems, ...variableRecallItems];
+
+    // Match the label's text content, not the label itself: an element's label is its raw headline HTML
+    // (`<p class="fb-editor-paragraph">…`), so comparing against it made every query for question text
+    // miss. `includes` rather than `startsWith` so a query also matches mid-headline words, and so it
+    // still matches items whose displayed label is elided by the truncation below.
     return [...surveyElementRecallItems, ...hiddenFieldRecallItems, ...variableRecallItems].filter(
-      (recallItems) => {
-        if (searchValue.trim() === "") return true;
-        else {
-          return recallItems.label.toLowerCase().startsWith(searchValue.toLowerCase());
-        }
-      }
+      (recallItem) => getTextContent(recallItem.label).toLowerCase().includes(query)
     );
   }, [surveyElementRecallItems, hiddenFieldRecallItems, variableRecallItems, searchValue]);
 

--- a/docs/api-v3-reference/openapi.yml
+++ b/docs/api-v3-reference/openapi.yml
@@ -38,7 +38,7 @@ info:
     **Workflows Scope 1**
     Workflows are a follow-up extension of the existing v3 Survey API work. The Survey API establishes API-first survey authoring; Workflows build on that same v3 style to automate actions around survey responses through workspace-scoped JSON definitions. Scope 1 models the existing Follow-ups capability as workflows: one `response.completed` trigger with an optional `endingCardIds` filter, and `send_email` actions with Follow-up email field parity. The definition and run shapes mirror the shared Zod schemas in `packages/workflows` (ENG-1100), which are the implementation source of truth for this contract.
 
-    Workflows use `draft`, `enabled`, and `disabled` lifecycle states plus an `archived` soft-delete state. Status only changes through the lifecycle endpoints (`enable`, `disable`, `archive`, `unarchive`); it is not writable via `POST` or `PATCH`. Enabling validates that the definition is executable and snapshots an immutable workflow version; runs reference that snapshot via `workflowVersionId`. Dry-run tests create real run records with `isDryRun: true` that mock action execution and never send email. Runs execute asynchronously: `POST .../test` returns a `queued` run to poll via `GET /api/v3/workflows/runs/{runId}`.
+    Workflows use `draft`, `enabled`, and `disabled` lifecycle states plus an `archived` soft-delete state. Status only changes through the lifecycle endpoints (`enable`, `disable`, `archive`, `unarchive`); it is not writable via `POST` or `PATCH`. Enabling validates that the definition is executable and snapshots an immutable workflow version; runs reference that snapshot via `workflowVersionId`. `POST .../test` is a dry run: it validates the definition and resolves the trigger's references synchronously, creating no run and sending no email, and returns `{ workflowId, ok, problems }` directly. Real runs execute asynchronously and are polled via `GET /api/v3/workflows/runs/{runId}`.
 
     **Overview migration note**
     The v3-backed survey overview page intentionally removes actions that are not yet exposed by this contract: `Created by` filtering, `Duplicate`, `Copy...`, `Preview`, and `Copy link`.
@@ -1973,7 +1973,7 @@ paths:
 
         The response is always `200` with `{ data: { workflowId, ok, problems } }`. `data.ok` is `true` when the workflow would execute; otherwise `data.problems` lists every issue found — each with a machine-readable `code` and the offending `field` — so they can be fixed in a single pass.
 
-        Only `enabled` and `disabled` workflows can be tested. Testing a `draft` or `archived` workflow returns **422** with code `invalid_workflow_state`.
+        Drafts are testable — validating the setup before going live is the point of a dry run. Only an `archived` workflow is rejected, with **422** and code `invalid_workflow_state`.
       tags:
         - V3 Workflows
       parameters:

--- a/docs/api-v3-reference/src/openapi.yml
+++ b/docs/api-v3-reference/src/openapi.yml
@@ -129,9 +129,10 @@ info:
     endpoints (`enable`, `disable`, `archive`, `unarchive`); it is not writable
     via `POST` or `PATCH`. Enabling validates that the definition is executable
     and snapshots an immutable workflow version; runs reference that snapshot
-    via `workflowVersionId`. Dry-run tests create real run records with
-    `isDryRun: true` that mock action execution and never send email. Runs
-    execute asynchronously: `POST .../test` returns a `queued` run to poll via
+    via `workflowVersionId`. `POST .../test` is a dry run: it validates the
+    definition and resolves the trigger's references synchronously, creating no
+    run and sending no email, and returns `{ workflowId, ok, problems }`
+    directly. Real runs execute asynchronously and are polled via
     `GET /api/v3/workflows/runs/{runId}`.
 
 

--- a/docs/api-v3-reference/src/paths/api_v3_workflows_{workflowId}_test.yml
+++ b/docs/api-v3-reference/src/paths/api_v3_workflows_{workflowId}_test.yml
@@ -14,8 +14,8 @@ post:
     machine-readable `code` and the offending `field` — so they can be fixed in a single pass.
 
 
-    Only `enabled` and `disabled` workflows can be tested. Testing a `draft` or `archived` workflow
-    returns **422** with code `invalid_workflow_state`.
+    Drafts are testable — validating the setup before going live is the point of a dry run. Only an
+    `archived` workflow is rejected, with **422** and code `invalid_workflow_state`.
   tags:
     - V3 Workflows
   parameters:

--- a/docs/development/technical-handbook/mcp-server.mdx
+++ b/docs/development/technical-handbook/mcp-server.mdx
@@ -79,8 +79,8 @@ Supported scopes:
 
 | Scope | Use |
 | --- | --- |
-| `surveys:read` | `list_surveys`, `get_survey`, and read-only validation paths |
-| `surveys:write` | `create_survey`, `patch_survey`, `delete_survey`, and write validations |
+| `surveys:read` | `list_surveys`, `get_survey`, `validate_survey` |
+| `surveys:write` | `create_survey`, `patch_survey`, `delete_survey` |
 | `workflows:read` | `list_workflows`, `get_workflow`, `list_workflow_runs`, `get_workflow_run`, `test_workflow` |
 | `workflows:write` | `create_workflow`, `patch_workflow`, `duplicate_workflow`, `delete_workflow`, and the enable/disable/archive/unarchive mutations |
 | `feedbackRecords:read` | `list_feedback_datasets`, `list_feedback_records`, `count_feedback_records`, `get_feedback_record`, `search_feedback_records`, `find_similar_feedback_records` |
@@ -104,7 +104,7 @@ handlers is still gated, but the guarantee is by convention there rather than by
 converging them onto `registerScopedTool` is a known follow-up.
 
 **There is no single mandatory baseline scope.** Authentication requires *at least one* resource scope
-(`MCP_MINIMUM_SCOPES`), so a workflows-only or `feedbackRecords:read`-only grant is a legitimate MCP
+(`MCP_RESOURCE_SCOPES`), so a workflows-only or `feedbackRecords:read`-only grant is a legitimate MCP
 client. `list_workspaces` — the workspaceId-discovery prerequisite for every resource tool — therefore
 gates on any resource read scope rather than one specific one; its result is derived from the caller's
 own memberships and key grants, so admitting any read scope exposes nothing extra.
@@ -159,14 +159,14 @@ API key permissions are enforced through the same workspace access checks as the
 | `list_surveys` | `read` |
 | `get_survey` | `read` |
 | `create_survey` | `write` or `manage` |
-| `validate_survey` | `write` or `manage` when the validation request checks write access |
+| `validate_survey` | `read` — a dry run; it validates a create or patch payload without writing |
 | `patch_survey` | `write` or `manage` |
 | `delete_survey` | `write` or `manage` |
 | `list_workflows` | `read` |
 | `get_workflow` | `read` |
 | `list_workflow_runs` | `read` |
 | `get_workflow_run` | `read` |
-| `test_workflow` | `write` or `manage` — the tool mutates nothing, but the handler authorizes it like a write |
+| `test_workflow` | `read` — a dry run; it validates the definition and resolves its trigger references, creating no run |
 | `create_workflow` | `write` or `manage` |
 | `patch_workflow` | `write` or `manage` |
 | `duplicate_workflow` | `write` or `manage` |
@@ -250,6 +250,14 @@ curl -sS -X POST http://localhost:3000/api/auth/oauth2/register \
   it later requests (e.g. it registers surveys-only but requests `offline_access`) is rejected with
   `invalid_scope`. To smoke-test the real path, omit `scope` and let the client adopt the advertised
   set, or pass exactly what the metadata advertises.
+</Note>
+
+<Note>
+  For the same reason, the `scope` in the MCP endpoint's 401 `WWW-Authenticate` challenge is exactly
+  the metadata's `scopes_supported`, not a subset — a client that hits the 401 before fetching the
+  metadata uses the challenge string as its registration scope. The two are derived from one constant
+  (`MCP_CHALLENGE_SCOPE`) and a test asserts they stay equal; when they diverged, every new client
+  failed its first connect with `invalid_scope` and only succeeded on retry.
 </Note>
 
 The consent screen is served at `/account/authorize`. Users can revoke approved MCP clients from
@@ -636,7 +644,8 @@ Output uses the same survey resource shape as `GET /api/v3/surveys/{surveyId}` a
 ### validate_survey
 
 Validates a create or patch payload without writing survey changes. The tool is read-only and
-idempotent, but create validation still checks workspace write access when `workspaceId` is present.
+idempotent; workspace access is still checked when `workspaceId` is present, at `read` level —
+matching the `surveys:read` scope the tool declares.
 
 Create validation input:
 
@@ -798,9 +807,9 @@ Gets one workflow run with its ordered step logs. Read-only and idempotent.
 
 Dry-runs a workflow: validates its live definition would execute and resolves the trigger's survey +
 ending cards. No run is persisted and no side effects occur; the result reports `{ ok, problems }`.
-Annotated read-only (no world mutation). Only **enabled or disabled** workflows can be tested — a
-draft or archived workflow is rejected with `422 invalid_workflow_state`, so after `create_workflow`
-(which always creates a draft), enable the workflow before testing it.
+Annotated read-only (no world mutation). **Drafts are testable** — checking the setup before going
+live is the point of a dry run — so a workflow can be tested straight after `create_workflow`. Only
+**archived** workflows are rejected, with `422 invalid_workflow_state`, since they are soft-deleted.
 
 ```json
 { "workflowId": "clwf1234567890123456789012" }

--- a/packages/workflows/src/handlers/workflows.handlers.test.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.test.ts
@@ -668,6 +668,16 @@ describe("testWorkflow", () => {
     expect(body.data).toEqual({ workflowId, ok: true, problems: [] });
   });
 
+  test("authorizes at read — it is a dry run and the MCP tool is workflows:read scoped", async () => {
+    // ENG-2223: this authorized at "readWrite", so a read-scoped caller got a 403 from a tool that
+    // persists nothing. Raising it back means moving test_workflow's declared MCP scope with it.
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "enabled" }));
+
+    await handlers.testWorkflow({ ctx: makeCtx(), params: { workflowId } });
+
+    expect(authorizeAllow).toHaveBeenCalledWith(workspaceId, "read");
+  });
+
   test("tests a disabled workflow", async () => {
     service.getWorkflowById.mockResolvedValue(makeRow({ status: "disabled" }));
 
@@ -1272,5 +1282,46 @@ describe("getRun", () => {
     expect(authorizeAllow).toHaveBeenCalledWith("cm9zr4other00000000000000x", "read");
     const body = await readJson<{ code: string }>(res);
     expect(body.code).toBe("forbidden");
+  });
+});
+
+// Negative controls for the authorization level itself. This PR lowered two handlers from
+// "readWrite" to "read" after verifying they write nothing; without these, making the same move on a
+// handler that DOES write would pass the whole suite — the level was previously asserted in only
+// three places, all of them expecting "read".
+describe("write handlers authorize at readWrite", () => {
+  const jsonRequest = (method: string, body: unknown): Request =>
+    new Request("http://localhost/api/v3/workflows/x", {
+      method,
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    });
+
+  const params = { workflowId };
+
+  const writeHandlers: [string, () => Promise<Response>][] = [
+    [
+      "create",
+      () =>
+        handlers.create({ req: jsonRequest("POST", { workspaceId, name: "n", definition }), ctx: makeCtx() }),
+    ],
+    ["patch", () => handlers.patch({ req: jsonRequest("PATCH", { name: "n" }), ctx: makeCtx(), params })],
+    ["duplicate", () => handlers.duplicate({ req: jsonRequest("POST", {}), ctx: makeCtx(), params })],
+    ["delete", () => handlers.delete({ ctx: makeCtx(), params })],
+    ["archive", () => handlers.archive({ ctx: makeCtx(), params })],
+    ["unarchive", () => handlers.unarchive({ ctx: makeCtx(), params })],
+    ["enable", () => handlers.enable({ ctx: makeCtx(), params })],
+    ["disable", () => handlers.disable({ ctx: makeCtx(), params })],
+  ];
+
+  test.each(writeHandlers)("%s authorizes at readWrite", async (_name, invoke) => {
+    service.getWorkflowById.mockResolvedValue(makeRow({ status: "enabled" }));
+    service.createWorkflow.mockResolvedValue(makeRow());
+    service.updateWorkflow.mockResolvedValue(makeRow());
+    service.duplicateWorkflow.mockResolvedValue(makeRow());
+
+    await invoke();
+
+    expect(authorizeAllow).toHaveBeenCalledWith(workspaceId, "readWrite");
   });
 });

--- a/packages/workflows/src/handlers/workflows.handlers.ts
+++ b/packages/workflows/src/handlers/workflows.handlers.ts
@@ -505,7 +505,12 @@ export const createWorkflowsHandlers = (service: WorkflowsService): WorkflowsHan
    */
   async testWorkflow({ ctx, params }) {
     try {
-      const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "readWrite");
+      // "read", not "readWrite": as the doc comment above says, this validates the definition and
+      // resolves its trigger references — nothing is executed and no run is created, so there is no
+      // side effect to gate on. The MCP test_workflow tool is registered workflows:read and
+      // annotated readOnlyHint, so requiring write here 403'd every read-scoped caller on a tool
+      // that writes nothing (ENG-2223). Raising this back means moving that tool's scope with it.
+      const loaded = await loadAndAuthorize(service, ctx, params.workflowId, "read");
       if (loaded instanceof Response) return loaded;
       // Drafts are testable too — the whole point of a dry run is checking the setup BEFORE going
       // live. Only archived workflows are rejected: they are soft-deleted.


### PR DESCRIPTION
## What & why

**Combined backport to `release/5.3` of #8718 (ENG-2120, Javi) and #8743 (the 5.3 QA §9 fixes).** #8756 was squash-merged into this branch, so this single PR now carries both; the title and description have been updated to match what it actually delivers.

The two belong together: #8743's ENG-2175 fix makes the 401 challenge advertise `offline_access` so a fresh MCP client can connect on its first attempt, and #8718 makes that same challenge parseable by a strict client. Shipping either half alone leaves the "first connect works" journey broken. Landing #8718 first is also what let all 13 of #8743's commits cherry-pick with **zero conflicts**.

### From #8718 (ENG-2120)

**The 401 `WWW-Authenticate` challenge was malformed.** It emitted `Bearer resource_metadata="…" scope="…"` — space-separated — but auth-params are a comma-separated list (RFC 9110 §11.6.1 `#auth-param`, as used by RFC 6750 and RFC 9728). A strict parser reads the space-separated tail as one malformed param and never extracts `resource_metadata`, the pointer an MCP client follows to discover this server.

**A tool-scope denial didn't say which scope was missing.** `guardMcpScopes` hands its `Response` to `responseToMcpToolResult`, which serialises the JSON body into a JSON-RPC result and drops every header — so the challenge built for it is unreachable on the tool path. The required scopes now appear in the problem `detail`, which does survive that conversion.

Plus a dead-search fix in the survey editor: the recall dropdown filtered against `recallItem.label`, which for an element is its raw headline HTML, so typing any question text returned "No recall items found".

### From #8743 (the QA findings)

**Duplicate `singleUseId` returned 500 instead of 409 (ENG-2174).** `@prisma/adapter-pg` derives the P2002 column list by regex-scraping the Postgres error `DETAIL` and never unquotes it, so `singleUseId` arrives as `"singleUseId"` while `token_hash` arrives bare — and every caller compares with exact equality. Stripping one symmetric pair of quotes in the shared helper fixes four call sites with no call-site changes, including re-adding an existing tag to a response, which also 500'd and which nobody had noticed.

**Every new MCP client failed its first OAuth connect (ENG-2175).** The challenge advertised six scopes; the protected-resource metadata advertises those plus `offline_access`. A client that hits the 401 before fetching the metadata registers narrow, authorizes wide, and the provider rejects it with `invalid_scope`. Both lists now derive from one constant.

**No MCP mutation had ever been audited (ENG-2173).** Every MCP tool passed the bare path `/api/mcp` as the audit event's `apiUrl`; the schema validates that with `z.url()` and `logAuditEvent` catches the failure and downgrades it to a `logger.error` line, dropping the event before it reaches `logger.audit`. That includes `delete_feedback_record`, which the tooling documents as producing an audit entry containing the removed content.

**Read-scoped callers were refused by two dry runs (ENG-2179 + ENG-2223).** `validate_survey` and `test_workflow` are registered `:read` and annotated `readOnlyHint`, but the v3 layer authorized both at `readWrite`, so a read-scoped token got a 403 from tools that persist nothing.

## Linear ticket

Backport — links only, no status change (the main PRs #8718/#8743 resolve these):

- Ref ENG-2120
- Ref ENG-2174
- Ref ENG-2175
- Ref ENG-2173
- Ref ENG-2179
- Ref ENG-2223

## How this was tested

#8718 was cherry-picked with `-x` (clean, 7 files, authorship preserved), then #8743's 13 commits on top — **zero conflicts**. Of the 28 files from #8743, **26 are byte-identical to the merged `main` version**; the 4 that differ do so only because `release/5.3` already carries #8736 (backported as #8754) while the `main` branch predated it. I verified that delta is exactly #8736's recipient rewording and nothing else.

Run against this branch:

- `apps/web` full unit suite: **587 files / 7554 tests passed** ✅
- `apps/web` integration suite (real Postgres): **21 files / 77 tests passed** ✅
- `@formbricks/workflows`: **13 files / 242 tests passed** ✅
- `tsc --noEmit --project tsconfig.typecheck.json`: **0 errors** ✅
- `eslint` on every changed file: **clean** ✅

**Verified over HTTP** against a dev server running this branch, confirming both halves hold together on the 5.3 base:

```
www-authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource/api/mcp", scope="… offline_access"
comma separator (#8718):   YES
offline_access (ENG-2175): YES
challenge == metadata:     YES
```

I also ran the header through a strict RFC 9110 `#auth-param` parser (one that refuses space-separated params): scheme `Bearer`, both params extracted, `resource_metadata` recovered intact.

The equivalent checks on the `main` PR additionally covered a DCR round-trip (a client registering from the challenge string now receives every advertised scope), duplicate `singleUseId` returning **200 → 409** on both `/api/v1/` and `/api/v2/client/{ws}/responses`, and a read-only key getting **200** on `/api/v3/surveys/validate` while still getting **403** on `POST /api/v3/surveys` with nothing created.

**Not observed end-to-end**: the MCP browser OAuth connect (needs an interactive login and a genuinely de-registered client — a cached DCR registration hides the bug), the audit-log line (needs `AUDIT_LOG_ENABLED=1` plus a log tail), and `test_workflow` over HTTP — workflows are licence-gated, so a local instance answers `403 "Workflows are not enabled for this organization"` before authorization is reached. That one is covered by a direct unit assertion (`expect(authorizeAllow).toHaveBeenCalledWith(workspaceId, "read")` immediately after `testWorkflow`), with a table-driven control proving all eight write handlers stay at `readWrite`.

A security review found **no qualifying vulnerabilities**, and confirmed the invariant that matters most: the baseline MCP authentication gate still reads `MCP_RESOURCE_SCOPES`, and `MCP_CHALLENGE_SCOPE` (which includes `offline_access`) reaches exactly one production site — the response header — never `hasAnyMcpScope`. A token holding only `offline_access` is still refused, and there is now a test asserting it.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] **Challenge is comma-separated** — send an unauthenticated `POST /api/mcp`. Response is **401**; the `WWW-Authenticate` header must read `Bearer resource_metadata="<host>/…/api/mcp", scope="…"` — note the **comma** after the closing quote. A space there is the bug.
- [ ] **Challenge matches metadata** — `GET /.well-known/oauth-protected-resource/api/mcp` and the 401 above must list the same **seven** scopes, `offline_access` included.
- [ ] **MCP first connect** — revoke any existing client at `/account/settings/authorized-apps`, then connect a fresh MCP client (`claude mcp add --transport http <name> <host>/api/mcp`, then `/mcp` → authenticate). The **first** attempt must succeed. Previously it failed with `invalid_scope` and only worked on retry.
- [ ] **Denial names the scope** — with an MCP OAuth token holding read scopes only, call a write tool (e.g. `create_survey`). The JSON-RPC result's `error.detail` must end with the specific scope, e.g. `…required MCP scope: surveys:write`.
- [ ] **Duplicate single-use response** — submit the same single-use link twice. Second submit → **409** `{"code":"conflict",…}`. Previously **500**. Check both `/api/v1/client/{workspaceId}/responses` and `/api/v2/…`.
- [ ] **Duplicate tag** — add a tag to a response, then add the **same** tag again. Expect a silent no-op. Previously an error toast / 500.
- [ ] **Recall search works** — in the survey editor, open a recall dropdown (`@`) and type part of another question's headline. The match must appear; previously any typed text returned "No recall items found". Try a mid-headline word too.
- [ ] **MCP audit** — with `AUDIT_LOG_ENABLED=1`, run any MCP mutation and check the log for a `"level":"audit"` record with `"apiUrl":"<host>/api/mcp"`. Previously there was no audit record, only a `Failed to log audit event` line.
- [ ] **Read-scoped dry runs** — with a **read**-permission API key: `POST /api/v3/surveys/validate` → **200**, and `POST /api/v3/workflows/{id}/test` → **200**. Both were **403**.
- [ ] **Negative controls (must still be 403)** — same read-only key against `POST /api/v3/surveys` and `PATCH /api/v3/workflows/{id}`, and against a workspace it has no access to. If any returns 200, the authorization change went too far.

**Preconditions / test data**

- A workspace with single-use links enabled on a link survey, plus at least one response and one tag.
- A survey with at least two questions, for the recall dropdown.
- Two API keys on the same workspace: one **read**, one **manage**.
- An MCP OAuth client with a read-only grant (for the denial check) and one that can be fully de-registered (for the connect check — a cached registration masks the fix).
- `AUDIT_LOG_ENABLED=1` and access to the application log for the audit check.
- The workflow dry-run check needs an org with the **workflows entitlement**; without it the endpoint 403s for a different reason.

**Risks & regressions**

- The scope change is the highest-risk part: `offline_access` must reach the 401 challenge and **nothing else**. The baseline authentication gate stays on resource scopes, so a token holding only `offline_access` is still refused — worth re-checking if the auth code is touched again.
- The `WWW-Authenticate` format change affects any client parsing that header. Lenient parsers (splitting on whitespace) keep working; the fix exists for strict ones.
- The constraint fix affects every P2002 consumer, not just the response endpoints. Action-class duplicate names/keys should still report the right field.
- The dry-run authorization change also applies to the plain REST endpoints, so read-only API keys and read-only team members can now call them. Neither branch writes, and a `:read` caller could already obtain the same information from `get_survey` / `get_workflow`.
- Self-hosters with `AUDIT_LOG_ENABLED=1` will start receiving audit events for MCP mutations that were previously dropped. That is the fix, but it is a volume change worth expecting.
- A feedback-source mapping collision now reports `FEEDBACK_SOURCE_FORMBRICKS_MAPPING_DUPLICATE` instead of `FEEDBACK_SOURCE_NAME_DUPLICATE` — same 400, same error class, but a visible message change. The previous classification was wrong.

**Migrations / env / cutover**

- none

