### PR TITLE
chore: add Claude Code SessionStart hook and commit .claude project config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/claude-session-start.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "startup|resume"
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -78,8 +78,11 @@ stats.html
 .next-docs/
 
 # robots (installed agent assets - machine-local, do not commit)
-# .claude is machine-local except committed symlinks into .agents/skills
+# .claude is machine-local except committed symlinks into .agents/skills and
+# settings.json, which carries the shared SessionStart hook (it is the only
+# settings layer that reaches Claude Code cloud sessions)
 .claude/*
+!.claude/settings.json
 !.claude/skills/
 .claude/skills/*
 !.claude/skills/nextjs-docs

--- a/.gitignore
+++ b/.gitignore
@@ -77,13 +77,11 @@ stats.html
 # next-agents-md
 .next-docs/
 
-# robots (installed agent assets - machine-local, do not commit)
-# .claude is machine-local except committed symlinks into .agents/skills and
-# settings.json, which carries the shared SessionStart hook (it is the only
-# settings layer that reaches Claude Code cloud sessions)
-.claude/*
-!.claude/settings.json
-!.claude/skills/
-.claude/skills/*
-!.claude/skills/nextjs-docs
+# Claude Code config under .claude is team-shared and belongs in the repo:
+# settings.json, repo-specific skills, subagents and commands. Company-wide
+# skills are distributed from formbricks/skills, not installed into .claude, so
+# there is nothing machine-local left to ignore here except personal overrides.
+.claude/settings.local.json
+
+# robots design context (machine-local install, not committed)
 .agents/formbricks-context

--- a/scripts/claude-session-start.sh
+++ b/scripts/claude-session-start.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Claude Code SessionStart hook.
+#
+# Prepares a checkout so tests, linters and `pnpm db:up` work right away, in a
+# plain local clone, in a git worktree, and in a cloud session. Every step is
+# idempotent and cheap once a checkout is prepared, so re-running on resume is
+# nearly free.
+#
+# Cloud sessions start dockerd here rather than in the cloud environment's setup
+# script: that script only runs while the environment cache is being built, and
+# the cache is a filesystem snapshot, so it keeps installed files but not
+# running processes.
+#
+# Never exits non-zero: a broken checkout should still give you a session.
+
+set -uo pipefail
+
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-}"
+if [[ -z "${REPO_ROOT}" ]]; then
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+fi
+cd "${REPO_ROOT}" 2>/dev/null || exit 0
+
+log() {
+  printf 'session-start: %s\n' "$1"
+}
+
+# A fresh worktree has no .env of its own. Every worktree on a machine talks to
+# the same docker-compose Postgres, so generating a fresh ENCRYPTION_KEY here
+# would leave rows written by another checkout undecryptable. Copy the main
+# worktree's .env when there is one; scripts/setup-dev-env.sh then fills in
+# whatever is still missing, and leaves an existing .env alone.
+prepare_env_file() {
+  if [[ ! -f .env ]]; then
+    local main_root
+    main_root="$(git worktree list --porcelain 2>/dev/null |
+      awk 'NR == 1 && /^worktree /{ print substr($0, 10) }')"
+
+    if [[ -n "${main_root}" && "${main_root}" != "${REPO_ROOT}" && -f "${main_root}/.env" ]]; then
+      cp "${main_root}/.env" .env && log "seeded .env from ${main_root}"
+    fi
+  fi
+
+  # Called directly rather than through `pnpm dev:setup`: booting pnpm costs
+  # about a minute on a cold VM, and this step must not pay that when there is
+  # nothing to install.
+  if [[ -f scripts/setup-dev-env.sh ]]; then
+    bash scripts/setup-dev-env.sh >/dev/null 2>&1 ||
+      log "scripts/setup-dev-env.sh failed - run 'pnpm dev:setup' manually"
+  fi
+}
+
+# pnpm links from a global store, so a worktree's install is mostly symlinks,
+# but each worktree still needs its own node_modules.
+#
+# Staleness is tracked with a hash of the lockfile rather than mtimes: a cloud
+# session restores node_modules from the environment cache and then clones the
+# repo on top, which leaves the lockfile newer than node_modules every time and
+# would reinstall on every session start.
+install_dependencies() {
+  local lock_hash marker="node_modules/.formbricks-lock-hash"
+
+  lock_hash="$(git hash-object pnpm-lock.yaml 2>/dev/null || cksum pnpm-lock.yaml)"
+
+  if [[ -d node_modules && -n "${lock_hash}" && -f "${marker}" ]] &&
+    [[ "$(cat "${marker}" 2>/dev/null)" == "${lock_hash}" ]]; then
+    return 0
+  fi
+
+  if ! command -v pnpm >/dev/null 2>&1; then
+    corepack enable >/dev/null 2>&1 || true
+  fi
+
+  log "installing dependencies"
+  if pnpm install --frozen-lockfile --prefer-offline >/dev/null 2>&1; then
+    printf '%s\n' "${lock_hash}" >"${marker}" 2>/dev/null || true
+  else
+    log "pnpm install failed - run 'pnpm install' manually"
+  fi
+}
+
+# apps/web resolves @formbricks/* through each package's dist/, so vitest cannot
+# even load a suite in a checkout where the packages have never been built.
+# Turbo decides what actually needs rebuilding; a warm cache costs a second or
+# two, a cold one about a minute.
+build_workspace_packages() {
+  # Any package's dist would do as the cold-build sentinel; this one is imported
+  # widely enough that its absence always means a cold cache.
+  [[ -d packages/logger/dist ]] || log "building workspace packages (first run, takes a minute)"
+
+  pnpm turbo run build --filter='./packages/*' >/dev/null 2>&1 ||
+    log "workspace package build failed - run 'pnpm build' manually"
+}
+
+# Cloud only. On a developer machine the Docker daemon is the developer's
+# business, and dockerd is not ours to start.
+start_docker_daemon() {
+  [[ "${CLAUDE_CODE_REMOTE:-}" == "true" ]] || return 0
+  docker info >/dev/null 2>&1 && return 0
+  command -v dockerd >/dev/null 2>&1 || return 0
+
+  dockerd >/var/log/dockerd.log 2>&1 &
+
+  for _ in $(seq 1 30); do
+    if docker info >/dev/null 2>&1; then
+      log "dockerd started"
+      return 0
+    fi
+    sleep 1
+  done
+
+  log "dockerd did not start - see /var/log/dockerd.log"
+}
+
+prepare_env_file
+install_dependencies
+build_workspace_packages
+start_docker_daemon
+
+exit 0


### PR DESCRIPTION
## What & why

Two related problems with how this repo bootstraps Claude Code sessions.

**1. Cloud sessions could not run `pnpm db:up` or `pnpm test`.**

Cloud environment setup scripts only run while the environment cache is being built, and that cache is a filesystem snapshot: it keeps installed files but not running processes. A `dockerd` started from a setup script therefore runs exactly once, on the session that builds the cache, and never again. Separately, nothing built the workspace packages, and `apps/web` resolves `@formbricks/*` through each package's `dist/` — so `vitest` could not even load a suite importing `@formbricks/logger`.

`scripts/claude-session-start.sh` moves per-session work into a `SessionStart` hook: start `dockerd` (cloud only), ensure `.env`, install dependencies, build the workspace packages. It is committed rather than configured per-account, so it also prepares plain clones and git worktrees, which otherwise start with none of the three.

Two details worth knowing when reading it:

- Staleness is tracked with a hash of `pnpm-lock.yaml`, not mtimes. A cloud session restores `node_modules` from the environment cache and then clones the repo on top, which leaves the lockfile newer than `node_modules` every time and would reinstall on every session start.
- A new worktree seeds `.env` from the main worktree instead of generating fresh secrets. `docker-compose.dev.yml` binds fixed host ports, so every worktree on a machine shares one Postgres, and a new `ENCRYPTION_KEY` cannot decrypt rows written under the previous one.

**2. `.claude/*` was ignored, which hid everything meant to be shared.**

The rule dates from #8467, where it was narrowed from a blanket `.claude/` to allow one committed symlink. Its purpose was to stop the robots installer's machine-local assets from being committed. The side effect is that `settings.json`, repo-specific skills, subagents and commands were all ignored too — and `git add` skips ignored paths silently, so adding one appeared to work and simply did nothing. Anthropic's guidance is the opposite: `.claude/settings.json` is "checked into source control and shared with your team", and only `.claude/settings.local.json` is "not checked in".

Since company-wide skills are moving to the `formbricks/skills` marketplace rather than being installed into `.claude/`, the deny-by-default rule no longer protects anything, so this inverts it: ignore only `settings.local.json`.

**Consequence for robots:** installing shared skills into `.claude/` is superseded by the marketplace and should stop — a repo that both commits `.claude/` and has a tool writing machine-local files into it will leak those files into `git status` and eventually into a commit. Two parts deliberately stay: `.agents/skills/` remains committed and symlinked because `.codex/skills/` reads the same source, and `.agents/formbricks-context` remains ignored as a machine-local install. `AGENTS.md` § "Agent setup (robots)" still describes the old arrangement and needs a follow-up once `formbricks/skills` is live.

## Linear ticket

No ticket — developer-tooling change that came out of setting up the cloud environment for this repo.

## How this was tested

Measured in a clean-room `git worktree` with no `.env`, no `node_modules`, and no built packages, plus a cloud session for the docker path.

- Hook, cold worktree: prepared in **7.7s**, exit 0 — seeded `.env` from the main worktree, installed dependencies, built workspace packages. Warm re-run: **0.08s**.
- `pnpm exec vitest run lib/crypto.test.ts` in that worktree: **37 passed**. The same test fails on `main` with `Failed to resolve entry for package "@formbricks/logger"`, which is what the build step fixes.
- `pnpm exec eslint lib/crypto.ts` in that worktree: clean, exit 0.
- `pnpm install --frozen-lockfile --prefer-offline` on a prepared checkout: `Already up to date`, 450ms — confirms the marker skips redundant installs.
- Lockfile-hash marker: install runs when the marker is absent, skips when it matches.
- `dockerd` in a cloud session: not running before the hook (as predicted by the cache-snapshot behavior), started in ~1s by the hook. Confirmed live on a `SessionStart:resume` in this session.
- `git check-ignore` after the ignore change: `settings.local.json` ignored; `settings.json`, `agents/`, `commands/`, `rules/`, `skills/` all committable; `.agents/formbricks-context` still ignored. `git status` shows no newly untracked files.

No product code is touched, so `pnpm test` in full was not run for this diff.

## Breaking changes

None — developer tooling only. No API, schema, env var or runtime behavior changes.

Worth flagging for reviewers rather than as a breaking change: after this merges, anything that writes machine-local files into `.claude/` will start showing up in `git status`.

## QA / Test Plan

**How to test**

This PR has no product surface — it changes only how a developer's Claude Code session prepares a checkout. There is nothing to exercise in the running app or the API, so it is not release-QA relevant. Verification is developer-side and covered under "How this was tested".

**Preconditions / test data**

- None. Requires no account, seed data, feature flag or plan entitlement.

**Risks & regressions**

- Session startup adds ~8s on a cold checkout and ~0.1s on a prepared one, because the hook runs synchronously.
- The hook never exits non-zero and logs failures instead, so a broken checkout still yields a usable session.
- `.claude/` contents are now visible to git; a stale robots install in that directory would appear as untracked files.

**Migrations / env / cutover**

- none

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JTnk843QTLFhaUkFotkFea

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTnk843QTLFhaUkFotkFea)_