### PR TITLE
fix(entitlements): treat null self-hosted workspace license as unlimited

### DIFF
--- a/apps/web/modules/ee/license-check/lib/utils.test.ts
+++ b/apps/web/modules/ee/license-check/lib/utils.test.ts
@@ -579,13 +579,41 @@ describe("License Utils", () => {
       expect(result).toBe(5);
     });
 
-    test("returns 3 for self-hosted without active workspace entitlement", async () => {
+    test("returns Infinity for self-hosted when an active license grants unlimited workspaces", async () => {
       vi.mocked(constants).IS_FORMBRICKS_CLOUD = false;
       vi.mocked(getOrganizationEntitlementsContext).mockResolvedValue({
         ...defaultEntitlementsContext,
         source: "self_hosted_license",
         licenseStatus: "active",
         licenseFeatures: { ...defaultFeatures, workspaces: null },
+      });
+
+      const result = await getOrganizationWorkspacesLimit("org_1");
+
+      expect(result).toBe(Infinity);
+    });
+
+    test("returns 3 for self-hosted when the license is not active", async () => {
+      vi.mocked(constants).IS_FORMBRICKS_CLOUD = false;
+      vi.mocked(getOrganizationEntitlementsContext).mockResolvedValue({
+        ...defaultEntitlementsContext,
+        source: "self_hosted_license",
+        licenseStatus: "expired",
+        licenseFeatures: { ...defaultFeatures, workspaces: null },
+      });
+
+      const result = await getOrganizationWorkspacesLimit("org_1");
+
+      expect(result).toBe(3);
+    });
+
+    test("returns 3 for self-hosted when there are no license features", async () => {
+      vi.mocked(constants).IS_FORMBRICKS_CLOUD = false;
+      vi.mocked(getOrganizationEntitlementsContext).mockResolvedValue({
+        ...defaultEntitlementsContext,
+        source: "self_hosted_license",
+        licenseStatus: "active",
+        licenseFeatures: null,
       });
 
       const result = await getOrganizationWorkspacesLimit("org_1");

--- a/apps/web/modules/ee/license-check/lib/utils.ts
+++ b/apps/web/modules/ee/license-check/lib/utils.ts
@@ -193,11 +193,9 @@ export const getOrganizationWorkspacesLimit = async (organizationId: string): Pr
     return entitlementsContext.limits.workspaces ?? Infinity;
   }
 
-  if (
-    entitlementsContext.licenseStatus === "active" &&
-    entitlementsContext.licenseFeatures?.workspaces != null
-  ) {
-    return entitlementsContext.licenseFeatures.workspaces;
+  // `workspaces: null` on an active license means unlimited, mirroring the cloud branch above.
+  if (entitlementsContext.licenseStatus === "active" && entitlementsContext.licenseFeatures) {
+    return entitlementsContext.licenseFeatures.workspaces ?? Infinity;
   }
 
   return 3;

--- a/apps/web/modules/entitlements/lib/self-hosted-provider.test.ts
+++ b/apps/web/modules/entitlements/lib/self-hosted-provider.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
+import type { TOrganization } from "@formbricks/types/organizations";
 import { getOrganization } from "@/lib/organization/service";
 import { getEnterpriseLicense } from "@/modules/ee/license-check/lib/license";
 import { TEnterpriseLicenseFeatures } from "@/modules/ee/license-check/types/enterprise-license";
@@ -19,6 +20,27 @@ const mockGetOrg = vi.mocked(getOrganization);
 const mockGetLicense = vi.mocked(getEnterpriseLicense);
 
 type TLicenseResult = Awaited<ReturnType<typeof getEnterpriseLicense>>;
+
+/**
+ * The provider reads nothing off the organization — it only rejects a missing one — so this exists to
+ * satisfy the return type rather than to carry meaningful values. Typed so it still has to be a real
+ * `TOrganization` if the shape changes.
+ */
+const organization: TOrganization = {
+  id: "org1",
+  name: "Test Organization",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  billing: {
+    stripeCustomerId: null,
+    limits: {
+      workspaces: 3,
+      monthly: { responses: 1500, workflowRuns: null },
+    },
+    usageCycleAnchor: null,
+  },
+  isAISmartToolsEnabled: false,
+};
 
 /**
  * Complete feature set, everything off. Typed rather than cast so a new field on
@@ -83,7 +105,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
   });
 
   test("returns context with no license features", async () => {
-    mockGetOrg.mockResolvedValue({ id: "org1" } as any);
+    mockGetOrg.mockResolvedValue(organization);
     mockGetLicense.mockResolvedValue(noLicense());
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
@@ -102,7 +124,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
   });
 
   test("maps license features to entitlements", async () => {
-    mockGetOrg.mockResolvedValue({ id: "org1" } as any);
+    mockGetOrg.mockResolvedValue(organization);
     mockGetLicense.mockResolvedValue(
       activeLicense({
         removeBranding: true,
@@ -125,7 +147,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
   });
 
   test("keeps workspaces null (unlimited) when an active license grants unlimited workspaces", async () => {
-    mockGetOrg.mockResolvedValue({ id: "org1" } as any);
+    mockGetOrg.mockResolvedValue(organization);
     mockGetLicense.mockResolvedValue(activeLicense({ workspaces: null, contacts: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
@@ -134,7 +156,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
   });
 
   test("defaults workspaces to 3 when license is inactive", async () => {
-    mockGetOrg.mockResolvedValue({ id: "org1" } as any);
+    mockGetOrg.mockResolvedValue(organization);
     mockGetLicense.mockResolvedValue(
       expiredLicense({ workspaces: 10, contacts: true, spamProtection: true })
     );
@@ -146,7 +168,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
   });
 
   test("maps whitelabel feature to hide-branding", async () => {
-    mockGetOrg.mockResolvedValue({ id: "org1" } as any);
+    mockGetOrg.mockResolvedValue(organization);
     mockGetLicense.mockResolvedValue(activeLicense({ whitelabel: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
@@ -155,7 +177,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
   });
 
   test("maps aiSmartTools feature to ai-smart-tools entitlement", async () => {
-    mockGetOrg.mockResolvedValue({ id: "org1" } as any);
+    mockGetOrg.mockResolvedValue(organization);
     mockGetLicense.mockResolvedValue(activeLicense({ aiSmartTools: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
@@ -164,7 +186,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
   });
 
   test("maps feedbackDirectories feature to feedback-directories entitlement", async () => {
-    mockGetOrg.mockResolvedValue({ id: "org1" } as any);
+    mockGetOrg.mockResolvedValue(organization);
     mockGetLicense.mockResolvedValue(activeLicense({ feedbackDirectories: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
@@ -174,7 +196,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
   });
 
   test("maps dashboards feature to dashboards entitlement", async () => {
-    mockGetOrg.mockResolvedValue({ id: "org1" } as any);
+    mockGetOrg.mockResolvedValue(organization);
     mockGetLicense.mockResolvedValue(activeLicense({ dashboards: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
@@ -184,7 +206,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
   });
 
   test("maps workflows feature to workflows entitlement", async () => {
-    mockGetOrg.mockResolvedValue({ id: "org1" } as any);
+    mockGetOrg.mockResolvedValue(organization);
     mockGetLicense.mockResolvedValue(activeLicense({ workflows: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
@@ -194,7 +216,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
   });
 
   test("does not map workflows entitlement when the license flag is off", async () => {
-    mockGetOrg.mockResolvedValue({ id: "org1" } as any);
+    mockGetOrg.mockResolvedValue(organization);
     mockGetLicense.mockResolvedValue(activeLicense({ workflows: false, dashboards: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
@@ -203,7 +225,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
   });
 
   test("maps both Hub features when all enabled", async () => {
-    mockGetOrg.mockResolvedValue({ id: "org1" } as any);
+    mockGetOrg.mockResolvedValue(organization);
     mockGetLicense.mockResolvedValue(activeLicense({ feedbackDirectories: true, dashboards: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
@@ -213,7 +235,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
   });
 
   test("does not map Hub features when license inactive even if flags are true", async () => {
-    mockGetOrg.mockResolvedValue({ id: "org1" } as any);
+    mockGetOrg.mockResolvedValue(organization);
     mockGetLicense.mockResolvedValue(expiredLicense({ feedbackDirectories: true, dashboards: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");

--- a/apps/web/modules/entitlements/lib/self-hosted-provider.test.ts
+++ b/apps/web/modules/entitlements/lib/self-hosted-provider.test.ts
@@ -73,6 +73,19 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
     expect(result.limits.workspaces).toBe(10);
   });
 
+  test("keeps workspaces null (unlimited) when an active license grants unlimited workspaces", async () => {
+    mockGetOrg.mockResolvedValue({ id: "org1" } as any);
+    mockGetLicense.mockResolvedValue({
+      status: "active",
+      active: true,
+      features: { workspaces: null, contacts: true },
+    } as any);
+
+    const result = await getSelfHostedOrganizationEntitlementsContext("org1");
+
+    expect(result.limits.workspaces).toBeNull();
+  });
+
   test("defaults workspaces to 3 when license is inactive", async () => {
     mockGetOrg.mockResolvedValue({ id: "org1" } as any);
     mockGetLicense.mockResolvedValue({

--- a/apps/web/modules/entitlements/lib/self-hosted-provider.test.ts
+++ b/apps/web/modules/entitlements/lib/self-hosted-provider.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { getOrganization } from "@/lib/organization/service";
 import { getEnterpriseLicense } from "@/modules/ee/license-check/lib/license";
+import { TEnterpriseLicenseFeatures } from "@/modules/ee/license-check/types/enterprise-license";
 import { getSelfHostedOrganizationEntitlementsContext } from "./self-hosted-provider";
 
 vi.mock("server-only", () => ({}));
@@ -17,6 +18,58 @@ vi.mock("@/modules/ee/license-check/lib/license", () => ({
 const mockGetOrg = vi.mocked(getOrganization);
 const mockGetLicense = vi.mocked(getEnterpriseLicense);
 
+type TLicenseResult = Awaited<ReturnType<typeof getEnterpriseLicense>>;
+
+/**
+ * Complete feature set, everything off. Typed rather than cast so a new field on
+ * `ZEnterpriseLicenseFeatures` breaks this file instead of silently defaulting to absent — the tests
+ * below assert on which entitlements a flag does and does not produce, which only means something if
+ * the unnamed flags are genuinely off.
+ */
+const licenseFeatures = (
+  overrides: Partial<TEnterpriseLicenseFeatures> = {}
+): TEnterpriseLicenseFeatures => ({
+  isMultiOrgEnabled: false,
+  contacts: false,
+  workspaces: 3,
+  whitelabel: false,
+  removeBranding: false,
+  twoFactorAuth: false,
+  sso: false,
+  saml: false,
+  spamProtection: false,
+  aiSmartTools: false,
+  auditLogs: false,
+  accessControl: false,
+  quotas: false,
+  feedbackDirectories: false,
+  dashboards: false,
+  workflows: false,
+  ...overrides,
+});
+
+const activeLicense = (features: Partial<TEnterpriseLicenseFeatures> = {}): TLicenseResult => ({
+  status: "active",
+  active: true,
+  features: licenseFeatures(features),
+  lastChecked: new Date(),
+  isPendingDowngrade: false,
+  fallbackLevel: "live",
+});
+
+const expiredLicense = (features: Partial<TEnterpriseLicenseFeatures> = {}): TLicenseResult => ({
+  ...activeLicense(features),
+  status: "expired",
+  active: false,
+});
+
+const noLicense = (): TLicenseResult => ({
+  ...activeLicense(),
+  status: "no-license",
+  active: false,
+  features: null,
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -24,14 +77,14 @@ beforeEach(() => {
 describe("getSelfHostedOrganizationEntitlementsContext", () => {
   test("throws ResourceNotFoundError when organization is null", async () => {
     mockGetOrg.mockResolvedValue(null);
-    mockGetLicense.mockResolvedValue({ status: "no-license", features: null, active: false } as any);
+    mockGetLicense.mockResolvedValue(noLicense());
 
     await expect(getSelfHostedOrganizationEntitlementsContext("org1")).rejects.toThrow(ResourceNotFoundError);
   });
 
   test("returns context with no license features", async () => {
     mockGetOrg.mockResolvedValue({ id: "org1" } as any);
-    mockGetLicense.mockResolvedValue({ status: "no-license", features: null, active: false } as any);
+    mockGetLicense.mockResolvedValue(noLicense());
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
 
@@ -50,18 +103,16 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
 
   test("maps license features to entitlements", async () => {
     mockGetOrg.mockResolvedValue({ id: "org1" } as any);
-    mockGetLicense.mockResolvedValue({
-      status: "active",
-      active: true,
-      features: {
+    mockGetLicense.mockResolvedValue(
+      activeLicense({
         removeBranding: true,
         accessControl: true,
         quotas: false,
         spamProtection: true,
         contacts: true,
         workspaces: 10,
-      },
-    } as any);
+      })
+    );
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
 
@@ -75,11 +126,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
 
   test("keeps workspaces null (unlimited) when an active license grants unlimited workspaces", async () => {
     mockGetOrg.mockResolvedValue({ id: "org1" } as any);
-    mockGetLicense.mockResolvedValue({
-      status: "active",
-      active: true,
-      features: { workspaces: null, contacts: true },
-    } as any);
+    mockGetLicense.mockResolvedValue(activeLicense({ workspaces: null, contacts: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
 
@@ -88,11 +135,9 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
 
   test("defaults workspaces to 3 when license is inactive", async () => {
     mockGetOrg.mockResolvedValue({ id: "org1" } as any);
-    mockGetLicense.mockResolvedValue({
-      status: "expired",
-      active: false,
-      features: { workspaces: 10, contacts: true, spamProtection: true },
-    } as any);
+    mockGetLicense.mockResolvedValue(
+      expiredLicense({ workspaces: 10, contacts: true, spamProtection: true })
+    );
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
 
@@ -102,11 +147,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
 
   test("maps whitelabel feature to hide-branding", async () => {
     mockGetOrg.mockResolvedValue({ id: "org1" } as any);
-    mockGetLicense.mockResolvedValue({
-      status: "active",
-      active: true,
-      features: { whitelabel: true },
-    } as any);
+    mockGetLicense.mockResolvedValue(activeLicense({ whitelabel: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
 
@@ -115,11 +156,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
 
   test("maps aiSmartTools feature to ai-smart-tools entitlement", async () => {
     mockGetOrg.mockResolvedValue({ id: "org1" } as any);
-    mockGetLicense.mockResolvedValue({
-      status: "active",
-      active: true,
-      features: { aiSmartTools: true },
-    } as any);
+    mockGetLicense.mockResolvedValue(activeLicense({ aiSmartTools: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
 
@@ -128,11 +165,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
 
   test("maps feedbackDirectories feature to feedback-directories entitlement", async () => {
     mockGetOrg.mockResolvedValue({ id: "org1" } as any);
-    mockGetLicense.mockResolvedValue({
-      status: "active",
-      active: true,
-      features: { feedbackDirectories: true },
-    } as any);
+    mockGetLicense.mockResolvedValue(activeLicense({ feedbackDirectories: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
 
@@ -142,11 +175,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
 
   test("maps dashboards feature to dashboards entitlement", async () => {
     mockGetOrg.mockResolvedValue({ id: "org1" } as any);
-    mockGetLicense.mockResolvedValue({
-      status: "active",
-      active: true,
-      features: { dashboards: true },
-    } as any);
+    mockGetLicense.mockResolvedValue(activeLicense({ dashboards: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
 
@@ -156,11 +185,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
 
   test("maps workflows feature to workflows entitlement", async () => {
     mockGetOrg.mockResolvedValue({ id: "org1" } as any);
-    mockGetLicense.mockResolvedValue({
-      status: "active",
-      active: true,
-      features: { workflows: true },
-    } as any);
+    mockGetLicense.mockResolvedValue(activeLicense({ workflows: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
 
@@ -170,11 +195,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
 
   test("does not map workflows entitlement when the license flag is off", async () => {
     mockGetOrg.mockResolvedValue({ id: "org1" } as any);
-    mockGetLicense.mockResolvedValue({
-      status: "active",
-      active: true,
-      features: { workflows: false, dashboards: true },
-    } as any);
+    mockGetLicense.mockResolvedValue(activeLicense({ workflows: false, dashboards: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
 
@@ -183,11 +204,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
 
   test("maps both Hub features when all enabled", async () => {
     mockGetOrg.mockResolvedValue({ id: "org1" } as any);
-    mockGetLicense.mockResolvedValue({
-      status: "active",
-      active: true,
-      features: { feedbackDirectories: true, dashboards: true },
-    } as any);
+    mockGetLicense.mockResolvedValue(activeLicense({ feedbackDirectories: true, dashboards: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
 
@@ -197,11 +214,7 @@ describe("getSelfHostedOrganizationEntitlementsContext", () => {
 
   test("does not map Hub features when license inactive even if flags are true", async () => {
     mockGetOrg.mockResolvedValue({ id: "org1" } as any);
-    mockGetLicense.mockResolvedValue({
-      status: "expired",
-      active: false,
-      features: { feedbackDirectories: true, dashboards: true },
-    } as any);
+    mockGetLicense.mockResolvedValue(expiredLicense({ feedbackDirectories: true, dashboards: true }));
 
     const result = await getSelfHostedOrganizationEntitlementsContext("org1");
 

--- a/apps/web/modules/entitlements/lib/self-hosted-provider.ts
+++ b/apps/web/modules/entitlements/lib/self-hosted-provider.ts
@@ -60,7 +60,8 @@ export const getSelfHostedOrganizationEntitlementsContext = async (
     source: "self_hosted_license",
     features: license.active ? mapLicenseFeaturesToEntitlements(license.features) : [],
     limits: {
-      workspaces: license.active ? (license.features?.workspaces ?? 3) : 3,
+      // null = unlimited; only an inactive or feature-less license falls back to the community default.
+      workspaces: license.active && license.features ? license.features.workspaces : 3,
       // Self-hosted response limits are not license-server-managed today.
       monthlyResponses: null,
       // Self-hosted workflows are gated by the boolean license feature, not metered (ENG-1936).


### PR DESCRIPTION
## What & why

On self-hosted instances an Enterprise license granting **unlimited** workspaces was enforced as the community default of **3**, so paying customers could not create a 4th workspace while the license page still read "Unlimited".

`null` is the wire representation of "unlimited" (`workspaces: z.number().nullable()`), but the self-hosted branch of `getOrganizationWorkspacesLimit` guarded on `licenseFeatures?.workspaces != null`. A `null` value failed that guard and fell through to `return 3` — the exact inverse of the cloud branch three lines above, which does `limits.workspaces ?? Infinity`. The limit is then enforced at `organizationWorkspacesCount >= organizationWorkspacesLimit`, so the 4th workspace threw `OperationNotAllowedError`.

Changes:

- `apps/web/modules/ee/license-check/lib/utils.ts` — the self-hosted branch now gates on the presence of `licenseFeatures` and resolves `workspaces ?? Infinity`, mirroring the cloud branch. An inactive/missing/`unreachable` license still resolves to 3, and a numeric value is still returned unchanged.
- `apps/web/modules/entitlements/lib/self-hosted-provider.ts` — the same `null`-collapse (`license.features?.workspaces ?? 3`) is corrected so `null` is carried through as `null` (unlimited) rather than flattened to 3. Nothing reads `limits.workspaces` on the self-hosted path today (the one reader in `getBiggerUploadFileSizePermission` sits behind an `IS_FORMBRICKS_CLOUD` guard), so this is inert today and only stops the two paths diverging again.

This is a regression from PR #5740, which rewrote `licenseFeatures.projects ?? Infinity` into a `!= null` check; the `projects` → `workspaces` rename in Formbricks 5 carried the defect over.

## Linear ticket

Fixes ENG-2394

## How this was tested

- `pnpm test` in `apps/web` ✅ — full suite green:
  ```
  Test Files  608 passed (608)
       Tests  8001 passed (8001)
    Duration  174.40s
  ```
- Tests updated/added (all four exercise the changed lines):
  - `modules/ee/license-check/lib/utils.test.ts` — the existing case *"returns 3 for self-hosted without active workspace entitlement"* asserted `workspaces: null → 3`, locking in the bug; it is inverted to expect `Infinity`. Two new cases cover an **expired** license and a **`licenseFeatures: null`** license still resolving to 3.
  - `modules/entitlements/lib/self-hosted-provider.test.ts` — new case asserting `limits.workspaces` stays `null` for an active license with `workspaces: null`.
- Confirmed the new assertions can actually fail: with the two source files stashed and only the test changes applied, they fail on `main`'s behaviour —
  ```
  × keeps workspaces null (unlimited) when an active license grants unlimited workspaces
    AssertionError: expected 3 to be null
  × returns Infinity for self-hosted when an active license grants unlimited workspaces
    AssertionError: expected 3 to be Infinity
  Tests  2 failed | 51 passed (53)
  ```
- `pnpm lint --filter=@formbricks/web` ✅ — `21 successful, 21 total`, 0 errors (6 pre-existing warnings elsewhere; ESLint on the four changed files is clean).
- `pnpm format:check` ✅ — `All matched files use Prettier code style!`
- Review follow-up (`644e732`, `9624854`) — `self-hosted-provider.test.ts` had cast every mock with
  `as any`, so the tests accepted any license or organization shape. Both are now typed fixtures
  (`licenseFeatures`/`activeLicense`/`expiredLicense`/`noLicense`, plus a `TOrganization`), and the file
  has no `as any` left. Behaviour and assertions are unchanged — 13 tests still pass. Since
  `tsconfig.typecheck.json` excludes `*.test.ts`, CI will not catch drift here, so I confirmed the
  fixtures really do type-check by running `tsc` against the file with a temporary config, and confirmed
  they bite by deleting a required field and watching it error.
- No UI change, so no screenshots.

## Breaking changes

None

## QA / Test Plan

**How to test**

- [ ] On a self-hosted instance with an active Enterprise license whose workspace entitlement is **Unlimited**, go to *Organization Settings → Enterprise License* and confirm the license shows as **active**. Create a 4th workspace → it is created successfully (before this fix: `Organization workspace limit reached`). Creating a 5th and 6th also succeeds.
- [ ] Self-hosted with an active license carrying a **numeric** workspace limit (e.g. 5): create workspaces up to 5 → all succeed; the 6th → blocked with "Organization workspace limit reached". Unchanged behaviour.
- [ ] Self-hosted with **no license** (community): the 4th workspace → blocked with "Organization workspace limit reached". Unchanged.
- [ ] Self-hosted with an **expired** license, or an instance that cannot reach `ee.formbricks.com` past the 3-day grace period (status degrades to `unreachable`): the 4th workspace → blocked. Unchanged — note this is a separate cause with identical symptoms, so verify the license reads **active** before treating a block as a bug.
- [ ] Formbricks Cloud, unlimited plan: creating a 4th+ workspace still succeeds; Cloud with a bounded plan still blocks at its limit. The cloud branch is untouched.

**Preconditions / test data**

- A self-hosted deployment (`IS_FORMBRICKS_CLOUD` unset/false) with an organization owner or manager account able to create workspaces.
- Enterprise license keys for three states: active + unlimited workspaces, active + numeric workspace limit, and expired/absent.
- A Cloud environment for the regression check on the untouched cloud path.

**Risks & regressions**

- The workspace-creation gate is the only behaviour intended to change; re-check that community and expired-license instances are still capped at 3, since the fallback is shared by both.
- Workspace-count UI (limit banners, "create workspace" affordances) reads the same resolver — confirm an unlimited self-hosted license no longer shows an "at limit" state.
- `getBiggerUploadFileSizePermission` also reads `limits.workspaces`, but only on the Cloud path; verify Cloud upload-size gating is unchanged.

**Migrations / env / cutover**

- none

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDiu2Devg6C2EFwDuE8GuS)_
