### PR TITLE
fix(unify-feedback): render feedback record value text as a textarea

### DIFF
--- a/apps/web/modules/ee/unify-feedback/components/feedback-record-form-drawer.tsx
+++ b/apps/web/modules/ee/unify-feedback/components/feedback-record-form-drawer.tsx
@@ -34,6 +34,7 @@ import {
   SheetTitle,
 } from "@/modules/ui/components/sheet";
 import { Switch } from "@/modules/ui/components/switch";
+import { Textarea } from "@/modules/ui/components/textarea";
 import { deleteFeedbackRecordAction, retrieveFeedbackRecordAction } from "../actions";
 import { FIELD_TYPE_OPTIONS, type TFeedbackRecordFormValues } from "../lib/types";
 import {
@@ -379,29 +380,35 @@ export const FeedbackRecordFormDrawer = ({
                   )}
                 />
 
-                <div className="grid grid-cols-2 gap-3">
-                  <FormField
-                    control={form.control}
-                    name="value_text"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>{t("workspace.unify.value_text")}</FormLabel>
-                        <FormControl>
-                          <Input {...field} value={field.value ?? ""} disabled />
-                        </FormControl>
-                      </FormItem>
-                    )}
-                  />
+                {/* Full width, multi-line: open-text answers are the longest values on the record and
+                    have to stay readable without horizontal scrolling. */}
+                <FormField
+                  control={form.control}
+                  name="value_text"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>{t("workspace.unify.value_text")}</FormLabel>
+                      <FormControl>
+                        <Textarea
+                          {...field}
+                          value={field.value ?? ""}
+                          rows={5}
+                          className="resize-y"
+                          disabled
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
 
-                  {/* ENG-1673: read-only — the stable option identity is managed by ingestion/backfill;
-                      hand-editing it would desync the record from its source option. Always shown so the
-                      canonical Value ID is visible even when the record has none. */}
-                  <div className="space-y-2">
-                    <Label htmlFor="value_id" className="block text-slate-800">
-                      {t("workspace.unify.value_id")}
-                    </Label>
-                    <Input id="value_id" value={record.value_id ?? ""} disabled readOnly />
-                  </div>
+                {/* ENG-1673: read-only — the stable option identity is managed by ingestion/backfill;
+                    hand-editing it would desync the record from its source option. Always shown so the
+                    canonical Value ID is visible even when the record has none. */}
+                <div className="space-y-2">
+                  <Label htmlFor="value_id" className="block text-slate-800">
+                    {t("workspace.unify.value_id")}
+                  </Label>
+                  <Input id="value_id" value={record.value_id ?? ""} disabled readOnly />
                 </div>
 
                 {translatedText && (


### PR DESCRIPTION
## What & why

The **Value (Text)** field in the Feedback Record drawer rendered as a single-line `Input` in a half-width grid cell. Open-text answers are the longest values on a record, so anything past ~40 characters was clipped and only readable by scrolling inside the input — the common case for verbatim feedback.

`Value (Text)` is now a full-width, 5-row `Textarea` (vertically resizable, still read-only/disabled like every other field in this drawer), so long verbatims wrap and are readable at a glance. `Value ID` moves out of the shared two-column grid onto its own full-width row, matching the other single-field rows (`Source type`, `Field group label`).

No behavior change: the field stays disabled, the value binding is unchanged, and the translation / AI-enrichment panels below it are untouched.

## Linear ticket

No ticket — drive-by UI readability fix on the Unify Feedback record drawer, reported directly while reviewing a Swedish verbatim that was clipped in the field.

## How this was tested

- `vitest run modules/ee/unify-feedback` → **226 tests passed**, 19/20 files passed. The one failing file (`lib/contacts.test.ts`) fails to resolve `@formbricks/database` in this worktree — a pre-existing environment issue (no generated Prisma client), unrelated to this diff. Per AGENTS.md, `.tsx` components are not unit-tested.
- ESLint + Prettier via the pre-commit lint-staged run ✅
- Verified visually with a component render (Playwright, using this repo's compiled Tailwind CSS and the real `Input`/`Textarea`/`Label` classes). **These are component renders, not live app captures** — the web app can't be stood up in this worktree (no DB / Hub backend), so the surrounding drawer chrome is omitted and the rows that changed are shown in isolation.

Left: single-line input clipping a Swedish verbatim (the reported bug). Right: full-width textarea, whole answer readable.

![Value (Text) before and after](https://raw.githubusercontent.com/formbricks/formbricks/assets-value-text-textarea/value-text-before-after.png)

<sub>Screenshot lives on the orphan branch `assets-value-text-textarea` (PNG only, not part of this diff) — safe to delete after merge.</sub>

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Open a workspace with Unify Feedback enabled → **Feedback** → **Records**, click any record row → the details drawer opens from the right.
- [ ] Pick a record whose answer is a long open text (2+ sentences) → **Value (Text)** spans the full drawer width as a multi-line box, the whole answer is visible/wrapped, and no text is cut off horizontally.
- [ ] Drag the bottom-right corner of the **Value (Text)** box → it resizes vertically; the rest of the drawer reflows without overlap.
- [ ] Confirm **Value (Text)** is still read-only: clicking into it does not allow typing.
- [ ] **Value ID** now sits on its own row directly below **Value (Text)**, full width, read-only (empty when the record has no value ID).
- [ ] Open a record with a non-text answer (number / date / rating / boolean) → **Value (Text)** is empty, and the `Translated text` and `AI enrichment` panels behave exactly as before (they only show for text records).
- [ ] Open a record with a translation → the `Translated text` panel still renders below **Value (Text)**.

**Preconditions / test data**

- Workspace with the Unify Feedback (Hub) surface available, plus at least one feedback record with a long free-text value — ideally one non-English so the `Translated text` panel also shows.
- Owner/manager role to see the Delete action in the drawer footer (unrelated to this change, but the drawer footer is in the same view).

**Risks & regressions**

- Drawer layout only: the two-column grid that previously held `Value (Text)` + `Value ID` was split into two full-width rows. Re-check the drawer's vertical rhythm and that the following rows (`Value (Number)` / `Value (Date)`, `Value (Boolean)`, `Language` / `User identifier`, `Metadata`) are unchanged.
- Narrow viewports: verify the drawer on a small screen — the grid rows were already stacking, so only the textarea height should differ.

**Migrations / env / cutover**

- none
