### PR TITLE
fix(segments): bound caller-controlled surveyIds before the Prisma IN query

### DIFF
--- a/apps/web/modules/ee/contacts/segments/lib/segment-schema.test.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/segment-schema.test.ts
@@ -1,6 +1,7 @@
 import { createId } from "@paralleldrive/cuid2";
 import { describe, expect, test } from "vitest";
 import {
+  MAX_SEGMENT_SURVEYS,
   type TBaseFilters,
   type TSurveyInteractionOperator,
   ZSegmentCreateInput,
@@ -87,6 +88,38 @@ describe("segment schema validation", () => {
   test("accepts segment updates with a valid filter", () => {
     const result = ZSegmentUpdateInput.safeParse({
       filters: validFilters,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts a linked survey list at the cap", () => {
+    const result = ZSegmentUpdateInput.safeParse({
+      surveys: Array.from({ length: MAX_SEGMENT_SURVEYS }, () => createId()),
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a linked survey list over the cap", () => {
+    const result = ZSegmentUpdateInput.safeParse({
+      surveys: Array.from({ length: MAX_SEGMENT_SURVEYS + 1 }, () => createId()),
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects a linked survey id that is not a valid id", () => {
+    const result = ZSegmentUpdateInput.safeParse({
+      surveys: ["not-a-valid-id"],
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts an empty linked survey list", () => {
+    const result = ZSegmentUpdateInput.safeParse({
+      surveys: [],
     });
 
     expect(result.success).toBe(true);

--- a/apps/web/modules/ee/contacts/segments/lib/segments.test.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/segments.test.ts
@@ -198,6 +198,43 @@ describe("Segment Service Tests", () => {
 
       expect(result.size).toBe(0);
     });
+
+    test("short-circuits to an empty map without querying when no ids are given", async () => {
+      const result = await getSurveyWorkspaceIdMap([]);
+
+      expect(result.size).toBe(0);
+      expect(prisma.survey.findMany).not.toHaveBeenCalled();
+    });
+
+    test("deduplicates ids before querying", async () => {
+      vi.mocked(prisma.survey.findMany).mockResolvedValue([{ id: "survey1", workspaceId: "ws-a" }] as any);
+
+      const result = await getSurveyWorkspaceIdMap(["survey1", "survey1", "survey1"]);
+
+      expect(result).toEqual(new Map([["survey1", "ws-a"]]));
+      expect(prisma.survey.findMany).toHaveBeenCalledTimes(1);
+      expect(prisma.survey.findMany).toHaveBeenCalledWith({
+        where: { id: { in: ["survey1"] } },
+        select: { id: true, workspaceId: true },
+      });
+    });
+
+    test("splits an oversized id list into bounded batches and merges the results", async () => {
+      const surveyIds = Array.from({ length: 450 }, (_, index) => `survey_${index}`);
+      vi.mocked(prisma.survey.findMany).mockImplementation((async ({ where }: any) =>
+        where.id.in.map((id: string) => ({ id, workspaceId: "ws-a" }))) as any);
+
+      const result = await getSurveyWorkspaceIdMap(surveyIds);
+
+      // 450 ids at a batch size of 200 -> 200 / 200 / 50, every id still present in the merged map.
+      const batchSizes = vi
+        .mocked(prisma.survey.findMany)
+        .mock.calls.map(([args]: any) => args.where.id.in.length);
+      expect(batchSizes).toEqual([200, 200, 50]);
+      expect(result.size).toBe(450);
+      expect(result.get("survey_0")).toBe("ws-a");
+      expect(result.get("survey_449")).toBe("ws-a");
+    });
   });
 
   describe("getExistingWorkspaceSurveyIds", () => {

--- a/apps/web/modules/ee/contacts/segments/lib/segments.ts
+++ b/apps/web/modules/ee/contacts/segments/lib/segments.ts
@@ -415,17 +415,43 @@ export const resetSegmentInSurvey = async (surveyId: string): Promise<TSegment> 
   }
 };
 
-// Batched lookup of the owning workspace for a set of surveys, used to keep segment↔survey links
-// within one workspace (ENG-1920). A single query avoids fanning out one lookup per survey id over
-// a caller-controlled, unbounded array. Missing ids are simply absent from the map.
+// Upper bound on ids per `IN (...)` lookup below. ZSegment/ZSegmentUpdateInput already cap what a
+// client can submit (MAX_SEGMENT_SURVEYS), but this helper is also reached with ids read back from
+// the database (updateSurveyInternal's skipValidation path, rows persisted before the cap existed),
+// so it bounds the query itself instead of trusting the caller's array length.
+const SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE = 200;
+
+/**
+ * Batched lookup of the owning workspace for a set of surveys, used to keep segment↔survey links
+ * within one workspace (ENG-1920). Ids are deduplicated and queried in bounded batches — one query
+ * per batch rather than one per id, so the non-N+1 shape is preserved without letting a
+ * caller-controlled array size the SQL parameter payload (ENG-2004). Batches run sequentially: the
+ * point is to cap concurrent database work, not to fan it out. Missing ids are simply absent from
+ * the returned map.
+ */
 export const getSurveyWorkspaceIdMap = reactCache(
   async (surveyIds: string[]): Promise<Map<string, string>> => {
+    const uniqueSurveyIds = Array.from(new Set(surveyIds));
+    const workspaceIdBySurveyId = new Map<string, string>();
+
+    if (uniqueSurveyIds.length === 0) {
+      return workspaceIdBySurveyId;
+    }
+
     try {
-      const surveys = await prisma.survey.findMany({
-        where: { id: { in: surveyIds } },
-        select: { id: true, workspaceId: true },
-      });
-      return new Map(surveys.map((survey) => [survey.id, survey.workspaceId]));
+      for (let i = 0; i < uniqueSurveyIds.length; i += SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE) {
+        const batch = uniqueSurveyIds.slice(i, i + SURVEY_WORKSPACE_LOOKUP_BATCH_SIZE);
+        const surveys = await prisma.survey.findMany({
+          where: { id: { in: batch } },
+          select: { id: true, workspaceId: true },
+        });
+
+        for (const survey of surveys) {
+          workspaceIdBySurveyId.set(survey.id, survey.workspaceId);
+        }
+      }
+
+      return workspaceIdBySurveyId;
     } catch (error) {
       if (error instanceof Prisma.PrismaClientKnownRequestError) {
         throw new DatabaseError(error.message);

--- a/packages/types/segment.ts
+++ b/packages/types/segment.ts
@@ -414,6 +414,19 @@ const ZRequiredSegmentFilters = ZSegmentFilters.refine((filters) => filters.leng
   error: "At least one filter is required",
 });
 
+/**
+ * Maximum number of surveys a single segment may be linked to. The links are supplied by the client
+ * (segment update, and the nested segment on a survey update) and land in a Prisma `id IN (...)`
+ * lookup, so the array has to be bounded: an unbounded one is a cheap authenticated way to blow up
+ * the SQL parameter payload. A saved segment reused by this many surveys is already far past any
+ * shape the product produces.
+ */
+export const MAX_SEGMENT_SURVEYS = 500;
+
+// `ZId` (cuid2) also keeps non-id junk from reaching the database. Ownership is still enforced at
+// write time — every id must resolve to a survey in the segment's workspace (ENG-1749/ENG-1920).
+const ZSegmentSurveyIds = z.array(ZId).max(MAX_SEGMENT_SURVEYS);
+
 export const ZSegment = z.object({
   id: z.string(),
   title: z.string(),
@@ -423,7 +436,7 @@ export const ZSegment = z.object({
   workspaceId: ZId,
   createdAt: z.date(),
   updatedAt: z.date(),
-  surveys: z.array(z.string()),
+  surveys: ZSegmentSurveyIds,
 });
 
 // Minimal segment shape for the public client API — strips sensitive targeting logic
@@ -555,7 +568,7 @@ export const ZSegmentUpdateInput = z
     description: z.string().nullable(),
     isPrivate: z.boolean().prefault(true),
     filters: ZRequiredSegmentFilters,
-    surveys: z.array(z.string()),
+    surveys: ZSegmentSurveyIds,
   })
   .partial();
 


### PR DESCRIPTION
## What & why

The segment `surveys` array is caller-controlled and was unbounded. `ZSegment.surveys` and `ZSegmentUpdateInput.surveys` were both `z.array(z.string())` — no length cap, no ID-format check, no dedupe — and that array is passed straight into `prisma.survey.findMany({ where: { id: { in: surveyIds } } })` by `getSurveyWorkspaceIdMap`. An authenticated user could submit a segment update carrying tens of thousands of entries and blow up the SQL parameter payload: extra DB memory and CPU per request, i.e. a cheap authenticated DoS lever. Follow-up on the workspace-scoping work in #8596 (ENG-1749 / ENG-1920), found by CodeRabbit on #8615.

Fixed in two layers:

**1. Zod boundary (`packages/types/segment.ts`).** New exported `MAX_SEGMENT_SURVEYS = 500` and a shared `z.array(ZId).max(MAX_SEGMENT_SURVEYS)`, applied to both `ZSegment.surveys` (covers the nested segment on a survey update, via `updateSurveyInternal`'s `validateInputs([updatedSurvey, ZSurvey])`) and `ZSegmentUpdateInput.surveys` (covers `updateSegmentAction` and the `updateSegment` service). `ZId` (cuid2) also stops non-id junk before it reaches the database.

On the cap value: the existing `ZSegmentSurveyInteractionFilterValue.surveyIds` uses `.max(100)`, but that is a user explicitly picking surveys in one filter UI. Segment↔survey links accumulate on their own as surveys reuse a saved segment, so there is more drift risk there; 500 still bounds the parameter payload hard while leaving no realistic chance of blocking a large workspace from saving.

**2. Defensive helper (`getSurveyWorkspaceIdMap`).** Dedupes via a `Set`, short-circuits on an empty list without querying, and runs the lookup in bounded batches of 200 merged into a single `Map`. Batches are **sequential** on purpose — the goal is capping concurrent DB work, not fanning it out. The single-query-per-batch (non-N+1) shape is preserved, and missing ids are still simply absent from the map. This layer matters because the helper is also reached with ids read back from the database (`updateSurveyInternal`'s `skipValidation` path, plus rows persisted before the cap existed) which never pass the Zod boundary.

Not changed: `assertSurveyInteractionSurveyIds` / `getExistingWorkspaceSurveyIds` have the same unbounded-`IN` shape reachable from the same action (`ZSegmentFilters` is an unbounded array and each `surveyInteraction` filter carries up to 100 ids, deduped but not capped). Out of this ticket's scope — flagging it for a separate follow-up.

## Linear ticket

https://linear.app/formbricks/issue/ENG-2004/segments-bound-caller-controlled-surveyids-before-building-the-prisma

## How this was tested

- `pnpm test` for `apps/web` ✅ — 591 files, 7633 tests passed. One flake in `scripts/typegen.test.ts` (5s timeout on a `spawnSync pnpm typegen` under parallel load); passes standalone, unrelated to this diff.
- `pnpm turbo run test --filter='!@formbricks/web'` ✅ — 16/16 tasks green (`@formbricks/surveys` 665 tests, `@formbricks/js-core` 288 tests, etc.).
- `pnpm turbo run typecheck --filter=@formbricks/types --filter=@formbricks/web` ✅.
- ESLint + Prettier clean on all changed files (also via the lint-staged pre-commit hook).
- Tests added — `segment-schema.test.ts`: list at the cap accepted, over the cap rejected, non-cuid id rejected, empty list accepted.
- Tests added — `segments.test.ts`: empty input returns an empty map without querying; duplicate ids collapse to a single query; 450 ids split into batches of `[200, 200, 50]` with all 450 entries present in the merged map.
- No UI change, so no screenshots.

## Breaking changes

None

The cap is new validation on an input, but 500 linked surveys per segment is far beyond any shape the product produces, and `surveys` is not accepted by any public API route (the v3 survey targeting schema takes `filters` only). Existing rows are unaffected — reads are not Zod-parsed.

## QA / Test Plan

**How to test**

- [ ] Contact targeting requires an Enterprise entitlement. In a workspace with it enabled, go to **Contacts → Segments**, create a segment with at least one filter, and save → segment saves normally.
- [ ] Open an **app** survey → **Settings → Survey Trigger / Audience**, attach that saved segment, and save the survey → saves normally, and the segment shows the survey under its linked surveys.
- [ ] Attach the same saved segment to a few more app surveys and save each → all links persist, no errors.
- [ ] Edit the segment's filters (add/remove a condition) and save → saves normally; the previously linked surveys stay linked.
- [ ] Delete a survey that used the segment → segment survives, and the link disappears.
- [ ] Negative / boundary (needs an API client or devtools, not reachable through the UI): call the `updateSegment` server action with a `surveys` array of 501 valid survey ids → the request is rejected with a validation error and nothing is persisted. With 500 valid ids it is accepted. **Please verify the 500 boundary manually** — the number is a product cap chosen in this PR, not an existing constraint.
- [ ] Negative (same path): send `surveys: ["not-a-valid-id"]` → rejected with a validation error, not a database error.
- [ ] Cross-tenant guard still holds: send a `surveys` array containing a survey id from a different workspace → rejected with "Survey and segment are not in the same workspace". This is the ENG-1920 behavior and must not regress.

**Preconditions / test data**

- An organization with the advanced targeting / contact-targeting entitlement (Enterprise). Without it the segment UI is gated and none of the above applies.
- At least two workspaces with app surveys, so the cross-tenant rejection case can be exercised.
- Works the same on Cloud and self-host; no feature flag.

**Risks & regressions**

- Segment save and survey save are the two write paths that carry `surveys`. Both now validate id format and list length, so the main risk is a legitimate save being rejected. Re-check: saving a segment from the UI, saving an app survey that has a segment attached, and the survey editor's client-side `ZSurvey` validation (the editor blocks the save button on a parse failure).
- `getSurveyWorkspaceIdMap` now issues more than one query when given over 200 ids. Re-check that the cross-workspace rejection (ENG-1920) still fires for a foreign survey id, since that check reads this map.
- Private segments (one per app survey, created automatically) go through the same schemas — confirm creating a new app survey and toggling its targeting still works.

**Migrations / env / cutover**

- none
