### PR TITLE
fix(workflows): stop read-only members getting an interactive editor

### DIFF
--- a/apps/web/i18n.lock
+++ b/apps/web/i18n.lock
@@ -4054,6 +4054,8 @@ checksums:
     workspace/workflows/duplicate_failed: 56b15c01ba3e3fafbfd226520023204f
     workspace/workflows/duplicate_success: b94c796f27301d2957a710dc06e73679
     workspace/workflows/edit_blocked_active: 11f02e65cffdf7a8533906eff1de4ffb
+    workspace/workflows/edit_blocked_archived: c288a75c4825cb3aac3b692fe15c9090
+    workspace/workflows/edit_blocked_read_only: a7b6e332e4e9b5f63e7f261fcb173f50
     workspace/workflows/email_attach_response_data_description: 7d312092941888d63361690ee8706102
     workspace/workflows/email_attach_response_data_label: 32eff1a88e1a044fc22b0bff54f3c683
     workspace/workflows/email_body_label: e88eb1ea71f5ef886aa43ea6ba292d87

--- a/apps/web/locales/de-DE.json
+++ b/apps/web/locales/de-DE.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "Workflow konnte nicht dupliziert werden. Bitte versuche es erneut.",
       "duplicate_success": "Workflow dupliziert.",
       "edit_blocked_active": "Deaktiviere den Workflow, um hier Änderungen vorzunehmen.",
+      "edit_blocked_archived": "Hebe die Archivierung des Workflows auf, um hier Änderungen vorzunehmen.",
+      "edit_blocked_read_only": "Du hast keine Berechtigung, diesen Workflow zu bearbeiten.",
       "email_attach_response_data_description": "Füge die auslösende Umfrageantwort zur E-Mail-Payload hinzu.",
       "email_attach_response_data_label": "Antwortdaten anhängen",
       "email_body_label": "Nachricht",

--- a/apps/web/locales/en-US.json
+++ b/apps/web/locales/en-US.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "Failed to duplicate the workflow. Please try again.",
       "duplicate_success": "Workflow duplicated.",
       "edit_blocked_active": "Disable the workflow to make changes here.",
+      "edit_blocked_archived": "Unarchive the workflow to make changes here.",
+      "edit_blocked_read_only": "You don't have permission to edit this workflow.",
       "email_attach_response_data_description": "Include the triggering survey response with the email payload.",
       "email_attach_response_data_label": "Attach response data",
       "email_body_label": "Body",

--- a/apps/web/locales/es-ES.json
+++ b/apps/web/locales/es-ES.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "No se pudo duplicar el flujo de trabajo. Por favor, inténtalo de nuevo.",
       "duplicate_success": "Flujo de trabajo duplicado.",
       "edit_blocked_active": "Desactiva el flujo de trabajo para hacer cambios aquí.",
+      "edit_blocked_archived": "Desarchivar el flujo de trabajo para hacer cambios aquí.",
+      "edit_blocked_read_only": "No tienes permiso para editar este flujo de trabajo.",
       "email_attach_response_data_description": "Incluye la respuesta de la encuesta que activó el flujo con la carga del correo electrónico.",
       "email_attach_response_data_label": "Adjuntar datos de respuesta",
       "email_body_label": "Cuerpo",

--- a/apps/web/locales/fr-FR.json
+++ b/apps/web/locales/fr-FR.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "Échec de la duplication du workflow. Réessaye.",
       "duplicate_success": "Workflow dupliqué.",
       "edit_blocked_active": "Désactive le workflow pour apporter des modifications ici.",
+      "edit_blocked_archived": "Désarchive le workflow pour effectuer des modifications ici.",
+      "edit_blocked_read_only": "Tu n'as pas la permission de modifier ce workflow.",
       "email_attach_response_data_description": "Inclure la réponse au sondage déclencheur avec la charge utile de l'e-mail.",
       "email_attach_response_data_label": "Joindre les données de réponse",
       "email_body_label": "Corps",

--- a/apps/web/locales/hu-HU.json
+++ b/apps/web/locales/hu-HU.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "A munkafolyamat másolása sikertelen volt. Kérjük, próbálja meg újra.",
       "duplicate_success": "A munkafolyamat lemásolva.",
       "edit_blocked_active": "A módosítások elvégzéséhez kérem, tiltsa le a munkafolyamatot.",
+      "edit_blocked_archived": "Kérem, archiválja vissza a munkafolyamatot a módosítások eszközléséhez.",
+      "edit_blocked_read_only": "Önnek nincs jogosultsága ezen munkafolyamat szerkesztéséhez.",
       "email_attach_response_data_description": "A kiváltó felmérési válasz csatolása az e-mail adatcsomaghoz.",
       "email_attach_response_data_label": "Válaszadatok csatolása",
       "email_body_label": "Törzs",

--- a/apps/web/locales/ja-JP.json
+++ b/apps/web/locales/ja-JP.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "ワークフローの複製に失敗しました。もう一度お試しください。",
       "duplicate_success": "ワークフローを複製しました。",
       "edit_blocked_active": "ここで変更を行うには、ワークフローを無効にしてください。",
+      "edit_blocked_archived": "ここで変更を加えるには、ワークフローのアーカイブを解除してください。",
+      "edit_blocked_read_only": "このワークフローを編集する権限がありません。",
       "email_attach_response_data_description": "トリガーとなったアンケート回答をメールペイロードに含めます。",
       "email_attach_response_data_label": "回答データを添付",
       "email_body_label": "本文",

--- a/apps/web/locales/nl-NL.json
+++ b/apps/web/locales/nl-NL.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "Dupliceren van de workflow is mislukt. Probeer het opnieuw.",
       "duplicate_success": "Workflow gedupliceerd.",
       "edit_blocked_active": "Schakel de workflow uit om hier wijzigingen aan te brengen.",
+      "edit_blocked_archived": "Dearchiveer de workflow om hier wijzigingen aan te brengen.",
+      "edit_blocked_read_only": "Je hebt geen toestemming om deze workflow te bewerken.",
       "email_attach_response_data_description": "Voeg de antwoordgegevens van de enquête toe aan de e-mailpayload.",
       "email_attach_response_data_label": "Antwoordgegevens toevoegen",
       "email_body_label": "Bericht",

--- a/apps/web/locales/pt-BR.json
+++ b/apps/web/locales/pt-BR.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "Falha ao duplicar o fluxo de trabalho. Tente novamente.",
       "duplicate_success": "Fluxo de trabalho duplicado.",
       "edit_blocked_active": "Desative o fluxo de trabalho para fazer alterações aqui.",
+      "edit_blocked_archived": "Desarquive o fluxo de trabalho para fazer alterações aqui.",
+      "edit_blocked_read_only": "Você não tem permissão para editar este fluxo de trabalho.",
       "email_attach_response_data_description": "Inclui a resposta da pesquisa que disparou o fluxo junto com os dados do e-mail.",
       "email_attach_response_data_label": "Anexar dados da resposta",
       "email_body_label": "Corpo",

--- a/apps/web/locales/pt-PT.json
+++ b/apps/web/locales/pt-PT.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "Falha ao duplicar o fluxo de trabalho. Por favor, tenta novamente.",
       "duplicate_success": "Fluxo de trabalho duplicado.",
       "edit_blocked_active": "Desativa o fluxo de trabalho para fazer alterações aqui.",
+      "edit_blocked_archived": "Desarquiva o fluxo de trabalho para fazer alterações aqui.",
+      "edit_blocked_read_only": "Não tens permissão para editar este fluxo de trabalho.",
       "email_attach_response_data_description": "Incluir a resposta do inquérito que desencadeou a ação no corpo do e-mail.",
       "email_attach_response_data_label": "Anexar dados da resposta",
       "email_body_label": "Corpo",

--- a/apps/web/locales/ro-RO.json
+++ b/apps/web/locales/ro-RO.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "Nu s-a putut duplica workflow-ul. Te rugăm să încerci din nou.",
       "duplicate_success": "Workflow duplicat.",
       "edit_blocked_active": "Dezactivează fluxul de lucru pentru a face modificări aici.",
+      "edit_blocked_archived": "Dezarhivează fluxul de lucru pentru a face modificări aici.",
+      "edit_blocked_read_only": "Nu ai permisiunea de a edita acest flux de lucru.",
       "email_attach_response_data_description": "Include răspunsul la sondaj care a declanșat fluxul împreună cu payload-ul emailului.",
       "email_attach_response_data_label": "Atașează datele răspunsului",
       "email_body_label": "Conținut",

--- a/apps/web/locales/ru-RU.json
+++ b/apps/web/locales/ru-RU.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "Не удалось дублировать воркфлоу. Попробуй ещё раз.",
       "duplicate_success": "Воркфлоу дублирован.",
       "edit_blocked_active": "Отключите процесс, чтобы внести изменения.",
+      "edit_blocked_archived": "Разархивируй воркфлоу, чтобы внести изменения.",
+      "edit_blocked_read_only": "У тебя нет прав на редактирование этого воркфлоу.",
       "email_attach_response_data_description": "Включить в письмо данные ответа на опрос, который запустил рабочий процесс.",
       "email_attach_response_data_label": "Прикрепить данные ответа",
       "email_body_label": "Текст письма",

--- a/apps/web/locales/sv-SE.json
+++ b/apps/web/locales/sv-SE.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "Det gick inte att duplicera arbetsflödet. Försök igen.",
       "duplicate_success": "Arbetsflödet har duplicerats.",
       "edit_blocked_active": "Inaktivera arbetsflödet för att göra ändringar här.",
+      "edit_blocked_archived": "Avarkivera arbetsflödet för att göra ändringar här.",
+      "edit_blocked_read_only": "Du har inte behörighet att redigera det här arbetsflödet.",
       "email_attach_response_data_description": "Inkludera det utlösande enkätsvaret tillsammans med e-postinnehållet.",
       "email_attach_response_data_label": "Bifoga svarsdata",
       "email_body_label": "Meddelande",

--- a/apps/web/locales/tr-TR.json
+++ b/apps/web/locales/tr-TR.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "İş akışı kopyalanamadı. Lütfen tekrar deneyin.",
       "duplicate_success": "İş akışı kopyalandı.",
       "edit_blocked_active": "Değişiklik yapmak için iş akışını devre dışı bırakın.",
+      "edit_blocked_archived": "Buradan değişiklik yapmak için iş akışının arşivini kaldır.",
+      "edit_blocked_read_only": "Bu iş akışını düzenleme izniniz yok.",
       "email_attach_response_data_description": "E-posta yüküne tetikleyen anket yanıtını ekle.",
       "email_attach_response_data_label": "Yanıt verisini ekle",
       "email_body_label": "Gövde",

--- a/apps/web/locales/zh-Hans-CN.json
+++ b/apps/web/locales/zh-Hans-CN.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "复制工作流失败。请重试。",
       "duplicate_success": "工作流已复制。",
       "edit_blocked_active": "请停用工作流以进行更改。",
+      "edit_blocked_archived": "取消归档该工作流以进行更改。",
+      "edit_blocked_read_only": "你没有权限编辑此工作流。",
       "email_attach_response_data_description": "在电子邮件负载中包含触发调查的响应数据。",
       "email_attach_response_data_label": "附加响应数据",
       "email_body_label": "正文",

--- a/apps/web/locales/zh-Hant-TW.json
+++ b/apps/web/locales/zh-Hant-TW.json
@@ -4216,6 +4216,8 @@
       "duplicate_failed": "無法複製工作流程,請再試一次。",
       "duplicate_success": "工作流程已複製。",
       "edit_blocked_active": "請停用工作流程以進行變更。",
+      "edit_blocked_archived": "取消封存此工作流程以進行變更。",
+      "edit_blocked_read_only": "你沒有編輯此工作流程的權限。",
       "email_attach_response_data_description": "在電子郵件內容中包含觸發的調查回應。",
       "email_attach_response_data_label": "附加回應資料",
       "email_body_label": "內容",

--- a/apps/web/modules/ee/workflows/components/canvas/workflow-canvas.tsx
+++ b/apps/web/modules/ee/workflows/components/canvas/workflow-canvas.tsx
@@ -244,6 +244,12 @@ const WorkflowCanvasContent = ({ isEditable }: Readonly<WorkflowCanvasProps>) =>
         fitViewOptions={{ padding: 0.25, maxZoom: WORKFLOW_CANVAS_MAX_ZOOM, minZoom: 0.4 }}
         defaultViewport={{ x: 0, y: 0, zoom: WORKFLOW_CANVAS_MAX_ZOOM }}
         nodesDraggable={canMutate}
+        // Disable the delete key entirely when mutation is gated. RF's deleteKeyCode defaults to
+        // "Backspace"; leaving it on lets a read-only member (or an editor on an enabled/archived
+        // workflow) visually drop a selected node — applyNodeChanges removes it from local flowNodes
+        // without ever touching the definition, so the change never persists and re-syncs on reload
+        // into an inconsistent canvas (orphaned edge). `null` disables the shortcut in RF 12.
+        deleteKeyCode={canMutate ? "Backspace" : null}
         nodesConnectable={false}
         snapGrid={WORKFLOW_CANVAS_SNAP_GRID}
         snapToGrid={isSnapToCanvasEnabled}

--- a/apps/web/modules/ee/workflows/components/inspector/workflow-node-config-panel.tsx
+++ b/apps/web/modules/ee/workflows/components/inspector/workflow-node-config-panel.tsx
@@ -5,8 +5,10 @@ import { useTranslation } from "react-i18next";
 import type { TWorkflowDefinition, TWorkflowNode } from "@formbricks/workflows";
 import { getNodeRegistryEntry } from "@/modules/ee/workflows/lib/node-registry";
 import {
+  isWorkflowReadOnlyAtom,
   selectedWorkflowNodeIdAtom,
   setWorkflowDefinitionAtom,
+  workflowAtom,
   workflowDefinitionAtom,
 } from "@/modules/ee/workflows/state/editor";
 import { Alert, AlertDescription } from "@/modules/ui/components/alert";
@@ -50,10 +52,22 @@ export const WorkflowNodeConfigPanel = ({ isEditable }: Readonly<WorkflowNodeCon
   const { t } = useTranslation();
   const definition = useAtomValue(workflowDefinitionAtom);
   const selectedNodeId = useAtomValue(selectedWorkflowNodeIdAtom);
+  const workflow = useAtomValue(workflowAtom);
+  const isReadOnly = useAtomValue(isWorkflowReadOnlyAtom);
   const setDefinition = useSetAtom(setWorkflowDefinitionAtom);
 
   const selectedNode = findSelectedNode(definition, selectedNodeId);
   if (!selectedNode || !definition) return null;
+
+  // `isEditable` collapses three distinct block reasons (no permission, archived, enabled) into one
+  // boolean; name the actual reason instead of always blaming an "active" workflow. Permission wins
+  // — a read-only member sees the permission message even on an enabled/archived workflow.
+  const blockedReason = (() => {
+    if (isEditable) return null;
+    if (isReadOnly) return t("workspace.workflows.edit_blocked_read_only");
+    if (workflow?.status === "archived") return t("workspace.workflows.edit_blocked_archived");
+    return t("workspace.workflows.edit_blocked_active");
+  })();
 
   const registryEntry = getNodeRegistryEntry(selectedNode);
   const ConfigForm = registryEntry.ConfigForm;
@@ -77,9 +91,9 @@ export const WorkflowNodeConfigPanel = ({ isEditable }: Readonly<WorkflowNodeCon
       </header>
       <div className="scroll-bar min-h-0 flex-1 overflow-y-auto">
         <div className="flex flex-col gap-3 px-3 pt-3 pb-4">
-          {!isEditable && (
+          {blockedReason && (
             <Alert variant="info" size="small">
-              <AlertDescription>{t("workspace.workflows.edit_blocked_active")}</AlertDescription>
+              <AlertDescription>{blockedReason}</AlertDescription>
             </Alert>
           )}
           {ConfigForm ? (

--- a/apps/web/modules/ee/workflows/components/inspector/workflow-node-config-panel.tsx
+++ b/apps/web/modules/ee/workflows/components/inspector/workflow-node-config-panel.tsx
@@ -2,14 +2,14 @@
 
 import { useAtomValue, useSetAtom } from "jotai";
 import { useTranslation } from "react-i18next";
-import type { TWorkflowDefinition, TWorkflowNode } from "@formbricks/workflows";
+import type { TWorkflowDefinition, TWorkflowNode, TWorkflowResource } from "@formbricks/workflows";
 import { getNodeRegistryEntry } from "@/modules/ee/workflows/lib/node-registry";
 import {
   isWorkflowReadOnlyAtom,
   selectedWorkflowNodeIdAtom,
   setWorkflowDefinitionAtom,
-  workflowAtom,
   workflowDefinitionAtom,
+  workflowStatusAtom,
 } from "@/modules/ee/workflows/state/editor";
 import { Alert, AlertDescription } from "@/modules/ui/components/alert";
 
@@ -24,6 +24,21 @@ const findSelectedNode = (
   if (!definition || !selectedNodeId) return null;
   if (definition.trigger?.id === selectedNodeId) return definition.trigger;
   return definition.nodes.find((node) => node.id === selectedNodeId) ?? null;
+};
+
+// `isEditable` collapses three distinct block reasons (no permission, archived, enabled) into one
+// boolean; name the actual reason instead of always blaming an "active" workflow. Precedence:
+// permission wins — a read-only member sees the permission message even on an enabled/archived
+// workflow — then archived, then active/enabled. Returns the translation key; the caller runs t().
+const getBlockedReasonKey = (
+  isEditable: boolean,
+  isReadOnly: boolean,
+  status: TWorkflowResource["status"] | undefined | null
+): string | null => {
+  if (isEditable) return null;
+  if (isReadOnly) return "workspace.workflows.edit_blocked_read_only";
+  if (status === "archived") return "workspace.workflows.edit_blocked_archived";
+  return "workspace.workflows.edit_blocked_active";
 };
 
 const replaceNode = (definition: TWorkflowDefinition, node: TWorkflowNode): TWorkflowDefinition => {
@@ -52,22 +67,18 @@ export const WorkflowNodeConfigPanel = ({ isEditable }: Readonly<WorkflowNodeCon
   const { t } = useTranslation();
   const definition = useAtomValue(workflowDefinitionAtom);
   const selectedNodeId = useAtomValue(selectedWorkflowNodeIdAtom);
-  const workflow = useAtomValue(workflowAtom);
+  // Read only the status primitive, not the whole workflow: autosave replaces the workflow atom
+  // with the API response every ~2s, and subscribing to it here would re-render this panel (and the
+  // rich-text email editor it hosts) on every save. Jotai bails out when the primitive is unchanged.
+  const status = useAtomValue(workflowStatusAtom);
   const isReadOnly = useAtomValue(isWorkflowReadOnlyAtom);
   const setDefinition = useSetAtom(setWorkflowDefinitionAtom);
 
   const selectedNode = findSelectedNode(definition, selectedNodeId);
   if (!selectedNode || !definition) return null;
 
-  // `isEditable` collapses three distinct block reasons (no permission, archived, enabled) into one
-  // boolean; name the actual reason instead of always blaming an "active" workflow. Permission wins
-  // — a read-only member sees the permission message even on an enabled/archived workflow.
-  const blockedReason = (() => {
-    if (isEditable) return null;
-    if (isReadOnly) return t("workspace.workflows.edit_blocked_read_only");
-    if (workflow?.status === "archived") return t("workspace.workflows.edit_blocked_archived");
-    return t("workspace.workflows.edit_blocked_active");
-  })();
+  const blockedReasonKey = getBlockedReasonKey(isEditable, isReadOnly, status);
+  const blockedReason = blockedReasonKey ? t(blockedReasonKey) : null;
 
   const registryEntry = getNodeRegistryEntry(selectedNode);
   const ConfigForm = registryEntry.ConfigForm;

--- a/apps/web/modules/ee/workflows/components/inspector/workflow-node-config-panel.tsx
+++ b/apps/web/modules/ee/workflows/components/inspector/workflow-node-config-panel.tsx
@@ -29,16 +29,19 @@ const findSelectedNode = (
 // `isEditable` collapses three distinct block reasons (no permission, archived, enabled) into one
 // boolean; name the actual reason instead of always blaming an "active" workflow. Precedence:
 // permission wins — a read-only member sees the permission message even on an enabled/archived
-// workflow — then archived, then active/enabled. Returns the translation key; the caller runs t().
-const getBlockedReasonKey = (
+// workflow — then archived, then active/enabled. Returns a reason discriminant, not the i18n key,
+// so the caller resolves it with literal `t("…")` calls the translation scanner can detect.
+type TBlockedReason = "readOnly" | "archived" | "active";
+
+const getBlockedReason = (
   isEditable: boolean,
   isReadOnly: boolean,
   status: TWorkflowResource["status"] | undefined | null
-): string | null => {
+): TBlockedReason | null => {
   if (isEditable) return null;
-  if (isReadOnly) return "workspace.workflows.edit_blocked_read_only";
-  if (status === "archived") return "workspace.workflows.edit_blocked_archived";
-  return "workspace.workflows.edit_blocked_active";
+  if (isReadOnly) return "readOnly";
+  if (status === "archived") return "archived";
+  return "active";
 };
 
 const replaceNode = (definition: TWorkflowDefinition, node: TWorkflowNode): TWorkflowDefinition => {
@@ -77,8 +80,15 @@ export const WorkflowNodeConfigPanel = ({ isEditable }: Readonly<WorkflowNodeCon
   const selectedNode = findSelectedNode(definition, selectedNodeId);
   if (!selectedNode || !definition) return null;
 
-  const blockedReasonKey = getBlockedReasonKey(isEditable, isReadOnly, status);
-  const blockedReason = blockedReasonKey ? t(blockedReasonKey) : null;
+  const blockedReasonType = getBlockedReason(isEditable, isReadOnly, status);
+  const blockedReason =
+    blockedReasonType === "readOnly"
+      ? t("workspace.workflows.edit_blocked_read_only")
+      : blockedReasonType === "archived"
+        ? t("workspace.workflows.edit_blocked_archived")
+        : blockedReasonType === "active"
+          ? t("workspace.workflows.edit_blocked_active")
+          : null;
 
   const registryEntry = getNodeRegistryEntry(selectedNode);
   const ConfigForm = registryEntry.ConfigForm;

--- a/apps/web/modules/ee/workflows/components/workflow-header-cta.tsx
+++ b/apps/web/modules/ee/workflows/components/workflow-header-cta.tsx
@@ -99,53 +99,60 @@ export const WorkflowHeaderCta = ({ workflowId, isReadOnly }: Readonly<WorkflowH
       {isEditTab && (
         <>
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
+            {/* `disabled` must sit on the trigger, not only the child Button: Radix's open guard
+                reads the trigger's own prop, so a value passed solely to the Button leaves the menu
+                openable (the DOM attribute and the JS guard disagree). Belt-and-suspenders, the
+                content is also withheld from read-only members, so a bypassed trigger has nothing
+                to select — the list page hides its actions the same way. */}
+            <DropdownMenuTrigger asChild disabled={isReadOnly || isBusy}>
               <Button size="sm" loading={builder.isTransitioning} disabled={isReadOnly || isBusy}>
                 {getWorkflowStatusBadge(workflow.status, t).label}
                 <ChevronDownIcon />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-52">
-              {isArchived ? (
-                <>
-                  <DropdownMenuItem
-                    icon={<ArchiveRestoreIcon className="size-4" />}
-                    onSelect={() => void builder.unarchive()}>
-                    {t("common.unarchive")}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    icon={<TrashIcon className="size-4" />}
-                    className="text-red-600 focus:text-red-600"
-                    onSelect={() => setIsDeleteDialogOpen(true)}>
-                    {t("common.delete")}
-                  </DropdownMenuItem>
-                </>
-              ) : (
-                <>
-                  {isActive ? (
+            {!isReadOnly && (
+              <DropdownMenuContent align="end" className="w-52">
+                {isArchived ? (
+                  <>
                     <DropdownMenuItem
-                      icon={<CirclePauseIcon className="size-4" />}
-                      onSelect={() => void builder.disable()}>
-                      {t("common.disable")}
+                      icon={<ArchiveRestoreIcon className="size-4" />}
+                      onSelect={() => void builder.unarchive()}>
+                      {t("common.unarchive")}
                     </DropdownMenuItem>
-                  ) : (
-                    // Enabling requires a workflow the server would accept; the readiness hint next
-                    // to the Save button says what is still missing.
                     <DropdownMenuItem
-                      icon={<CirclePlayIcon className="size-4" />}
-                      disabled={!validity.isReady}
-                      onSelect={() => void builder.enable()}>
-                      {t("common.enable")}
+                      icon={<TrashIcon className="size-4" />}
+                      className="text-red-600 focus:text-red-600"
+                      onSelect={() => setIsDeleteDialogOpen(true)}>
+                      {t("common.delete")}
                     </DropdownMenuItem>
-                  )}
-                  <DropdownMenuItem
-                    icon={<ArchiveIcon className="size-4" />}
-                    onSelect={() => setIsArchiveModalOpen(true)}>
-                    {t("common.archive")}
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
+                  </>
+                ) : (
+                  <>
+                    {isActive ? (
+                      <DropdownMenuItem
+                        icon={<CirclePauseIcon className="size-4" />}
+                        onSelect={() => void builder.disable()}>
+                        {t("common.disable")}
+                      </DropdownMenuItem>
+                    ) : (
+                      // Enabling requires a workflow the server would accept; the readiness hint next
+                      // to the Save button says what is still missing.
+                      <DropdownMenuItem
+                        icon={<CirclePlayIcon className="size-4" />}
+                        disabled={!validity.isReady}
+                        onSelect={() => void builder.enable()}>
+                        {t("common.enable")}
+                      </DropdownMenuItem>
+                    )}
+                    <DropdownMenuItem
+                      icon={<ArchiveIcon className="size-4" />}
+                      onSelect={() => setIsArchiveModalOpen(true)}>
+                      {t("common.archive")}
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            )}
           </DropdownMenu>
 
           <ConfirmationModal

--- a/apps/web/modules/ee/workflows/components/workflow-header-cta.tsx
+++ b/apps/web/modules/ee/workflows/components/workflow-header-cta.tsx
@@ -59,7 +59,11 @@ export const WorkflowHeaderCta = ({ workflowId, isReadOnly }: Readonly<WorkflowH
 
   const isArchived = workflow.status === "archived";
   const isActive = workflow.status === "enabled";
-  const isBusy = builder.isTransitioning || builder.isSaving || isDeleting;
+  // The status dropdown stays reachable during an autosave (isSaving) so the control never goes dead
+  // mid-save with no spinner: transition() already refuses to run while a save is in flight, so
+  // writes stay serialized. A pending lifecycle transition or delete still blocks it, as does a
+  // read-only member (who also has no menu content to select).
+  const isTransitioning = builder.isTransitioning;
 
   const handleArchiveConfirm = async () => {
     await builder.archive();
@@ -104,8 +108,11 @@ export const WorkflowHeaderCta = ({ workflowId, isReadOnly }: Readonly<WorkflowH
                 openable (the DOM attribute and the JS guard disagree). Belt-and-suspenders, the
                 content is also withheld from read-only members, so a bypassed trigger has nothing
                 to select — the list page hides its actions the same way. */}
-            <DropdownMenuTrigger asChild disabled={isReadOnly || isBusy}>
-              <Button size="sm" loading={builder.isTransitioning} disabled={isReadOnly || isBusy}>
+            <DropdownMenuTrigger asChild disabled={isReadOnly || isTransitioning || isDeleting}>
+              <Button
+                size="sm"
+                loading={builder.isTransitioning}
+                disabled={isReadOnly || isTransitioning || isDeleting}>
                 {getWorkflowStatusBadge(workflow.status, t).label}
                 <ChevronDownIcon />
               </Button>

--- a/apps/web/modules/ee/workflows/hooks/use-workflow-builder.test.ts
+++ b/apps/web/modules/ee/workflows/hooks/use-workflow-builder.test.ts
@@ -714,6 +714,24 @@ describe("transition", () => {
     expect(toastError).toHaveBeenCalledWith("workspace.workflows.archive_failed");
   });
 
+  test("read-only members never fire a lifecycle request", async () => {
+    getWorkflow.mockResolvedValue(apiWorkflow);
+
+    const { result } = renderBuilder({ workflowId: "wf-api", isReadOnly: true });
+    await waitFor(() => expect(result.current.workflow?.id).toBe("wf-api"));
+
+    await act(() => result.current.enable());
+    await act(() => result.current.disable());
+    await act(() => result.current.archive());
+    await act(() => result.current.unarchive());
+
+    // The server rejects these with 403; the hook must not even attempt them.
+    expect(enableWorkflow).not.toHaveBeenCalled();
+    expect(disableWorkflow).not.toHaveBeenCalled();
+    expect(archiveWorkflow).not.toHaveBeenCalled();
+    expect(unarchiveWorkflow).not.toHaveBeenCalled();
+  });
+
   test("blocks enable with a toast when the pre-flight flush fails", async () => {
     getWorkflow.mockResolvedValue(apiWorkflow);
     updateWorkflow.mockRejectedValue(offlineError());

--- a/apps/web/modules/ee/workflows/hooks/use-workflow-builder.test.ts
+++ b/apps/web/modules/ee/workflows/hooks/use-workflow-builder.test.ts
@@ -586,6 +586,7 @@ describe("autosave", () => {
       store.set(hydrateWorkflowEditorAtom, {
         workflow: { ...apiWorkflow, id: "wf-other", name: "Another workflow" },
         flowNodes: [],
+        isReadOnly: false,
       });
       store.set(setWorkflowNameAtom, "Edited on the other workflow");
     });

--- a/apps/web/modules/ee/workflows/hooks/use-workflow-builder.ts
+++ b/apps/web/modules/ee/workflows/hooks/use-workflow-builder.ts
@@ -188,6 +188,7 @@ export const useWorkflowBuilder = ({
         hydrateEditor({
           workflow: loadedWorkflow,
           flowNodes: workflowDefinitionToFlowNodes(loadedWorkflow.definition, t),
+          isReadOnly,
         });
       })
       .catch((error) => {
@@ -202,7 +203,7 @@ export const useWorkflowBuilder = ({
       });
 
     return () => controller.abort();
-  }, [workspaceId, workflowId, hydrateEditor, setWorkflow, store, t, loadOnMount]);
+  }, [workspaceId, workflowId, hydrateEditor, setWorkflow, store, t, loadOnMount, isReadOnly]);
 
   const isArchived = workflow?.status === "archived";
   const isEnabled = workflow?.status === "enabled";
@@ -402,6 +403,10 @@ export const useWorkflowBuilder = ({
   const transition = useCallback(
     async (operation: "enable" | "disable" | "archive" | "unarchive") => {
       if (!workflow) return;
+      // Permission gate at the hook layer, not just the UI: the server rejects every lifecycle call
+      // from a read-only member with 403, so never fire the request (and never flush a save on their
+      // behalf below). The header also hides these controls, but the hook must not rely on that.
+      if (isReadOnly) return;
       // Serialize against a save or another transition in flight; overlapping lifecycle writes
       // race and the last response to land wins, desyncing the displayed status from the server.
       if (store.get(isWorkflowSavingAtom) || store.get(isWorkflowTransitioningAtom)) return;
@@ -457,7 +462,7 @@ export const useWorkflowBuilder = ({
         setIsTransitioning(false);
       }
     },
-    [store, workflow, setWorkflow, setIsTransitioning, save, t]
+    [store, workflow, setWorkflow, setIsTransitioning, save, t, isReadOnly]
   );
 
   return {

--- a/apps/web/modules/ee/workflows/hooks/use-workflow-node-url-sync.test.ts
+++ b/apps/web/modules/ee/workflows/hooks/use-workflow-node-url-sync.test.ts
@@ -44,6 +44,7 @@ const renderSync = (isEnabled = true) => {
   store.set(hydrateWorkflowEditorAtom, {
     workflow,
     flowNodes: [flowNode("trigger-1"), flowNode("email-1")],
+    isReadOnly: false,
   });
   const wrapper = ({ children }: { children: ReactNode }) => createElement(Provider, { store }, children);
   return { store, ...renderHook(() => useWorkflowNodeUrlSync({ isEnabled }), { wrapper }) };

--- a/apps/web/modules/ee/workflows/state/editor.test.ts
+++ b/apps/web/modules/ee/workflows/state/editor.test.ts
@@ -69,7 +69,7 @@ const workflow = {
 describe("hydrateWorkflowEditorAtom", () => {
   test("seeds name, description, definition, selection from the workflow", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [], isReadOnly: false });
 
     expect(store.get(workflowAtom)).toBe(workflow);
     expect(store.get(workflowNameAtom)).toBe("Hello");
@@ -83,6 +83,7 @@ describe("hydrateWorkflowEditorAtom", () => {
     store.set(hydrateWorkflowEditorAtom, {
       workflow: { ...workflow, description: null } as unknown as TWorkflowResource,
       flowNodes: [],
+      isReadOnly: false,
     });
 
     expect(store.get(workflowDescriptionAtom)).toBe("");
@@ -133,7 +134,7 @@ describe("definition + flow node updaters accept value or callback", () => {
     // 'width'" as soon as it measured a node.
     const store = createStore();
     const node = { id: "n1", measured: { width: 100, height: 40 } };
-    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [node as never] });
+    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [node as never], isReadOnly: false });
     store.set(setWorkflowNameAtom, "renamed");
 
     const [storedNode] = store.get(workflowFlowNodesAtom);
@@ -189,7 +190,11 @@ describe("canEditWorkflowDefinitionAtom", () => {
     ["archived", false],
   ])("status %s -> %s", (status, expected) => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow: workflowWithStatus(status), flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, {
+      workflow: workflowWithStatus(status),
+      flowNodes: [],
+      isReadOnly: false,
+    });
     expect(store.get(canEditWorkflowDefinitionAtom)).toBe(expected);
   });
 
@@ -212,7 +217,11 @@ describe("canEditWorkflowDefinitionAtom", () => {
 describe("canMutateCanvasAtom", () => {
   test("requires an editable status AND an unlocked canvas", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow: workflowWithStatus("draft"), flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, {
+      workflow: workflowWithStatus("draft"),
+      flowNodes: [],
+      isReadOnly: false,
+    });
 
     // Canvas starts in pointer mode (unlocked), so a draft is mutable right away.
     expect(store.get(isCanvasLockedAtom)).toBe(false);
@@ -225,7 +234,11 @@ describe("canMutateCanvasAtom", () => {
     expect(store.get(canMutateCanvasAtom)).toBe(true);
 
     // Editable status removed -> blocked again even while unlocked.
-    store.set(hydrateWorkflowEditorAtom, { workflow: workflowWithStatus("enabled"), flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, {
+      workflow: workflowWithStatus("enabled"),
+      flowNodes: [],
+      isReadOnly: false,
+    });
     store.set(isCanvasLockedAtom, false);
     expect(store.get(canMutateCanvasAtom)).toBe(false);
   });
@@ -491,7 +504,7 @@ describe("hydrateWorkflowEditorAtom with a trigger-less draft", () => {
       ...workflow,
       definition: { ...definition, trigger: null, entryNodeId: null },
     } as unknown as TWorkflowResource;
-    store.set(hydrateWorkflowEditorAtom, { workflow: triggerlessWorkflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow: triggerlessWorkflow, flowNodes: [], isReadOnly: false });
 
     expect(store.get(selectedWorkflowNodeIdAtom)).toBeNull();
   });
@@ -519,7 +532,7 @@ describe("deleteWorkflowNodeAtom bridge without sourceHandle", () => {
 describe("isWorkflowDirtyAtom + markWorkflowDraftSavedAtom", () => {
   test("is clean right after hydrate and dirty after an edit", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [], isReadOnly: false });
 
     expect(store.get(isWorkflowDirtyAtom)).toBe(false);
 
@@ -529,7 +542,7 @@ describe("isWorkflowDirtyAtom + markWorkflowDraftSavedAtom", () => {
 
   test("trailing whitespace the save flow trims anyway does not count as dirty", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [], isReadOnly: false });
 
     store.set(setWorkflowNameAtom, "Hello ");
     expect(store.get(isWorkflowDirtyAtom)).toBe(false);
@@ -537,7 +550,7 @@ describe("isWorkflowDirtyAtom + markWorkflowDraftSavedAtom", () => {
 
   test("markWorkflowDraftSavedAtom records the sent draft, so mid-flight edits stay dirty", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [], isReadOnly: false });
     store.set(setWorkflowNameAtom, "Renamed");
     // Simulates an edit landing while the PATCH for "Renamed" was in flight.
     store.set(setWorkflowDescriptionAtom, "Edited during save");
@@ -560,7 +573,7 @@ describe("isWorkflowDirtyAtom + markWorkflowDraftSavedAtom", () => {
 
   test("definition edits count as dirty", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [], isReadOnly: false });
 
     store.set(setWorkflowDefinitionAtom, (current) =>
       current ? { ...current, edges: [...current.edges] } : current
@@ -580,7 +593,7 @@ describe("isWorkflowDirtyAtom + markWorkflowDraftSavedAtom", () => {
 describe("workflow save error", () => {
   test("a successful save clears the failed state in the same write as lastSavedAt", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [], isReadOnly: false });
     store.set(setWorkflowNameAtom, "Renamed");
     // save() records the failure against the signature of the draft it actually sent.
     store.set(setWorkflowSaveErrorAtom, {
@@ -604,7 +617,7 @@ describe("workflow save error", () => {
 
   test("reverting the draft clears the alarm without a save", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [], isReadOnly: false });
     store.set(setWorkflowNameAtom, "Renamed");
     const failedError = {
       draftSignature: store.get(workflowDraftSignatureAtom),
@@ -623,7 +636,7 @@ describe("workflow save error", () => {
 
   test("the failed state is scoped to the draft that failed", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [], isReadOnly: false });
     store.set(setWorkflowNameAtom, "Renamed");
     store.set(setWorkflowSaveErrorAtom, {
       draftSignature: store.get(workflowDraftSignatureAtom),
@@ -642,7 +655,7 @@ describe("workflow save error", () => {
 
   test("a redundant clear does not churn editor state", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [], isReadOnly: false });
     const before = store.get(workflowEditorAtom);
 
     store.set(setWorkflowSaveErrorAtom, null);
@@ -654,7 +667,7 @@ describe("workflow save error", () => {
 describe("workflowDraftSignatureAtom", () => {
   test("changes with any editable field and is stable otherwise", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow, flowNodes: [], isReadOnly: false });
     const hydrated = store.get(workflowDraftSignatureAtom);
 
     store.set(setWorkflowNameAtom, "Renamed");
@@ -708,7 +721,7 @@ describe("workflowValidityAtom", () => {
 
   test("is ready when the name is set, the definition is executable, and the survey resolves", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow: executableWorkflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow: executableWorkflow, flowNodes: [], isReadOnly: false });
 
     expect(store.get(workflowValidityAtom)).toEqual({
       isNameValid: true,
@@ -720,7 +733,7 @@ describe("workflowValidityAtom", () => {
 
   test("an empty name makes the workflow not ready", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow: executableWorkflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow: executableWorkflow, flowNodes: [], isReadOnly: false });
     store.set(setWorkflowNameAtom, "   ");
 
     const validity = store.get(workflowValidityAtom);
@@ -730,7 +743,7 @@ describe("workflowValidityAtom", () => {
 
   test("an incomplete send_email node makes the definition not executable", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow: executableWorkflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow: executableWorkflow, flowNodes: [], isReadOnly: false });
     store.set(setWorkflowDefinitionAtom, (current) =>
       current
         ? {
@@ -749,7 +762,7 @@ describe("workflowValidityAtom", () => {
 
   test("an unresolved trigger survey makes the workflow not ready", () => {
     const store = createStore();
-    store.set(hydrateWorkflowEditorAtom, { workflow: executableWorkflow, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow: executableWorkflow, flowNodes: [], isReadOnly: false });
     store.set(hasBoundTriggerSurveyAtom, false);
 
     const validity = store.get(workflowValidityAtom);
@@ -764,7 +777,7 @@ describe("workflowValidityAtom", () => {
       ...workflow,
       definition: { ...executableDefinition, trigger: null, nodes: [], edges: [], entryNodeId: null },
     } as unknown as TWorkflowResource;
-    store.set(hydrateWorkflowEditorAtom, { workflow: triggerless, flowNodes: [] });
+    store.set(hydrateWorkflowEditorAtom, { workflow: triggerless, flowNodes: [], isReadOnly: false });
 
     expect(store.get(workflowValidityAtom).isDefinitionExecutable).toBe(false);
   });
@@ -804,6 +817,7 @@ describe("workflowValidationProblemsAtom", () => {
     store.set(hydrateWorkflowEditorAtom, {
       workflow: { ...workflow, definition } as unknown as TWorkflowResource,
       flowNodes: [],
+      isReadOnly: false,
     });
   };
 

--- a/apps/web/modules/ee/workflows/state/editor.test.ts
+++ b/apps/web/modules/ee/workflows/state/editor.test.ts
@@ -197,6 +197,16 @@ describe("canEditWorkflowDefinitionAtom", () => {
     const store = createStore();
     expect(store.get(canEditWorkflowDefinitionAtom)).toBe(false);
   });
+
+  test("is false for a read-only member even on an editable status", () => {
+    const store = createStore();
+    store.set(hydrateWorkflowEditorAtom, {
+      workflow: workflowWithStatus("draft"),
+      flowNodes: [],
+      isReadOnly: true,
+    });
+    expect(store.get(canEditWorkflowDefinitionAtom)).toBe(false);
+  });
 });
 
 describe("canMutateCanvasAtom", () => {
@@ -217,6 +227,17 @@ describe("canMutateCanvasAtom", () => {
     // Editable status removed -> blocked again even while unlocked.
     store.set(hydrateWorkflowEditorAtom, { workflow: workflowWithStatus("enabled"), flowNodes: [] });
     store.set(isCanvasLockedAtom, false);
+    expect(store.get(canMutateCanvasAtom)).toBe(false);
+  });
+
+  test("is false for a read-only member on an editable, unlocked canvas", () => {
+    const store = createStore();
+    store.set(hydrateWorkflowEditorAtom, {
+      workflow: workflowWithStatus("draft"),
+      flowNodes: [],
+      isReadOnly: true,
+    });
+    expect(store.get(isCanvasLockedAtom)).toBe(false);
     expect(store.get(canMutateCanvasAtom)).toBe(false);
   });
 });

--- a/apps/web/modules/ee/workflows/state/editor.ts
+++ b/apps/web/modules/ee/workflows/state/editor.ts
@@ -77,6 +77,12 @@ export type TWorkflowSaveError = {
 
 type TWorkflowEditorState = {
   workflow: TWorkflowResource | null;
+  /**
+   * Auth-derived: the current member has read-only workspace access. Seeded at hydrate time so the
+   * canvas atoms (which the node card reads directly, bypassing the hook layer) can gate mutations
+   * on permissions, not just status. See canEditWorkflowDefinitionAtom.
+   */
+  isReadOnly: boolean;
   workflowName: string;
   workflowDescription: string;
   definition: TWorkflowDefinition | null;
@@ -95,6 +101,7 @@ type TWorkflowEditorState = {
 
 const initialWorkflowEditorState: TWorkflowEditorState = {
   workflow: null,
+  isReadOnly: false,
   workflowName: "",
   workflowDescription: "",
   definition: null,
@@ -422,12 +429,19 @@ export const workflowValidationProblemsAtom = atom((get) => get(workflowValidati
 // user-driven — nothing auto-switches it; mutations are gated separately by canMutateCanvasAtom.
 export const isCanvasLockedAtom = atom<boolean>(false);
 
-// Derived: the workflow's definition is editable when its status allows it (the API rejects
-// definition PATCHes on enabled / archived workflows). The auth-derived `isReadOnly` flag is
-// applied separately by the hook layer; this atom is the status check the canvas + inspector
-// share for hiding/disabling structural controls.
+// Auth-derived read-only flag, seeded at hydrate time. Exposed so the inspector can name the
+// actual reason edits are blocked (permission vs. status).
+export const isWorkflowReadOnlyAtom = atom((get) => get(workflowEditorAtom).isReadOnly);
+
+// Derived: the workflow's definition is editable when both status and permissions allow it. The API
+// rejects definition PATCHes on enabled / archived workflows, and a read-only member may not edit at
+// all. This atom is the single source the canvas node card reads directly — folding `isReadOnly` in
+// here (rather than only in the hook layer) keeps that card from offering add/delete/drag to a
+// read-only member on a draft workflow, where the status check alone would pass.
 export const canEditWorkflowDefinitionAtom = atom((get) => {
-  const status = get(workflowEditorAtom).workflow?.status;
+  const state = get(workflowEditorAtom);
+  if (state.isReadOnly) return false;
+  const status = state.workflow?.status;
   return status === "draft" || status === "disabled";
 });
 
@@ -475,9 +489,11 @@ export const hydrateWorkflowEditorAtom = atom(
     {
       workflow,
       flowNodes,
+      isReadOnly = false,
     }: {
       workflow: TWorkflowResource;
       flowNodes: Array<Node<TWorkflowNodeData>>;
+      isReadOnly?: boolean;
     }
   ) => {
     // Optimistic default until the builder page re-syncs it from the authoring context;
@@ -491,6 +507,7 @@ export const hydrateWorkflowEditorAtom = atom(
       workflowEditorAtom,
       produce(initialWorkflowEditorState, (draft) => {
         draft.workflow = workflow;
+        draft.isReadOnly = isReadOnly;
         draft.workflowName = workflow.name;
         draft.workflowDescription = workflow.description ?? "";
         draft.definition = workflow.definition;

--- a/apps/web/modules/ee/workflows/state/editor.ts
+++ b/apps/web/modules/ee/workflows/state/editor.ts
@@ -121,6 +121,7 @@ export const workflowEditorAtom = atom<TWorkflowEditorState>(initialWorkflowEdit
 
 export const workflowAtom = atom((get) => get(workflowEditorAtom).workflow);
 export const workflowNameAtom = atom((get) => get(workflowEditorAtom).workflowName);
+export const workflowStatusAtom = atom((get) => get(workflowEditorAtom).workflow?.status ?? null);
 export const workflowDescriptionAtom = atom((get) => get(workflowEditorAtom).workflowDescription);
 export const workflowDefinitionAtom = atom((get) => get(workflowEditorAtom).definition);
 export const selectedWorkflowNodeIdAtom = atom((get) => get(workflowEditorAtom).selectedNodeId);
@@ -489,11 +490,11 @@ export const hydrateWorkflowEditorAtom = atom(
     {
       workflow,
       flowNodes,
-      isReadOnly = false,
+      isReadOnly,
     }: {
       workflow: TWorkflowResource;
       flowNodes: Array<Node<TWorkflowNodeData>>;
-      isReadOnly?: boolean;
+      isReadOnly: boolean;
     }
   ) => {
     // Optimistic default until the builder page re-syncs it from the authoring context;


### PR DESCRIPTION
## What & why

A read-only workspace member opened the workflow editor and, despite the "Read-only" pill, got a broadly interactive editor. Three defects, one theme — the UI advertised edits the server can never accept and explained them wrongly:

- **Lifecycle dropdown opened despite being disabled.** `disabled` was passed only to the child `Button`, not to `DropdownMenuTrigger`; Radix's open guard reads the trigger's own prop, so the DOM attribute and the JS guard disagreed and the menu opened. Enable / Unarchive / Delete then fired real mutations (all 403s).
- **Canvas add/delete/drag were live.** `workflow-canvas-node.tsx` reads `canMutateCanvasAtom` directly, and that atom checked status only — no permission. On a draft/disabled workflow the status check passed, so structural edits went live against local state that autosave never persists (silently lost on reload).
- **Wrong blocked-edit copy.** The inspector always showed "Disable the workflow to make changes here.", even for read-only members and archived workflows where that instruction is wrong.

Fix:

- Fold `isReadOnly` into the editor state and `canEditWorkflowDefinitionAtom`, seeded at hydrate time, so the node card gates on permissions, not just status — one source of truth instead of two.
- Pass `disabled` to `DropdownMenuTrigger` **and** withhold the menu content from read-only members (the list page hides its actions the same way).
- Guard `transition()` in the hook so lifecycle ops never fire for a read-only member, independent of UI gating.
- Replace the single `edit_blocked_active` string with reason-aware copy: no-permission / archived / enabled (permission wins).

No security or data impact: server-side authz already rejects every lifecycle call with 403 and autosave never fired for read-only users. This is a presentation/affordance fix.

## Linear ticket

Fixes ENG-2176

## How this was tested

- `pnpm vitest run` on the two affected suites — **102 passed**:
  - `state/editor.test.ts` (64) — added cases: `canEditWorkflowDefinitionAtom` and `canMutateCanvasAtom` are `false` for a read-only member on an editable/unlocked draft.
  - `hooks/use-workflow-builder.test.ts` (38) — added: a read-only member fires none of enable/disable/archive/unarchive.
- `eslint` + `prettier` clean on all changed files.
- Typecheck: no errors in the changed files (the worktree's unbuilt-package module-resolution noise is unrelated).

<!-- UI change: attach a before/after of the lifecycle dropdown (no longer opens for read-only) and the inspector alert copy. -->

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Preconditions below. As a **read-only** member, open `/workspaces/<workspaceId>/workflows/<workflowId>` on a **draft** workflow.
- [ ] Header shows the "Read-only" pill; click the status dropdown trigger → **it does not open** (no menu, no items).
- [ ] On the canvas: the trigger card shows **no `+`** affordance; nodes have **no delete/drag** and no context menu.
- [ ] Select a node → inspector alert reads **"You don't have permission to edit this workflow."** (not "Disable the workflow…").
- [ ] Repeat on an **archived** workflow as an editor (owner/manager) → inspector alert reads **"Unarchive the workflow to make changes here."**
- [ ] Repeat on an **enabled** workflow as an editor → inspector alert still reads **"Disable the workflow to make changes here."**
- [ ] Regression (editor role): owner/manager on a draft can still open the lifecycle menu, add/delete/drag nodes, and Enable/Disable/Archive/Unarchive as before.

**Preconditions / test data**

- EE-entitled org (Workflows is Enterprise-gated). A member with **read-only** workspace access, plus an owner/manager to verify the editable path. Workflows in draft, enabled, and archived status.

**Risks & regressions**

- Lifecycle menu gating and canvas node affordances for editor roles — confirm nothing was over-gated. Inspector field editing for editors unchanged (field-level gating already lived in `handleChange`).

**Migrations / env / cutover**

- none
