### PR TITLE
refactor: route feedback dataset authorization through central interface

### DIFF
--- a/apps/web/app/api/(internal)/unify-feedback/sources/csv/import/route.test.ts
+++ b/apps/web/app/api/(internal)/unify-feedback/sources/csv/import/route.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { logger } from "@formbricks/logger";
+import { AuthorizationError } from "@formbricks/types/errors";
+import { assertFeedbackSourceDirectoryAccess } from "@/lib/feedback-source/access";
+import { importCsvFile } from "@/lib/feedback-source/csv-file-import";
+import { getFeedbackSourceWithMappingsById } from "@/lib/feedback-source/service";
+import { getUser } from "@/lib/user/service";
+import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
+import { getOrganizationIdFromFeedbackSourceId } from "@/lib/utils/helper";
+import { getSession } from "@/modules/auth/lib/session";
+import { POST } from "./route";
+
+vi.mock("@formbricks/logger", () => ({
+  logger: { error: vi.fn() },
+}));
+vi.mock("@/lib/feedback-source/access", () => ({
+  assertFeedbackSourceDirectoryAccess: vi.fn(),
+}));
+vi.mock("@/lib/feedback-source/csv-file-import", () => ({
+  CsvImportValidationError: class CsvImportValidationError extends Error {},
+  importCsvFile: vi.fn(),
+}));
+vi.mock("@/lib/feedback-source/service", () => ({
+  getFeedbackSourceWithMappingsById: vi.fn(),
+}));
+vi.mock("@/lib/user/service", () => ({ getUser: vi.fn() }));
+vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
+  checkAuthorizationUpdated: vi.fn(),
+}));
+vi.mock("@/lib/utils/helper", () => ({
+  getOrganizationIdFromFeedbackSourceId: vi.fn(),
+}));
+vi.mock("@/modules/auth/lib/session", () => ({ getSession: vi.fn() }));
+
+const userId = "user_1";
+const organizationId = "organization_1";
+const workspaceId = "workspace_1";
+const feedbackSourceId = "source_1";
+const feedbackDirectoryId = "directory_1";
+
+const makeRequest = (): Request => {
+  const body = new FormData();
+  body.set("workspaceId", workspaceId);
+  body.set("feedbackSourceId", feedbackSourceId);
+  body.set("file", new File(["value\nexample"], "feedback.csv", { type: "text/csv" }));
+  return new Request("http://localhost/api/unify-feedback/sources/csv/import", { method: "POST", body });
+};
+
+describe("CSV feedback source import authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getSession).mockResolvedValue({ user: { id: userId } } as never);
+    vi.mocked(getUser).mockResolvedValue({ id: userId } as never);
+    vi.mocked(getOrganizationIdFromFeedbackSourceId).mockResolvedValue(organizationId);
+    vi.mocked(checkAuthorizationUpdated).mockResolvedValue(true);
+    vi.mocked(getFeedbackSourceWithMappingsById).mockResolvedValue({ feedbackDirectoryId } as never);
+    vi.mocked(assertFeedbackSourceDirectoryAccess).mockResolvedValue(undefined);
+    vi.mocked(importCsvFile).mockResolvedValue({ imported: 1 } as never);
+  });
+
+  test("requires exact assignment write access before importing", async () => {
+    const response = await POST(makeRequest());
+
+    expect(response.status).toBe(200);
+    expect(assertFeedbackSourceDirectoryAccess).toHaveBeenCalledWith(
+      userId,
+      feedbackDirectoryId,
+      workspaceId,
+      "write"
+    );
+    expect(importCsvFile).toHaveBeenCalledWith({ feedbackSourceId, workspaceId, file: expect.any(File) });
+  });
+
+  test("preserves the existing forbidden response for a denied assignment", async () => {
+    vi.mocked(assertFeedbackSourceDirectoryAccess).mockRejectedValue(
+      new AuthorizationError("Not authorized")
+    );
+
+    const response = await POST(makeRequest());
+
+    expect(response.status).toBe(403);
+    expect(importCsvFile).not.toHaveBeenCalled();
+  });
+
+  test("does not log identifiers or raw operational errors", async () => {
+    vi.mocked(assertFeedbackSourceDirectoryAccess).mockRejectedValue(
+      new Error(`evaluator failed for ${feedbackDirectoryId} and ${feedbackSourceId}`)
+    );
+
+    const response = await POST(makeRequest());
+
+    expect(response.status).toBe(500);
+    const logOutput = JSON.stringify(vi.mocked(logger.error).mock.calls);
+    expect(logOutput).not.toContain(feedbackDirectoryId);
+    expect(logOutput).not.toContain(feedbackSourceId);
+    expect(logOutput).not.toContain("evaluator failed");
+  });
+});

--- a/apps/web/app/api/(internal)/unify-feedback/sources/csv/import/route.ts
+++ b/apps/web/app/api/(internal)/unify-feedback/sources/csv/import/route.ts
@@ -6,7 +6,9 @@ import {
   InvalidInputError,
   ResourceNotFoundError,
 } from "@formbricks/types/errors";
+import { assertFeedbackSourceDirectoryAccess } from "@/lib/feedback-source/access";
 import { CsvImportValidationError, importCsvFile } from "@/lib/feedback-source/csv-file-import";
+import { getFeedbackSourceWithMappingsById } from "@/lib/feedback-source/service";
 import { getUser } from "@/lib/user/service";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromFeedbackSourceId } from "@/lib/utils/helper";
@@ -94,6 +96,17 @@ export const POST = async (request: Request) => {
       ],
     });
 
+    const feedbackSource = await getFeedbackSourceWithMappingsById(feedbackSourceId, workspaceId);
+    if (!feedbackSource) {
+      throw new ResourceNotFoundError("FeedbackSource", feedbackSourceId);
+    }
+    await assertFeedbackSourceDirectoryAccess(
+      user.id,
+      feedbackSource.feedbackDirectoryId,
+      workspaceId,
+      "write"
+    );
+
     const result = await importCsvFile({ feedbackSourceId, workspaceId, file });
 
     return NextResponse.json(result);
@@ -121,7 +134,10 @@ export const POST = async (request: Request) => {
       return buildCsvImportErrorResponse(error.message, 400);
     }
 
-    logger.error({ error }, "Failed to import CSV feedback source data");
+    logger.error(
+      { errorName: error instanceof Error ? error.name : "unknown" },
+      "Failed to import CSV feedback source data"
+    );
     return buildCsvImportErrorResponse(CSV_IMPORT_FAILED_ERROR_CODE, 500);
   }
 };

--- a/apps/web/app/api/v3/feedbackRecords/lib/access.ts
+++ b/apps/web/app/api/v3/feedbackRecords/lib/access.ts
@@ -1,11 +1,12 @@
 import "server-only";
 import type { logger } from "@formbricks/logger";
 import type { TAuthenticationApiKey } from "@formbricks/types/auth";
-import { AuthorizationError } from "@formbricks/types/errors";
+import { getV3AuthorizationActor } from "@/app/api/v3/lib/auth";
 import { requireUnifyFeedbackWorkspaceAccess } from "@/app/api/v3/lib/feedback-access";
 import { problemBadRequest, problemForbidden, problemUnprocessableContent } from "@/app/api/v3/lib/response";
 import type { TV3Authentication } from "@/app/api/v3/lib/types";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
+import { can } from "@/lib/authorization";
+import { getFeedbackDirectoryAssignmentActionForPermission } from "@/lib/authorization/compatibility";
 import {
   getFeedbackDirectoriesByWorkspaceId,
   getFeedbackDirectoryAuthContext,
@@ -48,6 +49,22 @@ export type TResolvedFeedbackTenant = {
 };
 
 type TResolveResult = ({ ok: true } & TResolvedFeedbackTenant) | { ok: false; response: Response };
+
+const canAccessFeedbackDirectoryAssignment = async (
+  authentication: TV3Authentication,
+  feedbackDirectoryId: string,
+  workspaceId: string,
+  minPermission: TTeamPermission
+): Promise<boolean> => {
+  const actor = getV3AuthorizationActor(authentication);
+  if (!actor) return false;
+
+  return can(actor, getFeedbackDirectoryAssignmentActionForPermission(minPermission), {
+    type: "feedbackDirectoryAssignment",
+    id: feedbackDirectoryId,
+    workspaceId,
+  });
+};
 
 /**
  * Resolve (and authorize) the Hub tenant for a feedback-records request. This is the single tenant-
@@ -97,6 +114,23 @@ export async function resolveWorkspaceFeedbackTenant({
         ),
       };
     }
+    if (
+      !(await canAccessFeedbackDirectoryAssignment(
+        authentication,
+        requested.id.trim(),
+        resolvedWorkspaceId,
+        minPermission
+      ))
+    ) {
+      return {
+        ok: false,
+        response: problemForbidden(
+          requestId,
+          "You are not authorized to access this feedback dataset",
+          instance
+        ),
+      };
+    }
     return {
       ok: true,
       workspaceId: resolvedWorkspaceId,
@@ -126,6 +160,24 @@ export async function resolveWorkspaceFeedbackTenant({
         requestId,
         "Multiple feedback datasets are assigned to this workspace; specify datasetId",
         { instance }
+      ),
+    };
+  }
+
+  if (
+    !(await canAccessFeedbackDirectoryAssignment(
+      authentication,
+      directories[0].id.trim(),
+      resolvedWorkspaceId,
+      minPermission
+    ))
+  ) {
+    return {
+      ok: false,
+      response: problemForbidden(
+        requestId,
+        "You are not authorized to access this feedback dataset",
+        instance
       ),
     };
   }
@@ -250,21 +302,16 @@ async function requireOrganizationOwnerOrManager({
     return { ok: false, response: forbidFeedbackRecordMutation(requestId, instance) };
   }
 
-  try {
-    await checkAuthorizationUpdated({
-      userId,
-      organizationId: resolution.organizationId,
-      access: [{ type: "organization", roles: ["owner", "manager"] }],
-    });
-    return { ok: true };
-  } catch (error) {
-    if (error instanceof AuthorizationError) {
-      log.warn({ statusCode: 403 }, "Feedback record mutation denied: not an organization owner or manager");
-      return { ok: false, response: forbidFeedbackRecordMutation(requestId, instance) };
-    }
-
-    throw error;
+  const allowed = await can({ type: "user", id: userId }, "organization.manage", {
+    type: "organization",
+    id: resolution.organizationId,
+  });
+  if (!allowed) {
+    log.warn({ statusCode: 403 }, "Feedback record mutation denied: not an organization owner or manager");
+    return { ok: false, response: forbidFeedbackRecordMutation(requestId, instance) };
   }
+
+  return { ok: true };
 }
 
 /** The single 403 for "you may not change records here", so every refusal reads identically. */

--- a/apps/web/app/api/v3/feedbackRecords/lib/access.ts
+++ b/apps/web/app/api/v3/feedbackRecords/lib/access.ts
@@ -61,7 +61,7 @@ const canAccessFeedbackDirectoryAssignment = async (
 
   return can(actor, getFeedbackDirectoryAssignmentActionForPermission(minPermission), {
     type: "feedbackDirectoryAssignment",
-    id: feedbackDirectoryId,
+    feedbackDirectoryId,
     workspaceId,
   });
 };

--- a/apps/web/app/api/v3/feedbackRecords/lib/operations.test.ts
+++ b/apps/web/app/api/v3/feedbackRecords/lib/operations.test.ts
@@ -145,7 +145,7 @@ describe("shared authorization + tenant resolution", () => {
     expect(response.status).toBe(403);
     expect(can).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "feedbackDirectoryAssignment.read", {
       type: "feedbackDirectoryAssignment",
-      id: directoryId,
+      feedbackDirectoryId: directoryId,
       workspaceId,
     });
     expect(listFeedbackRecords).not.toHaveBeenCalled();
@@ -1919,7 +1919,7 @@ describe("feedback record mutation role (ENG-1770)", () => {
 
     expect(can).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "feedbackDirectoryAssignment.read", {
       type: "feedbackDirectoryAssignment",
-      id: directoryId,
+      feedbackDirectoryId: directoryId,
       workspaceId,
     });
     expect(can).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "organization.manage", {
@@ -1965,7 +1965,7 @@ describe("feedback record mutation role (ENG-1770)", () => {
     expect(deleted.status).toBe(204);
     expect(can).toHaveBeenCalledWith({ type: "apiKey", id: "key_1" }, "feedbackDirectoryAssignment.manage", {
       type: "feedbackDirectoryAssignment",
-      id: directoryId,
+      feedbackDirectoryId: directoryId,
       workspaceId,
     });
     expect(can).not.toHaveBeenCalledWith(expect.anything(), "organization.manage", expect.anything());
@@ -1979,7 +1979,7 @@ describe("feedback record mutation role (ENG-1770)", () => {
     expect(updated.status).toBe(200);
     expect(can).toHaveBeenCalledWith({ type: "apiKey", id: "key_1" }, "feedbackDirectoryAssignment.write", {
       type: "feedbackDirectoryAssignment",
-      id: directoryId,
+      feedbackDirectoryId: directoryId,
       workspaceId,
     });
     expect(can).not.toHaveBeenCalledWith(expect.anything(), "organization.manage", expect.anything());

--- a/apps/web/app/api/v3/feedbackRecords/lib/operations.test.ts
+++ b/apps/web/app/api/v3/feedbackRecords/lib/operations.test.ts
@@ -1,9 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { AuthorizationError } from "@formbricks/types/errors";
-import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
+import { getV3AuthorizationActor, requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
 import type { TV3AuditLog, TV3Authentication } from "@/app/api/v3/lib/types";
 import type { V3WorkspaceContext } from "@/app/api/v3/lib/workspace-context";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
+import { can } from "@/lib/authorization";
 import {
   getFeedbackDirectoriesByWorkspaceId,
   getFeedbackDirectoryAuthContext,
@@ -40,10 +39,11 @@ vi.mock("@formbricks/logger", () => ({
   logger: { withContext: vi.fn(() => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn() })) },
 }));
 
-vi.mock("@/app/api/v3/lib/auth", () => ({ requireV3WorkspaceAccess: vi.fn() }));
-vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
-  checkAuthorizationUpdated: vi.fn(),
+vi.mock("@/app/api/v3/lib/auth", () => ({
+  getV3AuthorizationActor: vi.fn(),
+  requireV3WorkspaceAccess: vi.fn(),
 }));
+vi.mock("@/lib/authorization", () => ({ can: vi.fn() }));
 vi.mock("@/modules/ee/license-check/lib/utils", () => ({ getIsFeedbackDirectoriesEnabled: vi.fn() }));
 vi.mock("@/modules/ee/feedback-directory/lib/feedback-directory", () => ({
   getFeedbackDirectoriesByWorkspaceId: vi.fn(),
@@ -99,6 +99,13 @@ const foreignOrgApiKeyAuth = {
 beforeEach(() => {
   vi.resetAllMocks();
   vi.mocked(requireV3WorkspaceAccess).mockResolvedValue(context);
+  vi.mocked(getV3AuthorizationActor).mockImplementation((authentication) => {
+    if (authentication && "apiKeyId" in authentication && authentication.apiKeyId) {
+      return { type: "apiKey", id: authentication.apiKeyId };
+    }
+    return { type: "user", id: "user_1" };
+  });
+  vi.mocked(can).mockResolvedValue(true);
   vi.mocked(getIsFeedbackDirectoriesEnabled).mockResolvedValue(true);
   vi.mocked(getFeedbackDirectoriesByWorkspaceId).mockResolvedValue([{ id: directoryId, name: "Support" }]);
   // Unshared by default, so only the tests that opt into sharing exercise the ENG-2189 rule.
@@ -107,7 +114,6 @@ beforeEach(() => {
     workspaceIds: [workspaceId],
     isArchived: false,
   });
-  vi.mocked(checkAuthorizationUpdated).mockResolvedValue(true);
 });
 
 describe("shared authorization + tenant resolution", () => {
@@ -128,6 +134,29 @@ describe("shared authorization + tenant resolution", () => {
     const response = await listV3FeedbackRecords(base);
 
     expect(response.status).toBe(403);
+    expect(listFeedbackRecords).not.toHaveBeenCalled();
+  });
+
+  test("denies when the exact dataset assignment is not authorized", async () => {
+    vi.mocked(can).mockResolvedValue(false);
+
+    const response = await listV3FeedbackRecords({ ...base, authentication: sessionAuth });
+
+    expect(response.status).toBe(403);
+    expect(can).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "feedbackDirectoryAssignment.read", {
+      type: "feedbackDirectoryAssignment",
+      id: directoryId,
+      workspaceId,
+    });
+    expect(listFeedbackRecords).not.toHaveBeenCalled();
+  });
+
+  test("keeps central evaluator failures operational instead of converting them to denial", async () => {
+    vi.mocked(can).mockRejectedValue(new Error("evaluator unavailable"));
+
+    const response = await listV3FeedbackRecords({ ...base, authentication: sessionAuth });
+
+    expect(response.status).toBe(500);
     expect(listFeedbackRecords).not.toHaveBeenCalled();
   });
 
@@ -668,16 +697,13 @@ describe("deleteV3FeedbackRecord", () => {
     vi.mocked(deleteFeedbackRecord).mockResolvedValue({ data: { deleted: true }, error: null });
   });
 
-  // ENG-2083: DELETE is reserved for `manage` everywhere else in the API and record deletion is
-  // unrecoverable, so this path asks for `manage` rather than `readWrite`. Both delete paths moved —
-  // see the gateway's route table for the other one.
-  test("requires manage access", async () => {
+  test("requires assignment read access before the organization mutation gate", async () => {
     await deleteV3FeedbackRecord(deleteBase);
 
     expect(requireV3WorkspaceAccess).toHaveBeenCalledWith(
       sessionAuth,
       workspaceId,
-      "manage",
+      "read",
       requestId,
       instance
     );
@@ -1621,13 +1647,13 @@ describe("updateV3FeedbackRecord", () => {
     vi.mocked(updateFeedbackRecord).mockResolvedValue({ data: updated, error: null });
   });
 
-  test("requires readWrite access", async () => {
+  test("requires assignment read access before the organization mutation gate", async () => {
     await updateV3FeedbackRecord({ ...updateBase, body: { value_text: "x" } });
 
     expect(requireV3WorkspaceAccess).toHaveBeenCalledWith(
       sessionAuth,
       workspaceId,
-      "readWrite",
+      "read",
       requestId,
       instance
     );
@@ -1891,15 +1917,19 @@ describe("feedback record mutation role (ENG-1770)", () => {
   test("asks for an organization owner or manager, with no workspace-team fallback", async () => {
     await updateV3FeedbackRecord(updateArgs);
 
-    expect(checkAuthorizationUpdated).toHaveBeenCalledWith({
-      userId: "user_1",
-      organizationId: context.organizationId,
-      access: [{ type: "organization", roles: ["owner", "manager"] }],
+    expect(can).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "feedbackDirectoryAssignment.read", {
+      type: "feedbackDirectoryAssignment",
+      id: directoryId,
+      workspaceId,
+    });
+    expect(can).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "organization.manage", {
+      type: "organization",
+      id: context.organizationId,
     });
   });
 
   test("refuses an update from a workspace member who is not an owner or manager", async () => {
-    vi.mocked(checkAuthorizationUpdated).mockRejectedValue(new AuthorizationError("Not authorized"));
+    vi.mocked(can).mockImplementation(async (_actor, action) => action !== "organization.manage");
 
     const response = await updateV3FeedbackRecord(updateArgs);
 
@@ -1910,7 +1940,7 @@ describe("feedback record mutation role (ENG-1770)", () => {
   });
 
   test("refuses a delete from a workspace member who is not an owner or manager", async () => {
-    vi.mocked(checkAuthorizationUpdated).mockRejectedValue(new AuthorizationError("Not authorized"));
+    vi.mocked(can).mockImplementation(async (_actor, action) => action !== "organization.manage");
 
     const response = await deleteV3FeedbackRecord(deleteArgs);
 
@@ -1933,7 +1963,12 @@ describe("feedback record mutation role (ENG-1770)", () => {
     const deleted = await deleteV3FeedbackRecord({ ...deleteArgs, authentication: apiKeyAuth });
 
     expect(deleted.status).toBe(204);
-    expect(checkAuthorizationUpdated).not.toHaveBeenCalled();
+    expect(can).toHaveBeenCalledWith({ type: "apiKey", id: "key_1" }, "feedbackDirectoryAssignment.manage", {
+      type: "feedbackDirectoryAssignment",
+      id: directoryId,
+      workspaceId,
+    });
+    expect(can).not.toHaveBeenCalledWith(expect.anything(), "organization.manage", expect.anything());
   });
 
   // The positive control for update: without it, a regression refusing every API-key update would still
@@ -1942,7 +1977,12 @@ describe("feedback record mutation role (ENG-1770)", () => {
     const updated = await updateV3FeedbackRecord({ ...updateArgs, authentication: apiKeyAuth });
 
     expect(updated.status).toBe(200);
-    expect(checkAuthorizationUpdated).not.toHaveBeenCalled();
+    expect(can).toHaveBeenCalledWith({ type: "apiKey", id: "key_1" }, "feedbackDirectoryAssignment.write", {
+      type: "feedbackDirectoryAssignment",
+      id: directoryId,
+      workspaceId,
+    });
+    expect(can).not.toHaveBeenCalledWith(expect.anything(), "organization.manage", expect.anything());
   });
 
   describe("API key in a shared dataset (ENG-2189)", () => {

--- a/apps/web/app/api/v3/feedbackRecords/lib/operations.ts
+++ b/apps/web/app/api/v3/feedbackRecords/lib/operations.ts
@@ -12,6 +12,7 @@ import {
 } from "@/app/api/v3/lib/response";
 import type { TV3AuditLog, TV3Authentication } from "@/app/api/v3/lib/types";
 import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
+import type { TTeamPermission } from "@/modules/ee/teams/workspace-teams/types/team";
 import {
   countFeedbackRecords,
   createFeedbackRecord,
@@ -77,6 +78,11 @@ import {
  */
 
 const CACHE = "private, no-store" as const;
+
+const getMutationAssignmentPermission = (
+  authentication: TV3Authentication,
+  apiKeyPermission: Extract<TTeamPermission, "readWrite" | "manage">
+): TTeamPermission => (authentication && "apiKeyId" in authentication ? apiKeyPermission : "read");
 
 /**
  * Build the Hub create payload. This field list *is* the allowlist — never a spread of the input — so
@@ -790,7 +796,7 @@ export async function updateV3FeedbackRecord({
       authentication,
       workspaceId,
       datasetId,
-      minPermission: "readWrite",
+      minPermission: getMutationAssignmentPermission(authentication, "readWrite"),
       requestId,
       instance,
     });
@@ -917,7 +923,7 @@ export async function deleteV3FeedbackRecord({
       datasetId,
       // `manage`, matching the gateway's DELETE route and `methodPermissionMap` everywhere else in the
       // API. Both delete paths had to move or the bar would only apply to one of them (ENG-2083).
-      minPermission: "manage",
+      minPermission: getMutationAssignmentPermission(authentication, "manage"),
       requestId,
       instance,
     });

--- a/apps/web/app/api/v3/lib/auth.test.ts
+++ b/apps/web/app/api/v3/lib/auth.test.ts
@@ -5,7 +5,7 @@ import { can } from "@/lib/authorization";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { getWorkspace } from "@/lib/workspace/service";
-import { requireSessionWorkspaceAccess, requireV3WorkspaceAccess } from "./auth";
+import { getV3AuthorizationActor, requireSessionWorkspaceAccess, requireV3WorkspaceAccess } from "./auth";
 
 vi.mock("@formbricks/logger", () => ({
   logger: {
@@ -33,6 +33,25 @@ vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
 vi.mock("@/lib/authorization", () => ({ can: vi.fn() }));
 
 const requestId = "req-123";
+
+describe("getV3AuthorizationActor", () => {
+  test("maps session and API-key authentication to Formbricks actors", () => {
+    expect(getV3AuthorizationActor({ user: { id: "user_1" } } as any)).toEqual({
+      type: "user",
+      id: "user_1",
+    });
+    expect(getV3AuthorizationActor({ apiKeyId: "key_1" } as any)).toEqual({
+      type: "apiKey",
+      id: "key_1",
+    });
+  });
+
+  test("rejects missing or incomplete authentication", () => {
+    expect(getV3AuthorizationActor(null)).toBeNull();
+    expect(getV3AuthorizationActor({ user: {} } as any)).toBeNull();
+    expect(getV3AuthorizationActor({ apiKeyId: "" } as any)).toBeNull();
+  });
+});
 
 describe("requireSessionWorkspaceAccess", () => {
   test("returns 401 when authentication is null", async () => {

--- a/apps/web/app/api/v3/lib/auth.test.ts
+++ b/apps/web/app/api/v3/lib/auth.test.ts
@@ -6,6 +6,7 @@ import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-clie
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { getWorkspace } from "@/lib/workspace/service";
 import { getV3AuthorizationActor, requireSessionWorkspaceAccess, requireV3WorkspaceAccess } from "./auth";
+import type { TV3Authentication } from "./types";
 
 vi.mock("@formbricks/logger", () => ({
   logger: {
@@ -36,11 +37,11 @@ const requestId = "req-123";
 
 describe("getV3AuthorizationActor", () => {
   test("maps session and API-key authentication to Formbricks actors", () => {
-    expect(getV3AuthorizationActor({ user: { id: "user_1" } } as any)).toEqual({
+    expect(getV3AuthorizationActor({ user: { id: "user_1" } } as unknown as TV3Authentication)).toEqual({
       type: "user",
       id: "user_1",
     });
-    expect(getV3AuthorizationActor({ apiKeyId: "key_1" } as any)).toEqual({
+    expect(getV3AuthorizationActor({ apiKeyId: "key_1" } as unknown as TV3Authentication)).toEqual({
       type: "apiKey",
       id: "key_1",
     });
@@ -48,8 +49,8 @@ describe("getV3AuthorizationActor", () => {
 
   test("rejects missing or incomplete authentication", () => {
     expect(getV3AuthorizationActor(null)).toBeNull();
-    expect(getV3AuthorizationActor({ user: {} } as any)).toBeNull();
-    expect(getV3AuthorizationActor({ apiKeyId: "" } as any)).toBeNull();
+    expect(getV3AuthorizationActor({ user: {} } as unknown as TV3Authentication)).toBeNull();
+    expect(getV3AuthorizationActor({ apiKeyId: "" } as unknown as TV3Authentication)).toBeNull();
   });
 });
 

--- a/apps/web/app/api/v3/lib/auth.ts
+++ b/apps/web/app/api/v3/lib/auth.ts
@@ -4,13 +4,25 @@
 import { logger } from "@formbricks/logger";
 import type { TAuthenticationApiKey } from "@formbricks/types/auth";
 import { AuthorizationError, ResourceNotFoundError } from "@formbricks/types/errors";
-import { can } from "@/lib/authorization";
+import { type TAuthorizationActor, can } from "@/lib/authorization";
 import { getWorkspaceActionForPermission } from "@/lib/authorization/compatibility";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import type { TTeamPermission } from "@/modules/ee/teams/workspace-teams/types/team";
 import { problemForbidden, problemUnauthorized } from "./response";
 import type { TV3Authentication } from "./types";
 import { type V3WorkspaceContext, resolveV3WorkspaceContext } from "./workspace-context";
+
+export const getV3AuthorizationActor = (authentication: TV3Authentication): TAuthorizationActor | null => {
+  if (authentication && "user" in authentication && authentication.user?.id) {
+    return { type: "user", id: authentication.user.id };
+  }
+
+  if (authentication && "apiKeyId" in authentication && authentication.apiKeyId) {
+    return { type: "apiKey", id: authentication.apiKeyId };
+  }
+
+  return null;
+};
 
 /**
  * Require session and workspace access. workspaceId is resolved via the V3 workspace-context layer.

--- a/apps/web/app/api/v3/unify-feedback/taxonomy/lib/access.test.ts
+++ b/apps/web/app/api/v3/unify-feedback/taxonomy/lib/access.test.ts
@@ -1,26 +1,19 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { AuthorizationError } from "@formbricks/types/errors";
-import { requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
+import { getV3AuthorizationActor, requireV3WorkspaceAccess } from "@/app/api/v3/lib/auth";
 import type { TV3Authentication } from "@/app/api/v3/lib/types";
 import type { V3WorkspaceContext } from "@/app/api/v3/lib/workspace-context";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
-import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
+import { can } from "@/lib/authorization";
 import { getIsFeedbackDirectoriesEnabled } from "@/modules/ee/license-check/lib/utils";
 import { getSessionUserId, requireUnifyDirectoryAccess, requireUnifyDirectoryMutationAccess } from "./access";
 
 vi.mock("server-only", () => ({}));
 
 vi.mock("@/app/api/v3/lib/auth", () => ({
+  getV3AuthorizationActor: vi.fn(),
   requireV3WorkspaceAccess: vi.fn(),
 }));
 
-vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
-  checkAuthorizationUpdated: vi.fn(),
-}));
-
-vi.mock("@/modules/ee/feedback-directory/lib/feedback-directory", () => ({
-  getFeedbackDirectoriesByWorkspaceId: vi.fn(),
-}));
+vi.mock("@/lib/authorization", () => ({ can: vi.fn() }));
 
 vi.mock("@/modules/ee/license-check/lib/utils", () => ({
   getIsFeedbackDirectoriesEnabled: vi.fn(),
@@ -35,13 +28,30 @@ describe("requireUnifyDirectoryAccess", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(requireV3WorkspaceAccess).mockResolvedValue(context);
+    vi.mocked(getV3AuthorizationActor).mockImplementation((authentication) =>
+      authentication && "user" in authentication && authentication.user?.id
+        ? { type: "user", id: authentication.user.id }
+        : null
+    );
     vi.mocked(getIsFeedbackDirectoriesEnabled).mockResolvedValue(true);
-    vi.mocked(getFeedbackDirectoriesByWorkspaceId).mockResolvedValue([{ id: directoryId, name: "Dataset" }]);
+    vi.mocked(can).mockResolvedValue(true);
   });
 
   test("returns the workspace context when all checks pass", async () => {
-    const result = await requireUnifyDirectoryAccess(null, workspaceId, directoryId, "read", "req_1", "/x");
+    const result = await requireUnifyDirectoryAccess(
+      session,
+      workspaceId,
+      directoryId,
+      "read",
+      "req_1",
+      "/x"
+    );
     expect(result).toEqual(context);
+    expect(can).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "feedbackDirectoryAssignment.read", {
+      type: "feedbackDirectoryAssignment",
+      id: directoryId,
+      workspaceId,
+    });
   });
 
   test("short-circuits with the auth Response and skips the extra checks when workspace access is denied", async () => {
@@ -52,7 +62,7 @@ describe("requireUnifyDirectoryAccess", () => {
 
     expect(result).toBe(denied);
     expect(getIsFeedbackDirectoriesEnabled).not.toHaveBeenCalled();
-    expect(getFeedbackDirectoriesByWorkspaceId).not.toHaveBeenCalled();
+    expect(can).not.toHaveBeenCalled();
   });
 
   test("returns 403 when the feedbackDirectories entitlement is off", async () => {
@@ -62,21 +72,33 @@ describe("requireUnifyDirectoryAccess", () => {
 
     expect(result).toBeInstanceOf(Response);
     expect((result as Response).status).toBe(403);
-    expect(getFeedbackDirectoriesByWorkspaceId).not.toHaveBeenCalled();
+    expect(can).not.toHaveBeenCalled();
   });
 
   test("returns 403 when the directory is not assigned to the workspace", async () => {
-    vi.mocked(getFeedbackDirectoriesByWorkspaceId).mockResolvedValue([{ id: "other", name: "Other" }]);
+    vi.mocked(can).mockResolvedValue(false);
 
-    const result = await requireUnifyDirectoryAccess(null, workspaceId, directoryId, "read", "req_1", "/x");
+    const result = await requireUnifyDirectoryAccess(
+      session,
+      workspaceId,
+      directoryId,
+      "read",
+      "req_1",
+      "/x"
+    );
 
     expect(result).toBeInstanceOf(Response);
     expect((result as Response).status).toBe(403);
   });
 
   test("forwards the requested permission to the workspace-access check", async () => {
-    await requireUnifyDirectoryAccess(null, workspaceId, directoryId, "readWrite", "req_1", "/x");
-    expect(requireV3WorkspaceAccess).toHaveBeenCalledWith(null, workspaceId, "readWrite", "req_1", "/x");
+    await requireUnifyDirectoryAccess(session, workspaceId, directoryId, "readWrite", "req_1", "/x");
+    expect(requireV3WorkspaceAccess).toHaveBeenCalledWith(session, workspaceId, "readWrite", "req_1", "/x");
+    expect(can).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "feedbackDirectoryAssignment.write", {
+      type: "feedbackDirectoryAssignment",
+      id: directoryId,
+      workspaceId,
+    });
   });
 });
 
@@ -86,9 +108,13 @@ describe("requireUnifyDirectoryMutationAccess", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(requireV3WorkspaceAccess).mockResolvedValue(context);
+    vi.mocked(getV3AuthorizationActor).mockImplementation((authentication) =>
+      authentication && "user" in authentication && authentication.user?.id
+        ? { type: "user", id: authentication.user.id }
+        : null
+    );
     vi.mocked(getIsFeedbackDirectoriesEnabled).mockResolvedValue(true);
-    vi.mocked(getFeedbackDirectoriesByWorkspaceId).mockResolvedValue([{ id: directoryId, name: "Dataset" }]);
-    vi.mocked(checkAuthorizationUpdated).mockResolvedValue(true);
+    vi.mocked(can).mockResolvedValue(true);
   });
 
   test("returns the workspace context for an organization owner or manager", async () => {
@@ -101,10 +127,9 @@ describe("requireUnifyDirectoryMutationAccess", () => {
     );
 
     expect(result).toEqual(context);
-    expect(checkAuthorizationUpdated).toHaveBeenCalledWith({
-      userId: "user_1",
-      organizationId: context.organizationId,
-      access: [{ type: "organization", roles: ["owner", "manager"] }],
+    expect(can).toHaveBeenLastCalledWith({ type: "user", id: "user_1" }, "organization.manage", {
+      type: "organization",
+      id: context.organizationId,
     });
   });
 
@@ -114,7 +139,7 @@ describe("requireUnifyDirectoryMutationAccess", () => {
   });
 
   test("returns 403 for a workspace readWrite member who is not an owner or manager", async () => {
-    vi.mocked(checkAuthorizationUpdated).mockRejectedValue(new AuthorizationError("Not authorized"));
+    vi.mocked(can).mockResolvedValueOnce(true).mockResolvedValueOnce(false);
 
     const result = await requireUnifyDirectoryMutationAccess(
       session,
@@ -133,11 +158,11 @@ describe("requireUnifyDirectoryMutationAccess", () => {
 
     expect(result).toBeInstanceOf(Response);
     expect((result as Response).status).toBe(401);
-    expect(checkAuthorizationUpdated).not.toHaveBeenCalled();
+    expect(can).not.toHaveBeenCalled();
   });
 
   test("short-circuits with the directory Response and skips the role check", async () => {
-    vi.mocked(getFeedbackDirectoriesByWorkspaceId).mockResolvedValue([{ id: "other", name: "Other" }]);
+    vi.mocked(can).mockResolvedValue(false);
 
     const result = await requireUnifyDirectoryMutationAccess(
       session,
@@ -149,7 +174,7 @@ describe("requireUnifyDirectoryMutationAccess", () => {
 
     expect(result).toBeInstanceOf(Response);
     expect((result as Response).status).toBe(403);
-    expect(checkAuthorizationUpdated).not.toHaveBeenCalled();
+    expect(can).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/web/app/api/v3/unify-feedback/taxonomy/lib/access.test.ts
+++ b/apps/web/app/api/v3/unify-feedback/taxonomy/lib/access.test.ts
@@ -49,7 +49,7 @@ describe("requireUnifyDirectoryAccess", () => {
     expect(result).toEqual(context);
     expect(can).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "feedbackDirectoryAssignment.read", {
       type: "feedbackDirectoryAssignment",
-      id: directoryId,
+      feedbackDirectoryId: directoryId,
       workspaceId,
     });
   });
@@ -96,7 +96,7 @@ describe("requireUnifyDirectoryAccess", () => {
     expect(requireV3WorkspaceAccess).toHaveBeenCalledWith(session, workspaceId, "readWrite", "req_1", "/x");
     expect(can).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "feedbackDirectoryAssignment.write", {
       type: "feedbackDirectoryAssignment",
-      id: directoryId,
+      feedbackDirectoryId: directoryId,
       workspaceId,
     });
   });

--- a/apps/web/app/api/v3/unify-feedback/taxonomy/lib/access.ts
+++ b/apps/web/app/api/v3/unify-feedback/taxonomy/lib/access.ts
@@ -44,7 +44,7 @@ export async function requireUnifyDirectoryAccess(
 
   const allowed = await can(actor, getFeedbackDirectoryAssignmentActionForPermission(minPermission), {
     type: "feedbackDirectoryAssignment",
-    id: directoryId,
+    feedbackDirectoryId: directoryId,
     workspaceId: context.workspaceId,
   });
   if (!allowed) {

--- a/apps/web/app/api/v3/unify-feedback/taxonomy/lib/access.ts
+++ b/apps/web/app/api/v3/unify-feedback/taxonomy/lib/access.ts
@@ -1,11 +1,11 @@
 import "server-only";
-import { AuthorizationError } from "@formbricks/types/errors";
+import { getV3AuthorizationActor } from "@/app/api/v3/lib/auth";
 import { requireUnifyFeedbackWorkspaceAccess } from "@/app/api/v3/lib/feedback-access";
 import { problemForbidden, problemUnauthorized } from "@/app/api/v3/lib/response";
 import type { TV3Authentication } from "@/app/api/v3/lib/types";
 import type { V3WorkspaceContext } from "@/app/api/v3/lib/workspace-context";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
-import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
+import { can } from "@/lib/authorization";
+import { getFeedbackDirectoryAssignmentActionForPermission } from "@/lib/authorization/compatibility";
 import type { TTeamPermission } from "@/modules/ee/teams/workspace-teams/types/team";
 
 /**
@@ -37,8 +37,17 @@ export async function requireUnifyDirectoryAccess(
     return context;
   }
 
-  const directories = await getFeedbackDirectoriesByWorkspaceId(context.workspaceId);
-  if (!directories.some((directory) => directory.id === directoryId)) {
+  const actor = getV3AuthorizationActor(authentication);
+  if (!actor) {
+    return problemUnauthorized(requestId, "Not authenticated", instance);
+  }
+
+  const allowed = await can(actor, getFeedbackDirectoryAssignmentActionForPermission(minPermission), {
+    type: "feedbackDirectoryAssignment",
+    id: directoryId,
+    workspaceId: context.workspaceId,
+  });
+  if (!allowed) {
     return problemForbidden(requestId, "You are not authorized to access this resource", instance);
   }
 
@@ -81,21 +90,16 @@ export async function requireUnifyDirectoryMutationAccess(
     return problemUnauthorized(requestId, "Session required", instance);
   }
 
-  try {
-    await checkAuthorizationUpdated({
-      userId,
-      organizationId: context.organizationId,
-      access: [{ type: "organization", roles: ["owner", "manager"] }],
-    });
-  } catch (err) {
-    if (err instanceof AuthorizationError) {
-      return problemForbidden(
-        requestId,
-        "Only organization owners and managers can change a feedback directory's taxonomy",
-        instance
-      );
-    }
-    throw err;
+  const allowed = await can({ type: "user", id: userId }, "organization.manage", {
+    type: "organization",
+    id: context.organizationId,
+  });
+  if (!allowed) {
+    return problemForbidden(
+      requestId,
+      "Only organization owners and managers can change a feedback directory's taxonomy",
+      instance
+    );
   }
 
   return context;

--- a/apps/web/lib/authorization/compatibility.test.ts
+++ b/apps/web/lib/authorization/compatibility.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import {
+  getFeedbackDirectoryActionForPermission,
+  getFeedbackDirectoryAssignmentActionForPermission,
+} from "./compatibility";
+
+describe("feedback directory action compatibility", () => {
+  test.each([
+    ["read", "feedbackDirectory.read"],
+    ["write", "feedbackDirectory.write"],
+    ["manage", "feedbackDirectory.manage"],
+  ] as const)("maps directory %s to the central vocabulary", (permission, action) => {
+    expect(getFeedbackDirectoryActionForPermission(permission)).toBe(action);
+  });
+
+  test.each([
+    [undefined, "feedbackDirectoryAssignment.read"],
+    ["read", "feedbackDirectoryAssignment.read"],
+    ["readWrite", "feedbackDirectoryAssignment.write"],
+    ["manage", "feedbackDirectoryAssignment.manage"],
+  ] as const)("maps assignment %s to the central vocabulary", (permission, action) => {
+    expect(getFeedbackDirectoryAssignmentActionForPermission(permission)).toBe(action);
+  });
+});

--- a/apps/web/lib/authorization/compatibility.ts
+++ b/apps/web/lib/authorization/compatibility.ts
@@ -3,6 +3,13 @@ import type { TTeamPermission } from "@/modules/ee/teams/workspace-teams/types/t
 import type { TAuthorizationAction } from "./contract";
 
 type TWorkspaceAction = Extract<TAuthorizationAction, `workspace.${string}`>;
+type TFeedbackDirectoryAction = Extract<TAuthorizationAction, `feedbackDirectory.${string}`>;
+type TFeedbackDirectoryAssignmentAction = Extract<
+  TAuthorizationAction,
+  `feedbackDirectoryAssignment.${string}`
+>;
+
+export type TFeedbackDirectoryPermission = "read" | "write" | "manage";
 
 /**
  * Maps the current WorkspaceTeam permission ladder to the central vocabulary.
@@ -14,4 +21,16 @@ export const getWorkspaceActionForPermission = (minPermission?: TTeamPermission)
   if (minPermission === "manage") return "workspace.manage";
   if (minPermission === "readWrite") return "workspace.write";
   return "workspace.read";
+};
+
+export const getFeedbackDirectoryActionForPermission = (
+  permission: TFeedbackDirectoryPermission
+): TFeedbackDirectoryAction => `feedbackDirectory.${permission}`;
+
+export const getFeedbackDirectoryAssignmentActionForPermission = (
+  minPermission?: TTeamPermission
+): TFeedbackDirectoryAssignmentAction => {
+  if (minPermission === "manage") return "feedbackDirectoryAssignment.manage";
+  if (minPermission === "readWrite") return "feedbackDirectoryAssignment.write";
+  return "feedbackDirectoryAssignment.read";
 };

--- a/apps/web/lib/authorization/context.test.ts
+++ b/apps/web/lib/authorization/context.test.ts
@@ -76,6 +76,13 @@ describe("authorization request context", () => {
     });
   });
 
+  test("maps both authenticated feedback gateway principal types", async () => {
+    await withAuthorizationSurface("feedback_gateway", async () => {
+      expect(getAuthorizationRolloutTarget("user")).toBe("feedback_gateway:user");
+      expect(getAuthorizationRolloutTarget("apiKey")).toBe("feedback_gateway:apiKey");
+    });
+  });
+
   test("does not accept comparison work outside a request context", () => {
     expect(getAuthorizationRolloutTarget("user")).toBeNull();
     expect(enqueueAuthorizationComparison(vi.fn())).toBe(false);

--- a/apps/web/lib/authorization/context.ts
+++ b/apps/web/lib/authorization/context.ts
@@ -8,7 +8,13 @@ import {
 import type { TAuthorizationActor } from "./contract";
 import { recordAuthorizationChecksPerRequest } from "./metrics";
 
-export type TAuthorizationSurface = "server_action" | "api_v1" | "api_v2" | "api_v3" | "mcp";
+export type TAuthorizationSurface =
+  | "server_action"
+  | "api_v1"
+  | "api_v2"
+  | "api_v3"
+  | "mcp"
+  | "feedback_gateway";
 
 type TComparisonJob = () => Promise<void>;
 

--- a/apps/web/lib/authorization/resource-inventory.ts
+++ b/apps/web/lib/authorization/resource-inventory.ts
@@ -88,6 +88,7 @@ export const AUDIT_TARGET_AUTHORIZATION_RESOURCE_INVENTORY = {
   dashboardWidget: "parent_derived_or_data_integrity",
   feedbackDirectory: "direct_authorization_resource",
   feedbackRecord: "parent_derived_or_data_integrity",
+  feedbackSource: "parent_derived_or_data_integrity",
   file: "workspace_inherited_resource",
   integration: "workspace_inherited_resource",
   invite: "authentication_or_application",

--- a/apps/web/lib/authzed/rollout-contract.ts
+++ b/apps/web/lib/authzed/rollout-contract.ts
@@ -14,6 +14,8 @@ export const AUTHZED_AUTHORIZATION_ROLLOUT_TARGETS = [
   "api_v3:apiKey",
   "mcp:user",
   "mcp:apiKey",
+  "feedback_gateway:user",
+  "feedback_gateway:apiKey",
 ] as const;
 
 export type TAuthzedAuthorizationRolloutTarget = (typeof AUTHZED_AUTHORIZATION_ROLLOUT_TARGETS)[number];

--- a/apps/web/lib/env.test.ts
+++ b/apps/web/lib/env.test.ts
@@ -330,7 +330,7 @@ describe("env", () => {
       AUTHZED_ENDPOINT: "spicedb:50051",
       AUTHZED_MINIMUM_SNAPSHOT: "opaque-snapshot-token",
       AUTHZED_SHADOW_ORGANIZATION_IDS: "org_a, org_b",
-      AUTHZED_SHADOW_TARGETS: "server_action:user,api_v3:user",
+      AUTHZED_SHADOW_TARGETS: "server_action:user,api_v3:user,feedback_gateway:user,feedback_gateway:apiKey",
       AUTHZED_SYSTEM_KEY: "formbricks",
       AUTHZED_TOKEN: "test-authzed-token",
     });
@@ -338,7 +338,9 @@ describe("env", () => {
     const { env } = await import("./env");
 
     expect(env.AUTHZED_AUTHORIZATION_COHORT).toBe("sandbox_users");
-    expect(env.AUTHZED_SHADOW_TARGETS).toBe("server_action:user,api_v3:user");
+    expect(env.AUTHZED_SHADOW_TARGETS).toBe(
+      "server_action:user,api_v3:user,feedback_gateway:user,feedback_gateway:apiKey"
+    );
   });
 
   test("treats an empty optional AuthZed snapshot as unset", async () => {

--- a/apps/web/lib/feedback-source/access.test.ts
+++ b/apps/web/lib/feedback-source/access.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { assertCan } from "@/lib/authorization";
+import { assertFeedbackSourceDirectoryAccess } from "./access";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/authorization", () => ({ assertCan: vi.fn() }));
+
+describe("assertFeedbackSourceDirectoryAccess", () => {
+  beforeEach(() => {
+    vi.mocked(assertCan).mockReset().mockResolvedValue(undefined);
+  });
+
+  test.each([
+    ["read", "feedbackDirectoryAssignment.read"],
+    ["write", "feedbackDirectoryAssignment.write"],
+  ] as const)("maps %s access to the exact dataset assignment", async (permission, action) => {
+    await assertFeedbackSourceDirectoryAccess("user_1", "directory_1", "workspace_1", permission);
+
+    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user_1" }, action, {
+      type: "feedbackDirectoryAssignment",
+      id: "directory_1",
+      workspaceId: "workspace_1",
+    });
+  });
+});

--- a/apps/web/lib/feedback-source/access.test.ts
+++ b/apps/web/lib/feedback-source/access.test.ts
@@ -18,7 +18,7 @@ describe("assertFeedbackSourceDirectoryAccess", () => {
 
     expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user_1" }, action, {
       type: "feedbackDirectoryAssignment",
-      id: "directory_1",
+      feedbackDirectoryId: "directory_1",
       workspaceId: "workspace_1",
     });
   });

--- a/apps/web/lib/feedback-source/access.ts
+++ b/apps/web/lib/feedback-source/access.ts
@@ -9,6 +9,6 @@ export const assertFeedbackSourceDirectoryAccess = async (
 ): Promise<void> =>
   assertCan({ type: "user", id: userId }, `feedbackDirectoryAssignment.${permission}`, {
     type: "feedbackDirectoryAssignment",
-    id: feedbackDirectoryId,
+    feedbackDirectoryId,
     workspaceId,
   });

--- a/apps/web/lib/feedback-source/access.ts
+++ b/apps/web/lib/feedback-source/access.ts
@@ -1,0 +1,14 @@
+import "server-only";
+import { assertCan } from "@/lib/authorization";
+
+export const assertFeedbackSourceDirectoryAccess = async (
+  userId: string,
+  feedbackDirectoryId: string,
+  workspaceId: string,
+  permission: "read" | "write"
+): Promise<void> =>
+  assertCan({ type: "user", id: userId }, `feedbackDirectoryAssignment.${permission}`, {
+    type: "feedbackDirectoryAssignment",
+    id: feedbackDirectoryId,
+    workspaceId,
+  });

--- a/apps/web/lib/feedback-source/actions.test.ts
+++ b/apps/web/lib/feedback-source/actions.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
+import {
+  createFeedbackSourceWithMappingsAction,
+  deleteFeedbackSourceAction,
+  importHistoricalResponsesAction,
+  updateFeedbackSourceWithMappingsAction,
+} from "./actions";
+
+const mocks = vi.hoisted(() => {
+  const action = vi.fn((handler) => handler);
+  return {
+    action,
+    inputSchema: vi.fn(() => ({ action })),
+    applyRateLimit: vi.fn(),
+    checkAuthorizationUpdated: vi.fn(),
+    assertFeedbackSourceDirectoryAccess: vi.fn(),
+    getOrganizationIdFromFeedbackSourceId: vi.fn(),
+    getOrganizationIdFromWorkspaceId: vi.fn(),
+    getFeedbackSourceWithMappingsById: vi.fn(),
+    createFeedbackSourceWithMappings: vi.fn(),
+    updateFeedbackSourceWithMappings: vi.fn(),
+    deleteFeedbackSource: vi.fn(),
+    importHistoricalResponses: vi.fn(),
+    getSurvey: vi.fn(),
+    feedbackDirectoryFindUnique: vi.fn(),
+    feedbackSourceFindUnique: vi.fn(),
+  };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@formbricks/database", () => ({
+  prisma: {
+    feedbackDirectory: { findUnique: mocks.feedbackDirectoryFindUnique },
+    feedbackSource: { findUnique: mocks.feedbackSourceFindUnique },
+  },
+}));
+vi.mock("@/lib/utils/action-client", () => ({
+  authenticatedActionClient: { inputSchema: mocks.inputSchema },
+}));
+vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
+  checkAuthorizationUpdated: mocks.checkAuthorizationUpdated,
+}));
+vi.mock("@/lib/utils/helper", () => ({
+  getOrganizationIdFromFeedbackSourceId: mocks.getOrganizationIdFromFeedbackSourceId,
+  getOrganizationIdFromSurveyId: vi.fn(),
+  getOrganizationIdFromWorkspaceId: mocks.getOrganizationIdFromWorkspaceId,
+  getWorkspaceIdFromSurveyId: vi.fn(),
+}));
+vi.mock("@/lib/survey/service", () => ({ getSurvey: mocks.getSurvey }));
+vi.mock("@/lib/response/service", () => ({ getResponseCountBySurveyId: vi.fn() }));
+vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyRateLimit: mocks.applyRateLimit }));
+vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
+  withAuditLogging: vi.fn((_event, _target, handler) => handler),
+}));
+vi.mock("@/modules/ee/feedback-directory/lib/feedback-directory", () => ({
+  getFeedbackDirectoriesByWorkspaceId: vi.fn(),
+}));
+vi.mock("@/modules/ee/unify-feedback/lib/contacts", () => ({ getContactIdsByUserIds: vi.fn() }));
+vi.mock("@/modules/hub/service", () => ({ listFeedbackRecords: vi.fn() }));
+vi.mock("./access", () => ({
+  assertFeedbackSourceDirectoryAccess: mocks.assertFeedbackSourceDirectoryAccess,
+}));
+vi.mock("./import", () => ({ importHistoricalResponses: mocks.importHistoricalResponses }));
+vi.mock("./mappings", () => ({ resolveFormbricksMappingsInput: vi.fn() }));
+vi.mock("./service", () => ({
+  createFeedbackSourceWithMappings: mocks.createFeedbackSourceWithMappings,
+  deleteFeedbackSource: mocks.deleteFeedbackSource,
+  getFeedbackSourceWithMappingsById: mocks.getFeedbackSourceWithMappingsById,
+  updateFeedbackSourceWithMappings: mocks.updateFeedbackSourceWithMappings,
+}));
+
+const organizationId = "organization-1";
+const workspaceId = "workspace-1";
+const feedbackSourceId = "feedback-source-1";
+const feedbackDirectoryId = "feedback-directory-1";
+const ctx = { user: { id: "user-1" }, auditLoggingCtx: {} };
+
+describe("feedback source mutation safeguards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ctx.auditLoggingCtx = {};
+    mocks.getOrganizationIdFromFeedbackSourceId.mockResolvedValue(organizationId);
+    mocks.getOrganizationIdFromWorkspaceId.mockResolvedValue(organizationId);
+    mocks.feedbackDirectoryFindUnique.mockResolvedValue({
+      organizationId,
+      workspaces: [{ workspaceId }],
+    });
+    mocks.feedbackSourceFindUnique.mockResolvedValue({ feedbackDirectoryId, type: "csv" });
+    mocks.getFeedbackSourceWithMappingsById.mockResolvedValue({
+      id: feedbackSourceId,
+      feedbackDirectoryId,
+      type: "formbricks_survey",
+      formbricksMappings: [],
+    });
+    mocks.createFeedbackSourceWithMappings.mockResolvedValue({
+      id: feedbackSourceId,
+      feedbackDirectoryId,
+      type: "csv",
+    });
+    mocks.updateFeedbackSourceWithMappings.mockResolvedValue({
+      id: feedbackSourceId,
+      feedbackDirectoryId,
+      type: "csv",
+      name: "Renamed",
+    });
+    mocks.deleteFeedbackSource.mockResolvedValue({ id: feedbackSourceId });
+    mocks.getSurvey.mockResolvedValue({ id: "survey-1", workspaceId });
+    mocks.importHistoricalResponses.mockResolvedValue({ successes: 1, failures: 0, skipped: 0 });
+  });
+
+  test.each([
+    [
+      "create",
+      createFeedbackSourceWithMappingsAction,
+      {
+        workspaceId,
+        feedbackSourceInput: { feedbackDirectoryId, name: "Source", type: "csv" },
+      },
+    ],
+    [
+      "update",
+      updateFeedbackSourceWithMappingsAction,
+      { feedbackSourceId, workspaceId, feedbackSourceInput: {} },
+    ],
+    ["delete", deleteFeedbackSourceAction, { feedbackSourceId, workspaceId }],
+  ])("rate limits and audits %s", async (_name, action, parsedInput) => {
+    await (action as any)({ ctx, parsedInput });
+
+    expect(mocks.applyRateLimit).toHaveBeenCalledWith(
+      rateLimitConfigs.actions.feedbackSourceMutation,
+      "user-1"
+    );
+    expect(ctx.auditLoggingCtx).toMatchObject({
+      organizationId,
+      workspaceId,
+      feedbackSourceId,
+    });
+  });
+
+  test("uses the tighter historical import rate limit and audits only summary counts", async () => {
+    await (importHistoricalResponsesAction as any)({
+      ctx,
+      parsedInput: { feedbackSourceId, workspaceId, surveyId: "survey-1" },
+    });
+
+    expect(mocks.applyRateLimit).toHaveBeenCalledWith(
+      rateLimitConfigs.actions.historicalResponseImport,
+      "user-1"
+    );
+    expect(ctx.auditLoggingCtx).toMatchObject({
+      organizationId,
+      workspaceId,
+      feedbackSourceId,
+      newObject: { successes: 1, failures: 0, skipped: 0 },
+    });
+  });
+});

--- a/apps/web/lib/feedback-source/actions.ts
+++ b/apps/web/lib/feedback-source/actions.ts
@@ -25,6 +25,7 @@ import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-direc
 import { getContactIdsByUserIds } from "@/modules/ee/unify-feedback/lib/contacts";
 import { listFeedbackRecords } from "@/modules/hub/service";
 import type { FeedbackRecordListParams, FeedbackRecordListResponse } from "@/modules/hub/types";
+import { assertFeedbackSourceDirectoryAccess } from "./access";
 import { importHistoricalResponses } from "./import";
 import { resolveFormbricksMappingsInput } from "./mappings";
 import {
@@ -71,6 +72,20 @@ export const deleteFeedbackSourceAction = authenticatedActionClient
           },
         ],
       });
+
+      const feedbackSource = await getFeedbackSourceWithMappingsById(
+        parsedInput.feedbackSourceId,
+        parsedInput.workspaceId
+      );
+      if (!feedbackSource) {
+        throw new ResourceNotFoundError("FeedbackSource", parsedInput.feedbackSourceId);
+      }
+      await assertFeedbackSourceDirectoryAccess(
+        ctx.user.id,
+        feedbackSource.feedbackDirectoryId,
+        parsedInput.workspaceId,
+        "write"
+      );
 
       return deleteFeedbackSource(parsedInput.feedbackSourceId, parsedInput.workspaceId);
     }
@@ -161,6 +176,12 @@ export const createFeedbackSourceWithMappingsAction = authenticatedActionClient
     if (frd.workspaces.length === 0) {
       throw new InvalidInputError("FEEDBACK_SOURCE_DIRECTORY_NOT_ASSIGNED_TO_WORKSPACE");
     }
+    await assertFeedbackSourceDirectoryAccess(
+      ctx.user.id,
+      parsedInput.feedbackSourceInput.feedbackDirectoryId,
+      parsedInput.workspaceId,
+      "write"
+    );
 
     let mappingsInput: TMappingsInput | undefined;
 
@@ -227,11 +248,17 @@ export const updateFeedbackSourceWithMappingsAction = authenticatedActionClient
       // fails here rather than as a Prisma error from the update.
       const feedbackSource = await prisma.feedbackSource.findUnique({
         where: { id: parsedInput.feedbackSourceId, workspaceId: parsedInput.workspaceId },
-        select: { type: true },
+        select: { feedbackDirectoryId: true, type: true },
       });
       if (!feedbackSource) {
         throw new ResourceNotFoundError("FeedbackSource", parsedInput.feedbackSourceId);
       }
+      await assertFeedbackSourceDirectoryAccess(
+        ctx.user.id,
+        feedbackSource.feedbackDirectoryId,
+        parsedInput.workspaceId,
+        "write"
+      );
 
       let mappingsInput: TMappingsInput | undefined;
 
@@ -341,6 +368,12 @@ export const importHistoricalResponsesAction = authenticatedActionClient
       if (!feedbackSource) {
         throw new ResourceNotFoundError("FeedbackSource", parsedInput.feedbackSourceId);
       }
+      await assertFeedbackSourceDirectoryAccess(
+        ctx.user.id,
+        feedbackSource.feedbackDirectoryId,
+        parsedInput.workspaceId,
+        "write"
+      );
 
       const survey = await getSurvey(parsedInput.surveyId);
       if (!survey) {
@@ -406,6 +439,12 @@ export const listFeedbackRecordsAction = authenticatedActionClient
       if (!frds.some((f) => f.id === parsedInput.frdId)) {
         throw new Error("Feedback directory not accessible");
       }
+      await assertFeedbackSourceDirectoryAccess(
+        ctx.user.id,
+        parsedInput.frdId,
+        parsedInput.workspaceId,
+        "read"
+      );
 
       const params: FeedbackRecordListParams = {
         tenant_id: parsedInput.frdId,

--- a/apps/web/lib/feedback-source/actions.ts
+++ b/apps/web/lib/feedback-source/actions.ts
@@ -5,7 +5,6 @@ import { prisma } from "@formbricks/database";
 import { ZId } from "@formbricks/types/common";
 import { AuthorizationError, InvalidInputError, ResourceNotFoundError } from "@formbricks/types/errors";
 import {
-  TFeedbackSourceWithMappings,
   ZFeedbackSourceCreateInput,
   ZFeedbackSourceFieldMappingCreateInput,
   ZFeedbackSourceUpdateInput,
@@ -21,6 +20,9 @@ import {
   getOrganizationIdFromWorkspaceId,
   getWorkspaceIdFromSurveyId,
 } from "@/lib/utils/helper";
+import { applyRateLimit } from "@/modules/core/rate-limit/helpers";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
+import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
 import { getContactIdsByUserIds } from "@/modules/ee/unify-feedback/lib/contacts";
 import { listFeedbackRecords } from "@/modules/hub/service";
@@ -49,14 +51,13 @@ const ZDeleteFeedbackSourceAction = z.object({
 export const deleteFeedbackSourceAction = authenticatedActionClient
   .inputSchema(ZDeleteFeedbackSourceAction)
   .action(
-    async ({
-      ctx,
-      parsedInput,
-    }: {
-      ctx: AuthenticatedActionClientCtx;
-      parsedInput: z.infer<typeof ZDeleteFeedbackSourceAction>;
-    }) => {
+    withAuditLogging("deleted", "feedbackSource", async ({ ctx, parsedInput }) => {
+      ctx.auditLoggingCtx.feedbackSourceId = parsedInput.feedbackSourceId;
+      ctx.auditLoggingCtx.workspaceId = parsedInput.workspaceId;
+      await applyRateLimit(rateLimitConfigs.actions.feedbackSourceMutation, ctx.user.id);
+
       const organizationId = await getOrganizationIdFromFeedbackSourceId(parsedInput.feedbackSourceId);
+      ctx.auditLoggingCtx.organizationId = organizationId;
       await checkAuthorizationUpdated({
         userId: ctx.user.id,
         organizationId,
@@ -87,8 +88,13 @@ export const deleteFeedbackSourceAction = authenticatedActionClient
         "write"
       );
 
-      return deleteFeedbackSource(parsedInput.feedbackSourceId, parsedInput.workspaceId);
-    }
+      const deletedFeedbackSource = await deleteFeedbackSource(
+        parsedInput.feedbackSourceId,
+        parsedInput.workspaceId
+      );
+      ctx.auditLoggingCtx.oldObject = deletedFeedbackSource;
+      return deletedFeedbackSource;
+    })
   );
 
 const ZFormbricksSurveyMapping = z.object({
@@ -138,73 +144,82 @@ const ZCreateFeedbackSourceWithMappingsAction = z
 
 export const createFeedbackSourceWithMappingsAction = authenticatedActionClient
   .inputSchema(ZCreateFeedbackSourceWithMappingsAction)
-  .action(async ({ ctx, parsedInput }): Promise<TFeedbackSourceWithMappings> => {
-    const organizationId = await getOrganizationIdFromWorkspaceId(parsedInput.workspaceId);
-    await checkAuthorizationUpdated({
-      userId: ctx.user.id,
-      organizationId,
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
+  .action(
+    withAuditLogging("created", "feedbackSource", async ({ ctx, parsedInput }) => {
+      ctx.auditLoggingCtx.workspaceId = parsedInput.workspaceId;
+      await applyRateLimit(rateLimitConfigs.actions.feedbackSourceMutation, ctx.user.id);
+
+      const organizationId = await getOrganizationIdFromWorkspaceId(parsedInput.workspaceId);
+      ctx.auditLoggingCtx.organizationId = organizationId;
+      await checkAuthorizationUpdated({
+        userId: ctx.user.id,
+        organizationId,
+        access: [
+          {
+            type: "organization",
+            roles: ["owner", "manager"],
+          },
+          {
+            type: "workspaceTeam",
+            minPermission: "readWrite",
+            workspaceId: parsedInput.workspaceId,
+          },
+        ],
+      });
+
+      // Verify the directory belongs to the same org and is actually assigned to this workspace.
+      // The composite FK enforces the assignment at the DB level too; these checks return the
+      // friendlier errors first: a generic auth error for missing/cross-org directories, a typed
+      // error for a same-org directory that just isn't assigned to the workspace.
+      const frd = await prisma.feedbackDirectory.findUnique({
+        where: { id: parsedInput.feedbackSourceInput.feedbackDirectoryId },
+        select: {
+          organizationId: true,
+          workspaces: {
+            where: { workspaceId: parsedInput.workspaceId },
+            select: { workspaceId: true },
+          },
         },
-        {
-          type: "workspaceTeam",
-          minPermission: "readWrite",
-          workspaceId: parsedInput.workspaceId,
-        },
-      ],
-    });
+      });
+      if (frd?.organizationId !== organizationId) {
+        throw new AuthorizationError("Invalid feedback directory");
+      }
+      if (frd.workspaces.length === 0) {
+        throw new InvalidInputError("FEEDBACK_SOURCE_DIRECTORY_NOT_ASSIGNED_TO_WORKSPACE");
+      }
+      await assertFeedbackSourceDirectoryAccess(
+        ctx.user.id,
+        parsedInput.feedbackSourceInput.feedbackDirectoryId,
+        parsedInput.workspaceId,
+        "write"
+      );
 
-    // Verify the directory belongs to the same org and is actually assigned to this workspace.
-    // The composite FK enforces the assignment at the DB level too; these checks return the
-    // friendlier errors first: a generic auth error for missing/cross-org directories, a typed
-    // error for a same-org directory that just isn't assigned to the workspace.
-    const frd = await prisma.feedbackDirectory.findUnique({
-      where: { id: parsedInput.feedbackSourceInput.feedbackDirectoryId },
-      select: {
-        organizationId: true,
-        workspaces: {
-          where: { workspaceId: parsedInput.workspaceId },
-          select: { workspaceId: true },
-        },
-      },
-    });
-    if (frd?.organizationId !== organizationId) {
-      throw new AuthorizationError("Invalid feedback directory");
-    }
-    if (frd.workspaces.length === 0) {
-      throw new InvalidInputError("FEEDBACK_SOURCE_DIRECTORY_NOT_ASSIGNED_TO_WORKSPACE");
-    }
-    await assertFeedbackSourceDirectoryAccess(
-      ctx.user.id,
-      parsedInput.feedbackSourceInput.feedbackDirectoryId,
-      parsedInput.workspaceId,
-      "write"
-    );
+      let mappingsInput: TMappingsInput | undefined;
 
-    let mappingsInput: TMappingsInput | undefined;
+      const { formbricksMappings, fieldMappings } = parsedInput;
 
-    const { formbricksMappings, fieldMappings } = parsedInput;
+      if (formbricksMappings?.length) {
+        mappingsInput = await resolveFormbricksMappingsInput(formbricksMappings, parsedInput.workspaceId);
+      } else if (fieldMappings?.length) {
+        mappingsInput = {
+          type: "field",
+          mappings:
+            parsedInput.feedbackSourceInput.type === "csv"
+              ? sanitizeAndValidateCsvFieldMappings(fieldMappings)
+              : fieldMappings,
+        };
+      }
 
-    if (formbricksMappings?.length) {
-      mappingsInput = await resolveFormbricksMappingsInput(formbricksMappings, parsedInput.workspaceId);
-    } else if (fieldMappings?.length) {
-      mappingsInput = {
-        type: "field",
-        mappings:
-          parsedInput.feedbackSourceInput.type === "csv"
-            ? sanitizeAndValidateCsvFieldMappings(fieldMappings)
-            : fieldMappings,
-      };
-    }
-
-    return createFeedbackSourceWithMappings(
-      parsedInput.workspaceId,
-      { ...parsedInput.feedbackSourceInput, createdBy: ctx.user.id },
-      mappingsInput
-    );
-  });
+      const createdFeedbackSource = await createFeedbackSourceWithMappings(
+        parsedInput.workspaceId,
+        { ...parsedInput.feedbackSourceInput, createdBy: ctx.user.id },
+        mappingsInput
+      );
+      ctx.auditLoggingCtx.feedbackSourceId = createdFeedbackSource.id;
+      ctx.auditLoggingCtx.newObject = createdFeedbackSource;
+      return createdFeedbackSource;
+    })
+  );
 
 const ZUpdateFeedbackSourceWithMappingsAction = z.object({
   feedbackSourceId: ZId,
@@ -217,14 +232,13 @@ const ZUpdateFeedbackSourceWithMappingsAction = z.object({
 export const updateFeedbackSourceWithMappingsAction = authenticatedActionClient
   .inputSchema(ZUpdateFeedbackSourceWithMappingsAction)
   .action(
-    async ({
-      ctx,
-      parsedInput,
-    }: {
-      ctx: AuthenticatedActionClientCtx;
-      parsedInput: z.infer<typeof ZUpdateFeedbackSourceWithMappingsAction>;
-    }): Promise<TFeedbackSourceWithMappings> => {
+    withAuditLogging("updated", "feedbackSource", async ({ ctx, parsedInput }) => {
+      ctx.auditLoggingCtx.feedbackSourceId = parsedInput.feedbackSourceId;
+      ctx.auditLoggingCtx.workspaceId = parsedInput.workspaceId;
+      await applyRateLimit(rateLimitConfigs.actions.feedbackSourceMutation, ctx.user.id);
+
       const organizationId = await getOrganizationIdFromFeedbackSourceId(parsedInput.feedbackSourceId);
+      ctx.auditLoggingCtx.organizationId = organizationId;
       await checkAuthorizationUpdated({
         userId: ctx.user.id,
         organizationId,
@@ -277,13 +291,16 @@ export const updateFeedbackSourceWithMappingsAction = authenticatedActionClient
         };
       }
 
-      return updateFeedbackSourceWithMappings(
+      const updatedFeedbackSource = await updateFeedbackSourceWithMappings(
         parsedInput.feedbackSourceId,
         parsedInput.workspaceId,
         parsedInput.feedbackSourceInput,
         mappingsInput
       );
-    }
+      ctx.auditLoggingCtx.oldObject = feedbackSource;
+      ctx.auditLoggingCtx.newObject = updatedFeedbackSource;
+      return updatedFeedbackSource;
+    })
   );
 
 const ZGetResponseCountAction = z.object({
@@ -337,14 +354,13 @@ const ZImportHistoricalResponsesAction = z.object({
 export const importHistoricalResponsesAction = authenticatedActionClient
   .inputSchema(ZImportHistoricalResponsesAction)
   .action(
-    async ({
-      ctx,
-      parsedInput,
-    }: {
-      ctx: AuthenticatedActionClientCtx;
-      parsedInput: z.infer<typeof ZImportHistoricalResponsesAction>;
-    }) => {
+    withAuditLogging("updated", "feedbackSource", async ({ ctx, parsedInput }) => {
+      ctx.auditLoggingCtx.feedbackSourceId = parsedInput.feedbackSourceId;
+      ctx.auditLoggingCtx.workspaceId = parsedInput.workspaceId;
+      await applyRateLimit(rateLimitConfigs.actions.historicalResponseImport, ctx.user.id);
+
       const organizationId = await getOrganizationIdFromFeedbackSourceId(parsedInput.feedbackSourceId);
+      ctx.auditLoggingCtx.organizationId = organizationId;
       await checkAuthorizationUpdated({
         userId: ctx.user.id,
         organizationId,
@@ -390,8 +406,10 @@ export const importHistoricalResponsesAction = authenticatedActionClient
         throw new ResourceNotFoundError("Survey", parsedInput.surveyId);
       }
 
-      return importHistoricalResponses(feedbackSource, survey);
-    }
+      const importResult = await importHistoricalResponses(feedbackSource, survey);
+      ctx.auditLoggingCtx.newObject = importResult;
+      return importResult;
+    })
   );
 
 const ZListFeedbackRecordsAction = z.object({

--- a/apps/web/lib/utils/action-client/types/context.ts
+++ b/apps/web/lib/utils/action-client/types/context.ts
@@ -38,6 +38,7 @@ export type AuditLoggingCtx = {
   dashboardWidgetId?: string;
   feedbackDirectoryId?: string;
   feedbackRecordId?: string;
+  feedbackSourceId?: string;
 };
 
 export type ActionClientCtx = {

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.test.ts
@@ -101,6 +101,11 @@ describe("rateLimitConfigs", () => {
         "inviteMember",
         "bulkInviteMembers",
         "generateExampleResponses",
+        "feedbackSourceMutation",
+        "historicalResponseImport",
+        "chartCreation",
+        "feedbackDirectoryMutation",
+        "feedbackRecordDeletion",
       ]);
 
       // Exact values, not just presence: this quota is the only thing bounding one account from
@@ -110,6 +115,11 @@ describe("rateLimitConfigs", () => {
         interval: 60,
         allowedPerInterval: 30,
         namespace: "action:unsplash",
+      });
+      expect(rateLimitConfigs.actions.historicalResponseImport).toEqual({
+        interval: 3600,
+        allowedPerInterval: 10,
+        namespace: "action:historical-response-import",
       });
     });
 

--- a/apps/web/modules/core/rate-limit/rate-limit-configs.ts
+++ b/apps/web/modules/core/rate-limit/rate-limit-configs.ts
@@ -60,6 +60,31 @@ export const rateLimitConfigs = {
       allowedPerInterval: 1,
       namespace: "action:generate-example-responses",
     }, // 1 per minute per user — closes the multi-click race and bounds LLM spend
+    feedbackSourceMutation: {
+      interval: 60,
+      allowedPerInterval: 60,
+      namespace: "action:feedback-source-mutation",
+    }, // 60 per minute per user
+    historicalResponseImport: {
+      interval: 3600,
+      allowedPerInterval: 10,
+      namespace: "action:historical-response-import",
+    }, // 10 per hour per user — bounds repeated full-survey imports
+    chartCreation: {
+      interval: 60,
+      allowedPerInterval: 60,
+      namespace: "action:chart-creation",
+    }, // 60 per minute per user
+    feedbackDirectoryMutation: {
+      interval: 60,
+      allowedPerInterval: 60,
+      namespace: "action:feedback-directory-mutation",
+    }, // 60 per minute per user
+    feedbackRecordDeletion: {
+      interval: 60,
+      allowedPerInterval: 100,
+      namespace: "action:feedback-record-deletion",
+    }, // 100 per minute per user — supports deliberate bulk deletion while bounding abuse
   },
 
   storage: {

--- a/apps/web/modules/ee/analysis/charts/actions.test.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { executeQueryAction, generateAIChartAction } from "./actions";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
+import { createChartAction, executeQueryAction, generateAIChartAction } from "./actions";
 
 const mocks = vi.hoisted(() => {
   const actionClientAction = vi.fn((fn) => fn);
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => {
     executeTenantScopedQuery: vi.fn(),
     generateAIChartQuery: vi.fn(),
     updateChart: vi.fn(),
+    applyRateLimit: vi.fn(),
     getFeedbackSourcesWithMappings: vi.fn(),
     getSurvey: vi.fn(),
     getElementsFromBlocks: vi.fn(),
@@ -27,6 +29,8 @@ vi.mock("@/lib/utils/action-client", () => ({
     inputSchema: mocks.actionClientInputSchema,
   },
 }));
+
+vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyRateLimit: mocks.applyRateLimit }));
 
 vi.mock("@formbricks/logger", () => ({
   logger: {
@@ -143,6 +147,25 @@ describe("chart Cube actions", () => {
       userId: "user-1",
       source: "charts.executeQueryAction",
     });
+  });
+
+  test("createChartAction applies the chart creation rate limit", async () => {
+    await createChartAction({
+      ctx,
+      parsedInput: {
+        workspaceId: "workspace-1",
+        chartInput: {
+          name: "Chart",
+          type: "bar",
+          query: { measures: ["FeedbackRecords.count"] },
+          config: {},
+          feedbackDirectoryId: "frd-1",
+        },
+      },
+    } as any);
+
+    expect(mocks.applyRateLimit).toHaveBeenCalledWith(rateLimitConfigs.actions.chartCreation, "user-1");
+    expect(mocks.createChart).toHaveBeenCalled();
   });
 
   test("executeQueryAction does not delegate before workspace authorization succeeds", async () => {

--- a/apps/web/modules/ee/analysis/charts/actions.test.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.test.ts
@@ -130,9 +130,9 @@ describe("chart Cube actions", () => {
     expect(mocks.checkWorkspaceAccess).toHaveBeenCalledWith("user-1", "workspace-1", "read");
     expect(mocks.checkFeedbackDirectoryAccess).toHaveBeenCalledWith({
       feedbackDirectoryId: "frd-1",
-      organizationId: "organization-1",
       workspaceId: "workspace-1",
       userId: "user-1",
+      minPermission: "read",
       source: "charts.executeQueryAction",
     });
     expect(mocks.executeTenantScopedQuery).toHaveBeenCalledWith({

--- a/apps/web/modules/ee/analysis/charts/actions.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.ts
@@ -7,6 +7,8 @@ import { OperationNotAllowedError } from "@formbricks/types/errors";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { AuthenticatedActionClientCtx } from "@/lib/utils/action-client/types/context";
+import { applyRateLimit } from "@/modules/core/rate-limit/helpers";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { executeTenantScopedQuery } from "@/modules/ee/analysis/api/lib/cube-client";
 import { generateAIChartQuery } from "@/modules/ee/analysis/charts/lib/ai-chart-query.server";
 import {
@@ -50,6 +52,8 @@ export const createChartAction = authenticatedActionClient.inputSchema(ZCreateCh
       ctx: AuthenticatedActionClientCtx;
       parsedInput: z.infer<typeof ZCreateChartAction>;
     }) => {
+      ctx.auditLoggingCtx.workspaceId = parsedInput.workspaceId;
+      await applyRateLimit(rateLimitConfigs.actions.chartCreation, ctx.user.id);
       const { organizationId, workspaceId } = await checkWorkspaceAccess(
         ctx.user.id,
         parsedInput.workspaceId,

--- a/apps/web/modules/ee/analysis/charts/actions.ts
+++ b/apps/web/modules/ee/analysis/charts/actions.ts
@@ -59,9 +59,9 @@ export const createChartAction = authenticatedActionClient.inputSchema(ZCreateCh
 
       await checkFeedbackDirectoryAccess({
         feedbackDirectoryId: parsedInput.chartInput.feedbackDirectoryId,
-        organizationId,
         workspaceId,
         userId: ctx.user.id,
+        minPermission: "readWrite",
         source: "charts.createChartAction",
       });
 
@@ -273,9 +273,9 @@ export const executeQueryAction = authenticatedActionClient
 
       const { feedbackDirectoryId } = await checkFeedbackDirectoryAccess({
         feedbackDirectoryId: parsedInput.feedbackDirectoryId,
-        organizationId,
         workspaceId,
         userId: ctx.user.id,
+        minPermission: "read",
         source: "charts.executeQueryAction",
       });
 
@@ -322,9 +322,9 @@ export const generateAIChartAction = authenticatedActionClient
 
       const { feedbackDirectoryId } = await checkFeedbackDirectoryAccess({
         feedbackDirectoryId: parsedInput.feedbackDirectoryId,
-        organizationId,
         workspaceId,
         userId: ctx.user.id,
+        minPermission: "read",
         source: "charts.generateAIChartAction",
       });
 
@@ -395,9 +395,9 @@ export const getDimensionValuesAction = authenticatedActionClient
 
       const { feedbackDirectoryId } = await checkFeedbackDirectoryAccess({
         feedbackDirectoryId: parsedInput.feedbackDirectoryId,
-        organizationId,
         workspaceId,
         userId: ctx.user.id,
+        minPermission: "read",
         source: "charts.getDimensionValuesAction",
       });
 

--- a/apps/web/modules/ee/analysis/charts/components/charts-list-page.tsx
+++ b/apps/web/modules/ee/analysis/charts/components/charts-list-page.tsx
@@ -51,7 +51,7 @@ interface ChartsListPageProps {
 
 export async function ChartsListPage({ workspaceId }: Readonly<ChartsListPageProps>) {
   const t = await getTranslate();
-  const { isReadOnly, organization, isOwner, isManager } = await getWorkspaceAuth(workspaceId);
+  const { isReadOnly, organization, isOwner, isManager, session } = await getWorkspaceAuth(workspaceId);
 
   const isDashboardsAllowed = await getIsDashboardsEnabled(organization.id);
   if (!isDashboardsAllowed) {
@@ -81,7 +81,7 @@ export async function ChartsListPage({ workspaceId }: Readonly<ChartsListPagePro
   }
 
   const [feedbackDataAvailability, aiConfig] = await Promise.all([
-    getFeedbackDataAvailability(workspaceId),
+    getFeedbackDataAvailability(session.user.id, workspaceId),
     getOrganizationAIConfig(organization.id),
   ]);
   const aiUnavailableReason = getAISmartToolsUnavailableReason(aiConfig);

--- a/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/pages/dashboard-detail-page.tsx
@@ -11,8 +11,8 @@ import { resolveOptionGrouping } from "@/modules/ee/analysis/charts/lib/option-g
 import { AnalysisPageLayout } from "@/modules/ee/analysis/components/analysis-page-layout";
 import { checkFeedbackDirectoryAccess } from "@/modules/ee/analysis/lib/access";
 import type { TChartDataRow } from "@/modules/ee/analysis/types/analysis";
-import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
 import { getIsDashboardsEnabled } from "@/modules/ee/license-check/lib/utils";
+import { getAuthorizedWorkspaceFeedbackDirectories } from "@/modules/ee/unify-feedback/lib/access";
 import { UpgradePrompt } from "@/modules/ui/components/upgrade-prompt";
 import { getWorkspaceAuth } from "@/modules/workspaces/lib/utils";
 import { DashboardDetailClient } from "../components/dashboard-detail-client";
@@ -45,9 +45,9 @@ async function executeWidgetQuery(
   try {
     const tenant = await checkFeedbackDirectoryAccess({
       feedbackDirectoryId,
-      organizationId,
       workspaceId,
       userId,
+      minPermission: "read",
       source: "dashboards.widget",
     });
 
@@ -125,7 +125,7 @@ export async function DashboardDetailPage({
   }
 
   const [directories, aiConfig] = await Promise.all([
-    getFeedbackDirectoriesByWorkspaceId(workspaceId),
+    getAuthorizedWorkspaceFeedbackDirectories(session.user.id, workspaceId),
     getOrganizationAIConfig(organization.id),
   ]);
   const aiUnavailableReason = getAISmartToolsUnavailableReason(aiConfig);

--- a/apps/web/modules/ee/analysis/dashboards/pages/dashboards-list-page.tsx
+++ b/apps/web/modules/ee/analysis/dashboards/pages/dashboards-list-page.tsx
@@ -34,7 +34,7 @@ interface DashboardsListPageProps {
 
 export const DashboardsListPage = async ({ workspaceId }: Readonly<DashboardsListPageProps>) => {
   const t = await getTranslate();
-  const { isReadOnly, organization, isOwner, isManager } = await getWorkspaceAuth(workspaceId);
+  const { isReadOnly, organization, isOwner, isManager, session } = await getWorkspaceAuth(workspaceId);
 
   const isDashboardsAllowed = await getIsDashboardsEnabled(organization.id);
   if (!isDashboardsAllowed) {
@@ -63,7 +63,7 @@ export const DashboardsListPage = async ({ workspaceId }: Readonly<DashboardsLis
     );
   }
 
-  const feedbackDataAvailability = await getFeedbackDataAvailability(workspaceId);
+  const feedbackDataAvailability = await getFeedbackDataAvailability(session.user.id, workspaceId);
 
   if (feedbackDataAvailability.status === "no-directory") {
     return (

--- a/apps/web/modules/ee/analysis/lib/access.test.ts
+++ b/apps/web/modules/ee/analysis/lib/access.test.ts
@@ -94,7 +94,11 @@ describe("checkFeedbackDirectoryAccess", () => {
     expect(mocks.can).toHaveBeenCalledWith(
       { type: "user", id: "user-1" },
       "feedbackDirectoryAssignment.read",
-      { type: "feedbackDirectoryAssignment", id: "frd-1", workspaceId: "workspace-1" }
+      {
+        type: "feedbackDirectoryAssignment",
+        feedbackDirectoryId: "frd-1",
+        workspaceId: "workspace-1",
+      }
     );
   });
 

--- a/apps/web/modules/ee/analysis/lib/access.test.ts
+++ b/apps/web/modules/ee/analysis/lib/access.test.ts
@@ -5,19 +5,19 @@ import { checkFeedbackDirectoryAccess, checkWorkspaceAccess } from "./access";
 vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
+  can: vi.fn(),
   checkAuthorizationUpdated: vi.fn(),
-  getFeedbackDirectoryAuthContext: vi.fn(),
   getOrganizationIdFromWorkspaceId: vi.fn(),
-  loggerError: vi.fn(),
   loggerWarn: vi.fn(),
 }));
 
 vi.mock("@formbricks/logger", () => ({
   logger: {
-    error: mocks.loggerError,
     warn: mocks.loggerWarn,
   },
 }));
+
+vi.mock("@/lib/authorization", () => ({ can: mocks.can }));
 
 vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
   checkAuthorizationUpdated: mocks.checkAuthorizationUpdated,
@@ -27,15 +27,11 @@ vi.mock("@/lib/utils/helper", () => ({
   getOrganizationIdFromWorkspaceId: mocks.getOrganizationIdFromWorkspaceId,
 }));
 
-vi.mock("@/modules/ee/feedback-directory/lib/feedback-directory", () => ({
-  getFeedbackDirectoryAuthContext: mocks.getFeedbackDirectoryAuthContext,
-}));
-
 const accessInput = {
   feedbackDirectoryId: "frd-1",
-  organizationId: "organization-1",
   workspaceId: "workspace-1",
   userId: "user-1",
+  minPermission: "read" as const,
   source: "charts.executeQueryAction" as const,
 };
 
@@ -47,6 +43,7 @@ const workspaceAccessInput = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.can.mockResolvedValue(true);
 });
 
 describe("checkWorkspaceAccess", () => {
@@ -91,52 +88,31 @@ describe("checkWorkspaceAccess", () => {
 
 describe("checkFeedbackDirectoryAccess", () => {
   test("returns the feedback directory ID when it belongs to the authorized workspace", async () => {
-    mocks.getFeedbackDirectoryAuthContext.mockResolvedValue({
-      organizationId: "organization-1",
-      workspaceIds: ["workspace-1"],
-      isArchived: false,
-    });
-
     await expect(checkFeedbackDirectoryAccess(accessInput)).resolves.toEqual({
       feedbackDirectoryId: "frd-1",
     });
+    expect(mocks.can).toHaveBeenCalledWith(
+      { type: "user", id: "user-1" },
+      "feedbackDirectoryAssignment.read",
+      { type: "feedbackDirectoryAssignment", id: "frd-1", workspaceId: "workspace-1" }
+    );
   });
 
   test("rejects inaccessible feedback record directories with an audit-safe warning", async () => {
-    mocks.getFeedbackDirectoryAuthContext.mockResolvedValue({
-      organizationId: "organization-1",
-      workspaceIds: ["workspace-2"],
-      isArchived: false,
-    });
+    mocks.can.mockResolvedValue(false);
 
     await expect(checkFeedbackDirectoryAccess(accessInput)).rejects.toBeInstanceOf(AuthorizationError);
     expect(mocks.loggerWarn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        feedbackDirectoryId: "frd-1",
-        organizationId: "organization-1",
-        workspaceId: "workspace-1",
-        userId: "user-1",
-        source: "charts.executeQueryAction",
-      }),
+      { source: "charts.executeQueryAction" },
       "Feedback directory access denied for Cube query"
     );
   });
 
-  test("logs unexpected lookup failures before rethrowing", async () => {
+  test("propagates operational failures without logging identifiers or raw errors", async () => {
     const error = new Error("database unavailable");
-    mocks.getFeedbackDirectoryAuthContext.mockRejectedValue(error);
+    mocks.can.mockRejectedValue(error);
 
     await expect(checkFeedbackDirectoryAccess(accessInput)).rejects.toThrow("database unavailable");
-    expect(mocks.loggerError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        error,
-        feedbackDirectoryId: "frd-1",
-        organizationId: "organization-1",
-        workspaceId: "workspace-1",
-        userId: "user-1",
-        source: "charts.executeQueryAction",
-      }),
-      "Failed to verify feedback directory access for Cube query"
-    );
+    expect(mocks.loggerWarn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/modules/ee/analysis/lib/access.ts
+++ b/apps/web/modules/ee/analysis/lib/access.ts
@@ -51,7 +51,7 @@ export const checkFeedbackDirectoryAccess = async ({
   const allowed = await can(
     { type: "user", id: userId },
     getFeedbackDirectoryAssignmentActionForPermission(minPermission),
-    { type: "feedbackDirectoryAssignment", id: feedbackDirectoryId, workspaceId }
+    { type: "feedbackDirectoryAssignment", feedbackDirectoryId, workspaceId }
   );
 
   if (!allowed) {

--- a/apps/web/modules/ee/analysis/lib/access.ts
+++ b/apps/web/modules/ee/analysis/lib/access.ts
@@ -1,9 +1,10 @@
 import "server-only";
 import { logger } from "@formbricks/logger";
 import { AuthorizationError } from "@formbricks/types/errors";
+import { can } from "@/lib/authorization";
+import { getFeedbackDirectoryAssignmentActionForPermission } from "@/lib/authorization/compatibility";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
-import { getFeedbackDirectoryAuthContext } from "@/modules/ee/feedback-directory/lib/feedback-directory";
 import type { TTeamPermission } from "@/modules/ee/teams/workspace-teams/types/team";
 
 export const checkWorkspaceAccess = async (
@@ -34,57 +35,29 @@ type TFeedbackDirectoryAccessSource =
 
 type TCheckFeedbackDirectoryAccessInput = {
   feedbackDirectoryId: string;
-  organizationId: string;
   workspaceId: string;
   userId: string;
+  minPermission: TTeamPermission;
   source: TFeedbackDirectoryAccessSource;
 };
 
 export const checkFeedbackDirectoryAccess = async ({
   feedbackDirectoryId,
-  organizationId,
   workspaceId,
   userId,
+  minPermission,
   source,
 }: TCheckFeedbackDirectoryAccessInput): Promise<{ feedbackDirectoryId: string }> => {
-  try {
-    const directory = await getFeedbackDirectoryAuthContext(feedbackDirectoryId);
-    const isAccessible =
-      directory?.organizationId === organizationId &&
-      directory.workspaceIds.includes(workspaceId) &&
-      !directory.isArchived;
+  const allowed = await can(
+    { type: "user", id: userId },
+    getFeedbackDirectoryAssignmentActionForPermission(minPermission),
+    { type: "feedbackDirectoryAssignment", id: feedbackDirectoryId, workspaceId }
+  );
 
-    if (!isAccessible) {
-      logger.warn(
-        {
-          feedbackDirectoryId,
-          organizationId,
-          workspaceId,
-          userId,
-          source,
-        },
-        "Feedback directory access denied for Cube query"
-      );
-      throw new AuthorizationError("Feedback directory is not accessible from this workspace");
-    }
-
-    return { feedbackDirectoryId };
-  } catch (error) {
-    if (error instanceof AuthorizationError) {
-      throw error;
-    }
-
-    logger.error(
-      {
-        error,
-        feedbackDirectoryId,
-        organizationId,
-        workspaceId,
-        userId,
-        source,
-      },
-      "Failed to verify feedback directory access for Cube query"
-    );
-    throw error;
+  if (!allowed) {
+    logger.warn({ source }, "Feedback directory access denied for Cube query");
+    throw new AuthorizationError("Feedback directory is not accessible from this workspace");
   }
+
+  return { feedbackDirectoryId };
 };

--- a/apps/web/modules/ee/analysis/lib/feedback-data-availability.test.ts
+++ b/apps/web/modules/ee/analysis/lib/feedback-data-availability.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { getFeedbackSourcesWithMappings } from "@/lib/feedback-source/service";
 import { hasFeedbackRecordsInDirectories } from "@/modules/ee/analysis/lib/feedback-records";
-import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
+import { getAuthorizedWorkspaceFeedbackDirectories } from "@/modules/ee/unify-feedback/lib/access";
 import { getFeedbackDataAvailability } from "./feedback-data-availability";
 
 vi.mock("@/lib/feedback-source/service", () => ({
@@ -10,11 +10,12 @@ vi.mock("@/lib/feedback-source/service", () => ({
 vi.mock("@/modules/ee/analysis/lib/feedback-records", () => ({
   hasFeedbackRecordsInDirectories: vi.fn(),
 }));
-vi.mock("@/modules/ee/feedback-directory/lib/feedback-directory", () => ({
-  getFeedbackDirectoriesByWorkspaceId: vi.fn(),
+vi.mock("@/modules/ee/unify-feedback/lib/access", () => ({
+  getAuthorizedWorkspaceFeedbackDirectories: vi.fn(),
 }));
 
 const workspaceId = "ws-1";
+const userId = "user-1";
 const sources = [{ id: "src-1" }] as never;
 
 describe("getFeedbackDataAvailability", () => {
@@ -23,32 +24,32 @@ describe("getFeedbackDataAvailability", () => {
   });
 
   test("returns 'no-directory' and skips the records lookup when the workspace has no directories", async () => {
-    vi.mocked(getFeedbackDirectoriesByWorkspaceId).mockResolvedValue([] as never);
+    vi.mocked(getAuthorizedWorkspaceFeedbackDirectories).mockResolvedValue([] as never);
     vi.mocked(getFeedbackSourcesWithMappings).mockResolvedValue(sources);
 
-    const result = await getFeedbackDataAvailability(workspaceId);
+    const result = await getFeedbackDataAvailability(userId, workspaceId);
 
     expect(result).toEqual({ status: "no-directory", directories: [], feedbackSources: sources });
     expect(hasFeedbackRecordsInDirectories).not.toHaveBeenCalled();
   });
 
   test("fetches directories and sources for the given workspace in parallel", async () => {
-    vi.mocked(getFeedbackDirectoriesByWorkspaceId).mockResolvedValue([] as never);
+    vi.mocked(getAuthorizedWorkspaceFeedbackDirectories).mockResolvedValue([] as never);
     vi.mocked(getFeedbackSourcesWithMappings).mockResolvedValue(sources);
 
-    await getFeedbackDataAvailability(workspaceId);
+    await getFeedbackDataAvailability(userId, workspaceId);
 
-    expect(getFeedbackDirectoriesByWorkspaceId).toHaveBeenCalledWith(workspaceId);
+    expect(getAuthorizedWorkspaceFeedbackDirectories).toHaveBeenCalledWith(userId, workspaceId);
     expect(getFeedbackSourcesWithMappings).toHaveBeenCalledWith(workspaceId);
   });
 
   test("returns 'ready' when directories exist and they contain feedback records", async () => {
     const directories = [{ id: "dir-1" }, { id: "dir-2" }] as never;
-    vi.mocked(getFeedbackDirectoriesByWorkspaceId).mockResolvedValue(directories);
+    vi.mocked(getAuthorizedWorkspaceFeedbackDirectories).mockResolvedValue(directories);
     vi.mocked(getFeedbackSourcesWithMappings).mockResolvedValue(sources);
     vi.mocked(hasFeedbackRecordsInDirectories).mockResolvedValue(true);
 
-    const result = await getFeedbackDataAvailability(workspaceId);
+    const result = await getFeedbackDataAvailability(userId, workspaceId);
 
     expect(hasFeedbackRecordsInDirectories).toHaveBeenCalledWith(["dir-1", "dir-2"]);
     expect(result).toEqual({
@@ -61,11 +62,11 @@ describe("getFeedbackDataAvailability", () => {
 
   test("returns 'no-records' when directories exist but contain no feedback records", async () => {
     const directories = [{ id: "dir-1" }] as never;
-    vi.mocked(getFeedbackDirectoriesByWorkspaceId).mockResolvedValue(directories);
+    vi.mocked(getAuthorizedWorkspaceFeedbackDirectories).mockResolvedValue(directories);
     vi.mocked(getFeedbackSourcesWithMappings).mockResolvedValue(sources);
     vi.mocked(hasFeedbackRecordsInDirectories).mockResolvedValue(false);
 
-    const result = await getFeedbackDataAvailability(workspaceId);
+    const result = await getFeedbackDataAvailability(userId, workspaceId);
 
     expect(result).toEqual({
       status: "no-records",

--- a/apps/web/modules/ee/analysis/lib/feedback-data-availability.ts
+++ b/apps/web/modules/ee/analysis/lib/feedback-data-availability.ts
@@ -1,10 +1,10 @@
 import { getFeedbackSourcesWithMappings } from "@/lib/feedback-source/service";
 import { hasFeedbackRecordsInDirectories } from "@/modules/ee/analysis/lib/feedback-records";
-import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
+import { getAuthorizedWorkspaceFeedbackDirectories } from "@/modules/ee/unify-feedback/lib/access";
 
-export async function getFeedbackDataAvailability(workspaceId: string) {
+export async function getFeedbackDataAvailability(userId: string, workspaceId: string) {
   const [directories, feedbackSources] = await Promise.all([
-    getFeedbackDirectoriesByWorkspaceId(workspaceId),
+    getAuthorizedWorkspaceFeedbackDirectories(userId, workspaceId),
     getFeedbackSourcesWithMappings(workspaceId),
   ]);
 

--- a/apps/web/modules/ee/audit-logs/lib/handler.test.ts
+++ b/apps/web/modules/ee/audit-logs/lib/handler.test.ts
@@ -313,6 +313,21 @@ describe("withAuditLogging", () => {
     expect(callArgs.target.id).toBe("chart-1");
   });
 
+  test("resolves targetId for feedback source target type", async () => {
+    const feedbackSourceCtx = {
+      ...mockCtxBase,
+      auditLoggingCtx: { ...mockCtxBase.auditLoggingCtx, feedbackSourceId: "feedback-source-1" },
+    };
+    const handlerImpl = vi.fn().mockResolvedValue("ok");
+    const wrapped = OriginalHandler.withAuditLogging("created", "feedbackSource", handlerImpl);
+    await wrapped({ ctx: feedbackSourceCtx as any, parsedInput: mockParsedInput });
+    await new Promise(setImmediate);
+    expect(serviceLogAuditEventMockHandle).toHaveBeenCalled();
+    const callArgs = serviceLogAuditEventMockHandle.mock.calls[0][0];
+    expect(callArgs.target.type).toBe("feedbackSource");
+    expect(callArgs.target.id).toBe("feedback-source-1");
+  });
+
   test("resolves targetId for dashboard target type", async () => {
     const dashCtx = {
       ...mockCtxBase,

--- a/apps/web/modules/ee/audit-logs/lib/handler.ts
+++ b/apps/web/modules/ee/audit-logs/lib/handler.ts
@@ -327,6 +327,9 @@ export const withAuditLogging = <
           case "feedbackRecord":
             targetId = auditLoggingCtx.feedbackRecordId;
             break;
+          case "feedbackSource":
+            targetId = auditLoggingCtx.feedbackSourceId;
+            break;
           default:
             targetId = UNKNOWN_DATA;
             break;

--- a/apps/web/modules/ee/audit-logs/types/audit-log.ts
+++ b/apps/web/modules/ee/audit-logs/types/audit-log.ts
@@ -32,6 +32,7 @@ export const ZAuditTarget = z.enum([
   "cubeQuery",
   "feedbackDirectory",
   "feedbackRecord",
+  "feedbackSource",
 ]);
 export const ZAuditAction = z.enum([
   "created",

--- a/apps/web/modules/ee/feedback-directory/actions.test.ts
+++ b/apps/web/modules/ee/feedback-directory/actions.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { assertCan } from "@/lib/authorization";
+import {
+  createFeedbackDirectoryAction,
+  getFeedbackDirectoryDetailsAction,
+  updateFeedbackDirectoryAction,
+} from "./actions";
+
+const mocks = vi.hoisted(() => {
+  const action = vi.fn((handler) => handler);
+  return {
+    action,
+    inputSchema: vi.fn(() => ({ action })),
+    createFeedbackDirectory: vi.fn(),
+    getFeedbackDirectoryDetails: vi.fn(),
+    getOrganizationIdFromDirectoryId: vi.fn(),
+    updateFeedbackDirectory: vi.fn(),
+    getIsFeedbackDirectoriesEnabled: vi.fn(),
+  };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/authorization", () => ({ assertCan: vi.fn() }));
+vi.mock("@/lib/posthog", () => ({ capturePostHogEvent: vi.fn() }));
+vi.mock("@/lib/utils/action-client", () => ({
+  authenticatedActionClient: { inputSchema: mocks.inputSchema },
+}));
+vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
+  withAuditLogging: vi.fn((_event, _target, handler) => handler),
+}));
+vi.mock("@/modules/ee/feedback-directory/lib/feedback-directory", () => ({
+  createFeedbackDirectory: mocks.createFeedbackDirectory,
+  getFeedbackDirectoryDetails: mocks.getFeedbackDirectoryDetails,
+  getOrganizationIdFromDirectoryId: mocks.getOrganizationIdFromDirectoryId,
+  updateFeedbackDirectory: mocks.updateFeedbackDirectory,
+}));
+vi.mock("@/modules/ee/license-check/lib/utils", () => ({
+  getIsFeedbackDirectoriesEnabled: mocks.getIsFeedbackDirectoriesEnabled,
+}));
+
+const ctx = { user: { id: "user_1" }, auditLoggingCtx: {} };
+const organizationId = "organization_1";
+const directoryId = "directory_1";
+
+describe("feedback directory administration actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(assertCan).mockResolvedValue(undefined);
+    mocks.getIsFeedbackDirectoriesEnabled.mockResolvedValue(true);
+    mocks.getOrganizationIdFromDirectoryId.mockResolvedValue(organizationId);
+    mocks.createFeedbackDirectory.mockResolvedValue(directoryId);
+    mocks.getFeedbackDirectoryDetails.mockResolvedValue({ id: directoryId, name: "Dataset" });
+    mocks.updateFeedbackDirectory.mockResolvedValue({ id: directoryId });
+  });
+
+  test.each([
+    ["create", createFeedbackDirectoryAction, { organizationId, name: "Dataset" }],
+    ["read", getFeedbackDirectoryDetailsAction, { directoryId }],
+    ["update", updateFeedbackDirectoryAction, { directoryId, data: { name: "Renamed" } }],
+  ])("routes %s through organization.manage", async (_name, action, parsedInput) => {
+    await (action as any)({ ctx, parsedInput });
+
+    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "organization.manage", {
+      type: "organization",
+      id: organizationId,
+    });
+  });
+});

--- a/apps/web/modules/ee/feedback-directory/actions.test.ts
+++ b/apps/web/modules/ee/feedback-directory/actions.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { assertCan } from "@/lib/authorization";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import {
   createFeedbackDirectoryAction,
   getFeedbackDirectoryDetailsAction,
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => {
     createFeedbackDirectory: vi.fn(),
     getFeedbackDirectoryDetails: vi.fn(),
     getOrganizationIdFromDirectoryId: vi.fn(),
+    applyRateLimit: vi.fn(),
     updateFeedbackDirectory: vi.fn(),
     getIsFeedbackDirectoriesEnabled: vi.fn(),
   };
@@ -25,6 +27,7 @@ vi.mock("@/lib/posthog", () => ({ capturePostHogEvent: vi.fn() }));
 vi.mock("@/lib/utils/action-client", () => ({
   authenticatedActionClient: { inputSchema: mocks.inputSchema },
 }));
+vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyRateLimit: mocks.applyRateLimit }));
 vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
   withAuditLogging: vi.fn((_event, _target, handler) => handler),
 }));
@@ -64,5 +67,14 @@ describe("feedback directory administration actions", () => {
       type: "organization",
       id: organizationId,
     });
+
+    if (_name === "read") {
+      expect(mocks.applyRateLimit).not.toHaveBeenCalled();
+    } else {
+      expect(mocks.applyRateLimit).toHaveBeenCalledWith(
+        rateLimitConfigs.actions.feedbackDirectoryMutation,
+        "user_1"
+      );
+    }
   });
 });

--- a/apps/web/modules/ee/feedback-directory/actions.ts
+++ b/apps/web/modules/ee/feedback-directory/actions.ts
@@ -3,9 +3,9 @@
 import { z } from "zod";
 import { ZId } from "@formbricks/types/common";
 import { OperationNotAllowedError } from "@formbricks/types/errors";
+import { assertCan } from "@/lib/authorization";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import {
   createFeedbackDirectory,
@@ -34,15 +34,9 @@ export const createFeedbackDirectoryAction = authenticatedActionClient
   .action(
     withAuditLogging("created", "feedbackDirectory", async ({ ctx, parsedInput }) => {
       await checkFeedbackDirectoriesEnabled(parsedInput.organizationId);
-      await checkAuthorizationUpdated({
-        userId: ctx.user.id,
-        organizationId: parsedInput.organizationId,
-        access: [
-          {
-            type: "organization",
-            roles: ["owner", "manager"],
-          },
-        ],
+      await assertCan({ type: "user", id: ctx.user.id }, "organization.manage", {
+        type: "organization",
+        id: parsedInput.organizationId,
       });
 
       const result = await createFeedbackDirectory(
@@ -75,15 +69,9 @@ export const getFeedbackDirectoryDetailsAction = authenticatedActionClient
     const organizationId = await getOrganizationIdFromDirectoryId(parsedInput.directoryId);
     await checkFeedbackDirectoriesEnabled(organizationId);
 
-    await checkAuthorizationUpdated({
-      userId: ctx.user.id,
-      organizationId,
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-      ],
+    await assertCan({ type: "user", id: ctx.user.id }, "organization.manage", {
+      type: "organization",
+      id: organizationId,
     });
 
     return await getFeedbackDirectoryDetails(parsedInput.directoryId);
@@ -101,15 +89,9 @@ export const updateFeedbackDirectoryAction = authenticatedActionClient
       const organizationId = await getOrganizationIdFromDirectoryId(parsedInput.directoryId);
       await checkFeedbackDirectoriesEnabled(organizationId);
 
-      await checkAuthorizationUpdated({
-        userId: ctx.user.id,
-        organizationId,
-        access: [
-          {
-            type: "organization",
-            roles: ["owner", "manager"],
-          },
-        ],
+      await assertCan({ type: "user", id: ctx.user.id }, "organization.manage", {
+        type: "organization",
+        id: organizationId,
       });
 
       ctx.auditLoggingCtx.organizationId = organizationId;

--- a/apps/web/modules/ee/feedback-directory/actions.ts
+++ b/apps/web/modules/ee/feedback-directory/actions.ts
@@ -6,6 +6,8 @@ import { OperationNotAllowedError } from "@formbricks/types/errors";
 import { assertCan } from "@/lib/authorization";
 import { capturePostHogEvent } from "@/lib/posthog";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
+import { applyRateLimit } from "@/modules/core/rate-limit/helpers";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import {
   createFeedbackDirectory,
@@ -33,6 +35,8 @@ export const createFeedbackDirectoryAction = authenticatedActionClient
   .inputSchema(ZCreateFeedbackDirectoryAction)
   .action(
     withAuditLogging("created", "feedbackDirectory", async ({ ctx, parsedInput }) => {
+      ctx.auditLoggingCtx.organizationId = parsedInput.organizationId;
+      await applyRateLimit(rateLimitConfigs.actions.feedbackDirectoryMutation, ctx.user.id);
       await checkFeedbackDirectoriesEnabled(parsedInput.organizationId);
       await assertCan({ type: "user", id: ctx.user.id }, "organization.manage", {
         type: "organization",
@@ -86,6 +90,8 @@ export const updateFeedbackDirectoryAction = authenticatedActionClient
   .inputSchema(ZUpdateFeedbackDirectoryAction)
   .action(
     withAuditLogging("updated", "feedbackDirectory", async ({ ctx, parsedInput }) => {
+      ctx.auditLoggingCtx.feedbackDirectoryId = parsedInput.directoryId;
+      await applyRateLimit(rateLimitConfigs.actions.feedbackDirectoryMutation, ctx.user.id);
       const organizationId = await getOrganizationIdFromDirectoryId(parsedInput.directoryId);
       await checkFeedbackDirectoriesEnabled(organizationId);
 

--- a/apps/web/modules/ee/feedback-directory/page.tsx
+++ b/apps/web/modules/ee/feedback-directory/page.tsx
@@ -1,6 +1,6 @@
 import { SettingsCard } from "@/app/(app)/workspaces/[workspaceId]/settings/components/SettingsCard";
+import { can } from "@/lib/authorization";
 import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
-import { getAccessFlags } from "@/lib/membership/utils";
 import { getTranslate } from "@/lingodotdev/server";
 import { FeedbackDirectoryView } from "@/modules/ee/feedback-directory/components/feedback-directory-view";
 import { getIsFeedbackDirectoriesEnabled } from "@/modules/ee/license-check/lib/utils";
@@ -17,9 +17,7 @@ export const FeedbackDirectoriesPage = async (props: { params: Promise<{ organiz
 
   await redirectBillingRoleFromRestrictedOrgSettings(params.organizationId);
 
-  const { currentUserMembership, organization } = await getOrganizationAuth(params.organizationId);
-
-  const { isOwner, isManager } = getAccessFlags(currentUserMembership.role);
+  const { currentUserMembership, organization, session } = await getOrganizationAuth(params.organizationId);
 
   const isFeedbackDirectoriesAllowed = await getIsFeedbackDirectoriesEnabled(organization.id);
   const pageTitle = t("workspace.settings.feedback_directories.title");
@@ -55,7 +53,12 @@ export const FeedbackDirectoriesPage = async (props: { params: Promise<{ organiz
     );
   }
 
-  if (!isOwner && !isManager) {
+  const canManageFeedbackDirectories = await can(
+    { type: "user", id: session.user.id },
+    "organization.manage",
+    { type: "organization", id: organization.id }
+  );
+  if (!canManageFeedbackDirectories) {
     return (
       <PageContentWrapper>
         <PageHeader pageTitle={pageTitle} />

--- a/apps/web/modules/ee/unify-feedback/actions.test.ts
+++ b/apps/web/modules/ee/unify-feedback/actions.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
+import { deleteFeedbackRecordAction } from "./actions";
+
+const mocks = vi.hoisted(() => {
+  const action = vi.fn((handler) => handler);
+  return {
+    action,
+    inputSchema: vi.fn(() => ({ action })),
+    applyRateLimit: vi.fn(),
+    ensureDeleteAccess: vi.fn(),
+    getWorkspaceDirectoryIds: vi.fn(),
+    retrieveFeedbackRecord: vi.fn(),
+    deleteFeedbackRecord: vi.fn(),
+    assertRecordBelongsToWorkspace: vi.fn(),
+    assertFeedbackDirectoryAssignmentAccess: vi.fn(),
+  };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/utils/action-client", () => ({
+  authenticatedActionClient: { inputSchema: mocks.inputSchema },
+}));
+vi.mock("@/modules/core/rate-limit/helpers", () => ({ applyRateLimit: mocks.applyRateLimit }));
+vi.mock("@/modules/ee/audit-logs/lib/handler", () => ({
+  withAuditLogging: vi.fn((_event, _target, handler) => handler),
+}));
+vi.mock("@/modules/ee/unify-feedback/lib/access", () => ({
+  assertFeedbackDirectoryAssignmentAccess: mocks.assertFeedbackDirectoryAssignmentAccess,
+  assertRecordBelongsToWorkspace: mocks.assertRecordBelongsToWorkspace,
+  ensureDeleteAccess: mocks.ensureDeleteAccess,
+  ensureReadAccess: vi.fn(),
+  getWorkspaceDirectoryIds: mocks.getWorkspaceDirectoryIds,
+}));
+vi.mock("@/modules/hub/service", () => ({
+  deleteFeedbackRecord: mocks.deleteFeedbackRecord,
+  retrieveFeedbackRecord: mocks.retrieveFeedbackRecord,
+}));
+
+describe("deleteFeedbackRecordAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.ensureDeleteAccess.mockResolvedValue("organization-1");
+    mocks.getWorkspaceDirectoryIds.mockResolvedValue(["directory-1"]);
+    mocks.retrieveFeedbackRecord.mockResolvedValue({
+      data: {
+        id: "record-1",
+        tenant_id: "directory-1",
+        submission_id: "submission-1",
+        source_type: "survey",
+        source_id: "source-1",
+        field_id: "field-1",
+        field_type: "text",
+        collected_at: "2026-08-16T00:00:00.000Z",
+      },
+      error: null,
+    });
+    mocks.deleteFeedbackRecord.mockResolvedValue({ data: { id: "record-1" }, error: null });
+  });
+
+  test("rate limits the mutation before deleting the record", async () => {
+    const ctx = { user: { id: "user-1" }, auditLoggingCtx: {} };
+
+    await deleteFeedbackRecordAction({
+      ctx,
+      parsedInput: { recordId: "record-1", workspaceId: "workspace-1" },
+    } as any);
+
+    expect(mocks.applyRateLimit).toHaveBeenCalledWith(
+      rateLimitConfigs.actions.feedbackRecordDeletion,
+      "user-1"
+    );
+    expect(mocks.deleteFeedbackRecord).toHaveBeenCalledWith("record-1");
+    expect(mocks.applyRateLimit.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.deleteFeedbackRecord.mock.invocationCallOrder[0]
+    );
+  });
+});

--- a/apps/web/modules/ee/unify-feedback/actions.ts
+++ b/apps/web/modules/ee/unify-feedback/actions.ts
@@ -3,6 +3,8 @@
 import { ResourceNotFoundError } from "@formbricks/types/errors";
 import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { AuthenticatedActionClientCtx } from "@/lib/utils/action-client/types/context";
+import { applyRateLimit } from "@/modules/core/rate-limit/helpers";
+import { rateLimitConfigs } from "@/modules/core/rate-limit/rate-limit-configs";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import {
   assertFeedbackDirectoryAssignmentAccess,
@@ -59,6 +61,7 @@ export const deleteFeedbackRecordAction = authenticatedActionClient
     withAuditLogging("deleted", "feedbackRecord", async ({ ctx, parsedInput }) => {
       // Set before the access check so a refused or failed attempt is still attributable.
       ctx.auditLoggingCtx.feedbackRecordId = parsedInput.recordId;
+      await applyRateLimit(rateLimitConfigs.actions.feedbackRecordDeletion, ctx.user.id);
 
       const [organizationId, workspaceDirectoryIds] = await Promise.all([
         ensureDeleteAccess(ctx.user.id, parsedInput.workspaceId),

--- a/apps/web/modules/ee/unify-feedback/actions.ts
+++ b/apps/web/modules/ee/unify-feedback/actions.ts
@@ -5,6 +5,7 @@ import { authenticatedActionClient } from "@/lib/utils/action-client";
 import { AuthenticatedActionClientCtx } from "@/lib/utils/action-client/types/context";
 import { withAuditLogging } from "@/modules/ee/audit-logs/lib/handler";
 import {
+  assertFeedbackDirectoryAssignmentAccess,
   assertRecordBelongsToWorkspace,
   ensureDeleteAccess,
   ensureReadAccess,
@@ -42,6 +43,11 @@ export const retrieveFeedbackRecordAction = authenticatedActionClient
         recordResult.data.tenant_id,
         parsedInput.recordId
       );
+      await assertFeedbackDirectoryAssignmentAccess(
+        ctx.user.id,
+        recordResult.data.tenant_id,
+        parsedInput.workspaceId
+      );
 
       return recordResult.data;
     }
@@ -69,6 +75,11 @@ export const deleteFeedbackRecordAction = authenticatedActionClient
         workspaceDirectoryIds,
         currentRecordResult.data.tenant_id,
         parsedInput.recordId
+      );
+      await assertFeedbackDirectoryAssignmentAccess(
+        ctx.user.id,
+        currentRecordResult.data.tenant_id,
+        parsedInput.workspaceId
       );
 
       const deleteResult = await deleteFeedbackRecord(parsedInput.recordId);

--- a/apps/web/modules/ee/unify-feedback/lib/access.test.ts
+++ b/apps/web/modules/ee/unify-feedback/lib/access.test.ts
@@ -4,18 +4,23 @@ import {
   OperationNotAllowedError,
   ResourceNotFoundError,
 } from "@formbricks/types/errors";
+import { assertCan } from "@/lib/authorization";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
 import { getIsFeedbackDirectoriesEnabled } from "@/modules/ee/license-check/lib/utils";
 import {
+  assertFeedbackDirectoryAssignmentAccess,
   assertRecordBelongsToWorkspace,
   ensureDeleteAccess,
   ensureReadAccess,
+  getAuthorizedWorkspaceFeedbackDirectories,
   getWorkspaceDirectoryIds,
 } from "./access";
 
 vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/authorization", () => ({ assertCan: vi.fn() }));
 
 vi.mock("@/modules/ee/feedback-directory/lib/feedback-directory", () => ({
   getFeedbackDirectoriesByWorkspaceId: vi.fn(),
@@ -66,6 +71,45 @@ describe("getWorkspaceDirectoryIds", () => {
   });
 });
 
+describe("getAuthorizedWorkspaceFeedbackDirectories", () => {
+  test("checks every exact directory assignment before returning the source rows", async () => {
+    const directories = [
+      { id: sharedDirectoryId, name: "Shared" },
+      { id: otherOrgDirectoryId, name: "Support" },
+    ];
+    vi.mocked(getFeedbackDirectoriesByWorkspaceId).mockResolvedValue(directories);
+    vi.mocked(assertCan).mockResolvedValue(undefined);
+
+    await expect(getAuthorizedWorkspaceFeedbackDirectories(userId, workspaceId)).resolves.toEqual(
+      directories
+    );
+    expect(assertCan).toHaveBeenCalledTimes(2);
+    expect(assertCan).toHaveBeenNthCalledWith(
+      1,
+      { type: "user", id: userId },
+      "feedbackDirectoryAssignment.read",
+      { type: "feedbackDirectoryAssignment", id: sharedDirectoryId, workspaceId }
+    );
+    expect(assertCan).toHaveBeenNthCalledWith(
+      2,
+      { type: "user", id: userId },
+      "feedbackDirectoryAssignment.read",
+      { type: "feedbackDirectoryAssignment", id: otherOrgDirectoryId, workspaceId }
+    );
+  });
+
+  test("propagates an exact assignment refusal", async () => {
+    vi.mocked(getFeedbackDirectoriesByWorkspaceId).mockResolvedValue([
+      { id: sharedDirectoryId, name: "Shared" },
+    ]);
+    vi.mocked(assertCan).mockRejectedValue(new AuthorizationError("Not authorized"));
+
+    await expect(getAuthorizedWorkspaceFeedbackDirectories(userId, workspaceId)).rejects.toThrow(
+      AuthorizationError
+    );
+  });
+});
+
 describe("assertRecordBelongsToWorkspace", () => {
   test("passes when the record's tenant is a directory assigned to the workspace", () => {
     expect(() =>
@@ -106,6 +150,7 @@ describe("license gating", () => {
     vi.mocked(getOrganizationIdFromWorkspaceId).mockResolvedValue(organizationId);
     vi.mocked(getIsFeedbackDirectoriesEnabled).mockResolvedValue(true);
     vi.mocked(checkAuthorizationUpdated).mockResolvedValue(true);
+    vi.mocked(assertCan).mockResolvedValue(undefined);
   });
 
   test.each([
@@ -116,6 +161,7 @@ describe("license gating", () => {
 
     await expect(ensureAccess(userId, workspaceId)).rejects.toThrow(OperationNotAllowedError);
     expect(checkAuthorizationUpdated).not.toHaveBeenCalled();
+    expect(assertCan).not.toHaveBeenCalled();
   });
 });
 
@@ -128,6 +174,7 @@ describe("ensureDeleteAccess", () => {
     vi.mocked(getOrganizationIdFromWorkspaceId).mockResolvedValue(organizationId);
     vi.mocked(getIsFeedbackDirectoriesEnabled).mockResolvedValue(true);
     vi.mocked(checkAuthorizationUpdated).mockResolvedValue(true);
+    vi.mocked(assertCan).mockResolvedValue(undefined);
   });
 
   // Re-adding a workspaceTeam entry to this access list is what reopens ENG-1770, so the list itself is
@@ -135,10 +182,9 @@ describe("ensureDeleteAccess", () => {
   test("requires an organization owner or manager, with no workspace-team fallback", async () => {
     await ensureDeleteAccess(userId, workspaceId);
 
-    expect(checkAuthorizationUpdated).toHaveBeenCalledWith({
-      userId,
-      organizationId,
-      access: [{ type: "organization", roles: ["owner", "manager"] }],
+    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: userId }, "organization.manage", {
+      type: "organization",
+      id: organizationId,
     });
   });
 
@@ -147,9 +193,23 @@ describe("ensureDeleteAccess", () => {
   });
 
   test("propagates the refusal for a caller who is not an owner or manager", async () => {
-    vi.mocked(checkAuthorizationUpdated).mockRejectedValue(new AuthorizationError("Not authorized"));
+    vi.mocked(assertCan).mockRejectedValue(new AuthorizationError("Not authorized"));
 
     await expect(ensureDeleteAccess(userId, workspaceId)).rejects.toThrow(AuthorizationError);
+  });
+});
+
+describe("assertFeedbackDirectoryAssignmentAccess", () => {
+  test("checks exact directory and workspace read access", async () => {
+    vi.mocked(assertCan).mockResolvedValue(undefined);
+
+    await assertFeedbackDirectoryAssignmentAccess(userId, sharedDirectoryId, workspaceId);
+
+    expect(assertCan).toHaveBeenCalledWith({ type: "user", id: userId }, "feedbackDirectoryAssignment.read", {
+      type: "feedbackDirectoryAssignment",
+      id: sharedDirectoryId,
+      workspaceId,
+    });
   });
 });
 

--- a/apps/web/modules/ee/unify-feedback/lib/access.test.ts
+++ b/apps/web/modules/ee/unify-feedback/lib/access.test.ts
@@ -88,13 +88,13 @@ describe("getAuthorizedWorkspaceFeedbackDirectories", () => {
       1,
       { type: "user", id: userId },
       "feedbackDirectoryAssignment.read",
-      { type: "feedbackDirectoryAssignment", id: sharedDirectoryId, workspaceId }
+      { type: "feedbackDirectoryAssignment", feedbackDirectoryId: sharedDirectoryId, workspaceId }
     );
     expect(assertCan).toHaveBeenNthCalledWith(
       2,
       { type: "user", id: userId },
       "feedbackDirectoryAssignment.read",
-      { type: "feedbackDirectoryAssignment", id: otherOrgDirectoryId, workspaceId }
+      { type: "feedbackDirectoryAssignment", feedbackDirectoryId: otherOrgDirectoryId, workspaceId }
     );
   });
 
@@ -207,7 +207,7 @@ describe("assertFeedbackDirectoryAssignmentAccess", () => {
 
     expect(assertCan).toHaveBeenCalledWith({ type: "user", id: userId }, "feedbackDirectoryAssignment.read", {
       type: "feedbackDirectoryAssignment",
-      id: sharedDirectoryId,
+      feedbackDirectoryId: sharedDirectoryId,
       workspaceId,
     });
   });

--- a/apps/web/modules/ee/unify-feedback/lib/access.ts
+++ b/apps/web/modules/ee/unify-feedback/lib/access.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { OperationNotAllowedError, ResourceNotFoundError } from "@formbricks/types/errors";
+import { assertCan } from "@/lib/authorization";
 import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getOrganizationIdFromWorkspaceId } from "@/lib/utils/helper";
 import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
@@ -54,17 +55,38 @@ export const ensureReadAccess = async (userId: string, workspaceId: string): Pro
  */
 export const ensureDeleteAccess = async (userId: string, workspaceId: string): Promise<string> => {
   const organizationId = await ensureUnifyEnabled(workspaceId);
-  await checkAuthorizationUpdated({
-    userId,
-    organizationId,
-    access: [
-      {
-        type: "organization",
-        roles: ["owner", "manager"],
-      },
-    ],
+  await assertCan({ type: "user", id: userId }, "organization.manage", {
+    type: "organization",
+    id: organizationId,
   });
   return organizationId;
+};
+
+export const assertFeedbackDirectoryAssignmentAccess = async (
+  userId: string,
+  feedbackDirectoryId: string,
+  workspaceId: string
+): Promise<void> =>
+  assertCan({ type: "user", id: userId }, "feedbackDirectoryAssignment.read", {
+    type: "feedbackDirectoryAssignment",
+    id: feedbackDirectoryId,
+    workspaceId,
+  });
+
+/**
+ * Return the active datasets assigned to a workspace after issuing one exact assignment check per dataset.
+ * The PostgreSQL lookup remains authoritative; the checks give shadow mode coverage for server-rendered
+ * dataset, source, chart, and taxonomy entry points without introducing a second filtering model.
+ */
+export const getAuthorizedWorkspaceFeedbackDirectories = async (
+  userId: string,
+  workspaceId: string
+): Promise<{ id: string; name: string }[]> => {
+  const directories = await getFeedbackDirectoriesByWorkspaceId(workspaceId);
+  await Promise.all(
+    directories.map(({ id }) => assertFeedbackDirectoryAssignmentAccess(userId, id, workspaceId))
+  );
+  return directories;
 };
 
 /** Ids of the feedback directories (Hub tenants) assigned to a workspace. */

--- a/apps/web/modules/ee/unify-feedback/lib/access.ts
+++ b/apps/web/modules/ee/unify-feedback/lib/access.ts
@@ -69,7 +69,7 @@ export const assertFeedbackDirectoryAssignmentAccess = async (
 ): Promise<void> =>
   assertCan({ type: "user", id: userId }, "feedbackDirectoryAssignment.read", {
     type: "feedbackDirectoryAssignment",
-    id: feedbackDirectoryId,
+    feedbackDirectoryId,
     workspaceId,
   });
 

--- a/apps/web/modules/ee/unify-feedback/page.tsx
+++ b/apps/web/modules/ee/unify-feedback/page.tsx
@@ -3,10 +3,10 @@ import { logger } from "@formbricks/logger";
 import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getFeedbackSourcesWithMappings } from "@/lib/feedback-source/service";
 import { getTranslate } from "@/lingodotdev/server";
-import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
 import { getIsFeedbackDirectoriesEnabled } from "@/modules/ee/license-check/lib/utils";
 import { FeedbackDataEmptyState } from "@/modules/ee/unify-feedback/components/feedback-data-empty-state";
 import { UnifyConfigNavigation } from "@/modules/ee/unify-feedback/components/unify-config-navigation";
+import { getAuthorizedWorkspaceFeedbackDirectories } from "@/modules/ee/unify-feedback/lib/access";
 import { getContactIdsByUserIds } from "@/modules/ee/unify-feedback/lib/contacts";
 import { listFeedbackRecords } from "@/modules/hub/service";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
@@ -71,7 +71,7 @@ export default async function UnifyFeedbackRecordsPage(
   }
 
   const [frds, feedbackSources] = await Promise.all([
-    getFeedbackDirectoriesByWorkspaceId(params.workspaceId),
+    getAuthorizedWorkspaceFeedbackDirectories(session.user.id, params.workspaceId),
     getFeedbackSourcesWithMappings(params.workspaceId),
   ]);
 

--- a/apps/web/modules/ee/unify-feedback/sources/page.tsx
+++ b/apps/web/modules/ee/unify-feedback/sources/page.tsx
@@ -3,10 +3,10 @@ import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/
 import { getFeedbackSourcesWithMappings } from "@/lib/feedback-source/service";
 import { getSurveys } from "@/lib/survey/service";
 import { getTranslate } from "@/lingodotdev/server";
-import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
 import { getIsFeedbackDirectoriesEnabled } from "@/modules/ee/license-check/lib/utils";
 import { FeedbackDataEmptyState } from "@/modules/ee/unify-feedback/components/feedback-data-empty-state";
 import { UnifyConfigNavigation } from "@/modules/ee/unify-feedback/components/unify-config-navigation";
+import { getAuthorizedWorkspaceFeedbackDirectories } from "@/modules/ee/unify-feedback/lib/access";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
 import { UpgradePrompt } from "@/modules/ui/components/upgrade-prompt";
@@ -74,7 +74,7 @@ export const UnifyFeedbackSourcesPage = async (
   const [feedbackSources, surveys, directories] = await Promise.all([
     getFeedbackSourcesWithMappings(workspaceId),
     getSurveys(workspaceId),
-    getFeedbackDirectoriesByWorkspaceId(workspaceId),
+    getAuthorizedWorkspaceFeedbackDirectories(session.user.id, workspaceId),
   ]);
 
   if (directories.length === 0) {

--- a/apps/web/modules/ee/unify-feedback/topics-subtopics/page.tsx
+++ b/apps/web/modules/ee/unify-feedback/topics-subtopics/page.tsx
@@ -1,10 +1,11 @@
 import { notFound } from "next/navigation";
+import { can } from "@/lib/authorization";
 import { ENTERPRISE_LICENSE_REQUEST_FORM_URL, IS_FORMBRICKS_CLOUD } from "@/lib/constants";
 import { getTranslate } from "@/lingodotdev/server";
-import { getFeedbackDirectoriesByWorkspaceId } from "@/modules/ee/feedback-directory/lib/feedback-directory";
 import { getIsFeedbackDirectoriesEnabled } from "@/modules/ee/license-check/lib/utils";
 import { FeedbackDataEmptyState } from "@/modules/ee/unify-feedback/components/feedback-data-empty-state";
 import { UnifyConfigNavigation } from "@/modules/ee/unify-feedback/components/unify-config-navigation";
+import { getAuthorizedWorkspaceFeedbackDirectories } from "@/modules/ee/unify-feedback/lib/access";
 import { PageContentWrapper } from "@/modules/ui/components/page-content-wrapper";
 import { PageHeader } from "@/modules/ui/components/page-header";
 import { UpgradePrompt } from "@/modules/ui/components/upgrade-prompt";
@@ -61,7 +62,7 @@ export const UnifyTopicsSubtopicsPage = async (
     );
   }
 
-  const directories = await getFeedbackDirectoriesByWorkspaceId(params.workspaceId);
+  const directories = await getAuthorizedWorkspaceFeedbackDirectories(session.user.id, params.workspaceId);
 
   if (directories.length === 0) {
     return (
@@ -82,7 +83,10 @@ export const UnifyTopicsSubtopicsPage = async (
   // A directory's taxonomy is one tree shared by every workspace the directory is assigned to, and it
   // carries no workspace of its own — so changing it (generate, rename, remove) is an org-level act
   // and stays with owners and managers (ENG-1770). Everyone else gets the read-only view.
-  const canWrite = isOwner || isManager;
+  const canWrite = await can({ type: "user", id: session.user.id }, "organization.manage", {
+    type: "organization",
+    id: organization.id,
+  });
 
   return (
     <TopicsSubtopicsPage workspaceId={params.workspaceId} directoryMap={directoryMap} canWrite={canWrite} />

--- a/apps/web/modules/envoy-auth/service.test.ts
+++ b/apps/web/modules/envoy-auth/service.test.ts
@@ -10,7 +10,7 @@ const {
   mockVerifyFeedbackRecordsGatewayToken,
   mockGetFeedbackDirectoryAuthContext,
   mockGetFeedbackRecordTenant,
-  mockCheckAuthorizationUpdated,
+  mockCan,
   mockUserFindUnique,
   mockGetIsFeedbackDirectoriesEnabled,
 } = vi.hoisted(() => ({
@@ -21,7 +21,7 @@ const {
   mockVerifyFeedbackRecordsGatewayToken: vi.fn(),
   mockGetFeedbackDirectoryAuthContext: vi.fn(),
   mockGetFeedbackRecordTenant: vi.fn(),
-  mockCheckAuthorizationUpdated: vi.fn(),
+  mockCan: vi.fn(),
   mockUserFindUnique: vi.fn(),
   mockGetIsFeedbackDirectoriesEnabled: vi.fn(),
 }));
@@ -64,8 +64,8 @@ vi.mock("@/modules/hub/service", () => ({
   getFeedbackRecordTenant: mockGetFeedbackRecordTenant,
 }));
 
-vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
-  checkAuthorizationUpdated: mockCheckAuthorizationUpdated,
+vi.mock("@/lib/authorization", () => ({
+  can: mockCan,
 }));
 
 vi.mock("@formbricks/logger", () => ({
@@ -116,7 +116,7 @@ describe("authorizeEnvoyRequest", () => {
       data: { tenantId: feedbackDirectoryId },
       error: null,
     });
-    mockCheckAuthorizationUpdated.mockResolvedValue(true);
+    mockCan.mockResolvedValue(true);
     mockUserFindUnique.mockResolvedValue({ id: "user_1", isActive: true });
     mockGetIsFeedbackDirectoriesEnabled.mockResolvedValue(true);
   });
@@ -144,7 +144,10 @@ describe("authorizeEnvoyRequest", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("x-envoy-auth-headers-to-remove")).toBe("x-api-key,authorization,cookie");
-    expect(mockCheckAuthorizationUpdated).not.toHaveBeenCalled();
+    expect(mockCan).toHaveBeenCalledWith({ type: "apiKey", id: "key_1" }, "feedbackDirectory.write", {
+      type: "feedbackDirectory",
+      id: feedbackDirectoryId,
+    });
   });
 
   test("returns 400 when bulkDelete is missing tenant_id", async () => {
@@ -292,15 +295,9 @@ describe("authorizeEnvoyRequest", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mockCheckAuthorizationUpdated).toHaveBeenCalledWith({
-      userId: "user_1",
-      organizationId: "org_1",
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-      ],
+    expect(mockCan).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "organization.manage", {
+      type: "organization",
+      id: "org_1",
     });
   });
 
@@ -318,20 +315,9 @@ describe("authorizeEnvoyRequest", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mockCheckAuthorizationUpdated).toHaveBeenCalledWith({
-      userId: "user_2",
-      organizationId: "org_1",
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-        {
-          type: "workspaceTeam",
-          workspaceId: "workspace_1",
-          minPermission: "read",
-        },
-      ],
+    expect(mockCan).toHaveBeenCalledWith({ type: "user", id: "user_2" }, "feedbackDirectory.read", {
+      type: "feedbackDirectory",
+      id: feedbackDirectoryId,
     });
   });
 

--- a/apps/web/modules/hub/feedback-records-gateway.test.ts
+++ b/apps/web/modules/hub/feedback-records-gateway.test.ts
@@ -1,8 +1,9 @@
 import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { logger } from "@formbricks/logger";
 import type { TAuthenticationApiKey } from "@formbricks/types/auth";
-import { AuthorizationError } from "@formbricks/types/errors";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
+import { can } from "@/lib/authorization";
+import { withAuthorizationSurface } from "@/lib/authorization/context";
 import { getFeedbackDirectoryAuthContext } from "@/modules/ee/feedback-directory/lib/feedback-directory";
 import { getIsFeedbackDirectoriesEnabled } from "@/modules/ee/license-check/lib/utils";
 import type { TGatewayAuthenticatedPrincipal } from "@/modules/gateway-auth/lib/request";
@@ -29,8 +30,9 @@ vi.mock("@/app/lib/api/request-body", () => ({
   RequestBodyTooLargeError: class RequestBodyTooLargeError extends Error {},
 }));
 
-vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
-  checkAuthorizationUpdated: vi.fn(),
+vi.mock("@/lib/authorization", () => ({ can: vi.fn() }));
+vi.mock("@/lib/authorization/context", () => ({
+  withAuthorizationSurface: vi.fn((_surface, callback) => callback()),
 }));
 
 vi.mock("@/modules/ee/feedback-directory/lib/feedback-directory", () => ({
@@ -83,8 +85,6 @@ const authorize = async (
   });
 };
 
-const accessArg = () => vi.mocked(checkAuthorizationUpdated).mock.calls.at(-1)?.[0];
-
 describe("feedbackRecordsGatewayAuthorizer", () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -96,7 +96,7 @@ describe("feedbackRecordsGatewayAuthorizer", () => {
     });
     vi.mocked(getIsFeedbackDirectoriesEnabled).mockResolvedValue(true);
     vi.mocked(getFeedbackRecordTenant).mockResolvedValue({ data: { tenantId: directoryId }, error: null });
-    vi.mocked(checkAuthorizationUpdated).mockResolvedValue(true);
+    vi.mocked(can).mockResolvedValue(true);
   });
 
   // ENG-1770: records in a shared directory carry no workspace, so a workspace permission cannot
@@ -112,16 +112,15 @@ describe("feedbackRecordsGatewayAuthorizer", () => {
         const decision = await authorize(method, path, userPrincipal);
 
         expect(decision.status).toBe("allow");
-        expect(accessArg()).toEqual({
-          userId: "user-1",
-          organizationId,
-          access: [{ type: "organization", roles: ["owner", "manager"] }],
+        expect(can).toHaveBeenLastCalledWith({ type: "user", id: "user-1" }, "organization.manage", {
+          type: "organization",
+          id: organizationId,
         });
       }
     );
 
     test("denies a delete when the caller is not an organization owner or manager", async () => {
-      vi.mocked(checkAuthorizationUpdated).mockRejectedValue(new AuthorizationError("Not authorized"));
+      vi.mocked(can).mockResolvedValue(false);
 
       const decision = await authorize("DELETE", `/api/v3/feedbackRecords/${recordId}`, userPrincipal);
 
@@ -133,14 +132,9 @@ describe("feedbackRecordsGatewayAuthorizer", () => {
       const decision = await authorize("GET", `/api/v3/feedbackRecords/${recordId}`, userPrincipal);
 
       expect(decision.status).toBe("allow");
-      expect(accessArg()).toEqual({
-        userId: "user-1",
-        organizationId,
-        access: [
-          { type: "organization", roles: ["owner", "manager"] },
-          { type: "workspaceTeam", workspaceId: workspaceA, minPermission: "read" },
-          { type: "workspaceTeam", workspaceId: workspaceB, minPermission: "read" },
-        ],
+      expect(can).toHaveBeenLastCalledWith({ type: "user", id: "user-1" }, "feedbackDirectory.read", {
+        type: "feedbackDirectory",
+        id: directoryId,
       });
     });
 
@@ -150,11 +144,10 @@ describe("feedbackRecordsGatewayAuthorizer", () => {
       });
 
       expect(decision.status).toBe("allow");
-      expect(accessArg()?.access).toEqual([
-        { type: "organization", roles: ["owner", "manager"] },
-        { type: "workspaceTeam", workspaceId: workspaceA, minPermission: "readWrite" },
-        { type: "workspaceTeam", workspaceId: workspaceB, minPermission: "readWrite" },
-      ]);
+      expect(can).toHaveBeenLastCalledWith({ type: "user", id: "user-1" }, "feedbackDirectory.write", {
+        type: "feedbackDirectory",
+        id: directoryId,
+      });
     });
   });
 
@@ -261,7 +254,7 @@ describe("feedbackRecordsGatewayAuthorizer", () => {
     const decision = await authorize("GET", `/api/v3/feedbackRecords/${recordId}`, userPrincipal);
 
     expect(decision.status).toBe("deny");
-    expect(checkAuthorizationUpdated).not.toHaveBeenCalled();
+    expect(can).not.toHaveBeenCalled();
   });
 
   // The directory-not-found half of the combined guard (!feedbackDirectory ||
@@ -273,5 +266,28 @@ describe("feedbackRecordsGatewayAuthorizer", () => {
 
     expect(decision.status).toBe("deny");
     expect(decision.status === "deny" && decision.response.status).toBe(403);
+  });
+
+  test("assigns authenticated gateway checks to the feedback gateway rollout surface", async () => {
+    await authorize("GET", `/api/v3/feedbackRecords/${recordId}`, userPrincipal);
+
+    expect(withAuthorizationSurface).toHaveBeenCalledWith("feedback_gateway", expect.any(Function));
+  });
+
+  test("does not put directory or record identifiers in authorization logs", async () => {
+    await authorize("GET", `/api/v3/feedbackRecords/${recordId}`, userPrincipal);
+
+    expect(JSON.stringify(vi.mocked(logger.info).mock.calls)).not.toContain(directoryId);
+    expect(JSON.stringify(vi.mocked(logger.info).mock.calls)).not.toContain(recordId);
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(directoryId);
+    expect(JSON.stringify(vi.mocked(logger.warn).mock.calls)).not.toContain(recordId);
+  });
+
+  test("propagates central evaluator failures instead of converting them to denial", async () => {
+    vi.mocked(can).mockRejectedValue(new Error("evaluator unavailable"));
+
+    await expect(authorize("GET", `/api/v3/feedbackRecords/${recordId}`, userPrincipal)).rejects.toThrow(
+      "evaluator unavailable"
+    );
   });
 });

--- a/apps/web/modules/hub/feedback-records-gateway.ts
+++ b/apps/web/modules/hub/feedback-records-gateway.ts
@@ -3,14 +3,14 @@ import { NextRequest } from "next/server";
 import { z } from "zod";
 import { logger } from "@formbricks/logger";
 import { ZId } from "@formbricks/types/common";
-import { AuthorizationError } from "@formbricks/types/errors";
 import { RequestBodyTooLargeError, readRequestBodyWithLimit } from "@/app/lib/api/request-body";
+import { can } from "@/lib/authorization";
+import { getFeedbackDirectoryActionForPermission } from "@/lib/authorization/compatibility";
+import { withAuthorizationSurface } from "@/lib/authorization/context";
 import { verifyFeedbackRecordsGatewayToken } from "@/lib/jwt";
-import { checkAuthorizationUpdated } from "@/lib/utils/action-client/action-client-middleware";
 import { getBearerTokenFromHeaders } from "@/modules/api/lib/api-key-auth";
 import { getFeedbackDirectoryAuthContext } from "@/modules/ee/feedback-directory/lib/feedback-directory";
 import { getIsFeedbackDirectoriesEnabled } from "@/modules/ee/license-check/lib/utils";
-import type { TTeamPermission } from "@/modules/ee/teams/workspace-teams/types/team";
 import {
   TGatewayAuthenticatedPrincipal,
   TGatewayRequestAuthorizer,
@@ -62,20 +62,6 @@ const RECORD_MUTATING_OPERATIONS = new Set<TFeedbackRecordsGatewayOperation>([
   "delete",
   "bulkDelete",
 ]);
-
-/**
- * What a session principal's workspace team membership must grant for a given route permission.
- *
- * Only consulted for non-mutating operations — mutations drop the workspace-team fallback entirely
- * (ENG-1770) — so the `manage` entry is unreachable today, every `manage` route being a mutation. It is
- * spelled out anyway because a Record forces the next permission value added to the union to be mapped
- * deliberately, where a ternary would silently collapse it onto `readWrite`.
- */
-const GATEWAY_PERMISSION_TO_TEAM_PERMISSION: Record<TFeedbackRecordsGatewayPermission, TTeamPermission> = {
-  read: "read",
-  write: "readWrite",
-  manage: "manage",
-};
 
 const parseFeedbackRecordsGatewayRoute = (method: string, pathname: string): TParsedGatewayRoute | null => {
   const normalizedPath = normalizeFeedbackRecordsPath(pathname);
@@ -227,19 +213,13 @@ const resolveTenantId = async (
   const tenantLookup = await getFeedbackRecordTenant(route.recordId!);
   if (tenantLookup.error) {
     if (tenantLookup.error.status === 404) {
-      logger.warn(
-        { requestId, recordId: route.recordId },
-        "Feedback record tenant lookup returned not found"
-      );
+      logger.warn({ requestId }, "Feedback record tenant lookup returned not found");
       return {
         errorResponse: buildGatewayStatusResponse(403, "Forbidden"),
       };
     }
 
-    logger.warn(
-      { requestId, recordId: route.recordId, hubStatus: tenantLookup.error.status },
-      "Feedback record tenant lookup failed"
-    );
+    logger.warn({ requestId, hubStatus: tenantLookup.error.status }, "Feedback record tenant lookup failed");
     return {
       errorResponse: buildGatewayStatusResponse(503, "Feedback record lookup failed"),
     };
@@ -247,10 +227,7 @@ const resolveTenantId = async (
 
   const tenantId = parseTenantId(tenantLookup.data?.tenantId ?? null);
   if (!tenantId) {
-    logger.warn(
-      { requestId, recordId: route.recordId },
-      "Feedback record tenant lookup returned invalid tenant"
-    );
+    logger.warn({ requestId }, "Feedback record tenant lookup returned invalid tenant");
     return {
       errorResponse: buildGatewayStatusResponse(503, "Feedback record lookup failed"),
     };
@@ -279,47 +256,35 @@ const authorizeFeedbackRecordsGatewayRequest = async (
   }
 
   if (principal.type === "apiKey") {
-    return hasApiKeyImplicitFeedbackDirectoryAccess(
+    const legacySafeguardsAllow = hasApiKeyImplicitFeedbackDirectoryAccess(
       principal.authentication,
       feedbackDirectory.organizationId,
       feedbackDirectory.workspaceIds,
       requiredPermission,
       isRecordMutation
-    )
-      ? { allowed: true }
-      : { allowed: false };
+    );
+    if (!legacySafeguardsAllow) return { allowed: false };
+
+    const allowed = await can(
+      { type: "apiKey", id: principal.authentication.apiKeyId },
+      getFeedbackDirectoryActionForPermission(requiredPermission),
+      { type: "feedbackDirectory", id: feedbackDirectoryId }
+    );
+    return { allowed };
   }
 
-  try {
-    const minPermission = GATEWAY_PERMISSION_TO_TEAM_PERMISSION[requiredPermission];
+  const allowed = isRecordMutation
+    ? await can({ type: "user", id: principal.userId }, "organization.manage", {
+        type: "organization",
+        id: feedbackDirectory.organizationId,
+      })
+    : await can(
+        { type: "user", id: principal.userId },
+        getFeedbackDirectoryActionForPermission(requiredPermission),
+        { type: "feedbackDirectory", id: feedbackDirectoryId }
+      );
 
-    await checkAuthorizationUpdated({
-      userId: principal.userId,
-      organizationId: feedbackDirectory.organizationId,
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-        // Mutating an existing record is owners/managers only, so no workspace-team fallback.
-        ...(isRecordMutation
-          ? []
-          : feedbackDirectory.workspaceIds.map((workspaceId) => ({
-              type: "workspaceTeam" as const,
-              workspaceId,
-              minPermission,
-            }))),
-      ],
-    });
-
-    return { allowed: true };
-  } catch (error) {
-    if (error instanceof AuthorizationError) {
-      return { allowed: false };
-    }
-
-    throw error;
-  }
+  return { allowed };
 };
 
 export const feedbackRecordsGatewayAuthorizer: TGatewayRequestAuthorizer = {
@@ -328,57 +293,56 @@ export const feedbackRecordsGatewayAuthorizer: TGatewayRequestAuthorizer = {
     getTokenFromHeaders: getFeedbackRecordsGatewayJwtFromHeaders,
     verifyToken: verifyFeedbackRecordsGatewayToken,
   },
-  authorize: async ({ request, originalRequest, principal, requestId }) => {
-    const route = parseFeedbackRecordsGatewayRoute(originalRequest.method, originalRequest.url.pathname);
-    if (!route) {
-      return {
-        status: "deny",
-        response: buildGatewayStatusResponse(400, "Unsupported FeedbackRecords route"),
-      };
-    }
+  authorize: async ({ request, originalRequest, principal, requestId }) =>
+    withAuthorizationSurface("feedback_gateway", async () => {
+      const route = parseFeedbackRecordsGatewayRoute(originalRequest.method, originalRequest.url.pathname);
+      if (!route) {
+        return {
+          status: "deny",
+          response: buildGatewayStatusResponse(400, "Unsupported FeedbackRecords route"),
+        };
+      }
 
-    const tenantResolution = await resolveTenantId(request, route, originalRequest.url, requestId);
-    if ("errorResponse" in tenantResolution) {
-      return {
-        status: "deny",
-        response: tenantResolution.errorResponse,
-      };
-    }
+      const tenantResolution = await resolveTenantId(request, route, originalRequest.url, requestId);
+      if ("errorResponse" in tenantResolution) {
+        return {
+          status: "deny",
+          response: tenantResolution.errorResponse,
+        };
+      }
 
-    const authorizationResult = await authorizeFeedbackRecordsGatewayRequest(
-      principal,
-      tenantResolution.tenantId,
-      route.requiredPermission,
-      route.operation
-    );
-    if (!authorizationResult.allowed) {
+      const authorizationResult = await authorizeFeedbackRecordsGatewayRequest(
+        principal,
+        tenantResolution.tenantId,
+        route.requiredPermission,
+        route.operation
+      );
+      if (!authorizationResult.allowed) {
+        logger.info(
+          {
+            requestId,
+            principalType: principal.type,
+            operation: route.operation,
+            verdict: "deny",
+          },
+          "Feedback records gateway authorization denied"
+        );
+        return {
+          status: "deny",
+          response: buildGatewayStatusResponse(403, "Forbidden"),
+        };
+      }
+
       logger.info(
         {
           requestId,
-          principalType: principal.type,
           operation: route.operation,
-          feedbackDirectoryId: tenantResolution.tenantId,
-          verdict: "deny",
+          principalType: principal.type,
+          verdict: "allow",
         },
-        "Feedback records gateway authorization denied"
+        "Feedback records gateway authorization allowed"
       );
-      return {
-        status: "deny",
-        response: buildGatewayStatusResponse(403, "Forbidden"),
-      };
-    }
 
-    logger.info(
-      {
-        requestId,
-        operation: route.operation,
-        principalType: principal.type,
-        feedbackDirectoryId: tenantResolution.tenantId,
-        verdict: "allow",
-      },
-      "Feedback records gateway authorization allowed"
-    );
-
-    return allowGatewayRequest();
-  },
+      return allowGatewayRequest();
+    }),
 };

--- a/apps/web/modules/traefik-auth/service.test.ts
+++ b/apps/web/modules/traefik-auth/service.test.ts
@@ -10,7 +10,7 @@ const {
   mockVerifyFeedbackRecordsGatewayToken,
   mockGetFeedbackDirectoryAuthContext,
   mockGetFeedbackRecordTenant,
-  mockCheckAuthorizationUpdated,
+  mockCan,
   mockUserFindUnique,
   mockGetIsFeedbackDirectoriesEnabled,
 } = vi.hoisted(() => ({
@@ -21,7 +21,7 @@ const {
   mockVerifyFeedbackRecordsGatewayToken: vi.fn(),
   mockGetFeedbackDirectoryAuthContext: vi.fn(),
   mockGetFeedbackRecordTenant: vi.fn(),
-  mockCheckAuthorizationUpdated: vi.fn(),
+  mockCan: vi.fn(),
   mockUserFindUnique: vi.fn(),
   mockGetIsFeedbackDirectoriesEnabled: vi.fn(),
 }));
@@ -64,8 +64,8 @@ vi.mock("@/modules/hub/service", () => ({
   getFeedbackRecordTenant: mockGetFeedbackRecordTenant,
 }));
 
-vi.mock("@/lib/utils/action-client/action-client-middleware", () => ({
-  checkAuthorizationUpdated: mockCheckAuthorizationUpdated,
+vi.mock("@/lib/authorization", () => ({
+  can: mockCan,
 }));
 
 vi.mock("@formbricks/logger", () => ({
@@ -125,7 +125,7 @@ describe("authorizeTraefikRequest", () => {
       data: { tenantId: feedbackDirectoryId },
       error: null,
     });
-    mockCheckAuthorizationUpdated.mockResolvedValue(true);
+    mockCan.mockResolvedValue(true);
     mockUserFindUnique.mockResolvedValue({ id: "user_1", isActive: true });
     mockGetIsFeedbackDirectoriesEnabled.mockResolvedValue(true);
   });
@@ -204,15 +204,9 @@ describe("authorizeTraefikRequest", () => {
 
     expect(response.status).toBe(200);
     expect(mockGetFeedbackRecordTenant).toHaveBeenCalledWith(feedbackRecordId);
-    expect(mockCheckAuthorizationUpdated).toHaveBeenCalledWith({
-      userId: "user_1",
-      organizationId: "org_1",
-      access: [
-        {
-          type: "organization",
-          roles: ["owner", "manager"],
-        },
-      ],
+    expect(mockCan).toHaveBeenCalledWith({ type: "user", id: "user_1" }, "organization.manage", {
+      type: "organization",
+      id: "org_1",
     });
   });
 

--- a/authzed/README.md
+++ b/authzed/README.md
@@ -278,6 +278,26 @@ standalone Phase 1 SpiceDB resources. Charts and workflows inherit workspace aut
 `createdBy` is metadata rather than authorization ownership, and record-level tenant/integrity checks
 remain in the application and Hub layers.
 
+### Feedback Dataset authorization routing
+
+Current feedback access is routed through the central Formbricks authorization interface without changing
+its effective rules:
+
+- dataset administration checks `organization.manage`;
+- workspace-scoped records, taxonomy, sources, CSV imports, chart queries, and server-rendered Unify
+  entry points check the exact `feedbackDirectoryAssignment` resource;
+- directory-wide gateway reads and creates check `feedbackDirectory.read` or
+  `feedbackDirectory.write` across all active assignments;
+- existing-record mutations still require organization management for users and an exclusively assigned
+  dataset plus the existing workspace permission for API keys;
+- archive, entitlement, OAuth-scope, Hub tenant, source ownership, and record-integrity checks remain in
+  the application layer and execute in their existing order.
+
+Authenticated feedback-gateway requests use the bounded rollout targets `feedback_gateway:user` and
+`feedback_gateway:apiKey`. Public and unauthenticated gateway traffic is never scoped for shadow or
+enforcement. The ENG-2398 rollout is shadow-only; moving either target into an enforcement allowlist
+requires a separate rollout decision.
+
 ## Resource parent resolution during the current-model migration
 
 The initial migration deliberately does not project one relationship for every


### PR DESCRIPTION
## What & why

Feedback Dataset authorization still bypassed the central `can(actor, action, resource)` interface on several product surfaces, which meant the new SpiceDB model could not be compared safely in shadow mode. This PR routes the current Feedback Directory rules through exact directory or directory/workspace-assignment resources while preserving PostgreSQL and the legacy evaluator as the authority.

The routing covers Feedback Dataset administration, server-rendered Unify pages, feedback records, sources and CSV imports, taxonomy, chart queries and creation, V3 operations, MCP-backed paths, and the Feedback Records gateway. It also introduces the bounded `feedback_gateway:user` and `feedback_gateway:apiKey` shadow targets. Existing entitlement, archive, OAuth-scope, Hub tenant, ownership/integrity, HTTP-status, and API-key single-workspace safeguards remain in place.

The ENG-2398 foundation from #8867 is now merged into `epic/authzed`; this routing PR targets that branch directly. The earlier #8863, #8864, #8805, and #8846 prerequisites are also present in the epic branch.

## Linear ticket

Fixes ENG-2398

## How this was tested

- `CUBEJS_API_URL=http://localhost:4000 HUB_API_URL=http://localhost:3003 HUB_API_KEY=test pnpm --filter @formbricks/web exec vitest run 'app/api/(internal)/unify-feedback/sources/csv/import/route.test.ts' lib/authorization lib/authzed app/api/v3/unify-feedback app/api/v3/feedbackRecords modules/hub modules/ee/feedback-directory modules/ee/analysis lib/feedback-source modules/mcp` — 102 files and 1,795 tests passed.
- Focused routing regression suite — 10 files and 222 tests passed.
- `pnpm --filter @formbricks/web typecheck` passed.
- Changed-file lint completed with 0 errors; 46 pre-existing warnings remain outside this change.
- `pnpm authzed:validate` passed with 31 relationships, 144 assertions, and 2 expected relations.
- `pnpm authzed:smoke` passed the isolated schema, relationship, persistence, health, outage, and secret-safety lifecycle.
- `pnpm build --filter=@formbricks/web... --force` passed with AuthZed disabled and credentials absent.
- The same build passed with AuthZed enabled and `127.0.0.1:1` as an unreachable endpoint, confirming no build-time RPC.
- A temporary Client Component importing the new direct runtime failed `next build` at the expected `server-only` boundary; the fixture was removed and the clean build rerun.
- No focused Feedback Dataset/Chart/MCP Playwright specs currently exist. The complete live UI/API matrix is intentionally listed below for the post-merge sandbox rollout.
- No visual UI behavior changed, so there is no before/after screenshot.

## Breaking changes

None — authorization outcomes, external APIs, environment variables, and database schema are unchanged.

## QA / Test Plan

**How to test**

- [ ] In an Enterprise-enabled sandbox with AuthZed enforcement lists empty, open an active Feedback Dataset as an organization owner and manager → dataset settings, records, sources, taxonomy, charts, and queries remain accessible.
- [ ] Repeat as a billing user and an unassigned member → existing denied surfaces remain denied and return their existing UI/API errors.
- [ ] Assign a team to workspace A with `read`, `readWrite`, then `manage` and exercise records, sources, taxonomy, chart queries, and chart creation → read/write/manage operations follow the existing permission ladder.
- [ ] Attempt the same dataset through unassigned workspace B → exact assignment checks deny access; access granted through workspace A cannot authorize workspace B.
- [ ] Archive the dataset → UI, V3, MCP, CSV import, and gateway access remain denied according to the existing archive behavior.
- [ ] Exercise V3 feedback-record list/read/create/update/delete with a user and API key → status codes and sanitized error bodies remain unchanged; API-key update/delete still requires exactly one assigned workspace.
- [ ] Exercise Feedback Records gateway read/create/update/delete as a session user and API key → existing allow/deny behavior remains unchanged and shadow comparisons are emitted for `feedback_gateway:user` and `feedback_gateway:apiKey`.
- [ ] Exercise MCP feedback-record tools with valid/invalid OAuth scopes → OAuth scope checks remain authoritative and the corresponding central checks are shadowed under the existing MCP surfaces.
- [ ] Create, update, delete, and CSV-import a feedback source → the operation succeeds only for the exact assigned directory/workspace and existing entitlement/source-integrity checks still apply.
- [ ] Query charts and create a chart → queries require assignment read; creation requires assignment write; chart `createdBy` does not grant authorization.
- [ ] Stop SpiceDB while shadow mode is active → legacy-authorized requests keep their existing result and only a sanitized operational comparison error is recorded.
- [ ] Inspect comparison metrics after the complete matrix → every expected check is represented, with zero decision mismatches and zero unexplained operational errors; ordinary logs contain no successful-match identifiers.

**Preconditions / test data**

- Enterprise Feedback Directories enabled in `authzed-sandbox`.
- One disposable organization with owner, manager, member, billing, team-admin/contributor users, and read/write/manage API keys.
- Two workspaces, multiple teams, an active and archived dataset, feedback records and sources, taxonomy data, and chart data.
- ENG-2398 foundation schema applied and relationship repair clean.
- `AUTHZED_AUTHORIZATION_ENABLED=true`; new gateway plus relevant server-action, V3, and MCP targets configured for shadow only; all enforcement target and organization lists empty.

**Risks & regressions**

- Exact workspace assignment resolution could reveal an existing caller that omits or supplies the wrong workspace; re-check every UI, V3, MCP, gateway, source, taxonomy, and chart path above.
- Gateway mutations must retain the stricter organization-manager/session and API-key single-workspace safeguards.
- Shadow comparison failures must never alter the legacy-authoritative response.
- Re-run ENG-2364 and ENG-2365 API/UI matrices after deploying the merged stack.

**Migrations / env / cutover**

- No database migration or new environment variable.
- This PR adds accepted values to the existing shadow/enforcement target CSV contract, but ENG-2398 must remain shadow-only.
- Apply the guarded schema and run a clean full relationship repair before enabling the new sandbox shadow targets.


### Stack refresh after #8863 repair

The latest parent chain restores the production AuthZed Compose bootstrap/migration/server contract that was accidentally lost during the main-to-epic synchronization. The refreshed combined head passes repository formatting, Docker Compose contracts, Docker tests, Helm lint/render contracts, AuthZed schema validation (31 relationships / 144 assertions / 2 expected relations), 798 focused authorization/AuthZed tests, and web typecheck. GitHub CI is green on this exact head, including lint, typecheck, unit, E2E, AuthZed schema, Helm, and Sonar checks.

### Gateway adapter test repair

The refreshed full unit job exposed stale Envoy and Traefik adapter fixtures that still mocked `checkAuthorizationUpdated()` after this PR routed gateway decisions through central `can()`. Commit `c38d8fdc7` updates those tests to mock the actual central boundary and assert the semantic `feedbackDirectory.*` / `organization.manage` calls. The focused gateway suite passes 4 files / 62 tests; GitHub CI is green on the exact head, including the full unit and E2E suites.

### Foundation Sonar remediation propagation

Merged the #8867 SonarCloud remediation into this child branch so the routing PR now tests the exact corrected foundation head. The combined routing validation passed 102 files / 1,804 tests, web typecheck, and AuthZed schema validation with 31 relationships, 144 assertions, and 2 expected relations. The expected projection-failure log was emitted only by the regression test that verifies a post-commit projection failure does not alter the successful source mutation.

### Parent stack refresh after ENG-2340

Merged the refreshed #8867 foundation parent, including the latest `epic/authzed` ENG-2340 schema changes and resolved Turbo task-input contract. The combined routing head passes 103 focused files / 1,806 tests, web typecheck, and AuthZed validation with 36 relationships, 149 assertions, and 2 expected relations. The projection-failure log remains the expected output of the best-effort post-commit regression test.


### Refresh after #8863 merged

- Merged refreshed foundation parent #8867 (`3dbb1d19c`); no routing conflicts occurred.
- Validation on `b0497e74c`: 103 focused files / 1,806 tests passed, web typecheck passed, and AuthZed validation passed with 36 relationships / 149 assertions / 2 expected relations. Expected projection-failure and feedback-source warnings came from explicit regression fixtures.



### Parent reviewer-fix propagation

- Merged refreshed foundation head `482dfb06a`, carrying the #8864 Sonar fixes through the routing stack without changing routing behavior.
- Validation on `6a54597ae`: 103 focused files / 1,806 tests passed, web typecheck passed, and AuthZed validation passed with 36 relationships / 149 assertions / 2 expected relations. The feedback-source warning is expected regression-fixture output.



### Foundation refresh after #8864 merged

- Merged refreshed foundation head `2f4a38954`, carrying the resolved parent history and ENG-2340-compatible membership fixtures through the routing stack.
- Validation on `4fb2313d5`: 103 focused files / 1,806 tests passed, web typecheck passed, and AuthZed validation passed with 36 relationships / 149 assertions / 2 expected relations. The projection-failure log is expected output from the best-effort post-commit regression fixture.

### Foundation review-fix propagation

- Merged foundation commit `f9d95f018` and updated all routing callers/tests to the explicit `feedbackDirectoryId` assignment input contract.
- Preserved the generated assignment object ID as an internal SpiceDB-only scope value.
- Validation on `b3a762c3d`: 103 focused files / 1,808 tests passed, web typecheck and focused ESLint passed, and AuthZed validation passed with 36 relationships / 149 assertions / 2 expected relations.

### CodeRabbit review fixes

- Replaced malformed V3 authentication fixture `any` casts with explicit `unknown` to `TV3Authentication` casts.
- Added scoped per-user rate limits to every mutation action touched by this PR: feedback-source create/update/delete, historical response import, chart creation, feedback-directory create/update, and feedback-record deletion. Historical imports use a separate 10-per-hour limit; ordinary feedback mutations retain higher workflow-friendly limits.
- Added audit coverage for feedback-source create/update/delete/import with a dedicated `feedbackSource` target and identifier-safe summary data for historical imports.
- Added focused mutation-safeguard tests and classified the new audit target in the authorization resource inventory.
- Validation on `1bbf67be3`: 126 focused files / 2,067 tests passed; web typecheck and changed-file ESLint passed; AuthZed validation passed with 36 relationships / 149 assertions / 2 expected relations; the full forced web build passed with AuthZed disabled. The projection-failure and mapping warning logs are expected regression-fixture output.