### PR TITLE
fix(ci): don't mislabel PRs breaking-change; tolerate a hand-removed label

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,10 +30,11 @@ payloads, changed defaults, new/removed/renamed env vars or config, and DB migra
 action. If YES:
   1. Fill the table below — one row per change. This text feeds the GitHub release notes and the
      self-hoster migration guide, so write it for an external integrator, not for the team.
-  2. The `breaking-change` label is applied automatically from this section. Add it by hand if it
-     doesn't appear — a change written as prose rather than a table can be missed.
-If there are no breaking changes, leave "None" below; a short reason is fine ("None — docs only",
-"N/A"), and it will not be mistaken for a declaration. -->
+  2. The `breaking-change` label is applied automatically from this section — a table or prose both
+     count, so you should not need to touch it. Add it by hand if it doesn't appear.
+If there are no breaking changes, leave "None" below. A short scope reason is fine ("None — docs only",
+"N/A", "No breaking changes"); anything more specific than that reads as a declaration and applies the
+label, so spell out what changed only when it really is breaking. -->
 
 None
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,10 +28,12 @@ self-hosted setups? Count as breaking: API/SDK request or response shape (rename
 fields, or changed values like `EN` → `en-US`), removed/renamed endpoints or routes, changed webhook
 payloads, changed defaults, new/removed/renamed env vars or config, and DB migrations that need manual
 action. If YES:
-  1. Add the `breaking-change` label to this PR.
-  2. Fill the table below — one row per change. This text feeds the GitHub release notes and the
+  1. Fill the table below — one row per change. This text feeds the GitHub release notes and the
      self-hoster migration guide, so write it for an external integrator, not for the team.
-If there are no breaking changes, leave "None" below. -->
+  2. The `breaking-change` label is applied automatically from this section. Add it by hand if it
+     doesn't appear — a change written as prose rather than a table can be missed.
+If there are no breaking changes, leave "None" below; a short reason is fine ("None — docs only",
+"N/A"), and it will not be mistaken for a declaration. -->
 
 None
 

--- a/.github/workflows/pr-label-sync.yml
+++ b/.github/workflows/pr-label-sync.yml
@@ -47,21 +47,35 @@ jobs:
             // the exact word labelled those PRs as breaking, and this label feeds the GitHub release
             // notes and the self-hoster migration guide, so a false positive is expensive.
             //
-            // Anything after a negative opener is ignored only when it reads as an aside — introduced
-            // by a dash, colon, comma, period or bracket. Prose that merely *starts* with a negative
-            // word stays declared, so "No breaking changes to the API, but the `--legacy` flag is
-            // removed" and "None of the endpoints are removed, but the response shape changed" are
-            // still labelled. Being wrong in that direction is the safe one: the label is also set by
-            // hand per the template, and this job removes a label it considers inactive.
-            const NOTHING_DECLARED =
-              /^(?:none|n\/?a|not applicable|no breaking changes?)(?:\s*[—–:,.(\[-][\s\S]*)?$/i;
+            // A negative opener alone is not enough to clear the section, because "No breaking changes,
+            // but the response shape changed" declares a real one. So an aside after the opener counts
+            // as "nothing here" only when *every* word in it is a scope word — docs, tests, internal,
+            // only… One unrecognised word (endpoint, renamed, shape) makes the section declared.
+            //
+            // That asymmetry is deliberate. A missed breaking change silently omits a migration-guide
+            // entry that self-hosters need; a spurious label is caught by whoever reads the release
+            // notes. So anything the vocabulary does not recognise errs towards labelling, and an
+            // unusual way of writing "nothing here" costs one label removal by hand.
+            const NEGATIVE_OPENER = /^(?:none|n\/?a|not applicable|no breaking changes?)\b/i;
+            const SCOPE_WORD =
+              /^(?:a|and|is|the|this|pr|no|not|nothing|none|n\/?a|applicable|only|just|pure|purely|docs?|documentation|readme|comments?|tests?|ci|chore|refactor(?:ing)?|typos?|styling?|formatting|internal|product|code|changes?)$/i;
 
             const isDeclared = (content) => {
               const normalized = content
                 .replace(/^\s*[-*+]\s+/, "") // a leading list marker ("- none")
                 .replace(/[*_`]/g, "") // markdown emphasis / code ticks ("**None**")
                 .trim();
-              return normalized !== "" && !NOTHING_DECLARED.test(normalized);
+              if (normalized === "") return false;
+              const opener = NEGATIVE_OPENER.exec(normalized);
+              if (!opener) return true;
+              // Split on whitespace and the punctuation that introduces an aside, but not on "/", so
+              // an "N/A" inside the aside survives as one token.
+              const aside = normalized
+                .slice(opener[0].length)
+                .split(/[\s—–:,.;()\[\]-]+/)
+                .filter(Boolean);
+              if (aside.length === 0) return false; // "None", "None.", "N/A"
+              return !(aside.length <= 6 && aside.every((word) => SCOPE_WORD.test(word)));
             };
 
             // Label rules. Add an entry to sync a new label from a new "## <heading>" PR-body section.

--- a/.github/workflows/pr-label-sync.yml
+++ b/.github/workflows/pr-label-sync.yml
@@ -40,9 +40,29 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // A section is "declared" when it holds real content — a filled table or prose —
-            // i.e. it is neither empty nor a bare "None". Reusable default rule predicate.
-            const isDeclared = (content) => !(content === "" || /^none\.?$/i.test(content));
+            // A section is "declared" when it holds real content — a filled table or prose.
+            //
+            // The template asks for a bare "None" when there is nothing to declare, but authors
+            // routinely add a clause: "None — docs only", "N/A", "No breaking changes". Accepting only
+            // the exact word labelled those PRs as breaking, and this label feeds the GitHub release
+            // notes and the self-hoster migration guide, so a false positive is expensive.
+            //
+            // Anything after a negative opener is ignored only when it reads as an aside — introduced
+            // by a dash, colon, comma, period or bracket. Prose that merely *starts* with a negative
+            // word stays declared, so "No breaking changes to the API, but the `--legacy` flag is
+            // removed" and "None of the endpoints are removed, but the response shape changed" are
+            // still labelled. Being wrong in that direction is the safe one: the label is also set by
+            // hand per the template, and this job removes a label it considers inactive.
+            const NOTHING_DECLARED =
+              /^(?:none|n\/?a|not applicable|no breaking changes?)(?:\s*[—–:,.(\[-][\s\S]*)?$/i;
+
+            const isDeclared = (content) => {
+              const normalized = content
+                .replace(/^\s*[-*+]\s+/, "") // a leading list marker ("- none")
+                .replace(/[*_`]/g, "") // markdown emphasis / code ticks ("**None**")
+                .trim();
+              return normalized !== "" && !NOTHING_DECLARED.test(normalized);
+            };
 
             // Label rules. Add an entry to sync a new label from a new "## <heading>" PR-body section.
             // `isActive(content)` decides whether the label should be present for the given section text.

--- a/.github/workflows/pr-label-sync.yml
+++ b/.github/workflows/pr-label-sync.yml
@@ -103,13 +103,22 @@ jobs:
                 });
                 core.info(`[${rule.label}] added.`);
               } else if (!active && has) {
-                await github.rest.issues.removeLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: pr.number,
-                  name: rule.label,
-                });
-                core.info(`[${rule.label}] removed.`);
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    name: rule.label,
+                  });
+                  core.info(`[${rule.label}] removed.`);
+                } catch (error) {
+                  // A 404 means the label is already gone. `pr.labels` is a snapshot taken when the event
+                  // fired, so a label removed by hand races with the `edited` event that still observes it
+                  // — #8762 went red exactly that way, the two events two seconds apart. The desired end
+                  // state is already in place, so treat it as success; anything else is a real failure.
+                  if (error.status !== 404) throw error;
+                  core.info(`[${rule.label}] already removed by hand; nothing to do.`);
+                }
               } else {
                 core.info(`[${rule.label}] already in the correct state.`);
               }


### PR DESCRIPTION
## What & why

Two independent bugs in `pr-label-sync.yml`, both surfaced by the same PR (#8762).

**1. The "nothing here" check was wrong in both directions.** The workflow decided the **Breaking changes** section was "declared" unless its content matched `/^none\.?$/i` — so the bare word `None` was the only accepted way to say *nothing here*. Any clause after it flipped the PR to `breaking-change`:

| Section content | Before | After |
| --- | --- | --- |
| `None` | not labelled | not labelled |
| `None — documentation only.` | **labelled** ❌ | not labelled |
| `N/A` | **labelled** ❌ | not labelled |
| `No breaking changes` | **labelled** ❌ | not labelled |
| `None (internal only)` | **labelled** ❌ | not labelled |

That's how #8762 — a docs-only change to `AGENTS.md` — ended up tagged `breaking-change`. It isn't cosmetic: per the workflow's own comment the Release QA audit filters on this label to compile the **GitHub release notes and the self-hoster migration guide**, so a false positive puts a non-existent breaking change in customer-facing output, and dilutes the label until people stop trusting it.

The obvious fix — accept a negative opener plus a trailing aside — overshoots, because the aside can itself be the declaration. Thanks to @coderabbitai for catching that the first pass did exactly that: with the aside matching `[\s\S]*`, these all resolved to *not declared*, and since this job **removes** a label it considers inactive, it would have stripped a `breaking-change` label a human had set correctly:

| Section content | First pass | Now |
| --- | --- | --- |
| `No breaking changes, but the response shape changed` | **missed** ❌ | labelled |
| `None: the endpoint was removed` | **missed** ❌ | labelled |
| `N/A, but we renamed the webhook payload field` | **missed** ❌ | labelled |
| `None. Actually the /v1/foo route is gone` | **missed** ❌ | labelled |

So an aside clears the section only when **every word in it is a scope word** — `docs`, `tests`, `internal`, `only`, `chore`, `refactor`… One unrecognised word (`endpoint`, `renamed`, `shape`) makes the section declared. `None — docs only` and `N/A — tests only` still pass; `None — the contactId field is gone` does not.

The asymmetry is deliberate, and it's the opposite of what the first pass assumed. A missed breaking change silently omits a migration-guide entry that self-hosters need; a spurious label is caught by whoever reads the release notes. So anything the vocabulary doesn't recognise errs towards labelling, and an unusual way of writing "nothing here" costs one label removal by hand.

**The template moves with it.** The guidance said to leave `None` *and nothing else*, which is what led authors to write `None — docs only` in the first place, so it now says a short scope reason is fine — and that anything more specific reads as a declaration. It also drops a claim that was never true (that prose rather than a table "can be missed" — prose is labelled), and reorders the YES steps: filling the table is the action, and the label follows from the section automatically. Shipping both halves together is deliberate: separately, whichever landed first would document behaviour the other half didn't have yet.

**2. Removing a label that's already gone failed the job.** Fixing the label on #8762 meant removing it by hand and rewriting the section in the same breath — and that turned the check red. `pr.labels` is a snapshot taken when the event fired, so the `edited` event two seconds after the manual unlabel still reported the label present: the job took the removal branch, `DELETE /issues/8762/labels/breaking-change` returned `404 Label does not exist`, and the unhandled rejection failed the run — with the end state already exactly what it wanted. Re-running doesn't clear it either, since a re-run replays the same payload.

Removal is now idempotent: a 404 is logged and treated as success, any other status still fails. Only the removal branch needs it — the worst a stale payload does on the add side is re-add a label that's already present, which the API accepts.

Beyond `isDeclared` and that catch, no change to the rules engine, the trigger, permissions, or the `RULES` table.

## Linear ticket

No ticket — CI papercuts found while opening #8762, fixed in passing.

## How this was tested

Everything below extracts the code **from the parsed workflow YAML** (`js-yaml` → the `github-script` step's `script` block) rather than testing a copy, so what ran is what Actions will run, block scalar and all.

- **Predicate: 40 phrasings, 40 passed, 0 failed.** Covers every negative form the template invites, the scope-word asides (`docs only`, `tests only`, `no product code changes`, `N/A`), and — the point of the second pass — the seven phrasings that open negatively but declare a real change, including both of @coderabbitai's examples and the `None. Actually the /v1/foo route is gone` case the Risks section previously accepted as a known miss. Also pins two near-misses that must not match the openers at all: `name changes to the API` and `Nonetheless the payload changed`.
- **Whole script: 30 cases, 30 passed, 0 failed.** The parsed `script` block runs inside an async wrapper against stubbed `github` / `context` / `core`. It reproduces #8762's exact shape (payload still carrying the label, body reading a bare `None`, `removeLabel` throwing `404`) and asserts the job survives it and logs why; asserts `403`, `422` and `500` on the same call still fail it; and pins the paths that must not move — add, happy-path removal, already-in-the-correct-state, no section present, and an untouched template.
- YAML parses cleanly. The template's HTML comment markers are still balanced (13 opens / 13 closes — an unbalanced one would leak the guidance into every PR body), and an untouched template still resolves to exactly `"None"` under the workflow's own section parser, so a default PR gets no label.
- Not exercised end to end on this PR **by design**: `pull_request_target` always runs the workflow definition from the base branch, so this takes effect once merged and cannot self-run on its own PR (the workflow's header comment already notes this). Reviewers can confirm on the first PR merged after this one — or by editing the body of any open PR and watching the `sync-labels` run.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] After merge, open a PR whose **Breaking changes** section reads `None — <a short scope reason>` → the `breaking-change` label is **not** applied.
- [ ] Same with `N/A`, `No breaking changes`, `None (internal only)`, `- none`, `**None**`, `None — tests only` → **not** applied.
- [ ] Open a PR whose section holds a filled table (one row per change) → label **is** applied.
- [ ] Must still label, opener notwithstanding: `No breaking changes, but the response shape changed` → label **is** applied.
- [ ] Same for `None: the endpoint was removed` and `No breaking changes to the public API, but the --legacy CLI flag is removed` → **is** applied.
- [ ] Open a PR **without editing the template's Breaking changes section** → the default `None` yields no label, and the rendered body shows no leaked guidance text.
- [ ] Regression: a PR whose body has **no** `## Breaking changes` heading at all → the job logs "no section found" and leaves labels untouched, adding and removing nothing.
- [ ] Removal still works: on a labelled PR, edit the section down to `None` → the label is removed on the `edited` event.
- [ ] The race that failed #8762: on a labelled PR, remove the label **by hand** and edit the body immediately after → the run logs `already removed by hand; nothing to do.` and stays **green**. Before this it failed with `Label does not exist`.

**Preconditions / test data**

- None. Any PR against `main` after this merges; the job runs on `opened`, `edited` and `reopened`.

**Risks & regressions**

- An unusual way of writing "nothing to declare" — one using a word outside the scope vocabulary, e.g. `None — this is a spike` — now gets labelled. Deliberate: that's the cheap direction (remove the label by hand, or reword the section), whereas the reverse silently drops a migration-guide entry. The vocabulary is one regex and easy to extend when a phrasing shows up.
- Swallowing the 404 gives up one signal: a `RULES` entry naming a label that doesn't exist in the repo would no longer fail loudly on removal. Narrow in practice — a revoked `pull-requests: write` returns `403` and still fails, and a mistyped label name shows up as the label never being applied at all.
- Behaviour is unchanged for the bare `None`, for a filled table, for a body with no such section, and for a removal that succeeds.

**Migrations / env / cutover**

- none
