### PR TITLE
fix(surveys): clear stale link-survey PIN token on survey switch [ENG-2002]

### DIFF
--- a/packages/surveys/src/lib/response.queue.test.ts
+++ b/packages/surveys/src/lib/response.queue.test.ts
@@ -372,6 +372,29 @@ describe("ResponseQueue", () => {
     }
   });
 
+  test("sendResponse forwards the PIN auth token in the create payload", async () => {
+    surveyState.pinAuthToken = "pin-token-123";
+    apiMock.createResponse.mockResolvedValue({ ok: true, data: { id: "newid" } });
+
+    await queue.sendResponse(responseUpdate);
+
+    expect(apiMock.createResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ pinAuthToken: "pin-token-123" })
+    );
+  });
+
+  test("sendResponse forwards the PIN auth token in the update payload", async () => {
+    surveyState.responseId = "resp1";
+    surveyState.pinAuthToken = "pin-token-123";
+    apiMock.updateResponse.mockResolvedValue({ ok: true, data: { quotaFull: false } });
+
+    await queue.sendResponse(responseUpdate);
+
+    expect(apiMock.updateResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ pinAuthToken: "pin-token-123" })
+    );
+  });
+
   test("updateSurveyState updates surveyState", () => {
     const newState = getSurveyState();
     queue.updateSurveyState(newState);

--- a/packages/surveys/src/lib/survey-state.test.ts
+++ b/packages/surveys/src/lib/survey-state.test.ts
@@ -44,6 +44,18 @@ describe("SurveyState", () => {
       expect(surveyState.responseId).toBeNull();
       expect(surveyState.responseAcc).toEqual({ finished: false, data: {}, ttc: {}, variables: {} });
     });
+
+    test("should clear the pinAuthToken when switching to a different survey", () => {
+      surveyState.pinAuthToken = "pin-token-for-survey1";
+      surveyState.setSurveyId("survey2");
+      expect(surveyState.pinAuthToken).toBeNull();
+    });
+
+    test("should preserve the pinAuthToken on a same-survey reset", () => {
+      surveyState.pinAuthToken = "pin-token-for-survey1";
+      surveyState.setSurveyId(initialSurveyId);
+      expect(surveyState.pinAuthToken).toBe("pin-token-for-survey1");
+    });
   });
 
   describe("copy", () => {

--- a/packages/surveys/src/lib/survey-state.ts
+++ b/packages/surveys/src/lib/survey-state.ts
@@ -32,6 +32,13 @@ export class SurveyState {
    * @param id - The survey ID
    */
   setSurveyId(id: string) {
+    // Clear the PIN auth token when switching to a different survey: it is a signed
+    // capability bound to a single surveyId and must not outlive that survey. Preserve
+    // it for same-survey resets so a user restarting the same PIN-protected survey is
+    // not re-prompted for the PIN.
+    if (id !== this.surveyId) {
+      this.pinAuthToken = null;
+    }
     this.surveyId = id;
     this.clear(); // Reset the state when setting a new surveyId
   }


### PR DESCRIPTION
## What & why

`SurveyState.clear()` never reset `pinAuthToken`, so `setSurveyId()` — which reuses the instance and calls `clear()` — carried the previous survey's signed PIN JWT (bound to one `surveyId`, 1h TTL) over to a different survey. `ResponseQueue.sendResponse()` then forwarded that stale capability token in every create and update response payload:

- Credential hygiene: a valid, unexpired token sent to endpoints it was never issued for.
- If the new survey is also PIN-protected, server-side verification fails (`payload.surveyId !== surveyId`) → 401 instead of re-prompting → silently lost responses.

No cross-survey authorization bypass (the server checks the token's bound `surveyId`), but a stale credential should never outlive its survey.

Fix: `setSurveyId(id)` clears `pinAuthToken` only when `id !== this.surveyId` (captured before overwrite), and preserves it for same-survey resets so a user finishing/restarting the same PIN-protected survey is not re-prompted.

Follow-up from CodeRabbit on PR #8615; the code originates on `main` (PR #8506 / ENG-1579 PIN enforcement).

## Linear ticket

Fixes ENG-2002

## How this was tested

- `vitest run src/lib/survey-state.test.ts src/lib/response.queue.test.ts` → ✅ 77 passed
- Added `SurveyState` tests: token cleared on survey switch, preserved on same-survey reset.
- Added `ResponseQueue` tests: both create and update payloads forward a non-null `pinAuthToken`.
- `prettier --check` on changed files → clean.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] App-mode SDK with two link surveys where survey A is PIN-protected. Enter A's PIN, submit a response → 200, response recorded.
- [ ] In the same widget instance, switch to survey B (different `surveyId`), submit → request must NOT carry survey A's `pinAuthToken`; response recorded normally.
- [ ] If survey B is also PIN-protected → user is re-prompted for B's PIN (not silently 401'd with A's stale token).
- [ ] Same-survey restart of PIN survey A (finish then restart) → NOT re-prompted for the PIN; token preserved.

**Preconditions / test data**

- Client/app-mode embed with at least two link surveys, one PIN-protected. Client response API.

**Risks & regressions**

- PIN re-prompt UX on survey switch; same-survey restart should still skip the PIN. Re-check response create/update payloads still include the token for the active survey.

**Migrations / env / cutover**

- none
