### PR TITLE
docs: add Collect Google Reviews best practice

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -212,7 +212,8 @@
               "surveys/best-practices/pmf-survey",
               "surveys/best-practices/quiz-time",
               "surveys/best-practices/improve-trial-cr",
-              "surveys/best-practices/research-panel"
+              "surveys/best-practices/research-panel",
+              "surveys/best-practices/google-reviews"
             ]
           }
         ],

--- a/docs/surveys/best-practices/google-reviews.mdx
+++ b/docs/surveys/best-practices/google-reviews.mdx
@@ -1,0 +1,80 @@
+---
+title: "Collect Google Reviews"
+description: "A step-by-step guide to asking for feedback and turning it into public Google reviews with Formbricks."
+icon: "star"
+---
+
+Google reviews are the first thing a potential customer sees about your business. The hard part is not writing them, it is asking at the right moment — and making the ask a single click.
+
+## Purpose
+
+Most happy customers would leave a review, they just never get around to it. A short survey right after a good experience catches them while the goodwill is fresh, gives you private feedback either way, and hands the review link to the people who want to share it publicly.
+
+## Formbricks Approach
+
+- Ask one question, not ten. The survey is the ask, not the review.
+- Give everyone the review link — never only the happy ones (see the note below).
+- Keep the private feedback, so a bad experience still reaches you instead of Google.
+
+<Note>
+  Google's [prohibited content policy](https://support.google.com/contributionpolicy/answer/7400114) forbids "review gating": selectively soliciting positive reviews or discouraging negative ones. So do not use a rating question to decide **who** gets the review link. Use it to decide **what you say** while offering the link to everyone.
+</Note>
+
+## Setup
+
+To collect Google reviews with Formbricks you need to:
+
+1. Get your Google review link
+2. Build a short survey
+3. Add the review link to the ending card
+4. Share the survey at the right moment
+
+### 1. Get your Google review link
+
+In your [Google Business Profile](https://business.google.com/), open **Read reviews** and choose **Get more reviews**. Google gives you a short link in the form:
+
+```
+https://g.page/r/<your-place-id>/review
+```
+
+Opening that link takes a signed-in user straight to the review dialog for your business. Copy it — you will paste it into Formbricks in step 3.
+
+### 2. Build a short survey
+
+Create a survey and keep it to one or two questions:
+
+- A [Rating](/surveys/question-type/rating) question, for example "How was your experience with us?" — smileys or stars, 5-point scale.
+- An optional [Free Text](/surveys/question-type/free-text) question for anything they want to add.
+
+This gives you the private signal. The review itself happens on Google, not in Formbricks.
+
+### 3. Add the review link to the ending card
+
+Open the [Thank You card](/surveys/question-type/thank-you-card) at the bottom of the editor, turn on **Show Button** and fill in:
+
+- **Button Label**: `Leave a Google review`
+- **Button URL**: the link from step 1
+
+Every respondent now sees the review button after submitting.
+
+To tailor the wording without gating the link, add a second ending with **Add ending** and route between them with [Conditional Logic](/surveys/general-features/conditional-logic) — for example "Glad we got it right! Mind sharing that on Google?" for high ratings and "Thanks for telling us — we'll fix this. If you'd like to leave a public review, here's the link" for low ones. Both endings keep the same button.
+
+<Note>
+  On Formbricks Cloud, custom external URLs in the Button URL field require a paid plan. This helps us prevent phishing. Self-hosted instances have no such restriction.
+</Note>
+
+### 4. Share the survey at the right moment
+
+Timing matters more than copy. Send the survey when the experience just happened:
+
+- **[Link survey](/surveys/link-surveys/quickstart)** in a post-purchase or post-visit email or SMS.
+- **QR code** — download it from the survey summary and print it on the receipt, the table tent, or the packaging.
+- **[Website or app survey](/surveys/website-app-surveys/quickstart)** triggered after a successful action, such as a completed order.
+
+<Note>
+  Responses collected via QR code are anonymous, which is exactly what you want for a walk-in or in-store ask.
+</Note>
+
+## Follow up on what you learn
+
+The reviews are only half the value. Use [Email Follow-ups](/surveys/general-features/email-followups) to alert your team whenever someone submits a low rating, so you can reach out before the experience turns into a public review you did not want.

--- a/docs/surveys/best-practices/google-reviews.mdx
+++ b/docs/surveys/best-practices/google-reviews.mdx
@@ -57,10 +57,14 @@ Open the [Thank You card](/surveys/question-type/thank-you-card) at the bottom o
 
 Every respondent now sees the review button after submitting.
 
-To tailor the wording without gating the link, add a second ending with **Add ending** and route between them with [Conditional Logic](/surveys/general-features/conditional-logic) — for example "Glad we got it right! Mind sharing that on Google?" for high ratings and "Thanks for telling us — we'll fix this. If you'd like to leave a public review, here's the link" for low ones. Both endings keep the same button.
-
 <Note>
   On Formbricks Cloud, custom external URLs in the Button URL field require a paid plan. This helps us prevent phishing. Self-hosted instances have no such restriction.
+</Note>
+
+To tailor the wording without gating the link, give low ratings their own ending. Duplicate the ending you just configured with the copy icon in its header — that carries the button label and URL over — then change the copy on the duplicate and route between the two with [Conditional Logic](/surveys/general-features/conditional-logic). For example "Glad we got it right! Mind sharing that on Google?" for high ratings and "Thanks for telling us — we'll fix this. If you'd like to leave a public review, here's the link" for low ones. Both endings keep the review button.
+
+<Note>
+  Duplicate rather than **Add ending**: a new ending starts with the Formbricks default button (`Create your own Survey`, pointing at formbricks.com), so you would have to enter the review link again — and if you miss it, low-rating respondents lose the link your anti-gating setup depends on.
 </Note>
 
 ### 4. Share the survey at the right moment
@@ -77,4 +81,14 @@ Timing matters more than copy. Send the survey when the experience just happened
 
 ## Follow up on what you learn
 
-The reviews are only half the value. Use [Email Follow-ups](/surveys/general-features/email-followups) to alert your team whenever someone submits a low rating, so you can reach out before the experience turns into a public review you did not want.
+The reviews are only half the value. Build a [Workflow](/workflows/overview) that alerts your team whenever someone has a bad experience, so you can reach out before it turns into a public review you did not want.
+
+The second ending from step 3 is what makes this work: a workflow filters on the ending card the respondent reached, not on the rating itself. So the low-rating ending is your signal.
+
+1. Create a workflow with the **Response completed** trigger and select your review survey.
+2. Under **Ending cards**, choose **Specific endings** and pick the ending you route low ratings to.
+3. Add the **Send email** action and pick the workspace member who owns follow-ups as the recipient. Type `@` in the body to recall the rating and the comment, or turn on **Attach response data** to send the whole response.
+
+<Note>
+  Workflows are part of the Formbricks [Enterprise Edition](/self-hosting/advanced/license).
+</Note>


### PR DESCRIPTION
## What & why

"How do I get people to leave a Google review?" is a support question with no docs answer, even though Formbricks already has every piece needed: a rating question, an ending card with a CTA button, conditional logic, QR codes and Workflows. Nothing tied them together.

Adds `docs/surveys/best-practices/google-reviews.mdx` and registers it in the Best Practices nav. It walks through: getting the review link from the Google Business Profile, a one-or-two-question survey, putting the link behind **Show Button** on the ending card, where to share the survey (post-purchase email/SMS, printed QR code, in-app trigger), and finally a Workflow that emails the team whenever someone reaches the low-rating ending.

One deliberate call worth reviewing: the page **tells readers not to gate the review link behind a good rating**. The obvious design — high rating → Google, low rating → private form — is review gating, which Google's [prohibited content policy](https://support.google.com/contributionpolicy/answer/7400114) forbids, and we should not be on record recommending it. The page instead uses the rating to change the wording across two endings while both keep the same review button. Happy to revisit the framing if we read the policy differently.

> ⚠️ **Merge after #8822.** This page links to `/surveys/question-type/thank-you-card`, which #8822 adds. Merging this one first leaves that link 404ing until the other lands.

### Updates since the first review

- **Alerting uses Workflows, not Email Follow-ups** — Follow-ups are being deprecated, so the last section now builds a workflow: `Response completed` trigger on the review survey → **Specific endings** filter on the low-rating ending → **Send email** action to a workspace member, with recall or `Attach response data` for the rating and comment. Because a workflow filters by ending card and not by answer, the two-ending setup from step 3 is what makes the alert possible — the page now says so explicitly. Carries the Enterprise Edition note, matching `docs/workflows/overview.mdx`.
- **Fixed the second-ending step** (Claude's inline finding, confirmed): the page said to create the second ending with **Add ending**, then claimed "both endings keep the same button." `getDefaultEndingCard` (`apps/web/app/lib/survey-builder.ts:79`) gives a new ending the default `Create your own Survey` / `https://formbricks.com` button, so a reader following it literally would ship a low-rating ending without the review link — breaking exactly the anti-gating design the page prescribes. It now says to duplicate the configured ending with the copy icon in its header (`duplicateEndingCard` spreads `buttonLabel`/`buttonLink`), with a note on why not **Add ending**.

## Linear ticket

No ticket — docs-only change requested directly.

## How this was tested

- Verified against the product rather than written from memory: the ending card's **Show Button** → **Button Label** / **Button URL** fields (`apps/web/modules/survey/editor/components/end-screen-form.tsx`), duplicate-vs-add-ending behavior (`duplicateEndingCard` in `edit-ending-card.tsx:169` vs `getDefaultEndingCard` in `apps/web/app/lib/survey-builder.ts:79`), the Cloud paid-plan gate on external URLs (`getExternalUrlsPermission` in `apps/web/modules/survey/lib/permission.ts`), and the QR-code anonymity wording, taken from the product string `qr_code_description` in `apps/web/locales/en-US.json`.
- The workflow steps were checked against `docs/workflows/overview.mdx` and `docs/workflows/build.mdx`: `Response completed` is the only trigger, the ending-card filter with its **All endings** / **Specific endings** scopes is the only condition, **Send email** is the only action, a workspace member is a valid **Send to** target, and `@` recall plus **Attach response data** are both real options. The Enterprise note matches the one on the Workflows overview.
- Every internal link target exists in `docs/`: rating, free-text, thank-you-card (from #8822), conditional-logic, workflows/overview, self-hosting/advanced/license, link-surveys/quickstart, website-app-surveys/quickstart.
- `npx prettier --check docs/docs.json` ✅. `docs.json` parses as valid JSON after the nav edit. `.mdx` is in `.prettierignore` by design.
- Mintlify preview built green on the first revision; re-checking after this push.
- Not run: `pnpm test` / `pnpm lint` — no application code is touched by this PR.
- No screenshots: the page is instructional prose and links to #8822 for the ending-card screenshots rather than duplicating them.

## Breaking changes

None — docs only.

## QA / Test Plan

**How to test**

- [ ] Open the docs site → Surveys (Ask) → Best Practices → **Collect Google Reviews** appears at the end of the list and renders with a star icon.
- [ ] All four `<Note>` callouts render as callouts, and the fenced `https://g.page/r/<your-place-id>/review` block renders as a code block.
- [ ] Every internal link resolves (Rating, Free Text, Thank You card, Conditional Logic, Workflows, Enterprise Edition license, Link survey quickstart, Website/app quickstart) — the Thank You card link requires #8822 to be merged.
- [ ] The external links open the right pages: Google's prohibited content policy and business.google.com.
- [ ] Walk the guide end to end in the product: create a survey with a Rating question, open the ending card, toggle **Show Button**, set a label and a `https://g.page/r/.../review` URL, publish as a link survey, submit a response → the button appears on the last screen and opens the URL.
- [ ] Duplicate that ending with the copy icon in the card header → the copy already carries your review label and URL (the page's core claim). For contrast, click **Add ending** → the new ending instead shows `Create your own Survey` / `https://formbricks.com`.
- [ ] Route low ratings to the duplicated ending with conditional logic → a low rating lands there, and the review button is still present on both endings.
- [ ] Build the alert workflow: `Response completed` on that survey → **Ending cards** → **Specific endings** → the low-rating ending → **Send email** to a workspace member → enable it. Submit a low-rating response → the run appears with a successful status and the email arrives. Submit a high-rating response → no run is triggered.

**Preconditions / test data**

- A workspace where you can publish a link survey.
- Workflows are Enterprise Edition — an active license (or Cloud plan that includes it) is needed for the last step. Self-hosted also needs the Redis-backed Job Runner and SMTP configured, per `docs/self-hosting/configuration/job-runner`.
- On Formbricks Cloud, a paid plan is needed to save a custom external Button URL; self-hosted has no restriction. Worth confirming the free-plan wording matches what a free Cloud org actually sees.

**Risks & regressions**

- Docs-only; no runtime behavior changes. Two things could go stale: Google's review-link format (`https://g.page/r/<place-id>/review`) and the Google Business Profile navigation path ("Read reviews" → "Get more reviews"), both owned by Google.
- The workflow section describes today's single trigger/condition/action set. When branching, webhooks or user-authored conditions ship, this section should be revisited.

**Migrations / env / cutover**

- none