### PR TITLE
docs: update SSO callback URIs for the Better Auth path change [ENG-1973]

### DIFF
--- a/docs/self-hosting/configuration/auth-sso/azure-ad-oauth.mdx
+++ b/docs/self-hosting/configuration/auth-sso/azure-ad-oauth.mdx
@@ -16,7 +16,14 @@ Do you have a Microsoft Entra ID Tenant? Integrate it with your Formbricks insta
 
 - A Formbricks instance running and accessible.
 
-- The callback URI for your Formbricks instance: `{WEBAPP_URL}/api/auth/callback/azure-ad`
+- The callback URI for your Formbricks instance: `{WEBAPP_URL}/api/auth/oauth2/callback/azuread`
+
+<Warning>
+  **Upgrading from v5.1 or earlier?** This path changed in v5.2. The old URI was
+  `{WEBAPP_URL}/api/auth/callback/azure-ad`. Add the new one under **Redirect URIs** in your app
+  registration or logins will fail. See the [migration guide](/self-hosting/advanced/migration) for the
+  full list of changed callback URLs.
+</Warning>
 
 ## How to connect your Formbricks instance to Microsoft Entra
 

--- a/docs/self-hosting/configuration/auth-sso/keycloak-oidc.mdx
+++ b/docs/self-hosting/configuration/auth-sso/keycloak-oidc.mdx
@@ -12,7 +12,14 @@ Integrating Keycloak with your Formbricks instance allows users to log in using 
 
 - A running Keycloak instance with a configured realm and users.
 - A self-hosted Formbricks instance with a valid [Enterprise license](/self-hosting/advanced/license).
-- The Formbricks callback URI: `{WEBAPP_URL}/api/auth/callback/openid`
+- The Formbricks callback URI: `{WEBAPP_URL}/api/auth/oauth2/callback/openid`
+
+<Warning>
+  **Upgrading from v5.1 or earlier?** This path changed in v5.2. The old URI was
+  `{WEBAPP_URL}/api/auth/callback/openid` (without `/oauth2`). Add the new one to your Keycloak client's
+  **Valid redirect URIs** or logins will fail. See the
+  [migration guide](/self-hosting/advanced/migration) for the full list of changed callback URLs.
+</Warning>
 
 ## Setting up Keycloak OIDC
 
@@ -39,7 +46,7 @@ Integrating Keycloak with your Formbricks instance allows users to log in using 
     - Under **Valid redirect URIs**, add your Formbricks callback URI:
 
     ```
-    https://your-formbricks-domain.com/api/auth/callback/openid
+    https://your-formbricks-domain.com/api/auth/oauth2/callback/openid
     ```
 
     Replace `your-formbricks-domain.com` with your actual Formbricks URL.
@@ -182,7 +189,8 @@ AUTH_SSO_DEFAULT_TEAM_ID=your-team-id-here
   </Accordion>
 
   <Accordion title="Authentication fails with a redirect error">
-    - Verify the **Valid redirect URI** in your Keycloak client matches exactly: `{WEBAPP_URL}/api/auth/callback/openid`
+    - Verify the **Valid redirect URI** in your Keycloak client matches exactly: `{WEBAPP_URL}/api/auth/oauth2/callback/openid`
+    - If you upgraded from v5.1 or earlier, note the path changed in v5.2 — the old `/api/auth/callback/openid` URI no longer works on its own.
     - Check that the OIDC issuer URL is reachable from your Formbricks server. You can test with:
     ```bash
     curl https://your-keycloak-domain.com/realms/your-realm-name/.well-known/openid-configuration

--- a/docs/self-hosting/configuration/auth-sso/open-id-connect.mdx
+++ b/docs/self-hosting/configuration/auth-sso/open-id-connect.mdx
@@ -19,8 +19,15 @@ Integrating your own OIDC (OpenID Connect) instance with your Formbricks instanc
 - `OIDC_SIGNING_ALGORITHM`
 
 <Note>
-  Make sure the Redirect URI for your OIDC Client is set to `{WEBAPP_URL}/api/auth/callback/openid`.
+  Make sure the Redirect URI for your OIDC Client is set to `{WEBAPP_URL}/api/auth/oauth2/callback/openid`.
 </Note>
+
+<Warning>
+  **Upgrading from v5.1 or earlier?** This path changed in v5.2. The old URI was
+  `{WEBAPP_URL}/api/auth/callback/openid` (without `/oauth2`). Add the new one at your OIDC provider or
+  logins will fail. See the [migration guide](/self-hosting/advanced/migration) for the full list of
+  changed callback URLs.
+</Warning>
 
 - Update these environment variables in your `docker-compose.yml` or pass it directly to the running container.
 


### PR DESCRIPTION
## What & why

Since v5.2 the auth stack is Better Auth, which serves generic OAuth providers at
`/api/auth/oauth2/callback/{providerId}` instead of NextAuth's `/api/auth/callback/{provider}`. The
migration guide was updated for this, but the three per-provider SSO setup pages were not — they still
told self-hosters to register the old path. Anyone following those pages (or upgrading and checking
them, as in the linked issue) ends up with a redirect URI their IdP rejects, and SSO login fails.

Docs-only fix, no code touched:

- **OIDC** and **Keycloak**: `/api/auth/callback/openid` → `/api/auth/oauth2/callback/openid`
  (Keycloak had it in three places — requirements, the redirect-URI step, and troubleshooting).
- **Azure AD**: `/api/auth/callback/azure-ad` → `/api/auth/oauth2/callback/azuread`. The provider id
  changed too — `ssoGenericOAuthConfig` registers `azuread`, and `provider-normalization.ts` plus the
  `20260416110000_backfill_legacy_sso_accounts` migration remap existing `account.provider` rows.
- Each page gets a `<Warning>` saying the path changed in v5.2, what the old value was, and a link to
  the migration guide — the issue reporter's point was that the migration guide is clear but these
  pages are where people actually look.

Deliberately left alone: **Google** (`google-oauth.mdx`) is correct as-is — Google and GitHub use
Better Auth's built-in social providers, which keep `/api/auth/callback/{provider}`. **SAML**
(`saml-sso.mdx`) never documented a redirect URI; `preload-connection.ts` creates the Jackson
connection with a wildcard `${WEBAPP_URL}/*`, so there is nothing for a self-hoster to update there.

## Linear ticket

Fixes ENG-1973
Fixes #8603

## How this was tested

- Traced the actual paths in code rather than trusting the docs: `better-auth-providers.ts` splits
  `ssoSocialProviders` (google, github → `/api/auth/callback/{provider}`) from
  `ssoGenericOAuthConfig` (azuread, openid, saml → `/api/auth/oauth2/callback/{providerId}`).
- Confirmed there is no compat shim for the old path — `apps/web/app/api/auth/[...all]` is the only
  Better Auth route, and there is no rewrite for `/api/auth/callback/*` in `next.config` or the proxy.
  So the old URI really does break, matching the issue report.
- Confirmed the Azure provider-id rename is handled server-side (`provider-normalization.ts` maps
  `azure-ad` → `azuread`; the backfill migration updates existing rows), so `azuread` is the correct
  value to document.
- Swept the whole `docs/` tree for `api/auth` to catch anything else stale. Remaining hits are
  correct: the rate-limiting page (`/api/auth/callback/credentials`, `/api/auth/callback/token`, both
  still current per `envoy-rate-limit-coverage.ts`) and the SAML ACS URL
  (`/api/auth/saml/callback`, unchanged).
- `npx prettier --check "docs/self-hosting/configuration/auth-sso/*.mdx"` ✅ ("All matched files use
  Prettier code style!").
- No unit or e2e tests — text-only change to `.mdx` files, no runtime behavior touched.

## Breaking changes

None — docs only. (The underlying callback-path change shipped in v5.2 and is already documented in
the migration guide; this PR only corrects pages that were left out of it.)

## QA / Test Plan

**How to test**

- [ ] Open `/self-hosting/configuration/auth-sso/open-id-connect` in the docs → the Redirect URI note
      reads `{WEBAPP_URL}/api/auth/oauth2/callback/openid`, followed by a warning box about the v5.2
      change that links to the migration guide.
- [ ] Open `/self-hosting/configuration/auth-sso/keycloak-oidc` → all three spots show
      `/api/auth/oauth2/callback/openid`: the Requirements bullet, the "Set the redirect URI" code
      block, and the "Authentication fails with a redirect error" troubleshooting entry.
- [ ] Open `/self-hosting/configuration/auth-sso/azure-ad-oauth` → the Requirements bullet reads
      `{WEBAPP_URL}/api/auth/oauth2/callback/azuread` (note: `azuread`, no hyphen), with the v5.2
      warning box below it.
- [ ] Click the "migration guide" link in each warning → lands on
      `/self-hosting/advanced/migration`, whose SSO Callback URL Change table matches these values.
- [ ] Open `/self-hosting/configuration/auth-sso/google-oauth` → still shows
      `{WEBAPP_URL}/api/auth/callback/google` (unchanged on purpose, no `/oauth2`).
- [ ] End-to-end on a self-hosted instance with an Enterprise license: register
      `{WEBAPP_URL}/api/auth/oauth2/callback/openid` as the only redirect URI on the OIDC client, set
      `OIDC_CLIENT_ID` / `OIDC_CLIENT_SECRET` / `OIDC_ISSUER`, restart, and sign in via the OIDC
      button → login succeeds and lands in the app.
- [ ] Negative check: register only the old `{WEBAPP_URL}/api/auth/callback/openid` and sign in → the
      IdP rejects the request with a redirect-URI mismatch, confirming the doc change is the fix and
      not cosmetic.

**Preconditions / test data**

- Self-hosted Formbricks v5.2+ with a valid Enterprise license (all three providers are
  Enterprise-gated).
- An OIDC provider to point at — Keycloak realm, FusionAuth, or any spec-compliant IdP. An Entra ID
  tenant if you want to cover the Azure page too.
- Docs preview build for the rendering checks; a running instance for the login checks.

**Risks & regressions**

- Very low — no runtime code changed, so nothing can regress in the product.
- Main risk is doc drift in the other direction: if anyone reads the new warning as "replace the old
  URI", they could break a v5.1 rollback. The migration guide advises keeping both registered through
  the transition, and the warnings say "add the new one" rather than "replace", which is worth
  confirming reads clearly.
- Worth a second pair of eyes on the Azure provider id (`azuread` vs `azure-ad`) — it is the one value
  here that is not a straight path prefix change.

**Migrations / env / cutover**

- none
