### PR TITLE
fix(security): bind email-change tokens to credential state [ENG-2106]

### DIFF
--- a/apps/web/app/api/v2/client/[workspaceId]/responses/lib/utils.test.ts
+++ b/apps/web/app/api/v2/client/[workspaceId]/responses/lib/utils.test.ts
@@ -49,7 +49,10 @@ vi.mock("@formbricks/logger", () => ({
   },
 }));
 
-vi.mock("@/lib/crypto", () => ({
+// Stub only `symmetricDecrypt`. The rest of the module stays real because the single-use signature
+// check on this path runs through `constantTimeEqual` — stubbing it out would reject valid signatures.
+vi.mock("@/lib/crypto", async (importOriginal: () => Promise<typeof import("@/lib/crypto")>) => ({
+  ...(await importOriginal()),
   symmetricDecrypt: vi.fn(),
 }));
 vi.mock("@/lib/constants", () => ({

--- a/apps/web/lib/crypto.test.ts
+++ b/apps/web/lib/crypto.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { logger } from "@formbricks/logger";
 // Import after unmocking
 import {
+  constantTimeEqual,
   generateStandardWebhookSignature,
   generateWebhookSecret,
   getWebhookSecretBytes,
@@ -116,6 +117,37 @@ describe("Crypto Utils", () => {
       const expectedHash = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
 
       expect(hashSha256(input)).toBe(expectedHash);
+    });
+  });
+
+  describe("constantTimeEqual", () => {
+    test("should return true for identical values", () => {
+      expect(constantTimeEqual("a-signature-value", "a-signature-value")).toBe(true);
+    });
+
+    test("should return false for values that differ", () => {
+      expect(constantTimeEqual("a-signature-value", "a-signature-valuf")).toBe(false);
+    });
+
+    test("should return false for values of different lengths", () => {
+      expect(constantTimeEqual("short", "considerably-longer")).toBe(false);
+    });
+
+    test("should compare hex values by their decoded bytes", () => {
+      expect(constantTimeEqual("ab".repeat(32), "ab".repeat(32), "hex")).toBe(true);
+      expect(constantTimeEqual("ab".repeat(32), "cd".repeat(32), "hex")).toBe(false);
+    });
+
+    test("should return false rather than matching when either value is empty", () => {
+      expect(constantTimeEqual("", "")).toBe(false);
+      expect(constantTimeEqual("a-signature-value", "")).toBe(false);
+    });
+
+    // Buffer.from drops input that is invalid for the encoding, so both of these decode to zero bytes.
+    // Without the empty-buffer guard they would compare equal and pass as a valid signature.
+    test("should return false for values that are invalid for the encoding", () => {
+      expect(constantTimeEqual("zz", "yy", "hex")).toBe(false);
+      expect(constantTimeEqual("zz", "ab".repeat(32), "hex")).toBe(false);
     });
   });
 

--- a/apps/web/lib/crypto.ts
+++ b/apps/web/lib/crypto.ts
@@ -1,5 +1,12 @@
 import { compare, hash } from "bcryptjs";
-import { createCipheriv, createDecipheriv, createHash, createHmac, randomBytes } from "node:crypto";
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createHmac,
+  randomBytes,
+  timingSafeEqual,
+} from "node:crypto";
 import { logger } from "@formbricks/logger";
 import { ENCRYPTION_KEY } from "@/lib/constants";
 
@@ -119,6 +126,27 @@ export const verifySecret = async (secret: string, hashedSecret: string): Promis
  */
 export const hashSha256 = (input: string): string => {
   return createHash("sha256").update(input).digest("hex");
+};
+
+/**
+ * Compare two secrets — MACs, signatures, token fingerprints — without leaking how far the match got.
+ * `timingSafeEqual` throws on length mismatch, so the lengths are checked first; that check is not
+ * itself constant-time, which is fine because the length of a fixed-width digest is not the secret.
+ *
+ * Use this for anything an attacker supplies and can vary between attempts. Plain `===` on a secret is
+ * the bug this exists to prevent.
+ */
+export const constantTimeEqual = (a: string, b: string, encoding: BufferEncoding = "utf8"): boolean => {
+  const aBytes = Buffer.from(a, encoding);
+  const bBytes = Buffer.from(b, encoding);
+
+  // `Buffer.from` silently drops input that is invalid for the encoding — `Buffer.from("zz", "hex")` is
+  // an empty buffer — so without this guard two malformed values would compare equal at length 0.
+  if (aBytes.length === 0 || bBytes.length === 0) {
+    return false;
+  }
+
+  return aBytes.length === bBytes.length && timingSafeEqual(aBytes, bBytes);
 };
 
 /**

--- a/apps/web/lib/jwt.test.ts
+++ b/apps/web/lib/jwt.test.ts
@@ -95,10 +95,11 @@ vi.mock("@formbricks/database", () => ({
   },
 }));
 
-// Stand-in for the bcrypt hash on the user's `credential` account. Email-change tokens are bound to it,
-// so swapping it in the prisma mock is how these tests simulate a password reset or change.
-const TEST_CREDENTIAL_PASSWORD_HASH = "$2a$12$0123456789012345678901uOriginalHashValueForTests";
-const ROTATED_CREDENTIAL_PASSWORD_HASH = "$2a$12$0123456789012345678901uRotatedHashValueForTests.";
+// `updatedAt` on the user's `credential` account, which Prisma bumps on every password write.
+// Email-change tokens are bound to it, so moving it in the prisma mock is how these tests simulate a
+// password reset or change.
+const CREDENTIAL_UPDATED_AT = new Date("2026-01-01T00:00:00.000Z");
+const CREDENTIAL_UPDATED_AT_AFTER_RESET = new Date("2026-01-02T09:30:00.000Z");
 
 // Mock logger
 vi.mock("@formbricks/logger", () => ({
@@ -113,7 +114,7 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
   const mockUser = {
     id: "test-user-id",
     email: "test@example.com",
-    accounts: [{ password: TEST_CREDENTIAL_PASSWORD_HASH }],
+    accounts: [{ updatedAt: CREDENTIAL_UPDATED_AT }],
   };
 
   let mockSymmetricEncrypt: any;
@@ -254,7 +255,7 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
       });
     });
 
-    test("should refuse to mint a token for a user without a credential password", async () => {
+    test("should refuse to mint a token for a user without a credential account", async () => {
       (prisma.user.findUnique as any).mockResolvedValue({ ...mockUser, accounts: [] });
 
       await expect(createEmailChangeToken(mockUser.id, "new@example.com")).rejects.toThrow(
@@ -688,9 +689,11 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
       test("should reject a token minted before the password was reset", async () => {
         const token = await createEmailChangeToken(mockUser.id, "attacker@evil.com");
 
+        // Prisma bumps the credential row's updatedAt on the password write. Note this holds even if the
+        // reset set the *same* password, which binding to the hash itself would have missed.
         (prisma.user.findUnique as any).mockResolvedValue({
           ...mockUser,
-          accounts: [{ password: ROTATED_CREDENTIAL_PASSWORD_HASH }],
+          accounts: [{ updatedAt: CREDENTIAL_UPDATED_AT_AFTER_RESET }],
         });
 
         await expect(verifyEmailChangeToken(token)).rejects.toThrow("Email change token is no longer valid");

--- a/apps/web/lib/jwt.test.ts
+++ b/apps/web/lib/jwt.test.ts
@@ -95,6 +95,11 @@ vi.mock("@formbricks/database", () => ({
   },
 }));
 
+// Stand-in for the bcrypt hash on the user's `credential` account. Email-change tokens are bound to it,
+// so swapping it in the prisma mock is how these tests simulate a password reset or change.
+const TEST_CREDENTIAL_PASSWORD_HASH = "$2a$12$0123456789012345678901uOriginalHashValueForTests";
+const ROTATED_CREDENTIAL_PASSWORD_HASH = "$2a$12$0123456789012345678901uRotatedHashValueForTests.";
+
 // Mock logger
 vi.mock("@formbricks/logger", () => ({
   logger: {
@@ -108,6 +113,7 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
   const mockUser = {
     id: "test-user-id",
     email: "test@example.com",
+    accounts: [{ password: TEST_CREDENTIAL_PASSWORD_HASH }],
   };
 
   let mockSymmetricEncrypt: any;
@@ -229,8 +235,8 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
   });
 
   describe("createEmailChangeToken", () => {
-    test("should create a valid email change token with 1 day expiration", () => {
-      const token = createEmailChangeToken(mockUser.id, mockUser.email);
+    test("should create a valid email change token with 1 day expiration", async () => {
+      const token = await createEmailChangeToken(mockUser.id, mockUser.email);
       expect(token).toBeDefined();
       expect(mockSymmetricEncrypt).toHaveBeenCalledWith(mockUser.id, TEST_ENCRYPTION_KEY);
       expect(mockSymmetricEncrypt).toHaveBeenCalledWith(mockUser.email, TEST_ENCRYPTION_KEY);
@@ -243,7 +249,17 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
     });
 
     test("should throw error if NEXTAUTH_SECRET or ENCRYPTION_KEY is not set", async () => {
-      await testMissingSecretsError(createEmailChangeToken, [mockUser.id, mockUser.email]);
+      await testMissingSecretsError(createEmailChangeToken, [mockUser.id, mockUser.email], {
+        isAsync: true,
+      });
+    });
+
+    test("should refuse to mint a token for a user without a credential password", async () => {
+      (prisma.user.findUnique as any).mockResolvedValue({ ...mockUser, accounts: [] });
+
+      await expect(createEmailChangeToken(mockUser.id, "new@example.com")).rejects.toThrow(
+        "Email change token cannot be bound"
+      );
     });
   });
 
@@ -621,9 +637,9 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
 
   describe("verifyEmailChangeToken", () => {
     test("should verify and decrypt valid email change token", async () => {
-      const userId = "test-user-id";
-      const email = "test@example.com";
-      const token = createEmailChangeToken(userId, email);
+      const userId = mockUser.id;
+      const email = "new@example.com";
+      const token = await createEmailChangeToken(userId, email);
       const result = await verifyEmailChangeToken(token);
       expect(result).toEqual({ id: userId, email });
     });
@@ -653,17 +669,6 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
       );
     });
 
-    test("should return original id/email if decryption fails", async () => {
-      mockSymmetricDecrypt.mockImplementation(() => {
-        throw new Error("Decryption failed");
-      });
-
-      const payload = { id: "plain-id", email: "plain@example.com" };
-      const token = jwt.sign(payload, TEST_NEXTAUTH_SECRET);
-      const result = await verifyEmailChangeToken(token);
-      expect(result).toEqual(payload);
-    });
-
     test("should throw error for token with wrong signature", async () => {
       const invalidToken = jwt.sign(
         {
@@ -674,6 +679,91 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
       );
 
       await expect(verifyEmailChangeToken(invalidToken)).rejects.toThrow();
+    });
+
+    // ENG-2106: the link is consumable without a session, so the token must die with the credential
+    // state it was minted against — otherwise a password recovery revokes every session but leaves a
+    // token that can still move the login address (and the password-reset destination) to an attacker.
+    describe("credential-state binding", () => {
+      test("should reject a token minted before the password was reset", async () => {
+        const token = await createEmailChangeToken(mockUser.id, "attacker@evil.com");
+
+        (prisma.user.findUnique as any).mockResolvedValue({
+          ...mockUser,
+          accounts: [{ password: ROTATED_CREDENTIAL_PASSWORD_HASH }],
+        });
+
+        await expect(verifyEmailChangeToken(token)).rejects.toThrow("Email change token is no longer valid");
+      });
+
+      test("should reject a token replayed after the email already changed", async () => {
+        const token = await createEmailChangeToken(mockUser.id, "new@example.com");
+
+        // First use succeeds and moves the login address...
+        await expect(verifyEmailChangeToken(token)).resolves.toEqual({
+          id: mockUser.id,
+          email: "new@example.com",
+        });
+
+        // ...which is exactly what makes the same link inert on a second click.
+        (prisma.user.findUnique as any).mockResolvedValue({ ...mockUser, email: "new@example.com" });
+
+        await expect(verifyEmailChangeToken(token)).rejects.toThrow("Email change token is no longer valid");
+      });
+
+      test("should reject a token once the credential account is gone", async () => {
+        const token = await createEmailChangeToken(mockUser.id, "new@example.com");
+
+        (prisma.user.findUnique as any).mockResolvedValue({ ...mockUser, accounts: [] });
+
+        await expect(verifyEmailChangeToken(token)).rejects.toThrow("Email change token cannot be bound");
+      });
+
+      test("should reject an unbound token in the pre-fix shape", async () => {
+        const unboundToken = jwt.sign(
+          { id: `encrypted_${mockUser.id}`, email: "encrypted_attacker@evil.com" },
+          TEST_NEXTAUTH_SECRET,
+          { expiresIn: "1d" }
+        );
+
+        await expect(verifyEmailChangeToken(unboundToken)).rejects.toThrow(
+          "Token is invalid or missing required fields"
+        );
+      });
+
+      test("should reject a token whose fingerprint does not match", async () => {
+        const forgedToken = jwt.sign(
+          {
+            id: `encrypted_${mockUser.id}`,
+            email: "encrypted_attacker@evil.com",
+            purpose: "email_change",
+            fingerprint: "ab".repeat(32),
+          },
+          TEST_NEXTAUTH_SECRET,
+          { expiresIn: "1d" }
+        );
+
+        await expect(verifyEmailChangeToken(forgedToken)).rejects.toThrow(
+          "Email change token is no longer valid"
+        );
+      });
+
+      test("should reject a token issued for a different flow", async () => {
+        const wrongPurposeToken = jwt.sign(
+          {
+            id: `encrypted_${mockUser.id}`,
+            email: "encrypted_attacker@evil.com",
+            purpose: "email_verification",
+            fingerprint: "ab".repeat(32),
+          },
+          TEST_NEXTAUTH_SECRET,
+          { expiresIn: "1d" }
+        );
+
+        await expect(verifyEmailChangeToken(wrongPurposeToken)).rejects.toThrow(
+          "Token is invalid or missing required fields"
+        );
+      });
     });
   });
 
@@ -977,23 +1067,26 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
         expect(result.email).toBe(mockUser.email);
       });
 
-      test("should handle mixed encrypted/unencrypted fields", async () => {
+      // Email-change tokens deliberately have no legacy path — an unbound payload is rejected outright
+      // (see the credential-state binding tests) — so the per-field decryption fallback is covered here
+      // on the invite token, which still accepts pre-encryption payloads.
+      test("should handle mixed encrypted/unencrypted fields", () => {
         mockSymmetricDecrypt
-          .mockImplementationOnce(() => mockUser.id) // id decrypts successfully
+          .mockImplementationOnce(() => "test-invite-id") // inviteId decrypts successfully
           .mockImplementationOnce(() => {
             throw new Error("Email not encrypted");
           }); // email fails
 
         const token = jwt.sign(
           {
-            id: "encrypted_test-id",
+            inviteId: "encrypted_test-invite-id",
             email: "plain-email@example.com",
           },
           TEST_NEXTAUTH_SECRET
         );
 
-        const result = await verifyEmailChangeToken(token);
-        expect(result.id).toBe(mockUser.id);
+        const result = verifyInviteToken(token);
+        expect(result.inviteId).toBe("test-invite-id");
         expect(result.email).toBe("plain-email@example.com");
       });
 

--- a/apps/web/lib/jwt.test.ts
+++ b/apps/web/lib/jwt.test.ts
@@ -722,6 +722,23 @@ describe("JWT Functions - Comprehensive Security Tests", () => {
         await expect(verifyEmailChangeToken(token)).rejects.toThrow("Email change token cannot be bound");
       });
 
+      // The row this binds to must be the one Better Auth bumps on a password write — the full
+      // `(provider, providerAccountId)` unique tuple. Matching on `provider` alone would take an arbitrary
+      // `credential` row for a user that somehow had two, binding to a timestamp a reset never moves.
+      test("should scope the credential lookup to this user's own credential row", async () => {
+        await createEmailChangeToken(mockUser.id, "new@example.com");
+
+        expect(prisma.user.findUnique).toHaveBeenCalledWith(
+          expect.objectContaining({
+            select: expect.objectContaining({
+              accounts: expect.objectContaining({
+                where: { provider: "credential", providerAccountId: mockUser.id },
+              }),
+            }),
+          })
+        );
+      });
+
       test("should reject an unbound token in the pre-fix shape", async () => {
         const unboundToken = jwt.sign(
           { id: `encrypted_${mockUser.id}`, email: "encrypted_attacker@evil.com" },

--- a/apps/web/lib/jwt.ts
+++ b/apps/web/lib/jwt.ts
@@ -1,9 +1,9 @@
 import jwt, { JwtPayload, SignOptions } from "jsonwebtoken";
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHmac } from "node:crypto";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
 import { ENCRYPTION_KEY, NEXTAUTH_SECRET } from "@/lib/constants";
-import { symmetricDecrypt, symmetricEncrypt } from "@/lib/crypto";
+import { constantTimeEqual, symmetricDecrypt, symmetricEncrypt } from "@/lib/crypto";
 import { TGatewayAuthService, getGatewayAuthServiceTokenPurpose } from "@/modules/gateway-auth/lib/service";
 
 const FEEDBACK_RECORDS_GATEWAY_TOKEN_TTL_SECONDS = 60 * 10;
@@ -166,7 +166,15 @@ const getEmailChangeCredentialFingerprint = async (userId: string): Promise<stri
     where: { id: userId },
     select: {
       email: true,
-      accounts: { where: { provider: "credential" }, select: { updatedAt: true } },
+      // Scoped to the full `(provider, providerAccountId)` unique tuple, not just the provider: this
+      // must resolve to the one row Better Auth bumps `updatedAt` on for a password write — the same
+      // row getCredentialPasswordHash reads. Matching on `provider` alone would take an arbitrary
+      // first row if a user ever ended up with a second `credential` row under a different
+      // providerAccountId, binding the token to a timestamp that never moves on a reset.
+      accounts: {
+        where: { provider: "credential", providerAccountId: userId },
+        select: { updatedAt: true },
+      },
     },
   });
 
@@ -181,13 +189,6 @@ const getEmailChangeCredentialFingerprint = async (userId: string): Promise<stri
   return createHmac("sha256", NEXTAUTH_SECRET)
     .update(`${userId}:${user.email}:${credentialUpdatedAt.toISOString()}`)
     .digest("hex");
-};
-
-const fingerprintsMatch = (tokenFingerprint: string, currentFingerprint: string): boolean => {
-  const tokenBytes = Buffer.from(tokenFingerprint, "hex");
-  const currentBytes = Buffer.from(currentFingerprint, "hex");
-
-  return tokenBytes.length === currentBytes.length && timingSafeEqual(tokenBytes, currentBytes);
 };
 
 export const verifyEmailChangeToken = async (token: string): Promise<{ id: string; email: string }> => {
@@ -223,7 +224,9 @@ export const verifyEmailChangeToken = async (token: string): Promise<{ id: strin
   const decryptedId = decryptWithFallback(payload.id, ENCRYPTION_KEY);
   const decryptedEmail = decryptWithFallback(payload.email, ENCRYPTION_KEY);
 
-  if (!fingerprintsMatch(payload.fingerprint, await getEmailChangeCredentialFingerprint(decryptedId))) {
+  const currentFingerprint = await getEmailChangeCredentialFingerprint(decryptedId);
+
+  if (!constantTimeEqual(payload.fingerprint, currentFingerprint, "hex")) {
     throw new Error("Email change token is no longer valid");
   }
 

--- a/apps/web/lib/jwt.ts
+++ b/apps/web/lib/jwt.ts
@@ -144,12 +144,18 @@ export const createTokenForLinkSurvey = (surveyId: string, userEmail: string): s
  * before it stayed usable for the rest of its 24 hours, long enough to point the account at an
  * attacker-controlled mailbox and reset the password back (ENG-2106, CWE-613).
  *
- * Binding the token to the login email plus the credential password hash ties it to that state, so a
- * password reset or change — or any other email change — re-keys the fingerprint and kills every token
- * issued before it. It also makes the link single-use for free: consuming it changes the email.
+ * Binding the token to the login email plus the last write to the user's `credential` account ties it
+ * to that state, so a password reset or change — or any other email change — re-keys the fingerprint and
+ * kills every token issued before it. It also makes the link single-use for free: consuming it changes
+ * the email.
  *
- * HMAC rather than a bare hash so the claim, which travels in a readable JWT payload, discloses nothing
- * about the password hash it covers.
+ * The credential's `updatedAt` is the binding, deliberately not its password hash: no password-derived
+ * material then travels in the token at all, and it still invalidates a reset that happens to set the
+ * *same* password, which a hash would not. This relies on every write to that row going through Prisma,
+ * which applies `@updatedAt` — keep it that way; a raw-SQL password write would leave stale tokens live.
+ *
+ * HMAC rather than a bare hash so the claim, which travels in a readable JWT payload, cannot be
+ * recomputed or probed by whoever holds the token.
  */
 const getEmailChangeCredentialFingerprint = async (userId: string): Promise<string> => {
   if (!NEXTAUTH_SECRET) {
@@ -160,20 +166,20 @@ const getEmailChangeCredentialFingerprint = async (userId: string): Promise<stri
     where: { id: userId },
     select: {
       email: true,
-      accounts: { where: { provider: "credential" }, select: { password: true } },
+      accounts: { where: { provider: "credential" }, select: { updatedAt: true } },
     },
   });
 
-  const passwordHash = user?.accounts?.[0]?.password;
+  const credentialUpdatedAt = user?.accounts?.[0]?.updatedAt;
 
-  // Fail closed: with no credential password there is nothing to bind to, and an email change is only
+  // Fail closed: with no credential account there is nothing to bind to, and an email change is only
   // ever offered to credential users in the first place.
-  if (!user || !passwordHash) {
-    throw new Error("Email change token cannot be bound: user has no credential password");
+  if (!user || !credentialUpdatedAt) {
+    throw new Error("Email change token cannot be bound: user has no credential account");
   }
 
   return createHmac("sha256", NEXTAUTH_SECRET)
-    .update(`${userId}:${user.email}:${passwordHash}`)
+    .update(`${userId}:${user.email}:${credentialUpdatedAt.toISOString()}`)
     .digest("hex");
 };
 

--- a/apps/web/lib/jwt.ts
+++ b/apps/web/lib/jwt.ts
@@ -1,4 +1,5 @@
 import jwt, { JwtPayload, SignOptions } from "jsonwebtoken";
+import { createHmac, timingSafeEqual } from "node:crypto";
 import { prisma } from "@formbricks/database";
 import { logger } from "@formbricks/logger";
 import { ENCRYPTION_KEY, NEXTAUTH_SECRET } from "@/lib/constants";
@@ -25,9 +26,11 @@ const decryptWithFallback = (encryptedText: string, key: string): string => {
  */
 export const LINK_SURVEY_EMAIL_VERIFICATION_PURPOSE = "link_survey_email_verification";
 export const EMAIL_DISPLAY_TOKEN_PURPOSE = "email_display";
+export const EMAIL_CHANGE_TOKEN_PURPOSE = "email_change";
 
 const LINK_SURVEY_TOKEN_TTL = "7d";
 const EMAIL_DISPLAY_TOKEN_TTL = "1d";
+const EMAIL_CHANGE_TOKEN_TTL = "1d";
 
 export const VERIFICATION_TOKEN_PURPOSES = ["email_verification", "sso_recovery"] as const;
 
@@ -130,6 +133,57 @@ export const createTokenForLinkSurvey = (surveyId: string, userEmail: string): s
   );
 };
 
+/**
+ * Fingerprint of the credential state an email-change token was minted against.
+ *
+ * The email-change link is deliberately consumable without a session — the user clicks it from the new
+ * mailbox, often in another browser — so for its whole lifetime the token *is* a credential that can
+ * move the account's login address, and with it where every future password-reset link is delivered. A
+ * bare `{ id, email }` JWT therefore outlived the events that are supposed to end an attacker's hold on
+ * the account: a password recovery revoked every session and rotated the password, yet a token minted
+ * before it stayed usable for the rest of its 24 hours, long enough to point the account at an
+ * attacker-controlled mailbox and reset the password back (ENG-2106, CWE-613).
+ *
+ * Binding the token to the login email plus the credential password hash ties it to that state, so a
+ * password reset or change — or any other email change — re-keys the fingerprint and kills every token
+ * issued before it. It also makes the link single-use for free: consuming it changes the email.
+ *
+ * HMAC rather than a bare hash so the claim, which travels in a readable JWT payload, discloses nothing
+ * about the password hash it covers.
+ */
+const getEmailChangeCredentialFingerprint = async (userId: string): Promise<string> => {
+  if (!NEXTAUTH_SECRET) {
+    throw new Error("NEXTAUTH_SECRET is not set");
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      email: true,
+      accounts: { where: { provider: "credential" }, select: { password: true } },
+    },
+  });
+
+  const passwordHash = user?.accounts?.[0]?.password;
+
+  // Fail closed: with no credential password there is nothing to bind to, and an email change is only
+  // ever offered to credential users in the first place.
+  if (!user || !passwordHash) {
+    throw new Error("Email change token cannot be bound: user has no credential password");
+  }
+
+  return createHmac("sha256", NEXTAUTH_SECRET)
+    .update(`${userId}:${user.email}:${passwordHash}`)
+    .digest("hex");
+};
+
+const fingerprintsMatch = (tokenFingerprint: string, currentFingerprint: string): boolean => {
+  const tokenBytes = Buffer.from(tokenFingerprint, "hex");
+  const currentBytes = Buffer.from(currentFingerprint, "hex");
+
+  return tokenBytes.length === currentBytes.length && timingSafeEqual(tokenBytes, currentBytes);
+};
+
 export const verifyEmailChangeToken = async (token: string): Promise<{ id: string; email: string }> => {
   if (!NEXTAUTH_SECRET) {
     throw new Error("NEXTAUTH_SECRET is not set");
@@ -142,15 +196,30 @@ export const verifyEmailChangeToken = async (token: string): Promise<{ id: strin
   const payload = jwt.verify(token, NEXTAUTH_SECRET, { algorithms: ["HS256"] }) as {
     id: string;
     email: string;
+    purpose?: string;
+    fingerprint?: string;
   };
 
   if (!payload?.id || !payload?.email) {
     throw new Error("Token is invalid or missing required fields");
   }
 
+  // Every token in this file is signed with the same NEXTAUTH_SECRET, so require the claims that say
+  // this one was minted for an email change and against which credential state. Both are mandatory —
+  // treating a missing claim as legacy-and-therefore-acceptable would leave exactly the unbound token
+  // this check exists to reject. Links already in flight when this shipped stop working; re-requesting
+  // the change issues a bound one.
+  if (payload.purpose !== EMAIL_CHANGE_TOKEN_PURPOSE || !payload.fingerprint) {
+    throw new Error("Token is invalid or missing required fields");
+  }
+
   // Decrypt both fields with fallback
   const decryptedId = decryptWithFallback(payload.id, ENCRYPTION_KEY);
   const decryptedEmail = decryptWithFallback(payload.email, ENCRYPTION_KEY);
+
+  if (!fingerprintsMatch(payload.fingerprint, await getEmailChangeCredentialFingerprint(decryptedId))) {
+    throw new Error("Email change token is no longer valid");
+  }
 
   return {
     id: decryptedId,
@@ -190,7 +259,7 @@ export const verifyFeedbackRecordsGatewayToken = (
   return verifyGatewayServiceToken(token, "feedbackRecords");
 };
 
-export const createEmailChangeToken = (userId: string, email: string): string => {
+export const createEmailChangeToken = async (userId: string, email: string): Promise<string> => {
   if (!NEXTAUTH_SECRET) {
     throw new Error("NEXTAUTH_SECRET is not set");
   }
@@ -205,10 +274,14 @@ export const createEmailChangeToken = (userId: string, email: string): string =>
   const payload = {
     id: encryptedUserId,
     email: encryptedEmail,
+    purpose: EMAIL_CHANGE_TOKEN_PURPOSE,
+    // Ties the token to the credential state it was requested under; see
+    // getEmailChangeCredentialFingerprint.
+    fingerprint: await getEmailChangeCredentialFingerprint(userId),
   };
 
   return jwt.sign(payload, NEXTAUTH_SECRET, {
-    expiresIn: "1d",
+    expiresIn: EMAIL_CHANGE_TOKEN_TTL,
   });
 };
 

--- a/apps/web/lib/utils/single-use-surveys.test.ts
+++ b/apps/web/lib/utils/single-use-surveys.test.ts
@@ -10,7 +10,10 @@ import {
   validateSurveySingleUseSignature,
 } from "./single-use-surveys";
 
-vi.mock("@/lib/crypto", () => ({
+// Stub only the two functions these tests assert on. `constantTimeEqual` stays real — signature
+// validation is the behavior under test here, and a stub would make it pass without comparing anything.
+vi.mock("@/lib/crypto", async (importOriginal: () => Promise<typeof import("@/lib/crypto")>) => ({
+  ...(await importOriginal()),
   symmetricEncrypt: vi.fn(),
   symmetricDecrypt: vi.fn(),
 }));

--- a/apps/web/lib/utils/single-use-surveys.ts
+++ b/apps/web/lib/utils/single-use-surveys.ts
@@ -1,6 +1,6 @@
 import { createId, isCuid } from "@paralleldrive/cuid2";
-import { createHmac, timingSafeEqual } from "node:crypto";
-import { symmetricEncrypt } from "@/lib/crypto";
+import { createHmac } from "node:crypto";
+import { constantTimeEqual, symmetricEncrypt } from "@/lib/crypto";
 import { env } from "@/lib/env";
 
 const SINGLE_USE_SIGNATURE_PAYLOAD_PREFIX = "formbricks.single-use.v1";
@@ -58,11 +58,7 @@ export const validateSurveySingleUseSignature = (
     return false;
   }
 
-  const expectedSignature = generateSurveySingleUseSignature(surveyId, singleUseId);
-  const expected = Buffer.from(expectedSignature);
-  const received = Buffer.from(signature);
-
-  return expected.length === received.length && timingSafeEqual(expected, received);
+  return constantTimeEqual(generateSurveySingleUseSignature(surveyId, singleUseId), signature);
 };
 
 export const generateSurveySingleUseLinkParams = (

--- a/apps/web/modules/auth/lib/session-cookie.ts
+++ b/apps/web/modules/auth/lib/session-cookie.ts
@@ -1,4 +1,5 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHmac } from "node:crypto";
+import { constantTimeEqual } from "@/lib/crypto";
 import { env } from "@/lib/env";
 
 /**
@@ -53,9 +54,7 @@ const verifyAndExtractSessionToken = (signedValue: string | null): string | null
   const signature = signedValue.slice(lastDot + 1);
   const expected = createHmac("sha256", secret).update(token).digest("base64");
 
-  const expectedBuf = Buffer.from(expected);
-  const signatureBuf = Buffer.from(signature);
-  if (expectedBuf.length !== signatureBuf.length || !timingSafeEqual(expectedBuf, signatureBuf)) {
+  if (!constantTimeEqual(expected, signature)) {
     return null;
   }
 

--- a/apps/web/modules/auth/verify-email-change/actions.ts
+++ b/apps/web/modules/auth/verify-email-change/actions.ts
@@ -9,6 +9,9 @@ import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 
 export const verifyEmailChangeAction = actionClient.inputSchema(z.object({ token: z.string() })).action(
   withAuditLogging("updated", "user", async ({ ctx, parsedInput }) => {
+    // Unauthenticated on purpose — the link is clicked from the new mailbox, often in another browser.
+    // What makes that safe is the token's binding to the credential state it was issued under
+    // (verifyEmailChangeToken), so a password reset or a prior email change kills it (ENG-2106).
     const { id, email } = await verifyEmailChangeToken(parsedInput.token);
 
     if (!email) {

--- a/apps/web/modules/email/index.tsx
+++ b/apps/web/modules/email/index.tsx
@@ -125,7 +125,7 @@ export const sendVerificationNewEmail = async (
 ): Promise<boolean> => {
   try {
     const t = await getTranslate(locale);
-    const token = createEmailChangeToken(id, email);
+    const token = await createEmailChangeToken(id, email);
     const verifyLink = `${WEBAPP_URL}/verify-email-change?token=${encodeURIComponent(token)}`;
 
     const html = await renderNewEmailVerification({ verifyLink, t, ...legalProps });


### PR DESCRIPTION
## What & why

The email-change verification link is consumable **without a session** on purpose — the user clicks it from the new mailbox, often in a different browser. That means for its whole 24-hour life the token *is* a credential that can move the account's login address, and with it where every future password-reset link is delivered.

The token was a bare `{ id, email }` JWT, so it outlived the events that are supposed to end an attacker's hold on an account. Reported flow: given temporary possession of a session **and** the current password, an attacker requests a change to their own address and sits on the token without consuming it. The victim's password recovery revokes every session and rotates the password — but the stale token stays valid, long enough to repoint the account at the attacker's mailbox, receive a real password-reset email there, and reset the password back. (CWE-613 / CWE-284.)

The fix binds the token to the credential state it was issued under:

- `createEmailChangeToken` (`apps/web/lib/jwt.ts`) now mints a `purpose: "email_change"` claim plus a `fingerprint` — an HMAC-SHA256 over the user's current login email and the `updatedAt` of their `credential` `Account` row, looked up by the full `(provider, providerAccountId)` unique tuple so it resolves to the same row `getCredentialPasswordHash` reads. Prisma applies `@updatedAt` on every write to that row, and every password write goes through it (Better Auth's `prismaAdapter`; no raw-SQL password writes exist in the app), so the timestamp moves on every reset or change. HMAC so the claim, which travels in a readable JWT payload, can't be recomputed or probed by whoever holds the token.
- `verifyEmailChangeToken` requires both claims and recomputes the fingerprint from live DB state, rejecting the token on any mismatch (constant-time compare). A password reset or change — or any other email change — re-keys the fingerprint and kills every token issued before it. Consuming a token changes the email, which makes the link single-use for free.
- Fail closed: a user with no `credential` account can neither be issued a token nor verify one.

Binding to `updatedAt` rather than the password hash is deliberate — it keeps password-derived material out of the token entirely, and it invalidates a reset that happens to set the *same* password, which a hash binding would silently have let through. (It also clears the CodeQL `js/insufficient-password-hash` alert the first revision tripped; see the review thread.) The tradeoff is called out in the doc comment: the binding depends on writes to that row going through Prisma, so a future raw-SQL password write must not quietly leave stale tokens live.

Both claims are mandatory, with **no legacy allowance** — accepting a token that carries neither would leave exactly the unbound token this check exists to reject. Links already in flight when this ships stop working; re-requesting the change issues a bound one.

The TTL stays at 24 hours (matching the email copy) and the endpoint stays unauthenticated — shortening the window doesn't fix invalidation, and requiring a session would break clicking the link from another device.

### From review

- **Row scoping** (@mattinannt, @xernobyl): the fingerprint originally matched on `provider: "credential"` alone and took `accounts[0]` unordered. Only `(provider, providerAccountId)` is unique, so a user holding a second credential row could have bound to a timestamp that never moves on a reset — silently reopening the issue for that user, since mint and verify would be wrong identically and agree. Now scoped to the full tuple, with a test pinning it (the failure mode has no other observable symptom).
- **Shared constant-time compare** (@mattinannt): extracted `constantTimeEqual(a, b, encoding)` into `apps/web/lib/crypto.ts` and routed all three copies through it — `jwt.ts`, `single-use-surveys.ts`, and `session-cookie.ts` (which had the same shape inverted inside an `if`). The helper also guards a footgun all three shared: `Buffer.from` silently drops input invalid for its encoding, so two malformed hex values decoded to zero bytes and compared **equal**. Unreachable from current callers, since one side is always a freshly computed digest.

That refactor also required two test-mock fixes, both the same shape: `single-use-surveys.test.ts` and `app/api/v2/client/[workspaceId]/responses/lib/utils.test.ts` replaced `@/lib/crypto` wholesale, so the new export was `undefined` and the resulting TypeError surfaced as a *rejected valid signature*. Both now spread the real module and stub only what they assert on — keeping the signature comparison real, since a stub would let validation pass without comparing anything. The second of those is what turned CI red on `5a02ab6` and is fixed in `46d0f8b`.

## Linear ticket

Fixes ENG-2106

## How this was tested

- Targeted: `pnpm vitest run lib/jwt.test.ts lib/crypto.test.ts lib/utils/single-use-surveys.test.ts modules/auth/lib/session-cookie.test.ts "app/api/v2/client/[workspaceId]/responses/lib/utils.test.ts"` → all green.
- New unit tests in `apps/web/lib/jwt.test.ts` under `verifyEmailChangeToken › credential-state binding`, written behaviorally (mint under one credential state, mutate the state, verify):
  - token minted before a password reset → rejected (**the reported attack**)
  - token replayed after the email already changed → first use succeeds, second rejected
  - credential account gone → rejected
  - unbound token in the pre-fix `{ id, email }` shape → rejected
  - well-formed but non-matching fingerprint → rejected
  - token minted for a different flow (`purpose: "email_verification"`) → rejected
  - the credential lookup stays scoped to this user's own credential row
  - `createEmailChangeToken` refuses to mint for a user with no credential account
- New `constantTimeEqual` tests in `apps/web/lib/crypto.test.ts` (equal, differing, length mismatch, hex decoding, empty, invalid-for-encoding).
- Retargeted one legacy-compatibility test (per-field decryption fallback) from the email-change token — which no longer has a legacy path — to the invite token, which still does.
- **Whole-suite differential.** After the first CI failure I built a CI-equivalent env locally (`bash scripts/setup-dev-env.sh`, `REDIS_URL=` as the workflow does) and ran the full `apps/web` suite (602 files) at this branch and at the previous head, diffing the set of failing files. That's what identified the one regression, and the set is now **identical to the previous head's** — no new failures. (This container still can't run ~81 files for unrelated env/service reasons, which is why the differential rather than an absolute pass count.)
- `eslint`, `prettier --check`, and `tsc --noEmit` clean on all eight changed files.
- CI on `46d0f8b`: Unit Tests, Linters, Better Auth integration tests, both CodeQL analyses, Helm, PR size, translation keys all green.
- Not manually exercised end-to-end: the flow needs SMTP and a second mailbox, which this environment has neither of. See the QA plan below.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] **Happy path.** As a credential (email/password) user, go to Account Settings → Profile, change your email to a second address you control, enter your current password, save. → A verification email arrives at the **new** address. Click its link → `/verify-email-change` shows the success message, the browser is signed out, and you can sign in with the new address and the same password.
- [ ] **The reported attack (must now fail).** Sign in as the victim, request an email change to a second mailbox, and do **not** click the link. Sign out. Run a password recovery for the victim's original address (`/auth/forgot-password`) and set a new password. Now open the still-unclicked verification link from the second mailbox → the page must show **"invalid or expired token"** and the account's email must remain unchanged. Confirm by signing in with the original address and the new password.
- [ ] **Same-password reset.** Repeat the step above but set the recovery password to the *same* value as before. The pending link must still show **"invalid or expired token"**.
- [ ] **Password change, same expectation.** Request an email change, don't click the link, then change the password from Account Settings → Security instead of via recovery. The pending link → **"invalid or expired token"**.
- [ ] **Single use.** Complete a happy-path email change, then click the same verification link a second time → **"invalid or expired token"**; the email stays as the newly-verified address.
- [ ] **Superseded request.** Request a change to address A, then (before clicking) request a change to address B and complete B's link. A's link → **"invalid or expired token"**.
- [ ] **Unchanged rejections.** A malformed/truncated token and an expired one (older than 24h) both → **"invalid or expired token"**.
- [ ] **SSO users unaffected.** As an SSO-provisioned user, the email field in Account Settings → Profile is still not changeable (the action rejects with "Email update is not allowed for non-credential users").
- [ ] **Long-standing pre-Better-Auth account.** On an upgraded self-host, take a credential account created before the Better Auth cutover that has never reset its password since, and run the happy path → the email change still works end to end.
- [ ] **Regression sweep on the shared compare** (three call sites now route through `constantTimeEqual`): sign in and confirm the session sticks across a page reload (signed session cookie), open a single-use survey link and confirm it's accepted once and rejected on reuse, and tamper with a single character of a single-use link's signature → rejected. **Give this one real attention** — a mocked-out version of exactly this comparison is what turned CI red mid-review.

**Preconditions / test data**

- A self-host or staging deployment with SMTP configured (Mailpit is enough) and `EMAIL_VERIFICATION_DISABLED` **unset** — with verification disabled the email changes immediately and no token is involved.
- Two mailboxes you can read: the account's current address and the new one.
- A credential (email/password) account, plus an SSO account for the last check.
- `PASSWORD_RESET_DISABLED` unset, so the recovery step in the attack scenario is available.
- A survey with single-use links enabled, for the shared-compare sweep.

**Risks & regressions**

- Verification links **issued before this deploys** (up to 24h old) are rejected — expected, and users recover by re-requesting the change. Worth watching for support reports in the first day after release.
- `constantTimeEqual` is now on three auth-adjacent paths: session-cookie signature verification (forward-auth / proxy session), single-use survey link signatures, and the email-change fingerprint. Behavior is unchanged for every current caller — same length check, same `timingSafeEqual`, plus a stricter empty/invalid-encoding rejection — but a break here presents as "sessions don't stick" or "valid single-use links rejected", hence the sweep above.
- The fingerprint reads the user's `credential` `Account` row. That is not a new dependency for this flow — requesting an email change already re-verifies the password through the same row (`verifyUserPassword` → `getCredentialPasswordHash`), and the ENG-1054 `credential_account_backfill` migration created it for every pre-cutover user — so no upgraded account should be affected. The pre-Better-Auth QA step above confirms that on real upgraded data.
- Nearby flows sharing `lib/jwt.ts` — signup email verification, invite links, link-survey email verification, SSO recovery — are untouched; a smoke test of signup verification and an org invite is cheap insurance.

**Migrations / env / cutover**

- none

## Credit

Reported by Jaejun Cho.