### PR TITLE
fix: block unauthenticated account creation on closed instances via raw signup endpoint [ENG-2293]

### DIFF
--- a/apps/web/modules/auth/lib/auth.ts
+++ b/apps/web/modules/auth/lib/auth.ts
@@ -36,6 +36,7 @@ import { requirePasswordResetEnabledBeforeHandler } from "./better-auth-password
 import { getMcpOauthProviderOptions } from "./mcp-oauth-provider-options";
 import { getAuthIssuerUrl, getMcpResourceUrl } from "./oauth-urls";
 import { redisSecondaryStorage } from "./secondary-storage";
+import { signupPolicyBeforeHandler } from "./signup-policy";
 
 const DAY_IN_SECONDS = 60 * 60 * 24;
 
@@ -287,6 +288,13 @@ export const auth = betterAuth({
       // ENG-2105: reject password-reset requests at the native Better Auth layer when the operator
       // has disabled password resets (PASSWORD_RESET_DISABLED=1). See better-auth-password-reset-gate.ts.
       await requirePasswordResetEnabledBeforeHandler(ctx, PASSWORD_RESET_DISABLED);
+      // ENG-2293: enforce the closed-sign-up policy on Better Auth's native /sign-up/email, which is
+      // served beside createUserAction and used to bypass it entirely. Runs BEFORE the endpoint so the
+      // rejection can't double as an account-existence oracle (the handler looks the address up first,
+      // and an address that already has one never reaches a create hook). See signup-policy.ts.
+      // Ordered ahead of the breach check so a sign-up on a closed instance costs no outbound HIBP call.
+      // Path-disjoint from the reset gate above, so their relative order is not load-bearing.
+      await signupPolicyBeforeHandler(ctx);
       // ENG-1587: reject known-breached passwords on set (signup / reset) BEFORE the endpoint runs, so
       // the reset token isn't consumed on a rejection. Fails open when api.pwnedpasswords.com is
       // unreachable and honors PASSWORD_HIBP_CHECK_DISABLED. See better-auth-hibp.ts.

--- a/apps/web/modules/auth/lib/signup-policy.test.ts
+++ b/apps/web/modules/auth/lib/signup-policy.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { SIGNUP_DISABLED_ERROR_CODE } from "@formbricks/types/errors";
+import { getIsFreshInstance } from "@/lib/instance/service";
+import { isSignupDomainAllowed } from "@/modules/auth/lib/signup-request-context";
+import { getIsMultiOrgEnabled } from "@/modules/ee/license-check/lib/utils";
+import { isUninvitedSignupAllowed, signupPolicyBeforeHandler } from "./signup-policy";
+
+const constantsOverrides = vi.hoisted(() => ({ SIGNUP_ENABLED: true }));
+vi.mock("@/lib/constants", () => ({
+  get SIGNUP_ENABLED() {
+    return constantsOverrides.SIGNUP_ENABLED;
+  },
+}));
+vi.mock("@/lib/instance/service", () => ({ getIsFreshInstance: vi.fn() }));
+vi.mock("@/modules/ee/license-check/lib/utils", () => ({ getIsMultiOrgEnabled: vi.fn() }));
+vi.mock("@/modules/auth/lib/signup-request-context", () => ({ isSignupDomainAllowed: vi.fn() }));
+
+/** A closed self-hosted instance: SIGNUP_ENABLED is always false there, and it already has users. */
+const closeTheInstance = (): void => {
+  constantsOverrides.SIGNUP_ENABLED = false;
+  vi.mocked(getIsMultiOrgEnabled).mockResolvedValue(false);
+  vi.mocked(getIsFreshInstance).mockResolvedValue(false);
+};
+
+const rawSignup = { path: "/sign-up/email" } as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  constantsOverrides.SIGNUP_ENABLED = true;
+  vi.mocked(getIsMultiOrgEnabled).mockResolvedValue(true);
+  vi.mocked(getIsFreshInstance).mockResolvedValue(false);
+  vi.mocked(isSignupDomainAllowed).mockReturnValue(false);
+});
+
+describe("isUninvitedSignupAllowed", () => {
+  test("allows when public sign-up is genuinely open", async () => {
+    await expect(isUninvitedSignupAllowed()).resolves.toBe(true);
+  });
+
+  test("allows the initial administrator on a fresh instance", async () => {
+    closeTheInstance();
+    vi.mocked(getIsFreshInstance).mockResolvedValue(true);
+    await expect(isUninvitedSignupAllowed()).resolves.toBe(true);
+  });
+
+  test("refuses on a closed, already-provisioned instance", async () => {
+    closeTheInstance();
+    await expect(isUninvitedSignupAllowed()).resolves.toBe(false);
+  });
+
+  test("refuses when SIGNUP_ENABLED is set but the license forbids multiple organizations", async () => {
+    vi.mocked(getIsMultiOrgEnabled).mockResolvedValue(false);
+    await expect(isUninvitedSignupAllowed()).resolves.toBe(false);
+  });
+
+  // The two orderings below are the reason this predicate short-circuits the way it does: an
+  // unauthenticated caller must not be able to make us count the User table on every attempt.
+  test("does not count users once public sign-up has answered the question", async () => {
+    await expect(isUninvitedSignupAllowed()).resolves.toBe(true);
+    expect(getIsFreshInstance).not.toHaveBeenCalled();
+  });
+
+  test("does not consult the license when SIGNUP_ENABLED is false", async () => {
+    closeTheInstance();
+    await isUninvitedSignupAllowed();
+    expect(getIsMultiOrgEnabled).not.toHaveBeenCalled();
+  });
+});
+
+describe("signupPolicyBeforeHandler", () => {
+  test("rejects a raw credential sign-up on a closed instance", async () => {
+    closeTheInstance();
+    await expect(signupPolicyBeforeHandler(rawSignup)).rejects.toMatchObject({
+      status: "FORBIDDEN",
+      body: { code: SIGNUP_DISABLED_ERROR_CODE },
+    });
+  });
+
+  test("ignores every path other than the credential sign-up route", async () => {
+    closeTheInstance();
+    for (const path of ["/sign-in/email", "/reset-password", "/oauth2/callback/openid", "/get-session"]) {
+      await expect(signupPolicyBeforeHandler({ path } as never)).resolves.toBeUndefined();
+    }
+  });
+
+  // createUserAction applies the full policy — including the invite exemption this hook cannot see —
+  // and marks the request scope. Re-deciding here would reject legitimately invited sign-ups.
+  test("exempts a sign-up routed through createUserAction", async () => {
+    closeTheInstance();
+    vi.mocked(isSignupDomainAllowed).mockReturnValue(true);
+    await expect(signupPolicyBeforeHandler(rawSignup)).resolves.toBeUndefined();
+    expect(getIsFreshInstance).not.toHaveBeenCalled();
+  });
+
+  test("allows a raw credential sign-up while the instance is still fresh", async () => {
+    closeTheInstance();
+    vi.mocked(getIsFreshInstance).mockResolvedValue(true);
+    await expect(signupPolicyBeforeHandler(rawSignup)).resolves.toBeUndefined();
+  });
+
+  test("allows a raw credential sign-up when public sign-up is open", async () => {
+    await expect(signupPolicyBeforeHandler(rawSignup)).resolves.toBeUndefined();
+  });
+});

--- a/apps/web/modules/auth/lib/signup-policy.ts
+++ b/apps/web/modules/auth/lib/signup-policy.ts
@@ -1,0 +1,79 @@
+import "server-only";
+import { APIError } from "better-auth/api";
+import { SIGNUP_DISABLED_ERROR_CODE } from "@formbricks/types/errors";
+import { SIGNUP_ENABLED } from "@/lib/constants";
+import { getIsFreshInstance } from "@/lib/instance/service";
+import { isSignupDomainAllowed } from "@/modules/auth/lib/signup-request-context";
+import { getIsMultiOrgEnabled } from "@/modules/ee/license-check/lib/utils";
+import type { AuthHookContext } from "@/modules/ee/sso/lib/better-auth-hooks";
+
+/**
+ * The instance's closed-sign-up policy, in ONE place (ENG-2293).
+ *
+ * The policy had been written out twice — in `createUserAction`'s `assertSignupPolicyAllows` and, once
+ * this hole was found, again in the Better Auth hook. That duplication IS the bug class: ENG-2073 fixed
+ * the action and left the framework-mounted route open, which is what ENG-2293 then had to close. Both
+ * callers now share the predicate below, so a future change to the policy cannot land in one layer
+ * only. ENG-2344 tracks the third caller (SSO just-in-time provisioning) still deciding on its own.
+ */
+
+/**
+ * Whether an UNINVITED sign-up is allowed by instance policy. Callers that can carry an invite must
+ * check that themselves — a valid invite is an independent grant, and the raw Better Auth endpoint has
+ * no invite to present.
+ *
+ * Two legitimate ways to be allowed: public sign-up is genuinely open (Cloud / dev / E2E *and* the
+ * license permits multiple organizations), or the instance is still fresh, which is the initial
+ * administrator completing setup with no invite to show.
+ *
+ * Query cost is deliberate. `SIGNUP_ENABLED` is a derived constant
+ * (`IS_FORMBRICKS_CLOUD || IS_DEVELOPMENT || E2E_TESTING`), so testing it is free — do that first and
+ * only pay for a round trip that can still change the answer. On Cloud that answers the whole question
+ * from the (cached) license and never counts users; on self-hosted, where the constant is always false,
+ * it skips the license lookup and spends exactly one `count`. Evaluating freshness first — as the
+ * original fix did — instead made every unauthenticated raw sign-up attempt run `count(*)` on `User`.
+ */
+export const isUninvitedSignupAllowed = async (): Promise<boolean> => {
+  if (SIGNUP_ENABLED && (await getIsMultiOrgEnabled())) return true;
+  return getIsFreshInstance();
+};
+
+/** Better Auth's native credential sign-up route — the one that bypasses `createUserAction`. */
+const CREDENTIAL_SIGNUP_PATH = "/sign-up/email";
+
+/**
+ * Better Auth `before` hook: enforce the closed-sign-up policy on `POST /api/auth/sign-up/email`
+ * BEFORE the endpoint handler runs (ENG-2293).
+ *
+ * `apps/web/app/api/auth/[...all]/route.ts` mounts `auth.handler` raw, so Better Auth serves its own
+ * credential sign-up route beside ours. `createUserAction` gates correctly but nothing forced that
+ * route to, so an unauthenticated POST created an account on an instance the operator had closed.
+ *
+ * WHY here rather than only in `databaseHooks.user.create.before`: the route handler looks the email up
+ * *before* it creates anything (`api/routes/sign-up.mjs` — `findUserByEmail`, then the
+ * `shouldReturnGenericDuplicateResponse` branch returns a synthetic 200 for an address that already
+ * has an account, without writing a row, so no create hook ever runs). A gate that lives in the create
+ * hook is therefore only reachable for addresses that do NOT exist, which turns the rejection into an
+ * account-existence oracle: 200 for a registered address, 403 for an unregistered one. `autoSignIn:
+ * false` in auth.ts makes that duplicate branch unconditional, and its comment calls the behaviour
+ * "enumeration-safe" — so gating in the create hook would have quietly spent a property the sign-up
+ * flow works hard to hold (ENG-2091 / ENG-2099). Running before the handler rejects every request
+ * identically, whatever the address. Same reasoning and the same slot as
+ * `hibpBreachCheckBeforeHandler`, which sits here so a reset token isn't consumed before rejection.
+ *
+ * Action-routed sign-ups are exempt: `createUserAction` has already applied the full policy (including
+ * the invite exemption this hook cannot see) and marks the request scope before calling
+ * `auth.api.signUpEmail`. The absence of that mark is what identifies a raw POST.
+ */
+export const signupPolicyBeforeHandler = async (ctx: AuthHookContext): Promise<void> => {
+  if (ctx.path !== CREDENTIAL_SIGNUP_PATH) return;
+  // Already gated by createUserAction, which also honours a valid invite — do not re-decide it here.
+  if (isSignupDomainAllowed()) return;
+
+  if (!(await isUninvitedSignupAllowed())) {
+    throw new APIError("FORBIDDEN", {
+      message: "Signup is disabled on this instance.",
+      code: SIGNUP_DISABLED_ERROR_CODE,
+    });
+  }
+};

--- a/apps/web/modules/auth/lib/signup-policy.ts
+++ b/apps/web/modules/auth/lib/signup-policy.ts
@@ -42,6 +42,18 @@ export const isUninvitedSignupAllowed = async (): Promise<boolean> => {
 const CREDENTIAL_SIGNUP_PATH = "/sign-up/email";
 
 /**
+ * The rejection for a sign-up the instance policy forbids. Shared because two layers raise it — the
+ * before-hook below and the `user.create.before` backstop — and they must stay byte-identical: the
+ * response is the only thing an unauthenticated caller can see, so a divergence between them would be
+ * observable. The `code` is what a client localizes against; the message is display copy.
+ */
+export const signupDisabledError = (): APIError =>
+  new APIError("FORBIDDEN", {
+    message: "Signup is disabled on this instance.",
+    code: SIGNUP_DISABLED_ERROR_CODE,
+  });
+
+/**
  * Better Auth `before` hook: enforce the closed-sign-up policy on `POST /api/auth/sign-up/email`
  * BEFORE the endpoint handler runs (ENG-2293).
  *
@@ -71,9 +83,6 @@ export const signupPolicyBeforeHandler = async (ctx: AuthHookContext): Promise<v
   if (isSignupDomainAllowed()) return;
 
   if (!(await isUninvitedSignupAllowed())) {
-    throw new APIError("FORBIDDEN", {
-      message: "Signup is disabled on this instance.",
-      code: SIGNUP_DISABLED_ERROR_CODE,
-    });
+    throw signupDisabledError();
   }
 };

--- a/apps/web/modules/auth/signup/actions.ts
+++ b/apps/web/modules/auth/signup/actions.ts
@@ -12,13 +12,7 @@ import {
   UnknownError,
 } from "@formbricks/types/errors";
 import { ZUser, ZUserEmail, ZUserLocale, ZUserName, ZUserPassword } from "@formbricks/types/user";
-import {
-  IS_FORMBRICKS_CLOUD,
-  IS_TURNSTILE_CONFIGURED,
-  SIGNUP_ENABLED,
-  TURNSTILE_SECRET_KEY,
-} from "@/lib/constants";
-import { getIsFreshInstance } from "@/lib/instance/service";
+import { IS_FORMBRICKS_CLOUD, IS_TURNSTILE_CONFIGURED, TURNSTILE_SECRET_KEY } from "@/lib/constants";
 import { verifyInviteToken } from "@/lib/jwt";
 import { createMembership } from "@/lib/membership/service";
 import { createOrganization, getOrganization } from "@/lib/organization/service";
@@ -36,6 +30,7 @@ import { ATTRIBUTION_COOKIE_NAME, getAttributionPropertiesFromCookies } from "@/
 import { auth } from "@/modules/auth/lib/auth";
 import { isPasswordCompromisedError } from "@/modules/auth/lib/better-auth-hibp";
 import { isSignupEmailDomainBlocked } from "@/modules/auth/lib/signup-email-domain";
+import { isUninvitedSignupAllowed } from "@/modules/auth/lib/signup-policy";
 import {
   markSignupDomainAllowed,
   runWithSignupRequestContext,
@@ -359,14 +354,16 @@ async function assertSignupPolicyAllows(
     throw new InvalidInputError(INVITE_TOKEN_INVALID_ERROR_CODE);
   }
 
-  const isPublicSignupOpen = SIGNUP_ENABLED && (await getIsMultiOrgEnabled());
-  if (isPublicSignupOpen || inviteMatch === "valid") {
+  // A valid invite is an independent grant — it admits the holder whatever the instance policy says.
+  if (inviteMatch === "valid") {
     return;
   }
 
-  // Closed instance and no invite: the only remaining legitimate case is the initial administrator
-  // during fresh-instance setup, who has no invite to present.
-  if (!(await getIsFreshInstance())) {
+  // No invite, so it comes down to instance policy: public sign-up genuinely open, or the initial
+  // administrator during fresh-instance setup, who has no invite to present. That predicate is shared
+  // with the Better Auth hooks (signup-policy.ts) — writing it out twice is what left Better Auth's
+  // native /sign-up/email open after this action was fixed (ENG-2073 → ENG-2293).
+  if (!(await isUninvitedSignupAllowed())) {
     throw new InvalidInputError(SIGNUP_DISABLED_ERROR_CODE);
   }
 }

--- a/apps/web/modules/auth/signup/signup-closed-instance.integration.test.ts
+++ b/apps/web/modules/auth/signup/signup-closed-instance.integration.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { prisma } from "@formbricks/database";
+import { resetDb } from "@/integration/reset-db";
+import { auth } from "@/modules/auth/lib/auth";
+import { runWithSsoRequestContext } from "@/modules/ee/sso/lib/sso-request-context";
+
+/**
+ * ENG-2293 at the FRAMEWORK boundary: Better Auth's native `POST /sign-up/email` against a real
+ * Postgres, with no `createUserAction` in the way.
+ *
+ * This is the boundary the vulnerability lived at, so it is the boundary the regression test has to
+ * drive. `app/api/auth/[...all]/route.ts` mounts `auth.handler` raw, which serves Better Auth's own
+ * credential sign-up route beside ours; the closed-instance policy used to exist only in the server
+ * action, so an unauthenticated POST created an account on an instance the operator had closed. A unit
+ * test that calls the hook directly cannot show any of that — it asserts our function, not that the
+ * route is actually gated or that the caller gets a 403.
+ *
+ * Driven through `auth.handler` with a real `Request` — the same call `app/api/auth/[...all]/route.ts`
+ * makes, wrapped the same way — rather than `auth.api.signUpEmail`. That is not stylistic: an `APIError`
+ * thrown from a `hooks.before` middleware propagates to an `auth.api` caller as a rejected promise, and
+ * only the HTTP handler turns it into the 403 an attacker would actually receive. Asserting the status
+ * code is the whole point here, so the test has to go through the layer that produces one.
+ */
+
+/**
+ * A CLOSED self-hosted instance. `SIGNUP_ENABLED` is derived
+ * (`IS_FORMBRICKS_CLOUD || IS_DEVELOPMENT || E2E_TESTING`) and so is already false under vitest, but
+ * pin it: this suite is meaningless if an env change quietly opens sign-up, and a passing test would
+ * then prove nothing. Multi-org is forced off for the same reason — with it on, public sign-up counts
+ * as open and every assertion below would invert.
+ */
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  SIGNUP_ENABLED: false,
+}));
+
+vi.mock("@/modules/ee/license-check/lib/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/modules/ee/license-check/lib/utils")>()),
+  getIsMultiOrgEnabled: vi.fn(async () => false),
+}));
+
+const PASSWORD = "Passw0rd!";
+const ADMIN = "admin@corporate-example.com";
+const INTRUDER = "intruder@corporate-example.com";
+
+const SIGNUP_URL = "http://localhost:3000/api/auth/sign-up/email";
+
+/** An unauthenticated POST to the mounted route — the request the vulnerability was reported against. */
+const rawSignUp = (email: string): Promise<Response> =>
+  runWithSsoRequestContext(() =>
+    auth.handler(
+      new Request(SIGNUP_URL, {
+        method: "POST",
+        headers: { "content-type": "application/json", origin: "http://localhost:3000" },
+        body: JSON.stringify({ email, password: PASSWORD, name: "Someone" }),
+      })
+    )
+  );
+
+const userCount = (email: string): Promise<number> => prisma.user.count({ where: { email } });
+
+beforeEach(async () => {
+  await resetDb();
+  vi.clearAllMocks();
+});
+
+describe("raw Better Auth sign-up on a closed instance (real Postgres)", () => {
+  // The fresh-instance exception is deliberate and has to survive the fix: with zero users there is no
+  // administrator to invite anyone yet, so the first sign-up is how an instance gets set up at all.
+  test("admits the first administrator while the instance is still fresh", async () => {
+    expect(await prisma.user.count()).toBe(0);
+
+    const response = await rawSignUp(ADMIN);
+
+    expect(response.status).toBe(200);
+    expect(await userCount(ADMIN)).toBe(1);
+  });
+
+  test("rejects an uninvited sign-up once the instance has a user", async () => {
+    await rawSignUp(ADMIN); // consumes the fresh-instance exception
+    expect(await userCount(ADMIN)).toBe(1);
+
+    const response = await rawSignUp(INTRUDER);
+
+    // Before the fix this returned 200 and created the account.
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ code: "signup_disabled" });
+    expect(await userCount(INTRUDER)).toBe(0);
+  });
+
+  /**
+   * The reason the gate runs in `hooks.before` and not only in `databaseHooks.user.create.before`.
+   *
+   * Better Auth looks the address up before it creates anything, and answers an address that already
+   * has an account with a synthetic 200 without writing a row — so no create hook ever runs for it
+   * (see signup-duplicate-email.integration.test.ts, which pins that contract). A gate placed in the
+   * create hook is therefore reachable only for addresses that do NOT exist, and its rejection becomes
+   * an account-existence oracle: 403 for an unregistered address, 200 for a registered one. `autoSignIn:
+   * false` makes that branch unconditional and auth.ts calls it "enumeration-safe", so this test exists
+   * to keep it that way.
+   */
+  test("answers a registered and an unregistered address identically", async () => {
+    await rawSignUp(ADMIN);
+    expect(await userCount(ADMIN)).toBe(1);
+
+    const registered = await rawSignUp(ADMIN); // exists — would be a synthetic 200
+    const unregistered = await rawSignUp(INTRUDER); // does not exist
+
+    expect(registered.status).toBe(unregistered.status);
+    expect(await registered.json()).toStrictEqual(await unregistered.json());
+    // Still nothing written, and the existing account is untouched.
+    expect(await userCount(ADMIN)).toBe(1);
+    expect(await userCount(INTRUDER)).toBe(0);
+  });
+});

--- a/apps/web/modules/auth/signup/signup-duplicate-email.integration.test.ts
+++ b/apps/web/modules/auth/signup/signup-duplicate-email.integration.test.ts
@@ -14,6 +14,24 @@ import { sendVerificationLinkEmail } from "@/modules/email";
  * previously mocked `signUpEmail` into rejecting, which asserted a branch that cannot execute.
  */
 
+/**
+ * Open, Cloud-shaped instance — required since ENG-2293 gated Better Auth's native `/sign-up/email` on
+ * the closed-instance policy. These calls are deliberately NOT action-scoped, so on a closed instance
+ * the second sign-up below would be rejected outright and the duplicate branch would never run. The
+ * contract still matters exactly as asserted: `signUpUserSafely` reaches it through `createUserAction`,
+ * which is exempt from that gate, on open and closed instances alike. Closed-instance behaviour of the
+ * raw route is covered by signup-closed-instance.integration.test.ts.
+ */
+vi.mock("@/lib/constants", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/constants")>()),
+  SIGNUP_ENABLED: true,
+}));
+
+vi.mock("@/modules/ee/license-check/lib/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/modules/ee/license-check/lib/utils")>()),
+  getIsMultiOrgEnabled: vi.fn(async () => true),
+}));
+
 beforeEach(async () => {
   await resetDb();
   vi.clearAllMocks();

--- a/apps/web/modules/ee/sso/lib/better-auth-hooks.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-hooks.test.ts
@@ -2,11 +2,16 @@ import { getOAuthState } from "better-auth/api";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
 import { SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE } from "@formbricks/types/errors";
+import { getIsFreshInstance } from "@/lib/instance/service";
 import { identifyPostHogPerson } from "@/lib/posthog";
 import { findMatchingLocale } from "@/lib/utils/locale";
 import { isSignupEmailDomainBlocked } from "@/modules/auth/lib/signup-email-domain";
 import { isSignupDomainAllowed } from "@/modules/auth/lib/signup-request-context";
-import { getIsSamlSsoEnabled, getIsSsoEnabled } from "@/modules/ee/license-check/lib/utils";
+import {
+  getIsMultiOrgEnabled,
+  getIsSamlSsoEnabled,
+  getIsSsoEnabled,
+} from "@/modules/ee/license-check/lib/utils";
 import {
   blockedSignupDomainRedirectAfter,
   getSsoProviderFromContext,
@@ -40,10 +45,6 @@ vi.mock("better-auth/api", () => ({
 vi.mock("@formbricks/database", () => ({ prisma: { user: { findUnique: vi.fn() } } }));
 vi.mock("@/lib/posthog", () => ({ identifyPostHogPerson: vi.fn() }));
 vi.mock("@/lib/utils/locale", () => ({ findMatchingLocale: vi.fn() }));
-vi.mock("@/modules/ee/license-check/lib/utils", () => ({
-  getIsSsoEnabled: vi.fn(),
-  getIsSamlSsoEnabled: vi.fn(),
-}));
 vi.mock("./sso-provisioning", () => ({
   gateSsoProvisioning: vi.fn(),
   provisionSsoUserMemberships: vi.fn(),
@@ -51,6 +52,20 @@ vi.mock("./sso-provisioning", () => ({
 vi.mock("./sso-recovery", () => ({ startSsoRecovery: vi.fn() }));
 vi.mock("@/modules/auth/lib/signup-email-domain", () => ({ isSignupEmailDomainBlocked: vi.fn() }));
 vi.mock("@/modules/auth/lib/signup-request-context", () => ({ isSignupDomainAllowed: vi.fn() }));
+
+const constantsOverrides = vi.hoisted(() => ({ SIGNUP_ENABLED: true }));
+vi.mock("@/lib/constants", () => ({
+  WEBAPP_URL: "http://localhost:3000",
+  get SIGNUP_ENABLED() {
+    return constantsOverrides.SIGNUP_ENABLED;
+  },
+}));
+vi.mock("@/lib/instance/service", () => ({ getIsFreshInstance: vi.fn() }));
+vi.mock("@/modules/ee/license-check/lib/utils", () => ({
+  getIsMultiOrgEnabled: vi.fn(),
+  getIsSsoEnabled: vi.fn(),
+  getIsSamlSsoEnabled: vi.fn(),
+}));
 
 const callbackCtx = { path: "/oauth2/callback/:providerId", params: { providerId: "openid" } };
 const provisionDecision = {
@@ -62,11 +77,14 @@ const provisionDecision = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  constantsOverrides.SIGNUP_ENABLED = true;
   vi.mocked(findMatchingLocale).mockResolvedValue("en-US");
   vi.mocked(getOAuthState).mockResolvedValue({ callbackURL: "/" } as never);
   vi.mocked(gateSsoProvisioning).mockResolvedValue(provisionDecision);
   vi.mocked(getIsSsoEnabled).mockResolvedValue(true);
   vi.mocked(getIsSamlSsoEnabled).mockResolvedValue(true);
+  vi.mocked(getIsMultiOrgEnabled).mockResolvedValue(true);
+  vi.mocked(getIsFreshInstance).mockResolvedValue(false);
   vi.mocked(prisma.user.findUnique).mockResolvedValue({
     id: "u1",
     email: "a@b.com",
@@ -233,6 +251,58 @@ describe("ssoDatabaseHooks.user.create.before", () => {
       } as never
     );
     expect(result).toBeUndefined();
+  });
+
+  // ENG-2293: on a closed instance (SIGNUP_ENABLED=false, not fresh, multi-org disabled),
+  // a direct POST to Better Auth's native /sign-up/email must be blocked — the hook is the
+  // last line of defense, since the page and the server action both gate correctly.
+  describe("closed-instance policy", () => {
+    beforeEach(() => {
+      constantsOverrides.SIGNUP_ENABLED = false;
+      vi.mocked(getIsFreshInstance).mockResolvedValue(false);
+      vi.mocked(getIsMultiOrgEnabled).mockResolvedValue(false);
+    });
+
+    test("blocks a raw credential sign-up on a closed instance", async () => {
+      vi.mocked(isSignupDomainAllowed).mockReturnValue(false); // raw endpoint, not through the action
+      vi.mocked(isSignupEmailDomainBlocked).mockResolvedValue(false); // self-hosted: domain block is a no-op
+      await expect(
+        before({ id: "u1", email: "intruder@example.com" } as never, { path: "/sign-up/email" } as never)
+      ).rejects.toThrow("Signup is disabled on this instance");
+      expect(gateSsoProvisioning).not.toHaveBeenCalled();
+    });
+
+    test("still allows the first administrator during fresh-instance setup", async () => {
+      vi.mocked(getIsFreshInstance).mockResolvedValue(true);
+      vi.mocked(isSignupDomainAllowed).mockReturnValue(false);
+      vi.mocked(isSignupEmailDomainBlocked).mockResolvedValue(false);
+      const result = await before(
+        { id: "u1", email: "admin@example.com" } as never,
+        { path: "/sign-up/email" } as never
+      );
+      expect(result).toBeUndefined();
+    });
+
+    test("still allows a credential sign-up when public signup is open", async () => {
+      constantsOverrides.SIGNUP_ENABLED = true;
+      vi.mocked(getIsMultiOrgEnabled).mockResolvedValue(true);
+      vi.mocked(isSignupDomainAllowed).mockReturnValue(false);
+      vi.mocked(isSignupEmailDomainBlocked).mockResolvedValue(false);
+      const result = await before(
+        { id: "u1", email: "user@example.com" } as never,
+        { path: "/sign-up/email" } as never
+      );
+      expect(result).toBeUndefined();
+    });
+
+    test("still allows a credential sign-up via the action (domain already enforced)", async () => {
+      vi.mocked(isSignupDomainAllowed).mockReturnValue(true); // action marked the scope
+      const result = await before(
+        { id: "u1", email: "user@example.com" } as never,
+        { path: "/sign-up/email" } as never
+      );
+      expect(result).toBeUndefined();
+    });
   });
 });
 

--- a/apps/web/modules/ee/sso/lib/better-auth-hooks.test.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-hooks.test.ts
@@ -1,7 +1,7 @@
 import { getOAuthState } from "better-auth/api";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { prisma } from "@formbricks/database";
-import { SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE } from "@formbricks/types/errors";
+import { SIGNUP_DISABLED_ERROR_CODE, SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE } from "@formbricks/types/errors";
 import { getIsFreshInstance } from "@/lib/instance/service";
 import { identifyPostHogPerson } from "@/lib/posthog";
 import { findMatchingLocale } from "@/lib/utils/locale";
@@ -34,11 +34,16 @@ vi.mock("better-auth/api", () => ({
   getOAuthState: vi.fn(),
   // Passthrough so the wrapped hook is testable directly as its inner function.
   createAuthMiddleware: (fn: unknown) => fn,
+  // Keeps `body` like the real APIError does, so a test can assert the stable error CODE rather than
+  // the English message — dropping it would leave the message as the only assertable thing, which is
+  // display copy, not the contract callers depend on.
   APIError: class APIError extends Error {
     status: string;
-    constructor(status: string, body?: { message?: string }) {
+    body?: { message?: string; code?: string };
+    constructor(status: string, body?: { message?: string; code?: string }) {
       super(body?.message);
       this.status = status;
+      this.body = body;
     }
   },
 }));
@@ -268,7 +273,9 @@ describe("ssoDatabaseHooks.user.create.before", () => {
       vi.mocked(isSignupEmailDomainBlocked).mockResolvedValue(false); // self-hosted: domain block is a no-op
       await expect(
         before({ id: "u1", email: "intruder@example.com" } as never, { path: "/sign-up/email" } as never)
-      ).rejects.toThrow("Signup is disabled on this instance");
+        // The stable code is the contract callers localize against; the message is display copy, so a
+        // reworded message must not fail this test and a dropped code must.
+      ).rejects.toMatchObject({ status: "FORBIDDEN", body: { code: SIGNUP_DISABLED_ERROR_CODE } });
       expect(gateSsoProvisioning).not.toHaveBeenCalled();
     });
 

--- a/apps/web/modules/ee/sso/lib/better-auth-hooks.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-hooks.ts
@@ -3,14 +3,14 @@ import type { BetterAuthOptions } from "better-auth";
 import { APIError, createAuthMiddleware, getOAuthState } from "better-auth/api";
 import { cookies } from "next/headers";
 import { prisma } from "@formbricks/database";
-import { SIGNUP_DISABLED_ERROR_CODE, SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE } from "@formbricks/types/errors";
+import { SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE } from "@formbricks/types/errors";
 import { normalizeUserName } from "@formbricks/types/user";
 import { WEBAPP_URL } from "@/lib/constants";
 import { identifyPostHogPerson } from "@/lib/posthog";
 import { findMatchingLocale } from "@/lib/utils/locale";
 import { getAttributionPropertiesFromCookies } from "@/modules/auth/lib/attribution";
 import { isSignupEmailDomainBlocked } from "@/modules/auth/lib/signup-email-domain";
-import { isUninvitedSignupAllowed } from "@/modules/auth/lib/signup-policy";
+import { isUninvitedSignupAllowed, signupDisabledError } from "@/modules/auth/lib/signup-policy";
 import { isSignupDomainAllowed } from "@/modules/auth/lib/signup-request-context";
 import { getIsSamlSsoEnabled, getIsSsoEnabled } from "@/modules/ee/license-check/lib/utils";
 import { LINKED_SSO_LOOKUP_SELECT } from "./account-linking";
@@ -82,7 +82,9 @@ export const ssoDatabaseHooks: NonNullable<BetterAuthOptions["databaseHooks"]> =
           // invite exemption) and marks the request scope before calling signUpEmail. If that mark is
           // absent, this is a direct POST to Better Auth's native /sign-up/email — which bypasses the
           // action — so re-enforce the domain block here (no invite is carried on that raw path).
-          if (!isSignupDomainAllowed() && (await isSignupEmailDomainBlocked(user.email, async () => false))) {
+          // One read, two guards: both re-checks below exist only for a request that skipped the action.
+          const wentThroughAction = isSignupDomainAllowed();
+          if (!wentThroughAction && (await isSignupEmailDomainBlocked(user.email, async () => false))) {
             return false;
           }
           // ENG-2293 BACKSTOP: closed-instance policy (SIGNUP_ENABLED / multi-org / fresh-instance).
@@ -95,11 +97,8 @@ export const ssoDatabaseHooks: NonNullable<BetterAuthOptions["databaseHooks"]> =
           // Kept anyway because this hook covers EVERY credential user-creation path, not just the one
           // route the before-hook names: any future Better Auth plugin that creates a user (magic link,
           // email OTP, admin create) lands here, and on a closed instance it should not.
-          if (!isSignupDomainAllowed() && !(await isUninvitedSignupAllowed())) {
-            throw new APIError("FORBIDDEN", {
-              message: "Signup is disabled on this instance.",
-              code: SIGNUP_DISABLED_ERROR_CODE,
-            });
+          if (!wentThroughAction && !(await isUninvitedSignupAllowed())) {
+            throw signupDisabledError();
           }
           return; // otherwise keep credential-signup defaults
         }

--- a/apps/web/modules/ee/sso/lib/better-auth-hooks.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-hooks.ts
@@ -5,13 +5,18 @@ import { cookies } from "next/headers";
 import { prisma } from "@formbricks/database";
 import { SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE } from "@formbricks/types/errors";
 import { normalizeUserName } from "@formbricks/types/user";
-import { WEBAPP_URL } from "@/lib/constants";
+import { SIGNUP_ENABLED, WEBAPP_URL } from "@/lib/constants";
+import { getIsFreshInstance } from "@/lib/instance/service";
 import { identifyPostHogPerson } from "@/lib/posthog";
 import { findMatchingLocale } from "@/lib/utils/locale";
 import { getAttributionPropertiesFromCookies } from "@/modules/auth/lib/attribution";
 import { isSignupEmailDomainBlocked } from "@/modules/auth/lib/signup-email-domain";
 import { isSignupDomainAllowed } from "@/modules/auth/lib/signup-request-context";
-import { getIsSamlSsoEnabled, getIsSsoEnabled } from "@/modules/ee/license-check/lib/utils";
+import {
+  getIsMultiOrgEnabled,
+  getIsSamlSsoEnabled,
+  getIsSsoEnabled,
+} from "@/modules/ee/license-check/lib/utils";
 import { LINKED_SSO_LOOKUP_SELECT } from "./account-linking";
 import { normalizeSsoProvider } from "./provider-normalization";
 import { gateSsoProvisioning, provisionSsoUserMemberships } from "./sso-provisioning";
@@ -83,6 +88,22 @@ export const ssoDatabaseHooks: NonNullable<BetterAuthOptions["databaseHooks"]> =
           // action — so re-enforce the domain block here (no invite is carried on that raw path).
           if (!isSignupDomainAllowed() && (await isSignupEmailDomainBlocked(user.email, async () => false))) {
             return false;
+          }
+          // ENG-2293: the page and server action both enforce closed-instance policy (SIGNUP_ENABLED,
+          // multi-org, fresh-instance), but a direct POST to Better Auth's native /sign-up/email
+          // skips them. Enforce it here as the last line of defense — only when the request is not
+          // already action-scoped (isSignupDomainAllowed) to avoid redundant DB queries.
+          // Freshness is checked first: if the instance is fresh, we allow the first admin setup
+          // and skip the license-DB hit entirely; only check multi-org on non-fresh instances.
+          // Throwing APIError is Better Auth's documented pattern for signup gating — it surfaces a
+          // proper error code to the caller rather than the generic FAILED_TO_CREATE_USER that
+          // returning false produces.
+          if (!isSignupDomainAllowed()) {
+            if (!(await getIsFreshInstance()) && !(SIGNUP_ENABLED && (await getIsMultiOrgEnabled()))) {
+              throw new APIError("FORBIDDEN", {
+                message: "Signup is disabled on this instance.",
+              });
+            }
           }
           return; // otherwise keep credential-signup defaults
         }

--- a/apps/web/modules/ee/sso/lib/better-auth-hooks.ts
+++ b/apps/web/modules/ee/sso/lib/better-auth-hooks.ts
@@ -3,20 +3,16 @@ import type { BetterAuthOptions } from "better-auth";
 import { APIError, createAuthMiddleware, getOAuthState } from "better-auth/api";
 import { cookies } from "next/headers";
 import { prisma } from "@formbricks/database";
-import { SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE } from "@formbricks/types/errors";
+import { SIGNUP_DISABLED_ERROR_CODE, SIGNUP_EMAIL_DOMAIN_BLOCKED_ERROR_CODE } from "@formbricks/types/errors";
 import { normalizeUserName } from "@formbricks/types/user";
-import { SIGNUP_ENABLED, WEBAPP_URL } from "@/lib/constants";
-import { getIsFreshInstance } from "@/lib/instance/service";
+import { WEBAPP_URL } from "@/lib/constants";
 import { identifyPostHogPerson } from "@/lib/posthog";
 import { findMatchingLocale } from "@/lib/utils/locale";
 import { getAttributionPropertiesFromCookies } from "@/modules/auth/lib/attribution";
 import { isSignupEmailDomainBlocked } from "@/modules/auth/lib/signup-email-domain";
+import { isUninvitedSignupAllowed } from "@/modules/auth/lib/signup-policy";
 import { isSignupDomainAllowed } from "@/modules/auth/lib/signup-request-context";
-import {
-  getIsMultiOrgEnabled,
-  getIsSamlSsoEnabled,
-  getIsSsoEnabled,
-} from "@/modules/ee/license-check/lib/utils";
+import { getIsSamlSsoEnabled, getIsSsoEnabled } from "@/modules/ee/license-check/lib/utils";
 import { LINKED_SSO_LOOKUP_SELECT } from "./account-linking";
 import { normalizeSsoProvider } from "./provider-normalization";
 import { gateSsoProvisioning, provisionSsoUserMemberships } from "./sso-provisioning";
@@ -89,21 +85,21 @@ export const ssoDatabaseHooks: NonNullable<BetterAuthOptions["databaseHooks"]> =
           if (!isSignupDomainAllowed() && (await isSignupEmailDomainBlocked(user.email, async () => false))) {
             return false;
           }
-          // ENG-2293: the page and server action both enforce closed-instance policy (SIGNUP_ENABLED,
-          // multi-org, fresh-instance), but a direct POST to Better Auth's native /sign-up/email
-          // skips them. Enforce it here as the last line of defense — only when the request is not
-          // already action-scoped (isSignupDomainAllowed) to avoid redundant DB queries.
-          // Freshness is checked first: if the instance is fresh, we allow the first admin setup
-          // and skip the license-DB hit entirely; only check multi-org on non-fresh instances.
-          // Throwing APIError is Better Auth's documented pattern for signup gating — it surfaces a
-          // proper error code to the caller rather than the generic FAILED_TO_CREATE_USER that
-          // returning false produces.
-          if (!isSignupDomainAllowed()) {
-            if (!(await getIsFreshInstance()) && !(SIGNUP_ENABLED && (await getIsMultiOrgEnabled()))) {
-              throw new APIError("FORBIDDEN", {
-                message: "Signup is disabled on this instance.",
-              });
-            }
+          // ENG-2293 BACKSTOP: closed-instance policy (SIGNUP_ENABLED / multi-org / fresh-instance).
+          // The primary gate is `signupPolicyBeforeHandler` in auth.ts's `hooks.before`, which rejects
+          // `POST /sign-up/email` before Better Auth looks the address up — deliberately NOT here,
+          // because this hook only ever runs for an address that does not yet exist (the duplicate
+          // branch returns a synthetic 200 without creating anything), so rejecting here and nowhere
+          // else would answer "does this address have an account?". See signup-policy.ts.
+          //
+          // Kept anyway because this hook covers EVERY credential user-creation path, not just the one
+          // route the before-hook names: any future Better Auth plugin that creates a user (magic link,
+          // email OTP, admin create) lands here, and on a closed instance it should not.
+          if (!isSignupDomainAllowed() && !(await isUninvitedSignupAllowed())) {
+            throw new APIError("FORBIDDEN", {
+              message: "Signup is disabled on this instance.",
+              code: SIGNUP_DISABLED_ERROR_CODE,
+            });
           }
           return; // otherwise keep credential-signup defaults
         }


### PR DESCRIPTION
## What & why

Better Auth serves its own `POST /api/auth/sign-up/email` beside ours — `app/api/auth/[...all]/route.ts` mounts `auth.handler` raw — but the closed-instance policy (`SIGNUP_ENABLED`, multi-org, fresh-instance) lived only in `createUserAction`. An unauthenticated POST therefore walked around every gate and created an account on an invite-only instance. ENG-2073 fixed the server action and left the framework-mounted route open; this closes it.

The policy runs as a Better Auth `hooks.before` middleware on `/sign-up/email` (`modules/auth/lib/signup-policy.ts`), with the `user.create.before` database hook keeping the same check as a backstop for any other credential user-creation path. The predicate itself now lives in one place and is shared with `createUserAction`, because writing it out twice is what produced this ticket after ENG-2073.

Both legitimate exceptions are preserved: the initial administrator on a fresh instance (no invite exists to present yet), and any sign-up routed through `createUserAction`, which applies the full policy — including the invite exemption the hook cannot see — and marks the request scope before calling `auth.api.signUpEmail`.

**Why `hooks.before` and not just the database hook.** `sign-up.mjs` looks the address up *before* it creates anything, and answers an address that already has an account with a synthetic 200 — no row written, so no create hook runs for it. A gate reachable only for addresses that do *not* exist answers a question it shouldn't:

| Address, on a closed instance | Gate in the create hook | Gate in `hooks.before` |
|---|---|---|
| Not registered | 403 | 403 |
| Already registered | **200** (synthetic) | 403 |

That 200/403 split is an unauthenticated account-existence oracle. `autoSignIn: false` makes the duplicate branch unconditional and `auth.ts` calls it "enumeration-safe", so gating in the create hook would have spent a property ENG-2091/ENG-2099 protect. Running before the endpoint answers every request identically. Same slot and reasoning as `hibpBreachCheckBeforeHandler`, ordered ahead of it so a rejected sign-up costs no outbound HIBP call.

## Linear ticket

Fixes ENG-2293

## How this was tested

- **`signup-closed-instance.integration.test.ts`** (new, 3 tests) — drives `auth.handler` with a real `Request` against real Postgres, as the mounted route does. Asserts the first administrator is admitted while the instance is fresh; an uninvited sign-up afterwards gets 403 with nothing written; and a registered vs an unregistered address get identical status **and** identical body. `auth.api.signUpEmail` would not do: an `APIError` from a `before` hook reaches an `auth.api` caller as a rejected promise, and only the HTTP layer produces the 403 an attacker sees.
- **`signup-policy.test.ts`** (new, 11 tests) — path filtering, the action-scope exemption, both exceptions, and the two short-circuits that stop an unauthenticated request from triggering `count(*)` on `User`.
- `better-auth-hooks.test.ts` — 49 pass (45 pre-existing + 4 for the backstop).
- Full unit sweep of `modules/auth` + `modules/ee/sso` after the rebase onto current `main`: **512 pass, 47 files**. Whole-app sweep before the rebase: **7795 pass, 599 files**.
- Full integration suite before the rebase: **81 pass, 22 files**.
- `eslint`, `prettier --check`, `tsc --noEmit` clean on every touched file.
- **The oracle test is not vacuous:** commenting out `await signupPolicyBeforeHandler(ctx)` fails it with `AssertionError: expected 200 to be 403`, while the other two still pass — which is why the leak was easy to miss.
- **Bypass probe (throwaway, not committed):** seven spellings of the route against the real handler — trailing slash, uppercase, double slash, `%2F`, `/./`, query string. Each either hit the gate (403) or failed to route (404); none created a user.
- **Review follow-ups** (`29a1df23b`, `b33b8c8b0`): the closed-instance hook test now asserts the stable `signup_disabled` code instead of the English message — which needed this file's `better-auth/api` mock to stop discarding `APIError.body`, the reason the weaker assertion existed. Both layers that raise the rejection now throw one shared `signupDisabledError()`, since the response is all an unauthenticated caller sees and the two must stay byte-identical.
- **CI green on this head:** 18 checks passed, 0 failed — including `Run Unit Tests`, `Better Auth integration tests`, `Run E2E Tests`, Typecheck, Linters, CodeQL and SonarQube.
- **Not re-run locally after the rebase:** the integration suite. The only Postgres on :5432 now belongs to another worktree's stack and carries a different branch's schema, so a local run would have proved nothing about this one. CI's `Better Auth integration tests` job provisions its own DB from this PR's schema and is the check that matters — it was green pre-rebase and runs again here.

## Breaking changes

None

## QA / Test Plan

**How to test**

Requires a self-hosted instance (Cloud has public sign-up open, so the gate is inert there). "Closed" below means the default self-hosted configuration: `SIGNUP_ENABLED` is derived, not an env var, and is always false outside Cloud/dev/E2E.

- [ ] On a **brand-new** instance with zero users, `POST /api/auth/sign-up/email` with `{"email","password","name"}` → **200**, account created. The fresh-instance exception must survive; `/setup/intro` in the browser must still complete normally.
- [ ] With at least one user now existing, repeat the same POST with a **new** address → **403**, body contains `"code":"signup_disabled"`, and no account is created (confirm the address cannot then log in).
- [ ] Repeat with an address that **already has an account** → **403**, byte-identical response to the previous step. A 200 here is the bug: it would let anyone test which addresses are registered.
- [ ] Sign-up form at `/auth/signup` with a **valid invite** → still succeeds end to end (invite accepted, membership created). This is the path the gate must not touch.
- [ ] `/auth/signup` without an invite on the closed instance → still shows the existing "sign-up disabled" refusal, unchanged.
- [ ] Log in, request a password reset, and set a new password → unaffected (a second gate shares this hook slot; confirm they coexist).
- [ ] On Cloud/dev (public sign-up open), ordinary sign-up and the raw endpoint both still return 200 — the gate must be inert.

**Preconditions / test data**

- A self-hosted deployment you can reset to zero users (the fresh-instance step needs an empty `User` table).
- An HTTP client for the raw endpoint (curl/Postman) — this cannot be tested from the UI alone, which is the entire point of the ticket.
- One pending invite for the invite step. Multi-org (enterprise licence) off for the closed-instance steps; on, plus public sign-up, for the inert-on-Cloud step.

**Risks & regressions**

- Anything that creates users outside the sign-up form: SSO sign-in/JIT provisioning (must be unaffected — separate branch in the same hook), invited sign-ups, and E2E (sets `E2E_TESTING=1`, so sign-up is open and the gate is inert).
- `hooks.before` now holds two policy gates (this and ENG-2105's password-reset gate, merged the same day). They fire on disjoint paths, but re-check that a password reset and a sign-up both behave on the same instance.
- `signup-duplicate-email.integration.test.ts` now declares an open instance: it drives the raw path unscoped, which the gate rightly rejects on a closed one. The Better Auth contract it pins is reached in production through `createUserAction`, which is exempt.
- The database-hook backstop is unreachable via `/sign-up/email` now that the before-hook fires first; it exists for future user-creating plugins (magic link, email OTP, admin create) and is covered by unit tests only.

**Migrations / env / cutover**

- none — no schema change, no new or renamed env var, no config change. `SIGNUP_ENABLED` is a derived constant and is not operator-settable.

## Known adjacent issues (pre-existing, not introduced here)

1. **SSO provisioning ignores the closed-signup policy** (ENG-2344) — `gateSsoProvisioning` never checks `SIGNUP_ENABLED`, and its multi-org early return makes the invite requirement below it unreachable. It is the third writer of this policy, which is why the predicate was extracted here rather than copied again.
2. **TOCTOU race on fresh-instance detection** (ENG-2247) — `getIsFreshInstance` uses React `cache()`, so two concurrent sign-ups can both see `userCount === 0`. Unchanged here: the fresh-instance exception is deliberate and this gate consults the same primitive.
3. **User-creation audit gap** (ENG-2347) — `withAuditLogging("created", "user")` wraps only the server action, so native and SSO sign-ups write no `created` event, and a rejected sign-up emits no log line at all.
4. **Hook-slot convergence** (ENG-2402) — the four `hooks.before` gates are written three different ways, and ENG-2105's rejection carries no stable error code.

## Scope note

The ticket's worst case — "attacker owns the instance's first organization before the real admin completes setup" — is **not** closed by this PR, and cannot be by a sign-up gate: a fresh instance is open to its first user by design, via this route or the sign-up page. What this fixes is account creation on an instance *past* that window and closed. The residual fresh-instance exposure is ENG-2247.

The ticket also suggests recovering commit `129c79bc5` rather than rewriting. That commit carries no hook-level gate — its closed-sign-up work is the action-level fix, ENG-2073, already on `main` — so there was nothing to recover for this layer.
