### PR TITLE
fix(email): resolve the whitelabel logo path for workflow and follow-up emails

### DIFF
--- a/apps/web/modules/email/lib/survey-response-email.test.ts
+++ b/apps/web/modules/email/lib/survey-response-email.test.ts
@@ -280,4 +280,40 @@ describe("buildSurveyResponseEmailHtml", () => {
     await buildSurveyResponseEmailHtml({ body: "Body", survey, response, attachResponseData: false });
     expect(mockGetTranslate).toHaveBeenCalledWith("en-US");
   });
+
+  // The whitelabel logo is persisted as a relative `/storage/...` path. Passed through unresolved it
+  // reaches the email as `<img src="/storage/...">`, which no mail client can resolve — the header
+  // logo rendered broken in every workflow / follow-up email.
+  test("resolves a relative whitelabel logo path to an absolute URL", async () => {
+    await buildSurveyResponseEmailHtml({
+      body: "Body",
+      survey,
+      response,
+      attachResponseData: false,
+      logoUrl: "/storage/wsp123/public/logo--fid--abc.png",
+    });
+
+    expect(mockResolveStorageUrl).toHaveBeenCalledWith("/storage/wsp123/public/logo--fid--abc.png");
+    expect(mockRenderFollowUpEmail.mock.calls[0][0].logoUrl).toBe(
+      "https://cdn.example.com//storage/wsp123/public/logo--fid--abc.png"
+    );
+  });
+
+  // Callers pass `""` when the organization has no whitelabel logo; that must stay falsy so the
+  // template falls back to the default Formbricks logo instead of resolving an empty path.
+  test.each([
+    ["an empty logo url", ""],
+    ["no logo url", undefined],
+  ])("leaves the logo unset for %s", async (_label, logoUrl) => {
+    await buildSurveyResponseEmailHtml({
+      body: "Body",
+      survey,
+      response,
+      attachResponseData: false,
+      logoUrl,
+    });
+
+    expect(mockResolveStorageUrl).not.toHaveBeenCalled();
+    expect(mockRenderFollowUpEmail.mock.calls[0][0].logoUrl).toBeUndefined();
+  });
 });

--- a/apps/web/modules/email/lib/survey-response-email.ts
+++ b/apps/web/modules/email/lib/survey-response-email.ts
@@ -168,7 +168,10 @@ export const buildSurveyResponseEmailHtml = async ({
     responseData: buildResponseData(survey, response, attachResponseData),
     variables: buildVariables(survey, response, attachResponseData, includeVariables),
     hiddenFields: buildHiddenFields(survey, response, attachResponseData, includeHiddenFields),
-    logoUrl,
+    // The whitelabel logo is stored as a relative `/storage/...` path, which an email client cannot
+    // resolve — it has no origin to resolve against, so the `<img>` renders broken. Resolve it to an
+    // absolute URL here, exactly like every other email sender does (see `@/modules/email`).
+    logoUrl: logoUrl ? resolveStorageUrl(logoUrl) : undefined,
     t,
     privacyUrl: PRIVACY_URL || undefined,
     termsUrl: TERMS_URL || undefined,


### PR DESCRIPTION
## What & why

An organization's whitelabel logo is persisted as a **relative** `/storage/{workspaceId}/public/...` path (that is what `getSignedUrlForUpload` returns, and `updateOrganizationEmailLogoUrl` stores it verbatim). Every email sender in `apps/web/modules/email/index.tsx` therefore runs it through `resolveStorageUrl` before rendering — link-survey verification, embed-survey preview, the email-customization test email.

`buildSurveyResponseEmailHtml` did not. It handed the stored value straight to the template, so the email went out with:

```html
<img data-testid="logo-image" alt="Logo" src="/storage/wsp_.../public/logo--fid--....png" />
```

A mail client has no origin to resolve that against, so the header logo rendered as a broken image. Two senders share that helper and were both affected:

- the workflow `send_email` action (`process-workflow-run-job.ts` → `logoUrl: emailContext.logoUrl`)
- survey Follow-Ups (`sendFollowUpEmail`)

The response notification email looked fine only because it never passes a `logoUrl` at all — `ResponseFinishedEmail` always falls back to the hard-coded absolute Formbricks logo. So the difference the bug report shows is "whitelabel logo vs. default logo", not "workflows vs. notifications".

Fix: resolve the path in `buildSurveyResponseEmailHtml`, matching what the other senders already do. `""`/`undefined` stay falsy so the template keeps falling back to the default Formbricks logo.

## Linear ticket

No ticket — filed straight from a bug report in the product inbox.

## How this was tested

- `pnpm test modules/email/lib/survey-response-email.test.ts` ✅ 19 passed (3 new cases: a relative path is resolved; `""` and `undefined` leave the logo unset so the default logo still applies).
- `pnpm test modules/email` — 29 passed. `modules/email/embed-survey-preview-email.test.ts` fails to load in my worktree with `Failed to resolve entry for package "@formbricks/storage"` (unbuilt workspace dep); confirmed identical on a stashed, unmodified tree, so it is environmental and unrelated.
- Visual proof below: the real `renderFollowUpEmail` output for a whitelabel org, rendered with the stored value before the fix and the resolved value after, then opened from an origin that has no `/storage` — which is exactly the situation a mail client is in.

### Before — logo `src` is the stored relative path

![before](https://raw.githubusercontent.com/formbricks/formbricks/assets-workflow-email-logo/before.png)

`src="/storage/wsp_acme/public/acme-logo--fid--0e3b.png"` → broken image + the `Logo` alt text, matching the reported Gmail screenshot.

### After — logo `src` is resolved to an absolute URL

![after](https://raw.githubusercontent.com/formbricks/formbricks/assets-workflow-email-logo/after.png)

Both shots are real template output rather than live Gmail captures: the emails were rendered through `renderFollowUpEmail`, served from one local origin, and the logo served from a second origin standing in for the storage host. The assets branch `assets-workflow-email-logo` holds only these two PNGs and can be deleted once the PR is merged.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] As an owner/manager of an organization with a whitelabel license, go to organization settings → Email customization, upload a logo, and save it → the logo preview shows your logo.
- [ ] Click "Send test email" → the email you receive shows your uploaded logo in the header (this path already worked; it is the regression guard).
- [ ] In a workspace of that organization, create a survey with a workflow that has a `send_email` step addressed to your own address, and enable the workflow.
- [ ] Submit a response to the survey → the workflow email arrives with **your uploaded logo** in the header, not a broken image placeholder with the alt text "Logo".
- [ ] Repeat with a survey Follow-Up (survey editor → Follow-ups) instead of a workflow → the follow-up email also shows your uploaded logo.
- [ ] Remove the logo in Email customization, then trigger the workflow email again → the header falls back to the default Formbricks logo, which links to formbricks.com.
- [ ] Organization without a whitelabel logo configured → workflow and follow-up emails show the default Formbricks logo (unchanged behavior).

**Preconditions / test data**

- An organization on a plan/license that unlocks white-labeling (Email customization is gated behind it).
- Configured file storage (S3 or S3-compatible) so the logo upload succeeds.
- Working SMTP so the emails actually send.
- Reproduces on both Cloud and self-hosted; on self-hosted make sure the public domain env var is set correctly, since that is what the relative path now resolves against.

**Risks & regressions**

- Nearby: survey Follow-Up emails share the same helper — re-check that their logo still renders and that response data, variables and hidden-field blocks are unaffected.
- Re-check the default-logo fallback: an organization with no whitelabel logo must still get the Formbricks logo, not an empty or broken image.
- Self-hosted deployments where the public domain differs from the app URL — the resolved absolute logo URL follows the public domain, same as every other storage URL in emails.

**Migrations / env / cutover**

- none
