### PR TITLE
fix: clean up transient Prisma migrations directory after each run

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
 "❗️ migrations":
-  - packages/database/migrations/**/migration.sql
+  - packages/database/migration/**/migration.sql
 
 "❗️ .env changes":
   - .env.example

--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,7 @@ secrets/
 packages/lib/uploads
 apps/web/public/js
 packages/database/generated
-packages/database/migrations
+packages/database/.prisma-migrations
 branch.json
 .vercel
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -117,7 +117,7 @@ COPY --from=installer /app/apps/web/public ./apps/web/public
 RUN chown -R nextjs:nextjs ./apps/web/public && chmod -R 755 ./apps/web/public
 
 # Create packages/database directory structure with proper ownership for runtime migrations
-RUN mkdir -p ./packages/database/migrations && chown -R nextjs:nextjs ./packages/database
+RUN mkdir -p ./packages/database/.prisma-migrations && chown -R nextjs:nextjs ./packages/database
 
 COPY --from=installer /app/packages/database/package.json ./packages/database/package.json
 RUN chown nextjs:nextjs ./packages/database/package.json && chmod 644 ./packages/database/package.json

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -30,7 +30,7 @@ packages/database/
 │   │   └── migration.sql      # Schema migration file
 │   └── [timestamp_name]/      # Data migration folder
 │       └── migration.ts       # Data migration file
-├── migrations/                # Prisma internal migrations
+├── .prisma-migrations/        # Transient Prisma scratch dir (gitignored)
 ├── schema/                    # Prisma schema folder
 │   ├── main.prisma            # Shared models, datasource, and generators
 │   └── workflows.prisma       # Workflows models and enums
@@ -51,6 +51,8 @@ packages/database/
 - **Single Type per Subdirectory**: A migration subdirectory can only contain one file type—either `migration.sql` or `migration.ts`
 - **Custom Naming Convention**: Subdirectories follow the format `timestamp_name_of_the_migration` (e.g., `20241214112456_add_users_table`)
 - **Order of Execution**: Migrations are executed sequentially based on their timestamps, enabling precise control over the execution sequence
+
+> **Why two directories?** `migration/` (singular, checked in) is the source of truth — it contains both schema and data migrations interleaved by timestamp. `.prisma-migrations/` (hidden, gitignored) is a transient scratch directory generated at runtime: the runner copies only schema migrations into it and feeds them to `prisma migrate deploy`. The hidden name prevents accidental edits; developers should only work in `migration/`.
 
 ### Database Tracking
 

--- a/packages/database/prisma.config.ts
+++ b/packages/database/prisma.config.ts
@@ -11,7 +11,7 @@ config({ path: path.resolve(__dirname, "../../.env"), quiet: true });
 export default defineConfig({
   schema: "./schema",
   migrations: {
-    path: "./migrations",
+    path: "./.prisma-migrations",
   },
   datasource: {
     url: env("DATABASE_URL"),

--- a/packages/database/src/scripts/create-migration.ts
+++ b/packages/database/src/scripts/create-migration.ts
@@ -52,7 +52,7 @@ async function main(): Promise<void> {
   const migrationName = await promptForMigrationName();
   const migrationNameUnderscored = migrationName.replace(/\s+/g, "_");
 
-  const migrationsDir = path.resolve(__dirname, "../../migrations");
+  const migrationsDir = path.resolve(__dirname, "../../.prisma-migrations");
   const customMigrationsDir = path.resolve(__dirname, "../../migration");
 
   // Check if migration already exists in custom migrations

--- a/packages/database/src/scripts/migration-runner.ts
+++ b/packages/database/src/scripts/migration-runner.ts
@@ -45,7 +45,7 @@ const isBuilt = __filename.split(path.sep).includes("dist");
 const MIGRATIONS_DIR = isBuilt
   ? path.resolve(__dirname, "../migration") // From dist/scripts to dist/migration
   : path.resolve(__dirname, "../../migration"); // From src/scripts to migration
-const PRISMA_MIGRATIONS_DIR = path.resolve(__dirname, "../../migrations");
+const PRISMA_MIGRATIONS_DIR = path.resolve(__dirname, "../../.prisma-migrations");
 const DATABASE_PACKAGE_DIR = isBuilt ? path.resolve(__dirname, "../..") : path.resolve(__dirname, "../..");
 const REPO_ROOT_DIR = path.resolve(DATABASE_PACKAGE_DIR, "../..");
 const PRISMA_CONFIG_PATH = path.join(DATABASE_PACKAGE_DIR, "prisma.config.ts");
@@ -186,7 +186,7 @@ const runMigrations = async (migrations: MigrationScript[]): Promise<void> => {
   const startTime = Date.now();
 
   // packages/database/migration is the source of truth (checked in). We copy
-  // each schema migration into packages/database/migrations on demand for
+  // each schema migration into packages/database/.prisma-migrations on demand for
   // `prisma migrate deploy`, then wipe between runs so stale or experimental
   // migrations from a previous local invocation can't influence this one.
   await fs.rm(PRISMA_MIGRATIONS_DIR, { recursive: true, force: true });

--- a/prisma.config.mjs
+++ b/prisma.config.mjs
@@ -24,7 +24,7 @@ export default {
     // Do NOT repoint this at `packages/database/migration` — Prisma would treat the
     // data-migration dirs (tracked separately in the DataMigration table, not
     // `_prisma_migrations`) as pending SQL migrations and break. Decided in ENG-1145.
-    path: "packages/database/migrations",
+    path: "packages/database/.prisma-migrations",
     seed: "tsx packages/database/src/seed.ts",
   },
   datasource: {


### PR DESCRIPTION
## What & why

The database package had two near-identically-named directories — `migration/` (singular, checked-in source of truth with schema + data migrations) and `migrations/` (plural, gitignored scratch dir for Prisma) — that caused developer confusion. The similar names made it easy to read or edit the wrong one.

**Fix**: Rename the scratch directory to `.prisma-migrations/` (hidden). The dot-prefix makes it invisible in directory listings and clearly signals it is a generated, transient artifact. Developers should only work in `migration/`.

Document the dual-directory architecture in the README with a "Why two directories?" callout.

**Bonus**: Fix `.github/labeler.yml` which globbed the gitignored `migrations/**` instead of the checked-in `migration/**` — the label has never fired.

> **Future**: When [Prisma Next](https://www.prisma.io/blog/data-migrations-in-prisma-next) (or Prisma 8) ships with native data-migration support, we can collapse the dual-directory setup into a single canonical `migrations/` directory and remove the copy logic from the custom runner. This PR is the minimal fix to eliminate confusion now; the real consolidation is deferred until Prisma natively supports the pattern.

_Thanks to Anshuman for catching that the original try/finally approach broke `pnpm create-migration` — `prisma migrate dev --create-only` needs the scratch directory to mirror the applied history._

## Linear ticket

Fixes ENG-1683

## How this was tested

- `node --check` on source — ✅ passes
- `prettier --check` on all TS/MD files — ✅ passes
- `pnpm build --filter=@formbricks/database --force` — ✅ compiles, compiled dist uses new path
- E2E: built dist, ran 186 migrations against Docker Postgres — ✅ `create-migration` flow works (scratch directory stays on disk)
- Verified no stale `migrations` (plural) path references remain in any source file
- Verified all production features from #8627 intact: fresh-DB fast path, schema batching, atomic data-migration transactions

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] `ls packages/database/` → only `migration/` visible (`.prisma-migrations/` is hidden)
- [ ] `ls -a packages/database/` → `.prisma-migrations/` visible
- [ ] Run `pnpm db:migrate:dev` → migrations apply normally, scratch dir populated
- [ ] Run `pnpm create-migration` after → migration created successfully (no drift error)
- [ ] Open `packages/database/README.md` → "Why two directories?" callout visible

**Preconditions / test data**

- Running Postgres, configured DATABASE_URL

**Risks & regressions**

- None — the scratch directory behaviour is unchanged; only the name differs

**Migrations / env / cutover**

- Developers with a stale `migrations/` dir locally may want to `rm -rf packages/database/migrations` (it's gitignored)