### PR TITLE
fix(security): bump js-yaml to 4.3.1 for !!omap quadratic-CPU DoS [ENG-2278][ENG-2279]

### DIFF
--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -32,7 +32,7 @@
     "@formbricks/eslint-config": "workspace:*",
     "@types/js-yaml": "4.0.9",
     "@vitest/coverage-v8": "4.1.6",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "publint": "0.3.21",
     "rimraf": "^6.1.2",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ overrides:
   '@opentelemetry/core': 2.8.0
   esbuild: 0.28.1
   tar: 7.5.21
-  js-yaml@4: 4.3.0
+  js-yaml@4: 4.3.1
   sharp: 0.35.0
   '@opentelemetry/propagator-jaeger': 2.9.0
   valibot: 1.4.2
@@ -1387,8 +1387,8 @@ importers:
         specifier: 4.1.6
         version: 4.1.6(vitest@4.1.6)
       js-yaml:
-        specifier: 4.3.0
-        version: 4.3.0
+        specifier: 4.3.1
+        version: 4.3.1
       publint:
         specifier: 0.3.21
         version: 0.3.21
@@ -9156,8 +9156,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -14351,7 +14351,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -17120,7 +17120,7 @@ snapshots:
       get-port-please: 3.0.1
       glob: 7.2.3
       handlebars: 4.7.9
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       mobx: 6.12.3
       pluralize: 8.0.0
       react: 19.2.6
@@ -17150,7 +17150,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6
       js-levenshtein: 1.1.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -17164,7 +17164,7 @@ snapshots:
       colorette: 1.4.0
       https-proxy-agent: 7.0.6
       js-levenshtein: 1.1.6
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 5.1.9
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -17184,7 +17184,7 @@ snapshots:
       form-data: 4.0.6
       jest-diff: 29.7.0
       jest-matcher-utils: 29.7.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       json-pointer: 0.6.2
       jsonpath-plus: 10.3.0
       open: 10.1.0
@@ -21979,7 +21979,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,8 +95,11 @@ overrides:
   # lowest patched and stays <5. Scoped to the 4.x line so any 3.x consumer is untouched.
   # ENG-1952 / GHSA-52cp-r559-cp3m (CVE-2026-59869): js-yaml 4.0.0–4.2.x can spend quadratic CPU on a
   # merge-key mapping chain; patched in 4.3.0. Raises the 4.x pin from 4.2.0 to 4.3.0 (still <5).
+  # ENG-2278 / ENG-2279 / GHSA-5p4m-2wfm-xmqj (CVE-2026-59870): js-yaml 4.0.0–4.3.0 can spend quadratic
+  # CPU resolving a large !!omap (linear indexOf scan per entry); patched in 4.3.1. Raises the 4.x pin
+  # from 4.3.0 to 4.3.1 (still <5).
   # load-bearing: @redocly/openapi-core and @redocly/respect-core pin 4.2.0.
-  js-yaml@4: 4.3.0
+  js-yaml@4: 4.3.1
   # === Dependabot security batch (ENG-1988..ENG-1999) ===
   # ENG-1999 / ENG-1989 / GHSA-f88m-g3jw-g9cj: sharp <0.35.0 inherits libvips vulnerabilities
   # (CVE-2026-33327/33328/35590/35591). apps/web pins 0.35.0 directly; this override also coerces the


### PR DESCRIPTION
## What & why

`js-yaml` 4.0.0–4.3.0 resolves an ordered map (`!!omap`) by enforcing key uniqueness with a per-entry linear `objectKeys.indexOf()` scan, so resolution is **O(n²)** in the number of entries. `!!omap` is in the **default schema**, so a plain `yaml.load(untrusted)` with no options is affected — a modestly sized document blocks the Node event loop synchronously (a 2.48 MB doc ≈ 10.8s), a per-process DoS for any consumer of untrusted YAML.

**GHSA-5p4m-2wfm-xmqj / CVE-2026-59870**, patched in **4.3.1** (Set-based dedupe). Dependabot alerts [#710](https://github.com/formbricks/formbricks/security/dependabot/710) and [#711](https://github.com/formbricks/formbricks/security/dependabot/711).

Fix follows the repo's existing js-yaml security-pin pattern:
- Raise the `js-yaml@4` override in `pnpm-workspace.yaml` from `4.3.0` → `4.3.1` (with a documenting comment, matching the ENG-1527 / ENG-1952 entries above it). Scoped to the 4.x line.
- Bump the one direct pin (`packages/workflows/package.json`) to match.
- Regenerate `pnpm-lock.yaml`.

`@redocly/openapi-core` / `@redocly/respect-core` still resolve their 4.2.0 floor under the override; the override lifts every resolution to 4.3.1.

## Linear ticket

Fixes ENG-2278
Fixes ENG-2279

(Duplicate Dependabot alerts #710/#711 for the same CVE — one bump closes both.)

## How this was tested

- `pnpm install --lockfile-only` regenerated the lockfile cleanly.
- Verified every `js-yaml` resolution is now `4.3.1` with **zero** `js-yaml@4.3.0` references remaining (`grep -c "js-yaml@4.3.0" pnpm-lock.yaml` → 0).
- Patch bump within the 4.x line; the public API is unchanged (the change is internal to the `!!omap` resolver), so no source changes were required beyond the version pins.

## Breaking changes

None — patch-level dependency bump, no API change.

## QA / Test Plan

**How to test**

- [ ] `pnpm install` succeeds against the updated lockfile.
- [ ] App builds and any YAML-parsing paths (workflows import/export, OpenAPI tooling) behave as before → no functional change.
- [ ] Dependabot alerts #710 / #711 resolve after merge.

**Preconditions / test data**

- none

**Risks & regressions**

- Low. Patch bump; only the `!!omap` resolver internals changed upstream. Re-check anything that parses YAML with `!!omap` ordered maps still round-trips (duplicate-key rejection semantics are preserved by the upstream fix).

**Migrations / env / cutover**

- none
