### PR TITLE
fix(link-survey): don't serialize the survey PIN into the public page (ENG-2098)

### DIFF
--- a/apps/web/modules/survey/link/components/survey-renderer.tsx
+++ b/apps/web/modules/survey/link/components/survey-renderer.tsx
@@ -73,6 +73,11 @@ export const renderSurvey = async ({
   // Extract workspace from pre-fetched context
   const { workspace } = workspaceContext;
 
+  // Every prop passed to a client component is serialized into the RSC payload and readable in the
+  // page source, so the survey handed to them must never carry the PIN — the pin gate itself stays
+  // server-side (see the `survey.pin` branch below and `validateSurveyPinAction`).
+  const publicSurvey: TSurvey = { ...survey, pin: null };
+
   const isSpamProtectionEnabled = Boolean(IS_RECAPTCHA_CONFIGURED && survey.recaptcha?.enabled);
   const isScheduled = survey.status === "paused" && survey.publishOn !== null;
 
@@ -110,7 +115,7 @@ export const renderSurvey = async ({
     if (emailVerificationStatus === "fishy") {
       return (
         <VerifyEmail
-          survey={survey}
+          survey={publicSurvey}
           isErrorComponent={true}
           languageCode={getLanguageCode(langParam, survey)}
           styling={workspace.styling}
@@ -122,7 +127,7 @@ export const renderSurvey = async ({
       <VerifyEmail
         singleUseId={searchParams.suId ?? ""}
         singleUseToken={searchParams.suToken}
-        survey={survey}
+        survey={publicSurvey}
         languageCode={getLanguageCode(langParam, survey)}
         styling={workspace.styling}
         locale={locale}
@@ -169,7 +174,7 @@ export const renderSurvey = async ({
   // Render interactive survey with client component for interactivity
   return (
     <SurveyClientWrapper
-      survey={survey}
+      survey={publicSurvey}
       workspace={workspace}
       styling={styling}
       publicDomain={publicDomain}


### PR DESCRIPTION
## What & why

On the public link-survey page, `survey-renderer.tsx` rendered `<VerifyEmail survey={survey} />` — a `"use client"` component receiving the full `TSurvey` — **before** the `if (survey.pin)` gate. Everything passed to a client component is serialized into the RSC payload, so for a survey with both "Verify email before submission" and a PIN enabled, the plaintext PIN was readable in the page source by any anonymous visitor, bypassing the PIN gate entirely.

The fetcher (`getSurveyWithMetadata`) can't drop `pin`: `validateSurveyPinAction` and the renderer's own `if (survey.pin)` branch read it from the same cached result. So the fix strips it at the client boundary instead: `survey-renderer.tsx` builds `const publicSurvey: TSurvey = { ...survey, pin: null }` once and passes that to every client component that takes the survey — both `<VerifyEmail>` renders and `<SurveyClientWrapper>` (defensive there; it's only reached when `pin` is falsy). The PIN check itself stays server-side and is unchanged; `VerifyEmail` never reads `pin` (it uses id, name, languages and styling), so nothing observable changes for legitimate flows.

`PinScreen` was already safe — it receives `surveyId`, not the survey object.

## Linear ticket

Fixes ENG-2098

## How this was tested

- `npx vitest run modules/survey/link` — 12 files, 158 tests ✅
- `npx eslint` + `npx prettier --check` on the changed file ✅ (lint-staged also ran both on commit)
- `tsc --noEmit` over `apps/web`: no errors in the changed file or anywhere under `modules/survey/link` (remaining workspace errors are pre-existing infra noise — svg module declarations and playwright specs, which raw `tsc` outside Next's toolchain doesn't type).
- No unit test added: the change is inside a `.tsx` server component, and repo policy is no component/UI unit tests for `.tsx` files.

No UI change — the email-verification screen renders exactly as before; only the serialized RSC payload no longer contains the PIN.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Create a link survey, enable "Verify email before submission" (Settings → Response Options) and set a 4-digit PIN. Publish.
- [ ] Open the public link in an incognito window (no `?verify=` token) → the email-verification screen renders.
- [ ] View page source (and the network response for the document) and search for the PIN value → **it must not appear anywhere**.
- [ ] Complete the email verification (request the link, open it) → the PIN screen appears; entering the wrong PIN is rejected, entering the correct PIN opens the survey and it can be submitted.
- [ ] Regression — survey with email verification but **no** PIN: verification screen renders, then the survey loads and submits normally.
- [ ] Regression — survey with a PIN but **no** email verification: PIN screen renders directly; correct PIN opens the survey.
- [ ] Regression — multi-language survey with email verification: the verification screen still shows the translated survey name with `?lang=<code>`.

**Preconditions / test data**

- Any workspace with one published link survey; PIN + email verification toggles are in the survey's Response Options. No entitlement needed.
- A mail inbox (or local mail catcher) to receive the verification email.

**Risks & regressions**

- `VerifyEmail` and `SurveyClientWrapper` now receive a survey whose `pin` is always `null`. Neither reads `pin` today; if a future change needs it client-side, it must go through a server action instead.
- The server-side PIN gate (`if (survey.pin)`) and `validateSurveyPinAction` still read the unstripped survey — unchanged.

**Migrations / env / cutover**

- none
