### PR TITLE
fix: block native password-reset endpoints when PASSWORD_RESET_DISABLED (ENG-2105)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -116,6 +116,11 @@ jobs:
         run: |
           sed -i "s|REDIS_URL=.*|REDIS_URL=redis://localhost:6379|" .env
           sed -i "s|DATABASE_URL=.*|DATABASE_URL=postgresql://postgres:postgres@localhost:5432/formbricks_ba_test?schema=public|" .env
+          # The password-reset integration tests call Better Auth's native endpoints
+          # directly, so the before-hook gate added in ENG-2105 would block them when
+          # PASSWORD_RESET_DISABLED=1 (the .env.example default). Override to 0 so the
+          # reset-related test coverage still runs.
+          sed -i "s|PASSWORD_RESET_DISABLED=.*|PASSWORD_RESET_DISABLED=0|" .env
         shell: bash
 
       # Build the workspace packages the tests import (@formbricks/logger, cache, types, email, …) so

--- a/apps/web/modules/auth/lib/auth.ts
+++ b/apps/web/modules/auth/lib/auth.ts
@@ -12,6 +12,7 @@ import type { TUserLocale } from "@formbricks/types/user";
 import {
   EMAIL_AUTH_ENABLED,
   EMAIL_VERIFICATION_DISABLED,
+  PASSWORD_RESET_DISABLED,
   PASSWORD_RESET_TOKEN_LIFETIME_MINUTES,
   RATE_LIMITING_DISABLED,
   SESSION_MAX_AGE,
@@ -31,6 +32,7 @@ import { rejectInactiveUserOnSessionCreate } from "./better-auth-active-user-gat
 import { createBrevoCustomerAfterEmailVerification } from "./better-auth-email-verification";
 import { hibpBreachCheckBeforeHandler } from "./better-auth-hibp";
 import { auditPasswordReset, betterAuthLogger, signInAuditDatabaseHook } from "./better-auth-observability";
+import { requirePasswordResetEnabledBeforeHandler } from "./better-auth-password-reset-gate";
 import { getMcpOauthProviderOptions } from "./mcp-oauth-provider-options";
 import { getAuthIssuerUrl, getMcpResourceUrl } from "./oauth-urls";
 import { redisSecondaryStorage } from "./secondary-storage";
@@ -282,6 +284,9 @@ export const auth = betterAuth({
     before: createAuthMiddleware(async (ctx) => {
       await ssoLicenseGateBeforeHandler(ctx);
       await requireDeletionConfirmationBeforeHandler(ctx);
+      // ENG-2105: reject password-reset requests at the native Better Auth layer when the operator
+      // has disabled password resets (PASSWORD_RESET_DISABLED=1). See better-auth-password-reset-gate.ts.
+      await requirePasswordResetEnabledBeforeHandler(ctx, PASSWORD_RESET_DISABLED);
       // ENG-1587: reject known-breached passwords on set (signup / reset) BEFORE the endpoint runs, so
       // the reset token isn't consumed on a rejection. Fails open when api.pwnedpasswords.com is
       // unreachable and honors PASSWORD_HIBP_CHECK_DISABLED. See better-auth-hibp.ts.

--- a/apps/web/modules/auth/lib/better-auth-password-reset-gate.test.ts
+++ b/apps/web/modules/auth/lib/better-auth-password-reset-gate.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { requirePasswordResetEnabledBeforeHandler } from "./better-auth-password-reset-gate";
+
+describe("requirePasswordResetEnabledBeforeHandler (ENG-2105 password-reset disabled gate)", () => {
+  test("allows all paths when password reset is NOT disabled", async () => {
+    await expect(
+      requirePasswordResetEnabledBeforeHandler({ path: "/request-password-reset" }, false)
+    ).resolves.toBeUndefined();
+
+    await expect(
+      requirePasswordResetEnabledBeforeHandler({ path: "/reset-password" }, false)
+    ).resolves.toBeUndefined();
+
+    await expect(
+      requirePasswordResetEnabledBeforeHandler({ path: "/sign-in/email" }, false)
+    ).resolves.toBeUndefined();
+  });
+
+  test("blocks /request-password-reset when password reset is disabled", async () => {
+    await expect(
+      requirePasswordResetEnabledBeforeHandler({ path: "/request-password-reset" }, true)
+    ).rejects.toThrow("Password reset is disabled");
+  });
+
+  test("blocks /reset-password when password reset is disabled", async () => {
+    await expect(requirePasswordResetEnabledBeforeHandler({ path: "/reset-password" }, true)).rejects.toThrow(
+      "Password reset is disabled"
+    );
+  });
+
+  test("allows other paths even when password reset is disabled", async () => {
+    await expect(
+      requirePasswordResetEnabledBeforeHandler({ path: "/sign-in/email" }, true)
+    ).resolves.toBeUndefined();
+
+    await expect(
+      requirePasswordResetEnabledBeforeHandler({ path: "/sign-up/email" }, true)
+    ).resolves.toBeUndefined();
+
+    await expect(
+      requirePasswordResetEnabledBeforeHandler({ path: "/delete-user" }, true)
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/modules/auth/lib/better-auth-password-reset-gate.ts
+++ b/apps/web/modules/auth/lib/better-auth-password-reset-gate.ts
@@ -1,0 +1,22 @@
+import { APIError } from "better-auth/api";
+
+/**
+ * Before-hook gate that rejects password-reset requests when the operator has disabled password resets
+ * via PASSWORD_RESET_DISABLED=1. This closes the bypass where the native Better Auth HTTP endpoints
+ * (/api/auth/request-password-reset and /api/auth/reset-password) were reachable even though the
+ * wrapper server actions (forgotPasswordAction, resetPasswordAction) correctly blocked.
+ *
+ * ENG-2105.
+ */
+export const requirePasswordResetEnabledBeforeHandler = async (
+  ctx: { path: string },
+  passwordResetDisabled: boolean
+): Promise<void> => {
+  if (!passwordResetDisabled) return;
+
+  if (ctx.path === "/request-password-reset" || ctx.path === "/reset-password") {
+    throw new APIError("FORBIDDEN", {
+      message: "Password reset is disabled",
+    });
+  }
+};


### PR DESCRIPTION
## What & why

The `PASSWORD_RESET_DISABLED=1` kill-switch (shipped as the default) only blocked the wrapper server actions (`forgotPasswordAction`, `resetPasswordAction`). The native Better Auth HTTP endpoints at `/api/auth/request-password-reset` and `/api/auth/reset-password` were fully exposed — the `[...all]` route handler delegates directly to `auth.handler()` with no check, and `disabledPaths` only blocked `/token`.

Any caller who knew (or discovered) the API layout could request and complete a password reset regardless of the operator's intent.

**Fix**: a before-hook gate (`requirePasswordResetEnabledBeforeHandler`) that checks `ctx.path` and throws `APIError(FORBIDDEN)` when the flag is set, matching the pattern of the existing deletion-confirmation and HIBP gates. The wrapper actions still carry their own checks as defense in depth.

## Before / after (smoke test, `PASSWORD_RESET_DISABLED=1`)

### Before — main (`d1c109ea2`): bypass confirmed

```sh
$ curl -s http://localhost:3000/api/auth/request-password-reset \
  -X POST -H "Content-Type: application/json" -H "Origin: http://localhost:3000" \
  -d '{"email":"test@formbricks.com"}'
{"status":true,"message":"If this email exists in our system, check your email for the reset link"}
# ^^^ native endpoint processes the request normally — BYPASS

$ curl -s http://localhost:3000/api/auth/reset-password \
  -X POST -H "Content-Type: application/json" -H "Origin: http://localhost:3000" \
  -d '{"newPassword":"Test1234!","token":"fake-token"}'
{"message":"The password you entered has been found in a data breach.","code":"password_compromised"}
# ^^^ reached the HIBP check — BYPASS (the kill-switch never fired)
```

### After — `fix/ENG-2105_password-reset-bypass`: blocked

```sh
$ curl -s http://localhost:3000/api/auth/request-password-reset \
  -X POST -H "Content-Type: application/json" -H "Origin: http://localhost:3000" \
  -d '{"email":"test@formbricks.com"}'
{"message":"Password reset is disabled"}
# ^^^ HTTP 403 FORBIDDEN

$ curl -s http://localhost:3000/api/auth/reset-password \
  -X POST -H "Content-Type: application/json" -H "Origin: http://localhost:3000" \
  -d '{"newPassword":"Test1234!","token":"fake-token"}'
{"message":"Password reset is disabled"}
# ^^^ HTTP 403 FORBIDDEN

$ curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/auth/sign-in/email \
  -X POST -H "Content-Type: application/json" -H "Origin: http://localhost:3000" \
  -d '{"email":"x@x.com","password":"x"}'
401
# ^^^ other auth endpoints unaffected
```

Server log confirms:
```
ERROR [Better Auth]: Password reset is disabled
POST /api/auth/request-password-reset 403 in 43ms
ERROR [Better Auth]: Password reset is disabled
POST /api/auth/reset-password 403 in 57ms
```

## Flag on/off smoke test (fix branch)

Verified both states against the same running server on the fix branch:

### `PASSWORD_RESET_DISABLED=0` — endpoints work normally

| Endpoint | Result |
|---|---|
| `POST /api/auth/request-password-reset` | `200 {"status":true}` — works |
| `POST /api/auth/reset-password` | `400 {"code":"password_compromised"}` — HIBP check fires, endpoint active |
| `POST /api/auth/sign-in/email` | `401` — unaffected |

### `PASSWORD_RESET_DISABLED=1` — endpoints blocked

| Endpoint | Result |
|---|---|
| `POST /api/auth/request-password-reset` | `403 {"message":"Password reset is disabled"}` — BLOCKED |
| `POST /api/auth/reset-password` | `403 {"message":"Password reset is disabled"}` — BLOCKED |
| `POST /api/auth/sign-in/email` | `401` — unaffected |

Server log for both blocked requests: `ERROR [Better Auth]: Password reset is disabled`.

## Linear ticket

Fixes ENG-2105

## How this was tested

- **Unit tests**: `npx vitest run modules/auth/lib/better-auth-password-reset-gate.test.ts` — 4 tests pass (flag off allows all, flag on blocks both reset endpoints, flag on allows other paths)
- **Regression tests**: `npx vitest run modules/auth/lib/better-auth-hibp.test.ts modules/account/lib/better-auth-account-deletion.test.ts modules/auth/lib/better-auth-observability.test.ts` — all 60 adjacent tests pass
- **Security review**: clean — no injection, no authz bypass, no path traversal, no info leakage
- **Smoke test — main vs fix**: before/after against running dev server (see above) — bypass confirmed on main, blocked on fix branch
- **Smoke test — flag on/off**: both states tested against fix branch (see above) — endpoints work normally when off, blocked when on, other auth unaffected

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] With `PASSWORD_RESET_DISABLED=1`, `POST /api/auth/request-password-reset` → HTTP 403 `{"message":"Password reset is disabled"}`
- [ ] With `PASSWORD_RESET_DISABLED=1`, `POST /api/auth/reset-password` → HTTP 403 `{"message":"Password reset is disabled"}`
- [ ] With `PASSWORD_RESET_DISABLED=0`, both password-reset endpoints work normally
- [ ] Other auth endpoints (`/sign-in/email`, `/sign-up/email`, `/delete-user`) are unaffected regardless of flag state
- [ ] The forgot-password UI flow (login form → forgot password link → email → reset form) still works when the flag is off

**Preconditions / test data**

- `PASSWORD_RESET_DISABLED=1` in `.env` (the default)
- A user with `identityProvider === "email"` for the full UI flow test

**Risks & regressions**

- Verify the forgot-password UI flow still works normally when the flag is off
- Verify login/signup/SSO flows are unaffected

**Migrations / env / cutover**

- none

## Credit

Reported by Jaejun Cho.