### PR TITLE
feat(ui): add settings table primitive

### DIFF
--- a/apps/web/app/(app)/organizations/[organizationId]/settings/domain/page.tsx
+++ b/apps/web/app/(app)/organizations/[organizationId]/settings/domain/page.tsx
@@ -58,7 +58,8 @@ const Page = async (props: Readonly<{ params: Promise<{ organizationId: string }
 
       <SettingsCard
         title={t("workspace.settings.domain.title")}
-        description={t("workspace.settings.domain.description")}>
+        description={t("workspace.settings.domain.description")}
+        bodyVariant="flush">
         <PrettyUrlsTable surveys={surveys} />
       </SettingsCard>
     </PageContentWrapper>

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/domain/components/pretty-urls-table.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/domain/components/pretty-urls-table.tsx
@@ -28,7 +28,7 @@ export const getPrettyUrlColumns = (t: TFunction): TSettingsTableColumn<SurveyWi
   {
     id: "name",
     header: t("workspace.settings.domain.survey_name"),
-    width: "w-[40%]",
+    headerClassName: "w-[40%]",
     cellClassName: "font-medium",
     cell: (survey) => (
       <Link
@@ -41,13 +41,13 @@ export const getPrettyUrlColumns = (t: TFunction): TSettingsTableColumn<SurveyWi
   {
     id: "workspace",
     header: t("workspace.settings.domain.workspace"),
-    width: "w-[30%]",
+    headerClassName: "w-[30%]",
     cell: (survey) => survey.workspace.name,
   },
   {
     id: "slug",
     header: t("workspace.settings.domain.pretty_url"),
-    width: "w-[30%]",
+    headerClassName: "w-[30%]",
     cell: (survey) => <IdBadge id={survey.slug ?? ""} />,
   },
 ];

--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/domain/components/pretty-urls-table.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/domain/components/pretty-urls-table.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import type { TFunction } from "i18next";
 import Link from "next/link";
 import { useTranslation } from "react-i18next";
 import { TSurveyStatus } from "@formbricks/types/surveys/types";
 import { IdBadge } from "@/modules/ui/components/id-badge";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/modules/ui/components/table";
+import { SettingsTable, type TSettingsTableColumn } from "@/modules/ui/components/settings-table";
 
 interface SurveyWithSlug {
   id: string;
@@ -23,61 +24,43 @@ interface PrettyUrlsTableProps {
   surveys: SurveyWithSlug[];
 }
 
-export const PrettyUrlsTable = ({ surveys }: PrettyUrlsTableProps) => {
+export const getPrettyUrlColumns = (t: TFunction): TSettingsTableColumn<SurveyWithSlug>[] => [
+  {
+    id: "name",
+    header: t("workspace.settings.domain.survey_name"),
+    width: "w-[40%]",
+    cellClassName: "font-medium",
+    cell: (survey) => (
+      <Link
+        href={`/workspaces/${survey.workspace.id}/surveys/${survey.id}/summary`}
+        className="text-slate-900 hover:text-slate-700 hover:underline">
+        {survey.name}
+      </Link>
+    ),
+  },
+  {
+    id: "workspace",
+    header: t("workspace.settings.domain.workspace"),
+    width: "w-[30%]",
+    cell: (survey) => survey.workspace.name,
+  },
+  {
+    id: "slug",
+    header: t("workspace.settings.domain.pretty_url"),
+    width: "w-[30%]",
+    cell: (survey) => <IdBadge id={survey.slug ?? ""} />,
+  },
+];
+
+export const PrettyUrlsTable = ({ surveys }: Readonly<PrettyUrlsTableProps>) => {
   const { t } = useTranslation();
 
-  const tableHeaders = [
-    {
-      label: t("workspace.settings.domain.survey_name"),
-      key: "name",
-    },
-    {
-      label: t("workspace.settings.domain.workspace"),
-      key: "workspace",
-    },
-    {
-      label: t("workspace.settings.domain.pretty_url"),
-      key: "slug",
-    },
-  ];
-
   return (
-    <div className="overflow-hidden rounded-lg">
-      <Table>
-        <TableHeader>
-          <TableRow className="bg-slate-100">
-            {tableHeaders.map((header) => (
-              <TableHead key={header.key} className="font-medium text-slate-500">
-                {header.label}
-              </TableHead>
-            ))}
-          </TableRow>
-        </TableHeader>
-        <TableBody className="[&_tr:last-child]:border-b">
-          {surveys.length === 0 && (
-            <TableRow>
-              <TableCell colSpan={3} className="text-center text-slate-500">
-                {t("workspace.settings.domain.no_pretty_urls")}
-              </TableCell>
-            </TableRow>
-          )}
-          {surveys.map((survey) => (
-            <TableRow key={survey.id}>
-              <TableCell className="font-medium">
-                <Link
-                  href={`/workspaces/${survey.workspace.id}/surveys/${survey.id}/summary`}
-                  className="text-slate-900 hover:text-slate-700 hover:underline">
-                  {survey.name}
-                </Link>
-              </TableCell>
-              <TableCell>{survey.workspace.name}</TableCell>
-              <TableCell>
-                <IdBadge id={survey.slug ?? ""} />
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+    <SettingsTable
+      columns={getPrettyUrlColumns(t)}
+      rows={surveys}
+      getRowId={(survey) => survey.id}
+      emptyMessage={t("workspace.settings.domain.no_pretty_urls")}
+    />
   );
 };

--- a/apps/web/modules/ui/components/settings-table/index.tsx
+++ b/apps/web/modules/ui/components/settings-table/index.tsx
@@ -5,6 +5,7 @@ import {
   getFrameClassName,
   getHeaderCellClassName,
   getRowActivatorColumnId,
+  isRowActivatable,
 } from "./lib/column-classes";
 import { SettingsTableSkeletonRows } from "./settings-table-skeleton";
 import type { TSettingsTableProps } from "./types";
@@ -65,7 +66,11 @@ export const SettingsTable = <TRow,>({
 
     return rows.map((row, rowIndex) => {
       const isDisabled = isRowDisabled?.(row) ?? false;
-      const isClickable = Boolean(onRowClick) && (isRowClickable?.(row) ?? true);
+      const isClickable = isRowActivatable({
+        isDisabled,
+        hasRowClick: Boolean(onRowClick),
+        isRowClickable: isRowClickable?.(row),
+      });
 
       return (
         <TableRow

--- a/apps/web/modules/ui/components/settings-table/index.tsx
+++ b/apps/web/modules/ui/components/settings-table/index.tsx
@@ -104,13 +104,8 @@ export const SettingsTable = <TRow,>({
   };
 
   return (
-    <div className={getFrameClassName(frame)}>
-      <Table
-        id={id}
-        aria-label={ariaLabel}
-        data-testid={dataTestId}
-        className={className}
-        containerClassName={containerClassName}>
+    <div className={cn(getFrameClassName(frame), containerClassName)}>
+      <Table id={id} aria-label={ariaLabel} data-testid={dataTestId} className={className}>
         <TableHeader>
           <TableRow className="bg-slate-100">
             {columns.map((column) => (

--- a/apps/web/modules/ui/components/settings-table/index.tsx
+++ b/apps/web/modules/ui/components/settings-table/index.tsx
@@ -1,0 +1,141 @@
+import { cn } from "@/lib/cn";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/modules/ui/components/table";
+import {
+  getBodyCellClassName,
+  getFrameClassName,
+  getHeaderCellClassName,
+  getRowActivatorColumnId,
+} from "./lib/column-classes";
+import { SettingsTableSkeletonRows } from "./settings-table-skeleton";
+import type { TSettingsTableProps } from "./types";
+
+/**
+ * The settings-page table: one frame, a tinted `h-12` header, divided rows.
+ *
+ * Columns are declared as data rather than JSX so that the header, the cells, the responsive hiding and
+ * the loading skeleton all come from one source. Export the array from a `getXColumns(t, flags)` factory
+ * and a `loading.tsx` can reuse it, which is what keeps a skeleton from drifting out of sync.
+ *
+ * Defaults to frameless, because the `<SettingsCard bodyVariant="flush">` it usually sits in already
+ * provides the frame. Pass `frame="card"` when the table stands on its own.
+ *
+ * Deliberately has no `"use client"`: it holds no state, so a server component can render it too. Only
+ * the interactive props (`onRowClick`, `getRowProps`) require a client caller.
+ *
+ * For anything the column API cannot express, drop down to the `Table` parts directly — they carry the
+ * same visual defaults, so the escape hatch costs structural consistency but never visual consistency.
+ */
+export const SettingsTable = <TRow,>({
+  columns,
+  rows,
+  getRowId,
+  emptyMessage,
+  frame = "none",
+  isLoading = false,
+  skeletonRows,
+  isRowDisabled,
+  footer,
+  getRowProps,
+  bodyProps,
+  onRowClick,
+  getRowLabel,
+  isRowClickable,
+  className,
+  containerClassName,
+  id,
+  "aria-label": ariaLabel,
+  "data-testid": dataTestId,
+}: Readonly<TSettingsTableProps<TRow>>) => {
+  const activatorColumnId = getRowActivatorColumnId(columns);
+
+  const renderBody = () => {
+    if (isLoading) {
+      return <SettingsTableSkeletonRows columns={columns} rows={skeletonRows} />;
+    }
+
+    if (rows.length === 0) {
+      return (
+        <TableRow>
+          <TableCell colSpan={columns.length} className="h-24 text-center text-sm text-slate-500">
+            {emptyMessage}
+          </TableCell>
+        </TableRow>
+      );
+    }
+
+    return rows.map((row, rowIndex) => {
+      const isDisabled = isRowDisabled?.(row) ?? false;
+      const isClickable = Boolean(onRowClick) && (isRowClickable?.(row) ?? true);
+
+      return (
+        <TableRow
+          key={getRowId(row)}
+          aria-disabled={isDisabled || undefined}
+          className={cn(
+            isClickable && "cursor-pointer hover:bg-slate-50",
+            isDisabled && "pointer-events-none opacity-60"
+          )}
+          onClick={isClickable && onRowClick ? () => onRowClick(row) : undefined}
+          {...getRowProps?.(row)}>
+          {columns.map((column) => {
+            const content = column.cell(row, rowIndex);
+
+            return (
+              <TableCell
+                key={column.id}
+                className={getBodyCellClassName(column)}
+                onClick={column.stopRowClick ? (event) => event.stopPropagation() : undefined}>
+                {isClickable && getRowLabel && column.id === activatorColumnId ? (
+                  <button
+                    type="button"
+                    aria-label={getRowLabel(row)}
+                    className="-m-1 flex w-full items-center rounded-sm p-1 text-left focus-visible:ring-2 focus-visible:ring-slate-400 focus-visible:outline-hidden">
+                    {content}
+                  </button>
+                ) : (
+                  content
+                )}
+              </TableCell>
+            );
+          })}
+        </TableRow>
+      );
+    });
+  };
+
+  return (
+    <div className={getFrameClassName(frame)}>
+      <Table
+        id={id}
+        aria-label={ariaLabel}
+        data-testid={dataTestId}
+        className={className}
+        containerClassName={containerClassName}>
+        <TableHeader>
+          <TableRow className="bg-slate-100">
+            {columns.map((column) => (
+              <TableHead key={column.id} className={getHeaderCellClassName(column)}>
+                {column.header}
+                {column.header === null && column.srLabel ? (
+                  <span className="sr-only">{column.srLabel}</span>
+                ) : null}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody {...bodyProps}>{renderBody()}</TableBody>
+      </Table>
+      {footer}
+    </div>
+  );
+};
+
+export { SettingsTableSkeleton, SettingsTableSkeletonRows } from "./settings-table-skeleton";
+export type {
+  TSettingsTableAlign,
+  TSettingsTableBreakpoint,
+  TSettingsTableColumn,
+  TSettingsTableFrame,
+  TSettingsTableProps,
+  TSettingsTableSkeletonProps,
+} from "./types";

--- a/apps/web/modules/ui/components/settings-table/lib/column-classes.test.ts
+++ b/apps/web/modules/ui/components/settings-table/lib/column-classes.test.ts
@@ -29,12 +29,15 @@ describe("getFrameClassName", () => {
 });
 
 describe("getHeaderCellClassName", () => {
-  test("carries the width, because the header cell is what sizes the whole column", () => {
-    expect(getHeaderCellClassName(column({ width: "w-[22%]" }))).toBe("w-[22%]");
+  // The settings header type lives here rather than on the shared `TableHead`: a class on the `th` beats
+  // the colour a `<thead>` passes down, so putting it in the primitive would lighten every bare
+  // `TableHead` in the app — including contacts, attributes and survey responses.
+  test("sets the settings header type itself instead of relying on the shared primitive", () => {
+    expect(getHeaderCellClassName(column())).toBe("font-medium text-slate-500");
   });
 
-  test("is empty when the column asks for nothing, leaving the primitive's defaults intact", () => {
-    expect(getHeaderCellClassName(column())).toBe("");
+  test("carries the width, because the header cell is what sizes the whole column", () => {
+    expect(getHeaderCellClassName(column({ width: "w-[22%]" }))).toBe("font-medium text-slate-500 w-[22%]");
   });
 
   test.each([
@@ -42,7 +45,7 @@ describe("getHeaderCellClassName", () => {
     ["center", "text-center"],
     ["right", "text-right"],
   ] as const)("maps align %s", (align, expected) => {
-    expect(getHeaderCellClassName(column({ align }))).toBe(expected);
+    expect(getHeaderCellClassName(column({ align }))).toBe(`font-medium text-slate-500 ${expected}`);
   });
 
   test.each([
@@ -50,11 +53,13 @@ describe("getHeaderCellClassName", () => {
     ["md", "hidden md:table-cell"],
     ["lg", "hidden lg:table-cell"],
   ] as const)("hides below %s with table-cell, not block, so the column layout survives", (bp, expected) => {
-    expect(getHeaderCellClassName(column({ hideBelow: bp }))).toBe(expected);
+    expect(getHeaderCellClassName(column({ hideBelow: bp }))).toBe(`font-medium text-slate-500 ${expected}`);
   });
 
   test("ignores cellClassName — that is for body cells only", () => {
-    expect(getHeaderCellClassName(column({ cellClassName: "font-medium text-slate-900" }))).toBe("");
+    expect(getHeaderCellClassName(column({ cellClassName: "font-medium text-slate-900" }))).toBe(
+      "font-medium text-slate-500"
+    );
   });
 });
 

--- a/apps/web/modules/ui/components/settings-table/lib/column-classes.test.ts
+++ b/apps/web/modules/ui/components/settings-table/lib/column-classes.test.ts
@@ -5,6 +5,7 @@ import {
   getFrameClassName,
   getHeaderCellClassName,
   getRowActivatorColumnId,
+  isRowActivatable,
 } from "./column-classes";
 
 const column = (overrides: Partial<TSettingsTableColumn<unknown>> = {}): TSettingsTableColumn<unknown> => ({
@@ -79,6 +80,34 @@ describe("getBodyCellClassName", () => {
     expect(getBodyCellClassName(column({ align: "center", cellClassName: "text-left font-medium" }))).toBe(
       "text-left font-medium"
     );
+  });
+});
+
+describe("isRowActivatable", () => {
+  test("activates a row that has a handler and is not disabled", () => {
+    expect(isRowActivatable({ isDisabled: false, hasRowClick: true })).toBe(true);
+  });
+
+  // The regression this guards: `pointer-events-none` on a disabled row stops the mouse but leaves the
+  // activator button focusable, so Enter or Space would still fire the row's handler.
+  test("refuses a disabled row, so it gets neither a handler nor a focusable activator", () => {
+    expect(isRowActivatable({ isDisabled: true, hasRowClick: true })).toBe(false);
+  });
+
+  test("still refuses a disabled row that the consumer calls clickable", () => {
+    expect(isRowActivatable({ isDisabled: true, hasRowClick: true, isRowClickable: true })).toBe(false);
+  });
+
+  test("refuses when no handler was supplied", () => {
+    expect(isRowActivatable({ isDisabled: false, hasRowClick: false })).toBe(false);
+  });
+
+  test("honours a per-row opt-out", () => {
+    expect(isRowActivatable({ isDisabled: false, hasRowClick: true, isRowClickable: false })).toBe(false);
+  });
+
+  test("treats an absent per-row predicate as clickable, so the common case needs no opt-in", () => {
+    expect(isRowActivatable({ isDisabled: false, hasRowClick: true, isRowClickable: undefined })).toBe(true);
   });
 });
 

--- a/apps/web/modules/ui/components/settings-table/lib/column-classes.test.ts
+++ b/apps/web/modules/ui/components/settings-table/lib/column-classes.test.ts
@@ -37,8 +37,16 @@ describe("getHeaderCellClassName", () => {
     expect(getHeaderCellClassName(column())).toBe("font-medium text-slate-500");
   });
 
-  test("carries the width, because the header cell is what sizes the whole column", () => {
-    expect(getHeaderCellClassName(column({ width: "w-[22%]" }))).toBe("font-medium text-slate-500 w-[22%]");
+  test("merges headerClassName, which is where a column's width belongs", () => {
+    expect(getHeaderCellClassName(column({ headerClassName: "w-[22%]" }))).toBe(
+      "font-medium text-slate-500 w-[22%]"
+    );
+  });
+
+  test("merges headerClassName last, so a column can override the alignment it asked for", () => {
+    expect(getHeaderCellClassName(column({ align: "center", headerClassName: "text-right" }))).toBe(
+      "font-medium text-slate-500 text-right"
+    );
   });
 
   test.each([
@@ -65,8 +73,8 @@ describe("getHeaderCellClassName", () => {
 });
 
 describe("getBodyCellClassName", () => {
-  test("omits the width, so only the header sizes the column", () => {
-    expect(getBodyCellClassName(column({ width: "w-[22%]" }))).toBe("");
+  test("ignores headerClassName — a width there must not leak onto every cell", () => {
+    expect(getBodyCellClassName(column({ headerClassName: "w-[22%]" }))).toBe("");
   });
 
   test("repeats align and hideBelow, which have to match the header cell to stay aligned", () => {

--- a/apps/web/modules/ui/components/settings-table/lib/column-classes.test.ts
+++ b/apps/web/modules/ui/components/settings-table/lib/column-classes.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "vitest";
+import type { TSettingsTableColumn } from "../types";
+import {
+  getBodyCellClassName,
+  getFrameClassName,
+  getHeaderCellClassName,
+  getRowActivatorColumnId,
+} from "./column-classes";
+
+const column = (overrides: Partial<TSettingsTableColumn<unknown>> = {}): TSettingsTableColumn<unknown> => ({
+  id: "name",
+  header: "Name",
+  cell: () => null,
+  ...overrides,
+});
+
+describe("getFrameClassName", () => {
+  test("draws nothing for a frameless table, so a settings card can own the border", () => {
+    expect(getFrameClassName("none")).toBe("");
+  });
+
+  test("clips on the same element that rounds, so row fills do not square off the corners", () => {
+    const frame = getFrameClassName("card");
+
+    expect(frame).toContain("overflow-hidden");
+    expect(frame).toContain("rounded-xl");
+    expect(frame).toContain("border-slate-200");
+  });
+});
+
+describe("getHeaderCellClassName", () => {
+  test("carries the width, because the header cell is what sizes the whole column", () => {
+    expect(getHeaderCellClassName(column({ width: "w-[22%]" }))).toBe("w-[22%]");
+  });
+
+  test("is empty when the column asks for nothing, leaving the primitive's defaults intact", () => {
+    expect(getHeaderCellClassName(column())).toBe("");
+  });
+
+  test.each([
+    ["left", "text-left"],
+    ["center", "text-center"],
+    ["right", "text-right"],
+  ] as const)("maps align %s", (align, expected) => {
+    expect(getHeaderCellClassName(column({ align }))).toBe(expected);
+  });
+
+  test.each([
+    ["sm", "hidden sm:table-cell"],
+    ["md", "hidden md:table-cell"],
+    ["lg", "hidden lg:table-cell"],
+  ] as const)("hides below %s with table-cell, not block, so the column layout survives", (bp, expected) => {
+    expect(getHeaderCellClassName(column({ hideBelow: bp }))).toBe(expected);
+  });
+
+  test("ignores cellClassName — that is for body cells only", () => {
+    expect(getHeaderCellClassName(column({ cellClassName: "font-medium text-slate-900" }))).toBe("");
+  });
+});
+
+describe("getBodyCellClassName", () => {
+  test("omits the width, so only the header sizes the column", () => {
+    expect(getBodyCellClassName(column({ width: "w-[22%]" }))).toBe("");
+  });
+
+  test("repeats align and hideBelow, which have to match the header cell to stay aligned", () => {
+    expect(getBodyCellClassName(column({ align: "right", hideBelow: "sm" }))).toBe(
+      "text-right hidden sm:table-cell"
+    );
+  });
+
+  test("appends cellClassName last so a column can override the alignment it just set", () => {
+    // twMerge drops the losing `text-center` and keeps the input order of what survives.
+    expect(getBodyCellClassName(column({ align: "center", cellClassName: "text-left font-medium" }))).toBe(
+      "text-left font-medium"
+    );
+  });
+});
+
+describe("getRowActivatorColumnId", () => {
+  test("picks the first column, which is where a row's identifying content lives", () => {
+    expect(getRowActivatorColumnId([column({ id: "name" }), column({ id: "role" })])).toBe("name");
+  });
+
+  test("skips a leading stopRowClick column, so a checkbox never becomes the row's activator", () => {
+    expect(
+      getRowActivatorColumnId([column({ id: "select", stopRowClick: true }), column({ id: "name" })])
+    ).toBe("name");
+  });
+
+  test("returns undefined when every column opts out, leaving the row without an activator", () => {
+    expect(getRowActivatorColumnId([column({ id: "actions", stopRowClick: true })])).toBeUndefined();
+  });
+
+  test("returns undefined for no columns rather than throwing", () => {
+    expect(getRowActivatorColumnId([])).toBeUndefined();
+  });
+});

--- a/apps/web/modules/ui/components/settings-table/lib/column-classes.ts
+++ b/apps/web/modules/ui/components/settings-table/lib/column-classes.ts
@@ -56,6 +56,20 @@ export const getBodyCellClassName = <TRow>(column: TSettingsTableColumn<TRow>): 
   );
 
 /**
+ * Whether a row should carry a click handler and an activator button.
+ *
+ * A disabled row must answer `false`. Dimming it with `pointer-events-none` only stops the mouse: the
+ * activator `<button>` stays in the tab order, and Enter or Space on it fires a click that bubbles to
+ * the row's handler — so a "disabled" row would still be operable from the keyboard.
+ */
+export const isRowActivatable = ({
+  isDisabled,
+  hasRowClick,
+  isRowClickable = true,
+}: Readonly<{ isDisabled: boolean; hasRowClick: boolean; isRowClickable?: boolean }>): boolean =>
+  !isDisabled && hasRowClick && isRowClickable;
+
+/**
  * The row is activated by a real `<button>` wrapping one column's content, not by `role="button"` on
  * the `<tr>` — a `row` cannot also be a `button`, and overriding the role drops the row out of the
  * table's accessibility tree. The button carries no click handler of its own: a click on it (including

--- a/apps/web/modules/ui/components/settings-table/lib/column-classes.ts
+++ b/apps/web/modules/ui/components/settings-table/lib/column-classes.ts
@@ -34,18 +34,18 @@ const FRAME_CLASSES: Record<TSettingsTableFrame, string> = {
 export const getFrameClassName = (frame: TSettingsTableFrame): string => FRAME_CLASSES[frame];
 
 /**
- * Width lives on the header cell only — the browser applies it to the whole column.
- *
  * The header's type is set here rather than on the shared `TableHead`, because a class on the `th` beats
  * the `text-slate-800` a `<thead>` passes down: putting it in the primitive would lighten every bare
  * `TableHead` in the app, including the data tables for contacts, attributes and survey responses.
+ *
+ * `headerClassName` is merged last, so a column can override the alignment it just asked for.
  */
 export const getHeaderCellClassName = <TRow>(column: TSettingsTableColumn<TRow>): string =>
   cn(
     "font-medium text-slate-500",
-    column.width,
     column.align ? ALIGN_CLASSES[column.align] : undefined,
-    column.hideBelow ? HIDE_BELOW_CLASSES[column.hideBelow] : undefined
+    column.hideBelow ? HIDE_BELOW_CLASSES[column.hideBelow] : undefined,
+    column.headerClassName
   );
 
 export const getBodyCellClassName = <TRow>(column: TSettingsTableColumn<TRow>): string =>

--- a/apps/web/modules/ui/components/settings-table/lib/column-classes.ts
+++ b/apps/web/modules/ui/components/settings-table/lib/column-classes.ts
@@ -1,0 +1,58 @@
+import { cn } from "@/lib/cn";
+import type {
+  TSettingsTableAlign,
+  TSettingsTableBreakpoint,
+  TSettingsTableColumn,
+  TSettingsTableFrame,
+} from "../types";
+
+const ALIGN_CLASSES: Record<TSettingsTableAlign, string> = {
+  left: "text-left",
+  center: "text-center",
+  right: "text-right",
+};
+
+/**
+ * `table-cell` rather than `block`: restoring a `<td>`/`<th>` to `display: block` would drop it out of
+ * the table's column layout and misalign the whole row.
+ */
+const HIDE_BELOW_CLASSES: Record<TSettingsTableBreakpoint, string> = {
+  sm: "hidden sm:table-cell",
+  md: "hidden md:table-cell",
+  lg: "hidden lg:table-cell",
+};
+
+/**
+ * `overflow-hidden` has to sit on the same element as the radius, so row backgrounds are clipped by the
+ * corner instead of squaring it off.
+ */
+const FRAME_CLASSES: Record<TSettingsTableFrame, string> = {
+  none: "",
+  card: "overflow-hidden rounded-xl border border-slate-200 bg-white shadow-xs",
+};
+
+export const getFrameClassName = (frame: TSettingsTableFrame): string => FRAME_CLASSES[frame];
+
+/** Width lives on the header cell only — the browser applies it to the whole column. */
+export const getHeaderCellClassName = <TRow>(column: TSettingsTableColumn<TRow>): string =>
+  cn(
+    column.width,
+    column.align ? ALIGN_CLASSES[column.align] : undefined,
+    column.hideBelow ? HIDE_BELOW_CLASSES[column.hideBelow] : undefined
+  );
+
+export const getBodyCellClassName = <TRow>(column: TSettingsTableColumn<TRow>): string =>
+  cn(
+    column.align ? ALIGN_CLASSES[column.align] : undefined,
+    column.hideBelow ? HIDE_BELOW_CLASSES[column.hideBelow] : undefined,
+    column.cellClassName
+  );
+
+/**
+ * The row is activated by a real `<button>` wrapping one column's content, not by `role="button"` on
+ * the `<tr>` — a `row` cannot also be a `button`, and overriding the role drops the row out of the
+ * table's accessibility tree. The button carries no click handler of its own: a click on it (including
+ * the synthetic click a keyboard Enter/Space produces) bubbles to the row's own handler.
+ */
+export const getRowActivatorColumnId = <TRow>(columns: TSettingsTableColumn<TRow>[]): string | undefined =>
+  columns.find((column) => !column.stopRowClick)?.id;

--- a/apps/web/modules/ui/components/settings-table/lib/column-classes.ts
+++ b/apps/web/modules/ui/components/settings-table/lib/column-classes.ts
@@ -33,9 +33,16 @@ const FRAME_CLASSES: Record<TSettingsTableFrame, string> = {
 
 export const getFrameClassName = (frame: TSettingsTableFrame): string => FRAME_CLASSES[frame];
 
-/** Width lives on the header cell only — the browser applies it to the whole column. */
+/**
+ * Width lives on the header cell only — the browser applies it to the whole column.
+ *
+ * The header's type is set here rather than on the shared `TableHead`, because a class on the `th` beats
+ * the `text-slate-800` a `<thead>` passes down: putting it in the primitive would lighten every bare
+ * `TableHead` in the app, including the data tables for contacts, attributes and survey responses.
+ */
 export const getHeaderCellClassName = <TRow>(column: TSettingsTableColumn<TRow>): string =>
   cn(
+    "font-medium text-slate-500",
     column.width,
     column.align ? ALIGN_CLASSES[column.align] : undefined,
     column.hideBelow ? HIDE_BELOW_CLASSES[column.hideBelow] : undefined

--- a/apps/web/modules/ui/components/settings-table/settings-table-skeleton.tsx
+++ b/apps/web/modules/ui/components/settings-table/settings-table-skeleton.tsx
@@ -1,0 +1,62 @@
+import { cn } from "@/lib/cn";
+import { Skeleton } from "@/modules/ui/components/skeleton";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/modules/ui/components/table";
+import { getBodyCellClassName, getFrameClassName, getHeaderCellClassName } from "./lib/column-classes";
+import type { TSettingsTableColumn, TSettingsTableSkeletonProps } from "./types";
+
+const DEFAULT_SKELETON_ROWS = 3;
+
+/**
+ * Skeleton body rows for a table that is already rendering its own header. Kept separate from
+ * `SettingsTableSkeleton` so `SettingsTable`'s `isLoading` state can swap only the body and leave the
+ * real header in place.
+ */
+export const SettingsTableSkeletonRows = <TRow,>({
+  columns,
+  rows = DEFAULT_SKELETON_ROWS,
+}: Readonly<{ columns: TSettingsTableColumn<TRow>[]; rows?: number }>) => (
+  <>
+    {Array.from({ length: rows }, (_, rowIndex) => (
+      <TableRow key={`settings-table-skeleton-row-${rowIndex}`}>
+        {columns.map((column) => (
+          <TableCell key={column.id} className={getBodyCellClassName(column)}>
+            <Skeleton className={cn("h-4 rounded-xl", column.skeletonWidth ?? "w-24")} />
+          </TableCell>
+        ))}
+      </TableRow>
+    ))}
+  </>
+);
+
+/**
+ * A full loading table for `loading.tsx` files. Pass the **same column array** the real table uses —
+ * importing it from a shared `getXColumns(t, flags)` factory is what stops the skeleton drifting out of
+ * sync with the table it stands in for.
+ */
+export const SettingsTableSkeleton = <TRow,>({
+  columns,
+  frame = "none",
+  rows = DEFAULT_SKELETON_ROWS,
+  className,
+  containerClassName,
+}: Readonly<TSettingsTableSkeletonProps<TRow>>) => (
+  <div className={getFrameClassName(frame)}>
+    <Table className={className} containerClassName={containerClassName}>
+      <TableHeader>
+        <TableRow className="bg-slate-100">
+          {columns.map((column) => (
+            <TableHead key={column.id} className={getHeaderCellClassName(column)}>
+              {column.header}
+              {column.header === null && column.srLabel ? (
+                <span className="sr-only">{column.srLabel}</span>
+              ) : null}
+            </TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <SettingsTableSkeletonRows columns={columns} rows={rows} />
+      </TableBody>
+    </Table>
+  </div>
+);

--- a/apps/web/modules/ui/components/settings-table/settings-table-skeleton.tsx
+++ b/apps/web/modules/ui/components/settings-table/settings-table-skeleton.tsx
@@ -40,8 +40,8 @@ export const SettingsTableSkeleton = <TRow,>({
   className,
   containerClassName,
 }: Readonly<TSettingsTableSkeletonProps<TRow>>) => (
-  <div className={getFrameClassName(frame)}>
-    <Table className={className} containerClassName={containerClassName}>
+  <div className={cn(getFrameClassName(frame), containerClassName)}>
+    <Table className={className}>
       <TableHeader>
         <TableRow className="bg-slate-100">
           {columns.map((column) => (

--- a/apps/web/modules/ui/components/settings-table/types.ts
+++ b/apps/web/modules/ui/components/settings-table/types.ts
@@ -56,7 +56,7 @@ type SettingsTableBaseProps<TRow> = {
   "data-testid"?: string;
   /** Classes for the `<table>` itself. */
   className?: string;
-  /** Classes for the table's scroll container, for width and overflow tweaks. Not the frame. */
+  /** Extra classes for the frame wrapper, e.g. a width constraint. Merged after `frame`. */
   containerClassName?: string;
 };
 

--- a/apps/web/modules/ui/components/settings-table/types.ts
+++ b/apps/web/modules/ui/components/settings-table/types.ts
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react";
+
+export type TSettingsTableAlign = "left" | "center" | "right";
+export type TSettingsTableBreakpoint = "sm" | "md" | "lg";
+
+/**
+ * `none` — the table draws no frame, because a `<SettingsCard bodyVariant="flush">` already frames it.
+ * `card` — the table draws its own frame, for use outside a settings card.
+ */
+export type TSettingsTableFrame = "none" | "card";
+
+export type TSettingsTableColumn<TRow> = {
+  /** Stable identifier, used as the React key for this column's header and every one of its cells. */
+  id: string;
+  /** Already-translated header label. `null` renders an empty header cell — pair it with `srLabel`. */
+  header: ReactNode;
+  cell: (row: TRow, index: number) => ReactNode;
+  /**
+   * Tailwind width class for the `<th>`, e.g. `w-[22%]` or `w-16`. Omit to let the browser size the
+   * column. Percentages are suggestions: the table is `table-auto`, so a long value can still borrow
+   * space from a short one, and when a `hideBelow` column drops out the rest rescale.
+   */
+  width?: `w-${string}`;
+  /** Applies to the header cell and every body cell in this column. Defaults to `left`. */
+  align?: TSettingsTableAlign;
+  /** Hides the column below this breakpoint. Applied to the header and body cells together. */
+  hideBelow?: TSettingsTableBreakpoint;
+  /** Extra classes merged onto every `<td>` in this column, e.g. `font-medium text-slate-900`. */
+  cellClassName?: string;
+  /** Accessible name for a header cell whose `header` is `null` — typically an actions column. */
+  srLabel?: string;
+  /** Clicks inside this column do not activate the row. Use for action buttons and nested links. */
+  stopRowClick?: boolean;
+  /** Width of this column's skeleton bar. Defaults to `w-24`. */
+  skeletonWidth?: `w-${string}`;
+};
+
+type SettingsTableBaseProps<TRow> = {
+  columns: TSettingsTableColumn<TRow>[];
+  rows: TRow[];
+  getRowId: (row: TRow) => string;
+  /** Already-translated. Rendered in a full-width cell when there are no rows. */
+  emptyMessage: string;
+  frame?: TSettingsTableFrame;
+  isLoading?: boolean;
+  skeletonRows?: number;
+  /** Dims the row and blocks its interactions, e.g. while a sibling row's action is in flight. */
+  isRowDisabled?: (row: TRow) => boolean;
+  /** Non-row content rendered inside the frame, below the table — and outside its horizontal scroll. */
+  footer?: ReactNode;
+  /** Per-row DOM hooks. Prefer `data-testid` over `id`, which is not unique across rows. */
+  getRowProps?: (row: TRow) => { id?: string; "data-testid"?: string };
+  bodyProps?: { id?: string };
+  id?: string;
+  "aria-label"?: string;
+  "data-testid"?: string;
+  /** Classes for the `<table>` itself. */
+  className?: string;
+  /** Classes for the table's scroll container, for width and overflow tweaks. Not the frame. */
+  containerClassName?: string;
+};
+
+/**
+ * `getRowLabel` is required alongside `onRowClick`: the row's activator is a real `<button>`, and a
+ * button built out of arbitrary cell content needs an accessible name.
+ */
+type SettingsTableClickProps<TRow> =
+  | { onRowClick?: never; getRowLabel?: never; isRowClickable?: never }
+  | {
+      onRowClick: (row: TRow) => void;
+      getRowLabel: (row: TRow) => string;
+      isRowClickable?: (row: TRow) => boolean;
+    };
+
+export type TSettingsTableProps<TRow> = SettingsTableBaseProps<TRow> & SettingsTableClickProps<TRow>;
+
+export type TSettingsTableSkeletonProps<TRow> = Pick<
+  SettingsTableBaseProps<TRow>,
+  "columns" | "frame" | "className" | "containerClassName"
+> & { rows?: number };

--- a/apps/web/modules/ui/components/settings-table/types.ts
+++ b/apps/web/modules/ui/components/settings-table/types.ts
@@ -15,16 +15,19 @@ export type TSettingsTableColumn<TRow> = {
   /** Already-translated header label. `null` renders an empty header cell — pair it with `srLabel`. */
   header: ReactNode;
   cell: (row: TRow, index: number) => ReactNode;
-  /**
-   * Tailwind width class for the `<th>`, e.g. `w-[22%]` or `w-16`. Omit to let the browser size the
-   * column. Percentages are suggestions: the table is `table-auto`, so a long value can still borrow
-   * space from a short one, and when a `hideBelow` column drops out the rest rescale.
-   */
-  width?: `w-${string}`;
   /** Applies to the header cell and every body cell in this column. Defaults to `left`. */
   align?: TSettingsTableAlign;
   /** Hides the column below this breakpoint. Applied to the header and body cells together. */
   hideBelow?: TSettingsTableBreakpoint;
+  /**
+   * Extra classes merged onto the `<th>`.
+   *
+   * This is where a column's **width** belongs (`w-[22%]`, `w-16`), because the header cell is what
+   * sizes the whole column — putting a width on `cellClassName` only affects that one cell. Widths are
+   * suggestions rather than commands: the table is `table-auto`, so a long value can still borrow space
+   * from a short one, and when a `hideBelow` column drops out the remaining widths rescale.
+   */
+  headerClassName?: string;
   /** Extra classes merged onto every `<td>` in this column, e.g. `font-medium text-slate-900`. */
   cellClassName?: string;
   /** Accessible name for a header cell whose `header` is `null` — typically an actions column. */


### PR DESCRIPTION
## What & why

Third of the ENG-762 series. **Stacked on #8838 (which is stacked on #8837) — this PR's diff is only
its last commit.**

Adds `modules/ui/components/settings-table/`, the shared table for settings pages, and converts the
pretty URLs table onto it as the proof case. One new component, one converted table — deliberately
small, so if the corner geometry from #8838 is wrong you see it here with nothing else in the frame.

**Columns are declared as data, not JSX.** That is the part that earns its keep. The header, the cells,
the responsive hiding and the loading skeleton all derive from one array, so a `loading.tsx` importing
the same `getXColumns(t, flags)` factory *cannot* drift from the table it stands in for. Today's
skeletons do drift — `tags/loading.tsx:20` renders an actions column the real table gates behind
`!isReadOnly`, and the Notion and Google Sheets loading files have outright wrong column counts.

Design decisions worth a reviewer's attention:

- **Frameless by default.** The `SettingsCard bodyVariant="flush"` from #8838 provides the frame.
  `frame="card"` is for tables that stand alone (feedback sources, later in the series) and puts
  `overflow-hidden` on the same element as the radius, so row fills are clipped by the corner instead
  of squaring it off.
- **Widths are `w-*` on the `<th>` with `table-auto`, not `<colgroup>`.** Browsers do not honour
  `display: none` on a `<col>`, so a hidden column would keep reserving its width — which makes
  colgroup and responsive hiding mutually exclusive. With `table-auto`, the remaining percentages
  rescale when a `hideBelow` column drops out, which is exactly what `grid-cols-N` + `col-span` was
  imitating by hand. Precedent already in the repo: `OpenTextSummary.tsx:55-58`.
- **Row activation does not use `role="button"` on the `<tr>`.** `edit-api-keys.tsx:185` and
  `workflow-runs-table.tsx:86` both do that today, and it drops the row out of the table's
  accessibility tree — a `row` cannot also be a `button`. Instead: `onClick` on the `<tr>` for the
  mouse, plus a real `<button>` wrapping the first non-`stopRowClick` column's content. The button
  carries **no handler of its own**; its click — including the synthetic one a keyboard Enter/Space
  produces — bubbles to the row. One tab stop, real button semantics, `<tr>` stays a `row`.
- **`getRowLabel` is required whenever `onRowClick` is set**, via a discriminated union, so a nameless
  row activator is a compile error rather than a review comment.
- **No `"use client"`.** The component holds no state, so server components can render it too — which
  matters for the members table later in the series.

The class resolution lives in `lib/column-classes.ts` rather than inline, because it is pure input to
output and can therefore carry unit tests. That locks the class contract without locking markup, which
is what the repo's ban on `.tsx` component tests is protecting against.

## Linear ticket

Ref ENG-762

## Screenshots

> **These are component renders, not app screenshots.** No Docker daemon here, so no database to boot the
> app against. Real component markup, the repo's own compiled `globals.css`, and every class string put
> through the same `tailwind-merge` the components use. Tokens and spacing are exact; the data is
> fabricated and page chrome is absent. **A real visual pass is still owed.**

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8839/before-pretty-urls.jpg" width="440"> | <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8839/after-pretty-urls.jpg" width="440"> |

Before: the table sits inset inside the card with its own rounded box, a white gutter on both sides, and
a strip of white below the last row. After: it fills the card, the header band butts against the card's
title divider, and the last row meets the card's bottom border.

The empty state, which now spans `columns.length` rather than a hardcoded `3`:

<img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8839/after-pretty-urls-empty.jpg" width="440">

## How this was tested

- **`npx vitest run modules/ui/components/settings-table/lib/column-classes.test.ts` → 18/18 pass.**
  New tests, covering frame classes, width-on-header-only, all three `align` values, all three
  `hideBelow` breakpoints, `cellClassName` precedence, and the activator-column selection including
  the all-`stopRowClick` and empty-columns cases.
- One of those tests failed first time and the **test** was wrong, not the code: I had asserted
  `"font-medium text-left"` where `twMerge` correctly produces `"text-left font-medium"` — it drops the
  losing `text-center` and preserves input order. Fixed the assertion and left a comment saying why.
- **Verified the discriminated union actually bites.** Compiled a throwaway probe with two usages:
  `onRowClick` alone, and `onRowClick` + `getRowLabel`. The first fails with
  `TS2322: ... is not assignable to type 'IntrinsicAttributes & Readonly<TSettingsTableProps<...>>'`,
  the second compiles. Probe deleted; it is not part of the diff.
- `npx turbo run typecheck --filter=@formbricks/web` → **33 errors, same count as clean `main`** (all
  from `@formbricks/jobs` being unbuilt in my sandbox); **none in any file this PR adds or touches**.
- `npx eslint` over the new folder and both changed files → clean, 0 warnings.
- `prettier` via `lint-staged` → clean. Note it strips the trailing comma from `<TRow,>` in the `.ts`
  file but correctly preserves it in the `.tsx` files, where `<TRow>` would parse as JSX. Verified by
  grep after formatting.

**Still owed before merge:** a visual pass on a running app, including a narrow viewport — the renders
above are desktop width only, and the responsive `hideBelow` path has no consumer until PR 7.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Org settings → Domain → the "Pretty URLs" card → the table now fills the card edge to edge: no
      inset gap on the left or right, header band flush against the card's title divider, last row
      meeting the card's bottom border → previously the table sat inset with its own rounded box
- [ ] Same table → there should be exactly **one** border line at the top of the table and one at the
      bottom → two parallel lines a pixel apart means the nested-frame problem is still present
- [ ] Same table → column headers read "Survey name", "Workspace", "Pretty URL" in slate-500 medium,
      same as the other settings tables
- [ ] Same table → click a survey name → navigates to that survey's summary page
- [ ] Same table → hover a row → **no** highlight (these rows are not clickable as a whole; only the
      name is a link)
- [ ] Same table → copy icon on a pretty-URL badge → still copies the slug
- [ ] On an organization with no surveys that have a pretty URL → the table shows "No pretty URLs" as a
      single centred row, with the column headers still visible above it
- [ ] Narrow the browser to phone width → the three columns stay proportional and the row does not
      overflow the card; the table may scroll horizontally inside its own container, but the page must
      not scroll sideways

**Preconditions / test data**

- An organization with at least 2 surveys that have a pretty URL / slug set, ideally across 2 different
  workspaces so the Workspace column has varying values
- A second organization with no pretty URLs at all, to see the empty state

**Risks & regressions**

- This is the first consumer of the new primitive, so anything wrong in the shared component shows up
  here first — that is the intent of converting only one table in this PR.
- The empty-state row now spans all columns via `colSpan={columns.length}` rather than a hardcoded `3`.
  If a column is ever added and the empty row does not span it, that is the regression.
- The table lost `[&_tr:last-child]:border-b`. It was only there because the old container had no
  border; the card's own bottom border now draws that line. A missing line at the bottom of the table
  means `bodyVariant="flush"` did not get applied on the page.

**Migrations / env / cutover**

- none


<img width="948" height="208" alt="image" src="https://github.com/user-attachments/assets/4c85a0b0-5d05-4939-8604-c7e5e6edb20b" />

