### PR TITLE
fix(security): bind MCP access-token audience to this resource server

### DIFF
--- a/apps/web/app/api/mcp/route.test.ts
+++ b/apps/web/app/api/mcp/route.test.ts
@@ -58,6 +58,10 @@ const { MCP_CHALLENGE_SCOPE } = await import("@/modules/auth/lib/oauth-urls");
 // The auth-params are comma-separated per RFC 9110 §11.6.1 (#8718): asserting the whole string is what
 // keeps the separator from regressing, since a strict client parser needs it to read `resource_metadata`.
 // The scope list interpolates the real constant, so this stays honest as the advertised scopes change.
+// Real tokens always carry `aud`; the resource server rejects any token not minted for it, so the
+// fixtures have to look like something the authorization server would actually issue.
+const MCP_AUDIENCE = "http://localhost/api/mcp";
+
 const EXPECTED_CHALLENGE = `Bearer resource_metadata="http://localhost/.well-known/oauth-protected-resource/api/mcp", scope="${MCP_CHALLENGE_SCOPE}"`;
 
 vi.mock("@/modules/api/lib/api-key-auth", () => ({
@@ -144,6 +148,7 @@ describe("POST /api/mcp", () => {
     vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
     userFindUniqueMock.mockResolvedValue({ isActive: true });
     verifyAccessTokenMock.mockResolvedValue({
+      aud: MCP_AUDIENCE,
       sub: "user_1",
       email: "person@example.com",
       name: "Person",
@@ -449,6 +454,7 @@ describe("POST /api/mcp", () => {
 
   test("blocks write tools for read-only OAuth tokens", async () => {
     verifyAccessTokenMock.mockResolvedValueOnce({
+      aud: MCP_AUDIENCE,
       sub: "user_1",
       email: "person@example.com",
       scope: "openid profile email surveys:read",
@@ -494,6 +500,7 @@ describe("POST /api/mcp", () => {
     // A write-capable user whose OAuth token was only granted read scopes (surveys:read + workflows:read)
     // must not be able to reach a workflow mutation — the ENG-1967 token-scope boundary.
     verifyAccessTokenMock.mockResolvedValueOnce({
+      aud: MCP_AUDIENCE,
       sub: "user_1",
       email: "person@example.com",
       scope: "openid profile email surveys:read workflows:read",

--- a/apps/web/modules/auth/lib/mcp-oauth-provider-options.test.ts
+++ b/apps/web/modules/auth/lib/mcp-oauth-provider-options.test.ts
@@ -26,6 +26,9 @@ vi.mock("@/lib/env", () => ({
  * one) in modules/mcp/auth.ts, which is required by RFC 9068 §4 no matter how the provider behaves.
  */
 describe("getMcpOauthProviderOptions", () => {
+  // Also pinned in mcp-oauth-dcr.test.ts (#8828). The duplication is deliberate: this is the
+  // invariant the whole GHSA-p2fr-6hmx-4528 acceptance rests on, and the two suites can be deleted
+  // or rewritten independently. Do not "de-duplicate" this away.
   test("grants exactly one audience, so no token can be minted for a second resource server", () => {
     const { validAudiences } = getMcpOauthProviderOptions();
 

--- a/apps/web/modules/auth/lib/mcp-oauth-provider-options.test.ts
+++ b/apps/web/modules/auth/lib/mcp-oauth-provider-options.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, vi } from "vitest";
+import { getMcpOauthProviderOptions } from "./mcp-oauth-provider-options";
+import { MCP_OAUTH_SCOPES, getMcpResourceUrl } from "./oauth-urls";
+
+// Env-dependent URL getters resolve from here; scope constants stay real so these assertions cannot
+// be satisfied by a fixture agreeing with itself.
+vi.mock("@/lib/env", () => ({
+  env: {
+    WEBAPP_URL: "http://localhost:3000",
+    BETTER_AUTH_URL: undefined,
+    NEXTAUTH_URL: undefined,
+    PUBLIC_URL: undefined,
+  },
+}));
+
+/**
+ * `validAudiences` is the single mitigation standing between this deployment and
+ * GHSA-p2fr-6hmx-4528, and until now nothing asserted it.
+ *
+ * The provider does not bind an access token's `aud` to the resource approved at authorization: it
+ * stamps the token with the whole `validAudiences` allow-list. With one entry there is no second
+ * audience to escalate into, so the advisory cannot bite here. Add a second entry and it can —
+ * silently, with every existing test still green. That is what this suite exists to stop.
+ *
+ * The resource server enforces the other half (rejecting a token that names an audience beyond this
+ * one) in modules/mcp/auth.ts, which is required by RFC 9068 §4 no matter how the provider behaves.
+ */
+describe("getMcpOauthProviderOptions", () => {
+  test("grants exactly one audience, so no token can be minted for a second resource server", () => {
+    const { validAudiences } = getMcpOauthProviderOptions();
+
+    expect(validAudiences).toEqual([getMcpResourceUrl()]);
+  });
+
+  test("advertises only scopes it is willing to grant", () => {
+    const options = getMcpOauthProviderOptions();
+
+    // Registration defaults must stay within the advertised set, or a DCR client is handed a scope
+    // /authorize will then refuse.
+    expect(options.scopes).toEqual([...MCP_OAUTH_SCOPES]);
+    expect(options.clientRegistrationDefaultScopes).toEqual([...MCP_OAUTH_SCOPES]);
+    expect(options.advertisedMetadata?.scopes_supported).toEqual([...MCP_OAUTH_SCOPES]);
+  });
+
+  test("expires every write scope early, derived from the scope list rather than hand-listed", () => {
+    const { scopeExpirations } = getMcpOauthProviderOptions();
+
+    const writeScopes = MCP_OAUTH_SCOPES.filter((scope) => scope.endsWith(":write"));
+    expect(writeScopes.length).toBeGreaterThan(0);
+    expect(scopeExpirations).toEqual(Object.fromEntries(writeScopes.map((scope) => [scope, "15m"])));
+  });
+});

--- a/apps/web/modules/auth/lib/oauth-urls.test.ts
+++ b/apps/web/modules/auth/lib/oauth-urls.test.ts
@@ -73,4 +73,17 @@ describe("OAuth URL helpers", () => {
 
     expect(getAuthIssuerUrl()).toBe("https://admin.example.com/app/api/auth");
   });
+
+  // The MCP resource server allow-lists this exact string as the second permitted `aud` value, so
+  // a drift here would reject every token carrying the openid-implied UserInfo audience. Pinned
+  // against the issuer (not WEBAPP_URL) because that is the prefix the oauth-provider mounts under.
+  test("derives the UserInfo audience from the auth issuer, subpath included", async () => {
+    envMock.WEBAPP_URL = "https://admin.example.com";
+    envMock.BETTER_AUTH_URL = "https://auth.example.com/custom";
+
+    const { getAuthIssuerUrl, getOAuthUserInfoUrl } = await loadOAuthUrls();
+
+    expect(getOAuthUserInfoUrl()).toBe("https://auth.example.com/custom/api/auth/oauth2/userinfo");
+    expect(getOAuthUserInfoUrl()).toBe(`${getAuthIssuerUrl()}/oauth2/userinfo`);
+  });
 });

--- a/apps/web/modules/auth/lib/oauth-urls.ts
+++ b/apps/web/modules/auth/lib/oauth-urls.ts
@@ -52,6 +52,13 @@ export const getMcpOrigin = (): string => new URL(getMcpResourceUrl()).origin;
  *
  * Built off the issuer for the same reason `jwksUrl` is: Better Auth mounts its OAuth endpoints
  * under the auth base path, so the issuer is the prefix the plugin itself uses.
+ *
+ * The assumption is that this equals Better Auth's own `ctx.context.baseURL`, which is what it
+ * stamps into the audience. That holds while the configured auth URL is a bare origin — Better
+ * Auth's `withPath` appends `/api/auth` exactly as `getAuthIssuerUrl` does. It does NOT hold if
+ * `BETTER_AUTH_URL` carries a subpath, because `withPath` returns a URL that already has a path
+ * unchanged while we still append. Subpath deployments cannot complete a login at all today
+ * (ENG-606), so this is not a live gap — but it is the thing to fix here when that one is fixed.
  */
 export const getOAuthUserInfoUrl = (): string => `${getAuthIssuerUrl()}/oauth2/userinfo`;
 

--- a/apps/web/modules/auth/lib/oauth-urls.ts
+++ b/apps/web/modules/auth/lib/oauth-urls.ts
@@ -40,6 +40,21 @@ export const getMcpProtectedResourceMetadataUrl = (): string =>
 
 export const getMcpOrigin = (): string => new URL(getMcpResourceUrl()).origin;
 
+/**
+ * The authorization server's own UserInfo endpoint, which is a legitimate second value in an access
+ * token's `aud`.
+ *
+ * The oauth-provider treats UserInfo as an implicit resource: when `openid` is in scope it appends
+ * this identifier to the audience alongside the resource the client actually requested. It is the
+ * only audience besides the MCP resource URL that a Formbricks-issued MCP token may carry, so the
+ * resource server allow-lists exactly these two and rejects anything else (see
+ * `hasAcceptedMcpAudience` in modules/mcp/auth.ts).
+ *
+ * Built off the issuer for the same reason `jwksUrl` is: Better Auth mounts its OAuth endpoints
+ * under the auth base path, so the issuer is the prefix the plugin itself uses.
+ */
+export const getOAuthUserInfoUrl = (): string => `${getAuthIssuerUrl()}/oauth2/userinfo`;
+
 export const MCP_OAUTH_SCOPES = [
   "openid",
   "profile",

--- a/apps/web/modules/mcp/auth.test.ts
+++ b/apps/web/modules/mcp/auth.test.ts
@@ -1,3 +1,4 @@
+import { SignJWT, generateKeyPair, jwtVerify } from "jose";
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ApiKeyPermission } from "@formbricks/database/prisma";
@@ -56,6 +57,7 @@ vi.mock("@/modules/auth/lib/oauth-urls", async (importOriginal) => ({
     () => "https://app.example.com/.well-known/oauth-protected-resource/api/mcp"
   ),
   getMcpResourceUrl: vi.fn(() => "https://app.example.com/api/mcp"),
+  getOAuthUserInfoUrl: vi.fn(() => "https://app.example.com/api/auth/oauth2/userinfo"),
 }));
 
 vi.mock("@formbricks/logger", () => ({
@@ -76,6 +78,15 @@ const { MCP_CHALLENGE_SCOPE } = await import("@/modules/auth/lib/oauth-urls");
 // have to be rewritten every time the advertised scope list changes; the exact value is pinned once, from
 // the real constant, in app/api/mcp/route.test.ts.
 const CHALLENGE_GRAMMAR = /^Bearer resource_metadata="[^"]+", scope="[^"]+"$/;
+
+// Every mocked payload below carries `aud`, because every real token does — the authorization server
+// always stamps the resource a token was minted for. A fixture without it would sail past the
+// audience binding that production tokens have to satisfy, and the suite would be asserting against a
+// token shape that cannot exist.
+const MCP_AUDIENCE = "https://app.example.com/api/mcp";
+// The AS's own UserInfo endpoint, which it adds to `aud` as an implicit second resource whenever
+// `openid` is in scope. Derived from the mocked issuer above.
+const USERINFO_AUDIENCE = "https://app.example.com/api/auth/oauth2/userinfo";
 
 const apiKeyAuth = {
   type: "apiKey" as const,
@@ -278,6 +289,7 @@ describe("authenticateMcpRequest", () => {
 
   test("authenticates OAuth bearer tokens and rate limits by user and client", async () => {
     verifyAccessTokenMock.mockResolvedValue({
+      aud: MCP_AUDIENCE,
       sub: "user_1",
       email: "user@example.com",
       name: "Test User",
@@ -326,6 +338,7 @@ describe("authenticateMcpRequest", () => {
 
   test("rejects OAuth bearer tokens for inactive users", async () => {
     verifyAccessTokenMock.mockResolvedValue({
+      aud: MCP_AUDIENCE,
       sub: "user_1",
       azp: "client_1",
       scope: "surveys:read surveys:write",
@@ -364,6 +377,7 @@ describe("authenticateMcpRequest", () => {
 
   test("rejects OAuth bearer tokens holding no MCP resource scope at all", async () => {
     verifyAccessTokenMock.mockResolvedValue({
+      aud: MCP_AUDIENCE,
       sub: "user_1",
       client_id: "client_2",
       scope: "openid profile email",
@@ -394,6 +408,7 @@ describe("authenticateMcpRequest", () => {
   // token, but it grants no resource access, so it must never satisfy the baseline gate on its own.
   test("rejects an OAuth bearer token scoped only to offline_access", async () => {
     verifyAccessTokenMock.mockResolvedValue({
+      aud: MCP_AUDIENCE,
       sub: "user_1",
       client_id: "client_2",
       scope: "openid profile email offline_access",
@@ -417,7 +432,7 @@ describe("authenticateMcpRequest", () => {
   test.each([["feedbackRecords:read"], ["surveys:write"]])(
     "authenticates an OAuth token scoped only to %s",
     async (scope) => {
-      verifyAccessTokenMock.mockResolvedValue({ sub: "user_1", azp: "client_1", scope });
+      verifyAccessTokenMock.mockResolvedValue({ aud: MCP_AUDIENCE, sub: "user_1", azp: "client_1", scope });
 
       const result = await authenticateMcpRequest(
         createRequest("http://localhost/api/mcp", {
@@ -434,6 +449,7 @@ describe("authenticateMcpRequest", () => {
 
   test("rejects OAuth bearer tokens without a user subject", async () => {
     verifyAccessTokenMock.mockResolvedValue({
+      aud: MCP_AUDIENCE,
       azp: "client_1",
       scope: "surveys:read",
     });
@@ -484,6 +500,7 @@ describe("authenticateMcpRequest", () => {
 
   test("returns 429 when OAuth requests are rate limited", async () => {
     verifyAccessTokenMock.mockResolvedValue({
+      aud: MCP_AUDIENCE,
       sub: "user_1",
       azp: "client_1",
       scope: "surveys:read",
@@ -536,5 +553,117 @@ describe("handleAuthenticatedMcpRequest", () => {
     expect(response.headers.get("X-Request-Id")).toBe("req_2");
     expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(await response.json()).toEqual({ ok: true });
+  });
+});
+
+// GHSA-p2fr-6hmx-4528. Everywhere else in this file `verifyAccessToken` is stubbed with a payload,
+// which cannot show whether a token is really accepted — the audience rule lives in jose's semantics,
+// not in a fixture. Here the stub does what the real resource client does (hand the token to jose with
+// the production `verifyOptions`), and the tokens are genuinely signed, so these cases exercise the
+// actual verification path.
+describe("MCP OAuth access token audience binding", () => {
+  const ISSUER = "https://app.example.com/api/auth";
+  let keyPair: Awaited<ReturnType<typeof generateKeyPair>>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    userFindUniqueMock.mockResolvedValue({ isActive: true });
+    vi.mocked(applyRateLimit).mockResolvedValue({ allowed: true });
+    vi.mocked(applyIPRateLimit).mockResolvedValue({ allowed: true });
+
+    keyPair = await generateKeyPair("ES256");
+    verifyAccessTokenMock.mockImplementation(
+      async (token: string, opts: { verifyOptions: { audience: string; issuer: string } }) =>
+        (await jwtVerify(token, keyPair.publicKey, opts.verifyOptions)).payload
+    );
+  });
+
+  async function signAccessToken(aud: string | string[] | undefined): Promise<string> {
+    const token = new SignJWT({ scope: "surveys:read", azp: "client_1" })
+      .setProtectedHeader({ alg: "ES256" })
+      .setIssuer(ISSUER)
+      .setSubject("user_1")
+      .setIssuedAt()
+      .setExpirationTime("15m");
+
+    if (aud !== undefined) {
+      token.setAudience(aud);
+    }
+
+    return token.sign(keyPair.privateKey);
+  }
+
+  async function authenticateWithAudience(aud: string | string[] | undefined) {
+    return authenticateMcpRequest(
+      createRequest("http://localhost/api/mcp", {
+        authorization: `Bearer ${await signAccessToken(aud)}`,
+      })
+    );
+  }
+
+  test("accepts a token minted for the MCP resource", async () => {
+    const result = await authenticateWithAudience(MCP_AUDIENCE);
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("accepts a single-element audience array", async () => {
+    const result = await authenticateWithAudience([MCP_AUDIENCE]);
+
+    expect(result.ok).toBe(true);
+  });
+
+  // Not a hypothetical, and not a future shape either: the provider already appends its own UserInfo
+  // endpoint to `aud` whenever `openid` is in the granted scopes (`checkResource` does it today, and
+  // the 1.7 resource model keeps the behaviour). `openid` leads MCP_OAUTH_SCOPES and every
+  // DCR-registered client gets it, so a rule of "exactly one audience" would reject ordinary tokens
+  // right now — which is why the check is an allow-list.
+  test("accepts the MCP resource alongside the authorization server's UserInfo endpoint", async () => {
+    const result = await authenticateWithAudience([MCP_AUDIENCE, USERINFO_AUDIENCE]);
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects a token that also names a foreign resource server", async () => {
+    const foreignAudience = [MCP_AUDIENCE, "https://other.example.com/api"];
+
+    // The vulnerability, made explicit: handed the exact options production passes, jose accepts this
+    // token, because its `aud` check asks whether our identifier is *present*, not whether it is the
+    // only one. Nothing in the library layer stands between this token and the MCP tools.
+    await expect(
+      jwtVerify(await signAccessToken(foreignAudience), keyPair.publicKey, {
+        audience: MCP_AUDIENCE,
+        issuer: ISSUER,
+      })
+    ).resolves.toBeDefined();
+
+    const result = await authenticateWithAudience(foreignAudience);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+      // Same opaque refusal as any other bad token — the caller learns nothing about why.
+      expect(await result.response.json()).toMatchObject({ detail: "Invalid OAuth access token" });
+    }
+    expect(applyIPRateLimit).toHaveBeenCalledWith(expect.objectContaining({ namespace: "api:mcp:auth" }));
+    expect(applyRateLimit).not.toHaveBeenCalled();
+  });
+
+  test("rejects a token minted for a different resource server", async () => {
+    const result = await authenticateWithAudience("https://other.example.com/api");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+    }
+  });
+
+  test("rejects a token carrying no audience at all", async () => {
+    const result = await authenticateWithAudience(undefined);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+    }
   });
 });

--- a/apps/web/modules/mcp/auth.test.ts
+++ b/apps/web/modules/mcp/auth.test.ts
@@ -447,6 +447,54 @@ describe("authenticateMcpRequest", () => {
     }
   );
 
+  // Verification is stubbed here, so these two exercise the resource server's audience check on its
+  // own — with no jose `aud` enforcement upstream of it. That is not a contrived setup: the 1.7
+  // provider drops `verifyOptions.audience` from its own verification, at which point this check is
+  // the only thing standing between a foreign-audience token and the MCP tools.
+  test("rejects an OAuth token whose audience omits the MCP resource, independently of jose", async () => {
+    verifyAccessTokenMock.mockResolvedValue({
+      aud: "https://other.example.com/api",
+      sub: "user_1",
+      azp: "client_1",
+      scope: "surveys:read",
+    });
+
+    const result = await authenticateMcpRequest(
+      createRequest("http://localhost/api/mcp", {
+        authorization: "Bearer oauth_access_token",
+      })
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(401);
+      expect(await result.response.json()).toMatchObject({ detail: "Invalid OAuth access token" });
+    }
+    expect(applyRateLimit).not.toHaveBeenCalled();
+  });
+
+  test("returns 429 when audience-rejected tokens exceed the unauthenticated MCP rate limit", async () => {
+    verifyAccessTokenMock.mockResolvedValue({
+      aud: [MCP_AUDIENCE, "https://other.example.com/api"],
+      sub: "user_1",
+      azp: "client_1",
+      scope: "surveys:read",
+    });
+    vi.mocked(applyIPRateLimit).mockRejectedValue(new TooManyRequestsError("Too many auth requests", 45));
+
+    const result = await authenticateMcpRequest(
+      createRequest("http://localhost/api/mcp", {
+        authorization: "Bearer oauth_access_token",
+      })
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(429);
+      expect(result.response.headers.get("Retry-After")).toBe("45");
+    }
+  });
+
   test("rejects OAuth bearer tokens without a user subject", async () => {
     verifyAccessTokenMock.mockResolvedValue({
       aud: MCP_AUDIENCE,

--- a/apps/web/modules/mcp/auth.ts
+++ b/apps/web/modules/mcp/auth.ts
@@ -118,6 +118,15 @@ function getOAuthScopes(payload: JWTPayload): string[] {
   return typeof payload.scope === "string" ? payload.scope.split(" ").filter(Boolean) : [];
 }
 
+/** `aud` is a single string or an array (RFC 7519 §4.1.3); normalise both to a list. */
+function toAudienceList(aud: JWTPayload["aud"]): string[] {
+  if (typeof aud === "string") {
+    return [aud];
+  }
+
+  return Array.isArray(aud) ? aud : [];
+}
+
 /**
  * Rejects an access token that was not minted for this resource server.
  *
@@ -136,8 +145,7 @@ function getOAuthScopes(payload: JWTPayload): string[] {
  * for somebody else and must not be honoured here.
  */
 function hasAcceptedMcpAudience(payload: JWTPayload): boolean {
-  const { aud } = payload;
-  const audiences = typeof aud === "string" ? [aud] : Array.isArray(aud) ? aud : [];
+  const audiences = toAudienceList(payload.aud);
 
   const resourceUrl = getMcpResourceUrl();
   if (!audiences.includes(resourceUrl)) {
@@ -286,6 +294,38 @@ async function rateLimitUnauthenticatedMcpRequest(
   }
 }
 
+/**
+ * The shared refusal for a request that failed to authenticate: charge the unauthenticated rate-limit
+ * bucket first (so a bad credential cannot be retried for free), then answer 401 with the discovery
+ * challenge.
+ *
+ * `detail` is what the caller is told and defaults to the same opaque string for every OAuth failure
+ * — expired, forged, wrong audience and inactive user are deliberately indistinguishable. The reason
+ * lives in `logMessage`/`logContext` instead, where it is useful to us and not to an attacker.
+ */
+async function rejectUnauthenticatedMcpRequest(params: {
+  requestId: string;
+  instance: string;
+  log: ReturnType<typeof logger.withContext>;
+  logMessage: string;
+  detail?: string;
+  logContext?: Record<string, unknown>;
+}): Promise<TMcpAuthenticationResult> {
+  const { requestId, instance, log, logMessage, detail = "Invalid OAuth access token", logContext } = params;
+
+  const rateLimitResponse = await rateLimitUnauthenticatedMcpRequest(requestId, log);
+  if (rateLimitResponse) {
+    return { ok: false, requestId, response: rateLimitResponse };
+  }
+
+  log.warn({ statusCode: 401, ...logContext }, logMessage);
+  return {
+    ok: false,
+    requestId,
+    response: withOAuthChallenge(problemUnauthorized(requestId, detail, instance)),
+  };
+}
+
 async function authenticateMcpApiKey(
   request: NextRequest,
   requestId: string,
@@ -295,19 +335,13 @@ async function authenticateMcpApiKey(
   const authentication = await authenticateApiKeyFromHeaders(request.headers);
 
   if (!authentication) {
-    const rateLimitResponse = await rateLimitUnauthenticatedMcpRequest(requestId, log);
-    if (rateLimitResponse) {
-      return { ok: false, requestId, response: rateLimitResponse };
-    }
-
-    log.warn({ statusCode: 401 }, "MCP API key authentication failed");
-    return {
-      ok: false,
+    return await rejectUnauthenticatedMcpRequest({
       requestId,
-      response: withOAuthChallenge(
-        problemUnauthorized(requestId, "API key or OAuth access token required", instance)
-      ),
-    };
+      instance,
+      log,
+      detail: "API key or OAuth access token required",
+      logMessage: "MCP API key authentication failed",
+    });
   }
 
   try {
@@ -349,70 +383,48 @@ async function authenticateMcpOAuthBearer(
       jwksUrl: `${getAuthIssuerUrl()}/jwks`,
     });
   } catch {
-    const rateLimitResponse = await rateLimitUnauthenticatedMcpRequest(requestId, log);
-    if (rateLimitResponse) {
-      return { ok: false, requestId, response: rateLimitResponse };
-    }
-
-    log.warn({ statusCode: 401 }, "MCP OAuth authentication failed");
-    return {
-      ok: false,
+    return await rejectUnauthenticatedMcpRequest({
       requestId,
-      response: withOAuthChallenge(problemUnauthorized(requestId, "Invalid OAuth access token", instance)),
-    };
+      instance,
+      log,
+      logMessage: "MCP OAuth authentication failed",
+    });
   }
 
   if (!hasAcceptedMcpAudience(payload)) {
-    const rateLimitResponse = await rateLimitUnauthenticatedMcpRequest(requestId, log);
-    if (rateLimitResponse) {
-      return { ok: false, requestId, response: rateLimitResponse };
-    }
-
     // Logged distinctly — a token that verifies against our own issuer and JWKS but names a
     // different audience is a resource-confusion attempt, not the routine expired/garbage token the
-    // catch above handles. The client still gets the same opaque refusal so this is not an oracle.
-    log.warn(
-      { statusCode: 401, clientId: getOAuthClientId(payload), audience: payload.aud },
-      "MCP OAuth token audience is not bound to this resource server"
-    );
-    return {
-      ok: false,
+    // catch above handles.
+    return await rejectUnauthenticatedMcpRequest({
       requestId,
-      response: withOAuthChallenge(problemUnauthorized(requestId, "Invalid OAuth access token", instance)),
-    };
+      instance,
+      log,
+      logMessage: "MCP OAuth token audience is not bound to this resource server",
+      logContext: { clientId: getOAuthClientId(payload), audience: payload.aud },
+    });
   }
 
   const authInfo = createOAuthMcpAuthInfo(payload, requestId);
 
   if (!authInfo) {
-    const rateLimitResponse = await rateLimitUnauthenticatedMcpRequest(requestId, log);
-    if (rateLimitResponse) {
-      return { ok: false, requestId, response: rateLimitResponse };
-    }
-
-    log.warn({ statusCode: 401 }, "MCP OAuth token has no user subject");
-    return {
-      ok: false,
+    return await rejectUnauthenticatedMcpRequest({
       requestId,
-      response: withOAuthChallenge(
-        problemUnauthorized(requestId, "User OAuth access token required", instance)
-      ),
-    };
+      instance,
+      log,
+      detail: "User OAuth access token required",
+      logMessage: "MCP OAuth token has no user subject",
+    });
   }
 
   const sessionAuthentication = authInfo.extra.formbricksAuthentication as Session;
   if (!(await isOAuthUserActive(sessionAuthentication.user.id))) {
-    const rateLimitResponse = await rateLimitUnauthenticatedMcpRequest(requestId, log);
-    if (rateLimitResponse) {
-      return { ok: false, requestId, response: rateLimitResponse };
-    }
-
-    log.warn({ statusCode: 401, clientId: authInfo.clientId }, "MCP OAuth token user is inactive");
-    return {
-      ok: false,
+    return await rejectUnauthenticatedMcpRequest({
       requestId,
-      response: withOAuthChallenge(problemUnauthorized(requestId, "Invalid OAuth access token", instance)),
-    };
+      instance,
+      log,
+      logMessage: "MCP OAuth token user is inactive",
+      logContext: { clientId: authInfo.clientId },
+    });
   }
 
   // Minimum grant required to authenticate against the MCP server at all: at least ONE *resource*
@@ -530,19 +542,13 @@ export async function authenticateMcpRequest(request: NextRequest): Promise<TMcp
 
     const bearerToken = getBearerTokenFromHeaders(request.headers);
     if (!bearerToken) {
-      const rateLimitResponse = await rateLimitUnauthenticatedMcpRequest(requestId, log);
-      if (rateLimitResponse) {
-        return { ok: false, requestId, response: rateLimitResponse };
-      }
-
-      log.warn({ statusCode: 401 }, "MCP authentication credentials missing");
-      return {
-        ok: false,
+      return await rejectUnauthenticatedMcpRequest({
         requestId,
-        response: withOAuthChallenge(
-          problemUnauthorized(requestId, "API key or OAuth access token required", instance)
-        ),
-      };
+        instance,
+        log,
+        detail: "API key or OAuth access token required",
+        logMessage: "MCP authentication credentials missing",
+      });
     }
 
     if (parseApiKeyV2(bearerToken)) {

--- a/apps/web/modules/mcp/auth.ts
+++ b/apps/web/modules/mcp/auth.ts
@@ -318,7 +318,8 @@ async function rejectUnauthenticatedMcpRequest(params: {
     return { ok: false, requestId, response: rateLimitResponse };
   }
 
-  log.warn({ statusCode: 401, ...logContext }, logMessage);
+  // statusCode last: a caller's context must not be able to relabel the status this actually returns.
+  log.warn({ ...logContext, statusCode: 401 }, logMessage);
   return {
     ok: false,
     requestId,

--- a/apps/web/modules/mcp/auth.ts
+++ b/apps/web/modules/mcp/auth.ts
@@ -25,6 +25,7 @@ import {
   getMcpOrigin,
   getMcpProtectedResourceMetadataUrl,
   getMcpResourceUrl,
+  getOAuthUserInfoUrl,
 } from "@/modules/auth/lib/oauth-urls";
 import { applyIPRateLimit, applyRateLimit } from "@/modules/core/rate-limit/helpers";
 import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
@@ -115,6 +116,36 @@ function createApiKeyMcpAuthInfo(authentication: TAuthenticationApiKey, requestI
 
 function getOAuthScopes(payload: JWTPayload): string[] {
   return typeof payload.scope === "string" ? payload.scope.split(" ").filter(Boolean) : [];
+}
+
+/**
+ * Rejects an access token that was not minted for this resource server.
+ *
+ * `verifyOptions.audience` alone does NOT do this. It is handed to jose, whose `aud` check is a
+ * *membership* test — a token carrying `aud: [".../api/mcp", "https://other.example/api"]` passes it
+ * and would be accepted here, which is exactly the cross-resource escalation GHSA-p2fr-6hmx-4528
+ * describes. RFC 9068 §4 puts the burden on the resource server: it must reject a token whose
+ * audience is not itself, so this assert is required regardless of which provider version issued the
+ * token.
+ *
+ * Written as an allow-list rather than "exactly one audience", deliberately. When `openid` is in the
+ * granted scopes the authorization server treats its own UserInfo endpoint as an implicit second
+ * resource and appends it to `aud` — that is current behaviour, not something the pending provider
+ * upgrade introduces — so a perfectly ordinary MCP token is multi-valued. Those two identifiers are
+ * the only ones a Formbricks-issued MCP token may carry; anything else means the token was minted
+ * for somebody else and must not be honoured here.
+ */
+function hasAcceptedMcpAudience(payload: JWTPayload): boolean {
+  const { aud } = payload;
+  const audiences = typeof aud === "string" ? [aud] : Array.isArray(aud) ? aud : [];
+
+  const resourceUrl = getMcpResourceUrl();
+  if (!audiences.includes(resourceUrl)) {
+    return false;
+  }
+
+  const acceptedAudiences = new Set([resourceUrl, getOAuthUserInfoUrl()]);
+  return audiences.every((audience) => acceptedAudiences.has(audience));
 }
 
 function getOAuthClientId(payload: JWTPayload): string | null {
@@ -324,6 +355,26 @@ async function authenticateMcpOAuthBearer(
     }
 
     log.warn({ statusCode: 401 }, "MCP OAuth authentication failed");
+    return {
+      ok: false,
+      requestId,
+      response: withOAuthChallenge(problemUnauthorized(requestId, "Invalid OAuth access token", instance)),
+    };
+  }
+
+  if (!hasAcceptedMcpAudience(payload)) {
+    const rateLimitResponse = await rateLimitUnauthenticatedMcpRequest(requestId, log);
+    if (rateLimitResponse) {
+      return { ok: false, requestId, response: rateLimitResponse };
+    }
+
+    // Logged distinctly — a token that verifies against our own issuer and JWKS but names a
+    // different audience is a resource-confusion attempt, not the routine expired/garbage token the
+    // catch above handles. The client still gets the same opaque refusal so this is not an oracle.
+    log.warn(
+      { statusCode: 401, clientId: getOAuthClientId(payload), audience: payload.aud },
+      "MCP OAuth token audience is not bound to this resource server"
+    );
     return {
       ok: false,
       requestId,

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -178,15 +178,26 @@ overrides:
   # - apps/web/modules/auth/lib/mcp-oauth-provider-options.ts sets a single-entry validAudiences (the
   #   MCP resource URL), so there is no second audience for a client to escalate into. This is the
   #   load-bearing mitigation, and it holds only while that array stays single-entry.
-  # - apps/web/modules/mcp/auth.ts additionally pins `audience: getMcpResourceUrl()` on the resource
-  #   server's own verifyAccessToken call. That hardens the MCP endpoint but is NOT a substitute for the
-  #   above: the option flows straight into jose's jwtVerify, whose `aud` check is a membership test, so
-  #   a token whose `aud` array also lists other audiences still passes. The advisory's workaround also
-  #   requires rejecting multi-audience tokens, which verifyOptions.audience cannot express — that would
-  #   need an explicit assert on the returned payload. And if a second audience were ever added, the
-  #   party at risk is that other resource server, which our own pin does nothing for.
-  # - apps/web/modules/mcp/auth.test.ts asserts the audience/issuer pin, and
-  #   apps/web/modules/auth/lib/mcp-oauth-dcr.test.ts guards the single-entry validAudiences invariant.
+  # - apps/web/modules/mcp/auth.ts pins `audience: getMcpResourceUrl()` on the resource server's own
+  #   verify call AND, since ENG-2339, asserts the verified payload's `aud` itself. The pin alone was
+  #   never sufficient: it flows straight into jose's jwtVerify, whose `aud` check is a membership
+  #   test, so a token whose `aud` array also lists other audiences passes it. The advisory's own
+  #   workaround requires *rejecting* multi-audience tokens, which verifyOptions.audience cannot
+  #   express. The explicit assert is that rejection — an allow-list of {MCP resource, the AS's
+  #   UserInfo endpoint, which `openid` implies}, everything else refused.
+  # - What that does and does not buy: our MCP endpoint can no longer be reached with a token minted
+  #   for somebody else, which is the exploitable half. It does NOT make the AS compliant — 1.6.x
+  #   still never persists the approved resource, so there is nothing to bind the token request to.
+  #   That is unfixable from our side and is what the 1.7 upgrade (ENG-2343) is for. If a second
+  #   audience were ever added the party at risk is that other resource server, and nothing here
+  #   protects it.
+  # - Test coverage. Single-entry validAudiences is pinned twice, deliberately: in
+  #   apps/web/modules/auth/lib/mcp-oauth-dcr.test.ts (added by #8828) and in
+  #   apps/web/modules/auth/lib/mcp-oauth-provider-options.test.ts (ENG-2339), which also covers the
+  #   advertised-vs-registration scope agreement and the write-scope step-up expiry. Redundant on
+  #   purpose — it is the invariant this entire acceptance rests on. Separately,
+  #   apps/web/modules/mcp/auth.test.ts mints real signed JWTs and proves a multi-audience token is
+  #   refused (and that jose on its own accepts it).
   # Upgrade cost, for whoever picks up 1.7.0: the renames the 1.7 upgrade guide warns about do not apply
   # to us (migration 20260702093000_add_better_auth_oauth_provider already created `oauthClient`, not
   # `oauthApplication`, with an `oauthAccessToken.token` column, not `.accessToken`, plus the `sessionId`


### PR DESCRIPTION
## What & why

`@better-auth/oauth-provider` does not bind an access token's audience to the resource approved during authorization ([GHSA-p2fr-6hmx-4528](https://github.com/advisories/GHSA-p2fr-6hmx-4528), CVSS 6.4). The token endpoint stamps `aud` with the **client-supplied** `resource`, gated only by the static `validAudiences` allow-list — the authorization code stores no resource, so nothing ties the token request back to what the user consented to.

This deployment is not exploitable today only because `validAudiences` has exactly one entry, and **nothing asserted that**. It was one config edit away from being real, and the suite would have stayed green.

The upstream fix ships only in the unreleased 1.7 line (still no stable — npm `latest` is `1.6.27`, itself in the affected range), and that bump is coupled to `better-auth` core, touching login/sessions/2FA/SSO. That upgrade is tracked separately in ENG-2343, gated on a stable release. This PR closes the gap on our side with work that is correct on either version.

**The MCP resource server now asserts the verified payload's audience itself.** `verifyOptions.audience` cannot do this: it is handed to jose, whose `aud` check is a *membership* test, so a token naming our resource **and** a foreign one passes it. RFC 9068 §4 puts that duty on the resource server, so this assertion is required no matter which provider version issued the token — it is not scaffolding to be removed after the upgrade. (1.7 in fact drops `verifyOptions.audience` from its own verification, which makes it *more* load-bearing.)

The check is an **allow-list** of `{MCP resource, the AS's UserInfo endpoint}` rather than "exactly one audience". The provider appends UserInfo to `aud` whenever `openid` is in the *granted* scopes — current 1.6.23 behaviour, not something the pending upgrade introduces — so a single-value rule would reject those tokens outright.

### Commits

1. `fix(security)` — the audience assertion, the single-entry config assertion, and real-JWT audience tests.
2. `test` — closes two coverage gaps SonarCloud surfaced (see below).
3. `refactor` — extracts the six-times-duplicated "rate-limit, log, 401 + challenge" block that adding a fourth rejection pushed over Sonar's cognitive-complexity limit.
4. `docs` — records a latent assumption found while reviewing, and pins the logged `statusCode`.
5. `docs` — corrects the checked-in accepted-risk note in `pnpm-workspace.yaml`, which this branch made stale.

Rebased onto `main` after #8828 landed (it touches the same note). Worth knowing for review: **#8828 independently added the same single-entry `validAudiences` assertion**, in `mcp-oauth-dcr.test.ts`. Both are kept, and the duplication is now called out in a comment — it is the invariant this whole acceptance rests on, and the two suites can be edited independently.

## Linear ticket

Ref ENG-2339

<!-- Deliberately `Ref`, not `Fixes`: this PR closes the exploitable gap but does NOT
satisfy ENG-2339 as written (its acceptance criteria describe the library upgrade, which is
blocked on a 1.7 stable release and tracked in ENG-2343). Merging must not auto-close it. -->

## How this was tested

- `pnpm test` (full `apps/web` suite) ✅ — **599 files / 7823 tests passed**.
- Targeted: `modules/mcp/`, `modules/auth/lib/`, `app/api/mcp/`, `app/.well-known/` ✅ — 32 files / 376 tests.
- `eslint` ✅ clean, `prettier --check` ✅ clean, `tsc --noEmit -p tsconfig.typecheck.json` ✅ — zero errors in touched files.
- **Fault injection, run twice** (before and after the refactor, since it moved the guard): with the assertion short-circuited, exactly the three audience tests fail and the rest of the suite stays green. The multi-audience case fails with `expected true to be false` — i.e. the vulnerable token was *accepted*. Guard restored, suite re-run green.

Tests added:

- `modules/auth/lib/mcp-oauth-provider-options.test.ts` (new) — the single-entry audience invariant, plus advertised-vs-registration scope agreement and the derived write-scope step-up expiry.
- `modules/mcp/auth.test.ts` — a `MCP OAuth access token audience binding` block that signs **real** ES256 tokens and verifies them through jose with the production `verifyOptions`. Covers `aud` as a string, `[MCP]`, `[MCP, UserInfo]` (accepted), and `[MCP, foreign]`, foreign-only, absent (rejected). The multi-audience case also asserts jose *itself* accepts the token, so the test documents why the library layer is not sufficient.
- Two further cases drive the check through the stubbed verifier, exercising it with no jose `aud` enforcement upstream — the configuration 1.7 creates.
- `modules/auth/lib/oauth-urls.test.ts` — pins the UserInfo audience derivation, including a subpath `BETTER_AUTH_URL`.

Existing fixtures gained the `aud` claim every real token carries — without it they described a token the authorization server cannot issue, which is how this class of bug stayed invisible.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Connect an MCP client (Claude Code, MCP Inspector) to `/api/mcp` and complete the OAuth flow → connects as before, tools list and calls work. This is the regression that matters: the audience rule must not turn away legitimate clients.
- [ ] Repeat with a client that requests `openid` → still connects (this is the two-audience shape).
- [ ] `POST /api/mcp` with `Authorization: Bearer <garbage>` → `401` with a `WWW-Authenticate: Bearer resource_metadata="…", scope="…"` challenge, unchanged.
- [ ] `POST /api/mcp` with an API key (`x-api-key`) → unaffected.
- [ ] `POST /api/mcp` with no credentials at all → `401` with the same challenge, and the message still reads `API key or OAuth access token required` (the refusal helper is shared now, so this wording is worth eyeballing).
- [ ] Sign in normally, exercise 2FA and SSO → unchanged. No auth-library version moved in this PR.

**Preconditions / test data**

- A workspace with the MCP surface reachable and an MCP client able to complete Dynamic Client Registration.
- No feature flag, no new env var, no plan/entitlement gate.

**Risks & regressions**

- Blast radius is the OAuth-bearer path of `/api/mcp`. If the allow-list were wrong the symptom would be legitimate MCP clients getting `401` instead of connecting — hence the first two steps.
- The refactor touches the shared refusal path for **all** MCP auth failures, including the two API-key ones, so the "no credentials" and "bad API key" responses are worth a look even though their behaviour is unchanged.
- API-key MCP auth, the v3 REST API and browser session auth are otherwise untouched.
- A rejected token is logged distinctly (`audience is not bound to this resource server`) but the client receives the same opaque `Invalid OAuth access token`, so this adds no oracle.

**Migrations / env / cutover**

- none



