### PR TITLE
refactor(authorization): migrate the remaining scattered checks to the central interface (ENG-1737)

### DIFF
--- a/apps/web/app/(app)/(onboarding)/lib/onboarding-workspace.test.ts
+++ b/apps/web/app/(app)/(onboarding)/lib/onboarding-workspace.test.ts
@@ -1,18 +1,13 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthorizationError, ResourceNotFoundError } from "@formbricks/types/errors";
-import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
-import { getAccessFlags } from "@/lib/membership/utils";
+import { can } from "@/lib/authorization";
 import { getOrganization, updateOrganization } from "@/lib/organization/service";
 import { getUserWorkspaces, getWorkspaces } from "@/lib/workspace/service";
 import { getIsAISmartToolsEnabled } from "@/modules/ee/license-check/lib/utils";
 import { getOnboardingWorkspaceContext, selectOldestWorkspace } from "./onboarding-workspace";
 
-vi.mock("@/lib/membership/service", () => ({
-  getMembershipByUserIdOrganizationId: vi.fn(),
-}));
-
-vi.mock("@/lib/membership/utils", () => ({
-  getAccessFlags: vi.fn(),
+vi.mock("@/lib/authorization", () => ({
+  can: vi.fn(),
 }));
 
 vi.mock("@/lib/organization/service", () => ({
@@ -80,18 +75,7 @@ const olderWorkspace = {
 describe("onboarding-workspace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue({
-      organizationId: "org1",
-      userId: "user1",
-      accepted: true,
-      role: "owner",
-    });
-    vi.mocked(getAccessFlags).mockReturnValue({
-      isOwner: true,
-      isManager: false,
-      isBilling: false,
-      isMember: false,
-    });
+    vi.mocked(can).mockResolvedValue(true);
     vi.mocked(getOrganization).mockResolvedValue(mockOrganization);
     vi.mocked(getIsAISmartToolsEnabled).mockResolvedValue(true);
     vi.mocked(updateOrganization).mockResolvedValue({
@@ -172,16 +156,16 @@ describe("onboarding-workspace", () => {
     expect(updateOrganization).not.toHaveBeenCalled();
   });
 
-  test("throws when user is not owner or manager", async () => {
-    vi.mocked(getAccessFlags).mockReturnValueOnce({
-      isOwner: false,
-      isManager: false,
-      isBilling: false,
-      isMember: false,
-    });
+  test("throws when the user cannot manage the organization", async () => {
+    vi.mocked(can).mockResolvedValue(false);
 
     await expect(getOnboardingWorkspaceContext({ userId: "user1", organizationId: "org1" })).rejects.toThrow(
       AuthorizationError
     );
+
+    expect(can).toHaveBeenCalledWith({ type: "user", id: "user1" }, "organization.manage", {
+      type: "organization",
+      id: "org1",
+    });
   });
 });

--- a/apps/web/app/(app)/(onboarding)/lib/onboarding-workspace.ts
+++ b/apps/web/app/(app)/(onboarding)/lib/onboarding-workspace.ts
@@ -2,8 +2,7 @@ import "server-only";
 import { AuthorizationError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TOrganization } from "@formbricks/types/organizations";
 import { TWorkspace } from "@formbricks/types/workspace";
-import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
-import { getAccessFlags } from "@/lib/membership/utils";
+import { can } from "@/lib/authorization";
 import { getOrganization, updateOrganization } from "@/lib/organization/service";
 import { getUserWorkspaces, getWorkspaces } from "@/lib/workspace/service";
 import { getIsAISmartToolsEnabled } from "@/modules/ee/license-check/lib/utils";
@@ -17,10 +16,14 @@ export const selectOldestWorkspace = (workspaces: TWorkspace[]): TWorkspace | un
 };
 
 const assertCanManageOnboardingWorkspace = async (userId: string, organizationId: string): Promise<void> => {
-  const membership = await getMembershipByUserIdOrganizationId(userId, organizationId);
-  const { isOwner, isManager } = getAccessFlags(membership?.role);
+  // Owner-or-manager, expressed as the capability rather than the role pair: `organization.manage`
+  // is defined as exactly owner + manager. The message is kept, so the caller sees no change.
+  const canManage = await can({ type: "user", id: userId }, "organization.manage", {
+    type: "organization",
+    id: organizationId,
+  });
 
-  if (!isOwner && !isManager) {
+  if (!canManage) {
     throw new AuthorizationError("User is not authorized to create a workspace in this organization");
   }
 };

--- a/apps/web/app/(redirects)/environments/[environmentId]/[...path]/route.ts
+++ b/apps/web/app/(redirects)/environments/[environmentId]/[...path]/route.ts
@@ -1,7 +1,7 @@
 import { notFound, redirect } from "next/navigation";
 import { AuthenticationError, AuthorizationError } from "@formbricks/types/errors";
 import { findWorkspaceByIdOrLegacyEnvId } from "@/lib/utils/resolve-client-id";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { canUserNavigateWorkspace } from "@/lib/workspace/auth";
 import { getSession } from "@/modules/auth/lib/session";
 
 export const GET = async (
@@ -19,7 +19,7 @@ export const GET = async (
   const workspace = await findWorkspaceByIdOrLegacyEnvId(environmentId);
   if (!workspace) return notFound();
 
-  const hasAccess = await hasUserWorkspaceAccess(session.user.id, workspace.id);
+  const hasAccess = await canUserNavigateWorkspace(session.user.id, workspace);
   if (!hasAccess) throw new AuthorizationError("Unauthorized");
 
   return redirect(`/workspaces/${workspace.id}/${path.join("/")}`);

--- a/apps/web/app/(redirects)/environments/[environmentId]/route.ts
+++ b/apps/web/app/(redirects)/environments/[environmentId]/route.ts
@@ -1,7 +1,7 @@
 import { notFound, redirect } from "next/navigation";
 import { AuthenticationError, AuthorizationError } from "@formbricks/types/errors";
 import { findWorkspaceByIdOrLegacyEnvId } from "@/lib/utils/resolve-client-id";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { canUserNavigateWorkspace } from "@/lib/workspace/auth";
 import { getSession } from "@/modules/auth/lib/session";
 
 export const GET = async (_: Request, context: { params: Promise<{ environmentId: string }> }) => {
@@ -16,7 +16,7 @@ export const GET = async (_: Request, context: { params: Promise<{ environmentId
   const workspace = await findWorkspaceByIdOrLegacyEnvId(environmentId);
   if (!workspace) return notFound();
 
-  const hasAccess = await hasUserWorkspaceAccess(session.user.id, workspace.id);
+  const hasAccess = await canUserNavigateWorkspace(session.user.id, workspace);
   if (!hasAccess) throw new AuthorizationError("Unauthorized");
 
   return redirect(`/workspaces/${workspace.id}/`);

--- a/apps/web/lib/authorization/README.md
+++ b/apps/web/lib/authorization/README.md
@@ -119,21 +119,50 @@ migration; resource-level relationships belong to the later sharing phase.
 - Organization settings, workspace settings, team operations, and
   user-managed API-key settings migrated to explicit actions.
 
-### Assigned to ENG-1731
+### Migrated by ENG-1731
 
 - API-key principals in V1, V2, V3, MCP, and storage authorization paths.
 - `ApiKeyWorkspace` permissions and organization access-control flags.
 - Organization-only API-key opt-in and API-key revocation behavior.
 
-### Assigned to ENG-1737
+### Migrated by ENG-1737
 
-- The broad, non-action-aware `hasUserWorkspaceAccess` navigation helper.
-- Layout and UI-derived access flags.
-- Unrecognized action-client compatibility shapes and remaining
-  feature-specific role checks.
+- The broad, non-action-aware `hasUserWorkspaceAccess` helper is gone.
+  `getWorkspaceAuth` asks for `workspace.read`; the four navigation callers ask
+  `canUserNavigateWorkspace`, which is `workspace.read` or
+  `organization.manage_billing` — the second disjunct exists only because
+  reaching a workspace URL is how the `billing` role gets to billing.
+- The action-client adapter's parallel legacy evaluator is gone. Every access
+  shape the repository produces maps onto exactly one central action, so the
+  fallback could only repeat a decision already made. Its `team` shape was
+  removed with it, an unmapped organization role set is now refused and logged
+  as a caller bug, and an empty requirement list is refused rather than passing.
+- The two remaining role-name gates outside the module: workspace creation
+  during onboarding, and the self-hosted license recheck. The latter denied the
+  `member` role by name, which admitted `billing`; `organization.manage` is what
+  its own message always claimed.
+
+#### Retained by design
+
+These read a role but do not decide access, so they stay as they are:
+
+- **Rendering.** Navigation, sidebars, settings forms, and role pickers take
+  `getAccessFlags` output as props. Hiding a control is not a gate; the gate is
+  on the action or page behind it.
+- **Context output.** `getWorkspaceAuth` and `getOrganizationAuth` _return_ the
+  flags for those consumers. Their own gates are `can` calls.
+- **Invariants and finer rules.** An owner may not leave their organization; a
+  manager may only assign the `member` role; `billing` is Cloud-only. The
+  schema comments already name these as application rules — they constrain a
+  request's _content_, not the principal's capability.
+- **Invite fan-out.** The signup and invite paths derive from the _invited_
+  role whether to create `TeamUser` rows, since owners and managers get
+  workspace access from the role itself. That is a statement about the invite.
+- **List scoping.** Workspace list queries narrow by role instead of asking a
+  question per row. Replacing those with a permission-aware lookup is ENG-1713.
 
 New authorization-sensitive code must use `can` or `assertCan`; it must not add
-callers to the compatibility fallback or broad workspace helper.
+callers to the deprecated action-client adapter or reintroduce a role-name gate.
 
 ## Explicit exclusions
 

--- a/apps/web/lib/authorization/manage-access.integration.test.ts
+++ b/apps/web/lib/authorization/manage-access.integration.test.ts
@@ -1,0 +1,128 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import type { TOrganizationRole } from "@formbricks/types/memberships";
+import { resetDb } from "@/integration/reset-db";
+import { can } from "@/lib/authorization";
+import { USER_MANAGEMENT_MINIMUM_ROLE } from "@/lib/constants";
+import { getUserManagementAccess } from "@/lib/membership/utils";
+
+/**
+ * ENG-1737 (review follow-up): the two capabilities that reviewer feedback moved onto the central
+ * interface, decided against real rows.
+ *
+ * Both replacements are equivalence claims, so they get the same treatment as the rest of this
+ * change rather than a mocked assertion of what the code now does:
+ *
+ *   - `organization.manage_access` must answer exactly what the inline
+ *     `getUserManagementAccess(role, USER_MANAGEMENT_MINIMUM_ROLE)` answered in the membership-update
+ *     action. That helper is the comparison below, so the test tracks the deployment's configured
+ *     floor instead of hardcoding one — an install set to `owner` or `disabled` asserts against its
+ *     own policy. (Varying the constant per case would need module-level env mocking, which the unit
+ *     suite is the right place for; here the point is that the two agree under whatever is set.)
+ *
+ *   - `team.manage` must answer exactly "is a team admin, or an organization owner/manager", which is
+ *     what `getTeamsWhereUserIsAdmin` plus the owner/manager branch established in the invite action.
+ */
+const scenario: {
+  organizationId: string;
+  otherTeamId: string;
+  teamId: string;
+  userIdByLabel: Map<string, string>;
+} = { organizationId: "", otherTeamId: "", teamId: "", userIdByLabel: new Map() };
+
+const ORGANIZATION_ROLES: ReadonlyArray<TOrganizationRole> = ["owner", "manager", "member", "billing"];
+
+beforeAll(async () => {
+  await resetDb();
+
+  const organization = await prisma.organization.create({ data: { name: "Manage Access Org" } });
+  const team = await prisma.team.create({ data: { name: "Team A", organizationId: organization.id } });
+  const otherTeam = await prisma.team.create({ data: { name: "Team B", organizationId: organization.id } });
+
+  const makeUser = async (
+    label: string,
+    role: TOrganizationRole | null,
+    teamMembership?: { role: "admin" | "contributor"; teamId: string }
+  ) => {
+    const user = await prisma.user.create({ data: { name: label, email: `${label}@manage.test` } });
+    if (role) {
+      await prisma.membership.create({
+        data: { userId: user.id, organizationId: organization.id, role, accepted: true },
+      });
+    }
+    if (teamMembership) {
+      await prisma.teamUser.create({
+        data: { teamId: teamMembership.teamId, userId: user.id, role: teamMembership.role },
+      });
+    }
+    scenario.userIdByLabel.set(label, user.id);
+  };
+
+  for (const role of ORGANIZATION_ROLES) {
+    await makeUser(role, role);
+  }
+  await makeUser("team-admin", "member", { role: "admin", teamId: team.id });
+  await makeUser("team-contributor", "member", { role: "contributor", teamId: team.id });
+  await makeUser("outsider", null);
+
+  scenario.organizationId = organization.id;
+  scenario.teamId = team.id;
+  scenario.otherTeamId = otherTeam.id;
+}, 120_000);
+
+describe("organization.manage_access against a real database", () => {
+  test.each(ORGANIZATION_ROLES)(
+    "matches getUserManagementAccess for the %s role under the configured floor",
+    async (role) => {
+      const expected = getUserManagementAccess(role, USER_MANAGEMENT_MINIMUM_ROLE);
+
+      const actual = await can(
+        { type: "user", id: scenario.userIdByLabel.get(role)! },
+        "organization.manage_access",
+        { type: "organization", id: scenario.organizationId }
+      );
+
+      expect(actual).toBe(expected);
+    }
+  );
+
+  test("refuses a user outside the organization regardless of the floor", async () => {
+    const actual = await can(
+      { type: "user", id: scenario.userIdByLabel.get("outsider")! },
+      "organization.manage_access",
+      { type: "organization", id: scenario.organizationId }
+    );
+
+    expect(actual).toBe(false);
+  });
+});
+
+describe("team.manage against a real database", () => {
+  test.each([
+    ["owner", true],
+    ["manager", true],
+    ["team-admin", true],
+    ["team-contributor", false],
+    ["member", false],
+    ["billing", false],
+    ["outsider", false],
+  ] as const)("decides %s as %s for a team they may be admin of", async (label, expected) => {
+    const actual = await can({ type: "user", id: scenario.userIdByLabel.get(label)! }, "team.manage", {
+      type: "team",
+      id: scenario.teamId,
+    });
+
+    expect(actual).toBe(expected);
+  });
+
+  // The reason the invite path asks per requested team rather than once: admin of one team is not
+  // admin of another, and the invite writes to exactly the teams it names.
+  test("does not carry a team admin's authority to a sibling team", async () => {
+    const actual = await can({ type: "user", id: scenario.userIdByLabel.get("team-admin")! }, "team.manage", {
+      type: "team",
+      id: scenario.otherTeamId,
+    });
+
+    expect(actual).toBe(false);
+  });
+});

--- a/apps/web/lib/utils/action-client/action-client-authorization.integration.test.ts
+++ b/apps/web/lib/utils/action-client/action-client-authorization.integration.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, test } from "vitest";
 import { prisma } from "@formbricks/database";
+import { AuthorizationError } from "@formbricks/types/errors";
 import type { TOrganizationRole } from "@formbricks/types/memberships";
 import { resetDb } from "@/integration/reset-db";
 import { type TAccess, checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
@@ -59,6 +60,12 @@ const replayDeletedLegacyPath = async (
   return false;
 };
 
+/**
+ * Only an `AuthorizationError` is a decision. Anything else — a Prisma failure, a bug in the central
+ * path — must reach the runner: a bare `catch` would turn it into `false`, which agrees with the
+ * legacy replay in most cells and would let this matrix pass green while measuring nothing. The
+ * cell-count assertion below does not catch that, because the cells would all still be evaluated.
+ */
 const decidesAllow = async (
   userId: string,
   organizationId: string,
@@ -66,8 +73,9 @@ const decidesAllow = async (
 ): Promise<boolean> => {
   try {
     return (await checkAuthorizationUpdated({ userId, organizationId, access })) === true;
-  } catch {
-    return false;
+  } catch (error) {
+    if (error instanceof AuthorizationError) return false;
+    throw error;
   }
 };
 

--- a/apps/web/lib/utils/action-client/action-client-authorization.integration.test.ts
+++ b/apps/web/lib/utils/action-client/action-client-authorization.integration.test.ts
@@ -1,0 +1,194 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import type { TOrganizationRole } from "@formbricks/types/memberships";
+import { resetDb } from "@/integration/reset-db";
+import { type TAccess, checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
+
+/**
+ * ENG-1737: proof that deleting the action-client's legacy evaluator changed no live decision.
+ *
+ * Removing it was justified by an inventory (all 125 call sites use one of five organization role
+ * sets, none uses the `team` shape) plus the argument that the central path is a superset of the
+ * legacy one for every shape that remains. The inventory was a regex over the repository and the
+ * superset claim was reasoning — neither is a measurement, and reasoning about which evaluator
+ * enforces what is precisely what went wrong once already in this change.
+ *
+ * So: every access shape the repository actually produces, crossed with every organization role and
+ * workspace-grant combination, decided twice against real rows in Postgres — once by
+ * `checkAuthorizationUpdated` as it now stands (central only), and once by the deleted
+ * `checkLegacyAuthorization`, replayed below from
+ * `git show origin/epic/authzed:apps/web/lib/utils/action-client/action-client-middleware.ts`.
+ *
+ * The old function was `central OR legacy`. If central and legacy agree on every cell, that union
+ * was a no-op and removing it moved nothing.
+ */
+const TEAM_PERMISSION_WEIGHT = { read: 1, readWrite: 2, manage: 3 } as const;
+
+const replayDeletedLegacyPath = async (
+  userId: string,
+  organizationId: string,
+  access: TAccess<never>[]
+): Promise<boolean> => {
+  const membership = await prisma.membership.findUnique({
+    where: { userId_organizationId: { userId, organizationId } },
+    select: { role: true },
+  });
+  const role = membership?.role;
+
+  for (const accessItem of access) {
+    if (accessItem.type === "organization" && role && accessItem.roles.includes(role)) return true;
+
+    if (accessItem.type === "workspaceTeam") {
+      // getWorkspacePermissionByUserId: highest WorkspaceTeam permission across the user's teams.
+      const grants = await prisma.workspaceTeam.findMany({
+        where: { workspaceId: accessItem.workspaceId, team: { teamUsers: { some: { userId } } } },
+        select: { permission: true },
+      });
+      if (grants.length > 0) {
+        const highest = grants.reduce(
+          (max, grant) =>
+            TEAM_PERMISSION_WEIGHT[grant.permission] > TEAM_PERMISSION_WEIGHT[max] ? grant.permission : max,
+          grants[0].permission
+        );
+        const required = accessItem.minPermission;
+        if (!required || TEAM_PERMISSION_WEIGHT[highest] >= TEAM_PERMISSION_WEIGHT[required]) return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+const decidesAllow = async (
+  userId: string,
+  organizationId: string,
+  access: TAccess<never>[]
+): Promise<boolean> => {
+  try {
+    return (await checkAuthorizationUpdated({ userId, organizationId, access })) === true;
+  } catch {
+    return false;
+  }
+};
+
+/** The eight shapes the repository produces, by organization role set and workspace grant level. */
+const buildShapes = (workspaceId: string): { access: TAccess<never>[]; name: string }[] => [
+  { name: "org(manager,owner)", access: [{ type: "organization", roles: ["owner", "manager"] }] },
+  {
+    name: "org(billing,manager,owner)",
+    access: [{ type: "organization", roles: ["owner", "manager", "billing"] }],
+  },
+  {
+    name: "org(manager,member,owner)",
+    access: [{ type: "organization", roles: ["owner", "manager", "member"] }],
+  },
+  {
+    name: "org(billing,manager,member,owner)",
+    access: [{ type: "organization", roles: ["owner", "manager", "member", "billing"] }],
+  },
+  ...(["read", "readWrite", "manage"] as const).map((minPermission) => ({
+    name: `org(manager,owner) + ws(${minPermission})`,
+    access: [
+      { type: "organization" as const, roles: ["owner", "manager"] as TOrganizationRole[] },
+      { type: "workspaceTeam" as const, workspaceId, minPermission },
+    ],
+  })),
+  {
+    name: "org(manager,owner) + ws(DEFAULT)",
+    access: [
+      { type: "organization", roles: ["owner", "manager"] },
+      { type: "workspaceTeam", workspaceId },
+    ],
+  },
+];
+
+const scenario: {
+  organizationId: string;
+  users: { name: string; userId: string }[];
+  workspaceId: string;
+} = { organizationId: "", users: [], workspaceId: "" };
+
+beforeAll(async () => {
+  await resetDb();
+
+  const organization = await prisma.organization.create({ data: { name: "Action Client Org" } });
+  const workspace = await prisma.workspace.create({
+    data: { name: "Action Client Workspace", organizationId: organization.id },
+  });
+
+  const makeGrantedTeam = async (name: string, permission: "read" | "readWrite" | "manage") => {
+    const team = await prisma.team.create({ data: { name, organizationId: organization.id } });
+    await prisma.workspaceTeam.create({ data: { teamId: team.id, workspaceId: workspace.id, permission } });
+    return team.id;
+  };
+
+  const readTeam = await makeGrantedTeam("Readers", "read");
+  const manageTeam = await makeGrantedTeam("Managers", "manage");
+
+  const makeUser = async (label: string, role: TOrganizationRole | null, teamId?: string) => {
+    const user = await prisma.user.create({ data: { name: label, email: `${label}@ac.test` } });
+    if (role) {
+      await prisma.membership.create({
+        data: { userId: user.id, organizationId: organization.id, role, accepted: true },
+      });
+    }
+    if (teamId) {
+      await prisma.teamUser.create({ data: { teamId, userId: user.id, role: "contributor" } });
+    }
+    scenario.users.push({ name: label, userId: user.id });
+  };
+
+  await makeUser("owner", "owner");
+  await makeUser("manager", "manager");
+  await makeUser("billing", "billing");
+  await makeUser("member-read-grant", "member", readTeam);
+  await makeUser("member-manage-grant", "member", manageTeam);
+  await makeUser("member-no-grant", "member");
+  await makeUser("non-member", null);
+
+  scenario.organizationId = organization.id;
+  scenario.workspaceId = workspace.id;
+}, 120_000);
+
+describe("checkAuthorizationUpdated against a real database", () => {
+  test("central-only decisions match the deleted legacy path on every live shape", async () => {
+    const shapes = buildShapes(scenario.workspaceId);
+    const disagreements: { current: boolean; legacy: boolean; shape: string; user: string }[] = [];
+
+    for (const shape of shapes) {
+      for (const user of scenario.users) {
+        const current = await decidesAllow(user.userId, scenario.organizationId, shape.access);
+        const legacy = await replayDeletedLegacyPath(user.userId, scenario.organizationId, shape.access);
+        if (current !== legacy) {
+          disagreements.push({ current, legacy, shape: shape.name, user: user.name });
+        }
+      }
+    }
+
+    expect(disagreements).toEqual([]);
+    // Guard against a vacuous pass: the matrix must actually have been evaluated.
+    expect(shapes.length * scenario.users.length).toBe(56);
+  });
+
+  test("a denial is still a throw, and an empty requirement list denies", async () => {
+    const nonMember = scenario.users.find((user) => user.name === "non-member");
+
+    await expect(
+      checkAuthorizationUpdated({
+        userId: nonMember!.userId,
+        organizationId: scenario.organizationId,
+        access: [{ type: "organization", roles: ["owner", "manager"] }],
+      })
+    ).rejects.toThrow("Not authorized");
+
+    const owner = scenario.users.find((user) => user.name === "owner");
+
+    await expect(
+      checkAuthorizationUpdated({
+        userId: owner!.userId,
+        organizationId: scenario.organizationId,
+        access: [],
+      })
+    ).rejects.toThrow("Not authorized");
+  });
+});

--- a/apps/web/lib/utils/action-client/action-client-middleware.test.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.test.ts
@@ -2,23 +2,20 @@ import { cleanup } from "@testing-library/react";
 import { returnValidationErrors } from "next-safe-action";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { ZodIssue, z } from "zod";
+import { logger } from "@formbricks/logger";
 import { AuthorizationError } from "@formbricks/types/errors";
 import { can } from "@/lib/authorization";
-import { getMembershipRole } from "@/lib/membership/hooks/actions";
-import { getTeamRoleByTeamIdUserId, getWorkspacePermissionByUserId } from "@/modules/ee/teams/lib/roles";
 import { checkAuthorizationUpdated, formatErrors } from "./action-client-middleware";
 
 vi.mock("@/lib/authorization", () => ({
   can: vi.fn(),
 }));
 
-vi.mock("@/lib/membership/hooks/actions", () => ({
-  getMembershipRole: vi.fn(),
-}));
-
-vi.mock("@/modules/ee/teams/lib/roles", () => ({
-  getWorkspacePermissionByUserId: vi.fn(),
-  getTeamRoleByTeamIdUserId: vi.fn(),
+vi.mock("@formbricks/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
 }));
 
 vi.mock("next-safe-action", () => ({
@@ -29,7 +26,6 @@ describe("action-client-middleware", () => {
   const userId = "user-1";
   const organizationId = "org-1";
   const workspaceId = "workspace-1";
-  const teamId = "team-1";
 
   beforeEach(() => {
     vi.mocked(can).mockResolvedValue(false);
@@ -111,7 +107,6 @@ describe("action-client-middleware", () => {
         id: organizationId,
       });
       expect(can).toHaveBeenCalledTimes(expectedAction === "organization.read" ? 1 : 2);
-      expect(getMembershipRole).not.toHaveBeenCalled();
     });
 
     test.each([
@@ -139,30 +134,6 @@ describe("action-client-middleware", () => {
         type: "workspace",
         id: workspaceId,
       });
-      expect(getWorkspacePermissionByUserId).not.toHaveBeenCalled();
-    });
-
-    test("maps an admin team alternative to team.manage", async () => {
-      vi.mocked(can).mockImplementation(async (_actor, action) =>
-        ["organization.read", "team.manage"].includes(action)
-      );
-
-      await expect(
-        checkAuthorizationUpdated({
-          userId,
-          organizationId,
-          access: [
-            { type: "organization", roles: ["owner", "manager"] },
-            { type: "team", teamId, minPermission: "admin" },
-          ],
-        })
-      ).resolves.toBe(true);
-
-      expect(can).toHaveBeenCalledWith({ type: "user", id: userId }, "team.manage", {
-        type: "team",
-        id: teamId,
-      });
-      expect(getTeamRoleByTeamIdUserId).not.toHaveBeenCalled();
     });
 
     test("preserves ordered OR evaluation across multiple workspace alternatives", async () => {
@@ -243,34 +214,17 @@ describe("action-client-middleware", () => {
           access: [
             { type: "organization", roles: ["owner", "manager"] },
             { type: "workspaceTeam", workspaceId, minPermission: "manage" },
-            { type: "team", teamId, minPermission: "admin" },
           ],
         })
       ).rejects.toThrow(new AuthorizationError("Not authorized"));
     });
 
-    test("preserves legacy WorkspaceTeam access when the central workspace decision denies", async () => {
-      vi.mocked(can).mockImplementation(async (_actor, action) => action === "organization.read");
-      vi.mocked(getMembershipRole).mockResolvedValue("billing");
-      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("manage");
+    test("denies an empty requirement list instead of treating it as no requirement", async () => {
+      vi.mocked(can).mockResolvedValue(true);
 
-      await expect(
-        checkAuthorizationUpdated({
-          userId,
-          organizationId,
-          access: [
-            { type: "organization", roles: ["owner", "manager"] },
-            { type: "workspaceTeam", workspaceId, minPermission: "manage" },
-          ],
-        })
-      ).resolves.toBe(true);
-
-      expect(can).toHaveBeenCalledWith({ type: "user", id: userId }, "workspace.manage", {
-        type: "workspace",
-        id: workspaceId,
-      });
-      expect(getMembershipRole).toHaveBeenCalledWith(userId, organizationId);
-      expect(getWorkspacePermissionByUserId).toHaveBeenCalledWith(userId, workspaceId);
+      await expect(checkAuthorizationUpdated({ userId, organizationId, access: [] })).rejects.toThrow(
+        new AuthorizationError("Not authorized")
+      );
     });
 
     test("propagates central evaluator failures", async () => {
@@ -287,9 +241,11 @@ describe("action-client-middleware", () => {
     });
   });
 
-  describe("legacy fallback", () => {
-    test("preserves arbitrary organization role sets", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("member");
+  // ENG-1737 removed the parallel legacy evaluator these shapes used to reach. What replaces
+  // it is a refusal, so the cases below pin the failure mode rather than the old behavior.
+  describe("shapes with no central meaning", () => {
+    test("refuses an unmapped organization role set, and says so", async () => {
+      vi.mocked(can).mockResolvedValue(true);
 
       await expect(
         checkAuthorizationUpdated({
@@ -297,14 +253,20 @@ describe("action-client-middleware", () => {
           organizationId,
           access: [{ type: "organization", roles: ["member"] }],
         })
-      ).resolves.toBe(true);
+      ).rejects.toThrow(new AuthorizationError("Not authorized"));
 
-      expect(can).not.toHaveBeenCalled();
+      // The membership gate is the only decision that ran; the role set itself never mapped.
+      expect(can).toHaveBeenCalledTimes(1);
+      expect(logger.error).toHaveBeenCalledWith(
+        { roleSet: "member" },
+        "Unmapped organization role set in action-client authorization"
+      );
     });
 
-    test("preserves standalone workspace access", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("member");
-      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("readWrite");
+    test("evaluates a workspace-only requirement centrally, with no organization item", async () => {
+      vi.mocked(can).mockImplementation(async (_actor, action) =>
+        ["organization.read", "workspace.read"].includes(action)
+      );
 
       await expect(
         checkAuthorizationUpdated({
@@ -314,32 +276,16 @@ describe("action-client-middleware", () => {
         })
       ).resolves.toBe(true);
 
-      expect(getWorkspacePermissionByUserId).toHaveBeenCalledWith(userId, workspaceId);
-      expect(can).not.toHaveBeenCalled();
+      expect(can).toHaveBeenCalledWith({ type: "user", id: userId }, "workspace.read", {
+        type: "workspace",
+        id: workspaceId,
+      });
+      expect(logger.error).not.toHaveBeenCalled();
     });
 
-    test("preserves contributor team checks", async () => {
-      vi.mocked(getMembershipRole).mockResolvedValue("member");
-      vi.mocked(getTeamRoleByTeamIdUserId).mockResolvedValue("admin");
-
-      await expect(
-        checkAuthorizationUpdated({
-          userId,
-          organizationId,
-          access: [
-            { type: "organization", roles: ["owner", "manager"] },
-            { type: "team", teamId, minPermission: "contributor" },
-          ],
-        })
-      ).resolves.toBe(true);
-
-      expect(getTeamRoleByTeamIdUserId).toHaveBeenCalledWith(teamId, userId);
-      expect(can).not.toHaveBeenCalled();
-    });
-
-    test("preserves fallback schema validation", async () => {
+    test("still returns schema validation errors ahead of the role mapping", async () => {
       const schema = z.object({ name: z.string() });
-      vi.mocked(getMembershipRole).mockResolvedValue("member");
+      vi.mocked(can).mockResolvedValue(true);
       vi.mocked(returnValidationErrors).mockReturnValue("validation-error" as unknown as never);
 
       await expect(
@@ -357,7 +303,7 @@ describe("action-client-middleware", () => {
         })
       ).resolves.toBe("validation-error");
 
-      expect(can).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/lib/utils/action-client/action-client-middleware.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.ts
@@ -1,6 +1,7 @@
 import "server-only";
 import { returnValidationErrors } from "next-safe-action";
 import { ZodIssue, z } from "zod";
+import { logger } from "@formbricks/logger";
 import { AuthorizationError } from "@formbricks/types/errors";
 import { type TOrganizationRole } from "@formbricks/types/memberships";
 import {
@@ -10,9 +11,6 @@ import {
   can,
 } from "@/lib/authorization";
 import { getWorkspaceActionForPermission } from "@/lib/authorization/compatibility";
-import { getMembershipRole } from "@/lib/membership/hooks/actions";
-import { getTeamRoleByTeamIdUserId, getWorkspacePermissionByUserId } from "@/modules/ee/teams/lib/roles";
-import { type TTeamRole } from "@/modules/ee/teams/team-list/types/team";
 import { type TTeamPermission } from "@/modules/ee/teams/workspace-teams/types/team";
 
 export const formatErrors = (issues: ZodIssue[]): Record<string, { _errors: string[] }> => {
@@ -26,6 +24,15 @@ export const formatErrors = (issues: ZodIssue[]): Record<string, { _errors: stri
   };
 };
 
+/**
+ * The legacy action-client access shapes, each of which maps onto exactly one action in
+ * the central vocabulary.
+ *
+ * The `team` shape was removed under ENG-1737: no call site used it, and the only role it
+ * could express beyond `team.manage` was bare team membership, which is not an action the
+ * current contract exposes. Leaving it in the union would have meant a shape that type-checks
+ * and then quietly denies.
+ */
 export type TAccess<T extends z.ZodRawShape> =
   | {
       type: "organization";
@@ -37,29 +44,20 @@ export type TAccess<T extends z.ZodRawShape> =
       type: "workspaceTeam";
       minPermission?: TTeamPermission;
       workspaceId: string;
-    }
-  | {
-      type: "team";
-      minPermission?: TTeamRole;
-      teamId: string;
     };
 
-const teamPermissionWeight = {
-  read: 1,
-  readWrite: 2,
-  manage: 3,
-};
-
-const teamRoleWeight = {
-  contributor: 1,
-  admin: 2,
-};
-
 type TOrganizationAction = Extract<TAuthorizationAction, `organization.${string}`>;
-type TTeamAction = Extract<TAuthorizationAction, `team.${string}`>;
 type TUserActor = Extract<TAuthorizationActor, { type: "user" }>;
 type TOrganizationResource = Extract<TAuthorizationResource, { type: "organization" }>;
 
+/**
+ * Every organization role set the action clients express, keyed by its sorted members.
+ *
+ * These five sets are exhaustive over the repository: each one is the membership of exactly
+ * one organization permission in the schema, which is why the translation is lossless.
+ * A set outside this table has no defined meaning, so it is refused rather than guessed at
+ * (see {@link getOrganizationAction}).
+ */
 const ORGANIZATION_ACTION_BY_ROLE_SET: Readonly<Record<string, TOrganizationAction>> = {
   "billing,manager,member,owner": "organization.read",
   "manager,member,owner": "organization.read_access",
@@ -68,13 +66,26 @@ const ORGANIZATION_ACTION_BY_ROLE_SET: Readonly<Record<string, TOrganizationActi
   owner: "organization.write",
 };
 
-const getOrganizationAction = (roles: TOrganizationRole[]): TOrganizationAction | null => {
-  const roleSet = [...new Set(roles)].sort((roleA, roleB) => roleA.localeCompare(roleB)).join(",");
-  return ORGANIZATION_ACTION_BY_ROLE_SET[roleSet] ?? null;
+const byCodeUnit = (roleA: string, roleB: string): number => {
+  if (roleA < roleB) return -1;
+  return roleA > roleB ? 1 : 0;
 };
 
-const getTeamAction = (minPermission?: TTeamRole): TTeamAction | null =>
-  minPermission === "admin" ? "team.manage" : null;
+const getOrganizationAction = (roles: TOrganizationRole[]): TOrganizationAction | null => {
+  const roleSet = [...new Set(roles)].sort(byCodeUnit).join(",");
+  const action = ORGANIZATION_ACTION_BY_ROLE_SET[roleSet];
+
+  if (!action) {
+    // Fail closed, and say so. An unmapped set means an action client asked for a rule the
+    // central vocabulary cannot express, which is a bug in the caller rather than a decision
+    // about this request — the caller is refused, but silence would let it look like an
+    // ordinary denial. The role set is a fixed enum combination, never an identifier.
+    logger.error({ roleSet }, "Unmapped organization role set in action-client authorization");
+    return null;
+  }
+
+  return action;
+};
 
 const getOrganizationValidationError = <T extends z.ZodRawShape>(accessItem: TAccess<T>) => {
   if (accessItem.type !== "organization" || !accessItem.schema) return null;
@@ -87,116 +98,38 @@ const getOrganizationValidationError = <T extends z.ZodRawShape>(accessItem: TAc
   return returnValidationErrors(resultSchema, formatErrors(parsedResult.error.issues));
 };
 
-const checkOrganizationAccess = <T extends z.ZodRawShape>(
-  accessItem: TAccess<T>,
-  role: TOrganizationRole
-) => {
-  if (accessItem.type !== "organization") return false;
-
-  const validationError = getOrganizationValidationError(accessItem);
-  if (validationError) return validationError;
-
-  return accessItem.roles.includes(role);
-};
-
-const checkWorkspaceTeamAccess = async <T extends z.ZodRawShape>(accessItem: TAccess<T>, userId: string) => {
-  if (accessItem.type !== "workspaceTeam") return false;
-  const workspacePermission = await getWorkspacePermissionByUserId(userId, accessItem.workspaceId);
-  if (!workspacePermission) return false;
-  if (
-    accessItem.minPermission !== undefined &&
-    teamPermissionWeight[workspacePermission as keyof typeof teamPermissionWeight] <
-      teamPermissionWeight[accessItem.minPermission as keyof typeof teamPermissionWeight]
-  ) {
-    return false;
-  }
-  return true;
-};
-
-const checkTeamAccess = async <T extends z.ZodRawShape>(accessItem: TAccess<T>, userId: string) => {
-  if (accessItem.type !== "team") return false;
-  const teamRole = await getTeamRoleByTeamIdUserId(accessItem.teamId, userId);
-  if (!teamRole) return false;
-  if (
-    accessItem.minPermission !== undefined &&
-    teamRoleWeight[teamRole as keyof typeof teamRoleWeight] <
-      teamRoleWeight[accessItem.minPermission as keyof typeof teamRoleWeight]
-  ) {
-    return false;
-  }
-  return true;
-};
-
-const isCentralCompatibilityShape = <T extends z.ZodRawShape>(access: TAccess<T>[]): boolean => {
-  const includesOrganizationAccess = access.some((accessItem) => accessItem.type === "organization");
-  if (!includesOrganizationAccess) return false;
-
-  return access.every((accessItem) => {
-    if (accessItem.type === "organization") return getOrganizationAction(accessItem.roles) !== null;
-    if (accessItem.type === "workspaceTeam") return true;
-    return getTeamAction(accessItem.minPermission) !== null;
-  });
-};
-
-const checkLegacyAuthorization = async <T extends z.ZodRawShape>({
-  userId,
-  organizationId,
-  access,
-}: {
-  userId: string;
-  organizationId: string;
-  access: TAccess<T>[];
-}) => {
-  const role = await getMembershipRole(userId, organizationId);
-
-  for (const accessItem of access) {
-    if (accessItem.type === "organization") {
-      const orgResult = checkOrganizationAccess(accessItem, role);
-      if (orgResult === true) return true;
-      if (orgResult) return orgResult;
-    }
-
-    if (accessItem.type === "workspaceTeam" && (await checkWorkspaceTeamAccess(accessItem, userId))) {
-      return true;
-    }
-
-    if (accessItem.type === "team" && (await checkTeamAccess(accessItem, userId))) {
-      return true;
-    }
-  }
-
-  throw new AuthorizationError("Not authorized");
-};
-
-const checkCentralAccessItem = async <T extends z.ZodRawShape>(
+const checkAccessItem = async <T extends z.ZodRawShape>(
   accessItem: TAccess<T>,
   actor: TUserActor,
-  organization: TOrganizationResource,
-  isOrganizationMember: boolean
+  organization: TOrganizationResource
 ) => {
   if (accessItem.type === "organization") {
     const validationError = getOrganizationValidationError(accessItem);
     if (validationError) return validationError;
 
     const action = getOrganizationAction(accessItem.roles);
-    if (action === "organization.read") return isOrganizationMember;
+    // `organization.read` is "holds any membership role", which the caller has already
+    // established for this request; re-asking would be a second identical check.
+    if (action === "organization.read") return true;
     return action ? can(actor, action, organization) : false;
   }
 
-  if (accessItem.type === "workspaceTeam") {
-    const action = getWorkspaceActionForPermission(accessItem.minPermission);
-    return can(actor, action, { type: "workspace", id: accessItem.workspaceId });
-  }
-
-  const action = getTeamAction(accessItem.minPermission);
-  return action ? can(actor, action, { type: "team", id: accessItem.teamId }) : false;
+  const action = getWorkspaceActionForPermission(accessItem.minPermission);
+  return can(actor, action, { type: "workspace", id: accessItem.workspaceId });
 };
 
 /**
  * Compatibility adapter for the pre-ENG-1712 action-client authorization signature.
  *
- * @deprecated New code must call `can` or `assertCan` with a semantic action and
- * resource. Unrecognized legacy shapes remain supported only until ENG-1737.
+ * Every decision now goes through `can`. ENG-1737 removed the parallel legacy evaluator
+ * this used to fall back to: it was reachable only for shapes no call site produced, and
+ * for the live shapes the central path is a superset of it (organization role sets map onto
+ * the identically-defined schema permission, and the workspace ladder additionally admits
+ * owners and managers through `organization#manage`, which the organization item in those
+ * same shapes already admitted). Keeping both meant two implementations of one rule.
+ *
+ * @deprecated New code must call `can` or `assertCan` with a semantic action and resource
+ * rather than adding a caller here.
  */
 export const checkAuthorizationUpdated = async <T extends z.ZodRawShape>({
   userId,
@@ -207,25 +140,19 @@ export const checkAuthorizationUpdated = async <T extends z.ZodRawShape>({
   organizationId: string;
   access: TAccess<T>[];
 }) => {
-  if (!isCentralCompatibilityShape(access)) {
-    return checkLegacyAuthorization({ userId, organizationId, access });
-  }
-
   const actor = { type: "user", id: userId } as const;
   const organization = { type: "organization", id: organizationId } as const;
-  const isOrganizationMember = await can(actor, "organization.read", organization);
 
-  if (!isOrganizationMember) {
+  if (!(await can(actor, "organization.read", organization))) {
     throw new AuthorizationError("Not authorized");
   }
 
   for (const accessItem of access) {
-    const accessResult = await checkCentralAccessItem(accessItem, actor, organization, isOrganizationMember);
+    const accessResult = await checkAccessItem(accessItem, actor, organization);
     if (accessResult) return accessResult;
   }
 
-  // Some legacy OR signatures grant a WorkspaceTeam permission independently
-  // of the organization role. Keep that edge-case behavior until the
-  // compatibility adapter is removed under ENG-1737.
-  return checkLegacyAuthorization({ userId, organizationId, access });
+  // Reached when no item matched, and also when `access` is empty — an empty requirement
+  // list must not read as "no requirements".
+  throw new AuthorizationError("Not authorized");
 };

--- a/apps/web/lib/workspace/auth.test.ts
+++ b/apps/web/lib/workspace/auth.test.ts
@@ -1,22 +1,10 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { can } from "@/lib/authorization";
 import { validateInputs } from "../utils/validate";
-import { hasUserWorkspaceAccess, hasUserWorkspaceAccessForAction } from "./auth";
-
-const mocks = vi.hoisted(() => ({
-  membershipFindFirst: vi.fn(),
-  teamUserFindFirst: vi.fn(),
-}));
+import { canUserNavigateWorkspace, hasUserWorkspaceAccessForAction } from "./auth";
 
 vi.mock("@/lib/authorization", () => ({
   can: vi.fn(),
-}));
-
-vi.mock("@formbricks/database", () => ({
-  prisma: {
-    membership: { findFirst: mocks.membershipFindFirst },
-    teamUser: { findFirst: mocks.teamUserFindFirst },
-  },
 }));
 
 vi.mock("../utils/validate", () => ({
@@ -66,27 +54,52 @@ describe("hasUserWorkspaceAccessForAction", () => {
   });
 });
 
-describe("hasUserWorkspaceAccess navigation compatibility", () => {
+describe("canUserNavigateWorkspace", () => {
   const userId = "00000000-0000-0000-0000-000000000001";
-  const workspaceId = "00000000-0000-0000-0000-000000000002";
+  const workspace = {
+    id: "00000000-0000-0000-0000-000000000002",
+    organizationId: "00000000-0000-0000-0000-000000000003",
+  } as const;
+  const actor = { type: "user", id: userId } as const;
 
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  test("preserves billing-role navigation access", async () => {
-    mocks.membershipFindFirst.mockResolvedValue({ role: "billing" });
+  test("admits anyone who can read the workspace, without asking about billing", async () => {
+    vi.mocked(can).mockResolvedValue(true);
 
-    await expect(hasUserWorkspaceAccess(userId, workspaceId)).resolves.toBe(true);
+    await expect(canUserNavigateWorkspace(userId, workspace)).resolves.toBe(true);
 
-    expect(can).not.toHaveBeenCalled();
-    expect(mocks.teamUserFindFirst).not.toHaveBeenCalled();
+    expect(can).toHaveBeenCalledTimes(1);
+    expect(can).toHaveBeenCalledWith(actor, "workspace.read", {
+      type: "workspace",
+      id: workspace.id,
+    });
   });
 
-  test("preserves member navigation access through any workspace team", async () => {
-    mocks.membershipFindFirst.mockResolvedValue({ role: "member" });
-    mocks.teamUserFindFirst.mockResolvedValue({ userId });
+  test("admits the billing role, which cannot read the workspace", async () => {
+    vi.mocked(can).mockImplementation(async (_actor, action) => action === "organization.manage_billing");
 
-    await expect(hasUserWorkspaceAccess(userId, workspaceId)).resolves.toBe(true);
+    await expect(canUserNavigateWorkspace(userId, workspace)).resolves.toBe(true);
+
+    expect(can).toHaveBeenLastCalledWith(actor, "organization.manage_billing", {
+      type: "organization",
+      id: workspace.organizationId,
+    });
+  });
+
+  test("refuses an organization member with no grant for this workspace", async () => {
+    vi.mocked(can).mockResolvedValue(false);
+
+    await expect(canUserNavigateWorkspace(userId, workspace)).resolves.toBe(false);
+
+    expect(can).toHaveBeenCalledTimes(2);
+  });
+
+  test("propagates central evaluator failures instead of denying", async () => {
+    vi.mocked(can).mockRejectedValue(new Error("database unavailable"));
+
+    await expect(canUserNavigateWorkspace(userId, workspace)).rejects.toThrow("database unavailable");
   });
 });

--- a/apps/web/lib/workspace/auth.test.ts
+++ b/apps/web/lib/workspace/auth.test.ts
@@ -99,9 +99,11 @@ describe("canUserNavigateWorkspace", () => {
     expect(can).toHaveBeenCalledTimes(3);
   });
 
-  // `TeamUser` has no foreign key to `Membership`, so a stale team row could otherwise satisfy
-  // `workspace.read` for someone no longer in the organization. The helper this replaced established
-  // membership with its own query first; this keeps that precondition.
+  // Pins the composition, not a live gap: today's legacy evaluator already refuses a non-member
+  // inside `workspace.read`, so this case is unreachable through it. It matters for the SpiceDB
+  // definition, where `reader_team` is a projected edge carrying no membership requirement — see
+  // the note on canUserNavigateWorkspace. The real-database matrix in
+  // navigation-access.integration.test.ts is what proves the legacy behaviour is unchanged.
   test("refuses a non-member even when a team grant would satisfy workspace.read", async () => {
     vi.mocked(can).mockImplementation(async (_actor, action) => action === "workspace.read");
 

--- a/apps/web/lib/workspace/auth.test.ts
+++ b/apps/web/lib/workspace/auth.test.ts
@@ -71,15 +71,17 @@ describe("canUserNavigateWorkspace", () => {
 
     await expect(canUserNavigateWorkspace(userId, workspace)).resolves.toBe(true);
 
-    expect(can).toHaveBeenCalledTimes(1);
-    expect(can).toHaveBeenCalledWith(actor, "workspace.read", {
+    expect(can).toHaveBeenCalledTimes(2);
+    expect(can).toHaveBeenLastCalledWith(actor, "workspace.read", {
       type: "workspace",
       id: workspace.id,
     });
   });
 
   test("admits the billing role, which cannot read the workspace", async () => {
-    vi.mocked(can).mockImplementation(async (_actor, action) => action === "organization.manage_billing");
+    vi.mocked(can).mockImplementation(
+      async (_actor, action) => action === "organization.read" || action === "organization.manage_billing"
+    );
 
     await expect(canUserNavigateWorkspace(userId, workspace)).resolves.toBe(true);
 
@@ -90,11 +92,26 @@ describe("canUserNavigateWorkspace", () => {
   });
 
   test("refuses an organization member with no grant for this workspace", async () => {
-    vi.mocked(can).mockResolvedValue(false);
+    vi.mocked(can).mockImplementation(async (_actor, action) => action === "organization.read");
 
     await expect(canUserNavigateWorkspace(userId, workspace)).resolves.toBe(false);
 
-    expect(can).toHaveBeenCalledTimes(2);
+    expect(can).toHaveBeenCalledTimes(3);
+  });
+
+  // `TeamUser` has no foreign key to `Membership`, so a stale team row could otherwise satisfy
+  // `workspace.read` for someone no longer in the organization. The helper this replaced established
+  // membership with its own query first; this keeps that precondition.
+  test("refuses a non-member even when a team grant would satisfy workspace.read", async () => {
+    vi.mocked(can).mockImplementation(async (_actor, action) => action === "workspace.read");
+
+    await expect(canUserNavigateWorkspace(userId, workspace)).resolves.toBe(false);
+
+    expect(can).toHaveBeenCalledTimes(1);
+    expect(can).toHaveBeenCalledWith(actor, "organization.read", {
+      type: "organization",
+      id: workspace.organizationId,
+    });
   });
 
   test("propagates central evaluator failures instead of denying", async () => {

--- a/apps/web/lib/workspace/auth.ts
+++ b/apps/web/lib/workspace/auth.ts
@@ -1,8 +1,5 @@
 import "server-only";
-import { prisma } from "@formbricks/database";
-import { Prisma } from "@formbricks/database/prisma";
 import { ZId } from "@formbricks/types/common";
-import { DatabaseError } from "@formbricks/types/errors";
 import { can } from "@/lib/authorization";
 import type { LegacyWorkspaceAction } from "@/lib/authorization/legacy-workspace-access";
 import { validateInputs } from "../utils/validate";
@@ -39,10 +36,10 @@ export const hasUserWorkspaceAccessForAction = async (
  * These are credential *mutations* delivered over GET: completing the flow writes the workspace's
  * third-party credentials, after which survey responses are forwarded to whichever account was
  * connected. They must therefore be gated on readWrite, not on mere workspace access —
- * {@link hasUserWorkspaceAccess} returns true for the `billing` role (which is otherwise excluded from
- * all product data) and for a `read`-only team member, either of whom could otherwise bind their own
- * account as the workspace integration and start receiving another team's responses, or overwrite the
- * credentials an admin configured.
+ * {@link canUserNavigateWorkspace} admits the `billing` role (which is otherwise excluded from all
+ * product data) and `workspace.read` admits a `read`-only team member, either of whom could otherwise
+ * bind their own account as the workspace integration and start receiving another team's responses, or
+ * overwrite the credentials an admin configured.
  */
 export const canUserWriteWorkspaceIntegrations = async (
   userId: string,
@@ -51,7 +48,7 @@ export const canUserWriteWorkspaceIntegrations = async (
 
 /**
  * Read-only counterpart for routes that only surface a connected integration's data. Unlike
- * {@link hasUserWorkspaceAccess} this still excludes the `billing` role.
+ * {@link canUserNavigateWorkspace} this still excludes the `billing` role.
  */
 export const canUserReadWorkspaceIntegrations = async (
   userId: string,
@@ -59,58 +56,35 @@ export const canUserReadWorkspaceIntegrations = async (
 ): Promise<boolean> => hasUserWorkspaceAccessForAction(userId, workspaceId, "GET");
 
 /**
- * Navigation/layout compatibility check.
+ * Whether a user may land on a workspace URL at all — the navigation/layout gate,
+ * as opposed to a gate on any of the workspace's data.
  *
- * @deprecated This helper is not action-aware and intentionally includes the
- * billing role. Do not use it for new data-access or mutation authorization;
- * migrate remaining callers under ENG-1737.
+ * Reaching a workspace is deliberately broader than reading it: the `billing` role
+ * is excluded from all product data but must still be able to follow a workspace
+ * link, because that is how it arrives at the billing screens the layout redirects
+ * it to. Expressed in the central vocabulary that is exactly:
+ *
+ *     workspace.read  OR  organization.manage_billing
+ *
+ * `workspace.read` covers owners and managers (through `organization#manage`) and
+ * any team member holding a `WorkspaceTeam` grant. `organization.manage_billing`
+ * is `owner + manager + billing`, so the second check only ever adds the billing
+ * role — an organization `member` with no grant for this workspace is in neither,
+ * and is still refused. It is ordered second so the common case costs one check.
+ *
+ * Callers pass the resolved workspace rather than an id: every one of them has
+ * already loaded it, and requiring the owning organization here keeps this helper
+ * from hiding a lookup behind an authorization decision.
  */
-export const hasUserWorkspaceAccess = async (userId: string, workspaceId: string) => {
-  validateInputs([userId, ZId], [workspaceId, ZId]);
+export const canUserNavigateWorkspace = async (
+  userId: string,
+  workspace: Readonly<{ id: string; organizationId: string }>
+): Promise<boolean> => {
+  validateInputs([userId, ZId], [workspace.id, ZId], [workspace.organizationId, ZId]);
 
-  try {
-    const orgMembership = await prisma.membership.findFirst({
-      where: {
-        userId,
-        organization: {
-          workspaces: {
-            some: {
-              id: workspaceId,
-            },
-          },
-        },
-      },
-    });
+  const actor = { type: "user", id: userId } as const;
 
-    if (!orgMembership) return false;
+  if (await can(actor, "workspace.read", { type: "workspace", id: workspace.id })) return true;
 
-    if (
-      orgMembership.role === "owner" ||
-      orgMembership.role === "manager" ||
-      orgMembership.role === "billing"
-    )
-      return true;
-
-    const teamMembership = await prisma.teamUser.findFirst({
-      where: {
-        userId,
-        team: {
-          workspaceTeams: {
-            some: {
-              workspaceId,
-            },
-          },
-        },
-      },
-    });
-
-    if (teamMembership) return true;
-
-    return false;
-  } catch (error) {
-    if (error instanceof Prisma.PrismaClientKnownRequestError) {
-      throw new DatabaseError(error.message);
-    }
-    throw error;
-  }
+  return can(actor, "organization.manage_billing", { type: "organization", id: workspace.organizationId });
 };

--- a/apps/web/lib/workspace/auth.ts
+++ b/apps/web/lib/workspace/auth.ts
@@ -72,6 +72,15 @@ export const canUserReadWorkspaceIntegrations = async (
  * role — an organization `member` with no grant for this workspace is in neither,
  * and is still refused. It is ordered second so the common case costs one check.
  *
+ * Membership in the owning organization is checked first, because it is a
+ * precondition the helper this replaced enforced with its own query and neither
+ * disjunct re-derives. `TeamUser` has no foreign key to `Membership` — it cascades
+ * from `Team` and `User` only — so "removed from the organization" and "still has a
+ * team row" are separable states in the schema. `deleteMembership` deletes both in
+ * one serializable transaction, so that state should not occur; this check is what
+ * makes it not matter if it ever does, and keeps the migration from quietly
+ * widening what the old query allowed.
+ *
  * Callers pass the resolved workspace rather than an id: every one of them has
  * already loaded it, and requiring the owning organization here keeps this helper
  * from hiding a lookup behind an authorization decision.
@@ -83,8 +92,11 @@ export const canUserNavigateWorkspace = async (
   validateInputs([userId, ZId], [workspace.id, ZId], [workspace.organizationId, ZId]);
 
   const actor = { type: "user", id: userId } as const;
+  const organization = { type: "organization", id: workspace.organizationId } as const;
+
+  if (!(await can(actor, "organization.read", organization))) return false;
 
   if (await can(actor, "workspace.read", { type: "workspace", id: workspace.id })) return true;
 
-  return can(actor, "organization.manage_billing", { type: "organization", id: workspace.organizationId });
+  return can(actor, "organization.manage_billing", organization);
 };

--- a/apps/web/lib/workspace/auth.ts
+++ b/apps/web/lib/workspace/auth.ts
@@ -72,14 +72,17 @@ export const canUserReadWorkspaceIntegrations = async (
  * role — an organization `member` with no grant for this workspace is in neither,
  * and is still refused. It is ordered second so the common case costs one check.
  *
- * Membership in the owning organization is checked first, because it is a
- * precondition the helper this replaced enforced with its own query and neither
- * disjunct re-derives. `TeamUser` has no foreign key to `Membership` — it cascades
- * from `Team` and `User` only — so "removed from the organization" and "still has a
- * team row" are separable states in the schema. `deleteMembership` deletes both in
- * one serializable transaction, so that state should not occur; this check is what
- * makes it not matter if it ever does, and keeps the migration from quietly
- * widening what the old query allowed.
+ * Membership in the owning organization is asked for first so that this
+ * composition does not depend on which evaluator backs `workspace.read`. Today the
+ * legacy evaluator opens with the same membership query the deleted helper used, so
+ * the check is redundant — but the SpiceDB definition is `reader + reader_team +
+ * write`, where `reader_team` is a projected `team#member` edge that carries no
+ * membership requirement of its own. `TeamUser` has no foreign key to `Membership`
+ * (it cascades from `Team` and `User` only), so "removed from the organization" and
+ * "still has a team row" are separable states in the schema; `deleteMembership`
+ * closes both in one serializable transaction and reconciles the projection, so a
+ * stale edge should not exist. This states the precondition rather than inheriting
+ * it, which is what keeps the two evaluators answering alike here.
  *
  * Callers pass the resolved workspace rather than an id: every one of them has
  * already loaded it, and requiring the owning organization here keeps this helper

--- a/apps/web/lib/workspace/navigation-access.integration.test.ts
+++ b/apps/web/lib/workspace/navigation-access.integration.test.ts
@@ -1,0 +1,156 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import type { TOrganizationRole } from "@formbricks/types/memberships";
+import { resetDb } from "@/integration/reset-db";
+import { canUserNavigateWorkspace } from "@/lib/workspace/auth";
+
+/**
+ * ENG-1737: proof that replacing `hasUserWorkspaceAccess` did not move the boundary.
+ *
+ * The claim the migration rests on is an equivalence over the whole role/grant space, and a mocked
+ * `can()` cannot test it — mocking the decision is assuming the answer. So this drives the real
+ * `canUserNavigateWorkspace` (real `can()`, real legacy evaluator, real Prisma) against a real
+ * Postgres, and compares every case to the deleted helper's own logic, replayed below against the
+ * same rows.
+ *
+ * `expectedByOldHelper` is not a restatement of what the new code does; it is a transcription of the
+ * query the old one ran (`git show origin/epic/authzed:apps/web/lib/workspace/auth.ts`):
+ *
+ *   1. a Membership for this user in the organization that owns the workspace, else false
+ *   2. role owner | manager | billing → true
+ *   3. otherwise a TeamUser row on a team holding any WorkspaceTeam grant for this workspace
+ */
+const replayDeletedHelper = async (userId: string, workspaceId: string): Promise<boolean> => {
+  const orgMembership = await prisma.membership.findFirst({
+    where: { userId, organization: { workspaces: { some: { id: workspaceId } } } },
+  });
+
+  if (!orgMembership) return false;
+  if (["owner", "manager", "billing"].includes(orgMembership.role)) return true;
+
+  const teamMembership = await prisma.teamUser.findFirst({
+    where: { userId, team: { workspaceTeams: { some: { workspaceId } } } },
+  });
+
+  return teamMembership !== null;
+};
+
+type TCase = Readonly<{ expected: boolean; name: string; userId: string }>;
+
+const scenario: {
+  cases: TCase[];
+  otherWorkspaceId: string;
+  workspace: { id: string; organizationId: string };
+} = { cases: [], otherWorkspaceId: "", workspace: { id: "", organizationId: "" } };
+
+const createMember = async (
+  email: string,
+  organizationId: string,
+  role: TOrganizationRole | null
+): Promise<string> => {
+  const user = await prisma.user.create({ data: { name: email, email } });
+  if (role) {
+    await prisma.membership.create({ data: { userId: user.id, organizationId, role, accepted: true } });
+  }
+  return user.id;
+};
+
+beforeAll(async () => {
+  await resetDb();
+
+  const organization = await prisma.organization.create({ data: { name: "Nav Org" } });
+  const otherOrganization = await prisma.organization.create({ data: { name: "Other Org" } });
+
+  const workspace = await prisma.workspace.create({
+    data: { name: "Nav Workspace", organizationId: organization.id },
+  });
+  const otherWorkspace = await prisma.workspace.create({
+    data: { name: "Ungranted Workspace", organizationId: organization.id },
+  });
+
+  // A team holding a read grant on `workspace` only.
+  const grantedTeam = await prisma.team.create({
+    data: { name: "Granted", organizationId: organization.id },
+  });
+  await prisma.workspaceTeam.create({
+    data: { teamId: grantedTeam.id, workspaceId: workspace.id, permission: "read" },
+  });
+  // A team with no workspace grant at all.
+  const ungrantedTeam = await prisma.team.create({
+    data: { name: "Ungranted", organizationId: organization.id },
+  });
+
+  const owner = await createMember("owner@nav.test", organization.id, "owner");
+  const manager = await createMember("manager@nav.test", organization.id, "manager");
+  const billing = await createMember("billing@nav.test", organization.id, "billing");
+  const grantedMember = await createMember("granted@nav.test", organization.id, "member");
+  const ungrantedMember = await createMember("ungranted@nav.test", organization.id, "member");
+  const teamlessMember = await createMember("teamless@nav.test", organization.id, "member");
+  const stranger = await createMember("stranger@nav.test", organization.id, null);
+  const otherOrgOwner = await createMember("other-owner@nav.test", otherOrganization.id, "owner");
+  // A team row that outlived its membership — `TeamUser` cascades from `Team` and `User`, never
+  // from `Membership`. Both implementations refuse it, and for the same reason: the legacy
+  // evaluator behind `workspace.read` opens with the same membership query the deleted helper did.
+  // So this row does NOT exercise the explicit precondition in canUserNavigateWorkspace (the matrix
+  // passes with that line removed); it pins that the state is refused at all.
+  const removedMember = await createMember("removed@nav.test", organization.id, null);
+
+  await prisma.teamUser.createMany({
+    data: [
+      { teamId: grantedTeam.id, userId: grantedMember, role: "contributor" },
+      { teamId: ungrantedTeam.id, userId: ungrantedMember, role: "contributor" },
+      { teamId: grantedTeam.id, userId: removedMember, role: "contributor" },
+    ],
+  });
+
+  scenario.workspace = { id: workspace.id, organizationId: organization.id };
+  scenario.otherWorkspaceId = otherWorkspace.id;
+  scenario.cases = [
+    { expected: true, name: "owner, no team grant", userId: owner },
+    { expected: true, name: "manager, no team grant", userId: manager },
+    { expected: true, name: "billing, no team grant", userId: billing },
+    { expected: true, name: "member with a team grant on this workspace", userId: grantedMember },
+    { expected: false, name: "member whose team holds no grant here", userId: ungrantedMember },
+    { expected: false, name: "member on no team at all", userId: teamlessMember },
+    { expected: false, name: "user with no membership anywhere", userId: stranger },
+    { expected: false, name: "owner of a different organization", userId: otherOrgOwner },
+    { expected: false, name: "removed member whose team row survived", userId: removedMember },
+  ];
+}, 120_000);
+
+describe("canUserNavigateWorkspace against a real database", () => {
+  test("the role/grant matrix is decided the same way the deleted helper decided it", async () => {
+    const rows = await Promise.all(
+      scenario.cases.map(async (testCase) => ({
+        name: testCase.name,
+        expected: testCase.expected,
+        old: await replayDeletedHelper(testCase.userId, scenario.workspace.id),
+        current: await canUserNavigateWorkspace(testCase.userId, scenario.workspace),
+      }))
+    );
+
+    // One assertion over the whole matrix so a failure prints every disagreeing row at once.
+    expect(rows).toEqual(
+      scenario.cases.map((testCase) => ({
+        name: testCase.name,
+        expected: testCase.expected,
+        old: testCase.expected,
+        current: testCase.expected,
+      }))
+    );
+  });
+
+  test("a grant on one workspace does not carry to a sibling workspace", async () => {
+    const grantedMember = scenario.cases.find((testCase) =>
+      testCase.name.startsWith("member with a team grant")
+    );
+
+    const sibling = {
+      id: scenario.otherWorkspaceId,
+      organizationId: scenario.workspace.organizationId,
+    };
+
+    expect(await canUserNavigateWorkspace(grantedMember!.userId, sibling)).toBe(false);
+    expect(await replayDeletedHelper(grantedMember!.userId, sibling.id)).toBe(false);
+  });
+});

--- a/apps/web/modules/ee/license-check/actions.ts
+++ b/apps/web/modules/ee/license-check/actions.ts
@@ -7,9 +7,9 @@ import {
   OperationNotAllowedError,
   ResourceNotFoundError,
 } from "@formbricks/types/errors";
+import { can } from "@/lib/authorization";
 import { cache } from "@/lib/cache";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
-import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getOrganization } from "@/lib/organization/service";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { AuthenticatedActionClientCtx } from "@/lib/utils/action-client/types/context";
@@ -57,13 +57,21 @@ export const recheckLicenseAction = authenticatedActionClient
         throw new ResourceNotFoundError("Organization", null);
       }
 
-      // Check user is owner or manager (not member)
-      const currentUserMembership = await getMembershipByUserIdOrganizationId(ctx.user.id, organization.id);
-      if (!currentUserMembership) {
+      // Check user is owner or manager.
+      //
+      // ENG-1737: this used to deny the `member` role by name, which let the `billing` role
+      // through — it is neither an owner nor a manager, but it is also not a member, so the
+      // negative test missed it. Asking for `organization.manage` (defined as exactly owner +
+      // manager) is what the comment and the error message always claimed. Membership is still
+      // established separately so a non-member keeps reporting as a non-member.
+      const actor = { type: "user", id: ctx.user.id } as const;
+      const organizationResource = { type: "organization", id: organization.id } as const;
+
+      if (!(await can(actor, "organization.read", organizationResource))) {
         throw new AuthenticationError("User not a member of this organization");
       }
 
-      if (currentUserMembership.role === "member") {
+      if (!(await can(actor, "organization.manage", organizationResource))) {
         throw new OperationNotAllowedError("Only owners and managers can recheck license");
       }
 

--- a/apps/web/modules/ee/license-check/actions.ts
+++ b/apps/web/modules/ee/license-check/actions.ts
@@ -2,12 +2,7 @@
 
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
-import {
-  AuthenticationError,
-  OperationNotAllowedError,
-  ResourceNotFoundError,
-} from "@formbricks/types/errors";
-import { can } from "@/lib/authorization";
+import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { cache } from "@/lib/cache";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getOrganization } from "@/lib/organization/service";
@@ -25,6 +20,7 @@ import {
   fetchLicenseFresh,
   getCacheKeys,
 } from "./lib/license";
+import { assertCanRecheckLicense } from "./lib/recheck-authorization";
 
 const ZRecheckLicenseAction = z.object({
   workspaceId: ZId,
@@ -57,23 +53,7 @@ export const recheckLicenseAction = authenticatedActionClient
         throw new ResourceNotFoundError("Organization", null);
       }
 
-      // Check user is owner or manager.
-      //
-      // ENG-1737: this used to deny the `member` role by name, which let the `billing` role
-      // through — it is neither an owner nor a manager, but it is also not a member, so the
-      // negative test missed it. Asking for `organization.manage` (defined as exactly owner +
-      // manager) is what the comment and the error message always claimed. Membership is still
-      // established separately so a non-member keeps reporting as a non-member.
-      const actor = { type: "user", id: ctx.user.id } as const;
-      const organizationResource = { type: "organization", id: organization.id } as const;
-
-      if (!(await can(actor, "organization.read", organizationResource))) {
-        throw new AuthenticationError("User not a member of this organization");
-      }
-
-      if (!(await can(actor, "organization.manage", organizationResource))) {
-        throw new OperationNotAllowedError("Only owners and managers can recheck license");
-      }
+      await assertCanRecheckLicense(ctx.user.id, organization.id);
 
       // Clear main license cache (preserves previous result cache for grace period)
       // This prevents instant downgrade if the license server is temporarily unreachable

--- a/apps/web/modules/ee/license-check/lib/recheck-authorization.integration.test.ts
+++ b/apps/web/modules/ee/license-check/lib/recheck-authorization.integration.test.ts
@@ -1,0 +1,64 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import { AuthenticationError, OperationNotAllowedError } from "@formbricks/types/errors";
+import type { TOrganizationRole } from "@formbricks/types/memberships";
+import { resetDb } from "@/integration/reset-db";
+import { assertCanRecheckLicense } from "@/modules/ee/license-check/lib/recheck-authorization";
+
+/**
+ * ENG-1737: the license-recheck gate, decided against real memberships.
+ *
+ * This is the one behavior change in the branch — the old gate denied the `member` role by name, so
+ * `billing` passed it. The unit test beside this file pins the composition with a mocked `can()`;
+ * this pins the outcome per real organization role, which is the part that actually regressed.
+ */
+const scenario: { organizationId: string; userIdByRole: Map<string, string> } = {
+  organizationId: "",
+  userIdByRole: new Map(),
+};
+
+beforeAll(async () => {
+  await resetDb();
+
+  const organization = await prisma.organization.create({ data: { name: "License Org" } });
+
+  const makeUser = async (label: string, role: TOrganizationRole | null) => {
+    const user = await prisma.user.create({ data: { name: label, email: `${label}@license.test` } });
+    if (role) {
+      await prisma.membership.create({
+        data: { userId: user.id, organizationId: organization.id, role, accepted: true },
+      });
+    }
+    scenario.userIdByRole.set(label, user.id);
+  };
+
+  await makeUser("owner", "owner");
+  await makeUser("manager", "manager");
+  await makeUser("billing", "billing");
+  await makeUser("member", "member");
+  await makeUser("outsider", null);
+
+  scenario.organizationId = organization.id;
+}, 120_000);
+
+describe("assertCanRecheckLicense against a real database", () => {
+  test.each(["owner", "manager"])("allows %s", async (role) => {
+    await expect(
+      assertCanRecheckLicense(scenario.userIdByRole.get(role)!, scenario.organizationId)
+    ).resolves.toBeUndefined();
+  });
+
+  // `billing` is the regression: it holds a membership, so it passes the membership check, and it is
+  // not a `member`, so the old role-name test never caught it.
+  test.each(["billing", "member"])("refuses %s as unable to manage the organization", async (role) => {
+    await expect(
+      assertCanRecheckLicense(scenario.userIdByRole.get(role)!, scenario.organizationId)
+    ).rejects.toThrow(OperationNotAllowedError);
+  });
+
+  test("reports a user outside the organization as a non-member", async () => {
+    await expect(
+      assertCanRecheckLicense(scenario.userIdByRole.get("outsider")!, scenario.organizationId)
+    ).rejects.toThrow(AuthenticationError);
+  });
+});

--- a/apps/web/modules/ee/license-check/lib/recheck-authorization.test.ts
+++ b/apps/web/modules/ee/license-check/lib/recheck-authorization.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AuthenticationError, OperationNotAllowedError } from "@formbricks/types/errors";
+import { can } from "@/lib/authorization";
+import { assertCanRecheckLicense } from "./recheck-authorization";
+
+vi.mock("@/lib/authorization", () => ({ can: vi.fn() }));
+
+describe("assertCanRecheckLicense", () => {
+  const userId = "user-1";
+  const organizationId = "org-1";
+  const actor = { type: "user", id: userId } as const;
+  const organization = { type: "organization", id: organizationId } as const;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("allows a caller who can manage the organization", async () => {
+    vi.mocked(can).mockResolvedValue(true);
+
+    await expect(assertCanRecheckLicense(userId, organizationId)).resolves.toBeUndefined();
+
+    expect(can).toHaveBeenCalledWith(actor, "organization.read", organization);
+    expect(can).toHaveBeenCalledWith(actor, "organization.manage", organization);
+  });
+
+  test("reports a non-member as a non-member, without asking about management", async () => {
+    vi.mocked(can).mockResolvedValue(false);
+
+    await expect(assertCanRecheckLicense(userId, organizationId)).rejects.toThrow(AuthenticationError);
+
+    expect(can).toHaveBeenCalledTimes(1);
+  });
+
+  // The ENG-1737 behavior change. `billing` and `member` both hold a membership and both fail
+  // `organization.manage`; the old check named `member` and so let `billing` through.
+  test("refuses a member who cannot manage the organization", async () => {
+    vi.mocked(can).mockImplementation(async (_actor, action) => action === "organization.read");
+
+    await expect(assertCanRecheckLicense(userId, organizationId)).rejects.toThrow(
+      new OperationNotAllowedError("Only owners and managers can recheck license")
+    );
+  });
+
+  test("propagates an evaluator failure instead of turning it into a denial", async () => {
+    vi.mocked(can).mockRejectedValue(new Error("database unavailable"));
+
+    await expect(assertCanRecheckLicense(userId, organizationId)).rejects.toThrow("database unavailable");
+  });
+});

--- a/apps/web/modules/ee/license-check/lib/recheck-authorization.ts
+++ b/apps/web/modules/ee/license-check/lib/recheck-authorization.ts
@@ -1,0 +1,31 @@
+import "server-only";
+import { AuthenticationError, OperationNotAllowedError } from "@formbricks/types/errors";
+import { can } from "@/lib/authorization";
+
+/**
+ * Who may force a license recheck: organization owners and managers.
+ *
+ * ENG-1737 moved this off a role-name test. It used to deny the `member` role by name, which let
+ * `billing` through — that role is neither an owner nor a manager, but it is also not a member, so
+ * the negative test missed it. `organization.manage` is defined as exactly owner + manager, which is
+ * what this action's own error message has always claimed.
+ *
+ * Membership is established separately from the capability so a caller outside the organization keeps
+ * reporting as a non-member rather than as an insufficient one. It lives here, outside the action, so
+ * it can be tested without the `authenticatedActionClient` wrapper.
+ *
+ * @throws AuthenticationError when the user holds no membership in the organization.
+ * @throws OperationNotAllowedError when the user is a member but may not manage the organization.
+ */
+export const assertCanRecheckLicense = async (userId: string, organizationId: string): Promise<void> => {
+  const actor = { type: "user", id: userId } as const;
+  const organization = { type: "organization", id: organizationId } as const;
+
+  if (!(await can(actor, "organization.read", organization))) {
+    throw new AuthenticationError("User not a member of this organization");
+  }
+
+  if (!(await can(actor, "organization.manage", organization))) {
+    throw new OperationNotAllowedError("Only owners and managers can recheck license");
+  }
+};

--- a/apps/web/modules/ee/role-management/actions.ts
+++ b/apps/web/modules/ee/role-management/actions.ts
@@ -9,9 +9,9 @@ import {
   ValidationError,
 } from "@formbricks/types/errors";
 import { ZMembershipUpdateInput } from "@formbricks/types/memberships";
-import { IS_FORMBRICKS_CLOUD, USER_MANAGEMENT_MINIMUM_ROLE } from "@/lib/constants";
+import { can } from "@/lib/authorization";
+import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
-import { getUserManagementAccess } from "@/lib/membership/utils";
 import { getOrganization } from "@/lib/organization/service";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
@@ -100,12 +100,19 @@ export const updateMembershipAction = authenticatedActionClient.inputSchema(ZUpd
     if (!currentUserMembership) {
       throw new AuthenticationError("User not a member of this organization");
     }
-    const hasUserManagementAccess = getUserManagementAccess(
-      currentUserMembership.role,
-      USER_MANAGEMENT_MINIMUM_ROLE
-    );
+    // `organization.manage_access` *is* this decision in the central vocabulary: the legacy
+    // evaluator answers it with `getUserManagementAccess(role, USER_MANAGEMENT_MINIMUM_ROLE)`, and
+    // the SpiceDB evaluator maps the same setting onto the schema (`owner` → write, `manager` →
+    // manage_access, `disabled` → deny). Asking centrally is what puts this role mutation — the
+    // highest-risk one in the product — in front of shadow comparison and enforcement. The check
+    // below it stays `organization.manage`, which is a different and additionally required
+    // capability, so both remain.
+    const canManageAccess = await can({ type: "user", id: ctx.user.id }, "organization.manage_access", {
+      type: "organization",
+      id: parsedInput.organizationId,
+    });
 
-    if (!hasUserManagementAccess) {
+    if (!canManageAccess) {
       throw new OperationNotAllowedError("User management is not allowed for your role");
     }
 

--- a/apps/web/modules/organization/settings/teams/actions.ts
+++ b/apps/web/modules/organization/settings/teams/actions.ts
@@ -7,6 +7,7 @@ import { logger } from "@formbricks/logger";
 import { ZId, ZUuid } from "@formbricks/types/common";
 import { AuthenticationError, OperationNotAllowedError, ValidationError } from "@formbricks/types/errors";
 import { TOrganizationRole, ZOrganizationRole } from "@formbricks/types/memberships";
+import { can } from "@/lib/authorization";
 import { INVITE_DISABLED, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { createInviteToken } from "@/lib/jwt";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
@@ -294,6 +295,31 @@ export const inviteUserAction = authenticatedActionClient.inputSchema(ZInviteUse
           },
         ],
       });
+    } else {
+      // Team admins reach this action too, and until ENG-1737 their capability was established only
+      // by `getTeamsWhereUserIsAdmin`, so a successful team-admin invite produced no central decision
+      // — no shadow comparison, and legacy-authoritative under enforcement. `team.manage` is that
+      // capability (legacy answers it as `teamRole === "admin" || org owner/manager`), asked once per
+      // requested team so the answer covers exactly the teams this invite would write to.
+      //
+      // The narrower rules below stay in application logic, as they should: which invitation role a
+      // team admin may grant, and that they must name at least one team, are policy about the
+      // request's content rather than a capability the vocabulary expresses.
+      const actor = { type: "user", id: ctx.user.id } as const;
+      const refusedTeamIds = (
+        await Promise.all(
+          parsedInput.teamIds.map(async (teamId) => ({
+            teamId,
+            allowed: await can(actor, "team.manage", { type: "team", id: teamId }),
+          }))
+        )
+      )
+        .filter((decision) => !decision.allowed)
+        .map((decision) => decision.teamId);
+
+      if (refusedTeamIds.length > 0) {
+        throw new OperationNotAllowedError("Team admins can only add users to teams where they are admin");
+      }
     }
 
     // Validate team admin restrictions

--- a/apps/web/modules/organization/settings/teams/actions.ts
+++ b/apps/web/modules/organization/settings/teams/actions.ts
@@ -35,6 +35,9 @@ import { type TBulkInviteResult, getInviteFailureReason } from "./lib/invite-fai
 // Hard cap on a single bulk import to bound payload size and email fan-out.
 const BULK_INVITE_MAX_INVITEES = 500;
 
+// Cap on the teams one invite may name. See ZInviteUserAction.
+const INVITE_MAX_TEAMS = 100;
+
 const ZDeleteInviteAction = z.object({
   inviteId: ZUuid,
 });
@@ -248,7 +251,10 @@ const ZInviteUserAction = z.object({
   email: z.string(),
   name: z.string().trim().min(1, "Name is required"),
   role: ZOrganizationRole,
-  teamIds: z.array(ZId),
+  // Bounded because a team admin's authorization is now decided per named team: without a cap the
+  // number of authorization decisions would follow the request body. The UI offers the teams the
+  // inviter can see, so this is far above any real selection.
+  teamIds: z.array(ZId).max(INVITE_MAX_TEAMS, `An invite is limited to ${INVITE_MAX_TEAMS} teams`),
 });
 
 export const inviteUserAction = authenticatedActionClient.inputSchema(ZInviteUserAction).action(
@@ -305,20 +311,18 @@ export const inviteUserAction = authenticatedActionClient.inputSchema(ZInviteUse
       // The narrower rules below stay in application logic, as they should: which invitation role a
       // team admin may grant, and that they must name at least one team, are policy about the
       // request's content rather than a capability the vocabulary expresses.
+      //
+      // Distinct ids, checked one at a time and stopping at the first refusal. Asking per team means
+      // the number of authorization decisions follows the request body, so it is deduplicated first
+      // (repeating a team is meaningless) and bounded by the schema above. Sequential rather than
+      // Promise.all for the same reason: a request naming many teams should not fan out that many
+      // concurrent checks, and the honest answer is available as soon as one is refused.
       const actor = { type: "user", id: ctx.user.id } as const;
-      const refusedTeamIds = (
-        await Promise.all(
-          parsedInput.teamIds.map(async (teamId) => ({
-            teamId,
-            allowed: await can(actor, "team.manage", { type: "team", id: teamId }),
-          }))
-        )
-      )
-        .filter((decision) => !decision.allowed)
-        .map((decision) => decision.teamId);
 
-      if (refusedTeamIds.length > 0) {
-        throw new OperationNotAllowedError("Team admins can only add users to teams where they are admin");
+      for (const teamId of new Set(parsedInput.teamIds)) {
+        if (!(await can(actor, "team.manage", { type: "team", id: teamId }))) {
+          throw new OperationNotAllowedError("Team admins can only add users to teams where they are admin");
+        }
       }
     }
 

--- a/apps/web/modules/organization/settings/teams/actions.ts
+++ b/apps/web/modules/organization/settings/teams/actions.ts
@@ -246,6 +246,55 @@ const validateTeamAdminInvitePermissions = (
   }
 };
 
+/**
+ * The capability half of "may this person send this invite", routed through the central interface.
+ *
+ * Organization owners and managers are decided once at the organization. Team admins reach this
+ * action too, and before ENG-1737 their capability was established only by `getTeamsWhereUserIsAdmin`,
+ * so a successful team-admin invite produced no central decision at all — no shadow comparison, and
+ * legacy-authoritative under enforcement. `team.manage` is that capability (legacy answers it as
+ * `teamRole === "admin" || organization owner/manager`), asked once per requested team so the answer
+ * covers exactly the teams the invite would write to.
+ *
+ * Distinct ids, checked one at a time, stopping at the first refusal: asking per team makes the
+ * number of authorization decisions follow the request body, so repeats are collapsed (naming a team
+ * twice asks the same question twice) and the array is capped in the schema. Sequential rather than
+ * `Promise.all` for the same reason — a request naming many teams should not fan out that many
+ * concurrent checks, and the answer is available as soon as one team is refused.
+ *
+ * The narrower rules stay with the caller, in `validateTeamAdminInvitePermissions`: which invitation
+ * role a team admin may grant, and that they must name at least one team, are policy about the
+ * request's content rather than capabilities the vocabulary expresses.
+ */
+const assertInviterMayInvite = async ({
+  isOrgOwnerOrManager,
+  organizationId,
+  teamIds,
+  userId,
+}: Readonly<{
+  isOrgOwnerOrManager: boolean;
+  organizationId: string;
+  teamIds: ReadonlyArray<string>;
+  userId: string;
+}>): Promise<void> => {
+  if (isOrgOwnerOrManager) {
+    await checkAuthorizationUpdated({
+      userId,
+      organizationId,
+      access: [{ type: "organization", roles: ["owner", "manager"] }],
+    });
+    return;
+  }
+
+  const actor = { type: "user", id: userId } as const;
+
+  for (const teamId of new Set(teamIds)) {
+    if (!(await can(actor, "team.manage", { type: "team", id: teamId }))) {
+      throw new OperationNotAllowedError("Team admins can only add users to teams where they are admin");
+    }
+  }
+};
+
 const ZInviteUserAction = z.object({
   organizationId: ZId,
   email: z.string(),
@@ -289,42 +338,12 @@ export const inviteUserAction = authenticatedActionClient.inputSchema(ZInviteUse
       throw new AuthenticationError("Not authorized to invite members");
     }
 
-    if (isOrgOwnerOrManager) {
-      // Standard org-level auth check
-      await checkAuthorizationUpdated({
-        userId: ctx.user.id,
-        organizationId: parsedInput.organizationId,
-        access: [
-          {
-            type: "organization",
-            roles: ["owner", "manager"],
-          },
-        ],
-      });
-    } else {
-      // Team admins reach this action too, and until ENG-1737 their capability was established only
-      // by `getTeamsWhereUserIsAdmin`, so a successful team-admin invite produced no central decision
-      // — no shadow comparison, and legacy-authoritative under enforcement. `team.manage` is that
-      // capability (legacy answers it as `teamRole === "admin" || org owner/manager`), asked once per
-      // requested team so the answer covers exactly the teams this invite would write to.
-      //
-      // The narrower rules below stay in application logic, as they should: which invitation role a
-      // team admin may grant, and that they must name at least one team, are policy about the
-      // request's content rather than a capability the vocabulary expresses.
-      //
-      // Distinct ids, checked one at a time and stopping at the first refusal. Asking per team means
-      // the number of authorization decisions follows the request body, so it is deduplicated first
-      // (repeating a team is meaningless) and bounded by the schema above. Sequential rather than
-      // Promise.all for the same reason: a request naming many teams should not fan out that many
-      // concurrent checks, and the honest answer is available as soon as one is refused.
-      const actor = { type: "user", id: ctx.user.id } as const;
-
-      for (const teamId of new Set(parsedInput.teamIds)) {
-        if (!(await can(actor, "team.manage", { type: "team", id: teamId }))) {
-          throw new OperationNotAllowedError("Team admins can only add users to teams where they are admin");
-        }
-      }
-    }
+    await assertInviterMayInvite({
+      isOrgOwnerOrManager,
+      organizationId: parsedInput.organizationId,
+      teamIds: parsedInput.teamIds,
+      userId: ctx.user.id,
+    });
 
     // Validate team admin restrictions
     validateTeamAdminInvitePermissions(

--- a/apps/web/modules/workspaces/lib/utils.test.ts
+++ b/apps/web/modules/workspaces/lib/utils.test.ts
@@ -2,10 +2,10 @@ import { redirect } from "next/navigation";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { AuthenticationError, AuthorizationError, ResourceNotFoundError } from "@formbricks/types/errors";
 import type { TMembership, TOrganizationRole } from "@formbricks/types/memberships";
+import { can } from "@/lib/authorization";
 import { getBillingFallbackPath } from "@/lib/membership/navigation";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getOrganization } from "@/lib/organization/service";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
 import { getWorkspace } from "@/lib/workspace/service";
 import { getSession } from "@/modules/auth/lib/session";
 import { getWorkspacePermissionByUserId } from "@/modules/ee/teams/lib/roles";
@@ -23,7 +23,8 @@ vi.mock("@/lib/constants", async (importOriginal) => ({
   IS_FORMBRICKS_CLOUD: mocks.isFormbricksCloud,
 }));
 vi.mock("@/lib/workspace/service", () => ({ getWorkspace: vi.fn() }));
-vi.mock("@/lib/workspace/auth", () => ({ hasUserWorkspaceAccess: vi.fn() }));
+vi.mock("@/lib/authorization", () => ({ can: vi.fn() }));
+vi.mock("@/lib/workspace/auth", () => ({ canUserNavigateWorkspace: vi.fn() }));
 vi.mock("@/lib/organization/service", () => ({
   getOrganization: vi.fn(),
   getMonthlyOrganizationResponseCount: vi.fn(),
@@ -56,7 +57,7 @@ const primeAuth = (role: TOrganizationRole) => {
     userId,
     accepted: true,
   } as TMembership);
-  vi.mocked(hasUserWorkspaceAccess).mockResolvedValue(true);
+  vi.mocked(can).mockResolvedValue(true);
   vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue(null);
   vi.mocked(getBillingFallbackPath).mockReturnValue(billingFallbackPath);
 };
@@ -120,10 +121,15 @@ describe("getWorkspaceAuth workspace-access gate + isReadOnly (ENG-1769)", () =>
   // The core fix: an org member with no WorkspaceTeam grant for this workspace
   // must be rejected instead of being admitted (and mislabeled as a writer).
   test("throws AuthorizationError when the user has no workspace access", async () => {
-    vi.mocked(hasUserWorkspaceAccess).mockResolvedValue(false);
+    vi.mocked(can).mockResolvedValue(false);
     vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue(null);
     await expect(getWorkspaceAuth(workspaceId)).rejects.toThrow(AuthorizationError);
-    expect(hasUserWorkspaceAccess).toHaveBeenCalledWith(userId, workspaceId);
+    // The narrow read permission, not the navigation check: billing has already been
+    // redirected above, so this choke point must not re-admit it.
+    expect(can).toHaveBeenCalledWith({ type: "user", id: userId }, "workspace.read", {
+      type: "workspace",
+      id: workspaceId,
+    });
   });
 
   test("marks a member with a read grant as read-only", async () => {

--- a/apps/web/modules/workspaces/lib/utils.test.ts
+++ b/apps/web/modules/workspaces/lib/utils.test.ts
@@ -6,12 +6,16 @@ import { can } from "@/lib/authorization";
 import { getBillingFallbackPath } from "@/lib/membership/navigation";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
 import { getOrganization } from "@/lib/organization/service";
+import { getUser } from "@/lib/user/service";
+import { canUserNavigateWorkspace } from "@/lib/workspace/auth";
 import { getWorkspace } from "@/lib/workspace/service";
 import { getSession } from "@/modules/auth/lib/session";
+import { getEnterpriseLicense } from "@/modules/ee/license-check/lib/license";
+import { getAccessControlPermission } from "@/modules/ee/license-check/lib/utils";
 import { getWorkspacePermissionByUserId } from "@/modules/ee/teams/lib/roles";
-import { getWorkspaceAuth } from "./utils";
+import { getWorkspaceAuth, getWorkspaceLayoutData, workspaceIdLayoutChecks } from "./utils";
 
-const mocks = vi.hoisted(() => ({ isFormbricksCloud: false }));
+const mocks = vi.hoisted(() => ({ isFormbricksCloud: false, workspaceFindUnique: vi.fn() }));
 
 // Real getAccessFlags and getTeamPermissionFlags are used on purpose so the tests exercise the
 // actual role -> isBilling mapping (the redirect branch) and the permission -> isReadOnly mapping.
@@ -25,6 +29,10 @@ vi.mock("@/lib/constants", async (importOriginal) => ({
 vi.mock("@/lib/workspace/service", () => ({ getWorkspace: vi.fn() }));
 vi.mock("@/lib/authorization", () => ({ can: vi.fn() }));
 vi.mock("@/lib/workspace/auth", () => ({ canUserNavigateWorkspace: vi.fn() }));
+vi.mock("@formbricks/database", () => ({ prisma: { workspace: { findUnique: mocks.workspaceFindUnique } } }));
+vi.mock("@/lib/user/service", () => ({ getUser: vi.fn() }));
+vi.mock("@/modules/ee/license-check/lib/utils", () => ({ getAccessControlPermission: vi.fn() }));
+vi.mock("@/modules/ee/license-check/lib/license", () => ({ getEnterpriseLicense: vi.fn() }));
 vi.mock("@/lib/organization/service", () => ({
   getOrganization: vi.fn(),
   getMonthlyOrganizationResponseCount: vi.fn(),
@@ -180,5 +188,112 @@ describe("getWorkspaceAuth workspace-access gate + isReadOnly (ENG-1769)", () =>
     expect(auth.organization).toMatchObject({ id: organizationId });
     expect(auth.session.user.id).toBe(userId);
     expect(auth.workspacePermission).toBe("read");
+  });
+});
+
+// The layout helpers gate navigation rather than data, so unlike getWorkspaceAuth they must keep
+// admitting the billing role — that is how it reaches the billing screens. These ids are real
+// cuid2s because getWorkspaceLayoutData validates them.
+describe("layout navigation gates (ENG-1737)", () => {
+  const layoutWorkspaceId = "cl9ebqhxk00003b600tymydho";
+  const layoutOrganizationId = "cl9ebqhxk00013b60vqhmydho";
+  const layoutUserId = "cl9ebqhxk00023b60kzlmydho";
+
+  const organizationRelation = {
+    id: layoutOrganizationId,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+    name: "Org",
+    billing: { stripeCustomerId: null, limits: {}, usageCycleAnchor: null, stripe: null },
+    isAISmartToolsEnabled: false,
+    whitelabel: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSession).mockResolvedValue({
+      user: { id: layoutUserId },
+      expires: new Date(0).toISOString(),
+    } as Awaited<ReturnType<typeof getSession>>);
+    vi.mocked(getUser).mockResolvedValue({ id: layoutUserId } as Awaited<ReturnType<typeof getUser>>);
+    vi.mocked(canUserNavigateWorkspace).mockResolvedValue(true);
+    mocks.workspaceFindUnique.mockResolvedValue({ organization: organizationRelation });
+  });
+
+  describe("workspaceIdLayoutChecks", () => {
+    test("asks the navigation question about the resolved workspace and its organization", async () => {
+      const result = await workspaceIdLayoutChecks(layoutWorkspaceId);
+
+      expect(canUserNavigateWorkspace).toHaveBeenCalledWith(layoutUserId, {
+        id: layoutWorkspaceId,
+        organizationId: layoutOrganizationId,
+      });
+      expect(result.organization).toMatchObject({ id: layoutOrganizationId });
+    });
+
+    test("throws AuthorizationError when the user may not navigate there", async () => {
+      vi.mocked(canUserNavigateWorkspace).mockResolvedValue(false);
+
+      await expect(workspaceIdLayoutChecks(layoutWorkspaceId)).rejects.toThrow(AuthorizationError);
+    });
+
+    // Existence is now answered before access, so a missing workspace reports itself as missing
+    // instead of as a denial — matching getWorkspaceAuth.
+    test("throws ResourceNotFoundError for a workspace that does not exist", async () => {
+      mocks.workspaceFindUnique.mockResolvedValue(null);
+
+      await expect(workspaceIdLayoutChecks(layoutWorkspaceId)).rejects.toThrow(ResourceNotFoundError);
+      expect(canUserNavigateWorkspace).not.toHaveBeenCalled();
+    });
+
+    test("returns early without deciding access when there is no session", async () => {
+      vi.mocked(getSession).mockResolvedValue(null);
+
+      const result = await workspaceIdLayoutChecks(layoutWorkspaceId);
+
+      expect(result.session).toBeNull();
+      expect(canUserNavigateWorkspace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getWorkspaceLayoutData", () => {
+    beforeEach(() => {
+      mocks.workspaceFindUnique.mockResolvedValue({
+        id: layoutWorkspaceId,
+        organizationId: layoutOrganizationId,
+        organization: { ...organizationRelation, memberships: [{ userId: layoutUserId, role: "member" }] },
+      });
+      vi.mocked(getAccessControlPermission).mockResolvedValue(false);
+      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("read");
+      vi.mocked(getEnterpriseLicense).mockResolvedValue({ active: false } as Awaited<
+        ReturnType<typeof getEnterpriseLicense>
+      >);
+    });
+
+    test("asks the navigation question about the resolved workspace and its organization", async () => {
+      await getWorkspaceLayoutData(layoutWorkspaceId, layoutUserId);
+
+      expect(canUserNavigateWorkspace).toHaveBeenCalledWith(layoutUserId, {
+        id: layoutWorkspaceId,
+        organizationId: layoutOrganizationId,
+      });
+    });
+
+    test("throws AuthorizationError when the user may not navigate there", async () => {
+      vi.mocked(canUserNavigateWorkspace).mockResolvedValue(false);
+
+      await expect(getWorkspaceLayoutData(layoutWorkspaceId, layoutUserId)).rejects.toThrow(
+        AuthorizationError
+      );
+    });
+
+    test("throws ResourceNotFoundError for a workspace that does not exist", async () => {
+      mocks.workspaceFindUnique.mockResolvedValue(null);
+
+      await expect(getWorkspaceLayoutData(layoutWorkspaceId, layoutUserId)).rejects.toThrow(
+        ResourceNotFoundError
+      );
+      expect(canUserNavigateWorkspace).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/modules/workspaces/lib/utils.ts
+++ b/apps/web/modules/workspaces/lib/utils.ts
@@ -10,6 +10,7 @@ import {
   DatabaseError,
   ResourceNotFoundError,
 } from "@formbricks/types/errors";
+import { can } from "@/lib/authorization";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getBillingFallbackPath } from "@/lib/membership/navigation";
 import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
@@ -17,7 +18,7 @@ import { getAccessFlags } from "@/lib/membership/utils";
 import { getMonthlyOrganizationResponseCount, getOrganization } from "@/lib/organization/service";
 import { getUser } from "@/lib/user/service";
 import { validateInputs } from "@/lib/utils/validate";
-import { hasUserWorkspaceAccess } from "@/lib/workspace/auth";
+import { canUserNavigateWorkspace } from "@/lib/workspace/auth";
 import { getWorkspace } from "@/lib/workspace/service";
 import { getTranslate } from "@/lingodotdev/server";
 import { getSession } from "@/modules/auth/lib/session";
@@ -75,8 +76,18 @@ export const getWorkspaceAuth = reactCache(async (workspaceId: string): Promise<
   // getWorkspaceAuth is safe to reuse anywhere. An org member with no WorkspaceTeam
   // grant for this workspace has no access and must be rejected — not silently
   // treated as a writer. Runs alongside the permission lookup to avoid extra latency.
+  //
+  // `workspace.read` and not the broader navigation check: the billing redirect above
+  // already returned, so the only roles that reach this line are owner, manager, and
+  // member, for which the two are identical. Asking for the narrower permission means
+  // the choke point no longer depends on the redirect running first to keep the billing
+  // role out of product data — if that ordering were ever disturbed, billing would be
+  // refused here rather than admitted.
   const [hasWorkspaceAccess, workspacePermission] = await Promise.all([
-    hasUserWorkspaceAccess(session.user.id, workspace.id),
+    can({ type: "user", id: session.user.id }, "workspace.read", {
+      type: "workspace",
+      id: workspace.id,
+    }),
     getWorkspacePermissionByUserId(session.user.id, workspace.id),
   ]);
 
@@ -125,11 +136,10 @@ export const workspaceIdLayoutChecks = async (workspaceId: string) => {
     return { t, session, user: null, organization: null };
   }
 
-  const hasAccess = await hasUserWorkspaceAccess(session.user.id, workspaceId);
-  if (!hasAccess) {
-    throw new AuthorizationError(t("common.not_authorized"));
-  }
-
+  // Resolved before the access check because the navigation gate is expressed against the
+  // owning organization as well as the workspace. Answering "does it exist" first also
+  // matches getWorkspaceAuth above, so a missing workspace reports itself as missing here
+  // too instead of as a denial.
   const workspace = await prisma.workspace.findUnique({
     where: { id: workspaceId },
     select: {
@@ -156,6 +166,17 @@ export const workspaceIdLayoutChecks = async (workspaceId: string) => {
 
   if (!workspace) {
     throw new ResourceNotFoundError(t("common.workspace"), workspaceId);
+  }
+
+  // Navigation, not data: these layouts are also what a billing-role member has to pass
+  // through on the way to the billing screens, so this keeps admitting that role. The
+  // pages themselves gate their data on workspace.read.
+  const hasAccess = await canUserNavigateWorkspace(session.user.id, {
+    id: workspaceId,
+    organizationId: workspace.organization.id,
+  });
+  if (!hasAccess) {
+    throw new AuthorizationError(t("common.not_authorized"));
   }
 
   return { t, session, user, organization: workspace.organization };
@@ -288,17 +309,25 @@ export const getWorkspaceLayoutData = reactCache(
       throw new AuthenticationError(t("common.not_authenticated"));
     }
 
-    const hasAccess = await hasUserWorkspaceAccess(userId, workspaceId);
-    if (!hasAccess) {
-      throw new AuthorizationError(t("common.not_authorized"));
-    }
-
+    // Resolved first so the navigation gate below can name the owning organization. This is
+    // the same request-memoized read the rest of this function already relied on, so it costs
+    // nothing extra; it only moves.
     const relationData = await getWorkspaceWithRelations(workspaceId, userId);
     if (!relationData) {
       throw new ResourceNotFoundError(t("common.workspace"), workspaceId);
     }
 
     const { workspace, organization, membership } = relationData;
+
+    // Navigation, not data — the layout shell a billing-role member passes through on the way
+    // to billing. Product data on the pages inside stays gated on workspace.read.
+    const hasAccess = await canUserNavigateWorkspace(userId, {
+      id: workspace.id,
+      organizationId: organization.id,
+    });
+    if (!hasAccess) {
+      throw new AuthorizationError(t("common.not_authorized"));
+    }
 
     if (!membership) {
       throw new AuthorizationError(t("common.membership_not_found"));


### PR DESCRIPTION
## What & why

`can()`/`assertCan()` has been the central authorization interface since ENG-1712, but three
authorization surfaces still decided access their own way. Each one was a second implementation of a
rule the schema already defines, which is how the two of them drift apart.

**The broad workspace helper.** `hasUserWorkspaceAccess` read Prisma directly and answered "may this
user see this workspace at all", deliberately including the `billing` role. It is gone.

- `getWorkspaceAuth` no longer needs it. The billing redirect above it has already returned by the
  time the access check runs, so only owner, manager and member reach that line — for which the broad
  check and `workspace.read` are the same answer. Asking for the narrower permission means this choke
  point no longer *depends* on that ordering to keep billing out of product data.
- The four navigation callers do still need to admit billing, because following a workspace link is
  how a billing-role member reaches the billing screens. In the central vocabulary that is exactly
  `workspace.read OR organization.manage_billing`: `manage_billing` is owner + manager + billing, and
  owners and managers already satisfy `workspace.read`, so the second disjunct only ever adds the
  billing role. An organization member with no grant for this workspace is in neither and is still
  refused. No new action or schema change was needed.

**The action-client adapter's second evaluator.** `checkAuthorizationUpdated` kept a parallel legacy
engine, entered when an access shape had no central mapping and again as a tail fallback when every
central decision denied. Neither is reachable. All 125 call sites use one of five organization role
sets and none use the `team` shape; each of those five sets is the membership of exactly one schema
permission, so the translation is lossless, and the workspace ladder additionally admits owners and
managers via `organization#manage` — which the organization item in those same shapes already
admitted. The fallback could only ever repeat a decision already made.

What replaces it is narrower and louder: the `team` shape is gone from `TAccess` (the one rule it
could express beyond `team.manage` was bare team membership, which the contract does not expose, so
it is now a compile error rather than a shape that type-checks and quietly denies), an unmapped role
set is refused *and logged as a caller bug*, and an empty requirement list is refused rather than
falling through.

**Role-name gates outside the module.** An audit of all 29 `getAccessFlags` callers and every direct
`Membership.role` comparison found exactly two that decide access. Both now ask for the capability;
the other 27 are documented as retained in the module README with the reason each is not a gate.

### One behavior fix worth calling out

The self-hosted license recheck denied the `member` role **by name**. `billing` is not a member, so
it passed — able to clear the license cache and trigger a fetch against the license server, through
an action whose own error message reads *"Only owners and managers can recheck license"*. It now asks
for `organization.manage`, which is what the comment and the message always claimed.

Low severity (self-hosted only, rate-limited to 5/min, and `billing` is an invited role) but it is
the exact failure mode this ticket exists to remove: enumerating the denied role instead of naming
the required capability. Found while migrating it, fixed in the same change since the migration *is*
the fix. No existing ticket or open PR covers it — happy to file one for traceability if you'd rather
it be tracked separately.

### On the membership precondition (and a correction)

`canUserNavigateWorkspace` asks for `organization.read` before either disjunct. I first added that
believing it closed a state the replacement would otherwise have admitted — a user removed from the
organization whose `TeamUser` row survived, since `TeamUser` cascades from `Team` and `User` but never
from `Membership`.

**That was wrong, and the real-database test is what caught it.** The legacy evaluator behind
`workspace.read` opens with the same membership query the deleted helper used, so a removed member was
already refused; the equivalence matrix passes with the precondition removed. I only found that by
deleting the line and re-running, rather than trusting a green test I had written to match my own fix.

The line stays for a narrower, accurate reason: the SpiceDB definition of `workspace.read` is
`reader + reader_team + write`, and `reader_team` is a projected edge carrying no membership
requirement of its own. Stating the precondition keeps this composition answering the same way under
either evaluator instead of inheriting the guarantee from whichever one happens to be enforcing.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1737/migrate-remaining-scattered-authorization-checks-to-the

## How this was tested

- `pnpm --dir apps/web test` — **628 files, 8200 tests, all passing**. Nothing outside the touched
  suites moved.
- `pnpm turbo run typecheck --filter=@formbricks/web` ✅ (removing the `team` variant from `TAccess`
  is a compile-time change, so this is the check that matters most).
- `eslint` and `prettier --check` clean on every changed file.
- Tests updated to the new behavior rather than around it:
  - `lib/workspace/auth.test.ts` — the navigation composition: a workspace reader is admitted without
    the billing check even running; the billing role is admitted only by the second check; a member
    with no grant is refused after both; evaluator failures propagate instead of denying.
  - `lib/utils/action-client/action-client-middleware.test.ts` — the three tests that pinned the
    legacy fallback now pin the refusal, including the log line; added the empty-`access` case.
  - `modules/workspaces/lib/utils.test.ts` — asserts the choke point asks for `workspace.read`
    specifically, not the navigation check.
  - `app/(app)/(onboarding)/lib/onboarding-workspace.test.ts` — asserts the exact
    `organization.manage` call.
- **`pnpm --dir apps/web test:integration lib/workspace/navigation-access.integration.test.ts`** — a
  new real-Postgres test. Every other test here mocks `can()`, which cannot prove an equivalence
  claim. This seeds the role/grant matrix into the database and runs the real helper (real `can()`,
  real legacy evaluator, real Prisma) against the deleted helper's own query replayed over the same
  rows: owner, manager, billing, member with a grant here, member whose team holds a grant on a
  sibling workspace, member on no team, non-member, owner of another organization, and a team row
  that outlived its membership. Nine cases, two implementations, identical answers.
- **`pnpm --dir apps/web test:integration lib/utils/action-client/action-client-authorization.integration.test.ts`**
  — the same treatment for the fallback removal. The eight access shapes the repository produces,
  crossed with every organization role and workspace-grant combination (56 decisions), each decided
  twice against real rows: once by the adapter as it stands, once by the deleted
  `checkLegacyAuthorization` replayed from the commit that removed it. The old function was
  `central OR legacy`; they agree on every cell, so the union was a no-op.
- Both matrices were **mutation-checked**, not assumed. Removing the membership precondition left the
  navigation matrix green — which is how the correction above surfaced. Remapping
  `roles: ["owner", "manager"]` to `organization.write` makes the action-client matrix report the
  manager as denied-by-central/allowed-by-legacy on exactly the shape where no workspace grant can
  carry them, so a green run there means it can see a difference when there is one.
- Security scan on the diff: `gitleaks` clean (3 commits), `semgrep` p/typescript + p/security-audit
  + p/owasp-top-ten — **11 targets scanned, 0 findings**.
- `modules/workspaces/lib/utils.test.ts` also gained coverage for `workspaceIdLayoutChecks` and
  `getWorkspaceLayoutData`, which previously had none. Those two navigation gates were the only
  uncovered new lines in the change (Sonar caught it at 76.1%), and they are the ones where a
  mistake is visible in both directions — a billing member 403'd instead of redirected, or a
  team-less member let into the layout.
- The license-recheck gate moved to `assertCanRecheckLicense` in the module's `lib/` — where the
  convention here puts something a server action wraps — so the one behavior change in this branch is
  directly testable. It has a unit test for the composition and a real-database test for the outcome
  per organization role, `billing` included, since that is the role that used to slip through.
  (Raised by CodeRabbit; I had recorded skipping it as deliberate, and it shouldn't have been.)

## Breaking changes

None for integrations or self-hosters. Two intentional behavior changes inside the app, both
narrowing:

- A `billing`-role member can no longer trigger a self-hosted license recheck (see above).
- `workspaceIdLayoutChecks` and `getWorkspaceLayoutData` now resolve the workspace before deciding
  access, so a **non-existent** workspace id reports as not-found instead of not-authorized. That
  matches what `getWorkspaceAuth` — the path every product page already takes — has always done.
  A second consequence of the same reorder, found on review rather than while writing it:
  `getWorkspaceWithRelations` throws `ResourceNotFoundError("OrganizationBilling")` when an
  organization has no billing row, and that now fires ahead of the access check too. So an
  authenticated-but-unauthorized user can distinguish "no billing row" from a plain denial. It is one
  bit about an internal invariant on a workspace whose existence the reorder already reveals, so I
  left it rather than splitting the relation read in two — flagging it because it is a consequence,
  not an intention.

## QA / Test Plan

**How to test**

- [ ] As an **owner** or **manager**, open `/environments/<legacy environment id>` → redirected to
      `/workspaces/<workspaceId>/`, workspace loads normally.
- [ ] As a **member with a team grant** on that workspace, same URL → same redirect, workspace loads.
- [ ] As a **member with no team grant** on that workspace, open `/workspaces/<workspaceId>` → "not
      authorized", no workspace data rendered.
- [ ] As a **billing-role member** (Cloud), open `/workspaces/<workspaceId>` → still redirected to
      the billing/enterprise screen, *not* an authorization error. This is the case the navigation
      check exists for; a regression here looks like a 403 instead of a redirect.
- [ ] As a **billing-role member**, confirm you still cannot see workspace product data (surveys,
      responses, contacts) by direct navigation.
- [ ] Open `/environments/<id>/summary` (the catch-all redirect) as owner and as a team-less member →
      redirect for the first, "not authorized" for the second.
- [ ] Team, workspace-settings, organization-settings and survey-editor actions as owner, manager,
      team member and read-only member → unchanged; every action client still allows and denies
      exactly who it did before.
- [ ] **Self-hosted only:** as a `billing`-role member, trigger the license recheck from
      organization settings → "Only owners and managers can recheck license". As an owner or manager
      → recheck succeeds. (Before this PR the billing role succeeded here.)
- [ ] Onboarding: as a member (not owner/manager), attempt to create a workspace in an existing
      organization → refused. As an owner or manager → succeeds.
- [ ] Open a workspace URL with a **made-up workspace id** → not-found page rather than an
      authorization error.

**Preconditions / test data**

- One organization with all four roles represented: owner, manager, member (with a `WorkspaceTeam`
  grant), member (with no grant), and — for the billing cases — a `billing`-role member. The billing
  role is Cloud-only, so its cases need `IS_FORMBRICKS_CLOUD`.
- At least two workspaces in the organization, so "member with a grant on workspace A but not B" is
  testable.
- The license-recheck step needs a **self-hosted** instance (the action refuses on Cloud).
- Authorization rollout/enforcement flags can stay at their defaults; this PR does not change which
  evaluator runs, only which question is asked.

**Risks & regressions**

- The billing-role redirect is the highest-risk path: it is the one place where a check *must* stay
  broad, and it is now expressed as a second `can()` call rather than a role read.
- The action clients are the widest blast radius — 125 call sites now have no fallback behind them.
  Re-check a spread of them across teams, workspace settings, organization settings and the survey
  editor rather than only one.
- `getWorkspaceAuth` is the choke point every product page flows through; a mistake there is visible
  immediately as blanket 403s.

**Migrations / env / cutover**

- none
