### PR TITLE
refactor(ui): unify table primitive defaults

### DIFF
--- a/apps/web/app/(app)/account/settings/authorized-apps/page.tsx
+++ b/apps/web/app/(app)/account/settings/authorized-apps/page.tsx
@@ -89,7 +89,7 @@ const Page = async () => {
                 const clientHost = getHostFromUrl(client?.client_uri);
 
                 return (
-                  <TableRow key={consent.id}>
+                  <TableRow key={consent.id} className="hover:bg-slate-100">
                     <TableCell>
                       <div className="space-y-1">
                         <p className="font-medium text-slate-900">{clientName}</p>

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/domain/components/pretty-urls-table.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/domain/components/pretty-urls-table.tsx
@@ -47,22 +47,20 @@ export const PrettyUrlsTable = ({ surveys }: PrettyUrlsTableProps) => {
         <TableHeader>
           <TableRow className="bg-slate-100">
             {tableHeaders.map((header) => (
-              <TableHead key={header.key} className="font-medium text-slate-500">
-                {header.label}
-              </TableHead>
+              <TableHead key={header.key}>{header.label}</TableHead>
             ))}
           </TableRow>
         </TableHeader>
         <TableBody className="[&_tr:last-child]:border-b">
           {surveys.length === 0 && (
-            <TableRow className="hover:bg-transparent">
+            <TableRow>
               <TableCell colSpan={3} className="text-center text-slate-500">
                 {t("workspace.settings.domain.no_pretty_urls")}
               </TableCell>
             </TableRow>
           )}
           {surveys.map((survey) => (
-            <TableRow key={survey.id} className="border-slate-200 hover:bg-transparent">
+            <TableRow key={survey.id}>
               <TableCell className="font-medium">
                 <Link
                   href={`/workspaces/${survey.workspace.id}/surveys/${survey.id}/summary`}

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/domain/components/pretty-urls-table.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/domain/components/pretty-urls-table.tsx
@@ -47,7 +47,9 @@ export const PrettyUrlsTable = ({ surveys }: PrettyUrlsTableProps) => {
         <TableHeader>
           <TableRow className="bg-slate-100">
             {tableHeaders.map((header) => (
-              <TableHead key={header.key}>{header.label}</TableHead>
+              <TableHead key={header.key} className="font-medium text-slate-500">
+                {header.label}
+              </TableHead>
             ))}
           </TableRow>
         </TableHeader>

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/components/EnterpriseLicenseFeaturesTable.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/components/EnterpriseLicenseFeaturesTable.tsx
@@ -113,7 +113,7 @@ export const EnterpriseLicenseFeaturesTable = ({ features }: EnterpriseLicenseFe
       noPadding>
       <Table>
         <TableHeader>
-          <TableRow className="hover:bg-white">
+          <TableRow>
             <TableHead>{t("workspace.settings.enterprise.license_features_table_feature")}</TableHead>
             <TableHead>{t("workspace.settings.enterprise.license_features_table_access")}</TableHead>
             <TableHead>{t("workspace.settings.enterprise.license_features_table_value")}</TableHead>
@@ -133,7 +133,7 @@ export const EnterpriseLicenseFeaturesTable = ({ features }: EnterpriseLicenseFe
             }
 
             return (
-              <TableRow key={feature.key} className="hover:bg-white">
+              <TableRow key={feature.key}>
                 <TableCell className="font-medium text-slate-900">{t(feature.labelKey)}</TableCell>
                 <TableCell>
                   <Badge

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTable.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTable.tsx
@@ -250,7 +250,7 @@ export const ResponseTable = ({
         <div className="w-fit max-w-full overflow-hidden overflow-x-auto rounded-xl border border-slate-200">
           <div className="w-full overflow-x-auto">
             <Table className="w-full" style={{ tableLayout: "fixed" }} id="response-table">
-              <TableHeader className="pointer-events-auto">
+              <TableHeader>
                 {table.getHeaderGroups().map((headerGroup) => (
                   <TableRow key={headerGroup.id}>
                     <SortableContext items={columnOrder} strategy={horizontalListSortingStrategy}>

--- a/apps/web/modules/ee/contacts/attributes/components/attributes-table.tsx
+++ b/apps/web/modules/ee/contacts/attributes/components/attributes-table.tsx
@@ -254,7 +254,7 @@ export const AttributesTable = ({
         />
         <div className="w-full overflow-x-auto rounded-xl border border-slate-200">
           <Table className="w-full" style={{ tableLayout: "fixed" }}>
-            <TableHeader className="pointer-events-auto">
+            <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id}>
                   <SortableContext items={columnOrder} strategy={horizontalListSortingStrategy}>

--- a/apps/web/modules/ee/contacts/components/contacts-table.tsx
+++ b/apps/web/modules/ee/contacts/components/contacts-table.tsx
@@ -258,7 +258,7 @@ export const ContactsTable = ({
         />
         <div className="w-full overflow-x-auto rounded-xl border border-slate-200">
           <Table className="w-full" style={{ tableLayout: "fixed" }}>
-            <TableHeader className="pointer-events-auto">
+            <TableHeader>
               {table.getHeaderGroups().map((headerGroup) => (
                 <TableRow key={headerGroup.id}>
                   <SortableContext items={columnOrder} strategy={horizontalListSortingStrategy}>
@@ -302,7 +302,7 @@ export const ContactsTable = ({
                 </TableRow>
               ))}
               {table.getRowModel().rows.length === 0 && (
-                <TableRow className="hover:bg-white">
+                <TableRow>
                   <TableCell colSpan={columns.length} className="h-24 text-center">
                     <p className="text-slate-400">{t("common.no_results")}</p>
                   </TableCell>

--- a/apps/web/modules/ee/contacts/segments/components/segment-table.tsx
+++ b/apps/web/modules/ee/contacts/segments/components/segment-table.tsx
@@ -124,7 +124,7 @@ export function SegmentTable({
                 );
               })
             ) : (
-              <TableRow className="hover:bg-white">
+              <TableRow>
                 <TableCell colSpan={columns.length} className="h-24 rounded-b-lg text-center">
                   <p className="text-slate-400">{t("workspace.segments.create_your_first_segment")}</p>
                 </TableCell>

--- a/apps/web/modules/ee/feedback-directory/components/feedback-directory-table.tsx
+++ b/apps/web/modules/ee/feedback-directory/components/feedback-directory-table.tsx
@@ -143,9 +143,11 @@ export const FeedbackDirectoryTable = ({
         <Table>
           <TableHeader role="rowgroup">
             <TableRow className="bg-slate-100" role="row">
-              <TableHead>{t("workspace.settings.feedback_directories.directory_name")}</TableHead>
-              <TableHead>{t("common.workspaces")}</TableHead>
-              <TableHead>{t("common.status")}</TableHead>
+              <TableHead className="font-medium text-slate-500">
+                {t("workspace.settings.feedback_directories.directory_name")}
+              </TableHead>
+              <TableHead className="font-medium text-slate-500">{t("common.workspaces")}</TableHead>
+              <TableHead className="font-medium text-slate-500">{t("common.status")}</TableHead>
               <TableHead></TableHead>
             </TableRow>
           </TableHeader>

--- a/apps/web/modules/ee/feedback-directory/components/feedback-directory-table.tsx
+++ b/apps/web/modules/ee/feedback-directory/components/feedback-directory-table.tsx
@@ -143,24 +143,22 @@ export const FeedbackDirectoryTable = ({
         <Table>
           <TableHeader role="rowgroup">
             <TableRow className="bg-slate-100" role="row">
-              <TableHead className="font-medium text-slate-500">
-                {t("workspace.settings.feedback_directories.directory_name")}
-              </TableHead>
-              <TableHead className="font-medium text-slate-500">{t("common.workspaces")}</TableHead>
-              <TableHead className="font-medium text-slate-500">{t("common.status")}</TableHead>
+              <TableHead>{t("workspace.settings.feedback_directories.directory_name")}</TableHead>
+              <TableHead>{t("common.workspaces")}</TableHead>
+              <TableHead>{t("common.status")}</TableHead>
               <TableHead></TableHead>
             </TableRow>
           </TableHeader>
           <TableBody className="[&_tr:last-child]:border-b">
             {filteredDirectories.length === 0 && (
               <TableRow>
-                <TableCell colSpan={4} className="text-center hover:bg-transparent">
+                <TableCell colSpan={4} className="text-center">
                   {t("workspace.settings.feedback_directories.empty_state")}
                 </TableCell>
               </TableRow>
             )}
             {filteredDirectories.map((directory) => (
-              <TableRow key={directory.id} className="hover:bg-transparent">
+              <TableRow key={directory.id}>
                 <TableCell>{directory.name}</TableCell>
                 <TableCell>{directory.workspaceCount}</TableCell>
                 <TableCell>

--- a/apps/web/modules/ee/teams/team-list/components/teams-table.tsx
+++ b/apps/web/modules/ee/teams/team-list/components/teams-table.tsx
@@ -78,8 +78,10 @@ export const TeamsTable = ({
         <Table>
           <TableHeader role="rowgroup">
             <TableRow className="bg-slate-100" role="row">
-              <TableHead>{t("workspace.settings.teams.team_name")}</TableHead>
-              <TableHead>{t("common.size")}</TableHead>
+              <TableHead className="font-medium text-slate-500">
+                {t("workspace.settings.teams.team_name")}
+              </TableHead>
+              <TableHead className="font-medium text-slate-500">{t("common.size")}</TableHead>
               <TableHead></TableHead>
               <TableHead></TableHead>
             </TableRow>

--- a/apps/web/modules/ee/teams/team-list/components/teams-table.tsx
+++ b/apps/web/modules/ee/teams/team-list/components/teams-table.tsx
@@ -78,10 +78,8 @@ export const TeamsTable = ({
         <Table>
           <TableHeader role="rowgroup">
             <TableRow className="bg-slate-100" role="row">
-              <TableHead className="font-medium text-slate-500">
-                {t("workspace.settings.teams.team_name")}
-              </TableHead>
-              <TableHead className="font-medium text-slate-500">{t("common.size")}</TableHead>
+              <TableHead>{t("workspace.settings.teams.team_name")}</TableHead>
+              <TableHead>{t("common.size")}</TableHead>
               <TableHead></TableHead>
               <TableHead></TableHead>
             </TableRow>
@@ -89,13 +87,13 @@ export const TeamsTable = ({
           <TableBody className="[&_tr:last-child]:border-b">
             {allTeams.length === 0 && (
               <TableRow>
-                <TableCell colSpan={4} className="text-center hover:bg-transparent">
+                <TableCell colSpan={4} className="text-center">
                   {t("workspace.settings.teams.empty_teams_state")}
                 </TableCell>
               </TableRow>
             )}
             {userTeams.map((team) => (
-              <TableRow key={team.id} id={team.name} className="hover:bg-transparent">
+              <TableRow key={team.id} id={team.name}>
                 <TableCell>{team.name}</TableCell>
                 <TableCell>{t("common.count_members", { count: team.memberCount })}</TableCell>
                 <TableCell>
@@ -112,7 +110,7 @@ export const TeamsTable = ({
               </TableRow>
             ))}
             {otherTeams.map((team) => (
-              <TableRow key={team.id} id={team.name} className="hover:bg-transparent">
+              <TableRow key={team.id} id={team.name}>
                 <TableCell>{team.name}</TableCell>
                 <TableCell>{t("common.count_members", { count: team.memberCount })}</TableCell>
                 <TableCell></TableCell>

--- a/apps/web/modules/ee/teams/workspace-teams/components/access-table.tsx
+++ b/apps/web/modules/ee/teams/workspace-teams/components/access-table.tsx
@@ -18,22 +18,22 @@ export const AccessTable = ({ teams }: AccessTableProps) => {
       <Table>
         <TableHeader>
           <TableRow className="bg-slate-100">
-            <TableHead className="font-medium text-slate-500">{t("workspace.teams.team_name")}</TableHead>
-            <TableHead className="font-medium text-slate-500">{t("common.size")}</TableHead>
-            <TableHead className="font-medium text-slate-500">{t("common.team_id")}</TableHead>
-            <TableHead className="font-medium text-slate-500">{t("workspace.teams.permission")}</TableHead>
+            <TableHead>{t("workspace.teams.team_name")}</TableHead>
+            <TableHead>{t("common.size")}</TableHead>
+            <TableHead>{t("common.team_id")}</TableHead>
+            <TableHead>{t("workspace.teams.permission")}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody className="[&_tr:last-child]:border-b">
           {teams.length === 0 && (
-            <TableRow className="hover:bg-transparent">
+            <TableRow>
               <TableCell colSpan={4} className="text-center">
                 {t("workspace.teams.no_teams_found")}
               </TableCell>
             </TableRow>
           )}
           {teams.map((team) => (
-            <TableRow key={team.id} className="border-slate-200 hover:bg-transparent">
+            <TableRow key={team.id}>
               <TableCell className="font-medium">{team.name}</TableCell>
               <TableCell>{t("common.count_members", { count: team.memberCount })}</TableCell>
               <TableCell>

--- a/apps/web/modules/ee/teams/workspace-teams/components/access-table.tsx
+++ b/apps/web/modules/ee/teams/workspace-teams/components/access-table.tsx
@@ -18,10 +18,10 @@ export const AccessTable = ({ teams }: AccessTableProps) => {
       <Table>
         <TableHeader>
           <TableRow className="bg-slate-100">
-            <TableHead>{t("workspace.teams.team_name")}</TableHead>
-            <TableHead>{t("common.size")}</TableHead>
-            <TableHead>{t("common.team_id")}</TableHead>
-            <TableHead>{t("workspace.teams.permission")}</TableHead>
+            <TableHead className="font-medium text-slate-500">{t("workspace.teams.team_name")}</TableHead>
+            <TableHead className="font-medium text-slate-500">{t("common.size")}</TableHead>
+            <TableHead className="font-medium text-slate-500">{t("common.team_id")}</TableHead>
+            <TableHead className="font-medium text-slate-500">{t("workspace.teams.permission")}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody className="[&_tr:last-child]:border-b">

--- a/apps/web/modules/ee/workflows/components/runs/workflow-runs-table.tsx
+++ b/apps/web/modules/ee/workflows/components/runs/workflow-runs-table.tsx
@@ -92,7 +92,7 @@ export const WorkflowRunsTable = ({
                       setSelectedRunId(run.id);
                     }
                   }}
-                  className="cursor-pointer focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:outline-hidden">
+                  className="cursor-pointer hover:bg-slate-100 focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:outline-hidden">
                   <TableCell className="min-w-0 px-4 py-2">
                     {showWorkflowColumn ? (
                       <>
@@ -116,7 +116,7 @@ export const WorkflowRunsTable = ({
               );
             })}
             {runs.length === 0 && (
-              <TableRow className="hover:bg-white">
+              <TableRow>
                 <TableCell colSpan={4} className="h-24 text-center">
                   <p className="text-slate-400">{t("common.no_results")}</p>
                 </TableCell>

--- a/apps/web/modules/ui/components/table/index.tsx
+++ b/apps/web/modules/ui/components/table/index.tsx
@@ -1,26 +1,30 @@
 import * as React from "react";
 import { cn } from "@/lib/cn";
 
-const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
-  ({ className, ...props }, ref) => (
-    <div className="relative overflow-auto">
-      <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
-    </div>
-  )
-);
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement> & {
+    /** Classes for the scroll container wrapping the table — this is where a frame belongs. */
+    containerClassName?: string;
+  }
+>(({ className, containerClassName, ...props }, ref) => (
+  <div className={cn("relative overflow-auto", containerClassName)}>
+    <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+  </div>
+));
 Table.displayName = "Table";
 
 const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
   ({ className, ...props }, ref) => (
-    <thead
-      ref={ref}
-      className={cn("pointer-events-none text-slate-800 [&_tr]:border-b", className)}
-      {...props}
-    />
+    <thead ref={ref} className={cn("text-slate-800 [&_tr]:border-b", className)} {...props} />
   )
 );
 TableHeader.displayName = "TableHeader";
 
+/**
+ * The last row never draws a bottom border — the surrounding frame closes the table. A consumer that
+ * re-adds `[&_tr:last-child]:border-b` is compensating for a missing frame; give it a frame instead.
+ */
 const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
   ({ className, ...props }, ref) => (
     <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
@@ -40,7 +44,7 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
     <tr
       ref={ref}
       className={cn(
-        "border-b bg-white transition-colors hover:bg-slate-100 data-[state=selected]:bg-slate-100",
+        "border-b border-slate-200 bg-white transition-colors data-[state=selected]:bg-slate-100",
         className
       )}
       {...props}
@@ -53,7 +57,10 @@ const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<
   ({ className, ...props }, ref) => (
     <th
       ref={ref}
-      className={cn("h-12 px-4 text-left align-middle has-[[role=checkbox]]:pr-0", className)}
+      className={cn(
+        "h-12 px-4 text-left align-middle font-medium text-slate-500 has-[[role=checkbox]]:pr-0",
+        className
+      )}
       {...props}
     />
   )

--- a/apps/web/modules/ui/components/table/index.tsx
+++ b/apps/web/modules/ui/components/table/index.tsx
@@ -1,17 +1,13 @@
 import * as React from "react";
 import { cn } from "@/lib/cn";
 
-const Table = React.forwardRef<
-  HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement> & {
-    /** Classes for the scroll container wrapping the table — this is where a frame belongs. */
-    containerClassName?: string;
-  }
->(({ className, containerClassName, ...props }, ref) => (
-  <div className={cn("relative overflow-auto", containerClassName)}>
-    <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
-  </div>
-));
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative overflow-auto">
+      <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+    </div>
+  )
+);
 Table.displayName = "Table";
 
 const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
@@ -22,8 +18,9 @@ const TableHeader = React.forwardRef<HTMLTableSectionElement, React.HTMLAttribut
 TableHeader.displayName = "TableHeader";
 
 /**
- * The last row never draws a bottom border — the surrounding frame closes the table. A consumer that
- * re-adds `[&_tr:last-child]:border-b` is compensating for a missing frame; give it a frame instead.
+ * The last row draws no bottom border, on the assumption that a frame around the table closes it.
+ * Several consumers re-add `[&_tr:last-child]:border-b` because their container has a radius but no
+ * border, so nothing else draws that line; they lose the override once they gain a real frame.
  */
 const TableBody = React.forwardRef<HTMLTableSectionElement, React.HTMLAttributes<HTMLTableSectionElement>>(
   ({ className, ...props }, ref) => (
@@ -57,10 +54,7 @@ const TableHead = React.forwardRef<HTMLTableCellElement, React.ThHTMLAttributes<
   ({ className, ...props }, ref) => (
     <th
       ref={ref}
-      className={cn(
-        "h-12 px-4 text-left align-middle font-medium text-slate-500 has-[[role=checkbox]]:pr-0",
-        className
-      )}
+      className={cn("h-12 px-4 text-left align-middle has-[[role=checkbox]]:pr-0", className)}
       {...props}
     />
   )


### PR DESCRIPTION
## What & why

First of a series unifying the settings tables (ENG-762). This one touches no layout and adds no
component — it fixes the shared `Table` primitive, whose defaults several consumers had to undo.

`apps/web/modules/ui/components/table/index.tsx`:

| Change | Why |
| --- | --- |
| `TableRow`: `border-b` → `border-b border-slate-200` | The bare `border-b` resolved to **gray-200** via the Tailwind v3 compat shim (`modules/ui/globals.css:206-212`), while every card frame paints **slate-200**. That mismatch is why two tables were adding `border-slate-200` by hand. |
| `TableRow` drops `hover:bg-slate-100` | 7 rows only ever set `hover:bg-transparent` to cancel it, 2 more set it on a `TableCell` where it was already a no-op, and 5 set `hover:bg-white`. |
| `TableHeader` drops `pointer-events-none` | 3 TanStack tables undid it so their drag/resize handles work. It also suppressed the header row's hover — which is why it ships in the same commit as the row-hover change, not separately. |
| `TableBody` comment | Documents why several consumers re-add `[&_tr:last-child]:border-b` and when they stop. No code change. |

Two files genuinely relied on the inherited hover and now ask for it explicitly:
`workflow-runs-table.tsx` and `account/settings/authorized-apps/page.tsx`.

Net: **19 override classes deleted, 2 added back.**

### Changed after review

Originally this PR also added `font-medium text-slate-500` to `TableHead` and deleted 10 copies of that
string. [@mattinannt caught](https://github.com/formbricks/formbricks/pull/8837#discussion_r3773694367)
that this was wrong: a class on the `th` beats the `text-slate-800` a `<thead>` passes down, so every
consumer that had merely *inherited* the darker colour would silently lighten. That is far wider than
this series — `data-table-header.tsx` sets no colour, so contacts, contact attributes and survey
responses were all affected, plus workflow runs, segments, authorized apps and `OpenTextSummary`.

Header typography is a *settings-table* concern, so it moved to `SettingsTable` in #8839. The four
settings tables keep their explicit classes here and shed them when they convert in #8839/#8841/#8842,
so the duplication still goes away — one PR later, and without touching anything outside the series.

`containerClassName` was dropped for the same reason it was flagged: with the frame living on
`SettingsTable`'s own wrapper, nothing passes it.

`TableBody` is deliberately unchanged. Its `[&_tr:last-child]:border-0` is correct under a frame, and
the four tables that undo it do so because three of them have no border on their container — that
last-row border is currently the only thing closing the table.

## Linear ticket

Ref ENG-762

## Screenshots

> **These are component renders, not app screenshots.** This environment has no Docker daemon and so no
> database to boot the app against. Each image is the real component markup rendered against the repo's
> own stylesheet (`apps/web/modules/ui/globals.css` compiled through `@tailwindcss/postcss`), with every
> class string passed through the same `tailwind-merge` the components use via `cn`. That makes the
> tokens exact — including the gray-200/slate-200 hairline this PR is about — but the data is fabricated
> and the surrounding page chrome is absent.

**These two should be indistinguishable, and that is the point.** After the review fix, the only visual
change this PR makes is the row hairline shifting from gray-200 (`#e5e7eb`) to slate-200 (`#e2e8f0`) —
sub-perceptual at normal zoom. The other two changes (row hover, header `pointer-events`) are hover-only
and cannot be captured in a static image at all.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8837/before-settings-tables.jpg?v=2" width="440"> | <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8837/after-settings-tables.jpg?v=2" width="440"> |

Two tables in each shot: **Team access**, which keeps its own `font-medium text-slate-500` headers, and
**License features**, whose header stays white with bold `<th>` text. If you can spot a difference in
header weight or colour between these two images, something is wrong — that change belongs to #8839 and
#8840, not here.

## How this was tested

- `npx turbo run typecheck --filter=@formbricks/web` → **33 errors, byte-identical to the count on
  clean `main`** (verified by stashing). All 33 come from `@formbricks/jobs` being unbuilt in my
  sandbox; **none are in any file this PR touches**.
- `npx eslint` over every changed file → **0 errors**, 2 pre-existing `react-hooks/exhaustive-deps`
  warnings in `contacts-table.tsx` / `attributes-table.tsx` that this PR does not introduce or touch.
- `prettier` via `lint-staged` on commit → clean.
- Audited **all 14 `Table` consumers individually** for each change, rather than relying on a grep. The
  two hover regressions that audit found are the two additions above. Verified the three TanStack tables
  are unaffected by the hover removal because their cells set `bg-white` plus `group-hover:bg-slate-100`,
  so the cell fill covers the row (`contacts-table.tsx:293`, `ResponseTableCell.tsx:49`,
  `attributes-table.tsx:314`).
- **After the review, re-checked the same 14 consumers for the colour-inheritance problem specifically**
  and confirmed the reviewer's list was complete: `workflow-runs-table.tsx:70-75` and
  `segment-table.tsx:79` set `bg-white font-semibold`, `data-table-header.tsx:43` sets `bg-white` with
  `font-semibold` on an inner div, and `authorized-apps/page.tsx:79-83` and `OpenTextSummary.tsx:55-58`
  are bare — none set a text colour.
- Rebased onto the current `main` after it advanced; the five PRs stacked on this one were rebased with
  it and the chain re-verified with `git merge-base --is-ancestor` at each link.
- No unit tests exist for any touched component, per the repo's rule that `.tsx` is covered by
  Playwright rather than component tests. No `.ts` logic changed, so no test was added.

**Still owed before merge:** a visual pass on a running app. The hairline change is the kind of thing a
render harness reproduces faithfully but a human should still glance at in context.

## Breaking changes

None

## QA / Test Plan

**How to test**

Nothing should move and no interaction should change. The point of the pass is to confirm that.

- [ ] Any table → the horizontal hairline between rows → it is now slate-200 and should match the colour
      of the surrounding card border rather than being very slightly warmer
- [ ] Org settings → Domain (pretty URLs), Enterprise, Feedback Directories; Workspace settings → Team
      Access; Org settings → Teams → hover each body row → **no** background change (these tables were
      never meant to have row hover)
- [ ] Same tables → header weight and colour are **unchanged from before this PR** → a lighter or
      heavier header here means the reverted typography change crept back in
- [ ] Account settings → Authorized apps → hover a row → row still highlights (this PR re-adds that
      hover explicitly; a row that no longer highlights is the regression)
- [ ] Workspace → a workflow → Runs tab → hover a run row → row still highlights, and clicking still
      opens the run detail
- [ ] Survey → Responses table → hover a row → row highlights as before; drag a column header to
      reorder and drag its right edge to resize → both still work (this PR removed
      `pointer-events-none` from the header)
- [ ] Contacts and Contacts → Attributes tables → same check: hover, row click, column reorder/resize
- [ ] Contacts → select a row via its checkbox → the selected-row background still applies

**Preconditions / test data**

- An org with at least 2 members, 1 team, 1 API key, 1 survey with a pretty URL, and a few responses
- Enterprise license active, to render the Enterprise and Feedback Directories tables
- At least one OAuth app authorized, for the Authorized apps table
- At least one workflow with a run, for the Runs table

**Risks & regressions**

- The three TanStack tables (responses, contacts, attributes) are the highest-traffic tables in the
  product and are **not** part of ENG-762's scope — they are touched only because they undid the
  primitive's defaults. Column reorder, column resize and row hover are the things to re-check there.
- Removing `pointer-events-none` from `TableHeader` makes header cells interactive again. Audited as
  safe, but a header that now shows an unexpected hover or captures a click is the failure mode.
- Losing row hover somewhere I did not catch. The audit says the only two cases are the ones fixed here;
  a third would show up as a data row that no longer highlights.

**Migrations / env / cutover**

- none
