### PR TITLE
fix(surveys): require draft-to-draft for skip-validation survey updates

### DIFF
--- a/apps/web/lib/survey/service.scheduling.test.ts
+++ b/apps/web/lib/survey/service.scheduling.test.ts
@@ -82,13 +82,15 @@ describe("survey service scheduling", () => {
       status: "inProgress",
     } as never);
 
+    // Publishing runs through updateSurveyAction -> updateSurvey, i.e. with validation. Leaving a
+    // draft is never allowed on the skip-validation path (ENG-2115).
     await updateSurveyInternal(
       {
         ...updateSurveyInput,
         publishOn: scheduledPublishSelection,
         status: "inProgress",
       },
-      true
+      false
     );
 
     expect(prisma.survey.update).toHaveBeenCalledWith(
@@ -153,6 +155,8 @@ describe("survey service scheduling", () => {
     } as never);
     prisma.survey.findMany.mockResolvedValueOnce([] as never).mockResolvedValueOnce([] as never);
 
+    // Scheduling a draft also runs through updateSurveyAction -> updateSurvey, i.e. with validation
+    // (ENG-2115: the skip-validation path may not move a survey out of draft).
     await updateSurveyInternal(
       {
         ...updateSurveyInput,
@@ -160,7 +164,7 @@ describe("survey service scheduling", () => {
         publishOn: scheduledPublishSelection,
         status: "paused",
       },
-      true
+      false
     );
 
     expect(prisma.survey.update).toHaveBeenCalledWith(

--- a/apps/web/lib/survey/service.test.ts
+++ b/apps/web/lib/survey/service.test.ts
@@ -482,8 +482,9 @@ describe("Tests for updateSurvey", () => {
     // ENG-1749/ENG-1920: the app-survey segment block connects segment.surveys by id; a survey from
     // another workspace must not be connectable (would re-point that survey's targeting).
     test("rejects connecting a survey from another workspace to the segment (app survey update)", async () => {
-      // Draft row: this exercises the skip-validation path, which the ENG-1939 guard restricts to
-      // drafts. The cross-workspace segment check under test is unaffected by the status.
+      // Draft row and draft payload: this exercises the skip-validation path, which the
+      // ENG-1939/ENG-2115 guard restricts to draft-to-draft writes. The cross-workspace segment check
+      // under test is unaffected by the status.
       prisma.survey.findUnique.mockResolvedValueOnce({ ...mockSurveyOutput, status: "draft" }); // getSurvey → current survey (own workspace)
       prisma.segment.findUnique.mockResolvedValueOnce({
         workspaceId: updateSurveyInput.workspaceId,
@@ -496,6 +497,7 @@ describe("Tests for updateSurvey", () => {
         updateSurveyInternal(
           {
             ...updateSurveyInput,
+            status: "draft",
             type: "app",
             segment: {
               id: "clownsegment000000000001",
@@ -1403,6 +1405,7 @@ describe("updateSurveyDraftAction", () => {
       // Create a survey with incomplete i18n/fields
       const incompleteSurvey = {
         ...updateSurveyInput,
+        status: "draft",
         questions: [
           {
             id: "q1",
@@ -1424,6 +1427,7 @@ describe("updateSurveyDraftAction", () => {
 
       const surveyWithInvalidImage = {
         ...updateSurveyInput,
+        status: "draft",
         questions: [
           {
             id: "q1",
@@ -1464,13 +1468,29 @@ describe("updateSurveyDraftAction", () => {
 
     // ENG-1939: the lenient draft schema does not validate elements, so skipping validation on an
     // already-published survey would let structurally invalid blocks reach the DB and silently
-    // revert the survey to draft. Gate on the PERSISTED status, not the payload's.
+    // revert the survey to draft. Gate on the PERSISTED status. The payload stays a draft here so
+    // the case isolates the persisted-status half of the guard.
     test.each(["inProgress", "paused", "completed"] as const)(
       "rejects a skip-validation update when the stored survey is %s",
       async (status) => {
         prisma.survey.findUnique.mockResolvedValue({ ...mockSurveyOutput, status });
 
-        await expect(updateSurveyInternal(updateSurveyInput as TSurvey, true)).rejects.toThrow(
+        await expect(
+          updateSurveyInternal({ ...updateSurveyInput, status: "draft" } as TSurvey, true)
+        ).rejects.toThrow(OperationNotAllowedError);
+        expect(prisma.survey.update).not.toHaveBeenCalled();
+      }
+    );
+
+    // ENG-2115: the mirror image of the case above. `status` flows straight through to the write, so
+    // a persisted draft could otherwise be published (or paused/completed) through the skip-validation
+    // path with blocks that never passed ZSurvey. Both sides of the transition must be a draft.
+    test.each(["inProgress", "paused", "completed"] as const)(
+      "rejects a skip-validation update that moves a stored draft to %s",
+      async (status) => {
+        prisma.survey.findUnique.mockResolvedValue(mockDraftSurveyOutput);
+
+        await expect(updateSurveyInternal({ ...updateSurveyInput, status } as TSurvey, true)).rejects.toThrow(
           OperationNotAllowedError
         );
         expect(prisma.survey.update).not.toHaveBeenCalled();

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -340,13 +340,17 @@ export const updateSurveyInternal = async (
     // tenant's language. Mirrors the create path guard (covers drafts too — runs before validation).
     await assertSurveyLanguagesBelongToWorkspace(currentSurvey.workspaceId, languages);
 
-    // ENG-1939: validation may only be skipped while the survey is still a draft. Gate on the
-    // PERSISTED status, not the payload's — the lenient draft schema (ZSurveyDraft) does not validate
-    // elements at all, so without this a caller could push structurally invalid blocks onto a live
-    // survey (crashing downstream consumers that trust the schema) and silently revert it to draft,
-    // stopping it from collecting responses. Deliberately placed after the ENG-1749 tenant guards so
-    // a cross-workspace attempt still reports the authorization failure first.
-    if (skipValidation && currentSurvey.status !== "draft") {
+    // ENG-1939/ENG-2115: validation may only be skipped for a draft-to-draft write, so BOTH sides of
+    // the transition are gated. The lenient draft schema (ZSurveyDraft) does not validate elements at
+    // all, so skipping validation on any other transition lets structurally invalid blocks reach the
+    // DB and crash downstream consumers that trust the schema:
+    //   - persisted status (ENG-1939): stops a caller pushing invalid blocks onto a live survey and
+    //     silently reverting it to draft, stopping it from collecting responses.
+    //   - payload status (ENG-2115): stops a caller publishing a draft that never passed ZSurvey.
+    //     `status` is not destructured out of surveyData below, so it flows straight to the write.
+    // Deliberately placed after the ENG-1749 tenant guards so a cross-workspace attempt still reports
+    // the authorization failure first, and before prisma.survey.update so nothing is persisted.
+    if (skipValidation && (currentSurvey.status !== "draft" || updatedSurvey.status !== "draft")) {
       throw new OperationNotAllowedError("Only draft surveys can be updated without validation");
     }
 


### PR DESCRIPTION
## What & why

`updateSurveyInternal` gated its `skipValidation` path on the **persisted** status only:

```ts
if (skipValidation && currentSurvey.status !== "draft") { … }
```

ENG-1939 (#8600) added that to stop a caller pushing structurally invalid blocks onto a **live** survey. It closes that direction but not the other one: when the persisted survey *is* a draft, the payload's own `status` was never checked, and `status` is not among the keys destructured out of `surveyData` (`triggers`, `segment`, `questions`, `languages`, `type`, `followUps`, `workspaceId`, `id`, `archivedAt`), so it flowed straight through to `prisma.survey.update`. A survey could therefore be written as live with blocks that never passed `ZSurvey`, and start collecting responses.

This gates **both** sides of the transition — skip-validation is only ever a draft-to-draft write — and still rejects before the write:

```ts
if (skipValidation && (currentSurvey.status !== "draft" || updatedSurvey.status !== "draft")) { … }
```

The guard stays after the ENG-1749 tenant checks so a cross-workspace attempt still reports the authorization failure first.

**One correction to the ticket's severity.** The reachable exploit it describes — posting `status: "inProgress"` at `updateSurveyDraftAction` — is already blocked one layer up: `ZSurveyDraft` pins `status: z.literal("draft")` (`apps/web/modules/survey/editor/types/survey.ts:13`), so that payload fails input validation before reaching the service. I could not find a currently-reachable path that exploits this. The service-layer hole is real but latent: `updateSurveyDraft` is exported from `apps/web/lib/survey/service.ts` with no schema in front of it, and `updateSurveyInternal(survey, true)` is a general-purpose entry point, so the invariant belongs here rather than resting on one caller's schema. Treating this as hardening rather than a live vulnerability.

I also checked the scheduling path as a possible second door and it is closed: the `publish` transition only promotes surveys whose current status is `paused` (`getTransitionConfig`), so a draft with a due `publishOn` is never auto-published.

## Linear ticket

Fixes ENG-2115

## How this was tested

- `npx vitest run lib/survey modules/survey app/api/v3/surveys` → **98 files, 1479 tests passed** ✅
- `npx tsc --noEmit --project tsconfig.typecheck.json` (after `pnpm typegen`) → **clean, exit 0** ✅
- `npx eslint` on the three touched files → **clean, exit 0** ✅
- `npx prettier --check` on the three touched files → **clean** ✅

Tests added/updated in `apps/web/lib/survey/service.test.ts`:

- **New:** `test.each(["inProgress","paused","completed"])` — "rejects a skip-validation update that moves a stored draft to %s", asserting `OperationNotAllowedError` **and** `expect(prisma.survey.update).not.toHaveBeenCalled()`, so the rejection is proven to land before the DB write.
- **Tightened:** the existing ENG-1939 `test.each` now sends a `draft` payload, so it isolates the persisted-status half of the guard instead of tripping both conditions at once.
- **Fixed fixture status:** the two draft-save happy-path cases and the cross-workspace segment case spread `updateSurveyInput`, whose status is `inProgress`; they now carry `status: "draft"`, which is what those tests always meant to exercise.

Two tests in `service.scheduling.test.ts` ("manual publish clears publishOn", "scheduling from draft keeps closeOn when publishOn is set") drove `draft → inProgress` / `draft → paused` with `skipValidation=true`. That flag did not match production: publishing and scheduling both run through `updateSurveyAction → updateSurvey`, i.e. **with** validation. They now pass `false`, which is the path the editor actually takes; their scheduling-normalization assertions are unchanged and still pass.

No E2E test added. This is a server-side guard with no UI surface, and per `AGENTS.md` ("Pure logic or edge cases: unit test") unit coverage is the right level — the editor cannot produce this payload, and the action-layer schema rejects it before the service is reached, so a browser test could not exercise the guard.

## Breaking changes

None

## QA / Test Plan

**How to test**

The guard is not reachable from the UI by design, so the QA value here is confirming the surrounding flows still work rather than reproducing the exploit.

- [ ] Create a new survey → it opens in the editor as a draft. Edit a question, wait ~10s for auto-save (or click **Save**) → "Changes saved" toast, no error. Reload → edits persisted.
- [ ] Save a *deliberately incomplete* draft (e.g. a question with an empty headline) → saving still succeeds; drafts are allowed to be incomplete.
- [ ] With that draft open, click **Publish** → survey goes live and appears as In progress on the summary page. Publishing an incomplete survey should still be blocked by the normal validation message (unchanged behavior).
- [ ] Schedule a draft instead of publishing: set a future publish date → survey saves as scheduled/paused with the date shown, no error.
- [ ] On a live survey, use the summary status dropdown to Pause → Complete → resume. Each transition succeeds.
- [ ] Open an archived survey and attempt to edit → still rejected with the existing "This survey is archived. Restore it before editing." message (guard ordering unchanged).

**Preconditions / test data**

- Any workspace where the account has edit rights on surveys (owner/manager, or workspace team `readWrite`). No feature flags, plan, or env changes. Cloud and self-host behave identically.

**Risks & regressions**

- The blast radius is every write through `updateSurveyInternal`: editor draft auto-save and manual save, publish, schedule, the summary status dropdown, and archive/restore. Draft auto-save and publish are the two worth re-checking most closely — a regression would show as a save silently failing or a 403 "Only draft surveys can be updated without validation" surfacing in the editor.
- A 403 with that message during ordinary editing would be the signal that the guard is too tight; it should never appear from the UI.

**Migrations / env / cutover**

- none


---
_Generated by [Claude Code](https://claude.ai/code/session_01R8jAZ5KXJsv6wgu86YX1mb)_