### PR TITLE
feat(helm): add scalable background embedding pool

### DIFF
--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -120,6 +120,86 @@ jobs:
 
           helm template qa "$chart" \
             --set formbricks.webappUrl=https://qa.example.com \
+            --set hub.embeddings.enabled=true \
+            --show-only templates/hub-deployment.yaml \
+            --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-embeddings-legacy.yaml"
+          test "$(grep -c 'http://formbricks-hub-embeddings:8080/v1' "$render_dir/hub-embeddings-legacy.yaml")" -eq 2
+          ! grep -q 'hub-embeddings-background:8080/v1' "$render_dir/hub-embeddings-legacy.yaml"
+          grep -A1 'name: EMBEDDING_BATCH_SIZE' "$render_dir/hub-embeddings-legacy.yaml" | grep -q 'value: "1"'
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set hub.embeddings.enabled=true \
+            --set hub.embeddings.background.enabled=true \
+            --set-string hub.embeddings.background.maxConcurrent=24 \
+            --set-string hub.embeddings.background.batchSize=8 \
+            --set-string hub.embeddings.background.batchMaxWaitMs=25 \
+            --set-string hub.embeddings.background.batchMaxInFlight=3 \
+            --set hub.embeddings.background.persistence.storageClass=gp3 \
+            --set hub.embeddings.background.autoscaling.enabled=true \
+            --show-only templates/hub-deployment.yaml \
+            --show-only templates/hub-worker-deployment.yaml \
+            --show-only templates/hub-embeddings-background-statefulset.yaml \
+            --show-only templates/hub-embeddings-background-service.yaml \
+            --show-only templates/hub-hpa.yaml > "$render_dir/hub-embeddings-background.yaml"
+          test "$(grep -c 'http://formbricks-hub-embeddings:8080/v1' "$render_dir/hub-embeddings-background.yaml")" -eq 1
+          test "$(grep -c 'http://formbricks-hub-embeddings-background:8080/v1' "$render_dir/hub-embeddings-background.yaml")" -eq 1
+          grep -A1 'name: EMBEDDING_MAX_CONCURRENT' "$render_dir/hub-embeddings-background.yaml" | grep -q 'value: "24"'
+          grep -A1 'name: EMBEDDING_BATCH_SIZE' "$render_dir/hub-embeddings-background.yaml" | grep -q 'value: "8"'
+          grep -q '^kind: StatefulSet$' "$render_dir/hub-embeddings-background.yaml"
+          grep -q 'podManagementPolicy: Parallel' "$render_dir/hub-embeddings-background.yaml"
+          test "$(grep -c 'whenScaled: Retain' "$render_dir/hub-embeddings-background.yaml")" -eq 1
+          grep -q '^  volumeClaimTemplates:$' "$render_dir/hub-embeddings-background.yaml"
+          grep -q 'storageClassName: "gp3"' "$render_dir/hub-embeddings-background.yaml"
+          grep -A3 'kind: StatefulSet' "$render_dir/hub-embeddings-background.yaml" | grep -q 'hub-embeddings-background'
+          grep -q '^  minReplicas: 1$' "$render_dir/hub-embeddings-background.yaml"
+          grep -q '^  maxReplicas: 6$' "$render_dir/hub-embeddings-background.yaml"
+          grep -q 'stabilizationWindowSeconds: 900' "$render_dir/hub-embeddings-background.yaml"
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set hub.embeddings.enabled=true \
+            --set hub.embeddings.background.enabled=true \
+            --set hub.embeddings.background.persistence.enabled=false \
+            --show-only templates/hub-embeddings-background-statefulset.yaml > "$render_dir/hub-embeddings-background-ephemeral.yaml"
+          grep -q '^      volumes:$' "$render_dir/hub-embeddings-background-ephemeral.yaml"
+          grep -q 'emptyDir: {}' "$render_dir/hub-embeddings-background-ephemeral.yaml"
+          ! grep -q '^  volumeClaimTemplates:$' "$render_dir/hub-embeddings-background-ephemeral.yaml"
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            > "$render_dir/hub-embedding-backfill-disabled.yaml"
+          ! grep -q 'app.kubernetes.io/component: hub-embedding-backfill' "$render_dir/hub-embedding-backfill-disabled.yaml"
+
+          if helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set hub.embeddings.enabled=true \
+            --set hub.embeddingBackfill.enabled=true \
+            --show-only templates/hub-embedding-backfill-job.yaml > "$render_dir/hub-embedding-backfill-invalid.yaml" 2>&1; then
+            echo "Expected an enabled embedding backfill without runId to fail" >&2
+            exit 1
+          fi
+          grep -q 'hub.embeddingBackfill.runId is required' "$render_dir/hub-embedding-backfill-invalid.yaml"
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
+            --set hub.embeddings.enabled=true \
+            --set hub.embeddings.background.enabled=true \
+            --set hub.embeddingBackfill.enabled=true \
+            --set hub.embeddingBackfill.runId=eu-canary-001 \
+            --set hub.embeddingBackfill.taxonomy=true \
+            --set hub.embeddingBackfill.tenantId=tenant-a \
+            --set hub.embeddingBackfill.countOnly=false \
+            --set hub.embeddingBackfill.maxRecords=500 \
+            --show-only templates/hub-embedding-backfill-job.yaml > "$render_dir/hub-embedding-backfill.yaml"
+          grep -q '^kind: Job$' "$render_dir/hub-embedding-backfill.yaml"
+          grep -q 'embedding-backfill-eu-canary-001' "$render_dir/hub-embedding-backfill.yaml"
+          grep -q -- '- --taxonomy' "$render_dir/hub-embedding-backfill.yaml"
+          grep -A1 -- '- --tenant-id' "$render_dir/hub-embedding-backfill.yaml" | grep -q -- '- "tenant-a"'
+          grep -A1 -- '- --max-records' "$render_dir/hub-embedding-backfill.yaml" | grep -q -- '- "500"'
+
+          helm template qa "$chart" \
+            --set formbricks.webappUrl=https://qa.example.com \
             --show-only templates/hub-deployment.yaml \
             --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-default.yaml"
           ! grep -q 'qa-hub-credentials' "$render_dir/hub-default.yaml"

--- a/.github/workflows/helm-chart-validation.yml
+++ b/.github/workflows/helm-chart-validation.yml
@@ -121,11 +121,13 @@ jobs:
           helm template qa "$chart" \
             --set formbricks.webappUrl=https://qa.example.com \
             --set hub.embeddings.enabled=true \
+            --set-string hub.embeddings.background.batchMaxWaitMs=37 \
             --show-only templates/hub-deployment.yaml \
             --show-only templates/hub-worker-deployment.yaml > "$render_dir/hub-embeddings-legacy.yaml"
           test "$(grep -c 'http://formbricks-hub-embeddings:8080/v1' "$render_dir/hub-embeddings-legacy.yaml")" -eq 2
           ! grep -q 'hub-embeddings-background:8080/v1' "$render_dir/hub-embeddings-legacy.yaml"
           grep -A1 'name: EMBEDDING_BATCH_SIZE' "$render_dir/hub-embeddings-legacy.yaml" | grep -q 'value: "1"'
+          grep -A1 'name: EMBEDDING_BATCH_MAX_WAIT_MS' "$render_dir/hub-embeddings-legacy.yaml" | grep -q 'value: "25"'
 
           helm template qa "$chart" \
             --set formbricks.webappUrl=https://qa.example.com \

--- a/charts/formbricks/README.md
+++ b/charts/formbricks/README.md
@@ -113,6 +113,47 @@ The generated Hub embedding configuration is:
 - `EMBEDDING_BASE_URL=http://<release>-hub-embeddings:8080/v1`
 - `EMBEDDING_PROVIDER_API_KEY` from a dedicated embeddings Secret
 
+For sustained background throughput, enable the worker-only TEI pool. Hub API and semantic-search
+queries continue to use the foreground service; only `hub-worker` receives the background URL and
+micro-batch settings:
+
+```yaml
+hub:
+  embeddings:
+    enabled: true
+    background:
+      enabled: true
+      maxConcurrent: "24"
+      batchSize: "8"
+      batchMaxWaitMs: "25"
+      batchMaxInFlight: "3"
+      persistence:
+        storageClass: gp3
+      resources:
+        requests:
+          cpu: "8"
+          memory: 8Gi
+      autoscaling:
+        enabled: true
+        minReplicas: 1
+        maxReplicas: 6
+```
+
+The background pool is a StatefulSet with one retained RWO cache PVC per replica. Before a planned
+backfill, temporarily set both autoscaling replica bounds to the desired pre-warmed count and wait
+for every pod to become Ready. Restore the steady-state bounds after the backlog drains.
+
+Embedding backfills are opt-in and never render a Job unless `hub.embeddingBackfill.enabled=true`.
+Each deliberate run requires a new `runId`; start with `countOnly: true`, then use `tenantId` or
+`maxRecords` to limit canary waves before an unlimited run. The selected Hub image must include
+`/app/backfill-embeddings` (a release containing [formbricks/hub#121](https://github.com/formbricks/hub/pull/121));
+older images cannot run this Job.
+
+Hub exports the durable missing-record count as
+`hub_enrichment_pending_records{enrichment="taxonomy_embedding"}`. Alert when it remains above zero
+while `hub_river_queue_depth{queue="embeddings"}` remains zero for 15 minutes; that detects a
+stranded taxonomy backfill even when the UI progress bar has stopped moving.
+
 The TEI service is internal-only (`ClusterIP`) and not exposed through ingress. For private or gated models, provide `hub.embeddings.huggingFace.token` or set `hub.embeddings.huggingFace.existingSecret`.
 
 When TEI auth is enabled, configure the shared key through `hub.embeddings.auth.apiKey` or `hub.embeddings.auth.existingSecret`; the chart manages both TEI `API_KEY` and Hub `EMBEDDING_PROVIDER_API_KEY` from that source.
@@ -418,6 +459,21 @@ tokens, provider response bodies, and collector URLs are never telemetry fields.
 | hub.embeddings.auth.enabled                                        | bool   | `true`                                                                      |                                                           |
 | hub.embeddings.auth.existingSecret                                 | string | `""`                                                                        |                                                           |
 | hub.embeddings.auth.secretKey                                      | string | `"EMBEDDING_PROVIDER_API_KEY"`                                              |                                                           |
+| hub.embeddings.background.autoscaling.enabled                      | bool   | `false`                                                                     |                                                           |
+| hub.embeddings.background.autoscaling.maxReplicas                  | int    | `6`                                                                         |                                                           |
+| hub.embeddings.background.autoscaling.minReplicas                  | int    | `1`                                                                         |                                                           |
+| hub.embeddings.background.baseUrl                                  | string | `""`                                                                        | Defaults to the worker-only background TEI service URL.   |
+| hub.embeddings.background.batchMaxInFlight                         | string | `"1"`                                                                       |                                                           |
+| hub.embeddings.background.batchMaxWaitMs                           | string | `"25"`                                                                      |                                                           |
+| hub.embeddings.background.batchSize                                | string | `"1"`                                                                       |                                                           |
+| hub.embeddings.background.enabled                                  | bool   | `false`                                                                     |                                                           |
+| hub.embeddings.background.maxConcurrent                            | string | `"5"`                                                                       |                                                           |
+| hub.embeddings.background.persistence.enabled                      | bool   | `true`                                                                      |                                                           |
+| hub.embeddings.background.persistence.size                         | string | `"10Gi"`                                                                    | One retained cache volume per StatefulSet replica.        |
+| hub.embeddings.background.persistence.storageClass                 | string | `""`                                                                        |                                                           |
+| hub.embeddings.background.replicas                                 | int    | `1`                                                                         | Used when background autoscaling is disabled.             |
+| hub.embeddings.background.resources.requests.cpu                   | string | `"8"`                                                                       |                                                           |
+| hub.embeddings.background.resources.requests.memory                | string | `"8Gi"`                                                                     |                                                           |
 | hub.embeddings.autoscaling.enabled                                 | bool   | `false`                                                                     |                                                           |
 | hub.embeddings.autoscaling.maxReplicas                             | int    | `2`                                                                         |                                                           |
 | hub.embeddings.autoscaling.minReplicas                             | int    | `1`                                                                         |                                                           |
@@ -447,6 +503,12 @@ tokens, provider response bodies, and collector URLs are never telemetry fields.
 | hub.embeddings.service.port                                        | int    | `8080`                                                                      |                                                           |
 | hub.embeddings.service.type                                        | string | `"ClusterIP"`                                                               |                                                           |
 | hub.env                                                            | object | `{}`                                                                        |                                                           |
+| hub.embeddingBackfill.countOnly                                    | bool   | `true`                                                                      | Preview missing records without enqueueing.               |
+| hub.embeddingBackfill.enabled                                      | bool   | `false`                                                                     |                                                           |
+| hub.embeddingBackfill.maxRecords                                   | int    | `0`                                                                         | Zero means unlimited.                                     |
+| hub.embeddingBackfill.runId                                        | string | `""`                                                                        | Required unique identifier for each enabled Job run.      |
+| hub.embeddingBackfill.taxonomy                                     | bool   | `false`                                                                     | Use taxonomy-translated embedding input.                  |
+| hub.embeddingBackfill.tenantId                                     | string | `""`                                                                        | Restrict the run to one tenant.                           |
 | hub.existingSecret                                                 | string | `""`                                                                        |                                                           |
 | hub.extraVolumeMounts                                              | list   | `[]`                                                                        | Additional volume mounts for Hub API and worker.          |
 | hub.extraVolumes                                                   | list   | `[]`                                                                        | Additional pod volumes for Hub API and worker.            |

--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -404,6 +404,17 @@ Hub embeddings runtime resource name.
 {{- printf "%s-hub-embeddings" $base | trimSuffix "-" }}
 {{- end }}
 
+{{/* Worker-only background embeddings runtime resource name. */}}
+{{- define "formbricks.hubEmbeddingsBackgroundName" -}}
+{{- $base := include "formbricks.name" . | trunc 37 | trimSuffix "-" }}
+{{- printf "%s-hub-embeddings-background" $base | trimSuffix "-" }}
+{{- end }}
+
+{{/* Headless service for stable background StatefulSet identities. */}}
+{{- define "formbricks.hubEmbeddingsBackgroundHeadlessName" -}}
+{{- printf "%s-headless" (include "formbricks.hubEmbeddingsBackgroundName" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{/*
 Secret used by Hub and the embeddings runtime for the embeddings API key.
 */}}
@@ -436,6 +447,15 @@ OpenAI-compatible embeddings base URL used by Hub.
 {{- end -}}
 {{- end }}
 
+{{/* Worker-only OpenAI-compatible background embeddings base URL. */}}
+{{- define "formbricks.hubEmbeddingsBackgroundBaseURL" -}}
+{{- if .Values.hub.embeddings.background.baseUrl -}}
+{{- .Values.hub.embeddings.background.baseUrl -}}
+{{- else -}}
+{{- printf "http://%s:%v/v1" (include "formbricks.hubEmbeddingsBackgroundName" .) (.Values.hub.embeddings.background.service.port | default .Values.hub.embeddings.port) -}}
+{{- end -}}
+{{- end }}
+
 {{/*
 Embedding API key value for the generated embeddings secret.
 */}}
@@ -459,22 +479,39 @@ self-hosted runtime is enabled so Hub API and Hub worker cannot drift.
 */}}
 {{- define "formbricks.hubEmbeddingEnv" -}}
 {{- $root := .root -}}
+{{- $worker := .worker | default false -}}
 {{- if $root.Values.hub.embeddings.enabled }}
 - name: EMBEDDING_PROVIDER
   value: "openai"
 - name: EMBEDDING_MODEL
   value: {{ include "formbricks.hubEmbeddingsServedModelName" $root | quote }}
 - name: EMBEDDING_BASE_URL
+  {{- if and $worker $root.Values.hub.embeddings.background.enabled }}
+  value: {{ include "formbricks.hubEmbeddingsBackgroundBaseURL" $root | quote }}
+  {{- else }}
   value: {{ include "formbricks.hubEmbeddingsBaseURL" $root | quote }}
+  {{- end }}
 - name: EMBEDDING_PROVIDER_API_KEY
   valueFrom:
     secretKeyRef:
       name: {{ include "formbricks.hubEmbeddingsSecretName" $root }}
       key: {{ $root.Values.hub.embeddings.auth.secretKey | default "EMBEDDING_PROVIDER_API_KEY" }}
 - name: EMBEDDING_MAX_CONCURRENT
+  {{- if and $worker $root.Values.hub.embeddings.background.enabled }}
+  value: {{ $root.Values.hub.embeddings.background.maxConcurrent | quote }}
+  {{- else }}
   value: {{ $root.Values.hub.embeddings.maxConcurrent | quote }}
+  {{- end }}
 - name: EMBEDDING_NORMALIZE
   value: {{ $root.Values.hub.embeddings.normalize | quote }}
+{{- if $worker }}
+- name: EMBEDDING_BATCH_SIZE
+  value: {{ ternary $root.Values.hub.embeddings.background.batchSize "1" $root.Values.hub.embeddings.background.enabled | quote }}
+- name: EMBEDDING_BATCH_MAX_WAIT_MS
+  value: {{ $root.Values.hub.embeddings.background.batchMaxWaitMs | quote }}
+- name: EMBEDDING_BATCH_MAX_IN_FLIGHT
+  value: {{ ternary $root.Values.hub.embeddings.background.batchMaxInFlight "1" $root.Values.hub.embeddings.background.enabled | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 
@@ -483,9 +520,15 @@ Returns true when an env var is managed by hub.embeddings and should not be rend
 */}}
 {{- define "formbricks.hubEmbeddingEnvManaged" -}}
 {{- $key := .key -}}
-{{- if has $key (list "EMBEDDING_PROVIDER" "EMBEDDING_MODEL" "EMBEDDING_BASE_URL" "EMBEDDING_PROVIDER_API_KEY" "EMBEDDING_MAX_CONCURRENT" "EMBEDDING_NORMALIZE") -}}
+{{- if has $key (list "EMBEDDING_PROVIDER" "EMBEDDING_MODEL" "EMBEDDING_BASE_URL" "EMBEDDING_PROVIDER_API_KEY" "EMBEDDING_MAX_CONCURRENT" "EMBEDDING_NORMALIZE" "EMBEDDING_BATCH_SIZE" "EMBEDDING_BATCH_MAX_WAIT_MS" "EMBEDDING_BATCH_MAX_IN_FLIGHT") -}}
 true
 {{- end -}}
+{{- end }}
+
+{{/* Name of one deliberate embedding backfill run. */}}
+{{- define "formbricks.hubEmbeddingBackfillName" -}}
+{{- $runID := regexReplaceAll "[^a-z0-9-]+" (.Values.hub.embeddingBackfill.runId | lower) "-" | trunc 20 | trimAll "-" -}}
+{{- printf "%s-embedding-backfill-%s" (include "formbricks.hubname" . | trunc 22 | trimSuffix "-") $runID | trunc 63 | trimSuffix "-" -}}
 {{- end }}
 
 

--- a/charts/formbricks/templates/_helpers.tpl
+++ b/charts/formbricks/templates/_helpers.tpl
@@ -429,6 +429,13 @@ Secret used by the embeddings runtime for Hugging Face access.
 {{- default (include "formbricks.hubEmbeddingsSecretName" .) .Values.hub.embeddings.huggingFace.existingSecret -}}
 {{- end }}
 
+{{/* Reject Hugging Face tokens that cannot be written into an externally managed auth secret. */}}
+{{- define "formbricks.validateHubEmbeddingsHuggingFaceSecret" -}}
+{{- if and .Values.hub.embeddings.auth.existingSecret .Values.hub.embeddings.huggingFace.token (not .Values.hub.embeddings.huggingFace.existingSecret) -}}
+{{- fail "hub.embeddings.huggingFace.token cannot be stored when hub.embeddings.auth.existingSecret is set; put HF_TOKEN in the existing auth secret or set hub.embeddings.huggingFace.existingSecret" -}}
+{{- end -}}
+{{- end }}
+
 {{/*
 Model name Hub sends to the OpenAI-compatible embeddings endpoint.
 */}}
@@ -508,7 +515,7 @@ self-hosted runtime is enabled so Hub API and Hub worker cannot drift.
 - name: EMBEDDING_BATCH_SIZE
   value: {{ ternary $root.Values.hub.embeddings.background.batchSize "1" $root.Values.hub.embeddings.background.enabled | quote }}
 - name: EMBEDDING_BATCH_MAX_WAIT_MS
-  value: {{ $root.Values.hub.embeddings.background.batchMaxWaitMs | quote }}
+  value: {{ ternary $root.Values.hub.embeddings.background.batchMaxWaitMs "25" $root.Values.hub.embeddings.background.enabled | quote }}
 - name: EMBEDDING_BATCH_MAX_IN_FLIGHT
   value: {{ ternary $root.Values.hub.embeddings.background.batchMaxInFlight "1" $root.Values.hub.embeddings.background.enabled | quote }}
 {{- end }}

--- a/charts/formbricks/templates/hub-embedding-backfill-job.yaml
+++ b/charts/formbricks/templates/hub-embedding-backfill-job.yaml
@@ -1,0 +1,82 @@
+{{- if and .Values.hub.enabled .Values.hub.embeddingBackfill.enabled }}
+{{- if not .Values.hub.embeddings.enabled }}
+  {{- fail "hub.embeddingBackfill.enabled requires hub.embeddings.enabled" }}
+{{- end }}
+{{- if not .Values.hub.embeddingBackfill.runId }}
+  {{- fail "hub.embeddingBackfill.runId is required when the backfill Job is enabled" }}
+{{- end }}
+{{- if not (regexReplaceAll "[^a-z0-9-]+" (.Values.hub.embeddingBackfill.runId | lower) "-" | trimAll "-") }}
+  {{- fail "hub.embeddingBackfill.runId must contain at least one letter or number" }}
+{{- end }}
+{{- if lt (int .Values.hub.embeddingBackfill.maxRecords) 0 }}
+  {{- fail "hub.embeddingBackfill.maxRecords cannot be negative" }}
+{{- end }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "formbricks.hubEmbeddingBackfillName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.hubEmbeddingBackfillName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: hub-embedding-backfill
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+spec:
+  backoffLimit: {{ .Values.hub.embeddingBackfill.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.hub.embeddingBackfill.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "formbricks.hubEmbeddingBackfillName" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: hub-embedding-backfill
+    spec:
+      restartPolicy: Never
+      {{- if .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.deployment.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: backfill-embeddings
+          image: {{ include "formbricks.hubImage" . }}
+          imagePullPolicy: {{ .Values.hub.image.pullPolicy }}
+          command:
+            - /app/backfill-embeddings
+          {{- if or .Values.hub.embeddingBackfill.taxonomy .Values.hub.embeddingBackfill.tenantId .Values.hub.embeddingBackfill.countOnly (gt (int .Values.hub.embeddingBackfill.maxRecords) 0) }}
+          args:
+            {{- if .Values.hub.embeddingBackfill.taxonomy }}
+            - --taxonomy
+            {{- end }}
+            {{- with .Values.hub.embeddingBackfill.tenantId }}
+            - --tenant-id
+            - {{ . | quote }}
+            {{- end }}
+            {{- if .Values.hub.embeddingBackfill.countOnly }}
+            - --count-only
+            {{- end }}
+            {{- if gt (int .Values.hub.embeddingBackfill.maxRecords) 0 }}
+            - --max-records
+            - {{ .Values.hub.embeddingBackfill.maxRecords | quote }}
+            {{- end }}
+          {{- end }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+          envFrom:
+            - secretRef:
+                name: {{ include "formbricks.hubSecretName" . }}
+          env:
+            {{- include "formbricks.hubEmbeddingEnv" (dict "root" $ "worker" true) | nindent 12 }}
+            {{- range $key, $value := .Values.hub.env }}
+            {{- if not (and $.Values.hub.embeddings.enabled (include "formbricks.hubEmbeddingEnvManaged" (dict "key" $key))) }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
+            {{- end }}
+            {{- end }}
+          {{- with .Values.hub.embeddingBackfill.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/charts/formbricks/templates/hub-embeddings-background-service.yaml
+++ b/charts/formbricks/templates/hub-embeddings-background-service.yaml
@@ -1,0 +1,58 @@
+{{- if and .Values.hub.enabled .Values.hub.embeddings.enabled .Values.hub.embeddings.background.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "formbricks.hubEmbeddingsBackgroundName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.hubEmbeddingsBackgroundName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: hub-embeddings-background
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+    {{- with .Values.hub.embeddings.background.service.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.hub.embeddings.background.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: {{ include "formbricks.hubEmbeddingsBackgroundName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.hub.embeddings.background.service.port }}
+      targetPort: http
+      protocol: TCP
+    - name: metrics
+      port: {{ .Values.hub.embeddings.prometheusPort }}
+      targetPort: metrics
+      protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "formbricks.hubEmbeddingsBackgroundHeadlessName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.hubEmbeddingsBackgroundName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: hub-embeddings-background
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: {{ include "formbricks.hubEmbeddingsBackgroundName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: {{ .Values.hub.embeddings.background.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/formbricks/templates/hub-embeddings-background-statefulset.yaml
+++ b/charts/formbricks/templates/hub-embeddings-background-statefulset.yaml
@@ -1,7 +1,5 @@
 {{- if and .Values.hub.enabled .Values.hub.embeddings.enabled .Values.hub.embeddings.background.enabled }}
-{{- if and .Values.hub.embeddings.auth.existingSecret .Values.hub.embeddings.huggingFace.token (not .Values.hub.embeddings.huggingFace.existingSecret) }}
-  {{- fail "hub.embeddings.huggingFace.token cannot be stored when hub.embeddings.auth.existingSecret is set; put HF_TOKEN in the existing auth secret or set hub.embeddings.huggingFace.existingSecret" }}
-{{- end }}
+{{- include "formbricks.validateHubEmbeddingsHuggingFaceSecret" . }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/charts/formbricks/templates/hub-embeddings-background-statefulset.yaml
+++ b/charts/formbricks/templates/hub-embeddings-background-statefulset.yaml
@@ -1,0 +1,170 @@
+{{- if and .Values.hub.enabled .Values.hub.embeddings.enabled .Values.hub.embeddings.background.enabled }}
+{{- if and .Values.hub.embeddings.auth.existingSecret .Values.hub.embeddings.huggingFace.token (not .Values.hub.embeddings.huggingFace.existingSecret) }}
+  {{- fail "hub.embeddings.huggingFace.token cannot be stored when hub.embeddings.auth.existingSecret is set; put HF_TOKEN in the existing auth secret or set hub.embeddings.huggingFace.existingSecret" }}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "formbricks.hubEmbeddingsBackgroundName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.hubEmbeddingsBackgroundName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: hub-embeddings-background
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+spec:
+  serviceName: {{ include "formbricks.hubEmbeddingsBackgroundHeadlessName" . }}
+  podManagementPolicy: Parallel
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
+  updateStrategy:
+    type: RollingUpdate
+  {{- if not .Values.hub.embeddings.background.autoscaling.enabled }}
+  replicas: {{ .Values.hub.embeddings.background.replicas | default 1 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "formbricks.hubEmbeddingsBackgroundName" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "formbricks.hubEmbeddingsBackgroundName" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: hub-embeddings-background
+        {{- with .Values.hub.embeddings.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.hub.embeddings.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.hub.embeddings.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.embeddings.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.embeddings.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.embeddings.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.hub.embeddings.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.deployment.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.deployment.imagePullSecrets | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: hub-embeddings-background
+          image: "{{ .Values.hub.embeddings.image.repository }}:{{ .Values.hub.embeddings.image.tag }}"
+          imagePullPolicy: {{ .Values.hub.embeddings.image.pullPolicy }}
+          {{- with .Values.hub.embeddings.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.hub.embeddings.args }}
+          args:
+            {{- toYaml .Values.hub.embeddings.args | nindent 12 }}
+          {{- else }}
+          args:
+            - --model-id
+            - {{ .Values.hub.embeddings.model | quote }}
+            - --port
+            - {{ .Values.hub.embeddings.port | quote }}
+            - --huggingface-hub-cache
+            - {{ .Values.hub.embeddings.background.persistence.mountPath | quote }}
+            - --served-model-name
+            - {{ include "formbricks.hubEmbeddingsServedModelName" . | quote }}
+            {{- with .Values.hub.embeddings.revision }}
+            - --revision
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.hub.embeddings.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.hub.embeddings.port }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.hub.embeddings.prometheusPort }}
+              protocol: TCP
+          {{- if or .Values.hub.embeddings.auth.enabled .Values.hub.embeddings.huggingFace.existingSecret .Values.hub.embeddings.huggingFace.token (gt (len .Values.hub.embeddings.env) 0) }}
+          env:
+            {{- if .Values.hub.embeddings.auth.enabled }}
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "formbricks.hubEmbeddingsSecretName" . }}
+                  key: {{ .Values.hub.embeddings.auth.secretKey | default "EMBEDDING_PROVIDER_API_KEY" | quote }}
+            {{- end }}
+            {{- if or .Values.hub.embeddings.huggingFace.existingSecret .Values.hub.embeddings.huggingFace.token }}
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "formbricks.hubEmbeddingsHuggingFaceSecretName" . }}
+                  key: {{ .Values.hub.embeddings.huggingFace.tokenKey | default "HF_TOKEN" | quote }}
+            {{- end }}
+            {{- range $key, $value := .Values.hub.embeddings.env }}
+            {{- if not (or (and $.Values.hub.embeddings.auth.enabled (eq $key "API_KEY")) (and (or $.Values.hub.embeddings.huggingFace.existingSecret $.Values.hub.embeddings.huggingFace.token) (eq $key "HF_TOKEN"))) }}
+            {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- with .Values.hub.embeddings.probes.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.hub.embeddings.probes.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.hub.embeddings.probes.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.hub.embeddings.background.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.hub.embeddings.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: model-cache
+              mountPath: {{ .Values.hub.embeddings.background.persistence.mountPath }}
+      {{- if not .Values.hub.embeddings.background.persistence.enabled }}
+      volumes:
+        - name: model-cache
+          emptyDir: {}
+      {{- end }}
+  {{- if .Values.hub.embeddings.background.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: model-cache
+      spec:
+        accessModes:
+          {{- toYaml .Values.hub.embeddings.background.persistence.accessModes | nindent 10 }}
+        resources:
+          requests:
+            storage: {{ .Values.hub.embeddings.background.persistence.size }}
+        {{- with .Values.hub.embeddings.background.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/formbricks/templates/hub-embeddings-deployment.yaml
+++ b/charts/formbricks/templates/hub-embeddings-deployment.yaml
@@ -1,11 +1,9 @@
 {{- if and .Values.hub.enabled .Values.hub.embeddings.enabled }}
 {{- $embeddingsReplicas := int (.Values.hub.embeddings.replicas | default 1) -}}
 {{- $embeddingsMaxReplicas := int (.Values.hub.embeddings.autoscaling.maxReplicas | default 1) -}}
+{{- include "formbricks.validateHubEmbeddingsHuggingFaceSecret" . }}
 {{- if and .Values.hub.embeddings.persistence.enabled (not .Values.hub.embeddings.persistence.existingClaim) (not (has "ReadWriteMany" .Values.hub.embeddings.persistence.accessModes)) (or (gt $embeddingsReplicas 1) (and .Values.hub.embeddings.autoscaling.enabled (gt $embeddingsMaxReplicas 1))) }}
   {{- fail "hub.embeddings persistence with multiple replicas requires persistence.accessModes to include ReadWriteMany, or set hub.embeddings.persistence.enabled=false/use a ReadWriteMany existingClaim" }}
-{{- end }}
-{{- if and .Values.hub.embeddings.auth.existingSecret .Values.hub.embeddings.huggingFace.token (not .Values.hub.embeddings.huggingFace.existingSecret) }}
-  {{- fail "hub.embeddings.huggingFace.token cannot be stored when hub.embeddings.auth.existingSecret is set; put HF_TOKEN in the existing auth secret or set hub.embeddings.huggingFace.existingSecret" }}
 {{- end }}
 ---
 apiVersion: apps/v1

--- a/charts/formbricks/templates/hub-hpa.yaml
+++ b/charts/formbricks/templates/hub-hpa.yaml
@@ -100,6 +100,40 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}
+{{- if and .Values.hub.enabled .Values.hub.embeddings.enabled .Values.hub.embeddings.background.enabled .Values.hub.embeddings.background.autoscaling.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "formbricks.hubEmbeddingsBackgroundName" . }}
+  labels:
+    helm.sh/chart: {{ include "formbricks.chart" . }}
+    app.kubernetes.io/name: {{ include "formbricks.hubEmbeddingsBackgroundName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: hub-embeddings-background
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/part-of: {{ .Values.partOfOverride | default (include "formbricks.name" .) }}
+    {{- with .Values.hub.embeddings.background.autoscaling.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.hub.embeddings.background.autoscaling.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "formbricks.hubEmbeddingsBackgroundName" . }}
+  minReplicas: {{ .Values.hub.embeddings.background.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.hub.embeddings.background.autoscaling.maxReplicas }}
+  metrics:
+    {{- toYaml .Values.hub.embeddings.background.autoscaling.metrics | nindent 4 }}
+  {{- with .Values.hub.embeddings.background.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
 {{- if and .Values.taxonomy.enabled .Values.taxonomy.autoscaling.enabled }}
 ---
 apiVersion: autoscaling/v2

--- a/charts/formbricks/templates/hub-worker-deployment.yaml
+++ b/charts/formbricks/templates/hub-worker-deployment.yaml
@@ -87,7 +87,7 @@ spec:
           {{- if or .Values.hub.embeddings.enabled (gt (len .Values.hub.env) 0) (gt (len .Values.hub.worker.env) 0) }}
           env:
             {{- $workerEnv := merge (dict) .Values.hub.env .Values.hub.worker.env }}
-            {{- include "formbricks.hubEmbeddingEnv" (dict "root" $ "env" $workerEnv) | nindent 12 }}
+            {{- include "formbricks.hubEmbeddingEnv" (dict "root" $ "env" $workerEnv "worker" true) | nindent 12 }}
             {{- range $key, $value := .Values.hub.env }}
             {{- if and (not (hasKey $.Values.hub.worker.env $key)) (not (and $.Values.hub.embeddings.enabled (include "formbricks.hubEmbeddingEnvManaged" (dict "key" $key)))) }}
             {{- include "formbricks.envVar" (dict "name" $key "value" $value "context" $) | nindent 12 }}

--- a/charts/formbricks/values.yaml
+++ b/charts/formbricks/values.yaml
@@ -1122,6 +1122,64 @@ hub:
     normalize: "false"
     replicas: 1
 
+    # Optional worker-only TEI pool. Hub API keeps using the foreground runtime
+    # above, while hub-worker uses this endpoint and document micro-batching.
+    background:
+      enabled: false
+      baseUrl: ""
+      maxConcurrent: "5"
+      batchSize: "1"
+      batchMaxWaitMs: "25"
+      batchMaxInFlight: "1"
+      replicas: 1
+
+      service:
+        port: 8080
+        annotations: {}
+        additionalLabels: {}
+
+      persistence:
+        enabled: true
+        storageClass: ""
+        accessModes:
+          - ReadWriteOnce
+        size: 10Gi
+        mountPath: /data
+
+      resources:
+        requests:
+          cpu: "8"
+          memory: 8Gi
+        limits:
+          memory: 8Gi
+
+      autoscaling:
+        enabled: false
+        additionalLabels: {}
+        annotations: {}
+        minReplicas: 1
+        maxReplicas: 6
+        metrics:
+          - type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 70
+        behavior:
+          scaleDown:
+            stabilizationWindowSeconds: 900
+            policies:
+              - type: Pods
+                value: 1
+                periodSeconds: 300
+          scaleUp:
+            stabilizationWindowSeconds: 0
+            policies:
+              - type: Pods
+                value: 2
+                periodSeconds: 60
+
     image:
       repository: "ghcr.io/huggingface/text-embeddings-inference"
       tag: "cpu-1.9"
@@ -1248,6 +1306,24 @@ hub:
     tolerations: []
     affinity: {}
     topologySpreadConstraints: []
+
+  # Opt-in, deliberately named embedding backfill Job. A new runId is required
+  # for each preview or enqueue run so upgrades never execute it implicitly.
+  embeddingBackfill:
+    enabled: false
+    runId: ""
+    taxonomy: false
+    tenantId: ""
+    countOnly: true
+    maxRecords: 0
+    backoffLimit: 1
+    activeDeadlineSeconds: 900
+    resources:
+      requests:
+        cpu: "50m"
+        memory: 64Mi
+      limits:
+        memory: 256Mi
 
   # Upgrade migration job runs goose + river before Helm upgrades Hub resources.
   # Fresh installs run the same migrations through the Hub deployment init container.


### PR DESCRIPTION
## What & why

Self-hosted embedding jobs and interactive semantic search currently share one TEI deployment, so a backfill saturates the same CPU service and can progress at less than one record per second.

This adds an opt-in worker-only TEI pool as a StatefulSet with one retained RWO cache PVC per replica, a load-balancing service, a headless identity service, and CPU HPA support. Hub API stays on the foreground endpoint while hub-worker receives the background URL and micro-batch settings. It also adds a guarded, disabled-by-default embedding backfill Job that requires a unique run ID.

The batching variables and packaged backfill binary require [formbricks/hub#121](https://github.com/formbricks/hub/pull/121). The pool itself remains disabled by default, and the legacy single-TEI render is covered by CI.

## Linear ticket

No Linear ticket was provided for this incident fix.

## How this was tested

- `helm lint charts/formbricks --set formbricks.webappUrl=https://qa.example.com` ✅
- Rendered legacy single-TEI mode and verified API plus worker both use the foreground endpoint with batch size 1 ✅
- Rendered enabled background mode and verified API/worker endpoint separation, `24 / 8 / 25 / 3` worker settings, StatefulSet, normal/headless services, retained per-replica PVCs, and HPA `1..6` with 900-second scale-down stabilization ✅
- Rendered persistence-disabled mode and verified `emptyDir` replaces volume claim templates ✅
- Verified the backfill Job is absent by default, rejects missing/invalid `runId`, and renders taxonomy/tenant/max-record arguments when enabled ✅
- Rendered the chart with staging, EU production, and KSA GitOps values; staging enables the pool while both production targets remain gated ✅
- Added the same render assertions to the Helm chart validation workflow.

## Breaking changes

| Change | Before | After | Who's affected | Action required |
| --- | --- | --- | --- | --- |
| New `hub.embeddings.background.*` values and worker `EMBEDDING_BATCH_*` settings | Hub worker shared the foreground TEI endpoint | Operators can opt into a worker-only scalable TEI pool and batching | Self-hosters enabling the new pool | Use a Hub release containing formbricks/hub#121 before enabling batching or the backfill Job; no action when left disabled |

## QA / Test Plan

**How to test**

- [ ] Deploy with `hub.embeddings.background.enabled=false` → Hub API and hub-worker remain healthy and both use the existing foreground TEI service.
- [ ] Deploy with the background pool enabled → a separate background StatefulSet becomes Ready; Hub API continues serving semantic search through the foreground TEI service while hub-worker drains embedding jobs through the background service.
- [ ] Scale the background HPA to six ready replicas and enqueue representative staging records → sustained embedding throughput reaches at least 5 inputs/s and semantic-search p95 remains within 20% of baseline.
- [ ] Enable a backfill Job with a new `runId`, `taxonomy: true`, and `countOnly: true` → the Job reports the missing count without increasing the embedding queue.
- [ ] Re-run with `maxRecords: 500` and count-only disabled → no more than 500 candidates are enqueued; changing `runId` creates the next deliberate Job.

**Preconditions / test data**

- A Hub image release containing formbricks/hub#121.
- Self-hosted TEI enabled with the same model, arguments, and authentication for both pools.
- Representative staging taxonomy feedback and metrics export enabled.

**Risks & regressions**

- Worker/API endpoint separation, TEI model compatibility, RWO PVC scheduling, HPA scale behavior, River retries, and foreground semantic-search latency.
- If batching regresses, set batch size to 1 while retaining the isolated pool. If the pool fails, disable it and restore foreground worker concurrency to 1.

**Migrations / env / cutover**

- No database migration.
- New optional chart values under `hub.embeddings.background.*` and `hub.embeddingBackfill.*`.
- New chart-managed worker variables: `EMBEDDING_BATCH_SIZE`, `EMBEDDING_BATCH_MAX_WAIT_MS`, and `EMBEDDING_BATCH_MAX_IN_FLIGHT`.
