### PR TITLE
fix(survey): use validated SURVEY_SCHEDULING_TIME_ZONE for archive purge

### DIFF
--- a/apps/web/modules/survey/archive/lib/constants.ts
+++ b/apps/web/modules/survey/archive/lib/constants.ts
@@ -1,3 +1,5 @@
+import { env } from "@/lib/env";
+
 // Archived surveys are permanently deleted after this many days (see ENG-1042).
 export const SURVEY_ARCHIVE_RETENTION_DAYS = 30;
 
@@ -5,8 +7,9 @@ export const SURVEY_ARCHIVE_RETENTION_DAYS = 30;
 export const SURVEY_ARCHIVE_PURGE_BATCH_SIZE = 100;
 
 // Daily at 01:30 in the same time zone as survey scheduling, offset from the scheduling job.
-export const SURVEY_ARCHIVE_PURGE_TIME_ZONE =
-  process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE ?? "Europe/Berlin";
+// Reuses the validated, server-only SURVEY_SCHEDULING_TIME_ZONE (single source of truth in
+// apps/web/lib/env.ts), which already defaults to "Europe/Berlin".
+export const SURVEY_ARCHIVE_PURGE_TIME_ZONE = env.SURVEY_SCHEDULING_TIME_ZONE;
 export const SURVEY_ARCHIVE_PURGE_DAILY_CRON_PATTERN = "30 1 * * *";
 export const SURVEY_ARCHIVE_PURGE_GLOBAL_SCOPE = "global";
 export const SURVEY_ARCHIVE_PURGE_DAILY_SCHEDULE_ID = "daily-survey-archive-purge";


### PR DESCRIPTION
## What & why

The survey-archive purge job derived its time zone from `process.env.NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE` — a leftover from before the scheduling time zone was renamed to the server-only, validated `SURVEY_SCHEDULING_TIME_ZONE`. That public env var no longer exists, so the purge job always fell back to the hard-coded `"Europe/Berlin"` and could never be overridden, silently diverging from the scheduling job it is meant to stay aligned with.

This reads the validated env value instead (`env.SURVEY_SCHEDULING_TIME_ZONE`, single source of truth in `apps/web/lib/env.ts`, still defaulting to `Europe/Berlin`), so the purge time zone tracks scheduling again. EU deployments are unaffected because the fallback was already `Europe/Berlin`.

## Linear ticket

No ticket — follow-up cleanup from the `SURVEY_SCHEDULING_TIME_ZONE` env rename.

## How this was tested

- `pnpm vitest run modules/survey/archive/lib/process-survey-archive-purge-job.test.ts instrumentation-jobs.test.ts` ✅ (14 passed)
- Grepped the repo: no remaining references to `NEXT_PUBLIC_SURVEY_SCHEDULING_TIME_ZONE`.

## Breaking changes

None

## QA / Test Plan

Server-only cron-configuration change; no user-facing UI.

**How to test**

- [ ] Self-host with `SURVEY_SCHEDULING_TIME_ZONE` set to a non-default IANA zone (e.g. `America/New_York`) → the daily archive-purge job schedules in that zone (01:30 local), matching the scheduling job's zone.
- [ ] Leave the var unset → purge job schedules at 01:30 `Europe/Berlin` (unchanged default).
- [ ] Set an invalid zone → rejected by `apps/web/lib/env.ts` validation at boot (existing behavior, now also covers the purge job).

**Preconditions / test data**

- Self-hosted deployment able to set `SURVEY_SCHEDULING_TIME_ZONE`.

**Risks & regressions**

- Purge job now honors `SURVEY_SCHEDULING_TIME_ZONE`; any deployment that had (incorrectly) relied on the removed `NEXT_PUBLIC_` var will now correctly use the server-only var. Default behavior (`Europe/Berlin`) is unchanged.

**Migrations / env / cutover**

- none
