### PR TITLE
fix: canonicalize client IP resolution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -366,7 +366,9 @@ ENTERPRISE_LICENSE_KEY=
 # only the rightmost N entries were added by infrastructure you control. Defaults to 1, which is
 # correct for a single nginx/Traefik/Envoy in front of the app. Set it to 2 if Cloudflare (or another
 # CDN) also fronts that proxy, and so on. Setting it higher than your real topology lets callers spoof
-# their address again by prepending entries; setting it to 0 believes no forwarding header at all,
+# their address again by prepending entries. A chain shorter than this setting, or a malformed selected
+# hop, fails closed. IPv4 ports appended by gateways are removed and IPv6 addresses are grouped by /64.
+# Setting it to 0 believes no forwarding header at all,
 # which means IP-based rate limiting and the IP recorded on responses and audit logs cannot identify
 # individual clients. cf-connecting-ip is never trusted — Cloudflare also populates X-Forwarded-For.
 # TRUSTED_PROXY_HOP_COUNT=1

--- a/.env.example
+++ b/.env.example
@@ -367,8 +367,8 @@ ENTERPRISE_LICENSE_KEY=
 # correct for a single nginx/Traefik/Envoy in front of the app. Set it to 2 if Cloudflare (or another
 # CDN) also fronts that proxy, and so on. Setting it higher than your real topology lets callers spoof
 # their address again by prepending entries. A chain shorter than this setting, or a malformed selected
-# hop, fails closed. IPv4 ports appended by gateways are removed and IPv6 addresses are grouped by /64.
-# Setting it to 0 believes no forwarding header at all,
+# hop, fails closed. Ports appended by gateways are removed and IPv6 addresses are grouped by /64.
+# Setting it to 0 trusts no forwarding headers at all,
 # which means IP-based rate limiting and the IP recorded on responses and audit logs cannot identify
 # individual clients. cf-connecting-ip is never trusted — Cloudflare also populates X-Forwarded-For.
 # TRUSTED_PROXY_HOP_COUNT=1

--- a/apps/web/lib/utils/client-ip.test.ts
+++ b/apps/web/lib/utils/client-ip.test.ts
@@ -176,21 +176,25 @@ describe("client IP diagnostics", () => {
   test("emits throttled, reason-specific warnings without forwarding values", async () => {
     const { logger, freshResolveClientIp } = await loadFresh();
     const invalidValue = "sensitive-invalid-forwarded-value";
+    const ignoredHeaderValue = "sensitive-untrusted-forwarding-value";
 
     freshResolveClientIp(buildHeaders({ "x-forwarded-for": "203.0.113.7" }), 0);
     freshResolveClientIp(buildHeaders({ "x-forwarded-for": "203.0.113.7" }), 0);
+    freshResolveClientIp(buildHeaders({ "x-real-ip": ignoredHeaderValue }), 1);
     freshResolveClientIp(buildHeaders({ "x-forwarded-for": "203.0.113.7" }), 2);
     freshResolveClientIp(buildHeaders({ "x-forwarded-for": invalidValue }), 1);
 
-    expect(logger.warn).toHaveBeenCalledTimes(3);
+    expect(logger.warn).toHaveBeenCalledTimes(4);
     const warningText = vi
       .mocked(logger.warn)
       .mock.calls.map(([message]) => message)
       .join(" ");
     expect(warningText).toContain("disabled");
+    expect(warningText).toContain("X-Forwarded-For is absent");
     expect(warningText).toContain("fewer entries");
     expect(warningText).toContain("not a valid supported IP address");
     expect(warningText).not.toContain(invalidValue);
+    expect(warningText).not.toContain(ignoredHeaderValue);
   });
 
   test("warns again after the ten-minute throttle window", async () => {

--- a/apps/web/lib/utils/client-ip.test.ts
+++ b/apps/web/lib/utils/client-ip.test.ts
@@ -1,116 +1,110 @@
+import { getIp } from "@better-auth/core/utils/ip";
 import * as nextHeaders from "next/headers";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { UNTRUSTED_CLIENT_IP, getClientIpFromHeaders, resolveClientIp } from "./client-ip";
-
-// Mock next/headers
-declare module "next/headers" {
-  export function headers(): any;
-}
+import {
+  BETTER_AUTH_IP_ADDRESS_CONFIG,
+  FORMBRICKS_CLIENT_IP_HEADER,
+  UNTRUSTED_CLIENT_IP,
+  getClientIpFromHeaders,
+  resolveClientIp,
+} from "./client-ip";
 
 vi.mock("next/headers", () => ({
   headers: vi.fn(),
 }));
 
-// Mirrors the shipped default of 1: one trusted reverse proxy in front of the app.
-vi.mock("@/lib/constants", () => ({ TRUSTED_PROXY_HOP_COUNT: 1 }));
-
 vi.mock("@formbricks/logger", () => ({
-  logger: { error: vi.fn() },
+  logger: { error: vi.fn(), warn: vi.fn() },
 }));
 
-const buildHeaders = (headerMap: Record<string, string | undefined>): Headers =>
-  ({
-    get: (key: string) => headerMap[key.toLowerCase()] ?? null,
-  }) as Headers;
+const buildHeaders = (headerMap: Record<string, string> = {}): Headers => new Headers(headerMap);
 
-const mockHeaders = (headerMap: Record<string, string | undefined>) => {
-  vi.mocked(nextHeaders.headers).mockReturnValue(buildHeaders(headerMap));
+const mockHeaders = (headerMap: Record<string, string>) => {
+  vi.mocked(nextHeaders.headers).mockResolvedValue(buildHeaders(headerMap) as never);
 };
 
 describe("resolveClientIp", () => {
-  // Regression: X-Forwarded-For is appended to by each proxy, so its leftmost entry is client-supplied.
-  // Reading it let a caller rotate the header to mint a fresh rate-limit bucket per request, bypassing
-  // the login / forgot-password / signup / public-API limits, and to forge captured IPs.
-  describe("with one trusted proxy", () => {
-    test("takes the entry the trusted proxy appended, not the client-supplied one", () => {
-      const headers = buildHeaders({ "x-forwarded-for": "1.1.1.1, 203.0.113.7" });
-      expect(resolveClientIp(headers, 1)).toBe("203.0.113.7");
+  test("selects the trusted hop from the right and ignores any client-prepended entries", () => {
+    const headers = buildHeaders({
+      "x-forwarded-for": "9.9.9.9, 8.8.8.8, 203.0.113.7, 10.0.0.1",
     });
 
-    test("ignores a spoofed chain the client prepended", () => {
-      const headers = buildHeaders({
-        "x-forwarded-for": "9.9.9.9, 8.8.8.8, 7.7.7.7, 203.0.113.7",
-      });
-      expect(resolveClientIp(headers, 1)).toBe("203.0.113.7");
-    });
-
-    // A hop count says "one proxy is in front", not "that proxy is Cloudflare". Traefik, Envoy and
-    // nginx all pass cf-connecting-ip through untouched, so believing it ahead of the hop-counted
-    // chain would hand the spoof straight back to the caller.
-    test("ignores cf-connecting-ip in favour of the forwarded chain", () => {
-      const headers = buildHeaders({
-        "cf-connecting-ip": "198.51.100.5",
-        "x-forwarded-for": "1.1.1.1, 203.0.113.7",
-      });
-      expect(resolveClientIp(headers, 1)).toBe("203.0.113.7");
-    });
-
-    test("ignores cf-connecting-ip even when it is the only header present", () => {
-      const headers = buildHeaders({ "cf-connecting-ip": "198.51.100.5" });
-      expect(resolveClientIp(headers, 1)).toBe(UNTRUSTED_CLIENT_IP);
-    });
-
-    test("trims whitespace around the selected entry", () => {
-      const headers = buildHeaders({ "x-forwarded-for": "  1.1.1.1  ,   203.0.113.7  " });
-      expect(resolveClientIp(headers, 1)).toBe("203.0.113.7");
-    });
-
-    // Regression: x-real-ip is only ever reached when no XFF arrived, which means the request did not
-    // come through the proxy this app is configured to trust — so the header is caller-supplied, and
-    // honouring it would hand back the per-request bucket rotation this function exists to stop.
-    test("ignores x-real-ip when there is no forwarded chain", () => {
-      const headers = buildHeaders({ "x-real-ip": "203.0.113.9" });
-      expect(resolveClientIp(headers, 1)).toBe(UNTRUSTED_CLIENT_IP);
-    });
-
-    test("ignores x-real-ip even when a forwarded chain is present", () => {
-      const headers = buildHeaders({
-        "x-forwarded-for": "1.1.1.1, 203.0.113.7",
-        "x-real-ip": "9.9.9.9",
-      });
-      expect(resolveClientIp(headers, 1)).toBe("203.0.113.7");
-    });
-
-    test("reports the client as untrusted when no header identifies it", () => {
-      expect(resolveClientIp(buildHeaders({}), 1)).toBe(UNTRUSTED_CLIENT_IP);
-    });
+    expect(resolveClientIp(headers, 2)).toBe("203.0.113.7");
   });
 
-  describe("with two trusted proxies", () => {
-    test("takes the second entry from the right", () => {
-      const headers = buildHeaders({ "x-forwarded-for": "1.1.1.1, 203.0.113.7, 10.0.0.1" });
-      expect(resolveClientIp(headers, 2)).toBe("203.0.113.7");
-    });
+  test.each(["203.0.113.7:80", "203.0.113.7:443", "203.0.113.7:65535"])(
+    "removes a valid IPv4 port from %s",
+    (forwardedIp) => {
+      expect(resolveClientIp(buildHeaders({ "x-forwarded-for": forwardedIp }), 1)).toBe("203.0.113.7");
+    }
+  );
 
-    test("clamps to the earliest entry when the chain is shorter than configured", () => {
-      const headers = buildHeaders({ "x-forwarded-for": "203.0.113.7" });
-      expect(resolveClientIp(headers, 2)).toBe("203.0.113.7");
-    });
+  test("keeps distinct IPv4 clients in distinct identities", () => {
+    const firstClient = resolveClientIp(buildHeaders({ "x-forwarded-for": "203.0.113.7" }), 1);
+    const secondClient = resolveClientIp(buildHeaders({ "x-forwarded-for": "203.0.113.8" }), 1);
+
+    expect(firstClient).not.toBe(secondClient);
   });
 
-  describe("with no trusted proxy", () => {
-    test.each([
-      ["x-forwarded-for", { "x-forwarded-for": "1.1.1.1, 203.0.113.7" }],
-      ["cf-connecting-ip", { "cf-connecting-ip": "1.1.1.1" }],
-      ["x-real-ip", { "x-real-ip": "1.1.1.1" }],
-    ])("does not believe %s", (_label, headerMap) => {
-      expect(resolveClientIp(buildHeaders(headerMap), 0)).toBe(UNTRUSTED_CLIENT_IP);
-    });
+  test.each(["[2001:DB8:abcd:12::99]", "[2001:DB8:abcd:12::99]:443"])(
+    "accepts bracketed IPv6 with an optional valid port in %s",
+    (forwardedIp) => {
+      expect(resolveClientIp(buildHeaders({ "x-forwarded-for": forwardedIp }), 1)).toBe(
+        "2001:0db8:abcd:0012:0000:0000:0000:0000"
+      );
+    }
+  );
 
-    test("treats a negative hop count as zero", () => {
-      const headers = buildHeaders({ "x-forwarded-for": "1.1.1.1" });
-      expect(resolveClientIp(headers, -1)).toBe(UNTRUSTED_CLIENT_IP);
-    });
+  test("converts IPv4-mapped IPv6 to IPv4", () => {
+    expect(resolveClientIp(buildHeaders({ "x-forwarded-for": "::ffff:192.0.2.128" }), 1)).toBe("192.0.2.128");
+  });
+
+  test.each(["2001:DB8:abcd:12::1", "2001:0db8:abcd:0012:ffff:eeee:dddd:cccc"])(
+    "canonicalizes IPv6 variants and masks host bits for %s",
+    (forwardedIp) => {
+      expect(resolveClientIp(buildHeaders({ "x-forwarded-for": forwardedIp }), 1)).toBe(
+        "2001:0db8:abcd:0012:0000:0000:0000:0000"
+      );
+    }
+  );
+
+  test("treats a valid raw IPv6 value as an address, not an unbracketed socket", () => {
+    expect(resolveClientIp(buildHeaders({ "x-forwarded-for": "2001:db8::1:443" }), 1)).toBe(
+      "2001:0db8:0000:0000:0000:0000:0000:0000"
+    );
+  });
+
+  test.each([
+    "",
+    "not-an-ip",
+    "203.0.113.7:0",
+    "203.0.113.7:65536",
+    "203.0.113.7:http",
+    "[203.0.113.7]:443",
+    "[2001:db8::1",
+    "[2001:db8::1]:",
+    "[2001:db8::1]:443:1",
+    "2001:db8::1%eth0",
+  ])("rejects malformed or ambiguous selected values: %s", (forwardedIp) => {
+    expect(resolveClientIp(buildHeaders({ "x-forwarded-for": forwardedIp }), 1)).toBeNull();
+  });
+
+  test("returns null when the forwarding chain is absent", () => {
+    expect(resolveClientIp(buildHeaders(), 1)).toBeNull();
+  });
+
+  test("returns null instead of clamping when the chain is shorter than configured", () => {
+    expect(resolveClientIp(buildHeaders({ "x-forwarded-for": "203.0.113.7" }), 2)).toBeNull();
+  });
+
+  test("returns null when trusted-hop resolution is disabled", () => {
+    expect(resolveClientIp(buildHeaders({ "x-forwarded-for": "203.0.113.7" }), 0)).toBeNull();
+  });
+
+  test("never falls back to untrusted forwarding headers", () => {
+    expect(
+      resolveClientIp(buildHeaders({ "cf-connecting-ip": "198.51.100.5", "x-real-ip": "203.0.113.9" }), 1)
+    ).toBeNull();
   });
 });
 
@@ -119,31 +113,59 @@ describe("getClientIpFromHeaders", () => {
     vi.clearAllMocks();
   });
 
-  // At the shipped default of 1, the address is the entry the single trusted proxy appended, and the
-  // client-supplied prefix and `cf-connecting-ip` are both ignored.
-  test("takes the trusted proxy's entry at the default hop count of 1", async () => {
-    mockHeaders({ "cf-connecting-ip": "1.2.3.4", "x-forwarded-for": "9.9.9.9, 203.0.113.7" });
-    await expect(getClientIpFromHeaders()).resolves.toBe("203.0.113.7");
+  test("returns the canonical identity from the private Proxy header", async () => {
+    mockHeaders({ [FORMBRICKS_CLIENT_IP_HEADER]: "2001:DB8:abcd:12::99" });
+
+    await expect(getClientIpFromHeaders()).resolves.toBe("2001:0db8:abcd:0012:0000:0000:0000:0000");
   });
 
-  test("reports the client as untrusted when no header identifies it", async () => {
-    mockHeaders({});
-    await expect(getClientIpFromHeaders()).resolves.toBe(UNTRUSTED_CLIENT_IP);
-  });
-
-  test("handles errors when headers() throws an exception", async () => {
-    vi.mocked(nextHeaders.headers).mockImplementation(() => {
-      throw new Error("Failed to get headers");
+  test("ignores raw forwarding headers when the private Proxy header is absent", async () => {
+    mockHeaders({
+      "x-forwarded-for": "198.51.100.4",
+      "x-real-ip": "198.51.100.5",
+      "cf-connecting-ip": "198.51.100.6",
     });
 
     await expect(getClientIpFromHeaders()).resolves.toBe(UNTRUSTED_CLIENT_IP);
   });
+
+  test.each(["not-an-ip", "203.0.113.7:443", "203.0.113.7, 198.51.100.4"])(
+    "rejects a non-canonical private header value: %s",
+    async (clientIp) => {
+      mockHeaders({ [FORMBRICKS_CLIENT_IP_HEADER]: clientIp });
+      await expect(getClientIpFromHeaders()).resolves.toBe(UNTRUSTED_CLIENT_IP);
+    }
+  );
+
+  test("returns the stable untrusted identity when the private header is absent", async () => {
+    mockHeaders({});
+    await expect(getClientIpFromHeaders()).resolves.toBe(UNTRUSTED_CLIENT_IP);
+  });
+
+  test("returns the stable untrusted identity when headers() fails", async () => {
+    vi.mocked(nextHeaders.headers).mockRejectedValue(new Error("Failed to get headers"));
+    await expect(getClientIpFromHeaders()).resolves.toBe(UNTRUSTED_CLIENT_IP);
+  });
 });
 
-describe("misconfiguration warning", () => {
-  // The throttle timestamp is module-level state, so each case re-imports the module to get a fresh
-  // one. The logger has to be imported *after* the reset too, or it would be a different mock instance
-  // than the one the re-imported module captured.
+describe("Better Auth IP configuration", () => {
+  test("resolves only the single-value private Proxy header with the shared IPv6 prefix", () => {
+    const requestHeaders = buildHeaders({
+      [FORMBRICKS_CLIENT_IP_HEADER]: "2001:0db8:abcd:0012:0000:0000:0000:0000",
+      "x-forwarded-for": "198.51.100.4, 203.0.113.7",
+    });
+
+    expect(BETTER_AUTH_IP_ADDRESS_CONFIG).toEqual({
+      ipAddressHeaders: [FORMBRICKS_CLIENT_IP_HEADER],
+      ipv6Subnet: 64,
+    });
+    expect(getIp(requestHeaders, { advanced: { ipAddress: BETTER_AUTH_IP_ADDRESS_CONFIG } } as never)).toBe(
+      "2001:0db8:abcd:0012:0000:0000:0000:0000"
+    );
+  });
+});
+
+describe("client IP diagnostics", () => {
   const loadFresh = async () => {
     vi.resetModules();
     const { logger } = await import("@formbricks/logger");
@@ -151,53 +173,49 @@ describe("misconfiguration warning", () => {
     return { logger, freshResolveClientIp };
   };
 
-  test("warns once per throttle window when forwarding headers arrive but no hop is trusted", async () => {
+  test("emits throttled, reason-specific warnings without forwarding values", async () => {
     const { logger, freshResolveClientIp } = await loadFresh();
-    const headers = buildHeaders({ "x-forwarded-for": "1.1.1.1, 203.0.113.7" });
+    const invalidValue = "sensitive-invalid-forwarded-value";
 
-    freshResolveClientIp(headers, 0);
-    freshResolveClientIp(headers, 0);
-    freshResolveClientIp(buildHeaders({ "cf-connecting-ip": "1.1.1.1" }), 0);
+    freshResolveClientIp(buildHeaders({ "x-forwarded-for": "203.0.113.7" }), 0);
+    freshResolveClientIp(buildHeaders({ "x-forwarded-for": "203.0.113.7" }), 0);
+    freshResolveClientIp(buildHeaders({ "x-forwarded-for": "203.0.113.7" }), 2);
+    freshResolveClientIp(buildHeaders({ "x-forwarded-for": invalidValue }), 1);
 
-    expect(logger.error).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(logger.error).mock.calls[0][0]).toContain("TRUSTED_PROXY_HOP_COUNT");
+    expect(logger.warn).toHaveBeenCalledTimes(3);
+    const warningText = vi
+      .mocked(logger.warn)
+      .mock.calls.map(([message]) => message)
+      .join(" ");
+    expect(warningText).toContain("disabled");
+    expect(warningText).toContain("fewer entries");
+    expect(warningText).toContain("not a valid supported IP address");
+    expect(warningText).not.toContain(invalidValue);
   });
 
-  // The point of the time window over a once-per-process flag: an operator who leaves
-  // TRUSTED_PROXY_HOP_COUNT=0 keeps getting a signal, instead of one line at boot and silence after.
-  test("warns again after the throttle window elapses", async () => {
+  test("warns again after the ten-minute throttle window", async () => {
     const { logger, freshResolveClientIp } = await loadFresh();
-    const headers = buildHeaders({ "x-forwarded-for": "1.1.1.1, 203.0.113.7" });
+    const forwardedHeaders = buildHeaders({ "x-forwarded-for": "203.0.113.7" });
 
     vi.useFakeTimers();
     try {
-      freshResolveClientIp(headers, 0);
-      expect(logger.error).toHaveBeenCalledTimes(1);
-
+      freshResolveClientIp(forwardedHeaders, 0);
       vi.advanceTimersByTime(9 * 60 * 1000);
-      freshResolveClientIp(headers, 0);
-      expect(logger.error).toHaveBeenCalledTimes(1);
-
+      freshResolveClientIp(forwardedHeaders, 0);
       vi.advanceTimersByTime(2 * 60 * 1000);
-      freshResolveClientIp(headers, 0);
-      expect(logger.error).toHaveBeenCalledTimes(2);
+      freshResolveClientIp(forwardedHeaders, 0);
+
+      expect(logger.warn).toHaveBeenCalledTimes(2);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  test("stays quiet when the request carries no forwarding header at all", async () => {
+  test("keeps completely headerless requests quiet", async () => {
     const { logger, freshResolveClientIp } = await loadFresh();
 
-    expect(freshResolveClientIp(buildHeaders({}), 0)).toBe(UNTRUSTED_CLIENT_IP);
-    expect(logger.error).not.toHaveBeenCalled();
-  });
-
-  test("stays quiet when a hop is trusted", async () => {
-    const { logger, freshResolveClientIp } = await loadFresh();
-
-    freshResolveClientIp(buildHeaders({ "x-forwarded-for": "1.1.1.1, 203.0.113.7" }), 1);
-
-    expect(logger.error).not.toHaveBeenCalled();
+    expect(freshResolveClientIp(buildHeaders(), 0)).toBeNull();
+    expect(freshResolveClientIp(buildHeaders(), 1)).toBeNull();
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/lib/utils/client-ip.ts
+++ b/apps/web/lib/utils/client-ip.ts
@@ -22,12 +22,15 @@ const VALID_DECIMAL_PORT = /^[1-9]\d{0,4}$/;
 const BRACKETED_ADDRESS = /^\[([^\[\]]+)\](?::([^:]+))?$/;
 const IPV4_SOCKET = /^([^:]+):(\d+)$/;
 
-type ClientIpWarningReason = "disabled" | "invalid-selected-hop" | "short-chain";
+type ClientIpWarningReason = "disabled" | "invalid-selected-hop" | "missing-chain" | "short-chain";
 
 const clientIpWarningMessages: Record<ClientIpWarningReason, string> = {
   disabled:
     "Client IP resolution is disabled because TRUSTED_PROXY_HOP_COUNT is 0 while forwarding headers " +
     "are present. IP-based limits and captured IP metadata will use the shared untrusted identity.",
+  "missing-chain":
+    "Client IP resolution failed because X-Forwarded-For is absent. Configure the proxy to append it; " +
+    "x-real-ip and cf-connecting-ip are not trusted client identity sources.",
   "short-chain":
     "Client IP resolution failed because X-Forwarded-For has fewer entries than " +
     "TRUSTED_PROXY_HOP_COUNT. Verify that every configured proxy appends to the forwarding chain.",
@@ -106,7 +109,7 @@ export const resolveClientIp = (headersList: Headers, hopCount: number): string 
 
   const xForwardedFor = headersList.get("x-forwarded-for");
   if (xForwardedFor === null) {
-    if (hasAnyForwardingHeader(headersList)) warnAboutClientIp("short-chain");
+    if (hasAnyForwardingHeader(headersList)) warnAboutClientIp("missing-chain");
     return null;
   }
 

--- a/apps/web/lib/utils/client-ip.ts
+++ b/apps/web/lib/utils/client-ip.ts
@@ -1,107 +1,140 @@
+import { isValidIP, normalizeIP } from "@better-auth/core/utils/ip";
 import { headers } from "next/headers";
 import { logger } from "@formbricks/logger";
-import { TRUSTED_PROXY_HOP_COUNT } from "@/lib/constants";
 
-/**
- * Returned when no forwarding header may be believed, so the client is genuinely unidentifiable.
- *
- * Next 16 exposes no socket peer address to route handlers or server actions (`NextRequest.ip` was
- * removed and `headers()` carries only HTTP headers), so with no trusted proxy there is nothing else to
- * fall back to.
- */
+/** Private request header written by Proxy after the trusted forwarding hop has been resolved. */
+export const FORMBRICKS_CLIENT_IP_HEADER = "x-formbricks-client-ip";
+
+/** Collapse IPv6 identities to a stable network prefix before rate limiting or persistence. */
+export const CLIENT_IP_IPV6_SUBNET_PREFIX = 64;
+
+/** Better Auth must consume exactly the same private request identity as the rest of Formbricks. */
+export const BETTER_AUTH_IP_ADDRESS_CONFIG = {
+  ipAddressHeaders: [FORMBRICKS_CLIENT_IP_HEADER],
+  ipv6Subnet: CLIENT_IP_IPV6_SUBNET_PREFIX,
+};
+
+/** Stable downstream identity when Proxy could not establish a trustworthy client address. */
 export const UNTRUSTED_CLIENT_IP = "untrusted-client-ip";
 
-/**
- * Throttle window for the misconfiguration warning. Time-based rather than once-per-process: a warning
- * that fires only on the first request goes silent for the life of a long-running deployment, so an
- * ongoing misconfiguration disappears from monitoring after one line. Raised by CodeRabbit on #8680.
- */
-const UNTRUSTED_IP_WARNING_INTERVAL_MS = 10 * 60 * 1000;
+const CLIENT_IP_WARNING_INTERVAL_MS = 10 * 60 * 1000;
+const VALID_DECIMAL_PORT = /^[1-9]\d{0,4}$/;
+const BRACKETED_ADDRESS = /^\[([^\[\]]+)\](?::([^:]+))?$/;
+const IPV4_SOCKET = /^([^:]+):(\d+)$/;
 
-let lastUntrustedIpWarningAt: number | null = null;
+type ClientIpWarningReason = "disabled" | "invalid-selected-hop" | "short-chain";
 
-const warnAboutUntrustedIp = (): void => {
+const clientIpWarningMessages: Record<ClientIpWarningReason, string> = {
+  disabled:
+    "Client IP resolution is disabled because TRUSTED_PROXY_HOP_COUNT is 0 while forwarding headers " +
+    "are present. IP-based limits and captured IP metadata will use the shared untrusted identity.",
+  "short-chain":
+    "Client IP resolution failed because X-Forwarded-For has fewer entries than " +
+    "TRUSTED_PROXY_HOP_COUNT. Verify that every configured proxy appends to the forwarding chain.",
+  "invalid-selected-hop":
+    "Client IP resolution failed because the selected trusted X-Forwarded-For hop is not a valid " +
+    "supported IP address. The request will use the shared untrusted identity.",
+};
+
+const lastClientIpWarningAt: Partial<Record<ClientIpWarningReason, number>> = {};
+
+const warnAboutClientIp = (reason: ClientIpWarningReason): void => {
   const now = Date.now();
-  if (
-    lastUntrustedIpWarningAt !== null &&
-    now - lastUntrustedIpWarningAt < UNTRUSTED_IP_WARNING_INTERVAL_MS
-  ) {
-    return;
-  }
-  lastUntrustedIpWarningAt = now;
-  logger.error(
-    "TRUSTED_PROXY_HOP_COUNT is set to 0 but the request carries forwarding headers. IP-based rate " +
-      "limiting and IP capture cannot identify individual clients while no hop is trusted. Unset it to " +
-      "take the default of 1, or set it to the number of reverse proxies actually in front of this app."
-  );
+  const lastWarningAt = lastClientIpWarningAt[reason];
+  if (lastWarningAt !== undefined && now - lastWarningAt < CLIENT_IP_WARNING_INTERVAL_MS) return;
+
+  lastClientIpWarningAt[reason] = now;
+  logger.warn(clientIpWarningMessages[reason]);
+};
+
+const isValidPort = (port: string): boolean => {
+  if (!VALID_DECIMAL_PORT.test(port)) return false;
+  return Number(port) <= 65_535;
+};
+
+const canonicalizeIp = (ip: string): string | null => {
+  if (!isValidIP(ip)) return null;
+  return normalizeIP(ip, { ipv6Subnet: CLIENT_IP_IPV6_SUBNET_PREFIX });
 };
 
 /**
- * Resolves the client IP from forwarding headers, trusting only as many proxy hops as configured.
+ * Parse the selected X-Forwarded-For token without guessing at ambiguous socket forms.
  *
- * `X-Forwarded-For` is *appended* to by each proxy, so its leftmost entry is whatever the client itself
- * sent — reading that, as this used to, let a caller supply any value. Because the result keys the
- * IP-based rate limits (login, forgot-password, signup, the public client API), a caller could rotate
- * the header to mint a fresh bucket per request and bypass all of them, and could also forge the
- * `ipAddress` recorded on responses and in audit-log entries.
- *
- * With `hopCount` proxies in front, the address the outermost trusted proxy observed is the
- * `hopCount`-th entry from the right; everything left of it is client-supplied and ignored.
- * `TRUSTED_PROXY_HOP_COUNT` defaults to 1, matching every supported topology; `0` is an explicit
- * opt-out that trusts nothing and therefore cannot identify a client at all.
- *
- * `cf-connecting-ip` is deliberately *not* consulted. It is only trustworthy when the request provably
- * came from Cloudflare's edge, and a hop count cannot establish that: `hopCount >= 1` says "one proxy is
- * in front", which for most deployments is Traefik, Envoy or nginx — none of which strip
- * `cf-connecting-ip`. Preferring it would therefore hand the spoof straight back to the caller. Nothing
- * is lost by dropping it: Cloudflare also puts the visitor address into `X-Forwarded-For`, so a
- * Cloudflare deployment is just `hopCount = 1` (or 2 with a proxy of its own behind it).
- *
- * Exported separately from {@link getClientIpFromHeaders} so the parsing is unit-testable without
- * mocking `next/headers`.
+ * Azure Application Gateway can append an IPv4 client port. Bracketed IPv6 follows the standard
+ * unambiguous socket spelling; a valid unbracketed IPv6 value is always treated as an address.
  */
-export const resolveClientIp = (headersList: Headers, hopCount: number): string => {
-  const xForwardedFor = headersList.get("x-forwarded-for");
+const canonicalizeForwardedIp = (value: string): string | null => {
+  const plainIp = canonicalizeIp(value);
+  if (plainIp) return plainIp;
 
-  if (hopCount <= 0) {
-    if (xForwardedFor || headersList.get("cf-connecting-ip") || headersList.get("x-real-ip")) {
-      warnAboutUntrustedIp();
-    }
-    return UNTRUSTED_CLIENT_IP;
+  const bracketedMatch = BRACKETED_ADDRESS.exec(value);
+  if (bracketedMatch) {
+    const address = bracketedMatch[1];
+    const port = bracketedMatch[2];
+    if (!address?.includes(":") || (port !== undefined && !isValidPort(port))) return null;
+    return canonicalizeIp(address);
   }
 
-  if (xForwardedFor) {
-    const entries = xForwardedFor
-      .split(",")
-      .map((entry) => entry.trim())
-      .filter(Boolean);
+  const ipv4SocketMatch = IPV4_SOCKET.exec(value);
+  if (ipv4SocketMatch) {
+    const address = ipv4SocketMatch[1];
+    const port = ipv4SocketMatch[2];
+    if (!address || !port || !isValidPort(port)) return null;
 
-    if (entries.length > 0) {
-      // Clamped rather than falling back to the leftmost entry: a request with fewer hops than
-      // configured arrived through a shorter path than expected, and the earliest entry present is the
-      // closest thing to what a trusted proxy saw.
-      const index = Math.max(0, entries.length - hopCount);
-      return entries[index];
-    }
+    const canonicalAddress = canonicalizeIp(address);
+    return canonicalAddress?.includes(":") ? null : canonicalAddress;
   }
 
-  // No `x-real-ip` fallback. It is only reachable when no `X-Forwarded-For` arrived at all, and a proxy
-  // that is genuinely in front appends to XFF — so the absence of XFF means the request did not come
-  // through the trusted hop this app is configured for, and `x-real-ip` is then whatever the caller
-  // chose to send. Reading it would restore exactly the per-request bucket rotation this function
-  // exists to stop. This is the same argument the docstring makes against `cf-connecting-ip`; applying
-  // it to one header and not the other was inconsistent. Raised by @pandeymangg on #8680.
-  return UNTRUSTED_CLIENT_IP;
+  return null;
 };
 
+const hasAnyForwardingHeader = (headersList: Headers): boolean =>
+  ["x-forwarded-for", "x-real-ip", "cf-connecting-ip"].some((header) => headersList.has(header));
+
+/**
+ * Resolve and canonicalize the exact trusted hop from X-Forwarded-For.
+ *
+ * Proxy is the only caller. Entries to the left of the configured hop can be client-supplied and are
+ * ignored. A missing, short, or malformed chain fails closed instead of falling back to another raw
+ * forwarding header or clamping to the leftmost entry.
+ */
+export const resolveClientIp = (headersList: Headers, hopCount: number): string | null => {
+  if (hopCount <= 0) {
+    if (hasAnyForwardingHeader(headersList)) warnAboutClientIp("disabled");
+    return null;
+  }
+
+  const xForwardedFor = headersList.get("x-forwarded-for");
+  if (xForwardedFor === null) {
+    if (hasAnyForwardingHeader(headersList)) warnAboutClientIp("short-chain");
+    return null;
+  }
+
+  const entries = xForwardedFor.split(",").map((entry) => entry.trim());
+  if (entries.length < hopCount) {
+    warnAboutClientIp("short-chain");
+    return null;
+  }
+
+  const selectedEntry = entries[entries.length - hopCount];
+  const clientIp = selectedEntry ? canonicalizeForwardedIp(selectedEntry) : null;
+  if (!clientIp) warnAboutClientIp("invalid-selected-hop");
+
+  return clientIp;
+};
+
+/** Read only the private identity established by Proxy; raw forwarding headers are never fallbacks. */
 export async function getClientIpFromHeaders(): Promise<string> {
   let headersList: Headers;
   try {
     headersList = await headers();
-  } catch (e) {
-    logger.error(e, "Failed to get headers in getClientIpFromHeaders");
+  } catch (error) {
+    logger.error(error, "Failed to get headers in getClientIpFromHeaders");
     return UNTRUSTED_CLIENT_IP;
   }
 
-  return resolveClientIp(headersList, TRUSTED_PROXY_HOP_COUNT);
+  const internalClientIp = headersList.get(FORMBRICKS_CLIENT_IP_HEADER);
+  if (!internalClientIp) return UNTRUSTED_CLIENT_IP;
+
+  return canonicalizeIp(internalClientIp) ?? UNTRUSTED_CLIENT_IP;
 }

--- a/apps/web/modules/auth/lib/auth-email-password.integration.test.ts
+++ b/apps/web/modules/auth/lib/auth-email-password.integration.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "vitest";
 import { prisma } from "@formbricks/database";
 import { resetDb } from "@/integration/reset-db";
+import { BETTER_AUTH_IP_ADDRESS_CONFIG } from "@/lib/utils/client-ip";
 import { auth } from "@/modules/auth/lib/auth";
 
 /**
@@ -14,6 +15,10 @@ beforeEach(async () => {
 });
 
 describe("Better Auth email/password (real Postgres)", () => {
+  test("uses the canonical private client-IP configuration", () => {
+    expect(auth.options.advanced?.ipAddress).toEqual(BETTER_AUTH_IP_ADDRESS_CONFIG);
+  });
+
   test("sign-up creates the user and a bcrypt credential account via the Formbricks field mappings", async () => {
     const response = await auth.api.signUpEmail({
       body: { email: "alice@example.com", password: "Sup3rSecret!", name: "Alice Example" },

--- a/apps/web/modules/auth/lib/auth.ts
+++ b/apps/web/modules/auth/lib/auth.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/constants";
 import { hashSecret, verifySecret } from "@/lib/crypto";
 import { env } from "@/lib/env";
+import { BETTER_AUTH_IP_ADDRESS_CONFIG } from "@/lib/utils/client-ip";
 import {
   accountDeletionConfig,
   requireDeletionConfirmationBeforeHandler,
@@ -325,7 +326,9 @@ export const auth = betterAuth({
     // write path) would reject BA-created users at cutover — caught by the SSO-provisioning test.
     database: { generateId: () => createId() },
     defaultCookieAttributes: { sameSite: "lax", httpOnly: true, secure: USE_SECURE_COOKIES, path: "/" },
-    ipAddress: { ipAddressHeaders: ["x-forwarded-for"] }, // pin to the trusted proxy header
+    // Proxy has already selected the configured trusted hop. Do not re-parse forwarding chains or add
+    // Better Auth trustedProxies here; the private single-value header is the canonical identity.
+    ipAddress: BETTER_AUTH_IP_ADDRESS_CONFIG,
   },
 
   // Route Better Auth's logs to @formbricks/logger and capture errors to Sentry (Phase 7 parity).

--- a/apps/web/modules/auth/signup/actions.test.ts
+++ b/apps/web/modules/auth/signup/actions.test.ts
@@ -1,3 +1,4 @@
+import { cookies, headers } from "next/headers";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   INVITE_TOKEN_INVALID_ERROR_CODE,
@@ -18,6 +19,17 @@ import { UNKNOWN_DATA } from "@/modules/ee/audit-logs/types/audit-log";
 import { getIsMultiOrgEnabled } from "@/modules/ee/license-check/lib/utils";
 import { subscribeUserToMailingList } from "@/modules/ee/mailing/lib/mailing-subscription";
 import { createUserAction } from "./actions";
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+  headers: vi.fn(),
+}));
+
+const requestHeaders = new Headers({ "x-formbricks-client-ip": "203.0.113.7" });
+const mockNextRequestData = () => {
+  vi.mocked(headers).mockResolvedValue(requestHeaders as never);
+  vi.mocked(cookies).mockResolvedValue({ get: () => undefined } as never);
+};
 
 vi.mock("@formbricks/logger", () => ({
   logger: {
@@ -117,6 +129,7 @@ describe("createUserAction — signup verification email callbackURL", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    mockNextRequestData();
     constantsOverrides.IS_FORMBRICKS_CLOUD = false;
     constantsOverrides.SIGNUP_DOMAIN_CHECK_ON_INVITES = false;
     constantsOverrides.SIGNUP_ENABLED = true;
@@ -138,6 +151,7 @@ describe("createUserAction — signup verification email callbackURL", () => {
 
     expect(auth.api.signUpEmail).toHaveBeenCalledWith({
       body: { email: "ada@example.com", password: "Password123!", name: "Ada", callbackURL: undefined },
+      headers: requestHeaders,
     });
   });
 
@@ -178,6 +192,7 @@ describe("createUserAction — signup verification email callbackURL", () => {
         password: "Password123!",
         name: "Ada",
       },
+      headers: requestHeaders,
     });
   });
 
@@ -335,6 +350,7 @@ describe("createUserAction — personal email domain block (Cloud)", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
+    mockNextRequestData();
     constantsOverrides.IS_FORMBRICKS_CLOUD = true;
     constantsOverrides.SIGNUP_ENABLED = true;
     vi.mocked(getIsFreshInstance).mockResolvedValue(true);

--- a/apps/web/modules/auth/signup/actions.ts
+++ b/apps/web/modules/auth/signup/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { z } from "zod";
 import { logger } from "@formbricks/logger";
 import {
@@ -138,6 +138,7 @@ async function signUpUserSafely(
     // legacy verification-token email.
     const signUpResult = await auth.api.signUpEmail({
       body: { email: normalizedEmail, password, name },
+      headers: await headers(),
     });
     signedUpUserId = signUpResult.user.id;
   } catch (error) {

--- a/apps/web/modules/traefik-auth/service.ts
+++ b/apps/web/modules/traefik-auth/service.ts
@@ -14,7 +14,7 @@ export const authorizeTraefikRequest = async (request: NextRequest): Promise<Res
     request,
     originalRequest: requestMetadata.originalRequest,
     authorizers: gatewayRequestAuthorizers,
-    requestId: request.headers.get("x-request-id") ?? request.headers.get("x-forwarded-for") ?? "unknown",
+    requestId: request.headers.get("x-request-id") ?? "unknown",
     buildAllowResponse: buildTraefikAllowResponse,
     unsupportedRouteMessage: "Unsupported Traefik auth route",
   });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "i18n:generate": "dotenv -e ../../.env -- npx lingo.dev@latest run && dotenv -e ../../.env -- npx lingo.dev@latest lockfile --force"
   },
   "dependencies": {
+    "@better-auth/core": "1.6.23",
     "@better-auth/oauth-provider": "1.6.23",
     "@better-auth/utils": "0.4.2",
     "@boxyhq/saml-jackson": "26.2.0",

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -191,9 +191,18 @@ describe("proxy matcher", () => {
     "/api/auth/sign-in/email",
     "/api/auth/sso-recovery/request",
     "/api/auth/sso-recovery/consume/token",
-  ])("includes Better Auth request %s", (url) => {
+    "/api/v1/client/workspace-1/responses",
+    "/api/v2/client/workspace-1/responses",
+  ])("includes client-IP consumer %s", (url) => {
     expect(unstable_doesMiddlewareMatch({ config, url })).toBe(true);
   });
+
+  test.each(["/jsonresponse", "/iconscustom", "/publicapi/foo"])(
+    "includes dynamic route with asset-like prefix %s",
+    (url) => {
+      expect(unstable_doesMiddlewareMatch({ config, url })).toBe(true);
+    }
+  );
 
   test("includes server-action requests", () => {
     expect(

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -1,6 +1,8 @@
+import { unstable_doesMiddlewareMatch } from "next/experimental/testing/server";
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { proxy } from "./proxy";
+import { FORMBRICKS_CLIENT_IP_HEADER } from "@/lib/utils/client-ip";
+import { config, proxy } from "./proxy";
 
 const { mockGetProxySession, mockIsPublicDomainConfigured, mockIsRequestFromPublicDomain } = vi.hoisted(
   () => ({
@@ -25,6 +27,7 @@ vi.mock("@/app/middleware/endpoint-validator", () => ({
 }));
 
 vi.mock("@/lib/constants", () => ({
+  TRUSTED_PROXY_HOP_COUNT: 1,
   WEBAPP_URL: "http://localhost:3000",
 }));
 
@@ -47,6 +50,7 @@ vi.mock("@/lib/utils/url", () => ({
 vi.mock("@formbricks/logger", () => ({
   logger: {
     error: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
@@ -147,4 +151,64 @@ describe("proxy", () => {
 
     expect(response.cookies.get("formbricks-workspace-id")?.value).toBe("ws-456");
   });
+
+  test("overwrites a caller-supplied private IP header with the canonical trusted hop", async () => {
+    mockGetProxySession.mockResolvedValue(null);
+    const request = new NextRequest("http://localhost:3000/api/auth/sign-in/email", {
+      headers: {
+        [FORMBRICKS_CLIENT_IP_HEADER]: "198.51.100.99",
+        "x-forwarded-for": "198.51.100.10, 203.0.113.7:54321",
+      },
+    });
+
+    const response = await proxy(request);
+
+    expect(response.headers.get(`x-middleware-request-${FORMBRICKS_CLIENT_IP_HEADER}`)).toBe("203.0.113.7");
+    expect(response.headers.get(FORMBRICKS_CLIENT_IP_HEADER)).toBeNull();
+  });
+
+  test("removes a caller-supplied private IP header when trusted-hop resolution fails", async () => {
+    mockGetProxySession.mockResolvedValue(null);
+    const request = new NextRequest("http://localhost:3000/api/auth/sign-in/email", {
+      headers: {
+        [FORMBRICKS_CLIENT_IP_HEADER]: "198.51.100.99",
+        "x-forwarded-for": "not-an-ip",
+      },
+    });
+
+    const response = await proxy(request);
+
+    expect(response.headers.get(`x-middleware-request-${FORMBRICKS_CLIENT_IP_HEADER}`)).toBeNull();
+    expect(response.headers.get("x-middleware-override-headers")?.split(",")).not.toContain(
+      FORMBRICKS_CLIENT_IP_HEADER
+    );
+    expect(response.headers.get(FORMBRICKS_CLIENT_IP_HEADER)).toBeNull();
+  });
+});
+
+describe("proxy matcher", () => {
+  test.each([
+    "/api/auth/sign-in/email",
+    "/api/auth/sso-recovery/request",
+    "/api/auth/sso-recovery/consume/token",
+  ])("includes Better Auth request %s", (url) => {
+    expect(unstable_doesMiddlewareMatch({ config, url })).toBe(true);
+  });
+
+  test("includes server-action requests", () => {
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        url: "/workspaces/workspace-1/surveys",
+        headers: { "next-action": "server-action-id" },
+      })
+    ).toBe(true);
+  });
+
+  test.each(["/_next/static/chunks/app.js", "/_next/image", "/images/logo.svg", "/favicon.ico"])(
+    "excludes static asset %s",
+    (url) => {
+      expect(unstable_doesMiddlewareMatch({ config, url })).toBe(false);
+    }
+  );
 });

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -115,6 +115,8 @@ export const proxy = async (originalRequest: NextRequest) => {
 
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|js|css|images|fonts|icons|public|animated-bgs).*)",
+    // Keep asset exclusions segment-bound: every dynamic route must traverse Proxy so callers cannot
+    // bypass the private client-IP header overwrite by choosing an asset-like route prefix.
+    "/((?!_next/(?:static|image)(?:/|$)|(?:favicon\\.ico|sitemap\\.xml|robots\\.txt)$|(?:js|css|images|fonts|icons|public|animated-bgs)(?:/|$)).*)",
   ],
 };

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -3,8 +3,9 @@ import { v4 as uuidv4 } from "uuid";
 import { logger } from "@formbricks/logger";
 import { isPublicDomainConfigured, isRequestFromPublicDomain } from "@/app/middleware/domain-utils";
 import { isAuthProtectedRoute, isRouteAllowedForDomain } from "@/app/middleware/endpoint-validator";
-import { WEBAPP_URL } from "@/lib/constants";
+import { TRUSTED_PROXY_HOP_COUNT, WEBAPP_URL } from "@/lib/constants";
 import { FORMBRICKS_WORKSPACE_ID_COOKIE } from "@/lib/localStorage";
+import { FORMBRICKS_CLIENT_IP_HEADER, resolveClientIp } from "@/lib/utils/client-ip";
 import { getValidatedCallbackUrl } from "@/lib/utils/url";
 import { getProxySession } from "@/modules/auth/lib/proxy-session";
 
@@ -67,6 +68,15 @@ export const proxy = async (originalRequest: NextRequest) => {
   const request = new NextRequest(originalRequest, {
     headers: new Headers(originalRequest.headers),
   });
+
+  const clientIp = resolveClientIp(request.headers, TRUSTED_PROXY_HOP_COUNT);
+  if (clientIp) {
+    request.headers.set(FORMBRICKS_CLIENT_IP_HEADER, clientIp);
+  } else {
+    // A caller may send this private header directly. Removing it on failure is what makes Proxy the
+    // trust boundary; downstream code must never see an identity Proxy did not establish itself.
+    request.headers.delete(FORMBRICKS_CLIENT_IP_HEADER);
+  }
 
   request.headers.set("x-request-id", uuidv4());
   request.headers.set("x-start-time", Date.now().toString());

--- a/docs/self-hosting/advanced/migration.mdx
+++ b/docs/self-hosting/advanced/migration.mdx
@@ -25,7 +25,11 @@ hops:
   load balancers in front of Formbricks (e.g. an ingress plus a CDN = `2`). An explicit `0` trusts no
   proxy at all: the runtime exposes no socket peer address, so the client IP then resolves to a fixed
   "untrusted" placeholder that rate limiting and response audit logging record in place of a real address.
-  Leave it at `1` (or your real hop count) unless you deliberately want to stop capturing client IPs.
+  A forwarding chain shorter than the configured count, or a malformed selected hop, also fails closed.
+  Ports appended by gateways such as
+  [Azure Application Gateway](https://learn.microsoft.com/en-us/azure/application-gateway/how-application-gateway-works#modifications-to-the-request)
+  are removed, and IPv6 addresses are normalized to their `/64` network. Leave the setting at `1` (or
+  your real hop count) unless you deliberately want to stop capturing client IPs.
 
 <Warning>
   Setting `TRUSTED_PROXY_HOP_COUNT` **higher** than your real hop count lets a client spoof its IP by

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@better-auth/core':
+        specifier: 1.6.23
+        version: 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.2)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/oauth-provider':
         specifier: 1.6.23
         version: 1.6.23(318efca8bd447cadcd3b2d8af4d22c46)


### PR DESCRIPTION
## What & why

Client IP resolution diverged between Formbricks and Better Auth. Better Auth received a multi-value `X-Forwarded-For` header it could not trust and collapsed unauthenticated traffic into one shared rate-limit bucket, while Formbricks used unvalidated raw tokens that could vary by IPv6 spelling, host rotation, or Azure gateway source port.

This change makes Proxy the single client-IP trust boundary:

- select the configured trusted XFF hop exactly once and fail closed for missing, short, or invalid chains
- validate and normalize IPv4/IPv6, strip supported socket ports, convert mapped IPv6, and group IPv6 identities by `/64`
- overwrite or remove the private request-only `x-formbricks-client-ip` header before forwarding
- make Formbricks and Better Auth consume only that canonical identity
- keep asset exclusions segment-bound so asset-like dynamic route prefixes cannot bypass the private-header overwrite
- emit distinct, value-free diagnostics when XFF is absent but untrusted forwarding headers are present
- forward request headers into server-side sign-up and document the existing proxy topology requirement

No rate-limit thresholds, database schema, or configuration defaults change.

## Linear ticket

Fixes ENG-2097

## How this was tested

- `pnpm --filter @formbricks/web exec vitest run lib/utils/client-ip.test.ts proxy.test.ts modules/core/rate-limit/helpers.test.ts modules/auth/signup/actions.test.ts modules/traefik-auth/service.test.ts` — 6 files / 115 tests passed
- `pnpm --filter @formbricks/web typecheck` — passed after generating route types
- affected-file ESLint — passed
- targeted Prettier check and `git diff --check` — passed
- pre-commit lint-staged formatting and ESLint — passed
- fresh PR CI — 19 checks passed, including Better Auth integration tests, full unit tests, linters, web build, E2E, Docker build validation, CodeQL, and Sonar; 1 deployment check intentionally skipped

## Breaking changes

None — no public API/SDK contract, database migration, new environment variable, rate-limit threshold, or configuration-default change.

## QA / Test Plan

**How to test**

- [ ] Send repeated failed email sign-ins while changing only client-prepended XFF entries → all attempts for the same real client reach the existing 429 threshold in one bucket.
- [ ] Send the same IPv4 client through Azure-style `IP:port` values while changing the port → requests still reach 429 in one bucket.
- [ ] Rotate IPv6 host addresses within one `/64` → requests share one bucket; use a client in a different `/64` → it receives a separate bucket.
- [ ] Exhaust the limit for one real client, then sign in from a second real client → the second client is not locked out by the first.
- [ ] Complete a successful sign-in and submit a response → session, audit-log, and response metadata use the same canonical client identity.
- [ ] Send a malformed or shorter-than-configured forwarding chain with a spoofed `x-formbricks-client-ip` header → the spoofed value is removed and requests use the fail-closed shared bucket.
- [ ] Send only `x-real-ip` or `cf-connecting-ip` without XFF → the private header remains absent and diagnostics identify the missing trusted chain without logging header values.
- [ ] Load login pages and static assets, then exercise asset-like dynamic routes → auth/client requests traverse Proxy and assets continue loading normally.

**Preconditions / test data**

- A deployment with Redis-backed rate limiting enabled.
- `TRUSTED_PROXY_HOP_COUNT` set to the exact number of controlled proxies/load balancers.
- Two test clients with distinct real IPs, plus the ability to vary XFF values at the edge.
- A test account and access to the deployment's session/audit and response metadata views.

**Risks & regressions**

- An incorrect trusted-hop count can still choose an attacker-prepended entry when the forged chain is long enough; operators must configure the real topology.
- IPv6 values persisted in sessions, responses, and audit logs now use canonical `/64` network addresses.
- Auth routes, client response routes, and server actions depend on the Proxy matcher continuing to cover dynamic requests.

**Migrations / env / cutover**

- No migration or new environment variable.
- Confirm the existing `TRUSTED_PROXY_HOP_COUNT` matches the deployed proxy topology before rollout.
