### PR TITLE
fix(security): bump hono to 4.12.34 and patch 4 advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@grpc/grpc-js': 1.14.4
   '@hono/node-server': 2.0.10
+  hono: 4.12.34
   protobufjs@8: 8.6.6
   '@tootallnate/once': 2.0.1
   '@xmldom/xmldom': 0.9.10
@@ -2572,7 +2573,7 @@ packages:
     resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
     engines: {node: '>=20'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.34
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -6764,6 +6765,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xobotyi/scrollbar-width@1.9.5':
     resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
@@ -8681,8 +8683,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.27:
-    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+  hono@4.12.34:
+    resolution: {integrity: sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -14365,9 +14367,9 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.3
 
-  '@hono/node-server@2.0.10(hono@4.12.27)':
+  '@hono/node-server@2.0.10(hono@4.12.34)':
     dependencies:
-      hono: 4.12.27
+      hono: 4.12.34
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.2.6))':
     dependencies:
@@ -14784,7 +14786,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 2.0.10(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.34)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -14794,7 +14796,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.27
+      hono: 4.12.34
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -16197,13 +16199,13 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 2.0.10(hono@4.12.27)
+      '@hono/node-server': 2.0.10(hono@4.12.34)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2
       foreground-child: 3.3.1
       get-port-please: 3.2.0
-      hono: 4.12.27
+      hono: 4.12.34
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
@@ -21388,7 +21390,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.27: {}
+  hono@4.12.34: {}
 
   html-encoding-sniffer@6.0.0(@noble/hashes@2.0.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,16 @@ overrides:
   # patched in 2.0.10. Pinned to 2.0.10 to close both.
   # load-bearing: @prisma/dev pins 1.19.11 and @modelcontextprotocol/sdk resolves 1.19.15.
   "@hono/node-server": 2.0.10
+  # ENG-2195 / GHSA-8j4g-w8fx-2239 (CVE-2026-69207): hono's CORS middleware has a ReDoS in the
+  # Access-Control-Request-Headers parser on preflight requests.
+  # ENG-2300 / GHSA-54fx-42gc-7vw4 (CVE-2026-71848): languageDetector middleware algorithmic-complexity
+  # DoS via a long hyphen-separated language tag.
+  # ENG-2319 / GHSA-f23p-vx2j-j53r (CVE-2026-71850): hono/jsx's memo() retains SSR output across
+  # requests, leaking one user's rendered HTML to another.
+  # ENG-2320 / GHSA-79qm-7rj5-m7r9 (CVE-2026-71849): Proxy Helper forwards response headers named in
+  # the origin's Connection header instead of stripping them. All four patched in 4.12.34.
+  # load-bearing: @hono/node-server resolves 4.x via @modelcontextprotocol/sdk and @prisma/dev (dev/MCP-only).
+  hono: 4.12.34
   # OpenTelemetry / protobuf chains.
   # ENG-1962 / GHSA-j3f2-48v5-ccww (CVE-2026-59877): protobufjs .proto option-parsing infinite-loop DoS,
   # patched in 8.6.6. ENG-1963 / GHSA-jfj6-75fj-8934 (CVE-2026-59876): text-format map prototype
@@ -141,7 +151,7 @@ overrides:
   # advisory. load-bearing: @redocly/ajv and ajv pull 3.1.4 (dev-only, API-docs tooling).
   fast-uri@3: 3.1.5
   # === Removed once upstream caught up (kept as a record of what no longer needs a pin) ===
-  # ajv@6, @babel/core, body-parser, engine.io@6, hono, linkify-it, protobufjs@7 and uuid@11
+  # ajv@6, @babel/core, body-parser, engine.io@6, linkify-it, protobufjs@7 and uuid@11
   # all resolve to the patched version on their own now.
   # js-cookie, shell-quote and form-data@4 were retired by bumping react-use to 17.6.1 (js-cookie ^3),
   # concurrently to 9.2.4 (shell-quote 1.9.0) and @redocly/cli to 1.34.17 (form-data 4.0.6) instead.


### PR DESCRIPTION
## What & why

Daily Dependabot sweep found 31 open security alerts. Cross-checking against open PRs showed 27 of
them already resolved by two other PRs that merged today (#8828 `fix(deps): remediate container image
vulnerabilities` and #8807 `fix(deps): bump undici, socket.io-parser, fast-uri, ip-address for
high-risk advisories`). `hono` was the one package neither of those touched — its only proposed fix
was sitting in the still-draft, now-conflicting PR #8797, which bundles hono together with a lot of
now-redundant changes to packages already fixed elsewhere.

This PR extracts just the hono half: four Dependabot alerts against the transitive `hono@4.12.27`
resolved via `@hono/node-server` (pulled in by `@modelcontextprotocol/sdk` and `@prisma/dev`, so
dev/MCP-tooling only, not the app's own HTTP framework) are all patched in `4.12.34`:

- ReDoS in the CORS middleware's `Access-Control-Request-Headers` parser (GHSA-8j4g-w8fx-2239)
- Algorithmic-complexity DoS in the `languageDetector` middleware (GHSA-54fx-42gc-7vw4)
- `hono/jsx`'s `memo()` retaining SSR output across requests, leaking one user's HTML to another (GHSA-f23p-vx2j-j53r)
- Proxy Helper forwarding response headers named in the origin's `Connection` header instead of stripping them (GHSA-79qm-7rj5-m7r9)

Added a `hono: 4.12.34` override to `pnpm-workspace.yaml`, matching the file's existing comment
convention, and removed `hono` from the "resolves on its own" record now that a pin is needed again.

## Linear ticket

Fixes ENG-2195
Fixes ENG-2300
Fixes ENG-2319
Fixes ENG-2320

## How this was tested

- `pnpm install` ✅ — resolves `hono@4.12.34` cleanly (`pnpm why hono` confirms 4.12.27 is gone).
- `pnpm audit` ✅ — no hono findings; only the two pre-existing accepted findings remain
  (`brace-expansion`, tracked by ENG-2234, and `@better-auth/oauth-provider`, documented accepted risk).
- `pnpm format` ✅ — `pnpm-workspace.yaml` reported unchanged (already matches Prettier's style).
- `pnpm lint` — could not complete: `@formbricks/database#build` fails in this sandbox with
  `PrismaConfigEnvError: Cannot resolve environment variable: DATABASE_URL` before any lint rule runs.
  No `DATABASE_URL` is configured anywhere in this checkout; this is a pre-existing sandbox limitation,
  not something this diff introduces (the change here is a lockfile/override entry only, unrelated to
  Prisma). Packages that could lint independently of that build step had no new errors.
- `pnpm test` — same `@formbricks/database#build` blocker prevented the full run, but every suite that
  isn't gated on it passed: `@formbricks/js-core` (291 tests), `@formbricks/ai` (90), `@formbricks/cache`
  (158), `@formbricks/jobs` (58), `@formbricks/i18n-utils` (80), all green. Dependency-only change
  (dev/MCP-tooling transitive bump); no application source touched.

## Breaking changes

None — transitive security patch bump to a dev/MCP-tooling dependency, no public contract change.

## QA / Test Plan

Regression smoke only — hono here is only reachable through the MCP SDK's Node server and Prisma's dev
tooling, not the app's own request path, so there's no user-facing surface to click through.

- [ ] With an MCP client registered against staging, authorize and call an MCP tool → authorization
      succeeds for the MCP resource and the tool call completes normally.
- [ ] Confirm the four listed Dependabot alerts (hono) auto-close after merge.

**Preconditions / test data**

- An MCP client configured against the staging MCP resource.

**Risks & regressions**

- Re-check MCP tool authorization/invocation after the bump; `@hono/node-server`/`@modelcontextprotocol/sdk`
  wiring is the only consumer.
- PR #8797 still has an open, conflicting draft covering hono plus several packages already fixed by
  #8828/#8807 — worth closing or rebasing down to nothing once this merges, to avoid a fourth
  competing diff to the same `pnpm-workspace.yaml` region.

**Migrations / env / cutover**

- none
