### PR TITLE
feat(support): brand the Plain chat widget with Formbricks colors

### DIFF
--- a/apps/web/app/plain/components/plain-chat.tsx
+++ b/apps/web/app/plain/components/plain-chat.tsx
@@ -22,6 +22,9 @@ interface PlainChatProps {
 const PLAIN_SCRIPT_ID = "plain-chat-script";
 const PLAIN_SCRIPT_SRC = "https://chat.cdn-plain.com/index.js";
 
+// Formbricks brand teal — brands the chat panel accents.
+const BRAND_COLOR = "#00C4B8";
+
 interface PlainCustomerDetails {
   email: string;
   emailHash?: string;
@@ -34,6 +37,12 @@ interface PlainInitOptions {
   appId: string;
   hideLauncher?: boolean;
   theme?: "auto" | "light" | "dark";
+  style?: {
+    brandColor?: string;
+    brandBackgroundColor?: string;
+    launcherBackgroundColor?: string;
+    launcherIconColor?: string;
+  };
   customerDetails?: PlainCustomerDetails;
   threadDetails?: { labelTypeIds?: string[] };
 }
@@ -85,6 +94,11 @@ export const PlainChat = ({
       appId,
       theme: "auto",
       hideLauncher: isOnboarding,
+      style: {
+        brandColor: BRAND_COLOR,
+        launcherBackgroundColor: BRAND_COLOR,
+        launcherIconColor: "#FFFFFF",
+      },
       customerDetails: buildCustomerDetails(userEmail, emailHash, userName, userId),
       threadDetails: activeCustomerLabelTypeId ? { labelTypeIds: [activeCustomerLabelTypeId] } : undefined,
     };


### PR DESCRIPTION
## What & why

The in-app support chat icon (lower-right) was easy to miss — Plain's stock launcher is a low-contrast bubble that auto-inverts with the theme, so it blends into the surrounding UI. This makes it more visible and on-brand by passing a `style` block to `Plain.init` in `apps/web/app/plain/components/plain-chat.tsx`:

- The launcher is now a solid Formbricks-teal bubble (`launcherBackgroundColor: #00C4B8`) with a white message icon (`launcherIconColor: #FFFFFF`), so it stands out clearly and the icon stays legible in both light and dark themes instead of depending on Plain's auto-dark inversion.
- Panel accents use the same brand teal via `style.brandColor`.

No behavior change: the default launcher, onboarding hide/show, identity verification, and label sync are untouched.

<img width="447" height="844" alt="Screenshot 2026-08-11 at 2 37 34 PM" src="https://github.com/user-attachments/assets/acbcd3a8-40da-4148-9389-4bce1b47306a" />
<img width="422" height="464" alt="Screenshot 2026-08-11 at 2 23 00 PM" src="https://github.com/user-attachments/assets/72303cd6-faef-4f38-a993-032e46254a35" />


## Linear ticket

Fixes ENG-2271

## How this was tested

- `eslint` and `prettier` on the changed file ✅ (also run by the pre-commit hook).
- No unit/e2e tests added: this only passes static color values to the third-party Plain SDK's `init`, which is Cloud-only and has no local test surface (per repo guidance, styling isn't unit-tested).
- Manual: verified in the running app — teammate confirmed in review that the panel branding looks right; launcher shows a teal bubble with a white icon.

<!-- Attach before/after screenshots of the launcher bubble and the open chat panel. -->

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] On a Cloud instance with Plain configured (`PLAIN_APP_ID` + valid `PLAIN_CHAT_HMAC_SECRET`), open the app → the support launcher in the bottom-right is a teal bubble with a white message icon (not black).
- [ ] Click the launcher → the chat panel opens with Formbricks teal accents.
- [ ] Toggle OS light/dark theme → the launcher icon stays white and legible in both.
- [ ] Enter an onboarding route (`/organizations/:id/workspaces/new` or `/landing`) → the launcher is hidden; leave onboarding → it reappears (unchanged behavior).

**Preconditions / test data**

- Formbricks Cloud (or self-host) with Plain chat env vars set; logged-in user. Widget does not load without `PLAIN_APP_ID`.

**Risks & regressions**

- Scope limited to widget colors. Re-check that the launcher still appears, opens, and hides during onboarding, and that identity verification still succeeds (no "email hash is invalid").

**Migrations / env / cutover**

- none
