### PR TITLE
docs: state the minimum mobile SDK versions for interaction-based segments

### DIFF
--- a/docs/surveys/website-app-surveys/framework-guides.mdx
+++ b/docs/surveys/website-app-surveys/framework-guides.mdx
@@ -302,6 +302,10 @@ Now, visit the [Validate Your Setup](#validate-your-setup) section to verify you
 
 ## React Native
 
+<Info>
+  **Interaction-based Segments:** targeting users by whether they have seen, started or completed a survey requires **@formbricks/react-native 3.1.0** or higher. See [Survey Display Logic](/surveys/website-app-surveys/survey-display-logic#level-4-interaction-based-segments).
+</Info>
+
 Install the Formbricks React Native SDK using one of the package managers, i.e., npm, pnpm, or yarn.
 
 ```bash npm
@@ -350,13 +354,17 @@ Now, visit the [Validate Your Setup](#validate-your-setup) section to verify you
 
 <Info>**Minimum iOS Version:** The Formbricks iOS SDK requires **iOS 16.4** or higher.</Info>
 
+<Info>
+  **Interaction-based Segments:** targeting users by whether they have seen, started or completed a survey requires **FormbricksSDK 2.1.0** or higher. See [Survey Display Logic](/surveys/website-app-surveys/survey-display-logic#level-4-interaction-based-segments).
+</Info>
+
 Install the Formbricks iOS SDK using the following steps:
 
 **Swift Package Manager**
 
 1. In Xcode choose **File → Add Packages…**
 2. Enter your repo URL (e.g. `https://github.com/formbricks/ios.git`)
-3. Choose version rule (e.g. "Up to Next Major" starting at `1.0.0`).
+3. Choose version rule (e.g. "Up to Next Major" starting at `2.1.0`).
 4. Import in your code:
 
    ```swift
@@ -372,7 +380,7 @@ Install the Formbricks iOS SDK using the following steps:
    use_frameworks! :linkage => :static
 
    target 'YourTargetName' do
-     pod 'FormbricksSDK', '1.0.0 (or the latest version)'
+     pod 'FormbricksSDK', '~> 2.1'
    end
    ```
 
@@ -438,6 +446,10 @@ Now, visit the [Validate Your Setup](#validate-your-setup) section to verify you
   **Minimum Android Version:** The Formbricks Android SDK requires **Android 10 (API level 29)** or higher.
 </Info>
 
+<Info>
+  **Interaction-based Segments:** targeting users by whether they have seen, started or completed a survey requires **com.formbricks:android 2.1.0** or higher. See [Survey Display Logic](/surveys/website-app-surveys/survey-display-logic#level-4-interaction-based-segments).
+</Info>
+
 Install the Formbricks Android SDK using the following steps:
 
 ### Installation
@@ -451,7 +463,7 @@ repositories {
 }
 
 dependencies {
-    implementation("com.formbricks:android:1.0.0") // replace with latest version
+    implementation("com.formbricks:android:2.1.0") // or a later version
 }
 ```
 
@@ -508,6 +520,10 @@ Formbricks.logout()
 
 <Info>
   **Platform Support:** The Formbricks Flutter SDK targets **iOS and Android only**. Flutter Web and desktop are not supported.
+</Info>
+
+<Info>
+  **Interaction-based Segments:** targeting users by whether they have seen, started or completed a survey requires **formbricks 1.1.0** or higher. See [Survey Display Logic](/surveys/website-app-surveys/survey-display-logic#level-4-interaction-based-segments).
 </Info>
 
 Install the Formbricks Flutter SDK from [pub.dev](https://pub.dev/packages/formbricks):

--- a/docs/surveys/website-app-surveys/survey-display-logic.mdx
+++ b/docs/surveys/website-app-surveys/survey-display-logic.mdx
@@ -95,7 +95,7 @@ See [Attribute-based Targeting](/surveys/website-app-surveys/attribute-based-tar
 Interaction-based segments add a fourth Segment filter type: target users by **how they interacted with your surveys** — seen, started, or completed within a recent window. Because these look at a *specific* survey's own displays and responses, they do what the shared Cooldown Period clock cannot.
 
 <Info>
-  **Mobile apps need iOS 2.1.0, Android 2.1.0, React Native 3.1.0 or Flutter 1.1.0.** Older SDKs target the wrong people here, silently — see the warning at the end of this section. Web has no minimum.
+  **Mobile apps need a recent Formbricks SDK** — `FormbricksSDK` 2.1.0 on iOS, `com.formbricks:android` 2.1.0, `@formbricks/react-native` 3.1.0, or `formbricks` 1.1.0 on Flutter. Older SDKs target the wrong people here, silently — see the warning at the end of this section. Web has no minimum.
 </Info>
 
 A filter reads as one sentence:
@@ -139,11 +139,11 @@ flowchart LR
 - **Re-engage drop-offs:** `have started responding to Onboarding AND have not completed Onboarding within 14 days`.
 
 <Note>
-  **Interaction membership refreshes on sync, not instantly.** Recontact and the Cooldown Period react the moment a survey is shown; interaction-segment membership is recalculated when the user's data syncs (on load, when you set a user ID or attributes, and after the user interacts with a survey). This lag is irrelevant for long windows like the 3-month cadence above — the short Cooldown Period guard covers it — but don't rely on interaction filters for *instant* re-display suppression, and don't pair one with *Show only once*, which already blocks re-display permanently.
+  **Interaction membership refreshes on sync, not instantly.** Recontact and the Cooldown Period react the moment a survey is shown; interaction-segment membership is recalculated when the user's data syncs — on load, when you set a user ID or attributes, and after a survey is displayed, answered or completed. On a supported SDK version that lag is irrelevant for long windows like the 3-month cadence above, since the short Cooldown Period guard covers it — but don't rely on interaction filters for *instant* re-display suppression, and don't pair one with *Show only once*, which already blocks re-display permanently.
 </Note>
 
 <Warning>
-  **On mobile, this needs a recent SDK.** The post-interaction refresh only exists from **iOS 2.1.0**, **Android 2.1.0**, **React Native 3.1.0** and **Flutter 1.1.0**. Older versions keep the segment list they received when the app started, so interaction filters go stale for the whole session: a survey can keep appearing after the user has already seen or completed it, and one that just became eligible won't appear until the app is relaunched. Nothing errors — the targeting is simply wrong. See the [Framework Guides](/surveys/website-app-surveys/framework-guides) for the version each SDK needs.
+  **On mobile, this needs a recent SDK.** The post-interaction refresh only exists from `FormbricksSDK` **2.1.0** (iOS), `com.formbricks:android` **2.1.0**, `@formbricks/react-native` **3.1.0** and `formbricks` **1.1.0** (Flutter). Older versions keep the segment list they received when the app started, so interaction filters go stale for the whole session: a survey can keep appearing after the user has already seen or completed it, and one that just became eligible won't appear until the app is relaunched. A short Cooldown Period does not compensate — it expires while the membership is still stale. Nothing errors, the targeting is simply wrong. See the [Framework Guides](/surveys/website-app-surveys/framework-guides) for each SDK's install snippet.
 </Warning>
 
 ## Putting it all together

--- a/docs/surveys/website-app-surveys/survey-display-logic.mdx
+++ b/docs/surveys/website-app-surveys/survey-display-logic.mdx
@@ -94,6 +94,10 @@ See [Attribute-based Targeting](/surveys/website-app-surveys/attribute-based-tar
 
 Interaction-based segments add a fourth Segment filter type: target users by **how they interacted with your surveys** — seen, started, or completed within a recent window. Because these look at a *specific* survey's own displays and responses, they do what the shared Cooldown Period clock cannot.
 
+<Info>
+  **Mobile apps need iOS 2.1.0, Android 2.1.0, React Native 3.1.0 or Flutter 1.1.0.** Older SDKs target the wrong people here, silently — see the warning at the end of this section. Web has no minimum.
+</Info>
+
 A filter reads as one sentence:
 
 > `<operator>` `<any survey | specific surveys>` **within** `<number>` `<days | weeks | months>`
@@ -135,8 +139,12 @@ flowchart LR
 - **Re-engage drop-offs:** `have started responding to Onboarding AND have not completed Onboarding within 14 days`.
 
 <Note>
-  **Interaction membership refreshes on sync, not instantly.** Recontact and the Cooldown Period react the moment a survey is shown; interaction-segment membership is recalculated when the user's data syncs (on load, on `identify`/`setAttributes`, and periodically). This lag is irrelevant for long windows like the 3-month cadence above — the short Cooldown Period guard covers it — but don't rely on interaction filters for *instant* re-display suppression, and don't pair one with *Show only once*, which already blocks re-display permanently.
+  **Interaction membership refreshes on sync, not instantly.** Recontact and the Cooldown Period react the moment a survey is shown; interaction-segment membership is recalculated when the user's data syncs (on load, when you set a user ID or attributes, and after the user interacts with a survey). This lag is irrelevant for long windows like the 3-month cadence above — the short Cooldown Period guard covers it — but don't rely on interaction filters for *instant* re-display suppression, and don't pair one with *Show only once*, which already blocks re-display permanently.
 </Note>
+
+<Warning>
+  **On mobile, this needs a recent SDK.** The post-interaction refresh only exists from **iOS 2.1.0**, **Android 2.1.0**, **React Native 3.1.0** and **Flutter 1.1.0**. Older versions keep the segment list they received when the app started, so interaction filters go stale for the whole session: a survey can keep appearing after the user has already seen or completed it, and one that just became eligible won't appear until the app is relaunched. Nothing errors — the targeting is simply wrong. See the [Framework Guides](/surveys/website-app-surveys/framework-guides) for the version each SDK needs.
+</Warning>
 
 ## Putting it all together
 


### PR DESCRIPTION
Interaction-based segments ([Level 4](/surveys/website-app-surveys/survey-display-logic#level-4-interaction-based-segments)) need the SDK to refetch user state right after a display, response or finish. The mobile SDKs only gained that in the releases that just went out:

| SDK | Minimum version |
| --- | --- |
| iOS — `FormbricksSDK` | **2.1.0** |
| Android — `com.formbricks:android` | **2.1.0** |
| React Native — `@formbricks/react-native` | **3.1.0** |
| Flutter — `formbricks` | **1.1.0** |

Below those versions nothing errors. The SDK keeps the segment list it received when the app started, so for the rest of the session a survey can keep appearing after the user has already seen or completed it, and one that just became eligible won't appear until the app is relaunched. The targeting is simply wrong, quietly — which is exactly the kind of thing a reader has no way to guess.

## What changed

**`survey-display-logic.mdx`**

- An up-front `<Info>` under the Level 4 intro, for readers who only skim the operator table and never reach the bottom of the section.
- A `<Warning>` next to the existing sync note, spelling out what actually goes wrong on an old SDK.
- **Corrected the existing sync note.** It said membership is recalculated "on load, on `identify`/`setAttributes`, and periodically". That "periodically" is precisely what the old mobile SDKs do not do, so the sentence read as universally true while being wrong for them. It also used JS-only method names on a page that covers every platform. Reworded to describe when a refresh happens without promising a periodic one.

**`framework-guides.mdx`**

- A version `<Info>` in each of the four mobile sections, following the existing `**Minimum iOS Version:**` / `**Minimum Android Version:**` pattern already on that page. React Native had no callout of any kind before this.

## Also: the install snippets were pinning 1.0.0

Worth calling out separately, because it made the docs actively harmful for this feature — anyone copying them landed *below* the version it needs, straight into the silent-misbehaviour case above.

| Line | Before | After |
| --- | --- | --- |
| iOS SPM | ``starting at `1.0.0` `` | ``starting at `2.1.0` `` |
| iOS CocoaPods | `pod 'FormbricksSDK', '1.0.0 (or the latest version)'` | `pod 'FormbricksSDK', '~> 2.1'` |
| Android | `implementation("com.formbricks:android:1.0.0")` | `implementation("com.formbricks:android:2.1.0")` |

The CocoaPods line was not valid Podfile syntax either — `'1.0.0 (or the latest version)'` is a single version string with prose inside it, so it would not have resolved. `~> 2.1` expresses the "or later, same major" intent properly.

React Native and Flutter pin nothing (`npm install @formbricks/react-native`, `flutter pub add formbricks`), which is fine — those resolve to latest.

## Notes for reviewers

1. **No new page.** The feature is already documented; this adds the platform caveat to the pages that describe it. `framework-guides.mdx` is the only page documenting the mobile SDKs — they're anchor sections there, not standalone pages.
2. **Callout choice follows the repo.** `<Info>` for the requirement, `<Warning>` for the consequence — matching how this repo already uses them (`<Note>` 198 uses, `<Info>` 79, `<Warning>` 39, `<Tip>` 8, `<Check>` 0, so `<Check>` deliberately avoided).
3. **The SDK list is maintained by hand and drifts.** Existing mobile caveats in `spam-protection.mdx` and `hidden-fields.mdx` still omit Flutter entirely, from before it existed. Not fixed here — separate concern — but worth a look at some point.
4. **Out of scope, but spotted:** `framework-guides.mdx` says the iOS SDK needs **iOS 16.4**, while the podspec declares `s.platform = :ios, "16.6"` and `Package.swift` declares `.iOS(.v16)`. Three different numbers. Someone who knows the intended floor should reconcile them.
