### PR TITLE
fix(surveys): stop no-overlay surveys blocking the host page (backport #8804 to release/5.3)

### DIFF
--- a/packages/js-core/src/lib/common/constants.ts
+++ b/packages/js-core/src/lib/common/constants.ts
@@ -2,4 +2,7 @@ export const JS_LOCAL_STORAGE_KEY = "formbricks-js";
 export const LEGACY_JS_WEBSITE_LOCAL_STORAGE_KEY = "formbricks-js-website";
 export const LEGACY_JS_APP_LOCAL_STORAGE_KEY = "formbricks-js-app";
 export const CONTAINER_ID = "formbricks-modal-container";
+// Shipped id contract with the surveys renderer (packages/surveys/src/lib/live-region.ts) — old SDKs
+// stay on the wire for years, so this value must never change.
+export const LIVE_REGION_ID = "formbricks-live-region";
 export const RECAPTCHA_SCRIPT_ID = "formbricks-recaptcha-script";

--- a/packages/js-core/src/lib/common/setup.ts
+++ b/packages/js-core/src/lib/common/setup.ts
@@ -4,7 +4,7 @@ import { addCleanupEventListeners, addEventListeners } from "@/lib/common/event-
 import { Logger } from "@/lib/common/logger";
 import { getIsSetup, setIsSetup } from "@/lib/common/status";
 import { filterSurveys, getIsDebug, isNowExpired, wrapThrows } from "@/lib/common/utils";
-import { closeSurvey, preloadSurveysScript } from "@/lib/survey/widget";
+import { addLiveRegionContainer, closeSurvey, preloadSurveysScript } from "@/lib/survey/widget";
 import { DEFAULT_USER_STATE_NO_USER_ID } from "@/lib/user/state";
 import { sendUpdatesToBackend } from "@/lib/user/update";
 import { fetchWorkspaceState } from "@/lib/workspace/state";
@@ -329,6 +329,10 @@ export const setup = async (
   logger.debug("Adding event listeners");
   addEventListeners();
   addCleanupEventListeners();
+
+  // Mount the status live region now so assistive tech has registered it long before the
+  // first survey announces its opening into it.
+  addLiveRegionContainer();
 
   // Preload surveys script so it's ready when a survey triggers
   preloadSurveysScript(configInput.appUrl);

--- a/packages/js-core/src/lib/common/tests/setup.test.ts
+++ b/packages/js-core/src/lib/common/tests/setup.test.ts
@@ -7,6 +7,7 @@ import { handleErrorOnFirstSetup, setup, tearDown } from "@/lib/common/setup";
 import { setIsSetup } from "@/lib/common/status";
 import { filterSurveys, getIsDebug, isNowExpired } from "@/lib/common/utils";
 import type * as Utils from "@/lib/common/utils";
+import { addLiveRegionContainer } from "@/lib/survey/widget";
 import { DEFAULT_USER_STATE_NO_USER_ID } from "@/lib/user/state";
 import { sendUpdatesToBackend } from "@/lib/user/update";
 import { fetchWorkspaceState } from "@/lib/workspace/state";
@@ -73,6 +74,7 @@ vi.mock("@/lib/survey/no-code-action", () => ({
 vi.mock("@/lib/survey/widget", () => ({
   closeSurvey: vi.fn(),
   preloadSurveysScript: vi.fn(),
+  addLiveRegionContainer: vi.fn(),
 }));
 
 describe("setup.ts", () => {
@@ -156,6 +158,7 @@ describe("setup.ts", () => {
 
       const result = await setup({ workspaceId: "ws_123", appUrl: "https://my.url" });
       expect(result.ok).toBe(true);
+      expect(addLiveRegionContainer).toHaveBeenCalledOnce();
       expect(fetchWorkspaceState).toHaveBeenCalledWith(
         expect.objectContaining({
           workspaceId: "ws_123",

--- a/packages/js-core/src/lib/survey/widget.ts
+++ b/packages/js-core/src/lib/survey/widget.ts
@@ -1,5 +1,5 @@
 import { Config } from "@/lib/common/config";
-import { CONTAINER_ID } from "@/lib/common/constants";
+import { CONTAINER_ID, LIVE_REGION_ID } from "@/lib/common/constants";
 import { Logger } from "@/lib/common/logger";
 import { executeRecaptcha, loadRecaptchaScript } from "@/lib/common/recaptcha";
 import { TimeoutStack } from "@/lib/common/timeout-stack";
@@ -272,6 +272,30 @@ export const addWidgetContainer = (): void => {
   const containerElement = document.createElement("div");
   containerElement.id = CONTAINER_ID;
   document.body.appendChild(containerElement);
+};
+
+/**
+ * Mounts the persistent, visually hidden status region surveys announce their opening into
+ * (a no-overlay survey never takes focus, so this is the only signal assistive tech gets).
+ * Created at setup — not at survey open — because screen readers only reliably announce
+ * changes made to a live region that already existed; a region inserted together with its
+ * content is announced inconsistently. The surveys renderer writes the message
+ * (packages/surveys/src/lib/live-region.ts) and re-creates the region if an older embed
+ * script did not have this function.
+ */
+export const addLiveRegionContainer = (): void => {
+  // The SDK can be imported (not just script-tagged) and evaluated during SSR.
+  if (typeof document === "undefined") return;
+  if (document.getElementById(LIVE_REGION_ID)) return;
+
+  const liveRegion = document.createElement("div");
+  liveRegion.id = LIVE_REGION_ID;
+  liveRegion.setAttribute("role", "status");
+  liveRegion.setAttribute("aria-live", "polite");
+  liveRegion.setAttribute("aria-atomic", "true");
+  liveRegion.style.cssText =
+    "position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0";
+  document.body.appendChild(liveRegion);
 };
 
 export const removeWidgetContainer = (): void => {

--- a/packages/surveys/i18n.lock
+++ b/packages/surveys/i18n.lock
@@ -31,6 +31,7 @@ checksums:
     common/select_options: d5a80087e889848e0fed3f1be359366f
     common/sending_responses: 244f1aebc3f6a101ae2f8b630d7967ec
     common/survey_dialog: 7401ad8978e423009da68141c739bda0
+    common/survey_opened_announcement: 43ffc9486130e59b034d140b3d9425dc
     common/takes_less_than_x_minutes: 1208ce0d4c0a679c11c7bd209b6ccc47
     common/takes_x_minutes: 001d12366d07b406f50669e761d63e69
     common/takes_x_plus_minutes: 145b8f287de140e98f492c8db2f9fa0b

--- a/packages/surveys/locales/ar-EG.json
+++ b/packages/surveys/locales/ar-EG.json
@@ -30,6 +30,7 @@
     "select_options": "اختر الخيارات",
     "sending_responses": "جارٍ إرسال الردود...",
     "survey_dialog": "مربع حوار الاستبيان",
+    "survey_opened_announcement": "تم فتح استبيان في نهاية الصفحة.",
     "takes_less_than_x_minutes": "{count, plural, zero {يستغرق أقل من دقيقة} one {يستغرق أقل من دقيقة واحدة} two {يستغرق أقل من دقيقتين} few {يستغرق أقل من {count} دقائق} many {يستغرق أقل من {count} دقيقة} other {يستغرق أقل من {count} دقيقة}}",
     "takes_x_minutes": "{count, plural, zero {يستغرق صفر دقائق} one {يستغرق دقيقة واحدة} two {يستغرق دقيقتين} few {يستغرق {count} دقائق} many {يستغرق {count} دقيقة} other {يستغرق {count} دقيقة}}",
     "takes_x_plus_minutes": "يستغرق {count}+ دقيقة",

--- a/packages/surveys/locales/da-DK.json
+++ b/packages/surveys/locales/da-DK.json
@@ -30,6 +30,7 @@
     "select_options": "Vælg muligheder",
     "sending_responses": "Sender svar…",
     "survey_dialog": "Undersøgelsesdialog",
+    "survey_opened_announcement": "En undersøgelse er åbnet i bunden af siden.",
     "takes_less_than_x_minutes": "{count, plural, one {Tager mindre end 1 minut} other {Tager mindre end {count} minutter}}",
     "takes_x_minutes": "{count, plural, one {Tager 1 minut} other {Tager {count} minutter}}",
     "takes_x_plus_minutes": "Tager {count}+ minutter",

--- a/packages/surveys/locales/de-DE.json
+++ b/packages/surveys/locales/de-DE.json
@@ -30,6 +30,7 @@
     "select_options": "Wähle Optionen",
     "sending_responses": "Antworten werden gesendet...",
     "survey_dialog": "Umfragedialog",
+    "survey_opened_announcement": "Am Ende der Seite wurde eine Umfrage geöffnet.",
     "takes_less_than_x_minutes": "{count, plural, one {Dauert weniger als 1 Minute} other {Dauert weniger als {count} Minuten}}",
     "takes_x_minutes": "{count, plural, one {Dauert 1 Minute} other {Dauert {count} Minuten}}",
     "takes_x_plus_minutes": "Dauert {count}+ Minuten",

--- a/packages/surveys/locales/en-US.json
+++ b/packages/surveys/locales/en-US.json
@@ -30,6 +30,7 @@
     "select_options": "Select options",
     "sending_responses": "Sending responses…",
     "survey_dialog": "Survey Dialog",
+    "survey_opened_announcement": "A survey has opened at the end of the page.",
     "takes_less_than_x_minutes": "{count, plural, one {Takes less than 1 minute} other {Takes less than {count} minutes}}",
     "takes_x_minutes": "{count, plural, one {Takes 1 minute} other {Takes {count} minutes}}",
     "takes_x_plus_minutes": "Takes {count}+ minutes",

--- a/packages/surveys/locales/es-ES.json
+++ b/packages/surveys/locales/es-ES.json
@@ -30,6 +30,7 @@
     "select_options": "Selecciona opciones",
     "sending_responses": "Enviando respuestas...",
     "survey_dialog": "Diálogo de encuesta",
+    "survey_opened_announcement": "Se ha abierto una encuesta al final de la página.",
     "takes_less_than_x_minutes": "{count, plural, one {Toma menos de 1 minuto} other {Toma menos de {count} minutos}}",
     "takes_x_minutes": "{count, plural, one {Toma 1 minuto} other {Toma {count} minutos}}",
     "takes_x_plus_minutes": "Toma {count}+ minutos",

--- a/packages/surveys/locales/et-EE.json
+++ b/packages/surveys/locales/et-EE.json
@@ -30,6 +30,7 @@
     "select_options": "Vali variandid",
     "sending_responses": "Vastuste saatmine…",
     "survey_dialog": "Küsitluse dialoog",
+    "survey_opened_announcement": "Lehe lõppu on avatud küsitlus.",
     "takes_less_than_x_minutes": "{count, plural, one {Võtab vähem kui 1 minuti} other {Võtab vähem kui {count} minutit}}",
     "takes_x_minutes": "{count, plural, one {Võtab 1 minuti} other {Võtab {count} minutit}}",
     "takes_x_plus_minutes": "Võtab {count}+ minutit",

--- a/packages/surveys/locales/fr-FR.json
+++ b/packages/surveys/locales/fr-FR.json
@@ -30,6 +30,7 @@
     "select_options": "Sélectionner des options",
     "sending_responses": "Envoi des réponses...",
     "survey_dialog": "Boîte de dialogue du sondage",
+    "survey_opened_announcement": "Un sondage s'est ouvert à la fin de la page.",
     "takes_less_than_x_minutes": "{count, plural, one {Prend moins d'une minute} other {Prend moins de {count} minutes}}",
     "takes_x_minutes": "{count, plural, one {Prend 1 minute} other {Prend {count} minutes}}",
     "takes_x_plus_minutes": "Prend {count}+ minutes",

--- a/packages/surveys/locales/hi-IN.json
+++ b/packages/surveys/locales/hi-IN.json
@@ -30,6 +30,7 @@
     "select_options": "विकल्प चुनें",
     "sending_responses": "प्रतिक्रियाएँ भेज रहे हैं...",
     "survey_dialog": "सर्वेक्षण संवाद",
+    "survey_opened_announcement": "पेज के अंत में एक सर्वे खुल गया है।",
     "takes_less_than_x_minutes": "{count, plural, one {1 मिनट से कम लगता है} other {{count} मिनट से कम लगता है}}",
     "takes_x_minutes": "{count, plural, one {1 मिनट लगता है} other {{count} मिनट लगते हैं}}",
     "takes_x_plus_minutes": "{count}+ मिनट लगते हैं",

--- a/packages/surveys/locales/hu-HU.json
+++ b/packages/surveys/locales/hu-HU.json
@@ -30,6 +30,7 @@
     "select_options": "Lehetőségek kiválasztása",
     "sending_responses": "Válaszok küldése…",
     "survey_dialog": "Kérdőív párbeszédablak",
+    "survey_opened_announcement": "Egy felmérés megnyílt az oldal végén.",
     "takes_less_than_x_minutes": "{count, plural, one {Kevesebb mint 1 percet vesz igénybe} other {Kevesebb mint {count} percet vesz igénybe}}",
     "takes_x_minutes": "{count, plural, one {1 percet vesz igénybe} other {{count} percet vesz igénybe}}",
     "takes_x_plus_minutes": "{count}+ percet vesz igénybe",

--- a/packages/surveys/locales/id-ID.json
+++ b/packages/surveys/locales/id-ID.json
@@ -30,6 +30,7 @@
     "select_options": "Pilih opsi",
     "sending_responses": "Mengirim respons…",
     "survey_dialog": "Dialog Survei",
+    "survey_opened_announcement": "Survei telah terbuka di akhir halaman.",
     "takes_less_than_x_minutes": "{count, plural, other {Kurang dari {count} menit}}",
     "takes_x_minutes": "{count, plural, other {{count} menit}}",
     "takes_x_plus_minutes": "{count}+ menit",

--- a/packages/surveys/locales/it-IT.json
+++ b/packages/surveys/locales/it-IT.json
@@ -30,6 +30,7 @@
     "select_options": "Seleziona opzioni",
     "sending_responses": "Invio risposte in corso...",
     "survey_dialog": "Finestra di dialogo del sondaggio",
+    "survey_opened_announcement": "Un sondaggio è stato aperto alla fine della pagina.",
     "takes_less_than_x_minutes": "{count, plural, one {Richiede meno di 1 minuto} other {Richiede meno di {count} minuti}}",
     "takes_x_minutes": "{count, plural, one {Richiede 1 minuto} other {Richiede {count} minuti}}",
     "takes_x_plus_minutes": "Richiede più di {count} minuti",

--- a/packages/surveys/locales/ja-JP.json
+++ b/packages/surveys/locales/ja-JP.json
@@ -30,6 +30,7 @@
     "select_options": "オプションを選択",
     "sending_responses": "回答を送信中...",
     "survey_dialog": "アンケートダイアログ",
+    "survey_opened_announcement": "ページの最後にアンケートが表示されました。",
     "takes_less_than_x_minutes": "{count, plural, one {1分未満} other {{count}分未満}}",
     "takes_x_minutes": "{count, plural, one {1分} other {{count}分}}",
     "takes_x_plus_minutes": "{count}分以上",

--- a/packages/surveys/locales/nl-NL.json
+++ b/packages/surveys/locales/nl-NL.json
@@ -30,6 +30,7 @@
     "select_options": "Selecteer opties",
     "sending_responses": "Reacties verzenden...",
     "survey_dialog": "Enquête-dialoogvenster",
+    "survey_opened_announcement": "Er is een enquête geopend aan het einde van de pagina.",
     "takes_less_than_x_minutes": "{count, plural, one {Duurt minder dan 1 minuut} other {Duurt minder dan {count} minuten}}",
     "takes_x_minutes": "{count, plural, one {Duurt 1 minuut} other {Duurt {count} minuten}}",
     "takes_x_plus_minutes": "Duurt {count}+ minuten",

--- a/packages/surveys/locales/pt-BR.json
+++ b/packages/surveys/locales/pt-BR.json
@@ -30,6 +30,7 @@
     "select_options": "Selecione opções",
     "sending_responses": "Enviando respostas...",
     "survey_dialog": "Caixa de diálogo da pesquisa",
+    "survey_opened_announcement": "Uma pesquisa foi aberta no final da página.",
     "takes_less_than_x_minutes": "{count, plural, one {Leva menos de 1 minuto} other {Leva menos de {count} minutos}}",
     "takes_x_minutes": "{count, plural, one {Leva 1 minuto} other {Leva {count} minutos}}",
     "takes_x_plus_minutes": "Leva {count}+ minutos",

--- a/packages/surveys/locales/ro-RO.json
+++ b/packages/surveys/locales/ro-RO.json
@@ -30,6 +30,7 @@
     "select_options": "Selectează opțiuni",
     "sending_responses": "Trimiterea răspunsurilor...",
     "survey_dialog": "Dialog sondaj",
+    "survey_opened_announcement": "Un sondaj s-a deschis la sfârșitul paginii.",
     "takes_less_than_x_minutes": "{count, plural, one {Durează mai puțin de 1 minut} few {Durează mai puțin de {count} minute} other {Durează mai puțin de {count} de minute}}",
     "takes_x_minutes": "{count, plural, one {Durează 1 minut} few {Durează {count} minute} other {Durează {count} de minute}}",
     "takes_x_plus_minutes": "Durează peste {count} minute",

--- a/packages/surveys/locales/ru-RU.json
+++ b/packages/surveys/locales/ru-RU.json
@@ -30,6 +30,7 @@
     "select_options": "Выбери варианты",
     "sending_responses": "Отправка ответов...",
     "survey_dialog": "Диалог опроса",
+    "survey_opened_announcement": "В конце страницы открылся опрос.",
     "takes_less_than_x_minutes": "{count, plural, one {Займёт меньше 1 минуты} few {Займёт меньше {count} минут} many {Займёт меньше {count} минут} other {Займёт меньше {count} минуты}}",
     "takes_x_minutes": "{count, plural, one {Займёт 1 минуту} few {Займёт {count} минуты} many {Займёт {count} минут} other {Займёт {count} минуты}}",
     "takes_x_plus_minutes": "Займёт {count}+ минут",

--- a/packages/surveys/locales/sv-SE.json
+++ b/packages/surveys/locales/sv-SE.json
@@ -30,6 +30,7 @@
     "select_options": "Välj alternativ",
     "sending_responses": "Skickar svar...",
     "survey_dialog": "Enkätdialog",
+    "survey_opened_announcement": "En enkät har öppnats i slutet av sidan.",
     "takes_less_than_x_minutes": "{count, plural, one {Tar mindre än 1 minut} other {Tar mindre än {count} minuter}}",
     "takes_x_minutes": "{count, plural, one {Tar 1 minut} other {Tar {count} minuter}}",
     "takes_x_plus_minutes": "Tar {count}+ minuter",

--- a/packages/surveys/locales/tr-TR.json
+++ b/packages/surveys/locales/tr-TR.json
@@ -30,6 +30,7 @@
     "select_options": "Seçenekleri seçin",
     "sending_responses": "Yanıtlar gönderiliyor…",
     "survey_dialog": "Anket iletişim kutusu",
+    "survey_opened_announcement": "Sayfanın sonunda bir anket açıldı.",
     "takes_less_than_x_minutes": "{count, plural, one {1 dakikadan az sürer} other {{count} dakikadan az sürer}}",
     "takes_x_minutes": "{count, plural, one {1 dakika sürer} other {{count} dakika sürer}}",
     "takes_x_plus_minutes": "{count}+ dakika sürer",

--- a/packages/surveys/locales/ur-PK.json
+++ b/packages/surveys/locales/ur-PK.json
@@ -30,6 +30,7 @@
     "select_options": "اختیارات منتخب کریں",
     "sending_responses": "جوابات بھیجے جا رہے ہیں…",
     "survey_dialog": "سروے ڈائیلاگ",
+    "survey_opened_announcement": "صفحہ کے آخر میں ایک سروے کھل گیا ہے۔",
     "takes_less_than_x_minutes": "{count, plural, one {1 منٹ سے بھی کم وقت لگتا ہے} other {{count} منٹ سے بھی کم وقت لگتا ہے}}",
     "takes_x_minutes": "{count, plural, one {1 منٹ لگتا ہے} other {{count} منٹ لگتے ہیں}}",
     "takes_x_plus_minutes": "{count}+ منٹ لگتے ہیں",

--- a/packages/surveys/locales/uz-UZ.json
+++ b/packages/surveys/locales/uz-UZ.json
@@ -30,6 +30,7 @@
     "select_options": "Variantlarni tanla",
     "sending_responses": "Javoblar yuborilmoqda...",
     "survey_dialog": "So‘rovnoma dialog oynasi",
+    "survey_opened_announcement": "Sahifa oxirida so'rovnoma ochildi.",
     "takes_less_than_x_minutes": "{count, plural, one {1 daqiqadan kam vaqt oladi} other {{count} daqiqadan kam vaqt oladi}}",
     "takes_x_minutes": "{count, plural, one {1 daqiqa vaqt oladi} other {{count} daqiqa vaqt oladi}}",
     "takes_x_plus_minutes": "{count}+ daqiqa vaqt oladi",

--- a/packages/surveys/locales/vi-VN.json
+++ b/packages/surveys/locales/vi-VN.json
@@ -30,6 +30,7 @@
     "select_options": "Chọn các tùy chọn",
     "sending_responses": "Đang gửi phản hồi…",
     "survey_dialog": "Hộp thoại khảo sát",
+    "survey_opened_announcement": "Một khảo sát đã được mở ở cuối trang.",
     "takes_less_than_x_minutes": "{count, plural, other {Mất ít hơn {count} phút}}",
     "takes_x_minutes": "{count, plural, other {Mất {count} phút}}",
     "takes_x_plus_minutes": "Mất {count}+ phút",

--- a/packages/surveys/locales/zh-Hans-CN.json
+++ b/packages/surveys/locales/zh-Hans-CN.json
@@ -30,6 +30,7 @@
     "select_options": "请选择多个选项",
     "sending_responses": "正在发送响应...",
     "survey_dialog": "调查对话框",
+    "survey_opened_announcement": "页面底部已打开一项调查问卷。",
     "takes_less_than_x_minutes": "{count, plural, one {少于 1 分钟} other {少于 {count} 分钟}}",
     "takes_x_minutes": "{count, plural, one {1 分钟} other {{count} 分钟}}",
     "takes_x_plus_minutes": "{count}+ 分钟",

--- a/packages/surveys/locales/zh-Hant-TW.json
+++ b/packages/surveys/locales/zh-Hant-TW.json
@@ -30,6 +30,7 @@
     "select_options": "選擇選項",
     "sending_responses": "正在傳送回覆…",
     "survey_dialog": "問卷對話框",
+    "survey_opened_announcement": "頁面底部已開啟一份問卷調查。",
     "takes_less_than_x_minutes": "{count, plural, other {少於 {count} 分鐘}}",
     "takes_x_minutes": "{count, plural, other {{count} 分鐘}}",
     "takes_x_plus_minutes": "{count}+ 分鐘",

--- a/packages/surveys/src/components/buttons/submit-button.tsx
+++ b/packages/surveys/src/components/buttons/submit-button.tsx
@@ -42,6 +42,21 @@ export function SubmitButton({
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       if ((event.metaKey || event.ctrlKey) && event.key === "Enter" && !disabled && !isProcessing) {
+        // The listener sits on `document` so the chord still works when focus is on <body>, which is
+        // the normal state for link surveys. An embedded survey shares the page with a host app that
+        // owns its own shortcuts, so don't claim the chord — or preventDefault it — while the user is
+        // focused inside their page.
+        const surveyRoot = buttonRef.current?.closest("#fbjs");
+        const activeElement = document.activeElement;
+        if (
+          surveyRoot &&
+          activeElement &&
+          activeElement !== document.body &&
+          !surveyRoot.contains(activeElement)
+        ) {
+          return;
+        }
+
         event.preventDefault();
         setIsProcessing(true);
         const button = buttonRef.current;

--- a/packages/surveys/src/components/general/render-survey.tsx
+++ b/packages/surveys/src/components/general/render-survey.tsx
@@ -52,11 +52,17 @@ export function RenderSurvey(props: SurveyContainerProps) {
     return null;
   }
 
+  const mode = props.mode ?? "modal";
   const hasOverlay = props.overlay && props.overlay !== "none";
+  // A modal survey with no overlay appears over a page the user is still working in, often mid-form.
+  // Moving the caret into the survey on open would pull them out of the field they are typing in, so
+  // leave focus where it is. With an overlay the page is blocked anyway, so taking focus is correct.
+  // Only ever force this off — everything else keeps the existing default (see survey.tsx).
+  const autoFocus = props.autoFocus ?? (mode === "modal" && !hasOverlay ? false : undefined);
 
   return (
     <SurveyContainer
-      mode={props.mode ?? "modal"}
+      mode={mode}
       placement={props.placement}
       overlay={props.overlay}
       clickOutside={props.clickOutside}
@@ -65,6 +71,7 @@ export function RenderSurvey(props: SurveyContainerProps) {
       dir={dir}>
       <Survey
         {...props}
+        autoFocus={autoFocus}
         clickOutside={hasOverlay ? props.clickOutside : true}
         onClose={close}
         onFinished={() => {

--- a/packages/surveys/src/components/wrappers/survey-container.tsx
+++ b/packages/surveys/src/components/wrappers/survey-container.tsx
@@ -2,8 +2,13 @@ import { type ComponentChildren } from "preact";
 import { useEffect } from "preact/hooks";
 import { useTranslation } from "react-i18next";
 import { type TOverlay, type TPlacement } from "@formbricks/types/common";
+import { ensureLiveRegion } from "@/lib/live-region";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { cn } from "@/lib/utils";
+
+// Give a fallback-created live region (older SDK, see live-region.ts) a beat to be registered by
+// assistive tech before the message lands. Harmless when the region already exists.
+const ANNOUNCE_DELAY_MS = 100;
 
 interface SurveyContainerProps {
   mode: "modal" | "inline";
@@ -28,8 +33,16 @@ export function SurveyContainer({
 }: Readonly<SurveyContainerProps>) {
   const isModal = mode === "modal";
   const { t } = useTranslation();
-  const modalRef = useFocusTrap<HTMLDivElement>({ enabled: isModal && isOpen, onEscapeKeyDown: onClose });
   const hasOverlay = overlay !== "none";
+  // The overlay is what makes a survey modal: it covers the host page and the page stops being usable.
+  // Without one the page underneath stays visible and clickable, so the survey is a notification, not a
+  // modal. Trapping focus there steals the caret and the text selection from the host page — the trap's
+  // document-level listeners pull focus back in on every click, tab and drag. Matches the gate the
+  // click-outside effect below already uses.
+  const modalRef = useFocusTrap<HTMLDivElement>({
+    enabled: isModal && isOpen && hasOverlay,
+    onEscapeKeyDown: onClose,
+  });
 
   useEffect(() => {
     if (!isModal) return;
@@ -52,6 +65,48 @@ export function SurveyContainer({
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, [clickOutside, hasOverlay, modalRef, onClose, isModal, isOpen]);
+
+  // Without an overlay the focus trap is off, so nothing handles Escape. Listen on the container node
+  // instead of on `document`: Escape closes the survey only while focus is inside it, and never cancels
+  // the host page's own Escape handling. Keep the listener imperative — a keydown JSX prop on a
+  // non-interactive role="dialog" element fails a11y linting.
+  useEffect(() => {
+    if (!isModal || !isOpen || hasOverlay) return;
+
+    const container = modalRef.current;
+    if (!container) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape" || event.altKey || event.ctrlKey || event.metaKey) return;
+
+      event.preventDefault();
+      onClose?.();
+    };
+
+    container.addEventListener("keydown", handleKeyDown);
+    return () => {
+      container.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isModal, isOpen, hasOverlay, onClose, modalRef]);
+
+  // A no-overlay survey never takes focus (see the trap gate above), so its opening is announced
+  // through the persistent status region — otherwise screen-reader users get no signal it appeared.
+  // With an overlay the trap moves focus into the dialog, which is its own announcement. Cleared on
+  // close because setting identical text twice is not a change, so a later open would stay silent.
+  useEffect(() => {
+    if (!isModal || !isOpen || hasOverlay) return;
+
+    const liveRegion = ensureLiveRegion();
+    liveRegion.textContent = "";
+    const announceTimeout = setTimeout(() => {
+      liveRegion.textContent = t("common.survey_opened_announcement");
+    }, ANNOUNCE_DELAY_MS);
+
+    return () => {
+      clearTimeout(announceTimeout);
+      liveRegion.textContent = "";
+    };
+  }, [isModal, isOpen, hasOverlay, t]);
 
   const getPlacementStyle = (placement: TPlacement): string => {
     switch (placement) {
@@ -83,7 +138,9 @@ export function SurveyContainer({
   return (
     <div id="fbjs" className="formbricks-form" dir={dir}>
       <div
-        aria-live="assertive"
+        // In-dialog updates (question changes after a submit) should wait for the reader to finish
+        // speaking, not interrupt it — a survey is never urgent enough for assertive.
+        aria-live="polite"
         className={cn(
           hasOverlay ? "pointer-events-auto" : "pointer-events-none",
           isModal && "fixed inset-0 z-999999 flex items-end"
@@ -97,7 +154,10 @@ export function SurveyContainer({
           <div
             ref={modalRef}
             role="dialog"
-            aria-modal="true"
+            // Only a survey that actually blocks the page is a modal dialog. `aria-modal` makes
+            // assistive tech ignore everything outside it, so setting it on a corner survey hides the
+            // host page from screen-reader users while they can still see and use it.
+            aria-modal={hasOverlay ? "true" : undefined}
             aria-label={t("common.survey_dialog")}
             tabIndex={-1}
             className={cn(

--- a/packages/surveys/src/lib/live-region.ts
+++ b/packages/surveys/src/lib/live-region.ts
@@ -1,0 +1,29 @@
+/**
+ * The persistent, visually hidden status region that survey opens are announced into. The
+ * @formbricks/js SDK mounts it at setup time (packages/js-core/src/lib/survey/widget.ts,
+ * `addLiveRegionContainer`) so assistive tech has registered the region long before the first
+ * message lands — screen readers only reliably announce changes made to a live region that
+ * already existed, not a region inserted together with its content.
+ *
+ * Embed scripts stay on customer pages for years, so an older SDK may not create the region.
+ * `ensureLiveRegion` re-creates it as a degraded fallback (the announcement is delayed a beat
+ * to give assistive tech a chance to register the fresh region — see the caller).
+ */
+
+// Shipped id contract with the SDK (packages/js-core/src/lib/common/constants.ts) — must never change.
+const LIVE_REGION_ID = "formbricks-live-region";
+
+export const ensureLiveRegion = (): HTMLElement => {
+  const existingRegion = document.getElementById(LIVE_REGION_ID);
+  if (existingRegion) return existingRegion;
+
+  const liveRegion = document.createElement("div");
+  liveRegion.id = LIVE_REGION_ID;
+  liveRegion.setAttribute("role", "status");
+  liveRegion.setAttribute("aria-live", "polite");
+  liveRegion.setAttribute("aria-atomic", "true");
+  liveRegion.style.cssText =
+    "position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0";
+  document.body.appendChild(liveRegion);
+  return liveRegion;
+};


### PR DESCRIPTION
## What & why

Backport of #8804 to `release/5.3`.

Ref ENG-2304

A survey opening in a corner with **no overlay** made the page underneath partly unusable: the caret was pulled out of whatever field the user was typing in, text could not be drag-selected, Tab could not leave the survey, and Escape and Cmd/Ctrl+Enter stopped reaching the host page. Mouse clicks kept working, which is why it read as a CSS problem.

The CSS is not the cause — that full-screen layer is already `pointer-events: none` with no overlay. The cause was `survey-container.tsx` arming `useFocusTrap` for **every** modal survey regardless of overlay. The trap registers `focusin`/`focusout`/`keydown` on `document`, so every host-page mousedown pulled focus back into the survey ~17ms later, landing on the survey's text field and collapsing the selection.

The rule this encodes: **the overlay is what makes a survey modal.** With an overlay the page is deliberately blocked, so trapping focus is correct. Without one the survey is a notification sitting on a page the user is still working in, and it must not take anything.

- `survey-container.tsx` — gate `useFocusTrap` on `hasOverlay`; set `aria-modal` only when there is an overlay; move Escape from the trap's `document` listener to a container-scoped listener (closes only while focus is inside the survey, and still bubbles to the host page). `role="dialog"` stays — without `aria-modal` that is exactly a non-modal dialog.
- `render-survey.tsx` — default `autoFocus` off for modal + no overlay. Only ever forces it *off*; every other case keeps the existing default.
- `submit-button.tsx` — don't claim (or `preventDefault`) Cmd/Ctrl+Enter while focus is inside the host page.
- **Screen-reader announcement** (`js-core/.../widget.ts`, `surveys/src/lib/live-region.ts`, one new i18n string): a no-overlay survey deliberately never takes focus, which would otherwise leave screen-reader users with no signal it appeared. The SDK mounts a persistent visually-hidden `role="status"` region at `setup()` and the renderer announces the open into it. This is carried deliberately — dropping it would backport an accessibility regression alongside the fix.

`placement bottomRight` + `overlay none` are the schema defaults, so this affects most existing app surveys.

## Linear ticket

Ref ENG-2304 (already resolved by #8804 on `main`; linked here without a closing keyword).

## How this was tested

Validated on this branch, against `release/5.3`:

- `pnpm test --filter=@formbricks/surveys` ✅ — 26 files, **665/665** pass.
- `pnpm test --filter=@formbricks/js-core` ✅ — 20 files, **288/288** pass.
- `eslint` in `packages/surveys` and `packages/js-core` ✅ — clean.
- `tsc --noEmit` in both packages ✅ — clean.
- `prettier --check` on every changed file ✅ — "All matched files use Prettier code style!".
- `pnpm build --filter=@formbricks/surveys --filter=@formbricks/js-core --force` ✅ — both bundles build; `formbricks-live-region` verified present in the emitted `surveys.umd.cjs` and `js-core/dist/index.umd.cjs`.
- Patch fidelity: the cherry-picked diff is a strict **subset** of #8804's — a line-level comparison found zero lines present here that are not in the original. No conflicts; the cherry-pick applied clean.

Unrelated pre-existing failure, for the record: `@formbricks/jobs` lint fails on `release/5.3` with 45 `no-explicit-any` errors. Confirmed present on untouched `origin/release/5.3`; this backport changes no file under `packages/jobs`.

**Dropped from the original PR** (per backport policy — no net-new tests):

- `apps/web/playwright/survey-modal-non-blocking.spec.ts` (net-new e2e spec)
- `apps/web/playwright/utils/app-survey.ts` (net-new seeder, used only by that spec)
- `packages/surveys/src/lib/live-region.test.ts` (net-new unit test file)
- the three net-new `addLiveRegionContainer` cases in `packages/js-core/src/lib/survey/tests/widget.test.ts`

Kept: the edit to `packages/js-core/src/lib/common/tests/setup.test.ts`, which adds `addLiveRegionContainer` to the existing `vi.mock` factory — without it the pre-existing suite fails. The full behaviour is covered by the e2e spec and unit tests on `main`. Heads-up: with `live-region.ts` carried but its test dropped, Sonar's new-code coverage gate may flag this PR.

No screenshots: there is **no visual change**. The widget renders pixel-identically in both states — only focus and keyboard behaviour changed.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] In a workspace whose widget settings are Placement = Bottom Right and Overlay = None, publish an app survey triggered by a code action. On a test page running the SDK, click into a text field, type some text, then fire the action → the survey appears bottom-right and **the cursor stays in your field**; continuing to type keeps going into your field, not the survey.
- [ ] With the survey open, drag across a paragraph of page text → the text highlights normally and the highlight follows the mouse.
- [ ] With the survey open, press Tab repeatedly from a field on the page → focus moves through the page's own controls instead of cycling inside the survey.
- [ ] With the survey open, click into the survey's answer box and type → it works normally. Press Escape → the survey closes.
- [ ] With the survey open and focus on the page (not the survey), press Escape → the survey stays open and the page's own Escape behaviour (e.g. closing its own dialog) works.
- [ ] With focus in a page textarea that has its own Cmd/Ctrl+Enter shortcut, press Cmd/Ctrl+Enter → the page's shortcut runs and the survey does **not** advance.
- [ ] Set Overlay to Dark or Light and repeat → the old behaviour is expected here: the page is dimmed, the survey takes focus on open, focus stays inside it, and Escape closes it.
- [ ] Announcement, no screen reader needed: after the host page loads the SDK, DevTools → Elements shows an empty `<div id="formbricks-live-region" role="status">` at the end of `<body>` (present **before** any survey opens). Open the no-overlay survey → its text becomes "A survey has opened at the end of the page.". Close the survey → the text clears. Reopen it → the text is set again on every open, not just the first.
- [ ] Screen reader (VoiceOver / NVDA): with Overlay = None, opening the survey plays that announcement politely (waits for current speech, does not interrupt) and focus does not move; the rest of the page stays reachable while the survey is open. With an overlay, focus moves into the survey, the page outside is not reachable, and no extra announcement plays.
- [ ] Link surveys (`/s/<id>`) and the survey preview in the editor: unchanged — autofocus and Cmd/Ctrl+Enter still behave as before.
- [ ] Bundle freshness when testing locally: `/js/*.umd.cjs` is served with `max-age=3600`, so hard-refresh (or DevTools → disable cache) before judging — a stale `formbricks.umd.cjs` shows the old behaviour (no region at all).

**Preconditions / test data**

- An app-type survey with status In Progress, a code action trigger, and Display Option set to "respond multiple times" so it can be reopened.
- A host page loading the JS SDK that has selectable text, at least one input, and ideally its own Escape / Cmd+Enter shortcut to prove we no longer swallow them.
- Widget Placement and Overlay live on the workspace's widget settings, not on the survey.

**Risks & regressions**

- Highest risk is the overlay path: confirm surveys **with** an overlay are unchanged (focus taken on open, focus contained, Escape closes). The e2e spec pins this on `main` but was dropped here per backport policy, so this needs eyes during QA.
- `center` placement combined with Overlay = None is now treated as non-modal. It still looks like a centered modal to a sighted user.
- Keyboard-only discoverability: a no-overlay survey is no longer auto-focused, so a keyboard user must Tab to it (the container is appended last to `<body>`, so it is last in tab order). Screen-reader users get the status-region announcement; sighted keyboard users get no cue beyond the survey appearing.

**Migrations / env / cutover**

- No migrations or env changes.
- On deploy, purge the CDN entries for **both** `/js/surveys.umd.cjs` and `/js/formbricks.umd.cjs` (the live-region change touches js-core too). `apps/web/next.config.mjs` serves `/js/(.*)` with `s-maxage=2592000`, so embedding sites would otherwise keep the old bundles for up to 30 days. Sites loading the SDK from npm instead of `/js/` get the region via the surveys-side fallback until they upgrade.
