### PR TITLE
refactor(ui): replace SettingsCard noPadding with bodyVariant

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/components/SettingsCard.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/components/SettingsCard.tsx
@@ -12,12 +12,28 @@ interface ButtonInfo {
   variant: "secondary" | "default" | "outline" | "ghost" | "link";
 }
 
+/**
+ * How the card treats its body:
+ * - `padded` — the default `px-4 pt-4` gutter, for ordinary form content.
+ * - `bleed` — no gutter; the child supplies its own padding.
+ * - `flush` — no gutter *and* no bottom padding, so edge-to-edge content (a table) meets the card's
+ *   bottom border. Pairs with `overflow-hidden` on the card, which clips the content with the card's
+ *   own inner radius — a `rounded-b-*` on the child would be off by the border width.
+ */
+export type TSettingsCardBodyVariant = "padded" | "bleed" | "flush";
+
+const BODY_VARIANT_CLASSES: Record<TSettingsCardBodyVariant, string> = {
+  padded: "px-4 pt-4",
+  bleed: "",
+  flush: "-mb-4",
+};
+
 export const SettingsCard = ({
   title,
   description,
   children,
   soon = false,
-  noPadding = false,
+  bodyVariant = "padded",
   beta,
   className,
   buttonInfo,
@@ -27,7 +43,7 @@ export const SettingsCard = ({
   description: string;
   children: any;
   soon?: boolean;
-  noPadding?: boolean;
+  bodyVariant?: TSettingsCardBodyVariant;
   beta?: boolean;
   className?: string;
   buttonInfo?: ButtonInfo;
@@ -38,6 +54,7 @@ export const SettingsCard = ({
     <div
       className={cn(
         "relative my-4 w-full max-w-4xl rounded-xl border border-slate-200 bg-white py-4 text-left shadow-xs",
+        bodyVariant === "flush" && "overflow-hidden",
         className
       )}
       id={title}>
@@ -61,7 +78,7 @@ export const SettingsCard = ({
             </Button>
           ))}
       </div>
-      <div className={cn(noPadding ? "" : "px-4 pt-4")}>{children}</div>
+      <div className={BODY_VARIANT_CLASSES[bodyVariant]}>{children}</div>
     </div>
   );
 };

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/components/EnterpriseLicenseFeaturesTable.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/components/EnterpriseLicenseFeaturesTable.tsx
@@ -110,7 +110,7 @@ export const EnterpriseLicenseFeaturesTable = ({ features }: EnterpriseLicenseFe
     <SettingsCard
       title={t("workspace.settings.enterprise.license_features_table_title")}
       description={t("workspace.settings.enterprise.license_features_table_description")}
-      noPadding>
+      bodyVariant="flush">
       <Table>
         <TableHeader>
           <TableRow>

--- a/apps/web/modules/ee/whitelabel/email-customization/components/email-customization-settings.tsx
+++ b/apps/web/modules/ee/whitelabel/email-customization/components/email-customization-settings.tsx
@@ -203,7 +203,7 @@ export const EmailCustomizationSettings = ({
       className="overflow-hidden pb-0"
       title={t("workspace.look.email_customization")}
       description={t("workspace.look.email_customization_description")}
-      noPadding>
+      bodyVariant="bleed">
       <div className="px-6 pt-6">
         {hasWhiteLabelPermission ? (
           <div className="flex items-end justify-between gap-4">

--- a/apps/web/modules/ee/whitelabel/remove-branding/components/branding-settings-card.tsx
+++ b/apps/web/modules/ee/whitelabel/remove-branding/components/branding-settings-card.tsx
@@ -69,7 +69,7 @@ export const BrandingSettingsCard = async ({
     <SettingsCard
       title={t("workspace.look.formbricks_branding")}
       description={t("workspace.look.formbricks_branding_settings_description")}
-      noPadding={showLiteLicenseTip}>
+      bodyVariant={showLiteLicenseTip ? "bleed" : "padded"}>
       {brandingContent}
       {isReadOnly && (
         <Alert variant="warning" className="mt-4" role="status">


### PR DESCRIPTION
## What & why

Second of the ENG-762 series. **Stacked on #8837 — review that one first; this PR's diff is only the
last commit.**

Every settings table renders inside `SettingsCard`, which is already a
`rounded-xl border border-slate-200 bg-white shadow-xs` frame. So a table that draws its own frame
produces a nested double border — which is what almost every settings table does today, and why the
`rounded-t-lg` on all seven grid-based table headers has never actually been visible.

`noPadding` was the escape hatch, but it only removed the gutter. The card's `py-4` survived it, so
edge-to-edge content still had 16px of white beneath it and its last row could never meet the card's
rounded bottom corner. `email-customization-settings.tsx` had already worked around this by hand with
`className="overflow-hidden pb-0"`.

`bodyVariant` names the three real cases instead of implying two:

| Variant | Body classes | For |
| --- | --- | --- |
| `padded` (default) | `px-4 pt-4` | ordinary form content |
| `bleed` | none | the child supplies its own padding — what the whitelabel cards actually wanted |
| `flush` | `-mb-4` + `overflow-hidden` on the card | edge-to-edge content that should meet the card's bottom border |

`flush` relies on `overflow-hidden` rather than a `rounded-b-xl` on the child, because the child's
radius would be off by the border width — the card's own radius clips at the correct *inner* curve.
That is also why this is a card-level change and not something each table does for itself.

`noPadding` had exactly 3 consumers, so it is replaced outright rather than kept as a deprecated alias.

## Linear ticket

Ref ENG-762

## Screenshots

> **These are component renders, not app screenshots.** No Docker daemon here, so no database to boot the
> app against. Real component markup, the repo's own compiled `globals.css`, and every class string put
> through the same `tailwind-merge` the components use — so spacing and tokens are exact, but the data is
> fabricated and page chrome is absent. **A real visual pass is still owed.**

The bottom edge of the card is the whole point of this PR. Look at the gap between the last row and the
card's border.

| Before — `noPadding` | After — `bodyVariant="flush"` |
| --- | --- |
| <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8838/before-card-bottom.jpg" width="440"> | <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8838/after-card-bottom.jpg" width="440"> |

Before: a 16px strip of white below the final row, and the row's fill stops short of the rounded corner.
After: the last row runs to the card's border and is clipped by the card's own radius, so there is one
line and one corner instead of a floating table inside a box.

## How this was tested

- `npx turbo run typecheck --filter=@formbricks/web` → **33 errors, the same count as clean `main`**
  (all from `@formbricks/jobs` being unbuilt in my sandbox); **none in any file this PR touches**. This
  matters more than usual here: the prop was renamed, so a missed call site would surface as a type
  error, and there are none.
- `grep -rn "noPadding" apps/web --include="*.tsx"` → **no matches**, confirming all 3 consumers were
  migrated and nothing references the old prop.
- `npx eslint` over the 4 changed files → clean, 0 warnings.
- `prettier` via `lint-staged` → clean.
- Two of the three migrations are intended to be **visually identical**:
  `email-customization-settings.tsx` keeps its own `overflow-hidden pb-0` and `px-6 pt-6`, and
  `branding-settings-card.tsx` maps `noPadding={showLiteLicenseTip}` to
  `bodyVariant={showLiteLicenseTip ? "bleed" : "padded"}`. Only the enterprise table intentionally
  changes.

**Still owed before merge:** a visual pass on a running app — particularly the two whitelabel cards,
which are supposed to be pixel-identical and which my renders don't cover.

## Breaking changes

None

<!-- `SettingsCard` is an internal app component, not a published API — the prop rename cannot affect
API consumers, SDK users or self-hosted configuration. All 3 call sites are migrated in this PR. -->

## QA / Test Plan

**How to test**

- [ ] Org settings → Enterprise → the "License features" table → its last row now meets the card's
      bottom border, with no strip of white between the final row and the card edge, and the corner is
      rounded cleanly → previously there was a 16px white gap below the table
- [ ] Same table → check the bottom-left and bottom-right corners closely → the row's background is
      clipped to the card's rounded corner, with no square corner poking out and no 1px sliver of
      border visible inside the curve
- [ ] Workspace settings → Look & feel → Email customization → the whole card → **unchanged** from
      before this PR: same padding around the logo and email preview, same bottom spacing
- [ ] Workspace settings → Look & feel → Formbricks branding → with an Enterprise license (no upgrade
      tip shown) → card body keeps its normal padding
- [ ] Same card → on a plan that shows the lite-license tip → the tip renders edge-to-edge exactly as
      before
- [ ] Any other settings page (Org → General, Workspace → General, Account → Profile) → cards keep
      their normal `px-4 pt-4` body padding → nothing shifted

**Preconditions / test data**

- Enterprise license active, to render Org → Enterprise and the whitelabel cards
- To exercise the branding card's second state, an instance/plan where the lite-license tip shows

**Risks & regressions**

- The rename is compile-checked, so a missed call site cannot ship silently.
- `overflow-hidden` is now applied to the card whenever `bodyVariant="flush"`. Only the enterprise
  table uses it, and that table has no dropdowns, tooltips or popovers to clip. Worth knowing for the
  follow-up PRs: the row kebab, tooltip and combobox primitives all portal to `document.body`
  (`dropdown-menu/index.tsx:72`, `tooltip/index.tsx:21`, `popover/index.tsx:16`), so they escape the
  clip — anything added later that does not portal would be clipped.
- `-mb-4` cancels the card's `pb-4`. A `flush` card whose child is *not* edge-to-edge would look
  cramped at the bottom; that is why the variant is opt-in and named.

**Migrations / env / cutover**

- none
