### PR TITLE
chore: add CODEOWNERS with CI validation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,11 @@
 #     route segment such as `[workspaceId]` in a pattern — the brackets are
 #     unsupported. Own the `modules/` path instead of the `app/` route path.
 #  6. Owners must have WRITE access to this repo, or they are silently dropped.
-#  7. Within a section, keep rules ordered by depth, then alphabetically.
+#  7. Within a section — or within a `# --- labelled group ---` inside one —
+#     keep rules in alphabetical order, with no exceptions, so there is exactly
+#     one obvious place to insert a new rule. Ordering *between* sections is
+#     what controls precedence (rule 1); ordering *within* one is purely for
+#     scannability, and no rule in this file relies on it.
 #
 #  Changes to this file only take effect once merged — GitHub always reads the
 #  version on the pull request's BASE branch.
@@ -59,15 +63,15 @@
 #  1. Repo, build & tooling
 # ------------------------------------------------------------------------------
 /package.json                              @xernobyl @BhagyaAmarasinghe
-/pnpm-workspace.yaml                       @xernobyl @BhagyaAmarasinghe
-/prisma.config.mjs                         @Dhruwang @xernobyl
-/sonar-project.properties                  @BhagyaAmarasinghe @xernobyl
-/turbo.json                                @xernobyl @BhagyaAmarasinghe
-/scripts/                                  @BhagyaAmarasinghe @xernobyl
 /packages/config-eslint/                   @xernobyl @itsjavi
 /packages/config-prettier/                 @xernobyl @itsjavi
 /packages/config-typescript/               @xernobyl @itsjavi
 /packages/vite-plugins/                    @xernobyl @itsjavi
+/pnpm-workspace.yaml                       @xernobyl @BhagyaAmarasinghe
+/prisma.config.mjs                         @Dhruwang @xernobyl
+/scripts/                                  @BhagyaAmarasinghe @xernobyl
+/sonar-project.properties                  @BhagyaAmarasinghe @xernobyl
+/turbo.json                                @xernobyl @BhagyaAmarasinghe
 
 
 # ------------------------------------------------------------------------------
@@ -114,30 +118,32 @@
 # ------------------------------------------------------------------------------
 #  6. Testing & QA
 # ------------------------------------------------------------------------------
+/apps/web/playwright/                      @itsjavi @Dhruwang @pandeymangg
 /playwright.config.ts                      @itsjavi @Dhruwang
 /playwright.service.config.ts              @itsjavi @Dhruwang
-/apps/web/playwright/                      @itsjavi @Dhruwang @pandeymangg
 
 
 # ------------------------------------------------------------------------------
 #  7. apps/web — broad defaults, app config & instrumentation
 #
-#  The first three rules cover the whole Next.js app. Everything in sections
-#  8-14 overrides them for a narrower path, so keep them here at the top.
+#  `app/`, `lib/` and `modules/` are the broad defaults covering the whole
+#  Next.js app; sections 8-14 override them for narrower paths. Their position
+#  inside this section does not matter — precedence comes from section order —
+#  so they sit in the same alphabetical run as everything else here.
 #
 #  `scripts/` reads deployment secrets and validates env at container start;
 #  `proxy*` is the request-routing edge. Both are more sensitive than their
 #  location suggests.
 # ------------------------------------------------------------------------------
 /apps/web/app/                             @Dhruwang @pandeymangg @xernobyl
+/apps/web/instrumentation*                 @BhagyaAmarasinghe @xernobyl
+/apps/web/integration/                     @xernobyl @itsjavi
 /apps/web/lib/                             @Dhruwang @xernobyl @pandeymangg
 /apps/web/modules/                         @Dhruwang @pandeymangg @xernobyl
-/apps/web/integration/                     @xernobyl @itsjavi
-/apps/web/scripts/                         @BhagyaAmarasinghe @xernobyl
-/apps/web/instrumentation*                 @BhagyaAmarasinghe @xernobyl
 /apps/web/next.config.mjs                  @xernobyl @BhagyaAmarasinghe
 /apps/web/prometheus.yml                   @BhagyaAmarasinghe @xernobyl
 /apps/web/proxy*                           @xernobyl @BhagyaAmarasinghe
+/apps/web/scripts/                         @BhagyaAmarasinghe @xernobyl
 /apps/web/sentry.*                         @BhagyaAmarasinghe @xernobyl
 /apps/web/vite*                            @itsjavi @xernobyl
 
@@ -151,6 +157,7 @@
 /apps/web/modules/analysis/                @Dhruwang @pandeymangg
 /apps/web/modules/api/                     @pandeymangg @xernobyl @BhagyaAmarasinghe
 /apps/web/modules/core/                    @xernobyl @Dhruwang
+/apps/web/modules/ee/contacts/             @pandeymangg @Dhruwang
 /apps/web/modules/hub/                     @xernobyl @Dhruwang
 /apps/web/modules/mcp/                     @xernobyl @pandeymangg
 /apps/web/modules/organization/            @pandeymangg @Dhruwang
@@ -159,14 +166,13 @@
 /apps/web/modules/survey/                  @Dhruwang @itsjavi @pandeymangg
 /apps/web/modules/ui/                      @itsjavi @Dhruwang
 /apps/web/modules/workspaces/              @pandeymangg @Dhruwang
-/apps/web/modules/ee/contacts/             @pandeymangg @Dhruwang
 
 
 # ------------------------------------------------------------------------------
 #  9. Workflows
 # ------------------------------------------------------------------------------
-/packages/workflows/                       @itsjavi @xernobyl
 /apps/web/modules/ee/workflows/            @itsjavi @xernobyl
+/packages/workflows/                       @itsjavi @xernobyl
 
 
 # ------------------------------------------------------------------------------
@@ -176,12 +182,12 @@
 #  is a release event. v3 is the current surface for new work. `(internal)`
 #  carries no compatibility promise.
 # ------------------------------------------------------------------------------
-/openapi.yml                               @pandeymangg @xernobyl
 /apps/web/app/api/(internal)/              @xernobyl @BhagyaAmarasinghe
 /apps/web/app/api/v1/                      @pandeymangg @Dhruwang
 /apps/web/app/api/v2/                      @pandeymangg @xernobyl
 /apps/web/app/api/v3/                      @xernobyl @BhagyaAmarasinghe @pandeymangg
 /apps/web/modules/api/v2/                  @pandeymangg @xernobyl
+/openapi.yml                               @pandeymangg @xernobyl
 
 
 # ------------------------------------------------------------------------------
@@ -190,21 +196,21 @@
 #  `/.github/` also covers this CODEOWNERS file, which is GitHub's recommended
 #  way to protect it.
 # ------------------------------------------------------------------------------
-/docker-compose.dev.yml                    @BhagyaAmarasinghe @xernobyl
 /.github/                                  @BhagyaAmarasinghe @xernobyl
+/apps/web/Dockerfile                       @BhagyaAmarasinghe @xernobyl
 /charts/                                   @BhagyaAmarasinghe @Dhruwang
 /docker/                                   @BhagyaAmarasinghe @xernobyl
-/apps/web/Dockerfile                       @BhagyaAmarasinghe @xernobyl
+/docker-compose.dev.yml                    @BhagyaAmarasinghe @xernobyl
 
 
 # ------------------------------------------------------------------------------
 #  12. Documentation
 # ------------------------------------------------------------------------------
 /CONTRIBUTING.md                           @jobenjada @BhagyaAmarasinghe
-/README.md                                 @jobenjada @pandeymangg
 /docs/                                     @jobenjada @pandeymangg
 /docs/api-v3-reference/                    @xernobyl @jobenjada
 /docs/self-hosting/                        @BhagyaAmarasinghe @jobenjada
+/README.md                                 @jobenjada @pandeymangg
 
 
 # ------------------------------------------------------------------------------
@@ -238,8 +244,8 @@
 /apps/web/lib/crypto.ts                    @xernobyl @BhagyaAmarasinghe
 /apps/web/lib/jwt.ts                       @xernobyl @BhagyaAmarasinghe
 /apps/web/lib/oauth/                       @xernobyl @pandeymangg
-/apps/web/modules/auth/                    @xernobyl @Dhruwang
 /apps/web/modules/api/v2/auth/             @xernobyl @pandeymangg
+/apps/web/modules/auth/                    @xernobyl @Dhruwang
 /apps/web/modules/ee/auth/                 @xernobyl @Dhruwang
 /apps/web/modules/ee/sso/                  @xernobyl @pandeymangg
 /apps/web/modules/ee/two-factor-auth/      @xernobyl @Dhruwang
@@ -267,10 +273,10 @@
 
 # --- Environment, secrets & supply chain ---
 /.env.example                              @BhagyaAmarasinghe @xernobyl
-/pnpm-lock.yaml                            @xernobyl @BhagyaAmarasinghe
 /apps/web/lib/constants.ts                 @xernobyl @Dhruwang
-/apps/web/lib/env.ts                       @xernobyl @BhagyaAmarasinghe
 /apps/web/lib/env-client.ts                @xernobyl @BhagyaAmarasinghe
+/apps/web/lib/env.ts                       @xernobyl @BhagyaAmarasinghe
+/pnpm-lock.yaml                            @xernobyl @BhagyaAmarasinghe
 
 # --- Security policy ---
 /SECURITY.md                               @xernobyl @BhagyaAmarasinghe

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,276 @@
+# ==============================================================================
+#  Formbricks — Code Owners
+# ==============================================================================
+#
+#  WHAT THIS FILE IS FOR
+#
+#  Every rule below answers one question about a path: "who knows this part of
+#  the app best?" It exists so review requests can be routed automatically — by
+#  our AI review assignment, and by GitHub's own reviewer suggestions — to the
+#  people with the most context.
+#
+#  It is ADVISORY. Nothing here is wired into branch protection, no owner is
+#  required to approve a pull request, and no rule in this file can block a
+#  merge.
+#
+#  HOW TO READ IT
+#
+#  * Owners are listed PRIMARY FIRST. The first name is the person with the
+#    deepest context; the rest are fallbacks. GitHub ignores this order — it is
+#    here for humans and for review-routing tools.
+#  * Any ONE owner is enough. Extra names widen the pool, they do not multiply
+#    the review burden.
+#  * There is no catch-all `*` rule. A path with no rule means "no designated
+#    expert", and reviewer selection falls back to normal judgement. That is
+#    intentional, not an omission.
+#
+#  HOW TO EDIT IT
+#
+#  1. THE LAST MATCHING PATTERN WINS, and owners do not accumulate across
+#     rules — the winning line is the complete owner list. General rules go
+#     first, specific overrides go last. NEVER add a broad rule at the bottom
+#     of this file; it will silently take over every path above it. Section 14
+#     must stay last.
+#  2. All owners for one pattern MUST be on the SAME LINE. Split across two
+#     lines, only the last line counts. This fails silently.
+#  3. Anchor paths with a leading slash: `/apps/web/` not `apps/web/`. Without
+#     it, the pattern matches a directory of that name at ANY depth.
+#  4. `dir/` owns the whole subtree. `dir/*` owns only its direct children —
+#     almost always a bug in a monorepo.
+#  5. Unlike .gitignore, these DO NOT WORK here: `!` negation, `[a-z]` ranges,
+#     `\#` escaping, and `{a,b}` brace expansion. Never put a Next.js dynamic
+#     route segment such as `[workspaceId]` in a pattern — the brackets are
+#     unsupported. Own the `modules/` path instead of the `app/` route path.
+#  6. Owners must have WRITE access to this repo, or they are silently dropped.
+#  7. Within a section, keep rules ordered by depth, then alphabetically.
+#
+#  Changes to this file only take effect once merged — GitHub always reads the
+#  version on the pull request's BASE branch.
+#
+#  CI validates this file on every change and weekly:
+#  .github/workflows/codeowners-validation.yml
+#
+#  Reference:
+#  https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# ==============================================================================
+
+
+# ------------------------------------------------------------------------------
+#  1. Repo, build & tooling
+# ------------------------------------------------------------------------------
+/package.json                              @xernobyl @BhagyaAmarasinghe
+/pnpm-workspace.yaml                       @xernobyl @BhagyaAmarasinghe
+/prisma.config.mjs                         @Dhruwang @xernobyl
+/sonar-project.properties                  @BhagyaAmarasinghe @xernobyl
+/turbo.json                                @xernobyl @BhagyaAmarasinghe
+/scripts/                                  @BhagyaAmarasinghe @xernobyl
+/packages/config-eslint/                   @xernobyl @itsjavi
+/packages/config-prettier/                 @xernobyl @itsjavi
+/packages/config-typescript/               @xernobyl @itsjavi
+/packages/vite-plugins/                    @xernobyl @itsjavi
+
+
+# ------------------------------------------------------------------------------
+#  2. Data & platform packages
+# ------------------------------------------------------------------------------
+/packages/ai/                              @Dhruwang @xernobyl
+/packages/cache/                           @xernobyl @BhagyaAmarasinghe
+/packages/database/                        @Dhruwang @pandeymangg @xernobyl
+/packages/email/                           @Dhruwang @itsjavi
+/packages/i18n-utils/                      @Dhruwang @pandeymangg
+/packages/logger/                          @BhagyaAmarasinghe @xernobyl
+/packages/storage/                         @BhagyaAmarasinghe @pandeymangg
+/packages/types/                           @Dhruwang @pandeymangg @xernobyl
+
+
+# ------------------------------------------------------------------------------
+#  3. Background jobs
+#
+#  Job *infrastructure* is a backend concern. The workflows product that
+#  schedules them is owned separately — see section 9.
+# ------------------------------------------------------------------------------
+/packages/jobs/                            @xernobyl @itsjavi
+
+
+# ------------------------------------------------------------------------------
+#  4. Survey experience & embeddable SDK
+#
+#  `surveys` is the embeddable runtime and `js-core` the browser SDK. Both ship
+#  to end users' websites, so they carry the strictest compatibility bar in the
+#  repo.
+# ------------------------------------------------------------------------------
+/packages/js-core/                         @pandeymangg @Dhruwang
+/packages/surveys/                         @Dhruwang @pandeymangg @itsjavi
+
+
+# ------------------------------------------------------------------------------
+#  5. UI, design system & accessibility
+# ------------------------------------------------------------------------------
+/ACCESSIBILITY.md                          @itsjavi @Dhruwang
+/apps/storybook/                           @itsjavi @Dhruwang
+/packages/survey-ui/                       @itsjavi @Dhruwang
+
+
+# ------------------------------------------------------------------------------
+#  6. Testing & QA
+# ------------------------------------------------------------------------------
+/playwright.config.ts                      @itsjavi @Dhruwang
+/playwright.service.config.ts              @itsjavi @Dhruwang
+/apps/web/playwright/                      @itsjavi @Dhruwang @pandeymangg
+
+
+# ------------------------------------------------------------------------------
+#  7. apps/web — broad defaults, app config & instrumentation
+#
+#  The first three rules cover the whole Next.js app. Everything in sections
+#  8-14 overrides them for a narrower path, so keep them here at the top.
+#
+#  `scripts/` reads deployment secrets and validates env at container start;
+#  `proxy*` is the request-routing edge. Both are more sensitive than their
+#  location suggests.
+# ------------------------------------------------------------------------------
+/apps/web/app/                             @Dhruwang @pandeymangg @xernobyl
+/apps/web/lib/                             @Dhruwang @xernobyl @pandeymangg
+/apps/web/modules/                         @Dhruwang @pandeymangg @xernobyl
+/apps/web/integration/                     @xernobyl @itsjavi
+/apps/web/scripts/                         @BhagyaAmarasinghe @xernobyl
+/apps/web/instrumentation*                 @BhagyaAmarasinghe @xernobyl
+/apps/web/next.config.mjs                  @xernobyl @BhagyaAmarasinghe
+/apps/web/prometheus.yml                   @BhagyaAmarasinghe @xernobyl
+/apps/web/proxy*                           @xernobyl @BhagyaAmarasinghe
+/apps/web/sentry.*                         @BhagyaAmarasinghe @xernobyl
+/apps/web/vite*                            @itsjavi @xernobyl
+
+
+# ------------------------------------------------------------------------------
+#  8. apps/web — feature modules
+#
+#  Only modules whose ownership differs from the section 7 default are listed.
+#  A module that is absent here is covered by the default on purpose.
+# ------------------------------------------------------------------------------
+/apps/web/modules/analysis/                @Dhruwang @pandeymangg
+/apps/web/modules/api/                     @pandeymangg @xernobyl @BhagyaAmarasinghe
+/apps/web/modules/core/                    @xernobyl @Dhruwang
+/apps/web/modules/hub/                     @xernobyl @Dhruwang
+/apps/web/modules/mcp/                     @xernobyl @pandeymangg
+/apps/web/modules/organization/            @pandeymangg @Dhruwang
+/apps/web/modules/setup/                   @BhagyaAmarasinghe @Dhruwang
+/apps/web/modules/storage/                 @BhagyaAmarasinghe @pandeymangg
+/apps/web/modules/survey/                  @Dhruwang @itsjavi @pandeymangg
+/apps/web/modules/ui/                      @itsjavi @Dhruwang
+/apps/web/modules/workspaces/              @pandeymangg @Dhruwang
+/apps/web/modules/ee/contacts/             @pandeymangg @Dhruwang
+
+
+# ------------------------------------------------------------------------------
+#  9. Workflows
+# ------------------------------------------------------------------------------
+/packages/workflows/                       @itsjavi @xernobyl
+/apps/web/modules/ee/workflows/            @itsjavi @xernobyl
+
+
+# ------------------------------------------------------------------------------
+#  10. Public API surfaces
+#
+#  v1 and v2 are published contracts that self-hosters depend on; breaking them
+#  is a release event. v3 is the current surface for new work. `(internal)`
+#  carries no compatibility promise.
+# ------------------------------------------------------------------------------
+/openapi.yml                               @pandeymangg @xernobyl
+/apps/web/app/api/(internal)/              @xernobyl @BhagyaAmarasinghe
+/apps/web/app/api/v1/                      @pandeymangg @Dhruwang
+/apps/web/app/api/v2/                      @pandeymangg @xernobyl
+/apps/web/app/api/v3/                      @xernobyl @BhagyaAmarasinghe @pandeymangg
+/apps/web/modules/api/v2/                  @pandeymangg @xernobyl
+
+
+# ------------------------------------------------------------------------------
+#  11. Infrastructure, deployment & CI
+#
+#  `/.github/` also covers this CODEOWNERS file, which is GitHub's recommended
+#  way to protect it.
+# ------------------------------------------------------------------------------
+/docker-compose.dev.yml                    @BhagyaAmarasinghe @xernobyl
+/.github/                                  @BhagyaAmarasinghe @xernobyl
+/charts/                                   @BhagyaAmarasinghe @Dhruwang
+/docker/                                   @BhagyaAmarasinghe @xernobyl
+/apps/web/Dockerfile                       @BhagyaAmarasinghe @xernobyl
+
+
+# ------------------------------------------------------------------------------
+#  12. Documentation
+# ------------------------------------------------------------------------------
+/CONTRIBUTING.md                           @jobenjada @BhagyaAmarasinghe
+/README.md                                 @jobenjada
+/docs/                                     @jobenjada
+/docs/api-v3-reference/                    @xernobyl @jobenjada
+/docs/self-hosting/                        @BhagyaAmarasinghe @jobenjada
+
+
+# ------------------------------------------------------------------------------
+#  13. Localization
+#
+#  `en-US.json` is the hand-written source of truth. Every other locale file is
+#  machine-generated by Lingo.dev and is deliberately left without an owner —
+#  there is nothing for a human to review. Same for `i18n.lock` and the
+#  vendored tarball under apps/web/vendor/.
+# ------------------------------------------------------------------------------
+/apps/web/locales/en-US.json               @Dhruwang @pandeymangg
+/packages/surveys/locales/en-US.json       @Dhruwang @pandeymangg
+
+
+# ==============================================================================
+#  14. HIGH-RISK OVERRIDES  —  THIS SECTION MUST STAY LAST
+#
+#  Every rule below deliberately overrides a broader rule above it. Because the
+#  last matching pattern wins, anything added after this block would shadow
+#  these paths. Do not append to this file — insert into the section above that
+#  fits.
+#
+#  Note: LICENSE and apps/web/modules/ee/LICENSE intentionally have no rule.
+#  Licensing is a founder decision and is not routed through this file.
+# ==============================================================================
+
+# --- Auth & identity ---
+/apps/web/app/(auth)/                      @xernobyl @Dhruwang
+/apps/web/app/api/auth/                    @xernobyl @pandeymangg
+/apps/web/lib/auth.ts                      @xernobyl @Dhruwang
+/apps/web/lib/crypto.ts                    @xernobyl @BhagyaAmarasinghe
+/apps/web/lib/jwt.ts                       @xernobyl @BhagyaAmarasinghe
+/apps/web/lib/oauth/                       @xernobyl @pandeymangg
+/apps/web/modules/auth/                    @xernobyl @Dhruwang
+/apps/web/modules/api/v2/auth/             @xernobyl @pandeymangg
+/apps/web/modules/ee/auth/                 @xernobyl @Dhruwang
+/apps/web/modules/ee/sso/                  @xernobyl @pandeymangg
+/apps/web/modules/ee/two-factor-auth/      @xernobyl @Dhruwang
+
+# --- Internal gateway auth (Envoy / Traefik) ---
+/apps/web/modules/envoy-auth/              @BhagyaAmarasinghe @xernobyl
+/apps/web/modules/gateway-auth/            @BhagyaAmarasinghe @xernobyl
+/apps/web/modules/traefik-auth/            @BhagyaAmarasinghe @xernobyl
+
+# --- Billing, entitlements & licensing ---
+/apps/web/app/api/billing/                 @Dhruwang @pandeymangg
+/apps/web/modules/billing/                 @Dhruwang @pandeymangg
+/apps/web/modules/ee/billing/              @Dhruwang @pandeymangg
+/apps/web/modules/ee/license-check/        @xernobyl @Dhruwang
+/apps/web/modules/ee/quotas/               @Dhruwang @xernobyl
+/apps/web/modules/entitlements/            @Dhruwang @xernobyl
+
+# --- Audit logs & compliance ---
+/apps/web/modules/ee/audit-logs/           @xernobyl @BhagyaAmarasinghe
+
+# --- Database migrations ---
+#  Reviewing a migration needs the data model AND the rollout blast radius,
+#  which is why this differs from /packages/database/ above.
+/packages/database/migration/              @Dhruwang @xernobyl @BhagyaAmarasinghe
+
+# --- Environment, secrets & supply chain ---
+/.env.example                              @BhagyaAmarasinghe @xernobyl
+/pnpm-lock.yaml                            @xernobyl @BhagyaAmarasinghe
+/apps/web/lib/constants.ts                 @xernobyl @Dhruwang
+/apps/web/lib/env.ts                       @xernobyl @BhagyaAmarasinghe
+/apps/web/lib/env-client.ts                @xernobyl @BhagyaAmarasinghe
+
+# --- Security policy ---
+/SECURITY.md                               @xernobyl @BhagyaAmarasinghe

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -201,8 +201,8 @@
 #  12. Documentation
 # ------------------------------------------------------------------------------
 /CONTRIBUTING.md                           @jobenjada @BhagyaAmarasinghe
-/README.md                                 @jobenjada
-/docs/                                     @jobenjada
+/README.md                                 @jobenjada @pandeymangg
+/docs/                                     @jobenjada @pandeymangg
 /docs/api-v3-reference/                    @xernobyl @jobenjada
 /docs/self-hosting/                        @BhagyaAmarasinghe @jobenjada
 

--- a/.github/workflows/codeowners-validation.yml
+++ b/.github/workflows/codeowners-validation.yml
@@ -1,0 +1,55 @@
+name: Validate CODEOWNERS
+
+# CODEOWNERS fails silently: an unparseable line is skipped, an owner without
+# write access is dropped, and a pattern whose directory was renamed simply
+# stops matching. None of that surfaces anywhere, so it is checked here.
+#
+# This workflow is deliberately NOT part of pr.yml's `required` gate. Ownership
+# metadata going stale must never block unrelated work.
+
+on:
+  pull_request:
+    paths:
+      - ".github/CODEOWNERS"
+      - ".github/workflows/codeowners-validation.yml"
+  # The weekly run is the important one. Renaming a directory elsewhere in the
+  # repo breaks a pattern without touching CODEOWNERS, so the pull_request
+  # trigger above would never fire for it.
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Validate CODEOWNERS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Validate CODEOWNERS
+        uses: mszostok/codeowners-validator@7f3f5e28c6d7b8dfae5731e54ce2272ca384592f # v0.7.4
+        with:
+          # syntax       - unparseable lines, which GitHub would skip silently
+          # duppatterns  - the same pattern declared twice
+          # files        - patterns that match nothing, i.e. a renamed directory
+          # owners       - owners who do not exist or have lost write access
+          checks: "syntax,duppatterns,files,owners"
+          # avoid-shadowing enforces the general-to-specific ordering the whole
+          # file depends on, since the last matching pattern wins.
+          experimental_checks: "avoid-shadowing"
+          # The `owners` check reads organization membership, which the default
+          # GITHUB_TOKEN cannot do. Needs a PAT with read:org.
+          github_access_token: ${{ secrets.CODEOWNERS_VALIDATOR_TOKEN }}

--- a/.github/workflows/codeowners-validation.yml
+++ b/.github/workflows/codeowners-validation.yml
@@ -39,6 +39,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+      - name: Note reduced check set on fork pull requests
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::notice::Fork pull request: repository secrets are not available, so the 'owners' check is skipped. The other four checks still run, and 'owners' is covered by the weekly scheduled run against the default branch."
+
       - name: Validate CODEOWNERS
         uses: mszostok/codeowners-validator@7f3f5e28c6d7b8dfae5731e54ce2272ca384592f # v0.7.4
         with:
@@ -46,10 +51,20 @@ jobs:
           # duppatterns  - the same pattern declared twice
           # files        - patterns that match nothing, i.e. a renamed directory
           # owners       - owners who do not exist or have lost write access
-          checks: "syntax,duppatterns,files,owners"
+          #
+          # `owners` is dropped for pull requests from a fork. GitHub does not
+          # forward repository secrets to those runs, so the token below would
+          # resolve empty and the check would fail on authentication — a red X on
+          # an outside contributor's PR that says nothing about their change. The
+          # weekly scheduled run covers `owners` against the default branch.
+          checks: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && 'syntax,duppatterns,files,owners' || 'syntax,duppatterns,files' }}
           # avoid-shadowing enforces the general-to-specific ordering the whole
           # file depends on, since the last matching pattern wins.
           experimental_checks: "avoid-shadowing"
           # The `owners` check reads organization membership, which the default
-          # GITHUB_TOKEN cannot do. Needs a PAT with read:org.
+          # GITHUB_TOKEN cannot do. Requires a CLASSIC PAT with `read:org` —
+          # fine-grained tokens do not send the X-OAuth-Scopes header the
+          # validator reads, so they fail with `missing scopes: "read:org"`. The
+          # token must belong to an org member, or private members are invisible
+          # and every owner is reported invalid.
           github_access_token: ${{ secrets.CODEOWNERS_VALIDATOR_TOKEN }}


### PR DESCRIPTION
## What & why

The repo has no CODEOWNERS file, so nothing tells an automated reviewer-assignment step who to ask about a given path. This adds one whose sole job is to answer "who knows this part of the app best?" per path.

It is **advisory**. It is not wired into branch protection and cannot block a merge.

Design decisions worth knowing before reading the diff:

- **Named individuals, not teams.** For a blocking gate a team slug is right, but here it destroys the signal — `@formbricks/engineering` on `packages/database/migration/` says nothing useful. "Who knows this best" resolves to a person.
- **Owners are listed primary-first.** GitHub ignores that order; it is the signal for humans and routing tools. Documented in the file header.
- **Two to three owners per path**, so no path is orphaned by a holiday or a departure. GitHub treats multiple owners as "any of", so extra names widen the pool rather than adding review burden. All 98 rules carry two or three.
- **No catch-all `*` rule.** An unmatched path means "no designated expert" and falls through to normal reviewer selection. 95% of tracked files resolve to an owner; the rest are static assets, machine-generated locales and root dotfiles.
- **14 commented sections ordered broad → specific**, with high-risk overrides (auth, billing, licensing, migrations, env/secrets) strictly last, because the last matching pattern wins. Precedence comes from section order; ordering *within* a section is alphabetical purely for scannability and carries no meaning.

Assignments were derived from each engineer's specialism, using 18 months of per-path commit history as the tiebreaker rather than the primary signal. Ordering strictly by commit volume would have made one person the first-named owner on most of the repo, which defeats the purpose.

The second file is a standalone validation workflow. CODEOWNERS fails **silently**: an unparseable line is skipped, an owner without write access is dropped, and a pattern whose directory got renamed simply stops matching. Nothing surfaces any of that. The workflow runs `syntax`, `duppatterns`, `files` and `owners`, plus the experimental `avoid-shadowing` check that enforces the broad→specific ordering the file depends on.

It is deliberately **outside** `pr.yml`'s `required` gate, so ownership metadata going stale never blocks unrelated work. The weekly cron matters as much as the PR trigger: renaming a directory elsewhere breaks a pattern without touching CODEOWNERS, so the `paths` filter would never fire for it.

`owners` is dropped for pull requests **from a fork**, because GitHub does not forward repository secrets to those runs — the token would resolve empty and the check would fail on authentication, putting a red X on an outside contributor's PR for a reason unrelated to their change. Fork PRs keep the other four checks, a log notice explains the reduced set, and `owners` stays covered by the weekly run against `main`.

## Linear ticket

No ticket — repo tooling/config change, raised directly rather than through planning.

## How this was tested

- **The validation workflow passes on this PR**, with all five checks executing against the real file:
  ```
  ==> Executing Duplicated Pattern Checker (78.056µs)            Check OK
  ==> Executing Valid Syntax Checker (313.727µs)                 Check OK
  ==> Executing [Experimental] Avoid Shadowing Checker (1.51ms)  Check OK
  ==> Executing File Exist Checker (34.11ms)                     Check OK
  ==> Executing Valid Owner Checker (868.75ms)                   Check OK
  5 check(s) executed, no failure(s)
  ```
  `Valid Owner Checker` confirms every named owner is a valid org member holding write access — the sub-second timing is live API calls, versus microseconds for the offline checks. `avoid-shadowing` is the meaningful one for the file's structure: it proves no later rule silently voids an earlier override.
- **Full CI green**: 16 checks, no failures.
- **GitHub's own CODEOWNERS parser: 0 errors** (`GET /repos/formbricks/formbricks/codeowners/errors?ref=…`). This is the authoritative check that no line will be silently skipped.
- **Independent resolution** with `hmarr/codeowners` across 26 representative paths, confirming intent rather than just validity: `modules/auth/` beats the `modules/` default, `modules/ee/ai-translation/` correctly falls through to that default, `locales/de-DE.json` is unowned while `locales/en-US.json` is owned, `charts/formbricks/values.yaml` routes to the infra owner.
- **The alphabetical re-sort was verified behaviour-preserving, not assumed**: resolving all 4,566 tracked files against the file before and after the sort produces byte-identical owners.
- **Every owner verified to hold write access** via the collaborators API, since GitHub silently drops owners who don't.
- `prettier --check` clean; the pre-commit hook passed. No unit or E2E tests apply — this is configuration, and `AGENTS.md` discourages low-signal coverage.

## Breaking changes

None

## QA / Test Plan

Not user-facing: nothing in the product changes, so there is nothing to exercise in the running app. The observable checks are all in the GitHub UI.

**How to test**

- [ ] Open the **Checks** tab on this PR → "Validate CODEOWNERS" has run and passed, and its log shows `5 check(s) executed, no failure(s)`.
- [ ] Browse to `.github/CODEOWNERS` on this branch → GitHub renders it with no syntax-error banner. A banner would name the offending line.
- [ ] After merge, open any file under `charts/formbricks/` in the GitHub UI and hover the shield icon near the file header → tooltip reads `Owned by BhagyaAmarasinghe (from CODEOWNERS line N)`. This is also how you debug which rule won for any path.
- [ ] After merge, open a PR touching only `apps/web/modules/ui/` → the UI/design-system owner is auto-requested, not the whole team.
- [ ] Edge case, after merge: a PR touching only `apps/web/locales/de-DE.json` → **no** owner is requested, because machine-translated output is deliberately unowned. A PR touching `apps/web/locales/en-US.json` **does** request owners.
- [ ] Edge case, fork PR: open a PR from a fork that edits `.github/CODEOWNERS` → the workflow runs `4 check(s)` instead of 5, and the log carries a notice explaining that `owners` was skipped because repository secrets are unavailable. It should **not** fail.

**Preconditions / test data**

- A `CODEOWNERS_VALIDATOR_TOKEN` repository secret must exist for the `owners` check: a **classic** PAT with the `read:org` scope, belonging to an organization member. Fine-grained tokens do not send the `X-OAuth-Scopes` header the validator reads and fail with `missing scopes: "read:org"`. `read:org` is the only scope needed — the validator's own docs also suggest `public_repo`, which over-specifies for a public repo. Note this diagnosis applies only to same-repo runs; on a fork the secret is never forwarded at all, which is why `owners` is skipped there rather than attempted.
- No app, database, seed data, or feature flag needed.
- Note the chicken-and-egg: GitHub always reads CODEOWNERS from the pull request's **base** branch, so the routing behaviour above cannot be observed on this PR itself — only once merged to `main`. The two reviewers on this PR were resolved from the branch version of the file by hand for that reason.

**Risks & regressions**

- Reviewer routing is the only behaviour introduced. Because nothing is wired into branch protection, a wrong or missing owner cannot block a merge — the worst case is a review request going to the wrong person.
- Watch for review-request noise on the broadest rules (`/apps/web/app/`, `/apps/web/lib/`, `/apps/web/modules/`). If a section proves noisy, narrow that rule rather than deleting owners.
- Coverage gap to be aware of: an ownership defect introduced by a fork PR is not caught until the weekly scheduled run, since `owners` cannot run without secrets there.
- The validator workflow can fail for a token reason rather than an ownership one: classic PATs expire, and on expiry the weekly run goes red. That is expected and is a credential renewal, not a CODEOWNERS defect.
- If rules are ever appended to the **end** of the file, they will shadow the high-risk overrides. The `avoid-shadowing` check exists to catch exactly that, and the file header says so.

**Migrations / env / cutover**

- No DB migrations, no application env vars, no `.env.example` change.
- One repository **secret** is required, as described above: `CODEOWNERS_VALIDATOR_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lfb7QA7A5V5KCvnWmmS43w
