### PR TITLE
refactor(settings): move enterprise license features onto SettingsTable

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/components/EnterpriseLicenseFeaturesTable.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/organization/enterprise/components/EnterpriseLicenseFeaturesTable.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "react-i18next";
 import { SettingsCard } from "@/app/(app)/workspaces/[workspaceId]/settings/components/SettingsCard";
 import type { TEnterpriseLicenseFeatures } from "@/modules/ee/license-check/types/enterprise-license";
 import { Badge } from "@/modules/ui/components/badge";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/modules/ui/components/table";
+import { SettingsTable, type TSettingsTableColumn } from "@/modules/ui/components/settings-table";
 
 type TPublicLicenseFeatureKey = Exclude<keyof TEnterpriseLicenseFeatures, "isMultiOrgEnabled">;
 
@@ -103,7 +103,76 @@ interface EnterpriseLicenseFeaturesTableProps {
   features: TEnterpriseLicenseFeatures;
 }
 
-export const EnterpriseLicenseFeaturesTable = ({ features }: EnterpriseLicenseFeaturesTableProps) => {
+/** A feature is on when the flag is true, or when its limit is unlimited (`null`) or greater than zero. */
+const isFeatureEnabled = (value: TEnterpriseLicenseFeatures[TPublicLicenseFeatureKey]): boolean =>
+  typeof value === "boolean" ? value : value === null || value > 0;
+
+const getFeatureValueLabel = (
+  value: TEnterpriseLicenseFeatures[TPublicLicenseFeatureKey],
+  t: TFunction
+): number | string => {
+  if (typeof value === "number") return value;
+  if (value === null) return t("workspace.settings.enterprise.license_features_table_unlimited");
+  return "—";
+};
+
+const getLicenseFeatureColumns = (
+  t: TFunction,
+  features: TEnterpriseLicenseFeatures
+): TSettingsTableColumn<TFeatureDefinition>[] => [
+  {
+    id: "feature",
+    header: t("workspace.settings.enterprise.license_features_table_feature"),
+    headerClassName: "w-[40%]",
+    cellClassName: "font-medium text-slate-900",
+    cell: (feature) => t(feature.labelKey),
+  },
+  {
+    id: "access",
+    header: t("workspace.settings.enterprise.license_features_table_access"),
+    headerClassName: "w-[20%]",
+    cell: (feature) => {
+      const isEnabled = isFeatureEnabled(features[feature.key]);
+
+      return (
+        <Badge
+          type={isEnabled ? "success" : "gray"}
+          size="normal"
+          text={
+            isEnabled
+              ? t("workspace.settings.enterprise.license_features_table_enabled")
+              : t("workspace.settings.enterprise.license_features_table_disabled")
+          }
+        />
+      );
+    },
+  },
+  {
+    id: "value",
+    header: t("workspace.settings.enterprise.license_features_table_value"),
+    headerClassName: "w-[20%]",
+    cellClassName: "text-slate-600",
+    cell: (feature) => getFeatureValueLabel(features[feature.key], t),
+  },
+  {
+    id: "documentation",
+    header: t("common.documentation"),
+    headerClassName: "w-[20%]",
+    cell: (feature) => (
+      <Link
+        href={feature.docsUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-sm font-medium text-slate-700 underline underline-offset-2 hover:text-slate-900">
+        {t("common.read_docs")}
+      </Link>
+    ),
+  },
+];
+
+export const EnterpriseLicenseFeaturesTable = ({
+  features,
+}: Readonly<EnterpriseLicenseFeaturesTableProps>) => {
   const { t } = useTranslation();
 
   return (
@@ -111,56 +180,13 @@ export const EnterpriseLicenseFeaturesTable = ({ features }: EnterpriseLicenseFe
       title={t("workspace.settings.enterprise.license_features_table_title")}
       description={t("workspace.settings.enterprise.license_features_table_description")}
       bodyVariant="flush">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>{t("workspace.settings.enterprise.license_features_table_feature")}</TableHead>
-            <TableHead>{t("workspace.settings.enterprise.license_features_table_access")}</TableHead>
-            <TableHead>{t("workspace.settings.enterprise.license_features_table_value")}</TableHead>
-            <TableHead>{t("common.documentation")}</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {getFeatureDefinitions(t).map((feature) => {
-            const value = features[feature.key];
-            const isEnabled = typeof value === "boolean" ? value : value === null || value > 0;
-            let displayValue: number | string = "—";
-
-            if (typeof value === "number") {
-              displayValue = value;
-            } else if (value === null) {
-              displayValue = t("workspace.settings.enterprise.license_features_table_unlimited");
-            }
-
-            return (
-              <TableRow key={feature.key}>
-                <TableCell className="font-medium text-slate-900">{t(feature.labelKey)}</TableCell>
-                <TableCell>
-                  <Badge
-                    type={isEnabled ? "success" : "gray"}
-                    size="normal"
-                    text={
-                      isEnabled
-                        ? t("workspace.settings.enterprise.license_features_table_enabled")
-                        : t("workspace.settings.enterprise.license_features_table_disabled")
-                    }
-                  />
-                </TableCell>
-                <TableCell className="text-slate-600">{displayValue}</TableCell>
-                <TableCell>
-                  <Link
-                    href={feature.docsUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm font-medium text-slate-700 underline underline-offset-2 hover:text-slate-900">
-                    {t("common.read_docs")}
-                  </Link>
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
+      <SettingsTable
+        columns={getLicenseFeatureColumns(t, features)}
+        rows={getFeatureDefinitions(t)}
+        getRowId={(feature) => feature.key}
+        // Unreachable: the feature list is a compile-time constant, never empty.
+        emptyMessage={t("common.no_results")}
+      />
     </SettingsCard>
   );
 };


### PR DESCRIPTION
## What & why

Fourth of the ENG-762 series. **#8837, #8838 and #8839 have all merged, so this now sits directly on
`main` — one commit, one file.**

Converts the license features table to the shared settings table. **This is its own PR because its diff
carries a design decision, not a mechanical conversion:** it is currently the only settings table with a
white header (it set `hover:bg-white` on the header row), and it gains the `bg-slate-100` tint that every
other settings table already has. That is a deliberate appearance change and worth signing off on its
own, before the bulk conversions land behind it.

Also pulls two derivations out of the render body, where they were an inline `let displayValue`
reassigned across three branches inside the `.map`:

- `isFeatureEnabled` — a flag that is `true`, or a limit that is unlimited (`null`) or greater than zero.
- `getFeatureValueLabel` — the number, "Unlimited", or an em dash.

Both are now named, single-expression, and computed once per row rather than twice.

The empty state is unreachable here — `getFeatureDefinitions` returns a compile-time constant of 15
entries — so `emptyMessage` gets `common.no_results` with a comment saying why, rather than a new
translation key for copy that can never render.

## Linear ticket

Ref ENG-762

## Screenshots

> **These are component renders, not app screenshots.** No Docker daemon here, so no database to boot the
> app against. Real component markup, the repo's own compiled `globals.css`, and every class string put
> through the same `tailwind-merge` the components use. Tokens are exact; the licence values shown are
> fabricated. **A real visual pass is still owed** — and for this PR in particular, since the whole point
> is a visual change.

| Before — white header | After — tinted header |
| --- | --- |
| <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8840/before-enterprise-header.jpg" width="440"> | <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8840/after-enterprise-header.jpg" width="440"> |

The header row goes from white with browser-default **bold slate-800** `<th>` text to
**slate-100 with medium slate-500** text. The table also becomes flush at the bottom, inheriting
`bodyVariant="flush"` from #8838. **This is the diff to accept or reject** — everything else in the
series is mechanical.

## How this was tested

- **Rebased onto `main` after #8839 was squash-merged.** Worth calling out, because the squash is exactly
  what made this diff look wrong for a while: the squashed commit on `main` has a different SHA from the
  one this branch was stacked on, so git replayed the whole `settings-table/` primitive as new files —
  8 files, +622/−107, and a conflicted merge state. Rebasing onto the squashed `main` drops the
  already-merged commit and the diff is back to **1 file, +78/−52**. The two later PRs in the chain
  (#8841, #8842) were replayed on top and are correct again too.
- `npx turbo run typecheck --filter=@formbricks/web` → **12/12 tasks successful, 0 errors.** (Earlier
  runs in this series reported 33 pre-existing errors; those came from `@formbricks/jobs` being unbuilt
  in my sandbox, and turbo has since built it. There is now a clean baseline, which also matters because
  `main` just gained a `pnpm typecheck` CI gate.) For this PR specifically: the indexed access
  `TEnterpriseLicenseFeatures[TPublicLicenseFeatureKey]` in the two new helpers resolves to the right
  `boolean | number | null` union, which is what typechecking confirms.
- `npx eslint` on the changed file → clean, 0 warnings.
- `prettier --check` → clean.
- Sonar: **0 bugs, 0 vulnerabilities, 0 code smells**, quality gate OK. Also verified locally with
  `react/no-unstable-nested-components`, ESLint's analogue of `typescript:S6478` — the column factory
  here was already at module level, which is the pattern #8841 and #8842 have now been brought in line
  with.
- No test added: this file is `.tsx`, which the repo covers with Playwright rather than component tests,
  and the two extracted helpers are private to the module. If a reviewer wants them tested, they would
  need to move to a `.ts` file — happy to do that, but it seemed like over-engineering for 15 static
  rows.
- Checked the 15 rows still map to the same keys and docs URLs — `getFeatureDefinitions` is untouched.
- The render above exercises all three Value cases (em dash, "Unlimited", and a Disabled badge), which is
  the logic that moved into a helper.

**Still owed before merge:** a visual pass on a running app with a real licence payload — my renders
fabricate the values, so they confirm the *styling* change but not that a real licence maps to the right
badge and value.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] Org settings → Enterprise → the "License features" card → the header row is now tinted light grey
      (`bg-slate-100`) instead of white, matching the header on Org → Domain, Org → Teams and Workspace
      → Team access → this is the intended change
- [ ] Same table → all 15 feature rows still present, in the same order, with the same labels
- [ ] Same table → each row's Access column shows a green "Enabled" or grey "Disabled" badge matching
      the license → toggle or use a license where e.g. `contacts` is off and confirm that row reads
      Disabled
- [ ] Same table → the Value column shows a number for count-limited features, "Unlimited" for features
      with no cap, and an em dash (—) for plain on/off features → this is the logic that moved into a
      helper, so it is the main regression risk
- [ ] Same table → "Read docs" in the last column opens the feature's docs page in a **new tab**
- [ ] Same table → hover any row → no highlight (these rows are not interactive)
- [ ] Same table → last row sits flush against the card's bottom border, with the corner clipped cleanly
- [ ] Narrow the browser → the four columns stay proportional; the page must not scroll sideways

**Preconditions / test data**

- An Enterprise license, so the card renders at all
- Ideally two licenses to compare: one with a count limit set (to see a number and the "Unlimited" case)
  and one with a feature disabled (to see the grey badge). A self-hosted instance with a modified
  license payload is the easiest way to cover the Disabled and numeric-value rows.

**Risks & regressions**

- The Value column's three-way logic (number / "Unlimited" / em dash) moved from an inline `let` into
  `getFeatureValueLabel`. A row showing an em dash where it used to show `0`, or a number where it used
  to show "Unlimited", is the regression to look for.
- The Access badge is computed once now instead of twice per row. Same inputs, same output, but it is
  the other extracted helper, so worth an eye on the green/grey split.
- Header tint is an intentional change; if it looks wrong for this table specifically, that is a design
  call to make here rather than after the rest of the series lands on top.

**Migrations / env / cutover**

- none
