### PR TITLE
feat(embedded-data): add the single embedded-value resolver and readable-fields helper

### DIFF
--- a/packages/types/embedded-data-resolver.test.ts
+++ b/packages/types/embedded-data-resolver.test.ts
@@ -1,0 +1,690 @@
+import { describe, expect, test } from "vitest";
+import {
+  RESERVED_FIELD_CATALOG,
+  type TEmbeddedValueRef,
+  type TEmbeddedValueResponse,
+  type TLinkedEmbeddedField,
+  type TReservedFieldCatalogEntry,
+  coerceToEmbeddedDataType,
+  deriveLegacyEmbeddedData,
+  listReadableFields,
+  projectReservedValues,
+  resolveEmbeddedValue,
+} from "./embedded-data-resolver";
+import type { TResponseData, TResponseVariables } from "./responses";
+import type { TSurveyBlocks } from "./surveys/blocks";
+import { TSurveyElementTypeEnum } from "./surveys/elements";
+
+const SCORE_VARIABLE_ID = "clx0000000000000000000v1";
+const DUAL_KEY = "clx0000000000000000000v2";
+
+/** A response with every location the read seam can point at populated. */
+const response: TEmbeddedValueResponse = {
+  id: "clx0000000000000000000r1",
+  surveyId: "clx0000000000000000000s1",
+  createdAt: new Date("2026-08-01T09:00:00.000Z"),
+  updatedAt: new Date("2026-08-01T09:05:00.000Z"),
+  finished: true,
+  language: "de",
+  data: {
+    plan: "premium",
+    seats: "25",
+    rating: 4,
+    zero: "0",
+    empty: "",
+    opted_in: "TRUE",
+    signup_date: "2026-08-06",
+    bad_date: "banana",
+    bad_number: "abc",
+    multi: ["a", "b"],
+    matrix: { row1: "col1" },
+    [DUAL_KEY]: "from-data",
+  },
+  variables: {
+    [SCORE_VARIABLE_ID]: 42,
+    [DUAL_KEY]: "from-variables",
+  },
+  ttc: { q1: 10_000, _total: 30_000 },
+  meta: {
+    source: "web",
+    url: "https://example.com?plan=premium",
+    userAgent: { browser: "Chrome", os: "macOS" },
+    country: "DE",
+  },
+};
+
+/** A response where everything optional is absent — the "nothing was captured" case. */
+const sparseResponse: TEmbeddedValueResponse = {
+  id: "clx0000000000000000000r2",
+  surveyId: "clx0000000000000000000s1",
+  createdAt: new Date("2026-08-02T12:00:00.000Z"),
+  updatedAt: new Date("2026-08-02T12:00:00.000Z"),
+  finished: false,
+  language: null,
+  data: {},
+  variables: {},
+  meta: {},
+};
+
+const makeField = (
+  overrides: Partial<TLinkedEmbeddedField["field"]> = {}
+): TLinkedEmbeddedField["field"] => ({
+  name: "Field",
+  source: "ingested",
+  dataType: "string",
+  defaultValue: null,
+  locked: false,
+  ...overrides,
+});
+
+const resolve = (
+  field: TLinkedEmbeddedField["field"],
+  storageKey: string,
+  onResponse: TEmbeddedValueResponse = response
+) => resolveEmbeddedValue({ field, link: { storageKey } }, onResponse);
+
+/** Sample catalog entries — contents live in the tests only; the production catalog is ENG-1839's. */
+const countryEntry: TReservedFieldCatalogEntry = {
+  name: "country",
+  dataType: "string",
+  read: (r) => r.meta.country,
+};
+const browserEntry: TReservedFieldCatalogEntry = {
+  name: "browser",
+  dataType: "string",
+  read: (r) => r.meta.userAgent?.browser,
+};
+const totalTimeEntry: TReservedFieldCatalogEntry = {
+  name: "total_time",
+  dataType: "number",
+  read: (r) => r.ttc?._total,
+};
+const languageEntry: TReservedFieldCatalogEntry = {
+  name: "response_language",
+  dataType: "string",
+  read: (r) => r.language,
+};
+const completedEntry: TReservedFieldCatalogEntry = {
+  name: "completed",
+  dataType: "boolean",
+  read: (r) => r.finished,
+};
+const startedAtEntry: TReservedFieldCatalogEntry = {
+  name: "started_at",
+  dataType: "date",
+  read: (r) => r.createdAt,
+};
+const actionEntry: TReservedFieldCatalogEntry = {
+  name: "action",
+  dataType: "string",
+  read: (r) => r.meta.action,
+};
+
+describe("resolveEmbeddedValue", () => {
+  describe("computed fields read response.variables", () => {
+    test("returns the value stored under the link's storageKey", () => {
+      const field = makeField({ source: "computed", dataType: "number", defaultValue: 0 });
+      expect(resolve(field, SCORE_VARIABLE_ID)).toBe(42);
+    });
+
+    test("reads variables, never data, when the same key exists in both", () => {
+      const field = makeField({ source: "computed" });
+      expect(resolve(field, DUAL_KEY)).toBe("from-variables");
+    });
+
+    test("coerces a string stored in variables to the field's number dataType", () => {
+      const field = makeField({ source: "computed", dataType: "number" });
+      const withStringScore: TEmbeddedValueResponse = {
+        ...response,
+        variables: { [SCORE_VARIABLE_ID]: "42" },
+      };
+      expect(resolve(field, SCORE_VARIABLE_ID, withStringScore)).toBe(42);
+    });
+  });
+
+  describe("ingested fields read response.data", () => {
+    test("returns the value stored under the link's storageKey", () => {
+      expect(resolve(makeField(), "plan")).toBe("premium");
+    });
+
+    test("reads data, never variables, when the same key exists in both", () => {
+      expect(resolve(makeField(), DUAL_KEY)).toBe("from-data");
+    });
+
+    test("coerces a string answer to the field's number dataType", () => {
+      const field = makeField({ dataType: "number" });
+      expect(resolve(field, "seats")).toBe(25);
+    });
+
+    test('treats "0" as a present number value, not as missing', () => {
+      const field = makeField({ dataType: "number", defaultValue: 9 });
+      expect(resolve(field, "zero")).toBe(0);
+    });
+
+    test("treats an empty string as a present string value, not as missing", () => {
+      const field = makeField({ defaultValue: "fallback" });
+      expect(resolve(field, "empty")).toBe("");
+    });
+  });
+
+  describe("reserved catalog entries read through their typed accessor", () => {
+    test("resolves a meta field", () => {
+      expect(resolveEmbeddedValue({ entry: countryEntry }, response)).toBe("DE");
+    });
+
+    test("resolves a nested meta.userAgent field", () => {
+      expect(resolveEmbeddedValue({ entry: browserEntry }, response)).toBe("Chrome");
+    });
+
+    test("resolves ttc._total", () => {
+      expect(resolveEmbeddedValue({ entry: totalTimeEntry }, response)).toBe(30_000);
+    });
+
+    test("resolves a top-level field", () => {
+      expect(resolveEmbeddedValue({ entry: languageEntry }, response)).toBe("de");
+    });
+
+    test("resolves a boolean field, where false is a value and not a gap", () => {
+      expect(resolveEmbeddedValue({ entry: completedEntry }, response)).toBe(true);
+      expect(resolveEmbeddedValue({ entry: completedEntry }, sparseResponse)).toBe(false);
+    });
+
+    test("resolves a Date-backed date field to its ISO string", () => {
+      expect(resolveEmbeddedValue({ entry: startedAtEntry }, response)).toBe("2026-08-01T09:00:00.000Z");
+    });
+
+    test("returns undefined when the accessor finds nothing (no default tier for reserved)", () => {
+      expect(resolveEmbeddedValue({ entry: countryEntry }, sparseResponse)).toBeUndefined();
+      expect(resolveEmbeddedValue({ entry: totalTimeEntry }, sparseResponse)).toBeUndefined();
+      expect(resolveEmbeddedValue({ entry: languageEntry }, sparseResponse)).toBeUndefined();
+    });
+
+    test("returns undefined for a stored row that claims source reserved", () => {
+      // ZEmbeddedData rejects such rows; this arm only defends against data that skipped the schema.
+      const field = makeField({ source: "reserved", defaultValue: "should-not-surface" });
+      expect(resolve(field, "plan")).toBeUndefined();
+    });
+  });
+
+  describe("locked ingested fields", () => {
+    test("resolve to the default even when data holds a value", () => {
+      const field = makeField({ locked: true, defaultValue: "enterprise" });
+      expect(resolve(field, "plan")).toBe("enterprise");
+    });
+
+    test("resolve to undefined when locked with no default, ignoring the stored value", () => {
+      const field = makeField({ locked: true, defaultValue: null });
+      expect(resolve(field, "plan")).toBeUndefined();
+    });
+
+    test("locked is ignored for computed fields, which never receive outside writes", () => {
+      const field = makeField({ source: "computed", dataType: "number", locked: true, defaultValue: 0 });
+      expect(resolve(field, SCORE_VARIABLE_ID)).toBe(42);
+    });
+  });
+
+  describe("missing values fall back to defaultValue, then to undefined", () => {
+    test("missing ingested value returns the default", () => {
+      const field = makeField({ defaultValue: "fallback" });
+      expect(resolve(field, "not-captured")).toBe("fallback");
+    });
+
+    test("missing ingested value with a null default returns undefined", () => {
+      expect(resolve(makeField(), "not-captured")).toBeUndefined();
+    });
+
+    test("missing computed value returns the default", () => {
+      const field = makeField({ source: "computed", dataType: "number", defaultValue: 0 });
+      expect(resolve(field, "clx0000000000000000000v9")).toBe(0);
+    });
+
+    test("an uncoercible stored value is treated as missing and falls to the default", () => {
+      const field = makeField({ dataType: "number", defaultValue: 7 });
+      expect(resolve(field, "bad_number")).toBe(7);
+    });
+
+    test("an uncoercible stored value with a null default returns undefined", () => {
+      const field = makeField({ dataType: "number", defaultValue: null });
+      expect(resolve(field, "bad_number")).toBeUndefined();
+    });
+
+    test("a default that cannot be coerced to the dataType resolves to undefined", () => {
+      // The schema forbids a mismatched default, so this only occurs for unparsed input — the
+      // resolver still keeps its contract: the result agrees with dataType or is undefined.
+      const field = makeField({ dataType: "number", defaultValue: "not-a-number" });
+      expect(resolve(field, "not-captured")).toBeUndefined();
+    });
+  });
+
+  describe("non-scalar response data (shared map with question answers)", () => {
+    test("a string[] answer under the storage key is treated as missing", () => {
+      const field = makeField({ defaultValue: "fallback" });
+      expect(resolve(field, "multi")).toBe("fallback");
+    });
+
+    test("a record answer under the storage key is treated as missing", () => {
+      expect(resolve(makeField(), "matrix")).toBeUndefined();
+    });
+  });
+
+  test("a mixed field/link/entry shape is unrepresentable at compile time", () => {
+    const acceptsRef = (ref: TEmbeddedValueRef): TEmbeddedValueRef => ref;
+    const mixed = { field: makeField(), link: { storageKey: "plan" }, entry: countryEntry };
+
+    // @ts-expect-error — the `?: never` exclusion props reject a ref that is both shapes at once,
+    // so the resolver never has to pick a winner silently. Fails typecheck if the props are removed.
+    acceptsRef(mixed);
+
+    // The exclusion props must not tax the two legitimate shapes.
+    expect(acceptsRef({ field: makeField(), link: { storageKey: "plan" } })).toBeTruthy();
+    expect(acceptsRef({ entry: countryEntry })).toBeTruthy();
+  });
+});
+
+describe("coerceToEmbeddedDataType", () => {
+  describe("string", () => {
+    test.each([
+      ["hello", "hello"],
+      ["", ""],
+      [42, "42"],
+      [true, "true"],
+      [false, "false"],
+    ])("coerces %p to %p", (input, expected) => {
+      expect(coerceToEmbeddedDataType(input, "string")).toBe(expected);
+    });
+
+    test("coerces a Date to its ISO string", () => {
+      expect(coerceToEmbeddedDataType(new Date("2026-08-01T09:00:00.000Z"), "string")).toBe(
+        "2026-08-01T09:00:00.000Z"
+      );
+    });
+
+    test.each([[["a", "b"]], [{ row1: "col1" }], [null], [undefined], [Number.NaN]])(
+      "rejects %p",
+      (input) => {
+        expect(coerceToEmbeddedDataType(input, "string")).toBeUndefined();
+      }
+    );
+  });
+
+  describe("number", () => {
+    test.each([
+      [42, 42],
+      [3.14, 3.14],
+      ["42", 42],
+      [" 7 ", 7],
+      ["-1.5", -1.5],
+      ["0", 0],
+    ])("coerces %p to %p", (input, expected) => {
+      expect(coerceToEmbeddedDataType(input, "number")).toBe(expected);
+    });
+
+    test.each<[unknown, string]>([
+      ["", 'empty string — Number("") === 0 is an artifact, not data'],
+      ["   ", "blank string"],
+      ["abc", "non-numeric string"],
+      [true, "boolean"],
+      [Number.NaN, "NaN"],
+      [Number.POSITIVE_INFINITY, "Infinity"],
+      [new Date("2026-08-01"), "Date"],
+      [["1"], "array"],
+    ])("rejects %p (%s)", (input) => {
+      expect(coerceToEmbeddedDataType(input, "number")).toBeUndefined();
+    });
+  });
+
+  describe("boolean", () => {
+    test.each([
+      [true, true],
+      [false, false],
+      ["true", true],
+      ["TRUE", true],
+      [" False ", false],
+    ])("coerces %p to %p", (input, expected) => {
+      expect(coerceToEmbeddedDataType(input, "boolean")).toBe(expected);
+    });
+
+    test.each<[unknown, string]>([
+      ["1", "numeric string — truthiness guessing is write-side ingest policy"],
+      ["yes", "colloquial truthy string"],
+      ["", "empty string"],
+      [1, "number"],
+      [0, "number"],
+    ])("rejects %p (%s)", (input) => {
+      expect(coerceToEmbeddedDataType(input, "boolean")).toBeUndefined();
+    });
+  });
+
+  describe("date", () => {
+    test("keeps an ISO date string as-is, not promoted to a midnight datetime", () => {
+      expect(coerceToEmbeddedDataType("2026-08-06", "date")).toBe("2026-08-06");
+    });
+
+    test("keeps an ISO datetime string as-is", () => {
+      expect(coerceToEmbeddedDataType("2026-08-06T10:30:00Z", "date")).toBe("2026-08-06T10:30:00Z");
+    });
+
+    test("coerces a Date instance to its ISO string", () => {
+      expect(coerceToEmbeddedDataType(new Date("2026-08-06T10:30:00.000Z"), "date")).toBe(
+        "2026-08-06T10:30:00.000Z"
+      );
+    });
+
+    test("rejects an invalid Date instance", () => {
+      expect(coerceToEmbeddedDataType(new Date("banana"), "date")).toBeUndefined();
+    });
+
+    test.each<[unknown, string]>([
+      ["banana", "non-date string"],
+      ["42", "would year-parse via new Date, which is not a date the user stored"],
+      ["2026-13-45", "impossible calendar date"],
+      ["06.08.2026", "non-ISO format — write-side coercion (ENG-1845) normalizes formats"],
+      [1_723_000_000_000, "epoch number"],
+      [true, "boolean"],
+    ])("rejects %p (%s)", (input) => {
+      expect(coerceToEmbeddedDataType(input, "date")).toBeUndefined();
+    });
+  });
+});
+
+describe("projectReservedValues", () => {
+  test("projects catalog entries into a name-keyed map, omitting absent values", () => {
+    const projected = projectReservedValues(
+      [browserEntry, totalTimeEntry, languageEntry, completedEntry, actionEntry],
+      response
+    );
+
+    expect(projected).toStrictEqual({
+      browser: "Chrome",
+      total_time: 30_000,
+      response_language: "de",
+      // Booleans are stringified: the recall/logic maps have no boolean slot.
+      completed: "true",
+    });
+    // meta.action was never captured, so the key must be absent — not null, not "".
+    expect("action" in projected).toBe(false);
+  });
+
+  test("the projected map merges into the maps recall and logic already read", () => {
+    const projected = projectReservedValues([browserEntry, totalTimeEntry], response);
+
+    // Compile-time fit: assignable to both existing lookup-map types.
+    const asVariables: TResponseVariables = projected;
+    const asData: TResponseData = projected;
+
+    // Runtime fit: a merged map serves reserved values through plain key lookup, the only access
+    // pattern replaceRecallInfo / getLeftOperandValue use.
+    const mergedVariables = { ...response.variables, ...asVariables };
+    expect(mergedVariables.browser).toBe("Chrome");
+    expect(mergedVariables[SCORE_VARIABLE_ID]).toBe(42);
+    expect(asData.total_time).toBe(30_000);
+  });
+
+  test("projects an empty map when nothing was captured", () => {
+    expect(projectReservedValues([countryEntry, totalTimeEntry], sparseResponse)).toStrictEqual({});
+  });
+
+  test("the production catalog is empty until ENG-1839 and projects to an empty map", () => {
+    expect(RESERVED_FIELD_CATALOG).toHaveLength(0);
+    expect(projectReservedValues(RESERVED_FIELD_CATALOG, response)).toStrictEqual({});
+  });
+});
+
+describe("listReadableFields", () => {
+  const blocks: TSurveyBlocks = [
+    {
+      id: "clx0000000000000000000b1",
+      name: "Block 1",
+      elements: [
+        {
+          id: "q1",
+          type: TSurveyElementTypeEnum.OpenText,
+          headline: { default: "What is your name?" },
+          required: false,
+          inputType: "text",
+          charLimit: { enabled: false },
+        },
+        {
+          id: "q2",
+          type: TSurveyElementTypeEnum.OpenText,
+          headline: { default: "<p>Rate <b>us</b></p>" },
+          required: false,
+          inputType: "text",
+          charLimit: { enabled: false },
+        },
+      ],
+    },
+    {
+      id: "clx0000000000000000000b2",
+      name: "Block 2",
+      elements: [
+        {
+          id: "q3",
+          type: TSurveyElementTypeEnum.OpenText,
+          headline: { default: "#recall:q1/fallback:there# how are you?" },
+          required: false,
+          inputType: "text",
+          charLimit: { enabled: false },
+        },
+        {
+          id: "q4",
+          type: TSurveyElementTypeEnum.OpenText,
+          headline: { default: "" },
+          required: false,
+          inputType: "text",
+          charLimit: { enabled: false },
+        },
+        {
+          id: "q5",
+          type: TSurveyElementTypeEnum.OpenText,
+          headline: { default: "How likely?", de: "Wie wahrscheinlich?" },
+          required: false,
+          inputType: "text",
+          charLimit: { enabled: false },
+        },
+      ],
+    },
+  ];
+
+  const embeddedDataPairs: TLinkedEmbeddedField[] = [
+    {
+      field: makeField({ name: "Score", source: "computed", dataType: "number", defaultValue: 0 }),
+      link: { storageKey: SCORE_VARIABLE_ID },
+    },
+    { field: makeField({ name: "Plan" }), link: { storageKey: "plan" } },
+  ];
+
+  test("returns all four groups, each entry keyed by its reference key", () => {
+    const fields = listReadableFields({
+      blocks,
+      embeddedData: embeddedDataPairs,
+      reservedEntries: [countryEntry, totalTimeEntry],
+      contactAttributeKeys: [
+        { key: "email", name: "Email address" },
+        { key: "user_id", name: null },
+      ],
+    });
+
+    expect(fields.question.map((field) => field.key)).toEqual(["q1", "q2", "q3", "q4", "q5"]);
+    expect(fields.embeddedData).toEqual([
+      { key: SCORE_VARIABLE_ID, label: "Score" },
+      { key: "plan", label: "Plan" },
+    ]);
+    expect(fields.reserved).toEqual([
+      { key: "country", label: "Country" },
+      { key: "total_time", label: "Total Time" },
+    ]);
+    expect(fields.contactAttribute).toEqual([
+      { key: "email", label: "Email address" },
+      { key: "user_id", label: "user_id" },
+    ]);
+  });
+
+  test("question labels come from headlines: HTML stripped, recall flattened, empty falls back to id", () => {
+    const fields = listReadableFields({
+      blocks,
+      embeddedData: [],
+      reservedEntries: [],
+      contactAttributeKeys: [],
+    });
+
+    expect(fields.question).toEqual([
+      { key: "q1", label: "What is your name?" },
+      { key: "q2", label: "Rate us" },
+      { key: "q3", label: "___ how are you?" },
+      { key: "q4", label: "q4" },
+      { key: "q5", label: "How likely?" },
+    ]);
+  });
+
+  test("resolves headlines for the requested language, falling back to default", () => {
+    const fields = listReadableFields({
+      blocks,
+      embeddedData: [],
+      reservedEntries: [],
+      contactAttributeKeys: [],
+      languageCode: "de",
+    });
+
+    const q5 = fields.question.find((field) => field.key === "q5");
+    const q1 = fields.question.find((field) => field.key === "q1");
+    expect(q5?.label).toBe("Wie wahrscheinlich?");
+    expect(q1?.label).toBe("What is your name?");
+  });
+
+  test("embedded data labels fall back to the storageKey when the definition name is blank", () => {
+    // ZEmbeddedData forbids blank names, but derived legacy pairs carry plain variable names.
+    const fields = listReadableFields({
+      blocks: [],
+      embeddedData: [{ field: makeField({ name: "   " }), link: { storageKey: "plan" } }],
+      reservedEntries: [],
+      contactAttributeKeys: [],
+    });
+
+    expect(fields.embeddedData).toEqual([{ key: "plan", label: "plan" }]);
+  });
+
+  test("contact attribute labels fall back to the key when the name is blank", () => {
+    const fields = listReadableFields({
+      blocks: [],
+      embeddedData: [],
+      reservedEntries: [],
+      contactAttributeKeys: [{ key: "user_id", name: "" }],
+    });
+
+    expect(fields.contactAttribute).toEqual([{ key: "user_id", label: "user_id" }]);
+  });
+
+  test("returns four empty groups for empty inputs", () => {
+    const fields = listReadableFields({
+      blocks: [],
+      embeddedData: [],
+      reservedEntries: [],
+      contactAttributeKeys: [],
+    });
+
+    expect(fields).toStrictEqual({ question: [], embeddedData: [], reserved: [], contactAttribute: [] });
+  });
+});
+
+describe("deriveLegacyEmbeddedData", () => {
+  const legacySurvey = {
+    variables: [
+      { id: "clx0000000000000000000v1", name: "score", type: "number" as const, value: 10 },
+      { id: "clx0000000000000000000v3", name: "plan_name", type: "text" as const, value: "basic" },
+    ],
+    hiddenFields: { enabled: true, fieldIds: ["source_page", "Coupon-Code"] },
+  };
+
+  test("maps a variable to a computed field addressed by its existing cuid", () => {
+    const [scorePair] = deriveLegacyEmbeddedData(legacySurvey);
+    expect(scorePair).toStrictEqual({
+      field: { name: "score", source: "computed", dataType: "number", defaultValue: 10, locked: false },
+      link: { storageKey: "clx0000000000000000000v1" },
+    });
+  });
+
+  test("maps a text variable to a string field with its value as default", () => {
+    const pairs = deriveLegacyEmbeddedData(legacySurvey);
+    expect(pairs[1]).toStrictEqual({
+      field: {
+        name: "plan_name",
+        source: "computed",
+        dataType: "string",
+        defaultValue: "basic",
+        locked: false,
+      },
+      link: { storageKey: "clx0000000000000000000v3" },
+    });
+  });
+
+  test("maps hidden fields to ingested string fields addressed by name, keeping legacy spellings", () => {
+    const pairs = deriveLegacyEmbeddedData(legacySurvey);
+    expect(pairs.slice(2)).toStrictEqual([
+      {
+        field: {
+          name: "source_page",
+          source: "ingested",
+          dataType: "string",
+          defaultValue: null,
+          locked: false,
+        },
+        link: { storageKey: "source_page" },
+      },
+      {
+        field: {
+          name: "Coupon-Code",
+          source: "ingested",
+          dataType: "string",
+          defaultValue: null,
+          locked: false,
+        },
+        link: { storageKey: "Coupon-Code" },
+      },
+    ]);
+  });
+
+  test("derives declared hidden fields even when hiddenFields is disabled", () => {
+    // Recall and logic consult fieldIds alone today; a disabled field just never receives a value.
+    const pairs = deriveLegacyEmbeddedData({
+      variables: [],
+      hiddenFields: { enabled: false, fieldIds: ["plan"] },
+    });
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].link.storageKey).toBe("plan");
+  });
+
+  test("handles absent fieldIds and fully empty declarations", () => {
+    expect(deriveLegacyEmbeddedData({ variables: [], hiddenFields: { enabled: true } })).toEqual([]);
+    expect(
+      deriveLegacyEmbeddedData({ variables: [], hiddenFields: { enabled: false, fieldIds: [] } })
+    ).toEqual([]);
+  });
+
+  test("derived pairs resolve end-to-end through resolveEmbeddedValue", () => {
+    const pairs = deriveLegacyEmbeddedData(legacySurvey);
+
+    // The variable's value arrives under its cuid in response.variables.
+    expect(resolveEmbeddedValue(pairs[0], response)).toBe(42);
+    // No stored value → the variable's declared value serves as the default.
+    expect(resolveEmbeddedValue(pairs[0], sparseResponse)).toBe(10);
+    // Hidden fields read response.data under their name; absent ones stay unset (null default).
+    expect(resolveEmbeddedValue(pairs[2], sparseResponse)).toBeUndefined();
+  });
+
+  test("derived pairs enumerate through listReadableFields keyed by storageKey", () => {
+    const fields = listReadableFields({
+      blocks: [],
+      embeddedData: deriveLegacyEmbeddedData(legacySurvey),
+      reservedEntries: [],
+      contactAttributeKeys: [],
+    });
+
+    expect(fields.embeddedData).toEqual([
+      { key: "clx0000000000000000000v1", label: "score" },
+      { key: "clx0000000000000000000v3", label: "plan_name" },
+      { key: "source_page", label: "source_page" },
+      { key: "Coupon-Code", label: "Coupon-Code" },
+    ]);
+  });
+});

--- a/packages/types/embedded-data-resolver.test.ts
+++ b/packages/types/embedded-data-resolver.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { ZEmbeddedData } from "./embedded-data";
 import {
   RESERVED_FIELD_CATALOG,
   type TEmbeddedValueRef,
@@ -11,6 +12,7 @@ import {
   projectReservedValues,
   resolveEmbeddedValue,
 } from "./embedded-data-resolver";
+import type { TI18nString } from "./i18n";
 import type { TResponseData, TResponseVariables } from "./responses";
 import type { TSurveyBlocks } from "./surveys/blocks";
 import { TSurveyElementTypeEnum } from "./surveys/elements";
@@ -204,6 +206,18 @@ describe("resolveEmbeddedValue", () => {
       const field = makeField({ source: "reserved", defaultValue: "should-not-surface" });
       expect(resolve(field, "plan")).toBeUndefined();
     });
+
+    test("a throwing accessor reads as missing instead of crashing the resolve", () => {
+      const hostnameEntry: TReservedFieldCatalogEntry = {
+        name: "hostname",
+        dataType: "string",
+        read: (r) => new URL(r.meta.url ?? "").hostname,
+      };
+      // sparseResponse has no meta.url, so the accessor throws on `new URL("")` — the resolver must
+      // treat that like every other dirty input: one field unset, no exception escaping.
+      expect(resolveEmbeddedValue({ entry: hostnameEntry }, sparseResponse)).toBeUndefined();
+      expect(resolveEmbeddedValue({ entry: hostnameEntry }, response)).toBe("example.com");
+    });
   });
 
   describe("locked ingested fields", () => {
@@ -268,6 +282,9 @@ describe("resolveEmbeddedValue", () => {
   });
 
   test("a mixed field/link/entry shape is unrepresentable at compile time", () => {
+    // This pin is enforced by `tsc` (this package's tsconfig includes *.test.ts, and an unused
+    // expect-error directive fails the build), NOT by vitest — no CI workflow currently runs
+    // typecheck, so the pin bites on local and agent `pnpm typecheck` runs only.
     const acceptsRef = (ref: TEmbeddedValueRef): TEmbeddedValueRef => ref;
     const mixed = { field: makeField(), link: { storageKey: "plan" }, entry: countryEntry };
 
@@ -278,6 +295,13 @@ describe("resolveEmbeddedValue", () => {
     // The exclusion props must not tax the two legitimate shapes.
     expect(acceptsRef({ field: makeField(), link: { storageKey: "plan" } })).toBeTruthy();
     expect(acceptsRef({ entry: countryEntry })).toBeTruthy();
+  });
+
+  test("a degenerate ref carrying entry: undefined resolves through its field, not the entry branch", () => {
+    // The discriminator is definedness, not key presence — a `"entry" in ref` check would route
+    // this object into the entry branch and crash on `undefined.read`.
+    const ref: TEmbeddedValueRef = { field: makeField(), link: { storageKey: "plan" }, entry: undefined };
+    expect(resolveEmbeddedValue(ref, response)).toBe("premium");
   });
 });
 
@@ -305,6 +329,10 @@ describe("coerceToEmbeddedDataType", () => {
         expect(coerceToEmbeddedDataType(input, "string")).toBeUndefined();
       }
     );
+
+    test("rejects an invalid Date instance instead of throwing on toISOString", () => {
+      expect(coerceToEmbeddedDataType(new Date("banana"), "string")).toBeUndefined();
+    });
   });
 
   describe("number", () => {
@@ -323,6 +351,7 @@ describe("coerceToEmbeddedDataType", () => {
       ["", 'empty string — Number("") === 0 is an artifact, not data'],
       ["   ", "blank string"],
       ["abc", "non-numeric string"],
+      ["25 seats", "partially numeric string — parseFloat would invent 25 where Number rejects"],
       [true, "boolean"],
       [Number.NaN, "NaN"],
       [Number.POSITIVE_INFINITY, "Infinity"],
@@ -384,6 +413,41 @@ describe("coerceToEmbeddedDataType", () => {
     ])("rejects %p (%s)", (input) => {
       expect(coerceToEmbeddedDataType(input, "date")).toBeUndefined();
     });
+
+    test("accepts exactly the strings ZEmbeddedData accepts as date defaults — the two rules must not drift", () => {
+      // Both files declare the ISO rule privately on purpose (each owns its side); this corpus is
+      // the pin that keeps them the same rule. If either side alone gains offset/local acceptance,
+      // a stored default becomes unresolvable (or vice versa) and this goes red.
+      const dateDefaultRow = (defaultValue: string) => ({
+        id: "clx0000000000000000000e1",
+        createdAt: new Date("2026-08-01T09:00:00.000Z"),
+        updatedAt: new Date("2026-08-01T09:00:00.000Z"),
+        key: null,
+        name: "Signup date",
+        description: null,
+        source: "ingested",
+        dataType: "date",
+        defaultValue,
+        locked: false,
+        surveyId: "clx0000000000000000000s1",
+        workspaceId: "clx0000000000000000000w1",
+      });
+
+      const corpus = [
+        "2026-08-06",
+        "2026-08-06T10:30:00Z",
+        "2026-08-06T10:30:00.123Z",
+        "2026-08-06T10:30:00+02:00",
+        "2026-08-06T10:30:00",
+        " 2026-08-06",
+      ];
+
+      for (const candidate of corpus) {
+        const rowAccepts = ZEmbeddedData.safeParse(dateDefaultRow(candidate)).success;
+        const readAccepts = coerceToEmbeddedDataType(candidate, "date") !== undefined;
+        expect({ candidate, readAccepts }).toStrictEqual({ candidate, readAccepts: rowAccepts });
+      }
+    });
   });
 });
 
@@ -422,6 +486,59 @@ describe("projectReservedValues", () => {
 
   test("projects an empty map when nothing was captured", () => {
     expect(projectReservedValues([countryEntry, totalTimeEntry], sparseResponse)).toStrictEqual({});
+  });
+
+  test("projects through the resolver's coercion — a Date-backed entry lands as its ISO string", () => {
+    // The one entry kind where resolving differs from the raw read: a raw `Date` must never reach
+    // the recall/logic maps.
+    expect(projectReservedValues([startedAtEntry], response)).toStrictEqual({
+      started_at: "2026-08-01T09:00:00.000Z",
+    });
+  });
+
+  test("omits an entry whose raw value cannot be coerced to its dataType", () => {
+    const miscastEntry: TReservedFieldCatalogEntry = {
+      name: "total_time",
+      dataType: "number",
+      read: (r) => r.meta.source, // "web" — present, but not a number; projecting it would invent data
+    };
+    expect(projectReservedValues([miscastEntry], response)).toStrictEqual({});
+  });
+
+  test("keeps falsy-but-present values: false stringifies, empty string and zero stay in the map", () => {
+    const emptySourceEntry: TReservedFieldCatalogEntry = {
+      name: "empty_source",
+      dataType: "string",
+      read: () => "",
+    };
+    const zeroTimeEntry: TReservedFieldCatalogEntry = {
+      name: "zero_time",
+      dataType: "number",
+      read: () => 0,
+    };
+
+    // sparseResponse has finished: false — a value, not a gap, exactly like "" and 0.
+    expect(
+      projectReservedValues([completedEntry, emptySourceEntry, zeroTimeEntry], sparseResponse)
+    ).toStrictEqual({
+      completed: "false",
+      empty_source: "",
+      zero_time: 0,
+    });
+  });
+
+  test("a throwing accessor is skipped without aborting the rest of the catalog", () => {
+    const hostnameEntry: TReservedFieldCatalogEntry = {
+      name: "hostname",
+      dataType: "string",
+      read: (r) => new URL(r.meta.url ?? "").hostname,
+    };
+
+    // meta emptied: the hostname accessor throws on `new URL("")`, and the entries after it must
+    // still be evaluated.
+    expect(projectReservedValues([hostnameEntry, languageEntry], { ...response, meta: {} })).toStrictEqual({
+      response_language: "de",
+    });
   });
 
   test("the production catalog is empty until ENG-1839 and projects to an empty map", () => {
@@ -552,6 +669,80 @@ describe("listReadableFields", () => {
     expect(q1?.label).toBe("What is your name?");
   });
 
+  const singleElementBlocks = (elementId: string, headline: TI18nString): TSurveyBlocks => [
+    {
+      id: "clx0000000000000000000b3",
+      name: "Block",
+      elements: [
+        {
+          id: elementId,
+          type: TSurveyElementTypeEnum.OpenText,
+          headline,
+          required: false,
+          inputType: "text",
+          charLimit: { enabled: false },
+        },
+      ],
+    },
+  ];
+
+  test("a blank locale entry falls back to the default headline, not to a blank label", () => {
+    // Blank locale entries are a real stored shape; today's apps/web picker labels this case with
+    // the bare element id (its getLocalizedValue has no default fallback) — this pins the improved,
+    // packages/surveys-style semantics the module documents.
+    const fields = listReadableFields({
+      blocks: singleElementBlocks("q6", { default: "How likely?", de: "" }),
+      embeddedData: [],
+      reservedEntries: [],
+      contactAttributeKeys: [],
+      languageCode: "de",
+    });
+
+    expect(fields.question).toEqual([{ key: "q6", label: "How likely?" }]);
+  });
+
+  test("flattens every recall token in a headline, not only the first", () => {
+    const fields = listReadableFields({
+      blocks: singleElementBlocks("q7", {
+        default: "#recall:q1/fallback:a# and #recall:q2/fallback:b#",
+      }),
+      embeddedData: [],
+      reservedEntries: [],
+      contactAttributeKeys: [],
+    });
+
+    expect(fields.question).toEqual([{ key: "q7", label: "___ and ___" }]);
+  });
+
+  test("a non-string default in unparsed survey JSON degrades to the id fallback instead of throwing", () => {
+    // prisma-json-types reads skip zod, so dirty i18n objects are representable at runtime.
+    const dirtyHeadline = { default: 42 } as unknown as TI18nString;
+    const fields = listReadableFields({
+      blocks: singleElementBlocks("q8", dirtyHeadline),
+      embeddedData: [],
+      reservedEntries: [],
+      contactAttributeKeys: [],
+    });
+
+    expect(fields.question).toEqual([{ key: "q8", label: "q8" }]);
+  });
+
+  test("reserved labels fall back to the entry name when title-casing yields nothing", () => {
+    const underscoreEntry: TReservedFieldCatalogEntry = {
+      name: "_",
+      dataType: "string",
+      read: () => undefined,
+    };
+    const fields = listReadableFields({
+      blocks: [],
+      embeddedData: [],
+      reservedEntries: [underscoreEntry],
+      contactAttributeKeys: [],
+    });
+
+    expect(fields.reserved).toEqual([{ key: "_", label: "_" }]);
+  });
+
   test("embedded data labels fall back to the storageKey when the definition name is blank", () => {
     // ZEmbeddedData forbids blank names, but derived legacy pairs carry plain variable names.
     const fields = listReadableFields({
@@ -645,7 +836,8 @@ describe("deriveLegacyEmbeddedData", () => {
   });
 
   test("derives declared hidden fields even when hiddenFields is disabled", () => {
-    // Recall and logic consult fieldIds alone today; a disabled field just never receives a value.
+    // Recall and logic consult fieldIds alone today — and the link-survey URL path ingests values
+    // even when disabled — so deriving must not hide fields that may hold data.
     const pairs = deriveLegacyEmbeddedData({
       variables: [],
       hiddenFields: { enabled: false, fieldIds: ["plan"] },

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import type { TContactAttributeKey } from "./contact-attribute-key";
 import type { TEmbeddedData, TEmbeddedDataType, TSurveyEmbeddedData } from "./embedded-data";
+import { toDesiredEmbeddedFields } from "./embedded-data-mapping";
 import type { TI18nString } from "./i18n";
 import type { TResponse } from "./responses";
 import { formatSnakeCaseToTitleCase } from "./safe-identifier";
@@ -278,6 +279,9 @@ export const resolveEmbeddedValue = (
  * maps: absent values are omitted (recall then falls back to its fallback text and logic sees
  * `undefined`, exactly like an absent hidden field today), and booleans are stringified to
  * `"true"`/`"false"` — what `String()` would render anyway, in a map type that has no boolean slot.
+ *
+ * An entry name that matches an element id or hidden field name shadows it in the merged map, and
+ * `FORBIDDEN_IDS` guards none of the names §9b proposes — so ENG-1839 picks names knowing that.
  */
 export const projectReservedValues = (
   entries: readonly TReservedFieldCatalogEntry[],
@@ -329,7 +333,10 @@ export interface TListReadableFieldsInput {
   languageCode?: string;
 }
 
-/** Matches one full recall token (`#recall:<id>/fallback:<text>#`) — the editor's storage syntax. */
+/**
+ * Matches one full recall token (`#recall:<id>/fallback:<text>#`) — the editor's storage syntax.
+ * `.replace()` only: `.test()`/`.exec()` would carry `lastIndex` across calls on this shared instance.
+ */
 const RECALL_TOKEN_REGEX = /#recall:[A-Za-z0-9_-]+\/fallback:[^#]*#/g;
 
 /**
@@ -402,9 +409,10 @@ export const listReadableFields = (input: TListReadableFieldsInput): TReadableFi
  * ENG-1837 serve surveys whose rows haven't been backfilled (migration spec §8), with no fetch
  * logic here.
  *
- * Per §8: a variable becomes a `computed` field of its declared type whose `defaultValue` is the
- * variable's value, addressed by its existing cuid (recall tokens and stored responses already use
- * it); a hidden field becomes an `ingested` string field with no default, addressed by its name.
+ * The §8 rules live in `toDesiredEmbeddedFields`, shared with ENG-1978's write bridge and ENG-1835's
+ * backfill; this only reshapes them into `{field, link}` pairs and adds `locked: false`, which has no
+ * legacy equivalent.
+ *
  * `hiddenFields.enabled` is deliberately ignored: recall and logic consult `fieldIds` alone today,
  * and ingestion is split on the flag — the js-core SDK drops hidden fields when disabled, while the
  * link-survey URL path fills them regardless (`getHiddenFieldsFromSearchParams` receives only
@@ -414,32 +422,8 @@ export const listReadableFields = (input: TListReadableFieldsInput): TReadableFi
 export const deriveLegacyEmbeddedData = (survey: {
   variables: TSurveyVariables;
   hiddenFields: TSurveyHiddenFields;
-}): TLinkedEmbeddedField[] => {
-  const fromVariables = survey.variables.map(
-    (variable): TLinkedEmbeddedField => ({
-      field: {
-        name: variable.name,
-        source: "computed",
-        dataType: variable.type === "number" ? "number" : "string",
-        defaultValue: variable.value,
-        locked: false,
-      },
-      link: { storageKey: variable.id },
-    })
-  );
-
-  const fromHiddenFields = (survey.hiddenFields.fieldIds ?? []).map(
-    (fieldId): TLinkedEmbeddedField => ({
-      field: {
-        name: fieldId,
-        source: "ingested",
-        dataType: "string",
-        defaultValue: null,
-        locked: false,
-      },
-      link: { storageKey: fieldId },
-    })
-  );
-
-  return [...fromVariables, ...fromHiddenFields];
-};
+}): TLinkedEmbeddedField[] =>
+  toDesiredEmbeddedFields(survey).map(({ storageKey, ...field }) => ({
+    field: { ...field, locked: false },
+    link: { storageKey },
+  }));

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -10,9 +10,13 @@ import { getTextContent } from "./surveys/validation";
 
 /**
  * What a resolved Embedded Data value can be. A `date` field resolves to its ISO 8601 string, not a
- * `Date` — recall and logic operate on strings and numbers, and recall already date-formats ISO
- * strings for display. Booleans exist only for reserved fields (e.g. `finished`); the projection
- * into the recall/logic maps stringifies them, see {@link projectReservedValues}.
+ * `Date` — machine-facing values stay ISO/UTC; display formatting is the consumer's job. One gap to
+ * inherit consciously (ENG-1837/1839): today's recall formatters recognize date-ONLY strings
+ * (`isValidDateString` in packages/surveys; `formatStoredDateForDisplay` in apps/web, which runs
+ * only on the responseData branch), so a datetime resolved from a `Date` renders verbatim until the
+ * consumers learn to format it. Booleans come from `boolean`-dataType stored fields (legal on
+ * ingested rows) as well as reserved reads; {@link projectReservedValues} stringifies them for the
+ * recall/logic maps, and direct resolver callers own their own boolean handling.
  */
 export type TResolvedEmbeddedValue = string | number | boolean;
 
@@ -60,7 +64,11 @@ export interface TReservedFieldCatalogEntry {
    */
   name: string;
   dataType: TEmbeddedDataType;
-  /** Reads the raw value off a response. Coercion to `dataType` is the resolver's job, not the accessor's. */
+  /**
+   * Reads the raw value off a response. Coercion to `dataType` is the resolver's job, not the
+   * accessor's. Accessors should be total functions; one that throws is treated as "nothing
+   * captured" by the resolver rather than crashing the caller.
+   */
   read: (response: TEmbeddedValueResponse) => TReservedFieldRawValue;
 }
 
@@ -136,10 +144,14 @@ const ZIsoDateOrDateTime = z.union([z.iso.date(), z.iso.datetime()]);
  * - `boolean`: booleans, and exactly `"true"`/`"false"` (case-insensitive, trimmed) — the URL-param
  *   spelling. `1`/`"yes"`/`"on"` stay uncoercible: guessing truthiness is write-side ingest policy
  *   (ENG-1845), and the read seam must not resolve a value ingest would have rejected.
- * - `date`: `Date` instances become ISO strings; strings must already be ISO 8601 (date or
- *   datetime — the same rule `ZEmbeddedData` enforces on date defaults) and pass through as-is, so
- *   a date-only value is not silently promoted to a midnight-UTC datetime. Epoch numbers stay
- *   uncoercible — nothing upstream produces them intentionally.
+ * - `date`: `Date` instances become ISO strings; strings must be an ISO 8601 date (`2026-08-06`)
+ *   or UTC datetime (`2026-08-06T10:30:00Z`) — the exact subset `ZEmbeddedData` pins for date
+ *   defaults. That deliberately excludes offset (`+02:00`) and zone-less datetimes, and, unlike
+ *   the number and boolean arms, tolerates no surrounding whitespace — write-side ingest
+ *   (ENG-1845) must normalize to this same subset, or consciously widen both rules together.
+ *   Accepted strings pass through as-is, so a date-only value is not silently promoted to a
+ *   midnight-UTC datetime. Epoch numbers stay uncoercible — nothing upstream produces them
+ *   intentionally.
  */
 export const coerceToEmbeddedDataType = (
   value: unknown,
@@ -185,7 +197,8 @@ export const coerceToEmbeddedDataType = (
 /**
  * The single read seam for Embedded Data: returns one field's value from a response, or `undefined`
  * when the field has no value there. Every downstream surface (recall, logic, export, pickers)
- * reads through this so "where does a field's value live" is answered exactly once:
+ * will read through this once ENG-1837 repoints them, so "where does a field's value live" is
+ * answered exactly once:
  *
  * - `computed` → `response.variables[storageKey]` (written by the logic engine)
  * - `ingested` → `response.data[storageKey]` (written from URL params / SDK)
@@ -212,6 +225,13 @@ export const coerceToEmbeddedDataType = (
  * (b) Both recall paths (`replaceRecallInfo` in packages/surveys, `parseRecallInfo` in apps/web)
  *     render whatever sits in the lookup maps with no dataType awareness, so the same stored
  *     `"abc"` renders verbatim in recall today — here it resolves to defaultValue-or-`undefined`.
+ * (c) On a key present in both maps, today's consumers disagree with each other —
+ *     `replaceRecallInfo` lets `responseData` win (its data check runs last), `parseRecallInfo`
+ *     lets `variables` win (checked first). Here the declared source is exclusive: computed reads
+ *     only `variables`, ingested reads only `data`.
+ * (d) A response missing a variable's key entirely (stored before the variable was added, or
+ *     API-created) is `0` / `""` to logic and fallback text to recall today — here it resolves to
+ *     the field's `defaultValue`, which for §8-derived pairs is the variable's declared value.
  */
 export const resolveEmbeddedValue = (
   ref: TEmbeddedValueRef,
@@ -221,7 +241,14 @@ export const resolveEmbeddedValue = (
   // from narrowing the union, and this way a degenerate `{ field, link, entry: undefined }` object
   // still resolves through its field instead of crashing on `undefined.read`.
   if (ref.entry !== undefined) {
-    return coerceToEmbeddedDataType(ref.entry.read(response), ref.entry.dataType);
+    // A throwing accessor reads as missing rather than escalating: one dirty response row fed to a
+    // computing accessor (e.g. URL parsing) must degrade like every other dirty input here — one
+    // field unset — not abort a caller's whole render or export loop over the catalog.
+    try {
+      return coerceToEmbeddedDataType(ref.entry.read(response), ref.entry.dataType);
+    } catch {
+      return undefined;
+    }
   }
 
   const { field, link } = ref;
@@ -287,10 +314,10 @@ export interface TReadableFields {
 }
 
 /**
- * Inputs are explicit because none of them live on `TSurvey` today: the field/link pairs arrive
- * with ENG-1837, contact attribute keys are workspace-level, and the reserved catalog is code.
- * Passing them in keeps this pure and lets legacy surveys participate via
- * {@link deriveLegacyEmbeddedData}.
+ * Inputs are explicit: the field/link pairs don't live on `TSurvey` until ENG-1837 inlines them,
+ * contact attribute keys are workspace-level, the reserved catalog is code — and `blocks`, which
+ * does live on `TSurvey`, is taken alone so the function needs no survey object. Passing them in
+ * keeps this pure and lets legacy surveys participate via {@link deriveLegacyEmbeddedData}.
  */
 export interface TListReadableFieldsInput {
   /** The survey's blocks — elements live here (the legacy `questions` model is not enumerated). */
@@ -314,14 +341,18 @@ const RECALL_TOKEN_REGEX = /#recall:[A-Za-z0-9_-]+\/fallback:[^#]*#/g;
 const labelOrKey = (label: string, key: string): string => (label.trim() === "" ? key : label);
 
 /**
- * Headline → picker label. Mirrors what `getRecallItemLabel` (apps/web) produces: localized with
- * blank-falls-back-to-`default` semantics, HTML stripped so rich-text markup never shows raw, and
- * nested recall tokens flattened to `___` — a headline that recalls another answer would otherwise
- * leak storage syntax into the picker. Both steps are cheap (one parse, one regex pass).
+ * Headline → picker label: localized, HTML stripped so rich-text markup never shows raw, and recall
+ * tokens flattened to `___` so storage syntax never leaks into a picker (what the apps/web pickers
+ * achieve via `replaceRecallInfoWithUnderline`). Localization follows packages/surveys'
+ * `getLocalizedValue` — a blank or missing locale entry falls back to the `default` entry. That is
+ * deliberately NOT today's apps/web picker behavior, whose `getLocalizedValue` has no default
+ * fallback, so an untranslated headline labels there as the bare element id; ENG-1840/1853 inherit
+ * this as a conscious label improvement when they swap pickers onto {@link listReadableFields}.
  */
 const toElementLabel = (headline: TI18nString, languageCode: string): string => {
   const localized = headline[languageCode];
-  const raw = typeof localized === "string" && localized.trim() !== "" ? localized : (headline.default ?? "");
+  const fallback = typeof headline.default === "string" ? headline.default : "";
+  const raw = typeof localized === "string" && localized.trim() !== "" ? localized : fallback;
   return getTextContent(raw).replace(RECALL_TOKEN_REGEX, "___").trim();
 };
 
@@ -375,8 +406,10 @@ export const listReadableFields = (input: TListReadableFieldsInput): TReadableFi
  * variable's value, addressed by its existing cuid (recall tokens and stored responses already use
  * it); a hidden field becomes an `ingested` string field with no default, addressed by its name.
  * `hiddenFields.enabled` is deliberately ignored: recall and logic consult `fieldIds` alone today,
- * and a disabled field simply never receives a value — the resolver then reports it as unset, which
- * is the same behavior with honest mechanics.
+ * and ingestion is split on the flag — the js-core SDK drops hidden fields when disabled, while the
+ * link-survey URL path fills them regardless (`getHiddenFieldsFromSearchParams` receives only
+ * `fieldIds`). Deriving from `fieldIds` alone therefore preserves today's read behavior exactly:
+ * whatever either path stored still resolves, and what nothing stored reports as unset.
  */
 export const deriveLegacyEmbeddedData = (survey: {
   variables: TSurveyVariables;

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -1,0 +1,412 @@
+import { z } from "zod";
+import type { TContactAttributeKey } from "./contact-attribute-key";
+import type { TEmbeddedData, TEmbeddedDataType, TSurveyEmbeddedData } from "./embedded-data";
+import type { TI18nString } from "./i18n";
+import type { TResponse } from "./responses";
+import { formatSnakeCaseToTitleCase } from "./safe-identifier";
+import type { TSurveyBlocks } from "./surveys/blocks";
+import type { TSurveyHiddenFields, TSurveyVariables } from "./surveys/types";
+import { getTextContent } from "./surveys/validation";
+
+/**
+ * What a resolved Embedded Data value can be. A `date` field resolves to its ISO 8601 string, not a
+ * `Date` — recall and logic operate on strings and numbers, and recall already date-formats ISO
+ * strings for display. Booleans exist only for reserved fields (e.g. `finished`); the projection
+ * into the recall/logic maps stringifies them, see {@link projectReservedValues}.
+ */
+export type TResolvedEmbeddedValue = string | number | boolean;
+
+/**
+ * The slice of a response the read seam consumes. A full `TResponse` is assignable, but resolvers
+ * and reserved-catalog accessors are typed against this slice so they can never depend on fields
+ * the seam doesn't own (contact, tags, display bookkeeping) — and so tests and future callers that
+ * only hold partial data don't have to fabricate them.
+ */
+export type TEmbeddedValueResponse = Pick<
+  TResponse,
+  | "id"
+  | "surveyId"
+  | "createdAt"
+  | "updatedAt"
+  | "finished"
+  | "language"
+  | "data"
+  | "variables"
+  | "ttc"
+  | "meta"
+>;
+
+/**
+ * What a reserved-catalog accessor may return. Confined to scalars and `Date` on purpose: an entry
+ * that could return `meta` or `data` wholesale would leak objects into the value maps, and the
+ * compiler stops that here rather than a runtime check discovering it per response.
+ */
+export type TReservedFieldRawValue = string | number | boolean | Date | null | undefined;
+
+/**
+ * One reserved field: auto-captured system metadata every survey can reference without declaring
+ * anything (see `ZEmbeddedDataSource` — reserved fields are never stored as rows).
+ *
+ * The response location is a typed accessor rather than a dot-path string. Reserved fields are a
+ * static catalog in code, so the "path" can be code too — which makes an entry that points at a
+ * nonexistent response field a compile error instead of a silent `undefined`, and needs no
+ * path-walking machinery whose edge cases would have to be tested separately.
+ */
+export interface TReservedFieldCatalogEntry {
+  /**
+   * The key consumers reference the field by — the recall token id, the logic operand, the key in
+   * the projected value map. This is the "storageKey" of a reserved field, except nothing is
+   * stored: the name only ever addresses catalog reads.
+   */
+  name: string;
+  dataType: TEmbeddedDataType;
+  /** Reads the raw value off a response. Coercion to `dataType` is the resolver's job, not the accessor's. */
+  read: (response: TEmbeddedValueResponse) => TReservedFieldRawValue;
+}
+
+/**
+ * The production reserved-field catalog. Deliberately empty: ENG-1836 ships the mechanism, ENG-1839
+ * decides the contents. It exists now so call sites (ENG-1837) can wire
+ * `projectReservedValues(RESERVED_FIELD_CATALOG, response)` today and light up when the entries
+ * land, without another round of call-site changes.
+ */
+export const RESERVED_FIELD_CATALOG: readonly TReservedFieldCatalogEntry[] = [];
+
+/**
+ * The slice of a stored field definition the resolver needs — `TEmbeddedData` minus the ownership
+ * and bookkeeping columns. `source` stays the full enum even though `ZEmbeddedData` rejects
+ * `"reserved"` rows: narrowing it here would force every caller holding a parsed row to re-prove
+ * at runtime what the schema already guaranteed. A row that still claims `"reserved"` resolves to
+ * `undefined` (see {@link resolveEmbeddedValue}).
+ */
+export type TResolvableEmbeddedField = Pick<TEmbeddedData, "source" | "dataType" | "defaultValue" | "locked">;
+
+/** The slice of the survey link the read seam needs: the key the value is stored under in the response. */
+export type TEmbeddedDataLink = Pick<TSurveyEmbeddedData, "storageKey">;
+
+/**
+ * A reference to one embedded value on a response. Two shapes because the data model has two:
+ * a stored field is only addressable through the survey link that carries its `storageKey`, while
+ * a reserved field has no link and no storage — only a catalog entry. Modeling this as a union
+ * makes the mismatch unrepresentable: there is no way to hand the resolver a catalog entry with a
+ * storage key, or a stored field without one.
+ *
+ * The `?: never` exclusion props are what make that claim actually hold. Against a bare union,
+ * TypeScript's excess-property check admits keys from any constituent, so a mixed
+ * `{ field, link, entry }` object would compile and the resolver would have to pick a winner
+ * silently; with the exclusions it is a compile error instead.
+ */
+export type TEmbeddedValueRef =
+  | { field: TResolvableEmbeddedField; link: TEmbeddedDataLink; entry?: never }
+  | { entry: TReservedFieldCatalogEntry; field?: never; link?: never };
+
+/**
+ * A stored field definition paired with the survey link that addresses it — the unit
+ * {@link listReadableFields} enumerates and {@link deriveLegacyEmbeddedData} synthesizes. The pair
+ * is assignable to {@link TEmbeddedValueRef}, so whatever a caller lists it can also resolve,
+ * without repackaging.
+ */
+export interface TLinkedEmbeddedField {
+  field: TResolvableEmbeddedField & Pick<TEmbeddedData, "name">;
+  link: TEmbeddedDataLink;
+}
+
+/**
+ * Mirrors the date rule `ZEmbeddedData` pins for `date` default values (kept private there on
+ * purpose — this module owns read-side semantics, that one owns the row schema).
+ */
+const ZIsoDateOrDateTime = z.union([z.iso.date(), z.iso.datetime()]);
+
+/**
+ * Coerces a raw stored value to a field's `dataType`, returning `undefined` when the value cannot
+ * honestly represent one. This is the single vocabulary of read-side coercion — every tier of
+ * {@link resolveEmbeddedValue} (stored value, reserved read, default value) goes through it, so a
+ * resolved value always agrees with its declared `dataType` no matter which tier produced it.
+ *
+ * The rules, and why:
+ * - `null`, `undefined` and non-scalars (`string[]`, `Record<string, string>`) are missing. Response
+ *   data shares one map with question answers, so a multi-select array or matrix record under the
+ *   storage key means the key collided with an element id — joining it into a string would invent a
+ *   value the respondent never provided for this field.
+ * - `string`: strings pass through unchanged, including `""` — an ingested empty string is a present
+ *   value, and whether to display something else is the consumer's fallback logic, not data
+ *   semantics. Numbers, booleans and valid dates stringify losslessly.
+ * - `number`: finite numbers and non-blank numeric strings. Blank strings are missing, never `0`
+ *   (`Number("") === 0` is a coercion artifact, not data).
+ * - `boolean`: booleans, and exactly `"true"`/`"false"` (case-insensitive, trimmed) — the URL-param
+ *   spelling. `1`/`"yes"`/`"on"` stay uncoercible: guessing truthiness is write-side ingest policy
+ *   (ENG-1845), and the read seam must not resolve a value ingest would have rejected.
+ * - `date`: `Date` instances become ISO strings; strings must already be ISO 8601 (date or
+ *   datetime — the same rule `ZEmbeddedData` enforces on date defaults) and pass through as-is, so
+ *   a date-only value is not silently promoted to a midnight-UTC datetime. Epoch numbers stay
+ *   uncoercible — nothing upstream produces them intentionally.
+ */
+export const coerceToEmbeddedDataType = (
+  value: unknown,
+  dataType: TEmbeddedDataType
+): TResolvedEmbeddedValue | undefined => {
+  if (value === null || value === undefined) return undefined;
+
+  switch (dataType) {
+    case "string": {
+      if (typeof value === "string") return value;
+      if (typeof value === "number") return Number.isFinite(value) ? String(value) : undefined;
+      if (typeof value === "boolean") return String(value);
+      if (value instanceof Date) return Number.isNaN(value.getTime()) ? undefined : value.toISOString();
+      return undefined;
+    }
+    case "number": {
+      if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+      if (typeof value === "string") {
+        if (value.trim() === "") return undefined;
+        const parsed = Number(value);
+        return Number.isFinite(parsed) ? parsed : undefined;
+      }
+      return undefined;
+    }
+    case "boolean": {
+      if (typeof value === "boolean") return value;
+      if (typeof value === "string") {
+        const normalized = value.trim().toLowerCase();
+        if (normalized === "true") return true;
+        if (normalized === "false") return false;
+        return undefined;
+      }
+      return undefined;
+    }
+    case "date": {
+      if (value instanceof Date) return Number.isNaN(value.getTime()) ? undefined : value.toISOString();
+      if (typeof value === "string") return ZIsoDateOrDateTime.safeParse(value).success ? value : undefined;
+      return undefined;
+    }
+  }
+};
+
+/**
+ * The single read seam for Embedded Data: returns one field's value from a response, or `undefined`
+ * when the field has no value there. Every downstream surface (recall, logic, export, pickers)
+ * reads through this so "where does a field's value live" is answered exactly once:
+ *
+ * - `computed` → `response.variables[storageKey]` (written by the logic engine)
+ * - `ingested` → `response.data[storageKey]` (written from URL params / SDK)
+ * - reserved catalog entry → wherever its typed accessor points (`meta.*`, `ttc._total`, …)
+ *
+ * A `locked` ingested field ignores `response.data` entirely — locking means outside writes are
+ * refused, so the default IS the value; honoring a stored value here would let a crafted URL
+ * override what locking promised. Missing or uncoercible values fall back to the field's
+ * `defaultValue` (`null` means "no default"), which is coerced through the same rules, so the
+ * result always agrees with the field's `dataType` or is `undefined`. Reserved entries have no
+ * default tier: they are captured metadata, and a default would fake a capture that never happened.
+ *
+ * A stored row whose `source` still claims `"reserved"` resolves to `undefined` — such a row cannot
+ * pass `ZEmbeddedData`, so this arm only defends against data that skipped the schema.
+ *
+ * ENG-1837 swap checklist — two consumer behaviors this seam deliberately does not reproduce; the
+ * repointed call sites inherit these deltas and must do so consciously. The mismatched state is
+ * realistic today: `performCalculation`'s `assign` (packages/surveys/src/lib/logic.ts) stores raw
+ * strings into number variables unconditionally.
+ * (a) `getVariableValue` in that same file evaluates a number variable as `Number(value) || 0` (its
+ *     text arm collapses falsy values to `""`), so a non-numeric or empty string stored in
+ *     `response.variables` is `0` to logic today — here that state is a coercion failure and
+ *     resolves to defaultValue-or-`undefined`.
+ * (b) Both recall paths (`replaceRecallInfo` in packages/surveys, `parseRecallInfo` in apps/web)
+ *     render whatever sits in the lookup maps with no dataType awareness, so the same stored
+ *     `"abc"` renders verbatim in recall today — here it resolves to defaultValue-or-`undefined`.
+ */
+export const resolveEmbeddedValue = (
+  ref: TEmbeddedValueRef,
+  response: TEmbeddedValueResponse
+): TResolvedEmbeddedValue | undefined => {
+  // Definedness, not `"entry" in ref`: the `entry?: never` exclusion prop keeps the `in` operator
+  // from narrowing the union, and this way a degenerate `{ field, link, entry: undefined }` object
+  // still resolves through its field instead of crashing on `undefined.read`.
+  if (ref.entry !== undefined) {
+    return coerceToEmbeddedDataType(ref.entry.read(response), ref.entry.dataType);
+  }
+
+  const { field, link } = ref;
+  if (field.source === "reserved") return undefined;
+
+  const storedValue =
+    field.source === "computed"
+      ? response.variables[link.storageKey]
+      : field.locked
+        ? undefined
+        : response.data[link.storageKey];
+
+  const coerced = coerceToEmbeddedDataType(storedValue, field.dataType);
+  if (coerced !== undefined) return coerced;
+  if (field.defaultValue === null) return undefined;
+  return coerceToEmbeddedDataType(field.defaultValue, field.dataType);
+};
+
+/**
+ * Resolves every catalog entry into a plain map keyed by entry name — the piece that lets reserved
+ * fields ride through recall and logic with zero per-consumer special-casing. Those consumers
+ * already read two maps (`variables[...]`, `responseData[...]`); merging this projection into
+ * either one makes reserved values reachable by name exactly like every other field, which matters
+ * because `response.meta` is not otherwise passed into the recall/logic resolvers at all.
+ *
+ * The value type is deliberately `string | number` so the result is assignable into both existing
+ * maps: absent values are omitted (recall then falls back to its fallback text and logic sees
+ * `undefined`, exactly like an absent hidden field today), and booleans are stringified to
+ * `"true"`/`"false"` — what `String()` would render anyway, in a map type that has no boolean slot.
+ */
+export const projectReservedValues = (
+  entries: readonly TReservedFieldCatalogEntry[],
+  response: TEmbeddedValueResponse
+): Record<string, string | number> => {
+  const values: Record<string, string | number> = {};
+  for (const entry of entries) {
+    const value = resolveEmbeddedValue({ entry }, response);
+    if (value === undefined) continue;
+    values[entry.name] = typeof value === "boolean" ? String(value) : value;
+  }
+  return values;
+};
+
+/** One referenceable field, carrying the key a consumer must use to address it. */
+export interface TReadableField {
+  /** The reference key: element id, link `storageKey`, catalog entry name, or contact attribute key. */
+  key: string;
+  /** Display label for pickers. Falls back to the key when nothing better exists. */
+  label: string;
+}
+
+/**
+ * Everything a survey can reference, grouped. All four groups are always present (empty arrays
+ * included) so consumers render stable sections instead of probing for keys. Contact attributes
+ * stay their own clearly-labelled group — they describe the person, not the response, and the
+ * unified picker must not blur that line.
+ */
+export interface TReadableFields {
+  question: TReadableField[];
+  embeddedData: TReadableField[];
+  reserved: TReadableField[];
+  contactAttribute: TReadableField[];
+}
+
+/**
+ * Inputs are explicit because none of them live on `TSurvey` today: the field/link pairs arrive
+ * with ENG-1837, contact attribute keys are workspace-level, and the reserved catalog is code.
+ * Passing them in keeps this pure and lets legacy surveys participate via
+ * {@link deriveLegacyEmbeddedData}.
+ */
+export interface TListReadableFieldsInput {
+  /** The survey's blocks — elements live here (the legacy `questions` model is not enumerated). */
+  blocks: TSurveyBlocks;
+  embeddedData: readonly TLinkedEmbeddedField[];
+  reservedEntries: readonly TReservedFieldCatalogEntry[];
+  contactAttributeKeys: readonly Pick<TContactAttributeKey, "key" | "name">[];
+  /** Language for element headlines; falls back to each headline's `default` entry. */
+  languageCode?: string;
+}
+
+/** Matches one full recall token (`#recall:<id>/fallback:<text>#`) — the editor's storage syntax. */
+const RECALL_TOKEN_REGEX = /#recall:[A-Za-z0-9_-]+\/fallback:[^#]*#/g;
+
+/**
+ * A blank label draws a row with nothing to read or click (the same reasoning behind
+ * `ZEmbeddedData`'s name rule), and not every source guarantees a non-blank name — legacy variable
+ * names and contact attribute display names are plain strings. The reference key always exists, so
+ * it is the fallback, applied uniformly to all four groups.
+ */
+const labelOrKey = (label: string, key: string): string => (label.trim() === "" ? key : label);
+
+/**
+ * Headline → picker label. Mirrors what `getRecallItemLabel` (apps/web) produces: localized with
+ * blank-falls-back-to-`default` semantics, HTML stripped so rich-text markup never shows raw, and
+ * nested recall tokens flattened to `___` — a headline that recalls another answer would otherwise
+ * leak storage syntax into the picker. Both steps are cheap (one parse, one regex pass).
+ */
+const toElementLabel = (headline: TI18nString, languageCode: string): string => {
+  const localized = headline[languageCode];
+  const raw = typeof localized === "string" && localized.trim() !== "" ? localized : (headline.default ?? "");
+  return getTextContent(raw).replace(RECALL_TOKEN_REGEX, "___").trim();
+};
+
+/**
+ * Enumerates everything referenceable from a survey — the one list recall pickers, logic builders
+ * and export columns will all read (ENG-1840/1853), so "what can I reference and by which key"
+ * has a single answer. Each entry's `key` is the exact string {@link resolveEmbeddedValue} and the
+ * existing map lookups address the value by:
+ *
+ * - question → the element id (label from its headline; the id itself when the headline is empty)
+ * - embeddedData → the link's `storageKey` (never the definition's library `key` — the storage key
+ *   is what recall tokens and response maps use, and the two can differ)
+ * - reserved → the catalog entry name (title-cased for the label until the picker adds real labels)
+ * - contactAttribute → the contact attribute key (label from its display name when one is set)
+ */
+export const listReadableFields = (input: TListReadableFieldsInput): TReadableFields => {
+  const languageCode = input.languageCode ?? "default";
+
+  const question = input.blocks
+    .flatMap((block) => block.elements)
+    .map((element) => ({
+      key: element.id,
+      label: labelOrKey(toElementLabel(element.headline, languageCode), element.id),
+    }));
+
+  const embeddedData = input.embeddedData.map(({ field, link }) => ({
+    key: link.storageKey,
+    label: labelOrKey(field.name, link.storageKey),
+  }));
+
+  const reserved = input.reservedEntries.map((entry) => ({
+    key: entry.name,
+    label: labelOrKey(formatSnakeCaseToTitleCase(entry.name), entry.name),
+  }));
+
+  const contactAttribute = input.contactAttributeKeys.map((attributeKey) => ({
+    key: attributeKey.key,
+    label: labelOrKey(attributeKey.name ?? "", attributeKey.key),
+  }));
+
+  return { question, embeddedData, reserved, contactAttribute };
+};
+
+/**
+ * Maps a survey's legacy declarations (`variables`, `hiddenFields.fieldIds`) into the same
+ * field/link pairs the resolver and enumerator consume — the pure-function fallback that lets
+ * ENG-1837 serve surveys whose rows haven't been backfilled (migration spec §8), with no fetch
+ * logic here.
+ *
+ * Per §8: a variable becomes a `computed` field of its declared type whose `defaultValue` is the
+ * variable's value, addressed by its existing cuid (recall tokens and stored responses already use
+ * it); a hidden field becomes an `ingested` string field with no default, addressed by its name.
+ * `hiddenFields.enabled` is deliberately ignored: recall and logic consult `fieldIds` alone today,
+ * and a disabled field simply never receives a value — the resolver then reports it as unset, which
+ * is the same behavior with honest mechanics.
+ */
+export const deriveLegacyEmbeddedData = (survey: {
+  variables: TSurveyVariables;
+  hiddenFields: TSurveyHiddenFields;
+}): TLinkedEmbeddedField[] => {
+  const fromVariables = survey.variables.map(
+    (variable): TLinkedEmbeddedField => ({
+      field: {
+        name: variable.name,
+        source: "computed",
+        dataType: variable.type === "number" ? "number" : "string",
+        defaultValue: variable.value,
+        locked: false,
+      },
+      link: { storageKey: variable.id },
+    })
+  );
+
+  const fromHiddenFields = (survey.hiddenFields.fieldIds ?? []).map(
+    (fieldId): TLinkedEmbeddedField => ({
+      field: {
+        name: fieldId,
+        source: "ingested",
+        dataType: "string",
+        defaultValue: null,
+        locked: false,
+      },
+      link: { storageKey: fieldId },
+    })
+  );
+
+  return [...fromVariables, ...fromHiddenFields];
+};


### PR DESCRIPTION
## What & why

Recall, logic, export and the pickers each carry their own private answer to "where does a field's value live" — and with Embedded Data definitions moving into the workspace-level tables (ENG-1833, #8687), every one of those surfaces would need to relearn it. This PR builds the single read seam they will all use instead, as pure functions in `@formbricks/types/embedded-data-resolver`. **Nothing calls it yet**: ENG-1837 repoints the call sites, ENG-1839 supplies the reserved catalog contents.

- **`resolveEmbeddedValue(ref, response)`** — one field's value, by source: `computed` → `response.variables[storageKey]`, `ingested` → `response.data[storageKey]`, reserved catalog entry → its typed accessor (`meta.*`, `ttc._total`, top-level fields; an accessor that throws reads as "nothing captured" rather than crashing the caller's loop over the catalog). A `locked` ingested field ignores `response.data` entirely — the default IS the value; honoring a stored value would let a crafted URL override what locking promised. Missing or uncoercible values fall back to `defaultValue` (`null` = no default) → unset, and every tier passes through one exported `coerceToEmbeddedDataType`, so the result always agrees with the declared `dataType` or is `undefined`. The ref is a two-member union with `?: never` exclusion props — a stored field is only addressable with its link's `storageKey`, a reserved entry can never carry one, and a mixed literal is a compile error (pinned by a `@ts-expect-error` test).
- **`projectReservedValues(entries, response)`** — resolves catalog entries into a `Record<string, string | number>` that is statically assignable into both maps recall and logic already read (`variables[...]` / `responseData[...]`; compile-asserted in the tests). This is the ticket's "projection, not a special branch" design: reserved values become reachable by bare name with zero per-consumer special-casing — which matters because `response.meta` is not otherwise passed into those resolvers at all. Absent values are omitted (recall falls to its fallback text, logic sees `undefined` — exactly like an absent hidden field today); falsy-but-present values (`false` → `"false"`, `""`, `0`) stay in the map.
- **`RESERVED_FIELD_CATALOG`** — deliberately empty. This PR ships the mechanism (typed entries whose `read` accessor makes a bad "path" a compile error instead of a silent `undefined`); ENG-1839 decides the contents. Call sites can wire the constant now and light up when entries land.
- **`listReadableFields(input)`** — the grouped "what can I reference, and by which key" enumeration: **question · embeddedData · reserved · contactAttribute** (contact attributes stay their own clearly-labelled group). Each entry carries the exact reference key — element id, link `storageKey` (never the library `key`; the two can differ), catalog entry name, contact attribute key — and labels fall back to the key whenever blank.
- **`deriveLegacyEmbeddedData(survey)`** — maps un-backfilled `variables` / `hiddenFields.fieldIds` into the same field/link pairs per migration-spec §8, so ENG-1837 has a fetch-free fallback for surveys whose rows don't exist yet (local dev before the backfill).

**Four deliberate behavioral deltas are documented as an "ENG-1837 swap checklist"** on `resolveEmbeddedValue`, so the repointing inherits them consciously instead of discovering them in production: (a) today `getVariableValue` evaluates a number variable as `Number(value) || 0`, so a non-numeric string sitting in a number variable (a state `performCalculation`'s `assign` produces today) is `0` to logic, while here it is a coercion failure resolving to defaultValue-or-unset; (b) both recall paths render raw strings type-obliviously today; (c) on a key present in both maps today's consumers disagree with each other (packages/surveys lets `data` win, apps/web lets `variables` win) while here the declared source is exclusive; (d) a response missing a variable's key entirely resolves to the field's `defaultValue` here, where today logic yields `0`/`""` and recall falls to fallback text. The date rule is also pinned precisely: ISO date or UTC datetime only — the exact subset `ZEmbeddedData` accepts for date defaults, excluded offsets and padding included — with a cross-schema corpus test that goes red if either side drifts.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1836/single-resolver-resolveembeddedvalue-list-all-readable-fields-helper

## How this was tested

- `pnpm --filter @formbricks/types test` — 4 files, **192 passed** (103 new in `embedded-data-resolver.test.ts`, 89 pre-existing). The new suite covers: per-source resolution incl. dual-key precedence cases; `locked` (incl. locked-with-no-default and locked-ignored-on-computed); missing → default → unset; the full coercion matrix (string 12 / number 15 / boolean 10 / date 11 cases) incl. uncoercible inputs per type, partially-numeric strings (`"25 seats"`), both non-scalar response shapes, and a corpus test binding the read-side date rule to `ZEmbeddedData`'s default-value rule; projection over nested `meta.userAgent.*`, `ttc._total`, top-level fields, absent-key omission, Date→ISO coercion, uncoercible-entry omission, falsy-but-present retention, and throwing-accessor isolation; four-group enumeration with per-entry reference keys, blank-label and blank-locale fallbacks, multi-token recall flattening, dirty-i18n degradation, and `de` localization; §8 legacy derivation fed end-to-end through resolver and enumerator; and a `@ts-expect-error` pin that the mixed ref shape stays unrepresentable.
- `pnpm --filter @formbricks/types typecheck` — clean; this package's tsconfig includes `*.test.ts`, so the pin above is live on every typecheck run. Note `pnpm typecheck` runs in no CI workflow, so the compile-level pins bite on local/agent runs, not in the merge gate.
- `pnpm typecheck` (root, all packages) — clean.
- `pnpm --filter @formbricks/types lint` — 0 errors; 4 pre-existing unused-disable warnings in untouched `surveys/*` files.
- `npx prettier --check` on both new files — pass. (The root has no `format:check` script, only the mutating `format`, so the check was scoped.)
- Nothing imports the module: the module name appears only in its own test's import; no other tracked file references it and none was modified, so there is no production behaviour change.
- Two adversarial review rounds. Round 1 (pre-PR): consumer-semantics comparison against `replaceRecallInfo`, `parseRecallInfo`, `getLeftOperandValue`/`performCalculation` — findings applied (swap checklist, blank-label fallbacks, `?: never` exclusion props). Round 2 (on the PR head, three parallel finders incl. a sandboxed mutation battery with red controls): 10 suite-surviving mutations → the 13 tests above; executed zod probes → the date-rule and swap-checklist doc corrections; verified-against-source citations → five JSDoc corrections (boolean provenance, label-mirror attribution, the `hiddenFields.enabled` link-survey gap, `blocks`-on-TSurvey, caller tense) plus the throwing-accessor hardening and the `toElementLabel` dirty-default guard.

## Breaking changes

None

## QA / Test Plan

**How to test**

Nothing user-visible ships here — two new files that no code imports yet. The useful manual check is that nothing regressed around the surfaces this seam will later serve:

- [ ] Open a survey with variables and hidden fields in the editor → both cards load and list their fields exactly as before
- [ ] Use a variable and a hidden field in recall (`@`) and in a logic condition, then submit a response → the values resolve as before
- [ ] Export that survey's responses → variable and hidden-field columns appear with the same headers and values as before

**Preconditions / test data**

- Any workspace with a survey that has at least one variable and one hidden field, plus a response or two.

**Risks & regressions**

- Low: additive files only; no existing file changed; the module is unreachable from production code paths. The area to re-check is simply that the app still builds and existing survey/response flows behave unchanged.

**Migrations / env / cutover**

- none