### PR TITLE
fix(security): restrict the onboarding invite path to organization owners [ENG-2169]

### DIFF
--- a/apps/web/lib/organization/auth.test.ts
+++ b/apps/web/lib/organization/auth.test.ts
@@ -1,21 +1,10 @@
 import { describe, expect, test, vi } from "vitest";
-import { TMembership } from "@formbricks/types/memberships";
 import { TOrganization } from "@formbricks/types/organizations";
-import { getMembershipByUserIdOrganizationId } from "../membership/service";
-import { getAccessFlags } from "../membership/utils";
-import { canUserAccessOrganization, verifyUserRoleAccess } from "./auth";
+import { canUserAccessOrganization } from "./auth";
 import { getOrganizationsByUserId } from "./service";
 
 vi.mock("./service", () => ({
   getOrganizationsByUserId: vi.fn(),
-}));
-
-vi.mock("../membership/service", () => ({
-  getMembershipByUserIdOrganizationId: vi.fn(),
-}));
-
-vi.mock("../membership/utils", () => ({
-  getAccessFlags: vi.fn(),
 }));
 
 describe("auth", () => {
@@ -44,83 +33,6 @@ describe("auth", () => {
 
       const result = await canUserAccessOrganization("user1", "org1");
       expect(result).toBe(true);
-    });
-  });
-
-  describe("verifyUserRoleAccess", () => {
-    test("returns all access for owner role", async () => {
-      const mockMembership: TMembership = {
-        organizationId: "org1",
-        userId: "user1",
-        accepted: true,
-        role: "owner",
-      };
-      vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(mockMembership);
-      vi.mocked(getAccessFlags).mockReturnValue({
-        isOwner: true,
-        isManager: false,
-        isBilling: false,
-        isMember: false,
-      });
-
-      const result = await verifyUserRoleAccess("org1", "user1");
-      expect(result).toEqual({
-        hasCreateOrUpdateAccess: true,
-        hasDeleteAccess: true,
-        hasCreateOrUpdateMembersAccess: true,
-        hasDeleteMembersAccess: true,
-        hasBillingAccess: true,
-      });
-    });
-
-    test("returns limited access for manager role", async () => {
-      const mockMembership: TMembership = {
-        organizationId: "org1",
-        userId: "user1",
-        accepted: true,
-        role: "manager",
-      };
-      vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(mockMembership);
-      vi.mocked(getAccessFlags).mockReturnValue({
-        isOwner: false,
-        isManager: true,
-        isBilling: false,
-        isMember: false,
-      });
-
-      const result = await verifyUserRoleAccess("org1", "user1");
-      expect(result).toEqual({
-        hasCreateOrUpdateAccess: false,
-        hasDeleteAccess: false,
-        hasCreateOrUpdateMembersAccess: true,
-        hasDeleteMembersAccess: true,
-        hasBillingAccess: true,
-      });
-    });
-
-    test("returns no access for member role", async () => {
-      const mockMembership: TMembership = {
-        organizationId: "org1",
-        userId: "user1",
-        accepted: true,
-        role: "member",
-      };
-      vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(mockMembership);
-      vi.mocked(getAccessFlags).mockReturnValue({
-        isOwner: false,
-        isManager: false,
-        isBilling: false,
-        isMember: true,
-      });
-
-      const result = await verifyUserRoleAccess("org1", "user1");
-      expect(result).toEqual({
-        hasCreateOrUpdateAccess: false,
-        hasDeleteAccess: false,
-        hasCreateOrUpdateMembersAccess: false,
-        hasDeleteMembersAccess: false,
-        hasBillingAccess: false,
-      });
     });
   });
 });

--- a/apps/web/lib/organization/auth.ts
+++ b/apps/web/lib/organization/auth.ts
@@ -1,7 +1,5 @@
 import "server-only";
 import { ZId } from "@formbricks/types/common";
-import { getMembershipByUserIdOrganizationId } from "../membership/service";
-import { getAccessFlags } from "../membership/utils";
 import { validateInputs } from "../utils/validate";
 import { getOrganizationsByUserId } from "./service";
 
@@ -14,42 +12,4 @@ export const canUserAccessOrganization = async (userId: string, organizationId: 
   } catch (error) {
     throw error;
   }
-};
-
-export const verifyUserRoleAccess = async (
-  organizationId: string,
-  userId: string
-): Promise<{
-  hasCreateOrUpdateAccess: boolean;
-  hasDeleteAccess: boolean;
-  hasCreateOrUpdateMembersAccess: boolean;
-  hasDeleteMembersAccess: boolean;
-  hasBillingAccess: boolean;
-}> => {
-  const accessObject = {
-    hasCreateOrUpdateAccess: true,
-    hasDeleteAccess: true,
-    hasCreateOrUpdateMembersAccess: true,
-    hasDeleteMembersAccess: true,
-    hasBillingAccess: true,
-  };
-
-  const currentUserMembership = await getMembershipByUserIdOrganizationId(userId, organizationId);
-  const { isOwner, isManager } = getAccessFlags(currentUserMembership?.role);
-
-  if (!isOwner) {
-    accessObject.hasCreateOrUpdateAccess = false;
-    accessObject.hasDeleteAccess = false;
-    accessObject.hasCreateOrUpdateMembersAccess = false;
-    accessObject.hasDeleteMembersAccess = false;
-    accessObject.hasBillingAccess = false;
-  }
-
-  if (isManager) {
-    accessObject.hasCreateOrUpdateMembersAccess = true;
-    accessObject.hasDeleteMembersAccess = true;
-    accessObject.hasBillingAccess = true;
-  }
-
-  return accessObject;
 };

--- a/apps/web/modules/setup/organization/[organizationId]/invite/actions.ts
+++ b/apps/web/modules/setup/organization/[organizationId]/invite/actions.ts
@@ -27,13 +27,19 @@ export const inviteOrganizationMemberAction = authenticatedActionClient
         throw new AuthenticationError("Invite disabled");
       }
 
+      // Owner-only, deliberately narrower than the org settings invite path: this action takes no
+      // role and `inviteUser` always persists an owner invite, so allowing managers here would let
+      // them mint owners and bypass the "managers can only invite users as members" rule enforced in
+      // `modules/organization/settings/teams/actions.ts`. Nothing legitimate is lost — the only entry
+      // to this screen is the redirect right after `createOrganizationAction`, which makes the
+      // creator an owner.
       await checkAuthorizationUpdated({
         userId: ctx.user.id,
         organizationId: parsedInput.organizationId,
         access: [
           {
             type: "organization",
-            roles: ["owner", "manager"],
+            roles: ["owner"],
           },
         ],
       });

--- a/apps/web/modules/setup/organization/[organizationId]/invite/actions.ts
+++ b/apps/web/modules/setup/organization/[organizationId]/invite/actions.ts
@@ -6,11 +6,11 @@ import { AuthenticationError } from "@formbricks/types/errors";
 import { ZUserEmail, ZUserName } from "@formbricks/types/user";
 import { INVITE_DISABLED } from "@/lib/constants";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { applyRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import { sendInviteMemberEmail } from "@/modules/email";
+import { checkSetupInviteAuthorization } from "@/modules/setup/organization/[organizationId]/invite/lib/authorization";
 import { inviteUser } from "@/modules/setup/organization/[organizationId]/invite/lib/invite";
 
 const ZInviteOrganizationMemberAction = z.object({
@@ -27,22 +27,9 @@ export const inviteOrganizationMemberAction = authenticatedActionClient
         throw new AuthenticationError("Invite disabled");
       }
 
-      // Owner-only, deliberately narrower than the org settings invite path: this action takes no
-      // role and `inviteUser` always persists an owner invite, so allowing managers here would let
-      // them mint owners and bypass the "managers can only invite users as members" rule enforced in
-      // `modules/organization/settings/teams/actions.ts`. Nothing legitimate is lost — the only entry
-      // to this screen is the redirect right after `createOrganizationAction`, which makes the
-      // creator an owner.
-      await checkAuthorizationUpdated({
-        userId: ctx.user.id,
-        organizationId: parsedInput.organizationId,
-        access: [
-          {
-            type: "organization",
-            roles: ["owner"],
-          },
-        ],
-      });
+      // Owner-only — see `SETUP_INVITE_ROLES` for why this path is narrower than the org settings
+      // invite path.
+      await checkSetupInviteAuthorization(ctx.user.id, parsedInput.organizationId);
 
       ctx.auditLoggingCtx.organizationId = parsedInput.organizationId;
 

--- a/apps/web/modules/setup/organization/[organizationId]/invite/lib/authorization.test.ts
+++ b/apps/web/modules/setup/organization/[organizationId]/invite/lib/authorization.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { AuthorizationError } from "@formbricks/types/errors";
+import { TOrganizationRole } from "@formbricks/types/memberships";
+import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
+import { checkSetupInviteAuthorization, hasSetupInviteAccess } from "./authorization";
+
+// Only the storage boundary is mocked: the real `checkAuthorizationUpdated` role matching runs, so
+// these assertions describe the actual authorization outcome per role rather than the arguments a
+// mock was called with.
+vi.mock("@/lib/membership/service", () => ({
+  getMembershipByUserIdOrganizationId: vi.fn(),
+}));
+
+vi.mock("@/modules/ee/teams/lib/roles", () => ({
+  getTeamRoleByTeamIdUserId: vi.fn(),
+  getWorkspacePermissionByUserId: vi.fn(),
+}));
+
+const userId = "test-user-id";
+const organizationId = "test-organization-id";
+
+const mockRole = (role: TOrganizationRole | null) => {
+  vi.mocked(getMembershipByUserIdOrganizationId).mockResolvedValue(role ? ({ role } as any) : null);
+};
+
+// ENG-2169: the onboarding invite path persists an owner invite and takes no role input, so anything
+// other than an owner must be rejected here — a manager passing this check could mint an owner.
+const deniedRoles: TOrganizationRole[] = ["manager", "member", "billing"];
+
+describe("checkSetupInviteAuthorization", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("allows an organization owner", async () => {
+    mockRole("owner");
+
+    await expect(checkSetupInviteAuthorization(userId, organizationId)).resolves.not.toThrow();
+  });
+
+  test.each(deniedRoles)("rejects a %s", async (role) => {
+    mockRole(role);
+
+    await expect(checkSetupInviteAuthorization(userId, organizationId)).rejects.toThrow(AuthorizationError);
+  });
+
+  test("rejects a user without a membership in the organization", async () => {
+    mockRole(null);
+
+    await expect(checkSetupInviteAuthorization(userId, organizationId)).rejects.toThrow(AuthorizationError);
+  });
+});
+
+describe("hasSetupInviteAccess", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("is true for an organization owner", async () => {
+    mockRole("owner");
+
+    await expect(hasSetupInviteAccess(userId, organizationId)).resolves.toBe(true);
+  });
+
+  test.each(deniedRoles)("is false for a %s", async (role) => {
+    mockRole(role);
+
+    await expect(hasSetupInviteAccess(userId, organizationId)).resolves.toBe(false);
+  });
+
+  test("is false for a user without a membership in the organization", async () => {
+    mockRole(null);
+
+    await expect(hasSetupInviteAccess(userId, organizationId)).resolves.toBe(false);
+  });
+});

--- a/apps/web/modules/setup/organization/[organizationId]/invite/lib/authorization.ts
+++ b/apps/web/modules/setup/organization/[organizationId]/invite/lib/authorization.ts
@@ -1,0 +1,40 @@
+import { TOrganizationRole } from "@formbricks/types/memberships";
+import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
+import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
+
+/**
+ * The organization roles allowed on the onboarding invite path (ENG-2169).
+ *
+ * Deliberately narrower than the org settings invite path, where managers may invite members: this
+ * path takes no role input and `inviteUser` always persists an owner invite, so adding "manager"
+ * here lets a manager mint an owner without an existing owner's approval. Nothing legitimate is
+ * lost — the only entry to this screen is the redirect right after `createOrganizationAction`,
+ * which makes the creator an owner.
+ *
+ * Both the page gate and the action authorization derive from this list so the two cannot drift.
+ */
+export const SETUP_INVITE_ROLES: TOrganizationRole[] = ["owner"];
+
+/** Throws `AuthorizationError` unless the user may invite through the onboarding path. */
+export const checkSetupInviteAuthorization = async (
+  userId: string,
+  organizationId: string
+): Promise<void> => {
+  await checkAuthorizationUpdated({
+    userId,
+    organizationId,
+    access: [
+      {
+        type: "organization",
+        roles: SETUP_INVITE_ROLES,
+      },
+    ],
+  });
+};
+
+/** Non-throwing variant for the page gate, which renders a 404 instead of surfacing an error. */
+export const hasSetupInviteAccess = async (userId: string, organizationId: string): Promise<boolean> => {
+  const membership = await getMembershipByUserIdOrganizationId(userId, organizationId);
+
+  return membership ? SETUP_INVITE_ROLES.includes(membership.role) : false;
+};

--- a/apps/web/modules/setup/organization/[organizationId]/invite/lib/invite.ts
+++ b/apps/web/modules/setup/organization/[organizationId]/invite/lib/invite.ts
@@ -42,6 +42,10 @@ export const inviteUser = async ({
         organization: { connect: { id: organizationId } },
         creator: { connect: { id: currentUserId } },
         acceptor: user ? { connect: { id: user.id } } : undefined,
+        // Onboarding invites are owner invites: this matches the default role used when an
+        // organization has no access-control license (see `individual-invite-tab.tsx`). Safe only
+        // because the caller is owner-gated — keep `inviteOrganizationMemberAction` owner-only, or
+        // thread a validated role through instead of widening the caller's roles.
         role: "owner",
         expiresAt,
       },

--- a/apps/web/modules/setup/organization/[organizationId]/invite/page.tsx
+++ b/apps/web/modules/setup/organization/[organizationId]/invite/page.tsx
@@ -2,11 +2,10 @@ import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { AuthenticationError } from "@formbricks/types/errors";
 import { SMTP_HOST, SMTP_PASSWORD, SMTP_PORT, SMTP_USER } from "@/lib/constants";
-import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
-import { getAccessFlags } from "@/lib/membership/utils";
 import { getTranslate } from "@/lingodotdev/server";
 import { getSession } from "@/modules/auth/lib/session";
 import { InviteMembers } from "@/modules/setup/organization/[organizationId]/invite/components/invite-members";
+import { hasSetupInviteAccess } from "@/modules/setup/organization/[organizationId]/invite/lib/authorization";
 
 export const metadata: Metadata = {
   title: "Invite",
@@ -28,14 +27,10 @@ export const InvitePage = async (props: InvitePageProps) => {
   const session = await getSession();
   if (!session) throw new AuthenticationError(t("common.session_not_found"));
 
-  // Owner-only, matching `inviteOrganizationMemberAction`: this screen creates owner invites, so a
-  // manager must not reach it (the previous `hasCreateOrUpdateMembersAccess` flag is true for
-  // managers too). Not the security boundary — the action is — but keep the two in sync so managers
-  // get a 404 instead of a form that fails on submit.
-  const membership = await getMembershipByUserIdOrganizationId(session.user.id, params.organizationId);
-  const { isOwner } = getAccessFlags(membership?.role);
-
-  if (!isOwner) return notFound();
+  // Not the security boundary — `inviteOrganizationMemberAction` is — but this shares the action's
+  // role list so a manager gets a 404 instead of a form that fails on submit. The previous
+  // `verifyUserRoleAccess().hasCreateOrUpdateMembersAccess` flag was true for managers too.
+  if (!(await hasSetupInviteAccess(session.user.id, params.organizationId))) return notFound();
 
   return <InviteMembers IS_SMTP_CONFIGURED={IS_SMTP_CONFIGURED} organizationId={params.organizationId} />;
 };

--- a/apps/web/modules/setup/organization/[organizationId]/invite/page.tsx
+++ b/apps/web/modules/setup/organization/[organizationId]/invite/page.tsx
@@ -28,8 +28,7 @@ export const InvitePage = async (props: InvitePageProps) => {
   if (!session) throw new AuthenticationError(t("common.session_not_found"));
 
   // Not the security boundary — `inviteOrganizationMemberAction` is — but this shares the action's
-  // role list so a manager gets a 404 instead of a form that fails on submit. The previous
-  // `verifyUserRoleAccess().hasCreateOrUpdateMembersAccess` flag was true for managers too.
+  // role list so a manager gets a 404 instead of a form that fails on submit.
   if (!(await hasSetupInviteAccess(session.user.id, params.organizationId))) return notFound();
 
   return <InviteMembers IS_SMTP_CONFIGURED={IS_SMTP_CONFIGURED} organizationId={params.organizationId} />;

--- a/apps/web/modules/setup/organization/[organizationId]/invite/page.tsx
+++ b/apps/web/modules/setup/organization/[organizationId]/invite/page.tsx
@@ -2,7 +2,8 @@ import { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { AuthenticationError } from "@formbricks/types/errors";
 import { SMTP_HOST, SMTP_PASSWORD, SMTP_PORT, SMTP_USER } from "@/lib/constants";
-import { verifyUserRoleAccess } from "@/lib/organization/auth";
+import { getMembershipByUserIdOrganizationId } from "@/lib/membership/service";
+import { getAccessFlags } from "@/lib/membership/utils";
 import { getTranslate } from "@/lingodotdev/server";
 import { getSession } from "@/modules/auth/lib/session";
 import { InviteMembers } from "@/modules/setup/organization/[organizationId]/invite/components/invite-members";
@@ -27,12 +28,14 @@ export const InvitePage = async (props: InvitePageProps) => {
   const session = await getSession();
   if (!session) throw new AuthenticationError(t("common.session_not_found"));
 
-  const { hasCreateOrUpdateMembersAccess } = await verifyUserRoleAccess(
-    params.organizationId,
-    session.user.id
-  );
+  // Owner-only, matching `inviteOrganizationMemberAction`: this screen creates owner invites, so a
+  // manager must not reach it (the previous `hasCreateOrUpdateMembersAccess` flag is true for
+  // managers too). Not the security boundary — the action is — but keep the two in sync so managers
+  // get a 404 instead of a form that fails on submit.
+  const membership = await getMembershipByUserIdOrganizationId(session.user.id, params.organizationId);
+  const { isOwner } = getAccessFlags(membership?.role);
 
-  if (!hasCreateOrUpdateMembersAccess) return notFound();
+  if (!isOwner) return notFound();
 
   return <InviteMembers IS_SMTP_CONFIGURED={IS_SMTP_CONFIGURED} organizationId={params.organizationId} />;
 };

--- a/apps/web/playwright/setup-invite-role-access.spec.ts
+++ b/apps/web/playwright/setup-invite-role-access.spec.ts
@@ -1,0 +1,55 @@
+import { expect } from "@playwright/test";
+import { prisma } from "@formbricks/database";
+import type { UsersFixture } from "./fixtures/users";
+import { test } from "./lib/fixtures";
+
+// ENG-2169 regression: the onboarding invite screen creates owner invites (the role is hardcoded, the
+// action takes no role input) but authorized managers as well, so a manager could navigate straight to
+// this route — nothing ties it to the moments after organization creation — and mint an owner, going
+// around the "managers can only invite users as members" rule enforced on the org settings invite
+// path. Both the page and the action are owner-only now. The owner test guards against a fix that
+// over-blocks and breaks the real onboarding step.
+
+const setupOrgWithManager = async (users: UsersFixture) => {
+  const owner = await users.create();
+  if (!owner.organizationId) {
+    throw new Error("Owner org not seeded for test");
+  }
+
+  const manager = await users.create({ withoutWorkspace: true });
+  await prisma.membership.create({
+    data: {
+      userId: manager.id,
+      organizationId: owner.organizationId,
+      role: "manager",
+      accepted: true,
+    },
+  });
+
+  return {
+    owner,
+    manager,
+    inviteUrl: `/setup/organization/${owner.organizationId}/invite`,
+  };
+};
+
+test.describe("Setup invite role access (ENG-2169)", () => {
+  test("404s for an organization manager", async ({ page, users }) => {
+    const { manager, inviteUrl } = await setupOrgWithManager(users);
+
+    await manager.login();
+    await page.goto(inviteUrl, { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByTestId("error-code")).toHaveText("404");
+    await expect(page.getByText("Invite your Organization members")).not.toBeVisible();
+  });
+
+  test("keeps the onboarding invite screen for the organization owner", async ({ page, users }) => {
+    const { owner, inviteUrl } = await setupOrgWithManager(users);
+
+    await owner.login();
+    await page.goto(inviteUrl, { waitUntil: "domcontentloaded" });
+
+    await expect(page.getByText("Invite your Organization members")).toBeVisible();
+  });
+});


### PR DESCRIPTION
## What & why

The onboarding invite screen (`/setup/organization/{organizationId}/invite`) creates **owner** invites — `inviteUser` hardcodes `role: "owner"` and `inviteOrganizationMemberAction` has no role input — but it authorized `["owner", "manager"]`. Nothing ties the route to the moments right after organization creation, so a manager could navigate straight to it and mint an owner, going around the `Managers can only invite users as members` rule enforced in `modules/organization/settings/teams/actions.ts`. Acceptance trusts the stored role, so the invitee lands as a real owner membership — able to manage billing, remove other owners and delete the organization.

Exposure is organizations where managers exist at all, i.e. those with the access-control license; without it every invite is an owner by design.

- `invite/lib/authorization.ts` (new) — `SETUP_INVITE_ROLES` is the single source of truth for who may use this path (`["owner"]`), with `checkSetupInviteAuthorization` for the action and `hasSetupInviteAccess` for the page gate, so the two cannot drift.
- `invite/actions.ts` — authorization narrowed to owners via `checkSetupInviteAuthorization`. This is the fix; the action is the boundary. It still goes through `checkAuthorizationUpdated`, so the authorization pattern and the `AuthorizationError` contract are unchanged.
- `invite/page.tsx` — gate swapped from `verifyUserRoleAccess().hasCreateOrUpdateMembersAccess` (true for managers) to `hasSetupInviteAccess`, so a manager gets a 404 instead of a form that fails on submit.
- `invite/lib/invite.ts` — the hardcoded owner role stays (it matches the default for organizations with no access-control license) with a comment on why it is only safe behind an owner-gated caller.
- `lib/organization/auth.ts` — `verifyUserRoleAccess` deleted along with its test block. The invite page was its last production call site, and only `hasCreateOrUpdateMembersAccess` was ever read from it. `canUserAccessOrganization` stays; the organization layout still uses it.

Nothing legitimate is lost: the only entry to this screen is the redirect right after `createOrganizationAction`, which makes the creator an owner.

Reported through responsible disclosure by [meifukun](https://github.com/meifukun).

## Linear ticket

Fixes ENG-2169

## How this was tested

- **New unit test** `invite/lib/authorization.test.ts` — 10 tests over the role decision: an owner is allowed, a manager, member, billing user and a user with no membership are all rejected, for both the action helper and the page helper. Only the membership lookup is mocked, so the real `checkAuthorizationUpdated` role matching executes and the assertions are about outcomes per role, not about the arguments a mock received. ✅
- **New Playwright spec** `apps/web/playwright/setup-invite-role-access.spec.ts` — a manager navigating to the invite URL gets a 404; the owner still gets the onboarding form (guards against a fix that over-blocks). Both pass ✅
- **Bug-catch checks** — each guard was verified to actually fail on the unfixed code:
  - Reverted only the page gate and re-ran the Playwright manager test → fails (the manager sees "Invite your Organization members").
  - Added `"manager"` back to `SETUP_INVITE_ROLES` and re-ran the unit test → `rejects a manager` and `is false for a manager` both fail.
  - Both restored; green again.
- `pnpm vitest run` across `lib/organization` and the touched module — 11 files / 138 tests ✅ (after deleting `verifyUserRoleAccess`, confirmed no references remain anywhere)
- `pnpm typecheck` (apps/web) ✅, Prettier ✅
- No unit test for the action file itself — `**/actions.ts` is coverage-excluded, which is why the role decision lives in `lib/authorization.ts` where it can be tested directly.

No UI change: the screen is unchanged for the owner who legitimately reaches it.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] As an organization **owner**, sign up and create a new organization → you land on "Invite your Organization members" and can send invites as before.
- [ ] As an owner, copy that URL (`/setup/organization/{organizationId}/invite`) and open it again later → the invite form still loads.
- [ ] Invite a second user, set their organization role to **Manager** in Settings → Teams (needs the access-control entitlement), and log in as them.
- [ ] As the manager, open `/setup/organization/{organizationId}/invite` for that same organization → **404 Not Found**, no invite form.
- [ ] As the manager, go to Settings → Teams → Invite → the normal invite flow still works and still offers **Member** only.
- [ ] Check the invite created by the manager in Settings → Teams shows role **Member**, and any invite created from the onboarding screen by an owner shows **Owner**.
- [ ] As a **member** or **billing** user, open the invite URL → 404 (unchanged behavior).

**Preconditions / test data**

- Two accounts in the same organization: one owner, one manager.
- Promoting someone to manager needs the access-control (role management) entitlement — on a plan/licence without it, everyone is an owner and no manager exists to test with.
- SMTP configured if you want the invite emails to actually send; not required for the authorization checks.

**Risks & regressions**

- Onboarding right after organization creation — the owner must still reach the invite step; a too-strict gate would 404 the happy path.
- Organization Settings → Teams invites for owners, managers and team admins are untouched and must keep working, including the manager → member restriction.
- Accepting an existing invite (both sign-up and already-logged-in paths) is untouched; roles on already-issued invites are unchanged.

**Migrations / env / cutover**

- none
