### PR TITLE
fix: prevent duplicate otel log export (backport release/5.3)

### DIFF
--- a/apps/web/instrumentation-node-config.test.ts
+++ b/apps/web/instrumentation-node-config.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+import { nodeAutoInstrumentationConfig } from "./instrumentation-node-config";
+
+describe("nodeAutoInstrumentationConfig", () => {
+  test("leaves Pino log export to the OTEL_LOGS_ENABLED transport", () => {
+    expect(nodeAutoInstrumentationConfig["@opentelemetry/instrumentation-pino"]).toMatchObject({
+      disableLogSending: true,
+    });
+  });
+
+  test.each(["/health", "/metrics", "/metrics/runtime", "/api/v2/health"])(
+    "ignores the %s endpoint",
+    (url) => {
+      const config = nodeAutoInstrumentationConfig["@opentelemetry/instrumentation-http"];
+      expect(config?.ignoreIncomingRequestHook?.({ url } as never)).toBe(true);
+    }
+  );
+
+  test("instruments application routes", () => {
+    const config = nodeAutoInstrumentationConfig["@opentelemetry/instrumentation-http"];
+    expect(config?.ignoreIncomingRequestHook?.({ url: "/auth/login" } as never)).toBe(false);
+  });
+});

--- a/apps/web/instrumentation-node-config.test.ts
+++ b/apps/web/instrumentation-node-config.test.ts
@@ -8,16 +8,21 @@ describe("nodeAutoInstrumentationConfig", () => {
     });
   });
 
-  test.each(["/health", "/metrics", "/metrics/runtime", "/api/v2/health"])(
-    "ignores the %s endpoint",
-    (url) => {
-      const config = nodeAutoInstrumentationConfig["@opentelemetry/instrumentation-http"];
-      expect(config?.ignoreIncomingRequestHook?.({ url } as never)).toBe(true);
-    }
-  );
-
-  test("instruments application routes", () => {
+  test.each([
+    "/health",
+    "/health?probe=1",
+    "/metrics",
+    "/metrics?format=prometheus",
+    "/metrics/runtime",
+    "/api/v2/health",
+    "/api/v2/health?probe=1",
+  ])("ignores the %s endpoint", (url) => {
     const config = nodeAutoInstrumentationConfig["@opentelemetry/instrumentation-http"];
-    expect(config?.ignoreIncomingRequestHook?.({ url: "/auth/login" } as never)).toBe(false);
+    expect(config?.ignoreIncomingRequestHook?.({ url } as never)).toBe(true);
+  });
+
+  test.each(["/auth/login", "/metrics-dashboard"])("instruments the %s route", (url) => {
+    const config = nodeAutoInstrumentationConfig["@opentelemetry/instrumentation-http"];
+    expect(config?.ignoreIncomingRequestHook?.({ url } as never)).toBe(false);
   });
 });

--- a/apps/web/instrumentation-node-config.ts
+++ b/apps/web/instrumentation-node-config.ts
@@ -1,0 +1,30 @@
+import { type InstrumentationConfigMap } from "@opentelemetry/auto-instrumentations-node";
+
+export const nodeAutoInstrumentationConfig: InstrumentationConfigMap = {
+  "@opentelemetry/instrumentation-fs": {
+    enabled: false,
+  },
+  "@opentelemetry/instrumentation-dns": {
+    enabled: false,
+  },
+  "@opentelemetry/instrumentation-net": {
+    enabled: false,
+  },
+  // PrismaInstrumentation handles database tracing.
+  "@opentelemetry/instrumentation-pg": {
+    enabled: false,
+  },
+  "@opentelemetry/instrumentation-http": {
+    ignoreIncomingRequestHook: (req) => {
+      const url = req.url || "";
+      return url === "/health" || url.startsWith("/metrics") || url === "/api/v2/health";
+    },
+  },
+  "@opentelemetry/instrumentation-pino": {
+    // The dedicated Pino transport is gated by OTEL_LOGS_ENABLED and owns log export.
+    disableLogSending: true,
+  },
+  "@opentelemetry/instrumentation-runtime-node": {
+    enabled: true,
+  },
+};

--- a/apps/web/instrumentation-node-config.ts
+++ b/apps/web/instrumentation-node-config.ts
@@ -16,8 +16,13 @@ export const nodeAutoInstrumentationConfig: InstrumentationConfigMap = {
   },
   "@opentelemetry/instrumentation-http": {
     ignoreIncomingRequestHook: (req) => {
-      const url = req.url || "";
-      return url === "/health" || url.startsWith("/metrics") || url === "/api/v2/health";
+      const pathname = new URL(req.url || "/", "http://localhost").pathname;
+      return (
+        pathname === "/health" ||
+        pathname === "/api/v2/health" ||
+        pathname === "/metrics" ||
+        pathname.startsWith("/metrics/")
+      );
     },
   },
   "@opentelemetry/instrumentation-pino": {

--- a/apps/web/instrumentation-node.ts
+++ b/apps/web/instrumentation-node.ts
@@ -18,6 +18,7 @@ import {
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from "@opentelemetry/semantic-conventions";
 import { PrismaInstrumentation } from "@prisma/instrumentation";
 import { logger } from "@formbricks/logger";
+import { nodeAutoInstrumentationConfig } from "./instrumentation-node-config";
 
 // --- Configuration from environment ---
 const serviceName = process.env.OTEL_SERVICE_NAME || "formbricks";
@@ -140,33 +141,7 @@ const sdk = new NodeSDK({
     : [],
   metricReaders: metricReaders.length > 0 ? metricReaders : undefined,
   instrumentations: [
-    getNodeAutoInstrumentations({
-      // Disable noisy/unnecessary instrumentations
-      "@opentelemetry/instrumentation-fs": {
-        enabled: false,
-      },
-      "@opentelemetry/instrumentation-dns": {
-        enabled: false,
-      },
-      "@opentelemetry/instrumentation-net": {
-        enabled: false,
-      },
-      // Disable pg instrumentation - PrismaInstrumentation handles DB tracing
-      "@opentelemetry/instrumentation-pg": {
-        enabled: false,
-      },
-      "@opentelemetry/instrumentation-http": {
-        // Ignore health/metrics endpoints to reduce noise
-        ignoreIncomingRequestHook: (req) => {
-          const url = req.url || "";
-          return url === "/health" || url.startsWith("/metrics") || url === "/api/v2/health";
-        },
-      },
-      // Enable runtime metrics for Node.js process monitoring
-      "@opentelemetry/instrumentation-runtime-node": {
-        enabled: true,
-      },
-    }),
+    getNodeAutoInstrumentations(nodeAutoInstrumentationConfig),
     // Prisma instrumentation for database query tracing
     new PrismaInstrumentation(),
   ],

--- a/apps/web/vite.config.mts
+++ b/apps/web/vite.config.mts
@@ -47,6 +47,7 @@ export default defineConfig({
         "modules/**/*.ts",
         "lib/**/*.ts",
         "lingodotdev/**/*.ts",
+        "instrumentation-node-config.ts",
         "instrumentation-jobs.ts",
         "proxy.ts",
       ],

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -13,6 +13,7 @@ const originalOtelLogsEnabled = process.env.OTEL_LOGS_ENABLED;
 const originalOtelServiceName = process.env.OTEL_SERVICE_NAME;
 const originalNpmPackageVersion = process.env.npm_package_version;
 const originalEnvironment = process.env.ENVIRONMENT;
+const processHandlersAttachedKey = Symbol.for("@formbricks/logger/process-handlers-attached");
 
 const restoreEnv = (key: string, value: string | undefined): void => {
   if (value === undefined) {
@@ -109,6 +110,7 @@ describe("Logger", () => {
     delete process.env.OTEL_SERVICE_NAME;
     delete process.env.npm_package_version;
     delete process.env.ENVIRONMENT;
+    Reflect.deleteProperty(process, processHandlersAttachedKey);
   });
 
   afterEach(() => {
@@ -120,6 +122,7 @@ describe("Logger", () => {
     restoreEnv("OTEL_SERVICE_NAME", originalOtelServiceName);
     restoreEnv("npm_package_version", originalNpmPackageVersion);
     restoreEnv("ENVIRONMENT", originalEnvironment);
+    Reflect.deleteProperty(process, processHandlersAttachedKey);
   });
 
   test("logger is created with development config when NODE_ENV is not production", async () => {
@@ -350,6 +353,20 @@ describe("Logger", () => {
     expect(processSpy).toHaveBeenCalledWith("unhandledRejection", expect.any(Function));
     expect(processSpy).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
     expect(processSpy).toHaveBeenCalledWith("SIGINT", expect.any(Function));
+
+    processSpy.mockRestore();
+  });
+
+  test("process handlers are attached only once across bundled logger instances", async () => {
+    const processSpy = vi.spyOn(process, "on");
+    processSpy.mockImplementation(() => process);
+    process.env.NEXT_RUNTIME = "nodejs";
+
+    await import("./logger");
+    vi.resetModules();
+    await import("./logger");
+
+    expect(processSpy).toHaveBeenCalledTimes(4);
 
     processSpy.mockRestore();
   });

--- a/packages/logger/src/logger.test.ts
+++ b/packages/logger/src/logger.test.ts
@@ -371,6 +371,41 @@ describe("Logger", () => {
     processSpy.mockRestore();
   });
 
+  test("removes partially attached process handlers before retrying registration", async () => {
+    const registrationError = new Error("registration failed");
+    let registrationCount = 0;
+    const processOnSpy = vi.spyOn(process, "on");
+    const processOffSpy = vi.spyOn(process, "off");
+    processOnSpy.mockImplementation(() => {
+      registrationCount += 1;
+      if (registrationCount === 3) throw registrationError;
+      return process;
+    });
+    processOffSpy.mockImplementation(() => process);
+    process.env.NEXT_RUNTIME = "nodejs";
+
+    await import("./logger");
+    expect(processOffSpy).toHaveBeenCalledTimes(2);
+    expect(processOffSpy).toHaveBeenCalledWith("unhandledRejection", expect.any(Function));
+    expect(processOffSpy).toHaveBeenCalledWith("uncaughtException", expect.any(Function));
+    expect(
+      (process as typeof process & { [key: symbol]: boolean | undefined })[processHandlersAttachedKey]
+    ).toBe(undefined);
+
+    processOnSpy.mockClear();
+    processOnSpy.mockImplementation(() => process);
+    processOffSpy.mockClear();
+    vi.resetModules();
+
+    await import("./logger");
+
+    expect(processOnSpy).toHaveBeenCalledTimes(4);
+    expect(processOffSpy).not.toHaveBeenCalled();
+
+    processOnSpy.mockRestore();
+    processOffSpy.mockRestore();
+  });
+
   test("process handlers are not attached outside Node.js environment", async () => {
     const processSpy = vi.spyOn(process, "on");
     processSpy.mockImplementation(() => process); // Return process for chaining

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -198,20 +198,23 @@ const attachNodeProcessHandlers = (): void => {
   if (nodeProcess[PROCESS_HANDLERS_ATTACHED_KEY]) return;
 
   nodeProcess[PROCESS_HANDLERS_ATTACHED_KEY] = true;
+  const removeAttachedHandlers: Array<() => void> = [];
+  const handleUncaughtException = (err: Error): void => handleShutdown("uncaughtException", err);
+  const handleUnhandledRejection = (err: unknown): void => handleShutdown("unhandledRejection", err as Error);
+  const handleSigterm = (): void => handleShutdown("SIGTERM");
+  const handleSigint = (): void => handleShutdown("SIGINT");
+
   try {
-    process.on("uncaughtException", (err) => {
-      handleShutdown("uncaughtException", err);
-    });
-    process.on("unhandledRejection", (err) => {
-      handleShutdown("unhandledRejection", err as Error);
-    });
-    process.on("SIGTERM", () => {
-      handleShutdown("SIGTERM");
-    });
-    process.on("SIGINT", () => {
-      handleShutdown("SIGINT");
-    });
+    process.on("uncaughtException", handleUncaughtException);
+    removeAttachedHandlers.push(() => process.off("uncaughtException", handleUncaughtException));
+    process.on("unhandledRejection", handleUnhandledRejection);
+    removeAttachedHandlers.push(() => process.off("unhandledRejection", handleUnhandledRejection));
+    process.on("SIGTERM", handleSigterm);
+    removeAttachedHandlers.push(() => process.off("SIGTERM", handleSigterm));
+    process.on("SIGINT", handleSigint);
+    removeAttachedHandlers.push(() => process.off("SIGINT", handleSigint));
   } catch (error) {
+    removeAttachedHandlers.reverse().forEach((removeHandler) => removeHandler());
     Reflect.deleteProperty(nodeProcess, PROCESS_HANDLERS_ATTACHED_KEY);
     throw error;
   }

--- a/packages/logger/src/logger.ts
+++ b/packages/logger/src/logger.ts
@@ -4,6 +4,7 @@ import { type TLogLevel, ZLogLevel } from "../types/logger";
 const IS_PRODUCTION = !process.env.NODE_ENV || process.env.NODE_ENV === "production";
 const IS_BUILD = process.env.NEXT_PHASE === "phase-production-build";
 const PROCESS_GLOBAL_KEY = "process";
+const PROCESS_HANDLERS_ATTACHED_KEY = Symbol.for("@formbricks/logger/process-handlers-attached");
 const NEXT_STANDALONE_APP_DIR_PATTERN = /[/\\]apps[/\\]web$/;
 const OTEL_TRANSPORT_PACKAGE_PATH =
   "node_modules/pino-opentelemetry-transport/lib/pino-opentelemetry-transport.js";
@@ -190,8 +191,14 @@ const handleShutdown = (event: string, err?: Error): void => {
 
 // Create a separate function for attaching Node.js process handlers
 const attachNodeProcessHandlers = (): void => {
-  // Only attach handlers if we're in a Node.js environment with full process support
-  if (process.env.NEXT_RUNTIME === "nodejs") {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  // Next.js can evaluate bundled copies of this module in one process.
+  const nodeProcess = process as typeof process & { [key: symbol]: boolean | undefined };
+  if (nodeProcess[PROCESS_HANDLERS_ATTACHED_KEY]) return;
+
+  nodeProcess[PROCESS_HANDLERS_ATTACHED_KEY] = true;
+  try {
     process.on("uncaughtException", (err) => {
       handleShutdown("uncaughtException", err);
     });
@@ -204,6 +211,9 @@ const attachNodeProcessHandlers = (): void => {
     process.on("SIGINT", () => {
       handleShutdown("SIGINT");
     });
+  } catch (error) {
+    Reflect.deleteProperty(nodeProcess, PROCESS_HANDLERS_ATTACHED_KEY);
+    throw error;
   }
 };
 


### PR DESCRIPTION
Backport of #8770 for the 5.3 production release line.

## What & why

Production canary validation found that setting `OTEL_EXPORTER_OTLP_ENDPOINT` exported Pino logs through auto-instrumentation even when `OTEL_LOGS_ENABLED=0`. Enabling the dedicated Pino transport then duplicated those logs. Bundled logger instances also accumulated process signal/error handlers and emitted `MaxListenersExceededWarning`.

This keeps Pino trace-context injection while disabling its automatic log sending, leaves log export exclusively to the transport gated by `OTEL_LOGS_ENABLED`, and makes process-handler registration idempotent with rollback after partial registration failure.

## Linear ticket

No Linear ticket; this follows up directly on the production OTEL rollout incident.

## How this was tested

- `pnpm --filter @formbricks/logger exec vitest run src/logger.test.ts` - 16 tests passed
- `pnpm --filter @formbricks/logger typecheck` - passed
- `pnpm --filter @formbricks/logger lint` - passed
- `pnpm --filter @formbricks/web exec vitest run instrumentation-node-config.test.ts` - 10 tests passed
- targeted web coverage - 100% statements/lines/functions and 83.33% branches
- production-isolated canary - traces, metrics, and dedicated logs reached SigNoz with zero restarts and no public Service routing
- production rollout guardrail test - 95/95 public health probes returned 200

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Start with `OTEL_EXPORTER_OTLP_ENDPOINT` set and `OTEL_LOGS_ENABLED=0`, then load the login page -> traces and metrics appear in SigNoz, while Pino transport logs remain disabled.
- [ ] Set `OTEL_LOGS_ENABLED=1` and repeat the request -> each Pino event appears once through the dedicated transport.
- [ ] Exercise health URLs with query strings and `/metrics/*` -> those requests do not create spans; `/metrics-dashboard` remains instrumented.
- [ ] Restart the pod -> it terminates cleanly without `MaxListenersExceededWarning`, Pino worker exits, or missing-module errors.

**Preconditions / test data**

- SigNoz collector reachable over OTLP HTTP.
- Existing `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_LOGS_ENABLED` environment variables.

**Risks & regressions**

- Pino trace-context injection must remain active.
- Logger shutdown handlers must attach once and still flush on process termination.
- OTEL transport startup and shutdown must not affect web readiness.

**Migrations / env / cutover**

- none
