### PR TITLE
fix(surveys): stop no-overlay surveys blocking the host page (ENG-2304)

### DIFF
--- a/apps/web/playwright/survey-modal-non-blocking.spec.ts
+++ b/apps/web/playwright/survey-modal-non-blocking.spec.ts
@@ -1,0 +1,188 @@
+import { expect } from "@playwright/test";
+import http from "http";
+import { type AddressInfo } from "net";
+import { test } from "./lib/fixtures";
+import { seedAppSurvey } from "./utils/app-survey";
+
+/**
+ * A corner survey with no overlay must not take anything from the page it sits on.
+ *
+ * The widget used to arm a full focus trap for every modal survey regardless of
+ * overlay (packages/surveys/src/components/wrappers/survey-container.tsx), so a
+ * bottom-right survey stole the caret, wiped text selections mid-drag, trapped Tab,
+ * claimed Escape and Cmd/Ctrl+Enter document-wide, and told screen readers to ignore
+ * the host page. Mouse clicks kept working the whole time, which is what made it hard
+ * to spot. These specs pin the non-blocking contract, and the overlay case pins the
+ * modal behaviour that must survive it — otherwise someone "simplifies" the gate away.
+ */
+
+declare global {
+  interface Window {
+    formbricks: {
+      setup: (config: { workspaceId: string; appUrl: string }) => Promise<void>;
+      track: (name: string) => Promise<void>;
+    };
+    __hostEscapes: number;
+    __hostChordDefaultPrevented: boolean | null;
+  }
+}
+
+// Prose long enough that a drag across it selects an unmistakable number of characters.
+const HOST_PROSE =
+  "The quick brown fox jumps over the lazy dog while the host page stays fully usable underneath.";
+
+const hostPage = (workspaceId: string) => `<!doctype html>
+<html>
+  <head>
+    <script type="text/javascript">
+      !(function () {
+        var t = document.createElement("script");
+        (t.type = "text/javascript"), (t.async = !0), (t.src = "http://localhost:3000/js/formbricks.umd.cjs");
+        t.onload = function () {
+          window.formbricks.setup({ workspaceId: "${workspaceId}", appUrl: "http://localhost:3000" });
+        };
+        var e = document.getElementsByTagName("script")[0];
+        e.parentNode.insertBefore(t, e);
+      })();
+    </script>
+  </head>
+  <body style="background-color: #fff; font-family: sans-serif">
+    <p id="prose" style="max-width: 480px">${HOST_PROSE}</p>
+    <input id="host-input" aria-label="Host input" />
+    <textarea id="host-textarea" aria-label="Host textarea"></textarea>
+    <button id="host-button" type="button" onclick="window.__hostButtonClicks=(window.__hostButtonClicks||0)+1">
+      Host button
+    </button>
+    <script>
+      window.__hostEscapes = 0;
+      window.__hostChordDefaultPrevented = null;
+      document.addEventListener("keydown", function (e) {
+        if (e.key === "Escape") window.__hostEscapes++;
+        if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+          window.__hostChordDefaultPrevented = e.defaultPrevented;
+        }
+      });
+    </script>
+  </body>
+</html>`;
+
+test.describe("App survey widget does not block the host page", () => {
+  let server: http.Server;
+  let hostUrl = "";
+
+  test.setTimeout(3 * 60 * 1000);
+
+  // The workspace comes in on the query string so the two tests can share one server
+  // without sharing mutable state, and the port is ephemeral so parallel workers do
+  // not fight over it.
+  test.beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      const workspaceId = new URL(req.url ?? "/", "http://localhost").searchParams.get("workspaceId") ?? "";
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(hostPage(workspaceId));
+    });
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => {
+        hostUrl = `http://localhost:${(server.address() as AddressInfo).port}`;
+        resolve();
+      });
+    });
+  });
+
+  test.afterAll(async () => {
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  test("overlay:none leaves the host page fully usable", async ({ page, users }) => {
+    const seeded = await seedAppSurvey(users, { overlay: "none", placement: "bottomRight" });
+
+    await page.goto(`${hostUrl}/?workspaceId=${seeded.workspaceId}`);
+    await page.waitForFunction(() => Boolean(window.formbricks), null, { timeout: 120000 });
+
+    // Park the caret in a host field first — this is the customer's scenario: a survey
+    // firing mid-form must not pull the user out of what they are typing.
+    await page.locator("#host-input").fill("BEFORE");
+
+    await page.evaluate((key) => window.formbricks.track(key), seeded.actionKey);
+
+    const dialog = page.locator("#fbjs [role='dialog']");
+    await expect(dialog).toBeVisible({ timeout: 120000 });
+    // Let the card transition settle so any deferred focus has had its chance to land.
+    await page.waitForTimeout(1500);
+
+    // The survey must not have taken the caret.
+    await expect(page.locator("#host-input")).toBeFocused();
+    await page.keyboard.type("-AFTER");
+    await expect(page.locator("#host-input")).toHaveValue("BEFORE-AFTER");
+
+    // A survey that does not block the page must not claim to be a modal dialog:
+    // aria-modal makes assistive tech ignore everything outside it.
+    await expect(dialog).not.toHaveAttribute("aria-modal", /.*/);
+
+    // Text on the host page must stay selectable — the focus trap used to wipe the
+    // selection ~17ms into the drag by pulling focus back into the survey.
+    const prose = page.locator("#prose");
+    const box = await prose.boundingBox();
+    if (!box) throw new Error("host prose has no bounding box");
+    const midY = box.y + box.height / 2;
+    await page.mouse.move(box.x + 2, midY);
+    await page.mouse.down();
+    for (let step = 1; step <= 6; step++) {
+      await page.mouse.move(box.x + 2 + ((box.width - 6) * step) / 6, midY, { steps: 3 });
+    }
+    await page.mouse.up();
+    const selectedLength = await page.evaluate(() => String(window.getSelection() ?? "").length);
+    expect(selectedLength).toBeGreaterThan(20);
+
+    // Tab must be able to move through the host page instead of cycling in the survey.
+    await page.locator("#host-input").focus();
+    await page.keyboard.press("Tab");
+    await expect(page.locator("#host-textarea")).toBeFocused();
+
+    // Escape belongs to the host page while focus is on the host page.
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeVisible();
+    expect(await page.evaluate(() => window.__hostEscapes)).toBeGreaterThan(0);
+
+    // Same for the Cmd/Ctrl+Enter chord: the survey must not swallow it.
+    await page.locator("#host-textarea").focus();
+    await page.keyboard.press("ControlOrMeta+Enter");
+    expect(await page.evaluate(() => window.__hostChordDefaultPrevented)).toBe(false);
+    await expect(dialog).toBeVisible();
+
+    // The survey itself is still fully usable — it just does not grab anything.
+    const surveyInput = page.locator("#fbjs input[type='text'], #fbjs textarea").first();
+    await surveyInput.click();
+    await surveyInput.fill("still works");
+    await expect(surveyInput).toHaveValue("still works");
+
+    // Escape closes the survey when focus is inside it.
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+  });
+
+  test("overlay:dark keeps the modal behaviour", async ({ page, users }) => {
+    const seeded = await seedAppSurvey(users, { overlay: "dark", placement: "center" });
+
+    await page.goto(`${hostUrl}/?workspaceId=${seeded.workspaceId}`);
+    await page.waitForFunction(() => Boolean(window.formbricks), null, { timeout: 120000 });
+
+    await page.locator("#host-input").fill("BEFORE");
+    await page.evaluate((key) => window.formbricks.track(key), seeded.actionKey);
+
+    const dialog = page.locator("#fbjs [role='dialog']");
+    await expect(dialog).toBeVisible({ timeout: 120000 });
+    await page.waitForTimeout(1500);
+
+    // A survey that does block the page is a real modal: it announces itself as one,
+    // takes focus, and keeps it.
+    await expect(dialog).toHaveAttribute("aria-modal", "true");
+    await expect(page.locator("#host-input")).not.toBeFocused();
+
+    await page.locator("#host-input").focus();
+    const focusStayedInSurvey = await page.evaluate(() =>
+      Boolean(document.getElementById("fbjs")?.contains(document.activeElement))
+    );
+    expect(focusStayedInSurvey).toBe(true);
+  });
+});

--- a/apps/web/playwright/survey-modal-non-blocking.spec.ts
+++ b/apps/web/playwright/survey-modal-non-blocking.spec.ts
@@ -149,7 +149,9 @@ test.describe("App survey widget does not block the host page", () => {
 
     // It takes nothing from the page, so the open is announced through the pre-existing status
     // region instead of a focus move — otherwise screen-reader users get no signal it appeared.
-    await expect(liveRegion).toHaveText("A survey has opened. Press Tab to reach it.");
+    // The message states where the survey is (the widget mounts last in <body>) rather than
+    // promising a keystroke: Tab follows DOM order, so one Tab press would not reach it.
+    await expect(liveRegion).toHaveText("A survey has opened at the end of the page.");
 
     // Text on the host page must stay selectable — the focus trap used to wipe the
     // selection ~17ms into the drag by pulling focus back into the survey.

--- a/apps/web/playwright/survey-modal-non-blocking.spec.ts
+++ b/apps/web/playwright/survey-modal-non-blocking.spec.ts
@@ -127,8 +127,9 @@ test.describe("App survey widget does not block the host page", () => {
 
     const dialog = page.locator("#fbjs [role='dialog']");
     await expect(dialog).toBeVisible({ timeout: 120000 });
-    // Let the card transition settle so any deferred focus has had its chance to land.
-    await page.waitForTimeout(1500);
+    // The card fades in over 500ms (survey-container.tsx); opacity 1 marks the survey fully open, by
+    // which point any mount-time focus move has had its chance to land.
+    await expect(dialog).toHaveCSS("opacity", "1");
 
     // The survey must not have taken the caret.
     await expect(page.locator("#host-input")).toBeFocused();
@@ -210,7 +211,8 @@ test.describe("App survey widget does not block the host page", () => {
 
     const dialog = page.locator("#fbjs [role='dialog']");
     await expect(dialog).toBeVisible({ timeout: 120000 });
-    await page.waitForTimeout(1500);
+    // Same observable wait as the no-overlay spec: fully faded in means the trap has armed and focused.
+    await expect(dialog).toHaveCSS("opacity", "1");
 
     // A survey that does block the page is a real modal: it announces itself as one,
     // takes focus, and keeps it.

--- a/apps/web/playwright/survey-modal-non-blocking.spec.ts
+++ b/apps/web/playwright/survey-modal-non-blocking.spec.ts
@@ -23,7 +23,7 @@ declare global {
       track: (name: string) => Promise<void>;
     };
     __workspaceId: string;
-    __hostEscapes: number;
+    __hostEscapeDefaultPrevented: boolean | null;
     __hostChordDefaultPrevented: boolean | null;
   }
 }
@@ -57,12 +57,28 @@ const HOST_PAGE = `<!doctype html>
       Host button
     </button>
     <script>
-      window.__hostEscapes = 0;
+      window.__hostEscapeDefaultPrevented = null;
       window.__hostChordDefaultPrevented = null;
+      // Both reads are deferred to the next task. This listener is registered at page load
+      // and the survey's on mount, so on the same target in the same phase they fire in
+      // registration order — a synchronous read here always sees \`defaultPrevented === false\`
+      // no matter what the survey does. The event object outlives dispatch, so a deferred
+      // read observes the final state.
       document.addEventListener("keydown", function (e) {
-        if (e.key === "Escape") window.__hostEscapes++;
+        if (e.key === "Escape") {
+          setTimeout(function () {
+            window.__hostEscapeDefaultPrevented = e.defaultPrevented;
+          }, 0);
+        }
         if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-          window.__hostChordDefaultPrevented = e.defaultPrevented;
+          // Read on the next task, not inline. Both this listener and the survey's live on
+          // \`document\` in the bubble phase, and this one was registered first (page load vs
+          // survey mount), so listeners fire in registration order and \`defaultPrevented\` is
+          // still false at this point in dispatch no matter what the survey does. The event
+          // object outlives dispatch, so a deferred read observes the final state.
+          setTimeout(function () {
+            window.__hostChordDefaultPrevented = e.defaultPrevented;
+          }, 0);
         }
       });
     </script>
@@ -128,34 +144,49 @@ test.describe("App survey widget does not block the host page", () => {
     const prose = page.locator("#prose");
     const box = await prose.boundingBox();
     if (!box) throw new Error("host prose has no bounding box");
-    const midY = box.y + box.height / 2;
-    await page.mouse.move(box.x + 2, midY);
+    // Drag corner to corner so the selection covers every line wherever the text wraps. A
+    // horizontal drag through the middle samples only the last wrapped line, whose length is
+    // a function of the machine's fonts (measured: 30 chars at 16px, 18 at 14px).
+    const startY = box.y + 4;
+    const endY = box.y + box.height - 4;
+    await page.mouse.move(box.x + 2, startY);
     await page.mouse.down();
     for (let step = 1; step <= 6; step++) {
-      await page.mouse.move(box.x + 2 + ((box.width - 6) * step) / 6, midY, { steps: 3 });
+      await page.mouse.move(box.x + 2 + ((box.width - 6) * step) / 6, startY + ((endY - startY) * step) / 6, {
+        steps: 3,
+      });
     }
     await page.mouse.up();
-    const selectedLength = await page.evaluate(() => String(window.getSelection() ?? "").length);
-    expect(selectedLength).toBeGreaterThan(20);
+    expect(await page.evaluate(() => String(window.getSelection() ?? ""))).toBe(HOST_PROSE);
+    // Pin the mechanism, not just the effect: the trap wiped the selection by pulling focus
+    // into the survey mid-drag.
+    expect(
+      await page.evaluate(() => Boolean(document.getElementById("fbjs")?.contains(document.activeElement)))
+    ).toBe(false);
 
     // Tab must be able to move through the host page instead of cycling in the survey.
     await page.locator("#host-input").focus();
     await page.keyboard.press("Tab");
     await expect(page.locator("#host-textarea")).toBeFocused();
 
-    // Escape belongs to the host page while focus is on the host page.
+    // Escape belongs to the host page while focus is on the host page: the survey neither
+    // closes on it nor cancels it.
     await page.keyboard.press("Escape");
     await expect(dialog).toBeVisible();
-    expect(await page.evaluate(() => window.__hostEscapes)).toBeGreaterThan(0);
+    await expect.poll(() => page.evaluate(() => window.__hostEscapeDefaultPrevented)).toBe(false);
 
-    // Same for the Cmd/Ctrl+Enter chord: the survey must not swallow it.
+    // Same for the Cmd/Ctrl+Enter chord: the survey must neither cancel it nor act on it.
+    const surveyInput = page.locator("#fbjs input[type='text'], #fbjs textarea").first();
+    await expect(surveyInput).toBeVisible();
     await page.locator("#host-textarea").focus();
     await page.keyboard.press("ControlOrMeta+Enter");
-    expect(await page.evaluate(() => window.__hostChordDefaultPrevented)).toBe(false);
-    await expect(dialog).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.__hostChordDefaultPrevented)).toBe(false);
+    // And the survey must still be on the question card. Asserting the dialog is visible is
+    // not enough: submitting advances to the ending card, which has no text input but still
+    // matches [role="dialog"].
+    await expect(surveyInput).toBeVisible();
 
     // The survey itself is still fully usable — it just does not grab anything.
-    const surveyInput = page.locator("#fbjs input[type='text'], #fbjs textarea").first();
     await surveyInput.click();
     await surveyInput.fill("still works");
     await expect(surveyInput).toHaveValue("still works");
@@ -184,7 +215,9 @@ test.describe("App survey widget does not block the host page", () => {
     // A survey that does block the page is a real modal: it announces itself as one,
     // takes focus, and keeps it.
     await expect(dialog).toHaveAttribute("aria-modal", "true");
-    await expect(page.locator("#host-input")).not.toBeFocused();
+    expect(
+      await page.evaluate(() => Boolean(document.getElementById("fbjs")?.contains(document.activeElement)))
+    ).toBe(true);
 
     await page.locator("#host-input").focus();
     const focusStayedInSurvey = await page.evaluate(() =>

--- a/apps/web/playwright/survey-modal-non-blocking.spec.ts
+++ b/apps/web/playwright/survey-modal-non-blocking.spec.ts
@@ -22,6 +22,7 @@ declare global {
       setup: (config: { workspaceId: string; appUrl: string }) => Promise<void>;
       track: (name: string) => Promise<void>;
     };
+    __workspaceId: string;
     __hostEscapes: number;
     __hostChordDefaultPrevented: boolean | null;
   }
@@ -31,7 +32,9 @@ declare global {
 const HOST_PROSE =
   "The quick brown fox jumps over the lazy dog while the host page stays fully usable underneath.";
 
-const hostPage = (workspaceId: string) => `<!doctype html>
+// A constant page — the workspace is injected per test with `page.addInitScript` rather
+// than templated in, so nothing the test controls is ever interpolated into served HTML.
+const HOST_PAGE = `<!doctype html>
 <html>
   <head>
     <script type="text/javascript">
@@ -39,7 +42,7 @@ const hostPage = (workspaceId: string) => `<!doctype html>
         var t = document.createElement("script");
         (t.type = "text/javascript"), (t.async = !0), (t.src = "http://localhost:3000/js/formbricks.umd.cjs");
         t.onload = function () {
-          window.formbricks.setup({ workspaceId: "${workspaceId}", appUrl: "http://localhost:3000" });
+          window.formbricks.setup({ workspaceId: window.__workspaceId, appUrl: "http://localhost:3000" });
         };
         var e = document.getElementsByTagName("script")[0];
         e.parentNode.insertBefore(t, e);
@@ -72,14 +75,12 @@ test.describe("App survey widget does not block the host page", () => {
 
   test.setTimeout(3 * 60 * 1000);
 
-  // The workspace comes in on the query string so the two tests can share one server
-  // without sharing mutable state, and the port is ephemeral so parallel workers do
-  // not fight over it.
+  // The port is ephemeral so parallel workers do not fight over it, and the response is
+  // a constant so the server holds no per-test state.
   test.beforeAll(async () => {
-    server = http.createServer((req, res) => {
-      const workspaceId = new URL(req.url ?? "/", "http://localhost").searchParams.get("workspaceId") ?? "";
+    server = http.createServer((_, res) => {
       res.writeHead(200, { "Content-Type": "text/html" });
-      res.end(hostPage(workspaceId));
+      res.end(HOST_PAGE);
     });
     await new Promise<void>((resolve) => {
       server.listen(0, () => {
@@ -96,7 +97,10 @@ test.describe("App survey widget does not block the host page", () => {
   test("overlay:none leaves the host page fully usable", async ({ page, users }) => {
     const seeded = await seedAppSurvey(users, { overlay: "none", placement: "bottomRight" });
 
-    await page.goto(`${hostUrl}/?workspaceId=${seeded.workspaceId}`);
+    await page.addInitScript((workspaceId) => {
+      window.__workspaceId = workspaceId;
+    }, seeded.workspaceId);
+    await page.goto(hostUrl);
     await page.waitForFunction(() => Boolean(window.formbricks), null, { timeout: 120000 });
 
     // Park the caret in a host field first — this is the customer's scenario: a survey
@@ -164,7 +168,10 @@ test.describe("App survey widget does not block the host page", () => {
   test("overlay:dark keeps the modal behaviour", async ({ page, users }) => {
     const seeded = await seedAppSurvey(users, { overlay: "dark", placement: "center" });
 
-    await page.goto(`${hostUrl}/?workspaceId=${seeded.workspaceId}`);
+    await page.addInitScript((workspaceId) => {
+      window.__workspaceId = workspaceId;
+    }, seeded.workspaceId);
+    await page.goto(hostUrl);
     await page.waitForFunction(() => Boolean(window.formbricks), null, { timeout: 120000 });
 
     await page.locator("#host-input").fill("BEFORE");

--- a/apps/web/playwright/survey-modal-non-blocking.spec.ts
+++ b/apps/web/playwright/survey-modal-non-blocking.spec.ts
@@ -119,6 +119,13 @@ test.describe("App survey widget does not block the host page", () => {
     await page.goto(hostUrl);
     await page.waitForFunction(() => Boolean(window.formbricks), null, { timeout: 120000 });
 
+    // The status region is mounted at SDK setup — long before any survey opens — because screen
+    // readers only reliably announce changes to a live region that already existed.
+    const liveRegion = page.locator("#formbricks-live-region");
+    await expect(liveRegion).toBeAttached({ timeout: 120000 });
+    await expect(liveRegion).toHaveAttribute("role", "status");
+    await expect(liveRegion).toBeEmpty();
+
     // Park the caret in a host field first — this is the customer's scenario: a survey
     // firing mid-form must not pull the user out of what they are typing.
     await page.locator("#host-input").fill("BEFORE");
@@ -139,6 +146,10 @@ test.describe("App survey widget does not block the host page", () => {
     // A survey that does not block the page must not claim to be a modal dialog:
     // aria-modal makes assistive tech ignore everything outside it.
     await expect(dialog).not.toHaveAttribute("aria-modal", /.*/);
+
+    // It takes nothing from the page, so the open is announced through the pre-existing status
+    // region instead of a focus move — otherwise screen-reader users get no signal it appeared.
+    await expect(liveRegion).toHaveText("A survey has opened. Press Tab to reach it.");
 
     // Text on the host page must stay selectable — the focus trap used to wipe the
     // selection ~17ms into the drag by pulling focus back into the survey.
@@ -195,6 +206,10 @@ test.describe("App survey widget does not block the host page", () => {
     // Escape closes the survey when focus is inside it.
     await page.keyboard.press("Escape");
     await expect(dialog).toBeHidden();
+
+    // Closing clears the announcement: identical text twice is not a change, so without the clear
+    // a later open would stay silent.
+    await expect(liveRegion).toBeEmpty();
   });
 
   test("overlay:dark keeps the modal behaviour", async ({ page, users }) => {
@@ -226,5 +241,9 @@ test.describe("App survey widget does not block the host page", () => {
       Boolean(document.getElementById("fbjs")?.contains(document.activeElement))
     );
     expect(focusStayedInSurvey).toBe(true);
+
+    // With an overlay the trap's focus move is the announcement — the status region stays silent
+    // so screen readers don't hear the open twice.
+    await expect(page.locator("#formbricks-live-region")).toBeEmpty();
   });
 });

--- a/apps/web/playwright/utils/app-survey.ts
+++ b/apps/web/playwright/utils/app-survey.ts
@@ -1,0 +1,112 @@
+import { createId } from "@paralleldrive/cuid2";
+import { prisma } from "@formbricks/database";
+import { Prisma } from "@formbricks/database/prisma";
+import { type TSurveyEnding } from "@formbricks/types/surveys/types";
+import { transformQuestionsToBlocks } from "@/app/lib/api/survey-transformation";
+import { type UsersFixture } from "../fixtures/users";
+
+/**
+ * Self-seeding helper for app-survey widget specs.
+ *
+ * Provisions a workspace plus a published app survey wired to a code action, all
+ * through Prisma — the same boundary the `users` fixture writes through — so a spec
+ * does not have to drive the survey editor UI to get a survey on a host page. The
+ * legacy `questions` shape is converted with the SAME `transformQuestionsToBlocks`
+ * the v1 management API uses server-side rather than hand-crafting blocks JSON.
+ *
+ * Widget placement and overlay live on the Workspace, not the Survey (see
+ * `packages/database/schema/main.prisma` `WidgetPlacement` / `SurveyOverlay`), so the
+ * caller picks them here.
+ */
+
+// The transform's own (legacy v1) question input type, derived from its signature so
+// this file does not reference the deprecated TSurveyQuestion name directly.
+type TLegacyQuestions = Parameters<typeof transformQuestionsToBlocks>[0];
+
+// Named so the i18n scanner's t(...) pattern does not treat these fixture strings as
+// translation keys (this file is scanned; *.spec.ts files are not).
+const i18nValue = (value: string): { default: string } => ({ default: value });
+
+export interface SeededAppSurvey {
+  workspaceId: string;
+  /** `key` of the code action that triggers the survey — pass to `formbricks.track()`. */
+  actionKey: string;
+}
+
+export interface SeedAppSurveyOptions {
+  overlay?: "none" | "light" | "dark";
+  placement?: "bottomRight" | "bottomLeft" | "topRight" | "topLeft" | "center";
+}
+
+const buildQuestions = () =>
+  [
+    {
+      id: "openText",
+      type: "openText",
+      headline: i18nValue("What would you like to know?"),
+      required: false,
+      inputType: "text",
+      longAnswer: false,
+      charLimit: { enabled: false },
+      placeholder: i18nValue("Type your answer here..."),
+    },
+  ] as unknown as TLegacyQuestions;
+
+const buildEndings = () =>
+  [
+    {
+      id: createId(),
+      type: "endScreen",
+      headline: i18nValue("Thanks!"),
+    },
+  ] as unknown as TSurveyEnding[];
+
+/**
+ * Seeds a workspace user plus one published app survey triggered by a code action.
+ * The survey re-displays on every trigger (`respondMultiple`, no cooldown) so a spec
+ * can open it repeatedly without recontact rules getting in the way.
+ */
+export const seedAppSurvey = async (
+  users: UsersFixture,
+  options: SeedAppSurveyOptions = {}
+): Promise<SeededAppSurvey> => {
+  const { overlay = "none", placement = "bottomRight" } = options;
+
+  const user = await users.create({ skipSurveySeed: true });
+  const workspaceId = user.workspaceId;
+  if (!workspaceId) {
+    throw new Error("users.create() did not return a workspaceId");
+  }
+
+  await prisma.workspace.update({
+    where: { id: workspaceId },
+    data: { placement, overlay, clickOutsideClose: true },
+  });
+
+  const actionKey = `e2e-open-survey-${createId()}`;
+  const actionClass = await prisma.actionClass.create({
+    data: { name: actionKey, type: "code", key: actionKey, workspaceId },
+    select: { id: true },
+  });
+
+  const endings = buildEndings();
+  const blocks = transformQuestionsToBlocks(buildQuestions(), endings);
+
+  await prisma.survey.create({
+    data: {
+      workspaceId,
+      createdBy: user.id,
+      name: "App survey (non-blocking widget spec)",
+      type: "app",
+      status: "inProgress",
+      displayOption: "respondMultiple",
+      delay: 0,
+      blocks: blocks as unknown as Prisma.InputJsonValue[],
+      endings: endings as unknown as Prisma.InputJsonValue[],
+      triggers: { create: { actionClassId: actionClass.id } },
+    },
+    select: { id: true },
+  });
+
+  return { workspaceId, actionKey };
+};

--- a/apps/web/playwright/utils/app-survey.ts
+++ b/apps/web/playwright/utils/app-survey.ts
@@ -63,8 +63,11 @@ const buildEndings = () =>
 
 /**
  * Seeds a workspace user plus one published app survey triggered by a code action.
- * The survey re-displays on every trigger (`respondMultiple`, no cooldown) so a spec
- * can open it repeatedly without recontact rules getting in the way.
+ * The survey re-displays on every trigger so a spec can open it repeatedly without
+ * recontact rules getting in the way: `respondMultiple`, plus an explicit
+ * `recontactDays: 0`. The explicit 0 matters — leaving it null falls through to
+ * `Workspace.recontactDays`, which defaults to 7 (`main.prisma:613`), so a second
+ * `track()` in the same browser context would silently show nothing.
  */
 export const seedAppSurvey = async (
   users: UsersFixture,
@@ -100,6 +103,7 @@ export const seedAppSurvey = async (
       type: "app",
       status: "inProgress",
       displayOption: "respondMultiple",
+      recontactDays: 0,
       delay: 0,
       blocks: blocks as unknown as Prisma.InputJsonValue[],
       endings: endings as unknown as Prisma.InputJsonValue[],

--- a/packages/js-core/src/lib/common/constants.ts
+++ b/packages/js-core/src/lib/common/constants.ts
@@ -2,4 +2,7 @@ export const JS_LOCAL_STORAGE_KEY = "formbricks-js";
 export const LEGACY_JS_WEBSITE_LOCAL_STORAGE_KEY = "formbricks-js-website";
 export const LEGACY_JS_APP_LOCAL_STORAGE_KEY = "formbricks-js-app";
 export const CONTAINER_ID = "formbricks-modal-container";
+// Shipped id contract with the surveys renderer (packages/surveys/src/lib/live-region.ts) — old SDKs
+// stay on the wire for years, so this value must never change.
+export const LIVE_REGION_ID = "formbricks-live-region";
 export const RECAPTCHA_SCRIPT_ID = "formbricks-recaptcha-script";

--- a/packages/js-core/src/lib/common/setup.ts
+++ b/packages/js-core/src/lib/common/setup.ts
@@ -4,7 +4,7 @@ import { addCleanupEventListeners, addEventListeners } from "@/lib/common/event-
 import { Logger } from "@/lib/common/logger";
 import { getIsSetup, setIsSetup } from "@/lib/common/status";
 import { filterSurveys, getIsDebug, isNowExpired, wrapThrows } from "@/lib/common/utils";
-import { closeSurvey, preloadSurveysScript } from "@/lib/survey/widget";
+import { addLiveRegionContainer, closeSurvey, preloadSurveysScript } from "@/lib/survey/widget";
 import { DEFAULT_USER_STATE_NO_USER_ID } from "@/lib/user/state";
 import { sendUpdatesToBackend } from "@/lib/user/update";
 import { fetchWorkspaceState } from "@/lib/workspace/state";
@@ -329,6 +329,10 @@ export const setup = async (
   logger.debug("Adding event listeners");
   addEventListeners();
   addCleanupEventListeners();
+
+  // Mount the status live region now so assistive tech has registered it long before the
+  // first survey announces its opening into it.
+  addLiveRegionContainer();
 
   // Preload surveys script so it's ready when a survey triggers
   preloadSurveysScript(configInput.appUrl);

--- a/packages/js-core/src/lib/common/tests/setup.test.ts
+++ b/packages/js-core/src/lib/common/tests/setup.test.ts
@@ -7,6 +7,7 @@ import { handleErrorOnFirstSetup, setup, tearDown } from "@/lib/common/setup";
 import { setIsSetup } from "@/lib/common/status";
 import { filterSurveys, getIsDebug, isNowExpired } from "@/lib/common/utils";
 import type * as Utils from "@/lib/common/utils";
+import { addLiveRegionContainer } from "@/lib/survey/widget";
 import { DEFAULT_USER_STATE_NO_USER_ID } from "@/lib/user/state";
 import { sendUpdatesToBackend } from "@/lib/user/update";
 import { fetchWorkspaceState } from "@/lib/workspace/state";
@@ -157,6 +158,7 @@ describe("setup.ts", () => {
 
       const result = await setup({ workspaceId: "ws_123", appUrl: "https://my.url" });
       expect(result.ok).toBe(true);
+      expect(addLiveRegionContainer).toHaveBeenCalledOnce();
       expect(fetchWorkspaceState).toHaveBeenCalledWith(
         expect.objectContaining({
           workspaceId: "ws_123",

--- a/packages/js-core/src/lib/common/tests/setup.test.ts
+++ b/packages/js-core/src/lib/common/tests/setup.test.ts
@@ -73,6 +73,7 @@ vi.mock("@/lib/survey/no-code-action", () => ({
 vi.mock("@/lib/survey/widget", () => ({
   closeSurvey: vi.fn(),
   preloadSurveysScript: vi.fn(),
+  addLiveRegionContainer: vi.fn(),
 }));
 
 describe("setup.ts", () => {

--- a/packages/js-core/src/lib/survey/tests/widget.test.ts
+++ b/packages/js-core/src/lib/survey/tests/widget.test.ts
@@ -280,6 +280,40 @@ describe("widget-file", () => {
     expect(el).not.toBeNull();
   });
 
+  test("addLiveRegionContainer creates an accessible visually hidden status region", () => {
+    widget.addLiveRegionContainer();
+
+    expect(document.createElement).toHaveBeenCalledWith("div");
+    expect(document.body.appendChild).toHaveBeenCalledTimes(1);
+
+    const liveRegion = vi.mocked(document.body.appendChild).mock.calls[0][0] as HTMLElement;
+    expect(liveRegion.id).toBe("formbricks-live-region");
+    expect(liveRegion.setAttribute).toHaveBeenCalledWith("role", "status");
+    expect(liveRegion.setAttribute).toHaveBeenCalledWith("aria-live", "polite");
+    expect(liveRegion.setAttribute).toHaveBeenCalledWith("aria-atomic", "true");
+    expect(liveRegion.style.cssText).toContain("position:absolute");
+  });
+
+  test("addLiveRegionContainer reuses an existing region", () => {
+    vi.mocked(document.getElementById).mockReturnValueOnce({} as HTMLElement);
+
+    widget.addLiveRegionContainer();
+
+    expect(document.createElement).not.toHaveBeenCalled();
+    expect(document.body.appendChild).not.toHaveBeenCalled();
+  });
+
+  test("addLiveRegionContainer is safe during server-side rendering", () => {
+    const browserDocument = globalThis.document;
+    vi.stubGlobal("document", undefined);
+
+    try {
+      expect(() => widget.addLiveRegionContainer()).not.toThrow();
+    } finally {
+      vi.stubGlobal("document", browserDocument);
+    }
+  });
+
   test("removeWidgetContainer removes #formbricks-container if it exists", () => {
     document.body.innerHTML = `<div id="formbricks-container"></div>`;
     widget.removeWidgetContainer();

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -1,5 +1,5 @@
 import { Config } from "@/lib/common/config";
-import { CONTAINER_ID } from "@/lib/common/constants";
+import { CONTAINER_ID, LIVE_REGION_ID } from "@/lib/common/constants";
 import { Logger } from "@/lib/common/logger";
 import { executeRecaptcha, loadRecaptchaScript } from "@/lib/common/recaptcha";
 import { TimeoutStack } from "@/lib/common/timeout-stack";
@@ -272,6 +272,30 @@ export const addWidgetContainer = (): void => {
   const containerElement = document.createElement("div");
   containerElement.id = CONTAINER_ID;
   document.body.appendChild(containerElement);
+};
+
+/**
+ * Mounts the persistent, visually hidden status region surveys announce their opening into
+ * (a no-overlay survey never takes focus, so this is the only signal assistive tech gets).
+ * Created at setup — not at survey open — because screen readers only reliably announce
+ * changes made to a live region that already existed; a region inserted together with its
+ * content is announced inconsistently. The surveys renderer writes the message
+ * (packages/surveys/src/lib/live-region.ts) and re-creates the region if an older embed
+ * script did not have this function.
+ */
+export const addLiveRegionContainer = (): void => {
+  // The SDK can be imported (not just script-tagged) and evaluated during SSR.
+  if (typeof document === "undefined") return;
+  if (document.getElementById(LIVE_REGION_ID)) return;
+
+  const liveRegion = document.createElement("div");
+  liveRegion.id = LIVE_REGION_ID;
+  liveRegion.setAttribute("role", "status");
+  liveRegion.setAttribute("aria-live", "polite");
+  liveRegion.setAttribute("aria-atomic", "true");
+  liveRegion.style.cssText =
+    "position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0";
+  document.body.appendChild(liveRegion);
 };
 
 export const removeWidgetContainer = (): void => {

--- a/packages/surveys/i18n.lock
+++ b/packages/surveys/i18n.lock
@@ -31,6 +31,7 @@ checksums:
     common/select_options: d5a80087e889848e0fed3f1be359366f
     common/sending_responses: 244f1aebc3f6a101ae2f8b630d7967ec
     common/survey_dialog: 7401ad8978e423009da68141c739bda0
+    common/survey_opened_announcement: 4845fdc773074d76170caa7281fb2fa5
     common/takes_less_than_x_minutes: 1208ce0d4c0a679c11c7bd209b6ccc47
     common/takes_x_minutes: 001d12366d07b406f50669e761d63e69
     common/takes_x_plus_minutes: 145b8f287de140e98f492c8db2f9fa0b

--- a/packages/surveys/i18n.lock
+++ b/packages/surveys/i18n.lock
@@ -31,7 +31,7 @@ checksums:
     common/select_options: d5a80087e889848e0fed3f1be359366f
     common/sending_responses: 244f1aebc3f6a101ae2f8b630d7967ec
     common/survey_dialog: 7401ad8978e423009da68141c739bda0
-    common/survey_opened_announcement: 4845fdc773074d76170caa7281fb2fa5
+    common/survey_opened_announcement: 43ffc9486130e59b034d140b3d9425dc
     common/takes_less_than_x_minutes: 1208ce0d4c0a679c11c7bd209b6ccc47
     common/takes_x_minutes: 001d12366d07b406f50669e761d63e69
     common/takes_x_plus_minutes: 145b8f287de140e98f492c8db2f9fa0b

--- a/packages/surveys/locales/ar-EG.json
+++ b/packages/surveys/locales/ar-EG.json
@@ -30,6 +30,7 @@
     "select_options": "اختر الخيارات",
     "sending_responses": "جارٍ إرسال الردود...",
     "survey_dialog": "مربع حوار الاستبيان",
+    "survey_opened_announcement": "تم فتح استطلاع رأي. اضغط على Tab للوصول إليه.",
     "takes_less_than_x_minutes": "{count, plural, zero {يستغرق أقل من دقيقة} one {يستغرق أقل من دقيقة واحدة} two {يستغرق أقل من دقيقتين} few {يستغرق أقل من {count} دقائق} many {يستغرق أقل من {count} دقيقة} other {يستغرق أقل من {count} دقيقة}}",
     "takes_x_minutes": "{count, plural, zero {يستغرق صفر دقائق} one {يستغرق دقيقة واحدة} two {يستغرق دقيقتين} few {يستغرق {count} دقائق} many {يستغرق {count} دقيقة} other {يستغرق {count} دقيقة}}",
     "takes_x_plus_minutes": "يستغرق {count}+ دقيقة",

--- a/packages/surveys/locales/ar-EG.json
+++ b/packages/surveys/locales/ar-EG.json
@@ -30,7 +30,7 @@
     "select_options": "اختر الخيارات",
     "sending_responses": "جارٍ إرسال الردود...",
     "survey_dialog": "مربع حوار الاستبيان",
-    "survey_opened_announcement": "تم فتح استطلاع رأي. اضغط على Tab للوصول إليه.",
+    "survey_opened_announcement": "تم فتح استبيان في نهاية الصفحة.",
     "takes_less_than_x_minutes": "{count, plural, zero {يستغرق أقل من دقيقة} one {يستغرق أقل من دقيقة واحدة} two {يستغرق أقل من دقيقتين} few {يستغرق أقل من {count} دقائق} many {يستغرق أقل من {count} دقيقة} other {يستغرق أقل من {count} دقيقة}}",
     "takes_x_minutes": "{count, plural, zero {يستغرق صفر دقائق} one {يستغرق دقيقة واحدة} two {يستغرق دقيقتين} few {يستغرق {count} دقائق} many {يستغرق {count} دقيقة} other {يستغرق {count} دقيقة}}",
     "takes_x_plus_minutes": "يستغرق {count}+ دقيقة",

--- a/packages/surveys/locales/da-DK.json
+++ b/packages/surveys/locales/da-DK.json
@@ -30,6 +30,7 @@
     "select_options": "Vælg muligheder",
     "sending_responses": "Sender svar…",
     "survey_dialog": "Undersøgelsesdialog",
+    "survey_opened_announcement": "En undersøgelse er åbnet. Tryk på Tab for at nå den.",
     "takes_less_than_x_minutes": "{count, plural, one {Tager mindre end 1 minut} other {Tager mindre end {count} minutter}}",
     "takes_x_minutes": "{count, plural, one {Tager 1 minut} other {Tager {count} minutter}}",
     "takes_x_plus_minutes": "Tager {count}+ minutter",

--- a/packages/surveys/locales/da-DK.json
+++ b/packages/surveys/locales/da-DK.json
@@ -30,7 +30,7 @@
     "select_options": "Vælg muligheder",
     "sending_responses": "Sender svar…",
     "survey_dialog": "Undersøgelsesdialog",
-    "survey_opened_announcement": "En undersøgelse er åbnet. Tryk på Tab for at nå den.",
+    "survey_opened_announcement": "En undersøgelse er åbnet i bunden af siden.",
     "takes_less_than_x_minutes": "{count, plural, one {Tager mindre end 1 minut} other {Tager mindre end {count} minutter}}",
     "takes_x_minutes": "{count, plural, one {Tager 1 minut} other {Tager {count} minutter}}",
     "takes_x_plus_minutes": "Tager {count}+ minutter",

--- a/packages/surveys/locales/de-DE.json
+++ b/packages/surveys/locales/de-DE.json
@@ -30,7 +30,7 @@
     "select_options": "Wähle Optionen",
     "sending_responses": "Antworten werden gesendet...",
     "survey_dialog": "Umfragedialog",
-    "survey_opened_announcement": "Eine Umfrage wurde geöffnet. Drücke Tab, um sie zu erreichen.",
+    "survey_opened_announcement": "Am Ende der Seite wurde eine Umfrage geöffnet.",
     "takes_less_than_x_minutes": "{count, plural, one {Dauert weniger als 1 Minute} other {Dauert weniger als {count} Minuten}}",
     "takes_x_minutes": "{count, plural, one {Dauert 1 Minute} other {Dauert {count} Minuten}}",
     "takes_x_plus_minutes": "Dauert {count}+ Minuten",

--- a/packages/surveys/locales/de-DE.json
+++ b/packages/surveys/locales/de-DE.json
@@ -30,6 +30,7 @@
     "select_options": "Wähle Optionen",
     "sending_responses": "Antworten werden gesendet...",
     "survey_dialog": "Umfragedialog",
+    "survey_opened_announcement": "Eine Umfrage wurde geöffnet. Drücke Tab, um sie zu erreichen.",
     "takes_less_than_x_minutes": "{count, plural, one {Dauert weniger als 1 Minute} other {Dauert weniger als {count} Minuten}}",
     "takes_x_minutes": "{count, plural, one {Dauert 1 Minute} other {Dauert {count} Minuten}}",
     "takes_x_plus_minutes": "Dauert {count}+ Minuten",

--- a/packages/surveys/locales/en-US.json
+++ b/packages/surveys/locales/en-US.json
@@ -30,7 +30,7 @@
     "select_options": "Select options",
     "sending_responses": "Sending responses…",
     "survey_dialog": "Survey Dialog",
-    "survey_opened_announcement": "A survey has opened. Press Tab to reach it.",
+    "survey_opened_announcement": "A survey has opened at the end of the page.",
     "takes_less_than_x_minutes": "{count, plural, one {Takes less than 1 minute} other {Takes less than {count} minutes}}",
     "takes_x_minutes": "{count, plural, one {Takes 1 minute} other {Takes {count} minutes}}",
     "takes_x_plus_minutes": "Takes {count}+ minutes",

--- a/packages/surveys/locales/en-US.json
+++ b/packages/surveys/locales/en-US.json
@@ -30,6 +30,7 @@
     "select_options": "Select options",
     "sending_responses": "Sending responses…",
     "survey_dialog": "Survey Dialog",
+    "survey_opened_announcement": "A survey has opened. Press Tab to reach it.",
     "takes_less_than_x_minutes": "{count, plural, one {Takes less than 1 minute} other {Takes less than {count} minutes}}",
     "takes_x_minutes": "{count, plural, one {Takes 1 minute} other {Takes {count} minutes}}",
     "takes_x_plus_minutes": "Takes {count}+ minutes",

--- a/packages/surveys/locales/es-ES.json
+++ b/packages/surveys/locales/es-ES.json
@@ -30,6 +30,7 @@
     "select_options": "Selecciona opciones",
     "sending_responses": "Enviando respuestas...",
     "survey_dialog": "Diálogo de encuesta",
+    "survey_opened_announcement": "Se ha abierto una encuesta. Pulsa Tab para acceder a ella.",
     "takes_less_than_x_minutes": "{count, plural, one {Toma menos de 1 minuto} other {Toma menos de {count} minutos}}",
     "takes_x_minutes": "{count, plural, one {Toma 1 minuto} other {Toma {count} minutos}}",
     "takes_x_plus_minutes": "Toma {count}+ minutos",

--- a/packages/surveys/locales/es-ES.json
+++ b/packages/surveys/locales/es-ES.json
@@ -30,7 +30,7 @@
     "select_options": "Selecciona opciones",
     "sending_responses": "Enviando respuestas...",
     "survey_dialog": "Diálogo de encuesta",
-    "survey_opened_announcement": "Se ha abierto una encuesta. Pulsa Tab para acceder a ella.",
+    "survey_opened_announcement": "Se ha abierto una encuesta al final de la página.",
     "takes_less_than_x_minutes": "{count, plural, one {Toma menos de 1 minuto} other {Toma menos de {count} minutos}}",
     "takes_x_minutes": "{count, plural, one {Toma 1 minuto} other {Toma {count} minutos}}",
     "takes_x_plus_minutes": "Toma {count}+ minutos",

--- a/packages/surveys/locales/et-EE.json
+++ b/packages/surveys/locales/et-EE.json
@@ -30,7 +30,7 @@
     "select_options": "Vali variandid",
     "sending_responses": "Vastuste saatmine…",
     "survey_dialog": "Küsitluse dialoog",
-    "survey_opened_announcement": "Küsitlus on avatud. Vajuta Tab, et sinna jõuda.",
+    "survey_opened_announcement": "Lehe lõppu on avatud küsitlus.",
     "takes_less_than_x_minutes": "{count, plural, one {Võtab vähem kui 1 minuti} other {Võtab vähem kui {count} minutit}}",
     "takes_x_minutes": "{count, plural, one {Võtab 1 minuti} other {Võtab {count} minutit}}",
     "takes_x_plus_minutes": "Võtab {count}+ minutit",

--- a/packages/surveys/locales/et-EE.json
+++ b/packages/surveys/locales/et-EE.json
@@ -30,6 +30,7 @@
     "select_options": "Vali variandid",
     "sending_responses": "Vastuste saatmine…",
     "survey_dialog": "Küsitluse dialoog",
+    "survey_opened_announcement": "Küsitlus on avatud. Vajuta Tab, et sinna jõuda.",
     "takes_less_than_x_minutes": "{count, plural, one {Võtab vähem kui 1 minuti} other {Võtab vähem kui {count} minutit}}",
     "takes_x_minutes": "{count, plural, one {Võtab 1 minuti} other {Võtab {count} minutit}}",
     "takes_x_plus_minutes": "Võtab {count}+ minutit",

--- a/packages/surveys/locales/fr-FR.json
+++ b/packages/surveys/locales/fr-FR.json
@@ -30,7 +30,7 @@
     "select_options": "Sélectionner des options",
     "sending_responses": "Envoi des réponses...",
     "survey_dialog": "Boîte de dialogue du sondage",
-    "survey_opened_announcement": "Un sondage est ouvert. Appuie sur Tab pour y accéder.",
+    "survey_opened_announcement": "Un sondage s'est ouvert à la fin de la page.",
     "takes_less_than_x_minutes": "{count, plural, one {Prend moins d'une minute} other {Prend moins de {count} minutes}}",
     "takes_x_minutes": "{count, plural, one {Prend 1 minute} other {Prend {count} minutes}}",
     "takes_x_plus_minutes": "Prend {count}+ minutes",

--- a/packages/surveys/locales/fr-FR.json
+++ b/packages/surveys/locales/fr-FR.json
@@ -30,6 +30,7 @@
     "select_options": "Sélectionner des options",
     "sending_responses": "Envoi des réponses...",
     "survey_dialog": "Boîte de dialogue du sondage",
+    "survey_opened_announcement": "Un sondage est ouvert. Appuie sur Tab pour y accéder.",
     "takes_less_than_x_minutes": "{count, plural, one {Prend moins d'une minute} other {Prend moins de {count} minutes}}",
     "takes_x_minutes": "{count, plural, one {Prend 1 minute} other {Prend {count} minutes}}",
     "takes_x_plus_minutes": "Prend {count}+ minutes",

--- a/packages/surveys/locales/hi-IN.json
+++ b/packages/surveys/locales/hi-IN.json
@@ -30,6 +30,7 @@
     "select_options": "विकल्प चुनें",
     "sending_responses": "प्रतिक्रियाएँ भेज रहे हैं...",
     "survey_dialog": "सर्वेक्षण संवाद",
+    "survey_opened_announcement": "एक सर्वे खुल गया है। इस तक पहुंचने के लिए Tab दबाएं।",
     "takes_less_than_x_minutes": "{count, plural, one {1 मिनट से कम लगता है} other {{count} मिनट से कम लगता है}}",
     "takes_x_minutes": "{count, plural, one {1 मिनट लगता है} other {{count} मिनट लगते हैं}}",
     "takes_x_plus_minutes": "{count}+ मिनट लगते हैं",

--- a/packages/surveys/locales/hi-IN.json
+++ b/packages/surveys/locales/hi-IN.json
@@ -30,7 +30,7 @@
     "select_options": "विकल्प चुनें",
     "sending_responses": "प्रतिक्रियाएँ भेज रहे हैं...",
     "survey_dialog": "सर्वेक्षण संवाद",
-    "survey_opened_announcement": "एक सर्वे खुल गया है। इस तक पहुंचने के लिए Tab दबाएं।",
+    "survey_opened_announcement": "पेज के अंत में एक सर्वे खुल गया है।",
     "takes_less_than_x_minutes": "{count, plural, one {1 मिनट से कम लगता है} other {{count} मिनट से कम लगता है}}",
     "takes_x_minutes": "{count, plural, one {1 मिनट लगता है} other {{count} मिनट लगते हैं}}",
     "takes_x_plus_minutes": "{count}+ मिनट लगते हैं",

--- a/packages/surveys/locales/hu-HU.json
+++ b/packages/surveys/locales/hu-HU.json
@@ -30,6 +30,7 @@
     "select_options": "Lehetőségek kiválasztása",
     "sending_responses": "Válaszok küldése…",
     "survey_dialog": "Kérdőív párbeszédablak",
+    "survey_opened_announcement": "Egy felmérés megnyílt. Nyomja meg a Tab billentyűt a megnyitásához.",
     "takes_less_than_x_minutes": "{count, plural, one {Kevesebb mint 1 percet vesz igénybe} other {Kevesebb mint {count} percet vesz igénybe}}",
     "takes_x_minutes": "{count, plural, one {1 percet vesz igénybe} other {{count} percet vesz igénybe}}",
     "takes_x_plus_minutes": "{count}+ percet vesz igénybe",

--- a/packages/surveys/locales/hu-HU.json
+++ b/packages/surveys/locales/hu-HU.json
@@ -30,7 +30,7 @@
     "select_options": "Lehetőségek kiválasztása",
     "sending_responses": "Válaszok küldése…",
     "survey_dialog": "Kérdőív párbeszédablak",
-    "survey_opened_announcement": "Egy felmérés megnyílt. Nyomja meg a Tab billentyűt a megnyitásához.",
+    "survey_opened_announcement": "Egy felmérés megnyílt az oldal végén.",
     "takes_less_than_x_minutes": "{count, plural, one {Kevesebb mint 1 percet vesz igénybe} other {Kevesebb mint {count} percet vesz igénybe}}",
     "takes_x_minutes": "{count, plural, one {1 percet vesz igénybe} other {{count} percet vesz igénybe}}",
     "takes_x_plus_minutes": "{count}+ percet vesz igénybe",

--- a/packages/surveys/locales/id-ID.json
+++ b/packages/surveys/locales/id-ID.json
@@ -30,7 +30,7 @@
     "select_options": "Pilih opsi",
     "sending_responses": "Mengirim respons…",
     "survey_dialog": "Dialog Survei",
-    "survey_opened_announcement": "Survei telah dibuka. Tekan Tab untuk mengaksesnya.",
+    "survey_opened_announcement": "Survei telah terbuka di akhir halaman.",
     "takes_less_than_x_minutes": "{count, plural, other {Kurang dari {count} menit}}",
     "takes_x_minutes": "{count, plural, other {{count} menit}}",
     "takes_x_plus_minutes": "{count}+ menit",

--- a/packages/surveys/locales/id-ID.json
+++ b/packages/surveys/locales/id-ID.json
@@ -30,6 +30,7 @@
     "select_options": "Pilih opsi",
     "sending_responses": "Mengirim respons…",
     "survey_dialog": "Dialog Survei",
+    "survey_opened_announcement": "Survei telah dibuka. Tekan Tab untuk mengaksesnya.",
     "takes_less_than_x_minutes": "{count, plural, other {Kurang dari {count} menit}}",
     "takes_x_minutes": "{count, plural, other {{count} menit}}",
     "takes_x_plus_minutes": "{count}+ menit",

--- a/packages/surveys/locales/it-IT.json
+++ b/packages/surveys/locales/it-IT.json
@@ -30,6 +30,7 @@
     "select_options": "Seleziona opzioni",
     "sending_responses": "Invio risposte in corso...",
     "survey_dialog": "Finestra di dialogo del sondaggio",
+    "survey_opened_announcement": "È stato aperto un sondaggio. Premi Tab per raggiungerlo.",
     "takes_less_than_x_minutes": "{count, plural, one {Richiede meno di 1 minuto} other {Richiede meno di {count} minuti}}",
     "takes_x_minutes": "{count, plural, one {Richiede 1 minuto} other {Richiede {count} minuti}}",
     "takes_x_plus_minutes": "Richiede più di {count} minuti",

--- a/packages/surveys/locales/it-IT.json
+++ b/packages/surveys/locales/it-IT.json
@@ -30,7 +30,7 @@
     "select_options": "Seleziona opzioni",
     "sending_responses": "Invio risposte in corso...",
     "survey_dialog": "Finestra di dialogo del sondaggio",
-    "survey_opened_announcement": "È stato aperto un sondaggio. Premi Tab per raggiungerlo.",
+    "survey_opened_announcement": "Un sondaggio è stato aperto alla fine della pagina.",
     "takes_less_than_x_minutes": "{count, plural, one {Richiede meno di 1 minuto} other {Richiede meno di {count} minuti}}",
     "takes_x_minutes": "{count, plural, one {Richiede 1 minuto} other {Richiede {count} minuti}}",
     "takes_x_plus_minutes": "Richiede più di {count} minuti",

--- a/packages/surveys/locales/ja-JP.json
+++ b/packages/surveys/locales/ja-JP.json
@@ -30,6 +30,7 @@
     "select_options": "オプションを選択",
     "sending_responses": "回答を送信中...",
     "survey_dialog": "アンケートダイアログ",
+    "survey_opened_announcement": "アンケートが開きました。Tabキーを押してアクセスしてください。",
     "takes_less_than_x_minutes": "{count, plural, one {1分未満} other {{count}分未満}}",
     "takes_x_minutes": "{count, plural, one {1分} other {{count}分}}",
     "takes_x_plus_minutes": "{count}分以上",

--- a/packages/surveys/locales/ja-JP.json
+++ b/packages/surveys/locales/ja-JP.json
@@ -30,7 +30,7 @@
     "select_options": "オプションを選択",
     "sending_responses": "回答を送信中...",
     "survey_dialog": "アンケートダイアログ",
-    "survey_opened_announcement": "アンケートが開きました。Tabキーを押してアクセスしてください。",
+    "survey_opened_announcement": "ページの最後にアンケートが表示されました。",
     "takes_less_than_x_minutes": "{count, plural, one {1分未満} other {{count}分未満}}",
     "takes_x_minutes": "{count, plural, one {1分} other {{count}分}}",
     "takes_x_plus_minutes": "{count}分以上",

--- a/packages/surveys/locales/nl-NL.json
+++ b/packages/surveys/locales/nl-NL.json
@@ -30,6 +30,7 @@
     "select_options": "Selecteer opties",
     "sending_responses": "Reacties verzenden...",
     "survey_dialog": "Enquête-dialoogvenster",
+    "survey_opened_announcement": "Er is een enquête geopend. Druk op Tab om deze te bereiken.",
     "takes_less_than_x_minutes": "{count, plural, one {Duurt minder dan 1 minuut} other {Duurt minder dan {count} minuten}}",
     "takes_x_minutes": "{count, plural, one {Duurt 1 minuut} other {Duurt {count} minuten}}",
     "takes_x_plus_minutes": "Duurt {count}+ minuten",

--- a/packages/surveys/locales/nl-NL.json
+++ b/packages/surveys/locales/nl-NL.json
@@ -30,7 +30,7 @@
     "select_options": "Selecteer opties",
     "sending_responses": "Reacties verzenden...",
     "survey_dialog": "Enquête-dialoogvenster",
-    "survey_opened_announcement": "Er is een enquête geopend. Druk op Tab om deze te bereiken.",
+    "survey_opened_announcement": "Er is een enquête geopend aan het einde van de pagina.",
     "takes_less_than_x_minutes": "{count, plural, one {Duurt minder dan 1 minuut} other {Duurt minder dan {count} minuten}}",
     "takes_x_minutes": "{count, plural, one {Duurt 1 minuut} other {Duurt {count} minuten}}",
     "takes_x_plus_minutes": "Duurt {count}+ minuten",

--- a/packages/surveys/locales/pt-BR.json
+++ b/packages/surveys/locales/pt-BR.json
@@ -30,7 +30,7 @@
     "select_options": "Selecione opções",
     "sending_responses": "Enviando respostas...",
     "survey_dialog": "Caixa de diálogo da pesquisa",
-    "survey_opened_announcement": "Uma pesquisa foi aberta. Pressione Tab para acessá-la.",
+    "survey_opened_announcement": "Uma pesquisa foi aberta no final da página.",
     "takes_less_than_x_minutes": "{count, plural, one {Leva menos de 1 minuto} other {Leva menos de {count} minutos}}",
     "takes_x_minutes": "{count, plural, one {Leva 1 minuto} other {Leva {count} minutos}}",
     "takes_x_plus_minutes": "Leva {count}+ minutos",

--- a/packages/surveys/locales/pt-BR.json
+++ b/packages/surveys/locales/pt-BR.json
@@ -30,6 +30,7 @@
     "select_options": "Selecione opções",
     "sending_responses": "Enviando respostas...",
     "survey_dialog": "Caixa de diálogo da pesquisa",
+    "survey_opened_announcement": "Uma pesquisa foi aberta. Pressione Tab para acessá-la.",
     "takes_less_than_x_minutes": "{count, plural, one {Leva menos de 1 minuto} other {Leva menos de {count} minutos}}",
     "takes_x_minutes": "{count, plural, one {Leva 1 minuto} other {Leva {count} minutos}}",
     "takes_x_plus_minutes": "Leva {count}+ minutos",

--- a/packages/surveys/locales/ro-RO.json
+++ b/packages/surveys/locales/ro-RO.json
@@ -30,7 +30,7 @@
     "select_options": "Selectează opțiuni",
     "sending_responses": "Trimiterea răspunsurilor...",
     "survey_dialog": "Dialog sondaj",
-    "survey_opened_announcement": "S-a deschis un chestionar. Apasă Tab pentru a ajunge la el.",
+    "survey_opened_announcement": "Un sondaj s-a deschis la sfârșitul paginii.",
     "takes_less_than_x_minutes": "{count, plural, one {Durează mai puțin de 1 minut} few {Durează mai puțin de {count} minute} other {Durează mai puțin de {count} de minute}}",
     "takes_x_minutes": "{count, plural, one {Durează 1 minut} few {Durează {count} minute} other {Durează {count} de minute}}",
     "takes_x_plus_minutes": "Durează peste {count} minute",

--- a/packages/surveys/locales/ro-RO.json
+++ b/packages/surveys/locales/ro-RO.json
@@ -30,6 +30,7 @@
     "select_options": "Selectează opțiuni",
     "sending_responses": "Trimiterea răspunsurilor...",
     "survey_dialog": "Dialog sondaj",
+    "survey_opened_announcement": "S-a deschis un chestionar. Apasă Tab pentru a ajunge la el.",
     "takes_less_than_x_minutes": "{count, plural, one {Durează mai puțin de 1 minut} few {Durează mai puțin de {count} minute} other {Durează mai puțin de {count} de minute}}",
     "takes_x_minutes": "{count, plural, one {Durează 1 minut} few {Durează {count} minute} other {Durează {count} de minute}}",
     "takes_x_plus_minutes": "Durează peste {count} minute",

--- a/packages/surveys/locales/ru-RU.json
+++ b/packages/surveys/locales/ru-RU.json
@@ -30,6 +30,7 @@
     "select_options": "Выбери варианты",
     "sending_responses": "Отправка ответов...",
     "survey_dialog": "Диалог опроса",
+    "survey_opened_announcement": "Открылся опрос. Нажмите Tab, чтобы перейти к нему.",
     "takes_less_than_x_minutes": "{count, plural, one {Займёт меньше 1 минуты} few {Займёт меньше {count} минут} many {Займёт меньше {count} минут} other {Займёт меньше {count} минуты}}",
     "takes_x_minutes": "{count, plural, one {Займёт 1 минуту} few {Займёт {count} минуты} many {Займёт {count} минут} other {Займёт {count} минуты}}",
     "takes_x_plus_minutes": "Займёт {count}+ минут",

--- a/packages/surveys/locales/ru-RU.json
+++ b/packages/surveys/locales/ru-RU.json
@@ -30,7 +30,7 @@
     "select_options": "Выбери варианты",
     "sending_responses": "Отправка ответов...",
     "survey_dialog": "Диалог опроса",
-    "survey_opened_announcement": "Открылся опрос. Нажмите Tab, чтобы перейти к нему.",
+    "survey_opened_announcement": "В конце страницы открылся опрос.",
     "takes_less_than_x_minutes": "{count, plural, one {Займёт меньше 1 минуты} few {Займёт меньше {count} минут} many {Займёт меньше {count} минут} other {Займёт меньше {count} минуты}}",
     "takes_x_minutes": "{count, plural, one {Займёт 1 минуту} few {Займёт {count} минуты} many {Займёт {count} минут} other {Займёт {count} минуты}}",
     "takes_x_plus_minutes": "Займёт {count}+ минут",

--- a/packages/surveys/locales/sv-SE.json
+++ b/packages/surveys/locales/sv-SE.json
@@ -30,7 +30,7 @@
     "select_options": "Välj alternativ",
     "sending_responses": "Skickar svar...",
     "survey_dialog": "Enkätdialog",
-    "survey_opened_announcement": "En enkät har öppnats. Tryck på Tab för att nå den.",
+    "survey_opened_announcement": "En enkät har öppnats i slutet av sidan.",
     "takes_less_than_x_minutes": "{count, plural, one {Tar mindre än 1 minut} other {Tar mindre än {count} minuter}}",
     "takes_x_minutes": "{count, plural, one {Tar 1 minut} other {Tar {count} minuter}}",
     "takes_x_plus_minutes": "Tar {count}+ minuter",

--- a/packages/surveys/locales/sv-SE.json
+++ b/packages/surveys/locales/sv-SE.json
@@ -30,6 +30,7 @@
     "select_options": "Välj alternativ",
     "sending_responses": "Skickar svar...",
     "survey_dialog": "Enkätdialog",
+    "survey_opened_announcement": "En enkät har öppnats. Tryck på Tab för att nå den.",
     "takes_less_than_x_minutes": "{count, plural, one {Tar mindre än 1 minut} other {Tar mindre än {count} minuter}}",
     "takes_x_minutes": "{count, plural, one {Tar 1 minut} other {Tar {count} minuter}}",
     "takes_x_plus_minutes": "Tar {count}+ minuter",

--- a/packages/surveys/locales/tr-TR.json
+++ b/packages/surveys/locales/tr-TR.json
@@ -30,6 +30,7 @@
     "select_options": "Seçenekleri seçin",
     "sending_responses": "Yanıtlar gönderiliyor…",
     "survey_dialog": "Anket iletişim kutusu",
+    "survey_opened_announcement": "Bir anket açıldı. Ulaşmak için Tab tuşuna bas.",
     "takes_less_than_x_minutes": "{count, plural, one {1 dakikadan az sürer} other {{count} dakikadan az sürer}}",
     "takes_x_minutes": "{count, plural, one {1 dakika sürer} other {{count} dakika sürer}}",
     "takes_x_plus_minutes": "{count}+ dakika sürer",

--- a/packages/surveys/locales/tr-TR.json
+++ b/packages/surveys/locales/tr-TR.json
@@ -30,7 +30,7 @@
     "select_options": "Seçenekleri seçin",
     "sending_responses": "Yanıtlar gönderiliyor…",
     "survey_dialog": "Anket iletişim kutusu",
-    "survey_opened_announcement": "Bir anket açıldı. Ulaşmak için Tab tuşuna bas.",
+    "survey_opened_announcement": "Sayfanın sonunda bir anket açıldı.",
     "takes_less_than_x_minutes": "{count, plural, one {1 dakikadan az sürer} other {{count} dakikadan az sürer}}",
     "takes_x_minutes": "{count, plural, one {1 dakika sürer} other {{count} dakika sürer}}",
     "takes_x_plus_minutes": "{count}+ dakika sürer",

--- a/packages/surveys/locales/ur-PK.json
+++ b/packages/surveys/locales/ur-PK.json
@@ -30,6 +30,7 @@
     "select_options": "اختیارات منتخب کریں",
     "sending_responses": "جوابات بھیجے جا رہے ہیں…",
     "survey_dialog": "سروے ڈائیلاگ",
+    "survey_opened_announcement": "ایک سروے کھل گیا ہے۔ اس تک پہنچنے کے لیے Tab دبائیں۔",
     "takes_less_than_x_minutes": "{count, plural, one {1 منٹ سے بھی کم وقت لگتا ہے} other {{count} منٹ سے بھی کم وقت لگتا ہے}}",
     "takes_x_minutes": "{count, plural, one {1 منٹ لگتا ہے} other {{count} منٹ لگتے ہیں}}",
     "takes_x_plus_minutes": "{count}+ منٹ لگتے ہیں",

--- a/packages/surveys/locales/ur-PK.json
+++ b/packages/surveys/locales/ur-PK.json
@@ -30,7 +30,7 @@
     "select_options": "اختیارات منتخب کریں",
     "sending_responses": "جوابات بھیجے جا رہے ہیں…",
     "survey_dialog": "سروے ڈائیلاگ",
-    "survey_opened_announcement": "ایک سروے کھل گیا ہے۔ اس تک پہنچنے کے لیے Tab دبائیں۔",
+    "survey_opened_announcement": "صفحہ کے آخر میں ایک سروے کھل گیا ہے۔",
     "takes_less_than_x_minutes": "{count, plural, one {1 منٹ سے بھی کم وقت لگتا ہے} other {{count} منٹ سے بھی کم وقت لگتا ہے}}",
     "takes_x_minutes": "{count, plural, one {1 منٹ لگتا ہے} other {{count} منٹ لگتے ہیں}}",
     "takes_x_plus_minutes": "{count}+ منٹ لگتے ہیں",

--- a/packages/surveys/locales/uz-UZ.json
+++ b/packages/surveys/locales/uz-UZ.json
@@ -30,6 +30,7 @@
     "select_options": "Variantlarni tanla",
     "sending_responses": "Javoblar yuborilmoqda...",
     "survey_dialog": "So‘rovnoma dialog oynasi",
+    "survey_opened_announcement": "So'rovnoma ochildi. Unga o'tish uchun Tab tugmasini bosing.",
     "takes_less_than_x_minutes": "{count, plural, one {1 daqiqadan kam vaqt oladi} other {{count} daqiqadan kam vaqt oladi}}",
     "takes_x_minutes": "{count, plural, one {1 daqiqa vaqt oladi} other {{count} daqiqa vaqt oladi}}",
     "takes_x_plus_minutes": "{count}+ daqiqa vaqt oladi",

--- a/packages/surveys/locales/uz-UZ.json
+++ b/packages/surveys/locales/uz-UZ.json
@@ -30,7 +30,7 @@
     "select_options": "Variantlarni tanla",
     "sending_responses": "Javoblar yuborilmoqda...",
     "survey_dialog": "So‘rovnoma dialog oynasi",
-    "survey_opened_announcement": "So'rovnoma ochildi. Unga o'tish uchun Tab tugmasini bosing.",
+    "survey_opened_announcement": "Sahifa oxirida so'rovnoma ochildi.",
     "takes_less_than_x_minutes": "{count, plural, one {1 daqiqadan kam vaqt oladi} other {{count} daqiqadan kam vaqt oladi}}",
     "takes_x_minutes": "{count, plural, one {1 daqiqa vaqt oladi} other {{count} daqiqa vaqt oladi}}",
     "takes_x_plus_minutes": "{count}+ daqiqa vaqt oladi",

--- a/packages/surveys/locales/vi-VN.json
+++ b/packages/surveys/locales/vi-VN.json
@@ -30,7 +30,7 @@
     "select_options": "Chọn các tùy chọn",
     "sending_responses": "Đang gửi phản hồi…",
     "survey_dialog": "Hộp thoại khảo sát",
-    "survey_opened_announcement": "Một khảo sát đã được mở. Nhấn Tab để truy cập.",
+    "survey_opened_announcement": "Một khảo sát đã được mở ở cuối trang.",
     "takes_less_than_x_minutes": "{count, plural, other {Mất ít hơn {count} phút}}",
     "takes_x_minutes": "{count, plural, other {Mất {count} phút}}",
     "takes_x_plus_minutes": "Mất {count}+ phút",

--- a/packages/surveys/locales/vi-VN.json
+++ b/packages/surveys/locales/vi-VN.json
@@ -30,6 +30,7 @@
     "select_options": "Chọn các tùy chọn",
     "sending_responses": "Đang gửi phản hồi…",
     "survey_dialog": "Hộp thoại khảo sát",
+    "survey_opened_announcement": "Một khảo sát đã được mở. Nhấn Tab để truy cập.",
     "takes_less_than_x_minutes": "{count, plural, other {Mất ít hơn {count} phút}}",
     "takes_x_minutes": "{count, plural, other {Mất {count} phút}}",
     "takes_x_plus_minutes": "Mất {count}+ phút",

--- a/packages/surveys/locales/zh-Hans-CN.json
+++ b/packages/surveys/locales/zh-Hans-CN.json
@@ -30,6 +30,7 @@
     "select_options": "请选择多个选项",
     "sending_responses": "正在发送响应...",
     "survey_dialog": "调查对话框",
+    "survey_opened_announcement": "调查问卷已打开。按 Tab 键访问。",
     "takes_less_than_x_minutes": "{count, plural, one {少于 1 分钟} other {少于 {count} 分钟}}",
     "takes_x_minutes": "{count, plural, one {1 分钟} other {{count} 分钟}}",
     "takes_x_plus_minutes": "{count}+ 分钟",

--- a/packages/surveys/locales/zh-Hans-CN.json
+++ b/packages/surveys/locales/zh-Hans-CN.json
@@ -30,7 +30,7 @@
     "select_options": "请选择多个选项",
     "sending_responses": "正在发送响应...",
     "survey_dialog": "调查对话框",
-    "survey_opened_announcement": "调查问卷已打开。按 Tab 键访问。",
+    "survey_opened_announcement": "页面底部已打开一项调查问卷。",
     "takes_less_than_x_minutes": "{count, plural, one {少于 1 分钟} other {少于 {count} 分钟}}",
     "takes_x_minutes": "{count, plural, one {1 分钟} other {{count} 分钟}}",
     "takes_x_plus_minutes": "{count}+ 分钟",

--- a/packages/surveys/locales/zh-Hant-TW.json
+++ b/packages/surveys/locales/zh-Hant-TW.json
@@ -30,6 +30,7 @@
     "select_options": "選擇選項",
     "sending_responses": "正在傳送回覆…",
     "survey_dialog": "問卷對話框",
+    "survey_opened_announcement": "問卷調查已開啟。按 Tab 鍵以前往。",
     "takes_less_than_x_minutes": "{count, plural, other {少於 {count} 分鐘}}",
     "takes_x_minutes": "{count, plural, other {{count} 分鐘}}",
     "takes_x_plus_minutes": "{count}+ 分鐘",

--- a/packages/surveys/locales/zh-Hant-TW.json
+++ b/packages/surveys/locales/zh-Hant-TW.json
@@ -30,7 +30,7 @@
     "select_options": "選擇選項",
     "sending_responses": "正在傳送回覆…",
     "survey_dialog": "問卷對話框",
-    "survey_opened_announcement": "問卷調查已開啟。按 Tab 鍵以前往。",
+    "survey_opened_announcement": "頁面底部已開啟一份問卷調查。",
     "takes_less_than_x_minutes": "{count, plural, other {少於 {count} 分鐘}}",
     "takes_x_minutes": "{count, plural, other {{count} 分鐘}}",
     "takes_x_plus_minutes": "{count}+ 分鐘",

--- a/packages/surveys/src/components/buttons/submit-button.tsx
+++ b/packages/surveys/src/components/buttons/submit-button.tsx
@@ -42,6 +42,21 @@ export function SubmitButton({
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key === "Enter" && !disabled && !isProcessing) {
+        // The listener sits on `document` so the chord still works when focus is on <body>, which is
+        // the normal state for link surveys. An embedded survey shares the page with a host app that
+        // owns its own shortcuts, so don't claim the chord — or preventDefault it — while the user is
+        // focused inside their page.
+        const surveyRoot = buttonRef.current?.closest("#fbjs");
+        const activeElement = document.activeElement;
+        if (
+          surveyRoot &&
+          activeElement &&
+          activeElement !== document.body &&
+          !surveyRoot.contains(activeElement)
+        ) {
+          return;
+        }
+
         event.preventDefault();
         setIsProcessing(true);
         const button = buttonRef.current;

--- a/packages/surveys/src/components/general/render-survey.tsx
+++ b/packages/surveys/src/components/general/render-survey.tsx
@@ -52,11 +52,17 @@ export function RenderSurvey(props: SurveyContainerProps) {
     return null;
   }
 
+  const mode = props.mode ?? "modal";
   const hasOverlay = props.overlay && props.overlay !== "none";
+  // A modal survey with no overlay appears over a page the user is still working in, often mid-form.
+  // Moving the caret into the survey on open would pull them out of the field they are typing in, so
+  // leave focus where it is. With an overlay the page is blocked anyway, so taking focus is correct.
+  // Only ever force this off — everything else keeps the existing default (see survey.tsx).
+  const autoFocus = props.autoFocus ?? (mode === "modal" && !hasOverlay ? false : undefined);
 
   return (
     <SurveyContainer
-      mode={props.mode ?? "modal"}
+      mode={mode}
       placement={props.placement}
       overlay={props.overlay}
       clickOutside={props.clickOutside}
@@ -65,6 +71,7 @@ export function RenderSurvey(props: SurveyContainerProps) {
       dir={dir}>
       <Survey
         {...props}
+        autoFocus={autoFocus}
         clickOutside={hasOverlay ? props.clickOutside : true}
         onClose={close}
         onFinished={() => {

--- a/packages/surveys/src/components/wrappers/survey-container.tsx
+++ b/packages/surveys/src/components/wrappers/survey-container.tsx
@@ -2,8 +2,13 @@ import { type ComponentChildren } from "preact";
 import { useEffect } from "preact/hooks";
 import { useTranslation } from "react-i18next";
 import { type TOverlay, type TPlacement } from "@formbricks/types/common";
+import { ensureLiveRegion } from "@/lib/live-region";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { cn } from "@/lib/utils";
+
+// Give a fallback-created live region (older SDK, see live-region.ts) a beat to be registered by
+// assistive tech before the message lands. Harmless when the region already exists.
+const ANNOUNCE_DELAY_MS = 100;
 
 interface SurveyContainerProps {
   mode: "modal" | "inline";
@@ -84,6 +89,25 @@ export function SurveyContainer({
     };
   }, [isModal, isOpen, hasOverlay, onClose, modalRef]);
 
+  // A no-overlay survey never takes focus (see the trap gate above), so its opening is announced
+  // through the persistent status region — otherwise screen-reader users get no signal it appeared.
+  // With an overlay the trap moves focus into the dialog, which is its own announcement. Cleared on
+  // close because setting identical text twice is not a change, so a later open would stay silent.
+  useEffect(() => {
+    if (!isModal || !isOpen || hasOverlay) return;
+
+    const liveRegion = ensureLiveRegion();
+    liveRegion.textContent = "";
+    const announceTimeout = setTimeout(() => {
+      liveRegion.textContent = t("common.survey_opened_announcement");
+    }, ANNOUNCE_DELAY_MS);
+
+    return () => {
+      clearTimeout(announceTimeout);
+      liveRegion.textContent = "";
+    };
+  }, [isModal, isOpen, hasOverlay, t]);
+
   const getPlacementStyle = (placement: TPlacement): string => {
     switch (placement) {
       case "bottomRight":
@@ -114,7 +138,9 @@ export function SurveyContainer({
   return (
     <div id="fbjs" className="formbricks-form" dir={dir}>
       <div
-        aria-live="assertive"
+        // In-dialog updates (question changes after a submit) should wait for the reader to finish
+        // speaking, not interrupt it — a survey is never urgent enough for assertive.
+        aria-live="polite"
         className={cn(
           hasOverlay ? "pointer-events-auto" : "pointer-events-none",
           isModal && "fixed inset-0 z-999999 flex items-end"

--- a/packages/surveys/src/components/wrappers/survey-container.tsx
+++ b/packages/surveys/src/components/wrappers/survey-container.tsx
@@ -1,4 +1,4 @@
-import { type ComponentChildren } from "preact";
+import { type ComponentChildren, type JSX } from "preact";
 import { useEffect } from "preact/hooks";
 import { useTranslation } from "react-i18next";
 import { type TOverlay, type TPlacement } from "@formbricks/types/common";
@@ -28,8 +28,16 @@ export function SurveyContainer({
 }: Readonly<SurveyContainerProps>) {
   const isModal = mode === "modal";
   const { t } = useTranslation();
-  const modalRef = useFocusTrap<HTMLDivElement>({ enabled: isModal && isOpen, onEscapeKeyDown: onClose });
   const hasOverlay = overlay !== "none";
+  // The overlay is what makes a survey modal: it covers the host page and the page stops being usable.
+  // Without one the page underneath stays visible and clickable, so the survey is a notification, not a
+  // modal. Trapping focus there steals the caret and the text selection from the host page — the trap's
+  // document-level listeners pull focus back in on every click, tab and drag. Matches the gate the
+  // click-outside effect below already uses.
+  const modalRef = useFocusTrap<HTMLDivElement>({
+    enabled: isModal && isOpen && hasOverlay,
+    onEscapeKeyDown: onClose,
+  });
 
   useEffect(() => {
     if (!isModal) return;
@@ -52,6 +60,17 @@ export function SurveyContainer({
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, [clickOutside, hasOverlay, modalRef, onClose, isModal, isOpen]);
+
+  // Without an overlay the focus trap is off, so nothing handles Escape. Handle it on the container
+  // instead of on `document`: Escape closes the survey only while focus is inside it, and never cancels
+  // the host page's own Escape handling.
+  const handleContainerKeyDown = (event: JSX.TargetedKeyboardEvent<HTMLDivElement>) => {
+    if (hasOverlay) return; // the focus trap already handles Escape
+    if (event.key !== "Escape" || event.altKey || event.ctrlKey || event.metaKey) return;
+
+    event.preventDefault();
+    onClose?.();
+  };
 
   const getPlacementStyle = (placement: TPlacement): string => {
     switch (placement) {
@@ -97,9 +116,13 @@ export function SurveyContainer({
           <div
             ref={modalRef}
             role="dialog"
-            aria-modal="true"
+            // Only a survey that actually blocks the page is a modal dialog. `aria-modal` makes
+            // assistive tech ignore everything outside it, so setting it on a corner survey hides the
+            // host page from screen-reader users while they can still see and use it.
+            aria-modal={hasOverlay ? "true" : undefined}
             aria-label={t("common.survey_dialog")}
             tabIndex={-1}
+            onKeyDown={handleContainerKeyDown}
             className={cn(
               getPlacementStyle(placement),
               isOpen ? "opacity-100" : "opacity-0",

--- a/packages/surveys/src/components/wrappers/survey-container.tsx
+++ b/packages/surveys/src/components/wrappers/survey-container.tsx
@@ -1,4 +1,4 @@
-import { type ComponentChildren, type JSX } from "preact";
+import { type ComponentChildren } from "preact";
 import { useEffect } from "preact/hooks";
 import { useTranslation } from "react-i18next";
 import { type TOverlay, type TPlacement } from "@formbricks/types/common";
@@ -61,16 +61,28 @@ export function SurveyContainer({
     };
   }, [clickOutside, hasOverlay, modalRef, onClose, isModal, isOpen]);
 
-  // Without an overlay the focus trap is off, so nothing handles Escape. Handle it on the container
+  // Without an overlay the focus trap is off, so nothing handles Escape. Listen on the container node
   // instead of on `document`: Escape closes the survey only while focus is inside it, and never cancels
-  // the host page's own Escape handling.
-  const handleContainerKeyDown = (event: JSX.TargetedKeyboardEvent<HTMLDivElement>) => {
-    if (hasOverlay) return; // the focus trap already handles Escape
-    if (event.key !== "Escape" || event.altKey || event.ctrlKey || event.metaKey) return;
+  // the host page's own Escape handling. Keep the listener imperative — a keydown JSX prop on a
+  // non-interactive role="dialog" element fails a11y linting.
+  useEffect(() => {
+    if (!isModal || !isOpen || hasOverlay) return;
 
-    event.preventDefault();
-    onClose?.();
-  };
+    const container = modalRef.current;
+    if (!container) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.altKey || event.ctrlKey || event.metaKey) return;
+
+      event.preventDefault();
+      onClose?.();
+    };
+
+    container.addEventListener("keydown", handleKeyDown);
+    return () => {
+      container.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isModal, isOpen, hasOverlay, onClose, modalRef]);
 
   const getPlacementStyle = (placement: TPlacement): string => {
     switch (placement) {
@@ -122,7 +134,6 @@ export function SurveyContainer({
             aria-modal={hasOverlay ? "true" : undefined}
             aria-label={t("common.survey_dialog")}
             tabIndex={-1}
-            onKeyDown={handleContainerKeyDown}
             className={cn(
               getPlacementStyle(placement),
               isOpen ? "opacity-100" : "opacity-0",

--- a/packages/surveys/src/lib/live-region.test.ts
+++ b/packages/surveys/src/lib/live-region.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, test } from "vitest";
+import { ensureLiveRegion } from "./live-region";
+
+const LIVE_REGION_ID = "formbricks-live-region";
+
+describe("ensureLiveRegion", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("creates an accessible visually hidden status region", () => {
+    const liveRegion = ensureLiveRegion();
+
+    expect(liveRegion.id).toBe(LIVE_REGION_ID);
+    expect(liveRegion.getAttribute("role")).toBe("status");
+    expect(liveRegion.getAttribute("aria-live")).toBe("polite");
+    expect(liveRegion.getAttribute("aria-atomic")).toBe("true");
+    expect(liveRegion.style.position).toBe("absolute");
+    expect(document.body.lastElementChild).toBe(liveRegion);
+  });
+
+  test("reuses an existing live region", () => {
+    const existingRegion = document.createElement("div");
+    existingRegion.id = LIVE_REGION_ID;
+    existingRegion.textContent = "Existing announcement";
+    document.body.appendChild(existingRegion);
+
+    expect(ensureLiveRegion()).toBe(existingRegion);
+    expect(document.querySelectorAll(`#${LIVE_REGION_ID}`)).toHaveLength(1);
+    expect(existingRegion.textContent).toBe("Existing announcement");
+  });
+});

--- a/packages/surveys/src/lib/live-region.ts
+++ b/packages/surveys/src/lib/live-region.ts
@@ -1,0 +1,29 @@
+/**
+ * The persistent, visually hidden status region that survey opens are announced into. The
+ * @formbricks/js SDK mounts it at setup time (packages/js-core/src/lib/survey/widget.ts,
+ * `addLiveRegionContainer`) so assistive tech has registered the region long before the first
+ * message lands — screen readers only reliably announce changes made to a live region that
+ * already existed, not a region inserted together with its content.
+ *
+ * Embed scripts stay on customer pages for years, so an older SDK may not create the region.
+ * `ensureLiveRegion` re-creates it as a degraded fallback (the announcement is delayed a beat
+ * to give assistive tech a chance to register the fresh region — see the caller).
+ */
+
+// Shipped id contract with the SDK (packages/js-core/src/lib/common/constants.ts) — must never change.
+const LIVE_REGION_ID = "formbricks-live-region";
+
+export const ensureLiveRegion = (): HTMLElement => {
+  const existingRegion = document.getElementById(LIVE_REGION_ID);
+  if (existingRegion) return existingRegion;
+
+  const liveRegion = document.createElement("div");
+  liveRegion.id = LIVE_REGION_ID;
+  liveRegion.setAttribute("role", "status");
+  liveRegion.setAttribute("aria-live", "polite");
+  liveRegion.setAttribute("aria-atomic", "true");
+  liveRegion.style.cssText =
+    "position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0";
+  document.body.appendChild(liveRegion);
+  return liveRegion;
+};


### PR DESCRIPTION
## What & why

A survey opening in a corner with **no overlay** made the page underneath partly unusable: the user's caret was pulled out of whatever field they were typing in, text could not be drag-selected, Tab could not leave the survey, and Escape and Cmd/Ctrl+Enter stopped reaching the host page. Mouse clicks kept working, which is why this read as a CSS problem — reported as "the widget container renders `fixed inset-0` and blocks the page".

The CSS is not the cause. That full-screen layer is already `pointer-events: none` when there is no overlay (`survey-container.tsx:88`). The cause is `survey-container.tsx:31`, which armed `useFocusTrap` for **every** modal survey regardless of overlay. The trap registers `focusin` / `focusout` / `keydown` on `document`, so on every host-page mousedown it pulls focus back into the survey ~17ms later (`use-focus-trap.ts:255-261`), landing on the survey's text field and collapsing the selection. Two smaller focus grabs made it worse: the card autofocuses its first control on mount, and the submit button claims Cmd/Ctrl+Enter document-wide.

The rule this encodes: **the overlay is what makes a survey modal.** With an overlay the page is deliberately blocked, so trapping focus is correct. Without one the survey is a notification sitting on a page the user is still working in, and it must not take anything.

- `survey-container.tsx:31` — gate `useFocusTrap` on `hasOverlay`, matching the gate the click-outside effect already uses two lines below.
- `survey-container.tsx:119` — set `aria-modal` only when there is an overlay, and move Escape from the trap's `document` listener to a container-scoped handler. Precisely: with focus on the host page the survey no longer sees Escape at all, so it neither closes nor cancels it. With focus *inside* the survey, Escape closes the survey and — since the handler calls `preventDefault()` but not `stopPropagation()` — still reaches the host page's own handler. That is the safer of the two options. Per ARIA APG, `aria-modal` is only valid when code prevents interaction outside *and* styling obscures it; neither holds here, and it currently hides the whole host page from screen-reader users.
- `render-survey.tsx:57` — default `autoFocus` off for modal + no overlay, using the prop that already exists on `SurveyBaseProps` and is already threaded to `survey.tsx:252`. This only ever forces it *off*; every other case keeps the existing default. Focus still follows Next/Back, which is user-initiated.
- `submit-button.tsx:44` — don't claim (or `preventDefault`) Cmd/Ctrl+Enter while focus is inside the host page.

`role="dialog"` stays — without `aria-modal` that is exactly a non-modal dialog. The survey remains fully usable; it just no longer grabs anything.

Note on default behaviour: `placement bottomRight` + `overlay none` are the schema defaults (`main.prisma:616,618`), so this affects most existing app surveys. It is a bug fix rather than a new option — putting it behind a setting would ship the bug as a feature — but it is worth a release note. The one real cost: keyboard-only users no longer land inside a corner survey automatically and have to Tab to it (screen-reader users now get an announcement, see below).

### Follow-ups in this PR

**Screen-reader announcement for no-overlay opens** (`9e8edbb5a`). A no-overlay survey deliberately never takes focus, which left screen-reader users with no signal it appeared: the widget's existing `aria-live` wrapper mounts *together with* the survey content, and live regions are only reliably announced when they already existed before their content changes (WCAG 2.1 SC 4.1.3). The SDK now mounts a persistent, visually hidden `role="status"` region at `setup()` (`js-core/src/lib/survey/widget.ts`, `addLiveRegionContainer`), and the renderer announces the open into it — `common.survey_opened_announcement`, "A survey has opened at the end of the page.", localized into all widget locales — creating the region as a fallback when an older embed script didn't (`surveys/src/lib/live-region.ts`). The wording states the survey's position in reading order (the widget mounts last in `<body>`) rather than promising a keystroke — an earlier "Press Tab to reach it" draft was wrong because Tab follows DOM order, so one press lands on the next host control (`2ad3c649b`). The message clears on close so a later open re-announces (identical text twice is not a change and would stay silent). Overlay surveys stay silent there — the trap's focus move into the dialog is their announcement. The in-dialog `aria-live` wrapper also drops from `assertive` to `polite`: question changes should wait for the reader, not interrupt it. The region-creation code is intentionally duplicated between js-core and surveys rather than shared: the two ship in separately deployed bundles with real version skew (a years-old npm `@formbricks/js` loads today's `surveys.umd.cjs`), js-core deliberately has zero runtime dependencies, and the same duplication contract already exists for the `formbricks-modal-container` id.

**Sonar findings** (`5dfe01183`). The spec's two fixed 1500 ms waits became the observable condition they approximated — the dialog's fade-in reaching `opacity: 1` (S2925 ×2). The no-overlay Escape handler moved from a JSX `onKeyDown` prop on the `role="dialog"` div to an imperative listener on the same node (S6847), which also removed the deprecated `JSX.TargetedKeyboardEvent` type (S1874). Semantics unchanged: Escape closes only while focus is inside the survey.

## Linear ticket

Fixes ENG-2304

## How this was tested

- `pnpm test` ✅ — 24/24 turbo tasks, 598 test files. `packages/surveys` alone: 665 tests pass.
- `tsc --noEmit` (surveys + web) ✅, `eslint` on changed files ✅, `pnpm format:check` ✅.
- **New e2e spec** `apps/web/playwright/survey-modal-non-blocking.spec.ts` ✅ — 2/2. Covers both directions: `overlay:none` must not block, `overlay:dark` must still be modal. New Prisma seeder `playwright/utils/app-survey.ts` provisions an app survey + code action without driving the editor UI.
- **Negative control, per assertion.** A whole-spec revert only proves the *first* assertion bites, because Playwright aborts the test there. So each assertion was isolated into its own test and run against a bundle rebuilt from `b204241c9` (verified pre-fix: the `closest("#fbjs")` guard absent from the built bundle). Result: **every isolated assertion fails pre-fix and passes post-fix** — host-input focus, Escape `defaultPrevented`, full-string drag selection, focus-outside-survey after the drag, and the Cmd/Ctrl+Enter chord.
- Review (thanks @itsjavi) caught that the original Cmd/Ctrl+Enter assertion could not fail: both keydown listeners sit on `document` in the bubble phase and the host page registers first, so an inline `defaultPrevented` read always saw `false`. Auditing the rest of the spec for the same pattern found three more weak assertions. All fixed in `85965d457`; details in the review thread.
- **Manual, against the real JS playground on a local stack** (real `formbricks.umd.cjs` + real `surveys.umd.cjs`, app survey, bottomRight, overlay none) — 10/10 checks:

  | Check | Before | After |
  | --- | --- | --- |
  | Drag-select host prose | 0 chars | full string |
  | Focus after survey opens | survey `textarea` | host `button` (untouched) |
  | Typing after survey opens | goes to the survey | goes to the host input |
  | Tab ×6 from host page | all 6 inside survey | all 6 on host controls |
  | `aria-modal` | `"true"` | absent |
  | Escape on host page | closed the survey | host keeps it, survey stays open |
  | Cmd+Enter in host textarea | survey submitted, `defaultPrevented: true` | host handler runs, survey unchanged |
  | Survey still usable | ✅ | ✅ (types, Escape closes it) |

- **Overlay regression check on the real bundle** — 8/8: `overlay:dark` still sets `aria-modal="true"`, still takes focus on open, still snaps focus back when pulled out, layer still `pointer-events: auto`. `overlay:none` inverts on all four.
- **Follow-up commits** (`5dfe01183`, `9e8edbb5a`): `packages/js-core` vitest 40/40 (setup + widget), `packages/surveys` focus-trap 13/13, `tsc --noEmit` (js-core) ✅, eslint on every changed file ✅, `pnpm i18n` regenerated all widget locales for the new string. E2E spec re-run locally after both commits: 2/2 ✅ — it now also pins the announcement contract: the region exists (`role="status"`) before any survey opens, receives the message on open, clears on close, and stays silent for `overlay:dark`.
- **Sonar coverage follow-up** (`8ef4efc6a`): added direct unit coverage for the SDK and renderer live-region helpers, including creation, accessibility attributes, existing-region reuse, setup invocation, and SSR safety. Full package coverage passes at 667/667 surveys tests and 291/291 js-core tests. The new `live-region.ts` reports 12/12 covered lines and 2/2 covered branches; all added executable lines and branches in Sonar-included `.ts` code are covered.
- **Manual re-check on the local playground with rebuilt bundles**: region mounted at `setup()`; announcement lands ~100 ms after open; cleared on close; re-open re-announces; Escape-inside still closes after the S6847 listener refactor; overlay mode silent with `aria-modal` and the focus trap intact.

No screenshots: there is **no visual change**. The widget renders pixel-identically in both states — only focus and keyboard behaviour changed, which the measurements above capture.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] In a workspace whose widget settings are Placement = Bottom Right and Overlay = None, publish an app survey triggered by a code action. On a test page running the SDK, click into a text field, type some text, then fire the action → the survey appears bottom-right and **the cursor stays in your field**; continuing to type keeps going into your field, not the survey.
- [ ] With the survey open, drag across a paragraph of page text → the text highlights normally and the highlight follows the mouse.
- [ ] With the survey open, press Tab repeatedly from a field on the page → focus moves through the page's own controls instead of cycling inside the survey.
- [ ] With the survey open, click into the survey's answer box and type → it works normally. Press Escape → the survey closes.
- [ ] With the survey open and focus on the page (not the survey), press Escape → the survey stays open and the page's own Escape behaviour (e.g. closing its own dialog) works.
- [ ] With focus in a page textarea that has its own Cmd/Ctrl+Enter shortcut, press Cmd/Ctrl+Enter → the page's shortcut runs and the survey does **not** advance.
- [ ] Set Overlay to Dark or Light and repeat → the old behaviour is expected here: the page is dimmed, the survey takes focus on open, focus stays inside it, and Escape closes it.
- [ ] Announcement, no screen reader needed: after the host page loads the SDK, DevTools → Elements shows an empty `<div id="formbricks-live-region" role="status">` at the end of `<body>` (present **before** any survey opens). Open the no-overlay survey → its text becomes "A survey has opened at the end of the page.". Close the survey → the text clears. Reopen it → the text is set again on every open, not just the first.
- [ ] Screen reader (VoiceOver / NVDA): with Overlay = None, opening the survey plays that announcement politely (it waits for current speech, does not interrupt) and focus does not move; the rest of the page stays reachable while the survey is open. With an overlay, focus moves into the survey, the page outside is not reachable, and no extra announcement plays.
- [ ] Bundle freshness when testing locally: `/js/*.umd.cjs` is served with `max-age=3600`, so hard-refresh (or DevTools → disable cache) before judging — a stale `formbricks.umd.cjs` shows the old behaviour (no region at all).
- [ ] Link surveys (`/s/<id>`) and the survey preview in the editor: unchanged — autofocus and Cmd/Ctrl+Enter still behave as before.

**Preconditions / test data**

- An app-type survey with status In Progress, a code action trigger, and Display Option set to "respond multiple times" so it can be reopened.
- A host page loading the JS SDK that has selectable text, at least one input, and ideally its own Escape / Cmd+Enter shortcut to prove we no longer swallow them.
- Widget Placement and Overlay live on the workspace's widget settings, not on the survey.

**Risks & regressions**

- Highest risk is the overlay path: confirm surveys **with** an overlay are unchanged (focus taken on open, focus contained, Escape closes). The e2e spec pins this, but it is worth eyes.
- `center` placement combined with Overlay = None is now treated as non-modal. It still looks like a centered modal to a sighted user. Flagging for a product decision — the editor labels it "Centered Modal" while overlay is an independent control.
- Keyboard-only discoverability: a no-overlay survey is no longer auto-focused, so a keyboard user must Tab to it (the container is appended last to `<body>`, so it is last in tab order). Screen-reader users now hear the open announced through the status region; sighted keyboard users still get no cue beyond the survey appearing.
- Not addressed here, pre-existing: below 640px the survey is a full-width bar pinned to the bottom (`survey-container.tsx:106`, placement classes are `sm:`-only), so it can cover a sticky footer on mobile. Deliberate design from 2023; separate ticket.
- Not addressed here, found while investigating and worth their own tickets: `hasYieldedToPage` never resets once the trap gives up (`use-focus-trap.ts:184/190`); `focusScopesStack.add` pauses the outgoing scope but nothing resumes it (`:27-39`); `removeWidgetContainer()` detaches the container without unmounting Preact, leaking the trap's `document` listeners (`js-core/src/lib/survey/widget.ts:277-279`).

**Migrations / env / cutover**

- No migrations or env changes.
- On deploy, purge the CDN entries for **both** `/js/surveys.umd.cjs` and `/js/formbricks.umd.cjs` (the live-region commit changed js-core too). `apps/web/next.config.mjs` serves `/js/(.*)` with `s-maxage=2592000`, so embedding sites would otherwise keep the old bundles for up to 30 days. Sites loading the SDK from npm instead of `/js/` get the region via the surveys-side fallback until they upgrade.


