### PR TITLE
fix(unify-feedback): exclude draft surveys from feedback source suggestions

### DIFF
--- a/apps/web/modules/ee/unify-feedback/sources/components/feedback-sources-page-client.tsx
+++ b/apps/web/modules/ee/unify-feedback/sources/components/feedback-sources-page-client.tsx
@@ -25,7 +25,7 @@ import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper
 import { PageHeader } from "@/modules/ui/components/page-header";
 import { UnifyConfigNavigation } from "../../components/unify-config-navigation";
 import { TFieldMapping, TUnifySurvey, getTranslatedFeedbackSourceError } from "../types";
-import { getSelectableQuestionIds } from "../utils";
+import { getSelectableQuestionIds, getSuggestedSurveys } from "../utils";
 import { CreateFeedbackSourceModal } from "./create-feedback-source-modal";
 import { CsvImportModal } from "./csv-import-modal";
 import { EditFeedbackSourceModal } from "./edit-feedback-source-modal";
@@ -70,11 +70,11 @@ export function FeedbackSourcesSection({
       ),
     [initialFeedbackSources]
   );
-  // Surveys that aren't backing a source yet are surfaced as "Suggestions" below the table.
-  const suggestedSurveys = useMemo(() => {
-    const connectedSurveyIdSet = new Set(connectedSurveyIds);
-    return initialSurveys.filter((survey) => !connectedSurveyIdSet.has(survey.id));
-  }, [initialSurveys, connectedSurveyIds]);
+  // Surveys that aren't backing a source yet (and aren't drafts) are surfaced as "Suggestions" below the table.
+  const suggestedSurveys = useMemo(
+    () => getSuggestedSurveys(initialSurveys, connectedSurveyIds),
+    [initialSurveys, connectedSurveyIds]
+  );
   const directoryNames = directories.map((directory) => directory.name).join(", ");
   const feedbackDirectoryAccessText =
     directories.length === 1

--- a/apps/web/modules/ee/unify-feedback/sources/utils.test.ts
+++ b/apps/web/modules/ee/unify-feedback/sources/utils.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, test } from "vitest";
-import { CSV_HIDDEN_STATIC_MAPPINGS, MAX_CSV_VALUES, TFieldMapping, TSourceField } from "./types";
+import {
+  CSV_HIDDEN_STATIC_MAPPINGS,
+  MAX_CSV_VALUES,
+  TFieldMapping,
+  TSourceField,
+  TUnifySurvey,
+} from "./types";
 import {
   areAllRequiredCsvFieldsMapped,
   autoMapCsvSourceFields,
   getCsvIdentityMappingAlert,
   getFeedbackSourceOptions,
+  getSuggestedSurveys,
   inferFieldType,
   isCsvUserDefinedStaticValueMapping,
   isFeedbackSourceNameValid,
@@ -15,6 +22,52 @@ import {
 } from "./utils";
 
 const mockT = (key: string) => key;
+
+const makeUnifySurvey = (overrides: Partial<TUnifySurvey> = {}): TUnifySurvey => ({
+  id: "survey-1",
+  name: "Survey 1",
+  status: "active",
+  elements: [],
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  ...overrides,
+});
+
+describe("getSuggestedSurveys", () => {
+  test("excludes surveys already backing a feedback source", () => {
+    const surveys = [makeUnifySurvey({ id: "connected" }), makeUnifySurvey({ id: "unconnected" })];
+    const result = getSuggestedSurveys(surveys, ["connected"]);
+    expect(result.map((s) => s.id)).toEqual(["unconnected"]);
+  });
+
+  test("excludes draft surveys", () => {
+    const surveys = [
+      makeUnifySurvey({ id: "draft", status: "draft" }),
+      makeUnifySurvey({ id: "active", status: "active" }),
+      makeUnifySurvey({ id: "paused", status: "paused" }),
+      makeUnifySurvey({ id: "completed", status: "completed" }),
+    ];
+    const result = getSuggestedSurveys(surveys, []);
+    expect(result.map((s) => s.id)).toEqual(["active", "paused", "completed"]);
+  });
+
+  test("excludes surveys that are both connected and drafts", () => {
+    const surveys = [
+      makeUnifySurvey({ id: "connected-draft", status: "draft" }),
+      makeUnifySurvey({ id: "connected-active", status: "active" }),
+      makeUnifySurvey({ id: "suggestable", status: "active" }),
+    ];
+    const result = getSuggestedSurveys(surveys, ["connected-draft", "connected-active"]);
+    expect(result.map((s) => s.id)).toEqual(["suggestable"]);
+  });
+
+  test("returns an empty array when every survey is a draft or connected", () => {
+    const surveys = [
+      makeUnifySurvey({ id: "draft", status: "draft" }),
+      makeUnifySurvey({ id: "connected", status: "active" }),
+    ];
+    expect(getSuggestedSurveys(surveys, ["connected"])).toEqual([]);
+  });
+});
 
 describe("getFeedbackSourceOptions", () => {
   test("returns formbricks, csv, api ingestion, and mcp options", () => {

--- a/apps/web/modules/ee/unify-feedback/sources/utils.ts
+++ b/apps/web/modules/ee/unify-feedback/sources/utils.ts
@@ -17,6 +17,19 @@ import {
 
 export const getDismissedStorageKey = (workspaceId: string) => `${workspaceId}-dismissedFeedbackSuggestions`;
 
+/**
+ * Surveys to surface as import suggestions below the connected sources.
+ * Excludes surveys already backing a source, and drafts — a draft has never collected responses,
+ * so suggesting it for import would only offer an empty source.
+ */
+export const getSuggestedSurveys = (
+  surveys: TUnifySurvey[],
+  connectedSurveyIds: string[]
+): TUnifySurvey[] => {
+  const connectedSurveyIdSet = new Set(connectedSurveyIds);
+  return surveys.filter((survey) => !connectedSurveyIdSet.has(survey.id) && survey.status !== "draft");
+};
+
 /** Survey element ids that can be mapped to a feedback source (drops unsupported question types). */
 export const getSelectableQuestionIds = (survey: TUnifySurvey): string[] =>
   survey.elements


### PR DESCRIPTION
## What & why

The **Feedback Data → Feedback Sources** page suggests workspace surveys you can connect as a
feedback source. Until now it suggested *every* survey not already backing a source — including
**drafts**. A draft has never been published and has no responses, so "Import responses" on it would
only ever create an empty source, and "Select questions for import" offers a survey that has collected
nothing.

This filters draft-status surveys out of that suggestions list. The connected/draft filtering is
pulled into a small pure helper, `getSuggestedSurveys(surveys, connectedSurveyIds)`, in
`sources/utils.ts` so the rule lives in one place and is unit-testable. The create/edit source picker
is intentionally left unchanged — this only affects the auto-suggested rows.

## Linear ticket

No Linear ticket — small UI refinement to the Unify feedback source suggestions list. Happy to attach
one if preferred.

## How this was tested

- `pnpm exec vitest run modules/ee/unify-feedback/sources/utils.test.ts` ✅ — 94 passed, incl. 4 new
  `getSuggestedSurveys` cases (excludes drafts, excludes connected, excludes both, empty result).
- `pnpm exec eslint` on the three changed files ✅ (exit 0, no warnings); `prettier --write` clean.
- Manual: on the Feedback Sources tab, a draft survey in the workspace no longer shows up as a
  "Suggestion" row; active/paused/completed surveys still do. See before/after below.

**Before / after** (Feedback Sources → suggestions list). The draft row is highlighted for
illustration; drafts carry no visible badge in the real UI — the point is that the draft survey is
suggested before and filtered out after.

![Before and after: draft survey removed from feedback source suggestions](https://raw.githubusercontent.com/formbricks/formbricks/assets/pr-8803-draft-filtering/pr-8803-draft-filtering-before-after.png)

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Precondition: an Enterprise/licensed workspace with Feedback Directories enabled and at least
  one feedback directory (dataset) created.
- [ ] In the same workspace, have at least two surveys: one in **Draft** status and one **In progress**
  (active), neither yet connected as a feedback source.
- [ ] Go to **Workspace → Feedback Data → Feedback Sources**.
- [ ] Expected: the active survey appears in the suggestions list (below the sources table) with a
  "Suggestion" badge and the "Select questions for import" / "Import responses" actions. The **draft**
  survey does **not** appear.
- [ ] Publish the draft survey (status becomes In progress) and reload the page → it now appears as a
  suggestion.
- [ ] Edge case: a workspace whose only unconnected surveys are all drafts → the suggestions list is
  empty (no suggestion rows rendered), and the sources table/empty state is unaffected.
- [ ] Regression: "Add feedback source" modal and the edit-source survey picker still list surveys as
  before (this change does not touch those pickers).

**Preconditions / test data**

- Enterprise license / Feedback Directories entitlement; a workspace with a feedback directory.
- Surveys of mixed status (draft + active) that are not already backing a feedback source.

**Risks & regressions**

- Only the auto-suggested rows are filtered. Re-check that already-connected sources still render
  their survey name (unaffected — `surveyNameById` still built from all surveys) and that the
  create/edit source pickers still show the full survey list.

**Migrations / env / cutover**

- none
