### PR TITLE
fix(auth): fail closed on an unrecognized minPermission

### DIFF
--- a/apps/web/lib/utils/action-client/action-client-middleware.test.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.test.ts
@@ -366,6 +366,62 @@ describe("action-client-middleware", () => {
       expect(result).toBe(true);
     });
 
+    test("refuses workspaceTeam access when minPermission is an unrecognized value", async () => {
+      vi.mocked(getMembershipRole).mockResolvedValue("member");
+
+      // "write" is the feedback-records gateway spelling, not a TTeamPermission ("readWrite").
+      // An unrecognized minimum must not admit a read-only member.
+      const access = [
+        {
+          type: "workspaceTeam" as const,
+          workspaceId,
+          minPermission: "write" as any,
+        },
+      ];
+
+      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("read");
+
+      await expect(checkAuthorizationUpdated({ userId, organizationId, access })).rejects.toThrow(
+        AuthorizationError
+      );
+    });
+
+    test("refuses workspaceTeam access when the granted permission is an unrecognized value", async () => {
+      vi.mocked(getMembershipRole).mockResolvedValue("member");
+
+      const access = [
+        {
+          type: "workspaceTeam" as const,
+          workspaceId,
+          minPermission: "readWrite" as const,
+        },
+      ];
+
+      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("write" as any);
+
+      await expect(checkAuthorizationUpdated({ userId, organizationId, access })).rejects.toThrow(
+        AuthorizationError
+      );
+    });
+
+    test("refuses team access when minPermission is an unrecognized value", async () => {
+      vi.mocked(getMembershipRole).mockResolvedValue("member");
+
+      const access = [
+        {
+          type: "team" as const,
+          teamId,
+          minPermission: "manage" as any,
+        },
+      ];
+
+      vi.mocked(getTeamRoleByTeamIdUserId).mockResolvedValue("contributor");
+
+      await expect(checkAuthorizationUpdated({ userId, organizationId, access })).rejects.toThrow(
+        AuthorizationError
+      );
+    });
+
     test("handles team access without minPermission specified", async () => {
       vi.mocked(getMembershipRole).mockResolvedValue("member");
 

--- a/apps/web/lib/utils/action-client/action-client-middleware.test.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.test.ts
@@ -438,5 +438,42 @@ describe("action-client-middleware", () => {
 
       expect(result).toBe(true);
     });
+
+    // Omitting minPermission asks for "any grant on this workspace/team", not "no check at all" — an
+    // unrecognized grant is still refused. Not reachable through the current callers, whose grants come
+    // from Postgres enums, but the helper must not fail open for one that isn't enum-backed.
+    test("refuses workspaceTeam access when the granted permission is unrecognized and no minPermission is set", async () => {
+      vi.mocked(getMembershipRole).mockResolvedValue("member");
+
+      const access = [
+        {
+          type: "workspaceTeam" as const,
+          workspaceId,
+        },
+      ];
+
+      vi.mocked(getWorkspacePermissionByUserId).mockResolvedValue("write" as any);
+
+      await expect(checkAuthorizationUpdated({ userId, organizationId, access })).rejects.toThrow(
+        AuthorizationError
+      );
+    });
+
+    test("refuses team access when the granted role is unrecognized and no minPermission is set", async () => {
+      vi.mocked(getMembershipRole).mockResolvedValue("member");
+
+      const access = [
+        {
+          type: "team" as const,
+          teamId,
+        },
+      ];
+
+      vi.mocked(getTeamRoleByTeamIdUserId).mockResolvedValue("owner" as any);
+
+      await expect(checkAuthorizationUpdated({ userId, organizationId, access })).rejects.toThrow(
+        AuthorizationError
+      );
+    });
   });
 });

--- a/apps/web/lib/utils/action-client/action-client-middleware.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.ts
@@ -91,15 +91,22 @@ const meetsMinimumWeight = (
   return grantedWeight >= minimumWeight;
 };
 
-const checkWorkspaceTeamAccess = async (accessItem: any, userId: string) => {
-  if (accessItem.type !== "workspaceTeam") return false;
+/**
+ * The `workspaceTeam` and `team` variants of `TAccess` carry no schema, so neither depends on `T` —
+ * hence the concrete `z.ZodRawShape` here rather than threading the generic through these two helpers.
+ * `checkAuthorizationUpdated` narrows on `type` before calling either, so each receives exactly its
+ * own variant and `workspaceId` / `teamId` / `minPermission` are checked at compile time.
+ */
+type TWorkspaceTeamAccess = Extract<TAccess<z.ZodRawShape>, { type: "workspaceTeam" }>;
+type TTeamAccess = Extract<TAccess<z.ZodRawShape>, { type: "team" }>;
+
+const checkWorkspaceTeamAccess = async (accessItem: TWorkspaceTeamAccess, userId: string) => {
   const workspacePermission = await getWorkspacePermissionByUserId(userId, accessItem.workspaceId);
   if (!workspacePermission) return false;
   return meetsMinimumWeight(teamPermissionWeight, workspacePermission, accessItem.minPermission);
 };
 
-const checkTeamAccess = async (accessItem: any, userId: string) => {
-  if (accessItem.type !== "team") return false;
+const checkTeamAccess = async (accessItem: TTeamAccess, userId: string) => {
   const teamRole = await getTeamRoleByTeamIdUserId(accessItem.teamId, userId);
   if (!teamRole) return false;
   return meetsMinimumWeight(teamRoleWeight, teamRole, accessItem.minPermission);

--- a/apps/web/lib/utils/action-client/action-client-middleware.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.ts
@@ -63,32 +63,39 @@ const checkOrganizationAccess = <T extends z.ZodRawShape>(
   return accessItem.roles.includes(role);
 };
 
+/**
+ * Compares a granted role/permission against the minimum required one.
+ *
+ * Both sides are looked up explicitly and an unrecognized value on either side is refused. Comparing
+ * the weights directly would fail open: an unknown value resolves to `undefined`, `number < undefined`
+ * is `false`, so the insufficient-permission guard would not fire and every member would be admitted.
+ */
+const meetsMinimumWeight = (
+  weights: Record<string, number>,
+  granted: string,
+  minimum: string | undefined
+): boolean => {
+  if (minimum === undefined) return true;
+
+  const grantedWeight = weights[granted];
+  const minimumWeight = weights[minimum];
+  if (grantedWeight === undefined || minimumWeight === undefined) return false;
+
+  return grantedWeight >= minimumWeight;
+};
+
 const checkWorkspaceTeamAccess = async (accessItem: any, userId: string) => {
   if (accessItem.type !== "workspaceTeam") return false;
   const workspacePermission = await getWorkspacePermissionByUserId(userId, accessItem.workspaceId);
   if (!workspacePermission) return false;
-  if (
-    accessItem.minPermission !== undefined &&
-    teamPermissionWeight[workspacePermission as keyof typeof teamPermissionWeight] <
-      teamPermissionWeight[accessItem.minPermission as keyof typeof teamPermissionWeight]
-  ) {
-    return false;
-  }
-  return true;
+  return meetsMinimumWeight(teamPermissionWeight, workspacePermission, accessItem.minPermission);
 };
 
 const checkTeamAccess = async (accessItem: any, userId: string) => {
   if (accessItem.type !== "team") return false;
   const teamRole = await getTeamRoleByTeamIdUserId(accessItem.teamId, userId);
   if (!teamRole) return false;
-  if (
-    accessItem.minPermission !== undefined &&
-    teamRoleWeight[teamRole as keyof typeof teamRoleWeight] <
-      teamRoleWeight[accessItem.minPermission as keyof typeof teamRoleWeight]
-  ) {
-    return false;
-  }
-  return true;
+  return meetsMinimumWeight(teamRoleWeight, teamRole, accessItem.minPermission);
 };
 
 export const checkAuthorizationUpdated = async <T extends z.ZodRawShape>({

--- a/apps/web/lib/utils/action-client/action-client-middleware.ts
+++ b/apps/web/lib/utils/action-client/action-client-middleware.ts
@@ -69,17 +69,24 @@ const checkOrganizationAccess = <T extends z.ZodRawShape>(
  * Both sides are looked up explicitly and an unrecognized value on either side is refused. Comparing
  * the weights directly would fail open: an unknown value resolves to `undefined`, `number < undefined`
  * is `false`, so the insufficient-permission guard would not fire and every member would be admitted.
+ *
+ * `granted` is validated before the no-minimum case, so an unrecognized grant is refused even when the
+ * caller asks for no minimum. Both current callers read `granted` from a native Postgres enum, so this
+ * is unreachable today; it is here so the helper stays fail-closed for a future caller whose grant is
+ * not enum-backed.
  */
 const meetsMinimumWeight = (
   weights: Record<string, number>,
   granted: string,
   minimum: string | undefined
 ): boolean => {
+  const grantedWeight = weights[granted];
+  if (grantedWeight === undefined) return false;
+
   if (minimum === undefined) return true;
 
-  const grantedWeight = weights[granted];
   const minimumWeight = weights[minimum];
-  if (grantedWeight === undefined || minimumWeight === undefined) return false;
+  if (minimumWeight === undefined) return false;
 
   return grantedWeight >= minimumWeight;
 };


### PR DESCRIPTION
## What & why

`checkWorkspaceTeamAccess` in the shared server-action middleware compared permission weights directly:

```ts
teamPermissionWeight[workspacePermission] < teamPermissionWeight[accessItem.minPermission]
```

If `minPermission` is anything outside `{read, readWrite, manage}` the right-hand lookup is `undefined`, `number < undefined` is `false`, the insufficient-permission guard never fires, and **every workspace member is admitted — read-only included**. The same holds if the *granted* permission is unrecognized. `accessItem` is typed `any` inside the function, so TypeScript does not protect the body; only `TAccess` at the call sites does.

This diff looks both sides up explicitly in a small `meetsMinimumWeight` helper and refuses an unknown value on either side. `checkTeamAccess` carried the identical pattern against `teamRoleWeight`, so it uses the same helper rather than leaving the same fail-open in the adjacent function.

**Latent — no current behaviour changes.** All 86 non-test call sites pass valid string literals (64 `readWrite`, 32 `read`, 9 `manage` on `workspaceTeam`; 4 `admin`, 3 `contributor` on `team`), and for recognized values the new `granted >= minimum` is exactly the old `!(granted < minimum)`. The value is removing an asymmetry: #8741 introduced two adjacent permission vocabularies — `TFeedbackRecordsGatewayPermission` (`read | write | manage`) and `TTeamPermission` (`read | readWrite | manage`) — so passing the gateway spelling `"write"` where the team spelling is expected is now a plausible mistake. It fails **closed** in `apiKeyPermissionAllows` (`app/api/v3/lib/auth.ts`) and, before this change, **open** here.

Tightening `accessItem: any` prevents the class outright, and is now done in this PR (it turned out not to need `checkOrganizationAccess`'s signature after all): `checkWorkspaceTeamAccess` and `checkTeamAccess` each take their own `Extract<TAccess<...>, ...>` variant, so a typo in `workspaceId`/`teamId`/`minPermission` — or passing the wrong variant — is now a compile error. `checkAuthorizationUpdated` already narrows on `type` before calling either, so the internal type guards were unreachable once the parameters were typed and have been removed.

## Linear ticket

Fixes ENG-2246

## How this was tested

- `pnpm test` in `apps/web` ✅ — full suite green:
  ```
  Test Files  608 passed (608)
       Tests  8001 passed (8001)
    Duration  172.03s
  ```
  The 8 pre-existing `checkAuthorizationUpdated` cases covering valid permissions and roles still pass, which is the evidence that recognized values are unaffected.
- Three cases added to `lib/utils/action-client/action-client-middleware.test.ts`, all driven through the real `checkAuthorizationUpdated` call path (not the guard expression in isolation):
  - a read-only member with `minPermission: "write"` (the gateway spelling, not a `TTeamPermission`) → `AuthorizationError`;
  - a workspace permission of `"write"` against `minPermission: "readWrite"` → `AuthorizationError`;
  - a `team` item with `minPermission: "manage"` (a `TTeamPermission`, not a `TTeamRole`) against a `contributor` → `AuthorizationError`.
- Confirmed all three can actually fail: with the source file stashed and only the test changes applied, they fail on `main`'s behaviour, each admitting the caller —
  ```
  × refuses workspaceTeam access when minPermission is an unrecognized value
  × refuses workspaceTeam access when the granted permission is an unrecognized value
  × refuses team access when minPermission is an unrecognized value
    AssertionError: promise resolved "true" instead of rejecting  (×3)
  Tests  3 failed | 49 passed (52)
  ```
  This also demonstrates the `team` variant of the fail-open end-to-end, which the ticket had only inferred.
- `pnpm lint --filter=@formbricks/web` ✅ — `21 successful, 21 total`, 0 errors (warnings are pre-existing and elsewhere; ESLint on both changed files is clean).
- `pnpm format:check` ✅ — `All matched files use Prettier code style!`
- No UI change, so no screenshots.

## Breaking changes

None

## QA / Test Plan

This is a latent hardening fix with no reachable behaviour change today, so the QA goal is confirming **nothing regressed** in permission enforcement across the app. Server actions are the surface — every permission-gated action in the product runs through this middleware.

**How to test**

- [ ] As a workspace member with **read** permission on a workspace: open a survey in that workspace → you can view it; attempt an edit-level action (rename the survey, change a question, publish) → blocked with "Not authorized". Unchanged.
- [ ] As a member with **readWrite**: create, edit and publish a survey in that workspace → all succeed. Deleting the workspace or managing its members → blocked. Unchanged.
- [ ] As a member with **manage**: workspace-level management (workspace settings, workspace deletion, member permissions) → succeeds. Unchanged.
- [ ] Team roles: as a team **contributor**, team-management actions (renaming the team, adding/removing members) → blocked; as a team **admin** → succeed. Unchanged.
- [ ] Organization roles: as an org **owner**/**manager**, actions gated on organization role still succeed; as a plain **member** with no workspace permission on the target workspace → blocked with "Not authorized".
- [ ] A user with **no membership** in the target workspace → every workspace-scoped action blocked. Unchanged.
- [ ] Access items that specify **no** minimum permission still admit any member of the workspace/team holding a recognized permission (e.g. a read-only member reaching a no-minimum action succeeds). Note the helper now validates the *granted* value even when no minimum is set, so an unrecognized grant is refused rather than admitted — not reachable through today's callers, whose grants come from Postgres enums.

**Preconditions / test data**

- One organization with at least two workspaces and a team.
- Four accounts: workspace `read`, workspace `readWrite`, workspace `manage`, and one with no membership in the target workspace.
- One team with a `contributor` and an `admin` member.
- Access control / RBAC must be available on the plan for per-workspace permissions to be assignable (Enterprise entitlement, or a self-hosted instance with an active license).

**Risks & regressions**

- Highest risk is an over-tightening regression: a permission that used to be accepted now being refused. The escalation path is the whole product, so spread the spot checks across surfaces (surveys, contacts, integrations, workspace and team settings) rather than one screen.
- The `team` code path is touched as well as `workspaceTeam` — re-check team-scoped actions specifically, not just workspace ones.
- Nothing about organization-role checks changed (`checkOrganizationAccess` is untouched); a failure there would point at something else.

**Migrations / env / cutover**

- none

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDiu2Devg6C2EFwDuE8GuS)_
