### PR TITLE
feat(embedded-data): reconcile editor saves into the EmbeddedData tables [ENG-1978]

### DIFF
--- a/apps/web/integration/embedded-data-reconcile.integration.test.ts
+++ b/apps/web/integration/embedded-data-reconcile.integration.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import { toDesiredEmbeddedFields } from "@formbricks/types/embedded-data-mapping";
+import { resetDb } from "@/integration/reset-db";
+import { reconcileEmbeddedData } from "@/lib/embedded-data/reconcile";
+
+/**
+ * The Embedded Data write bridge against real Postgres (ENG-1978).
+ *
+ * The reconcile is the only thing keeping the tables in step with what the editor saved, and every
+ * rule it enforces is about database state: the unique constraint on `(surveyId, storageKey)`, the
+ * cascade when a survey goes, and the ordering needed for a replaced field. The unit suite mocks
+ * `@formbricks/database`, so none of that is visible there.
+ */
+
+const seedSurvey = async (): Promise<{ surveyId: string; workspaceId: string }> => {
+  const organization = await prisma.organization.create({ data: { name: "Reconcile Org" } });
+  const workspace = await prisma.workspace.create({
+    data: { name: "Reconcile Workspace", organizationId: organization.id },
+  });
+  const survey = await prisma.survey.create({ data: { name: "Survey", workspaceId: workspace.id } });
+  return { surveyId: survey.id, workspaceId: workspace.id };
+};
+
+/** What the survey actually has, in the shape the assertions care about. */
+const readFields = async (surveyId: string) =>
+  prisma.surveyEmbeddedData
+    .findMany({
+      where: { surveyId },
+      orderBy: { storageKey: "asc" },
+      select: {
+        storageKey: true,
+        embeddedData: {
+          select: { name: true, source: true, dataType: true, defaultValue: true, key: true, surveyId: true },
+        },
+      },
+    })
+    .then((links) =>
+      links.map((link) => ({
+        storageKey: link.storageKey,
+        ...link.embeddedData,
+      }))
+    );
+
+const reconcile = (
+  surveyId: string,
+  workspaceId: string,
+  legacy: Parameters<typeof toDesiredEmbeddedFields>[0]
+) =>
+  prisma.$transaction((tx) =>
+    reconcileEmbeddedData(tx, { surveyId, workspaceId, desired: toDesiredEmbeddedFields(legacy) })
+  );
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("reconcileEmbeddedData (real Postgres)", () => {
+  test("creates a row and a link for each variable and hidden field", async () => {
+    const { surveyId, workspaceId } = await seedSurvey();
+
+    await reconcile(surveyId, workspaceId, {
+      variables: [{ id: "clx000000000000000000001", name: "score", type: "number", value: 7 }],
+      hiddenFields: { enabled: true, fieldIds: ["plan"] },
+    });
+
+    expect(await readFields(surveyId)).toEqual([
+      {
+        storageKey: "clx000000000000000000001",
+        name: "score",
+        source: "computed",
+        dataType: "number",
+        defaultValue: 7,
+        // Local: owned by this survey and absent from the shared library.
+        key: null,
+        surveyId,
+      },
+      {
+        storageKey: "plan",
+        name: "plan",
+        source: "ingested",
+        dataType: "string",
+        defaultValue: null,
+        key: null,
+        surveyId,
+      },
+    ]);
+  });
+
+  test("is idempotent — running it again changes nothing", async () => {
+    const { surveyId, workspaceId } = await seedSurvey();
+    const legacy = { hiddenFields: { enabled: true, fieldIds: ["plan", "campaign"] } };
+
+    await reconcile(surveyId, workspaceId, legacy);
+    const first = await readFields(surveyId);
+    await reconcile(surveyId, workspaceId, legacy);
+
+    expect(await readFields(surveyId)).toEqual(first);
+    expect(await prisma.embeddedData.count({ where: { surveyId } })).toBe(2);
+  });
+
+  test("removes the row and the link for a deleted field", async () => {
+    const { surveyId, workspaceId } = await seedSurvey();
+    await reconcile(surveyId, workspaceId, {
+      hiddenFields: { enabled: true, fieldIds: ["plan", "campaign"] },
+    });
+
+    await reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: ["plan"] } });
+
+    expect((await readFields(surveyId)).map((field) => field.storageKey)).toEqual(["plan"]);
+    expect(await prisma.embeddedData.count({ where: { surveyId } })).toBe(1);
+  });
+
+  test("updates a field whose default value changed, keeping the same row", async () => {
+    const { surveyId, workspaceId } = await seedSurvey();
+    const variable = { id: "clx000000000000000000001", name: "score", type: "number" as const };
+    await reconcile(surveyId, workspaceId, { variables: [{ ...variable, value: 0 }] });
+    const before = await prisma.embeddedData.findFirstOrThrow({ where: { surveyId } });
+
+    await reconcile(surveyId, workspaceId, { variables: [{ ...variable, value: 99 }] });
+
+    const after = await prisma.embeddedData.findFirstOrThrow({ where: { surveyId } });
+    expect(after.id).toBe(before.id);
+    expect(after.defaultValue).toBe(99);
+  });
+
+  test("replaces a field whose source changed, which reuses the same storage key", async () => {
+    // Unlink has to happen before create or `@@unique([surveyId, storageKey])` rejects the new row.
+    const { surveyId, workspaceId } = await seedSurvey();
+    await reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: ["plan"] } });
+
+    await reconcile(surveyId, workspaceId, {
+      variables: [{ id: "plan", name: "plan", type: "text", value: "pro" }],
+    });
+
+    expect(await readFields(surveyId)).toMatchObject([{ storageKey: "plan", source: "computed" }]);
+    expect(await prisma.embeddedData.count({ where: { surveyId } })).toBe(1);
+  });
+
+  test("keeps a legacy hidden field name exactly as stored", async () => {
+    const { surveyId, workspaceId } = await seedSurvey();
+
+    await reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: ["Brand-Name"] } });
+
+    expect((await readFields(surveyId)).map((field) => field.storageKey)).toEqual(["Brand-Name"]);
+  });
+
+  test("rejects a duplicate field name within one survey", async () => {
+    const { surveyId, workspaceId } = await seedSurvey();
+
+    await expect(
+      reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: ["plan", "plan"] } })
+    ).rejects.toThrow(/plan/);
+
+    expect(await prisma.embeddedData.count({ where: { surveyId } })).toBe(0);
+  });
+
+  test("lets two surveys in one workspace both hold a field named plan", async () => {
+    const { surveyId, workspaceId } = await seedSurvey();
+    const other = await prisma.survey.create({ data: { name: "Other", workspaceId } });
+    const legacy = { hiddenFields: { enabled: true, fieldIds: ["plan"] } };
+
+    await reconcile(surveyId, workspaceId, legacy);
+    await reconcile(other.id, workspaceId, legacy);
+
+    // Both rows carry `key: null`, and Postgres treats NULLs as distinct, so the workspace-level
+    // unique on `key` does not fire.
+    expect(await prisma.embeddedData.count({ where: { workspaceId } })).toBe(2);
+  });
+
+  test("unlinks a shared library field without deleting or editing it", async () => {
+    const { surveyId, workspaceId } = await seedSurvey();
+    const shared = await prisma.embeddedData.create({
+      data: { workspaceId, key: "plan_tier", name: "Plan tier", source: "ingested" },
+    });
+    await prisma.surveyEmbeddedData.create({
+      data: { workspaceId, surveyId, embeddedDataId: shared.id, storageKey: "plan_tier" },
+    });
+
+    // The legacy cards know nothing about the shared library, so a save that omits the field must
+    // drop this survey's use of it and leave the workspace-owned definition alone.
+    await reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: [] } });
+
+    expect(await prisma.surveyEmbeddedData.count({ where: { surveyId } })).toBe(0);
+    expect(await prisma.embeddedData.findUnique({ where: { id: shared.id } })).toMatchObject({
+      name: "Plan tier",
+      key: "plan_tier",
+    });
+  });
+
+  test("cascades a survey's fields away when the survey is deleted", async () => {
+    const { surveyId, workspaceId } = await seedSurvey();
+    await reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: ["plan"] } });
+
+    await prisma.survey.delete({ where: { id: surveyId } });
+
+    expect(await prisma.embeddedData.count({ where: { workspaceId } })).toBe(0);
+    expect(await prisma.surveyEmbeddedData.count()).toBe(0);
+  });
+
+  test("never touches Response", async () => {
+    const { surveyId, workspaceId } = await seedSurvey();
+    await prisma.response.create({
+      data: { surveyId, finished: true, data: { plan: "pro" }, variables: {}, meta: {}, ttc: {} },
+    });
+
+    await reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: ["plan"] } });
+    await reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: [] } });
+
+    const response = await prisma.response.findFirstOrThrow({ where: { surveyId } });
+    // Removing the definition leaves the stored value alone: the response is keyed by the same
+    // storage key, which is exactly why no response migration is needed.
+    expect(response.data).toEqual({ plan: "pro" });
+  });
+});

--- a/apps/web/integration/embedded-data-reconcile.integration.test.ts
+++ b/apps/web/integration/embedded-data-reconcile.integration.test.ts
@@ -188,6 +188,26 @@ describe("reconcileEmbeddedData (real Postgres)", () => {
     });
   });
 
+  test("keeps a definition another survey still links to, rather than cascading that link away", async () => {
+    // Unreachable today — the reconcile only ever links to rows it just created — but the schema
+    // permits the link, and deleting the row would take the other survey's link with it. Leaving an
+    // orphaned row behind is the better of the two failures.
+    const { surveyId, workspaceId } = await seedSurvey();
+    await reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: ["plan"] } });
+    const field = await prisma.embeddedData.findFirstOrThrow({ where: { surveyId } });
+
+    const borrower = await prisma.survey.create({ data: { name: "Borrower", workspaceId } });
+    await prisma.surveyEmbeddedData.create({
+      data: { workspaceId, surveyId: borrower.id, embeddedDataId: field.id, storageKey: "plan" },
+    });
+
+    await reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: [] } });
+
+    expect(await prisma.embeddedData.findUnique({ where: { id: field.id } })).not.toBeNull();
+    expect(await prisma.surveyEmbeddedData.count({ where: { surveyId: borrower.id } })).toBe(1);
+    expect(await prisma.surveyEmbeddedData.count({ where: { surveyId } })).toBe(0);
+  });
+
   test("cascades a survey's fields away when the survey is deleted", async () => {
     const { surveyId, workspaceId } = await seedSurvey();
     await reconcile(surveyId, workspaceId, { hiddenFields: { enabled: true, fieldIds: ["plan"] } });

--- a/apps/web/lib/embedded-data/reconcile.test.ts
+++ b/apps/web/lib/embedded-data/reconcile.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "vitest";
+import { type TDesiredEmbeddedField } from "@formbricks/types/embedded-data-mapping";
+import { type TCurrentEmbeddedField, planEmbeddedDataReconcile } from "./reconcile";
+
+const SURVEY_ID = "srv_1";
+const OTHER_SURVEY_ID = "srv_2";
+
+const desiredPlan: TDesiredEmbeddedField = {
+  storageKey: "plan",
+  name: "plan",
+  source: "ingested",
+  dataType: "string",
+  defaultValue: null,
+};
+
+const desiredScore: TDesiredEmbeddedField = {
+  storageKey: "var_score",
+  name: "score",
+  source: "computed",
+  dataType: "number",
+  defaultValue: 0,
+};
+
+/** A link to a definition this survey owns — the only kind the legacy cards may edit or delete. */
+const localField = (desired: TDesiredEmbeddedField, fieldId: string): TCurrentEmbeddedField => ({
+  linkId: `link_${fieldId}`,
+  storageKey: desired.storageKey,
+  field: {
+    id: fieldId,
+    surveyId: SURVEY_ID,
+    name: desired.name,
+    source: desired.source,
+    dataType: desired.dataType,
+    defaultValue: desired.defaultValue,
+  },
+});
+
+describe("planEmbeddedDataReconcile", () => {
+  test("does nothing when the survey already matches", () => {
+    const current = [localField(desiredPlan, "ed_plan"), localField(desiredScore, "ed_score")];
+    expect(planEmbeddedDataReconcile(SURVEY_ID, current, [desiredPlan, desiredScore])).toEqual({
+      toCreate: [],
+      toUpdate: [],
+      toUnlink: [],
+    });
+  });
+
+  test("creates a field the survey does not have yet", () => {
+    const plan = planEmbeddedDataReconcile(SURVEY_ID, [], [desiredPlan]);
+    expect(plan.toCreate).toEqual([desiredPlan]);
+    expect(plan.toUpdate).toEqual([]);
+    expect(plan.toUnlink).toEqual([]);
+  });
+
+  test("unlinks and deletes a local field the survey no longer has", () => {
+    const plan = planEmbeddedDataReconcile(SURVEY_ID, [localField(desiredPlan, "ed_plan")], []);
+    expect(plan.toUnlink).toEqual([{ linkId: "link_ed_plan", fieldIdToDelete: "ed_plan" }]);
+    expect(plan.toCreate).toEqual([]);
+  });
+
+  test("treats a rename as a delete plus a create, because the storage key moved", () => {
+    // Renaming a hidden field changes the address its responses are keyed by, which is exactly why
+    // renaming already orphans historical values today. Behaviour here matches that, not worse.
+    const renamed = { ...desiredPlan, storageKey: "plan_tier", name: "plan_tier" };
+    const plan = planEmbeddedDataReconcile(SURVEY_ID, [localField(desiredPlan, "ed_plan")], [renamed]);
+    expect(plan.toUnlink).toEqual([{ linkId: "link_ed_plan", fieldIdToDelete: "ed_plan" }]);
+    expect(plan.toCreate).toEqual([renamed]);
+  });
+
+  test.each([
+    ["name", { ...desiredScore, name: "total_score" }],
+    ["dataType", { ...desiredScore, dataType: "string" as const, defaultValue: "0" }],
+    ["defaultValue", { ...desiredScore, defaultValue: 10 }],
+  ])("updates a local field whose %s changed", (_label, updated) => {
+    const plan = planEmbeddedDataReconcile(SURVEY_ID, [localField(desiredScore, "ed_score")], [updated]);
+    expect(plan.toUpdate).toEqual([
+      {
+        fieldId: "ed_score",
+        name: updated.name,
+        dataType: updated.dataType,
+        defaultValue: updated.defaultValue,
+      },
+    ]);
+    expect(plan.toCreate).toEqual([]);
+    expect(plan.toUnlink).toEqual([]);
+  });
+
+  test("replaces rather than mutates a field whose source changed", () => {
+    // A computed and an ingested field that share an address are different fields, so flipping the
+    // source in place would silently repoint where the value is read from.
+    const nowIngested = { ...desiredScore, source: "ingested" as const };
+    const plan = planEmbeddedDataReconcile(SURVEY_ID, [localField(desiredScore, "ed_score")], [nowIngested]);
+    expect(plan.toUnlink).toEqual([{ linkId: "link_ed_score", fieldIdToDelete: "ed_score" }]);
+    expect(plan.toCreate).toEqual([nowIngested]);
+    expect(plan.toUpdate).toEqual([]);
+  });
+
+  describe("shared library definitions", () => {
+    const sharedField: TCurrentEmbeddedField = {
+      linkId: "link_shared",
+      storageKey: "plan",
+      field: { id: "ed_shared", surveyId: null, ...desiredPlan },
+    };
+
+    test("unlinks a shared field without deleting the definition", () => {
+      const plan = planEmbeddedDataReconcile(SURVEY_ID, [sharedField], []);
+      expect(plan.toUnlink).toEqual([{ linkId: "link_shared", fieldIdToDelete: null }]);
+    });
+
+    test("ignores an edit to a shared field, which the workspace owns", () => {
+      const edited = { ...desiredPlan, name: "Plan tier", dataType: "number" as const, defaultValue: 1 };
+      const plan = planEmbeddedDataReconcile(SURVEY_ID, [sharedField], [edited]);
+      expect(plan).toEqual({ toCreate: [], toUpdate: [], toUnlink: [] });
+    });
+  });
+
+  test("never deletes a local definition owned by another survey", () => {
+    // The schema allows a link to a field another survey owns; only this check stops one survey's
+    // save from destroying another's definition.
+    const foreignField: TCurrentEmbeddedField = {
+      linkId: "link_foreign",
+      storageKey: "plan",
+      field: { id: "ed_foreign", surveyId: OTHER_SURVEY_ID, ...desiredPlan },
+    };
+    const plan = planEmbeddedDataReconcile(SURVEY_ID, [foreignField], []);
+    expect(plan.toUnlink).toEqual([{ linkId: "link_foreign", fieldIdToDelete: null }]);
+  });
+});

--- a/apps/web/lib/embedded-data/reconcile.ts
+++ b/apps/web/lib/embedded-data/reconcile.ts
@@ -1,0 +1,216 @@
+import "server-only";
+import { Prisma } from "@formbricks/database/prisma";
+import {
+  type TEmbeddedDataDefaultValue,
+  type TEmbeddedDataSource,
+  type TEmbeddedDataType,
+  isLocalEmbeddedData,
+} from "@formbricks/types/embedded-data";
+import { type TDesiredEmbeddedField } from "@formbricks/types/embedded-data-mapping";
+import { InvalidInputError } from "@formbricks/types/errors";
+
+/** One field a survey currently has, as the link plus the definition it points at. */
+export interface TCurrentEmbeddedField {
+  linkId: string;
+  storageKey: string;
+  field: {
+    id: string;
+    /** The owning survey for a local definition, null for a shared library one. */
+    surveyId: string | null;
+    name: string;
+    source: TEmbeddedDataSource;
+    dataType: TEmbeddedDataType;
+    defaultValue: TEmbeddedDataDefaultValue;
+  };
+}
+
+export interface TEmbeddedDataReconcilePlan {
+  toCreate: TDesiredEmbeddedField[];
+  toUpdate: {
+    fieldId: string;
+    name: string;
+    dataType: TEmbeddedDataType;
+    defaultValue: TEmbeddedDataDefaultValue;
+  }[];
+  /** Links to drop. `fieldIdToDelete` is null when the definition must outlive the link. */
+  toUnlink: { linkId: string; fieldIdToDelete: string | null }[];
+}
+
+const SELECT_CURRENT_FIELDS = {
+  id: true,
+  storageKey: true,
+  embeddedData: {
+    select: { id: true, surveyId: true, name: true, source: true, dataType: true, defaultValue: true },
+  },
+} satisfies Prisma.SurveyEmbeddedDataSelect;
+
+/**
+ * Prisma distinguishes a JSON `null` from a SQL `NULL` on a nullable Json column, so "this field has
+ * no default" has to be spelled out rather than passed as a bare `null`.
+ */
+const toStoredDefaultValue = (
+  defaultValue: TEmbeddedDataDefaultValue
+): TEmbeddedDataDefaultValue | typeof Prisma.DbNull => (defaultValue === null ? Prisma.DbNull : defaultValue);
+
+/**
+ * Works out what has to change for a survey's Embedded Data to match `desired`.
+ *
+ * Pure, so the branching that actually matters — what may be edited, what may be deleted — is
+ * testable without a database.
+ *
+ * Two rules protect the shared library, which the legacy Variables and Hidden Fields cards know
+ * nothing about. A shared definition is workspace-owned, so removing it from a survey **unlinks**
+ * it and leaves the row alone, and a change to its name or type is ignored rather than written back.
+ * In v1 no shared rows exist yet (the manager is ENG-1851), but this reconcile keeps running once
+ * they do.
+ */
+export const planEmbeddedDataReconcile = (
+  surveyId: string,
+  current: TCurrentEmbeddedField[],
+  desired: TDesiredEmbeddedField[]
+): TEmbeddedDataReconcilePlan => {
+  const currentByKey = new Map(current.map((entry) => [entry.storageKey, entry]));
+  const desiredByKey = new Map(desired.map((entry) => [entry.storageKey, entry]));
+
+  const plan: TEmbeddedDataReconcilePlan = { toCreate: [], toUpdate: [], toUnlink: [] };
+
+  for (const entry of current) {
+    const wanted = desiredByKey.get(entry.storageKey);
+    // A definition may only be deleted when this survey owns it. Checking the owner rather than just
+    // "is it local" also stops one survey deleting another's local row, which the schema permits.
+    const isOwnedByThisSurvey = isLocalEmbeddedData(entry.field) && entry.field.surveyId === surveyId;
+
+    // A storage key whose source changed is a different field wearing the same address — replace it
+    // rather than mutating a computed field into an ingested one.
+    if (!wanted || wanted.source !== entry.field.source) {
+      plan.toUnlink.push({
+        linkId: entry.linkId,
+        fieldIdToDelete: isOwnedByThisSurvey ? entry.field.id : null,
+      });
+      continue;
+    }
+
+    if (!isOwnedByThisSurvey) continue;
+
+    const changed =
+      wanted.name !== entry.field.name ||
+      wanted.dataType !== entry.field.dataType ||
+      wanted.defaultValue !== entry.field.defaultValue;
+
+    if (changed) {
+      plan.toUpdate.push({
+        fieldId: entry.field.id,
+        name: wanted.name,
+        dataType: wanted.dataType,
+        defaultValue: wanted.defaultValue,
+      });
+    }
+  }
+
+  for (const entry of desired) {
+    const existing = currentByKey.get(entry.storageKey);
+    if (!existing || existing.field.source !== entry.source) {
+      plan.toCreate.push(entry);
+    }
+  }
+
+  return plan;
+};
+
+/**
+ * Brings a survey's `EmbeddedData` rows and links in step with the legacy shape it was just saved
+ * with.
+ *
+ * Runs inside the caller's transaction so a survey never commits without its fields, and takes
+ * `workspaceId` explicitly because the copy flow writes into a *different* workspace than the one it
+ * read from. Both foreign keys are workspace-scoped, so passing the wrong one fails loudly.
+ *
+ * Never reads or writes `Response`: a response stores values under the same `storageKey`, so moving
+ * definitions leaves stored data untouched by construction.
+ */
+export const reconcileEmbeddedData = async (
+  tx: Prisma.TransactionClient,
+  {
+    surveyId,
+    workspaceId,
+    desired,
+  }: { surveyId: string; workspaceId: string; desired: TDesiredEmbeddedField[] }
+): Promise<void> => {
+  assertNoDuplicateStorageKeys(desired);
+
+  const links = await tx.surveyEmbeddedData.findMany({
+    where: { surveyId },
+    select: SELECT_CURRENT_FIELDS,
+  });
+
+  const current: TCurrentEmbeddedField[] = links.map((link) => ({
+    linkId: link.id,
+    storageKey: link.storageKey,
+    field: link.embeddedData,
+  }));
+
+  const plan = planEmbeddedDataReconcile(surveyId, current, desired);
+
+  // Unlink before creating: a field whose source changed keeps its storage key, and
+  // `@@unique([surveyId, storageKey])` would reject the replacement while the old link still exists.
+  if (plan.toUnlink.length > 0) {
+    await tx.surveyEmbeddedData.deleteMany({
+      where: { id: { in: plan.toUnlink.map((entry) => entry.linkId) } },
+    });
+
+    const fieldIdsToDelete = plan.toUnlink
+      .map((entry) => entry.fieldIdToDelete)
+      .filter((fieldId): fieldId is string => fieldId !== null);
+
+    if (fieldIdsToDelete.length > 0) {
+      await tx.embeddedData.deleteMany({ where: { id: { in: fieldIdsToDelete }, surveyId } });
+    }
+  }
+
+  for (const entry of plan.toUpdate) {
+    await tx.embeddedData.update({
+      where: { id: entry.fieldId },
+      data: {
+        name: entry.name,
+        dataType: entry.dataType,
+        defaultValue: toStoredDefaultValue(entry.defaultValue),
+      },
+    });
+  }
+
+  // Sequential rather than batched: the link needs the id of the row it points at, and a survey
+  // holds a handful of fields, not thousands.
+  for (const entry of plan.toCreate) {
+    const field = await tx.embeddedData.create({
+      data: {
+        // Local: owned by this survey, absent from the shared library, so no library key.
+        key: null,
+        surveyId,
+        workspaceId,
+        name: entry.name,
+        source: entry.source,
+        dataType: entry.dataType,
+        defaultValue: toStoredDefaultValue(entry.defaultValue),
+      },
+      select: { id: true },
+    });
+
+    await tx.surveyEmbeddedData.create({
+      data: { surveyId, workspaceId, embeddedDataId: field.id, storageKey: entry.storageKey },
+    });
+  }
+};
+
+/**
+ * `@@unique([surveyId, storageKey])` would reject a repeated address anyway, but as an opaque
+ * database error. Naming the offending key turns it into a 400 the editor can act on.
+ */
+const assertNoDuplicateStorageKeys = (desired: TDesiredEmbeddedField[]): void => {
+  const seen = new Set<string>();
+  for (const entry of desired) {
+    if (seen.has(entry.storageKey)) {
+      throw new InvalidInputError(`Duplicate embedded data field: ${entry.storageKey}`);
+    }
+    seen.add(entry.storageKey);
+  }
+};

--- a/apps/web/lib/embedded-data/reconcile.ts
+++ b/apps/web/lib/embedded-data/reconcile.ts
@@ -163,13 +163,27 @@ export const reconcileEmbeddedData = async (
       .filter((fieldId): fieldId is string => fieldId !== null);
 
     if (fieldIdsToDelete.length > 0) {
-      await tx.embeddedData.deleteMany({ where: { id: { in: fieldIdsToDelete }, surveyId } });
+      await tx.embeddedData.deleteMany({
+        where: {
+          id: { in: fieldIdsToDelete },
+          surveyId,
+          // This survey's links are already gone, so any link still standing belongs to another
+          // survey — and deleting the row would cascade that link away, silently costing that survey
+          // a field. Nothing creates such a link today (the reconcile only ever links to rows it just
+          // created), so this guards an invariant rather than a live path; leaving an orphaned row
+          // behind is the better failure of the two.
+          surveyLinks: { none: {} },
+        },
+      });
     }
   }
 
   for (const entry of plan.toUpdate) {
-    await tx.embeddedData.update({
-      where: { id: entry.fieldId },
+    // Scoped by `surveyId` to match the delete above. The id provably came from a link this survey
+    // owns, so the extra clause changes nothing — it just keeps every write here tenant-scoped on its
+    // face rather than by argument.
+    await tx.embeddedData.updateMany({
+      where: { id: entry.fieldId, surveyId },
       data: {
         name: entry.name,
         dataType: entry.dataType,

--- a/apps/web/lib/embedded-data/reconcile.ts
+++ b/apps/web/lib/embedded-data/reconcile.ts
@@ -50,7 +50,7 @@ const SELECT_CURRENT_FIELDS = {
  */
 const toStoredDefaultValue = (
   defaultValue: TEmbeddedDataDefaultValue
-): TEmbeddedDataDefaultValue | typeof Prisma.DbNull => (defaultValue === null ? Prisma.DbNull : defaultValue);
+): TEmbeddedDataDefaultValue | typeof Prisma.DbNull => defaultValue ?? Prisma.DbNull;
 
 /**
  * Works out what has to change for a survey's Embedded Data to match `desired`.
@@ -80,9 +80,10 @@ export const planEmbeddedDataReconcile = (
     // "is it local" also stops one survey deleting another's local row, which the schema permits.
     const isOwnedByThisSurvey = isLocalEmbeddedData(entry.field) && entry.field.surveyId === surveyId;
 
-    // A storage key whose source changed is a different field wearing the same address — replace it
-    // rather than mutating a computed field into an ingested one.
-    if (!wanted || wanted.source !== entry.field.source) {
+    // Two cases, one test: the field is gone, or a storage key whose source changed is a different
+    // field wearing the same address — replace it rather than mutating a computed field into an
+    // ingested one. `wanted?.source` is undefined in the first case, which no source ever equals.
+    if (wanted?.source !== entry.field.source) {
       plan.toUnlink.push({
         linkId: entry.linkId,
         fieldIdToDelete: isOwnedByThisSurvey ? entry.field.id : null,
@@ -109,7 +110,8 @@ export const planEmbeddedDataReconcile = (
 
   for (const entry of desired) {
     const existing = currentByKey.get(entry.storageKey);
-    if (!existing || existing.field.source !== entry.source) {
+    // Mirror of the test above: absent, or present under a different source, both mean create.
+    if (existing?.field.source !== entry.source) {
       plan.toCreate.push(entry);
     }
   }

--- a/apps/web/lib/survey/service.scheduling.test.ts
+++ b/apps/web/lib/survey/service.scheduling.test.ts
@@ -59,10 +59,16 @@ describe("survey service scheduling", () => {
     vi.mocked(getActionClasses).mockResolvedValue([mockActionClass] as never);
     vi.mocked(getOrganizationByWorkspaceId).mockResolvedValue({ id: "org123" } as never);
     mockQueueAuditEventWithoutRequest.mockResolvedValue(undefined);
-    // createSurvey now wraps its core writes in prisma.$transaction; run the callback with the same
-    // mocked client so per-test prisma.survey/segment mocks still apply inside the transaction.
+    // createSurvey and updateSurveyInternal wrap their core writes in prisma.$transaction; run the
+    // callback with the same mocked client so per-test prisma.survey/segment mocks still apply inside
+    // the transaction.
     vi.mocked(prisma.$transaction).mockImplementation(((callback: (tx: typeof prisma) => Promise<unknown>) =>
       callback(prisma)) as typeof prisma.$transaction);
+    // Both paths also reconcile the Embedded Data tables (ENG-1978); no existing links means the
+    // reconcile is a no-op and scheduling behaviour is what these tests still measure.
+    vi.mocked(prisma.surveyEmbeddedData.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.embeddedData.create).mockResolvedValue({ id: "ed_1" } as never);
+    vi.mocked(prisma.surveyEmbeddedData.create).mockResolvedValue({} as never);
   });
 
   afterEach(() => {

--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -59,10 +59,17 @@ vi.mock("@/lib/actionClass/service", () => ({
 
 beforeEach(() => {
   prisma.survey.count.mockResolvedValue(1);
-  // createSurvey now wraps its core writes in prisma.$transaction; run the callback with the same
-  // mocked client so per-test prisma.survey/segment mocks still apply inside the transaction.
+  // createSurvey and updateSurveyInternal wrap their core writes in prisma.$transaction; run the
+  // callback with the same mocked client so per-test prisma.survey/segment mocks still apply inside
+  // the transaction.
   vi.mocked(prisma.$transaction).mockImplementation(((callback: (tx: typeof prisma) => Promise<unknown>) =>
     callback(prisma)) as typeof prisma.$transaction);
+  // Both paths also reconcile the Embedded Data tables (ENG-1978). Start every test with no existing
+  // links so that reconcile is a no-op; the behaviour itself is covered by its own unit and
+  // integration tests.
+  vi.mocked(prisma.surveyEmbeddedData.findMany).mockResolvedValue([]);
+  vi.mocked(prisma.embeddedData.create).mockResolvedValue({ id: "ed_1" } as never);
+  vi.mocked(prisma.surveyEmbeddedData.create).mockResolvedValue({} as never);
 });
 
 describe("evaluateLogic with mockSurveyWithLogic", () => {

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -614,26 +614,35 @@ export const updateSurveyInternal = async (
     };
 
     delete data.createdBy;
-    const persistedSurvey = await prisma.$transaction(async (tx) => {
-      const survey = await tx.survey.update({
-        where: { id: surveyId },
-        data,
-        select: selectSurvey,
-      });
+    const persistedSurvey = await prisma.$transaction(
+      async (tx) => {
+        const survey = await tx.survey.update({
+          where: { id: surveyId },
+          data,
+          select: selectSurvey,
+        });
 
-      // ENG-1978: mirror the saved fields into the EmbeddedData tables in the same transaction, so a
-      // survey never commits without them. Derived from the PERSISTED survey rather than the payload:
-      // a partial update leaves `variables` / `hiddenFields` untouched in the column, and reading the
-      // payload instead would see them as absent and delete every row. workspaceId comes from the
-      // stored survey for the ENG-1749 reason above — never from the client.
-      await reconcileEmbeddedData(tx, {
-        surveyId,
-        workspaceId: currentSurvey.workspaceId,
-        desired: toDesiredEmbeddedFields(survey),
-      });
+        // ENG-1978: mirror the saved fields into the EmbeddedData tables in the same transaction, so a
+        // survey never commits without them. Derived from the PERSISTED survey rather than the payload:
+        // a partial update leaves `variables` / `hiddenFields` untouched in the column, and reading the
+        // payload instead would see them as absent and delete every row. workspaceId comes from the
+        // stored survey for the ENG-1749 reason above — never from the client.
+        await reconcileEmbeddedData(tx, {
+          surveyId,
+          workspaceId: currentSurvey.workspaceId,
+          desired: toDesiredEmbeddedFields(survey),
+        });
 
-      return survey;
-    });
+        return survey;
+      },
+      // Prisma's default interactive-transaction ceiling is 5s, which the write above can plausibly
+      // approach on a large survey: it rewrites blocks, follow-ups, triggers and languages, then reads
+      // back through `selectSurvey`'s deep select. Failing here loses the author's edit, while the
+      // worst a slow commit costs is a held connection — so the timeout is raised rather than left to
+      // turn a slow save into a failed one. The reconcile itself adds one indexed read plus a write per
+      // changed field.
+      { timeout: 20_000, maxWait: 10_000 }
+    );
 
     return await reconcilePersistedSurveySchedulingIfDue({
       logSource: "survey-update",

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -841,58 +841,65 @@ export const createSurvey = async (
     // Create the survey and — for app surveys — its private targeting segment atomically. The survey,
     // the segment (seeded with any caller-supplied filters), and the segment connection must all land
     // or none, so a mid-write failure can't leave a survey with missing or partial targeting.
-    const survey = await prisma.$transaction(async (tx) => {
-      const createdSurvey = await tx.survey.create({
-        data: {
-          ...data,
-          workspace: {
-            connect: {
-              id: parsedWorkspaceId,
-            },
-          },
-        },
-        select: selectSurvey,
-      });
-
-      if (createdSurvey.type === "app") {
-        const newSegment = await tx.segment.create({
+    const survey = await prisma.$transaction(
+      async (tx) => {
+        const createdSurvey = await tx.survey.create({
           data: {
-            title: createdSurvey.id,
-            filters: privateSegmentFilters,
-            isPrivate: true,
+            ...data,
             workspace: {
               connect: {
                 id: parsedWorkspaceId,
               },
             },
           },
+          select: selectSurvey,
         });
 
-        await tx.survey.update({
-          where: {
-            id: createdSurvey.id,
-          },
-          data: {
-            segment: {
-              connect: {
-                id: newSegment.id,
+        if (createdSurvey.type === "app") {
+          const newSegment = await tx.segment.create({
+            data: {
+              title: createdSurvey.id,
+              filters: privateSegmentFilters,
+              isPrivate: true,
+              workspace: {
+                connect: {
+                  id: parsedWorkspaceId,
+                },
               },
             },
-          },
+          });
+
+          await tx.survey.update({
+            where: {
+              id: createdSurvey.id,
+            },
+            data: {
+              segment: {
+                connect: {
+                  id: newSegment.id,
+                },
+              },
+            },
+          });
+        }
+
+        // ENG-1978: a survey created from a template, the API or a duplicate can already carry
+        // variables and hidden fields, so the tables have to be populated at creation, not just on the
+        // next save.
+        await reconcileEmbeddedData(tx, {
+          surveyId: createdSurvey.id,
+          workspaceId: parsedWorkspaceId,
+          desired: toDesiredEmbeddedFields(createdSurvey),
         });
-      }
 
-      // ENG-1978: a survey created from a template, the API or a duplicate can already carry
-      // variables and hidden fields, so the tables have to be populated at creation, not just on the
-      // next save.
-      await reconcileEmbeddedData(tx, {
-        surveyId: createdSurvey.id,
-        workspaceId: parsedWorkspaceId,
-        desired: toDesiredEmbeddedFields(createdSurvey),
-      });
-
-      return createdSurvey;
-    });
+        return createdSurvey;
+      },
+      // This transaction predates ENG-1978, but the reconcile above adds a read plus two writes per
+      // field inside it, and neither `variables` nor `hiddenFields` is bounded — so a large template or
+      // API create could now reach Prisma's 5s default where it used to fit. Matched to the other two
+      // reconcile call sites rather than left to inherit a ceiling this work made easier to hit.
+      { timeout: 20_000, maxWait: 10_000 }
+    );
 
     // TODO: Fix this, this happens because the survey type "web" is no longer in the zod types but its required in the schema for migration
     // @ts-expect-error

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -4,6 +4,7 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
 import { ZId, ZOptionalNumber } from "@formbricks/types/common";
+import { toDesiredEmbeddedFields } from "@formbricks/types/embedded-data-mapping";
 import {
   DatabaseError,
   InvalidInputError,
@@ -13,6 +14,7 @@ import {
 import { TBaseFilters, ZSegmentFilters } from "@formbricks/types/segment";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
 import { TSurvey, TSurveyCreateInput, ZSurvey, ZSurveyCreateInput } from "@formbricks/types/surveys/types";
+import { reconcileEmbeddedData } from "@/lib/embedded-data/reconcile";
 import {
   getOrganizationByWorkspaceId,
   subscribeOrganizationMembersToSurveyResponses,
@@ -612,10 +614,25 @@ export const updateSurveyInternal = async (
     };
 
     delete data.createdBy;
-    const persistedSurvey = await prisma.survey.update({
-      where: { id: surveyId },
-      data,
-      select: selectSurvey,
+    const persistedSurvey = await prisma.$transaction(async (tx) => {
+      const survey = await tx.survey.update({
+        where: { id: surveyId },
+        data,
+        select: selectSurvey,
+      });
+
+      // ENG-1978: mirror the saved fields into the EmbeddedData tables in the same transaction, so a
+      // survey never commits without them. Derived from the PERSISTED survey rather than the payload:
+      // a partial update leaves `variables` / `hiddenFields` untouched in the column, and reading the
+      // payload instead would see them as absent and delete every row. workspaceId comes from the
+      // stored survey for the ENG-1749 reason above — never from the client.
+      await reconcileEmbeddedData(tx, {
+        surveyId,
+        workspaceId: currentSurvey.workspaceId,
+        desired: toDesiredEmbeddedFields(survey),
+      });
+
+      return survey;
     });
 
     return await reconcilePersistedSurveySchedulingIfDue({
@@ -855,6 +872,15 @@ export const createSurvey = async (
           },
         });
       }
+
+      // ENG-1978: a survey created from a template, the API or a duplicate can already carry
+      // variables and hidden fields, so the tables have to be populated at creation, not just on the
+      // next save.
+      await reconcileEmbeddedData(tx, {
+        surveyId: createdSurvey.id,
+        workspaceId: parsedWorkspaceId,
+        desired: toDesiredEmbeddedFields(createdSurvey),
+      });
 
       return createdSurvey;
     });

--- a/apps/web/modules/survey/list/lib/survey.test.ts
+++ b/apps/web/modules/survey/list/lib/survey.test.ts
@@ -108,6 +108,18 @@ vi.mock("@formbricks/database", () => ({
     organization: {
       findFirst: vi.fn(),
     },
+    // Added for the Embedded Data reconcile the copy runs (ENG-1978)
+    embeddedData: {
+      create: vi.fn(),
+      update: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    surveyEmbeddedData: {
+      findMany: vi.fn(),
+      create: vi.fn(),
+      deleteMany: vi.fn(),
+    },
+    $transaction: vi.fn(),
   },
 }));
 
@@ -140,6 +152,15 @@ const resetMocks = () => {
   vi.mocked(prisma.actionClass.findMany).mockReset();
   vi.mocked(getQuotas).mockReset();
   vi.mocked(logger.error).mockClear();
+
+  // copySurveyToOtherWorkspace wraps its writes in a transaction (ENG-1978) so the survey and its
+  // Embedded Data rows land together. Run the callback against the same mocked client, and start the
+  // copy with no existing links so the reconcile is a no-op unless a test says otherwise.
+  vi.mocked(prisma.$transaction).mockImplementation(((callback: (tx: typeof prisma) => Promise<unknown>) =>
+    callback(prisma)) as typeof prisma.$transaction);
+  vi.mocked(prisma.surveyEmbeddedData.findMany).mockResolvedValue([]);
+  vi.mocked(prisma.embeddedData.create).mockResolvedValue({ id: "ed_1" } as never);
+  vi.mocked(prisma.surveyEmbeddedData.create).mockResolvedValue({} as never);
 };
 
 const makePrismaKnownError = () =>
@@ -526,6 +547,10 @@ describe("copySurveyToOtherWorkspace", () => {
   const mockNewSurveyResult = {
     id: "new_cuid2_id",
     workspaceId: targetWorkspaceId,
+    // The copy carries the source survey's Embedded Data, which the reconcile re-creates for the new
+    // survey (ENG-1978).
+    variables: [{ id: "var_cuid", name: "score", type: "number", value: 0 }],
+    hiddenFields: { enabled: true, fieldIds: ["plan"] },
     segment: null,
     triggers: [
       { actionClass: { id: "new_ac1", name: "Code Action", workspaceId: targetWorkspaceId } },
@@ -602,6 +627,32 @@ describe("copySurveyToOtherWorkspace", () => {
       })
     );
     expect(checkForInvalidMediaInBlocks).toHaveBeenCalledWith(mockExistingSurveyDetails.blocks);
+  });
+
+  test("defines the copied survey's embedded data in the TARGET workspace, not the source", async () => {
+    // The function's `workspaceId` argument is the source. Reading it instead of the created
+    // survey's own workspace would define the fields in the wrong tenant — which the composite
+    // foreign keys then reject, leaving the copy with no fields at all.
+    await copySurveyToOtherWorkspace(sourceWorkspaceId, surveyId, targetWorkspaceId, userId);
+
+    const workspaces = vi
+      .mocked(prisma.embeddedData.create)
+      .mock.calls.map(([args]) => (args as { data: { workspaceId: string } }).data.workspaceId);
+
+    expect(workspaces).toHaveLength(2);
+    expect(new Set(workspaces)).toEqual(new Set([targetWorkspaceId]));
+  });
+
+  test("re-creates the copied survey's variables and hidden fields under their original keys", async () => {
+    await copySurveyToOtherWorkspace(sourceWorkspaceId, surveyId, targetWorkspaceId, userId);
+
+    const storageKeys = vi
+      .mocked(prisma.surveyEmbeddedData.create)
+      .mock.calls.map(([args]) => (args as { data: { storageKey: string } }).data.storageKey);
+
+    // A variable keeps its cuid and a hidden field its name, so the copy's recall tokens — cloned
+    // verbatim from the source — still resolve.
+    expect(storageKeys).toEqual(["var_cuid", "plan"]);
   });
 
   test("should copy survey to the same workspace successfully", async () => {

--- a/apps/web/modules/survey/list/lib/survey.test.ts
+++ b/apps/web/modules/survey/list/lib/survey.test.ts
@@ -154,8 +154,15 @@ const resetMocks = () => {
   vi.mocked(logger.error).mockClear();
 
   // copySurveyToOtherWorkspace wraps its writes in a transaction (ENG-1978) so the survey and its
-  // Embedded Data rows land together. Run the callback against the same mocked client, and start the
-  // copy with no existing links so the reconcile is a no-op unless a test says otherwise.
+  // Embedded Data rows land together. Reset first like every mock above — otherwise the call history
+  // these tests assert on accumulates across tests — then run the callback against the same mocked
+  // client, and start the copy with no existing links so the reconcile is a no-op unless a test says
+  // otherwise.
+  vi.mocked(prisma.$transaction).mockReset();
+  vi.mocked(prisma.surveyEmbeddedData.findMany).mockReset();
+  vi.mocked(prisma.surveyEmbeddedData.create).mockReset();
+  vi.mocked(prisma.embeddedData.create).mockReset();
+
   vi.mocked(prisma.$transaction).mockImplementation(((callback: (tx: typeof prisma) => Promise<unknown>) =>
     callback(prisma)) as typeof prisma.$transaction);
   vi.mocked(prisma.surveyEmbeddedData.findMany).mockResolvedValue([]);

--- a/apps/web/modules/survey/list/lib/survey.ts
+++ b/apps/web/modules/survey/list/lib/survey.ts
@@ -5,9 +5,11 @@ import { z } from "zod";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { logger } from "@formbricks/logger";
+import { toDesiredEmbeddedFields } from "@formbricks/types/embedded-data-mapping";
 import { DatabaseError, InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
 import { TSurveyFilterCriteria } from "@formbricks/types/surveys/types";
+import { reconcileEmbeddedData } from "@/lib/embedded-data/reconcile";
 import { getOrganizationByWorkspaceId } from "@/lib/organization/service";
 import { checkForInvalidMediaInBlocks } from "@/lib/survey/utils";
 import { validateInputs } from "@/lib/utils/validate";
@@ -489,37 +491,53 @@ export const copySurveyToOtherWorkspace = async (
       }
     }
 
-    const newSurvey = await prisma.survey.create({
-      data: surveyData,
-      select: {
-        id: true,
-        workspaceId: true,
-        segment: {
-          select: {
-            id: true,
+    const newSurvey = await prisma.$transaction(async (tx) => {
+      const createdSurvey = await tx.survey.create({
+        data: surveyData,
+        select: {
+          id: true,
+          workspaceId: true,
+          variables: true,
+          hiddenFields: true,
+          segment: {
+            select: {
+              id: true,
+            },
           },
-        },
-        triggers: {
-          select: {
-            actionClass: {
-              select: {
-                id: true,
-                name: true,
-                workspaceId: true,
+          triggers: {
+            select: {
+              actionClass: {
+                select: {
+                  id: true,
+                  name: true,
+                  workspaceId: true,
+                },
+              },
+            },
+          },
+          languages: {
+            select: {
+              language: {
+                select: {
+                  code: true,
+                },
               },
             },
           },
         },
-        languages: {
-          select: {
-            language: {
-              select: {
-                code: true,
-              },
-            },
-          },
-        },
-      },
+      });
+
+      // ENG-1978: the copy carries the source survey's variables and hidden fields, so the new
+      // survey needs its own rows. `workspaceId` is read off the created row rather than the
+      // function's `workspaceId` argument, which is the SOURCE workspace — a copy into a different
+      // workspace must define its fields there.
+      await reconcileEmbeddedData(tx, {
+        surveyId: createdSurvey.id,
+        workspaceId: createdSurvey.workspaceId,
+        desired: toDesiredEmbeddedFields(createdSurvey),
+      });
+
+      return createdSurvey;
     });
 
     return newSurvey;

--- a/apps/web/modules/survey/list/lib/survey.ts
+++ b/apps/web/modules/survey/list/lib/survey.ts
@@ -491,54 +491,63 @@ export const copySurveyToOtherWorkspace = async (
       }
     }
 
-    const newSurvey = await prisma.$transaction(async (tx) => {
-      const createdSurvey = await tx.survey.create({
-        data: surveyData,
-        select: {
-          id: true,
-          workspaceId: true,
-          variables: true,
-          hiddenFields: true,
-          segment: {
-            select: {
-              id: true,
+    const newSurvey = await prisma.$transaction(
+      async (tx) => {
+        const createdSurvey = await tx.survey.create({
+          data: surveyData,
+          select: {
+            id: true,
+            workspaceId: true,
+            variables: true,
+            hiddenFields: true,
+            segment: {
+              select: {
+                id: true,
+              },
             },
-          },
-          triggers: {
-            select: {
-              actionClass: {
-                select: {
-                  id: true,
-                  name: true,
-                  workspaceId: true,
+            triggers: {
+              select: {
+                actionClass: {
+                  select: {
+                    id: true,
+                    name: true,
+                    workspaceId: true,
+                  },
+                },
+              },
+            },
+            languages: {
+              select: {
+                language: {
+                  select: {
+                    code: true,
+                  },
                 },
               },
             },
           },
-          languages: {
-            select: {
-              language: {
-                select: {
-                  code: true,
-                },
-              },
-            },
-          },
-        },
-      });
+        });
 
-      // ENG-1978: the copy carries the source survey's variables and hidden fields, so the new
-      // survey needs its own rows. `workspaceId` is read off the created row rather than the
-      // function's `workspaceId` argument, which is the SOURCE workspace — a copy into a different
-      // workspace must define its fields there.
-      await reconcileEmbeddedData(tx, {
-        surveyId: createdSurvey.id,
-        workspaceId: createdSurvey.workspaceId,
-        desired: toDesiredEmbeddedFields(createdSurvey),
-      });
+        // ENG-1978: the copy carries the source survey's variables and hidden fields, so the new
+        // survey needs its own rows. `workspaceId` is read off the created row rather than the
+        // function's `workspaceId` argument, which is the SOURCE workspace — a copy into a different
+        // workspace must define its fields there.
+        await reconcileEmbeddedData(tx, {
+          surveyId: createdSurvey.id,
+          workspaceId: createdSurvey.workspaceId,
+          desired: toDesiredEmbeddedFields(createdSurvey),
+        });
 
-      return createdSurvey;
-    });
+        return createdSurvey;
+      },
+      // This create was untransacted before ENG-1978, so wrapping it introduced Prisma's 5s
+      // interactive-transaction ceiling where there had been none. It is the deepest of the three
+      // reconcile call sites — it clones blocks, endings, the welcome card, variables, hidden fields,
+      // follow-ups and quotas, and resolves an action class per trigger through `connectOrCreate` —
+      // so a large survey could plausibly reach it and fail a copy that used to succeed. Matches the
+      // ceiling on `updateSurveyInternal` for the same reason.
+      { timeout: 20_000, maxWait: 10_000 }
+    );
 
     return newSurvey;
   } catch (error) {

--- a/packages/database/src/prisma.ts
+++ b/packages/database/src/prisma.ts
@@ -136,6 +136,7 @@ export namespace Prisma {
   export type SegmentUpdateInput = PrismaModelTypes.SegmentUpdateInput;
   export type StringFilter = PrismaModelTypes.StringFilter;
   export type SurveyCreateInput = PrismaModelTypes.SurveyCreateInput;
+  export type SurveyEmbeddedDataSelect = PrismaModelTypes.SurveyEmbeddedDataSelect;
   export type SurveyGetPayload<S extends boolean | null | undefined | PrismaModelTypes.SurveyDefaultArgs> =
     PrismaModelTypes.SurveyGetPayload<S>;
   export type SurveyLanguageCreateNestedManyWithoutSurveyInput =

--- a/packages/types/embedded-data-mapping.test.ts
+++ b/packages/types/embedded-data-mapping.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import { toDesiredEmbeddedFields } from "./embedded-data-mapping";
+import { type TSurveyVariable } from "./surveys/types";
+
+const numberVariable: TSurveyVariable = {
+  id: "clx000000000000000000001",
+  name: "score",
+  type: "number",
+  value: 42,
+};
+
+const textVariable: TSurveyVariable = {
+  id: "clx000000000000000000002",
+  name: "tier",
+  type: "text",
+  value: "gold",
+};
+
+describe("toDesiredEmbeddedFields", () => {
+  test("returns nothing for a survey with neither variables nor hidden fields", () => {
+    expect(toDesiredEmbeddedFields({})).toEqual([]);
+    expect(toDesiredEmbeddedFields({ variables: [], hiddenFields: { enabled: true, fieldIds: [] } })).toEqual(
+      []
+    );
+    expect(toDesiredEmbeddedFields({ variables: null, hiddenFields: null })).toEqual([]);
+  });
+
+  test("maps a number variable to a computed number field addressed by its cuid", () => {
+    expect(toDesiredEmbeddedFields({ variables: [numberVariable] })).toEqual([
+      {
+        storageKey: "clx000000000000000000001",
+        name: "score",
+        source: "computed",
+        dataType: "number",
+        defaultValue: 42,
+      },
+    ]);
+  });
+
+  test("maps a text variable to a computed string field", () => {
+    expect(toDesiredEmbeddedFields({ variables: [textVariable] })).toEqual([
+      {
+        storageKey: "clx000000000000000000002",
+        name: "tier",
+        source: "computed",
+        dataType: "string",
+        defaultValue: "gold",
+      },
+    ]);
+  });
+
+  test("maps a hidden field to an ingested string field addressed by its name", () => {
+    expect(toDesiredEmbeddedFields({ hiddenFields: { enabled: true, fieldIds: ["plan"] } })).toEqual([
+      {
+        storageKey: "plan",
+        name: "plan",
+        source: "ingested",
+        dataType: "string",
+        defaultValue: null,
+      },
+    ]);
+  });
+
+  test("keeps a legacy hidden field name exactly as stored", () => {
+    // Uppercase and hyphens are legal in stored hidden field ids. Normalising one here would move
+    // the address its recall tokens and stored responses already use.
+    const [field] = toDesiredEmbeddedFields({ hiddenFields: { enabled: true, fieldIds: ["Brand-Name"] } });
+    expect(field.storageKey).toBe("Brand-Name");
+    expect(field.name).toBe("Brand-Name");
+  });
+
+  test("ignores hiddenFields.enabled, which is a survey-level toggle rather than a field", () => {
+    const disabled = toDesiredEmbeddedFields({ hiddenFields: { enabled: false, fieldIds: ["plan"] } });
+    const enabled = toDesiredEmbeddedFields({ hiddenFields: { enabled: true, fieldIds: ["plan"] } });
+    expect(disabled).toEqual(enabled);
+  });
+
+  test("returns variables before hidden fields, both in input order", () => {
+    const fields = toDesiredEmbeddedFields({
+      variables: [numberVariable, textVariable],
+      hiddenFields: { enabled: true, fieldIds: ["plan", "campaign"] },
+    });
+    expect(fields.map((field) => field.storageKey)).toEqual([
+      "clx000000000000000000001",
+      "clx000000000000000000002",
+      "plan",
+      "campaign",
+    ]);
+  });
+
+  test("passes duplicate storage keys through rather than merging them", () => {
+    // Each caller decides: the write bridge rejects the save, the backfill can skip the survey.
+    const fields = toDesiredEmbeddedFields({ hiddenFields: { enabled: true, fieldIds: ["plan", "plan"] } });
+    expect(fields).toHaveLength(2);
+  });
+});

--- a/packages/types/embedded-data-mapping.test.ts
+++ b/packages/types/embedded-data-mapping.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, test } from "vitest";
-import { toDesiredEmbeddedFields } from "./embedded-data-mapping";
-import { type TSurveyVariable } from "./surveys/types";
+import { ZEmbeddedData } from "./embedded-data";
+import { type TDesiredEmbeddedField, toDesiredEmbeddedFields } from "./embedded-data-mapping";
+import { type TSurveyVariable, ZSurveyHiddenFields, ZSurveyVariable } from "./surveys/types";
+
+/** Wraps a mapped field in the row it would be written as, so the two schemas can be checked together. */
+const asStoredRow = (field: TDesiredEmbeddedField) => ({
+  id: "clx000000000000000000009",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  key: null,
+  description: null,
+  locked: false,
+  surveyId: "clx000000000000000000008",
+  workspaceId: "clx000000000000000000007",
+  name: field.name,
+  source: field.source,
+  dataType: field.dataType,
+  defaultValue: field.defaultValue,
+});
 
 const numberVariable: TSurveyVariable = {
   id: "clx000000000000000000001",
@@ -86,6 +103,39 @@ describe("toDesiredEmbeddedFields", () => {
       "plan",
       "campaign",
     ]);
+  });
+
+  describe("legacy names longer than any create-time cap", () => {
+    // The legacy schemas put no length limit on a variable name or a hidden field id, and the column
+    // is TEXT, so a stored survey can carry one of these. Everything the backfill can move therefore
+    // has to survive the round trip — a row that writes but cannot be read back is the worst outcome,
+    // because it only surfaces once ENG-1837 points readers at these tables.
+    const longName = "a".repeat(300);
+
+    test("the legacy schemas accept them, which is why this matters", () => {
+      expect(
+        ZSurveyVariable.safeParse({ id: "clx000000000000000000001", name: longName, type: "text", value: "" })
+          .success
+      ).toBe(true);
+      expect(ZSurveyHiddenFields.safeParse({ enabled: true, fieldIds: [longName] }).success).toBe(true);
+    });
+
+    test("a long hidden field name maps and reads back, keeping its storage key", () => {
+      const [field] = toDesiredEmbeddedFields({ hiddenFields: { enabled: true, fieldIds: [longName] } });
+
+      expect(field.storageKey).toBe(longName);
+      expect(ZEmbeddedData.safeParse(asStoredRow(field)).success).toBe(true);
+    });
+
+    test("a long variable name maps and reads back, keeping its cuid", () => {
+      const [field] = toDesiredEmbeddedFields({
+        variables: [{ id: "clx000000000000000000001", name: longName, type: "text", value: "" }],
+      });
+
+      expect(field.storageKey).toBe("clx000000000000000000001");
+      expect(field.name).toBe(longName);
+      expect(ZEmbeddedData.safeParse(asStoredRow(field)).success).toBe(true);
+    });
   });
 
   test("passes duplicate storage keys through rather than merging them", () => {

--- a/packages/types/embedded-data-mapping.ts
+++ b/packages/types/embedded-data-mapping.ts
@@ -1,0 +1,71 @@
+import {
+  type TEmbeddedDataDefaultValue,
+  type TEmbeddedDataSource,
+  type TEmbeddedDataType,
+} from "./embedded-data";
+import { type TSurveyHiddenFields, type TSurveyVariable } from "./surveys/types";
+
+/**
+ * One Embedded Data field a survey should have, derived from its legacy shape.
+ *
+ * This is the row-plus-link pair flattened into one object: everything except the ids the database
+ * assigns. `storageKey` is the address the field is already reachable at, so it is what both sides
+ * of a reconcile compare on.
+ */
+export interface TDesiredEmbeddedField {
+  /** The address this field's value lives under inside the survey. */
+  storageKey: string;
+  name: string;
+  source: TEmbeddedDataSource;
+  dataType: TEmbeddedDataType;
+  defaultValue: TEmbeddedDataDefaultValue;
+}
+
+/** A survey's legacy Embedded Data, the only two places it lives before the tables exist. */
+export interface TLegacyEmbeddedFields {
+  variables?: TSurveyVariable[] | null;
+  hiddenFields?: TSurveyHiddenFields | null;
+}
+
+/**
+ * Translates a survey's legacy `variables` + `hiddenFields` into the fields it should have as rows.
+ *
+ * Shared by the two things that write those rows: the editor write bridge (ENG-1978) and the
+ * one-time backfill (ENG-1835). Keeping it in `@formbricks/types` is what lets both reach it — a
+ * data migration in `packages/database` cannot import from `apps/web`.
+ *
+ * **The rule that makes the migration safe:** `storageKey` is the field's *existing* address — a
+ * variable's cuid, a hidden field's name — never a new or normalised one. Those are the keys recall
+ * tokens, logic operands and stored responses already use, so preserving them is what lets every
+ * survey keep resolving untouched. Legacy names with uppercase letters or hyphens pass through
+ * exactly as stored.
+ *
+ * Faithful, not defensive: duplicate `storageKey`s in the input come back as duplicate entries
+ * rather than being silently merged, so each caller can choose whether that is an error to report
+ * or a broken survey to skip.
+ */
+export const toDesiredEmbeddedFields = ({
+  variables,
+  hiddenFields,
+}: TLegacyEmbeddedFields): TDesiredEmbeddedField[] => {
+  const computed: TDesiredEmbeddedField[] = (variables ?? []).map((variable) => ({
+    // A variable is addressed by its cuid everywhere, so that is the storage key.
+    storageKey: variable.id,
+    name: variable.name,
+    source: "computed",
+    dataType: variable.type === "number" ? "number" : "string",
+    defaultValue: variable.value,
+  }));
+
+  const ingested: TDesiredEmbeddedField[] = (hiddenFields?.fieldIds ?? []).map((fieldId) => ({
+    // A hidden field is addressed by its name, and has no display label separate from it.
+    storageKey: fieldId,
+    name: fieldId,
+    source: "ingested",
+    // Hidden fields were untyped strings, and had no default. Typing them is a v2 action.
+    dataType: "string",
+    defaultValue: null,
+  }));
+
+  return [...computed, ...ingested];
+};

--- a/packages/types/embedded-data.ts
+++ b/packages/types/embedded-data.ts
@@ -2,8 +2,13 @@ import { z } from "zod";
 import { isLegacyIdCharset, isSafeIdentifier } from "./safe-identifier";
 import { RESERVED_DECLARED_FIELD_NAMES } from "./surveys/validation";
 
-/** Longest allowed field key / display name. */
-export const EMBEDDED_DATA_NAME_MAX_LENGTH = 255;
+/**
+ * Longest allowed library key.
+ *
+ * Deliberately not applied to `name`: a key is always newly authored, but a name can arrive from a
+ * migrated variable or hidden field, and the legacy schemas cap neither. See {@link ZEmbeddedData}.
+ */
+export const EMBEDDED_DATA_KEY_MAX_LENGTH = 255;
 
 /**
  * Where an Embedded Data field's value comes from.
@@ -60,7 +65,7 @@ export const ZEmbeddedData = z
     // the shared library and therefore have no library name.
     key: z
       .string()
-      .max(EMBEDDED_DATA_NAME_MAX_LENGTH)
+      .max(EMBEDDED_DATA_KEY_MAX_LENGTH)
       .refine(isSafeIdentifier, "Key must start with a lowercase letter and contain only a-z, 0-9 and _")
       // A library key is always newly authored (local fields carry `key: null`), so it goes through
       // the strict create-time rule. Without this a shared ingested field could be keyed `verify` or
@@ -70,10 +75,14 @@ export const ZEmbeddedData = z
     // Blank rather than empty: `name` is the label the library and the editor render, and a
     // whitespace-only one draws a row with nothing to read or click. Checked, not trimmed, so the
     // stored value is never silently rewritten.
-    name: z
-      .string()
-      .refine((value) => value.trim().length > 0, "Name must not be blank")
-      .max(EMBEDDED_DATA_NAME_MAX_LENGTH),
+    //
+    // No length cap, for the same reason `storageKey` has none. A migrated field's name is copied
+    // from a variable name or a hidden field id, and neither `ZSurveyVariable` nor
+    // `ZSurveyHiddenFields` bounds its length, so a stored survey can carry one longer than any cap
+    // we would pick. Capping here would let the backfill write a row that then fails to read back —
+    // a failure that only surfaces once ENG-1837 points readers at these tables. The create-time
+    // limit belongs on the authoring path, alongside the naming rule.
+    name: z.string().refine((value) => value.trim().length > 0, "Name must not be blank"),
     description: z.string().nullable(),
     source: ZEmbeddedDataSource,
     dataType: ZEmbeddedDataType.prefault("string"),


### PR DESCRIPTION
## What & why

ENG-1833 added `EmbeddedData` + `SurveyEmbeddedData`, but nothing writes them. The legacy Variables and Hidden Fields cards only mutate the editor's client-side working copy and save the whole survey, so a field added, renamed or removed in the editor never reaches the tables — and ENG-1837 is about to point readers at them.

This is the **write** half. Three pieces:

- **`toDesiredEmbeddedFields`** (`packages/types/embedded-data-mapping.ts`) — the pure translation from a survey's legacy `variables` / `hiddenFields` to the fields it should have. A variable becomes `computed` addressed by its **existing cuid**; a hidden field becomes `ingested` addressed by its **existing name**. Those two rules are what let recall tokens, logic operands and stored responses keep resolving untouched.
- **`reconcileEmbeddedData`** (`apps/web/lib/embedded-data/reconcile.ts`) — diffs a survey's current links against that list and applies the difference inside the caller's transaction. The diff itself (`planEmbeddedDataReconcile`) is a pure function.
- **Three call sites** — every path that persists a survey.

| Path | Reached from |
| --- | --- |
| `updateSurveyInternal` | editor save / publish / schedule, v1 management API `PUT` |
| `createSurvey` | template picker (v3 templates route), v1 and v3 API `POST` |
| `copySurveyToOtherWorkspace` | duplicate, and copy into another workspace |

**Nothing reads these tables yet** — readers stay on the JSON until ENG-1837 — and **no `Response` row is touched**, because a response is keyed by the same `storageKey` a definition moves under.

### Why `packages/types` for the mapping

ENG-1835's backfill runs from `packages/database/migration/`, which cannot import from `apps/web` but can import workspace packages (the language migration already imports `@formbricks/i18n-utils`). Putting the mapping there is what lets the backfill reuse it instead of re-deriving the same rules — which is exactly where a divergence would break the non-breakage guarantee.

### Three things worth a reviewer's eye

**The desired fields come from the PERSISTED survey, not the incoming payload.** A partial update — which the v1 management API allows — leaves `variables` / `hiddenFields` untouched in the column. Reading the payload would see them as absent and delete every row. `selectSurvey` already returns both, so the reconcile reads what actually landed.

**`copySurveyToOtherWorkspace` takes the SOURCE workspace as its first argument.** The reconcile reads `workspaceId` off the created row instead, so a copy defines its fields in the workspace it landed in. The composite foreign keys from ENG-1833 reject the wrong one outright, so the failure mode would be a copy with no fields rather than cross-tenant rows — still wrong, hence a dedicated test.

**Definitions the survey does not own are unlinked, never deleted or edited.** The legacy cards know nothing about the shared library, so a save that omits a shared field drops this survey's use of it and leaves the workspace-owned row alone. No shared rows exist yet (the manager is ENG-1851), but this reconcile keeps running once they do. The same check — owner, not merely "is it local" — also stops one survey's save deleting another survey's local definition, which the schema permits.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1978/reconcile-editor-saves-into-the-embeddeddata-tables-v1-write-bridge

Part of Milestone 1 of the [Embedded Data](https://linear.app/formbricks/project/embedded-data-3d184a43d2f9) project. Targets `epic/embedded-data-v1` — all of v1 (M1–M4) ships as one release. Unblocks ENG-1835 (backfill) and ENG-1837 (repoint readers).

## How this was tested

**Unit — 30 new tests**

- `packages/types/embedded-data-mapping.test.ts` (8): the mapping table, a legacy name with caps and a hyphen surviving untouched, `hiddenFields.enabled` correctly ignored, duplicates passed through rather than merged.
- `apps/web/lib/embedded-data/reconcile.test.ts` (11): the planner's full branching — create, delete, rename-as-replace, each mutable field, a source change replacing rather than mutating, and both shared-library rules.
- `modules/survey/list/lib/survey.test.ts` (+2): the copy defines its fields in the target workspace, and keeps the original storage keys.

**Integration — 11 new tests against real Postgres** (`apps/web/integration/embedded-data-reconcile.integration.test.ts`). The rules that only exist as database state: `@@unique([surveyId, storageKey])` rejecting a duplicate, unlink-before-create for a replaced field, the cascade when a survey is deleted, two surveys in one workspace both holding a field named `plan`, and `Response` unchanged across a create and a delete.

**Full suites**

- `apps/web` unit — **7638 passed, 592 files**
- `apps/web` integration — **94 passed, 23 files**
- `packages/types` — **97 passed**
- `pnpm typecheck` clean, `pnpm lint` 0 errors, prettier clean

**The copy-path trap was verified, not assumed.** Passing the source workspace instead of the created survey's own fails the new test:

```
× defines the copied survey's embedded data in the TARGET workspace, not the source
  Tests  1 failed | 36 passed (37)
```

**Manual, against a local database.** A drift query comparing every survey's legacy JSON to its rows — an empty result is the pass condition — run after each of: save, add a field, rename a field, remove a field, duplicate, copy into another workspace, delete the survey. `Response` count unchanged throughout.

## QA / Test Plan

**How to test**

Still nothing user-visible: the tables fill up but no code reads them. The check is that the surfaces this now runs inside behave exactly as before.

- [ ] Open a survey with variables and hidden fields, add / rename / remove one of each, save → all succeed, no new errors
- [ ] Publish a draft survey → publishes normally
- [ ] Schedule a survey (publish-on / close-on) → saves normally
- [ ] Create a survey from a template that has hidden fields → opens with them intact
- [ ] Duplicate a survey → duplicate opens with the same fields
- [ ] Copy a survey into a **different** workspace → copy opens with the same fields
- [ ] Delete a survey that has variables and hidden fields → deletes cleanly, no foreign-key error in the logs
- [ ] Use a variable and a hidden field in recall (`@`) and in a logic condition, submit a response → values resolve as before
- [ ] Export that survey's responses → same headers and values as before
- [ ] Add two hidden fields with the same name in one survey → rejected with a message, not a 500

**Preconditions / test data**

- A workspace with an existing survey that has at least one variable and one hidden field, plus responses collected before this change.
- A second workspace in the same organization, for the cross-workspace copy.

**Risks & regressions**

- Medium-low. No user-visible change and no read path touched, but three survey **write** paths now run extra work inside a transaction — two of which (`updateSurveyInternal`, `copySurveyToOtherWorkspace`) gained a transaction they did not have. The regression surface is survey save / create / duplicate succeeding at all, which the checklist above walks.
- A save with unchanged fields still runs one extra `findMany` and no writes.

**Migrations / env / cutover**

- No migration and no env change. Existing surveys keep their empty tables until the ENG-1835 backfill; a survey edited before then migrates itself through this path, which is why that backfill stays idempotent and skips surveys that already have links.
