### PR TITLE
fix(security): tie the contact detail page to the workspace in the URL (backport #8789 to release/5.3)

### DIFF
--- a/apps/web/lib/display/service.ts
+++ b/apps/web/lib/display/service.ts
@@ -55,13 +55,21 @@ export const getDisplayCountBySurveyId = reactCache(
   }
 );
 
+/**
+ * Scoped by workspace on purpose: this feeds the contact detail page, which is reached through a
+ * workspace id in the URL. A contact id alone is not a tenant boundary, so the displays are
+ * filtered through the workspace of the contact they belong to.
+ */
 export const getDisplaysByContactId = reactCache(
-  async (contactId: string): Promise<Pick<TDisplay, "id" | "createdAt" | "surveyId">[]> => {
-    validateInputs([contactId, ZId]);
+  async (
+    contactId: string,
+    workspaceId: string
+  ): Promise<Pick<TDisplay, "id" | "createdAt" | "surveyId">[]> => {
+    validateInputs([contactId, ZId], [workspaceId, ZId]);
 
     try {
       const displays = await prisma.display.findMany({
-        where: { contactId },
+        where: { contactId, contact: { workspaceId } },
         select: {
           id: true,
           createdAt: true,

--- a/apps/web/lib/display/tests/display-queries.test.ts
+++ b/apps/web/lib/display/tests/display-queries.test.ts
@@ -127,11 +127,11 @@ describe("getDisplaysByContactId", () => {
     test("returns displays for a contact ordered by createdAt desc", async () => {
       vi.mocked(prisma.display.findMany).mockResolvedValue(mockDisplaysForContact as any);
 
-      const result = await getDisplaysByContactId(mockContactId);
+      const result = await getDisplaysByContactId(mockContactId, mockWorkspaceId);
 
       expect(result).toEqual(mockDisplaysForContact);
       expect(prisma.display.findMany).toHaveBeenCalledWith({
-        where: { contactId: mockContactId },
+        where: { contactId: mockContactId, contact: { workspaceId: mockWorkspaceId } },
         select: {
           id: true,
           createdAt: true,
@@ -144,7 +144,7 @@ describe("getDisplaysByContactId", () => {
     test("returns empty array when contact has no displays", async () => {
       vi.mocked(prisma.display.findMany).mockResolvedValue([]);
 
-      const result = await getDisplaysByContactId(mockContactId);
+      const result = await getDisplaysByContactId(mockContactId, mockWorkspaceId);
 
       expect(result).toEqual([]);
     });
@@ -152,7 +152,7 @@ describe("getDisplaysByContactId", () => {
 
   describe("Sad Path", () => {
     test("throws a ValidationError if the contactId is invalid", async () => {
-      await expect(getDisplaysByContactId("not-a-cuid")).rejects.toThrow(ValidationError);
+      await expect(getDisplaysByContactId("not-a-cuid", mockWorkspaceId)).rejects.toThrow(ValidationError);
     });
 
     test("throws DatabaseError on PrismaClientKnownRequestError", async () => {
@@ -163,13 +163,13 @@ describe("getDisplaysByContactId", () => {
 
       vi.mocked(prisma.display.findMany).mockRejectedValue(errToThrow);
 
-      await expect(getDisplaysByContactId(mockContactId)).rejects.toThrow(DatabaseError);
+      await expect(getDisplaysByContactId(mockContactId, mockWorkspaceId)).rejects.toThrow(DatabaseError);
     });
 
     test("throws generic Error for other exceptions", async () => {
       vi.mocked(prisma.display.findMany).mockRejectedValue(new Error("Mock error"));
 
-      await expect(getDisplaysByContactId(mockContactId)).rejects.toThrow(Error);
+      await expect(getDisplaysByContactId(mockContactId, mockWorkspaceId)).rejects.toThrow(Error);
     });
   });
 });

--- a/apps/web/lib/response/service.ts
+++ b/apps/web/lib/response/service.ts
@@ -103,14 +103,20 @@ const mapResponsePrismaToResponse = (
   tags: responsePrisma.tags.map((tagPrisma: { tag: TTag }) => tagPrisma.tag),
 });
 
+/**
+ * Scoped by workspace on purpose: this feeds the contact detail page, which is reached through a
+ * workspace id in the URL. A contact id alone is not a tenant boundary, so the responses are
+ * filtered through the workspace of the contact they belong to.
+ */
 export const getResponsesByContactId = reactCache(
-  async (contactId: string, page?: number): Promise<TResponseWithQuotas[]> => {
-    validateInputs([contactId, ZId], [page, ZOptionalNumber]);
+  async (contactId: string, workspaceId: string, page?: number): Promise<TResponseWithQuotas[]> => {
+    validateInputs([contactId, ZId], [workspaceId, ZId], [page, ZOptionalNumber]);
 
     try {
       const responsePrisma = await prisma.response.findMany({
         where: {
           contactId,
+          contact: { workspaceId },
         },
         select: {
           ...responseSelection,

--- a/apps/web/modules/ee/contacts/[contactId]/components/activity-section.tsx
+++ b/apps/web/modules/ee/contacts/[contactId]/components/activity-section.tsx
@@ -18,10 +18,14 @@ interface ActivitySectionProps {
   environmentTags: TTag[];
 }
 
-export const ActivitySection = async ({ workspaceId, contactId, environmentTags }: ActivitySectionProps) => {
+export const ActivitySection = async ({
+  workspaceId,
+  contactId,
+  environmentTags,
+}: Readonly<ActivitySectionProps>) => {
   const [responses, displays, workspace] = await Promise.all([
-    getResponsesByContactId(contactId),
-    getDisplaysByContactId(contactId),
+    getResponsesByContactId(contactId, workspaceId),
+    getDisplaysByContactId(contactId, workspaceId),
     getWorkspace(workspaceId),
   ]);
 

--- a/apps/web/modules/ee/contacts/[contactId]/components/attributes-section.tsx
+++ b/apps/web/modules/ee/contacts/[contactId]/components/attributes-section.tsx
@@ -4,17 +4,22 @@ import { getResponsesByContactId } from "@/lib/response/service";
 import { getLocale } from "@/lingodotdev/language";
 import { getTranslate } from "@/lingodotdev/server";
 import { getContactAttributesWithKeyInfo } from "@/modules/ee/contacts/lib/contact-attributes";
-import { getContact } from "@/modules/ee/contacts/lib/contacts";
+import { getContactInWorkspace } from "@/modules/ee/contacts/lib/contacts";
 import { formatAttributeValue } from "@/modules/ee/contacts/lib/format-attribute-value";
 import { getContactAttributeDataTypeIcon } from "@/modules/ee/contacts/utils";
 import { IdBadge } from "@/modules/ui/components/id-badge";
 
-export const AttributesSection = async ({ contactId }: { contactId: string }) => {
+interface AttributesSectionProps {
+  contactId: string;
+  workspaceId: string;
+}
+
+export const AttributesSection = async ({ contactId, workspaceId }: Readonly<AttributesSectionProps>) => {
   const t = await getTranslate();
   const [locale, contact, attributesWithKeyInfo] = await Promise.all([
     getLocale(),
-    getContact(contactId),
-    getContactAttributesWithKeyInfo(contactId),
+    getContactInWorkspace(contactId, workspaceId),
+    getContactAttributesWithKeyInfo(contactId, workspaceId),
   ]);
 
   if (!contact) {
@@ -22,8 +27,8 @@ export const AttributesSection = async ({ contactId }: { contactId: string }) =>
   }
 
   const [responses, displays] = await Promise.all([
-    getResponsesByContactId(contactId),
-    getDisplaysByContactId(contactId),
+    getResponsesByContactId(contactId, workspaceId),
+    getDisplaysByContactId(contactId, workspaceId),
   ]);
   const numberOfResponses = responses?.length || 0;
   const numberOfDisplays = displays?.length || 0;

--- a/apps/web/modules/ee/contacts/[contactId]/page.tsx
+++ b/apps/web/modules/ee/contacts/[contactId]/page.tsx
@@ -5,13 +5,13 @@ import { AttributesSection } from "@/modules/ee/contacts/[contactId]/components/
 import { ContactControlBar } from "@/modules/ee/contacts/[contactId]/components/contact-control-bar";
 import { getContactAttributeKeys } from "@/modules/ee/contacts/lib/contact-attribute-keys";
 import { getContactAttributesWithKeyInfo } from "@/modules/ee/contacts/lib/contact-attributes";
-import { getContact } from "@/modules/ee/contacts/lib/contacts";
+import { getContactAuth } from "@/modules/ee/contacts/lib/contact-auth";
+import { getContactInWorkspace } from "@/modules/ee/contacts/lib/contacts";
 import { getPublishedLinkSurveys } from "@/modules/ee/contacts/lib/surveys";
 import { getIsQuotasEnabled } from "@/modules/ee/license-check/lib/utils";
 import { GoBackButton } from "@/modules/ui/components/go-back-button";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
-import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
 import { ActivitySection } from "./components/activity-section";
 
 export const SingleContactPage = async (props: {
@@ -20,14 +20,16 @@ export const SingleContactPage = async (props: {
   const params = await props.params;
   const t = await getTranslate();
 
-  const { isReadOnly, organization, workspace } = await getWorkspaceAuth(params.workspaceId);
+  // Ties the contact in the URL to the workspace in the URL: authorizing the workspace alone would
+  // let any authenticated user read a foreign contact's PII through their own workspace.
+  const { isReadOnly, organization, workspace } = await getContactAuth(params.workspaceId, params.contactId);
 
   const [environmentTags, contact, publishedLinkSurveys, attributesWithKeyInfo, allAttributeKeys] =
     await Promise.all([
       getTagsByWorkspaceId(workspace.id),
-      getContact(params.contactId),
+      getContactInWorkspace(params.contactId, workspace.id),
       getPublishedLinkSurveys(workspace.id),
-      getContactAttributesWithKeyInfo(params.contactId),
+      getContactAttributesWithKeyInfo(params.contactId, workspace.id),
       getContactAttributeKeys(workspace.id),
     ]);
 
@@ -63,7 +65,7 @@ export const SingleContactPage = async (props: {
       <PageHeader pageTitle={contactIdentifier} cta={getContactControlBar()} />
       <section className="pb-24 pt-6">
         <div className="grid grid-cols-4 gap-x-8">
-          <AttributesSection contactId={params.contactId} />
+          <AttributesSection contactId={params.contactId} workspaceId={workspace.id} />
           <ActivitySection
             workspaceId={workspace.id}
             contactId={params.contactId}

--- a/apps/web/modules/ee/contacts/lib/contact-attributes.test.ts
+++ b/apps/web/modules/ee/contacts/lib/contact-attributes.test.ts
@@ -116,10 +116,10 @@ describe("getContactAttributesWithKeyInfo", () => {
       >
     );
 
-    const result = await getContactAttributesWithKeyInfo(contactId);
+    const result = await getContactAttributesWithKeyInfo(contactId, workspaceId);
 
     expect(prisma.contactAttribute.findMany).toHaveBeenCalledWith({
-      where: { contactId },
+      where: { contactId, contact: { workspaceId } },
       select: {
         value: true,
         valueNumber: true,
@@ -158,7 +158,7 @@ describe("getContactAttributesWithKeyInfo", () => {
   test("returns empty array if no attributes", async () => {
     vi.mocked(prisma.contactAttribute.findMany).mockResolvedValue([]);
 
-    const result = await getContactAttributesWithKeyInfo(contactId);
+    const result = await getContactAttributesWithKeyInfo(contactId, workspaceId);
 
     expect(result).toEqual([]);
   });
@@ -189,7 +189,7 @@ describe("getContactAttributesWithKeyInfo", () => {
       mixedTypeAttributes as unknown as Prisma.Result<typeof prisma.contactAttribute, unknown, "findMany">
     );
 
-    const result = await getContactAttributesWithKeyInfo(contactId);
+    const result = await getContactAttributesWithKeyInfo(contactId, workspaceId);
 
     expect(result).toHaveLength(3);
     expect(result[0].dataType).toBe("string");
@@ -209,14 +209,14 @@ describe("getContactAttributesWithKeyInfo", () => {
     });
     vi.mocked(prisma.contactAttribute.findMany).mockRejectedValue(prismaError);
 
-    await expect(getContactAttributesWithKeyInfo(contactId)).rejects.toThrow(DatabaseError);
+    await expect(getContactAttributesWithKeyInfo(contactId, workspaceId)).rejects.toThrow(DatabaseError);
   });
 
   test("rethrows non-Prisma errors", async () => {
     const genericError = new Error("Generic error");
     vi.mocked(prisma.contactAttribute.findMany).mockRejectedValue(genericError);
 
-    await expect(getContactAttributesWithKeyInfo(contactId)).rejects.toThrow("Generic error");
+    await expect(getContactAttributesWithKeyInfo(contactId, workspaceId)).rejects.toThrow("Generic error");
   });
 });
 

--- a/apps/web/modules/ee/contacts/lib/contact-attributes.ts
+++ b/apps/web/modules/ee/contacts/lib/contact-attributes.ts
@@ -46,13 +46,19 @@ export const getContactAttributes = reactCache(async (contactId: string) => {
   }
 });
 
-export const getContactAttributesWithKeyInfo = reactCache(async (contactId: string) => {
-  validateInputs([contactId, ZId]);
+/**
+ * Scoped by workspace on purpose: this feeds the contact detail page, which is reached through a
+ * workspace id in the URL. `ContactAttribute` has no workspace column of its own, so the tenant
+ * check goes through the contact it hangs off.
+ */
+export const getContactAttributesWithKeyInfo = reactCache(async (contactId: string, workspaceId: string) => {
+  validateInputs([contactId, ZId], [workspaceId, ZId]);
 
   try {
     const prismaAttributes = await prisma.contactAttribute.findMany({
       where: {
         contactId,
+        contact: { workspaceId },
       },
       select: selectContactAttribute,
     });

--- a/apps/web/modules/ee/contacts/lib/contact-auth.ts
+++ b/apps/web/modules/ee/contacts/lib/contact-auth.ts
@@ -1,0 +1,64 @@
+import "server-only";
+import { notFound } from "next/navigation";
+import { cache as reactCache } from "react";
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { logger } from "@formbricks/logger";
+import { DatabaseError } from "@formbricks/types/errors";
+import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
+import { TWorkspaceAuth } from "@/modules/workspaces/types/workspace-auth";
+
+/**
+ * Resolves the workspace a contact belongs to, or null when the contact does not exist.
+ *
+ * Deliberately not run through `validateInputs`: `contactId` arrives as a raw URL segment, and a
+ * malformed one should 404 exactly like a well-formed id belonging to someone else. Validating here
+ * would raise a `ValidationError` instead and make the two cases distinguishable.
+ *
+ * Module-private on purpose — "resolve any contact's workspace, unscoped" is not something callers
+ * should reach for from the module that owns the tenant boundary. Go through `getContactAuth`.
+ */
+const getWorkspaceIdOfContact = reactCache(async (contactId: string): Promise<string | null> => {
+  try {
+    const contact = await prisma.contact.findUnique({
+      where: { id: contactId },
+      select: { workspaceId: true },
+    });
+
+    return contact?.workspaceId ?? null;
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      logger.error(error, "Error resolving the workspace of a contact");
+      throw new DatabaseError(error.message);
+    }
+    throw error;
+  }
+});
+
+/**
+ * Authorization for pages addressed by both a workspace id and a contact id.
+ *
+ * `getWorkspaceAuth` only ever sees the workspace in the URL, so on its own it cannot tell
+ * whether the contact in the URL is one of that workspace's contacts. Composing "authorize
+ * workspace A" with "load contact X" therefore lets any authenticated user substitute their own
+ * workspace id and read a foreign contact — its attributes (email, userId, arbitrary custom PII),
+ * its responses and its displays. This helper ties the two together and is the choke point every
+ * contact-scoped page must go through.
+ *
+ * Fails closed with a 404 rather than a 403, so a foreign contact id is indistinguishable from one
+ * that does not exist.
+ */
+export const getContactAuth = reactCache(
+  async (workspaceId: string, contactId: string): Promise<TWorkspaceAuth> => {
+    const [workspaceAuth, contactWorkspaceId] = await Promise.all([
+      getWorkspaceAuth(workspaceId),
+      getWorkspaceIdOfContact(contactId),
+    ]);
+
+    if (contactWorkspaceId !== workspaceAuth.workspace.id) {
+      notFound();
+    }
+
+    return workspaceAuth;
+  }
+);

--- a/apps/web/modules/ee/contacts/lib/contacts.ts
+++ b/apps/web/modules/ee/contacts/lib/contacts.ts
@@ -192,6 +192,32 @@ export const getContact = reactCache(async (contactId: string): Promise<TContact
   }
 });
 
+/**
+ * Workspace-scoped variant of {@link getContact}: returns null when the contact exists but lives in
+ * another workspace, so a caller holding an authorized workspace id cannot read a foreign contact.
+ */
+export const getContactInWorkspace = reactCache(
+  async (contactId: string, workspaceId: string): Promise<TContact | null> => {
+    validateInputs([contactId, ZId], [workspaceId, ZId]);
+
+    try {
+      return await prisma.contact.findFirst({
+        where: {
+          id: contactId,
+          workspaceId,
+        },
+        select: selectContact,
+      });
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError) {
+        throw new DatabaseError(error.message);
+      }
+
+      throw error;
+    }
+  }
+);
+
 export const deleteContact = async (contactId: string): Promise<TContact | null> => {
   validateInputs([contactId, ZId]);
 


### PR DESCRIPTION
## What & why

Backport of #8789 to `release/5.3`.

The contact detail page authorized the `workspaceId` in the URL but loaded the contact by `contactId` alone, so any authenticated user could pair their own workspace id with another organization's contact id and read that contact's full attribute set (email, userId, names, custom PII) plus its responses and displays. This adds `getContactAuth(workspaceId, contactId)` and routes the page through it (fails closed with a 404, so a foreign contact id is indistinguishable from a nonexistent one), and scopes the four loaders the page's server components use (`getContactInWorkspace`, `getContactAttributesWithKeyInfo`, `getResponsesByContactId`, `getDisplaysByContactId`) by `workspaceId`.

Minimal single-fix backport per policy. Files changed:

- `apps/web/modules/ee/contacts/lib/contact-auth.ts` (new guard)
- `apps/web/modules/ee/contacts/lib/contacts.ts` (`getContactInWorkspace`)
- `apps/web/modules/ee/contacts/lib/contact-attributes.ts`
- `apps/web/lib/response/service.ts`
- `apps/web/lib/display/service.ts`
- `apps/web/modules/ee/contacts/[contactId]/page.tsx` + `components/activity-section.tsx` + `components/attributes-section.tsx`
- Updates to existing tests: `lib/display/tests/display-queries.test.ts`, `modules/ee/contacts/lib/contact-attributes.test.ts`

Dropped from the original PR per backport policy (net-new tests only): `contact-auth.test.ts`, the new test cases added to `contacts.test.ts` and `response.test.ts`, and `playwright/cross-tenant-contact-access.spec.ts`.

## Linear ticket

Ref ENG-2290

## How this was tested

- `npx vitest run` on the touched suites (`display-queries.test.ts`, `response.test.ts`, `contact-attributes.test.ts`, `contacts.test.ts`): 4 files, 126 tests ✅
- `npx eslint` on all changed source files: clean ✅
- Original PR #8789 was verified red/green on main with a cross-tenant Playwright spec and full `pnpm test` (593 files / 7647 tests ✅); the cherry-pick applied clean (only cosmetic Tailwind class-order drift vs main in `page.tsx`).

No UI change — the only visual difference is a 404 where foreign PII used to render.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] As user A (own org + workspace), open `/workspaces/{workspaceA}/contacts` and click any contact → detail page opens and shows that contact's attributes, responses and displays.
- [ ] In a second org as user B, create a contact and copy its id from the URL. Back as user A, open `/workspaces/{workspaceA}/contacts/{contactOfB}` → **404 "Page not found"**, and none of B's attribute values appear anywhere on the page (check the rendered HTML too).
- [ ] As user A, open `/workspaces/{workspaceA}/contacts/{madeUpId}` → same 404, visually identical to the foreign-contact case. Try both a well-formed-but-unused cuid and obvious junk like `/contacts/abc`.
- [ ] Regression: on A's own contact, the Activity timeline still lists that contact's responses and displays, and the Responses/Displays counts still match.

**Preconditions / test data**

- Two separate organizations, each with its own workspace and at least one contact carrying an email, a userId and one custom attribute.
- The victim contact needs at least one response and one display to exercise the activity loaders.
- Enterprise Contacts entitlement enabled (Cloud or a licensed self-host).

**Risks & regressions**

- Over-blocking: a workspace's own contacts must still open.
- `getResponsesByContactId` and `getDisplaysByContactId` changed signature; both are used only by this page's two components — re-check the Activity timeline and the Responses/Displays counts.
- The missing-contact error changed from `ResourceNotFoundError` to a 404 page — intended, so the two cases are indistinguishable.

**Migrations / env / cutover**

- none
