### PR TITLE
fix(authzed): exclude the billing role from team-derived workspace access [ENG-2340]

### DIFF
--- a/apps/web/lib/turbo-build-schema-input.test.ts
+++ b/apps/web/lib/turbo-build-schema-input.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+// Guards the coupling between `vite.authzed-cli.config.mts` and `turbo.json` (ENG-2340), the same
+// shape as the next.config.mjs guard in `turbo-build-env.test.ts`.
+//
+// The web build reads the canonical authorization schema from the repo root at build time and emits
+// it into the packaged operator CLI, so `formbricks-authzed schema check` / `apply` ship whatever
+// that build captured. But `authzed/schema.zed` lives outside `apps/web`, and the `build` task
+// declares no `inputs`, so Turbo hashes only files inside the package: without an explicit
+// declaration the file that defines the shipped authorization semantics is hashed by nothing, and a
+// warm cache is free to restore a CLI carrying the previous schema.
+//
+// This bit, concretely: a schema-only change (exactly what ENG-2340 is) touches no file under
+// `apps/web`, so it is the case most likely to hit a cache that has no reason to miss.
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..", "..", "..");
+const turboJsonPath = path.join(repoRoot, "turbo.json");
+const cliConfigPath = path.join(repoRoot, "apps", "web", "vite.authzed-cli.config.mts");
+
+const CANONICAL_SCHEMA = "authzed/schema.zed";
+
+describe("turbo hashes the canonical AuthZed schema into the web build", () => {
+  const turboJson = JSON.parse(fs.readFileSync(turboJsonPath, "utf-8")) as {
+    globalDependencies?: string[];
+    tasks: Record<string, { inputs?: string[] }>;
+  };
+
+  test("the CLI build still bundles the schema, so this guard still has a subject", () => {
+    const cliConfig = fs.readFileSync(cliConfigPath, "utf-8");
+    // If this ever stops being true the coupling is gone and the assertion below can be dropped —
+    // but it should be dropped deliberately, not left asserting something that no longer exists.
+    expect(cliConfig).toContain("schema.zed");
+  });
+
+  test("a schema-only change invalidates the cached web build", () => {
+    // Either mechanism is fine; what matters is that the file is hashed somewhere that reaches
+    // `@formbricks/web#build`. `globalDependencies` is the simpler of the two because package-scoped
+    // task configs replace rather than merge, so an `inputs` override would have to restate the
+    // whole build task.
+    const globalDependencies = turboJson.globalDependencies ?? [];
+    const buildInputs = turboJson.tasks["@formbricks/web#build"]?.inputs ?? [];
+
+    const hashed =
+      globalDependencies.includes(CANONICAL_SCHEMA) ||
+      buildInputs.some((input) => input.endsWith(CANONICAL_SCHEMA));
+
+    expect(
+      hashed,
+      `${CANONICAL_SCHEMA} is not hashed into @formbricks/web#build. Add it to turbo.json's ` +
+        "`globalDependencies` (or to that task's `inputs`), or a cached build can ship a stale " +
+        "authorization schema inside the packaged formbricks-authzed CLI (ENG-2340)."
+    ).toBe(true);
+  });
+});

--- a/apps/web/lib/turbo-build-schema-input.test.ts
+++ b/apps/web/lib/turbo-build-schema-input.test.ts
@@ -33,7 +33,7 @@ describe("turbo hashes the canonical AuthZed schema into the web build", () => {
     const cliConfig = fs.readFileSync(cliConfigPath, "utf-8");
     // If this ever stops being true the coupling is gone and the assertion below can be dropped —
     // but it should be dropped deliberately, not left asserting something that no longer exists.
-    expect(cliConfig).toContain("schema.zed");
+    expect(cliConfig).toContain(CANONICAL_SCHEMA);
   });
 
   test("a schema-only change invalidates the cached web build", () => {

--- a/authzed/schema-validation.yaml
+++ b/authzed/schema-validation.yaml
@@ -12,12 +12,25 @@
 #   organization:acme
 #     owner   user:olivia         manager user:mark
 #     member  user:mia            (no team — must see no product data)
-#     billing user:bella          (billing surfaces only)
+#     billing user:bella          (billing surfaces only — AND on team:product, see below)
+#     member  user:tom, user:tina, user:uma   (the team users; every TeamUser row in the
+#                                              product has a matching Membership, so the
+#                                              fixture models that rather than team rows
+#                                              floating free of the organization)
 #     api_key_reader api_key:org_reader_key   (accessControl.read)
 #     api_key_writer api_key:org_writer_key   (accessControl.write)
 #   workspace:main, workspace:other            (both owned by acme)
-#   team:product   admin user:tom, contributor user:tina  -> readWrite on workspace:main
-#   team:analysts  contributor user:uma                   -> read      on workspace:main
+#   team:product   admin user:tom, contributor user:tina, contributor user:bella
+#                                                          -> readWrite on workspace:main
+#     bella is on this team deliberately. Without that row the scenario-2 billing assertions
+#     only prove the teamless case, and the schema could grant a billing member every workspace
+#     their teams reach while this suite stayed green — which is exactly what it used to do.
+#   team:analysts  contributor user:uma, contributor user:ghost
+#                                                          -> read      on workspace:main
+#     ghost holds a team row but NO membership in acme — the state legacy denies at
+#     `if (!orgMembership) return false;` before it reaches the team ladder. No application path
+#     creates it today (every TeamUser write is org-validated), so this is defence in depth: the
+#     schema states the invariant instead of inheriting it from the writers.
 #   api_key:ci_reader                                     -> read      on workspace:main
 #   api_key:ci_writer                                     -> write     on workspace:main
 #   api_key:ci_manager                                    -> manage    on workspace:main
@@ -32,6 +45,9 @@ relationships: |-
   organization:acme#manager@user:mark
   organization:acme#member@user:mia
   organization:acme#billing@user:bella
+  organization:acme#member@user:tom
+  organization:acme#member@user:tina
+  organization:acme#member@user:uma
   organization:acme#api_key_reader@api_key:org_reader_key
   organization:acme#api_key_writer@api_key:org_writer_key
   api_key:org_reader_key#organization@organization:acme
@@ -44,8 +60,10 @@ relationships: |-
   team:product#organization@organization:acme
   team:product#admin@user:tom
   team:product#contributor@user:tina
+  team:product#contributor@user:bella
   team:analysts#organization@organization:acme
   team:analysts#contributor@user:uma
+  team:analysts#contributor@user:ghost
   workspace:main#writer_team@team:product#member
   workspace:main#reader_team@team:analysts#member
   workspace:main#reader@api_key:ci_reader
@@ -186,6 +204,12 @@ assertions:
 
     # Scenario 2 — billing is excluded from every product surface and from
     # member/API-key management.
+    #
+    # bella holds a `team:product` contributor row, so these prove the exclusion survives team
+    # membership rather than only holding for a billing user who happens to be on no team. The
+    # first assertion pins the mechanism (`team#member` intersects the organization's non-billing
+    # membership); the rest are the product surfaces that would open if it regressed.
+    - team:product#member@user:bella
     - organization:acme#manage@user:bella
     - organization:acme#write@user:bella
     - organization:acme#manage_access@user:bella
@@ -199,6 +223,13 @@ assertions:
     - response:r1#export@user:bella
     - dashboard:insights#read@user:bella
     - dashboard:insights#write@user:bella
+
+    # A team row without a membership in the team's organization grants nothing, mirroring
+    # legacy's `if (!orgMembership) return false;` ahead of the team ladder.
+    - team:analysts#member@user:ghost
+    - workspace:main#read@user:ghost
+    - survey:onboarding#read@user:ghost
+    - response:r1#export@user:ghost
 
     # Scenario 3 — readWrite teams stop below manage; team scope does not
     # leak into other workspaces; contributors do not manage the team.
@@ -263,9 +294,9 @@ validation:
     - "[team:product#member] is <workspace:main#writer_team>"
     - "[user:mark] is <organization:acme#manager>"
     - "[user:olivia] is <organization:acme#owner>"
-    - "[user:tina] is <team:product#contributor>"
-    - "[user:tom] is <team:product#admin>"
-    - "[user:uma] is <team:analysts#contributor>"
+    - "[user:tina] is <organization:acme#member>/<team:product#contributor>"
+    - "[user:tom] is <organization:acme#member>/<team:product#admin>"
+    - "[user:uma] is <organization:acme#member>/<team:analysts#contributor>"
   response:r1#export:
     - "[api_key:ci_reader] is <workspace:main#reader>"
     - "[api_key:ci_writer] is <workspace:main#writer>"
@@ -274,6 +305,6 @@ validation:
     - "[team:product#member] is <workspace:main#writer_team>"
     - "[user:mark] is <organization:acme#manager>"
     - "[user:olivia] is <organization:acme#owner>"
-    - "[user:tina] is <team:product#contributor>"
-    - "[user:tom] is <team:product#admin>"
-    - "[user:uma] is <team:analysts#contributor>"
+    - "[user:tina] is <organization:acme#member>/<team:product#contributor>"
+    - "[user:tom] is <organization:acme#member>/<team:product#admin>"
+    - "[user:uma] is <organization:acme#member>/<team:analysts#contributor>"

--- a/authzed/schema.zed
+++ b/authzed/schema.zed
@@ -101,6 +101,16 @@ definition organization {
 
     /** Who can create, update, or delete API keys: owners and managers (api-keys settings actions). */
     permission manage_api_keys: user = owner + manager
+
+    /**
+     * Members eligible for product data: every membership role EXCEPT `billing`.
+     *
+     * This exists to be intersected into `team#member`, so that team-derived workspace access
+     * carries the same two preconditions the application enforces before it consults the team
+     * ladder at all (`hasUserWorkspaceAccessForActionLegacy`): the principal must hold a membership
+     * in this organization, and that membership must not be `billing`.
+     */
+    permission product_member: user = owner + manager + member
 }
 
 /**
@@ -117,8 +127,21 @@ definition team {
     /** Team contributor (`TeamUser.role = contributor`). */
     relation contributor: user
 
-    /** All members of the team; carries workspace access granted to the team. */
-    permission member: user = admin + contributor
+    /**
+     * All members of the team; carries workspace access granted to the team.
+     *
+     * Intersected with the organization's non-billing membership because a `TeamUser` row is not
+     * sufficient on its own in the application. `hasUserWorkspaceAccessForActionLegacy` opens with
+     * two gates before it ever looks at `WorkspaceTeam`:
+     *
+     *     if (!orgMembership) return false;
+     *     if (orgMembership.role === "billing") return false;
+     *
+     * Without the intersection this schema would grant a billing-role member every workspace their
+     * teams can reach — surveys, responses, contact PII — which the application denies, breaking
+     * this file's own rule that moving a check here must not change who can access what.
+     */
+    permission member: user = (admin + contributor) & organization->product_member
 
     /**
      * Who can view the team: its members, organization owners/managers, and API

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,7 @@
   "$schema": "https://turborepo.org/schema.json",
   "cacheMaxSize": "10GB",
   "globalEnv": ["MIGRATE_DATABASE_URL", "SHADOW_DATABASE_URL"],
+  "globalDependencies": ["authzed/schema.zed"],
   "tasks": {
     "@formbricks/ai#build": {
       "dependsOn": ["@formbricks/logger#build"],

--- a/turbo.json
+++ b/turbo.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://turborepo.org/schema.json",
   "cacheMaxSize": "10GB",
-  "globalEnv": ["MIGRATE_DATABASE_URL", "SHADOW_DATABASE_URL"],
   "globalDependencies": ["authzed/schema.zed"],
+  "globalEnv": ["MIGRATE_DATABASE_URL", "SHADOW_DATABASE_URL"],
   "tasks": {
     "@formbricks/ai#build": {
       "dependsOn": ["@formbricks/logger#build"],


### PR DESCRIPTION
## What & why

Found while verifying an adversarial security review of `epic/authzed`. The SpiceDB schema has no equivalent of the legacy evaluator's billing exclusion, so under enforcement a `billing`-role member who is on a team reaches every workspace that team can reach.

**Legacy denies.** `hasUserWorkspaceAccessForActionLegacy` opens with two gates, both *above* the `WorkspaceTeam` lookup:

```ts
if (!orgMembership) return false;
if (orgMembership.role === "billing") return false;
```

**The schema allowed.** `team#member` was `admin + contributor` with no organization condition, feeding `workspace.reader_team` / `writer_team` / `manager_team` unconditionally. `grep -rn "billing" apps/web/lib/authzed/ apps/web/lib/authorization/` returns exactly one hit outside the legacy evaluator: `relationship-map.ts:27`, which *writes* the `billing` tuple. Nothing read it for product access.

This breaks the rule stated at the top of `schema.zed` — *"a principal must never gain or lose access by moving a check from the application code to this schema"* — and contradicts three guarantees in `authzed/README.md`, including *"Billing role blocked from product data."*

**Not exploitable today:** enforcement is off by default and the epic is unmerged. It matters because it is a *known-in-advance* guaranteed shadow mismatch — RUNBOOK §6.3 requires zero mismatches over a seven-day window, so discovering this during shadow burns an observation cycle for the first cohort containing a billing-role team member. Billing-role product access is also a bug class we have closed four times already (ENG-1763, ENG-2077, ENG-1028, ENG-982).

## The fix

```zed
// definition organization
permission product_member: user = owner + manager + member   // every role EXCEPT billing

// definition team
permission member: user = (admin + contributor) & organization->product_member
```

The intersection reproduces *both* legacy preconditions at once — hold a membership in this organization, and don't be billing — so it also closes the cross-org arm (a `TeamUser` row whose user has no membership in the team's organization). That arm has no live trigger path today, since every `teamUser` write is org-validated and `membership.delete` has a single call site that removes both rows in one serializable transaction; it is defence in depth, and the schema now states the invariant instead of inheriting it from the writers.

It depends on `organization#member` tuples existing for team users, which they do — `relationship-map.ts:25-30` projects all four `Membership.role` values.

## Why the validation suite didn't catch it

Two fixture defects, both fixed here:

1. **The billing user was on no team.** So the thirteen billing `assertFalse` lines only ever proved the teamless case. The suite was green while the guarantee was false.
2. **The team users had no organization membership at all** — a state the database cannot produce, since every `TeamUser` write path is org-validated. The fixture was not representative of projected data, and the fix does not validate against it.

The fixture now models reality: `tom`/`tina`/`uma` are members; `bella` is a billing member who is **also** a `team:product` contributor; and a new `ghost` principal holds a team row with no membership, pinning the second precondition directly.

## Turbo: stop shipping a stale schema

Also declares `authzed/schema.zed` in `globalDependencies`. The web build reads the canonical schema at build time and emits it into the packaged operator CLI (`vite.authzed-cli.config.mts` → `dist/authzed-cli/schema.zed`), but the file lives outside `apps/web` and the `build` task declares no `inputs` — so it was hashed by nothing, and a warm cache could restore a `formbricks-authzed` binary carrying the previous schema. A schema-only change is exactly this PR's shape, which makes it the case most likely to hit a cache with no reason to miss.

Declared globally rather than as an `@formbricks/web#build` override because package-scoped task configs *replace* rather than merge, so an `inputs` override would mean restating that task's whole env/passThroughEnv/outputs block (the ENG-1682 trap).

## Linear ticket

Fixes ENG-2340

## How this was tested

- `pnpm authzed:validate` — **136 assertions pass** (was 131).
- **Mutation-checked the fix**: reverting the intersection fails **13 assertions** across both arms — 9 for the billing user (`team:product#member`, `workspace:main#read`, `survey:onboarding#read`/`response_read`, `response:r1#read`/`write`/`export`, `dashboard:insights#read`/`write`) and 4 for the membership-less one.
- **Mutation-checked the turbo guard**: removing `globalDependencies` fails the new test.
- **Verified the turbo fix with a control** — editing `authzed/schema.zed` now changes the `@formbricks/web#build` hash (`606859c0` → `f92eb91b`), editing an `apps/web` file still changes it too, and restoring the schema returns the hash to baseline.
- `pnpm --dir apps/web test` — **8,234 passing**. The 6 failures in
  `scripts/authzed-entrypoints.test.ts` are pre-existing and unrelated: that file is not in this
  diff, it asserts `stderr === ""`, and local Node 26 emits a `DEP0205` deprecation warning. CI
  (Node 24) is **green on this exact head**.
- **Mutation-checked three ways**, all re-run at `cf3a8bae9`:
  - reverting the `team#member` intersection → **13 assertions fail** (9 billing, 4 membership-less);
  - adding `billing` to `product_member` → **9 assertions fail**, proving the exclusion is what the
    suite actually pins rather than something incidental;
  - dropping `globalDependencies` → the new turbo test fails.
- **Smoke test** (`pnpm authzed:smoke`, real SpiceDB + Postgres in Docker): reaches the outage-recovery
  stage and then fails on this machine. Confirmed **not caused by this change** — running the identical
  smoke against the *base* `epic/authzed` schema fails at the byte-identical command
  (`scripts/authzed-health.ts` during SpiceDB recreation). It is a local Node 26 / container-restart
  artifact, and `authzed:smoke` is not part of CI. Everything before that stage passed, including
  schema apply, projection, permission ladders, and revocation against the real engine.
- typecheck, lint, prettier — clean.

## Breaking changes

None to shipped behaviour: legacy remains authoritative and this changes no application code. It changes what SpiceDB *would* answer under enforcement, which is the point — bringing it back in line with what the application already enforces.

## QA / Test Plan

Schema semantics only; there is no user-facing click path, and enforcement is off. Verification is the assertion suite.

**How to test**

- [ ] `pnpm authzed:validate` → `Success! - 32 relationships loaded, 136 assertions run`.
- [ ] Revert `team#member` to `admin + contributor` and re-run → 13 assertions fail; restore.
- [ ] `pnpm --dir apps/web test lib/turbo-build` → 6 passing; remove `globalDependencies` from `turbo.json` and re-run → the schema-input test fails.
- [ ] Confirm no behaviour change today: `AUTHZED_ENFORCEMENT_TARGETS` is unset by default, so `can()` still routes to the legacy evaluator.

**Preconditions / test data**

- `pnpm authzed:validate` runs fully offline via the pinned `authzed/zed` container; no SpiceDB server needed.

**Risks & regressions**

- The intersection adds one arrow hop to every team-derived workspace check. Cheap on paper, and the ENG-1739 harness is available to confirm it if anyone wants a number before enforcement.
- If projection of `organization#member` tuples ever regressed, team-derived access would fail *closed* rather than open — the safe direction, and the backfill's existing audit categories would surface it.

**Migrations / env / cutover**

- None. Existing SpiceDB data needs no repair: this changes how a permission is computed, not what relationships are stored.

