### PR TITLE
fix: stop the sentiment_score filter description from inviting -1/1 as a default

### DIFF
--- a/apps/web/app/api/v3/feedbackRecords/lib/schemas.ts
+++ b/apps/web/app/api/v3/feedbackRecords/lib/schemas.ts
@@ -180,14 +180,16 @@ export const ZV3FeedbackRecordFilters = z
       .max(1)
       .optional()
       .describe(
-        "Only records whose sentiment score is at least this value, from -1 to 1 (inclusive). Unenriched records carry no score and are therefore never matched, so this implies 'enriched only'."
+        "Only records whose sentiment score is at least this value (inclusive). Sentiment scores range from -1 to 1, but that is the validation bound, not a default to fill in — omit this filter to leave the lower end unbounded rather than passing -1. Unenriched records carry no score and are therefore never matched, so this implies 'enriched only'."
       ),
     sentiment_score_max: z
       .number()
       .min(-1)
       .max(1)
       .optional()
-      .describe("Only records whose sentiment score is at most this value, from -1 to 1 (inclusive)."),
+      .describe(
+        "Only records whose sentiment score is at most this value (inclusive). Sentiment scores range from -1 to 1, but that is the validation bound, not a default to fill in — omit this filter to leave the upper end unbounded rather than passing 1."
+      ),
 
     has_sentiment: presenceFilter(
       "Restrict to records that do (true) or do not (false) carry a sentiment label. Use false to find records enrichment has not reached yet."


### PR DESCRIPTION
## What & why

`sentiment_score_min`/`sentiment_score_max` are the only numeric feedback-record filters with a
local `.min(-1).max(1)`, which compiles to `minimum`/`maximum` on the MCP tool's `inputSchema`.
Combined with a description that read as the field's *operating range* ("...from -1 to 1
(inclusive)") rather than a validation ceiling, an agent would pass
`sentiment_score_min: -1, sentiment_score_max: 1` even when it wanted no sentiment-score filtering
at all — those are the field's own defaults, so specifying them is a redundant no-op. Noticed while
demoing the ENG-2275 filters.

`value_number_min`/`max` don't have this problem: they carry no local `.min()/.max()`, so they
render as a bare `{type: "number"}` with nothing inviting a "fill in the range" reading.

Reworded both descriptions to say plainly that omitting the filter leaves that bound unset, and
that -1/1 are the validation bound rather than a default to supply. No behavior change — the
Zod validation, the Hub-side semantics, and the existing out-of-range test are all untouched.

## Linear ticket

Fixes ENG-2392

## How this was tested

- `node ../../node_modules/.bin/vitest run app/api/v3/feedbackRecords/lib/operations.test.ts modules/mcp/tools/feedback-records.test.ts` (run from `apps/web`) → **182 tests passing** ✅ — no test asserts the literal description text, so none needed updating.
- `pnpm prettier --check` on the changed file → clean ✅
- `pnpm eslint` on the changed file → clean ✅
- Manually verified against a local Hub 0.8.4 + this branch: fetched the MCP tool's live `inputSchema` for `count_feedback_records` before and after — confirmed the `sentiment_score_min` description now states the omit-for-unbounded behavior while `minimum: -1`/`maximum: 1` (the real validation bound) are unchanged.

## Breaking changes

None — description-only change, no schema/behavior change.

## QA / Test Plan

**How to test**

- [ ] Call `GET /api/v3/feedbackRecords` (or the `list_feedback_records`/`count_feedback_records` MCP tools) with no `sentiment_score_min`/`sentiment_score_max` → same result as before (no bound applied).
- [ ] Call with `sentiment_score_min: -2` → still `400`/`invalid_params` naming `sentiment_score_min` (validation unchanged).
- [ ] Inspect the MCP tool's `inputSchema` for `sentiment_score_min`/`sentiment_score_max` (e.g. via `tools/list`) → description now says omitting the filter leaves that bound unset.

**Preconditions / test data**

- None beyond the existing feedback-records/Unify Feedback setup.

**Risks & regressions**

- None expected — this only changes a `.describe()` string consumed by the MCP tool schema and the OpenAPI-adjacent docs; no runtime logic changed.

**Migrations / env / cutover**

- none