### PR TITLE
fix(surveys): open pasted links in a new tab and keep element text selectable

### DIFF
--- a/apps/web/modules/ui/components/editor/components/auto-link-matchers.test.ts
+++ b/apps/web/modules/ui/components/editor/components/auto-link-matchers.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+import { LINK_ATTRIBUTES, MATCHERS } from "./auto-link-matchers";
+
+const [matchUrl, matchEmail] = MATCHERS;
+
+describe("auto-link matchers", () => {
+  describe("URL matcher", () => {
+    test.each([
+      ["https://formbricks.com", "https://formbricks.com"],
+      ["http://formbricks.com/path?a=1", "http://formbricks.com/path?a=1"],
+      ["www.formbricks.com", "www.formbricks.com"],
+    ])("auto-links %s so it opens in a new tab", (input, expectedUrl) => {
+      const match = matchUrl(input);
+
+      expect(match).not.toBeNull();
+      expect(match?.url).toBe(expectedUrl);
+      // Auto-linked URLs must carry the same attributes the link toolbar applies,
+      // otherwise following one mid-survey navigates the respondent away from their
+      // in-progress response.
+      expect(match?.attributes).toEqual({ target: "_blank", rel: "noopener noreferrer" });
+    });
+
+    test("reports the offset and length of a URL inside surrounding text", () => {
+      const match = matchUrl("visit https://formbricks.com now");
+
+      expect(match).toMatchObject({
+        index: 6,
+        length: "https://formbricks.com".length,
+        text: "https://formbricks.com",
+        attributes: LINK_ATTRIBUTES,
+      });
+    });
+
+    test("returns null when there is no URL", () => {
+      expect(matchUrl("no link in here")).toBeNull();
+    });
+  });
+
+  describe("email matcher", () => {
+    test("auto-links an email address as mailto and keeps the current tab", () => {
+      const match = matchEmail("hi@formbricks.com");
+
+      expect(match).toMatchObject({
+        index: 0,
+        length: "hi@formbricks.com".length,
+        text: "hi@formbricks.com",
+        url: "mailto:hi@formbricks.com",
+      });
+      // No target/rel: handing off to the mail client must not open a blank tab.
+      expect(match?.attributes).toBeUndefined();
+    });
+
+    test("returns null when there is no email address", () => {
+      expect(matchEmail("no address in here")).toBeNull();
+    });
+  });
+});

--- a/apps/web/modules/ui/components/editor/components/auto-link-matchers.ts
+++ b/apps/web/modules/ui/components/editor/components/auto-link-matchers.ts
@@ -1,7 +1,7 @@
 import type { LinkMatcher } from "@lexical/link";
 
 const URL_MATCHER =
-  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
+  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&/=]*)/;
 
 const EMAIL_MATCHER = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/;
 

--- a/apps/web/modules/ui/components/editor/components/auto-link-matchers.ts
+++ b/apps/web/modules/ui/components/editor/components/auto-link-matchers.ts
@@ -1,0 +1,43 @@
+import type { LinkMatcher } from "@lexical/link";
+
+const URL_MATCHER =
+  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
+
+const EMAIL_MATCHER = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/;
+
+// Auto-linked URLs must behave like links inserted through the link toolbar, which
+// sets the same attributes: a survey opened in the same tab navigates the respondent
+// away from an in-progress response.
+export const LINK_ATTRIBUTES = {
+  target: "_blank",
+  rel: "noopener noreferrer",
+};
+
+const matchUrl: LinkMatcher = (text) => {
+  const match = URL_MATCHER.exec(text);
+  if (!match) return null;
+
+  return {
+    index: match.index,
+    length: match[0].length,
+    text: match[0],
+    url: match[0],
+    attributes: LINK_ATTRIBUTES,
+  };
+};
+
+// mailto: links deliberately keep the current tab — handing off to the mail client
+// does not navigate the respondent away from their in-progress response.
+const matchEmail: LinkMatcher = (text) => {
+  const match = EMAIL_MATCHER.exec(text);
+  if (!match) return null;
+
+  return {
+    index: match.index,
+    length: match[0].length,
+    text: match[0],
+    url: `mailto:${match[0]}`,
+  };
+};
+
+export const MATCHERS: LinkMatcher[] = [matchUrl, matchEmail];

--- a/apps/web/modules/ui/components/editor/components/auto-link-plugin.tsx
+++ b/apps/web/modules/ui/components/editor/components/auto-link-plugin.tsx
@@ -4,6 +4,15 @@ const URL_MATCHER =
   /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
 
 const EMAIL_MATCHER = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/;
+
+// Auto-linked URLs must behave like links inserted through the link toolbar, which
+// sets the same attributes: a survey opened in the same tab navigates the respondent
+// away from an in-progress response.
+const LINK_ATTRIBUTES = {
+  target: "_blank",
+  rel: "noopener noreferrer",
+};
+
 const MATCHERS = [
   (text: any) => {
     const match = URL_MATCHER.exec(text);
@@ -13,6 +22,7 @@ const MATCHERS = [
         length: match[0].length,
         text: match[0],
         url: match[0],
+        attributes: LINK_ATTRIBUTES,
       }
     );
   },

--- a/apps/web/modules/ui/components/editor/components/auto-link-plugin.tsx
+++ b/apps/web/modules/ui/components/editor/components/auto-link-plugin.tsx
@@ -1,43 +1,5 @@
 import { AutoLinkPlugin } from "@lexical/react/LexicalAutoLinkPlugin";
-
-const URL_MATCHER =
-  /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)/;
-
-const EMAIL_MATCHER = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/;
-
-// Auto-linked URLs must behave like links inserted through the link toolbar, which
-// sets the same attributes: a survey opened in the same tab navigates the respondent
-// away from an in-progress response.
-const LINK_ATTRIBUTES = {
-  target: "_blank",
-  rel: "noopener noreferrer",
-};
-
-const MATCHERS = [
-  (text: any) => {
-    const match = URL_MATCHER.exec(text);
-    return (
-      match && {
-        index: match.index,
-        length: match[0].length,
-        text: match[0],
-        url: match[0],
-        attributes: LINK_ATTRIBUTES,
-      }
-    );
-  },
-  (text: any) => {
-    const match = EMAIL_MATCHER.exec(text);
-    return (
-      match && {
-        index: match.index,
-        length: match[0].length,
-        text: match[0],
-        url: `mailto:${match[0]}`,
-      }
-    );
-  },
-];
+import { MATCHERS } from "./auto-link-matchers";
 
 export const PlaygroundAutoLinkPlugin = () => {
   return <AutoLinkPlugin matchers={MATCHERS} />;

--- a/packages/survey-ui/src/components/general/label.tsx
+++ b/packages/survey-ui/src/components/general/label.tsx
@@ -8,17 +8,15 @@ interface LabelProps extends React.ComponentProps<"label"> {
   variant?: LabelVariant;
 }
 
-const VARIANT_CLASSES: Record<LabelVariant, string> = {
-  default: "label-default",
-  headline: "label-headline",
-  description: "label-description",
-  card: "label-card",
-};
-
 // Element headlines and descriptions are content respondents read (and may want to
 // copy or have translated), so they stay selectable. Labels that act as controls —
 // choices, cards — keep select-none so a stray drag doesn't highlight them.
-const READABLE_VARIANTS: LabelVariant[] = ["headline", "description"];
+const VARIANT_CLASSES: Record<LabelVariant, string> = {
+  default: "label-default select-none",
+  headline: "label-headline select-text",
+  description: "label-description select-text",
+  card: "label-card select-none",
+};
 
 /**
  * Checks if a string contains valid HTML markup
@@ -56,7 +54,6 @@ function Label({
   const baseClasses = cn(
     isHtml && safeHtml ? "flex flex-col gap-2" : "flex items-center gap-2",
     "leading-6 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-    READABLE_VARIANTS.includes(variant) ? "select-text" : "select-none",
     VARIANT_CLASSES[variant]
   );
 

--- a/packages/survey-ui/src/components/general/label.tsx
+++ b/packages/survey-ui/src/components/general/label.tsx
@@ -1,6 +1,5 @@
-import { sanitize } from "isomorphic-dompurify";
 import * as React from "react";
-import { cn, stripInlineStyles } from "@/lib/utils";
+import { cn, sanitizeSurveyHtml, stripInlineStyles } from "@/lib/utils";
 
 interface LabelProps extends React.ComponentProps<"label"> {
   /** Label variant for different styling contexts */
@@ -37,13 +36,7 @@ function Label({
   const childrenString = typeof children === "string" ? children : null;
   const strippedContent = childrenString ? stripInlineStyles(childrenString) : "";
   const isHtml = childrenString ? isValidHTML(strippedContent) : false;
-  const safeHtml =
-    isHtml && strippedContent
-      ? sanitize(strippedContent, {
-          ADD_ATTR: ["target"],
-          FORBID_ATTR: ["style"],
-        })
-      : "";
+  const safeHtml = isHtml && strippedContent ? sanitizeSurveyHtml(strippedContent) : "";
 
   // Determine variant class
   let variantClass = "label-default";
@@ -55,11 +48,17 @@ function Label({
     variantClass = "label-card";
   }
 
+  // Element headlines and descriptions are content respondents read (and may want to
+  // copy or have translated), so they stay selectable. Labels that act as controls —
+  // choices, cards — keep select-none so a stray drag doesn't highlight them.
+  const isReadableContent = variant === "headline" || variant === "description";
+
   // Base classes - use flex-col for HTML content to allow line breaks, flex items-center for non-HTML
-  const baseClasses =
-    isHtml && safeHtml
-      ? "flex flex-col gap-2 leading-6 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50"
-      : "flex items-center gap-2 leading-6 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50";
+  const baseClasses = cn(
+    isHtml && safeHtml ? "flex flex-col gap-2" : "flex items-center gap-2",
+    "leading-6 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+    isReadableContent ? "select-text" : "select-none"
+  );
 
   // If HTML, render with dangerouslySetInnerHTML, otherwise render normally
   if (isHtml && safeHtml) {
@@ -93,11 +92,7 @@ function Label({
       <label
         data-slot="label"
         data-variant={variant}
-        className={cn(
-          "flex items-center gap-2 leading-6 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-          variantClass,
-          className
-        )}
+        className={cn(baseClasses, variantClass, className)}
         htmlFor={htmlFor}
         form={form}
         {...restProps}>
@@ -110,11 +105,7 @@ function Label({
     <span
       data-slot="label"
       data-variant={variant}
-      className={cn(
-        "flex items-center gap-2 leading-6 select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        variantClass,
-        className
-      )}
+      className={cn(baseClasses, variantClass, className)}
       {...restProps}>
       {children}
     </span>

--- a/packages/survey-ui/src/components/general/label.tsx
+++ b/packages/survey-ui/src/components/general/label.tsx
@@ -1,10 +1,24 @@
 import * as React from "react";
 import { cn, sanitizeSurveyHtml, stripInlineStyles } from "@/lib/utils";
 
+type LabelVariant = "default" | "headline" | "description" | "card";
+
 interface LabelProps extends React.ComponentProps<"label"> {
   /** Label variant for different styling contexts */
-  variant?: "default" | "headline" | "description" | "card";
+  variant?: LabelVariant;
 }
+
+const VARIANT_CLASSES: Record<LabelVariant, string> = {
+  default: "label-default",
+  headline: "label-headline",
+  description: "label-description",
+  card: "label-card",
+};
+
+// Element headlines and descriptions are content respondents read (and may want to
+// copy or have translated), so they stay selectable. Labels that act as controls —
+// choices, cards — keep select-none so a stray drag doesn't highlight them.
+const READABLE_VARIANTS: LabelVariant[] = ["headline", "description"];
 
 /**
  * Checks if a string contains valid HTML markup
@@ -38,26 +52,12 @@ function Label({
   const isHtml = childrenString ? isValidHTML(strippedContent) : false;
   const safeHtml = isHtml && strippedContent ? sanitizeSurveyHtml(strippedContent) : "";
 
-  // Determine variant class
-  let variantClass = "label-default";
-  if (variant === "headline") {
-    variantClass = "label-headline";
-  } else if (variant === "description") {
-    variantClass = "label-description";
-  } else if (variant === "card") {
-    variantClass = "label-card";
-  }
-
-  // Element headlines and descriptions are content respondents read (and may want to
-  // copy or have translated), so they stay selectable. Labels that act as controls —
-  // choices, cards — keep select-none so a stray drag doesn't highlight them.
-  const isReadableContent = variant === "headline" || variant === "description";
-
   // Base classes - use flex-col for HTML content to allow line breaks, flex items-center for non-HTML
   const baseClasses = cn(
     isHtml && safeHtml ? "flex flex-col gap-2" : "flex items-center gap-2",
     "leading-6 group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-    isReadableContent ? "select-text" : "select-none"
+    READABLE_VARIANTS.includes(variant) ? "select-text" : "select-none",
+    VARIANT_CLASSES[variant]
   );
 
   // If HTML, render with dangerouslySetInnerHTML, otherwise render normally
@@ -67,7 +67,7 @@ function Label({
         <label
           data-slot="label"
           data-variant={variant}
-          className={cn(baseClasses, variantClass, className)}
+          className={cn(baseClasses, className)}
           htmlFor={htmlFor}
           form={form}
           {...restProps}
@@ -80,7 +80,7 @@ function Label({
       <span
         data-slot="label"
         data-variant={variant}
-        className={cn(baseClasses, variantClass, className)}
+        className={cn(baseClasses, className)}
         {...restProps}
         dangerouslySetInnerHTML={{ __html: safeHtml }}
       />
@@ -92,7 +92,7 @@ function Label({
       <label
         data-slot="label"
         data-variant={variant}
-        className={cn(baseClasses, variantClass, className)}
+        className={cn(baseClasses, className)}
         htmlFor={htmlFor}
         form={form}
         {...restProps}>
@@ -102,15 +102,11 @@ function Label({
   }
 
   return (
-    <span
-      data-slot="label"
-      data-variant={variant}
-      className={cn(baseClasses, variantClass, className)}
-      {...restProps}>
+    <span data-slot="label" data-variant={variant} className={cn(baseClasses, className)} {...restProps}>
       {children}
     </span>
   );
 }
 
 export { Label };
-export type { LabelProps };
+export type { LabelProps, LabelVariant };

--- a/packages/survey-ui/src/index.ts
+++ b/packages/survey-ui/src/index.ts
@@ -35,6 +35,7 @@ export {
 export { Matrix, type MatrixProps, type MatrixOption } from "@/components/elements/matrix";
 export { DateElement, type DateElementProps } from "@/components/elements/date";
 export { getDateFnsLocale } from "@/lib/locale";
+export { sanitizeSurveyHtml } from "@/lib/utils";
 export { isSafeMediaUrl } from "@/lib/video";
 export {
   PictureSelect,

--- a/packages/survey-ui/src/lib/utils-sanitize.test.ts
+++ b/packages/survey-ui/src/lib/utils-sanitize.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+// Kept out of `utils.test.ts`, which mocks isomorphic-dompurify away — these cases need
+// the real sanitizer to prove what survives it.
+import { sanitizeSurveyHtml, stripInlineStyles } from "./utils";
+
+describe("sanitizeSurveyHtml", () => {
+  test("opens a link pasted as plain text in a new tab", () => {
+    const sanitized = sanitizeSurveyHtml('<p>Read the <a href="https://example.com">policy</a></p>');
+
+    expect(sanitized).toContain('target="_blank"');
+    expect(sanitized).toContain('rel="noopener noreferrer"');
+  });
+
+  test("keeps links that already target a new tab", () => {
+    const sanitized = sanitizeSurveyHtml('<a href="https://example.com" target="_blank">Go</a>');
+
+    expect(sanitized).toContain('target="_blank"');
+    expect(sanitized).toContain('rel="noopener noreferrer"');
+  });
+
+  test("leaves an explicit same-tab target alone", () => {
+    const sanitized = sanitizeSurveyHtml('<a href="https://example.com" target="_self">Go</a>');
+
+    expect(sanitized).toContain('target="_self"');
+    expect(sanitized).not.toContain("noopener");
+  });
+
+  test("strips inline styles and dangerous markup", () => {
+    const sanitized = sanitizeSurveyHtml(
+      '<script>alert("x")</script><a href="https://example.com" onclick="alert(1)" style="color:red">Go</a>'
+    );
+
+    expect(sanitized).not.toContain("<script");
+    expect(sanitized).not.toContain("onclick=");
+    expect(sanitized).not.toContain("style=");
+  });
+
+  test("returns empty string unchanged", () => {
+    expect(sanitizeSurveyHtml("")).toBe("");
+  });
+
+  test("does not leak its link handling into later sanitize calls", () => {
+    sanitizeSurveyHtml('<a href="https://example.com">Go</a>');
+
+    expect(stripInlineStyles('<a href="https://example.com">Go</a>')).not.toContain("target=");
+  });
+});

--- a/packages/survey-ui/src/lib/utils.ts
+++ b/packages/survey-ui/src/lib/utils.ts
@@ -1,5 +1,5 @@
 import { type ClassValue, clsx } from "clsx";
-import { sanitize } from "isomorphic-dompurify";
+import { addHook, removeHook, sanitize } from "isomorphic-dompurify";
 import { extendTailwindMerge } from "tailwind-merge";
 
 const twMerge = extendTailwindMerge({
@@ -42,6 +42,43 @@ export const stripInlineStyles = (html: string): string => {
     ADD_ATTR: ["target"],
     KEEP_CONTENT: true,
   });
+};
+
+/**
+ * Force every link in survey content to open in a new tab.
+ * Links pasted as plain text are auto-linked without a target, so without this a
+ * respondent following one navigates away from the survey they are filling in.
+ * Kept on the render path so surveys authored before the editor fix behave too.
+ * @param node - The node DOMPurify is currently sanitizing
+ */
+const openLinksInNewTab = (node: Element): void => {
+  if (node.tagName !== "A" || !node.hasAttribute("href")) return;
+  if (!node.getAttribute("target")) {
+    node.setAttribute("target", "_blank");
+  }
+  if (node.getAttribute("target") === "_blank") {
+    node.setAttribute("rel", "noopener noreferrer");
+  }
+};
+
+/**
+ * Sanitize survey content HTML for rendering: strips inline styles (CSP) and makes
+ * links open in a new tab.
+ * @param html - The HTML string to sanitize
+ * @returns Sanitized HTML string, safe to pass to dangerouslySetInnerHTML
+ */
+export const sanitizeSurveyHtml = (html: string): string => {
+  if (!html) return html;
+
+  addHook("afterSanitizeAttributes", openLinksInNewTab);
+  try {
+    return sanitize(stripInlineStyles(html), {
+      ADD_ATTR: ["target"],
+      FORBID_ATTR: ["style"],
+    });
+  } finally {
+    removeHook("afterSanitizeAttributes");
+  }
 };
 
 /**

--- a/packages/surveys/src/components/general/headline.tsx
+++ b/packages/surveys/src/components/general/headline.tsx
@@ -1,6 +1,5 @@
-import DOMPurify from "isomorphic-dompurify";
 import { useTranslation } from "react-i18next";
-import { isValidHTML, stripInlineStyles } from "@/lib/html-utils";
+import { isValidHTML, sanitizeSurveyHtml, stripInlineStyles } from "@/lib/html-utils";
 
 interface HeadlineProps {
   headline: string;
@@ -24,13 +23,7 @@ export function Headline({
   // Strip inline styles BEFORE parsing to avoid CSP violations
   const strippedHeadline = stripInlineStyles(headline);
   const isHeadlineHtml = isValidHTML(strippedHeadline);
-  const safeHtml =
-    isHeadlineHtml && strippedHeadline
-      ? DOMPurify.sanitize(strippedHeadline, {
-          ADD_ATTR: ["target"],
-          FORBID_ATTR: ["style"], // Additional safeguard to remove any remaining inline styles
-        })
-      : "";
+  const safeHtml = isHeadlineHtml && strippedHeadline ? sanitizeSurveyHtml(strippedHeadline) : "";
 
   return (
     <div className="text-heading mb-[3px] flex flex-col">

--- a/packages/surveys/src/components/general/subheader.tsx
+++ b/packages/surveys/src/components/general/subheader.tsx
@@ -1,5 +1,4 @@
-import DOMPurify from "isomorphic-dompurify";
-import { isValidHTML, stripInlineStyles } from "@/lib/html-utils";
+import { isValidHTML, sanitizeSurveyHtml, stripInlineStyles } from "@/lib/html-utils";
 
 interface SubheaderProps {
   subheader?: string;
@@ -9,13 +8,7 @@ export function Subheader({ subheader }: SubheaderProps) {
   // Strip inline styles BEFORE parsing to avoid CSP violations
   const strippedSubheader = subheader ? stripInlineStyles(subheader) : "";
   const isHtml = strippedSubheader ? isValidHTML(strippedSubheader) : false;
-  const safeHtml =
-    isHtml && strippedSubheader
-      ? DOMPurify.sanitize(strippedSubheader, {
-          ADD_ATTR: ["target"],
-          FORBID_ATTR: ["style"], // Additional safeguard to remove any remaining inline styles
-        })
-      : "";
+  const safeHtml = isHtml && strippedSubheader ? sanitizeSurveyHtml(strippedSubheader) : "";
 
   if (!subheader) return null;
 

--- a/packages/surveys/src/lib/html-utils.test.ts
+++ b/packages/surveys/src/lib/html-utils.test.ts
@@ -101,46 +101,14 @@ describe("html-utils", () => {
     });
   });
 
+  // Behavior is covered in survey-ui, which owns the implementation; this checks the
+  // re-export survives the survey bundle's React → Preact aliasing.
   describe("sanitizeSurveyHtml", () => {
     test("opens a link pasted as plain text in a new tab", () => {
       const sanitized = sanitizeSurveyHtml('<p>Read the <a href="https://example.com">policy</a></p>');
 
       expect(sanitized).toContain('target="_blank"');
       expect(sanitized).toContain('rel="noopener noreferrer"');
-    });
-
-    test("keeps links that already target a new tab", () => {
-      const sanitized = sanitizeSurveyHtml('<a href="https://example.com" target="_blank">Go</a>');
-
-      expect(sanitized).toContain('target="_blank"');
-      expect(sanitized).toContain('rel="noopener noreferrer"');
-    });
-
-    test("leaves an explicit same-tab target alone", () => {
-      const sanitized = sanitizeSurveyHtml('<a href="https://example.com" target="_self">Go</a>');
-
-      expect(sanitized).toContain('target="_self"');
-      expect(sanitized).not.toContain("noopener");
-    });
-
-    test("strips inline styles and dangerous markup", () => {
-      const sanitized = sanitizeSurveyHtml(
-        '<script>alert("x")</script><a href="https://example.com" onclick="alert(1)" style="color:red">Go</a>'
-      );
-
-      expect(sanitized).not.toContain("<script");
-      expect(sanitized).not.toContain("onclick=");
-      expect(sanitized).not.toContain("style=");
-    });
-
-    test("returns empty string unchanged", () => {
-      expect(sanitizeSurveyHtml("")).toBe("");
-    });
-
-    test("does not leak its link handling into later sanitize calls", () => {
-      sanitizeSurveyHtml('<a href="https://example.com">Go</a>');
-
-      expect(stripInlineStyles('<a href="https://example.com">Go</a>')).not.toContain("target=");
     });
   });
 });

--- a/packages/surveys/src/lib/html-utils.test.ts
+++ b/packages/surveys/src/lib/html-utils.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { describe, expect, test } from "vitest";
-import { htmlToPlainText, isValidHTML, stripInlineStyles } from "./html-utils";
+import { htmlToPlainText, isValidHTML, sanitizeSurveyHtml, stripInlineStyles } from "./html-utils";
 
 describe("html-utils", () => {
   describe("stripInlineStyles", () => {
@@ -98,6 +98,49 @@ describe("html-utils", () => {
 
     test("returns empty string unchanged", () => {
       expect(htmlToPlainText("")).toBe("");
+    });
+  });
+
+  describe("sanitizeSurveyHtml", () => {
+    test("opens a link pasted as plain text in a new tab", () => {
+      const sanitized = sanitizeSurveyHtml('<p>Read the <a href="https://example.com">policy</a></p>');
+
+      expect(sanitized).toContain('target="_blank"');
+      expect(sanitized).toContain('rel="noopener noreferrer"');
+    });
+
+    test("keeps links that already target a new tab", () => {
+      const sanitized = sanitizeSurveyHtml('<a href="https://example.com" target="_blank">Go</a>');
+
+      expect(sanitized).toContain('target="_blank"');
+      expect(sanitized).toContain('rel="noopener noreferrer"');
+    });
+
+    test("leaves an explicit same-tab target alone", () => {
+      const sanitized = sanitizeSurveyHtml('<a href="https://example.com" target="_self">Go</a>');
+
+      expect(sanitized).toContain('target="_self"');
+      expect(sanitized).not.toContain("noopener");
+    });
+
+    test("strips inline styles and dangerous markup", () => {
+      const sanitized = sanitizeSurveyHtml(
+        '<script>alert("x")</script><a href="https://example.com" onclick="alert(1)" style="color:red">Go</a>'
+      );
+
+      expect(sanitized).not.toContain("<script");
+      expect(sanitized).not.toContain("onclick=");
+      expect(sanitized).not.toContain("style=");
+    });
+
+    test("returns empty string unchanged", () => {
+      expect(sanitizeSurveyHtml("")).toBe("");
+    });
+
+    test("does not leak its link handling into later sanitize calls", () => {
+      sanitizeSurveyHtml('<a href="https://example.com">Go</a>');
+
+      expect(stripInlineStyles('<a href="https://example.com">Go</a>')).not.toContain("target=");
     });
   });
 });

--- a/packages/surveys/src/lib/html-utils.ts
+++ b/packages/surveys/src/lib/html-utils.ts
@@ -25,6 +25,43 @@ export const stripInlineStyles = (html: string): string => {
 };
 
 /**
+ * Force every link in survey content to open in a new tab.
+ * Links pasted as plain text are auto-linked without a target, so without this a
+ * respondent following one navigates away from the survey they are filling in.
+ * Kept on the render path so surveys authored before the editor fix behave too.
+ * @param node - The node DOMPurify is currently sanitizing
+ */
+const openLinksInNewTab = (node: Element): void => {
+  if (node.tagName !== "A" || !node.hasAttribute("href")) return;
+  if (!node.getAttribute("target")) {
+    node.setAttribute("target", "_blank");
+  }
+  if (node.getAttribute("target") === "_blank") {
+    node.setAttribute("rel", "noopener noreferrer");
+  }
+};
+
+/**
+ * Sanitize survey content HTML for rendering: strips inline styles (CSP) and makes
+ * links open in a new tab.
+ * @param html - The HTML string to sanitize
+ * @returns Sanitized HTML string, safe to pass to dangerouslySetInnerHTML
+ */
+export const sanitizeSurveyHtml = (html: string): string => {
+  if (!html) return html;
+
+  DOMPurify.addHook("afterSanitizeAttributes", openLinksInNewTab);
+  try {
+    return DOMPurify.sanitize(stripInlineStyles(html), {
+      ADD_ATTR: ["target"],
+      FORBID_ATTR: ["style"], // Additional safeguard to remove any remaining inline styles
+    });
+  } finally {
+    DOMPurify.removeHook("afterSanitizeAttributes");
+  }
+};
+
+/**
  * Lightweight HTML detection for browser environments
  * Uses native DOMParser (built-in, 0 KB bundle size)
  * @param str - The input string to test

--- a/packages/surveys/src/lib/html-utils.ts
+++ b/packages/surveys/src/lib/html-utils.ts
@@ -1,5 +1,9 @@
 import DOMPurify from "isomorphic-dompurify";
 
+// Sanitization that has to stay identical between the SDK bundle and the React
+// components lives in survey-ui; re-exported here so callers keep one import.
+export { sanitizeSurveyHtml } from "@formbricks/survey-ui";
+
 /**
  * Strip inline style attributes from HTML string to avoid CSP violations
  * Uses DOMPurify for secure, proper HTML parsing instead of regex
@@ -22,43 +26,6 @@ export const stripInlineStyles = (html: string): string => {
     ADD_ATTR: ["target"],
     KEEP_CONTENT: true,
   });
-};
-
-/**
- * Force every link in survey content to open in a new tab.
- * Links pasted as plain text are auto-linked without a target, so without this a
- * respondent following one navigates away from the survey they are filling in.
- * Kept on the render path so surveys authored before the editor fix behave too.
- * @param node - The node DOMPurify is currently sanitizing
- */
-const openLinksInNewTab = (node: Element): void => {
-  if (node.tagName !== "A" || !node.hasAttribute("href")) return;
-  if (!node.getAttribute("target")) {
-    node.setAttribute("target", "_blank");
-  }
-  if (node.getAttribute("target") === "_blank") {
-    node.setAttribute("rel", "noopener noreferrer");
-  }
-};
-
-/**
- * Sanitize survey content HTML for rendering: strips inline styles (CSP) and makes
- * links open in a new tab.
- * @param html - The HTML string to sanitize
- * @returns Sanitized HTML string, safe to pass to dangerouslySetInnerHTML
- */
-export const sanitizeSurveyHtml = (html: string): string => {
-  if (!html) return html;
-
-  DOMPurify.addHook("afterSanitizeAttributes", openLinksInNewTab);
-  try {
-    return DOMPurify.sanitize(stripInlineStyles(html), {
-      ADD_ATTR: ["target"],
-      FORBID_ATTR: ["style"], // Additional safeguard to remove any remaining inline styles
-    });
-  } finally {
-    DOMPurify.removeHook("afterSanitizeAttributes");
-  }
 };
 
 /**


### PR DESCRIPTION
## What & why

Two respondent-facing bugs reported by a government customer.

**1. Links pasted into the editor open in the same tab.** The link toolbar sets `target="_blank" rel="noopener noreferrer"`, but a URL typed or pasted as plain text is turned into a link by the Lexical auto-link plugin, whose matcher set no attributes at all. Following such a link mid-survey navigated the respondent away from their in-progress response.

- `auto-link-plugin.tsx` — the URL matcher now returns the same attributes the link toolbar applies (`mailto:` matches deliberately keep the current tab).
- `sanitizeSurveyHtml()` in `packages/survey-ui` (re-exported from `packages/surveys`, so both renderers share one implementation) — the render path now sets `target="_blank" rel="noopener noreferrer"` on links that have no explicit target, so **surveys authored before this fix are fixed too**, without re-saving them. An explicit `target="_self"` is left alone. The DOMPurify hook is added and removed around each call, so no other sanitize call is affected.

**2. Question text can't be selected or copied.** Every `Label` variant in `survey-ui` carried `select-none`, and element headlines/descriptions render through it (`ElementHeader`). Respondents could not select the question text — to copy it, look it up, or paste it into a translator. Now only labels that act as controls (choice options, cards) keep `select-none`; `headline` and `description` are `select-text`. The class list was also collapsed into one `baseClasses` const instead of being repeated across four branches.

## Linear ticket

No ticket — filed directly from a customer-feedback review. Happy to link one if you'd rather track it.

## How this was tested

- `packages/surveys`: `npx vitest run` → 26 files, 666 tests ✅
- `packages/survey-ui`: `npx vitest run --coverage` → 5 files, 90 tests ✅ (new `utils-sanitize.test.ts`; the new lines are fully covered — the remaining gap in `utils.ts` is the pre-existing `getRTLScaleOptionClasses`)
- `apps/web`: `npx vitest run modules/ui/components/editor` → 11 tests ✅
- `pnpm build --filter=@formbricks/surveys... --force` ✅ (typecheck + bundle)
- `eslint` on every changed file → 0 errors, `pnpm format` clean
- Text selection verified in Chrome on a reduced repro of the label markup: with `user-select: none` a drag over the label selects nothing and focuses the input; with `user-select: text` the text selects and focus is *not* stolen (Chrome skips label activation when the click was a drag-select), so clicking the headline still focuses the input as before.

New tests cover: link without target gets `_blank` + `rel`, existing `_blank` keeps `rel`, explicit `_self` untouched, scripts/inline styles/event handlers still stripped, empty input, and that the hook does not leak into later sanitize calls.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Editor → open a survey, in a question headline **paste or type a bare URL** (e.g. `https://formbricks.com`) so it auto-links → publish → open the survey link → click the link → it opens in a **new tab** and the survey stays open with answers intact.
- [ ] Same check for a link added with the toolbar's link button (unchanged behavior) → opens in a new tab.
- [ ] Type an email address as plain text (e.g. `hi@formbricks.com`) → it auto-links → clicking it opens the mail client, **not** a blank tab.
- [ ] Existing survey (created before this build) with a pasted URL in a headline or description → clicking it now also opens a new tab, without editing or re-saving the survey.
- [ ] Live survey → drag across a **question headline** and its description → the text highlights and Cmd/Ctrl+C copies it.
- [ ] Open text question → click (don't drag) the headline → the input is still focused, as before.
- [ ] Single/multi select → drag across an **answer option** label → it does not highlight, and clicking the option still selects it.
- [ ] Rich-text headline containing bold/italic and a link → renders correctly, link opens in a new tab, and the text is still selectable.

**Preconditions / test data**

- Any workspace; one link survey with a question whose headline contains a pasted URL, and one with a toolbar-inserted link.
- For the "existing survey" step, use a survey created before this build (or one whose headline HTML has no `target` attribute).

**Risks & regressions**

- Sanitization of survey content (headline, description, labels) — check that rich text, recall values and RTL content still render, and that no styles/scripts leak through.
- Label click-to-focus association for open text, consent, and choice questions.
- Survey preview inside the editor uses the same renderer — re-check there as well as in a live link survey.

**Migrations / env / cutover**

- none
