### PR TITLE
docs: clarify custom subpath storage setup

### DIFF
--- a/docs/self-hosting/configuration/custom-subpath.mdx
+++ b/docs/self-hosting/configuration/custom-subpath.mdx
@@ -19,9 +19,24 @@ assets, and sign-in redirects honor the prefix.
 ### Requirements and limitations
 
 - `BASE_PATH` must be present during `pnpm build`; changing it afterward requires a rebuild.
-- Official Formbricks Docker images do **not** accept this flag for technical reasons, so you must build your own image.
+- Next.js inlines the base path into the client bundles, so setting `BASE_PATH` on an already-built official Formbricks
+  image has no effect. You must build your own Formbricks web image with the required value.
 - All Formbricks URLs (`WEBAPP_URL`, `NEXTAUTH_URL`, webhook targets, OAuth callbacks, MCP clients, etc.) need the same prefix.
 - Your proxy must rewrite `/custom-path/*` to the Formbricks container while keeping the prefix visible to clients.
+
+### Configure object storage separately
+
+`BASE_PATH` applies only to the Formbricks web application. It does not add the same prefix to RustFS, MinIO, or
+another S3-compatible storage service, and the custom image described below is a Formbricks image—not a custom
+storage image.
+
+Keep the S3 API at the root of a dedicated endpoint such as `https://files.example.com` and set `S3_ENDPOINT_URL`
+to that endpoint. Do not route it through an arbitrary prefix such as `https://example.com/custom-path/storage`:
+the request path is part of the AWS Signature Version 4 signature, so proxy path rewriting can invalidate signed and
+presigned requests. Provider settings that expose a management console under a subpath do not change the S3 API
+base path.
+
+For the complete storage and CORS setup, see [File Uploads Configuration](/self-hosting/configuration/file-uploads).
 
 ### Configure environment variables
 

--- a/docs/self-hosting/configuration/custom-subpath.mdx
+++ b/docs/self-hosting/configuration/custom-subpath.mdx
@@ -21,7 +21,10 @@ assets, and sign-in redirects honor the prefix.
 - `BASE_PATH` must be present during `pnpm build`; changing it afterward requires a rebuild.
 - Next.js inlines the base path into the client bundles, so setting `BASE_PATH` on an already-built official Formbricks
   image has no effect. You must build your own Formbricks web image with the required value.
-- All Formbricks URLs (`WEBAPP_URL`, `NEXTAUTH_URL`, webhook targets, OAuth callbacks, MCP clients, etc.) need the same prefix.
+- Formbricks-owned public URLs need the prefix, but each variable expects a different path: `WEBAPP_URL` uses the
+  app root, while `NEXTAUTH_URL` and optional `BETTER_AUTH_URL` use the full auth endpoint under
+  `/custom-path/api/auth`. External webhook target URLs do not need the prefix unless they point to a Formbricks
+  endpoint.
 - Your proxy must rewrite `/custom-path/*` to the Formbricks container while keeping the prefix visible to clients.
 
 ### Configure object storage separately
@@ -45,12 +48,12 @@ Add the following variables to the environment you use for builds (local, CI, or
 ```bash
 BASE_PATH="/custom-path"
 WEBAPP_URL="https://yourdomain.com/custom-path"
-NEXTAUTH_URL="https://yourdomain.com/custom-path"
-BETTER_AUTH_URL="https://yourdomain.com/custom-path"
+NEXTAUTH_URL="https://yourdomain.com/custom-path/api/auth"
+BETTER_AUTH_URL="https://yourdomain.com/custom-path/api/auth"
 ```
 
-If you use email links, webhooks, or third-party OAuth providers, ensure every URL you register includes the prefix.
-MCP clients must use `https://yourdomain.com/custom-path/api/mcp`, and OAuth discovery is served from
+If you use third-party OAuth providers, ensure every Formbricks callback URL you register includes the prefix. MCP
+clients must use `https://yourdomain.com/custom-path/api/mcp`, and OAuth discovery is served from
 `https://yourdomain.com/custom-path/.well-known/oauth-authorization-server/api/auth`.
 
 ### Build a Docker image with a custom subpath

--- a/docs/self-hosting/configuration/custom-subpath.mdx
+++ b/docs/self-hosting/configuration/custom-subpath.mdx
@@ -13,8 +13,8 @@ icon: "link"
 
 Use a custom subpath (also called a Next.js base path) when your reverse proxy reserves the root domain for another
 service, but you still want Formbricks to live under the same hostname—for example `https://example.com/feedback`.
-Support for a build-time `BASE_PATH` variable is available in the Formbricks web app so that all internal routes,
-assets, and sign-in redirects honor the prefix.
+Support for a build-time `BASE_PATH` variable is available in the Formbricks web app so that Next.js-managed routes,
+assets, and navigation honor the prefix.
 
 ### Requirements and limitations
 
@@ -25,6 +25,9 @@ assets, and sign-in redirects honor the prefix.
   app root, while `NEXTAUTH_URL` and optional `BETTER_AUTH_URL` use the full auth endpoint under
   `/custom-path/api/auth`. External webhook target URLs do not need the prefix unless they point to a Formbricks
   endpoint.
+- Known limitation: the browser auth client currently sends login and sign-up requests to `/api/auth` at the domain
+  root instead of `/custom-path/api/auth`. Authentication therefore does not work for a true subpath-only deployment,
+  and changing the URL environment variables does not correct the browser request path.
 - Your proxy must rewrite `/custom-path/*` to the Formbricks container while keeping the prefix visible to clients.
 
 ### Configure object storage separately
@@ -93,17 +96,18 @@ docker build \
 
 ### Verify the deployment
 
-1. Open `https://yourdomain.com/custom-path` and complete the onboarding flow.
-2. Create a survey and preview it—embedded scripts now load assets relative to the subpath.
-3. Sign out and confirm the login page still includes `/custom-path`.
+1. Open `https://yourdomain.com/custom-path/auth/login` and confirm the page loads under the prefix.
+2. In your browser's network panel, confirm Next.js assets and navigation requests include `/custom-path`.
+3. Do not use login or onboarding as a successful deployment check until the browser auth-client limitation above is
+   fixed.
 
 ### Troubleshooting checklist
 
 - Confirm your build pipeline actually passes `BASE_PATH` (and, if needed, `WEBAPP_URL`/`NEXTAUTH_URL`) into the build
   stage—check CI logs for the `BASE PATH /your-prefix` line and make sure custom Dockerfiles or wrappers forward
   `--build-arg BASE_PATH=...` correctly.
-- If you cannot log in, double-check that `WEBAPP_URL`, `NEXTAUTH_URL`, and `BETTER_AUTH_URL` (if set)
-  include the prefix. Formbricks derives Better Auth OAuth endpoints under `/api/auth`.
+- Keep `WEBAPP_URL`, `NEXTAUTH_URL`, and `BETTER_AUTH_URL` (if set) configured as shown above for server-side callbacks
+  and discovery, but note that they do not fix the browser auth-client request path.
 - Re-run the Docker build when changing `BASE_PATH`; simply editing the container environment is not sufficient.
 - Inspect your proxy configuration to ensure it does not rewrite paths internally (e.g., `strip_prefix` needs to stay
   disabled).


### PR DESCRIPTION
## What & why

The custom-subpath guide could be read as requiring a custom RustFS or MinIO image, even though `BASE_PATH` only affects the Formbricks web build. This update clarifies that customers must build the Formbricks web image, keep the S3 API at the root of a dedicated endpoint, and avoid arbitrary proxy prefixes that can invalidate SigV4 requests. It also documents the distinct app-root and auth-endpoint URL values, distinguishes Formbricks routes from external webhook destinations, and links directly to the file-upload configuration.

The guide now also documents the current browser auth-client limitation: login and sign-up requests still target the domain-root `/api/auth` path. It no longer presents onboarding/login as a successful verification step or suggests that changing server URL variables fixes that client-side path.

## Linear ticket

No Linear ticket; this is a documentation follow-up to a self-hosting configuration discussion.

## How this was tested

- `pnpm exec prettier --check docs/self-hosting/configuration/custom-subpath.mdx` ✅
- `git diff --check` ✅
- Confirmed the linked `docs/self-hosting/configuration/file-uploads.mdx` page exists.
- Confirmed Better Auth preserves a configured server path, so auth URLs must include `/custom-path/api/auth`.
- Confirmed the unconfigured browser client resolves its auth base to `https://yourdomain.com/api/auth`, without the custom prefix.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Open the Custom Subpath documentation → the requirements identify the custom image as the Formbricks web image.
- [ ] Read the known limitation → it states that browser login/sign-up requests currently omit the custom prefix and that URL environment variables do not fix the client request path.
- [ ] Check the environment example → `WEBAPP_URL` ends at the app subpath, while `NEXTAUTH_URL` and `BETTER_AUTH_URL` use the full `/api/auth` endpoint for server-side callbacks and discovery.
- [ ] Check the URL guidance → external webhook targets are not instructed to inherit the Formbricks subpath.
- [ ] Read “Verify the deployment” → it checks prefixed pages/assets without claiming onboarding or login works.
- [ ] Read “Configure object storage separately” → the page recommends a dedicated root S3 endpoint and explains the SigV4 limitation.
- [ ] Select “File Uploads Configuration” → the file-upload configuration page opens.

**Preconditions / test data**

- Documentation preview or published documentation.

**Risks & regressions**

- Documentation-only change; verify the limitations, URL examples, internal link, and storage terminology remain accurate.

**Migrations / env / cutover**

- none