### PR TITLE
refactor(settings): move team access and feedback directories onto SettingsTable

### DIFF
--- a/apps/web/modules/ee/feedback-directory/components/feedback-directory-table.tsx
+++ b/apps/web/modules/ee/feedback-directory/components/feedback-directory-table.tsx
@@ -82,7 +82,10 @@ const getFeedbackDirectoryColumns = ({
     header: null,
     srLabel: t("common.actions"),
     headerClassName: "w-[25%]",
-    align: "right",
+    // No `align: "right"`. The buttons are block-level, so `text-align` cannot move them — the flex here
+    // is what right-aligns them, and it is also what right-aligns a skeleton bar if this array is ever
+    // fed to `SettingsTableSkeleton`. Declaring `align` too would leave two mechanisms for one intent,
+    // with the inert one looking authoritative.
     cellClassName: "flex justify-end gap-2",
     stopRowClick: true,
     cell: (directory) => (

--- a/apps/web/modules/ee/feedback-directory/components/feedback-directory-table.tsx
+++ b/apps/web/modules/ee/feedback-directory/components/feedback-directory-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { TFunction } from "i18next";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
@@ -22,8 +23,8 @@ import {
 import { TOrganizationWorkspace } from "@/modules/ee/teams/team-list/types/workspace";
 import { Badge } from "@/modules/ui/components/badge";
 import { Button } from "@/modules/ui/components/button";
+import { SettingsTable, type TSettingsTableColumn } from "@/modules/ui/components/settings-table";
 import { Switch } from "@/modules/ui/components/switch";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/modules/ui/components/table";
 
 interface FeedbackDirectoryTableProps {
   directories: TFeedbackDirectory[];
@@ -32,6 +33,95 @@ interface FeedbackDirectoryTableProps {
   workspaceAccessByWorkspace: TWorkspaceFeedbackDirectoryAccess[];
   membershipRole: TOrganizationRole;
 }
+
+/**
+ * Defined at module level rather than inside the component: an inline `cell` that returns JSX reads as a
+ * nested component definition to Sonar (typescript:S6478), and re-declaring the array per render buys
+ * nothing.
+ */
+const getFeedbackDirectoryColumns = ({
+  t,
+  isOwnerOrManager,
+  loadingDirectoryId,
+  viewDataWorkspaceIdByDirectory,
+  onManage,
+  onUnarchive,
+}: Readonly<{
+  t: TFunction;
+  isOwnerOrManager: boolean;
+  loadingDirectoryId: string | null;
+  viewDataWorkspaceIdByDirectory: Map<string, string>;
+  onManage: (directoryId: string) => void;
+  onUnarchive: (directoryId: string) => void;
+}>): TSettingsTableColumn<TFeedbackDirectory>[] => [
+  {
+    id: "name",
+    header: t("workspace.settings.feedback_directories.directory_name"),
+    headerClassName: "w-[45%]",
+    cell: (directory) => directory.name,
+  },
+  {
+    id: "workspaceCount",
+    header: t("common.workspaces"),
+    headerClassName: "w-[15%]",
+    cell: (directory) => directory.workspaceCount,
+  },
+  {
+    id: "status",
+    header: t("common.status"),
+    headerClassName: "w-[15%]",
+    cell: (directory) =>
+      directory.isArchived ? (
+        <Badge type="gray" size="tiny" text={t("common.archived")} />
+      ) : (
+        <Badge type="success" size="tiny" text={t("common.active")} />
+      ),
+  },
+  {
+    id: "actions",
+    header: null,
+    srLabel: t("common.actions"),
+    headerClassName: "w-[25%]",
+    align: "right",
+    cellClassName: "flex justify-end gap-2",
+    stopRowClick: true,
+    cell: (directory) => (
+      <>
+        {/* Never disabled: it is plain navigation with nothing to race. */}
+        {!directory.isArchived && viewDataWorkspaceIdByDirectory.has(directory.id) && (
+          <Button size="sm" variant="ghost" asChild>
+            <Link
+              href={`/workspaces/${viewDataWorkspaceIdByDirectory.get(directory.id)}/unify/feedback-records`}>
+              {t("workspace.settings.feedback_directories.view_data")}
+            </Link>
+          </Button>
+        )}
+        {/* `disabled` on the button itself, not `pointer-events-none` on the row: the latter blocks the
+            mouse but leaves the button focusable, so Enter would still start a second request. */}
+        {isOwnerOrManager && !directory.isArchived && (
+          <Button
+            size="sm"
+            variant="secondary"
+            loading={loadingDirectoryId === directory.id}
+            disabled={loadingDirectoryId !== null}
+            onClick={() => onManage(directory.id)}>
+            {t("common.manage")}
+          </Button>
+        )}
+        {isOwnerOrManager && directory.isArchived && (
+          <Button
+            size="sm"
+            variant="secondary"
+            loading={loadingDirectoryId === directory.id}
+            disabled={loadingDirectoryId !== null}
+            onClick={() => onUnarchive(directory.id)}>
+            {t("workspace.settings.feedback_directories.unarchive")}
+          </Button>
+        )}
+      </>
+    ),
+  },
+];
 
 export const FeedbackDirectoryTable = ({
   directories,
@@ -126,7 +216,8 @@ export const FeedbackDirectoryTable = ({
   return (
     <>
       {isOwnerOrManager && (
-        <div className="mb-4 flex items-center justify-between">
+        // The table runs edge to edge, so the controls above it carry the card's gutter themselves.
+        <div className="mb-4 flex items-center justify-between px-4 pt-4">
           <div className="flex items-center gap-2">
             <Switch checked={showArchived} onCheckedChange={setShowArchived} />
             <span className="text-sm text-slate-500">
@@ -139,72 +230,20 @@ export const FeedbackDirectoryTable = ({
         </div>
       )}
 
-      <div className="overflow-hidden rounded-lg border" aria-label="Feedback directories list">
-        <Table>
-          <TableHeader role="rowgroup">
-            <TableRow className="bg-slate-100" role="row">
-              <TableHead className="font-medium text-slate-500">
-                {t("workspace.settings.feedback_directories.directory_name")}
-              </TableHead>
-              <TableHead className="font-medium text-slate-500">{t("common.workspaces")}</TableHead>
-              <TableHead className="font-medium text-slate-500">{t("common.status")}</TableHead>
-              <TableHead></TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody className="[&_tr:last-child]:border-b">
-            {filteredDirectories.length === 0 && (
-              <TableRow>
-                <TableCell colSpan={4} className="text-center">
-                  {t("workspace.settings.feedback_directories.empty_state")}
-                </TableCell>
-              </TableRow>
-            )}
-            {filteredDirectories.map((directory) => (
-              <TableRow key={directory.id}>
-                <TableCell>{directory.name}</TableCell>
-                <TableCell>{directory.workspaceCount}</TableCell>
-                <TableCell>
-                  {directory.isArchived ? (
-                    <Badge type="gray" size="tiny" text={t("common.archived")} />
-                  ) : (
-                    <Badge type="success" size="tiny" text={t("common.active")} />
-                  )}
-                </TableCell>
-                <TableCell className="flex justify-end gap-2">
-                  {!directory.isArchived && viewDataWorkspaceIdByDirectory.has(directory.id) && (
-                    <Button size="sm" variant="ghost" asChild>
-                      <Link
-                        href={`/workspaces/${viewDataWorkspaceIdByDirectory.get(directory.id)}/unify/feedback-records`}>
-                        {t("workspace.settings.feedback_directories.view_data")}
-                      </Link>
-                    </Button>
-                  )}
-                  {isOwnerOrManager && !directory.isArchived && (
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      loading={loadingDirectoryId === directory.id}
-                      disabled={loadingDirectoryId !== null}
-                      onClick={() => handleManageDirectory(directory.id)}>
-                      {t("common.manage")}
-                    </Button>
-                  )}
-                  {isOwnerOrManager && directory.isArchived && (
-                    <Button
-                      size="sm"
-                      variant="secondary"
-                      loading={loadingDirectoryId === directory.id}
-                      disabled={loadingDirectoryId !== null}
-                      onClick={() => handleUnarchiveDirectory(directory.id)}>
-                      {t("workspace.settings.feedback_directories.unarchive")}
-                    </Button>
-                  )}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
+      <SettingsTable
+        columns={getFeedbackDirectoryColumns({
+          t,
+          isOwnerOrManager,
+          loadingDirectoryId,
+          viewDataWorkspaceIdByDirectory,
+          onManage: handleManageDirectory,
+          onUnarchive: handleUnarchiveDirectory,
+        })}
+        rows={filteredDirectories}
+        getRowId={(directory) => directory.id}
+        emptyMessage={t("workspace.settings.feedback_directories.empty_state")}
+        aria-label={t("workspace.settings.feedback_directories.title")}
+      />
 
       {openCreateModal && (
         <FeedbackDirectorySettingsModal

--- a/apps/web/modules/ee/feedback-directory/components/feedback-directory-table.tsx
+++ b/apps/web/modules/ee/feedback-directory/components/feedback-directory-table.tsx
@@ -82,14 +82,15 @@ const getFeedbackDirectoryColumns = ({
     header: null,
     srLabel: t("common.actions"),
     headerClassName: "w-[25%]",
-    // No `align: "right"`. The buttons are block-level, so `text-align` cannot move them — the flex here
-    // is what right-aligns them, and it is also what right-aligns a skeleton bar if this array is ever
-    // fed to `SettingsTableSkeleton`. Declaring `align` too would leave two mechanisms for one intent,
-    // with the inert one looking authoritative.
-    cellClassName: "flex justify-end gap-2",
     stopRowClick: true,
+    // The flex belongs on a wrapper inside the cell, never on `cellClassName` — that class lands on the
+    // `<td>`, and `display: flex` there stops it being a table-cell, which silently kills the shared
+    // `align-middle` (`vertical-align` applies only to inline-level and table-cell boxes) and makes the
+    // browser wrap the cell in an anonymous table-cell defaulting to baseline. The buttons would sit high
+    // in the row instead of centred. `align: "right"` is not an alternative here: the wrapper is
+    // block-level, so `text-align` cannot move it.
     cell: (directory) => (
-      <>
+      <div className="flex justify-end gap-2">
         {/* Never disabled: it is plain navigation with nothing to race. */}
         {!directory.isArchived && viewDataWorkspaceIdByDirectory.has(directory.id) && (
           <Button size="sm" variant="ghost" asChild>
@@ -121,7 +122,7 @@ const getFeedbackDirectoryColumns = ({
             {t("workspace.settings.feedback_directories.unarchive")}
           </Button>
         )}
-      </>
+      </div>
     ),
   },
 ];

--- a/apps/web/modules/ee/feedback-directory/components/feedback-directory-view.tsx
+++ b/apps/web/modules/ee/feedback-directory/components/feedback-directory-view.tsx
@@ -28,7 +28,8 @@ export const FeedbackDirectoryView = async ({
   return (
     <SettingsCard
       title={t("workspace.settings.feedback_directories.title")}
-      description={t("workspace.settings.feedback_directories.description")}>
+      description={t("workspace.settings.feedback_directories.description")}
+      bodyVariant="flush">
       <FeedbackDirectoryTable
         directories={directories}
         organizationId={organizationId}

--- a/apps/web/modules/ee/teams/workspace-teams/components/access-table.tsx
+++ b/apps/web/modules/ee/teams/workspace-teams/components/access-table.tsx
@@ -1,51 +1,55 @@
 "use client";
 
+import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { TeamPermissionMapping } from "@/modules/ee/teams/utils/teams";
 import { TWorkspaceTeam } from "@/modules/ee/teams/workspace-teams/types/team";
 import { IdBadge } from "@/modules/ui/components/id-badge";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/modules/ui/components/table";
+import { SettingsTable, type TSettingsTableColumn } from "@/modules/ui/components/settings-table";
 
 interface AccessTableProps {
   teams: TWorkspaceTeam[];
 }
 
-export const AccessTable = ({ teams }: AccessTableProps) => {
+const getWorkspaceTeamColumns = (t: TFunction): TSettingsTableColumn<TWorkspaceTeam>[] => [
+  {
+    id: "name",
+    header: t("workspace.teams.team_name"),
+    headerClassName: "w-[30%]",
+    cellClassName: "font-medium",
+    cell: (team) => team.name,
+  },
+  {
+    id: "size",
+    header: t("common.size"),
+    headerClassName: "w-[15%]",
+    cell: (team) => t("common.count_members", { count: team.memberCount }),
+  },
+  {
+    id: "teamId",
+    header: t("common.team_id"),
+    headerClassName: "w-[30%]",
+    cell: (team) => <IdBadge id={team.id} />,
+  },
+  {
+    id: "permission",
+    header: t("workspace.teams.permission"),
+    headerClassName: "w-[25%]",
+    cellClassName: "capitalize",
+    cell: (team) => TeamPermissionMapping[team.permission],
+  },
+];
+
+export const AccessTable = ({ teams }: Readonly<AccessTableProps>) => {
   const { t } = useTranslation();
 
   return (
-    <div className="overflow-hidden rounded-lg">
-      <Table>
-        <TableHeader>
-          <TableRow className="bg-slate-100">
-            <TableHead className="font-medium text-slate-500">{t("workspace.teams.team_name")}</TableHead>
-            <TableHead className="font-medium text-slate-500">{t("common.size")}</TableHead>
-            <TableHead className="font-medium text-slate-500">{t("common.team_id")}</TableHead>
-            <TableHead className="font-medium text-slate-500">{t("workspace.teams.permission")}</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody className="[&_tr:last-child]:border-b">
-          {teams.length === 0 && (
-            <TableRow>
-              <TableCell colSpan={4} className="text-center">
-                {t("workspace.teams.no_teams_found")}
-              </TableCell>
-            </TableRow>
-          )}
-          {teams.map((team) => (
-            <TableRow key={team.id}>
-              <TableCell className="font-medium">{team.name}</TableCell>
-              <TableCell>{t("common.count_members", { count: team.memberCount })}</TableCell>
-              <TableCell>
-                <IdBadge id={team.id} />
-              </TableCell>
-              <TableCell>
-                <p className="capitalize">{TeamPermissionMapping[team.permission]}</p>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
+    <SettingsTable
+      columns={getWorkspaceTeamColumns(t)}
+      rows={teams}
+      getRowId={(team) => team.id}
+      emptyMessage={t("workspace.teams.no_teams_found")}
+      aria-label={t("common.team_access")}
+    />
   );
 };

--- a/apps/web/modules/ee/teams/workspace-teams/components/access-view.tsx
+++ b/apps/web/modules/ee/teams/workspace-teams/components/access-view.tsx
@@ -16,8 +16,10 @@ export const AccessView = ({ teams }: AccessViewProps) => {
     <>
       <SettingsCard
         title={t("common.team_access")}
-        description={t("workspace.teams.team_settings_description")}>
-        <div className="mb-4 flex justify-end">
+        description={t("workspace.teams.team_settings_description")}
+        bodyVariant="flush">
+        {/* The table is edge-to-edge, so the control above it carries the card's gutter itself. */}
+        <div className="mb-4 flex justify-end px-4 pt-4">
           <ManageTeam />
         </div>
         <AccessTable teams={teams} />

--- a/apps/web/modules/ui/components/settings-table/lib/column-classes.test.ts
+++ b/apps/web/modules/ui/components/settings-table/lib/column-classes.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "vitest";
 import type { TSettingsTableColumn } from "../types";
 import {
@@ -136,5 +139,100 @@ describe("getRowActivatorColumnId", () => {
 
   test("returns undefined for no columns rather than throwing", () => {
     expect(getRowActivatorColumnId([])).toBeUndefined();
+  });
+});
+
+/**
+ * `headerClassName` and `cellClassName` are merged straight onto the `<th>`/`<td>`, so a display utility
+ * there stops the element being a table cell: the shared `align-middle` becomes a no-op (`vertical-align`
+ * applies only to inline-level and table-cell boxes) and the browser wraps the cell in an anonymous
+ * table-cell that defaults to baseline, leaving content sitting high in the row.
+ *
+ * That constraint was documented on both props and immediately violated in four column definitions
+ * anyway, so it is checked here rather than left to prose. Layout for cell content belongs on a wrapper
+ * element inside `cell`.
+ *
+ * This reads source text, so it only catches the literal form every call site actually uses
+ * (`cellClassName: "..."`). A computed value or a `cn()` call would slip past — it is a guard against the
+ * easy mistake, not a proof.
+ */
+describe("column class props never change a cell's display", () => {
+  const DISPLAY_UTILITIES = new Set([
+    "block",
+    "inline-block",
+    "inline",
+    "flex",
+    "inline-flex",
+    "table",
+    "inline-table",
+    "table-caption",
+    "table-cell",
+    "table-column",
+    "table-column-group",
+    "table-footer-group",
+    "table-header-group",
+    "table-row-group",
+    "table-row",
+    "flow-root",
+    "grid",
+    "inline-grid",
+    "contents",
+    "list-item",
+    "hidden",
+  ]);
+
+  const IGNORED_DIRS = new Set(["node_modules", ".next", "dist", "coverage"]);
+  const CLASS_PROP = /\b(cellClassName|headerClassName):\s*"([^"]*)"/g;
+
+  /** `sm:flex` and `hover:block` set display just as surely as the bare utility does. */
+  const withoutVariants = (token: string): string => token.slice(token.lastIndexOf(":") + 1);
+
+  const collectSourceFiles = (dir: string, found: string[] = []): string[] => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        if (!IGNORED_DIRS.has(entry.name)) collectSourceFiles(path.join(dir, entry.name), found);
+      } else if (entry.name.endsWith(".tsx") || entry.name.endsWith(".ts")) {
+        found.push(path.join(dir, entry.name));
+      }
+    }
+    return found;
+  };
+
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const appRoot = path.resolve(here, "..", "..", "..", "..", "..");
+
+  test("no column definition in the app puts a display utility on a header or body cell", () => {
+    const offenders: string[] = [];
+
+    for (const file of [
+      ...collectSourceFiles(path.join(appRoot, "modules")),
+      ...collectSourceFiles(path.join(appRoot, "app")),
+    ]) {
+      const source = fs.readFileSync(file, "utf-8");
+
+      for (const [, prop, classes] of source.matchAll(CLASS_PROP)) {
+        const display = classes
+          .split(/\s+/)
+          .filter(Boolean)
+          .map(withoutVariants)
+          .filter((token) => DISPLAY_UTILITIES.has(token));
+
+        if (display.length > 0) {
+          offenders.push(
+            `${path.relative(appRoot, file)} — ${prop}: "${classes}" sets ${display.join(", ")}`
+          );
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  test("the scan actually reaches the settings tables it is meant to guard", () => {
+    const files = collectSourceFiles(path.join(appRoot, "modules"));
+
+    // A silently empty walk would make the test above pass for the wrong reason.
+    expect(files.some((file) => file.endsWith("feedback-directory-table.tsx"))).toBe(true);
+    expect(files.some((file) => file.endsWith("column-classes.ts"))).toBe(true);
   });
 });

--- a/apps/web/modules/ui/components/settings-table/types.ts
+++ b/apps/web/modules/ui/components/settings-table/types.ts
@@ -15,7 +15,15 @@ export type TSettingsTableColumn<TRow> = {
   /** Already-translated header label. `null` renders an empty header cell — pair it with `srLabel`. */
   header: ReactNode;
   cell: (row: TRow, index: number) => ReactNode;
-  /** Applies to the header cell and every body cell in this column. Defaults to `left`. */
+  /**
+   * Sets `text-align` on the header cell and every body cell in this column. Defaults to `left`.
+   *
+   * It moves **inline** content only. A cell holding block-level content — buttons, a link, a badge —
+   * is unaffected, and needs a flex `cellClassName` (`flex justify-end`) to move instead. Don't declare
+   * both for one column: the flex wins, and the `align` sitting next to it reads as load-bearing while
+   * being inert. The skeleton draws its bar through the same two class sources, so whichever mechanism
+   * aligns the real cell is also the one aligning the skeleton.
+   */
   align?: TSettingsTableAlign;
   /** Hides the column below this breakpoint. Applied to the header and body cells together. */
   hideBelow?: TSettingsTableBreakpoint;

--- a/apps/web/modules/ui/components/settings-table/types.ts
+++ b/apps/web/modules/ui/components/settings-table/types.ts
@@ -18,11 +18,10 @@ export type TSettingsTableColumn<TRow> = {
   /**
    * Sets `text-align` on the header cell and every body cell in this column. Defaults to `left`.
    *
-   * It moves **inline** content only. A cell holding block-level content — buttons, a link, a badge —
-   * is unaffected, and needs a flex `cellClassName` (`flex justify-end`) to move instead. Don't declare
-   * both for one column: the flex wins, and the `align` sitting next to it reads as load-bearing while
-   * being inert. The skeleton draws its bar through the same two class sources, so whichever mechanism
-   * aligns the real cell is also the one aligning the skeleton.
+   * It moves **inline-level** content, which covers text, badges and `Button`/`Link` (both `inline-flex`).
+   * It cannot move a block-level child, so a cell whose content is a wrapper `<div>` — or the skeleton's
+   * placeholder bar — is unaffected by it. Declaring it alongside a flex wrapper is therefore inert; pick
+   * one and let it be the only alignment source for the column.
    */
   align?: TSettingsTableAlign;
   /** Hides the column below this breakpoint. Applied to the header and body cells together. */
@@ -36,7 +35,16 @@ export type TSettingsTableColumn<TRow> = {
    * from a short one, and when a `hideBelow` column drops out the remaining widths rescale.
    */
   headerClassName?: string;
-  /** Extra classes merged onto every `<td>` in this column, e.g. `font-medium text-slate-900`. */
+  /**
+   * Extra classes merged onto every `<td>` in this column, e.g. `font-medium text-slate-900`.
+   *
+   * **Do not change the cell's `display` here** — no `flex`, `grid` or `block`. These classes land on the
+   * `<td>` itself, so overriding `display` stops it being a table-cell: the shared `align-middle` becomes
+   * a no-op (`vertical-align` applies only to inline-level and table-cell boxes) and the browser wraps the
+   * cell in an anonymous table-cell that defaults to baseline, so the content sits high in the row. To lay
+   * cell content out, put the flex on a wrapper element **inside** `cell` instead. (`hideBelow` exists for
+   * the same reason — it uses `table-cell`, not `block`.)
+   */
   cellClassName?: string;
   /** Accessible name for a header cell whose `header` is `null` — typically an actions column. */
   srLabel?: string;


### PR DESCRIPTION
## What & why

Fifth of the ENG-762 series. **Stacked on #8840 — this PR's diff is only its last commit.**
(#8837, #8838 and #8839 have merged.)

Two conversions, grouped because neither has Playwright coverage to update and both were already on the
`Table` primitive.

**Team access** (`access-table.tsx`, `access-view.tsx`) — straight conversion. The card gets
`bodyVariant="flush"` so the table runs edge to edge, and the `ManageTeam` button above it carries
`px-4 pt-4` itself, since a flush body no longer supplies the gutter.

**Feedback directories** (`feedback-directory-table.tsx`, `feedback-directory-view.tsx`) — same
conversion, plus dropping the redundant `role="rowgroup"`/`role="row"` that were set on a real
`<thead>`/`<tr>`.

### Changed after review

Three things came out of review, all worth stating plainly:

1. **The table had no frame at all.** I converted it to `SettingsTable` (which defaults to
   `frame="none"`) and deleted its own `overflow-hidden rounded-lg border` wrapper, but never updated
   `feedback-directory-view.tsx` — its `SettingsCard` still defaulted to `bodyVariant="padded"`. So
   neither the table nor the card drew a frame. Fixed by adding `bodyVariant="flush"` to the parent,
   matching `access-view.tsx`.
2. **`isRowDisabled` is gone from this table.** I had replaced per-button `disabled` with row-level
   dimming, which broke two things: it blocked the "View data" navigation link (never disabled before,
   and it has nothing to race), and `pointer-events-none` only stops the mouse — a keyboard user could
   still Tab to another row's Manage and press Enter, starting exactly the concurrent request the guard
   was meant to prevent. `disabled={loadingDirectoryId !== null}` is back on Manage/Unarchive,
   byte-identical to the pre-PR behaviour, and "View data" is untouched.
3. **Columns moved to a module-level factory.** An inline `cell` arrow returning JSX reads as a nested
   component definition to Sonar (`typescript:S6478`), which flagged 2 issues here. The factory pattern
   the pretty-URLs and enterprise tables already use has 0 — so this aligns the series rather than
   suppressing anything.

Also un-exported `getWorkspaceTeamColumns`: the factory-export pattern exists so a `loading.tsx` can
share the columns, and this one's skeleton isn't a table, so nothing consumed it.

**Not changed:** `TeamPermissionMapping` renders English literals (`"Read"`, `"Manage"`). Real bug, but
pre-existing — the old code rendered the identical literal — and fixing it means new i18n keys, a shared
util's contract, and its unit test. Out of scope for a restyle; flagged as follow-up.

## Linear ticket

Ref ENG-762

## Screenshots

> **Component renders, not app screenshots** — no Docker here, so no database to boot the app against.
> Real markup, the repo's own compiled `globals.css`, and every class string through the same
> `tailwind-merge` the components use.
>
> **These are now known to be misleading in one respect**, and it is worth saying why: the harness drew
> the "after" state I *intended*, not the state the code produced. It models the table but not
> `feedback-directory-view.tsx`, so it could not show the missing frame that review caught. Treat them as
> illustrating the target, not as evidence the code reaches it.

| Before | After (intended) |
| --- | --- |
| <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8841/before-feedback-directories.jpg" width="440"> | <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8841/after-feedback-directories.jpg" width="440"> |

The in-flight dimming shot that was here has been removed — that behaviour no longer exists.

## How this was tested

- **Rebased after #8839 was squash-merged.** The squash gave `main` a different SHA from the commit this
  chain was stacked on, so the whole `settings-table/` primitive replayed as new files in #8840's diff
  (8 files, +622/−107, conflicted). #8840 was rebased onto the squashed `main` and this branch replayed
  on top; its diff is back to its own **4 files, +152/−106**. One drift adopted from `main` in passing:
  `getPrettyUrlColumns` is exported there, so that export stays.
- `npx turbo run typecheck --filter=@formbricks/web` → **12/12 tasks successful, 0 errors.** (Earlier
  runs in this series reported 33 pre-existing errors from `@formbricks/jobs` being unbuilt in my
  sandbox; turbo has since built it, so there is a genuinely clean baseline now — which matters more
  because `main` just gained a `pnpm typecheck` CI gate.)
- `npx eslint` on all four changed files → clean.
- `npx vitest run` on the settings-table suite → **25/25 pass**.
- `prettier --check` on every changed file → clean.
- **Queried the SonarCloud API across the whole series** rather than reading one warning in isolation:
  `#8839` 0 issues, `#8840` 0, `#8841` 2, `#8842` 2 — perfectly correlated with whether the columns were
  inline or in a module-level factory. That is what identified the fix as a pattern rather than a
  one-off.
- **Then verified the fix locally instead of waiting on CI.**
  `react/no-unstable-nested-components` is ESLint's analogue of `typescript:S6478` — it emits the same
  sentence Sonar does (*"move this component definition out of the parent component and pass data as
  props"*). Ran it over all six files in the series: **0 errors.** Also confirmed the rule genuinely
  fires on the flagged pattern, by running it against a four-line fixture holding an inline
  JSX-returning `cell` arrow — it flags that. So the check is meaningful, not vacuously passing.
- Verified every i18n key used already exists; no new keys, so `pnpm i18n` has nothing to regenerate.
- Confirmed no Playwright spec references either table's DOM.

**Still owed before merge:** a visual pass on a running app. This PR is the reason to insist on it — a
missing prop in a parent file is exactly what a component-render harness cannot catch.

## Breaking changes

None

## QA / Test Plan

**How to test**

Team access:

- [ ] Open Workspace settings → Team access → the table fills the card edge to edge, header band flush
      against the card's title divider, last row meeting the card's bottom border
- [ ] On that page, check the "Manage" button above the table → still inset from the card's edges with
      the same spacing as before → a button touching the card edge is the regression
- [ ] Read across a row → team name, size, team ID badge, permission (capitalised)
- [ ] Click the copy icon on a team ID badge → the ID is copied
- [ ] Hover a row → no highlight (rows are not interactive)
- [ ] Open the page for a workspace with no teams → "No teams found" as a single centred row, headers
      still visible

Feedback directories:

- [ ] Open Org settings → Feedback directories → **the table has a visible border and rounded corners,
      filling the card edge to edge** → no border at all is the bug this PR fixes; two parallel lines is
      the nested-frame bug
- [ ] Check the "Show archived" switch and "Create" button above the table → both inset from the card
      edges, not touching them
- [ ] Click "Manage" on a directory → its button shows a spinner and the other rows' Manage/Unarchive
      buttons become disabled → **the other rows do not dim, and "View data" on them stays clickable**
- [ ] While that request is in flight, Tab to another row's "Manage" and press Enter → nothing happens
      (the button is genuinely disabled, not just unclickable by mouse)
- [ ] While that request is in flight, click "View data" on a different row → it navigates normally
- [ ] Toggle "Show archived" → archived directories appear with a grey "Archived" badge and an
      "Unarchive" button
- [ ] Click "Unarchive" → same spinner and disabling behaviour → directory becomes Active
- [ ] Click "Unarchive" on a directory whose workspace already has another directory → the conflict
      toast appears and nothing changes
- [ ] Open the page for an org with no directories → the empty-state row shows, headers still visible

**Preconditions / test data**

- Enterprise license (both surfaces are EE)
- An org with at least 3 feedback directories, one archived, at least one linked to a workspace the test
  user can reach (so "View data" renders)
- A workspace with 2+ teams at different permission levels, plus one workspace with none
- For the unarchive conflict: two directories assigned to the same workspace, one archived

**Risks & regressions**

- The frame fix touches `feedback-directory-view.tsx`, which was outside the original diff. Confirm the
  card's own padding still looks right around the controls above the table.
- Action-button behaviour is now back to pre-PR parity, so the risk is the opposite of before: a button
  that *isn't* disabled during another row's request, or a "View data" link that *is*.
- The columns moved to a module-level factory. Same rendered output, but the actions column is the one
  with real branching (archived vs not, owner/manager vs not), so it's worth clicking through both
  states.

**Migrations / env / cutover**

- none
