### PR TITLE
feat(embedded-data): repoint readers to the tables and inline definitions on survey load [ENG-1837]

### DIFF
--- a/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/components/AddIntegrationModal.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/settings/workspace/integrations/notion/components/AddIntegrationModal.tsx
@@ -7,6 +7,7 @@ import { useForm } from "react-hook-form";
 import toast from "react-hot-toast";
 import { useTranslation } from "react-i18next";
 import { TContactAttributeKey } from "@formbricks/types/contact-attribute-key";
+import { getComputedEmbeddedFields, getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
 import { TIntegrationInput } from "@formbricks/types/integration";
 import {
   TIntegrationNotion,
@@ -121,19 +122,24 @@ export const AddIntegrationModal = ({
         }))
       : [];
 
-    const variables =
-      selectedSurvey?.variables.map((variable) => ({
-        id: variable.id,
-        name: variable.name,
-        type: TSurveyElementTypeEnum.OpenText,
-      })) || [];
+    // ENG-1837: the mapping list must name the same things the pipeline exports, and
+    // `handle-integrations.ts` labels a computed field by `field.name` and an ingested one by its
+    // storage key — so both come from the survey's Embedded Data definitions, not the legacy columns.
+    const variables = selectedSurvey
+      ? getComputedEmbeddedFields(selectedSurvey).map(({ field, link }) => ({
+          id: link.storageKey,
+          name: field.name,
+          type: TSurveyElementTypeEnum.OpenText,
+        }))
+      : [];
 
-    const hiddenFields =
-      selectedSurvey?.hiddenFields.fieldIds?.map((fId) => ({
-        id: fId,
-        name: `${t("common.hidden_field")} : ${fId}`,
-        type: TSurveyElementTypeEnum.OpenText,
-      })) || [];
+    const hiddenFields = selectedSurvey
+      ? getIngestedStorageKeys(selectedSurvey).map((storageKey) => ({
+          id: storageKey,
+          name: `${t("common.hidden_field")} : ${storageKey}`,
+          type: TSurveyElementTypeEnum.OpenText,
+        }))
+      : [];
     const Metadata = [
       {
         id: "metadata",

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/components/ResponseDataView.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/components/ResponseDataView.tsx
@@ -3,6 +3,7 @@
 import { TFunction } from "i18next";
 import React from "react";
 import { useTranslation } from "react-i18next";
+import { getComputedEmbeddedFields, getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
 import { TSurveyQuota } from "@formbricks/types/quota";
 import { TResponseDataValue, TResponseTableData, TResponseWithQuotas } from "@formbricks/types/responses";
 import { TSurvey } from "@formbricks/types/surveys/types";
@@ -72,10 +73,8 @@ const extractResponseData = (response: TResponseWithQuotas, survey: TSurvey): Re
     }
   }
 
-  if (survey.hiddenFields.fieldIds) {
-    for (const fieldId of survey.hiddenFields.fieldIds) {
-      responseData[fieldId] = response.data[fieldId];
-    }
+  for (const fieldId of getIngestedStorageKeys(survey)) {
+    responseData[fieldId] = response.data[fieldId];
   }
 
   return responseData;
@@ -96,9 +95,10 @@ const mapResponsesToTableData = (
     responseId: response.id,
     singleUseId: response.singleUseId,
     tags: response.tags,
-    variables: survey.variables.reduce(
-      (acc, curr) => {
-        return Object.assign(acc, { [curr.id]: response.variables[curr.id] });
+    // The raw slot, uncoerced: a response predating a field has no key and the cell stays empty.
+    variables: getComputedEmbeddedFields(survey).reduce(
+      (acc, { link }) => {
+        return Object.assign(acc, { [link.storageKey]: response.variables[link.storageKey] });
       },
       {} as Record<string, string | number>
     ),

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTableColumns.tsx
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/responses/components/ResponseTableColumns.tsx
@@ -4,6 +4,10 @@ import { ColumnDef } from "@tanstack/react-table";
 import { TFunction } from "i18next";
 import { CircleHelpIcon, EyeOffIcon, MailIcon, TagIcon } from "lucide-react";
 import Link from "next/link";
+import {
+  getComputedEmbeddedFields,
+  getIngestedEmbeddedFields,
+} from "@formbricks/types/embedded-data-resolver";
 import { TResponseTableData } from "@formbricks/types/responses";
 import { TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
@@ -371,45 +375,52 @@ export const generateResponseTableColumns = (
     },
   };
 
-  const variableColumns: ColumnDef<TResponseTableData>[] = survey.variables.map((variable) => {
-    return {
-      accessorKey: "VARIABLE_" + variable.id,
-      header: () => (
-        <div className="flex items-center gap-x-2 overflow-hidden">
-          <span className="size-4">{VARIABLES_ICON_MAP[variable.type]}</span>
-          <span className="truncate">{variable.name}</span>
-        </div>
-      ),
-      cell: ({ row }) => {
-        const variableResponse = row.original.variables[variable.id];
-        if (typeof variableResponse === "string" || typeof variableResponse === "number") {
-          return <div className="text-slate-900">{variableResponse}</div>;
-        }
-      },
-    };
-  });
+  // ENG-1837: both column groups are built from the survey's Embedded Data definitions. The accessor
+  // keys stay the storage keys — they address `row.original.variables` / `responseData`, which are
+  // written from the response, not the definitions.
+  const variableColumns: ColumnDef<TResponseTableData>[] = getComputedEmbeddedFields(survey).map(
+    ({ field, link }) => {
+      return {
+        accessorKey: "VARIABLE_" + link.storageKey,
+        header: () => (
+          <div className="flex items-center gap-x-2 overflow-hidden">
+            <span className="size-4">
+              {VARIABLES_ICON_MAP[field.dataType === "number" ? "number" : "text"]}
+            </span>
+            <span className="truncate">{field.name}</span>
+          </div>
+        ),
+        cell: ({ row }) => {
+          const variableResponse = row.original.variables[link.storageKey];
+          if (typeof variableResponse === "string" || typeof variableResponse === "number") {
+            return <div className="text-slate-900">{variableResponse}</div>;
+          }
+        },
+      };
+    }
+  );
 
-  const hiddenFieldColumns: ColumnDef<TResponseTableData>[] = survey.hiddenFields.fieldIds
-    ? survey.hiddenFields.fieldIds.map((hiddenFieldId) => {
-        return {
-          accessorKey: "HIDDEN_FIELD_" + hiddenFieldId,
-          header: () => (
-            <div className="flex items-center gap-x-2 overflow-hidden">
-              <span className="size-4">
-                <EyeOffIcon className="size-4" />
-              </span>
-              <span className="truncate">{hiddenFieldId}</span>
-            </div>
-          ),
-          cell: ({ row }) => {
-            const hiddenFieldResponse = row.original.responseData[hiddenFieldId];
-            if (typeof hiddenFieldResponse === "string") {
-              return <div className="text-slate-900">{hiddenFieldResponse}</div>;
-            }
-          },
-        };
-      })
-    : [];
+  const hiddenFieldColumns: ColumnDef<TResponseTableData>[] = getIngestedEmbeddedFields(survey).map(
+    ({ field, link }) => {
+      return {
+        accessorKey: "HIDDEN_FIELD_" + link.storageKey,
+        header: () => (
+          <div className="flex items-center gap-x-2 overflow-hidden">
+            <span className="size-4">
+              <EyeOffIcon className="size-4" />
+            </span>
+            <span className="truncate">{field.name}</span>
+          </div>
+        ),
+        cell: ({ row }) => {
+          const hiddenFieldResponse = row.original.responseData[link.storageKey];
+          if (typeof hiddenFieldResponse === "string") {
+            return <div className="text-slate-900">{hiddenFieldResponse}</div>;
+          }
+        },
+      };
+    }
+  );
 
   const metadataColumns = getMetadataColumnsData(t);
 

--- a/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/surveySummary.ts
+++ b/apps/web/app/(app)/workspaces/[workspaceId]/surveys/[surveyId]/(analysis)/summary/lib/surveySummary.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { ZId, ZOptionalNumber } from "@formbricks/types/common";
+import { getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import {
   TResponseContact,
@@ -959,7 +960,7 @@ export const getElementSummary = async (
     }
   }
 
-  survey.hiddenFields?.fieldIds?.forEach((hiddenFieldId) => {
+  getIngestedStorageKeys(survey).forEach((hiddenFieldId) => {
     let values: TSurveyElementSummaryHiddenFields["samples"] = [];
     responses.forEach((response) => {
       const answer = response.data[hiddenFieldId];

--- a/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.ts
+++ b/apps/web/app/api/v1/client/[workspaceId]/environment/lib/data.ts
@@ -10,6 +10,7 @@ import {
   TJsWorkspaceStateWorkspaceSetting,
 } from "@formbricks/types/js";
 import { type TBaseFilters, buildSurveyInteractionRefreshMap } from "@formbricks/types/segment";
+import { selectSurveyEmbeddedDataLinks } from "@/lib/embedded-data/survey-fields";
 import { toLegacyLanguageCodes } from "@/lib/i18n/utils";
 import { validateInputs } from "@/lib/utils/validate";
 import { resolveStorageUrlsInObject } from "@/modules/storage/utils";
@@ -161,6 +162,9 @@ export const getWorkspaceStateData = async (workspaceId: string): Promise<Worksp
             displayLimit: true,
             displayOption: true,
             hiddenFields: true,
+            // ENG-1837: the definitions the SDK-rendered survey's recall and logic engines resolve
+            // through. Rides in the same 60s-cached workspace-state payload as the columns above.
+            embeddedDataLinks: selectSurveyEmbeddedDataLinks,
             isBackButtonHidden: true,
             isAutoProgressingEnabled: true,
             triggers: {

--- a/apps/web/app/api/v1/management/surveys/[surveyId]/route.ts
+++ b/apps/web/app/api/v1/management/surveys/[surveyId]/route.ts
@@ -15,6 +15,7 @@ import {
   transformQuestionsToBlocks,
   validateSurveyInput,
   withDerivedQuestions,
+  withoutInternalSurveyProjections,
 } from "@/app/lib/api/survey-transformation";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
 import { THandlerParams, withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
@@ -65,7 +66,9 @@ export const GET = withV1ApiWrapper({
       // consumers get a consistent shape regardless of how the survey was built.
       return {
         response: responses.successResponse(
-          addLegacyProjectOverwrites(resolveStorageUrlsInObject(withDerivedQuestions(result.survey)))
+          addLegacyProjectOverwrites(
+            resolveStorageUrlsInObject(withoutInternalSurveyProjections(withDerivedQuestions(result.survey)))
+          )
         ),
       };
     } catch (error) {
@@ -219,7 +222,11 @@ export const PUT = withV1ApiWrapper({
 
         return {
           response: responses.successResponse(
-            addLegacyProjectOverwrites(resolveStorageUrlsInObject(withDerivedQuestions(updatedSurvey)))
+            addLegacyProjectOverwrites(
+              resolveStorageUrlsInObject(
+                withoutInternalSurveyProjections(withDerivedQuestions(updatedSurvey))
+              )
+            )
           ),
         };
       } catch (error) {

--- a/apps/web/app/api/v1/management/surveys/route.ts
+++ b/apps/web/app/api/v1/management/surveys/route.ts
@@ -14,6 +14,7 @@ import {
   transformQuestionsToBlocks,
   validateSurveyInput,
   withDerivedQuestions,
+  withoutInternalSurveyProjections,
 } from "@/app/lib/api/survey-transformation";
 import { transformErrorToDetails } from "@/app/lib/api/validator";
 import { withV1ApiWrapper } from "@/app/lib/api/with-api-logging";
@@ -43,7 +44,9 @@ export const GET = withV1ApiWrapper({
 
       // Always expose `questions` (derived from blocks) alongside `blocks` so API v1
       // consumers get a consistent shape regardless of how the survey was built.
-      const surveysWithQuestions = surveys.map((survey) => withDerivedQuestions(survey));
+      const surveysWithQuestions = surveys.map((survey) =>
+        withoutInternalSurveyProjections(withDerivedQuestions(survey))
+      );
 
       return {
         response: responses.successResponse(
@@ -147,7 +150,9 @@ export const POST = withV1ApiWrapper({
 
       return {
         response: responses.successResponse(
-          addLegacyProjectOverwrites(resolveStorageUrlsInObject(withDerivedQuestions(survey)))
+          addLegacyProjectOverwrites(
+            resolveStorageUrlsInObject(withoutInternalSurveyProjections(withDerivedQuestions(survey)))
+          )
         ),
       };
     } catch (error) {

--- a/apps/web/app/api/v3/surveys/patch.test.ts
+++ b/apps/web/app/api/v3/surveys/patch.test.ts
@@ -35,6 +35,18 @@ vi.mock("@formbricks/database", () => {
     segment: {
       update: vi.fn(),
     },
+    // ENG-1837: the patch reconciles the EmbeddedData rows in the same transaction as the survey
+    // write, so the models the reconcile touches have to exist on the client.
+    surveyEmbeddedData: {
+      findMany: vi.fn(),
+      deleteMany: vi.fn(),
+      create: vi.fn(),
+    },
+    embeddedData: {
+      create: vi.fn(),
+      deleteMany: vi.fn(),
+      updateMany: vi.fn(),
+    },
     // Interactive transaction: run the callback with the mocked client as the tx client.
     $transaction: vi.fn((callback: (tx: typeof prisma) => Promise<unknown>) => callback(prisma)),
   };
@@ -228,6 +240,15 @@ describe("patchV3Survey", () => {
     });
     vi.mocked(prisma.$transaction).mockImplementation(((callback: (tx: typeof prisma) => Promise<unknown>) =>
       callback(prisma)) as typeof prisma.$transaction);
+    // ENG-1837: the patch reconciles the EmbeddedData rows in the same transaction as the survey
+    // write, so the models that reconcile touches have to answer. Left as the real reconcile rather
+    // than a module mock, so these tests keep proving it runs through the transaction's client.
+    vi.mocked(prisma.surveyEmbeddedData.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.surveyEmbeddedData.deleteMany).mockResolvedValue({ count: 0 } as never);
+    vi.mocked(prisma.surveyEmbeddedData.create).mockResolvedValue({} as never);
+    vi.mocked(prisma.embeddedData.create).mockResolvedValue({ id: "ed_1" } as never);
+    vi.mocked(prisma.embeddedData.deleteMany).mockResolvedValue({ count: 0 } as never);
+    vi.mocked(prisma.embeddedData.updateMany).mockResolvedValue({ count: 0 } as never);
     vi.mocked(normalizeSurveyScheduling).mockImplementation(({ closeOn, publishOn }) => ({
       closeOn,
       publishOn,
@@ -278,6 +299,92 @@ describe("patchV3Survey", () => {
         }),
       })
     );
+  });
+
+  /**
+   * ENG-1837 made the EmbeddedData tables the read source of truth for definitions, so a patch that
+   * moves `variables` / `hiddenFields` has to reconcile the rows in the same transaction — otherwise
+   * recall, the logic engine, export columns and the response filters keep reading the pre-patch set.
+   * v3 patch is the one write path that did not do this.
+   */
+  describe("Embedded Data reconcile", () => {
+    test("writes a row and a link for a variable the patch adds", async () => {
+      await patchV3Survey(
+        currentSurvey,
+        { variables: [{ id: "clvar123456789012345678901", name: "score", type: "number", value: 7 }] },
+        "req_qa",
+        "org_1"
+      );
+
+      expect(prisma.embeddedData.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            surveyId: currentSurvey.id,
+            // Never the client payload's workspace — the stored survey's (ENG-1749).
+            workspaceId: currentSurvey.workspaceId,
+            name: "score",
+            source: "computed",
+            dataType: "number",
+          }),
+        })
+      );
+      expect(prisma.surveyEmbeddedData.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            surveyId: currentSurvey.id,
+            // A variable is addressed by its cuid, which is what recall tokens and responses use.
+            storageKey: "clvar123456789012345678901",
+          }),
+        })
+      );
+    });
+
+    test("writes a row and a link for a hidden field the patch adds", async () => {
+      await patchV3Survey(
+        currentSurvey,
+        { hiddenFields: { enabled: true, fieldIds: ["utm_source"] } },
+        "req_qa",
+        "org_1"
+      );
+
+      expect(prisma.embeddedData.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ name: "utm_source", source: "ingested", dataType: "string" }),
+        })
+      );
+      expect(prisma.surveyEmbeddedData.create).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ storageKey: "utm_source" }) })
+      );
+    });
+
+    test("reconciles from the PERSISTED survey, so a patch that omits the fields keeps its rows", async () => {
+      // The patch document carries neither key. Reading it instead of the persisted row would see
+      // them as absent and unlink every field the survey has.
+      vi.mocked(prisma.surveyEmbeddedData.findMany).mockResolvedValueOnce([
+        {
+          id: "link_1",
+          storageKey: "utm_source",
+          embeddedData: {
+            id: "ed_existing",
+            surveyId: currentSurvey.id,
+            name: "utm_source",
+            source: "ingested",
+            dataType: "string",
+            defaultValue: null,
+          },
+        },
+      ] as never);
+      vi.mocked(prisma.survey.update).mockResolvedValueOnce({
+        ...currentSurvey,
+        name: "Renamed",
+        hiddenFields: { enabled: true, fieldIds: ["utm_source"] },
+      } as never);
+
+      await patchV3Survey(currentSurvey, { name: "Renamed" }, "req_qa", "org_1");
+
+      expect(prisma.surveyEmbeddedData.deleteMany).not.toHaveBeenCalled();
+      expect(prisma.embeddedData.create).not.toHaveBeenCalled();
+    });
   });
 
   test("patches metadata and hidden fields through v3 persistence", async () => {
@@ -744,6 +851,18 @@ describe("patchV3Survey", () => {
       const tx = {
         survey: { update: vi.fn(vi.mocked(prisma.survey.update).getMockImplementation()) },
         segment: { update: vi.fn() },
+        // ENG-1837: the EmbeddedData reconcile is part of the same transaction, so it has to be
+        // reachable on the tx client — and the assertions below prove it used that client.
+        surveyEmbeddedData: {
+          findMany: vi.fn().mockResolvedValue([]),
+          deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+          create: vi.fn().mockResolvedValue({}),
+        },
+        embeddedData: {
+          create: vi.fn().mockResolvedValue({ id: "ed_1" }),
+          deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+          updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+        },
       };
       vi.mocked(prisma.$transaction).mockImplementationOnce(((
         callback: (client: typeof tx) => Promise<unknown>
@@ -765,6 +884,9 @@ describe("patchV3Survey", () => {
       );
       expect(tx.survey.update).toHaveBeenCalled();
       expect(prisma.survey.update).not.toHaveBeenCalled();
+      // The Embedded Data reconcile rides the same transaction — never the global client.
+      expect(tx.surveyEmbeddedData.findMany).toHaveBeenCalled();
+      expect(prisma.surveyEmbeddedData.findMany).not.toHaveBeenCalled();
     });
 
     test("rejects a targeting change when the app survey has no segment", async () => {

--- a/apps/web/app/api/v3/surveys/patch.ts
+++ b/apps/web/app/api/v3/surveys/patch.ts
@@ -1,9 +1,11 @@
 import "server-only";
 import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
+import { toDesiredEmbeddedFields } from "@formbricks/types/embedded-data-mapping";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import type { TSurvey } from "@formbricks/types/surveys/types";
 import { getActionClasses } from "@/lib/actionClass/service";
+import { reconcileEmbeddedData } from "@/lib/embedded-data/reconcile";
 import { selectSurvey } from "@/lib/survey/service";
 import {
   APP_SURVEY_TRIGGER_REQUIRED_MESSAGE,
@@ -222,15 +224,43 @@ export async function executeV3SurveyPatch(params: {
     client.survey.update({ where: { id: currentSurvey.id }, data, select: selectSurvey });
 
   try {
-    // Segment filters live on a separate row; when they change, write them in the SAME transaction as
-    // the survey update so the two can't diverge on a mid-write failure. Patches that don't touch
-    // targeting stay a single statement (no transaction overhead).
-    const persistedSurvey = segmentFilterWrite
-      ? await prisma.$transaction(async (tx) => {
+    // One transaction, always. Two writes have to land with the survey or not at all:
+    //
+    // - Segment filters live on a separate row, so a mid-write failure would leave targeting out of
+    //   step with the survey it belongs to.
+    // - ENG-1837 made the EmbeddedData tables the read source of truth for definitions, so a patch
+    //   that moves `variables` / `hiddenFields` without reconciling the rows leaves recall, the logic
+    //   engine, export columns and the response filters reading the pre-patch set. This used to be a
+    //   dormant inconsistency (readers used the legacy columns this write does update); it stops
+    //   being dormant the moment the readers point at the rows.
+    //
+    // The reconcile therefore runs here rather than after the commit — matching `updateSurveyInternal`
+    // — which is what makes the unconditional transaction necessary: a same-statement fast path can
+    // no longer be correct.
+    const persistedSurvey = await prisma.$transaction(
+      async (tx) => {
+        if (segmentFilterWrite) {
           await setV3SurveySegmentFilters(segmentFilterWrite.segmentId, segmentFilterWrite.filters, tx);
-          return runSurveyUpdate(tx);
-        })
-      : await runSurveyUpdate();
+        }
+
+        const survey = await runSurveyUpdate(tx);
+
+        // Derived from the PERSISTED survey, not the patch document: a patch may omit `variables` or
+        // `hiddenFields` entirely, and reading the payload would see them as absent and delete every
+        // row. `workspaceId` comes from the stored survey, never the client (ENG-1749).
+        await reconcileEmbeddedData(tx, {
+          surveyId: currentSurvey.id,
+          workspaceId: currentSurvey.workspaceId,
+          desired: toDesiredEmbeddedFields(survey),
+        });
+
+        return survey;
+      },
+      // Matched to the other reconcile call sites: this transaction rewrites blocks and languages,
+      // reads back through `selectSurvey`'s deep select, and now adds an indexed read plus a write
+      // per changed field — enough to approach Prisma's 5s default on a large survey.
+      { timeout: 20_000, maxWait: 10_000 }
+    );
 
     return await reconcilePersistedV3SurveyPatch({
       survey: transformPrismaSurvey<TSurvey>(persistedSurvey),

--- a/apps/web/app/api/v3/surveys/patch.ts
+++ b/apps/web/app/api/v3/surveys/patch.ts
@@ -220,7 +220,7 @@ export async function executeV3SurveyPatch(params: {
       ? await buildV3AppSurveyPatchWrites({ currentSurvey, document, data })
       : null;
 
-  const runSurveyUpdate = (client: Prisma.TransactionClient = prisma) =>
+  const runSurveyUpdate = (client: Prisma.TransactionClient) =>
     client.survey.update({ where: { id: currentSurvey.id }, data, select: selectSurvey });
 
   try {
@@ -248,6 +248,13 @@ export async function executeV3SurveyPatch(params: {
         // Derived from the PERSISTED survey, not the patch document: a patch may omit `variables` or
         // `hiddenFields` entirely, and reading the payload would see them as absent and delete every
         // row. `workspaceId` comes from the stored survey, never the client (ENG-1749).
+        //
+        // NOTE for whoever moves the v3 serializer onto the tables (ENG-1853): `survey` was read
+        // BEFORE this reconcile, so the `embeddedDataLinks` it carries — and the `embeddedFields`
+        // inlined from them below — describe the PRE-patch rows. Inert today, because
+        // `serializeV3SurveyResource` and the audit log read the legacy columns and nothing else
+        // consumes them (`updateSurveyInternal` has the same shape). The moment the serializer reads
+        // the rows, this returns a stale PATCH/MCP response and needs a re-read after the reconcile.
         await reconcileEmbeddedData(tx, {
           surveyId: currentSurvey.id,
           workspaceId: currentSurvey.workspaceId,

--- a/apps/web/app/lib/api/survey-transformation.ts
+++ b/apps/web/app/lib/api/survey-transformation.ts
@@ -532,6 +532,21 @@ export const withDerivedQuestions = <
   };
 };
 
+/**
+ * Drops read-only projections the v1 survey contract does not describe.
+ *
+ * `embeddedFields` (ENG-1837) is joined onto every survey the management endpoints read, but v1 is a
+ * versioned public contract and how Embedded Data is serialised is ENG-1838's call — so it does not
+ * leak out ahead of that decision. Write paths are unaffected: the key is omitted from both create
+ * schemas and stripped again in `updateSurveyInternal`.
+ */
+export const withoutInternalSurveyProjections = <T extends { embeddedFields?: unknown }>(
+  survey: T
+): Omit<T, "embeddedFields"> => {
+  const { embeddedFields: _embeddedFields, ...rest } = survey;
+  return rest;
+};
+
 export const validateSurveyInput = (input: {
   questions?: TSurveyQuestion[];
   blocks?: TSurveyBlock[];

--- a/apps/web/integration/embedded-data-read.integration.test.ts
+++ b/apps/web/integration/embedded-data-read.integration.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import { toDesiredEmbeddedFields } from "@formbricks/types/embedded-data-mapping";
+import { deriveLegacyEmbeddedData, getSurveyEmbeddedFields } from "@formbricks/types/embedded-data-resolver";
+import { type TSurvey } from "@formbricks/types/surveys/types";
+import { resetDb } from "@/integration/reset-db";
+import { reconcileEmbeddedData } from "@/lib/embedded-data/reconcile";
+import { selectSurvey } from "@/lib/survey/service";
+import { transformPrismaSurvey } from "@/lib/survey/utils";
+
+/**
+ * The Embedded Data read seam against real Postgres (ENG-1837).
+ *
+ * What only a real database can show: that the join in `selectSurvey` actually returns the rows the
+ * write bridge wrote, that the inlined list comes back in the order the export headers and pickers
+ * depend on, and that a survey whose rows are missing still resolves off its legacy columns. The unit
+ * suite mocks `@formbricks/database`, so the join itself is invisible there.
+ */
+
+const LEGACY = {
+  variables: [
+    { id: "clx000000000000000000002", name: "tier", type: "text" as const, value: "free" },
+    { id: "clx000000000000000000001", name: "score", type: "number" as const, value: 7 },
+  ],
+  hiddenFields: { enabled: true, fieldIds: ["utm_source", "plan"] },
+};
+
+const seedSurvey = async (): Promise<{ surveyId: string; workspaceId: string }> => {
+  const organization = await prisma.organization.create({ data: { name: "Read Org" } });
+  const workspace = await prisma.workspace.create({
+    data: { name: "Read Workspace", organizationId: organization.id },
+  });
+  const survey = await prisma.survey.create({
+    data: {
+      name: "Survey",
+      workspaceId: workspace.id,
+      variables: LEGACY.variables,
+      hiddenFields: LEGACY.hiddenFields,
+    },
+  });
+
+  await prisma.$transaction((tx) =>
+    reconcileEmbeddedData(tx, {
+      surveyId: survey.id,
+      workspaceId: workspace.id,
+      desired: toDesiredEmbeddedFields(LEGACY),
+    })
+  );
+
+  return { surveyId: survey.id, workspaceId: workspace.id };
+};
+
+/** The read path a survey page takes: the join in `selectSurvey`, inlined by `transformPrismaSurvey`. */
+const loadSurvey = async (surveyId: string): Promise<TSurvey> => {
+  const surveyPrisma = await prisma.survey.findUniqueOrThrow({
+    where: { id: surveyId },
+    select: selectSurvey,
+  });
+  return transformPrismaSurvey<TSurvey>(surveyPrisma);
+};
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("Embedded Data read seam (real Postgres)", () => {
+  test("a loaded survey carries the rows the write bridge wrote", async () => {
+    const { surveyId } = await seedSurvey();
+
+    const survey = await loadSurvey(surveyId);
+
+    expect(survey.embeddedFields).toEqual(deriveLegacyEmbeddedData(LEGACY));
+    expect(getSurveyEmbeddedFields(survey)).toEqual(deriveLegacyEmbeddedData(LEGACY));
+  });
+
+  test("the raw relation never leaks onto the survey object", async () => {
+    const { surveyId } = await seedSurvey();
+
+    expect(await loadSurvey(surveyId)).not.toHaveProperty("embeddedDataLinks");
+  });
+
+  test("the inlined order is the declared order, not the database's", async () => {
+    const { surveyId } = await seedSurvey();
+
+    const survey = await loadSurvey(surveyId);
+
+    // Declared order is variables-then-hidden-fields, and `tier` is declared before `score` even
+    // though `clx…001` sorts before `clx…002`. This is CSV/XLSX header order and picker order.
+    expect(survey.embeddedFields?.map(({ link }) => link.storageKey)).toEqual([
+      "clx000000000000000000002",
+      "clx000000000000000000001",
+      "utm_source",
+      "plan",
+    ]);
+  });
+
+  test("a survey that missed the backfill still resolves off its legacy columns", async () => {
+    const { surveyId } = await seedSurvey();
+    await prisma.surveyEmbeddedData.deleteMany({ where: { surveyId } });
+
+    const survey = await loadSurvey(surveyId);
+
+    expect(survey.embeddedFields).toEqual([]);
+    expect(getSurveyEmbeddedFields(survey)).toEqual(deriveLegacyEmbeddedData(LEGACY));
+  });
+
+  test("a partial row set wins outright — the rows are the source of truth once any exist", async () => {
+    // Not reachable today: `reconcileEmbeddedData` writes the whole derived set in one plan. Asserted
+    // so the fallback's "empty list only" rule is a decision on record rather than an accident.
+    const { surveyId } = await seedSurvey();
+    await prisma.surveyEmbeddedData.deleteMany({ where: { surveyId, storageKey: { in: ["plan"] } } });
+
+    const survey = await loadSurvey(surveyId);
+
+    expect(getSurveyEmbeddedFields(survey).map(({ link }) => link.storageKey)).toEqual([
+      "clx000000000000000000002",
+      "clx000000000000000000001",
+      "utm_source",
+    ]);
+  });
+
+  test("reading a survey writes nothing to the Embedded Data tables", async () => {
+    const { surveyId } = await seedSurvey();
+    const before = await prisma.surveyEmbeddedData.findMany({ where: { surveyId } });
+
+    await loadSurvey(surveyId);
+
+    expect(await prisma.surveyEmbeddedData.findMany({ where: { surveyId } })).toEqual(before);
+  });
+});

--- a/apps/web/integration/embedded-data-read.integration.test.ts
+++ b/apps/web/integration/embedded-data-read.integration.test.ts
@@ -119,6 +119,68 @@ describe("Embedded Data read seam (real Postgres)", () => {
     ]);
   });
 
+  /**
+   * `variables` and `hiddenFields` are unvalidated `Json` columns, so a row can hold an object where
+   * an array belongs. `toDesiredEmbeddedFields` maps both with `?? []`, which does not catch a wrong
+   * type — so before the read-boundary guards this threw `(variables ?? []).map is not a function`
+   * inside `transformPrismaSurvey` and failed the whole survey read.
+   *
+   * The malformation is written with raw SQL on purpose: Prisma's generated types make the bad shape
+   * unrepresentable through the client, so a fixture built in TypeScript would only resemble the row
+   * this is defending against. These write the actual bytes.
+   */
+  describe("a survey whose legacy JSON is malformed", () => {
+    test("still loads when `variables` holds an object instead of an array", async () => {
+      const { surveyId } = await seedSurvey();
+      await prisma.$executeRaw`UPDATE "Survey" SET variables = '{}'::jsonb WHERE id = ${surveyId}`;
+
+      const survey = await loadSurvey(surveyId);
+
+      // The hidden fields — the well-formed group — keep their declared order; only the malformed
+      // group loses its ranking and sorts last, in the select's storageKey order.
+      expect(getSurveyEmbeddedFields(survey).map(({ link }) => link.storageKey)).toEqual([
+        "utm_source",
+        "plan",
+        "clx000000000000000000001",
+        "clx000000000000000000002",
+      ]);
+    });
+
+    test("still loads when `hiddenFields.fieldIds` holds a string instead of an array", async () => {
+      const { surveyId } = await seedSurvey();
+      await prisma.$executeRaw`
+        UPDATE "Survey" SET "hiddenFields" = '{"enabled": true, "fieldIds": "utm_source"}'::jsonb
+        WHERE id = ${surveyId}`;
+
+      const survey = await loadSurvey(surveyId);
+
+      expect(getSurveyEmbeddedFields(survey).map(({ link }) => link.storageKey)).toEqual([
+        "clx000000000000000000002",
+        "clx000000000000000000001",
+        "plan",
+        "utm_source",
+      ]);
+    });
+
+    test("still loads when both columns are malformed", async () => {
+      const { surveyId } = await seedSurvey();
+      await prisma.$executeRaw`
+        UPDATE "Survey" SET variables = '"not-an-array"'::jsonb, "hiddenFields" = '[]'::jsonb
+        WHERE id = ${surveyId}`;
+
+      const survey = await loadSurvey(surveyId);
+
+      // Nothing ranks, so every row falls back to the select's storageKey order — and crucially the
+      // definitions are all still there.
+      expect(getSurveyEmbeddedFields(survey).map(({ link }) => link.storageKey)).toEqual([
+        "clx000000000000000000001",
+        "clx000000000000000000002",
+        "plan",
+        "utm_source",
+      ]);
+    });
+  });
+
   test("reading a survey writes nothing to the Embedded Data tables", async () => {
     const { surveyId } = await seedSurvey();
     const before = await prisma.surveyEmbeddedData.findMany({ where: { surveyId } });

--- a/apps/web/integration/embedded-data-v3-patch.integration.test.ts
+++ b/apps/web/integration/embedded-data-v3-patch.integration.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { prisma } from "@formbricks/database";
+import { toDesiredEmbeddedFields } from "@formbricks/types/embedded-data-mapping";
+import { type TSurvey } from "@formbricks/types/surveys/types";
+import { patchV3Survey } from "@/app/api/v3/surveys/patch";
+import { resetDb } from "@/integration/reset-db";
+import { reconcileEmbeddedData } from "@/lib/embedded-data/reconcile";
+import { selectSurvey } from "@/lib/survey/service";
+import { transformPrismaSurvey } from "@/lib/survey/utils";
+
+/**
+ * The v3 PATCH write path against real Postgres (ENG-1837).
+ *
+ * `PATCH /api/v3/surveys/{surveyId}` and MCP `patch_survey` write `variables` / `hiddenFields`
+ * straight through `survey.update`. Once readers resolve definitions through the EmbeddedData tables,
+ * a patch that does not reconcile leaves the rows describing the pre-patch survey — a variable added
+ * over the API would be invisible to the logic engine, the export columns and the response filters,
+ * and a deleted one would keep its column. The unit suite mocks `@formbricks/database`, so only a
+ * real database shows that the rows actually end up agreeing with the columns.
+ */
+
+const BLOCKS = [
+  {
+    id: "clbk1234567890123456789012",
+    name: "Main Block",
+    elements: [
+      {
+        id: "satisfaction",
+        type: "openText",
+        headline: { default: "What should we improve?" },
+        required: true,
+        inputType: "text",
+        charLimit: { enabled: false },
+      },
+    ],
+  },
+];
+
+const seedSurvey = async (legacy?: {
+  variables?: unknown[];
+  hiddenFields?: { enabled: boolean; fieldIds?: string[] };
+}): Promise<TSurvey> => {
+  const organization = await prisma.organization.create({ data: { name: "V3 Patch Org" } });
+  const workspace = await prisma.workspace.create({
+    data: { name: "V3 Patch Workspace", organizationId: organization.id },
+  });
+  const survey = await prisma.survey.create({
+    data: {
+      name: "Product Feedback",
+      type: "link",
+      status: "draft",
+      workspaceId: workspace.id,
+      blocks: BLOCKS,
+      variables: (legacy?.variables ?? []) as never,
+      hiddenFields: (legacy?.hiddenFields ?? { enabled: false }) as never,
+    },
+    select: selectSurvey,
+  });
+
+  // Mirror the state every stored survey is in: rows reconciled from the columns it was saved with.
+  await prisma.$transaction((tx) =>
+    reconcileEmbeddedData(tx, {
+      surveyId: survey.id,
+      workspaceId: workspace.id,
+      desired: toDesiredEmbeddedFields(survey),
+    })
+  );
+
+  return transformPrismaSurvey<TSurvey>(survey);
+};
+
+/** The survey's rows, in the shape `toDesiredEmbeddedFields` produces, so the two can be compared. */
+const readRows = async (surveyId: string) =>
+  prisma.surveyEmbeddedData
+    .findMany({
+      where: { surveyId },
+      select: {
+        storageKey: true,
+        embeddedData: { select: { name: true, source: true, dataType: true, defaultValue: true } },
+      },
+    })
+    .then((links) =>
+      links
+        .map(({ storageKey, embeddedData }) => ({ storageKey, ...embeddedData }))
+        .sort((a, b) => a.storageKey.localeCompare(b.storageKey))
+    );
+
+/** What the rows SHOULD be, read back from the columns the patch persisted. */
+const expectedRowsFromColumns = async (surveyId: string) => {
+  const survey = await prisma.survey.findUniqueOrThrow({
+    where: { id: surveyId },
+    select: { variables: true, hiddenFields: true },
+  });
+
+  return toDesiredEmbeddedFields(survey).sort((a, b) => a.storageKey.localeCompare(b.storageKey));
+};
+
+const expectRowsAgreeWithColumns = async (surveyId: string) => {
+  expect(await readRows(surveyId)).toEqual(await expectedRowsFromColumns(surveyId));
+};
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("v3 survey patch keeps the Embedded Data rows in step (real Postgres)", () => {
+  test("a patch that adds a variable writes its row and link", async () => {
+    const survey = await seedSurvey();
+
+    await patchV3Survey(
+      survey,
+      { variables: [{ id: "clvar123456789012345678901", name: "score", type: "number", value: 7 }] },
+      "req_v3_patch_add_variable"
+    );
+
+    expect(await readRows(survey.id)).toEqual([
+      {
+        storageKey: "clvar123456789012345678901",
+        name: "score",
+        source: "computed",
+        dataType: "number",
+        defaultValue: 7,
+      },
+    ]);
+    await expectRowsAgreeWithColumns(survey.id);
+  });
+
+  test("a patch that adds a hidden field writes its row and link", async () => {
+    const survey = await seedSurvey();
+
+    await patchV3Survey(
+      survey,
+      { hiddenFields: { enabled: true, fieldIds: ["utm_source"] } },
+      "req_v3_patch_add_hidden_field"
+    );
+
+    expect(await readRows(survey.id)).toEqual([
+      {
+        storageKey: "utm_source",
+        name: "utm_source",
+        source: "ingested",
+        dataType: "string",
+        defaultValue: null,
+      },
+    ]);
+    await expectRowsAgreeWithColumns(survey.id);
+  });
+
+  test("a patch that renames a variable updates its row rather than orphaning it", async () => {
+    const survey = await seedSurvey({
+      variables: [{ id: "clvar123456789012345678901", name: "score", type: "number", value: 7 }],
+    });
+
+    await patchV3Survey(
+      survey,
+      { variables: [{ id: "clvar123456789012345678901", name: "renamed_score", type: "number", value: 9 }] },
+      "req_v3_patch_rename_variable"
+    );
+
+    expect(await readRows(survey.id)).toEqual([
+      {
+        storageKey: "clvar123456789012345678901",
+        name: "renamed_score",
+        source: "computed",
+        dataType: "number",
+        defaultValue: 9,
+      },
+    ]);
+    await expectRowsAgreeWithColumns(survey.id);
+  });
+
+  test("a patch that removes a field drops its row, so it stops appearing as a column", async () => {
+    const survey = await seedSurvey({
+      variables: [{ id: "clvar123456789012345678901", name: "score", type: "number", value: 7 }],
+      hiddenFields: { enabled: true, fieldIds: ["utm_source", "plan"] },
+    });
+
+    await patchV3Survey(
+      survey,
+      { hiddenFields: { enabled: true, fieldIds: ["plan"] } },
+      "req_v3_patch_remove_hidden_field"
+    );
+
+    expect((await readRows(survey.id)).map(({ storageKey }) => storageKey)).toEqual([
+      "clvar123456789012345678901",
+      "plan",
+    ]);
+    await expectRowsAgreeWithColumns(survey.id);
+  });
+
+  test("a patch that touches neither key leaves the rows alone", async () => {
+    // The patch document carries no `variables` / `hiddenFields`, so the reconcile has to read the
+    // persisted survey — reading the payload would see them as absent and unlink every field.
+    const survey = await seedSurvey({
+      variables: [{ id: "clvar123456789012345678901", name: "score", type: "number", value: 7 }],
+      hiddenFields: { enabled: true, fieldIds: ["utm_source"] },
+    });
+    const before = await readRows(survey.id);
+
+    await patchV3Survey(survey, { name: "Renamed survey" }, "req_v3_patch_name_only");
+
+    expect(await readRows(survey.id)).toEqual(before);
+    await expectRowsAgreeWithColumns(survey.id);
+  });
+
+  test("writes nothing to Response", async () => {
+    const survey = await seedSurvey({
+      hiddenFields: { enabled: true, fieldIds: ["utm_source"] },
+    });
+
+    await patchV3Survey(
+      survey,
+      { hiddenFields: { enabled: true, fieldIds: ["renamed_source"] } },
+      "req_v3_patch_no_response_write"
+    );
+
+    expect(await prisma.response.count({ where: { surveyId: survey.id } })).toBe(0);
+  });
+});

--- a/apps/web/integration/embedded-data-v3-patch.integration.test.ts
+++ b/apps/web/integration/embedded-data-v3-patch.integration.test.ts
@@ -19,6 +19,9 @@ import { transformPrismaSurvey } from "@/lib/survey/utils";
  * real database shows that the rows actually end up agreeing with the columns.
  */
 
+/** A variable's storage key is its cuid, so a rename moves the name but never the address. */
+const VARIABLE_ID = "clvar123456789012345678901";
+
 const BLOCKS = [
   {
     id: "clbk1234567890123456789012",
@@ -109,13 +112,13 @@ describe("v3 survey patch keeps the Embedded Data rows in step (real Postgres)",
 
     await patchV3Survey(
       survey,
-      { variables: [{ id: "clvar123456789012345678901", name: "score", type: "number", value: 7 }] },
+      { variables: [{ id: VARIABLE_ID, name: "score", type: "number", value: 7 }] },
       "req_v3_patch_add_variable"
     );
 
     expect(await readRows(survey.id)).toEqual([
       {
-        storageKey: "clvar123456789012345678901",
+        storageKey: VARIABLE_ID,
         name: "score",
         source: "computed",
         dataType: "number",
@@ -148,18 +151,18 @@ describe("v3 survey patch keeps the Embedded Data rows in step (real Postgres)",
 
   test("a patch that renames a variable updates its row rather than orphaning it", async () => {
     const survey = await seedSurvey({
-      variables: [{ id: "clvar123456789012345678901", name: "score", type: "number", value: 7 }],
+      variables: [{ id: VARIABLE_ID, name: "score", type: "number", value: 7 }],
     });
 
     await patchV3Survey(
       survey,
-      { variables: [{ id: "clvar123456789012345678901", name: "renamed_score", type: "number", value: 9 }] },
+      { variables: [{ id: VARIABLE_ID, name: "renamed_score", type: "number", value: 9 }] },
       "req_v3_patch_rename_variable"
     );
 
     expect(await readRows(survey.id)).toEqual([
       {
-        storageKey: "clvar123456789012345678901",
+        storageKey: VARIABLE_ID,
         name: "renamed_score",
         source: "computed",
         dataType: "number",
@@ -171,7 +174,7 @@ describe("v3 survey patch keeps the Embedded Data rows in step (real Postgres)",
 
   test("a patch that removes a field drops its row, so it stops appearing as a column", async () => {
     const survey = await seedSurvey({
-      variables: [{ id: "clvar123456789012345678901", name: "score", type: "number", value: 7 }],
+      variables: [{ id: VARIABLE_ID, name: "score", type: "number", value: 7 }],
       hiddenFields: { enabled: true, fieldIds: ["utm_source", "plan"] },
     });
 
@@ -181,10 +184,7 @@ describe("v3 survey patch keeps the Embedded Data rows in step (real Postgres)",
       "req_v3_patch_remove_hidden_field"
     );
 
-    expect((await readRows(survey.id)).map(({ storageKey }) => storageKey)).toEqual([
-      "clvar123456789012345678901",
-      "plan",
-    ]);
+    expect((await readRows(survey.id)).map(({ storageKey }) => storageKey)).toEqual([VARIABLE_ID, "plan"]);
     await expectRowsAgreeWithColumns(survey.id);
   });
 
@@ -192,7 +192,7 @@ describe("v3 survey patch keeps the Embedded Data rows in step (real Postgres)",
     // The patch document carries no `variables` / `hiddenFields`, so the reconcile has to read the
     // persisted survey — reading the payload would see them as absent and unlink every field.
     const survey = await seedSurvey({
-      variables: [{ id: "clvar123456789012345678901", name: "score", type: "number", value: 7 }],
+      variables: [{ id: VARIABLE_ID, name: "score", type: "number", value: 7 }],
       hiddenFields: { enabled: true, fieldIds: ["utm_source"] },
     });
     const before = await readRows(survey.id);
@@ -203,17 +203,56 @@ describe("v3 survey patch keeps the Embedded Data rows in step (real Postgres)",
     await expectRowsAgreeWithColumns(survey.id);
   });
 
-  test("writes nothing to Response", async () => {
+  test("renaming both kinds of field leaves stored responses byte-identical (AC #4)", async () => {
+    // The realistic violation is not a Response being created — it is a reconcile that "helpfully"
+    // migrates stored answers when a field's address changes. So the response has to actually HOLD
+    // the keys being renamed, in both maps, or a mutation would have nothing to corrupt.
     const survey = await seedSurvey({
+      variables: [{ id: VARIABLE_ID, name: "score", type: "number", value: 7 }],
       hiddenFields: { enabled: true, fieldIds: ["utm_source"] },
+    });
+
+    const storedData = { utm_source: "google", satisfaction: "great" };
+    const storedVariables = { [VARIABLE_ID]: 42 };
+    const response = await prisma.response.create({
+      data: {
+        surveyId: survey.id,
+        finished: true,
+        data: storedData as never,
+        variables: storedVariables as never,
+      },
+      select: { id: true, updatedAt: true },
     });
 
     await patchV3Survey(
       survey,
-      { hiddenFields: { enabled: true, fieldIds: ["renamed_source"] } },
+      {
+        // Both addresses move: the hidden field's storage key IS its name, and the variable keeps its
+        // cuid while its name changes — the two shapes a migration would treat differently.
+        hiddenFields: { enabled: true, fieldIds: ["renamed_source"] },
+        variables: [{ id: VARIABLE_ID, name: "renamed_score", type: "number", value: 7 }],
+      },
       "req_v3_patch_no_response_write"
     );
 
-    expect(await prisma.response.count({ where: { surveyId: survey.id } })).toBe(0);
+    // The definitions moved...
+    expect((await readRows(survey.id)).map(({ storageKey, name }) => `${storageKey}:${name}`)).toEqual([
+      `${VARIABLE_ID}:renamed_score`,
+      "renamed_source:renamed_source",
+    ]);
+
+    // ...and the response did not. Both maps compared whole, so a re-keyed, added or dropped entry
+    // fails — not just a changed value.
+    const stored = await prisma.response.findUniqueOrThrow({
+      where: { id: response.id },
+      select: { data: true, variables: true, updatedAt: true },
+    });
+    expect(stored.data).toEqual(storedData);
+    expect(stored.variables).toEqual(storedVariables);
+    // A rewrite that happened to produce the same JSON would still bump `updatedAt` (@updatedAt).
+    expect(stored.updatedAt).toEqual(response.updatedAt);
+
+    // And nothing was inserted or deleted either.
+    expect(await prisma.response.count({ where: { surveyId: survey.id } })).toBe(1);
   });
 });

--- a/apps/web/lib/embedded-data/survey-fields.test.ts
+++ b/apps/web/lib/embedded-data/survey-fields.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, test } from "vitest";
+import { type TLinkedEmbeddedField } from "@formbricks/types/embedded-data-resolver";
+import { isDeepEqual } from "@/lib/utils/object";
+import { inlineSurveyEmbeddedFields, withInlinedEmbeddedFields } from "./survey-fields";
+
+const link = (storageKey: string, name: string, source: "computed" | "ingested") => ({
+  storageKey,
+  embeddedData: {
+    name,
+    source,
+    dataType: "string" as const,
+    defaultValue: null,
+    locked: false,
+  },
+});
+
+const LEGACY = {
+  variables: [
+    { id: "clx000000000000000000002", name: "tier", type: "text" as const, value: "free" },
+    { id: "clx000000000000000000001", name: "score", type: "number" as const, value: 7 },
+  ],
+  hiddenFields: { enabled: true, fieldIds: ["utm_source", "plan"] },
+};
+
+/** The join's own output order: `orderBy: { storageKey: "asc" }`. */
+const JOINED_LINKS = [
+  link("clx000000000000000000001", "score", "computed"),
+  link("clx000000000000000000002", "tier", "computed"),
+  link("plan", "plan", "ingested"),
+  link("utm_source", "utm_source", "ingested"),
+];
+
+describe("inlineSurveyEmbeddedFields", () => {
+  test("returns undefined when the select omitted the join, so the accessor can fall back", () => {
+    expect(inlineSurveyEmbeddedFields({ ...LEGACY })).toBeUndefined();
+  });
+
+  test("reshapes the rows into {field, link} pairs", () => {
+    const fields = inlineSurveyEmbeddedFields({ ...LEGACY, embeddedDataLinks: JOINED_LINKS });
+
+    expect(fields?.[0]).toStrictEqual({
+      field: { name: "tier", source: "computed", dataType: "string", defaultValue: null, locked: false },
+      link: { storageKey: "clx000000000000000000002" },
+    });
+  });
+
+  test("orders by the legacy declaration, not by storage key", () => {
+    // `tier` is declared before `score` even though its cuid sorts after. This is CSV/XLSX header
+    // order and picker order, so the join's `storageKey asc` is only the tie-break.
+    expect(
+      inlineSurveyEmbeddedFields({ ...LEGACY, embeddedDataLinks: JOINED_LINKS })?.map(
+        ({ link: { storageKey } }) => storageKey
+      )
+    ).toStrictEqual(["clx000000000000000000002", "clx000000000000000000001", "utm_source", "plan"]);
+  });
+
+  test("keeps a row the legacy columns do not know, sorted last", () => {
+    const fields = inlineSurveyEmbeddedFields({
+      ...LEGACY,
+      embeddedDataLinks: [...JOINED_LINKS, link("orphan", "orphan", "ingested")],
+    });
+
+    expect(fields?.map(({ link: { storageKey } }) => storageKey).at(-1)).toBe("orphan");
+    expect(fields).toHaveLength(5);
+  });
+
+  test("a survey with no declarations and no rows inlines an empty list", () => {
+    expect(
+      inlineSurveyEmbeddedFields({
+        variables: [],
+        hiddenFields: { enabled: false, fieldIds: [] },
+        embeddedDataLinks: [],
+      })
+    ).toStrictEqual([]);
+  });
+});
+
+describe("withInlinedEmbeddedFields", () => {
+  test("swaps the raw relation for the inlined pairs", () => {
+    const survey = { id: "s1", ...LEGACY, embeddedDataLinks: JOINED_LINKS };
+    const transformed = withInlinedEmbeddedFields(survey);
+
+    expect(transformed).not.toHaveProperty("embeddedDataLinks");
+    expect(transformed).toHaveProperty("embeddedFields");
+  });
+
+  test("leaves a survey read without the join untouched, adding no key", () => {
+    const survey = { id: "s1", ...LEGACY };
+
+    expect(withInlinedEmbeddedFields(survey)).toStrictEqual(survey);
+    expect(withInlinedEmbeddedFields(survey)).not.toHaveProperty("embeddedFields");
+  });
+
+  test("adds the key even when the survey has no fields at all", () => {
+    // Load-bearing for the editor invariant below: once a select carries the join, EVERY survey read
+    // through it has an `embeddedFields` key, empty list included.
+    const transformed = withInlinedEmbeddedFields({
+      id: "s1",
+      variables: [],
+      hiddenFields: { enabled: false, fieldIds: [] },
+      embeddedDataLinks: [],
+    });
+
+    expect(transformed).toHaveProperty("embeddedFields", []);
+  });
+});
+
+/**
+ * The survey editor clones the server survey into its working copy and the menu bar compares the two
+ * with {@link isDeepEqual} to gate the draft auto-save, the discard-changes dialog and the
+ * beforeunload prompt. That comparison short-circuits on differing key counts, so the working copy
+ * must stay structurally identical to what the server sent — which is why ENG-1837 does NOT strip the
+ * inlined `embeddedFields` there and gives editor surfaces `getDeclaredEmbeddedFields` instead.
+ *
+ * These cases fail if anyone reintroduces a key-shape mutation on the editor's clone: an untouched
+ * editor would then report unsaved changes forever and re-save an open draft every 10 seconds.
+ */
+describe("the editor's clone stays comparable to the server survey", () => {
+  const surveyWithRows = withInlinedEmbeddedFields({
+    id: "s1",
+    updatedAt: new Date("2026-08-13T10:00:00.000Z"),
+    ...LEGACY,
+    embeddedDataLinks: JOINED_LINKS,
+  });
+
+  const surveyWithoutFields = withInlinedEmbeddedFields({
+    id: "s1",
+    updatedAt: new Date("2026-08-13T10:00:00.000Z"),
+    variables: [],
+    hiddenFields: { enabled: false, fieldIds: [] },
+    embeddedDataLinks: [],
+  });
+
+  test.each([
+    ["with rows", surveyWithRows],
+    ["with no fields at all", surveyWithoutFields],
+  ])("an untouched clone deep-equals the server survey (%s)", (_label, survey) => {
+    const localSurvey = structuredClone(survey);
+
+    // beforeunload compares the whole objects; back-navigation and auto-save strip `updatedAt` first.
+    expect(isDeepEqual(localSurvey, survey)).toBe(true);
+
+    const { updatedAt: _localUpdatedAt, ...localSurveyRest } = localSurvey;
+    const { updatedAt: _surveyUpdatedAt, ...surveyRest } = survey;
+    expect(isDeepEqual(localSurveyRest, surveyRest)).toBe(true);
+  });
+
+  test.each([
+    ["with rows", surveyWithRows],
+    ["with no fields at all", surveyWithoutFields],
+  ])("dropping embeddedFields from the clone would break that comparison (%s)", (_label, survey) => {
+    const { embeddedFields: _embeddedFields, ...strippedClone } = structuredClone(survey);
+
+    expect(isDeepEqual(strippedClone, survey)).toBe(false);
+  });
+});

--- a/apps/web/lib/embedded-data/survey-fields.ts
+++ b/apps/web/lib/embedded-data/survey-fields.ts
@@ -2,6 +2,7 @@ import "server-only";
 import { Prisma } from "@formbricks/database/prisma";
 import { toDesiredEmbeddedFields } from "@formbricks/types/embedded-data-mapping";
 import { type TLinkedEmbeddedField } from "@formbricks/types/embedded-data-resolver";
+import { type TSurveyVariable } from "@formbricks/types/surveys/types";
 
 /**
  * The join that makes the `EmbeddedData` / `SurveyEmbeddedData` tables the read source of truth
@@ -38,6 +39,48 @@ interface TSurveyWithEmbeddedDataLinks {
 }
 
 /**
+ * `variables` and `hiddenFields` are `Json` columns. Prisma types them from the schema annotation,
+ * but nothing enforces that shape in the database, so a row can hold an object where an array
+ * belongs. `toDesiredEmbeddedFields` maps both with `?? []`, which catches `null` and `undefined`
+ * but not a wrong type — one malformed row would throw `(variables ?? []).map is not a function`
+ * inside `transformPrismaSurvey` and fail the **entire survey read**, not just its ordering.
+ *
+ * Guarded here rather than inside `toDesiredEmbeddedFields`, because that mapper is shared with
+ * `reconcileEmbeddedData` on the WRITE path, where throwing is the correct behaviour: silently
+ * mapping a malformed survey to an empty desired set would delete every row it has. Reads must
+ * degrade, writes must fail loudly — so the leniency belongs at this boundary and nowhere else.
+ * (ENG-1835's `planSurveyBackfill` makes the same call from the other side: it checks these shapes
+ * and skips the survey.)
+ *
+ * The two groups are guarded independently on purpose. A survey whose `variables` are malformed
+ * still ranks its hidden fields correctly; only the malformed group loses its declared order and
+ * sorts last. A blanket `try`/`catch` would lose both — and would also swallow a genuine bug inside
+ * the mapper.
+ */
+
+/**
+ * Not "is a valid variable list" — only that mapping over it cannot throw. Entries that are objects
+ * but not variables yield a garbage `storageKey`, which simply matches no row and therefore ranks
+ * nothing; entries that are `null` would throw on the property read, so they disqualify the list.
+ */
+const toRankableVariables = (value: unknown): TSurveyVariable[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === "object" && entry !== null)
+    ? (value as TSurveyVariable[])
+    : [];
+
+/** Non-string ids cannot be storage keys, so they are dropped rather than disqualifying the list. */
+const toRankableFieldIds = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((id): id is string => typeof id === "string") : [];
+
+/** Reads `hiddenFields.fieldIds` without assuming `hiddenFields` is an object at all. */
+const readFieldIds = (hiddenFields: unknown): string[] =>
+  toRankableFieldIds(
+    typeof hiddenFields === "object" && hiddenFields !== null
+      ? (hiddenFields as { fieldIds?: unknown }).fieldIds
+      : undefined
+  );
+
+/**
  * Reshapes the joined rows into the `{ field, link }` pairs the read seam consumes, or `undefined`
  * when the select omitted the join — which is exactly the input `getSurveyEmbeddedFields`' fallback
  * expects, so a survey read through a narrower select keeps resolving off its legacy columns.
@@ -56,12 +99,13 @@ export const inlineSurveyEmbeddedFields = (
   const links = surveyPrisma.embeddedDataLinks;
   if (!links) return undefined;
 
+  // Still routed through `toDesiredEmbeddedFields` rather than reading the ids here: which key a
+  // field is addressed by (a variable's cuid, a hidden field's name) is that function's rule, and
+  // re-deriving it at this boundary is how the ordering would silently drift from the rows.
   const legacyRankByStorageKey = new Map(
     toDesiredEmbeddedFields({
-      variables: surveyPrisma.variables as Parameters<typeof toDesiredEmbeddedFields>[0]["variables"],
-      hiddenFields: surveyPrisma.hiddenFields as Parameters<
-        typeof toDesiredEmbeddedFields
-      >[0]["hiddenFields"],
+      variables: toRankableVariables(surveyPrisma.variables),
+      hiddenFields: { enabled: false, fieldIds: readFieldIds(surveyPrisma.hiddenFields) },
     }).map((field, index) => [field.storageKey, index] as const)
   );
   const rank = (storageKey: string): number =>

--- a/apps/web/lib/embedded-data/survey-fields.ts
+++ b/apps/web/lib/embedded-data/survey-fields.ts
@@ -1,0 +1,87 @@
+import "server-only";
+import { Prisma } from "@formbricks/database/prisma";
+import { toDesiredEmbeddedFields } from "@formbricks/types/embedded-data-mapping";
+import { type TLinkedEmbeddedField } from "@formbricks/types/embedded-data-resolver";
+
+/**
+ * The join that makes the `EmbeddedData` / `SurveyEmbeddedData` tables the read source of truth
+ * (ENG-1837). Add it to a survey select and pass the row through {@link inlineSurveyEmbeddedFields};
+ * every reader then resolves definitions through `getSurveyEmbeddedFields` instead of reading
+ * `survey.variables` / `survey.hiddenFields`.
+ *
+ * Only the columns the read seam consumes are selected — this shape reaches public survey payloads
+ * (the SDK workspace state and the link-survey page), so the row's ids, ownership and timestamps
+ * stay server-side. It mirrors `SELECT_CURRENT_FIELDS` in reconcile.ts minus exactly those.
+ *
+ * `orderBy` is not optional: without it Postgres row order is unspecified, and this list drives
+ * user-visible column and picker order. It is the tie-break, not the ordering rule — see
+ * {@link inlineSurveyEmbeddedFields}.
+ */
+export const selectSurveyEmbeddedDataLinks = {
+  select: {
+    storageKey: true,
+    embeddedData: {
+      select: { name: true, source: true, dataType: true, defaultValue: true, locked: true },
+    },
+  },
+  orderBy: { storageKey: "asc" },
+} as const satisfies Prisma.SurveySelect["embeddedDataLinks"];
+
+/** The shape {@link selectSurveyEmbeddedDataLinks} produces, as much of it as the mapping needs. */
+interface TSurveyWithEmbeddedDataLinks {
+  variables?: unknown;
+  hiddenFields?: unknown;
+  embeddedDataLinks?: {
+    storageKey: string;
+    embeddedData: TLinkedEmbeddedField["field"];
+  }[];
+}
+
+/**
+ * Reshapes the joined rows into the `{ field, link }` pairs the read seam consumes, or `undefined`
+ * when the select omitted the join — which is exactly the input `getSurveyEmbeddedFields`' fallback
+ * expects, so a survey read through a narrower select keeps resolving off its legacy columns.
+ *
+ * **Ordering.** Neither table carries an ordinal column, so the rows cannot reproduce the order the
+ * author put their variables and hidden fields in — and that order is user-visible: it is the CSV
+ * and XLSX header order and the order of every picker. Until the legacy JSON columns are dropped
+ * they therefore remain the source of truth for *order* while the rows are the source of truth for
+ * *definitions*, which is what this sort expresses. A row whose storage key the columns don't know
+ * (impossible today — `reconcileEmbeddedData` writes exactly the derived set in one plan) sorts last
+ * rather than being dropped, in the select's `storageKey` order.
+ */
+export const inlineSurveyEmbeddedFields = (
+  surveyPrisma: TSurveyWithEmbeddedDataLinks
+): TLinkedEmbeddedField[] | undefined => {
+  const links = surveyPrisma.embeddedDataLinks;
+  if (!links) return undefined;
+
+  const legacyRankByStorageKey = new Map(
+    toDesiredEmbeddedFields({
+      variables: surveyPrisma.variables as Parameters<typeof toDesiredEmbeddedFields>[0]["variables"],
+      hiddenFields: surveyPrisma.hiddenFields as Parameters<
+        typeof toDesiredEmbeddedFields
+      >[0]["hiddenFields"],
+    }).map((field, index) => [field.storageKey, index] as const)
+  );
+  const rank = (storageKey: string): number =>
+    legacyRankByStorageKey.get(storageKey) ?? Number.MAX_SAFE_INTEGER;
+
+  // Array.prototype.sort is stable, so rows the columns don't rank keep the select's storageKey order.
+  return links
+    .map((link) => ({ field: link.embeddedData, link: { storageKey: link.storageKey } }))
+    .sort((a, b) => rank(a.link.storageKey) - rank(b.link.storageKey));
+};
+
+/**
+ * Replaces the raw `embeddedDataLinks` relation on a Prisma survey row with the inlined
+ * `embeddedFields` the read seam consumes, so the relation shape never leaks onto `TSurvey`.
+ * A no-op for rows read through a select without the join.
+ */
+export const withInlinedEmbeddedFields = <T extends TSurveyWithEmbeddedDataLinks>(
+  surveyPrisma: T
+): Omit<T, "embeddedDataLinks"> => {
+  const { embeddedDataLinks: _links, ...rest } = surveyPrisma;
+  const embeddedFields = inlineSurveyEmbeddedFields(surveyPrisma);
+  return embeddedFields ? { ...rest, embeddedFields } : rest;
+};

--- a/apps/web/lib/response/utils.test.ts
+++ b/apps/web/lib/response/utils.test.ts
@@ -629,6 +629,73 @@ describe("Response Utils", () => {
       const result = extractSurveyDetails(linkSurvey, mockResponses as TResponse[]);
       expect(result.userAttributes).toEqual(["email"]);
     });
+
+    /**
+     * ENG-1837: the export columns are built from the survey's Embedded Data definitions rather than
+     * `variables` / `hiddenFields`. Both the grouping (variables labelled by name, hidden fields by
+     * storage key) and the order inside each group are user-visible CSV/XLSX header order, so they
+     * are asserted exactly, not by membership.
+     */
+    describe("Embedded Data columns", () => {
+      const legacySurvey = {
+        ...mockSurvey,
+        variables: [
+          { id: "clx0000000000000000000v2", name: "tier", type: "text", value: "" },
+          { id: "clx0000000000000000000v1", name: "score", type: "number", value: 0 },
+        ],
+        hiddenFields: { enabled: true, fieldIds: ["utm_source", "hidden1"] },
+      } as TSurvey;
+
+      test("derives both column groups from the legacy columns when the join is absent", () => {
+        const result = extractSurveyDetails(legacySurvey, mockResponses as TResponse[]);
+
+        expect(result.variables).toEqual(["tier", "score"]);
+        expect(result.hiddenFields).toEqual(["utm_source", "hidden1"]);
+      });
+
+      test("takes the column labels from the rows when the join is present", () => {
+        const withRows = {
+          ...legacySurvey,
+          embeddedFields: [
+            {
+              field: {
+                name: "renamed_tier",
+                source: "computed",
+                dataType: "string",
+                defaultValue: "",
+                locked: false,
+              },
+              link: { storageKey: "clx0000000000000000000v2" },
+            },
+            {
+              field: {
+                name: "score",
+                source: "computed",
+                dataType: "number",
+                defaultValue: 0,
+                locked: false,
+              },
+              link: { storageKey: "clx0000000000000000000v1" },
+            },
+            {
+              field: {
+                name: "utm_source",
+                source: "ingested",
+                dataType: "string",
+                defaultValue: null,
+                locked: false,
+              },
+              link: { storageKey: "utm_source" },
+            },
+          ],
+        } as TSurvey;
+
+        const result = extractSurveyDetails(withRows, mockResponses as TResponse[]);
+
+        expect(result.variables).toEqual(["renamed_tier", "score"]);
+        expect(result.hiddenFields).toEqual(["utm_source"]);
+      });
+    });
   });
 
   describe("getResponsesJson", () => {
@@ -695,6 +762,45 @@ describe("Response Utils", () => {
       expect(result[0]["userAgent - browser"]).toBe("Chrome");
       expect(result[0]["1. Question 1"]).toBe("answer1");
       expect(result[0]["person.email"]).toBe("test@example.com");
+    });
+
+    test("a computed field the response never captured leaves an empty cell", () => {
+      // resolveEmbeddedValue would substitute the declared default here — i.e. display a value the
+      // respondent's run never produced. The export deliberately reads the raw slot instead.
+      const surveyWithVariables = {
+        ...mockSurvey,
+        variables: [{ id: "clx0000000000000000000v1", name: "score", type: "number", value: 5 }],
+      } as TSurvey;
+
+      const result = getResponsesJson(
+        surveyWithVariables,
+        [{ ...mockResponses[0], variables: {} }] as TResponse[],
+        [["1. Question 1"]],
+        [],
+        [],
+        false
+      );
+
+      expect(result[0]).toHaveProperty("score");
+      expect(result[0].score).toBeUndefined();
+    });
+
+    test("writes a captured computed value under the field's name, keyed by its storage key", () => {
+      const surveyWithVariables = {
+        ...mockSurvey,
+        variables: [{ id: "clx0000000000000000000v1", name: "score", type: "number", value: 5 }],
+      } as TSurvey;
+
+      const result = getResponsesJson(
+        surveyWithVariables,
+        [{ ...mockResponses[0], variables: { clx0000000000000000000v1: 12 } }] as TResponse[],
+        [["1. Question 1"]],
+        [],
+        [],
+        false
+      );
+
+      expect(result[0].score).toBe(12);
     });
 
     test("should namespace person attributes for link surveys too", () => {

--- a/apps/web/lib/response/utils.ts
+++ b/apps/web/lib/response/utils.ts
@@ -1,4 +1,5 @@
 import { normalizeLanguageCode } from "@formbricks/i18n-utils/src/canonical";
+import { getComputedEmbeddedFields, getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
 import {
   TResponse,
   TResponseDataValue,
@@ -158,11 +159,13 @@ export const extractSurveyDetails = (survey: TSurvey, responses: TResponse[]) =>
     }
   });
 
-  const hiddenFields = survey.hiddenFields?.fieldIds || [];
+  // ENG-1837: the two column groups keep today's shape — computed fields labelled by name, ingested
+  // ones by storage key — and today's order, which `inlineSurveyEmbeddedFields` preserves.
+  const hiddenFields = getIngestedStorageKeys(survey);
   const userAttributes = Array.from(
     new Set(responses.map((response) => Object.keys(response.contactAttributes ?? {})).flat())
   );
-  const variables = survey.variables?.map((variable) => variable.name) || [];
+  const variables = getComputedEmbeddedFields(survey).map(({ field }) => field.name);
 
   return { metaDataFields, elements, hiddenFields, variables, userAttributes };
 };
@@ -246,9 +249,12 @@ export const getResponsesJson = (
       }
     });
 
-    survey.variables?.forEach((variable) => {
-      const answer = response.variables[variable.id];
-      jsonData[idx][variable.name] = answer;
+    // The raw slot, uncoerced and with no default substituted: a response written before this field
+    // existed has no key, and the cell must stay empty rather than display a value that run never
+    // produced. (This is why the export does not read through `resolveEmbeddedValue`.)
+    getComputedEmbeddedFields(survey).forEach(({ field, link }) => {
+      const answer = response.variables[link.storageKey];
+      jsonData[idx][field.name] = answer;
     });
 
     userAttributes.forEach((attribute) => {
@@ -351,18 +357,18 @@ export const getResponseHiddenFields = (
   try {
     const hiddenFields: { [key: string]: Set<string> } = {};
 
-    const surveyHiddenFields = survey?.hiddenFields.fieldIds;
-    const hasHiddenFields = surveyHiddenFields && surveyHiddenFields.length > 0;
+    const surveyHiddenFields = getIngestedStorageKeys(survey);
+    const hasHiddenFields = surveyHiddenFields.length > 0;
 
     if (hasHiddenFields) {
       // adding hidden fields to meta
-      survey?.hiddenFields.fieldIds?.forEach((fieldId) => {
+      surveyHiddenFields.forEach((fieldId) => {
         hiddenFields[fieldId] = new Set();
       });
 
       responses.forEach((response) => {
         // Handling data fields(Hidden fields)
-        surveyHiddenFields?.forEach((fieldId) => {
+        surveyHiddenFields.forEach((fieldId) => {
           const hiddenFieldValue = response.data[fieldId];
           if (hiddenFieldValue) {
             if (typeof hiddenFieldValue === "string") {

--- a/apps/web/lib/survey/__mock__/survey.mock.ts
+++ b/apps/web/lib/survey/__mock__/survey.mock.ts
@@ -1,6 +1,7 @@
 import { Prisma } from "@formbricks/database/prisma";
 import { TActionClass } from "@formbricks/types/action-classes";
 import { TContactAttributeKey } from "@formbricks/types/contact-attribute-key";
+import { type TLinkedEmbeddedField } from "@formbricks/types/embedded-data-resolver";
 import { TOrganization } from "@formbricks/types/organizations";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import {
@@ -257,6 +258,9 @@ export const mockSyncSurveyOutput: SurveyMock = {
   segmentId: null,
   inlineTriggers: null,
   languages: mockSurveyLanguages,
+  // ENG-1837: the join `selectSurvey` now carries. Empty here, so readers fall back to the legacy
+  // columns above — the shape these fixtures have always described.
+  embeddedDataLinks: [],
   ...baseSurveyProperties,
   followUps: [],
   variables: [],
@@ -284,6 +288,7 @@ export const mockSurveyOutput: SurveyMock = {
   segmentId: null,
   inlineTriggers: null,
   languages: mockSurveyLanguages,
+  embeddedDataLinks: [],
   followUps: [],
   variables: [],
   showLanguageSwitch: null,
@@ -327,13 +332,18 @@ export const updateSurveyInput: TSurvey = {
   customHeadScriptsMode: null,
 };
 
-export const mockTransformedSurveyOutput = {
-  ...mockSurveyOutput,
-};
+/**
+ * What `transformPrismaSurvey` returns: the raw `embeddedDataLinks` relation is replaced by the
+ * inlined `embeddedFields` the read seam consumes (ENG-1837).
+ */
+const withInlinedEmbeddedFields = <T extends { embeddedDataLinks: unknown[] }>({
+  embeddedDataLinks,
+  ...survey
+}: T) => ({ ...survey, embeddedFields: [] as TLinkedEmbeddedField[] });
 
-export const mockTransformedSyncSurveyOutput = {
-  ...mockSyncSurveyOutput,
-};
+export const mockTransformedSurveyOutput = withInlinedEmbeddedFields(mockSurveyOutput);
+
+export const mockTransformedSyncSurveyOutput = withInlinedEmbeddedFields(mockSyncSurveyOutput);
 
 export const mockSurveyWithLogic: TSurvey = {
   ...mockSyncSurveyOutput,

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -637,6 +637,22 @@ export const updateSurveyInternal = async (
         // a partial update leaves `variables` / `hiddenFields` untouched in the column, and reading the
         // payload instead would see them as absent and delete every row. workspaceId comes from the
         // stored survey for the ENG-1749 reason above — never from the client.
+        //
+        // NOTE (ENG-1837): `survey` was read BEFORE this reconcile, so the `embeddedDataLinks` it
+        // carries — and the `embeddedFields` inlined from them by `transformPrismaSurvey` below —
+        // describe the PRE-reconcile rows. A save that renames or removes a field therefore returns a
+        // non-empty *stale* list. No consumer reads it today: the editor's save action feeds the
+        // return into `setLocalSurvey` / `surveyRef.current` and every editor surface resolves through
+        // `getDeclaredEmbeddedFields` (the cards); the v1 management route strips the key with
+        // `withoutInternalSurveyProjections`; the summary's single-use action discards the value and
+        // refreshes. The one surface that does carry it is the audit log's `newObject`.
+        //
+        // Deliberately NOT re-read here: it would put a second deep `selectSurvey` on the editor-save
+        // hot path for a value nothing consumes. If a future consumer needs it (ENG-1853 pointing a
+        // serializer at the rows), the fix must be a re-read through `selectSurvey` — which preserves
+        // the returned object's key shape. Do not strip or re-derive the key instead: this return
+        // value reaches `survey-menu-bar.tsx`, whose change detection deep-compares it against the
+        // editor's working copy and short-circuits on differing key counts.
         await reconcileEmbeddedData(tx, {
           surveyId,
           workspaceId: currentSurvey.workspaceId,

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -15,6 +15,7 @@ import { TBaseFilters, ZSegmentFilters } from "@formbricks/types/segment";
 import { TSurveyBlock } from "@formbricks/types/surveys/blocks";
 import { TSurvey, TSurveyCreateInput, ZSurvey, ZSurveyCreateInput } from "@formbricks/types/surveys/types";
 import { reconcileEmbeddedData } from "@/lib/embedded-data/reconcile";
+import { selectSurveyEmbeddedDataLinks, withInlinedEmbeddedFields } from "@/lib/embedded-data/survey-fields";
 import {
   getOrganizationByWorkspaceId,
   subscribeOrganizationMembersToSurveyResponses,
@@ -124,6 +125,9 @@ export const selectSurvey = {
   },
   followUps: true,
   slug: true,
+  // ENG-1837: the definitions every reader resolves through, joined and inlined by
+  // `transformPrismaSurvey`. Read-only — the rows are written by `reconcileEmbeddedData`.
+  embeddedDataLinks: selectSurveyEmbeddedDataLinks,
 } satisfies Prisma.SurveySelect;
 
 const reconcilePersistedSurveySchedulingIfDue = async ({
@@ -329,6 +333,12 @@ export const updateSurveyInternal = async (
       id: _id,
       // archivedAt is owned exclusively by the archive/restore flows; never let a survey update touch it.
       archivedAt: _archivedAt,
+      // ENG-1837: `embeddedFields` is a read-only projection of the EmbeddedData tables, inlined by
+      // the join below. `surveyData` is spread straight into `tx.survey.update`'s `data`, and
+      // `Survey` owns relations named `embeddedData` / `embeddedDataLinks` — so leaving it in would
+      // turn a read projection into a nested relation write. The rows are written by
+      // `reconcileEmbeddedData` from the persisted legacy columns instead.
+      embeddedFields: _embeddedFields,
       ...surveyData
     } = updatedSurvey;
 
@@ -904,7 +914,11 @@ export const createSurvey = async (
     // TODO: Fix this, this happens because the survey type "web" is no longer in the zod types but its required in the schema for migration
     // @ts-expect-error
     const transformedSurvey: TSurvey = {
-      ...survey,
+      // ENG-1837: this result is hand-built rather than routed through `transformPrismaSurvey`, so
+      // the inlining has to happen here too — otherwise the raw relation leaks onto TSurvey. The
+      // rows are reconciled *after* the create above, so the list is empty here and the accessor
+      // falls back to the freshly written legacy columns, which carry the same definitions.
+      ...withInlinedEmbeddedFields(survey),
       ...(survey.segment && {
         segment: {
           ...survey.segment,

--- a/apps/web/lib/survey/service.ts
+++ b/apps/web/lib/survey/service.ts
@@ -906,8 +906,9 @@ export const createSurvey = async (
       },
       // This transaction predates ENG-1978, but the reconcile above adds a read plus two writes per
       // field inside it, and neither `variables` nor `hiddenFields` is bounded — so a large template or
-      // API create could now reach Prisma's 5s default where it used to fit. Matched to the other two
-      // reconcile call sites rather than left to inherit a ceiling this work made easier to hit.
+      // API create could now reach Prisma's 5s default where it used to fit. Matched to the other
+      // reconcile call sites (enumerated on `getDeclaredEmbeddedFields`) rather than left to inherit
+      // a ceiling this work made easier to hit.
       { timeout: 20_000, maxWait: 10_000 }
     );
 

--- a/apps/web/lib/survey/utils.ts
+++ b/apps/web/lib/survey/utils.ts
@@ -17,6 +17,7 @@ import {
   TSurveyStatus,
   TSurveyType,
 } from "@formbricks/types/surveys/types";
+import { withInlinedEmbeddedFields } from "@/lib/embedded-data/survey-fields";
 import { isValidVideoUrl } from "@/lib/utils/video-upload";
 import { isValidImageFile } from "@/modules/storage/utils";
 
@@ -54,7 +55,10 @@ export const transformPrismaSurvey = <T extends TSurvey | TJsWorkspaceStateSurve
   }
 
   const transformedSurvey = {
-    ...surveyPrisma,
+    // ENG-1837: swaps the raw `embeddedDataLinks` relation for the inlined `embeddedFields` the read
+    // seam consumes, so the Prisma relation shape never leaks onto TSurvey. A no-op for surveys read
+    // through a select without the join — those fall back to their legacy columns in the accessor.
+    ...withInlinedEmbeddedFields(surveyPrisma),
     displayPercentage: Number(surveyPrisma.displayPercentage) || null,
     segment,
     customHeadScriptsMode: surveyPrisma.customHeadScriptsMode,

--- a/apps/web/lib/surveyLogic/utils.test.ts
+++ b/apps/web/lib/surveyLogic/utils.test.ts
@@ -1377,3 +1377,174 @@ describe("surveyLogic", () => {
     ).toBe(false);
   });
 });
+
+/**
+ * The server-side twin of `packages/surveys/src/lib/logic.ts`, exercised by quotas, the summary and
+ * follow-up conditions — i.e. against ALREADY-STORED responses. ENG-1837 repointed the definition
+ * lookup onto the EmbeddedData tables and deliberately left every value expression alone; these
+ * tests pin both, and each one flips if a call site is later "simplified" onto `resolveEmbeddedValue`.
+ */
+describe("computed fields resolve through the inlined EmbeddedData rows", () => {
+  const STORAGE_KEY = "cm9gptbhg0000192zceq9ayzz";
+
+  const buildSurvey = (
+    variables: TJsWorkspaceStateSurvey["variables"],
+    embeddedFields?: TJsWorkspaceStateSurvey["embeddedFields"]
+  ): TJsWorkspaceStateSurvey =>
+    ({
+      id: "cm9gptbhg0000192zceq9ayuc",
+      name: "Survey",
+      type: "link",
+      status: "inProgress",
+      welcomeCard: { enabled: false },
+      questions: [],
+      blocks: [{ id: "block1", name: "Block 1", elements: [] }],
+      endings: [],
+      variables,
+      embeddedFields,
+      hiddenFields: { enabled: true, fieldIds: ["plan"] },
+      languages: [],
+      triggers: [],
+      styling: null,
+      segment: null,
+      recaptcha: null,
+      autoClose: null,
+      delay: 0,
+      displayLimit: null,
+      displayOption: "displayOnce",
+      displayPercentage: null,
+      recontactDays: null,
+      showLanguageSwitch: null,
+      isBackButtonHidden: false,
+      isAutoProgressingEnabled: false,
+      workspaceOverwrites: null,
+    }) as unknown as TJsWorkspaceStateSurvey;
+
+  const computedRow = (dataType: "number" | "string", defaultValue: number | string) => [
+    {
+      field: { name: "score", source: "computed" as const, dataType, defaultValue, locked: false },
+      link: { storageKey: STORAGE_KEY },
+    },
+  ];
+
+  const equalsStatic = (value: number | string): TConditionGroup => ({
+    id: "group1",
+    connector: "and",
+    conditions: [
+      {
+        id: "condition1",
+        operator: "equals",
+        leftOperand: { type: "variable", value: STORAGE_KEY },
+        rightOperand: { type: "static", value },
+      },
+    ],
+  });
+
+  test("the row's dataType wins over the legacy column's", () => {
+    const legacyTextVariable = [
+      { id: STORAGE_KEY, name: "score", type: "text" as const, value: "" },
+    ] as TJsWorkspaceStateSurvey["variables"];
+
+    expect(
+      evaluateLogic(
+        buildSurvey(legacyTextVariable, computedRow("number", 0)),
+        {},
+        { [STORAGE_KEY]: "42" },
+        equalsStatic(42),
+        "default"
+      )
+    ).toBe(true);
+
+    expect(
+      evaluateLogic(buildSurvey(legacyTextVariable), {}, { [STORAGE_KEY]: "42" }, equalsStatic(42), "default")
+    ).toBe(false);
+  });
+
+  test("an empty row list falls back to the legacy column rather than losing the field", () => {
+    const legacyNumberVariable = [
+      { id: STORAGE_KEY, name: "score", type: "number" as const, value: 0 },
+    ] as TJsWorkspaceStateSurvey["variables"];
+
+    expect(
+      evaluateLogic(
+        buildSurvey(legacyNumberVariable, []),
+        {},
+        { [STORAGE_KEY]: "42" },
+        equalsStatic(42),
+        "default"
+      )
+    ).toBe(true);
+  });
+
+  test("delta (a): a non-numeric stored value is still 0, not the declared default", () => {
+    expect(
+      evaluateLogic(
+        buildSurvey([], computedRow("number", 5)),
+        {},
+        { [STORAGE_KEY]: "abc" },
+        equalsStatic(0),
+        "default"
+      )
+    ).toBe(true);
+  });
+
+  test('delta (a): a string field holding 0 is still "", not "0"', () => {
+    expect(
+      evaluateLogic(
+        buildSurvey([], computedRow("string", "fallback")),
+        {},
+        { [STORAGE_KEY]: 0 },
+        equalsStatic(""),
+        "default"
+      )
+    ).toBe(true);
+  });
+
+  test('delta (d): a response missing the key evaluates as 0 / "", not the declared default', () => {
+    expect(evaluateLogic(buildSurvey([], computedRow("number", 5)), {}, {}, equalsStatic(0), "default")).toBe(
+      true
+    );
+    expect(
+      evaluateLogic(buildSurvey([], computedRow("string", "gold")), {}, {}, equalsStatic(""), "default")
+    ).toBe(true);
+  });
+
+  test('performCalculation seeds from 0 / "" and skips an undeclared field', () => {
+    const calculate = (
+      survey: TJsWorkspaceStateSurvey,
+      action: TSurveyBlockLogicAction,
+      data: TResponseData,
+      calculations: TResponseVariables
+    ) => performActions(survey, [action], data, calculations).calculations;
+
+    expect(
+      calculate(
+        buildSurvey([], computedRow("number", 5)),
+        {
+          id: "a1",
+          objective: "calculate",
+          variableId: STORAGE_KEY,
+          operator: "add",
+          value: { type: "static", value: 3 },
+        },
+        {},
+        {}
+      )
+    ).toEqual({ [STORAGE_KEY]: 3 });
+
+    expect(
+      calculate(
+        buildSurvey([], computedRow("number", 5)),
+        {
+          id: "a1",
+          objective: "calculate",
+          variableId: "unknown_key",
+          operator: "add",
+          value: { type: "static", value: 3 },
+        },
+        {},
+        {}
+      )
+    ).toEqual({});
+  });
+});

--- a/apps/web/lib/surveyLogic/utils.test.ts
+++ b/apps/web/lib/surveyLogic/utils.test.ts
@@ -1509,6 +1509,80 @@ describe("computed fields resolve through the inlined EmbeddedData rows", () => 
     ).toBe(true);
   });
 
+  test("a number field compared against a hidden field still coerces the right operand", () => {
+    // The engines' twin in packages/surveys pins this too; it is the branch the guard below sits in
+    // front of, so both directions are asserted in both engines.
+    const condition: TConditionGroup = {
+      id: "group1",
+      connector: "and",
+      conditions: [
+        {
+          id: "condition1",
+          operator: "equals",
+          leftOperand: { type: "variable", value: STORAGE_KEY },
+          rightOperand: { type: "hiddenField", value: "plan" },
+        },
+      ],
+    };
+
+    expect(
+      evaluateLogic(
+        buildSurvey([], computedRow("number", 0)),
+        { plan: "42" },
+        { [STORAGE_KEY]: 42 },
+        condition,
+        "default"
+      )
+    ).toBe(true);
+  });
+
+  /**
+   * A condition can outlive the field it names: the variable is renamed or deleted, the logic rule
+   * keeps the old storage key. The `dataType` read that drives the number coercion runs BEFORE the
+   * operator switch, so an unguarded `undefined` throws there — and `evaluateSingleCondition`'s
+   * try/catch turns that into a silent `false` rather than a visible crash, which on this side of the
+   * fence quietly changes a quota's or a summary's answer. These assert the evaluated RESULT, not the
+   * absence of a throw, precisely because the catch would hide one.
+   */
+  describe("a condition naming a field the survey no longer declares", () => {
+    const staleOperand = (operator: TSingleCondition["operator"]): TConditionGroup => ({
+      id: "group1",
+      connector: "and",
+      conditions: [
+        {
+          id: "condition1",
+          operator,
+          leftOperand: { type: "variable", value: "storage_key_of_a_deleted_variable" },
+          rightOperand: { type: "hiddenField", value: "plan" },
+        },
+      ],
+    });
+
+    test("evaluates on its own merits instead of collapsing to false", () => {
+      expect(
+        evaluateLogic(
+          buildSurvey([], computedRow("number", 0)),
+          { plan: "42" },
+          {},
+          staleOperand("isNotSet"),
+          "default"
+        )
+      ).toBe(true);
+    });
+
+    test("does not coerce the right operand, since the left operand's type is unknown", () => {
+      expect(
+        evaluateLogic(
+          buildSurvey([], computedRow("number", 0)),
+          { plan: "42" },
+          {},
+          staleOperand("isSet"),
+          "default"
+        )
+      ).toBe(false);
+    });
+  });
+
   test('performCalculation seeds from 0 / "" and skips an undeclared field', () => {
     const calculate = (
       survey: TJsWorkspaceStateSurvey,

--- a/apps/web/lib/surveyLogic/utils.ts
+++ b/apps/web/lib/surveyLogic/utils.ts
@@ -1,8 +1,9 @@
 import { createId } from "@paralleldrive/cuid2";
 import {
-  type TLinkedEmbeddedField,
-  type TResolvableEmbeddedField,
+  findComputedEmbeddedField,
   getComputedEmbeddedFields,
+  getComputedFieldDataType,
+  getLogicVariableValue,
 } from "@formbricks/types/embedded-data-resolver";
 import { TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { TResponseData, TResponseVariables } from "@formbricks/types/responses";
@@ -277,26 +278,23 @@ const evaluateSingleCondition = (
 
     const computedFields = getComputedEmbeddedFields(localSurvey);
 
-    let leftField: TSurveyElement | TResolvableEmbeddedField | string;
+    // Only element and hiddenField operands are inspected below; a `variable` operand's declared
+    // type is read through `getComputedFieldDataType` instead, which tolerates a condition naming a
+    // field the survey no longer declares.
+    let leftField: TSurveyElement | string;
 
     if (condition.leftOperand?.type === "element") {
       leftField = elements.find((q) => q.id === condition.leftOperand?.value) ?? "";
-    } else if (condition.leftOperand?.type === "variable") {
-      leftField = findComputedField(computedFields, condition.leftOperand.value)
-        ?.field as TResolvableEmbeddedField;
     } else if (condition.leftOperand?.type === "hiddenField") {
       leftField = condition.leftOperand.value as string;
     } else {
       leftField = "";
     }
 
-    let rightField: TSurveyElement | TResolvableEmbeddedField | string;
+    let rightField: TSurveyElement | string;
 
     if (condition.rightOperand?.type === "element") {
       rightField = elements.find((q) => q.id === condition.rightOperand?.value) ?? "";
-    } else if (condition.rightOperand?.type === "variable") {
-      rightField = findComputedField(computedFields, condition.rightOperand.value)
-        ?.field as TResolvableEmbeddedField;
     } else if (condition.rightOperand?.type === "hiddenField") {
       rightField = condition.rightOperand.value as string;
     } else {
@@ -305,7 +303,7 @@ const evaluateSingleCondition = (
 
     if (
       condition.leftOperand.type === "variable" &&
-      (leftField as TResolvableEmbeddedField).dataType === "number" &&
+      getComputedFieldDataType(computedFields, condition.leftOperand.value) === "number" &&
       condition.rightOperand?.type === "hiddenField"
     ) {
       rightValue = Number(rightValue as string);
@@ -499,30 +497,6 @@ const evaluateSingleCondition = (
   }
 };
 
-/** Finds a computed field by the key its value is stored under in `response.variables`. */
-const findComputedField = (
-  computedFields: TLinkedEmbeddedField[],
-  storageKey: string
-): TLinkedEmbeddedField | undefined => computedFields.find((f) => f.link.storageKey === storageKey);
-
-/**
- * ENG-1837 repoints the *definition* lookup onto the EmbeddedData tables; the value expression below
- * is deliberately unchanged, and must stay in step with its twin in packages/surveys/src/lib/logic.ts.
- * `resolveEmbeddedValue` would coerce a non-numeric stored value to the field's declared default
- * instead of `0`, and render a text field holding `0` as `"0"` rather than `""` — both of which change
- * what already-stored responses evaluate to (quotas, summaries, follow-up conditions).
- */
-const getVariableValue = (
-  computedFields: TLinkedEmbeddedField[],
-  variableId: string,
-  variablesData: TResponseVariables
-) => {
-  const field = findComputedField(computedFields, variableId);
-  if (!field) return undefined;
-  const variableValue = variablesData[variableId];
-  return field.field.dataType === "number" ? Number(variableValue) || 0 : variableValue || "";
-};
-
 const getLeftOperandValue = (
   localSurvey: TJsWorkspaceStateSurvey,
   data: TResponseData,
@@ -611,7 +585,7 @@ const getLeftOperandValue = (
 
       return data[leftOperand.value];
     case "variable":
-      return getVariableValue(getComputedEmbeddedFields(localSurvey), leftOperand.value, variablesData);
+      return getLogicVariableValue(getComputedEmbeddedFields(localSurvey), leftOperand.value, variablesData);
     case "hiddenField":
       return data[leftOperand.value];
     default:
@@ -631,7 +605,7 @@ const getRightOperandValue = (
     case "element":
       return data[rightOperand.value];
     case "variable":
-      return getVariableValue(getComputedEmbeddedFields(localSurvey), rightOperand.value, variablesData);
+      return getLogicVariableValue(getComputedEmbeddedFields(localSurvey), rightOperand.value, variablesData);
     case "hiddenField":
       return data[rightOperand.value];
     case "static":
@@ -681,7 +655,7 @@ const performCalculation = (
   data: TResponseData,
   calculations: Record<string, number | string>
 ): number | string | undefined => {
-  const computedField = findComputedField(getComputedEmbeddedFields(survey), action.variableId);
+  const computedField = findComputedEmbeddedField(getComputedEmbeddedFields(survey), action.variableId);
 
   if (!computedField) return undefined;
 

--- a/apps/web/lib/surveyLogic/utils.ts
+++ b/apps/web/lib/surveyLogic/utils.ts
@@ -1,4 +1,9 @@
 import { createId } from "@paralleldrive/cuid2";
+import {
+  type TLinkedEmbeddedField,
+  type TResolvableEmbeddedField,
+  getComputedEmbeddedFields,
+} from "@formbricks/types/embedded-data-resolver";
 import { TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { TResponseData, TResponseVariables } from "@formbricks/types/responses";
 import {
@@ -8,7 +13,7 @@ import {
 } from "@formbricks/types/surveys/blocks";
 import { TSurveyElement, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TConditionGroup, TSingleCondition } from "@formbricks/types/surveys/logic";
-import { TActionCalculate, TSurveyLogicAction, TSurveyVariable } from "@formbricks/types/surveys/types";
+import { TActionCalculate, TSurveyLogicAction } from "@formbricks/types/surveys/types";
 import { getLocalizedValue } from "@/lib/i18n/utils";
 import { getElementsFromBlocks } from "@/modules/survey/lib/client-utils";
 
@@ -270,26 +275,28 @@ const evaluateSingleCondition = (
 
     const elements = getElementsFromBlocks(localSurvey.blocks);
 
-    let leftField: TSurveyElement | TSurveyVariable | string;
+    const computedFields = getComputedEmbeddedFields(localSurvey);
+
+    let leftField: TSurveyElement | TResolvableEmbeddedField | string;
 
     if (condition.leftOperand?.type === "element") {
       leftField = elements.find((q) => q.id === condition.leftOperand?.value) ?? "";
     } else if (condition.leftOperand?.type === "variable") {
-      leftField = localSurvey.variables.find((v) => v.id === condition.leftOperand?.value) as TSurveyVariable;
+      leftField = findComputedField(computedFields, condition.leftOperand.value)
+        ?.field as TResolvableEmbeddedField;
     } else if (condition.leftOperand?.type === "hiddenField") {
       leftField = condition.leftOperand.value as string;
     } else {
       leftField = "";
     }
 
-    let rightField: TSurveyElement | TSurveyVariable | string;
+    let rightField: TSurveyElement | TResolvableEmbeddedField | string;
 
     if (condition.rightOperand?.type === "element") {
       rightField = elements.find((q) => q.id === condition.rightOperand?.value) ?? "";
     } else if (condition.rightOperand?.type === "variable") {
-      rightField = localSurvey.variables.find(
-        (v) => v.id === condition.rightOperand?.value
-      ) as TSurveyVariable;
+      rightField = findComputedField(computedFields, condition.rightOperand.value)
+        ?.field as TResolvableEmbeddedField;
     } else if (condition.rightOperand?.type === "hiddenField") {
       rightField = condition.rightOperand.value as string;
     } else {
@@ -298,7 +305,7 @@ const evaluateSingleCondition = (
 
     if (
       condition.leftOperand.type === "variable" &&
-      (leftField as TSurveyVariable).type === "number" &&
+      (leftField as TResolvableEmbeddedField).dataType === "number" &&
       condition.rightOperand?.type === "hiddenField"
     ) {
       rightValue = Number(rightValue as string);
@@ -492,15 +499,28 @@ const evaluateSingleCondition = (
   }
 };
 
+/** Finds a computed field by the key its value is stored under in `response.variables`. */
+const findComputedField = (
+  computedFields: TLinkedEmbeddedField[],
+  storageKey: string
+): TLinkedEmbeddedField | undefined => computedFields.find((f) => f.link.storageKey === storageKey);
+
+/**
+ * ENG-1837 repoints the *definition* lookup onto the EmbeddedData tables; the value expression below
+ * is deliberately unchanged, and must stay in step with its twin in packages/surveys/src/lib/logic.ts.
+ * `resolveEmbeddedValue` would coerce a non-numeric stored value to the field's declared default
+ * instead of `0`, and render a text field holding `0` as `"0"` rather than `""` — both of which change
+ * what already-stored responses evaluate to (quotas, summaries, follow-up conditions).
+ */
 const getVariableValue = (
-  variables: TSurveyVariable[],
+  computedFields: TLinkedEmbeddedField[],
   variableId: string,
   variablesData: TResponseVariables
 ) => {
-  const variable = variables.find((v) => v.id === variableId);
-  if (!variable) return undefined;
+  const field = findComputedField(computedFields, variableId);
+  if (!field) return undefined;
   const variableValue = variablesData[variableId];
-  return variable.type === "number" ? Number(variableValue) || 0 : variableValue || "";
+  return field.field.dataType === "number" ? Number(variableValue) || 0 : variableValue || "";
 };
 
 const getLeftOperandValue = (
@@ -591,8 +611,7 @@ const getLeftOperandValue = (
 
       return data[leftOperand.value];
     case "variable":
-      const variables = localSurvey.variables || [];
-      return getVariableValue(variables, leftOperand.value, variablesData);
+      return getVariableValue(getComputedEmbeddedFields(localSurvey), leftOperand.value, variablesData);
     case "hiddenField":
       return data[leftOperand.value];
     default:
@@ -612,8 +631,7 @@ const getRightOperandValue = (
     case "element":
       return data[rightOperand.value];
     case "variable":
-      const variables = localSurvey.variables || [];
-      return getVariableValue(variables, rightOperand.value, variablesData);
+      return getVariableValue(getComputedEmbeddedFields(localSurvey), rightOperand.value, variablesData);
     case "hiddenField":
       return data[rightOperand.value];
     case "static":
@@ -663,14 +681,15 @@ const performCalculation = (
   data: TResponseData,
   calculations: Record<string, number | string>
 ): number | string | undefined => {
-  const variables = survey.variables || [];
-  const variable = variables.find((v) => v.id === action.variableId);
+  const computedField = findComputedField(getComputedEmbeddedFields(survey), action.variableId);
 
-  if (!variable) return undefined;
+  if (!computedField) return undefined;
+
+  const { dataType } = computedField.field;
 
   let currentValue = calculations[action.variableId];
   if (currentValue === undefined) {
-    currentValue = variable.type === "number" ? 0 : "";
+    currentValue = dataType === "number" ? 0 : "";
   }
   let operandValue: string | number | undefined;
 
@@ -685,11 +704,14 @@ const performCalculation = (
         operandValue = value;
       }
       break;
+    // Deliberately no `default` arm: a legacy `"question"` operand (admitted at the type level by
+    // ZDynamicLogicFieldValueDeprecated, normalized away at the API boundary) stays unresolved and
+    // the calculation returns undefined, exactly as before.
     case "element":
     case "hiddenField":
       const val = data[action.value.value];
       if (typeof val === "number" || typeof val === "string") {
-        if (variable.type === "number" && !isNaN(Number(val))) {
+        if (dataType === "number" && !isNaN(Number(val))) {
           operandValue = Number(val);
         } else {
           operandValue = val;

--- a/apps/web/lib/surveyLogic/utils.ts
+++ b/apps/web/lib/surveyLogic/utils.ts
@@ -685,7 +685,7 @@ const performCalculation = (
     case "hiddenField":
       const val = data[action.value.value];
       if (typeof val === "number" || typeof val === "string") {
-        if (dataType === "number" && !isNaN(Number(val))) {
+        if (dataType === "number" && !Number.isNaN(Number(val))) {
           operandValue = Number(val);
         } else {
           operandValue = val;

--- a/apps/web/lib/utils/recall.test.ts
+++ b/apps/web/lib/utils/recall.test.ts
@@ -446,17 +446,19 @@ describe("recall utility functions", () => {
     });
 
     test("classifies a field declared since the last save, which the rows do not know", () => {
-      // Without this the token would stay unclassified and render as a raw `#recall:…#` tag.
+      // The rows are non-empty and omit `hidden2`, so the stored accessor would not fall back — this
+      // fails if the resolution is switched back to it. Without the declared source the token stays
+      // unclassified and renders as a raw `#recall:…#` tag.
       const survey = {
         blocks: [],
-        hiddenFields: { fieldIds: ["hidden1"] },
+        hiddenFields: { fieldIds: ["hidden1", "hidden2"] },
         variables: [],
-        embeddedFields: [],
+        embeddedFields: [embeddedField("hidden1", "hidden1", "ingested")],
       } as unknown as TSurvey;
 
-      const result = getRecallItems("Text with #recall:hidden1/fallback:b#", survey, "en");
+      const result = getRecallItems("Text with #recall:hidden2/fallback:b#", survey, "en");
 
-      expect(result).toEqual([{ id: "hidden1", label: "hidden1", type: "hiddenField" }]);
+      expect(result).toEqual([{ id: "hidden2", label: "hidden2", type: "hiddenField" }]);
     });
 
     test("a storage key that also matches an element id still resolves as a hidden field", () => {

--- a/apps/web/lib/utils/recall.test.ts
+++ b/apps/web/lib/utils/recall.test.ts
@@ -402,6 +402,83 @@ describe("recall utility functions", () => {
     });
   });
 
+  /**
+   * ENG-1837: a recall token's label and type come from the survey's Embedded Data definitions —
+   * the joined rows when present, the legacy columns otherwise — instead of `hiddenFields.fieldIds`
+   * and `variables`. The precedence (ingested → element → computed) is load-bearing and unchanged.
+   */
+  describe("recall items resolve through the inlined EmbeddedData rows", () => {
+    const embeddedField = (
+      storageKey: string,
+      name: string,
+      source: "computed" | "ingested",
+      dataType: "string" | "number" = "string"
+    ) => ({
+      field: { name, source, dataType, defaultValue: null, locked: false },
+      link: { storageKey },
+    });
+
+    test("uses the rows' names as labels when the join is present", () => {
+      const survey = {
+        blocks: [],
+        hiddenFields: { fieldIds: ["hidden1"] },
+        variables: [{ id: "var1", name: "Stale Name", type: "text", value: "" }],
+        embeddedFields: [
+          embeddedField("var1", "Variable One", "computed"),
+          embeddedField("hidden1", "hidden1", "ingested"),
+        ],
+      } as unknown as TSurvey;
+
+      const result = getRecallItems(
+        "Text with #recall:var1/fallback:a# and #recall:hidden1/fallback:b#",
+        survey,
+        "en"
+      );
+
+      expect(result).toEqual([
+        { id: "var1", label: "Variable One", type: "variable" },
+        { id: "hidden1", label: "hidden1", type: "hiddenField" },
+      ]);
+    });
+
+    test("an empty row list falls back to the legacy columns", () => {
+      const survey = {
+        blocks: [],
+        hiddenFields: { fieldIds: ["hidden1"] },
+        variables: [],
+        embeddedFields: [],
+      } as unknown as TSurvey;
+
+      const result = getRecallItems("Text with #recall:hidden1/fallback:b#", survey, "en");
+
+      expect(result).toEqual([{ id: "hidden1", label: "hidden1", type: "hiddenField" }]);
+    });
+
+    test("a storage key that also matches an element id still resolves as a hidden field", () => {
+      const survey = {
+        blocks: [{ id: "b1", elements: [{ id: "shared", headline: { en: "Question headline" } }] }],
+        hiddenFields: { fieldIds: ["shared"] },
+        variables: [],
+      } as unknown as TSurvey;
+
+      const result = getRecallItems("Text with #recall:shared/fallback:x#", survey, "en");
+
+      expect(result).toEqual([{ id: "shared", label: "shared", type: "hiddenField" }]);
+    });
+
+    test("an element wins over a computed field on a colliding key", () => {
+      const survey = {
+        blocks: [{ id: "b1", elements: [{ id: "shared", headline: { en: "Question headline" } }] }],
+        hiddenFields: { fieldIds: [] },
+        variables: [{ id: "shared", name: "Variable One", type: "text", value: "" }],
+      } as unknown as TSurvey;
+
+      const result = getRecallItems("Text with #recall:shared/fallback:x#", survey, "en");
+
+      expect(result).toEqual([{ id: "shared", label: "Question headline", type: "element" }]);
+    });
+  });
+
   describe("getFallbackValues", () => {
     test("extracts fallback values from text", () => {
       const text = "Text #recall:id1/fallback:value1# and #recall:id2/fallback:value2#";

--- a/apps/web/lib/utils/recall.test.ts
+++ b/apps/web/lib/utils/recall.test.ts
@@ -403,11 +403,13 @@ describe("recall utility functions", () => {
   });
 
   /**
-   * ENG-1837: a recall token's label and type come from the survey's Embedded Data definitions —
-   * the joined rows when present, the legacy columns otherwise — instead of `hiddenFields.fieldIds`
-   * and `variables`. The precedence (ingested → element → computed) is load-bearing and unchanged.
+   * ENG-1837: a recall token's label and type come from the survey's Embedded Data definitions
+   * instead of `hiddenFields.fieldIds` and `variables` — specifically from what the survey
+   * *declares*, because the picker writes `@label` into the text and these functions read it back,
+   * so the two must agree on the same instant. The precedence (ingested → element → computed) is
+   * load-bearing and unchanged.
    */
-  describe("recall items resolve through the inlined EmbeddedData rows", () => {
+  describe("recall items resolve through the survey's declared Embedded Data", () => {
     const embeddedField = (
       storageKey: string,
       name: string,
@@ -418,13 +420,15 @@ describe("recall utility functions", () => {
       link: { storageKey },
     });
 
-    test("uses the rows' names as labels when the join is present", () => {
+    test("labels a token from the declarations, not from a stale inlined row", () => {
+      // The editor's working copy carries the rows as of the last save. Labelling from them would
+      // desync this from the recall picker, which offers the current name.
       const survey = {
         blocks: [],
         hiddenFields: { fieldIds: ["hidden1"] },
-        variables: [{ id: "var1", name: "Stale Name", type: "text", value: "" }],
+        variables: [{ id: "var1", name: "Renamed Variable", type: "text", value: "" }],
         embeddedFields: [
-          embeddedField("var1", "Variable One", "computed"),
+          embeddedField("var1", "Stale Name", "computed"),
           embeddedField("hidden1", "hidden1", "ingested"),
         ],
       } as unknown as TSurvey;
@@ -436,12 +440,13 @@ describe("recall utility functions", () => {
       );
 
       expect(result).toEqual([
-        { id: "var1", label: "Variable One", type: "variable" },
+        { id: "var1", label: "Renamed Variable", type: "variable" },
         { id: "hidden1", label: "hidden1", type: "hiddenField" },
       ]);
     });
 
-    test("an empty row list falls back to the legacy columns", () => {
+    test("classifies a field declared since the last save, which the rows do not know", () => {
+      // Without this the token would stay unclassified and render as a raw `#recall:…#` tag.
       const survey = {
         blocks: [],
         hiddenFields: { fieldIds: ["hidden1"] },

--- a/apps/web/lib/utils/recall.ts
+++ b/apps/web/lib/utils/recall.ts
@@ -1,3 +1,4 @@
+import { type TLinkedEmbeddedField, getSurveyEmbeddedFields } from "@formbricks/types/embedded-data-resolver";
 import { type TI18nString } from "@formbricks/types/i18n";
 import { TResponseData, TResponseDataValue, TResponseVariables } from "@formbricks/types/responses";
 import { TSurveyElement } from "@formbricks/types/surveys/elements";
@@ -54,13 +55,30 @@ export const findRecallInfoById = (text: string, id: string): string | null => {
   return match ? match[0] : null;
 };
 
+/**
+ * A recall token addresses an Embedded Data field by its storage key. ENG-1837 resolves what that key
+ * means through the EmbeddedData tables (with the legacy columns as fallback) rather than reading
+ * `hiddenFields.fieldIds` / `variables` directly; `source` is what used to be the array a key was
+ * found in.
+ */
+const findEmbeddedField = (
+  embeddedFields: TLinkedEmbeddedField[],
+  storageKey: string,
+  source: "computed" | "ingested"
+): TLinkedEmbeddedField | undefined =>
+  embeddedFields.find(({ field, link }) => link.storageKey === storageKey && field.source === source);
+
 export const getRecallItemLabel = <T extends TSurvey>(
   recallItemId: string,
   survey: T,
   languageCode: string
 ): string | undefined => {
-  const isHiddenField = survey.hiddenFields.fieldIds?.includes(recallItemId);
-  if (isHiddenField) return recallItemId;
+  const embeddedFields = getSurveyEmbeddedFields(survey);
+
+  // Precedence is load-bearing and unchanged: ingested first, then elements, then computed — so a
+  // storage key that also matches an element id keeps resolving the way it does today.
+  const ingestedField = findEmbeddedField(embeddedFields, recallItemId, "ingested");
+  if (ingestedField) return ingestedField.field.name;
 
   const questions = getElementsFromBlocks(survey.blocks);
   const surveyQuestion = questions.find((question) => question.id === recallItemId);
@@ -70,8 +88,8 @@ export const getRecallItemLabel = <T extends TSurvey>(
     return headline ? getTextContent(headline) : headline;
   }
 
-  const variable = survey.variables?.find((variable) => variable.id === recallItemId);
-  if (variable) return variable.name;
+  const computedField = findEmbeddedField(embeddedFields, recallItemId, "computed");
+  if (computedField) return computedField.field.name;
 };
 
 // Converts recall information in a headline to a corresponding recall question headline, with or without a slash.
@@ -159,12 +177,13 @@ export const getRecallItems = (text: string, survey: TSurvey, languageCode: stri
   if (!text.includes("#recall:")) return [];
 
   const ids = extractIds(text);
+  const embeddedFields = getSurveyEmbeddedFields(survey);
   let recallItems: TSurveyRecallItem[] = [];
   ids.forEach((recallItemId) => {
-    const isHiddenField = survey.hiddenFields.fieldIds?.includes(recallItemId);
+    const isHiddenField = findEmbeddedField(embeddedFields, recallItemId, "ingested");
     const questions = getElementsFromBlocks(survey.blocks);
     const isSurveyQuestion = questions.find((question) => question.id === recallItemId);
-    const isVariable = survey.variables.find((variable) => variable.id === recallItemId);
+    const isVariable = findEmbeddedField(embeddedFields, recallItemId, "computed");
 
     const recallItemLabel = getRecallItemLabel(recallItemId, survey, languageCode);
 

--- a/apps/web/lib/utils/recall.ts
+++ b/apps/web/lib/utils/recall.ts
@@ -215,7 +215,7 @@ export const getRecallItems = (text: string, survey: TSurvey, languageCode: stri
   let recallItems: TSurveyRecallItem[] = [];
   ids.forEach((recallItemId) => {
     const isHiddenField = findEmbeddedField(embeddedFields, recallItemId, "ingested");
-    const isSurveyQuestion = elements.find((question) => question.id === recallItemId);
+    const isSurveyQuestion = elements.some((question) => question.id === recallItemId);
     const isVariable = findEmbeddedField(embeddedFields, recallItemId, "computed");
 
     const recallItemLabel = resolveRecallItemLabel(recallItemId, elements, languageCode, embeddedFields);

--- a/apps/web/lib/utils/recall.ts
+++ b/apps/web/lib/utils/recall.ts
@@ -68,9 +68,9 @@ export const findRecallInfoById = (text: string, id: string): string | null => {
  * (`headlineToRecall` matches on the label), so both sides must see the same instant's definitions —
  * against the editor's working copy the stored rows are one save behind, which would render a
  * just-added field as a raw `#recall:…#` token and stop a just-renamed one from matching. For a
- * saved survey the two agree element for element, because `reconcileEmbeddedData` writes exactly
- * `toDesiredEmbeddedFields(survey)` in the same transaction as every survey write. See the
- * accessor's own doc block for when that stops being true (ENG-1851/ENG-1853).
+ * saved survey the two agree element for element, because every write path that persists those
+ * columns reconciles the rows in the same transaction. See the accessor's own doc block for the
+ * enumeration of those paths and for when the two stop agreeing (ENG-1851/ENG-1853).
  */
 const findEmbeddedField = (
   embeddedFields: TLinkedEmbeddedField[],

--- a/apps/web/lib/utils/recall.ts
+++ b/apps/web/lib/utils/recall.ts
@@ -80,14 +80,15 @@ const findEmbeddedField = (
   embeddedFields.find(({ field, link }) => link.storageKey === storageKey && field.source === source);
 
 /**
- * Takes the resolved field list rather than a survey, so callers that label several tokens — a
- * headline with nested recalls, a whole text — resolve the definitions once instead of once per
- * token. On a survey without joined rows that lookup re-derives the whole list, and these run on
- * every editor render.
+ * Takes the already-resolved element list and field list rather than a survey, so callers that label
+ * several tokens — a headline with nested recalls, a whole text — flatten the blocks and resolve the
+ * definitions once instead of once per token. Both are non-trivial (the field lookup re-derives the
+ * whole list from the declarations, and flattening walks every block), and these run on every editor
+ * render.
  */
 const resolveRecallItemLabel = (
   recallItemId: string,
-  survey: Pick<TSurvey, "blocks">,
+  elements: TSurveyElement[],
   languageCode: string,
   embeddedFields: TLinkedEmbeddedField[]
 ): string | undefined => {
@@ -96,8 +97,7 @@ const resolveRecallItemLabel = (
   const ingestedField = findEmbeddedField(embeddedFields, recallItemId, "ingested");
   if (ingestedField) return ingestedField.field.name;
 
-  const questions = getElementsFromBlocks(survey.blocks);
-  const surveyQuestion = questions.find((question) => question.id === recallItemId);
+  const surveyQuestion = elements.find((question) => question.id === recallItemId);
   if (surveyQuestion) {
     const headline = getLocalizedValue(surveyQuestion.headline, languageCode);
     // Strip HTML tags to prevent raw HTML from showing in nested recalls
@@ -113,7 +113,12 @@ export const getRecallItemLabel = <T extends TSurvey>(
   survey: T,
   languageCode: string
 ): string | undefined =>
-  resolveRecallItemLabel(recallItemId, survey, languageCode, getDeclaredEmbeddedFields(survey));
+  resolveRecallItemLabel(
+    recallItemId,
+    getElementsFromBlocks(survey.blocks),
+    languageCode,
+    getDeclaredEmbeddedFields(survey)
+  );
 
 // Converts recall information in a headline to a corresponding recall question headline, with or without a slash.
 export const recallToHeadline = <T extends TSurvey>(
@@ -128,6 +133,7 @@ export const recallToHeadline = <T extends TSurvey>(
   if (!localizedHeadline?.includes("#recall:")) return headline;
 
   const embeddedFields = getDeclaredEmbeddedFields(survey);
+  const elements = getElementsFromBlocks(survey.blocks);
 
   const replaceNestedRecalls = (text: string): string => {
     while (text.includes("#recall:")) {
@@ -138,7 +144,7 @@ export const recallToHeadline = <T extends TSurvey>(
       if (!recallItemId) break;
 
       let recallItemLabel =
-        resolveRecallItemLabel(recallItemId, survey, languageCode, embeddedFields) || recallItemId;
+        resolveRecallItemLabel(recallItemId, elements, languageCode, embeddedFields) || recallItemId;
 
       while (recallItemLabel.includes("#recall:")) {
         const nestedRecallInfo = extractRecallInfo(recallItemLabel);
@@ -203,15 +209,16 @@ export const getRecallItems = (text: string, survey: TSurvey, languageCode: stri
   if (!text.includes("#recall:")) return [];
 
   const ids = extractIds(text);
+  // Both lists are resolved once for the whole text, not once per token.
   const embeddedFields = getDeclaredEmbeddedFields(survey);
+  const elements = getElementsFromBlocks(survey.blocks);
   let recallItems: TSurveyRecallItem[] = [];
   ids.forEach((recallItemId) => {
     const isHiddenField = findEmbeddedField(embeddedFields, recallItemId, "ingested");
-    const questions = getElementsFromBlocks(survey.blocks);
-    const isSurveyQuestion = questions.find((question) => question.id === recallItemId);
+    const isSurveyQuestion = elements.find((question) => question.id === recallItemId);
     const isVariable = findEmbeddedField(embeddedFields, recallItemId, "computed");
 
-    const recallItemLabel = resolveRecallItemLabel(recallItemId, survey, languageCode, embeddedFields);
+    const recallItemLabel = resolveRecallItemLabel(recallItemId, elements, languageCode, embeddedFields);
 
     const getRecallItemType = () => {
       if (isHiddenField) return "hiddenField";

--- a/apps/web/lib/utils/recall.ts
+++ b/apps/web/lib/utils/recall.ts
@@ -1,4 +1,7 @@
-import { type TLinkedEmbeddedField, getSurveyEmbeddedFields } from "@formbricks/types/embedded-data-resolver";
+import {
+  type TLinkedEmbeddedField,
+  getDeclaredEmbeddedFields,
+} from "@formbricks/types/embedded-data-resolver";
 import { type TI18nString } from "@formbricks/types/i18n";
 import { TResponseData, TResponseDataValue, TResponseVariables } from "@formbricks/types/responses";
 import { TSurveyElement } from "@formbricks/types/surveys/elements";
@@ -56,10 +59,18 @@ export const findRecallInfoById = (text: string, id: string): string | null => {
 };
 
 /**
- * A recall token addresses an Embedded Data field by its storage key. ENG-1837 resolves what that key
- * means through the EmbeddedData tables (with the legacy columns as fallback) rather than reading
- * `hiddenFields.fieldIds` / `variables` directly; `source` is what used to be the array a key was
- * found in.
+ * A recall token addresses an Embedded Data field by its storage key. ENG-1837 resolves what that
+ * key means through the resolver rather than reading `hiddenFields.fieldIds` / `variables` directly;
+ * `source` is what used to be the array a key was found in.
+ *
+ * Deliberately `getDeclaredEmbeddedFields`, not `getSurveyEmbeddedFields`: a token's label is
+ * authoring syntax. The recall picker writes `@label` into the text and these functions read it back
+ * (`headlineToRecall` matches on the label), so both sides must see the same instant's definitions —
+ * against the editor's working copy the stored rows are one save behind, which would render a
+ * just-added field as a raw `#recall:…#` token and stop a just-renamed one from matching. For a
+ * saved survey the two agree element for element, because `reconcileEmbeddedData` writes exactly
+ * `toDesiredEmbeddedFields(survey)` in the same transaction as every survey write. See the
+ * accessor's own doc block for when that stops being true (ENG-1851/ENG-1853).
  */
 const findEmbeddedField = (
   embeddedFields: TLinkedEmbeddedField[],
@@ -68,13 +79,18 @@ const findEmbeddedField = (
 ): TLinkedEmbeddedField | undefined =>
   embeddedFields.find(({ field, link }) => link.storageKey === storageKey && field.source === source);
 
-export const getRecallItemLabel = <T extends TSurvey>(
+/**
+ * Takes the resolved field list rather than a survey, so callers that label several tokens — a
+ * headline with nested recalls, a whole text — resolve the definitions once instead of once per
+ * token. On a survey without joined rows that lookup re-derives the whole list, and these run on
+ * every editor render.
+ */
+const resolveRecallItemLabel = (
   recallItemId: string,
-  survey: T,
-  languageCode: string
+  survey: Pick<TSurvey, "blocks">,
+  languageCode: string,
+  embeddedFields: TLinkedEmbeddedField[]
 ): string | undefined => {
-  const embeddedFields = getSurveyEmbeddedFields(survey);
-
   // Precedence is load-bearing and unchanged: ingested first, then elements, then computed — so a
   // storage key that also matches an element id keeps resolving the way it does today.
   const ingestedField = findEmbeddedField(embeddedFields, recallItemId, "ingested");
@@ -92,6 +108,13 @@ export const getRecallItemLabel = <T extends TSurvey>(
   if (computedField) return computedField.field.name;
 };
 
+export const getRecallItemLabel = <T extends TSurvey>(
+  recallItemId: string,
+  survey: T,
+  languageCode: string
+): string | undefined =>
+  resolveRecallItemLabel(recallItemId, survey, languageCode, getDeclaredEmbeddedFields(survey));
+
 // Converts recall information in a headline to a corresponding recall question headline, with or without a slash.
 export const recallToHeadline = <T extends TSurvey>(
   headline: TI18nString,
@@ -104,6 +127,8 @@ export const recallToHeadline = <T extends TSurvey>(
 
   if (!localizedHeadline?.includes("#recall:")) return headline;
 
+  const embeddedFields = getDeclaredEmbeddedFields(survey);
+
   const replaceNestedRecalls = (text: string): string => {
     while (text.includes("#recall:")) {
       const recallInfo = extractRecallInfo(text);
@@ -112,7 +137,8 @@ export const recallToHeadline = <T extends TSurvey>(
       const recallItemId = extractId(recallInfo);
       if (!recallItemId) break;
 
-      let recallItemLabel = getRecallItemLabel(recallItemId, survey, languageCode) || recallItemId;
+      let recallItemLabel =
+        resolveRecallItemLabel(recallItemId, survey, languageCode, embeddedFields) || recallItemId;
 
       while (recallItemLabel.includes("#recall:")) {
         const nestedRecallInfo = extractRecallInfo(recallItemLabel);
@@ -177,7 +203,7 @@ export const getRecallItems = (text: string, survey: TSurvey, languageCode: stri
   if (!text.includes("#recall:")) return [];
 
   const ids = extractIds(text);
-  const embeddedFields = getSurveyEmbeddedFields(survey);
+  const embeddedFields = getDeclaredEmbeddedFields(survey);
   let recallItems: TSurveyRecallItem[] = [];
   ids.forEach((recallItemId) => {
     const isHiddenField = findEmbeddedField(embeddedFields, recallItemId, "ingested");
@@ -185,7 +211,7 @@ export const getRecallItems = (text: string, survey: TSurvey, languageCode: stri
     const isSurveyQuestion = questions.find((question) => question.id === recallItemId);
     const isVariable = findEmbeddedField(embeddedFields, recallItemId, "computed");
 
-    const recallItemLabel = getRecallItemLabel(recallItemId, survey, languageCode);
+    const recallItemLabel = resolveRecallItemLabel(recallItemId, survey, languageCode, embeddedFields);
 
     const getRecallItemType = () => {
       if (isHiddenField) return "hiddenField";

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/HiddenFields.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/HiddenFields.tsx
@@ -15,13 +15,16 @@ interface HiddenFieldsProps {
 export const HiddenFields = ({ hiddenFields, responseData }: Readonly<HiddenFieldsProps>) => {
   const { t } = useTranslation();
 
-  let hiddenFieldsData: { field: string; value: string }[] = [];
+  // `storageKey` is the React key: it is unique per survey by `@@unique([surveyId, storageKey])`,
+  // whereas a field's display name carries no uniqueness constraint.
+  let hiddenFieldsData: { storageKey: string; label: string; value: string }[] = [];
 
   hiddenFields.forEach(({ field, link }) => {
     const value = responseData[link.storageKey];
     if (value) {
       hiddenFieldsData.push({
-        field: field.name,
+        storageKey: link.storageKey,
+        label: field.name,
         value: typeof value === "string" ? value : "",
       });
     }
@@ -35,9 +38,9 @@ export const HiddenFields = ({ hiddenFields, responseData }: Readonly<HiddenFiel
     <div data-testid="main-hidden-fields-div" className="mt-6 flex flex-col gap-6">
       {hiddenFieldsData.map((fieldData) => {
         return (
-          <div key={fieldData.field}>
+          <div key={fieldData.storageKey}>
             <div className="flex gap-x-2 text-sm text-slate-500">
-              <p>{fieldData.field}</p>
+              <p>{fieldData.label}</p>
               <div className="flex items-center gap-x-2 rounded-full bg-slate-100 px-2">
                 <TooltipProvider delayDuration={50}>
                   <Tooltip>

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/HiddenFields.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/HiddenFields.tsx
@@ -2,26 +2,27 @@
 
 import { EyeOffIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { type TLinkedEmbeddedField } from "@formbricks/types/embedded-data-resolver";
 import { TResponseData } from "@formbricks/types/responses";
-import { TSurveyHiddenFields } from "@formbricks/types/surveys/types";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/modules/ui/components/tooltip";
 
 interface HiddenFieldsProps {
-  hiddenFields: TSurveyHiddenFields;
+  /** The survey's ingested Embedded Data fields, resolved through `getSurveyEmbeddedFields`. */
+  hiddenFields: TLinkedEmbeddedField[];
   responseData: TResponseData;
 }
 
-export const HiddenFields = ({ hiddenFields, responseData }: HiddenFieldsProps) => {
+export const HiddenFields = ({ hiddenFields, responseData }: Readonly<HiddenFieldsProps>) => {
   const { t } = useTranslation();
-  const fieldIds = hiddenFields.fieldIds ?? [];
 
   let hiddenFieldsData: { field: string; value: string }[] = [];
 
-  fieldIds.forEach((field) => {
-    if (responseData[field]) {
+  hiddenFields.forEach(({ field, link }) => {
+    const value = responseData[link.storageKey];
+    if (value) {
       hiddenFieldsData.push({
-        field,
-        value: typeof responseData[field] === "string" ? responseData[field] : "",
+        field: field.name,
+        value: typeof value === "string" ? value : "",
       });
     }
   });

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/ResponseVariables.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/ResponseVariables.tsx
@@ -2,34 +2,35 @@
 
 import { FileDigitIcon, FileType2Icon } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { type TLinkedEmbeddedField } from "@formbricks/types/embedded-data-resolver";
 import { TResponseVariables } from "@formbricks/types/responses";
-import { TSurveyVariables } from "@formbricks/types/surveys/types";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/modules/ui/components/tooltip";
 
-interface HiddenFieldsProps {
-  variables: TSurveyVariables;
+interface ResponseVariablesProps {
+  /** The survey's computed Embedded Data fields, resolved through `getSurveyEmbeddedFields`. */
+  variables: TLinkedEmbeddedField[];
   variablesData: TResponseVariables;
 }
 
-export const ResponseVariables = ({ variables, variablesData }: HiddenFieldsProps) => {
+export const ResponseVariables = ({ variables, variablesData }: Readonly<ResponseVariablesProps>) => {
   const { t } = useTranslation();
   return (
     <div className="mt-6 flex flex-col gap-6">
-      {variables.map((variable) => {
+      {variables.map(({ field, link }) => {
         if (
-          variablesData[variable.id] === undefined ||
-          !["string", "number"].includes(typeof variablesData[variable.id])
+          variablesData[link.storageKey] === undefined ||
+          !["string", "number"].includes(typeof variablesData[link.storageKey])
         )
           return null;
         return (
-          <div key={variable.id}>
+          <div key={link.storageKey}>
             <div className="flex gap-x-2 text-sm text-slate-500">
-              <p>{variable.name}</p>
+              <p>{field.name}</p>
               <div className="flex items-center gap-x-2 rounded-full bg-slate-100 px-2">
                 <TooltipProvider delayDuration={50}>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      {variable.type === "number" ? (
+                      {field.dataType === "number" ? (
                         <FileDigitIcon className="size-4" />
                       ) : (
                         <FileType2Icon className="size-4" />
@@ -42,7 +43,9 @@ export const ResponseVariables = ({ variables, variablesData }: HiddenFieldsProp
                 </TooltipProvider>
               </div>
             </div>
-            <p className="ph-no-capture mt-2 font-semibold text-slate-700">{variablesData[variable.id]}</p>
+            <p className="ph-no-capture mt-2 font-semibold text-slate-700">
+              {variablesData[link.storageKey]}
+            </p>
           </div>
         );
       })}

--- a/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
+++ b/apps/web/modules/analysis/components/SingleResponseCard/components/SingleResponseCardBody.tsx
@@ -2,6 +2,10 @@
 
 import { CheckCircle2Icon } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import {
+  getComputedEmbeddedFields,
+  getIngestedEmbeddedFields,
+} from "@formbricks/types/embedded-data-resolver";
 import { TResponseWithQuotas } from "@formbricks/types/responses";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/constants";
 import { TSurvey } from "@formbricks/types/surveys/types";
@@ -33,6 +37,10 @@ export const SingleResponseCardBody = ({
   locale,
 }: SingleResponseCardBodyProps) => {
   const elements = getElementsFromBlocks(survey.blocks);
+  // ENG-1837: both blocks below render the survey's Embedded Data definitions, resolved through the
+  // tables with the legacy columns as fallback.
+  const computedFields = getComputedEmbeddedFields(survey);
+  const ingestedFields = getIngestedEmbeddedFields(survey);
   const dateFormats = getSurveyDateFormatMap(elements);
   const isFirstElementAnswered = elements[0] ? !!response.data[elements[0].id] : false;
   const { t } = useTranslation();
@@ -47,7 +55,7 @@ export const SingleResponseCardBody = ({
         return (
           <span
             key={index}
-            className="ml-0.5 mr-0.5 rounded-md border border-slate-200 bg-slate-50 px-1 py-0.5 text-sm first:ml-0">
+            className="mr-0.5 ml-0.5 rounded-md border border-slate-200 bg-slate-50 px-1 py-0.5 text-sm first:ml-0">
             @{part}
           </span>
         );
@@ -141,11 +149,11 @@ export const SingleResponseCardBody = ({
           );
         })}
       </div>
-      {survey.variables.length > 0 && (
-        <ResponseVariables variables={survey.variables} variablesData={response.variables} />
+      {computedFields.length > 0 && (
+        <ResponseVariables variables={computedFields} variablesData={response.variables} />
       )}
-      {survey.hiddenFields.fieldIds && (
-        <HiddenFields hiddenFields={survey.hiddenFields} responseData={response.data} />
+      {ingestedFields.length > 0 && (
+        <HiddenFields hiddenFields={ingestedFields} responseData={response.data} />
       )}
 
       <ResponseCardQuotas quotas={response.quotas} />

--- a/apps/web/modules/email/index.tsx
+++ b/apps/web/modules/email/index.tsx
@@ -74,7 +74,9 @@ interface SendEmailDataProps {
 }
 
 export type TResponseFinishedEmailSurvey = TElementResponseMappingSurvey &
-  Pick<TSurvey, "id" | "name" | "variables" | "hiddenFields">;
+  // `variables` / `hiddenFields` are the resolver's fallback; `embeddedFields` carries the joined
+  // EmbeddedData rows the template resolves definitions through (ENG-1837).
+  Pick<TSurvey, "id" | "name" | "variables" | "hiddenFields" | "embeddedFields">;
 
 export const sendEmail = async (emailData: SendEmailDataProps): Promise<boolean> => {
   if (!IS_SMTP_CONFIGURED) {

--- a/apps/web/modules/email/lib/survey-response-email.ts
+++ b/apps/web/modules/email/lib/survey-response-email.ts
@@ -7,6 +7,7 @@ import {
   ProcessedVariable,
   renderFollowUpEmail,
 } from "@formbricks/email";
+import { getComputedEmbeddedFields, getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
 import { TResponse } from "@formbricks/types/responses";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey } from "@formbricks/types/surveys/types";
@@ -97,19 +98,21 @@ const buildVariables = (
 ): ProcessedVariable[] => {
   if (!attachResponseData || !includeVariables) return [];
 
-  return survey.variables
-    .filter((variable) => {
-      const variableResponse = response.variables[variable.id];
+  // ENG-1837: definitions from the EmbeddedData tables; the value read stays the raw response slot,
+  // so a response that never captured this field is filtered out rather than shown its default.
+  return getComputedEmbeddedFields(survey)
+    .filter(({ link }) => {
+      const variableResponse = response.variables[link.storageKey];
       return (
         (typeof variableResponse === "string" || typeof variableResponse === "number") &&
         variableResponse !== undefined
       );
     })
-    .map((variable) => ({
-      id: variable.id,
-      name: variable.name,
-      type: variable.type,
-      value: response.variables[variable.id],
+    .map(({ field, link }) => ({
+      id: link.storageKey,
+      name: field.name,
+      type: field.dataType === "number" ? ("number" as const) : ("text" as const),
+      value: response.variables[link.storageKey],
     }));
 };
 
@@ -121,17 +124,15 @@ const buildHiddenFields = (
 ): ProcessedHiddenField[] => {
   if (!attachResponseData || !includeHiddenFields) return [];
 
-  return (
-    survey.hiddenFields.fieldIds
-      ?.filter((hiddenFieldId) => {
-        const hiddenFieldResponse = response.data[hiddenFieldId];
-        return hiddenFieldResponse && typeof hiddenFieldResponse === "string";
-      })
-      .map((hiddenFieldId) => ({
-        id: hiddenFieldId,
-        value: response.data[hiddenFieldId] as string,
-      })) ?? []
-  );
+  return getIngestedStorageKeys(survey)
+    .filter((hiddenFieldId) => {
+      const hiddenFieldResponse = response.data[hiddenFieldId];
+      return hiddenFieldResponse && typeof hiddenFieldResponse === "string";
+    })
+    .map((hiddenFieldId) => ({
+      id: hiddenFieldId,
+      value: response.data[hiddenFieldId] as string,
+    }));
 };
 
 /**

--- a/apps/web/modules/response-pipeline/lib/handle-integrations.ts
+++ b/apps/web/modules/response-pipeline/lib/handle-integrations.ts
@@ -1,4 +1,5 @@
 import { logger } from "@formbricks/logger";
+import { getComputedEmbeddedFields, getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
 import { Result } from "@formbricks/types/error-handlers";
 import { TIntegration, TIntegrationType } from "@formbricks/types/integration";
 import { TIntegrationAirtable } from "@formbricks/types/integration/airtable";
@@ -26,7 +27,12 @@ type TIntegrationPipelineData = {
   response: Pick<TResponse, "createdAt" | "data" | "meta" | "variables" | "contactAttributes">;
   surveyId: string;
 };
-type TPipelineIntegrationSurvey = Pick<TSurvey, "blocks" | "hiddenFields" | "variables" | "name">;
+// `hiddenFields` / `variables` stay in the pick as the resolver's fallback; `embeddedFields` carries
+// the joined EmbeddedData rows the definitions are resolved through (ENG-1837).
+type TPipelineIntegrationSurvey = Pick<
+  TSurvey,
+  "blocks" | "hiddenFields" | "variables" | "embeddedFields" | "name"
+>;
 
 const NOTION_PERSON_ATTRIBUTE_PREFIX = "person.";
 
@@ -87,10 +93,8 @@ const processDataForIntegration = async (
     includeVariables,
     includeContactAttributes,
   } = selection;
-  const ids =
-    includeHiddenFields && survey.hiddenFields.fieldIds
-      ? [...elementIds, ...survey.hiddenFields.fieldIds]
-      : elementIds;
+  const ingestedStorageKeys = getIngestedStorageKeys(survey);
+  const ids = includeHiddenFields ? [...elementIds, ...ingestedStorageKeys] : elementIds;
   const { responses, elements } = await extractResponses(integrationType, data, ids, survey);
 
   if (includeMetadata) {
@@ -98,11 +102,13 @@ const processDataForIntegration = async (
     elements.push("Metadata");
   }
   if (includeVariables) {
-    survey.variables?.forEach((variable) => {
-      const value = data.response.variables[variable.id];
+    // The raw slot, uncoerced and with no default substituted — a response that never captured this
+    // field is skipped rather than exported with a value that run never produced.
+    getComputedEmbeddedFields(survey).forEach(({ field, link }) => {
+      const value = data.response.variables[link.storageKey];
       if (value !== undefined) {
-        responses.push(String(data.response.variables[variable.id]));
-        elements.push(variable.name);
+        responses.push(String(value));
+        elements.push(field.name);
       }
     });
   }
@@ -329,9 +335,11 @@ const extractResponses = async (
   const surveyElements = getElementsFromBlocks(survey.blocks);
   const emptyResponseObject = createEmptyResponseObject(pipelineData.response.data);
 
+  const ingestedStorageKeys = getIngestedStorageKeys(survey);
+
   for (const elementId of elementIds) {
-    // Check for hidden field Ids
-    if (survey.hiddenFields.fieldIds?.includes(elementId)) {
+    // Check for ingested (hidden) field storage keys
+    if (ingestedStorageKeys.includes(elementId)) {
       responses.push(processResponseData(pipelineData.response.data[elementId]));
       elements.push(elementId);
       continue;

--- a/apps/web/modules/response-pipeline/lib/handle-integrations.ts
+++ b/apps/web/modules/response-pipeline/lib/handle-integrations.ts
@@ -341,6 +341,15 @@ const extractResponses = async (
     // Check for ingested (hidden) field storage keys
     if (ingestedStorageKeys.includes(elementId)) {
       responses.push(processResponseData(pipelineData.response.data[elementId]));
+      // Labelled by storage key, while a computed field above is labelled by `field.name`. The
+      // asymmetry is deliberate: a computed field's storage key is an opaque cuid, whereas an
+      // ingested field's storage key IS its name today (`toDesiredEmbeddedFields` sets both to the
+      // hidden field id), and the Notion mapping modal both keys and labels on the storage key. So
+      // the two are equal today, and switching this side alone would desync the pipeline from that
+      // picker — and silently re-header the spreadsheet/Notion columns of every already-configured
+      // integration, since `elements` IS the column header. When names can diverge from storage keys
+      // (ENG-1851), this and `AddIntegrationModal.tsx` have to move together, with a migration for
+      // existing mappings.
       elements.push(elementId);
       continue;
     }

--- a/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
+++ b/apps/web/modules/response-pipeline/lib/process-response-pipeline-job.ts
@@ -4,9 +4,11 @@ import { prisma } from "@formbricks/database";
 import { PipelineTriggers, Prisma, type Webhook } from "@formbricks/database/prisma";
 import { type JobHandler, type TResponsePipelineJobData, UnrecoverableError } from "@formbricks/jobs";
 import { logger } from "@formbricks/logger";
+import { type TLinkedEmbeddedField } from "@formbricks/types/embedded-data-resolver";
 import { type TUserLocale, ZUserLocale } from "@formbricks/types/user";
 import { DANGEROUSLY_ALLOW_WEBHOOK_INTERNAL_URLS, POSTHOG_KEY } from "@/lib/constants";
 import { generateStandardWebhookSignature } from "@/lib/crypto";
+import { selectSurveyEmbeddedDataLinks, withInlinedEmbeddedFields } from "@/lib/embedded-data/survey-fields";
 import { handleFeedbackSourcePipeline } from "@/lib/feedback-source/pipeline-handler";
 import { getIntegrations } from "@/lib/integration/service";
 import { isDatabasePoolExhaustionError } from "@/lib/jobs/pool-exhaustion";
@@ -49,6 +51,9 @@ const pipelineSurveySelect = {
   blocks: true,
   hiddenFields: true,
   variables: true,
+  // ENG-1837: the definitions the notification email, follow-ups and integrations below resolve
+  // through. Inlined by `getSurveyForPipeline` so the raw relation never reaches the handlers.
+  embeddedDataLinks: selectSurveyEmbeddedDataLinks,
   followUps: true,
   autoComplete: true,
   languages: {
@@ -70,7 +75,10 @@ const pipelineSurveySelect = {
 } satisfies Prisma.SurveySelect;
 
 type TPipelineOrganization = Prisma.OrganizationGetPayload<{ select: typeof pipelineOrganizationSelect }>;
-type TPipelineSurvey = Prisma.SurveyGetPayload<{ select: typeof pipelineSurveySelect }>;
+type TPipelineSurveyRow = Prisma.SurveyGetPayload<{ select: typeof pipelineSurveySelect }>;
+type TPipelineSurvey = Omit<TPipelineSurveyRow, "embeddedDataLinks"> & {
+  embeddedFields?: TLinkedEmbeddedField[];
+};
 
 const getOrganizationForPipeline = async (workspaceId: string): Promise<TPipelineOrganization | null> =>
   prisma.organization.findFirst({
@@ -84,13 +92,16 @@ const getOrganizationForPipeline = async (workspaceId: string): Promise<TPipelin
     select: pipelineOrganizationSelect,
   });
 
-const getSurveyForPipeline = async (surveyId: string): Promise<TPipelineSurvey | null> =>
-  prisma.survey.findUnique({
+const getSurveyForPipeline = async (surveyId: string): Promise<TPipelineSurvey | null> => {
+  const survey = await prisma.survey.findUnique({
     where: {
       id: surveyId,
     },
     select: pipelineSurveySelect,
   });
+
+  return survey ? withInlinedEmbeddedFields(survey) : null;
+};
 
 const getPipelineLogContext = (
   data: TResponsePipelineJobData,

--- a/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
+++ b/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { getSurveyEmbeddedFields, listReadableFields } from "@formbricks/types/embedded-data-resolver";
 import { TSurveyElement, TSurveyElementId, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey, TSurveyHiddenFields, TSurveyRecallItem } from "@formbricks/types/surveys/types";
 import { getTextContent } from "@formbricks/types/surveys/validation";
@@ -82,36 +83,48 @@ export const RecallItemSelect = ({
     return recallItems.map((recallItem) => recallItem.id);
   }, [recallItems]);
 
-  const hiddenFieldRecallItems = useMemo(() => {
-    if (localSurvey.hiddenFields.fieldIds) {
-      return localSurvey.hiddenFields.fieldIds
-        .filter((hiddenFieldId) => {
-          return !recallItemIds.includes(hiddenFieldId);
-        })
-        .map((hiddenFieldId) => ({
-          id: hiddenFieldId,
-          label: hiddenFieldId,
-          type: "hiddenField" as const,
-        }));
-    }
-    return [];
-  }, [localSurvey.hiddenFields, recallItemIds]);
+  // ENG-1837: both groups are enumerated from the survey's Embedded Data definitions. Only the
+  // `embeddedData` group of `listReadableFields` is used — its keys and labels are exactly today's
+  // (storage key / field name); the element group keeps this file's own labelling, which stores the
+  // raw headline HTML and searches it through `getTextContent`.
+  const embeddedDataFields = useMemo(
+    () =>
+      listReadableFields({
+        blocks: [],
+        embeddedData: getSurveyEmbeddedFields(localSurvey),
+        reservedEntries: [],
+        contactAttributeKeys: [],
+      }).embeddedData,
+    [localSurvey]
+  );
 
-  const variableRecallItems = useMemo(() => {
-    if (localSurvey.variables.length) {
-      return localSurvey.variables
-        .filter((variable) => !recallItemIds.includes(variable.id))
-        .map((variable) => {
-          return {
-            id: variable.id,
-            label: variable.name,
-            type: "variable" as const,
-          };
-        });
-    }
+  const embeddedFieldSources = useMemo(
+    () =>
+      new Map(
+        getSurveyEmbeddedFields(localSurvey).map(({ field, link }) => [link.storageKey, field] as const)
+      ),
+    [localSurvey]
+  );
 
-    return [];
-  }, [localSurvey.variables, recallItemIds]);
+  const hiddenFieldRecallItems = useMemo(
+    () =>
+      embeddedDataFields
+        .filter(
+          ({ key }) => embeddedFieldSources.get(key)?.source === "ingested" && !recallItemIds.includes(key)
+        )
+        .map(({ key, label }) => ({ id: key, label, type: "hiddenField" as const })),
+    [embeddedDataFields, embeddedFieldSources, recallItemIds]
+  );
+
+  const variableRecallItems = useMemo(
+    () =>
+      embeddedDataFields
+        .filter(
+          ({ key }) => embeddedFieldSources.get(key)?.source === "computed" && !recallItemIds.includes(key)
+        )
+        .map(({ key, label }) => ({ id: key, label, type: "variable" as const })),
+    [embeddedDataFields, embeddedFieldSources, recallItemIds]
+  );
 
   const surveyElementRecallItems = useMemo(() => {
     const isWelcomeCard = elementId === "start";
@@ -162,8 +175,7 @@ export const RecallItemSelect = ({
       case "hiddenField":
         return EyeOffIcon;
       case "variable": {
-        const variable = localSurvey.variables.find((variable) => variable.id === recallItem.id);
-        return variable?.type === "number" ? FileDigitIcon : FileTextIcon;
+        return embeddedFieldSources.get(recallItem.id)?.dataType === "number" ? FileDigitIcon : FileTextIcon;
       }
       default:
         return null;

--- a/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
+++ b/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
@@ -97,22 +97,29 @@ export const RecallItemSelect = ({
     [localSurvey.variables, localSurvey.hiddenFields]
   );
 
-  /** `[storageKey, source, label]` triples, in the definitions' own order. */
-  const embeddedFieldEntries = useMemo(
-    () =>
+  /**
+   * The definitions joined to their picker labels, in the definitions' own order. Keyed on
+   * `storageKey`, not on position: `listReadableFields` happens to emit one entry per input today,
+   * but a future filter there would silently shift every label past the first drop.
+   */
+  const embeddedFieldEntries = useMemo(() => {
+    const labelByKey = new Map(
       listReadableFields({
         blocks: [],
         embeddedData: embeddedFields,
         reservedEntries: [],
         contactAttributeKeys: [],
-      }).embeddedData.map(({ key, label }, index) => ({
-        key,
-        label,
-        source: embeddedFields[index].field.source,
-        dataType: embeddedFields[index].field.dataType,
-      })),
-    [embeddedFields]
-  );
+      }).embeddedData.map(({ key, label }) => [key, label] as const)
+    );
+
+    return embeddedFields.map(({ field, link }) => ({
+      key: link.storageKey,
+      // The enumerator's blank-name fallback is the key, so mirror it when a field is not listed.
+      label: labelByKey.get(link.storageKey) ?? link.storageKey,
+      source: field.source,
+      dataType: field.dataType,
+    }));
+  }, [embeddedFields]);
 
   const hiddenFieldRecallItems = useMemo(
     () =>

--- a/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
+++ b/apps/web/modules/survey/components/element-form-input/components/recall-item-select.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getSurveyEmbeddedFields, listReadableFields } from "@formbricks/types/embedded-data-resolver";
+import { getDeclaredEmbeddedFields, listReadableFields } from "@formbricks/types/embedded-data-resolver";
 import { TSurveyElement, TSurveyElementId, TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurvey, TSurveyHiddenFields, TSurveyRecallItem } from "@formbricks/types/surveys/types";
 import { getTextContent } from "@formbricks/types/surveys/validation";
@@ -83,47 +83,51 @@ export const RecallItemSelect = ({
     return recallItems.map((recallItem) => recallItem.id);
   }, [recallItems]);
 
-  // ENG-1837: both groups are enumerated from the survey's Embedded Data definitions. Only the
+  // ENG-1837: both groups are enumerated from the survey's Embedded Data definitions, derived from
+  // the editor's cards (`getDeclaredEmbeddedFields`) so a rename shows here without a reload. Only the
   // `embeddedData` group of `listReadableFields` is used — its keys and labels are exactly today's
   // (storage key / field name); the element group keeps this file's own labelling, which stores the
   // raw headline HTML and searches it through `getTextContent`.
-  const embeddedDataFields = useMemo(
+  const embeddedFields = useMemo(
+    () =>
+      getDeclaredEmbeddedFields({
+        variables: localSurvey.variables,
+        hiddenFields: localSurvey.hiddenFields,
+      }),
+    [localSurvey.variables, localSurvey.hiddenFields]
+  );
+
+  /** `[storageKey, source, label]` triples, in the definitions' own order. */
+  const embeddedFieldEntries = useMemo(
     () =>
       listReadableFields({
         blocks: [],
-        embeddedData: getSurveyEmbeddedFields(localSurvey),
+        embeddedData: embeddedFields,
         reservedEntries: [],
         contactAttributeKeys: [],
-      }).embeddedData,
-    [localSurvey]
-  );
-
-  const embeddedFieldSources = useMemo(
-    () =>
-      new Map(
-        getSurveyEmbeddedFields(localSurvey).map(({ field, link }) => [link.storageKey, field] as const)
-      ),
-    [localSurvey]
+      }).embeddedData.map(({ key, label }, index) => ({
+        key,
+        label,
+        source: embeddedFields[index].field.source,
+        dataType: embeddedFields[index].field.dataType,
+      })),
+    [embeddedFields]
   );
 
   const hiddenFieldRecallItems = useMemo(
     () =>
-      embeddedDataFields
-        .filter(
-          ({ key }) => embeddedFieldSources.get(key)?.source === "ingested" && !recallItemIds.includes(key)
-        )
+      embeddedFieldEntries
+        .filter(({ key, source }) => source === "ingested" && !recallItemIds.includes(key))
         .map(({ key, label }) => ({ id: key, label, type: "hiddenField" as const })),
-    [embeddedDataFields, embeddedFieldSources, recallItemIds]
+    [embeddedFieldEntries, recallItemIds]
   );
 
   const variableRecallItems = useMemo(
     () =>
-      embeddedDataFields
-        .filter(
-          ({ key }) => embeddedFieldSources.get(key)?.source === "computed" && !recallItemIds.includes(key)
-        )
+      embeddedFieldEntries
+        .filter(({ key, source }) => source === "computed" && !recallItemIds.includes(key))
         .map(({ key, label }) => ({ id: key, label, type: "variable" as const })),
-    [embeddedDataFields, embeddedFieldSources, recallItemIds]
+    [embeddedFieldEntries, recallItemIds]
   );
 
   const surveyElementRecallItems = useMemo(() => {
@@ -175,7 +179,8 @@ export const RecallItemSelect = ({
       case "hiddenField":
         return EyeOffIcon;
       case "variable": {
-        return embeddedFieldSources.get(recallItem.id)?.dataType === "number" ? FileDigitIcon : FileTextIcon;
+        const dataType = embeddedFieldEntries.find(({ key }) => key === recallItem.id)?.dataType;
+        return dataType === "number" ? FileDigitIcon : FileTextIcon;
       }
       default:
         return null;

--- a/apps/web/modules/survey/editor/components/logic-editor-actions.tsx
+++ b/apps/web/modules/survey/editor/components/logic-editor-actions.tsx
@@ -3,6 +3,7 @@
 import { createId } from "@paralleldrive/cuid2";
 import { CopyIcon, CornerDownRightIcon, EllipsisVerticalIcon, PlusIcon, TrashIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { getComputedEmbeddedFields } from "@formbricks/types/embedded-data-resolver";
 import {
   TSurveyBlock,
   TSurveyBlockLogic,
@@ -56,6 +57,17 @@ export function LogicEditorActions({
   const { t } = useTranslation();
 
   const blockLogic = block.logic ?? [];
+
+  /**
+   * ENG-1837: which input widget a calculate action gets is driven by the computed field's declared
+   * type, resolved through the survey's Embedded Data definitions (the editor cards while editing).
+   */
+  const getCalculateFieldType = (storageKey: string): "text" | "number" | undefined => {
+    const dataType = getComputedEmbeddedFields(localSurvey).find(({ link }) => link.storageKey === storageKey)
+      ?.field.dataType;
+    if (dataType === undefined) return undefined;
+    return dataType === "number" ? "number" : "text";
+  };
 
   const handleActionsChange = (
     operation: "remove" | "addBelow" | "duplicate" | "update",
@@ -189,10 +201,7 @@ export function LogicEditorActions({
                         id={`action-${idx}-operator`}
                         key={`operator-${action.id}`}
                         showSearch={false}
-                        options={getActionOperatorOptions(
-                          t,
-                          localSurvey.variables.find((v) => v.id === action.variableId)?.type
-                        )}
+                        options={getActionOperatorOptions(t, getCalculateFieldType(action.variableId))}
                         value={action.operator}
                         onChangeValue={(val: string | number | string[]) => {
                           handleValuesChange(idx, {
@@ -214,7 +223,7 @@ export function LogicEditorActions({
                         value={action.value?.value ?? ""}
                         inputProps={{
                           placeholder: "Value",
-                          type: localSurvey.variables.find((v) => v.id === action.variableId)?.type || "text",
+                          type: getCalculateFieldType(action.variableId) ?? "text",
                         }}
                         groupedOptions={getActionValueOptions(action.variableId, localSurvey, blockIdx, t)}
                         onChangeValue={(val, option, fromInput) => {

--- a/apps/web/modules/survey/editor/components/logic-editor-actions.tsx
+++ b/apps/web/modules/survey/editor/components/logic-editor-actions.tsx
@@ -3,7 +3,7 @@
 import { createId } from "@paralleldrive/cuid2";
 import { CopyIcon, CornerDownRightIcon, EllipsisVerticalIcon, PlusIcon, TrashIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { getComputedEmbeddedFields } from "@formbricks/types/embedded-data-resolver";
+import { getDeclaredComputedFields } from "@formbricks/types/embedded-data-resolver";
 import {
   TSurveyBlock,
   TSurveyBlockLogic,
@@ -60,10 +60,11 @@ export function LogicEditorActions({
 
   /**
    * ENG-1837: which input widget a calculate action gets is driven by the computed field's declared
-   * type, resolved through the survey's Embedded Data definitions (the editor cards while editing).
+   * type, read from the Variables card rather than the saved rows — the author may have just changed
+   * it, and the rows only catch up on save.
    */
   const getCalculateFieldType = (storageKey: string): "text" | "number" | undefined => {
-    const dataType = getComputedEmbeddedFields(localSurvey).find(({ link }) => link.storageKey === storageKey)
+    const dataType = getDeclaredComputedFields(localSurvey).find(({ link }) => link.storageKey === storageKey)
       ?.field.dataType;
     if (dataType === undefined) return undefined;
     return dataType === "number" ? "number" : "text";

--- a/apps/web/modules/survey/editor/components/survey-editor.tsx
+++ b/apps/web/modules/survey/editor/components/survey-editor.tsx
@@ -88,16 +88,12 @@ export const SurveyEditor = ({
 }: SurveyEditorProps) => {
   const [activeView, setActiveView] = useState<TSurveyEditorTabs>("elements");
   const [activeElementId, setActiveElementId] = useState<string | null>(null);
-  // ENG-1837 — **editor surfaces derive from the cards; every other surface resolves through the
-  // rows.** `localSurvey` is cloned once at mount and never re-fetched, while the EmbeddedData rows
-  // are only written on save, so an inlined `embeddedFields` would go stale the moment a variable or
-  // hidden field is edited and every editor picker, the logic builder and the editor preview would
-  // keep showing pre-edit definitions. Dropping it here makes `getSurveyEmbeddedFields` fall back to
-  // the legacy cards — which ARE the editor's live source of truth — for all of them at once.
-  const [localSurvey, setLocalSurvey] = useState<TSurvey | null>(() => {
-    const { embeddedFields: _embeddedFields, ...surveyWithoutEmbeddedFields } = survey;
-    return structuredClone(surveyWithoutEmbeddedFields);
-  });
+  // `localSurvey` must stay a structural clone of `survey`: the menu bar compares the two with
+  // `isDeepEqual` to gate the draft auto-save, the back-navigation dialog and the beforeunload
+  // prompt, and that comparison short-circuits on differing key counts. ENG-1837 therefore does NOT
+  // strip the inlined `embeddedFields` here — editor surfaces read their definitions through
+  // `getDeclaredEmbeddedFields` instead, which ignores the rows and derives from the cards.
+  const [localSurvey, setLocalSurvey] = useState<TSurvey | null>(() => structuredClone(survey));
   const [invalidElements, setInvalidElements] = useState<string[] | null>(null);
   const [hasIncompleteTranslations, setHasIncompleteTranslations] = useState(false);
 
@@ -132,6 +128,9 @@ export const SurveyEditor = ({
     if (survey) {
       if (localSurvey) return;
 
+      // Must stay identical to the `useState` initializer above: the working copy is compared
+      // against `survey` key-for-key by the menu bar, so any reshaping has to apply to both or
+      // neither. (Unreachable today — the initializer never yields null.)
       const surveyClone = structuredClone(survey);
       setLocalSurvey(surveyClone);
 

--- a/apps/web/modules/survey/editor/components/survey-editor.tsx
+++ b/apps/web/modules/survey/editor/components/survey-editor.tsx
@@ -88,7 +88,16 @@ export const SurveyEditor = ({
 }: SurveyEditorProps) => {
   const [activeView, setActiveView] = useState<TSurveyEditorTabs>("elements");
   const [activeElementId, setActiveElementId] = useState<string | null>(null);
-  const [localSurvey, setLocalSurvey] = useState<TSurvey | null>(() => structuredClone(survey));
+  // ENG-1837 — **editor surfaces derive from the cards; every other surface resolves through the
+  // rows.** `localSurvey` is cloned once at mount and never re-fetched, while the EmbeddedData rows
+  // are only written on save, so an inlined `embeddedFields` would go stale the moment a variable or
+  // hidden field is edited and every editor picker, the logic builder and the editor preview would
+  // keep showing pre-edit definitions. Dropping it here makes `getSurveyEmbeddedFields` fall back to
+  // the legacy cards — which ARE the editor's live source of truth — for all of them at once.
+  const [localSurvey, setLocalSurvey] = useState<TSurvey | null>(() => {
+    const { embeddedFields: _embeddedFields, ...surveyWithoutEmbeddedFields } = survey;
+    return structuredClone(surveyWithoutEmbeddedFields);
+  });
   const [invalidElements, setInvalidElements] = useState<string[] | null>(null);
   const [hasIncompleteTranslations, setHasIncompleteTranslations] = useState(false);
 

--- a/apps/web/modules/survey/editor/lib/utils.tsx
+++ b/apps/web/modules/survey/editor/lib/utils.tsx
@@ -1,7 +1,10 @@
 import { TFunction } from "i18next";
 import { EyeOffIcon, FileDigitIcon, FileType2Icon } from "lucide-react";
 import { HTMLInputTypeAttribute, JSX } from "react";
-import { getComputedEmbeddedFields, getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
+import {
+  getDeclaredComputedFields,
+  getDeclaredIngestedStorageKeys,
+} from "@formbricks/types/embedded-data-resolver";
 import { TI18nString } from "@formbricks/types/i18n";
 import { TSurveyQuota } from "@formbricks/types/quota";
 import { TSurveyBlockLogic, TSurveyBlockLogicAction } from "@formbricks/types/surveys/blocks";
@@ -140,9 +143,9 @@ const getElementHeadline = (
  * filters on an id/name/type triple, so the definitions are adapted to that shape once here rather
  * than reshaped at each of the five pickers below.
  *
- * In the editor the legacy cards are still the live source of truth — `survey-editor.tsx` drops the
- * inlined `embeddedFields` for exactly that reason — so this resolves off the cards while the survey
- * is being edited, and off the rows everywhere else.
+ * Sourced from `getDeclaredEmbeddedFields`, which derives from the Variables and Hidden Fields cards
+ * and ignores the saved rows — in the editor the cards are the live source of truth, and the rows
+ * only catch up on save.
  */
 interface TComputedFieldOption {
   id: string;
@@ -151,7 +154,7 @@ interface TComputedFieldOption {
 }
 
 const getComputedFieldOptions = (localSurvey: TSurvey): TComputedFieldOption[] =>
-  getComputedEmbeddedFields(localSurvey).map(({ field, link }) => ({
+  getDeclaredComputedFields(localSurvey).map(({ field, link }) => ({
     id: link.storageKey,
     name: field.name,
     type: field.dataType === "number" ? "number" : "text",
@@ -162,7 +165,7 @@ export const getConditionValueOptions = (
   t: TFunction,
   blockIdx?: number // Optional - if provided, includes elements from this block and all previous blocks
 ): TComboboxGroupedOption[] => {
-  const hiddenFields = getIngestedStorageKeys(localSurvey);
+  const hiddenFields = getDeclaredIngestedStorageKeys(localSurvey);
   const variables = getComputedFieldOptions(localSurvey);
 
   // If blockIdx is provided, get elements from current block and all previous blocks
@@ -413,7 +416,7 @@ export const getMatchValueProps = (
           .flatMap((block) => block.elements);
 
   let variables = getComputedFieldOptions(localSurvey);
-  let hiddenFields = getIngestedStorageKeys(localSurvey);
+  let hiddenFields = getDeclaredIngestedStorageKeys(localSurvey);
 
   const selectedElement = elements.find((element) => element.id === condition.leftOperand.value);
   const selectedVariable = variables.find((variable) => variable.id === condition.leftOperand.value);
@@ -1139,7 +1142,7 @@ export const getActionValueOptions = (
   const allElements = localSurvey.blocks
     .slice(0, blockIdx + 1) // Include blocks from 0 to blockIdx (inclusive)
     .flatMap((block) => block.elements);
-  const hiddenFields = getIngestedStorageKeys(localSurvey);
+  const hiddenFields = getDeclaredIngestedStorageKeys(localSurvey);
   let variables = getComputedFieldOptions(localSurvey);
 
   const hiddenFieldsOptions = hiddenFields.map((field) => {

--- a/apps/web/modules/survey/editor/lib/utils.tsx
+++ b/apps/web/modules/survey/editor/lib/utils.tsx
@@ -1,6 +1,7 @@
 import { TFunction } from "i18next";
 import { EyeOffIcon, FileDigitIcon, FileType2Icon } from "lucide-react";
 import { HTMLInputTypeAttribute, JSX } from "react";
+import { getComputedEmbeddedFields, getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
 import { TI18nString } from "@formbricks/types/i18n";
 import { TSurveyQuota } from "@formbricks/types/quota";
 import { TSurveyBlockLogic, TSurveyBlockLogicAction } from "@formbricks/types/surveys/blocks";
@@ -134,13 +135,35 @@ const getElementHeadline = (
   return getTSurveyElementTypeEnumName(element.type, t) ?? "";
 };
 
+/**
+ * ENG-1837: the editor's view of one computed Embedded Data field. The logic builder renders and
+ * filters on an id/name/type triple, so the definitions are adapted to that shape once here rather
+ * than reshaped at each of the five pickers below.
+ *
+ * In the editor the legacy cards are still the live source of truth — `survey-editor.tsx` drops the
+ * inlined `embeddedFields` for exactly that reason — so this resolves off the cards while the survey
+ * is being edited, and off the rows everywhere else.
+ */
+interface TComputedFieldOption {
+  id: string;
+  name: string;
+  type: "text" | "number";
+}
+
+const getComputedFieldOptions = (localSurvey: TSurvey): TComputedFieldOption[] =>
+  getComputedEmbeddedFields(localSurvey).map(({ field, link }) => ({
+    id: link.storageKey,
+    name: field.name,
+    type: field.dataType === "number" ? "number" : "text",
+  }));
+
 export const getConditionValueOptions = (
   localSurvey: TSurvey,
   t: TFunction,
   blockIdx?: number // Optional - if provided, includes elements from this block and all previous blocks
 ): TComboboxGroupedOption[] => {
-  const hiddenFields = localSurvey.hiddenFields?.fieldIds ?? [];
-  const variables = localSurvey.variables ?? [];
+  const hiddenFields = getIngestedStorageKeys(localSurvey);
+  const variables = getComputedFieldOptions(localSurvey);
 
   // If blockIdx is provided, get elements from current block and all previous blocks
   // Otherwise, get all elements from all blocks
@@ -326,7 +349,7 @@ export const getConditionOperatorOptions = (
   t: TFunction
 ): TComboboxOption[] => {
   if (condition.leftOperand.type === "variable") {
-    const variables = localSurvey.variables ?? [];
+    const variables = getComputedFieldOptions(localSurvey);
     const variableType =
       variables.find((variable) => variable.id === condition.leftOperand.value)?.type || "text";
     return getLogicRules(t)[`variable.${variableType}`].options;
@@ -389,8 +412,8 @@ export const getMatchValueProps = (
           .slice(0, blockIdx + 1) // Include blocks from 0 to blockIdx (inclusive)
           .flatMap((block) => block.elements);
 
-  let variables = localSurvey.variables ?? [];
-  let hiddenFields = localSurvey.hiddenFields?.fieldIds ?? [];
+  let variables = getComputedFieldOptions(localSurvey);
+  let hiddenFields = getIngestedStorageKeys(localSurvey);
 
   const selectedElement = elements.find((element) => element.id === condition.leftOperand.value);
   const selectedVariable = variables.find((variable) => variable.id === condition.leftOperand.value);
@@ -1050,7 +1073,7 @@ export const getActionTargetOptions = (
 };
 
 export const getActionVariableOptions = (localSurvey: TSurvey): TComboboxOption[] => {
-  const variables = localSurvey.variables ?? [];
+  const variables = getComputedFieldOptions(localSurvey);
 
   return variables.map((variable) => {
     return {
@@ -1116,8 +1139,8 @@ export const getActionValueOptions = (
   const allElements = localSurvey.blocks
     .slice(0, blockIdx + 1) // Include blocks from 0 to blockIdx (inclusive)
     .flatMap((block) => block.elements);
-  const hiddenFields = localSurvey.hiddenFields?.fieldIds ?? [];
-  let variables = localSurvey.variables ?? [];
+  const hiddenFields = getIngestedStorageKeys(localSurvey);
+  let variables = getComputedFieldOptions(localSurvey);
 
   const hiddenFieldsOptions = hiddenFields.map((field) => {
     return {

--- a/apps/web/modules/survey/follow-ups/components/follow-up-item.tsx
+++ b/apps/web/modules/survey/follow-ups/components/follow-up-item.tsx
@@ -4,6 +4,7 @@ import { createId } from "@paralleldrive/cuid2";
 import { CopyIcon, Trash2Icon } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurveyFollowUp } from "@formbricks/types/surveys/follow-up";
 import { TSurvey } from "@formbricks/types/surveys/types";
@@ -70,8 +71,17 @@ export const FollowUpItem = ({
       return false;
     });
 
+    // ENG-1837: the id list comes from the Embedded Data definitions, but the `enabled` gate stays.
+    // `deriveLegacyEmbeddedData` ignores `hiddenFields.enabled` by design and TLinkedEmbeddedField
+    // carries no equivalent, and this is the one reader that consults the flag — reading it here is a
+    // flag read, not a field-list read, so it keeps this recipient label behaving exactly as before.
     const matchedHiddenField = localSurvey.hiddenFields?.enabled
-      ? (localSurvey.hiddenFields.fieldIds ?? []).find((fieldId) => fieldId === to)
+      ? getIngestedStorageKeys({
+          // The two slices the ingested list can come from, passed individually so this memo keeps
+          // depending on them rather than on the whole survey object.
+          hiddenFields: localSurvey.hiddenFields,
+          embeddedFields: localSurvey.embeddedFields,
+        }).find((storageKey) => storageKey === to)
       : undefined;
 
     const updatedTeamMemberDetails = teamMemberDetails.map((teamMemberDetail) => {
@@ -95,8 +105,8 @@ export const FollowUpItem = ({
     return !matchedQuestion && !matchedHiddenField && !matchedEmail;
   }, [
     followUp.action.properties,
-    localSurvey.hiddenFields?.enabled,
-    localSurvey.hiddenFields?.fieldIds,
+    localSurvey.hiddenFields,
+    localSurvey.embeddedFields,
     localSurvey.blocks,
     teamMemberDetails,
     userEmail,
@@ -156,7 +166,7 @@ export const FollowUpItem = ({
           </div>
         </button>
 
-        <div className="absolute right-4 top-4 flex items-center">
+        <div className="absolute top-4 right-4 flex items-center">
           <TooltipRenderer tooltipContent={t("common.delete")}>
             <Button
               variant="ghost"

--- a/apps/web/modules/survey/follow-ups/components/follow-up-item.tsx
+++ b/apps/web/modules/survey/follow-ups/components/follow-up-item.tsx
@@ -4,7 +4,7 @@ import { createId } from "@paralleldrive/cuid2";
 import { CopyIcon, Trash2Icon } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
+import { getDeclaredIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import { TSurveyFollowUp } from "@formbricks/types/surveys/follow-up";
 import { TSurvey } from "@formbricks/types/surveys/types";
@@ -76,12 +76,12 @@ export const FollowUpItem = ({
     // carries no equivalent, and this is the one reader that consults the flag — reading it here is a
     // flag read, not a field-list read, so it keeps this recipient label behaving exactly as before.
     const matchedHiddenField = localSurvey.hiddenFields?.enabled
-      ? getIngestedStorageKeys({
-          // The two slices the ingested list can come from, passed individually so this memo keeps
-          // depending on them rather than on the whole survey object.
-          hiddenFields: localSurvey.hiddenFields,
-          embeddedFields: localSurvey.embeddedFields,
-        }).find((storageKey) => storageKey === to)
+      ? // Editor surface: the ids come from the Hidden Fields card, not the saved rows. Only the
+        // slice that feeds it is passed, so this memo keeps depending on it rather than on the whole
+        // survey object.
+        getDeclaredIngestedStorageKeys({ hiddenFields: localSurvey.hiddenFields }).find(
+          (storageKey) => storageKey === to
+        )
       : undefined;
 
     const updatedTeamMemberDetails = teamMemberDetails.map((teamMemberDetail) => {
@@ -106,7 +106,6 @@ export const FollowUpItem = ({
   }, [
     followUp.action.properties,
     localSurvey.hiddenFields,
-    localSurvey.embeddedFields,
     localSurvey.blocks,
     teamMemberDetails,
     userEmail,

--- a/apps/web/modules/survey/follow-ups/lib/email-send-to-options.ts
+++ b/apps/web/modules/survey/follow-ups/lib/email-send-to-options.ts
@@ -1,4 +1,5 @@
 import type { TFunction } from "i18next";
+import { getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import type { TSurvey } from "@formbricks/types/surveys/types";
 import { getTextContent } from "@formbricks/types/surveys/validation";
@@ -48,7 +49,7 @@ export const buildEmailSendToOptions = ({
     return false;
   });
 
-  const hiddenFieldIds = survey.hiddenFields.fieldIds ?? [];
+  const hiddenFieldIds = getIngestedStorageKeys(survey);
 
   const updatedTeamMemberDetails = teamMemberDetails.map((teamMemberDetail) =>
     teamMemberDetail.email === userEmail ? { name: "Yourself", email: userEmail } : teamMemberDetail

--- a/apps/web/modules/survey/follow-ups/lib/email-send-to-options.ts
+++ b/apps/web/modules/survey/follow-ups/lib/email-send-to-options.ts
@@ -1,5 +1,5 @@
 import type { TFunction } from "i18next";
-import { getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
+import { getDeclaredIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
 import type { TSurvey } from "@formbricks/types/surveys/types";
 import { getTextContent } from "@formbricks/types/surveys/validation";
@@ -49,7 +49,10 @@ export const buildEmailSendToOptions = ({
     return false;
   });
 
-  const hiddenFieldIds = getIngestedStorageKeys(survey);
+  // Authoring surface (the editor's Follow-Ups tab and the workflow email inspector), so the ids come
+  // from the Hidden Fields card rather than the saved rows — the picker that WRITES a recipient and
+  // `follow-up-item.tsx`, which renders the stored one back, must agree on the same instant.
+  const hiddenFieldIds = getDeclaredIngestedStorageKeys(survey);
 
   const updatedTeamMemberDetails = teamMemberDetails.map((teamMemberDetail) =>
     teamMemberDetail.email === userEmail ? { name: "Yourself", email: userEmail } : teamMemberDetail

--- a/apps/web/modules/survey/lib/survey.ts
+++ b/apps/web/modules/survey/lib/survey.ts
@@ -4,6 +4,7 @@ import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TOrganizationBilling } from "@formbricks/types/organizations";
 import { TSurvey } from "@formbricks/types/surveys/types";
+import { selectSurveyEmbeddedDataLinks } from "@/lib/embedded-data/survey-fields";
 import { getOrganizationBillingWithReadThroughSync } from "@/modules/ee/billing/lib/organization-billing";
 import { transformPrismaSurvey } from "@/modules/survey/lib/utils";
 
@@ -99,6 +100,9 @@ export const selectSurvey = {
     },
   },
   followUps: true,
+  // ENG-1837: the definitions every reader resolves through, joined and inlined by
+  // `transformPrismaSurvey`. Read-only — the rows are written by `reconcileEmbeddedData`.
+  embeddedDataLinks: selectSurveyEmbeddedDataLinks,
 } satisfies Prisma.SurveySelect;
 
 export const getOrganizationBilling = reactCache(

--- a/apps/web/modules/survey/lib/utils.ts
+++ b/apps/web/modules/survey/lib/utils.ts
@@ -3,6 +3,7 @@ import { Prisma } from "@formbricks/database/prisma";
 import { TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { TSegment } from "@formbricks/types/segment";
 import { TSurvey, TSurveyFilterCriteria } from "@formbricks/types/surveys/types";
+import { withInlinedEmbeddedFields } from "@/lib/embedded-data/survey-fields";
 
 export const transformPrismaSurvey = <T extends TSurvey | TJsWorkspaceStateSurvey>(surveyPrisma: any): T => {
   let segment: TSegment | null = null;
@@ -15,7 +16,10 @@ export const transformPrismaSurvey = <T extends TSurvey | TJsWorkspaceStateSurve
   }
 
   const transformedSurvey = {
-    ...surveyPrisma,
+    // ENG-1837: swaps the raw `embeddedDataLinks` relation for the inlined `embeddedFields` the read
+    // seam consumes, so the Prisma relation shape never leaks onto TSurvey. A no-op for surveys read
+    // through a select without the join — those fall back to their legacy columns in the accessor.
+    ...withInlinedEmbeddedFields(surveyPrisma),
     displayPercentage: Number(surveyPrisma.displayPercentage) || null,
     segment,
     customHeadScriptsMode: surveyPrisma.customHeadScriptsMode,

--- a/apps/web/modules/survey/link/lib/data.ts
+++ b/apps/web/modules/survey/link/lib/data.ts
@@ -4,6 +4,7 @@ import { prisma } from "@formbricks/database";
 import { Prisma } from "@formbricks/database/prisma";
 import { DatabaseError, ResourceNotFoundError } from "@formbricks/types/errors";
 import { TSurvey } from "@formbricks/types/surveys/types";
+import { selectSurveyEmbeddedDataLinks } from "@/lib/embedded-data/survey-fields";
 import { getOrganizationBillingWithReadThroughSync } from "@/modules/ee/billing/lib/organization-billing";
 import { transformPrismaSurvey } from "@/modules/survey/lib/utils";
 
@@ -118,6 +119,9 @@ export const getSurveyWithMetadata = reactCache(async (surveyId: string) => {
           },
         },
         followUps: true,
+
+        // ENG-1837: the definitions the renderer's recall and logic engines resolve through.
+        embeddedDataLinks: selectSurveyEmbeddedDataLinks,
       },
     });
 

--- a/apps/web/modules/survey/list/lib/survey.ts
+++ b/apps/web/modules/survey/list/lib/survey.ts
@@ -541,11 +541,12 @@ export const copySurveyToOtherWorkspace = async (
         return createdSurvey;
       },
       // This create was untransacted before ENG-1978, so wrapping it introduced Prisma's 5s
-      // interactive-transaction ceiling where there had been none. It is the deepest of the three
-      // reconcile call sites — it clones blocks, endings, the welcome card, variables, hidden fields,
-      // follow-ups and quotas, and resolves an action class per trigger through `connectOrCreate` —
-      // so a large survey could plausibly reach it and fail a copy that used to succeed. Matches the
-      // ceiling on `updateSurveyInternal` for the same reason.
+      // interactive-transaction ceiling where there had been none. It is the deepest of the
+      // reconcile call sites (enumerated on `getDeclaredEmbeddedFields`) — it clones blocks, endings,
+      // the welcome card, variables, hidden fields, follow-ups and quotas, and resolves an action
+      // class per trigger through `connectOrCreate` — so a large survey could plausibly reach it and
+      // fail a copy that used to succeed. Matches the ceiling on `updateSurveyInternal` for the same
+      // reason.
       { timeout: 20_000, maxWait: 10_000 }
     );
 

--- a/apps/web/modules/ui/components/preview-survey/index.tsx
+++ b/apps/web/modules/ui/components/preview-survey/index.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Workspace } from "@formbricks/database/prisma-browser";
 import { getLanguageLabel } from "@formbricks/i18n-utils/src/utils";
+import { getDeclaredEmbeddedFields } from "@formbricks/types/embedded-data-resolver";
 import { getLinkSurveyCardMaxWidth } from "@formbricks/types/styling";
 import { TSurvey, TSurveyLanguage, TSurveyStyling } from "@formbricks/types/surveys/types";
 import { TUserLocale } from "@formbricks/types/user";
@@ -54,6 +55,21 @@ export const PreviewSurvey = ({
   isSpamProtectionAllowed,
   publicDomain,
 }: PreviewSurveyProps) => {
+  // ENG-1837: the preview is an authoring surface — the Variables and Hidden Fields cards are the
+  // live source of truth, and the saved EmbeddedData rows only catch up on save. Overriding the
+  // inlined definitions with the card-derived ones is what makes a rename or a new field show up in
+  // the preview's recall and logic on the next render, without a reload.
+  const previewSurvey = useMemo(
+    () => ({
+      ...survey,
+      embeddedFields: getDeclaredEmbeddedFields({
+        variables: survey.variables,
+        hiddenFields: survey.hiddenFields,
+      }),
+    }),
+    [survey]
+  );
+
   const [isModalOpen, setIsModalOpen] = useState(true);
   const [isFullScreenPreview, setIsFullScreenPreview] = useState(false);
   const { t } = useTranslation();
@@ -275,7 +291,7 @@ export const PreviewSurvey = ({
                     <SurveyInline
                       appUrl={publicDomain}
                       isPreviewMode={true}
-                      survey={toJsWorkspaceStateSurvey(survey)}
+                      survey={toJsWorkspaceStateSurvey(previewSurvey)}
                       isBrandingEnabled={workspace.inAppSurveyBranding}
                       isRedirectDisabled={true}
                       languageCode={languageCode}
@@ -323,7 +339,7 @@ export const PreviewSurvey = ({
                           appUrl={publicDomain}
                           isPreviewMode={true}
                           isBrandingEnabled={workspace.linkSurveyBranding}
-                          survey={toJsWorkspaceStateSurvey({ ...survey, type: "link" })}
+                          survey={toJsWorkspaceStateSurvey({ ...previewSurvey, type: "link" })}
                           isRedirectDisabled={true}
                           languageCode={languageCode}
                           responseCount={42}
@@ -409,7 +425,7 @@ export const PreviewSurvey = ({
                   <SurveyInline
                     appUrl={publicDomain}
                     isPreviewMode={true}
-                    survey={toJsWorkspaceStateSurvey(survey)}
+                    survey={toJsWorkspaceStateSurvey(previewSurvey)}
                     isBrandingEnabled={workspace.inAppSurveyBranding}
                     isRedirectDisabled={true}
                     languageCode={languageCode}
@@ -464,7 +480,7 @@ export const PreviewSurvey = ({
                         <SurveyInline
                           appUrl={publicDomain}
                           isPreviewMode={true}
-                          survey={toJsWorkspaceStateSurvey({ ...survey, type: "link" })}
+                          survey={toJsWorkspaceStateSurvey({ ...previewSurvey, type: "link" })}
                           isBrandingEnabled={workspace.linkSurveyBranding}
                           isRedirectDisabled={true}
                           languageCode={languageCode}

--- a/apps/web/playwright/survey-editor-embedded-fields.spec.ts
+++ b/apps/web/playwright/survey-editor-embedded-fields.spec.ts
@@ -1,0 +1,311 @@
+import { type Locator, type Page, expect } from "@playwright/test";
+import { prisma } from "@formbricks/database";
+import { test } from "./lib/fixtures";
+import { createSurveyFromScratch, fillRichTextEditor } from "./utils/helper";
+
+/**
+ * Embedded Data definitions in the survey editor (ENG-1837).
+ *
+ * The `EmbeddedData` / `SurveyEmbeddedData` tables are the read source of truth for Embedded Data
+ * definitions (variables + hidden fields): readers resolve through the `embeddedFields` list inlined
+ * onto the survey at load instead of reading `survey.variables` / `survey.hiddenFields`. The editor
+ * is the one surface where those rows must NOT win: `localSurvey` is cloned once at mount and never
+ * re-fetched, while the rows are only rewritten on save — so a reader resolving through them would
+ * show pre-edit definitions until a reload.
+ *
+ * That regression is invisible on a survey with no rows (an empty inlined list falls back to the
+ * cards anyway), so this spec deliberately saves first and reloads: from there on, `localSurvey`
+ * carries real rows and every assertion below can tell "derived from the cards" apart from
+ * "resolved through the rows".
+ */
+
+const QUESTION_HEADLINE = "Which plan are you on?";
+const VARIABLE_NAME_PLACEHOLDER = "Field name e.g, score, price";
+
+/**
+ * Safe-identifier names (lowercase letters, digits and underscores, leading letter) with a random
+ * suffix, so an assertion can never match a name another run left behind.
+ */
+const uniqueName = (prefix: string): string => `${prefix}_${Math.random().toString(36).slice(2, 8)}`;
+
+/** The editor's left panel. Scoping to it keeps the live preview's copies of the same text out. */
+const editorPanel = (page: Page): Locator => page.getByRole("main");
+
+/** Same label -> container walk as `fillRichTextEditor` (utils/helper.ts). */
+const headlineEditor = (page: Page): Locator =>
+  editorPanel(page).locator('label:has-text("Question*")').locator("..").locator("..");
+
+/** The Variables card's forms in card order — one per variable, then the "create" form last. */
+const variableForms = (page: Page): Locator =>
+  editorPanel(page)
+    .locator("form")
+    .filter({ has: page.getByPlaceholder(VARIABLE_NAME_PLACEHOLDER) });
+
+/**
+ * Opens one of the editor's collapsible cards. Only one card is open at a time, so opening is
+ * expressed as "click until its content is on screen": the click is a toggle, and asserting on the
+ * content first keeps that idempotent whichever card was open before.
+ */
+const openCard = async (page: Page, name: "Variables" | "Hidden fields"): Promise<void> => {
+  const content =
+    name === "Variables"
+      ? editorPanel(page).getByRole("button", { name: "Add variable", exact: true })
+      : editorPanel(page).locator("#hiddenField");
+
+  await expect(async () => {
+    if (!(await content.isVisible())) {
+      await editorPanel(page).getByText(name, { exact: true }).click();
+    }
+    await expect(content).toBeVisible({ timeout: 5000 });
+  }).toPass({ timeout: 30000 });
+};
+
+/**
+ * Picks a variable's type and commits it. The card's edit forms submit on blur, so leaving the
+ * select is what writes the change into `localSurvey`.
+ */
+const selectVariableType = async (page: Page, form: Locator, type: "Text" | "Number"): Promise<void> => {
+  await form.getByRole("combobox").click();
+  await page.getByRole("option", { name: type, exact: true }).click();
+  const valueInput = form.getByPlaceholder("Initial value");
+  await valueInput.click();
+  await valueInput.press("Tab");
+};
+
+const addVariable = async (page: Page, name: string, type: "Text" | "Number"): Promise<void> => {
+  const existingCount = await variableForms(page).count();
+  const createForm = variableForms(page).last();
+
+  await createForm.getByPlaceholder(VARIABLE_NAME_PLACEHOLDER).fill(name);
+  await selectVariableType(page, createForm, type);
+  await createForm.getByRole("button", { name: "Add variable", exact: true }).click();
+
+  // The create form resets and the new variable renders its own edit form above it.
+  await expect(variableForms(page)).toHaveCount(existingCount + 1);
+  await expect(variableForms(page).first().getByPlaceholder(VARIABLE_NAME_PLACEHOLDER)).toHaveValue(name);
+};
+
+const renameVariable = async (page: Page, from: string, to: string): Promise<void> => {
+  const form = variableForms(page).first();
+  const nameInput = form.getByPlaceholder(VARIABLE_NAME_PLACEHOLDER);
+
+  await expect(nameInput).toHaveValue(from);
+  await nameInput.fill(to);
+  // Blur commits the rename — the edit forms have no submit button.
+  await nameInput.press("Tab");
+  await expect(nameInput).toHaveValue(to);
+};
+
+const addHiddenField = async (page: Page, name: string): Promise<void> => {
+  await openCard(page, "Hidden fields");
+  await editorPanel(page).locator("#hiddenField").fill(name);
+  await editorPanel(page).getByRole("button", { name: "Add hidden field ID", exact: true }).click();
+  await expect(editorPanel(page).getByText(name, { exact: true })).toBeVisible();
+};
+
+/** Opens the element card if it is collapsed — same click-until-open shape as {@link openCard}. */
+const openQuestionCard = async (page: Page, heading = QUESTION_HEADLINE): Promise<void> => {
+  const questionLabel = editorPanel(page).locator('label:has-text("Question*")');
+
+  await expect(async () => {
+    if (!(await questionLabel.isVisible())) {
+      await editorPanel(page).getByRole("heading", { name: heading }).click();
+    }
+    await expect(questionLabel).toBeVisible({ timeout: 5000 });
+  }).toPass({ timeout: 30000 });
+};
+
+/**
+ * Opens the recall picker on the question headline. Both entry points are covered: the `@` key the
+ * ticket names, and the editor toolbar's "Recall data" button.
+ */
+const openRecallPicker = async (page: Page, via: "at-key" | "toolbar"): Promise<Locator> => {
+  await openQuestionCard(page);
+
+  if (via === "at-key") {
+    const input = headlineEditor(page).locator(".editor-input").first();
+    await input.click();
+    await input.press("End");
+    await input.press("@");
+  } else {
+    await headlineEditor(page).getByRole("button", { name: "Recall data", exact: true }).click();
+  }
+
+  const picker = page.locator("[data-recall-dropdown]");
+  await expect(picker).toBeVisible();
+  return picker;
+};
+
+const closeRecallPicker = async (page: Page): Promise<void> => {
+  await page.keyboard.press("Escape");
+  await expect(page.locator("[data-recall-dropdown]")).toBeHidden();
+};
+
+const recallItem = (picker: Locator, name: string): Locator =>
+  picker.getByRole("menuitem", { name, exact: true });
+
+/** Opens the block's conditional logic, adding the first rule when the block has none yet. */
+const openBlockLogic = async (page: Page): Promise<void> => {
+  await openQuestionCard(page);
+
+  const showSettings = editorPanel(page).getByText("Show Block settings", { exact: true });
+  if (await showSettings.isVisible().catch(() => false)) {
+    await showSettings.click();
+  }
+  await expect(editorPanel(page).getByText("Hide Block settings", { exact: true })).toBeVisible();
+
+  const firstConditionOperand = page.locator("#condition-0-0-conditionValue");
+  if (await firstConditionOperand.isVisible().catch(() => false)) return;
+
+  const logicSection = editorPanel(page).getByRole("button", { name: "Conditional Logic" });
+  if (await logicSection.isVisible().catch(() => false)) {
+    await logicSection.click();
+  } else {
+    await editorPanel(page).locator("#logicJumps").click();
+  }
+  await expect(firstConditionOperand).toBeVisible();
+};
+
+const openCombobox = async (page: Page, id: string): Promise<Locator> => {
+  await page.locator(`#${id}`).click();
+  const menu = page.getByTestId("dropdown-menu-content");
+  await expect(menu).toBeVisible();
+  return menu;
+};
+
+const closeCombobox = async (page: Page): Promise<void> => {
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("dropdown-menu-content")).toBeHidden();
+};
+
+const saveDraft = async (page: Page): Promise<void> => {
+  await page.getByRole("button", { name: "Save as draft", exact: true }).click({ noWaitAfter: true });
+  await expect(page.getByText("Changes saved.", { exact: true })).toBeVisible();
+};
+
+test.describe("Survey editor Embedded Data definitions @slow", () => {
+  test.setTimeout(1000 * 60 * 3);
+
+  test("card edits reach the recall, logic and calculate pickers without a reload", async ({
+    page,
+    users,
+  }) => {
+    const variableName = uniqueName("var_alpha");
+    const renamedVariableName = uniqueName("var_beta");
+    const staleRowName = uniqueName("var_stale");
+    const firstHiddenField = uniqueName("hidden_one");
+    const secondHiddenField = uniqueName("hidden_two");
+
+    const user = await users.create();
+    await user.login();
+    await page.waitForURL(/\/workspaces\/[^/]+\/surveys/);
+    const surveyId = await createSurveyFromScratch(page);
+
+    await openQuestionCard(page, "What would you like to know?");
+    await fillRichTextEditor(page, "Question*", QUESTION_HEADLINE);
+
+    // A text variable and a hidden field, declared on the legacy cards.
+    await openCard(page, "Variables");
+    await addVariable(page, variableName, "Text");
+    await addHiddenField(page, firstHiddenField);
+
+    // Persist them, which is what writes the EmbeddedData rows, then reload so the editor mounts
+    // with those rows inlined on the survey. Everything below is asserted against that state — the
+    // only one in which "reads the rows" and "derives from the cards" can disagree.
+    await saveDraft(page);
+    expect(await prisma.surveyEmbeddedData.count({ where: { surveyId } })).toBe(2);
+
+    // Force that disagreement rather than waiting for it: the saved row is edited behind the
+    // editor's back so it claims a different name and a different type than the card does. This is
+    // what an editor reader resolving through the rows would show, so every card-derived assertion
+    // below now has something to be wrong about.
+    const staleRowUpdate = await prisma.embeddedData.updateMany({
+      where: { surveyId, source: "computed" },
+      data: { name: staleRowName, dataType: "number" },
+    });
+    expect(staleRowUpdate.count).toBe(1);
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(editorPanel(page).getByRole("heading", { name: QUESTION_HEADLINE })).toBeVisible();
+    // The editor really was handed that row: the survey reaches this client component as a
+    // serialized prop, so the stale name is in the payload even though no picker may show it.
+    // Without this the assertions below could pass for the wrong reason (rows never inlined at all).
+    expect(
+      (await page.content()).includes(staleRowName),
+      "the editor page should carry the diverging row in its serialized survey prop"
+    ).toBe(true);
+
+    // Baseline: the cards' definitions are offered, not the rows'.
+    const pickerBeforeEdit = await openRecallPicker(page, "at-key");
+    await expect(recallItem(pickerBeforeEdit, variableName)).toHaveAttribute("title", "variable");
+    await expect(recallItem(pickerBeforeEdit, firstHiddenField)).toHaveAttribute("title", "hiddenField");
+    await expect(recallItem(pickerBeforeEdit, staleRowName)).toHaveCount(0);
+    await closeRecallPicker(page);
+
+    await openBlockLogic(page);
+    const operandsBeforeEdit = await openCombobox(page, "condition-0-0-conditionValue");
+    await expect(operandsBeforeEdit.getByRole("option", { name: variableName, exact: true })).toBeVisible();
+    await expect(operandsBeforeEdit.getByRole("option", { name: staleRowName, exact: true })).toHaveCount(0);
+    await operandsBeforeEdit.getByRole("option", { name: firstHiddenField, exact: true }).click();
+
+    await openCombobox(page, "action-0-objective");
+    await page.getByRole("option", { name: "Calculate", exact: true }).click();
+    const variablesBeforeEdit = await openCombobox(page, "action-0-variableId");
+    await variablesBeforeEdit.getByRole("option", { name: variableName, exact: true }).click();
+    // The card says text while the row says number, so this is the card's answer.
+    await expect(page.locator("#action-0-value-input")).toHaveAttribute("type", "text");
+
+    // Edit the definitions through the legacy cards: rename the variable, retype it to a number,
+    // and declare a second hidden field. None of this touches the saved rows.
+    await openCard(page, "Variables");
+    await renameVariable(page, variableName, renamedVariableName);
+    await selectVariableType(page, variableForms(page).first(), "Number");
+    await addHiddenField(page, secondHiddenField);
+
+    // Recall picker: the new name and the new hidden field, and no trace of the stale one.
+    const pickerAfterEdit = await openRecallPicker(page, "toolbar");
+    await expect(recallItem(pickerAfterEdit, renamedVariableName)).toHaveAttribute("title", "variable");
+    await expect(recallItem(pickerAfterEdit, secondHiddenField)).toHaveAttribute("title", "hiddenField");
+    await expect(recallItem(pickerAfterEdit, variableName)).toHaveCount(0);
+    await closeRecallPicker(page);
+
+    // Logic operand picker: same, live.
+    await openBlockLogic(page);
+    const operandsAfterEdit = await openCombobox(page, "condition-0-0-conditionValue");
+    await expect(
+      operandsAfterEdit.getByRole("option", { name: renamedVariableName, exact: true })
+    ).toBeVisible();
+    await expect(
+      operandsAfterEdit.getByRole("option", { name: secondHiddenField, exact: true })
+    ).toBeVisible();
+    await expect(operandsAfterEdit.getByRole("option", { name: variableName, exact: true })).toHaveCount(0);
+    await closeCombobox(page);
+
+    // Calculate action: still bound to the same field (renaming keeps its id), now labelled with the
+    // new name, and its value widget follows the field's new type.
+    await expect(page.locator("#action-0-variableId")).toContainText(renamedVariableName);
+    await expect(page.locator("#action-0-value-input")).toHaveAttribute("type", "number");
+
+    // The edits survive a save and a reload, and the save is also what makes the rows catch up:
+    // the deliberately stale row is rewritten from the card it belongs to.
+    await saveDraft(page);
+    expect(await prisma.surveyEmbeddedData.count({ where: { surveyId } })).toBe(3);
+    expect(await prisma.embeddedData.findFirst({ where: { surveyId, source: "computed" } })).toMatchObject({
+      name: renamedVariableName,
+      dataType: "number",
+    });
+    await page.reload({ waitUntil: "domcontentloaded" });
+
+    await openCard(page, "Variables");
+    await expect(variableForms(page).first().getByPlaceholder(VARIABLE_NAME_PLACEHOLDER)).toHaveValue(
+      renamedVariableName
+    );
+    await openCard(page, "Hidden fields");
+    await expect(editorPanel(page).getByText(firstHiddenField, { exact: true })).toBeVisible();
+    await expect(editorPanel(page).getByText(secondHiddenField, { exact: true })).toBeVisible();
+
+    await openBlockLogic(page);
+    await expect(page.locator("#action-0-variableId")).toContainText(renamedVariableName);
+    await expect(page.locator("#action-0-value-input")).toHaveAttribute("type", "number");
+  });
+});

--- a/apps/web/playwright/utils/helper.ts
+++ b/apps/web/playwright/utils/helper.ts
@@ -303,19 +303,19 @@ export const signUpAndLogin = async (
   await page.getByPlaceholder("*******").fill(password);
   await page.getByRole("button", { name: "Continue with Email" }).click();
   await page.getByText("Login").click();
-  await page.getByRole("button", { name: "Login with Email" }).click();
+  await page.getByRole("button", { name: "Log in with Email" }).click();
   await page.getByPlaceholder("work@email.com").fill(email);
   await page.getByPlaceholder("*******").click();
   await page.getByPlaceholder("*******").fill(password);
-  await page.getByRole("button", { name: "Login with Email" }).click();
+  await page.getByRole("button", { name: "Log in with Email" }).click();
 };
 
 export const login = async (page: Page, email: string, password: string): Promise<void> => {
   await page.goto("/auth/login");
 
-  await expect(page.getByRole("button", { name: "Login with Email" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Log in with Email" })).toBeVisible();
 
-  await page.getByRole("button", { name: "Login with Email" }).click();
+  await page.getByRole("button", { name: "Log in with Email" }).click();
 
   await expect(page.getByPlaceholder("work@email.com")).toBeVisible();
 
@@ -325,7 +325,7 @@ export const login = async (page: Page, email: string, password: string): Promis
 
   await page.getByPlaceholder("*******").click();
   await page.getByPlaceholder("*******").fill(password);
-  await page.getByRole("button", { name: "Login with Email" }).click();
+  await page.getByRole("button", { name: "Log in with Email" }).click();
 };
 
 export const apiLogin = async (page: Page, email: string, password: string) => {
@@ -416,11 +416,11 @@ export const signupUsingInviteToken = async (page: Page, name: string, email: st
   await page.waitForTimeout(500);
   await page.getByText("Continue with Email").click();
   await page.getByText("Login").click();
-  await page.getByRole("button", { name: "Login with Email" }).click();
+  await page.getByRole("button", { name: "Log in with Email" }).click();
   await page.getByPlaceholder("work@email.com").fill(email);
   await page.getByPlaceholder("*******").click();
   await page.getByPlaceholder("*******").fill(password);
-  await page.getByRole("button", { name: "Login with Email" }).click();
+  await page.getByRole("button", { name: "Log in with Email" }).click();
 };
 
 /**

--- a/packages/email/emails/survey/response-finished-email.tsx
+++ b/packages/email/emails/survey/response-finished-email.tsx
@@ -1,5 +1,6 @@
 import { Column, Container, Heading, Hr, Link, Row, Section, Text } from "@react-email/components";
 import { FileDigitIcon, FileType2Icon } from "lucide-react";
+import { getComputedEmbeddedFields, getIngestedStorageKeys } from "@formbricks/types/embedded-data-resolver";
 import type { TOrganization } from "@formbricks/types/organizations";
 import type { TResponse } from "@formbricks/types/responses";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/elements";
@@ -13,7 +14,12 @@ import { TEmailTemplateLegalProps } from "../../src/types/email";
 import { ProcessedResponseElement } from "../../src/types/follow-up";
 import { TFunction } from "../../src/types/translations";
 
-type TResponseFinishedEmailSurvey = Pick<TSurvey, "id" | "name" | "variables" | "hiddenFields">;
+// `variables` / `hiddenFields` stay in the pick as the fallback the resolver reads when a survey's
+// EmbeddedData rows are not joined in; the rows themselves arrive as `embeddedFields` (ENG-1837).
+type TResponseFinishedEmailSurvey = Pick<
+  TSurvey,
+  "id" | "name" | "variables" | "hiddenFields" | "embeddedFields"
+>;
 
 export interface ResponseFinishedEmailProps extends TEmailTemplateLegalProps {
   readonly survey: TResponseFinishedEmailSurvey;
@@ -28,8 +34,9 @@ export interface ResponseFinishedEmailProps extends TEmailTemplateLegalProps {
 
 const mockGetElementResponseMapping = (survey: TResponseFinishedEmailSurvey, response: TResponse) => {
   // For preview, just return the response data as elements
+  const ingestedStorageKeys = getIngestedStorageKeys(survey);
   return Object.entries(response.data)
-    .filter(([key]) => !survey.hiddenFields.fieldIds?.includes(key))
+    .filter(([key]) => !ingestedStorageKeys.includes(key))
     .map(([key, value]) => ({
       element: key,
       response: value as string | string[],
@@ -71,26 +78,26 @@ export function ResponseFinishedEmail({
                 </Row>
               );
             })}
-            {survey.variables
-              .filter((variable) => {
-                const variableResponse = response.variables[variable.id];
+            {getComputedEmbeddedFields(survey)
+              .filter(({ link }) => {
+                const variableResponse = response.variables[link.storageKey];
                 if (typeof variableResponse !== "string" && typeof variableResponse !== "number") {
                   return false;
                 }
                 return variableResponse !== undefined;
               })
-              .map((variable) => {
-                const variableResponse = response.variables[variable.id];
+              .map(({ field, link }) => {
+                const variableResponse = response.variables[link.storageKey];
                 return (
-                  <Row key={variable.id}>
+                  <Row key={link.storageKey}>
                     <Column className="w-full text-sm font-medium">
                       <Text className="mb-1 flex items-center gap-2">
-                        {variable.type === "number" ? (
+                        {field.dataType === "number" ? (
                           <FileDigitIcon className="h-4 w-4" />
                         ) : (
                           <FileType2Icon className="h-4 w-4" />
                         )}
-                        {variable.name}
+                        {field.name}
                       </Text>
                       <Text className="mt-0 whitespace-pre-wrap break-words font-medium">
                         {variableResponse}
@@ -99,8 +106,8 @@ export function ResponseFinishedEmail({
                   </Row>
                 );
               })}
-            {survey.hiddenFields.fieldIds
-              ?.filter((hiddenFieldId) => {
+            {getIngestedStorageKeys(survey)
+              .filter((hiddenFieldId) => {
                 const hiddenFieldResponse = response.data[hiddenFieldId];
                 return hiddenFieldResponse && typeof hiddenFieldResponse === "string";
               })

--- a/packages/js-core/src/types/config.ts
+++ b/packages/js-core/src/types/config.ts
@@ -78,6 +78,11 @@ export interface TWorkspaceStateSurvey {
     enabled: boolean;
     fieldIds?: string[];
   };
+  // The survey's Embedded Data definitions, joined and inlined server-side (ENG-1837). The SDK never
+  // reads or reconstructs them — it stores the survey object as received and hands it to
+  // `renderSurvey` — so this is a structural declaration only, kept loose because the SDK has no
+  // stake in the shape.
+  embeddedFields?: TJsonObject[];
   delay: number;
   workspaceOverwrites: {
     clickOutsideClose?: boolean | null;

--- a/packages/surveys/src/components/general/survey.tsx
+++ b/packages/surveys/src/components/general/survey.tsx
@@ -1,5 +1,9 @@
 import { type JSX } from "preact";
 import { useCallback, useEffect, useMemo, useRef, useState } from "preact/hooks";
+import {
+  coerceToEmbeddedDataType,
+  getComputedEmbeddedFields,
+} from "@formbricks/types/embedded-data-resolver";
 import { SurveyContainerProps } from "@formbricks/types/formbricks-surveys";
 import { TJsFileUploadParams, type TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import type {
@@ -240,14 +244,26 @@ export function Survey({
     setlocalSurvey(survey);
   }, [survey]);
 
+  // ENG-1837: computed fields are seeded from their definitions in the EmbeddedData tables, falling
+  // back to the legacy `variables` column for surveys whose rows are not joined in. Only `variables`
+  // and `embeddedFields` are passed (and depended on): a computed field can never be derived from
+  // `hiddenFields`, so nothing else can change this map.
   useEffect(() => {
     setCurrentVariables(
-      survey.variables.reduce<TResponseVariables>((acc, variable) => {
-        acc[variable.id] = variable.value;
+      getComputedEmbeddedFields({
+        variables: survey.variables,
+        embeddedFields: survey.embeddedFields,
+      }).reduce<TResponseVariables>((acc, { field, link }) => {
+        // Provably the variable's declared value for every field derived from the legacy shape:
+        // ZSurveyVariable pins a number variable to a number and a text one to a string, and both
+        // are pass-throughs here (see the seeding test in embedded-data-mapping.test.ts). Booleans
+        // and dates have no slot in TResponseVariables and no computed field can carry one.
+        const seed = coerceToEmbeddedDataType(field.defaultValue, field.dataType);
+        if (typeof seed === "string" || typeof seed === "number") acc[link.storageKey] = seed;
         return acc;
       }, {})
     );
-  }, [survey.variables]);
+  }, [survey.variables, survey.embeddedFields]);
 
   const autoFocusEnabled = autoFocus ?? window.self === window.top;
 

--- a/packages/surveys/src/lib/logic.test.ts
+++ b/packages/surveys/src/lib/logic.test.ts
@@ -1708,6 +1708,57 @@ describe("computed fields resolve through the inlined EmbeddedData rows", () => 
     ).toBe(true);
   });
 
+  /**
+   * A condition can outlive the field it names: the variable is renamed or deleted, the logic rule
+   * keeps the old storage key. The `dataType` read that drives the number coercion runs BEFORE the
+   * operator switch, so an unguarded `undefined` throws there — and `evaluateSingleCondition`'s
+   * try/catch turns that into a silent `false` rather than a visible crash, quietly sending the
+   * respondent down the wrong branch. These assert the evaluated RESULT, not the absence of a throw,
+   * precisely because the catch would hide one.
+   */
+  describe("a condition naming a field the survey no longer declares", () => {
+    const staleOperand = (operator: TSingleCondition["operator"]): TConditionGroup => ({
+      id: "group1",
+      connector: "and",
+      conditions: [
+        {
+          id: "condition1",
+          operator,
+          leftOperand: { type: "variable", value: "storage_key_of_a_deleted_variable" },
+          rightOperand: { type: "hiddenField", value: "plan" },
+        },
+      ],
+    });
+
+    test("evaluates on its own merits instead of collapsing to false", () => {
+      // The left operand resolves to no value, so `isNotSet` is genuinely true. Without the guard the
+      // `.dataType` read throws first and the catch returns false.
+      expect(
+        evaluateLogic(
+          buildSurvey([], computedRow("number", 0)),
+          { plan: "42" },
+          {},
+          staleOperand("isNotSet"),
+          "default"
+        )
+      ).toBe(true);
+    });
+
+    test("does not coerce the right operand, since the left operand's type is unknown", () => {
+      // `isSet` on an unresolvable left operand is false either way; the point is that it is false by
+      // evaluating, not by throwing — paired with the case above, which would flip.
+      expect(
+        evaluateLogic(
+          buildSurvey([], computedRow("number", 0)),
+          { plan: "42" },
+          {},
+          staleOperand("isSet"),
+          "default"
+        )
+      ).toBe(false);
+    });
+  });
+
   describe("performCalculation", () => {
     const calculate = (
       survey: TJsWorkspaceStateSurvey,

--- a/packages/surveys/src/lib/logic.test.ts
+++ b/packages/surveys/src/lib/logic.test.ts
@@ -1526,3 +1526,262 @@ describe("Survey Logic", () => {
     });
   });
 });
+
+/**
+ * ENG-1837 repointed the *definition* lookup for computed fields onto the EmbeddedData tables while
+ * leaving every value expression alone. These tests pin both halves: that the inlined rows are what
+ * the engine reads, and that the four deltas `resolveEmbeddedValue` documents are NOT inherited —
+ * each case below flips if someone later "simplifies" a call site onto the resolver.
+ */
+describe("computed fields resolve through the inlined EmbeddedData rows", () => {
+  const STORAGE_KEY = "var1";
+
+  const buildSurvey = (
+    variables: TSurveyVariable[],
+    embeddedFields?: TJsWorkspaceStateSurvey["embeddedFields"]
+  ): TJsWorkspaceStateSurvey =>
+    ({
+      id: "survey1",
+      name: "Survey 1",
+      questions: [],
+      blocks: [{ id: "block1", name: "Block 1", elements: [] }],
+      variables,
+      embeddedFields,
+      hiddenFields: { enabled: true, fieldIds: ["plan"] },
+      autoClose: null,
+      type: "link",
+      delay: 0,
+      displayLimit: 0,
+      displayOption: "displayMultiple",
+      displayPercentage: 0,
+      recaptcha: { enabled: false, threshold: 0.5 },
+      isBackButtonHidden: false,
+      isAutoProgressingEnabled: false,
+      segment: null,
+      welcomeCard: { enabled: false, showResponseCount: false, timeToFinish: false },
+      triggers: [],
+      styling: null,
+      status: "inProgress",
+      showLanguageSwitch: false,
+      languages: [],
+      endings: [],
+      workspaceOverwrites: null,
+      recontactDays: null,
+    }) as TJsWorkspaceStateSurvey;
+
+  const computedRow = (dataType: "number" | "string", defaultValue: number | string) => [
+    {
+      field: { name: "score", source: "computed" as const, dataType, defaultValue, locked: false },
+      link: { storageKey: STORAGE_KEY },
+    },
+  ];
+
+  const equalsStatic = (value: number | string): TConditionGroup => ({
+    id: "group1",
+    connector: "and",
+    conditions: [
+      {
+        id: "condition1",
+        operator: "equals",
+        leftOperand: { type: "variable", value: STORAGE_KEY },
+        rightOperand: { type: "static", value },
+      },
+    ],
+  });
+
+  test("the row's dataType wins over the legacy column's", () => {
+    const legacyTextVariable: TSurveyVariable[] = [
+      { id: STORAGE_KEY, name: "score", type: "text", value: "" },
+    ];
+
+    // Row says number: "42" is read as the number 42 and equals the static 42.
+    expect(
+      evaluateLogic(
+        buildSurvey(legacyTextVariable, computedRow("number", 0)),
+        {},
+        { [STORAGE_KEY]: "42" },
+        equalsStatic(42),
+        "default"
+      )
+    ).toBe(true);
+
+    // Same survey without the join: the legacy column's "text" applies and "42" stays a string.
+    expect(
+      evaluateLogic(buildSurvey(legacyTextVariable), {}, { [STORAGE_KEY]: "42" }, equalsStatic(42), "default")
+    ).toBe(false);
+  });
+
+  test("an empty row list falls back to the legacy column rather than losing the field", () => {
+    const legacyNumberVariable: TSurveyVariable[] = [
+      { id: STORAGE_KEY, name: "score", type: "number", value: 0 },
+    ];
+
+    expect(
+      evaluateLogic(
+        buildSurvey(legacyNumberVariable, []),
+        {},
+        { [STORAGE_KEY]: "42" },
+        equalsStatic(42),
+        "default"
+      )
+    ).toBe(true);
+  });
+
+  test("delta (a): a non-numeric stored value is still 0, not the declared default", () => {
+    // resolveEmbeddedValue would fail coercion and fall back to defaultValue (5); logic must not.
+    expect(
+      evaluateLogic(
+        buildSurvey([], computedRow("number", 5)),
+        {},
+        { [STORAGE_KEY]: "abc" },
+        equalsStatic(0),
+        "default"
+      )
+    ).toBe(true);
+  });
+
+  test('delta (a): a string field holding 0 is still "", not "0"', () => {
+    expect(
+      evaluateLogic(
+        buildSurvey([], computedRow("string", "fallback")),
+        {},
+        { [STORAGE_KEY]: 0 },
+        equalsStatic(""),
+        "default"
+      )
+    ).toBe(true);
+  });
+
+  test('delta (d): a response missing the key evaluates as 0 / "", not the declared default', () => {
+    expect(evaluateLogic(buildSurvey([], computedRow("number", 5)), {}, {}, equalsStatic(0), "default")).toBe(
+      true
+    );
+    expect(
+      evaluateLogic(buildSurvey([], computedRow("string", "gold")), {}, {}, equalsStatic(""), "default")
+    ).toBe(true);
+  });
+
+  test("an operand pointing at no declared field resolves to undefined", () => {
+    expect(
+      evaluateLogic(
+        buildSurvey([], computedRow("number", 0)),
+        {},
+        {},
+        {
+          id: "group1",
+          connector: "and",
+          conditions: [
+            {
+              id: "condition1",
+              operator: "isSet",
+              leftOperand: { type: "variable", value: "unknown_key" },
+            },
+          ],
+        },
+        "default"
+      )
+    ).toBe(false);
+  });
+
+  test("a number field compared against a hidden field still coerces the right operand", () => {
+    const condition: TConditionGroup = {
+      id: "group1",
+      connector: "and",
+      conditions: [
+        {
+          id: "condition1",
+          operator: "equals",
+          leftOperand: { type: "variable", value: STORAGE_KEY },
+          rightOperand: { type: "hiddenField", value: "plan" },
+        },
+      ],
+    };
+
+    expect(
+      evaluateLogic(
+        buildSurvey([], computedRow("number", 0)),
+        { plan: "42" },
+        { [STORAGE_KEY]: 42 },
+        condition,
+        "default"
+      )
+    ).toBe(true);
+  });
+
+  describe("performCalculation", () => {
+    const calculate = (
+      survey: TJsWorkspaceStateSurvey,
+      action: TSurveyBlockLogicAction,
+      data: TResponseData,
+      calculations: TResponseVariables
+    ) => performActions(survey, [action], data, calculations).calculations;
+
+    test('seeds an unset number field from 0 and a string field from ""', () => {
+      expect(
+        calculate(
+          buildSurvey([], computedRow("number", 5)),
+          {
+            id: "a1",
+            objective: "calculate",
+            variableId: STORAGE_KEY,
+            operator: "add",
+            value: { type: "static", value: 3 },
+          },
+          {},
+          {}
+        )
+      ).toEqual({ [STORAGE_KEY]: 3 });
+
+      expect(
+        calculate(
+          buildSurvey([], computedRow("string", "gold")),
+          {
+            id: "a1",
+            objective: "calculate",
+            variableId: STORAGE_KEY,
+            operator: "concat",
+            value: { type: "static", value: "x" },
+          },
+          {},
+          {}
+        )
+      ).toEqual({ [STORAGE_KEY]: "x" });
+    });
+
+    test("a calculation on a field the survey does not declare is skipped", () => {
+      expect(
+        calculate(
+          buildSurvey([], computedRow("number", 0)),
+          {
+            id: "a1",
+            objective: "calculate",
+            variableId: "unknown_key",
+            operator: "add",
+            value: { type: "static", value: 3 },
+          },
+          {},
+          {}
+        )
+      ).toEqual({});
+    });
+
+    test('a legacy "question" operand stays unresolved', () => {
+      expect(
+        calculate(
+          buildSurvey([], computedRow("number", 0)),
+          {
+            id: "a1",
+            objective: "calculate",
+            variableId: STORAGE_KEY,
+            operator: "add",
+            // Admitted at the type level by ZDynamicLogicFieldValueDeprecated; normalized to
+            // "element" at the API boundary, so the engines deliberately leave it unresolved.
+            value: { type: "question", value: "q1" },
+          } as unknown as TSurveyBlockLogicAction,
+          { q1: 3 },
+          {}
+        )
+      ).toEqual({});
+    });
+  });
+});

--- a/packages/surveys/src/lib/logic.ts
+++ b/packages/surveys/src/lib/logic.ts
@@ -473,7 +473,7 @@ const performCalculation = (
     case "hiddenField":
       const val = data[action.value.value];
       if (typeof val === "number" || typeof val === "string") {
-        if (dataType === "number" && !isNaN(Number(val))) {
+        if (dataType === "number" && !Number.isNaN(Number(val))) {
           operandValue = Number(val);
         }
         operandValue = val;

--- a/packages/surveys/src/lib/logic.ts
+++ b/packages/surveys/src/lib/logic.ts
@@ -1,7 +1,8 @@
 import {
-  type TLinkedEmbeddedField,
-  type TResolvableEmbeddedField,
+  findComputedEmbeddedField,
   getComputedEmbeddedFields,
+  getComputedFieldDataType,
+  getLogicVariableValue,
 } from "@formbricks/types/embedded-data-resolver";
 import { type TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { type TResponseData, type TResponseVariables } from "@formbricks/types/responses";
@@ -11,30 +12,6 @@ import type { TSurveyElement } from "@formbricks/types/surveys/elements";
 import { type TConditionGroup, type TSingleCondition } from "@formbricks/types/surveys/logic";
 import { getLocalizedValue } from "@/lib/i18n";
 import { getElementsFromSurveyBlocks } from "./utils";
-
-/** Finds a computed field by the key its value is stored under in `response.variables`. */
-const findComputedField = (
-  computedFields: TLinkedEmbeddedField[],
-  storageKey: string
-): TLinkedEmbeddedField | undefined => computedFields.find((f) => f.link.storageKey === storageKey);
-
-/**
- * ENG-1837 repoints the *definition* lookup onto the EmbeddedData tables; the value expression below
- * is deliberately unchanged. `resolveEmbeddedValue` would coerce a non-numeric stored value to the
- * field's declared default instead of `0`, and render a text field holding `0` as `"0"` rather than
- * `""` — both of which change what existing responses evaluate to. See the swap checklist on
- * `resolveEmbeddedValue`.
- */
-const getVariableValue = (
-  computedFields: TLinkedEmbeddedField[],
-  variableId: string,
-  variablesData: TResponseVariables
-) => {
-  const field = findComputedField(computedFields, variableId);
-  if (!field) return undefined;
-  const variableValue = variablesData[variableId];
-  return field.field.dataType === "number" ? Number(variableValue) || 0 : variableValue || "";
-};
 
 type TCondition = TSingleCondition | TConditionGroup;
 
@@ -188,7 +165,7 @@ const getLeftOperandValue = (
 
       return data[leftOperand.value];
     case "variable":
-      return getVariableValue(getComputedEmbeddedFields(localSurvey), leftOperand.value, variablesData);
+      return getLogicVariableValue(getComputedEmbeddedFields(localSurvey), leftOperand.value, variablesData);
     case "hiddenField":
       return data[leftOperand.value];
     default:
@@ -208,7 +185,7 @@ const getRightOperandValue = (
     case "element":
       return data[rightOperand.value];
     case "variable":
-      return getVariableValue(getComputedEmbeddedFields(localSurvey), rightOperand.value, variablesData);
+      return getLogicVariableValue(getComputedEmbeddedFields(localSurvey), rightOperand.value, variablesData);
     case "hiddenField":
       return data[rightOperand.value];
     case "static":
@@ -237,28 +214,25 @@ const evaluateSingleCondition = (
       ? getRightOperandValue(localSurvey, data, variablesData, condition.rightOperand)
       : undefined;
 
-    let leftField: TSurveyElement | TResolvableEmbeddedField | string;
+    // Only element and hiddenField operands are inspected below; a `variable` operand's declared
+    // type is read through `getComputedFieldDataType` instead, which tolerates a condition naming a
+    // field the survey no longer declares.
+    let leftField: TSurveyElement | string;
 
     const questions = getElementsFromSurveyBlocks(localSurvey.blocks);
     const computedFields = getComputedEmbeddedFields(localSurvey);
     if (condition.leftOperand?.type === "element") {
       leftField = questions.find((q) => q.id === condition.leftOperand?.value) ?? "";
-    } else if (condition.leftOperand?.type === "variable") {
-      leftField = findComputedField(computedFields, condition.leftOperand.value)
-        ?.field as TResolvableEmbeddedField;
     } else if (condition.leftOperand?.type === "hiddenField") {
       leftField = condition.leftOperand.value as string;
     } else {
       leftField = "";
     }
 
-    let rightField: TSurveyElement | TResolvableEmbeddedField | string;
+    let rightField: TSurveyElement | string;
 
     if (condition.rightOperand?.type === "element") {
       rightField = questions.find((q) => q.id === condition.rightOperand?.value) ?? "";
-    } else if (condition.rightOperand?.type === "variable") {
-      rightField = findComputedField(computedFields, condition.rightOperand.value)
-        ?.field as TResolvableEmbeddedField;
     } else if (condition.rightOperand?.type === "hiddenField") {
       rightField = condition.rightOperand.value as string;
     } else {
@@ -267,7 +241,7 @@ const evaluateSingleCondition = (
 
     if (
       condition.leftOperand.type === "variable" &&
-      (leftField as TResolvableEmbeddedField).dataType === "number" &&
+      getComputedFieldDataType(computedFields, condition.leftOperand.value) === "number" &&
       condition.rightOperand?.type === "hiddenField"
     ) {
       rightValue = Number(rightValue as string);
@@ -469,7 +443,7 @@ const performCalculation = (
   data: TResponseData,
   calculations: Record<string, number | string>
 ): number | string | undefined => {
-  const computedField = findComputedField(getComputedEmbeddedFields(survey), action.variableId);
+  const computedField = findComputedEmbeddedField(getComputedEmbeddedFields(survey), action.variableId);
 
   if (!computedField) return undefined;
 

--- a/packages/surveys/src/lib/logic.ts
+++ b/packages/surveys/src/lib/logic.ts
@@ -1,22 +1,39 @@
+import {
+  type TLinkedEmbeddedField,
+  type TResolvableEmbeddedField,
+  getComputedEmbeddedFields,
+} from "@formbricks/types/embedded-data-resolver";
 import { type TJsWorkspaceStateSurvey } from "@formbricks/types/js";
 import { type TResponseData, type TResponseVariables } from "@formbricks/types/responses";
 import { type TActionCalculate, type TSurveyBlockLogicAction } from "@formbricks/types/surveys/blocks";
 import { TSurveyElementTypeEnum } from "@formbricks/types/surveys/constants";
 import type { TSurveyElement } from "@formbricks/types/surveys/elements";
 import { type TConditionGroup, type TSingleCondition } from "@formbricks/types/surveys/logic";
-import { type TSurveyVariable } from "@formbricks/types/surveys/types";
 import { getLocalizedValue } from "@/lib/i18n";
 import { getElementsFromSurveyBlocks } from "./utils";
 
+/** Finds a computed field by the key its value is stored under in `response.variables`. */
+const findComputedField = (
+  computedFields: TLinkedEmbeddedField[],
+  storageKey: string
+): TLinkedEmbeddedField | undefined => computedFields.find((f) => f.link.storageKey === storageKey);
+
+/**
+ * ENG-1837 repoints the *definition* lookup onto the EmbeddedData tables; the value expression below
+ * is deliberately unchanged. `resolveEmbeddedValue` would coerce a non-numeric stored value to the
+ * field's declared default instead of `0`, and render a text field holding `0` as `"0"` rather than
+ * `""` — both of which change what existing responses evaluate to. See the swap checklist on
+ * `resolveEmbeddedValue`.
+ */
 const getVariableValue = (
-  variables: TSurveyVariable[],
+  computedFields: TLinkedEmbeddedField[],
   variableId: string,
   variablesData: TResponseVariables
 ) => {
-  const variable = variables.find((v) => v.id === variableId);
-  if (!variable) return undefined;
+  const field = findComputedField(computedFields, variableId);
+  if (!field) return undefined;
   const variableValue = variablesData[variableId];
-  return variable.type === "number" ? Number(variableValue) || 0 : variableValue || "";
+  return field.field.dataType === "number" ? Number(variableValue) || 0 : variableValue || "";
 };
 
 type TCondition = TSingleCondition | TConditionGroup;
@@ -171,8 +188,7 @@ const getLeftOperandValue = (
 
       return data[leftOperand.value];
     case "variable":
-      const variables = localSurvey.variables || [];
-      return getVariableValue(variables, leftOperand.value, variablesData);
+      return getVariableValue(getComputedEmbeddedFields(localSurvey), leftOperand.value, variablesData);
     case "hiddenField":
       return data[leftOperand.value];
     default:
@@ -192,8 +208,7 @@ const getRightOperandValue = (
     case "element":
       return data[rightOperand.value];
     case "variable":
-      const variables = localSurvey.variables || [];
-      return getVariableValue(variables, rightOperand.value, variablesData);
+      return getVariableValue(getComputedEmbeddedFields(localSurvey), rightOperand.value, variablesData);
     case "hiddenField":
       return data[rightOperand.value];
     case "static":
@@ -222,27 +237,28 @@ const evaluateSingleCondition = (
       ? getRightOperandValue(localSurvey, data, variablesData, condition.rightOperand)
       : undefined;
 
-    let leftField: TSurveyElement | TSurveyVariable | string;
+    let leftField: TSurveyElement | TResolvableEmbeddedField | string;
 
     const questions = getElementsFromSurveyBlocks(localSurvey.blocks);
+    const computedFields = getComputedEmbeddedFields(localSurvey);
     if (condition.leftOperand?.type === "element") {
       leftField = questions.find((q) => q.id === condition.leftOperand?.value) ?? "";
     } else if (condition.leftOperand?.type === "variable") {
-      leftField = localSurvey.variables.find((v) => v.id === condition.leftOperand?.value) as TSurveyVariable;
+      leftField = findComputedField(computedFields, condition.leftOperand.value)
+        ?.field as TResolvableEmbeddedField;
     } else if (condition.leftOperand?.type === "hiddenField") {
       leftField = condition.leftOperand.value as string;
     } else {
       leftField = "";
     }
 
-    let rightField: TSurveyElement | TSurveyVariable | string;
+    let rightField: TSurveyElement | TResolvableEmbeddedField | string;
 
     if (condition.rightOperand?.type === "element") {
       rightField = questions.find((q) => q.id === condition.rightOperand?.value) ?? "";
     } else if (condition.rightOperand?.type === "variable") {
-      rightField = localSurvey.variables.find(
-        (v) => v.id === condition.rightOperand?.value
-      ) as TSurveyVariable;
+      rightField = findComputedField(computedFields, condition.rightOperand.value)
+        ?.field as TResolvableEmbeddedField;
     } else if (condition.rightOperand?.type === "hiddenField") {
       rightField = condition.rightOperand.value as string;
     } else {
@@ -251,7 +267,7 @@ const evaluateSingleCondition = (
 
     if (
       condition.leftOperand.type === "variable" &&
-      (leftField as TSurveyVariable).type === "number" &&
+      (leftField as TResolvableEmbeddedField).dataType === "number" &&
       condition.rightOperand?.type === "hiddenField"
     ) {
       rightValue = Number(rightValue as string);
@@ -453,14 +469,15 @@ const performCalculation = (
   data: TResponseData,
   calculations: Record<string, number | string>
 ): number | string | undefined => {
-  const variables = survey.variables || [];
-  const variable = variables.find((v) => v.id === action.variableId);
+  const computedField = findComputedField(getComputedEmbeddedFields(survey), action.variableId);
 
-  if (!variable) return undefined;
+  if (!computedField) return undefined;
+
+  const { dataType } = computedField.field;
 
   let currentValue = calculations[action.variableId];
   if (currentValue === undefined) {
-    currentValue = variable.type === "number" ? 0 : "";
+    currentValue = dataType === "number" ? 0 : "";
   }
   let operandValue: string | number | undefined;
 
@@ -475,11 +492,14 @@ const performCalculation = (
         operandValue = value;
       }
       break;
+    // Deliberately no `default` arm: a legacy `"question"` operand (admitted at the type level by
+    // ZDynamicLogicFieldValueDeprecated, normalized away at the API boundary) stays unresolved and
+    // the calculation returns undefined, exactly as before.
     case "element":
     case "hiddenField":
       const val = data[action.value.value];
       if (typeof val === "number" || typeof val === "string") {
-        if (variable.type === "number" && !isNaN(Number(val))) {
+        if (dataType === "number" && !isNaN(Number(val))) {
           operandValue = Number(val);
         }
         operandValue = val;

--- a/packages/types/embedded-data-mapping.test.ts
+++ b/packages/types/embedded-data-mapping.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { ZEmbeddedData } from "./embedded-data";
 import { type TDesiredEmbeddedField, toDesiredEmbeddedFields } from "./embedded-data-mapping";
+import { coerceToEmbeddedDataType } from "./embedded-data-resolver";
 import { type TSurveyVariable, ZSurveyHiddenFields, ZSurveyVariable } from "./surveys/types";
 
 /** Wraps a mapped field in the row it would be written as, so the two schemas can be checked together. */
@@ -142,5 +143,38 @@ describe("toDesiredEmbeddedFields", () => {
     // Each caller decides: the write bridge rejects the save, the backfill can skip the survey.
     const fields = toDesiredEmbeddedFields({ hiddenFields: { enabled: true, fieldIds: ["plan", "plan"] } });
     expect(fields).toHaveLength(2);
+  });
+});
+
+/**
+ * The proof behind ENG-1837's decision to seed the renderer's variable map from a computed field's
+ * `defaultValue` instead of `survey.variables[].value`. `ZSurveyVariable` guarantees a number
+ * variable holds a number and a text variable a string, and `toDesiredEmbeddedFields` copies that
+ * value verbatim — so coercing it back through the resolver is a pure pass-through and the seeded
+ * map is byte-identical to today's. If either schema ever loosens, this test fails before the
+ * renderer starts seeding a different value.
+ */
+describe("computed-field seeding is value-preserving", () => {
+  const variables: TSurveyVariable[] = [
+    numberVariable,
+    textVariable,
+    { id: "clx000000000000000000003", name: "zero", type: "number", value: 0 },
+    { id: "clx000000000000000000004", name: "blank", type: "text", value: "" },
+    { id: "clx000000000000000000005", name: "negative", type: "number", value: -12.5 },
+    { id: "clx000000000000000000006", name: "numeric_text", type: "text", value: "0" },
+  ];
+
+  test.each(variables)("$name coerces back to exactly its declared value", (variable) => {
+    const [field] = toDesiredEmbeddedFields({ variables: [variable] });
+
+    expect(coerceToEmbeddedDataType(field.defaultValue, field.dataType)).toBe(variable.value);
+  });
+
+  test("a variable's declared value is never dropped by the coercion", () => {
+    const fields = toDesiredEmbeddedFields({ variables });
+
+    expect(fields.map((field) => coerceToEmbeddedDataType(field.defaultValue, field.dataType))).toStrictEqual(
+      variables.map((variable) => variable.value)
+    );
   });
 });

--- a/packages/types/embedded-data-resolver.test.ts
+++ b/packages/types/embedded-data-resolver.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { ZEmbeddedData } from "./embedded-data";
+import { z } from "zod";
+import { ZEmbeddedData, ZLinkedEmbeddedField } from "./embedded-data";
 import {
   RESERVED_FIELD_CATALOG,
   type TEmbeddedValueRef,
@@ -8,6 +9,10 @@ import {
   type TReservedFieldCatalogEntry,
   coerceToEmbeddedDataType,
   deriveLegacyEmbeddedData,
+  getComputedEmbeddedFields,
+  getIngestedEmbeddedFields,
+  getIngestedStorageKeys,
+  getSurveyEmbeddedFields,
   listReadableFields,
   projectReservedValues,
   resolveEmbeddedValue,
@@ -878,5 +883,127 @@ describe("deriveLegacyEmbeddedData", () => {
       { key: "source_page", label: "source_page" },
       { key: "Coupon-Code", label: "Coupon-Code" },
     ]);
+  });
+});
+
+describe("getSurveyEmbeddedFields", () => {
+  const legacySurvey = {
+    variables: [{ id: "clx0000000000000000000v1", name: "score", type: "number" as const, value: 10 }],
+    hiddenFields: { enabled: true, fieldIds: ["source_page"] },
+  };
+
+  const rows: TLinkedEmbeddedField[] = [
+    {
+      field: {
+        name: "renamed_score",
+        source: "computed",
+        dataType: "number",
+        defaultValue: 7,
+        locked: false,
+      },
+      link: { storageKey: "clx0000000000000000000v1" },
+    },
+  ];
+
+  test("uses the joined rows when the survey carries them", () => {
+    expect(getSurveyEmbeddedFields({ ...legacySurvey, embeddedFields: rows })).toStrictEqual(rows);
+  });
+
+  test("falls back to the legacy columns when the select omitted the join", () => {
+    expect(getSurveyEmbeddedFields(legacySurvey)).toStrictEqual(deriveLegacyEmbeddedData(legacySurvey));
+    expect(getSurveyEmbeddedFields({ ...legacySurvey, embeddedFields: null })).toStrictEqual(
+      deriveLegacyEmbeddedData(legacySurvey)
+    );
+  });
+
+  test("falls back on an empty row list, so a survey that missed the backfill still resolves", () => {
+    // The empty-list test is the reason this is `?.length` and not `!== undefined`.
+    expect(getSurveyEmbeddedFields({ ...legacySurvey, embeddedFields: [] })).toStrictEqual(
+      deriveLegacyEmbeddedData(legacySurvey)
+    );
+  });
+
+  test("a survey with no fields at all answers [] through either path", () => {
+    const empty = { variables: [], hiddenFields: { enabled: false, fieldIds: [] } };
+    expect(getSurveyEmbeddedFields(empty)).toEqual([]);
+    expect(getSurveyEmbeddedFields({ ...empty, embeddedFields: [] })).toEqual([]);
+  });
+
+  test("partitions by source, preserving the inlined order within each group", () => {
+    const survey = {
+      ...legacySurvey,
+      embeddedFields: [
+        ...rows,
+        {
+          field: {
+            name: "utm_source",
+            source: "ingested" as const,
+            dataType: "string" as const,
+            defaultValue: null,
+            locked: false,
+          },
+          link: { storageKey: "utm_source" },
+        },
+        {
+          field: {
+            name: "plan",
+            source: "ingested" as const,
+            dataType: "string" as const,
+            defaultValue: null,
+            locked: false,
+          },
+          link: { storageKey: "plan" },
+        },
+      ],
+    };
+
+    expect(getComputedEmbeddedFields(survey)).toStrictEqual([rows[0]]);
+    expect(getIngestedStorageKeys(survey)).toStrictEqual(["utm_source", "plan"]);
+    expect(getIngestedEmbeddedFields(survey).map(({ field }) => field.name)).toStrictEqual([
+      "utm_source",
+      "plan",
+    ]);
+  });
+
+  test("the partitions fall back too, keeping variables-then-hidden-fields order", () => {
+    expect(getComputedEmbeddedFields(legacySurvey).map(({ link }) => link.storageKey)).toStrictEqual([
+      "clx0000000000000000000v1",
+    ]);
+    expect(getIngestedStorageKeys(legacySurvey)).toStrictEqual(["source_page"]);
+  });
+});
+
+describe("ZLinkedEmbeddedField mirrors TLinkedEmbeddedField", () => {
+  const pair: TLinkedEmbeddedField = {
+    field: { name: "score", source: "computed", dataType: "number", defaultValue: 10, locked: false },
+    link: { storageKey: "clx0000000000000000000v1" },
+  };
+
+  test("a TLinkedEmbeddedField parses, and the parsed value is assignable back", () => {
+    const parsed = ZLinkedEmbeddedField.parse(pair);
+    // Compile-time half of the check: the inferred type must satisfy the interface, and vice versa.
+    const roundTripped: TLinkedEmbeddedField = parsed;
+    const asSchemaType: z.infer<typeof ZLinkedEmbeddedField> = pair;
+    expect(roundTripped).toStrictEqual(pair);
+    expect(asSchemaType).toStrictEqual(pair);
+  });
+
+  test("every field deriveLegacyEmbeddedData produces round-trips through the schema", () => {
+    const derived = deriveLegacyEmbeddedData({
+      variables: [
+        { id: "clx0000000000000000000v1", name: "score", type: "number", value: 10 },
+        { id: "clx0000000000000000000v3", name: "plan_name", type: "text", value: "basic" },
+      ],
+      hiddenFields: { enabled: true, fieldIds: ["source_page", "Coupon-Code"] },
+    });
+
+    expect(z.array(ZLinkedEmbeddedField).parse(derived)).toStrictEqual(derived);
+  });
+
+  test("strips nothing the readers need, and rejects a blank name or storage key", () => {
+    expect(ZLinkedEmbeddedField.safeParse({ ...pair, field: { ...pair.field, name: "  " } }).success).toBe(
+      false
+    );
+    expect(ZLinkedEmbeddedField.safeParse({ ...pair, link: { storageKey: "" } }).success).toBe(false);
   });
 });

--- a/packages/types/embedded-data-resolver.test.ts
+++ b/packages/types/embedded-data-resolver.test.ts
@@ -1038,11 +1038,28 @@ describe("getDeclaredEmbeddedFields", () => {
     expect(getDeclaredIngestedStorageKeys(legacySurvey)).toStrictEqual(["source_page"]);
   });
 
-  test("agrees with the stored accessor whenever the rows match the declarations", () => {
-    // True for every saved survey: `reconcileEmbeddedData` writes exactly `toDesiredEmbeddedFields`
-    // in the same transaction as the survey write.
-    const inSync = { ...legacySurvey, embeddedFields: deriveLegacyEmbeddedData(legacySurvey) };
+  test("still answers from the declarations when the rows are a superset", () => {
+    // A row for a field the survey no longer declares: the stored accessor keeps it, the declared
+    // accessor does not. Asserted with a genuinely differing pair rather than two runs of the same
+    // derivation, which could not fail.
+    const withExtraRow = {
+      ...legacySurvey,
+      embeddedFields: [
+        ...deriveLegacyEmbeddedData(legacySurvey),
+        {
+          field: {
+            name: "removed",
+            source: "ingested" as const,
+            dataType: "string" as const,
+            defaultValue: null,
+            locked: false,
+          },
+          link: { storageKey: "removed" },
+        },
+      ],
+    };
 
-    expect(getDeclaredEmbeddedFields(inSync)).toStrictEqual(getSurveyEmbeddedFields(inSync));
+    expect(getDeclaredIngestedStorageKeys(withExtraRow)).toStrictEqual(["source_page"]);
+    expect(getIngestedStorageKeys(withExtraRow)).toStrictEqual(["source_page", "removed"]);
   });
 });

--- a/packages/types/embedded-data-resolver.test.ts
+++ b/packages/types/embedded-data-resolver.test.ts
@@ -1004,10 +1004,19 @@ describe("ZLinkedEmbeddedField mirrors TLinkedEmbeddedField", () => {
   });
 
   test("strips nothing the readers need, and rejects a blank name or storage key", () => {
+    // The valid pair parses, so the rejections below are the rules firing and not the whole shape
+    // being refused.
+    expect(ZLinkedEmbeddedField.safeParse(pair).success).toBe(true);
+
     expect(ZLinkedEmbeddedField.safeParse({ ...pair, field: { ...pair.field, name: "  " } }).success).toBe(
       false
     );
     expect(ZLinkedEmbeddedField.safeParse({ ...pair, link: { storageKey: "" } }).success).toBe(false);
+    // Whitespace-only, not just empty: an ingested field's storage key is its URL param name, so a
+    // padded `" plan "` would never match `?plan=` while still counting as a distinct field under
+    // `@@unique([surveyId, storageKey])`. Rejected twice over — by the blank check and by the
+    // legacy-charset rule — so removing either one alone keeps this passing.
+    expect(ZLinkedEmbeddedField.safeParse({ ...pair, link: { storageKey: "  " } }).success).toBe(false);
   });
 });
 

--- a/packages/types/embedded-data-resolver.test.ts
+++ b/packages/types/embedded-data-resolver.test.ts
@@ -9,12 +9,15 @@ import {
   type TReservedFieldCatalogEntry,
   coerceToEmbeddedDataType,
   deriveLegacyEmbeddedData,
+  findComputedEmbeddedField,
   getComputedEmbeddedFields,
+  getComputedFieldDataType,
   getDeclaredComputedFields,
   getDeclaredEmbeddedFields,
   getDeclaredIngestedStorageKeys,
   getIngestedEmbeddedFields,
   getIngestedStorageKeys,
+  getLogicVariableValue,
   getSurveyEmbeddedFields,
   listReadableFields,
   projectReservedValues,
@@ -1070,5 +1073,74 @@ describe("getDeclaredEmbeddedFields", () => {
 
     expect(getDeclaredIngestedStorageKeys(withExtraRow)).toStrictEqual(["source_page"]);
     expect(getIngestedStorageKeys(withExtraRow)).toStrictEqual(["source_page", "removed"]);
+  });
+});
+
+/**
+ * The logic engines' read of a computed field. Lives here because
+ * `packages/surveys/src/lib/logic.ts` and `apps/web/lib/surveyLogic/utils.ts` are near-copies and
+ * both consume it — one definition of the value-preservation rule instead of two that can drift.
+ */
+describe("getLogicVariableValue", () => {
+  const computedField = (storageKey: string, dataType: "number" | "string", defaultValue: number | string) =>
+    ({
+      field: { name: storageKey, source: "computed" as const, dataType, defaultValue, locked: false },
+      link: { storageKey },
+    }) satisfies TLinkedEmbeddedField;
+
+  const numberField = computedField("score", "number", 5);
+  const textField = computedField("tier", "string", "gold");
+  const fields = [numberField, textField];
+
+  test("reads a stored value under the field's declared type", () => {
+    expect(getLogicVariableValue(fields, "score", { score: 42 })).toBe(42);
+    expect(getLogicVariableValue(fields, "tier", { tier: "silver" })).toBe("silver");
+  });
+
+  test("a number field coerces its stored value, numeric strings included", () => {
+    expect(getLogicVariableValue(fields, "score", { score: "42" })).toBe(42);
+  });
+
+  // The four cases below are the deltas `resolveEmbeddedValue` deliberately does not reproduce.
+  // Swapping this helper onto it would change what already-stored responses evaluate to, and
+  // responses are never migrated — so each one is asserted against the declared default it must NOT
+  // fall back to.
+  test("delta (a): a non-numeric stored value is 0, never the declared default", () => {
+    expect(getLogicVariableValue(fields, "score", { score: "abc" })).toBe(0);
+  });
+
+  test('delta (a): a string field holding 0 is "", never "0"', () => {
+    expect(getLogicVariableValue(fields, "tier", { tier: 0 })).toBe("");
+  });
+
+  test('delta (d): a response missing the key is 0 / "", never the declared default', () => {
+    expect(getLogicVariableValue(fields, "score", {})).toBe(0);
+    expect(getLogicVariableValue(fields, "tier", {})).toBe("");
+  });
+
+  test("a key the survey does not declare resolves to undefined, not to a coerced blank", () => {
+    // Distinct from the "missing value" cases above: there is no field, so there is no type to
+    // evaluate under, and the caller must be able to tell the two apart.
+    expect(getLogicVariableValue(fields, "deleted_variable", { deleted_variable: 7 })).toBeUndefined();
+  });
+});
+
+describe("getComputedFieldDataType", () => {
+  const fields: TLinkedEmbeddedField[] = [
+    {
+      field: { name: "score", source: "computed", dataType: "number", defaultValue: 5, locked: false },
+      link: { storageKey: "score" },
+    },
+  ];
+
+  test("answers the declared type", () => {
+    expect(getComputedFieldDataType(fields, "score")).toBe("number");
+  });
+
+  test("answers undefined for a field the survey no longer declares, instead of throwing", () => {
+    // The guard both engines depend on: this runs before the operator switch, and a throw here is
+    // swallowed by `evaluateSingleCondition`'s try/catch into a silent `false`.
+    expect(getComputedFieldDataType(fields, "deleted_variable")).toBeUndefined();
+    expect(findComputedEmbeddedField(fields, "deleted_variable")).toBeUndefined();
   });
 });

--- a/packages/types/embedded-data-resolver.test.ts
+++ b/packages/types/embedded-data-resolver.test.ts
@@ -10,6 +10,9 @@ import {
   coerceToEmbeddedDataType,
   deriveLegacyEmbeddedData,
   getComputedEmbeddedFields,
+  getDeclaredComputedFields,
+  getDeclaredEmbeddedFields,
+  getDeclaredIngestedStorageKeys,
   getIngestedEmbeddedFields,
   getIngestedStorageKeys,
   getSurveyEmbeddedFields,
@@ -1005,5 +1008,41 @@ describe("ZLinkedEmbeddedField mirrors TLinkedEmbeddedField", () => {
       false
     );
     expect(ZLinkedEmbeddedField.safeParse({ ...pair, link: { storageKey: "" } }).success).toBe(false);
+  });
+});
+
+describe("getDeclaredEmbeddedFields", () => {
+  const legacySurvey = {
+    variables: [{ id: "clx0000000000000000000v1", name: "score", type: "number" as const, value: 10 }],
+    hiddenFields: { enabled: true, fieldIds: ["source_page"] },
+  };
+
+  const staleRows: TLinkedEmbeddedField[] = [
+    {
+      field: { name: "old_name", source: "computed", dataType: "string", defaultValue: "", locked: false },
+      link: { storageKey: "clx0000000000000000000v1" },
+    },
+  ];
+
+  test("ignores the stored rows and answers from the declarations", () => {
+    // The editor's working copy carries the rows as of the last save, so a rename or a newly added
+    // field is only visible through this accessor.
+    expect(getDeclaredEmbeddedFields({ ...legacySurvey, embeddedFields: staleRows })).toStrictEqual(
+      deriveLegacyEmbeddedData(legacySurvey)
+    );
+    expect(getSurveyEmbeddedFields({ ...legacySurvey, embeddedFields: staleRows })).toStrictEqual(staleRows);
+  });
+
+  test("partitions the declarations the same way the stored accessor does", () => {
+    expect(getDeclaredComputedFields(legacySurvey).map(({ field }) => field.name)).toStrictEqual(["score"]);
+    expect(getDeclaredIngestedStorageKeys(legacySurvey)).toStrictEqual(["source_page"]);
+  });
+
+  test("agrees with the stored accessor whenever the rows match the declarations", () => {
+    // True for every saved survey: `reconcileEmbeddedData` writes exactly `toDesiredEmbeddedFields`
+    // in the same transaction as the survey write.
+    const inSync = { ...legacySurvey, embeddedFields: deriveLegacyEmbeddedData(legacySurvey) };
+
+    expect(getDeclaredEmbeddedFields(inSync)).toStrictEqual(getSurveyEmbeddedFields(inSync));
   });
 });

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -1,12 +1,11 @@
 import { z } from "zod";
 import type { TContactAttributeKey } from "./contact-attribute-key";
 import type { TEmbeddedData, TEmbeddedDataType, TSurveyEmbeddedData } from "./embedded-data";
-import { toDesiredEmbeddedFields } from "./embedded-data-mapping";
+import { type TLegacyEmbeddedFields, toDesiredEmbeddedFields } from "./embedded-data-mapping";
 import type { TI18nString } from "./i18n";
 import type { TResponse } from "./responses";
 import { formatSnakeCaseToTitleCase } from "./safe-identifier";
 import type { TSurveyBlocks } from "./surveys/blocks";
-import type { TSurveyHiddenFields, TSurveyVariables } from "./surveys/types";
 import { getTextContent } from "./surveys/validation";
 
 /**
@@ -419,11 +418,50 @@ export const listReadableFields = (input: TListReadableFieldsInput): TReadableFi
  * `fieldIds`). Deriving from `fieldIds` alone therefore preserves today's read behavior exactly:
  * whatever either path stored still resolves, and what nothing stored reports as unset.
  */
-export const deriveLegacyEmbeddedData = (survey: {
-  variables: TSurveyVariables;
-  hiddenFields: TSurveyHiddenFields;
-}): TLinkedEmbeddedField[] =>
+export const deriveLegacyEmbeddedData = (survey: TLegacyEmbeddedFields): TLinkedEmbeddedField[] =>
   toDesiredEmbeddedFields(survey).map(({ storageKey, ...field }) => ({
     field: { ...field, locked: false },
     link: { storageKey },
   }));
+
+/**
+ * The survey slice {@link getSurveyEmbeddedFields} needs. Deliberately looser than `TSurvey`: the
+ * readers this serves hold everything from a full survey to a four-key `Pick`, and every one of them
+ * must be able to call the accessor without widening its own select.
+ */
+export interface TEmbeddedFieldsSurvey extends TLegacyEmbeddedFields {
+  /** The rows, joined and inlined at load. Absent when the select omitted the join. */
+  embeddedFields?: TLinkedEmbeddedField[] | null;
+}
+
+/**
+ * **The one place that decides where a survey's Embedded Data definitions come from.** Every reader
+ * — recall, logic, export columns, response filters, pickers, emails, integrations — calls this and
+ * nothing else; no reader may call {@link deriveLegacyEmbeddedData} directly, which is what makes
+ * "exactly one fallback decision point" a property a reviewer can check with grep.
+ *
+ * Rows win when present. The empty-list test is deliberate rather than `!== undefined`: a select
+ * that omits the join yields `undefined`, and a survey read through it must still resolve, while
+ * `deriveLegacyEmbeddedData` returns `[]` for a survey whose legacy columns are empty — so a survey
+ * that genuinely has zero fields answers `[]` either way, and one that missed the ENG-1835 backfill
+ * falls back instead of silently losing every field.
+ *
+ * This is a *definition* lookup only. ENG-1837 repoints where a field's name, source and dataType
+ * come from; it deliberately does not repoint value arithmetic onto {@link resolveEmbeddedValue},
+ * whose coercion and default tiers differ from today's call-site expressions (see the swap checklist
+ * on {@link resolveEmbeddedValue}) and would change what stored responses render as.
+ */
+export const getSurveyEmbeddedFields = (survey: TEmbeddedFieldsSurvey): TLinkedEmbeddedField[] =>
+  survey.embeddedFields?.length ? survey.embeddedFields : deriveLegacyEmbeddedData(survey);
+
+/** The computed (ex-variable) fields of a survey, in inlined order. */
+export const getComputedEmbeddedFields = (survey: TEmbeddedFieldsSurvey): TLinkedEmbeddedField[] =>
+  getSurveyEmbeddedFields(survey).filter(({ field }) => field.source === "computed");
+
+/** The ingested (ex-hidden-field) fields of a survey, in inlined order. */
+export const getIngestedEmbeddedFields = (survey: TEmbeddedFieldsSurvey): TLinkedEmbeddedField[] =>
+  getSurveyEmbeddedFields(survey).filter(({ field }) => field.source === "ingested");
+
+/** The storage keys of a survey's ingested fields — what `response.data` addresses them by. */
+export const getIngestedStorageKeys = (survey: TEmbeddedFieldsSurvey): string[] =>
+  getIngestedEmbeddedFields(survey).map(({ link }) => link.storageKey);

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -3,7 +3,7 @@ import type { TContactAttributeKey } from "./contact-attribute-key";
 import type { TEmbeddedData, TEmbeddedDataType, TSurveyEmbeddedData } from "./embedded-data";
 import { type TLegacyEmbeddedFields, toDesiredEmbeddedFields } from "./embedded-data-mapping";
 import type { TI18nString } from "./i18n";
-import type { TResponse } from "./responses";
+import type { TResponse, TResponseVariables } from "./responses";
 import { formatSnakeCaseToTitleCase } from "./safe-identifier";
 import type { TSurveyBlocks } from "./surveys/blocks";
 import { getTextContent } from "./surveys/validation";
@@ -265,6 +265,58 @@ export const resolveEmbeddedValue = (
   if (coerced !== undefined) return coerced;
   if (field.defaultValue === null) return undefined;
   return coerceToEmbeddedDataType(field.defaultValue, field.dataType);
+};
+
+/**
+ * Finds a computed field by the key its value is stored under in `response.variables`.
+ *
+ * Returns `undefined` when nothing matches, which is a state that reaches production: a logic
+ * condition or a calculate action outlives the field it names whenever a variable is renamed or
+ * deleted and the rule keeps the old storage key.
+ */
+export const findComputedEmbeddedField = (
+  computedFields: readonly TLinkedEmbeddedField[],
+  storageKey: string
+): TLinkedEmbeddedField | undefined => computedFields.find((field) => field.link.storageKey === storageKey);
+
+/**
+ * The declared type of the computed field an operand names, or `undefined` when it names none.
+ *
+ * The optional chain is the point: both logic engines consult this to decide whether to coerce a
+ * hidden-field operand to a number, and that decision is made BEFORE the operator switch. Reading
+ * `.dataType` off a missing field throws there, and `evaluateSingleCondition`'s try/catch turns the
+ * throw into a silent `false` — so a stale operand would quietly change which branch a respondent
+ * takes, or what a quota counts, with no error anywhere. Unknown type means the coercion simply does
+ * not fire and evaluation falls through exactly as it does for a text variable.
+ */
+export const getComputedFieldDataType = (
+  computedFields: readonly TLinkedEmbeddedField[],
+  storageKey: string
+): TEmbeddedDataType | undefined => findComputedEmbeddedField(computedFields, storageKey)?.field.dataType;
+
+/**
+ * What the logic engines read a computed field's value as — **not** {@link resolveEmbeddedValue}.
+ *
+ * ENG-1837 repointed the *definition* lookup onto the EmbeddedData tables and deliberately left this
+ * value expression alone. `resolveEmbeddedValue` would coerce a non-numeric stored value to the
+ * field's declared default instead of `0`, and render a text field holding `0` as `"0"` rather than
+ * `""` — both of which change what already-stored responses evaluate to, and responses are never
+ * migrated (see the swap checklist on {@link resolveEmbeddedValue}, deltas (a) and (d)).
+ *
+ * Shared by `packages/surveys/src/lib/logic.ts` (the renderer) and `apps/web/lib/surveyLogic/utils.ts`
+ * (quotas, summaries, follow-up conditions), which are near-copies of each other. It lives here so
+ * the rule has one definition rather than two that can drift apart — the engines evaluating the same
+ * survey differently is its own bug class.
+ */
+export const getLogicVariableValue = (
+  computedFields: readonly TLinkedEmbeddedField[],
+  storageKey: string,
+  variablesData: TResponseVariables
+): string | number | undefined => {
+  const field = findComputedEmbeddedField(computedFields, storageKey);
+  if (!field) return undefined;
+  const variableValue = variablesData[storageKey];
+  return field.field.dataType === "number" ? Number(variableValue) || 0 : variableValue || "";
 };
 
 /**

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -488,11 +488,15 @@ export const getIngestedStorageKeys = (survey: TEmbeddedFieldsSurvey): string[] 
  *    two must agree on the same instant's definitions or the round-trip desyncs — a field added
  *    since the last save would render as a raw `#recall:…#` token, and a renamed one would stop
  *    matching. The same functions also label saved surveys for exports and summaries, where this is
- *    a provable no-op: `reconcileEmbeddedData` writes exactly `toDesiredEmbeddedFields(survey)` in
- *    the same transaction as every survey write, so a saved survey's rows and declarations agree
- *    element for element. They can only diverge once a shared library definition can be renamed
- *    independently of the survey (ENG-1851), which is also when the unified picker (ENG-1853) moves
- *    recall and the pickers onto the tables together.
+ *    a no-op — a saved survey's rows and declarations agree element for element, because every write
+ *    path that persists those columns calls `reconcileEmbeddedData` with
+ *    `toDesiredEmbeddedFields(<the persisted survey>)` in the same transaction. There are exactly
+ *    four: `updateSurveyInternal` and `createSurvey` (apps/web/lib/survey/service.ts), the copy flow
+ *    (modules/survey/list/lib/survey.ts) and the v3 patch (app/api/v3/surveys/patch.ts) — a
+ *    `reconcileEmbeddedData(` grep is the audit, and a fifth write that skips it reintroduces the
+ *    divergence. They can also diverge once a shared library definition can be renamed independently
+ *    of the survey (ENG-1851), which is when the unified picker (ENG-1853) moves recall and the
+ *    pickers onto the tables together.
  */
 // Takes the same survey slice as {@link getSurveyEmbeddedFields}, not the narrower legacy one, so a
 // caller holding a full survey can pass it and the "ignores the stored rows" contract is visible in

--- a/packages/types/embedded-data-resolver.ts
+++ b/packages/types/embedded-data-resolver.ts
@@ -435,10 +435,11 @@ export interface TEmbeddedFieldsSurvey extends TLegacyEmbeddedFields {
 }
 
 /**
- * **The one place that decides where a survey's Embedded Data definitions come from.** Every reader
- * — recall, logic, export columns, response filters, pickers, emails, integrations — calls this and
- * nothing else; no reader may call {@link deriveLegacyEmbeddedData} directly, which is what makes
- * "exactly one fallback decision point" a property a reviewer can check with grep.
+ * **Where a saved survey's Embedded Data definitions come from.** Every reader outside the editor —
+ * recall, logic, export columns, response filters, response tables, emails, integrations — calls
+ * this and nothing else. Its counterpart is {@link getDeclaredEmbeddedFields}; between the two, no
+ * reader may call {@link deriveLegacyEmbeddedData} directly, which is what keeps "exactly two named
+ * decisions, and no third" a property a reviewer can check with grep.
  *
  * Rows win when present. The empty-list test is deliberate rather than `!== undefined`: a select
  * that omits the join yields `undefined`, and a survey read through it must still resolve, while
@@ -465,3 +466,46 @@ export const getIngestedEmbeddedFields = (survey: TEmbeddedFieldsSurvey): TLinke
 /** The storage keys of a survey's ingested fields — what `response.data` addresses them by. */
 export const getIngestedStorageKeys = (survey: TEmbeddedFieldsSurvey): string[] =>
   getIngestedEmbeddedFields(survey).map(({ link }) => link.storageKey);
+
+/**
+ * **What a survey declares right now, ignoring what is stored.** The counterpart to
+ * {@link getSurveyEmbeddedFields}; between the two, no caller needs
+ * {@link deriveLegacyEmbeddedData} directly, so "which of two named decisions does this reader
+ * make" stays a property a reviewer can check with grep.
+ *
+ * Two groups of callers need this rather than the stored rows:
+ *
+ * 1. **The editor.** Its working copy is cloned from the server survey at mount and never
+ *    re-fetched, while the rows are only written on save — so an inlined `embeddedFields` is stale
+ *    from the first card edit until the next save. Deriving is what makes a rename or a newly added
+ *    field show up in the pickers, the logic builder, the calculate widget, the follow-up recipient
+ *    list and the preview on the next render. Note this cannot be fixed by reshaping the working
+ *    copy instead: it is compared against the server survey with a key-count-sensitive deep equal
+ *    to gate the draft auto-save, the discard-changes dialog and the beforeunload prompt, and a
+ *    save round-trip puts the server's shape back anyway.
+ * 2. **Recall labelling** (`apps/web/lib/utils/recall.ts`). A recall token's label is authoring
+ *    syntax: the picker writes `@label` into the text and the label resolver reads it back, so the
+ *    two must agree on the same instant's definitions or the round-trip desyncs — a field added
+ *    since the last save would render as a raw `#recall:…#` token, and a renamed one would stop
+ *    matching. The same functions also label saved surveys for exports and summaries, where this is
+ *    a provable no-op: `reconcileEmbeddedData` writes exactly `toDesiredEmbeddedFields(survey)` in
+ *    the same transaction as every survey write, so a saved survey's rows and declarations agree
+ *    element for element. They can only diverge once a shared library definition can be renamed
+ *    independently of the survey (ENG-1851), which is also when the unified picker (ENG-1853) moves
+ *    recall and the pickers onto the tables together.
+ */
+// Takes the same survey slice as {@link getSurveyEmbeddedFields}, not the narrower legacy one, so a
+// caller holding a full survey can pass it and the "ignores the stored rows" contract is visible in
+// the signature rather than enforced by which keys happen to be omitted at the call site.
+export const getDeclaredEmbeddedFields = (survey: TEmbeddedFieldsSurvey): TLinkedEmbeddedField[] =>
+  deriveLegacyEmbeddedData(survey);
+
+/** The computed (ex-variable) fields a survey declares right now. */
+export const getDeclaredComputedFields = (survey: TEmbeddedFieldsSurvey): TLinkedEmbeddedField[] =>
+  getDeclaredEmbeddedFields(survey).filter(({ field }) => field.source === "computed");
+
+/** The storage keys of the ingested (ex-hidden) fields a survey declares right now. */
+export const getDeclaredIngestedStorageKeys = (survey: TEmbeddedFieldsSurvey): string[] =>
+  getDeclaredEmbeddedFields(survey)
+    .filter(({ field }) => field.source === "ingested")
+    .map(({ link }) => link.storageKey);

--- a/packages/types/embedded-data.ts
+++ b/packages/types/embedded-data.ts
@@ -38,6 +38,22 @@ export const ZEmbeddedDataDefaultValue = z.union([z.string(), z.number(), z.bool
 
 export type TEmbeddedDataDefaultValue = z.infer<typeof ZEmbeddedDataDefaultValue>;
 
+/**
+ * A field's display name.
+ *
+ * Blank rather than empty: `name` is the label the library and the editor render, and a
+ * whitespace-only one draws a row with nothing to read or click. Checked, not trimmed, so the
+ * stored value is never silently rewritten.
+ *
+ * No length cap, for the same reason `storageKey` has none. A migrated field's name is copied
+ * from a variable name or a hidden field id, and neither `ZSurveyVariable` nor
+ * `ZSurveyHiddenFields` bounds its length, so a stored survey can carry one longer than any cap
+ * we would pick. Capping here would let the backfill write a row that then fails to read back —
+ * a failure that only surfaces once ENG-1837 points readers at these tables. The create-time
+ * limit belongs on the authoring path, alongside the naming rule.
+ */
+const ZEmbeddedDataName = z.string().refine((value) => value.trim().length > 0, "Name must not be blank");
+
 /** A `date` default is stored as a string, so pin it to ISO 8601 — either a date or a datetime. */
 const ZIsoDateOrDateTime = z.union([z.iso.date(), z.iso.datetime()]);
 
@@ -72,17 +88,7 @@ export const ZEmbeddedData = z
       // `lang`, and ingestion would then refuse to fill it — a field that can never hold a value.
       .refine((key) => !RESERVED_DECLARED_FIELD_NAMES.has(key.toLowerCase()), "Key is reserved")
       .nullable(),
-    // Blank rather than empty: `name` is the label the library and the editor render, and a
-    // whitespace-only one draws a row with nothing to read or click. Checked, not trimmed, so the
-    // stored value is never silently rewritten.
-    //
-    // No length cap, for the same reason `storageKey` has none. A migrated field's name is copied
-    // from a variable name or a hidden field id, and neither `ZSurveyVariable` nor
-    // `ZSurveyHiddenFields` bounds its length, so a stored survey can carry one longer than any cap
-    // we would pick. Capping here would let the backfill write a row that then fails to read back —
-    // a failure that only surfaces once ENG-1837 points readers at these tables. The create-time
-    // limit belongs on the authoring path, alongside the naming rule.
-    name: z.string().refine((value) => value.trim().length > 0, "Name must not be blank"),
+    name: ZEmbeddedDataName,
     description: z.string().nullable(),
     source: ZEmbeddedDataSource,
     dataType: ZEmbeddedDataType.prefault("string"),
@@ -208,3 +214,28 @@ export const ZSurveyEmbeddedData = z.object({
 });
 
 export type TSurveyEmbeddedData = z.infer<typeof ZSurveyEmbeddedData>;
+
+/**
+ * The Zod mirror of `TLinkedEmbeddedField` (embedded-data-resolver.ts) — a stored field definition
+ * paired with the survey link that addresses it, as it rides inlined on a survey object.
+ *
+ * It exists as a schema because ENG-1837 inlines these pairs onto `ZSurveyBase`, and Zod v4 strips
+ * keys a schema does not declare: without this the join would survive the fetch and then vanish the
+ * first time a survey passed through `ZSurvey.parse` — including on the SDK and link-survey payload
+ * paths, which are exactly the ones that need it.
+ *
+ * Only the columns the read seam consumes are mirrored (the resolver's `TResolvableEmbeddedField`
+ * plus `name`), never the row's ids, ownership or timestamps: this shape ships to public survey
+ * payloads, so anything extra would be a leak rather than an unused field. A type-level
+ * assignability test in embedded-data-resolver.test.ts keeps the two definitions in step.
+ */
+export const ZLinkedEmbeddedField = z.object({
+  field: z.object({
+    name: ZEmbeddedDataName,
+    source: ZEmbeddedDataSource,
+    dataType: ZEmbeddedDataType,
+    defaultValue: ZEmbeddedDataDefaultValue,
+    locked: z.boolean(),
+  }),
+  link: ZSurveyEmbeddedData.pick({ storageKey: true }),
+});

--- a/packages/types/js.ts
+++ b/packages/types/js.ts
@@ -24,6 +24,9 @@ export const ZJsWorkspaceStateSurvey = ZSurveyBase.pick({
   displayLimit: true,
   displayOption: true,
   hiddenFields: true,
+  // The inlined Embedded Data definitions (ENG-1837). Picked so the join survives this parse and
+  // reaches the renderer's logic/recall engines, which resolve definitions through it.
+  embeddedFields: true,
   triggers: true,
   displayPercentage: true,
   delay: true,

--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -3826,7 +3826,18 @@ const validateBlockLogic = (
 };
 
 // ZSurvey is refined, so update/create inputs start from ZSurveyBase and reapply the same refinement.
-export const ZSurveyUpdateInput = ZSurveyBase.omit({ createdAt: true, updatedAt: true, followUps: true })
+export const ZSurveyUpdateInput = ZSurveyBase.omit({
+  createdAt: true,
+  updatedAt: true,
+  followUps: true,
+  // Read-only projection of the EmbeddedData tables (ENG-1837), omitted for the same reason as on
+  // both create inputs: nothing may reach a Prisma write through this schema. Omitting STRIPS rather
+  // than rejects, so the v1 PUT round-trip — which re-parses the loaded survey merged with the patch
+  // — is unaffected; `updateSurveyInternal` still destructures the key out, because callers that hand
+  // it a raw `TSurvey` (the editor's save actions, the summary's single-use toggle) never go through
+  // this schema at all.
+  embeddedFields: true,
+})
   .extend({
     followUps: z
       .array(

--- a/packages/types/surveys/types.ts
+++ b/packages/types/surveys/types.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { ZActionClass, ZActionClassNoCodeConfig } from "../action-classes";
 import { ZColor, ZEndingCardUrl, ZId, ZOverlay, ZPlacement, ZStorageUrl, getZSafeUrl } from "../common";
 import { ZContactAttributes } from "../contact-attribute";
+import { ZLinkedEmbeddedField } from "../embedded-data";
 import { type TI18nString, ZI18nString } from "../i18n";
 import { isLegacyIdCharset, isLegacyVariableName } from "../safe-identifier";
 import { ZSegment } from "../segment";
@@ -921,6 +922,18 @@ export const ZSurveyBase = z.object({
     }
   }),
   hiddenFields: ZSurveyHiddenFields,
+  /**
+   * The survey's Embedded Data definitions, joined from `EmbeddedData` / `SurveyEmbeddedData` and
+   * inlined when the survey is loaded (ENG-1837). This is the **read** source of truth for every
+   * reader — reach it through `getSurveyEmbeddedFields`, never directly, so surveys read through a
+   * select that omits the join still fall back to the legacy columns below.
+   *
+   * Read-only and optional. Optional because every survey literal, fixture and create payload in the
+   * codebase predates it; read-only because `variables` / `hiddenFields` remain the written columns
+   * until the legacy JSON is dropped — the write paths that spread a survey object into Prisma strip
+   * this key explicitly, and both create-input schemas omit it.
+   */
+  embeddedFields: z.array(ZLinkedEmbeddedField).optional(),
   variables: ZSurveyVariables.superRefine((variables, ctx) => {
     // variable ids must be unique
     const variableIds = variables.map((v) => v.id);
@@ -3856,6 +3869,11 @@ export const ZSurveyCreateInput = makeSchemaOptional(ZSurveyBase)
     // archivedAt is owned exclusively by the archive/restore flows; a create must never set it,
     // otherwise a caller could POST an already-archived, purge-eligible survey.
     archivedAt: true,
+    // Read-only projection of the EmbeddedData tables (ENG-1837). `createSurvey` spreads the parsed
+    // body straight into `Prisma.SurveyCreateInput`, and `Survey` owns relations named
+    // `embeddedData` / `embeddedDataLinks`, so admitting this key would turn a read projection into
+    // a nested relation write. The rows are written by `reconcileEmbeddedData` instead.
+    embeddedFields: true,
   })
   .extend({
     name: z.string(), // Keep name required
@@ -3907,6 +3925,11 @@ export const ZSurveyCreateInputWithWorkspaceId = makeSchemaOptional(ZSurveyBase)
     // archivedAt is owned exclusively by the archive/restore flows; a create must never set it,
     // otherwise a caller could POST an already-archived, purge-eligible survey.
     archivedAt: true,
+    // Read-only projection of the EmbeddedData tables (ENG-1837). `createSurvey` spreads the parsed
+    // body straight into `Prisma.SurveyCreateInput`, and `Survey` owns relations named
+    // `embeddedData` / `embeddedDataLinks`, so admitting this key would turn a read projection into
+    // a nested relation write. The rows are written by `reconcileEmbeddedData` instead.
+    embeddedFields: true,
   })
   .extend({
     name: z.string(), // Keep name required

--- a/turbo.json
+++ b/turbo.json
@@ -418,7 +418,8 @@
       "persistent": true
     },
     "generate": {
-      "dependsOn": ["^generate"]
+      "dependsOn": ["^generate"],
+      "outputs": ["generated/prisma/**"]
     },
     "go": {
       "cache": false,


### PR DESCRIPTION
## What & why

ENG-1833 added the tables, ENG-1978 keeps them current on editor saves, ENG-1836 built the read seam
and ENG-1835 backfilled every existing survey. Nothing read any of it yet. This makes the tables the
read source of truth: survey loads join the linked `EmbeddedData` rows and inline them onto the survey
object as `embeddedFields`, and every reader resolves definitions through that instead of
`survey.variables` / `survey.hiddenFields`.

**Definitions move; values do not.** That distinction is the whole PR. The resolver's own ENG-1837 swap
checklist (`embedded-data-resolver.ts`) names four places where `resolveEmbeddedValue`'s semantics
deliberately differ from today's consumers — a number variable holding a non-numeric string, a response
missing a variable's key, recall rendering uncoerced values, and the two recall paths disagreeing on a
key present in both maps. Adopting it for value lookup would have satisfied "no direct reads" while
silently changing exported data, so **every call site keeps its value expression verbatim**:
`Number(v) || 0`, `v || ""`, `response.variables[storageKey]` and `response.data[storageKey]` are
untouched. `resolveEmbeddedValue` is called from **zero** call sites; `coerceToEmbeddedDataType` from
exactly one — seeding a computed field's initial value, where it provably equals the declared value for
every legacy variable shape (`ZSurveyVariable.value` is always non-null and type-matched, so the coerce
is a pass-through).

### Two accessors, two questions

| Accessor | Answers | Callers |
| --- | --- | --- |
| `getSurveyEmbeddedFields` | *what is stored* — rows win, cards as fallback | export, response filters, response table, summary, single-response card, emails, integrations, both logic engines, Notion mapping |
| `getDeclaredEmbeddedFields` | *what the author declares right now* — cards only | recall picker, logic operand picker, calculate widget, follow-up recipients, editor preview, recall labelling |

The editor needs the second because `localSurvey` is cloned once at mount and the rows are only written
on save. An earlier attempt stripped `embeddedFields` from that clone instead — which broke change
detection for **every** survey, since `isDeepEqual` short-circuits on key count, leaving an idle draft
editor auto-saving every ten seconds. `localSurvey` is a plain `structuredClone` again and there is a
guard test pinning that.

Recall *labelling* sits on the declared side too, because the picker writes `@label` into the text and
`getRecallItems` reads it back by matching that label — split them and a field renamed since the last
save leaves a raw `#recall:…#` tag in the input. **This constrains ENG-1853:** the unified picker has to
move recall and the picker onto the tables together, not one at a time.

### Order

Neither table carries an ordinal column, so the legacy JSON columns stay the source of truth for
**order** while the rows are the source of truth for **definitions**. Joined rows are sorted by their
index in `toDesiredEmbeddedFields`, which reproduces today's CSV and picker order exactly. Revisit when
the legacy columns are dropped.

### One write path had to change

`patchV3Survey` wrote `variables` / `hiddenFields` and never reconciled the rows, so the reconciling
writes were three, not four. Dormant while readers used the legacy columns this write *does* update —
but pointing readers at the rows makes it a live regression: after `PATCH /api/v3/surveys/{id}` or MCP
`patch_survey`, a newly added variable would be invisible to the logic engine, export columns, the
response table, the summary and the response filters. The reconcile now runs in the same transaction as
the survey update, derived from the persisted survey rather than the patch document (a patch may omit
either key, and reading the payload would see them as absent and delete every row). The transaction is
unconditional now, where it previously existed only when targeting changed.

Both doc comments enumerate the four reconciling writes by name, so `grep reconcileEmbeddedData(` is the
audit rather than a claim to be trusted.

### Two unrelated fixes, in their own commits

Both were found while working on this and are independent of the read repoint — split out so they can be
dropped or cherry-picked without touching the rest.

- **`fix(playwright)`** — `login`, `signUpAndLogin` and `signupUsingInviteToken` queried
  `getByRole("button", { name: "Login with Email" })`, but the button renders "Log in with Email". Role
  name matching is substring-based, so none of the seven queries could ever match. Dead code today
  (every spec authenticates through the `users` fixture), which is why nobody noticed.
- **`fix(turbo)`** — the `generate` task declared no `outputs`, so turbo cached it with an empty output
  set. On a cache hit it restores nothing *and* skips the task, including the clean step that deletes
  `generated/prisma` — so once the client is missing it stays missing while turbo reports FULL TURBO,
  and every downstream typecheck and build fails on the absent client. Reproduced and fixed against that
  exact case. This bit me mid-PR.

## Linear ticket

https://linear.app/formbricks/issue/ENG-1837/repoint-readers-to-the-tables-inline-definitions-on-survey-load

Milestone 1 of [Embedded Data](https://linear.app/formbricks/project/embedded-data-3d184a43d2f9).
Targets `epic/embedded-data-v1` — all of v1 ships as one release, so this does not reach production
until the epic merges. Ships together with ENG-1838 (SDK/API serialisation back-compat).

## Screenshots

**Identical output is the acceptance criterion here, not a coincidence** — v1 is invisible plumbing, so
a conventional before/after would just be the same image twice. Instead, this is the *same page* served
through the two code paths this PR puts side by side: on the left the survey's `SurveyEmbeddedData`
links are deleted, so definitions resolve through the legacy JSON columns (the fallback); on the right
they resolve through the tables.

| Before — legacy JSON path | After — EmbeddedData tables path |
| --- | --- |
| <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8857/before-legacy-json-path.jpg" width="440"> | <img src="https://raw.githubusercontent.com/formbricks/formbricks/assets-itsjavi-prs/pr-8857/after-tables-path.jpg" width="440"> |

Same survey, same responses, same scroll position; column headers and every cell match, verified
programmatically as well as visually. Note the second row: `utm_source` is `ads` but `plan` is **empty**,
because that response never captured it — a resolver-based implementation would have filled it with the
field's default. That empty cell is the point of the PR.

## How this was tested

**Full suite green, against a clean baseline.** `pnpm test` on the epic base before any change was
25/25 tasks with zero failures, so there is no pre-existing noise to hide behind — every number below is
directly comparable.

| | baseline `244afe6` | this branch |
| --- | --- | --- |
| turbo tasks | 25/25 | 25/25 |
| `@formbricks/web` | 7638 | 7667 |
| `@formbricks/surveys` | 665 | 675 |
| `@formbricks/types` | 203 | 222 |

`pnpm typecheck` 25/25 · `pnpm lint` 20/20, 0 errors (web warnings 43, all pre-existing, verified
against baseline blobs) · `prettier --check` clean on every changed file · `pnpm i18n:validate` passed
(no strings changed).

**Integration — 12 new against real Postgres.** `embedded-data-read.integration.test.ts` (6): the join
round-trips, the raw relation never leaks onto `TSurvey`, declared ordering is preserved, a survey
missing its backfill falls back, the partial-row case is pinned, and reads write nothing.
`embedded-data-v3-patch.integration.test.ts` (6): add / rename / remove a variable or hidden field via
the **real** `patchV3Survey` and assert the rows match the persisted columns, plus response integrity.

**Every claim was checked by sabotage, not assumed.** Each of these was run by breaking the code and
confirming the intended test — and only that test — fails:

| Sabotage | Result |
| --- | --- |
| delete the `reconcileEmbeddedData` call in the v3 patch | 4 of 6 integration tests fail (add / add / rename / remove) |
| make the reconcile migrate stored answers on rename | **only** the AC-4 response-integrity test fails, with the exact corruption it forbids |
| revert recall labelling to the stored accessor | 2 recall tests fail |
| remove the `storageKey` refinements | the blank/whitespace schema test fails |
| strip `embeddedFields` from the editor clone | the change-detection guard fails |

Three tests that *couldn't* fail were caught in review and rebuilt: one compared a pure function with
itself; one used an empty `embeddedFields`, which the stored accessor treats as "no join" and answers
from the declarations anyway; and the AC-4 test seeded no responses, so it could only have caught a
reconcile that *created* a row rather than one that re-keyed existing answers.

**End-to-end against a running app.** A fixture survey was built so the row order and the declared order
disagree in both groups (variables `zscore`→`atext`, hidden fields `utm_source`→`plan`; under
`storageKey ASC` the DB returns `plan, atext, zscore, utm_source`). Exported through the real UI:

```
… ,"1. How satisfied are you with our product?","zscore","atext","utm_source","plan"
1,"…0003", … ,"","abc","","","free"
2,"…0002", … ,"",13,,"ads",""
3,"…0001", … ,"",42,"alpha","newsletter","pro"
```

Declared order, and the three preserved deltas visible in real data: response `…0002` has no `atext`
and no `plan`, so both cells are **empty** rather than showing the declared defaults `"seed"` / a
fallback; response `…0003` holds `"abc"` in the *number* variable and exports it verbatim rather than
coercing it or substituting the declared `7`. Under a resolver-based implementation all three cells
would have changed.

**Playwright — 1 new spec**, `survey-editor-embedded-fields.spec.ts` (`@slow`), covering AC #3, the one
criterion only a browser can prove. It saves a survey, then **poisons the stored row behind the
editor's back** (renames it, flips its `dataType`) so the row and the card actively disagree, and
asserts every editor surface follows the card — recall picker via both the `@` keyboard path and the
toolbar button, logic operand picker, and the calculate widget's input `type`. Then it renames and
retypes the variable live, without reloading, and re-asserts all three. The poisoned row is what makes
the test able to fail: on a fresh survey an empty row list falls back to the cards anyway, so a naïve
implementation would pass.

`npx playwright test survey-editor-embedded-fields.spec.ts --project=chromium` → 1 passed;
`--repeat-each=3 --workers=1` → 3 passed; alongside `survey-editor-rich-text-tabs.spec.ts` → 3 passed.

⚠️ Under 2 parallel workers it flakes on the shared `waitForSurveyEditor` helper. **Pre-existing and
environmental** — it reproduces identically on `survey-editor-rich-text-tabs.spec.ts`, which this PR
does not touch, and is caused by 2 workers plus a `next dev --turbopack` server on 4 vCPUs with HMR
remounts mid-run. CI builds for production and runs `pnpm start`. No timeout was raised to paper over
it.

**Not tested here:** follow-up emails (needs SMTP) and the third-party integrations (need credentials) —
both are covered by unit tests only. Widget bundle grew 952,982 → 954,348 B (+0.14%); zod was already
present, so no new dependency.

## Breaking changes

None.

`embeddedFields` is explicitly stripped from the v1 management responses
(`withoutInternalSurveyProjections`, applied at all four survey-returning sites), because API
serialisation belongs to ENG-1838. The SDK workspace state and the link-survey payload deliberately
carry it — that is part 1 of this ticket. v2 has no survey-body endpoint and v3 builds an explicit
object.

## QA / Test Plan

**How to test**

- [ ] Open a survey with at least two variables and two hidden fields → Responses → Download → CSV →
      the variable and hidden-field columns appear in the order they were declared in the editor cards,
      variables first, exactly as before this change
- [ ] Same survey → Responses table → the same columns in the same order
- [ ] A response that never captured one of those fields → the cell is **empty**, not the field's
      default value
- [ ] A number variable whose stored value is not a number (e.g. set by a calculate action) → exports
      verbatim, not coerced and not replaced by its default
- [ ] Survey editor → add a hidden field in the Hidden Fields card → **without reloading**, type `@` in
      a question headline → the new field is offered in the recall dropdown
- [ ] Same, without reloading → open Logic → the new field appears in the operand picker
- [ ] Rename a variable and change its type Text → Number → without reloading, the calculate action's
      value input becomes numeric and the logic operand picker shows the new name
- [ ] Follow-ups tab → "Send to" dropdown → a hidden field added moments ago (unsaved) is offered
- [ ] Open a draft survey editor and leave it untouched for ~30 seconds → **no** auto-save fires (the
      survey's "last updated" does not advance); pressing Back navigates without a discard-changes
      dialog
- [ ] `PATCH /api/v3/surveys/{surveyId}` adding a variable → that variable then appears as an export
      column and can be used in a logic condition
- [ ] Rename a hidden field via the API on a survey with responses → previously collected responses keep
      their original values under the original key (renaming orphans history, exactly as before)
- [ ] Recall, logic branching and calculations on an existing survey behave exactly as before

**Preconditions / test data**

- A workspace with surveys that have both variables and hidden fields, and responses collected before
  this change — including at least one response predating a variable's creation, so the "missing key
  stays empty" case is exercised.
- Ideally a survey whose variables were reordered after creation, to confirm export header order.
- For the v3 patch case: an API key with survey write access, or the MCP `patch_survey` tool.

**Risks & regressions**

- **Highest:** anything reading Embedded Data now goes through a join. If a survey select were missed,
  that reader falls back to the legacy columns and stays correct — the failure mode is silent staleness,
  not an error. The place to look first is export column order and the response table.
- **v3 PATCH now always runs in a transaction** where targeting-free patches previously ran as a single
  statement. Watch for lock duration or connection-pool pressure under concurrent patching.
- Editor change detection is the subtle one: if the draft auto-save starts firing on an untouched
  editor, or Back always prompts to discard, that is this PR.
- Recall tokens for fields renamed since the last save are the second subtle one: a raw `#recall:…#`
  tag rendering in an input means the picker and the labeller have desynced.

**Migrations / env / cutover**

- none. No schema change, no data migration, no env change. Reads only — no `Response` row is read or
  written by anything this PR adds.
