### PR TITLE
chore(vendor): document the vendored xlsx tarball (ENG-1684)

### DIFF
--- a/apps/web/vendor/README.md
+++ b/apps/web/vendor/README.md
@@ -1,0 +1,21 @@
+# Vendored dependencies
+
+Third-party packages that cannot be installed from the npm registry and are
+committed here as tarballs instead. Keep this directory to the minimum — a
+vendored dependency skips registry provenance and Dependabot, so every entry
+needs a reason.
+
+## `xlsx-0.20.3.tgz`
+
+SheetJS (`xlsx`) no longer publishes to npm. The registry copy is frozen on an
+old release with known security advisories; the fixed builds are distributed
+only from SheetJS's own CDN. `0.20.3` is that patched build, vendored here and
+referenced from `apps/web/package.json` as:
+
+```json
+"xlsx": "file:vendor/xlsx-0.20.3.tgz"
+```
+
+Added in #6321 (XLSX security update → SheetJS). To upgrade: download the new
+tarball from https://cdn.sheetjs.com, replace this file, and bump the version in
+both the filename and the `package.json` reference.


### PR DESCRIPTION
## What & why

`ENG-1684` (monorepo config audit) asked for three things: delete the orphaned `packages/ui`, delete the empty `vendor/minimatch-3.1.5` stub, and leave a short note explaining the one legitimately vendored tarball — with install/build staying green.

The two deletions already landed on `main` before this PR: `packages/ui` was renamed to `packages/survey-ui` (`5e20e98`), and the empty minimatch stub was removed with the vendored-minimatch cleanup (#7608). Neither path exists on `main` today, and the only vendored tarball left is `apps/web/vendor/xlsx-0.20.3.tgz`.

So this PR closes the remaining criterion: it adds `apps/web/vendor/README.md` documenting why `xlsx` is vendored (SheetJS no longer publishes `xlsx` to npm; the registry copy is frozen on a version with known advisories, and the patched build ships only from SheetJS's CDN — added in #6321). The note also records the `file:vendor/...` reference and the upgrade steps, so the entry no longer reads as an unexplained supply-chain artifact in a security review.

## Linear ticket

Fixes ENG-1684

## How this was tested

- Confirmed on `main` that both deletion criteria are already satisfied: `git ls-tree -r origin/main` shows no `packages/ui` (only `packages/survey-ui`) and no `minimatch` path anywhere; the sole `vendor/` entry is `apps/web/vendor/xlsx-0.20.3.tgz`.
- Confirmed no stale references to the removed paths in workspace/build config (`pnpm-workspace.yaml` uses `packages/*`; the only `packages/ui` hit is a cal.com URL in a code comment).
- Docs-only change (adds one `README.md`); it touches no build input, so install/build stay green — nothing in the tree changed except the new note.
- No automated tests apply to a vendor README.

## Breaking changes

None — docs only.

## QA / Test Plan

CI/repo-hygiene and documentation only. Nothing is observable in the running app or the live API, so a manual tester with no repo access has nothing to exercise. For anyone with a checkout:

**How to test**

- [ ] Open `apps/web/vendor/README.md` → it explains why `xlsx-0.20.3.tgz` is vendored and how to upgrade it.
- [ ] `git ls-files packages/ui vendor` (repo root) → no output (both already removed on `main`).
- [ ] `pnpm install` on the branch → succeeds; `xlsx` resolves from `file:vendor/xlsx-0.20.3.tgz` as before.

**Preconditions / test data**

- A local checkout with `pnpm install`. No accounts, seed data, flags, or entitlements.

**Risks & regressions**

- None. The change adds a Markdown file and removes nothing; the vendored tarball and its `package.json` reference are untouched.

**Migrations / env / cutover**

- none
