### PR TITLE
fix(security): tie the contact detail page to the workspace in the URL [ENG-2290]

### DIFF
--- a/apps/web/lib/display/service.ts
+++ b/apps/web/lib/display/service.ts
@@ -55,13 +55,21 @@ export const getDisplayCountBySurveyId = reactCache(
   }
 );
 
+/**
+ * Scoped by workspace on purpose: this feeds the contact detail page, which is reached through a
+ * workspace id in the URL. A contact id alone is not a tenant boundary, so the displays are
+ * filtered through the workspace of the contact they belong to.
+ */
 export const getDisplaysByContactId = reactCache(
-  async (contactId: string): Promise<Pick<TDisplay, "id" | "createdAt" | "surveyId">[]> => {
-    validateInputs([contactId, ZId]);
+  async (
+    contactId: string,
+    workspaceId: string
+  ): Promise<Pick<TDisplay, "id" | "createdAt" | "surveyId">[]> => {
+    validateInputs([contactId, ZId], [workspaceId, ZId]);
 
     try {
       const displays = await prisma.display.findMany({
-        where: { contactId },
+        where: { contactId, contact: { workspaceId } },
         select: {
           id: true,
           createdAt: true,

--- a/apps/web/lib/display/tests/display-queries.test.ts
+++ b/apps/web/lib/display/tests/display-queries.test.ts
@@ -127,11 +127,11 @@ describe("getDisplaysByContactId", () => {
     test("returns displays for a contact ordered by createdAt desc", async () => {
       vi.mocked(prisma.display.findMany).mockResolvedValue(mockDisplaysForContact as any);
 
-      const result = await getDisplaysByContactId(mockContactId);
+      const result = await getDisplaysByContactId(mockContactId, mockWorkspaceId);
 
       expect(result).toEqual(mockDisplaysForContact);
       expect(prisma.display.findMany).toHaveBeenCalledWith({
-        where: { contactId: mockContactId },
+        where: { contactId: mockContactId, contact: { workspaceId: mockWorkspaceId } },
         select: {
           id: true,
           createdAt: true,
@@ -144,15 +144,29 @@ describe("getDisplaysByContactId", () => {
     test("returns empty array when contact has no displays", async () => {
       vi.mocked(prisma.display.findMany).mockResolvedValue([]);
 
-      const result = await getDisplaysByContactId(mockContactId);
+      const result = await getDisplaysByContactId(mockContactId, mockWorkspaceId);
 
       expect(result).toEqual([]);
+    });
+
+    // ENG-2290: a contact id alone is not a tenant boundary. The query must join through the
+    // contact's workspace so an authorized workspace id cannot be paired with a foreign contact.
+    test("scopes the query to the workspace of the contact", async () => {
+      vi.mocked(prisma.display.findMany).mockResolvedValue([]);
+
+      await getDisplaysByContactId(mockContactId, mockWorkspaceId);
+
+      expect(prisma.display.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ contact: { workspaceId: mockWorkspaceId } }),
+        })
+      );
     });
   });
 
   describe("Sad Path", () => {
     test("throws a ValidationError if the contactId is invalid", async () => {
-      await expect(getDisplaysByContactId("not-a-cuid")).rejects.toThrow(ValidationError);
+      await expect(getDisplaysByContactId("not-a-cuid", mockWorkspaceId)).rejects.toThrow(ValidationError);
     });
 
     test("throws DatabaseError on PrismaClientKnownRequestError", async () => {
@@ -163,13 +177,13 @@ describe("getDisplaysByContactId", () => {
 
       vi.mocked(prisma.display.findMany).mockRejectedValue(errToThrow);
 
-      await expect(getDisplaysByContactId(mockContactId)).rejects.toThrow(DatabaseError);
+      await expect(getDisplaysByContactId(mockContactId, mockWorkspaceId)).rejects.toThrow(DatabaseError);
     });
 
     test("throws generic Error for other exceptions", async () => {
       vi.mocked(prisma.display.findMany).mockRejectedValue(new Error("Mock error"));
 
-      await expect(getDisplaysByContactId(mockContactId)).rejects.toThrow(Error);
+      await expect(getDisplaysByContactId(mockContactId, mockWorkspaceId)).rejects.toThrow(Error);
     });
   });
 });

--- a/apps/web/lib/response/service.ts
+++ b/apps/web/lib/response/service.ts
@@ -103,14 +103,20 @@ const mapResponsePrismaToResponse = (
   tags: responsePrisma.tags.map((tagPrisma: { tag: TTag }) => tagPrisma.tag),
 });
 
+/**
+ * Scoped by workspace on purpose: this feeds the contact detail page, which is reached through a
+ * workspace id in the URL. A contact id alone is not a tenant boundary, so the responses are
+ * filtered through the workspace of the contact they belong to.
+ */
 export const getResponsesByContactId = reactCache(
-  async (contactId: string, page?: number): Promise<TResponseWithQuotas[]> => {
-    validateInputs([contactId, ZId], [page, ZOptionalNumber]);
+  async (contactId: string, workspaceId: string, page?: number): Promise<TResponseWithQuotas[]> => {
+    validateInputs([contactId, ZId], [workspaceId, ZId], [page, ZOptionalNumber]);
 
     try {
       const responsePrisma = await prisma.response.findMany({
         where: {
           contactId,
+          contact: { workspaceId },
         },
         select: {
           ...responseSelection,

--- a/apps/web/lib/response/tests/response.test.ts
+++ b/apps/web/lib/response/tests/response.test.ts
@@ -1,6 +1,7 @@
 import {
   getMockUpdateResponseInput,
   mockContact,
+  mockContactId,
   mockDisplay,
   mockResponse,
   mockResponseData,
@@ -32,6 +33,7 @@ import {
   getResponseCountBySurveyId,
   getResponseDownloadFile,
   getResponseWithQuotas,
+  getResponsesByContactId,
   getResponsesByWorkspaceId,
   responseSelection,
   updateResponse,
@@ -533,4 +535,28 @@ describe("Tests for getResponseCountBySurveyId service", () => {
       await expect(getResponseCountBySurveyId(mockSurveyId)).rejects.toThrow(Error);
     });
   });
+});
+
+// ENG-2290: a contact id alone is not a tenant boundary. The contact detail page is reached through
+// a workspace id in the URL, so the responses it loads must be filtered through the workspace of the
+// contact they belong to — otherwise an authorized workspace id paired with a foreign contact id
+// reads that contact's answers.
+describe("getResponsesByContactId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("scopes the query to the workspace of the contact", async () => {
+    prisma.response.findMany.mockResolvedValue([]);
+
+    await getResponsesByContactId(mockContactId, mockWorkspaceId);
+
+    expect(prisma.response.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { contactId: mockContactId, contact: { workspaceId: mockWorkspaceId } },
+      })
+    );
+  });
+
+  testInputValidation(getResponsesByContactId, "123#", mockWorkspaceId);
 });

--- a/apps/web/modules/ee/contacts/[contactId]/components/activity-section.tsx
+++ b/apps/web/modules/ee/contacts/[contactId]/components/activity-section.tsx
@@ -20,8 +20,8 @@ interface ActivitySectionProps {
 
 export const ActivitySection = async ({ workspaceId, contactId, environmentTags }: ActivitySectionProps) => {
   const [responses, displays, workspace] = await Promise.all([
-    getResponsesByContactId(contactId),
-    getDisplaysByContactId(contactId),
+    getResponsesByContactId(contactId, workspaceId),
+    getDisplaysByContactId(contactId, workspaceId),
     getWorkspace(workspaceId),
   ]);
 

--- a/apps/web/modules/ee/contacts/[contactId]/components/activity-section.tsx
+++ b/apps/web/modules/ee/contacts/[contactId]/components/activity-section.tsx
@@ -18,7 +18,11 @@ interface ActivitySectionProps {
   environmentTags: TTag[];
 }
 
-export const ActivitySection = async ({ workspaceId, contactId, environmentTags }: ActivitySectionProps) => {
+export const ActivitySection = async ({
+  workspaceId,
+  contactId,
+  environmentTags,
+}: Readonly<ActivitySectionProps>) => {
   const [responses, displays, workspace] = await Promise.all([
     getResponsesByContactId(contactId, workspaceId),
     getDisplaysByContactId(contactId, workspaceId),

--- a/apps/web/modules/ee/contacts/[contactId]/components/attributes-section.tsx
+++ b/apps/web/modules/ee/contacts/[contactId]/components/attributes-section.tsx
@@ -4,17 +4,22 @@ import { getResponsesByContactId } from "@/lib/response/service";
 import { getLocale } from "@/lingodotdev/language";
 import { getTranslate } from "@/lingodotdev/server";
 import { getContactAttributesWithKeyInfo } from "@/modules/ee/contacts/lib/contact-attributes";
-import { getContact } from "@/modules/ee/contacts/lib/contacts";
+import { getContactInWorkspace } from "@/modules/ee/contacts/lib/contacts";
 import { formatAttributeValue } from "@/modules/ee/contacts/lib/format-attribute-value";
 import { getContactAttributeDataTypeIcon } from "@/modules/ee/contacts/utils";
 import { IdBadge } from "@/modules/ui/components/id-badge";
 
-export const AttributesSection = async ({ contactId }: { contactId: string }) => {
+interface AttributesSectionProps {
+  contactId: string;
+  workspaceId: string;
+}
+
+export const AttributesSection = async ({ contactId, workspaceId }: Readonly<AttributesSectionProps>) => {
   const t = await getTranslate();
   const [locale, contact, attributesWithKeyInfo] = await Promise.all([
     getLocale(),
-    getContact(contactId),
-    getContactAttributesWithKeyInfo(contactId),
+    getContactInWorkspace(contactId, workspaceId),
+    getContactAttributesWithKeyInfo(contactId, workspaceId),
   ]);
 
   if (!contact) {
@@ -22,8 +27,8 @@ export const AttributesSection = async ({ contactId }: { contactId: string }) =>
   }
 
   const [responses, displays] = await Promise.all([
-    getResponsesByContactId(contactId),
-    getDisplaysByContactId(contactId),
+    getResponsesByContactId(contactId, workspaceId),
+    getDisplaysByContactId(contactId, workspaceId),
   ]);
   const numberOfResponses = responses?.length || 0;
   const numberOfDisplays = displays?.length || 0;

--- a/apps/web/modules/ee/contacts/[contactId]/page.tsx
+++ b/apps/web/modules/ee/contacts/[contactId]/page.tsx
@@ -5,13 +5,13 @@ import { AttributesSection } from "@/modules/ee/contacts/[contactId]/components/
 import { ContactControlBar } from "@/modules/ee/contacts/[contactId]/components/contact-control-bar";
 import { getContactAttributeKeys } from "@/modules/ee/contacts/lib/contact-attribute-keys";
 import { getContactAttributesWithKeyInfo } from "@/modules/ee/contacts/lib/contact-attributes";
-import { getContact } from "@/modules/ee/contacts/lib/contacts";
+import { getContactAuth } from "@/modules/ee/contacts/lib/contact-auth";
+import { getContactInWorkspace } from "@/modules/ee/contacts/lib/contacts";
 import { getPublishedLinkSurveys } from "@/modules/ee/contacts/lib/surveys";
 import { getIsQuotasEnabled } from "@/modules/ee/license-check/lib/utils";
 import { GoBackButton } from "@/modules/ui/components/go-back-button";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
-import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
 import { ActivitySection } from "./components/activity-section";
 
 export const SingleContactPage = async (props: {
@@ -20,14 +20,16 @@ export const SingleContactPage = async (props: {
   const params = await props.params;
   const t = await getTranslate();
 
-  const { isReadOnly, organization, workspace } = await getWorkspaceAuth(params.workspaceId);
+  // Ties the contact in the URL to the workspace in the URL: authorizing the workspace alone would
+  // let any authenticated user read a foreign contact's PII through their own workspace.
+  const { isReadOnly, organization, workspace } = await getContactAuth(params.workspaceId, params.contactId);
 
   const [environmentTags, contact, publishedLinkSurveys, attributesWithKeyInfo, allAttributeKeys] =
     await Promise.all([
       getTagsByWorkspaceId(workspace.id),
-      getContact(params.contactId),
+      getContactInWorkspace(params.contactId, workspace.id),
       getPublishedLinkSurveys(workspace.id),
-      getContactAttributesWithKeyInfo(params.contactId),
+      getContactAttributesWithKeyInfo(params.contactId, workspace.id),
       getContactAttributeKeys(workspace.id),
     ]);
 
@@ -63,7 +65,7 @@ export const SingleContactPage = async (props: {
       <PageHeader pageTitle={contactIdentifier} cta={getContactControlBar()} />
       <section className="pt-6 pb-24">
         <div className="grid grid-cols-4 gap-x-8">
-          <AttributesSection contactId={params.contactId} />
+          <AttributesSection contactId={params.contactId} workspaceId={workspace.id} />
           <ActivitySection
             workspaceId={workspace.id}
             contactId={params.contactId}

--- a/apps/web/modules/ee/contacts/lib/contact-attributes.test.ts
+++ b/apps/web/modules/ee/contacts/lib/contact-attributes.test.ts
@@ -116,10 +116,10 @@ describe("getContactAttributesWithKeyInfo", () => {
       >
     );
 
-    const result = await getContactAttributesWithKeyInfo(contactId);
+    const result = await getContactAttributesWithKeyInfo(contactId, workspaceId);
 
     expect(prisma.contactAttribute.findMany).toHaveBeenCalledWith({
-      where: { contactId },
+      where: { contactId, contact: { workspaceId } },
       select: {
         value: true,
         valueNumber: true,
@@ -158,7 +158,7 @@ describe("getContactAttributesWithKeyInfo", () => {
   test("returns empty array if no attributes", async () => {
     vi.mocked(prisma.contactAttribute.findMany).mockResolvedValue([]);
 
-    const result = await getContactAttributesWithKeyInfo(contactId);
+    const result = await getContactAttributesWithKeyInfo(contactId, workspaceId);
 
     expect(result).toEqual([]);
   });
@@ -189,7 +189,7 @@ describe("getContactAttributesWithKeyInfo", () => {
       mixedTypeAttributes as unknown as Prisma.Result<typeof prisma.contactAttribute, unknown, "findMany">
     );
 
-    const result = await getContactAttributesWithKeyInfo(contactId);
+    const result = await getContactAttributesWithKeyInfo(contactId, workspaceId);
 
     expect(result).toHaveLength(3);
     expect(result[0].dataType).toBe("string");
@@ -202,6 +202,20 @@ describe("getContactAttributesWithKeyInfo", () => {
     expect(result[2].value).toBe("2024-01-01T00:00:00.000Z"); // resolved from valueDate
   });
 
+  // ENG-2290: a contact id alone is not a tenant boundary. The query must join through the contact's
+  // workspace so a caller holding an authorized workspace id cannot read a foreign contact's PII.
+  test("scopes the query to the workspace of the contact", async () => {
+    vi.mocked(prisma.contactAttribute.findMany).mockResolvedValue([]);
+
+    await getContactAttributesWithKeyInfo(contactId, workspaceId);
+
+    expect(prisma.contactAttribute.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ contact: { workspaceId } }),
+      })
+    );
+  });
+
   test("throws DatabaseError on Prisma error", async () => {
     const prismaError = new Prisma.PrismaClientKnownRequestError("Test error", {
       code: "P2002",
@@ -209,14 +223,14 @@ describe("getContactAttributesWithKeyInfo", () => {
     });
     vi.mocked(prisma.contactAttribute.findMany).mockRejectedValue(prismaError);
 
-    await expect(getContactAttributesWithKeyInfo(contactId)).rejects.toThrow(DatabaseError);
+    await expect(getContactAttributesWithKeyInfo(contactId, workspaceId)).rejects.toThrow(DatabaseError);
   });
 
   test("rethrows non-Prisma errors", async () => {
     const genericError = new Error("Generic error");
     vi.mocked(prisma.contactAttribute.findMany).mockRejectedValue(genericError);
 
-    await expect(getContactAttributesWithKeyInfo(contactId)).rejects.toThrow("Generic error");
+    await expect(getContactAttributesWithKeyInfo(contactId, workspaceId)).rejects.toThrow("Generic error");
   });
 });
 

--- a/apps/web/modules/ee/contacts/lib/contact-attributes.ts
+++ b/apps/web/modules/ee/contacts/lib/contact-attributes.ts
@@ -46,13 +46,19 @@ export const getContactAttributes = reactCache(async (contactId: string) => {
   }
 });
 
-export const getContactAttributesWithKeyInfo = reactCache(async (contactId: string) => {
-  validateInputs([contactId, ZId]);
+/**
+ * Scoped by workspace on purpose: this feeds the contact detail page, which is reached through a
+ * workspace id in the URL. `ContactAttribute` has no workspace column of its own, so the tenant
+ * check goes through the contact it hangs off.
+ */
+export const getContactAttributesWithKeyInfo = reactCache(async (contactId: string, workspaceId: string) => {
+  validateInputs([contactId, ZId], [workspaceId, ZId]);
 
   try {
     const prismaAttributes = await prisma.contactAttribute.findMany({
       where: {
         contactId,
+        contact: { workspaceId },
       },
       select: selectContactAttribute,
     });

--- a/apps/web/modules/ee/contacts/lib/contact-auth.test.ts
+++ b/apps/web/modules/ee/contacts/lib/contact-auth.test.ts
@@ -1,15 +1,25 @@
 import { notFound } from "next/navigation";
 import { Mocked, beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { DatabaseError } from "@formbricks/types/errors";
 import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
 import { TWorkspaceAuth } from "@/modules/workspaces/types/workspace-auth";
-import { getContactAuth, getWorkspaceIdOfContact } from "./contact-auth";
+import { getContactAuth } from "./contact-auth";
 
 vi.mock("@formbricks/database", () => ({
   prisma: {
     contact: {
       findUnique: vi.fn(),
     },
+  },
+}));
+
+vi.mock("@formbricks/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
   },
 }));
 
@@ -38,28 +48,6 @@ const CONTACT_ID = "contact_victim";
 const buildWorkspaceAuth = (workspaceId: string) =>
   ({ workspace: { id: workspaceId }, isOwner: true }) as unknown as TWorkspaceAuth;
 
-describe("getWorkspaceIdOfContact", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  test("resolves the workspace of an existing contact with a narrow select", async () => {
-    mockPrismaContact.findUnique.mockResolvedValueOnce({ workspaceId: VICTIM_WORKSPACE_ID } as any);
-
-    await expect(getWorkspaceIdOfContact(CONTACT_ID)).resolves.toBe(VICTIM_WORKSPACE_ID);
-    expect(mockPrismaContact.findUnique).toHaveBeenCalledWith({
-      where: { id: CONTACT_ID },
-      select: { workspaceId: true },
-    });
-  });
-
-  test("resolves to null when the contact does not exist", async () => {
-    mockPrismaContact.findUnique.mockResolvedValueOnce(null);
-
-    await expect(getWorkspaceIdOfContact("contact_missing")).resolves.toBeNull();
-  });
-});
-
 describe("getContactAuth", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -73,6 +61,11 @@ describe("getContactAuth", () => {
 
     expect(auth.workspace.id).toBe(VICTIM_WORKSPACE_ID);
     expect(notFound).not.toHaveBeenCalled();
+    // The contact lookup stays narrow — it exists to place the contact in a workspace, nothing else.
+    expect(mockPrismaContact.findUnique).toHaveBeenCalledWith({
+      where: { id: CONTACT_ID },
+      select: { workspaceId: true },
+    });
   });
 
   test("404s when the caller pairs their own workspace with a foreign contact", async () => {
@@ -97,5 +90,24 @@ describe("getContactAuth", () => {
     mockPrismaContact.findUnique.mockResolvedValueOnce({ workspaceId: VICTIM_WORKSPACE_ID } as any);
 
     await expect(getContactAuth(VICTIM_WORKSPACE_ID, CONTACT_ID)).rejects.toThrow("not authorized");
+  });
+
+  test("wraps a Prisma failure of the contact lookup in a DatabaseError", async () => {
+    const prismaError = new Prisma.PrismaClientKnownRequestError("DB Error", {
+      code: "P2002",
+      clientVersion: "5.0.0",
+    });
+    mockGetWorkspaceAuth.mockResolvedValueOnce(buildWorkspaceAuth(VICTIM_WORKSPACE_ID));
+    mockPrismaContact.findUnique.mockRejectedValueOnce(prismaError);
+
+    await expect(getContactAuth(VICTIM_WORKSPACE_ID, CONTACT_ID)).rejects.toThrow(DatabaseError);
+  });
+
+  test("re-throws a non-Prisma failure of the contact lookup unchanged", async () => {
+    const error = new Error("Unknown error");
+    mockGetWorkspaceAuth.mockResolvedValueOnce(buildWorkspaceAuth(VICTIM_WORKSPACE_ID));
+    mockPrismaContact.findUnique.mockRejectedValueOnce(error);
+
+    await expect(getContactAuth(VICTIM_WORKSPACE_ID, CONTACT_ID)).rejects.toThrow(error);
   });
 });

--- a/apps/web/modules/ee/contacts/lib/contact-auth.test.ts
+++ b/apps/web/modules/ee/contacts/lib/contact-auth.test.ts
@@ -1,0 +1,101 @@
+import { notFound } from "next/navigation";
+import { Mocked, beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
+import { TWorkspaceAuth } from "@/modules/workspaces/types/workspace-auth";
+import { getContactAuth, getWorkspaceIdOfContact } from "./contact-auth";
+
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    contact: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+vi.mock("@/modules/workspaces/lib/utils", () => ({
+  getWorkspaceAuth: vi.fn(),
+}));
+
+// reactCache(fn) returns fn, which is then invoked
+vi.mock("react", () => ({
+  cache: vi.fn((fn) => fn),
+}));
+
+const mockPrismaContact = prisma.contact as Mocked<typeof prisma.contact>;
+const mockGetWorkspaceAuth = vi.mocked(getWorkspaceAuth);
+
+const ATTACKER_WORKSPACE_ID = "workspace_attacker";
+const VICTIM_WORKSPACE_ID = "workspace_victim";
+const CONTACT_ID = "contact_victim";
+
+const buildWorkspaceAuth = (workspaceId: string) =>
+  ({ workspace: { id: workspaceId }, isOwner: true }) as unknown as TWorkspaceAuth;
+
+describe("getWorkspaceIdOfContact", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("resolves the workspace of an existing contact with a narrow select", async () => {
+    mockPrismaContact.findUnique.mockResolvedValueOnce({ workspaceId: VICTIM_WORKSPACE_ID } as any);
+
+    await expect(getWorkspaceIdOfContact(CONTACT_ID)).resolves.toBe(VICTIM_WORKSPACE_ID);
+    expect(mockPrismaContact.findUnique).toHaveBeenCalledWith({
+      where: { id: CONTACT_ID },
+      select: { workspaceId: true },
+    });
+  });
+
+  test("resolves to null when the contact does not exist", async () => {
+    mockPrismaContact.findUnique.mockResolvedValueOnce(null);
+
+    await expect(getWorkspaceIdOfContact("contact_missing")).resolves.toBeNull();
+  });
+});
+
+describe("getContactAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("returns the workspace authorization when the contact belongs to the workspace", async () => {
+    mockGetWorkspaceAuth.mockResolvedValueOnce(buildWorkspaceAuth(VICTIM_WORKSPACE_ID));
+    mockPrismaContact.findUnique.mockResolvedValueOnce({ workspaceId: VICTIM_WORKSPACE_ID } as any);
+
+    const auth = await getContactAuth(VICTIM_WORKSPACE_ID, CONTACT_ID);
+
+    expect(auth.workspace.id).toBe(VICTIM_WORKSPACE_ID);
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  test("404s when the caller pairs their own workspace with a foreign contact", async () => {
+    // The cross-tenant read: authorization for the attacker's own workspace succeeds, but the
+    // contact in the URL belongs to someone else.
+    mockGetWorkspaceAuth.mockResolvedValueOnce(buildWorkspaceAuth(ATTACKER_WORKSPACE_ID));
+    mockPrismaContact.findUnique.mockResolvedValueOnce({ workspaceId: VICTIM_WORKSPACE_ID } as any);
+
+    await expect(getContactAuth(ATTACKER_WORKSPACE_ID, CONTACT_ID)).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  test("404s when the contact does not exist, so a foreign id is indistinguishable", async () => {
+    mockGetWorkspaceAuth.mockResolvedValueOnce(buildWorkspaceAuth(ATTACKER_WORKSPACE_ID));
+    mockPrismaContact.findUnique.mockResolvedValueOnce(null);
+
+    await expect(getContactAuth(ATTACKER_WORKSPACE_ID, "contact_missing")).rejects.toThrow("NEXT_NOT_FOUND");
+  });
+
+  test("propagates the workspace authorization failure instead of masking it as a 404", async () => {
+    mockGetWorkspaceAuth.mockRejectedValueOnce(new Error("not authorized"));
+    mockPrismaContact.findUnique.mockResolvedValueOnce({ workspaceId: VICTIM_WORKSPACE_ID } as any);
+
+    await expect(getContactAuth(VICTIM_WORKSPACE_ID, CONTACT_ID)).rejects.toThrow("not authorized");
+  });
+});

--- a/apps/web/modules/ee/contacts/lib/contact-auth.ts
+++ b/apps/web/modules/ee/contacts/lib/contact-auth.ts
@@ -1,0 +1,57 @@
+import "server-only";
+import { notFound } from "next/navigation";
+import { cache as reactCache } from "react";
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { logger } from "@formbricks/logger";
+import { DatabaseError } from "@formbricks/types/errors";
+import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
+import { TWorkspaceAuth } from "@/modules/workspaces/types/workspace-auth";
+
+/**
+ * Resolves the workspace a contact belongs to, or null when the contact does not exist.
+ */
+export const getWorkspaceIdOfContact = reactCache(async (contactId: string): Promise<string | null> => {
+  try {
+    const contact = await prisma.contact.findUnique({
+      where: { id: contactId },
+      select: { workspaceId: true },
+    });
+
+    return contact?.workspaceId ?? null;
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      logger.error(error, "Error resolving the workspace of a contact");
+      throw new DatabaseError(error.message);
+    }
+    throw error;
+  }
+});
+
+/**
+ * Authorization for pages addressed by both a workspace id and a contact id.
+ *
+ * `getWorkspaceAuth` only ever sees the workspace in the URL, so on its own it cannot tell
+ * whether the contact in the URL is one of that workspace's contacts. Composing "authorize
+ * workspace A" with "load contact X" therefore lets any authenticated user substitute their own
+ * workspace id and read a foreign contact — its attributes (email, userId, arbitrary custom PII),
+ * its responses and its displays. This helper ties the two together and is the choke point every
+ * contact-scoped page must go through.
+ *
+ * Fails closed with a 404 rather than a 403, so a foreign contact id is indistinguishable from one
+ * that does not exist.
+ */
+export const getContactAuth = reactCache(
+  async (workspaceId: string, contactId: string): Promise<TWorkspaceAuth> => {
+    const [workspaceAuth, contactWorkspaceId] = await Promise.all([
+      getWorkspaceAuth(workspaceId),
+      getWorkspaceIdOfContact(contactId),
+    ]);
+
+    if (contactWorkspaceId !== workspaceAuth.workspace.id) {
+      notFound();
+    }
+
+    return workspaceAuth;
+  }
+);

--- a/apps/web/modules/ee/contacts/lib/contact-auth.ts
+++ b/apps/web/modules/ee/contacts/lib/contact-auth.ts
@@ -10,8 +10,15 @@ import { TWorkspaceAuth } from "@/modules/workspaces/types/workspace-auth";
 
 /**
  * Resolves the workspace a contact belongs to, or null when the contact does not exist.
+ *
+ * Deliberately not run through `validateInputs`: `contactId` arrives as a raw URL segment, and a
+ * malformed one should 404 exactly like a well-formed id belonging to someone else. Validating here
+ * would raise a `ValidationError` instead and make the two cases distinguishable.
+ *
+ * Module-private on purpose — "resolve any contact's workspace, unscoped" is not something callers
+ * should reach for from the module that owns the tenant boundary. Go through `getContactAuth`.
  */
-export const getWorkspaceIdOfContact = reactCache(async (contactId: string): Promise<string | null> => {
+const getWorkspaceIdOfContact = reactCache(async (contactId: string): Promise<string | null> => {
   try {
     const contact = await prisma.contact.findUnique({
       where: { id: contactId },

--- a/apps/web/modules/ee/contacts/lib/contacts.test.ts
+++ b/apps/web/modules/ee/contacts/lib/contacts.test.ts
@@ -431,6 +431,13 @@ describe("Contacts Lib", () => {
 
       await expect(getContactInWorkspace(mockContactId, mockWorkspaceId)).rejects.toThrow(DatabaseError);
     });
+
+    test("re-throws non-Prisma errors", async () => {
+      const error = new Error("Unknown error");
+      vi.mocked(prisma.contact.findFirst).mockRejectedValue(error);
+
+      await expect(getContactInWorkspace(mockContactId, mockWorkspaceId)).rejects.toThrow(error);
+    });
   });
 
   describe("deleteContact", () => {

--- a/apps/web/modules/ee/contacts/lib/contacts.test.ts
+++ b/apps/web/modules/ee/contacts/lib/contacts.test.ts
@@ -13,6 +13,7 @@ import {
   deleteContact,
   generatePersonalLinks,
   getContact,
+  getContactInWorkspace,
   getContacts,
   getContactsInSegment,
 } from "./contacts";
@@ -22,6 +23,7 @@ vi.mock("@formbricks/database", () => ({
   prisma: {
     contact: {
       findMany: vi.fn(),
+      findFirst: vi.fn(),
       findUnique: vi.fn(),
       delete: vi.fn(),
       create: vi.fn(),
@@ -386,6 +388,48 @@ describe("Contacts Lib", () => {
       vi.mocked(prisma.contact.findUnique).mockRejectedValue(error);
 
       await expect(getContact(mockContactId)).rejects.toThrow(error);
+    });
+  });
+
+  // ENG-2290: the contact detail page authorizes the workspace in the URL and must not be able to
+  // load a contact from another workspace with it. `getContact` stays unscoped on purpose — it is
+  // what derives a contact's workspace elsewhere — so page reads go through this scoped sibling.
+  describe("getContactInWorkspace", () => {
+    test("returns the contact when it belongs to the workspace", async () => {
+      vi.mocked(prisma.contact.findFirst).mockResolvedValue(mockPrismaContact as any);
+
+      const result = await getContactInWorkspace(mockContactId, mockWorkspaceId);
+
+      expect(result).toEqual(mockPrismaContact);
+      expect(prisma.contact.findFirst).toHaveBeenCalledWith({
+        where: { id: mockContactId, workspaceId: mockWorkspaceId },
+        select: expect.any(Object),
+      });
+    });
+
+    test("returns null for a contact in another workspace", async () => {
+      // The scoped where clause is what makes this null: Prisma finds no row for the pair.
+      vi.mocked(prisma.contact.findFirst).mockResolvedValue(null);
+
+      const result = await getContactInWorkspace(mockContactId, "workspace-attacker");
+
+      expect(result).toBeNull();
+      expect(prisma.contact.findFirst).toHaveBeenCalledWith({
+        where: { id: mockContactId, workspaceId: "workspace-attacker" },
+        select: expect.any(Object),
+      });
+      // The unscoped lookup must not be used as a fallback.
+      expect(prisma.contact.findUnique).not.toHaveBeenCalled();
+    });
+
+    test("throws DatabaseError on Prisma error", async () => {
+      const prismaError = new Prisma.PrismaClientKnownRequestError("DB Error", {
+        code: "P2002",
+        clientVersion: "5.0.0",
+      });
+      vi.mocked(prisma.contact.findFirst).mockRejectedValue(prismaError);
+
+      await expect(getContactInWorkspace(mockContactId, mockWorkspaceId)).rejects.toThrow(DatabaseError);
     });
   });
 

--- a/apps/web/modules/ee/contacts/lib/contacts.ts
+++ b/apps/web/modules/ee/contacts/lib/contacts.ts
@@ -192,6 +192,32 @@ export const getContact = reactCache(async (contactId: string): Promise<TContact
   }
 });
 
+/**
+ * Workspace-scoped variant of {@link getContact}: returns null when the contact exists but lives in
+ * another workspace, so a caller holding an authorized workspace id cannot read a foreign contact.
+ */
+export const getContactInWorkspace = reactCache(
+  async (contactId: string, workspaceId: string): Promise<TContact | null> => {
+    validateInputs([contactId, ZId], [workspaceId, ZId]);
+
+    try {
+      return await prisma.contact.findFirst({
+        where: {
+          id: contactId,
+          workspaceId,
+        },
+        select: selectContact,
+      });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw new DatabaseError(error.message);
+      }
+
+      throw error;
+    }
+  }
+);
+
 export const deleteContact = async (contactId: string): Promise<TContact | null> => {
   validateInputs([contactId, ZId]);
 

--- a/apps/web/playwright/cross-tenant-contact-access.spec.ts
+++ b/apps/web/playwright/cross-tenant-contact-access.spec.ts
@@ -1,0 +1,96 @@
+import { expect } from "@playwright/test";
+import { prisma } from "@formbricks/database";
+import type { UsersFixture } from "./fixtures/users";
+import { test } from "./lib/fixtures";
+
+// ENG-2290 regression: the contact detail page authorized the workspaceId in the URL but loaded the
+// contact by contactId alone, so pairing your own workspace with someone else's contact id read that
+// contact's attributes (email, userId, arbitrary custom PII), its responses and its displays. Every
+// read on this page now goes through getContactAuth, which ties the two ids together and fails
+// closed with a 404. The second test guards against a fix that over-blocks and takes the owner's own
+// contacts down with it.
+
+const seedTenant = async (users: UsersFixture, label: string) => {
+  const user = await users.create({ organizationName: `${label} Org` });
+
+  if (!user.workspaceId) {
+    throw new Error("Workspace not seeded for test");
+  }
+
+  const workspaceId = user.workspaceId;
+  const contact = await prisma.contact.create({ data: { workspaceId } });
+
+  // The users fixture seeds the default attribute keys (email, firstName, lastName, userId) per
+  // workspace; add a custom one so the test also covers operator-uploaded PII.
+  const keys = await prisma.contactAttributeKey.findMany({
+    where: { workspaceId },
+    select: { id: true, key: true },
+  });
+  const customKey = await prisma.contactAttributeKey.create({
+    data: { workspaceId, name: "Plan", key: "plan", type: "custom" },
+  });
+
+  // Unique per tenant and per run, so an assertion on the page HTML cannot pass by accident.
+  const pii = {
+    email: `${label}-pii-${Date.now()}@example.com`,
+    userId: `${label}-user-${Date.now()}`,
+    plan: `${label}-secret-plan-${Date.now()}`,
+    answer: `${label}-answer-${Date.now()}`,
+  };
+
+  const keyId = (key: string) => keys.find((k) => k.key === key)?.id;
+
+  await prisma.contactAttribute.createMany({
+    data: [
+      { contactId: contact.id, attributeKeyId: keyId("email")!, value: pii.email },
+      { contactId: contact.id, attributeKeyId: keyId("userId")!, value: pii.userId },
+      { contactId: contact.id, attributeKeyId: customKey.id, value: pii.plan },
+    ],
+  });
+
+  // Give the contact activity too, so the response/display loaders are exercised, not just the
+  // attribute one.
+  const survey = await prisma.survey.findFirstOrThrow({ where: { workspaceId }, select: { id: true } });
+  await prisma.display.create({ data: { surveyId: survey.id, contactId: contact.id } });
+  await prisma.response.create({
+    data: { surveyId: survey.id, contactId: contact.id, finished: true, data: { q1: pii.answer } },
+  });
+
+  return { user, workspaceId, contactId: contact.id, pii };
+};
+
+test.describe("Cross-tenant contact access (ENG-2290)", () => {
+  test("404s when a foreign contact id is paired with an authorized workspace", async ({ page, users }) => {
+    const victim = await seedTenant(users, "victim");
+    const attacker = await seedTenant(users, "attacker");
+
+    await attacker.user.login();
+
+    await page.goto(`/workspaces/${attacker.workspaceId}/contacts/${victim.contactId}`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.getByTestId("error-code")).toHaveText("404");
+
+    // Assert against the full document rather than visible text: this also catches PII serialized
+    // into the RSC flight payload but never painted.
+    const html = await page.content();
+    for (const [field, value] of Object.entries({ ...victim.pii, contactId: victim.contactId })) {
+      expect(html, `the page must not expose the victim's ${field}`).not.toContain(value);
+    }
+  });
+
+  test("keeps access to the workspace's own contacts", async ({ page, users }) => {
+    const owner = await seedTenant(users, "owner");
+
+    await owner.user.login();
+
+    await page.goto(`/workspaces/${owner.workspaceId}/contacts/${owner.contactId}`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.getByRole("heading", { name: owner.pii.email })).toBeVisible();
+    await expect(page.getByText(owner.pii.userId)).toBeVisible();
+    await expect(page.getByText(owner.pii.plan)).toBeVisible();
+  });
+});

--- a/apps/web/playwright/cross-tenant-contact-access.spec.ts
+++ b/apps/web/playwright/cross-tenant-contact-access.spec.ts
@@ -73,9 +73,11 @@ test.describe("Cross-tenant contact access (ENG-2290)", () => {
     await expect(page.getByTestId("error-code")).toHaveText("404");
 
     // Assert against the full document rather than visible text: this also catches PII serialized
-    // into the RSC flight payload but never painted.
+    // into the RSC flight payload but never painted. The contact id itself is deliberately not
+    // asserted on — it is the attacker's own input and Next echoes the request path back in the
+    // router state.
     const html = await page.content();
-    for (const [field, value] of Object.entries({ ...victim.pii, contactId: victim.contactId })) {
+    for (const [field, value] of Object.entries(victim.pii)) {
       expect(html, `the page must not expose the victim's ${field}`).not.toContain(value);
     }
   });


### PR DESCRIPTION
## What & why

The contact detail page authorized the `workspaceId` in the URL but loaded the contact by `contactId` alone, and nothing compared the two. Any authenticated user could pair **their own** workspace id with **another organization's** contact id and read that contact's full attribute set — email, userId, first/last name and arbitrary custom PII, i.e. the operator's uploaded customer list — plus its survey responses and display history. A free account was enough.

`getWorkspaceAuth(workspaceId)` cannot close this: it only ever receives a workspace id, so it has nothing to tie the contact to. This adds `getContactAuth(workspaceId, contactId)` (`apps/web/modules/ee/contacts/lib/contact-auth.ts`) — it runs `getWorkspaceAuth` and a narrow `contact.workspaceId` lookup in parallel and `notFound()`s unless they match — and routes the page through it. It fails closed with a **404, not a 403**, so a foreign contact id is indistinguishable from one that does not exist.

The page guard alone would have been enough to stop the render, but both child server components re-run the same queries independently, so the loaders are scoped as well:

| Loader | Before | After |
| --- | --- | --- |
| `getContact` → `getContactInWorkspace` | `findUnique({ where: { id } })` | `findFirst({ where: { id, workspaceId } })` |
| `getContactAttributesWithKeyInfo` | `where: { contactId }` | `where: { contactId, contact: { workspaceId } }` |
| `getResponsesByContactId` | `where: { contactId }` | `where: { contactId, contact: { workspaceId } }` |
| `getDisplaysByContactId` | `where: { contactId }` | `where: { contactId, contact: { workspaceId } }` |

`getContact` in `modules/ee/contacts/lib/contacts.ts` keeps its signature rather than gaining a required `workspaceId`: its two remaining production callers — `modules/ee/contacts/actions.ts:192` and `modules/ee/contacts/lib/update-contact-attributes.ts:21` — both use it to *derive* a contact's workspace before authorizing, which is the one legitimate reason to look a contact up unscoped. The server actions were never vulnerable for that reason: `deleteContactAction`, `updateContactAttributesAction` and `generatePersonalSurveyLinkAction` all resolve org and workspace from the `contactId` and then call `checkAuthorizationUpdated`. Only the RSC read path was.

Same shape as #8783 (ENG-2101) so the two read as one remediation; that PR is still open and this one does not depend on it. That does leave `contact-auth.ts` and `survey-auth.ts` as near-identical twins, plus a third narrow variant already in `lib/utils/services.ts:278`. Deliberately not consolidated here — whichever of the two PRs merges second is the point to decide whether a shared `assertResourceInWorkspace` earns its keep.

**Out of scope, noticed while here:** this page never calls `getIsContactsEnabled`, so contact PII renders even with the entitlement off (ENG-1768). Left alone deliberately.

## Linear ticket

Fixes ENG-2290

## How this was tested

Both tiers were run **red then green** — against the unfixed code first, to prove the bug was real, then against the fix.

**Playwright** — `apps/web/playwright/cross-tenant-contact-access.spec.ts`. Two independent tenants; each contact carries run-unique PII plus a response and a display. The attacker logs in and requests `/workspaces/{ownWorkspaceId}/contacts/{victimContactId}`.

| Build | 404s on a foreign contact | Own contact still works |
| --- | --- | --- |
| unfixed (`de993bb`) | ❌ page rendered, no 404 | ✅ |
| with this PR | ✅ 404, none of the victim's PII in the document | ✅ |

The red run's page snapshot — the attacker's browser rendering the victim tenant's contact:

```
- heading "victim-pii-…@example.com" [level=1]
  - definition: victim-pii-…@example.com      # Email
  - definition: victim-user-…                 # userId
  - definition: victim-secret-plan-…          # custom "Plan" attribute
  - term: Responses  → definition: "1"
  - term: Displays   → definition: "1"
```

The second test exists so a fix that over-blocks cannot pass; it is green in both directions. Assertions run against `page.content()`, not visible text, so PII serialized into the RSC flight payload but never painted would still fail the test.

**Unit** — `pnpm test`: 593 files / 7647 tests ✅. Against the unfixed loaders the new scoping assertions fail 7/86, which is the same red/green story at the query level. The `DatabaseError` wrapping and non-Prisma re-throw in both new query helpers are asserted too, so new-code coverage is 100% on the two files Sonar tracks here.

**Environment:** run locally against real Postgres 16 + pgvector + Redis with two full `pnpm build` production builds (one per side of the red/green). `pnpm lint` ✅, `pnpm format` ✅. `segments.spec.ts` and `api/management/contacts.spec.ts` fail in that sandbox, but both gate on `getIsContactsEnabled` and it has no `ENTERPRISE_LICENSE_KEY`; neither touches a file in this diff.

No UI change — the only visual difference is a 404 where PII used to be.

## Breaking changes

None

## QA / Test Plan

Placeholders below are written as `{braces}` — substitute real ids.

**How to test**

- [ ] As user A (own org + workspace), open `/workspaces/{workspaceA}/contacts` and click any contact → the detail page opens and shows that contact's attributes, responses and displays.
- [ ] In a second org as user B, create a contact and copy its id from the URL. Back as user A, open `/workspaces/{workspaceA}/contacts/{contactOfB}` → **404 "Page not found"**, and none of B's attribute values appear anywhere on the page (check the rendered HTML too).
- [ ] As user A, open `/workspaces/{workspaceA}/contacts/{madeUpId}` → the same 404, visually identical to the foreign-contact case (a foreign id must not be distinguishable from a nonexistent one). Try both a well-formed-but-unused cuid and obvious junk like `/contacts/abc`.
- [ ] As a member of A's org with read-only workspace access, open A's own contact → still renders, with the edit/delete/generate-link actions hidden as before.
- [ ] Regression: on A's own contact, the Activity timeline still lists that contact's responses and displays, and the Responses/Displays counts still match.

**Preconditions / test data**

- Two separate organizations, each with its own workspace and at least one contact carrying an email, a userId and one custom attribute.
- The victim contact needs at least one response and one display to exercise the activity loaders.
- Enterprise Contacts entitlement enabled (Cloud or a licensed self-host).

**Risks & regressions**

- Over-blocking: a workspace's own contacts must still open. Covered by the second E2E test.
- `getResponsesByContactId` and `getDisplaysByContactId` changed signature; both are used only by this page's two components, but re-check the Activity timeline and the Responses/Displays counts.
- The missing-contact error changed from `ResourceNotFoundError` to a 404 page — intended, so the two cases are indistinguishable.
- `apps/web/playwright/**` is neither linted nor typechecked in this repo, so the new spec has no static safety net; the manual steps above are its only cover.

**Migrations / env / cutover**

- none
