### PR TITLE
refactor(settings): move organization teams onto SettingsTable

### DIFF
--- a/apps/web/modules/ee/teams/team-list/components/teams-table.tsx
+++ b/apps/web/modules/ee/teams/team-list/components/teams-table.tsx
@@ -86,7 +86,9 @@ const getTeamColumns = ({
     header: null,
     srLabel: t("common.actions"),
     headerClassName: "w-[20%]",
-    align: "right",
+    // No `align: "right"`: the header is empty and the cell's button is block-level, so `text-align` has
+    // nothing to move in either. The flex is what right-aligns the button — and a skeleton bar, if this
+    // array is ever fed to `SettingsTableSkeleton`.
     cellClassName: "flex justify-end",
     stopRowClick: true,
     cell: (row) => (

--- a/apps/web/modules/ee/teams/team-list/components/teams-table.tsx
+++ b/apps/web/modules/ee/teams/team-list/components/teams-table.tsx
@@ -86,18 +86,19 @@ const getTeamColumns = ({
     header: null,
     srLabel: t("common.actions"),
     headerClassName: "w-[20%]",
-    // No `align: "right"`: the header is empty and the cell's button is block-level, so `text-align` has
-    // nothing to move in either. The flex is what right-aligns the button — and a skeleton bar, if this
-    // array is ever fed to `SettingsTableSkeleton`.
-    cellClassName: "flex justify-end",
     stopRowClick: true,
+    // The flex goes on a wrapper inside the cell, not on `cellClassName`: that class lands on the `<td>`,
+    // and `display: flex` there stops it being a table-cell, which kills the shared `align-middle` and
+    // leaves the button baseline-aligned. `align: "right"` is no help either — the wrapper is block-level.
     cell: (row) => (
-      <ManageTeamButton
-        disabled={isManageDisabled(row, isOwnerOrManager)}
-        onClick={() => {
-          onManage(row.team.id);
-        }}
-      />
+      <div className="flex justify-end">
+        <ManageTeamButton
+          disabled={isManageDisabled(row, isOwnerOrManager)}
+          onClick={() => {
+            onManage(row.team.id);
+          }}
+        />
+      </div>
     ),
   },
 ];

--- a/apps/web/modules/ee/teams/team-list/components/teams-table.tsx
+++ b/apps/web/modules/ee/teams/team-list/components/teams-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { TFunction } from "i18next";
 import { useState } from "react";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
@@ -19,7 +20,19 @@ import {
 } from "@/modules/ee/teams/team-list/types/team";
 import { TOrganizationWorkspace } from "@/modules/ee/teams/team-list/types/workspace";
 import { Badge } from "@/modules/ui/components/badge";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/modules/ui/components/table";
+import { SettingsTable, type TSettingsTableColumn } from "@/modules/ui/components/settings-table";
+
+/** A team plus whether the current user is in it — the only thing the two source lists differ by. */
+type TTeamRow = { team: TUserTeam; isMember: true } | { team: TOtherTeam; isMember: false };
+
+/**
+ * Owners and managers can manage any team. Everyone else can only manage a team they are an admin of,
+ * which by definition means a team they belong to.
+ */
+const isManageDisabled = (row: TTeamRow, isOwnerOrManager: boolean): boolean => {
+  if (isOwnerOrManager) return false;
+  return !row.isMember || row.team.userRole !== "admin";
+};
 
 interface TeamsTableProps {
   teams: { userTeams: TUserTeam[]; otherTeams: TOtherTeam[] };
@@ -30,6 +43,63 @@ interface TeamsTableProps {
   currentUserId: string;
 }
 
+/**
+ * Defined at module level rather than inside the component: an inline `cell` that returns JSX reads as a
+ * nested component definition to Sonar (typescript:S6478), and re-declaring the array per render buys
+ * nothing.
+ */
+const getTeamColumns = ({
+  t,
+  isOwnerOrManager,
+  onManage,
+}: Readonly<{
+  t: TFunction;
+  isOwnerOrManager: boolean;
+  onManage: (teamId: string) => void;
+}>): TSettingsTableColumn<TTeamRow>[] => [
+  {
+    id: "name",
+    header: t("workspace.settings.teams.team_name"),
+    headerClassName: "w-[40%]",
+    cell: (row) => row.team.name,
+  },
+  {
+    id: "size",
+    header: t("common.size"),
+    headerClassName: "w-[20%]",
+    cell: (row) => t("common.count_members", { count: row.team.memberCount }),
+  },
+  {
+    id: "membership",
+    header: null,
+    // A column header is announced for every row in the column, so it has to be neutral —
+    // "You are a member" would claim membership on the rows that have no badge.
+    srLabel: t("common.membership"),
+    headerClassName: "w-[20%]",
+    cell: (row) =>
+      row.isMember ? (
+        <Badge type="success" size="tiny" text={t("workspace.settings.teams.you_are_a_member")} />
+      ) : null,
+  },
+  {
+    id: "actions",
+    header: null,
+    srLabel: t("common.actions"),
+    headerClassName: "w-[20%]",
+    align: "right",
+    cellClassName: "flex justify-end",
+    stopRowClick: true,
+    cell: (row) => (
+      <ManageTeamButton
+        disabled={isManageDisabled(row, isOwnerOrManager)}
+        onClick={() => {
+          onManage(row.team.id);
+        }}
+      />
+    ),
+  },
+];
+
 export const TeamsTable = ({
   teams,
   organizationId,
@@ -37,7 +107,7 @@ export const TeamsTable = ({
   orgWorkspaces,
   membershipRole,
   currentUserId,
-}: TeamsTableProps) => {
+}: Readonly<TeamsTableProps>) => {
   const { t } = useTranslation();
   const [openSettingsModal, setOpenSettingsModal] = useState(false);
   const [selectedTeam, setSelectedTeam] = useState<TTeamDetails>();
@@ -64,71 +134,34 @@ export const TeamsTable = ({
 
   const { userTeams, otherTeams } = teams;
 
-  const allTeams = [...userTeams, ...otherTeams];
+  // One row list, tagged with whether the current user belongs to the team. The two lists used to be
+  // mapped separately into a shared <TableBody>, which meant duplicating all four cells to vary two of
+  // them; the tag lets the membership badge and the manage-permission rule branch per row instead.
+  const rows: TTeamRow[] = [
+    ...userTeams.map((team) => ({ team, isMember: true as const })),
+    ...otherTeams.map((team) => ({ team, isMember: false as const })),
+  ];
 
   return (
     <>
       {isOwnerOrManager && (
-        <div className="mb-4 flex justify-end">
+        // The table is edge-to-edge, so the control above it carries the card's gutter itself.
+        <div className="mb-4 flex justify-end px-4 pt-4">
           <CreateTeamButton organizationId={organizationId} />
         </div>
       )}
 
-      <div className="overflow-hidden rounded-lg" aria-label="Teams list">
-        <Table>
-          <TableHeader role="rowgroup">
-            <TableRow className="bg-slate-100" role="row">
-              <TableHead className="font-medium text-slate-500">
-                {t("workspace.settings.teams.team_name")}
-              </TableHead>
-              <TableHead className="font-medium text-slate-500">{t("common.size")}</TableHead>
-              <TableHead></TableHead>
-              <TableHead></TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody className="[&_tr:last-child]:border-b">
-            {allTeams.length === 0 && (
-              <TableRow>
-                <TableCell colSpan={4} className="text-center">
-                  {t("workspace.settings.teams.empty_teams_state")}
-                </TableCell>
-              </TableRow>
-            )}
-            {userTeams.map((team) => (
-              <TableRow key={team.id} id={team.name}>
-                <TableCell>{team.name}</TableCell>
-                <TableCell>{t("common.count_members", { count: team.memberCount })}</TableCell>
-                <TableCell>
-                  <Badge type="success" size={"tiny"} text={t("workspace.settings.teams.you_are_a_member")} />
-                </TableCell>
-                <TableCell className="flex justify-end">
-                  <ManageTeamButton
-                    disabled={!isOwnerOrManager && team.userRole !== "admin"}
-                    onClick={() => {
-                      handleManageTeam(team.id);
-                    }}
-                  />
-                </TableCell>
-              </TableRow>
-            ))}
-            {otherTeams.map((team) => (
-              <TableRow key={team.id} id={team.name}>
-                <TableCell>{team.name}</TableCell>
-                <TableCell>{t("common.count_members", { count: team.memberCount })}</TableCell>
-                <TableCell></TableCell>
-                <TableCell className="flex justify-end">
-                  <ManageTeamButton
-                    disabled={!isOwnerOrManager}
-                    onClick={() => {
-                      handleManageTeam(team.id);
-                    }}
-                  />
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
+      <SettingsTable
+        columns={getTeamColumns({ t, isOwnerOrManager, onManage: handleManageTeam })}
+        rows={rows}
+        getRowId={(row) => row.team.id}
+        emptyMessage={t("workspace.settings.teams.empty_teams_state")}
+        // A constant testid, not one built from the team name: names are user-supplied and not unique,
+        // so a name-keyed testid would reintroduce the collision that dropping `id={team.name}` fixed.
+        // Specs narrow by row text instead.
+        getRowProps={() => ({ "data-testid": "team-row" })}
+        aria-label={t("common.teams")}
+      />
       {openSettingsModal && selectedTeam && (
         <TeamSettingsModal
           open={openSettingsModal}

--- a/apps/web/modules/ee/teams/team-list/components/teams-view.tsx
+++ b/apps/web/modules/ee/teams/team-list/components/teams-view.tsx
@@ -50,7 +50,9 @@ export const TeamsView = async ({
   return (
     <SettingsCard
       title={t("workspace.settings.teams.teams")}
-      description={t("workspace.settings.teams.teams_description")}>
+      description={t("workspace.settings.teams.teams_description")}
+      // The table runs edge to edge; the upgrade prompt shown in its place still wants the gutter.
+      bodyVariant={isAccessControlAllowed ? "flush" : "padded"}>
       {isAccessControlAllowed ? (
         <TeamsTable
           teams={teams}

--- a/apps/web/modules/organization/settings/teams/components/edit-memberships/edit-memberships.tsx
+++ b/apps/web/modules/organization/settings/teams/components/edit-memberships/edit-memberships.tsx
@@ -1,7 +1,6 @@
 import { TOrganizationRole } from "@formbricks/types/memberships";
 import { TOrganization } from "@formbricks/types/organizations";
 import { IS_FORMBRICKS_CLOUD } from "@/lib/constants";
-import { getTranslate } from "@/lingodotdev/server";
 import { MembersInfo } from "@/modules/organization/settings/teams/components/edit-memberships/members-info";
 import { getInvitesByOrganizationId } from "@/modules/organization/settings/teams/lib/invite";
 import { getMembershipByOrganizationId } from "@/modules/organization/settings/teams/lib/membership";
@@ -14,6 +13,11 @@ interface EditMembershipsProps {
   isUserManagementDisabledFromUi: boolean;
 }
 
+/**
+ * The column headers used to live here, hand-rolled as a `grid-cols-12` of divs, while the rows lived in
+ * `MembersInfo` — two files repeating the same `col-span-*` sequence and the same two feature flags. They
+ * are now one column array in `MembersInfo`, which is where the flags already were.
+ */
 export const EditMemberships = async ({
   organization,
   currentUserId,
@@ -23,37 +27,19 @@ export const EditMemberships = async ({
 }: EditMembershipsProps) => {
   const members = await getMembershipByOrganizationId(organization.id);
   const invites = await getInvitesByOrganizationId(organization.id);
-  const t = await getTranslate();
+
+  if (!role) return null;
 
   return (
-    <div>
-      <div className="rounded-lg border border-slate-200">
-        <div className="grid h-12 w-full max-w-full grid-cols-12 items-center gap-x-4 rounded-t-lg bg-slate-100 px-4 text-left text-sm font-semibold text-slate-900">
-          <div className="col-span-2 overflow-hidden">{t("common.full_name")}</div>
-          <div className="col-span-3 overflow-hidden">{t("common.email")}</div>
-
-          {isAccessControlAllowed && <div className="col-span-2 whitespace-nowrap">{t("common.role")}</div>}
-
-          <div className="col-span-2 whitespace-nowrap">{t("common.status")}</div>
-
-          {!isUserManagementDisabledFromUi && (
-            <div className="col-span-3 text-center whitespace-nowrap">{t("common.actions")}</div>
-          )}
-        </div>
-
-        {role && (
-          <MembersInfo
-            organization={organization}
-            currentUserId={currentUserId}
-            invites={invites ?? []}
-            members={members ?? []}
-            currentUserRole={role}
-            isAccessControlAllowed={isAccessControlAllowed}
-            isFormbricksCloud={IS_FORMBRICKS_CLOUD}
-            isUserManagementDisabledFromUi={isUserManagementDisabledFromUi}
-          />
-        )}
-      </div>
-    </div>
+    <MembersInfo
+      organization={organization}
+      currentUserId={currentUserId}
+      invites={invites ?? []}
+      members={members ?? []}
+      currentUserRole={role}
+      isAccessControlAllowed={isAccessControlAllowed}
+      isFormbricksCloud={IS_FORMBRICKS_CLOUD}
+      isUserManagementDisabledFromUi={isUserManagementDisabledFromUi}
+    />
   );
 };

--- a/apps/web/modules/organization/settings/teams/components/edit-memberships/members-info.tsx
+++ b/apps/web/modules/organization/settings/teams/components/edit-memberships/members-info.tsx
@@ -171,12 +171,14 @@ const getMemberColumns = ({
       id: "actions",
       header: t("common.actions"),
       headerClassName: "w-[24%]",
-      // Unlike the other actions columns in this series, `align` is doing real work here: this header has
+      // `align` is doing real work here, unlike the other actions columns in this series: this header has
       // visible text, and `text-align` is the only thing that moves it. Right rather than the centre the
-      // old header used, so the label sits over the controls it names. The flex below is a separate job —
-      // moving the block-level buttons, which `text-align` cannot.
+      // old header used, so the label sits over the controls it names.
+      //
+      // Nothing goes on `cellClassName`: `MemberActions` already renders its own `flex justify-end`
+      // wrapper, and putting the flex on the `<td>` would stop it being a table-cell — killing the shared
+      // `align-middle` and leaving the buttons baseline-aligned rather than centred.
       align: "right",
-      cellClassName: "flex justify-end",
       cell: (member) => (
         <MemberActions
           organization={organization}

--- a/apps/web/modules/organization/settings/teams/components/edit-memberships/members-info.tsx
+++ b/apps/web/modules/organization/settings/teams/components/edit-memberships/members-info.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 import { TMember, TOrganizationRole } from "@formbricks/types/memberships";
 import { TOrganization } from "@formbricks/types/organizations";
@@ -10,7 +11,190 @@ import { MemberActions } from "@/modules/organization/settings/teams/components/
 import { isInviteExpired } from "@/modules/organization/settings/teams/lib/utils";
 import { TInvite } from "@/modules/organization/settings/teams/types/invites";
 import { Badge } from "@/modules/ui/components/badge";
+import { SettingsTable, type TSettingsTableColumn } from "@/modules/ui/components/settings-table";
 import { TooltipRenderer } from "@/modules/ui/components/tooltip";
+
+/** The two row shapes this table mixes: accepted memberships and pending invites. */
+type TMemberRow = TMember | TInvite;
+
+// Type guard to check if member is an invitee
+const isInvitee = (member: TMemberRow): member is TInvite => {
+  return (member as TInvite).expiresAt !== undefined;
+};
+
+/**
+ * The four badge texts are English literals, as they were before this conversion. Fixing that needs new
+ * i18n keys and is a behaviour change rather than a restyle, so it stays a follow-up.
+ */
+const getMembershipBadge = (member: TMemberRow, t: TFunction, locale: string) => {
+  if (isInvitee(member)) {
+    return isInviteExpired(member) ? (
+      <Badge type="gray" text="Expired" size="tiny" data-testid="expired-badge" />
+    ) : (
+      <TooltipRenderer
+        tooltipContent={`${t("workspace.settings.general.invite_expires_on", {
+          date: formatDateWithOrdinal(member.expiresAt, locale),
+        })}`}>
+        <Badge type="warning" text="Pending" size="tiny" />
+      </TooltipRenderer>
+    );
+  }
+
+  if (!member.isActive) {
+    return <Badge type="gray" text="Inactive" size="tiny" />;
+  }
+
+  return <Badge type="success" text="Active" size="tiny" />;
+};
+
+const showDeleteButton = (
+  member: TMemberRow,
+  {
+    isOwnerOrManager,
+    isManager,
+    currentUserId,
+    doesOrgHaveMoreThanOneOwner,
+  }: Readonly<{
+    isOwnerOrManager: boolean;
+    isManager: boolean;
+    currentUserId: string;
+    doesOrgHaveMoreThanOneOwner: boolean;
+  }>
+): boolean => {
+  if (isInvitee(member)) {
+    return isOwnerOrManager;
+  }
+
+  if (!isOwnerOrManager) {
+    return false;
+  }
+
+  if (member.userId === currentUserId) {
+    return false;
+  }
+
+  if (isManager) {
+    return member.role !== "owner";
+  }
+
+  if (member.role === "owner") {
+    return doesOrgHaveMoreThanOneOwner;
+  }
+
+  return true;
+};
+
+/**
+ * Defined at module level rather than inside the component: an inline `cell` that returns JSX reads as a
+ * nested component definition to Sonar (typescript:S6478), and re-declaring the array per render buys
+ * nothing.
+ *
+ * The two optional columns are pushed onto one array instead of being guarded in both a header file and a
+ * row file. That duplication — the same two flags spelled out twice, in two components — is what let the
+ * header and the rows drift apart in the first place.
+ */
+const getMemberColumns = ({
+  t,
+  locale,
+  organization,
+  currentUserRole,
+  currentUserId,
+  isAccessControlAllowed,
+  isFormbricksCloud,
+  isUserManagementDisabledFromUi,
+  isOwnerOrManager,
+  isManager,
+  doesOrgHaveMoreThanOneOwner,
+}: Readonly<{
+  t: TFunction;
+  locale: string;
+  organization: TOrganization;
+  currentUserRole: TOrganizationRole;
+  currentUserId: string;
+  isAccessControlAllowed: boolean;
+  isFormbricksCloud: boolean;
+  isUserManagementDisabledFromUi: boolean;
+  isOwnerOrManager: boolean;
+  isManager: boolean;
+  doesOrgHaveMoreThanOneOwner: boolean;
+}>): TSettingsTableColumn<TMemberRow>[] => {
+  // `ph-no-capture` on the name, email and role cells is PostHog redaction, not styling.
+  const columns: TSettingsTableColumn<TMemberRow>[] = [
+    {
+      id: "name",
+      header: t("common.full_name"),
+      headerClassName: "w-[17%]",
+      cellClassName: "ph-no-capture",
+      cell: (member) => member.name,
+    },
+    {
+      id: "email",
+      header: t("common.email"),
+      headerClassName: "w-[25%]",
+      cellClassName: "ph-no-capture",
+      cell: (member) => member.email,
+    },
+  ];
+
+  if (isAccessControlAllowed) {
+    columns.push({
+      id: "role",
+      header: t("common.role"),
+      headerClassName: "w-[17%]",
+      cellClassName: "ph-no-capture",
+      cell: (member) => (
+        <EditMembershipRole
+          currentUserRole={currentUserRole}
+          memberRole={member.role}
+          memberId={!isInvitee(member) ? member.userId : ""}
+          organizationId={organization.id}
+          userId={currentUserId}
+          memberAccepted={!isInvitee(member) ? member.accepted : undefined}
+          inviteId={isInvitee(member) ? member.id : ""}
+          doesOrgHaveMoreThanOneOwner={doesOrgHaveMoreThanOneOwner}
+          isFormbricksCloud={isFormbricksCloud}
+          isUserManagementDisabledFromUi={isUserManagementDisabledFromUi}
+        />
+      ),
+    });
+  }
+
+  columns.push({
+    id: "status",
+    header: t("common.status"),
+    headerClassName: "w-[17%]",
+    cell: (member) => getMembershipBadge(member, t, locale),
+  });
+
+  if (!isUserManagementDisabledFromUi) {
+    columns.push({
+      id: "actions",
+      header: t("common.actions"),
+      headerClassName: "w-[24%]",
+      // Unlike the other actions columns in this series, `align` is doing real work here: this header has
+      // visible text, and `text-align` is the only thing that moves it. Right rather than the centre the
+      // old header used, so the label sits over the controls it names. The flex below is a separate job —
+      // moving the block-level buttons, which `text-align` cannot.
+      align: "right",
+      cellClassName: "flex justify-end",
+      cell: (member) => (
+        <MemberActions
+          organization={organization}
+          member={isInvitee(member) ? undefined : member}
+          invite={isInvitee(member) ? member : undefined}
+          showDeleteButton={showDeleteButton(member, {
+            isOwnerOrManager,
+            isManager,
+            currentUserId,
+            doesOrgHaveMoreThanOneOwner,
+          })}
+        />
+      ),
+    });
+  }
+
+  return columns;
+};
 
 interface MembersInfoProps {
   organization: TOrganization;
@@ -23,11 +207,6 @@ interface MembersInfoProps {
   isUserManagementDisabledFromUi: boolean;
 }
 
-// Type guard to check if member is an invitee
-const isInvitee = (member: TMember | TInvite): member is TInvite => {
-  return (member as TInvite).expiresAt !== undefined;
-};
-
 export const MembersInfo = ({
   organization,
   invites,
@@ -37,105 +216,43 @@ export const MembersInfo = ({
   isAccessControlAllowed,
   isFormbricksCloud,
   isUserManagementDisabledFromUi,
-}: MembersInfoProps) => {
-  const allMembers = [...members, ...invites];
+}: Readonly<MembersInfoProps>) => {
   const { t, i18n } = useTranslation();
   const locale = i18n.resolvedLanguage ?? i18n.language ?? "en-US";
 
-  const getMembershipBadge = (member: TMember | TInvite) => {
-    if (isInvitee(member)) {
-      return isInviteExpired(member) ? (
-        <Badge type="gray" text="Expired" size="tiny" data-testid="expired-badge" />
-      ) : (
-        <TooltipRenderer
-          tooltipContent={`${t("workspace.settings.general.invite_expires_on", {
-            date: formatDateWithOrdinal(member.expiresAt, locale),
-          })}`}>
-          <Badge type="warning" text="Pending" size="tiny" />
-        </TooltipRenderer>
-      );
-    }
-
-    if (!member.isActive) {
-      return <Badge type="gray" text="Inactive" size="tiny" />;
-    }
-
-    return <Badge type="success" text="Active" size="tiny" />;
-  };
+  const allMembers = [...members, ...invites];
 
   const { isOwner, isManager } = getAccessFlags(currentUserRole);
   const isOwnerOrManager = isOwner || isManager;
 
   const doesOrgHaveMoreThanOneOwner = allMembers.filter((member) => member.role === "owner").length > 1;
 
-  const showDeleteButton = (member: TMember | TInvite) => {
-    if (isInvitee(member)) {
-      return isOwnerOrManager;
-    }
-
-    if (!isOwnerOrManager) {
-      return false;
-    }
-
-    if (member.userId === currentUserId) {
-      return false;
-    }
-
-    if (isManager) {
-      return member.role !== "owner";
-    }
-
-    if (member.role === "owner") {
-      return doesOrgHaveMoreThanOneOwner;
-    }
-
-    return true;
-  };
-
   return (
-    <div className="max-w-full space-y-4 px-4 py-3" id="membersInfoWrapper">
-      {allMembers.map((member) => (
-        <div
-          id="singleMemberInfo"
-          className="grid w-full max-w-full grid-cols-12 items-center gap-x-4 text-left text-sm text-slate-900"
-          key={member.email}>
-          <div className="ph-no-capture col-span-2 overflow-hidden">
-            <p className="w-full truncate">{member.name}</p>
-          </div>
-          <div className="ph-no-capture col-span-3 overflow-hidden">
-            <p className="w-full truncate"> {member.email}</p>
-          </div>
-
-          {isAccessControlAllowed && allMembers?.length > 0 && (
-            <div className="ph-no-capture col-span-2">
-              <EditMembershipRole
-                currentUserRole={currentUserRole}
-                memberRole={member.role}
-                memberId={!isInvitee(member) ? member.userId : ""}
-                organizationId={organization.id}
-                userId={currentUserId}
-                memberAccepted={!isInvitee(member) ? member.accepted : undefined}
-                inviteId={isInvitee(member) ? member.id : ""}
-                doesOrgHaveMoreThanOneOwner={doesOrgHaveMoreThanOneOwner}
-                isFormbricksCloud={isFormbricksCloud}
-                isUserManagementDisabledFromUi={isUserManagementDisabledFromUi}
-              />
-            </div>
-          )}
-          <div className="col-span-2 flex items-center">{getMembershipBadge(member)}</div>
-
-          {!isUserManagementDisabledFromUi && (
-            <div className="col-span-3">
-              <MemberActions
-                organization={organization}
-                member={isInvitee(member) ? undefined : member}
-                invite={isInvitee(member) ? member : undefined}
-                showDeleteButton={showDeleteButton(member)}
-              />
-            </div>
-          )}
-        </div>
-      ))}
-    </div>
+    <SettingsTable
+      columns={getMemberColumns({
+        t,
+        locale,
+        organization,
+        currentUserRole,
+        currentUserId,
+        isAccessControlAllowed,
+        isFormbricksCloud,
+        isUserManagementDisabledFromUi,
+        isOwnerOrManager,
+        isManager,
+        doesOrgHaveMoreThanOneOwner,
+      })}
+      rows={allMembers}
+      getRowId={(member) => member.email}
+      // Effectively unreachable: whoever is looking at this page is themselves a member.
+      emptyMessage={t("common.no_results")}
+      // These two ids are what `organization.spec.ts` and `invite-existing-account.spec.ts` locate. Kept
+      // exactly where they were — on the row container and on each row — so this conversion needs no
+      // spec changes. `#singleMemberInfo` repeating per row is invalid HTML and worth retiring, but that
+      // is a spec change, so it stays a follow-up.
+      bodyProps={{ id: "membersInfoWrapper" }}
+      getRowProps={() => ({ id: "singleMemberInfo" })}
+      aria-label={t("workspace.settings.general.manage_members")}
+    />
   );
 };

--- a/apps/web/modules/organization/settings/teams/components/members-view.tsx
+++ b/apps/web/modules/organization/settings/teams/components/members-view.tsx
@@ -20,8 +20,9 @@ interface MembersViewProps {
   isUserManagementDisabledFromUi: boolean;
 }
 
+// Carries its own gutter for the same reason the controls above do: the card body is flush.
 export const MembersLoading = () => (
-  <div className="px-2">
+  <div className="px-4">
     {Array.from(Array(2)).map((_, index) => (
       <div key={index} className="mt-4">
         <div className={`h-8 w-80 animate-pulse rounded-full bg-slate-200`} />
@@ -58,24 +59,28 @@ export const MembersView = async ({
   return (
     <SettingsCard
       title={t("workspace.settings.general.manage_members")}
-      description={t("workspace.settings.general.manage_members_description")}>
+      description={t("workspace.settings.general.manage_members_description")}
+      bodyVariant="flush">
+      {/* The table is edge-to-edge, so the controls above it carry the card's gutter themselves. */}
       {membershipRole && (
-        <OrganizationActions
-          organization={organization}
-          membershipRole={membershipRole}
-          role={membershipRole}
-          isLeaveOrganizationDisabled={isLeaveOrganizationDisabled}
-          isInviteDisabled={INVITE_DISABLED}
-          isAccessControlAllowed={isAccessControlAllowed}
-          isFormbricksCloud={IS_FORMBRICKS_CLOUD}
-          enterpriseLicenseRequestFormUrl={ENTERPRISE_LICENSE_REQUEST_FORM_URL}
-          isMultiOrgEnabled={isMultiOrgEnabled}
-          teams={teams}
-          isUserManagementDisabledFromUi={isUserManagementDisabledFromUi}
-          isTeamAdmin={isTeamAdminUser}
-          userAdminTeamIds={userAdminTeamIds}
-          isBulkInviteAllowed={isBulkInviteAllowed}
-        />
+        <div className="px-4 pt-4">
+          <OrganizationActions
+            organization={organization}
+            membershipRole={membershipRole}
+            role={membershipRole}
+            isLeaveOrganizationDisabled={isLeaveOrganizationDisabled}
+            isInviteDisabled={INVITE_DISABLED}
+            isAccessControlAllowed={isAccessControlAllowed}
+            isFormbricksCloud={IS_FORMBRICKS_CLOUD}
+            enterpriseLicenseRequestFormUrl={ENTERPRISE_LICENSE_REQUEST_FORM_URL}
+            isMultiOrgEnabled={isMultiOrgEnabled}
+            teams={teams}
+            isUserManagementDisabledFromUi={isUserManagementDisabledFromUi}
+            isTeamAdmin={isTeamAdminUser}
+            userAdminTeamIds={userAdminTeamIds}
+            isBulkInviteAllowed={isBulkInviteAllowed}
+          />
+        </div>
       )}
 
       {membershipRole && (

--- a/apps/web/playwright/organization.spec.ts
+++ b/apps/web/playwright/organization.spec.ts
@@ -127,7 +127,7 @@ test.describe("Create, update and delete team", async () => {
     await page.getByRole("button", { name: "Create new team" }).click();
     await page.locator("#team-name").fill("E2E");
     await page.getByRole("button", { name: "Create" }).click();
-    await expect(page.locator("#E2E")).toBeVisible();
+    await expect(page.getByTestId("team-row").filter({ hasText: "E2E" })).toBeVisible();
 
     await page.getByRole("button", { name: "Manage team" }).click();
 


### PR DESCRIPTION
## What & why

Sixth of the ENG-762 series, and the last of Wave 2. **Stacked on #8841 — this PR's diff is its last two
commits.** (#8837, #8838, #8839 and #8840 have merged.)

It converts **both tables on the organization settings page** onto `SettingsTable`: Teams, and — after
review — Manage members. They had to go together; see below.

### Organization teams (`8d6c828`)

- **One row list instead of two.** `userTeams` and `otherTeams` were mapped separately into one shared
  `<TableBody>`, which meant writing all four cells twice in order to vary two of them. They are now a
  single list tagged `isMember`, so the badge and the permission rule branch per row.
- **The permission rule is named.** It was duplicated and slightly opaque —
  `!isOwnerOrManager && team.userRole !== "admin"` on one list, `!isOwnerOrManager` on the other. Now
  `isManageDisabled` states it once: owners and managers can manage any team, everyone else only a team
  they are an admin of. (Those two expressions were equivalent only because `userRole` exists solely on
  the user's own teams — exactly the kind of thing worth making explicit.)
- **`id={team.name}` → a constant `data-testid="team-row"`**, with `organization.spec.ts:130` narrowing by
  row text: `getByTestId("team-row").filter({ hasText: "E2E" })`. A team name is user-supplied and not
  unique, so it was never a safe DOM id — and keying the testid off it would have reproduced the same
  collision.

### Manage members (`9f16f59`) — added after review

Dhruwang pointed out that converting only Teams left **two table styles on one page**: Members kept an
inner `rounded-lg border` frame with `font-semibold text-slate-900` headers while Teams became
edge-to-edge with `font-medium text-slate-500`. That is a regression of this ticket's own goal, caused
purely by conversion order, so it is fixed here rather than deferred.

Members was originally scheduled as a later PR because I'd assessed it as the riskiest of the eleven
tables. **Two of those concerns were wrong**, and saying so is the honest justification for pulling it
forward:

- I'd recorded that the server/client split would have to collapse, since a `columns` array holds `cell`
  functions and functions cannot cross the server→client boundary. True as a constraint, moot in
  practice: `members-info.tsx` is **already `"use client"`** and already held `t` and every flag.
- I'd expected to rewrite selectors in two specs. Not needed — `bodyProps` and `getRowProps` put
  `#membersInfoWrapper` on the `<tbody>` and `#singleMemberInfo` on each `<tr>`, exactly where they were.
  **Zero spec changes**, so this is *lower* E2E risk than the teams commit, which did edit a spec.

The structural fix: headers lived in `edit-memberships.tsx` as a `grid-cols-12` of divs while rows lived
in `members-info.tsx`, so both files repeated the same `col-span-*` sequence **and the same two feature
flags**. They are now one array with the optional columns pushed onto it, so a column and its header
cannot drift apart. `edit-memberships.tsx` is left with just its two data fetches.

Both cards pick `bodyVariant="flush"`, so the controls above each table carry the gutter themselves. The
teams card picks its variant conditionally, because an `UpgradePrompt` renders in place of the table when
access control isn't licensed and still wants the padding.

## Earlier review fixes (teams commit)

- **Constant testid, not `team-row-${row.team.name}`** — the first version contradicted this PR's own
  reason for dropping `id={team.name}`.
- **`srLabel: t("common.membership")`, not the badge text** — a column header is announced for *every*
  cell in the column, so "You are a member" would have claimed membership on rows with no badge.
- **`Readonly<TeamsTableProps>`**, per the repo convention.
- **`getTeamColumns` moved to module level** — Sonar reads an inline JSX-returning `cell` arrow as a
  nested component definition (`typescript:S6478`). Sonar's gate now reports **0 new issues**.

## Behaviour deltas to be aware of

| Change | Why |
| --- | --- |
| Long member names/emails **wrap instead of truncating** | They were `truncate` inside a fixed grid fraction; a `<td>` has none. Full value stays visible, row may grow taller. Say the word and I'll constrain the cell instead. |
| Members' **Actions header moves centre → right** | It now sits over the buttons it labels. |
| Both tables' headers go **bold slate-900 → medium slate-500** | The shared settings-table treatment. |
| Members rows go **gapped (`space-y-4`) → divided** | The largest visual delta in the series, and what makes the two tables match. |

`ph-no-capture` is preserved on the name, email and role cells — PostHog redaction, not styling.

## Linear ticket

Ref ENG-762

## Screenshots

> **Component renders, not app screenshots.** No Docker daemon here, so no database to boot the app
> against. Real component markup, the repo's own compiled `globals.css`, and every class string put through
> the same `tailwind-merge` the components use. Tokens and spacing are exact; the teams shown are
> fabricated. **A real visual pass is still owed** — and note that this harness models a table but not its
> parent file, which is exactly how a missing `bodyVariant` slipped through on #8841.

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8842/before-org-teams.jpg" width="440"> | <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8842/after-org-teams.jpg" width="440"> |

These cover the teams table only; the members conversion landed after they were rendered. The thing to
look at on a running app is the **pair** of cards together, which no render here shows.

## How this was tested

- `npx turbo run typecheck --filter=@formbricks/web` → **12/12 tasks successful, 0 errors.** This PR leans
  on it: `TTeamRow` is a discriminated union, so `row.team.userRole` inside `isManageDisabled` is only
  legal on the `isMember: true` branch — the typechecker is what proves the permission rule didn't change
  shape. Same for `TMemberRow`, where `isActive`/`userId`/`accepted` are only reachable after the
  `isInvitee` guard.
- `npx vitest run modules/ui/components/settings-table` → **25/25 pass**.
- `npx eslint` on all changed components → clean. `npx prettier --check` → clean.
- **Sonar quality gate passed, 0 new issues, 0 security hotspots.** Independently verified the S6478 fix
  locally with `react/no-unstable-nested-components` (ESLint's analogue, same message text) across all
  files in the series — 0 errors — and confirmed the rule really fires on the flagged pattern using a
  four-line fixture, so the pass isn't vacuous.
- **Rebased twice.** #8839 and then #8840 merged as squashes, each time orphaning the commit this chain
  sat on and inflating the diff with already-merged files. Current base is #8841 on top of `main`
  `48b9a17`; the per-PR diff is 6 files.
- **Read both members specs line by line** rather than assuming the id passthrough works:
  `organization.spec.ts:41` asserts `#membersInfoWrapper` visible (now the `<tbody>` — has a bounding box,
  so still visible), `:43` filters `#singleMemberInfo` by email text, `:48` locates `#shareInviteButton`
  *inside* that row (it lives in `MemberActions`, untouched), and `:46` reads the `"Pending"` badge text.
  The commented-out `:100` uses `#membersInfoWrapper > #singleMemberInfo:last-child` — a direct-child
  selector that `tbody > tr` still satisfies.

**Still owed before merge:** I cannot run Playwright here — no Docker, so no database and no app. Three
specs touch this work. `organization.spec.ts` has **one edited line** (the teams testid). The two members
specs should pass **completely unchanged** — if either fails, the `bodyProps`/`getRowProps` id passthrough
is the first place to look. Everything in the QA plan below needs a running app.

## Breaking changes

None

## QA / Test Plan

**How to test**

Both cards live on Organization settings → Teams (`/organizations/<id>/settings/teams`).

- [ ] Open Organization settings → Teams, and compare the two cards → **both tables must read as one
      style**: same header tint, same medium grey header type, both edge-to-edge, neither with an inner
      border → an inner frame on Members is the bug this PR fixes
- [ ] On that page, look at the "Invite member" and "Create new team" buttons → both inset from their
      card's edges, not touching them
- [ ] On that page, read across a members row → full name, email, role dropdown, status badge, three
      action buttons right-aligned under a right-aligned "Actions" header
- [ ] On that page, read across a teams row → team name, size, membership badge, "Manage team" button
- [ ] Invite a member, then reload the page → the new row shows a "Pending" badge; hover it → tooltip
      gives the expiry date
- [ ] Click the role dropdown on a members row → it opens and is **not clipped** by the card edge (the
      card now has `overflow-hidden`; the menu portals out, so clipping would be the regression)
- [ ] Change a member's role via that dropdown → toast appears, row reflects the new role after refresh
- [ ] Click the trash button on a members row, confirm → the row disappears
- [ ] Click the share-invite button on a pending row → the invite-link modal opens
- [ ] Sign in as an **owner or manager**, open the page → "Manage team" is enabled on every teams row,
      including teams you are not in
- [ ] Sign in as a **plain member who is admin of exactly one team**, open the page → "Manage team" is
      enabled only on that team's row, disabled on all others → this is the refactored permission rule and
      the main thing to verify
- [ ] Sign in as a **plain member who is only a contributor**, open the page → "Manage team" is disabled
      on every row
- [ ] Click "Manage team" → the team settings modal opens with that team's name as its heading
- [ ] Create a team, then delete it from the modal → it appears in, then disappears from, the table
- [ ] Open the page for an org with no teams → an empty-state row shows with the headers still above it
- [ ] Open the page on an instance **without** an Enterprise license → the upgrade prompt renders in place
      of the teams table and keeps its normal padding inside the card, not edge to edge
- [ ] Open the page as a role where the Role column is gated off (no access-control license) → the members
      table drops that column with no empty gap left behind
- [ ] Narrow the browser to ~600px, then reload → neither table forces the page to scroll sideways
- [ ] Turn on a screen reader and move through the teams table → the badge column announces as
      "Membership" on every row, and rows without a badge do not announce as being a member
- [ ] Open DevTools and inspect a members row → `ph-no-capture` is still present on the name, email and
      role cells → losing it is a privacy regression, not a style one

**Preconditions / test data**

- Enterprise license for the teams table; a non-licensed instance or org for the upgrade-prompt branch,
  and one without access control for the gated Role column
- Three accounts for the permission matrix: an org owner/manager, a plain member who is admin of exactly
  one team, and a plain member who is only a contributor
- An org with at least 3 teams — one the test user belongs to, one they don't
- At least one pending invite and one accepted member, plus ideally an expired invite for the "Expired"
  badge
- A member whose name or email is long enough to have previously truncated (~40+ chars), to see the new
  wrapping

**Risks & regressions**

- `isManageDisabled` is the highest-risk extraction: getting it wrong either locks a team admin out of
  their own team or lets a contributor manage teams. The permission matrix above is the check.
- `showDeleteButton` moved to module level with its four inputs passed explicitly. Its five branches
  (invitee, non-manager, self, manager-vs-owner, last-owner) are unchanged, but the last-owner rule is
  subtle: verify an org with a single owner cannot delete that owner, and one with two owners can.
- Row order is unchanged — user teams before other teams, members before invites. A reshuffle is a
  regression.
- `organization.spec.ts:130` now depends on `data-testid="team-row"` plus a `hasText: "E2E"` filter.
- The two members specs depend on `#membersInfoWrapper` and `#singleMemberInfo` surviving as `<tbody>` and
  `<tr>` ids.

**Migrations / env / cutover**

- none

## Follow-ups this PR deliberately does not do

- `#singleMemberInfo` repeats on every row — invalid HTML, pre-existing. Retiring it means editing two
  specs I can't run.
- The four member status badges render English literals (`"Active"`, `"Pending"`, `"Expired"`,
  `"Inactive"`) instead of `t()` calls. Pre-existing; needs new i18n keys.
- `organization.spec.ts:22` and `invite-existing-account.spec.ts:30` both wait for
  `[data-testid="members-loading-card"]` to become hidden, and **that testid exists nowhere in the app** —
  so the wait resolves instantly and those specs have no real guard against racing the members list.
  Pre-existing and untouched here, but worth fixing.
